### PR TITLE
fix(core): log dropped fact-extractor ops where they are computed (follow-up to #11241)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -11,6 +11,7 @@
  */
 
 import z from "zod";
+import { logger } from "../../../logger.ts";
 
 /**
  * Categories that durable facts can belong to. Closed set — the extractor
@@ -168,24 +169,40 @@ export type ExtractorOutput = z.infer<typeof ExtractorOutputSchema>;
  * real, launch-critical memory loss.
  *
  * This validates the envelope leniently (`{ ops: [...] }`), then validates each
- * op independently, keeping only the ones that pass and reporting how many were
- * dropped so the caller can log it. Returns null only when the envelope itself
- * is not `{ ops: array }` (a genuinely malformed section).
+ * op independently, keeping only the ones that pass. Drops are logged HERE
+ * (one aggregate warn with per-op issues) — the only production caller is an
+ * evaluator `parse` hook (`parse?(output): TOutput | null`,
+ * `types/evaluator.ts`) which has no runtime/logger in scope, so a returned
+ * drop count could never be reported and per-op loss stayed silent in prod.
+ * Returns null only when the envelope itself is not `{ ops: array }` (a
+ * genuinely malformed section).
  */
 export function parseExtractorOutputTolerant(
 	output: unknown,
-): { value: ExtractorOutput; dropped: number } | null {
+): ExtractorOutput | null {
 	const envelope = z.object({ ops: z.array(z.unknown()) }).safeParse(output);
 	if (!envelope.success) return null;
 	const ops: ExtractorOp[] = [];
-	let dropped = 0;
+	const issues: string[] = [];
 	for (const raw of envelope.data.ops) {
 		const parsed = OpSchema.safeParse(raw);
 		if (parsed.success) {
 			ops.push(parsed.data);
 		} else {
-			dropped += 1;
+			issues.push(
+				parsed.error.issues
+					.map(
+						(issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`,
+					)
+					.join("; "),
+			);
 		}
 	}
-	return { value: { ops }, dropped };
+	if (issues.length > 0) {
+		logger.warn(
+			{ src: "factMemory", count: issues.length, issues },
+			"dropped malformed extractor op(s)",
+		);
+	}
+	return { ops };
 }

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import { logger } from "../../../logger.ts";
 import type {
 	EvaluatorProcessorContext,
 	IAgentRuntime,
 	Memory,
 	UUID,
 } from "../../../types/index.ts";
+import { parseExtractorOutputTolerant } from "./factExtractor.schema.ts";
 import { factMemoryEvaluator } from "./reflection-items.ts";
 
 const agentId = "00000000-0000-0000-0000-0000000000aa" as UUID;
@@ -204,54 +206,69 @@ describe("reflection evaluator schemas are strict-structured-output safe", () =>
 });
 
 describe("factExtractor tolerant parsing (#11235)", () => {
-	it("accepts an add op that omits structured_fields (wire-optional, prompt-unnamed)", async () => {
-		const { parseExtractorOutputTolerant } = await import(
-			"./factExtractor.schema.ts"
-		);
+	it("accepts an add op that omits structured_fields (wire-optional, prompt-unnamed)", () => {
 		const parsed = parseExtractorOutputTolerant({
 			ops: [
 				{ op: "add_durable", claim: "lives in Berlin", category: "identity" },
 			],
 		});
 		expect(parsed).not.toBeNull();
-		expect(parsed?.dropped).toBe(0);
-		expect(parsed?.value.ops).toHaveLength(1);
+		expect(parsed?.ops).toHaveLength(1);
 		// The default keeps structured_fields a concrete record for downstream use.
-		expect(parsed?.value.ops[0]).toMatchObject({
+		expect(parsed?.ops[0]).toMatchObject({
 			op: "add_durable",
 			structured_fields: {},
 		});
 	});
 
-	it("keeps valid ops when one op in the array is malformed (no whole-turn discard)", async () => {
-		const { parseExtractorOutputTolerant } = await import(
-			"./factExtractor.schema.ts"
-		);
-		const parsed = parseExtractorOutputTolerant({
-			ops: [
-				{ op: "add_durable", claim: "likes tea", category: "preference" },
-				{ op: "contradict" }, // invalid: missing required factId + reason
-				{ op: "strengthen", factId: "fact-123" },
-			],
-		});
-		expect(parsed).not.toBeNull();
-		expect(parsed?.dropped).toBe(1);
-		expect(parsed?.value.ops.map((o) => o.op)).toEqual([
-			"add_durable",
-			"strengthen",
-		]);
+	it("keeps valid ops when one op is malformed, and warns about the drop", () => {
+		// The evaluator parse contract (`parse?(output): TOutput | null`) has no
+		// runtime/logger, so the drop MUST be logged where it is computed —
+		// otherwise per-op loss is silent in prod (the regression #11241 killed).
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const parsed = parseExtractorOutputTolerant({
+				ops: [
+					{ op: "add_durable", claim: "likes tea", category: "preference" },
+					{ op: "contradict" }, // invalid: missing required factId + reason
+					{ op: "strengthen", factId: "fact-123" },
+				],
+			});
+			expect(parsed).not.toBeNull();
+			expect(parsed?.ops.map((o) => o.op)).toEqual([
+				"add_durable",
+				"strengthen",
+			]);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					src: "factMemory",
+					count: 1,
+					issues: [expect.stringContaining("factId")],
+				}),
+				"dropped malformed extractor op(s)",
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
-	it("returns null only when the envelope itself is not { ops: array }", async () => {
-		const { parseExtractorOutputTolerant } = await import(
-			"./factExtractor.schema.ts"
-		);
+	it("does not warn when every op parses", () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			parseExtractorOutputTolerant({
+				ops: [{ op: "strengthen", factId: "fact-123" }],
+			});
+			expect(warnSpy).not.toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("returns null only when the envelope itself is not { ops: array }", () => {
 		expect(parseExtractorOutputTolerant({ nope: true })).toBeNull();
 		expect(parseExtractorOutputTolerant(null)).toBeNull();
 		// An empty ops array is a VALID (zero-op) turn, not a parse failure.
-		expect(parseExtractorOutputTolerant({ ops: [] })).toMatchObject({
-			dropped: 0,
-			value: { ops: [] },
-		});
+		expect(parseExtractorOutputTolerant({ ops: [] })).toEqual({ ops: [] });
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -900,10 +900,11 @@ ${formatKnownLines(current.slice(0, MAX_KNOWN_PER_KIND), "current")}`;
 	},
 	parse(output) {
 		// Tolerant, op-by-op: a single malformed op must not discard the whole
-		// turn's valid fact ops (see parseExtractorOutputTolerant). Returns null
-		// only when the envelope itself isn't `{ ops: [...] }`.
-		const result = parseExtractorOutputTolerant(output);
-		return result ? result.value : null;
+		// turn's valid fact ops. Drops are logged inside
+		// parseExtractorOutputTolerant — this parse contract has no
+		// runtime/logger, so it could never report them. Returns null only when
+		// the envelope itself isn't `{ ops: [...] }`.
+		return parseExtractorOutputTolerant(output);
 	},
 	processors: [
 		{


### PR DESCRIPTION
Follow-up to #11241 (deepscan MAJOR: silent-discard regression at finer granularity).

## Problem

`parseExtractorOutputTolerant` (factExtractor.schema.ts) returned `{ value, dropped }` with a docstring promising the drop count is "reported so the caller can log it". But the only production caller is the factMemory evaluator `parse` hook (reflection-items.ts):

```ts
const result = parseExtractorOutputTolerant(output);
return result ? result.value : null;
```

The `Evaluator.parse` contract is `parse?(output): TOutput | null` (types/evaluator.ts) — no runtime, no logger in scope. The caller structurally CANNOT log the count, so it discards it. Result: per-op drops of malformed extractor ops were 100% silent in prod — re-creating the exact silent-discard failure #11241 (sev-high) existed to kill, just per-op instead of per-turn.

## Fix

- Log the drop **where it is computed**: `parseExtractorOutputTolerant` now emits one aggregate `logger.warn({ src: "factMemory", count, issues }, "dropped malformed extractor op(s)")` with the per-op zod issue summaries.
- Delete the now-pointless `dropped` field; the function returns `ExtractorOutput | null` and the evaluator `parse` passes it straight through.
- New test asserts the warn actually fires on a malformed op (count + issues payload) and stays quiet when every op parses.
- Nit from the same review: reflection-items.test.ts repeated `await import("./factExtractor.schema.ts")` in 3 tests with no `vi.mock` justification — replaced with one top-level static import, dropped the needless `async`.

## Verification

```
$ bunx vitest run src/features/advanced-capabilities/evaluators/reflection-items.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ bun run --cwd packages/core typecheck   # tsgo --noEmit
(clean, exit 0)
```

Behavior evidence (the thing a reviewer confirms without reading code): the new test `"keeps valid ops when one op is malformed, and warns about the drop"` feeds `{ op: "contradict" }` (missing required `factId` + `reason`) among two valid ops and asserts `logger.warn` is called exactly once with `{ src: "factMemory", count: 1, issues: [<contains "factId">] }` while both valid ops survive. The zero-drop test asserts no warn — no log spam on clean turns.

N/A — live-LLM trajectory / screenshots: pure parse-layer logging change in a deterministic zod validator; the model-facing wire schema, prompts, and stored fact ops are byte-identical. Covered by direct unit tests of the exact function.
