### PR TITLE
perf(ui): lazy-load settings sections + Streamdown render stack (#11351)

### DIFF
--- a/packages/benchmarks/loadperf/budgets.json
+++ b/packages/benchmarks/loadperf/budgets.json
@@ -6,7 +6,7 @@
     "largestChunkBrotliBytes": 2300000,
     "maxDuplicateLibBytes": 1200000,
     "perChunkWarnBrotliBytes": 600000,
-    "eagerGraphBrotliBytes": 1500000
+    "eagerGraphBrotliBytes": 1374505
   },
   "boot": {
     "coldReadyMs": 25000,

--- a/packages/ui/src/cloud-ui/components/ai-elements/memoized-chat-message.tsx
+++ b/packages/ui/src/cloud-ui/components/ai-elements/memoized-chat-message.tsx
@@ -6,8 +6,7 @@
 "use client";
 
 import { Check, Copy, Loader2, Square, Volume2 } from "lucide-react";
-import { memo, useEffect } from "react";
-import { Streamdown } from "streamdown";
+import { lazy, memo, type ReactNode, Suspense, useEffect } from "react";
 import { Button } from "../../../components/ui/button";
 import Image from "../../runtime/image";
 import { type ChatMediaAttachment, ContentType } from "../../types/chat-media";
@@ -16,6 +15,41 @@ import {
   useReasoningTypewriter,
   useTypewriterText,
 } from "./hooks/use-typewriter-text";
+
+/**
+ * Plain-text fallback used when the lazy `streamdown` chunk fails to load
+ * (#11351). Renders the raw markdown source as pre-wrapped text so a stale
+ * deploy or offline/transient chunk-load rejection degrades to the same
+ * unstyled text the Suspense pending fallback shows — never a thrown error that
+ * blanks the message.
+ */
+function StreamdownTextFallback({ children }: { children?: ReactNode }) {
+  return <span className="whitespace-pre-wrap">{children}</span>;
+}
+
+/**
+ * Lazily load the markdown/shiki/katex render stack (#11351). The `streamdown`
+ * dependency (~372 KB) previously sat on the eager boot graph via a top-level
+ * import even though it only renders once the first rich message appears. A
+ * `React.lazy` boundary defers the whole stack until a message body actually
+ * renders; the Suspense fallback below shows the raw message text immediately,
+ * preserving the existing "show content now, upgrade to markdown when ready"
+ * behavior. `streamdown` is ESM-only with a named `Streamdown` export, so it is
+ * normalized to the `default` shape `lazy()` expects. A `.catch` resolves the
+ * import to the plain-text fallback instead of rejecting, so a chunk-load
+ * failure never throws out of `Suspense` and blanks the chat message.
+ */
+const Streamdown = lazy(() =>
+  import("streamdown")
+    .then((m) => ({ default: m.Streamdown }))
+    .catch(() => ({
+      // Cast keeps the two `lazy()` resolution branches assignable: on
+      // chunk-load failure we render the raw-text fallback in place of the
+      // real component, which only ever receives `children` here.
+      default:
+        StreamdownTextFallback as unknown as typeof import("streamdown").Streamdown,
+    })),
+);
 
 /**
  * Normalize markdown list formatting.
@@ -398,11 +432,23 @@ function ChatMessageComponent(props: MemoizedChatMessageProps) {
                   <div
                     className={`streaming-text-wrapper text-[15px] leading-relaxed text-white/90 prose prose-invert prose-sm max-w-none prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-headings:my-3 prose-pre:my-2 break-words [&_pre]:overflow-x-auto [&_pre_code]:whitespace-pre-wrap [&_pre_code]:break-words ${isStreamingMessage ? "streaming-text-content" : "message-text-complete"}`}
                   >
-                    <Streamdown>
-                      {normalizeMarkdownLists(
-                        isStreamingMessage ? displayText : message.content.text,
-                      )}
-                    </Streamdown>
+                    <Suspense
+                      fallback={
+                        <span className="whitespace-pre-wrap">
+                          {isStreamingMessage
+                            ? displayText
+                            : message.content.text}
+                        </span>
+                      }
+                    >
+                      <Streamdown>
+                        {normalizeMarkdownLists(
+                          isStreamingMessage
+                            ? displayText
+                            : message.content.text,
+                        )}
+                      </Streamdown>
+                    </Suspense>
                     {/* Elegant blinking cursor for streaming messages */}
                     {isStreamingMessage && (
                       <span

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -1,7 +1,7 @@
 import { isViewVisible } from "@elizaos/core";
 import { ArrowLeft } from "lucide-react";
 import type * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { listExtraSettingsGroups } from "../../cloud/settings/cloud-settings-group";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
@@ -188,6 +188,20 @@ function SectionBackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
+/**
+ * Loading placeholder for a lazily-loaded section body (#11351). Deliberately
+ * minimal — a single muted, `aria-busy` line so the split is visually quiet and
+ * never shifts the section header or nav rail while the chunk resolves.
+ */
+function SettingsSectionLoading() {
+  return (
+    <div
+      aria-busy="true"
+      className="flex min-h-[6rem] items-center text-sm text-muted"
+    />
+  );
+}
+
 /** The active section's body: optional back, header (icon + title), content. */
 function SettingsSectionContent({
   section,
@@ -227,7 +241,11 @@ function SettingsSectionContent({
             />
           )}
         >
-          <Component />
+          {/* Section bodies are `React.lazy` (#11351); the boundary keeps the
+              split transparent with a minimal, unobtrusive loading state. */}
+          <Suspense fallback={<SettingsSectionLoading />}>
+            <Component />
+          </Suspense>
         </ErrorBoundary>
       </div>
     </div>

--- a/packages/ui/src/components/settings/settings-section-registry.ts
+++ b/packages/ui/src/components/settings/settings-section-registry.ts
@@ -1,6 +1,6 @@
 import type { ViewKind } from "@elizaos/core";
 import type { LucideIcon } from "lucide-react";
-import type { ComponentType } from "react";
+import type { ComponentType, LazyExoticComponent } from "react";
 import type { SettingsSectionGroup } from "./settings-section-meta";
 
 /**
@@ -69,7 +69,12 @@ export interface SettingsSectionDef {
    * toggles. See `ViewKind` in `@elizaos/core`.
    */
   viewKind?: ViewKind;
-  Component: ComponentType;
+  /**
+   * The section body. Accepts a plain component or a `React.lazy` wrapper so
+   * sections can be code-split off the eager boot graph (#11351); the Settings
+   * view renders it behind a `<Suspense>` boundary either way.
+   */
+  Component: ComponentType | LazyExoticComponent<ComponentType>;
 }
 
 interface SettingsSectionRegistryStore {

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -20,30 +20,12 @@ import {
   Wallpaper,
   Webhook,
 } from "lucide-react";
-import type { ComponentType } from "react";
+import { type ComponentType, type LazyExoticComponent, lazy } from "react";
 import { registerCloudConnectorsSettingsSection } from "../../cloud/connectors";
 import {
   CLOUD_SETTINGS_GROUP_ID,
   registerSettingsGroup,
 } from "../../cloud/settings/cloud-settings-group";
-import { MyRuntimesContainer } from "../cockpit/MyRuntimesContainer";
-import { ReleaseCenterView } from "../pages/ReleaseCenterView";
-import { AdvancedSection } from "./AdvancedSection";
-import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
-import { AppPermissionsSection } from "./AppPermissionsSection";
-import { AppsManagementSection } from "./AppsManagementSection";
-import { BackgroundSettingsSection } from "./BackgroundSettingsSection";
-import { CapabilitiesSection } from "./CapabilitiesSection";
-import { CloudAgentsSection } from "./CloudAgentsSection";
-import { CloudOverviewSection } from "./CloudOverviewSection";
-import { ConnectorsSection } from "./ConnectorsSection";
-import { IdentitySettingsSection } from "./IdentitySettingsSection";
-import { PermissionsSection } from "./PermissionsSection";
-import { ProviderSwitcher } from "./ProviderSwitcher";
-import { RemotePluginHostSection } from "./RemotePluginHostSection";
-import { RuntimeSettingsSection } from "./RuntimeSettingsSection";
-import { SecretsManagerSection } from "./SecretsManagerSection";
-import { SecuritySettingsSection } from "./SecuritySettingsSection";
 import {
   SETTINGS_GROUP_LABEL,
   SETTINGS_GROUP_ORDER,
@@ -57,8 +39,108 @@ import {
   type SettingsSectionHue,
   type SettingsSectionTone,
 } from "./settings-section-registry";
-import { VoiceSectionMount } from "./VoiceSectionMount";
-import { WalletRpcSection } from "./WalletRpcSection";
+
+/**
+ * Section bodies are lazy-loaded (#11351): the settings-section registry used to
+ * pull ~15 section components (Identity, ProviderSwitcher, Connectors, Runtime,
+ * Advanced, ReleaseCenter, …) into the eager boot graph through the
+ * `@elizaos/ui/browser` barrel. `SettingsView` is already lazy, but the whole
+ * registry rode along on the initial chunk. Wrapping each `Component` in
+ * `React.lazy` moves those bodies onto their own on-demand chunks; the active
+ * section's `<Component/>` render in `SettingsView` sits behind a `<Suspense>`
+ * boundary so the split is transparent. Named exports are normalized to the
+ * `default` shape `lazy()` expects.
+ */
+const IdentitySettingsSection = lazy(() =>
+  import("./IdentitySettingsSection").then((m) => ({
+    default: m.IdentitySettingsSection,
+  })),
+);
+const ProviderSwitcher = lazy(() =>
+  import("./ProviderSwitcher").then((m) => ({ default: m.ProviderSwitcher })),
+);
+const VoiceSectionMount = lazy(() =>
+  import("./VoiceSectionMount").then((m) => ({ default: m.VoiceSectionMount })),
+);
+const CapabilitiesSection = lazy(() =>
+  import("./CapabilitiesSection").then((m) => ({
+    default: m.CapabilitiesSection,
+  })),
+);
+const AppsManagementSection = lazy(() =>
+  import("./AppsManagementSection").then((m) => ({
+    default: m.AppsManagementSection,
+  })),
+);
+const ConnectorsSection = lazy(() =>
+  import("./ConnectorsSection").then((m) => ({ default: m.ConnectorsSection })),
+);
+const RuntimeSettingsSection = lazy(() =>
+  import("./RuntimeSettingsSection").then((m) => ({
+    default: m.RuntimeSettingsSection,
+  })),
+);
+const AppearanceSettingsSection = lazy(() =>
+  import("./AppearanceSettingsSection").then((m) => ({
+    default: m.AppearanceSettingsSection,
+  })),
+);
+const BackgroundSettingsSection = lazy(() =>
+  import("./BackgroundSettingsSection").then((m) => ({
+    default: m.BackgroundSettingsSection,
+  })),
+);
+const RemotePluginHostSection = lazy(() =>
+  import("./RemotePluginHostSection").then((m) => ({
+    default: m.RemotePluginHostSection,
+  })),
+);
+const WalletRpcSection = lazy(() =>
+  import("./WalletRpcSection").then((m) => ({ default: m.WalletRpcSection })),
+);
+const ReleaseCenterView = lazy(() =>
+  import("../pages/ReleaseCenterView").then((m) => ({
+    default: m.ReleaseCenterView,
+  })),
+);
+const AdvancedSection = lazy(() =>
+  import("./AdvancedSection").then((m) => ({ default: m.AdvancedSection })),
+);
+const AppPermissionsSection = lazy(() =>
+  import("./AppPermissionsSection").then((m) => ({
+    default: m.AppPermissionsSection,
+  })),
+);
+const PermissionsSection = lazy(() =>
+  import("./PermissionsSection").then((m) => ({
+    default: m.PermissionsSection,
+  })),
+);
+const SecretsManagerSection = lazy(() =>
+  import("./SecretsManagerSection").then((m) => ({
+    default: m.SecretsManagerSection,
+  })),
+);
+const SecuritySettingsSection = lazy(() =>
+  import("./SecuritySettingsSection").then((m) => ({
+    default: m.SecuritySettingsSection,
+  })),
+);
+const CloudOverviewSection = lazy(() =>
+  import("./CloudOverviewSection").then((m) => ({
+    default: m.CloudOverviewSection,
+  })),
+);
+const CloudAgentsSection = lazy(() =>
+  import("./CloudAgentsSection").then((m) => ({
+    default: m.CloudAgentsSection,
+  })),
+);
+const MyRuntimesContainer = lazy(() =>
+  import("../cockpit/MyRuntimesContainer").then((m) => ({
+    default: m.MyRuntimesContainer,
+  })),
+);
 
 export {
   getSettingsSection,
@@ -106,7 +188,7 @@ interface SectionVisual {
   developerOnly?: boolean;
   /** Hide on the cloud mobile build (no host machine). */
   hideOnCloud?: boolean;
-  Component: ComponentType;
+  Component: ComponentType | LazyExoticComponent<ComponentType>;
 }
 
 const SECTION_VISUALS: Record<string, SectionVisual> = {


### PR DESCRIPTION
Ships the two ranked eager-boot lazy-load wins from the #10724 perf epic (Scope A, frontend bundle). Closes the acceptance criteria in #11351 with real before/after numbers.

## What / why

**Opt A — settings-sections registry (~570 KB) was eager.**
`packages/ui/src/components/settings/settings-sections.ts` held ~15 direct `Component:` refs (Identity, ProviderSwitcher, Connectors, Runtime, Advanced, ReleaseCenter, …) pulled through the `@elizaos/ui/browser` barrel into the eager graph. `SettingsView` is already lazy, but the whole section registry rode along on the initial chunk.

- Each section `Component` ref is now wrapped in `React.lazy()` (named → `default` normalized).
- The active section's `<Component/>` render in `SettingsView.tsx` sits behind a `<Suspense>` boundary with a minimal, unobtrusive `aria-busy` placeholder that never shifts the section header or nav rail.
- The registry `Component` type widens to `ComponentType | LazyExoticComponent<ComponentType>`.

**Opt B — markdown/shiki/katex render stack (~372 KB) was eager.**
`packages/ui/src/cloud-ui/components/ai-elements/memoized-chat-message.tsx` did a top-level `import { Streamdown } from "streamdown"`, loading the rich-markdown stack before the first rich message renders.

- Converted to `React.lazy()`; the `<Suspense>` fallback shows the raw message text immediately, preserving the existing "show content now, upgrade to markdown when ready" behavior and memoization.
- The lazy loader `.catch()`es a chunk-load failure and resolves to a plain-text fallback component, so a stale-deploy/offline chunk rejection degrades to raw text instead of throwing out of `Suspense` and blanking the message.

## Measurements (real, not speculative)

Clean `bun run --cwd packages/app build:web`, same config before and after, measured with `packages/benchmarks/loadperf/bundle-kpi.mjs`:

| metric (brotli) | before | after | delta |
| --- | --- | --- | --- |
| eager first-paint graph | 3229.6 KB | 3107.1 KB | **-122.6 KB** |
| initial entry chunk | 3064.8 KB | 2936.7 KB | **-128.1 KB** |
| lazy (on-demand) | 1845.9 KB | 1995.9 KB | +150.0 KB (moved off critical path) |
| total assets | 5075.6 KB | 5103.0 KB | +27.4 KB (per-chunk split overhead) |
| asset count | 356 | 378 | +22 lazy chunks |

~150 KB of eager weight is moved onto on-demand chunks; the small total bump (+27 KB) is expected code-split overhead, off the first-paint path. This is the ratchet-down win the epic asks for.

> Note on absolute numbers: this measurement was taken with `build:web` under `ELIZA_WEB_ABSOLUTE_BASE=1`, which keeps vendor-crypto/three on the eager path, so the absolute eager figure differs from BASELINE.md's clean-build 1202 KB. What's load-bearing here is the **same-config before/after delta** (-122.6 KB), which is directly attributable to this change.

Ratcheted the loadperf `eagerGraphBrotliBytes` budget down by the realized saving: `1,500,000 → 1,374,505`.

## Tests / verification

- `vitest`: `SettingsView.test.tsx`, `register-cloud-settings.test.ts`, `App.navigate-view-wiring.test.tsx`, `will-change-gate.test.ts` all pass.
- `biome check`: clean on all touched files.
- `tsc --noEmit -p packages/ui/tsconfig.json`: **no new errors in the touched files** (pre-existing cross-package dependency-resolution errors in this checkout are unrelated).
- `verify-chunk-safety.mjs`: OK (bn.js/crypto graph confined to lazy vendor chunks).
- **codex-reviewed** (gpt-5.5): flagged one P2 — a lazy `streamdown` chunk-load failure could bubble past `Suspense` and blank the message. Fixed with the `.catch()` → plain-text fallback described above.

Did **not** touch `packages/app/vite.config.ts`, `packages/app/index.html`, `packages/ui/src/api/client-base.ts`, binaries, or `bun.lock`.

I could not run the `audit:app` Playwright visual loop in this environment (needs browsers); the changes are behavior-preserving (same components render, just split), the Suspense fallbacks match existing loading patterns, and the render path is exercised by `SettingsView.test.tsx`.

— [sol-orch]
