### PR TITLE
fix(orchestrator): re-land #11243 turn-timeout detach + Discord room routing (reverted by #11271)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { resolveInitialTaskPromptTimeoutMs } from "../services/acp-service.ts";
+
+describe("background initial task prompt timeout", () => {
+  it("detaches spawned initial tasks from the service/chat-turn timeout when no explicit timeout is set", () => {
+    expect(resolveInitialTaskPromptTimeoutMs(undefined)).toBe(0);
+  });
+
+  it("preserves explicit caller timeouts", () => {
+    expect(resolveInitialTaskPromptTimeoutMs(120_000)).toBe(120_000);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { readOrigin } from "../services/sub-agent-router.ts";
+import type { SessionInfo } from "../services/types.ts";
+
+const ORIGIN_ROOM = "11111111-1111-4111-8111-111111111111";
+const TASK_ROOM = "22222222-2222-4222-8222-222222222222";
+const MSG = "33333333-3333-4333-8333-333333333333";
+
+function session(metadata: Record<string, unknown>): SessionInfo {
+  return {
+    id: "sess-1",
+    agentType: "codex",
+    workdir: "/tmp/work",
+    status: "ready",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata,
+  } as unknown as SessionInfo;
+}
+
+describe("sub-agent Discord reply routing", () => {
+  it("keeps origin.roomId pointed at the user-facing Discord room, not the internal task room", () => {
+    const origin = readOrigin(
+      session({
+        originRoomId: ORIGIN_ROOM,
+        taskRoomId: TASK_ROOM,
+        roomId: TASK_ROOM,
+        messageId: MSG,
+        source: "discord",
+        label: "build game",
+      }),
+    );
+
+    expect(origin?.roomId).toBe(ORIGIN_ROOM);
+    expect(origin?.taskRoomId).toBe(TASK_ROOM);
+  });
+
+  it("falls back to legacy roomId when no distinct origin room was persisted", () => {
+    const origin = readOrigin(
+      session({
+        roomId: ORIGIN_ROOM,
+        messageId: MSG,
+        source: "discord",
+      }),
+    );
+
+    expect(origin?.roomId).toBe(ORIGIN_ROOM);
+    expect(origin?.taskRoomId).toBe(ORIGIN_ROOM);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -159,6 +159,16 @@ const ORPHAN_RESUME_STATUSES: ReadonlySet<string> = new Set([
 ]);
 const ORPHAN_RESUME_PROMPT =
   "[System] Your previous turn was interrupted by a runtime restart. Continue where you left off on the original task and report results as usual.";
+// Background sub-agent initial tasks are fire-and-forget from the originating
+// chat turn. When no action-level timeout is explicit, do not bind the
+// session/prompt request to the ACP service default (often configured to the
+// connector message budget, e.g. 120s). User cancel / shutdown still flow
+// through cancelSession()/stopSession(), and explicit timeouts remain honored.
+export function resolveInitialTaskPromptTimeoutMs(
+  explicitTimeoutMs: number | undefined,
+): number | undefined {
+  return explicitTimeoutMs ?? 0;
+}
 const DEFAULT_AGENTS: AgentType[] = ["elizaos", "codex", "claude", "opencode"];
 // Path segment the app-core coding-account bridge uses for per-account Codex
 // homes (`<stateDir>/auth/_codex-home/<accountId>`). buildEnv keys off this
@@ -686,7 +696,7 @@ export class AcpService extends Service {
           (opts.metadata as Record<string, unknown> | undefined)
             ?.keepAliveAfterComplete === true;
         void this.sendPrompt(id, initialTask ?? "", {
-          timeoutMs: opts.timeoutMs,
+          timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
           model: opts.model,
         })
           .catch((err: unknown) => {
@@ -759,7 +769,7 @@ export class AcpService extends Service {
         (opts.metadata as Record<string, unknown> | undefined)
           ?.keepAliveAfterComplete === true;
       void this.sendPrompt(id, initialTask ?? "", {
-        timeoutMs: opts.timeoutMs,
+        timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
         model: opts.model,
       })
         .catch((err: unknown) => {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1419,14 +1419,15 @@ export class SubAgentRouter extends Service {
       const delivered = await sendToTarget(
         {
           source,
-          roomId: target.roomId,
+          roomId: origin.roomId,
         },
         threadedResponse,
       ).catch((err) => {
         this.log("warn", "sub-agent reply delivery failed", {
           sessionId,
           source,
-          roomId: target.roomId,
+          roomId: origin.roomId,
+          targetRoomId: target.roomId,
           error: err instanceof Error ? err.message : String(err),
         });
         return undefined;
@@ -1879,7 +1880,9 @@ function publicPreferredUrls(urls: string[]): string[] {
 }
 
 interface OriginInfo {
+  /** Original user-facing room, e.g. the Discord channel-backed room. */
   roomId: UUID;
+  /** Internal task/swarm room minted for sub-agent coordination. */
   taskRoomId: UUID;
   worktreeRoomId?: UUID;
   swarmRooms: SwarmRoomTarget[];
@@ -1932,11 +1935,12 @@ export function spawnRootIdFromMeta(
   );
 }
 
-function readOrigin(session: SessionInfo): OriginInfo | null {
+export function readOrigin(session: SessionInfo): OriginInfo | null {
   const meta = session.metadata as Record<string, unknown> | undefined;
   if (!meta) return null;
   const taskRoomId = pickUuid(meta.taskRoomId) ?? pickUuid(meta.roomId);
-  const roomId = taskRoomId ?? pickUuid(meta.roomId);
+  const roomId =
+    pickUuid(meta.originRoomId) ?? pickUuid(meta.sourceRoomId) ?? taskRoomId;
   if (!roomId || !taskRoomId) return null;
   const worktreeRoomId = pickUuid(meta.worktreeRoomId);
   const swarmRooms = normalizeSwarmRooms(


### PR DESCRIPTION
## What

Re-lands #11243 ("fix(orchestrator): detach coding-agent turns from chat timeout", squash `87a04565a8`), which was silently reverted by #11271 (squash `5b714c74e6`, merged from a stale base). Part of the revert sweep tracked in #11419.

## What #11271 reverted

- **Bug 1 (fully reverted):** `AcpService.spawnSession` background `initialTask` prompts went back to passing raw `opts.timeoutMs` at both call sites, re-binding fire-and-forget coding-agent turns to the implicit 120s chat-turn timeout. The `resolveInitialTaskPromptTimeoutMs` guard was deleted.
- **Bug 2 (partially reverted):** sub-agent reply delivery in `sub-agent-router.ts` went back to `target.roomId` (internal task room) instead of `origin.roomId` (user-facing room), which breaks Discord with "Could not resolve Discord channel ID for room \<task-room-uuid\>". The `readOrigin` preference for `originRoomId`/`sourceRoomId` was also lost.
- **Both regression test files were deleted:** `initial-task-timeout.test.ts` and `sub-agent-discord-routing.test.ts`.

## How this re-land was done

Surgically restored on top of current `develop` tip, NOT via blind checkout, preserving the later `acp-service.ts` changes (`82f7bfd6cb` TOCTOU busy-guard, `afabc5d03d` landlock fallback):

- `src/services/acp-service.ts`: re-add `resolveInitialTaskPromptTimeoutMs()` (explicit timeout honored, otherwise `0` so background turns detach from the connector message budget); apply at both `initialTask` `sendPrompt` call sites. Cancel/shutdown still flow through `cancelSession()`/`stopSession()`.
- `src/services/sub-agent-router.ts`: reply callback delivers to `origin.roomId` with `targetRoomId` kept in the failure log; `readOrigin` prefers `originRoomId ?? sourceRoomId ?? taskRoomId` and is exported for the test; `OriginInfo` doc comments restored.
- Restored both test files verbatim from `87a04565a8`.

## Testing

- `bunx vitest run src/__tests__/initial-task-timeout.test.ts src/__tests__/sub-agent-discord-routing.test.ts` from the plugin dir: **2 files, 4/4 tests pass**.
- `bunx biome check` on all 4 touched files: clean.
- `codex review --uncommitted`: no regressions found ("timeout helper is applied only to fire-and-forget initial prompts while explicit timeouts remain honored, and the routing change aligns the connector callback with the persisted origin room metadata").
- Verified the restored router logic matches `87a04565a8`'s intent line-for-line on the `origin.roomId`/`originRoomId`/`sourceRoomId` references.

Refs: #11419 (tracker), #11243 (original), #11271 (reverting merge)

— [sol-orch]
