### PR TITLE
docs(cloud): document agent-first cloud experience

### DIFF
--- a/.github/issue-evidence/11340-agent-first-cloud-experience.md
+++ b/.github/issue-evidence/11340-agent-first-cloud-experience.md
@@ -1,0 +1,70 @@
+# Issue #11340 Evidence - Agent-First Cloud Experience Plan
+
+Date: 2026-07-02
+Branch: `docs/11340-agent-first-cloud-experience`
+
+## What Changed
+
+- Added `packages/cloud/AGENT_FIRST_EXPERIENCE.md`, a screen-by-screen
+  agent-first Cloud plan covering setup, hosted/local ownership, entry points,
+  and surface consolidation targets.
+- Updated `packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md`
+  so agents use the current managed frontend hosting contract instead of the
+  obsolete "not yet first-class" guidance.
+- Updated `packages/cloud/APP_PLATFORM_REVIEW.md` where it still described
+  managed frontend hosting as future work.
+
+## Sources Reviewed
+
+- `packages/ui/src/cloud/shell/CloudRouterShell.tsx`
+- `packages/ui/src/cloud/register-all.ts`
+- `packages/ui/src/cloud/applications/index.ts`
+- `packages/ui/src/components/pages/launcher-curation.ts`
+- `packages/app/src/cloud-apps-view.ts`
+- `packages/app/src/main.tsx`
+- `packages/app/vite.config.ts`
+- `packages/app/functions/_proxy.ts`
+- `packages/app/wrangler.toml`
+- `packages/cloud/api/v1/apps/[id]/frontend/route.ts`
+- `packages/cloud/api/v1/apps/[id]/frontend/[deploymentId]/route.ts`
+- `packages/cloud/api/v1/apps/[id]/frontend/[deploymentId]/activate/route.ts`
+- `packages/cloud/api/v1/apps/[id]/frontend/preview/[[...path]]/route.ts`
+- `packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts`
+- `packages/cloud/shared/src/lib/services/app-frontend-hosting.ts`
+- `packages/skills/skills/eliza-cloud/SKILL.md`
+
+## Manual Review
+
+- Confirmed `cloud-apps` is hidden when `cloudActive` is false.
+- Confirmed native/desktop uses `cloud-apps-view` and web uses
+  `CloudRouterShell`.
+- Confirmed `packages/cloud-frontend` is deleted and `packages/app` is the
+  single hosted web build/proxy.
+- Confirmed managed frontend publish, list, preview, detail, delete, activate,
+  public serve, SEO injection, page-view beacon, server-side page-view record,
+  and synthesized `robots.txt`/`sitemap.xml` paths exist.
+
+## Verification
+
+- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light` - pass.
+- `git diff --check` - pass.
+- Stale-phrase scan - pass:
+  `rg -n "does not yet have first-class managed frontend hosting|Until managed frontend hosting lands|Do not claim Cloud can upload|largest missing seam|missing managed-frontend host" ...`
+  returned no matches in the touched docs.
+- Required-reference scan - pass: verified the new docs mention `cloud-apps`,
+  `CloudRouterShell`, `/dashboard/apps`, `/app-auth/authorize`,
+  `POST /api/v1/apps/:id/frontend`, hosted frontend serve paths,
+  `settings#billing`, and `packages/cloud-frontend`.
+- `bun run verify` - fails at the existing repo-wide type-safety ratchet before
+  lint/typecheck:
+  - `as unknown as: 80 / 77`
+  - core/agent/app-core `?? {}`: `379 / 377`
+
+## Not Applicable
+
+- Screenshots/video: N/A - documentation-only change; no UI behavior changed.
+- Backend/frontend logs: N/A - documentation-only change; no runtime path
+  changed.
+- Real-LLM trajectory: N/A - no model/action/provider behavior changed.
+- DB/domain/money artifacts: N/A - no database, domain, billing, payout, or
+  payment behavior changed.

--- a/packages/cloud/AGENT_FIRST_EXPERIENCE.md
+++ b/packages/cloud/AGENT_FIRST_EXPERIENCE.md
@@ -1,0 +1,164 @@
+# Agent-First Eliza Cloud Experience Plan
+
+Issue: #11340
+Date: 2026-07-02
+
+This plan defines the minimal Eliza Cloud experience from the user's point of
+view. The product rule is simple: the local Eliza agent stays primary; Cloud is
+the hosted control plane for durable identity, billing, app records, public
+auth, hosting, domains, analytics, monetization, and managed backend execution.
+
+## Product Contract
+
+- Chat is the first surface. A user should ask Eliza to build, manage, deploy,
+  monetize, or promote an app before they are sent to a Cloud console.
+- Cloud surfaces appear only when they represent hosted state the local app
+  cannot own: account connection, credits, app records, app auth, managed
+  frontend deployments, backend containers, domains, analytics, money, and
+  public token-gated flows.
+- Do not create a second Cloud launcher, a parallel local clone of Cloud app
+  management, or standalone tiles for every hosted capability. Fold hosted app
+  work into the Applications surface and its app detail tabs.
+- The local installed Apps view (`apps`) and Cloud Applications (`cloud-apps`,
+  `/dashboard/apps`) are different products and must stay separate.
+
+## Minimal Setup Flow
+
+### 1. First Open: Local Agent Home
+
+The first screen is the local app shell: chat, launcher, local settings, and
+local model/device/plugin surfaces. The user can run Eliza without Cloud.
+
+Cloud-only launcher entries stay hidden while the user is disconnected. Today
+`cloud-apps` is the only curated Cloud launcher id, and
+`curateLauncherPages(..., { cloudActive: false })` drops it.
+
+### 2. Connect Cloud From Account Or Model Setup
+
+When the user chooses a Cloud-backed model, account, billing, connector, or
+Cloud Dashboard action, the app asks them to connect Eliza Cloud. The current
+Cloud Dashboard owns the connected/disconnected state, billing summary,
+checkout/top-up affordances, auto top-up settings, and disconnect path.
+
+On the hosted web apex, unauthenticated control-plane visitors are routed to
+Steward login instead of the local agent catch-all. Public auth routes such as
+`/login`, `/auth/*`, and `/app-auth/authorize` are owned by the web-only
+`CloudRouterShell`.
+
+### 3. Ask Eliza For App Work
+
+The primary app-builder entry is chat. For a new monetized app, the agent uses
+`build-monetized-app` with `eliza-cloud`: register the Cloud app, build the
+frontend, publish the frontend deployment, deploy a backend only when server
+code is required, configure monetization, and offer a custom domain after the
+hosted app exists.
+
+For an existing app, `eliza-cloud` is the management skill: list apps, inspect
+analytics, update app config, regenerate API keys, charge users, check
+payments, request payouts, manage containers, and call the Cloud APIs.
+
+### 4. Open Cloud Applications When Connected
+
+When Cloud is active, native and desktop runtimes can surface the `cloud-apps`
+launcher tile. It opens `/cloud-apps` and lazy-loads the self-contained native
+Applications studio.
+
+On the hosted web build, the Applications surface is served by
+`CloudRouterShell` through `/dashboard/apps` and `/dashboard/apps/:id`. The
+web shell also owns public, auth, payment, approval, invite, app-auth, terms,
+privacy, and dashboard compatibility routes.
+
+### 5. Manage Hosted App State In One Applications Surface
+
+The Applications list and app detail screens are the Cloud app management home.
+The app detail route is the place for app record settings, app auth/API-key
+custody, monetization, earnings, domains, analytics, promotion, users, and
+settings.
+
+Managed frontend hosting is real but the dashboard upload UI remains a product
+gap. Until that UI lands, the agent/API path owns frontend publish and preview:
+`POST /api/v1/apps/:id/frontend`, `GET /api/v1/apps/:id/frontend`,
+`POST /api/v1/apps/:id/frontend/:deploymentId/activate`, and
+`GET /api/v1/apps/:id/frontend/preview`.
+
+## Hosted Vs Local Split
+
+| Hosted by Eliza Cloud | Stays local / agent-first |
+| --- | --- |
+| Steward login, session, redirects, and `/app-auth/authorize` | Primary chat, planner, and action loop |
+| Web `CloudRouterShell` routes for public/auth/payment/approval/invite/app-auth/terms/privacy/dashboard paths | Launcher, local installed Apps view, local settings, and local model selection |
+| Organizations, API keys, credits, usage, billing, Stripe checkout, invoices, and account settings | Local model/device plugins, native connectors, and local provider preference |
+| Cloud app records, app API keys, app auth, allowed origins, redirect URIs, app users | Building frontend artifacts and deciding whether server-side code is needed |
+| Managed frontend hosting: R2-backed immutable deployments, activation/rollback, preview, public system/custom-domain serving, SEO injection, and page-view beaconing | Local static frontend development and local test serving before publish |
+| Custom domains, registrar/DNS/SSL/health checks, verified external domains, and domain money paths | Asking for explicit confirmation before paid domain purchases or ad spend |
+| Backend containers, agent server/control-plane provisioning, cloud tunnels, and production worker/container runtime | Avoiding containers for static frontend-only apps |
+| Monetization, creator earnings, app charge requests, x402 payment requests, redemptions, admin review | Explaining the requested money move and collecting explicit confirmation |
+| Content generation, promotion, advertising, ad inventory, and campaign/account records | Drafting content locally and handing Cloud only durable hosted or paid actions |
+
+## Agent-First Entry Points
+
+- Chat: the user asks Eliza to build, deploy, monetize, promote, debug, or
+  manage an app; `eliza-cloud` owns Cloud API operations and
+  `build-monetized-app` owns new app launch flow.
+- Settings / account / AI model setup: connect Cloud, choose Cloud-backed
+  providers, view credits, top up org credits, and disconnect.
+- Native/desktop launcher: `cloud-apps` appears only when `cloudActive` is true.
+- Hosted web: `/dashboard/apps`, `/dashboard/apps/:id`, `/settings#billing`,
+  `/settings#api-keys`, `/dashboard/agents`, and `/dashboard/api-explorer`
+  are routed by `CloudRouterShell`.
+- Public links: `/login`, `/auth/*`, `/payment/*`, `/approve/*`,
+  `/invite/accept`, `/accept-invitation`, `/app-auth/authorize`,
+  `/terms-of-service`, and `/privacy-policy`.
+
+## Removed And Unified Surfaces
+
+Current unification already in the repo:
+
+- `packages/cloud-frontend` is deleted. `packages/app` is the single hosted web
+  build for both the apex Cloud console and `app.elizacloud.ai`.
+- `CloudRouterShell` is web-only. Native and desktop mount the local tab/view
+  app directly and use `cloud-apps-view` only for the Applications studio.
+- `cloud-apps` is gated by Cloud connection state and must not appear for a
+  disconnected user.
+- Legacy dashboard routes redirect into the unified app IA:
+  `dashboard/build/*` -> `dashboard/my-agents`,
+  media/gallery/voices -> `dashboard/api-explorer`,
+  containers -> agents,
+  agent chat deep links -> agent detail,
+  `dashboard/apps/create` -> `dashboard/apps`,
+  billing -> `settings#billing`,
+  API keys -> `settings#api-keys`,
+  documents -> agents.
+
+Targets for sibling cleanup work:
+
+- Keep one Cloud Applications surface for app list/detail, not separate
+  launcher tiles for domains, monetization, analytics, promotion, users, or
+  frontend deployments.
+- Keep one billing/settings entry for credits, checkout, auto top-up,
+  developer/API keys, connections, and organization/account management.
+- Keep one API Explorer for generation/media/API testing surfaces.
+- Keep one Agents surface for hosted agents, containers, instances, and old
+  container deep links.
+- Put app-specific domains, monetization, earnings, analytics, promote, users,
+  frontend deployments, and settings under the app detail route.
+
+## Source Of Truth
+
+- App platform status: `packages/cloud/APP_PLATFORM_REVIEW.md`
+- Cloud skill contract: `packages/skills/skills/eliza-cloud/SKILL.md`
+- App lifecycle reference:
+  `packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md`
+- Cloud router shell: `packages/ui/src/cloud/shell/CloudRouterShell.tsx`
+- Cloud route registration: `packages/ui/src/cloud/register-all.ts`
+- Applications routes: `packages/ui/src/cloud/applications/index.ts`
+- Native Applications tile: `packages/app/src/cloud-apps-view.ts`
+- Launcher Cloud gate: `packages/ui/src/components/pages/launcher-curation.ts`
+- Hosted web build/proxy: `packages/app/wrangler.toml`,
+  `packages/app/functions/_proxy.ts`, `packages/app/src/main.tsx`
+- Managed frontend API:
+  `packages/cloud/api/v1/apps/[id]/frontend/**/route.ts`
+- Public hosted frontend serve path:
+  `packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts`
+- Frontend hosting service:
+  `packages/cloud/shared/src/lib/services/app-frontend-hosting.ts`

--- a/packages/cloud/APP_PLATFORM_REVIEW.md
+++ b/packages/cloud/APP_PLATFORM_REVIEW.md
@@ -4,7 +4,8 @@ Issue: #10690
 Date: 2026-07-01
 
 This review maps the current Cloud app platform and fixes the product contract
-that agents should follow while the missing managed-frontend host is built.
+that agents should follow for the app record, managed frontend host, backend
+container, domain, analytics, monetization, and promotion lifecycle.
 
 ## Current Platform Map
 
@@ -13,8 +14,8 @@ that agents should follow while the missing managed-frontend host is built.
 | App lifecycle | `packages/cloud/api/v1/apps/route.ts`, `packages/cloud/api/v1/apps/[id]/route.ts`, `packages/cloud/shared/src/db/schemas/apps.ts`, `packages/cloud/shared/src/lib/services/apps.ts`, `packages/cloud/shared/src/lib/services/app-factory.ts` | Real. Apps are org-owned, have API keys, `app_url`, `allowed_origins`, `production_url`, GitHub repo metadata, deployment state, monetization fields, automation config, promotional assets, and usage counters. |
 | Backend hosting | `packages/cloud/api/v1/apps/[id]/deploy/route.ts`, `packages/cloud/api/v1/apps/[id]/deploy/status/route.ts`, `packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts`, `packages/cloud/shared/src/lib/services/app-deployments.ts`, `packages/cloud/shared/src/db/schemas/containers.ts`, `packages/cloud/shared/src/db/schemas/app-databases.ts`, `packages/cloud/services/container-control-plane/` | Real but production-gated. Container deploys are queued, quota-checked, billed, and run through the control-plane/Hetzner path when `APPS_DEPLOY_ENABLED=1` and the org allowlist permits it. |
 | Custom domains | `packages/cloud/api/v1/apps/[id]/domains/*/route.ts`, `packages/cloud/api/v1/domains/*/route.ts`, `packages/cloud/shared/src/db/schemas/app-domains.ts`, `packages/cloud/shared/src/db/schemas/managed-domains.ts`, `packages/cloud/shared/src/lib/services/managed-domains.ts`, `packages/cloud/shared/src/lib/services/domain-pricing.ts`, `packages/cloud/shared/src/lib/services/domain-health.ts`, `packages/cloud/shared/src/lib/services/domain-renewals.ts` | Real. Managed buys, external verification, DNS, SSL/status, health, and renewals exist. Live registration is money/secret gated and tracked by #10621/#10691. |
-| Analytics | `packages/cloud/api/v1/apps/[id]/analytics/route.ts`, `packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts`, `packages/cloud/api/v1/apps/[id]/users/route.ts`, `packages/cloud/shared/src/db/schemas/apps.ts`, `packages/cloud/shared/src/lib/services/app-analytics.ts`, `packages/cloud/shared/src/lib/services/analytics.ts`, `packages/cloud/shared/src/lib/services/analytics-derived.ts` | Real for API and request analytics. It does not yet include a first-class hosted-frontend page-view/session/funnel beacon. |
-| SEO and promotion | `packages/cloud/api/v1/apps/[id]/promote/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/preview/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/assets/route.ts`, `packages/cloud/shared/src/lib/services/app-promotion.ts`, `packages/cloud/shared/src/lib/services/app-promotion-assets.ts`, `packages/cloud/shared/src/lib/services/seo.ts` | Real but not fully effective for unhosted frontends. SEO can generate metadata/artifacts and promotion can post or configure channels, but Cloud cannot inject page metadata until it hosts or controls the frontend response. |
+| Analytics | `packages/cloud/api/v1/apps/[id]/analytics/route.ts`, `packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts`, `packages/cloud/api/v1/apps/[id]/users/route.ts`, `packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts`, `packages/cloud/shared/src/db/schemas/apps.ts`, `packages/cloud/shared/src/lib/services/app-analytics.ts`, `packages/cloud/shared/src/lib/services/analytics.ts`, `packages/cloud/shared/src/lib/services/analytics-derived.ts` | Real for API/request analytics and hosted-frontend page views. Session/funnel analytics remain a product tail. |
+| SEO and promotion | `packages/cloud/api/v1/apps/[id]/promote/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/preview/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/assets/route.ts`, `packages/cloud/shared/src/lib/services/app-promotion.ts`, `packages/cloud/shared/src/lib/services/app-promotion-assets.ts`, `packages/cloud/shared/src/lib/services/seo.ts`, `packages/cloud/shared/src/lib/services/app-frontend-hosting.ts` | Real. SEO can generate metadata/artifacts; managed frontend hosting injects metadata at response time, synthesizes `robots.txt`/`sitemap.xml` when absent, and external hosts still need the builder to install metadata manually. |
 | Advertising and growth | `packages/cloud/api/v1/advertising/**/route.ts`, `packages/cloud/shared/src/lib/services/advertising/`, `packages/cloud/shared/src/db/schemas/ad-accounts.ts`, `ad-campaigns.ts`, `ad-creatives.ts`, `ad-transactions.ts` | Real for advertiser-side Google/Meta/TikTok campaign/account/creative paths. Influencer marketplace, PR distribution, publisher inventory/SSP, brand approval, and more networks are tracked by #10687. |
 | Content generation | `packages/cloud/api/v1/generate-image/route.ts`, `generate-video/route.ts`, `generate-music/route.ts`, `generate-prompts/route.ts`, `packages/cloud/api/v1/apps/[id]/generate-image/route.ts`, `packages/cloud/shared/src/lib/services/generations.ts`, `packages/cloud/shared/src/db/schemas/generations.ts`, `packages/cloud/shared/src/lib/providers/image/` | Real for image, video, music, and prompt generation. Files/assets CRUD, video/audio provider registries, provider roster expansion, and scenario coverage are tracked by #10688/#10689. |
 | Agent skill contract | `packages/skills/skills/eliza-cloud/SKILL.md`, `references/apps-and-containers.md`, `references/cloud-backend-and-monetization.md`, `references/payments-and-promotion.md` | Real but needed a unified lifecycle reference. This PR adds `references/app-platform-lifecycle.md` and points the skill at it. |
@@ -41,25 +42,23 @@ identities.
 
 ## Frontend Hosting Decision
 
-Managed frontend hosting is the largest missing seam. The platform currently
-stores external `app_url` values and backend `production_url` values, but it
-does not own user frontend artifacts.
+Managed frontend hosting has landed on the recommended Worker/R2 static-host
+shape. The platform can now own user frontend artifacts without forcing a
+backend container for static apps.
 
-Use a Worker/R2 static-host implementation for first-class frontend hosting.
+Implemented shape:
 
-Recommended shape:
-
-- Store immutable frontend build artifacts in R2 under an org/app/deployment
+- Immutable frontend build artifacts are stored in R2 under an org/app/deployment
   prefix.
-- Add a frontend deployment record that points an app at the active manifest,
-  build metadata, content hash, and rollback target.
-- Serve hosted frontend responses through a Cloud Worker route or app hostname
-  handler so Cloud can inject analytics beacons, SEO metadata, security
+- `app_frontend_deployments` points an app at the active manifest, build
+  metadata, content hash, and rollback target.
+- Hosted frontend responses are served through the Cloud Worker route or app
+  hostname handler so Cloud can inject analytics beacons, SEO metadata, security
   headers, cache policy, and app-auth bootstrap consistently.
-- Keep container hosting for server-side workloads. Do not force a container for
-  static frontend-only apps.
-- Reuse existing app domains so a custom domain can target either the hosted
-  frontend, backend container, or an app-level routing policy.
+- Container hosting remains for server-side workloads. Do not force a container
+  for static frontend-only apps.
+- Existing app domains can target either the hosted frontend, backend container,
+  or an app-level routing policy.
 
 Why this path:
 
@@ -77,10 +76,10 @@ Why this path:
 > `apps/[id]/frontend` routes (publish/list/detail/activate-rollback/preview),
 > the public `hosted-frontend/serve` path with host→app resolution, SEO `<head>`
 > injection + a page-view beacon + server-side page-view recording, and the
-> `DEPLOY_FRONTEND` agent action + SDK methods. Remaining: `sitemap.xml`/`robots.txt`
-> generation, session/funnel analytics (slice 3 tail), the dashboard upload UI
-> (slice 4), and pointing production DNS/wildcard hosts at the Worker (operator,
-> tracked with the domain money-path in #10621).
+> `DEPLOY_FRONTEND` agent action + SDK methods. Remaining: session/funnel
+> analytics (slice 3 tail), the dashboard upload UI (slice 4), and pointing
+> production DNS/wildcard hosts at the Worker (operator, tracked with the
+> domain money-path in #10621).
 
 1. Frontend artifact model and routes:
    - schema/repository for frontend deployments and active manifest
@@ -112,8 +111,8 @@ Why this path:
 | App CRUD/auth | Available to authenticated org users/API keys | Keep org isolation and API-key custody enforced. |
 | Backend deploy | Production-gated by env and org allowlist | Keep gate until #10621 deploy image/secrets/staging evidence are done; expose clear 503/403 errors. |
 | Domains | Available by route, but live registrar depends on production keys and credits | Use #10691 for real purchase evidence; all paid buys need explicit confirmation. |
-| Analytics | Available for API/request paths | Add hosted frontend analytics only after frontend host exists. |
-| SEO | Available as artifacts/provider calls | Make response injection real through managed frontend hosting. |
+| Analytics | Available for API/request paths and hosted frontend page views | Add session/funnel analytics after the page-view base is stable. |
+| SEO | Available as artifacts/provider calls and managed-host response injection | External frontends still need the builder to install metadata. |
 | Advertising | Advertiser-side paid campaigns exist | Do not start spend without account ownership, policy, destination URL, creative, audience, and budget confirmation. |
 | Content generation | General media generation exists | Add files/assets CRUD and provider registries before treating generated assets as a managed library. |
 

--- a/packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md
+++ b/packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md
@@ -24,25 +24,33 @@ Use this order:
 
 ## Current Hosting Reality
 
-Cloud has first-class app records, app auth, backend container deploys, custom
-domains, analytics, monetization, promotion, advertising, and content
-generation. It does not yet have first-class managed frontend hosting for user
-build artifacts.
+Cloud has first-class app records, app auth, managed frontend hosting, backend
+container deploys, custom domains, analytics, monetization, promotion,
+advertising, and content generation.
 
-Until managed frontend hosting lands:
+Use this hosting split:
 
-- For static frontend-only apps, use an external/static host and register that
-  URL in `app_url` and `allowed_origins`.
-- For apps that need server-side code, deploy a container and use its
-  `production_url` or attached custom domain.
-- Do not claim Cloud can upload and serve arbitrary user frontend build output
-  as a managed static site yet.
-- Do not deploy a container just to get a static frontend online.
+- For static frontend-only apps, publish the built site with
+  `POST /api/v1/apps/:id/frontend` or the `DEPLOY_FRONTEND` agent action. Cloud
+  content-addresses the files to R2, creates an immutable frontend deployment,
+  and can activate it immediately. `GET /api/v1/apps/:id/frontend` lists
+  deployments and the active id.
+- Preview the active or selected deployment at
+  `/api/v1/apps/:id/frontend/preview`.
+- Public traffic is served from the app's system frontend host or a verified
+  active custom domain through the Cloud Worker/R2 serve path. Cloud injects SEO
+  metadata and a page-view analytics beacon into document responses and records
+  the page view server-side.
+- Activate an older deployment with
+  `POST /api/v1/apps/:id/frontend/:deploymentId/activate` to roll back.
+- Use an external/static host only when the app intentionally should not use
+  Cloud managed frontend hosting; register that URL in `app_url` and
+  `allowed_origins`.
+- Deploy a backend container only when the app needs server-side code.
 
-The planned managed frontend host should be Worker/R2 based: immutable frontend
-artifacts in R2, an active manifest on the app, Worker/hostname serving,
-SEO/meta injection, page analytics beaconing, cache policy, rollback, and
-domain routing through the existing app/domain model.
+Remaining product/operator gaps: dashboard upload/activate/rollback UI,
+production DNS/wildcard host pointing for all managed frontend hosts, and the
+remaining session/funnel analytics tail.
 
 ## Backend Container Rule
 
@@ -71,13 +79,13 @@ parent/user confirmation.
 
 ## Analytics And SEO Rule
 
-Current analytics are strongest for API/request usage. Page-view/session/funnel
-analytics become first-class once Cloud owns frontend responses.
+Cloud records API/request analytics and hosted-frontend page views. Session and
+funnel analytics are still product gaps.
 
-Current SEO can create metadata/artifacts, but Cloud cannot reliably inject
-them into arbitrary external frontends. For external hosts, return the metadata
-for the app builder to install. For managed frontend hosting, inject metadata,
-`robots.txt`, `sitemap.xml`, and structured data at the serving layer.
+For managed frontend hosting, Cloud owns the response and can inject metadata,
+SEO tags, page-view beaconing, `robots.txt`, `sitemap.xml`, and structured data
+at the serving layer. For external hosts, Cloud cannot reliably inject into the
+response; return the metadata for the app builder to install in that frontend.
 
 ## Promotion, Advertising, And Content
 
@@ -96,10 +104,18 @@ is real.
 ## Source Map
 
 - Platform review: `packages/cloud/APP_PLATFORM_REVIEW.md`
+- Agent-first experience plan: `packages/cloud/AGENT_FIRST_EXPERIENCE.md`
 - App routes: `packages/cloud/api/v1/apps/**/route.ts`
+- Frontend routes: `packages/cloud/api/v1/apps/[id]/frontend/**/route.ts`
+- Hosted frontend serve route:
+  `packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts`
 - Domain routes: `packages/cloud/api/v1/apps/[id]/domains/**/route.ts`
 - Backend deploy: `packages/cloud/api/v1/apps/[id]/deploy/route.ts`
 - App schema: `packages/cloud/shared/src/db/schemas/apps.ts`
+- Frontend deployment schema:
+  `packages/cloud/shared/src/db/schemas/app-frontend-deployments.ts`
+- Frontend hosting service:
+  `packages/cloud/shared/src/lib/services/app-frontend-hosting.ts`
 - Deploy services: `packages/cloud/shared/src/lib/services/app-deployments.ts`,
   `app-deploy-orchestrator.ts`
 - Promotion: `packages/cloud/shared/src/lib/services/app-promotion.ts`,


### PR DESCRIPTION
## Summary
- add an agent-first Eliza Cloud experience plan covering setup flow, hosted-vs-local ownership, entry points, and surface consolidation targets
- refresh the eliza-cloud app lifecycle reference now that managed frontend hosting exists
- align the app platform review with current managed frontend hosting, hosted page views, SEO injection, robots/sitemap synthesis, and remaining product/operator gaps

## Evidence
- .github/issue-evidence/11340-agent-first-cloud-experience.md

## Verification
- ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light
- git diff --check origin/develop
- stale managed-hosting phrase scan: no matches in touched docs
- required route/surface reference scan: pass
- bun run verify (fails at existing repo-wide type-safety ratchet: as unknown as 80/77 and core/agent/app-core ?? {} 379/377)

Closes #11340