### PR TITLE
test(ui): cover MCPs persisted Steward session gate

### DIFF
--- a/packages/ui/src/cloud/mcps/McpsRoute.test.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("./McpsView", () => ({
+  McpsView: () => <div data-testid="mcps-view">MCPs view</div>,
+}));
+
+import { McpsSurface } from "./McpsRoute";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
+}
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+let storage: Storage;
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("McpsSurface session resolution", () => {
+  it("renders the MCPs view when the session exists only as the persisted JWT", () => {
+    storage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    render(<McpsSurface />);
+
+    expect(screen.getByTestId("mcps-view")).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Loading MCPs" })).toBeNull();
+  });
+
+  it("keeps the surface gated when no persisted session exists", () => {
+    render(<McpsSurface />);
+
+    expect(screen.getByRole("status", { name: "Loading MCPs" })).toBeTruthy();
+    expect(screen.queryByTestId("mcps-view")).toBeNull();
+  });
+
+  it("does not accept an expired persisted JWT", () => {
+    storage.setItem(
+      STEWARD_TOKEN_KEY,
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+    );
+
+    render(<McpsSurface />);
+
+    expect(screen.getByRole("status", { name: "Loading MCPs" })).toBeTruthy();
+    expect(screen.queryByTestId("mcps-view")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused `McpsSurface` jsdom regression test for the #11463 reload path.
- Verifies that a valid persisted Steward JWT renders the MCPs view even with no Steward provider mounted.
- Verifies missing and expired persisted sessions remain gated on the loading state.

Relates to #11463.

## Evidence
- `bun install --frozen-lockfile --ignore-scripts` completed in the worktree, lockfile unchanged.
- `node packages/shared/scripts/generate-keywords.mjs --target ts` generated required local keyword data before tests.
- `bun run --cwd packages/ui test src/cloud/mcps/McpsRoute.test.tsx` passed: 3 tests.
- `bunx @biomejs/biome check packages/ui/src/cloud/mcps/McpsRoute.test.tsx` passed.
- `bun run --cwd packages/contracts build && bun run --cwd packages/ui typecheck` passed.
- `bun run verify` passed: 483 Turbo tasks plus build/typecheck/script/test-realness/dist-path audits.

## Evidence rows
- Frontend logs/screenshots/video: N/A — test-only change, no runtime UI implementation or visual output changed in this PR.
- Backend logs: N/A — test-only UI coverage, no backend path changed.
- Real-LLM trajectories: N/A — no model/prompt/action/provider behavior.
- DB/domain artifacts: N/A — no schema, data, memory, scheduled-task, wallet, or generated user artifact change.