### PR TITLE
fix(ui): clear shell back button so spatial-view filter chips are tappable (#11144)

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -80,19 +80,32 @@ test("inbox decomposed view: channel filters toggle", async ({ page }) => {
   // and the rendered list: the active chip is renamed "* <Channel>", its
   // thread stays, and the other channel's thread disappears.
   //
-  // KNOWN BUG (documented, not accepted): the first chip in the row ("Email")
-  // sits under the shell's floating "Go back" button (fixed, z-60, top-left),
-  // which intercepts pointer events on BOTH the desktop and Pixel-7 lanes, so
-  // the Email chip is untappable. Drive the same filter semantics through the
-  // "Discord" chip (clear of the overlay) until the shell occlusion is fixed.
-  await page.getByRole("button", { name: "Discord", exact: true }).click();
+  // Regression guard for #11144: the FIRST chip ("Email") used to sit under the
+  // shell's floating "Go back" button (fixed, z-60, top-left) which intercepted
+  // its pointer events, making it untappable. The spatial surface now reserves
+  // --shell-backnav-clearance, so the chip clears the button. Assert the fix
+  // directly: hit-test the first chip's center and confirm it resolves to the
+  // chip itself, then drive the real filter through the Email chip.
+  const emailChip = page.getByRole("button", { name: "Email", exact: true });
+  await expect(emailChip).toBeVisible({ timeout: 15_000 });
+  const chipIsTopmostAtCenter = await emailChip.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      r.left + r.width / 2,
+      r.top + r.height / 2,
+    );
+    return el === hit || el.contains(hit);
+  });
+  expect(chipIsTopmostAtCenter).toBe(true);
+
+  await emailChip.click();
   await expect(
-    page.getByRole("button", { name: "* Discord", exact: true }),
+    page.getByRole("button", { name: "* Email", exact: true }),
   ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByText("gm everyone — standup in 10").first(),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("Invoice #42 overdue")).toHaveCount(0, {
+  await expect(page.getByText("Invoice #42 overdue").first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("gm everyone — standup in 10")).toHaveCount(0, {
     timeout: 15_000,
   });
 });
@@ -210,18 +223,19 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
-  // #11145 (fixed): the graph container is clamped to the viewport
-  // (`w-full max-w-full` + internal `overflow-auto`), so the zoomed SVG pans
-  // INSIDE it instead of stretching the layout box to the SVG width (was
-  // measured at 1188px on a 412px Pixel-7 viewport → horizontal page scroll).
-  // Assert the container's rendered box never exceeds the viewport width.
+  // Layout sanity (#11145 lineage): the relationships view is the unified
+  // list-based SpatialView (RelationshipsView.tsx renders RelationshipsSpatialView,
+  // which emits [data-spatial-surface] — the legacy [data-graph-container] from
+  // the retired RelationshipsGraphPanel is no longer on this route). Assert the
+  // rendered container is laid out and never exceeds the viewport width (no
+  // horizontal page-scroll blowout).
   const viewport = page.viewportSize();
   if (viewport) {
     const box = await page
-      .locator("[data-graph-container]")
+      .locator("[data-spatial-surface]")
       .first()
       .boundingBox();
-    expect(box, "graph container should be laid out").not.toBeNull();
+    expect(box, "spatial surface should be laid out").not.toBeNull();
     if (box) {
       // +1px slack for sub-pixel rounding.
       expect(box.width).toBeLessThanOrEqual(viewport.width + 1);
@@ -239,15 +253,24 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
-  // Clicking the active kind chip again deselects it (back to every kind).
-  // KNOWN BUG (documented, not accepted): the dedicated "All" chip is the
-  // first chip in the row and sits under the shell's floating "Go back"
-  // button (fixed, z-60, top-left) on both lanes, so it is untappable — same
-  // occlusion as the inbox "Email" chip. The toggle-off path exercises the
-  // same restore semantics.
-  await page
-    .getByRole("button", { name: "Organizations", exact: true })
-    .click();
+  // Restore every kind via the dedicated "All" chip — the FIRST chip in the row.
+  // Regression guard for #11144: this chip used to sit under the shell's floating
+  // "Go back" button (fixed, z-60, top-left) and was untappable; the spatial
+  // surface now reserves --shell-backnav-clearance. Hit-test its center to prove
+  // it's on top, then click it directly to restore Graph (3).
+  const allChip = page.getByRole("button", { name: "All", exact: true });
+  await expect(allChip).toBeVisible({ timeout: 15_000 });
+  const allChipTopmost = await allChip.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      r.left + r.width / 2,
+      r.top + r.height / 2,
+    );
+    return el === hit || el.contains(hit);
+  });
+  expect(allChipTopmost).toBe(true);
+
+  await allChip.click();
   await expect(page.getByText("Graph (3)").first()).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,6 +12,7 @@ import { ArrowLeft, X } from "lucide-react";
 import "./components/chat/chat-source-registration";
 import {
   type ComponentType,
+  type CSSProperties,
   type LazyExoticComponent,
   lazy,
   type ReactNode,
@@ -1499,7 +1500,15 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
       ? APP_SHELL_CLASS_TRANSPARENT
       : APP_SHELL_CLASS;
   return (
-    <div key={`tab-shell-${props.tab}`} className={shellClass}>
+    // --shell-backnav-clearance reserves top space for the fixed ShellBackButton
+    // so spatial views' first row (filter chips) clears it (#11144). 0.75rem top
+    // offset + 2.25rem button = 3rem. Consumed by SpatialSurface (spatial/dom.tsx);
+    // unset elsewhere → 0px.
+    <div
+      key={`tab-shell-${props.tab}`}
+      className={shellClass}
+      style={{ "--shell-backnav-clearance": "3rem" } as CSSProperties}
+    >
       <ShellBackButton onBack={props.onNavigateBack} />
       {props.desktopTabBar}
       <main className={routedShellMainClass(props.tab)}>
@@ -1523,7 +1532,11 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
  */
 function FullBleedShellContent(props: ShellContentProps): ReactNode {
   return (
-    <div key={`fullbleed-shell-${props.tab}`} className={APP_SHELL_CLASS}>
+    <div
+      key={`fullbleed-shell-${props.tab}`}
+      className={APP_SHELL_CLASS}
+      style={{ "--shell-backnav-clearance": "3rem" } as CSSProperties}
+    >
       <ShellBackButton onBack={props.onNavigateBack} />
       <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
         <ViewRouter />

--- a/packages/ui/src/spatial/dom.tsx
+++ b/packages/ui/src/spatial/dom.tsx
@@ -106,6 +106,12 @@ export function SpatialSurface({
           minHeight: 0,
           minWidth: 0,
           boxSizing: "border-box",
+          // Clear the fixed shell back button (top-left, z-60) so it never
+          // occludes a spatial view's first row (e.g. filter chips). The shell
+          // wrappers that render ShellBackButton set --shell-backnav-clearance;
+          // everywhere else (chat overlay, XR, TUI, stories) it is unset → 0px.
+          // See #11144.
+          paddingTop: "var(--shell-backnav-clearance, 0px)",
         }}
       >
         {children}


### PR DESCRIPTION
Closes #11144.

## Problem
The fixed `ShellBackButton` (top-left, `z-60`, 48px square) renders as a floating sibling of `<main>`, but no layer reserved clearance for it. So the **first filter chip** of every unified spatial view sat under it and was **untappable on desktop AND mobile** — `document.elementFromPoint` at the chip center returned the back button:
- Inbox: the `Email` chip (first channel)
- Relationships: the `All` chip (first kind)

The existing spec had two KNOWN-BUG workarounds routing around this (clicking `Discord` / toggling `Organizations` off instead).

## Fix (shared CSS var, no per-view edits)
- The two shell wrappers that render `ShellBackButton` (`RoutedShellContent`, `FullBleedShellContent` in `packages/ui/src/App.tsx`) set `--shell-backnav-clearance: 3rem` (0.75rem offset + 2.25rem button).
- The single shared `SpatialSurface` seam (`packages/ui/src/spatial/dom.tsx`) consumes it as `paddingTop: var(--shell-backnav-clearance, 0px)` → **0 everywhere the button is absent** (chat overlay, XR, TUI, stories), 48px clearance where it's present.
- No z-index change, no button relocation, no `<main>` class change, no per-plugin edits.

## Un-larp the tests (no more workarounds)
- Inbox + relationships tests now click the **real first chip** (`Email` / `All`), each with a `document.elementFromPoint` occlusion-regression assertion at the chip center (proves the chip, not the back button, is topmost).
- Retargeted a **stale** assertion: the relationships test waited on `[data-graph-container]` from the **retired** `RelationshipsGraphPanel`; the route now renders the unified list-based `RelationshipsSpatialView` (which emits `[data-spatial-surface]`), so that wait could never resolve on develop. Repointed the viewport-width-clamp check to the real container. (This was a pre-existing dead assertion, unrelated to the occlusion — fixing it while here.)

## Evidence
- `apps-personal-assistant-decomposed-interactions.spec.ts` **inbox + relationships pass on BOTH `chromium` and `mobile-chromium` (4/4)** — verified locally. Before: inbox used a workaround; relationships timed out 3min on the stale `[data-graph-container]`. After: both click the real first chip and pass in ~8-20s.
- Failure→fix screenshot confirms the chip row now renders clearly below the back button with `Graph (3)` populated.
- `typecheck` (only pre-existing unrelated `iwer` module error) + `biome` clean.
- Risk: uniform ~48px top clearance on all spatial views under the routed/full-bleed shell (intended); non-spatial routed views unaffected (var consumed only by SpatialSurface); chat overlay/XR/TUI/stories unaffected (var unset → 0).

— nubs-cloud (laptop lane; soloing UI burn-down with the Fable-5 fleet)