### PR TITLE
docs(scripts): record process supervision split

### DIFF
--- a/.github/issue-evidence/11366-process-supervision-split.md
+++ b/.github/issue-evidence/11366-process-supervision-split.md
@@ -1,0 +1,77 @@
+# Issue #11366 - process supervision split
+
+## Outcome
+
+Chose the documented-split path instead of extracting a shared helper.
+
+The inspected seams do not have identical lifecycle behavior:
+
+- `api-supervisor.mjs`: long-lived single API child, hot-reload restarts,
+  rolling crash-window give-up, `SIGTERM` to `SIGKILL` restart escalation.
+- `dev-ui.mjs` / `dev-platform.mjs`: dev-session orchestration around the API
+  supervisor with Vite/Electrobun-specific stream filtering, port allocation,
+  and whole-session teardown.
+- `dev-all.mjs`: long-lived detached service stack, process-group shutdown,
+  fixed `SIGKILL` fallback, and stop-the-stack-on-any-service-exit behavior.
+- `run-all-tests.mjs` / `test-task-pool.mjs`: bounded batch execution, no
+  respawn, deterministic shard membership through `digest.readUInt32BE(0)`,
+  quiet buffered output for pooled tasks, and all-failures reporting.
+
+The in-tree rationale is recorded in
+`packages/scripts/process-supervision.md`, linked from
+`packages/app-core/scripts/README.md`, and guarded by
+`packages/scripts/__tests__/test-task-pool.test.ts`.
+
+## Verification
+
+```bash
+bun test packages/scripts/__tests__/test-task-pool.test.ts
+```
+
+Result: 28 tests passed, 0 failed, 1899 assertions. This includes shard
+bucketing, `--plan` mode, and the process-supervision-boundary documentation
+guard.
+
+```bash
+node packages/scripts/run-all-tests.mjs --plan=json --only=test --no-cloud --filter=^@elizaos/core
+```
+
+Result: passed. Plan mode printed a one-task JSON inventory for
+`@elizaos/core (packages/core)#test`, with `cloudStep: false`.
+
+```bash
+bunx @biomejs/biome check packages/scripts/process-supervision.md \
+  packages/scripts/__tests__/test-task-pool.test.ts \
+  packages/app-core/scripts/README.md
+```
+
+Result: passed. Biome checked the TypeScript test file and reported no fixes
+needed; Markdown files are outside this Biome target.
+
+```bash
+bun run audit:scripts
+```
+
+Result: passed. The audit reported no orphan, no-op, or broken scripts.
+
+```bash
+bun run audit:scripts:inventory
+```
+
+Result: passed. Summary showed 90 total `packages/scripts/*.mjs` files and 0
+orphan files.
+
+```bash
+bun run verify
+```
+
+Result: failed before reaching this change path in the existing type-safety
+ratchet:
+
+```text
+as unknown as: 80 current > 77 baseline
+`?? {}` (core/agent/app-core): 379 current > 377 baseline
+```
+
+UI evidence: N/A - documentation/test-only build-script change with no rendered
+UI surface.

--- a/packages/app-core/scripts/README.md
+++ b/packages/app-core/scripts/README.md
@@ -25,3 +25,12 @@ Most scripts here are invoked from **root `package.json`** (`bun run …`). **Ap
 | `vite-renderer-dist-stale.mjs` | Cheap mtime check so `vite build` is skipped when `apps/app/dist` is still fresh — avoids redundant multi‑minute production builds on restart. |
 | `kill-ui-listen-port.mjs` | Clears the UI port before Vite binds; Unix uses `lsof`, Windows uses `netstat` + `taskkill` because `lsof` is not standard there. |
 | `kill-process-tree.mjs` | Kills **only** the PID tree rooted at each spawned child — avoids `pkill bun` style collateral damage to other workspaces. |
+
+### Process supervision split
+
+`dev-ui.mjs`, `dev-platform.mjs`, `dev-all.mjs`, and
+`packages/scripts/run-all-tests.mjs` intentionally do not share one generic
+child-process supervision helper. Their lifecycle contracts differ enough that a
+shared helper would mostly be flags for incompatible behavior. The in-tree
+rationale is tracked in
+[`packages/scripts/process-supervision.md`](../../scripts/process-supervision.md).

--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -161,6 +161,23 @@ describe("runPool", () => {
   });
 });
 
+describe("process supervision boundary", () => {
+  test("documents why dev supervisors and the test pool stay split", () => {
+    const doc = readFileSync(
+      new URL("../process-supervision.md", import.meta.url),
+      "utf8",
+    );
+
+    expect(doc).toContain("keep the seams separate");
+    expect(doc).toContain("api-supervisor.mjs");
+    expect(doc).toContain("dev-all.mjs");
+    expect(doc).toContain("run-all-tests.mjs");
+    expect(doc).toContain("long-lived single-child supervisor");
+    expect(doc).toContain("bounded batch runner");
+    expect(doc).toContain("digest.readUInt32BE(0)");
+  });
+});
+
 describe("normalizeConcurrency", () => {
   test("defaults to 1 (fully serial) for empty/invalid input", () => {
     for (const value of [undefined, null, "", "abc", "0", "-3", 0, -1]) {

--- a/packages/scripts/process-supervision.md
+++ b/packages/scripts/process-supervision.md
@@ -1,0 +1,64 @@
+# Process Supervision Boundaries
+
+Issue #11366 asked whether the dev orchestrators and the cross-package test
+runner should share one child-process supervision/fan-out helper. The decision
+for the current code is: keep the seams separate and document why.
+
+## Decision
+
+Do not extract a shared helper between:
+
+- `packages/app-core/scripts/lib/api-supervisor.mjs`
+- `packages/app-core/scripts/dev-ui.mjs`
+- `packages/app-core/scripts/dev-platform.mjs`
+- `packages/scripts/dev-all.mjs`
+- `packages/scripts/run-all-tests.mjs`
+- `packages/scripts/lib/test-task-pool.mjs`
+
+They all spawn children, but the identical part is too small to carry the real
+behavior safely. A shared abstraction today would mostly be switches for
+different lifecycles, not a simpler production seam.
+
+## Why They Stay Separate
+
+`api-supervisor.mjs` is a long-lived single-child supervisor. Its contract is to
+keep the API server alive across intentional restarts and non-shutdown exits. It
+tracks a rolling crash streak, relaunches after exit 0 / 75 / other non-shutdown
+exits, treats source-watch reloads as intentional, escalates a stuck restart
+from `SIGTERM` to `SIGKILL`, and gives up only after the restart window trips.
+
+`dev-ui.mjs` and `dev-platform.mjs` wrap that API supervisor, but each owns
+different process-tree and stream behavior. `dev-ui.mjs` filters API startup
+noise, supervises Vite with its own restart guard, and coordinates API/UI hot
+reloads. `dev-platform.mjs` prefixes several processes, allocates ports, and
+shuts down API/Vite/Electrobun as one terminal session when the desktop app
+quits or a signal arrives.
+
+`dev-all.mjs` is a long-lived stack launcher, not a restart supervisor. It
+starts several detached services, waits for dependent ports, prefixes each
+service stream, and stops the whole stack when any service exits. Its shutdown
+contract is process-group termination followed by a fixed `SIGKILL` fallback.
+
+`run-all-tests.mjs` is a bounded batch runner. It never respawns a failed test
+child. In serial mode it preserves the historical fail-fast behavior. In
+parallel mode it partitions tasks through `test-task-pool.mjs`, buffers pooled
+child output so logs do not interleave, runs every parallel-safe task to
+completion, drains the unsafe tasks serially, and reports all failures together.
+Its sharding contract is stable package bucketing via
+`digest.readUInt32BE(0)`.
+
+## Extraction Criteria
+
+A future shared helper is allowed only if two callers have the same answers for
+all of these:
+
+- child lifetime: one long-lived child, long-lived stack, or bounded batch task
+- exit semantics: relaunch, fail-fast, collect-all-failures, or stop-the-stack
+- stream policy: live prefixing, filtering, or quiet buffering until failure
+- signal policy: direct child kill, process-group kill, process-tree kill, or no
+  parent-owned shutdown path
+- restart policy: none, hot-reload-only, fixed retry, or rolling crash window
+- result shape: process exit, per-task result array, or dev session teardown
+
+Until those match, keep behavior in the existing purpose-specific modules and
+test their invariants where they live.


### PR DESCRIPTION
## Summary
- document the #11366 decision to keep dev supervision and test fan-out as separate seams
- link the rationale from `packages/app-core/scripts/README.md`
- add a guard in `test-task-pool.test.ts` so the split rationale and shard invariant remain discoverable

Closes #11366

## Evidence
- `.github/issue-evidence/11366-process-supervision-split.md`

## Verification
- `bun test packages/scripts/__tests__/test-task-pool.test.ts` - 28 passed, 1899 assertions
- `node packages/scripts/run-all-tests.mjs --plan=json --only=test --no-cloud --filter=^@elizaos/core` - passed; one-task JSON plan, no cloud step
- `bunx @biomejs/biome check packages/scripts/process-supervision.md packages/scripts/__tests__/test-task-pool.test.ts packages/app-core/scripts/README.md` - passed; Biome checked the TS test target, Markdown ignored by this target
- `bun run audit:scripts` - passed
- `bun run audit:scripts:inventory` - passed; 0 orphan script files
- `bun run verify` - fails before this change path in existing `audit:type-safety-ratchet`: `as unknown as` 80 > 77 and core/agent/app-core `?? {}` 379 > 377

## UI Evidence
N/A - documentation/test-only build-script change with no rendered UI surface.