### PR TITLE
Fix LifeOps scheduled task completion auto-fire

### DIFF
--- a/.github/issue-evidence/11354-lifeops-completion-autofire.md
+++ b/.github/issue-evidence/11354-lifeops-completion-autofire.md
@@ -1,0 +1,63 @@
+# Issue #11354 — LifeOps completion checks auto-fire
+
+## What Changed
+
+- `MESSAGE_RECEIVED` now drives `user_replied_within` completion for fired scheduled tasks that have an open pending prompt in the same room, gated by owner access.
+- The existing `processDueScheduledTasks` tick now evaluates fired `subject_updated` and `health_signal_observed` checks before completion-timeout handling.
+- `SubjectStoreView` can be registered per runtime and is read through a live runtime view, so cached runners still see later subject-store wiring.
+
+## Production-Path Evidence
+
+- `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts`
+  - Fires a real repository-backed `user_replied_within` check-in through `processDueScheduledTasks`, emits a real `MESSAGE_RECEIVED`, and verifies the DB row transitions to `completed` without an LLM `SCHEDULED_TASKS` action.
+  - Verifies fire -> no reply -> still `fired` before timeout.
+  - Verifies fired `subject_updated` completes during the production tick before the timeout pass can skip it.
+
+## Commands Run
+
+```bash
+bun run --cwd plugins/plugin-birdclaw build
+bun run --cwd plugins/plugin-calendar build
+bun run --cwd plugins/plugin-scheduling build
+```
+
+Result: passed. These generated ignored local `dist/` artifacts required by
+the Vitest/package type resolvers after rebasing onto current `origin/develop`.
+
+```bash
+bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+```
+
+Result: passed, 1 file / 13 tests.
+
+```bash
+bun run --cwd plugins/plugin-personal-assistant test -- test/lifeops-scheduled-task-simulation.test.ts src/lifeops/domains/reminders-service.process-scheduled-work.test.ts src/lifeops/domains/reminders-service.state-log-rollover.test.ts
+```
+
+Result: passed, 3 files / 13 tests.
+
+```bash
+bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/index.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.process-scheduled-work.test.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.state-log-rollover.test.ts plugins/plugin-personal-assistant/src/plugin.ts
+```
+
+Result: passed, no fixes needed.
+
+```bash
+bun run --cwd plugins/plugin-personal-assistant typecheck
+```
+
+Result: blocked by pre-existing workspace/dist drift unrelated to this change:
+
+- `@elizaos/plugin-google` type declarations unavailable from this side worktree install.
+- Existing `src/lifeops/domains/gmail-service.ts(236,42)` implicit-any after the missing Google import path.
+- `@elizaos/app-core/api/auth` built export drift for `ensureSessionForRequest`.
+
+```bash
+bun run verify
+```
+
+Result: blocked before typecheck/lint by repo-wide type-safety ratchet on current
+`origin/develop`: `as unknown as` is `80 / 77` and core/agent/app-core
+``?? {}`` is `379 / 377`.
+
+No UI, native, connector, audio, or live-LLM behavior changed in this fix; evidence for those rows is N/A.

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.process-scheduled-work.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.process-scheduled-work.test.ts
@@ -18,6 +18,7 @@ vi.mock("../scheduled-task/scheduler.js", async (importOriginal) => {
 const NOW = "2026-07-01T12:00:00.000Z";
 
 const emptyScheduledTaskResult: ProcessDueScheduledTasksResult = {
+  completions: [],
   fires: [],
   completionTimeouts: [],
   pendingPrompts: [],
@@ -140,6 +141,7 @@ describe("RemindersDomain.processScheduledWork subsystem isolation", () => {
     const { domain, overrides } = makeDomain();
     overrides.syncWebsiteAccessState.mockRejectedValue(new Error("boom"));
     vi.mocked(processDueScheduledTasks).mockResolvedValue({
+      completions: [],
       fires: [
         {
           taskId: "st-1",

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.state-log-rollover.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.state-log-rollover.test.ts
@@ -38,6 +38,7 @@ vi.mock("../scheduled-task/service.js", async (importOriginal) => {
 const NOW = "2026-07-01T12:00:00.000Z";
 
 const emptyScheduledTaskResult: ProcessDueScheduledTasksResult = {
+  completions: [],
   fires: [],
   completionTimeouts: [],
   pendingPrompts: [],

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -5310,6 +5310,7 @@ export class RemindersDomain {
         }),
     );
     const scheduledTaskFallback: ProcessDueScheduledTasksResult = {
+      completions: [],
       fires: [],
       completionTimeouts: [],
       pendingPrompts: [],

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/index.ts
@@ -11,7 +11,11 @@ export * from "@elizaos/plugin-scheduling";
 export {
   type ProcessDueScheduledTasksRequest,
   type ProcessDueScheduledTasksResult,
+  type ProcessScheduledTaskInboundMessageRequest,
+  type ProcessScheduledTaskInboundMessageResult,
   processDueScheduledTasks,
+  processScheduledTaskInboundMessage,
+  type ScheduledTaskCompletionResult,
   type ScheduledTaskProcessingError,
 } from "./scheduler.js";
 export {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -62,6 +62,21 @@ interface RepositoryBackedStores {
   logStore: ScheduledTaskLogStore;
 }
 
+const subjectStoresByRuntime = new WeakMap<IAgentRuntime, SubjectStoreView>();
+
+export function registerLifeOpsScheduledTaskSubjectStore(
+  runtime: IAgentRuntime,
+  subjectStore: SubjectStoreView,
+): void {
+  subjectStoresByRuntime.set(runtime, subjectStore);
+}
+
+function getLifeOpsScheduledTaskSubjectStore(
+  runtime: IAgentRuntime,
+): SubjectStoreView | null {
+  return subjectStoresByRuntime.get(runtime) ?? null;
+}
+
 /**
  * Bind the in-memory facade to the LifeOpsRepository SQL methods. Each
  * call routes through the repository so the runner is DB-backed but
@@ -208,10 +223,14 @@ function makeMissingActivityBusView(
  * Same warn-once semantics as the activity-bus shim; `subject_updated`
  * completion-checks will report no-update until a real store is wired.
  */
-function makeMissingSubjectStoreView(runtime: IAgentRuntime): SubjectStoreView {
+function makeRuntimeSubjectStoreView(runtime: IAgentRuntime): SubjectStoreView {
   let warned = false;
   return {
-    wasUpdatedSince() {
+    wasUpdatedSince(args) {
+      const registered = getLifeOpsScheduledTaskSubjectStore(runtime);
+      if (registered) {
+        return registered.wasUpdatedSince(args);
+      }
       if (!warned) {
         warned = true;
         logger.warn(
@@ -544,7 +563,7 @@ function buildLifeOpsRunnerDeps(
     getActivitySignalBus(opts.runtime) ??
     makeMissingActivityBusView(opts.runtime);
   const subjectStore: SubjectStoreView =
-    opts.subjectStore ?? makeMissingSubjectStoreView(opts.runtime);
+    opts.subjectStore ?? makeRuntimeSubjectStoreView(opts.runtime);
 
   return {
     store: stores.store,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -14,18 +14,20 @@
  * mobile `/api/background/run-due-tasks` route both call.
  */
 
-import { logger } from "@elizaos/core";
+import { EventType, logger, type Memory, type UUID } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.ts";
 import { createGlobalPauseStore } from "../global-pause/store.ts";
+import { resolvePendingPromptsStore } from "../pending-prompts/store.ts";
 import { LifeOpsRepository } from "../repository.ts";
 import {
   APPROVAL_DEFAULT_FOLLOWUP_AFTER_MINUTES,
   type ScheduledTask,
 } from "./index.ts";
+import { registerLifeOpsScheduledTaskSubjectStore } from "./runtime-wiring.ts";
 import { processDueScheduledTasks } from "./scheduler.ts";
 import { getScheduledTaskRunner } from "./service.ts";
 
@@ -450,6 +452,177 @@ describe("processDueScheduledTasks — production wiring", () => {
     );
     expect(recorded?.roomId).toBe("room-approval");
     expect(recorded?.expectedReplyKind).toBe("approval");
+  });
+
+  it("completes a fired user_replied_within task from an owner MESSAGE_RECEIVED event", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const ownerId = "owner-11354";
+    const roomId = "room-11354-reply";
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId, false);
+
+    const fireAt = "2026-05-09T12:00:00.000Z";
+    const tickAt = new Date("2026-05-09T12:01:00.000Z");
+    const runner = getScheduledTaskRunner(runtime, {
+      agentId: runtime.agentId,
+      now: () => tickAt,
+    });
+    const scheduled = await runner.schedule({
+      kind: "checkin",
+      promptInstructions: "How is the morning going?",
+      trigger: { kind: "once", atIso: fireAt },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      completionCheck: {
+        kind: "user_replied_within",
+        followupAfterMinutes: 30,
+      },
+      metadata: { pendingPromptRoomId: roomId },
+    });
+
+    const fireResult = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: tickAt,
+      limit: 5,
+    });
+    expect(fireResult.errors).toEqual([]);
+    expect(
+      fireResult.fires.find((f) => f.taskId === scheduled.taskId)?.status,
+    ).toBe("fired");
+    expect(
+      (
+        await resolvePendingPromptsStore(runtime).list(roomId, {
+          now: tickAt,
+        })
+      ).map((prompt) => prompt.taskId),
+    ).toContain(scheduled.taskId);
+
+    const replyAt = "2026-05-09T12:02:00.000Z";
+    const message: Memory = {
+      id: "msg-11354-reply" as UUID,
+      entityId: ownerId as UUID,
+      roomId: roomId as UUID,
+      createdAt: Date.parse(replyAt),
+      content: { text: "I am back online." },
+    };
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+      message,
+      source: "client_chat",
+    });
+
+    const repo = new LifeOpsRepository(runtime);
+    const completed = await repo.getScheduledTask(
+      runtime.agentId,
+      scheduled.taskId,
+    );
+    expect(completed?.state.status).toBe("completed");
+    expect(completed?.state.completedAt).toBe(replyAt);
+    expect(completed?.state.lastDecisionLog).toBe(
+      "completion-check:user_replied_within",
+    );
+    expect(
+      await resolvePendingPromptsStore(runtime).list(roomId, {
+        now: new Date(replyAt),
+      }),
+    ).toEqual([]);
+  });
+
+  it("leaves a fired user_replied_within task open when no reply arrived before timeout", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+
+    const firedAt = "2026-05-09T12:00:00.000Z";
+    const seed = await seedScheduledTask(runtime, {
+      kind: "checkin",
+      promptInstructions: "Check in with the owner.",
+      trigger: { kind: "once", atIso: firedAt },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: {
+        kind: "user_replied_within",
+        followupAfterMinutes: 30,
+      },
+      metadata: { pendingPromptRoomId: "room-11354-no-reply" },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt,
+      },
+    });
+
+    const result = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T12:10:00.000Z"),
+      limit: 5,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.completions).toEqual([]);
+    expect(result.completionTimeouts).toEqual([]);
+    const repo = new LifeOpsRepository(runtime);
+    const persisted = await repo.getScheduledTask(runtime.agentId, seed.taskId);
+    expect(persisted?.state.status).toBe("fired");
+  });
+
+  it("completes subject_updated during the production tick before timeout skip", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    registerLifeOpsScheduledTaskSubjectStore(runtime, {
+      wasUpdatedSince: async ({ subject, sinceIso }) =>
+        subject.kind === "document" &&
+        subject.id === "doc-11354" &&
+        sinceIso === "2026-05-09T12:00:00.000Z",
+    });
+
+    const firedAt = "2026-05-09T12:00:00.000Z";
+    const seed = await seedScheduledTask(runtime, {
+      kind: "watcher",
+      promptInstructions: "Watch the document until it changes.",
+      trigger: { kind: "event", eventKind: "document.updated" },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "plugin",
+      ownerVisible: true,
+      subject: { kind: "document", id: "doc-11354" },
+      completionCheck: {
+        kind: "subject_updated",
+        followupAfterMinutes: 1,
+      },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt,
+      },
+    });
+
+    const result = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T12:02:00.000Z"),
+      limit: 5,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.completions).toEqual([
+      {
+        taskId: seed.taskId,
+        status: "completed",
+        reason: "completion-check:subject_updated",
+        completionCheckKind: "subject_updated",
+      },
+    ]);
+    expect(result.completionTimeouts).toEqual([]);
+    const repo = new LifeOpsRepository(runtime);
+    const persisted = await repo.getScheduledTask(runtime.agentId, seed.taskId);
+    expect(persisted?.state.status).toBe("completed");
+    expect(persisted?.state.completedAt).toBe("2026-05-09T12:02:00.000Z");
   });
 
   it("fires a watcher (event) via a due scheduled-override", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -1,4 +1,10 @@
-import { type IAgentRuntime, logger } from "@elizaos/core";
+import { hasOwnerAccess } from "@elizaos/agent";
+import {
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type MessagePayload,
+} from "@elizaos/core";
 import type { ScheduledTask } from "@elizaos/plugin-scheduling";
 import {
   expectedReplyKindForTask,
@@ -36,14 +42,34 @@ export interface ScheduledTaskFireResult {
 
 export interface ScheduledTaskProcessingError {
   taskId: string;
-  phase: "fire" | "completion_timeout" | "pending_prompt";
+  phase: "fire" | "completion_check" | "completion_timeout" | "pending_prompt";
   message: string;
 }
 
+export interface ScheduledTaskCompletionResult {
+  taskId: string;
+  status: ScheduledTask["state"]["status"];
+  reason: string;
+  completionCheckKind: string;
+}
+
 export interface ProcessDueScheduledTasksResult {
+  completions: ScheduledTaskCompletionResult[];
   fires: ScheduledTaskFireResult[];
   completionTimeouts: ScheduledTaskFireResult[];
   pendingPrompts: RecordedPendingPrompt[];
+  errors: ScheduledTaskProcessingError[];
+}
+
+export interface ProcessScheduledTaskInboundMessageRequest {
+  runtime: IAgentRuntime;
+  agentId: string;
+  message: Memory;
+  now?: Date;
+}
+
+export interface ProcessScheduledTaskInboundMessageResult {
+  completions: ScheduledTaskCompletionResult[];
   errors: ScheduledTaskProcessingError[];
 }
 
@@ -57,6 +83,39 @@ function shouldRecordPendingPrompt(task: ScheduledTask): boolean {
     task.completionCheck?.kind === "user_acknowledged" ||
     task.kind === "approval"
   );
+}
+
+function isTickDrivenCompletionCheck(task: ScheduledTask): boolean {
+  return (
+    task.completionCheck?.kind === "subject_updated" ||
+    task.completionCheck?.kind === "health_signal_observed"
+  );
+}
+
+function isTerminalStatus(status: ScheduledTask["state"]["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "skipped" ||
+    status === "expired" ||
+    status === "failed" ||
+    status === "dismissed"
+  );
+}
+
+function completionResult(task: ScheduledTask): ScheduledTaskCompletionResult {
+  return {
+    taskId: task.taskId,
+    status: task.state.status,
+    reason: task.state.lastDecisionLog ?? "completed",
+    completionCheckKind: task.completionCheck?.kind ?? "unknown",
+  };
+}
+
+function readMessageOccurredAt(message: Memory, fallback: Date): Date {
+  return typeof message.createdAt === "number" &&
+    Number.isFinite(message.createdAt)
+    ? new Date(message.createdAt)
+    : fallback;
 }
 
 async function recordPendingPromptIfNeeded(args: {
@@ -88,6 +147,7 @@ export async function processDueScheduledTasks(
   request: ProcessDueScheduledTasksRequest,
 ): Promise<ProcessDueScheduledTasksResult> {
   const result: ProcessDueScheduledTasksResult = {
+    completions: [],
     fires: [],
     completionTimeouts: [],
     pendingPrompts: [],
@@ -150,7 +210,32 @@ export async function processDueScheduledTasks(
   const timeoutCandidates = await repo.listScheduledTasks(request.agentId, {
     status: ["fired"],
   });
+  const completedTaskIds = new Set<string>();
   const timeoutTaskIds = new Set<string>();
+
+  for (const task of timeoutCandidates) {
+    if (result.completions.length >= limit) {
+      break;
+    }
+    if (!isTickDrivenCompletionCheck(task)) continue;
+    try {
+      const evaluated = await runner.evaluateCompletion(task.taskId, {});
+      if (evaluated.state.status === "completed") {
+        result.completions.push(completionResult(evaluated));
+        completedTaskIds.add(evaluated.taskId);
+      }
+    } catch (error) {
+      const message = errorMessage(error);
+      logger.warn(
+        `[lifeops-scheduled-task] completion check failed for ${task.taskId}: ${message}`,
+      );
+      result.errors.push({
+        taskId: task.taskId,
+        phase: "completion_check",
+        message,
+      });
+    }
+  }
 
   // Each pass gets its OWN budget of `limit`, not a shared one. A shared
   // budget lets a burst of completion-timeouts (this pass) consume the whole
@@ -159,6 +244,7 @@ export async function processDueScheduledTasks(
   // cheap indexed DB ops in a pathological burst and guarantee the due-fire
   // pass always gets its full `limit`.
   for (const task of timeoutCandidates) {
+    if (completedTaskIds.has(task.taskId)) continue;
     if (result.completionTimeouts.length >= limit) {
       break;
     }
@@ -190,6 +276,7 @@ export async function processDueScheduledTasks(
   }
 
   for (const task of dueCandidates) {
+    if (completedTaskIds.has(task.taskId)) continue;
     if (timeoutTaskIds.has(task.taskId)) continue;
     if (result.fires.length >= limit) {
       break;
@@ -219,6 +306,106 @@ export async function processDueScheduledTasks(
   }
 
   return result;
+}
+
+export async function processScheduledTaskInboundMessage(
+  request: ProcessScheduledTaskInboundMessageRequest,
+): Promise<ProcessScheduledTaskInboundMessageResult> {
+  const result: ProcessScheduledTaskInboundMessageResult = {
+    completions: [],
+    errors: [],
+  };
+  const roomId =
+    typeof request.message.roomId === "string" &&
+    request.message.roomId.length > 0
+      ? request.message.roomId
+      : null;
+  if (!roomId) return result;
+  if (request.message.entityId === request.agentId) return result;
+  if (!(await hasOwnerAccess(request.runtime, request.message))) return result;
+
+  const now = request.now ?? readMessageOccurredAt(request.message, new Date());
+  const repliedAtIso = now.toISOString();
+  const promptStore = resolvePendingPromptsStore(request.runtime);
+  const prompts = await promptStore.list(roomId, { now });
+  if (prompts.length === 0) return result;
+
+  const repo = new LifeOpsRepository(request.runtime);
+  const runner = getScheduledTaskRunner(request.runtime, {
+    agentId: request.agentId,
+    now: () => now,
+  });
+
+  for (const prompt of prompts) {
+    try {
+      const task = await repo.getScheduledTask(request.agentId, prompt.taskId);
+      if (!task) {
+        await promptStore.resolve(roomId, prompt.taskId);
+        continue;
+      }
+      if (
+        isTerminalStatus(task.state.status) ||
+        task.state.status !== "fired"
+      ) {
+        await promptStore.resolve(roomId, prompt.taskId);
+        continue;
+      }
+      if (task.completionCheck?.kind !== "user_replied_within") {
+        continue;
+      }
+      const evaluated = await runner.evaluateCompletion(task.taskId, {
+        repliedAtIso,
+      });
+      if (evaluated.state.status === "completed") {
+        result.completions.push(completionResult(evaluated));
+        await promptStore.resolve(roomId, prompt.taskId);
+      }
+    } catch (error) {
+      const message = errorMessage(error);
+      logger.warn(
+        `[lifeops-scheduled-task] inbound completion check failed for ${prompt.taskId}: ${message}`,
+      );
+      result.errors.push({
+        taskId: prompt.taskId,
+        phase: "completion_check",
+        message,
+      });
+    }
+  }
+
+  return result;
+}
+
+export async function handleScheduledTaskInboundMessage(
+  payload: MessagePayload,
+): Promise<void> {
+  try {
+    const runtime = payload.runtime;
+    if (!runtime || !payload.message) return;
+    const result = await processScheduledTaskInboundMessage({
+      runtime,
+      agentId: runtime.agentId,
+      message: payload.message,
+    });
+    if (result.completions.length > 0) {
+      logger.info(
+        {
+          src: "lifeops:scheduled-task",
+          agentId: runtime.agentId,
+          taskIds: result.completions.map((entry) => entry.taskId),
+        },
+        "[lifeops-scheduled-task] Completed fired scheduled task(s) from owner inbound reply",
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      {
+        src: "lifeops:scheduled-task",
+        error,
+      },
+      "[lifeops-scheduled-task] Inbound completion handler failed",
+    );
+  }
 }
 
 /**

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -132,6 +132,7 @@ import {
   registerLifeOpsTaskWorker,
 } from "./lifeops/runtime.js";
 import { registerLifeOpsScheduledTaskRunnerDeps } from "./lifeops/scheduled-task/runtime-wiring.js";
+import { handleScheduledTaskInboundMessage } from "./lifeops/scheduled-task/scheduler.js";
 import { getScheduledTaskRunner as getProductionScheduledTaskRunner } from "./lifeops/scheduled-task/service.js";
 import { lifeOpsSchema } from "./lifeops/schema.js";
 import {
@@ -821,6 +822,7 @@ const rawPersonalAssistantPlugin: Plugin = {
   // overview"). Domain views live in the per-domain plugins; the personal
   // assistant is the chat itself (PERSONAL_ASSISTANT action).
   events: {
+    [EventType.MESSAGE_RECEIVED]: [handleScheduledTaskInboundMessage],
     // Fold recognized voice turns into the entity/relationship graph via
     // the merge engine, then round-trip the binding to the voice-profile
     // owner. See lifeops/entities/voice-observer-bridge.ts.
@@ -1283,8 +1285,11 @@ export type {
   GateDecision,
   ProcessDueScheduledTasksRequest,
   ProcessDueScheduledTasksResult,
+  ProcessScheduledTaskInboundMessageRequest,
+  ProcessScheduledTaskInboundMessageResult,
   ScheduledTask,
   ScheduledTaskCompletionCheck,
+  ScheduledTaskCompletionResult,
   ScheduledTaskContextRequest,
   ScheduledTaskDueContext,
   ScheduledTaskDueDecision,
@@ -1320,6 +1325,7 @@ export {
   DEFAULT_ESCALATION_LADDERS,
   PRIORITY_DEFAULT_LADDER_KEYS,
   processDueScheduledTasks,
+  processScheduledTaskInboundMessage,
   registerBuiltInCompletionChecks,
   registerBuiltInGates,
   registerDefaultEscalationLadders,
@@ -1327,7 +1333,10 @@ export {
   STATE_LOG_DEFAULT_RETENTION_DAYS,
 } from "./lifeops/scheduled-task/index.js";
 export type { CreateRuntimeRunnerOptions } from "./lifeops/scheduled-task/runtime-wiring.js";
-export { createRuntimeScheduledTaskRunner } from "./lifeops/scheduled-task/runtime-wiring.js";
+export {
+  createRuntimeScheduledTaskRunner,
+  registerLifeOpsScheduledTaskSubjectStore,
+} from "./lifeops/scheduled-task/runtime-wiring.js";
 export type { GetScheduledTaskRunnerOptions } from "./lifeops/scheduled-task/service.js";
 export {
   getScheduledTaskRunner,


### PR DESCRIPTION
Closes #11354

## Summary
- complete fired `user_replied_within` scheduled tasks from owner `MESSAGE_RECEIVED` events in the same room
- evaluate fired `subject_updated` and `health_signal_observed` checks during the production tick before timeout handling
- add runtime subject-store registration so cached runners see later subject store wiring

## Evidence
- `bun run --cwd plugins/plugin-birdclaw build` passed
- `bun run --cwd plugins/plugin-calendar build` passed
- `bun run --cwd plugins/plugin-scheduling build` passed
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts` passed, 1 file / 13 tests
- `bun run --cwd plugins/plugin-personal-assistant test -- test/lifeops-scheduled-task-simulation.test.ts src/lifeops/domains/reminders-service.process-scheduled-work.test.ts src/lifeops/domains/reminders-service.state-log-rollover.test.ts` passed, 3 files / 13 tests
- `bunx @biomejs/biome check ...` passed on touched files
- `bun run --cwd plugins/plugin-personal-assistant typecheck` blocked by unrelated workspace drift: missing `@elizaos/plugin-google` declarations, existing Gmail implicit-any after that import path, and stale `@elizaos/app-core/api/auth` export for `ensureSessionForRequest`
- `bun run verify` blocked before typecheck/lint by current repo type-safety ratchet: `as unknown as` 80 / 77 and core/agent/app-core `?? {}` 379 / 377

Evidence file: `.github/issue-evidence/11354-lifeops-completion-autofire.md`

No UI, native, connector, audio, or live-LLM behavior changed; those evidence rows are N/A.