### PR TITLE
fix(core): exclude action_result rows from the summarization dialogue count (follow-up #11254)

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
@@ -119,3 +119,109 @@ describe("summaryEvaluator storeSummary processor — first-store offset (regres
 		expect(stored[0].messageCount).toBe(2);
 	});
 });
+
+describe("summaryEvaluator.shouldRun — dialogue count matches canonical MESSAGE memories (#11250)", () => {
+	function messageMemory(
+		id: string,
+		metadataType: string,
+		contentType = "text",
+	): Memory {
+		return {
+			id,
+			entityId: "user-1",
+			roomId: "room-1",
+			content: { text: `line ${id}`, type: contentType },
+			metadata: { type: metadataType },
+			createdAt: 1,
+		} as unknown as Memory;
+	}
+
+	function runtimeWithMessages(
+		metadataType: string,
+		count: number,
+		extraMemories: Memory[] = [],
+	) {
+		const memories = [
+			...Array.from({ length: count }, (_v, i) =>
+				messageMemory(`m-${i}`, metadataType),
+			),
+			...extraMemories,
+		];
+		const memoryService = {
+			getConfig: () => ({
+				shortTermSummarizationThreshold: 16,
+				shortTermSummarizationInterval: 8,
+			}),
+			getCurrentSessionSummary: async () => null,
+		};
+		return createMockRuntime({
+			agentId: "agent-1",
+			character: { name: "Agent" },
+			getService: (name: string) =>
+				name === "memory" ? (memoryService as never) : null,
+			getMemories: async () => memories,
+		} as never);
+	}
+
+	const trigger = {
+		id: "trigger",
+		roomId: "room-1",
+		content: { text: "hello", type: "text" },
+		metadata: { type: "message" },
+		createdAt: 2,
+	} as unknown as Memory;
+
+	it("fires at threshold for canonical MemoryType.MESSAGE ('message') memories", async () => {
+		const rt = runtimeWithMessages("message", 16);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(true);
+	});
+
+	it("still counts the legacy metadata types (back-compat)", async () => {
+		const rt = runtimeWithMessages("user_message", 16);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(true);
+	});
+
+	it("does not fire below threshold", async () => {
+		const rt = runtimeWithMessages("message", 4);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(false);
+	});
+
+	it("does not count action_result rows stamped metadata.type 'message' as dialogue", async () => {
+		// The real action_result writers (advanced-capabilities message/post
+		// actions) stamp content.type "action_result" with metadata.type
+		// "message". Those rows must be excluded on content.type alone — the
+		// old predicate also required metadata.type === "action_result", so
+		// they inflated the dialogue count past the threshold.
+		const actionResults = Array.from({ length: 8 }, (_v, i) =>
+			messageMemory(`ar-${i}`, "message", "action_result"),
+		);
+		const rt = runtimeWithMessages("message", 12, actionResults);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		// 12 real dialogue rows < 16 threshold; the 8 action_result rows must
+		// not push the count over.
+		expect(run).toBe(false);
+	});
+});

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -8,6 +8,7 @@ import type {
 	RegisteredEvaluator,
 	UUID,
 } from "../../../types/index.ts";
+import { MemoryType } from "../../../types/memory.ts";
 import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
 import { isObjectRecord as isRecord } from "../../../utils/type-guards.ts";
 import type { MemoryService } from "../services/memory-service.ts";
@@ -86,14 +87,22 @@ function toStringArray(value: unknown): string[] {
 }
 
 function isDialogueMessage(msg: Memory): boolean {
+	const metadataType = msg.metadata?.type as string | undefined;
 	return (
 		!isSyntheticConversationArtifactMemory(msg) &&
-		!(
-			msg.content.type === "action_result" &&
-			(msg.metadata?.type as string) === "action_result"
-		) &&
-		((msg.metadata?.type as string) === "agent_response_message" ||
-			(msg.metadata?.type as string) === "user_message")
+		// Exclude action results on content.type alone (matching the dialogue
+		// filter in recentMessages): the action_result writers stamp
+		// content.type "action_result" with metadata.type "message", so
+		// requiring both would count them as dialogue.
+		msg.content.type !== "action_result" &&
+		// The canonical current format: createMessageMemory stamps
+		// MemoryType.MESSAGE ("message") — matching this is what actually makes
+		// summarization fire. The two legacy strings are kept for back-compat but
+		// nothing in the repo writes them anymore, so without MESSAGE the dialogue
+		// count was permanently 0 and short-term summarization never ran (silently).
+		(metadataType === MemoryType.MESSAGE ||
+			metadataType === "agent_response_message" ||
+			metadataType === "user_message")
 	);
 }
 


### PR DESCRIPTION
## Summary

Follow-up correctness fix to #11254 (session-summarization dialogue count).

`isDialogueMessage` in `packages/core/src/features/advanced-memory/evaluators/memory-items.ts` excluded action results only when **both** `content.type === "action_result"` **and** `metadata.type === "action_result"`. But the real action_result writers — `packages/core/src/features/advanced-capabilities/actions/message.ts` (~1856/1870) and `actions/post.ts` (~322/336) — stamp `content.type: "action_result"` with `metadata.type: "message"`. After #11254 added the `MemoryType.MESSAGE` branch, those rows (e.g. "Message sent via discord to #general.") passed the dialogue filter and inflated the short-term summarization trigger count with non-dialogue rows.

## Fix

Exclude on `content.type === "action_result"` alone — the exact predicate the established dialogue filter in `packages/core/src/features/basic-capabilities/providers/recentMessages.ts` (L433, `!(msg.content && msg.content.type === "action_result")`) already uses. The `metadata.type` allowlist branch (MESSAGE + legacy strings) is unchanged.

## Test

Extended `memory-items.test.ts` (#11250 suite) with a regression test: 12 canonical dialogue memories + 8 `content.type: "action_result"` / `metadata.type: "message"` rows must **not** fire summarization (threshold 16). Under the old predicate the count would be 20 and summarization fires — the test fails without the fix.

## Evidence

```
bun run --cwd packages/core test src/features/advanced-memory/evaluators/memory-items.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

All 7 tests in the file pass (the 3 pre-existing #11250 threshold tests, the bounded-window and offset regressions, and the new action_result exclusion test).

N/A — screenshots/video/trajectories: backend-only evaluator predicate change with no UI or model-behavior surface; pinned by a real unit regression test driving `summaryEvaluator.shouldRun` end to end through `getMemories` → `isDialogueMessage` → threshold check.