### PR TITLE
fix(openrouter): surface live stream provider errors

### DIFF
--- a/.github/issue-evidence/11266-openrouter-stream-errors.md
+++ b/.github/issue-evidence/11266-openrouter-stream-errors.md
@@ -1,0 +1,82 @@
+# Issue #11266 - OpenRouter live stream error propagation
+
+Date: 2026-07-02
+Branch: `fix/11266-openrouter-stream-errors`
+Base: `origin/develop` at `3a2ea84f818d`
+
+## What Changed
+
+- Added `onError` capture to the OpenRouter live `streamText` path.
+- After the primary `textStream` drains, the generator now awaits the terminal
+  `finishReason` and rethrows any provider error captured by `onError` or
+  `finishReason`.
+- This prevents an OpenRouter provider failure from resolving as a successful
+  empty stream and lets upstream retry/failover logic see the thrown error.
+
+## Regression
+
+Added a unit regression in `plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts`:
+
+- mock `streamText` invokes the supplied `onError` with `Error("provider stream failed")`;
+- mock `textStream` yields no chunks, matching the AI SDK failure shape;
+- consuming the returned primary `textStream` rejects with `provider stream failed`;
+- the test also asserts OpenRouter passed an `onError` callback into `streamText`.
+
+## Verification
+
+Commands run from `/private/tmp/eliza-11266-openrouter-stream` after rebasing onto
+current `origin/develop`:
+
+```bash
+bun run --cwd plugins/plugin-openrouter test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000
+```
+
+Result: pass. `1 passed (1)`, `10 passed (10)`.
+
+```bash
+bun run --cwd plugins/plugin-openrouter test
+```
+
+Result: pass. `5 passed (5)`, `29 passed (29)`.
+
+```bash
+bun run --cwd plugins/plugin-openrouter typecheck
+```
+
+Result: pass.
+
+```bash
+bunx @biomejs/biome@2.5.2 check \
+  plugins/plugin-openrouter/models/text.ts \
+  plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+```
+
+Result: pass. `Checked 2 files`.
+
+```bash
+bun run --cwd plugins/plugin-openrouter build
+```
+
+Result: pass. Node ESM, browser ESM, and CJS builds completed.
+
+## Repo-Level Verify
+
+```bash
+bun run verify
+```
+
+Result: failed before typecheck/lint at `audit:type-safety-ratchet` on current
+`origin/develop`, unrelated to this OpenRouter change:
+
+- `as unknown as`: `80 current > 77 baseline`
+- ``?? {}``: `379 current > 377 baseline`
+
+The changed OpenRouter production source adds neither pattern.
+
+## Evidence Applicability
+
+- Live LLM trajectory: N/A for this patch. The failure mode is deterministic at
+  the AI SDK contract seam: `streamText` reports the provider failure through
+  `onError` and yields an empty text stream. The unit regression directly drives
+  that seam.
+- Screenshots/video/audio: N/A; no UI, native, audio, or visual surface changed.

--- a/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
@@ -290,6 +290,48 @@ describe("OpenRouter native text plumbing", () => {
     expect(generateText).not.toHaveBeenCalled();
   });
 
+  it("rejects provider errors delivered through streaming onError instead of resolving empty", async () => {
+    const providerError = new Error("provider stream failed");
+    const streamText = vi.fn((options: { onError?: (event: { error: unknown }) => void }) => {
+      options.onError?.({ error: providerError });
+      return {
+        textStream: (async function* textStream() {
+          // The AI SDK yields no text chunks for this failure mode.
+        })(),
+        text: Promise.resolve(""),
+        toolCalls: Promise.resolve([]),
+        finishReason: Promise.resolve("error"),
+        usage: Promise.resolve(undefined),
+      };
+    });
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(),
+      streamText,
+    }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({
+        chat: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "stream fails before first token",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(
+      (async () => {
+        for await (const _chunk of stream.textStream) {
+          // consume primary stream path
+        }
+      })()
+    ).rejects.toThrow("provider stream failed");
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
   it("turns attachment-only requests into a user message", async () => {
     const generateText = vi.fn(async () => ({
       text: "ok",

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -497,7 +497,13 @@ function handleStreamingGeneration(
   modelLabel: string,
   shouldReturnNativeResult: boolean
 ): TextStreamResult {
-  const streamResult = streamText(generateParams);
+  let capturedStreamError: unknown;
+  const streamResult = streamText({
+    ...(generateParams as Parameters<typeof streamText>[0]),
+    onError: ({ error }: { error: unknown }) => {
+      capturedStreamError = error;
+    },
+  });
   const usagePromise = Promise.resolve(streamResult.usage).then((usage) => {
     if (!usage) {
       return undefined;
@@ -514,6 +520,14 @@ function handleStreamingGeneration(
         yield chunk;
       }
       completed = true;
+      await Promise.resolve(streamResult.finishReason).catch((error) => {
+        capturedStreamError ??= error;
+      });
+      if (capturedStreamError) {
+        throw capturedStreamError instanceof Error
+          ? capturedStreamError
+          : new Error(`[OpenRouter] streaming provider error: ${String(capturedStreamError)}`);
+      }
     } finally {
       if (completed) {
         await usagePromise.catch(ignoreUsageError);


### PR DESCRIPTION
Closes #11266.

## Summary

- Adds `onError` capture to the OpenRouter live `streamText` path.
- After the primary `textStream` drains, awaits `finishReason` and rethrows any provider error captured by `onError` or `finishReason`.
- Prevents provider failures from resolving as successful empty streams, so upstream retry/failover sees the thrown error.
- Adds a regression that drives the AI SDK failure shape: `onError` fires, `textStream` yields no chunks, and consuming the primary stream rejects.

## Evidence

Evidence artifact: `.github/issue-evidence/11266-openrouter-stream-errors.md`

Ran after rebasing onto `origin/develop` at `3a2ea84f818d`:

```text
bun run --cwd plugins/plugin-openrouter test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000
Test Files  1 passed (1)
Tests       10 passed (10)

bun run --cwd plugins/plugin-openrouter test
Test Files  5 passed (5)
Tests       29 passed (29)

bun run --cwd plugins/plugin-openrouter typecheck
tsgo --noEmit -p tsconfig.json
exit 0

bunx @biomejs/biome@2.5.2 check plugins/plugin-openrouter/models/text.ts plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
Checked 2 files. No fixes applied.

bun run --cwd plugins/plugin-openrouter build
Node ESM, Browser ESM, and CJS builds completed
```

Repo-level verify:

```text
bun run verify
```

This still fails before typecheck/lint at the current `audit:type-safety-ratchet` baseline:

```text
as unknown as: 80 current > 77 baseline
?? {}: 379 current > 377 baseline
```

The changed OpenRouter production source adds neither pattern.

## Evidence matrix

Live LLM trajectory: N/A - this patch fixes deterministic error propagation at the AI SDK stream contract seam. The regression directly drives `streamText` reporting a provider failure through `onError` while yielding an empty text stream.

Backend logs: N/A - no server process changed; model-handler error propagation is covered by the regression.

Frontend logs/screenshots/video: N/A - no UI changed.

Native/device capture: N/A - no iOS/Android/native bridge changed.
