### PR TITLE
fix(orchestrator): stop agent-caching the framework-state examples provider (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/action-examples-cache.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/action-examples-cache.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { codingAgentExamplesProvider } from "../../src/providers/action-examples.js";
+
+// #11028 audit: the provider embeds live framework state (recommendedDefault,
+// configuredSubscriptionProvider) but was marked agent-stable, so a stale
+// recommendation pinned for the whole session. It must recompute per turn.
+describe("codingAgentExamplesProvider cache config", () => {
+  it("is not agent-cached because its body carries live framework state", () => {
+    expect(codingAgentExamplesProvider.cacheStable).toBe(false);
+    expect(codingAgentExamplesProvider.cacheScope).toBe("turn");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
@@ -29,8 +29,14 @@ export const codingAgentExamplesProvider: Provider = {
   position: -1,
   contexts: ["code", "agent_internal"],
   contextGate: { anyOf: ["code", "agent_internal"] },
-  cacheStable: true,
-  cacheScope: "agent",
+  // Not agent-cacheable: the body embeds live framework state
+  // (frameworkState.preferred / configuredSubscriptionProvider), which changes
+  // as auth/availability changes during the agent's lifetime. Recompute per turn
+  // like the sibling framework-state providers (active-workspace-context,
+  // coding-session-changes), so a stale recommendedDefault isn't pinned for the
+  // whole session.
+  cacheStable: false,
+  cacheScope: "turn",
 
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     try {


### PR DESCRIPTION
Audit-confirmed (3/3). `CODING_AGENT_EXAMPLES` was `cacheStable: true` / `cacheScope: "agent"`, but its body embeds live framework state — `frameworkState.preferred` (recommendedDefault + reason) and `configuredSubscriptionProvider` — which changes as coding-agent auth/availability changes during the session. Agent-caching pinned a stale recommendation (e.g. a now-unavailable framework kept as the default). Switched to `cacheStable: false` / `cacheScope: "turn"`, matching the sibling framework/session-state providers (`active-workspace-context`, `coding-session-changes`). +1 assertion test.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)