### PR TITLE
fix: partially settle chat completions aborts

### DIFF
--- a/.github/issue-evidence/11169-completions-abort-partial-settle.md
+++ b/.github/issue-evidence/11169-completions-abort-partial-settle.md
@@ -1,0 +1,48 @@
+# Issue #11169 Part 4 Evidence: Chat Completions Abort Partial Settlement
+
+Date: 2026-07-02
+
+## Scope
+
+Fixes the LOW residual in #11169: `/api/v1/chat/completions` streaming client
+abort no longer calls `settleReservation(0)` after text has already been sent.
+The route now settles the reservation against the prompt estimate plus delivered
+text-delta tokens, while provider-error paths still release the hold to `0`.
+
+## Verification
+
+- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-streaming-credit-leak.test.ts`
+  - 7 pass, 0 fail, 51 assertions.
+  - Covers provider 400/429/503 full refund, fullStream provider error full refund,
+    client abort after text deltas partial settlement, abort-like stream failure
+    partial settlement, and idempotent no-double-refund.
+- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-stream-credit-leak.test.ts`
+  - 6 pass, 0 fail, 19 assertions.
+- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-optimistic-billing.test.ts`
+  - 5 pass, 0 fail, 13 assertions.
+- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-tool-choice.test.ts`
+  - 18 pass, 0 fail, 26 assertions.
+- `bun run --cwd packages/cloud/api typecheck`
+  - pass.
+- `bun run --cwd packages/cloud/api build`
+  - pass.
+- `bunx @biomejs/biome check --write packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts`
+  - pass, no fixes after final edit.
+- `git diff --check`
+  - pass.
+- `bun run verify`
+  - pass after rebasing onto latest `origin/develop`.
+
+## Root Verify
+
+`bun run verify` completed successfully after the final rebase. The run included
+the type-safety ratchet, Turbo typecheck/lint, build-model and build-deps audits,
+secret/script/test-realness audits, and dist-path consumer typechecks.
+
+## N/A
+
+- UI screenshots/video: N/A - backend billing/stream settlement route only.
+- Native/mobile capture: N/A - no native surface changed.
+- Live LLM trajectory: N/A - no prompt/model behavior changed; the regression is
+  reservation settlement on client abort. The provider boundary is mocked in the
+  focused unit test and the credit reservation settler is real.

--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -19,8 +19,8 @@
  *   4. The success path settles to actual usage exactly once, and a later
  *      stray onError cannot double-refund (idempotent settler).
  *
- * `streamText` and `getLanguageModel` are mocked at the module boundary; the
- * settler and reservation math are real.
+ * `streamText`, `getLanguageModel`, and the billing-price lookup are mocked at
+ * the module boundary; the settler and reservation math are real.
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -30,7 +30,9 @@ import { APICallError } from "ai";
 // stranded by the process-wide registry replacement; restore in afterAll.
 const aiActual = require("ai") as Record<string, unknown>;
 
+import { estimateTokens } from "@/lib/pricing";
 import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
 
 // The REAL settler — explicitly NOT mocked. This is the component under test.
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
@@ -55,6 +57,42 @@ mock.module("@/lib/providers/language-model", () => ({
   getLanguageModel: () => ({}) as never,
 }));
 
+const INPUT_TOKEN_COST = 0.001;
+const OUTPUT_TOKEN_COST = 0.01;
+const billUsage = mock(async (_context: unknown, usage: unknown) => {
+  const record =
+    usage && typeof usage === "object"
+      ? (usage as {
+          inputTokens?: number;
+          promptTokens?: number;
+          outputTokens?: number;
+          completionTokens?: number;
+          totalTokens?: number;
+        })
+      : {};
+  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
+  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  const inputCost = inputTokens * INPUT_TOKEN_COST;
+  const outputCost = outputTokens * OUTPUT_TOKEN_COST;
+  return {
+    inputCost,
+    outputCost,
+    totalCost: inputCost + outputCost,
+    baseInputCost: inputCost,
+    baseOutputCost: outputCost,
+    baseTotalCost: inputCost + outputCost,
+    platformMarkup: 0,
+    inputTokens,
+    outputTokens,
+    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+    markupApplied: true,
+  };
+});
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  billUsage,
+}));
+
 // Import the route AFTER the mocks so it binds to the stubs.
 const { __streamingCreditTestHooks } = await import(
   "../v1/chat/completions/route"
@@ -64,6 +102,7 @@ const { handleStreamingRequest } = __streamingCreditTestHooks;
 afterAll(() => {
   mock.module("ai", () => aiActual);
   mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
 });
 
 /**
@@ -74,6 +113,7 @@ afterAll(() => {
 function makeLedgerReservation(startBalance: number, hold: number) {
   let balance = startBalance - hold; // upfront hold debited
   let reconcileCalls = 0;
+  const actualCosts: number[] = [];
   return {
     startBalance,
     hold,
@@ -83,10 +123,14 @@ function makeLedgerReservation(startBalance: number, hold: number) {
     get reconcileCalls() {
       return reconcileCalls;
     },
+    get actualCosts() {
+      return actualCosts;
+    },
     reservation: {
       reservedAmount: hold,
       reconcile: async (actualCost: number) => {
         reconcileCalls++;
+        actualCosts.push(actualCost);
         balance += hold - actualCost;
         return undefined;
       },
@@ -104,8 +148,9 @@ function makeApiCallError(statusCode: number) {
   });
 }
 
+const MODEL = "openai/gpt-oss-120b";
 const REQUEST = {
-  model: "openai/gpt-oss-120b",
+  model: MODEL,
   messages: [{ role: "user", content: "hello" }],
   stream: true,
 } as never;
@@ -113,9 +158,10 @@ const REQUEST = {
 /** Invoke handleStreamingRequest with the test's settler and a fixed shape. */
 function callStreaming(
   settleReservation: (actualCost: number) => Promise<unknown> | unknown,
+  options: { estimatedInputTokens?: number; signal?: AbortSignal } = {},
 ) {
   return handleStreamingRequest(
-    "openai/gpt-oss-120b",
+    MODEL,
     undefined,
     [{ role: "user", content: "hello" }] as never,
     REQUEST,
@@ -126,8 +172,9 @@ function callStreaming(
     "req-1",
     null,
     Date.now(),
-    undefined,
+    options.signal,
     30_000,
+    options.estimatedInputTokens ?? 1,
     settleReservation as never,
     {} as never,
     undefined,
@@ -138,6 +185,7 @@ function callStreaming(
 
 beforeEach(() => {
   streamText.mockClear();
+  billUsage.mockClear();
   streamTextImpl = null;
 });
 
@@ -222,6 +270,78 @@ describe("streaming chat — provider error releases the credit reservation", ()
     expect(body).toContain('"type":"service_unavailable"');
     expect(body).toContain('"code":503');
     expect(body.trimEnd().endsWith("data: [DONE]")).toBe(true);
+  });
+});
+
+describe("streaming chat — client abort settles delivered usage", () => {
+  test("abort after text deltas reconciles to prompt plus delivered-output cost, not 0", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const estimatedInputTokens = 12;
+    const deliveredText = "partial response already sent";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+    expect(expectedCost).toBeGreaterThan(0);
+
+    let onAbortPromise: Promise<unknown> | undefined;
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          yield { type: "abort", reason: "client disconnected" };
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, { estimatedInputTokens });
+    const body = await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+  });
+
+  test("abort-like stream failure after text deltas cannot win with settle(0)", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield {
+          type: "text-delta",
+          id: "text-1",
+          text: deliveredText,
+        };
+        throw new DOMException("The operation was aborted.", "AbortError");
+      })(),
+    });
+
+    const res = await callStreaming(settle, { estimatedInputTokens });
+    const body = await res.text();
+
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
   });
 });
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -19,7 +19,9 @@ import {
   jsonSchema,
   type ModelMessage,
   RetryError,
+  type StepResult,
   streamText,
+  type ToolSet,
 } from "ai";
 import { getErrorStatusCode } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -31,6 +33,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   calculateCost,
+  estimateTokens,
   getProviderFromModel,
   getSafeModelParams,
   modelUsesReasoningTokens,
@@ -53,6 +56,7 @@ import {
   resolveAiProviderSource,
 } from "@/lib/providers/language-model";
 import {
+  type AIUsage,
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
@@ -1260,6 +1264,7 @@ export async function handleChatCompletionsPOST(
           startTime,
           req.signal,
           routeTimeoutMs,
+          estimatedInputTokens,
           settleReservation,
           cotOptions,
           effectiveMaxTokens,
@@ -1352,6 +1357,149 @@ function openAiErrorTypeForStatus(status: number): string {
   return "api_error";
 }
 
+function summarizeFinishedStepUsage(
+  steps: readonly StepResult<ToolSet>[],
+): AIUsage | null {
+  let sawUsage = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let cacheReadInputTokens = 0;
+  let cacheWriteInputTokens = 0;
+
+  for (const step of steps) {
+    const usage = step.usage;
+    const stepInputTokens = firstNumber(usage.inputTokens) ?? 0;
+    const stepOutputTokens = firstNumber(usage.outputTokens) ?? 0;
+    const stepTotalTokens =
+      firstNumber(usage.totalTokens) ?? stepInputTokens + stepOutputTokens;
+    const stepCacheReadTokens =
+      firstNumber(
+        usage.inputTokenDetails?.cacheReadTokens,
+        usage.cachedInputTokens,
+      ) ?? 0;
+    const stepCacheWriteTokens =
+      firstNumber(usage.inputTokenDetails?.cacheWriteTokens) ?? 0;
+
+    if (
+      stepInputTokens > 0 ||
+      stepOutputTokens > 0 ||
+      stepTotalTokens > 0 ||
+      stepCacheReadTokens > 0 ||
+      stepCacheWriteTokens > 0
+    ) {
+      sawUsage = true;
+    }
+
+    inputTokens += stepInputTokens;
+    outputTokens += stepOutputTokens;
+    totalTokens += stepTotalTokens;
+    cacheReadInputTokens += stepCacheReadTokens;
+    cacheWriteInputTokens += stepCacheWriteTokens;
+  }
+
+  if (!sawUsage) return null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cacheReadInputTokens,
+    cacheWriteInputTokens,
+  };
+}
+
+function isAbortLikeStreamError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AbortError") return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes("aborted");
+}
+
+async function settleStreamingAbortReservation(params: {
+  model: string;
+  provider: string;
+  user: { id: string; organization_id: string };
+  apiKey: { id: string } | null;
+  affiliateCode: string | null;
+  appId: string | null;
+  requestId: string;
+  billingSource: PricingBillingSource;
+  estimatedInputTokens: number;
+  deliveredText: string;
+  steps: readonly StepResult<ToolSet>[];
+  settleReservation: (
+    actualCost: number,
+  ) => Promise<CreditReconciliationResult | null>;
+}): Promise<CreditReconciliationResult | null> {
+  const finishedStepUsage = summarizeFinishedStepUsage(params.steps);
+  const deliveredOutputTokens = estimateTokens(params.deliveredText);
+  const inputTokens = Math.max(
+    params.estimatedInputTokens,
+    finishedStepUsage?.inputTokens ?? 0,
+  );
+  const outputTokens = Math.max(
+    deliveredOutputTokens,
+    finishedStepUsage?.outputTokens ?? 0,
+  );
+  const totalTokens = Math.max(
+    inputTokens + outputTokens,
+    finishedStepUsage?.totalTokens ?? 0,
+  );
+
+  try {
+    const billing = await billUsage(
+      {
+        organizationId: params.user.organization_id,
+        userId: params.user.id,
+        apiKeyId: params.apiKey?.id,
+        model: params.model,
+        provider: params.provider,
+        billingSource: params.billingSource,
+        requestId: params.requestId,
+        metadata: buildProviderReconciliationMetadata(
+          params.provider,
+          params.model,
+          true,
+          params.appId,
+        ),
+        affiliateCode: params.affiliateCode,
+        ...buildProviderBillingFields(params.provider, params.model),
+      },
+      {
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        cacheReadInputTokens: finishedStepUsage?.cacheReadInputTokens,
+        cacheWriteInputTokens: finishedStepUsage?.cacheWriteInputTokens,
+      },
+    );
+    const reconciliation = await params.settleReservation(billing.totalCost);
+
+    logger.info(
+      "[Chat Completions] Stream aborted; reservation partially settled",
+      {
+        model: params.model,
+        inputTokens: billing.inputTokens,
+        outputTokens: billing.outputTokens,
+        totalCost: billing.totalCost,
+        deliveredChars: params.deliveredText.length,
+        finishedSteps: params.steps.length,
+      },
+    );
+
+    return reconciliation;
+  } catch (error) {
+    logger.error(
+      "[Chat Completions] Stream abort partial settlement failed; refunding reservation",
+      {
+        model: params.model,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return await params.settleReservation(0);
+  }
+}
+
 // ============================================================================
 // Streaming Handler
 // ============================================================================
@@ -1370,6 +1518,7 @@ async function handleStreamingRequest(
   startTime: number,
   abortSignal: AbortSignal | undefined,
   timeoutMs: number,
+  estimatedInputTokens: number,
   settleReservation: (
     actualCost: number,
   ) => Promise<CreditReconciliationResult | null>,
@@ -1382,6 +1531,7 @@ async function handleStreamingRequest(
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
+  let deliveredText = "";
 
   const safeParams = getSafeModelParams(model, {
     temperature: request.temperature,
@@ -1481,10 +1631,29 @@ async function handleStreamingRequest(
         });
       }
     },
-    onAbort: async () => {
-      await settleReservation(0);
+    onAbort: async ({
+      steps,
+    }: {
+      readonly steps: readonly StepResult<ToolSet>[];
+    }) => {
+      await settleStreamingAbortReservation({
+        model,
+        provider,
+        user,
+        apiKey,
+        affiliateCode,
+        appId,
+        requestId,
+        billingSource,
+        estimatedInputTokens,
+        deliveredText,
+        steps,
+        settleReservation,
+      });
       logger.info("[Chat Completions] Stream aborted before completion", {
         model,
+        estimatedInputTokens,
+        deliveredOutputTokens: estimateTokens(deliveredText),
       });
     },
     // A provider error during streaming (e.g. the cerebras 429/5xx the
@@ -1534,6 +1703,7 @@ async function handleStreamingRequest(
             controller.enqueue(
               encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
             );
+            deliveredText += part.text;
             continue;
           }
 
@@ -1678,7 +1848,27 @@ async function handleStreamingRequest(
         // does not await) onError, so settle the reservation here too. The
         // settler is idempotent, so this cannot double-refund if onError already
         // won the race.
-        await settleReservation(0);
+        const streamAborted =
+          abortSignal?.aborted === true ||
+          (deliveredText.length > 0 && isAbortLikeStreamError(error));
+        if (streamAborted) {
+          await settleStreamingAbortReservation({
+            model,
+            provider,
+            user,
+            apiKey,
+            affiliateCode,
+            appId,
+            requestId,
+            billingSource,
+            estimatedInputTokens,
+            deliveredText,
+            steps: [],
+            settleReservation,
+          });
+        } else {
+          await settleReservation(0);
+        }
         const status =
           getRecoverableProviderErrorStatus(error) ?? getErrorStatusCode(error);
         try {


### PR DESCRIPTION
## Summary

- Partially settle `/api/v1/chat/completions` streaming reservations on client abort instead of refunding the full hold with `settleReservation(0)` after text deltas were already sent.
- Track successfully enqueued text deltas and price abort settlement from the existing prompt estimate plus delivered output-token estimate; finished-step usage is used when the AI SDK provides it.
- Preserve provider-error behavior: provider 400/429/503 and fullStream provider errors still release the hold to `0`.

Refs #11169. This targets part 4 only; the part 3 durable stranded-reservation sweep remains separate money-infra work.

## Evidence

Artifact: `.github/issue-evidence/11169-completions-abort-partial-settle.md`

Verified after rebasing onto latest `origin/develop`:

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install`
- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-streaming-credit-leak.test.ts` — 7 pass
- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-stream-credit-leak.test.ts` — 6 pass
- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-optimistic-billing.test.ts` — 5 pass
- `bun test --conditions eliza-source --pass-with-no-tests __tests__/chat-completions-tool-choice.test.ts` — 18 pass
- `bun run --cwd packages/cloud/api typecheck` — pass
- `bun run --cwd packages/cloud/api build` — pass
- `bunx @biomejs/biome check packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts` — pass
- `git diff --check HEAD` — pass
- `bun run verify` — pass

N/A: UI screenshots/video and native capture; backend billing/stream settlement route only.
