### PR TITLE
fix(core): extend #11215 capability-denial + tool-retry rules to the direct-message template

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -844,7 +844,45 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(systemContent).toContain("- calendar [label=Calendar");
 		expect(systemContent).toContain("role>=ADMIN");
 		expect(systemContent).not.toContain(longDescription);
-		expect(systemContent.length).toBeLessThan(3_500);
+		// Compactness ceiling for the DM Stage-1 prompt. Any leaked context
+		// description (~2,500+ chars each) blows far past this; deliberate
+		// template rules only nudge it, so keep the ceiling tight.
+		expect(systemContent.length).toBeLessThan(3_800);
+	});
+
+	it("direct-channel prompt grounds capability denials in available_contexts and requires fresh tool retries", async () => {
+		// Mirror of the #11215 wording-regression test on the shared
+		// messageHandlerTemplate: Stage 1 for DM/API/SELF renders the compact
+		// DIRECT_MESSAGE_HANDLER_TEMPLATE instead, so the dashboard chat and
+		// 1:1 DMs — the primary surface where users hit "I don't have memory
+		// between sessions" / "I can't schedule" — need their own copies of
+		// the capability-denial and tool-retry rules.
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Hi.",
+			}),
+		]);
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const systemContent = params.messages?.[0]?.content ?? "";
+		expect(systemContent).toContain("task: Plan this direct message.");
+		expect(systemContent).toContain(
+			"Never deny a capability (memory, tasks, scheduling, reminders) when a matching context is in available_contexts — route to it; deny only when nothing matches.",
+		);
+		expect(systemContent).toContain(
+			"A tool that errored on an earlier turn may work now; on a repeated ask, retry it fresh and report this turn's result, not the old failure.",
+		);
 	});
 
 	it("keeps tool-like direct messages on the structured routing path", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3010,6 +3010,8 @@ direct/private rules:
 - Use non-simple context/action names only for tools, live facts, private state, files, web, shell, side effects, scheduling, memory, settings, secrets, wallet/finance, media, or device/app control.
 - Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context. If a specific name/thing is unclear, choose general or memory.
 - Never claim searched/scanned/recalled unless tool returned it; includes "I scanned the chat" or "Spawning a sub-agent".
+- Never deny a capability (memory, tasks, scheduling, reminders) when a matching context is in available_contexts — route to it; deny only when nothing matches.
+- A tool that errored on an earlier turn may work now; on a repeated ask, retry it fresh and report this turn's result, not the old failure.
 - Crisis/legal/medical/self-harm/police/CPS: contexts=["simple"], replyText deferral only; no actions or conceal/evasion/testimony/contraband advice. Refer to lawyer/emergency services/poison control/doctor/therapist/crisis/DV hotline.
 - For tool/planning paths, replyText is only a brief ack ("On it."). Never refuse because tools may run after this stage.
 - If schema omits shouldRespond, do not invent it.


### PR DESCRIPTION
## Extend the #11215 capability-denial + tool-retry rules to direct channels

#11215 added the "never deny a capability that's in `available_contexts`" and "retry a previously-errored tool on a repeated ask" rules to the shared `messageHandlerTemplate`. But Stage-1 for `ChannelType.DM`/`API`/`SELF` (`directMessageChannel`) uses the **local compact `DIRECT_MESSAGE_HANDLER_TEMPLATE`** in `packages/core/src/services/message.ts`, not the shared template — so the dashboard chat (API) and 1:1 DMs, the primary surface where users hit "I don't have memory between sessions" / "I can't schedule", never got the guidance.

Adds compact one-line equivalents to `DIRECT_MESSAGE_HANDLER_TEMPLATE` (`available_contexts` is a real construct there — verified). Fail-without-fix: reverting `message.ts` reds the new stage-1 assertion; 73/73 green with it. Refs #11215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
