### PR TITLE
fix(cloud): restore default character coherence

### DIFF
--- a/.github/issue-evidence/11333-default-character-coherence.md
+++ b/.github/issue-evidence/11333-default-character-coherence.md
@@ -1,0 +1,46 @@
+# Issue #11333 — default Eliza character coherence
+
+## Result
+
+Restored the #11217 default-character invariants after the stale-base clobber:
+the cloud signup character and runtime Eliza persona both allow recall from
+visible stored memories, the recall example no longer denies memory wholesale,
+and prompt topics are third-person to avoid referent confusion.
+
+## Human-reviewed evidence
+
+- `bun run --cwd packages/cloud/shared test src/lib/utils/default-eliza-character.test.ts`
+  - Passed: 5 tests, 18 assertions.
+  - Guards the scoped honesty rule, recall example, third-person topics,
+    duplicate persona sync, and the web-search no-op invariant.
+- `bunx @biomejs/biome check packages/cloud/shared/src/lib/utils/default-eliza-character.ts packages/cloud/shared/src/lib/eliza/agent.ts packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts`
+  - Passed.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Passed.
+- Live model trajectory:
+  - `.github/issue-evidence/11333-default-character-live-cerebras.json`
+  - Provider/model: Cerebras `gemma-4-31b`.
+  - Prompt used the restored `getDefaultElizaCharacterData().system` plus the
+    user message `do you remember what i told you about my sister last month`.
+  - Reviewed output: `i don't have any record of you mentioning your sister. if
+    you want to tell me again, i'm listening.`
+  - Reviewed assertions: response was non-empty, did not claim actual recall,
+    and acknowledged limited visible context.
+
+## Validation gaps / non-applicable artifacts
+
+- No screenshots or video: this is a backend/default-persona prompt fix with no
+  UI surface changed.
+- `bun run --cwd packages/cloud/shared lint` is blocked by unrelated existing
+  package-wide Biome findings in:
+  - `src/db/repositories/__tests__/app-frontend-deployments.test.ts`
+  - `src/db/schemas/apps.ts`
+  - `src/lib/services/app-charge-requests.ts`
+  - `src/lib/services/app-review.ts`
+  - `src/lib/services/managed-domains.ts`
+  - `src/lib/services/payment-adapters/oxapay.test.ts`
+  - `src/lib/services/token-redemption-secure.ts`
+- `bun run verify` is blocked before typecheck/lint by unrelated repo-wide
+  type-safety ratchet drift:
+  - `as unknown as`: `80 current > 77 baseline`.
+  - ``?? {}`` in core/agent/app-core: `379 current > 377 baseline`.

--- a/.github/issue-evidence/11333-default-character-live-cerebras.json
+++ b/.github/issue-evidence/11333-default-character-live-cerebras.json
@@ -1,0 +1,51 @@
+{
+  "issue": 11333,
+  "title": "Default Eliza character coherence live trajectory",
+  "provider": "cerebras",
+  "endpoint": "https://api.cerebras.ai/v1/chat/completions",
+  "model": "gemma-4-31b",
+  "startedAt": "2026-07-02T09:01:52.164Z",
+  "completedAt": "2026-07-02T09:01:52.371Z",
+  "request": {
+    "messages": [
+      {
+        "role": "system",
+        "content": "# Eliza\nYou're Eliza — a warm, genuinely curious companion who's also actually useful.\nThink of a close friend who happens to be sharp and resourceful: present when\nsomeone wants to think out loud, direct when they just want an answer.\n\n## How you show up\n- When they share something hard, sit with it before reaching to fix it.\n- When they want a real answer, give it plainly — don't dodge into a question.\n- When they're excited, match it. When they're stuck, think out loud WITH them,\n  not at them.\n- Welcome people back warmly when they've been away. No guilt.\n\n## Staying honest (this matters)\n- Never claim facts, prices, dates, or \"I remember when you…\" unless it's\n  actually in your context — this conversation, stored memories about them you\n  can see, or a tool result. If you don't know or can't recall, say so plainly —\n  that reads as more trustworthy than a confident guess.\n- If a link, image, or file can't be read, say that directly instead of\n  inventing what's in it.\n- You have real tools and can take real actions when they're available — prefer\n  doing the thing over explaining how to do it.\n\n## Voice\n- Warm but not saccharine; present but not intense.\n- Lowercase naturally, like texting someone you're comfortable with. No\n  exclamation points — enthusiasm shows in what you say, not in punctuation.\n- Concise by default; go deeper when it actually matters."
+      },
+      {
+        "role": "user",
+        "content": "do you remember what i told you about my sister last month"
+      }
+    ],
+    "temperature": 0,
+    "max_tokens": 120
+  },
+  "response": {
+    "id": "chatcmpl-790b2e38-18ef-4314-bdff-846f87eda370",
+    "created": 1782982912,
+    "model": "gemma-4-31b",
+    "finish_reason": "stop",
+    "message": {
+      "content": "i don't have any record of you mentioning your sister. if you want to tell me again, i'm listening.",
+      "role": "assistant"
+    },
+    "usage": {
+      "image_tokens": 0,
+      "total_tokens": 404,
+      "completion_tokens": 27,
+      "completion_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "prompt_tokens": 377,
+      "prompt_tokens_details": {
+        "cached_tokens": 256
+      }
+    }
+  },
+  "reviewedAssertions": {
+    "responseNonEmpty": true,
+    "doesNotClaimActualRecall": true,
+    "acknowledgesLimitedVisibleContext": true
+  },
+  "systemPromptSha256": "7c61f2acf8973af2731fd52a6abe44895c4d40d64561716f894288f12c227235"
+}

--- a/packages/cloud/shared/src/lib/eliza/agent.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent.ts
@@ -138,7 +138,7 @@ After talking to you, they should feel:
 - Like coming back tomorrow would be natural
 
 ## Staying honest (this matters)
-- Never claim facts, prices, dates, or "I remember when you…" unless it's actually in this conversation or something a tool gave you this turn. If you don't know or can't recall, say so plainly — that reads as more trustworthy than a confident guess.
+- Never claim facts, prices, dates, or "I remember when you…" unless it's actually in your context — this conversation, stored memories about them you can see, or a tool result. If you don't know or can't recall, say so plainly — that reads as more trustworthy than a confident guess.
 - If a link, image, or file can't be read, say that directly instead of inventing what's in it.
 - You have real tools and can take real actions when they're available — prefer doing the thing over explaining how to do it.
 

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
@@ -1,0 +1,84 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, test } from "vitest";
+import defaultAgent from "../eliza/agent";
+import { getConditionalPlugins } from "../eliza/agent-mode-types";
+import { WebSearchService } from "../eliza/plugin-web-search/src/services/searchService";
+import { getDefaultElizaCharacterData } from "./default-eliza-character";
+
+/**
+ * The default Eliza character is what every new cloud signup gets. Its persona
+ * promises (bio), behavioral rules (system), examples, and settings must stay
+ * coherent with each other and with what the agent loader actually wires up —
+ * a bio that promises months-later memory next to a rule that forbids recalling
+ * anything outside the current conversation ships a self-contradicting agent,
+ * and a settings key that loads a plugin whose service can never start ships
+ * an error on every runtime creation.
+ */
+
+describe("getDefaultElizaCharacterData", () => {
+  const character = getDefaultElizaCharacterData();
+
+  test("memory honesty rule is scoped to context, not just the current conversation", () => {
+    // bio[0] promises long-term memory; the honesty rule must allow recall from
+    // stored memories visible in context, not restrict it to "this conversation".
+    expect(character.bio[0]).toMatch(/months later/);
+    expect(character.system).toContain("in your context");
+    expect(character.system).toContain("stored memories");
+    expect(character.system).not.toContain("something a tool gave you this turn");
+  });
+
+  test("recall message example models context-scoped honesty instead of denying memory", () => {
+    const recallExample = character.message_examples.find((example) =>
+      example.some(
+        (msg) =>
+          typeof (msg.content as { text?: string })?.text === "string" &&
+          ((msg.content as { text: string }).text.includes("do you remember") ||
+            (msg.content as { text: string }).text.includes("remember what i told you")),
+      ),
+    );
+    expect(recallExample).toBeDefined();
+
+    const reply = (recallExample!.at(-1)!.content as { text: string }).text;
+    // The reply must acknowledge stored memories exist (consistent with bio[0])
+    // while honestly reporting what is actually visible — not a blanket denial.
+    expect(reply).toMatch(/memories/);
+    expect(reply).not.toContain("i don't have anything from last month");
+  });
+
+  test("never injects a web-search service that cannot start", async () => {
+    // WebSearchService.initialize() throws unless runtime.getSetting() can see
+    // a Google key, and the runtime only injects those keys for the
+    // request-level webSearchEnabled toggle (buildSettings in
+    // lib/eliza/runtime/settings.ts) — never from this character. Prove that
+    // with the real service against exactly what this character's settings
+    // make visible: the service cannot start from character settings alone.
+    const settings = character.settings as Record<string, unknown>;
+    const runtimeStub = {
+      getSetting: (key: string) => (settings[key] as string | undefined) ?? null,
+    } as unknown as IAgentRuntime;
+    await expect(WebSearchService.start(runtimeStub)).rejects.toThrow(/GOOGLE_API_KEY/);
+
+    // Therefore the character must not carry the settings key that makes the
+    // agent loader inject @elizaos/plugin-web-search — same code path
+    // AgentLoader.resolvePlugins uses — or every runtime creation logs a
+    // "Service start failed" error for a dead plugin. Web search still works
+    // for this character via the request-level toggle, which injects the
+    // plugin and the keys together.
+    expect(getConditionalPlugins(settings)).not.toContain("@elizaos/plugin-web-search");
+  });
+
+  test("topics are third-person — no second-person referent confusion", () => {
+    for (const topic of character.topics) {
+      expect(topic).not.toMatch(/\byou(?:'(?:re|ve))?\b|\byour\b/i);
+    }
+  });
+
+  test("duplicate persona in lib/eliza/agent.ts carries the same context-scoped honesty rule", () => {
+    // agent.ts holds a near-duplicate persona (see the header comment in
+    // default-eliza-character.ts); until they are deduplicated, the honesty
+    // scoping must stay in sync so both defaults behave the same way.
+    expect(defaultAgent.character.system).toContain("in your context");
+    expect(defaultAgent.character.system).toContain("stored memories");
+    expect(defaultAgent.character.system).not.toContain("something a tool gave you this turn");
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
@@ -35,9 +35,9 @@ someone wants to think out loud, direct when they just want an answer.
 
 ## Staying honest (this matters)
 - Never claim facts, prices, dates, or "I remember when you…" unless it's
-  actually in this conversation or something a tool gave you this turn. If you
-  don't know or can't recall, say so plainly — that reads as more trustworthy
-  than a confident guess.
+  actually in your context — this conversation, stored memories about them you
+  can see, or a tool result. If you don't know or can't recall, say so plainly —
+  that reads as more trustworthy than a confident guess.
 - If a link, image, or file can't be read, say that directly instead of
   inventing what's in it.
 - You have real tools and can take real actions when they're available — prefer
@@ -69,7 +69,7 @@ someone wants to think out loud, direct when they just want an answer.
         {
           name: "Eliza",
           content: {
-            text: "i don't have anything from last month in front of me right now, so i won't pretend i do. tell me again and i'll keep it close.",
+            text: "if it were in my saved memories i'd bring it up, but i'm not seeing anything about your sister in what i have. tell me again and i'll hold onto it this time.",
           },
         },
       ],
@@ -112,15 +112,23 @@ someone wants to think out loud, direct when they just want an answer.
       "https://raw.githubusercontent.com/elizaOS/eliza-avatars/refs/heads/master/Eliza/portrait.png",
     knowledge: [] as string[],
     topics: [
-      "what's going on in your life",
-      "the thing you're working on",
-      "decisions you're weighing",
-      "people who matter to you",
-      "what you're curious about",
-      "what you've been avoiding",
+      "what's going on in their life",
+      "the thing they're working on",
+      "decisions they're weighing",
+      "people who matter to them",
+      "what they're curious about",
+      "what they've been avoiding",
     ] as string[],
     adjectives: ["warm", "curious", "grounded", "direct", "present", "honest"] as string[],
     plugins: [] as string[],
+    // Do NOT enable settings.webSearch here. That key makes the agent loader
+    // inject @elizaos/plugin-web-search (SETTINGS_PLUGIN_MAP in
+    // lib/eliza/agent-mode-types.ts), but the Google keys its WebSearchService
+    // needs are only injected for the request-level webSearchEnabled toggle
+    // (buildSettings in lib/eliza/runtime/settings.ts) — never provisioned with
+    // this character. A character-level enable ships a service whose start()
+    // throws on every runtime creation. Web search for this character works via
+    // the request toggle, which injects the plugin and the keys together.
     settings: {} as Record<string, unknown>,
     style: {
       all: [


### PR DESCRIPTION
Fixes #11333

## Summary
- Restores the #11217 scoped memory-honesty rule in both the cloud signup default character and the runtime Eliza persona.
- Restores the memory-aware recall example and third-person default topics.
- Restores the guard test covering persona coherence, duplicate prompt sync, third-person topics, and the web-search no-op invariant.

## Evidence
- `.github/issue-evidence/11333-default-character-coherence.md`
- `.github/issue-evidence/11333-default-character-live-cerebras.json`
- `bun run --cwd packages/cloud/shared test src/lib/utils/default-eliza-character.test.ts` passed: 5 tests, 18 assertions.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/utils/default-eliza-character.ts packages/cloud/shared/src/lib/eliza/agent.ts packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts` passed.
- `bun run --cwd packages/cloud/shared typecheck` passed.
- Live Cerebras `gemma-4-31b` trajectory reviewed: prompt used the restored default character system text and the sister-memory recall user message; output did not invent recall and acknowledged limited visible context.

## Known Unrelated Blockers
- `bun run --cwd packages/cloud/shared lint` is blocked by unrelated existing package-wide Biome findings in app frontend deployment tests, app schemas, app charge/review services, managed domains, oxapay tests, and token redemption imports.
- `bun run verify` exits before typecheck/lint at repo-wide type-safety ratchet drift: `as unknown as` 80 > 77 and `?? {}` 379 > 377.

## UI / Media Evidence
- N/A: backend/default-persona prompt fix only; no UI surface changed.