### PR TITLE
fix(openai): finalize live stream telemetry

### DIFF
--- a/.github/issue-evidence/11265-openai-live-stream-trajectory.json
+++ b/.github/issue-evidence/11265-openai-live-stream-trajectory.json
@@ -1,0 +1,123 @@
+{
+  "issue": 11265,
+  "capturedAt": "2026-07-02T08:27:14.892Z",
+  "provider": "cerebras-openai-compatible",
+  "baseUrl": "https://api.cerebras.ai/v1",
+  "model": "gpt-oss-120b",
+  "prompt": "Write six short numbered lines about live streaming telemetry. Output only the numbered lines.",
+  "chunkCount": 16,
+  "chunks": [
+    {
+      "atMs": 271,
+      "text": "1. Live"
+    },
+    {
+      "atMs": 274,
+      "text": " streaming"
+    },
+    {
+      "atMs": 274,
+      "text": " telemetry"
+    },
+    {
+      "atMs": 276,
+      "text": " captures"
+    },
+    {
+      "atMs": 276,
+      "text": " real"
+    },
+    {
+      "atMs": 283,
+      "text": "‑time metrics such as bitrate, latency, and packet loss.  \n2. It monitors viewer connection stability, tracking reconnects and"
+    },
+    {
+      "atMs": 286,
+      "text": " buffering events.  \n3. Bandwidth usage is logged per stream"
+    },
+    {
+      "atMs": 291,
+      "text": " to detect spikes and optimize CDN"
+    },
+    {
+      "atMs": 296,
+      "text": " distribution.  \n4. Audio and video"
+    },
+    {
+      "atMs": 300,
+      "text": " quality indices (e.g., MOS,"
+    },
+    {
+      "atMs": 307,
+      "text": " PSNR) are measured to ensure playback fidelity"
+    },
+    {
+      "atMs": 316,
+      "text": ".  \n5. Geographic analytics map viewer"
+    },
+    {
+      "atMs": 316,
+      "text": " locations to assess regional performance and latency."
+    },
+    {
+      "atMs": 327,
+      "text": "  \n6. Alerts are triggered automatically"
+    },
+    {
+      "atMs": 327,
+      "text": " when thresholds for drop‑frames or"
+    },
+    {
+      "atMs": 332,
+      "text": " latency are exceeded."
+    }
+  ],
+  "result": {
+    "assembled": "1. Live streaming telemetry captures real‑time metrics such as bitrate, latency, and packet loss.  \n2. It monitors viewer connection stability, tracking reconnects and buffering events.  \n3. Bandwidth usage is logged per stream to detect spikes and optimize CDN distribution.  \n4. Audio and video quality indices (e.g., MOS, PSNR) are measured to ensure playback fidelity.  \n5. Geographic analytics map viewer locations to assess regional performance and latency.  \n6. Alerts are triggered automatically when thresholds for drop‑frames or latency are exceeded.",
+    "text": "1. Live streaming telemetry captures real‑time metrics such as bitrate, latency, and packet loss.  \n2. It monitors viewer connection stability, tracking reconnects and buffering events.  \n3. Bandwidth usage is logged per stream to detect spikes and optimize CDN distribution.  \n4. Audio and video quality indices (e.g., MOS, PSNR) are measured to ensure playback fidelity.  \n5. Geographic analytics map viewer locations to assess regional performance and latency.  \n6. Alerts are triggered automatically when thresholds for drop‑frames or latency are exceeded.",
+    "usage": {
+      "promptTokens": 97,
+      "completionTokens": 139,
+      "totalTokens": 236,
+      "cachedPromptTokens": 0,
+      "cacheReadInputTokens": 0
+    },
+    "finishReason": "stop"
+  },
+  "events": [
+    {
+      "type": "MODEL_USED",
+      "source": "openai",
+      "provider": "openai",
+      "modelType": "TEXT_SMALL",
+      "prompt": "Write six short numbered lines about live streaming telemetry. Output only the numbered lines.",
+      "tokens": {
+        "prompt": 97,
+        "completion": 139,
+        "total": 236,
+        "cached": 0
+      }
+    }
+  ],
+  "trajectoryCalls": [
+    {
+      "stepId": "issue-11265-live-step",
+      "actionType": "ai.streamText",
+      "model": "gpt-oss-120b",
+      "modelType": "TEXT_SMALL",
+      "provider": "vercel-ai-sdk",
+      "response": "1. Live streaming telemetry captures real‑time metrics such as bitrate, latency, and packet loss.  \n2. It monitors viewer connection stability, tracking reconnects and buffering events.  \n3. Bandwidth usage is logged per stream to detect spikes and optimize CDN distribution.  \n4. Audio and video quality indices (e.g., MOS, PSNR) are measured to ensure playback fidelity.  \n5. Geographic analytics map viewer locations to assess regional performance and latency.  \n6. Alerts are triggered automatically when thresholds for drop‑frames or latency are exceeded.",
+      "promptTokens": 97,
+      "completionTokens": 139,
+      "finishReason": "stop",
+      "latencyMs": 334
+    }
+  ],
+  "assertions": {
+    "streamedChunksObserved": true,
+    "modelUsedEventObserved": true,
+    "trajectoryResponseFilled": true,
+    "usageTokensRecorded": true,
+    "assembledMatchesText": true
+  }
+}

--- a/.github/issue-evidence/11265-openai-stream-usage.md
+++ b/.github/issue-evidence/11265-openai-stream-usage.md
@@ -1,0 +1,104 @@
+# Issue #11265 - OpenAI live-stream usage + trajectory telemetry
+
+## Scope
+
+Fixes `plugin-openai` live `streamText` chat turns so telemetry is finalized after
+the returned `textStream` is consumed instead of when the AI SDK stream object is
+created.
+
+## Code paths changed
+
+- `plugins/plugin-openai/models/text.ts`
+  - live streaming branch now accumulates emitted chunks
+  - awaits usage / finish reason / tool-call companion promises during stream
+    finalization
+  - emits `MODEL_USED` from real AI SDK usage
+  - logs `ai.streamText` trajectory entries with non-empty `response`, usage,
+    finish reason, and latency
+  - preserves strict trajectory active-step checking before the raw SDK call
+  - propagates AI SDK `onError` provider errors after the stream drains
+- `plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts`
+  - regression coverage for stream telemetry, early-break finalization, and
+    provider `onError`
+- `plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts`
+  - one Biome formatting cleanup required for package `lint:check`
+
+## Real provider evidence
+
+Artifact: `.github/issue-evidence/11265-openai-live-stream-trajectory.json`
+
+Manual review result: good.
+
+Live run details:
+
+- Provider: Cerebras OpenAI-compatible endpoint (`https://api.cerebras.ai/v1`)
+- Model: `gpt-oss-120b`
+- Path: `handleTextSmall(..., { stream: true })` through
+  `plugins/plugin-openai/models/text.ts`
+- Stream chunks captured: 16
+- `MODEL_USED` events captured: 1
+- trajectory `logLlmCall` records captured: 1
+- Assertions in artifact:
+  - `streamedChunksObserved: true`
+  - `modelUsedEventObserved: true`
+  - `trajectoryResponseFilled: true`
+  - `usageTokensRecorded: true`
+  - `assembledMatchesText: true`
+
+Sanitization check: the artifact stores provider, base URL, model, prompt, chunks,
+sanitized event payload, and sanitized trajectory fields only. It does not store
+the API key or the runtime object.
+
+## Verification
+
+Base synced before PR work:
+
+```bash
+git fetch origin
+git rebase origin/develop
+```
+
+Setup required for the fresh worktree:
+
+```bash
+bun install
+bun run --cwd packages/core prebuild
+bun run --cwd packages/core build:node
+```
+
+Focused and package gates:
+
+```bash
+bun run --cwd plugins/plugin-openai test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000
+# PASS: 1 file, 15 tests
+
+bun run --cwd plugins/plugin-openai test
+# PASS: 7 files passed, 1 skipped; 82 tests passed, 3 skipped
+
+bun run --cwd plugins/plugin-openai typecheck
+# PASS
+
+bun run --cwd plugins/plugin-openai lint:check
+# PASS
+
+bun run --cwd plugins/plugin-openai build
+# PASS
+```
+
+Repo-level gate:
+
+```bash
+bun run verify
+```
+
+Result: fails before typecheck/lint at the existing type-safety ratchet baseline:
+
+- `as unknown as: 80 current > 77 baseline`
+- `?? {}` in core/agent/app-core: `379 current > 377 baseline`
+
+This OpenAI patch adds neither pattern.
+
+## UI / media evidence
+
+N/A - this change is server/model-adapter telemetry only. No app UI, audio,
+native, mobile, desktop, or media rendering path changed.

--- a/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
@@ -289,11 +289,7 @@ Sample leaked refusal: ${bucket.samples.leak ? `"${bucket.samples.leak}"` : "(no
 
 const TRIALS = Number.parseInt(process.env.CEREBRAS_REFUSAL_TRIALS ?? "20", 10);
 const TIMEOUT_MS = TRIALS * 20_000 + 30_000;
-const CEREBRAS_REFUSAL_MODELS = [
-  "gemma-4-31b",
-  "gpt-oss-120b",
-  "zai-glm-4.7",
-] as const;
+const CEREBRAS_REFUSAL_MODELS = ["gemma-4-31b", "gpt-oss-120b", "zai-glm-4.7"] as const;
 
 liveDescribe("Cerebras `spawn sub-agent` Stage-1 refusal suppression — elizaOS/eliza#7620", () => {
   for (const model of CEREBRAS_REFUSAL_MODELS) {

--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -1,4 +1,5 @@
 import type { IAgentRuntime } from "@elizaos/core";
+import { EventType, ModelType, runWithTrajectoryContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const aiMocks = vi.hoisted(() => ({
@@ -76,12 +77,32 @@ vi.mock("../providers", () => ({
   }),
 }));
 
-function createRuntime() {
+interface CapturedLlmCall {
+  stepId: string;
+  actionType: string;
+  response?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  finishReason?: string;
+  toolCalls?: unknown;
+}
+
+function createRuntime(options?: { trajectoryCalls?: CapturedLlmCall[] }) {
+  const trajectoryLogger = options?.trajectoryCalls
+    ? {
+        isEnabled: () => true,
+        logLlmCall: (params: CapturedLlmCall) => {
+          options.trajectoryCalls?.push(params);
+        },
+      }
+    : null;
   const runtime = {
     character: { name: "Ada", system: "system prompt" },
     emitEvent: vi.fn(),
-    getService: vi.fn(() => null),
-    getServicesByType: vi.fn(() => []),
+    getService: vi.fn((name: string) => (name === "trajectories" ? trajectoryLogger : null)),
+    getServicesByType: vi.fn((type: string) =>
+      type === "trajectories" && trajectoryLogger ? [trajectoryLogger] : []
+    ),
     getSetting: vi.fn((key: string) => {
       const settings: Record<string, string> = {
         OPENAI_API_KEY: "test-key",
@@ -299,6 +320,132 @@ describe("OpenAI native text plumbing", () => {
     expect(chunks).toEqual(["hel", "lo"]);
     expect(onStreamChunk).toHaveBeenNthCalledWith(1, "hel");
     expect(onStreamChunk).toHaveBeenNthCalledWith(2, "lo");
+  });
+
+  it("emits usage and records the completed live-stream response after consumption", async () => {
+    const trajectoryCalls: CapturedLlmCall[] = [];
+    const toolCalls = [{ toolName: "lookup", input: { q: "x" } }];
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* textStream() {
+        yield "hel";
+        yield "lo";
+      })(),
+      text: Promise.resolve("hello"),
+      toolCalls: Promise.resolve(toolCalls),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 2, outputTokens: 1, cachedInputTokens: 1 }),
+    });
+
+    const runtime = createRuntime({ trajectoryCalls });
+    const { handleTextSmall } = await import("../models/text");
+    await runWithTrajectoryContext({ trajectoryStepId: "step-openai-stream" }, async () => {
+      const stream = (await handleTextSmall(runtime, {
+        prompt: "stream",
+        stream: true,
+      } as never)) as { textStream: AsyncIterable<string> };
+
+      const chunks: string[] = [];
+      for await (const chunk of stream.textStream) {
+        chunks.push(chunk);
+      }
+      expect(chunks.join("")).toBe("hello");
+    });
+
+    expect(runtime.emitEvent).toHaveBeenCalledWith(
+      EventType.MODEL_USED,
+      expect.objectContaining({
+        source: "openai",
+        provider: "openai",
+        type: ModelType.TEXT_SMALL,
+        prompt: "stream",
+        tokens: { prompt: 2, completion: 1, total: 3, cached: 1 },
+      })
+    );
+    expect(trajectoryCalls).toHaveLength(1);
+    expect(trajectoryCalls[0]).toMatchObject({
+      stepId: "step-openai-stream",
+      actionType: "ai.streamText",
+      response: "hello",
+      promptTokens: 2,
+      completionTokens: 1,
+      finishReason: "stop",
+      toolCalls,
+    });
+  });
+
+  it("finalizes live-stream telemetry when the runtime breaks the stream loop early", async () => {
+    const trajectoryCalls: CapturedLlmCall[] = [];
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* textStream() {
+        yield "first";
+        yield "second";
+      })(),
+      text: Promise.resolve("firstsecond"),
+      toolCalls: Promise.resolve([]),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 5, outputTokens: 2 }),
+    });
+
+    const runtime = createRuntime({ trajectoryCalls });
+    const { handleTextSmall } = await import("../models/text");
+    await runWithTrajectoryContext({ trajectoryStepId: "step-openai-break" }, async () => {
+      const stream = (await handleTextSmall(runtime, {
+        prompt: "break stream",
+        stream: true,
+      } as never)) as { textStream: AsyncIterable<string> };
+
+      for await (const chunk of stream.textStream) {
+        expect(chunk).toBe("first");
+        break;
+      }
+    });
+
+    expect(runtime.emitEvent).toHaveBeenCalledWith(
+      EventType.MODEL_USED,
+      expect.objectContaining({
+        type: ModelType.TEXT_SMALL,
+        prompt: "break stream",
+        tokens: { prompt: 5, completion: 2, total: 7 },
+      })
+    );
+    expect(trajectoryCalls).toHaveLength(1);
+    expect(trajectoryCalls[0]).toMatchObject({
+      stepId: "step-openai-break",
+      actionType: "ai.streamText",
+      response: "first",
+      promptTokens: 5,
+      completionTokens: 2,
+      finishReason: "stop",
+    });
+  });
+
+  it("surfaces live-stream provider errors reported through the AI SDK onError hook", async () => {
+    const providerError = new Error("stream provider failed");
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* textStream() {
+        yield "partial";
+      })(),
+      text: Promise.resolve("partial"),
+      toolCalls: Promise.resolve([]),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "stream error",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+    const call = aiMocks.streamText.mock.calls[0][0] as {
+      onError?: (event: { error: unknown }) => void;
+    };
+    call.onError?.({ error: providerError });
+
+    await expect(async () => {
+      for await (const _chunk of stream.textStream) {
+        // consume the stream so the deferred onError hook is checked
+      }
+    }).rejects.toThrow("stream provider failed");
   });
 
   it("maps string responseFormat json_object into the AI SDK responseFormat", async () => {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -12,8 +12,10 @@ import type {
   RecordLlmCallDetails,
 } from "@elizaos/core";
 import {
+  assertActiveTrajectoryForLlmCall,
   buildCanonicalSystemPrompt,
   dropDuplicateLeadingSystemMessage,
+  logActiveTrajectoryLlmCall,
   logger,
   ModelType,
   normalizeSchemaForCerebras,
@@ -1087,7 +1089,6 @@ async function generateTextWithTransientRetry(
   maxRetries = 3
 ): Promise<Awaited<ReturnType<typeof generateText<ToolSet>>>> {
   let attempt = 0;
-  // biome-ignore lint/suspicious/noExplicitAny: AI SDK's generateText overloads can't infer our NativeGenerateTextParams across the generic boundary.
   for (;;) {
     try {
       return (await generateText(
@@ -1333,19 +1334,103 @@ async function generateTextByModelType(
       generateParams
     );
     details.response = "";
-    const result = await recordLlmCall(runtime, details, () => streamText(generateParams));
+    assertActiveTrajectoryForLlmCall({
+      actionType: details.actionType,
+      model: details.model,
+      modelType: details.modelType,
+      purpose: details.purpose,
+    });
+    const startedAt =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const responseChunks: string[] = [];
+    let capturedStreamError: unknown;
+    let companionStreamError: unknown;
+    let telemetryFinalized = false;
+    const result = await streamText({
+      ...generateParams,
+      onError: ({ error }: { error: unknown }) => {
+        capturedStreamError = error;
+      },
+    });
+    const textPromise = handledPromise(result.text);
+    const rawUsagePromise = handledPromise(result.usage);
+    const rawFinishReasonPromise = handledPromise(result.finishReason);
+    const rawToolCallsPromise = handledPromise(result.toolCalls);
+    const usagePromise = handledMappedPromise(rawUsagePromise, convertUsage);
+    const finishReasonPromise = handledMappedPromise(
+      rawFinishReasonPromise,
+      (r) => r as string | undefined
+    );
+    const finalizeStreamingTelemetry = async () => {
+      if (telemetryFinalized) {
+        return;
+      }
+      telemetryFinalized = true;
+      const [usageResult, finishReasonResult, toolCallsResult] = await Promise.allSettled([
+        rawUsagePromise,
+        rawFinishReasonPromise,
+        rawToolCallsPromise,
+      ]);
+
+      details.response = responseChunks.join("");
+      if (usageResult.status === "fulfilled" && usageResult.value) {
+        applyUsageToDetails(details, usageResult.value);
+        emitModelUsageEvent(runtime, modelType, params.prompt ?? "", usageResult.value);
+      } else if (usageResult.status === "rejected") {
+        companionStreamError ??= usageResult.reason;
+      }
+      if (finishReasonResult.status === "fulfilled") {
+        details.finishReason = finishReasonResult.value as string | undefined;
+      } else {
+        companionStreamError ??= finishReasonResult.reason;
+      }
+      if (toolCallsResult.status === "fulfilled") {
+        details.toolCalls = toolCallsResult.value;
+      } else {
+        companionStreamError ??= toolCallsResult.reason;
+      }
+
+      const elapsed =
+        (typeof performance !== "undefined" && typeof performance.now === "function"
+          ? performance.now()
+          : Date.now()) - startedAt;
+      logActiveTrajectoryLlmCall(runtime, {
+        ...details,
+        response: details.response,
+        latencyMs: Math.max(0, Math.round(elapsed)),
+      });
+    };
 
     return {
       textStream: (async function* textStreamWithCallback() {
-        for await (const chunk of result.textStream) {
-          params.onStreamChunk?.(chunk);
-          yield chunk;
+        let streamIterationError: unknown;
+        try {
+          for await (const chunk of result.textStream) {
+            responseChunks.push(chunk);
+            params.onStreamChunk?.(chunk);
+            yield chunk;
+          }
+        } catch (error) {
+          streamIterationError = error;
+        } finally {
+          await finalizeStreamingTelemetry();
+        }
+        if (streamIterationError) {
+          throw streamIterationError;
+        }
+        if (capturedStreamError) {
+          throw capturedStreamError;
+        }
+        if (companionStreamError) {
+          throw companionStreamError;
         }
       })(),
-      text: handledPromise(result.text),
-      ...(shouldReturnNativeResult ? { toolCalls: handledPromise(result.toolCalls) } : {}),
-      usage: handledMappedPromise(result.usage, convertUsage),
-      finishReason: handledMappedPromise(result.finishReason, (r) => r as string | undefined),
+      text: textPromise,
+      ...(shouldReturnNativeResult ? { toolCalls: rawToolCallsPromise } : {}),
+      usage: usagePromise,
+      finishReason: finishReasonPromise,
     };
   }
 


### PR DESCRIPTION
## Summary
- finalize OpenAI live stream telemetry after `textStream` consumption instead of at stream-object creation
- emit `MODEL_USED` from resolved AI SDK streaming usage and log trajectory calls with filled response/usage/finish reason
- add regression coverage for completed streams, early loop breaks, and AI SDK `onError` propagation

## Evidence
- `.github/issue-evidence/11265-openai-stream-usage.md`
- `.github/issue-evidence/11265-openai-live-stream-trajectory.json` (real Cerebras OpenAI-compatible `gpt-oss-120b` stream: 16 chunks, 1 `MODEL_USED`, 1 trajectory LLM call with non-empty response and token usage)

## Verification
- `bun run --cwd plugins/plugin-openai test -- __tests__/native-plumbing.shape.test.ts --testTimeout 60000` - PASS: 15 tests
- `bun run --cwd plugins/plugin-openai test` - PASS: 82 passed, 3 skipped
- `bun run --cwd plugins/plugin-openai typecheck` - PASS
- `bun run --cwd plugins/plugin-openai lint:check` - PASS
- `bun run --cwd plugins/plugin-openai build` - PASS
- `bun run verify` - FAILS before workspace typecheck/lint on existing type-safety ratchet baseline: `as unknown as` 80 > 77, `?? {}` 379 > 377. This patch adds neither pattern.

Fixes #11265