### PR TITLE
fix(ci): pin the migrate-db gate's bun off canary like every sibling deploy job (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -124,7 +124,11 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary` like every other job in this workflow (#10839):
+          # the deploy-critical path does not gamble on canary regressions even
+          # on GitHub-hosted runners (the link-phase hang stranded two prod
+          # deploys this week).
+          bun-version: "latest"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Follow-up caught in #11289 review (my pin commit raced the merge and missed it): the new migrate-db job — now the schema gate every deploy job needs — was the one job in cloud-cf-deploy.yml still on bun canary after #11235 pinned the rest, post the link-phase hang that stranded two prod deploys (runs 28552075615, 28569068598). The hang was observed on self-hosted runners and this job is GitHub-hosted, but a canary regression here now fail-closed-blocks EVERY deploy — the critical path shouldn't gamble on canary at all.

One-line pin to `latest` with the same rationale comment the sibling jobs carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)