### PR TITLE
fix(cloud): make ad campaign refund paths concurrency- and spend-safe (#11236)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
@@ -123,6 +123,22 @@ export class AdCampaignsRepository {
     await db.delete(adCampaigns).where(eq(adCampaigns.id, id));
   }
 
+  /**
+   * Atomic org-scoped delete that RETURNs the removed row (#11236). Used as a
+   * claim: of N concurrent deletes for the same campaign, exactly ONE gets the
+   * row back — the losers get `undefined` and must not refund. The returned row
+   * also carries the FINAL `credits_spent`, so impressions that landed right up
+   * to the delete are counted as spent rather than refunded. Org-scoped so it
+   * doubles as the ownership gate (no TOCTOU against a prior findById).
+   */
+  async deleteReturning(id: string, organizationId: string): Promise<AdCampaign | undefined> {
+    const [deleted] = await db
+      .delete(adCampaigns)
+      .where(and(eq(adCampaigns.id, id), eq(adCampaigns.organization_id, organizationId)))
+      .returning();
+    return deleted;
+  }
+
   async getStats(
     organizationId: string,
     options?: { adAccountId?: string; platform?: AdPlatform },

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -4,11 +4,15 @@
  * createCampaign charges budget*markup up front (stored as credits_allocated).
  * Two money leaks were fixed:
  *
- *  - deleteCampaign refunded `credits_allocated - credits_spent`, but
- *    credits_spent is never written, so every delete refunded 100% of the
- *    prepaid budget + markup regardless of real ad spend ("free advertising").
- *    The fix refunds only the UNUSED fraction, derived from the real recorded
- *    spend (total_spend / budget_amount) scaled by credits_allocated.
+ *  - deleteCampaign refunded `credits_allocated - credits_spent`. The original
+ *    #10265 reasoning ("credits_spent is never written") is STALE — it only
+ *    checked incrementSpend's callers and missed recordServe's direct UPDATE, so
+ *    internal SSP spend IS written to credits_spent. The fix refunds only the
+ *    genuinely-UNUSED allocation, honoring BOTH spend streams — internal
+ *    `credits_spent` AND external `total_spend` — SUMmed (they are disjoint,
+ *    additive impression streams: findEligibleAd serves external campaigns too),
+ *    and claims the row via an atomic DELETE...RETURNING so concurrent deletes
+ *    can't double-refund (#11151/#11236).
  *
  *  - updateCampaign pushed a new budget LIVE to the ad platform but charged
  *    nothing for an increase and refunded nothing for a decrease. The fix
@@ -77,7 +81,14 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
   beforeEach(() => {
     // Not synced to a platform → no platform delete, no metrics refresh; the
     // stored total_spend is used directly (the simplest path through the fix).
-    track(spyOn(adCampaignsRepository, "delete").mockResolvedValue(undefined));
+    // deleteCampaign now CLAIMS the row via deleteReturning (#11236); delegate to
+    // the per-test findById stub so the refund math sees the same row the winner
+    // would get back from DELETE...RETURNING. (The concurrency describe below
+    // overrides this to model a losing claim.)
+    track(
+      spyOn(adCampaignsRepository, "deleteReturning").mockImplementation((async (id: string) =>
+        adCampaignsRepository.findById(id)) as never),
+    );
   });
 
   test("budget 100 / allocated 110 / spent 40 → refunds 66, not the full 110", async () => {
@@ -163,11 +174,13 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
     expect(refund).not.toHaveBeenCalled();
   });
 
-  test("#11151 mixed spend takes the MAX of internal+external measures (no double-refund)", async () => {
+  test("#11236 dual-stream spend SUMs internal+external (was MAX) — combined spend exhausts allocation → no refund", async () => {
     track(
       spyOn(adCampaignsRepository, "findById").mockResolvedValue(
-        // credits_spent 40 (allocated units) vs total_spend 100 USD → 100*1.1 = 110
-        // allocated-credit units; the external measure dominates → nothing left.
+        // credits_spent 40 (allocated units) + total_spend 100 USD → 110
+        // allocated-credit units. SUM = 150, clamped to allocated 110 → nothing
+        // left. (MAX would have given the same here; the divergence case is the
+        // next test.)
         makeCampaign({ credits_spent: "40", total_spend: "100" }) as never,
       ),
     );
@@ -179,6 +192,87 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
     await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
 
     expect(refund).not.toHaveBeenCalled();
+  });
+
+  test("#11236 dual-stream (internal + external) SUMs both — MAX would under-count and over-refund", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        // A campaign served on BOTH our SSP (credits_spent 30) and an external
+        // provider (total_spend 20 USD → 22 allocated-credit units). Disjoint
+        // impressions → additive. SUM = 52 spent, 110 - 52 = 58 unused.
+        makeCampaign({
+          external_campaign_id: "ext-1",
+          credits_spent: "30",
+          total_spend: "20",
+        }) as never,
+      ),
+    );
+    // external campaign → deleteCampaign refreshes spend; keep it at the stored 20.
+    track(
+      spyOn(advertisingService, "getCampaignMetrics").mockResolvedValue({
+        spend: 20,
+        impressions: 0,
+        clicks: 0,
+        conversions: 0,
+      } as never),
+    );
+    track(spyOn(advertisingService, "getProvider").mockReturnValue(stubProvider()));
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: "acct-1",
+        organization_id: ORG_ID,
+        platform: "meta",
+      } as never),
+    );
+    track(
+      spyOn(
+        advertisingService as unknown as { getCredentials: () => Promise<unknown> },
+        "getCredentials",
+      ).mockResolvedValue({} as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    const arg = refund.mock.calls[0]?.[0] as { amount: number };
+    // SUM: 110 - (30 + 20*1.1) = 58. A MAX(30, 22) would refund 80 — over-refunding
+    // the 22 external credits the campaign actually spent.
+    expect(arg.amount).toBeCloseTo(58, 6);
+  });
+});
+
+describe("deleteCampaign — concurrency (#11236): the claim wins exactly once", () => {
+  test("two concurrent deletes refund exactly ONCE (loser's DELETE...RETURNING is empty)", async () => {
+    const campaign = makeCampaign({ total_spend: "40" });
+    track(spyOn(adCampaignsRepository, "findById").mockResolvedValue(campaign as never));
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    // Model the DB: DELETE ... RETURNING hands the row back exactly once (winner);
+    // the loser's DELETE matches no row and returns undefined.
+    let rowClaimed = false;
+    track(
+      spyOn(adCampaignsRepository, "deleteReturning").mockImplementation((async () => {
+        if (rowClaimed) return undefined;
+        rowClaimed = true;
+        return campaign;
+      }) as never),
+    );
+
+    await Promise.all([
+      advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID),
+      advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID),
+    ]);
+
+    // Pre-fix (findById snapshot → refund → non-transactional delete): both callers
+    // saw creditsRemaining > 0 and BOTH refunded. Now exactly one claim wins.
+    expect(refund).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -306,5 +400,44 @@ describe("updateCampaign — reconciles the credit hold on a budget change", () 
     // No budgetAmount in the input → no budget delta → no credit movement.
     expect(deduct).not.toHaveBeenCalled();
     expect(refund).not.toHaveBeenCalled();
+  });
+
+  test("#11236 budget DECREASE refunds only the UNUSED portion, clamped to spend (not the full delta)", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1", total_spend: "80" }) as never,
+      ),
+    );
+    // Fresh external spend $80 → 88 allocated-credit units spent (markup 1.1),
+    // leaving only 22 of the 110 allocated genuinely unused.
+    track(
+      spyOn(advertisingService, "getCampaignMetrics").mockResolvedValue({
+        spend: 80,
+        impressions: 0,
+        clicks: 0,
+        conversions: 0,
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(advertisingService, "getProvider").mockReturnValue(stubProvider()));
+    track(
+      spyOn(adCampaignsRepository, "update").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+
+    // Decrease budget 100 → 10: the full credit delta is ~99, but only 22 are
+    // genuinely unused, so the refund must clamp to 22.
+    await advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, {
+      budgetAmount: 10,
+    });
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    const arg = refund.mock.calls[0]?.[0] as { amount: number };
+    // Pre-fix refunded the full ~99 delta — clawing back credits already spent
+    // on real impressions. Clamped to the 22 genuinely-unused credits.
+    expect(arg.amount).toBeCloseTo(22, 6);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -671,14 +671,37 @@ class AdvertisingService {
     }
 
     // Platform accepted — refund a budget DECREASE now (never refund before the
-    // live budget is actually lowered).
+    // live budget is actually lowered), but only the genuinely-UNUSED portion
+    // (#11236): refunding the full delta ignored spend, so lowering the budget
+    // of a campaign that had already spent could claw back credits spent on real
+    // impressions (the sibling of #11151 on the update path). Refresh external
+    // spend, then clamp the refund to the remaining unused allocation.
     if (budgetCreditDelta < 0) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: -budgetCreditDelta,
-        description: `Ad budget decrease refund: ${campaign.name}`,
-        metadata: { type: "ad_budget_decrease_refund", campaignId },
-      });
+      let totalSpendUsd = parseFloat(campaign.total_spend);
+      try {
+        const freshMetrics = await this.getCampaignMetrics(campaignId, organizationId);
+        if (Number.isFinite(Number(freshMetrics.spend))) {
+          totalSpendUsd = Number(freshMetrics.spend);
+        }
+      } catch (metricsError) {
+        logger.warn(
+          "[Advertising] spend refresh before budget-decrease refund failed; using stored total_spend",
+          {
+            campaignId,
+            error: metricsError instanceof Error ? metricsError.message : String(metricsError),
+          },
+        );
+      }
+      const { creditsRemaining } = this.computeSpentCredits(campaign, totalSpendUsd);
+      const refundAmount = Math.min(-budgetCreditDelta, creditsRemaining);
+      if (refundAmount > 0) {
+        await creditsService.refundCredits({
+          organizationId,
+          amount: refundAmount,
+          description: `Ad budget decrease refund: ${campaign.name}`,
+          metadata: { type: "ad_budget_decrease_refund", campaignId },
+        });
+      }
     }
 
     const updated = await adCampaignsRepository.update(campaignId, {
@@ -759,6 +782,47 @@ class AdvertisingService {
     return updated!;
   }
 
+  /**
+   * Credits genuinely spent on a campaign, honoring BOTH spend streams
+   * (#11151/#11236). Spend accrues on two different columns by campaign type:
+   *   - internal miniapp SSP spend → `credits_spent` (allocated-credit units,
+   *     written by adSlotsRepository.recordServe on every served impression,
+   *     #10942/#11029). NOTE: the old "credits_spent is never written" claim is
+   *     STALE — it only checked incrementSpend's callers and missed recordServe.
+   *   - external-provider spend → `total_spend` (USD, synced by getCampaignMetrics).
+   *
+   * The two are DISJOINT impression streams — `findEligibleAd` serves ANY active
+   * campaign with remaining budget (it does NOT exclude ones with an
+   * `external_campaign_id`), so a campaign can run on our SSP AND an external
+   * provider at once. They are therefore physically ADDITIVE: SUM them. (An
+   * earlier MAX under-counted such a dual-stream campaign by the smaller stream,
+   * over-refunding it.) Convert external USD to credits at the allocation-time
+   * markup, sum, and clamp to allocated so a refund can never exceed the budget —
+   * a campaign of either kind (or both) can never be refunded past its
+   * genuinely-unused allocation.
+   */
+  private computeSpentCredits(
+    campaign: {
+      credits_allocated: string;
+      credits_spent: string;
+      budget_amount: string;
+    },
+    totalSpendUsd: number,
+  ): {
+    creditsAllocated: number;
+    creditsSpent: number;
+    creditsRemaining: number;
+  } {
+    const creditsAllocated = parseFloat(campaign.credits_allocated);
+    const budgetAmountUsd = parseFloat(campaign.budget_amount);
+    const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
+    const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
+    const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
+    const creditsSpent = Math.min(creditsAllocated, internalSpentCredits + externalSpentCredits);
+    const creditsRemaining = Math.max(0, creditsAllocated - creditsSpent);
+    return { creditsAllocated, creditsSpent, creditsRemaining };
+  }
+
   async deleteCampaign(campaignId: string, organizationId: string): Promise<void> {
     const campaign = await adCampaignsRepository.findById(campaignId);
     if (!campaign || campaign.organization_id !== organizationId) {
@@ -778,23 +842,9 @@ class AdvertisingService {
       }
     }
 
-    // Refund the genuinely-UNUSED budget. Spend accrues on TWO different columns
-    // depending on the campaign type, and the refund must honor BOTH (#11151):
-    //   - internal miniapp SSP spend → `credits_spent` (allocated-credit units,
-    //     written by adSlotsRepository.recordServe on every served impression,
-    //     #10942/#11029). NOTE: the earlier "credits_spent is never written"
-    //     reasoning is STALE — it only checked incrementSpend's callers and
-    //     missed recordServe's direct UPDATE.
-    //   - external-provider spend → `total_spend` (USD, synced by getCampaignMetrics).
-    // Refunding off `total_spend` ALONE let a purely-internal campaign
-    // (external_campaign_id = null, so total_spend stays "0") refund its ENTIRE
-    // prepaid budget + markup after spending it on real impressions ("free
-    // advertising", platform eats the publisher payouts). Convert the external
-    // USD spend into allocated-credit units at the same markup applied at
-    // allocation, take the MAX of the two spent measures, and refund only the
-    // remainder — so a campaign of either kind (or both) can never be refunded
-    // past its genuinely-unused allocation. Best-effort refresh external spend
-    // first so a never-synced provider campaign can't over-refund.
+    // Best-effort refresh external spend BEFORE claiming the row
+    // (getCampaignMetrics needs the still-live campaign), so a never-synced
+    // provider campaign can't over-refund on a stale stored total_spend.
     let totalSpendUsd = parseFloat(campaign.total_spend);
     if (campaign.external_campaign_id) {
       try {
@@ -812,24 +862,31 @@ class AdvertisingService {
         );
       }
     }
-    const creditsAllocated = parseFloat(campaign.credits_allocated);
-    const budgetAmountUsd = parseFloat(campaign.budget_amount);
-    const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
-    // credits_spent is already in allocated-credit units; total_spend is USD → scale by markup.
-    const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
-    const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
-    const creditsSpent = Math.min(
-      creditsAllocated,
-      Math.max(internalSpentCredits, externalSpentCredits),
-    );
-    const creditsRemaining = Math.max(0, creditsAllocated - creditsSpent);
 
+    // Claim the row with an atomic, org-scoped DELETE ... RETURNING (#11236).
+    // Of N concurrent deletes, exactly ONE gets the row back and refunds; the
+    // losers get `undefined` and refund NOTHING — closing the double-refund race
+    // that the previous findById-snapshot → refund → delete opened (both callers
+    // read the live row, both saw creditsRemaining > 0, both refunded). The
+    // returned row also carries the FINAL credits_spent, so impressions that
+    // landed between the snapshot and the delete are counted as spent, not
+    // refunded.
+    const claimed = await adCampaignsRepository.deleteReturning(campaignId, organizationId);
+    if (!claimed) {
+      logger.info(
+        "[Advertising] Campaign already removed by a concurrent delete; skipping refund",
+        { campaignId },
+      );
+      return;
+    }
+
+    const { creditsRemaining } = this.computeSpentCredits(claimed, totalSpendUsd);
     if (creditsRemaining > 0) {
       await creditsService.refundCredits({
         organizationId,
         amount: creditsRemaining,
-        description: `Refund unused budget for deleted campaign: ${campaign.name}`,
-        metadata: { campaignId, campaignName: campaign.name },
+        description: `Refund unused budget for deleted campaign: ${claimed.name}`,
+        metadata: { campaignId, campaignName: claimed.name },
       });
 
       await adTransactionsRepository.create({
@@ -837,13 +894,11 @@ class AdvertisingService {
         campaign_id: campaignId,
         type: "refund",
         amount: String(creditsRemaining),
-        currency: campaign.budget_currency,
+        currency: claimed.budget_currency,
         credits_amount: String(creditsRemaining),
-        description: `Refund for deleted campaign: ${campaign.name}`,
+        description: `Refund for deleted campaign: ${claimed.name}`,
       });
     }
-
-    await adCampaignsRepository.delete(campaignId);
 
     logger.info("[Advertising] Campaign deleted", { campaignId });
   }

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -889,9 +889,16 @@ class AdvertisingService {
         metadata: { campaignId, campaignName: claimed.name },
       });
 
+      // The campaign row is already deleted by the claim above, so a
+      // campaign_id here would violate the ad_transactions FK (23503) and
+      // 500 every refunding delete AFTER the refund committed — dropping the
+      // ledger row. onDelete:"set null" only rewrites existing rows; it does
+      // not permit inserting a dangling reference. Record the deleted id in
+      // external_reference instead.
       await adTransactionsRepository.create({
         organization_id: organizationId,
-        campaign_id: campaignId,
+        campaign_id: null,
+        external_reference: campaignId,
         type: "refund",
         amount: String(creditsRemaining),
         currency: claimed.budget_currency,


### PR DESCRIPTION
Fixes all three findings in #11236 (residuals from the #11170 post-merge audit), all in `advertising/index.ts`.

## 1. MEDIUM — concurrent deletes double-refund
`deleteCampaign` refunded off a `findById` snapshot, then did a non-transactional `delete` with no claim/lock. Two concurrent DELETEs both read the live row, both saw `creditsRemaining > 0`, both refunded.
**Fix:** claim the row with an atomic, org-scoped `DELETE ... RETURNING` (new `adCampaignsRepository.deleteReturning`). Exactly one caller gets the row back and refunds; losers get `undefined` and refund nothing. The returned row also carries the FINAL `credits_spent`, so impressions between snapshot and delete are counted as spent (mirrors my escrow CAS-claim #11124).

## 2. MEDIUM — updateCampaign budget-decrease ignored spend
Lowering the budget refunded the full credit delta, clawing back credits already spent on impressions (sibling of #11151 on the update path).
**Fix:** refresh external spend, then clamp the refund to the genuinely-unused allocation.

## 3. LOW — MAX under-counted dual-stream spend
Internal SSP `credits_spent` and external `total_spend` are **disjoint, additive** impression streams — `findEligibleAd` serves external campaigns too (verified: no `external_campaign_id` filter), so a campaign can run on both. `MAX` under-counted such a campaign → over-refund.
**Fix:** SUM them, clamped to allocated. Extracted a shared `computeSpentCredits` helper used by both refund paths.

Also corrected the stale `credits_spent is never written` header in the test file.

## Tests (`ad-campaign-credit-reconciliation.test.ts`, +4 → 11 pass)
- **concurrent delete** → refunds exactly once (loser's `DELETE...RETURNING` empty);
- **dual-stream SUM** (internal 30 + external 22) → refunds 58, not MAX's 80;
- **budget-decrease clamp** → refunds 22 (unused), not the full ~99 delta;
- existing delete/update cases unchanged.

```
bun test .../ad-campaign-credit-reconciliation.test.ts   # 11 pass
```
`cloud/shared typecheck` + biome clean. Money-path — flagging for maintainer merge. Refs #11170 #11151. `[cloud-security]`