### PR TITLE
fix(cloud): atomic + spend-clamped ad-campaign refunds — stop concurrent/retry double-refund + decrease over-refund (#11292)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
@@ -123,6 +123,47 @@ export class AdCampaignsRepository {
     await db.delete(adCampaigns).where(eq(adCampaigns.id, id));
   }
 
+  /**
+   * Atomically apply an allocation-changing update ONLY if `credits_allocated`
+   * still equals `expectedAllocated` (compare-and-swap). Returns the updated row
+   * when this caller won the claim, or `undefined` when a concurrent budget
+   * change already moved the allocation. Used to make a budget-decrease refund
+   * single-winner so two concurrent decreases can't both refund (#11292).
+   */
+  async claimAllocationChange(
+    id: string,
+    organizationId: string,
+    expectedAllocated: string,
+    data: Partial<NewAdCampaign>,
+  ): Promise<AdCampaign | undefined> {
+    const [updated] = await db
+      .update(adCampaigns)
+      .set({ ...data, updated_at: new Date() })
+      .where(
+        and(
+          eq(adCampaigns.id, id),
+          eq(adCampaigns.organization_id, organizationId),
+          eq(adCampaigns.credits_allocated, expectedAllocated),
+        ),
+      )
+      .returning();
+    return updated;
+  }
+
+  /**
+   * Atomically delete the campaign and return the deleted row — but only the
+   * caller that actually removed the row gets it back; a concurrent second
+   * delete (or a retry after a mid-op failure) gets `undefined`. Gates the
+   * unused-budget refund so a delete can't double-refund (#11292).
+   */
+  async claimDelete(id: string, organizationId: string): Promise<AdCampaign | undefined> {
+    const [deleted] = await db
+      .delete(adCampaigns)
+      .where(and(eq(adCampaigns.id, id), eq(adCampaigns.organization_id, organizationId)))
+      .returning();
+    return deleted;
+  }
+
   async getStats(
     organizationId: string,
     options?: { adAccountId?: string; platform?: AdPlatform },

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -77,7 +77,9 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
   beforeEach(() => {
     // Not synced to a platform → no platform delete, no metrics refresh; the
     // stored total_spend is used directly (the simplest path through the fix).
-    track(spyOn(adCampaignsRepository, "delete").mockResolvedValue(undefined));
+    // claimDelete gates the refund: only the caller that wins the atomic delete
+    // gets the row back and refunds (#11292).
+    track(spyOn(adCampaignsRepository, "claimDelete").mockResolvedValue(makeCampaign() as never));
   });
 
   test("budget 100 / allocated 110 / spent 40 → refunds 66, not the full 110", async () => {
@@ -179,6 +181,26 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
     await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
 
     expect(refund).not.toHaveBeenCalled();
+  });
+
+  test("#11292 concurrent delete: the loser (claimDelete returns nothing) refunds nothing", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ total_spend: "40" }) as never,
+      ),
+    );
+    // This caller LOST the atomic delete race — claimDelete returns undefined.
+    track(spyOn(adCampaignsRepository, "claimDelete").mockResolvedValue(undefined as never));
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    const tx = track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    // The winner already refunded the 66 unused; the loser must NOT double-refund.
+    expect(refund).not.toHaveBeenCalled();
+    expect(tx).not.toHaveBeenCalled();
   });
 });
 
@@ -305,6 +327,134 @@ describe("updateCampaign — reconciles the credit hold on a budget change", () 
     expect(updated.name).toBe("Renamed");
     // No budgetAmount in the input → no budget delta → no credit movement.
     expect(deduct).not.toHaveBeenCalled();
+    expect(refund).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateCampaign — budget DECREASE refunds only unused + is atomic (#11292)", () => {
+  beforeEach(() => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: "acct-1",
+        organization_id: ORG_ID,
+        platform: "meta",
+      } as never),
+    );
+    track(
+      spyOn(
+        advertisingService as unknown as { getCredentials: () => Promise<unknown> },
+        "getCredentials",
+      ).mockResolvedValue({} as never),
+    );
+    track(spyOn(advertisingService, "getProvider").mockReturnValue(stubProvider()));
+  });
+
+  test("decrease AFTER spend refunds only the UNUSED portion, not the full delta", async () => {
+    // budget 100 / allocated 110, external spend 80 USD → 88 allocated-credit
+    // units spent (markup 1.1). Decrease to 10 (new allocated 11): freed = 99,
+    // but only 110-88 = 22 is genuinely unused → refund 22, NOT 99 (the pre-fix
+    // over-refund that returned credits already spent on real impressions).
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    track(
+      spyOn(advertisingService, "getCampaignMetrics").mockResolvedValue({
+        spend: 80,
+        impressions: 0,
+        clicks: 0,
+        conversions: 0,
+      } as never),
+    );
+    const claim = track(
+      spyOn(adCampaignsRepository, "claimAllocationChange").mockResolvedValue(
+        makeCampaign({
+          external_campaign_id: "ext-1",
+          budget_amount: "10",
+          credits_allocated: "11",
+        }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+
+    await advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, { budgetAmount: 10 });
+
+    expect(claim).toHaveBeenCalledTimes(1);
+    // Atomic CAS keyed on the OBSERVED allocation ("110").
+    expect(claim.mock.calls[0]?.[2]).toBe("110");
+    // credits_allocated is written as newBudget*markup (11), NOT clamped to spend
+    // — so the markup derived at delete (allocated/budget) stays correct.
+    expect((claim.mock.calls[0]?.[3] as { credits_allocated?: string }).credits_allocated).toBe(
+      "11",
+    );
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(22, 9);
+  });
+
+  test("decrease with NO spend refunds the full freed amount", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    track(
+      spyOn(advertisingService, "getCampaignMetrics").mockResolvedValue({
+        spend: 0,
+        impressions: 0,
+        clicks: 0,
+        conversions: 0,
+      } as never),
+    );
+    track(
+      spyOn(adCampaignsRepository, "claimAllocationChange").mockResolvedValue(
+        makeCampaign({
+          external_campaign_id: "ext-1",
+          budget_amount: "10",
+          credits_allocated: "11",
+        }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+
+    await advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, { budgetAmount: 10 });
+
+    // freed = 110 - 11 = 99, unused = 110 (nothing spent) → refund the full 99.
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(99, 9);
+  });
+
+  test("concurrent decrease: a LOST CAS (claimAllocationChange returns nothing) throws and refunds nothing", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    track(
+      spyOn(advertisingService, "getCampaignMetrics").mockResolvedValue({
+        spend: 0,
+        impressions: 0,
+        clicks: 0,
+        conversions: 0,
+      } as never),
+    );
+    // Another concurrent decrease already moved credits_allocated → CAS misses.
+    track(
+      spyOn(adCampaignsRepository, "claimAllocationChange").mockResolvedValue(undefined as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+
+    await expect(
+      advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, { budgetAmount: 10 }),
+    ).rejects.toThrow("changed concurrently");
+
+    // The winner refunded; the loser must NOT double-refund.
     expect(refund).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -670,18 +670,7 @@ class AdvertisingService {
       throw new Error(result.error || "Failed to update campaign");
     }
 
-    // Platform accepted — refund a budget DECREASE now (never refund before the
-    // live budget is actually lowered).
-    if (budgetCreditDelta < 0) {
-      await creditsService.refundCredits({
-        organizationId,
-        amount: -budgetCreditDelta,
-        description: `Ad budget decrease refund: ${campaign.name}`,
-        metadata: { type: "ad_budget_decrease_refund", campaignId },
-      });
-    }
-
-    const updated = await adCampaignsRepository.update(campaignId, {
+    const updateData = {
       name: input.name,
       budget_amount: input.budgetAmount ? String(input.budgetAmount) : undefined,
       ...(newCreditsAllocated !== undefined
@@ -690,7 +679,50 @@ class AdvertisingService {
       start_date: input.startDate,
       end_date: input.endDate,
       targeting: input.targeting,
-    });
+    };
+
+    let updated: AdCampaign | undefined;
+    if (budgetCreditDelta < 0 && newCreditsAllocated !== undefined) {
+      // Platform accepted a budget DECREASE. Two money leaks fixed here (#11292):
+      //  1. Over-refund after spend: the old code refunded the FULL allocation
+      //     delta, ignoring spend. Refund only the genuinely-UNUSED portion (the
+      //     same clamp deleteCampaign applies), so a decrease can never refund
+      //     credits already spent on real impressions.
+      //  2. Concurrent double-refund: claim the allocation change atomically
+      //     (CAS on the observed credits_allocated) so only ONE of two
+      //     simultaneous decreases refunds.
+      // credits_allocated stays == newBudget*markup (never clamp the STORED
+      // allocation) so the markup derived at delete (allocated/budget) stays
+      // correct — only the REFUND is clamped.
+      const oldAllocated = parseFloat(campaign.credits_allocated);
+      const spentCredits = await this.computeCreditsSpent(campaign);
+      const freed = oldAllocated - newCreditsAllocated;
+      const unused = Math.max(0, oldAllocated - spentCredits);
+      const refundAmount = Math.max(0, Math.min(freed, unused));
+
+      updated = await adCampaignsRepository.claimAllocationChange(
+        campaignId,
+        organizationId,
+        campaign.credits_allocated,
+        updateData,
+      );
+      if (!updated) {
+        // Another budget change moved credits_allocated between our read and
+        // this atomic write — refuse rather than risk a double refund. Safe to
+        // retry (the campaign was not modified by this call).
+        throw new Error("Campaign budget changed concurrently; please retry");
+      }
+      if (refundAmount > 0) {
+        await creditsService.refundCredits({
+          organizationId,
+          amount: refundAmount,
+          description: `Ad budget decrease refund: ${campaign.name}`,
+          metadata: { type: "ad_budget_decrease_refund", campaignId },
+        });
+      }
+    } else {
+      updated = await adCampaignsRepository.update(campaignId, updateData);
+    }
 
     logger.info("[Advertising] Campaign updated", { campaignId });
 
@@ -759,6 +791,50 @@ class AdvertisingService {
     return updated!;
   }
 
+  /**
+   * Credits genuinely spent for a campaign, honoring BOTH spend columns (#11151):
+   *   - internal miniapp SSP spend → `credits_spent` (already in allocated-credit
+   *     units, written by adSlotsRepository.recordServe per served impression).
+   *   - external-provider spend → `total_spend` (USD; converted to allocated-
+   *     credit units at the same markup applied at allocation). Best-effort
+   *     refreshed from the provider first so a never-synced campaign can't
+   *     under-count spend and over-refund.
+   * Takes the MAX of the two measures (never double-count) and clamps to the
+   * allocation, so a refund derived from `allocated - spent` can never return
+   * credits already spent on real impressions. Shared by deleteCampaign and the
+   * updateCampaign budget-decrease refund (#11292).
+   */
+  private async computeCreditsSpent(campaign: {
+    id: string;
+    organization_id: string;
+    external_campaign_id: string | null;
+    credits_allocated: string;
+    budget_amount: string;
+    credits_spent: string;
+    total_spend: string;
+  }): Promise<number> {
+    let totalSpendUsd = parseFloat(campaign.total_spend);
+    if (campaign.external_campaign_id) {
+      try {
+        const freshMetrics = await this.getCampaignMetrics(campaign.id, campaign.organization_id);
+        if (Number.isFinite(Number(freshMetrics.spend))) {
+          totalSpendUsd = Number(freshMetrics.spend);
+        }
+      } catch (metricsError) {
+        logger.warn("[Advertising] spend refresh failed; using stored total_spend", {
+          campaignId: campaign.id,
+          error: metricsError instanceof Error ? metricsError.message : String(metricsError),
+        });
+      }
+    }
+    const creditsAllocated = parseFloat(campaign.credits_allocated);
+    const budgetAmountUsd = parseFloat(campaign.budget_amount);
+    const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
+    const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
+    const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
+    return Math.min(creditsAllocated, Math.max(internalSpentCredits, externalSpentCredits));
+  }
+
   async deleteCampaign(campaignId: string, organizationId: string): Promise<void> {
     const campaign = await adCampaignsRepository.findById(campaignId);
     if (!campaign || campaign.organization_id !== organizationId) {
@@ -778,51 +854,23 @@ class AdvertisingService {
       }
     }
 
-    // Refund the genuinely-UNUSED budget. Spend accrues on TWO different columns
-    // depending on the campaign type, and the refund must honor BOTH (#11151):
-    //   - internal miniapp SSP spend → `credits_spent` (allocated-credit units,
-    //     written by adSlotsRepository.recordServe on every served impression,
-    //     #10942/#11029). NOTE: the earlier "credits_spent is never written"
-    //     reasoning is STALE — it only checked incrementSpend's callers and
-    //     missed recordServe's direct UPDATE.
-    //   - external-provider spend → `total_spend` (USD, synced by getCampaignMetrics).
-    // Refunding off `total_spend` ALONE let a purely-internal campaign
-    // (external_campaign_id = null, so total_spend stays "0") refund its ENTIRE
-    // prepaid budget + markup after spending it on real impressions ("free
-    // advertising", platform eats the publisher payouts). Convert the external
-    // USD spend into allocated-credit units at the same markup applied at
-    // allocation, take the MAX of the two spent measures, and refund only the
-    // remainder — so a campaign of either kind (or both) can never be refunded
-    // past its genuinely-unused allocation. Best-effort refresh external spend
-    // first so a never-synced provider campaign can't over-refund.
-    let totalSpendUsd = parseFloat(campaign.total_spend);
-    if (campaign.external_campaign_id) {
-      try {
-        const freshMetrics = await this.getCampaignMetrics(campaignId, organizationId);
-        if (Number.isFinite(Number(freshMetrics.spend))) {
-          totalSpendUsd = Number(freshMetrics.spend);
-        }
-      } catch (metricsError) {
-        logger.warn(
-          "[Advertising] spend refresh before delete-refund failed; using stored total_spend",
-          {
-            campaignId,
-            error: metricsError instanceof Error ? metricsError.message : String(metricsError),
-          },
-        );
-      }
+    // Compute the genuinely-unused refund BEFORE the atomic claim — the spend
+    // refresh inside computeCreditsSpent needs the row to still exist. The
+    // two-column (#11151) spend logic lives in the shared helper.
+    const creditsSpent = await this.computeCreditsSpent(campaign);
+    const creditsRemaining = Math.max(0, parseFloat(campaign.credits_allocated) - creditsSpent);
+
+    // Atomic claim: only the caller that actually removes the row refunds, so
+    // two concurrent deletes (or a delete retried after a mid-op failure) can't
+    // both refund the unused budget (#11292). claimDelete returns the row only
+    // to the winner.
+    const deleted = await adCampaignsRepository.claimDelete(campaignId, organizationId);
+    if (!deleted) {
+      logger.info("[Advertising] Campaign already deleted concurrently; skipping refund", {
+        campaignId,
+      });
+      return;
     }
-    const creditsAllocated = parseFloat(campaign.credits_allocated);
-    const budgetAmountUsd = parseFloat(campaign.budget_amount);
-    const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
-    // credits_spent is already in allocated-credit units; total_spend is USD → scale by markup.
-    const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
-    const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
-    const creditsSpent = Math.min(
-      creditsAllocated,
-      Math.max(internalSpentCredits, externalSpentCredits),
-    );
-    const creditsRemaining = Math.max(0, creditsAllocated - creditsSpent);
 
     if (creditsRemaining > 0) {
       await creditsService.refundCredits({
@@ -842,8 +890,6 @@ class AdvertisingService {
         description: `Refund for deleted campaign: ${campaign.name}`,
       });
     }
-
-    await adCampaignsRepository.delete(campaignId);
 
     logger.info("[Advertising] Campaign deleted", { campaignId });
   }

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -799,10 +799,12 @@ class AdvertisingService {
    *     credit units at the same markup applied at allocation). Best-effort
    *     refreshed from the provider first so a never-synced campaign can't
    *     under-count spend and over-refund.
-   * Takes the MAX of the two measures (never double-count) and clamps to the
-   * allocation, so a refund derived from `allocated - spent` can never return
-   * credits already spent on real impressions. Shared by deleteCampaign and the
-   * updateCampaign budget-decrease refund (#11292).
+   * SUMS the two measures and clamps to the allocation (restoring merged
+   * #11255 semantics): the streams are additive, not alternative —
+   * findEligibleAd serves EXTERNAL campaigns through the internal SSP too, so
+   * credits_spent and total_spend accrue independently on one campaign, and
+   * MAX would under-count dual-stream spend and over-refund. Shared by
+   * deleteCampaign and the updateCampaign budget-decrease refund (#11292).
    */
   private async computeCreditsSpent(campaign: {
     id: string;
@@ -832,7 +834,7 @@ class AdvertisingService {
     const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
     const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
     const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
-    return Math.min(creditsAllocated, Math.max(internalSpentCredits, externalSpentCredits));
+    return Math.min(creditsAllocated, internalSpentCredits + externalSpentCredits);
   }
 
   async deleteCampaign(campaignId: string, organizationId: string): Promise<void> {
@@ -880,9 +882,16 @@ class AdvertisingService {
         metadata: { campaignId, campaignName: campaign.name },
       });
 
+      // The campaign row is already deleted by claimDelete, so a campaign_id
+      // here would violate the ad_transactions FK (23503) and 500 every
+      // refunding delete AFTER the refund committed — dropping the ledger row
+      // (onDelete:'set null' rewrites existing rows; it does not permit a
+      // dangling insert). Keep the deleted id in external_reference, matching
+      // the merged #11255 fix this branch predates.
       await adTransactionsRepository.create({
         organization_id: organizationId,
-        campaign_id: campaignId,
+        campaign_id: null,
+        external_reference: campaignId,
         type: "refund",
         amount: String(creditsRemaining),
         currency: campaign.budget_currency,


### PR DESCRIPTION
Fixes #11292 (follow-up to #11255).

## Two live-money leaks in the ad-campaign refund paths

**1. No atomic claim → concurrent / retry double-refund.**
`updateCampaign` (budget decrease) and `deleteCampaign` both did `findById` → compute refund → `refundCredits` with **no row-level claim**, so two concurrent decreases — or a delete retried after the refund succeeded but the row-delete threw — both refunded the same unused budget.

**2. `updateCampaign` decrease over-refunded after spend.**
It refunded the **full** allocation delta (`old_allocated - new_allocated`), ignoring `credits_spent`/`total_spend` — so lowering a budget after real ad spend returned credits already spent on impressions. (`deleteCampaign` already clamps; `updateCampaign` did not.)

## Fix
- **Atomic CAS claims** (new repo methods, mirroring the existing `incrementSpend` atomic-SQL pattern):
  - `claimAllocationChange` — `UPDATE … WHERE credits_allocated = <observed> RETURNING`; only the winner refunds a decrease, a lost CAS throws a **retryable** conflict (never double-refunds).
  - `claimDelete` — `DELETE … RETURNING`; only the caller that removes the row refunds.
- **Spend-clamped decrease refund** — `refund = min(freed, unused)`, reusing `deleteCampaign`'s proven two-column (#11151) spend logic, now extracted into a shared `computeCreditsSpent` helper (rule-2 reuse — one calculation for both paths).
- **Markup invariant preserved** — `credits_allocated` stays `= newBudget × markup` (only the *refund* is clamped, never the stored allocation), so the markup derived at delete (`allocated / budget`) stays correct. This is the coupling that would make a naive clamp corrupt future refund math (see #11292 for the full trace).

## Evidence
`bun test packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts`

```
 12 pass
 0 fail
 30 expect() calls
Ran 12 tests across 1 file.
```

The 5 existing #11151 delete tests + 3 existing update tests still pass (helper extraction is behavior-preserving); **4 new tests** cover the fixes:
- decrease-after-spend refunds only the unused 22, **not** the full 99;
- decrease with no spend refunds the full 99;
- concurrent decrease (lost CAS) **throws** and refunds nothing;
- concurrent delete (lost claimDelete) refunds nothing.

**Mutation-checked** (proving the tests catch the bugs, not just pass):
- revert the clamp to `Math.max(0, freed)` → the decrease-after-spend test fails (`Received: 99, Expected: 22`, the exact 77 over-refund);
- remove the conflict `throw` → the concurrent-decrease test fails (promise resolves instead of rejecting).

Biome clean. `N/A` UI/trajectory — backend money-arithmetic change, no UI/model surface; pinned by the unit suite driving the real `advertisingService` (only repo/credits/provider boundaries spied).

## ⚠️ Review note
Implemented by the main (Opus) model while the Fable agent was rate-capped — money code, so please scrutinize; **do not self-merge**, this is the money lane (@lalalune). The atomic-claim + markup-invariant reasoning is in #11292.
