### PR TITLE
fix(cloud): refund stranded hold on non-streaming app-chat post-provider failure (#11169 part 1)

### DIFF
--- a/packages/cloud/api/__tests__/apps-chat-nonstream-refund.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-nonstream-refund.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Money-leak guard for POST /api/v1/apps/:id/chat NON-streaming (#11169 part 1).
+ *
+ * A non-streaming app-chat reserves credits up front, then reads the provider
+ * body + computes cost and only THEN settles via reconcileCredits. Before this
+ * fix, a throw between the debit and the settle (a truncated body failing
+ * providerResponse.json(), or a transient pricing error in calculateCost) fell
+ * through to the outer catch, which returned 500 WITHOUT refunding — the hold
+ * was stranded (the streaming branch had reconcileStreamProcessingError; this
+ * one had nothing).
+ *
+ * This drives the REAL `reconcileNonStreamProcessingError` (the exact code the
+ * route runs) against a spy credit service, asserting the refund decision.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import { reconcileNonStreamProcessingError } from "../v1/apps/[id]/chat/non-stream-refund";
+import type { StreamRefundCredits } from "../v1/apps/[id]/chat/stream-refund";
+
+function makeCredits() {
+  const calls: Array<{ estimatedBaseCost: number; actualBaseCost: number }> =
+    [];
+  const reconcileCredits = mock(
+    async (args: { estimatedBaseCost: number; actualBaseCost: number }) => {
+      calls.push({
+        estimatedBaseCost: args.estimatedBaseCost,
+        actualBaseCost: args.actualBaseCost,
+      });
+      return null;
+    },
+  );
+  return { calls, reconcileCredits } satisfies {
+    calls: unknown;
+    reconcileCredits: StreamRefundCredits["reconcileCredits"];
+  };
+}
+
+const base = {
+  appId: "app-1",
+  userId: "user-1",
+  reservedBaseCost: 0.05,
+  errorMessage: "truncated provider body",
+};
+
+describe("reconcileNonStreamProcessingError (#11169)", () => {
+  test("failure BEFORE settle (reconciled=false) → full refund (actualBaseCost 0)", async () => {
+    const credits = makeCredits();
+    const result = await reconcileNonStreamProcessingError(
+      { ...base, reconciled: false },
+      credits,
+    );
+    expect(result.refunded).toBe(true);
+    expect(credits.reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(credits.calls).toEqual([
+      { estimatedBaseCost: 0.05, actualBaseCost: 0 },
+    ]);
+  });
+
+  test("failure AFTER settle (reconciled=true) → NO refund, charge kept", async () => {
+    const credits = makeCredits();
+    const result = await reconcileNonStreamProcessingError(
+      { ...base, reconciled: true },
+      credits,
+    );
+    expect(result.refunded).toBe(false);
+    expect(credits.reconcileCredits).not.toHaveBeenCalled();
+    expect(credits.calls).toEqual([]);
+  });
+
+  test("refund propagates the reserved amount exactly (no partial)", async () => {
+    const credits = makeCredits();
+    await reconcileNonStreamProcessingError(
+      { ...base, reconciled: false, reservedBaseCost: 0.1234 },
+      credits,
+    );
+    expect(credits.calls).toEqual([
+      { estimatedBaseCost: 0.1234, actualBaseCost: 0 },
+    ]);
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/chat/non-stream-refund.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/non-stream-refund.ts
@@ -1,0 +1,53 @@
+import { logger } from "@/lib/utils/logger";
+import type { StreamRefundCredits } from "./stream-refund";
+
+/**
+ * Money-critical (#11169): on the NON-streaming path, refund the upfront
+ * reservation when post-provider processing fails BEFORE the settle completes.
+ *
+ * A non-streaming app-chat request reserves credits up front, then reads the
+ * provider body (`providerResponse.json()`), computes `calculateCost`, and only
+ * THEN settles via `reconcileCredits`. If anything before the settle throws (a
+ * truncated body, a transient pricing-catalog error), the hold is stranded —
+ * the streaming branch is covered by {@link reconcileStreamProcessingError},
+ * this path was not.
+ *
+ * So we refund the full hold ONLY when `reconciled` is false (the settle had
+ * not yet run). Once `reconcileCredits` has settled, a later throw must NOT
+ * refund — the charge is real — mirroring the streaming branch's
+ * `streamCompleted` gating. Returns whether a refund was issued.
+ */
+export async function reconcileNonStreamProcessingError(
+  params: {
+    reconciled: boolean;
+    appId: string;
+    userId: string;
+    reservedBaseCost: number;
+    errorMessage: string;
+  },
+  credits: StreamRefundCredits,
+): Promise<{ refunded: boolean }> {
+  const { reconciled, appId, userId, reservedBaseCost, errorMessage } = params;
+
+  if (reconciled) {
+    logger.error(
+      "[App Chat] Non-streaming post-settle step failed AFTER reconcile; keeping charge (NOT refunding)",
+      { appId, userId, reservedBaseCost, error: errorMessage },
+    );
+    return { refunded: false };
+  }
+
+  logger.error(
+    "[App Chat] Non-streaming post-provider processing failed before settle, refunding reserved",
+    { appId, userId, reservedBaseCost, error: errorMessage },
+  );
+  await credits.reconcileCredits({
+    appId,
+    userId,
+    estimatedBaseCost: reservedBaseCost,
+    actualBaseCost: 0, // Refund full reserved amount
+    description: "Refund due to post-provider processing error",
+    metadata: { error: true, postProvider: true, streaming: false },
+  });
+  return { refunded: true };
+}

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -46,6 +46,7 @@ import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { reservationOutputTokens } from "./chat-reservation";
+import { reconcileNonStreamProcessingError } from "./non-stream-refund";
 import { reconcileStreamProcessingError } from "./stream-refund";
 
 const ROUTE_MAX_DURATION = 800;
@@ -659,73 +660,99 @@ async function handlePOST(
       );
     }
 
-    // Non-streaming response
-    const responseData = (await providerResponse.json()) as {
-      usage?: { prompt_tokens?: number; completion_tokens?: number };
-      choices?: Array<{ message?: { content?: string } }>;
-    };
+    // Non-streaming response. Everything below runs AFTER the upfront hold was
+    // debited, so a throw here — a truncated body failing providerResponse.json(),
+    // or calculateCost erroring — would strand the reserved hold (the streaming
+    // branch is covered by reconcileStreamProcessingError; this one was not,
+    // #11169). Full-refund on any failure BEFORE the settle completes; once
+    // reconcileCredits has settled, a later throw must NOT refund (the charge is
+    // real), mirroring the streaming branch's streamCompleted gating.
+    let reconciled = false;
+    try {
+      const responseData = (await providerResponse.json()) as {
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+        choices?: Array<{ message?: { content?: string } }>;
+      };
 
-    // Calculate actual cost - use fallback estimation if provider doesn't return usage
-    let actualInputTokens = responseData.usage?.prompt_tokens || 0;
-    let actualOutputTokens = responseData.usage?.completion_tokens || 0;
+      // Calculate actual cost - use fallback estimation if provider doesn't return usage
+      let actualInputTokens = responseData.usage?.prompt_tokens || 0;
+      let actualOutputTokens = responseData.usage?.completion_tokens || 0;
 
-    // Fallback: estimate tokens if usage not provided (matching streaming behavior)
-    if (actualInputTokens === 0 && actualOutputTokens === 0) {
-      const outputContent = responseData.choices?.[0]?.message?.content || "";
-      actualInputTokens = estimatedInputTokens; // Use pre-calculated estimate
-      actualOutputTokens = estimateTokens(outputContent);
+      // Fallback: estimate tokens if usage not provided (matching streaming behavior)
+      if (actualInputTokens === 0 && actualOutputTokens === 0) {
+        const outputContent = responseData.choices?.[0]?.message?.content || "";
+        actualInputTokens = estimatedInputTokens; // Use pre-calculated estimate
+        actualOutputTokens = estimateTokens(outputContent);
 
-      logger.warn("[App Chat] No usage data in response, using estimates", {
-        appId,
+        logger.warn("[App Chat] No usage data in response, using estimates", {
+          appId,
+          actualInputTokens,
+          actualOutputTokens,
+        });
+      }
+
+      const { totalCost: actualBaseCost } = await calculateCost(
+        normalizedModel,
+        provider,
         actualInputTokens,
         actualOutputTokens,
-      });
-    }
-
-    const { totalCost: actualBaseCost } = await calculateCost(
-      normalizedModel,
-      provider,
-      actualInputTokens,
-      actualOutputTokens,
-      billingSource,
-    );
-
-    // Reconcile the difference between reserved and actual costs
-    // Pass app to avoid N+1 query (app already fetched above)
-    const reconciliation = await appCreditsService.reconcileCredits({
-      appId,
-      userId: user.id,
-      estimatedBaseCost: reservedBaseCost,
-      actualBaseCost,
-      description: `Chat reconciliation: ${model}`,
-      metadata: {
-        model,
-        provider,
         billingSource,
+      );
+
+      // Reconcile the difference between reserved and actual costs
+      // Pass app to avoid N+1 query (app already fetched above)
+      const reconciliation = await appCreditsService.reconcileCredits({
+        appId,
+        userId: user.id,
+        estimatedBaseCost: reservedBaseCost,
+        actualBaseCost,
+        description: `Chat reconciliation: ${model}`,
+        metadata: {
+          model,
+          provider,
+          billingSource,
+          inputTokens: actualInputTokens,
+          outputTokens: actualOutputTokens,
+          streaming: false,
+        },
+        app,
+      });
+      reconciled = true;
+
+      const duration = Date.now() - startTime;
+      logger.info("[App Chat] Request completed", {
+        appId,
+        userId: user.id,
+        model,
+        duration,
         inputTokens: actualInputTokens,
         outputTokens: actualOutputTokens,
-        streaming: false,
-      },
-      app,
-    });
+        reservedBaseCost,
+        actualBaseCost,
+        reconciliation: {
+          action: reconciliation.action,
+          amount: reconciliation.adjustedAmount,
+        },
+      });
 
-    const duration = Date.now() - startTime;
-    logger.info("[App Chat] Request completed", {
-      appId,
-      userId: user.id,
-      model,
-      duration,
-      inputTokens: actualInputTokens,
-      outputTokens: actualOutputTokens,
-      reservedBaseCost,
-      actualBaseCost,
-      reconciliation: {
-        action: reconciliation.action,
-        amount: reconciliation.adjustedAmount,
-      },
-    });
-
-    return withCors(Response.json(responseData));
+      return withCors(Response.json(responseData));
+    } catch (postProviderError) {
+      // Refund the outstanding hold iff the settle had not yet run (#11169).
+      await reconcileNonStreamProcessingError(
+        {
+          reconciled,
+          appId,
+          userId: user.id,
+          reservedBaseCost,
+          errorMessage:
+            postProviderError instanceof Error
+              ? postProviderError.message
+              : String(postProviderError),
+        },
+        appCreditsService,
+      );
+      throw postProviderError;
+    }
   } catch (error) {
     logger.error("[App Chat] Error:", error);
 


### PR DESCRIPTION
Closes part 1 of #11169. The non-streaming branch of `apps/[id]/chat` read the provider body, computed cost, and settled — all outside any refund scope; a throw before the settle (truncated body failing `providerResponse.json()`, transient `calculateCost` error) fell through to the outer catch, which returned 500 WITHOUT refunding the upfront hold. The streaming branch was covered by `reconcileStreamProcessingError` (#10837); this path had nothing.

Extracts a pure `reconcileNonStreamProcessingError` helper (mirroring the stream one): wraps the post-provider block, tracks whether `reconcileCredits` settled, full-refunds iff the settle had not yet run — a body/cost failure can't keep the advertiser's credits, while a post-settle throw correctly keeps the real charge. 3 unit tests drive the real helper; existing stream-refund test still green; tsgo + biome clean.

Scope note: #11169 residual 2 (`/v1/chat` reserve sizing) already landed on develop; residuals 3 (stranded synchronous reservation on dropped `waitUntil`/eviction — needs a stale-reservation sweep mirroring `sweepStalePendingInferenceChargesDb`) and 4 (abort-mid-stream refund evasion) are the reservation-lifecycle sweep work, tracked on the issue for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)