### PR TITLE
fix(orchestrator): honor TASKS history filters

### DIFF
--- a/.github/issue-evidence/11345-tasks-history-filters.md
+++ b/.github/issue-evidence/11345-tasks-history-filters.md
@@ -1,0 +1,43 @@
+# Issue #11345 - TASKS History Filters
+
+## Change
+
+- `TASKS:history` now validates against the durable task service when ACP is absent, then consumes the advertised `window`, `statuses`, `search`, `limit`, and `includeArchived` parameters.
+- Durable task history uses `OrchestratorTaskService.listTasks()` and applies status/window/search filters before applying `limit`.
+- ACP session history fallback now applies the same supported status/window/search filters.
+- Removed the unused `_inferStatuses`, `_inferWindow`, `_inferSearch`, `_buildWindowFilters`, and `_renderThreadLine` helpers by replacing them with called, parameter-driven helpers.
+
+## Manual Review
+
+- Reviewed the action schema: `search`, `window`, `statuses`, `limit`, and `includeArchived` remain advertised for `action=history`.
+- Reviewed `runHistory`: planner-set filters flow into durable task listing, task DTO filtering, rendered output, and returned `data.filters`.
+- Reviewed ACP fallback: when the durable task service is absent, session history still respects `statuses`, `search`, `window`, and `limit`.
+- No UI, screenshot, video, live LLM trajectory, DB rows, migrations, wallet, or on-chain artifacts apply: this is an action-parameter behavior fix covered by unit tests.
+
+## Verification
+
+Passed:
+
+```bash
+bun run --cwd packages/core prebuild && bun run --cwd packages/core build:node
+bunx vitest run --config vitest.config.ts __tests__/unit/task-history.test.ts --testTimeout 60000
+bunx vitest run --config vitest.config.ts --testTimeout 60000
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+bun run --cwd plugins/plugin-agent-orchestrator build
+bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/actions/tasks.ts plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts --no-errors-on-unmatched
+git diff --check
+```
+
+Focused Vitest result: 1 file passed, 4 tests passed.
+
+Full orchestrator package test result after rebase: 141 files passed, 3 skipped; 1427 tests passed, 6 skipped.
+
+Known unrelated failures observed in this package/repo:
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator lint:check
+bun run verify
+```
+
+- Package-wide `lint:check` is currently blocked by pre-existing unrelated Biome findings outside the changed files.
+- Root `bun run verify` is currently blocked at the repo type-safety ratchet baseline (`as unknown as` 80 > 77, `?? {}` 379 > 377). The changed files are not listed in the ratchet output.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-history.test.ts
@@ -1,0 +1,216 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { taskHistoryAction } from "../../src/actions/tasks.js";
+import type { TaskThreadDto } from "../../src/services/orchestrator-task-mapper.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import {
+  callback,
+  memory,
+  serviceMock,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+function task(overrides: Partial<TaskThreadDto>): TaskThreadDto {
+  const now = Date.now();
+  return {
+    id: "task-1",
+    title: "Ship feature",
+    kind: "coding",
+    status: "active",
+    priority: "normal",
+    paused: false,
+    originalRequest: "Ship feature",
+    sessionCount: 1,
+    activeSessionCount: 1,
+    latestSessionId: "session-1",
+    latestSessionLabel: "agent-one",
+    latestWorkdir: "/repo",
+    latestRepo: null,
+    latestActivityAt: now,
+    decisionCount: 0,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      state: "unavailable",
+      byProvider: [],
+    },
+    createdAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    closedAt: null,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+function runtimeWithServices(opts: {
+  taskService?: unknown;
+  acpService?: unknown;
+}): IAgentRuntime {
+  return {
+    getService: vi.fn((serviceType: string) =>
+      serviceType === OrchestratorTaskService.serviceType
+        ? (opts.taskService ?? null)
+        : (opts.acpService ?? null),
+    ),
+    hasService: vi.fn(() => Boolean(opts.taskService ?? opts.acpService)),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never;
+}
+
+describe("TASKS:history", () => {
+  it("validates history when the durable task service is available without ACP", async () => {
+    const taskService = { listTasks: vi.fn(async () => []) };
+    const runtime = runtimeWithServices({ taskService });
+
+    await expect(
+      taskHistoryAction.validate(runtime, memory({ action: "history" })),
+    ).resolves.toBe(true);
+    await expect(
+      taskHistoryAction.validate(runtime, memory({ action: "create" })),
+    ).resolves.toBe(false);
+  });
+
+  it("honors planner-provided status and search filters against durable task threads", async () => {
+    const tasks = [
+      task({ id: "task-active", title: "Login flow", status: "active" }),
+      task({ id: "task-done", title: "Billing cleanup", status: "done" }),
+      task({ id: "task-blocked", title: "Billing gateway", status: "blocked" }),
+      task({
+        id: "task-blocked-auth",
+        title: "Auth gateway",
+        status: "blocked",
+      }),
+    ];
+    const taskService = { listTasks: vi.fn(async () => tasks) };
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ taskService }),
+      memory({ text: "show blocked billing tasks" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          metric: "list",
+          statuses: ["blocked"],
+          search: "billing",
+        },
+      },
+      callback(),
+    );
+
+    expect(taskService.listTasks).toHaveBeenCalledWith({
+      includeArchived: false,
+      search: "billing",
+    });
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain("Billing gateway [blocked]");
+    expect(result?.text).not.toContain("Billing cleanup");
+    expect(result?.text).not.toContain("Auth gateway");
+    expect(result?.data?.taskIds).toEqual(["task-blocked"]);
+    expect(result?.data?.filters).toMatchObject({
+      statuses: ["blocked"],
+      search: "billing",
+      includeArchived: false,
+    });
+  });
+
+  it("applies the active window before the requested result limit", async () => {
+    const tasks = [
+      task({ id: "task-active", title: "Active task", status: "active" }),
+      task({ id: "task-open", title: "Open task", status: "open" }),
+      task({ id: "task-done", title: "Done task", status: "done" }),
+    ];
+    const taskService = { listTasks: vi.fn(async () => tasks) };
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ taskService }),
+      memory({ text: "active task history" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          metric: "list",
+          window: "active",
+          limit: 1,
+        },
+      },
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain("I found 2 orchestrator tasks");
+    expect(result?.text).toContain("Active task [active]");
+    expect(result?.text).not.toContain("Open task");
+    expect(result?.data?.count).toBe(2);
+    expect(result?.data?.taskIds).toEqual(["task-active"]);
+    expect(result?.data?.filters).toMatchObject({
+      window: "active",
+      limit: 1,
+    });
+  });
+
+  it("falls back to ACP session history when the durable task service is absent", async () => {
+    const acpService = serviceMock({
+      listSessions: vi.fn(() => [
+        {
+          id: "session-a",
+          name: "agent-a",
+          agentType: "codex",
+          workdir: "/repo/a",
+          status: "ready",
+          approvalPreset: "standard",
+          createdAt: new Date("2026-05-03T10:00:00.000Z"),
+          lastActivityAt: new Date("2026-05-03T10:00:00.000Z"),
+          metadata: { label: "billing" },
+        },
+        {
+          id: "session-b",
+          name: "agent-b",
+          agentType: "codex",
+          workdir: "/repo/b",
+          status: "errored",
+          approvalPreset: "standard",
+          createdAt: new Date("2026-05-03T10:00:00.000Z"),
+          lastActivityAt: new Date("2026-05-03T10:00:00.000Z"),
+          metadata: { label: "other" },
+        },
+        {
+          id: "session-c",
+          name: "agent-c",
+          agentType: "codex",
+          workdir: "/repo/c",
+          status: "errored",
+          approvalPreset: "standard",
+          createdAt: new Date("2026-05-03T10:00:00.000Z"),
+          lastActivityAt: new Date("2026-05-03T10:00:00.000Z"),
+          metadata: { label: "billing" },
+        },
+      ]),
+    });
+
+    const result = await taskHistoryAction.handler(
+      runtimeWithServices({ acpService }),
+      memory({ text: "show active billing sessions" }),
+      state,
+      {
+        parameters: {
+          action: "history",
+          metric: "list",
+          window: "active",
+          search: "billing",
+        },
+      },
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain("billing");
+    expect(result?.text).not.toContain("session-b");
+    expect(result?.text).not.toContain("session-c");
+    expect(result?.data?.sessionIds).toEqual(["session-a"]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -40,11 +40,13 @@ import type {
 import { ChannelType, logger as coreLogger, stringToUuid } from "@elizaos/core";
 import type { IssueInfo, PullRequestInfo } from "git-workspace-service";
 import {
-  type OrchestratorTaskType,
   detectTaskType,
+  type OrchestratorTaskType,
 } from "../services/acceptance-criteria.js";
 import { augmentTaskWithDeployGuidance } from "../services/app-deploy-guidance.js";
+import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
+import type { OrchestratorTaskStatus } from "../services/orchestrator-task-types.js";
 import { normalizeRepositoryInput } from "../services/repo-input.js";
 import {
   runDurableTask,
@@ -56,7 +58,12 @@ import {
   resolveSpawnWorkdir,
 } from "../services/task-agent-routing.js";
 import { requireTaskAgentAccess } from "../services/task-policy.js";
-import type { AgentType, SpawnResult } from "../services/types.js";
+import {
+  type AgentType,
+  type SessionInfo,
+  type SpawnResult,
+  TERMINAL_SESSION_STATUSES,
+} from "../services/types.js";
 import type {
   AuthPromptCallback,
   CodingWorkspaceService,
@@ -145,6 +152,28 @@ type HistoryWindow =
   | "yesterday"
   | "last_7_days"
   | "last_30_days";
+
+const TASK_HISTORY_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set([
+  "open",
+  "active",
+  "waiting_on_user",
+  "blocked",
+  "validating",
+  "done",
+  "failed",
+  "archived",
+  "interrupted",
+]);
+
+const ACTIVE_TASK_HISTORY_STATUSES: ReadonlySet<OrchestratorTaskStatus> =
+  new Set([
+    "open",
+    "active",
+    "waiting_on_user",
+    "blocked",
+    "validating",
+    "interrupted",
+  ]);
 
 function startOfDay(date: Date): Date {
   const start = new Date(date);
@@ -521,9 +550,8 @@ function taskWithResolvedRoute(
 
 // Specialized (non-default) task types detectTaskType only returns for
 // unambiguous build/deploy/view signals — a bare personal to-do never trips them.
-const SPECIALIZED_CODING_TASK_TYPES: ReadonlySet<OrchestratorTaskType> = new Set(
-  ["view-create", "app-build", "deploy"],
-);
+const SPECIALIZED_CODING_TASK_TYPES: ReadonlySet<OrchestratorTaskType> =
+  new Set(["view-create", "app-build", "deploy"]);
 
 function looksLikePersonalLifeOpsTask(text: string): boolean {
   if (
@@ -1634,39 +1662,17 @@ function inferMetric(text: string, value?: string): HistoryMetric {
     return normalized;
   }
   if (/\bhow many\b|\bcount\b/i.test(text)) return "count";
+  if (/\bdetail\b|\bdetails\b|\bmost recent\b|\blatest\b/i.test(text)) {
+    return "detail";
+  }
   if (/\bshow me\b|\bgive me\b|\blist\b|\bwhat are\b/i.test(text))
     return "list";
-  return "detail";
+  return "list";
 }
 
-function _inferStatuses(
-  text: string,
-  rawStatuses?: string[],
-): string[] | undefined {
-  if (rawStatuses && rawStatuses.length > 0) {
-    return rawStatuses;
-  }
-  const statuses = new Set<string>();
-  if (/\bactive\b|\bright now\b|\bworking on right now\b/i.test(text)) {
-    statuses.add("active");
-  }
-  if (/\bblocked\b/i.test(text)) {
-    statuses.add("blocked");
-  }
-  if (/\binterrupted\b|\bpaused\b/i.test(text)) {
-    statuses.add("interrupted");
-  }
-  if (/\bdone\b|\bcompleted\b|\bfinished\b/i.test(text)) {
-    statuses.add("done");
-  }
-  if (/\bfailed\b|\berror\b/i.test(text)) {
-    statuses.add("failed");
-  }
-  return statuses.size > 0 ? Array.from(statuses) : undefined;
-}
-
-function _inferWindow(text: string, raw?: string): HistoryWindow | undefined {
-  const normalized = raw?.trim().toLowerCase();
+function historyWindowValue(value: unknown): HistoryWindow | undefined {
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : undefined;
   if (
     normalized === "active" ||
     normalized === "today" ||
@@ -1676,37 +1682,61 @@ function _inferWindow(text: string, raw?: string): HistoryWindow | undefined {
   ) {
     return normalized;
   }
-  if (/\bright now\b|\bcurrently\b|\bactive\b/i.test(text)) return "active";
-  if (/\byesterday\b/i.test(text)) return "yesterday";
-  if (/\blast week\b|\blast 7 days\b|\bin the last week\b/i.test(text)) {
-    return "last_7_days";
-  }
-  if (/\blast month\b|\blast 30 days\b/i.test(text)) return "last_30_days";
-  if (/\btoday\b/i.test(text)) return "today";
   return undefined;
 }
 
-function _inferSearch(text: string, raw?: string): string | undefined {
-  if (raw?.trim()) return raw.trim();
-  const quoted =
-    text.match(/"([^"]{3,120})"/)?.[1] ?? text.match(/'([^']{3,120})'/)?.[1];
-  if (quoted) return quoted.trim();
-  const topical =
-    text.match(/\bworking on\s+(.+?)(?:[?.!,]|$)/i)?.[1] ??
-    text.match(
-      /\ball tasks where we were working on\s+(.+?)(?:[?.!,]|$)/i,
-    )?.[1];
-  return topical?.trim();
+function normalizeHistoryStatus(
+  value: string,
+): OrchestratorTaskStatus | undefined {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (normalized === "all") return undefined;
+  if (normalized === "complete" || normalized === "completed") return "done";
+  if (
+    normalized === "error" ||
+    normalized === "errored" ||
+    normalized === "failure"
+  ) {
+    return "failed";
+  }
+  if (normalized === "paused" || normalized === "interrupted") {
+    return "interrupted";
+  }
+  if (TASK_HISTORY_STATUSES.has(normalized as OrchestratorTaskStatus)) {
+    return normalized as OrchestratorTaskStatus;
+  }
+  return undefined;
 }
 
-function _buildWindowFilters(window: HistoryWindow | undefined): {
+function historyStatusesValue(value: unknown): OrchestratorTaskStatus[] {
+  const raw = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+  const statuses = new Set<OrchestratorTaskStatus>();
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    const status = normalizeHistoryStatus(item);
+    if (status) statuses.add(status);
+  }
+  return Array.from(statuses);
+}
+
+function buildWindowFilters(window: HistoryWindow | undefined): {
   latestActivityAfter?: number;
   latestActivityBefore?: number;
+  statuses?: ReadonlySet<OrchestratorTaskStatus>;
   label?: string;
 } {
   const now = new Date();
   if (window === "active") {
-    return { label: "active tasks right now" };
+    return {
+      statuses: ACTIVE_TASK_HISTORY_STATUSES,
+      label: "active tasks right now",
+    };
   }
   if (window === "today") {
     const start = startOfDay(now);
@@ -1747,17 +1777,121 @@ function _buildWindowFilters(window: HistoryWindow | undefined): {
   return {};
 }
 
-function _renderThreadLine(entry: {
-  title: string;
-  status: string;
-  latestActivityAt?: number | null;
-  summary?: string;
-}): string {
+function renderThreadLine(entry: TaskThreadDto): string {
   const activity =
     typeof entry.latestActivityAt === "number"
-      ? new Date(entry.latestActivityAt).toLocaleString("en-US")
+      ? dateString(entry.latestActivityAt)
       : "unknown time";
-  return `- ${entry.title} [${entry.status}] (${activity})${entry.summary ? `: ${entry.summary}` : ""}`;
+  const session = entry.latestSessionLabel
+    ? ` via ${entry.latestSessionLabel}`
+    : entry.latestSessionId
+      ? ` via ${entry.latestSessionId}`
+      : "";
+  return `- ${entry.title} [${entry.status}] (${activity})${session}${entry.summary ? `: ${entry.summary}` : ""}`;
+}
+
+function taskMatchesHistoryFilters(
+  task: TaskThreadDto,
+  statuses: readonly OrchestratorTaskStatus[],
+  windowFilters: ReturnType<typeof buildWindowFilters>,
+  search: string | undefined,
+): boolean {
+  if (statuses.length > 0 && !statuses.includes(task.status)) return false;
+  if (windowFilters.statuses && !windowFilters.statuses.has(task.status)) {
+    return false;
+  }
+  if (search && !taskMatchesSearch(task, search)) return false;
+  const latest = task.latestActivityAt ?? Date.parse(task.updatedAt);
+  if (windowFilters.latestActivityAfter !== undefined) {
+    if (
+      !Number.isFinite(latest) ||
+      latest < windowFilters.latestActivityAfter
+    ) {
+      return false;
+    }
+  }
+  if (windowFilters.latestActivityBefore !== undefined) {
+    if (
+      !Number.isFinite(latest) ||
+      latest > windowFilters.latestActivityBefore
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function taskMatchesSearch(task: TaskThreadDto, search: string): boolean {
+  const needle = search.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = [
+    task.id,
+    task.title,
+    task.originalRequest,
+    task.summary,
+    task.latestSessionId,
+    task.latestSessionLabel,
+    task.latestWorkdir,
+    task.latestRepo,
+    task.kind,
+  ]
+    .filter((part): part is string => typeof part === "string")
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+function sessionMatchesHistoryFilters(
+  session: SessionInfo,
+  statuses: readonly OrchestratorTaskStatus[],
+  windowFilters: ReturnType<typeof buildWindowFilters>,
+  search: string | undefined,
+): boolean {
+  if (
+    statuses.length > 0 &&
+    !statuses.some((status) => sessionMatchesTaskStatus(session.status, status))
+  ) {
+    return false;
+  }
+  if (
+    windowFilters.statuses &&
+    !Array.from(windowFilters.statuses).some((status) =>
+      sessionMatchesTaskStatus(session.status, status),
+    )
+  ) {
+    return false;
+  }
+  if (search) {
+    const haystack =
+      `${session.id} ${session.name ?? ""} ${session.metadata?.label ?? ""} ${session.agentType} ${session.workdir}`.toLowerCase();
+    if (!haystack.includes(search.toLowerCase())) return false;
+  }
+  const latest = session.lastActivityAt.getTime();
+  if (windowFilters.latestActivityAfter !== undefined) {
+    if (latest < windowFilters.latestActivityAfter) return false;
+  }
+  if (windowFilters.latestActivityBefore !== undefined) {
+    if (latest > windowFilters.latestActivityBefore) return false;
+  }
+  return true;
+}
+
+function sessionMatchesTaskStatus(
+  sessionStatus: string,
+  taskStatus: OrchestratorTaskStatus,
+): boolean {
+  const status = sessionStatus.toLowerCase();
+  if (taskStatus === "active" || taskStatus === "open") {
+    return !TERMINAL_SESSION_STATUSES.has(status);
+  }
+  if (taskStatus === "blocked") return status === "blocked";
+  if (taskStatus === "done") {
+    return status === "completed" || status === "stopped";
+  }
+  if (taskStatus === "failed")
+    return status === "error" || status === "errored";
+  if (taskStatus === "interrupted") return status === "cancelled";
+  return status === taskStatus;
 }
 
 function failureResult(
@@ -1804,6 +1938,86 @@ async function runHistory(
   );
   const limit =
     Number.isFinite(limitRaw) && limitRaw > 0 ? Math.trunc(limitRaw) : 10;
+  const window = historyWindowValue(params.window ?? content.window);
+  const statuses = historyStatusesValue(params.statuses ?? content.statuses);
+  const search = textValue(params.search) ?? textValue(content.search);
+  const includeArchived =
+    pickBoolean(params, content, "includeArchived") ?? false;
+  const windowFilters = buildWindowFilters(window);
+  const taskService = runtime.getService?.(
+    OrchestratorTaskService.serviceType,
+  ) as OrchestratorTaskService | null | undefined;
+  if (taskService && typeof taskService.listTasks === "function") {
+    try {
+      const allTasks = (
+        await taskService.listTasks({
+          includeArchived,
+          ...(search ? { search } : {}),
+        })
+      ).filter((task) =>
+        taskMatchesHistoryFilters(task, statuses, windowFilters, search),
+      );
+      const count = allTasks.length;
+      const tasks = allTasks.slice(0, limit);
+      const filterParts = [
+        windowFilters.label ? `window ${windowFilters.label}` : undefined,
+        statuses.length > 0 ? `statuses ${statuses.join(", ")}` : undefined,
+        search ? `search "${search}"` : undefined,
+        includeArchived ? "including archived" : undefined,
+      ].filter((part): part is string => Boolean(part));
+      const filterSuffix =
+        filterParts.length > 0 ? ` matching ${filterParts.join("; ")}` : "";
+
+      let responseText = "";
+      if (metric === "count") {
+        responseText = `I found ${count} orchestrator task${count === 1 ? "" : "s"}${filterSuffix}.`;
+      } else if (tasks.length === 0) {
+        responseText = `I did not find any orchestrator task threads${filterSuffix}.`;
+      } else if (metric === "detail") {
+        const task = tasks[0];
+        responseText = [
+          `The most recent orchestrator task is "${task.title}" [${task.status}].`,
+          `Task id: ${task.id}`,
+          `Latest session: ${task.latestSessionLabel ?? task.latestSessionId ?? "none"}`,
+          `Workspace: ${task.latestWorkdir ?? "none"}`,
+          `Latest activity: ${task.latestActivityAt ? dateString(task.latestActivityAt) : "unknown"}`,
+          task.summary ? `Summary: ${task.summary}` : undefined,
+        ]
+          .filter(Boolean)
+          .join("\n");
+      } else {
+        responseText = [
+          `I found ${count} orchestrator task${count === 1 ? "" : "s"}${filterSuffix}.`,
+          ...tasks.map(renderThreadLine),
+        ].join("\n");
+      }
+
+      if (callback) await callback({ text: responseText });
+      return {
+        success: true,
+        text: responseText,
+        data: {
+          actionName: "TASKS:history",
+          count,
+          taskIds: tasks.map((task) => task.id),
+          filters: {
+            metric,
+            ...(window ? { window } : {}),
+            ...(statuses.length > 0 ? { statuses } : {}),
+            ...(search ? { search } : {}),
+            includeArchived,
+            limit,
+          },
+        },
+      };
+    } catch (error) {
+      const msg = failureMessage(error);
+      if (callback)
+        await callback({ text: `Failed to read task history: ${msg}` });
+      return failureResult("TASKS:history", "TASK_HISTORY_FAILED", msg);
+    }
+  }
+
   const service = getAcpService(runtime);
   if (!service) {
     const msg = "ACP service is not available.";
@@ -1812,7 +2026,11 @@ async function runHistory(
       reason: "acp_unavailable",
     });
   }
-  const sessions = (await listSessionsWithin(service, 2000)).slice(0, limit);
+  const sessions = (await listSessionsWithin(service, 2000))
+    .filter((session) =>
+      sessionMatchesHistoryFilters(session, statuses, windowFilters, search),
+    )
+    .slice(0, limit);
   const count = sessions.length;
 
   let responseText = "";
@@ -3352,21 +3570,31 @@ export const tasksAction: Action & {
     },
   ],
   validate: async (runtime, message) => {
+    const content = contentRecord(message);
     // Always allow when ACP service is available — action switch handles dispatch.
-    if (!getAcpService(runtime)) return false;
+    if (!getAcpService(runtime)) {
+      const taskService = runtime.getService?.(
+        OrchestratorTaskService.serviceType,
+      ) as OrchestratorTaskService | null | undefined;
+      return (
+        readOp(content) === "history" &&
+        typeof taskService?.listTasks === "function"
+      );
+    }
     // Sub-agent task_complete events are routed back through the runtime as
     // synthetic inbound messages. Most verified completions are handled by
     // the response evaluator, but incomplete completions still need the TASKS
     // surface so the parent can send a follow-up to the same session instead
     // of asking the user to paste command output.
-    const content = message.content as {
+    const messageContent = message.content as {
       metadata?: unknown;
       source?: unknown;
     };
-    if (content.source === "sub_agent") {
+    if (messageContent.source === "sub_agent") {
       const metadata =
-        content.metadata !== null && typeof content.metadata === "object"
-          ? (content.metadata as Record<string, unknown>)
+        messageContent.metadata !== null &&
+        typeof messageContent.metadata === "object"
+          ? (messageContent.metadata as Record<string, unknown>)
           : undefined;
       return (
         metadata?.subAgent === true &&


### PR DESCRIPTION
## Summary
- make `TASKS:history` validate against the durable task service even when ACP is absent
- honor the advertised `window`, `statuses`, `search`, `limit`, and `includeArchived` params for durable task history
- apply supported history filters to the ACP session fallback and remove the unused `_infer*` / parked history helpers
- add focused unit coverage for durable task filtering, active-window-before-limit, validation, and ACP fallback filtering

Closes #11345

## Evidence
- `.github/issue-evidence/11345-tasks-history-filters.md`

## Verification
- `bun run --cwd packages/core prebuild && bun run --cwd packages/core build:node`
- `bunx vitest run --config vitest.config.ts __tests__/unit/task-history.test.ts --testTimeout 60000` (1 file, 4 tests passed)
- `bunx vitest run --config vitest.config.ts --testTimeout 60000` (141 files passed, 3 skipped; 1427 tests passed, 6 skipped)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- `bun run --cwd plugins/plugin-agent-orchestrator build`
- changed-file Biome check listed in evidence

Known unrelated failures:
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` fails on existing package-wide Biome issues outside this change. Changed files pass Biome directly.
- `bun run verify` fails before Turbo at the repo type-safety ratchet baseline (`as unknown as` 80 > 77, `?? {}` 379 > 377); changed files are not listed.

## UI / live artifacts
N/A - action-parameter behavior fix only. No app UI, screenshot, video, audio, live LLM trajectory, DB, wallet, or on-chain artifacts apply.