### PR TITLE
revert(ui): #11230 — the inset is a no-op for the target views and regresses every routed tab

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -10,7 +10,6 @@
 // interaction owner that closes INTERACTION_DEBT in
 // view-interaction-coverage.test.ts.
 
-import type { Locator } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
@@ -22,40 +21,6 @@ test.beforeEach(async ({ page }) => {
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 });
-
-// Regression guard for #11144: the shell's fixed "Go back" button (z-[60],
-// top-left) used to sit on top of the FIRST filter chip of the decomposed
-// spatial views, so `document.elementFromPoint` at the chip centre returned the
-// back button and the chip was untappable on both the desktop and Pixel-7
-// lanes. The shell now reserves the back-button column (SHELL_BACK_INSET_CLASS
-// in packages/ui/src/App.tsx), so the chip centre must hit-test to the chip
-// itself (or a descendant). Assert that before driving the chip so a shell
-// regression fails here loudly instead of silently making the chip dead again.
-async function expectChipIsTopHit(chip: Locator): Promise<void> {
-  await expect(chip).toBeVisible({ timeout: 15_000 });
-  await chip.scrollIntoViewIfNeeded();
-  const hit = await chip.evaluate((el) => {
-    const r = el.getBoundingClientRect();
-    const top = document.elementFromPoint(
-      r.left + r.width / 2,
-      r.top + r.height / 2,
-    );
-    return {
-      isSelf: top === el || el.contains(top),
-      topLabel: top?.getAttribute("aria-label") ?? null,
-      topTestId: top?.getAttribute("data-testid") ?? null,
-    };
-  });
-  // The chip centre must resolve to the chip, NOT the shell back button
-  // (data-testid="shell-back-button", aria-label="Go back"). #11144.
-  expect(
-    hit.isSelf,
-    `first filter chip must be the top hit-test target at its centre, not ` +
-      `occluded by the shell back button (#11144). elementFromPoint resolved ` +
-      `to testId=${hit.topTestId} label=${hit.topLabel}`,
-  ).toBe(true);
-  expect(hit.topTestId).not.toBe("shell-back-button");
-}
 
 test("calendar decomposed view: day/week/month view-mode control switches", async ({
   page,
@@ -111,24 +76,23 @@ test("inbox decomposed view: channel filters toggle", async ({ page }) => {
     page.getByText("gm everyone — standup in 10").first(),
   ).toBeVisible({ timeout: 15_000 });
 
-  // #11144 regression guard: the FIRST chip in the row ("Email") used to be
-  // occluded by the shell's fixed "Go back" button (z-[60], top-left) and was
-  // untappable on both the desktop and Pixel-7 lanes. The shell now reserves
-  // the back-button column (SHELL_BACK_INSET_CLASS), so the Email chip centre
-  // must hit-test to the chip itself, and clicking it must drive the real
-  // channel-filter semantics: the active chip is renamed "* Email", the gmail
-  // thread stays, and the Discord thread disappears.
-  const email = page.getByRole("button", { name: "Email", exact: true });
-  await expectChipIsTopHit(email);
-  await email.click();
-  // Selecting Email narrows the server query to the gmail channel: the gmail
-  // thread stays and the Discord thread disappears. (The active chip renders a
-  // "* Email" affordance like the other channels' "* <Channel>", but the
-  // list-narrowing outcome is the label-independent proof the tap landed.)
-  await expect(page.getByText("Invoice #42 overdue").first()).toBeVisible({
-    timeout: 15_000,
-  });
-  await expect(page.getByText("gm everyone — standup in 10")).toHaveCount(0, {
+  // Activating a channel chip narrows the server query (?channels=<channel>)
+  // and the rendered list: the active chip is renamed "* <Channel>", its
+  // thread stays, and the other channel's thread disappears.
+  //
+  // KNOWN BUG (documented, not accepted): the first chip in the row ("Email")
+  // sits under the shell's floating "Go back" button (fixed, z-60, top-left),
+  // which intercepts pointer events on BOTH the desktop and Pixel-7 lanes, so
+  // the Email chip is untappable. Drive the same filter semantics through the
+  // "Discord" chip (clear of the overlay) until the shell occlusion is fixed.
+  await page.getByRole("button", { name: "Discord", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "* Discord", exact: true }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByText("gm everyone — standup in 10").first(),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("Invoice #42 overdue")).toHaveCount(0, {
     timeout: 15_000,
   });
 });
@@ -275,15 +239,15 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
-  // #11144 regression guard: the dedicated "All" chip is the FIRST chip in the
-  // row and used to sit under the shell's fixed "Go back" button (z-[60],
-  // top-left) on both lanes, so it was untappable — the same occlusion as the
-  // inbox "Email" chip. The shell now reserves the back-button column, so the
-  // "All" chip centre must hit-test to the chip, and tapping it restores every
-  // kind (Graph (3)).
-  const all = page.getByRole("button", { name: "All", exact: true });
-  await expectChipIsTopHit(all);
-  await all.click();
+  // Clicking the active kind chip again deselects it (back to every kind).
+  // KNOWN BUG (documented, not accepted): the dedicated "All" chip is the
+  // first chip in the row and sits under the shell's floating "Go back"
+  // button (fixed, z-60, top-left) on both lanes, so it is untappable — same
+  // occlusion as the inbox "Email" chip. The toggle-off path exercises the
+  // same restore semantics.
+  await page
+    .getByRole("button", { name: "Organizations", exact: true })
+    .click();
   await expect(page.getByText("Graph (3)").first()).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -112,18 +112,6 @@ import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell"
 
 const MOBILE_NAV_PADDING_CLASS =
   "pb-[calc(var(--eliza-mobile-nav-offset,0px)+var(--safe-area-bottom,0px)+var(--eliza-continuous-chat-clearance,5.25rem))]";
-
-// Reserve the ShellBackButton footprint on the LEFT of routed content so the
-// top-left of a view (e.g. the first filter chip of the decomposed spatial
-// views) is never under the fixed `z-[60]` back button and stays tappable.
-// The button is `left: calc(safe-area-left + 0.75rem)` and `h-9 w-9` (2.25rem),
-// so its right edge is at `safe-area-left + 3rem`; we add a 0.5rem gap → a
-// 3.5rem + safe-area reserved column. Applied to the routed shell, which always
-// renders ShellBackButton — so there is no width-dependent layout jump (the
-// button is present on both the desktop and mobile lanes). Full-bleed pages own
-// their edge-to-edge surface and position their own content, so they are left
-// untouched. See issue #11144.
-const SHELL_BACK_INSET_CLASS = "pl-[calc(var(--safe-area-left,0px)+3.5rem)]";
 type ExtractComponent<TValue> =
   TValue extends ComponentType<infer Props> ? ComponentType<Props> : never;
 
@@ -1483,17 +1471,13 @@ function routedShellMainClass(tab: string): string {
   // One tight page gutter for every routed view: minimal top so headers sit
   // right under the chrome, a small side gutter, modest bottom. Views that own
   // their full surface (browser/apps/views/background) still get zero padding.
-  // The LEFT gutter reserves the ShellBackButton footprint (#11144) so the
-  // top-left of a view — e.g. the first filter chip of the decomposed spatial
-  // views — never sits under the fixed `z-[60]` back button and stays tappable.
-  const fullSurface =
+  const pagePadding =
     tab === "browser" ||
     tab === "apps" ||
     tab === "views" ||
-    tab === "background";
-  const pagePadding = fullSurface
-    ? ""
-    : `pr-2 sm:pr-3 pt-2 pb-4 ${SHELL_BACK_INSET_CLASS}`;
+    tab === "background"
+      ? ""
+      : "px-2 sm:px-3 pt-2 pb-4";
   const mobilePadding = tab === "browser" ? "" : MOBILE_NAV_PADDING_CLASS;
   return `flex flex-1 min-h-0 min-w-0 overflow-hidden ${pagePadding} ${mobilePadding}`;
 }


### PR DESCRIPTION
Reverts #11230 (merge d3c3df65b9), which was **block-verdict** in adversarial review but merged mid-review. Receipts:

1. **The fix provably does not reach the views the issue is about.** The decomposed spatial views (/inbox, /relationships, /health, …) are plugin-manifest views at unknown top-level paths — `tabFromPath` resolves them to `tab="views"` (`navigation/index.ts:463-465`), the one branch `routedShellMainClass` deliberately leaves at zero padding, i.e. the branch the PR's 3.5rem inset **skips**.
2. **Its own new tests fail on its own head:** the PR's elementFromPoint occlusion guard fails on both desktop and Pixel-7 lanes — 4 failed / 14 passed with screenshots showing the chips still under the button (develop baseline passes, modulo the pre-existing relationships graph-container timeout).
3. **What it does land on is a regression:** every genuinely routed tab (settings, memories, wallet, models, documents, …) gets a permanent full-height 56px left gutter vs 8-12px right — the exact 'insets rippling across every routed view' failure mode the #11144 triage warned against — with no `audit:app` before/after evidence.

#11144 stays open. The correct fix per the triage is a shell-exposed clearance seam (e.g. a `--shell-backnav-clearance` CSS var set where ShellBackButton renders) consumed as `padding-inline-start` by the spatial views' first chip row — the pattern HealthSpatialView already uses; a proper implementation is being cut separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)