### PR TITLE
fix(benchmarks): skip gitignored residue of deleted benchmarks in adapter discovery

### DIFF
--- a/packages/benchmarks/orchestrator/adapters.py
+++ b/packages/benchmarks/orchestrator/adapters.py
@@ -743,6 +743,47 @@ def _is_benchmark_directory(path: Path) -> bool:
     return name not in IGNORED_BENCHMARK_DIRS
 
 
+def _git_visible_dir_names(benchmarks_root: Path) -> set[str] | None:
+    """Top-level names under ``benchmarks_root`` that contain at least one
+    git-tracked or untracked-but-not-ignored file, or ``None`` when git is
+    unavailable (non-repo checkouts keep the pure filesystem scan).
+
+    Benchmarks deleted from the tree (e.g. the #9475/#9506 de-larp waves:
+    claw-eval, loca-bench, qwen-claw-bench, skillsbench, swe-bench-pro, and
+    later lifeops-quality) can linger on disk in long-lived checkouts because
+    every remaining file in them is gitignored (venvs, results, media), so
+    ``git checkout`` never removes the directory. Such residue directories are
+    not part of the repo and must not be reported as benchmark directories the
+    orchestrator has to cover. Genuinely new, not-yet-committed benchmark
+    directories still show up: their files are untracked but not ignored.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(benchmarks_root),
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                "-z",
+                "--",
+                ".",
+            ],
+            capture_output=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    names: set[str] = set()
+    for entry in proc.stdout.decode("utf-8", errors="replace").split("\0"):
+        if entry:
+            names.add(entry.split("/", 1)[0])
+    return names
+
+
 def _make_registry_adapter(
     workspace_root: Path,
     benchmarks_root: Path,
@@ -2310,10 +2351,16 @@ def _score_from_personality_bench(path: Path) -> ScoreSummary:
 
 def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
     benchmarks_root = workspace_root / "benchmarks"
+    # Skip gitignored residue of benchmarks deleted from the tree — see
+    # _git_visible_dir_names. Directories whose only on-disk content is
+    # ignored (stale venvs/results/media surviving a `git checkout` after a
+    # de-larp deletion) are not benchmark directories.
+    git_visible = _git_visible_dir_names(benchmarks_root)
     benchmark_dirs = sorted(
         p.name
         for p in benchmarks_root.iterdir()
         if _is_benchmark_directory(p)
+        and (git_visible is None or p.name in git_visible)
     )
 
     score_extractor_factory = RegistryScoreExtractor(workspace_root)

--- a/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
+++ b/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
@@ -5,6 +5,7 @@ import importlib.util
 import contextlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -84,11 +85,78 @@ def test_discovery_covers_all_real_benchmark_directories() -> None:
     assert "view-bundle-size" not in discovery.all_directories
     assert "skillsbench" not in discovery.all_directories
     assert "skillsbench" not in orchestrator_adapters.IGNORED_BENCHMARK_DIRS
-    assert not (_workspace_root() / "benchmarks" / "skillsbench").exists()
+    # skillsbench was deleted from the tree (#9506), but gitignored residue can
+    # linger on disk in long-lived checkouts, so assert against the git index
+    # rather than the raw filesystem.
+    skillsbench_tracked = subprocess.run(
+        ["git", "-C", str(_workspace_root()), "ls-files", "--", "benchmarks/skillsbench"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+    assert skillsbench_tracked == ""
     assert "swe-bench-pro" not in discovery.all_directories
     assert "swe-bench-workspace" not in discovery.all_directories
     assert not any("gaia" in name.lower() for name in discovery.all_directories)
     assert not any("gaia" in adapter_id.lower() for adapter_id in discovery.adapters)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _make_workspace_with_residue(tmp_path: Path) -> Path:
+    """Git workspace whose benchmarks/ holds a tracked dir, an untracked WIP
+    dir, and a deleted-benchmark residue dir whose only content is gitignored."""
+    repo = tmp_path / "workspace"
+    benchmarks = repo / "benchmarks"
+    benchmarks.mkdir(parents=True)
+    _git("init", "-q", str(repo), cwd=tmp_path)
+    (benchmarks / ".gitignore").write_text("residue-bench/\n")
+    tracked = benchmarks / "tracked-bench"
+    tracked.mkdir()
+    (tracked / "README.md").write_text("real benchmark\n")
+    wip = benchmarks / "new-bench"
+    wip.mkdir()
+    (wip / "runner.py").write_text("print('wip benchmark')\n")
+    residue = benchmarks / "residue-bench" / "results"
+    residue.mkdir(parents=True)
+    (residue / "out.json").write_text("{}")
+    _git("add", "benchmarks/.gitignore", "benchmarks/tracked-bench", cwd=repo)
+    return repo
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="requires git")
+def test_git_visible_dir_names_filters_ignored_residue(tmp_path: Path) -> None:
+    # Regression for the #11196 review finding: benchmarks deleted from the
+    # tree (#9475/#9506 de-larp: claw-eval, loca-bench, qwen-claw-bench,
+    # skillsbench, swe-bench-pro; later lifeops-quality) linger on disk in
+    # long-lived checkouts because their remaining files are all gitignored,
+    # and were reported as phantom coverage gaps.
+    repo = _make_workspace_with_residue(tmp_path)
+
+    visible = orchestrator_adapters._git_visible_dir_names(repo / "benchmarks")
+
+    assert visible is not None
+    assert "tracked-bench" in visible  # tracked content stays visible
+    assert "new-bench" in visible  # untracked-but-not-ignored WIP stays visible
+    assert "residue-bench" not in visible  # all-gitignored residue is skipped
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="requires git")
+def test_discovery_skips_gitignored_residue_directories(tmp_path: Path) -> None:
+    repo = _make_workspace_with_residue(tmp_path)
+
+    discovery = discover_adapters(repo)
+
+    assert "tracked-bench" in discovery.all_directories
+    assert "new-bench" in discovery.all_directories
+    assert "residue-bench" not in discovery.all_directories
+
+
+def test_git_visible_dir_names_returns_none_outside_git_repo(tmp_path: Path) -> None:
+    # Non-repo checkouts (tarball exports) keep the pure filesystem scan.
+    assert orchestrator_adapters._git_visible_dir_names(tmp_path) is None
 
 
 def test_discovery_includes_directory_name_mismatches_and_special_tracks() -> None:


### PR DESCRIPTION
## Problem

`orchestrator/tests/test_adapter_discovery.py::test_discovery_covers_all_real_benchmark_directories` fails in long-lived checkouts, flagged during #11196 QA review ("claw-eval/loca-bench/skillsbench/swe-bench-pro uncovered — pre-existing dir-coverage drift"). The full uncovered set observed across dirty checkouts was `claw-eval`, `loca-bench`, `qwen-claw-bench`, `skillsbench`, `swe-bench-pro` (and `lifeops-quality` on pre-#11259 trees).

## Root cause — per directory

`discover_adapters()` enumerates raw on-disk directories under `packages/benchmarks`, filtered only by `IGNORED_BENCHMARK_DIRS`. Every "uncovered" directory is a benchmark **already deleted from the tree**, whose folder survives on disk because its only remaining content is gitignored, so `git checkout` can never remove it:

| Directory | Deleted by | On-disk residue that keeps the dir alive |
|---|---|---|
| `claw-eval` | #9475 de-larp (`bc4666f2ba1`) | `claw_eval.png`, `tasks/` (ignored assets) |
| `loca-bench` | #9475 de-larp (`bc4666f2ba1`) | `assets/`, `gem/` |
| `qwen-claw-bench` | #9475 de-larp (`bc4666f2ba1`) | `imgs/` |
| `swe-bench-pro` | #9475 de-larp (`bc4666f2ba1`) | `error_analysis/`, `helper_code/`, `run_scripts/` |
| `skillsbench` | #9506 (`a25ab89c140`) | `docs/`, `tasks/` |
| `lifeops-quality` | #11259/#11271 (`5b714c74e60`) | `results/`, `baseline.json`, … |

None of them needs an adapter — they are not in the repo. Three separate deletion waves produced this drift, so adding the names to `IGNORED_BENCHMARK_DIRS` would be whack-a-mole (and would "exclude" directories that don't exist in the tree). The enumeration itself was wrong: it cannot tell repo content from deleted-benchmark residue.

## Fix

- `discover_adapters()` consults git once (`git ls-files --cached --others --exclude-standard`) and skips top-level dirs containing **no tracked and no untracked-but-not-ignored** files. Tracked benchmarks and uncommitted WIP benchmark dirs remain visible; non-repo checkouts (tarball exports) fall back to the previous pure filesystem scan. This also cleans `all_directories` for the CLI coverage report and `inventory.py`.
- The coverage test's `skillsbench` assertion now checks the git index instead of raw `.exists()` (same residue blind spot). The coverage assertion itself is untouched — it still gates real drift.
- New regression tests: residue filter unit test, integrated `discover_adapters` test on a synthetic git workspace, and non-repo fallback.

## Evidence

**Before** (develop code, residue present — reproduces the #11196 review failure exactly):
```
FAILED orchestrator/tests/test_adapter_discovery.py::test_discovery_covers_all_real_benchmark_directories
E         'loca-bench'
E         'swe-bench-pro'
1 failed in 3.39s
```
Develop's `discover_adapters` against a real dirty checkout reported `uncovered: ['claw-eval', 'loca-bench', 'qwen-claw-bench', 'swe-bench-pro']`.

**After** (fix applied, same residue still on disk):
```
354 passed in 25.89s   # full orchestrator/tests/, residue dirs present
```
Patched `discover_adapters` against the same dirty checkout: `uncovered: []`. Clean worktree: 354 passed (351 pre-existing + 3 new). Genuinely-tracked dirs in old checkouts (e.g. `lifeops-quality` at a pre-#11259 HEAD) are correctly still reported there — the filter only drops all-gitignored residue.

Python-only change; no TS surfaces touched.

Refs #11196 (failure flagged in QA review), #9475, #9506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)