### PR TITLE
Fix mobile local model path re-anchoring

### DIFF
--- a/.github/issue-evidence/11371-model-path-reanchor.md
+++ b/.github/issue-evidence/11371-model-path-reanchor.md
@@ -1,0 +1,77 @@
+# Issue #11371 — local model path re-anchor
+
+## What Changed
+
+- Eliza-owned local-inference registry rows now persist model artifact paths
+  relative to the current `local-inference/` root.
+- Registry reads hydrate relative rows to absolute paths for runtime use.
+- Legacy absolute rows from a previous mobile container are re-anchored by their
+  `/local-inference/...` suffix under the current state root.
+- The iOS bridge now reads both relative rows and legacy absolute rows, and its
+  native download writer stores relative paths.
+
+## Regression Evidence
+
+- `plugins/plugin-local-inference/src/services/registry.test.ts`
+  - Verifies new registry writes store `path`, `bundleRoot`, and `manifestPath`
+    as relative values.
+  - Simulates an old container root in `registry.json`, creates the same model
+    artifact under a new state root, and verifies `listInstalledModels()`
+    resolves the model, bundle root, and manifest inside the new root.
+- `plugins/plugin-local-inference/src/services/downloader.test.ts`
+  - Verifies downloader raw registry output is relative while hydrated runtime
+    registry output remains absolute for verify/load callers.
+
+## Commands Run
+
+```bash
+bun run --cwd packages/contracts build
+bun run --cwd packages/skills build
+bun run --cwd packages/cloud/routing build
+bun run --cwd plugins/plugin-streaming build
+bun run --cwd plugins/plugin-sql build
+bun run --cwd plugins/plugin-coding-tools build
+bun run --cwd plugins/plugin-background-runner build
+bun run --cwd plugins/plugin-anthropic build
+```
+
+Result: passed. These generated ignored local `dist/` artifacts needed by the
+package typecheck resolvers in this side worktree.
+
+```bash
+bun run --cwd plugins/plugin-local-inference test
+```
+
+Result: passed, 223 files / 2240 tests; 1 file / 13 tests skipped.
+
+```bash
+bun run --cwd plugins/plugin-local-inference typecheck
+bun run --cwd plugins/plugin-capacitor-bridge typecheck
+```
+
+Result: both passed.
+
+```bash
+bun run --cwd plugins/plugin-local-inference build
+bun run --cwd plugins/plugin-capacitor-bridge build
+```
+
+Result: both passed.
+
+```bash
+bunx @biomejs/biome check plugins/plugin-local-inference/src/services/downloader.test.ts plugins/plugin-local-inference/src/services/paths.ts plugins/plugin-local-inference/src/services/registry.ts plugins/plugin-local-inference/src/services/registry.test.ts plugins/plugin-local-inference/src/local-inference-routes.ts plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+```
+
+Result: passed, no fixes needed.
+
+```bash
+bun run verify
+```
+
+Result: blocked before typecheck/lint by repo-wide type-safety ratchet on
+current `origin/develop`: `as unknown as` is `80 / 77` and core/agent/app-core
+``?? {}`` is `379 / 377`.
+
+No UI, LLM, audio, or Swift/Kotlin native-code behavior changed. Full iOS
+reinstall capture was not run in this branch; the root-change regression above
+exercises the stale-container absolute-path failure mode directly.

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -1356,13 +1356,62 @@ function installedModelForCatalogEntry(
 	};
 }
 
+function isSubpath(target: string, root: string): boolean {
+	const relative = path.relative(root, target);
+	return (
+		relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+	);
+}
+
+function normalizeStoredRelativeModelPath(input: string): string | null {
+	const normalized = input.trim().replaceAll("\\", "/");
+	if (
+		!normalized ||
+		normalized.includes("\0") ||
+		path.isAbsolute(normalized) ||
+		/^[A-Za-z]:[\\/]/.test(normalized) ||
+		normalized.startsWith("\\\\")
+	) {
+		return null;
+	}
+	const parts = normalized.split("/").filter(Boolean);
+	if (parts.length === 0) return null;
+	if (parts.some((part) => part === "." || part === "..")) return null;
+	return parts.join("/");
+}
+
+function toStoredInstalledModelPath(modelPath: string): string | null {
+	const root = path.resolve(localInferenceRootPath());
+	const resolved = path.resolve(modelPath);
+	if (!isSubpath(resolved, root)) return null;
+	return path.relative(root, resolved).split(path.sep).join("/");
+}
+
+function serializeInstalledModelEntry(
+	model: InstalledModelEntry,
+): InstalledModelEntry | null {
+	const storedPath = toStoredInstalledModelPath(model.path);
+	return storedPath ? { ...model, path: storedPath } : null;
+}
+
 function upsertInstalledModel(model: InstalledModelEntry): void {
+	const storedModel = serializeInstalledModelEntry(model);
+	if (!storedModel) {
+		throw new Error(
+			`iOS local-inference model path must live under ${localInferenceRootPath()}: ${model.path}`,
+		);
+	}
 	const existing = readInstalledModels().filter(
-		(entry) => entry.id !== model.id && entry.path !== model.path,
+		(entry) =>
+			entry.id !== model.id &&
+			entry.path !== model.path &&
+			serializeInstalledModelEntry(entry),
 	);
 	writeJsonObjectFile(localInferenceRegistryPath(), {
 		version: 1,
-		models: [...existing, model],
+		models: [...existing, model]
+			.map(serializeInstalledModelEntry)
+			.filter((entry): entry is InstalledModelEntry => Boolean(entry)),
 		updatedAt: new Date().toISOString(),
 	});
 }
@@ -1454,20 +1503,21 @@ function normalizeInstalledModelPath(rawPath: string): string | null {
 	const trimmed = rawPath.trim();
 	if (!trimmed || trimmed.includes("\0")) return null;
 	const currentRoot = localInferenceRootPath();
-	const candidates = new Set<string>([
-		trimmed,
-		trimmed.replace(/^\/private\/var\//, "/var/"),
-	]);
+	const candidates = new Set<string>();
+	const relativePath = normalizeStoredRelativeModelPath(trimmed);
+	if (relativePath) {
+		candidates.add(path.join(currentRoot, ...relativePath.split("/")));
+	}
+	candidates.add(trimmed);
+	candidates.add(trimmed.replace(/^\/private\/var\//, "/var/"));
 	const marker = "/local-inference/";
 	const markerIndex = trimmed.indexOf(marker);
 	if (markerIndex >= 0) {
-		const relativePath = trimmed.slice(markerIndex + marker.length);
-		if (
-			relativePath &&
-			!relativePath.startsWith("/") &&
-			!relativePath.split(/[\\/]+/).includes("..")
-		) {
-			candidates.add(path.join(currentRoot, relativePath));
+		const legacyRelativePath = normalizeStoredRelativeModelPath(
+			trimmed.slice(markerIndex + marker.length),
+		);
+		if (legacyRelativePath) {
+			candidates.add(path.join(currentRoot, ...legacyRelativePath.split("/")));
 		}
 	}
 	for (const candidate of candidates) {

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -26,6 +26,10 @@ import {
 	LOCAL_INFERENCE_TEXT_MODEL_TYPES,
 } from "./provider.js";
 import { classifyDeviceTier } from "./services/device-tier.js";
+import {
+	resolveLocalInferenceStoredPath,
+	toLocalInferenceStoredPath,
+} from "./services/paths.js";
 
 // Lazy service handle. Importing `./services/service.js` eagerly evaluates the
 // full engine/voice/catalog/downloader graph (~800ms) — far too heavy for the
@@ -479,9 +483,13 @@ async function readRegistry(): Promise<InstalledModel[]> {
 	const installed: InstalledModel[] = [];
 	for (const model of models) {
 		if (!model.id || !model.path) continue;
+		const modelPath = resolveLocalInferenceStoredPath(model.path);
+		if (!modelPath) continue;
 		try {
-			const stat = await fsp.stat(model.path);
-			if (stat.isFile()) installed.push({ ...model, sizeBytes: stat.size });
+			const stat = await fsp.stat(modelPath);
+			if (stat.isFile()) {
+				installed.push({ ...model, path: modelPath, sizeBytes: stat.size });
+			}
 		} catch {
 			// Ignore stale registry entries.
 		}
@@ -490,7 +498,18 @@ async function readRegistry(): Promise<InstalledModel[]> {
 }
 
 async function writeRegistry(models: InstalledModel[]): Promise<void> {
-	await writeJsonFile(registryPath(), { version: 1, models });
+	await writeJsonFile(registryPath(), {
+		version: 1,
+		models: models.map((model) => {
+			const storedPath = toLocalInferenceStoredPath(model.path);
+			if (!storedPath) {
+				throw new Error(
+					"[local-inference] installed model path must live under the local-inference root",
+				);
+			}
+			return { ...model, path: storedPath };
+		}),
+	});
 }
 
 async function upsertInstalledModel(model: InstalledModel): Promise<void> {

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -8,6 +8,7 @@ import { findCatalogModel } from "./catalog";
 import { Downloader } from "./downloader";
 import type { Eliza1DeviceCaps } from "./manifest";
 import { registryPath } from "./paths";
+import { listInstalledModels } from "./registry";
 import type {
 	CatalogModel,
 	DownloadJob,
@@ -396,19 +397,28 @@ describe("local inference downloader status", () => {
 		}
 
 		expect(job.state).toBe("completed");
-		expect(path.normalize(main.path).endsWith(path.normalize(textPath))).toBe(
-			true,
-		);
-		expect(bundleRoot).toBe(
-			path.join(root, "local-inference", "models", "eliza-1-2b.bundle"),
-		);
+		expect(main.path).toBe(path.join("models", "eliza-1-2b.bundle", textPath));
+		expect(bundleRoot).toBe(path.join("models", "eliza-1-2b.bundle"));
 		expect(main.manifestPath).toBe(path.join(bundleRoot, manifestFile));
 		expect(main.bundleVersion).toBe("1.0.0");
 		expect(main.bundleSizeBytes).toBeGreaterThan(main.sizeBytes);
-		expect(fs.existsSync(path.join(bundleRoot, voicePath))).toBe(true);
-		expect(fs.existsSync(path.join(bundleRoot, asrPath))).toBe(true);
-		expect(fs.existsSync(path.join(bundleRoot, vadPath))).toBe(true);
-		expect(fs.existsSync(path.join(bundleRoot, visionPath))).toBe(true);
+		const hydratedMain = (await listInstalledModels()).find(
+			(entry) => entry.id === model.id,
+		);
+		const hydratedBundleRoot = path.join(
+			root,
+			"local-inference",
+			"models",
+			"eliza-1-2b.bundle",
+		);
+		expect(hydratedMain?.bundleRoot).toBe(hydratedBundleRoot);
+		expect(hydratedMain?.manifestPath).toBe(
+			path.join(hydratedBundleRoot, manifestFile),
+		);
+		expect(fs.existsSync(path.join(hydratedBundleRoot, voicePath))).toBe(true);
+		expect(fs.existsSync(path.join(hydratedBundleRoot, asrPath))).toBe(true);
+		expect(fs.existsSync(path.join(hydratedBundleRoot, vadPath))).toBe(true);
+		expect(fs.existsSync(path.join(hydratedBundleRoot, visionPath))).toBe(true);
 		expect(installed.some((entry) => entry.id.endsWith("-drafter"))).toBe(
 			false,
 		);
@@ -668,8 +678,12 @@ describe("local inference downloader status", () => {
 		const installed = readOwnedRegistryModels();
 		const main = installed.find((m) => m.id === model.id);
 		expect(main?.bundleVerifiedAt).toBeTruthy();
-		expect(verifyCalls[0]?.bundleRoot).toBe(main?.bundleRoot);
-		expect(verifyCalls[0]?.manifestPath).toBe(main?.manifestPath);
+		expect(main?.bundleRoot).toBe("models/eliza-1-2b.bundle");
+		const hydratedMain = (await listInstalledModels()).find(
+			(entry) => entry.id === model.id,
+		);
+		expect(verifyCalls[0]?.bundleRoot).toBe(hydratedMain?.bundleRoot);
+		expect(verifyCalls[0]?.manifestPath).toBe(hydratedMain?.manifestPath);
 	});
 
 	it("fails the download (no install) when the verify-on-device hook rejects", async () => {

--- a/plugins/plugin-local-inference/src/services/paths.ts
+++ b/plugins/plugin-local-inference/src/services/paths.ts
@@ -20,6 +20,71 @@ export function downloadsStagingDir(): string {
 export function isWithinElizaRoot(target: string): boolean {
 	const root = path.resolve(localInferenceRoot());
 	const resolved = path.resolve(target);
-	if (resolved === root) return false;
-	return resolved.startsWith(`${root}${path.sep}`);
+	return isSubpath(resolved, root);
+}
+
+function isSubpath(target: string, root: string): boolean {
+	const relative = path.relative(root, target);
+	return (
+		relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
+	);
+}
+
+function looksAbsolute(input: string): boolean {
+	return (
+		path.isAbsolute(input) ||
+		/^[A-Za-z]:[\\/]/.test(input) ||
+		input.startsWith("\\\\")
+	);
+}
+
+function normalizeRelativeStoredPath(input: string): string | null {
+	const normalized = input.trim().replaceAll("\\", "/");
+	if (!normalized || normalized.includes("\0") || looksAbsolute(normalized)) {
+		return null;
+	}
+	const parts = normalized.split("/").filter(Boolean);
+	if (parts.length === 0) return null;
+	if (parts.some((part) => part === "." || part === "..")) return null;
+	return parts.join("/");
+}
+
+/**
+ * Convert an Eliza-owned artifact path to a stable registry value.
+ *
+ * Mobile app containers can be re-created with a new absolute root on every
+ * install, so owned model artifacts must be persisted relative to the current
+ * `local-inference/` root and re-anchored on read.
+ */
+export function toLocalInferenceStoredPath(target: string): string | null {
+	const root = path.resolve(localInferenceRoot());
+	const resolved = path.resolve(target);
+	if (!isSubpath(resolved, root)) return null;
+	return path.relative(root, resolved).split(path.sep).join("/");
+}
+
+/**
+ * Hydrate a persisted model artifact path against the current local-inference
+ * root. Accepts the new relative format and legacy absolute rows whose
+ * container prefix changed but still contain a `/local-inference/...` suffix.
+ */
+export function resolveLocalInferenceStoredPath(stored: string): string | null {
+	const trimmed = stored.trim();
+	if (!trimmed || trimmed.includes("\0")) return null;
+	const root = path.resolve(localInferenceRoot());
+	const relative = normalizeRelativeStoredPath(trimmed);
+	if (relative) return path.join(root, ...relative.split("/"));
+
+	const resolved = path.resolve(trimmed);
+	if (isSubpath(resolved, root)) return resolved;
+
+	const marker = "/local-inference/";
+	const normalizedAbsolute = trimmed.replaceAll("\\", "/");
+	const markerIndex = normalizedAbsolute.indexOf(marker);
+	if (markerIndex < 0) return null;
+
+	const legacyRelative = normalizeRelativeStoredPath(
+		normalizedAbsolute.slice(markerIndex + marker.length),
+	);
+	return legacyRelative ? path.join(root, ...legacyRelative.split("/")) : null;
 }

--- a/plugins/plugin-local-inference/src/services/registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/registry.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { registryPath } from "./paths";
 import {
 	listInstalledModels,
 	removeElizaModel,
@@ -45,7 +46,102 @@ function installedModel(
 	};
 }
 
+function readRawRegistry(): { models?: InstalledModel[] } {
+	return JSON.parse(fs.readFileSync(registryPath(), "utf8")) as {
+		models?: InstalledModel[];
+	};
+}
+
 describe("local inference registry removal", () => {
+	it("persists Eliza-owned artifact paths relative to the local-inference root", async () => {
+		const stateDir = useTempStateDir();
+		const bundleRoot = path.join(
+			stateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+		);
+		const modelPath = path.join(bundleRoot, "text", "model.gguf");
+		const manifestPath = path.join(bundleRoot, "eliza-1.manifest.json");
+		fs.mkdirSync(path.dirname(modelPath), { recursive: true });
+		fs.writeFileSync(modelPath, "fake-model");
+		fs.writeFileSync(manifestPath, "{}");
+
+		await upsertElizaModel(
+			installedModel("eliza-1-2b", modelPath, { bundleRoot, manifestPath }),
+		);
+
+		const rawModel = readRawRegistry().models?.[0];
+		expect(rawModel?.path).toBe("models/eliza-1-2b/text/model.gguf");
+		expect(rawModel?.bundleRoot).toBe("models/eliza-1-2b");
+		expect(rawModel?.manifestPath).toBe(
+			"models/eliza-1-2b/eliza-1.manifest.json",
+		);
+
+		const listed = await listInstalledModels();
+		expect(listed[0]?.path).toBe(modelPath);
+		expect(listed[0]?.bundleRoot).toBe(bundleRoot);
+		expect(listed[0]?.manifestPath).toBe(manifestPath);
+	});
+
+	it("reanchors legacy absolute registry paths when the state root changes", async () => {
+		const currentStateDir = useTempStateDir();
+		const previousStateDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-local-inference-old-state-"),
+		);
+		tempDirs.push(previousStateDir);
+
+		const currentBundleRoot = path.join(
+			currentStateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+		);
+		const currentModelPath = path.join(currentBundleRoot, "text", "model.gguf");
+		const currentManifestPath = path.join(
+			currentBundleRoot,
+			"eliza-1.manifest.json",
+		);
+		fs.mkdirSync(path.dirname(currentModelPath), { recursive: true });
+		fs.writeFileSync(currentModelPath, "fake-model");
+		fs.writeFileSync(currentManifestPath, "{}");
+
+		const legacyBundleRoot = path.join(
+			previousStateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+		);
+		const legacyModelPath = path.join(legacyBundleRoot, "text", "model.gguf");
+		const legacyManifestPath = path.join(
+			legacyBundleRoot,
+			"eliza-1.manifest.json",
+		);
+		fs.mkdirSync(path.dirname(registryPath()), { recursive: true });
+		fs.writeFileSync(
+			registryPath(),
+			JSON.stringify(
+				{
+					version: 1,
+					models: [
+						installedModel("eliza-1-2b", legacyModelPath, {
+							bundleRoot: legacyBundleRoot,
+							manifestPath: legacyManifestPath,
+						}),
+					],
+				},
+				null,
+				2,
+			),
+		);
+
+		const listed = await listInstalledModels();
+		expect(listed[0]?.path).toBe(currentModelPath);
+		expect(listed[0]?.bundleRoot).toBe(currentBundleRoot);
+		expect(listed[0]?.manifestPath).toBe(currentManifestPath);
+		expect(fs.existsSync(listed[0]?.path ?? "")).toBe(true);
+	});
+
 	it("removes an Eliza-owned bundle directory and clears the registry entry", async () => {
 		const stateDir = useTempStateDir();
 		const bundleRoot = path.join(

--- a/plugins/plugin-local-inference/src/services/registry.ts
+++ b/plugins/plugin-local-inference/src/services/registry.ts
@@ -11,13 +11,28 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { scanExternalModels } from "./external-scanner";
-import { isWithinElizaRoot, localInferenceRoot, registryPath } from "./paths";
+import {
+	isWithinElizaRoot,
+	localInferenceRoot,
+	registryPath,
+	resolveLocalInferenceStoredPath,
+	toLocalInferenceStoredPath,
+} from "./paths";
 import { type InstalledModel, withRuntimeClass } from "./types";
 
 interface RegistryFile {
 	version: 1;
-	models: InstalledModel[];
+	models: StoredInstalledModel[];
 }
+
+type StoredInstalledModel = Omit<
+	InstalledModel,
+	"path" | "bundleRoot" | "manifestPath"
+> & {
+	path: string;
+	bundleRoot?: string;
+	manifestPath?: string;
+};
 
 const EXTERNAL_SCAN_CACHE_TTL_MS = 5_000;
 
@@ -38,10 +53,9 @@ async function readElizaOwned(): Promise<InstalledModel[]> {
 		if (parsed?.version !== 1 || !Array.isArray(parsed.models)) {
 			return [];
 		}
-		return parsed.models.filter(
-			(m): m is InstalledModel =>
-				m && typeof m === "object" && m.source === "eliza-download",
-		);
+		return parsed.models
+			.map(hydrateStoredElizaModel)
+			.filter((model): model is InstalledModel => Boolean(model));
 	} catch {
 		return [];
 	}
@@ -50,9 +64,74 @@ async function readElizaOwned(): Promise<InstalledModel[]> {
 async function writeElizaOwned(models: InstalledModel[]): Promise<void> {
 	await ensureRootDir();
 	const tmp = `${registryPath()}.tmp`;
-	const payload: RegistryFile = { version: 1, models };
+	const payload: RegistryFile = {
+		version: 1,
+		models: models.map(serializeElizaOwnedModel),
+	};
 	await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
 	await fs.rename(tmp, registryPath());
+}
+
+function hydrateStoredElizaModel(
+	model: StoredInstalledModel,
+): InstalledModel | null {
+	if (
+		!model ||
+		typeof model !== "object" ||
+		model.source !== "eliza-download"
+	) {
+		return null;
+	}
+	if (typeof model.path !== "string") return null;
+	const modelPath = resolveLocalInferenceStoredPath(model.path);
+	if (!modelPath) return null;
+
+	const bundleRoot =
+		typeof model.bundleRoot === "string"
+			? resolveLocalInferenceStoredPath(model.bundleRoot)
+			: null;
+	const manifestPath =
+		typeof model.manifestPath === "string"
+			? resolveLocalInferenceStoredPath(model.manifestPath)
+			: null;
+
+	return {
+		...model,
+		path: modelPath,
+		...(bundleRoot ? { bundleRoot } : {}),
+		...(manifestPath ? { manifestPath } : {}),
+	};
+}
+
+function serializeElizaOwnedModel(model: InstalledModel): StoredInstalledModel {
+	const storedPath = toLocalInferenceStoredPath(model.path);
+	if (!storedPath) {
+		throw new Error(
+			"[local-inference] Eliza-owned model path must live under the local-inference root",
+		);
+	}
+	const storedBundleRoot = model.bundleRoot
+		? toLocalInferenceStoredPath(model.bundleRoot)
+		: null;
+	if (model.bundleRoot && !storedBundleRoot) {
+		throw new Error(
+			"[local-inference] Eliza-owned bundle root must live under the local-inference root",
+		);
+	}
+	const storedManifestPath = model.manifestPath
+		? toLocalInferenceStoredPath(model.manifestPath)
+		: null;
+	if (model.manifestPath && !storedManifestPath) {
+		throw new Error(
+			"[local-inference] Eliza-owned manifest path must live under the local-inference root",
+		);
+	}
+	return {
+		...model,
+		path: storedPath,
+		...(storedBundleRoot ? { bundleRoot: storedBundleRoot } : {}),
+		...(storedManifestPath ? { manifestPath: storedManifestPath } : {}),
+	};
 }
 
 function externalScanEnabled(): boolean {


### PR DESCRIPTION
Closes #11371

## Summary
- persist Eliza-owned local-inference model artifact paths relative to `local-inference/` instead of writing container-specific absolute paths
- hydrate relative rows to absolute paths for runtime load/verify callers
- re-anchor legacy absolute rows from an old mobile container by their `/local-inference/...` suffix under the current state root
- update the iOS bridge registry reader/writer for relative rows and legacy absolute rows

## Evidence
- `bun run --cwd plugins/plugin-local-inference test` passed, 223 files / 2240 tests; 1 file / 13 tests skipped
- `bun run --cwd plugins/plugin-local-inference typecheck` passed
- `bun run --cwd plugins/plugin-capacitor-bridge typecheck` passed
- `bun run --cwd plugins/plugin-local-inference build` passed
- `bun run --cwd plugins/plugin-capacitor-bridge build` passed
- `bunx @biomejs/biome check ...` passed on touched files
- `bun run verify` blocked by current repo type-safety ratchet: `as unknown as` 80 / 77 and core/agent/app-core `?? {}` 379 / 377

Evidence file: `.github/issue-evidence/11371-model-path-reanchor.md`

No UI, LLM, audio, or Swift/Kotlin native-code behavior changed. Full iOS reinstall capture was not run in this branch; the root-change regression directly exercises the stale-container absolute-path failure mode.