### PR TITLE
fix(ui): re-anchor mobile local model registry paths

### DIFF
--- a/.github/issue-evidence/11371-mobile-model-path-reanchor.md
+++ b/.github/issue-evidence/11371-mobile-model-path-reanchor.md
@@ -1,0 +1,78 @@
+# Issue #11371 - Mobile local-inference model path re-anchor
+
+Date: 2026-07-02
+Branch: `fix/11371-mobile-model-path-reanchor`
+
+## What Changed
+
+- `packages/ui/src/services/local-inference/registry.ts` now separates the
+  raw on-disk registry shape from the public `InstalledModel` API shape.
+- New registry writes store Eliza-owned `path`, `bundleRoot`, and
+  `manifestPath` relative to `localInferenceRoot()`, so new mobile installs do
+  not persist absolute iOS container UUIDs.
+- Legacy absolute paths are still accepted. If a legacy path contains a
+  `local-inference/...` suffix from a previous iOS app container, the registry
+  re-anchors that suffix under the current state root before returning the
+  model to the loader.
+- Malformed relative paths that escape the current local-inference root are
+  dropped at the registry-read boundary.
+
+## Verification
+
+```bash
+ELIZA_SKIP_ARTIFACT_SYNC=1 bun run install:light
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+```
+
+Result: dependency setup and generated declarations available in the fresh
+worktree.
+
+```bash
+bunx @biomejs/biome check \
+  packages/ui/src/services/local-inference/registry.ts \
+  packages/ui/src/services/local-inference/registry.test.ts
+```
+
+Result: passed.
+
+```bash
+bunx vitest run \
+  packages/ui/src/services/local-inference/registry.test.ts \
+  packages/ui/src/services/local-inference/active-model.test.ts
+```
+
+Result: 2 files passed, 21 tests passed.
+
+The new regression coverage includes:
+
+- fresh writes persist root-relative registry paths;
+- legacy absolute paths from an old simulated iOS container root resolve to the
+  current state root while preserving the model/bundle/manifest suffix.
+
+```bash
+bun run --cwd packages/ui typecheck
+```
+
+Result: passed after building `packages/contracts`.
+
+```bash
+bun run verify
+```
+
+Result: failed before this branch's change paths in the existing
+`audit:type-safety-ratchet` baseline:
+
+- `as unknown as`: 80 current > 77 baseline
+- ``?? {}`` in core/agent/app-core: 379 current > 377 baseline
+
+## N/A
+
+- Real iOS reinstall video: N/A - the PR adds deterministic regression coverage
+  for the root cause by simulating old and current app container roots.
+- App visual audit/screenshots: N/A - no rendered UI, layout, or styling path
+  changed.
+- Real-LLM trajectories: N/A - no model prompt, provider, action, evaluator, or
+  generation behavior changed.
+- Backend/domain artifacts: N/A - local registry path serialization only; no
+  server state, database rows, or external services changed.

--- a/packages/ui/src/services/local-inference/registry.test.ts
+++ b/packages/ui/src/services/local-inference/registry.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { registryPath } from "./paths";
 import {
   listInstalledModels,
   removeElizaModel,
@@ -11,6 +12,15 @@ import type { InstalledModel } from "./types";
 
 const originalEnv = { ...process.env };
 const tempDirs: string[] = [];
+
+type RawRegistryModel = Omit<
+  InstalledModel,
+  "path" | "bundleRoot" | "manifestPath"
+> & {
+  path: string;
+  bundleRoot?: string;
+  manifestPath?: string;
+};
 
 afterEach(() => {
   process.env = { ...originalEnv };
@@ -43,7 +53,110 @@ function installedModel(
   };
 }
 
+function readRegistryJson(): { models: RawRegistryModel[] } {
+  return JSON.parse(fs.readFileSync(registryPath(), "utf8")) as {
+    models: RawRegistryModel[];
+  };
+}
+
 describe("local inference registry removal", () => {
+  it("persists Eliza-owned artifact paths relative to the current local-inference root", async () => {
+    const stateDir = useTempStateDir();
+    const bundleRoot = path.join(
+      stateDir,
+      "local-inference",
+      "models",
+      "eliza-1-2b",
+    );
+    const modelPath = path.join(bundleRoot, "text", "model.gguf");
+    const manifestPath = path.join(bundleRoot, "eliza-1.manifest.json");
+    fs.mkdirSync(path.dirname(modelPath), { recursive: true });
+    fs.writeFileSync(modelPath, "fake-model");
+    fs.writeFileSync(manifestPath, "{}");
+
+    await upsertElizaModel(
+      installedModel("eliza-1-2b", modelPath, {
+        bundleRoot,
+        manifestPath,
+      }),
+    );
+
+    const raw = readRegistryJson().models[0];
+    expect(raw.path).toBe("models/eliza-1-2b/text/model.gguf");
+    expect(raw.bundleRoot).toBe("models/eliza-1-2b");
+    expect(raw.manifestPath).toBe("models/eliza-1-2b/eliza-1.manifest.json");
+    expect(path.isAbsolute(raw.path)).toBe(false);
+
+    await expect(listInstalledModels()).resolves.toMatchObject([
+      {
+        id: "eliza-1-2b",
+        path: modelPath,
+        bundleRoot,
+        manifestPath,
+      },
+    ]);
+  });
+
+  it("re-anchors legacy absolute paths from a previous iOS app container to the current state root", async () => {
+    const currentStateDir = useTempStateDir();
+    const oldStateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-ui-registry-old-ios-container-"),
+    );
+    tempDirs.push(oldStateDir);
+
+    const currentBundleRoot = path.join(
+      currentStateDir,
+      "local-inference",
+      "models",
+      "eliza-1-2b",
+    );
+    const currentModelPath = path.join(currentBundleRoot, "text", "model.gguf");
+    const currentManifestPath = path.join(
+      currentBundleRoot,
+      "eliza-1.manifest.json",
+    );
+    fs.mkdirSync(path.dirname(currentModelPath), { recursive: true });
+    fs.writeFileSync(currentModelPath, "fake-model");
+    fs.writeFileSync(currentManifestPath, "{}");
+
+    const oldBundleRoot = path.join(
+      oldStateDir,
+      "local-inference",
+      "models",
+      "eliza-1-2b",
+    );
+    const oldModelPath = path.join(oldBundleRoot, "text", "model.gguf");
+    const oldManifestPath = path.join(oldBundleRoot, "eliza-1.manifest.json");
+
+    fs.mkdirSync(path.dirname(registryPath()), { recursive: true });
+    fs.writeFileSync(
+      registryPath(),
+      JSON.stringify(
+        {
+          version: 1,
+          models: [
+            installedModel("eliza-1-2b", oldModelPath, {
+              bundleRoot: oldBundleRoot,
+              manifestPath: oldManifestPath,
+            }),
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    await expect(listInstalledModels()).resolves.toMatchObject([
+      {
+        id: "eliza-1-2b",
+        path: currentModelPath,
+        bundleRoot: currentBundleRoot,
+        manifestPath: currentManifestPath,
+      },
+    ]);
+  });
+
   it("removes an Eliza-owned bundle directory and clears the registry entry", async () => {
     const stateDir = useTempStateDir();
     const bundleRoot = path.join(

--- a/packages/ui/src/services/local-inference/registry.ts
+++ b/packages/ui/src/services/local-inference/registry.ts
@@ -14,13 +14,101 @@ import { scanExternalModels } from "./external-scanner";
 import { isWithinElizaRoot, localInferenceRoot, registryPath } from "./paths";
 import type { InstalledModel } from "./types";
 
+type StoredInstalledModel = Omit<
+  InstalledModel,
+  "path" | "bundleRoot" | "manifestPath"
+> & {
+  /** Relative to localInferenceRoot() for Eliza-owned rows; legacy JSON may be absolute. */
+  path: string;
+  bundleRoot?: string;
+  manifestPath?: string;
+};
+
 interface RegistryFile {
   version: 1;
-  models: InstalledModel[];
+  models: StoredInstalledModel[];
 }
 
 async function ensureRootDir(): Promise<void> {
   await fs.mkdir(localInferenceRoot(), { recursive: true });
+}
+
+function normalizeStoredPathSeparator(target: string): string {
+  return target.split(/[\\/]+/).join(path.sep);
+}
+
+function storedRelativePath(target: string): string {
+  const root = path.resolve(localInferenceRoot());
+  const resolved = path.resolve(target);
+  if (!isWithinElizaRoot(resolved)) return target;
+  return path.relative(root, resolved).split(path.sep).join("/");
+}
+
+function reanchorLegacyAbsolutePath(target: string): string {
+  const resolved = path.resolve(target);
+  if (isWithinElizaRoot(resolved)) return resolved;
+
+  const parts = normalizeStoredPathSeparator(resolved).split(path.sep);
+  const markerIndex = parts.lastIndexOf("local-inference");
+  if (markerIndex < 0 || markerIndex === parts.length - 1) {
+    return resolved;
+  }
+
+  const candidate = path.resolve(
+    localInferenceRoot(),
+    ...parts.slice(markerIndex + 1),
+  );
+  return isWithinElizaRoot(candidate) ? candidate : resolved;
+}
+
+function resolveStoredElizaPath(target: string): string | null {
+  if (typeof target !== "string" || target.trim().length === 0) return null;
+  if (path.isAbsolute(target) || /^[a-zA-Z]:[\\/]/.test(target)) {
+    return reanchorLegacyAbsolutePath(target);
+  }
+
+  const resolved = path.resolve(
+    localInferenceRoot(),
+    normalizeStoredPathSeparator(target),
+  );
+  return isWithinElizaRoot(resolved) ? resolved : null;
+}
+
+function hydrateStoredModel(
+  model: StoredInstalledModel,
+): InstalledModel | null {
+  const modelPath = resolveStoredElizaPath(model.path);
+  if (!modelPath) return null;
+
+  const bundleRoot = model.bundleRoot
+    ? resolveStoredElizaPath(model.bundleRoot)
+    : undefined;
+  const manifestPath = model.manifestPath
+    ? resolveStoredElizaPath(model.manifestPath)
+    : undefined;
+
+  if (model.bundleRoot && !bundleRoot) return null;
+  if (model.manifestPath && !manifestPath) return null;
+
+  return {
+    ...model,
+    path: modelPath,
+    ...(bundleRoot ? { bundleRoot } : {}),
+    ...(manifestPath ? { manifestPath } : {}),
+  };
+}
+
+function dehydrateStoredModel(model: InstalledModel): StoredInstalledModel {
+  return {
+    ...model,
+    path: storedRelativePath(model.path),
+    ...(model.bundleRoot
+      ? { bundleRoot: storedRelativePath(model.bundleRoot) }
+      : {}),
+    ...(model.manifestPath
+      ? { manifestPath: storedRelativePath(model.manifestPath) }
+      : {}),
+  };
 }
 
 async function readElizaOwned(): Promise<InstalledModel[]> {
@@ -30,10 +118,13 @@ async function readElizaOwned(): Promise<InstalledModel[]> {
     if (parsed?.version !== 1 || !Array.isArray(parsed.models)) {
       return [];
     }
-    return parsed.models.filter(
-      (m): m is InstalledModel =>
-        m && typeof m === "object" && m.source === "eliza-download",
-    );
+    return parsed.models
+      .filter(
+        (m): m is InstalledModel =>
+          m && typeof m === "object" && m.source === "eliza-download",
+      )
+      .map(hydrateStoredModel)
+      .filter((m): m is InstalledModel => m !== null);
   } catch {
     return [];
   }
@@ -42,7 +133,10 @@ async function readElizaOwned(): Promise<InstalledModel[]> {
 async function writeElizaOwned(models: InstalledModel[]): Promise<void> {
   await ensureRootDir();
   const tmp = `${registryPath()}.tmp`;
-  const payload: RegistryFile = { version: 1, models };
+  const payload: RegistryFile = {
+    version: 1,
+    models: models.map(dehydrateStoredModel),
+  };
   await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
   await fs.rename(tmp, registryPath());
 }


### PR DESCRIPTION
Closes #11371.

## Summary
- Store Eliza-owned local-inference registry artifact paths relative to `localInferenceRoot()` instead of persisting absolute mobile container paths.
- Hydrate registry rows back to absolute API paths at read time.
- Re-anchor legacy absolute `local-inference/...` paths from an old iOS container under the current state root.
- Add regression coverage for fresh relative persistence and stale-container path migration.

## Evidence
- `.github/issue-evidence/11371-mobile-model-path-reanchor.md`

## Verification
- `bunx @biomejs/biome check packages/ui/src/services/local-inference/registry.ts packages/ui/src/services/local-inference/registry.test.ts` — passed
- `bunx vitest run packages/ui/src/services/local-inference/registry.test.ts packages/ui/src/services/local-inference/active-model.test.ts` — 2 files / 21 tests passed
- `bun run --cwd packages/ui typecheck` — passed
- `bun run verify` — fails before this branch's paths at existing type-safety ratchet: `as unknown as` 80/77 and `?? {}` 379/377

## N/A
- App visual audit/screenshots: no rendered UI, layout, or styling changed.
- Real-LLM trajectories: no prompt/model/action/provider path changed.
- iOS reinstall video: simulated deterministically in the new registry regression test.