### PR TITLE
fix(ci): restore cloud-cf-deploy bun latest + $HOME install cache clobbered by #11271 (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -204,7 +204,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -222,7 +227,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
@@ -507,7 +519,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -525,7 +542,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
@@ -841,7 +865,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -859,7 +888,14 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
+          # Cache on LOCAL disk ($HOME), not under $PWD — the checkout dir lives
+          # on the box's /tmp, whose contended/slow filesystem stalls bun's link
+          # phase past the 900s cap and wedges deploys (bun itself logs "Slow
+          # filesystem detected ... consider setting $BUN_INSTALL_CACHE_DIR to a
+          # local folder"). This is the real fix; the earlier canary→latest pin
+          # (#11235) did not address it — the hang recurs on a released bun too
+          # (run 28572046433). Persistent across runs so the cache stays warm.
+          install_cache="${HOME}/.bun-install-cache-deploy"
           install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }


### PR DESCRIPTION
**Regression fix.** The Cloud CF Deploy failures (run 28569263716) are all `bun install` hangs: three attempts each timing out >900s in the link phase, with `warn: Slow filesystem detected ... .bun-install-cache is a network drive` — the install cache was back on the box's contended /tmp.

Root cause: two merged fixes were silently reverted — #11235 (`bun-version: canary → latest`; canary's link phase hangs on the robot fleet) and #11268 (install cache `$PWD/.bun-install-cache` on /tmp → `${HOME}/.bun-install-cache-deploy` on local disk). PR #11271 (a cloud-refund refactor) was branched off develop *before* those landed, so its squash-merge carried the stale `cloud-cf-deploy.yml` and reverted both across all three deploy jobs. Current develop still carries the regression → deploys keep hanging.

This surgically restores the file to its correct pre-clobber state (blob 7bcb749c033): `bun-version: latest` + `${HOME}` cache in all three jobs, explanatory comments intact. The concurrency block (#11188 per-ref serialization) is deliberately untouched — it's already correct (#11108 is closed/satisfied). YAML + actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)