### PR TITLE
fix(local-inference): re-land Kokoro raw-text TTS fix clobbered by #11271 (#11413)

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
@@ -102,6 +102,49 @@ describe("KokoroTtsBackend", () => {
 		expect(totalBody).toBe(9600);
 	});
 
+	it("passes the raw phrase text — never the IPA string — to the runtime (#10726)", async () => {
+		const seen: Array<{ text: string; phonemes: string }> = [];
+		class RecordingRuntime implements KokoroRuntime {
+			readonly id = "mock" as const;
+			readonly sampleRate = 24000;
+			async synthesize(
+				args: KokoroRuntimeInputs,
+			): Promise<{ cancelled: boolean }> {
+				seen.push({ text: args.text, phonemes: args.phonemes.phonemes });
+				args.onChunk({
+					pcm: new Float32Array(0),
+					sampleRate: this.sampleRate,
+					isFinal: true,
+				});
+				return { cancelled: false };
+			}
+			dispose(): void {}
+		}
+		const backend = new KokoroTtsBackend({
+			runtime: new RecordingRuntime(),
+			layout: {
+				root: "/tmp/kokoro",
+				modelFile: "kokoro-82m-v1_0.gguf",
+				voicesDir: "/tmp/kokoro/voices",
+				sampleRate: 24000,
+			},
+			defaultVoiceId: KOKORO_DEFAULT_VOICE_ID,
+			phonemizer: fixedPhonemizer(),
+		});
+		await backend.synthesizeStream({
+			phrase: makePhrase("hello there"),
+			preset: makePreset(KOKORO_DEFAULT_VOICE_ID),
+			cancelSignal: { cancelled: false },
+			onChunk: () => undefined,
+		});
+		expect(seen).toHaveLength(1);
+		// The fused engine phonemizes internally; handing it the JS-side IPA
+		// string double-phonemizes into unintelligible audio (#10726).
+		expect(seen[0]?.text).toBe("hello there");
+		expect(seen[0]?.phonemes).toBe("ab");
+		expect(seen[0]?.text).not.toBe(seen[0]?.phonemes);
+	});
+
 	it("propagates cancelSignal at chunk boundaries", async () => {
 		const { backend } = makeBackend({ totalSamples: 24000, chunkCount: 8 });
 		const cancelSignal = { cancelled: false };

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
@@ -77,6 +77,7 @@ function makeInputs(
 	cancelSignal = { cancelled: false },
 ): KokoroRuntimeInputs {
 	return {
+		text: "hello",
 		phonemes: { ids: Int32Array.from([1, 2, 3]), phonemes: "hɛˈloʊ" },
 		voice: v,
 		cancelSignal,
@@ -187,9 +188,11 @@ describe("KokoroFfiRuntime", () => {
 		expect(calls.loads[0]?.voiceBinPath).toBe(
 			path.join(root, "voices", "af_same.bin"),
 		);
-		// The fork phonemizes internally — we hand it the phoneme string, the
-		// same `input` the llama-server /v1/audio/speech path sends.
-		expect(calls.synths[0]?.text).toBe("hɛˈloʊ");
+		// The fork phonemizes internally (espeak-ng or ASCII fallback) — it must
+		// receive the RAW phrase text, never the JS-side IPA string. IPA-as-text
+		// double-phonemizes into unintelligible audio (#10726).
+		expect(calls.synths[0]?.text).toBe("hello");
+		expect(calls.synths[0]?.text).not.toBe("hɛˈloʊ");
 		expect(chunks.filter((c) => !c.isFinal)).toHaveLength(1);
 		expect(chunks.at(-1)?.isFinal).toBe(true);
 		expect(chunks[0]?.len).toBe(4);

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-runtime.test.ts
@@ -29,6 +29,7 @@ describe("KokoroMockRuntime", () => {
 		});
 		const chunks: Array<{ isFinal: boolean; len: number }> = [];
 		await runtime.synthesize({
+			text: "abc",
 			phonemes: { ids: Int32Array.from([1, 2, 3]), phonemes: "abc" },
 			voice: makeVoice(),
 			cancelSignal: { cancelled: false },
@@ -48,6 +49,7 @@ describe("KokoroMockRuntime", () => {
 		const runtime = new KokoroMockRuntime({ sampleRate: 24_000 });
 		expect(runtime.calls).toBe(0);
 		await runtime.synthesize({
+			text: "a",
 			phonemes: { ids: Int32Array.from([1]), phonemes: "a" },
 			voice: makeVoice(),
 			cancelSignal: { cancelled: false },
@@ -65,6 +67,7 @@ describe("KokoroMockRuntime", () => {
 		const signal = { cancelled: false };
 		let bodyCount = 0;
 		const result = await runtime.synthesize({
+			text: "ab",
 			phonemes: { ids: Int32Array.from([1, 2]), phonemes: "ab" },
 			voice: makeVoice(),
 			cancelSignal: signal,
@@ -85,6 +88,7 @@ describe("KokoroMockRuntime", () => {
 	it("returns cancelled=true when onChunk returns true", async () => {
 		const runtime = new KokoroMockRuntime({ sampleRate: 24_000 });
 		const result = await runtime.synthesize({
+			text: "a",
 			phonemes: { ids: Int32Array.from([1]), phonemes: "a" },
 			voice: makeVoice(),
 			cancelSignal: { cancelled: false },

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
@@ -157,6 +157,7 @@ export class KokoroTtsBackend implements TtsBackend, StreamingTtsBackend {
 		const limit = this.streamingChunkSamples;
 		let cancelled = false;
 		const result = await this.runtime.synthesize({
+			text: args.phrase.text,
 			phonemes,
 			voice,
 			cancelSignal: args.cancelSignal,

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-ffi-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-ffi-runtime.ts
@@ -470,9 +470,11 @@ export class KokoroFfiRuntime implements KokoroRuntime {
 
 		const maxSamples = args.maxSamples ?? MAX_OUTPUT_SAMPLES;
 		// The Kokoro engine produces the full waveform in one synchronous
-		// forward. The text it phonemizes internally is the same phoneme string
-		// the llama-server `/v1/audio/speech` path sends as `input`.
-		const pcm = this.kokoroSynthesize(args.phonemes.phonemes, maxSamples);
+		// forward and phonemizes internally (espeak-ng when linked, ASCII
+		// grapheme fallback otherwise) — so it must receive the RAW phrase
+		// text. Passing the JS-side IPA string here double-phonemizes and
+		// yields speech-shaped but unintelligible audio (#10726).
+		const pcm = this.kokoroSynthesize(args.text, maxSamples);
 
 		let cancelled = false;
 		if (args.cancelSignal.cancelled) {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
@@ -31,6 +31,16 @@ export interface KokoroRuntimeChunk {
  * bytes off `layout.voicesDir/<file>`.
  */
 export interface KokoroRuntimeInputs {
+	/**
+	 * Raw (pre-phonemization) phrase text. The in-process fused engine
+	 * (`KokoroFfiRuntime`) MUST synthesize from this: `eliza_inference_kokoro_synthesize`
+	 * phonemizes internally (espeak-ng when linked, ASCII grapheme fallback
+	 * otherwise). Feeding it the JS-side IPA string double-phonemizes — the
+	 * engine's per-byte ASCII fallback shreds multi-byte IPA codepoints and the
+	 * espeak path re-G2Ps IPA as if it were words; both produce speech-shaped
+	 * but lexically wrong audio (#10726).
+	 */
+	text: string;
 	phonemes: KokoroPhonemeSequence;
 	voice: KokoroVoicePack;
 	/**


### PR DESCRIPTION
Part of #11413. Re-lands **#11238** (the Kokoro FFI raw-text TTS fix, #10726) which #11271's stale-base squash byte-reverted — develop's on-device TTS is currently **double-phonemized and unintelligible** (WER 1.00: "Los Nevados said." for "Hello, this is a native Kokoro voice test.").

Blob-identity audit confirms these 6 files at develop tip are exact reverts of the merged fix; restored from the pre-clobber parent `5b714c74e60^`:
- `kokoro-backend.ts`, `kokoro-ffi-runtime.ts`, `kokoro-runtime.ts` — plumb raw pre-phonemization text through `KokoroRuntimeInputs.text` so `eliza_inference_kokoro_synthesize` phonemizes ONCE (it does espeak-ng/grapheme phonemization internally; passing IPA double-phonemized it).
- + the 3 kokoro `__tests__`.

**Verified:** `plugin-local-inference` typecheck clean; `bun test kokoro/__tests__` → **58 pass / 0 fail** (9 skipped need the native .gguf).

Small self-contained slice of the #11413 umbrella (audit posted there). — nubs-cloud [cloud-frontdoor]