### PR TITLE
fix(cloud): MCPs surface resolves the real session too

### DIFF
--- a/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-console-routes.spec.ts
@@ -16,7 +16,7 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sig`;
 }
 
-async function seedStewardToken(page: Page): Promise<void> {
+async function seedStewardToken(page: Page): Promise<string> {
   const token = makeJwt({
     sub: "cloud-console-route-smoke-user",
     email: "cloud-console-route-smoke@agent.local",
@@ -28,6 +28,7 @@ async function seedStewardToken(page: Page): Promise<void> {
     },
     { key: STEWARD_TOKEN_KEY, value: token },
   );
+  return token;
 }
 
 async function installAdminModerationRoutes(page: Page): Promise<void> {
@@ -61,16 +62,71 @@ async function installAdminModerationRoutes(page: Page): Promise<void> {
   });
 }
 
+async function installMcpRoutes(
+  page: Page,
+  expectedToken: string,
+): Promise<{ requestUrls: string[] }> {
+  const requestUrls: string[] = [];
+
+  await page.route("**/api/v1/mcps**", async (route) => {
+    const request = route.request();
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    expect(request.headers().authorization).toBe(`Bearer ${expectedToken}`);
+
+    const url = new URL(request.url());
+    const scope = url.searchParams.get("scope") ?? "own";
+    requestUrls.push(`${url.pathname}?scope=${scope}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        mcps: [],
+        total: 0,
+        scope,
+        filters: {},
+        pagination: { limit: 50, offset: 0 },
+      }),
+    });
+  });
+
+  await page.route("**/api/mcp/list", async (route) => {
+    const request = route.request();
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    requestUrls.push(new URL(request.url()).pathname);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        mcps: [],
+        total: 0,
+        categories: [],
+      }),
+    });
+  });
+
+  return { requestUrls };
+}
+
 test.describe("cloud console route wiring", () => {
   test.skip(
     !TEST_AUTH_ENABLED,
     "set VITE_PLAYWRIGHT_TEST_AUTH=true so StewardProvider renders the local test-auth route shell",
   );
 
+  let stewardToken: string;
+
   test.beforeEach(async ({ page }) => {
     installPageDiagnosticsGuard(page);
     await installDefaultAppRoutes(page);
-    await seedStewardToken(page);
+    stewardToken = await seedStewardToken(page);
   });
 
   test("registers /dashboard/analytics instead of falling through to the cloud 404", async ({
@@ -99,5 +155,27 @@ test.describe("cloud console route wiring", () => {
     ).toBeVisible();
     await expect(page.getByText("Sign in required")).toHaveCount(0);
     await expectNoPageDiagnostics(page, "dashboard admin persisted token gate");
+  });
+
+  test("MCPs route loads registry data with only a persisted Steward token", async ({
+    page,
+  }) => {
+    const mcpApi = await installMcpRoutes(page, stewardToken);
+
+    await page.goto("/dashboard/mcps", { waitUntil: "domcontentloaded" });
+
+    await expect(
+      page.getByText("You haven't registered any MCP servers yet."),
+    ).toBeVisible();
+    await expect
+      .poll(() => mcpApi.requestUrls)
+      .toEqual(
+        expect.arrayContaining([
+          "/api/v1/mcps?scope=own",
+          "/api/v1/mcps?scope=public",
+          "/api/mcp/list",
+        ]),
+      );
+    await expectNoPageDiagnostics(page, "dashboard MCPs persisted token gate");
   });
 });

--- a/packages/ui/src/cloud/mcps/McpsRoute.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.tsx
@@ -9,19 +9,20 @@
  * section gets it from `CloudSettingsSectionShell`.
  */
 
-import { useContext } from "react";
 import { PageHeaderProvider } from "../../cloud-ui";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
+import { useSessionAuth } from "../public-pages/lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
-import { LocalStewardAuthContext } from "../shell/StewardProvider";
 import { McpsView } from "./McpsView";
 
 /** The MCPs surface. Embeddable by the settings section and the standalone route. */
 export function McpsSurface() {
   const t = useCloudT();
-  const auth = useContext(LocalStewardAuthContext);
-  const ready = auth ? !auth.isLoading : false;
-  const authenticated = auth?.isAuthenticated ?? false;
+  // Console-wide session truth (SDK context OR persisted JWT) — the raw SDK
+  // context is empty on every full page load (MemoryStorage), which left this
+  // surface stuck on the loading state for signed-in users, same as the
+  // admin-gate bug fixed alongside.
+  const { ready, authenticated } = useSessionAuth();
 
   if (!ready || !authenticated) {
     return (

--- a/packages/ui/src/cloud/mcps/lib/use-mcps.ts
+++ b/packages/ui/src/cloud/mcps/lib/use-mcps.ts
@@ -8,11 +8,11 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { api } from "../../lib/api-client";
 import {
   authenticatedQueryKey,
   useAuthenticatedQueryGate,
-} from "../../api-keys/auth-gate";
-import { api } from "../../lib/api-client";
+} from "../../lib/auth-query";
 import type {
   BuiltinMcpListResponse,
   ListUserMcpsResponse,


### PR DESCRIPTION
One more instance of the #11456 class, pushed after that PR merged so it gets its own micro-PR: `McpsSurface` gated on the raw Steward SDK context, whose MemoryStorage session is empty on every full page load — a signed-in user landing on the MCPs surface after a reload sat on `Loading MCPs` forever.

This now resolves the surface through the console-wide `useSessionAuth` (SDK context OR persisted JWT), identical to the admin-gate fix in #11456. While verifying the PR, I found the MCP registry data hooks still used the raw-context-only `api-keys/auth-gate`; that would render the shell but leave `/api/v1/mcps` reads disabled after reload. This PR now moves MCP data hooks onto the shared persisted-token-aware `cloud/lib/auth-query` gate as well.

`use-join-session` was flagged in the same sweep but already ORs in a localStorage fallback — verified fine as-is, untouched.

Evidence:
- `bunx biome check packages/ui/src/cloud/mcps/McpsRoute.tsx packages/ui/src/cloud/mcps/lib/use-mcps.ts packages/app/test/ui-smoke/cloud-console-routes.spec.ts` — pass.
- `bun run --cwd packages/ui typecheck` — pass.
- `bun run --cwd packages/app typecheck` — pass.
- `VITE_PLAYWRIGHT_TEST_AUTH=true ELIZA_UI_SMOKE_PORT=2238 ELIZA_UI_SMOKE_API_PORT=32337 bunx playwright test --config playwright.ui-smoke.config.ts test/ui-smoke/cloud-console-routes.spec.ts --project=chromium` — 3 passed. The new MCP route case renders `/dashboard/mcps`, verifies owned/public/catalog MCP requests are issued with the persisted Steward bearer token, and checks browser diagnostics stay clean.
- `git fetch origin && git rebase origin/develop && bun install` — clean, artifacts current.
- `bun run verify` — pass: type-safety ratchet clean, Turbo typecheck/lint 483/483 tasks successful, build/typecheck/audit scripts passed, dist-path check passed for 28 consumer configs.

N/A: no model/action/provider prompt behavior changed; no real-LLM trajectory required. No visual styling changed; rendered route proof is the Playwright browser smoke above.
