### PR TITLE
fix(orchestrator): fail closed on a malformed smithers approval response (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/smithers-task-runner.test.ts
@@ -15,6 +15,7 @@ const TIMEOUT = 60_000;
 interface FakeOpts {
   doneOnTurn?: number; // per-agent turn at which runTurn reports done
   approved?: boolean;
+  malformedApproval?: boolean; // requestApproval returns a result missing `approved`
   throwOnTurnCall?: number; // throw a fatal error on the Nth runTurn call
   abort?: { controller: AbortController; onCall: number }; // abort + hang on the Nth call
 }
@@ -50,6 +51,11 @@ class FakeExecutor implements TaskStepExecutor {
 
   async requestApproval(_ctx: TaskStepContext): Promise<TaskApprovalResult> {
     this.approvalCalls += 1;
+    if (this.opts.malformedApproval) {
+      // Simulate a broken handler that omits `approved` at the untyped
+      // subprocess boundary.
+      return {} as unknown as TaskApprovalResult;
+    }
     return { approved: this.opts.approved !== false };
   }
 
@@ -136,6 +142,24 @@ describe("runTaskWithSmithers (durable Smithers-backed coding task)", () => {
       expect(result.approved).toBe(false);
       expect(fake.submitCalls).toBe(0);
       expect(result.submit).toBeUndefined();
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "fails closed (skips submit) when a present approval handler returns a malformed result (#11028)",
+    async () => {
+      // A handler that omits `approved` must NOT be treated as approval — a
+      // broken approval gate should hold the submit, not silently release it.
+      const fake = new FakeExecutor({ doneOnTurn: 1, malformedApproval: true });
+      const result = await runTaskWithSmithers(
+        spec({ submit: true, approvalBeforeSubmit: true }),
+        fake,
+      );
+      expect(fake.approvalCalls).toBe(1);
+      expect(result.approved).toBe(false);
+      expect(fake.submitCalls).toBe(0);
+      expect(result.status).toBe("denied");
     },
     TIMEOUT,
   );

--- a/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/smithers-task-runner.ts
@@ -320,7 +320,14 @@ export async function runTaskWithSmithers(
       assembled.turns += 1;
       assembled.agentsDone[ctx.agentIndex ?? 0] = out.done === true;
     } else if (kind === "approval") {
-      assembled.approved = out.approved !== false;
+      // Fail CLOSED: a present approval handler must EXPLICITLY approve. The
+      // prior `!== false` treated a malformed/ambiguous response (approved
+      // missing / null / undefined at this untyped subprocess boundary) as
+      // approval, so a broken approval handler silently let a task submit. Only
+      // an explicit `approved === true` clears the gate now. (The no-handler
+      // case is unaffected: it never reaches record(), so the permissive init
+      // default still stands for deployments that wire no requestApproval.)
+      assembled.approved = out.approved === true;
     } else if (kind === "submit") {
       assembled.submitOutput =
         (out.output as Record<string, unknown>) ?? assembled.submitOutput;


### PR DESCRIPTION
Audit-confirmed (3/3, high — security-relevant). The smithers submit gate recorded `assembled.approved = out.approved !== false`, so a **present** approval handler whose response omitted `approved` (or returned null/undefined at the untyped subprocess boundary — a broken/misbehaving handler) was treated as **approved**, and the task submitted (pushed / opened a PR) without a real approval. A safety gate must fail closed.

**Fix:** only an explicit `approved === true` clears the gate; anything else denies and skips submit.

**Scope is deliberate.** The *no-handler* case is unchanged — it never reaches `record()` (`dispatchStep` writes the fallback response directly), so the permissive init default still stands for deployments that intentionally set `approvalBeforeSubmit` without wiring a `requestApproval` handler (this matches the audit's separately-rejected "no handler auto-approves" finding). Only a **present** handler's malformed/ambiguous response flips from approve → deny.

```
$ bunx vitest run smithers-task-runner → 9 passed
```
+1 case: a present handler returning a result missing `approved` now yields status `denied` + zero submit calls. Existing explicit approve/deny tests unchanged.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)