### PR TITLE
fix(core): log evaluator output-validation failures instead of dropping them silently

### DIFF
--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -142,6 +142,7 @@ describe("EvaluatorService", () => {
 
 	it("isolates invalid sections and processor failures", async () => {
 		const runtime = makeRuntime();
+		const warnSpy = vi.spyOn(runtime.logger, "warn");
 		const processed: string[] = [];
 
 		runtime.registerEvaluator({
@@ -219,6 +220,12 @@ describe("EvaluatorService", () => {
 					error: "processor failed",
 				}),
 			]),
+		);
+		// A parse failure must no longer vanish silently — it logs like every
+		// sibling failure path so silent-drop bugs (#11239/#11253) are diagnosable.
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ evaluator: "invalid" }),
+			"Evaluator output section did not validate",
 		);
 	});
 

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -504,6 +504,21 @@ export class EvaluatorService extends BaseService {
 				? evaluator.parse(rawSection)
 				: (rawSection as JsonValue);
 			if (parsed === null || parsed === undefined) {
+				// Every sibling failure path (shouldRun/prepare/processor) logs, but
+				// this one did not — and no caller reads the returned `errors`, so a
+				// parse failure (e.g. a fact/relationship/memory evaluator's zod
+				// safeParse rejecting the model output) vanished with zero trace.
+				// That made silent-drop bugs like #11239/#11253 undiagnosable in the
+				// field. Match the sibling logger shape.
+				this.runtime.logger.warn(
+					{
+						src: "service:evaluator",
+						agentId: this.runtime.agentId,
+						evaluator: evaluator.name,
+						rawSection: JSON.stringify(rawSection).slice(0, 500),
+					},
+					"Evaluator output section did not validate",
+				);
 				errors.push({
 					evaluatorName: evaluator.name,
 					error: "Evaluator output section did not validate",


### PR DESCRIPTION
Fixes #11256. The observability gap behind the silent-drop memory bugs #11239 / #11253.

**Symptom:** when an evaluator's `parse()` returns null (a zod `safeParse` rejecting model output — facts/relationships/identities/skills/summary all do this), `EvaluatorService.processPreparedEntries` pushed an error to the returned `errors` array but **logged nothing** — while every sibling failure path (`shouldRun`/`prepare`/processor) does `logger.warn`. And **no caller reads `errors`**, so a parse failure vanished with zero trace (and `EVALUATOR_COMPLETED` still emitted `completed:true`). That's exactly why the two schema-mismatch memory drops were invisible in the field.

**Fix (observability only, no behavior change):** `logger.warn` in the parse-null branch, matching the sibling logger shape (`src`, agentId, evaluator name, truncated `rawSection`).

### Evidence
- The existing "isolates invalid sections and processor failures" test now spies `runtime.logger.warn` and asserts the "Evaluator output section did not validate" line fires for the invalid evaluator. **8/8.** Mutation-checked (removing the log reds the assertion).
- `tsgo --noEmit` + multi-target build + biome clean.

### N/A rows
- Screenshots / trajectory: N/A — a `logger.warn` addition; the test asserts the log call.