### PR TITLE
fix(orchestrator): bound slow-path insight extraction per trajectory (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trajectory-feedback-insight-cap.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { queryPastExperience } from "../../src/services/trajectory-feedback";
+
+/**
+ * Per-trajectory insight budget regression (audit-2 #7).
+ *
+ * The fast path (pre-extracted metadata insights) has always capped at 50
+ * insights per trajectory via `.slice(0, 50)`. The slow-path detail scan
+ * (legacy trajectories with no metadata insights) previously had NO such cap,
+ * so a single trajectory with many steps/LLM calls could balloon the
+ * intermediate `experiences` array before the final dedup + `maxEntries` cap.
+ * These tests pin BOTH paths to the same 50/trajectory budget.
+ */
+
+const MAX = 50;
+
+type Summary = {
+  id: string;
+  source: string;
+  startTime: number;
+  llmCallCount: number;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+function makeRuntime(logger: unknown) {
+  return {
+    getService: (type: string) => (type === "trajectories" ? logger : null),
+  } as unknown as Parameters<typeof queryPastExperience>[0];
+}
+
+/** A trajectory logger whose single trajectory drives the SLOW path (no
+ * metadata insights), returning a detail with `decisionCount` unique
+ * `DECISION:` lines in one LLM response. */
+function slowPathLogger(decisionCount: number) {
+  const summary: Summary = {
+    id: "traj-slow",
+    source: "orchestrator",
+    startTime: 1_000,
+    llmCallCount: 1,
+    createdAt: new Date(1_000).toISOString(),
+    // No metadata.insights → forces the slow path.
+    metadata: { orchestrator: { decisionType: "coordination" } },
+  };
+  const response = Array.from(
+    { length: decisionCount },
+    (_, i) => `DECISION: unique slow-path insight number ${i}`,
+  ).join("\n");
+  return {
+    listTrajectories: async () => ({ trajectories: [summary], total: 1 }),
+    getTrajectoryDetail: async () => ({
+      trajectoryId: "traj-slow",
+      steps: [{ llmCalls: [{ purpose: "coordination", response }] }],
+    }),
+  };
+}
+
+/** A trajectory logger whose single trajectory drives the FAST path
+ * (pre-extracted metadata insights). */
+function fastPathLogger(insightCount: number) {
+  const summary: Summary = {
+    id: "traj-fast",
+    source: "orchestrator",
+    startTime: 2_000,
+    llmCallCount: 0,
+    createdAt: new Date(2_000).toISOString(),
+    metadata: {
+      orchestrator: { decisionType: "coordination" },
+      insights: Array.from(
+        { length: insightCount },
+        (_, i) => `unique fast-path insight number ${i}`,
+      ),
+    },
+  };
+  return {
+    listTrajectories: async () => ({ trajectories: [summary], total: 1 }),
+    getTrajectoryDetail: async () => null,
+  };
+}
+
+describe("queryPastExperience per-trajectory insight cap (audit-2 #7)", () => {
+  it("caps the SLOW path at 50 insights from a single trajectory", async () => {
+    // 120 unique decisions in one trajectory; maxEntries is set high so the
+    // per-trajectory cap — not the final cap — is what limits the result.
+    const runtime = makeRuntime(slowPathLogger(120));
+    const result = await queryPastExperience(runtime, { maxEntries: 1_000 });
+    expect(result.length).toBe(MAX);
+  });
+
+  it("caps the FAST path at 50 insights from a single trajectory", async () => {
+    const runtime = makeRuntime(fastPathLogger(120));
+    const result = await queryPastExperience(runtime, { maxEntries: 1_000 });
+    expect(result.length).toBe(MAX);
+  });
+
+  it("returns all insights when a trajectory is under the cap", async () => {
+    const runtime = makeRuntime(slowPathLogger(10));
+    const result = await queryPastExperience(runtime, { maxEntries: 1_000 });
+    expect(result.length).toBe(10);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/trajectory-feedback.ts
@@ -18,6 +18,13 @@ import { logger as elizaLogger, type IAgentRuntime } from "@elizaos/core";
 /** Timeout for trajectory DB calls to prevent blocking agent spawn. */
 const QUERY_TIMEOUT_MS = 5000;
 const SLOW_PATH_BUDGET_MS = 15_000;
+/**
+ * Per-trajectory insight budget. The fast path already caps metadata insights
+ * at this many per trajectory; the slow-path detail scan mirrors it so a single
+ * legacy trajectory with many steps/LLM calls can't balloon the intermediate
+ * `experiences` array before the final dedup + `maxEntries` cap.
+ */
+const MAX_INSIGHTS_PER_TRAJECTORY = 50;
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
@@ -275,7 +282,7 @@ export async function queryPastExperience(
               (value): value is string =>
                 typeof value === "string" && value.trim().length > 0,
             )
-            .slice(0, 50)
+            .slice(0, MAX_INSIGHTS_PER_TRAJECTORY)
         : [];
       const decisionType = metadata?.orchestrator?.decisionType ?? "unknown";
       const taskLabel = metadata?.orchestrator?.taskLabel ?? "";
@@ -318,7 +325,11 @@ export async function queryPastExperience(
       ).catch(() => null);
       if (!detail?.steps) continue;
 
-      for (const step of detail.steps) {
+      // Mirror the fast path's per-trajectory insight budget so a single
+      // legacy trajectory with many steps/LLM calls can't balloon the
+      // intermediate array before the final dedup + maxEntries cap.
+      let insightsForThisTrajectory = 0;
+      stepsLoop: for (const step of detail.steps) {
         if (!step.llmCalls) continue;
 
         for (const call of step.llmCalls) {
@@ -330,12 +341,16 @@ export async function queryPastExperience(
           );
 
           for (const insight of insights) {
+            if (insightsForThisTrajectory >= MAX_INSIGHTS_PER_TRAJECTORY) {
+              break stepsLoop;
+            }
             experiences.push({
               timestamp: call.timestamp ?? summary.startTime,
               decisionType: call.purpose ?? decisionType,
               taskLabel,
               insight,
             });
+            insightsForThisTrajectory += 1;
           }
         }
       }


### PR DESCRIPTION
## What

`queryPastExperience` (trajectory-feedback) has two extraction paths:

- **Fast path** — pre-extracted metadata insights, already capped at **50/trajectory** via `.slice(0, 50)`.
- **Slow path** — legacy trajectories with no metadata insights; loads full detail and iterates `steps → llmCalls → extractInsights`. This path had **no per-trajectory cap**, so one trajectory with many steps/LLM calls could balloon the intermediate `experiences` array before the final dedup + `maxEntries` cap.

This mirrors the fast path's budget onto the slow path via a single shared constant `MAX_INSIGHTS_PER_TRAJECTORY = 50`, so both paths bound per-trajectory growth identically.

## Honest scope

This is **consistency + defense-in-depth**, not a reachable OOM fix. The slow-path loop was already bounded by:
- `maxTrajectories` (default 30) on the outer scan,
- a 15s slow-path budget (`SLOW_PATH_BUDGET_MS`) gating further detail loads,
- upstream 64 KB per-string truncation in `TrajectoriesService`.

The real defect was the **fast/slow asymmetry** — the fast path caps, the slow path didn't. Now they share one constant.

## Context

Surfaced during the plugin-agent-orchestrator audit tracked in #11028. Six sibling audit findings in the same sweep were verified against the current code and dispositioned as intentional/already-fixed (documented in #11028); this is the one with a genuine code inconsistency worth correcting.

## Testing

New `__tests__/unit/trajectory-feedback-insight-cap.test.ts`:
- **caps the SLOW path at 50** — a trajectory yielding 120 unique `DECISION:` insights returns exactly 50 (returns 120 without this change).
- **caps the FAST path at 50** — guards the shared constant on the metadata path.
- **returns all when under the cap** — 10 insights → 10 returned (no over-clamping).

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

`bun run typecheck` (tsgo) exits 0; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)