### PR TITLE
chore(cloud): dedupe domains-route guards + drop dead exports (no behavior change)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -7,14 +7,11 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
-import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import { loadCloudflareManagedDomain } from "../../../guards";
 
 const RecordTypes = ["A", "AAAA", "CNAME", "TXT", "MX", "SRV", "CAA"] as const;
 
@@ -34,40 +31,17 @@ const PatchRecordSchema = z
 
 const app = new Hono<AppEnv>();
 
-async function loadCloudflareManagedDomain(c: AppContext) {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const appId = c.req.param("id");
-  const domainParam = c.req.param("domain");
+async function loadDnsRecordContext(c: AppContext) {
+  const ctx = await loadCloudflareManagedDomain(c);
+  if ("error" in ctx) return ctx;
   const recordId = c.req.param("recordId");
-  if (!appId || !domainParam || !recordId) {
-    return { error: "missing path params", status: 400 as const };
-  }
-
-  const appRow = await appsService.getById(appId);
-  if (!appRow || appRow.organization_id !== user.organization_id) {
-    return { error: "App not found", status: 404 as const };
-  }
-  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-    return { error: "Access denied", status: 403 as const };
-  }
-
-  const md = await managedDomainsService.getOwnDomainRow(user.organization_id, decodeURIComponent(domainParam));
-  if (!md || md.organizationId !== user.organization_id || md.appId !== appId) {
-    return { error: "Domain not attached to this app", status: 404 as const };
-  }
-  if (md.registrar !== "cloudflare" || !md.cloudflareZoneId) {
-    return {
-      error:
-        "DNS records on external domains must be edited at your existing DNS provider",
-      status: 409 as const,
-    };
-  }
-  return { user, appId, domain: md, recordId };
+  if (!recordId) return { error: "missing path params", status: 400 as const };
+  return { ...ctx, recordId };
 }
 
 app.get("/", async (c) => {
   try {
-    const ctx = await loadCloudflareManagedDomain(c);
+    const ctx = await loadDnsRecordContext(c);
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
@@ -86,7 +60,7 @@ app.get("/", async (c) => {
 
 app.patch("/", async (c) => {
   try {
-    const ctx = await loadCloudflareManagedDomain(c);
+    const ctx = await loadDnsRecordContext(c);
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 
@@ -122,7 +96,7 @@ app.patch("/", async (c) => {
 
 app.delete("/", async (c) => {
   try {
-    const ctx = await loadCloudflareManagedDomain(c);
+    const ctx = await loadDnsRecordContext(c);
     if ("error" in ctx)
       return c.json({ success: false, error: ctx.error }, ctx.status);
 

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
@@ -10,14 +10,11 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
-import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
-import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadCloudflareManagedDomain } from "../../guards";
 
 const RecordTypes = ["A", "AAAA", "CNAME", "TXT", "MX", "SRV", "CAA"] as const;
 
@@ -31,35 +28,6 @@ const CreateRecordSchema = z.object({
 });
 
 const app = new Hono<AppEnv>();
-
-async function loadCloudflareManagedDomain(c: AppContext) {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const appId = c.req.param("id");
-  const domainParam = c.req.param("domain");
-  if (!appId || !domainParam)
-    return { error: "missing path params", status: 400 as const };
-
-  const appRow = await appsService.getById(appId);
-  if (!appRow || appRow.organization_id !== user.organization_id) {
-    return { error: "App not found", status: 404 as const };
-  }
-  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-    return { error: "Access denied", status: 403 as const };
-  }
-
-  const md = await managedDomainsService.getOwnDomainRow(user.organization_id, decodeURIComponent(domainParam));
-  if (!md || md.organizationId !== user.organization_id || md.appId !== appId) {
-    return { error: "Domain not attached to this app", status: 404 as const };
-  }
-  if (md.registrar !== "cloudflare" || !md.cloudflareZoneId) {
-    return {
-      error:
-        "DNS records on external domains must be edited at your existing DNS provider",
-      status: 409 as const,
-    };
-  }
-  return { user, app: appRow, appId, domain: md };
-}
 
 app.get("/", async (c) => {
   try {

--- a/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
@@ -7,30 +7,20 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { computeDomainPrice } from "@/lib/services/domain-pricing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadOwnedApp } from "../guards";
 import { domainBodySchema as CheckSchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const appId = c.req.param("id");
-    if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
-
-    const appRow = await appsService.getById(appId);
-    if (!appRow || appRow.organization_id !== user.organization_id) {
-      return c.json({ success: false, error: "App not found" }, 404);
-    }
-    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-      return c.json({ success: false, error: "Access denied" }, 403);
-    }
+    const ctx = await loadOwnedApp(c);
+    if ("error" in ctx)
+      return c.json({ success: false, error: ctx.error }, ctx.status);
 
     const parsed = CheckSchema.safeParse(await c.req.json());
     if (!parsed.success) {

--- a/packages/cloud/api/v1/apps/[id]/domains/guards.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/guards.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared request guards for the `/apps/:id/domains/*` route family.
+ *
+ * Every domains route authenticates the caller, loads the app, and enforces
+ * org ownership + app-scoped-key scope identically; the DNS routes further
+ * require the domain to be attached to the app and cloudflare-managed. One
+ * implementation keeps the acceptance criteria identical across list/attach/
+ * detach, check, sync, status, verify and the dns record routes.
+ *
+ * (The buy route keeps its own guard on purpose: it parses the body before
+ * the app lookup and returns 403 — not 404 — on a cross-org app.)
+ */
+
+import type { ManagedDomain } from "@/db/schemas/managed-domains";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
+import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { type App, appsService } from "@/lib/services/apps";
+import { managedDomainsService } from "@/lib/services/managed-domains";
+import type { AppContext } from "@/types/cloud-worker-env";
+
+/**
+ * Explicit result shapes (instead of inferred literal unions) so `"error" in
+ * ctx` narrowing keeps working across the module boundary at every call site.
+ */
+type GuardFailure = { error: string; status: 400 | 403 | 404 | 409 };
+type OwnedAppContext = {
+  user: Awaited<ReturnType<typeof requireUserOrApiKeyWithOrg>>;
+  app: App;
+  appId: string;
+};
+
+export async function loadOwnedApp(
+  c: AppContext,
+): Promise<GuardFailure | OwnedAppContext> {
+  const user = await requireUserOrApiKeyWithOrg(c);
+  const appId = c.req.param("id");
+  if (!appId) return { error: "missing path params", status: 400 as const };
+  const appRow = await appsService.getById(appId);
+  if (!appRow || appRow.organization_id !== user.organization_id) {
+    return { error: "App not found", status: 404 as const };
+  }
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+    return { error: "Access denied", status: 403 as const };
+  }
+  return { user, app: appRow, appId };
+}
+
+/**
+ * loadOwnedApp + the `:domain` path param resolved to the caller org's own
+ * managed-domains row, gated to cloudflare-registered domains (external
+ * domains are DNS-managed at the user's own provider).
+ */
+export async function loadCloudflareManagedDomain(
+  c: AppContext,
+): Promise<GuardFailure | (OwnedAppContext & { domain: ManagedDomain })> {
+  const base = await loadOwnedApp(c);
+  if ("error" in base) return base;
+
+  const domainParam = c.req.param("domain");
+  if (!domainParam)
+    return { error: "missing path params", status: 400 as const };
+
+  // getOwnDomainRow is already scoped to the caller's organization.
+  const md = await managedDomainsService.getOwnDomainRow(
+    base.user.organization_id,
+    decodeURIComponent(domainParam),
+  );
+  if (!md || md.appId !== base.appId) {
+    return { error: "Domain not attached to this app", status: 404 as const };
+  }
+  if (md.registrar !== "cloudflare" || !md.cloudflareZoneId) {
+    return {
+      error:
+        "DNS records on external domains must be edited at your existing DNS provider",
+      status: 409 as const,
+    };
+  }
+  return { ...base, domain: md };
+}

--- a/packages/cloud/api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/route.ts
@@ -11,31 +11,15 @@
 import crypto from "node:crypto";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
-import { appsService } from "@/lib/services/apps";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
-import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadOwnedApp } from "./guards";
 import { domainBodySchema as DomainSchema } from "./schemas";
 
 const app = new Hono<AppEnv>();
-
-async function loadOwnedApp(c: AppContext) {
-  const user = await requireUserOrApiKeyWithOrg(c);
-  const appId = c.req.param("id");
-  if (!appId) return { error: "missing path params", status: 400 as const };
-  const appRow = await appsService.getById(appId);
-  if (!appRow || appRow.organization_id !== user.organization_id) {
-    return { error: "App not found", status: 404 as const };
-  }
-  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-    return { error: "Access denied", status: 403 as const };
-  }
-  return { user, app: appRow, appId };
-}
 
 app.get("/", async (c) => {
   try {
@@ -182,15 +166,12 @@ app.delete("/", async (c) => {
     }
     const { domain } = parsed.data;
 
+    // getOwnDomainRow is already scoped to the caller's organization.
     const md = await managedDomainsService.getOwnDomainRow(
       ctx.user.organization_id,
       domain,
     );
-    if (
-      !md ||
-      md.organizationId !== ctx.user.organization_id ||
-      md.appId !== ctx.appId
-    ) {
+    if (!md || md.appId !== ctx.appId) {
       return c.json(
         { success: false, error: "Domain not attached to this app" },
         404,

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -7,29 +7,20 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadOwnedApp } from "../guards";
 import { domainBodySchema as StatusSchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const appId = c.req.param("id");
-    if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
-
-    const appRow = await appsService.getById(appId);
-    if (!appRow || appRow.organization_id !== user.organization_id) {
-      return c.json({ success: false, error: "App not found" }, 404);
-    }
-    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-      return c.json({ success: false, error: "Access denied" }, 403);
-    }
+    const ctx = await loadOwnedApp(c);
+    if ("error" in ctx)
+      return c.json({ success: false, error: ctx.error }, ctx.status);
+    const { user, appId } = ctx;
 
     const parsed = StatusSchema.safeParse(await c.req.json());
     if (!parsed.success) {
@@ -42,12 +33,12 @@ app.post("/", async (c) => {
       );
     }
 
-    const md = await managedDomainsService.getOwnDomainRow(user.organization_id, parsed.data.domain);
-    if (
-      !md ||
-      md.organizationId !== user.organization_id ||
-      md.appId !== appId
-    ) {
+    // getOwnDomainRow is already scoped to the caller's organization.
+    const md = await managedDomainsService.getOwnDomainRow(
+      user.organization_id,
+      parsed.data.domain,
+    );
+    if (!md || md.appId !== appId) {
       return c.json(
         { success: false, error: "Domain not attached to this app" },
         404,

--- a/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
@@ -8,30 +8,21 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadOwnedApp } from "../guards";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const appId = c.req.param("id");
-    if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
-
-    const appRow = await appsService.getById(appId);
-    if (!appRow || appRow.organization_id !== user.organization_id) {
-      return c.json({ success: false, error: "App not found" }, 404);
-    }
-    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-      return c.json({ success: false, error: "Access denied" }, 403);
-    }
+    const ctx = await loadOwnedApp(c);
+    if ("error" in ctx)
+      return c.json({ success: false, error: ctx.error }, ctx.status);
+    const { user, appId } = ctx;
 
     const domains = await managedDomainsService.listForApp(
       user.organization_id,

--- a/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
@@ -12,30 +12,21 @@
 import { promises as dns } from "node:dns";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { appsService } from "@/lib/services/apps";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { extractErrorMessage } from "@/lib/utils/error-handling";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { loadOwnedApp } from "../guards";
 import { domainBodySchema as VerifySchema } from "../schemas";
 
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const appId = c.req.param("id");
-    if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
-
-    const appRow = await appsService.getById(appId);
-    if (!appRow || appRow.organization_id !== user.organization_id) {
-      return c.json({ success: false, error: "App not found" }, 404);
-    }
-    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
-      return c.json({ success: false, error: "Access denied" }, 403);
-    }
+    const ctx = await loadOwnedApp(c);
+    if ("error" in ctx)
+      return c.json({ success: false, error: ctx.error }, ctx.status);
+    const { user, appId } = ctx;
 
     const parsed = VerifySchema.safeParse(await c.req.json());
     if (!parsed.success) {
@@ -48,12 +39,12 @@ app.post("/", async (c) => {
       );
     }
 
-    const md = await managedDomainsService.getOwnDomainRow(user.organization_id, parsed.data.domain);
-    if (
-      !md ||
-      md.organizationId !== user.organization_id ||
-      md.appId !== appId
-    ) {
+    // getOwnDomainRow is already scoped to the caller's organization.
+    const md = await managedDomainsService.getOwnDomainRow(
+      user.organization_id,
+      parsed.data.domain,
+    );
+    if (!md || md.appId !== appId) {
       return c.json(
         { success: false, error: "Domain not attached to this app" },
         404,

--- a/packages/cloud/shared/src/lib/services/managed-domains.ts
+++ b/packages/cloud/shared/src/lib/services/managed-domains.ts
@@ -22,17 +22,6 @@ import {
 } from "../../db/schemas/managed-domains";
 import { logger } from "../utils/logger";
 
-export interface InsertCloudflareDomainInput {
-  organizationId: string;
-  domain: string;
-  cloudflareZoneId: string;
-  cloudflareRegistrationId: string;
-  purchasePriceCents: number;
-  renewalPriceCents: number;
-  expiresAt: Date | null;
-  registrantInfo: DomainRegistrantInfo | null;
-}
-
 export interface UpsertCloudflareDomainInput {
   organizationId: string;
   domain: string;
@@ -45,46 +34,6 @@ export interface UpsertCloudflareDomainInput {
   status?: ManagedDomain["status"];
   verified?: boolean;
   autoRenew?: boolean;
-}
-
-/**
- * Insert a freshly-registered cloudflare domain. Sets registrar='cloudflare',
- * nameserver_mode='cloudflare' (cloudflare manages our DNS too), and
- * status='active' since cloudflare register-status was already polled to
- * active before this call.
- */
-export async function insertCloudflareRegisteredDomain(
-  input: InsertCloudflareDomainInput,
-): Promise<ManagedDomain> {
-  const row: NewManagedDomain = {
-    organizationId: input.organizationId,
-    domain: input.domain.toLowerCase().trim(),
-    registrar: "cloudflare",
-    nameserverMode: "cloudflare",
-    status: "active",
-    registeredAt: new Date(),
-    expiresAt: input.expiresAt,
-    autoRenew: true,
-    cloudflareZoneId: input.cloudflareZoneId,
-    cloudflareRegistrationId: input.cloudflareRegistrationId,
-    registrantInfo: input.registrantInfo,
-    purchasePrice: String(input.purchasePriceCents),
-    renewalPrice: String(input.renewalPriceCents),
-    paymentMethod: "credits",
-    verified: true,
-    verifiedAt: new Date(),
-  };
-
-  const [created] = await dbWrite.insert(managedDomains).values(row).returning();
-  if (!created) {
-    throw new Error("managed_domains insert returned no rows");
-  }
-  logger.info("[Managed Domains] inserted cloudflare-registered domain", {
-    domainId: created.id,
-    domain: created.domain,
-    zoneId: created.cloudflareZoneId,
-  });
-  return created;
 }
 
 /**
@@ -250,16 +199,6 @@ export async function getOwnDomainRow(
     ),
   });
   return row ?? null;
-}
-
-/**
- * Hard-delete a managed-domain row (the reclaim primitive #11024's expiry cron
- * needs — `unassignFromResource` only nulls resource FKs and keeps the row, so
- * before this there was no way to release a stale unverified pending row). Only
- * ever call for rows the caller owns or for expired unverified externals.
- */
-export async function releaseDomain(domainId: string): Promise<void> {
-  await dbWrite.delete(managedDomains).where(eq(managedDomains.id, domainId));
 }
 
 /**
@@ -471,7 +410,6 @@ export async function unassignFromResource(domainId: string): Promise<ManagedDom
 }
 
 export const managedDomainsService = {
-  insertCloudflareRegisteredDomain,
   upsertCloudflareRegisteredDomain,
   insertExternalDomain,
   assignToResource,
@@ -480,7 +418,6 @@ export const managedDomainsService = {
   getDomainById,
   getDomainByName,
   getOwnDomainRow,
-  releaseDomain,
   releaseStaleUnverifiedExternals,
   listForOrganization,
   listForApp,

--- a/packages/cloud/shared/src/lib/services/managed-domains.ts
+++ b/packages/cloud/shared/src/lib/services/managed-domains.ts
@@ -206,9 +206,7 @@ export async function getOwnDomainRow(
  * reclaim path that stops an unproven attach from squatting a domain forever.
  * Returns the number of rows released. Intended for a periodic cron.
  */
-export async function releaseStaleUnverifiedExternals(
-  olderThanMs: number,
-): Promise<number> {
+export async function releaseStaleUnverifiedExternals(olderThanMs: number): Promise<number> {
   const cutoff = new Date(Date.now() - olderThanMs);
   const deleted = await dbWrite
     .delete(managedDomains)


### PR DESCRIPTION
## What / why

Pure dedup + dead-code removal in the `apps/[id]/domains/**` routes — no behavior change. Surfaced by the launch-hardening deepscan (5 clean-code rules). Every item was verified live on current develop before touching; ambiguous ones were deliberately left (see below).

## Changes
- **Extracted two duplicated guards into a shared `domains/guards.ts`** (same pattern as the existing shared `schemas.ts`; route codegen ignores non-`route.ts` files — verified idempotent):
  - `loadCloudflareManagedDomain` (was near-duplicated across `dns/route.ts` + `dns/[recordId]/route.ts`).
  - `loadOwnedApp` (the auth + app-ownership + app-key-scope guard, was byte-identical across check/sync/status/verify). **`buy/route.ts` intentionally not migrated** — its guard genuinely differs (parses body first, returns 403 vs 404 on cross-org).
- **Removed a provably-always-false `md.organizationId !== user.organization_id` term at 5 sites.** `getOwnDomainRow(orgId, domain)` already filters `WHERE organizationId = orgId` (`managed-domains.ts:196-198`), and every site passes the caller's own org — the term can never be true. This is not a real ownership check; the ownership guarantee (via the scoped query) is unchanged.
- **Dropped two zero-caller dead exports** — `releaseDomain` and `insertCloudflareRegisteredDomain` (+ its only-consumer interface) from `managed-domains.ts`. Repo-wide grep (cloud, app, cli, sdk, generated router, tests) confirms no callers; the live reclaim path uses `releaseStaleUnverifiedExternals` (kept).

## Deliberately skipped (not safe as "no-behavior-change")
- **`errorMessage` local helpers** in `domain-health.ts` / `domain-renewals.ts` are *not* behavior-identical to the shared `extractErrorMessage` (differ on non-Error throws; output is persisted in `healthCheckError`) — swapping them needs a behavior-reviewed change.
- **`status/route.ts` 500-on-transient-CF-blip** is a real behavior bug (unguarded `getRegistrationStatus` propagates to a 5xx even though the stored row is in hand) — needs its own PR + test asserting a CF-throw still returns 200 with stored fields. Filed as a follow-up.

## Verification
- `tsgo --noEmit` clean on both `packages/cloud/api` and `packages/cloud/shared`.
- Domains tests green (isolated runner): `domains-buy-credit-debit` 10/10, `reclaim-stale-domains-cron` 5/5, `managed-domains-squat` 6/6, `domain-maintenance` 10/10.

Freely-mergeable (no money/behavior change) — opening for review; tracked in #8434.

— [cloud-security]
