### PR TITLE
fix(cloud-e2e): remove duplicate createTestCharacter decl in group-i (breaks the file on develop)

### DIFF
--- a/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
+++ b/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
@@ -158,26 +158,6 @@ async function getApp(id: string): Promise<AppDto | undefined> {
   return ((await res.json()) as GetAppResponse).app;
 }
 
-const createdCharacterIds: string[] = [];
-
-/**
- * Creates a real character owned by the test user. linked_character_ids on
- * PUT /api/v1/apps/:id enforces the character ownership guard (#10863), so
- * link targets must exist and be owned/public — made-up UUIDs 404.
- */
-async function createTestCharacter(): Promise<string> {
-  const res = await api.post(
-    "/api/my-agents/characters",
-    { name: uniqueName("Linked Character"), bio: ["app-link e2e fixture"] },
-    { headers: bearerHeaders() },
-  );
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { id?: string };
-  expect(body.id).toBeTruthy();
-  createdCharacterIds.push(body.id as string);
-  return body.id as string;
-}
-
 afterAll(async () => {
   if (!serverReachable || !hasTestApiKey) return;
   for (const appId of createdAppIds) {


### PR DESCRIPTION
**Develop-health hotfix.** #11191 and a parallel sibling refactor (#10863) both added `createTestCharacter` + `createdCharacterIds` to `group-i-apps-lifecycle.test.ts` → **duplicate declarations** that error the whole file. Removed the second copy (kept the first, adjacent to `createdAppIds`).

Evidence: file now has exactly one of each declaration; **32/32 green** against live staging (`api-staging.elizacloud.ai`, real Worker+DB). No behavior change — both copies were identical.

— `[cloud-frontdoor]`