### PR TITLE
fix(ci): unbreak four chronically-red nightly lanes (Publish, Live Scenarios, Hetzner E2E, Monetized loop)

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -145,6 +145,16 @@ jobs:
           bun run --cwd packages/skills build
           echo "::endgroup::"
 
+          echo "::group::Build plugins/plugin-commands"
+          # plugin-telegram's command-registration.ts imports @elizaos/plugin-commands
+          # via its dist exports (ConnectorCommand, getConnectorCommands,
+          # resolveCommand, …). Because installs run with --ignore-scripts this
+          # workspace dependency is never built implicitly, so plugin-telegram's
+          # `tsc` declaration emit fails with TS2307 "Cannot find module
+          # '@elizaos/plugin-commands'". Build it before the connector loop below.
+          bun run --cwd plugins/plugin-commands build
+          echo "::endgroup::"
+
           provider_package=""
           if [ -n "${GROQ_API_KEY:-}" ]; then
             provider_package="plugins/plugin-groq"

--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -150,6 +150,13 @@ jobs:
 
       - name: Run monetized full loop + example-apps showcase (real Hetzner)
         if: steps.secret_config.outputs.configured == 'true' && steps.cloud_auth.outputs.ready == 'true'
+        # Cap the run step below the 40m job budget. The real-staging deploy
+        # specs (example-edad / example-clone-ur-crush) drive a live Hetzner
+        # deploy that can stall; without a step cap the whole job hits the
+        # job-level 40m limit and reports an opaque "operation was canceled"
+        # with no report uploaded. A step timeout fails loudly ("step timed
+        # out") and leaves headroom for the always() artifact-upload steps.
+        timeout-minutes: 25
         run: bun run cloud:e2e -- monetized-full-loop.spec.ts example-apps-showcase.spec.ts example-edad-real-deploy.spec.ts example-clone-ur-crush-real-deploy.spec.ts
         env:
           CI: "true"

--- a/packages/examples/code/package.json
+++ b/packages/examples/code/package.json
@@ -4,7 +4,7 @@
   "description": "Async coding agent terminal app - Claude Code meets ElizaOS",
   "repository": {
     "type": "git",
-    "url": "https://github.com/elizaos/eliza.git",
+    "url": "git+https://github.com/elizaOS/eliza.git",
     "directory": "packages/examples/code"
   },
   "type": "module",

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-deploy-agent.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-deploy-agent.ts
@@ -63,6 +63,12 @@ async function requestJson(
 }
 
 async function createAgent(): Promise<string> {
+  // The create-agent endpoint is idempotent: a fresh create returns 201, but
+  // when the account already owns an agent (e.g. a prior run's agent that
+  // teardown never deleted — teardown only reaps the Hetzner server, not the
+  // cloud agent) it returns 200 with `created:false` and the existing record.
+  // Accept both so a leftover agent surfaces as an actionable warning + reuse
+  // instead of an opaque `POST … returned 200: {…}` throw that burns the lane.
   const { body } = await requestJson(
     "/api/v1/eliza/agents",
     {
@@ -82,11 +88,24 @@ async function createAgent(): Promise<string> {
         environmentVars: { HETZNER_E2E_RUN_ID: runId },
       }),
     },
-    [201],
+    [200, 201],
   );
   const data = body.data as JsonObject | undefined;
   if (!data || typeof data.id !== "string") {
     throw new Error("Create agent response missing data.id");
+  }
+  if (body.created === false) {
+    // Loud + actionable, but not fatal: reuse the pre-existing agent so the
+    // provision/healthcheck heartbeat still runs. Writing this id to the state
+    // file lets teardown pick it up. If the reused agent is unhealthy, the
+    // downstream provision/healthcheck steps fail loudly with the real reason.
+    console.log(
+      `::warning::[hetzner-e2e-deploy-agent] create returned created:false — ` +
+        `reusing pre-existing agent ${data.id} (${String(data.agentName ?? "")}). ` +
+        `A prior run's agent was not torn down (teardown reaps the Hetzner ` +
+        `server, not the cloud agent). Delete stale agents on the staging ` +
+        `showcase account if this recurs.`,
+    );
   }
   return data.id;
 }


### PR DESCRIPTION
Four independent, root-caused fixes for nightly lanes that were red daily:

1. **Publish @elizaos/example-code** — `npm publish` E422 provenance: `repository.url` declared lowercase `elizaos/eliza` but npm derives `elizaOS/eliza` (correct casing) from Actions, and the lane sets `NPM_CONFIG_PROVENANCE=true`. Fixed `packages/examples/code/package.json` repository.url casing (matches core, which publishes fine). *Finding: ~12 other packages/* still lowercase — latent if a provenance lane ever reaches them.*

2. **Live Scenarios** — failed at 'Build live scenario runtime packages': `Cannot find module '@elizaos/plugin-commands'` (a `workspace:*` dep of plugin-telegram built without building plugin-commands first; installs use `--ignore-scripts`). Build plugin-commands before the connector loop.

3. **Hetzner Agent E2E** — create-agent endpoint is idempotent (returns 200/`created:false` + the existing agent when the staging account already owns one from a prior run teardown didn't reap); the script accepted only 201 → opaque throw every run. Now accepts 200/201, emits a loud `::warning::` on `created:false`, and reuses the returned agent id so the heartbeat still runs. *Runbook: extend teardown to DELETE the agent by id (state file has it).*

4. **Monetized loop (real-Hetzner job)** — stalled to the 40m job budget and was killed with an opaque 'operation was canceled', no report. Added `timeout-minutes: 25` on the run step so a stall fails loudly as a step timeout with headroom for always() artifact uploads.

YAML + actionlint clean; package.json valid; hetzner script bun-bundle clean.

**Two real regressions surfaced by these lanes, filed separately (NOT blind-fixed — owner decisions):** (a) monetized showcase-mock proves per-app markup is not applied on the `X-App-Id` `/api/v1/messages` billing seam (creator earnings stay 0); (b) Nightly Build has 5 plugin-view ratchet-drift assertions in packages/agent. Both need their domain owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)