### PR TITLE
fix(cloud): await default api-key and character provisioning in steward sync

### DIFF
--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression: brand-new-user default provisioning must COMPLETE before
+ * syncUserFromSteward returns.
+ *
+ * The new-user branch provisions a default API key + a default Eliza character.
+ * These used to be fire-and-forget (`void ensureUserHasApiKey(...)` /
+ * `void ensureDefaultCharacter(...)`). This code runs on Cloudflare Workers,
+ * where a promise not registered via executionCtx.waitUntil may be cancelled
+ * once the response returns — and syncUserFromSteward is a shared-lib function
+ * with no request context to reach waitUntil. A cancelled promise left the new
+ * user permanently with no default character (ensureDefaultCharacter's only
+ * caller is this one-time new-user path; every later login returns at the
+ * existing-user branch). Fix: await both.
+ *
+ * The api-key and character create() mocks below are deferred promises whose
+ * settlement the test controls — modeling slow DB writes that would still be
+ * in flight when a fire-and-forget caller returned. The test proves the
+ * returned promise stays pending until BOTH creates have completed.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// A deferred whose settlement we control, to model a slow DB write that would
+// still be in flight if the caller did NOT await it.
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const apiKeyCreate = deferred<{ id: string }>();
+const characterCreate = deferred<{ id: string }>();
+let apiKeyCreateStarted = false;
+let apiKeyCreateResolved = false;
+let characterCreateResolved = false;
+
+const createdOrg = {
+  id: "org-new-1",
+  slug: "alice-abc123",
+  credit_balance: "0.00",
+};
+const createdUser = { id: "user-new-1", organization_id: "org-new-1" };
+const finalUserWithOrg = {
+  id: "user-new-1",
+  steward_user_id: "steward-123",
+  email: "alice@example.com",
+  name: "alice",
+  wallet_address: null,
+  role: "owner",
+  email_verified: true,
+  wallet_verified: false,
+  organization: { id: "org-new-1", name: "alice's Organization" },
+};
+
+mock.module("./services/credits", () => ({
+  creditsService: { addCredits: async () => ({ success: true }) },
+}));
+mock.module("./services/organizations", () => ({
+  organizationsService: {
+    getBySlug: async () => undefined,
+    create: async () => createdOrg,
+    update: async () => createdOrg,
+    delete: async () => undefined,
+  },
+}));
+mock.module("./services/users", () => ({
+  usersService: {
+    getByStewardId: async () => undefined,
+    getByEmailWithOrganization: async () => undefined,
+    getByWalletAddress: async () => undefined,
+    getByWalletAddressWithOrganization: async () => undefined,
+    getStewardIdentityForWrite: async () => undefined,
+    getByStewardIdForWrite: async () => finalUserWithOrg,
+    create: async () => createdUser,
+    update: async () => undefined,
+    linkStewardId: async () => undefined,
+    upsertStewardIdentity: async () => undefined,
+  },
+}));
+mock.module("./services/invites", () => ({
+  invitesService: { findPendingInviteByEmail: async () => undefined },
+}));
+mock.module("./services/api-keys", () => ({
+  apiKeysService: {
+    listByOrganization: async () => [],
+    create: async () => {
+      apiKeyCreateStarted = true;
+      const v = await apiKeyCreate.promise;
+      apiKeyCreateResolved = true;
+      return v;
+    },
+  },
+}));
+mock.module("./services/characters/characters", () => ({
+  charactersService: {
+    listByOrganization: async () => [],
+    create: async () => {
+      const v = await characterCreate.promise;
+      characterCreateResolved = true;
+      return v;
+    },
+  },
+}));
+mock.module("./services/discord", () => ({
+  discordService: { logUserSignup: async () => undefined },
+}));
+mock.module("./services/email", () => ({
+  emailService: { sendWelcomeEmail: async () => undefined },
+}));
+
+const { syncUserFromSteward } = await import("./steward-sync");
+
+describe("syncUserFromSteward default provisioning (await, not fire-and-forget)", () => {
+  test("does NOT resolve until both the api-key and character creates have completed", async () => {
+    let syncResolved = false;
+    const syncPromise = syncUserFromSteward({
+      stewardUserId: "steward-123",
+      email: "alice@example.com",
+    }).then((u) => {
+      syncResolved = true;
+      return u;
+    });
+
+    // Let microtasks drain: the api-key create has started but is still in
+    // flight, so the sync must still be pending (it awaits provisioning).
+    await new Promise((r) => setTimeout(r, 10));
+    expect(apiKeyCreateStarted).toBe(true);
+    expect(syncResolved).toBe(false);
+
+    // Settle the api key: the character create is still pending, so the sync
+    // must remain pending too.
+    apiKeyCreate.resolve({ id: "key-1" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(apiKeyCreateResolved).toBe(true);
+    expect(syncResolved).toBe(false);
+
+    // Settle the character: NOW the sync may resolve.
+    characterCreate.resolve({ id: "char-1" });
+    const user = await syncPromise;
+    expect(characterCreateResolved).toBe(true);
+    expect(syncResolved).toBe(true);
+    expect(user.id).toBe("user-new-1");
+  });
+});

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -684,11 +684,15 @@ export async function syncUserFromSteward(
       logger.error("[StewardSync] Discord signup log failed:", { error });
     });
 
-  // Auto-generate default API key (fire-and-forget)
-  void ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
-
-  // Auto-create default Eliza character (fire-and-forget)
-  void ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
+  // Await default provisioning: on Cloudflare Workers an un-awaited promise is
+  // cancelled once the response returns unless registered via
+  // executionCtx.waitUntil, which this shared-lib function cannot reach — and a
+  // cancelled create leaves the new user permanently without a default
+  // character/API key (this one-time new-user path is the only caller; later
+  // logins return at the existing-user branch). Both helpers are idempotent and
+  // swallow their own errors, so awaiting cannot fail the signup.
+  await ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
+  await ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
 
   return userWithOrg;
 }


### PR DESCRIPTION
Closes #11269

## Problem

The brand-new-user branch of `syncUserFromSteward` provisioned the default API key and default Eliza character with fire-and-forget promises (`void ensureUserHasApiKey(...)` / `void ensureDefaultCharacter(...)`). This runs on Cloudflare Workers, where a promise not registered via `executionCtx.waitUntil` can be cancelled once the response returns — and this shared-lib function has no request context to reach `waitUntil`. A cancelled create leaves the new user **permanently** without a default character/API key: `ensureDefaultCharacter`'s only caller is this one-time new-user path, and every later login returns early at the existing-user branch.

## Fix

Await both creations so they complete before `syncUserFromSteward` returns. Both helpers are idempotent (they re-check existing rows first) and swallow their own errors, so awaiting cannot fail or double-run the signup — it only guarantees provisioning finishes. The existing-user, invite, and account-linking paths return before this code and are untouched.

## Regression test

`steward-sync-default-provisioning.test.ts` mocks the api-key and character `create()` calls as deferred promises the test controls, then proves `syncUserFromSteward`'s returned promise stays pending until BOTH creates have completed:

- against the old `void` version the test fails at the first assertion (`syncResolved` is `true` while the api-key create is still in flight — exactly the cancellation window);
- against the awaited version the sync only resolves after the test settles both deferreds.

## Evidence

- `bun test steward-sync` (packages/cloud/shared): **11 pass, 0 fail** (3 files: default-provisioning, grant, profile-refresh)
- Same test run against the un-awaited version: **fails** at `expect(syncResolved).toBe(false)` (received `true`) — proves the regression is real
- `bun run --cwd packages/cloud/shared typecheck`: exit 0, zero `error TS`
- Biome on both touched files: zero new findings vs develop baseline
- N/A - screenshots/video: backend-only shared-lib change, no UI surface
- N/A - live model trajectory: no agent/prompt/model behavior change; deterministic provisioning path covered by the deferred-promise test above
