### PR TITLE
fix(cloud): recheck vacated invite org before delete

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts
@@ -148,6 +148,11 @@ async function orgExists(orgId: string): Promise<boolean> {
   return rows.rows.length > 0;
 }
 
+async function appExists(appId: string): Promise<boolean> {
+  const rows = await dbWrite.execute(`SELECT id FROM apps WHERE id = '${appId}';`);
+  return rows.rows.length > 0;
+}
+
 beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
@@ -287,6 +292,46 @@ describe("acceptInvite — existing owner of an empty solo org (#11332)", () => 
       expect((conversationRows.rows[0] as { organization_id: string }).organization_id).toBe(
         seeded.inviterOrgId,
       );
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "vacated org is not deleted if real state appears after the user move",
+    async () => {
+      expect(pgliteReady).toBe(true);
+      const seeded = await seedInviteScenario({ invitedRole: "member" });
+      const racedAppId = uid();
+
+      const { usersService } = await import("../users");
+      const originalUpdate = usersService.update;
+      let injected = false;
+      usersService.update = mock(async (id, data) => {
+        const updated = await originalUpdate.call(usersService, id, data);
+        if (id === seeded.inviteeUserId && !injected) {
+          injected = true;
+          await dbWrite.insert(schemas.apps).values({
+            id: racedAppId,
+            organization_id: seeded.inviteeOrgId,
+            created_by_user_id: seeded.inviteeUserId,
+            name: "race app",
+            slug: `race-${seeded.inviteeOrgId}`,
+            app_url: "https://example.com",
+          });
+        }
+        return updated;
+      }) as typeof usersService.update;
+
+      try {
+        const accepted = await invitesService.acceptInvite(seeded.token, seeded.inviteeUserId);
+
+        expect(accepted.status).toBe("accepted");
+        expect((await readUser(seeded.inviteeUserId)).organization_id).toBe(seeded.inviterOrgId);
+        expect(await orgExists(seeded.inviteeOrgId)).toBe(true);
+        expect(await appExists(racedAppId)).toBe(true);
+      } finally {
+        usersService.update = originalUpdate;
+      }
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/invites.ts
+++ b/packages/cloud/shared/src/lib/services/invites.ts
@@ -6,7 +6,6 @@ import {
   type NewOrganizationInvite,
   type OrganizationInvite,
   organizationInvitesRepository,
-  type User,
 } from "../../db/repositories";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { appsRepository } from "../../db/repositories/apps";
@@ -186,7 +185,7 @@ export class InvitesService {
     // actionable error — abandoning a real org needs an explicit path.
     const vacatedSoloOrgId = user.role === "owner" ? user.organization_id : null;
     if (vacatedSoloOrgId) {
-      await this.assertOwnerCanVacateSoloOrganization(user, vacatedSoloOrgId);
+      await this.assertOwnerCanVacateSoloOrganization(user.id, vacatedSoloOrgId);
     }
 
     const movedUser = await usersService.update(userId, {
@@ -213,11 +212,11 @@ export class InvitesService {
    * solo org (the auto-provisioned signup artifact), not a real organization.
    */
   private async assertOwnerCanVacateSoloOrganization(
-    user: User,
+    userId: string,
     organizationId: string,
   ): Promise<void> {
     const members = await usersService.listByOrganization(organizationId);
-    if (members.some((member) => member.id !== user.id)) {
+    if (members.some((member) => member.id !== userId)) {
       throw new Error(
         "You cannot join another organization while your current organization has other members. Transfer ownership or remove them first.",
       );
@@ -284,6 +283,7 @@ export class InvitesService {
         previousOrganizationId,
         newOrganizationId,
       );
+      await this.assertOwnerCanVacateSoloOrganization(userId, previousOrganizationId);
       await organizationsService.delete(previousOrganizationId);
     } catch (error) {
       logger.warn("[InvitesService] Failed to clean up vacated solo organization", {


### PR DESCRIPTION
## Summary
- Re-check the full owner-vacate safety predicate immediately before deleting the vacated solo org.
- Preserve the #11406 happy path, but do not cascade-delete an org if apps/agents/domains/extra credits appear after the user move.
- Add a PGlite regression that injects an app between `usersService.update` and cleanup, then verifies the old org and app survive.

## Validation
- `git diff --check origin/develop...HEAD`
- `bunx @biomejs/biome@2.5.2 check packages/cloud/shared/src/lib/services/invites.ts packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/invite-owner-accept.test.ts` (9/9 passing)
- `bun run --cwd packages/cloud/shared typecheck`

Follow-up to #11406 / #11332.
