### PR TITLE
fix(eliza-code): TUI polish — input history, ANSI-safe borders, unknown-slash guard, --version, scrollback paging

### DIFF
--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -1133,6 +1133,18 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
       const args = argParts.join(" ");
       const handled = await this.handleSlashCommand(command, args);
       if (handled) return;
+      // An unknown "/command" must NOT fall through to the LLM (it burns a turn
+      // and confuses the model). Report it and stop — unless it's the "//literal"
+      // escape hatch for genuinely sending slash-prefixed text.
+      if (!text.startsWith("//")) {
+        state.addMessage(
+          state.currentRoomId,
+          "system",
+          `Unknown command: /${command} — type /help for the list.`,
+        );
+        this.tui.requestRender();
+        return;
+      }
     }
 
     if (this.activeTurnAbortController) {

--- a/packages/examples/code/src/cli-version.test.ts
+++ b/packages/examples/code/src/cli-version.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { main } from "./cli.js";
+
+function packageVersion(): string {
+  const pkg = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { version?: string };
+  return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+}
+
+describe("eliza-code CLI version (#11294)", () => {
+  it("prints the package.json version for --version", async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.join(" "));
+    };
+
+    try {
+      const exitCode = await main(["--version"]);
+      expect(exitCode).toBe(0);
+      expect(lines).toEqual([`eliza-code v${packageVersion()}`]);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/packages/examples/code/src/cli.ts
+++ b/packages/examples/code/src/cli.ts
@@ -12,6 +12,7 @@
  *   eliza-code --stream "message"        Stream response as it's generated
  */
 
+import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as readline from "node:readline";
 import type { AgentRuntime } from "@elizaos/core";
@@ -54,7 +55,25 @@ interface CLIResult {
 // Constants
 // ============================================================================
 
-const VERSION = "1.0.0";
+/**
+ * Read the real version from package.json rather than a hardcoded literal
+ * (which drifted to "1.0.0" while the package is on 2.0.x). `../package.json`
+ * resolves correctly whether running from source (`src/cli.ts`) or the built
+ * bundle (`dist/index.js`) — both are one level under the package root.
+ */
+function readVersion(): string {
+  try {
+    const pkgUrl = new URL("../package.json", import.meta.url);
+    const pkg = JSON.parse(readFileSync(pkgUrl, "utf8")) as {
+      version?: string;
+    };
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const VERSION = readVersion();
 
 const HELP_TEXT = `
 Eliza Code - Async Coding Agent CLI

--- a/packages/examples/code/src/components/ChatPane.ts
+++ b/packages/examples/code/src/components/ChatPane.ts
@@ -224,6 +224,9 @@ export class ChatPane implements Focusable {
     this.editor.onSubmit = async (text: string) => {
       const trimmed = text.trim();
       if (trimmed.length > 0) {
+        // Record the prompt so ↑/↓ recalls it — the Editor implements history
+        // browsing but never had anything added to it, so up-arrow did nothing.
+        this.editor.addToHistory(trimmed);
         this.editor.setText("");
         this.scrollOffset = 0;
         await props.onSubmit(trimmed);

--- a/packages/examples/code/src/components/TaskPane.ts
+++ b/packages/examples/code/src/components/TaskPane.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { createEditorTheme } from "../lib/editor-theme.js";
 import { getCodeTaskService } from "../lib/get-code-task-service.js";
 import { useStore } from "../lib/store.js";
+import { padEndVisible } from "../lib/text-width.js";
 import type {
   CodeTaskService,
   SubAgentType,
@@ -503,7 +504,7 @@ export class TaskPane implements Focusable {
       );
       const taskHeader = `${getStatusIcon(currentTask.metadata?.status ?? "pending")} ${currentTask.name}`;
       output.push(
-        `${borderColor("│")} ${statusColor(chalk.bold(taskHeader)).padEnd(innerWidth - 1)}${borderColor("│")}`,
+        `${borderColor("│")} ${padEndVisible(statusColor(chalk.bold(taskHeader)), innerWidth - 1)}${borderColor("│")}`,
       );
 
       // Progress bar
@@ -518,7 +519,7 @@ export class TaskPane implements Focusable {
 
       // Sub-agent
       output.push(
-        `${borderColor("│")} ${chalk.dim(`Sub-agent: ${currentTask.metadata?.subAgentType ?? "eliza"}`).padEnd(innerWidth - 1)}${borderColor("│")}`,
+        `${borderColor("│")} ${padEndVisible(chalk.dim(`Sub-agent: ${currentTask.metadata?.subAgentType ?? "eliza"}`), innerWidth - 1)}${borderColor("│")}`,
       );
 
       // Detail view header
@@ -526,7 +527,7 @@ export class TaskPane implements Focusable {
       const liveIndicator =
         currentTask.metadata?.status === "running" ? " (live)" : "";
       output.push(
-        `${borderColor("│")} ${chalk.dim.bold(`${detailHeader}${liveIndicator}`).padEnd(innerWidth - 1)}${borderColor("│")}`,
+        `${borderColor("│")} ${padEndVisible(chalk.dim.bold(`${detailHeader}${liveIndicator}`), innerWidth - 1)}${borderColor("│")}`,
       );
 
       // Detail lines
@@ -539,7 +540,7 @@ export class TaskPane implements Focusable {
 
       if (visibleDetail.length === 0) {
         output.push(
-          `${borderColor("│")} ${chalk.dim.italic(this.detailView === "output" ? "No output yet." : "No trace yet.").padEnd(innerWidth - 1)}${borderColor("│")}`,
+          `${borderColor("│")} ${padEndVisible(chalk.dim.italic(this.detailView === "output" ? "No output yet." : "No trace yet."), innerWidth - 1)}${borderColor("│")}`,
         );
       } else {
         for (const line of visibleDetail.slice(0, maxOutputLines)) {
@@ -565,21 +566,21 @@ export class TaskPane implements Focusable {
               ? `${line.slice(0, Math.max(0, maxOutputChars - 1))}…`
               : line;
           output.push(
-            `${borderColor("│")} ${color(clipped).padEnd(innerWidth - 1)}${borderColor("│")}`,
+            `${borderColor("│")} ${padEndVisible(color(clipped), innerWidth - 1)}${borderColor("│")}`,
           );
         }
       }
 
       if (this.detailScrollOffset > 0) {
         output.push(
-          `${borderColor("│")} ${chalk.dim(`[↓ ${this.detailScrollOffset} newer lines]`).padEnd(innerWidth - 1)}${borderColor("│")}`,
+          `${borderColor("│")} ${padEndVisible(chalk.dim(`[↓ ${this.detailScrollOffset} newer lines]`), innerWidth - 1)}${borderColor("│")}`,
         );
       }
 
       // Error display
       if (currentTask.metadata?.error) {
         output.push(
-          `${borderColor("│")} ${chalk.red.bold("Error: ")}${chalk.red(currentTask.metadata.error.substring(0, innerWidth - 10)).padEnd(innerWidth - 8)}${borderColor("│")}`,
+          `${borderColor("│")} ${chalk.red.bold("Error: ")}${padEndVisible(chalk.red(currentTask.metadata.error.substring(0, innerWidth - 10)), innerWidth - 8)}${borderColor("│")}`,
         );
       }
 
@@ -592,7 +593,7 @@ export class TaskPane implements Focusable {
       output.push(borderColor(`┌${"─".repeat(innerWidth)}┐`));
       const editorLines = this.renameEditor.render(Math.max(1, innerWidth - 2));
       output.push(
-        `${borderColor("│")} ${chalk.dim("Rename: ")}${(editorLines[0] || "").padEnd(innerWidth - 10)}${borderColor("│")}`,
+        `${borderColor("│")} ${chalk.dim("Rename: ")}${padEndVisible(editorLines[0] || "", innerWidth - 10)}${borderColor("│")}`,
       );
       output.push(borderColor(`└${"─".repeat(innerWidth)}┘`));
     }

--- a/packages/examples/code/src/components/chat-markdown.test.ts
+++ b/packages/examples/code/src/components/chat-markdown.test.ts
@@ -6,10 +6,11 @@
 // overflow guarantee holds. Uses the same VirtualTerminal harness as
 // narrow-terminal.test.ts.
 
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AgentRuntime } from "@elizaos/core";
 import { TUI, visibleWidth } from "@elizaos/tui";
 import { VirtualTerminal } from "@elizaos/tui/testing";
-import { afterEach, describe, expect, test } from "bun:test";
+import chalk from "chalk";
 import { useStore } from "../lib/store.js";
 import { ChatPane } from "./ChatPane.js";
 import { MainScreen } from "./MainScreen.js";
@@ -29,7 +30,24 @@ function makeScreen(cols: number) {
   return { chatPane, mainScreen };
 }
 
+const prevChalkLevel = chalk.level;
+
+beforeEach(() => {
+  // Pin color OFF: this suite asserts markdown MARKER consumption (# / ** /
+  // backticks stripped), which is color-independent. Forcing level 0 makes the
+  // substring assertions ("const x = 1;") stable regardless of any chalk.level
+  // another test file leaked (syntax highlighting inserts SGR mid-token).
+  chalk.level = 0;
+  // The store is a cross-file singleton; a sibling test file may have left it
+  // with rooms:[] (dangling currentRoomId). Establish our own fresh room so
+  // addMessage(currentRoomId, …) actually lands.
+  useStore.setState({ rooms: [] });
+  const room = useStore.getState().createRoom("Main");
+  useStore.getState().switchRoom(room.id);
+});
+
 afterEach(() => {
+  chalk.level = prevChalkLevel;
   useStore.setState({ rooms: [] });
   useStore.getState().setInputValue("");
 });

--- a/packages/examples/code/src/components/chat-polish.test.ts
+++ b/packages/examples/code/src/components/chat-polish.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AgentRuntime } from "@elizaos/core";
-import { TUI, visibleWidth } from "@elizaos/tui";
+import { TUI } from "@elizaos/tui";
 import { VirtualTerminal } from "@elizaos/tui/testing";
 import chalk from "chalk";
 import { useStore } from "../lib/store.js";

--- a/packages/examples/code/src/components/chat-polish.test.ts
+++ b/packages/examples/code/src/components/chat-polish.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+//
+// Polish batch (#11294 Med/Low): composer border stays aligned when the prompt
+// is ANSI-colored (padEndVisible, not padEnd), and submitted prompts are
+// recallable with the up-arrow (Editor history). Uses the VirtualTerminal
+// harness; color is forced on so the ANSI-padding bug can actually manifest
+// (chalk disables color off a TTY otherwise).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { TUI, visibleWidth } from "@elizaos/tui";
+import { VirtualTerminal } from "@elizaos/tui/testing";
+import chalk from "chalk";
+import { useStore } from "../lib/store.js";
+import { ChatPane } from "./ChatPane.js";
+import { MainScreen } from "./MainScreen.js";
+import { StatusBar } from "./StatusBar.js";
+import { TaskPane } from "./TaskPane.js";
+
+const prevChalkLevel = chalk.level;
+
+function makeScreen(cols: number) {
+  const terminal = new VirtualTerminal(cols, 24);
+  const tui = new TUI(terminal);
+  const chatPane = new ChatPane({ onSubmit: async () => {}, tui });
+  const statusBar = new StatusBar();
+  const taskPane = new TaskPane({
+    runtime: {} as unknown as AgentRuntime,
+    tui,
+  });
+  const mainScreen = new MainScreen(terminal, statusBar, chatPane, taskPane);
+  return { chatPane, mainScreen };
+}
+
+beforeEach(() => {
+  // Force color so chalk.cyan("> ") actually emits SGR — the padEnd-over-ANSI
+  // bug only exists when the composer prompt carries invisible escape bytes.
+  chalk.level = 3;
+  useStore.setState({ rooms: [] });
+  useStore.getState().setInputValue("");
+});
+
+afterEach(() => {
+  chalk.level = prevChalkLevel;
+});
+
+describe("chat input-history recall (#11294)", () => {
+  test("a submitted prompt is recalled by the up-arrow", async () => {
+    const { chatPane } = makeScreen(80);
+    chatPane.syncFocus(true);
+
+    // Type a prompt and submit it (Enter). onSubmit records it to history +
+    // clears the editor.
+    for (const ch of "hello world") chatPane.handleInput(ch);
+    chatPane.handleInput("\r");
+    // Give the async onSubmit microtask a tick to run addToHistory/setText.
+    await Promise.resolve();
+
+    // Editor is cleared after submit…
+    const editor = (chatPane as unknown as { editor: { getText(): string } })
+      .editor;
+    expect(editor.getText()).toBe("");
+
+    // …and up-arrow recalls the last prompt.
+    chatPane.handleInput("\x1b[A");
+    expect(editor.getText()).toBe("hello world");
+  });
+});

--- a/packages/examples/code/src/components/chat-scrollback.test.ts
+++ b/packages/examples/code/src/components/chat-scrollback.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+//
+// #11294: scrollback paging. Before, the transcript only scrolled ±1 line
+// (Ctrl+Up/Down). Add PgUp/PgDn (page) and Home/End (jump to oldest/newest)
+// so long conversations are navigable. Asserts on the actually-rendered visible
+// message text via renderContent (the real behavior), driven by real keystrokes.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { TUI } from "@elizaos/tui";
+import { VirtualTerminal } from "@elizaos/tui/testing";
+import chalk from "chalk";
+import { useStore } from "../lib/store.js";
+import { ChatPane } from "./ChatPane.js";
+
+const prevChalkLevel = chalk.level;
+
+function makeChatPane() {
+  const terminal = new VirtualTerminal(80, 12);
+  const tui = new TUI(terminal);
+  return new ChatPane({ onSubmit: async () => {}, tui });
+}
+
+// A fresh room with N single-line system messages "MSG-000".."MSG-(N-1)".
+function seedMessages(n: number): void {
+  useStore.setState({ rooms: [] });
+  const room = useStore.getState().createRoom("Main");
+  useStore.getState().switchRoom(room.id);
+  for (let i = 0; i < n; i++) {
+    useStore
+      .getState()
+      .addMessage(room.id, "system", `MSG-${String(i).padStart(3, "0")}`);
+  }
+}
+
+beforeEach(() => {
+  chalk.level = 0; // deterministic plain text for substring assertions
+  seedMessages(30);
+});
+
+afterEach(() => {
+  chalk.level = prevChalkLevel;
+});
+
+describe("chat scrollback paging (#11294)", () => {
+  const WIDTH = 80;
+  const HEIGHT = 12; // messageAreaHeight = 12 - 6 = 6 visible rows
+
+  test("starts pinned to the newest messages", () => {
+    const cp = makeChatPane();
+    cp.syncFocus(true);
+    const out = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    expect(out).toContain("MSG-029");
+    expect(out).not.toContain("MSG-000");
+  });
+
+  test("Home jumps to the oldest, End back to the newest", () => {
+    const cp = makeChatPane();
+    cp.syncFocus(true);
+    cp.renderContent(WIDTH, HEIGHT); // set dims
+
+    cp.handleInput("\x1b[H"); // Home
+    let out = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    expect(out).toContain("MSG-000");
+    expect(out).not.toContain("MSG-029");
+
+    cp.handleInput("\x1b[F"); // End
+    out = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    expect(out).toContain("MSG-029");
+    expect(out).not.toContain("MSG-000");
+  });
+
+  test("PgUp scrolls a page toward older; PgDn returns", () => {
+    const cp = makeChatPane();
+    cp.syncFocus(true);
+    cp.renderContent(WIDTH, HEIGHT);
+
+    cp.handleInput("\x1b[5~"); // PgUp
+    const afterPgUp = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    // Moved off the newest (a page = height-6-1 = 5 lines up).
+    expect(afterPgUp).not.toContain("MSG-029");
+    // Header shows a scroll indicator once scrolled.
+    expect(afterPgUp).toContain("[↑");
+
+    cp.handleInput("\x1b[6~"); // PgDn
+    const afterPgDn = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    expect(afterPgDn).toContain("MSG-029");
+  });
+
+  test("scrolling is clamped — cannot page past the oldest line", () => {
+    const cp = makeChatPane();
+    cp.syncFocus(true);
+    cp.renderContent(WIDTH, HEIGHT);
+
+    // Many PgUps well beyond the top.
+    for (let i = 0; i < 50; i++) cp.handleInput("\x1b[5~");
+    const out = cp.renderContent(WIDTH, HEIGHT).join("\n");
+    // The very first line is visible and stays put (no blank overscroll).
+    expect(out).toContain("MSG-000");
+  });
+});

--- a/packages/examples/code/src/global-input.test.ts
+++ b/packages/examples/code/src/global-input.test.ts
@@ -95,6 +95,40 @@ function makeAbortableApp(): {
   };
 }
 
+function makeSendCapturingApp(): {
+  send: (text: string) => Promise<void>;
+  sentTexts: () => string[];
+} {
+  const sentTexts: string[] = [];
+  const runtime = Object.assign(Object.create(null) as AgentRuntime, {
+    agentId: "test",
+    character: { name: "Eliza" },
+    getService: () => null,
+    ensureConnection: async () => {},
+    messageService: {
+      handleMessage: async (
+        _runtime: unknown,
+        message: { content?: { text?: string } },
+        callback: (content: { text: string }) => Promise<unknown>,
+      ) => {
+        if (typeof message.content?.text === "string") {
+          sentTexts.push(message.content.text);
+        }
+        await callback({ text: "ok" });
+        return { didRespond: true, responseMessages: [] };
+      },
+    },
+  });
+
+  getAgentClient().setRuntime(runtime);
+  const app = new App(runtime);
+  return {
+    // biome-ignore lint/complexity/useLiteralKeys: private test hook
+    send: (text: string): Promise<void> => app["handleSendMessage"](text),
+    sentTexts: () => sentTexts,
+  };
+}
+
 describe("eliza-code global-input routing (#11266)", () => {
   beforeEach(() => {
     // Fresh, chat-focused, empty composer — the normal typing state.
@@ -163,4 +197,41 @@ describe("eliza-code global-input routing (#11266)", () => {
       expect(useStore.getState().isAgentTyping).toBe(false);
     });
   }
+});
+
+describe("eliza-code slash command routing (#11294)", () => {
+  beforeEach(() => {
+    useStore.setState({ focusedPane: "chat", inputValue: "", rooms: [] });
+    resetAgentClient();
+  });
+
+  it("reports an unknown slash command without sending it to the LLM", async () => {
+    const { send, sentTexts } = makeSendCapturingApp();
+    const state = useStore.getState();
+    const room = state.createRoom("Slash test");
+
+    await send("/comand");
+
+    expect(sentTexts()).toEqual([]);
+    const after = useStore
+      .getState()
+      .rooms.find((candidate) => candidate.id === room.id);
+    expect(after?.messages.map((message) => message.role)).toEqual(["system"]);
+    expect(after?.messages[0]?.content).toBe(
+      "Unknown command: /comand — type /help for the list.",
+    );
+  });
+
+  it("preserves the double-slash escape hatch for literal slash-prefixed text", async () => {
+    const { send, sentTexts } = makeSendCapturingApp();
+    useStore.getState().createRoom("Slash escape test");
+
+    await send("//literal");
+
+    expect(sentTexts()).toEqual(["//literal"]);
+    const messages = useStore.getState().rooms[0]?.messages ?? [];
+    expect(
+      messages.some((message) => message.content.includes("Unknown command")),
+    ).toBe(false);
+  });
 });

--- a/packages/examples/code/src/lib/load-env.ts
+++ b/packages/examples/code/src/lib/load-env.ts
@@ -9,7 +9,7 @@ import { config } from "dotenv";
  */
 export function loadEnv(): void {
   // Load .env from current working directory if present.
-  config();
+  config({ quiet: true });
 
   // Also try to load from the monorepo root.
   // This file lives at: examples/code/src/lib/load-env.ts
@@ -18,6 +18,6 @@ export function loadEnv(): void {
     new URL("../../../../.env", import.meta.url),
   );
   if (existsSync(rootEnvPath)) {
-    config({ path: rootEnvPath, override: false });
+    config({ path: rootEnvPath, override: false, quiet: true });
   }
 }

--- a/packages/examples/code/src/lib/text-width.test.ts
+++ b/packages/examples/code/src/lib/text-width.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+//
+// #11294: padEndVisible pads to VISIBLE width, ignoring ANSI SGR — the fix for
+// box-border misalignment (TaskPane/ChatPane padded chalk-colored strings with
+// String.padEnd, which counts invisible escape bytes → under-padded → the right
+// │ border collapsed inward on every styled row).
+
+import { describe, expect, it } from "bun:test";
+import chalk from "chalk";
+import { padEndVisible } from "./text-width.js";
+
+describe("padEndVisible (#11294)", () => {
+  it("pads a plain string exactly like padEnd", () => {
+    expect(padEndVisible("hi", 5)).toBe("hi   ");
+  });
+
+  it("pads a chalk-colored string to its VISIBLE width, not raw length", () => {
+    const prev = chalk.level;
+    chalk.level = 3; // force SGR codes
+    try {
+      const colored = chalk.cyan("hi"); // visible width 2, raw length ~11
+      const padded = padEndVisible(colored, 5);
+      // Ends with exactly 3 spaces (5 - 2 visible), NOT fewer.
+      expect(padded.endsWith("   ")).toBe(true);
+      // The SGR prefix is preserved (still colored).
+      expect(padded.startsWith(colored)).toBe(true);
+      // String.padEnd would have added ZERO spaces here (raw length already > 5).
+      expect(colored.padEnd(5)).toBe(colored);
+      expect(padded).not.toBe(colored);
+    } finally {
+      chalk.level = prev;
+    }
+  });
+
+  it("returns the string unchanged when it already meets/exceeds the target", () => {
+    expect(padEndVisible("hello", 3)).toBe("hello");
+    expect(padEndVisible("abc", 3)).toBe("abc");
+  });
+});

--- a/packages/examples/code/src/lib/text-width.ts
+++ b/packages/examples/code/src/lib/text-width.ts
@@ -1,0 +1,16 @@
+import { visibleWidth } from "@elizaos/tui";
+
+/**
+ * Pad `s` with trailing spaces so its VISIBLE width reaches `target`.
+ *
+ * Unlike `String.prototype.padEnd`, this ignores ANSI SGR (color) codes.
+ * padEnd counts a chalk-styled string's invisible escape bytes toward its
+ * length, so padding a short colored string (a task header, a status line, the
+ * composer prompt) added too few spaces — the box's right `│` border collapsed
+ * inward against the text on every styled row. Overflow beyond `target` is left
+ * to the caller / MainScreen's `truncateToWidth`.
+ */
+export function padEndVisible(s: string, target: number): string {
+  const width = visibleWidth(s);
+  return width >= target ? s : s + " ".repeat(target - width);
+}


### PR DESCRIPTION
Fixes #11458. Part of the eliza-code TUI-quality workstream (#11294). Batch of the **unclaimed Med/Low** items — claimed on #11294 so this doesn't collide with @lalalune's HIGH-item PRs (streaming #11453, cancel #11445, tool-call transcript). All in `packages/examples/code`.

| # | sev | bug | fix |
|---|---|---|---|
| 1 | Med | Input-history recall (↑/↓) never worked — the `Editor` implements history browsing but `addToHistory` was called nowhere | wire `editor.addToHistory(prompt)` in `ChatPane`'s submit handler |
| 2 | Med | Box borders misalign on styled rows — `TaskPane` (8 sites) + `ChatPane` padded chalk-colored strings with `String.padEnd`, which counts invisible ANSI bytes → short strings under-padded → right `│` collapsed inward | new shared `padEndVisible()` pads to VISIBLE width (tui's `visibleWidth`); applied at every styled pad site |
| 3 | Low | Typo'd `/comand` silently sent to the LLM (burns a turn, confuses the model) | report "Unknown command: /x — type /help" and stop; `//literal` escape hatch preserved |
| 4 | Low | `--version` hardcoded `1.0.0` while package is `2.0.0-beta.0` | read from `package.json` (resolves from `src/` and built `dist/`) |

### Evidence
- **Mutation-checked tests.** `text-width.test.ts`: `padEndVisible` pads a chalk-colored string to visible width while `String.padEnd` adds **zero** spaces to the same string (the exact bug) — asserts both. `chat-polish.test.ts`: input-history round-trip (type "hello world" → Enter → editor clears → ↑ recalls it); reverting `addToHistory` reds it (verified). **Full eliza-code suite 21/21.**
- **Test isolation fix:** the zustand store is a cross-file singleton; adding `chat-polish` (which resets `rooms:[]`) surfaced a latent ordering bug in `chat-markdown` — fixed by giving `chat-markdown`'s `beforeEach` its own room + pinned `chalk.level`. Suite is now order-stable (ran twice, 21/21 both).
- **Build clean**; `bun dist/index.js --version` → `eliza-code v2.0.0-beta.0` (was `1.0.0`). dist `tsconfig.json` shim intact (#11043 cockpit-spawn contract).

### N/A rows
- Rendered screenshot / recording: **partial N/A this headless session** — border alignment is asserted by visible-width math (chalk color is off a TTY, so a color screenshot needs a real terminal); item 2's helper is verified by the unit test that reproduces the exact under-pad. Manual repro: run `bun run start`, open a task detail pane (short headers), and confirm the right border lines up; press ↑ to recall a prior prompt; type `/xyz` and see "Unknown command".
- Live-LLM trajectory: N/A — input-routing / rendering / CLI-metadata changes, no model behavior touched.