### PR TITLE
fix(openai): emit usage for live streams

### DIFF
--- a/.github/issue-evidence/11265-openai-stream-usage.md
+++ b/.github/issue-evidence/11265-openai-stream-usage.md
@@ -1,0 +1,117 @@
+# Issue #11265 evidence: OpenAI streamed usage + trajectory response
+
+Branch: `fix/11265-openai-stream-usage-final`
+Base: `origin/develop@8bed05c1718`
+Date: 2026-07-02
+
+## What changed
+
+- `plugins/plugin-openai/models/text.ts` now records live streaming telemetry after
+  the returned `textStream` is consumed, not at stream construction time.
+- The stream generator accumulates emitted chunks, resolves `usage` and
+  `finishReason` in `finally`, emits `MODEL_USED`, and logs the LLM trajectory
+  with the real streamed response text.
+- Regression coverage asserts the trajectory is not logged before stream
+  consumption, then proves `MODEL_USED` and trajectory response/usage are present
+  after consumption.
+
+## Focused verification
+
+```bash
+bun install --frozen-lockfile
+bun run --cwd packages/core prebuild
+bun run --cwd packages/core build:node
+bun run --cwd plugins/plugin-openai test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000
+bun run --cwd plugins/plugin-openai test
+bun run --cwd plugins/plugin-openai typecheck
+bun run --cwd plugins/plugin-openai lint:check
+bun run --cwd plugins/plugin-openai build
+git diff --check
+```
+
+Results:
+
+- Focused native plumbing test: 1 file, 13 tests passed.
+- Full `plugin-openai` unit suite: 7 files passed, 1 skipped; 80 tests passed, 3 skipped.
+- `plugin-openai` typecheck: passed.
+- `plugin-openai` lint: passed.
+- `plugin-openai` build: passed.
+- `git diff --check`: passed.
+
+## Live provider proof
+
+No `OPENAI_API_KEY` was present in the shell, but `CEREBRAS_API_KEY` was
+available. Since `plugin-openai` supports Cerebras through its OpenAI-compatible
+endpoint, I ran a targeted live stream with:
+
+```bash
+OPENAI_API_KEY="$CEREBRAS_API_KEY" \
+OPENAI_BASE_URL=https://api.cerebras.ai/v1 \
+ELIZA_PROVIDER=cerebras \
+bun -e '<script imports handleTextSmall, consumes textStream, captures runtime events + trajectory log>'
+```
+
+Manually reviewed output:
+
+```json
+{
+  "streamed": "live stream telemetry ok",
+  "fullText": "live stream telemetry ok",
+  "usage": {
+    "promptTokens": 30,
+    "completionTokens": 5,
+    "totalTokens": 35,
+    "cachedPromptTokens": 0,
+    "cacheReadInputTokens": 0
+  },
+  "finishReason": "stop",
+  "modelUsedEvents": [
+    {
+      "type": "TEXT_SMALL",
+      "source": "openai",
+      "provider": "openai",
+      "tokens": {
+        "prompt": 30,
+        "completion": 5,
+        "total": 35,
+        "cached": 0
+      }
+    }
+  ],
+  "trajectoryCalls": [
+    {
+      "stepId": "issue-11265-live",
+      "actionType": "ai.streamText",
+      "response": "live stream telemetry ok",
+      "finishReason": "stop",
+      "promptTokens": 30,
+      "completionTokens": 5,
+      "latencyMs": 192
+    }
+  ]
+}
+```
+
+This proves the real streamed provider path no longer records an empty
+trajectory response and no longer drops `MODEL_USED`.
+
+## Additional note
+
+I also attempted the pre-existing `cloud-streaming.live.test.ts` against the
+Cerebras-backed OpenAI-compatible endpoint. It reached the live provider and
+streamed, but failed its old wall-clock assertion because all chunks arrived in
+the same millisecond (`distinctTimes` was 1). That failure is orthogonal to
+#11265; the targeted live proof above validates this issue's telemetry behavior.
+
+## Repo-level verify
+
+`bun run verify` still fails before typecheck/lint at the current `develop`
+type-safety ratchet baseline:
+
+```text
+[type-safety-ratchet] unsafe cast baseline exceeded
+  - as unknown as: 80 current > 77 baseline
+  - `?? {}` (core/agent/app-core): 379 current > 377 baseline
+```
+
+The changed production source does not add either pattern.

--- a/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
@@ -289,11 +289,7 @@ Sample leaked refusal: ${bucket.samples.leak ? `"${bucket.samples.leak}"` : "(no
 
 const TRIALS = Number.parseInt(process.env.CEREBRAS_REFUSAL_TRIALS ?? "20", 10);
 const TIMEOUT_MS = TRIALS * 20_000 + 30_000;
-const CEREBRAS_REFUSAL_MODELS = [
-  "gemma-4-31b",
-  "gpt-oss-120b",
-  "zai-glm-4.7",
-] as const;
+const CEREBRAS_REFUSAL_MODELS = ["gemma-4-31b", "gpt-oss-120b", "zai-glm-4.7"] as const;
 
 liveDescribe("Cerebras `spawn sub-agent` Stage-1 refusal suppression — elizaOS/eliza#7620", () => {
   for (const model of CEREBRAS_REFUSAL_MODELS) {

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -1,4 +1,5 @@
 import type { IAgentRuntime } from "@elizaos/core";
+import { EventType, runWithTrajectoryContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const aiMocks = vi.hoisted(() => ({
@@ -299,6 +300,73 @@ describe("OpenAI native text plumbing", () => {
     expect(chunks).toEqual(["hel", "lo"]);
     expect(onStreamChunk).toHaveBeenNthCalledWith(1, "hel");
     expect(onStreamChunk).toHaveBeenNthCalledWith(2, "lo");
+  });
+
+  it("emits streamed usage and records the consumed stream response in the trajectory", async () => {
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* textStream() {
+        yield "hel";
+        yield "lo";
+      })(),
+      text: Promise.resolve("hello"),
+      toolCalls: Promise.resolve([]),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 4, outputTokens: 2, cachedInputTokens: 1 }),
+    });
+
+    const runtime = createRuntime();
+    const trajectoryLogger = {
+      isEnabled: () => true,
+      logLlmCall: vi.fn(),
+    };
+    vi.mocked(runtime.getService).mockImplementation((name: string) =>
+      name === "trajectories" ? trajectoryLogger : null
+    );
+    vi.mocked(runtime.getServicesByType).mockImplementation((type: string) =>
+      type === "trajectories" ? [trajectoryLogger] : []
+    );
+
+    const { handleTextSmall } = await import("../models/text");
+    await runWithTrajectoryContext({ trajectoryStepId: "step-openai-stream" }, async () => {
+      const stream = (await handleTextSmall(runtime, {
+        prompt: "stream",
+        stream: true,
+      } as never)) as { textStream: AsyncIterable<string> };
+
+      expect(trajectoryLogger.logLlmCall).not.toHaveBeenCalled();
+
+      const chunks: string[] = [];
+      for await (const chunk of stream.textStream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.join("")).toBe("hello");
+    });
+
+    expect(runtime.emitEvent).toHaveBeenCalledWith(
+      EventType.MODEL_USED,
+      expect.objectContaining({
+        source: "openai",
+        type: "TEXT_SMALL",
+        tokens: {
+          prompt: 4,
+          completion: 2,
+          total: 6,
+          cached: 1,
+        },
+      })
+    );
+    expect(trajectoryLogger.logLlmCall).toHaveBeenCalledTimes(1);
+    expect(trajectoryLogger.logLlmCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepId: "step-openai-stream",
+        actionType: "ai.streamText",
+        response: "hello",
+        finishReason: "stop",
+        promptTokens: 4,
+        completionTokens: 2,
+      })
+    );
   });
 
   it("maps string responseFormat json_object into the AI SDK responseFormat", async () => {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -12,8 +12,10 @@ import type {
   RecordLlmCallDetails,
 } from "@elizaos/core";
 import {
+  assertActiveTrajectoryForLlmCall,
   buildCanonicalSystemPrompt,
   dropDuplicateLeadingSystemMessage,
+  logActiveTrajectoryLlmCall,
   logger,
   ModelType,
   normalizeSchemaForCerebras,
@@ -906,6 +908,12 @@ function handledPromise<T>(value: T | PromiseLike<T>): Promise<T> {
   return promise;
 }
 
+function getNowMs(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
 function handledMappedPromise<T, U>(
   value: T | PromiseLike<T>,
   mapper: (resolved: T) => U | PromiseLike<U>
@@ -1087,7 +1095,6 @@ async function generateTextWithTransientRetry(
   maxRetries = 3
 ): Promise<Awaited<ReturnType<typeof generateText<ToolSet>>>> {
   let attempt = 0;
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK's generateText overloads can't infer our NativeGenerateTextParams across the generic boundary.
   for (;;) {
     try {
       return (await generateText(
@@ -1333,13 +1340,54 @@ async function generateTextByModelType(
       generateParams
     );
     details.response = "";
-    const result = await recordLlmCall(runtime, details, () => streamText(generateParams));
+    assertActiveTrajectoryForLlmCall({
+      actionType: details.actionType,
+      model: details.model,
+      modelType,
+      purpose: details.purpose,
+    });
+    const streamStartedAt = getNowMs();
+    const result = await streamText(generateParams);
+    let finalizedStreamTelemetry = false;
+    const finalizeStreamTelemetry = async (response: string): Promise<void> => {
+      if (finalizedStreamTelemetry) {
+        return;
+      }
+      finalizedStreamTelemetry = true;
+
+      details.response = response;
+      const usage = await result.usage;
+      const finishReason = (await result.finishReason) as string | undefined;
+      details.finishReason = finishReason;
+
+      if (shouldReturnNativeResult) {
+        const toolCalls = await result.toolCalls;
+        details.toolCalls = toolCalls;
+      }
+
+      if (usage) {
+        applyUsageToDetails(details, usage);
+        emitModelUsageEvent(runtime, modelType, params.prompt ?? "", usage);
+      }
+
+      logActiveTrajectoryLlmCall(runtime, {
+        ...details,
+        response,
+        latencyMs: Math.max(0, Math.round(getNowMs() - streamStartedAt)),
+      });
+    };
 
     return {
       textStream: (async function* textStreamWithCallback() {
-        for await (const chunk of result.textStream) {
-          params.onStreamChunk?.(chunk);
-          yield chunk;
+        let streamedText = "";
+        try {
+          for await (const chunk of result.textStream) {
+            streamedText += chunk;
+            params.onStreamChunk?.(chunk);
+            yield chunk;
+          }
+        } finally {
+          await finalizeStreamTelemetry(streamedText);
         }
       })(),
       text: handledPromise(result.text),


### PR DESCRIPTION
## Summary
- delay plugin-openai live-stream trajectory logging until `textStream` consumption completes
- accumulate streamed chunks and use the real response text in the provider trajectory entry
- resolve streaming usage/finish reason in the generator `finally` path and emit `MODEL_USED` for streamed chat turns
- add a regression proving no early empty trajectory log, plus post-consumption usage/event/trajectory capture

Closes #11265.

## Evidence
- `.github/issue-evidence/11265-openai-stream-usage.md`
- Live provider proof used the available `CEREBRAS_API_KEY` through plugin-openai's OpenAI-compatible Cerebras endpoint and manually reviewed the streamed text, usage, `MODEL_USED`, and trajectory response.

## Verification
- `bun install --frozen-lockfile`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/core build:node`
- `bun run --cwd plugins/plugin-openai test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000`
- `bun run --cwd plugins/plugin-openai test`
- `bun run --cwd plugins/plugin-openai typecheck`
- `bun run --cwd plugins/plugin-openai lint:check`
- `bun run --cwd plugins/plugin-openai build`
- `git diff --check`

## Repo Verify
`bun run verify` still fails before typecheck/lint at the current `develop` type-safety ratchet baseline: `as unknown as: 80 > 77` and ``?? {}``: 379 > 377. The changed production source adds neither pattern.