### PR TITLE
fix(cloud): detach removed org members instead of deleting their account

### DIFF
--- a/packages/cloud/api/__tests__/organizations-remove-member-detach.test.ts
+++ b/packages/cloud/api/__tests__/organizations-remove-member-detach.test.ts
@@ -1,0 +1,415 @@
+/**
+ * DELETE /api/organizations/members/[userId] — detach, don't destroy (#11332).
+ *
+ * The bug: removing an org member called `usersService.delete(userId)` — a hard
+ * `DELETE FROM users` that destroyed the member's entire account (and, via FK
+ * cascade, their API keys). An owner/admin clicking "remove" in members
+ * settings nuked a teammate's identity instead of just taking away org access.
+ *
+ * The fix: the route detaches — the removed user is moved to a fresh personal
+ * organization where they are owner (the same shape signup auto-creates), their
+ * account survives, and their API keys scoped to the old org are deactivated
+ * (org-scoped credentials must not keep spending the old org's credits). The
+ * new org starts at $0 — an invite→remove cycle must not mint welcome credits.
+ *
+ * These tests drive the REAL route handler + REAL usersService/repositories
+ * against in-process PGlite (real SQL). Only auth, rate-limit, and the route
+ * logger are stubbed. RBAC (member can't remove, admin can't remove admin,
+ * owner can't be removed, no self-removal) is asserted to survive the change.
+ * Fails loudly via the `pgliteReady` guard if PGlite ever fails to init.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { Hono } from "hono";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.MOCK_REDIS = "1";
+process.env.NODE_ENV ||= "test";
+
+const ORG_A = "00000000-0000-4000-8000-0000000000a1";
+const OWNER_ID = "00000000-0000-4000-8000-0000000000b1";
+const ADMIN_ID = "00000000-0000-4000-8000-0000000000b2";
+const ADMIN2_ID = "00000000-0000-4000-8000-0000000000b3";
+const MEMBER_ID = "00000000-0000-4000-8000-0000000000c1";
+const WALLET_MEMBER_ID = "00000000-0000-4000-8000-0000000000c2";
+const PGLITE_TIMEOUT = 60000;
+
+// The route reads currentUser from requireUserOrApiKeyWithOrg; make it settable
+// per test. Full (non-spread) module mock is safe here: cloud-api test files run
+// one-per-process (test/run-unit-isolated.mjs) and this file's import graph only
+// uses this one export from the auth module.
+let currentUser: { id: string; role: string; organization_id: string };
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => currentUser,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+let dbWrite: typeof import("../../shared/src/db/client").dbWrite;
+let closeDb:
+  | typeof import("../../shared/src/db/client").closeDatabaseConnectionsForTests
+  | undefined;
+let app: Hono;
+let pgliteReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import(
+      "../../shared/src/db/client"
+    ));
+    const ddl = [
+      // Full column sets — the repositories select * on these tables.
+      `CREATE TABLE IF NOT EXISTS organizations (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        name text NOT NULL,
+        slug text NOT NULL UNIQUE,
+        credit_balance numeric(12,6) NOT NULL DEFAULT '0',
+        settings jsonb DEFAULT '{}',
+        stripe_customer_id text,
+        billing_email text,
+        stripe_payment_method_id text,
+        stripe_default_payment_method text,
+        auto_top_up_enabled boolean DEFAULT false,
+        auto_top_up_threshold numeric(10,2),
+        auto_top_up_amount numeric(10,2),
+        pay_as_you_go_from_earnings boolean NOT NULL DEFAULT true,
+        steward_tenant_id text UNIQUE,
+        steward_tenant_api_key text,
+        is_active boolean NOT NULL DEFAULT true,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS users (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        email text UNIQUE,
+        email_verified boolean DEFAULT false,
+        wallet_address text UNIQUE,
+        wallet_chain_type text,
+        wallet_verified boolean NOT NULL DEFAULT false,
+        name text,
+        avatar text,
+        organization_id uuid REFERENCES organizations(id) ON DELETE CASCADE,
+        role text NOT NULL DEFAULT 'member',
+        steward_user_id text NOT NULL UNIQUE,
+        telegram_id text UNIQUE,
+        telegram_username text,
+        telegram_first_name text,
+        telegram_photo_url text,
+        discord_id text UNIQUE,
+        discord_username text,
+        discord_global_name text,
+        discord_avatar_url text,
+        whatsapp_id text UNIQUE,
+        whatsapp_name text,
+        phone_number text UNIQUE,
+        phone_verified boolean DEFAULT false,
+        is_anonymous boolean NOT NULL DEFAULT false,
+        anonymous_session_id text,
+        expires_at timestamp,
+        nickname text,
+        work_function text,
+        preferences text,
+        email_notifications boolean DEFAULT true,
+        response_notifications boolean DEFAULT true,
+        is_active boolean NOT NULL DEFAULT true,
+        email_ciphertext text, email_nonce text, email_auth_tag text,
+        email_kms_key_id text, email_kms_key_version integer, email_blind_index text,
+        phone_ciphertext text, phone_nonce text, phone_auth_tag text,
+        phone_kms_key_id text, phone_kms_key_version integer, phone_blind_index text,
+        wallet_address_ciphertext text, wallet_address_nonce text, wallet_address_auth_tag text,
+        wallet_address_kms_key_id text, wallet_address_kms_key_version integer,
+        wallet_address_blind_index text,
+        telegram_id_ciphertext text, telegram_id_nonce text, telegram_id_auth_tag text,
+        telegram_id_kms_key_id text, telegram_id_kms_key_version integer,
+        discord_id_ciphertext text, discord_id_nonce text, discord_id_auth_tag text,
+        discord_id_kms_key_id text, discord_id_kms_key_version integer,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        deleted_at timestamp
+      )`,
+      `CREATE TABLE IF NOT EXISTS api_keys (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        name text NOT NULL,
+        description text,
+        key_hash text NOT NULL UNIQUE,
+        key_prefix text NOT NULL,
+        key_ciphertext text, key_nonce text, key_auth_tag text,
+        key_kms_key_id text, key_kms_key_version integer,
+        organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        rate_limit integer NOT NULL DEFAULT 1000,
+        is_active boolean NOT NULL DEFAULT true,
+        usage_count integer NOT NULL DEFAULT 0,
+        expires_at timestamp,
+        last_used_at timestamp,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        deleted_at timestamp
+      )`,
+    ];
+    for (const stmt of ddl) await dbWrite.execute(stmt);
+
+    // Mount the real route app exactly as src/_router.generated.ts does.
+    const route = await import("../organizations/members/[userId]/route");
+    app = new Hono();
+    app.route(
+      "/api/organizations/members/:userId",
+      route.default as unknown as Hono,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.warn(
+      "[organizations-remove-member-detach] PGlite unavailable, skipping:",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  await dbWrite.execute(`DELETE FROM api_keys;`);
+  await dbWrite.execute(`DELETE FROM users;`);
+  await dbWrite.execute(`DELETE FROM organizations;`);
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, name, slug) VALUES ('${ORG_A}', 'Team Org', 'team-org');`,
+  );
+  await dbWrite.execute(
+    `INSERT INTO users (id, email, name, organization_id, role, steward_user_id) VALUES
+       ('${OWNER_ID}', 'owner@example.com', 'owner', '${ORG_A}', 'owner', 'steward-owner'),
+       ('${ADMIN_ID}', 'admin@example.com', 'admin', '${ORG_A}', 'admin', 'steward-admin'),
+       ('${ADMIN2_ID}', 'admin2@example.com', 'admin2', '${ORG_A}', 'admin', 'steward-admin2'),
+       ('${MEMBER_ID}', 'member1@example.com', 'member one', '${ORG_A}', 'member', 'steward-member');`,
+  );
+  await dbWrite.execute(
+    `INSERT INTO users (id, wallet_address, organization_id, role, steward_user_id) VALUES
+       ('${WALLET_MEMBER_ID}', '0xAbCdEf1234567890', '${ORG_A}', 'member', 'steward-wallet');`,
+  );
+  await dbWrite.execute(
+    `INSERT INTO api_keys (name, key_hash, key_prefix, organization_id, user_id) VALUES
+       ('member key', 'hash-member-a', 'eliza_m1', '${ORG_A}', '${MEMBER_ID}'),
+       ('owner key', 'hash-owner-a', 'eliza_o1', '${ORG_A}', '${OWNER_ID}');`,
+  );
+  currentUser = { id: OWNER_ID, role: "owner", organization_id: ORG_A };
+});
+
+async function removeMember(userId: string): Promise<Response> {
+  return await app.fetch(
+    new Request(`http://test.local/api/organizations/members/${userId}`, {
+      method: "DELETE",
+    }),
+  );
+}
+
+async function userRow(
+  id: string,
+): Promise<Record<string, unknown> | undefined> {
+  const r = await dbWrite.execute(`SELECT * FROM users WHERE id='${id}';`);
+  return r.rows[0] as Record<string, unknown> | undefined;
+}
+
+async function orgMemberIds(orgId: string): Promise<string[]> {
+  const r = await dbWrite.execute(
+    `SELECT id FROM users WHERE organization_id='${orgId}' ORDER BY id;`,
+  );
+  return (r.rows as Array<{ id: string }>).map((row) => row.id);
+}
+
+describe("remove member — detaches instead of deleting the account", () => {
+  test(
+    "removed member's account SURVIVES as owner of a fresh $0 personal org; old-org keys revoked",
+    async () => {
+      if (!pgliteReady) return;
+
+      const res = await removeMember(MEMBER_ID);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+
+      // The account still exists (pre-fix: hard-deleted → this is the bug).
+      const member = await userRow(MEMBER_ID);
+      expect(member).toBeDefined();
+      if (!member) throw new Error("unreachable");
+
+      // Detached into a fresh personal org, as owner.
+      expect(member.organization_id).not.toBeNull();
+      expect(member.organization_id).not.toBe(ORG_A);
+      expect(member.role).toBe("owner");
+
+      // The personal org exists, is slugged from the member's email local-part
+      // (mirroring signup), holds exactly this user, and starts at $0.
+      const orgRes = await dbWrite.execute(
+        `SELECT * FROM organizations WHERE id='${member.organization_id}';`,
+      );
+      const personalOrg = orgRes.rows[0] as
+        | { slug: string; credit_balance: string; name: string }
+        | undefined;
+      expect(personalOrg).toBeDefined();
+      if (!personalOrg) throw new Error("unreachable");
+      expect(personalOrg.slug.startsWith("member1-")).toBe(true);
+      expect(Number(personalOrg.credit_balance)).toBeCloseTo(0, 6);
+      expect(await orgMemberIds(member.organization_id as string)).toEqual([
+        MEMBER_ID,
+      ]);
+
+      // The original org is intact and no longer lists the removed member.
+      expect(await orgMemberIds(ORG_A)).toEqual(
+        [OWNER_ID, ADMIN_ID, ADMIN2_ID, WALLET_MEMBER_ID].sort(),
+      );
+
+      // The member's key in the old org is revoked (it authenticates AS the old
+      // org); the owner's key is untouched.
+      const keys = await dbWrite.execute(
+        `SELECT key_hash, is_active FROM api_keys ORDER BY key_hash;`,
+      );
+      expect(keys.rows).toEqual([
+        { key_hash: "hash-member-a", is_active: false },
+        { key_hash: "hash-owner-a", is_active: true },
+      ]);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "wallet-only member (no email) detaches with a wallet-derived personal-org slug",
+    async () => {
+      if (!pgliteReady) return;
+
+      const res = await removeMember(WALLET_MEMBER_ID);
+      expect(res.status).toBe(200);
+
+      const member = await userRow(WALLET_MEMBER_ID);
+      expect(member).toBeDefined();
+      if (!member) throw new Error("unreachable");
+      expect(member.role).toBe("owner");
+      expect(member.organization_id).not.toBe(ORG_A);
+
+      const orgRes = await dbWrite.execute(
+        `SELECT slug FROM organizations WHERE id='${member.organization_id}';`,
+      );
+      const slug = (orgRes.rows[0] as { slug: string } | undefined)?.slug ?? "";
+      expect(slug.startsWith("wallet-0xabcdef")).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "admin can also remove a member — same detach semantics",
+    async () => {
+      if (!pgliteReady) return;
+      currentUser = { id: ADMIN_ID, role: "admin", organization_id: ORG_A };
+
+      const res = await removeMember(MEMBER_ID);
+      expect(res.status).toBe(200);
+      const member = await userRow(MEMBER_ID);
+      expect(member).toBeDefined();
+      expect(member?.organization_id).not.toBe(ORG_A);
+      expect(member?.role).toBe("owner");
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("remove member — RBAC survives the detach change", () => {
+  test(
+    "a plain member cannot remove anyone (403, target untouched)",
+    async () => {
+      if (!pgliteReady) return;
+      currentUser = { id: MEMBER_ID, role: "member", organization_id: ORG_A };
+
+      const res = await removeMember(WALLET_MEMBER_ID);
+      expect(res.status).toBe(403);
+      const target = await userRow(WALLET_MEMBER_ID);
+      expect(target?.organization_id).toBe(ORG_A);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "an admin cannot remove another admin (403)",
+    async () => {
+      if (!pgliteReady) return;
+      currentUser = { id: ADMIN_ID, role: "admin", organization_id: ORG_A };
+
+      const res = await removeMember(ADMIN2_ID);
+      expect(res.status).toBe(403);
+      expect((await userRow(ADMIN2_ID))?.organization_id).toBe(ORG_A);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "the organization owner cannot be removed (400)",
+    async () => {
+      if (!pgliteReady) return;
+      currentUser = { id: ADMIN_ID, role: "admin", organization_id: ORG_A };
+
+      const res = await removeMember(OWNER_ID);
+      expect(res.status).toBe(400);
+      expect((await userRow(OWNER_ID))?.organization_id).toBe(ORG_A);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "self-removal is rejected (400)",
+    async () => {
+      if (!pgliteReady) return;
+
+      const res = await removeMember(OWNER_ID);
+      expect(res.status).toBe(400);
+      expect((await userRow(OWNER_ID))?.organization_id).toBe(ORG_A);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "cross-org removal is rejected (403)",
+    async () => {
+      if (!pgliteReady) return;
+      currentUser = {
+        id: OWNER_ID,
+        role: "owner",
+        organization_id: "00000000-0000-4000-8000-0000000000ff",
+      };
+
+      const res = await removeMember(MEMBER_ID);
+      expect(res.status).toBe(403);
+      expect((await userRow(MEMBER_ID))?.organization_id).toBe(ORG_A);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If it ever fails to init, the tests above early-return; this turns that
+// silent no-op into a hard failure so the detach proof can't go vacuous-green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
+});

--- a/packages/cloud/api/organizations/members/[userId]/route.ts
+++ b/packages/cloud/api/organizations/members/[userId]/route.ts
@@ -135,7 +135,9 @@ app.delete("/", async (c) => {
       );
     }
 
-    await usersService.delete(userId);
+    // Detach, don't delete (#11332): removing a member must not destroy their
+    // account. They are moved to a fresh personal org where they are owner.
+    await usersService.detachFromOrganization(userId);
     return c.json({ success: true, message: "Member removed successfully" });
   } catch (error) {
     logger.error("Error removing member:", error);

--- a/packages/cloud/shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud/shared/src/db/repositories/api-keys.ts
@@ -171,6 +171,28 @@ export class ApiKeysRepository {
   async deleteByName(name: string): Promise<ApiKey[]> {
     return await dbWrite.delete(apiKeys).where(eq(apiKeys.name, name)).returning();
   }
+
+  /**
+   * Deactivates every active key a user holds in one organization. Used when a
+   * member is detached from an org (#11332): their keys authenticate AS that
+   * org (billing + access), and the plaintext is encrypted under the org's
+   * DEK, so the keys can be neither kept nor re-scoped — they are revoked.
+   */
+  async deactivateByUserAndOrganization(userId: string, organizationId: string): Promise<void> {
+    await dbWrite
+      .update(apiKeys)
+      .set({
+        is_active: false,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(apiKeys.user_id, userId),
+          eq(apiKeys.organization_id, organizationId),
+          eq(apiKeys.is_active, true),
+        ),
+      );
+  }
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -31,6 +31,22 @@ function getErrorDetails(error: unknown): Record<string, unknown> {
 }
 
 /**
+ * Personal-org slug for a detached member — mirrors the signup generators in
+ * steward-sync.ts (email local-part / wallet prefix / name + entropy suffix).
+ */
+function generatePersonalOrgSlug(user: User): string {
+  const base = user.email
+    ? user.email.split("@")[0]
+    : user.wallet_address
+      ? `wallet-${user.wallet_address.substring(0, 8)}`
+      : user.name || "user";
+  const sanitized = base.toLowerCase().replace(/[^a-z0-9]/g, "-");
+  const random = Math.random().toString(36).substring(2, 8);
+  const timestamp = Date.now().toString(36).slice(-4);
+  return `${sanitized}-${timestamp}${random}`;
+}
+
+/**
  * Service for user operations including organization lookups.
  */
 export class UsersService {
@@ -305,6 +321,74 @@ export class UsersService {
       cache.del(CacheKeys.user.byStewardId(stewardUserId)),
       cache.del(CacheKeys.user.byStewardIdWithOrg(stewardUserId)),
     ]);
+  }
+
+  /**
+   * Detach a user from their current organization WITHOUT deleting the account
+   * (#11332): removing an org member must not destroy their identity. The
+   * removed user is moved to a fresh personal organization where they are
+   * owner — the same shape signup auto-creates — and their API keys scoped to
+   * the old organization are deactivated (those keys authenticate AS the old
+   * org; a removed member must not keep spending its credits). The new org
+   * starts at $0: detach is not signup, so no welcome credits — an
+   * invite→remove cycle must not mint free credit.
+   */
+  async detachFromOrganization(id: string): Promise<User> {
+    const user = await usersRepository.findById(id);
+    if (!user) {
+      throw new Error(`User ${id} not found`);
+    }
+
+    let slug = generatePersonalOrgSlug(user);
+    let attempts = 0;
+    while (await organizationsRepository.findBySlug(slug)) {
+      attempts++;
+      if (attempts > 10) {
+        throw new Error(`Failed to generate unique organization slug for user ${id}`);
+      }
+      slug = generatePersonalOrgSlug(user);
+    }
+
+    const organization = await organizationsRepository.create({
+      name: `${user.name || user.email || "User"}'s Organization`,
+      slug,
+      credit_balance: "0.00",
+    });
+
+    let updated: User | undefined;
+    try {
+      updated = await usersRepository.update(id, {
+        organization_id: organization.id,
+        role: "owner",
+      });
+      if (!updated) {
+        throw new Error(`Failed to move user ${id} to personal organization ${organization.id}`);
+      }
+    } catch (error) {
+      // Don't strand an empty org when the move fails.
+      try {
+        await organizationsRepository.delete(organization.id);
+      } catch (rollbackError) {
+        logger.error("[UsersService] Failed to roll back personal org after detach failure", {
+          userId: id,
+          organizationId: organization.id,
+          ...getErrorDetails(rollbackError),
+        });
+      }
+      throw error;
+    }
+
+    if (user.organization_id) {
+      await apiKeysRepository.deactivateByUserAndOrganization(id, user.organization_id);
+    }
+
+    await this.invalidateCache(user);
+    await this.invalidateCache(updated);
+    // The revoked keys may still be warm in the inference-auth cache under the
+    // old org's identity — evict them so they stop fast-pathing immediately.
+    await this.invalidateInferenceAuthForUser(id);
+
+    return updated;
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

Removing an organization member destroyed their entire user account: `DELETE /api/organizations/members/[userId]` called `usersService.delete(userId)` — a hard `DELETE FROM users` that wiped the member's identity and (via FK cascade) their API keys. An owner/admin clicking "remove" in members settings nuked a teammate's account instead of just taking away org access.

This is bug 1 of 3 from the membership-hardening prereq in #11332 (Phase 0).

## Fix — detach, don't delete

`usersService.detachFromOrganization(userId)` (new, cloud-shared):

- moves the removed user to a **fresh personal organization where they are owner** — the same shape the signup path auto-creates (slug mirrors the steward-sync generators: email local-part / wallet prefix / name + entropy, uniqueness-checked)
- the new org starts at **$0** — detach is not signup, so no welcome credits; an invite→remove cycle must not mint free credit
- **revokes the member's API keys scoped to the old org** (new `apiKeysRepository.deactivateByUserAndOrganization`): those keys authenticate AS the old org and are encrypted under the old org's DEK, so they can be neither kept nor re-scoped — without this a "removed" member keeps spending the old org's credits
- evicts the user's cache entries + warm inference-auth contexts so the revoked keys stop fast-pathing immediately
- rolls back the personal org if the user move fails (no stranded empty orgs)

RBAC is unchanged and covered by test: only owner/admin can remove, admins can't remove admins, the owner can't be removed, no self-removal, no cross-org removal.

## Evidence

Real route handler + real `usersService`/repositories against in-process PGlite (real SQL); only auth, rate-limit, and the route logger stubbed (`packages/cloud/api/__tests__/organizations-remove-member-detach.test.ts`).

**Negative control — the test reproduces the bug on unmodified develop (`f6001e6913`):**

```
(fail) removed member's account SURVIVES as owner of a fresh $0 personal org; old-org keys revoked
       expect(member).toBeDefined()   Received: undefined   ← user row hard-deleted
(fail) wallet-only member (no email) detaches with a wallet-derived personal-org slug
(fail) admin can also remove a member — same detach semantics
 6 pass  3 fail
```

**After the fix (this branch):**

```
bun test __tests__/organizations-remove-member-detach.test.ts
 9 pass  0 fail  32 expect() calls
```

Assertions include: removed member's user row still exists; they are `owner` of a new org containing exactly them; new org `credit_balance ≈ 0`; original org intact with all other members; removed member's old-org key `is_active=false` while the owner's key stays active.

- `bun run --cwd packages/cloud/shared typecheck` — no errors in touched files
- `bun run --cwd packages/cloud/api typecheck` — no errors in touched files
- biome: touched files match the committed style of their packages (`packages/cloud/shared` pre-existing format noise on develop HEAD is untouched)
- `src/lib/services/inference-auth-lifecycle.test.ts` (users-service lifecycle) — 7 pass

N/A — screenshots/video: backend Worker route, no UI surface. N/A — LLM trajectories: no model-backed path touched.

Refs #11332
