### PR TITLE
fix(cockpit): stop orphaning the eliza-code session on unmount mid-spawn

### DIFF
--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
@@ -5,6 +5,7 @@
 // sessionId; error -> retry; unmount/close -> client.stopPtySession), mocking
 // only the client boundary and the xterm pane (which needs a real DOM/canvas).
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -126,5 +127,26 @@ describe("CockpitInteractiveTerminal — spawn → attach wiring", () => {
     fireEvent.click(screen.getByTestId("cockpit-terminal-close"));
     expect(mocks.stopPtySession).toHaveBeenCalledWith("sess-close");
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("unmount mid-spawn stops the session once it resolves (no orphan REPL)", async () => {
+    // spawnPtySession is async; unmount before it resolves. The cleanup runs
+    // first (activeSessionRef still null → stops nothing), so the fix must stop
+    // the session when the pending spawn finally resolves on a disposed component.
+    let resolveSpawn!: (v: { sessionId: string }) => void;
+    mocks.spawnPtySession.mockReturnValue(
+      new Promise<{ sessionId: string }>((r) => {
+        resolveSpawn = r;
+      }),
+    );
+    const { unmount } = render(<CockpitInteractiveTerminal tier="fast" />);
+    // Spawn is in flight (pane not mounted yet); unmount now.
+    unmount();
+    // Now the in-flight spawn resolves.
+    await act(async () => {
+      resolveSpawn({ sessionId: "sess-race" });
+      await Promise.resolve();
+    });
+    expect(mocks.stopPtySession).toHaveBeenCalledWith("sess-race");
   });
 });

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
@@ -47,6 +47,13 @@ export function CockpitInteractiveTerminal({
   const [error, setError] = useState<string | null>(null);
   const spawnStartedRef = useRef(false);
   const activeSessionRef = useRef<string | null>(null);
+  // True once the terminal has been unmounted or closed. Spawn is async, so a
+  // close/unmount that happens WHILE spawnPtySession is in flight would run the
+  // cleanup (which reads activeSessionRef = still null) and stop nothing — then
+  // the spawn resolves and leaves an orphaned eliza-code REPL alive until the
+  // 15-min idle reaper. Checking this after the await kills that session
+  // immediately instead.
+  const disposedRef = useRef(false);
 
   const spawn = useCallback(async () => {
     setPhase("spawning");
@@ -57,6 +64,12 @@ export function CockpitInteractiveTerminal({
         tier,
         ...(cwd ? { cwd } : {}),
       });
+      if (disposedRef.current) {
+        // Unmounted/closed mid-spawn — the cleanup already ran and saw no
+        // session, so stop this one now and don't touch state on a dead component.
+        void ptyClient.stopPtySession(id);
+        return;
+      }
       activeSessionRef.current = id;
       setSessionId(id);
       setPhase("ready");
@@ -81,6 +94,7 @@ export function CockpitInteractiveTerminal({
   // won't exit on its own, so an unclosed session would leave an orphan process.
   useEffect(
     () => () => {
+      disposedRef.current = true;
       const id = activeSessionRef.current;
       activeSessionRef.current = null;
       if (id) void ptyClient.stopPtySession(id);
@@ -93,6 +107,7 @@ export function CockpitInteractiveTerminal({
   }, [spawn]);
 
   const close = useCallback(() => {
+    disposedRef.current = true;
     const id = activeSessionRef.current;
     activeSessionRef.current = null;
     if (id) void ptyClient.stopPtySession(id);


### PR DESCRIPTION
Fixes #11263. Found by the Fable-5 lane hunt — a resource leak on the phone-first cockpit surface.

**Symptom:** `CockpitInteractiveTerminal.spawn()` is async. If the terminal unmounts or the user taps ✕ **while `spawnPtySession` is still in flight**, the unmount cleanup runs first (reads `activeSessionRef.current` = still null → stops nothing), then the spawn resolves on a dead component and the eliza-code REPL **orphans** until the 15-min idle reaper. Easy to hit on a phone: tap Terminal, immediately navigate back.

**Fix:** a `disposedRef` set in the unmount cleanup and in `close()`; after the spawn `await`, if disposed, stop the just-created session and return without touching dead-component state.

### Evidence
- Test: unmount before the spawn promise resolves, then resolve it → asserts `stopPtySession("sess-race")` was called. **6/6.** Mutation-checked (removing the disposed guard reds the new test).
- typecheck + view bundle build + biome clean.

### N/A rows
- Screenshots / trajectory: N/A — a lifecycle/resource-cleanup fix; the leak is a lingering server-side PTY process, asserted via the `stopPtySession` call in the race test.