### PR TITLE
fix(orchestrator): bound sub-agent-router per-session tracking maps (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-memory-bounds.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-memory-bounds.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { pruneOldestTracked } from "../../src/services/sub-agent-router.js";
+
+// Regression for the #11028 audit: the router's per-session tracking
+// collections (parentAgentBuffers / parentAgentDispatchCounts /
+// verifyRetryHandedOffSessions) accrued one entry per session and were only
+// cleared in stop(), leaking over a long orchestrator uptime. handleEvent now
+// caps each via pruneOldestTracked.
+describe("pruneOldestTracked", () => {
+  it("evicts the oldest entries of a Map down to the cap", () => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < 300; i++) m.set(`s${i}`, i);
+    pruneOldestTracked(m, 256);
+    expect(m.size).toBe(256);
+    // Oldest (s0..s43) evicted; newest retained.
+    expect(m.has("s0")).toBe(false);
+    expect(m.has("s43")).toBe(false);
+    expect(m.has("s44")).toBe(true);
+    expect(m.has("s299")).toBe(true);
+  });
+
+  it("evicts the oldest entries of a Set down to the cap", () => {
+    const s = new Set<string>();
+    for (let i = 0; i < 300; i++) s.add(`h${i}`);
+    pruneOldestTracked(s, 256);
+    expect(s.size).toBe(256);
+    expect(s.has("h0")).toBe(false);
+    expect(s.has("h299")).toBe(true);
+  });
+
+  it("is a no-op at or below the cap", () => {
+    const m = new Map<string, number>([["a", 1]]);
+    pruneOldestTracked(m, 256);
+    expect(m.size).toBe(1);
+  });
+
+  it("prunes the exact excess in one pass (no under-pruning)", () => {
+    const m = new Map<string, number>();
+    for (let i = 0; i < 500; i++) m.set(`k${i}`, i);
+    pruneOldestTracked(m, 100);
+    expect(m.size).toBe(100);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -669,6 +669,19 @@ export class SubAgentRouter extends Service {
     if (event === "message") {
       await this.maybeDispatchParentAgent(sessionId, data);
     }
+    // Bound the per-session tracking collections. Each accrues one entry per
+    // session (buffered parent-agent output, dispatch count, verify-retry
+    // handoff marker) and only stop() cleared them, so a long-lived orchestrator
+    // leaked one set of entries per finished session. Cap to the most recent N
+    // sessions — evicting an old, finished session's entry is harmless (its
+    // buffer/count are only used while it streams, and a handoff suppression is
+    // moot once the original session is long gone).
+    pruneOldestTracked(this.parentAgentBuffers, PARENT_AGENT_TRACKING_CAP);
+    pruneOldestTracked(this.parentAgentDispatchCounts, PARENT_AGENT_TRACKING_CAP);
+    pruneOldestTracked(
+      this.verifyRetryHandedOffSessions,
+      PARENT_AGENT_TRACKING_CAP,
+    );
     if (!shouldInject(event)) return;
     const acp = this.acp;
     if (!acp) return;
@@ -3096,6 +3109,36 @@ function pruneDelivered(set: Set<string>, max: number): void {
     if (next.done) break;
     set.delete(next.value);
   }
+}
+
+// Cap for the per-session parent-agent tracking collections (buffers, dispatch
+// counts, verify-retry handoffs). Far above any realistic concurrent-session
+// count; it exists only to stop unbounded growth over a long uptime.
+const PARENT_AGENT_TRACKING_CAP = 256;
+
+/**
+ * Evict the oldest entries from a Map or Set (insertion-ordered) so it never
+ * exceeds `max`. Collects the doomed keys first, then deletes, so it prunes the
+ * exact excess in one pass (unlike the older size-mutating loop in
+ * {@link pruneDelivered}).
+ */
+export function pruneOldestTracked(
+  collection: {
+    size: number;
+    keys(): IterableIterator<string>;
+    delete(key: string): unknown;
+  },
+  max: number,
+): void {
+  const excess = collection.size - max;
+  if (excess <= 0) return;
+  const doomed: string[] = [];
+  let seen = 0;
+  for (const key of collection.keys()) {
+    if (seen++ >= excess) break;
+    doomed.push(key);
+  }
+  for (const key of doomed) collection.delete(key);
 }
 
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {


### PR DESCRIPTION
Audit-confirmed (3/3 skeptics) memory leak in `SubAgentRouter`.

## Bug
Three per-session collections — `parentAgentBuffers`, `parentAgentDispatchCounts`, `verifyRetryHandedOffSessions` — accrued one entry per session and were only ever cleared in `stop()`. Over a long orchestrator uptime with many finished sessions, that is unbounded growth.

## Fix
`handleEvent` now caps each collection to the most recent `PARENT_AGENT_TRACKING_CAP` (256) sessions via a new `pruneOldestTracked` helper, mirroring the existing `delivered`-set pruning. Evicting an old finished session's entry is harmless — the buffer/count matter only while the session streams, and a verify-retry handoff suppression is moot once the original session is long gone. The helper prunes the exact excess in a single pass (the older `pruneDelivered` under-prunes because it re-reads `size` while deleting).

## Evidence
```
$ bunx vitest run sub-agent-router → 102 passed | 1 skipped
```
+4 cases: Map + Set eviction to the cap, no-op at/below cap, exact-excess prune.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)