### PR TITLE
fix(calendar): re-land calendar runtime clobbered by #11271 (#11413)

### DIFF
--- a/plugins/plugin-calendar/src/service/CalendarRepository.ts
+++ b/plugins/plugin-calendar/src/service/CalendarRepository.ts
@@ -210,11 +210,22 @@ export class CalendarRepository {
     timeMax: string,
     keepExternalIds: readonly string[],
     side: LifeOpsConnectorSide = "owner",
+    grantId?: string | null,
   ): Promise<void> {
     const calendarClause =
       calendarId && calendarId !== "all"
         ? `AND calendar_id = ${sqlQuote(calendarId)}`
         : "";
+    // Multi-account safety: two grants can expose a calendar with the same
+    // calendarId (every Google account names its default calendar "primary"),
+    // and the keep-list only contains the syncing grant's event ids — so an
+    // unscoped prune lets one account's sync delete the other account's cached
+    // events on every pass. When the caller syncs on behalf of a grant, only
+    // that grant's rows are pruned (plus legacy rows that predate grant
+    // attribution, so they converge instead of going permanently stale).
+    const grantClause = grantId
+      ? `AND (grant_id = ${sqlQuote(grantId)} OR grant_id IS NULL)`
+      : "";
     const keepClause =
       keepExternalIds.length > 0
         ? `AND external_event_id NOT IN (${keepExternalIds
@@ -228,6 +239,7 @@ export class CalendarRepository {
           AND provider = ${sqlQuote(provider)}
           AND side = ${sqlQuote(side)}
           ${calendarClause}
+          ${grantClause}
           AND end_at > ${sqlQuote(timeMin)}
           AND start_at < ${sqlQuote(timeMax)}
           ${keepClause}`,

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -451,6 +451,7 @@ export class CalendarService extends Service {
       args.timeMax,
       googleEvents.map((event) => event.id),
       grant.side,
+      grant.id,
     );
     await this.deleteCalendarReminderPlansForEvents(removedEventIds);
     for (const event of nextEvents) {

--- a/plugins/plugin-calendar/vitest.config.ts
+++ b/plugins/plugin-calendar/vitest.config.ts
@@ -43,9 +43,13 @@ export default defineConfig({
       "node_modules/**",
       "dist/**",
       "**/*.e2e.test.{ts,tsx}",
-      "**/*.real.test.{ts,tsx}",
       "**/*.real-*.test.{ts,tsx}",
-      "**/*.live.test.{ts,tsx}",
+      // #9310 §E: the guarded real/live connector suites (they self-skip
+      // without creds) are invocable only in the post-merge lane, where
+      // run-all-tests.mjs prints a named skip accounting.
+      ...(process.env.VITEST_LANE === "post-merge"
+        ? []
+        : ["**/*.real.test.{ts,tsx}", "**/*.live.test.{ts,tsx}"]),
       // Integration specs load @elizaos/agent, which (dynamically) pulls the full
       // connector plugin graph. Those connector packages aren't built in the unit
       // Plugin Tests lane, so Node fails to resolve their dist entries. Keep


### PR DESCRIPTION
Part of #11413. Re-lands the 3 plugin-calendar files (CalendarRepository/CalendarService + vitest.config) reverted by #11271's stale-base squash (part of #11259). Restored from pre-clobber parent `5b714c74e60^`; kept develop's newer calendar tests (divergent). Independent of the scheduling restore (no plugin-scheduling imports). **Verified under vitest: 130 passed / 2 skipped / 0 failed.** — nubs-cloud [cloud-frontdoor]