### PR TITLE
fix(ci): unhang MAIN prod deploys — port bun/cache/timeout fixes to main (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -204,7 +204,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -222,8 +222,8 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_cache="${HOME}/.bun-install-cache-deploy"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
@@ -507,7 +507,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -525,8 +525,8 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_cache="${HOME}/.bun-install-cache-deploy"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
@@ -841,7 +841,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -859,8 +859,8 @@ jobs:
         # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
-          install_cache="$PWD/.bun-install-cache"
-          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
+          install_cache="${HOME}/.bun-install-cache-deploy"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-2400}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"


### PR DESCRIPTION
Prod deploys run from **main** (production env allows only main), but main's cloud-cf-deploy still has the install-hang config (bun canary + /tmp cache + 900s). Ports the 3 fixes already on develop (#11235/#11268/#11304) so a main deploy can actually install. After merge, a main-push deploy: install OK → migrate-db (branch=main ✓, awaits required-reviewer) → Worker/Pages deploy → **money-integrity wave live**. CI-only. @lalalune — needs your merge to main + the prod-env reviewer approval. `[cloud-audit]`