### PR TITLE
fix(orchestrator): handle codex landlock fallback

### DIFF
--- a/.github/issue-evidence/11221-codex-landlock-fallback.md
+++ b/.github/issue-evidence/11221-codex-landlock-fallback.md
@@ -1,0 +1,125 @@
+# Issue #11221 Evidence: Codex ACP Landlock Fallback
+
+## Change
+
+- Added Codex ACP command resolution for sandbox overrides:
+  - `ELIZA_CODEX_SANDBOX_MODE` / `ELIZA_CODEX_ACP_SANDBOX_MODE`
+  - `ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE` / `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE`
+  - `ELIZA_CODEX_APPROVAL_POLICY` / `ELIZA_CODEX_ACP_APPROVAL_POLICY`
+  - `ELIZA_CODEX_LANDLOCK_AVAILABLE` / `ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE`
+- Added Linux Landlock detection from `/sys/kernel/security/lsm`.
+- Added a native transport retry path for the known Codex exit-101 Landlock panic.
+- Kept existing sandbox config in `ELIZA_CODEX_ACP_COMMAND` authoritative; no duplicate `sandbox_mode` args are appended.
+
+## Validation
+
+### Focused regression tests
+
+Command:
+
+```bash
+bunx vitest run --config vitest.config.ts __tests__/unit/codex-sandbox.test.ts __tests__/unit/acp-native-transport.test.ts __tests__/unit/acp-service.test.ts
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       69 passed (69)
+```
+
+The transport regression simulates the real Codex failure signature:
+
+```text
+permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock
+```
+
+and verifies a second spawn with:
+
+```text
+-c sandbox_mode="danger-full-access" -c approval_policy="never"
+```
+
+### Package gates
+
+```bash
+bun run --cwd packages/core build
+bun run --cwd packages/agent build
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+bun run --cwd plugins/plugin-agent-orchestrator build
+```
+
+Result: all passed.
+
+### Touched-file lint
+
+```bash
+bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
+```
+
+Result:
+
+```text
+Checked 6 files. No fixes applied.
+```
+
+### Known unrelated gate failures
+
+`bun run verify` fails before Turbo at the repository type-safety ratchet:
+
+```text
+[type-safety-ratchet] as unknown as: 80 / 77
+[type-safety-ratchet] `?? {}` (core/agent/app-core): 379 / 377
+[type-safety-ratchet] unsafe cast baseline exceeded
+```
+
+`bun run --cwd plugins/plugin-agent-orchestrator test:unit` currently times out in the full suite at `__tests__/unit/task-policy.test.ts`:
+
+```text
+keeps the built-in Discord ADMIN gate when only another connector is overridden
+Error: Test timed out in 5000ms.
+```
+
+That file passes when run by itself:
+
+```text
+Test Files  1 passed (1)
+Tests       2 passed (2)
+```
+
+The timeout is unrelated to Codex ACP command construction or native transport spawn behavior.
+
+`bun run --cwd plugins/plugin-agent-orchestrator lint:check` currently fails on pre-existing formatting/import issues in files outside this change set, including:
+
+- `src/__tests__/swarm-coordinator-acp-bind.test.ts`
+- `__tests__/fixtures/fake-acp-agent.mjs`
+- `__tests__/unit/interruption-decider.test.ts`
+- `src/__tests__/keyless-app-creation.e2e.test.ts`
+- `src/actions/tasks.ts`
+- `src/services/completion-envelope.ts`
+- `src/services/interruption-decider.ts`
+- `src/services/sub-agent-router.ts`
+- `src/services/workspace-diff.ts`
+
+## Live Platform Evidence
+
+This machine is macOS:
+
+```text
+Darwin Shaws-MacBook-Pro.local 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:09:56 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T6041 arm64
+```
+
+Docker CLI is installed, but the Docker daemon is not running:
+
+```text
+Cannot connect to the Docker daemon at unix:///Users/shawwalters/.docker/run/docker.sock. Is the docker daemon running?
+```
+
+So a live Linux no-Landlock container reproduction could not be captured on this host. The no-Landlock behavior is covered by deterministic unit tests that force detection to `false`, and by a transport-level regression that feeds the exact exit-101 panic text through the native ACP process lifecycle.
+
+## UI, Logs, And LLM Trajectories
+
+- UI screenshots/video: N/A - no UI behavior changed.
+- Frontend logs/network logs: N/A - no frontend path changed.
+- Live LLM trajectory: N/A - no prompt/model/action behavior changed; this is native process command construction and spawn recovery.
+- Backend logs: covered by unit assertions around the fallback path and service warning path; no long-running server was started for this infra-only change.

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -257,6 +257,10 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
+| `ELIZA_CODEX_SANDBOX_MODE` / `ELIZA_CODEX_ACP_SANDBOX_MODE` | unset | Optional Codex ACP sandbox override (`read-only`, `workspace-write`, `danger-full-access`) |
+| `ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE` / `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox used when Linux reports no Landlock support or the transport retries after the known Landlock panic |
+| `ELIZA_CODEX_APPROVAL_POLICY` / `ELIZA_CODEX_ACP_APPROVAL_POLICY` | unset | Optional Codex CLI approval policy appended with `-c approval_policy=...` |
+| `ELIZA_CODEX_LANDLOCK_AVAILABLE` / `ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE` | auto | Override host Landlock detection for Codex ACP (`true`/`false`) |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -257,6 +257,10 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
+| `ELIZA_CODEX_SANDBOX_MODE` / `ELIZA_CODEX_ACP_SANDBOX_MODE` | unset | Optional Codex ACP sandbox override (`read-only`, `workspace-write`, `danger-full-access`) |
+| `ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE` / `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox used when Linux reports no Landlock support or the transport retries after the known Landlock panic |
+| `ELIZA_CODEX_APPROVAL_POLICY` / `ELIZA_CODEX_ACP_APPROVAL_POLICY` | unset | Optional Codex CLI approval policy appended with `-c approval_policy=...` |
+| `ELIZA_CODEX_LANDLOCK_AVAILABLE` / `ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE` | auto | Override host Landlock detection for Codex ACP (`true`/`false`) |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -144,6 +144,10 @@ All configuration is via environment variables. Use `ELIZA_ACP_TRANSPORT=native`
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command. |
+| `ELIZA_CODEX_SANDBOX_MODE` / `ELIZA_CODEX_ACP_SANDBOX_MODE` | unset | Optional Codex ACP sandbox override (`read-only`, `workspace-write`, `danger-full-access`). |
+| `ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE` / `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | `danger-full-access` | Codex ACP sandbox used when Linux reports no Landlock support or the transport retries after the known Landlock panic. |
+| `ELIZA_CODEX_APPROVAL_POLICY` / `ELIZA_CODEX_ACP_APPROVAL_POLICY` | unset | Optional Codex CLI approval policy appended with `-c approval_policy=...`. |
+| `ELIZA_CODEX_LANDLOCK_AVAILABLE` / `ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE` | auto | Override host Landlock detection for Codex ACP (`true`/`false`). |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -219,6 +219,53 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     );
   });
 
+  it("retries Codex ACP with the Landlock fallback command after the known panic", async () => {
+    const first = queueProc();
+    const second = queueProc();
+    const onFallback = vi.fn();
+    const client = new NativeAcpClient({
+      command: "codex-acp --stdio",
+      landlockFallbackCommand:
+        'codex-acp --stdio -c sandbox_mode="danger-full-access" -c approval_policy="never"',
+      cwd: "/tmp/native-acp",
+      approvalPreset: "autonomous",
+      onFallback,
+    });
+
+    const started = client.start();
+    await waitForWrites(first, 1);
+    first.stderr.emit(
+      "data",
+      Buffer.from(
+        "thread 'main' panicked at linux_run_main.rs:311:9:\npermission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock\n",
+      ),
+    );
+    closeProc(first, 101, null);
+    await waitForSpawnCalls(2);
+    await waitForWrites(second, 1);
+
+    expect(spawnMock.mock.calls[1]?.[0]).toBe("codex-acp");
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      "--stdio",
+      "-c",
+      'sandbox_mode="danger-full-access"',
+      "-c",
+      'approval_policy="never"',
+    ]);
+    expect(onFallback).toHaveBeenCalledWith({
+      reason: "codex-landlock-unavailable",
+      command:
+        'codex-acp --stdio -c sandbox_mode="danger-full-access" -c approval_policy="never"',
+    });
+
+    emitJson(second, {
+      jsonrpc: "2.0",
+      id: writeAt(second, 0).id,
+      result: {},
+    });
+    await started;
+  });
+
   it("falls back from session/cancel request to notification when rejected", async () => {
     const { client, p } = await startClient();
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -21,6 +21,7 @@ type NativeEventHandler = (
 ) => void;
 type NativeOptions = {
   command: string;
+  landlockFallbackCommand?: string;
   cwd: string;
   approvalPreset: ApprovalPreset;
   timeoutMs?: number;
@@ -28,6 +29,7 @@ type NativeOptions = {
   env?: NodeJS.ProcessEnv;
   onEvent?: NativeEventHandler;
   onStderr?: (chunk: string) => void;
+  onFallback?: (event: { reason: string; command: string }) => void;
 };
 type MockNativeClient = {
   opts: NativeOptions;
@@ -139,7 +141,11 @@ type MockProc = EventEmitter & {
 const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
 
 function runtime(settings: Record<string, string | undefined> = {}) {
-  const values = { ELIZA_ACP_TRANSPORT: "cli", ...settings };
+  const values = {
+    ELIZA_ACP_TRANSPORT: "cli",
+    ELIZA_CODEX_LANDLOCK_AVAILABLE: "true",
+    ...settings,
+  };
   return {
     logger: {
       debug: vi.fn(),
@@ -493,6 +499,66 @@ describe("AcpService", () => {
     expect(nativeClientMock.instances[0]?.opts.command).toBe(
       "codex-acp --stdio",
     );
+  });
+
+  it("adds a Codex sandbox fallback when Linux reports no Landlock support", async () => {
+    const rt = runtime({
+      ELIZA_ACP_TRANSPORT: "native",
+      ELIZA_CODEX_ACP_COMMAND: "codex-acp --stdio",
+      ELIZA_CODEX_LANDLOCK_AVAILABLE: "false",
+    }) as {
+      logger: { warn: ReturnType<typeof vi.fn> };
+    };
+    const service = new AcpService(rt as never);
+    await service.start();
+
+    const result = await service.spawnSession({
+      name: "native-no-landlock",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(result.status).toBe("ready");
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      'codex-acp --stdio -c sandbox_mode="danger-full-access" -c approval_policy="never"',
+    );
+    expect(
+      nativeClientMock.instances[0]?.opts.landlockFallbackCommand,
+    ).toBeUndefined();
+    expect(rt.logger.warn).toHaveBeenCalledWith(
+      "[AcpService] Codex ACP landlock unavailable; using fallback",
+      {
+        sandboxMode: "danger-full-access",
+        approvalPolicy: "never",
+      },
+    );
+  });
+
+  it("does not duplicate Codex sandbox config already present in the native command", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ELIZA_CODEX_ACP_COMMAND:
+          'codex-acp --stdio -c sandbox_mode="workspace-write"',
+        ELIZA_CODEX_LANDLOCK_AVAILABLE: "false",
+      }),
+    );
+    await service.start();
+
+    await service.spawnSession({
+      name: "native-configured-sandbox",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      'codex-acp --stdio -c sandbox_mode="workspace-write"',
+    );
+    expect(
+      nativeClientMock.instances[0]?.opts.landlockFallbackCommand,
+    ).toBeUndefined();
   });
 
   it("does not emit task_complete from the session creation command", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCodexLandlockPanicExit,
+  resolveCodexAcpCommand,
+} from "../../src/services/codex-sandbox.js";
+
+function setting(values: Record<string, string | undefined>) {
+  return (key: string) => values[key];
+}
+
+describe("Codex ACP sandbox command resolution", () => {
+  it("applies the no-Landlock fallback when Linux reports no Landlock LSM", () => {
+    const resolved = resolveCodexAcpCommand("codex-acp --stdio", setting({}), {
+      platform: "linux",
+      readLinuxSecurityModules: () => "lockdown,yama,apparmor,bpf",
+    });
+
+    expect(resolved.command).toBe(
+      'codex-acp --stdio -c sandbox_mode="danger-full-access" -c approval_policy="never"',
+    );
+    expect(resolved.landlockFallbackCommand).toBeUndefined();
+    expect(resolved.noLandlockDetected).toBe(true);
+    expect(resolved.sandboxMode).toBe("danger-full-access");
+    expect(resolved.approvalPolicy).toBe("never");
+  });
+
+  it("uses explicit sandbox settings without waiting for Landlock detection", () => {
+    const resolved = resolveCodexAcpCommand(
+      "codex-acp --stdio",
+      setting({
+        ELIZA_CODEX_SANDBOX_MODE: "workspace-write",
+        ELIZA_CODEX_APPROVAL_POLICY: "on-request",
+      }),
+      { platform: "linux", readLinuxSecurityModules: () => undefined },
+    );
+
+    expect(resolved.command).toBe(
+      'codex-acp --stdio -c sandbox_mode="workspace-write" -c approval_policy="on-request"',
+    );
+    expect(resolved.landlockFallbackCommand).toBeUndefined();
+    expect(resolved.noLandlockDetected).toBe(false);
+  });
+
+  it("arms a retry fallback when Landlock availability is unknown", () => {
+    const resolved = resolveCodexAcpCommand("codex-acp --stdio", setting({}), {
+      platform: "linux",
+      readLinuxSecurityModules: () => undefined,
+    });
+
+    expect(resolved.command).toBe("codex-acp --stdio");
+    expect(resolved.landlockFallbackCommand).toBe(
+      'codex-acp --stdio -c sandbox_mode="danger-full-access" -c approval_policy="never"',
+    );
+    expect(resolved.noLandlockDetected).toBe(false);
+  });
+
+  it("does not duplicate sandbox args already present in the command", () => {
+    const resolved = resolveCodexAcpCommand(
+      'codex-acp --stdio -c sandbox_mode="read-only"',
+      setting({}),
+      {
+        platform: "linux",
+        readLinuxSecurityModules: () => "lockdown,yama,apparmor,bpf",
+      },
+    );
+
+    expect(resolved.command).toBe(
+      'codex-acp --stdio -c sandbox_mode="read-only"',
+    );
+    expect(resolved.landlockFallbackCommand).toBeUndefined();
+  });
+
+  it("recognizes the Codex Landlock panic signature", () => {
+    expect(
+      isCodexLandlockPanicExit({
+        code: 101,
+        stderr:
+          "permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+      }),
+    ).toBe(true);
+    expect(
+      isCodexLandlockPanicExit({
+        code: 1,
+        stderr:
+          "permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock",
+      }),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -173,6 +173,56 @@
         "default": "npx -y @zed-industries/codex-acp@0.14.0",
         "sensitive": false
       },
+      "ELIZA_CODEX_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Optional Codex ACP sandbox override: read-only, workspace-write, or danger-full-access.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Alias for ELIZA_CODEX_SANDBOX_MODE scoped to native ACP sessions.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Codex ACP sandbox mode used when Linux reports no Landlock support or Codex exits with the known Landlock panic.",
+        "required": false,
+        "default": "danger-full-access",
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE": {
+        "type": "string",
+        "description": "Alias for ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE scoped to native ACP sessions.",
+        "required": false,
+        "default": "danger-full-access",
+        "sensitive": false
+      },
+      "ELIZA_CODEX_APPROVAL_POLICY": {
+        "type": "string",
+        "description": "Optional Codex CLI approval_policy value appended to the ACP command with -c.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_APPROVAL_POLICY": {
+        "type": "string",
+        "description": "Alias for ELIZA_CODEX_APPROVAL_POLICY scoped to native ACP sessions.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_LANDLOCK_AVAILABLE": {
+        "type": "boolean",
+        "description": "Override Codex ACP host Landlock detection. Set false in no-Landlock containers to apply the fallback before spawn.",
+        "required": false,
+        "sensitive": false
+      },
+      "ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE": {
+        "type": "boolean",
+        "description": "Alias for ELIZA_CODEX_LANDLOCK_AVAILABLE scoped to native ACP sessions.",
+        "required": false,
+        "sensitive": false
+      },
       "ELIZA_CLAUDE_ACP_COMMAND": {
         "type": "string",
         "description": "Native ACP command used for Claude sessions when ELIZA_ACP_TRANSPORT=native. Pin this in production to avoid implicit package upgrades.",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -1,6 +1,11 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { lstat, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
+import {
+  appendCodexStderrTail,
+  type CodexLandlockFallbackEvent,
+  isCodexLandlockPanicExit,
+} from "./codex-sandbox.js";
 import type { AcpJsonRpcMessage, ApprovalPreset } from "./types.js";
 
 export type NativeAcpEventCallback = (
@@ -29,6 +34,7 @@ export type AcpMcpServerConfig =
 
 export type NativeAcpClientOptions = {
   command: string;
+  landlockFallbackCommand?: string;
   cwd: string;
   env?: NodeJS.ProcessEnv;
   approvalPreset: ApprovalPreset;
@@ -36,6 +42,7 @@ export type NativeAcpClientOptions = {
   timeoutMs?: number;
   onEvent?: NativeAcpEventCallback;
   onStderr?: (chunk: string) => void;
+  onFallback?: (event: CodexLandlockFallbackEvent) => void;
   /**
    * MCP servers to expose to the spawned sub-agent. Defaults to the opt-in
    * `ELIZA_ACP_MCP_SERVERS` env var (see `parseAcpMcpServersEnv`); when unset,
@@ -145,26 +152,48 @@ export class NativeAcpClient {
 
   async start(): Promise<void> {
     if (this.proc) return;
-    const { command, args } = splitCommandLine(this.opts.command);
+    try {
+      await this.startWithCommand(this.opts.command);
+    } catch (err) {
+      const fallbackCommand = this.opts.landlockFallbackCommand;
+      if (
+        fallbackCommand &&
+        isCodexLandlockPanicError(err) &&
+        fallbackCommand !== this.opts.command
+      ) {
+        this.resetAfterFailedStart();
+        this.opts.onFallback?.({
+          reason: "codex-landlock-unavailable",
+          command: fallbackCommand,
+        });
+        await this.startWithCommand(fallbackCommand);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async startWithCommand(commandLine: string): Promise<void> {
+    const { command, args } = splitCommandLine(commandLine);
     const proc = spawn(command, args, {
       cwd: this.opts.cwd,
       env: this.opts.env,
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.proc = proc;
+    let stderrTail = "";
 
     proc.stdout.on("data", (chunk: Buffer) => this.handleStdout(chunk));
-    proc.stderr.on("data", (chunk: Buffer) =>
-      this.opts.onStderr?.(chunk.toString("utf8")),
-    );
+    proc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stderrTail = appendCodexStderrTail(stderrTail, text);
+      this.opts.onStderr?.(text);
+    });
     proc.on("error", (err) => this.rejectAll(err));
     proc.on("close", (code, signal) => {
       this.closed = true;
-      this.rejectAll(
-        new Error(
-          `ACP agent exited with code ${code ?? "unknown"}${signal ? ` signal ${signal}` : ""}`,
-        ),
-      );
+      if (this.proc === proc) this.proc = undefined;
+      this.rejectAll(acpExitError(code, signal, stderrTail));
     });
 
     await this.request(
@@ -187,6 +216,12 @@ export class NativeAcpClient {
         ? this.opts.timeoutMs
         : DEFAULT_TIMEOUT_MS,
     );
+  }
+
+  private resetAfterFailedStart(): void {
+    this.proc = undefined;
+    this.closed = false;
+    this.readBuffer = "";
   }
 
   async createSession(cwd = this.opts.cwd): Promise<NativeAcpSession> {
@@ -732,6 +767,35 @@ class AcpRequestError extends Error {
     this.code = code;
     this.data = data;
   }
+}
+
+class AcpProcessExitError extends Error {
+  constructor(
+    message: string,
+    readonly code: number | null,
+    readonly signal: NodeJS.Signals | null,
+    readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "AcpProcessExitError";
+  }
+}
+
+function acpExitError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string,
+): Error {
+  const message = `ACP agent exited with code ${code ?? "unknown"}${signal ? ` signal ${signal}` : ""}`;
+  return new AcpProcessExitError(message, code, signal, stderr);
+}
+
+function isCodexLandlockPanicError(err: unknown): boolean {
+  if (!(err instanceof AcpProcessExitError)) return false;
+  return isCodexLandlockPanicExit({
+    code: err.code,
+    stderr: err.stderr,
+  });
 }
 
 function jsonRpcError(error: unknown): Error {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -8,6 +8,10 @@ import { type IAgentRuntime, Service } from "@elizaos/core";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
+  type CodexAcpCommandConfig,
+  resolveCodexAcpCommand,
+} from "./codex-sandbox.js";
+import {
   accountMetaFromSessionMetadata,
   type CodingAccountMeta,
   diagnoseCodingAccountFallback,
@@ -91,6 +95,12 @@ type RunResult = {
   stopReason?: string;
   cancelled?: boolean;
   durationMs: number;
+};
+
+type NativeAgentCommandConfig = {
+  command: string;
+  landlockFallbackCommand?: string;
+  codex?: CodexAcpCommandConfig;
 };
 
 const STDERR_CAP_BYTES = 64 * 1024;
@@ -1229,10 +1239,12 @@ export class AcpService extends Service {
     session: SessionInfo,
     opts: SpawnOptions,
   ): Promise<SpawnResult> {
-    const command = this.nativeAgentCommand(session.agentType);
+    const commandConfig = this.nativeAgentCommand(session.agentType);
+    this.logCodexCommandConfig(commandConfig.codex);
     const stderr: string[] = [];
     const client = new NativeAcpClient({
-      command,
+      command: commandConfig.command,
+      landlockFallbackCommand: commandConfig.landlockFallbackCommand,
       cwd: session.workdir,
       approvalPreset: session.approvalPreset,
       timeoutMs: opts.timeoutMs ?? this.sessionTimeoutMs,
@@ -1265,6 +1277,16 @@ export class AcpService extends Service {
       },
       onStderr: (chunk) => {
         stderr.push(chunk);
+      },
+      onFallback: (event) => {
+        if (event.reason === "codex-landlock-unavailable") {
+          stderr.length = 0;
+          this.log("warn", "Codex ACP landlock fallback activated", {
+            sessionId: id,
+            sandboxMode: commandConfig.codex?.sandboxMode,
+            approvalPolicy: commandConfig.codex?.approvalPolicy,
+          });
+        }
       },
     });
     try {
@@ -1442,37 +1464,71 @@ export class AcpService extends Service {
     }
   }
 
-  private nativeAgentCommand(agentType: AgentType): string {
+  private nativeAgentCommand(agentType: AgentType): NativeAgentCommandConfig {
     const normalizedAgentType =
       normalizeTaskAgentAdapter(agentType) ?? agentType;
     if (normalizedAgentType === "opencode") {
       const command = this.opencodeAgentCommand();
-      if (command) return command;
-      return this.setting("ELIZA_OPENCODE_ACP_COMMAND") ?? "opencode acp";
+      if (command) return { command };
+      return {
+        command: this.setting("ELIZA_OPENCODE_ACP_COMMAND") ?? "opencode acp",
+      };
     }
     const override = this.setting(
       `ELIZA_${String(normalizedAgentType)
         .toUpperCase()
         .replace(/[^A-Z0-9]/g, "_")}_ACP_COMMAND`,
     );
-    if (override?.trim()) return override.trim();
-    if (normalizedAgentType === "codex")
-      return (
-        this.setting("ELIZA_CODEX_ACP_COMMAND") ??
-        "npx -y @zed-industries/codex-acp@0.14.0"
+    if (normalizedAgentType === "codex") {
+      return this.codexAgentCommand(
+        override?.trim() ||
+          this.setting("ELIZA_CODEX_ACP_COMMAND") ||
+          "npx -y @zed-industries/codex-acp@0.14.0",
       );
+    }
+    if (override?.trim()) return { command: override.trim() };
     if (normalizedAgentType === "claude")
-      return (
-        this.setting("ELIZA_CLAUDE_ACP_COMMAND") ??
-        "npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
-      );
+      return {
+        command:
+          this.setting("ELIZA_CLAUDE_ACP_COMMAND") ??
+          "npx -y @agentclientprotocol/claude-agent-acp@0.34.0",
+      };
     // The elizaos native agent is the eliza-code ACP server
     // (packages/examples/code, bin `eliza-code-acp`). The elizaos CLI has no
     // ACP mode, so the bare-name fallback below would spawn the wrong binary —
     // resolve to the eliza-code bin unless an explicit command is configured.
     if (normalizedAgentType === "elizaos")
-      return this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ?? "eliza-code-acp";
-    return String(normalizedAgentType);
+      return {
+        command: this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ?? "eliza-code-acp",
+      };
+    return { command: String(normalizedAgentType) };
+  }
+
+  private codexAgentCommand(command: string): NativeAgentCommandConfig {
+    const codex = resolveCodexAcpCommand(command, (key) => this.setting(key));
+    return {
+      command: codex.command,
+      landlockFallbackCommand: codex.landlockFallbackCommand,
+      codex,
+    };
+  }
+
+  private logCodexCommandConfig(config: CodexAcpCommandConfig | undefined) {
+    if (!config) return;
+    for (const invalid of config.invalidSettings) {
+      this.log("warn", "ignoring invalid Codex ACP sandbox setting", invalid);
+    }
+    if (config.noLandlockDetected) {
+      this.log("warn", "Codex ACP landlock unavailable; using fallback", {
+        sandboxMode: config.sandboxMode,
+        approvalPolicy: config.approvalPolicy,
+      });
+    } else if (config.landlockFallbackCommand) {
+      this.log("debug", "armed Codex ACP landlock fallback", {
+        sandboxMode: config.sandboxMode,
+        approvalPolicy: config.approvalPolicy,
+      });
+    }
   }
 
   private async stopNativeClient(sessionId: string): Promise<void> {

--- a/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts
@@ -1,0 +1,299 @@
+import { readFileSync } from "node:fs";
+
+export type CodexSandboxMode =
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+export type CodexApprovalPolicy =
+  | "untrusted"
+  | "on-request"
+  | "on-failure"
+  | "never";
+
+export type CodexLandlockFallbackReason = "codex-landlock-unavailable";
+
+export type CodexLandlockFallbackEvent = {
+  reason: CodexLandlockFallbackReason;
+  command: string;
+};
+
+export type CodexAcpCommandConfig = {
+  command: string;
+  landlockFallbackCommand?: string;
+  noLandlockDetected: boolean;
+  sandboxMode?: CodexSandboxMode;
+  approvalPolicy?: CodexApprovalPolicy;
+  invalidSettings: Array<{ key: string; value: string }>;
+};
+
+type SettingReader = (key: string) => string | undefined;
+
+type LandlockOptions = {
+  platform?: NodeJS.Platform;
+  readLinuxSecurityModules?: () => string | undefined;
+};
+
+const SANDBOX_MODE_SETTINGS = [
+  "ELIZA_CODEX_ACP_SANDBOX_MODE",
+  "ELIZA_CODEX_SANDBOX_MODE",
+  "CODEX_EXEC_SANDBOX_MODE",
+  "CODING_AGENT_SANDBOX",
+] as const;
+
+const NO_LANDLOCK_SANDBOX_MODE_SETTINGS = [
+  "ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE",
+  "ELIZA_CODEX_NO_LANDLOCK_SANDBOX_MODE",
+] as const;
+
+const APPROVAL_POLICY_SETTINGS = [
+  "ELIZA_CODEX_ACP_APPROVAL_POLICY",
+  "ELIZA_CODEX_APPROVAL_POLICY",
+  "CODEX_APPROVAL_POLICY",
+] as const;
+
+const NO_LANDLOCK_APPROVAL_POLICY_SETTINGS = [
+  "ELIZA_CODEX_ACP_NO_LANDLOCK_APPROVAL_POLICY",
+  "ELIZA_CODEX_NO_LANDLOCK_APPROVAL_POLICY",
+] as const;
+
+const LANDLOCK_AVAILABLE_SETTINGS = [
+  "ELIZA_CODEX_ACP_LANDLOCK_AVAILABLE",
+  "ELIZA_CODEX_LANDLOCK_AVAILABLE",
+] as const;
+
+const DEFAULT_NO_LANDLOCK_SANDBOX_MODE: CodexSandboxMode = "danger-full-access";
+const DEFAULT_NO_LANDLOCK_APPROVAL_POLICY: CodexApprovalPolicy = "never";
+const STDERR_TAIL_LIMIT = 16 * 1024;
+
+export function resolveCodexAcpCommand(
+  baseCommand: string,
+  setting: SettingReader,
+  options: LandlockOptions = {},
+): CodexAcpCommandConfig {
+  const command = baseCommand.trim();
+  const invalidSettings: Array<{ key: string; value: string }> = [];
+  const explicitMode = readSandboxMode(setting, SANDBOX_MODE_SETTINGS, {
+    invalidSettings,
+  });
+  const explicitApprovalPolicy = readApprovalPolicy(
+    setting,
+    APPROVAL_POLICY_SETTINGS,
+    { invalidSettings },
+  );
+  const hasSandboxConfig = commandHasCodexSandboxConfig(command);
+  const hasApprovalPolicyConfig = commandHasCodexApprovalPolicyConfig(command);
+
+  if (explicitMode) {
+    return {
+      command: appendCodexConfig(command, {
+        sandboxMode: hasSandboxConfig ? undefined : explicitMode,
+        approvalPolicy: hasApprovalPolicyConfig
+          ? undefined
+          : explicitApprovalPolicy,
+      }),
+      noLandlockDetected: false,
+      sandboxMode: explicitMode,
+      approvalPolicy: explicitApprovalPolicy,
+      invalidSettings,
+    };
+  }
+
+  const fallbackMode =
+    readSandboxMode(setting, NO_LANDLOCK_SANDBOX_MODE_SETTINGS, {
+      invalidSettings,
+    }) ?? DEFAULT_NO_LANDLOCK_SANDBOX_MODE;
+  const fallbackApprovalPolicy =
+    explicitApprovalPolicy ??
+    readApprovalPolicy(setting, NO_LANDLOCK_APPROVAL_POLICY_SETTINGS, {
+      invalidSettings,
+    }) ??
+    DEFAULT_NO_LANDLOCK_APPROVAL_POLICY;
+
+  const fallbackCommand = hasSandboxConfig
+    ? undefined
+    : appendCodexConfig(command, {
+        sandboxMode: fallbackMode,
+        approvalPolicy: hasApprovalPolicyConfig
+          ? undefined
+          : fallbackApprovalPolicy,
+      });
+  const landlockAvailable = detectLandlockAvailability(setting, options);
+  const noLandlockDetected = landlockAvailable === false;
+
+  if (noLandlockDetected && fallbackCommand) {
+    return {
+      command: fallbackCommand,
+      noLandlockDetected: true,
+      sandboxMode: fallbackMode,
+      approvalPolicy: fallbackApprovalPolicy,
+      invalidSettings,
+    };
+  }
+
+  return {
+    command,
+    landlockFallbackCommand:
+      fallbackCommand && fallbackCommand !== command
+        ? fallbackCommand
+        : undefined,
+    noLandlockDetected,
+    sandboxMode: fallbackCommand ? fallbackMode : undefined,
+    approvalPolicy: fallbackCommand ? fallbackApprovalPolicy : undefined,
+    invalidSettings,
+  };
+}
+
+export function isCodexLandlockPanicExit(input: {
+  code: number | null;
+  stderr: string;
+}): boolean {
+  if (input.code !== 101) return false;
+  return (
+    /permission profiles requiring direct runtime enforcement are incompatible with --use-legacy-landlock/iu.test(
+      input.stderr,
+    ) || /landlock/iu.test(input.stderr)
+  );
+}
+
+export function appendCodexStderrTail(current: string, chunk: string): string {
+  const next = current + chunk;
+  if (next.length <= STDERR_TAIL_LIMIT) return next;
+  return next.slice(-STDERR_TAIL_LIMIT);
+}
+
+function detectLandlockAvailability(
+  setting: SettingReader,
+  options: LandlockOptions,
+): boolean | undefined {
+  const forced = readBoolSetting(setting, LANDLOCK_AVAILABLE_SETTINGS);
+  if (forced !== undefined) return forced;
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") return true;
+  const raw = readLinuxSecurityModules(options);
+  if (raw === undefined) return undefined;
+  return raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .includes("landlock");
+}
+
+function readLinuxSecurityModules(
+  options: LandlockOptions,
+): string | undefined {
+  if (options.readLinuxSecurityModules) {
+    return options.readLinuxSecurityModules();
+  }
+  try {
+    return readFileSync("/sys/kernel/security/lsm", "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function appendCodexConfig(
+  command: string,
+  opts: {
+    sandboxMode?: CodexSandboxMode;
+    approvalPolicy?: CodexApprovalPolicy;
+  },
+): string {
+  const args: string[] = [];
+  if (opts.sandboxMode) args.push("-c", `sandbox_mode="${opts.sandboxMode}"`);
+  if (opts.approvalPolicy)
+    args.push("-c", `approval_policy="${opts.approvalPolicy}"`);
+  return args.length > 0 ? `${command} ${args.join(" ")}` : command;
+}
+
+function commandHasCodexSandboxConfig(command: string): boolean {
+  return (
+    /\bsandbox_mode\b/u.test(command) ||
+    /\b--dangerously-bypass-approvals-and-sandbox\b/u.test(command) ||
+    /\s-s\s+(read-only|workspace-write|danger-full-access)(\s|$)/u.test(
+      ` ${command} `,
+    )
+  );
+}
+
+function commandHasCodexApprovalPolicyConfig(command: string): boolean {
+  return /\bapproval_policy\b/u.test(command);
+}
+
+function readSandboxMode(
+  setting: SettingReader,
+  keys: readonly string[],
+  opts: { invalidSettings: Array<{ key: string; value: string }> },
+): CodexSandboxMode | undefined {
+  const entry = firstSetting(setting, keys);
+  if (!entry) return undefined;
+  const mode = parseSandboxMode(entry.value);
+  if (mode) return mode;
+  opts.invalidSettings.push(entry);
+  return undefined;
+}
+
+function parseSandboxMode(value: string): CodexSandboxMode | undefined {
+  const normalized = value.trim().toLowerCase().replace(/_/gu, "-");
+  if (normalized === "read-only" || normalized === "readonly") {
+    return "read-only";
+  }
+  if (normalized === "workspace-write" || normalized === "workspace") {
+    return "workspace-write";
+  }
+  if (
+    normalized === "danger-full-access" ||
+    normalized === "danger" ||
+    normalized === "full-access" ||
+    normalized === "off" ||
+    normalized === "none" ||
+    normalized === "disabled" ||
+    normalized === "false" ||
+    normalized === "0"
+  ) {
+    return "danger-full-access";
+  }
+  return undefined;
+}
+
+function readApprovalPolicy(
+  setting: SettingReader,
+  keys: readonly string[],
+  opts: { invalidSettings: Array<{ key: string; value: string }> },
+): CodexApprovalPolicy | undefined {
+  const entry = firstSetting(setting, keys);
+  if (!entry) return undefined;
+  const normalized = entry.value.trim().toLowerCase().replace(/_/gu, "-");
+  if (
+    normalized === "untrusted" ||
+    normalized === "on-request" ||
+    normalized === "on-failure" ||
+    normalized === "never"
+  ) {
+    return normalized;
+  }
+  opts.invalidSettings.push(entry);
+  return undefined;
+}
+
+function readBoolSetting(
+  setting: SettingReader,
+  keys: readonly string[],
+): boolean | undefined {
+  const entry = firstSetting(setting, keys);
+  if (!entry) return undefined;
+  const normalized = entry.value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function firstSetting(
+  setting: SettingReader,
+  keys: readonly string[],
+): { key: string; value: string } | undefined {
+  for (const key of keys) {
+    const value = setting(key)?.trim();
+    if (value) return { key, value };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #11221.

- Adds Codex ACP sandbox command resolution with deployment knobs for sandbox mode, no-Landlock fallback mode, approval policy, and Landlock detection override.
- Detects Linux Landlock availability via `/sys/kernel/security/lsm` and applies the fallback before spawn when Landlock is known unavailable.
- Retries native Codex ACP once with the fallback command when the child exits 101 with the known Landlock panic.
- Keeps existing `ELIZA_CODEX_ACP_COMMAND` sandbox config authoritative and avoids duplicate `sandbox_mode` args.

## Evidence

Artifact: `.github/issue-evidence/11221-codex-landlock-fallback.md`

## Validation

Passed:

```bash
bun install
bunx vitest run --config vitest.config.ts __tests__/unit/codex-sandbox.test.ts __tests__/unit/acp-native-transport.test.ts __tests__/unit/acp-service.test.ts
bunx vitest run --config vitest.config.ts __tests__/unit/task-policy.test.ts
bun run --cwd plugins/plugin-agent-orchestrator typecheck
bun run --cwd plugins/plugin-agent-orchestrator build
bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts plugins/plugin-agent-orchestrator/src/services/codex-sandbox.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/codex-sandbox.test.ts
```

Known unrelated failures captured in the evidence artifact:

```bash
bun run verify
bun run --cwd plugins/plugin-agent-orchestrator test:unit
bun run --cwd plugins/plugin-agent-orchestrator lint:check
```

`bun run verify` stops at the existing repo-wide type-safety ratchet drift (`as unknown as: 80 / 77`, ``?? {}``: 379 / 377). Full orchestrator unit suite times out in `task-policy.test.ts` only under the full-suite run; that file passes by itself. Package lint fails on pre-existing files outside this change set.

## Evidence Checklist

- Real Linux no-Landlock container repro: N/A - local host is macOS and Docker daemon is not running; deterministic unit coverage simulates forced no-Landlock detection and the exact exit-101 panic text.
- UI screenshots/video: N/A - no UI behavior changed.
- Frontend console/network logs: N/A - no frontend behavior changed.
- Live LLM trajectory: N/A - no prompt/model/action behavior changed.
- Backend logs/domain artifacts: fallback path covered by service/transport unit tests and evidence artifact.
