### PR TITLE
fix(cloud): re-land money gates clobbered by #11271 stale-base squash (#11413)

### DIFF
--- a/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 import {
+  reconcileNonStreamingSettleError,
   reconcileStreamProcessingError,
   type StreamRefundCredits,
 } from "../v1/apps/[id]/chat/stream-refund";
@@ -104,5 +105,61 @@ describe("reconcileStreamProcessingError (#10837)", () => {
     // 2 delivered (no refund) + 2 pre-delivery failures (refund) = exactly 2 refunds.
     expect(credits.reconcileCredits).toHaveBeenCalledTimes(2);
     expect(credits.calls.every((c) => c.actualBaseCost === 0)).toBe(true);
+  });
+});
+
+const nonStreamBase = {
+  appId: "app-1",
+  userId: "user-1",
+  reservedBaseCost: 0.05,
+  model: "openai/gpt-oss-120b",
+  provider: "openai",
+  billingSource: "openai",
+  errorMessage: "provider body was not valid JSON",
+};
+
+describe("reconcileNonStreamingSettleError (#11169 part 1)", () => {
+  test("throw BEFORE the settle reconcile was invoked → full refund (actualBaseCost 0)", async () => {
+    const credits = makeCredits();
+    const result = await reconcileNonStreamingSettleError(
+      { ...nonStreamBase, settleStarted: false },
+      credits,
+    );
+    expect(result.refunded).toBe(true);
+    expect(credits.reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(credits.calls[0]).toEqual({
+      estimatedBaseCost: 0.05,
+      actualBaseCost: 0,
+    });
+  });
+
+  test("throw at/after the settle reconcile (incl. from INSIDE it — movement may have committed) → NO refund (no double-credit)", async () => {
+    const credits = makeCredits();
+    const result = await reconcileNonStreamingSettleError(
+      { ...nonStreamBase, settleStarted: true },
+      credits,
+    );
+    expect(result.refunded).toBe(false);
+    expect(credits.reconcileCredits).not.toHaveBeenCalled();
+  });
+
+  test("the refund is tagged non-streaming (streaming:false) so it's distinguishable in the ledger", async () => {
+    const metaCalls: Array<Record<string, unknown> | undefined> = [];
+    const credits = {
+      reconcileCredits: mock(
+        async (args: { metadata?: Record<string, unknown> }) => {
+          metaCalls.push(args.metadata);
+          return null;
+        },
+      ),
+    } as unknown as StreamRefundCredits;
+    await reconcileNonStreamingSettleError(
+      { ...nonStreamBase, settleStarted: false },
+      credits,
+    );
+    expect(metaCalls[0]).toMatchObject({
+      streaming: false,
+      refundReason: "non_streaming_settle_error",
+    });
   });
 });

--- a/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
+++ b/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
@@ -73,6 +73,15 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
+const mockCheckAgentCreditGate = mock(async () => ({
+  allowed: true as boolean,
+  balance: 10,
+  error: undefined as string | undefined,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: mockCheckAgentCreditGate,
+}));
+
 // Import after all mocks are in place.
 const { default: app } = await import("../eliza-app/provisioning-agent/route");
 
@@ -166,5 +175,28 @@ describe("provisioning-agent DEFAULT_DOCKER_IMAGE", () => {
     const call = firstCreateAgentCall();
     expect(call).toBeDefined();
     expect(call!.dockerImage).toMatch(/^ghcr\.io\//);
+  });
+
+  test("#11224: a credit-suspended org is blocked 402 — no dedicated agent created or provisioned", async () => {
+    mockListByOrganization.mockResolvedValue([]); // no existing sandbox → provision path
+    mockCreateAgent.mockClear();
+    mockEnqueueAgentProvision.mockClear();
+    mockCheckAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      headers: { Authorization: "Bearer valid-session-token" },
+    });
+    const res = await app.fetch(req);
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toMatchObject({ code: "insufficient_credits" });
+    // The gate fires BEFORE any dedicated agent is minted/provisioned.
+    expect(mockCreateAgent).not.toHaveBeenCalled();
+    expect(mockEnqueueAgentProvision).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/route.ts
@@ -13,6 +13,8 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
@@ -91,6 +93,36 @@ app.post("/", async (c) => {
 
     if (existing) {
       return c.json({ success: true, data: sandboxPayload(existing) });
+    }
+
+    // Credit gate before provisioning a NEW dedicated agent (#11224): this
+    // creates a custom-image (DEFAULT_DOCKER_IMAGE → dedicated) sandbox and
+    // eagerly enqueues its container, the same paid compute the main
+    // create/resume/wake paths gate. Without it a credit-suspended / zero-balance
+    // org gets a free dedicated container. New orgs clear this via the signup
+    // grant; only genuinely suspended orgs are blocked. (Existing sandboxes
+    // returned above are unaffected — this only fences the first provision.)
+    const creditCheck = await checkAgentCreditGate(session.organizationId);
+    if (!creditCheck.allowed) {
+      logger.warn(
+        "[eliza-app provisioning-agent] provision blocked: insufficient credits",
+        {
+          orgId: session.organizationId,
+          balance: creditCheck.balance,
+          required: AGENT_PRICING.MINIMUM_DEPOSIT,
+        },
+      );
+      return c.json(
+        {
+          success: false,
+          code: "insufficient_credits",
+          error:
+            creditCheck.error ?? "Insufficient credits to provision an agent",
+          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+          currentBalance: creditCheck.balance,
+        },
+        402,
+      );
     }
 
     // No sandbox yet — create one and enqueue provisioning.

--- a/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
@@ -68,3 +68,76 @@ export async function reconcileStreamProcessingError(
   });
   return { refunded: true };
 }
+
+/**
+ * Money-critical (#11169 part 1): the NON-streaming app-chat path debits the
+ * upfront hold, then reads the provider body + runs `calculateCost` +
+ * `reconcileCredits`. If the body-read or cost-calc throws AFTER the debit, the
+ * route's outer catch returns 500 WITHOUT refunding — stranding the reserved
+ * hold. Refund it: the caller received no billable answer and no settle was
+ * ever attempted.
+ *
+ * `settleStarted` is true once `reconcileCredits` has been INVOKED — not once
+ * it returned. `reconcileCredits` is not transactional: it commits its
+ * org-balance movement (refund or extra charge) before its earnings/counter
+ * writes, and that movement carries no idempotency key. A throw from inside it
+ * may therefore have already moved money, so refunding blindly would
+ * double-credit the org (mint credits during a DB blip, systemically across
+ * concurrent requests). Mirror of the streaming branch, which flips
+ * `streamCompleted` before ITS settle for the same reason. A hold stranded by
+ * that rare window is recovered by the stranded-reservation sweep
+ * (#11169 part 3).
+ */
+export async function reconcileNonStreamingSettleError(
+  params: {
+    settleStarted: boolean;
+    appId: string;
+    userId: string;
+    reservedBaseCost: number;
+    model: string;
+    provider: string;
+    billingSource: string;
+    errorMessage: string;
+  },
+  credits: StreamRefundCredits,
+): Promise<{ refunded: boolean }> {
+  const {
+    settleStarted,
+    appId,
+    userId,
+    reservedBaseCost,
+    model,
+    provider,
+    billingSource,
+    errorMessage,
+  } = params;
+
+  if (settleStarted) {
+    logger.error(
+      "[App Chat] Non-streaming throw at/after the settle reconcile; NOT refunding (movement may have committed — sweep recovers a stranded hold)",
+      { appId, userId, reservedBaseCost, error: errorMessage },
+    );
+    return { refunded: false };
+  }
+
+  logger.error(
+    "[App Chat] Non-streaming settle never started after debit; refunding reserved hold (#11169)",
+    { appId, userId, reservedBaseCost, error: errorMessage },
+  );
+  await credits.reconcileCredits({
+    appId,
+    userId,
+    estimatedBaseCost: reservedBaseCost,
+    actualBaseCost: 0, // Full refund — nothing was billed.
+    description: `Chat refund (non-streaming settle failed): ${model}`,
+    metadata: {
+      error: true,
+      streaming: false,
+      model,
+      provider,
+      billingSource,
+      refundReason: "non_streaming_settle_error",
+    },
+  });
+  return { refunded: true };
+}

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -684,11 +684,15 @@ export async function syncUserFromSteward(
       logger.error("[StewardSync] Discord signup log failed:", { error });
     });
 
-  // Auto-generate default API key (fire-and-forget)
-  void ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
-
-  // Auto-create default Eliza character (fire-and-forget)
-  void ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
+  // Await default provisioning: on Cloudflare Workers an un-awaited promise is
+  // cancelled once the response returns unless registered via
+  // executionCtx.waitUntil, which this shared-lib function cannot reach — and a
+  // cancelled create leaves the new user permanently without a default
+  // character/API key (this one-time new-user path is the only caller; later
+  // logins return at the existing-user branch). Both helpers are idempotent and
+  // swallow their own errors, so awaiting cannot fail the signup.
+  await ensureUserHasApiKey(userWithOrg.id, userWithOrg.organization?.id || "");
+  await ensureDefaultCharacter(userWithOrg.id, userWithOrg.organization?.id || "");
 
   return userWithOrg;
 }


### PR DESCRIPTION
Part of #11413 (the #11271 mass-revert incident). Re-lands the **launch-critical cloud money gates** that #11271's stale-base squash byte-reverted and are still missing at develop tip.

## Method (blob-identity, not diff-by-eye)
For each file the clobber squash (5b714c74e60) touched, compared: develop-tip blob vs clobbered blob vs correct pre-clobber blob (5b714c74e60^). These files are exact reverts (develop-tip == clobbered, != correct), restored via `git checkout 5b714c74e60^ -- <path>`:

| File | Restores | Impact |
|---|---|---|
| `eliza-app/provisioning-agent/route.ts` | #11240 org-credit gate | **HIGH money** — zero/neg-balance orgs could provision free dedicated-agent compute (gate + 402 was gone) |
| `v1/apps/[id]/chat/stream-refund.ts` | #11218 app-chat stream refund | money-path refund |
| `shared/lib/steward-sync.ts` | #11270 awaited-provisioning | reliability |
| + `provisioning-agent-default-image.test.ts`, `apps-chat-stream-refund.test.ts` | tests | coverage |

## Explicitly NOT touched
#11271's **intended** change — `influencer-marketplace.ts` escrow CAS fix (#11167) — is correct at tip and kept (the audit excludes it; blindly restoring to parent would revert the escrow fix).

## Verification
- `bun run --cwd packages/cloud/api typecheck` → exit 0, **0 errors** (the `@/lib/*`→`../shared/src/lib/*` alias resolves `checkAgentCreditGate` to the surviving shared `agent-billing-gate.ts`).
- `bun run --cwd packages/cloud/shared typecheck` → 0 errors.
- `bun test __tests__/provisioning-agent-default-image.test.ts __tests__/apps-chat-stream-refund.test.ts` → **11 pass / 0 fail**.

## Scope note
This is the money-gate slice. The full #11413 audit (183 safe byte-identical restores + 102 reconcile + 7 deletes, incl. the ~223-file #11259 LifeOps runtime) is posted on the umbrella for the coordinated re-land — kept out of this PR to keep the launch-critical money fix small and reviewable. cc @lalalune (money-path merge). — nubs-cloud [cloud-frontdoor]