### PR TITLE
fix(cloud): steward timeouts above real latency, self-healing redis sockets, per-request relay store

### DIFF
--- a/packages/cloud/api/__tests__/steward-embedded-signing.test.ts
+++ b/packages/cloud/api/__tests__/steward-embedded-signing.test.ts
@@ -237,4 +237,23 @@ describe("embeddedStewardHandler signing", () => {
     expect(json.ok).toBe(true);
     expect(captured!.calls).toHaveLength(0);
   });
+
+  it("maps upstream transport failures to steward_upstream_unavailable", async () => {
+    captured?.restore();
+    globalThis.fetch = (async () => {
+      throw new Error("upstream timed out");
+    }) as unknown as typeof globalThis.fetch;
+
+    const app = makeApp();
+    const res = await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { code?: string; error?: string };
+    expect(json.code).toBe("steward_upstream_unavailable");
+    expect(json.error).toBe("steward_upstream_unavailable");
+  });
 });

--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -31,6 +31,7 @@ import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
+  STEWARD_AUTH_UPSTREAM_TIMEOUT_MS,
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
@@ -248,7 +249,7 @@ async function callStewardExchange(
       method: "POST",
       headers,
       body: bodyText,
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(STEWARD_AUTH_UPSTREAM_TIMEOUT_MS),
     });
   } catch (err) {
     return {

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -32,6 +32,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
+  STEWARD_AUTH_UPSTREAM_TIMEOUT_MS,
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
@@ -223,7 +224,7 @@ async function callStewardRefresh(
       method: "POST",
       headers,
       body: bodyText,
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(STEWARD_AUTH_UPSTREAM_TIMEOUT_MS),
     });
   } catch (err) {
     return {

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -1,4 +1,6 @@
 import type { MiddlewareHandler } from "hono";
+import { STEWARD_AUTH_UPSTREAM_TIMEOUT_MS } from "@/lib/auth/steward-client";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
@@ -263,6 +265,11 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
     body: bodyBytes,
     // Don't forward cf-specific properties that confuse fetch on cross-zone calls.
     redirect: "manual",
+    // This proxy carries the magic-link send/verify legs, which Steward has
+    // been observed serving in up to 15s — bound it above that instead of
+    // leaving it unbounded (the one upstream fetch the DoS-timeout sweep
+    // missed).
+    signal: AbortSignal.timeout(STEWARD_AUTH_UPSTREAM_TIMEOUT_MS),
   };
   const headers = init.headers as Headers;
   headers.set("x-forwarded-host", url.host);
@@ -306,7 +313,24 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
     headers.set("x-steward-signature", `v1=${signature}`);
   }
 
-  const response = await fetch(upstreamUrl.toString(), init);
+  let response: Response;
+  try {
+    response = await fetch(upstreamUrl.toString(), init);
+  } catch (error) {
+    logger.error("[embedded-steward] upstream transport failure", {
+      message: error instanceof Error ? error.message : String(error),
+      path: url.pathname,
+    });
+    return c.json(
+      {
+        success: false,
+        error: "steward_upstream_unavailable",
+        code: "steward_upstream_unavailable",
+        message: "Steward upstream unavailable",
+      },
+      502,
+    );
+  }
   if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
     return patchProvidersResponse(response, c.env);
   }

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -24,6 +24,18 @@ import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
 
 /**
+ * Timeout for LOGIN-PATH calls to the Steward upstream: the OAuth code
+ * exchange (nonce-exchange), the refresh rotation, and the `/steward/*`
+ * proxy the magic-link send/verify ride. Steward's Railway service has been
+ * observed taking 10-15s server-side on these endpoints; a 10s abort turned
+ * slow-but-SUCCESSFUL logins into 502 steward_upstream_unavailable. 25s sits
+ * above the observed worst case while still bounding the Worker invocation.
+ * Read-side helpers (services/steward-client.ts) keep their short timeouts on
+ * purpose — they degrade to null instead of failing the user's request.
+ */
+export const STEWARD_AUTH_UPSTREAM_TIMEOUT_MS = 25_000;
+
+/**
  * Claims extracted from a verified Steward JWT.
  * Maps to the fields Steward encodes in its session tokens.
  */

--- a/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis-resilience.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Resilience tests for SocketRedis against a real local TCP server.
+ *
+ * On Cloudflare Workers a socket belongs to the request context that opened
+ * it; a client instance that survives that request holds a dead/poisoned
+ * socket. These tests pin the two recovery behaviors that keep a long-lived
+ * client usable after a bad connection:
+ *
+ *  1. A failed operation must DROP the connection so the next call
+ *     reconnects fresh (pre-fix, a non-timeout socket error left the dead
+ *     socket cached and every later op on the instance failed forever).
+ *  2. A caller queued behind a stalled operation must not hang unboundedly —
+ *     the stalled op times out, the queue drains, and the next op completes
+ *     on a fresh connection.
+ *
+ * The workerd-specific orphan (a predecessor whose `finally release()` never
+ * runs because its request context died) cannot be reproduced under Node —
+ * `finally` always runs here. The queue-wait bound added for that case is
+ * exercised indirectly: these tests prove the raced wait resolves "released"
+ * and behaves identically on the normal path.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Socket as NetSocket, type Server } from "node:net";
+import { SocketRedis } from "./socket-redis";
+
+const servers: Server[] = [];
+
+function listen(server: Server): Promise<number> {
+  servers.push(server);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address && typeof address === "object") resolve(address.port);
+      else reject(new Error("no port"));
+    });
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("SocketRedis connection resilience", () => {
+  test("drops a poisoned connection after a socket error and recovers on the next call", async () => {
+    let connections = 0;
+    const server = createServer((socket: NetSocket) => {
+      connections += 1;
+      if (connections === 1) {
+        // First connection dies as soon as the client speaks — a socket
+        // error, NOT a timeout (the path that previously never closed).
+        socket.once("data", () => socket.destroy());
+        return;
+      }
+      // Later connections behave: nil bulk reply to any command.
+      socket.on("data", () => socket.write("$-1\r\n"));
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    await expect(redis.get("k")).rejects.toThrow();
+    // Pre-fix: the dead socket stayed cached and this second call failed
+    // forever. Post-fix it reconnects and completes.
+    expect(await redis.get("k")).toBeNull();
+    expect(connections).toBe(2);
+
+    await redis.quit();
+  });
+
+  test("a caller queued behind a stalled operation completes on a fresh connection instead of hanging", async () => {
+    let connections = 0;
+    const server = createServer((socket: NetSocket) => {
+      connections += 1;
+      if (connections === 1) {
+        // Accept, read, never reply — a stalled origin.
+        socket.on("data", () => {});
+        return;
+      }
+      socket.on("data", () => socket.write("$-1\r\n"));
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    const started = Date.now();
+    const first = redis.get("a");
+    const second = redis.get("b");
+
+    await expect(first).rejects.toThrow(/timed out/);
+    expect(await second).toBeNull();
+    // Stall bound (1s) + second op — nowhere near an unbounded hang.
+    expect(Date.now() - started).toBeLessThan(5_000);
+    expect(connections).toBe(2);
+
+    await redis.quit();
+  });
+
+  test("drops partial RESP parser state when reconnecting after a stalled reply", async () => {
+    let connections = 0;
+    const server = createServer((socket: NetSocket) => {
+      connections += 1;
+      if (connections === 1) {
+        // Write half a bulk string, then stall. Without resetting the parser on
+        // close, the next connection's reply is parsed as the tail of this
+        // stale frame.
+        socket.on("data", () => socket.write("$5\r\nhe"));
+        return;
+      }
+      socket.on("data", () => socket.write("$-1\r\n"));
+    });
+    const port = await listen(server);
+    const redis = new SocketRedis(`redis://127.0.0.1:${port}`);
+
+    await expect(redis.get("partial")).rejects.toThrow(/timed out/);
+    expect(await redis.get("fresh")).toBeNull();
+    expect(connections).toBe(2);
+
+    await redis.quit();
+  });
+});

--- a/packages/cloud/shared/src/lib/cache/socket-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/socket-redis.ts
@@ -239,6 +239,10 @@ class Connection {
   private parser = new RespParser();
   private readonly opts: ParsedUrl;
   private inflight: Promise<unknown> = Promise.resolve();
+  // Bumped on every fresh socket. Failure cleanup closes a connection only if
+  // it is still the one the failing op used — a queued caller may already be
+  // on a newer socket, and a late loser must not tear that one down.
+  private generation = 0;
 
   constructor(opts: ParsedUrl) {
     this.opts = opts;
@@ -247,6 +251,7 @@ class Connection {
   private async ensureOpen(): Promise<void> {
     if (this.socket) return;
     const connect = await getConnect();
+    this.generation += 1;
     this.socket = connect(
       { hostname: this.opts.hostname, port: this.opts.port },
       { secureTransport: this.opts.tls ? "on" : "off", allowHalfOpen: false },
@@ -273,11 +278,44 @@ class Connection {
       release = r;
     });
     try {
-      await previous;
-      return await this.withTimeout(async () => {
-        await this.ensureOpen();
-        return await this.sendRaw(commands);
-      });
+      // Bound the queue wait too: on Workers a prior REQUEST's op can be
+      // orphaned mid-flight (its I/O context ends → workerd never runs its
+      // `finally release()`), so an unbounded `await previous` hangs every
+      // later caller on this connection forever (observed: 79s /embeddings
+      // stalls on staging). Each send() installs its own inflight promise
+      // before waiting, so the chain structurally recovers once we stop
+      // waiting on the orphan — but the socket's RESP framing state is
+      // unknown mid-op, so drop it and reconnect fresh.
+      let queueTimer: ReturnType<typeof setTimeout> | undefined;
+      const queueWait = await Promise.race([
+        previous.then(() => "released" as const),
+        new Promise<"orphaned">((resolve) => {
+          queueTimer = setTimeout(() => resolve("orphaned"), SOCKET_OP_TIMEOUT_MS);
+        }),
+      ]);
+      if (queueTimer) clearTimeout(queueTimer);
+      if (queueWait === "orphaned") {
+        await this.close().catch(() => {});
+      }
+      let opGeneration = -1;
+      try {
+        return await this.withTimeout(async () => {
+          await this.ensureOpen();
+          opGeneration = this.generation;
+          return await this.sendRaw(commands);
+        });
+      } catch (error) {
+        // Any mid-op failure leaves the RESP stream in an unknown state — and
+        // a cross-request I/O error means the socket belongs to a dead
+        // context. Drop the connection so the next call reconnects instead of
+        // reusing a poisoned socket for the isolate's lifetime. Guard on the
+        // generation: if a queued caller already reconnected, this failure
+        // belongs to the OLD socket and must not tear down the new one.
+        if (opGeneration === -1 || opGeneration === this.generation) {
+          await this.close().catch(() => {});
+        }
+        throw error;
+      }
     } finally {
       release();
     }
@@ -285,9 +323,10 @@ class Connection {
 
   /**
    * Bound a single connect+command to {@link SOCKET_OP_TIMEOUT_MS}. On timeout
-   * the socket may be half-open or stalled, so it is closed (forcing a fresh
-   * reconnect next call) and the error propagates to the caller, which falls
-   * back to its non-cached path instead of hanging.
+   * the error propagates to the caller, which falls back to its non-cached
+   * path instead of hanging. Closing the (possibly half-open or stalled)
+   * connection is `send()`'s job — it generation-guards the close so a late
+   * timeout can't tear down a successor's fresh socket.
    */
   private async withTimeout<T>(fn: () => Promise<T>): Promise<T> {
     const op = fn();
@@ -295,10 +334,8 @@ class Connection {
     // a post-timeout socket error doesn't surface as an unhandled rejection.
     op.catch(() => {});
     let timer: ReturnType<typeof setTimeout> | undefined;
-    let timedOut = false;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        timedOut = true;
         reject(new Error(`SocketRedis operation timed out after ${SOCKET_OP_TIMEOUT_MS}ms`));
       }, SOCKET_OP_TIMEOUT_MS);
     });
@@ -306,7 +343,6 @@ class Connection {
       return await Promise.race([op, timeout]);
     } finally {
       if (timer) clearTimeout(timer);
-      if (timedOut) await this.close().catch(() => {});
     }
   }
 
@@ -363,6 +399,7 @@ class Connection {
     this.socket = null;
     this.writer = null;
     this.reader = null;
+    this.parser = new RespParser();
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/content-safety.test.ts
@@ -18,12 +18,15 @@ const ORIGINAL_OPENAI_MODERATION_API_KEY = process.env.OPENAI_MODERATION_API_KEY
 const ORIGINAL_CONTENT_SAFETY_MODE = process.env.CONTENT_SAFETY_MODE;
 const ORIGINAL_CONTENT_SAFETY_REQUIRE_CONFIG = process.env.CONTENT_SAFETY_REQUIRE_CONFIG;
 const ORIGINAL_CONTENT_SAFETY_FAIL_OPEN = process.env.CONTENT_SAFETY_FAIL_OPEN;
+const loggerErrors: string[] = [];
 
 mock.module("@/lib/utils/logger", () => ({
   ...REAL_LOGGER,
   logger: {
     debug: () => {},
-    error: () => {},
+    error: (message: string) => {
+      loggerErrors.push(message);
+    },
     info: () => {},
     warn: () => {},
   },
@@ -41,6 +44,7 @@ afterAll(() => {
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
+  loggerErrors.length = 0;
   restoreEnv("OPENAI_API_KEY", ORIGINAL_OPENAI_API_KEY);
   restoreEnv("OPENAI_MODERATION_API_KEY", ORIGINAL_OPENAI_MODERATION_API_KEY);
   restoreEnv("CONTENT_SAFETY_MODE", ORIGINAL_CONTENT_SAFETY_MODE);
@@ -142,7 +146,12 @@ describe("contentSafetyService", () => {
 
   test("fails closed when moderation is configured but unavailable", async () => {
     process.env.OPENAI_API_KEY = "test-key";
-    globalThis.fetch = (async () => new Response("nope", { status: 503 })) as typeof fetch;
+    globalThis.fetch = (async () =>
+      // gitleaks:allow - synthetic low-entropy provider token used to assert log redaction.
+      new Response("Incorrect API key provided: sk-test-secret-1234567890", {
+        status: 503,
+        statusText: "Service Unavailable",
+      })) as typeof fetch;
 
     const { contentSafetyService } = await import(
       `../content-safety.ts?case=unavailable-${Date.now()}`
@@ -154,5 +163,29 @@ describe("contentSafetyService", () => {
         text: "Safe text",
       }),
     ).rejects.toThrow("Content safety moderation is unavailable");
+
+    expect(loggerErrors[0]).toContain("Incorrect API key provided: sk-[REDACTED]");
+    expect(loggerErrors[0]).not.toContain("sk-test-secret-1234567890");
+  });
+
+  test("fails closed when moderation transport rejects", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    globalThis.fetch = (async () => {
+      throw new Error("upstream timed out");
+    }) as typeof fetch;
+
+    const { contentSafetyService } = await import(
+      `../content-safety.ts?case=transport-${Date.now()}`
+    );
+
+    await expect(
+      contentSafetyService.assertSafeForPublicUse({
+        surface: "promotion_copy",
+        text: "Safe text",
+      }),
+    ).rejects.toThrow("Content safety moderation is unavailable");
+
+    expect(loggerErrors[0]).toContain("Moderation transport unavailable");
+    expect(loggerErrors[0]).toContain("failing closed");
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-gateway-relay-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-relay-store.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pins the per-call store construction in agentGatewayRelayService.
+ *
+ * On Cloudflare Workers a Redis TCP connection is bound to the request that
+ * opened it, so the service must NOT cache a Redis-backed store across calls
+ * (the cached socket poisons the isolate — observed live as the e2e relay
+ * disconnect 500 on staging). MOCK_REDIS's backing map is process-global by
+ * design, which is exactly what lets these tests assert that state written
+ * through one per-call store instance is visible through the next.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ["MOCK_REDIS", "REDIS_URL", "KV_REST_API_URL", "UPSTASH_REDIS_REST_URL"]) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("agentGatewayRelayService store scoping", () => {
+  test("full session lifecycle works across per-call Redis store instances", async () => {
+    process.env.MOCK_REDIS = "1";
+    const { agentGatewayRelayService } = await import("./agent-gateway-relay");
+    agentGatewayRelayService.resetForTests(null);
+
+    const session = await agentGatewayRelayService.registerSession({
+      organizationId: "org-1",
+      userId: "user-1",
+      runtimeAgentId: "agent-1",
+      agentName: "Test Agent",
+    });
+
+    // Each call builds a fresh store; the round-trip only works if the
+    // backing state is shared by the BACKEND (mock map / real Redis), not by
+    // a cached client.
+    const fetched = await agentGatewayRelayService.getSession(session.id);
+    expect(fetched?.id).toBe(session.id);
+    expect(fetched?.runtimeAgentId).toBe("agent-1");
+
+    await agentGatewayRelayService.disconnectSession(session.id);
+    expect(await agentGatewayRelayService.getSession(session.id)).toBeNull();
+  });
+
+  test("without Redis, relay state still survives across calls via the shared in-memory store", async () => {
+    const { agentGatewayRelayService } = await import("./agent-gateway-relay");
+    agentGatewayRelayService.resetForTests(null);
+
+    const session = await agentGatewayRelayService.registerSession({
+      organizationId: "org-2",
+      userId: "user-2",
+      runtimeAgentId: "agent-2",
+    });
+
+    const fetched = await agentGatewayRelayService.getSession(session.id);
+    expect(fetched?.id).toBe(session.id);
+
+    await agentGatewayRelayService.disconnectSession(session.id);
+    expect(await agentGatewayRelayService.getSession(session.id)).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-gateway-relay.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-relay.ts
@@ -87,24 +87,24 @@ function parseJson<T>(value: unknown): T | null {
   }
 }
 
-let redisClient: CompatibleRedis | null = null;
-let redisInitialized = false;
+// NOTE: no module-level Redis client here, on purpose. `cloudflare:sockets`
+// connections are bound to the I/O context of the request that opened them
+// and are closed when that request ends — a cached client poisons the whole
+// isolate after its first request (every later relay op 500s with
+// "Cannot perform I/O on behalf of a different request"; observed live as the
+// e2e relay disconnect 500 on staging). SocketRedis is cheap to construct
+// (lazy connect), so each call builds a fresh one in the CURRENT request's
+// context — the same pattern as rate-limit-hono-cloudflare and siwe-helpers.
+let loggedMissingRedis = false;
 
 function getRedisClient(): CompatibleRedis | null {
-  if (redisInitialized) {
-    return redisClient;
-  }
-
-  redisClient = buildRedisClient();
-  if (redisClient) {
-    logger.info?.("[agent-gateway-relay] Redis relay store initialized");
-  } else {
+  const client = buildRedisClient();
+  if (!client && !loggedMissingRedis) {
+    loggedMissingRedis = true;
     assertPersistentCloudStateConfigured("agent-gateway-relay", false);
     logger.warn?.("[agent-gateway-relay] Redis unavailable, using in-memory relay store");
   }
-
-  redisInitialized = true;
-  return redisClient;
+  return client;
 }
 
 class InMemoryRelayStore implements RelaySessionStore {
@@ -253,9 +253,14 @@ class RedisRelayStore implements RelaySessionStore {
   }
 }
 
+// The in-memory fallback IS module-scoped: without Redis (local dev), relay
+// state must survive across requests, and plain objects (unlike I/O handles)
+// may do so on Workers.
+const sharedInMemoryStore = new InMemoryRelayStore();
+
 function createStore(): RelaySessionStore {
   const redis = getRedisClient();
-  return redis ? new RedisRelayStore(redis) : new InMemoryRelayStore();
+  return redis ? new RedisRelayStore(redis) : sharedInMemoryStore;
 }
 
 class AgentGatewayRelayService {
@@ -266,11 +271,10 @@ class AgentGatewayRelayService {
   }
 
   private getStore(): RelaySessionStore {
-    if (!this.store) {
-      this.store = createStore();
-    }
-
-    return this.store;
+    // `this.store` is only ever a test override (resetForTests/constructor).
+    // In production the store is built PER CALL so the Redis connection lives
+    // in the calling request's I/O context — never cache it back.
+    return this.store ?? createStore();
   }
 
   resetForTests(store: RelaySessionStore | null = new InMemoryRelayStore()): void {

--- a/packages/cloud/shared/src/lib/services/content-safety.ts
+++ b/packages/cloud/shared/src/lib/services/content-safety.ts
@@ -89,6 +89,12 @@ const HARD_BLOCK_THRESHOLDS: Partial<Record<OpenAIModerationCategory, number>> =
 let loggedMissingKey = false;
 let loggedDisabled = false;
 
+function redactProviderErrorDetail(detail: string): string {
+  return detail
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "sk-[REDACTED]")
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [REDACTED]");
+}
+
 function compactText(input: ContentSafetyInput["text"]): string {
   const values = Array.isArray(input) ? input : [input];
   return values
@@ -267,30 +273,60 @@ export class ContentSafetyService {
     }
 
     const model = env.OPENAI_MODERATION_MODEL?.trim() || DEFAULT_MODERATION_MODEL;
-    const response = await fetch(OPENAI_MODERATIONS_URL, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model,
-        input: moderationInput,
-      }),
-    });
-
-    if (!response.ok) {
-      const issue = `moderation_unavailable_${response.status}`;
+    let response: Response;
+    try {
+      response = await fetch(OPENAI_MODERATIONS_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          input: moderationInput,
+        }),
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (error) {
+      const issue = "moderation_unavailable_transport";
+      const message = error instanceof Error ? error.message : String(error);
       if (env.CONTENT_SAFETY_FAIL_OPEN === "true") {
-        logger.error("[ContentSafety] Moderation unavailable; allowing because fail-open is set", {
-          surface: input.surface,
-          status: response.status,
-          statusText: response.statusText,
-        });
+        logger.error(
+          `[ContentSafety] Moderation transport unavailable on surface ${input.surface}; allowing because fail-open is set: ${message}`,
+        );
         const review = emptyReview(input, mode);
         review.issues.push(issue);
         return review;
       }
+      logger.error(
+        `[ContentSafety] Moderation transport unavailable on surface ${input.surface}; failing closed: ${message}`,
+      );
+      throw new ApiError(503, "internal_error", "Content safety moderation is unavailable", {
+        transport: "fetch",
+      });
+    }
+
+    if (!response.ok) {
+      const issue = `moderation_unavailable_${response.status}`;
+      // OpenAI's error body says WHY (invalid key vs quota vs org block) —
+      // inline it in the log MESSAGE: Workers Logs drops context objects, and
+      // this fail-closed path blocked staging image-gen with zero log trace
+      // of the upstream rejection.
+      const upstreamDetail = await response
+        .text()
+        .then((t) => redactProviderErrorDetail(t).slice(0, 300))
+        .catch(() => "");
+      if (env.CONTENT_SAFETY_FAIL_OPEN === "true") {
+        logger.error(
+          `[ContentSafety] Moderation unavailable (${response.status} ${response.statusText}) on surface ${input.surface}; allowing because fail-open is set: ${upstreamDetail}`,
+        );
+        const review = emptyReview(input, mode);
+        review.issues.push(issue);
+        return review;
+      }
+      logger.error(
+        `[ContentSafety] Moderation unavailable (${response.status} ${response.statusText}) on surface ${input.surface}; failing closed: ${upstreamDetail}`,
+      );
       throw new ApiError(503, "internal_error", "Content safety moderation is unavailable", {
         status: response.status,
         statusText: response.statusText,


### PR DESCRIPTION
## What

Four staging e2e findings root-caused from live CF Workers logs + code audit. Three are one bug class: **module-scoped clients holding TCP sockets across requests**, which workerd forbids.

1. **Magic-link sign-in 502s** (`Steward upstream unavailable`): the Steward Railway service serves auth endpoints in 10-15s server-side (its own Hono logs: `email/verify` 200 in **15s**, `refresh` 200 in **10s**), and the worker's 10s `AbortSignal`s on nonce-exchange/refresh aborted slow-but-*successful* logins. One shared `STEWARD_AUTH_UPSTREAM_TIMEOUT_MS = 25s` now bounds nonce-exchange, refresh, **and the embedded `/steward/*` proxy — which had no timeout at all** (the one upstream fetch the #5b28b012 DoS sweep missed). The real cure is fixing the Steward service's latency (ops); this stops the worker from turning its slowness into failed logins.

2. **`/api/v1/embeddings` hanging >60s on staging** (observed: 79.8s, cancelled, 6ms CPU, zero handler logs): `SocketRedis.send()`'s queue wait (`await previous`) sat *outside* the 1s op timeout. An op orphaned by a dead request context (workerd never runs its `finally release()`) hung every later caller on that connection forever. The queue wait is now bounded; any mid-op failure drops the connection (a non-timeout socket error previously never closed it — one cross-request failure poisoned the isolate permanently); and the close is **generation-guarded** so a late loser can't tear down a successor's fresh socket — the concurrency test caught exactly that flaw in the first version of this fix.

3. **Relay disconnect 500** (e2e `gateway-relay lifecycle`): `agent-gateway-relay` cached a Redis client + TCP socket at module scope — the first request owns the socket, every later request 500s `internal_error` with the real error swallowed. The store is now built per call in the calling request's I/O context (the `rate-limit-hono-cloudflare`/`siwe-helpers` pattern); the in-memory fallback stays module-scoped so no-Redis local dev keeps state across requests. Same anti-pattern still lives in `a2a-task-store.ts` and `credit-events-redis.ts` (and the `rate-limit-redis.ts` module global that logs `Cannot perform I/O...` on prod inference routes) — flagged for a follow-up rather than batch-changed here.

4. **Image-gen 503 "Content safety moderation is unavailable"** with zero log trace: the fail-closed throw never logged, and the OpenAI moderations fetch was unbounded. The upstream status + error body are now inlined in the log *message* (Workers Logs drops context objects — the lesson of the nonce-exchange week), fetch bounded at 15s. The staging 503 is a present-but-rejected OpenAI key: after this deploys, the log names why (ops follow-up).

## Test

- New `socket-redis-resilience.test.ts` against a **real local TCP server**: poisoned-socket recovery + stalled-predecessor drain — both **fail against the old code** (verified: they ran against clean develop via stash and failed there).
- New `agent-gateway-relay-store.test.ts`: full session lifecycle across per-call store instances (MOCK_REDIS) + shared in-memory fallback.
- `cache/` + `services/` sweep: **zero branch-only failures** vs clean develop (60 pre-existing environmental fails on both sides, verified by diff).
- `cloud/shared` typecheck clean; `cloud/api` clean apart from the pre-existing `agents/route.ts` develop error. Biome clean.

## Honest scope

The workerd orphaned-continuation itself can't be reproduced under Node (`finally` always runs there) — the queue-bound path is exercised via its raced normal path plus the live-observed failure signature. Worth a live verify on staging post-deploy: `/api/v1/embeddings` latency and the relay lifecycle e2e.