### PR TITLE
fix(cloud-api): remove duplicated decls in group-i e2e (develop typecheck red→green)

### DIFF
--- a/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
+++ b/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
@@ -158,26 +158,6 @@ async function getApp(id: string): Promise<AppDto | undefined> {
   return ((await res.json()) as GetAppResponse).app;
 }
 
-const createdCharacterIds: string[] = [];
-
-/**
- * Creates a real character owned by the test user. linked_character_ids on
- * PUT /api/v1/apps/:id enforces the character ownership guard (#10863), so
- * link targets must exist and be owned/public — made-up UUIDs 404.
- */
-async function createTestCharacter(): Promise<string> {
-  const res = await api.post(
-    "/api/my-agents/characters",
-    { name: uniqueName("Linked Character"), bio: ["app-link e2e fixture"] },
-    { headers: bearerHeaders() },
-  );
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { id?: string };
-  expect(body.id).toBeTruthy();
-  createdCharacterIds.push(body.id as string);
-  return body.id as string;
-}
-
 afterAll(async () => {
   if (!serverReachable || !hasTestApiKey) return;
   for (const appId of createdAppIds) {


### PR DESCRIPTION
`[cloud-money]` — caught by local verification of develop-tip.

`bun run --cwd packages/cloud/api typecheck` is **RED on develop tip** (4 errors), all from a merge that duplicated a block in `test/e2e/group-i-apps-lifecycle.test.ts`:
- TS2393 Duplicate function implementation (`createTestCharacter`) ×2
- TS2451 Cannot redeclare block-scoped variable (`createdCharacterIds`) ×2

Fix: removed the second (duplicate) copy of `const createdCharacterIds` + `async function createTestCharacter`. The first copy is intact and its 3 call-sites still resolve.

**Verified locally:** `bun run --cwd packages/cloud/api typecheck` → **exit 0** (was exit 1 / 4 errors). Single-file, test-only change; the Worker source was already clean.

(Ships the cloud-api typecheck back to green so it stops being noise on every cloud PR + the eventual promote.)