### PR TITLE
fix: classify openai classic quota envelope as a rotation-worthy limit

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
@@ -26,6 +26,41 @@ describe("classifyAccountFailure", () => {
     expect(classifyAccountFailure("quota exhausted")).toBe("rate-limited");
   });
 
+  it("flags OpenAI's classic quota envelope (inverted word order, no 429 literal)", () => {
+    expect(
+      classifyAccountFailure(
+        "You exceeded your current quota, please check your plan and billing details. " +
+          "For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
+      ),
+    ).toBe("rate-limited");
+    // Truncated variants: either envelope half alone still classifies.
+    expect(classifyAccountFailure("You exceeded your current quota")).toBe(
+      "rate-limited",
+    );
+    expect(
+      classifyAccountFailure("please check your plan and billing details"),
+    ).toBe("rate-limited");
+    // The machine-readable error code from the JSON envelope body.
+    expect(
+      classifyAccountFailure(
+        '{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}',
+      ),
+    ).toBe("rate-limited");
+  });
+
+  it("does NOT flag prose that merely talks about quotas / billing", () => {
+    expect(
+      classifyAccountFailure(
+        "the user asked how quotas work and whether billing resets monthly",
+      ),
+    ).toBeNull();
+    expect(
+      classifyAccountFailure(
+        "your quota looks fine; billing details are unchanged",
+      ),
+    ).toBeNull();
+  });
+
   it("flags unambiguous auth signals", () => {
     expect(classifyAccountFailure("401 Unauthorized")).toBe("needs-reauth");
     expect(classifyAccountFailure("invalid_grant")).toBe("needs-reauth");

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -281,8 +281,14 @@ export const RATE_LIMIT_COOLOFF_MS = 15 * 60_000;
 // never a bare "api key" / "login" token (those appear in ordinary build
 // output). A false positive evicts a HEALTHY account from the pool, so the bar
 // is intentionally high.
+// "exceeded your current quota" / "check your plan and billing details" /
+// `insufficient_quota` = OpenAI's CLASSIC quota envelope ("You exceeded your
+// current quota, please check your plan and billing details"), which contains
+// neither "quota exceeded" (inverted word order) nor a literal 429. Exact
+// envelope phrases / error code only — generic quota/billing prose must NOT
+// match. Keep in lockstep with plugin-cli-inference's isSubscriptionLimitError.
 const RATE_LIMIT_RE =
-  /\b429\b|rate[\s-]?limit(?:ed|ing)?|too many requests|quota (?:exceeded|exhausted)|usage limit reached/i;
+  /\b429\b|rate[\s-]?limit(?:ed|ing)?|too many requests|quota (?:exceeded|exhausted)|exceeded your current quota|check your plan and billing details|insufficient_quota|usage limit reached/i;
 const NEEDS_REAUTH_RE =
   /\b401\b|\b403\b|unauthorized|invalid_grant|authentication failed|token (?:has )?expired|expired token|invalid token|please (?:re-?authenticate|log ?in again)/i;
 

--- a/plugins/plugin-cli-inference/__tests__/account-rotation.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/account-rotation.test.ts
@@ -92,6 +92,41 @@ describe("isSubscriptionLimitError", () => {
     expect(isSubscriptionLimitError(new Error("too many requests"))).toBe(true);
   });
 
+  it("classifies OpenAI's classic quota envelope (inverted word order, no 429 literal)", () => {
+    // The real envelope: message text alone, no statusCode on the thrown error —
+    // the exact shape a codex-sdk turn surfaces. Must rotate, not tier-failover.
+    expect(
+      isSubscriptionLimitError(
+        new Error(
+          "You exceeded your current quota, please check your plan and billing details. " +
+            "For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors."
+        )
+      )
+    ).toBe(true);
+    // Truncated variants: either envelope half alone still classifies.
+    expect(isSubscriptionLimitError(new Error("You exceeded your current quota"))).toBe(true);
+    expect(isSubscriptionLimitError(new Error("please check your plan and billing details"))).toBe(
+      true
+    );
+    // The machine-readable error code from the JSON envelope body.
+    expect(
+      isSubscriptionLimitError(
+        new Error('{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}')
+      )
+    ).toBe(true);
+  });
+
+  it("does NOT classify prose that merely talks about quotas / billing", () => {
+    expect(
+      isSubscriptionLimitError(
+        new Error("the user asked how quotas work and whether billing resets monthly")
+      )
+    ).toBe(false);
+    expect(
+      isSubscriptionLimitError(new Error("your quota looks fine; billing details are unchanged"))
+    ).toBe(false);
+  });
+
   it("does NOT classify non-limit errors (would burn a healthy account)", () => {
     expect(
       isSubscriptionLimitError(new Error("[cli-inference:sdk] empty completion (subtype=success)"))
@@ -164,6 +199,25 @@ describe("withAccountRotation", () => {
     expect(c.onRotate).toHaveBeenCalledTimes(1);
     // Usage recorded against the account we rotated INTO on success.
     expect(bridge.recordUsage).toHaveBeenCalledWith("anthropic-subscription", "b", { ok: true });
+  });
+
+  it("rotates on OpenAI's classic quota envelope (the pre-fix silent tier-failover)", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error(
+          "You exceeded your current quota, please check your plan and billing details."
+        );
+      }
+      return "answer-on-account-b";
+    });
+    const c = ctx({ backend: "codex-sdk" });
+    await expect(withAccountRotation(attempt, c as never)).resolves.toBe("answer-on-account-b");
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(bridge.select).toHaveBeenCalledTimes(1);
+    expect(c.onRotate).toHaveBeenCalledTimes(1);
   });
 
   it("does NOT rotate on a non-limit error — rethrows immediately to failover", async () => {

--- a/plugins/plugin-cli-inference/src/account-rotation.ts
+++ b/plugins/plugin-cli-inference/src/account-rotation.ts
@@ -139,6 +139,15 @@ export function isSubscriptionLimitError(err: unknown): boolean {
     /rate[\s-]?limit(?:ed|ing)?/.test(t) ||
     t.includes("usage limit reached") ||
     /quota (?:exceeded|exhausted)/.test(t) ||
+    // OpenAI's CLASSIC quota envelope inverts the word order ("You exceeded
+    // your current quota, please check your plan and billing details") and
+    // carries the machine code `insufficient_quota` — none of which contain
+    // "quota exceeded" or a literal 429. Anchor on the provider's exact
+    // envelope phrases / error code, NOT generic quota/billing prose, so a
+    // model merely talking about quotas still does not rotate.
+    t.includes("exceeded your current quota") ||
+    t.includes("check your plan and billing details") ||
+    t.includes("insufficient_quota") ||
     t.includes("too many requests")
   );
 }


### PR DESCRIPTION
## Problem

Adversarial review of the merged Gap A chat-brain account rotation (#11228, issue #11180) found a hole in the limit classifier: OpenAI's classic quota envelope

> You exceeded your current quota, please check your plan and billing details.

contains neither `quota (exceeded|exhausted)` in the matched word order nor a literal `429`, so `isSubscriptionLimitError` returned false. The pooled openai-api / codex account then fell straight to tier-failover instead of rotating to the next healthy account, and the limited account was never `markRateLimited` — the pool kept handing it out.

The coding-side classifier (`RATE_LIMIT_RE` in `plugin-agent-orchestrator/src/services/coding-account-selection.ts`) had the same gap, so a spawned codex sub-agent hitting the classic envelope also missed pool eviction.

## Fix

Both classifiers now also anchor on the exact envelope phrases and the machine-readable error code:

- `exceeded your current quota`
- `check your plan and billing details`
- `insufficient_quota` (the JSON envelope's `type`/`code`)

Deliberately envelope-specific — generic prose about quotas/billing ("your quota looks fine; billing details are unchanged") still does NOT classify, so a model merely *talking* about quotas can't burn a healthy account out of the pool.

The two classifiers are intentionally parallel (plugin-cli-inference depends only on `@elizaos/core`; the existing comments already say "matches the orchestrator's classifier"). Both are updated in lockstep and cross-referenced. Consolidating them into one shared function would require a new shared package/export — noted as a follow-up, out of scope for this hardening pass.

## Tests

- `plugin-cli-inference/__tests__/account-rotation.test.ts`
  - classic envelope (full string, message-only, no statusCode — the exact codex-sdk throw shape) classifies → true
  - truncated halves + `insufficient_quota` JSON body classify → true
  - benign quota/billing prose does NOT classify → false
  - flow test: `withAccountRotation` on `codex-sdk` rotates to the next pooled account on the classic envelope (the pre-fix silent tier-failover) — select called once, warm session evicted, retry succeeds
- `plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts`
  - classic envelope + truncated halves + `insufficient_quota` → `"rate-limited"`
  - benign quota/billing prose → `null`

## Verification

```
bun run --cwd plugins/plugin-cli-inference test        # 6 files, 87 tests passed
bun run --cwd plugins/plugin-cli-inference typecheck   # clean
bun run --cwd plugins/plugin-agent-orchestrator test:unit  # 105 files, 1129 tests passed
bun run --cwd plugins/plugin-agent-orchestrator typecheck  # clean
```

Evidence: classifier is pure string classification driven by the provider's fixed error envelope; unit tests assert on the real envelope text verbatim. No UI, no live-model behavior change beyond routing an already-thrown error to rotation instead of failover — trajectories/screenshots N/A (pure error-classification hardening; the rotation flow itself was live-proven in #11228).

Follow-up (rule 2, one-function-per-purpose): the limit classifier now exists in two deliberately-parallel copies (chat + coding). If a third consumer appears, lift it into a shared export.
