### PR TITLE
fix(cloud): admin gate resolves the real session; register the forgotten analytics route

### DIFF
--- a/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
+++ b/packages/ui/src/cloud/admin/data/use-admin-gate.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The admin gate must resolve the session the same way the rest of the console
+// does. The Steward SDK context keeps its session in MemoryStorage — empty on
+// every full page load — so gating on the raw context locked fully signed-in
+// users out with "Sign in required" while billing/org rendered fine off the
+// localStorage JWT. These tests exercise the gate with ONLY the persisted
+// token present (no Steward provider mounted), which is the reload reality.
+
+import { useAdminGate } from "./use-admin-gate";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
+}
+
+// Node ≥22's bare localStorage global is non-functional under vitest and
+// shadows jsdom's — install a working in-memory Storage on both access paths.
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+let storage: Storage;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useAdminGate session resolution (no Steward provider mounted — the page-reload reality)", () => {
+  it("sees a session that exists only as the persisted localStorage JWT", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+  });
+
+  it("stays signed-out with no persisted token", async () => {
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("treats an expired persisted token as signed-out", async () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+    );
+
+    const { result } = renderHook(() => useAdminGate(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/admin/data/use-admin-gate.ts
+++ b/packages/ui/src/cloud/admin/data/use-admin-gate.ts
@@ -29,9 +29,8 @@ import type {
   AdminRole,
 } from "@elizaos/cloud-shared/lib/types/cloud-api";
 import { useQuery } from "@tanstack/react-query";
-import { useContext } from "react";
 import { apiFetch } from "../../lib/api-client";
-import { LocalStewardAuthContext } from "../../shell/StewardProvider";
+import { useSessionAuth } from "../../public-pages/lib/use-session-auth";
 
 export type AdminGateStatus = AdminModerationStatusResponse;
 
@@ -55,14 +54,18 @@ interface AdminAuthGate {
  * Read the Steward session and derive whether the admin gate query may run.
  * In dev the query is skipped entirely (the bypass synthesises the role), so it
  * is gated on an authenticated session existing at all.
+ *
+ * Uses the console-wide `useSessionAuth` — NOT the raw Steward SDK context.
+ * The SDK keeps its session in MemoryStorage (empty on every full page load),
+ * so the raw context reports signed-out for a perfectly live session; every
+ * other console surface already resolves auth through `useSessionAuth`'s
+ * localStorage-JWT fallback, and the admin gate must agree with them.
  */
 function useAdminAuthGate(): AdminAuthGate {
-  const auth = useContext(LocalStewardAuthContext);
-  const ready = auth ? !auth.isLoading : true;
-  const authenticated = auth?.isAuthenticated ?? false;
+  const session = useSessionAuth();
   return {
-    enabled: ready && authenticated,
-    userId: auth?.user?.id ?? null,
+    enabled: session.ready && session.authenticated,
+    userId: session.user?.id ?? null,
   };
 }
 

--- a/packages/ui/src/cloud/register-all.test.ts
+++ b/packages/ui/src/cloud/register-all.test.ts
@@ -14,6 +14,10 @@ describe("registerAllCloudSurfaces", () => {
     for (const p of [
       "join",
       "dashboard/agents",
+      // Analytics registers as an import side effect — this entry is the guard
+      // that the register-all import stays wired (it shipped forgotten once:
+      // page fully built, route 404ing on the dashboard/* catch-all).
+      "dashboard/analytics",
       "dashboard/billing",
       "dashboard/account",
       "dashboard/security",

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -18,6 +18,10 @@
 // `registerCloudRoute(...)` / `registerSettingsSection(...)` calls.
 import "./instances";
 import "./account-security";
+// Analytics registers dashboard/analytics as an import side effect; this
+// import was missing since the cloud→app collapse, so its KEEP surface
+// silently 404'd on the dashboard/* CloudNotFound catch-all.
+import "./analytics";
 import "./billing/routes";
 import "./organization/routes";
 


### PR DESCRIPTION
## What

Two authenticated-e2e findings on the staging console, same symptom class — a surface dead while its backend is perfectly healthy:

1. **/dashboard/admin showed "Sign in required" to a fully signed-in user.** The admin gate was the only console surface reading auth from the raw Steward SDK context — and the SDK keeps its session in `MemoryStorage`, which is empty on every full page load. Billing/org/agents rendered fine off the same session because they resolve auth through `useSessionAuth` (SDK context OR the persisted localStorage JWT). The gate now uses that same console-wide hook. Genuinely signed-out users still get the sign-in card; non-admins get the existing "Access denied". Note: `McpsRoute` and the join flow's `use-join-session` still read the raw context — same latent class, flagged for follow-up rather than batch-changed here.

2. **/dashboard/analytics 404'd** — but the page fully exists. It registers its route as an import side effect, and `register-all.ts` never imported the module (forgotten at creation in the cloud→app collapse, verified in git — not a later cull). One-line import, and the route is now pinned in `register-all.test.ts` so the next forgotten wire-up fails a test instead of a live e2e.

## Test

- New `use-admin-gate.test.tsx`: session present only as the persisted localStorage JWT (the page-reload reality — fails on the old code), signed-out, expired-token. 3/3.
- `register-all.test.ts` extended with `dashboard/analytics`. 2/2.
- `packages/ui` typecheck clean, biome clean.