### PR TITLE
feat(eliza-code): /copy — copy the last response to the clipboard via OSC 52

### DIFF
--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -15,6 +15,7 @@ import { MainScreen } from "./components/MainScreen.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { TaskPane } from "./components/TaskPane.js";
 import { getAgentClient } from "./lib/agent-client.js";
+import { osc52 } from "./lib/clipboard.js";
 import { getCwd, setCwd } from "./lib/cwd.js";
 import { FilteringTerminal } from "./lib/filtering-terminal.js";
 import { getCodeTaskService } from "./lib/get-code-task-service.js";
@@ -307,6 +308,11 @@ function formatTaskDetails(task: CodeTask): string {
 
 // Slash command autocomplete items
 const SLASH_COMMANDS: AutocompleteItem[] = [
+  {
+    label: "/copy",
+    description: "Copy the last response to the clipboard",
+    value: "/copy",
+  },
   { label: "/new", description: "Start new conversation", value: "/new " },
   {
     label: "/reset",
@@ -1043,6 +1049,29 @@ export class App {
         return true;
       }
 
+      case "copy": {
+        // Copy the last assistant reply to the system clipboard via OSC 52
+        // (works over SSH / inside the cockpit PTY, where there's no direct
+        // clipboard access).
+        const room = rooms.find((r) => r.id === currentRoomId);
+        const lastAssistant = [...(room?.messages ?? [])]
+          .reverse()
+          .find((m) => m.role === "assistant" && m.content.trim().length > 0);
+        if (!lastAssistant) {
+          addMessage(currentRoomId, "system", "Nothing to copy yet.");
+          this.tui.requestRender();
+          return true;
+        }
+        this.terminal.write(osc52(lastAssistant.content));
+        addMessage(
+          currentRoomId,
+          "system",
+          "Copied the last response to the clipboard.",
+        );
+        this.tui.requestRender();
+        return true;
+      }
+
       case "help": {
         addMessage(
           currentRoomId,
@@ -1052,7 +1081,7 @@ Conversations: /new [name], /conversations, /switch <n|name>, /rename <name>, /d
 Agent: /agent <type>
 Tasks: /task, /tasks
 Dir: /cd [path], /pwd
-UI: /clear
+UI: /clear, /copy
 Help: /help, ?
 
 Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,

--- a/packages/examples/code/src/copy-command.test.ts
+++ b/packages/examples/code/src/copy-command.test.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import type { AgentRuntime } from "@elizaos/core";
 import { App } from "./App.js";
+import { osc52 } from "./lib/clipboard.js";
 import { useStore } from "./lib/store.js";
 
 function makeApp() {
@@ -23,7 +24,16 @@ function makeApp() {
         handleSlashCommand(c: string, a: string): Promise<boolean>;
       }
     ).handleSlashCommand(cmd, args);
-  return { run };
+  // Capture terminal output so tests can assert the OSC-52 sequence is
+  // actually emitted, not just that the chat message says it was.
+  const written: string[] = [];
+  const terminal = (
+    app as unknown as { terminal: { write(data: string): void } }
+  ).terminal;
+  terminal.write = (data: string) => {
+    written.push(data);
+  };
+  return { run, written };
 }
 
 function freshRoom() {
@@ -45,8 +55,8 @@ describe("/copy command (#11294)", () => {
     freshRoom();
   });
 
-  it("reports success when there is an assistant reply to copy", async () => {
-    const { run } = makeApp();
+  it("emits the OSC-52 clipboard sequence for the last assistant reply", async () => {
+    const { run, written } = makeApp();
     const roomId = useStore.getState().currentRoomId;
     useStore.getState().addMessage(roomId, "user", "hi");
     useStore.getState().addMessage(roomId, "assistant", "the answer is 42");
@@ -54,10 +64,13 @@ describe("/copy command (#11294)", () => {
     const handled = await run("copy", "");
     expect(handled).toBe(true);
     expect(systemMessages(roomId).some((m) => m.includes("Copied"))).toBe(true);
+    // The core effect: the exact OSC-52 escape for the reply reached the
+    // terminal (deleting the emission must red this test).
+    expect(written).toContain(osc52("the answer is 42"));
   });
 
   it("says there is nothing to copy when no assistant reply exists", async () => {
-    const { run } = makeApp();
+    const { run, written } = makeApp();
     const roomId = useStore.getState().currentRoomId;
     useStore.getState().addMessage(roomId, "user", "hi"); // user only
 
@@ -66,5 +79,6 @@ describe("/copy command (#11294)", () => {
     expect(
       systemMessages(roomId).some((m) => m.includes("Nothing to copy")),
     ).toBe(true);
+    expect(written.filter((d) => d.includes("\x1b]52;"))).toHaveLength(0);
   });
 });

--- a/packages/examples/code/src/copy-command.test.ts
+++ b/packages/examples/code/src/copy-command.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+//
+// #11294: /copy copies the last assistant reply to the clipboard (OSC 52) and
+// reports it; with no assistant reply it says so. Drives the real
+// App.handleSlashCommand (constructor is synchronous; terminal.write emits the
+// OSC-52 to stdout harmlessly in a test).
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { App } from "./App.js";
+import { useStore } from "./lib/store.js";
+
+function makeApp() {
+  const runtime = {
+    agentId: "test",
+    character: { name: "Eliza" },
+    getService: () => null,
+  } as unknown as AgentRuntime;
+  const app = new App(runtime);
+  const run = (cmd: string, args: string): Promise<boolean> =>
+    (
+      app as unknown as {
+        handleSlashCommand(c: string, a: string): Promise<boolean>;
+      }
+    ).handleSlashCommand(cmd, args);
+  return { run };
+}
+
+function freshRoom() {
+  useStore.setState({ rooms: [] });
+  const room = useStore.getState().createRoom("Main");
+  useStore.getState().switchRoom(room.id);
+  return room.id;
+}
+
+function systemMessages(roomId: string): string[] {
+  const room = useStore.getState().rooms.find((r) => r.id === roomId);
+  return (room?.messages ?? [])
+    .filter((m) => m.role === "system")
+    .map((m) => m.content);
+}
+
+describe("/copy command (#11294)", () => {
+  beforeEach(() => {
+    freshRoom();
+  });
+
+  it("reports success when there is an assistant reply to copy", async () => {
+    const { run } = makeApp();
+    const roomId = useStore.getState().currentRoomId;
+    useStore.getState().addMessage(roomId, "user", "hi");
+    useStore.getState().addMessage(roomId, "assistant", "the answer is 42");
+
+    const handled = await run("copy", "");
+    expect(handled).toBe(true);
+    expect(systemMessages(roomId).some((m) => m.includes("Copied"))).toBe(true);
+  });
+
+  it("says there is nothing to copy when no assistant reply exists", async () => {
+    const { run } = makeApp();
+    const roomId = useStore.getState().currentRoomId;
+    useStore.getState().addMessage(roomId, "user", "hi"); // user only
+
+    const handled = await run("copy", "");
+    expect(handled).toBe(true);
+    expect(
+      systemMessages(roomId).some((m) => m.includes("Nothing to copy")),
+    ).toBe(true);
+  });
+});

--- a/packages/examples/code/src/lib/clipboard.test.ts
+++ b/packages/examples/code/src/lib/clipboard.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+//
+// #11294: OSC 52 clipboard escape for /copy.
+
+import { describe, expect, it } from "bun:test";
+import { osc52 } from "./clipboard.js";
+
+describe("osc52 (#11294)", () => {
+  it("wraps base64-encoded UTF-8 in the OSC 52 clipboard sequence", () => {
+    const seq = osc52("hello");
+    expect(seq.startsWith("\x1b]52;c;")).toBe(true);
+    expect(seq.endsWith("\x07")).toBe(true);
+    const b64 = seq.slice("\x1b]52;c;".length, -1);
+    expect(Buffer.from(b64, "base64").toString("utf8")).toBe("hello");
+  });
+
+  it("round-trips multi-line and unicode content", () => {
+    const text = "line one\nline two — ✅ 你好";
+    const seq = osc52(text);
+    const b64 = seq.slice("\x1b]52;c;".length, -1);
+    expect(Buffer.from(b64, "base64").toString("utf8")).toBe(text);
+  });
+});

--- a/packages/examples/code/src/lib/clipboard.ts
+++ b/packages/examples/code/src/lib/clipboard.ts
@@ -1,0 +1,13 @@
+/**
+ * Build an OSC 52 terminal escape that copies `text` to the system clipboard.
+ *
+ * OSC 52 lets a program set the clipboard through the terminal itself, so it
+ * works over SSH / inside the cockpit PTY where there's no direct clipboard
+ * access. Format: `ESC ] 52 ; c ; <base64> BEL` — `c` is the clipboard
+ * selection, the payload is base64-encoded UTF-8. Terminals that don't support
+ * OSC 52 (or have it disabled) simply ignore the sequence.
+ */
+export function osc52(text: string): string {
+  const b64 = Buffer.from(text, "utf8").toString("base64");
+  return `\x1b]52;c;${b64}\x07`;
+}


### PR DESCRIPTION
Fixes #11477. Closes out the actionable eliza-code TUI punch-list (#11294).

**Before:** no way to get a response out of the full-screen TUI — no reliable select-and-copy, no command. opencode/claude-code both offer this.

**Change:** `/copy` copies the last assistant reply to the system clipboard via **OSC 52** (`ESC ] 52 ; c ; <base64> BEL`) — works over SSH and inside the cockpit PTY where there's no direct clipboard access. New `lib/clipboard.ts` `osc52()` helper; `/copy` case in `handleSlashCommand` (writes the sequence + a "Copied…" system line, or "Nothing to copy yet." when there's no reply); registered in the slash autocomplete + `/help`.

### Evidence
- **Mutation-checked tests.** `clipboard.test.ts`: `osc52` wraps base64-encoded UTF-8 in the exact OSC-52 sequence and round-trips multi-line + unicode (`✅ 你好`). `copy-command.test.ts`: drives the real `App.handleSlashCommand` — reports "Copied" with an assistant reply present, "Nothing to copy" without. Breaking the last-assistant lookup reds the success test (verified). **Full eliza-code suite 44/44**; build clean; dist `tsconfig.json` shim intact.

### N/A rows
- Rendered/clipboard capture: **N/A this headless session** — OSC 52 sets the *terminal's* clipboard; there's no TTY to observe here. The escape-sequence construction is asserted by the round-trip unit test, and the command behavior by the handler test. Manual repro: `bun run start`, get a reply, `/copy`, then paste elsewhere.
- Live-LLM trajectory: N/A — clipboard/command plumbing, no model behavior changed.

With this, the #11294 actionable list is done (front door, markdown, streaming, cancel, tool-call, input-history, scrollback, ANSI borders, unknown-slash, `--version`, model indicator, multiline, `/copy`). Remaining: token/cost accounting, which overlaps #11265.