### PR TITLE
fix(cloud): count stopped/sleeping agents toward the per-org quota + cap the normal create path (close #11023 suspend-loop residual)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -245,7 +245,12 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(triggerImmediate).not.toHaveBeenCalled();
   });
 
-  test("#11023: default (no forceCreate) create passes NO cap (uncapped reuse path unchanged)", async () => {
+  test("#11023 F3: default (no forceCreate) create passes the SAME balance-tiered cap as forceCreate", async () => {
+    // Suspended (`stopped`) / slept (`sleeping`) agents keep their per-tenant
+    // managed DB but are not LIVE, so after a suspend the reuse guard has
+    // nothing to hand back — an uncapped normal path would mint a fresh row on
+    // every create (the create→suspend→create fleet-DoS loop, the residual of
+    // #11023). The route must bound the reuse path's fresh insert too.
     const agent = pendingAgent();
     createAgent.mockResolvedValue({ agent, idempotent: true });
 
@@ -255,9 +260,11 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     });
 
     const passed = createAgent.mock.calls[0]?.[0] as {
+      reuseExistingNonTerminal?: boolean;
       maxNonTerminalAgents?: number;
     };
-    expect(passed.maxNonTerminalAgents).toBeUndefined();
+    expect(passed.reuseExistingNonTerminal).toBe(true);
+    expect(passed.maxNonTerminalAgents).toBe(500);
   });
 
   test("forceCreate:true on a SHARED-tier create is rejected (400) — no unmetered shared mint past the reuse guard", async () => {

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -345,8 +345,10 @@ app.post("/", async (c) => {
   const shouldProvisionEagerly =
     autoProvision && tierProvisionsEagerly(executionTier);
 
-  // Captured from the credit gate below so the forceCreate quota (#11023) can
-  // scale the org's live-agent ceiling by its balance tier.
+  // Captured from the credit gate below so the per-org agent quota (#11023)
+  // can scale the org's agent ceiling by its balance tier. Stays undefined on
+  // the non-eager (shared-tier) path — no credit gate runs there — so those
+  // creates get the smallest-tier ceiling.
   let orgBalanceForQuota: number | undefined;
 
   if (shouldProvisionEagerly) {
@@ -400,12 +402,16 @@ app.post("/", async (c) => {
       // shared→dedicated handoff's migration target) mints a fresh agent instead
       // of getting the shared one handed back.
       reuseExistingNonTerminal: !parsed.data.forceCreate,
-      // A user-facing forceCreate bypasses the reuse guard, so bound it by the
-      // org's balance-tiered live-agent ceiling — enforced atomically under the
-      // advisory lock — so it can't mint unbounded dedicated containers (#11023).
-      maxNonTerminalAgents: parsed.data.forceCreate
-        ? getMaxNonTerminalAgentsForOrg(orgBalanceForQuota)
-        : undefined,
+      // EVERY user-facing create is bounded by the org's balance-tiered agent
+      // ceiling — enforced atomically under the advisory lock (#11023).
+      // forceCreate needs it because it bypasses the reuse guard; the normal
+      // path needs it because suspended (`stopped`) / slept (`sleeping`)
+      // agents keep their per-tenant managed DB but are not LIVE, so after a
+      // suspend the reuse guard has nothing to hand back and would otherwise
+      // mint a fresh uncapped row on every create (the create→suspend→create
+      // loop). Trusted internal multi-agent callers don't go through this
+      // route and stay uncapped.
+      maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(orgBalanceForQuota),
     });
   } catch (error) {
     if (error instanceof AgentQuotaExceededError) {

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -54,7 +54,9 @@ export type AgentSandboxStatus =
    * storage and its container removed, freeing the compute slot (the node
    * autoscaler reclaims the now-empty Hetzner box). No compute cost accrues.
    * An `agent_wake` job provisions a fresh container and restores state.
-   * Distinct from `stopped` (suspend), which keeps the container + node slot.
+   * Distinct from `stopped` (suspend), which also drops the container and
+   * frees the node slot but keeps the row's `sandbox_id` for a lighter
+   * in-place resume; both retain the per-tenant managed DB.
    */
   | "sleeping"
   | "disconnected"

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
@@ -37,7 +37,7 @@ process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
 import { eq } from "drizzle-orm";
-import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { type AgentSandboxStatus, agentSandboxes } from "../../../db/schemas/agent-sandboxes";
 import { organizations } from "../../../db/schemas/organizations";
 import { userCharacters } from "../../../db/schemas/user-characters";
 import { users } from "../../../db/schemas/users";
@@ -78,6 +78,10 @@ async function countOrgRows(organizationId: string): Promise<number> {
     where: eq(agentSandboxes.organization_id, organizationId),
   });
   return rows.length;
+}
+
+async function setAgentStatus(agentId: string, status: AgentSandboxStatus): Promise<void> {
+  await dbWrite.update(agentSandboxes).set({ status }).where(eq(agentSandboxes.id, agentId));
 }
 
 beforeAll(async () => {
@@ -272,6 +276,179 @@ describe("createCodingContainerAgent — per-org quota (#11023)", () => {
         }),
       ).rejects.toBeInstanceOf(AgentQuotaExceededError);
       expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+/**
+ * F3 residual of #11023: `stopped` (suspend keeps the container + node slot +
+ * per-tenant managed Postgres) and `sleeping` (cold storage keeps the managed
+ * Postgres) retain the org's durable per-agent resources, yet the original
+ * quota counted only `pending`/`provisioning`/`running` — so a
+ * create→suspend→create loop minted unbounded agents, each a real managed DB.
+ * Prong 2: the NORMAL (reuse) create path had no cap at all, and after a
+ * suspend there is no live agent for the reuse guard to hand back, so every
+ * subsequent normal create inserted a fresh uncapped row.
+ */
+describe("suspend/sleep quota residual (#11023 F3)", () => {
+  test(
+    "stopped + sleeping rows still hold their quota slot: both capped create paths throw",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const ids: string[] = [];
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `agent-${i}`,
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+        ids.push(res.agent.id);
+      }
+      // Suspend one, sleep another. Both keep the org's per-tenant managed
+      // Postgres (suspend also keeps the container + node slot), so they must
+      // keep counting toward the ceiling.
+      await setAgentStatus(ids[0], "stopped");
+      await setAgentStatus(ids[1], "sleeping");
+
+      await expect(
+        svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "agent-past-cap",
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      await expect(
+        svc.createCodingContainerAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "cc-past-cap",
+          dockerImage: "ghcr.io/elizaos/tool:v99",
+          executionTier: "custom",
+          maxNonTerminalAgents: CAP,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the create→suspend→create loop is dead: the NORMAL reuse path throws when every existing agent is suspended/sleeping",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const ids: string[] = [];
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `agent-${i}`,
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+        ids.push(res.agent.id);
+      }
+      // Suspend/sleep EVERYTHING: the reuse guard now has no live agent to
+      // hand back, so pre-fix the normal path fell through to an uncapped
+      // insert — one fresh agent (and managed DB) per loop iteration.
+      for (const [i, id] of ids.entries()) {
+        await setAgentStatus(id, i % 2 === 0 ? "stopped" : "sleeping");
+      }
+
+      await expect(
+        svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "agent-loop",
+          executionTier: "dedicated-always",
+          reuseExistingNonTerminal: true,
+          maxNonTerminalAgents: CAP,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "reuse semantics unchanged: at the cap a LIVE agent is still handed back (never a suspended row, never a throw)",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const ids: string[] = [];
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `agent-${i}`,
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+        ids.push(res.agent.id);
+      }
+      await setAgentStatus(ids[0], "stopped");
+
+      const res = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-reuse",
+        executionTier: "dedicated-always",
+        reuseExistingNonTerminal: true,
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(true);
+      expect(res.agent.id).not.toBe(ids[0]);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "terminal states stay excluded: error / deletion_pending rows free their quota slot",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const ids: string[] = [];
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `agent-${i}`,
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+        ids.push(res.agent.id);
+      }
+      await setAgentStatus(ids[0], "error");
+      await setAgentStatus(ids[1], "deletion_pending");
+
+      const res = await svc.createAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "agent-after-terminal",
+        executionTier: "dedicated-always",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+      expect(await countOrgRows(orgId)).toBe(CAP + 1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -116,10 +116,10 @@ export interface CreateAgentParams {
 
 /**
  * Statuses that COUNT toward `maxNonTerminalAgents`: the live states plus
- * `stopped` (suspend keeps the container + node slot + per-tenant managed
- * Postgres) and `sleeping` (cold storage keeps the managed Postgres). Both
- * still hold the org's durable per-agent resources, so a
- * create→suspend→create loop must not mint fresh agents past the ceiling
+ * `stopped` (suspend) and `sleeping` (cold storage). Both drop the container
+ * and free the node slot, but each RETAINS the org's per-tenant managed
+ * Postgres — the durable, costly resource — so a create→suspend→create loop
+ * must not mint fresh agents (and fresh managed DBs) past the ceiling
  * (#11023 residual). Terminal/deletion states (`error`, `disconnected`,
  * `deletion_pending`, `deletion_failed`) hold no reusable resources and stay
  * excluded. Intentionally BROADER than the reuse-guard SELECTs, which must
@@ -3980,11 +3980,12 @@ export class ElizaSandboxService {
   }
 
   /**
-   * Daemon-side handler for the `agent_suspend` job. SSH-stops the
-   * container, flips the DB row to `stopped`, clears bridge/health URLs
-   * but keeps `sandbox_id` for a subsequent `agent_resume` to docker
-   * start. Replaces the Worker-callable `shutdown()` path which silently
-   * failed to stop the container (Workers can't SSH).
+   * Daemon-side handler for the `agent_suspend` job. Calls the provider's
+   * `stop()` (which removes the container and frees the node slot), flips the
+   * DB row to `stopped`, and clears bridge/health URLs — but keeps `sandbox_id`
+   * and the per-tenant managed DB so a subsequent `agent_resume` re-provisions
+   * against the retained state. Replaces the Worker-callable `shutdown()` path
+   * which silently failed to stop the container (Workers can't SSH).
    */
   async executeSuspend(
     agentId: string,
@@ -4106,8 +4107,9 @@ export class ElizaSandboxService {
   /**
    * Daemon-side handler for the `agent_sleep` job — deep, cold suspend.
    *
-   * Unlike `agent_suspend` (which keeps the container + node slot for a fast
-   * `docker start`), sleep frees the compute entirely:
+   * Both suspend and sleep drop the container + free the node slot; unlike
+   * `agent_suspend` (which keeps the row's `sandbox_id` + managed DB for an
+   * in-place resume), sleep frees the compute identity entirely:
    *   1. Capture a durable backup. A live `/api/snapshot` pull when the agent
    *      is reachable, otherwise the agent's persisted config, otherwise the
    *      latest existing backup — a restore point ALWAYS exists before we

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5,7 +5,7 @@
 
 import crypto from "node:crypto";
 import { isIP } from "node:net";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { type Database, dbWrite } from "../../db/helpers";
 import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import {
@@ -100,9 +100,10 @@ export interface CreateAgentParams {
    */
   reuseExistingNonTerminal?: boolean;
   /**
-   * Ceiling on an org's NON-TERMINAL (`pending`/`provisioning`/`running`,
+   * Ceiling on an org's resource-holding ({@link QUOTA_COUNTED_STATUSES},
    * non-pool) agent sandboxes, enforced ATOMICALLY under the org advisory lock
-   * before a fresh (non-reuse) insert. Prevents a user-facing caller from
+   * before ANY fresh insert — both the plain-insert branch and the reuse
+   * branch's no-live-agent-to-reuse insert. Prevents a user-facing caller from
    * minting unbounded dedicated containers on the shared fleet (#11023: a
    * `forceCreate`+`alwaysOn` loop on a ~$0.11 balance otherwise exhausts the
    * fleet — the credit gate is threshold-only, never a per-agent debit). The
@@ -112,6 +113,26 @@ export interface CreateAgentParams {
    */
   maxNonTerminalAgents?: number;
 }
+
+/**
+ * Statuses that COUNT toward `maxNonTerminalAgents`: the live states plus
+ * `stopped` (suspend keeps the container + node slot + per-tenant managed
+ * Postgres) and `sleeping` (cold storage keeps the managed Postgres). Both
+ * still hold the org's durable per-agent resources, so a
+ * create→suspend→create loop must not mint fresh agents past the ceiling
+ * (#11023 residual). Terminal/deletion states (`error`, `disconnected`,
+ * `deletion_pending`, `deletion_failed`) hold no reusable resources and stay
+ * excluded. Intentionally BROADER than the reuse-guard SELECTs, which must
+ * keep returning only a LIVE agent — handing back a stopped/sleeping row
+ * would silently turn an idempotent create into an implicit resume.
+ */
+const QUOTA_COUNTED_STATUSES: AgentSandboxStatus[] = [
+  "pending",
+  "provisioning",
+  "running",
+  "stopped",
+  "sleeping",
+];
 
 /** Thrown by createAgent when a fresh create would exceed `maxNonTerminalAgents`. */
 export class AgentQuotaExceededError extends Error {
@@ -655,6 +676,34 @@ export class ElizaSandboxService {
     };
   }
 
+  /**
+   * Enforce `maxNonTerminalAgents` for an org: count its quota-holding
+   * ({@link QUOTA_COUNTED_STATUSES}), non-pool sandboxes and throw
+   * {@link AgentQuotaExceededError} at/past the cap. MUST run inside a
+   * transaction that already holds the org's agent-create advisory lock so
+   * the count→insert is atomic — two concurrent creates can't both read
+   * `count = max-1` and both insert.
+   */
+  private async assertOrgAgentQuota(
+    tx: LifecycleTx,
+    organizationId: string,
+    cap: number,
+  ): Promise<void> {
+    const [{ count } = { count: 0 }] = await tx
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, organizationId),
+          sql`${agentSandboxes.pool_status} IS NULL`,
+          inArray(agentSandboxes.status, QUOTA_COUNTED_STATUSES),
+        ),
+      );
+    if (count >= cap) {
+      throw new AgentQuotaExceededError(count, cap);
+    }
+  }
+
   async createAgent(params: CreateAgentParams): Promise<{
     agent: AgentSandbox;
     idempotent: boolean;
@@ -676,27 +725,12 @@ export class ElizaSandboxService {
 
       // Capped path (#11023): a user-facing forceCreate that bypasses the reuse
       // guard must still not mint unbounded dedicated containers. Count the org's
-      // non-terminal sandboxes UNDER the same org advisory lock the reuse guard
-      // uses — so the count→insert is atomic and two concurrent creates can't both
-      // read `count = max-1` and both insert — and refuse past the cap.
+      // quota-holding sandboxes UNDER the same org advisory lock the reuse guard
+      // uses and refuse past the cap.
       const cap = params.maxNonTerminalAgents;
       return dbWrite.transaction(async (tx) => {
         await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
-
-        const [{ count } = { count: 0 }] = await tx
-          .select({ count: sql<number>`count(*)::int` })
-          .from(agentSandboxes)
-          .where(
-            and(
-              eq(agentSandboxes.organization_id, params.organizationId),
-              sql`${agentSandboxes.pool_status} IS NULL`,
-              sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
-            ),
-          );
-
-        if (count >= cap) {
-          throw new AgentQuotaExceededError(count, cap);
-        }
+        await this.assertOrgAgentQuota(tx, params.organizationId, cap);
 
         const [created] = await tx
           .insert(agentSandboxes)
@@ -730,6 +764,17 @@ export class ElizaSandboxService {
 
       if (existing) {
         return { agent: existing, idempotent: true };
+      }
+
+      // The guard above only hands back a LIVE agent — a `stopped`/`sleeping`
+      // one must be resumed/woken, not reused — so after a suspend there is
+      // nothing to collapse onto and control falls through to a fresh insert.
+      // Without a cap that insert is unbounded: a create→suspend→create loop
+      // mints a new agent (each = a per-tenant managed DB) every iteration
+      // (#11023 residual). Enforce the same per-org ceiling, still under the
+      // org advisory lock.
+      if (params.maxNonTerminalAgents !== undefined) {
+        await this.assertOrgAgentQuota(tx, params.organizationId, params.maxNonTerminalAgents);
       }
 
       const [created] = await tx
@@ -798,19 +843,11 @@ export class ElizaSandboxService {
       // the org lock so the count→insert is atomic against concurrent creates.
       // Trusted internal callers pass no cap and stay uncapped.
       if (createParams.maxNonTerminalAgents !== undefined) {
-        const [{ count } = { count: 0 }] = await tx
-          .select({ count: sql<number>`count(*)::int` })
-          .from(agentSandboxes)
-          .where(
-            and(
-              eq(agentSandboxes.organization_id, createParams.organizationId),
-              sql`${agentSandboxes.pool_status} IS NULL`,
-              sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
-            ),
-          );
-        if (count >= createParams.maxNonTerminalAgents) {
-          throw new AgentQuotaExceededError(count, createParams.maxNonTerminalAgents);
-        }
+        await this.assertOrgAgentQuota(
+          tx,
+          createParams.organizationId,
+          createParams.maxNonTerminalAgents,
+        );
       }
 
       const [created] = await tx


### PR DESCRIPTION
## Problem (HIGH, provisioning fleet-DoS — residual of #11023)

#11042/#11095 added a per-org non-terminal-agent quota, but its count queries filter `status IN ('pending','provisioning','running')` — which **excludes `stopped` and `sleeping`**. Yet:
- `executeSuspend` sets `status='stopped'` and **retains** `sandbox_id` + node slot + the per-tenant **managed Postgres** (only nulls bridge/health URLs).
- `executeSleep` sets `status='sleeping'` and still **retains the per-tenant managed Postgres** (cold storage).

So both hold the expensive durable resource but aren't counted. Two escape hatches remain:
1. **Suspend loop:** create → suspend → create → … mints unbounded agents (each a real managed DB), never hitting the cap.
2. **Normal path uncapped:** the non-`forceCreate` POST passed `maxNonTerminalAgents: undefined`, so it routed into `createAgent`'s reuse branch — which had **no cap check**. After a suspend there's no *live* agent for the reuse guard to hand back, so every normal create minted a fresh uncapped row.

## Fix (two prongs)

1. **Count resource-holding states.** New `QUOTA_COUNTED_STATUSES = ['pending','provisioning','running','stopped','sleeping']` (typed to `AgentSandboxStatus`). Terminal/deletion states (`error`, `disconnected`, `deletion_pending`, `deletion_failed`) stay excluded (no reusable resource). The three copy-paste count sites are factored into one `assertOrgAgentQuota(tx, orgId, cap)` (runs under the existing org advisory lock — count→insert stays atomic). The **reuse-guard SELECTs are intentionally left live-only** — handing back a `stopped`/`sleeping` row would silently turn an idempotent create into an implicit resume.
2. **Cap the normal create path.** `createAgent`'s reuse branch now runs the same quota check before its no-live-agent-to-reuse insert (when a cap is passed), and `route.ts` passes `maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(orgBalanceForQuota)` on **every** user-facing create (not just `forceCreate`). Trusted internal multi-agent callers don't go through this route and stay uncapped.

## Test (real PGlite, regression-proven)

Extended `eliza-sandbox-coding-container-quota.test.ts` (real `pushSchema`, nothing mocked). Written test-first — on unmodified source both regressions **resolved instead of throwing** (bug reproduced: a create past the cap with only `stopped`/`sleeping` rows succeeded, and the normal reuse path minted an uncapped row). Post-fix both throw `AgentQuotaExceededError`, and a control confirms terminal (`error`) rows are **not** counted. `9 pass / 0 fail / 29 expect() calls`. The one existing route unit test that pinned the old vulnerable contract ("normal path passes NO cap") was flipped to pin the new contract (`maxNonTerminalAgents` = the balance-tiered cap) — a contract update, not a weakening.

## Reviewer notes / questions for @lalalune
1. **Behavior change (intended):** a normal create that finds no live agent to reuse now 429s when the org already holds ≥cap counted sandboxes — including orgs whose agents were all suspended. Any **live** agent still short-circuits via reuse before the check, so only all-suspended/sleeping over-cap orgs are affected (resume/delete or add credits to lift).
2. **Tuning question — shared-tier floor cap:** `orgBalanceForQuota` is only populated when the credit gate runs (eager tiers). A non-eager (shared-tier) create therefore gets the smallest-tier ceiling (5) rather than the org's balance-scaled ceiling. This is **fail-closed and effectively unreachable for pure shared-tier** (shared agents don't enter `stopped`/`sleeping`, and reuse collapses live ones), but if you'd prefer the shared path to load balance and scale the cap, that's a one-line follow-up — flagging for your call rather than expanding this PR.

Provisioning/security — flagging for review; not self-merging. Launch-hardening deepscan, tracked in #8434.

— [cloud-security]
