### PR TITLE
fix(shared,agent,ui): resolve a shared avatarIndex to the selected persona, not the last-declared one

### DIFF
--- a/packages/agent/src/api/server-helpers.test.ts
+++ b/packages/agent/src/api/server-helpers.test.ts
@@ -1,9 +1,13 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { resolveStylePresetById } from "@elizaos/shared";
 import fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   cloneWithoutBlockedObjectKeys,
   hasBlockedObjectKeyDeep,
+  resolveConversationGreetingText,
+  resolveMirroredAvatarPresetId,
 } from "./server-helpers";
 
 describe("blocked object key sanitization", () => {
@@ -64,5 +68,71 @@ describe("blocked object key sanitization", () => {
       ),
       { numRuns: 200 },
     );
+  });
+});
+
+describe("resolveConversationGreetingText persona selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeRuntime = (name: string) =>
+    ({ character: { name, postExamples: [] } }) as unknown as AgentRuntime;
+
+  // The greeting is picked at random from the resolved preset's postExamples.
+  // Sweep Math.random across every index so the full reachable greeting set is
+  // observable — Eliza and Chen share a couple of lines, so a single draw could
+  // mask a persona swap.
+  const collectGreetings = (
+    runtimeName: string,
+    uiConfig: { presetId?: string; avatarIndex?: number },
+  ): Set<string> => {
+    const greetings = new Set<string>();
+    for (let step = 0; step < 32; step += 1) {
+      vi.spyOn(Math, "random").mockReturnValue(step / 32);
+      greetings.add(
+        resolveConversationGreetingText(makeRuntime(runtimeName), "en", {
+          assistant: { name: runtimeName },
+          ...uiConfig,
+        }),
+      );
+      vi.restoreAllMocks();
+    }
+    return greetings;
+  };
+
+  it("greets a default-Eliza config (presetId eliza + shared avatarIndex) as Eliza, not Chen", () => {
+    const eliza = resolveStylePresetById("eliza");
+    expect(eliza).toBeDefined();
+    const greetings = collectGreetings("Eliza", {
+      presetId: "eliza",
+      avatarIndex: eliza?.avatarIndex,
+    });
+    expect(greetings).toEqual(new Set(eliza?.postExamples));
+  });
+
+  it("keeps Chen's greeting for a Chen config sharing the same avatarIndex", () => {
+    const chen = resolveStylePresetById("chen");
+    expect(chen).toBeDefined();
+    const greetings = collectGreetings("Chen", {
+      presetId: "chen",
+      avatarIndex: chen?.avatarIndex,
+    });
+    expect(greetings).toEqual(new Set(chen?.postExamples));
+  });
+});
+
+describe("resolveMirroredAvatarPresetId", () => {
+  it("keeps a persisted presetId that is consistent with the selected avatar", () => {
+    expect(resolveMirroredAvatarPresetId("chen", 1)).toBe("chen");
+    expect(resolveMirroredAvatarPresetId("eliza", 1)).toBe("eliza");
+  });
+
+  it("derives the default persona for an unnamed or inconsistent config", () => {
+    expect(resolveMirroredAvatarPresetId(undefined, 1)).toBe("eliza");
+    // jin renders asset 2 — selecting avatar 1 means the persisted id no
+    // longer matches, so the id is re-derived from the index (default-first).
+    expect(resolveMirroredAvatarPresetId("jin", 1)).toBe("eliza");
+    expect(resolveMirroredAvatarPresetId("chen", 2)).toBe("jin");
   });
 });

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -322,13 +322,17 @@ export function resolveConversationGreetingText(
 
   // Prefer explicit UI selections over the loaded character card: users pick a
   // style in first-run/roster (avatar + preset) while `runtime.character.name`
-  // can still reflect the bundled preset name until save/restart.
+  // can still reflect the bundled preset name until save/restart. presetId is
+  // checked before avatarIndex (matching the build-character paths): the id
+  // names one persona, while avatarIndex is a VRM art-asset index that several
+  // personas can share (Eliza and Chen both render asset 1), so the index
+  // alone cannot disambiguate the selected persona.
   const preset =
+    resolveStylePresetById(uiConfig?.presetId, normalizedLanguage) ??
     resolveStylePresetByAvatarIndex(
       uiConfig?.avatarIndex,
       normalizedLanguage,
     ) ??
-    resolveStylePresetById(uiConfig?.presetId, normalizedLanguage) ??
     resolveStylePresetByName(assistantName, normalizedLanguage) ??
     resolveStylePresetByName(characterName, normalizedLanguage);
 
@@ -349,6 +353,28 @@ export function resolveConversationGreetingText(
   return name
     ? `Hey, I'm ${name}. What can I help you with?`
     : "Hey — what can I help you with?";
+}
+
+/**
+ * Preset id to persist when a stream avatar selection is mirrored into
+ * eliza.json.
+ *
+ * avatarIndex is a VRM art-asset index that several personas can share (Eliza
+ * and Chen both render asset 1), so the index alone cannot identify a persona.
+ * When the config already names a preset consistent with the selected avatar,
+ * keep it — deriving a fresh presetId from the index would silently swap the
+ * user's persona to whichever preset wins the index lookup.
+ */
+export function resolveMirroredAvatarPresetId(
+  currentPresetId: string | null | undefined,
+  avatarIndex: number,
+  language?: unknown,
+): string | undefined {
+  const current = resolveStylePresetById(currentPresetId, language);
+  if (current?.avatarIndex === avatarIndex) {
+    return current.id;
+  }
+  return resolveStylePresetByAvatarIndex(avatarIndex, language)?.id;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -49,7 +49,6 @@ import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
 import {
   getStylePresets,
   normalizeCharacterLanguage,
-  resolveStylePresetByAvatarIndex,
 } from "@elizaos/shared/character-presets";
 import {
   isMobilePlatform,
@@ -437,6 +436,7 @@ import {
   hasPersistedFirstRunState,
   isUuidLike,
   patchTouchesProviderSelection,
+  resolveMirroredAvatarPresetId,
 } from "./server-helpers.ts";
 import { routeAutonomyTextToUser as routeProactiveText } from "./server-helpers-swarm.ts";
 import {
@@ -4622,11 +4622,19 @@ export async function startApiServer(opts?: {
               }
               const diskCfg = loadElizaConfig();
               const lang = state.config.ui?.language ?? diskCfg.ui?.language;
-              const preset = resolveStylePresetByAvatarIndex(avatarIndex, lang);
+              // Keep an already-consistent presetId: avatarIndex is a VRM
+              // art-asset index shared by several personas, so re-deriving the
+              // preset from the index would overwrite the user's persona (e.g.
+              // persisting presetId "chen" over an Eliza selection).
+              const presetId = resolveMirroredAvatarPresetId(
+                state.config.ui?.presetId ?? diskCfg.ui?.presetId,
+                avatarIndex,
+                lang,
+              );
               const nextUi: ElizaConfig["ui"] = {
                 ...(state.config.ui ?? {}),
                 avatarIndex,
-                ...(preset?.id ? { presetId: preset.id } : {}),
+                ...(presetId ? { presetId } : {}),
               };
               state.config = {
                 ...state.config,

--- a/packages/shared/src/character-presets.test.ts
+++ b/packages/shared/src/character-presets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { CHARACTER_DEFINITIONS } from "./character-presets.characters.js";
+import {
+  buildElizaCharacterCatalog,
+  getDefaultStylePreset,
+  resolveStylePresetByAvatarIndex,
+  resolveStylePresetById,
+} from "./character-presets.js";
+
+// avatarIndex is a VRM art-asset index, not a persona key: several personas can
+// share one art asset (the default Eliza and Chen both render asset 1). These
+// tests pin the resolution contract when the default character and a named
+// preset that shares its avatar are provisioned side by side.
+describe("character preset resolution with a shared avatarIndex", () => {
+  const defaultDefinition = CHARACTER_DEFINITIONS[0];
+  const sibling = CHARACTER_DEFINITIONS.find(
+    (definition) =>
+      definition !== defaultDefinition &&
+      definition.avatarIndex === defaultDefinition.avatarIndex,
+  );
+
+  it("bundles the ambiguous pair the contract is about (data premise)", () => {
+    expect(defaultDefinition?.id).toBe("eliza");
+    expect(sibling?.id).toBe("chen");
+    expect(sibling?.avatarIndex).toBe(defaultDefinition?.avatarIndex);
+  });
+
+  it("resolves every preset to its own persona by id", () => {
+    for (const definition of CHARACTER_DEFINITIONS) {
+      const preset = resolveStylePresetById(definition.id);
+      expect(preset?.id).toBe(definition.id);
+      expect(preset?.name).toBe(definition.name);
+      expect(preset?.system).toContain(definition.system);
+      expect(preset?.avatarIndex).toBe(definition.avatarIndex);
+    }
+  });
+
+  it("resolves the shared avatarIndex to the default persona, not the last-declared sibling", () => {
+    const preset = resolveStylePresetByAvatarIndex(
+      defaultDefinition.avatarIndex,
+    );
+    expect(preset?.id).toBe(defaultDefinition.id);
+    expect(preset?.name).toBe(defaultDefinition.name);
+    expect(preset?.system).toContain(defaultDefinition.system);
+  });
+
+  it("resolves every unshared avatarIndex to its own persona", () => {
+    for (const definition of CHARACTER_DEFINITIONS) {
+      const holders = CHARACTER_DEFINITIONS.filter(
+        (candidate) => candidate.avatarIndex === definition.avatarIndex,
+      );
+      if (holders.length > 1) {
+        continue;
+      }
+      expect(resolveStylePresetByAvatarIndex(definition.avatarIndex)?.id).toBe(
+        definition.id,
+      );
+    }
+  });
+
+  it("keeps the default Eliza and the sibling preset as two distinct personas", () => {
+    const eliza = resolveStylePresetById("eliza");
+    const chen = resolveStylePresetById("chen");
+    expect(eliza).toBeDefined();
+    expect(chen).toBeDefined();
+    expect(eliza?.system).not.toBe(chen?.system);
+    expect(eliza?.bio).not.toEqual(chen?.bio);
+    // The default persona must survive an avatarIndex round-trip: resolving
+    // the avatar it renders may not swap it for the sibling's persona.
+    expect(resolveStylePresetByAvatarIndex(eliza?.avatarIndex)?.id).toBe(
+      "eliza",
+    );
+    expect(getDefaultStylePreset().id).toBe("eliza");
+  });
+
+  it("emits unique catalog asset ids and one injected character per persona", () => {
+    const { assets, injectedCharacters } = buildElizaCharacterCatalog();
+    const ids = assets.map((asset) => asset.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const slugs = assets.map((asset) => asset.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    expect(injectedCharacters).toHaveLength(CHARACTER_DEFINITIONS.length);
+  });
+});

--- a/packages/shared/src/character-presets.ts
+++ b/packages/shared/src/character-presets.ts
@@ -80,12 +80,24 @@ const CHARACTER_DEFINITION_BY_NAME = new Map(
   ]),
 );
 
-const CHARACTER_DEFINITION_BY_AVATAR_INDEX = new Map(
-  CHARACTER_DEFINITIONS.map((definition) => [
-    definition.avatarIndex,
-    definition,
-  ]),
-);
+// avatarIndex is a VRM art-asset index, not a unique persona key — multiple
+// personas can share one art asset (the default Eliza and Chen both render
+// asset 1). Build this lookup first-wins so an ambiguous index resolves
+// deterministically to the earliest-declared persona (the default preset is
+// CHARACTER_DEFINITIONS[0]) instead of the Map constructor's last-wins
+// semantics letting a later persona silently clobber it.
+const CHARACTER_DEFINITION_BY_AVATAR_INDEX = new Map<
+  number,
+  CharacterDefinition
+>();
+for (const definition of CHARACTER_DEFINITIONS) {
+  if (!CHARACTER_DEFINITION_BY_AVATAR_INDEX.has(definition.avatarIndex)) {
+    CHARACTER_DEFINITION_BY_AVATAR_INDEX.set(
+      definition.avatarIndex,
+      definition,
+    );
+  }
+}
 
 // The first/default character ("eliza") is the app's default agent. A
 // white-label app rebrands that default to its own app name (e.g. "Milady")
@@ -243,15 +255,26 @@ export function buildElizaCharacterCatalog(): {
   // Use getStylePresets() (not the STYLE_PRESETS const) so the default-agent
   // rename from setDefaultAgentName() is reflected in the white-label catalog.
   const presets = getStylePresets(DEFAULT_LANGUAGE);
-  const assets = presets
-    .slice()
-    .sort((left, right) => left.avatarIndex - right.avatarIndex)
-    .map((preset) => ({
-      id: preset.avatarIndex,
-      slug: `eliza-${preset.avatarIndex}`,
-      title: preset.name,
-      sourceName: preset.name,
-    }));
+  // Assets are keyed by avatarIndex (the VRM art asset), which multiple
+  // personas can share — dedupe first-wins so the shared asset is titled after
+  // the earliest-declared persona instead of emitting duplicate asset ids.
+  const assetsByAvatarIndex = new Map<
+    number,
+    { id: number; slug: string; title: string; sourceName: string }
+  >();
+  for (const preset of presets) {
+    if (!assetsByAvatarIndex.has(preset.avatarIndex)) {
+      assetsByAvatarIndex.set(preset.avatarIndex, {
+        id: preset.avatarIndex,
+        slug: `eliza-${preset.avatarIndex}`,
+        title: preset.name,
+        sourceName: preset.name,
+      });
+    }
+  }
+  const assets = [...assetsByAvatarIndex.values()].sort(
+    (left, right) => left.id - right.id,
+  );
 
   const injectedCharacters = presets.map((preset) => ({
     catchphrase: preset.catchphrase,

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -8,7 +8,10 @@
  */
 
 import { logger } from "@elizaos/logger";
-import { resolveStylePresetByAvatarIndex } from "@elizaos/shared";
+import {
+  resolveStylePresetByAvatarIndex,
+  resolveStylePresetByName,
+} from "@elizaos/shared";
 import {
   type RefObject,
   useCallback,
@@ -647,19 +650,22 @@ export function useDataLoaders(deps: DataLoadersDeps) {
       return;
     }
 
-    const preset = resolveStylePresetByAvatarIndex(
-      selectedVrmIndex,
-      uiLanguage,
-    );
+    const characterName =
+      characterData?.name?.trim() ||
+      characterDraft?.name?.trim() ||
+      agentStatus?.agentName?.trim();
+
+    // Resolve the persona by name first: avatarIndex is a VRM art-asset index
+    // that several personas can share (Eliza and Chen both render asset 1), so
+    // the index alone would relocalize a named persona to its sibling.
+    const preset =
+      resolveStylePresetByName(characterName, uiLanguage) ??
+      resolveStylePresetByAvatarIndex(selectedVrmIndex, uiLanguage);
     if (!preset) {
       return;
     }
 
-    const resolvedName =
-      characterData?.name?.trim() ||
-      characterDraft?.name?.trim() ||
-      agentStatus?.agentName?.trim() ||
-      preset.name;
+    const resolvedName = characterName || preset.name;
 
     void (async () => {
       try {


### PR DESCRIPTION
Closes #11309

## Problem

`avatarIndex` is a VRM art-asset index, not a persona key — the default **Eliza** and **Chen** deliberately share asset 1. `CHARACTER_DEFINITION_BY_AVATAR_INDEX` was built with the plain `Map` constructor (duplicate keys = **last-wins**), so index 1 resolved to Chen and Chen clobbered the default Eliza everywhere resolution fell back to the index:

- a fully consistent default-Eliza config (`ui.presetId: "eliza"`, `ui.avatarIndex: 1`) **greeted as Chen** — `resolveConversationGreetingText` checked `avatarIndex` before `presetId`
- `mirrorStreamAvatarToElizaConfig` re-derived `presetId` from the index and could **persist `presetId: "chen"` over an Eliza config**
- legacy index-only configs built the Chen character in `buildCharacterFromConfig`
- the UI language sync relocalized the character from the index alone
- `buildElizaCharacterCatalog()` emitted **duplicate asset ids** (two `id: 1` entries)

## Fix (structural — no per-character special cases)

- `packages/shared/src/character-presets.ts`: build the by-index lookup **first-wins**, so an ambiguous art-asset index deterministically resolves to the earliest-declared persona (the default preset is `CHARACTER_DEFINITIONS[0]`); dedupe catalog assets by `avatarIndex`.
- `packages/agent/src/api/server-helpers.ts`: check `presetId` **before** `avatarIndex` in the greeting path (matching the build-character paths); new `resolveMirroredAvatarPresetId` keeps an already-consistent persisted `presetId` instead of re-deriving it from the index.
- `packages/agent/src/api/server.ts`: stream-avatar mirror uses `resolveMirroredAvatarPresetId`.
- `packages/ui/src/state/useDataLoaders.ts`: language sync resolves the persona by character name first, index as fallback.

Named-preset users are untouched: `presetId`/name still name their persona everywhere (Chen keeps Chen); only the previously ambiguous index-only fallback changes, and it now picks the default persona instead of a declaration-order accident.

## Repro / evidence

New deterministic tests **fail on `develop` before the fix**:

```
packages/shared  src/character-presets.test.ts     Tests  3 failed | 3 passed (6)
  - resolveStylePresetByAvatarIndex(1) returned 'chen', expected 'eliza'
  - avatarIndex round-trip swapped the default persona for the sibling
  - catalog emitted 9 assets with 8 unique ids
packages/agent   src/api/server-helpers.test.ts    Tests  1 failed | 4 passed (5)
  - a { presetId: "eliza", avatarIndex: 1 } config produced exactly Chen's greeting set
```

After the fix (post-rebase on latest `develop`):

```
packages/shared  bunx vitest run src/character-presets.test.ts    Tests  6 passed (6)
packages/agent   bunx vitest run src/api/server-helpers.test.ts   Tests  7 passed (7)
packages/shared  bunx vitest run (full package)                   Tests  1041 passed (1041), 82 files
typecheck: packages/shared ✓  packages/agent ✓  packages/ui ✓  (tsgo --noEmit)
biome check on the 6 touched files: no new diagnostics
```

The greeting test sweeps the RNG across every index so the full reachable greeting set is compared — Eliza and Chen share two greeting lines, so a single random draw could mask the persona swap.

Evidence notes: config/deterministic resolution-layer fix — no model behavior, prompts, or rendered UI change; the failing-then-passing unit tests above are the domain artifact (greeting-set swap + persisted presetId + catalog ids). Video/screenshots N/A — no visual surface changes (the VRM asset shown for index 1 is identical before/after).
