### PR TITLE
fix(cloud): let an owner of an empty solo org accept an org invite

### DIFF
--- a/packages/cloud/api/invites/accept/route.ts
+++ b/packages/cloud/api/invites/accept/route.ts
@@ -54,7 +54,8 @@ app.post("/", async (c) => {
       error instanceof Error ? error.message : "Failed to accept invitation";
     const status =
       errorMessage.includes("sign in with") ||
-      errorMessage.includes("already a member")
+      errorMessage.includes("already a member") ||
+      errorMessage.includes("cannot join another organization")
         ? 409
         : errorMessage.includes("Invalid invite") ||
             errorMessage.includes("expired")

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -743,6 +743,26 @@ export class AgentSandboxesRepository {
     return row?.count ?? 0;
   }
 
+  /**
+   * Count retained user-owned agent rows for an organization. Used by org-vacate
+   * guards where deleting the org would cascade agent state without going
+   * through the provisioning teardown path.
+   */
+  async countRetainedByOrganization(organizationId: string): Promise<number> {
+    await ensureAgentSandboxSchema();
+    const [row] = await dbRead
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, organizationId),
+          sql`${agentSandboxes.pool_status} is null`,
+          sql`${agentSandboxes.deleted_at} is null`,
+        ),
+      );
+    return row?.count ?? 0;
+  }
+
   async countUserProvisionsSince(sinceMs: number): Promise<number> {
     await ensureAgentSandboxSchema();
     const since = new Date(Date.now() - sinceMs);

--- a/packages/cloud/shared/src/db/repositories/characters.ts
+++ b/packages/cloud/shared/src/db/repositories/characters.ts
@@ -426,6 +426,30 @@ export class UserCharactersRepository {
   }
 
   /**
+   * Moves a user's characters from one organization to another. Used when a
+   * sole-member owner accepts an invite into another org (#11332): the vacated
+   * solo org is deleted, and without this re-home the org cascade would
+   * destroy the user's characters.
+   */
+  async reassignUserOrganization(
+    userId: string,
+    fromOrganizationId: string,
+    toOrganizationId: string,
+  ): Promise<number> {
+    const moved = await dbWrite
+      .update(userCharacters)
+      .set({ organization_id: toOrganizationId, updated_at: new Date() })
+      .where(
+        and(
+          eq(userCharacters.user_id, userId),
+          eq(userCharacters.organization_id, fromOrganizationId),
+        ),
+      )
+      .returning({ id: userCharacters.id });
+    return moved.length;
+  }
+
+  /**
    * Builds the sort order expression for search queries.
    */
   private buildSortOrder(sortOptions: SortOptions) {

--- a/packages/cloud/shared/src/db/repositories/conversations.ts
+++ b/packages/cloud/shared/src/db/repositories/conversations.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import {
   hydrateJsonField,
@@ -236,6 +236,30 @@ export class ConversationsRepository {
    */
   async delete(id: string): Promise<void> {
     await dbWrite.delete(conversations).where(eq(conversations.id, id));
+  }
+
+  /**
+   * Moves a user's conversations from one organization to another. Used when a
+   * sole-member owner accepts an invite into another org (#11332): the vacated
+   * solo org is deleted, and without this re-home the org cascade would
+   * destroy the user's chat history.
+   */
+  async reassignUserOrganization(
+    userId: string,
+    fromOrganizationId: string,
+    toOrganizationId: string,
+  ): Promise<number> {
+    const moved = await dbWrite
+      .update(conversations)
+      .set({ organization_id: toOrganizationId, updated_at: new Date() })
+      .where(
+        and(
+          eq(conversations.user_id, userId),
+          eq(conversations.organization_id, fromOrganizationId),
+        ),
+      )
+      .returning({ id: conversations.id });
+    return moved.length;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
@@ -14,8 +14,8 @@
  * when a sole-member owner of an empty solo org can accept — moved into the
  * inviting org with the invited role, characters + conversations re-homed, and
  * the vacated solo org deleted. The remaining cases pin the boundary: owners
- * whose org has other members, deployed apps/agents, or more credits than the
- * signup grant stay blocked with actionable errors.
+ * whose org has other members, deployed apps/agents/domains, or more credits
+ * than the signup grant stay blocked with actionable errors.
  *
  * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails
  * to initialize — never a silent skip.
@@ -42,9 +42,7 @@ const PGLITE_TIMEOUT = 60_000;
 
 let pgliteReady = true;
 let dbWrite: typeof import("../../../db/client").dbWrite;
-let closeDb:
-  | typeof import("../../../db/client").closeDatabaseConnectionsForTests
-  | undefined;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let invitesService: typeof import("../invites").invitesService;
 let generateInviteToken: typeof import("../../utils/invite-tokens").generateInviteToken;
 let hashInviteToken: typeof import("../../utils/invite-tokens").hashInviteToken;
@@ -56,6 +54,8 @@ let schemas: {
   conversations: typeof import("../../../db/schemas/conversations").conversations;
   apps: typeof import("../../../db/schemas/apps").apps;
   containers: typeof import("../../../db/schemas/containers").containers;
+  agentSandboxes: typeof import("../../../db/schemas/agent-sandboxes").agentSandboxes;
+  managedDomains: typeof import("../../../db/schemas/managed-domains").managedDomains;
 };
 
 let seq = 0;
@@ -136,9 +136,7 @@ async function seedInviteScenario(options?: {
   };
 }
 
-async function readUser(
-  userId: string,
-): Promise<{ organization_id: string | null; role: string }> {
+async function readUser(userId: string): Promise<{ organization_id: string | null; role: string }> {
   const rows = await dbWrite.execute(
     `SELECT organization_id, role FROM users WHERE id = '${userId}';`,
   );
@@ -146,42 +144,38 @@ async function readUser(
 }
 
 async function orgExists(orgId: string): Promise<boolean> {
-  const rows = await dbWrite.execute(
-    `SELECT id FROM organizations WHERE id = '${orgId}';`,
-  );
+  const rows = await dbWrite.execute(`SELECT id FROM organizations WHERE id = '${orgId}';`);
   return rows.rows.length > 0;
 }
 
 beforeAll(async () => {
   try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import(
-      "../../../db/client"
-    ));
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ invitesService } = await import("../invites"));
-    ({ generateInviteToken, hashInviteToken } = await import(
-      "../../utils/invite-tokens"
-    ));
+    ({ generateInviteToken, hashInviteToken } = await import("../../utils/invite-tokens"));
 
     const { organizations } = await import("../../../db/schemas/organizations");
     const { users } = await import("../../../db/schemas/users");
-    const { organizationInvites } = await import(
-      "../../../db/schemas/organization-invites"
-    );
-    const { userCharacters } = await import(
-      "../../../db/schemas/user-characters"
-    );
+    const { organizationInvites } = await import("../../../db/schemas/organization-invites");
+    const { userCharacters } = await import("../../../db/schemas/user-characters");
     const { conversations } = await import("../../../db/schemas/conversations");
     const { apiKeys } = await import("../../../db/schemas/api-keys");
-    const { creditTransactions } = await import(
-      "../../../db/schemas/credit-transactions"
-    );
-    const {
-      apps,
-      appDeploymentStatusEnum,
-      appReviewStatusEnum,
-      userDatabaseStatusEnum,
-    } = await import("../../../db/schemas/apps");
+    const { creditTransactions } = await import("../../../db/schemas/credit-transactions");
+    const { apps, appDeploymentStatusEnum, appReviewStatusEnum, userDatabaseStatusEnum } =
+      await import("../../../db/schemas/apps");
     const { containers } = await import("../../../db/schemas/containers");
+    const { agentSandboxes } = await import("../../../db/schemas/agent-sandboxes");
+    const {
+      domainModerationStatusEnum,
+      domainNameserverModeEnum,
+      domainRegistrarEnum,
+      domainResourceTypeEnum,
+      domainStatusEnum,
+      managedDomains,
+    } = await import("../../../db/schemas/managed-domains");
+    const { mcpPricingTypeEnum, mcpStatusEnum, userMcps } = await import(
+      "../../../db/schemas/user-mcps"
+    );
     schemas = {
       organizations,
       users,
@@ -190,6 +184,8 @@ beforeAll(async () => {
       conversations,
       apps,
       containers,
+      agentSandboxes,
+      managedDomains,
     };
 
     const { pushSchema } = await import("../../../db/push-schema-for-tests");
@@ -204,6 +200,16 @@ beforeAll(async () => {
         creditTransactions,
         apps,
         containers,
+        agentSandboxes,
+        managedDomains,
+        domainRegistrarEnum,
+        domainNameserverModeEnum,
+        domainResourceTypeEnum,
+        domainModerationStatusEnum,
+        domainStatusEnum,
+        userMcps,
+        mcpPricingTypeEnum,
+        mcpStatusEnum,
         appDeploymentStatusEnum,
         appReviewStatusEnum,
         userDatabaseStatusEnum,
@@ -213,10 +219,7 @@ beforeAll(async () => {
     await apply();
   } catch (error) {
     pgliteReady = false;
-    console.error(
-      "[invite-owner-accept.test] PGlite/pushSchema unavailable — failing.",
-      error,
-    );
+    console.error("[invite-owner-accept.test] PGlite/pushSchema unavailable — failing.", error);
   }
 }, PGLITE_TIMEOUT);
 
@@ -261,10 +264,7 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         status: "deleted",
       });
 
-      const accepted = await invitesService.acceptInvite(
-        seeded.token,
-        seeded.inviteeUserId,
-      );
+      const accepted = await invitesService.acceptInvite(seeded.token, seeded.inviteeUserId);
 
       expect(accepted.status).toBe("accepted");
       expect(accepted.accepted_by_user_id).toBe(seeded.inviteeUserId);
@@ -278,16 +278,15 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
       const characterRows = await dbWrite.execute(
         `SELECT organization_id FROM user_characters WHERE id = '${characterId}';`,
       );
-      expect(
-        (characterRows.rows[0] as { organization_id: string }).organization_id,
-      ).toBe(seeded.inviterOrgId);
+      expect((characterRows.rows[0] as { organization_id: string }).organization_id).toBe(
+        seeded.inviterOrgId,
+      );
       const conversationRows = await dbWrite.execute(
         `SELECT organization_id FROM conversations WHERE id = '${conversationId}';`,
       );
-      expect(
-        (conversationRows.rows[0] as { organization_id: string })
-          .organization_id,
-      ).toBe(seeded.inviterOrgId);
+      expect((conversationRows.rows[0] as { organization_id: string }).organization_id).toBe(
+        seeded.inviterOrgId,
+      );
     },
     PGLITE_TIMEOUT,
   );
@@ -305,9 +304,9 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         role: "member",
       });
 
-      await expect(
-        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
-      ).rejects.toThrow(/other members/);
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /other members/,
+      );
 
       const user = await readUser(seeded.inviteeUserId);
       expect(user.organization_id).toBe(seeded.inviteeOrgId);
@@ -333,12 +332,10 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         app_url: "https://example.com",
       });
 
-      await expect(
-        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
-      ).rejects.toThrow(/deployed apps or agents/);
-      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
-        seeded.inviteeOrgId,
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /deployed apps, agents, or managed domains/,
       );
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
       expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
     },
     PGLITE_TIMEOUT,
@@ -358,12 +355,53 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         status: "running",
       });
 
-      await expect(
-        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
-      ).rejects.toThrow(/deployed apps or agents/);
-      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
-        seeded.inviteeOrgId,
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /deployed apps, agents, or managed domains/,
       );
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner with a live shared agent sandbox stays blocked",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      await dbWrite.insert(schemas.agentSandboxes).values({
+        id: uid(),
+        organization_id: seeded.inviteeOrgId,
+        user_id: seeded.inviteeUserId,
+        status: "running",
+        execution_tier: "shared",
+        agent_name: "shared agent",
+      });
+
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /deployed apps, agents, or managed domains/,
+      );
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner with a managed domain stays blocked",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      await dbWrite.insert(schemas.managedDomains).values({
+        id: uid(),
+        organizationId: seeded.inviteeOrgId,
+        domain: `solo-${seeded.inviteeUserId}.example.com`,
+      });
+
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /deployed apps, agents, or managed domains/,
+      );
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
       expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
     },
     PGLITE_TIMEOUT,
@@ -377,12 +415,10 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         inviteeOrgBalance: "25.000000",
       });
 
-      await expect(
-        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
-      ).rejects.toThrow(/credits/);
-      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
-        seeded.inviteeOrgId,
+      await expect(invitesService.acceptInvite(seeded.token, seeded.inviteeUserId)).rejects.toThrow(
+        /credits/,
       );
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviteeOrgId);
       expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
     },
     PGLITE_TIMEOUT,
@@ -405,10 +441,7 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
         role: "owner",
       });
 
-      const accepted = await invitesService.acceptInvite(
-        seeded.token,
-        seeded.inviteeUserId,
-      );
+      const accepted = await invitesService.acceptInvite(seeded.token, seeded.inviteeUserId);
       expect(accepted.status).toBe("accepted");
 
       const user = await readUser(seeded.inviteeUserId);

--- a/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
@@ -1,0 +1,421 @@
+/**
+ * acceptInvite owner dead-end (#11332).
+ *
+ * Every self-signup provisions the new user as the OWNER of a fresh solo org
+ * (steward-sync `role: "owner"`), and `acceptInvite` blanket-rejects owners
+ * ("Organization owners cannot join other organizations"). Net effect: org
+ * invites only ever work for people who have NEVER signed up — any teammate
+ * with an existing Eliza Cloud account is permanently locked out of joining
+ * their team.
+ *
+ * These cases run the REAL `InvitesService.acceptInvite` against in-process
+ * PGlite (real users/organizations/invites SQL, real drizzle relational reads).
+ * Case 1 is the bug proof: it FAILS on the blanket owner block and passes only
+ * when a sole-member owner of an empty solo org can accept — moved into the
+ * inviting org with the invited role, characters + conversations re-homed, and
+ * the vacated solo org deleted. The remaining cases pin the boundary: owners
+ * whose org has other members, deployed apps/agents, or more credits than the
+ * signup grant stay blocked with actionable errors.
+ *
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails
+ * to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports.
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+// Not the seam under test: `invites.ts` imports the email service at module
+// level for createInvite's notification. acceptInvite never sends mail.
+mock.module("../email", () => ({
+  emailService: {
+    sendInviteEmail: mock(async () => false),
+  },
+}));
+
+const PGLITE_TIMEOUT = 60_000;
+
+let pgliteReady = true;
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb:
+  | typeof import("../../../db/client").closeDatabaseConnectionsForTests
+  | undefined;
+let invitesService: typeof import("../invites").invitesService;
+let generateInviteToken: typeof import("../../utils/invite-tokens").generateInviteToken;
+let hashInviteToken: typeof import("../../utils/invite-tokens").hashInviteToken;
+let schemas: {
+  organizations: typeof import("../../../db/schemas/organizations").organizations;
+  users: typeof import("../../../db/schemas/users").users;
+  organizationInvites: typeof import("../../../db/schemas/organization-invites").organizationInvites;
+  userCharacters: typeof import("../../../db/schemas/user-characters").userCharacters;
+  conversations: typeof import("../../../db/schemas/conversations").conversations;
+  apps: typeof import("../../../db/schemas/apps").apps;
+  containers: typeof import("../../../db/schemas/containers").containers;
+};
+
+let seq = 0;
+function uid(): string {
+  seq += 1;
+  return `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+}
+
+interface SeedResult {
+  inviterOrgId: string;
+  inviterUserId: string;
+  inviteeOrgId: string;
+  inviteeUserId: string;
+  inviteId: string;
+  token: string;
+}
+
+/**
+ * Seeds an inviting org (owner = inviter) plus an invitee who already owns a
+ * solo org, and a pending invite addressed to the invitee's email.
+ */
+async function seedInviteScenario(options?: {
+  inviteeOrgBalance?: string;
+  invitedRole?: "admin" | "member";
+}): Promise<SeedResult> {
+  const inviterOrgId = uid();
+  const inviterUserId = uid();
+  const inviteeOrgId = uid();
+  const inviteeUserId = uid();
+  const inviteeEmail = `invitee-${inviteeUserId}@example.com`;
+
+  await dbWrite.insert(schemas.organizations).values([
+    { id: inviterOrgId, name: "Team Org", slug: `team-${inviterOrgId}` },
+    {
+      id: inviteeOrgId,
+      name: "Solo Org",
+      slug: `solo-${inviteeOrgId}`,
+      credit_balance: options?.inviteeOrgBalance ?? "5.000000",
+    },
+  ]);
+  await dbWrite.insert(schemas.users).values([
+    {
+      id: inviterUserId,
+      steward_user_id: `steward-${inviterUserId}`,
+      email: `inviter-${inviterUserId}@example.com`,
+      organization_id: inviterOrgId,
+      role: "owner",
+    },
+    {
+      id: inviteeUserId,
+      steward_user_id: `steward-${inviteeUserId}`,
+      email: inviteeEmail,
+      organization_id: inviteeOrgId,
+      role: "owner",
+    },
+  ]);
+
+  const token = generateInviteToken();
+  const inviteId = uid();
+  await dbWrite.insert(schemas.organizationInvites).values({
+    id: inviteId,
+    organization_id: inviterOrgId,
+    inviter_user_id: inviterUserId,
+    invited_email: inviteeEmail,
+    invited_role: options?.invitedRole ?? "member",
+    token_hash: hashInviteToken(token),
+    expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    status: "pending",
+  });
+
+  return {
+    inviterOrgId,
+    inviterUserId,
+    inviteeOrgId,
+    inviteeUserId,
+    inviteId,
+    token,
+  };
+}
+
+async function readUser(
+  userId: string,
+): Promise<{ organization_id: string | null; role: string }> {
+  const rows = await dbWrite.execute(
+    `SELECT organization_id, role FROM users WHERE id = '${userId}';`,
+  );
+  return rows.rows[0] as { organization_id: string | null; role: string };
+}
+
+async function orgExists(orgId: string): Promise<boolean> {
+  const rows = await dbWrite.execute(
+    `SELECT id FROM organizations WHERE id = '${orgId}';`,
+  );
+  return rows.rows.length > 0;
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import(
+      "../../../db/client"
+    ));
+    ({ invitesService } = await import("../invites"));
+    ({ generateInviteToken, hashInviteToken } = await import(
+      "../../utils/invite-tokens"
+    ));
+
+    const { organizations } = await import("../../../db/schemas/organizations");
+    const { users } = await import("../../../db/schemas/users");
+    const { organizationInvites } = await import(
+      "../../../db/schemas/organization-invites"
+    );
+    const { userCharacters } = await import(
+      "../../../db/schemas/user-characters"
+    );
+    const { conversations } = await import("../../../db/schemas/conversations");
+    const { apiKeys } = await import("../../../db/schemas/api-keys");
+    const { creditTransactions } = await import(
+      "../../../db/schemas/credit-transactions"
+    );
+    const {
+      apps,
+      appDeploymentStatusEnum,
+      appReviewStatusEnum,
+      userDatabaseStatusEnum,
+    } = await import("../../../db/schemas/apps");
+    const { containers } = await import("../../../db/schemas/containers");
+    schemas = {
+      organizations,
+      users,
+      organizationInvites,
+      userCharacters,
+      conversations,
+      apps,
+      containers,
+    };
+
+    const { pushSchema } = await import("../../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        organizationInvites,
+        userCharacters,
+        conversations,
+        apiKeys,
+        creditTransactions,
+        apps,
+        containers,
+        appDeploymentStatusEnum,
+        appReviewStatusEnum,
+        userDatabaseStatusEnum,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[invite-owner-accept.test] PGlite/pushSchema unavailable — failing.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("acceptInvite — existing owner of an empty solo org (#11332)", () => {
+  test(
+    "sole-member owner of an empty solo org CAN accept: moved with invited role, content re-homed, solo org deleted",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario({ invitedRole: "member" });
+
+      // The auto-provisioned signup artifacts every solo org has: a default
+      // character and a conversation. Both are user-authored content and must
+      // survive the org move.
+      const characterId = uid();
+      await dbWrite.insert(schemas.userCharacters).values({
+        id: characterId,
+        organization_id: seeded.inviteeOrgId,
+        user_id: seeded.inviteeUserId,
+        name: "Eliza",
+        bio: ["default"],
+        character_data: { name: "Eliza" },
+      });
+      const conversationId = uid();
+      await dbWrite.insert(schemas.conversations).values({
+        id: conversationId,
+        organization_id: seeded.inviteeOrgId,
+        user_id: seeded.inviteeUserId,
+        title: "hello",
+        model: "test-model",
+      });
+      // A soft-deleted container must NOT count as a deployed agent.
+      await dbWrite.insert(schemas.containers).values({
+        id: uid(),
+        name: "old",
+        project_name: "old",
+        organization_id: seeded.inviteeOrgId,
+        user_id: seeded.inviteeUserId,
+        status: "deleted",
+      });
+
+      const accepted = await invitesService.acceptInvite(
+        seeded.token,
+        seeded.inviteeUserId,
+      );
+
+      expect(accepted.status).toBe("accepted");
+      expect(accepted.accepted_by_user_id).toBe(seeded.inviteeUserId);
+
+      const movedUser = await readUser(seeded.inviteeUserId);
+      expect(movedUser.organization_id).toBe(seeded.inviterOrgId);
+      expect(movedUser.role).toBe("member");
+
+      // Vacated solo org is gone; the user's content moved with them.
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(false);
+      const characterRows = await dbWrite.execute(
+        `SELECT organization_id FROM user_characters WHERE id = '${characterId}';`,
+      );
+      expect(
+        (characterRows.rows[0] as { organization_id: string }).organization_id,
+      ).toBe(seeded.inviterOrgId);
+      const conversationRows = await dbWrite.execute(
+        `SELECT organization_id FROM conversations WHERE id = '${conversationId}';`,
+      );
+      expect(
+        (conversationRows.rows[0] as { organization_id: string })
+          .organization_id,
+      ).toBe(seeded.inviterOrgId);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner of an org with another member stays blocked, user and invite untouched",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      await dbWrite.insert(schemas.users).values({
+        id: uid(),
+        steward_user_id: `steward-${uid()}`,
+        email: `member-${seeded.inviteeOrgId}@example.com`,
+        organization_id: seeded.inviteeOrgId,
+        role: "member",
+      });
+
+      await expect(
+        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+      ).rejects.toThrow(/other members/);
+
+      const user = await readUser(seeded.inviteeUserId);
+      expect(user.organization_id).toBe(seeded.inviteeOrgId);
+      expect(user.role).toBe("owner");
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+      const invite = await invitesService.getById(seeded.inviteId);
+      expect(invite?.status).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner with a deployed app stays blocked",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      await dbWrite.insert(schemas.apps).values({
+        id: uid(),
+        organization_id: seeded.inviteeOrgId,
+        created_by_user_id: seeded.inviteeUserId,
+        name: "my app",
+        slug: `app-${seeded.inviteeOrgId}`,
+        app_url: "https://example.com",
+      });
+
+      await expect(
+        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+      ).rejects.toThrow(/deployed apps or agents/);
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
+        seeded.inviteeOrgId,
+      );
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner with an active container (deployed agent) stays blocked",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      await dbWrite.insert(schemas.containers).values({
+        id: uid(),
+        name: "agent",
+        project_name: "agent",
+        organization_id: seeded.inviteeOrgId,
+        user_id: seeded.inviteeUserId,
+        status: "running",
+      });
+
+      await expect(
+        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+      ).rejects.toThrow(/deployed apps or agents/);
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
+        seeded.inviteeOrgId,
+      );
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "owner whose org holds more credits than the signup grant stays blocked",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario({
+        inviteeOrgBalance: "25.000000",
+      });
+
+      await expect(
+        invitesService.acceptInvite(seeded.token, seeded.inviteeUserId),
+      ).rejects.toThrow(/credits/);
+      expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(
+        seeded.inviteeOrgId,
+      );
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "non-owner member accept keeps working and never deletes the org they leave",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario();
+      // Reshape: the invitee is a plain member of an org that has an owner.
+      await dbWrite.execute(
+        `UPDATE users SET role = 'member' WHERE id = '${seeded.inviteeUserId}';`,
+      );
+      await dbWrite.insert(schemas.users).values({
+        id: uid(),
+        steward_user_id: `steward-owner-${seeded.inviteeOrgId}`,
+        email: `owner-${seeded.inviteeOrgId}@example.com`,
+        organization_id: seeded.inviteeOrgId,
+        role: "owner",
+      });
+
+      const accepted = await invitesService.acceptInvite(
+        seeded.token,
+        seeded.inviteeUserId,
+      );
+      expect(accepted.status).toBe("accepted");
+
+      const user = await readUser(seeded.inviteeUserId);
+      expect(user.organization_id).toBe(seeded.inviterOrgId);
+      // The org they left keeps existing — it still has its owner.
+      expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -8,6 +8,7 @@ import {
   organizationInvitesRepository,
   type User,
 } from "../../db/repositories";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { appsRepository } from "../../db/repositories/apps";
 import { userCharactersRepository } from "../../db/repositories/characters";
 import { containersRepository } from "../../db/repositories/containers";
@@ -16,6 +17,7 @@ import { getInitialCredits } from "../signup-credits";
 import { generateInviteToken, hashInviteToken } from "../utils/invite-tokens";
 import { logger } from "../utils/logger";
 import { emailService } from "./email";
+import { managedDomainsService } from "./managed-domains";
 import { organizationsService } from "./organizations";
 import { usersService } from "./users";
 
@@ -179,8 +181,8 @@ export class InvitesService {
     // Every self-signup provisions its user as the OWNER of a fresh solo org
     // (steward-sync), so a blanket owner block would dead-end every existing
     // account (#11332). An owner may accept iff their current org is an empty
-    // solo org: no other members, no deployed apps/agents, and no more credits
-    // than the signup grant. Anything richer keeps the block with an
+    // solo org: no other members, no deployed apps/agents/domains, and no more
+    // credits than the signup grant. Anything richer keeps the block with an
     // actionable error — abandoning a real org needs an explicit path.
     const vacatedSoloOrgId = user.role === "owner" ? user.organization_id : null;
     if (vacatedSoloOrgId) {
@@ -221,16 +223,23 @@ export class InvitesService {
       );
     }
 
-    const [appCount, containers] = await Promise.all([
+    const [appCount, containers, retainedAgentCount, managedDomainCount] = await Promise.all([
       appsRepository.countByOrganization(organizationId),
       containersRepository.listByOrganization(organizationId),
+      agentSandboxesRepository.countRetainedByOrganization(organizationId),
+      managedDomainsService.countForOrganization(organizationId),
     ]);
     const deployedContainers = containers.filter(
       (container) => container.status !== "deleted" && container.status !== "deleting",
     );
-    if (appCount > 0 || deployedContainers.length > 0) {
+    if (
+      appCount > 0 ||
+      deployedContainers.length > 0 ||
+      retainedAgentCount > 0 ||
+      managedDomainCount > 0
+    ) {
       throw new Error(
-        "You cannot join another organization while your current organization has deployed apps or agents. Delete them first.",
+        "You cannot join another organization while your current organization has deployed apps, agents, or managed domains. Delete or transfer them first.",
       );
     }
 
@@ -256,10 +265,13 @@ export class InvitesService {
     try {
       const remaining = await usersService.listByOrganization(previousOrganizationId);
       if (remaining.some((member) => member.id !== userId)) {
-        logger.warn("[InvitesService] Vacated org gained a member mid-accept; leaving it in place", {
-          previousOrganizationId,
-          userId,
-        });
+        logger.warn(
+          "[InvitesService] Vacated org gained a member mid-accept; leaving it in place",
+          {
+            previousOrganizationId,
+            userId,
+          },
+        );
         return;
       }
       await userCharactersRepository.reassignUserOrganization(

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -6,8 +6,15 @@ import {
   type NewOrganizationInvite,
   type OrganizationInvite,
   organizationInvitesRepository,
+  type User,
 } from "../../db/repositories";
+import { appsRepository } from "../../db/repositories/apps";
+import { userCharactersRepository } from "../../db/repositories/characters";
+import { containersRepository } from "../../db/repositories/containers";
+import { conversationsRepository } from "../../db/repositories/conversations";
+import { getInitialCredits } from "../signup-credits";
 import { generateInviteToken, hashInviteToken } from "../utils/invite-tokens";
+import { logger } from "../utils/logger";
 import { emailService } from "./email";
 import { organizationsService } from "./organizations";
 import { usersService } from "./users";
@@ -169,13 +176,18 @@ export class InvitesService {
       throw new Error("You are already a member of this organization");
     }
 
-    if (user.role === "owner") {
-      throw new Error(
-        "Organization owners cannot join other organizations. Contact support for assistance.",
-      );
+    // Every self-signup provisions its user as the OWNER of a fresh solo org
+    // (steward-sync), so a blanket owner block would dead-end every existing
+    // account (#11332). An owner may accept iff their current org is an empty
+    // solo org: no other members, no deployed apps/agents, and no more credits
+    // than the signup grant. Anything richer keeps the block with an
+    // actionable error — abandoning a real org needs an explicit path.
+    const vacatedSoloOrgId = user.role === "owner" ? user.organization_id : null;
+    if (vacatedSoloOrgId) {
+      await this.assertOwnerCanVacateSoloOrganization(user, vacatedSoloOrgId);
     }
 
-    await usersService.update(userId, {
+    const movedUser = await usersService.update(userId, {
       organization_id: invite.organization_id,
       role: invite.invited_role,
       updated_at: new Date(),
@@ -187,7 +199,87 @@ export class InvitesService {
       throw new Error("Failed to mark invite as accepted");
     }
 
+    if (vacatedSoloOrgId && movedUser?.organization_id === invite.organization_id) {
+      await this.cleanUpVacatedSoloOrganization(userId, vacatedSoloOrgId, invite.organization_id);
+    }
+
     return updatedInvite;
+  }
+
+  /**
+   * Gate for an owner accepting an invite: their current org must be an empty
+   * solo org (the auto-provisioned signup artifact), not a real organization.
+   */
+  private async assertOwnerCanVacateSoloOrganization(
+    user: User,
+    organizationId: string,
+  ): Promise<void> {
+    const members = await usersService.listByOrganization(organizationId);
+    if (members.some((member) => member.id !== user.id)) {
+      throw new Error(
+        "You cannot join another organization while your current organization has other members. Transfer ownership or remove them first.",
+      );
+    }
+
+    const [appCount, containers] = await Promise.all([
+      appsRepository.countByOrganization(organizationId),
+      containersRepository.listByOrganization(organizationId),
+    ]);
+    const deployedContainers = containers.filter(
+      (container) => container.status !== "deleted" && container.status !== "deleting",
+    );
+    if (appCount > 0 || deployedContainers.length > 0) {
+      throw new Error(
+        "You cannot join another organization while your current organization has deployed apps or agents. Delete them first.",
+      );
+    }
+
+    const organization = await organizationsService.getById(organizationId);
+    if (organization && Number(organization.credit_balance) > getInitialCredits()) {
+      throw new Error(
+        "You cannot join another organization while your current organization holds credits beyond the signup grant. Contact support to transfer them first.",
+      );
+    }
+  }
+
+  /**
+   * After a sole-member owner moved into the inviting org: re-home their
+   * characters and conversations (the org cascade would destroy them), then
+   * delete the now-empty solo org. The accept itself has already committed, so
+   * cleanup failure is logged, never surfaced as a request failure.
+   */
+  private async cleanUpVacatedSoloOrganization(
+    userId: string,
+    previousOrganizationId: string,
+    newOrganizationId: string,
+  ): Promise<void> {
+    try {
+      const remaining = await usersService.listByOrganization(previousOrganizationId);
+      if (remaining.some((member) => member.id !== userId)) {
+        logger.warn("[InvitesService] Vacated org gained a member mid-accept; leaving it in place", {
+          previousOrganizationId,
+          userId,
+        });
+        return;
+      }
+      await userCharactersRepository.reassignUserOrganization(
+        userId,
+        previousOrganizationId,
+        newOrganizationId,
+      );
+      await conversationsRepository.reassignUserOrganization(
+        userId,
+        previousOrganizationId,
+        newOrganizationId,
+      );
+      await organizationsService.delete(previousOrganizationId);
+    } catch (error) {
+      logger.warn("[InvitesService] Failed to clean up vacated solo organization", {
+        previousOrganizationId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async revokeInvite(inviteId: string, organizationId: string): Promise<OrganizationInvite> {

--- a/packages/cloud/shared/src/lib/services/managed-domains.ts
+++ b/packages/cloud/shared/src/lib/services/managed-domains.ts
@@ -12,7 +12,7 @@
  * work, not wrapping a one-line insert.
  */
 
-import { and, eq, isNotNull, lte, or } from "drizzle-orm";
+import { and, eq, isNotNull, lte, or, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import {
   type DomainRegistrantInfo,
@@ -227,6 +227,14 @@ export async function listForOrganization(organizationId: string): Promise<Manag
   });
 }
 
+export async function countForOrganization(organizationId: string): Promise<number> {
+  const [row] = await dbRead
+    .select({ count: sql<number>`count(*)::int` })
+    .from(managedDomains)
+    .where(eq(managedDomains.organizationId, organizationId));
+  return row?.count ?? 0;
+}
+
 export async function listForApp(organizationId: string, appId: string): Promise<ManagedDomain[]> {
   return await dbRead.query.managedDomains.findMany({
     where: and(eq(managedDomains.organizationId, organizationId), eq(managedDomains.appId, appId)),
@@ -418,6 +426,7 @@ export const managedDomainsService = {
   getOwnDomainRow,
   releaseStaleUnverifiedExternals,
   listForOrganization,
+  countForOrganization,
   listForApp,
   listVerifiedAppOrigins,
   listCloudflareRenewalsDue,

--- a/packages/cloud/shared/src/lib/signup-credits.ts
+++ b/packages/cloud/shared/src/lib/signup-credits.ts
@@ -1,0 +1,20 @@
+/**
+ * Signup welcome-credit amount.
+ *
+ * Lives in its own module (not steward-sync.ts) so services that steward-sync
+ * itself imports — e.g. the invites service, which compares a solo org's
+ * balance against the grant (#11332) — can read it without an import cycle.
+ */
+
+export const DEFAULT_INITIAL_CREDITS = 5.0;
+
+export const getInitialCredits = (): number => {
+  const envValue = process.env.INITIAL_FREE_CREDITS;
+  if (envValue) {
+    const parsed = parseFloat(envValue);
+    if (!isNaN(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_INITIAL_CREDITS;
+};

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -11,6 +11,7 @@
 import { organizationInvitesRepository } from "../db/repositories/organization-invites";
 import { usersRepository } from "../db/repositories/users";
 import { getClientIp } from "./runtime/request-context";
+import { getInitialCredits } from "./signup-credits";
 import { apiKeysService } from "./services/api-keys";
 import { charactersService } from "./services/characters/characters";
 import { creditsService } from "./services/credits";
@@ -25,17 +26,7 @@ import { getDefaultElizaCharacterData } from "./utils/default-eliza-character";
 import { getRandomUserAvatar } from "./utils/default-user-avatar";
 import { logger } from "./utils/logger";
 
-export const DEFAULT_INITIAL_CREDITS = 5.0;
-export const getInitialCredits = (): number => {
-  const envValue = process.env.INITIAL_FREE_CREDITS;
-  if (envValue) {
-    const parsed = parseFloat(envValue);
-    if (!isNaN(parsed) && parsed >= 0) {
-      return parsed;
-    }
-  }
-  return DEFAULT_INITIAL_CREDITS;
-};
+export { DEFAULT_INITIAL_CREDITS, getInitialCredits } from "./signup-credits";
 
 const STEWARD_IDENTITY_UNIQUE_CONSTRAINT = "user_identities_steward_user_id_unique";
 


### PR DESCRIPTION
## Problem

Org invites only work for people who have **never** signed up.

Every self-signup provisions the new user as the **owner** of a fresh solo org (`steward-sync.ts`, `session.ts`, and `eliza-app/user-service.ts` all create `role: "owner"`), and `acceptInvite` blanket-rejects owners. So a teammate who already has an Eliza Cloud account can never accept an org invite — the "existing-account invite dead-end" listed as membership bug 2 in #11332.

## Fix — keep the single-org model, allow vacating an *actually empty* solo org

`acceptInvite` now lets an owner accept **iff** their current org is the empty auto-provisioned signup artifact:

- no other members,
- no deployed apps,
- no active app containers (soft-`deleted`/`deleting` containers do not block),
- no retained `agent_sandboxes` rows (shared/dedicated agent state would otherwise cascade-delete without provisioning teardown),
- no `managed_domains` rows (paid/pending domains would otherwise vanish via org cascade),
- credit balance <= the signup grant (`getInitialCredits()`, honors `INITIAL_FREE_CREDITS`).

On permitted accept, the user moves into the inviting org with the invited role, their characters and conversations are re-homed first, and the now-empty solo org is deleted after a final membership re-check. Cleanup failure after the committed accept is logged and does not roll back the accepted invite.

Anything richer keeps the block with actionable 409-class errors.

`getInitialCredits`/`DEFAULT_INITIAL_CREDITS` moved to `lib/signup-credits.ts` and remain re-exported from `steward-sync` so existing imports and the #8427 grant-pin test are untouched.

## Verification

New suite `packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts` runs the real `InvitesService.acceptInvite` against in-process PGlite with real Drizzle SQL for users, organizations, invites, characters, conversations, apps, containers, `agent_sandboxes`, and `managed_domains`. The email singleton is stubbed only because `acceptInvite` never sends mail.

Covered cases:

1. sole-member owner of an empty solo org accepts; invite is accepted; user is moved; character/conversation rows are re-homed; vacated org row is gone; soft-deleted container does not block,
2. owner + another member stays blocked; user/invite/org untouched,
3. owner + deployed app stays blocked,
4. owner + running container stays blocked,
5. owner + live shared `agent_sandboxes` row stays blocked,
6. owner + `managed_domains` row stays blocked,
7. owner + $25 balance (> $5 grant) stays blocked,
8. non-owner member accept keeps working and never deletes the org they leave.

Commands run on rebased branch `4dbbaa66db9` over `origin/develop` `9735115011c`:

```bash
bun test src/lib/services/__tests__/invite-owner-accept.test.ts
# 8 pass, 0 fail, 38 expect() calls

bun test src/lib/services/__tests__/invite-owner-accept.test.ts \
  src/lib/utils/invite-tokens.test.ts src/lib/signup-grant-amount.test.ts \
  src/lib/services/__tests__/credits-deduct-guard.test.ts
# 27 pass, 0 fail, 121 expect() calls

bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/agent-sandboxes.ts \
  packages/cloud/shared/src/lib/services/managed-domains.ts \
  packages/cloud/shared/src/lib/services/invites.ts \
  packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
# clean

bun run --cwd packages/cloud/shared typecheck
# clean

bun run --cwd packages/cloud/api typecheck
# clean
```

`bun run verify` still fails at the repo-wide pre-existing `audit:type-safety-ratchet` gate before package checks: `as unknown as: 80 current > 77 baseline` and core/agent/app-core ``?? {}``: `379 current > 377 baseline`.

N/A screenshots/video: backend service + Worker route only; no UI surface changed. N/A LLM trajectories: no model-backed path touched. Domain artifacts are asserted directly by the PGlite suite (org/user/invite/character/conversation/app/container/agent_sandboxes/managed_domains rows before and after).

Refs #11332
