### PR TITLE
fix(eliza-code): fix the TUI front door — input routing + crash resilience

### DIFF
--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -564,15 +564,36 @@ export class App {
    */
   private consumeGlobalInput(data: string): boolean {
     if (this.showingHelp) {
-      if (data === "?" || data === "\x1b" || data === "\x08") {
+      // Ctrl+C / Ctrl+Q must still quit even with help open (they were trapped
+      // before). Otherwise close on ?, Esc, Backspace (\x08 Ctrl+H and \x7f DEL,
+      // which is what most terminals send), or q.
+      if (data === "\x03" || data === "\x11") {
+        useStore.getState().saveSessionState();
+        this.stop();
+        return true;
+      }
+      if (
+        data === "?" ||
+        data === "\x1b" ||
+        data === "\x08" ||
+        data === "\x7f" ||
+        data === "q"
+      ) {
         this.closeHelp();
       }
       return true;
     }
 
+    // `?` opens help only when it can't be a character the user is typing:
+    // task pane focused, or the chat composer is empty. Otherwise it must reach
+    // the editor so prompts like "what does this do?" aren't corrupted.
     if (data === "?") {
-      this.openHelp();
-      return true;
+      const state = useStore.getState();
+      if (state.focusedPane !== "chat" || state.inputValue.trim() === "") {
+        this.openHelp();
+        return true;
+      }
+      return false;
     }
 
     if (data === "\x03" || data === "\x11") {
@@ -602,12 +623,16 @@ export class App {
       return false;
     }
 
-    if (data === "\x1b[1;5D" || data === ",") {
+    // Ctrl+←/→ always resizes the task pane. Bare ","/"." resize ONLY when the
+    // task pane is focused — otherwise they are literal characters the chat
+    // composer must receive (you couldn't type "Fix App.ts, please." before).
+    const paneFocused = useStore.getState().focusedPane === "tasks";
+    if (data === "\x1b[1;5D" || (data === "," && paneFocused)) {
       useStore.getState().adjustTaskPaneWidth(-0.05);
       this.tui.requestRender();
       return true;
     }
-    if (data === "\x1b[1;5C" || data === ".") {
+    if (data === "\x1b[1;5C" || (data === "." && paneFocused)) {
       useStore.getState().adjustTaskPaneWidth(0.05);
       this.tui.requestRender();
       return true;
@@ -1020,8 +1045,9 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
     state.setAgentTyping(true);
     this.tui.requestRender();
 
+    const roomId = state.currentRoomId;
+    let placeholderId: string | null = null;
     try {
-      const roomId = state.currentRoomId;
       const room = state.rooms.find((r) => r.id === roomId);
       if (!room) {
         throw new Error("Current conversation not found");
@@ -1032,6 +1058,7 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
 
       const agentClient = getAgentClient();
       const placeholder = state.addMessage(roomId, "assistant", "", undefined);
+      placeholderId = placeholder.id;
       await agentClient.sendMessage({
         room,
         text,
@@ -1060,6 +1087,18 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
           ),
         }));
       }
+    } catch (err) {
+      // A provider error (network blip, 429, revoked key) or a missing-room
+      // throw must NOT crash the app — before this, the rejection bubbled to
+      // index.ts's unhandledRejection handler → process.exit(1), which left the
+      // terminal in raw mode (raw-mode/bracketed-paste/cursor restore only runs
+      // via app.stop()). Surface it as a system message and drop the empty
+      // assistant placeholder so no blank bubble lingers.
+      const messageText = err instanceof Error ? err.message : String(err);
+      if (placeholderId) {
+        state.removeMessage(roomId, placeholderId);
+      }
+      state.addMessage(roomId, "system", `Error: ${messageText}`);
     } finally {
       state.setLoading(false);
       state.setAgentTyping(false);

--- a/packages/examples/code/src/global-input.test.ts
+++ b/packages/examples/code/src/global-input.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+//
+// Regression tests for the eliza-code TUI "front door": global-shortcut input
+// routing (#11266). App's constructor is synchronous and only needs a runtime,
+// and FilteringTerminal routes stdin through App.consumeGlobalInput before the
+// focused component sees it — so we construct a real App with a minimal runtime
+// stub and drive the real interceptor, asserting which keys it consumes.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { App } from "./App.js";
+import { useStore } from "./lib/store.js";
+
+// App's constructor builds terminal/tui/panes synchronously; nothing touches
+// stdin (FilteringTerminal is inert until start()) or the network at construct
+// time, and TaskPane just stores its props. A bare object satisfies the fields
+// the construction path reads.
+function makeApp(): {
+  consume: (data: string) => boolean;
+} {
+  const runtime = {
+    agentId: "test",
+    character: { name: "Eliza" },
+    getService: () => null,
+  } as unknown as AgentRuntime;
+  const app = new App(runtime);
+  const consume = (data: string): boolean =>
+    (
+      app as unknown as { consumeGlobalInput(d: string): boolean }
+    ).consumeGlobalInput(data);
+  return { consume };
+}
+
+describe("eliza-code global-input routing (#11266)", () => {
+  beforeEach(() => {
+    // Fresh, chat-focused, empty composer — the normal typing state.
+    useStore.setState({ focusedPane: "chat", inputValue: "", rooms: [] });
+  });
+
+  it("does NOT consume punctuation while typing in the chat composer", () => {
+    const { consume } = makeApp();
+    useStore.setState({ focusedPane: "chat", inputValue: "Fix App.ts" });
+    // These reach the editor now (previously hijacked as resize/help).
+    expect(consume(",")).toBe(false);
+    expect(consume(".")).toBe(false);
+    expect(consume("?")).toBe(false);
+  });
+
+  it("opens help on '?' only when the composer is empty (or chat unfocused)", () => {
+    const { consume } = makeApp();
+    useStore.setState({ focusedPane: "chat", inputValue: "" });
+    expect(consume("?")).toBe(true); // empty buffer → help
+  });
+
+  it("treats bare ','/'.' as pane resize only when the task pane is focused", () => {
+    const { consume } = makeApp();
+    useStore.setState({ focusedPane: "tasks", inputValue: "" });
+    expect(consume(",")).toBe(true);
+    expect(consume(".")).toBe(true);
+  });
+
+  it("always honors the Ctrl+←/→ resize sequences regardless of focus", () => {
+    const { consume } = makeApp();
+    useStore.setState({ focusedPane: "chat", inputValue: "typing" });
+    expect(consume("\x1b[1;5D")).toBe(true);
+    expect(consume("\x1b[1;5C")).toBe(true);
+  });
+});

--- a/packages/examples/code/src/index.ts
+++ b/packages/examples/code/src/index.ts
@@ -64,6 +64,32 @@ function shouldRunCodingOnly(): boolean {
 
 let isShuttingDown = false;
 
+// Module-scoped handle to the live TUI app so the fatal handlers below can
+// restore the terminal (raw mode / bracketed paste / cursor) before exiting —
+// that teardown only runs via app.stop(), so a bare process.exit(1) on an
+// unhandled error used to leave the user's shell wedged.
+let activeApp: { stop: () => void } | undefined;
+
+/** Best-effort terminal restore before a fatal exit. Never throws. */
+function restoreTerminalBestEffort(): void {
+  try {
+    activeApp?.stop();
+  } catch {
+    // Nothing we can do; still try the raw escape-sequence restore below.
+  }
+  try {
+    if (process.stdout.isTTY) {
+      // Disable bracketed paste + Kitty keyboard protocol, show the cursor.
+      process.stdout.write("\x1b[?2004l\x1b[<u\x1b[?25h");
+    }
+    if (process.stdin.isTTY && process.stdin.setRawMode) {
+      process.stdin.setRawMode(false);
+    }
+  } catch {
+    // Give up quietly — we're already on the fatal path.
+  }
+}
+
 async function cleanup(runtime: AgentRuntime): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
@@ -129,7 +155,9 @@ async function runInteractive(): Promise<void> {
 
   // Create and run the app
   app = new App(runtime);
+  activeApp = app;
   await app.run();
+  activeApp = undefined;
 
   // App exited normally (e.g., Ctrl+Q)
   await cleanup(runtime);
@@ -156,17 +184,20 @@ async function main(): Promise<void> {
 
 // Handle uncaught errors
 process.on("uncaughtException", (error) => {
+  restoreTerminalBestEffort();
   console.error("Uncaught exception:", error);
   process.exit(1);
 });
 
 process.on("unhandledRejection", (reason) => {
+  restoreTerminalBestEffort();
   console.error("Unhandled rejection:", reason);
   process.exit(1);
 });
 
 // Run the app
 main().catch((error) => {
+  restoreTerminalBestEffort();
   console.error("Fatal error:", error);
   process.exit(1);
 });

--- a/packages/examples/code/src/lib/store.remove-message.test.ts
+++ b/packages/examples/code/src/lib/store.remove-message.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+//
+// removeMessage powers the eliza-code error-recovery path (#11266): when a turn
+// throws, the empty assistant placeholder is dropped and an error system
+// message is shown instead of a lingering blank bubble.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { useStore } from "./store.js";
+
+describe("store.removeMessage (#11266)", () => {
+  beforeEach(() => {
+    useStore.setState({ rooms: [] });
+  });
+
+  it("removes only the target message, leaving the rest intact", () => {
+    const s = useStore.getState();
+    const room = s.createRoom("Main");
+    s.addMessage(room.id, "user", "hello");
+    const placeholder = s.addMessage(room.id, "assistant", "");
+    s.addMessage(room.id, "system", "kept");
+
+    useStore.getState().removeMessage(room.id, placeholder.id);
+
+    const after = useStore.getState().rooms.find((r) => r.id === room.id);
+    expect(after?.messages.map((m) => m.role)).toEqual(["user", "system"]);
+    expect(after?.messages.some((m) => m.id === placeholder.id)).toBe(false);
+  });
+
+  it("is a no-op for an unknown id", () => {
+    const s = useStore.getState();
+    const room = s.createRoom("Main");
+    s.addMessage(room.id, "user", "hello");
+    useStore.getState().removeMessage(room.id, "does-not-exist");
+    const after = useStore.getState().rooms.find((r) => r.id === room.id);
+    expect(after?.messages).toHaveLength(1);
+  });
+});

--- a/packages/examples/code/src/lib/store.ts
+++ b/packages/examples/code/src/lib/store.ts
@@ -102,6 +102,8 @@ interface ElizaCodeState {
     messageId: string,
     content: string,
   ) => void;
+  /** Remove a single message (e.g. drop an empty assistant placeholder on error). No-op if not found. */
+  removeMessage: (roomId: string, messageId: string) => void;
   clearMessages: (roomId: string) => void;
 
   // Task Actions (for UI sync - actual data managed by CodeTaskService)
@@ -275,6 +277,20 @@ export const useStore = create<ElizaCodeState>((set, get) => ({
         );
         return { ...room, messages: nextMessages };
       }),
+    }));
+    debouncedSave(get());
+  },
+
+  removeMessage: (roomId: string, messageId: string) => {
+    set((state) => ({
+      rooms: state.rooms.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              messages: room.messages.filter((m) => m.id !== messageId),
+            }
+          : room,
+      ),
     }));
     debouncedSave(get());
   },


### PR DESCRIPTION
Fixes #11290. First PR of the TUI-quality workstream (nubs-directed: make eliza-code's TUI great, opencode-competitive). Found by a Fable-5 scan of the elizaOS TUI stack. eliza-code is both the standalone coding-agent TUI **and** the binary the coding cockpit's PTY spawns, so these hit both surfaces.

Three front-door defects (all `packages/examples/code`):

| # | sev | bug | fix |
|---|---|---|---|
| 1 | high | Typing `.` `,` `?` never reaches the chat input — `consumeGlobalInput` intercepts bare `,`/`.` as pane-resize and `?` as help unconditionally, so "Fix App.ts, please?" is corrupted (live-repro'd) | bare `,`/`.` resize only when the **task pane is focused**; `?` opens help only when the composer is empty or chat unfocused; Ctrl+←/→ resize always works |
| 2 | high | Any turn error crashes the whole TUI + wedges the terminal — `handleSendMessage` `try/finally` with no `catch` → unhandled rejection → `process.exit(1)` without `app.stop()`, leaving raw mode/bracketed-paste/cursor unrestored | catch → system "Error: …" + drop the empty assistant placeholder (`store.removeMessage`); `index.ts` fatal handlers best-effort restore the terminal before exit |
| 3 | low | Help overlay traps quit (Ctrl+C/Q consumed without quitting; Backspace doesn't close) | Ctrl+C/Q quit even with help open; add `\x7f`/`q` close keys |

### Evidence
- **Mutation-checked tests**: `global-input.test.ts` constructs a real `App` (its constructor is synchronous, needs only a runtime) and drives the real `consumeGlobalInput` — punctuation reaches the editor while typing, help is empty-buffer/focus gated, resize is task-focus gated, Ctrl+←/→ always resizes (8 assertions). `store.remove-message.test.ts` covers the error-recovery primitive. **12/12 eliza-code tests pass** (incl. the existing narrow-terminal suite). Reverting the punctuation gate reds the test (verified).
- Touched files typecheck clean; the only `tsgo` errors are the pre-existing `bun:test` types in `narrow-terminal.test.ts` (present on clean develop). Biome clean.

### N/A rows
- Rendered screenshot / recording: **partial N/A** — the fixes are input-routing + crash-path; behavior is asserted deterministically in tests. A full interactive capture belongs with the broader TUI-polish pass (streaming/markdown, tracked separately). Manual repro in the issue: run `bun run start`, type "Fix App.ts, please?" (now literal), and Ctrl+C out of an open help overlay (now quits).
- Live-LLM trajectory: N/A — TUI input/robustness, no model behavior changed.

Remaining TUI punch-list (markdown/syntax rendering, real token streaming, cancel/interrupt, tool-call visibility, scrollback paging) is filed follow-up work — this PR is the "you can actually type and it won't crash your shell" foundation.