### PR TITLE
fix(ci): restore orchestration tail gates

### DIFF
--- a/.github/issue-evidence/11413-ci-orchestration-tail.md
+++ b/.github/issue-evidence/11413-ci-orchestration-tail.md
@@ -1,0 +1,60 @@
+# Issue 11413 CI orchestration tail
+
+Date: 2026-07-02
+Branch: `fix/11413-ci-orchestration-tail`
+
+## Scope
+
+Restored and reconciled the deferred CI orchestration tail from the #11271 stale-base squash:
+
+- `.github/workflows/test.yml`: restored the personal-assistant integration lane and added it back to the aggregate `test-status` gate.
+- `.github/workflows/scenario-pr.yml`: restored the explicit real/live guarded-suite manifest gate and UI fixture-runner coverage ratchet.
+- `.github/workflows/kokoro-real-smoke.yml`: restored the post-#9588 F16 Kokoro smoke workflow comments, model path, and Linux espeak dependencies.
+- `packages/scripts/run-all-tests.mjs`: restored post-merge real/live manifest drift checking and named accounting output.
+- `packages/scripts/lib/real-live-suites.mjs`: restored the guarded real/live suite manifest and reconciled current `develop` drift by adding Birdclaw as a config-blocked real suite.
+- `packages/scripts/__tests__/real-live-suites.test.ts`: restored the manifest honesty tests and updated the lane-conditional config detector for current SQL config spelling.
+- `packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts`: restored the UI e2e runner workflow ratchet.
+- `.github/workflows/ui-e2e-gate.yml`: wired the nine currently orphaned `packages/ui` fixture runners into CI and added generated shared i18n setup required by the connectors runner.
+
+No `lifeops-quality-bench.yml` restore was attempted: `packages/benchmarks/lifeops-quality` is absent on current `develop`, and the issue tail called out the CI orchestration files above for reconciliation instead of blind restoration.
+
+## Verification
+
+Dependency setup:
+
+- `bun install --ignore-scripts --no-frozen-lockfile`: passed. This rewrote `bun.lock`; the lockfile side effect was reverted because it is unrelated to this fix.
+- `bunx playwright install chromium`: passed.
+- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`: passed and generated ignored local i18n artifacts for e2e validation.
+
+Restored script gates:
+
+- `bun test packages/scripts/__tests__/real-live-suites.test.ts`: passed, 7 tests.
+- `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts`: passed, 1 test.
+- `node --check packages/scripts/run-all-tests.mjs`: passed.
+- `TEST_LANE=post-merge node packages/scripts/run-all-tests.mjs --plan=text --no-cloud`: passed. It printed the restored named accounting: 4 armed, 19 missing-creds, 7 opt-in gated, 10 host-probed, 8 config-blocked real/live suites, then printed the post-merge plan.
+- `bunx @biomejs/biome check packages/scripts/run-all-tests.mjs packages/scripts/lib/real-live-suites.mjs packages/scripts/__tests__/real-live-suites.test.ts packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts`: exited 0. Biome still reports 13 existing `noUndeclaredEnvVars` warnings in `run-all-tests.mjs`.
+- `git diff --check`: passed.
+
+Newly wired UI fixture runners:
+
+- `bun run --cwd packages/ui test:agent-surface-e2e`: passed.
+- `bun run --cwd packages/ui test:ftu-home-e2e`: passed.
+- `bun run --cwd packages/ui test:orchestrator-accounts-e2e`: passed.
+- `bun run --cwd packages/ui test:background-e2e`: passed.
+- `bun run --cwd packages/ui test:connectors-e2e`: initially failed before generated shared i18n setup; after adding the workflow setup step, passed.
+- `bun run --cwd packages/ui test:bottombar-e2e`: passed.
+- `bun run --cwd packages/ui test:chat-ambient-e2e`: passed.
+- `bun run --cwd packages/ui test:fused-wake-integration-e2e`: skipped with `libwakeword not built`, matching the runner's host-capability skip behavior.
+- `bun run --cwd packages/ui test:view-lifecycle-e2e`: passed.
+
+Root verification:
+
+- `bun run verify`: failed before typecheck/lint at the pre-existing type-safety ratchet drift on current `develop`:
+  - `as unknown as: 80 current > 77 baseline`
+  - ``?? {}`` core/agent/app-core: `379 current > 377 baseline`
+
+## N/A evidence
+
+- Live model trajectories: N/A - no agent prompt, action, provider, or model behavior changed.
+- Backend/frontend runtime logs from a deployed app: N/A - this change restores CI workflow/script orchestration and runs isolated local CI/e2e scripts.
+- Before/after app screenshots and app audit: N/A - no app UI source behavior changed; the validation used the isolated `packages/ui` fixture e2e runners that this PR wires into CI.

--- a/.github/workflows/kokoro-real-smoke.yml
+++ b/.github/workflows/kokoro-real-smoke.yml
@@ -17,17 +17,21 @@ name: Kokoro real-weight smoke (Linux)
 # it. To run locally, see the staging steps in
 # `plugins/plugin-local-inference/README.md`.
 #
-# IMPORTANT — expected RED until the GGUF is republished. The published bundle
-# GGUF (elizaos/eliza-1 .../kokoro-82m-v1_0-Q4_K_M.gguf) is STILL the pre-#9588
-# all-F32 artifact that loads but synthesizes noise; the converter/loader fix
-# landed on develop (#9684) but the artifact regen + republish is a pending ops
-# step (#9588). So this gate fails the envelope-cv guard against the CURRENT
-# published assets. It is therefore wired to manual/tag dispatch ONLY — NOT the
-# path-based push auto-trigger the loader/converter changes would otherwise fire
-# — so it does not paint develop RED for a known pending-ops condition. Once the
-# fixed F16 GGUF is republished and a `kokoro-smoke-*` tag run goes green,
-# re-enable the path-scoped `push` auto-trigger (loader / converter / smoke /
-# this workflow / the llama.cpp submodule pointer) to gate future drift:
+# STATUS (2026-07-02) — the #9588 republish LANDED. elizaos/eliza-1
+# `bundles/2b/tts/kokoro/kokoro-82m-v1_0.gguf` (162,546,720 B F16, sha256
+# 165acd9d2d9b6c2d71fa5bd52b92a2559be08567f58ed496bade076e3d9cb46c) carries the
+# 457 post-#9684 tensor names (incl. the previously-missing
+# `kokoro.bert.embd_proj.bias`) and is byte-identical to a from-scratch
+# `convert_kokoro_pth_to_gguf.py` run on hexgrad/Kokoro-82M at fork pin
+# ba598f562. The old `-Q4_K_M` filename 404s and is no longer referenced here.
+# The lane stays manual/tag dispatch ONLY for now: on a desktop-CPU runner the
+# smoke loads + synthesizes real speech (envelope-cv ≈1.25, WER 0.13 with an
+# ASR bundle + the #10726 raw-text G2P fix) but still exceeds the 700 ms mobile
+# TTFA budget by orders of magnitude, so an auto-triggered run would paint
+# develop RED on perf, not drift. Once the double-G2P fix (#11238 / #10726) is
+# merged and the TTFA budget is made per-platform (or first-chunk streaming
+# lands), re-enable the path-scoped `push` auto-trigger (loader / converter /
+# smoke / this workflow / the llama.cpp submodule pointer) to gate future drift:
 #   push:
 #     branches: ["**"]
 #     paths:
@@ -54,9 +58,12 @@ permissions:
 env:
   NODE_VERSION: "24"
   BUN_VERSION: "canary"
-  # Published Kokoro bundle (the #9588 repro file — verified present on the repo).
+  # Published Kokoro bundle — the #9588-fixed F16 republish (2026-07-02).
+  # The former `kokoro-82m-v1_0-Q4_K_M.gguf` filename 404s on the repo; the
+  # canonical F16 name below is what discovery falls through to and what the
+  # download catalog (packages/shared/src/local-inference/catalog.ts) stages.
   KOKORO_HF_REPO: "elizaos/eliza-1"
-  KOKORO_GGUF_PATH: "bundles/2b/tts/kokoro/kokoro-82m-v1_0-Q4_K_M.gguf"
+  KOKORO_GGUF_PATH: "bundles/2b/tts/kokoro/kokoro-82m-v1_0.gguf"
   # Catalog FALLBACK voice (af_bella). af_same (Samantha) is not published yet —
   # discovery falls back to af_bella, which is the voice actually staged on HF.
   KOKORO_VOICE_PATH: "bundles/2b/tts/kokoro/voices/af_bella.bin"
@@ -90,7 +97,8 @@ jobs:
           for attempt in 1 2 3; do
             if sudo apt-get "${APT_ARGS[@]}" update && \
                sudo apt-get "${APT_ARGS[@]}" install -y --fix-missing \
-                 cmake ninja-build build-essential ccache git python3 curl libgomp1; then
+                 cmake ninja-build build-essential ccache git python3 curl libgomp1 \
+                 libespeak-ng-dev espeak-ng-data; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then echo "apt install failed"; exit 1; fi

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -857,6 +857,20 @@ jobs:
       - name: Script inventory (packages/app) smoke test
         run: bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
 
+      # #9310 §E: guarded *.real/*.live suite accounting. Keeps the post-merge
+      # lane's named-skip summary honest: manifest ↔ on-disk drift, phantom
+      # guard credentials, and vitest configs that would silently re-exclude a
+      # guarded suite from every lane. packages/scripts/__tests__ is outside
+      # workspace test discovery, so keep this explicit.
+      - name: Real/live guarded-suite manifest gate
+        run: bun test packages/scripts/__tests__/real-live-suites.test.ts
+
+      # #9310 §3.16: every packages/ui __e2e__ run-*.mjs fixture runner must
+      # have a package script AND a workflow leg (ui-fixture-e2e.yml et al) —
+      # a runner nothing invokes is coverage that does not exist.
+      - name: UI fixture-runner CI-coverage ratchet
+        run: bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
+
       # E2E coverage gate (issue #8802). Now REQUIRED: the baseline is green —
       # commands 38/38, #8791 shortcuts 1/1 (wired into SHORTCUT_COVERAGE),
       # plugin routes covered/exempt, view ship-gates intact, zero blocking gaps.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -478,6 +478,56 @@ jobs:
           echo "::error title=Plugin Tests::Plugin shard matrix finished with '${result}'"
           exit 1
 
+  # First CI consumer of the repo-level integration lane
+  # (packages/test/vitest/integration.config.ts). The lane was dead in CI:
+  # nothing invoked the config, its @elizaos/core alias broke the /node
+  # subpath, and its eliza/-prefixed paths matched zero files in a flat
+  # checkout (#11047). Runs plugin-personal-assistant's test:integration —
+  # the src-integration lane (scheduler/recurrence/global-pause real-DB
+  # suites) plus the repo config over the package's named test/ files —
+  # keyless. Burn down the remaining plugins/*/test integration suites from
+  # here.
+  integration-tests:
+    name: Integration Lane (personal-assistant)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true' || needs.changes.outputs.server == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_CACHE: remote:rw
+      PGLITE_WASM_MODE: node
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # The personal-assistant barrel imports sibling plugin dists (e.g.
+      # plugin-calendly pulls "@elizaos/core/node") straight from
+      # node_modules, so the lane needs the package's workspace dependency
+      # graph built. Turbo replays warm runs from cache.
+      - name: Build personal-assistant dependency graph
+        run: node packages/scripts/run-turbo.mjs run build --filter='@elizaos/plugin-personal-assistant...'
+
+      - name: Run personal-assistant integration lanes
+        timeout-minutes: 35
+        run: bun run --cwd plugins/plugin-personal-assistant test:integration
+
   desktop-contract:
     name: Electrobun Desktop Contract
     needs: changes
@@ -1187,6 +1237,7 @@ jobs:
       - client-tests
       - xr-harness-e2e
       - plugin-tests-status
+      - integration-tests
       - desktop-contract
       - zero-key-e2e
       - cloud-live-e2e
@@ -1204,6 +1255,7 @@ jobs:
           echo "client-tests:     ${{ needs.client-tests.result }}"
           echo "xr-harness-e2e:   ${{ needs.xr-harness-e2e.result }}"
           echo "plugin-tests:     ${{ needs.plugin-tests-status.result }}"
+          echo "integration-tests:${{ needs.integration-tests.result }}"
           echo "desktop-contract: ${{ needs.desktop-contract.result }}"
           echo "zero-key-e2e:     ${{ needs.zero-key-e2e.result }}"
           echo "cloud-live-e2e:   ${{ needs.cloud-live-e2e.result }}"
@@ -1218,6 +1270,7 @@ jobs:
             "client-tests:${{ needs.client-tests.result }}" \
             "xr-harness-e2e:${{ needs.xr-harness-e2e.result }}" \
             "plugin-tests:${{ needs.plugin-tests-status.result }}" \
+            "integration-tests:${{ needs.integration-tests.result }}" \
             "desktop-contract:${{ needs.desktop-contract.result }}" \
             "zero-key-e2e:${{ needs.zero-key-e2e.result }}" \
             "cloud-live-e2e:${{ needs.cloud-live-e2e.result }}" \

--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -1,4 +1,4 @@
-name: UI Chat Gesture E2E
+name: UI Fixture E2E
 
 # #9954/#10722: the chat-sheet drag-detent, TopicGroup gesture, and home-screen
 # e2e runners (src/components/shell/__e2e__/run-*.mjs) esbuild-bundle a fixture
@@ -18,20 +18,28 @@ on:
     paths:
       - "packages/ui/src/components/shell/**"
       - "packages/ui/src/components/pages/**"
+      - "packages/ui/src/components/chat/widgets/**"
+      - "packages/ui/src/components/views/**"
+      - "packages/ui/src/agent-surface/**"
       - "packages/ui/src/state/**"
       - "packages/ui/src/voice/**"
       - "packages/ui/src/testing/**"
       - "packages/ui/src/hooks/**"
+      - "packages/ui/package.json"
       - ".github/workflows/ui-e2e-gate.yml"
   push:
     branches: [main, develop]
     paths:
       - "packages/ui/src/components/shell/**"
       - "packages/ui/src/components/pages/**"
+      - "packages/ui/src/components/chat/widgets/**"
+      - "packages/ui/src/components/views/**"
+      - "packages/ui/src/agent-surface/**"
       - "packages/ui/src/state/**"
       - "packages/ui/src/voice/**"
       - "packages/ui/src/testing/**"
       - "packages/ui/src/hooks/**"
+      - "packages/ui/package.json"
 
 concurrency:
   group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -45,9 +53,9 @@ env:
   NODE_VERSION: "24.15.0"
 
 jobs:
-  chat-gesture-e2e:
+  ui-fixture-e2e:
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -67,12 +75,44 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
+
+      # AgentSurface capability bridge: list/focus/fill/click over synthetic and
+      # real plugin-hosted controls.
+      - name: Agent surface e2e
+        run: bun run --cwd packages/ui test:agent-surface-e2e
+
+      # First-time-use onboarding widget states and retired-state persistence.
+      - name: FTU home widget e2e
+        run: bun run --cwd packages/ui test:ftu-home-e2e
+
+      # Coding account + task-room roster widget visual states.
+      - name: Orchestrator accounts widget e2e
+        run: bun run --cwd packages/ui test:orchestrator-accounts-e2e
+
+      # Background view apply/undo/reset/export flow.
+      - name: Background view e2e
+        run: bun run --cwd packages/ui test:background-e2e
+
+      # Connector setup-panel config fields and screenshots.
+      - name: Connectors view e2e
+        run: bun run --cwd packages/ui test:connectors-e2e
 
       # Chat-sheet drag detents (open/peek/close pull-sheet state machine).
       - name: Chat sheet drag-gesture e2e
         run: bun run --cwd packages/ui test:chat-sheet-e2e
+
+      # Mobile bottom-bar affordances and overlays.
+      - name: Bottom bar e2e
+        run: bun run --cwd packages/ui test:bottombar-e2e
+
+      # Ambient /chat background screenshot pass.
+      - name: Chat ambient e2e
+        run: bun run --cwd packages/ui test:chat-ambient-e2e
 
       # TopicGroup collapse/expand (#8928) under REAL input (#10722): CDP touch
       # taps + the touch-action pan-y contract, and mouse flicks for the
@@ -86,6 +126,10 @@ jobs:
       - name: Home-screen real-touch e2e
         run: bun run --cwd packages/ui test:home-screen-e2e
 
+      # Fused wake phrase + shell integration fixture.
+      - name: Fused wake integration e2e
+        run: bun run --cwd packages/ui test:fused-wake-integration-e2e
+
       # Launcher grid (#10722): genuine CDP long-press pointer drag-to-reorder
       # (section 2b) → onReorder → persisted LAUNCHER_STORAGE_KEY order +
       # reorder telemetry + no duplicate ids. The jsdom Launcher.gestures suite
@@ -93,15 +137,27 @@ jobs:
       - name: Launcher real-drag reorder e2e
         run: bun run --cwd packages/ui test:launcher-e2e
 
-      - name: Upload chat gesture e2e artifacts
+      # App-shell view lifecycle transitions, errors, teardown, and telemetry.
+      - name: View lifecycle e2e
+        run: bun run --cwd packages/ui test:view-lifecycle-e2e
+
+      - name: Upload UI fixture e2e artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: chat-gesture-e2e-output
+          name: ui-fixture-e2e-output
           path: |
+            packages/ui/src/agent-surface/__e2e__/output
+            packages/ui/src/components/chat/widgets/__e2e__/output
+            packages/ui/src/components/chat/widgets/__e2e__/output-ftu
+            packages/ui/src/components/pages/__e2e__/output-background
+            packages/ui/src/components/pages/__e2e__/output-connectors
+            packages/ui/src/components/views/__e2e__/output-view-lifecycle
             packages/ui/src/components/shell/__e2e__/output
             packages/ui/src/components/shell/__e2e__/output-chatux
             packages/ui/src/components/shell/__e2e__/output-home
+            packages/ui/src/components/shell/__e2e__/output-bottombar
+            packages/ui/src/components/shell/__e2e__/output-fused-wake-integration
             packages/ui/src/components/pages/__e2e__/output-launcher
           retention-days: 14
           if-no-files-found: ignore

--- a/packages/scripts/__tests__/real-live-suites.test.ts
+++ b/packages/scripts/__tests__/real-live-suites.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Gate for the guarded `*.real.test.ts` / `*.live.test.ts` accounting
+ * (#9310 §E). The post-merge lane (run-all-tests.mjs, TEST_LANE=post-merge)
+ * prints a loud, named skip summary for every guarded suite instead of a
+ * silent green nothing; this test keeps that accounting honest:
+ *
+ *   1. the manifest matches the on-disk guarded set exactly (no drift);
+ *   2. every declared guard env var is really read by the suite (or a
+ *      declared guardVia helper) — no phantom credentials;
+ *   3. package vitest configs agree with the manifest: a non-blocked suite
+ *      is never unconditionally excluded (it must run — and self-skip loudly
+ *      — in the post-merge lane), and a `blocked` claim matches a real
+ *      unconditional exclude;
+ *   4. the accounting classification + summary formatting behave (precedence,
+ *      anyOf groups, the missing-creds line printed even at zero).
+ *
+ * packages/scripts/__tests__ is outside workspace test discovery — this file
+ * runs via an explicit `bun test` leg in .github/workflows/scenario-pr.yml.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  computeRealLiveAccounting,
+  diffRealLiveManifest,
+  discoverGuardedRealLiveFiles,
+  formatRealLiveSummaryLines,
+  GUARDED_REAL_LIVE_SUITES,
+} from "../lib/real-live-suites.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+
+interface ManifestEntry {
+  file: string;
+  requires?: string[];
+  anyOf?: string[][];
+  optIn?: string;
+  guardVia?: string[];
+  probe?: string;
+  blocked?: string;
+  notes?: string;
+}
+
+const manifest = GUARDED_REAL_LIVE_SUITES as ManifestEntry[];
+
+function suiteKind(file: string): "real" | "live" {
+  return /\.real\.test\.tsx?$/.test(file) ? "real" : "live";
+}
+
+/** Nearest ancestor dir of `file` (repo-relative) containing a package.json. */
+function owningPackageDir(file: string): string {
+  let dir = path.dirname(path.join(repoRoot, file));
+  while (dir.length > repoRoot.length) {
+    if (fs.existsSync(path.join(dir, "package.json"))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return repoRoot;
+}
+
+describe("real/live guarded-suite manifest (#9310 §E)", () => {
+  test("manifest matches the on-disk guarded set (no drift)", () => {
+    const drift = diffRealLiveManifest(discoverGuardedRealLiveFiles(repoRoot));
+    expect(
+      drift.unlisted,
+      "guarded on disk but missing from GUARDED_REAL_LIVE_SUITES — add an entry (with its cred/opt-in/probe guard) to packages/scripts/lib/real-live-suites.mjs",
+    ).toEqual([]);
+    expect(
+      drift.stale,
+      "listed in GUARDED_REAL_LIVE_SUITES but no longer guarded on disk — remove the stale entry",
+    ).toEqual([]);
+  });
+
+  test("every declared guard env var is read by the suite or its guardVia helpers", () => {
+    const problems: string[] = [];
+    for (const entry of manifest) {
+      const sources = [entry.file, ...(entry.guardVia ?? [])]
+        .map((rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8"))
+        .join("\n");
+      const declared = [
+        ...(entry.requires ?? []),
+        ...(entry.anyOf ?? []).flat(),
+        ...(entry.optIn ? [entry.optIn] : []),
+      ];
+      for (const name of declared) {
+        if (!sources.includes(name)) {
+          problems.push(
+            `${entry.file}: manifest declares ${name} but neither the suite nor its guardVia helpers mention it`,
+          );
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test("package vitest configs agree with the manifest blocked/invocable split", () => {
+    const problems: string[] = [];
+    for (const entry of manifest) {
+      const pkgDir = owningPackageDir(entry.file);
+      const configPath = path.join(pkgDir, "vitest.config.ts");
+      if (!fs.existsSync(configPath)) {
+        if (entry.blocked) {
+          problems.push(
+            `${entry.file}: marked blocked but ${path.relative(repoRoot, pkgDir)} has no vitest.config.ts to exclude it`,
+          );
+        }
+        continue; // vitest defaults include *.test.ts — invocable.
+      }
+      const config = fs.readFileSync(configPath, "utf8");
+      // The exclude-glob spelling for this suite kind, e.g. "*.real.test."
+      // matches "**/*.real.test.{ts,tsx}" / "**/*.real.test.*" /
+      // "src/**/*.real.test.ts" but NOT "*.real.e2e.test.*".
+      const kindGlob = `*.${suiteKind(entry.file)}.test.`;
+      const excludesKind = config.includes(kindGlob);
+      const laneConditional =
+        config.includes('VITEST_LANE === "post-merge"') ||
+        config.includes('VITEST_LANE !== "post-merge"') ||
+        config.includes("VITEST_EXCLUDE_REAL");
+      if (entry.blocked) {
+        if (!excludesKind) {
+          problems.push(
+            `${entry.file}: marked blocked but ${path.relative(repoRoot, configPath)} has no "${kindGlob}" exclude — update the manifest (the suite may be invocable now)`,
+          );
+        }
+      } else if (excludesKind && !laneConditional) {
+        problems.push(
+          `${entry.file}: ${path.relative(repoRoot, configPath)} unconditionally excludes "${kindGlob}" — either make the exclude lane-conditional (VITEST_LANE === "post-merge") so the suite runs in the post-merge sweep, or mark the manifest entry blocked with a reason`,
+        );
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+});
+
+describe("real/live accounting classification", () => {
+  const synthetic: ManifestEntry[] = [
+    { file: "a.real.test.ts", requires: ["KEY_A"] },
+    { file: "b.live.test.ts", optIn: "GATE_B", requires: ["KEY_B"] },
+    { file: "c.live.test.ts", anyOf: [["K1"], ["K2", "K3"]] },
+    { file: "d.real.test.ts", probe: "attached display" },
+    {
+      file: "e.real.test.ts",
+      blocked: "excluded in every lane",
+      requires: ["KEY_E"],
+    },
+    { file: "f.real.test.ts" },
+  ];
+
+  test("keyless env: named missing-creds skips, opt-in and blocked take precedence", () => {
+    const accounting = computeRealLiveAccounting({}, synthetic);
+    expect(accounting.missingCreds).toEqual([
+      { file: "a.real.test.ts", missing: ["KEY_A"] },
+      { file: "c.live.test.ts", missing: ["one of K1 | K2+K3"] },
+    ]);
+    expect(accounting.optIn).toEqual([
+      { file: "b.live.test.ts", gate: "GATE_B" },
+    ]);
+    expect(accounting.probed).toEqual([
+      { file: "d.real.test.ts", probe: "attached display" },
+    ]);
+    expect(accounting.blocked).toEqual([
+      { file: "e.real.test.ts", reason: "excluded in every lane" },
+    ]);
+    expect(accounting.armed.map((item) => item.file)).toEqual([
+      "f.real.test.ts",
+    ]);
+  });
+
+  test("creds satisfied: requires, anyOf group, and opt-in gate arm their suites", () => {
+    const accounting = computeRealLiveAccounting(
+      { KEY_A: "x", GATE_B: "1", KEY_B: "y", K2: "a", K3: "b" },
+      synthetic,
+    );
+    expect(accounting.armed.map((item) => item.file)).toEqual([
+      "a.real.test.ts",
+      "b.live.test.ts",
+      "c.live.test.ts",
+      "f.real.test.ts",
+    ]);
+    expect(accounting.missingCreds).toEqual([]);
+    // blocked always wins, even with the cred present.
+    const blocked = computeRealLiveAccounting({ KEY_E: "x" }, synthetic);
+    expect(blocked.blocked.map((item) => item.file)).toEqual([
+      "e.real.test.ts",
+    ]);
+  });
+
+  test("whitespace-only creds and non-'1' opt-in values do not arm a suite", () => {
+    const accounting = computeRealLiveAccounting(
+      { KEY_A: "  ", GATE_B: "true" },
+      synthetic,
+    );
+    expect(accounting.missingCreds.map((item) => item.file)).toContain(
+      "a.real.test.ts",
+    );
+    expect(accounting.optIn.map((item) => item.file)).toContain(
+      "b.live.test.ts",
+    );
+  });
+
+  test("summary always includes the missing-creds line, even at zero", () => {
+    const clean = formatRealLiveSummaryLines(
+      computeRealLiveAccounting({ KEY_A: "x" }, [
+        { file: "a.real.test.ts", requires: ["KEY_A"] },
+      ]),
+    );
+    expect(
+      clean.some((line) =>
+        line.includes("0 real suites skipped for missing creds: none"),
+      ),
+    ).toBe(true);
+
+    const missing = formatRealLiveSummaryLines(
+      computeRealLiveAccounting({}, [
+        { file: "a.real.test.ts", requires: ["KEY_A"] },
+      ]),
+    );
+    const missingLine = missing.find((line) =>
+      line.includes("1 real suites skipped for missing creds"),
+    );
+    expect(missingLine).toContain("a.real.test.ts (missing KEY_A)");
+  });
+});

--- a/packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
+++ b/packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts
@@ -1,0 +1,96 @@
+/**
+ * CI-coverage ratchet for the packages/ui fixture e2e runners (#9310 §3.16).
+ *
+ * Every `run-*.mjs` runner under a packages/ui/src `__e2e__` dir drives REAL
+ * shipped components in headless Chromium — coverage that exists only if something
+ * actually invokes it. Historically most runners were CI-orphaned: they had a
+ * package.json script but no workflow leg, so regressions they guard could
+ * only be caught by hand. This test enforces, for every runner on disk:
+ *
+ *   1. a packages/ui package.json script references it, and
+ *   2. at least one .github/workflows/*.yml invokes that script (or the
+ *      runner path directly).
+ *
+ * Adding a new runner therefore requires wiring it into a workflow leg (see
+ * ui-fixture-e2e.yml / ui-e2e-gate.yml / chat-shell-gestures.yml) in the same
+ * change — or consciously deleting it.
+ *
+ * packages/scripts/__tests__ is outside workspace test discovery — this file
+ * runs via an explicit `bun test` leg in .github/workflows/scenario-pr.yml.
+ */
+
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
+const uiRoot = path.join(repoRoot, "packages", "ui", "src");
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+
+function discoverRunners(): string[] {
+  const found: string[] = [];
+  const stack = [uiRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        stack.push(path.join(dir, entry.name));
+        continue;
+      }
+      if (
+        entry.isFile() &&
+        /^run-.*\.mjs$/.test(entry.name) &&
+        path.basename(dir) === "__e2e__"
+      ) {
+        found.push(
+          path
+            .relative(repoRoot, path.join(dir, entry.name))
+            .split(path.sep)
+            .join("/"),
+        );
+      }
+    }
+  }
+  return found.sort();
+}
+
+test("every packages/ui __e2e__ runner has a package script and a CI workflow leg", () => {
+  const runners = discoverRunners();
+  expect(runners.length).toBeGreaterThan(0);
+
+  const pkg = JSON.parse(
+    fs.readFileSync(
+      path.join(repoRoot, "packages", "ui", "package.json"),
+      "utf8",
+    ),
+  ) as { scripts?: Record<string, string> };
+  const scripts = pkg.scripts ?? {};
+
+  const workflows = fs
+    .readdirSync(workflowsDir)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .map((name) => fs.readFileSync(path.join(workflowsDir, name), "utf8"))
+    .join("\n");
+
+  const problems: string[] = [];
+  for (const runner of runners) {
+    const basename = path.basename(runner);
+    const scriptName = Object.keys(scripts).find((name) =>
+      scripts[name].includes(basename),
+    );
+    if (!scriptName) {
+      problems.push(
+        `${runner}: no packages/ui package.json script references it — add one (or delete the runner)`,
+      );
+      continue;
+    }
+    const inWorkflow =
+      workflows.includes(scriptName) || workflows.includes(basename);
+    if (!inWorkflow) {
+      problems.push(
+        `${runner}: script "${scriptName}" is not invoked by any .github/workflows/*.yml — wire a leg (ui-fixture-e2e.yml) or delete the runner with justification`,
+      );
+    }
+  }
+  expect(problems).toEqual([]);
+});

--- a/packages/scripts/lib/real-live-suites.mjs
+++ b/packages/scripts/lib/real-live-suites.mjs
@@ -1,0 +1,464 @@
+/**
+ * real-live-suites.mjs
+ *
+ * Manifest + accounting for every credential/opt-in-guarded `*.real.test.ts` /
+ * `*.live.test.ts` suite in the repo (#9310 §6/§E). These suites self-skip via
+ * `describe.skipIf`-style guards when a credential, opt-in gate, or host
+ * capability is missing — which historically produced a silent green nothing
+ * in the post-merge lane.
+ *
+ * run-all-tests.mjs (TEST_LANE=post-merge) consumes this module to print a
+ * loud, named accounting every run:
+ *   - which guarded suites are armed (will run live in the sweep),
+ *   - which are skipped for missing creds (counted + named, never silent),
+ *   - which are opt-in gated / host-probed / config-blocked, and why.
+ *
+ * The manifest is kept honest mechanically: discoverGuardedRealLiveFiles()
+ * re-derives the guarded set from disk, and both the post-merge lane and
+ * packages/scripts/__tests__/real-live-suites.test.ts hard-fail on drift
+ * (a new guarded suite MUST be added here, a deleted one removed).
+ *
+ * Entry fields:
+ *   file      repo-relative path (manifest key).
+ *   requires  env vars that must ALL be non-empty for the suite to run live.
+ *   anyOf     groups of env vars; at least one group must be fully satisfied.
+ *   optIn     env var that must equal "1" — deliberate operator opt-in gates
+ *             that the post-merge lane does NOT auto-set (destructive/heavy).
+ *   guardVia  repo-relative helper file(s) where the guard env vars are read
+ *             when the suite guards through a shared helper instead of
+ *             reading process.env directly (manifest-honesty test follows
+ *             these).
+ *   probe     host-capability description; the suite self-skips (or runs)
+ *             based on a runtime probe, not an env var.
+ *   blocked   the package vitest config excludes the file in EVERY lane; the
+ *             suite cannot run from the workspace sweep at all. Loudly
+ *             reported so it can never be mistaken for coverage.
+ *   notes     where else the suite runs (dedicated workflow / lane).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Same content pattern that defines the guarded set in issue #9310. */
+export const GUARD_CONTENT_PATTERN =
+  /describe\.skip|requireLiveProvider|ELIZA_LIVE_TEST/;
+
+export const REAL_LIVE_FILE_PATTERN = /\.(?:real|live)\.test\.tsx?$/;
+
+const DISCOVERY_SKIP_DIRS = new Set([
+  ".git",
+  ".turbo",
+  ".claude",
+  "coverage",
+  "dist",
+  "node_modules",
+  "target",
+]);
+
+export const GUARDED_REAL_LIVE_SUITES = [
+  {
+    file: "packages/app-core/src/services/coding-account-bridge.live.test.ts",
+    optIn: "ORCHESTRATOR_LIVE_MULTI_ACCOUNT",
+    notes: "runs in .github/workflows/orchestrator-live-multi-account.yml",
+  },
+  {
+    file: "packages/core/src/runtime/__tests__/field-registry-cerebras.live.test.ts",
+    optIn: "ELIZA_RUN_LIVE_TESTS",
+    requires: ["CEREBRAS_API_KEY"],
+  },
+  {
+    file: "packages/core/src/runtime/__tests__/pii-swap-live-cerebras.real.test.ts",
+    requires: ["CEREBRAS_API_KEY"],
+  },
+  {
+    file: "packages/core/src/__tests__/should-respond.live.test.ts",
+    optIn: "ELIZA_RUN_LIVE_TESTS",
+    probe: "local Ollama at OLLAMA_API_ENDPOINT",
+  },
+  {
+    file: "plugins/plugin-agent-orchestrator/__tests__/live/native-acp-smoke.live.test.ts",
+    optIn: "RUN_LIVE_NATIVE_ACP",
+  },
+  {
+    file: "plugins/plugin-agent-orchestrator/__tests__/live/sub-agent-router.live.test.ts",
+    optIn: "RUN_LIVE_ACPX",
+  },
+  {
+    file: "plugins/plugin-anthropic/__tests__/anthropic-drift.real.test.ts",
+    requires: ["ANTHROPIC_API_KEY"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-browser/src/benchmark/__tests__/external-dataset-chromium.real.test.ts",
+    probe: "playwright Chromium install",
+    notes: "runs in browser-real-bench.yml via test:real:chromium",
+  },
+  {
+    file: "plugins/plugin-browser/src/benchmark/__tests__/miniwob-chromium.real.test.ts",
+    probe: "playwright Chromium install",
+    notes: "runs in browser-real-bench.yml via test:real:chromium",
+  },
+  {
+    file: "plugins/plugin-browser/src/benchmark/__tests__/web-grounding-chromium.real.test.ts",
+    probe: "playwright Chromium install",
+    notes: "runs in browser-real-bench.yml via test:real:chromium",
+  },
+  {
+    file: "plugins/plugin-birdclaw/src/birdclaw/birdclaw.real.test.ts",
+    blocked:
+      "plugin-birdclaw vitest.config.ts excludes *.real.test.ts unless BIRDCLAW_REAL_TESTS=1; run via bun run --cwd plugins/plugin-birdclaw test:real",
+    probe: "birdclaw CLI at BIRDCLAW_REAL_BIN or on PATH",
+  },
+  {
+    file: "plugins/plugin-calendar/test/google-calendar-connector.real.test.ts",
+    requires: ["GOOGLE_CALENDAR_ACCESS_TOKEN"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-calendly/src/calendly-client.real.test.ts",
+    anyOf: [["CALENDLY_ACCESS_TOKEN"], ["ELIZA_E2E_CALENDLY_ACCESS_TOKEN"]],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-computeruse/src/__tests__/benchmark/osworld-local.real.test.ts",
+    blocked:
+      "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
+    probe: "desktop screenshot capability, non-CI",
+  },
+  {
+    file: "plugins/plugin-computeruse/src/__tests__/benchmark/osworld-tasks.real.test.ts",
+    blocked:
+      "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
+    optIn: "FORCE_OSWORLD_BENCHMARK",
+  },
+  {
+    file: "plugins/plugin-computeruse/src/__tests__/service.real.test.ts",
+    blocked:
+      "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
+    probe: "real desktop control (mouse/keyboard/screen)",
+  },
+  {
+    file: "plugins/plugin-computeruse/src/__tests__/windows-list.real.test.ts",
+    blocked:
+      "plugin-computeruse vitest.config.ts excludes *.real.test.ts in every lane (desktop-control host required)",
+    probe: "attached display",
+  },
+  {
+    file: "plugins/plugin-form/src/tests/json-integration.live.test.ts",
+    anyOf: [["ANTHROPIC_API_KEY"], ["OPENAI_API_KEY"]],
+  },
+  {
+    file: "plugins/plugin-google-genai/__tests__/integration/google-genai.live.test.ts",
+    requires: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+  },
+  {
+    file: "plugins/plugin-health/test/fitbit-connector.real.test.ts",
+    requires: ["FITBIT_ACCESS_TOKEN"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-health/test/oura-connector.real.test.ts",
+    requires: ["OURA_ACCESS_TOKEN"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-health/test/strava-connector.real.test.ts",
+    requires: ["STRAVA_ACCESS_TOKEN"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-health/test/withings-connector.real.test.ts",
+    requires: ["WITHINGS_ACCESS_TOKEN"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-hyperliquid/src/routes.real.test.ts",
+    notes:
+      "public API, no credential; also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-local-inference/src/services/voice/asr-timed.real.test.ts",
+    probe: "bun runtime + built libelizainference + staged voice models",
+  },
+  {
+    file: "plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-engine-bridge.real.test.ts",
+    probe: "bun runtime + built libelizainference + Kokoro model",
+  },
+  {
+    file: "plugins/plugin-local-inference/src/services/voice/speaker/diarizer-fused.real.test.ts",
+    probe: "bun runtime + built libelizainference + diarizer model",
+  },
+  {
+    file: "plugins/plugin-local-inference/src/services/voice/speaker/encoder-fused.real.test.ts",
+    probe: "bun runtime + built libelizainference + speaker-encoder model",
+  },
+  {
+    file: "plugins/plugin-ollama/__tests__/native-plumbing.live.test.ts",
+    requires: ["OLLAMA_API_ENDPOINT"],
+    probe: "reachable local Ollama server",
+  },
+  {
+    file: "plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts",
+    optIn: "ELIZA_RUN_LIVE_TESTS",
+    requires: ["CEREBRAS_API_KEY"],
+  },
+  {
+    file: "plugins/plugin-openai/__tests__/openai-drift.real.test.ts",
+    requires: ["OPENAI_API_KEY"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-openai/__tests__/trajectory.live.test.ts",
+    requires: ["OPENAI_API_KEY_REAL"],
+  },
+  {
+    file: "plugins/plugin-openrouter/__tests__/models.live.test.ts",
+    requires: ["OPENROUTER_API_KEY"],
+  },
+  {
+    file: "plugins/plugin-personal-assistant/test/apple-reminders.live.test.ts",
+    blocked:
+      "plugin-personal-assistant vitest.config.ts excludes *.live.test.ts in every lane; macOS-only EventKit suite",
+    optIn: "ELIZA_LIVE_APPLE_REMINDERS_TEST",
+    probe: "macOS host with EventKit access",
+  },
+  {
+    file: "plugins/plugin-personal-assistant/test/lifeops-life-chat.real.test.ts",
+    blocked:
+      "plugin-personal-assistant vitest.config.ts excludes *.real.test.ts in every lane; run via the PA real lanes (vitest.background-real.config.ts family)",
+    anyOf: [
+      ["CEREBRAS_API_KEY"],
+      ["GROQ_API_KEY"],
+      ["OPENAI_API_KEY"],
+      ["ANTHROPIC_API_KEY"],
+      ["GOOGLE_GENERATIVE_AI_API_KEY"],
+    ],
+    guardVia: ["packages/app-core/test/helpers/live-provider.ts"],
+  },
+  {
+    file: "plugins/plugin-personal-assistant/test/lifeops-llm-extraction.live.test.ts",
+    blocked:
+      "plugin-personal-assistant vitest.config.ts excludes *.live.test.ts in every lane; run via the PA real lanes (vitest.background-real.config.ts family)",
+    anyOf: [
+      ["CEREBRAS_API_KEY"],
+      ["GROQ_API_KEY"],
+      ["OPENAI_API_KEY"],
+      ["ANTHROPIC_API_KEY"],
+      ["GOOGLE_GENERATIVE_AI_API_KEY"],
+    ],
+    guardVia: ["packages/app-core/test/helpers/live-provider.ts"],
+  },
+  {
+    file: "plugins/plugin-polymarket/src/routes.real.test.ts",
+    notes:
+      "public API, no credential; also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-pty/test/pty.real.test.ts",
+    probe: "host PTY support (runs in every lane, POSIX)",
+  },
+  {
+    file: "plugins/plugin-shell/__tests__/shell.real.test.ts",
+    probe: "POSIX shell (skips on win32; runs in every lane elsewhere)",
+  },
+  {
+    file: "plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts",
+    requires: ["POSTGRES_URL"],
+    notes: "auto-provisioned by run-all-tests.mjs when local psql is available",
+  },
+  {
+    file: "plugins/plugin-sql/src/__tests__/integration/postgres/rls-logs.real.test.ts",
+    requires: ["POSTGRES_URL"],
+    notes: "auto-provisioned by run-all-tests.mjs when local psql is available",
+  },
+  {
+    file: "plugins/plugin-sql/src/__tests__/integration/postgres/rls-message-server-agents.real.test.ts",
+    requires: ["POSTGRES_URL"],
+    notes: "auto-provisioned by run-all-tests.mjs when local psql is available",
+  },
+  {
+    file: "plugins/plugin-sql/src/__tests__/integration/postgres/rls-server.real.test.ts",
+    requires: ["POSTGRES_URL"],
+    notes: "auto-provisioned by run-all-tests.mjs when local psql is available",
+  },
+  {
+    file: "plugins/plugin-vision/src/ocr-service-linux-tesseract.real.test.ts",
+    probe: "vendored tesseract binary on linux",
+  },
+  {
+    file: "plugins/plugin-wallet/src/chains/evm/__tests__/integration/rpc-providers.live.test.ts",
+    optIn: "ELIZA_LIVE_EVM_RPC_TEST",
+    guardVia: [
+      "plugins/plugin-wallet/src/chains/evm/__tests__/integration/live-rpc.ts",
+    ],
+  },
+  {
+    file: "plugins/plugin-wallet/src/chains/solana/__tests__/integration/birdeye-direct.live.test.ts",
+    requires: ["BIRDEYE_API_KEY"],
+  },
+  {
+    file: "plugins/plugin-wallet/src/routes/wallet-market-overview.real.test.ts",
+    notes:
+      "public CoinGecko API, no credential; also runs nightly in external-api-live-drift.yml",
+  },
+  {
+    file: "plugins/plugin-web-search/src/services/webSearchService.real.test.ts",
+    requires: ["TAVILY_API_KEY"],
+    notes: "also runs nightly in external-api-live-drift.yml",
+  },
+];
+
+/**
+ * Walk the repo for `*.real.test.ts(x)` / `*.live.test.ts(x)` files whose
+ * content matches GUARD_CONTENT_PATTERN — the mechanical definition of the
+ * guarded set. Returns repo-relative POSIX paths, sorted.
+ */
+export function discoverGuardedRealLiveFiles(repoRoot) {
+  const found = [];
+  const stack = [repoRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!DISCOVERY_SKIP_DIRS.has(entry.name)) {
+          stack.push(path.join(dir, entry.name));
+        }
+        continue;
+      }
+      if (!entry.isFile() || !REAL_LIVE_FILE_PATTERN.test(entry.name)) {
+        continue;
+      }
+      const absolute = path.join(dir, entry.name);
+      const content = fs.readFileSync(absolute, "utf8");
+      if (GUARD_CONTENT_PATTERN.test(content)) {
+        found.push(path.relative(repoRoot, absolute).split(path.sep).join("/"));
+      }
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Compare the on-disk guarded set against the manifest.
+ * Returns { unlisted, stale }; both empty means the manifest is current.
+ */
+export function diffRealLiveManifest(
+  discoveredFiles,
+  manifest = GUARDED_REAL_LIVE_SUITES,
+) {
+  const manifestFiles = new Set(manifest.map((entry) => entry.file));
+  const discovered = new Set(discoveredFiles);
+  return {
+    unlisted: discoveredFiles.filter((file) => !manifestFiles.has(file)),
+    stale: [...manifestFiles].filter((file) => !discovered.has(file)).sort(),
+  };
+}
+
+function credGaps(entry, env) {
+  const missing = (entry.requires ?? []).filter(
+    (name) => !(env[name] ?? "").trim(),
+  );
+  if (entry.anyOf) {
+    const satisfied = entry.anyOf.some((group) =>
+      group.every((name) => (env[name] ?? "").trim()),
+    );
+    if (!satisfied) {
+      missing.push(`one of ${entry.anyOf.map((g) => g.join("+")).join(" | ")}`);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Classify every manifest entry for the given env. Precedence:
+ * blocked > optIn (gate unset) > missingCreds > probed > armed.
+ */
+export function computeRealLiveAccounting(
+  env = process.env,
+  manifest = GUARDED_REAL_LIVE_SUITES,
+) {
+  const accounting = {
+    blocked: [],
+    optIn: [],
+    missingCreds: [],
+    probed: [],
+    armed: [],
+  };
+  for (const entry of manifest) {
+    if (entry.blocked) {
+      accounting.blocked.push({ file: entry.file, reason: entry.blocked });
+      continue;
+    }
+    if (entry.optIn && (env[entry.optIn] ?? "").trim() !== "1") {
+      accounting.optIn.push({ file: entry.file, gate: entry.optIn });
+      continue;
+    }
+    const missing = credGaps(entry, env);
+    if (missing.length > 0) {
+      accounting.missingCreds.push({ file: entry.file, missing });
+      continue;
+    }
+    if (entry.probe) {
+      accounting.probed.push({ file: entry.file, probe: entry.probe });
+      continue;
+    }
+    accounting.armed.push({ file: entry.file, notes: entry.notes });
+  }
+  return accounting;
+}
+
+/**
+ * Render the accounting as `[eliza-test]`-prefixed lines. The
+ * "real suites skipped for missing creds" line is emitted on EVERY call —
+ * including when the count is 0 — so a green post-merge run always states
+ * what it did not cover.
+ */
+export function formatRealLiveSummaryLines(accounting) {
+  const lines = [];
+  lines.push(
+    `[eliza-test] real/live guarded suites: ${accounting.armed.length} armed, ` +
+      `${accounting.missingCreds.length} missing creds, ${accounting.optIn.length} opt-in gated, ` +
+      `${accounting.probed.length} host-probed, ${accounting.blocked.length} config-blocked`,
+  );
+  lines.push(
+    `[eliza-test] ${accounting.missingCreds.length} real suites skipped for missing creds:` +
+      (accounting.missingCreds.length === 0
+        ? " none"
+        : `\n${accounting.missingCreds
+            .map(
+              (item) => `  - ${item.file} (missing ${item.missing.join(", ")})`,
+            )
+            .join("\n")}`),
+  );
+  if (accounting.optIn.length > 0) {
+    lines.push(
+      `[eliza-test] ${accounting.optIn.length} real suites gated behind explicit opt-in (set <GATE>=1 to run):\n` +
+        accounting.optIn
+          .map((item) => `  - ${item.file} (gate ${item.gate})`)
+          .join("\n"),
+    );
+  }
+  if (accounting.probed.length > 0) {
+    lines.push(
+      `[eliza-test] ${accounting.probed.length} real suites decide via host probe (self-skip when absent):\n` +
+        accounting.probed
+          .map((item) => `  - ${item.file} (${item.probe})`)
+          .join("\n"),
+    );
+  }
+  if (accounting.blocked.length > 0) {
+    lines.push(
+      `[eliza-test] ${accounting.blocked.length} real suites CONFIG-BLOCKED (excluded by their package vitest config in every lane — NOT covered by this run):\n` +
+        accounting.blocked
+          .map((item) => `  - ${item.file} (${item.reason})`)
+          .join("\n"),
+    );
+  }
+  return lines;
+}

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -77,6 +77,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  computeRealLiveAccounting,
+  diffRealLiveManifest,
+  discoverGuardedRealLiveFiles,
+  formatRealLiveSummaryLines,
+} from "./lib/real-live-suites.mjs";
+import {
   isParallelSafeTask,
   normalizeConcurrency,
   parseShardSpec,
@@ -272,6 +278,30 @@ if (TEST_LANE === "pr") {
     console.warn(
       `${YELLOW}[eliza-test] WARN TEST_LANE=post-merge — missing env vars:\n  ${missing.join("\n  ")}${RESET}`,
     );
+  }
+
+  // #9310 §E: loud, named accounting of every guarded *.real/*.live suite.
+  // A missing credential is a counted named skip printed on EVERY post-merge
+  // run — never a silent green nothing. The manifest is enforced against the
+  // on-disk guarded set here so it can't drift quietly.
+  const guardedOnDisk = discoverGuardedRealLiveFiles(repoRoot);
+  const drift = diffRealLiveManifest(guardedOnDisk);
+  if (drift.unlisted.length > 0 || drift.stale.length > 0) {
+    console.error(
+      `[eliza-test] FAIL real/live suite manifest drift (packages/scripts/lib/real-live-suites.mjs):` +
+        (drift.unlisted.length > 0
+          ? `\n  guarded on disk but not in manifest:\n    ${drift.unlisted.join("\n    ")}`
+          : "") +
+        (drift.stale.length > 0
+          ? `\n  in manifest but no longer guarded on disk:\n    ${drift.stale.join("\n    ")}`
+          : ""),
+    );
+    process.exit(1);
+  }
+  for (const line of formatRealLiveSummaryLines(
+    computeRealLiveAccounting(process.env),
+  )) {
+    console.log(line);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #11413
Refs #11419

Restores and reconciles the deferred CI-orchestration tail from the #11271 stale-base squash:

- restores the personal-assistant integration lane in `test.yml` and puts it back in the aggregate test status gate
- restores the scenario PR real/live guarded-suite manifest gate and UI fixture-runner coverage ratchet
- restores the Kokoro real smoke workflow's post-#9588 F16 model path/status and espeak Linux deps
- restores post-merge real/live manifest drift checking and named accounting in `run-all-tests.mjs`
- restores the real/live manifest and ratchet tests, reconciled for current `develop` drift
- wires the currently orphaned `packages/ui` fixture e2e runners into `ui-e2e-gate.yml`

I did not restore `lifeops-quality-bench.yml`: `packages/benchmarks/lifeops-quality` is absent on current `develop`, and the issue tail called out the CI orchestration files above for reconciliation instead of blind restoration.

## Evidence

Evidence note: `.github/issue-evidence/11413-ci-orchestration-tail.md`

Local verification:

- `bun install --ignore-scripts --no-frozen-lockfile` passed; reverted unrelated `bun.lock` rewrite from install
- `bunx playwright install chromium` passed
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs` passed
- `bun test packages/scripts/__tests__/real-live-suites.test.ts` passed, 7 tests
- `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` passed, 1 test
- `node --check packages/scripts/run-all-tests.mjs` passed
- `TEST_LANE=post-merge node packages/scripts/run-all-tests.mjs --plan=text --no-cloud` passed and printed named real/live accounting
- `bunx @biomejs/biome check packages/scripts/run-all-tests.mjs packages/scripts/lib/real-live-suites.mjs packages/scripts/__tests__/real-live-suites.test.ts packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` exited 0 with existing env-var warnings in `run-all-tests.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/test.yml .github/workflows/scenario-pr.yml .github/workflows/kokoro-real-smoke.yml .github/workflows/ui-e2e-gate.yml` passed
- `git diff --check` passed

Newly wired UI fixture runners:

- `bun run --cwd packages/ui test:agent-surface-e2e` passed
- `bun run --cwd packages/ui test:ftu-home-e2e` passed
- `bun run --cwd packages/ui test:orchestrator-accounts-e2e` passed
- `bun run --cwd packages/ui test:background-e2e` passed
- `bun run --cwd packages/ui test:connectors-e2e` passed after adding generated shared i18n setup
- `bun run --cwd packages/ui test:bottombar-e2e` passed
- `bun run --cwd packages/ui test:chat-ambient-e2e` passed
- `bun run --cwd packages/ui test:fused-wake-integration-e2e` skipped with `libwakeword not built`
- `bun run --cwd packages/ui test:view-lifecycle-e2e` passed

Root verification:

- `bun run verify` fails before typecheck/lint at the pre-existing current-`develop` type-safety ratchet drift:
  - `as unknown as: 80 current > 77 baseline`
  - ``?? {}`` core/agent/app-core: `379 current > 377 baseline`

## N/A

- Live model trajectories: N/A - no agent prompt, action, provider, or model behavior changed.
- Deployed app screenshots/logs: N/A - this restores CI workflow/script orchestration and uses isolated local CI/e2e scripts for proof.
