### PR TITLE
fix(cloud): unbreak the web /join flow — resolve the control plane from the page host

### DIFF
--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+  CapacitorHttp: {
+    get: vi.fn(),
+    post: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import { ElizaClient } from "./client-base";
+import "./client-cloud";
+
+// The /join flow's exact client state on hosted web: a signed-in Steward
+// session (token global set by selectOrProvisionCloudAgent) but NO agent
+// baseUrl yet. The direct-cloud base must resolve from the PAGE host — when it
+// resolved to null, getCloudCompatAgents fell through to the agent-proxy path
+// /api/cloud/compat/agents, which only agent servers mount; the cloud worker
+// 404s it and every web sign-in dead-ended on "Couldn't connect to your
+// agent".
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function setHostname(hostname: string, protocol = "https:"): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hostname,
+      host: hostname,
+      protocol,
+      origin: `${protocol}//${hostname}`,
+      href: `${protocol}//${hostname}/join`,
+    },
+  });
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+    "steward-jwt";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+});
+
+describe("getCloudCompatAgents on hosted web with no agent baseUrl (join flow)", () => {
+  it("resolves the control plane from the staging page host and lists agents via the direct v1 route", async () => {
+    setHostname("staging.elizacloud.ai");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ success: true, data: [] }));
+
+    const client = new ElizaClient("");
+    const result = await client.getCloudCompatAgents();
+
+    // The direct URL is same-site, so it is rewritten to the relative path
+    // and rides the co-hosted /api/* proxy with the Bearer attached.
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/v1/eliza/agents");
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer steward-jwt",
+    );
+    expect(result).toEqual({ success: true, data: [] });
+
+    // The agent-proxy fallback must never fire on a cloud host.
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain("/api/cloud/compat/agents");
+    }
+  });
+
+  it("resolves the prod page host to the prod control plane", async () => {
+    setHostname("elizacloud.ai");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ success: true, data: [] }));
+
+    const client = new ElizaClient("");
+    await client.getCloudCompatAgents();
+
+    expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/v1/eliza/agents");
+  });
+
+  it("keeps the agent-proxy fallback on non-cloud hosts", async () => {
+    setHostname("localhost", "http:");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ success: true, data: [] }));
+
+    const client = new ElizaClient("");
+    await client.getCloudCompatAgents();
+
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("/api/cloud/compat/agents"))).toBe(true);
+    expect(urls.some((u) => u.includes("/api/v1/eliza/agents"))).toBe(false);
+  });
+});

--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -91,6 +91,21 @@ describe("getCloudCompatAgents on hosted web with no agent baseUrl (join flow)",
     expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/v1/eliza/agents");
   });
 
+  it("resolves app Pages hosts to their matching control plane", async () => {
+    for (const hostname of ["app.elizacloud.ai", "app-staging.elizacloud.ai"]) {
+      setHostname(hostname);
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse({ success: true, data: [] }));
+
+      const client = new ElizaClient("");
+      await client.getCloudCompatAgents();
+
+      expect(String(fetchSpy.mock.calls[0][0])).toBe("/api/v1/eliza/agents");
+      vi.restoreAllMocks();
+    }
+  });
+
   it("keeps the agent-proxy fallback on non-cloud hosts", async () => {
     setHostname("localhost", "http:");
     const fetchSpy = vi

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -282,6 +282,19 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
       getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL,
     );
   }
+  // Web SPA served from a cloud host with no agent baseUrl yet — exactly the
+  // /join flow's state (selectOrProvisionCloudAgent runs BEFORE any agent
+  // connection exists). Resolve the control plane from the page host so the
+  // direct /api/v1 path works. Returning null here sent these calls down the
+  // agent-proxy fallback (/api/cloud/compat/*), a route only agent servers
+  // mount — the cloud worker 404s it, so every web sign-in dead-ended on
+  // "Couldn't connect to your agent".
+  if (typeof window !== "undefined") {
+    const byHost = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
+      window.location.hostname.toLowerCase(),
+    );
+    if (byHost) return byHost;
+  }
   return null;
 }
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -72,8 +72,10 @@ const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
   ["elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
   ["www.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
   ["dev.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
+  ["app.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
   ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
   ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
+  ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
 ]);
 const DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST = new Map([
   ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],


### PR DESCRIPTION
## What

The post-sign-in `/join` flow has never completed on hosted web (staging AND prod): after a fully successful Steward sign-in it dead-ends on **"Couldn't connect to your agent — Not found"**. This was the next blocker behind the session-loop fixes (#11016/#11067) — auth is now green end-to-end, and this 404 is what users hit instead.

## Root cause (verified live on staging with a real session)

`selectOrProvisionCloudAgent` runs **before** any agent connection exists, so the `ElizaClient` has no baseUrl. `resolveDirectCloudClientApiBase` only handled two cases — baseUrl-set and native — and returned `null` on hosted web. That made `directCloudRequest` bail, and `getCloudCompatAgents`/`createCloudCompatAgent` fell through to the agent-proxy fallback `/api/cloud/compat/agents` — a route **only agent servers mount**. The cloud worker 404s it (`resource_not_found`), the join flow throws, and the UI shows the dead-end.

Live evidence from a real staging session (magic-link login, all auth calls 200):
- `GET /api/cloud/compat/agents` (same-origin, authed) → **404** `resource_not_found`
- `GET https://api-staging.elizacloud.ai/api/v1/eliza/agents` with the same session's **Bearer only** → **200** `{"success":true,"data":[]}`

So the direct path the client *should* take works perfectly — it just never resolved.

## Fix

When the SPA is served from a known cloud host, resolve the direct API base from `window.location.hostname` via the existing `DIRECT_ELIZA_CLOUD_API_BY_HOST` map (which already carries prod + staging). The direct request is then same-site, gets rewritten to the relative `/api/v1` path by `resolveBrowserCloudApiRequestUrl`, and rides the co-hosted `/api/*` proxy with the Bearer attached. Non-cloud hosts (localhost/desktop connected to an agent server) keep the agent-proxy fallback unchanged.

## Test

- New `client-cloud-web-join-base.test.ts`: staging host → direct `/api/v1/eliza/agents` with Bearer (agent-proxy path asserted never called); prod host → same; localhost → agent-proxy fallback preserved. 3/3 pass.
- Full `packages/ui/src/api/` sweep: same 3 pre-existing environmental failures (Node 25 localStorage/webview class) on clean develop and on this branch — zero regressions.
- `bun run --cwd packages/ui typecheck` clean, biome clean.

## Verify after deploy

Sign in on staging → `/join` should list/provision an agent and land in chat, and `localStorage['elizaos:active-server']` should be written (it never was on web before this).