### PR TITLE
fix(cloud): guard refundRedemption against double-refund (in-tx row-locked idempotency check)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/redemption-refund-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/redemption-refund-idempotency.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Redemption refund idempotency — real Drizzle schema, in-process PGlite.
+ *
+ * The money bug: `refundRedemption` moved USD from `total_pending` back to
+ * `available_balance` and inserted an `entry_type='refund'` ledger row keyed
+ * by `redemption_id` with NO existing-refund check inside its transaction —
+ * its only guard was a stale-replica read in the caller
+ * (`payout-processor.ts` `refundStrandedRedemption`). Two concurrent (or
+ * retried) calls both passed the replica check and each credited
+ * `available_balance` — a double-refund. Its sibling `lockForRedemption`
+ * already guards in-tx (findFirst on user_id + redemption_id + entry_type
+ * under the row lock); the fix mirrors that pattern in `refundRedemption`.
+ *
+ * These tests drive the REAL `refundRedemption` against PGlite and assert:
+ *   1. Single refund — balances move correctly, exactly one refund row.
+ *   2. A duplicate call (same redemption_id, sequential AND concurrent)
+ *      refunds ONCE: available_balance up by the amount exactly once,
+ *      total_pending decremented once, ONE 'refund' ledger row.
+ *
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedUser(): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return user.id;
+}
+
+async function balances(userId: string): Promise<{ available: number; pending: number }> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return {
+    available: Number(row?.available_balance ?? 0),
+    pending: Number(row?.total_pending ?? 0),
+  };
+}
+
+async function refundLedgerCount(userId: string, redemptionId: string): Promise<number> {
+  const rows = await dbWrite.query.redeemableEarningsLedger.findMany({
+    where: and(
+      eq(redeemableEarningsLedger.user_id, userId),
+      eq(redeemableEarningsLedger.redemption_id, redemptionId),
+      eq(redeemableEarningsLedger.entry_type, "refund"),
+    ),
+  });
+  return rows.length;
+}
+
+beforeAll(async () => {
+  try {
+    ({ redeemableEarningsService } = await import("../redeemable-earnings"));
+    const schema = {
+      organizations,
+      users,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[redemption-refund-idempotency.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("refundRedemption idempotency", () => {
+  test("pglite applied (loud, never a silent no-op pass)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  let userId: string;
+  let redemptionId: string;
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    userId = await seedUser();
+    redemptionId = crypto.randomUUID();
+    // Refundable state via the real path: earn $10, then lock $4 for redemption.
+    const earned = await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 10,
+      source: "miniapp",
+      sourceId: uniq("earning"),
+      description: "Seed earnings",
+    });
+    expect(earned.success).toBe(true);
+    const locked = await redeemableEarningsService.lockForRedemption({
+      userId,
+      amount: 4,
+      redemptionId,
+    });
+    expect(locked.success).toBe(true);
+    expect(await balances(userId)).toEqual({ available: 6, pending: 4 });
+  });
+
+  test("single refund moves pending back to available and writes one refund row", async () => {
+    if (!pgliteReady) return;
+    const result = await redeemableEarningsService.refundRedemption({
+      userId,
+      redemptionId,
+      amount: 4,
+      reason: "Redemption failed",
+    });
+    expect(result.success).toBe(true);
+    expect(await balances(userId)).toEqual({ available: 10, pending: 0 });
+    expect(await refundLedgerCount(userId, redemptionId)).toBe(1);
+  });
+
+  test("REGRESSION: a duplicate refundRedemption for the same redemption_id refunds ONCE", async () => {
+    if (!pgliteReady) return;
+    const first = await redeemableEarningsService.refundRedemption({
+      userId,
+      redemptionId,
+      amount: 4,
+      reason: "Redemption failed",
+    });
+    // The retry that used to double-credit: same redemption_id, stale caller guard.
+    const second = await redeemableEarningsService.refundRedemption({
+      userId,
+      redemptionId,
+      amount: 4,
+      reason: "Redemption failed",
+    });
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    // Credited exactly once: available 6 → 10 (NOT 14), pending 4 → 0.
+    expect(await balances(userId)).toEqual({ available: 10, pending: 0 });
+    expect(await refundLedgerCount(userId, redemptionId)).toBe(1);
+  });
+
+  test("REGRESSION: a concurrent refund pair for the same redemption_id refunds ONCE", async () => {
+    if (!pgliteReady) return;
+    const [first, second] = await Promise.all([
+      redeemableEarningsService.refundRedemption({
+        userId,
+        redemptionId,
+        amount: 4,
+        reason: "Redemption failed",
+      }),
+      redeemableEarningsService.refundRedemption({
+        userId,
+        redemptionId,
+        amount: 4,
+        reason: "Redemption failed",
+      }),
+    ]);
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(await balances(userId)).toEqual({ available: 10, pending: 0 });
+    expect(await refundLedgerCount(userId, redemptionId)).toBe(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -822,7 +822,32 @@ class RedeemableEarningsService {
 
     const amountDecimal = new Decimal(amount).toFixed(4);
 
-    await dbWrite.transaction(async (tx) => {
+    const isExisting = await dbWrite.transaction(async (tx) => {
+      // Get earnings with row lock
+      const [earnings] = await tx
+        .select()
+        .from(redeemableEarnings)
+        .where(eq(redeemableEarnings.user_id, userId))
+        .for("update");
+
+      if (!earnings) {
+        throw new Error("Earnings record not found");
+      }
+
+      // Check for existing refund with same redemption ID (idempotency)
+      const existingRefund = await tx.query.redeemableEarningsLedger.findFirst({
+        where: and(
+          eq(redeemableEarningsLedger.user_id, userId),
+          eq(redeemableEarningsLedger.redemption_id, redemptionId),
+          eq(redeemableEarningsLedger.entry_type, "refund"),
+        ),
+      });
+
+      if (existingRefund) {
+        // Idempotent - already refunded, no mutation
+        return true;
+      }
+
       // Update balances - move from pending back to available
       const [updated] = await tx
         .update(redeemableEarnings)
@@ -851,6 +876,8 @@ class RedeemableEarningsService {
           refunded_at: new Date().toISOString(),
         }),
       });
+
+      return false;
     });
 
     logger.info("[RedeemableEarnings] Redemption refunded", {
@@ -858,6 +885,7 @@ class RedeemableEarningsService {
       redemptionId: redemptionId.slice(0, 8) + "...",
       amount,
       reason,
+      isExisting,
     });
 
     return { success: true };


### PR DESCRIPTION
## Problem (HIGH, money-integrity)

`RedeemableEarningsService.refundRedemption` moves USD from `total_pending` back to `available_balance` and inserts an `entry_type='refund'` ledger row (keyed by `redemption_id`) **with no idempotency check inside the transaction**. Its sibling `lockForRedemption` guards correctly (row-locks the earnings row, then `findFirst`s the existing ledger entry and returns it without re-mutating) — `refundRedemption` never got that guard.

The only current protection is a **replica read** in the sole caller (`payout-processor.ts` `refundStrandedRedemption`). Two concurrent stranded-refund passes both pass the stale replica check → the refund body runs twice → `available_balance` is **credited twice** (double-refund of real money).

## Fix

Add the same in-tx guard `lockForRedemption` uses, inside `refundRedemption`'s `dbWrite.transaction`, before any mutation:
1. `SELECT ... FOR UPDATE` the per-user `redeemableEarnings` row (serializes concurrent refunds on real Postgres under READ COMMITTED — a bare `findFirst`→`UPDATE` is **not** serialized; the row lock forces the second tx to block, then observe the committed refund row).
2. `findFirst` on `(user_id, redemption_id, entry_type='refund')`. If a refund row already exists → return early with no mutation; the function still returns its normal `{ success: true }`.
Otherwise the original UPDATE + ledger insert run unchanged. No signature/param changes; the caller's replica guard is left in place (defense in depth).

## Test (real PGlite, regression-proven)

New `redemption-refund-idempotency.test.ts` (mirrors `creator-earnings-idempotency.test.ts`; real `pglite://memory`, real `refundRedemption`). Written **test-first**: on the unmodified service both the sequential double-call and the `Promise.all` concurrent pair failed — `available_balance: 14` (expected 10) with **2** refund ledger rows. After the guard: `4 pass / 0 fail / 24 expect() calls`, exactly one refund row, balance moved once.

## Reviewer notes
- PGlite serializes on a single connection, so the concurrent-pair test can't truly interleave transactions the way prod Postgres can — the `FOR UPDATE` row lock is what carries the real-Postgres concurrency guarantee (identical reasoning to `lockForRedemption`).
- The guard keys on *any* existing `refund` row for that `redemption_id` regardless of amount — consistent with the single-refund-per-redemption model `lockForRedemption` already assumes.

Money-path — flagging for @lalalune / cloud-money review; not self-merging. Launch-hardening deepscan, tracked in #8434.

— [cloud-security]
