### PR TITLE
fix(goals): re-land goal check-in service + runtime clobbered by #11271 (#11413)

### DIFF
--- a/plugins/plugin-goals/package.json
+++ b/plugins/plugin-goals/package.json
@@ -53,6 +53,7 @@
     "@elizaos/agent": "workspace:*",
     "@elizaos/app-core": "workspace:*",
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-scheduling": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/ui": "workspace:*",
     "drizzle-orm": "0.45.2",

--- a/plugins/plugin-goals/src/actions/goals.ts
+++ b/plugins/plugin-goals/src/actions/goals.ts
@@ -26,6 +26,11 @@ import {
 import type { LifeOpsGoalRecord } from "@elizaos/shared";
 import { GoalsServiceError } from "../goal-normalize.ts";
 import { createOwnerGoalsService } from "../goals-runtime.ts";
+import {
+  GOAL_CHECKIN_PROGRESS_STATES,
+  type GoalCheckinProgress,
+  getGoalsCheckinService,
+} from "../services/checkin.ts";
 import { GOAL_ACTIONS, GOALS_CONTEXTS, GOALS_LOG_PREFIX } from "../types.ts";
 
 type GoalSubaction = (typeof GOAL_ACTIONS)[number];
@@ -34,6 +39,15 @@ interface GoalActionParams {
   id?: string;
   title?: string;
   description?: string;
+  note?: string;
+  progress?: string;
+}
+
+function parseCheckinProgress(
+  value: string | undefined,
+): GoalCheckinProgress | undefined {
+  if (value === undefined) return undefined;
+  return GOAL_CHECKIN_PROGRESS_STATES.find((state) => state === value);
 }
 
 const SUBACTIONS: SubactionsMap<GoalSubaction> = {
@@ -59,6 +73,13 @@ const SUBACTIONS: SubactionsMap<GoalSubaction> = {
     descriptionCompressed: "review owner goal state by id",
     required: ["id"],
   },
+  checkin: {
+    description:
+      "Record the owner's check-in response for a goal by id: optional note plus progress (on_track | at_risk | needs_attention).",
+    descriptionCompressed: "record goal check-in response by id",
+    required: ["id"],
+    optional: ["note", "progress"],
+  },
 };
 
 function describeGoal(record: LifeOpsGoalRecord): string {
@@ -68,9 +89,9 @@ function describeGoal(record: LifeOpsGoalRecord): string {
 export const ownerGoalsAction: Action = {
   name: "OWNER_GOALS",
   description:
-    "Manage the owner's long-horizon life goals. Actions: create, update, delete, review. Goals carry a horizon (e.g. quarter, year, life) and feed routine + reminder generation.",
+    "Manage the owner's long-horizon life goals. Actions: create, update, delete, review, checkin. Goals carry a horizon (e.g. quarter, year, life), feed routine + reminder generation, and cadenced goals get scheduled check-ins whose responses are recorded via checkin.",
   descriptionCompressed:
-    "owner goals: create|update|delete|review; long-horizon, drives routines",
+    "owner goals: create|update|delete|review|checkin; long-horizon, drives routines",
   contexts: [...GOALS_CONTEXTS],
   contextGate: { anyOf: [...GOALS_CONTEXTS] },
   roleGate: { minRole: "ADMIN" },
@@ -106,6 +127,21 @@ export const ownerGoalsAction: Action = {
       description: "Longer goal description (create/update).",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "note",
+      description: "Owner's check-in note (checkin).",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "progress",
+      description: "Reported goal progress (checkin).",
+      required: false,
+      schema: {
+        type: "string" as const,
+        enum: [...GOAL_CHECKIN_PROGRESS_STATES],
+      },
     },
   ],
   validate: async (_runtime: IAgentRuntime): Promise<boolean> => true,
@@ -174,6 +210,41 @@ export const ownerGoalsAction: Action = {
           const text = `Goal "${describeGoal(record)}" is ${record.goal.reviewState.replace(/_/g, " ")} (status: ${record.goal.status}).`;
           await callback?.({ text });
           return { success: true, text, data: { action: "review", record } };
+        }
+        case "checkin": {
+          const checkinService = getGoalsCheckinService(runtime);
+          if (!checkinService) {
+            const text = `${GOALS_LOG_PREFIX} the goal check-in engine is not available on this runtime.`;
+            await callback?.({ text });
+            return {
+              success: false,
+              text,
+              data: { action: "checkin", error: "checkin_service_missing" },
+            };
+          }
+          const progress = parseCheckinProgress(params.progress);
+          if (params.progress !== undefined && progress === undefined) {
+            const text = `${GOALS_LOG_PREFIX} progress must be one of: ${GOAL_CHECKIN_PROGRESS_STATES.join(", ")}.`;
+            await callback?.({ text });
+            return {
+              success: false,
+              text,
+              data: { action: "checkin", error: "invalid_progress" },
+            };
+          }
+          const { goal, completedTaskId } =
+            await checkinService.recordCheckinResponse({
+              goalId: params.id ?? "",
+              ...(params.note !== undefined ? { note: params.note } : {}),
+              ...(progress !== undefined ? { progress } : {}),
+            });
+          const text = `Logged check-in for "${goal.title}"${progress ? ` — ${progress.replace(/_/g, " ")}` : ""}.`;
+          await callback?.({ text });
+          return {
+            success: true,
+            text,
+            data: { action: "checkin", goal, completedTaskId },
+          };
         }
       }
     } catch (error) {

--- a/plugins/plugin-goals/src/goals-runtime.ts
+++ b/plugins/plugin-goals/src/goals-runtime.ts
@@ -27,6 +27,7 @@ import {
   type GoalsRecordAudit,
   GoalsService,
 } from "./goals-service.ts";
+import { getGoalsCheckinService } from "./services/checkin.ts";
 
 /** Owner-entity id PA derives for the admin/owner entity of an agent. */
 export function ownerEntityIdFor(runtime: IAgentRuntime): string {
@@ -79,5 +80,9 @@ export function createOwnerGoalsService(runtime: IAgentRuntime): GoalsService {
     });
   };
 
-  return new GoalsService(runtime, { recordAudit, normalizeOwnership });
+  return new GoalsService(runtime, {
+    recordAudit,
+    normalizeOwnership,
+    checkinSync: () => getGoalsCheckinService(runtime),
+  });
 }

--- a/plugins/plugin-goals/src/goals-service.ts
+++ b/plugins/plugin-goals/src/goals-service.ts
@@ -161,15 +161,29 @@ export type GoalsNormalizeOwnership = (
   current?: LifeOpsOwnership,
 ) => LifeOpsOwnership;
 
+/**
+ * Check-in engine hook. Implemented by `GoalsCheckinService`
+ * (`./services/checkin.ts`); wired lazily by both construction sites so goal
+ * writes keep per-goal check-in tasks on the scheduling spine in sync. A
+ * `null` resolution means no check-in engine runs on this runtime (e.g. the
+ * service is not registered) and goal writes proceed without scheduling.
+ */
+export interface GoalsCheckinSync {
+  syncGoalCheckins(goal: LifeOpsGoalDefinition): Promise<unknown>;
+  removeGoalCheckins(goalId: string): Promise<unknown>;
+}
+
 export interface GoalsServiceDependencies {
   recordAudit: GoalsRecordAudit;
   normalizeOwnership: GoalsNormalizeOwnership;
+  checkinSync?: () => GoalsCheckinSync | null;
 }
 
 export class GoalsService {
   readonly repository: GoalsRepository;
   private readonly recordAudit: GoalsRecordAudit;
   private readonly normalizeOwnership: GoalsNormalizeOwnership;
+  private readonly resolveCheckinSync: () => GoalsCheckinSync | null;
 
   constructor(
     private readonly runtime: IAgentRuntime,
@@ -178,6 +192,7 @@ export class GoalsService {
     this.repository = new GoalsRepository(runtime);
     this.recordAudit = deps.recordAudit;
     this.normalizeOwnership = deps.normalizeOwnership;
+    this.resolveCheckinSync = deps.checkinSync ?? (() => null);
   }
 
   private agentId(): string {
@@ -210,6 +225,7 @@ export class GoalsService {
       { title: goal.title },
       {},
     );
+    await this.resolveCheckinSync()?.removeGoalCheckins(goalId);
   }
 
   async listGoals(): Promise<LifeOpsGoalRecord[]> {
@@ -293,6 +309,8 @@ export class GoalsService {
           reviewState: dedupCandidate.record.reviewState,
         },
       );
+      // Idempotent heal: the dedup winner may predate the check-in engine.
+      await this.resolveCheckinSync()?.syncGoalCheckins(dedupCandidate.record);
       return {
         goal: dedupCandidate.record,
         links,
@@ -352,6 +370,7 @@ export class GoalsService {
         reviewState: goal.reviewState,
       },
     );
+    await this.resolveCheckinSync()?.syncGoalCheckins(goal);
     return {
       goal,
       links: [],
@@ -422,6 +441,7 @@ export class GoalsService {
         reviewState: nextGoal.reviewState,
       },
     );
+    await this.resolveCheckinSync()?.syncGoalCheckins(nextGoal);
     return {
       goal: nextGoal,
       links: current.links,

--- a/plugins/plugin-goals/src/plugin.ts
+++ b/plugins/plugin-goals/src/plugin.ts
@@ -20,8 +20,8 @@ const GOALS_PLUGIN_NAME = "@elizaos/plugin-goals";
 export const goalsPlugin: Plugin = {
   name: GOALS_PLUGIN_NAME,
   description:
-    "Life direction: owner-set long-horizon goals, goals/routines/reminders schema, and a self-care / mood / journal panel. Routines, reminders, alarms, and daily check-in handlers are still host-adapted by @elizaos/plugin-personal-assistant during migration.",
-  dependencies: ["@elizaos/plugin-sql"],
+    "Life direction: owner-set long-horizon goals with per-goal check-ins on the scheduling spine, goals/routines/reminders schema, and a self-care / mood / journal panel. Routines, reminders, and alarms are still host-adapted by @elizaos/plugin-personal-assistant during migration.",
+  dependencies: ["@elizaos/plugin-sql", "@elizaos/plugin-scheduling"],
   // Only OWNER_GOALS has been fully migrated into this standalone package.
   // Routines/reminders/alarms remain host-adapted PA actions for now; do not
   // register their scaffold handlers here.

--- a/plugins/plugin-goals/src/services/checkin.ts
+++ b/plugins/plugin-goals/src/services/checkin.ts
@@ -1,45 +1,629 @@
 /**
- * GoalsCheckinService — daily check-in engine for plugin-goals.
+ * GoalsCheckinService — per-goal check-in engine on the scheduling spine.
  *
- * STUB. The full implementation will be migrated from:
- *   plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts
- *   plugins/plugin-personal-assistant/src/lifeops/checkin/schedule-resolver.ts
- *   plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts
+ * Goal check-ins are plain `ScheduledTask` records (`kind: "checkin"`) on
+ * `@elizaos/plugin-scheduling`'s runner, created idempotently per goal +
+ * cadence slot and fired by the production tick/dispatcher like every other
+ * scheduled task. This service owns three seams:
  *
- * For the scaffold phase the service exists as a registered Service so the
- * plugin manifest is self-contained. Once foundations (core scheduler,
- * owner-state, registries) land, the PA CheckinService body — collectors,
- * acknowledgement window, escalation ladder, briefing assembly — moves into
- * this file.
+ *  - `syncGoalCheckins(goal)` — reconcile the goal's check-in tasks with its
+ *    current status + cadence (create missing slots, edit changed triggers,
+ *    dismiss slots the cadence no longer declares). Called by `GoalsService`
+ *    after every goal write via the `checkinSync` hook, and once per goal at
+ *    boot.
+ *  - `removeGoalCheckins(goalId)` — dismiss all live check-in tasks for a
+ *    deleted goal.
+ *  - `recordCheckinResponse(args)` — route an owner check-in response into
+ *    goal progress: complete the fired task, append a bounded
+ *    `metadata.checkinLog` entry, set `reviewState` from the reported
+ *    progress, and write a `goal_updated` audit event.
+ *
+ * Cron slots use the `owner_local` tz sentinel so check-ins fire at the
+ * owner's local hour wherever they are (resolved by the spine against
+ * owner facts).
+ *
+ * Deliberate non-features: a slot the owner dismissed is never resurrected
+ * for the same trigger shape (spine seed semantics); a goal with no cadence
+ * (or an unusable one) schedules no check-ins — that is logged, not padded
+ * with invented defaults.
  */
 
+import crypto from "node:crypto";
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
-
+import {
+  getScheduledTaskRunner,
+  OWNER_LOCAL_TZ,
+  type ScheduledTask,
+  type ScheduledTaskInput,
+  type ScheduledTaskRunnerHandle,
+  ScheduledTaskRunnerService,
+  type ScheduledTaskStatus,
+  type ScheduledTaskTrigger,
+  type TerminalState,
+} from "@elizaos/plugin-scheduling";
+import type {
+  LifeOpsGoalDefinition,
+  LifeOpsGoalReviewState,
+} from "@elizaos/shared";
+import { GoalsRepository } from "../db/goals-repository.ts";
+import { fail, requireAgentId } from "../goal-normalize.ts";
+import type { GoalsCheckinSync } from "../goals-service.ts";
 import { GOALS_CHECKIN_SERVICE_TYPE, GOALS_LOG_PREFIX } from "../types.ts";
 
-export class GoalsCheckinService extends Service {
+/** `createdBy` stamp identifying check-in tasks this engine owns. */
+export const GOAL_CHECKIN_CREATED_BY = "@elizaos/plugin-goals";
+
+/** Dismissal reason recorded when a cadence change retires a slot. */
+export const GOAL_CHECKIN_SYNC_DISMISS_REASON = "goal_checkin_sync";
+
+/** Bounded length of the per-goal `metadata.checkinLog` history. */
+export const GOAL_CHECKIN_LOG_LIMIT = 50;
+
+/** Progress states an owner check-in response may assign to a goal. */
+export const GOAL_CHECKIN_PROGRESS_STATES = [
+  "on_track",
+  "at_risk",
+  "needs_attention",
+] as const satisfies readonly LifeOpsGoalReviewState[];
+export type GoalCheckinProgress = (typeof GOAL_CHECKIN_PROGRESS_STATES)[number];
+
+const TERMINAL_TASK_STATUSES: ReadonlySet<ScheduledTaskStatus> =
+  new Set<TerminalState>([
+    "completed",
+    "skipped",
+    "expired",
+    "failed",
+    "dismissed",
+  ]);
+
+/**
+ * Representative owner-local hour for each named LifeOps time window.
+ * `custom` windows carry per-definition minutes the goal cadence does not,
+ * so they cannot be mapped here and are skipped with a warning.
+ */
+const WINDOW_HOURS: Readonly<Record<string, number>> = {
+  morning: 9,
+  afternoon: 15,
+  evening: 18,
+  night: 21,
+};
+
+export interface GoalCheckinPlan {
+  /** Stable slot identity within the goal (part of the idempotency key). */
+  slotKey: string;
+  trigger: ScheduledTaskTrigger;
+}
+
+export function checkinIdempotencyKey(goalId: string, slotKey: string): string {
+  return `goals:checkin:${goalId}:${slotKey}`;
+}
+
+function warnCadence(goalId: string, detail: string): void {
+  logger.warn(
+    `${GOALS_LOG_PREFIX} [GoalsCheckinService] goal ${goalId}: ${detail} — no check-in scheduled for it`,
+  );
+}
+
+function windowHoursOf(windows: unknown, goalId: string): number[] {
+  if (!Array.isArray(windows)) {
+    warnCadence(goalId, "cadence.windows is not an array");
+    return [];
+  }
+  const hours = new Set<number>();
+  for (const window of windows) {
+    const hour = typeof window === "string" ? WINDOW_HOURS[window] : undefined;
+    if (hour === undefined) {
+      warnCadence(
+        goalId,
+        `unsupported cadence window ${JSON.stringify(window)}`,
+      );
+      continue;
+    }
+    hours.add(hour);
+  }
+  return [...hours].sort((a, b) => a - b);
+}
+
+function cronWeekdaysOf(weekdays: unknown, goalId: string): number[] {
+  if (!Array.isArray(weekdays)) {
+    warnCadence(goalId, "cadence.weekdays is not an array");
+    return [];
+  }
+  const days = new Set<number>();
+  for (const day of weekdays) {
+    if (
+      typeof day === "number" &&
+      Number.isInteger(day) &&
+      day >= 0 &&
+      day <= 6
+    ) {
+      days.add(day);
+    } else {
+      warnCadence(goalId, `unsupported cadence weekday ${JSON.stringify(day)}`);
+    }
+  }
+  return [...days].sort((a, b) => a - b);
+}
+
+function ownerLocalCron(expression: string): ScheduledTaskTrigger {
+  return { kind: "cron", expression, tz: OWNER_LOCAL_TZ };
+}
+
+/**
+ * Map a goal's cadence (`LifeOpsCadence`-shaped `Record`) to concrete
+ * check-in trigger slots. Pure; validated field-by-field because
+ * `LifeOpsGoalDefinition.cadence` is persisted as an untyped record.
+ * Unusable cadences yield `[]` and a warning — never an invented default.
+ */
+export function checkinTriggersForGoal(
+  goal: LifeOpsGoalDefinition,
+): GoalCheckinPlan[] {
+  const cadence = goal.cadence;
+  if (!cadence) return [];
+  const kind = cadence.kind;
+  switch (kind) {
+    case "once": {
+      const dueAt = cadence.dueAt;
+      if (typeof dueAt !== "string" || Number.isNaN(Date.parse(dueAt))) {
+        warnCadence(goal.id, "once cadence has no parseable dueAt");
+        return [];
+      }
+      return [{ slotKey: "once", trigger: { kind: "once", atIso: dueAt } }];
+    }
+    case "daily": {
+      const hours = windowHoursOf(cadence.windows, goal.id);
+      if (hours.length === 0) return [];
+      return [
+        {
+          slotKey: "daily",
+          trigger: ownerLocalCron(`0 ${hours.join(",")} * * *`),
+        },
+      ];
+    }
+    case "weekly": {
+      const hours = windowHoursOf(cadence.windows, goal.id);
+      const days = cronWeekdaysOf(cadence.weekdays, goal.id);
+      if (hours.length === 0 || days.length === 0) return [];
+      return [
+        {
+          slotKey: "weekly",
+          trigger: ownerLocalCron(`0 ${hours.join(",")} * * ${days.join(",")}`),
+        },
+      ];
+    }
+    case "interval": {
+      const everyMinutes = cadence.everyMinutes;
+      if (
+        typeof everyMinutes !== "number" ||
+        !Number.isInteger(everyMinutes) ||
+        everyMinutes <= 0
+      ) {
+        warnCadence(goal.id, "interval cadence has no positive everyMinutes");
+        return [];
+      }
+      return [
+        { slotKey: "interval", trigger: { kind: "interval", everyMinutes } },
+      ];
+    }
+    case "times_per_day": {
+      const slots = cadence.slots;
+      if (!Array.isArray(slots) || slots.length === 0) {
+        warnCadence(goal.id, "times_per_day cadence has no slots");
+        return [];
+      }
+      const plans: GoalCheckinPlan[] = [];
+      for (const slot of slots) {
+        const record =
+          slot && typeof slot === "object" && !Array.isArray(slot)
+            ? (slot as Record<string, unknown>)
+            : null;
+        const key = record?.key;
+        const minuteOfDay = record?.minuteOfDay;
+        if (
+          typeof key !== "string" ||
+          key.length === 0 ||
+          typeof minuteOfDay !== "number" ||
+          !Number.isInteger(minuteOfDay) ||
+          minuteOfDay < 0 ||
+          minuteOfDay >= 24 * 60
+        ) {
+          warnCadence(
+            goal.id,
+            `unsupported times_per_day slot ${JSON.stringify(slot)}`,
+          );
+          continue;
+        }
+        const hour = Math.floor(minuteOfDay / 60);
+        const minute = minuteOfDay % 60;
+        plans.push({
+          slotKey: `slot-${key}`,
+          trigger: ownerLocalCron(`${minute} ${hour} * * *`),
+        });
+      }
+      return plans;
+    }
+    default:
+      warnCadence(goal.id, `unsupported cadence kind ${JSON.stringify(kind)}`);
+      return [];
+  }
+}
+
+/**
+ * Build the spine task input for one goal check-in slot. `nowIso` becomes
+ * `metadata.createdAtIso` — the cron due-scan base — so a fresh check-in
+ * never "catches up" an occurrence from before the slot existed.
+ */
+export function buildCheckinTaskInput(
+  goal: LifeOpsGoalDefinition,
+  plan: GoalCheckinPlan,
+  nowIso: string,
+): ScheduledTaskInput {
+  return {
+    kind: "checkin",
+    promptInstructions: `Run a goal check-in for "${goal.title}": ask the owner how progress toward this goal is going, listen for wins and blockers, and record their response against the goal.`,
+    trigger: plan.trigger,
+    priority: "medium",
+    respectsGlobalPause: true,
+    completionCheck: {
+      kind: "user_replied_within",
+      params: { lookbackMinutes: 60 },
+      followupAfterMinutes: 30,
+    },
+    contextRequest: {
+      includeOwnerFacts: ["preferredName", "timezone"],
+      includeRecentTaskStates: { kind: "checkin", lookbackHours: 48 },
+    },
+    idempotencyKey: checkinIdempotencyKey(goal.id, plan.slotKey),
+    source: "plugin",
+    createdBy: GOAL_CHECKIN_CREATED_BY,
+    ownerVisible: true,
+    metadata: {
+      goalId: goal.id,
+      goalTitle: goal.title,
+      slotKey: plan.slotKey,
+      createdAtIso: nowIso,
+    },
+  };
+}
+
+export interface GoalCheckinSyncResult {
+  scheduled: ScheduledTask[];
+  edited: ScheduledTask[];
+  dismissedTaskIds: string[];
+}
+
+export interface RecordGoalCheckinArgs {
+  goalId: string;
+  /** Specific fired task to complete; defaults to the latest fired one. */
+  taskId?: string;
+  note?: string;
+  progress?: GoalCheckinProgress;
+}
+
+export interface GoalCheckinLogEntry {
+  atIso: string;
+  taskId: string | null;
+  note: string | null;
+  progress: GoalCheckinProgress | null;
+}
+
+function readCheckinLog(
+  metadata: Record<string, unknown>,
+): GoalCheckinLogEntry[] {
+  const raw = metadata.checkinLog;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((entry): entry is GoalCheckinLogEntry => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return false;
+    }
+    return typeof (entry as Record<string, unknown>).atIso === "string";
+  });
+}
+
+export class GoalsCheckinService extends Service implements GoalsCheckinSync {
   static override readonly serviceType = GOALS_CHECKIN_SERVICE_TYPE;
 
   override capabilityDescription =
-    "Daily check-in engine: morning/night reports, mood/journal capture, acknowledgement-driven tone escalation.";
+    "Per-goal check-in engine on the scheduling spine: creates cadence-driven checkin tasks per goal, dismisses them when goals close, and records check-in responses into goal progress.";
+
+  private repositoryInstance: GoalsRepository | null = null;
+  private warnedSpineMissing = false;
+  private readonly now: () => Date;
+
+  constructor(runtime?: IAgentRuntime, now: () => Date = () => new Date()) {
+    super(runtime);
+    this.now = now;
+  }
 
   static override async start(
     runtime: IAgentRuntime,
   ): Promise<GoalsCheckinService> {
     logger.info(`${GOALS_LOG_PREFIX} starting GoalsCheckinService`);
-    return new GoalsCheckinService(runtime);
+    const service = new GoalsCheckinService(runtime);
+    void service.reconcileWhenReady();
+    return service;
   }
 
   override async stop(): Promise<void> {
     logger.info(`${GOALS_LOG_PREFIX} stopping GoalsCheckinService`);
   }
 
-  // TODO(migrate from plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts):
-  //   - runCheckin(request: RunCheckinRequest): Promise<CheckinReport>
-  //   - recordAcknowledgement(request: RecordAcknowledgementRequest): Promise<void>
-  //   - briefing assembly: getCheckinBriefing(kind, scope) -> sections
-  //   - escalation ladder + acknowledgement window
-  //   - collectors for habits / overdue todos / recent wins / sleep recap
+  private rt(): IAgentRuntime {
+    if (!this.runtime) {
+      throw new Error(
+        "GoalsCheckinService: runtime is not bound; was the service started?",
+      );
+    }
+    return this.runtime;
+  }
+
+  private repository(): GoalsRepository {
+    if (!this.repositoryInstance) {
+      this.repositoryInstance = new GoalsRepository(this.rt());
+    }
+    return this.repositoryInstance;
+  }
+
+  private runner(): ScheduledTaskRunnerHandle {
+    const runtime = this.rt();
+    return getScheduledTaskRunner(runtime, {
+      agentId: requireAgentId(runtime),
+    });
+  }
+
+  /**
+   * The spine is a declared plugin dependency, so in production this is
+   * always true. Test/minimal runtimes without `@elizaos/plugin-scheduling`
+   * get goal CRUD without scheduled check-ins — warned once, not silent.
+   */
+  private spineAvailable(): boolean {
+    if (this.rt().hasService(ScheduledTaskRunnerService.serviceType)) {
+      return true;
+    }
+    if (!this.warnedSpineMissing) {
+      this.warnedSpineMissing = true;
+      logger.warn(
+        `${GOALS_LOG_PREFIX} [GoalsCheckinService] scheduling spine not registered on this runtime; goal check-ins are NOT scheduled`,
+      );
+    }
+    return false;
+  }
+
+  private async listGoalTasks(
+    runner: ScheduledTaskRunnerHandle,
+    goalId: string,
+  ): Promise<ScheduledTask[]> {
+    const tasks = await runner.list({ kind: "checkin" });
+    return tasks.filter(
+      (task) =>
+        task.createdBy === GOAL_CHECKIN_CREATED_BY &&
+        task.metadata?.goalId === goalId,
+    );
+  }
+
+  /**
+   * Reconcile one goal's check-in tasks with its current status + cadence.
+   * Idempotent: unchanged slots are left untouched (spine idempotency-key
+   * dedupe), changed triggers are edited in place, retired slots are
+   * dismissed, and a slot the owner already dismissed stays dismissed.
+   */
+  async syncGoalCheckins(
+    goal: LifeOpsGoalDefinition,
+  ): Promise<GoalCheckinSyncResult> {
+    if (!this.spineAvailable()) {
+      return { scheduled: [], edited: [], dismissedTaskIds: [] };
+    }
+    const runner = this.runner();
+    const nowIso = this.now().toISOString();
+    const plans = goal.status === "active" ? checkinTriggersForGoal(goal) : [];
+    const desired = plans.map((plan) =>
+      buildCheckinTaskInput(goal, plan, nowIso),
+    );
+    const existing = await this.listGoalTasks(runner, goal.id);
+    const desiredKeys = new Set(desired.map((input) => input.idempotencyKey));
+
+    const dismissedTaskIds: string[] = [];
+    for (const task of existing) {
+      if (task.idempotencyKey && desiredKeys.has(task.idempotencyKey)) {
+        continue;
+      }
+      if (TERMINAL_TASK_STATUSES.has(task.state.status)) continue;
+      await runner.apply(task.taskId, "dismiss", {
+        reason: GOAL_CHECKIN_SYNC_DISMISS_REASON,
+      });
+      dismissedTaskIds.push(task.taskId);
+    }
+
+    const scheduled: ScheduledTask[] = [];
+    const edited: ScheduledTask[] = [];
+    for (const input of desired) {
+      const current = existing.find(
+        (task) => task.idempotencyKey === input.idempotencyKey,
+      );
+      if (!current) {
+        scheduled.push(await runner.schedule(input));
+        continue;
+      }
+      // A dismissed slot is a deliberate off-switch (owner or sync); never
+      // resurrect it for the same trigger shape.
+      if (current.state.status === "dismissed") continue;
+      const triggerChanged =
+        JSON.stringify(current.trigger) !== JSON.stringify(input.trigger);
+      const titleChanged = current.metadata?.goalTitle !== goal.title;
+      if (triggerChanged || titleChanged) {
+        edited.push(
+          await runner.apply(current.taskId, "edit", {
+            trigger: input.trigger,
+            promptInstructions: input.promptInstructions,
+            metadata: { ...current.metadata, goalTitle: goal.title },
+          }),
+        );
+      }
+    }
+
+    if (
+      scheduled.length > 0 ||
+      edited.length > 0 ||
+      dismissedTaskIds.length > 0
+    ) {
+      logger.info(
+        `${GOALS_LOG_PREFIX} [GoalsCheckinService] synced check-ins for goal ${goal.id}: ${scheduled.length} scheduled, ${edited.length} edited, ${dismissedTaskIds.length} dismissed`,
+      );
+    }
+    return { scheduled, edited, dismissedTaskIds };
+  }
+
+  /** Dismiss all live check-in tasks for a deleted goal. */
+  async removeGoalCheckins(
+    goalId: string,
+  ): Promise<{ dismissedTaskIds: string[] }> {
+    if (!this.spineAvailable()) {
+      return { dismissedTaskIds: [] };
+    }
+    const runner = this.runner();
+    const existing = await this.listGoalTasks(runner, goalId);
+    const dismissedTaskIds: string[] = [];
+    for (const task of existing) {
+      if (TERMINAL_TASK_STATUSES.has(task.state.status)) continue;
+      await runner.apply(task.taskId, "dismiss", {
+        reason: GOAL_CHECKIN_SYNC_DISMISS_REASON,
+      });
+      dismissedTaskIds.push(task.taskId);
+    }
+    if (dismissedTaskIds.length > 0) {
+      logger.info(
+        `${GOALS_LOG_PREFIX} [GoalsCheckinService] dismissed ${dismissedTaskIds.length} check-in task(s) for deleted goal ${goalId}`,
+      );
+    }
+    return { dismissedTaskIds };
+  }
+
+  /**
+   * Route an owner check-in response into goal progress: complete the fired
+   * check-in task (when one is live), append a bounded `checkinLog` entry to
+   * the goal's metadata, set `reviewState` from the reported progress, and
+   * write a `goal_updated` audit event.
+   */
+  async recordCheckinResponse(
+    args: RecordGoalCheckinArgs,
+  ): Promise<{ goal: LifeOpsGoalDefinition; completedTaskId: string | null }> {
+    const runtime = this.rt();
+    const agentId = requireAgentId(runtime);
+    const goal = await this.repository().getGoal(agentId, args.goalId);
+    if (!goal) {
+      fail(404, "life-ops goal not found");
+    }
+
+    const spine = this.spineAvailable();
+    const tasks = spine ? await this.listGoalTasks(this.runner(), goal.id) : [];
+    let target: ScheduledTask | undefined;
+    if (args.taskId) {
+      target = tasks.find((task) => task.taskId === args.taskId);
+      if (!target) {
+        fail(404, `check-in task ${args.taskId} not found for goal`);
+      }
+    } else {
+      target = tasks
+        .filter(
+          (task) =>
+            task.state.status === "fired" ||
+            task.state.status === "acknowledged",
+        )
+        .sort(
+          (a, b) =>
+            Date.parse(b.state.firedAt ?? "") -
+            Date.parse(a.state.firedAt ?? ""),
+        )[0];
+    }
+
+    let completedTaskId: string | null = null;
+    if (
+      target &&
+      (target.state.status === "fired" ||
+        target.state.status === "acknowledged")
+    ) {
+      await this.runner().apply(target.taskId, "complete", {
+        note: args.note ?? null,
+        progress: args.progress ?? null,
+      });
+      completedTaskId = target.taskId;
+    }
+
+    const atIso = this.now().toISOString();
+    const entry: GoalCheckinLogEntry = {
+      atIso,
+      taskId: completedTaskId,
+      note: args.note ?? null,
+      progress: args.progress ?? null,
+    };
+    const checkinLog = [...readCheckinLog(goal.metadata), entry].slice(
+      -GOAL_CHECKIN_LOG_LIMIT,
+    );
+    const updated: LifeOpsGoalDefinition = {
+      ...goal,
+      reviewState: args.progress ?? goal.reviewState,
+      metadata: { ...goal.metadata, checkinLog },
+      updatedAt: atIso,
+    };
+    await this.repository().updateGoal(updated);
+    await this.repository().createAuditEvent({
+      id: crypto.randomUUID(),
+      agentId,
+      eventType: "goal_updated",
+      ownerType: "goal",
+      ownerId: goal.id,
+      reason: "goal check-in response recorded",
+      inputs: {
+        taskId: completedTaskId,
+        note: entry.note,
+        progress: entry.progress,
+      },
+      decision: {
+        reviewState: updated.reviewState,
+        checkinCount: checkinLog.length,
+      },
+      actor: "user",
+      createdAt: atIso,
+    });
+    logger.info(
+      `${GOALS_LOG_PREFIX} [GoalsCheckinService] recorded check-in response for goal ${goal.id} (task ${completedTaskId ?? "none"}, progress ${entry.progress ?? "unchanged"})`,
+    );
+    return { goal: updated, completedTaskId };
+  }
+
+  /**
+   * Boot reconcile: once the runtime finished initializing, sync every goal
+   * so pre-existing goals (created before this engine, or while the spine
+   * was unavailable) get their check-in tasks. Failures are logged, not
+   * fatal — every subsequent goal write re-syncs its own goal.
+   */
+  private async reconcileWhenReady(): Promise<void> {
+    const runtime = this.rt();
+    try {
+      await runtime.initPromise;
+      if (!runtime.hasService(ScheduledTaskRunnerService.serviceType)) {
+        logger.info(
+          `${GOALS_LOG_PREFIX} [GoalsCheckinService] scheduling spine not registered on this runtime; skipping goal check-in reconcile`,
+        );
+        return;
+      }
+      await runtime.getServiceLoadPromise(
+        ScheduledTaskRunnerService.serviceType,
+      );
+      const goals = await this.repository().listGoals(requireAgentId(runtime));
+      for (const goal of goals) {
+        await this.syncGoalCheckins(goal);
+      }
+      logger.info(
+        `${GOALS_LOG_PREFIX} [GoalsCheckinService] boot reconcile complete for ${goals.length} goal(s)`,
+      );
+    } catch (error) {
+      logger.error(
+        { error },
+        `${GOALS_LOG_PREFIX} [GoalsCheckinService] boot check-in reconcile failed; goal writes will re-sync individually`,
+      );
+    }
+  }
 }
 
 export function getGoalsCheckinService(

--- a/plugins/plugin-goals/src/types.ts
+++ b/plugins/plugin-goals/src/types.ts
@@ -10,7 +10,13 @@
 export const GOALS_CONTEXTS = ["goals", "self_care", "owner"] as const;
 export type GoalsContext = (typeof GOALS_CONTEXTS)[number];
 
-export const GOAL_ACTIONS = ["create", "update", "delete", "review"] as const;
+export const GOAL_ACTIONS = [
+  "create",
+  "update",
+  "delete",
+  "review",
+  "checkin",
+] as const;
 export type GoalActionName = (typeof GOAL_ACTIONS)[number];
 
 export const ROUTINE_ACTIONS = [

--- a/plugins/plugin-goals/test/goals-service.test.ts
+++ b/plugins/plugin-goals/test/goals-service.test.ts
@@ -10,7 +10,6 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ownerGoalsAction } from "../src/actions/goals.ts";
-import { GoalsRepository } from "../src/db/goals-repository.ts";
 import { GoalsServiceError } from "../src/goal-normalize.ts";
 import { createOwnerGoalsService } from "../src/goals-runtime.ts";
 import {
@@ -126,6 +125,10 @@ function makeRuntime(): {
   const runtime = {
     agentId: AGENT_ID,
     adapter: { db: { execute } },
+    // No GoalsCheckinService registered in this SQL-shim runtime: the
+    // checkinSync hook resolves null and goal writes skip check-in sync.
+    getService: () => null,
+    hasService: () => false,
   } as unknown as IAgentRuntime;
 
   return { runtime, goals, links, audits, executedSql };

--- a/plugins/plugin-goals/test/plugin.test.ts
+++ b/plugins/plugin-goals/test/plugin.test.ts
@@ -19,9 +19,12 @@ import * as goalsExports from "../src/index.ts";
 import { GoalsCheckinService, GoalsView, goalsPlugin } from "../src/index.ts";
 
 describe("goalsPlugin manifest", () => {
-  it("identifies as @elizaos/plugin-goals and depends on plugin-sql", () => {
+  it("identifies as @elizaos/plugin-goals and depends on plugin-sql + the scheduling spine", () => {
     expect(goalsPlugin.name).toBe("@elizaos/plugin-goals");
-    expect(goalsPlugin.dependencies).toEqual(["@elizaos/plugin-sql"]);
+    expect(goalsPlugin.dependencies).toEqual([
+      "@elizaos/plugin-sql",
+      "@elizaos/plugin-scheduling",
+    ]);
   });
 
   it("registers exactly one view: the gui `goals` surface", () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/after-task-chain.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/after-task-chain.test.ts
@@ -1,18 +1,21 @@
 /**
- * A9 — `trigger.kind: "after_task"` chain-after-terminal coverage.
+ * `trigger.kind: "after_task"` — chain-after-terminal contract.
  *
- * The spine schema accepts `trigger: { kind: "after_task"; taskId; outcome }`
- * with `outcome: TerminalState` (`completed | skipped | expired | failed |
- * dismissed`). The runner does NOT auto-fire from `after_task` triggers — the
- * scheduler tick is the entry point, and the in-memory test fixture has no
- * tick. These tests therefore lock down the **structural acceptance** plus
- * the schedule-time semantics: the child task is persisted with the
- * `after_task` trigger pointing at the parent, and remains in `scheduled`
- * even after the parent reaches the recorded terminal outcome.
+ * CONTRACT CHANGE (#10721/#10723 trigger-realness wave): the previous
+ * revision of this file pinned that the runner does NOT auto-fire `after_task`
+ * children, making the trigger kind contract larp — schema-accepted, never
+ * fired by anything. The trigger is live in the SCHEDULED_TASKS action (users
+ * create chains from chat without editing the parent) and is NOT redundant
+ * with `pipeline.on*`: pipeline refs are declared on the PARENT and only
+ * propagate completed/skipped/failed, while `after_task` is declared on the
+ * CHILD and covers all five terminal outcomes. The runner now fires matching
+ * children on the parent's terminal transition (`settleTerminal` /
+ * `fireAfterTaskChildren` in runner.ts), race-safe via the store's atomic
+ * fire claim.
  *
- * If the runner gains an `after_task` evaluator, the
- * "child does not auto-fire" assertion below is the contract that needs to
- * change first — making this file the canonical seam.
+ * These tests lock the new contract: structural acceptance, auto-fire on the
+ * matching outcome, no fire on mismatched outcome/parent, and the documented
+ * global-pause exception (pause suppresses chaining).
  */
 
 import { describe, expect, it } from "vitest";
@@ -42,7 +45,7 @@ import {
 import { createInMemoryScheduledTaskLogStore } from "./state-log.js";
 import type { GlobalPauseView, ScheduledTask, TerminalState } from "./types.js";
 
-function makeRunner(): {
+function makeRunner(opts: { pauseActive?: boolean } = {}): {
   runner: ScheduledTaskRunnerHandle;
   setNow: (iso: string) => void;
 } {
@@ -65,7 +68,7 @@ function makeRunner(): {
     consolidation: createConsolidationRegistry(),
     ownerFacts: () => ({}),
     globalPause: {
-      current: async () => ({ active: false }),
+      current: async () => ({ active: opts.pauseActive === true }),
     } as GlobalPauseView,
     activity: { hasSignalSince: () => false },
     subjectStore: { wasUpdatedSince: () => false },
@@ -122,6 +125,15 @@ async function forceParentTerminal(
   }
 }
 
+async function getTask(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const found = (await runner.list()).find((t) => t.taskId === taskId);
+  if (!found) throw new Error(`task ${taskId} not found`);
+  return found;
+}
+
 const TERMINAL_OUTCOMES: TerminalState[] = [
   "completed",
   "skipped",
@@ -150,9 +162,11 @@ describe("ScheduledTaskRunner — after_task trigger structural acceptance (A9)"
       expect(child.trigger.outcome).toBe(outcome);
     });
   }
+});
 
+describe("ScheduledTaskRunner — after_task children fire on the parent's terminal transition", () => {
   for (const outcome of TERMINAL_OUTCOMES) {
-    it(`child does NOT auto-fire when the parent reaches ${outcome} (no scheduler-tick in fixture)`, async () => {
+    it(`auto-fires the child when the parent reaches ${outcome}`, async () => {
       const { runner } = makeRunner();
       const parent = await runner.schedule(baseInput());
       const child = await runner.schedule(
@@ -164,18 +178,139 @@ describe("ScheduledTaskRunner — after_task trigger structural acceptance (A9)"
 
       await forceParentTerminal(runner, parent.taskId, outcome);
 
-      const reloadedParent = (await runner.list()).find(
-        (t) => t.taskId === parent.taskId,
-      );
-      expect(reloadedParent?.state.status).toBe(outcome);
-
-      const reloadedChild = (await runner.list()).find(
-        (t) => t.taskId === child.taskId,
-      );
-      expect(reloadedChild?.state.status).toBe("scheduled");
-      expect(reloadedChild?.state.firedAt).toBeUndefined();
+      expect((await getTask(runner, parent.taskId)).state.status).toBe(outcome);
+      const reloadedChild = await getTask(runner, child.taskId);
+      expect(reloadedChild.state.status).toBe("fired");
+      expect(reloadedChild.state.firedAt).toBe("2026-05-09T12:00:00.000Z");
     });
   }
+
+  it("does not fire a child whose recorded outcome mismatches the transition", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const onFailure = await runner.schedule(
+      baseInput({
+        promptInstructions: "chain after failed",
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "failed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, onFailure.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("does not fire a child pointing at a different parent", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const otherParent = await runner.schedule(baseInput());
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: otherParent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, child.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("fires every child chained on the same parent + outcome", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const first = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+    const second = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+
+    expect((await getTask(runner, first.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, second.taskId)).state.status).toBe("fired");
+  });
+
+  it("chains transitively: grandchild fires when the fired child later completes", async () => {
+    const { runner } = makeRunner();
+    const parent = await runner.schedule(baseInput());
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+    const grandchild = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: child.taskId,
+          outcome: "completed",
+        },
+      }),
+    );
+
+    await runner.apply(parent.taskId, "complete", { reason: "test" });
+    expect((await getTask(runner, child.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, grandchild.taskId)).state.status).toBe(
+      "scheduled",
+    );
+
+    await runner.apply(child.taskId, "complete", { reason: "test" });
+    expect((await getTask(runner, grandchild.taskId)).state.status).toBe(
+      "fired",
+    );
+  });
+
+  it("global-pause skip does NOT chain: pause suppresses proactive behavior", async () => {
+    const { runner } = makeRunner({ pauseActive: true });
+    const parent = await runner.schedule(
+      baseInput({ respectsGlobalPause: true }),
+    );
+    const child = await runner.schedule(
+      baseInput({
+        trigger: {
+          kind: "after_task",
+          taskId: parent.taskId,
+          outcome: "skipped",
+        },
+      }),
+    );
+
+    const result = await runner.fireWithResult(parent.taskId);
+    expect(result.kind).toBe("skipped");
+    expect((await getTask(runner, parent.taskId)).state.status).toBe("skipped");
+    expect((await getTask(runner, child.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
 });
 
 describe("ScheduledTaskRunner — after_task trigger fire path is verb-driven (A9)", () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -160,3 +160,59 @@ describe("ScheduledTask due evaluation", () => {
     expect(pendingPromptRoomIdForTask(fired)).toBe("room-1");
   });
 });
+
+describe("owner_local cron tz resolution", () => {
+  // 2026-05-10 is inside US daylight time: America/Denver = UTC-6.
+  const trigger = {
+    kind: "cron",
+    expression: "0 9 * * *",
+    tz: "owner_local",
+  } as const;
+
+  it("is NOT due at 09:05 UTC when the owner is in America/Denver (03:05 local)", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T08:00:00.000Z" },
+      }),
+      {
+        now: new Date("2026-05-10T09:05:00.000Z"),
+        ownerFacts: { timezone: "America/Denver" },
+      },
+    );
+    expect(decision).toMatchObject({ due: false, reason: "cron_pending" });
+  });
+
+  it("is due at the Denver hour (15:00 UTC) — not the UTC hour", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T14:00:00.000Z" },
+      }),
+      {
+        now: new Date("2026-05-10T15:05:00.000Z"),
+        ownerFacts: { timezone: "America/Denver" },
+      },
+    );
+    expect(decision).toMatchObject({
+      due: true,
+      reason: "cron_due",
+      occurrenceAtIso: "2026-05-10T15:00:00.000Z",
+    });
+  });
+
+  it("resolves owner_local to UTC when the owner has no timezone on file", async () => {
+    const decision = await isScheduledTaskDue(
+      task({
+        trigger,
+        metadata: { createdAtIso: "2026-05-10T08:00:00.000Z" },
+      }),
+      { now: new Date("2026-05-10T09:05:00.000Z"), ownerFacts: {} },
+    );
+    expect(decision).toMatchObject({
+      due: true,
+      reason: "cron_due",
+      occurrenceAtIso: "2026-05-10T09:00:00.000Z",
+    });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -1,6 +1,7 @@
 import { computeNextCronRunAtMs } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
   ScheduledTask,
@@ -232,6 +233,7 @@ function cronDue(
   task: ScheduledTask,
   trigger: Extract<ScheduledTaskTrigger, { kind: "cron" }>,
   nowMs: number,
+  ownerFacts: OwnerFactsView | undefined,
 ): ScheduledTaskDueDecision {
   const baseMs =
     parseIsoMs(task.state.firedAt) ??
@@ -246,7 +248,11 @@ function cronDue(
   if (baseMs > nowMs) {
     return { due: false, reason: "cron_pending" };
   }
-  const nextMs = computeNextCronRunAtMs(trigger.expression, baseMs, trigger.tz);
+  const nextMs = computeNextCronRunAtMs(
+    trigger.expression,
+    baseMs,
+    resolveTriggerTz(trigger.tz, ownerFacts),
+  );
   if (nextMs === null) return { due: false, reason: "cron_invalid" };
   return nextMs <= nowMs
     ? {
@@ -443,7 +449,7 @@ export async function isScheduledTaskDue(
     case "interval":
       return intervalDue(task, task.trigger, nowMs);
     case "cron":
-      return cronDue(task, task.trigger, nowMs);
+      return cronDue(task, task.trigger, nowMs, context.ownerFacts);
     case "relative_to_anchor":
       return relativeAnchorDue(task, task.trigger, context, nowMs);
     case "during_window":

--- a/plugins/plugin-scheduling/src/scheduled-task/event-bridge.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/event-bridge.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Event-trigger bridge coverage: `runtime.emitEvent(eventKind, payload)` must
+ * fire `{ kind: "event" }` scheduled tasks exactly once, honor the optional
+ * payload filter, fan out to every matching task, and stay race-safe under
+ * concurrent emits via the store's atomic claim.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  createCompletionCheckRegistry,
+  registerBuiltInCompletionChecks,
+} from "./completion-check-registry.js";
+import {
+  createAnchorRegistry,
+  createConsolidationRegistry,
+} from "./consolidation-policy.js";
+import {
+  createEscalationLadderRegistry,
+  registerDefaultEscalationLadders,
+} from "./escalation.js";
+import {
+  eventFilterMatches,
+  fireEventTriggeredTasks,
+  installScheduledTaskEventBridge,
+} from "./event-bridge.js";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "./gate-registry.js";
+import {
+  createInMemoryScheduledTaskStore,
+  createScheduledTaskRunner,
+  type ScheduledTaskRunnerHandle,
+  TestNoopScheduledTaskDispatcher,
+} from "./runner.js";
+import { createInMemoryScheduledTaskLogStore } from "./state-log.js";
+import type { GlobalPauseView, ScheduledTask } from "./types.js";
+
+function makeRunner(): ScheduledTaskRunnerHandle {
+  const gates = createTaskGateRegistry();
+  registerBuiltInGates(gates);
+  const completionChecks = createCompletionCheckRegistry();
+  registerBuiltInCompletionChecks(completionChecks);
+  const ladders = createEscalationLadderRegistry();
+  registerDefaultEscalationLadders(ladders);
+  let counter = 0;
+  return createScheduledTaskRunner({
+    agentId: "test-agent",
+    store: createInMemoryScheduledTaskStore(),
+    logStore: createInMemoryScheduledTaskLogStore(),
+    gates,
+    completionChecks,
+    ladders,
+    anchors: createAnchorRegistry(),
+    consolidation: createConsolidationRegistry(),
+    ownerFacts: () => ({}),
+    globalPause: {
+      current: async () => ({ active: false }),
+    } as GlobalPauseView,
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    newTaskId: () => {
+      counter += 1;
+      return `task_${counter}`;
+    },
+    now: () => new Date("2026-06-01T12:00:00.000Z"),
+  });
+}
+
+const eventTaskInput = (
+  eventKind: string,
+  overrides: Partial<Omit<ScheduledTask, "taskId" | "state">> = {},
+): Omit<ScheduledTask, "taskId" | "state"> => ({
+  kind: "watcher",
+  promptInstructions: `react to ${eventKind}`,
+  trigger: { kind: "event", eventKind },
+  priority: "medium",
+  respectsGlobalPause: false,
+  source: "user_chat",
+  createdBy: "tester",
+  ownerVisible: true,
+  ...overrides,
+});
+
+async function getTask(
+  runner: ScheduledTaskRunnerHandle,
+  taskId: string,
+): Promise<ScheduledTask> {
+  const found = (await runner.list()).find((t) => t.taskId === taskId);
+  if (!found) throw new Error(`task ${taskId} not found`);
+  return found;
+}
+
+/**
+ * Minimal runtime standing in for core's event registry: same
+ * name-keyed handler map + `runtime`/`source` payload injection semantics as
+ * `AgentRuntime.registerEvent` / `emitEvent`. The `emit` helper takes the
+ * producer's plain data payload (core's `emitEvent` overloads require
+ * `EventPayload`-typed params; production emitters spread `runtime` in
+ * themselves, which `emit` mirrors here).
+ */
+function makeEventRuntime(): {
+  runtime: IAgentRuntime;
+  emit: (event: string, params?: Record<string, unknown>) => Promise<void>;
+} {
+  const events = new Map<
+    string,
+    Array<(params: Record<string, unknown>) => Promise<void>>
+  >();
+  const runtime = {
+    agentId: "test-agent",
+    registerEvent(event: string, handler: (params: never) => Promise<void>) {
+      const list = events.get(event) ?? [];
+      list.push(handler as (params: Record<string, unknown>) => Promise<void>);
+      events.set(event, list);
+    },
+    unregisterEvent(event: string, handler: (params: never) => Promise<void>) {
+      const list = (events.get(event) ?? []).filter((h) => h !== handler);
+      if (list.length > 0) events.set(event, list);
+      else events.delete(event);
+    },
+  } as unknown as IAgentRuntime;
+  const emit = async (
+    event: string,
+    params: Record<string, unknown> = {},
+  ): Promise<void> => {
+    const handlers = events.get(event);
+    if (!handlers) return;
+    const paramsWithRuntime = { ...params, runtime, source: "runtime" };
+    await Promise.all(handlers.map((handler) => handler(paramsWithRuntime)));
+  };
+  return { runtime, emit };
+}
+
+describe("eventFilterMatches", () => {
+  it("matches everything when the filter is absent", () => {
+    expect(eventFilterMatches(undefined, { a: 1 })).toBe(true);
+    expect(eventFilterMatches(null, undefined)).toBe(true);
+  });
+
+  it("subset-matches object filters against the payload", () => {
+    expect(
+      eventFilterMatches(
+        { calendarId: "work" },
+        { calendarId: "work", title: "standup" },
+      ),
+    ).toBe(true);
+    expect(
+      eventFilterMatches({ calendarId: "work" }, { calendarId: "personal" }),
+    ).toBe(false);
+    expect(eventFilterMatches({ calendarId: "work" }, {})).toBe(false);
+  });
+
+  it("deep-matches nested objects and exact arrays", () => {
+    expect(
+      eventFilterMatches(
+        { meeting: { room: "A" } },
+        { meeting: { room: "A", floor: 2 } },
+      ),
+    ).toBe(true);
+    expect(eventFilterMatches({ tags: ["a", "b"] }, { tags: ["a", "b"] })).toBe(
+      true,
+    );
+    expect(eventFilterMatches({ tags: ["a"] }, { tags: ["a", "b"] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("fireEventTriggeredTasks", () => {
+  it("fires a matching event task exactly once and leaves other kinds alone", async () => {
+    const runner = makeRunner();
+    const matching = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+    const otherKind = await runner.schedule(eventTaskInput("time.lunch.start"));
+    const cronTask = await runner.schedule(
+      eventTaskInput("unused", {
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
+      }),
+    );
+
+    const outcome = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { meetingId: "m1" },
+    });
+
+    expect(outcome.errors).toEqual([]);
+    expect(outcome.results).toHaveLength(1);
+    expect(outcome.results[0]).toMatchObject({
+      taskId: matching.taskId,
+      result: { kind: "fired" },
+    });
+    expect((await getTask(runner, matching.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, otherKind.taskId)).state.status).toBe(
+      "scheduled",
+    );
+    expect((await getTask(runner, cronTask.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("does not fire when the trigger filter mismatches the payload", async () => {
+    const runner = makeRunner();
+    const filtered = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended", {
+        trigger: {
+          kind: "event",
+          eventKind: "calendar.meeting.ended",
+          filter: { calendarId: "work" },
+        },
+      }),
+    );
+
+    const mismatch = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { calendarId: "personal" },
+    });
+    expect(mismatch.results).toHaveLength(0);
+    expect((await getTask(runner, filtered.taskId)).state.status).toBe(
+      "scheduled",
+    );
+
+    const match = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "calendar.meeting.ended",
+      payload: { calendarId: "work", title: "standup" },
+    });
+    expect(match.results).toHaveLength(1);
+    expect((await getTask(runner, filtered.taskId)).state.status).toBe("fired");
+  });
+
+  it("fires every task subscribed to the same event kind", async () => {
+    const runner = makeRunner();
+    const first = await runner.schedule(eventTaskInput("time.morning.start"));
+    const second = await runner.schedule(eventTaskInput("time.morning.start"));
+
+    const outcome = await fireEventTriggeredTasks({
+      runner,
+      eventKind: "time.morning.start",
+    });
+
+    expect(outcome.results.map((r) => r.result.kind)).toEqual([
+      "fired",
+      "fired",
+    ]);
+    expect((await getTask(runner, first.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, second.taskId)).state.status).toBe("fired");
+  });
+
+  it("is race-safe: concurrent emits of one event fire the task once", async () => {
+    const runner = makeRunner();
+    const task = await runner.schedule(eventTaskInput("health.wake.confirmed"));
+
+    const [first, second] = await Promise.all([
+      fireEventTriggeredTasks({ runner, eventKind: "health.wake.confirmed" }),
+      fireEventTriggeredTasks({ runner, eventKind: "health.wake.confirmed" }),
+    ]);
+
+    const kinds = [
+      ...first.results.map((r) => r.result.kind),
+      ...second.results.map((r) => r.result.kind),
+    ];
+    expect(kinds.filter((k) => k === "fired")).toHaveLength(1);
+    expect(kinds.filter((k) => k === "fired" || k === "raced")).toEqual(kinds);
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+    expect((await getTask(runner, task.taskId)).state.firedAt).toBe(
+      "2026-06-01T12:00:00.000Z",
+    );
+  });
+});
+
+describe("installScheduledTaskEventBridge", () => {
+  it("fires event tasks from runtime.emitEvent and stops after uninstall", async () => {
+    const runner = makeRunner();
+    const { runtime, emit } = makeEventRuntime();
+    const task = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+
+    const uninstall = installScheduledTaskEventBridge({
+      runtime,
+      eventKinds: ["calendar.meeting.ended"],
+      getRunner: () => runner,
+    });
+
+    await emit("calendar.meeting.ended", { meetingId: "m1" });
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+
+    const second = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended"),
+    );
+    uninstall();
+    await emit("calendar.meeting.ended", { meetingId: "m2" });
+    expect((await getTask(runner, second.taskId)).state.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("strips the injected runtime field before filter matching", async () => {
+    const runner = makeRunner();
+    const { runtime, emit } = makeEventRuntime();
+    const task = await runner.schedule(
+      eventTaskInput("calendar.meeting.ended", {
+        trigger: {
+          kind: "event",
+          eventKind: "calendar.meeting.ended",
+          filter: { calendarId: "work" },
+        },
+      }),
+    );
+
+    installScheduledTaskEventBridge({
+      runtime,
+      eventKinds: ["calendar.meeting.ended"],
+      getRunner: () => runner,
+    });
+
+    await emit("calendar.meeting.ended", { calendarId: "work" });
+    expect((await getTask(runner, task.taskId)).state.status).toBe("fired");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/event-bridge.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/event-bridge.ts
@@ -1,0 +1,176 @@
+/**
+ * Runtime-event → ScheduledTask fire bridge.
+ *
+ * `trigger.kind = "event"` tasks are push-fired: `isScheduledTaskDue`
+ * deliberately reports them not-due (the tick never wall-clock fires them),
+ * so something must map bus events onto `runner.fireWithResult`. This module
+ * is that mapping: a consumer (e.g. `@elizaos/plugin-personal-assistant`)
+ * installs a `runtime.registerEvent` handler per registered event kind, and
+ * every `runtime.emitEvent(eventKind, payload)` fires the scheduled tasks
+ * whose trigger matches `{ kind: "event", eventKind }` and whose optional
+ * `filter` subset-matches the emitted payload.
+ *
+ * Race safety: firing goes through `fireWithResult`, whose store-level
+ * atomic claim (`scheduled` → `fired`) guarantees one dispatch per task even
+ * when the same event is emitted concurrently — the loser observes `raced`.
+ */
+
+import { type EventPayload, type IAgentRuntime, logger } from "@elizaos/core";
+import type {
+  ScheduledTaskFireResult,
+  ScheduledTaskRunnerHandle,
+} from "./runner.js";
+
+const LOG_SRC = "ScheduledTaskEventBridge";
+
+/**
+ * The narrow runner surface the bridge needs. `list` finds candidate tasks;
+ * `fireWithResult` performs the race-safe fire.
+ */
+export type EventBridgeRunner = Pick<
+  ScheduledTaskRunnerHandle,
+  "list" | "fireWithResult"
+>;
+
+/**
+ * Subset-match an event trigger's `filter` against the emitted payload.
+ *
+ * Contract:
+ *  - `undefined` / `null` filter matches every payload.
+ *  - A plain-object filter matches when EVERY key it declares deep-equals the
+ *    corresponding payload field (payloads may carry extra fields).
+ *  - Arrays and primitives require exact deep equality.
+ */
+export function eventFilterMatches(filter: unknown, payload: unknown): boolean {
+  if (filter === undefined || filter === null) return true;
+  return subsetDeepEquals(filter, payload);
+}
+
+function subsetDeepEquals(expected: unknown, actual: unknown): boolean {
+  if (expected === actual) return true;
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      return false;
+    }
+    return expected.every((item, index) =>
+      subsetDeepEquals(item, actual[index]),
+    );
+  }
+  if (
+    typeof expected === "object" &&
+    expected !== null &&
+    typeof actual === "object" &&
+    actual !== null &&
+    !Array.isArray(actual)
+  ) {
+    return Object.entries(expected as Record<string, unknown>).every(
+      ([key, value]) =>
+        subsetDeepEquals(value, (actual as Record<string, unknown>)[key]),
+    );
+  }
+  return false;
+}
+
+export interface FireEventTriggeredTasksArgs {
+  runner: EventBridgeRunner;
+  eventKind: string;
+  payload?: unknown;
+}
+
+export interface EventTriggeredFireOutcome {
+  /** One entry per matched task, in `list` order. */
+  results: Array<{ taskId: string; result: ScheduledTaskFireResult }>;
+  /** Store/runner errors per task — surfaced, never swallowed silently. */
+  errors: Array<{ taskId: string; message: string }>;
+}
+
+/**
+ * Fire every `scheduled` task whose trigger matches the emitted event.
+ * Per-task errors are collected (and logged by the installer's handler) so
+ * one broken row cannot starve the other listeners of the same event.
+ */
+export async function fireEventTriggeredTasks(
+  args: FireEventTriggeredTasksArgs,
+): Promise<EventTriggeredFireOutcome> {
+  const scheduled = await args.runner.list({ status: "scheduled" });
+  const outcome: EventTriggeredFireOutcome = { results: [], errors: [] };
+  for (const task of scheduled) {
+    if (task.trigger.kind !== "event") continue;
+    if (task.trigger.eventKind !== args.eventKind) continue;
+    if (!eventFilterMatches(task.trigger.filter, args.payload)) continue;
+    try {
+      const result = await args.runner.fireWithResult(task.taskId, {
+        eventPayload: args.payload,
+      });
+      outcome.results.push({ taskId: task.taskId, result });
+    } catch (error) {
+      outcome.errors.push({
+        taskId: task.taskId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return outcome;
+}
+
+export interface InstallScheduledTaskEventBridgeArgs {
+  runtime: IAgentRuntime;
+  /**
+   * The event kinds to subscribe. Consumers enumerate their
+   * `EventKindRegistry` (events registered AFTER install are not picked up —
+   * re-install or install after registry population).
+   */
+  eventKinds: readonly string[];
+  /**
+   * Resolved per event so the bridge always fires through the current cached
+   * runner (never a stale handle with a frozen clock).
+   */
+  getRunner: () => EventBridgeRunner;
+}
+
+/**
+ * Subscribe `runtime.emitEvent(eventKind, …)` to event-triggered task fires.
+ * Returns an uninstall function that unregisters every handler.
+ *
+ * The handler strips the non-data envelope fields (`runtime`, `onComplete`)
+ * from the payload before filter matching and before the payload is handed to
+ * `fireWithResult` as the persisted `eventPayload`. `source` is kept: it is a
+ * plain producer string and a legitimate filter target.
+ */
+export function installScheduledTaskEventBridge(
+  args: InstallScheduledTaskEventBridgeArgs,
+): () => void {
+  const { runtime, getRunner } = args;
+  const registrations: Array<{
+    eventKind: string;
+    handler: (params: EventPayload) => Promise<void>;
+  }> = [];
+  for (const eventKind of args.eventKinds) {
+    const handler = async (params: EventPayload): Promise<void> => {
+      const { runtime: _runtime, onComplete: _onComplete, ...payload } = params;
+      const outcome = await fireEventTriggeredTasks({
+        runner: getRunner(),
+        eventKind,
+        payload,
+      });
+      for (const failure of outcome.errors) {
+        logger.error(
+          {
+            src: LOG_SRC,
+            agentId: runtime.agentId,
+            eventKind,
+            taskId: failure.taskId,
+          },
+          `[${LOG_SRC}] event-triggered fire failed: ${failure.message}`,
+        );
+      }
+    };
+    runtime.registerEvent(eventKind, handler);
+    registrations.push({ eventKind, handler });
+  }
+  return () => {
+    for (const { eventKind, handler } of registrations) {
+      runtime.unregisterEvent(eventKind, handler);
+    }
+  };
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -49,6 +49,15 @@ export {
   resolveEffectiveLadder,
 } from "./escalation.js";
 export {
+  type EventBridgeRunner,
+  type EventTriggeredFireOutcome,
+  eventFilterMatches,
+  type FireEventTriggeredTasksArgs,
+  fireEventTriggeredTasks,
+  type InstallScheduledTaskEventBridgeArgs,
+  installScheduledTaskEventBridge,
+} from "./event-bridge.js";
+export {
   createTaskGateRegistry,
   registerBuiltInGates,
   type TaskGateRegistry,
@@ -100,6 +109,7 @@ export {
   type ScheduledTaskLogStore,
   STATE_LOG_DEFAULT_RETENTION_DAYS,
 } from "./state-log.js";
+export { OWNER_LOCAL_TZ, resolveTriggerTz } from "./trigger-tz.js";
 export type {
   ActivitySignalBusView,
   AnchorConsolidationMode,

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.test.ts
@@ -178,3 +178,17 @@ describe("computeNextFireAt trigger baselines (no override)", () => {
     expect(next).toBeNull();
   });
 });
+
+describe("computeNextFireAt owner_local cron tz resolution", () => {
+  it("indexes the next fire at the owner's local hour, not the UTC hour", async () => {
+    // NOW = 2026-05-11T12:00Z. Denver (UTC-6, daylight time): 06:00 local.
+    // Daily 9am owner_local => next fire today at 15:00Z, not 2026-05-12T09:00Z.
+    const next = await computeNextFireAt(
+      taskWith({
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "owner_local" },
+      }),
+      { now: NOW, ownerFacts: { timezone: "America/Denver" }, anchors: null },
+    );
+    expect(next).toBe("2026-05-11T15:00:00.000Z");
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts
@@ -18,6 +18,7 @@
 import { computeNextCronRunAtMs } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
+import { resolveTriggerTz } from "./trigger-tz.js";
 import type {
   OwnerFactsView,
   ScheduledTask,
@@ -290,7 +291,7 @@ export async function computeNextFireAt(
       const nextMs = computeNextCronRunAtMs(
         trigger.expression,
         baseMs,
-        trigger.tz,
+        resolveTriggerTz(trigger.tz, context.ownerFacts),
       );
       return nextMs === null ? null : new Date(nextMs).toISOString();
     }

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -12,6 +12,10 @@
  *  - `idempotencyKey` deduplicates schedules.
  *  - `pipeline.onSkip` wins over `completionCheck.followupAfterMinutes` when
  *    both are set.
+ *  - `trigger.kind = "after_task"` children auto-fire when the parent reaches
+ *    the recorded terminal outcome through a runner transition (verbs,
+ *    gate-deny skip, dispatch failure, `pipeline()`), EXCEPT the global-pause
+ *    skip: pause suppresses proactive behavior, and chaining is proactive.
  */
 
 import { decideDispatchPolicy } from "../dispatch-policy.js";
@@ -795,7 +799,7 @@ export function createScheduledTaskRunner(
     await logger.log(task.taskId, "skipped", {
       reason: payload?.reason ?? "user skipped",
     });
-    await runPipeline(task, "skipped");
+    await settleTerminal(task, "skipped");
     return task;
   }
 
@@ -808,7 +812,7 @@ export function createScheduledTaskRunner(
     task.state.lastDecisionLog = payload?.reason ?? "completed";
     await persist(task);
     await logger.log(task.taskId, "completed", { reason: payload?.reason });
-    await runPipeline(task, "completed");
+    await settleTerminal(task, "completed");
     return task;
   }
 
@@ -820,6 +824,9 @@ export function createScheduledTaskRunner(
     task.state.lastDecisionLog = payload?.reason ?? "dismissed";
     await persist(task);
     await logger.log(task.taskId, "dismissed", { reason: payload?.reason });
+    // `pipeline.on*` deliberately does not propagate `dismissed`; `after_task`
+    // children DO cover it (the trigger union records all five outcomes).
+    await fireAfterTaskChildren(task, "dismissed");
     return task;
   }
 
@@ -946,8 +953,51 @@ export function createScheduledTaskRunner(
   }
 
   // -------------------------------------------------------------------------
-  // Pipeline propagation
+  // Pipeline propagation + after_task chaining
   // -------------------------------------------------------------------------
+
+  /**
+   * Fire every `scheduled` task whose trigger is
+   * `{ kind: "after_task", taskId: parent, outcome }`. This is the push side
+   * of the `after_task` contract (`isScheduledTaskDue` reports these tasks
+   * not-due, so the tick never wall-clock fires them). Firing goes through
+   * `fireWithResult`, whose atomic claim makes concurrent terminal
+   * transitions race-safe — one dispatch per child, losers observe `raced`.
+   *
+   * Unlike `pipeline.on*` (declared on the parent), `after_task` is declared
+   * on the CHILD, so chains can be attached without editing the parent, and
+   * they cover ALL five terminal outcomes (`pipeline` only propagates
+   * completed / skipped / failed).
+   */
+  async function fireAfterTaskChildren(
+    parent: ScheduledTask,
+    outcome: TerminalState,
+  ): Promise<void> {
+    const scheduled = await deps.store.list({ status: "scheduled" });
+    for (const child of scheduled) {
+      if (child.trigger.kind !== "after_task") continue;
+      if (child.trigger.taskId !== parent.taskId) continue;
+      if (child.trigger.outcome !== outcome) continue;
+      await fireWithResult(child.taskId, {
+        eventPayload: { afterTask: { taskId: parent.taskId, outcome } },
+      });
+    }
+  }
+
+  /**
+   * The single terminal-transition seam: propagate `pipeline.on*` refs, then
+   * fire matching `after_task` children. Every runner path that records a
+   * terminal outcome routes through here (the global-pause skip deliberately
+   * does not — pause suppresses chaining).
+   */
+  async function settleTerminal(
+    parent: ScheduledTask,
+    outcome: TerminalState,
+  ): Promise<ScheduledTask[]> {
+    const created = await runPipeline(parent, outcome);
+    await fireAfterTaskChildren(parent, outcome);
+    return created;
+  }
 
   async function runPipeline(
     parent: ScheduledTask,
@@ -1030,7 +1080,7 @@ export function createScheduledTaskRunner(
         reason: `pipeline: ${outcome}`,
       });
     }
-    return runPipeline(task, outcome);
+    return settleTerminal(task, outcome);
   }
 
   function outcomeToLogTransition(
@@ -1107,7 +1157,7 @@ export function createScheduledTaskRunner(
         message: failure.error.message,
       },
     });
-    await runPipeline(claimed, "failed");
+    await settleTerminal(claimed, "failed");
     return { kind: "dispatch_failed", task: claimed, error: failure.error };
   }
 
@@ -1194,7 +1244,7 @@ export function createScheduledTaskRunner(
       await logger.log(task.taskId, "skipped", {
         reason: task.state.lastDecisionLog,
       });
-      await runPipeline(task, "skipped");
+      await settleTerminal(task, "skipped");
       return {
         kind: "skipped",
         task,
@@ -1510,7 +1560,7 @@ export function createScheduledTaskRunner(
       reason: `dispatch_failed:${reason}`,
       detail: { message: detailMessage },
     });
-    await runPipeline(task, "failed");
+    await settleTerminal(task, "failed");
     return {
       kind: "dispatch_failed",
       task,

--- a/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/trigger-tz.ts
@@ -1,0 +1,23 @@
+import type { OwnerFactsView } from "./types.js";
+
+/**
+ * Sentinel `tz` value on cron triggers meaning "the owner's timezone,
+ * whatever it currently is". Default task packs use it so a pack authored
+ * once fires at the owner's local hour everywhere.
+ */
+export const OWNER_LOCAL_TZ = "owner_local";
+
+/**
+ * Resolve a cron trigger's `tz` to a concrete IANA zone before it reaches
+ * core's cron scheduler. `owner_local` resolves against owner facts, with an
+ * explicit UTC fallback when the owner has no timezone on file. Any other
+ * value passes through unchanged — core warns once and evaluates in UTC for
+ * invalid IANA names.
+ */
+export function resolveTriggerTz(
+  tz: string,
+  ownerFacts: OwnerFactsView | undefined,
+): string {
+  if (tz === OWNER_LOCAL_TZ) return ownerFacts?.timezone ?? "UTC";
+  return tz;
+}

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -119,6 +119,17 @@ export interface ScheduledTaskContextRequest {
   includeEventPayload?: boolean;
 }
 
+/**
+ * Push-fired kinds (never wall-clock due; `isScheduledTaskDue` reports them
+ * not-due and `next_fire_at` stays NULL):
+ *  - `event` — fired by the runtime event bridge when
+ *    `runtime.emitEvent(eventKind, payload)` matches the trigger (see
+ *    `event-bridge.ts`; `filter` subset-matches the payload).
+ *  - `after_task` — fired by the runner when the referenced parent task
+ *    reaches the recorded terminal `outcome` (all five terminal states,
+ *    unlike `pipeline.on*`; the global-pause skip does not chain).
+ *  - `manual` — fired only by an explicit `fire()` call.
+ */
 export type ScheduledTaskTrigger =
   | { kind: "once"; atIso: string }
   | { kind: "cron"; expression: string; tz: string }


### PR DESCRIPTION
Part of #11413. **Stacked on #11427** (scheduling restore — merge that first). Re-lands plugin-goals' check-in/runtime that #11271's stale-base squash reverted (part of #11259).

Restored from pre-clobber parent `5b714c74e60^`: `goals.ts`, `goals-runtime.ts`, `goals-service.ts`, **`checkin.ts`** (the real scheduled check-in service — refs #11358 'GoalsCheckinService is a registered stub'), `plugin.ts`, `types.ts`, `package.json` + service/plugin tests. `checkin.ts` imports `OWNER_LOCAL_TZ` from plugin-scheduling (restored in the base PR #11427).

**Kept develop's newer** `checkin.test.ts` / `checkin.harness.test.ts` (divergent since the clobber — not overwritten).

**Verified under the real harness** (`bunx vitest run`, goals' `test` script — NOT `bun test`, whose vi shim lacks `vi.stubGlobal`/`vi.hoisted`): **53 passed / 1 skipped / 0 failed**. typecheck clean (only the pre-existing packages/ui capacitor transitive noise documented in CLAUDE.md).

cc @lalalune. — nubs-cloud [cloud-frontdoor]