### PR TITLE
feat(eliza-code): show the active model/provider in the status bar

### DIFF
--- a/packages/examples/code/src/components/StatusBar.ts
+++ b/packages/examples/code/src/components/StatusBar.ts
@@ -40,6 +40,20 @@ export class StatusBar implements Component {
     const showFullRight = width >= 80;
     const showMediumRight = width >= 60;
 
+    // Room segment first — its real width feeds the layout math below (a fixed
+    // slack constant here overflowed the bar with long room names).
+    const maxRoomNameLen = 20;
+    const roomName = currentRoom?.name ?? "Chat";
+    const shortRoomName =
+      roomName.length > maxRoomNameLen
+        ? `${roomName.slice(0, maxRoomNameLen - 1)}…`
+        : roomName;
+    const roomDecor = ` (${roomIndex}/${rooms.length}) | `;
+    // Borders + surrounding spaces: "│ " … " │".
+    const frameOverhead = 4;
+    const leftFixedLen =
+      shortRoomName.length + roomDecor.length + frameOverhead;
+
     // Active model/provider — the "which model am I talking to" indicator every
     // comparable coding TUI shows. Only at full width (the bar is already busy
     // below 80), elided to a sane length, and omitted entirely when no provider
@@ -49,38 +63,58 @@ export class StatusBar implements Component {
       modelLabelRaw && modelLabelRaw.length > MODEL_LABEL_MAX
         ? `${modelLabelRaw.slice(0, MODEL_LABEL_MAX - 1)}…`
         : modelLabelRaw;
-    const modelPrefix = modelLabel ? `${modelLabel} | ` : "";
 
-    const rightTextPlain = showFullRight
-      ? `${modelPrefix}Tasks r${taskCounts.running} c${taskCounts.completed} f${taskCounts.failed} x${taskCounts.cancelled}${isLoading ? " …" : ""} | ?`
+    const rightBasePlain = showFullRight
+      ? `Tasks r${taskCounts.running} c${taskCounts.completed} f${taskCounts.failed} x${taskCounts.cancelled}${isLoading ? " …" : ""} | ?`
       : showMediumRight
         ? `Tasks r${taskCounts.running} f${taskCounts.failed}${isLoading ? " …" : ""} | ?`
         : `Tasks r${taskCounts.running}${isLoading ? " …" : ""} | ?`;
 
-    const maxCwdLen = Math.max(10, width - rightTextPlain.length - 24);
+    // Include the model indicator only when it fits without pushing the cwd
+    // below its 10-char floor — prefer dropping the indicator over overflowing
+    // the bar (which the screen would clip, cutting off the right border).
+    const modelPrefixCandidate = modelLabel ? `${modelLabel} | ` : "";
+    const modelPrefix =
+      modelPrefixCandidate.length > 0 &&
+      width -
+        (rightBasePlain.length + modelPrefixCandidate.length) -
+        leftFixedLen >=
+        10
+        ? modelPrefixCandidate
+        : "";
+    const rightTextPlain = `${modelPrefix}${rightBasePlain}`;
+
+    const maxCwdLen = Math.max(
+      10,
+      width - rightTextPlain.length - leftFixedLen,
+    );
     const shortCwd =
       this.cwd.length > maxCwdLen
         ? `...${this.cwd.slice(-(maxCwdLen - 3))}`
         : this.cwd;
 
-    const maxRoomNameLen = 20;
-    const roomName = currentRoom?.name ?? "Chat";
-    const shortRoomName =
-      roomName.length > maxRoomNameLen
-        ? `${roomName.slice(0, maxRoomNameLen - 1)}…`
-        : roomName;
-
     // Build the status bar
     const innerWidth = Math.max(1, width - 4);
 
-    const leftText = `${chalk.bold.magenta(shortRoomName)} ${chalk.dim(`(${roomIndex}/${rooms.length})`)} ${chalk.dim("|")} ${chalk.cyan(shortCwd)}`;
+    // Last resort at narrow widths: with the cwd already at its floor, elide
+    // the room name down to what actually fits rather than overflowing (the
+    // screen would clip the line, cutting off the right border and help hint).
+    const overflowBy =
+      shortRoomName.length +
+      roomDecor.length +
+      shortCwd.length +
+      rightTextPlain.length -
+      innerWidth;
+    const finalRoomName =
+      overflowBy > 0
+        ? `${shortRoomName.slice(0, Math.max(1, shortRoomName.length - overflowBy - 1))}…`
+        : shortRoomName;
+
+    const leftText = `${chalk.bold.magenta(finalRoomName)} ${chalk.dim(`(${roomIndex}/${rooms.length})`)} ${chalk.dim("|")} ${chalk.cyan(shortCwd)}`;
     const rightText = chalk.dim(rightTextPlain);
 
     // Calculate padding to right-align the right text
-    const leftLen =
-      shortRoomName.length +
-      ` (${roomIndex}/${rooms.length}) | `.length +
-      shortCwd.length;
+    const leftLen = finalRoomName.length + roomDecor.length + shortCwd.length;
     const rightLen = rightTextPlain.length;
     const padding = Math.max(0, innerWidth - leftLen - rightLen);
 

--- a/packages/examples/code/src/components/StatusBar.ts
+++ b/packages/examples/code/src/components/StatusBar.ts
@@ -1,7 +1,11 @@
 import type { Component } from "@elizaos/tui";
 import chalk from "chalk";
 import { getCwd } from "../lib/cwd.js";
+import { describeActiveModel } from "../lib/model-provider.js";
 import { useStore } from "../lib/store.js";
+
+/** Longest model label shown in the status bar before eliding. */
+const MODEL_LABEL_MAX = 22;
 
 export class StatusBar implements Component {
   private cwd = getCwd();
@@ -36,8 +40,19 @@ export class StatusBar implements Component {
     const showFullRight = width >= 80;
     const showMediumRight = width >= 60;
 
+    // Active model/provider — the "which model am I talking to" indicator every
+    // comparable coding TUI shows. Only at full width (the bar is already busy
+    // below 80), elided to a sane length, and omitted entirely when no provider
+    // is configured (describeActiveModel returns null rather than throwing).
+    const modelLabelRaw = showFullRight ? describeActiveModel() : null;
+    const modelLabel =
+      modelLabelRaw && modelLabelRaw.length > MODEL_LABEL_MAX
+        ? `${modelLabelRaw.slice(0, MODEL_LABEL_MAX - 1)}…`
+        : modelLabelRaw;
+    const modelPrefix = modelLabel ? `${modelLabel} | ` : "";
+
     const rightTextPlain = showFullRight
-      ? `Tasks r${taskCounts.running} c${taskCounts.completed} f${taskCounts.failed} x${taskCounts.cancelled}${isLoading ? " …" : ""} | ?`
+      ? `${modelPrefix}Tasks r${taskCounts.running} c${taskCounts.completed} f${taskCounts.failed} x${taskCounts.cancelled}${isLoading ? " …" : ""} | ?`
       : showMediumRight
         ? `Tasks r${taskCounts.running} f${taskCounts.failed}${isLoading ? " …" : ""} | ?`
         : `Tasks r${taskCounts.running}${isLoading ? " …" : ""} | ?`;

--- a/packages/examples/code/src/components/status-bar-model.test.ts
+++ b/packages/examples/code/src/components/status-bar-model.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { visibleWidth } from "@elizaos/tui";
 import chalk from "chalk";
+import { useStore } from "../lib/store.js";
 import { StatusBar } from "./StatusBar.js";
 
 const MODEL_ENV_KEYS = [
@@ -29,6 +30,10 @@ beforeEach(() => {
     saved[k] = process.env[k];
     delete process.env[k];
   }
+  // Isolate room state per test (some cases set a max-length room name).
+  useStore.setState({ rooms: [] });
+  const room = useStore.getState().createRoom("Main");
+  useStore.getState().switchRoom(room.id);
 });
 
 afterEach(() => {
@@ -68,6 +73,30 @@ describe("status bar model indicator (#11294)", () => {
     const joined = new StatusBar().render(120).join("\n");
     expect(joined).toContain("…"); // elided
     expect(joined).not.toContain("exceeds-the-cap");
+  });
+
+  test("never overflows with a max-length room name + long cwd (50/80/100/120)", () => {
+    process.env.ELIZA_CODE_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "sk-test";
+    // Elides to the 22-char cap — the widest the indicator can get.
+    process.env.OPENAI_LARGE_MODEL =
+      "some-absurdly-long-model-identifier-that-exceeds-the-cap";
+
+    useStore.setState({ rooms: [] });
+    const room = useStore.getState().createRoom("a".repeat(20));
+    useStore.getState().switchRoom(room.id);
+
+    const bar = new StatusBar();
+    // Pin a long cwd (the ctor already stamped lastCwdCheck, so render()
+    // won't refresh it away within this test).
+    (bar as unknown as { cwd: string }).cwd =
+      `/Users/someone/${"deeply/nested/".repeat(4)}project`;
+
+    for (const width of [50, 80, 100, 120] as const) {
+      for (const l of bar.render(width)) {
+        expect(visibleWidth(l)).toBeLessThanOrEqual(width);
+      }
+    }
   });
 
   test("omits the model at narrow width and never crashes unconfigured", () => {

--- a/packages/examples/code/src/components/status-bar-model.test.ts
+++ b/packages/examples/code/src/components/status-bar-model.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// #11294: the status bar surfaces the active model/provider ("which model am I
+// talking to") at full width, elided sanely, omitted when unconfigured, and
+// never overflowing / crashing. Drives the real StatusBar.render with env-driven
+// model config.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { visibleWidth } from "@elizaos/tui";
+import chalk from "chalk";
+import { StatusBar } from "./StatusBar.js";
+
+const MODEL_ENV_KEYS = [
+  "ELIZA_CODE_PROVIDER",
+  "OPENAI_API_KEY",
+  "OPENAI_LARGE_MODEL",
+  "OPENAI_MODEL",
+  "OPENAI_SMALL_MODEL",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_LARGE_MODEL",
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+const prevChalk = chalk.level;
+
+beforeEach(() => {
+  chalk.level = 0; // deterministic plain text
+  for (const k of MODEL_ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  chalk.level = prevChalk;
+  for (const k of MODEL_ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("status bar model indicator (#11294)", () => {
+  test("shows the configured model name at full width", () => {
+    process.env.ELIZA_CODE_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_LARGE_MODEL = "llama-3.3-70b";
+
+    const lines = new StatusBar().render(100);
+    const joined = lines.join("\n");
+    expect(joined).toContain("llama-3.3-70b");
+    for (const l of lines) expect(visibleWidth(l)).toBeLessThanOrEqual(100);
+  });
+
+  test("falls back to the bare provider when no model name is set", () => {
+    process.env.ELIZA_CODE_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "sk-ant";
+
+    const joined = new StatusBar().render(100).join("\n");
+    expect(joined).toContain("anthropic");
+  });
+
+  test("elides an overlong model name", () => {
+    process.env.ELIZA_CODE_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_LARGE_MODEL =
+      "some-absurdly-long-model-identifier-that-exceeds-the-cap";
+
+    const joined = new StatusBar().render(120).join("\n");
+    expect(joined).toContain("…"); // elided
+    expect(joined).not.toContain("exceeds-the-cap");
+  });
+
+  test("omits the model at narrow width and never crashes unconfigured", () => {
+    // No provider env at all → describeActiveModel returns null.
+    const narrow = new StatusBar().render(50);
+    expect(narrow.length).toBeGreaterThan(0);
+    for (const l of narrow) expect(visibleWidth(l)).toBeLessThanOrEqual(50);
+
+    // Even at full width with no keys, it renders (no model, no throw).
+    const full = new StatusBar().render(100);
+    for (const l of full) expect(visibleWidth(l)).toBeLessThanOrEqual(100);
+  });
+});

--- a/packages/examples/code/src/lib/model-provider.ts
+++ b/packages/examples/code/src/lib/model-provider.ts
@@ -46,12 +46,12 @@ export function describeActiveModel(
   } catch {
     return null;
   }
+  // Only the env vars the provider plugins actually honor — showing a model
+  // from a var the agent ignores (OPENAI_MODEL / ANTHROPIC_MODEL) would lie.
   const model =
     provider === "openai"
-      ? (env.OPENAI_LARGE_MODEL ?? env.OPENAI_MODEL ?? env.OPENAI_SMALL_MODEL)
-      : (env.ANTHROPIC_LARGE_MODEL ??
-        env.ANTHROPIC_MODEL ??
-        env.ANTHROPIC_SMALL_MODEL);
+      ? (env.OPENAI_LARGE_MODEL ?? env.OPENAI_SMALL_MODEL)
+      : (env.ANTHROPIC_LARGE_MODEL ?? env.ANTHROPIC_SMALL_MODEL);
   const trimmed = model?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : provider;
 }

--- a/packages/examples/code/src/lib/model-provider.ts
+++ b/packages/examples/code/src/lib/model-provider.ts
@@ -30,6 +30,32 @@ export function applyOpencodeProviderEnv(
     env.OPENAI_MEDIUM_MODEL = env.ELIZA_OPENCODE_MODEL_FAST;
 }
 
+/**
+ * A short human label for the active coding model, for the status bar — the
+ * model name if one is configured (what the user cares about: "which model am I
+ * talking to"), else the bare provider. Returns null when no provider is
+ * resolvable (unconfigured) so the caller can omit it rather than crash — the
+ * status bar renders on every frame and must never throw.
+ */
+export function describeActiveModel(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  let provider: ModelProvider;
+  try {
+    provider = resolveModelProvider(env);
+  } catch {
+    return null;
+  }
+  const model =
+    provider === "openai"
+      ? (env.OPENAI_LARGE_MODEL ?? env.OPENAI_MODEL ?? env.OPENAI_SMALL_MODEL)
+      : (env.ANTHROPIC_LARGE_MODEL ??
+        env.ANTHROPIC_MODEL ??
+        env.ANTHROPIC_SMALL_MODEL);
+  const trimmed = model?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : provider;
+}
+
 export function resolveModelProvider(
   env: Record<string, string | undefined>,
 ): ModelProvider {


### PR DESCRIPTION
Fixes #11475. Part of the eliza-code TUI-quality workstream (#11294).

**Before:** the status bar showed room / cwd / task-counts but not **which model the agent is using** — the "what am I talking to" indicator opencode / claude-code / every comparable coding TUI surface. eliza-code can run on Cerebras (via the opencode-compatible env), OpenAI, or Anthropic with no in-TUI signal of which.

**Change:** `describeActiveModel(env)` (new, next to `resolveModelProvider` in `lib/model-provider.ts`) → configured model name, else bare provider, else `null` when unconfigured (never throws — the status bar renders every frame). Surfaced in the right section at full width (≥80 cols), elided to 22 chars, omitted at narrow widths + when no provider is configured. `rightTextPlain` drives the existing alignment math, so cwd auto-shrinks to fit.

### Evidence
- **Mutation-checked test** (`status-bar-model.test.ts`, real `StatusBar.render`, env-driven): shows the model name at full width (`llama-3.3-70b`), falls back to the provider (`anthropic`) when no model name is set, elides an overlong name, omits at narrow width, and renders without throwing when unconfigured — width invariant asserted throughout. Forcing the model prefix off reds 3/4 (verified). **Full eliza-code suite 44/44**; build clean.

### Re-verification note
While picking this up I re-checked the #11294 backlog against current develop: the **multiline composer** item was already implemented by the streaming work (`renderComposerLines` + `windowAroundCursor` + `COMPOSER_MAX_LINES`), so this PR is the model-indicator item instead. (Branch name is a leftover from that pivot.) Remaining unclaimed on #11294: `/copy` (OSC-52) and token/cost accounting (the latter overlaps #11265).

### N/A rows
- Rendered color screenshot: **N/A this headless session** — chalk color is off a TTY; the test asserts the (color-independent) presence/elision/width behavior. Manual repro: `OPENAI_LARGE_MODEL=llama-3.3-70b bun run start` and read the status bar.
- Live-LLM trajectory: N/A — status-bar metadata display, no model behavior changed.