### PR TITLE
test(cloud): route-level regression guard for the #11218 non-streaming settle refund (double-refund on partial reconcile)

### DIFF
--- a/packages/cloud/api/__tests__/apps-chat-nonstreaming-settle-guard.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-nonstreaming-settle-guard.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Route-level double-credit guard for POST /api/v1/apps/:id/chat
+ * non-streaming settle (#11218 hardening).
+ *
+ * The route flips `nonStreamingSettleStarted` IMMEDIATELY BEFORE invoking
+ * `appCreditsService.reconcileCredits` — not after it returns. That ordering is
+ * the whole fix: `reconcileCredits` is not transactional; its refund branch
+ * commits `creditsService.refundCredits` (app-credits.ts) and can then throw
+ * from `reverseCreatorEarnings` / the apps-aggregate update. With the flag set
+ * only after return, that throw reaches the settle catch as "never settled" and
+ * the guard refunds the FULL hold a second time — double-credit.
+ *
+ * The helper tests (apps-chat-stream-refund.test.ts) drive
+ * `reconcileNonStreamingSettleError` with a pre-computed boolean, so they stay
+ * green even if the route's flag ordering regresses. This suite drives the REAL
+ * route with a credits seam that models the real non-transactional internals
+ * (refund committed, then throw), asserting the refund COUNT end to end.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const APP_ID = "00000000-0000-4000-8000-0000000000ee";
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: mock(async () => ({
+    user: { id: USER, organization_id: ORG },
+    apiKey: undefined,
+  })),
+}));
+
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: mock(async () => false),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getById: mock(async () => ({
+      id: APP_ID,
+      name: "guard-test-app",
+      organization_id: ORG,
+      monetization_enabled: true,
+      platform_offset_amount: 0,
+      purchase_share_percentage: 0,
+      inference_markup_percentage: 20,
+    })),
+  },
+}));
+
+// Estimate call returns 0.01 (reserved = 0.015 after the 1.5x buffer); the
+// settle call returns 0.001 so the settle reconcile takes the REFUND branch
+// (actual < reserved), matching the dominant production case the 1.5x safety
+// multiplier produces. A test can swap `settleCostImpl` to make the
+// settle-side cost calc throw.
+let calculateCostCalls = 0;
+let settleCostImpl: () => Promise<{ totalCost: number }> = async () => ({
+  totalCost: 0.001,
+});
+mock.module("@/lib/pricing", () => ({
+  calculateCost: mock(async () => {
+    calculateCostCalls += 1;
+    if (calculateCostCalls === 1) return { totalCost: 0.01 };
+    return settleCostImpl();
+  }),
+  estimateTokens: (text: string) => Math.max(1, Math.ceil(text.length / 4)),
+  getProviderFromModel: () => "openai",
+  normalizeModelName: (model: string) => model,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  canonicalizeCerebrasModelId: (model: string) => model,
+  getAiProviderConfigurationError: () => "AI services are not configured",
+  hasLanguageModelProviderConfigured: () => true,
+  resolveAiProviderSource: () => "openai",
+}));
+
+let providerResponseImpl: () => Response = () =>
+  new Response("{}", { headers: { "content-type": "application/json" } });
+mock.module("@/lib/providers", () => ({
+  getProviderForModelWithFallback: () => ({
+    primary: { chatCompletions: async () => providerResponseImpl() },
+    fallback: null,
+  }),
+  withProviderFallback: async (primary: () => Promise<Response>) => primary(),
+}));
+
+// Credits seam modeling the REAL app-credits reconcileCredits internals: the
+// refund branch commits the org-balance movement (creditsService.refundCredits)
+// FIRST, then reverseCreatorEarnings / the apps-aggregate update can throw.
+// `refundCommits` counts committed org-balance refunds — the double-credit
+// assertion target. The guard's own refund call (tagged refundReason
+// non_streaming_settle_error) never throws, exactly like a plain full refund.
+const refundCommits: Array<{ amount: number; description: string }> = [];
+const reconcileCalls: Array<{
+  estimatedBaseCost: number;
+  actualBaseCost: number;
+  metadata?: Record<string, unknown>;
+}> = [];
+let settleReverseEarningsThrows = false;
+
+const reconcileCredits = mock(
+  async (args: {
+    estimatedBaseCost: number;
+    actualBaseCost: number;
+    description: string;
+    metadata?: Record<string, unknown>;
+  }) => {
+    reconcileCalls.push({
+      estimatedBaseCost: args.estimatedBaseCost,
+      actualBaseCost: args.actualBaseCost,
+      metadata: args.metadata,
+    });
+    const isGuardRefund =
+      args.metadata?.refundReason === "non_streaming_settle_error";
+    if (args.actualBaseCost < args.estimatedBaseCost) {
+      // app-credits.ts refund branch: this movement COMMITS before the
+      // earnings/counter writes below can throw.
+      refundCommits.push({
+        amount: args.estimatedBaseCost - args.actualBaseCost,
+        description: args.description,
+      });
+    }
+    if (!isGuardRefund && settleReverseEarningsThrows) {
+      throw new Error("reverseCreatorEarnings failed: deadlock detected");
+    }
+    return {
+      reconciled: true,
+      difference: args.actualBaseCost - args.estimatedBaseCost,
+      action: "refund",
+      adjustedAmount: args.estimatedBaseCost - args.actualBaseCost,
+      newBalance: 99,
+    };
+  },
+);
+
+mock.module("@/lib/services/app-credits", () => ({
+  appCreditsService: {
+    deductCredits: mock(async (args: { baseCost: number }) => ({
+      success: true,
+      baseCost: args.baseCost,
+      creatorMarkup: 0,
+      totalCost: args.baseCost,
+      creatorEarnings: 0,
+      newBalance: 99,
+    })),
+    reconcileCredits,
+  },
+}));
+
+const { default: chatRoute } = await import("../v1/apps/[id]/chat/route");
+
+const app = new Hono();
+app.route("/api/v1/apps/:id/chat", chatRoute);
+
+async function postChat(): Promise<Response> {
+  return await app.request(`/api/v1/apps/${APP_ID}/chat`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "openai/gpt-oss-120b",
+      messages: [{ role: "user", content: "hello" }],
+      stream: false,
+    }),
+  });
+}
+
+function okProviderBody(): Response {
+  return new Response(
+    JSON.stringify({
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      choices: [{ message: { content: "hi there" } }],
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  refundCommits.length = 0;
+  reconcileCalls.length = 0;
+  reconcileCredits.mockClear();
+  calculateCostCalls = 0;
+  settleCostImpl = async () => ({ totalCost: 0.001 });
+  settleReverseEarningsThrows = false;
+  providerResponseImpl = okProviderBody;
+});
+
+describe("non-streaming settle double-credit guard (#11218)", () => {
+  test("settle reconcile throws AFTER its refund committed → NO second refund (no double-credit)", async () => {
+    settleReverseEarningsThrows = true;
+
+    const response = await postChat();
+
+    // The settle reconcile ran once, its internal refund committed once, and
+    // the guard did NOT issue a second full-hold refund on top of it.
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(refundCommits).toHaveLength(1);
+    expect(
+      reconcileCalls.some(
+        (c) => c.metadata?.refundReason === "non_streaming_settle_error",
+      ),
+    ).toBe(false);
+
+    // The original settle error surfaces unmasked.
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { message: string } };
+    expect(body.error.message).toBe(
+      "reverseCreatorEarnings failed: deadlock detected",
+    );
+  });
+
+  test("malformed provider body (throw BEFORE the reconcile) → auto-refund exactly once", async () => {
+    providerResponseImpl = () => new Response("definitely not json");
+
+    const response = await postChat();
+
+    // Guard refunds the full hold exactly once, tagged for the ledger.
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(refundCommits).toHaveLength(1);
+    expect(reconcileCalls[0].actualBaseCost).toBe(0);
+    expect(reconcileCalls[0].metadata).toMatchObject({
+      streaming: false,
+      refundReason: "non_streaming_settle_error",
+    });
+    expect(response.status).toBe(500);
+  });
+
+  test("calculateCost throws (throw BEFORE the reconcile) → auto-refund exactly once", async () => {
+    settleCostImpl = async () => {
+      throw new Error("pricing catalog unavailable");
+    };
+
+    const response = await postChat();
+
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(refundCommits).toHaveLength(1);
+    expect(reconcileCalls[0].actualBaseCost).toBe(0);
+    expect(reconcileCalls[0].metadata).toMatchObject({
+      refundReason: "non_streaming_settle_error",
+    });
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { message: string } };
+    expect(body.error.message).toBe("pricing catalog unavailable");
+  });
+
+  test("settle succeeds → 200 with the provider body and exactly one reconcile", async () => {
+    const response = await postChat();
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    expect(body.choices[0].message.content).toBe("hi there");
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(
+      reconcileCalls.some(
+        (c) => c.metadata?.refundReason === "non_streaming_settle_error",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Route-level regression guard for the #11218 non-streaming settle refund

#11218 hardened the non-streaming apps-chat settle so the upfront hold is refunded when the settle throws, and (second commit) flipped the guard to settle-**started** semantics: `nonStreamingSettleStarted` is set immediately **before** `await reconcileCredits(...)`, and the refund path refuses to auto-refund once reconcile was invoked (reconcile is non-transactional — it commits `refundCredits` then can throw in `reverseCreatorEarnings`/aggregate updates; a naive `settled`-after flag would double-refund on that throw).

The shipped helper tests pass a pre-computed boolean, so moving the flag back after the await would regress **silently** while every test stayed green. This adds `apps-chat-nonstreaming-settle-guard.test.ts` — drives the **real** Hono route with a credits seam modeling the non-transactional reconcile internals (refundCredits commits, then reverseCreatorEarnings throws) and asserts exactly ONE committed refund on the post-reconcile throw, plus a single auto-refund on the pre-reconcile (json/pricing) throw.

Fail-without-fix (verified against the real route): moving the flag assignment after the `reconcileCredits` await → the post-reconcile-throw test reds with 2 refund commits (the double-credit); shipped ordering → 4/4 green. Test-only; no production change. Refs #11218 #10837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
