### PR TITLE
fix(orchestrator): harden native ACP transport I/O robustness (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -666,4 +666,36 @@ describe("splitCommandLine", () => {
       args: ["-y", "pkg name", "--flag", "two words"],
     });
   });
+
+  it("does not let a throwing onEvent break message processing (#11028)", async () => {
+    const seen: unknown[] = [];
+    // A consumer whose onEvent throws must not derail the transport — before the
+    // fix this surfaced as an unhandled rejection out of the un-awaited
+    // handleLine (and broke request/notify synchronously).
+    const { client, p } = await startClient({
+      onEvent: (m) => {
+        seen.push(m);
+        throw new Error("observer boom");
+      },
+    });
+    expect(() =>
+      emitJson(p, { jsonrpc: "2.0", method: "session/update", params: { x: 1 } }),
+    ).not.toThrow();
+    // The client is still healthy: a fresh request round-trips.
+    const created = client.createSession("/tmp/native-acp/work");
+    await waitForWrites(p, 2);
+    const call = writeAt(p, p.stdinWrites.length - 1);
+    emitJson(p, { jsonrpc: "2.0", id: call.id as number, result: { sessionId: "s1" } });
+    await expect(created).resolves.toMatchObject({ sessionId: "s1" });
+    expect(seen.length).toBeGreaterThan(0);
+  });
+
+  it("does not let a throwing onStderr break the stderr stream (#11028)", async () => {
+    const { p } = await startClient({
+      onStderr: () => {
+        throw new Error("stderr observer boom");
+      },
+    });
+    expect(() => p.stderr.emit("data", Buffer.from("a log line"))).not.toThrow();
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -158,7 +158,13 @@ export class NativeAcpClient {
     proc.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
       this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-16_384);
-      this.opts.onStderr?.(text);
+      // Observer callback — a consumer throw here must not surface as a stream
+      // 'error' event that tears down stderr for the whole agent.
+      try {
+        this.opts.onStderr?.(text);
+      } catch {
+        // best-effort observability; swallow
+      }
     });
     proc.on("error", (err) => this.rejectAll(err));
     proc.on("close", (code, signal) => {
@@ -277,7 +283,7 @@ export class NativeAcpClient {
     const id = this.nextId++;
     const proc = this.requireProcess();
     const payload = { jsonrpc: "2.0", id, method, params };
-    this.opts.onEvent?.(payload as AcpJsonRpcMessage);
+    this.emitEvent(payload as AcpJsonRpcMessage);
     proc.stdin.write(`${JSON.stringify(payload)}\n`);
     return new Promise((resolve, reject) => {
       const timer =
@@ -295,8 +301,23 @@ export class NativeAcpClient {
   private async notify(method: string, params: unknown): Promise<void> {
     const proc = this.requireProcess();
     const payload = { jsonrpc: "2.0", method, params };
-    this.opts.onEvent?.(payload as AcpJsonRpcMessage);
+    this.emitEvent(payload as AcpJsonRpcMessage);
     proc.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  /**
+   * Fire the onEvent observer without letting a consumer's throw derail the
+   * transport. onEvent is best-effort observability (trajectory capture); a
+   * throw used to propagate — synchronously breaking `request`/`notify`, or as
+   * an unhandled rejection out of the un-awaited `handleLine` — instead of being
+   * contained here.
+   */
+  private emitEvent(message: AcpJsonRpcMessage): void {
+    try {
+      this.opts.onEvent?.(message);
+    } catch {
+      // best-effort observer; swallow so ACP I/O keeps flowing
+    }
   }
 
   private requireProcess(): ChildProcessWithoutNullStreams {
@@ -322,7 +343,7 @@ export class NativeAcpClient {
     } catch {
       return;
     }
-    this.opts.onEvent?.(message);
+    this.emitEvent(message);
 
     const id = (message as { id?: JsonRpcId }).id;
     if (id !== undefined && ("result" in message || "error" in message)) {
@@ -466,7 +487,15 @@ export class NativeAcpClient {
       record.output += chunk.toString("utf8");
       if (Buffer.byteLength(record.output, "utf8") > record.limit) {
         record.truncated = true;
-        record.output = record.output.slice(-record.limit);
+        // Keep the last `limit` BYTES, not characters. `String.slice(-limit)`
+        // keeps `limit` CHARACTERS, so multi-byte UTF-8 output could exceed the
+        // byte budget by up to 4×. Slice the encoded buffer to the last `limit`
+        // bytes, then drop any leading UTF-8 continuation bytes so we decode on
+        // a character boundary.
+        const tail = Buffer.from(record.output, "utf8").subarray(-record.limit);
+        let start = 0;
+        while (start < tail.length && (tail[start] & 0xc0) === 0x80) start += 1;
+        record.output = tail.subarray(start).toString("utf8");
       }
     };
     proc.stdout.on("data", capture);


### PR DESCRIPTION
Four audit-2 findings (adversarially verified) in `acp-native-transport.ts`.

- **Terminal byte cap truncated by characters (high).** `record.output.slice(-limit)` keeps `limit` *characters*, but the budget is *bytes* — multi-byte UTF-8 could retain up to 4× the limit. Now slices the encoded buffer to the last `limit` bytes and skips leading UTF-8 continuation bytes so it decodes on a char boundary.
- **`onEvent` could throw and derail the transport.** It fired raw at three sites (`request`, `notify`, `handleLine`); a consumer throw propagated synchronously out of `request`/`notify`, or as an unhandled rejection from the un-awaited `handleLine`. Routed all three through one `emitEvent()` that contains the throw — `onEvent` is best-effort observability (trajectory capture) and must not break ACP I/O.
- **`onStderr` could throw inside the stream `'data'` listener**, which can emit a stream `'error'` and tear down stderr for the whole agent. Wrapped in try/catch.

```
$ bunx vitest run acp-native-transport → 30 passed
```
+2 cases: a throwing `onEvent` still lets a fresh request round-trip (no throw on inbound); a throwing `onStderr` doesn't break the stream.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)