### PR TITLE
fix(orchestrator): route task-addressed resume through the durable task service (pause→resume dead-end)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   callback,
   memory,
   runtimeWith,
+  serviceMock,
   state,
 } from "../../src/test-utils/action-test-utils.js";
 
@@ -22,8 +23,12 @@ function taskServiceMock() {
     reopenTask: vi.fn(async (id: string) =>
       id === "t1" ? { task: { id, archived: false }, sessions: [] } : null,
     ),
+    // TaskThreadDetailDto keeps `paused` at the top level.
     pauseTask: vi.fn(async (id: string) =>
-      id === "t1" ? { task: { id, paused: true }, sessions: [] } : null,
+      id === "t1" ? { id, paused: true, sessions: [] } : null,
+    ),
+    resumeTask: vi.fn(async (id: string) =>
+      id === "t1" ? { id, paused: false, sessions: [] } : null,
     ),
   };
 }
@@ -67,6 +72,51 @@ describe("TASKS archive/reopen lifecycle (#11028)", () => {
       callback(),
     );
     expect(svc.pauseTask).toHaveBeenCalledWith("t1");
+    expect(result?.success).toBe(true);
+  });
+
+  it("resumes a paused task through the durable service (pause→resume no longer dead-ends in SESSION_NOT_FOUND)", async () => {
+    const svc = taskServiceMock();
+    // pauseTask sets paused:true AND stops the task's active sessions, so the
+    // mock's empty listSessions() mirrors the real post-pause state.
+    await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "control", controlAction: "pause", taskId: "t1" }),
+      callback(),
+    );
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "control", controlAction: "resume", taskId: "t1" }),
+      callback(),
+    );
+    expect(svc.resumeTask).toHaveBeenCalledWith("t1");
+    expect(result?.success).toBe(true);
+    expect(result?.error).not.toBe("SESSION_NOT_FOUND");
+    const task = (result?.data as { task?: { paused?: boolean } })?.task;
+    expect(task?.paused).toBe(false);
+  });
+
+  it("keeps session-scoped resume (no taskId) on the ACP path", async () => {
+    const svc = serviceMock();
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({ text: "resume" }),
+      state,
+      opts({
+        action: "control",
+        controlAction: "resume",
+        instruction: "keep going",
+      }),
+      callback(),
+    );
+    expect(svc.sendToSession).toHaveBeenCalledWith(
+      "abcdef123456",
+      "keep going",
+    );
     expect(result?.success).toBe(true);
   });
 

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1941,6 +1941,21 @@ async function runControl(
     return runTaskLifecycleControl(runtime, params, content, callback, action);
   }
 
+  // Resume is durable too whenever it names a task: pauseTask stops the
+  // task's active sessions AND sets paused:true, so a session-scoped resume
+  // after a pause dead-ends in SESSION_NOT_FOUND while the task stays paused.
+  // Route task-addressed resumes to the service's resumeTask (clears the
+  // pause, mirroring the /tasks/:id/resume route). Session-scoped resumes
+  // (approval-style follow-ups to a live session, no taskId) keep the ACP
+  // path below.
+  if (
+    action === "resume" &&
+    (pickString(params, content, "taskId") ??
+      pickString(params, content, "threadId"))
+  ) {
+    return runTaskLifecycleControl(runtime, params, content, callback, action);
+  }
+
   const instruction =
     textValue(params.instruction) ??
     textValue(content.instruction) ??
@@ -2709,17 +2724,18 @@ async function runManageIssues(
 
 // ── action: archive / reopen (ARCHIVE_CODING_TASK / REOPEN_CODING_TASK) ────
 
-type TaskLifecycleOp = "archive" | "reopen" | "pause";
+type TaskLifecycleOp = "archive" | "reopen" | "pause" | "resume";
 
 /**
- * Archive / reopen / pause a durable task via OrchestratorTaskService. These are
- * first-class operations on the durable task store — the
- * `/api/orchestrator/tasks/:id/{archive,reopen}` routes already expose them, and
- * `archiveTask`/`reopenTask`/`pauseTask` all exist. The old action paths returned
- * `UNSUPPORTED_OPERATION` ("ACP-only mode") from before the task service existed,
- * which then failed the very calls the archive/reopen similes train the planner
- * to make. Only a genuinely ACP-only runtime (no task service registered) still
- * reports the operation as unavailable.
+ * Archive / reopen / pause / resume a durable task via OrchestratorTaskService.
+ * These are first-class operations on the durable task store — the
+ * `/api/orchestrator/tasks/:id/{archive,reopen,pause,resume}` routes already
+ * expose them, and `archiveTask`/`reopenTask`/`pauseTask`/`resumeTask` all
+ * exist. The old action paths returned `UNSUPPORTED_OPERATION` ("ACP-only
+ * mode") from before the task service existed, which then failed the very
+ * calls the archive/reopen similes train the planner to make. Only a genuinely
+ * ACP-only runtime (no task service registered) still reports the operation as
+ * unavailable.
  */
 async function runTaskLifecycleControl(
   runtime: IAgentRuntime,
@@ -2756,7 +2772,9 @@ async function runTaskLifecycleControl(
         ? await taskService.archiveTask(taskId)
         : op === "reopen"
           ? await taskService.reopenTask(taskId)
-          : await taskService.pauseTask(taskId);
+          : op === "pause"
+            ? await taskService.pauseTask(taskId)
+            : await taskService.resumeTask(taskId);
     if (!result) {
       const msg = `Task ${taskId} not found.`;
       await callbackText(callback, msg);
@@ -2766,7 +2784,13 @@ async function runTaskLifecycleControl(
       });
     }
     const verb =
-      op === "archive" ? "Archived" : op === "reopen" ? "Reopened" : "Paused";
+      op === "archive"
+        ? "Archived"
+        : op === "reopen"
+          ? "Reopened"
+          : op === "pause"
+            ? "Paused"
+            : "Resumed";
     const out = `${verb} coding task ${taskId}.`;
     await callbackText(callback, out);
     return {


### PR DESCRIPTION
## The bug

QA follow-up on #11216 (which wired the TASKS control action's archive/reopen/pause verbs to the durable `OrchestratorTaskService`, closing #11028): the **resume** verb was left on the ACP-session-only path.

`OrchestratorTaskService.pauseTask` does two things (`src/services/orchestrator-task-service.ts:1580`): it **stops the task's active sessions** and sets `paused: true`. So pausing a task via `TASKS action=control controlAction=pause taskId=…` worked, but the matching resume then:

1. skipped the durable service entirely (never called the existing `resumeTask`, which the `POST /api/orchestrator/tasks/:id/resume` route already uses),
2. tried `resolveSession` against sessions that pause had just stopped, and
3. dead-ended with `SESSION_NOT_FOUND` — leaving the task `paused: true` forever. The agent could never un-pause a task it had just paused through its own action surface.

## The fix

`plugins/plugin-agent-orchestrator/src/actions/tasks.ts`:

- In `runControl`, a resume that names a task (`taskId`/`threadId`) now routes through `runTaskLifecycleControl` → `taskService.resumeTask(taskId)`, mirroring exactly how #11216 wired archive/reopen/pause (same `MISSING_TASK_ID` / `UNSUPPORTED_OPERATION` / `TASK_NOT_FOUND` / `LIFECYCLE_FAILED` error shape and success envelope).
- `TaskLifecycleOp` gains `"resume"`; dispatch + response verb extended accordingly.
- Session-scoped resumes (approval-style follow-ups like "do it" against a live session, with no taskId) keep the existing ACP `sendToSession` path — covered by a new regression test.

## Test evidence

Extended the #11216 suite `plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts`:

- `resumes a paused task through the durable service (pause→resume no longer dead-ends in SESSION_NOT_FOUND)` — pause then resume via the control action; asserts `resumeTask("t1")` is called, `success: true`, no `SESSION_NOT_FOUND`, and the returned task has `paused: false`.
- `keeps session-scoped resume (no taskId) on the ACP path` — asserts `sendToSession` still receives the follow-up instruction.

**Red on unfixed develop** (src change stashed, test change applied):

```
Tests  1 failed | 7 passed (8)
AssertionError: expected "vi.fn()" to be called with arguments: [ 't1' ]  (resumeTask, Number of calls: 0)
```

**Green with the fix:**

```
cd plugins/plugin-agent-orchestrator && bunx vitest run __tests__/unit/archive-reopen-lifecycle.test.ts
Test Files  1 passed (1) · Tests  8 passed (8)

cd plugins/plugin-agent-orchestrator && bunx vitest run __tests__/unit/
Test Files  106 passed (106) · Tests  1136 passed (1136)
```

Biome is clean on the new test file; the two pre-existing `tasks.ts` biome complaints (import sort at line 42, formatting at line 524) exist on develop tip untouched by this diff. `tsc` reports no errors in the touched files.

Refs #11216 #11028

🤖 Generated with [Claude Code](https://claude.com/claude-code)