### PR TITLE
test(android): pin the literal arm64 default floor so the #11201 SIGILL fix is guarded (de-tautologize)

### DIFF
--- a/packages/app-core/scripts/build-helpers/arm64-simd.test.mjs
+++ b/packages/app-core/scripts/build-helpers/arm64-simd.test.mjs
@@ -19,6 +19,16 @@ afterEach(() => {
 test("uses the Pixel-safe arm64 floor by default", () => {
   delete process.env.ELIZA_ANDROID_ARM64_I8MM;
 
+  // Literal guard (#11201): the DEFAULT floor must never bake i8mm — smmla
+  // SIGILLs on every pre-armv8.6 core (Tensor G1/G2 = Pixel 6/6a/7). Asserting
+  // the function output against ANDROID_ARM64_CPU_ARCH alone is tautological
+  // (re-adding "+i8mm" shifts both sides together), so pin the literal too.
+  assert.ok(
+    !ANDROID_ARM64_CPU_ARCH.includes("i8mm"),
+    `default arm64 floor must not include i8mm; got ${ANDROID_ARM64_CPU_ARCH}`,
+  );
+  assert.equal(ANDROID_ARM64_CPU_ARCH, "armv8.2-a+dotprod+fp16");
+
   assert.deepEqual(androidArm64SimdCmakeFlags("arm64-v8a"), [
     `-DGGML_CPU_ARM_ARCH=${ANDROID_ARM64_CPU_ARCH}`,
     "-DGGML_USE_DOTPROD=ON",


### PR DESCRIPTION
The #11201 regression test asserted `androidArm64SimdCmakeFlags()` against the `ANDROID_ARM64_CPU_ARCH` constant itself — tautological: re-adding `+i8mm` (reintroducing the `smmla` SIGILL on every pre-armv8.6 core: Tensor G1/G2 = Pixel 6/6a/7) shifts both sides together, so all 3 tests stayed green (confirmed by experiment). Pin the literal instead: the default floor must not include `i8mm` and must equal `armv8.2-a+dotprod+fp16`. Fail-without-fix: re-adding `+i8mm` to the default constant now reds the default-floor test; the env-gated `ELIZA_ANDROID_ARM64_I8MM=1` opt-in test is unaffected. Test-only. Refs #11201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)