### PR TITLE
fix(ui): close the notched-device safe-area gap in the #11144 back-button clearance + de-larp inbox first-chip e2e

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -80,19 +80,19 @@ test("inbox decomposed view: channel filters toggle", async ({ page }) => {
   // and the rendered list: the active chip is renamed "* <Channel>", its
   // thread stays, and the other channel's thread disappears.
   //
-  // KNOWN BUG (documented, not accepted): the first chip in the row ("Email")
-  // sits under the shell's floating "Go back" button (fixed, z-60, top-left),
-  // which intercepts pointer events on BOTH the desktop and Pixel-7 lanes, so
-  // the Email chip is untappable. Drive the same filter semantics through the
-  // "Discord" chip (clear of the overlay) until the shell occlusion is fixed.
-  await page.getByRole("button", { name: "Discord", exact: true }).click();
+  // "Email" is the FIRST chip in the row — #11144 (fixed: SpatialSurface's
+  // --shell-backnav-clearance seam + its safe-area term) used to leave it under
+  // the shell's floating "Go back" button. Clicking it directly IS the
+  // occlusion regression check: Playwright's actionability check fails the
+  // click if the button intercepts the chip's center again.
+  await page.getByRole("button", { name: "Email", exact: true }).click();
   await expect(
-    page.getByRole("button", { name: "* Discord", exact: true }),
+    page.getByRole("button", { name: "* Email", exact: true }),
   ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByText("gm everyone — standup in 10").first(),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("Invoice #42 overdue")).toHaveCount(0, {
+  await expect(page.getByText("Invoice #42 overdue").first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("gm everyone — standup in 10")).toHaveCount(0, {
     timeout: 15_000,
   });
 });
@@ -240,11 +240,14 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
   });
 
   // Clicking the active kind chip again deselects it (back to every kind).
-  // KNOWN BUG (documented, not accepted): the dedicated "All" chip is the
-  // first chip in the row and sits under the shell's floating "Go back"
-  // button (fixed, z-60, top-left) on both lanes, so it is untappable — same
-  // occlusion as the inbox "Email" chip. The toggle-off path exercises the
-  // same restore semantics.
+  // The "All" first-chip occlusion is fixed by the same clearance seam as the
+  // inbox "Email" chip (verified there), but this test cannot exercise the
+  // direct "All" click yet: a separate, pre-existing failure — the #11145
+  // `[data-graph-container]` boundingBox guard added above (line ~223) times
+  // out under the force-stub e2e, before this chip interaction is reached, and
+  // reproduces on develop independent of the clearance change. Drive
+  // "Organizations" (clear of the overlay) until that boundingBox failure is
+  // resolved on the relationships lane.
   await page
     .getByRole("button", { name: "Organizations", exact: true })
     .click();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1501,13 +1501,23 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
       : APP_SHELL_CLASS;
   return (
     // --shell-backnav-clearance reserves top space for the fixed ShellBackButton
-    // so spatial views' first row (filter chips) clears it (#11144). 0.75rem top
-    // offset + 2.25rem button = 3rem. Consumed by SpatialSurface (spatial/dom.tsx);
-    // unset elsewhere → 0px.
+    // so spatial views' first row (filter chips) clears it (#11144). The button
+    // bottom sits at safe-area-top + 3rem (0.75rem offset + 2.25rem button) in
+    // VIEWPORT coords, but this wrapper lives inside the root content column,
+    // which absorbs only max(safe-area-top - 1.25rem, 1.25rem) of the safe area
+    // — up to 1.25rem less than the button's full safe-area offset on notched
+    // devices. min(safe-area-top, 1.25rem) adds back exactly that deficit: 3rem
+    // at safe-area-top 0 (unchanged), tight at real notch insets (≥ 2.5rem).
+    // Consumed by SpatialSurface (spatial/dom.tsx); unset elsewhere → 0px.
     <div
       key={`tab-shell-${props.tab}`}
       className={shellClass}
-      style={{ "--shell-backnav-clearance": "3rem" } as CSSProperties}
+      style={
+        {
+          "--shell-backnav-clearance":
+            "calc(3rem + min(var(--safe-area-top, 0px), 1.25rem))",
+        } as CSSProperties
+      }
     >
       <ShellBackButton onBack={props.onNavigateBack} />
       {props.desktopTabBar}
@@ -1535,7 +1545,15 @@ function FullBleedShellContent(props: ShellContentProps): ReactNode {
     <div
       key={`fullbleed-shell-${props.tab}`}
       className={APP_SHELL_CLASS}
-      style={{ "--shell-backnav-clearance": "3rem" } as CSSProperties}
+      // Same clearance contract as RoutedShellContent (see the derivation
+      // there): 3rem button clearance + the ≤1.25rem safe-area deficit the
+      // root content column does not absorb (#11144).
+      style={
+        {
+          "--shell-backnav-clearance":
+            "calc(3rem + min(var(--safe-area-top, 0px), 1.25rem))",
+        } as CSSProperties
+      }
     >
       <ShellBackButton onBack={props.onNavigateBack} />
       <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden">

--- a/packages/ui/src/spatial/dom.backnav-clearance.test.tsx
+++ b/packages/ui/src/spatial/dom.backnav-clearance.test.tsx
@@ -90,39 +90,112 @@ describe("shell back-button clearance seam (#11144)", () => {
     // height (n * 0.25rem). The clearance each wrapper reserves must be at
     // least offset + height, or the padded chip row still starts under the
     // button's bottom edge.
-    const btnIdx = APP_SRC.indexOf('data-testid="shell-back-button"');
-    expect(btnIdx).toBeGreaterThan(-1);
-    const btnTag = APP_SRC.slice(btnIdx, APP_SRC.indexOf(">", btnIdx));
-
-    const topMatch = btnTag.match(
-      /top-\[calc\(var\(--safe-area-top,0px\)\+([\d.]+)rem\)\]/,
-    );
-    expect(
-      topMatch,
-      "back button lost its rem top offset class",
-    ).not.toBeNull();
-    const heightMatch = btnTag.match(/\bh-(\d+(?:\.\d+)?)\b/);
-    expect(
-      heightMatch,
-      "back button lost its Tailwind height class",
-    ).not.toBeNull();
-    const bottomEdgeRem =
-      Number((topMatch as RegExpMatchArray)[1]) +
-      Number((heightMatch as RegExpMatchArray)[1]) * 0.25;
-
-    const clearanceMatches = [
-      ...APP_SRC.matchAll(
-        new RegExp(`"${CLEARANCE_VAR}":\\s*"([\\d.]+)rem"`, "g"),
-      ),
-    ];
+    const bottomEdgeRem = buttonBottomEdgeRem(0);
+    const evaluators = parseClearanceEvaluators();
     // Per-wrapper coverage is the previous test's job; this one just must not
     // pass vacuously.
-    expect(clearanceMatches.length).toBeGreaterThanOrEqual(1);
-    for (const match of clearanceMatches) {
+    expect(evaluators.length).toBeGreaterThanOrEqual(1);
+    for (const clearanceRem of evaluators) {
       expect(
-        Number(match[1]),
-        `${CLEARANCE_VAR} (${match[1]}rem) no longer clears the back button's bottom edge (${bottomEdgeRem}rem)`,
+        clearanceRem(0),
+        `${CLEARANCE_VAR} (${clearanceRem(0)}rem at safe-area-top 0) no longer clears the back button's bottom edge (${bottomEdgeRem}rem)`,
       ).toBeGreaterThanOrEqual(bottomEdgeRem);
     }
   });
+
+  it("the clearance still clears the button on notched devices (safe-area-top > 1.25rem)", () => {
+    // The clearance padding stacks INSIDE the root content column, which
+    // absorbs only max(safe-area-top - shaveRem, floorRem) of the safe area,
+    // while the fixed button sits at the FULL safe-area-top + offset in
+    // viewport coords. So the chip's viewport top is rootPad + clearance and
+    // must reach the button's bottom (safe-area-top + offset + height) at
+    // EVERY inset — a flat 3rem clearance passes at safe-area-top 0 (the
+    // Playwright lanes) but leaves up to a 1.25rem overlap on notched phones.
+    const rootPadMatch = APP_SRC.match(
+      /"max\(calc\(var\(--safe-area-top, 0px\) - ([\d.]+)rem\), ([\d.]+)rem\)"/,
+    );
+    expect(
+      rootPadMatch,
+      "root content column lost its shaved safe-area paddingTop (App.tsx)",
+    ).not.toBeNull();
+    const [, shave, floor] = rootPadMatch as RegExpMatchArray;
+    const rootPadRem = (satRem: number) =>
+      Math.max(satRem - Number(shave), Number(floor));
+
+    const evaluators = parseClearanceEvaluators();
+    expect(evaluators.length).toBeGreaterThanOrEqual(1);
+    // 24px (just past the 1.25rem floor crossover), 40px (the worst-case
+    // boundary where the deficit peaks), 44px (iPhone notch), 59px (Dynamic
+    // Island) — all at the 16px root font size.
+    for (const satRem of [1.5, 2.5, 2.75, 3.6875]) {
+      const buttonBottom = buttonBottomEdgeRem(satRem);
+      for (const clearanceRem of evaluators) {
+        const chipTop = rootPadRem(satRem) + clearanceRem(satRem);
+        expect(
+          chipTop,
+          `at --safe-area-top ${satRem}rem the first chip row's top (${chipTop}rem) sits above the back button's bottom edge (${buttonBottom}rem) — the button occludes the chip (#11144)`,
+        ).toBeGreaterThanOrEqual(buttonBottom);
+      }
+    }
+  });
 });
+
+/**
+ * The back button's bottom edge in viewport rem at a given --safe-area-top,
+ * parsed from ShellBackButton's className: fixed at
+ * top-[calc(var(--safe-area-top,0px)+<offset>rem)] with a Tailwind h-<n>
+ * height (n * 0.25rem).
+ */
+function buttonBottomEdgeRem(satRem: number): number {
+  const btnIdx = APP_SRC.indexOf('data-testid="shell-back-button"');
+  expect(btnIdx).toBeGreaterThan(-1);
+  const btnTag = APP_SRC.slice(btnIdx, APP_SRC.indexOf(">", btnIdx));
+
+  const topMatch = btnTag.match(
+    /top-\[calc\(var\(--safe-area-top,0px\)\+([\d.]+)rem\)\]/,
+  );
+  expect(topMatch, "back button lost its rem top offset class").not.toBeNull();
+  const heightMatch = btnTag.match(/\bh-(\d+(?:\.\d+)?)\b/);
+  expect(
+    heightMatch,
+    "back button lost its Tailwind height class",
+  ).not.toBeNull();
+  return (
+    satRem +
+    Number((topMatch as RegExpMatchArray)[1]) +
+    Number((heightMatch as RegExpMatchArray)[1]) * 0.25
+  );
+}
+
+/**
+ * Every --shell-backnav-clearance value App.tsx sets, as an evaluator from
+ * --safe-area-top (rem) to the resolved clearance (rem). Understands the two
+ * shapes the seam has shipped: a flat `<n>rem` and
+ * `calc(<n>rem + min(var(--safe-area-top, 0px), <m>rem))`. Every set-site must
+ * parse — an unparseable value is a geometry we cannot verify, so it fails
+ * loudly instead of being skipped.
+ */
+function parseClearanceEvaluators(): Array<(satRem: number) => number> {
+  const evaluators: Array<(satRem: number) => number> = [];
+  for (const match of APP_SRC.matchAll(
+    new RegExp(`"${CLEARANCE_VAR}":\\s*"([^"]+)"`, "g"),
+  )) {
+    const value = match[1];
+    const flat = value.match(/^([\d.]+)rem$/);
+    if (flat) {
+      const rem = Number(flat[1]);
+      evaluators.push(() => rem);
+      continue;
+    }
+    const calc = value.match(
+      /^calc\(([\d.]+)rem \+ min\(var\(--safe-area-top, 0px\), ([\d.]+)rem\)\)$/,
+    );
+    expect(
+      calc,
+      `unparseable ${CLEARANCE_VAR} value "${value}" — teach parseClearanceEvaluators its shape so the geometry stays verified`,
+    ).not.toBeNull();
+    const [, base, cap] = calc as RegExpMatchArray;
+    evaluators.push((satRem) => Number(base) + Math.min(satRem, Number(cap)));
+  }
+  return evaluators;
+}


### PR DESCRIPTION
Follow-up to **#11144** (closed via #11279's vertical `--shell-backnav-clearance` seam). #11279 reserved a flat `3rem` so spatial views' first filter-chip row clears the fixed `ShellBackButton` — but that flat value leaves a **1.25rem (20px) occlusion on notched devices**, and the inbox/relationships e2e still routed *around* the occlusion via non-first chips. This closes both gaps.

## The remaining bug: a safe-area deficit

The shell wrapper that renders `ShellBackButton` lives **inside** the root content column, which absorbs only `max(calc(var(--safe-area-top) - 1.25rem), 1.25rem)` of the top inset. The button itself is `position: fixed`, so its bottom sits at `var(--safe-area-top) + 3rem` in **viewport** coords (`0.75rem` offset + `2.25rem` height).

So with a flat `3rem` clearance the first chip's top is:

```
chip_top   = max(SAT - 1.25rem, 1.25rem) + 3rem
button_bot = SAT + 3rem
```

For any device with `SAT > 1.25rem` (every notched phone), `chip_top = SAT + 1.75rem` — a **constant 1.25rem under** `button_bot`. The Playwright lanes run `SAT = 0`, so the flat `3rem` passed there while real notched phones still occluded (and partially blocked taps on) the first filter chip.

## Fix

Both shell wrappers (`RoutedShellContent`, `FullBleedShellContent`) now set:

```
--shell-backnav-clearance: calc(3rem + min(var(--safe-area-top, 0px), 1.25rem))
```

`min()` adds back exactly the clamped deficit — unchanged `3rem` at inset 0 (Playwright lanes stay identical), tight at real notch insets — so the chip clears the button at **every** safe-area value.

## Evidence (real runs, post-rebase onto current develop)

- **`dom.backnav-clearance.test.tsx`** (jsdom) — the geometry guard now parses both the flat and `calc()` clearance shapes (button-bottom is a function of `--safe-area-top`) and adds a **notched-device case** (`SAT` = 1.5 / 2.5 / 2.75 / 3.6875rem) asserting `chip_top ≥ button_bot` at every inset. **4 passed.**
  - **Falsification:** reverting both sites to flat `3rem` fails the new case at `SAT = 1.5rem` (`chip_top 4.25rem < button_bot 4.5rem`) → **1 failed / 3 passed**. The guard bites.
- **inbox decomposed e2e** — removed the `KNOWN BUG (documented, not accepted)` workaround; it now clicks the **first chip "Email" directly**. Playwright's actionability check *is* the occlusion assertion — it fails the click if the back button intercepts the chip center — then asserts the Email thread shown / Discord hidden. **Green on both `chromium` + `mobile-chromium`** (`ELIZA_UI_SMOKE_FORCE_STUB=1`, Node 24).
- Rebuilt `@elizaos/ui` before the e2e (ui-smoke imports the built dist); confirmed the `calc(...)` formula is present twice in `dist/App.js` (no stale-dist trap). Biome clean on all 3 files.

## Pre-existing, out of scope (flagged, not introduced here)

The **relationships** decomposed test keeps its `"Organizations"` (non-first) chip. The same clearance fixes its `"All"` first chip too, but that test **cannot exercise the direct click yet**: the `#11145` `[data-graph-container]` `boundingBox` guard added *above* the chip interaction (line ~223) times out (180s) under the force-stub e2e on **both** lanes, **before** the chip is reached. This reproduces on `develop` independent of this change — my only runtime edit is shell top-padding, which cannot affect that container's attachment, and the ui rebuild is from develop source. I updated that test's comment to record the situation and left the failing assertion untouched (it belongs to #11145's lane). Repro: `playwright --project=chromium --project=mobile-chromium … -g "relationships decomposed view"` → 2 failed at `boundingBox`.

## Scope

3 files: `packages/ui/src/App.tsx` (both wrappers), `packages/ui/src/spatial/dom.backnav-clearance.test.tsx` (geometry guard + notched case), `packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts` (inbox de-larp + relationships comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)