### PR TITLE
feat(eliza-code): render assistant replies as markdown, not flat text

### DIFF
--- a/packages/examples/code/src/components/ChatPane.ts
+++ b/packages/examples/code/src/components/ChatPane.ts
@@ -2,12 +2,21 @@ import {
   type AutocompleteProvider,
   Editor,
   type Focusable,
+  Markdown,
   type TUI,
 } from "@elizaos/tui";
 import chalk from "chalk";
 import { createEditorTheme } from "../lib/editor-theme.js";
+import { createChatMarkdownTheme } from "../lib/markdown-theme.js";
 import { useStore } from "../lib/store.js";
 import type { Message } from "../types.js";
+
+// Rendering markdown below ~40 cols is cramped (code fences + gutters eat the
+// line); fall back to the plain wrapper there. This also keeps the #11043
+// narrow-terminal guarantee simple on the cockpit's ~43-col phone xterm.
+const MARKDOWN_MIN_WIDTH = 40;
+// One shared theme instance (chalk style fns; cheap, but no need to rebuild).
+const chatMarkdownTheme = createChatMarkdownTheme();
 
 interface ChatPaneProps {
   onSubmit: (text: string) => Promise<void>;
@@ -21,6 +30,9 @@ interface RenderLine {
   dim?: boolean;
   italic?: boolean;
   bold?: boolean;
+  /** `text` is already ANSI-styled (e.g. Markdown output) — render verbatim,
+   *  do not re-apply chalk. */
+  raw?: boolean;
 }
 
 function formatTime(timestamp: Date | number | string | undefined): string {
@@ -116,9 +128,24 @@ function toRenderLines(messages: Message[], maxWidth: number): RenderLine[] {
 
     const indent = "  ";
     const contentWidth = Math.max(1, maxWidth - indent.length);
-    const wrapped = wrapText(msg.content, contentWidth);
-    for (const line of wrapped) {
-      lines.push({ text: indent + line });
+    if (contentWidth >= MARKDOWN_MIN_WIDTH) {
+      // Render the body as markdown (headings, lists, fenced code, inline
+      // styles) into pre-styled lines. Markdown wraps to contentWidth, so
+      // `indent + line` never exceeds maxWidth; MainScreen's truncateToWidth is
+      // the final overflow backstop.
+      const md = new Markdown(msg.content, 0, 0, chatMarkdownTheme).render(
+        contentWidth,
+      );
+      const body = md.length > 0 ? md : [""];
+      for (const line of body) {
+        lines.push({ text: indent + line, raw: true });
+      }
+    } else {
+      // Narrow terminal (e.g. the ~43-col cockpit xterm): plain wrap.
+      const wrapped = wrapText(msg.content, contentWidth);
+      for (const line of wrapped) {
+        lines.push({ text: indent + line });
+      }
     }
   }
 
@@ -257,6 +284,11 @@ export class ChatPane implements Focusable {
       }
     } else {
       for (const line of visibleLines) {
+        if (line.raw) {
+          // Already ANSI-styled (Markdown output) — don't re-chalk.
+          output.push(" ".repeat(paddingX) + line.text);
+          continue;
+        }
         let styled = line.text;
         if (line.bold) styled = chalk.bold(styled);
         if (line.italic) styled = chalk.italic(styled);

--- a/packages/examples/code/src/components/chat-markdown.test.ts
+++ b/packages/examples/code/src/components/chat-markdown.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+//
+// #11294: assistant replies render as real markdown (bold, fenced code) via
+// @elizaos/tui's Markdown component at usable widths, and fall back to plain
+// wrapped text on narrow terminals (the ~43-col cockpit xterm) so the #11043
+// overflow guarantee holds. Uses the same VirtualTerminal harness as
+// narrow-terminal.test.ts.
+
+import type { AgentRuntime } from "@elizaos/core";
+import { TUI, visibleWidth } from "@elizaos/tui";
+import { VirtualTerminal } from "@elizaos/tui/testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { useStore } from "../lib/store.js";
+import { ChatPane } from "./ChatPane.js";
+import { MainScreen } from "./MainScreen.js";
+import { StatusBar } from "./StatusBar.js";
+import { TaskPane } from "./TaskPane.js";
+
+function makeScreen(cols: number) {
+  const terminal = new VirtualTerminal(cols, 40);
+  const tui = new TUI(terminal);
+  const chatPane = new ChatPane({ onSubmit: async () => {}, tui });
+  const statusBar = new StatusBar();
+  const taskPane = new TaskPane({
+    runtime: {} as unknown as AgentRuntime,
+    tui,
+  });
+  const mainScreen = new MainScreen(terminal, statusBar, chatPane, taskPane);
+  return { chatPane, mainScreen };
+}
+
+afterEach(() => {
+  useStore.setState({ rooms: [] });
+  useStore.getState().setInputValue("");
+});
+
+describe("eliza-code chat markdown rendering (#11294)", () => {
+  const MD_BODY =
+    "# Title\n\nHere is **bold** and `inline code`:\n\n```ts\nconst x = 1;\n```";
+
+  test("renders assistant replies through the markdown component at a usable width", () => {
+    const { chatPane, mainScreen } = makeScreen(100);
+    chatPane.syncFocus(true);
+    const state = useStore.getState();
+    state.addMessage(state.currentRoomId, "assistant", MD_BODY);
+
+    const lines = mainScreen.render(100);
+    const joined = lines.join("\n");
+    // Content survives.
+    expect(joined).toContain("const x = 1;");
+    // Inline markdown markers are consumed (was flat raw text before): the
+    // heading "#", the bold "**", and the inline-code backticks are stripped
+    // — in a real TTY the runs are also colored via the chalk theme (color is
+    // disabled in this non-TTY test env, so we assert the marker-stripping,
+    // which is environment-independent).
+    expect(joined).toContain("Title");
+    expect(joined).not.toContain("# Title");
+    expect(joined).toContain("bold");
+    expect(joined).not.toContain("**bold**");
+    expect(joined).toContain("inline code");
+    expect(joined).not.toContain("`inline code`");
+    // Overflow invariant still holds.
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test("falls back to plain wrap on a narrow (cockpit phone) terminal", () => {
+    const { chatPane, mainScreen } = makeScreen(43);
+    chatPane.syncFocus(true);
+    const state = useStore.getState();
+    state.addMessage(state.currentRoomId, "assistant", MD_BODY);
+
+    const lines = mainScreen.render(43);
+    // No crash + width invariant (the #11043 guarantee) — the whole point of
+    // the narrow-width fallback.
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(43);
+    }
+  });
+});

--- a/packages/examples/code/src/lib/markdown-theme.ts
+++ b/packages/examples/code/src/lib/markdown-theme.ts
@@ -1,0 +1,36 @@
+/**
+ * A chalk-based {@link MarkdownTheme} for eliza-code's chat transcript.
+ *
+ * `@elizaos/tui` ships a full Markdown renderer (headings, lists, tables,
+ * inline styles, fenced code blocks) but exports no ready-made production
+ * theme — only a test fixture. This maps each theme slot to a chalk style so
+ * assistant replies render with real markdown formatting + code-block framing
+ * instead of the previous flat wrapped text (the biggest look-and-feel gap vs
+ * opencode/claude-code). Colors intentionally track the existing transcript
+ * palette (cyan/green accents, dim chrome); orange is reserved as accent
+ * elsewhere so we avoid it here.
+ */
+
+import type { MarkdownTheme } from "@elizaos/tui";
+import chalk from "chalk";
+
+export function createChatMarkdownTheme(): MarkdownTheme {
+  return {
+    heading: (t) => chalk.bold.cyan(t),
+    link: (t) => chalk.underline.cyan(t),
+    linkUrl: (t) => chalk.dim(t),
+    code: (t) => chalk.yellowBright(t),
+    codeBlock: (t) => chalk.greenBright(t),
+    codeBlockBorder: (t) => chalk.dim(t),
+    quote: (t) => chalk.italic.dim(t),
+    quoteBorder: (t) => chalk.dim(t),
+    hr: (t) => chalk.dim(t),
+    listBullet: (t) => chalk.cyan(t),
+    bold: (t) => chalk.bold(t),
+    italic: (t) => chalk.italic(t),
+    strikethrough: (t) => chalk.strikethrough(t),
+    underline: (t) => chalk.underline(t),
+    // Code blocks get a two-space gutter so they read as an indented block.
+    codeBlockIndent: "  ",
+  };
+}


### PR DESCRIPTION
Part of the eliza-code TUI-quality workstream (#11294). The scan called this "the single biggest look-and-feel gap vs opencode."

**Before:** the chat transcript rendered every reply through a hand-rolled plain-text `wrapText` — headings, `**bold**`, `inline code`, lists, and fenced code all arrived as raw text (literal `**` markers etc.). `@elizaos/tui` already ships a full `Markdown` renderer (headings/lists/tables/inline styles + code blocks, used in its own chat demo), but eliza-code never used it.

**Change:** route assistant/user message bodies through tui's `Markdown` with a chalk-based theme (new `lib/markdown-theme.ts`) into pre-styled lines (new `raw` `RenderLine` variant so the render loop doesn't re-chalk them). Independent of PR #11293 (different files).

**Safety:** Markdown wraps to `contentWidth`, so `indent + line` never exceeds `maxWidth`, and `MainScreen`'s `truncateToWidth` remains the final overflow backstop. Below 40 cols (the ~43-col cockpit phone xterm) it falls back to the plain wrapper — preserving the #11043 narrow-terminal guarantee.

### Evidence
- **Tests** (`chat-markdown.test.ts`, same VirtualTerminal harness as the #11043 suite): at width 100 the inline markers are consumed (`# Title`→`Title`, `**bold**`→`bold`, `` `inline code` ``→`inline code`) and the width invariant holds; at width 43 it falls back to plain wrap with no overflow. **Mutation-checked** (forcing the plain path reds the marker-stripping test). Full eliza-code suite **14/14**; build clean; dist `tsconfig.json` shim intact (cockpit-spawn contract, #11043).

### N/A rows
- **Rendered color screenshot: N/A in this headless session** — chalk disables color off a TTY, so the tests assert the environment-independent win (markdown parsing / marker consumption / width safety); the *coloring* uses the exact `Markdown` component + theme pattern tui's own chat demo ships, and is verified-by-construction. A live color pass (real terminal) is the one remaining visual check — happy to attach a capture, or it rides the broader cockpit device test.
- Live-LLM trajectory: N/A — render-path change, no model behavior.

Remaining #11294 items (real token streaming, cancel/interrupt, tool-call visibility, scrollback paging) are separate follow-up PRs.