### PR TITLE
fix(mobile): dead capacitor-llama bridge captures TEXT slots — Android local chat provider error (#11321)

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -997,6 +997,24 @@ public class ElizaAgentService extends Service {
         return extractedFile;
     }
 
+    /**
+     * Resolve a bundled native lib across BOTH packaging channels (#11277).
+     * The legacy assets contract stages libs under assets/agent/{abi}/ (the
+     * {@code abiDir} passed in, populated only when the build set
+     * ELIZA_AOSP_LLAMA_ASSET_DIR*); current builds ship them as jniLibs, which
+     * the installer extracts into {@link #nativeLibraryDir()}. Prefer the
+     * extracted assets copy when present, else fall back to the jniLibs copy —
+     * so a jniLibs-only APK still resolves the fused inference lib instead of
+     * booting with no inference mode at all.
+     */
+    private File resolveBundledNativeLib(File abiDir, String soname) {
+        File assetsCopy = new File(abiDir, soname);
+        if (assetsCopy.isFile() && assetsCopy.length() > 0) {
+            return assetsCopy;
+        }
+        return new File(nativeLibraryDir(), soname);
+    }
+
     private boolean linkPackagedRuntimeLibrary(
         File abiDir,
         String soname,
@@ -1465,10 +1483,25 @@ public class ElizaAgentService extends Service {
             // activates on any APK that predates the fused-lib cutover (where
             // only libllama.so + shim were staged). Once libllama.so stops
             // being built the fused lib alone trips the gate.
-            File abiFusedInference = new File(abiDir, "libelizainference.so");
-            File abiLibllama = new File(abiDir, "libllama.so");
-            File abiLlamaShim = new File(abiDir, "libeliza-llama-shim.so");
-            File abiGgmlVulkan = new File(abiDir, "libggml-vulkan.so");
+            //
+            // The libs ship through TWO packaging channels and the gate must
+            // accept either (#11277): the legacy assets contract stages them
+            // under assets/agent/{abi}/ (extracted into abiDir above, only
+            // populated when the build host set ELIZA_AOSP_LLAMA_ASSET_DIR*),
+            // while current builds ship them as jniLibs, extracted by the
+            // installer into nativeLibraryDir() — the same dir LD_LIBRARY_PATH
+            // and the voice host (ensureBionicVoiceHost) already use. Gating
+            // on abiDir alone left jniLibs-only APKs with NO inference mode at
+            // all: no bionic delegation, no ELIZA_LOCAL_LLAMA — the agent booted
+            // with only the (unattachable) device bridge and every chat turn
+            // failed with DEVICE_DISCONNECTED.
+            File abiFusedInference =
+                resolveBundledNativeLib(abiDir, "libelizainference.so");
+            File abiLibllama = resolveBundledNativeLib(abiDir, "libllama.so");
+            File abiLlamaShim =
+                resolveBundledNativeLib(abiDir, "libeliza-llama-shim.so");
+            File abiGgmlVulkan =
+                resolveBundledNativeLib(abiDir, "libggml-vulkan.so");
             boolean fusedInferenceBundled = abiFusedInference.isFile();
             boolean legacyLibllamaBundled = abiLibllama.isFile() && abiLlamaShim.isFile();
             boolean nativeLlamaBundled = fusedInferenceBundled || legacyLibllamaBundled;

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.gating.test.ts
@@ -1,0 +1,72 @@
+// Regression: the capacitor-llama TEXT handlers must NOT be registered while
+// nothing can serve them. On Android the WebView-side llama-cpp-capacitor
+// plugin is retired (#9560 one-bionic-path cutover), so the WS device bridge
+// can never attach; if the handlers register anyway they win `useModel`
+// routing at priority 0 and every chat turn dies with
+// "DEVICE_DISCONNECTED: no Capacitor llama device bridge attached" (#11277).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// SERVICE_ENABLED is read at module load, so enable the bridge before importing.
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+
+const ENV_KEYS = [
+	"ELIZA_LOCAL_LLAMA",
+	"ELIZA_BIONIC_HOST_DELEGATED",
+	"ELIZA_BIONIC_INFERENCE_SOCK",
+];
+const saved: Record<string, string | undefined> = {};
+
+function fakeRuntime() {
+	return {
+		registerModel: vi.fn(),
+		getModel: vi.fn(() => undefined),
+	};
+}
+
+describe("ensureMobileDeviceBridgeInferenceHandlers — dead-bridge gating (#11277)", () => {
+	beforeEach(() => {
+		for (const k of ENV_KEYS) {
+			saved[k] = process.env[k];
+			delete process.env[k];
+		}
+	});
+	afterEach(() => {
+		for (const k of ENV_KEYS) {
+			if (saved[k] === undefined) delete process.env[k];
+			else process.env[k] = saved[k];
+		}
+	});
+
+	it("does NOT register TEXT handlers when neither the bionic host nor a device bridge can serve", async () => {
+		const { ensureMobileDeviceBridgeInferenceHandlers, mobileDeviceBridge } =
+			await import("./mobile-device-bridge-bootstrap");
+		// No server attached → no device connected.
+		expect(mobileDeviceBridge.status().connected).toBe(false);
+
+		const runtime = fakeRuntime();
+		const registered = await ensureMobileDeviceBridgeInferenceHandlers(
+			runtime as never,
+		);
+
+		expect(registered).toBe(false);
+		// The critical assertion: the dead provider must not capture the slots.
+		expect(runtime.registerModel).not.toHaveBeenCalled();
+	});
+
+	it("registers immediately when the in-process bionic host is delegated (it can serve)", async () => {
+		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-inference-sock";
+		const { ensureMobileDeviceBridgeInferenceHandlers } = await import(
+			"./mobile-device-bridge-bootstrap"
+		);
+
+		const runtime = fakeRuntime();
+		const registered = await ensureMobileDeviceBridgeInferenceHandlers(
+			runtime as never,
+		);
+
+		expect(registered).toBe(true);
+		// TEXT_SMALL + TEXT_LARGE at minimum register through the served path.
+		expect(runtime.registerModel).toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -336,6 +336,7 @@ export interface MobileDeviceBridgeStatus {
 class MobileDeviceBridge {
 	private wss: WssInstance | null = null;
 	private readonly devices = new Map<string, ConnectedDevice>();
+	private readonly attachListeners = new Set<() => void>();
 	private readonly pendingLoads = new Map<string, Pending<void>>();
 	private readonly pendingUnloads = new Map<string, Pending<void>>();
 	private readonly pendingGenerates = new Map<string, Pending<string>>();
@@ -468,6 +469,7 @@ class MobileDeviceBridge {
 				logger.info(
 					`[mobile-device-bridge] Device connected: ${registeredDeviceId} (${msg.payload.capabilities.platform})`,
 				);
+				this.notifyDeviceAttached();
 				return;
 			}
 
@@ -571,6 +573,22 @@ class MobileDeviceBridge {
 			} else {
 				pending.reject(new Error(msg.error));
 			}
+		}
+	}
+
+	/**
+	 * Subscribe to real device-bridge attachment. Model handlers are only
+	 * registered once a bridge that can actually serve them exists, so the
+	 * bootstrap defers registration through this hook when neither the bionic
+	 * host nor a connected device is available at boot.
+	 */
+	onDeviceAttached(listener: () => void): void {
+		this.attachListeners.add(listener);
+	}
+
+	private notifyDeviceAttached(): void {
+		for (const listener of this.attachListeners) {
+			listener();
 		}
 	}
 
@@ -1782,14 +1800,18 @@ function makeBionicImageDescriptionHandler() {
 	};
 }
 
-export async function ensureMobileDeviceBridgeInferenceHandlers(
+/**
+ * Register the capacitor-llama TEXT/embedding handlers on the runtime.
+ *
+ * Callers must ensure a serving path actually exists first (bionic host
+ * delegation, or an attached device bridge): registering these handlers
+ * while nothing can serve them makes the dead provider win `useModel`
+ * routing and every chat turn fails with DEVICE_DISCONNECTED (#11277).
+ */
+function registerMobileDeviceBridgeModels(
 	runtime: AgentRuntime,
-): Promise<boolean> {
-	logger.debug("[mobile-device-bridge] Bootstrap entered");
-	if (!SERVICE_ENABLED || process.env.ELIZA_LOCAL_LLAMA?.trim() === "1") {
-		logger.debug("[mobile-device-bridge] Disabled or AOSP local llama active");
-		return false;
-	}
+	trigger: "bionic-host" | "device-bridge",
+): boolean {
 	if (registeredRuntimes.has(runtime)) {
 		logger.debug("[mobile-device-bridge] Handlers already registered");
 		return true;
@@ -1875,8 +1897,52 @@ export async function ensureMobileDeviceBridgeInferenceHandlers(
 	}
 
 	logger.info(
-		`[mobile-device-bridge] Registered ${PROVIDER} handlers for TEXT_SMALL / TEXT_LARGE${embeddingModelPath ? " / TEXT_EMBEDDING" : ""} at priority ${LOCAL_INFERENCE_PRIORITY}`,
+		`[mobile-device-bridge] Registered ${PROVIDER} handlers for TEXT_SMALL / TEXT_LARGE${embeddingModelPath ? " / TEXT_EMBEDDING" : ""} at priority ${LOCAL_INFERENCE_PRIORITY} (via ${trigger})`,
 	);
 	registeredRuntimes.add(runtime);
 	return true;
+}
+
+export async function ensureMobileDeviceBridgeInferenceHandlers(
+	runtime: AgentRuntime,
+): Promise<boolean> {
+	logger.debug("[mobile-device-bridge] Bootstrap entered");
+	if (!SERVICE_ENABLED || process.env.ELIZA_LOCAL_LLAMA?.trim() === "1") {
+		logger.debug("[mobile-device-bridge] Disabled or AOSP local llama active");
+		return false;
+	}
+	if (registeredRuntimes.has(runtime)) {
+		logger.debug("[mobile-device-bridge] Handlers already registered");
+		return true;
+	}
+
+	// Bionic-host delegation: the in-process GPU host serves TEXT/embed over
+	// the abstract UDS, so the handlers are live from boot.
+	if (bionicSocketName()) {
+		return registerMobileDeviceBridgeModels(runtime, "bionic-host");
+	}
+
+	// A device bridge is already attached (agent restart while the WebView
+	// stayed connected): the handlers can serve immediately.
+	if (mobileDeviceBridge.status().connected) {
+		return registerMobileDeviceBridgeModels(runtime, "device-bridge");
+	}
+
+	// Neither the bionic host nor a device bridge can serve a call right now.
+	// Do NOT register the handlers: a registered-but-dead capacitor-llama
+	// provider owns the TEXT slots, wins `useModel` routing, and turns every
+	// chat turn into "DEVICE_DISCONNECTED: no Capacitor llama device bridge
+	// attached" (#11277 — on Android the WebView-side llama-cpp-capacitor
+	// plugin is retired, so the WS bridge can never attach). Instead, defer
+	// registration until a device genuinely attaches; until then `useModel`
+	// fails loud with NoModelProviderConfiguredError, which the chat UI
+	// renders as an actionable "no provider configured" hint.
+	logger.warn(
+		"[mobile-device-bridge] No bionic host delegation and no device bridge attached — " +
+			`${PROVIDER} TEXT handlers stay unregistered until a device bridge connects`,
+	);
+	mobileDeviceBridge.onDeviceAttached(() => {
+		registerMobileDeviceBridgeModels(runtime, "device-bridge");
+	});
+	return false;
 }


### PR DESCRIPTION
## What

Closes #11321. **Android local chat was broken for all users** — every turn returned "Sorry, I'm having a provider issue". Two coupled root causes, both traced live on a Pixel 6a; see the issue for full device logs.

1. **Dead-bridge handler capture.** `mobile-device-bridge` registered `capacitor-llama` TEXT_SMALL/TEXT_LARGE/TEXT_EMBEDDING handlers at priority 0 unconditionally, but the WebView-side `llama-cpp-capacitor` plugin was retired in the one-bionic-path cutover (#9560) — the WS bridge can never attach on Android, so those handlers won `useModel` routing and every generation died with `DEVICE_DISCONNECTED`. Now handlers register **only when a serving path exists**: bionic-host delegation at boot, or a genuinely attached device bridge via a new `onDeviceAttached` hook. Otherwise routing falls through to the real local-inference provider / fails loud.

2. **jniLibs-only APK detected no inference mode.** `ElizaAgentService` gated fused-lib detection on the `assets/agent/{abi}/` channel only; current builds ship the fused lib as jniLibs (extracted to `nativeLibraryDir()`), so `nativeLlamaBundled` was false → no bionic delegation, no `ELIZA_LOCAL_LLAMA`, and the voice route couldn't find `libelizainference.so` either. New `resolveBundledNativeLib` helper accepts **either** channel, so a jniLibs-only APK stands up the in-process bionic host that serves both TEXT and voice.

## Evidence

| Type | Result |
|---|---|
| Regression test | `mobile-device-bridge-bootstrap.gating.test.ts` — 2/2: dead-bridge case does NOT register handlers; bionic-host-delegated case does. |
| Existing tests | `mobile-device-bridge-bootstrap.mtp.test.ts` 7/7 green (no regression). |
| Typecheck | touched TS clean (`tsgo` — no errors in `mobile-device-bridge-bootstrap.ts`). |
| Java compile | `:app:compileDebugJavaWithJavac` **BUILD SUCCESSFUL** — validates the `ElizaAgentService` edits. |
| On-device | Boot + provider selection re-verify on the Pixel 6a is queued on the main loop once this lands (the bug was captured live; the fix's device confirmation is the last step). |

## Notes for reviewers

- **Depends on #11276 / #11248:** develop HEAD currently has the #11248 mobile-bundle load crash re-introduced by a stale-tree clobber in `5b714c74e6` (#11271). #11276 restores it. The agent bundle must load before this routing fix can be exercised on-device; I cherry-picked #11276 locally for host bundle-load verification only (not included here — this PR is scoped to routing + native-lib detection).
- Scope kept tight: no behavior change on iOS (where a real device bridge can attach); voice-route serving now works via the same bionic host that TEXT uses, rather than adding a separate in-process lib env export.

Refs #10727, #9560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)