### PR TITLE
fix(orchestrator): make session updateStatus terminal-guard atomic (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
@@ -125,6 +125,30 @@ describe("InMemorySessionStore", () => {
     await expect(store.list()).resolves.toHaveLength(25);
   });
 
+  it("does not downgrade a terminal status under concurrent updates (#11028)", async () => {
+    const store = new InMemorySessionStore();
+    await store.create(session({ id: "race", status: "running" }));
+    // A terminal update racing several non-terminal ones. With the guard checked
+    // outside the write queue, all four read "running", all pass the guard, and
+    // the last-enqueued (a non-terminal) would win — downgrading the session
+    // back to a live status. The guard now lives inside the queue.
+    await Promise.all([
+      store.updateStatus("race", "busy"),
+      store.updateStatus("race", "stopped"),
+      store.updateStatus("race", "running"),
+      store.updateStatus("race", "tool_running"),
+    ]);
+    expect((await store.get("race"))?.status).toBe("stopped");
+  });
+
+  it("ignores a terminal → non-terminal downgrade", async () => {
+    const store = new InMemorySessionStore();
+    await store.create(session({ id: "term", status: "running" }));
+    await store.updateStatus("term", "stopped");
+    await store.updateStatus("term", "running");
+    expect((await store.get("term"))?.status).toBe("stopped");
+  });
+
   it("sweeps only old stopped and errored sessions", async () => {
     const store = new InMemorySessionStore();
     const old = new Date(Date.now() - 10_000);

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -385,28 +385,33 @@ export class InMemorySessionStore implements SessionStore {
       .map(cloneSession);
   }
 
+  // The actual mutation, run ONLY inside the write queue so read-modify-write is
+  // serialized. Never call from outside an enqueue() (would race).
+  private async applyUpdateLocked(
+    id: string,
+    patch: Partial<SessionInfo>,
+  ): Promise<void> {
+    const current = this.sessions.get(id);
+    if (!current) return;
+    const next: SessionInfo = {
+      ...current,
+      ...patch,
+      lastActivityAt: patch.lastActivityAt
+        ? new Date(patch.lastActivityAt)
+        : new Date(),
+      createdAt: patch.createdAt ? new Date(patch.createdAt) : current.createdAt,
+      metadata: patch.metadata
+        ? { ...patch.metadata }
+        : current.metadata
+          ? { ...current.metadata }
+          : undefined,
+    };
+    this.sessions.set(id, next);
+    await this.afterWrite();
+  }
+
   async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
-    await this.writes.enqueue(async () => {
-      const current = this.sessions.get(id);
-      if (!current) return;
-      const next: SessionInfo = {
-        ...current,
-        ...patch,
-        lastActivityAt: patch.lastActivityAt
-          ? new Date(patch.lastActivityAt)
-          : new Date(),
-        createdAt: patch.createdAt
-          ? new Date(patch.createdAt)
-          : current.createdAt,
-        metadata: patch.metadata
-          ? { ...patch.metadata }
-          : current.metadata
-            ? { ...current.metadata }
-            : undefined,
-      };
-      this.sessions.set(id, next);
-      await this.afterWrite();
-    });
+    await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
   }
 
   async updateStatus(
@@ -414,17 +419,23 @@ export class InMemorySessionStore implements SessionStore {
     status: SessionStatus,
     error?: string,
   ): Promise<void> {
-    const current = this.sessions.get(id);
-    if (
-      current &&
-      TERMINAL_SESSION_STATUSES.has(current.status) &&
-      !TERMINAL_SESSION_STATUSES.has(status)
-    ) {
-      return;
-    }
-    const patch: Partial<SessionInfo> = { status };
-    if (status === "errored") patch.lastError = error;
-    await this.update(id, patch);
+    // Guard + mutate atomically inside ONE queued op. Reading `current` outside
+    // the queue let two concurrent updates both observe a non-terminal status
+    // and both pass the guard, so one could downgrade a terminal status back to
+    // a live one (a stopped/errored session flipping back to running).
+    await this.writes.enqueue(async () => {
+      const current = this.sessions.get(id);
+      if (
+        current &&
+        TERMINAL_SESSION_STATUSES.has(current.status) &&
+        !TERMINAL_SESSION_STATUSES.has(status)
+      ) {
+        return;
+      }
+      const patch: Partial<SessionInfo> = { status };
+      if (status === "errored") patch.lastError = error;
+      await this.applyUpdateLocked(id, patch);
+    });
   }
 
   async delete(id: string): Promise<void> {
@@ -499,6 +510,18 @@ export class FileSessionStore extends InMemorySessionStore {
   async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
     await this.load();
     await super.update(id, patch);
+  }
+
+  override async updateStatus(
+    id: string,
+    status: SessionStatus,
+    error?: string,
+  ): Promise<void> {
+    // Reload from disk first so the terminal-status guard sees a concurrent
+    // process's writes (mirrors update()/delete()). super.updateStatus then runs
+    // the guard + mutate atomically inside the write queue.
+    await this.load();
+    await super.updateStatus(id, status, error);
   }
 
   async delete(id: string): Promise<void> {
@@ -673,26 +696,31 @@ export class RuntimeDbSessionStore implements SessionStore {
     return sessions.filter((session) => matchesFilter(session, filter));
   }
 
-  async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
-    await this.writes.enqueue(async () => {
-      await this.ensureInitialized();
-      const current = await this.getOne(
-        "SELECT * FROM acp_sessions WHERE id = ?",
-        [id],
-      );
-      if (!current) return;
-      await this.upsert({
-        ...current,
-        ...patch,
-        createdAt: patch.createdAt
-          ? new Date(patch.createdAt)
-          : current.createdAt,
-        lastActivityAt: patch.lastActivityAt
-          ? new Date(patch.lastActivityAt)
-          : new Date(),
-        metadata: patch.metadata ? { ...patch.metadata } : current.metadata,
-      });
+  // The actual mutation, run ONLY inside the write queue so read-modify-write is
+  // serialized. Never call from outside an enqueue() (would race).
+  private async applyUpdateLocked(
+    id: string,
+    patch: Partial<SessionInfo>,
+  ): Promise<void> {
+    await this.ensureInitialized();
+    const current = await this.getOne(
+      "SELECT * FROM acp_sessions WHERE id = ?",
+      [id],
+    );
+    if (!current) return;
+    await this.upsert({
+      ...current,
+      ...patch,
+      createdAt: patch.createdAt ? new Date(patch.createdAt) : current.createdAt,
+      lastActivityAt: patch.lastActivityAt
+        ? new Date(patch.lastActivityAt)
+        : new Date(),
+      metadata: patch.metadata ? { ...patch.metadata } : current.metadata,
     });
+  }
+
+  async update(id: string, patch: Partial<SessionInfo>): Promise<void> {
+    await this.writes.enqueue(() => this.applyUpdateLocked(id, patch));
   }
 
   async updateStatus(
@@ -700,17 +728,26 @@ export class RuntimeDbSessionStore implements SessionStore {
     status: SessionStatus,
     error?: string,
   ): Promise<void> {
-    const current = await this.get(id);
-    if (
-      current &&
-      TERMINAL_SESSION_STATUSES.has(current.status) &&
-      !TERMINAL_SESSION_STATUSES.has(status)
-    ) {
-      return;
-    }
-    const patch: Partial<SessionInfo> = { status };
-    if (status === "errored") patch.lastError = error;
-    await this.update(id, patch);
+    // Guard + mutate atomically inside ONE queued op. Reading `current` outside
+    // the queue let a concurrent update slip a terminal status back to a live
+    // one (the same race as InMemorySessionStore).
+    await this.writes.enqueue(async () => {
+      await this.ensureInitialized();
+      const current = await this.getOne(
+        "SELECT * FROM acp_sessions WHERE id = ?",
+        [id],
+      );
+      if (
+        current &&
+        TERMINAL_SESSION_STATUSES.has(current.status) &&
+        !TERMINAL_SESSION_STATUSES.has(status)
+      ) {
+        return;
+      }
+      const patch: Partial<SessionInfo> = { status };
+      if (status === "errored") patch.lastError = error;
+      await this.applyUpdateLocked(id, patch);
+    });
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
Audit-2 confirmed (3/3, high — concurrency) in both `InMemorySessionStore` and `RuntimeDbSessionStore`.

## Bug
`updateStatus` checked the terminal-status downgrade guard **outside** the write queue (`get(id)` → guard → separately-enqueued `update`). Concurrent calls could all read the same non-terminal `current`, all pass the guard, and enqueue in an order where a non-terminal update lands **after** a terminal one — flipping a `stopped`/`errored` session back to `running`/`busy`/`tool_running`, corrupting lifecycle accounting (the spawn-slot gate, terminal filters, cleanup).

## Fix
Extracted the mutation into `applyUpdateLocked` and run **read → guard → write as one queued operation** in both stores, so the guard is serialized against every other write.

```
$ bunx vitest run session-store → 26 passed (2 files)
```
+2 cases: a terminal update racing four non-terminal ones keeps the terminal status (fails without the fix); a terminal→non-terminal downgrade is a no-op.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)