### PR TITLE
fix(cloud): restore the 3 [cloud-security] money fixes clobbered by #11271 (#11227 + #11240 + #11261)

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
@@ -66,6 +66,15 @@ mock.module("@/lib/services/provisioning-worker-health", () => ({
   }),
 }));
 
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 10,
+  error: undefined as string | undefined,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
   handleCorsOptions: () => new Response(null, { status: 204 }),
@@ -115,6 +124,12 @@ describe("eliza agent pairing token route", () => {
     generateToken.mockClear();
     enqueueAgentProvisionOnce.mockClear();
     checkProvisioningWorkerHealth.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 10,
+      error: undefined,
+    });
     publicBaseDomain = "elizacloud.ai";
   });
 
@@ -222,5 +237,66 @@ describe("eliza agent pairing token route", () => {
       code: "AGENT_WEB_UI_NOT_READY",
     });
     expect(generateToken).not.toHaveBeenCalled();
+  });
+
+  test("#11224: pairing a STOPPED shared-runtime agent does not credit-gate or provision", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("shared"),
+      status: "stopped",
+    });
+
+    const response = await postPairingToken();
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "AGENT_WEB_UI_NOT_READY",
+    });
+    expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+    expect(generateToken).not.toHaveBeenCalled();
+  });
+
+  test("#11224: pairing a STOPPED dedicated agent for a suspended org is blocked 402 — no free re-provision", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("dedicated-lazy"),
+      status: "stopped",
+    });
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const response = await postPairingToken();
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({
+      code: "insufficient_credits",
+    });
+    // The paid re-provision must NOT be enqueued for a suspended org.
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+  });
+
+  test("#11224: pairing a STOPPED dedicated agent for a FUNDED org still re-provisions (no regression)", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("dedicated-lazy"),
+      status: "stopped",
+    });
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 10,
+      error: undefined,
+    });
+    enqueueAgentProvisionOnce.mockResolvedValue({
+      job: { id: "job-1" },
+      created: true,
+    });
+
+    await postPairingToken();
+
+    expect(checkAgentCreditGate).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvisionOnce).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -3,10 +3,12 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import {
   getElizaAgentDirectWebUiUrl,
   getElizaAgentPublicWebUiUrl,
 } from "@/lib/eliza-agent-web-ui";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -29,6 +31,22 @@ const STARTING_STATUSES = new Set([
   "disconnected",
 ]);
 const RETRY_AFTER_SECONDS = 5;
+
+function agentWebUiNotReadyResponse() {
+  return applyCorsHeaders(
+    Response.json(
+      {
+        success: false,
+        code: "AGENT_WEB_UI_NOT_READY",
+        error:
+          "Agent Web UI is not configured through the managed HTTPS route yet. Retry in a moment.",
+        retryable: true,
+      },
+      { status: 503 },
+    ),
+    CORS_METHODS,
+  );
+}
 
 type PairingSandbox = NonNullable<
   Awaited<ReturnType<typeof agentSandboxesRepository.findByIdAndOrg>>
@@ -151,6 +169,10 @@ async function __hono_POST(
       );
     }
 
+    if (sandbox.execution_tier === "shared") {
+      return agentWebUiNotReadyResponse();
+    }
+
     if (sandbox.status !== "running") {
       // Agent is pending/provisioning/stopped/disconnected — kick off (or
       // detect in-flight) provisioning and tell the client to retry.
@@ -172,6 +194,40 @@ async function __hono_POST(
             Response.json(provisioningWorkerFailureBody(workerHealth), {
               status: workerHealth.status,
             }),
+            CORS_METHODS,
+          );
+        }
+
+        // Credit gate before re-provisioning a DEDICATED container (#11224):
+        // pairing a stopped/reaped agent re-provisions its container, the same
+        // paid-compute wake the resume/restart/wake routes gate. Shared agents
+        // already returned early (execution_tier === "shared" above), so this
+        // only fences the dedicated case — a suspended/zero-balance org can't
+        // use pairing to get free compute the resume gate would have blocked.
+        const creditCheck = await checkAgentCreditGate(user.organization_id);
+        if (!creditCheck.allowed) {
+          logger.warn(
+            "[pairing-token] auto-resume blocked: insufficient credits",
+            {
+              agentId,
+              orgId: user.organization_id,
+              balance: creditCheck.balance,
+              required: AGENT_PRICING.MINIMUM_DEPOSIT,
+            },
+          );
+          return applyCorsHeaders(
+            Response.json(
+              {
+                success: false,
+                code: "insufficient_credits",
+                error:
+                  creditCheck.error ??
+                  "Insufficient credits to resume this agent",
+                requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+                currentBalance: creditCheck.balance,
+              },
+              { status: 402 },
+            ),
             CORS_METHODS,
           );
         }
@@ -234,19 +290,7 @@ async function __hono_POST(
 
     const webUiUrl = resolveManagedWebUiUrl(sandbox);
     if (!webUiUrl) {
-      return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            code: "AGENT_WEB_UI_NOT_READY",
-            error:
-              "Agent Web UI is not configured through the managed HTTPS route yet. Retry in a moment.",
-            retryable: true,
-          },
-          { status: 503 },
-        ),
-        CORS_METHODS,
-      );
+      return agentWebUiNotReadyResponse();
     }
 
     const tokenService = getPairingTokenService();


### PR DESCRIPTION
**Restores the 3 [cloud-security] money fixes that #11271's bad rebase clobbered AND that no one re-did.**

#11271 (`5b714c74e6`, the rejectDelivered refund fold) was cut from a stale branch and reverted ~15k lines across 304 files (root-cause on charter #11157). It clobbered 5 of my merged fixes. Two were already re-implemented by the fleet (#11218→#11278, #11255→#11369) — **this PR does NOT touch those.** The remaining **three had no re-do and were live money holes:**

| Fix | Hole re-opened | Restored |
|---|---|---|
| **#11227** | pairing-token: suspended org re-provisions a stopped DEDICATED agent free | gate + 2 tests |
| **#11240** | eliza-app provisioning-agent: suspended org's first dedicated provision free | gate + test |
| **#11261** | shared-runtime turn: a throw between reserve and settle strands the hold (DEFAULT tier) | outer refund guard + test |

Restored to the exact pre-clobber state (`git checkout 5b714c74e6^ -- <files>`; nothing touched them after #11271, so drift-free + brings back the deleted shared-turn test). **Tests green:** pairing-token 9 pass, provisioning-agent 4 pass, shared-turn 2 pass. biome clean.

**⚠️ STOPGAP:** the cleaner fix for the FULL #11271 regression (persona #11333, lifeops #11376, CI workflows, benchmarks, 300+ files) is a wholesale surgical revert (recipe on #11157). If that lands, it restores these too — drop this PR then. Filing because these 3 were untracked live money holes I found by auditing #11271's money collateral. Money-path — maintainer merge. Refs #11271 #11224 #11169. `[cloud-security]`