### PR TITLE
fix(cloud): single-flight chat abort billing

### DIFF
--- a/.github/issue-evidence/11460-chat-abort-billing/README.md
+++ b/.github/issue-evidence/11460-chat-abort-billing/README.md
@@ -1,0 +1,55 @@
+# #11460 Chat Abort Billing Evidence
+
+Captured on Windows 11 in worktree
+`C:\Users\Administrator\.codex\worktrees\4a18\eliza-11460-chat-billing` on
+2026-07-02.
+
+## What Changed
+
+- `handleStreamingRequest` now single-flights all streaming settlement outcomes
+  (`onFinish`, `onAbort`, `onError`, and the `ReadableStream` catch path) so an
+  aborted request can run `billUsage` at most once.
+- The stream catch path treats a partial-settle abort as a client abort only
+  when `req.signal.aborted === true`; an AbortError-shaped provider failure now
+  refunds instead of charging partial usage.
+- Partial abort billing now writes usage analytics and an `aiBillingRecords`
+  audit record, matching the successful streaming/non-streaming billing paths.
+- Affiliate earnings source IDs in `billUsage` / `billFlatUsage` are
+  deterministic when `BillingContext.requestId` is present, so
+  `dedupeBySourceId` can suppress duplicate cashable earnings.
+
+## Commands Run
+
+```bash
+bunx @biomejs/biome@2.5.2 check packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts packages/cloud/shared/src/lib/services/ai-billing.ts packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
+bun run --cwd packages/cloud/api test chat-completions-streaming-credit-leak
+bun run --cwd packages/cloud/shared test src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
+git diff --check
+```
+
+## Results
+
+- Focused Biome check: passed on all four touched files.
+- `chat-completions-streaming-credit-leak`: 9 passed, 0 failed, 68 assertions.
+  New coverage proves:
+  - `onAbort` plus cancelled-controller catch settles once and calls `billUsage`
+    once.
+  - AbortError-shaped provider failure without request abort refunds to zero and
+    does not call `billUsage`.
+  - Request-signal abort still bills delivered partial output and writes usage +
+    audit records.
+- `ai-billing-anon-affiliate`: 3 passed, 0 failed, 12 assertions. New coverage
+  proves repeated paying-org calls with the same `requestId` use the same
+  affiliate `sourceId` with `dedupeBySourceId: true`.
+- `git diff --check`: passed.
+
+## Limitations / N/A
+
+- Screenshots and screen recording are N/A: this is a backend billing race fix
+  with no UI surface.
+- Full package typecheck was attempted from this sparse Windows worktree, but it
+  is not a clean signal here: `packages/cloud/shared typecheck` fails before the
+  touched files on missing sparse workspace sources/generated artifacts such as
+  `@elizaos/plugin-cloud-apps`, `@elizaos/prompts`, `@elizaos/contracts`, and
+  validation keyword data. The focused tests above exercise the changed runtime
+  paths directly.

--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -33,6 +33,7 @@ const aiActual = require("ai") as Record<string, unknown>;
 import { estimateTokens } from "@/lib/pricing";
 import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as aiBillingRecordsActual from "@/lib/services/ai-billing-records";
 
 // The REAL settler — explicitly NOT mocked. This is the component under test.
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
@@ -88,9 +89,20 @@ const billUsage = mock(async (_context: unknown, usage: unknown) => {
     markupApplied: true,
   };
 });
+const recordUsageAnalytics = mock(async () => ({ id: "usage-1" }));
 mock.module("@/lib/services/ai-billing", () => ({
   ...aiBillingActual,
   billUsage,
+  recordUsageAnalytics,
+}));
+
+const aiBillingRecord = mock(async () => ({ id: "billing-record-1" }));
+mock.module("@/lib/services/ai-billing-records", () => ({
+  ...aiBillingRecordsActual,
+  aiBillingRecordsService: {
+    ...aiBillingRecordsActual.aiBillingRecordsService,
+    record: aiBillingRecord,
+  },
 }));
 
 // Import the route AFTER the mocks so it binds to the stubs.
@@ -103,6 +115,10 @@ afterAll(() => {
   mock.module("ai", () => aiActual);
   mock.module("@/lib/providers/language-model", () => languageModelActual);
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+  mock.module(
+    "@/lib/services/ai-billing-records",
+    () => aiBillingRecordsActual,
+  );
 });
 
 /**
@@ -186,6 +202,8 @@ function callStreaming(
 beforeEach(() => {
   streamText.mockClear();
   billUsage.mockClear();
+  recordUsageAnalytics.mockClear();
+  aiBillingRecord.mockClear();
   streamTextImpl = null;
 });
 
@@ -315,9 +333,10 @@ describe("streaming chat — client abort settles delivered usage", () => {
     expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
   });
 
-  test("abort-like stream failure after text deltas cannot win with settle(0)", async () => {
+  test("request-signal abort after text deltas settles partial usage", async () => {
     const ledger = makeLedgerReservation(100, 0.015);
     const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
     const estimatedInputTokens = 8;
     const deliveredText = "sent before disconnect";
     const expectedCost =
@@ -331,17 +350,95 @@ describe("streaming chat — client abort settles delivered usage", () => {
           id: "text-1",
           text: deliveredText,
         };
+        controller.abort();
         throw new DOMException("The operation was aborted.", "AbortError");
       })(),
     });
 
-    const res = await callStreaming(settle, { estimatedInputTokens });
+    const res = await callStreaming(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
     const body = await res.text();
 
     expect(body).toContain(deliveredText);
     expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(aiBillingRecord).toHaveBeenCalledTimes(1);
     expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
     expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+  });
+
+  test("AbortError-shaped provider failure without request abort refunds and does not bill", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const deliveredText = "sent before provider failure";
+
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield {
+          type: "text-delta",
+          id: "text-1",
+          text: deliveredText,
+        };
+        throw new DOMException("upstream connection aborted", "AbortError");
+      })(),
+    });
+
+    const res = await callStreaming(settle);
+    const body = await res.text();
+
+    expect(body).toContain(deliveredText);
+    expect(body).toContain('"error"');
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(recordUsageAnalytics).not.toHaveBeenCalled();
+    expect(aiBillingRecord).not.toHaveBeenCalled();
+  });
+
+  test("onAbort plus cancelled-controller catch single-flights partial settlement", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    let onAbortPromise: Promise<unknown> | undefined;
+
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          controller.abort();
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          throw new DOMException("The operation was aborted.", "AbortError");
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
+    await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(aiBillingRecord).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
   });
 });
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -57,6 +57,7 @@ import {
 } from "@/lib/providers/language-model";
 import {
   type AIUsage,
+  type BillingContext,
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
@@ -140,6 +141,42 @@ function buildProviderBillingFields(
       process.env.VAST_BASE_URL ??
       null,
   };
+}
+
+function buildChatBillingContext(params: {
+  user: { id: string; organization_id: string };
+  apiKey: { id: string } | null;
+  model: string;
+  provider: string;
+  billingSource: PricingBillingSource;
+  requestId: string;
+  appId: string | null;
+  affiliateCode: string | null;
+  streaming: boolean;
+}): BillingContext {
+  return {
+    organizationId: params.user.organization_id,
+    userId: params.user.id,
+    apiKeyId: params.apiKey?.id,
+    model: params.model,
+    provider: params.provider,
+    billingSource: params.billingSource,
+    requestId: params.requestId,
+    metadata: buildProviderReconciliationMetadata(
+      params.provider,
+      params.model,
+      params.streaming,
+      params.appId,
+    ),
+    affiliateCode: params.affiliateCode,
+    ...buildProviderBillingFields(params.provider, params.model),
+  };
+}
+
+function buildChatPromptForBilling(request: ChatRequest): string {
+  return request.messages
+    .map((m) => `[${m.role}] ${getMessageContent(m)}`)
+    .join("\n");
 }
 
 /**
@@ -1409,12 +1446,6 @@ function summarizeFinishedStepUsage(
   };
 }
 
-function isAbortLikeStreamError(error: unknown): boolean {
-  if (error instanceof Error && error.name === "AbortError") return true;
-  const message = error instanceof Error ? error.message : String(error);
-  return message.toLowerCase().includes("aborted");
-}
-
 async function settleStreamingAbortReservation(params: {
   model: string;
   provider: string;
@@ -1423,6 +1454,10 @@ async function settleStreamingAbortReservation(params: {
   affiliateCode: string | null;
   appId: string | null;
   requestId: string;
+  idempotencyKey: string;
+  systemPrompt: string | undefined;
+  prompt: string;
+  startTime: number;
   billingSource: PricingBillingSource;
   estimatedInputTokens: number;
   deliveredText: string;
@@ -1447,33 +1482,56 @@ async function settleStreamingAbortReservation(params: {
   );
 
   try {
-    const billing = await billUsage(
-      {
-        organizationId: params.user.organization_id,
-        userId: params.user.id,
-        apiKeyId: params.apiKey?.id,
-        model: params.model,
-        provider: params.provider,
-        billingSource: params.billingSource,
-        requestId: params.requestId,
-        metadata: buildProviderReconciliationMetadata(
-          params.provider,
-          params.model,
-          true,
-          params.appId,
-        ),
-        affiliateCode: params.affiliateCode,
-        ...buildProviderBillingFields(params.provider, params.model),
-      },
-      {
-        inputTokens,
-        outputTokens,
-        totalTokens,
-        cacheReadInputTokens: finishedStepUsage?.cacheReadInputTokens,
-        cacheWriteInputTokens: finishedStepUsage?.cacheWriteInputTokens,
-      },
-    );
+    const billingContext = buildChatBillingContext({
+      user: params.user,
+      apiKey: params.apiKey,
+      model: params.model,
+      provider: params.provider,
+      billingSource: params.billingSource,
+      requestId: params.requestId,
+      appId: params.appId,
+      affiliateCode: params.affiliateCode,
+      streaming: true,
+    });
+    const billing = await billUsage(billingContext, {
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      cacheReadInputTokens: finishedStepUsage?.cacheReadInputTokens,
+      cacheWriteInputTokens: finishedStepUsage?.cacheWriteInputTokens,
+    });
     const reconciliation = await params.settleReservation(billing.totalCost);
+    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
+      type: "chat",
+      isSuccessful: false,
+      errorMessage: "client_aborted_stream",
+      content: params.deliveredText,
+      systemPrompt: params.systemPrompt,
+      prompt: params.prompt,
+      latencyMs: Date.now() - params.startTime,
+    });
+    if (usageRecord) {
+      try {
+        await aiBillingRecordsService.record({
+          context: billingContext,
+          billing,
+          usageRecord,
+          idempotencyKey: params.idempotencyKey,
+          reconciliation,
+        });
+      } catch (auditError) {
+        logger.error("[Chat Completions] audit record failed (non-fatal)", {
+          error:
+            auditError instanceof Error
+              ? auditError.message
+              : String(auditError),
+          cause:
+            auditError instanceof Error && auditError.cause
+              ? String((auditError.cause as Error).message ?? auditError.cause)
+              : undefined,
+        });
+      }
+    }
 
     logger.info(
       "[Chat Completions] Stream aborted; reservation partially settled",
@@ -1531,7 +1589,48 @@ async function handleStreamingRequest(
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
+  const billingPrompt = buildChatPromptForBilling(request);
   let deliveredText = "";
+  let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
+    null;
+
+  const settleStreamingOnce = (
+    factory: () => Promise<CreditReconciliationResult | null>,
+  ): Promise<CreditReconciliationResult | null> => {
+    if (!streamingSettlementPromise) {
+      streamingSettlementPromise = factory().catch((error) => {
+        streamingSettlementPromise = null;
+        throw error;
+      });
+    }
+    return streamingSettlementPromise;
+  };
+
+  const refundStreamingReservationOnce = () =>
+    settleStreamingOnce(async () => await settleReservation(0));
+
+  const settleStreamingAbortOnce = (steps: readonly StepResult<ToolSet>[]) =>
+    settleStreamingOnce(
+      async () =>
+        await settleStreamingAbortReservation({
+          model,
+          provider,
+          user,
+          apiKey,
+          affiliateCode,
+          appId,
+          requestId,
+          idempotencyKey,
+          systemPrompt,
+          prompt: billingPrompt,
+          startTime,
+          billingSource,
+          estimatedInputTokens,
+          deliveredText,
+          steps,
+          settleReservation,
+        }),
+    );
 
   const safeParams = getSafeModelParams(model, {
     temperature: request.temperature,
@@ -1559,97 +1658,85 @@ async function handleStreamingRequest(
     ...(effectiveMaxTokens != null && { maxOutputTokens: effectiveMaxTokens }),
     ...cotOptions,
     onFinish: async ({ text, usage }) => {
-      try {
-        const billingContext = {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId: apiKey?.id,
-          model,
-          provider,
-          billingSource,
-          requestId,
-          metadata: buildProviderReconciliationMetadata(
-            provider,
+      await settleStreamingOnce(async () => {
+        try {
+          const billingContext = buildChatBillingContext({
+            user,
+            apiKey,
             model,
-            true,
+            provider,
+            billingSource,
+            requestId,
             appId,
-          ),
-          affiliateCode,
-          ...buildProviderBillingFields(provider, model),
-        };
-        const billing = await billUsage(billingContext, usage);
-        const reconciliation = await settleReservation(billing.totalCost);
+            affiliateCode,
+            streaming: true,
+          });
+          const billing = await billUsage(billingContext, usage);
+          const reconciliation = await settleReservation(billing.totalCost);
 
-        const usageRecord = await recordUsageAnalytics(
-          billingContext,
-          billing,
-          {
-            type: "chat",
-            content: text,
-            systemPrompt,
-            prompt: request.messages
-              .map((m) => `[${m.role}] ${getMessageContent(m)}`)
-              .join("\n"),
-            latencyMs: Date.now() - startTime,
-          },
-        );
-        if (usageRecord) {
-          try {
-            await aiBillingRecordsService.record({
-              context: billingContext,
-              billing,
-              usageRecord,
-              idempotencyKey,
-              reconciliation,
-            });
-          } catch (auditError) {
-            logger.error("[Chat Completions] audit record failed (non-fatal)", {
-              error:
-                auditError instanceof Error
-                  ? auditError.message
-                  : String(auditError),
-              cause:
-                auditError instanceof Error && auditError.cause
-                  ? String(
-                      (auditError.cause as Error).message ?? auditError.cause,
-                    )
-                  : undefined,
-            });
+          const usageRecord = await recordUsageAnalytics(
+            billingContext,
+            billing,
+            {
+              type: "chat",
+              content: text,
+              systemPrompt,
+              prompt: billingPrompt,
+              latencyMs: Date.now() - startTime,
+            },
+          );
+          if (usageRecord) {
+            try {
+              await aiBillingRecordsService.record({
+                context: billingContext,
+                billing,
+                usageRecord,
+                idempotencyKey,
+                reconciliation,
+              });
+            } catch (auditError) {
+              logger.error(
+                "[Chat Completions] audit record failed (non-fatal)",
+                {
+                  error:
+                    auditError instanceof Error
+                      ? auditError.message
+                      : String(auditError),
+                  cause:
+                    auditError instanceof Error && auditError.cause
+                      ? String(
+                          (auditError.cause as Error).message ??
+                            auditError.cause,
+                        )
+                      : undefined,
+                },
+              );
+            }
           }
-        }
 
-        logger.info("[Chat Completions] Streaming complete", {
-          durationMs: Date.now() - startTime,
-          inputTokens: billing.inputTokens,
-          outputTokens: billing.outputTokens,
-          totalCost: billing.totalCost,
-        });
-      } catch (error) {
-        await settleReservation(0);
-        logger.error("[Chat Completions] onFinish error", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+          logger.info("[Chat Completions] Streaming complete", {
+            durationMs: Date.now() - startTime,
+            inputTokens: billing.inputTokens,
+            outputTokens: billing.outputTokens,
+            totalCost: billing.totalCost,
+          });
+
+          return reconciliation;
+        } catch (error) {
+          const reconciliation = await settleReservation(0);
+          logger.error("[Chat Completions] onFinish error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return reconciliation;
+        }
+      });
     },
     onAbort: async ({
       steps,
     }: {
       readonly steps: readonly StepResult<ToolSet>[];
     }) => {
-      await settleStreamingAbortReservation({
-        model,
-        provider,
-        user,
-        apiKey,
-        affiliateCode,
-        appId,
-        requestId,
-        billingSource,
-        estimatedInputTokens,
-        deliveredText,
-        steps,
-        settleReservation,
-      });
+      await settleStreamingAbortOnce(steps);
       logger.info("[Chat Completions] Stream aborted before completion", {
         model,
         estimatedInputTokens,
@@ -1663,7 +1750,7 @@ async function handleStreamingRequest(
     // settleReservation(0). The settler is idempotent (first-call-wins), so a
     // later onFinish/onAbort cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
-      await settleReservation(0);
+      await refundStreamingReservationOnce();
       logger.error(
         "[Chat Completions] Stream provider error — reservation refunded",
         {
@@ -1848,26 +1935,11 @@ async function handleStreamingRequest(
         // does not await) onError, so settle the reservation here too. The
         // settler is idempotent, so this cannot double-refund if onError already
         // won the race.
-        const streamAborted =
-          abortSignal?.aborted === true ||
-          (deliveredText.length > 0 && isAbortLikeStreamError(error));
+        const streamAborted = abortSignal?.aborted === true;
         if (streamAborted) {
-          await settleStreamingAbortReservation({
-            model,
-            provider,
-            user,
-            apiKey,
-            affiliateCode,
-            appId,
-            requestId,
-            billingSource,
-            estimatedInputTokens,
-            deliveredText,
-            steps: [],
-            settleReservation,
-          });
+          await settleStreamingAbortOnce([]);
         } else {
-          await settleReservation(0);
+          await refundStreamingReservationOnce();
         }
         const status =
           getRecoverableProviderErrorStatus(error) ?? getErrorStatusCode(error);
@@ -2007,25 +2079,20 @@ async function handleNonStreamingRequest(
     // Bill using actual usage from SDK response. Deferred via waitUntil so the
     // ~0.7-1.1s of reconciliation/audit DB writes never block the response.
     // Same code, same amounts, same reservation — only the timing moves.
+    const billingPrompt = buildChatPromptForBilling(request);
     await settleOffResponsePath(executionCtx, async () => {
       try {
-        const billingContext = {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId: apiKey?.id,
+        const billingContext = buildChatBillingContext({
+          user,
+          apiKey,
           model,
           provider,
           billingSource,
           requestId,
-          metadata: buildProviderReconciliationMetadata(
-            provider,
-            model,
-            false,
-            appId,
-          ),
+          appId,
           affiliateCode,
-          ...buildProviderBillingFields(provider, model),
-        };
+          streaming: false,
+        });
         const billing = await billUsage(billingContext, result.usage);
         const reconciliation = await settleReservation(billing.totalCost);
 
@@ -2036,9 +2103,7 @@ async function handleNonStreamingRequest(
             type: "chat",
             content: result.text,
             systemPrompt,
-            prompt: request.messages
-              .map((m) => `[${m.role}] ${getMessageContent(m)}`)
-              .join("\n"),
+            prompt: billingPrompt,
             latencyMs: responseLatencyMs,
           },
         );

--- a/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
@@ -85,11 +85,48 @@ describe("billUsage affiliate earnings guard (#10853)", () => {
     );
 
     expect(addEarnings).toHaveBeenCalledTimes(1);
-    const arg = addEarnings.mock.calls[0][0] as { userId: string; amount: number; source: string };
+    const arg = addEarnings.mock.calls[0][0] as {
+      userId: string;
+      amount: number;
+      source: string;
+    };
     expect(arg.userId).toBe(AFFILIATE_USER);
     expect(arg.source).toBe("affiliate");
     expect(arg.amount).toBeCloseTo(0.3 * 0.1, 6); // 10% of the $0.30 cost
     // Affiliate markup was layered onto the charged cost for the paying org.
     expect(result.totalCost).toBeCloseTo(0.3 + 0.03, 6);
+  });
+
+  test("paying org affiliate earnings use deterministic request sourceId for dedupe", async () => {
+    await billUsage(
+      {
+        ...BASE,
+        organizationId: "00000000-0000-4000-8000-0000000000org",
+        requestId: "req-affiliate-1",
+      },
+      USAGE,
+    );
+    await billUsage(
+      {
+        ...BASE,
+        organizationId: "00000000-0000-4000-8000-0000000000org",
+        requestId: "req-affiliate-1",
+      },
+      USAGE,
+    );
+
+    expect(addEarnings).toHaveBeenCalledTimes(2);
+    const first = addEarnings.mock.calls[0][0] as {
+      sourceId: string;
+      dedupeBySourceId: boolean;
+    };
+    const second = addEarnings.mock.calls[1][0] as {
+      sourceId: string;
+      dedupeBySourceId: boolean;
+    };
+    expect(first.sourceId).toBe("ai_billing:usage:req-affiliate-1");
+    expect(second.sourceId).toBe(first.sourceId);
+    expect(first.dedupeBySourceId).toBe(true);
+    expect(second.dedupeBySourceId).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -82,6 +82,17 @@ export interface FlatBillingCost {
   platformMarkup: number;
 }
 
+function getAffiliateEarningsSourceId(
+  context: BillingContext,
+  operation: "usage" | "flat",
+): string {
+  const requestId = context.requestId?.trim();
+  if (requestId) {
+    return `ai_billing:${operation}:${requestId}`;
+  }
+  return `legacy_${crypto.randomUUID()}`;
+}
+
 // ============================================================================
 // Usage Normalization
 // ============================================================================
@@ -254,9 +265,7 @@ export async function billUsage(
 
       // Credit the affiliate owner
       if (affiliateEarnings > 0) {
-        // Prevent double booking on identical reservations easily,
-        // using the transaction ID or random ID if none present.
-        const sourceId = `legacy_${crypto.randomUUID()}`;
+        const sourceId = getAffiliateEarningsSourceId(context, "usage");
 
         await redeemableEarningsService
           .addEarnings({
@@ -334,7 +343,7 @@ export async function billFlatUsage(
       inputCost = totalCost;
 
       if (affiliateEarnings > 0) {
-        const sourceId = `legacy_${crypto.randomUUID()}`;
+        const sourceId = getAffiliateEarningsSourceId(context, "flat");
 
         await redeemableEarningsService
           .addEarnings({


### PR DESCRIPTION
## Summary

Fixes #11460.

- Single-flights streaming chat settlement across `onFinish`, `onAbort`, `onError`, and the `ReadableStream` catch path so aborted streams can call `billUsage` at most once.
- Treats the catch path as a client abort only when `req.signal.aborted === true`; AbortError-shaped provider failures now refund instead of partial-billing.
- Writes usage analytics and `aiBillingRecords` audit rows for partial abort charges.
- Makes affiliate earnings source IDs deterministic from `BillingContext.requestId` so `dedupeBySourceId` can suppress duplicate cashable earnings.

## Evidence

Checked-in evidence: `.github/issue-evidence/11460-chat-abort-billing/README.md`

Commands run:

```bash
bunx @biomejs/biome@2.5.2 check packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts packages/cloud/shared/src/lib/services/ai-billing.ts packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
bun run --cwd packages/cloud/api test chat-completions-streaming-credit-leak
bun run --cwd packages/cloud/shared test src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
git diff --check
```

Results:

- Biome focused check: pass.
- `chat-completions-streaming-credit-leak`: 9 pass / 0 fail / 68 assertions.
- `ai-billing-anon-affiliate`: 3 pass / 0 fail / 12 assertions.
- `git diff --check`: pass.

## Notes

Full package typecheck was attempted from the sparse Windows worktree, but it is not a clean signal here because this checkout lacks unrelated workspace/generated sources (`@elizaos/plugin-cloud-apps`, `@elizaos/prompts`, `@elizaos/contracts`, validation keyword data). The focused tests exercise the changed money paths directly.

Screenshots/video are N/A: backend billing race fix with no UI surface.