### PR TITLE
fix(openrouter): surface live stream provider errors

### DIFF
--- a/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
@@ -270,6 +270,58 @@ describe("OpenRouter native text plumbing", () => {
     expect(call.providerOptions).toBeUndefined();
   });
 
+  it("rejects live streaming when the provider reports an async stream error", async () => {
+    const providerError = new Error("provider stream failed");
+    const streamText = vi.fn((params: { onError?: (event: { error: unknown }) => void }) => {
+      params.onError?.({ error: providerError });
+      return {
+        textStream: (async function* emptyStream() {})(),
+        text: Promise.resolve(""),
+        usage: Promise.resolve(undefined),
+        finishReason: Promise.resolve("stop"),
+      };
+    });
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(),
+      streamText,
+    }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({
+        chat: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = (await handleTextSmall(createRuntime(), {
+      prompt: "stream this",
+      stream: true,
+    } as never)) as {
+      text: Promise<string>;
+      textStream: AsyncIterable<string>;
+      finishReason: Promise<string | undefined>;
+    };
+
+    const collect = async () => {
+      const chunks: string[] = [];
+      for await (const chunk of result.textStream) {
+        chunks.push(chunk);
+      }
+      return chunks.join("");
+    };
+
+    const textRejects = expect(result.text).rejects.toThrow("provider stream failed");
+    const finishReasonRejects = expect(result.finishReason).rejects.toThrow(
+      "provider stream failed"
+    );
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+    await expect(collect()).rejects.toThrow("provider stream failed");
+    await textRejects;
+    await finishReasonRejects;
+  });
+
   it("rejects malformed text params before invoking the provider model", async () => {
     const generateText = vi.fn();
     const chat = vi.fn();

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -315,6 +315,16 @@ function usesNativeTextResult(params: GenerateTextParamsWithAttachments): boolea
   return Boolean(params.messages || params.tools || params.toolChoice || params.responseSchema);
 }
 
+function handledPromise<T>(value: T | PromiseLike<T>): Promise<T> {
+  const promise = Promise.resolve(value);
+  promise.catch(() => {
+    // Streaming callers commonly consume textStream only. Companion promises
+    // should still reject when awaited, but must not produce unhandled
+    // rejections when a caller ignores them.
+  });
+  return promise;
+}
+
 type TextModelType =
   | typeof TEXT_NANO_MODEL_TYPE
   | typeof ModelType.TEXT_SMALL
@@ -497,14 +507,39 @@ function handleStreamingGeneration(
   modelLabel: string,
   shouldReturnNativeResult: boolean
 ): TextStreamResult {
-  const streamResult = streamText(generateParams);
-  const usagePromise = Promise.resolve(streamResult.usage).then((usage) => {
-    if (!usage) {
-      return undefined;
-    }
-
-    return emitModelUsageEvent(runtime, modelType, prompt, usage, modelName, modelLabel);
+  let capturedStreamError: unknown;
+  const streamResult = streamText({
+    ...(generateParams as Parameters<typeof streamText>[0]),
+    onError: ({ error }: { error: unknown }) => {
+      capturedStreamError = error;
+    },
   });
+  const finishReasonPromise = handledPromise(
+    Promise.resolve(streamResult.finishReason).then((finishReason) => {
+      if (capturedStreamError) {
+        throw capturedStreamError;
+      }
+      return finishReason as string | undefined;
+    })
+  );
+  const usagePromise = handledPromise(
+    Promise.resolve(streamResult.usage).then(async (usage) => {
+      await finishReasonPromise;
+      if (!usage) {
+        return undefined;
+      }
+
+      return emitModelUsageEvent(runtime, modelType, prompt, usage, modelName, modelLabel);
+    })
+  );
+  const toolCallsPromise = shouldReturnNativeResult
+    ? handledPromise(
+        Promise.resolve(streamResult.toolCalls).then(async (toolCalls) => {
+          await finishReasonPromise;
+          return toolCalls;
+        })
+      )
+    : undefined;
   const ignoreUsageError = (): undefined => undefined;
 
   async function* textStreamWithUsage(): AsyncIterable<string> {
@@ -513,6 +548,7 @@ function handleStreamingGeneration(
       for await (const chunk of streamResult.textStream) {
         yield chunk;
       }
+      await finishReasonPromise;
       completed = true;
     } finally {
       if (completed) {
@@ -523,13 +559,16 @@ function handleStreamingGeneration(
 
   return {
     textStream: textStreamWithUsage(),
-    text: Promise.resolve(streamResult.text).then(async (text) => {
-      await usagePromise.catch(ignoreUsageError);
-      return text;
-    }),
-    ...(shouldReturnNativeResult ? { toolCalls: Promise.resolve(streamResult.toolCalls) } : {}),
+    text: handledPromise(
+      Promise.resolve(streamResult.text).then(async (text) => {
+        await finishReasonPromise;
+        await usagePromise.catch(ignoreUsageError);
+        return text;
+      })
+    ),
+    ...(toolCallsPromise ? { toolCalls: toolCallsPromise } : {}),
     usage: usagePromise,
-    finishReason: Promise.resolve(streamResult.finishReason) as Promise<string | undefined>,
+    finishReason: finishReasonPromise,
   };
 }
 


### PR DESCRIPTION
## What

Fixes #11266 by making the OpenRouter live-streaming text path treat AI SDK `streamText` provider errors as failed calls instead of successful empty replies.

Changes:
- pass `onError` into `streamText()` and capture async provider stream errors
- await `finishReason` after `textStream` consumption so the stream lifecycle settles before reporting success
- make companion promises (`text`, `finishReason`, `usage`, `toolCalls`) preserve rejection when awaited without causing unhandled rejections when a caller only consumes `textStream`
- add a regression shape test that simulates `onError` + empty stream and asserts the stream/text/finish promises reject

## Evidence

Windows local validation:
- `git diff --check origin/develop...HEAD` passed
- `bunx @biomejs/biome@2.5.2 check plugins/plugin-openrouter/models/text.ts plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts` passed
- `NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd plugins/plugin-openrouter typecheck` passed
- `NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd plugins/plugin-openrouter test -- __tests__/native-plumbing.shape.test.ts` passed: 10/10
- `NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd plugins/plugin-openrouter test -- --testTimeout 120000` passed: 5 files, 29/29
- `NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd plugins/plugin-openrouter build` passed

Note: the full OpenRouter suite hit the local Windows/Vitest default 60s timeout in the dynamic-import-heavy native plumbing file on the first full-suite attempt; rerunning the same suite with `--testTimeout 120000` passed cleanly.

Live OpenRouter key / trajectory evidence: N/A for this local patch; regression is covered by a provider-shape unit test because no live OpenRouter key is available in this Windows workspace.