### PR TITLE
fix(local-inference): stage flat bionic bundles

### DIFF
--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
@@ -3,7 +3,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { BionicHostLoader } from "./bionic-host-loader";
+import { BionicHostLoader, deriveBundleDir } from "./bionic-host-loader";
 
 /**
  * Real-IPC test: stand up an actual abstract-namespace AF_UNIX server (the same
@@ -69,6 +69,75 @@ function makeBundleModelPath(manifest: unknown = {}): string {
 	return path.join(bundleRoot, "text", "model.gguf");
 }
 
+describe("deriveBundleDir", () => {
+	it("returns the bundle root for the canonical text directory layout", () => {
+		const modelPath = path.join(
+			"/data",
+			"x",
+			"eliza-1",
+			"bundle",
+			"text",
+			"model.gguf",
+		);
+		expect(deriveBundleDir(modelPath)).toBe(
+			path.join("/data", "x", "eliza-1", "bundle"),
+		);
+	});
+
+	it("stages a hidden bundle view for flat Android Eliza-1 GGUFs", () => {
+		const modelsDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-bionic-flat-models-"),
+		);
+		tempDirs.push(modelsDir);
+		const modelPath = path.join(modelsDir, "eliza-1-2b-128k.gguf");
+		fs.writeFileSync(modelPath, "GGUF");
+
+		const bundleDir = deriveBundleDir(modelPath);
+		const expectedBundleDir = path.join(
+			modelsDir,
+			".bionic-bundles",
+			"eliza-1-2b-128k",
+		);
+		const stagedPath = path.join(
+			expectedBundleDir,
+			"text",
+			"eliza-1-2b-128k.gguf",
+		);
+
+		expect(bundleDir).toBe(expectedBundleDir);
+		expect(fs.existsSync(stagedPath)).toBe(true);
+		expect(fs.readFileSync(stagedPath, "utf8")).toBe("GGUF");
+	});
+
+	it("does not stage arbitrary flat GGUF files into a fused Eliza-1 bundle", () => {
+		const modelsDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-bionic-flat-generic-"),
+		);
+		tempDirs.push(modelsDir);
+		const modelPath = path.join(modelsDir, "flat-model.gguf");
+		fs.writeFileSync(modelPath, "GGUF");
+
+		expect(deriveBundleDir(modelPath)).toBe("");
+		expect(fs.existsSync(path.join(modelsDir, ".bionic-bundles"))).toBe(false);
+	});
+
+	it("keeps flat text-only bundle aliases behind the ASR bundle gate", async () => {
+		const modelsDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-bionic-flat-text-only-"),
+		);
+		tempDirs.push(modelsDir);
+		const modelPath = path.join(modelsDir, "eliza-1-2b-128k.gguf");
+		fs.writeFileSync(modelPath, "GGUF");
+
+		const loader = new BionicHostLoader("unused-asr-gate");
+		await loader.loadModel({ modelPath });
+
+		await expect(
+			loader.transcribe({ pcmBase64: "AAAA", sampleRate: 16000 }),
+		).rejects.toThrow(/requires an active Gemma ASR-capable bundle/);
+	});
+});
+
 describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 	it("round-trips a buffered generate and returns the host completion", async () => {
 		let seen: Record<string, unknown> | null = null;
@@ -103,7 +172,7 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 		});
 	});
 
-	it("forwards an empty bundleDir when the model is not in a text/ bundle", async () => {
+	it("forwards an empty bundleDir when a non-Eliza model is not in a text/ bundle", async () => {
 		let seen: Record<string, unknown> | null = null;
 		host = startHost(SOCK, (req) => {
 			seen = req;

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
@@ -21,6 +21,14 @@
  * discriminator for that.
  */
 
+import {
+	existsSync,
+	linkSync,
+	mkdirSync,
+	statSync,
+	symlinkSync,
+	unlinkSync,
+} from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { logger } from "@elizaos/core";
@@ -37,6 +45,8 @@ import {
 const REQUEST_TIMEOUT_MS = 120_000;
 /** Defensive ceiling on a single response frame (a full completion). */
 const MAX_FRAME_BYTES = 64 * 1024 * 1024;
+const FLAT_ELIZA_1_GGUF_RE = /^eliza-1-[a-z0-9_.-]+\.gguf$/i;
+const BIONIC_FLAT_BUNDLE_DIR = ".bionic-bundles";
 
 interface BionicGenerateResponse {
 	ok: boolean;
@@ -58,12 +68,48 @@ interface BionicTextResponse {
  * Derive the fused-bundle root from a model GGUF path. The host's
  * `eliza_inference_create(bundleDir)` expects the directory that contains
  * `text/<model>.gguf`; when the installed model is laid out that way we forward
- * it, otherwise we send empty and let the host fall back to its default bundle.
+ * it. Android smoke and first-run paths can stage the curated Eliza-1 text GGUF
+ * flat under `local-inference/models/`, so for those files we create a hidden
+ * hardlink/symlink bundle view without copying the multi-GB model bytes.
  */
-function deriveBundleDir(modelPath: string): string {
+export function deriveBundleDir(modelPath: string): string {
 	if (!modelPath) return "";
 	const dir = path.dirname(modelPath);
 	if (path.basename(dir) === "text") return path.dirname(dir);
+	if (!FLAT_ELIZA_1_GGUF_RE.test(path.basename(modelPath))) return "";
+	if (!existsSync(modelPath)) return "";
+
+	const modelName = path.basename(modelPath);
+	const bundleRoot = path.join(
+		dir,
+		BIONIC_FLAT_BUNDLE_DIR,
+		path.basename(modelName, path.extname(modelName)),
+	);
+	const textDir = path.join(bundleRoot, "text");
+	const stagedPath = path.join(textDir, modelName);
+	try {
+		mkdirSync(textDir, { recursive: true });
+		if (existsSync(stagedPath)) {
+			try {
+				const source = statSync(modelPath);
+				const staged = statSync(stagedPath);
+				if (source.size === staged.size) return bundleRoot;
+			} catch {
+				// Recreate stale or broken aliases below.
+			}
+			unlinkSync(stagedPath);
+		}
+		try {
+			linkSync(modelPath, stagedPath);
+		} catch {
+			symlinkSync(modelPath, stagedPath);
+		}
+		return bundleRoot;
+	} catch (err) {
+		logger.warn(
+			`[BionicHostLoader] could not stage bionic bundle view for flat model "${modelPath}": ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
 	return "";
 }
 


### PR DESCRIPTION
## Summary
- Refs #11335 by making `BionicHostLoader` derive a real fused bundle root for flat staged Eliza-1 GGUFs.
- When a curated `eliza-1-*.gguf` is staged flat under `local-inference/models/`, the loader now creates a hidden `.bionic-bundles/<model>/text/<model>.gguf` hardlink/symlink view and sends that bundle root to the Android bionic host.
- Keeps arbitrary flat GGUFs on the old host-default path and keeps ASR gated on real ASR bundle files/provenance.

## Evidence
- `git fetch origin` + `git rebase origin/develop` completed cleanly after `origin/develop` moved to `26724fc8019`.
- `bun run --cwd plugins/plugin-local-inference test -- src/services/bionic-host-loader.test.ts` -> 4 passed, 9 skipped on macOS (Linux-only abstract-UDS tests skipped as expected).
- `bunx biome check plugins/plugin-local-inference/src/services/bionic-host-loader.ts plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts` -> clean.
- `bun run --cwd packages/contracts build && bun run --cwd plugins/plugin-local-inference typecheck` -> clean.
- `bun run --cwd plugins/plugin-local-inference build` -> clean.
- `git diff --check origin/develop...HEAD` -> clean.
- `bun run verify` -> clean; Turbo build/typecheck completed 483/483 tasks, follow-up audits passed, and 28 dist-path consumer configs typechecked.

## Not run / N/A
- Android Pixel bionic-host local-chat smoke, screenshots, and video: still required before closing #11335. This Mac verification proves the path derivation and repo gates, but not the real Android hardware lane.
- Real-LLM trajectories, backend logs, frontend logs, domain artifacts: N/A for this code path derivation change; no prompt/model/action/provider behavior or user-facing UI changed.
