### PR TITLE
test(app): de-larp mobile back-button + launcher-swipe e2e — certify the LIVE contract, delete synthetic/fallback larp

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -9,7 +9,6 @@ import "./cloud-apps-view";
 // running build's identity is observable in-app and assertable on-device (#9309).
 import "./renderer-build-stamp";
 
-import { App as CapacitorApp } from "@capacitor/app";
 import { BackgroundRunner } from "@capacitor/background-runner";
 import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
 import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
@@ -63,12 +62,9 @@ import {
 } from "@elizaos/ui/config";
 import {
   AGENT_READY_EVENT,
-  APP_PAUSE_EVENT,
-  APP_RESUME_EVENT,
   COMMAND_PALETTE_EVENT,
   CONNECT_EVENT,
   dispatchAppEvent,
-  dispatchBackIntent,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
@@ -354,8 +350,6 @@ let mobileAgentTunnelListener: PluginListenerHandle | null = null;
 let mobileAgentTunnelStartPromise: Promise<void> | null = null;
 let mobileRuntimeModeListenerInstalled = false;
 let keyboardListenersRegistered = false;
-let lifecycleListenersRegistered = false;
-let activeVisibilityHandler: (() => void) | null = null;
 let iosFullBunSmokeStarted = false;
 let iosOnboardingSmokeStarted = false;
 
@@ -1442,7 +1436,7 @@ async function initializePlatform(): Promise<void> {
   if (isIOS || isAndroid) {
     await initializeStatusBar();
     await initializeKeyboard();
-    initializeAppLifecycle();
+    getMobileLifecycle().initializeAppLifecycle();
     initializeMobileRuntimeModeListener();
     void getMobileLifecycle().initializeNetworkListener();
     void initializeMobileDeviceBridge();
@@ -1541,85 +1535,15 @@ async function initializeKeyboard(): Promise<void> {
   });
 }
 
-function initializeAppLifecycle(): void {
-  // Each Capacitor listener fires its handler N times if added N times.
-  // Vite HMR and any redundant initialization paths re-invoke this function,
-  // so guard against duplicate registrations.
-  if (lifecycleListenersRegistered) return;
-  lifecycleListenersRegistered = true;
-
-  let lastActive: boolean | null = null;
-  const setAppActive = (active: boolean): void => {
-    if (lastActive === active) return;
-    lastActive = active;
-    dispatchAppEvent(active ? APP_RESUME_EVENT : APP_PAUSE_EVENT);
-  };
-
-  void Promise.resolve(
-    CapacitorApp.addListener("appStateChange", ({ isActive }) => {
-      setAppActive(isActive);
-    }),
-  ).catch((error) => {
-    logNativePluginUnavailable("App", error);
-  });
-
-  if (activeVisibilityHandler) {
-    document.removeEventListener("visibilitychange", activeVisibilityHandler);
-  }
-  activeVisibilityHandler = () => {
-    setAppActive(document.visibilityState !== "hidden");
-  };
-  document.addEventListener("visibilitychange", activeVisibilityHandler);
-
-  void Promise.resolve(
-    CapacitorApp.addListener("backButton", ({ canGoBack }) => {
-      // Give the shell first crack at the back press: an open chat sheet (or any
-      // future back-dismissable overlay) closes ONE layer and reports it
-      // handled, so hardware back dismisses the sheet instead of navigating the
-      // app out from under it — matching desktop/web Escape-to-close (#9148).
-      // `dispatchBackIntent` resolves synchronously; only an unhandled press
-      // falls through to the app's default back below.
-      if (dispatchBackIntent()) return;
-      if (canGoBack) {
-        window.history.back();
-      } else {
-        // At the root view the hardware back button was a no-op (the app felt
-        // frozen). Match Android convention: send the app to the background
-        // (minimize) rather than killing it, so the agent + state survive.
-        void CapacitorApp.minimizeApp().catch(() => {
-          // minimizeApp is Android-only; ignore where unavailable.
-        });
-      }
-    }),
-  ).catch((error) => {
-    logNativePluginUnavailable("App", error);
-  });
-
-  void Promise.resolve(
-    CapacitorApp.addListener("appUrlOpen", ({ url }) => {
-      handleDeepLink(url);
-    }),
-  ).catch((error) => {
-    logNativePluginUnavailable("App", error);
-  });
-
-  void CapacitorApp.getLaunchUrl()
-    .then((result) => {
-      if (result?.url) {
-        handleDeepLink(result.url);
-      }
-    })
-    .catch((error) => {
-      logNativePluginUnavailable("App", error);
-    });
-}
-
 /**
  * Live Android/Capacitor lifecycle helper. `main.tsx` keeps its own
- * status-bar / keyboard / app-lifecycle wiring (the app-lifecycle path carries
- * the hardware-back `minimizeApp` behavior the extracted helper predates), but
- * the network listener is delegated here so the #10472 window `online`/`offline`
- * fallback actually runs in the live entrypoint. Before this the fallback lived
+ * status-bar / keyboard wiring, but the app-lifecycle path (foreground/
+ * background events + the `visibilitychange` fallback, the hardware-back
+ * contract — `dispatchBackIntent()` first, then `history.back()` /
+ * `minimizeApp()` when unhandled (#9148) — and the deep-link bootstrap) and
+ * the network listener are delegated here so the extracted module IS the
+ * shipped behavior, not a stale duplicate. The network delegation carries the
+ * #10472 window `online`/`offline` fallback: before it, the fallback lived
  * only in `mobile-lifecycle.ts` and had zero importers, so on Android — where
  * the Capacitor `Network` plugin can be absent from the WebView bridge — the
  * `networkStatusChange` listener never registered and NETWORK_STATUS_CHANGE_EVENT

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -11,6 +11,7 @@ import {
   APP_PAUSE_EVENT,
   APP_RESUME_EVENT,
   dispatchAppEvent,
+  dispatchBackIntent,
   NETWORK_STATUS_CHANGE_EVENT,
   type NetworkStatusChangeDetail,
 } from "@elizaos/ui/events";
@@ -128,8 +129,23 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
 
     void Promise.resolve(
       CapacitorApp.addListener("backButton", ({ canGoBack }) => {
+        // Give the shell first crack at the back press: an open chat sheet (or
+        // any future back-dismissable overlay) closes ONE layer and reports it
+        // handled, so hardware back dismisses the sheet instead of navigating
+        // the app out from under it — matching desktop/web Escape-to-close
+        // (#9148). `dispatchBackIntent` resolves synchronously; only an
+        // unhandled press falls through to the app's default back below.
+        if (dispatchBackIntent()) return;
         if (canGoBack) {
           window.history.back();
+        } else {
+          // At the root view the hardware back button was a no-op (the app
+          // felt frozen). Match Android convention: send the app to the
+          // background (minimize) rather than killing it, so the agent + state
+          // survive.
+          void CapacitorApp.minimizeApp().catch(() => {
+            // minimizeApp is Android-only; ignore where unavailable.
+          });
         }
       }),
     ).catch((error) => {

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -9,9 +9,12 @@
  *   - `initializeAppLifecycle()` — `@capacitor/app` `appStateChange` /
  *     `backButton` / `appUrlOpen` listeners + the cold-launch `getLaunchUrl()`
  *     deep-link bootstrap. Asserts the events the module dispatches
- *     (`APP_RESUME_EVENT` / `APP_PAUSE_EVENT`), that `window.history.back()` is
- *     called only when `canGoBack` is true, and that both cold (`getLaunchUrl`)
- *     and warm (`appUrlOpen`) launches route through `ctx.handleDeepLink`.
+ *     (`APP_RESUME_EVENT` / `APP_PAUSE_EVENT`), the shipped Android hardware
+ *     back contract (#9148) — `dispatchBackIntent()` gets first crack and a
+ *     handled press returns early; an unhandled press falls through to
+ *     `window.history.back()` when `canGoBack`, else `CapacitorApp.minimizeApp()`
+ *     — and that both cold (`getLaunchUrl`) and warm (`appUrlOpen`) launches
+ *     route through `ctx.handleDeepLink`.
  *   - `initializeNetworkListener()` — `@capacitor/network` `networkStatusChange`
  *     listener → `NETWORK_STATUS_CHANGE_EVENT` with the `{ connected }` detail.
  *
@@ -31,6 +34,8 @@ import { join } from "node:path";
 import {
   APP_PAUSE_EVENT,
   APP_RESUME_EVENT,
+  type BackIntentEventDetail,
+  ELIZA_BACK_INTENT_EVENT,
   NETWORK_STATUS_CHANGE_EVENT,
 } from "@elizaos/ui/events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -73,6 +78,7 @@ const { appListeners, networkListeners, capacitorAppMock, networkMock } =
             record(appListeners, eventName, handler),
         ),
         getLaunchUrl: vi.fn(() => Promise.resolve(launchUrl)),
+        minimizeApp: vi.fn(() => Promise.resolve()),
         __setLaunchUrl(next: { url?: string } | null) {
           launchUrl = next;
         },
@@ -153,16 +159,23 @@ afterEach(() => {
 });
 
 describe("createMobileLifecycle — app lifecycle", () => {
-  it("keeps the production app entrypoint wired to the visibilitychange fallback", () => {
+  it("keeps the production app entrypoint delegating app lifecycle to this module (no stale inline duplicate)", () => {
     const mainSrc = readFileSync(join(import.meta.dirname, "../src/main.tsx"), {
       encoding: "utf8",
     });
 
-    expect(mainSrc).toContain('addEventListener("visibilitychange"');
-    expect(mainSrc).toContain('document.visibilityState !== "hidden"');
+    // The live entrypoint must route through the extracted helper — this suite
+    // certifies the shipped behavior only while main.tsx actually calls it.
+    expect(mainSrc).toContain("getMobileLifecycle().initializeAppLifecycle()");
     expect(mainSrc).toContain(
-      "dispatchAppEvent(active ? APP_RESUME_EVENT : APP_PAUSE_EVENT)",
+      "getMobileLifecycle().initializeNetworkListener()",
     );
+    // ...and must not keep an inline duplicate of the wiring this module owns
+    // (the pre-extraction copies of the visibilitychange fallback and the
+    // hardware-back handler), or the tested code diverges from what ships.
+    expect(mainSrc).not.toContain('addEventListener("visibilitychange"');
+    expect(mainSrc).not.toContain('addListener("backButton"');
+    expect(mainSrc).not.toContain('addListener("appStateChange"');
   });
 
   it("dispatches APP_RESUME_EVENT when the app becomes active", async () => {
@@ -244,16 +257,51 @@ describe("createMobileLifecycle — app lifecycle", () => {
     setVisibility("visible");
   });
 
-  it("calls window.history.back() only when the back button can go back", async () => {
+  it("gives dispatchBackIntent first crack: a handled back press neither navigates nor minimizes", async () => {
     const lifecycle = createMobileLifecycle(makeContext());
     lifecycle.initializeAppLifecycle();
     await vi.waitFor(() => expect(appListeners.has("backButton")).toBe(true));
 
-    fireAppEvent("backButton", { canGoBack: false });
-    expect(historyBackSpy).not.toHaveBeenCalled();
+    // A shell consumer (e.g. the open chat sheet) claims the press (#9148).
+    const consumeBackIntent = (event: Event) => {
+      (event as CustomEvent<BackIntentEventDetail>).detail.handled = true;
+    };
+    window.addEventListener(ELIZA_BACK_INTENT_EVENT, consumeBackIntent);
+    try {
+      fireAppEvent("backButton", { canGoBack: true });
+      fireAppEvent("backButton", { canGoBack: false });
+    } finally {
+      window.removeEventListener(ELIZA_BACK_INTENT_EVENT, consumeBackIntent);
+    }
 
+    // Handled → early return: no history navigation, no minimize — regardless
+    // of canGoBack.
+    expect(historyBackSpy).not.toHaveBeenCalled();
+    expect(capacitorAppMock.minimizeApp).not.toHaveBeenCalled();
+  });
+
+  it("falls through an unhandled back press to window.history.back() when canGoBack", async () => {
+    const lifecycle = createMobileLifecycle(makeContext());
+    lifecycle.initializeAppLifecycle();
+    await vi.waitFor(() => expect(appListeners.has("backButton")).toBe(true));
+
+    // No consumer claims the intent (sheet at rest) → default back navigation.
     fireAppEvent("backButton", { canGoBack: true });
+
     expect(historyBackSpy).toHaveBeenCalledTimes(1);
+    expect(capacitorAppMock.minimizeApp).not.toHaveBeenCalled();
+  });
+
+  it("minimizes the app on an unhandled back press at the root view (!canGoBack)", async () => {
+    const lifecycle = createMobileLifecycle(makeContext());
+    lifecycle.initializeAppLifecycle();
+    await vi.waitFor(() => expect(appListeners.has("backButton")).toBe(true));
+
+    // No consumer + no history → Android convention: background, don't freeze.
+    fireAppEvent("backButton", { canGoBack: false });
+
+    expect(historyBackSpy).not.toHaveBeenCalled();
+    expect(capacitorAppMock.minimizeApp).toHaveBeenCalledTimes(1);
   });
 
   it("routes warm-launch appUrlOpen URLs through handleDeepLink", async () => {

--- a/packages/app/test/ui-smoke/launcher-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-interaction.spec.ts
@@ -1,6 +1,11 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page, test } from "@playwright/test";
+// Shared REAL-touch gesture helper (#10722): genuine CDP
+// `Input.dispatchTouchEvent` through the browser's hit-test / touch-action /
+// implicit-capture pipeline — NOT a synthetic `el.dispatchEvent(new
+// PointerEvent(...))` that bypasses all of it.
+import { touchSwipe } from "../../../ui/src/testing/real-touch-gestures";
 import {
   installDefaultAppRoutes,
   openAppPath,
@@ -49,61 +54,64 @@ async function tileIds(scope: Locator): Promise<string[]> {
   );
 }
 
-async function swipeLauncherPage(
+/**
+ * Where the launcher page rail physically sits: the rail's computed transform
+ * X plus one page's width. When page 0 is active the rail rests at x≈0; a
+ * committed swipe to page 1 translates it to x≈-pageWidth. Asserting on this
+ * (alongside the `aria-hidden` page state) proves the rail actually moved —
+ * the same signal run-home-screen-e2e.mjs asserts after its real-touch swipe.
+ */
+async function railGeometry(
+  page: Page,
+): Promise<{ x: number; pageWidth: number }> {
+  return page.getByTestId("launcher-page-rail").evaluate((el) => {
+    const transform = getComputedStyle(el).transform;
+    const matrix =
+      transform && transform !== "none"
+        ? new DOMMatrixReadOnly(transform)
+        : new DOMMatrixReadOnly();
+    const firstPage = el.querySelector('[data-testid="launcher-page-0"]');
+    return {
+      x: matrix.m41,
+      pageWidth: (firstPage ?? el).getBoundingClientRect().width,
+    };
+  });
+}
+
+/**
+ * REAL touch swipe across the launcher page window — CDP touch input in a
+ * `hasTouch` context, the same parameters the boot-free launcher runner
+ * (run-home-screen-e2e.mjs) drives paging with. There is deliberately NO
+ * fallback here: if touch paging is broken, this test FAILS. The previous
+ * version of this spec dispatched synthetic PointerEvents and silently fell
+ * back to clicking the desktop `<`/`>` edge buttons whenever the "swipe"
+ * didn't page, so it stayed green with touch paging entirely broken — the
+ * exact anti-pattern #10722 de-larps. Edge buttons are covered by their own
+ * explicit test below.
+ */
+async function touchSwipeLauncher(
   page: Page,
   direction: "next" | "prev",
-): Promise<"pointer-swipe" | "edge-button"> {
-  const pageWindow = page.getByTestId("launcher-page-window");
-  const targetPage = page.getByTestId(
-    direction === "next" ? "launcher-page-1" : "launcher-page-0",
-  );
-  const box = await pageWindow.boundingBox();
-  if (!box) throw new Error("launcher page window is not laid out");
-  const y = box.y + box.height * 0.52;
-  const startX = box.x + box.width * (direction === "next" ? 0.82 : 0.16);
-  const endX = box.x + box.width * (direction === "next" ? 0.16 : 0.82);
-  const pointer = {
-    bubbles: true,
-    cancelable: true,
-    pointerId: 9144,
-    pointerType: "touch",
-    isPrimary: true,
-    buttons: 1,
-  };
-  await pageWindow.dispatchEvent("pointerdown", {
-    ...pointer,
-    clientX: startX,
-    clientY: y,
+): Promise<void> {
+  const dx = direction === "next" ? -280 : 280;
+  await touchSwipe(page, '[data-testid="launcher-page-window"]', dx, 0, {
+    steps: 10,
+    stepDelayMs: 16,
   });
-  await pageWindow.dispatchEvent("pointermove", {
-    ...pointer,
-    clientX: box.x + box.width * 0.55,
-    clientY: y + 2,
-  });
-  await pageWindow.dispatchEvent("pointermove", {
-    ...pointer,
-    clientX: endX,
-    clientY: y + 2,
-  });
-  await pageWindow.dispatchEvent("pointerup", {
-    ...pointer,
-    buttons: 0,
-    clientX: endX,
-    clientY: y + 2,
-  });
-  const swiped = await targetPage
-    .evaluate((node) => node.getAttribute("aria-hidden") === "false")
-    .catch(() => false);
-  if (swiped) return "pointer-swipe";
+}
 
-  const edgeButton = page.getByTestId(`launcher-pager-edge-${direction}`);
-  if ((await edgeButton.count()) === 0) {
-    throw new Error(
-      `launcher pointer swipe did not move to the ${direction} page and no ${direction} pager button rendered`,
-    );
-  }
-  await edgeButton.click();
-  return "edge-button";
+async function bootLauncher(
+  page: Page,
+  size: { width: number; height: number },
+): Promise<void> {
+  await page.setViewportSize(size);
+  await seedAppStorage(page);
+  await installDefaultAppRoutes(page);
+  await installLauncherEvidenceRoutes(page);
+  await openAppPath(page, "/views");
+  await expect(page.getByTestId("launcher")).toBeVisible({
+    timeout: 60_000,
+  });
 }
 
 /**
@@ -114,109 +122,188 @@ async function swipeLauncherPage(
  * boot. The launcher has NO dock / featured-views surface (#11174): every view
  * is an ordinary tile on the swipeable pages, with the curated "Apps" page
  * (page 0) leading with Chat and Settings. Covered here: the no-dock contract,
- * curated page-0 ordering, swipe paging, and tap-to-launch of the Chat tile.
- * Run with E2E_RECORD=1 to capture a video walkthrough.
+ * curated page-0 ordering, REAL-touch swipe paging (#10722), tap-to-launch of
+ * the Chat tile, and — separately and explicitly — the desktop `<`/`>` pager
+ * edge buttons. Run with E2E_RECORD=1 to capture a video walkthrough.
  */
 test.describe("launcher catalog interactions", () => {
-  for (const viewport of [
-    { name: "desktop", size: { width: 1440, height: 1000 } },
-    { name: "mobile", size: { width: 390, height: 844 } },
-  ] as const) {
-    test(`no dock, page tiles, swipe paging, and Chat tile launch on ${viewport.name}`, async ({
-      page,
-    }, testInfo) => {
-      const consoleLines: string[] = [];
-      const pageErrors: string[] = [];
-      const httpErrors: string[] = [];
-      page.on("console", (message) =>
-        consoleLines.push(`${message.type()}: ${message.text()}`),
-      );
-      page.on("pageerror", (e) => pageErrors.push(e.message));
-      page.on("response", (response) => {
-        if (response.status() < 400) return;
-        httpErrors.push(
-          `${response.status()} ${response.request().method()} ${response.url()}`,
+  // Real CDP touch input is only accepted in a touch-enabled context, so the
+  // paging lane opts into `hasTouch` (same pattern as chat-clear-swipe's
+  // real-touch describe). The gesture itself is Chromium CDP; this spec runs
+  // on the chromium project only.
+  test.describe("real-touch swipe paging (#10722 — no synthetic events, no fallback)", () => {
+    test.use({ hasTouch: true });
+
+    for (const viewport of [
+      { name: "desktop", size: { width: 1440, height: 1000 } },
+      { name: "mobile", size: { width: 390, height: 844 } },
+    ] as const) {
+      test(`no dock, page tiles, real-touch swipe paging, and Chat tile launch on ${viewport.name}`, async ({
+        page,
+      }, testInfo) => {
+        const consoleLines: string[] = [];
+        const pageErrors: string[] = [];
+        const httpErrors: string[] = [];
+        page.on("console", (message) =>
+          consoleLines.push(`${message.type()}: ${message.text()}`),
         );
-      });
+        page.on("pageerror", (e) => pageErrors.push(e.message));
+        page.on("response", (response) => {
+          if (response.status() < 400) return;
+          httpErrors.push(
+            `${response.status()} ${response.request().method()} ${response.url()}`,
+          );
+        });
 
-      await page.setViewportSize(viewport.size);
-      await seedAppStorage(page);
-      await installDefaultAppRoutes(page);
-      await installLauncherEvidenceRoutes(page);
-      await openAppPath(page, "/views");
+        await bootLauncher(page, viewport.size);
 
-      await expect(page.getByTestId("launcher")).toBeVisible({
-        timeout: 60_000,
-      });
-      const firstPage = page.getByTestId("launcher-page-0");
-      // The featured-views dock was removed (#11174): no dock element exists,
-      // and Chat/Settings are ordinary page tiles at the head of page 0.
-      await expect(page.getByTestId("launcher-dock")).toHaveCount(0);
-      await expect(firstPage.getByTestId("launcher-tile-chat")).toBeVisible();
-      await expect(
-        firstPage.getByTestId("launcher-tile-settings"),
-      ).toBeVisible();
-      await expect(
-        firstPage.locator('[data-testid^="launcher-tile-"]').first(),
-      ).toBeVisible();
-      await expect(page.getByTestId("chat-composer-textarea")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Edit" })).toHaveCount(0);
-      await expect(page.getByRole("button", { name: "Done" })).toHaveCount(0);
+        const firstPage = page.getByTestId("launcher-page-0");
+        // The featured-views dock was removed (#11174): no dock element exists,
+        // and Chat/Settings are ordinary page tiles at the head of page 0.
+        await expect(page.getByTestId("launcher-dock")).toHaveCount(0);
+        await expect(firstPage.getByTestId("launcher-tile-chat")).toBeVisible();
+        await expect(
+          firstPage.getByTestId("launcher-tile-settings"),
+        ).toBeVisible();
+        await expect(
+          firstPage.locator('[data-testid^="launcher-tile-"]').first(),
+        ).toBeVisible();
+        await expect(page.getByTestId("chat-composer-textarea")).toBeVisible();
+        await expect(page.getByRole("button", { name: "Edit" })).toHaveCount(0);
+        await expect(page.getByRole("button", { name: "Done" })).toHaveCount(0);
 
-      await page.waitForTimeout(300);
-      await screenshot(page, `${viewport.name}-launcher-page-tiles`);
-      const firstPageTileIds = await tileIds(firstPage);
+        await page.waitForTimeout(300);
+        await screenshot(page, `${viewport.name}-launcher-page-tiles`);
+        const firstPageTileIds = await tileIds(firstPage);
 
-      const secondPage = page.getByTestId("launcher-page-1");
-      let pageAdvanceMethod: "pointer-swipe" | "edge-button" | "single-page" =
-        "single-page";
-      if ((await secondPage.count()) > 0) {
-        pageAdvanceMethod = await swipeLauncherPage(page, "next");
+        // The builtin catalog always curates multiple pages (Apps first, then
+        // the overflow/Developer pages — launcher-curation.ts) — hard-assert
+        // page 1 exists instead of conditionally skipping, so a regression to
+        // a single page can never silently turn the swipe coverage into a
+        // no-op.
+        const secondPage = page.getByTestId("launcher-page-1");
+        await expect(secondPage).toHaveCount(1);
+        await expect(secondPage).toHaveAttribute("aria-hidden", "true");
+        const railBefore = await railGeometry(page);
+
+        // ── Swipe NEXT with a real finger. Page advancement is asserted on
+        // the pager's real state (`aria-hidden` flips with the active page)
+        // AND on the rail's physical transform — never on an edge-button
+        // fallback.
+        await touchSwipeLauncher(page, "next");
         await expect(secondPage).toHaveAttribute("aria-hidden", "false");
+        await expect(firstPage).toHaveAttribute("aria-hidden", "true");
+        await expect
+          .poll(async () => (await railGeometry(page)).x, {
+            message: "rail translates to page 1 after the real-touch swipe",
+          })
+          .toBeLessThan(-railBefore.pageWidth * 0.5);
+        const railAfterNext = await railGeometry(page);
+        // Page 2's tiles are really there (not just an attribute flip).
+        await expect(
+          secondPage.locator('[data-testid^="launcher-tile-"]').first(),
+        ).toBeVisible();
+        const secondPageTileIds = await tileIds(secondPage);
+        expect(secondPageTileIds.length).toBeGreaterThan(0);
         await page.waitForTimeout(300);
         await screenshot(page, `${viewport.name}-launcher-after-swipe`);
-      }
 
-      // Chat launches from its ordinary page tile. Return to page 0 first if
-      // the paging step above advanced (page-1 tiles are inert while inactive).
-      if (pageAdvanceMethod !== "single-page") {
-        await swipeLauncherPage(page, "prev");
+        // ── Swipe PREV back to the Apps page — same real-touch path.
+        await touchSwipeLauncher(page, "prev");
         await expect(firstPage).toHaveAttribute("aria-hidden", "false");
-      }
-      await firstPage
-        .getByTestId("launcher-tile-chat")
-        .locator("button")
-        .click();
-      await expect
-        .poll(() => new URL(page.url()).hash + new URL(page.url()).pathname)
-        .toContain("/chat");
-      await expect(page.getByTestId("chat-composer-textarea")).toBeVisible();
-      await page.waitForTimeout(300);
-      await screenshot(page, `${viewport.name}-chat-tile-launched`);
+        await expect(secondPage).toHaveAttribute("aria-hidden", "true");
+        await expect
+          .poll(async () => (await railGeometry(page)).x, {
+            message: "rail translates back to page 0 after the prev swipe",
+          })
+          .toBeGreaterThan(-railBefore.pageWidth * 0.5);
+        const railAfterPrev = await railGeometry(page);
 
-      const evidence = {
-        viewport: viewport.name,
-        firstPageTiles: firstPageTileIds,
-        pageAdvanceMethod,
-        finalUrl: page.url(),
-        pageErrors,
-        httpErrors,
-        consoleLines,
-      };
-      // Curated "Apps" page order leads with Chat then Settings
-      // (launcher-curation.ts APPS_PAGE_ORDER) — as page tiles, not a dock.
-      expect(evidence.firstPageTiles.slice(0, 2)).toEqual(["chat", "settings"]);
-      expect(pageErrors, "no uncaught page errors").toEqual([]);
-      expect(httpErrors, "no HTTP error responses").toEqual([]);
+        // Chat launches from its ordinary page tile on page 0.
+        await firstPage
+          .getByTestId("launcher-tile-chat")
+          .locator("button")
+          .click();
+        await expect
+          .poll(() => new URL(page.url()).hash + new URL(page.url()).pathname)
+          .toContain("/chat");
+        await expect(page.getByTestId("chat-composer-textarea")).toBeVisible();
+        await page.waitForTimeout(300);
+        await screenshot(page, `${viewport.name}-chat-tile-launched`);
 
-      await writeEvidenceFile(
-        `${viewport.name}-launcher-observations.json`,
-        `${JSON.stringify(evidence, null, 2)}\n`,
-      );
-      await testInfo.attach(`${viewport.name} launcher observations`, {
-        body: JSON.stringify(evidence, null, 2),
-        contentType: "application/json",
+        const evidence = {
+          viewport: viewport.name,
+          firstPageTiles: firstPageTileIds,
+          secondPageTiles: secondPageTileIds,
+          pageAdvance: "real-cdp-touch-swipe" as const,
+          rail: {
+            pageWidth: railBefore.pageWidth,
+            xBefore: railBefore.x,
+            xAfterNextSwipe: railAfterNext.x,
+            xAfterPrevSwipe: railAfterPrev.x,
+          },
+          finalUrl: page.url(),
+          pageErrors,
+          httpErrors,
+          consoleLines,
+        };
+        // Curated "Apps" page order leads with Chat then Settings
+        // (launcher-curation.ts APPS_PAGE_ORDER) — as page tiles, not a dock.
+        expect(evidence.firstPageTiles.slice(0, 2)).toEqual([
+          "chat",
+          "settings",
+        ]);
+        expect(pageErrors, "no uncaught page errors").toEqual([]);
+        expect(httpErrors, "no HTTP error responses").toEqual([]);
+
+        await writeEvidenceFile(
+          `${viewport.name}-launcher-observations.json`,
+          `${JSON.stringify(evidence, null, 2)}\n`,
+        );
+        await testInfo.attach(`${viewport.name} launcher observations`, {
+          body: JSON.stringify(evidence, null, 2),
+          contentType: "application/json",
+        });
       });
-    });
-  }
+    }
+  });
+
+  // The `<`/`>` pager edge buttons are a REAL desktop affordance (#10717:
+  // fine-pointer / hover-capable devices, where the swipe gesture is not the
+  // sole navigation). They get their own explicit assertions here — in the
+  // default non-touch Desktop Chrome context where they actually render —
+  // instead of doubling as a silent fallback inside the swipe test.
+  test("desktop pager edge buttons page next/prev (explicit affordance, not a swipe fallback)", async ({
+    page,
+  }) => {
+    await bootLauncher(page, { width: 1440, height: 1000 });
+
+    const firstPage = page.getByTestId("launcher-page-0");
+    const secondPage = page.getByTestId("launcher-page-1");
+    await expect(secondPage).toHaveCount(1);
+    await expect(firstPage).toHaveAttribute("aria-hidden", "false");
+
+    // On page 0 only the `>` button renders (canPrev is false at the first
+    // page, PagerEdgeButtons self-hides the dead direction).
+    const nextButton = page.getByTestId("launcher-pager-edge-next");
+    await expect(nextButton).toBeVisible();
+    await expect(page.getByTestId("launcher-pager-edge-prev")).toHaveCount(0);
+
+    await nextButton.click();
+    await expect(secondPage).toHaveAttribute("aria-hidden", "false");
+    await expect(firstPage).toHaveAttribute("aria-hidden", "true");
+
+    // And back: off page 0, `<` appears (no assumption that page 1 is the
+    // LAST page — the catalog may curate more than two pages, in which case
+    // `>` legitimately stays visible here).
+    const prevButton = page.getByTestId("launcher-pager-edge-prev");
+    await expect(prevButton).toBeVisible();
+    await prevButton.click();
+    await expect(firstPage).toHaveAttribute("aria-hidden", "false");
+    await expect(secondPage).toHaveAttribute("aria-hidden", "true");
+    // canPrev self-hide re-engages at the first page.
+    await expect(page.getByTestId("launcher-pager-edge-prev")).toHaveCount(0);
+
+    await screenshot(page, "desktop-launcher-edge-buttons");
+  });
 });


### PR DESCRIPTION
## Round 7c — two de-larp fixes for the app's mobile-lifecycle + launcher e2e

Round-7 Fable-subagent sweep across chat/UI/view issues + PRs surfaced two tests that were **green while asserting the wrong thing**. Both are fixed to certify the shipped behavior, verified in both directions (pass on real behavior, fail when the behavior is broken).

### 1. `refactor(app)`: extract the Android back-button contract into `initializeAppLifecycle`

The shipped Android back contract (`dispatchBackIntent()` first → `canGoBack ? history.back() : minimizeApp()`) lived **only inline in `main.tsx` with zero unit coverage**, while `mobile-lifecycle.test.ts` certified a **stale duplicate** in `mobile-lifecycle.ts` (history.back only — no back-intent, no minimize) that `main.tsx` never called. 10 of 15 tests exercised dead code; the "entrypoint wired" test actually pinned the duplicate in place.

- Finished the Phase-5D extraction the network listener already got: the contract now lives in `initializeAppLifecycle` (`mobile-lifecycle.ts`); `main.tsx` delegates via `getMobileLifecycle().initializeAppLifecycle()` and the inline duplicate + its dead module state/imports are deleted (**−92 lines in `main.tsx`**). Status-bar/keyboard wiring stays in `main.tsx` (preserves the network-extraction split).
- Tests now assert the **live** contract: handled back-intent → early return; unhandled + canGoBack → `history.back`; unhandled + !canGoBack → `minimizeApp`; plus a delegation guard that `main.tsx` has no inline `backButton`/`appStateChange`/`visibilitychange` wiring.

### 2. `test(app)`: drive launcher paging with real CDP touch, delete the silent edge-button fallback

`launcher-interaction.spec.ts` paged via **synthetic** `pageWindow.dispatchEvent('pointerdown'/'pointermove'/'pointerup', {pointerType:'touch'})` — bypassing the browser hit-test, `touch-action: pan-y`, and implicit touch capture (the exact anti-pattern #10722 de-larps) — and ran on the chromium project (`hasTouch:false`) where real touch could never be delivered. Worse, it had a **silent always-available fallback**: if the "swipe" didn't flip `aria-hidden` it just clicked `launcher-pager-edge-<dir>` and returned `edge-button`, so the test stayed green with touch paging completely broken. Swipe coverage was also conditionally skippable.

- Rewrote to **real CDP touch** via the shared `touchSwipe` (`Input.dispatchTouchEvent`, dx±280/steps10/stepDelayMs16 — same params as the boot-free launcher runner), under `test.use({hasTouch:true})` like `chat-clear-swipe`. Assertions on **real page advancement only, no fallback**: `launcher-page-1[aria-hidden=false]` / `launcher-page-0[aria-hidden=true]`, `expect.poll` on the rail transform X crossing −pageWidth/2, page-2 tiles visible, then a real prev-swipe back. Page 1 is hard-asserted (`toHaveCount 1`), not skipped.
- Edge buttons kept as a **separate explicit test** in the non-touch fine-pointer context where `PagerEdgeButtons` actually renders.

## Evidence (real runs, post-rebase onto current develop)

- **`mobile-lifecycle.test.ts`** — `bun run --cwd packages/app test test/mobile-lifecycle.test.ts` → **17/17 passed** (13 now exercise the module `main.tsx` actually calls; 3 dedicated to the back contract, 1 delegation guard). `tsgo` clean after the `main.tsx` deletion; biome clean.
- **`launcher-interaction.spec.ts`** — `playwright --project=chromium` (Node 24, `ELIZA_UI_SMOKE_FORCE_STUB=1`) → **3/3 passed (1.4m)**: desktop real-touch paging, mobile real-touch paging, edge-button explicit test. Evidence JSON records `pageAdvance: "real-cdp-touch-swipe"` with the rail transform moving 0 → −1214px (desktop) / 0 → −317px (mobile), zero page/HTTP errors.
- **Falsification (proves the assertions bite):**
  - Back contract: swapping any branch (drop the back-intent early return, or `history.back` ↔ `minimizeApp`) reddens the dedicated case.
  - Launcher swipe: a sub-threshold 20px real drag (below the pager's 48px flick minimum) **fails both swipe tests** on the `aria-hidden` assert while the edge-button test still passes — the swipe now detects broken paging and edge buttons can no longer mask it.
- **WebKit cross-engine** — `chat-overlay-controls-interactions.spec.ts` on `--project=webkit` (`PLAYWRIGHT_WEBKIT=1`) → **4/4 passed** (confirms the `-webkit-user-select` probe from #11103's sibling fix; unrelated to this diff but re-verified in the same sweep).

## Scope

4 files: `packages/app/src/main.tsx`, `packages/app/src/mobile-lifecycle.ts`, `packages/app/test/mobile-lifecycle.test.ts`, `packages/app/test/ui-smoke/launcher-interaction.spec.ts`. No runtime behavior change — the back-button contract is byte-for-byte the shipped logic, relocated; the launcher change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)