### PR TITLE
ci: unbreak Linux ISO (ripgrep) + fail-fast preflights for e1-chip attestation & inference-bench manifest

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -100,8 +100,13 @@ jobs:
               echo "have_kvm=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install just
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends just
+      - name: Install just + ripgrep
+        # ripgrep (rg) is a hard dependency of packages/os/linux/scripts/static-smoke.sh
+        # (the "Verify riscv64 contract" step). It is no longer pre-installed on the
+        # ubuntu-24.04 runner image, so the step used to build every riscv64 target
+        # successfully and then exit 1 with the opaque "ripgrep (rg) is required …"
+        # line. Install it explicitly here so the smoke check can run.
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends just ripgrep
 
       - name: Register qemu-user-static binfmt (non-amd64 only)
         if: matrix.arch != 'amd64'

--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -28,6 +28,25 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Preflight — AlphaChip checkpoint-blocker attestation freshness
+        # `make clean ci-fast` (the regression step below) runs docs-check ->
+        # ai-eda-alphachip-checkpoint-blocker-check, a MONTHLY attestation that
+        # the AlphaChip TPU checkpoint is still 403-blocked / closed-source. The
+        # check fails when docs/toolchain/alphachip-checkpoint-blocker.md +
+        # external/circuit_training/pin-manifest.json ("Last audited" /
+        # last_audited) are not in the current month. On a month rollover it
+        # therefore fails DEEP inside the run — after ~10 min of building the
+        # Verilator/yosys tool image — with an opaque `make: Error 1`.
+        #
+        # The check is pure Python (pyyaml only) and needs no built toolchain, so
+        # run it on the host FIRST. A stale attestation fails here in seconds with
+        # the exact actionable message instead of burning the toolchain build.
+        # This is a fail-fast surface for a deliberate human re-attestation gate;
+        # it does not weaken or auto-satisfy the gate.
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/ai_eda/check_alphachip_checkpoint_blocker.py --run-id "preflight-${GITHUB_RUN_ID}"
+
       - name: Build tool image
         run: docker build -t eliza-soc-tools .
 

--- a/.github/workflows/local-inference-bench.yml
+++ b/.github/workflows/local-inference-bench.yml
@@ -152,6 +152,16 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Preflight — published eliza-1 manifest shape
+        # The harness downloads the PUBLISHED HuggingFace bundle manifest and
+        # validates it against the Eliza-1 manifest schema before fetching any
+        # weight. A malformed published manifest (e.g. `files.vision` as an
+        # object instead of an array — the 2026-06→07 Gemma-4 cutover defect)
+        # otherwise fails the run ~5 minutes in, AFTER a full bun install +
+        # agent boot, with an opaque "expected array, received object" trace.
+        # Fail fast here with an operator-actionable message instead.
+        run: node packages/scripts/benchmark/preflight-eliza1-manifest.mjs eliza-1-2b
+
       - name: Install dependencies
         run: bun install --frozen-lockfile || bun install --no-frozen-lockfile
 

--- a/packages/scripts/benchmark/preflight-eliza1-manifest.mjs
+++ b/packages/scripts/benchmark/preflight-eliza1-manifest.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Loud preflight for the Local Inference Bench nightly lane.
+//
+// The nightly job boots `bun run dev`, then `profile-inference.mjs --ensure-models`
+// asks the running agent to download the bench models. The agent fetches the
+// PUBLISHED HuggingFace bundle manifest and validates it against the Eliza-1
+// manifest schema before touching any weight byte. When a published manifest is
+// malformed (e.g. `files.vision` emitted as an object instead of an array, as
+// happened during the 2026-06→07 Gemma-4 cutover), the download fails with a
+// mid-run stack trace ~5 minutes into the run — AFTER a full `bun install` +
+// agent boot. That is a confusing, expensive red for what is really a
+// bad-published-artifact problem the CI runner cannot fix.
+//
+// This preflight fetches the published manifest(s) for the bench tiers and
+// asserts the shape the runtime schema requires (packages/shared manifest
+// schema: every `files.<kind>` bucket is an ARRAY). It runs in seconds, before
+// the install/boot, and fails LOUDLY with an operator-actionable message so the
+// lane stops burning minutes on an unfixable artifact defect.
+//
+// Usage:
+//   node packages/scripts/benchmark/preflight-eliza1-manifest.mjs eliza-1-2b [eliza-1-4b ...]
+//
+// Exit codes: 0 = manifest(s) valid; 2 = malformed/unreachable manifest.
+
+const HF_REPO = "elizaos/eliza-1";
+const HF_BASE = (process.env.ELIZA_HF_BASE_URL || "https://huggingface.co").replace(/\/+$/, "");
+
+// tier id -> published bundle prefix (mirrors catalog `bundleRemotePrefix`)
+const TIER_SLUG = {
+  "eliza-1-2b": "2b",
+  "eliza-1-4b": "4b",
+  "eliza-1-9b": "9b",
+  "eliza-1-27b": "27b",
+  "eliza-1-27b-256k": "27b-256k",
+};
+
+// Buckets the runtime schema requires to be a NON-EMPTY array.
+const REQUIRED_ARRAY = ["text", "voice", "cache"];
+// Buckets the runtime schema requires to be an array (may be empty).
+const ARRAY_KINDS = ["asr", "vision", "mtp"];
+
+function manifestUrl(tierId) {
+  const slug = TIER_SLUG[tierId];
+  if (!slug) throw new Error(`unknown tier id: ${tierId}`);
+  return `${HF_BASE}/${HF_REPO}/resolve/main/bundles/${slug}/eliza-1.manifest.json?download=true`;
+}
+
+async function fetchManifest(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} fetching ${url}`);
+  }
+  return res.json();
+}
+
+function validateShape(tierId, manifest) {
+  const problems = [];
+  const files = manifest?.files;
+  if (files == null || typeof files !== "object" || Array.isArray(files)) {
+    problems.push("`files` is missing or not an object");
+    return problems;
+  }
+  for (const kind of [...REQUIRED_ARRAY, ...ARRAY_KINDS]) {
+    const v = files[kind];
+    if (!Array.isArray(v)) {
+      problems.push(
+        `files.${kind}: expected array, received ${v === undefined ? "undefined" : Array.isArray(v) ? "array" : typeof v}`,
+      );
+      continue;
+    }
+    if (REQUIRED_ARRAY.includes(kind) && v.length === 0) {
+      problems.push(`files.${kind}: required non-empty array, received empty array`);
+    }
+  }
+  return problems;
+}
+
+async function main() {
+  const tiers = process.argv.slice(2);
+  if (tiers.length === 0) {
+    process.stderr.write("[preflight-manifest] no tier ids supplied\n");
+    process.exit(2);
+  }
+  let failed = false;
+  for (const tierId of tiers) {
+    const url = manifestUrl(tierId);
+    try {
+      const manifest = await fetchManifest(url);
+      const problems = validateShape(tierId, manifest);
+      if (problems.length > 0) {
+        failed = true;
+        process.stderr.write(
+          `\n[preflight-manifest] ✗ ${tierId} published manifest is MALFORMED:\n`,
+        );
+        for (const p of problems) process.stderr.write(`    - ${p}\n`);
+        process.stderr.write(`    manifest: ${url}\n`);
+      } else {
+        process.stdout.write(
+          `[preflight-manifest] ✓ ${tierId} published manifest shape OK\n`,
+        );
+      }
+    } catch (err) {
+      failed = true;
+      process.stderr.write(`\n[preflight-manifest] ✗ ${tierId}: ${err.message}\n`);
+    }
+  }
+  if (failed) {
+    process.stderr.write(
+      "\n[preflight-manifest] The nightly bench downloads the PUBLISHED HuggingFace\n" +
+        "  bundle manifest and validates it against the Eliza-1 manifest schema before\n" +
+        "  fetching weights. The manifest above does not match the schema, so booting\n" +
+        "  the agent and running the harness would fail ~5 minutes in with an opaque\n" +
+        "  'expected array, received object' stack trace.\n\n" +
+        "  This is a PUBLISHED-ARTIFACT defect, not a code or runner problem. Fix it by\n" +
+        "  regenerating the bundle manifest with packages/training/scripts/manifest/ and\n" +
+        `  re-publishing to https://huggingface.co/${HF_REPO} (needs HF write access).\n`,
+    );
+    process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`[preflight-manifest] FATAL: ${err?.stack || err}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
Triage of the remaining chronically-red infra/nightly lanes. Three code changes; two other lanes are already-resolved no-ops (reported, not manufactured).

1. **Build elizaOS Linux ISO** (code-fixable): the 'Verify riscv64 contract' step builds all 4 targets green, then `static-smoke.sh` hard-requires `rg` for its banned-color/theme greps — ripgrep is no longer pre-installed on ubuntu-24.04 runners, so it exits 1 after ~30s. Install `ripgrep` alongside `just` (the gate is legitimate; satisfy the dep rather than drop the check). *Follow-up: elizaos-os-release.yml shares this.*

2. **e1-chip** (deliberate monthly-attestation gate + fail-fast): the AlphaChip checkpoint-blocker doc audit went stale on the June→July rollover (`stale: 2026-06-02, current month 2026-07`), failing ~10 min in after the full EDA toolchain build. Added a cheap pyyaml-only preflight as the first step so a stale month fails in seconds with the exact remediation — does NOT weaken or fake the attestation. Runbook in the PR/commit for the monthly re-attest.

3. **Local Inference Bench** (artifact-gated, already re-published + hardened): the published HF `eliza-1-2b` manifest emitted `files.vision` as an object during the Gemma-4 cutover; runtime + generator both correctly require an array, so it rejected ~5 min in with an opaque trace. The HF artifact is already re-published (2b + 4b now arrays). Added a manifest preflight that fails fast in seconds with an operator-actionable message if a future republish is malformed.

No-ops (honest): 'github_actions Update #1443566760' Dependabot job — the bump (github-script v9) is already applied, zero open bump PRs. 'Training Stack' — already fixed on develop by #10632 (`f51f2d0133c`); the two runs after it are green.

actionlint clean on all 3 workflows; node --check clean on the new preflight; both preflights tested pass-and-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)