### PR TITLE
fix(orchestrator): validate route inputs + guard workspace null-deref (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/route-input-validation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/route-input-validation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  asBoolean,
+  asFiniteNumber,
+  asString,
+  asStringArray,
+} from "../../src/api/route-utils.js";
+
+// Boundary coercion for untyped JSON request bodies (#11028 audit): route
+// handlers used to `body.x as string` / `as boolean`, letting a client send
+// `{repo: 123}` straight into a service call. These validate the type first.
+describe("route input validation helpers", () => {
+  it("asString: trims non-empty strings, rejects non-strings and blanks", () => {
+    expect(asString("  hi ")).toBe("hi");
+    expect(asString("")).toBeUndefined();
+    expect(asString("   ")).toBeUndefined();
+    expect(asString(123)).toBeUndefined();
+    expect(asString(true)).toBeUndefined();
+    expect(asString(null)).toBeUndefined();
+    expect(asString(undefined)).toBeUndefined();
+    expect(asString(["a"])).toBeUndefined();
+  });
+
+  it("asBoolean: only real booleans, never truthy strings", () => {
+    expect(asBoolean(true)).toBe(true);
+    expect(asBoolean(false)).toBe(false);
+    // The bug this guards: a client sending "yes"/"false"/"0" must NOT coerce.
+    expect(asBoolean("true")).toBeUndefined();
+    expect(asBoolean("false")).toBeUndefined();
+    expect(asBoolean(1)).toBeUndefined();
+    expect(asBoolean(0)).toBeUndefined();
+    expect(asBoolean(undefined)).toBeUndefined();
+  });
+
+  it("asFiniteNumber: numbers/numeric strings only, rejects NaN/Infinity/junk", () => {
+    expect(asFiniteNumber(100)).toBe(100);
+    expect(asFiniteNumber("250")).toBe(250);
+    expect(asFiniteNumber("abc")).toBeUndefined();
+    expect(asFiniteNumber(Number.NaN)).toBeUndefined();
+    expect(asFiniteNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(asFiniteNumber("")).toBeUndefined();
+    expect(asFiniteNumber(null)).toBeUndefined();
+  });
+
+  it("asStringArray: filters to trimmed strings, undefined for non-arrays", () => {
+    expect(asStringArray(["a", " b ", 3, "", "c"])).toEqual(["a", "b", "c"]);
+    expect(asStringArray([1, 2, 3])).toEqual([]);
+    expect(asStringArray("nope")).toBeUndefined();
+    expect(asStringArray(undefined)).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -787,7 +787,11 @@ export async function handleAgentRoutes(
     try {
       const sessionId = outputMatch[1];
       const url = new URL(req.url || "", `http://${req.headers.host}`);
-      const lines = parseInt(url.searchParams.get("lines") || "100", 10);
+      // Guard against a non-numeric ?lines= (parseInt("abc") → NaN would reach
+      // getSessionOutput); fall back to the default 100 on anything invalid.
+      const parsedLines = parseInt(url.searchParams.get("lines") || "100", 10);
+      const lines =
+        Number.isFinite(parsedLines) && parsedLines > 0 ? parsedLines : 100;
 
       const output = await ctx.acpService.getSessionOutput?.(sessionId, lines);
       sendJson(res, { sessionId, output });

--- a/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/issue-routes.ts
@@ -10,7 +10,13 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RouteContext } from "./route-utils.js";
-import { parseBody, sendError, sendJson } from "./route-utils.js";
+import {
+  asString,
+  asStringArray,
+  parseBody,
+  sendError,
+  sendJson,
+} from "./route-utils.js";
 
 /**
  * Handle issue routes (/api/issues/*)
@@ -72,16 +78,18 @@ export async function handleIssueRoutes(
 
     try {
       const body = await parseBody(req);
-      const { repo, title, body: issueBody, labels } = body;
+      const repo = asString(body.repo);
+      const title = asString(body.title);
       if (!repo || !title) {
         sendError(res, "repo and title are required", 400);
         return true;
       }
+      const labels = asStringArray(body.labels);
 
-      const issue = await ctx.workspaceService.createIssue(repo as string, {
-        title: title as string,
-        body: (issueBody as string) ?? "",
-        labels: labels as string[] | undefined,
+      const issue = await ctx.workspaceService.createIssue(repo, {
+        title,
+        body: asString(body.body) ?? "",
+        ...(labels ? { labels } : {}),
       });
       sendJson(res, issue, 201);
     } catch (error) {
@@ -133,14 +141,15 @@ export async function handleIssueRoutes(
       const repo = `${commentMatch[1]}/${commentMatch[2]}`;
       const issueNumber = parseInt(commentMatch[3], 10);
       const body = await parseBody(req);
-      if (!body.body) {
+      const commentBody = asString(body.body);
+      if (!commentBody) {
         sendError(res, "body is required", 400);
         return true;
       }
       const comment = await ctx.workspaceService.addComment(
         repo,
         issueNumber,
-        body.body as string,
+        commentBody,
       );
       sendJson(res, comment, 201);
     } catch (error) {

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -30,6 +30,9 @@ import type {
 } from "../services/orchestrator-task-types.js";
 import type { RouteContext } from "./route-utils.js";
 import {
+  asBoolean,
+  asString,
+  asStringArray,
   parseBody,
   sendError,
   sendJson,
@@ -49,20 +52,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : undefined;
-}
-
-function asStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const items = value.filter(
-    (v): v is string => typeof v === "string" && v.trim().length > 0,
-  );
-  return items.length > 0 ? items.map((s) => s.trim()) : [];
-}
-
 function asPriority(value: unknown): OrchestratorTaskPriority | undefined {
   return typeof value === "string" && PRIORITIES.has(value)
     ? (value as OrchestratorTaskPriority)
@@ -79,10 +68,6 @@ function asProviderPolicy(value: unknown): TaskProviderPolicy | undefined {
   if (source) policy.providerSource = source;
   if (model) policy.model = model;
   return policy;
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
 }
 
 function asRetryMode(

--- a/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/route-utils.ts
@@ -56,6 +56,44 @@ export async function parseBody(
   });
 }
 
+/**
+ * Boundary coercion helpers for JSON request bodies. Route handlers receive
+ * untyped `parseBody` output, so casting `body.x as string` lets a client send
+ * `{repo: 123}` straight through to a service call. These validate first and
+ * return `undefined` on a type mismatch, so a handler can reject cleanly.
+ */
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+/** A boolean, never a truthy string ("false"/"no"/"0" must not become `true`). */
+export function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+/** Trimmed non-empty strings from an array; undefined if not an array, [] if the
+ *  array holds no usable strings. */
+export function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.filter(
+    (v): v is string => typeof v === "string" && v.trim().length > 0,
+  );
+  return items.length > 0 ? items.map((s) => s.trim()) : [];
+}
+
+/** A finite number from a number or numeric string; rejects NaN/Infinity. */
+export function asFiniteNumber(value: unknown): number | undefined {
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(n) ? n : undefined;
+}
+
 // Helper to send JSON response
 export function sendJson(
   res: ServerResponse,

--- a/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/workspace-routes.ts
@@ -10,7 +10,13 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RouteContext } from "./route-utils.js";
-import { parseBody, sendError, sendJson } from "./route-utils.js";
+import {
+  asBoolean,
+  asString,
+  parseBody,
+  sendError,
+  sendJson,
+} from "./route-utils.js";
 
 /**
  * Handle workspace routes (/api/workspace/*)
@@ -33,15 +39,22 @@ export async function handleWorkspaceRoutes(
 
     try {
       const body = await parseBody(req);
-      const { repo, baseBranch, useWorktree, parentWorkspaceId, branchName } =
-        body;
+      const repo = asString(body.repo);
+      if (!repo) {
+        sendError(res, "repo is required");
+        return true;
+      }
+      const baseBranch = asString(body.baseBranch);
+      const branchName = asString(body.branchName);
+      const parentWorkspaceId = asString(body.parentWorkspaceId);
+      const useWorktree = asBoolean(body.useWorktree);
 
       const workspace = await ctx.workspaceService.provisionWorkspace({
-        repo: repo as string,
-        baseBranch: baseBranch as string,
-        branchName: branchName as string | undefined,
-        useWorktree: useWorktree as boolean,
-        parentWorkspaceId: parentWorkspaceId as string,
+        repo,
+        ...(baseBranch ? { baseBranch } : {}),
+        ...(branchName ? { branchName } : {}),
+        ...(useWorktree !== undefined ? { useWorktree } : {}),
+        ...(parentWorkspaceId ? { parentWorkspaceId } : {}),
       });
 
       sendJson(
@@ -128,10 +141,12 @@ export async function handleWorkspaceRoutes(
     try {
       const workspaceId = pushMatch[1];
       const body = await parseBody(req);
+      const force = asBoolean(body.force);
+      const setUpstream = asBoolean(body.setUpstream);
 
       const result = await ctx.workspaceService.push(workspaceId, {
-        force: body.force as boolean,
-        setUpstream: body.setUpstream as boolean,
+        ...(force !== undefined ? { force } : {}),
+        ...(setUpstream !== undefined ? { setUpstream } : {}),
       });
 
       sendJson(res, result);
@@ -156,12 +171,20 @@ export async function handleWorkspaceRoutes(
     try {
       const workspaceId = prMatch[1];
       const body = await parseBody(req);
+      const title = asString(body.title);
+      const prBody = asString(body.body);
+      if (!title || !prBody) {
+        sendError(res, "title and body are required");
+        return true;
+      }
+      const base = asString(body.baseBranch);
+      const draft = asBoolean(body.draft);
 
       const result = await ctx.workspaceService.createPR(workspaceId, {
-        title: body.title as string,
-        body: body.body as string,
-        base: body.baseBranch as string,
-        draft: body.draft as boolean,
+        title,
+        body: prBody,
+        ...(base ? { base } : {}),
+        ...(draft !== undefined ? { draft } : {}),
       });
 
       sendJson(res, result, 201);

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -774,10 +774,13 @@ export class CodingWorkspaceService {
       (this.runtime.getSetting("ELIZA_CODING_DIRECTORY") as string) ??
       this.readConfigEnvKey("ELIZA_CODING_DIRECTORY") ??
       process.env.ELIZA_CODING_DIRECTORY;
-    const codingDir = rawCodingDir.trim()
-      ? rawCodingDir.trim().startsWith("~")
-        ? path.join(os.homedir(), rawCodingDir.trim().slice(1))
-        : path.resolve(rawCodingDir.trim())
+    // ELIZA_CODING_DIRECTORY is optional — guard the trim so an unconfigured
+    // runtime (rawCodingDir === undefined) doesn't crash scratch-dir cleanup.
+    const trimmedCodingDir = rawCodingDir?.trim();
+    const codingDir = trimmedCodingDir
+      ? trimmedCodingDir.startsWith("~")
+        ? path.join(os.homedir(), trimmedCodingDir.slice(1))
+        : path.resolve(trimmedCodingDir)
       : undefined;
     const allowedDirs = codingDir ? [codingDir] : undefined;
     return removeScratchDir(
@@ -986,7 +989,7 @@ export class CodingWorkspaceService {
         (this.runtime.getSetting("ELIZA_CODING_DIRECTORY") as string) ??
         this.readConfigEnvKey("ELIZA_CODING_DIRECTORY") ??
         process.env.ELIZA_CODING_DIRECTORY;
-      if (codingDir.trim()) return "persistent";
+      if (codingDir?.trim()) return "persistent";
     }
     return "pending_decision";
   }


### PR DESCRIPTION
Audit-confirmed findings (each adversarially verified by 3 independent skeptics) in the route + workspace layer.

## Route input validation (findings #7–11)
`workspace-routes` (provision/push/PR), `issue-routes` (create/comment), and `agent-routes` (getSessionOutput) coerced untyped `parseBody` output with `body.x as string` / `as boolean` — so a client sending `{repo: 123}` or `{useWorktree: "yes"}` flowed straight into `provisionWorkspace`/`push`/`createPR`/`createIssue`, and `getSessionOutput` passed `parseInt("abc") === NaN` to the service.

Added shared boundary coercers to `route-utils` — `asString` / `asBoolean` (never coerces a truthy string) / `asStringArray` / `asFiniteNumber` — applied them so wrong types are rejected (400) or dropped, and **deduped** `orchestrator-routes`' local `asString`/`asBoolean`/`asStringArray` onto the shared ones (single source of truth).

## Workspace null-deref (findings #12–13)
`CodingWorkspaceService.removeScratchDir` and `getScratchRetentionPolicy` called `rawCodingDir.trim()` where `ELIZA_CODING_DIRECTORY` is **optional** — an unconfigured runtime (value `undefined`) crashed scratch-dir cleanup with `Cannot read properties of undefined (reading 'trim')`. Guarded with optional chaining.

## Evidence
```
$ bunx vitest run route-input-validation                              → 4 passed
$ bunx vitest run orchestrator-routes provision-workspace \
    workspace-isolation bridge-routes issue-routes workspace-diff     → 68 passed (6 files)
```

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)