### PR TITLE
fix(ci): bun install cache on local $HOME not slow /tmp — real deploy-hang fix (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -227,7 +227,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
@@ -535,7 +542,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
@@ -874,7 +888,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }


### PR DESCRIPTION
The bun-pin #11235 was the wrong root cause — run 28572046433 hung on install 17min+ on released bun too. Real cause: the install cache under \`\$PWD\` sits on the box /tmp (slow/contended FS), stalling bun's link phase past 900s. bun explicitly warns "Slow filesystem detected ... set \$BUN_INSTALL_CACHE_DIR to a local folder". Moves the cache to \`\$HOME/.bun-install-cache-deploy\` (local, warm) on all 3 jobs. Refs #10839. `[cloud-audit]`