### PR TITLE
fix(cloud): allow monetized messages attribution

### DIFF
--- a/.github/issue-evidence/11310-messages-app-markup.md
+++ b/.github/issue-evidence/11310-messages-app-markup.md
@@ -1,0 +1,54 @@
+# Issue #11310 — `/api/v1/messages` X-App-Id creator markup
+
+## Result
+
+Fixed the `/api/v1/messages` monetized-app path for fresh cross-org callers:
+monetized apps are public to authenticated callers for paid inference
+attribution, while non-monetized apps remain excluded from this hot path.
+
+## Human-reviewed evidence
+
+- `bun test packages/cloud/api/__tests__/messages-iac-fast-path.test.ts`
+  - Passed: 3 tests, 22 assertions.
+  - Regression proves a monetized `X-App-Id` request uses
+    `appCreditsService.reserveInferenceCredits(...)`, not plain
+    `reserveCredits(...)`.
+- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts`
+  - Passed: 21 tests, 89 assertions.
+  - Regression proves cross-org authenticated callers resolve monetized apps,
+    analytics-only `app_users` rows do not block monetized inference, and
+    non-monetized apps still return `undefined`.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Passed.
+- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/apps.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts packages/cloud/api/__tests__/messages-iac-fast-path.test.ts packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts`
+  - Passed.
+- `bun run --cwd packages/test/cloud-e2e test monetized-mock-llm-journey.spec.ts`
+  - Passed: 1 Playwright test.
+  - Domain artifacts reviewed from test output and `packages/test/cloud-e2e/.logs/cloud-api.log`:
+    - Draft monetization gate returned `403`.
+    - Approved monetization update returned `200`.
+    - `POST /api/v1/messages` with `X-App-Id` returned `200`.
+    - Mock LLM returned `PONG`.
+    - End-user org debit: `1000 -> 999.999984` (`0.000015999999959603883` debited).
+    - App earnings: `0 -> 0.000008`.
+
+## Validation gaps / non-applicable artifacts
+
+- No screenshots or video: this is a backend billing/API path; no UI surface changed.
+- No live-LLM trajectory: the targeted always-on regression is intentionally the
+  keyless mock-LLM cloud-e2e path. It drives real cloud-api, PGlite, auth,
+  credits, markup, and earnings ledgers; only provider bytes are mocked.
+- `bun run --cwd packages/cloud/api typecheck` is blocked by unrelated existing
+  cloud-api errors:
+  - `__tests__/stripe-connect-webhook-route.test.ts(233,5)` Stripe API version
+    literal mismatch.
+  - `fal/proxy/route.ts` Hono type mismatch between installed `hono@4.12.18`
+    and `hono@4.12.27`.
+- `bun run --cwd packages/test/cloud-e2e typecheck` is blocked before source
+  checking by `tsconfig.json(15,5): TS5101` because this workspace resolves
+  TypeScript 6 and the package still uses deprecated `baseUrl` without
+  `ignoreDeprecations`.
+- `bun run verify` is blocked before typecheck/lint by unrelated repo-wide
+  type-safety ratchet drift:
+  - `as unknown as`: `80 current > 77 baseline`.
+  - ``?? {}`` in core/agent/app-core: `379 current > 377 baseline`.

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -100,17 +100,20 @@ mock.module("@/lib/services/credits", () => ({
   },
 }));
 
+const reserveInferenceCredits = mock();
 mock.module("@/lib/services/app-credits", () => ({
   appCreditsService: {
     calculateCostWithMarkup: async () => ({ totalCost: 0.002 }),
     checkBalance: async () => ({ sufficient: true }),
+    reserveInferenceCredits,
     recordUsage: async () => undefined,
   },
 }));
 
+const getAuthorizedMonetizedAppForUser = mock();
 mock.module("@/lib/services/apps", () => ({
   appsService: {
-    getAuthorizedMonetizedAppForUser: async () => null,
+    getAuthorizedMonetizedAppForUser,
     getById: async () => null,
   },
 }));
@@ -154,6 +157,8 @@ beforeEach(() => {
   billUsage.mockReset();
   estimateInputTokens.mockReset();
   recordUsageAnalytics.mockReset();
+  reserveInferenceCredits.mockReset();
+  getAuthorizedMonetizedAppForUser.mockReset();
   createCreditReservationSettler.mockReset();
   generateText.mockReset();
 
@@ -169,8 +174,13 @@ beforeEach(() => {
   validateApiKey.mockResolvedValue({ id: API_KEY_ID });
   shouldBlockUser.mockResolvedValue(false);
   estimateInputTokens.mockReturnValue(8);
+  getAuthorizedMonetizedAppForUser.mockResolvedValue(null);
   reserveCredits.mockResolvedValue({
     reservedAmount: 0.01,
+    reconcile: async () => null,
+  });
+  reserveInferenceCredits.mockResolvedValue({
+    reservedAmount: 0.02,
     reconcile: async () => null,
   });
   createCreditReservationSettler.mockReturnValue(async () => null);
@@ -179,12 +189,13 @@ beforeEach(() => {
   });
 });
 
-function postMessages() {
+function postMessages(extraHeaders: Record<string, string> = {}) {
   return messagesRoute.request("/", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-api-key": "eliza_test_key",
+      ...extraHeaders,
     },
     body: JSON.stringify({
       model: "claude-3-5-sonnet-20241022",
@@ -233,5 +244,63 @@ describe("/v1/messages IAC fast path", () => {
     expect(shouldBlockUser).not.toHaveBeenCalled();
     expect(reserveCredits).not.toHaveBeenCalled();
     expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("monetized X-App-Id messages use app-credit reservation with creator markup", async () => {
+    const appReservation = {
+      reservedAmount: 0.02,
+      reconcile: async () => null,
+    };
+    const settleAppReservation = mock(async () => null);
+    getAuthorizedMonetizedAppForUser.mockResolvedValueOnce({
+      id: "00000000-0000-4000-8000-0000000000dd",
+      monetization_enabled: true,
+      inference_markup_percentage: "100",
+    });
+    reserveInferenceCredits.mockResolvedValueOnce(appReservation);
+    createCreditReservationSettler.mockReturnValueOnce(settleAppReservation);
+    generateText.mockResolvedValueOnce({
+      text: "hello",
+      usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+      finishReason: "stop",
+    });
+    billUsage.mockResolvedValueOnce({
+      inputCost: 0.001,
+      outputCost: 0.001,
+      totalCost: 0.002,
+      baseInputCost: 0.0008,
+      baseOutputCost: 0.0008,
+      baseTotalCost: 0.0016,
+      platformMarkup: 0.0004,
+      inputTokens: 5,
+      outputTokens: 2,
+      totalTokens: 7,
+      markupApplied: true,
+    });
+
+    const response = await postMessages({
+      "X-App-Id": "00000000-0000-4000-8000-0000000000dd",
+    });
+
+    expect(response.status).toBe(200);
+    expect(getAuthorizedMonetizedAppForUser).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-0000000000dd",
+      { id: USER, organization_id: ORG },
+    );
+    expect(reserveInferenceCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "00000000-0000-4000-8000-0000000000dd",
+        userId: USER,
+        estimatedBaseCost: 0.002,
+        description: "Messages API: anthropic/claude-3-5-sonnet-20241022",
+        app: expect.objectContaining({
+          id: "00000000-0000-4000-8000-0000000000dd",
+        }),
+      }),
+    );
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(createCreditReservationSettler).toHaveBeenCalledWith(appReservation);
+    expect(settleAppReservation).toHaveBeenCalledWith(0.002);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -42,6 +42,7 @@ import {
   appAnalytics,
   appDeploymentStatusEnum,
   appRequests,
+  appReviewStatusEnum,
   apps,
   appUsers,
   userDatabaseStatusEnum,
@@ -116,6 +117,7 @@ beforeAll(async () => {
       appDomains,
       appConfig,
       appDeploymentStatusEnum,
+      appReviewStatusEnum,
       userDatabaseStatusEnum,
     };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
@@ -376,7 +378,7 @@ describe("App-auth attribution grants", () => {
     expect(after?.user_agent).toBe("test-agent");
   });
 
-  test("X-App-Id attribution requires same org or an OAuth app-auth grant", async () => {
+  test("monetized X-App-Id inference attribution is public to authenticated callers", async () => {
     if (!pgliteReady) return;
     const appOrg = await seedOrg();
     const callerOrg = await seedOrg();
@@ -389,6 +391,12 @@ describe("App-auth attribution grants", () => {
       created_by_user_id: appOwner,
       monetization_enabled: true,
     });
+    const nonMonetizedApp = await createApp({
+      name: "Internal App",
+      organization_id: appOrg,
+      created_by_user_id: appOwner,
+      monetization_enabled: false,
+    });
 
     const sameOrg = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
       id: sameOrgUser,
@@ -396,11 +404,11 @@ describe("App-auth attribution grants", () => {
     });
     expect(sameOrg?.id).toBe(app.id);
 
-    const crossOrgBefore = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
+    const crossOrg = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
       id: caller,
       organization_id: callerOrg,
     });
-    expect(crossOrgBefore).toBeUndefined();
+    expect(crossOrg?.id).toBe(app.id);
 
     await appsRepository.trackAppUserActivity(app.id, caller, "0.01", {
       route: "messages",
@@ -409,7 +417,7 @@ describe("App-auth attribution grants", () => {
       id: caller,
       organization_id: callerOrg,
     });
-    expect(analyticsOnly).toBeUndefined();
+    expect(analyticsOnly?.id).toBe(app.id);
 
     await appsRepository.connectUser({
       appId: app.id,
@@ -421,6 +429,12 @@ describe("App-auth attribution grants", () => {
       organization_id: callerOrg,
     });
     expect(oauthGranted?.id).toBe(app.id);
+
+    const nonMonetized = await appsService.getAuthorizedMonetizedAppForUser(nonMonetizedApp.id, {
+      id: caller,
+      organization_id: callerOrg,
+    });
+    expect(nonMonetized).toBeUndefined();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -168,41 +168,22 @@ export class AppsService {
   }
 
   /**
-   * Resolve a monetized app id only when the caller may attribute inference to it.
+   * Resolve a monetized app id for paid inference attribution.
    *
-   * Same-org callers are app owners/operators. Cross-org callers must have gone
-   * through the app-auth connect flow, which persists an app_users row with
-   * signup_source="oauth". Plain inference tracking also creates app_users rows,
-   * but without that OAuth source, so first-touch analytics cannot bootstrap its
-   * own authorization.
+   * Monetized apps are public to authenticated callers: the debit lands on the
+   * caller's organization balance and the creator earns only the configured
+   * markup. Non-monetized apps are still excluded from this hot path.
    */
   async getAuthorizedMonetizedAppForUser(
     appId: string,
-    user: { id: string; organization_id: string },
+    _user: { id: string; organization_id: string },
   ): Promise<App | undefined> {
     const app = await this.getById(appId);
     if (!app?.monetization_enabled) {
       return undefined;
     }
 
-    if (app.organization_id === user.organization_id) {
-      return app;
-    }
-
-    const appUser = await appsRepository.findAppUser(app.id, user.id);
-    if (appUser?.signup_source === "oauth") {
-      return app;
-    }
-
-    logger.warn("[Apps] Rejected unauthorized X-App-Id attribution", {
-      appId: app.id,
-      userId: user.id,
-      userOrganizationId: user.organization_id,
-      appOrganizationId: app.organization_id,
-      hasAppUser: Boolean(appUser),
-      appUserSignupSource: appUser?.signup_source ?? null,
-    });
-    return undefined;
+    return app;
   }
 
   /**

--- a/packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts
+++ b/packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts
@@ -13,6 +13,7 @@
  * fully real and runs without any paid key.
  */
 
+import { appsRepository } from "@elizaos/cloud-shared/db/repositories/apps";
 import { seedTestUser } from "../src/fixtures/seed";
 import { authedClient } from "../src/helpers/monetization";
 import { seedModelPricing } from "../src/helpers/seed-pricing";
@@ -70,6 +71,21 @@ test.describe("creator-monetization journey (mock LLM, keyless)", () => {
     const appId = created.json.app?.id;
     expect(appId, "apps.create returns an app id").toBeTruthy();
     if (!appId) throw new Error("apps.create did not return an app id");
+
+    const draftMonetize = await creator(
+      "PUT",
+      `/api/v1/apps/${appId}/monetization`,
+      {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 100,
+        purchaseSharePercentage: 10,
+      },
+    );
+    expect(
+      draftMonetize.status,
+      "draft app cannot enable monetization before compliance approval",
+    ).toBe(403);
+    await approveAppForMockJourney(appId);
 
     const monetize = await creator(
       "PUT",
@@ -184,3 +200,14 @@ test.describe("creator-monetization journey (mock LLM, keyless)", () => {
     expect(redeemBal.status).toBe(200);
   });
 });
+
+async function approveAppForMockJourney(appId: string): Promise<void> {
+  // This spec validates billing + creator earnings, not the live review model.
+  // Use the deterministic grandfathered approval used by the other monetization
+  // e2e suites so the money path can run after proving the draft gate is closed.
+  await appsRepository.update(appId, {
+    review_status: "approved",
+    review_content_hash: null,
+    reviewed_at: new Date(),
+  });
+}


### PR DESCRIPTION
Fixes #11310

## Summary
- Treat monetized apps as public to authenticated callers in `getAuthorizedMonetizedAppForUser`, so `/api/v1/messages` requests with `X-App-Id` use the app-credit reservation path and creator markup.
- Keep non-monetized apps excluded from the billing attribution path.
- Add focused route, service/repository, and cloud-e2e coverage for cross-org monetized inference and creator earnings.

## Evidence
- `.github/issue-evidence/11310-messages-app-markup.md`
- `bun test packages/cloud/api/__tests__/messages-iac-fast-path.test.ts` passed: 3 tests, 22 assertions.
- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts` passed: 21 tests, 89 assertions.
- `bun run --cwd packages/cloud/shared typecheck` passed.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/apps.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts packages/cloud/api/__tests__/messages-iac-fast-path.test.ts packages/test/cloud-e2e/tests/monetized-mock-llm-journey.spec.ts` passed.
- `bun run --cwd packages/test/cloud-e2e test monetized-mock-llm-journey.spec.ts` passed: 1 Playwright test; reviewed logs show draft monetization 403, approved monetization 200, `/api/v1/messages` 200, end-user debit `1000 -> 999.999984`, and app earnings `0 -> 0.000008`.

## Known Unrelated Blockers
- `bun run verify` exits before typecheck/lint at repo-wide type-safety ratchet drift: `as unknown as` 80 > 77 and `?? {}` 379 > 377.
- `bun run --cwd packages/cloud/api typecheck` is blocked by unrelated Stripe API version and Hono type skew errors.
- `bun run --cwd packages/test/cloud-e2e typecheck` is blocked before source checking by TS6 `baseUrl` deprecation in that package config.

## UI / Media Evidence
- N/A: backend billing/API path only; no UI surface changed.
- N/A: no live LLM trajectory; the targeted cloud-e2e path drives real cloud-api, auth, PGlite, credits, markup, and earnings ledgers with only provider bytes mocked.