### PR TITLE
fix(scheduling): re-land #11259 scheduler runtime (tz/cron/event-bridge) clobbered by #11271 (#11413)

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/after-task-chain.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/after-task-chain.test.ts
@@ -1,18 +1,21 @@
 /**
- * A9 — `trigger.kind: "after_task"` chain-after-terminal coverage.
+ * `trigger.kind: "after_task"` — chain-after-terminal contract.
  *
- * The spine schema accepts `trigger: { kind: "after_task"; taskId; outcome }`
- * with `outcome: TerminalState` (`completed | skipped | expired | failed |
- * dismissed`). The runner does NOT auto-fire from `after_task` triggers — the
- * scheduler tick is the entry point, and the in-memory test fixture has no
- * tick. These tests therefore lock down the **structural acceptance** plus
- * the schedule-time semantics: the child task is persisted with the
- * `after_task` trigger pointing at the parent, and remains in `scheduled`
- * even after the parent reaches the recorded terminal outcome.
+ * CONTRACT CHANGE (#10721/#10723 trigger-realness wave): the previous
+ * revision of this file pinned that the runner does NOT auto-fire `after_task`
+ * children, making the trigger kind contract larp — schema-accepted, never
+ * fired by anything. The trigger is live in the SCHEDULED_TASKS action (users
+ * create chains from chat without editing the parent) and is NOT redundant
+ * with `pipeline.on*`: pipeline refs are declared on the PARENT and only
+ * propagate completed/skipped/failed, while `after_task` is declared on the
+ * CHILD and covers all five terminal outcomes. The runner now fires matching
+ * children on the parent's terminal transition (`settleTerminal` /
+ * `fireAfterTaskChildren` in runner.ts), race-safe via the store's atomic
+ * fire claim.
  *
- * If the runner gains an `after_task` evaluator, the
- * "child does not auto-fire" assertion below is the contract that needs to
- * change first — making this file the canonical seam.
+ * These tests lock the new contract: structural acceptance, auto-fire on the
+ * matching outcome, no fire on mismatched outcome/parent, and the documented
+ * global-pause exception (pause suppresses chaining).
  */
 
 import { describe, expect, it } from "vitest";
@@ -42,7 +45,7 @@ import {
 import { createInMemoryScheduledTaskLogStore } from "./state-log.js";
 import type { GlobalPauseView, ScheduledTask, TerminalState } from "./types.js";
 
-function makeRunner(): {
+function makeRunner(opts: { pauseActive?: boolean } = {}): {
   runner: ScheduledTaskRunnerHandle;
   setNow: (iso: string) => void;
 } {
@@ -65,7 +68,7 @@ function makeRunner(): {
     consolidation: createConsolidationRegistry(),
     ownerFacts: () => ({}),
     globalPause: {
-      current: async () => ({ active: false }),
+      current: async () => ({ active: opts.pauseActive === true }),
     } as GlobalPauseView,
     activity: { hasSignalSince: () => false },
     subjectStore: { wasUpdatedSince: () => false },
@@ -122,6 +125,15 @@ async function forceParentTerminal(
   }
 }
 
+async function getTask(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const found = (await runner.list()).find((t) => t.taskId === taskId);
+  if (!found) throw new Error(`task ${taskId} not found`);
+  return found;
+}
+
 const TERMINAL_OUTCOMES: TerminalState[] = [
   "completed",
   "skipped",
@@ -150,9 +162,11 @@ describe("ScheduledTaskRunner — after_task trigger structural acceptance (A9)"
       expect(child.trigger.outcome).toBe(outcome);
     });
   }
+});
 
+describe("ScheduledTaskRunner — after_task children fire on the parent's terminal transition", () => {
   for (const outcome of TERMINAL_OUTCOMES) {
-    it(`child does NOT auto-fire when the parent reaches ${outcome} (no scheduler-tick in fixture)`, async () => {
+    it(`auto-fires the child when the parent reaches ${outcome}`, async () => {
       const { runner } = makeRunner();
       const parent = await runner.schedule(baseInput());
       const child = await runner.schedule(
@@ -164,18 +178,139 @@ describe("ScheduledTaskRunner — after_task trigger structural acceptance (A9)"
 
       await forceParentTerminal(runner, parent.taskId, outcome);
 
-      const reloadedParent = (await runner.list()).find(
-        (t) => t.taskId === parent.taskId,
-      );
-      expect(reloadedParent?.state.status).toBe(outcome);
-
-      const reloadedChild = (await runner.list()).find(
-        (t) => t.taskId === child.taskId,
-      );
-      expect(reloadedChild?.state.status).toBe("scheduled");
-      expect(reloadedChild?.state.firedAt).toBeUndefined();
+      expect((await getTask(runner, parent.taskId)).state.status).toBe(outcome);
+      const reloadedChild = await getTask(runner, child.taskId);
+      expect(reloadedChild.state.status).toBe("fired");
+      expect(reloadedChild.state.firedAt).toBe("2026-05-09T12:00:00.000Z");
     });
   }
+
+  it("does not fire a child whose recorded outcome mismatches the transition", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const onFailure = await runner.schedule(
+      baseInput({
+        promptInstructions: "chain after failed",
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "failed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, onFailure.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("does not fire a child pointing at a different parent", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const otherParent = await runner.schedule(baseInput());
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: otherParent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, child.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("fires every child chained on the same parent + outcome", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const first = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+    const second = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, first.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, second.taskId)).state.status).toBe("fired");
+  });
+
+  it("chains transitively: grandchild fires when the fired child later completes", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+    const grandchild = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: child.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+    expect((await getTask(runner, child.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, grandchild.taskId)).state.status).toBe(
+      "scheduled",
+    );
+
+    await runner.apply(child.taskId, "complete", { reason: "test" });
+    expect((await getTask(runner, grandchild.taskId)).state.status).toBe(
+      "fired",
+    );
+  });
+
+  it("global-pause skip does NOT chain: pause suppresses proactive behavior", async () => {
+    const { runner } = makeRunner({ pauseActive: true });
+    const parent = await runner.schedule(
+      baseInput({ respectsGlobalPause: true }),
+    );
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "skipped",
+        },
+      }),
+    );
+
+    const result = await runner.fireWithResult(parent.taskId);
+    expect(result.kind).toBe("skipped");
+    expect((await getTask(runner, parent.taskId)).state.status).toBe("skipped");
+    expect((await getTask(runner, child.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
 });
 
 describe("ScheduledTaskRunner — after_task trigger fire path is verb-driven (A9)", () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -160,3 +160,59 @@ describe("ScheduledTask due evaluation", () => {
     expect(pendingPromptRoomIdForTask(fired)).toBe("room-1");
   });
 });
+
+describe("owner_local cron tz resolution", () => {
+  // 2026-05-10 is inside US daylight time: America/Denver = UTC-6.
+  const trigger = {
+    kind: "cron",
+    expression: "0 9 * * *",
+    tz: "owner_local",
+  } as const;
+
+  it("is NOT due at 09:05 UTC when the owner is in America/Denver (03:05 local)", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T08:00:00.000Z" },
+      }),
+      {
+        now: new Date("2026-05-10T09:05:00.000Z"),
+        ownerFacts: { timezone: "America/Denver" },
+      },
+    );
+    expect(decision).toMatchObject({ due: false, reason: "cron_pending" });
+  });
+
+  it("is due at the Denver hour (15:00 UTC) — not the UTC hour", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T14:00:00.000Z" },
+      }),
+      {
+        now: new Date("2026-05-10T15:05:00.000Z"),
+        ownerFacts: { timezone: "America/Denver" },
+      },
+    );
+    expect(decision).toMatchObject({
+      due: true,
+      reason: "cron_due",
+      occurrenceAtIso: "2026-05-10T15:00:00.000Z",
+    });
+  });
+
+  it("resolves owner_local to UTC when the owner has no timezone on file", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T08:00:00.000Z" },
+      }),
+      { now: new Date("2026-05-10T09:05:00.000Z"), ownerFacts: {} },
+    );
+    expect(decision).toMatchObject({
+      due: true,
+      reason: "cron_due",
+      occurrenceAtIso: "2026-05-10T09:00:00.000Z",
+    });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -1,6 +1,7 @@
 import { computeNextCronRunAtMs } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
   ScheduledTask,
@@ -232,6 +233,7 @@ function cronDue(
   task: ScheduledTask,
   trigger: Extract<ScheduledTaskTrigger, { kind: "cron" }>,
   nowMs: number,
+  ownerFacts: OwnerFactsView | undefined,
 ): ScheduledTaskDueDecision {
   const baseMs =
     parseIsoMs(task.state.firedAt) ??
@@ -246,7 +248,11 @@ function cronDue(
   if (baseMs > nowMs) {
     return { due: false, reason: "cron_pending" };
   }
-  const nextMs = computeNextCronRunAtMs(trigger.expression, baseMs, trigger.tz);
+  const nextMs = computeNextCronRunAtMs(
+    trigger.expression,
+    baseMs,
+    resolveTriggerTz(trigger.tz, ownerFacts),
+  );
   if (nextMs === null) return { due: false, reason: "cron_invalid" };
   return nextMs <= nowMs
     ? {
@@ -443,7 +449,7 @@ export async function isScheduledTaskDue(
     case "interval":
       return intervalDue(task, task.trigger, nowMs);
     case "cron":
-      return cronDue(task, task.trigger, nowMs);
+      return cronDue(task, task.trigger, nowMs, context.ownerFacts);
     case "relative_to_anchor":
       return relativeAnchorDue(task, task.trigger, context, nowMs);
     case "during_window":

--- a/plugins/plugin-scheduling/src/scheduled-task/event-bridge.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/event-bridge.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Event-trigger bridge coverage: `runtime.emitEvent(eventKind, payload)` must
+ * fire `{ kind: "event" }` scheduled tasks exactly once, honor the optional
+ * payload filter, fan out to every matching task, and stay race-safe under
+ * concurrent emits via the store's atomic claim.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "./completion-check-registry.js";
+import {
+  createAnchorRegistry,
+  createConsolidationRegistry,
+} from "./consolidation-policy.js";
+import {
+  createEscalationLadderRegistry,
+  registerDefaultEscalationLadders,
+} from "./escalation.js";
+import {
+  eventFilterMatches,
+  fireEventTriggeredTasks,
+  installScheduledTaskEventBridge,
+} from "./event-bridge.js";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./gate-registry.js";
+import {
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  type ScheduledTaskRunnerHandle,
+  TestNoopScheduledTaskDispatcher,
+} from "./runner.js";
+import { createInMemoryScheduledTaskLogStore } from "./state-log.js";
+import type { GlobalPauseView, ScheduledTask } from "./types.js";
+
+function makeRunner(): ScheduledTaskRunnerHandle {
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  let counter = 0;
+  return createScheduledTaskRunner({
+    agentId: "test-agent",
+    store: createInMemoryScheduledTaskStore(),
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ({}),
+    globalPause: {
+      current: async () => ({ active: false }),
+    } as GlobalPauseView,
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    newTaskId: () => {
+      counter += 1;
+      return `task_${counter}`;
+    },
+    now: () => new Date("2026-06-01T12:00:00.000Z"),
+  });
+}
+
+const eventTaskInput = (
+  eventKind: string,
+  overrides: Partial<Omit<ScheduledTask, "taskId" | "state">> = {},
+): Omit<ScheduledTask, "taskId" | "state"> => ({
+  kind: "watcher",
+  promptInstructions: `react to ${eventKind}`,
+  trigger: { kind: "event", eventKind },
+  priority: "medium",
+  respectsGlobalPause: false,
+  source: "user_chat",
+  createdBy: "tester",
+  ownerVisible: true,
+  ...overrides,
+});
+
+async function getTask(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const found = (await runner.list()).find((t) => t.taskId === taskId);
+  if (!found) throw new Error(`task ${taskId} not found`);
+  return found;
+}
+
+/**
+ * Minimal runtime standing in for core's event registry: same
+ * name-keyed handler map + `runtime`/`source` payload injection semantics as
+ * `AgentRuntime.registerEvent` / `emitEvent`. The `emit` helper takes the
+ * producer's plain data payload (core's `emitEvent` overloads require
+ * `EventPayload`-typed params; production emitters spread `runtime` in
+ * themselves, which `emit` mirrors here).
+ */
+function makeEventRuntime(): {
+  runtime: IAgentRuntime;
+  emit: (event: string, params?: Record<string, unknown>) => Promise<void>;
+} {
+  const events = new Map<
+    string,
+    Array<(params: Record<string, unknown>) => Promise<void>>
+  >();
+  const runtime = {
+    agentId: "test-agent",
+    registerEvent(event: string, handler: (params: never) => Promise<void>) {
+      const list = events.get(event) ?? [];
+      list.push(handler as (params: Record<string, unknown>) => Promise<void>);
+      events.set(event, list);
+    },
+    unregisterEvent(event: string, handler: (params: never) => Promise<void>) {
+      const list = (events.get(event) ?? []).filter((h) => h !== handler);
+      if (list.length > 0) events.set(event, list);
+      else events.delete(event);
+    },
+  } as unknown as IAgentRuntime;
+  const emit = async (
+    event: string,
+    params: Record<string, unknown> = {},
+  ): Promise<void> => {
+    const handlers = events.get(event);
+    if (!handlers) return;
+    const paramsWithRuntime = { ...params, runtime, source: "runtime" };
+    await Promise.all(handlers.map((handler) => handler(paramsWithRuntime)));
+  };
+  return { runtime, emit };
+}
+
+describe("eventFilterMatches", () => {
+  it("matches everything when the filter is absent", () => {
+    expect(eventFilterMatches(undefined, { a: 1 })).toBe(true);
+    expect(eventFilterMatches(null, undefined)).toBe(true);
+  });
+
+  it("subset-matches object filters against the payload", () => {
+    expect(
+      eventFilterMatches(
+        { calendarId: "work" },
+        { calendarId: "work", title: "standup" },
+      ),
+    ).toBe(true);
+    expect(
+      eventFilterMatches({ calendarId: "work" }, { calendarId: "personal" }),
+    ).toBe(false);
+    expect(eventFilterMatches({ calendarId: "work" }, {})).toBe(false);
+  });
+
+  it("deep-matches nested objects and exact arrays", () => {
+    expect(
+      eventFilterMatches(
+        { meeting: { room: "A" } },
+        { meeting: { room: "A", floor: 2 } },
+      ),
+    ).toBe(true);
+    expect(eventFilterMatches({ tags: ["a", "b"] }, { tags: ["a", "b"] })).toBe(
+      true,
+    );
+    expect(eventFilterMatches({ tags: ["a"] }, { tags: ["a", "b"] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("fireEventTriggeredTasks", () => {
+  it("fires a matching event task exactly once and leaves other kinds alone", async () => {
+    const runner = makeRunner();
+    const matching = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+    const otherKind = await runner.schedule(eventTaskInput("time.lunch.start"));
+    const cronTask = await runner.schedule(
+      eventTaskInput("unused", {
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
+      }),
+    );
+
+    const outcome = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { meetingId: "m1" },
+    });
+
+    expect(outcome.errors).toEqual([]);
+    expect(outcome.results).toHaveLength(1);
+    expect(outcome.results[0]).toMatchObject({
+      taskId: matching.taskId,
+      result: { kind: "fired" },
+    });
+    expect((await getTask(runner, matching.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, otherKind.taskId)).state.status).toBe(
+      "scheduled",
+    );
+    expect((await getTask(runner, cronTask.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("does not fire when the trigger filter mismatches the payload", async () => {
+    const runner = makeRunner();
+    const filtered = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended", {
+        trigger: {
+          kind: "event",
+          eventKind: "calendar.meeting.ended",
+          filter: { calendarId: "work" },
+        },
+      }),
+    );
+
+    const mismatch = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { calendarId: "personal" },
+    });
+    expect(mismatch.results).toHaveLength(0);
+    expect((await getTask(runner, filtered.taskId)).state.status).toBe(
+      "scheduled",
+    );
+
+    const match = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { calendarId: "work", title: "standup" },
+    });
+    expect(match.results).toHaveLength(1);
+    expect((await getTask(runner, filtered.taskId)).state.status).toBe("fired");
+  });
+
+  it("fires every task subscribed to the same event kind", async () => {
+    const runner = makeRunner();
+    const first = await runner.schedule(eventTaskInput("time.morning.start"));
+    const second = await runner.schedule(eventTaskInput("time.morning.start"));
+
+    const outcome = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "time.morning.start",
+    });
+
+    expect(outcome.results.map((r) => r.result.kind)).toEqual([
+      "fired",
+      "fired",
+    ]);
+    expect((await getTask(runner, first.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, second.taskId)).state.status).toBe("fired");
+  });
+
+  it("is race-safe: concurrent emits of one event fire the task once", async () => {
+    const runner = makeRunner();
+    const task = await runner.schedule(eventTaskInput("health.wake.confirmed"));
+
+    const [first, second] = await Promise.all([
+      fireEventTriggeredTasks({ runner, eventKind: "health.wake.confirmed" }),
+      fireEventTriggeredTasks({ runner, eventKind: "health.wake.confirmed" }),
+    ]);
+
+    const kinds = [
+      ...first.results.map((r) => r.result.kind),
+      ...second.results.map((r) => r.result.kind),
+    ];
+    expect(kinds.filter((k) => k === "fired")).toHaveLength(1);
+    expect(kinds.filter((k) => k === "fired" || k === "raced")).toEqual(kinds);
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, task.taskId)).state.firedAt).toBe(
+      "2026-06-01T12:00:00.000Z",
+    );
+  });
+});
+
+describe("installScheduledTaskEventBridge", () => {
+  it("fires event tasks from runtime.emitEvent and stops after uninstall", async () => {
+    const runner = makeRunner();
+    const { runtime, emit } = makeEventRuntime();
+    const task = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+
+    const uninstall = installScheduledTaskEventBridge({
+      runtime,
+      eventKinds: ["calendar.meeting.ended"],
+      getRunner: () => runner,
+    });
+
+    await emit("calendar.meeting.ended", { meetingId: "m1" });
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+
+    const second = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+    uninstall();
+    await emit("calendar.meeting.ended", { meetingId: "m2" });
+    expect((await getTask(runner, second.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("strips the injected runtime field before filter matching", async () => {
+    const runner = makeRunner();
+    const { runtime, emit } = makeEventRuntime();
+    const task = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended", {
+        trigger: {
+          kind: "event",
+          eventKind: "calendar.meeting.ended",
+          filter: { calendarId: "work" },
+        },
+      }),
+    );
+
+    installScheduledTaskEventBridge({
+      runtime,
+      eventKinds: ["calendar.meeting.ended"],
+      getRunner: () => runner,
+    });
+
+    await emit("calendar.meeting.ended", { calendarId: "work" });
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/event-bridge.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/event-bridge.ts
@@ -1,0 +1,176 @@
+/**
+ * Runtime-event → ScheduledTask fire bridge.
+ *
+ * `trigger.kind = "event"` tasks are push-fired: `isScheduledTaskDue`
+ * deliberately reports them not-due (the tick never wall-clock fires them),
+ * so something must map bus events onto `runner.fireWithResult`. This module
+ * is that mapping: a consumer (e.g. `@elizaos/plugin-personal-assistant`)
+ * installs a `runtime.registerEvent` handler per registered event kind, and
+ * every `runtime.emitEvent(eventKind, payload)` fires the scheduled tasks
+ * whose trigger matches `{ kind: "event", eventKind }` and whose optional
+ * `filter` subset-matches the emitted payload.
+ *
+ * Race safety: firing goes through `fireWithResult`, whose store-level
+ * atomic claim (`scheduled` → `fired`) guarantees one dispatch per task even
+ * when the same event is emitted concurrently — the loser observes `raced`.
+ */
+
+import { type EventPayload, type IAgentRuntime, logger } from "@elizaos/core";
+import type {
+  ScheduledTaskFireResult,
+  ScheduledTaskRunnerHandle,
+} from "./runner.js";
+
+const LOG_SRC = "ScheduledTaskEventBridge";
+
+/**
+ * The narrow runner surface the bridge needs. `list` finds candidate tasks;
+ * `fireWithResult` performs the race-safe fire.
+ */
+export type EventBridgeRunner = Pick<
+  ScheduledTaskRunnerHandle,
+  "list" | "fireWithResult"
+>;
+
+/**
+ * Subset-match an event trigger's `filter` against the emitted payload.
+ *
+ * Contract:
+ *  - `undefined` / `null` filter matches every payload.
+ *  - A plain-object filter matches when EVERY key it declares deep-equals the
+ *    corresponding payload field (payloads may carry extra fields).
+ *  - Arrays and primitives require exact deep equality.
+ */
+export function eventFilterMatches(filter: unknown, payload: unknown): boolean {
+  if (filter === undefined || filter === null) return true;
+  return subsetDeepEquals(filter, payload);
+}
+
+function subsetDeepEquals(expected: unknown, actual: unknown): boolean {
+  if (expected === actual) return true;
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      return false;
+    }
+    return expected.every((item, index) =>
+      subsetDeepEquals(item, actual[index]),
+    );
+  }
+  if (
+    typeof expected === "object" &&
+    expected !== null &&
+    typeof actual === "object" &&
+    actual !== null &&
+    !Array.isArray(actual)
+  ) {
+    return Object.entries(expected as Record<string, unknown>).every(
+      ([key, value]) =>
+        subsetDeepEquals(value, (actual as Record<string, unknown>)[key]),
+    );
+  }
+  return false;
+}
+
+export interface FireEventTriggeredTasksArgs {
+  runner: EventBridgeRunner;
+  eventKind: string;
+  payload?: unknown;
+}
+
+export interface EventTriggeredFireOutcome {
+  /** One entry per matched task, in `list` order. */
+  results: Array<{ taskId: string; result: ScheduledTaskFireResult }>;
+  /** Store/runner errors per task — surfaced, never swallowed silently. */
+  errors: Array<{ taskId: string; message: string }>;
+}
+
+/**
+ * Fire every `scheduled` task whose trigger matches the emitted event.
+ * Per-task errors are collected (and logged by the installer's handler) so
+ * one broken row cannot starve the other listeners of the same event.
+ */
+export async function fireEventTriggeredTasks(
+  args: FireEventTriggeredTasksArgs,
+): Promise<EventTriggeredFireOutcome> {
+  const scheduled = await args.runner.list({ status: "scheduled" });
+  const outcome: EventTriggeredFireOutcome = { results: [], errors: [] };
+  for (const task of scheduled) {
+    if (task.trigger.kind !== "event") continue;
+    if (task.trigger.eventKind !== args.eventKind) continue;
+    if (!eventFilterMatches(task.trigger.filter, args.payload)) continue;
+    try {
+      const result = await args.runner.fireWithResult(task.taskId, {
+        eventPayload: args.payload,
+      });
+      outcome.results.push({ taskId: task.taskId, result });
+    } catch (error) {
+      outcome.errors.push({
+        taskId: task.taskId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return outcome;
+}
+
+export interface InstallScheduledTaskEventBridgeArgs {
+  runtime: IAgentRuntime;
+  /**
+   * The event kinds to subscribe. Consumers enumerate their
+   * `EventKindRegistry` (events registered AFTER install are not picked up —
+   * re-install or install after registry population).
+   */
+  eventKinds: readonly string[];
+  /**
+   * Resolved per event so the bridge always fires through the current cached
+   * runner (never a stale handle with a frozen clock).
+   */
+  getRunner: () => EventBridgeRunner;
+}
+
+/**
+ * Subscribe `runtime.emitEvent(eventKind, …)` to event-triggered task fires.
+ * Returns an uninstall function that unregisters every handler.
+ *
+ * The handler strips the non-data envelope fields (`runtime`, `onComplete`)
+ * from the payload before filter matching and before the payload is handed to
+ * `fireWithResult` as the persisted `eventPayload`. `source` is kept: it is a
+ * plain producer string and a legitimate filter target.
+ */
+export function installScheduledTaskEventBridge(
+  args: InstallScheduledTaskEventBridgeArgs,
+): () => void {
+  const { runtime, getRunner } = args;
+  const registrations: Array<{
+    eventKind: string;
+    handler: (params: EventPayload) => Promise<void>;
+  }> = [];
+  for (const eventKind of args.eventKinds) {
+    const handler = async (params: EventPayload): Promise<void> => {
+      const { runtime: _runtime, onComplete: _onComplete, ...payload } = params;
+      const outcome = await fireEventTriggeredTasks({
+        runner: getRunner(),
+        eventKind,
+        payload,
+      });
+      for (const failure of outcome.errors) {
+        logger.error(
+          {
+            src: LOG_SRC,
+            agentId: runtime.agentId,
+            eventKind,
+            taskId: failure.taskId,
+          },
+          `[${LOG_SRC}] event-triggered fire failed: ${failure.message}`,
+        );
+      }
+    };
+    runtime.registerEvent(eventKind, handler);
+    registrations.push({ eventKind, handler });
+  }
+  return () => {
+    for (const { eventKind, handler } of registrations) {
+      runtime.unregisterEvent(eventKind, handler);
+    }
+  };
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -49,6 +49,15 @@ export {
   resolveEffectiveLadder,
 } from "./escalation.js";
 export {
+  type EventBridgeRunner,
+  type EventTriggeredFireOutcome,
+  eventFilterMatches,
+  type FireEventTriggeredTasksArgs,
+  fireEventTriggeredTasks,
+  type InstallScheduledTaskEventBridgeArgs,
+  installScheduledTaskEventBridge,
+} from "./event-bridge.js";
+export {
   createTaskGateRegistry,
   registerBuiltInGates,
   type TaskGateRegistry,
@@ -100,6 +109,7 @@ export {
   type ScheduledTaskLogStore,
   STATE_LOG_DEFAULT_RETENTION_DAYS,
 } from "./state-log.js";
+export { OWNER_LOCAL_TZ, resolveTriggerTz } from "./trigger-tz.js";
 export type {
   ActivitySignalBusView,
   AnchorConsolidationMode,

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.test.ts
@@ -178,3 +178,17 @@ describe("computeNextFireAt trigger baselines (no override)", () => {
     expect(next).toBeNull();
   });
 });
+
+describe("computeNextFireAt owner_local cron tz resolution", () => {
+  it("indexes the next fire at the owner's local hour, not the UTC hour", async () => {
+    // NOW = 2026-05-11T12:00Z. Denver (UTC-6, daylight time): 06:00 local.
+    // Daily 9am owner_local => next fire today at 15:00Z, not 2026-05-12T09:00Z.
+    const next = await computeNextFireAt(
+      taskWith({
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "owner_local" },
+      }),
+      { now: NOW, ownerFacts: { timezone: "America/Denver" }, anchors: null },
+    );
+    expect(next).toBe("2026-05-11T15:00:00.000Z");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
@@ -18,6 +18,7 @@
 import { computeNextCronRunAtMs } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
   ScheduledTask,
@@ -290,7 +291,7 @@ export async function computeNextFireAt(
       const nextMs = computeNextCronRunAtMs(
         trigger.expression,
         baseMs,
-        trigger.tz,
+        resolveTriggerTz(trigger.tz, context.ownerFacts),
       );
       return nextMs === null ? null : new Date(nextMs).toISOString();
     }

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -12,6 +12,10 @@
  *  - `idempotencyKey` deduplicates schedules.
  *  - `pipeline.onSkip` wins over `completionCheck.followupAfterMinutes` when
  *    both are set.
+ *  - `trigger.kind = "after_task"` children auto-fire when the parent reaches
+ *    the recorded terminal outcome through a runner transition (verbs,
+ *    gate-deny skip, dispatch failure, `pipeline()`), EXCEPT the global-pause
+ *    skip: pause suppresses proactive behavior, and chaining is proactive.
  */
 
 import { decideDispatchPolicy } from "../dispatch-policy.js";
@@ -795,7 +799,7 @@ export function createScheduledTaskRunner(
     await logger.log(task.taskId, "skipped", {
       reason: payload?.reason ?? "user skipped",
     });
-    await runPipeline(task, "skipped");
+    await settleTerminal(task, "skipped");
     return task;
   }
 
@@ -808,7 +812,7 @@ export function createScheduledTaskRunner(
     task.state.lastDecisionLog = payload?.reason ?? "completed";
     await persist(task);
     await logger.log(task.taskId, "completed", { reason: payload?.reason });
-    await runPipeline(task, "completed");
+    await settleTerminal(task, "completed");
     return task;
   }
 
@@ -820,6 +824,9 @@ export function createScheduledTaskRunner(
     task.state.lastDecisionLog = payload?.reason ?? "dismissed";
     await persist(task);
     await logger.log(task.taskId, "dismissed", { reason: payload?.reason });
+    // `pipeline.on*` deliberately does not propagate `dismissed`; `after_task`
+    // children DO cover it (the trigger union records all five outcomes).
+    await fireAfterTaskChildren(task, "dismissed");
     return task;
   }
 
@@ -946,8 +953,51 @@ export function createScheduledTaskRunner(
   }
 
   // -------------------------------------------------------------------------
-  // Pipeline propagation
+  // Pipeline propagation + after_task chaining
   // -------------------------------------------------------------------------
+
+  /**
+   * Fire every `scheduled` task whose trigger is
+   * `{ kind: "after_task", taskId: parent, outcome }`. This is the push side
+   * of the `after_task` contract (`isScheduledTaskDue` reports these tasks
+   * not-due, so the tick never wall-clock fires them). Firing goes through
+   * `fireWithResult`, whose atomic claim makes concurrent terminal
+   * transitions race-safe — one dispatch per child, losers observe `raced`.
+   *
+   * Unlike `pipeline.on*` (declared on the parent), `after_task` is declared
+   * on the CHILD, so chains can be attached without editing the parent, and
+   * they cover ALL five terminal outcomes (`pipeline` only propagates
+   * completed / skipped / failed).
+   */
+  async function fireAfterTaskChildren(
+    parent: ScheduledTask,
+    outcome: TerminalState,
+  ): Promise<void> {
+    const scheduled = await deps.store.list({ status: "scheduled" });
+    for (const child of scheduled) {
+      if (child.trigger.kind !== "after_task") continue;
+      if (child.trigger.taskId !== parent.taskId) continue;
+      if (child.trigger.outcome !== outcome) continue;
+      await fireWithResult(child.taskId, {
+        eventPayload: { afterTask: { taskId: parent.taskId, outcome } },
+      });
+    }
+  }
+
+  /**
+   * The single terminal-transition seam: propagate `pipeline.on*` refs, then
+   * fire matching `after_task` children. Every runner path that records a
+   * terminal outcome routes through here (the global-pause skip deliberately
+   * does not — pause suppresses chaining).
+   */
+  async function settleTerminal(
+    parent: ScheduledTask,
+    outcome: TerminalState,
+  ): Promise<ScheduledTask[]> {
+    const created = await runPipeline(parent, outcome);
+    await fireAfterTaskChildren(parent, outcome);
+    return created;
+  }
 
   async function runPipeline(
     parent: ScheduledTask,
@@ -1030,7 +1080,7 @@ export function createScheduledTaskRunner(
         reason: `pipeline: ${outcome}`,
       });
     }
-    return runPipeline(task, outcome);
+    return settleTerminal(task, outcome);
   }
 
   function outcomeToLogTransition(
@@ -1107,7 +1157,7 @@ export function createScheduledTaskRunner(
         message: failure.error.message,
       },
     });
-    await runPipeline(claimed, "failed");
+    await settleTerminal(claimed, "failed");
     return { kind: "dispatch_failed", task: claimed, error: failure.error };
   }
 
@@ -1194,7 +1244,7 @@ export function createScheduledTaskRunner(
       await logger.log(task.taskId, "skipped", {
         reason: task.state.lastDecisionLog,
       });
-      await runPipeline(task, "skipped");
+      await settleTerminal(task, "skipped");
       return {
         kind: "skipped",
         task,
@@ -1510,7 +1560,7 @@ export function createScheduledTaskRunner(
       reason: `dispatch_failed:${reason}`,
       detail: { message: detailMessage },
     });
-    await runPipeline(task, "failed");
+    await settleTerminal(task, "failed");
     return {
       kind: "dispatch_failed",
       task,

--- a/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
@@ -1,0 +1,23 @@
+import type { OwnerFactsView } from "./types.js";
+
+/**
+ * Sentinel `tz` value on cron triggers meaning "the owner's timezone,
+ * whatever it currently is". Default task packs use it so a pack authored
+ * once fires at the owner's local hour everywhere.
+ */
+export const OWNER_LOCAL_TZ = "owner_local";
+
+/**
+ * Resolve a cron trigger's `tz` to a concrete IANA zone before it reaches
+ * core's cron scheduler. `owner_local` resolves against owner facts, with an
+ * explicit UTC fallback when the owner has no timezone on file. Any other
+ * value passes through unchanged — core warns once and evaluates in UTC for
+ * invalid IANA names.
+ */
+export function resolveTriggerTz(
+  tz: string,
+  ownerFacts: OwnerFactsView | undefined,
+): string {
+  if (tz === OWNER_LOCAL_TZ) return ownerFacts?.timezone ?? "UTC";
+  return tz;
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -119,6 +119,17 @@ export interface ScheduledTaskContextRequest {
   includeEventPayload?: boolean;
 }
 
+/**
+ * Push-fired kinds (never wall-clock due; `isScheduledTaskDue` reports them
+ * not-due and `next_fire_at` stays NULL):
+ *  - `event` — fired by the runtime event bridge when
+ *    `runtime.emitEvent(eventKind, payload)` matches the trigger (see
+ *    `event-bridge.ts`; `filter` subset-matches the payload).
+ *  - `after_task` — fired by the runner when the referenced parent task
+ *    reaches the recorded terminal `outcome` (all five terminal states,
+ *    unlike `pipeline.on*`; the global-pause skip does not chain).
+ *  - `manual` — fired only by an explicit `fire()` call.
+ */
 export type ScheduledTaskTrigger =
   | { kind: "once"; atIso: string }
   | { kind: "cron"; expression: string; tz: string }


### PR DESCRIPTION
Part of #11413. Re-lands the **dependency root** of the reverted #11259 one-scheduler runtime: `plugin-scheduling`'s core, which #11271's stale-base squash byte-reverted (trigger-tz.ts + event-bridge.ts were DELETED at develop tip).

Restored from the pre-clobber parent `5b714c74e60^` (blob-identity verified):
- **trigger-tz.ts** (re-created) — `OWNER_LOCAL_TZ` + `resolveTriggerTz` seam. Without it, `buildTzFormatter`'s catch→null makes an invalid `owner_local` trigger tz silently evaluate as UTC (wrong fire times).
- **event-bridge.ts** (re-created) — the scheduled-task event bridge `index.ts` imports.
- **due.ts / next-fire-at.ts** — call `resolveTriggerTz(trigger.tz, ownerFacts)` instead of passing raw `trigger.tz` to the cron computation.
- index.ts / runner.ts / types.ts + the scheduled-task tests.

**Additive & safe:** it restores the tz seam + event bridge the good merges added; it removes nothing develop's current (clobbered) consumers use. Landing this **first** so the follow-up goals/calendar/PA re-lands (which import `OWNER_LOCAL_TZ` from this package) resolve cleanly once CI rebuilds this dist.

**Verified:** `plugin-scheduling` typecheck clean (0 errors); `bun test src/scheduled-task/` → **207 pass / 0 fail**; clean rebuild confirms `OWNER_LOCAL_TZ` exported from dist.

Next slices under #11413: goals + calendar + PA (checkin/completion-checks), then feed/benchmarks. — nubs-cloud [cloud-frontdoor]