### PR TITLE
fix(cloud): encrypt agent sandbox environment secrets at rest

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts
@@ -1,0 +1,259 @@
+/**
+ * At-rest encryption of `agent_sandboxes.environment_vars` (#11332).
+ *
+ * The bug: `updateAgentEnvironment` persisted PATCHed BYO provider keys
+ * (ANTHROPIC_API_KEY / OPENAI_API_KEY / ...) verbatim into the plaintext jsonb
+ * column, so user secrets sat unencrypted at rest. The first suite's at-rest
+ * assertions FAIL against that pre-fix write path (negative control) and pass
+ * after it: the value handed to the repository is an `enc:v1:` envelope, not
+ * the secret.
+ *
+ * The crypto is the REAL FieldEncryptionService (AES-256-GCM, org DEK wrapped
+ * by SECRETS_MASTER_KEY) — only its org-key persistence (the db helpers) is
+ * swapped for an in-memory store, exactly the boundary the sibling service
+ * tests already mock. The repository row store is `spyOn`-captured so the test
+ * asserts the exact bytes that would land in Postgres.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { randomUUID } from "node:crypto";
+
+import * as realHelpersNs from "../../db/helpers";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+
+// ---- in-memory organization_encryption_keys store for FieldEncryptionService ----
+interface OrgKeyRow {
+  id: string;
+  organization_id: string;
+  encrypted_dek: string;
+  key_version: number;
+  created_at: Date;
+  rotated_at: Date | null;
+}
+const orgKeyRows: OrgKeyRow[] = [];
+
+const orgKeyDb = {
+  query: {
+    organizationEncryptionKeys: {
+      // Single-org tests: the row set has at most one entry, so the `where`
+      // clause (org id / key id) always resolves to it.
+      findFirst: async () => orgKeyRows[0],
+    },
+  },
+  insert: () => ({
+    values: (v: Record<string, unknown>) => ({
+      onConflictDoNothing: () => ({
+        returning: async () => {
+          const row: OrgKeyRow = {
+            id: randomUUID(),
+            key_version: 1,
+            created_at: new Date(),
+            rotated_at: null,
+            organization_id: v.organization_id as string,
+            encrypted_dek: v.encrypted_dek as string,
+          };
+          orgKeyRows.push(row);
+          return [row];
+        },
+      }),
+    }),
+  }),
+};
+
+const realHelpers = { ...realHelpersNs };
+mock.module("../../db/helpers", () => ({
+  ...realHelpers,
+  dbRead: orgKeyDb,
+  dbWrite: orgKeyDb,
+}));
+afterAll(() => {
+  mock.module("../../db/helpers", () => realHelpers);
+});
+
+// ---- captured repository writes (the at-rest boundary) ----
+const ORG_ID = "00000000-0000-4000-8000-00000000a001";
+const AGENT_ID = "00000000-0000-4000-8000-00000000a002";
+const SECRET = "sk-ant-api03-users-real-provider-key";
+
+function sandboxRow(env: Record<string, string>): AgentSandbox {
+  return {
+    id: AGENT_ID,
+    organization_id: ORG_ID,
+    environment_vars: env,
+    status: "running",
+    execution_tier: "dedicated-lazy",
+  } as unknown as AgentSandbox;
+}
+
+let storedRow: AgentSandbox;
+let capturedUpdate: Record<string, unknown> | undefined;
+
+const findSpy = spyOn(
+  agentSandboxesRepository,
+  "findByIdAndOrg",
+).mockImplementation(async () => storedRow);
+const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+  async (_id, data) => {
+    capturedUpdate = data as Record<string, unknown>;
+    storedRow = { ...storedRow, ...data } as AgentSandbox;
+    return storedRow;
+  },
+);
+
+const TEST_MASTER_KEY = "a".repeat(64);
+
+beforeEach(() => {
+  process.env.SECRETS_MASTER_KEY = TEST_MASTER_KEY;
+  storedRow = sandboxRow({});
+  capturedUpdate = undefined;
+  findSpy.mockClear();
+  updateSpy.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.SECRETS_MASTER_KEY;
+});
+
+afterAll(() => {
+  findSpy.mockRestore();
+  updateSpy.mockRestore();
+});
+
+async function patchEnv(
+  env: Record<string, string>,
+): Promise<Record<string, string>> {
+  const { elizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+  const updated = await elizaSandboxService.updateAgentEnvironment(
+    AGENT_ID,
+    ORG_ID,
+    env,
+  );
+  expect(updated).toBeDefined();
+  expect(capturedUpdate).toBeDefined();
+  return (capturedUpdate as { environment_vars: Record<string, string> })
+    .environment_vars;
+}
+
+describe("agent environment secrets are encrypted at rest (#11332)", () => {
+  test("a PATCHed provider key is ciphertext at rest — NOT the plaintext secret", async () => {
+    const stored = await patchEnv({
+      ANTHROPIC_API_KEY: SECRET,
+      ELIZA_PLUGIN_SET: "lean-chat",
+    });
+
+    // The at-rest bug: pre-fix these assertions fail — the row held the secret verbatim.
+    expect(stored.ANTHROPIC_API_KEY).not.toBe(SECRET);
+    expect(stored.ANTHROPIC_API_KEY.startsWith("enc:v1:")).toBe(true);
+    expect(JSON.stringify(stored)).not.toContain(SECRET);
+
+    // Non-secret config stays plaintext (value-inspected by the managed-env merge).
+    expect(stored.ELIZA_PLUGIN_SET).toBe("lean-chat");
+
+    // Round-trip: materialization returns the real value to the container.
+    const { decryptAgentEnvVars } = await import(
+      "./agent-env-crypto.ts?actual"
+    );
+    const materialized = await decryptAgentEnvVars(stored);
+    expect(materialized.ANTHROPIC_API_KEY).toBe(SECRET);
+    expect(materialized.ELIZA_PLUGIN_SET).toBe("lean-chat");
+  });
+
+  test("a legacy plaintext row materializes unchanged (no backfill required)", async () => {
+    const { decryptAgentEnvVars } = await import(
+      "./agent-env-crypto.ts?actual"
+    );
+    const legacy = {
+      OPENAI_API_KEY: "sk-legacy-plaintext-row",
+      ELIZA_UI_ENABLE: "true",
+    };
+    expect(await decryptAgentEnvVars(legacy)).toEqual(legacy);
+  });
+
+  test("platform bridge tokens are never encrypted — control-plane sync reads stay intact", async () => {
+    // The create route funnels the full managed env (incl. the platform's own
+    // tokens) through updateAgentEnvironment; getAgentApiToken / the dedicated
+    // proxy read these synchronously from the stored row, so they must stay
+    // plaintext.
+    const stored = await patchEnv({
+      ELIZA_API_TOKEN: "agent_platformtoken",
+      ELIZAOS_API_KEY: "legacy_alias_token",
+      ELIZAOS_CLOUD_API_KEY: "cloud_platform_key",
+      ANTHROPIC_API_KEY: SECRET,
+    });
+    expect(stored.ELIZA_API_TOKEN).toBe("agent_platformtoken");
+    expect(stored.ELIZAOS_API_KEY).toBe("legacy_alias_token");
+    expect(stored.ELIZAOS_CLOUD_API_KEY).toBe("cloud_platform_key");
+    expect(stored.ANTHROPIC_API_KEY.startsWith("enc:v1:")).toBe(true);
+  });
+
+  test("read-modify-write PATCH echoing stored ciphertext does not double-encrypt", async () => {
+    const first = await patchEnv({ OPENAI_API_KEY: "sk-first-secret" });
+    const firstCiphertext = first.OPENAI_API_KEY;
+    expect(firstCiphertext.startsWith("enc:v1:")).toBe(true);
+
+    // The environment route merges { ...existing, ...patch } — stored values
+    // ride back through the write path verbatim.
+    const second = await patchEnv({
+      OPENAI_API_KEY: firstCiphertext,
+      GITHUB_TOKEN: "ghp_new_secret",
+    });
+    expect(second.OPENAI_API_KEY).toBe(firstCiphertext);
+    expect(second.GITHUB_TOKEN.startsWith("enc:v1:")).toBe(true);
+
+    const { decryptAgentEnvVars } = await import(
+      "./agent-env-crypto.ts?actual"
+    );
+    const materialized = await decryptAgentEnvVars(second);
+    expect(materialized.OPENAI_API_KEY).toBe("sk-first-secret");
+    expect(materialized.GITHUB_TOKEN).toBe("ghp_new_secret");
+  });
+
+  test("without SECRETS_MASTER_KEY the write degrades to legacy plaintext (no hard dependency)", async () => {
+    delete process.env.SECRETS_MASTER_KEY;
+    const stored = await patchEnv({ ANTHROPIC_API_KEY: SECRET });
+    expect(stored.ANTHROPIC_API_KEY).toBe(SECRET);
+  });
+
+  test("decrypt failure fails closed with the key name — never ships ciphertext as a secret", async () => {
+    const { decryptAgentEnvVars } = await import(
+      "./agent-env-crypto.ts?actual"
+    );
+    const stored = await patchEnv({ ANTHROPIC_API_KEY: SECRET });
+    const corrupted = `${stored.ANTHROPIC_API_KEY.slice(0, -6)}AAAAAA`;
+    expect(
+      decryptAgentEnvVars({ ANTHROPIC_API_KEY: corrupted }),
+    ).rejects.toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  test("sensitivity classifier: BYO secrets in, platform tokens and plain config out", async () => {
+    const { isSensitiveAgentEnvKey } = await import(
+      "./agent-env-crypto.ts?actual"
+    );
+    // user BYO secrets — encrypted
+    expect(isSensitiveAgentEnvKey("ANTHROPIC_API_KEY")).toBe(true);
+    expect(isSensitiveAgentEnvKey("OPENAI_API_KEY")).toBe(true);
+    expect(isSensitiveAgentEnvKey("GITHUB_TOKEN")).toBe(true);
+    expect(isSensitiveAgentEnvKey("MY_DB_PASSWORD")).toBe(true);
+    expect(isSensitiveAgentEnvKey("AGENT_SERVER_SHARED_SECRET")).toBe(true);
+    // platform-managed control-plane tokens — never encrypted
+    expect(isSensitiveAgentEnvKey("ELIZA_API_TOKEN")).toBe(false);
+    expect(isSensitiveAgentEnvKey("ELIZAOS_API_KEY")).toBe(false);
+    expect(isSensitiveAgentEnvKey("ELIZAOS_CLOUD_API_KEY")).toBe(false);
+    expect(isSensitiveAgentEnvKey("DATABASE_URL")).toBe(false);
+    expect(isSensitiveAgentEnvKey("STEWARD_AGENT_TOKEN")).toBe(false);
+    // plain config — untouched
+    expect(isSensitiveAgentEnvKey("ELIZA_PLUGIN_SET")).toBe(false);
+    expect(isSensitiveAgentEnvKey("ELIZA_ALLOWED_ORIGINS")).toBe(false);
+    expect(isSensitiveAgentEnvKey("POSTGRES_POOL_MAX")).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-env-crypto.ts
+++ b/packages/cloud/shared/src/lib/services/agent-env-crypto.ts
@@ -1,0 +1,134 @@
+/**
+ * At-rest encryption for `agent_sandboxes.environment_vars` (#11332).
+ *
+ * The column is plain jsonb, and it is the one place users can land BYO
+ * provider keys today (PATCH /v1/eliza/agents/:id/environment, agent create,
+ * coding-container create). Without this layer those secrets sit in plaintext
+ * at rest. Values whose key looks secret-bearing are encrypted on WRITE with
+ * the EXISTING org-scoped envelope crypto (`FieldEncryptionService`:
+ * AES-256-GCM, per-org DEK wrapped by `SECRETS_MASTER_KEY`, `enc:v1:` encoded
+ * strings — the same primitive that already protects tenant DB DSNs) and
+ * decrypted only at the points the env is materialized for the agent (container
+ * create, fleet upgrade, runtime bootstrap), so the running agent still sees
+ * the real values.
+ *
+ * Backward compatible by construction:
+ * - Decrypt passes any non-`enc:v1:` value through untouched, so legacy
+ *   plaintext rows keep working with no forced backfill. Legacy plaintext
+ *   secrets are opportunistically re-encrypted the next time the row's env is
+ *   written through the service.
+ * - When `SECRETS_MASTER_KEY` is not configured, writes stay plaintext (exact
+ *   legacy behavior) with a structured warning, so environments without the
+ *   key (local dev, self-hosters) do not break. To activate, configure the
+ *   SAME key on the cloud API Worker and the provisioning daemon — the same
+ *   deployment requirement tenant-DB DSN encryption (`user-database.ts`)
+ *   already imposes.
+ *
+ * Platform-managed control-plane tokens (`RESERVED_PLATFORM_ENV_KEYS` plus the
+ * legacy `ELIZAOS_API_KEY` alias) are NEVER encrypted: the control plane reads
+ * them synchronously outside the materialization path (bridge auth headers,
+ * the dedicated-agent proxy, pairing routes), and they are minted and owned by
+ * the platform — they are not user BYO secrets.
+ */
+
+import { logger } from "../utils/logger";
+import { fieldEncryption } from "./field-encryption";
+import { RESERVED_PLATFORM_ENV_KEYS } from "./reserved-env-keys";
+
+/**
+ * Key-name heuristic for secret-bearing env vars (ANTHROPIC_API_KEY,
+ * OPENAI_API_KEY, GITHUB_TOKEN, AGENT_SERVER_SHARED_SECRET, ...). Deliberately
+ * broad: a false positive only costs an encrypt/decrypt round-trip through the
+ * materialization path; a false negative leaves a secret in plaintext.
+ */
+const SENSITIVE_ENV_KEY_PATTERN =
+  /(KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|PRIVATE)/i;
+
+/**
+ * Platform tokens the control plane must read synchronously from the stored
+ * row (bridge auth, proxies, pairing) — never encrypted. All of them are
+ * blocked from the user PATCH surface by the reserved-key gate except
+ * `ELIZAOS_API_KEY`, the legacy bridge-token alias `getAgentApiToken` falls
+ * back to.
+ */
+const NEVER_ENCRYPT_ENV_KEYS: ReadonlySet<string> = new Set(
+  [...RESERVED_PLATFORM_ENV_KEYS, "ELIZAOS_API_KEY"].map((key) =>
+    key.toUpperCase(),
+  ),
+);
+
+/** Whether a caller-supplied env key should be encrypted at rest. */
+export function isSensitiveAgentEnvKey(key: string): boolean {
+  if (NEVER_ENCRYPT_ENV_KEYS.has(key.toUpperCase())) return false;
+  return SENSITIVE_ENV_KEY_PATTERN.test(key);
+}
+
+/**
+ * Encrypt the secret-bearing values of an agent env map for storage in
+ * `agent_sandboxes.environment_vars`. Non-sensitive config values and
+ * platform tokens pass through unchanged; values that are already `enc:v1:`
+ * ciphertext (e.g. a read-modify-write PATCH echoing stored values back) are
+ * never double-encrypted.
+ *
+ * Fail-open ONLY for the key-not-configured case (legacy plaintext behavior,
+ * loudly logged); any real encryption failure propagates so a secret is never
+ * silently persisted in plaintext when encryption was expected to work.
+ */
+export async function encryptAgentEnvVarsForStorage(
+  organizationId: string,
+  environmentVars: Record<string, string>,
+): Promise<Record<string, string>> {
+  const pending = Object.entries(environmentVars).filter(
+    ([key, value]) =>
+      isSensitiveAgentEnvKey(key) &&
+      typeof value === "string" &&
+      value.length > 0 &&
+      !fieldEncryption.isEncrypted(value),
+  );
+  if (pending.length === 0) return { ...environmentVars };
+
+  // Same source FieldEncryptionService reads (the Worker populates process.env
+  // from bindings under nodejs_compat). No key -> legacy plaintext, warn loud.
+  if (!process.env.SECRETS_MASTER_KEY) {
+    logger.warn(
+      "[agent-env-crypto] SECRETS_MASTER_KEY not configured — storing agent environment secrets as PLAINTEXT (legacy behavior). Configure the key on the cloud API and provisioning daemon to encrypt at rest.",
+      { organizationId, keys: pending.map(([key]) => key) },
+    );
+    return { ...environmentVars };
+  }
+
+  const out: Record<string, string> = { ...environmentVars };
+  for (const [key, value] of pending) {
+    out[key] = await fieldEncryption.encrypt(organizationId, value);
+  }
+  return out;
+}
+
+/**
+ * Materialize a stored agent env map back to real values. `enc:v1:` values are
+ * decrypted; everything else (legacy plaintext rows, non-sensitive config)
+ * passes through untouched. Decrypt failures fail CLOSED with the key name —
+ * handing ciphertext to a container as if it were the secret would be a silent
+ * misconfiguration.
+ */
+export async function decryptAgentEnvVars(
+  environmentVars: Record<string, string> | null | undefined,
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(environmentVars ?? {})) {
+    if (typeof value === "string" && fieldEncryption.isEncrypted(value)) {
+      try {
+        out[key] = await fieldEncryption.decrypt(value);
+      } catch (error) {
+        throw new Error(
+          `Failed to decrypt agent environment variable ${key}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -40,6 +40,7 @@ import {
   incrementalChainDepth,
   planIncrementalBackup,
 } from "./agent-backup-diff";
+import { decryptAgentEnvVars, encryptAgentEnvVarsForStorage } from "./agent-env-crypto";
 import {
   type AIUsage,
   type BillingContext,
@@ -545,10 +546,18 @@ export class ElizaSandboxService {
     >,
   ): Promise<string> {
     const createEndpoint = await this.getAgentApiEndpoint(rec, "/api/agents");
+    // Bootstrap secrets (OPENAI_API_KEY / ANTHROPIC_API_KEY / ...) are copied
+    // out of environment_vars, which stores them encrypted at rest (#11332) —
+    // materialize real values before building the bootstrap payload.
+    const bootstrapEnv = await decryptAgentEnvVars(
+      (rec.environment_vars as Record<string, string> | null) ?? {},
+    );
     const createRes = await fetch(createEndpoint, {
       method: "POST",
       headers: this.getAgentJsonHeaders(rec),
-      body: JSON.stringify({ agent: this.buildRuntimeBootstrapAgent(rec) }),
+      body: JSON.stringify({
+        agent: this.buildRuntimeBootstrapAgent({ ...rec, environment_vars: bootstrapEnv }),
+      }),
       signal: AbortSignal.timeout(60_000),
     });
     if (!createRes.ok) {
@@ -665,6 +674,18 @@ export class ElizaSandboxService {
       reuse: params.reuseExistingNonTerminal ?? false,
     });
 
+    // Caller-supplied env can carry BYO secrets — encrypt them before the row
+    // is inserted (#11332), mirroring updateAgentEnvironment.
+    if (params.environmentVars && Object.keys(params.environmentVars).length > 0) {
+      params = {
+        ...params,
+        environmentVars: await encryptAgentEnvVarsForStorage(
+          params.organizationId,
+          params.environmentVars,
+        ),
+      };
+    }
+
     // Multi-agent-per-org callers (waifu launches, compat) leave the flag unset
     // and keep the plain insert — they legitimately mint several agents per org.
     if (!params.reuseExistingNonTerminal) {
@@ -748,6 +769,11 @@ export class ElizaSandboxService {
     const createParams: CreateAgentParams & { dockerImage: string } = {
       ...params,
       executionTier: params.executionTier ?? "custom",
+      // Coding-container env carries caller secrets (tokens, provider keys) —
+      // encrypt them before the row is inserted (#11332).
+      environmentVars: params.environmentVars
+        ? await encryptAgentEnvVarsForStorage(params.organizationId, params.environmentVars)
+        : params.environmentVars,
     };
 
     logger.info("[agent-sandbox] Creating coding-container agent", {
@@ -837,8 +863,11 @@ export class ElizaSandboxService {
   ): Promise<AgentSandbox | undefined> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
     if (!rec) return undefined;
+    // BYO secrets (provider API keys, tokens) are encrypted at rest (#11332);
+    // the materialization paths (provision / fleet upgrade / runtime
+    // bootstrap) decrypt, so the running agent still sees real values.
     return agentSandboxesRepository.update(rec.id, {
-      environment_vars: environmentVars,
+      environment_vars: await encryptAgentEnvVarsForStorage(orgId, environmentVars),
     });
   }
 
@@ -1216,12 +1245,32 @@ export class ElizaSandboxService {
     const MAX_PROVISION_ATTEMPTS = 3;
     let lastError: string = "Unknown error";
 
+    // Materialize the stored env for the container: BYO secrets are encrypted
+    // at rest (#11332); legacy plaintext values pass through unchanged. A
+    // decrypt failure fails the provision (never boot a container with
+    // ciphertext standing in for a secret) and is surfaced like any other
+    // pre-provision failure.
+    let materializedEnv: Record<string, string>;
+    try {
+      materializedEnv = await decryptAgentEnvVars(
+        (rec.environment_vars as Record<string, string>) ?? {},
+      );
+    } catch (envError) {
+      const message = envError instanceof Error ? envError.message : String(envError);
+      await this.markError(rec, `Environment decryption failed: ${message}`);
+      return {
+        success: false,
+        sandboxRecord: await agentSandboxesRepository.findById(rec.id),
+        error: message,
+      };
+    }
+
     for (let attempt = 1; attempt <= MAX_PROVISION_ATTEMPTS; attempt++) {
       let handle;
 
       try {
         // 2. Sandbox (via provider)
-        const callerEnv = (rec.environment_vars as Record<string, string>) ?? {};
+        const callerEnv = materializedEnv;
         // DATABASE_URL precedence: a self-contained image (e.g. a coding
         // container running its own bot) can ship its OWN database. Do not
         // silently clobber it with the managed shared DB URL — that would force the
@@ -4381,6 +4430,10 @@ export class ElizaSandboxService {
       };
     }
 
+    // Materialize at-rest-encrypted BYO secrets before container create (#11332).
+    const upgradeEnv = await decryptAgentEnvVars(
+      (agent.environment_vars as Record<string, string>) ?? {},
+    );
     const config = {
       agentId,
       agentName: agent.agent_name ?? "",
@@ -4395,10 +4448,8 @@ export class ElizaSandboxService {
       // narrow helper deliberately avoids the full provision merge, which would
       // mint a new API key / strip DATABASE_URL / flip local-state on upgrade (#8434).
       environmentVars: {
-        ...((agent.environment_vars as Record<string, string>) ?? {}),
-        ...applyManagedAgentInferenceEnvDefaults(
-          (agent.environment_vars as Record<string, string>) ?? {},
-        ),
+        ...upgradeEnv,
+        ...applyManagedAgentInferenceEnvDefaults(upgradeEnv),
       },
       dockerImage: digestPinnedImageRef(dockerImage, toDigest),
       excludeNodeId: oldNodeId,
@@ -4689,15 +4740,17 @@ export class ElizaSandboxService {
     }
 
     const rollbackImage = agent.previous_docker_image ?? dockerImage;
+    // Materialize at-rest-encrypted BYO secrets before container create (#11332).
+    const rollbackEnv = await decryptAgentEnvVars(
+      (agent.environment_vars as Record<string, string>) ?? {},
+    );
     const config = {
       agentId,
       agentName: agent.agent_name ?? "",
       organizationId: orgId,
       environmentVars: {
-        ...((agent.environment_vars as Record<string, string>) ?? {}),
-        ...applyManagedAgentInferenceEnvDefaults(
-          (agent.environment_vars as Record<string, string>) ?? {},
-        ),
+        ...rollbackEnv,
+        ...applyManagedAgentInferenceEnvDefaults(rollbackEnv),
       },
       dockerImage: digestPinnedImageRef(rollbackImage, toDigest),
       excludeNodeId: oldNodeId,


### PR DESCRIPTION
## Problem

`agent_sandboxes.environment_vars` is a plain jsonb column. `PATCH /v1/eliza/agents/:id/environment` — the only BYO-key surface today — persisted user provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, GitHub tokens, ...) **verbatim into the row**, so user secrets sat unencrypted at rest. Agent create and coding-container create take the same plaintext path. This is the `environment_vars` finding in #11332.

Verified before fixing: schema (`packages/cloud/shared/src/db/schemas/agent-sandboxes.ts:124`), the write path (`updateAgentEnvironment` → `agentSandboxesRepository.update`, no crypto anywhere), and the read path (`provision()` spreads `rec.environment_vars` straight into `provider.create`; `buildRuntimeBootstrapAgent` copies `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/... into runtime secrets). The new test fails against that write path (negative control below).

## Fix — reuse the existing envelope crypto, no schema change, no migration

- **Encrypt on write** (`updateAgentEnvironment`, `createAgent`, `createCodingContainerAgent`): values whose key looks secret-bearing (`KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|PRIVATE`) are encrypted with the **existing** `FieldEncryptionService` — AES-256-GCM, per-org DEK wrapped by `SECRETS_MASTER_KEY`, `enc:v1:` encoded strings — the same primitive already protecting tenant DB DSNs (`user-database.ts`). No new crypto was written.
- **Decrypt at materialization only**: `provision()` (container env, also covers wake), fleet `executeUpgrade`/`executeDowngrade`, and the runtime bootstrap payload. The running agent sees identical real values.
- **Never encrypted**: `RESERVED_PLATFORM_ENV_KEYS` + the legacy `ELIZAOS_API_KEY` alias — platform-minted tokens the control plane reads synchronously from the stored row (bridge auth headers, dedicated-agent proxy, pairing routes). These are blocked from the user PATCH surface by the existing reserved-key gate anyway.

### Backward compatibility (prod table, conservative rollout)

- Decrypt passes any non-`enc:v1:` value through untouched → **legacy plaintext rows keep working with no forced backfill**. They are opportunistically re-encrypted the next time the env is written.
- Without `SECRETS_MASTER_KEY` configured, writes keep exact legacy plaintext behavior with a loud structured warning — local dev / self-hosters don't break. To activate, set the same key on the cloud API Worker and the provisioning daemon (the same deployment requirement tenant-DB DSN encryption already imposes).
- Encryption failures when the key IS configured propagate (never silently persist plaintext); decrypt failures fail closed with the key name (never boot a container with ciphertext standing in for a secret).
- A read-modify-write PATCH echoing stored ciphertext back is not double-encrypted (`isEncrypted` guard).
- Zero DDL: values stay strings in the same jsonb column.

## Tests

`packages/cloud/shared/src/lib/services/agent-env-crypto.test.ts` — real `FieldEncryptionService` crypto (only its org-key persistence is swapped for an in-memory store, the same db-helpers boundary the sibling suites already mock), repository write captured via `spyOn` so assertions run against the exact bytes that would land in Postgres:

1. PATCHed provider key is `enc:v1:` ciphertext at rest, not the plaintext, and round-trips on materialization
2. legacy plaintext row materializes unchanged (no backfill required)
3. platform bridge tokens stay plaintext (control-plane sync reads intact)
4. ciphertext echo is not double-encrypted
5. no `SECRETS_MASTER_KEY` → legacy plaintext (graceful degradation)
6. decrypt failure fails closed naming the key
7. sensitivity classifier boundaries

### Verification (real output)

Negative control — same test against the pre-fix write path (fix stashed):

```
137 |     // The at-rest bug: pre-fix these assertions fail — the row held the secret verbatim.
138 |     expect(stored.ANTHROPIC_API_KEY).not.toBe(SECRET);
error: expect(received).not.toBe(expected)
(fail) agent environment secrets are encrypted at rest (#11332) > a PATCHed provider key is ciphertext at rest — NOT the plaintext secret
 3 pass
 4 fail
```

With the fix (plus all neighboring sandbox suites):

```
bun test src/lib/services/agent-env-crypto.test.ts src/lib/services/eliza-sandbox.test.ts \
  src/lib/services/eliza-sandbox-create-idempotency.test.ts src/lib/services/managed-eliza-config.test.ts \
  src/lib/services/coding-containers.test.ts src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts \
  src/lib/services/eliza-sandbox-shared-billing.test.ts src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
 117 pass / 0 fail (445 expect() calls)

bun run --cwd packages/cloud/shared typecheck   # tsgo --noEmit → clean, exit 0
```

Biome on the touched files: no new findings (the pre-existing `eliza-sandbox.ts` lints are byte-identical on develop, line numbers shifted).

Evidence notes: UI screenshots/video N/A — backend-only, no UI surface changed. Live-LLM trajectory N/A — no agent/prompt/model behavior changed; the container env contract is proven identical by the round-trip + neighboring-suite tests.

## Scope / follow-ups

- Follow-up (optional, noted not forced): a backfill job re-encrypting existing plaintext rows; until then legacy rows heal on next env write.
- The legacy Apps `containers.environment_vars` lane is out of scope here (separate table/lane, tracked by #11332's phase work).

Fixes the `agent_sandboxes.environment_vars` plaintext finding in #11332.
