### PR TITLE
fix(scripts): count root operator script entrypoints

### DIFF
--- a/.github/issue-evidence/11367-script-inventory-operator-entrypoints.md
+++ b/.github/issue-evidence/11367-script-inventory-operator-entrypoints.md
@@ -1,0 +1,86 @@
+# Issue #11367 - script inventory operator entrypoints
+
+## What changed
+
+`packages/scripts/audit-scripts-inventory.mjs` now treats every named root
+`package.json` script as a lower-priority operator entrypoint. Files reached
+only from these commands are categorized as
+`reachable-from-operator-script`, not `orphan`, and each direct root caller is
+listed in `operatorScriptCallers`.
+
+## Verification
+
+```bash
+bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
+```
+
+Result: 9 tests passed, 0 failed, 206 assertions.
+
+```bash
+bunx @biomejs/biome check packages/scripts/audit-scripts-inventory.mjs \
+  packages/scripts/__tests__/audit-scripts-inventory.test.ts
+```
+
+Result: 2 files checked, no fixes needed.
+
+```bash
+node packages/scripts/audit-scripts-inventory.mjs --json | jq \
+  '{summary:.summary, devAllFile:(.files[]|select(.file=="dev-all.mjs")), orphanFiles:[.files[]|select(.category=="orphan")|.file]}'
+```
+
+Key inspected output:
+
+```json
+{
+  "summary": {
+    "totalFiles": 90,
+    "orphanFiles": 0,
+    "rootScriptsByCategory": {
+      "reachable-from-operator-script": 134,
+      "orphan": 0
+    },
+    "operatorScriptFileReferences": 96,
+    "documentationFileReferences": 411
+  },
+  "devAllFile": {
+    "file": "dev-all.mjs",
+    "category": "reachable-from-operator-script",
+    "operatorScriptCallers": [
+      {
+        "packageJson": "package.json",
+        "script": "dev:all"
+      }
+    ]
+  },
+  "orphanFiles": []
+}
+```
+
+```bash
+bun run audit:scripts:inventory
+```
+
+Result: passed. Summary showed 90 total `packages/scripts/*.mjs` files, 16
+`reachable-from-operator-script` files, 3 `reachable-from-docs` files, and 0
+orphan files.
+
+```bash
+bun run audit:scripts
+```
+
+Result: passed. The audit reported no orphan, no-op, or broken scripts.
+
+```bash
+bun run verify
+```
+
+Result: failed before reaching this change path in the existing type-safety
+ratchet:
+
+```text
+as unknown as: 80 current > 77 baseline
+`?? {}` (core/agent/app-core): 379 current > 377 baseline
+```
+
+UI evidence: N/A - this is a repository automation script and unit test change
+with no rendered UI surface.

--- a/packages/scripts/__tests__/audit-scripts-inventory.test.ts
+++ b/packages/scripts/__tests__/audit-scripts-inventory.test.ts
@@ -32,7 +32,9 @@ const FILE_CATEGORIES = [
   "reachable-from-test",
   "reachable-from-build",
   "reachable-from-ci-workflow",
+  "reachable-from-operator-script",
   "reachable-from-package-script",
+  "reachable-from-docs",
   "orphan",
 ];
 
@@ -111,5 +113,50 @@ describe("script inventory: packages/app surface (issue #10200)", () => {
       inv.summary.filesByCategory["reachable-from-package-script"],
     ).toBeGreaterThan(0);
     expect(inv.summary.packageScriptFileReferences).toBeGreaterThan(0);
+  });
+
+  test("named root operator scripts keep their entrypoint files out of the orphan bucket", () => {
+    const byFile = (name: string) => inv.files.find((f) => f.file === name);
+    const byRoot = (name: string) => inv.roots.find((r) => r.name === name);
+
+    expect(byRoot("dev:all")?.category).toBe("reachable-from-operator-script");
+    expect(byFile("dev-all.mjs")?.category).toBe(
+      "reachable-from-operator-script",
+    );
+    expect(byFile("dev-all.mjs")?.operatorScriptCallers).toContainEqual({
+      packageJson: "package.json",
+      script: "dev:all",
+    });
+    expect(byRoot("audit:scripts:inventory")?.category).toBe(
+      "reachable-from-operator-script",
+    );
+    expect(byFile("audit-scripts-inventory.mjs")?.category).toBe(
+      "reachable-from-operator-script",
+    );
+    expect(
+      byFile("audit-scripts-inventory.mjs")?.operatorScriptCallers,
+    ).toContainEqual({
+      packageJson: "package.json",
+      script: "audit:scripts:inventory",
+    });
+    expect(
+      inv.summary.filesByCategory["reachable-from-operator-script"],
+    ).toBeGreaterThan(0);
+    expect(inv.summary.operatorScriptFileReferences).toBeGreaterThan(0);
+  });
+
+  test("documented standalone scripts are tracked separately from true orphans", () => {
+    const byFile = (name: string) => inv.files.find((f) => f.file === name);
+
+    expect(byFile("ensure-skills.mjs")?.category).toBe("reachable-from-docs");
+    expect(byFile("run-scenarios-isolated.mjs")?.category).toBe(
+      "reachable-from-docs",
+    );
+    expect(byFile("validate-tee-local-stack.mjs")?.category).toBe(
+      "reachable-from-docs",
+    );
+    expect(inv.summary.filesByCategory.orphan).toBe(0);
+    expect(inv.summary.orphanFiles).toBe(0);
+    expect(inv.summary.documentationFileReferences).toBeGreaterThan(0);
   });
 });

--- a/packages/scripts/audit-scripts-inventory.mjs
+++ b/packages/scripts/audit-scripts-inventory.mjs
@@ -10,7 +10,9 @@
  *   - reachable-from-test
  *   - reachable-from-build
  *   - reachable-from-ci-workflow
+ *   - reachable-from-operator-script
  *   - reachable-from-package-script
+ *   - reachable-from-docs
  *   - reachable-from-app-internal   (packages/app scripts only)
  *   - orphan
  *
@@ -23,13 +25,16 @@
  *   1. Root scripts form a call graph: a script body that runs `bun run X` /
  *      `npm run X` makes root script X reachable transitively.
  *   2. The seed entrypoints are `verify` (+ its `check` alias), `test`, `build`,
- *      and every root script name referenced from a `.github/` workflow.
+ *      every root script name referenced from a `.github/` workflow, and every
+ *      named root script as a lower-priority human/operator entrypoint.
  *   3. A reachable script body that runs `node packages/scripts/X.mjs` (or
  *      otherwise names a packages/scripts file) makes that file reachable.
  *   4. `.github/` workflows that directly name a packages/scripts file make it
  *      reachable-from-ci-workflow.
  *   5. A reachable `.mjs` file that spawnSync/exec/imports/names another
  *      packages/scripts `.mjs` propagates reachability to it.
+ *   6. A packages/scripts file named from docs/source/test text is documented
+ *      as an intentional standalone/support entrypoint, not a true orphan.
  *
  * Output:
  *   - machine-readable JSON to reports/scripts-inventory.json (gitignored).
@@ -60,7 +65,9 @@ const CATEGORIES = [
   "reachable-from-test",
   "reachable-from-build",
   "reachable-from-ci-workflow",
+  "reachable-from-operator-script",
   "reachable-from-package-script",
+  "reachable-from-docs",
   "orphan",
 ];
 
@@ -87,6 +94,21 @@ const PACKAGE_JSON_PRUNE_DIRS = new Set([
   "dist",
   "node_modules",
   "reports",
+]);
+
+const DOCUMENTATION_REFERENCE_EXTENSIONS = new Set([
+  ".cjs",
+  ".js",
+  ".json",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".py",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".yaml",
+  ".yml",
 ]);
 
 function readJson(file) {
@@ -222,6 +244,32 @@ function filesFromRootScripts(reachedRoots, rootScripts, fileUniverse) {
   return seeds;
 }
 
+/** Root `package.json` script callers for packages/scripts/*.mjs files. */
+function filesFromOperatorScripts(reachedRoots, rootScripts, fileUniverse) {
+  const callersByFile = new Map();
+  for (const name of reachedRoots) {
+    for (const scriptFile of referencedScriptFiles(
+      rootScripts[name] ?? "",
+      fileUniverse,
+    )) {
+      if (!callersByFile.has(scriptFile)) callersByFile.set(scriptFile, []);
+      callersByFile.get(scriptFile).push({
+        packageJson: "package.json",
+        script: name,
+      });
+    }
+  }
+
+  for (const callers of callersByFile.values()) {
+    callers.sort((a, b) =>
+      `${a.packageJson}:${a.script}`.localeCompare(
+        `${b.packageJson}:${b.script}`,
+      ),
+    );
+  }
+  return callersByFile;
+}
+
 /**
  * packages/scripts files invoked from package-local `package.json` scripts.
  *
@@ -256,6 +304,37 @@ function filesFromPackageScripts(fileUniverse) {
     );
   }
   return callersByFile;
+}
+
+/**
+ * packages/scripts files referenced from docs/source/test text outside their own
+ * script file. This is intentionally low priority: package.json / CI /
+ * operator-script reachability wins, but a documented standalone support script
+ * is not a true zero-reference orphan.
+ */
+function filesFromDocumentation(fileUniverse) {
+  const referencesByFile = new Map();
+  walkPruned(ROOT, (file) => {
+    const rel = path.relative(ROOT, file);
+    if (rel === "package.json" || path.basename(file) === "package.json") {
+      return;
+    }
+    if (!DOCUMENTATION_REFERENCE_EXTENSIONS.has(path.extname(file))) return;
+    const body = readTextIfReadable(file);
+    if (!body) return;
+    for (const scriptFile of referencedScriptFiles(body, fileUniverse)) {
+      const ownScriptPath = path.join("packages", "scripts", scriptFile);
+      if (rel === ownScriptPath) continue;
+      if (!referencesByFile.has(scriptFile))
+        referencesByFile.set(scriptFile, []);
+      referencesByFile.get(scriptFile).push(rel);
+    }
+  });
+
+  for (const references of referencesByFile.values()) {
+    references.sort((a, b) => a.localeCompare(b));
+  }
+  return referencesByFile;
 }
 
 /**
@@ -369,6 +448,7 @@ function buildInventory() {
   const fileUniverse = collectScriptFiles();
   const fileGraph = buildFileGraph(fileUniverse);
   const packageScriptCallersByFile = filesFromPackageScripts(fileUniverse);
+  const documentationReferencesByFile = filesFromDocumentation(fileUniverse);
 
   // CI workflow corpus + the root-script names + script files it references.
   const workflowChunks = [];
@@ -384,8 +464,18 @@ function buildInventory() {
   const testRoots = reachableRootScripts(["test"], rootScripts);
   const buildRoots = reachableRootScripts(["build"], rootScripts);
   const ciRoots = reachableRootScripts(ciRootSeeds, rootScripts);
+  const operatorRoots = reachableRootScripts(
+    Object.keys(rootScripts),
+    rootScripts,
+  );
+  const operatorScriptCallersByFile = filesFromOperatorScripts(
+    operatorRoots,
+    rootScripts,
+    fileUniverse,
+  );
 
-  // Reachable file sets, colored by entrypoint (priority verify>test>build>ci).
+  // Reachable file sets, colored by entrypoint
+  // (priority verify > test > build > ci > operator > package-local script).
   const verifyFiles = reachableFiles(
     filesFromRootScripts(verifyRoots, rootScripts, fileUniverse),
     fileGraph,
@@ -405,8 +495,16 @@ function buildInventory() {
     ]),
     fileGraph,
   );
+  const operatorFiles = reachableFiles(
+    new Set(operatorScriptCallersByFile.keys()),
+    fileGraph,
+  );
   const packageScriptFiles = reachableFiles(
     new Set(packageScriptCallersByFile.keys()),
+    fileGraph,
+  );
+  const documentedFiles = reachableFiles(
+    new Set(documentationReferencesByFile.keys()),
     fileGraph,
   );
 
@@ -415,6 +513,7 @@ function buildInventory() {
     if (testRoots.has(name)) return "reachable-from-test";
     if (buildRoots.has(name)) return "reachable-from-build";
     if (ciRoots.has(name)) return "reachable-from-ci-workflow";
+    if (operatorRoots.has(name)) return "reachable-from-operator-script";
     return "orphan";
   };
   const classifyFile = (file) => {
@@ -422,7 +521,9 @@ function buildInventory() {
     if (testFiles.has(file)) return "reachable-from-test";
     if (buildFiles.has(file)) return "reachable-from-build";
     if (ciFiles.has(file)) return "reachable-from-ci-workflow";
+    if (operatorFiles.has(file)) return "reachable-from-operator-script";
     if (packageScriptFiles.has(file)) return "reachable-from-package-script";
+    if (documentedFiles.has(file)) return "reachable-from-docs";
     return "orphan";
   };
 
@@ -430,7 +531,9 @@ function buildInventory() {
     file,
     loc: loc(path.join(SCRIPTS_DIR, file)),
     category: classifyFile(file),
+    operatorScriptCallers: operatorScriptCallersByFile.get(file) ?? [],
     packageScriptCallers: packageScriptCallersByFile.get(file) ?? [],
+    documentationReferences: documentationReferencesByFile.get(file) ?? [],
   }));
   const roots = Object.keys(rootScripts).map((name) => ({
     name,
@@ -463,7 +566,7 @@ function buildInventory() {
   };
   for (const name of Object.keys(rootScripts)) {
     const color = classifyRoot(name);
-    if (color === "orphan") continue;
+    if (!(color in appSeedsByColor)) continue;
     for (const app of appScriptsViaCwd(rootScripts[name], appUniverse)) {
       appSeedsByColor[color].add(app);
     }
@@ -543,6 +646,12 @@ function buildInventory() {
       packageScriptFileReferences: [
         ...packageScriptCallersByFile.values(),
       ].reduce((sum, callers) => sum + callers.length, 0),
+      operatorScriptFileReferences: [
+        ...operatorScriptCallersByFile.values(),
+      ].reduce((sum, callers) => sum + callers.length, 0),
+      documentationFileReferences: [
+        ...documentationReferencesByFile.values(),
+      ].reduce((sum, references) => sum + references.length, 0),
       totalAppScripts: appScriptList.length,
       orphanAppScripts: appTotals.orphan,
       appScriptsByCategory: appTotals,
@@ -584,7 +693,7 @@ function printSummary(inv) {
     for (const f of orphans) w(`    - ${f.file} (${f.loc} LOC)\n`);
     w(
       "\n  note: orphan here means no root/CI/package-script caller found, " +
-        'not "safe to delete".\n\n',
+        'not "safe to delete". Root operator commands are tracked separately.\n\n',
     );
   }
 


### PR DESCRIPTION
## Summary
- classify root `package.json` scripts as lower-priority `reachable-from-operator-script` entrypoints
- record direct root callers in `operatorScriptCallers` so `dev:all` -> `dev-all.mjs` is visible in JSON
- keep the orphan bucket at true zero-caller files by classifying documented standalone support scripts as `reachable-from-docs`
- add regression coverage for `dev:all` and the zero-orphan/docs bucket

Fixes #11367

## Evidence
- `.github/issue-evidence/11367-script-inventory-operator-entrypoints.md`

## Verification
- `bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts` - 9 passed, 206 assertions
- `bunx @biomejs/biome check packages/scripts/audit-scripts-inventory.mjs packages/scripts/__tests__/audit-scripts-inventory.test.ts` - passed
- `node packages/scripts/audit-scripts-inventory.mjs --json | jq ...` - `dev-all.mjs` is `reachable-from-operator-script`; `orphanFiles: 0`
- `bun run audit:scripts:inventory` - passed; 0 orphan files
- `bun run audit:scripts` - passed
- `bun run verify` - fails before this change path in existing `audit:type-safety-ratchet`: `as unknown as` 80 > 77 and core/agent/app-core `?? {}` 379 > 377

## UI Evidence
N/A - repository automation script and test only; no rendered UI surface.