### PR TITLE
fix(cloud): stop caching Redis clients across requests on Workers (rate limiter + A2A task store)

### DIFF
--- a/packages/cloud/shared/src/lib/cache/redis-factory.ts
+++ b/packages/cloud/shared/src/lib/cache/redis-factory.ts
@@ -63,3 +63,14 @@ export function hasRedisConfig(env?: RedisFactoryEnv): boolean {
   const restToken = e.KV_REST_API_TOKEN || e.UPSTASH_REDIS_REST_TOKEN;
   return !!(restUrl && restToken);
 }
+
+/**
+ * True inside workerd, where a TCP socket is bound to the I/O context of the
+ * request that opened it. A module-cached client built from
+ * {@link buildRedisClient} poisons the isolate there after its first request
+ * ("Cannot perform I/O on behalf of a different request") — cache clients
+ * ONLY when this is false; on Workers, build per call.
+ */
+export function isCloudflareWorkerRuntime(): boolean {
+  return typeof globalThis !== "undefined" && "WebSocketPair" in globalThis;
+}

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-redis-scoping.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-redis-scoping.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Pins the client scoping in the Redis rate limiter and the A2A task store:
+ * state must live in the BACKEND, not in a cached client object, so that
+ * per-call clients (the only safe shape on Cloudflare Workers, where a TCP
+ * socket belongs to the request that opened it) still see one shared window.
+ * MOCK_REDIS's backing map is process-global by design, which is what lets
+ * these tests assert cross-instance visibility.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { TaskStoreEntry } from "../services/a2a-task-store";
+
+const savedEnv: Record<string, string | undefined> = {};
+const REDIS_ENV_KEYS = [
+  "MOCK_REDIS",
+  "REDIS_URL",
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+] as const;
+let savedWebSocketPair: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  for (const key of REDIS_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.MOCK_REDIS = "1";
+  savedWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+  Object.defineProperty(globalThis, "WebSocketPair", {
+    configurable: true,
+    value: class WebSocketPair {},
+  });
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  if (savedWebSocketPair) {
+    Object.defineProperty(globalThis, "WebSocketPair", savedWebSocketPair);
+  } else {
+    Reflect.deleteProperty(globalThis, "WebSocketPair");
+  }
+  savedWebSocketPair = undefined;
+});
+
+describe("checkRateLimitRedis client scoping", () => {
+  test("successive checks accumulate in one sliding window across client instances", async () => {
+    const { checkRateLimitRedis } = await import("./rate-limit-redis");
+    const key = `scoping-test-${Math.random().toString(36).slice(2)}`;
+
+    const first = await checkRateLimitRedis(key, 60_000, 2);
+    const second = await checkRateLimitRedis(key, 60_000, 2);
+    const third = await checkRateLimitRedis(key, 60_000, 2);
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    // Only works if the two prior requests landed in the SAME backend window
+    // — i.e. the state outlives any single client instance.
+    expect(third.allowed).toBe(false);
+    expect(third.retryAfter).toBeGreaterThan(0);
+  });
+
+  test("does not reuse a stale Worker client when Redis config disappears", async () => {
+    const { checkRateLimitRedis } = await import("./rate-limit-redis");
+    const key = `stale-client-test-${Math.random().toString(36).slice(2)}`;
+
+    expect((await checkRateLimitRedis(key, 60_000, 1)).allowed).toBe(true);
+    delete process.env.MOCK_REDIS;
+
+    const second = await checkRateLimitRedis(key, 60_000, 1);
+
+    // A module-cached client would still see the first hit and block this.
+    // Workers must build a fresh client in the current request context instead.
+    expect(second.allowed).toBe(true);
+    expect(second.retryAfter).toBeUndefined();
+  });
+});
+
+describe("a2aTaskStore client scoping", () => {
+  test("set/get/delete round-trips across per-call client instances", async () => {
+    const { a2aTaskStoreService: a2aTaskStore } = await import("../services/a2a-task-store");
+    const taskId = `task-${Math.random().toString(36).slice(2)}`;
+    const now = new Date().toISOString();
+    const entry: TaskStoreEntry = {
+      task: {
+        id: taskId,
+        contextId: "ctx-1",
+        status: { state: "submitted", timestamp: now },
+      },
+      userId: "user-scoping",
+      organizationId: "org-scoping",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await a2aTaskStore.set(taskId, entry);
+    const fetched = await a2aTaskStore.get(taskId, "org-scoping");
+    expect(fetched?.task.id).toBe(taskId);
+
+    expect(await a2aTaskStore.delete(taskId, "org-scoping")).toBe(true);
+    expect(await a2aTaskStore.get(taskId, "org-scoping")).toBeNull();
+  });
+
+  test("does not reuse a stale Worker client when Redis config disappears", async () => {
+    const { a2aTaskStoreService: a2aTaskStore } = await import("../services/a2a-task-store");
+    const taskId = `stale-task-${Math.random().toString(36).slice(2)}`;
+    const now = new Date().toISOString();
+    const entry: TaskStoreEntry = {
+      task: {
+        id: taskId,
+        contextId: "ctx-1",
+        status: { state: "submitted", timestamp: now },
+      },
+      userId: "user-scoping",
+      organizationId: "org-scoping",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await a2aTaskStore.set(taskId, entry);
+    delete process.env.MOCK_REDIS;
+
+    await expect(a2aTaskStore.get(taskId, "org-scoping")).rejects.toThrow(
+      "Redis-backed shared storage is required",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-redis.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-redis.ts
@@ -12,27 +12,44 @@
  * @see ANALYTICS_PR_REVIEW_ANALYSIS.md - Issue #1
  */
 
-import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
+import {
+  buildRedisClient,
+  type CompatibleRedis,
+  isCloudflareWorkerRuntime,
+} from "../cache/redis-factory";
 import { logger } from "../utils/logger";
 
 /** Environment prefix — prevents rate-limit key collisions when dev/prod share the same Redis instance. */
 const ENV_PREFIX = process.env.ENVIRONMENT || "local";
 
-let redis: CompatibleRedis | null = null;
+let cachedRedis: CompatibleRedis | null = null;
+let loggedInit = false;
+let loggedMissing = false;
 
 function getRedisClient(): CompatibleRedis | null {
-  if (redis) return redis;
+  // On Workers the client is built PER CALL: a cached TCP socket belongs to
+  // the request that opened it and every later request fails with "Cannot
+  // perform I/O on behalf of a different request" (observed on the prod
+  // inference routes). Node keeps the persistent connection.
+  if (!isCloudflareWorkerRuntime() && cachedRedis) return cachedRedis;
 
-  redis = buildRedisClient();
-  if (!redis) {
-    logger.error(
-      "[Rate Limit Redis] Missing Redis credentials. Set REDIS_URL or KV_REST_API_URL/KV_REST_API_TOKEN",
-    );
+  const client = buildRedisClient();
+  if (!client) {
+    if (!loggedMissing) {
+      loggedMissing = true;
+      logger.error(
+        "[Rate Limit Redis] Missing Redis credentials. Set REDIS_URL or KV_REST_API_URL/KV_REST_API_TOKEN",
+      );
+    }
     return null;
   }
 
-  logger.info("[Rate Limit Redis] Redis client initialized");
-  return redis;
+  if (!loggedInit) {
+    loggedInit = true;
+    logger.info("[Rate Limit Redis] Redis client initialized");
+  }
+  if (!isCloudflareWorkerRuntime()) cachedRedis = client;
+  return client;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/a2a-task-store.ts
+++ b/packages/cloud/shared/src/lib/services/a2a-task-store.ts
@@ -10,7 +10,11 @@
  * - Organization-scoped task isolation
  */
 
-import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
+import {
+  buildRedisClient,
+  type CompatibleRedis,
+  isCloudflareWorkerRuntime,
+} from "../cache/redis-factory";
 import type { Task } from "../types/a2a";
 import { logger } from "../utils/logger";
 import { assertPersistentCloudStateConfigured } from "../utils/persistence-guard";
@@ -40,23 +44,30 @@ const TASK_ORG_INDEX_PREFIX = "a2a:org:";
 // Redis Client
 // ============================================================================
 
-let redis: CompatibleRedis | null = null;
-let initialized = false;
+let cachedRedis: CompatibleRedis | null = null;
+let loggedInit = false;
 
 function getRedisClient(): CompatibleRedis {
-  if (initialized && redis) return redis;
+  // On Workers the client is built PER CALL: a cached TCP socket belongs to
+  // the request that opened it and every later request fails with "Cannot
+  // perform I/O on behalf of a different request". Node keeps the persistent
+  // connection.
+  if (!isCloudflareWorkerRuntime() && cachedRedis) return cachedRedis;
 
-  redis = buildRedisClient();
-  if (!redis) {
+  const client = buildRedisClient();
+  if (!client) {
     assertPersistentCloudStateConfigured("A2A TaskStore", false);
     throw new Error(
       "[A2A TaskStore] Redis-backed shared storage is required; configure REDIS_URL or KV_* credentials before starting the service.",
     );
   }
 
-  logger.info("[A2A TaskStore] ✓ Redis task store initialized");
-  initialized = true;
-  return redis;
+  if (!loggedInit) {
+    loggedInit = true;
+    logger.info("[A2A TaskStore] ✓ Redis task store initialized");
+  }
+  if (!isCloudflareWorkerRuntime()) cachedRedis = client;
+  return client;
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Follow-up to #11457 (which fixed the relay store): the same module-scoped-Redis-client anti-pattern in the two remaining **live** modules.

1. **`rate-limit-redis.ts`** — the module-cached client is why prod inference routes log `[Rate Limit Redis] Error checking rate limit: Cannot perform I/O on behalf of a different request` (observed ×13 in 48h on `/api/v1/chat/completions` + `/embeddings`). Since `checkRateLimitRedis` catches errors and **falls open**, the practical effect is that the prod rate limiter mostly doesn't limit on warm isolates.
2. **`a2a-task-store.ts`** — identical module cache + `initialized` latch.

Both now build the client **per call inside workerd** (SocketRedis lazy-connects in the current request's I/O context — combined with #11457's generation-guarded self-heal this closes the class) and keep the persistent-connection module cache **on Node**, where it's the right thing (the rate limiter sits on the inference hot path; no reason to pay per-call reconnects outside workerd). The runtime check is exported from `redis-factory` next to `buildRedisClient`, so the condition lives with the factory it guards.

`credit-events-redis.ts` has the same shape but zero consumers outside its own module — flagged for a dead-code sweep rather than hardening dead code here.

## Evidence

- `bun test packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-redis-scoping.test.ts` — 19 passed.
  - The new scoping file now simulates workerd with a temporary `WebSocketPair` marker.
  - It verifies a 2-max sliding window accumulates across per-call clients.
  - It verifies stale Worker clients are not reused by removing Redis config after the first request: the rate limiter falls open instead of blocking from stale cached state, and A2A throws the required persistent-storage error instead of reading stale cached state.
- `bunx biome check packages/cloud/shared/src/lib/cache/redis-factory.ts packages/cloud/shared/src/lib/middleware/rate-limit-redis.ts packages/cloud/shared/src/lib/middleware/rate-limit-redis-scoping.test.ts packages/cloud/shared/src/lib/services/a2a-task-store.ts` — pass.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `git fetch origin && git rebase origin/develop && bun install` — clean, artifacts current.
- `bun run verify` — pass: type-safety ratchet clean, Turbo typecheck/lint 483/483 tasks successful, build/typecheck/audit scripts passed, dist-path check passed for 28 consumer configs.

N/A: no model/action/provider prompt behavior changed; no real-LLM trajectory required. No UI changed; screenshots/video not applicable. No DB migration or schema change.
