### PR TITLE
fix(ui/chat/cockpit): round-7 sweep batch — draft bleed, dead controls, cockpit terminal resilience, dead tile

### DIFF
--- a/packages/agent/src/api/pty-ws-bridge.test.ts
+++ b/packages/agent/src/api/pty-ws-bridge.test.ts
@@ -1,0 +1,244 @@
+// Unit tests for the WS-side PTY plumbing extracted from server.ts:
+// 1. attachPtySessionWsBridge — session_output AND session_exit are bridged
+//    to the client (pty-output / pty-exit), filtered per session, and both
+//    listeners detach together. Before this, session_exit was never bridged,
+//    so a dead PTY looked alive to the dashboard forever.
+// 2. schedulePtySessionStopAfterGrace / cancelPendingPtySessionStop — a WS
+//    close schedules the reap after a grace window instead of killing the
+//    client's sessions instantly on a phone lock / network blip.
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  attachPtySessionWsBridge,
+  cancelPendingPtySessionStop,
+  DEFAULT_PTY_DISCONNECT_GRACE_MS,
+  type PtyWsFrame,
+  resolvePtyDisconnectGraceMs,
+  schedulePtySessionStopAfterGrace,
+} from "./pty-ws-bridge.ts";
+
+function makeBridge() {
+  const emitter = new EventEmitter();
+  return {
+    emitter,
+    bridge: {
+      on: (event: string, listener: (...args: unknown[]) => void) =>
+        void emitter.on(event, listener),
+      off: (event: string, listener: (...args: unknown[]) => void) =>
+        void emitter.off(event, listener),
+    },
+  };
+}
+
+describe("attachPtySessionWsBridge", () => {
+  it("forwards session_output as pty-output frames for the subscribed session only", () => {
+    const { emitter, bridge } = makeBridge();
+    const frames: PtyWsFrame[] = [];
+    attachPtySessionWsBridge({
+      bridge,
+      sessionId: "sess-a",
+      send: (frame) => frames.push(frame),
+    });
+
+    emitter.emit("session_output", { sessionId: "sess-a", data: "hello" });
+    emitter.emit("session_output", { sessionId: "sess-other", data: "nope" });
+
+    expect(frames).toEqual([
+      { type: "pty-output", sessionId: "sess-a", data: "hello" },
+    ]);
+  });
+
+  it("forwards session_exit as a pty-exit frame with the exit code", () => {
+    const { emitter, bridge } = makeBridge();
+    const frames: PtyWsFrame[] = [];
+    attachPtySessionWsBridge({
+      bridge,
+      sessionId: "sess-a",
+      send: (frame) => frames.push(frame),
+    });
+
+    emitter.emit("session_exit", { sessionId: "sess-other", exitCode: 1 });
+    emitter.emit("session_exit", { sessionId: "sess-a", exitCode: 0 });
+
+    expect(frames).toEqual([
+      { type: "pty-exit", sessionId: "sess-a", exitCode: 0 },
+    ]);
+  });
+
+  it("normalizes a missing/killed exit code to null", () => {
+    const { emitter, bridge } = makeBridge();
+    const frames: PtyWsFrame[] = [];
+    attachPtySessionWsBridge({
+      bridge,
+      sessionId: "sess-a",
+      send: (frame) => frames.push(frame),
+    });
+
+    emitter.emit("session_exit", { sessionId: "sess-a", exitCode: null });
+
+    expect(frames).toEqual([
+      { type: "pty-exit", sessionId: "sess-a", exitCode: null },
+    ]);
+  });
+
+  it("detach removes BOTH listeners (pty-unsubscribe / ws close cleanup)", () => {
+    const { emitter, bridge } = makeBridge();
+    const frames: PtyWsFrame[] = [];
+    const detach = attachPtySessionWsBridge({
+      bridge,
+      sessionId: "sess-a",
+      send: (frame) => frames.push(frame),
+    });
+
+    detach();
+    emitter.emit("session_output", { sessionId: "sess-a", data: "late" });
+    emitter.emit("session_exit", { sessionId: "sess-a", exitCode: 0 });
+
+    expect(frames).toEqual([]);
+    expect(emitter.listenerCount("session_output")).toBe(0);
+    expect(emitter.listenerCount("session_exit")).toBe(0);
+  });
+
+  it("ignores malformed bridge payloads instead of forwarding junk", () => {
+    const { emitter, bridge } = makeBridge();
+    const frames: PtyWsFrame[] = [];
+    attachPtySessionWsBridge({
+      bridge,
+      sessionId: "sess-a",
+      send: (frame) => frames.push(frame),
+    });
+
+    emitter.emit("session_output", null);
+    emitter.emit("session_output", { sessionId: "sess-a", data: 42 });
+    emitter.emit("session_exit", "sess-a");
+
+    expect(frames).toEqual([]);
+  });
+});
+
+describe("schedulePtySessionStopAfterGrace", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does NOT stop sessions before the grace window elapses", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    const stop = vi.fn();
+    schedulePtySessionStopAfterGrace({
+      clientId: "client-1",
+      graceMs: 30_000,
+      pendingStops,
+      clientHasLiveConnection: () => false,
+      stopOwnedSessions: stop,
+    });
+
+    vi.advanceTimersByTime(29_999);
+    expect(stop).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(pendingStops.size).toBe(0);
+  });
+
+  it("a reconnect within the window cancels the pending stop", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    const stop = vi.fn();
+    schedulePtySessionStopAfterGrace({
+      clientId: "client-1",
+      graceMs: 30_000,
+      pendingStops,
+      clientHasLiveConnection: () => false,
+      stopOwnedSessions: stop,
+    });
+
+    vi.advanceTimersByTime(5_000);
+    expect(cancelPendingPtySessionStop("client-1", pendingStops)).toBe(true);
+
+    vi.advanceTimersByTime(60_000);
+    expect(stop).not.toHaveBeenCalled();
+    expect(pendingStops.size).toBe(0);
+  });
+
+  it("skips scheduling when another live socket shares the clientId (multi-tab)", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    const stop = vi.fn();
+    schedulePtySessionStopAfterGrace({
+      clientId: "client-1",
+      graceMs: 30_000,
+      pendingStops,
+      clientHasLiveConnection: () => true,
+      stopOwnedSessions: stop,
+    });
+
+    expect(pendingStops.size).toBe(0);
+    vi.advanceTimersByTime(60_000);
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("re-checks liveness at fire time (cancel raced the timer)", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    const stop = vi.fn();
+    let live = false;
+    schedulePtySessionStopAfterGrace({
+      clientId: "client-1",
+      graceMs: 30_000,
+      pendingStops,
+      clientHasLiveConnection: () => live,
+      stopOwnedSessions: stop,
+    });
+
+    live = true; // client reconnected but the cancel path was missed
+    vi.advanceTimersByTime(30_000);
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("re-scheduling for the same clientId replaces the previous timer", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    const stop = vi.fn();
+    const schedule = () =>
+      schedulePtySessionStopAfterGrace({
+        clientId: "client-1",
+        graceMs: 30_000,
+        pendingStops,
+        clientHasLiveConnection: () => false,
+        stopOwnedSessions: stop,
+      });
+
+    schedule();
+    vi.advanceTimersByTime(20_000);
+    schedule(); // e.g. close fired again for a short-lived reconnect
+    vi.advanceTimersByTime(20_000); // 40s after first schedule, 20s after second
+    expect(stop).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(10_000);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelPendingPtySessionStop returns false when nothing is pending", () => {
+    const pendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+    expect(cancelPendingPtySessionStop("client-1", pendingStops)).toBe(false);
+  });
+});
+
+describe("resolvePtyDisconnectGraceMs", () => {
+  it("defaults when unset/blank/invalid/negative", () => {
+    expect(resolvePtyDisconnectGraceMs(undefined)).toBe(
+      DEFAULT_PTY_DISCONNECT_GRACE_MS,
+    );
+    expect(resolvePtyDisconnectGraceMs("")).toBe(
+      DEFAULT_PTY_DISCONNECT_GRACE_MS,
+    );
+    expect(resolvePtyDisconnectGraceMs("nope")).toBe(
+      DEFAULT_PTY_DISCONNECT_GRACE_MS,
+    );
+    expect(resolvePtyDisconnectGraceMs("-5")).toBe(
+      DEFAULT_PTY_DISCONNECT_GRACE_MS,
+    );
+  });
+
+  it("honors explicit values, including 0 (legacy stop-on-close)", () => {
+    expect(resolvePtyDisconnectGraceMs("0")).toBe(0);
+    expect(resolvePtyDisconnectGraceMs("15000")).toBe(15_000);
+  });
+});

--- a/packages/agent/src/api/pty-ws-bridge.ts
+++ b/packages/agent/src/api/pty-ws-bridge.ts
@@ -1,0 +1,150 @@
+/**
+ * WebSocket-side PTY session plumbing for the agent server.
+ *
+ * Two responsibilities, both extracted from the `/ws` connection handler in
+ * `server.ts` so they are unit-testable without booting the HTTP server:
+ *
+ * 1. {@link attachPtySessionWsBridge} — subscribes one WS client to a PTY
+ *    session on the console bridge, forwarding `session_output` as
+ *    `pty-output` frames AND `session_exit` as a `pty-exit` frame. Before
+ *    this, only `session_output` was bridged, so a dead session looked
+ *    "ready forever" to the dashboard terminal.
+ *
+ * 2. {@link schedulePtySessionStopAfterGrace} — delays the "client
+ *    disconnected → kill its PTY sessions" reap by a grace window, cancelable
+ *    when the same clientId reconnects. Before this, ANY WS close/error
+ *    (phone lock, app switch, network blip) killed the interactive session
+ *    instantly.
+ */
+
+import type { ConsoleBridge } from "./parse-action-block.ts";
+
+/**
+ * Max UTF-16 length of a single `pty-input` WS message the server accepts.
+ * This is a DoS cap, not a paste-size cap: the client splits larger input
+ * into ordered chunks of at most this size (see `sendPtyInput` in
+ * `packages/ui/src/api/client-agent.ts`, which mirrors this value).
+ */
+export const MAX_PTY_INPUT_MESSAGE_LENGTH = 4096;
+
+/** Grace window before a disconnected client's PTY sessions are stopped. */
+export const DEFAULT_PTY_DISCONNECT_GRACE_MS = 30_000;
+
+/**
+ * Parses `ELIZA_PTY_WS_DISCONNECT_GRACE_MS`-style overrides. Empty/absent or
+ * unparseable/negative values fall back to the default; `0` is honored as
+ * "no grace" (legacy stop-on-close behavior).
+ */
+export function resolvePtyDisconnectGraceMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_PTY_DISCONNECT_GRACE_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_PTY_DISCONNECT_GRACE_MS;
+  }
+  return parsed;
+}
+
+/** Frame shapes the bridge forwards to the WS client. */
+export type PtyWsFrame =
+  | { type: "pty-output"; sessionId: string; data: string }
+  | { type: "pty-exit"; sessionId: string; exitCode: number | null };
+
+/** The two bridge events this module consumes. */
+type PtyBridgeEvents = Pick<ConsoleBridge, "on" | "off">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Attach one WS client's listeners for `sessionId` on the PTY console bridge.
+ * `session_output` → `{type:"pty-output"}` and `session_exit` →
+ * `{type:"pty-exit", exitCode}`. Returns a detach function that removes BOTH
+ * listeners (stored as the per-session unsubscribe in the server's
+ * subscription map).
+ */
+export function attachPtySessionWsBridge(opts: {
+  bridge: PtyBridgeEvents;
+  sessionId: string;
+  /** Caller guards socket readiness (ws.readyState === OPEN) before sending. */
+  send: (frame: PtyWsFrame) => void;
+}): () => void {
+  const { bridge, sessionId, send } = opts;
+
+  const outputListener = (...args: unknown[]): void => {
+    const evt = args[0];
+    if (!isRecord(evt) || evt.sessionId !== sessionId) return;
+    if (typeof evt.data !== "string") return;
+    send({ type: "pty-output", sessionId, data: evt.data });
+  };
+
+  const exitListener = (...args: unknown[]): void => {
+    const evt = args[0];
+    if (!isRecord(evt) || evt.sessionId !== sessionId) return;
+    send({
+      type: "pty-exit",
+      sessionId,
+      exitCode: typeof evt.exitCode === "number" ? evt.exitCode : null,
+    });
+  };
+
+  bridge.on("session_output", outputListener);
+  bridge.on("session_exit", exitListener);
+  return () => {
+    bridge.off("session_output", outputListener);
+    bridge.off("session_exit", exitListener);
+  };
+}
+
+/**
+ * Schedule stopping a disconnected client's PTY sessions after `graceMs`.
+ *
+ * - Skipped entirely when the client still has another live connection.
+ * - Re-checked at fire time, so a reconnect during the window survives even
+ *   if the cancel path raced.
+ * - Re-scheduling for the same clientId replaces the previous timer.
+ * - The timer is unref'd so a pending reap never holds the process open.
+ */
+export function schedulePtySessionStopAfterGrace(opts: {
+  clientId: string;
+  graceMs: number;
+  pendingStops: Map<string, ReturnType<typeof setTimeout>>;
+  clientHasLiveConnection: () => boolean;
+  stopOwnedSessions: () => void;
+}): void {
+  const {
+    clientId,
+    graceMs,
+    pendingStops,
+    clientHasLiveConnection,
+    stopOwnedSessions,
+  } = opts;
+  if (clientHasLiveConnection()) return;
+  const existing = pendingStops.get(clientId);
+  if (existing !== undefined) clearTimeout(existing);
+  const timer = setTimeout(() => {
+    pendingStops.delete(clientId);
+    if (clientHasLiveConnection()) return;
+    stopOwnedSessions();
+  }, graceMs);
+  timer.unref?.();
+  pendingStops.set(clientId, timer);
+}
+
+/**
+ * Cancel a pending grace-window stop for `clientId` (called when the same
+ * clientId re-authenticates a new WS connection). Returns true when a pending
+ * stop was actually canceled — i.e. the client reconnected within the window.
+ */
+export function cancelPendingPtySessionStop(
+  clientId: string,
+  pendingStops: Map<string, ReturnType<typeof setTimeout>>,
+): boolean {
+  const timer = pendingStops.get(clientId);
+  if (timer === undefined) return false;
+  clearTimeout(timer);
+  pendingStops.delete(clientId);
+  return true;
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1803,6 +1803,13 @@ function getOrCreateRuntimeOperationManager(
 }
 
 import {
+  attachPtySessionWsBridge,
+  cancelPendingPtySessionStop,
+  MAX_PTY_INPUT_MESSAGE_LENGTH,
+  resolvePtyDisconnectGraceMs,
+  schedulePtySessionStopAfterGrace,
+} from "./pty-ws-bridge.ts";
+import {
   isLifeOpsCloudPluginRoute,
   maybeRouteAutonomyEventToConversation,
 } from "./server-autonomy-helpers.ts";
@@ -4725,6 +4732,18 @@ export async function startApiServer(opts?: {
     Map<string, () => void>
   >();
   /**
+   * Grace-window reap timers for disconnected PTY owners, keyed by clientId.
+   * A WS close/error no longer kills the client's PTY sessions instantly —
+   * phone lock, app switch, or a network blip would otherwise nuke a live
+   * interactive terminal. The stop is delayed by the grace window and
+   * canceled when the same clientId re-authenticates (ownership survives
+   * reconnects because sessions are owned by clientId, not by socket).
+   */
+  const wsPtyPendingStops = new Map<string, ReturnType<typeof setTimeout>>();
+  const wsPtyDisconnectGraceMs = resolvePtyDisconnectGraceMs(
+    process.env.ELIZA_PTY_WS_DISCONNECT_GRACE_MS,
+  );
+  /**
    * Short-window idempotency cache for client-tagged WS messages, keyed by
    * `${clientId}:${msgId}`. A message resent after a reconnect (same id) is
    * dropped if seen within the TTL. Entries expire so the map stays bounded.
@@ -4851,6 +4870,14 @@ export async function startApiServer(opts?: {
 
     const activateAuthenticatedConnection = () => {
       wsClients.add(ws);
+      if (
+        wsClientId &&
+        cancelPendingPtySessionStop(wsClientId, wsPtyPendingStops)
+      ) {
+        logger.info(
+          `[eliza-api] client ${wsClientId} reconnected within the PTY grace window; keeping its PTY sessions alive`,
+        );
+      }
       addLog("info", "WebSocket client connected", "websocket", [
         "server",
         "websocket",
@@ -4918,6 +4945,35 @@ export async function startApiServer(opts?: {
       }
     };
 
+    /**
+     * Reap this client's PTY sessions only after the disconnect grace window,
+     * and only if no other live authenticated socket carries the same
+     * clientId (multi-tab) and the client hasn't reconnected in the interim.
+     */
+    const scheduleStopOwnedPtySessions = (reason: string): void => {
+      if (!wsClientId) return;
+      const clientId = wsClientId;
+      const clientHasLiveConnection = (): boolean => {
+        for (const other of wsClients) {
+          if (
+            other !== ws &&
+            other.readyState === 1 &&
+            wsClientIds.get(other) === clientId
+          ) {
+            return true;
+          }
+        }
+        return false;
+      };
+      schedulePtySessionStopAfterGrace({
+        clientId,
+        graceMs: wsPtyDisconnectGraceMs,
+        pendingStops: wsPtyPendingStops,
+        clientHasLiveConnection,
+        stopOwnedSessions: () => stopOwnedPtySessions(reason),
+      });
+    };
+
     ws.on("message", async (data: unknown) => {
       try {
         const msg = JSON.parse(String(data));
@@ -4975,28 +5031,19 @@ export async function startApiServer(opts?: {
             // Don't double-subscribe
             if (!subs.has(msg.sessionId)) {
               const targetId = msg.sessionId;
-              const listener = (evt: { sessionId: string; data: string }) => {
-                if (evt.sessionId !== targetId) return;
-                if (ws.readyState === 1) {
-                  ws.send(
-                    JSON.stringify({
-                      type: "pty-output",
-                      sessionId: targetId,
-                      data: evt.data,
-                    }),
-                  );
-                }
-              };
-              bridge.on(
-                "session_output",
-                listener as (...args: unknown[]) => void,
-              );
-              subs.set(targetId, () =>
-                bridge.off(
-                  "session_output",
-                  listener as (...args: unknown[]) => void,
-                ),
-              );
+              // Bridges BOTH `session_output` (→ pty-output) and
+              // `session_exit` (→ pty-exit) so the client can surface a dead
+              // session instead of showing a "ready" pane forever.
+              const detach = attachPtySessionWsBridge({
+                bridge,
+                sessionId: targetId,
+                send: (frame) => {
+                  if (ws.readyState === 1) {
+                    ws.send(JSON.stringify(frame));
+                  }
+                },
+              });
+              subs.set(targetId, detach);
             }
           }
         } else if (
@@ -5024,10 +5071,23 @@ export async function startApiServer(opts?: {
             logger.warn(
               `[eliza-api] pty-input rejected: client ${wsClientId ?? "unknown"} does not own session ${msg.sessionId}`,
             );
-          } else if (msg.data.length > 4096) {
+          } else if (msg.data.length > MAX_PTY_INPUT_MESSAGE_LENGTH) {
+            // Per-message DoS cap only — the client chunks large pastes into
+            // <=cap messages (sendPtyInput), so hitting this means a
+            // misbehaving client. Echo a pty-error so the drop isn't silent.
             logger.warn(
-              `[eliza-api] pty-input rejected: payload too large (${msg.data.length} bytes) for session ${msg.sessionId}`,
+              `[eliza-api] pty-input rejected: payload too large (${msg.data.length} chars) for session ${msg.sessionId}`,
             );
+            if (ws.readyState === 1) {
+              ws.send(
+                JSON.stringify({
+                  type: "pty-error",
+                  sessionId: msg.sessionId,
+                  code: "input-too-large",
+                  message: `pty-input exceeds ${MAX_PTY_INPUT_MESSAGE_LENGTH} chars; send large input in chunks`,
+                }),
+              );
+            }
           } else {
             const bridge = getPtyConsoleBridge(state);
             if (bridge) {
@@ -5108,7 +5168,7 @@ export async function startApiServer(opts?: {
         for (const unsub of subs.values()) unsub();
         subs.clear();
       }
-      stopOwnedPtySessions("websocket close");
+      scheduleStopOwnedPtySessions("websocket close");
       addLog("info", "WebSocket client disconnected", "websocket", [
         "server",
         "websocket",
@@ -5127,7 +5187,7 @@ export async function startApiServer(opts?: {
         for (const unsub of subs.values()) unsub();
         subs.clear();
       }
-      stopOwnedPtySessions("websocket error");
+      scheduleStopOwnedPtySessions("websocket error");
     });
   });
 

--- a/packages/ui/src/api/client-agent-pty-input.test.ts
+++ b/packages/ui/src/api/client-agent-pty-input.test.ts
@@ -1,0 +1,112 @@
+// Regression: pasting >4096 chars into the web terminal was silently
+// discarded. xterm delivers a paste as ONE onData chunk, the client sent it
+// as ONE ws message, and the agent server drops any pty-input whose data
+// exceeds its 4096-char per-message cap (DoS protection) with only a server
+// log. sendPtyInput must therefore split oversized input into ordered
+// <=4096-char messages that reassemble to the full paste.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { chunkPtyInput, MAX_PTY_INPUT_CHUNK_LENGTH } from "./client-agent";
+import { ElizaClient } from "./client-base";
+
+function makeClient(): {
+  client: ElizaClient;
+  sent: Array<Record<string, unknown>>;
+} {
+  setBootConfig({ branding: {} });
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  const sent: Array<Record<string, unknown>> = [];
+  vi.spyOn(client, "sendWsMessage").mockImplementation(
+    (data: Record<string, unknown>) => {
+      sent.push(data);
+    },
+  );
+  return { client, sent };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sendPtyInput — paste chunking", () => {
+  it("sends a normal keystroke as a single message (previous behavior)", () => {
+    const { client, sent } = makeClient();
+    client.sendPtyInput("sess-1", "ls -la\r");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: "pty-input",
+      sessionId: "sess-1",
+      data: "ls -la\r",
+    });
+  });
+
+  it("splits a >4096-char paste into ordered <=4096 chunks covering the whole input", () => {
+    const { client, sent } = makeClient();
+    // A 10,000-char "stack trace" whose content encodes its own position, so
+    // reassembly order is verifiable, not just length.
+    const paste = Array.from({ length: 1000 }, (_, i) =>
+      `line-${String(i).padStart(4, "0")}`.padEnd(10, "x"),
+    ).join("");
+    expect(paste.length).toBe(10_000);
+
+    client.sendPtyInput("sess-1", paste);
+
+    expect(sent.length).toBe(3);
+    for (const msg of sent) {
+      expect(msg.type).toBe("pty-input");
+      expect(msg.sessionId).toBe("sess-1");
+      expect(typeof msg.data).toBe("string");
+      expect((msg.data as string).length).toBeLessThanOrEqual(
+        MAX_PTY_INPUT_CHUNK_LENGTH,
+      );
+    }
+    // In-order reassembly reproduces the paste exactly.
+    expect(sent.map((msg) => msg.data as string).join("")).toBe(paste);
+  });
+
+  it("sends an exactly-4096-char input as one message", () => {
+    const { client, sent } = makeClient();
+    const paste = "a".repeat(MAX_PTY_INPUT_CHUNK_LENGTH);
+    client.sendPtyInput("sess-1", paste);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.data).toBe(paste);
+  });
+});
+
+describe("chunkPtyInput", () => {
+  it("returns the input untouched when it fits in one chunk", () => {
+    expect(chunkPtyInput("")).toEqual([""]);
+    expect(chunkPtyInput("hello")).toEqual(["hello"]);
+  });
+
+  it("never splits a surrogate pair across a chunk boundary", () => {
+    // "😀" is a surrogate pair; placing it to straddle the 4096 boundary
+    // forces the chunker to end the first chunk one unit early.
+    const paste = `${"a".repeat(MAX_PTY_INPUT_CHUNK_LENGTH - 1)}😀${"b".repeat(200)}`;
+    const chunks = chunkPtyInput(paste);
+
+    expect(chunks.join("")).toBe(paste);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(MAX_PTY_INPUT_CHUNK_LENGTH);
+      // No chunk starts or ends mid-pair.
+      const first = chunk.charCodeAt(0);
+      const last = chunk.charCodeAt(chunk.length - 1);
+      expect(first >= 0xdc00 && first <= 0xdfff).toBe(false);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+    }
+    expect(chunks[0]?.length).toBe(MAX_PTY_INPUT_CHUNK_LENGTH - 1);
+  });
+
+  it("covers arbitrary sizes with ordered <=cap chunks", () => {
+    for (const size of [4097, 8192, 12_289]) {
+      const paste = Array.from({ length: size }, (_, i) =>
+        String.fromCharCode(97 + (i % 26)),
+      ).join("");
+      const chunks = chunkPtyInput(paste);
+      expect(chunks.every((c) => c.length <= MAX_PTY_INPUT_CHUNK_LENGTH)).toBe(
+        true,
+      );
+      expect(chunks.join("")).toBe(paste);
+    }
+  });
+});

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -4305,12 +4305,54 @@ ElizaClient.prototype.unsubscribePtyOutput = function (
   this.sendWsMessage({ type: "pty-unsubscribe", sessionId });
 };
 
+/**
+ * Max UTF-16 length of a single `pty-input` WS message the agent server
+ * accepts (its per-message DoS cap — see `MAX_PTY_INPUT_MESSAGE_LENGTH` in
+ * `packages/agent/src/api/pty-ws-bridge.ts`). Anything larger must be split
+ * client-side: xterm delivers an entire paste as ONE `onData` call, so a
+ * pasted stack trace/diff easily exceeds this.
+ */
+export const MAX_PTY_INPUT_CHUNK_LENGTH = 4096;
+
+/**
+ * Split PTY input into ordered chunks of at most `maxLength` UTF-16 units so
+ * each fits under the server's per-message cap. Never splits a surrogate
+ * pair across chunks (a lone surrogate would be mangled to U+FFFD when the
+ * server writes the chunk to the PTY as UTF-8). Input at or under the cap is
+ * returned as a single chunk, preserving the previous one-message behavior.
+ */
+export function chunkPtyInput(
+  data: string,
+  maxLength: number = MAX_PTY_INPUT_CHUNK_LENGTH,
+): string[] {
+  if (data.length <= maxLength) return [data];
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < data.length) {
+    let end = Math.min(start + maxLength, data.length);
+    if (end < data.length && end - start > 1) {
+      const boundary = data.charCodeAt(end - 1);
+      // High surrogate at the cut point → keep the pair together by ending
+      // the chunk one unit earlier.
+      if (boundary >= 0xd800 && boundary <= 0xdbff) end -= 1;
+    }
+    chunks.push(data.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}
+
 ElizaClient.prototype.sendPtyInput = function (
   this: ElizaClient,
   sessionId,
   data,
 ) {
-  this.sendWsMessage({ type: "pty-input", sessionId, data });
+  // One WS message per chunk, sent in order. Each message gets its own msgId
+  // (sendWsMessage stamps it), and both the open-socket path and the offline
+  // send-queue preserve call order, so the PTY receives the paste intact.
+  for (const chunk of chunkPtyInput(data)) {
+    this.sendWsMessage({ type: "pty-input", sessionId, data: chunk });
+  }
 };
 
 ElizaClient.prototype.resizePty = function (

--- a/packages/ui/src/components/cockpit/cockpit-modes.ts
+++ b/packages/ui/src/components/cockpit/cockpit-modes.ts
@@ -23,7 +23,14 @@ import type {
 /** Eliza Cloud inference tiers. `small` is fast; `large` is smart. */
 export type ElizaCloudTier = "small" | "large";
 
-/** Canonical Cerebras model id per tier. */
+/**
+ * Canonical Cerebras model id per tier.
+ *
+ * NOTE: until a distinct "smart" model ships, BOTH tiers lower to the same
+ * model. Tier UI must check `small === large` and hide/disable the choice when
+ * they collapse — flipping between identical tiers is a no-op that still
+ * persists policy and restarts the live worker (see CockpitSessionPane).
+ */
 export const ELIZA_CLOUD_TIER_MODEL: Record<ElizaCloudTier, string> = {
   small: DEFAULT_CEREBRAS_TEXT_MODEL,
   large: DEFAULT_CEREBRAS_TEXT_MODEL,

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ViewEntry } from "../../hooks/view-catalog";
-import { canonicalLauncherId, curateLauncherPages } from "./launcher-curation";
+import {
+  canonicalLauncherId,
+  curateLauncherPages,
+  LAUNCHER_HIDDEN_IDS,
+} from "./launcher-curation";
 
 const ENABLED = { developer: true, preview: true } as const;
 
@@ -288,6 +292,21 @@ describe("curateLauncherPages — full realistic view set", () => {
       "camera",
       "files",
     ]);
+  });
+});
+
+describe("launcher dead-tile guard", () => {
+  it("hides the legacy 'rolodex' alias (no directViews branch → would land on the fallback)", () => {
+    // rolodex is a routable tab with a launcher tile but no renderStaticViewRouterTab
+    // branch, so tapping it bounced the user back to the launcher fallback. The
+    // real contact surface is `relationships`.
+    expect(LAUNCHER_HIDDEN_IDS.has("rolodex")).toBe(true);
+    const pages = curateLauncherPages(
+      [entry("chat"), entry("rolodex"), entry("relationships")],
+      { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+    );
+    expect(pages.flat().map((e) => e.id)).not.toContain("rolodex");
+    expect(pages.flat().map((e) => e.id)).toContain("relationships");
   });
 });
 

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -82,6 +82,12 @@ export const LAUNCHER_HIDDEN_IDS: ReadonlySet<string> = new Set([
   // Wallet sub-views — reached from inside the Wallet app, not the launcher.
   "hyperliquid",
   "polymarket",
+  // Legacy alias for the relationships/contact-graph surface: `rolodex` is a
+  // routable tab (TAB_PATHS "/rolodex") with a launcher tile but NO directViews
+  // branch in renderStaticViewRouterTab, so tapping it lands on the
+  // ViewUnavailableFallback (bounces the user back to the launcher). The real
+  // contact surface is `relationships`; hide this dead alias.
+  "rolodex",
 ]);
 
 /**

--- a/packages/ui/src/components/settings/SecretsManagerSection.tsx
+++ b/packages/ui/src/components/settings/SecretsManagerSection.tsx
@@ -1,5 +1,10 @@
 import { KeyRound, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../api/client";
 import {
   dispatchSecretsManagerOpen,
   useSecretsManagerModalState,
@@ -83,8 +88,12 @@ export function SecretsManagerSection() {
 
   const refreshSummary = useCallback(async () => {
     const [bRes, pRes] = await Promise.all([
-      fetch("/api/secrets/manager/backends"),
-      fetch("/api/secrets/manager/preferences"),
+      client.rawRequest("/api/secrets/manager/backends", undefined, {
+        allowNonOk: true,
+      }),
+      client.rawRequest("/api/secrets/manager/preferences", undefined, {
+        allowNonOk: true,
+      }),
     ]);
     if (!bRes.ok || !pRes.ok) return;
     const bJson = (await bRes.json()) as { backends: BackendStatus[] };
@@ -333,13 +342,27 @@ function VaultBody({
         agentsRes,
         appsRes,
       ] = await Promise.all([
-        fetch("/api/secrets/manager/backends"),
-        fetch("/api/secrets/manager/preferences"),
-        fetch("/api/secrets/manager/install/methods"),
-        fetch("/api/secrets/inventory"),
-        fetch("/api/secrets/routing"),
-        fetch("/api/agents").catch(() => null),
-        fetch("/api/apps").catch(() => null),
+        client.rawRequest("/api/secrets/manager/backends", undefined, {
+          allowNonOk: true,
+        }),
+        client.rawRequest("/api/secrets/manager/preferences", undefined, {
+          allowNonOk: true,
+        }),
+        client.rawRequest("/api/secrets/manager/install/methods", undefined, {
+          allowNonOk: true,
+        }),
+        client.rawRequest("/api/secrets/inventory", undefined, {
+          allowNonOk: true,
+        }),
+        client.rawRequest("/api/secrets/routing", undefined, {
+          allowNonOk: true,
+        }),
+        client
+          .rawRequest("/api/agents", undefined, { allowNonOk: true })
+          .catch(() => null),
+        client
+          .rawRequest("/api/apps", undefined, { allowNonOk: true })
+          .catch(() => null),
       ]);
       if (!backendsRes.ok)
         throw new Error(`backends: HTTP ${backendsRes.status}`);
@@ -401,8 +424,12 @@ function VaultBody({
   // full re-load but always gives sibling tabs the latest data.
   const refreshInventory = useCallback(async () => {
     const [entriesRes, routingRes] = await Promise.all([
-      fetch("/api/secrets/inventory"),
-      fetch("/api/secrets/routing"),
+      client.rawRequest("/api/secrets/inventory", undefined, {
+        allowNonOk: true,
+      }),
+      client.rawRequest("/api/secrets/routing", undefined, {
+        allowNonOk: true,
+      }),
     ]);
     if (entriesRes.ok) {
       const json = (await entriesRes.json()) as { entries: VaultEntryMeta[] };
@@ -426,11 +453,15 @@ function VaultBody({
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/secrets/manager/preferences", {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ preferences }),
-      });
+      const res = await client.rawRequest(
+        "/api/secrets/manager/preferences",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ preferences }),
+        },
+        { allowNonOk: true },
+      );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = (await res.json()) as { preferences: ManagerPreferences };
       setPreferences(json.preferences);
@@ -444,11 +475,15 @@ function VaultBody({
 
   const onSignout = useCallback(
     async (backendId: InstallableBackendId) => {
-      const res = await fetch("/api/secrets/manager/signout", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ backendId }),
-      });
+      const res = await client.rawRequest(
+        "/api/secrets/manager/signout",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ backendId }),
+        },
+        { allowNonOk: true },
+      );
       if (!res.ok) {
         setError(`sign-out HTTP ${res.status}`);
         return;

--- a/packages/ui/src/components/settings/VaultInventoryPanel.tsx
+++ b/packages/ui/src/components/settings/VaultInventoryPanel.tsx
@@ -44,6 +44,11 @@ import {
   useState,
 } from "react";
 import { useAgentElement } from "../../agent-surface";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../api/client";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -173,7 +178,9 @@ export function VaultInventoryPanel(props: VaultInventoryPanelProps = {}) {
   const load = useCallback(async () => {
     setError(null);
     try {
-      const res = await fetch("/api/secrets/inventory");
+      const res = await client.rawRequest("/api/secrets/inventory", undefined, {
+        allowNonOk: true,
+      });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = (await res.json()) as { entries: VaultEntryMeta[] };
       setInternalEntries(body.entries);
@@ -406,8 +413,10 @@ const EntryRow = memo(function EntryRow({
   const reveal = useCallback(async () => {
     setRevealing(true);
     setRevealError(null);
-    const res = await fetch(
+    const res = await client.rawRequest(
       `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
+      undefined,
+      { allowNonOk: true },
     );
     if (!res.ok) {
       setRevealError(`HTTP ${res.status}`);
@@ -437,9 +446,10 @@ const EntryRow = memo(function EntryRow({
       `Delete "${entry.label}"? This drops the value, every profile, and the metadata.`,
     );
     if (!confirmed) return;
-    const res = await fetch(
+    const res = await client.rawRequest(
       `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
       { method: "DELETE" },
+      { allowNonOk: true },
     );
     if (res.ok) onChanged();
   }, [entry.key, entry.label, onChanged]);
@@ -659,7 +669,7 @@ function ProfilesPanel({
       if (!newId || !newValue) return;
       setSubmitting(true);
       setErr(null);
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}/profiles`,
         {
           method: "POST",
@@ -670,6 +680,7 @@ function ProfilesPanel({
             value: newValue,
           }),
         },
+        { allowNonOk: true },
       );
       setSubmitting(false);
       if (!res.ok) {
@@ -687,13 +698,14 @@ function ProfilesPanel({
 
   const onActivate = useCallback(
     async (profileId: string) => {
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}/active-profile`,
         {
           method: "PUT",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ profileId }),
         },
+        { allowNonOk: true },
       );
       if (res.ok) onChanged();
     },
@@ -704,9 +716,10 @@ function ProfilesPanel({
     async (profileId: string) => {
       const confirmed = window.confirm(`Delete profile "${profileId}"?`);
       if (!confirmed) return;
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}/profiles/${encodeURIComponent(profileId)}`,
         { method: "DELETE" },
+        { allowNonOk: true },
       );
       if (res.ok) onChanged();
     },
@@ -716,11 +729,15 @@ function ProfilesPanel({
   const onMigrate = useCallback(async () => {
     setMigrating(true);
     setErr(null);
-    const res = await fetch("/api/secrets/inventory/migrate-to-profiles", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ key: entry.key }),
-    });
+    const res = await client.rawRequest(
+      "/api/secrets/inventory/migrate-to-profiles",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key: entry.key }),
+      },
+      { allowNonOk: true },
+    );
     setMigrating(false);
     if (!res.ok) {
       setErr(`HTTP ${res.status}`);
@@ -1110,7 +1127,7 @@ function AddSecretForm({
       if (!key.trim() || !value) return;
       setSubmitting(true);
       setErr(null);
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(key.trim())}`,
         {
           method: "PUT",
@@ -1122,6 +1139,7 @@ function AddSecretForm({
             category,
           }),
         },
+        { allowNonOk: true },
       );
       setSubmitting(false);
       if (!res.ok) {

--- a/packages/ui/src/components/settings/VoiceSection.helpers.ts
+++ b/packages/ui/src/components/settings/VoiceSection.helpers.ts
@@ -9,7 +9,5 @@ export const DEFAULT_VAD_AUTO_STOP_PREFS: VadAutoStopPrefs = {
 
 export const DEFAULT_VOICE_SECTION_PREFS: VoiceSectionPrefs = {
   continuous: DEFAULT_VOICE_CONTINUOUS_MODE,
-  cloudFirstLineCache: false,
-  autoLearnVoices: true,
   vadAutoStop: DEFAULT_VAD_AUTO_STOP_PREFS,
 };

--- a/packages/ui/src/components/settings/VoiceSection.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.test.tsx
@@ -37,10 +37,24 @@ describe("VoiceSection", () => {
     expect(screen.getByTestId("voice-section-wake-row")).toBeTruthy();
     expect(screen.getByTestId("voice-section-models")).toBeTruthy();
     expect(screen.getByTestId("voice-profile-section")).toBeTruthy();
-    expect(screen.getByTestId("voice-section-privacy")).toBeTruthy();
     // The local-vs-cloud strategy control was removed — per-modality routing
     // is owned by RoutingMatrix, not VoiceSection.
     expect(screen.queryByTestId("voice-section-strategy-select")).toBeNull();
+  });
+
+  it("no longer renders the dead privacy toggles (cloud cache / auto-learn)", () => {
+    render(
+      <VoiceSection
+        {...baseProps}
+        prefs={DEFAULT_VOICE_SECTION_PREFS}
+        onPrefsChange={() => {}}
+      />,
+    );
+    // `messages.voice.{cloudFirstLineCache,autoLearnVoices}` have no readers;
+    // the controls were removed so the UI stops offering no-op privacy opt-ins.
+    expect(screen.queryByTestId("voice-section-privacy")).toBeNull();
+    expect(screen.queryByTestId("voice-section-cloud-cache-toggle")).toBeNull();
+    expect(screen.queryByTestId("voice-section-auto-learn-toggle")).toBeNull();
   });
 
   it("renders the models slot when supplied", () => {
@@ -83,44 +97,6 @@ describe("VoiceSection", () => {
     expect(onPrefsChange).toHaveBeenCalledTimes(1);
     const call = onPrefsChange.mock.calls[0]?.[0] as VoiceSectionPrefs;
     expect(call.continuous).toBe("always-on");
-  });
-
-  it("propagates auto-learn-voices changes", () => {
-    const onPrefsChange = vi.fn();
-    render(
-      <VoiceSection
-        {...baseProps}
-        prefs={DEFAULT_VOICE_SECTION_PREFS}
-        onPrefsChange={onPrefsChange}
-      />,
-    );
-    const autoLearn = screen.getByTestId(
-      "voice-section-auto-learn-toggle",
-    ) as HTMLInputElement;
-    // Default is on; clicking turns it off.
-    expect(autoLearn.checked).toBe(true);
-    fireEvent.click(autoLearn);
-    expect(onPrefsChange).toHaveBeenCalled();
-    const call = onPrefsChange.mock.calls[0]?.[0] as VoiceSectionPrefs;
-    expect(call.autoLearnVoices).toBe(false);
-  });
-
-  it("toggles the privacy switches", () => {
-    const onPrefsChange = vi.fn();
-    render(
-      <VoiceSection
-        {...baseProps}
-        prefs={DEFAULT_VOICE_SECTION_PREFS}
-        onPrefsChange={onPrefsChange}
-      />,
-    );
-    const cloudToggle = screen.getByTestId(
-      "voice-section-cloud-cache-toggle",
-    ) as HTMLInputElement;
-    expect(cloudToggle.checked).toBe(false);
-    fireEvent.click(cloudToggle);
-    const call = onPrefsChange.mock.calls[0]?.[0] as VoiceSectionPrefs;
-    expect(call.cloudFirstLineCache).toBe(true);
   });
 
   it("falls back to GOOD tier when null is supplied", () => {

--- a/packages/ui/src/components/settings/VoiceSection.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.tsx
@@ -1,13 +1,13 @@
 /**
  * VoiceSection — top-level Settings → Voice tree. Mounts the device-tier
  * banner, continuous-chat mode, wake word, end-of-turn tuning, the models
- * slot, voice profiles, and privacy toggles.
+ * slot, and voice profiles.
  *
  * Per-modality local-vs-cloud routing is owned by the RoutingMatrix control
  * (per-slot policy rows), not by this section.
  */
 
-import { Database, Mic, Shield, Sliders, Timer } from "lucide-react";
+import { Database, Mic, Sliders, Timer } from "lucide-react";
 import * as React from "react";
 import { useAgentElement } from "../../agent-surface";
 import type { VoiceProfilesClient } from "../../api/client-voice-profiles";
@@ -108,8 +108,6 @@ function VadSlider({
 
 export interface VoiceSectionPrefs {
   continuous: VoiceContinuousMode;
-  cloudFirstLineCache: boolean;
-  autoLearnVoices: boolean;
   /**
    * VAD / local-ASR end-of-turn tuning. Optional so older persisted prefs (and
    * the registry mount) stay valid; falls back to {@link DEFAULT_VAD_AUTO_STOP_PREFS}.
@@ -188,31 +186,6 @@ export function VoiceSection({
       status: wakeWordEnabled ? "active" : "inactive",
       onActivate: () => onWakeWordToggle?.(!wakeWordEnabled),
     });
-  const { ref: cloudCacheRef, agentProps: cloudCacheAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "voice-section-cloud-cache-toggle",
-      role: "toggle",
-      label: t("voicesection.cloudFirstLineCacheAria", {
-        defaultValue: "Cloud first-line cache opt-in",
-      }),
-      group: "voice-section",
-      status: prefs.cloudFirstLineCache ? "active" : "inactive",
-      onActivate: () =>
-        updatePrefs({ cloudFirstLineCache: !prefs.cloudFirstLineCache }),
-    });
-  const { ref: autoLearnRef, agentProps: autoLearnAgentProps } =
-    useAgentElement<HTMLInputElement>({
-      id: "voice-section-auto-learn-toggle",
-      role: "toggle",
-      label: t("voicesection.autoLearnVoices", {
-        defaultValue: "Auto-learn new voices",
-      }),
-      group: "voice-section",
-      status: prefs.autoLearnVoices ? "active" : "inactive",
-      onActivate: () =>
-        updatePrefs({ autoLearnVoices: !prefs.autoLearnVoices }),
-    });
-
   return (
     <section data-testid="voice-section" className={cn(className)}>
       <SettingsStack>
@@ -357,57 +330,19 @@ export function VoiceSection({
           <VoiceProfileSection profilesClient={profilesClient} />
         </SettingsGroup>
 
-        <SettingsGroup
-          title={t("voicesection.privacy", { defaultValue: "Privacy" })}
-          data-testid="voice-section-privacy"
-        >
-          <SettingsRow
-            icon={Shield}
-            label={t("voicesection.cloudFirstLineCache", {
-              defaultValue: "Cloud first-line cache",
-            })}
-            control={
-              <input
-                ref={cloudCacheRef}
-                type="checkbox"
-                checked={prefs.cloudFirstLineCache}
-                onChange={(e) =>
-                  updatePrefs({ cloudFirstLineCache: e.target.checked })
-                }
-                data-testid="voice-section-cloud-cache-toggle"
-                className="h-5 w-5 rounded-sm border-border accent-accent"
-                aria-current={prefs.cloudFirstLineCache ? "true" : undefined}
-                aria-label={t("voicesection.cloudFirstLineCacheAria", {
-                  defaultValue: "Cloud first-line cache opt-in",
-                })}
-                {...cloudCacheAgentProps}
-              />
-            }
-          />
-          <SettingsRow
-            icon={Shield}
-            label={t("voicesection.autoLearnVoices", {
-              defaultValue: "Auto-learn new voices",
-            })}
-            control={
-              <input
-                ref={autoLearnRef}
-                type="checkbox"
-                checked={prefs.autoLearnVoices}
-                onChange={(e) =>
-                  updatePrefs({ autoLearnVoices: e.target.checked })
-                }
-                data-testid="voice-section-auto-learn-toggle"
-                className="h-5 w-5 rounded-sm border-border accent-accent"
-                aria-current={prefs.autoLearnVoices ? "true" : undefined}
-                aria-label={t("voicesection.autoLearnVoices", {
-                  defaultValue: "Auto-learn new voices",
-                })}
-                {...autoLearnAgentProps}
-              />
-            }
-          />
-        </SettingsGroup>
+        {/*
+          The former "Privacy" group ("Cloud first-line cache" and
+          "Auto-learn new voices" toggles) was removed: both persisted to
+          `messages.voice.{cloudFirstLineCache,autoLearnVoices}` but NOTHING
+          reads those keys, so they were dead privacy opt-ins. The first-line
+          cache implementation exists (`wrapWithFirstLineCache`, wired
+          unconditionally via
+          packages/app-core/src/runtime/tts-cache-wiring.ts →
+          tts-provider-registry.ts) but does not consult the setting; gate that
+          consumer on `messages.voice.cloudFirstLineCache` before re-adding the
+          toggle. `autoLearnVoices` has no consumer anywhere — build the
+          voice-profile auto-learn pipeline first.
+        */}
       </SettingsStack>
     </section>
   );

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -96,3 +96,56 @@ describe("VoiceSectionMount — wake-word toggle wiring (FIX 3)", () => {
     expect(toggle.checked).toBe(false);
   });
 });
+
+const CONTINUOUS_KEY = "eliza:voice:continuous-chat-mode";
+
+describe("VoiceSectionMount — continuous-chat localStorage mirror", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clientMock.getConfig.mockResolvedValue({});
+    clientMock.updateConfig.mockResolvedValue({});
+    clientMock.getLocalInferenceDeviceTier.mockResolvedValue({
+      tier: "GOOD",
+      reason: "",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("mirrors a continuous-chat change into the localStorage key the chat surfaces read", async () => {
+    const user = userEvent.setup();
+    render(<VoiceSectionMount />);
+    const row = await screen.findByTestId("voice-section-continuous-row");
+    const alwaysOn = row.querySelector(
+      "button[data-mode='always-on']",
+    ) as HTMLButtonElement;
+    expect(alwaysOn).toBeTruthy();
+
+    await user.click(alwaysOn);
+
+    // ChatView / useShellController implement continuous chat by reading
+    // loadContinuousChatMode() (this key) — the server config alone is not
+    // enough, so the control must mirror the store on every change.
+    await waitFor(() =>
+      expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe("always-on"),
+    );
+    // And the server config still gets the same value.
+    await waitFor(() => expect(clientMock.updateConfig).toHaveBeenCalled());
+    const payload = clientMock.updateConfig.mock.calls[0]?.[0] as {
+      messages: { voice: { continuous: string } };
+    };
+    expect(payload.messages.voice.continuous).toBe("always-on");
+  });
+
+  it("seeds the localStorage mirror from the server config on load", async () => {
+    clientMock.getConfig.mockResolvedValue({
+      messages: { voice: { continuous: "vad-gated" } },
+    });
+    render(<VoiceSectionMount />);
+    await waitFor(() =>
+      expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe("vad-gated"),
+    );
+  });
+});

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -18,6 +18,7 @@ import type { DeviceTier } from "../../api/client-local-inference";
 import { createVoiceProfilesClient } from "../../api/client-voice-profiles";
 import {
   loadWakeWordEnabled,
+  saveContinuousChatMode,
   saveVadAutoStop,
   saveWakeWordEnabled,
 } from "../../state/persistence";
@@ -69,18 +70,13 @@ function readStoredVoicePrefs(
     string,
     unknown
   >;
+  // Note: legacy `cloudFirstLineCache` / `autoLearnVoices` keys may still sit
+  // in older persisted `messages.voice` blobs; they are dead (no readers) and
+  // intentionally dropped here — see the removal note in VoiceSection.tsx.
   return {
     continuous: isContinuousMode(stored.continuous)
       ? stored.continuous
       : DEFAULT_VOICE_SECTION_PREFS.continuous,
-    cloudFirstLineCache:
-      typeof stored.cloudFirstLineCache === "boolean"
-        ? stored.cloudFirstLineCache
-        : DEFAULT_VOICE_SECTION_PREFS.cloudFirstLineCache,
-    autoLearnVoices:
-      typeof stored.autoLearnVoices === "boolean"
-        ? stored.autoLearnVoices
-        : DEFAULT_VOICE_SECTION_PREFS.autoLearnVoices,
     vadAutoStop: readVadAutoStop(stored.vadAutoStop),
   };
 }
@@ -108,8 +104,13 @@ export function VoiceSectionMount(): React.ReactElement {
       if (cancelled) return;
       const loaded = readStoredVoicePrefs(config);
       setPrefs(loaded);
-      // Seed the local mirror so the capture hot path reads the server value.
+      // Seed the local mirrors so the capture hot path reads the server value.
       if (loaded.vadAutoStop) saveVadAutoStop(loaded.vadAutoStop);
+      // The surfaces that implement continuous chat (ChatView,
+      // useShellController) read ONLY the localStorage mirror via
+      // loadContinuousChatMode — never `messages.voice.continuous` — so the
+      // server value must be seeded into it, same as vadAutoStop above.
+      saveContinuousChatMode(loaded.continuous);
     })();
     return () => {
       cancelled = true;
@@ -143,6 +144,10 @@ export function VoiceSectionMount(): React.ReactElement {
       // Mirror to localStorage immediately so the capture path picks up the new
       // VAD thresholds without waiting on the config round-trip.
       if (next.vadAutoStop) saveVadAutoStop(next.vadAutoStop);
+      // Mirror continuous-chat mode too: ChatView / useShellController read it
+      // synchronously from localStorage (loadContinuousChatMode) and never see
+      // the `messages.voice.continuous` config blob.
+      saveContinuousChatMode(next.continuous);
       try {
         const config = await client.getConfig();
         const messages = (config.messages ?? {}) as Record<string, unknown>;

--- a/packages/ui/src/components/settings/WalletKeysSection.test.tsx
+++ b/packages/ui/src/components/settings/WalletKeysSection.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+/**
+ * WalletKeysSection — regression tests for the fetch-routing fix: every
+ * secrets/wallet request must go through the shared `client` (which applies
+ * the configured apiBase + injected auth token), never bare `fetch` against
+ * the page origin. Also pins the 404 → "route not mounted" empty-state
+ * mapping.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientMock = vi.hoisted(() => ({
+  rawRequest: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+import { WalletKeysSection } from "./WalletKeysSection";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("WalletKeysSection — requests route through the shared client", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clientMock.rawRequest.mockReset();
+    // Any bare fetch here would hit the page origin without the client's
+    // apiBase/token — the exact bug this guards against.
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("bare fetch must not be used"));
+  });
+
+  afterEach(() => {
+    cleanup();
+    fetchSpy.mockRestore();
+  });
+
+  it("loads the wallet inventory via client.rawRequest, not bare fetch", async () => {
+    clientMock.rawRequest.mockResolvedValue(
+      jsonResponse(200, {
+        entries: [
+          {
+            key: "EVM_PRIVATE_KEY",
+            label: "EVM_PRIVATE_KEY",
+            category: "wallet",
+            hasProfiles: false,
+            kind: "secret",
+          },
+        ],
+      }),
+    );
+
+    render(<WalletKeysSection />);
+
+    await screen.findByTestId("wallet-keys-list");
+    expect(clientMock.rawRequest).toHaveBeenCalledWith(
+      "/api/secrets/inventory?category=wallet",
+      undefined,
+      { allowNonOk: true },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("wallet-keys-error")).toBeNull();
+  });
+
+  it("maps a 404 (secrets route not mounted) to the empty state, not an error", async () => {
+    clientMock.rawRequest.mockResolvedValue(
+      jsonResponse(404, { error: "not found" }),
+    );
+
+    render(<WalletKeysSection />);
+
+    await screen.findByTestId("wallet-keys-empty");
+    expect(screen.queryByTestId("wallet-keys-error")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("surfaces non-404 HTTP failures as an error banner", async () => {
+    clientMock.rawRequest.mockResolvedValue(
+      jsonResponse(500, { error: "boom" }),
+    );
+
+    render(<WalletKeysSection />);
+
+    const banner = await screen.findByTestId("wallet-keys-error");
+    expect(banner.textContent).toContain("HTTP 500");
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet-keys-empty")).toBeTruthy(),
+    );
+  });
+});

--- a/packages/ui/src/components/settings/WalletKeysSection.tsx
+++ b/packages/ui/src/components/settings/WalletKeysSection.tsx
@@ -9,6 +9,11 @@
 import { Eye, EyeOff, Loader2, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../api/client";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
 import { Label } from "../ui/label";
@@ -115,7 +120,11 @@ export function WalletKeysSection() {
     setError(null);
     setEntries(null);
     try {
-      const res = await fetch("/api/secrets/inventory?category=wallet");
+      const res = await client.rawRequest(
+        "/api/secrets/inventory?category=wallet",
+        undefined,
+        { allowNonOk: true },
+      );
       if (res.status === 404) {
         // Secrets/vault route not mounted on this surface (e.g. the mobile
         // agent) — show the empty "no wallet keys" state, not a raw red
@@ -150,8 +159,10 @@ export function WalletKeysSection() {
     async (key: string) => {
       setRevealLoading((prev) => ({ ...prev, [key]: true }));
       try {
-        const res = await fetch(
+        const res = await client.rawRequest(
           `/api/secrets/inventory/${encodeURIComponent(key)}`,
+          undefined,
+          { allowNonOk: true },
         );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = (await res.json()) as RevealPayload;
@@ -198,9 +209,10 @@ export function WalletKeysSection() {
         }),
       );
       if (!ok) return;
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(entry.key)}`,
         { method: "DELETE" },
+        { allowNonOk: true },
       );
       if (!res.ok) {
         setError(`HTTP ${res.status}`);
@@ -219,7 +231,7 @@ export function WalletKeysSection() {
       if (!key || !value) return;
       setSubmitting(true);
       setError(null);
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/inventory/${encodeURIComponent(key)}`,
         {
           method: "PUT",
@@ -229,6 +241,7 @@ export function WalletKeysSection() {
             category: "wallet",
           }),
         },
+        { allowNonOk: true },
       );
       setSubmitting(false);
       if (!res.ok) {

--- a/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/LoginsTab.tsx
@@ -7,6 +7,11 @@
 import { Bot, ExternalLink, Loader2, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { useAgentElement } from "../../../agent-surface";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../../api/client";
 import { useTranslation } from "../../../state/TranslationContext.hooks";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
@@ -136,8 +141,10 @@ export function LoginsTab() {
       const unique = Array.from(new Set(domains.filter(Boolean)));
       const responses = await Promise.all(
         unique.map(async (d): Promise<readonly [string, boolean]> => {
-          const res = await fetch(
+          const res = await client.rawRequest(
             `/api/secrets/logins/${encodeURIComponent(d)}/autoallow`,
+            undefined,
+            { allowNonOk: true },
           );
           if (!res.ok) return [d, false] as const;
           const json = (await res.json()) as {
@@ -157,7 +164,9 @@ export function LoginsTab() {
     setError(null);
     setLogins(null);
     try {
-      const res = await fetch("/api/secrets/logins");
+      const res = await client.rawRequest("/api/secrets/logins", undefined, {
+        allowNonOk: true,
+      });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = (await res.json()) as {
         logins: SavedLogin[];
@@ -190,13 +199,14 @@ export function LoginsTab() {
     async (domain: string, next: boolean) => {
       // Optimistic update; reverted on error.
       setAutoallowMap((prev) => ({ ...prev, [domain]: next }));
-      const res = await fetch(
+      const res = await client.rawRequest(
         `/api/secrets/logins/${encodeURIComponent(domain)}/autoallow`,
         {
           method: "PUT",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ allowed: next }),
         },
+        { allowNonOk: true },
       );
       if (!res.ok) {
         setError(`HTTP ${res.status} (autoallow update failed)`);
@@ -216,15 +226,19 @@ export function LoginsTab() {
       if (!addDomain.trim() || !addUsername || !addPassword) return;
       setSubmitting(true);
       setError(null);
-      const res = await fetch("/api/secrets/logins", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          domain: addDomain.trim(),
-          username: addUsername,
-          password: addPassword,
-        }),
-      });
+      const res = await client.rawRequest(
+        "/api/secrets/logins",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            domain: addDomain.trim(),
+            username: addUsername,
+            password: addPassword,
+          }),
+        },
+        { allowNonOk: true },
+      );
       setSubmitting(false);
       if (!res.ok) {
         setError(`HTTP ${res.status}`);
@@ -255,7 +269,11 @@ export function LoginsTab() {
       const domainPart = colon > 0 ? login.identifier.slice(0, colon) : "";
       const userPart = colon > 0 ? login.identifier.slice(colon + 1) : "";
       const path = `/api/secrets/logins/${encodeURIComponent(domainPart)}/${encodeURIComponent(userPart)}`;
-      const res = await fetch(path, { method: "DELETE" });
+      const res = await client.rawRequest(
+        path,
+        { method: "DELETE" },
+        { allowNonOk: true },
+      );
       if (!res.ok) {
         setError(`HTTP ${res.status}`);
         return;

--- a/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/OverviewTab.tsx
@@ -25,7 +25,13 @@ import {
   useState,
 } from "react";
 import { useAgentElement } from "../../../agent-surface";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../../api/client";
 import { useTranslation } from "../../../state/TranslationContext.hooks";
+import { resolveApiUrl } from "../../../utils/asset-url";
 import { openEventSource } from "../../../utils/event-source";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
@@ -624,11 +630,15 @@ export function InstallSheet({
       setError(null);
       setDone(false);
       try {
-        const res = await fetch("/api/secrets/manager/install", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ backendId, method }),
-        });
+        const res = await client.rawRequest(
+          "/api/secrets/manager/install",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ backendId, method }),
+          },
+          { allowNonOk: true },
+        );
         if (!res.ok) {
           const body = (await res.json().catch(() => ({}))) as {
             error?: string;
@@ -637,7 +647,12 @@ export function InstallSheet({
         }
         const { jobId } = (await res.json()) as { jobId: string };
 
-        const source = openEventSource(`/api/secrets/manager/install/${jobId}`);
+        // EventSource cannot carry the client's Authorization header (browser
+        // limitation), but it must at least target the configured apiBase —
+        // a bare relative URL would open the stream against the page origin.
+        const source = openEventSource(
+          resolveApiUrl(`/api/secrets/manager/install/${jobId}`),
+        );
         sourceRef.current = source;
         if (!source) {
           throw new Error(
@@ -958,11 +973,15 @@ export function SigninSheet({
         body.bitwardenClientId = bwClientId;
         body.bitwardenClientSecret = bwClientSecret;
       }
-      const res = await fetch("/api/secrets/manager/signin", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      const res = await client.rawRequest(
+        "/api/secrets/manager/signin",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        { allowNonOk: true },
+      );
       if (!res.ok) {
         const errBody = (await res.json().catch(() => ({}))) as {
           error?: string;

--- a/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
+++ b/packages/ui/src/components/settings/vault-tabs/RoutingTab.tsx
@@ -15,6 +15,11 @@ import {
   useState,
 } from "react";
 import { useAgentElement } from "../../../agent-surface";
+// All requests go through the shared client (never bare `fetch`) so they hit
+// the configured apiBase and carry the injected auth token — a bare relative
+// fetch targets the page origin unauthenticated, which breaks remote/token-
+// authed runtimes (e.g. the Android local agent).
+import { client } from "../../../api/client";
 import { useTranslation } from "../../../state/TranslationContext.hooks";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
@@ -224,11 +229,15 @@ export function RoutingTab(props: RoutingTabProps) {
       setSaving(true);
       setError(null);
       try {
-        const res = await fetch("/api/secrets/routing", {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ config: next }),
-        });
+        const res = await client.rawRequest(
+          "/api/secrets/routing",
+          {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ config: next }),
+          },
+          { allowNonOk: true },
+        );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as { config: RoutingConfig };
         onConfigChange(body.config);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -20,6 +20,7 @@ import {
 
 import {
   clearChatDraft,
+  readChatDraft,
   writeChatDraft,
 } from "../../state/ChatComposerContext.hooks";
 
@@ -66,6 +67,7 @@ import { ContinuousChatOverlay } from "./ContinuousChatOverlay";
 import type { ShellMessage } from "./shell-state";
 import {
   buildConversationNav,
+  type ConversationNav,
   type ShellController,
 } from "./useShellController";
 
@@ -2816,5 +2818,99 @@ describe("ContinuousChatOverlay — OS assistant / deep-link launch (#9148)", ()
       (screen.getByLabelText("message") as HTMLTextAreaElement).value,
     ).toBe("half-written thought");
     clearChatDraft("conv-draft-x");
+  });
+
+  // Draft handoff on conversation switch (mirrors ChatView's
+  // handleSelectConversation fix): the leaving conversation's in-progress text
+  // must be flushed under ITS OWN key, and a draftless target must CLEAR the
+  // composer — not inherit the previous conversation's text (which the
+  // debounced persister would then re-home under the WRONG conversation's key).
+  describe("draft handoff on conversation switch", () => {
+    const navFor = (activeId: string): ConversationNav => ({
+      hasPrev: false,
+      hasNext: false,
+      goPrev: () => {},
+      goNext: () => {},
+      activeId,
+      index: 0,
+    });
+
+    beforeEach(() => {
+      clearChatDraft("conv-a");
+      clearChatDraft("conv-b");
+    });
+
+    afterEach(() => {
+      clearChatDraft("conv-a");
+      clearChatDraft("conv-b");
+    });
+
+    it("switching A(typed) → B(no draft) clears the composer and saves the text under A's key — never B's", async () => {
+      const { rerender } = render(
+        <ContinuousChatOverlay
+          controller={makeController({ conversationNav: navFor("conv-a") })}
+        />,
+      );
+      const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+      fireEvent.change(input, { target: { value: "half-typed for A" } });
+
+      rerender(
+        <ContinuousChatOverlay
+          controller={makeController({ conversationNav: navFor("conv-b") })}
+        />,
+      );
+
+      // The draftless target CLEARS — A's text must not stay visible in B.
+      expect(input.value).toBe("");
+      // The handoff flushed the text under the LEAVING conversation's key
+      // synchronously (the debounced persister's pending timer is cancelled
+      // by the switch, so only the explicit flush can have written this).
+      expect(readChatDraft("conv-a")).toBe("half-typed for A");
+      expect(readChatDraft("conv-b")).toBeNull();
+
+      // Outlast the 500ms persist debounce: the wrong-conversation write
+      // (A's text under B's key) must NEVER land.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+      });
+      expect(readChatDraft("conv-b")).toBeNull();
+      expect(readChatDraft("conv-a")).toBe("half-typed for A");
+    });
+
+    it("switching A(typed) → B(saved draft) restores B's own draft and keeps A's under A's key", () => {
+      writeChatDraft("conv-b", "B's parked reply");
+      const { rerender } = render(
+        <ContinuousChatOverlay
+          controller={makeController({ conversationNav: navFor("conv-a") })}
+        />,
+      );
+      const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+      fireEvent.change(input, { target: { value: "half-typed for A" } });
+
+      rerender(
+        <ContinuousChatOverlay
+          controller={makeController({ conversationNav: navFor("conv-b") })}
+        />,
+      );
+
+      expect(input.value).toBe("B's parked reply");
+      expect(readChatDraft("conv-a")).toBe("half-typed for A");
+      expect(readChatDraft("conv-b")).toBe("B's parked reply");
+    });
+
+    it("a successful send still clears both the composer and the active conversation's saved draft", () => {
+      writeChatDraft("conv-a", "stale saved draft");
+      const controller = makeController({ conversationNav: navFor("conv-a") });
+      render(<ContinuousChatOverlay controller={controller} />);
+      const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+      fireEvent.change(input, { target: { value: "ship it" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(vi.mocked(controller.send).mock.calls[0]?.[0]).toBe("ship it");
+      expect(input.value).toBe("");
+      // The submit path drops the persisted draft immediately (not just via
+      // the debounced persist of the now-empty draft).
+      expect(readChatDraft("conv-a")).toBeNull();
+    });
   });
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -59,7 +59,9 @@ import { cn } from "../../lib/utils";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
 import {
   clearChatDraft,
+  readChatDraft,
   useChatComposerDraftPersistence,
+  writeChatDraft,
 } from "../../state/ChatComposerContext.hooks";
 import { goHome, goLauncher } from "../../state/shell-surface-store";
 import { useViewChatBinding } from "../../state/view-chat-binding";
@@ -1608,8 +1610,47 @@ export function ContinuousChatOverlay({
   // conversation-id change — so a just-prefilled composer is never clobbered. The
   // successful-send path clears it (below).
   const activeConversationId = conversationNav.activeId;
+  // Draft HANDOFF on conversation switch (mirrors ChatView's
+  // handleSelectConversation fix in useChatCallbacks): swiping A→B must repaint
+  // the composer for the TARGET. Flush the LEAVING conversation's in-progress
+  // text under ITS OWN key first (the debounced persister's pending timer is
+  // cancelled by the id change, so a fast edit would otherwise be lost), then
+  // restore the target's own saved draft — or CLEAR the composer when it has
+  // none. The explicit `?? ""` clear is load-bearing: the persistence hook's
+  // restore only sets when a saved draft EXISTS, so without the clear a
+  // draftless target inherits the previous conversation's composer text, which
+  // the debounced persister then saves under the TARGET's key — the half-typed
+  // message silently re-homes to (and would send to) the wrong conversation.
+  //
+  // The persistence hook is keyed by `persistedConversationId`, which trails
+  // `activeConversationId` by exactly this handoff commit — so the hook never
+  // observes the (new id, old conversation's draft) combination and never even
+  // schedules a write of the old text under the new key. Exactly one
+  // steady-state persistence path (the hook) remains; this effect only adds
+  // the one-shot switch-time flush + repaint the hook cannot do.
+  //
+  // Both null transitions are deliberate no-repaints: on boot (null → id) the
+  // composer may already hold a prefill (CHAT_PREFILL / assistant-launch) that
+  // must NOT be clobbered, and on id → null there is no target to paint.
+  const [persistedConversationId, setPersistedConversationId] = React.useState<
+    string | null
+  >(activeConversationId);
+  // Live handle to the draft so the handoff effect keys off the id change
+  // alone (a keystroke never re-runs it), same pattern as messagesRef above.
+  const draftRef = React.useRef(draft);
+  draftRef.current = draft;
+  React.useLayoutEffect(() => {
+    if (persistedConversationId === activeConversationId) return;
+    if (persistedConversationId !== null) {
+      writeChatDraft(persistedConversationId, draftRef.current);
+      if (activeConversationId !== null) {
+        setDraft(readChatDraft(activeConversationId) ?? "");
+      }
+    }
+    setPersistedConversationId(activeConversationId);
+  }, [activeConversationId, persistedConversationId]);
   useChatComposerDraftPersistence({
-    activeConversationId,
+    activeConversationId: persistedConversationId,
     chatInput: draft,
     setChatInput: setDraft,
   });

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.test.tsx
@@ -5,6 +5,7 @@
 // sessionId; error -> retry; unmount/close -> client.stopPtySession), mocking
 // only the client boundary and the xterm pane (which needs a real DOM/canvas).
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -14,10 +15,31 @@ import {
 import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  spawnPtySession: vi.fn(),
-  stopPtySession: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const wsHandlers = new Map<
+    string,
+    Set<(data: Record<string, unknown>) => void>
+  >();
+  return {
+    spawnPtySession: vi.fn(),
+    stopPtySession: vi.fn(),
+    wsHandlers,
+    onWsEvent: vi.fn(
+      (type: string, handler: (data: Record<string, unknown>) => void) => {
+        let handlers = wsHandlers.get(type);
+        if (!handlers) {
+          handlers = new Set();
+          wsHandlers.set(type, handlers);
+        }
+        handlers.add(handler);
+        return () => handlers.delete(handler);
+      },
+    ),
+    emitWsEvent: (type: string, data: Record<string, unknown>) => {
+      for (const handler of wsHandlers.get(type) ?? []) handler(data);
+    },
+  };
+});
 
 type ButtonMockProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "size"> & {
   agent?: string;
@@ -31,6 +53,7 @@ vi.mock("@elizaos/ui", () => ({
   client: {
     spawnPtySession: mocks.spawnPtySession,
     stopPtySession: mocks.stopPtySession,
+    onWsEvent: mocks.onWsEvent,
   },
   Button: (props: ButtonMockProps) => {
     const {
@@ -66,6 +89,7 @@ import { CockpitInteractiveTerminal } from "./CockpitInteractiveTerminal";
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  mocks.wsHandlers.clear();
 });
 
 describe("CockpitInteractiveTerminal — spawn → attach wiring", () => {
@@ -126,5 +150,96 @@ describe("CockpitInteractiveTerminal — spawn → attach wiring", () => {
     fireEvent.click(screen.getByTestId("cockpit-terminal-close"));
     expect(mocks.stopPtySession).toHaveBeenCalledWith("sess-close");
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("CockpitInteractiveTerminal — session death (pty-exit)", () => {
+  it("shows the ended state when the session's pty-exit arrives (was: stuck 'ready' forever)", async () => {
+    mocks.spawnPtySession.mockResolvedValue({ sessionId: "sess-exit" });
+    render(<CockpitInteractiveTerminal tier="fast" />);
+    const pane = await screen.findByTestId("pty-pane");
+    expect(pane.getAttribute("data-visible")).toBe("true");
+
+    act(() => {
+      mocks.emitWsEvent("pty-exit", {
+        type: "pty-exit",
+        sessionId: "sess-exit",
+        exitCode: 0,
+      });
+    });
+
+    const ended = await screen.findByTestId("cockpit-terminal-ended");
+    expect(ended.textContent).toContain("session ended");
+    expect(ended.textContent).toContain("exit 0");
+    // The dead pane is no longer presented as the live surface.
+    expect(screen.getByTestId("pty-pane").getAttribute("data-visible")).toBe(
+      "false",
+    );
+  });
+
+  it("does not stop an already-dead session on unmount", async () => {
+    mocks.spawnPtySession.mockResolvedValue({ sessionId: "sess-dead" });
+    const { unmount } = render(<CockpitInteractiveTerminal tier="fast" />);
+    await screen.findByTestId("pty-pane");
+
+    act(() => {
+      mocks.emitWsEvent("pty-exit", {
+        type: "pty-exit",
+        sessionId: "sess-dead",
+        exitCode: null,
+      });
+    });
+    await screen.findByTestId("cockpit-terminal-ended");
+
+    unmount();
+    expect(mocks.stopPtySession).not.toHaveBeenCalled();
+  });
+
+  it("ignores pty-exit for a different session", async () => {
+    mocks.spawnPtySession.mockResolvedValue({ sessionId: "sess-mine" });
+    render(<CockpitInteractiveTerminal tier="fast" />);
+    await screen.findByTestId("pty-pane");
+
+    act(() => {
+      mocks.emitWsEvent("pty-exit", {
+        type: "pty-exit",
+        sessionId: "sess-other",
+        exitCode: 1,
+      });
+    });
+
+    expect(screen.queryByTestId("cockpit-terminal-ended")).toBeNull();
+    expect(screen.getByTestId("pty-pane").getAttribute("data-visible")).toBe(
+      "true",
+    );
+  });
+
+  it("restart spawns a fresh session after the old one ended", async () => {
+    mocks.spawnPtySession.mockResolvedValueOnce({ sessionId: "sess-old" });
+    render(<CockpitInteractiveTerminal tier="smart" />);
+    await screen.findByTestId("pty-pane");
+
+    act(() => {
+      mocks.emitWsEvent("pty-exit", {
+        type: "pty-exit",
+        sessionId: "sess-old",
+        exitCode: 137,
+      });
+    });
+    await screen.findByTestId("cockpit-terminal-ended");
+
+    mocks.spawnPtySession.mockResolvedValueOnce({ sessionId: "sess-new" });
+    fireEvent.click(screen.getByTestId("cockpit-terminal-restart"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pty-pane").getAttribute("data-session")).toBe(
+        "sess-new",
+      );
+    });
+    expect(screen.getByTestId("pty-pane").getAttribute("data-visible")).toBe(
+      "true",
+    );
+    expect(screen.queryByTestId("cockpit-terminal-ended")).toBeNull();
+    expect(mocks.spawnPtySession).toHaveBeenCalledTimes(2);
   });
 });

--- a/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitInteractiveTerminal.tsx
@@ -14,7 +14,7 @@ export interface CockpitInteractiveTerminalProps {
   onClose?: () => void;
 }
 
-type Phase = "spawning" | "ready" | "error";
+type Phase = "spawning" | "ready" | "ended" | "error";
 
 type InteractivePtyClient = typeof client & {
   spawnPtySession(options: {
@@ -45,12 +45,14 @@ export function CockpitInteractiveTerminal({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [phase, setPhase] = useState<Phase>("spawning");
   const [error, setError] = useState<string | null>(null);
+  const [exitCode, setExitCode] = useState<number | null>(null);
   const spawnStartedRef = useRef(false);
   const activeSessionRef = useRef<string | null>(null);
 
   const spawn = useCallback(async () => {
     setPhase("spawning");
     setError(null);
+    setExitCode(null);
     try {
       const { sessionId: id } = await ptyClient.spawnPtySession({
         kind: "eliza-code",
@@ -76,6 +78,23 @@ export function CockpitInteractiveTerminal({
     spawnStartedRef.current = true;
     void spawn();
   }, [spawn]);
+
+  // Surface session death. The agent server bridges the PTY's `session_exit`
+  // as a `pty-exit` WS event; without this the pane stays "ready" forever over
+  // a dead session (nothing echoes, input goes nowhere).
+  useEffect(() => {
+    if (!sessionId) return;
+    return ptyClient.onWsEvent("pty-exit", (data: Record<string, unknown>) => {
+      if (data.sessionId !== sessionId) return;
+      // The process is already dead — clear the ref so unmount/close doesn't
+      // issue a redundant stop against a reaped session.
+      if (activeSessionRef.current === sessionId) {
+        activeSessionRef.current = null;
+      }
+      setExitCode(typeof data.exitCode === "number" ? data.exitCode : null);
+      setPhase("ended");
+    });
+  }, [sessionId]);
 
   // Kill the session when the terminal goes away — eliza-code is a REPL and
   // won't exit on its own, so an unclosed session would leave an orphan process.
@@ -152,6 +171,33 @@ export function CockpitInteractiveTerminal({
             }}
           >
             Starting interactive eliza-code on Cerebras…
+          </div>
+        ) : null}
+
+        {phase === "ended" ? (
+          <div
+            data-testid="cockpit-terminal-ended"
+            style={{
+              padding: 16,
+              fontSize: 13,
+              color: "var(--txt-muted, #9aa0aa)",
+            }}
+          >
+            <div>
+              eliza-code session ended
+              {exitCode !== null ? ` (exit ${exitCode})` : ""}.
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              data-testid="cockpit-terminal-restart"
+              onClick={retry}
+              style={{
+                marginTop: 10,
+              }}
+            >
+              Restart
+            </Button>
           </div>
         ) : null}
 

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
@@ -32,6 +32,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// The REAL ELIZA_CLOUD_TIER_MODEL currently maps BOTH tiers to the same
+// Cerebras model (no smart model has shipped), which makes the pane hide the
+// Fast/Smart toggle. Mock it as a mutable record so the flip test can exercise
+// divergent tiers and the collapse test can exercise identical ones.
+const tierModels = vi.hoisted(() => ({
+  small: "gemma-4-31b",
+  large: "qwen-3-huge",
+}));
+
 const calls = {
   getOrchestratorStatus: vi.fn(),
   listCodingAgentTaskThreads: vi.fn(),
@@ -59,6 +68,7 @@ vi.mock("@elizaos/ui", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
+    ELIZA_CLOUD_TIER_MODEL: tierModels,
     client: {
       getOrchestratorStatus: () => calls.getOrchestratorStatus(),
       listCodingAgentTaskThreads: (o: unknown) =>
@@ -276,6 +286,10 @@ const timelineItems: CodingAgentTaskTimelineItem[] = [
 ];
 
 beforeEach(() => {
+  // Divergent tiers by default (the flip test needs a real choice); the
+  // collapse test overrides this per-case.
+  tierModels.small = "gemma-4-31b";
+  tierModels.large = "qwen-3-huge";
   for (const fn of Object.values(calls)) fn.mockReset();
   calls.getOrchestratorStatus.mockResolvedValue({ taskCount: 1 });
   calls.listCodingAgentTaskThreads.mockResolvedValue([
@@ -391,7 +405,7 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
       expect(calls.updateOrchestratorTask).toHaveBeenCalledWith(
         "task-1",
         expect.objectContaining({
-          providerPolicy: expect.objectContaining({ model: "gemma-4-31b" }),
+          providerPolicy: expect.objectContaining({ model: tierModels.large }),
         }),
       ),
     );
@@ -404,6 +418,43 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
       ),
     );
     expect(calls.addOrchestratorAgent).not.toHaveBeenCalled();
+  });
+
+  it("Eliza Cloud: hides the tier toggle when both tiers lower to the SAME model (no destructive placebo restart)", async () => {
+    // Mirror today's production reality: no smart model has shipped, so
+    // small === large. Offering the toggle would persist an identical policy
+    // and restart({stopActive:true}) — killing the live worker for nothing.
+    tierModels.large = tierModels.small;
+    calls.getCodingAgentTaskThread.mockResolvedValue({
+      ...detailFixture,
+      providerPolicy: {
+        preferredFramework: "elizaos",
+        providerSource: "eliza-cloud",
+        model: tierModels.small,
+      },
+    });
+    renderPane();
+    // The pane is fully loaded (title + transcript rendered)…
+    await waitFor(() =>
+      expect(screen.getByTestId("orchestrator-user-message")).toBeTruthy(),
+    );
+    // …but neither tier segment exists, so no flip (and no restart) can fire.
+    expect(screen.queryByTestId("cockpit-tier-small")).toBeNull();
+    expect(screen.queryByTestId("cockpit-tier-large")).toBeNull();
+    expect(calls.updateOrchestratorTask).not.toHaveBeenCalled();
+    expect(calls.restartOrchestratorTask).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed inspector action as an alert banner (actionError is not silent)", async () => {
+    calls.pauseOrchestratorTask.mockRejectedValue(new Error("pause exploded"));
+    renderPane();
+    const pause = await screen.findByTestId("orchestrator-inspector-pause");
+    fireEvent.click(pause);
+    // runMutation catches (does NOT rethrow) and stores the message as
+    // actionError — the pane must render it or every failed action is silent.
+    const banner = await screen.findByTestId("cockpit-session-action-error");
+    expect(banner.getAttribute("role")).toBe("alert");
+    expect(banner.textContent).toContain("pause exploded");
   });
 
   it("surfaces an error when a composer-driven message fails to deliver", async () => {
@@ -457,7 +508,10 @@ describe("CockpitSessionPane — inspector layout per surface (#11159 audit)", (
       const inspector = await screen.findByTestId("orchestrator-inspector");
       expect(inspector.className).not.toContain("w-80");
       // Drawer geometry comes from the inline style (closed => hidden).
-      expect(inspector.style.display === "none" || inspector.style.position === "absolute").toBe(true);
+      expect(
+        inspector.style.display === "none" ||
+          inspector.style.position === "absolute",
+      ).toBe(true);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -75,7 +75,7 @@ export function CockpitSessionPane({
   t = fallbackTranslate,
   locale,
 }: CockpitSessionPaneProps) {
-  const { detail, messages, events, mutating, runMutation } =
+  const { detail, messages, events, mutating, actionError, runMutation } =
     useOrchestratorData({
       selectedId: taskId,
       showArchived: false,
@@ -160,12 +160,16 @@ export function CockpitSessionPane({
   const isElizaCloud =
     detail?.providerPolicy?.preferredFramework === "elizaos" &&
     detail?.providerPolicy?.providerSource === "eliza-cloud";
-  const currentTier: ElizaCloudTier =
-    ELIZA_CLOUD_TIER_MODEL.small === ELIZA_CLOUD_TIER_MODEL.large
-      ? "small"
-      : detail?.providerPolicy?.model === ELIZA_CLOUD_TIER_MODEL.large
-        ? "large"
-        : "small";
+  // While both tiers lower to the SAME model, flipping the toggle would persist
+  // an identical policy and then restart({stopActive:true}) — killing the live
+  // worker mid-task for zero effect. Hide the toggle until the tiers diverge.
+  const tiersDiverge =
+    ELIZA_CLOUD_TIER_MODEL.small !== ELIZA_CLOUD_TIER_MODEL.large;
+  const currentTier: ElizaCloudTier = !tiersDiverge
+    ? "small"
+    : detail?.providerPolicy?.model === ELIZA_CLOUD_TIER_MODEL.large
+      ? "large"
+      : "small";
   const onTierChange = useCallback(
     (tier: ElizaCloudTier) => {
       const model = ELIZA_CLOUD_TIER_MODEL[tier];
@@ -275,7 +279,7 @@ export function CockpitSessionPane({
           {detail?.title ??
             t("cockpit.session.loading", { defaultValue: "Loading room…" })}
         </h2>
-        {isElizaCloud ? (
+        {isElizaCloud && tiersDiverge ? (
           <CockpitTierToggle
             value={currentTier}
             onChange={onTierChange}
@@ -347,6 +351,20 @@ export function CockpitSessionPane({
           className="shrink-0 border-destructive/40 border-b bg-destructive/10 px-3 py-2 text-xs text-destructive"
         >
           {composerError}
+        </div>
+      ) : null}
+
+      {/* Inspector-action failures (pause/resume/archive/delete/fork/restart/
+          validate/add-agent/stop-agent/tier-flip): useOrchestratorData's
+          runMutation catches instead of rethrowing and surfaces the message as
+          `actionError` — without this banner every failed action is silent. */}
+      {actionError ? (
+        <div
+          role="alert"
+          data-testid="cockpit-session-action-error"
+          className="shrink-0 border-destructive/40 border-b bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          {actionError}
         </div>
       ) : null}
 

--- a/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitTerminalPanel.test.tsx
@@ -67,6 +67,8 @@ const ui = vi.hoisted(() => {
     resizePty: vi.fn(),
     sendPtyInput: vi.fn(),
     stopCodingAgent: vi.fn(),
+    // PtyTerminalPane re-sends pty-subscribe on WS reconnect.
+    onReconnect: vi.fn(() => () => undefined),
   };
   const emit = (event: string, payload: unknown) => {
     for (const handler of handlers[event] ?? []) handler(payload);

--- a/plugins/plugin-task-coordinator/src/PtyTerminalPane.test.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyTerminalPane.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for the WS-reconnect path: a reconnect opens a NEW
+// server-side socket whose per-connection PTY subscription map is empty, so a
+// mounted pane that doesn't re-send pty-subscribe silently stops receiving
+// output and has its keystrokes rejected as "not subscribed". The pane must
+// re-subscribe on every reconnect and tear the listener down on unmount.
+// xterm and the client boundary are mocked; the component logic is real.
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const reconnectListeners = new Set<() => void>();
+  return {
+    reconnectListeners,
+    subscribePtyOutput: vi.fn(),
+    unsubscribePtyOutput: vi.fn(),
+    getPtyBufferedOutput: vi.fn(async () => ""),
+    sendPtyInput: vi.fn(),
+    resizePty: vi.fn(),
+    onWsEvent: vi.fn(() => () => undefined),
+    onReconnect: vi.fn((listener: () => void) => {
+      reconnectListeners.add(listener);
+      return () => reconnectListeners.delete(listener);
+    }),
+    fireReconnect: () => {
+      for (const listener of reconnectListeners) listener();
+    },
+  };
+});
+
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    subscribePtyOutput: mocks.subscribePtyOutput,
+    unsubscribePtyOutput: mocks.unsubscribePtyOutput,
+    getPtyBufferedOutput: mocks.getPtyBufferedOutput,
+    sendPtyInput: mocks.sendPtyInput,
+    resizePty: mocks.resizePty,
+    onWsEvent: mocks.onWsEvent,
+    onReconnect: mocks.onReconnect,
+  },
+}));
+
+// Lightweight xterm stand-ins — jsdom has no canvas for the real renderer.
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class TerminalMock {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    scrollToBottom(): void {}
+    onData(): void {}
+    dispose(): void {}
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class FitAddonMock {
+    fit(): void {}
+  },
+}));
+
+import { PtyTerminalPane } from "./PtyTerminalPane";
+
+class ResizeObserverMock {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    (cb: FrameRequestCallback): number =>
+      setTimeout(() => cb(0), 0) as unknown as number,
+  );
+  vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
+    clearTimeout(id as unknown as ReturnType<typeof setTimeout>);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mocks.reconnectListeners.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("PtyTerminalPane — WS reconnect re-subscribe", () => {
+  it("subscribes on mount and re-sends pty-subscribe on every reconnect", async () => {
+    render(<PtyTerminalPane sessionId="sess-42" visible={true} />);
+
+    await waitFor(() =>
+      expect(mocks.subscribePtyOutput).toHaveBeenCalledWith("sess-42"),
+    );
+    expect(mocks.subscribePtyOutput).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.onReconnect).toHaveBeenCalledTimes(1));
+
+    mocks.fireReconnect();
+    expect(mocks.subscribePtyOutput).toHaveBeenCalledTimes(2);
+    expect(mocks.subscribePtyOutput).toHaveBeenLastCalledWith("sess-42");
+
+    mocks.fireReconnect();
+    expect(mocks.subscribePtyOutput).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops re-subscribing after unmount (listener disposed, session unsubscribed)", async () => {
+    const { unmount } = render(
+      <PtyTerminalPane sessionId="sess-42" visible={true} />,
+    );
+    await waitFor(() => expect(mocks.onReconnect).toHaveBeenCalledTimes(1));
+
+    unmount();
+    expect(mocks.unsubscribePtyOutput).toHaveBeenCalledWith("sess-42");
+    expect(mocks.reconnectListeners.size).toBe(0);
+
+    mocks.fireReconnect();
+    expect(mocks.subscribePtyOutput).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-task-coordinator/src/PtyTerminalPane.tsx
+++ b/plugins/plugin-task-coordinator/src/PtyTerminalPane.tsx
@@ -24,6 +24,7 @@ export function PtyTerminalPane({
 
     let disposed = false;
     let unsub: (() => void) | undefined;
+    let unsubReconnect: (() => void) | undefined;
     let resizeObserver: ResizeObserver | undefined;
 
     (async () => {
@@ -108,6 +109,12 @@ export function PtyTerminalPane({
       }
 
       client.subscribePtyOutput(sessionId);
+      // A reconnect opens a NEW server-side socket with an empty subscription
+      // map — without re-subscribing, the pane silently stops receiving
+      // output and its keystrokes are rejected as "not subscribed".
+      unsubReconnect = client.onReconnect(() => {
+        if (!disposed) client.subscribePtyOutput(sessionId);
+      });
       unsub = client.onWsEvent(
         "pty-output",
         (data: Record<string, unknown>) => {
@@ -148,6 +155,7 @@ export function PtyTerminalPane({
     return () => {
       disposed = true;
       unsub?.();
+      unsubReconnect?.();
       client.unsubscribePtyOutput(sessionId);
       termRef.current?.dispose();
       termRef.current = null;


### PR DESCRIPTION
## Summary

Fixes 9 confirmed **major** findings from the round-7 Fable find/verify sweep (view-lifecycle, cockpit, settings, larp re-verify), each root-caused and pinned with real tests.

### Chat
- **Overlay draft bleed (shipped via #11200):** switching conversation A→B kept A's typed text in B's composer and then persisted it under B's key — the half-typed message re-homed to (and would send to) the wrong conversation. Fixed by re-keying the persistence hook to a trailing `persistedConversationId` + a one-shot switch-time flush/clear. +3 tests.

### Cockpit / interactive terminal
- **Silent inspector-action failures:** pause/resume/archive/delete/fork/restart/validate/add-agent all failed with zero feedback — now a role=alert banner (`actionError` was rendered by the workbench but not the cockpit pane).
- **Destructive placebo tier toggle:** both tiers mapped to the same model, yet tapping Smart killed the live agent (`restartOrchestratorTask stopActive`) for zero effect and still showed Fast — toggle now renders only when the tiers actually diverge.
- **Paste >4096 chars silently discarded:** `sendPtyInput` now chunks into ordered ≤4096 messages (surrogate-safe); server echoes a `pty-error` instead of dropping silently.
- **WS blip killed the session instantly + death never surfaced:** new `pty-ws-bridge` forwards `session_exit`→`pty-exit`, adds a 30s disconnect grace (skipped when another socket shares the clientId; cancelled on re-auth), re-subscribes panes on reconnect, and gives the terminal an "ended (exit N) — Restart" state.

### Settings
- **'Continuous chat' control wrote a store nothing reads** — now mirrors the localStorage key ChatView/useShellController actually read.
- **Two dead voice privacy toggles** (cloud-cache, auto-learn — zero readers) removed.
- **Wallet/Secrets/Vault used bare `fetch('/api/...')`** bypassing the client's apiBase + auth token — all ~32 sites routed through `client.rawRequest` (breaks remote-runtime + token-authed agents otherwise).

### Launcher
- **Dead 'Rolodex' tile** (routable but no view → bounced to the launcher fallback) hidden; the real surface is `relationships`.

## Evidence
Consolidated 395 `packages/ui` unit + plugin-task-coordinator 217 + agent pty-ws-bridge 13 + settings 210; gesture e2e (chat-sheet, conversation-swipe, launcher) all green.

Refs the round-7 sweep, #11158, #11200. Follow-ups noted: CockpitModePicker create-time tier placebo, missed-pty-exit replay on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)