### PR TITLE
fix(orchestrator): don't clobber task metadata when re-engage races a delete (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -266,6 +266,12 @@ export interface RerunFromEventInput {
   instruction?: string;
   planRevisionId?: string;
   stopActive?: boolean;
+  /**
+   * Rerun always preserves history; destructive rerun is intentionally
+   * unsupported. `boolean` (not the literal `true`) is deliberate: JSON callers
+   * can send `false`, and the boundary rejects it with a clear
+   * RecoveryConflictError rather than silently ignoring the request.
+   */
   preserveHistory?: boolean;
   agent?: SpawnAgentForTaskOptions;
 }
@@ -1983,13 +1989,20 @@ export class OrchestratorTaskService extends Service {
     // can replay the gap. Re-read the doc so an upstream metadata write in this
     // same pass (e.g. the valid-envelope stamp) is preserved.
     const doc = await this.store.getTask(taskId);
+    if (!doc) {
+      // The task was deleted concurrently (e.g. the user cancelled during
+      // auto-verify). Bail: there is nothing to re-engage, and writing partial
+      // metadata back with `...doc?.task.metadata` spreading to `{}` would
+      // clobber the completion envelope this very re-read exists to preserve.
+      return;
+    }
     const attemptReflections = [
-      ...readAttemptReflections(doc?.task.metadata),
+      ...readAttemptReflections(doc.task.metadata),
       { attempt: attempt + 1, missing, summary },
     ].slice(-MAX_ATTEMPT_REFLECTIONS);
     await this.store.updateTask(taskId, {
       metadata: {
-        ...doc?.task.metadata,
+        ...doc.task.metadata,
         autoVerifyAttempts: attempt + 1,
         attemptReflections,
       },


### PR DESCRIPTION
Audit-confirmed correctness fix in `OrchestratorTaskService`.

## Bug (#3, high — 3/3 skeptics)
`reEngageOrEscalate` re-reads the task doc *specifically to preserve* an upstream metadata write from the same auto-verify pass (the completion envelope — see the comment). But it merged with `...doc?.task.metadata`: if the task was concurrently deleted (user cancels mid auto-verify), `doc` is null, the spread collapses to `{}`, and `updateTask` writes metadata back **without** the envelope. Guarded: if the re-read finds no task, bail (nothing to re-engage, nothing to preserve).

## Dispositions of the two sibling findings
- **`preserveHistory` "advertised but rejected"** — this is honest boundary validation, not larp: JSON callers can send `false`, and the boundary rejects destructive rerun with a clear `RecoveryConflictError` rather than silently ignoring intent. `boolean` is the correct type (tightening to `true` breaks the legitimate runtime `=== false` guard). Clarified with a doc comment; no behavior change.
- **`recordUsage` "orphaned foreign key"** — **false positive**. The store persists usage **inline in the task JSON document**; there is no usage table and no FK. Task-level usage without a live session row still totals correctly, and dropping it would lose accounting. No change.

## Evidence
```
$ bunx vitest run orchestrator-task-service → 59 passed
```

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)