### PR TITLE
fix(orchestrator): close TOCTOU in the native ACP busy-guard (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1815,4 +1815,32 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     );
     expect(active).toHaveLength(2);
   });
+
+  it("rejects a concurrent prompt for the same native session (TOCTOU #11028)", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: undefined }));
+    await service.start();
+    const spawned = await service.spawnSession({
+      name: "busy-guard",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    // Hold the first prompt in-flight so the session stays claimed while the
+    // second call races it.
+    let release: (() => void) | undefined;
+    firstNativeClient().prompt = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ stopReason: "end_turn" });
+        }),
+    );
+    const p1 = service.sendPrompt(spawned.sessionId, "first");
+    await new Promise((r) => setTimeout(r, 10));
+    // Before the fix, the busy marker was only set deep inside sendNativePrompt,
+    // so this concurrent prompt slipped through and ran on the same session.
+    await expect(
+      service.sendPrompt(spawned.sessionId, "second"),
+    ).rejects.toThrow(/busy/i);
+    release?.();
+    await p1;
+  });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1834,7 +1834,10 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
         }),
     );
     const p1 = service.sendPrompt(spawned.sessionId, "first");
-    await new Promise((r) => setTimeout(r, 10));
+    // NO tick between the two sendPrompt calls: the race the fix closes is a
+    // same-tick check-then-claim, and inserting even a 10ms sleep here made the
+    // test pass on the PRE-fix code (the first prompt's claim landed during the
+    // sleep). Issuing both in the same microtask is what reproduces the TOCTOU.
     // Before the fix, the busy marker was only set deep inside sendNativePrompt,
     // so this concurrent prompt slipped through and ran on the same session.
     await expect(

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -795,8 +795,20 @@ export class AcpService extends Service {
       if (this.nativePromptSessionIds.has(sessionId)) {
         throw new Error(`ACP session is already busy: ${sessionId}`);
       }
-      await this.store.updateStatus(sessionId, "busy");
-      return this.sendNativePrompt(session, text, opts, startedAt);
+      // Claim the session SYNCHRONOUSLY, before the first await. Previously the
+      // busy marker was only added deep inside sendNativePrompt (after
+      // `updateStatus` + client setup await), so two concurrent sendPrompt calls
+      // could both pass the has() check before either added, driving two prompts
+      // onto the same native session. Cleanup on the pre-prompt error paths;
+      // sendNativePrompt's own finally clears it on the normal path.
+      this.nativePromptSessionIds.add(sessionId);
+      try {
+        await this.store.updateStatus(sessionId, "busy");
+        return await this.sendNativePrompt(session, text, opts, startedAt);
+      } catch (err) {
+        this.nativePromptSessionIds.delete(sessionId);
+        throw err;
+      }
     }
     await this.store.updateStatus(sessionId, "busy");
     const args = this.baseArgs({


### PR DESCRIPTION
Audit-confirmed (3/3, high). `sendPrompt`'s native path checked `nativePromptSessionIds.has(sessionId)` and threw "already busy", but the marker was only **added** deep inside `sendNativePrompt` — after `await updateStatus(…,"busy")` + client setup. Between the check and that add the event loop yields, so two concurrent `sendPrompt` calls for the same session both passed the guard and drove two prompts onto one native session (interleaved output, doubled cost, cancel/stop confusion).

**Fix:** claim the session **synchronously** right after the `has()` check, before the first await, and delete it on the pre-prompt error paths (also fixing a pre-existing leak when `updateStatus`/setup throws before `sendNativePrompt`'s own `finally` runs). `sendNativePrompt`'s add stays idempotent; its `finally` still clears the normal path.

```
$ bunx vitest run acp-service.test → 44 passed
```
+1 case: a concurrent prompt for the same in-flight native session now rejects.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)