### PR TITLE
fix(ci): bun install timeout 900s->2400s — stopgap for the slow deploy box (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -315,7 +315,7 @@ jobs:
           # (#11235) did not address it — the hang recurs on a released bun too
           # (run 28572046433). Persistent across runs so the cache stays warm.
           install_cache="${HOME}/.bun-install-cache-deploy"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
@@ -639,7 +639,7 @@ jobs:
           # (#11235) did not address it — the hang recurs on a released bun too
           # (run 28572046433). Persistent across runs so the cache stays warm.
           install_cache="${HOME}/.bun-install-cache-deploy"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
@@ -990,7 +990,7 @@ jobs:
           # (#11235) did not address it — the hang recurs on a released bun too
           # (run 28572046433). Persistent across runs so the cache stays warm.
           install_cache="${HOME}/.bun-install-cache-deploy"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"


### PR DESCRIPTION
Stopgap. 3 money-wave deploys hung at the 900s install cap even after the bun-pin (#11235) and cache-to-$HOME (#11268) fixes → the box is slow/degraded. 2400s lets a slow-but-completing install finish in one attempt; if it still fails, it's a true hang needing on-box attention (escalated to @Stan on #10839). CI-only, no prod/runtime change. `[cloud-audit]`