### PR TITLE
fix(orchestrator): resume/reopen clears the durable paused flag (pause was a one-way door, post-#11216)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
@@ -1,0 +1,298 @@
+/**
+ * #11216 wired control PAUSE to the durable pauseTask (stops sessions, sets
+ * paused:true, which freezes advanceTaskStatus) — but the paired
+ * resume/continue branch only did a bare ACP session send, so pause was a
+ * one-way door from the action surface: no unpause path ever cleared the
+ * durable flag. These tests drive the REAL OrchestratorTaskService (in-memory
+ * store + fake ACP) through the TASKS control action and pin the symmetry:
+ * pause freezes the status state machine, resume/continue unfreezes it, and
+ * the plain ACP-send fallback for sessions with no durable task survives.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { tasksAction } from "../../src/actions/tasks.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import {
+  callback,
+  memory,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+// Same rationale as orchestrator-task-service.test.ts: disable the #8896
+// default-criteria contract so criteria-free tasks keep the original
+// state-machine behaviour these tests pin.
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
+
+interface LiveSession {
+  id: string;
+  name: string;
+  agentType: string;
+  workdir: string;
+  status: string;
+  createdAt: Date;
+  lastActivityAt: Date;
+}
+
+/**
+ * Fake AcpService serving both consumers: the task service's event bridge /
+ * lifecycle calls (onSessionEvent, spawnSession, stopSession) and the control
+ * action's session resolution + send path (listSessions, getSession,
+ * sendToSession).
+ */
+class FakeAcp {
+  private handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | null = null;
+  private counter = 0;
+  live: LiveSession[] = [];
+  readonly sent: { sessionId: string; message: string }[] = [];
+  readonly stopped: string[] = [];
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+
+  spawnSession(opts: Record<string, unknown>): Promise<{
+    sessionId: string;
+    agentType: string;
+    workdir: string;
+    status: string;
+  }> {
+    this.counter += 1;
+    return Promise.resolve({
+      sessionId: `session-${this.counter}`,
+      agentType: (opts.agentType as string | undefined) ?? "codex",
+      workdir: (opts.workdir as string | undefined) ?? "/repo",
+      status: "ready",
+    });
+  }
+
+  sendToSession(sessionId: string, message: string): Promise<void> {
+    this.sent.push({ sessionId, message });
+    return Promise.resolve();
+  }
+
+  stopSession(sessionId: string): Promise<void> {
+    this.stopped.push(sessionId);
+    this.live = this.live.filter((session) => session.id !== sessionId);
+    return Promise.resolve();
+  }
+
+  listSessions(): LiveSession[] {
+    return this.live;
+  }
+
+  getSession(id: string): LiveSession | undefined {
+    return this.live.find((session) => session.id === id);
+  }
+}
+
+function liveSession(id: string): LiveSession {
+  const now = new Date("2026-07-02T10:00:00.000Z");
+  return {
+    id,
+    name: "agent-one",
+    agentType: "codex",
+    workdir: "/repo",
+    status: "ready",
+    createdAt: now,
+    lastActivityAt: now,
+  };
+}
+
+/** Yield a macrotask so the fire-and-forget event handler chain settles. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+async function drive(
+  acp: FakeAcp,
+  sessionId: string,
+  event: string,
+  data: unknown = {},
+): Promise<void> {
+  acp.emit(sessionId, event, data);
+  await flush();
+}
+
+const opts = (parameters: Record<string, unknown>) => ({ parameters });
+
+/**
+ * A real, started OrchestratorTaskService with one task and one spawned
+ * session, plus a runtime that resolves the task service by its own
+ * serviceType and the fake ACP for everything else (mirrors the live plugin
+ * wiring runControl sees).
+ */
+async function harness(): Promise<{
+  acp: FakeAcp;
+  runtime: IAgentRuntime;
+  taskService: OrchestratorTaskService;
+  taskId: string;
+  sessionId: string;
+}> {
+  const acp = new FakeAcp();
+  let taskService: OrchestratorTaskService | null = null;
+  const runtime = {
+    getService: vi.fn((type: string) =>
+      type === OrchestratorTaskService.serviceType ? taskService : acp,
+    ),
+    hasService: vi.fn(() => true),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never as IAgentRuntime;
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  taskService = new OrchestratorTaskService(runtime, { store });
+  await taskService.start();
+  const task = await taskService.createTask({
+    title: "Ship feature",
+    goal: "Implement and verify",
+  });
+  const detail = await taskService.spawnAgentForTask(task.id);
+  const sessionId = detail?.sessions[0]?.sessionId;
+  if (!sessionId) throw new Error("expected a spawned session");
+  return { acp, runtime, taskService, taskId: task.id, sessionId };
+}
+
+async function control(
+  runtime: IAgentRuntime,
+  parameters: Record<string, unknown>,
+) {
+  return tasksAction.handler(
+    runtime,
+    memory({}),
+    state,
+    opts(parameters),
+    callback(),
+  );
+}
+
+describe("TASKS control pause/resume symmetry (#11216 follow-up)", () => {
+  it("pause freezes the task; resume clears paused and unfreezes advanceTaskStatus", async () => {
+    const { acp, runtime, taskService, taskId, sessionId } = await harness();
+
+    const paused = await control(runtime, {
+      action: "control",
+      controlAction: "pause",
+      taskId,
+    });
+    expect(paused?.success).toBe(true);
+    expect((await taskService.getTask(taskId))?.paused).toBe(true);
+
+    // Frozen: session events cannot advance the durable status while paused.
+    await drive(acp, sessionId, "blocked", { message: "stuck" });
+    expect((await taskService.getTask(taskId))?.status).not.toBe("blocked");
+
+    const resumed = await control(runtime, {
+      action: "control",
+      controlAction: "resume",
+      taskId,
+    });
+    expect(resumed?.success).toBe(true);
+    expect((await taskService.getTask(taskId))?.paused).toBe(false);
+
+    // Unfrozen: the same event now advances the task status.
+    await drive(acp, sessionId, "blocked", { message: "stuck" });
+    expect((await taskService.getTask(taskId))?.status).toBe("blocked");
+  });
+
+  it("continue also clears the durable paused flag when no live session remains", async () => {
+    const { runtime, taskService, taskId } = await harness();
+
+    await control(runtime, {
+      action: "control",
+      controlAction: "pause",
+      taskId,
+    });
+    expect((await taskService.getTask(taskId))?.paused).toBe(true);
+
+    const result = await control(runtime, {
+      action: "control",
+      controlAction: "continue",
+      taskId,
+    });
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain(`Resumed coding task ${taskId}`);
+    expect((await taskService.getTask(taskId))?.paused).toBe(false);
+  });
+
+  it("resume with a taskId and a live session clears paused AND still sends the follow-up", async () => {
+    const { acp, runtime, taskService, taskId } = await harness();
+
+    await control(runtime, {
+      action: "control",
+      controlAction: "pause",
+      taskId,
+    });
+    acp.live = [liveSession("live-1")];
+    const sentBefore = acp.sent.length;
+
+    const result = await control(runtime, {
+      action: "control",
+      controlAction: "resume",
+      taskId,
+      instruction: "pick the work back up",
+    });
+    expect(result?.success).toBe(true);
+    expect((await taskService.getTask(taskId))?.paused).toBe(false);
+    expect(acp.sent.length).toBe(sentBefore + 1);
+    expect(acp.sent.at(-1)).toEqual({
+      sessionId: "live-1",
+      message: "pick the work back up",
+    });
+  });
+
+  it("resume without a taskId keeps the plain ACP-send fallback (no durable task touched)", async () => {
+    const { acp, runtime, taskService } = await harness();
+    const resumeSpy = vi.spyOn(taskService, "resumeTask");
+    acp.live = [liveSession("live-2")];
+    const sentBefore = acp.sent.length;
+
+    const result = await control(runtime, {
+      action: "control",
+      controlAction: "resume",
+      instruction: "keep going",
+    });
+    expect(result?.success).toBe(true);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(acp.sent.length).toBe(sentBefore + 1);
+    expect(acp.sent.at(-1)).toEqual({
+      sessionId: "live-2",
+      message: "keep going",
+    });
+  });
+
+  it("reopen clears a paused flag left by pause-then-archive", async () => {
+    const { runtime, taskService, taskId } = await harness();
+
+    await control(runtime, {
+      action: "control",
+      controlAction: "pause",
+      taskId,
+    });
+    await control(runtime, { action: "archive", taskId });
+    expect((await taskService.getTask(taskId))?.paused).toBe(true);
+
+    const result = await control(runtime, { action: "reopen", taskId });
+    expect(result?.success).toBe(true);
+    const detail = await taskService.getTask(taskId);
+    expect(detail?.paused).toBe(false);
+    expect(detail?.status).toBe("active");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1945,12 +1945,61 @@ async function runControl(
     textValue(params.instruction) ??
     textValue(content.instruction) ??
     (action === "continue" || action === "resume" ? text : undefined);
+
+  // Resume/continue must clear the durable paused flag before any ACP send:
+  // the pause branch above routes to pauseTask, which stops the task's
+  // sessions and sets paused:true — freezing advanceTaskStatus. A bare
+  // session send can never unpause the task (and after a pause there is
+  // usually no live session left to send to), so without this pause would be
+  // a one-way door from the action surface. Session-only calls (no
+  // taskId/threadId, or no task service) keep the plain ACP-send fallback.
+  const controlTaskId =
+    action === "resume" || action === "continue"
+      ? (pickString(params, content, "taskId") ??
+        pickString(params, content, "threadId"))
+      : undefined;
+  let resumedTask: Awaited<ReturnType<OrchestratorTaskService["resumeTask"]>> =
+    null;
+  if (controlTaskId) {
+    const taskService = runtime.getService?.(
+      OrchestratorTaskService.serviceType,
+    ) as OrchestratorTaskService | null | undefined;
+    if (taskService) {
+      try {
+        resumedTask = await taskService.resumeTask(controlTaskId);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        coreLogger.warn(`[TASKS:control] resume failed: ${errMsg}`);
+        const out = `Failed to resume coding task ${controlTaskId}: ${errMsg}`;
+        if (callback) await callback({ text: out });
+        return failureResult("TASKS:control", "LIFECYCLE_FAILED", out, {
+          reason: "lifecycle_failed",
+          taskId: controlTaskId,
+        });
+      }
+    }
+  }
+
   const target = await resolveSession(
     service,
     pickString(params, content, "sessionId"),
     state,
   );
   if (!target.session) {
+    if (resumedTask && controlTaskId) {
+      const out = `Resumed coding task ${controlTaskId}. No active ACP session to instruct — the task is unpaused.`;
+      if (callback) await callback({ text: out });
+      return {
+        success: true,
+        text: out,
+        data: {
+          actionName: "TASKS:control",
+          action,
+          taskId: controlTaskId,
+          task: resumedTask,
+        },
+      };
+    }
     const msg = target.missingId
       ? `Session ${target.missingId} not found.`
       : "No active ACP session found.";
@@ -1966,6 +2015,9 @@ async function runControl(
     sessionId: target.session.id,
     action,
   };
+  if (resumedTask && controlTaskId) {
+    data = { ...data, taskId: controlTaskId };
+  }
 
   let responseText = "";
   if (action === "stop") {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1609,6 +1609,9 @@ export class OrchestratorTaskService extends Service {
     if (!doc) return null;
     await this.store.updateTask(taskId, {
       archived: false,
+      // A paused-then-archived task must not reopen frozen: paused:true would
+      // keep advanceTaskStatus inert with no archive surface left to clear it.
+      paused: false,
       status: doc.sessions.length > 0 ? "active" : "open",
       archivedAt: null,
       closedAt: null,


### PR DESCRIPTION
## Make orchestrator task resume clear the durable `paused` flag (post-#11216)

#11216 wired control **pause** to the durable `pauseTask` (stops sessions, sets `paused:true`, which freezes `advanceTaskStatus`). But the paired resume/continue branch in `runControl` only did an ACP `sendToSession` — it never called `taskService.resumeTask`, and `reopenTask` didn't clear `paused`. Pause was a **one-way door from the chat/action surface**: every unpause path left the durable `paused:true` set, so the task stayed frozen.

**Fix (symmetric with pause):** `runControl` routes `resume`/`continue` through `taskService.resumeTask` (clearing `paused`) before any ACP send, and `reopenTask` now clears `paused:false` (a pause-then-archive task otherwise reopens frozen with no archive surface left to clear it). The ACP-send fallback for sessions with no durable task is preserved.

Fail-without-fix: 5/5 with the fix; reverting the two production hunks reds 3 (resume/continue clear paused; reopen clears pause-then-archive). Full plugin unit suite 107 files / 1139 tests green.

Refs #11216 #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
