### PR TITLE
fix(plugin-sql): detect reused pglite lock pids

### DIFF
--- a/.github/issue-evidence/11222-pglite-pid1-stale-lock.md
+++ b/.github/issue-evidence/11222-pglite-pid1-stale-lock.md
@@ -1,0 +1,97 @@
+# Issue #11222 - PGlite pid-1 stale lock self-heal
+
+Date: 2026-07-02
+Branch: `fix/11222-pglite-pid1-stale-lock`
+Base: `origin/develop` at `8bed05c1718a`
+
+## What Changed
+
+- `PGliteClientManager` now writes Linux boot id and `/proc` process start ticks
+  into `eliza-pglite.lock` when available.
+- Existing locks are no longer trusted on bare PID liveness alone. If the lock
+  metadata proves that the currently-live PID started after the lock was
+  written, the lock is stale and is reclaimed.
+- This covers the container pid-1 crash-loop case: a new container process can
+  reuse pid 1, but it cannot have created a lock before it started.
+
+## Regression
+
+Added coverage in
+`plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts`:
+
+- existing live-lock coverage now preserves the current process identity so a
+  long-running owner is still honored even when `createdAt` is old;
+- new regression creates a legacy lock whose PID is live but whose `createdAt`
+  predates that PID's process generation, then asserts `PGliteClientManager`
+  reclaims it and removes the lock file;
+- existing non-running-PID and second-manager lock tests still pass.
+
+## Verification
+
+Commands run from `/private/tmp/eliza-11222-pglite-lock` after rebasing onto
+current `origin/develop` and running `bun install`.
+
+```bash
+bunx vitest run --config vitest.real.config.ts \
+  __tests__/integration/postgres/pglite-manager-lock.real.test.ts \
+  --testTimeout 60000
+```
+
+Run from `plugins/plugin-sql/src`.
+
+Result: pass. `1 passed (1)`, `4 passed (4)`.
+
+```bash
+bun run --cwd plugins/plugin-sql test
+```
+
+Result: pass. `9 passed (9)`, `50 passed (50)`.
+
+```bash
+bun run --cwd plugins/plugin-sql typecheck
+```
+
+Result: pass.
+
+```bash
+bun run --cwd plugins/plugin-sql lint:check
+```
+
+Result: pass. `Checked 180 files`.
+
+```bash
+bun run --cwd plugins/plugin-sql build
+```
+
+Result: pass. Node ESM, browser ESM, CJS, and declarations built.
+
+```bash
+git diff --check origin/develop...HEAD
+```
+
+Result: pass.
+
+## Repo-Level Verify
+
+```bash
+bun run verify
+```
+
+Result: failed before turbo typecheck/lint at `audit:type-safety-ratchet` on
+current `origin/develop`, unrelated to this plugin-sql change:
+
+- `as unknown as`: `80 current > 77 baseline`
+- ``?? {}``: `379 current > 377 baseline`
+
+The changed production file does not add either ratchet pattern.
+
+## Evidence Applicability
+
+- Live LLM trajectory: N/A; this is storage/locking behavior, not model or agent
+  prompt behavior.
+- UI screenshots/video/audio: N/A; no UI, native visual, voice, or audio surface
+  changed.
+- Domain artifact: covered by the real PGlite lock regression. The test writes a
+  real `eliza-pglite.lock` in a temporary file-backed data dir, constructs the
+  real `PGliteClientManager`, and verifies the stale lock file is removed before
+  the manager closes.

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
@@ -1,11 +1,51 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PGLITE_ERROR_CODES } from "../../../pglite/errors";
 import { PGliteClientManager } from "../../../pglite/manager";
 
 const lockPathFor = (dataDir: string) => path.join(dataDir, "eliza-pglite.lock");
+
+const readLinuxBootId = (): string | null => {
+  try {
+    const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+    return bootId.length > 0 ? bootId : null;
+  } catch {
+    return null;
+  }
+};
+
+const readLinuxProcStartTicks = (pid: number | "self"): string | null => {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const commEnd = stat.lastIndexOf(")");
+    if (commEnd === -1) {
+      return null;
+    }
+    const fieldsAfterComm = stat
+      .slice(commEnd + 2)
+      .trim()
+      .split(/\s+/);
+    const startTicks = fieldsAfterComm[19];
+    return startTicks && /^\d+$/.test(startTicks) ? startTicks : null;
+  } catch {
+    return null;
+  }
+};
+
+const currentProcessIdentity = (): { bootId?: string; processStartTicks?: string } => {
+  const bootId = readLinuxBootId();
+  const processStartTicks = readLinuxProcStartTicks("self");
+  return {
+    ...(bootId ? { bootId } : {}),
+    ...(processStartTicks ? { processStartTicks } : {}),
+  };
+};
+
+type PGliteManagerInternals = {
+  readLinuxProcessStartedAtMs(pid: number): number | null;
+};
 
 describe("PGliteClientManager file lock", () => {
   const tempDirs: string[] = [];
@@ -51,7 +91,12 @@ describe("PGliteClientManager file lock", () => {
     const ancientCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
     writeFileSync(
       lockPathFor(dataDir),
-      `${JSON.stringify({ pid: process.pid, createdAt: ancientCreatedAt, dataDir })}\n`
+      `${JSON.stringify({
+        pid: process.pid,
+        createdAt: ancientCreatedAt,
+        dataDir,
+        ...currentProcessIdentity(),
+      })}\n`
     );
 
     let error: unknown;
@@ -63,6 +108,41 @@ describe("PGliteClientManager file lock", () => {
     expect((error as { code?: string }).code).toBe(PGLITE_ERROR_CODES.ACTIVE_LOCK);
     // The live lock must be left intact, not reclaimed.
     expect(existsSync(lockPathFor(dataDir))).toBe(true);
+  });
+
+  it("reclaims a legacy live-pid lock when proc start time proves PID reuse", async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), "eliza-pglite-lock-"));
+    tempDirs.push(dataDir);
+
+    const lockCreatedAtMs = Date.now() - 60_000;
+    const processStartedAfterLockMs = lockCreatedAtMs + 10_000;
+    const startTimeSpy = vi
+      .spyOn(
+        PGliteClientManager.prototype as unknown as PGliteManagerInternals,
+        "readLinuxProcessStartedAtMs"
+      )
+      .mockReturnValue(processStartedAfterLockMs);
+
+    try {
+      // The PID is alive, but the lock predates that PID's process generation.
+      // A process cannot create a lock before it starts, so the PID was reused.
+      // This is the pid-1-in-container failure mode from #11222 generalized to
+      // the current test runner PID.
+      writeFileSync(
+        lockPathFor(dataDir),
+        `${JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date(lockCreatedAtMs).toISOString(),
+          dataDir,
+        })}\n`
+      );
+
+      const manager = new PGliteClientManager({ dataDir });
+      await manager.close();
+      expect(existsSync(lockPathFor(dataDir))).toBe(false);
+    } finally {
+      startTimeSpy.mockRestore();
+    }
   });
 
   it("reclaims a lock owned by a non-running PID", async () => {

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -41,6 +41,13 @@ type PglitePidFileStatus =
   | "cleared-malformed"
   | "check-failed";
 
+interface PgliteDataDirLockInfo {
+  pid: number | null;
+  createdAt: number | null;
+  bootId: string | null;
+  processStartTicks: string | null;
+}
+
 /**
  * Runtime sync status of the Electric Sync client wired into PGlite.
  * - syncing: the sync stream is connecting or catching up with the source.
@@ -106,6 +113,7 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   // 7 days comfortably exceeds any real unconfirmable window while still
   // bounding the false-positive blast radius. See isLockActive.
   private static readonly LOCK_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+  private static readonly PID_REUSE_GRACE_MS = 5_000;
 
   private client: PGlite;
   private options: PGliteOptions;
@@ -328,29 +336,121 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
     return `${dataDir}/eliza-pglite.lock`;
   }
 
-  private getLockInfo(lockPath: string): { pid: number | null; createdAt: number | null } {
+  private getLockInfo(lockPath: string): PgliteDataDirLockInfo {
     try {
       const raw = readFileSync(lockPath, "utf-8");
-      const parsed = JSON.parse(raw) as { pid?: unknown; createdAt?: unknown };
+      const parsed = JSON.parse(raw) as {
+        pid?: unknown;
+        createdAt?: unknown;
+        bootId?: unknown;
+        processStartTicks?: unknown;
+      };
       const pid = typeof parsed.pid === "number" && parsed.pid > 0 ? parsed.pid : null;
       const createdAtMs = typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
       const createdAt = Number.isNaN(createdAtMs) ? null : createdAtMs;
-      return { pid, createdAt };
+      const bootId =
+        typeof parsed.bootId === "string" && parsed.bootId.length > 0 ? parsed.bootId : null;
+      const processStartTicks =
+        typeof parsed.processStartTicks === "string" && /^\d+$/.test(parsed.processStartTicks)
+          ? parsed.processStartTicks
+          : null;
+      return { pid, createdAt, bootId, processStartTicks };
     } catch {
-      return { pid: null, createdAt: null };
+      return { pid: null, createdAt: null, bootId: null, processStartTicks: null };
     }
+  }
+
+  private readLinuxBootId(): string | null {
+    try {
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+      return bootId.length > 0 ? bootId : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private readLinuxUptimeSeconds(): number | null {
+    try {
+      const raw = readFileSync("/proc/uptime", "utf-8").trim().split(/\s+/)[0];
+      const uptimeSeconds = Number.parseFloat(raw ?? "");
+      return Number.isFinite(uptimeSeconds) && uptimeSeconds > 0 ? uptimeSeconds : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private readLinuxProcStartTicks(pid: number | "self"): string | null {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const commEnd = stat.lastIndexOf(")");
+      if (commEnd === -1) {
+        return null;
+      }
+      const fieldsAfterComm = stat
+        .slice(commEnd + 2)
+        .trim()
+        .split(/\s+/);
+      const startTicks = fieldsAfterComm[19];
+      return startTicks && /^\d+$/.test(startTicks) ? startTicks : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private estimateLinuxClockTicksPerSecond(): number | null {
+    const selfStartTicks = this.readLinuxProcStartTicks("self");
+    const uptimeSeconds = this.readLinuxUptimeSeconds();
+    if (!selfStartTicks || uptimeSeconds === null) {
+      return null;
+    }
+
+    const selfStartSecondsAfterBoot = uptimeSeconds - process.uptime();
+    if (!Number.isFinite(selfStartSecondsAfterBoot) || selfStartSecondsAfterBoot <= 0) {
+      return null;
+    }
+
+    const ticksPerSecond = Number(selfStartTicks) / selfStartSecondsAfterBoot;
+    return Number.isFinite(ticksPerSecond) && ticksPerSecond > 0 ? ticksPerSecond : null;
+  }
+
+  private readLinuxProcessStartedAtMs(pid: number): number | null {
+    const processStartTicks = this.readLinuxProcStartTicks(pid);
+    const uptimeSeconds = this.readLinuxUptimeSeconds();
+    const ticksPerSecond = this.estimateLinuxClockTicksPerSecond();
+    if (!processStartTicks || uptimeSeconds === null || ticksPerSecond === null) {
+      return null;
+    }
+
+    const bootStartedAtMs = Date.now() - uptimeSeconds * 1000;
+    return bootStartedAtMs + (Number(processStartTicks) / ticksPerSecond) * 1000;
+  }
+
+  private isLockPidReuseProven(pid: number, createdAt: number | null): boolean {
+    if (createdAt === null) {
+      return false;
+    }
+
+    const processStartedAt = this.readLinuxProcessStartedAtMs(pid);
+    return (
+      processStartedAt !== null &&
+      processStartedAt - createdAt > PGliteClientManager.PID_REUSE_GRACE_MS
+    );
   }
 
   /**
    * Decide whether an existing lock should be honored as held by a live owner.
    *
-   * Single-writer safety comes first: a *confirmed-running* PID is always
-   * honored, regardless of how old its `createdAt` is. A long-running agent
-   * (days or weeks of uptime) must never have its live lock reclaimed by a
-   * second manager — that would open a dual-writer window, which is
-   * unrecoverable, whereas a falsely-bricked boot is recoverable by removing
-   * the lock file. This matches the sibling `reconcilePglitePidFile`, which
-   * also treats a live PID as "active".
+   * Single-writer safety comes first: a confirmed-running PID whose recorded
+   * process identity still matches is honored regardless of lock age. A
+   * long-running agent (days or weeks of uptime) must never have its live lock
+   * reclaimed by a second manager.
+   *
+   * Bare PID liveness alone is not enough in containers: after an unclean
+   * shutdown, the next container can reuse pid 1, making `kill(1, 0)` look
+   * live forever. New locks therefore record Linux boot id + `/proc` process
+   * start ticks. Legacy locks are also protected by comparing their createdAt
+   * timestamp against the currently-live PID's `/proc/<pid>/stat` start time:
+   * if the PID started after the lock was written, it cannot be the owner.
    *
    * The staleness window only rescues the *unconfirmable* case. A bare
    * `process.kill(pid, 0)` is vulnerable to PID reuse, and a recycled
@@ -361,10 +461,29 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
    * is treated as stale and reclaimed so an aliased PID cannot brick boot
    * forever. `ESRCH` is unambiguous — the process is gone and the lock is stale.
    */
-  private isLockActive(pid: number, createdAt: number | null): boolean {
+  private isLockActive(lockInfo: PgliteDataDirLockInfo): boolean {
+    const { pid, createdAt, bootId, processStartTicks } = lockInfo;
+    if (!pid) {
+      return false;
+    }
+
+    const currentBootId = this.readLinuxBootId();
+    if (bootId && currentBootId && bootId !== currentBootId) {
+      return false;
+    }
+
+    if (processStartTicks) {
+      const currentProcessStartTicks = this.readLinuxProcStartTicks(pid);
+      if (currentProcessStartTicks && currentProcessStartTicks !== processStartTicks) {
+        return false;
+      }
+    } else if (this.isLockPidReuseProven(pid, createdAt)) {
+      return false;
+    }
+
     try {
       process.kill(pid, 0);
-      // Confirmed alive -> honor unconditionally (preserve single-writer).
+      // Confirmed alive with matching identity -> preserve single-writer.
       return true;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
@@ -398,6 +517,8 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
             pid: process.pid,
             createdAt: new Date().toISOString(),
             dataDir,
+            bootId: this.readLinuxBootId() ?? undefined,
+            processStartTicks: this.readLinuxProcStartTicks("self") ?? undefined,
           })}\n`
         );
         this.lockFd = fd;
@@ -409,8 +530,9 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
           throw this.createActiveLockError(dataDir, err);
         }
 
-        const { pid, createdAt } = this.getLockInfo(lockPath);
-        if (pid && this.isLockActive(pid, createdAt)) {
+        const lockInfo = this.getLockInfo(lockPath);
+        const { pid } = lockInfo;
+        if (this.isLockActive(lockInfo)) {
           throw this.createActiveLockError(
             dataDir,
             new Error(`PGlite lock file is held by running process ${pid}`)


### PR DESCRIPTION
## Summary\n- add Linux boot id and /proc process-start metadata to file-backed PGlite data-dir locks\n- reject bare PID liveness when lock metadata or legacy lock timing proves the PID was reused\n- add regression coverage for a live PID whose current process generation started after the legacy lock was written\n\nCloses #11222\n\n## Evidence\n- Evidence file: .github/issue-evidence/11222-pglite-pid1-stale-lock.md\n- Focused real lock test: bunx vitest run --config vitest.real.config.ts __tests__/integration/postgres/pglite-manager-lock.real.test.ts --testTimeout 60000 -> 1 file / 4 tests passed\n- Default plugin-sql tests: bun run --cwd plugins/plugin-sql test -> 9 files / 50 tests passed\n- plugin-sql typecheck: passed\n- plugin-sql lint:check: passed\n- plugin-sql build: passed\n- git diff --check origin/develop...HEAD: passed\n\n## Repo Verify\n- bun run verify currently fails before turbo typecheck/lint at audit:type-safety-ratchet on current develop, unrelated to this plugin-sql change:\n  - as unknown as: 80 current > 77 baseline\n  - ?? {}: 379 current > 377 baseline\n\n## N/A\n- Live LLM trajectory: N/A, storage/locking change only.\n- UI screenshots/video/audio: N/A, no UI or media surface changed.