### PR TITLE
fix(agent-orchestrator): fallback Codex ACP without Landlock

### DIFF
--- a/.github/issue-evidence/11221-codex-landlock-sandbox.md
+++ b/.github/issue-evidence/11221-codex-landlock-sandbox.md
@@ -1,0 +1,63 @@
+# Issue #11221 - Codex ACP Landlock Sandbox Fallback
+
+## Change
+
+- Added Codex ACP sandbox command handling in `AcpService`:
+  - `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` appends `-c sandbox_mode=<mode>`.
+  - `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` appends `-c approval_policy=<policy>`.
+  - `ELIZA_CODEX_ACP_LANDLOCK=0` / `ELIZA_CODEX_LANDLOCK=0` forces the no-Landlock fallback.
+  - When Linux LSM probing proves Landlock unavailable, Codex ACP starts with `sandbox_mode=danger-full-access` and `approval_policy=never` by default.
+  - If Codex still exits with the Landlock panic at startup, the orchestrator retries once with the same no-Landlock fallback before marking the session errored.
+- Added `NativeAcpClient` startup stderr capture so exit-101 errors preserve the Codex panic text.
+- Documented the deployment knobs in package metadata, README, CLAUDE.md, and AGENTS.md.
+
+## Manual Review
+
+- Reviewed the command strings passed into mocked `NativeAcpClient`:
+  - configured sandbox: `codex-acp --stdio -c sandbox_mode=workspace-write -c approval_policy=never`
+  - generic alias sandbox: `codex-acp --stdio -c sandbox_mode=read-only -c approval_policy=on-request`
+  - no-Landlock probe fallback: `codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never`
+  - panic retry first starts with `codex-acp --stdio`, then retries with the fallback command.
+- Reviewed the warning assertions to confirm operators see a clear `Landlock unavailable` fallback log.
+- No UI, screenshots, video, live LLM trajectory, DB rows, audio, wallet, or on-chain artifacts apply: this is a Node-only ACP spawn/configuration fix covered by process-command and stderr behavior tests.
+
+## Verification
+
+Passed:
+
+```bash
+bun install --frozen-lockfile
+bun run --cwd packages/core prebuild && bun run --cwd packages/core build:node
+bun run --cwd packages/agent build
+bunx vitest run --config vitest.config.ts __tests__/unit/codex-sandbox.test.ts __tests__/unit/acp-service.test.ts __tests__/unit/acp-native-transport.test.ts --testTimeout 60000
+bunx vitest run --config vitest.config.ts __tests__/unit --testTimeout 60000
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+bun run --cwd plugins/plugin-agent-orchestrator test
+bun run --cwd plugins/plugin-agent-orchestrator build
+bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/package.json plugins/plugin-agent-orchestrator/README.md plugins/plugin-agent-orchestrator/CLAUDE.md plugins/plugin-agent-orchestrator/AGENTS.md --no-errors-on-unmatched
+```
+
+Focused Vitest result after rebase: 3 files passed, 71 tests passed.
+
+Full unit result after rebase with explicit timeout: 111 files passed, 1161 tests passed.
+
+Full orchestrator test result after rebase: 140 files passed, 3 skipped; 1419 tests passed, 6 skipped.
+
+Known unrelated failures observed:
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator lint:check
+```
+
+Fails on pre-existing package-wide lint/format issues outside this change, including `src/__tests__/swarm-coordinator-acp-bind.test.ts`, `src/__tests__/keyless-app-creation.e2e.test.ts`, `__tests__/fixtures/fake-acp-agent.mjs`, `src/actions/tasks.ts`, `src/services/completion-envelope.ts`, `src/services/interruption-decider.ts`, `src/services/sub-agent-router.ts`, and `src/services/workspace-diff.ts`. The changed files pass Biome directly.
+
+```bash
+bun run verify
+```
+
+Fails before Turbo at the current repository type-safety ratchet baseline:
+
+- `as unknown as`: 80 current > 77 baseline
+- `?? {}` (core/agent/app-core): 379 current > 377 baseline
+
+The changed files are not listed in the ratchet output.

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -257,6 +257,10 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access` |
+| `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override |
+| `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -257,6 +257,10 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access` |
+| `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override |
+| `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -144,6 +144,10 @@ All configuration is via environment variables. Use `ELIZA_ACP_TRANSPORT=native`
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command. |
+| `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional Codex ACP `sandbox_mode` override: `read-only`, `workspace-write`, or `danger-full-access`. |
+| `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox mode used when Linux Landlock is unavailable. |
+| `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional Codex ACP `approval_policy` override. |
+| `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false`. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -351,6 +351,29 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     expect((error as Error).message).toBe("ACP request timed out: initialize");
   });
 
+  it("includes captured stderr in startup close errors", async () => {
+    const p = queueProc();
+    const client = new NativeAcpClient({
+      command: "codex-acp",
+      cwd: "/tmp/native-acp",
+      approvalPreset: "autonomous",
+    });
+
+    const started = client.start();
+    await waitForWrites(p, 1);
+    p.stderr.emit(
+      "data",
+      Buffer.from(
+        "permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock\n",
+      ),
+    );
+    closeProc(p, 101);
+
+    await expect(started).rejects.toThrow(
+      /ACP agent exited with code 101: .*--use-legacy-landlock/,
+    );
+  });
+
   it("returns method-not-found for unsupported client request methods", async () => {
     const { p } = await startClient();
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -46,6 +46,7 @@ type MockNativeClient = {
 type NativeMockState = {
   NativeAcpClient?: new (opts: NativeOptions) => MockNativeClient;
   instances: MockNativeClient[];
+  startImplementation?: (client: MockNativeClient) => Promise<void>;
 };
 
 function getNativeMockState(): NativeMockState {
@@ -65,7 +66,9 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
   {
     opts: NativeOptions;
     eventHandler?: NativeEventHandler;
-    start = vi.fn(async () => undefined);
+    start = vi.fn(async () => {
+      await getNativeMockState().startImplementation?.(this);
+    });
     createSession = vi.fn(async () => ({
       sessionId: "protocol-session",
       agentSessionId: "agent-session",
@@ -247,6 +250,7 @@ async function waitForSessionStatus(
 beforeEach(() => {
   spawnMock.mockReset();
   nativeClientMock.instances.length = 0;
+  nativeClientMock.startImplementation = undefined;
 });
 
 afterEach(() => {
@@ -493,6 +497,132 @@ describe("AcpService", () => {
     expect(nativeClientMock.instances[0]?.opts.command).toBe(
       "codex-acp --stdio",
     );
+  });
+
+  it("adds configured Codex ACP sandbox settings to the native command", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+        ELIZA_CODEX_ACP_SANDBOX_MODE: "workspace-write",
+        ELIZA_CODEX_ACP_APPROVAL_POLICY: "never",
+      }),
+    );
+    await service.start();
+
+    await service.spawnSession({
+      name: "codex-sandbox-config",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      "codex-acp --stdio -c sandbox_mode=workspace-write -c approval_policy=never",
+    );
+  });
+
+  it("honors generic Codex sandbox setting aliases", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+        ELIZA_CODEX_SANDBOX_MODE: "read-only",
+        ELIZA_CODEX_APPROVAL_POLICY: "on-request",
+      }),
+    );
+    await service.start();
+
+    await service.spawnSession({
+      name: "codex-sandbox-aliases",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      "codex-acp --stdio -c sandbox_mode=read-only -c approval_policy=on-request",
+    );
+  });
+
+  it("starts Codex ACP with the no-Landlock fallback when the runtime probe is disabled", async () => {
+    const rt = runtime({
+      ELIZA_ACP_TRANSPORT: "native",
+      ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+      ELIZA_CODEX_ACP_LANDLOCK: "0",
+    });
+    const service = new AcpService(rt);
+    await service.start();
+
+    await service.spawnSession({
+      name: "codex-no-landlock",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
+    );
+    const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
+      .logger;
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Landlock unavailable"),
+      expect.objectContaining({
+        sandboxMode: "danger-full-access",
+        approvalPolicy: "never",
+      }),
+    );
+  });
+
+  it("retries Codex ACP once with a no-Landlock sandbox fallback after the panic", async () => {
+    const previousOverride = process.env.ELIZA_CODEX_ACP_LANDLOCK;
+    process.env.ELIZA_CODEX_ACP_LANDLOCK = "1";
+    try {
+      nativeClientMock.startImplementation = async (client) => {
+        if (!client.opts.command.includes("sandbox_mode=danger-full-access")) {
+          throw new Error(
+            "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+          );
+        }
+      };
+      const rt = runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+      });
+      const service = new AcpService(rt);
+      await service.start();
+
+      const result = await service.spawnSession({
+        name: "codex-landlock-retry",
+        agentType: "codex",
+        workdir: "/tmp/acp-test",
+      });
+
+      expect(result.status).toBe("ready");
+      expect(nativeClientMock.instances).toHaveLength(2);
+      expect(nativeClientMock.instances[0]?.opts.command).toBe(
+        "codex-acp --stdio",
+      );
+      expect(nativeClientMock.instances[1]?.opts.command).toBe(
+        "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
+      );
+      const logger = (rt as { logger: { warn: ReturnType<typeof vi.fn> } })
+        .logger;
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Codex ACP Landlock unavailable"),
+        expect.objectContaining({
+          sandboxMode: "danger-full-access",
+          approvalPolicy: "never",
+        }),
+      );
+    } finally {
+      if (previousOverride === undefined) {
+        delete process.env.ELIZA_CODEX_ACP_LANDLOCK;
+      } else {
+        process.env.ELIZA_CODEX_ACP_LANDLOCK = previousOverride;
+      }
+    }
   });
 
   it("does not emit task_complete from the session creation command", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendCodexAcpSandboxConfig,
+  commandHasCodexSandboxConfig,
+  detectLandlockAvailability,
+  isCodexLandlockPanic,
+  normalizeCodexSandboxMode,
+} from "../../src/services/codex-sandbox.js";
+
+describe("codex ACP sandbox helpers", () => {
+  it("normalizes supported sandbox modes and off aliases", () => {
+    expect(normalizeCodexSandboxMode("read-only")).toBe("read-only");
+    expect(normalizeCodexSandboxMode("readonly")).toBe("read-only");
+    expect(normalizeCodexSandboxMode("workspace")).toBe("workspace-write");
+    expect(normalizeCodexSandboxMode("off")).toBe("danger-full-access");
+    expect(normalizeCodexSandboxMode("bogus")).toBeUndefined();
+  });
+
+  it("detects Landlock from Linux LSM state without treating unknown as unavailable", () => {
+    expect(
+      detectLandlockAvailability({
+        platform: "linux",
+        existsSync: (path) => path === "/sys/kernel/security/lsm",
+        readFileSync: () => "lockdown,capability,landlock,yama",
+      }),
+    ).toBe("available");
+    expect(
+      detectLandlockAvailability({
+        platform: "linux",
+        existsSync: (path) => path === "/sys/kernel/security/lsm",
+        readFileSync: () => "lockdown,capability,yama",
+      }),
+    ).toBe("unavailable");
+    expect(
+      detectLandlockAvailability({
+        platform: "linux",
+        existsSync: () => false,
+      }),
+    ).toBe("unknown");
+    expect(
+      detectLandlockAvailability({
+        platform: "darwin",
+      }),
+    ).toBe("not-linux");
+  });
+
+  it("honors explicit Landlock availability overrides", () => {
+    expect(
+      detectLandlockAvailability({
+        platform: "darwin",
+        env: { ELIZA_CODEX_ACP_LANDLOCK: "0" },
+      }),
+    ).toBe("unavailable");
+    expect(
+      detectLandlockAvailability({
+        platform: "linux",
+        existsSync: () => false,
+        env: { ELIZA_CODEX_LANDLOCK: "true" },
+      }),
+    ).toBe("available");
+  });
+
+  it("appends sandbox config without duplicating existing command settings", () => {
+    expect(
+      appendCodexAcpSandboxConfig(
+        "codex-acp --stdio",
+        "danger-full-access",
+        "never",
+      ),
+    ).toBe(
+      "codex-acp --stdio -c sandbox_mode=danger-full-access -c approval_policy=never",
+    );
+    expect(
+      appendCodexAcpSandboxConfig(
+        "codex-acp -c sandbox_mode=read-only -c approval_policy=on-request",
+        "danger-full-access",
+        "never",
+      ),
+    ).toBe("codex-acp -c sandbox_mode=read-only -c approval_policy=on-request");
+    expect(commandHasCodexSandboxConfig("codex-acp -s workspace-write")).toBe(
+      true,
+    );
+  });
+
+  it("recognizes Codex Landlock panic text", () => {
+    expect(
+      isCodexLandlockPanic(
+        "ACP agent exited with code 101: thread 'main' panicked: permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+      ),
+    ).toBe(true);
+    expect(isCodexLandlockPanic("Authentication required")).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -173,6 +173,49 @@
         "default": "npx -y @zed-industries/codex-acp@0.14.0",
         "sensitive": false
       },
+      "ELIZA_CODEX_ACP_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Optional Codex ACP sandbox_mode override. Accepted values: read-only, workspace-write, danger-full-access.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Compatibility alias for ELIZA_CODEX_ACP_SANDBOX_MODE.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Codex ACP sandbox_mode used when Linux Landlock is unavailable.",
+        "required": false,
+        "default": "danger-full-access",
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_APPROVAL_POLICY": {
+        "type": "string",
+        "description": "Optional Codex ACP approval_policy override. The no-Landlock fallback defaults this to never when unset.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_APPROVAL_POLICY": {
+        "type": "string",
+        "description": "Compatibility alias for ELIZA_CODEX_ACP_APPROVAL_POLICY.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_LANDLOCK": {
+        "type": "string",
+        "description": "Force Codex ACP Landlock detection for container deployments or tests. Accepted values include 1/true and 0/false. Unset means auto-detect.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_LANDLOCK": {
+        "type": "string",
+        "description": "Compatibility alias for ELIZA_CODEX_ACP_LANDLOCK.",
+        "required": false,
+        "sensitive": false
+      },
       "ELIZA_CLAUDE_ACP_COMMAND": {
         "type": "string",
         "description": "Native ACP command used for Claude sessions when ELIZA_ACP_TRANSPORT=native. Pin this in production to avoid implicit package upgrades.",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -129,6 +129,7 @@ export class NativeAcpClient {
   private proc?: ChildProcessWithoutNullStreams;
   private nextId = 1;
   private readBuffer = "";
+  private stderrBuffer = "";
   private pending = new Map<JsonRpcId, PendingRequest>();
   private terminals = new Map<string, TerminalRecord>();
   private closed = false;
@@ -154,15 +155,18 @@ export class NativeAcpClient {
     this.proc = proc;
 
     proc.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
-    proc.stderr.on("data", (chunk: Buffer) =>
-      this.opts.onStderr?.(chunk.toString("utf8")),
-    );
+    proc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-16_384);
+      this.opts.onStderr?.(text);
+    });
     proc.on("error", (err) => this.rejectAll(err));
     proc.on("close", (code, signal) => {
       this.closed = true;
+      const stderr = this.stderrBuffer.trim();
       this.rejectAll(
         new Error(
-          `ACP agent exited with code ${code ?? "unknown"}${signal ? ` signal ${signal}` : ""}`,
+          `ACP agent exited with code ${code ?? "unknown"}${signal ? ` signal ${signal}` : ""}${stderr ? `: ${stderr}` : ""}`,
         ),
       );
     });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -8,6 +8,15 @@ import { type IAgentRuntime, Service } from "@elizaos/core";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
+  appendCodexAcpSandboxConfig,
+  type CodexSandboxMode,
+  commandHasCodexSandboxConfig,
+  detectLandlockAvailability,
+  isCodexLandlockPanic,
+  normalizeCodexApprovalPolicy,
+  normalizeCodexSandboxMode,
+} from "./codex-sandbox.js";
+import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
   diagnoseCodingAccountFallback,
@@ -96,6 +105,9 @@ type RunResult = {
 const STDERR_CAP_BYTES = 64 * 1024;
 const KILL_GRACE_MS = 5_000;
 const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
+const DEFAULT_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
+const CODEX_NO_LANDLOCK_SANDBOX_MODE: CodexSandboxMode = "danger-full-access";
+const CODEX_NO_LANDLOCK_APPROVAL_POLICY = "never";
 
 /**
  * Resolve the absolute workdir for a spawned session. When `isolate` is true,
@@ -1224,50 +1236,146 @@ export class AcpService extends Service {
     return resolveVendoredOpencodeAcpCommand();
   }
 
+  private codexAcpSandboxMode(): CodexSandboxMode | undefined {
+    const raw =
+      this.setting("ELIZA_CODEX_ACP_SANDBOX_MODE") ??
+      this.setting("ELIZA_CODEX_SANDBOX_MODE");
+    const mode = normalizeCodexSandboxMode(raw);
+    if (raw?.trim() && !mode) {
+      this.log("warn", "Ignoring invalid Codex ACP sandbox mode", {
+        value: raw,
+        supported: ["read-only", "workspace-write", "danger-full-access"],
+      });
+    }
+    return mode;
+  }
+
+  private codexAcpApprovalPolicy(): string | undefined {
+    const raw =
+      this.setting("ELIZA_CODEX_ACP_APPROVAL_POLICY") ??
+      this.setting("ELIZA_CODEX_APPROVAL_POLICY");
+    const policy = normalizeCodexApprovalPolicy(raw);
+    if (raw?.trim() && !policy) {
+      this.log("warn", "Ignoring invalid Codex ACP approval policy", {
+        value: raw,
+        supported: ["untrusted", "on-request", "on-failure", "never"],
+      });
+    }
+    return policy;
+  }
+
+  private codexNoLandlockSandboxMode(): CodexSandboxMode {
+    const raw = this.setting("ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE");
+    const mode = normalizeCodexSandboxMode(raw);
+    if (raw?.trim() && !mode) {
+      this.log("warn", "Ignoring invalid Codex ACP no-Landlock sandbox mode", {
+        value: raw,
+        supported: ["read-only", "workspace-write", "danger-full-access"],
+      });
+    }
+    return mode ?? CODEX_NO_LANDLOCK_SANDBOX_MODE;
+  }
+
+  private codexAgentCommand(): string {
+    const command =
+      this.setting("ELIZA_CODEX_ACP_COMMAND") ?? DEFAULT_CODEX_ACP_COMMAND;
+    const configuredSandboxMode = this.codexAcpSandboxMode();
+    if (configuredSandboxMode) {
+      return appendCodexAcpSandboxConfig(
+        command,
+        configuredSandboxMode,
+        this.codexAcpApprovalPolicy() ??
+          (configuredSandboxMode === "danger-full-access"
+            ? CODEX_NO_LANDLOCK_APPROVAL_POLICY
+            : undefined),
+      );
+    }
+    if (commandHasCodexSandboxConfig(command)) return command;
+
+    const landlock = detectLandlockAvailability({
+      env: {
+        ELIZA_CODEX_ACP_LANDLOCK: this.setting("ELIZA_CODEX_ACP_LANDLOCK"),
+        ELIZA_CODEX_LANDLOCK: this.setting("ELIZA_CODEX_LANDLOCK"),
+      },
+    });
+    if (landlock !== "unavailable") return command;
+
+    this.log(
+      "warn",
+      "Landlock unavailable; starting Codex ACP with sandbox fallback",
+      {
+        sandboxMode: this.codexNoLandlockSandboxMode(),
+        approvalPolicy:
+          this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+      },
+    );
+    return appendCodexAcpSandboxConfig(
+      command,
+      this.codexNoLandlockSandboxMode(),
+      this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+    );
+  }
+
+  private codexLandlockFallbackCommand(
+    agentType: AgentType,
+    command: string,
+    message: string,
+  ): string | undefined {
+    if ((normalizeTaskAgentAdapter(agentType) ?? agentType) !== "codex")
+      return undefined;
+    if (!isCodexLandlockPanic(message)) return undefined;
+    if (commandHasCodexSandboxConfig(command)) return undefined;
+    return appendCodexAcpSandboxConfig(
+      command,
+      this.codexAcpSandboxMode() ?? this.codexNoLandlockSandboxMode(),
+      this.codexAcpApprovalPolicy() ?? CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+    );
+  }
+
   private async spawnNativeSession(
     id: string,
     session: SessionInfo,
     opts: SpawnOptions,
   ): Promise<SpawnResult> {
     const command = this.nativeAgentCommand(session.agentType);
-    const stderr: string[] = [];
-    const client = new NativeAcpClient({
-      command,
-      cwd: session.workdir,
-      approvalPreset: session.approvalPreset,
-      timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
-      terminal: !this.shouldDisableTerminalCapability(),
-      env: this.buildEnv(
-        opts.env,
-        opts.customCredentials,
-        opts.model,
-        session.agentType,
-        id,
-      ),
-      // Auto-inherit the parent runtime's configured MCP servers (config
-      // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
-      // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
-      mcpServers: readConfigMcpServers(),
-      onEvent: (event, protocolSessionId) => {
-        this.handleAcpEvent(
-          event,
+    const createClient = (clientCommand: string, stderr: string[]) =>
+      new NativeAcpClient({
+        command: clientCommand,
+        cwd: session.workdir,
+        approvalPreset: session.approvalPreset,
+        timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
+        terminal: !this.shouldDisableTerminalCapability(),
+        env: this.buildEnv(
+          opts.env,
+          opts.customCredentials,
+          opts.model,
+          session.agentType,
           id,
-          "",
-          Date.now(),
-          false,
-          new Set<string>(),
-        );
-        if (protocolSessionId && protocolSessionId !== id) {
-          void this.store
-            .update(id, { acpxSessionId: protocolSessionId })
-            .catch(() => undefined);
-        }
-      },
-      onStderr: (chunk) => {
-        stderr.push(chunk);
-      },
-    });
-    try {
+        ),
+        // Auto-inherit the parent runtime's configured MCP servers (config
+        // `mcp.servers`) so the sub-agent gets the same MCP tools. Undefined when
+        // none are configured → the transport falls back to ELIZA_ACP_MCP_SERVERS.
+        mcpServers: readConfigMcpServers(),
+        onEvent: (event, protocolSessionId) => {
+          this.handleAcpEvent(
+            event,
+            id,
+            "",
+            Date.now(),
+            false,
+            new Set<string>(),
+          );
+          if (protocolSessionId && protocolSessionId !== id) {
+            void this.store
+              .update(id, { acpxSessionId: protocolSessionId })
+              .catch(() => undefined);
+          }
+        },
+        onStderr: (chunk) => {
+          stderr.push(chunk);
+        },
+      });
+    const attachClient = async (client: NativeAcpClient) => {
       await client.start();
       const nativeSession = await client.createSession(session.workdir);
       this.nativeClients.set(id, client);
@@ -1286,13 +1394,45 @@ export class AcpService extends Service {
       });
       const updated = await this.store.get(id);
       return toSpawnResult(updated ?? { ...session, status: "ready" });
+    };
+    let stderr: string[] = [];
+    let client = createClient(command, stderr);
+    try {
+      return await attachClient(client);
     } catch (err) {
       await client.close().catch(() => undefined);
       // A failed spawn must not leave a closed client registered: the entry is
       // set above before the store writes that can throw here. Idempotent when
       // the failure happened before the set.
       this.nativeClients.delete(id);
-      const message = stderr.join("").trim() || errorMessage(err);
+      let message = stderr.join("").trim() || errorMessage(err);
+      const fallbackCommand = this.codexLandlockFallbackCommand(
+        session.agentType,
+        command,
+        message,
+      );
+      if (fallbackCommand) {
+        this.log(
+          "warn",
+          "Codex ACP Landlock unavailable; retrying with sandbox fallback",
+          {
+            sessionId: id,
+            sandboxMode: this.codexNoLandlockSandboxMode(),
+            approvalPolicy:
+              this.codexAcpApprovalPolicy() ??
+              CODEX_NO_LANDLOCK_APPROVAL_POLICY,
+          },
+        );
+        stderr = [];
+        client = createClient(fallbackCommand, stderr);
+        try {
+          return await attachClient(client);
+        } catch (retryErr) {
+          await client.close().catch(() => undefined);
+          this.nativeClients.delete(id);
+          message = stderr.join("").trim() || errorMessage(retryErr);
+        }
+      }
       await this.store.updateStatus(id, "errored", message);
       this.emitSessionEvent(id, "error", {
         message,
@@ -1450,17 +1590,13 @@ export class AcpService extends Service {
       if (command) return command;
       return this.setting("ELIZA_OPENCODE_ACP_COMMAND") ?? "opencode acp";
     }
+    if (normalizedAgentType === "codex") return this.codexAgentCommand();
     const override = this.setting(
       `ELIZA_${String(normalizedAgentType)
         .toUpperCase()
         .replace(/[^A-Z0-9]/g, "_")}_ACP_COMMAND`,
     );
     if (override?.trim()) return override.trim();
-    if (normalizedAgentType === "codex")
-      return (
-        this.setting("ELIZA_CODEX_ACP_COMMAND") ??
-        "npx -y @zed-industries/codex-acp@0.14.0"
-      );
     if (normalizedAgentType === "claude")
       return (
         this.setting("ELIZA_CLAUDE_ACP_COMMAND") ??

--- a/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync } from "node:fs";
+import { platform } from "node:os";
+
+export type CodexSandboxMode =
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+export type LandlockAvailability =
+  | "available"
+  | "unavailable"
+  | "unknown"
+  | "not-linux";
+
+type LandlockProbeOptions = {
+  platform?: NodeJS.Platform;
+  existsSync?: (path: string) => boolean;
+  readFileSync?: (path: string, encoding: BufferEncoding) => string;
+  env?: Record<string, string | undefined>;
+};
+
+const CODEX_SANDBOX_MODES = new Set<CodexSandboxMode>([
+  "read-only",
+  "workspace-write",
+  "danger-full-access",
+]);
+const SETTING_OFF = /^(?:off|false|0|none|disabled)$/iu;
+const SETTING_ON = /^(?:on|true|1|enabled)$/iu;
+const LSM_PATH = "/sys/kernel/security/lsm";
+const LANDLOCK_DIR = "/sys/kernel/security/landlock";
+
+export function normalizeCodexSandboxMode(
+  value: string | undefined,
+): CodexSandboxMode | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (SETTING_OFF.test(normalized)) return "danger-full-access";
+  if (normalized === "readonly") return "read-only";
+  if (normalized === "workspace") return "workspace-write";
+  return CODEX_SANDBOX_MODES.has(normalized as CodexSandboxMode)
+    ? (normalized as CodexSandboxMode)
+    : undefined;
+}
+
+export function normalizeCodexApprovalPolicy(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return ["untrusted", "on-request", "on-failure", "never"].includes(normalized)
+    ? normalized
+    : undefined;
+}
+
+export function detectLandlockAvailability(
+  opts: LandlockProbeOptions = {},
+): LandlockAvailability {
+  const env = opts.env ?? process.env;
+  const override = env.ELIZA_CODEX_ACP_LANDLOCK ?? env.ELIZA_CODEX_LANDLOCK;
+  if (override?.trim()) {
+    const normalized = override.trim();
+    if (SETTING_OFF.test(normalized)) return "unavailable";
+    if (SETTING_ON.test(normalized)) return "available";
+  }
+
+  const currentPlatform = opts.platform ?? platform();
+  if (currentPlatform !== "linux") return "not-linux";
+
+  const exists = opts.existsSync ?? ((path: string) => existsSync(path));
+  const read =
+    opts.readFileSync ??
+    ((path: string, encoding: BufferEncoding) => readFileSync(path, encoding));
+  if (exists(LANDLOCK_DIR)) return "available";
+  if (!exists(LSM_PATH)) return "unknown";
+
+  try {
+    const lsm = read(LSM_PATH, "utf8");
+    const enabled = lsm
+      .split(/[\s,]+/u)
+      .map((part) => part.trim().toLowerCase())
+      .filter(Boolean);
+    return enabled.includes("landlock") ? "available" : "unavailable";
+  } catch {
+    return "unknown";
+  }
+}
+
+export function commandHasCodexConfigKey(
+  command: string,
+  key: string,
+): boolean {
+  const args = splitCommandLineArgs(command);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "-c" && args[i] !== "--config") continue;
+    const value = args[i + 1]?.trim();
+    if (value?.startsWith(`${key}=`)) return true;
+  }
+  return false;
+}
+
+export function commandHasCodexSandboxConfig(command: string): boolean {
+  const args = splitCommandLineArgs(command);
+  return (
+    commandHasCodexConfigKey(command, "sandbox_mode") ||
+    args.includes("--dangerously-bypass-approvals-and-sandbox") ||
+    args.some(
+      (arg, index) =>
+        arg === "-s" &&
+        CODEX_SANDBOX_MODES.has(args[index + 1] as CodexSandboxMode),
+    )
+  );
+}
+
+export function appendCodexAcpSandboxConfig(
+  command: string,
+  sandboxMode: CodexSandboxMode,
+  approvalPolicy?: string,
+): string {
+  const args: string[] = [];
+  if (!commandHasCodexSandboxConfig(command)) {
+    args.push("-c", `sandbox_mode=${sandboxMode}`);
+  }
+  if (approvalPolicy && !commandHasCodexConfigKey(command, "approval_policy")) {
+    args.push("-c", `approval_policy=${approvalPolicy}`);
+  }
+  if (args.length === 0) return command.trim();
+  return [command.trim(), ...args].filter(Boolean).join(" ");
+}
+
+export function isCodexLandlockPanic(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return (
+    normalized.includes("landlock") &&
+    (normalized.includes("use-legacy-landlock") ||
+      normalized.includes("requires direct runtime enforcement") ||
+      normalized.includes("linux-sandbox")) &&
+    (normalized.includes("panicked") ||
+      normalized.includes("code 101") ||
+      normalized.includes("exited with code 101"))
+  );
+}
+
+function splitCommandLineArgs(input: string): string[] {
+  return (input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? []).map((part) =>
+    part.replace(/^(['"])(.*)\1$/u, "$2"),
+  );
+}


### PR DESCRIPTION
## Summary
- add Codex ACP sandbox config helpers and deployment knobs for sandbox mode, approval policy, and Landlock probe override
- start Codex ACP with the no-Landlock fallback when the Linux LSM probe proves Landlock is unavailable
- retry one Codex ACP startup after the exit-101 Landlock panic with `sandbox_mode=danger-full-access` / `approval_policy=never`
- preserve native ACP startup stderr so the Landlock panic text survives close errors

Closes #11221

## Evidence
- `.github/issue-evidence/11221-codex-landlock-sandbox.md`

## Verification
- `bun install --frozen-lockfile`
- `bun run --cwd packages/core prebuild && bun run --cwd packages/core build:node`
- `bun run --cwd packages/agent build`
- `bunx vitest run --config vitest.config.ts __tests__/unit/codex-sandbox.test.ts __tests__/unit/acp-service.test.ts __tests__/unit/acp-native-transport.test.ts --testTimeout 60000` (3 files, 71 tests passed)
- `bunx vitest run --config vitest.config.ts __tests__/unit --testTimeout 60000` (111 files, 1161 tests passed)
- `bun run --cwd plugins/plugin-agent-orchestrator test` (140 files passed, 3 skipped; 1419 tests passed, 6 skipped)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- `bun run --cwd plugins/plugin-agent-orchestrator build`
- changed-file Biome check listed in evidence

Known unrelated failures:
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` still fails on existing package-wide Biome issues outside this change. Changed files pass Biome directly.
- `bun run verify` still fails before Turbo at the repo type-safety ratchet baseline (`as unknown as` 80 > 77, `?? {}` 379 > 377); changed files are not listed.

## UI / live artifacts
N/A - Node-only ACP spawn/configuration fix. No app UI, screenshots, video, audio, live LLM trajectory, DB, wallet, or on-chain artifacts apply.