### PR TITLE
fix(code): add TUI scrollback paging

### DIFF
--- a/.github/issue-evidence/11294-tui-scrollback-composer.md
+++ b/.github/issue-evidence/11294-tui-scrollback-composer.md
@@ -1,0 +1,63 @@
+# Issue #11294: eliza-code TUI Scrollback + Multiline Composer
+
+Date: 2026-07-02
+
+Scope:
+- `packages/examples/code` TUI `ChatPane`
+- Adds PgUp/PgDn/Home/End scrollback controls, keeps the transcript viewport pinned while scrolled, and renders multiple visible composer rows.
+- No model, prompt, provider, action, connector, browser, native, or web app behavior changed.
+
+## Rendered Proof
+
+Manually reviewed terminal render from the real `ChatPane.renderContent` path at the cockpit phone width (`43` columns):
+
+```text
+--- multiline composer, 43 cols ---
+
+┌───────────────────────────────────────┐
+│ >  first line                         │
+│    second line                        │
+│    third line                         │
+└───────────────────────────────────────┘
+Enter: send • PgUp/PgDn: scroll • Esc: c...
+--- scroll pinned first visible ---
+transcript line 16
+transcript line 16
+ Chat: Evidence (30) [↑ 16]
+```
+
+Manual review notes:
+- All composer rows stay inside the 43-column frame.
+- The second and third composer rows are visible instead of being collapsed.
+- After PgUp, appending transcript lines 29 and 30 kept the first visible line at `transcript line 16`; the scroll indicator stayed visible.
+
+## Verification
+
+Commands run from `/private/tmp/eliza-11294-tui-scrollback` unless noted:
+
+```bash
+ELIZA_SKIP_ARTIFACT_SYNC=1 bun install
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun test --conditions eliza-source --pass-with-no-tests src/components/narrow-terminal.test.ts
+bun test --conditions eliza-source --pass-with-no-tests src/components/narrow-terminal.test.ts src/components/chat-markdown.test.ts src/global-input.test.ts src/lib/agent-client.streaming.test.ts src/tool-transcript-events.test.ts src/lib/tool-transcript.test.ts src/lib/store.remove-message.test.ts
+bunx @biomejs/biome check packages/examples/code/src/components/ChatPane.ts packages/examples/code/src/components/HelpOverlay.ts packages/examples/code/src/components/narrow-terminal.test.ts
+bunx turbo run build --filter=@elizaos/example-code...
+bun run --cwd packages/examples/code typecheck
+bun run --cwd packages/examples/code build
+```
+
+Results:
+- Focused narrow-terminal suite: 12 pass, 83 assertions.
+- Broader eliza-code TUI regression set: 29 pass, 219 assertions.
+- Biome check: pass.
+- Turbo dependency build for `@elizaos/example-code...`: 97 successful.
+- Package typecheck: pass.
+- Package build: pass.
+
+## Evidence Matrix
+
+- Real-LLM trajectories: N/A - no model, prompt, action, provider, or agent decision behavior changed.
+- Backend logs: N/A - terminal-only render/input handling change.
+- Frontend console/network logs: N/A - no browser/web app surface.
+- Screenshots/video: N/A - not a browser/native UI path; rendered terminal proof and VirtualTerminal tests cover the changed TUI surface.
+- Domain artifacts: N/A - no persistence, memory, DB, task, file, wallet, or on-chain artifacts produced.

--- a/packages/examples/code/src/components/ChatPane.ts
+++ b/packages/examples/code/src/components/ChatPane.ts
@@ -1,10 +1,14 @@
 import {
   type AutocompleteProvider,
+  CURSOR_MARKER,
   Editor,
   type Focusable,
   Loader,
   Markdown,
+  matchesKey,
   type TUI,
+  truncateToWidth,
+  visibleWidth,
 } from "@elizaos/tui";
 import chalk from "chalk";
 import { createEditorTheme } from "../lib/editor-theme.js";
@@ -16,6 +20,12 @@ import type { Message } from "../types.js";
 // line); fall back to the plain wrapper there. This also keeps the #11043
 // narrow-terminal guarantee simple on the cockpit's ~43-col phone xterm.
 const MARKDOWN_MIN_WIDTH = 40;
+const COMPOSER_MAX_LINES = 6;
+const COMPOSER_PROMPT = "> ";
+const ANSI_SGR_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-9;]*m`,
+  "g",
+);
 // One shared theme instance (chalk style fns; cheap, but no need to rebuild).
 const chatMarkdownTheme = createChatMarkdownTheme();
 
@@ -107,6 +117,37 @@ function wrapText(text: string, maxWidth: number): string[] {
   return lines.length > 0 ? lines : [""];
 }
 
+function padToVisibleWidth(text: string, maxWidth: number): string {
+  const clipped = truncateToWidth(text, maxWidth, "");
+  const padding = Math.max(0, maxWidth - visibleWidth(clipped));
+  return `${clipped}${" ".repeat(padding)}`;
+}
+
+function isEditorRule(line: string, width: number): boolean {
+  if (visibleWidth(line) !== width) return false;
+  const plain = line
+    .replaceAll(CURSOR_MARKER, "")
+    .replace(ANSI_SGR_PATTERN, "");
+  return plain.length > 0 && [...plain].every((char) => char === "─");
+}
+
+function windowAroundCursor(lines: string[], maxLines: number): string[] {
+  if (lines.length <= maxLines) return lines;
+
+  const cursorIndex = lines.findIndex(
+    (line) => line.includes(CURSOR_MARKER) || line.includes("\x1b[7m"),
+  );
+  if (cursorIndex === -1) {
+    return lines.slice(-maxLines);
+  }
+
+  const start = Math.min(
+    Math.max(0, cursorIndex - maxLines + 1),
+    Math.max(0, lines.length - maxLines),
+  );
+  return lines.slice(start, start + maxLines);
+}
+
 function toRenderLines(messages: Message[], maxWidth: number): RenderLine[] {
   const lines: RenderLine[] = [];
 
@@ -168,8 +209,10 @@ export class ChatPane implements Focusable {
   private typingLoader: Loader | null = null;
   private typingLoaderRunning = false;
   private scrollOffset = 0;
-  private width = 80;
-  private height = 24;
+  private lastMessageAreaHeight = 1;
+  private lastMaxScroll = 0;
+  private lastRenderedLineCount = 0;
+  private lastRenderedRoomId: string | null = null;
 
   constructor(props: ChatPaneProps) {
     this.props = props;
@@ -182,6 +225,7 @@ export class ChatPane implements Focusable {
       const trimmed = text.trim();
       if (trimmed.length > 0) {
         this.editor.setText("");
+        this.scrollOffset = 0;
         await props.onSubmit(trimmed);
       }
     };
@@ -206,13 +250,32 @@ export class ChatPane implements Focusable {
   handleInput(char: string): void {
     if (!this.focused) return;
 
-    // Ctrl+Up/Down to scroll
-    if (char === "\x1b[1;5A") {
-      this.scrollUp();
+    // Transcript scrollback. Page keys always control history; Home/End do so
+    // when the composer is empty or the user is already reading scrollback.
+    if (matchesKey(char, "ctrl+up")) {
+      this.scrollBy(1);
       return;
     }
-    if (char === "\x1b[1;5B") {
-      this.scrollDown();
+    if (matchesKey(char, "ctrl+down")) {
+      this.scrollBy(-1);
+      return;
+    }
+    if (matchesKey(char, "pageUp")) {
+      this.scrollBy(this.getPageScrollAmount());
+      return;
+    }
+    if (matchesKey(char, "pageDown")) {
+      this.scrollBy(-this.getPageScrollAmount());
+      return;
+    }
+    const shouldRouteHomeEndToScroll =
+      this.editor.getText().length === 0 || this.scrollOffset > 0;
+    if (shouldRouteHomeEndToScroll && matchesKey(char, "home")) {
+      this.scrollToTop();
+      return;
+    }
+    if (shouldRouteHomeEndToScroll && matchesKey(char, "end")) {
+      this.scrollToBottom();
       return;
     }
 
@@ -231,20 +294,25 @@ export class ChatPane implements Focusable {
     this.props.tui.requestRender();
   }
 
-  private scrollUp(): void {
-    const state = useStore.getState();
-    const room = state.rooms.find((r) => r.id === state.currentRoomId);
-    const messages = room?.messages ?? [];
-    const innerWidth = Math.max(1, this.width - 4);
-    const allLines = toRenderLines(messages, innerWidth);
-    const messageAreaHeight = Math.max(1, this.height - 6);
-    const maxScroll = Math.max(0, allLines.length - messageAreaHeight);
-    this.scrollOffset = Math.min(this.scrollOffset + 1, maxScroll);
+  private getPageScrollAmount(): number {
+    return Math.max(1, this.lastMessageAreaHeight - 1);
+  }
+
+  private scrollBy(deltaLines: number): void {
+    this.scrollOffset = Math.max(
+      0,
+      Math.min(this.scrollOffset + deltaLines, this.lastMaxScroll),
+    );
     this.props.tui.requestRender();
   }
 
-  private scrollDown(): void {
-    this.scrollOffset = Math.max(0, this.scrollOffset - 1);
+  private scrollToTop(): void {
+    this.scrollOffset = this.lastMaxScroll;
+    this.props.tui.requestRender();
+  }
+
+  private scrollToBottom(): void {
+    this.scrollOffset = 0;
     this.props.tui.requestRender();
   }
 
@@ -281,10 +349,17 @@ export class ChatPane implements Focusable {
       .map((line) => ({ text: line, raw: true }));
   }
 
+  private renderComposerLines(editorWidth: number, maxLines: number): string[] {
+    const editorLines = this.editor.render(editorWidth);
+    const bodyLines = editorLines.filter(
+      (line) => !isEditorRule(line, editorWidth),
+    );
+    const visibleBody = bodyLines.length > 0 ? bodyLines : [""];
+    return windowAroundCursor(visibleBody, maxLines);
+  }
+
   /** Region body for the chat column (messages + input chrome). */
   renderContent(width: number, height: number): string[] {
-    this.width = width;
-    this.height = height;
     this.editor.setPaddingX(1);
 
     const state = useStore.getState();
@@ -296,8 +371,21 @@ export class ChatPane implements Focusable {
     const paddingX = 1;
 
     const headerHeight = 1;
-    const inputHeight = 3;
     const helpHeight = 1;
+    const inputChromeHeight = 2;
+    const editorWidth = Math.max(1, innerWidth - 3);
+    const composerMaxLines = Math.max(
+      1,
+      Math.min(
+        COMPOSER_MAX_LINES,
+        height - headerHeight - helpHeight - inputChromeHeight - 1,
+      ),
+    );
+    const composerLines = state.isLoading
+      ? []
+      : this.renderComposerLines(editorWidth, composerMaxLines);
+    const inputBodyHeight = state.isLoading ? 1 : composerLines.length;
+    const inputHeight = inputChromeHeight + inputBodyHeight;
     const messageAreaHeight = Math.max(
       1,
       height - headerHeight - inputHeight - helpHeight,
@@ -310,8 +398,23 @@ export class ChatPane implements Focusable {
       this.stopTypingLoader();
     }
 
+    if (this.lastRenderedRoomId !== state.currentRoomId) {
+      this.scrollOffset = 0;
+    } else if (
+      this.scrollOffset > 0 &&
+      allLines.length > this.lastRenderedLineCount
+    ) {
+      this.scrollOffset += allLines.length - this.lastRenderedLineCount;
+    }
+
     const maxScroll = Math.max(0, allLines.length - messageAreaHeight);
     const clampedScroll = Math.min(this.scrollOffset, maxScroll);
+    this.scrollOffset = clampedScroll;
+    this.lastMaxScroll = maxScroll;
+    this.lastMessageAreaHeight = messageAreaHeight;
+    this.lastRenderedLineCount = allLines.length;
+    this.lastRenderedRoomId = state.currentRoomId;
+
     const startIndex = Math.max(
       0,
       allLines.length - messageAreaHeight - clampedScroll,
@@ -370,16 +473,16 @@ export class ChatPane implements Focusable {
         `${borderColor("│")} ${chalk.dim(visibleText)}${" ".repeat(Math.max(0, innerWidth - visibleText.length - 1))}${borderColor("│")}`,
       );
     } else {
-      // The composer row wraps the editor in "│ > " + "│" — 5 columns of
-      // chrome on top of innerWidth (= width - 4), so the editor must render
-      // narrower than innerWidth or the row exceeds the terminal width and
-      // the TUI's overflow guard aborts — fatal on phone-width terminals
-      // (the cockpit xterm is ~43 cols).
-      const editorLines = this.editor.render(Math.max(1, innerWidth - 3));
-      const promptLine = chalk.cyan("> ") + (editorLines[0] || "");
-      output.push(
-        `${borderColor("│")} ${promptLine.padEnd(innerWidth - 1)}${borderColor("│")}`,
-      );
+      for (let i = 0; i < composerLines.length; i++) {
+        const prompt =
+          i === 0
+            ? chalk.cyan(COMPOSER_PROMPT)
+            : " ".repeat(COMPOSER_PROMPT.length);
+        const content = ` ${prompt}${composerLines[i] ?? ""}`;
+        output.push(
+          `${borderColor("│")}${padToVisibleWidth(content, innerWidth)}${borderColor("│")}`,
+        );
+      }
     }
 
     output.push(bottomBorder);
@@ -388,8 +491,8 @@ export class ChatPane implements Focusable {
       ? "Tab: focus"
       : state.inputValue.startsWith("/")
         ? "Enter: run • Tab: complete • Esc: clear • ?: help"
-        : "Enter: send • Tab: tasks • Esc: clear • ?: help";
-    output.push(chalk.dim(helpText));
+        : "Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help";
+    output.push(truncateToWidth(chalk.dim(helpText), width));
 
     return output;
   }

--- a/packages/examples/code/src/components/HelpOverlay.ts
+++ b/packages/examples/code/src/components/HelpOverlay.ts
@@ -49,7 +49,7 @@ export class HelpOverlay implements Component {
       ` ${borderColor("│")} ${chalk.bold("Chat")}${" ".repeat(innerWidth - 5)}${borderColor("│")}`,
     );
     output.push(
-      ` ${borderColor("│")} ${chalk.dim("Enter: send | Esc: clear | Ctrl+↑↓: scroll")}${" ".repeat(Math.max(0, innerWidth - 43))}${borderColor("│")}`,
+      ` ${borderColor("│")} ${chalk.dim("Enter: send | PgUp/PgDn/Home/End: scroll | Esc: clear")}${" ".repeat(Math.max(0, innerWidth - 54))}${borderColor("│")}`,
     );
     output.push(
       ` ${borderColor("│")} ${chalk.dim("/help: show commands")}${" ".repeat(Math.max(0, innerWidth - 21))}${borderColor("│")}`,

--- a/packages/examples/code/src/components/narrow-terminal.test.ts
+++ b/packages/examples/code/src/components/narrow-terminal.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { type AgentRuntime, stringToUuid } from "@elizaos/core";
 import { TUI, visibleWidth } from "@elizaos/tui";
 import { VirtualTerminal } from "@elizaos/tui/testing";
 import { useStore } from "../lib/store.js";
@@ -11,20 +12,20 @@ import { TaskPane } from "./TaskPane.js";
 // Regression for #11040 / #10830: the cockpit xterm is ~43 cols. At that
 // width the eliza-code TUI used to abort every frame — the composer row
 // exceeded the terminal width (editor rendered at innerWidth, then wrapped in
-// "│ > … │" chrome → width + 1) and the 47-col help footer overflowed too.
+// "│ > … │" chrome → width + 1) and fixed footer chrome overflowed too.
 // The TUI's final render guard throws when any line's visible width exceeds
 // the terminal width (see packages/tui/src/tui.ts: `visibleWidth(line) >
 // width`), so an overflow is a hard crash, not a cosmetic glitch.
 //
-// The fix has two seams and this suite bites both:
+// The narrow-width guarantee has two seams and this suite bites both:
 //   * ChatPane renders the editor at innerWidth - 3 so the composer row fits.
 //   * MainScreen clips every assembled line via truncateToWidth so fixed-width
-//     chrome (the 47-col footer) can never overflow.
+//     chrome can never overflow.
 
 const PHONE_COLS = 43;
 
-function makeScreen(cols: number) {
-  const terminal = new VirtualTerminal(cols, 24);
+function makeScreen(cols: number, rows = 24) {
+  const terminal = new VirtualTerminal(cols, rows);
   const tui = new TUI(terminal);
   const chatPane = new ChatPane({ onSubmit: async () => {}, tui });
   const statusBar = new StatusBar();
@@ -38,19 +39,76 @@ function makeScreen(cols: number) {
   return { chatPane, mainScreen };
 }
 
+function resetChatStore(): void {
+  useStore.setState({
+    rooms: [
+      {
+        id: "test-room",
+        name: "Main",
+        messages: [],
+        createdAt: new Date(0),
+        taskIds: [],
+        elizaRoomId: stringToUuid("eliza-code-narrow-terminal-test-room"),
+      },
+    ],
+    currentRoomId: "test-room",
+    focusedPane: "chat",
+    taskPaneVisibility: "hidden",
+    inputValue: "",
+    isLoading: false,
+    isAgentTyping: false,
+  });
+}
+
+function plainText(lines: string[]): string {
+  return lines.map((line) => stripVTControlCharacters(line)).join("\n");
+}
+
+function inputFrameLines(lines: string[]): string[] {
+  const topBorderIdx = lines.findIndex((line) => line.includes("┌"));
+  expect(topBorderIdx).toBeGreaterThanOrEqual(0);
+  const bottomBorderIdx = lines.findIndex(
+    (line, index) => index > topBorderIdx && line.includes("└"),
+  );
+  expect(bottomBorderIdx).toBeGreaterThan(topBorderIdx);
+  return lines.slice(topBorderIdx + 1, bottomBorderIdx);
+}
+
+function typeIntoChat(chatPane: ChatPane, text: string): void {
+  for (const char of text) {
+    chatPane.handleInput(char);
+  }
+}
+
+function addTranscriptMessages(count: number): void {
+  const state = useStore.getState();
+  for (let i = 1; i <= count; i++) {
+    state.addMessage(
+      state.currentRoomId,
+      "assistant",
+      `transcript line ${i.toString().padStart(2, "0")}`,
+    );
+  }
+}
+
+function firstVisibleTranscriptLine(rendered: string): string | undefined {
+  return rendered.match(/transcript line \d{2}/)?.[0];
+}
+
 // Keep the shared zustand store deterministic across tests.
+beforeEach(() => {
+  resetChatStore();
+});
+
 afterEach(() => {
-  useStore.getState().setInputValue("");
-  useStore.getState().setLoading(false);
-  useStore.getState().setAgentTyping(false);
+  resetChatStore();
 });
 
 describe("eliza-code TUI at cockpit phone width", () => {
   test("MainScreen never emits a line wider than the terminal (would crash the TUI)", () => {
     const { chatPane, mainScreen } = makeScreen(PHONE_COLS);
-    // Chat focused → the full 47-col help footer renders (the fixed-width
-    // overflow the clip seam guards). Add a long message so the message area
-    // has real content too.
+    // Chat focused → the help footer renders along with real message content,
+    // so both child layout and MainScreen clipping are exercised.
     chatPane.syncFocus(true);
     const state = useStore.getState();
     state.addMessage(
@@ -100,6 +158,71 @@ describe("eliza-code TUI at cockpit phone width", () => {
     // Without the innerWidth - 3 fix this row is width + 1 (44) and the TUI
     // aborts; with the fix it is width - 2 (41).
     expect(visibleWidth(composer)).toBeLessThanOrEqual(PHONE_COLS);
+  });
+
+  test("ChatPane renders multiple visible composer rows without overflowing", () => {
+    const { chatPane } = makeScreen(PHONE_COLS);
+    chatPane.syncFocus(true);
+
+    typeIntoChat(chatPane, "first line\nsecond line\nthird line");
+
+    const lines = chatPane.renderContent(PHONE_COLS, 24);
+    const composerLines = inputFrameLines(lines);
+    const composerText = plainText(composerLines);
+
+    expect(composerLines.length).toBeGreaterThanOrEqual(3);
+    expect(composerText).toContain("first line");
+    expect(composerText).toContain("second line");
+    expect(composerText).toContain("third line");
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(PHONE_COLS);
+    }
+  });
+
+  test("ChatPane supports page and edge scrollback keys", () => {
+    const { chatPane } = makeScreen(80, 18);
+    chatPane.syncFocus(true);
+    addTranscriptMessages(28);
+
+    const bottom = plainText(chatPane.renderContent(80, 18));
+    expect(bottom).toContain("transcript line 28");
+
+    chatPane.handleInput("\x1b[5~"); // PageUp
+    const pageUp = plainText(chatPane.renderContent(80, 18));
+    expect(pageUp).toContain("[↑ ");
+    expect(firstVisibleTranscriptLine(pageUp)).not.toBe(
+      firstVisibleTranscriptLine(bottom),
+    );
+
+    chatPane.handleInput("\x1b[H"); // Home
+    const top = plainText(chatPane.renderContent(80, 18));
+    expect(top).toContain("transcript line 01");
+
+    chatPane.handleInput("\x1b[F"); // End
+    const backAtBottom = plainText(chatPane.renderContent(80, 18));
+    expect(backAtBottom).toContain("transcript line 28");
+    expect(backAtBottom).not.toContain("[↑ ");
+  });
+
+  test("ChatPane keeps the visible scrollback viewport pinned while new messages arrive", () => {
+    const { chatPane } = makeScreen(80, 18);
+    chatPane.syncFocus(true);
+    addTranscriptMessages(28);
+    chatPane.renderContent(80, 18);
+
+    chatPane.handleInput("\x1b[5~"); // PageUp
+    const beforeAppend = plainText(chatPane.renderContent(80, 18));
+    const firstBeforeAppend = firstVisibleTranscriptLine(beforeAppend);
+    expect(firstBeforeAppend).toBeDefined();
+
+    const state = useStore.getState();
+    state.addMessage(state.currentRoomId, "assistant", "transcript line 29");
+    state.addMessage(state.currentRoomId, "assistant", "transcript line 30");
+
+    const afterAppend = plainText(chatPane.renderContent(80, 18));
+    expect(firstVisibleTranscriptLine(afterAppend)).toBe(firstBeforeAppend);
+    expect(afterAppend).not.toContain("transcript line 30");
+    expect(afterAppend).toContain("[↑ ");
   });
 
   test("ChatPane loading row advertises abort without overflowing narrow terminals", () => {


### PR DESCRIPTION
## Summary

- Add transcript scrollback controls in eliza-code ChatPane: Ctrl+Up/Down, PgUp/PgDn, and Home/End when the composer is empty or already scrolled.
- Keep the current scrollback viewport pinned when new transcript lines arrive while the user is scrolled up.
- Render multiple visible composer rows inside the input frame and preserve narrow-terminal width safety.
- Add issue evidence: `.github/issue-evidence/11294-tui-scrollback-composer.md`.

Part of #11294. This PR only covers scrollback paging and visible multiline composer rows; `/copy`, status bar, input-history recall, border-alignment, unknown slash command handling, and `--version` remain separate.

## Verification

Final synced run after rebasing onto `origin/develop`:

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install` - pass, no dependency changes
- `bun run verify` - pass

Focused checks run before the final root verify:

- `bun test --conditions eliza-source --pass-with-no-tests src/components/narrow-terminal.test.ts` - 12 pass, 83 assertions
- `bun test --conditions eliza-source --pass-with-no-tests src/components/narrow-terminal.test.ts src/components/chat-markdown.test.ts src/global-input.test.ts src/lib/agent-client.streaming.test.ts src/tool-transcript-events.test.ts src/lib/tool-transcript.test.ts src/lib/store.remove-message.test.ts` - 29 pass, 219 assertions
- `bunx @biomejs/biome check packages/examples/code/src/components/ChatPane.ts packages/examples/code/src/components/HelpOverlay.ts packages/examples/code/src/components/narrow-terminal.test.ts` - pass
- `bunx turbo run build --filter=@elizaos/example-code...` - pass, 97 successful
- `bun run --cwd packages/examples/code typecheck` - pass
- `bun run --cwd packages/examples/code build` - pass

## Evidence

- `.github/issue-evidence/11294-tui-scrollback-composer.md`
- Real-LLM trajectories: N/A - no model, prompt, action, provider, or agent decision behavior changed.
- Browser/native screenshots/video: N/A - terminal-only TUI render/input path; rendered terminal proof and VirtualTerminal tests are attached in evidence.
