### PR TITLE
fix(shared,agent,ui): resolve #11309 — shared avatarIndex no longer last-wins-clobbers the default Eliza persona with Chen

### DIFF
--- a/packages/agent/src/api/server-helpers.test.ts
+++ b/packages/agent/src/api/server-helpers.test.ts
@@ -1,9 +1,13 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { resolveStylePresetById } from "@elizaos/shared/character-presets";
 import fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   cloneWithoutBlockedObjectKeys,
   hasBlockedObjectKeyDeep,
+  resolveConversationGreetingText,
+  resolveMirroredAvatarPresetId,
 } from "./server-helpers";
 
 describe("blocked object key sanitization", () => {
@@ -64,5 +68,67 @@ describe("blocked object key sanitization", () => {
       ),
       { numRuns: 200 },
     );
+  });
+});
+
+describe("resolveConversationGreetingText persona resolution", () => {
+  it("greets as Eliza for a consistent default-Eliza config (presetId eliza + shared avatarIndex 1)", () => {
+    const eliza = resolveStylePresetById("eliza");
+    const chen = resolveStylePresetById("chen");
+    if (!eliza || !chen) {
+      throw new Error("expected eliza and chen presets to exist");
+    }
+    // The scenario only exists because both personas share avatarIndex 1 —
+    // the id must win over the ambiguous art-asset index.
+    expect(eliza.avatarIndex).toBe(chen.avatarIndex);
+
+    const runtime = {
+      character: { name: "Eliza", postExamples: [] },
+    } as unknown as AgentRuntime;
+
+    // Sweep the greeting RNG across every pick slot so the full greeting set
+    // is observed deterministically.
+    const randomSpy = vi.spyOn(Math, "random");
+    const produced = new Set<string>();
+    try {
+      const steps = 64;
+      for (let i = 0; i < steps; i++) {
+        randomSpy.mockReturnValue(i / steps);
+        produced.add(
+          resolveConversationGreetingText(runtime, "en", {
+            presetId: "eliza",
+            avatarIndex: 1,
+          }),
+        );
+      }
+    } finally {
+      randomSpy.mockRestore();
+    }
+
+    const elizaGreetings = new Set(
+      eliza.postExamples.map((value) => value.trim()),
+    );
+    expect([...produced].sort()).toEqual([...elizaGreetings].sort());
+  });
+});
+
+describe("resolveMirroredAvatarPresetId", () => {
+  it("keeps an already-consistent persisted presetId for a shared avatar index", () => {
+    // chen and eliza intentionally share avatarIndex 1 — mirroring the shared
+    // index must not rewrite either persona to its sibling.
+    expect(resolveMirroredAvatarPresetId(1, "chen")).toBe("chen");
+    expect(resolveMirroredAvatarPresetId(1, "eliza")).toBe("eliza");
+  });
+
+  it("derives first-wins from the index when no presetId is persisted", () => {
+    expect(resolveMirroredAvatarPresetId(1, undefined)).toBe("eliza");
+  });
+
+  it("re-derives from the index when the persisted presetId points at another avatar", () => {
+    const jin = resolveStylePresetById("jin");
+    if (!jin) {
+      throw new Error("expected jin preset to exist");
+    }
+    expect(resolveMirroredAvatarPresetId(jin.avatarIndex, "eliza")).toBe("jin");
   });
 });

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -322,13 +322,16 @@ export function resolveConversationGreetingText(
 
   // Prefer explicit UI selections over the loaded character card: users pick a
   // style in first-run/roster (avatar + preset) while `runtime.character.name`
-  // can still reflect the bundled preset name until save/restart.
+  // can still reflect the bundled preset name until save/restart. The preset id
+  // names exactly one persona, while `avatarIndex` is a shared art-asset index
+  // that cannot disambiguate siblings using the same VRM — so the id must win
+  // (matching the build-character paths).
   const preset =
+    resolveStylePresetById(uiConfig?.presetId, normalizedLanguage) ??
     resolveStylePresetByAvatarIndex(
       uiConfig?.avatarIndex,
       normalizedLanguage,
     ) ??
-    resolveStylePresetById(uiConfig?.presetId, normalizedLanguage) ??
     resolveStylePresetByName(assistantName, normalizedLanguage) ??
     resolveStylePresetByName(characterName, normalizedLanguage);
 
@@ -349,6 +352,27 @@ export function resolveConversationGreetingText(
   return name
     ? `Hey, I'm ${name}. What can I help you with?`
     : "Hey — what can I help you with?";
+}
+
+/**
+ * Resolve the preset id to persist when the stream tab mirrors an avatar
+ * selection into eliza.json. `avatarIndex` is a shared art-asset index —
+ * several personas can use the same VRM — so an already-consistent persisted
+ * presetId must be kept rather than re-derived from the ambiguous index (which
+ * would clobber the persona with its earliest-declared sibling). Only when the
+ * existing presetId is absent or points at a different avatar do we derive the
+ * persona from the index.
+ */
+export function resolveMirroredAvatarPresetId(
+  avatarIndex: number,
+  existingPresetId: string | null | undefined,
+  language?: unknown,
+): string | undefined {
+  const existing = resolveStylePresetById(existingPresetId, language);
+  if (existing && existing.avatarIndex === avatarIndex) {
+    return existing.id;
+  }
+  return resolveStylePresetByAvatarIndex(avatarIndex, language)?.id;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -49,7 +49,6 @@ import type { WalletRouteDependencies } from "@elizaos/plugin-wallet";
 import {
   getStylePresets,
   normalizeCharacterLanguage,
-  resolveStylePresetByAvatarIndex,
 } from "@elizaos/shared/character-presets";
 import {
   isMobilePlatform,
@@ -437,6 +436,7 @@ import {
   hasPersistedFirstRunState,
   isUuidLike,
   patchTouchesProviderSelection,
+  resolveMirroredAvatarPresetId,
 } from "./server-helpers.ts";
 import { routeAutonomyTextToUser as routeProactiveText } from "./server-helpers-swarm.ts";
 import {
@@ -4622,11 +4622,18 @@ export async function startApiServer(opts?: {
               }
               const diskCfg = loadElizaConfig();
               const lang = state.config.ui?.language ?? diskCfg.ui?.language;
-              const preset = resolveStylePresetByAvatarIndex(avatarIndex, lang);
+              // Keep an already-consistent persisted presetId; the shared
+              // art-asset index alone cannot disambiguate sibling personas
+              // using the same VRM (see resolveMirroredAvatarPresetId).
+              const presetId = resolveMirroredAvatarPresetId(
+                avatarIndex,
+                state.config.ui?.presetId ?? diskCfg.ui?.presetId,
+                lang,
+              );
               const nextUi: ElizaConfig["ui"] = {
                 ...(state.config.ui ?? {}),
                 avatarIndex,
-                ...(preset?.id ? { presetId: preset.id } : {}),
+                ...(presetId ? { presetId } : {}),
               };
               state.config = {
                 ...state.config,

--- a/packages/shared/src/character-presets.test.ts
+++ b/packages/shared/src/character-presets.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildElizaCharacterCatalog,
+  getDefaultStylePreset,
+  resolveStylePresetByAvatarIndex,
+  resolveStylePresetById,
+} from "./character-presets.js";
+
+// `avatarIndex` is a VRM art-asset index, not a persona key — several personas
+// can intentionally share one art asset (default Eliza and Chen both use
+// index 1). Resolution over an ambiguous index must be deterministic and
+// first-wins (earliest-declared persona), never last-wins.
+describe("avatar-index resolution (shared art assets)", () => {
+  it("resolves an ambiguous avatar index to the earliest-declared persona", () => {
+    const defaultPreset = getDefaultStylePreset();
+    const byIndex = resolveStylePresetByAvatarIndex(defaultPreset.avatarIndex);
+    expect(byIndex?.id).toBe(defaultPreset.id);
+  });
+
+  it("resolves avatarIndex 1 to eliza, not the sibling persona sharing the asset", () => {
+    expect(resolveStylePresetByAvatarIndex(1)?.id).toBe("eliza");
+  });
+
+  it("still resolves unshared avatar indexes to their own persona", () => {
+    const chen = resolveStylePresetById("chen");
+    expect(chen).toBeDefined();
+    // Chen deliberately shares avatarIndex 1 with default Eliza; every other
+    // persona owns its index and must keep resolving to itself.
+    const jin = resolveStylePresetById("jin");
+    expect(jin).toBeDefined();
+    if (!jin) {
+      throw new Error("jin preset missing");
+    }
+    expect(resolveStylePresetByAvatarIndex(jin.avatarIndex)?.id).toBe("jin");
+  });
+});
+
+describe("buildElizaCharacterCatalog", () => {
+  it("emits assets with unique ids (dedupes shared avatar indexes)", () => {
+    const { assets } = buildElizaCharacterCatalog();
+    const ids = assets.map((asset) => asset.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const slugs = assets.map((asset) => asset.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("titles a shared asset after the earliest-declared persona", () => {
+    const { assets } = buildElizaCharacterCatalog();
+    const defaultPreset = getDefaultStylePreset();
+    const shared = assets.find(
+      (asset) => asset.id === defaultPreset.avatarIndex,
+    );
+    expect(shared?.title).toBe(defaultPreset.name);
+  });
+
+  it("keeps every persona in injectedCharacters even when assets are shared", () => {
+    const { injectedCharacters } = buildElizaCharacterCatalog();
+    const names = injectedCharacters.map((character) => character.name);
+    expect(names).toContain("Eliza");
+    expect(names).toContain("Chen");
+  });
+});

--- a/packages/shared/src/character-presets.ts
+++ b/packages/shared/src/character-presets.ts
@@ -80,12 +80,24 @@ const CHARACTER_DEFINITION_BY_NAME = new Map(
   ]),
 );
 
-const CHARACTER_DEFINITION_BY_AVATAR_INDEX = new Map(
-  CHARACTER_DEFINITIONS.map((definition) => [
-    definition.avatarIndex,
-    definition,
-  ]),
-);
+// `avatarIndex` is a VRM art-asset index, not a persona key — several personas
+// can intentionally share one art asset (e.g. default Eliza and Chen both use
+// index 1). Build the lookup first-wins so an ambiguous index deterministically
+// resolves to the earliest-declared persona (the default preset is
+// CHARACTER_DEFINITIONS[0]); the plain Map constructor would be last-wins and
+// let a later sibling clobber it.
+const CHARACTER_DEFINITION_BY_AVATAR_INDEX = new Map<
+  number,
+  CharacterDefinition
+>();
+for (const definition of CHARACTER_DEFINITIONS) {
+  if (!CHARACTER_DEFINITION_BY_AVATAR_INDEX.has(definition.avatarIndex)) {
+    CHARACTER_DEFINITION_BY_AVATAR_INDEX.set(
+      definition.avatarIndex,
+      definition,
+    );
+  }
+}
 
 // The first/default character ("eliza") is the app's default agent. A
 // white-label app rebrands that default to its own app name (e.g. "Milady")
@@ -243,9 +255,21 @@ export function buildElizaCharacterCatalog(): {
   // Use getStylePresets() (not the STYLE_PRESETS const) so the default-agent
   // rename from setDefaultAgentName() is reflected in the white-label catalog.
   const presets = getStylePresets(DEFAULT_LANGUAGE);
+  // Assets are keyed by avatarIndex, and several personas may share one art
+  // asset — dedupe so ids/slugs stay unique. The stable sort keeps declaration
+  // order within a shared index, so the surviving asset is titled after the
+  // earliest-declared persona (the default preset for index 1).
+  const seenAvatarIndexes = new Set<number>();
   const assets = presets
     .slice()
     .sort((left, right) => left.avatarIndex - right.avatarIndex)
+    .filter((preset) => {
+      if (seenAvatarIndexes.has(preset.avatarIndex)) {
+        return false;
+      }
+      seenAvatarIndexes.add(preset.avatarIndex);
+      return true;
+    })
     .map((preset) => ({
       id: preset.avatarIndex,
       slug: `eliza-${preset.avatarIndex}`,

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -8,7 +8,10 @@
  */
 
 import { logger } from "@elizaos/logger";
-import { resolveStylePresetByAvatarIndex } from "@elizaos/shared";
+import {
+  resolveStylePresetByAvatarIndex,
+  resolveStylePresetByName,
+} from "@elizaos/shared";
 import {
   type RefObject,
   useCallback,
@@ -647,19 +650,22 @@ export function useDataLoaders(deps: DataLoadersDeps) {
       return;
     }
 
-    const preset = resolveStylePresetByAvatarIndex(
-      selectedVrmIndex,
-      uiLanguage,
-    );
+    // Resolve the persona by its name first: the VRM index is a shared
+    // art-asset index (several personas can use one avatar), so relocalizing
+    // from the index alone could rewrite the character with a sibling
+    // persona's payload. The index is only a fallback for unnamed characters.
+    const currentName =
+      characterData?.name?.trim() ||
+      characterDraft?.name?.trim() ||
+      agentStatus?.agentName?.trim();
+    const preset =
+      resolveStylePresetByName(currentName, uiLanguage) ??
+      resolveStylePresetByAvatarIndex(selectedVrmIndex, uiLanguage);
     if (!preset) {
       return;
     }
 
-    const resolvedName =
-      characterData?.name?.trim() ||
-      characterDraft?.name?.trim() ||
-      agentStatus?.agentName?.trim() ||
-      preset.name;
+    const resolvedName = currentName || preset.name;
 
     void (async () => {
       try {


### PR DESCRIPTION
Fixes #11309.

## The bug

`packages/shared/src/character-presets.characters.ts` deliberately gives the default **Eliza** and **Chen** the same `avatarIndex: 1` — `avatarIndex` is a VRM **art-asset** index, not a persona key, and several personas can share one art asset. But `CHARACTER_DEFINITION_BY_AVATAR_INDEX` was built with the plain `Map` constructor, whose duplicate-key semantics are **last-wins**, so index 1 resolved to Chen and silently clobbered the default Eliza persona **everywhere resolution falls back to the avatar index**:

1. **Greeting swap** — `resolveConversationGreetingText` checked `avatarIndex` *before* `presetId`, so a fully consistent default-Eliza config (`ui.presetId:"eliza"`, `ui.avatarIndex:1`) opened the conversation with **Chen's** greeting.
2. **Persisted persona clobber** — `mirrorStreamAvatarToElizaConfig` re-derived `presetId` from the avatar index and persisted it, writing `presetId:"chen"` over an Eliza `eliza.json`.
3. **Character-build fallback** — partial configs with only `ui.avatarIndex:1` built the *Chen* character.
4. **Language relocalization** — the UI language sync resolved the preset from the VRM index alone, rewriting the character with the sibling persona's localized payload on a language switch.
5. **Catalog duplicate ids** — `buildElizaCharacterCatalog()` emitted two assets with `id:1` / slug `eliza-1`.

## Structural fix (no per-character special-cases, no persona hardcoding)

- **First-wins map**: build `CHARACTER_DEFINITION_BY_AVATAR_INDEX` by skipping an index already present, so an ambiguous art-asset index deterministically resolves to the **earliest-declared** persona — which is the default preset `CHARACTER_DEFINITIONS[0]`.
- **`presetId` before `avatarIndex`** in `resolveConversationGreetingText` — the id names one persona; the shared index cannot disambiguate. Matches the build-character paths.
- **Stream-avatar mirror** keeps an already-consistent persisted `presetId` via a new `resolveMirroredAvatarPresetId(avatarIndex, existingPresetId, language)` helper (only derives from the first-wins index when no consistent id is set).
- **UI language sync** resolves the persona by character **name first**, VRM index only as fallback.
- **Catalog** dedupes assets by `avatarIndex` (stable sort keeps the earliest-declared persona's title for the shared asset), so ids stay unique.

No persona **data** changed — the shared `avatarIndex:1` is intentional; the fix is in the resolution logic. `build-character-from-config` and `character-voice-config` already order id-before-index or are corrected transitively by the first-wins map.

## Evidence (real vitest runs, post-rebase onto current develop)

Deterministic **failing→passing** (the failing state reproduces the bug on develop):

| Suite | Pre-fix | Post-fix |
|---|---|---|
| `packages/shared` `character-presets.test.ts` | **3 failed / 3 passed** | **6 passed** |
| `packages/agent` `server-helpers.test.ts` | **1 failed / 3 passed** | **7 passed** (incl. 3 mirror-helper cases + an RNG-swept greeting assert) |

- Pre-fix probe: `resolveStylePresetByAvatarIndex(1)?.id → "chen"`; catalog 9 assets / **8 unique ids**. Post-fix probe: `byAvatarIndex(1) → eliza`; catalog **8 assets / 8 unique ids**; `injectedCharacters` still 9 (every persona kept).
- Sibling regressions green: `build-character-config.test.ts` (4), `character-language.test.ts` (5), `useDataLoaders` auth-gate + conversation-cache (5).
- Biome clean on all 6 files; `packages/shared` + `packages/agent` typecheck clean. (`packages/ui` has one pre-existing unrelated `iwer` missing-module error in an immersive e2e fixture — not touched by this diff; `useDataLoaders.ts` itself typechecks clean.)

## Scope

6 files: `packages/shared/src/character-presets.ts` (+ new test), `packages/agent/src/api/server-helpers.ts` (+ test), `packages/agent/src/api/server.ts`, `packages/ui/src/state/useDataLoaders.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)