### PR TITLE
fix(lifeops-bench): align manifest with expanded corpus

### DIFF
--- a/.github/issue-evidence/11436-lifeops-manifest-expanded-corpus.md
+++ b/.github/issue-evidence/11436-lifeops-manifest-expanded-corpus.md
@@ -1,0 +1,68 @@
+# Issue 11436 - LifeOpsBench Expanded Corpus Manifest
+
+Date: 2026-07-02
+Branch: `fix/11436-lifeops-manifest-expanded-corpus`
+
+## Change
+
+- Extended the LifeOpsBench manifest augment so regenerated manifests cover
+  benchmark-only expanded-corpus fields on scheduled tasks and selected live
+  plugin action names.
+- Kept the overlay narrow and explicit in
+  `eliza_lifeops_bench.manifest_export`.
+- Regenerated `manifests/actions.manifest.json` from the in-tree generator.
+- Added regression coverage in `tests/test_manifest_export.py`.
+
+## Reproduction
+
+After #11417, the full package suite reached 97% and failed in:
+
+```bash
+python3 -m pytest tests/ -q
+```
+
+Observed failures:
+
+- `tests/test_expanded_scenarios.py::test_expanded_scenarios_validate_against_manifest`
+  rejected undeclared expanded-corpus kwargs on regenerated manifest actions.
+- Initial missing fields included scheduled-task metadata/pipeline fields,
+  blocker/travel/finance overlay fields, and numeric `BOOK_TRAVEL.passengers`.
+
+## Verification
+
+Passed:
+
+```bash
+bun run lifeops-bench:manifest
+python3 -m pytest tests/test_manifest_export.py tests/test_expanded_scenarios.py::test_expanded_scenarios_validate_against_manifest tests/test_scenarios_corpus.py -q
+python3 -m pytest tests/test_manifest_export.py tests/test_expanded_scenarios.py tests/test_scenarios_corpus.py -q
+node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts --out "$manifest_tmp" --summary-out "$summary_tmp"
+diff -u packages/benchmarks/lifeops-bench/manifests/actions.manifest.json "$manifest_tmp"
+diff -u packages/benchmarks/lifeops-bench/manifests/actions.summary.md "$summary_tmp"
+bunx @biomejs/biome check scripts/lifeops-bench/export-action-manifest.ts package.json .github/workflows/lifeops-bench-manifest.yml --no-errors-on-unmatched
+git diff --check
+```
+
+Results reviewed:
+
+- Focused pytest: `21 passed`.
+- Expanded + manifest + corpus pytest: `28 passed`.
+- Drift check: regenerated manifest and summary matched committed artifacts.
+- Manifest still reports `174` actions and `20` bench umbrella entries.
+
+Known unrelated repo-level blocker:
+
+```bash
+bun run verify
+```
+
+Result: failed before typecheck/lint at the existing type-safety ratchet drift:
+
+- `as unknown as: 80 current > 77 baseline`
+- ``?? {}`` `(core/agent/app-core): 379 current > 377 baseline`
+
+## N/A
+
+- UI screenshots/video: N/A - benchmark manifest/schema tooling only.
+- Live model trajectory: N/A - no model behavior changed; this fixes corpus
+  validation against the generated manifest.

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/manifest_export.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/manifest_export.py
@@ -195,22 +195,29 @@ _BENCH_UMBRELLA_AUGMENTS: dict[str, dict[str, Any]] = {
             "destination": {"type": "string"},
             "departureDate": {"type": "string"},
             "returnDate": {"type": "string"},
-            # passengers is an array of objects, not a bare integer count.
-            # Each item carries name (string) and seat_class (economy|business|first).
-            # The scorer coerces integer counts to this canonical array form.
+            # The corpus uses both integer counts and the canonical array form.
+            # The scorer coerces counts to passenger objects.
             "passengers": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "seat_class": {
-                            "type": "string",
-                            "enum": ["economy", "business", "first"],
+                "description": (
+                    "Either an integer passenger count or the canonical passenger array."
+                ),
+                "oneOf": [
+                    {"type": "number"},
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "seat_class": {
+                                    "type": "string",
+                                    "enum": ["economy", "business", "first"],
+                                },
+                            },
+                            "required": ["name", "seat_class"],
                         },
                     },
-                    "required": ["name", "seat_class"],
-                },
+                ],
             },
         },
     },
@@ -225,6 +232,12 @@ _BENCH_UMBRELLA_AUGMENTS: dict[str, dict[str, Any]] = {
             "source": {"type": "string"},
             "priority": {"type": "string"},
             "ownerVisible": {"type": "boolean"},
+            "respectsGlobalPause": {"type": "boolean"},
+            "metadata": {"type": "object", "additionalProperties": True},
+            "subject": {"type": "object", "additionalProperties": True},
+            "output": {"type": "object", "additionalProperties": True},
+            "pipeline": {"type": "object", "additionalProperties": True},
+            "escalation": {"type": "object", "additionalProperties": True},
         },
     },
     "SCHEDULED_TASK_UPDATE": {
@@ -234,6 +247,7 @@ _BENCH_UMBRELLA_AUGMENTS: dict[str, dict[str, Any]] = {
         "extra_properties": {
             "taskId": {"type": "string"},
             "trigger": {"type": "object", "additionalProperties": True},
+            "updates": {"type": "object", "additionalProperties": True},
             "reason": {"type": "string"},
         },
     },
@@ -246,6 +260,58 @@ _BENCH_UMBRELLA_AUGMENTS: dict[str, dict[str, Any]] = {
             "minutes": {"type": "number"},
             "reason": {"type": "string"},
         },
+    },
+}
+
+# Some expanded-corpus scenarios intentionally carry benchmark metadata through
+# live plugin action names. The generated plugin schemas stay strict for agent
+# tooling, so the bench manifest overlays only these scenario-side fields.
+_BENCH_PROPERTY_OVERLAYS: dict[str, dict[str, Any]] = {
+    "BLOCK_BLOCK": {
+        "exceptions": {
+            "type": "array",
+            "items": {"type": "object", "additionalProperties": True},
+        },
+        "mode": {"type": "string"},
+        "policy": {"type": "string"},
+        "schedule": {"type": "object", "additionalProperties": True},
+    },
+    "BLOCK_LIST_ACTIVE": {
+        "includeScheduled": {"type": "boolean"},
+    },
+    "BLOCK_REQUEST_PERMISSION": {
+        "confirmationRequired": {"type": "boolean"},
+        "mode": {"type": "string"},
+        "noBypass": {"type": "boolean"},
+    },
+    "BLOCK_STATUS": {
+        "scope": {"type": "string"},
+    },
+    "BOOK_TRAVEL": {
+        "approval": {"type": "object", "additionalProperties": True},
+        "calendarSync": {"type": "boolean"},
+        "hotelCheckIn": {"type": "string"},
+        "rebookReason": {"type": "string"},
+    },
+    "ENTITY": {
+        "storeAllowed": {"type": "boolean"},
+    },
+    "LIFE_SKIP": {
+        "reason": {"type": "string"},
+        "target": {"type": "string"},
+    },
+    "LIFE_UPDATE": {
+        "target": {"type": "string"},
+        "updates": {"type": "object", "additionalProperties": True},
+    },
+    "MONEY_SPENDING_SUMMARY": {
+        "groupBy": {"type": "string"},
+    },
+    "MONEY_SUBSCRIPTION_AUDIT": {
+        "category": {"type": "string"},
+    },
+    "MONEY_SUBSCRIPTION_CANCEL": {
+        "candidateId": {"type": "string"},
     },
 }
 
@@ -316,6 +382,29 @@ def bench_umbrella_actions() -> list[dict[str, Any]]:
     return [_build_entry(name, spec) for name, spec in _BENCH_UMBRELLA_AUGMENTS.items()]
 
 
+def _apply_property_overlays(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return entries with benchmark-only scenario properties merged in."""
+    patched_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        name = entry.get("function", {}).get("name")
+        overlays = _BENCH_PROPERTY_OVERLAYS.get(name)
+        if not overlays:
+            patched_entries.append(entry)
+            continue
+
+        patched = dict(entry)
+        function = dict(patched["function"])
+        parameters = dict(function["parameters"])
+        properties = dict(parameters.get("properties", {}))
+        for key, schema in overlays.items():
+            properties.setdefault(key, schema)
+        parameters["properties"] = properties
+        function["parameters"] = parameters
+        patched["function"] = function
+        patched_entries.append(patched)
+    return patched_entries
+
+
 def augment_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``manifest`` with bench-only umbrella entries appended.
 
@@ -347,6 +436,7 @@ def augment_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
             continue
         deduplicated.append(entry)
         existing.add(name)
+    deduplicated = _apply_property_overlays(deduplicated)
     deduplicated.sort(key=lambda a: a["function"]["name"])
     out = dict(manifest)
     out["actions"] = deduplicated

--- a/packages/benchmarks/lifeops-bench/manifests/actions.manifest.json
+++ b/packages/benchmarks/lifeops-bench/manifests/actions.manifest.json
@@ -209,6 +209,23 @@
             "durationMinutes": {
               "type": "number",
               "description": "Block duration minutes. Omit/null = indefinite until manual removal."
+            },
+            "exceptions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "mode": {
+              "type": "string"
+            },
+            "policy": {
+              "type": "string"
+            },
+            "schedule": {
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "additionalProperties": false
@@ -322,6 +339,9 @@
             "durationMinutes": {
               "type": "number",
               "description": "Block duration minutes. Omit/null = indefinite until manual removal."
+            },
+            "includeScheduled": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -548,6 +568,15 @@
             "durationMinutes": {
               "type": "number",
               "description": "Block duration minutes. Omit/null = indefinite until manual removal."
+            },
+            "confirmationRequired": {
+              "type": "boolean"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "noBypass": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -661,6 +690,9 @@
             "durationMinutes": {
               "type": "number",
               "description": "Block duration minutes. Omit/null = indefinite until manual removal."
+            },
+            "scope": {
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -838,27 +870,48 @@
               "type": "string"
             },
             "passengers": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "seat_class": {
-                    "type": "string",
-                    "enum": [
-                      "economy",
-                      "business",
-                      "first"
+              "description": "Either an integer passenger count or the canonical passenger array.",
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "seat_class": {
+                        "type": "string",
+                        "enum": [
+                          "economy",
+                          "business",
+                          "first"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "seat_class"
                     ]
                   }
-                },
-                "required": [
-                  "name",
-                  "seat_class"
-                ]
-              }
+                }
+              ]
+            },
+            "approval": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "calendarSync": {
+              "type": "boolean"
+            },
+            "hotelCheckIn": {
+              "type": "string"
+            },
+            "rebookReason": {
+              "type": "string"
             }
           },
           "required": [],
@@ -5600,6 +5653,9 @@
             "evidence": {
               "type": "string",
               "description": "Evidence string for set_identity/set_relationship observations."
+            },
+            "storeAllowed": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -6765,6 +6821,12 @@
             "details": {
               "type": "object",
               "additionalProperties": true
+            },
+            "reason": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
             }
           },
           "required": [
@@ -6876,6 +6938,13 @@
               "type": "string"
             },
             "details": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "target": {
+              "type": "string"
+            },
+            "updates": {
               "type": "object",
               "additionalProperties": true
             }
@@ -7459,6 +7528,9 @@
             },
             "windowDays": {
               "type": "number"
+            },
+            "groupBy": {
+              "type": "string"
             }
           },
           "required": [
@@ -7509,6 +7581,9 @@
             },
             "queryWindowDays": {
               "type": "number"
+            },
+            "category": {
+              "type": "string"
             }
           },
           "required": [
@@ -7565,6 +7640,9 @@
             },
             "confirmed": {
               "type": "boolean"
+            },
+            "candidateId": {
+              "type": "string"
             }
           },
           "required": [
@@ -17936,6 +18014,29 @@
             },
             "ownerVisible": {
               "type": "boolean"
+            },
+            "respectsGlobalPause": {
+              "type": "boolean"
+            },
+            "metadata": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "subject": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "output": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "pipeline": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "escalation": {
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "required": [
@@ -18048,6 +18149,10 @@
               "type": "string"
             },
             "trigger": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "updates": {
               "type": "object",
               "additionalProperties": true
             },

--- a/packages/benchmarks/lifeops-bench/tests/test_manifest_export.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_manifest_export.py
@@ -70,6 +70,56 @@ def test_manifest_actions_are_unique_sorted_and_augmented() -> None:
     }.issubset(bench_names)
 
 
+def test_scheduled_task_augments_cover_expanded_scenario_kwargs() -> None:
+    actions = {
+        entry["function"]["name"]: entry
+        for entry in _manifest()["actions"]
+    }
+    create_properties = actions["SCHEDULED_TASK_CREATE"]["function"]["parameters"][
+        "properties"
+    ]
+    update_properties = actions["SCHEDULED_TASK_UPDATE"]["function"]["parameters"][
+        "properties"
+    ]
+
+    assert {
+        "escalation",
+        "metadata",
+        "output",
+        "pipeline",
+        "respectsGlobalPause",
+        "subject",
+    }.issubset(create_properties)
+    assert "updates" in update_properties
+
+
+def test_plugin_action_overlays_cover_expanded_scenario_kwargs() -> None:
+    actions = {
+        entry["function"]["name"]: entry for entry in _manifest()["actions"]
+    }
+    block_properties = actions["BLOCK_BLOCK"]["function"]["parameters"][
+        "properties"
+    ]
+    travel_properties = actions["BOOK_TRAVEL"]["function"]["parameters"][
+        "properties"
+    ]
+    finance_properties = actions["MONEY_SUBSCRIPTION_CANCEL"]["function"][
+        "parameters"
+    ]["properties"]
+
+    assert {"exceptions", "mode", "policy", "schedule"}.issubset(
+        block_properties
+    )
+    assert {"approval", "calendarSync", "hotelCheckIn", "rebookReason"}.issubset(
+        travel_properties
+    )
+    assert {schema["type"] for schema in travel_properties["passengers"]["oneOf"]} == {
+        "array",
+        "number",
+    }
+    assert "candidateId" in finance_properties
+
+
 def test_summary_counts_match_manifest() -> None:
     actions = _manifest()["actions"]
     summary = SUMMARY_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Extends the LifeOpsBench manifest augment so regenerated manifests validate the checked-in expanded scenario corpus.
- Adds narrow benchmark-only overlays for scheduled-task metadata plus blocker/travel/finance scenario fields.
- Allows `BOOK_TRAVEL.passengers` to be either the canonical passenger array or the numeric count the scorer already coerces.
- Adds regression coverage in `tests/test_manifest_export.py` and regenerates `actions.manifest.json`.

Fixes #11436. Follow-up to #11382 / #11417.

## Evidence

See `.github/issue-evidence/11436-lifeops-manifest-expanded-corpus.md`.

Passed after rebase onto latest `origin/develop`:

```bash
bun install --frozen-lockfile
bun run lifeops-bench:manifest
python3 -m pytest tests/test_manifest_export.py tests/test_expanded_scenarios.py tests/test_scenarios_corpus.py -q
node --conditions=eliza-source --conditions=development --import tsx scripts/lifeops-bench/export-action-manifest.ts --out "$manifest_tmp" --summary-out "$summary_tmp"
diff -u packages/benchmarks/lifeops-bench/manifests/actions.manifest.json "$manifest_tmp"
diff -u packages/benchmarks/lifeops-bench/manifests/actions.summary.md "$summary_tmp"
bunx @biomejs/biome check scripts/lifeops-bench/export-action-manifest.ts package.json .github/workflows/lifeops-bench-manifest.yml --no-errors-on-unmatched
git diff --check
```

Known unrelated blocker:

```bash
bun run verify
```

Fails before typecheck/lint at the existing type-safety ratchet drift: `as unknown as` 80 > 77 and `?? {}` 379 > 377.

N/A: UI screenshots/video and live model trajectory; this is benchmark manifest/schema tooling only.
