### PR TITLE
test(cloud): re-land 10 clobbered cloud e2e suites — restore REQUIRE_E2E_SERVER fail-loud (#11419)

### DIFF
--- a/packages/cloud/api/test/e2e/agent-token-flow.test.ts
+++ b/packages/cloud/api/test/e2e/agent-token-flow.test.ts
@@ -16,15 +16,12 @@
  *   7.  Use the *new* key to confirm the freshly-issued token is valid.
  *
  * Skip behavior:
- *   - If TEST_API_BASE_URL / TEST_BASE_URL is unreachable, every test skips
- *     with a clear message. Operator has to start `wrangler dev` (or the
- *     Next.js dev server) and re-run.
- *   - Some assertions accept a small set of statuses (200/201) because the
- *     Hono Worker and the legacy Next.js implementation differ in shape on
- *     a few edges; we want a single test that runs against either.
+ *   - By default (REQUIRE_E2E_SERVER unset) an unreachable Worker fails the
+ *     preload/health probe loudly. With REQUIRE_E2E_SERVER=0 every test in
+ *     this file reports as a counted, named `skip` — never a silent pass.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import {
   api,
   bearerHeaders,
@@ -33,32 +30,27 @@ import {
   isServerReachable,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-let sessionCookie: string | null = null;
-const createdApiKeyIds: string[] = [];
-
-function shouldRun(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[agent-token-flow] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+if (!hasTestApiKey) {
+  console.warn(
+    "[agent-token-flow] TEST_API_KEY is not set; the preload could not bootstrap " +
+      "a test API key. Tests will SKIP.",
+  );
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[agent-token-flow] ${getBaseUrl()} did not respond to /api/health. ` +
-        "Tests will skip. Start the Worker (bun run dev:api → wrangler dev) " +
-        "or set TEST_API_BASE_URL to a reachable host.",
-    );
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[agent-token-flow] TEST_API_KEY is not set; the preload could not bootstrap " +
-        "a test API key. Tests requiring auth will skip.",
-    );
-  }
-});
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+
+let sessionCookie: string | null = null;
+const createdApiKeyIds: string[] = [];
 
 afterAll(async () => {
   if (!serverReachable || !sessionCookie) return;
@@ -69,9 +61,8 @@ afterAll(async () => {
   }
 });
 
-describe("Foundation: agent token flow", () => {
+describeE2E("Foundation: agent token flow", () => {
   test("server responds at /api/health", async () => {
-    if (!serverReachable) return; // health check doesn't need API key
     const res = await api.get("/api/health");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { status?: string };
@@ -79,9 +70,7 @@ describe("Foundation: agent token flow", () => {
   });
 
   test("Bearer eliza_* unlocks GET /api/v1/user", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/user", { headers: bearerHeaders() });
-    expect([200, 401, 403]).toContain(res.status);
     if (res.status !== 200) {
       const body = await res.text();
       throw new Error(
@@ -93,11 +82,9 @@ describe("Foundation: agent token flow", () => {
   });
 
   test("Bearer eliza_* unlocks GET /api/v1/credits/balance", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/credits/balance", {
       headers: bearerHeaders(),
     });
-    expect([200, 401, 403]).toContain(res.status);
     if (res.status !== 200) {
       const body = await res.text();
       throw new Error(
@@ -109,13 +96,11 @@ describe("Foundation: agent token flow", () => {
   });
 
   test("API key trades for a session cookie via /api/test/auth/session", async () => {
-    if (!shouldRun()) return;
     sessionCookie = await exchangeApiKeyForSession();
     expect(sessionCookie).toMatch(/^[^=]+=.+/);
   });
 
   test("session cookie unlocks GET /api/v1/api-keys (session-only path)", async () => {
-    if (!shouldRun()) return;
     if (!sessionCookie)
       throw new Error("session cookie not set — earlier step failed");
     const res = await api.get("/api/v1/api-keys", {
@@ -131,7 +116,6 @@ describe("Foundation: agent token flow", () => {
   });
 
   test("session cookie can create a new API key, and that key works as Bearer", async () => {
-    if (!shouldRun()) return;
     if (!sessionCookie)
       throw new Error("session cookie not set — earlier step failed");
 
@@ -145,7 +129,7 @@ describe("Foundation: agent token flow", () => {
       { headers: { Cookie: sessionCookie } },
     );
 
-    expect([200, 201]).toContain(createRes.status);
+    expect(createRes.status).toBe(201);
     const created = (await createRes.json()) as {
       apiKey?: { id?: string };
       plainKey?: string;

--- a/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
+++ b/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
@@ -29,16 +29,16 @@
  *      contract.
  *   3. Validation — at least one body / param failure returns 400.
  *
- * Skip behavior mirrors `agent-token-flow.test.ts`:
- *   - If `/api/health` is unreachable, every test skips silently.
- *   - If `TEST_API_KEY` was not bootstrapped (e.g. SKIP_DB_DEPENDENT=1 or
- *     no Postgres), tests that require a key skip; auth-gate assertions
- *     still run because they only need the server to answer.
- *   - External-provider routes assert deterministic configured/unconfigured
- *     behavior instead of skipping when provider secrets are absent.
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass. Session-only tests additionally skip
+ * loudly when the test-session exchange is unavailable. External-provider
+ * routes assert deterministic configured/unconfigured behavior keyed on the
+ * provider secret's presence in this env (shared with wrangler dev in the
+ * local lane).
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { buildWalletProvisionChallenge } from "@elizaos/cloud-sdk";
 import { privateKeyToAccount } from "viem/accounts";
 import {
@@ -50,25 +50,50 @@ import {
   isServerReachable,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-b-account-billing] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-b-account-billing] TEST_API_KEY is not set; the preload could " +
+      "not bootstrap a test API key. Tests will SKIP.",
+  );
+}
+
 let sessionCookie: string | null = null;
+if (serverReachable && hasTestApiKey) {
+  try {
+    sessionCookie = await exchangeApiKeyForSession();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[group-b-account-billing] session exchange failed (session tests will SKIP): ${msg}`,
+    );
+  }
+}
+
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+// Session-only routes; loud skip when the test-session exchange is unavailable.
+const testSession = test.skipIf(
+  !serverReachable || !hasTestApiKey || sessionCookie === null,
+);
+// Live Steward provisioning is an explicit opt-in integration check.
+const liveStewardWallet = process.env.RUN_STEWARD_WALLET_E2E === "1";
+// Stripe checkout: deterministic keyless 503 vs live 200, keyed on the secret
+// the Worker itself reads (shared env in the local lane).
+const stripeConfigured = Boolean(process.env.STRIPE_SECRET_KEY?.trim());
+
 const createdApiKeyIds: string[] = [];
 const TEST_WALLET_ACCOUNT = privateKeyToAccount(
   "0x1111111111111111111111111111111111111111111111111111111111111111",
 );
-
-function shouldRunAuthed(): boolean {
-  return serverReachable && hasTestApiKey;
-}
-
-function shouldRunLiveStewardWalletE2E(): boolean {
-  return process.env.RUN_STEWARD_WALLET_E2E === "1";
-}
-
-function shouldRunSession(): boolean {
-  return shouldRunAuthed() && sessionCookie !== null;
-}
 
 async function signedWalletHeaders(
   path: string,
@@ -103,32 +128,6 @@ async function signedProvisionProof(
   return { signature, timestamp, nonce };
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-b-account-billing] ${getBaseUrl()} did not respond to /api/health. ` +
-        "Tests will skip. Start the Worker (bun run dev → wrangler dev) " +
-        "or set TEST_API_BASE_URL to a reachable host.",
-    );
-    return;
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-b-account-billing] TEST_API_KEY is not set; the preload could not " +
-        "bootstrap a test API key. Tests requiring auth will skip.",
-    );
-    return;
-  }
-  try {
-    sessionCookie = await exchangeApiKeyForSession();
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[group-b-account-billing] session exchange failed: ${msg}`);
-  }
-});
-
 afterAll(async () => {
   if (!serverReachable || !sessionCookie) return;
   for (const id of createdApiKeyIds) {
@@ -140,52 +139,50 @@ afterAll(async () => {
 
 // -------- /api/v1/api-keys/explorer ----------------------------------------
 
-describe("GET /api/v1/api-keys/explorer", () => {
+describeE2E("GET /api/v1/api-keys/explorer", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/api-keys/explorer");
     expect(res.status).toBe(401);
   });
 
   test("happy path: returns or creates the explorer key with Bearer auth", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/v1/api-keys/explorer", {
       headers: bearerHeaders(),
     });
-    expect([200, 201]).toContain(res.status);
+    // get-or-create: 201 exactly when the key was created (isNew), 200 when
+    // it already existed — the pair must agree, anything else is a defect.
     const body = (await res.json()) as {
       apiKey?: { id?: string; key?: string; name?: string };
       isNew?: boolean;
     };
+    expect(typeof body.isNew).toBe("boolean");
+    expect(res.status).toBe(body.isNew ? 201 : 200);
     expect(body.apiKey?.id).toBeTruthy();
     expect(body.apiKey?.name).toBe("API Explorer Key");
-    expect(typeof body.isNew).toBe("boolean");
   });
 
   test("validation: rejects POST (only GET is mounted)", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/api-keys/explorer",
       {},
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    // Hono answers 404 for methods that are not mounted on the sub-app.
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/v1/api-keys/:id/regenerate ----------------------------------
 
-describe("POST /api/v1/api-keys/:id/regenerate", () => {
+describeE2E("POST /api/v1/api-keys/:id/regenerate", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post(
       "/api/v1/api-keys/00000000-0000-0000-0000-000000000000/regenerate",
     );
     expect(res.status).toBe(401);
   });
 
-  test("happy path: regenerates a freshly created key", async () => {
-    if (!shouldRunSession()) return;
+  testSession("happy path: regenerates a freshly created key", async () => {
     if (!sessionCookie) throw new Error("session cookie missing");
 
     const createRes = await api.post(
@@ -197,7 +194,7 @@ describe("POST /api/v1/api-keys/:id/regenerate", () => {
       },
       { headers: { Cookie: sessionCookie } },
     );
-    expect([200, 201]).toContain(createRes.status);
+    expect(createRes.status).toBe(201);
     const created = (await createRes.json()) as {
       apiKey?: { id?: string };
       plainKey?: string;
@@ -221,21 +218,20 @@ describe("POST /api/v1/api-keys/:id/regenerate", () => {
   });
 
   test("validation: 404 for an unknown id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/api-keys/00000000-0000-0000-0000-000000000000/regenerate",
       undefined,
       { headers: bearerHeaders() },
     );
-    expect([400, 404]).toContain(res.status);
+    // Well-formed UUID that misses the lookup → 404.
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- PATCH /api/v1/api-keys/:id (update) ------------------------------
 
-describe("PATCH /api/v1/api-keys/:id", () => {
+describeE2E("PATCH /api/v1/api-keys/:id", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.patch(
       "/api/v1/api-keys/00000000-0000-0000-0000-000000000000",
       { is_active: false },
@@ -243,8 +239,7 @@ describe("PATCH /api/v1/api-keys/:id", () => {
     expect(res.status).toBe(401);
   });
 
-  test("happy path: renames and disables a freshly created key", async () => {
-    if (!shouldRunSession()) return;
+  testSession("happy path: renames and disables a freshly created key", async () => {
     if (!sessionCookie) throw new Error("session cookie missing");
 
     const createRes = await api.post(
@@ -256,7 +251,7 @@ describe("PATCH /api/v1/api-keys/:id", () => {
       },
       { headers: { Cookie: sessionCookie } },
     );
-    expect([200, 201]).toContain(createRes.status);
+    expect(createRes.status).toBe(201);
     const created = (await createRes.json()) as { apiKey?: { id?: string } };
     expect(created.apiKey?.id).toBeTruthy();
     if (created.apiKey?.id) createdApiKeyIds.push(created.apiKey.id);
@@ -282,27 +277,24 @@ describe("PATCH /api/v1/api-keys/:id", () => {
   });
 
   test("validation: 404 for an unknown id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.patch(
       "/api/v1/api-keys/00000000-0000-0000-0000-000000000000",
       { is_active: false },
       { headers: bearerHeaders() },
     );
-    expect([400, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/v1/user/avatar (R2 multipart upload) ------------------------
 
-describe("/api/v1/user/avatar", () => {
+describeE2E("/api/v1/user/avatar", () => {
   test("auth gate: without credentials expect 401 from /api/", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/user/avatar");
     expect(res.status).toBe(401);
   });
 
   test("validation: JSON body returns 400 (multipart required)", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/user/avatar",
       { dummy: 1 },
@@ -312,7 +304,6 @@ describe("/api/v1/user/avatar", () => {
   });
 
   test("validation: GET returns 405", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/v1/user/avatar", {
       headers: bearerHeaders(),
     });
@@ -322,29 +313,26 @@ describe("/api/v1/user/avatar", () => {
 
 // -------- /api/v1/user/email -----------------------------------------------
 
-describe("PATCH /api/v1/user/email", () => {
+describeE2E("PATCH /api/v1/user/email", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.patch("/api/v1/user/email", { email: "x@y.com" });
     expect(res.status).toBe(401);
   });
 
   test("happy path: the bootstrapped user already has an email → 400 with success=false", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.patch(
       "/api/v1/user/email",
       { email: `group-b+${Date.now()}@example.com` },
       { headers: bearerHeaders() },
     );
-    // The local test fixture user has an email; the handler refuses to overwrite.
-    // 200 is acceptable too if the bootstrap left email blank.
-    expect([200, 400]).toContain(res.status);
+    // The preload's fixture user always carries an email; the handler
+    // refuses to overwrite it → 400 with success=false.
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { success?: boolean; error?: string };
-    expect(typeof body.success).toBe("boolean");
+    expect(body.success).toBe(false);
   });
 
   test("validation: 400 on invalid email format", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.patch(
       "/api/v1/user/email",
       { email: "not-an-email" },
@@ -359,45 +347,39 @@ describe("PATCH /api/v1/user/email", () => {
 
 // -------- /api/v1/user/wallets ---------------------------------------------
 
-describe("GET /api/v1/user/wallets", () => {
+describeE2E("GET /api/v1/user/wallets", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/user/wallets");
     expect(res.status).toBe(401);
   });
 
   test("happy path: returns a wallets array for the authed org", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/v1/user/wallets", {
       headers: bearerHeaders(),
     });
-    expect([200, 403]).toContain(res.status);
-    if (res.status === 200) {
-      const body = (await res.json()) as {
-        success?: boolean;
-        data?: unknown[];
-      };
-      expect(body.success).toBe(true);
-      expect(Array.isArray(body.data)).toBe(true);
-    }
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success?: boolean;
+      data?: unknown[];
+    };
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data)).toBe(true);
   });
 
   test("validation: POST is not mounted on this collection (only GET)", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/user/wallets",
       {},
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/v1/user/wallets/provision -----------------------------------
 
-describe("POST /api/v1/user/wallets/provision", () => {
+describeE2E("POST /api/v1/user/wallets/provision", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/user/wallets/provision", {
       chainType: "evm",
       clientAddress: "0x0000000000000000000000000000000000000000",
@@ -405,13 +387,9 @@ describe("POST /api/v1/user/wallets/provision", () => {
     expect(res.status).toBe(401);
   });
 
-  test("happy path: provisions when external signer is configured, otherwise fails after auth", async () => {
-    if (!shouldRunAuthed()) return;
-    // Live Steward provisioning is an integration check, not a release smoke.
-    // Keep the default deploy gate deterministic; opt in when explicitly
-    // validating Steward wallet provisioning.
-    if (!shouldRunLiveStewardWalletE2E()) return;
-
+  // Live Steward provisioning is an integration check, not a release smoke.
+  // Loud, counted opt-in via RUN_STEWARD_WALLET_E2E=1.
+  test.skipIf(!liveStewardWallet)("happy path: provisions when external signer is configured, otherwise fails after auth", async () => {
     const clientAddress = TEST_WALLET_ACCOUNT.address;
     const res = await api.post(
       "/api/v1/user/wallets/provision",
@@ -422,12 +400,14 @@ describe("POST /api/v1/user/wallets/provision", () => {
       },
       { headers: bearerHeaders() },
     );
-    // Proof verified → reaches Steward (200) or its downstream failure modes.
+    // Live-only (RUN_STEWARD_WALLET_E2E=1): the proof must be ACCEPTED — any
+    // 400/401 means the signed challenge broke. Beyond that the status is
+    // Steward's (200 provisioned; 403/500/503 downstream), named here because
+    // the external service's failure modes are not this Worker's contract.
     expect([200, 403, 500, 503]).toContain(res.status);
   });
 
   test("proof required: 400 when controlProof is absent", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/user/wallets/provision",
       { chainType: "evm", clientAddress: TEST_WALLET_ACCOUNT.address },
@@ -440,7 +420,6 @@ describe("POST /api/v1/user/wallets/provision", () => {
   });
 
   test("proof rejected: 401 when the proof is not signed by clientAddress", async () => {
-    if (!shouldRunAuthed()) return;
     // clientAddress the caller does NOT control; proof signed by TEST_WALLET.
     const squattedAddress = "0x000000000000000000000000000000000000dEaD";
     const res = await api.post(
@@ -457,7 +436,6 @@ describe("POST /api/v1/user/wallets/provision", () => {
   });
 
   test("validation: 400 on invalid clientAddress for chainType=evm", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/user/wallets/provision",
       {
@@ -479,9 +457,8 @@ describe("POST /api/v1/user/wallets/provision", () => {
 
 // -------- /api/v1/user/wallets/rpc -----------------------------------------
 
-describe("POST /api/v1/user/wallets/rpc", () => {
+describeE2E("POST /api/v1/user/wallets/rpc", () => {
   test("auth gate: 401 without wallet signature headers", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/user/wallets/rpc", {
       clientAddress: "0x0000000000000000000000000000000000000000",
       payload: { method: "eth_blockNumber", params: [] },
@@ -489,12 +466,12 @@ describe("POST /api/v1/user/wallets/rpc", () => {
       timestamp: Date.now(),
       nonce: "n-0",
     });
-    // Wallet auth rejects: 401 (or 400 if validation fires before auth).
-    expect([400, 401]).toContain(res.status);
+    // Wallet auth runs before ownership/RPC handling and rejects the bogus
+    // signature with 401 (the body itself is schema-valid).
+    expect(res.status).toBe(401);
   });
 
   test("validation: 400 on missing required fields", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/user/wallets/rpc", {
       clientAddress: "0xabc",
     });
@@ -504,7 +481,6 @@ describe("POST /api/v1/user/wallets/rpc", () => {
   });
 
   test("happy path: signed wallet auth reaches ownership or RPC checks", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/user/wallets/rpc",
       {
@@ -516,14 +492,16 @@ describe("POST /api/v1/user/wallets/rpc", () => {
       },
       { headers: await signedWalletHeaders("/api/v1/user/wallets/rpc") },
     );
-    expect([401, 403]).toContain(res.status);
+    // The signature verifies, but TEST_WALLET is not a provisioned wallet for
+    // any org → ownership check rejects with 401.
+    expect(res.status).toBe(401);
   });
 });
 
 // -------- /api/v1/topup/{10,50,100} (x402 wallet topup) --------------------
 
 for (const amount of [10, 50, 100] as const) {
-  describe(`POST /api/v1/topup/${amount}`, () => {
+  describeE2E(`POST /api/v1/topup/${amount}`, () => {
     test("auth gate: public path, request without auth still hits the live handler", async () => {
       if (!serverReachable) return;
       const res = await api.post(`/api/v1/topup/${amount}`);
@@ -539,6 +517,8 @@ for (const amount of [10, 50, 100] as const) {
         { walletAddress: TEST_WALLET_ACCOUNT.address },
         { headers: bearerHeaders() },
       );
+      // Env-keyed pair: 402 payment-required when x402 is configured on the
+      // Worker, 503 x402_not_configured otherwise — the body discriminates.
       expect([402, 503]).toContain(res.status);
       const body = (await res.json()) as {
         error?: string;
@@ -556,16 +536,15 @@ for (const amount of [10, 50, 100] as const) {
     test("validation: GET is not mounted (only POST)", async () => {
       if (!serverReachable) return;
       const res = await api.get(`/api/v1/topup/${amount}`);
-      expect([404, 405]).toContain(res.status);
+      expect(res.status).toBe(404);
     });
   });
 }
 
 // -------- /api/v1/pricing/summary ------------------------------------------
 
-describe("GET /api/v1/pricing/summary", () => {
+describeE2E("GET /api/v1/pricing/summary", () => {
   test("public route: returns pricing snapshot without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/pricing/summary");
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -577,7 +556,6 @@ describe("GET /api/v1/pricing/summary", () => {
   });
 
   test("happy path: returns pricing snapshot with asOf timestamp", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/v1/pricing/summary", {
       headers: bearerHeaders(),
     });
@@ -591,27 +569,24 @@ describe("GET /api/v1/pricing/summary", () => {
   });
 
   test("validation: POST is not mounted", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/pricing/summary",
       {},
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/quotas/usage ------------------------------------------------
 
-describe("GET /api/quotas/usage", () => {
+describeE2E("GET /api/quotas/usage", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/quotas/usage");
     expect(res.status).toBe(401);
   });
 
   test("happy path: returns quota usage data for the authed org", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/quotas/usage", {
       headers: bearerHeaders(),
     });
@@ -622,27 +597,24 @@ describe("GET /api/quotas/usage", () => {
   });
 
   test("validation: POST is not mounted", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/quotas/usage",
       {},
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/stats/account -----------------------------------------------
 
-describe("GET /api/stats/account", () => {
+describeE2E("GET /api/stats/account", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/stats/account");
     expect(res.status).toBe(401);
   });
 
   test("happy path: returns the account-stats payload", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/stats/account", {
       headers: bearerHeaders(),
     });
@@ -660,72 +632,85 @@ describe("GET /api/stats/account", () => {
   });
 
   test("validation: POST is not mounted", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/stats/account",
       {},
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/stripe/credit-packs (public) --------------------------------
 
-describe("GET /api/stripe/credit-packs", () => {
+describeE2E("GET /api/stripe/credit-packs", () => {
   test("auth gate: public path, unauthenticated request reaches the handler", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/stripe/credit-packs");
-    // Public path: 200 if Stripe DB rows exist, 500 on db failure. Never 401.
-    expect(res.status).not.toBe(401);
-    expect([200, 500]).toContain(res.status);
+    // Public path (never 401) serving DB-backed packs — a 500 is a defect,
+    // not a tolerable state.
+    expect(res.status).toBe(200);
   });
 
   test("happy path: returns a creditPacks array", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/stripe/credit-packs");
-    if (res.status === 200) {
-      const body = (await res.json()) as { creditPacks?: unknown[] };
-      expect(Array.isArray(body.creditPacks)).toBe(true);
-    }
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { creditPacks?: unknown[] };
+    expect(Array.isArray(body.creditPacks)).toBe(true);
   });
 
   test("validation: POST is not mounted (only GET)", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/stripe/credit-packs");
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------- /api/stripe/create-checkout-session ------------------------------
 
-describe("POST /api/stripe/create-checkout-session", () => {
+describeE2E("POST /api/stripe/create-checkout-session", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/stripe/create-checkout-session", {
       amount: 5,
     });
     expect(res.status).toBe(401);
   });
 
-  test("happy path: creates Checkout when Stripe is configured, otherwise fails after auth", async () => {
-    if (!shouldRunSession()) return;
-    if (!sessionCookie) throw new Error("session cookie missing");
-    const res = await api.post(
-      "/api/stripe/create-checkout-session",
-      { amount: 5 },
-      { headers: { Cookie: sessionCookie } },
-    );
-    expect([200, 201, 500, 503]).toContain(res.status);
-    if (res.ok) {
+  // Keyless-deterministic variant: without STRIPE_SECRET_KEY the handler
+  // answers 503 service-unavailable after auth.
+  test.skipIf(
+    !serverReachable || !hasTestApiKey || sessionCookie === null || stripeConfigured,
+  )(
+    "keyless: checkout answers 503 when Stripe is not configured",
+    async () => {
+      if (!sessionCookie) throw new Error("session cookie missing");
+      const res = await api.post(
+        "/api/stripe/create-checkout-session",
+        { amount: 5 },
+        { headers: { Cookie: sessionCookie } },
+      );
+      expect(res.status).toBe(503);
+    },
+  );
+
+  // Live variant: with Stripe configured the checkout must fully succeed.
+  test.skipIf(
+    !serverReachable || !hasTestApiKey || sessionCookie === null || !stripeConfigured,
+  )(
+    "live: creates a Checkout session with id + https url",
+    async () => {
+      if (!sessionCookie) throw new Error("session cookie missing");
+      const res = await api.post(
+        "/api/stripe/create-checkout-session",
+        { amount: 5 },
+        { headers: { Cookie: sessionCookie } },
+      );
+      expect(res.status).toBe(200);
       const body = (await res.json()) as { sessionId?: string; url?: string };
       expect(body.sessionId).toBeTruthy();
       expect(body.url).toMatch(/^https:\/\//);
-    }
-  });
+    },
+  );
 
-  test("validation: 400 when neither creditPackId nor amount is provided", async () => {
-    if (!shouldRunSession()) return;
+  testSession("validation: 400 when neither creditPackId nor amount is provided", async () => {
     if (!sessionCookie) throw new Error("session cookie missing");
     const res = await api.post(
       "/api/stripe/create-checkout-session",
@@ -740,40 +725,27 @@ describe("POST /api/stripe/create-checkout-session", () => {
 
 // -------- /api/signup-code/redeem ------------------------------------------
 
-describe("POST /api/signup-code/redeem", () => {
+describeE2E("POST /api/signup-code/redeem", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/signup-code/redeem", { code: "any" });
     expect(res.status).toBe(401);
   });
 
-  test("happy path: invalid code path returns a structured error (no real code in fixtures)", async () => {
-    if (!shouldRunSession()) return;
+  testSession("happy path: invalid code path returns a structured error (no real code in fixtures)", async () => {
     if (!sessionCookie) throw new Error("session cookie missing");
-    // No fixture provisions a redeemable code, so we expect the negative
-    // path (400 INVALID_CODE / 409 ALREADY_USED). Any happy-path "200"
-    // would also be valid if a code is seeded.
+    // No fixture seeds a redeemable code and the random code cannot exist,
+    // so the contract is exactly the 400 INVALID_CODE negative path.
     const res = await api.post(
       "/api/signup-code/redeem",
       { code: `group-b-${Date.now()}` },
       { headers: { Cookie: sessionCookie } },
     );
-    expect([200, 400, 409]).toContain(res.status);
-    const body = (await res.json()) as {
-      success?: boolean;
-      error?: string;
-      bonus?: number;
-    };
-    if (res.status === 200) {
-      expect(body.success).toBe(true);
-      expect(typeof body.bonus).toBe("number");
-    } else {
-      expect(typeof body.error).toBe("string");
-    }
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(typeof body.error).toBe("string");
   });
 
-  test("validation: 400 on missing code field", async () => {
-    if (!shouldRunSession()) return;
+  testSession("validation: 400 on missing code field", async () => {
     if (!sessionCookie) throw new Error("session cookie missing");
     const res = await api.post(
       "/api/signup-code/redeem",

--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -3,28 +3,27 @@
  * `/api/characters`).
  *
  * For each route in the group, three assertions:
- *   1. **Auth gate** — request without credentials returns 401 (or, for
- *      service-key / public routes, the documented gate response).
+ *   1. **Auth gate** — request without credentials returns the exact
+ *      documented gate status.
  *   2. **Happy path** — with the bootstrapped Bearer eliza_* key, the route
- *      either returns its documented success shape or — for routes acting on
- *      a specific :agentId/:id we don't own — a recognized 401/403/404 from
- *      the auth/ownership gate. Either way the Worker is reachable and
- *      executing the handler.
+ *      returns its documented success shape, or — for routes acting on a
+ *      :agentId/:id we don't own — the exact not-found/ownership status.
  *   3. **Validation** — at least one body / query-param failure returns the
- *      expected 400 (or, where the handler defers validation behind auth,
- *      the auth gate fires first; we accept that and document it).
+ *      exact documented rejection.
  *
- * Mirrors the foundation test at `agent-token-flow.test.ts`. Skips cleanly
- * when the Worker isn't reachable or the preload couldn't bootstrap an API
- * key (`SKIP_DB_DEPENDENT=1`, no Postgres, etc.).
+ * Every status assertion pins the single status the local Worker contract
+ * produces (the CI lane runs this suite against `wrangler dev` with the
+ * PGlite bridge — see run-e2e-batches.mjs). The only tolerated pairs are
+ * genuinely env-keyed (named inline, e.g. HEADSCALE_INTERNAL_TOKEN).
+ *
+ * Skip behavior matches `agent-token-flow.test.ts`: with REQUIRE_E2E_SERVER=0
+ * and no reachable Worker (or no bootstrapped TEST_API_KEY) every test in
+ * this file reports as a counted, named `skip` — never a silent pass.
  *
  * UNOWNED_AGENT_ID — a syntactically-valid UUID we know isn't in the DB.
- * Routes that ownership-check land on 404 (or 401 if the route is service-
- * key only, or 403 for monetization which checks ownership before existence).
- *
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { Client } from "pg";
 
 import {
@@ -37,13 +36,26 @@ import {
 
 const UNOWNED_AGENT_ID = "00000000-0000-4000-8000-000000000000";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-const createdCharacterIds: string[] = [];
-
-function shouldRun(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-c-agents] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
 }
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-c-agents] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+
+const createdCharacterIds: string[] = [];
 
 async function seedOwnedCharacter(input: {
   id: string;
@@ -131,26 +143,8 @@ async function seedOwnedCharacter(input: {
   }
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-c-agents] ${getBaseUrl()} did not respond to /api/health. ` +
-        "Tests will skip. Start the Worker (bun run dev:api → wrangler dev) " +
-        "or set TEST_API_BASE_URL to a reachable host.",
-    );
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-c-agents] TEST_API_KEY is not set; the preload could not " +
-        "bootstrap a test API key. Tests requiring auth will skip.",
-    );
-  }
-});
-
 afterAll(async () => {
-  if (!shouldRun()) return;
+  if (!serverReachable || !hasTestApiKey) return;
   for (const id of createdCharacterIds) {
     await api.delete(`/api/my-agents/characters/${id}`, {
       headers: bearerHeaders(),
@@ -161,17 +155,13 @@ afterAll(async () => {
 // -------------------------------------------------------------------------
 // /api/agents/:id/a2a — public agent A2A endpoint (JSON-RPC POST + GET card)
 // -------------------------------------------------------------------------
-describe("/api/agents/:id/a2a", () => {
+describeE2E("/api/agents/:id/a2a", () => {
   test("GET unknown agent returns 404 even unauthenticated (public route, but agent must exist)", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/agents/${UNOWNED_AGENT_ID}/a2a`);
-    // 404 = no such agent; 403 = exists but not public/a2a-disabled; both are
-    // expected gate responses on a public route with no agent at this UUID.
-    expect([403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("POST without auth on unknown agent returns 404 (handler short-circuits before auth)", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/agents/${UNOWNED_AGENT_ID}/a2a`, {
       jsonrpc: "2.0",
       method: "chat",
@@ -179,207 +169,192 @@ describe("/api/agents/:id/a2a", () => {
       params: {},
     });
     // The route's flow: lookup agent first → 404 if missing → only then auth.
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("POST with malformed JSON-RPC body to unknown agent returns 404 (agent check first)", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/agents/${UNOWNED_AGENT_ID}/a2a`, {
       not: "a valid jsonrpc envelope",
     });
-    expect([400, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/agents/:id/headscale-ip — internal-token-only
 // -------------------------------------------------------------------------
-describe("/api/agents/:id/headscale-ip", () => {
-  test("GET without internal token returns 403 (or 503 if not configured)", async () => {
-    if (!serverReachable) return;
+describeE2E("/api/agents/:id/headscale-ip", () => {
+  // Env-keyed pair: with HEADSCALE_INTERNAL_TOKEN / CONTAINER_CONTROL_PLANE_TOKEN
+  // configured a missing/bogus token is rejected 403; the keyless local harness
+  // has neither configured, so the route answers 503 "not configured".
+  test("GET without internal token returns 403 (503 when no internal token is configured)", async () => {
     const res = await api.get(`/api/agents/${UNOWNED_AGENT_ID}/headscale-ip`);
     expect([403, 503]).toContain(res.status);
   });
 
-  test("GET with bogus internal token still 403 (constant-time mismatch)", async () => {
-    if (!serverReachable) return;
+  test("GET with bogus internal token still 403 (503 when no internal token is configured)", async () => {
     const res = await api.get(`/api/agents/${UNOWNED_AGENT_ID}/headscale-ip`, {
       headers: { "x-internal-token": "definitely-not-the-real-token" },
     });
     expect([403, 503]).toContain(res.status);
   });
 
-  test("GET with non-UUID id returns 403 before validation (auth fires first)", async () => {
-    if (!serverReachable) return;
+  test("GET with non-UUID id rejects before validation (auth gate fires first)", async () => {
     const res = await api.get("/api/agents/not-a-uuid/headscale-ip");
     // Without a valid internal token we never reach the UUID validation,
-    // so the response is the auth gate.
-    expect([400, 403, 503]).toContain(res.status);
+    // so the response is the auth gate (same env-keyed pair as above).
+    expect([403, 503]).toContain(res.status);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/agents/:id/mcp — public MCP endpoint
 // -------------------------------------------------------------------------
-describe("/api/agents/:id/mcp", () => {
+describeE2E("/api/agents/:id/mcp", () => {
   test("GET unknown agent returns 404 (public route, but agent must exist)", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/agents/${UNOWNED_AGENT_ID}/mcp`);
-    expect([403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("POST without auth on unknown agent returns 404 (agent check before auth)", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/agents/${UNOWNED_AGENT_ID}/mcp`, {
       jsonrpc: "2.0",
       method: "tools/list",
       id: 1,
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("POST with malformed JSON-RPC body returns 404 on unknown agent", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/agents/${UNOWNED_AGENT_ID}/mcp`, {
       not: "a valid jsonrpc envelope",
     });
-    expect([400, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId — GET only, requires user/key auth + ownership
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId", () => {
+describeE2E("/api/v1/agents/:agentId", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unowned agent returns 404 (not-found from repository)", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
-  test("GET with valid auth on malformed agentId still rejects (404 or 400)", async () => {
-    if (!shouldRun()) return;
+  test("GET with valid auth on malformed agentId returns 500 (no UUID validation on this route)", async () => {
     const res = await api.get("/api/v1/agents/not-a-uuid-at-all", {
       headers: bearerHeaders(),
     });
-    expect([400, 401, 403, 404, 500]).toContain(res.status);
+    // Current contract: the raw id reaches the repository and the Postgres
+    // uuid cast throws → 500. A route-layer UUID validator would make this a
+    // 400; update this pin when one lands.
+    expect(res.status).toBe(500);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/logs — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/logs", () => {
+describeE2E("/api/v1/agents/:agentId/logs", () => {
   test("GET without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/logs`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("GET with user Bearer (not service key) returns 401", async () => {
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/logs`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with bogus service key returns 401/403", async () => {
-    if (!serverReachable) return;
+  test("GET with bogus service key returns 401", async () => {
     const res = await api.get(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/logs?tail=10`,
       {
         headers: { "X-Service-Key": "not-a-real-service-key" },
       },
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/monetization — GET + PUT
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/monetization", () => {
+describeE2E("/api/v1/agents/:agentId/monetization", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/monetization`,
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unowned agent returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/monetization`,
       {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
-  test("PUT with invalid body schema returns 400 (or 404 if ownership fails first)", async () => {
-    if (!shouldRun()) return;
+  test("PUT with invalid body schema returns 400 (Zod validation fires before ownership)", async () => {
     const res = await api.put(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/monetization`,
       // markupPercentage above 1000 fails Zod validation
       { markupPercentage: 99999 },
       { headers: bearerHeaders() },
     );
-    expect([400, 401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(400);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/publish — POST + DELETE (user auth + ownership)
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/publish", () => {
+describeE2E("/api/v1/agents/:agentId/publish", () => {
   test("POST without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/v1/agents/${UNOWNED_AGENT_ID}/publish`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("POST with valid auth on unowned agent returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/publish`,
       {},
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("DELETE with valid auth on unowned agent returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.delete(`/api/v1/agents/${UNOWNED_AGENT_ID}/publish`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/restart — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/restart", () => {
+describeE2E("/api/v1/agents/:agentId/restart", () => {
   test("POST without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/v1/agents/${UNOWNED_AGENT_ID}/restart`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("POST with user Bearer (not service key) returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/restart`,
       undefined,
@@ -387,11 +362,10 @@ describe("/api/v1/agents/:agentId/restart", () => {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with bogus service key still 401/403", async () => {
-    if (!serverReachable) return;
+  test("POST with bogus service key returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/restart`,
       undefined,
@@ -399,22 +373,20 @@ describe("/api/v1/agents/:agentId/restart", () => {
         headers: { "X-Service-Key": "not-a-real-service-key" },
       },
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/resume — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/resume", () => {
+describeE2E("/api/v1/agents/:agentId/resume", () => {
   test("POST without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/v1/agents/${UNOWNED_AGENT_ID}/resume`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("POST with user Bearer (not service key) returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/resume`,
       undefined,
@@ -422,11 +394,10 @@ describe("/api/v1/agents/:agentId/resume", () => {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with bogus service key still 401/403", async () => {
-    if (!serverReachable) return;
+  test("POST with bogus service key returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/resume`,
       undefined,
@@ -434,101 +405,91 @@ describe("/api/v1/agents/:agentId/resume", () => {
         headers: { "X-Service-Key": "not-a-real-service-key" },
       },
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/status — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/status", () => {
+describeE2E("/api/v1/agents/:agentId/status", () => {
   test("GET without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/status`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("GET with user Bearer (not service key) returns 401", async () => {
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/status`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with bogus service key still 401/403", async () => {
-    if (!serverReachable) return;
+  test("GET with bogus service key returns 401", async () => {
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/status`, {
       headers: { "X-Service-Key": "not-a-real-service-key" },
     });
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/suspend — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/suspend", () => {
+describeE2E("/api/v1/agents/:agentId/suspend", () => {
   test("POST without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post(`/api/v1/agents/${UNOWNED_AGENT_ID}/suspend`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("POST with user Bearer (not service key) returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/suspend`,
       { reason: "test" },
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with bogus service key still 401/403", async () => {
-    if (!serverReachable) return;
+  test("POST with bogus service key returns 401", async () => {
     const res = await api.post(
       `/api/v1/agents/${UNOWNED_AGENT_ID}/suspend`,
       { reason: "test" },
       { headers: { "X-Service-Key": "not-a-real-service-key" } },
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/:agentId/usage — service-key only
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/:agentId/usage", () => {
+describeE2E("/api/v1/agents/:agentId/usage", () => {
   test("GET without service key returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/usage`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with user Bearer (not service key) still rejected", async () => {
-    if (!shouldRun()) return;
+  test("GET with user Bearer (not service key) returns 401", async () => {
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/usage`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("GET with bogus service key still 401/403", async () => {
-    if (!serverReachable) return;
+  test("GET with bogus service key returns 401", async () => {
     const res = await api.get(`/api/v1/agents/${UNOWNED_AGENT_ID}/usage`, {
       headers: { "X-Service-Key": "not-a-real-service-key" },
     });
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/v1/agents/by-token — public token lookup
 // -------------------------------------------------------------------------
-describe("/api/v1/agents/by-token", () => {
+describeE2E("/api/v1/agents/by-token", () => {
   test("GET without ?address returns 400", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/agents/by-token");
     expect(res.status).toBe(400);
     const body = (await res.json()) as { success?: boolean; error?: string };
@@ -536,17 +497,14 @@ describe("/api/v1/agents/by-token", () => {
     expect(body.error).toBeTruthy();
   });
 
-  test("GET with bogus address returns 404", async () => {
-    if (!serverReachable) return;
+  test("GET with well-formed unknown address returns 404 (no agent linked)", async () => {
     const res = await api.get(
       `/api/v1/agents/by-token?address=${encodeURIComponent("0xdeadbeef".repeat(4))}&chain=eth`,
     );
-    // 404 = no agent linked. 400 if normalization rejects the address shape.
-    expect([400, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("GET with overlong address returns 400", async () => {
-    if (!serverReachable) return;
     const longAddr = "x".repeat(257);
     const res = await api.get(`/api/v1/agents/by-token?address=${longAddr}`);
     expect(res.status).toBe(400);
@@ -556,54 +514,49 @@ describe("/api/v1/agents/by-token", () => {
 // -------------------------------------------------------------------------
 // /api/my-agents/characters — list + create
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters", () => {
+describeE2E("/api/my-agents/characters", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/my-agents/characters");
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth returns paginated character list", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/my-agents/characters?limit=10", {
       headers: bearerHeaders(),
     });
-    expect([200, 401, 403]).toContain(res.status);
-    if (res.status === 200) {
-      const body = (await res.json()) as {
-        success?: boolean;
-        data?: { characters?: unknown[]; pagination?: { page?: number } };
-      };
-      expect(body.success).toBe(true);
-      expect(Array.isArray(body.data?.characters)).toBe(true);
-      expect(body.data?.pagination?.page).toBe(1);
-    }
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success?: boolean;
+      data?: { characters?: unknown[]; pagination?: { page?: number } };
+    };
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data?.characters)).toBe(true);
+    expect(body.data?.pagination?.page).toBe(1);
   });
 
-  test("POST with malformed body fails", async () => {
-    if (!shouldRun()) return;
+  test("POST with malformed body returns 500 (create fails at the DB layer)", async () => {
     // Missing the required `name` field — the handler casts to ElizaCharacter
-    // and the create call will fail at the DB layer.
+    // without route-layer validation, so the insert fails in the repository.
+    // Current contract: 500. A route-layer validator would make this a 400;
+    // update this pin when one lands.
     const res = await api.post(
       "/api/my-agents/characters",
       { nope: "no name here" },
       { headers: bearerHeaders() },
     );
-    expect([400, 401, 403, 500]).toContain(res.status);
+    expect(res.status).toBe(500);
   });
 });
 
 // /api/my-agents/characters/avatar — Worker-safe multipart avatar upload.
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/avatar", () => {
+describeE2E("/api/my-agents/characters/avatar", () => {
   test("POST without auth returns 401 before upload validation", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/my-agents/characters/avatar");
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("POST with valid auth and no multipart body returns 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.post("/api/my-agents/characters/avatar", undefined, {
       headers: bearerHeaders(),
     });
@@ -614,7 +567,6 @@ describe("/api/my-agents/characters/avatar", () => {
   });
 
   test("POST with random JSON body returns upload validation error", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       "/api/my-agents/characters/avatar",
       { fake: "payload" },
@@ -627,125 +579,113 @@ describe("/api/my-agents/characters/avatar", () => {
 // -------------------------------------------------------------------------
 // /api/my-agents/characters/:id — GET + PUT + DELETE
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id", () => {
+describeE2E("/api/my-agents/characters/:id", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/my-agents/characters/${UNOWNED_AGENT_ID}`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unowned id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/my-agents/characters/${UNOWNED_AGENT_ID}`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("DELETE on unowned id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.delete(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}`,
       {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/my-agents/characters/:id/clone — POST
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id/clone", () => {
+describeE2E("/api/my-agents/characters/:id/clone", () => {
   test("POST without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/clone`,
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("POST with valid auth on unknown source id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/clone`,
       {},
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("POST with non-JSON body still hits not-found gate (handler tolerates empty body)", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/clone`,
       "this is not json",
       { headers: { ...bearerHeaders(), "Content-Type": "text/plain" } },
     );
-    expect([400, 401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/my-agents/characters/:id/share — GET + PUT
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id/share", () => {
+describeE2E("/api/my-agents/characters/:id/share", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/share`,
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unowned id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/share`,
       {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
-  test("PUT with invalid body returns 400 (or 404 if ownership fails first)", async () => {
-    if (!shouldRun()) return;
+  test("PUT with invalid body on unowned id returns 404 (ownership fails before body validation)", async () => {
     const res = await api.put(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/share`,
       { isPublic: "not-a-boolean" },
       { headers: bearerHeaders() },
     );
-    expect([400, 401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/my-agents/characters/:id/stats — GET
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id/stats", () => {
+describeE2E("/api/my-agents/characters/:id/stats", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/stats`,
     );
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unowned id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/stats`,
       {
         headers: bearerHeaders(),
       },
     );
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("GET with valid auth on owned id returns stored counters", async () => {
-    if (!shouldRun()) return;
     const userId = process.env.TEST_USER_ID;
     const organizationId = process.env.TEST_ORGANIZATION_ID;
     if (!userId || !organizationId) {
@@ -795,7 +735,6 @@ describe("/api/my-agents/characters/:id/stats", () => {
   });
 
   test("GET with malformed id returns 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/my-agents/characters/not-a-uuid/stats", {
       headers: bearerHeaders(),
     });
@@ -804,168 +743,149 @@ describe("/api/my-agents/characters/:id/stats", () => {
 });
 
 // -------------------------------------------------------------------------
-// /api/my-agents/characters/:id/track-interaction — POST (returns 410 gone)
+// /api/my-agents/characters/:id/track-interaction — POST (removed route)
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id/track-interaction", () => {
-  test("POST without auth returns 401 (auth gate before 410)", async () => {
-    if (!serverReachable) return;
+describeE2E("/api/my-agents/characters/:id/track-interaction", () => {
+  test("POST without auth returns 401 (global auth middleware fires first)", async () => {
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-interaction`,
     );
-    expect([401, 403, 410, 500]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with valid auth lands on 410 Gone", async () => {
-    if (!shouldRun()) return;
+  // Current contract for authed callers is 500, NOT the intended 410: the
+  // handler calls requireUserWithOrg (session-only — it rejects eliza_* API
+  // keys) inside a blanket try/catch that converts the auth rejection into
+  // "Failed to track interaction" 500. Pinned so the contract is visible;
+  // update to 410 if the handler drops the swallow (compare track-view).
+  test("POST with API-key Bearer returns 500 (auth rejection swallowed by the route's catch)", async () => {
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-interaction`,
       undefined,
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 410, 500]).toContain(res.status);
-    if (res.status === 410) {
-      const body = (await res.json()) as { success?: boolean; error?: string };
-      expect(body.success).toBe(false);
-      expect(body.error).toBeTruthy();
-    }
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBeTruthy();
   });
 
-  test("POST with body still 410 (route is removed)", async () => {
-    if (!shouldRun()) return;
+  test("POST with body behaves the same (500 for API-key callers)", async () => {
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-interaction`,
       { eventType: "click" },
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 410, 500]).toContain(res.status);
+    expect(res.status).toBe(500);
   });
 });
 
 // -------------------------------------------------------------------------
-// /api/my-agents/characters/:id/track-view — POST (returns 410 gone, no auth)
+// /api/my-agents/characters/:id/track-view — POST (returns 410 gone)
 // -------------------------------------------------------------------------
-describe("/api/my-agents/characters/:id/track-view", () => {
-  test("POST without auth returns 401 (global auth middleware) or 410", async () => {
-    if (!serverReachable) return;
+describeE2E("/api/my-agents/characters/:id/track-view", () => {
+  test("POST without auth returns 401 (global auth middleware fires first)", async () => {
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-view`,
     );
-    expect([401, 403, 410]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("POST with valid auth lands on 410 Gone", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-view`,
       undefined,
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 410]).toContain(res.status);
-    if (res.status === 410) {
-      const body = (await res.json()) as { success?: boolean; error?: string };
-      expect(body.success).toBe(false);
-    }
+    expect(res.status).toBe(410);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
   });
 
   test("POST with random body still 410", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/my-agents/characters/${UNOWNED_AGENT_ID}/track-view`,
       { random: "data" },
       { headers: bearerHeaders() },
     );
-    expect([401, 403, 410]).toContain(res.status);
+    expect(res.status).toBe(410);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/my-agents/saved — GET
 // -------------------------------------------------------------------------
-describe("/api/my-agents/saved", () => {
+describeE2E("/api/my-agents/saved", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/my-agents/saved");
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth returns saved-agent list", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/my-agents/saved", {
       headers: bearerHeaders(),
     });
-    expect([200, 401, 403]).toContain(res.status);
-    if (res.status === 200) {
-      const body = (await res.json()) as {
-        success?: boolean;
-        data?: { agents?: unknown[]; count?: number };
-      };
-      expect(body.success).toBe(true);
-      expect(Array.isArray(body.data?.agents)).toBe(true);
-      expect(typeof body.data?.count).toBe("number");
-    }
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success?: boolean;
+      data?: { agents?: unknown[]; count?: number };
+    };
+    expect(body.success).toBe(true);
+    expect(Array.isArray(body.data?.agents)).toBe(true);
+    expect(typeof body.data?.count).toBe("number");
   });
 
-  test("GET with junk Bearer is rejected", async () => {
-    if (!serverReachable) return;
+  test("GET with junk Bearer returns 401", async () => {
     const res = await api.get("/api/my-agents/saved", {
       headers: { Authorization: "Bearer eliza_completely-invalid-key" },
     });
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/my-agents/saved/:id — GET + DELETE
 // -------------------------------------------------------------------------
-describe("/api/my-agents/saved/:id", () => {
+describeE2E("/api/my-agents/saved/:id", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/my-agents/saved/${UNOWNED_AGENT_ID}`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with valid auth on unknown saved id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/my-agents/saved/${UNOWNED_AGENT_ID}`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("DELETE with valid auth on unknown saved id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.delete(`/api/my-agents/saved/${UNOWNED_AGENT_ID}`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
-// /api/my-agents/claim-affiliate-characters — POST (session auth)
+// /api/my-agents/claim-affiliate-characters — POST (session auth only)
 // -------------------------------------------------------------------------
-describe("/api/my-agents/claim-affiliate-characters", () => {
+describeE2E("/api/my-agents/claim-affiliate-characters", () => {
   test("POST without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/my-agents/claim-affiliate-characters", {});
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with valid Bearer (session-only) — 401 (requires session) or 200", async () => {
-    if (!shouldRun()) return;
-    // requireUserWithOrg accepts API keys too in current impl; if the route
-    // rejects the Bearer with 401 we still consider that a passing assertion
-    // because the route ran the auth gate.
+  test("POST with API-key Bearer returns 401 (route requires a session, rejects eliza_* keys)", async () => {
     const res = await api.post(
       "/api/my-agents/claim-affiliate-characters",
       {},
       { headers: bearerHeaders() },
     );
-    expect([200, 401, 403, 500]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
-  test("POST with non-JSON body is tolerated (route catches JSON parse errors)", async () => {
-    if (!shouldRun()) return;
+  test("POST with non-JSON body still hits the session gate first (401)", async () => {
     const res = await api.post(
       "/api/my-agents/claim-affiliate-characters",
       "not-json-at-all",
@@ -973,22 +893,20 @@ describe("/api/my-agents/claim-affiliate-characters", () => {
         headers: { ...bearerHeaders(), "Content-Type": "text/plain" },
       },
     );
-    expect([200, 400, 401, 403, 500]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/characters/:characterId/mcps — owned character MCP metadata
 // -------------------------------------------------------------------------
-describe("/api/characters/:characterId/mcps", () => {
+describeE2E("/api/characters/:characterId/mcps", () => {
   test("GET without auth returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/characters/${UNOWNED_AGENT_ID}/mcps`);
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("GET with malformed character id returns 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/characters/not-a-uuid/mcps", {
       headers: bearerHeaders(),
     });
@@ -996,15 +914,13 @@ describe("/api/characters/:characterId/mcps", () => {
   });
 
   test("GET with valid auth on unowned id returns 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/characters/${UNOWNED_AGENT_ID}/mcps`, {
       headers: bearerHeaders(),
     });
-    expect([401, 403, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("GET with valid auth on owned id returns MCP configuration", async () => {
-    if (!shouldRun()) return;
     const userId = process.env.TEST_USER_ID;
     const organizationId = process.env.TEST_ORGANIZATION_ID;
     if (!userId || !organizationId) {
@@ -1063,23 +979,21 @@ describe("/api/characters/:characterId/mcps", () => {
     });
   });
 
-  test("POST with valid auth is not mounted", async () => {
-    if (!shouldRun()) return;
+  test("POST is not mounted — 404", async () => {
     const res = await api.post(
       `/api/characters/${UNOWNED_AGENT_ID}/mcps`,
       { mcpId: "test" },
       { headers: bearerHeaders() },
     );
-    expect([404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
 // -------------------------------------------------------------------------
 // /api/characters/:characterId/public — public character info
 // -------------------------------------------------------------------------
-describe("/api/characters/:characterId/public", () => {
+describeE2E("/api/characters/:characterId/public", () => {
   test("GET unauthenticated for unknown character returns 404", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/characters/${UNOWNED_AGENT_ID}/public`);
     // Public route — no auth required, but unknown character is 404.
     expect(res.status).toBe(404);
@@ -1088,18 +1002,15 @@ describe("/api/characters/:characterId/public", () => {
   });
 
   test("GET with valid auth for unknown character still 404", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/characters/${UNOWNED_AGENT_ID}/public`, {
       headers: bearerHeaders(),
     });
     expect(res.status).toBe(404);
   });
 
-  test("GET with malformed characterId is rejected", async () => {
-    if (!serverReachable) return;
+  test("GET with malformed characterId returns 400 (UUID validator)", async () => {
     const res = await api.get("/api/characters/not-a-uuid/public");
-    // 404 = service treats it as not-found; 400/500 if a UUID validator fires.
-    expect([400, 404, 500]).toContain(res.status);
+    expect(res.status).toBe(400);
   });
 });
 
@@ -1108,20 +1019,8 @@ describe("/api/characters/:characterId/public", () => {
 // rest of these tests rely on. If this fails, the per-route 200 assertions
 // were always going to skip.
 // -------------------------------------------------------------------------
-describe("Group C sanity: bootstrapped key works", () => {
-  test("test API key is set when not SKIP_DB_DEPENDENT", () => {
-    if (!serverReachable) return;
-    if (process.env.SKIP_DB_DEPENDENT === "1") {
-      expect(hasTestApiKey).toBe(false);
-      return;
-    }
-    if (!hasTestApiKey) {
-      console.warn(
-        "[group-c-agents] preload did not export TEST_API_KEY — local Postgres unavailable",
-      );
-    }
-    if (hasTestApiKey) {
-      expect(getApiKey()).toMatch(/^eliza_/);
-    }
+describeE2E("Group C sanity: bootstrapped key works", () => {
+  test("test API key is set and eliza_-prefixed", () => {
+    expect(getApiKey()).toMatch(/^eliza_/);
   });
 });

--- a/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
+++ b/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
@@ -21,13 +21,15 @@
  *     inputs that validate auth and fail deterministically before upstream I/O.
  *   - Validation assertion for malformed bodies or unsupported methods.
  *
- * Skip behavior:
- *   - If TEST_API_BASE_URL / TEST_BASE_URL is unreachable, every test skips.
- *   - For routes that need an API key, tests skip if TEST_API_KEY isn't
- *     populated by the preload (e.g. SKIP_DB_DEPENDENT=1).
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass. The /api/v1/responses happy path is
+ * split into a keyless-deterministic variant (503, never 501) and a
+ * live-inference variant (200 + full response shape) keyed on provider-key
+ * availability.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import {
   api,
@@ -37,46 +39,46 @@ import {
   url,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-
-function shouldRunAuthed(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-d-ai-media] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
 }
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-d-ai-media] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+
+// Live-inference split: the local lane shares this process env with wrangler
+// dev, so a provider key here means the Worker can really forward. A remote
+// target (staging) opts in via E2E_LIVE_INFERENCE=1.
+const liveInferenceAvailable = Boolean(
+  process.env.OPENAI_API_KEY?.trim() ||
+    process.env.AI_GATEWAY_API_KEY?.trim() ||
+    process.env.E2E_LIVE_INFERENCE === "1",
+);
 
 function bearerOnlyHeaders(): Record<string, string> {
   const { Authorization } = bearerHeaders();
   return { Authorization };
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-d-ai-media] ${getBaseUrl()} did not respond to /api/health. ` +
-        "Tests will skip. Start the Worker (bun run dev:api → wrangler dev) " +
-        "or set TEST_API_BASE_URL to a reachable host.",
-    );
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-d-ai-media] TEST_API_KEY is not set; auth-gated happy-path " +
-        "tests will skip. Run without SKIP_DB_DEPENDENT and ensure local " +
-        "Postgres is reachable to bootstrap a key.",
-    );
-  }
-});
-
-describe("Group D — /api/elevenlabs/stt", () => {
+describeE2E("Group D — /api/elevenlabs/stt", () => {
   test("auth gate: missing credentials → 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/elevenlabs/stt", { audio: "test-audio" });
     expect(res.status).toBe(401);
   });
 
   test("happy path: with Bearer, handler is reachable without upstream STT", async () => {
-    if (!shouldRunAuthed()) return;
     const form = new FormData();
     form.set(
       "audio",
@@ -88,11 +90,12 @@ describe("Group D — /api/elevenlabs/stt", () => {
       body: form,
       signal: AbortSignal.timeout(30_000),
     });
-    expect([400, 500]).toContain(res.status);
+    // fileTypeFromBuffer cannot identify the bogus bytes → the route's own
+    // signature validation rejects with 400 before any upstream STT I/O.
+    expect(res.status).toBe(400);
   });
 
   test("validation: non-multipart body with auth returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post("/api/elevenlabs/stt", "not-json", {
       headers: { ...bearerHeaders(), "Content-Type": "application/json" },
     });
@@ -100,15 +103,13 @@ describe("Group D — /api/elevenlabs/stt", () => {
   });
 });
 
-describe("Group D — /api/elevenlabs/tts", () => {
+describeE2E("Group D — /api/elevenlabs/tts", () => {
   test("auth gate: missing credentials → 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/elevenlabs/tts", { text: "hello" });
     expect(res.status).toBe(401);
   });
 
   test("happy path: with Bearer, handler is reachable without upstream TTS", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/elevenlabs/tts",
       { text: "x".repeat(5001) },
@@ -118,7 +119,6 @@ describe("Group D — /api/elevenlabs/tts", () => {
   });
 
   test("validation: empty body with auth returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/elevenlabs/tts",
       {},
@@ -128,9 +128,8 @@ describe("Group D — /api/elevenlabs/tts", () => {
   });
 });
 
-describe("Group D — /api/v1/responses", () => {
+describeE2E("Group D — /api/v1/responses", () => {
   test("auth gate: missing credentials → 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/responses", {
       model: "google/gemini-2.5-flash",
       input: "hello",
@@ -139,7 +138,6 @@ describe("Group D — /api/v1/responses", () => {
   });
 
   test("validation: malformed body with auth returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/responses",
       {},
@@ -151,7 +149,6 @@ describe("Group D — /api/v1/responses", () => {
   });
 
   test("validation: streaming requests return a clear 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/responses",
       {
@@ -166,22 +163,38 @@ describe("Group D — /api/v1/responses", () => {
     expect(body.error?.message).toContain("/api/v1/chat/completions");
   });
 
-  test("happy path: with Bearer, non-streaming route is live and never returns 501", async () => {
-    if (!shouldRunAuthed()) return;
-    const res = await api.post(
-      "/api/v1/responses",
-      {
-        model: "google/gemini-2.5-flash",
-        instructions: "Reply briefly.",
-        input: [{ role: "user", content: "Say hello" }],
-      },
-      { headers: bearerHeaders() },
-    );
+  // Keyless-deterministic variant: without a provider key the route must
+  // answer 503 (provider unavailable) — never 501 (unimplemented).
+  test.skipIf(liveInferenceAvailable)(
+    "keyless: non-streaming route answers 503 provider-unavailable, not 501",
+    async () => {
+      const res = await api.post(
+        "/api/v1/responses",
+        {
+          model: "google/gemini-2.5-flash",
+          instructions: "Reply briefly.",
+          input: [{ role: "user", content: "Say hello" }],
+        },
+        { headers: bearerHeaders() },
+      );
+      expect(res.status).toBe(503);
+    },
+  );
 
-    expect(res.status).not.toBe(501);
-    expect([200, 402, 429, 503]).toContain(res.status);
-
-    if (res.status === 200) {
+  // Live variant: with a provider key the forward must fully succeed.
+  test.skipIf(!liveInferenceAvailable)(
+    "live: non-streaming route returns a complete response object",
+    async () => {
+      const res = await api.post(
+        "/api/v1/responses",
+        {
+          model: "google/gemini-2.5-flash",
+          instructions: "Reply briefly.",
+          input: [{ role: "user", content: "Say hello" }],
+        },
+        { headers: bearerHeaders() },
+      );
+      expect(res.status).toBe(200);
       const body = (await res.json()) as {
         object?: string;
         output_text?: string;
@@ -196,13 +209,12 @@ describe("Group D — /api/v1/responses", () => {
       expect(typeof body.output_text).toBe("string");
       expect(Array.isArray(body.output)).toBe(true);
       expect(typeof body.usage?.total_tokens).toBe("number");
-    }
-  });
+    },
+  );
 });
 
-describe("Group D — /api/v1/generate-image", () => {
+describeE2E("Group D — /api/v1/generate-image", () => {
   test("auth gate: missing credentials → 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/generate-image", {
       prompt: "A simple red circle",
     });
@@ -210,7 +222,6 @@ describe("Group D — /api/v1/generate-image", () => {
   });
 
   test("validation: malformed body with auth returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/generate-image",
       {},
@@ -221,7 +232,6 @@ describe("Group D — /api/v1/generate-image", () => {
   });
 
   test("validation: unsupported model is rejected before provider I/O", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/generate-image",
       { prompt: "A simple red circle", model: "unsupported/image-model" },
@@ -237,9 +247,8 @@ describe("Group D — /api/v1/generate-image", () => {
   });
 });
 
-describe("Group D — /api/v1/generate-video", () => {
+describeE2E("Group D — /api/v1/generate-video", () => {
   test("auth gate: missing credentials → 401", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/generate-video", {
       prompt: "A cinematic drone shot",
       model: "fal-ai/veo3",
@@ -248,7 +257,6 @@ describe("Group D — /api/v1/generate-video", () => {
   });
 
   test("validation: malformed body with auth returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/generate-video",
       {},
@@ -259,7 +267,6 @@ describe("Group D — /api/v1/generate-video", () => {
   });
 
   test("validation: unsupported model is rejected before fal.ai I/O", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/generate-video",
       { prompt: "A cinematic drone shot", model: "unsupported/video-model" },
@@ -275,24 +282,23 @@ describe("Group D — /api/v1/generate-video", () => {
   });
 });
 
-describe("Group D — /api/fal/proxy", () => {
+describeE2E("Group D — /api/fal/proxy", () => {
   test("auth gate: missing credentials → 401/403", async () => {
-    if (!serverReachable) return;
     // /api/fal/proxy is on the middleware public list, but the handler itself
     // calls requireUserOrApiKeyWithOrg, so an unauthenticated request should
     // be rejected with an auth error response.
     const res = await api.get("/api/fal/proxy");
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("happy path: with Bearer, proxy handler is reachable without upstream fal.ai", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get("/api/fal/proxy", { headers: bearerHeaders() });
-    expect([200, 400, 401, 500, 503]).toContain(res.status);
+    // Authed but without the x-fal-target-url header the proxy rejects with
+    // its own 400 ("Invalid request") before any upstream fal.ai I/O.
+    expect(res.status).toBe(400);
   });
 
   test("validation: PATCH (unsupported method) → not 200", async () => {
-    if (!shouldRunAuthed()) return;
     // The handler only registers GET/POST/PUT. PATCH should not produce a
     // success — Hono returns 404 for unmatched methods on a sub-app.
     const res = await api.patch(
@@ -300,21 +306,18 @@ describe("Group D — /api/fal/proxy", () => {
       {},
       { headers: bearerHeaders() },
     );
-    expect(res.status).not.toBe(200);
-    expect([400, 401, 403, 404, 405]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 });
 
-describe("Group D — /api/og", () => {
+describeE2E("Group D — /api/og", () => {
   test("public route: no auth required (no 401/403)", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/og?title=hello");
     expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(403);
   });
 
   test("happy path: returns a non-empty body with content-type set", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/og?title=hello");
     expect(res.status).toBe(200);
     const contentType = res.headers.get("content-type") ?? "";
@@ -326,7 +329,6 @@ describe("Group D — /api/og", () => {
   });
 
   test("validation: missing title uses default image text", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/og");
     expect(res.status).toBe(200);
     const body = await res.text();
@@ -334,16 +336,14 @@ describe("Group D — /api/og", () => {
   });
 });
 
-describe("Group D — /api/openapi.json", () => {
+describeE2E("Group D — /api/openapi.json", () => {
   test("public route: no auth required (no 401/403)", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/openapi.json");
     expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(403);
   });
 
   test("happy path: returns OpenAPI 3.1 JSON spec with required top-level fields", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/openapi.json");
     expect(res.status).toBe(200);
     const contentType = res.headers.get("content-type") ?? "";
@@ -363,11 +363,9 @@ describe("Group D — /api/openapi.json", () => {
   });
 
   test("validation: only GET is supported; POST/PUT/DELETE return non-200", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/openapi.json", {});
-    // Hono returns 404 for unmatched methods on a sub-app that only registers
-    // GET. Anything other than a successful 200 is acceptable.
-    expect(res.status).not.toBe(200);
-    expect([400, 404, 405]).toContain(res.status);
+    // Hono returns 404 for unmatched methods on a sub-app that only
+    // registers GET.
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/cloud/api/test/e2e/group-e-agent-admin.test.ts
+++ b/packages/cloud/api/test/e2e/group-e-agent-admin.test.ts
@@ -15,104 +15,101 @@
  *   /api/training/vertex/tune
  * Three assertions per route family:
  *
- *  1. Auth gate — unauthenticated request returns 401/403 (per the global auth
- *     middleware in `apps/api/src/middleware/auth.ts`; these are not public
- *     paths).
+ *  1. Auth gate — unauthenticated request returns exactly 401 (the global
+ *     auth middleware in `src/middleware/auth.ts` runs before any handler;
+ *     these are not public paths).
  *  2. Happy path / behavior — for routes with a real handler we assert the
- *     bearer-authenticated response shape; for the many 501 stubs ("Not
- *     implemented on Workers" — DockerSSHClient/node:fs blockers) we accept
- *     200/202/501 as documented in FANOUT.md.
+ *     bearer-authenticated response shape; Worker-boundary stubs
+ *     (DockerSSHClient/node:fs blockers) answer exactly 501 not_yet_migrated.
  *  3. Validation — for routes that take a body, send a known-bad payload and
  *     assert 400.
  *
  * Admin routes additionally require a wallet-bound admin user. The e2e preload
- * seeds the local test user as admin, then exchanges the bootstrapped API key
- * for a session cookie.
+ * seeds the local test user as admin (AGENT_TEST_BOOTSTRAP_ADMIN=true), then
+ * this file exchanges the bootstrapped API key for a session cookie.
+ *
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   api,
   bearerHeaders,
   exchangeApiKeyForSession,
+  getBaseUrl,
   isServerReachable,
   memberBearerHeaders,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-let sessionCookie: string | null = null;
-
-const adminSessionCookie = process.env.AGENT_TEST_ADMIN_SESSION?.trim() || null;
-
-function shouldRun(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-e-agent-admin] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-e-agent-admin] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
 }
 
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+
+const adminSessionCookie = process.env.AGENT_TEST_ADMIN_SESSION?.trim() || null;
+// The admin-session exchange requires PLAYWRIGHT_TEST_AUTH=true on the target
+// Worker (always true in the run-e2e-batches lane). Failing while the Worker
+// is up is a harness defect — fail loud, don't skip.
+const sessionCookie: string | null =
+  serverReachable && hasTestApiKey
+    ? adminSessionCookie || (await exchangeApiKeyForSession())
+    : null;
+
 function adminHeaders(): Record<string, string> {
-  const cookie = adminSessionCookie || sessionCookie;
-  if (!cookie) {
+  if (!sessionCookie) {
     throw new Error(
       "Admin session cookie missing; ensure the e2e preload exchanged the bootstrapped API key.",
     );
   }
-  return { Cookie: cookie, "Content-Type": "application/json" };
+  return { Cookie: sessionCookie, "Content-Type": "application/json" };
 }
-
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!hasTestApiKey) {
-    throw new Error(
-      "[group-e] TEST_API_KEY is not set; the e2e preload did not bootstrap auth.",
-    );
-  }
-
-  sessionCookie = adminSessionCookie || (await exchangeApiKeyForSession());
-});
-
-afterAll(async () => {
-  void sessionCookie;
-});
 
 const FAKE_UUID = "00000000-0000-4000-8000-000000000000";
-const NOT_IMPLEMENTED_OK_STATUSES = [200, 202, 501] as const;
 
 /**
- * Assert that an unauthenticated request to a protected /api/ path is rejected
- * by the global auth middleware. The middleware returns 401 for missing creds;
- * a route that returns its own 403 (e.g. for missing wallet/admin) is also
- * acceptable here. 404 is never acceptable — that would indicate the route is
- * not mounted at all.
+ * Assert the global auth middleware rejected an unauthenticated request with
+ * exactly 401. (403 would mean a handler ran; 404 would mean the route is not
+ * mounted at all — both are regressions.)
  */
 function expectAuthGate(status: number, path: string): void {
-  expect([401, 403]).toContain(status);
-  if (![401, 403].includes(status)) {
-    throw new Error(
-      `Expected 401/403 from unauthenticated ${path}, got ${status}`,
-    );
+  if (status !== 401) {
+    throw new Error(`Expected 401 from unauthenticated ${path}, got ${status}`);
   }
+  expect(status).toBe(401);
 }
 
-describe("Group E: admin / redemptions", () => {
+describeE2E("Group E: admin / redemptions", () => {
   test("GET /api/admin/redemptions rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/admin/redemptions");
     expectAuthGate(res.status, "GET /api/admin/redemptions");
   });
 
   test("GET /api/admin/redemptions rejects non-admin bearer with 403", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/admin/redemptions", {
       headers: memberBearerHeaders(),
     });
-    // Use the seeded member key here; the primary bootstrapped key is a super-admin
-    // when AGENT_TEST_BOOTSTRAP_ADMIN=true.
-    expect([401, 403]).toContain(res.status);
+    // The seeded member key authenticates fine (so not 401) but lacks the
+    // admin role → the route's own gate answers 403.
+    expect(res.status).toBe(403);
   });
 
   test("POST /api/admin/redemptions rejects invalid body with 400 (admin) or 401/403 (non-admin)", async () => {
-    if (!shouldRun()) return;
     const headers = adminHeaders();
     const res = await api.post(
       "/api/admin/redemptions",
@@ -123,7 +120,6 @@ describe("Group E: admin / redemptions", () => {
   });
 
   test("GET /api/admin/redemptions returns redemption list for admin", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/admin/redemptions?status=pending&limit=5", {
       headers: adminHeaders(),
     });
@@ -139,23 +135,20 @@ describe("Group E: admin / redemptions", () => {
   });
 });
 
-describe("Group E: admin / ai-pricing", () => {
+describeE2E("Group E: admin / ai-pricing", () => {
   test("GET /api/v1/admin/ai-pricing rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/admin/ai-pricing");
     expectAuthGate(res.status, "GET /api/v1/admin/ai-pricing");
   });
 
   test("GET /api/v1/admin/ai-pricing rejects non-admin bearer", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/admin/ai-pricing", {
       headers: memberBearerHeaders(),
     });
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(403);
   });
 
   test("PUT /api/v1/admin/ai-pricing rejects invalid body", async () => {
-    if (!shouldRun()) return;
     const headers = adminHeaders();
     const res = await api.put(
       "/api/v1/admin/ai-pricing",
@@ -171,7 +164,6 @@ describe("Group E: admin / ai-pricing", () => {
   });
 
   test("GET /api/v1/admin/ai-pricing returns pricing entries for admin", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/admin/ai-pricing", {
       headers: adminHeaders(),
     });
@@ -185,15 +177,13 @@ describe("Group E: admin / ai-pricing", () => {
   });
 });
 
-describe("Group E: admin / cloud-observability", () => {
+describeE2E("Group E: admin / cloud-observability", () => {
   test("GET /api/v1/admin/cloud-observability rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/admin/cloud-observability");
     expectAuthGate(res.status, "GET /api/v1/admin/cloud-observability");
   });
 
   test("GET /api/v1/admin/cloud-observability returns request telemetry for admin", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/admin/cloud-observability?limit=25", {
       headers: adminHeaders(),
     });
@@ -217,36 +207,32 @@ describe("Group E: admin / cloud-observability", () => {
   });
 });
 
-describe("Group E: admin / docker-containers (live + 501 stubs)", () => {
+describeE2E("Group E: admin / docker-containers (live + 501 stubs)", () => {
   test("GET /api/v1/admin/docker-containers rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/admin/docker-containers");
     expectAuthGate(res.status, "GET /api/v1/admin/docker-containers");
   });
 
   test("GET /api/v1/admin/docker-containers rejects non-super-admin bearer", async () => {
-    if (!shouldRun()) return;
     const res = await api.get("/api/v1/admin/docker-containers", {
       headers: memberBearerHeaders(),
     });
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(403);
   });
 
   test("GET /api/v1/admin/docker-containers rejects invalid status filter (admin)", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       "/api/v1/admin/docker-containers?status=garbage",
       {
         headers: adminHeaders(),
       },
     );
-    // ValidationError(400) when status is not in the allowed set; super_admin
-    // is required so 403 is also acceptable for non-super admins.
-    expect([400, 403]).toContain(res.status);
+    // ValidationError(400): status is not in the allowed set (the seeded
+    // session is super-admin, so the role gate never fires here).
+    expect(res.status).toBe(400);
   });
 
   test("GET /api/v1/admin/docker-containers/:id/logs is gated before route handling", async () => {
-    if (!shouldRun()) return;
     const unauthed = await api.get(
       `/api/v1/admin/docker-containers/${FAKE_UUID}/logs`,
     );
@@ -258,15 +244,12 @@ describe("Group E: admin / docker-containers (live + 501 stubs)", () => {
         headers: bearerHeaders(),
       },
     );
-    expect([404, 501]).toContain(authed.status);
-    if (authed.status === 501) {
-      const body = (await authed.json()) as { error?: string };
-      expect(body.error).toBe("not_yet_migrated");
-    }
+    expect(authed.status).toBe(501);
+    const body = (await authed.json()) as { error?: string };
+    expect(body.error).toBe("not_yet_migrated");
   });
 
   test("GET /api/v1/admin/docker-containers/audit returns the Worker boundary fallback", async () => {
-    if (!shouldRun()) return;
     const unauthed = await api.get("/api/v1/admin/docker-containers/audit");
     expectAuthGate(unauthed.status, "GET docker-containers/audit (unauth)");
 
@@ -277,7 +260,6 @@ describe("Group E: admin / docker-containers (live + 501 stubs)", () => {
   });
 
   test("POST /api/v1/admin/infrastructure/containers/actions rejects unauthenticated and returns the Worker boundary fallback", async () => {
-    if (!shouldRun()) return;
     const unauthed = await api.post(
       "/api/v1/admin/infrastructure/containers/actions",
       {
@@ -301,31 +283,27 @@ describe("Group E: admin / docker-containers (live + 501 stubs)", () => {
   });
 });
 
-describe("Group E: advertising / accounts", () => {
+describeE2E("Group E: advertising / accounts", () => {
   test("GET /api/v1/advertising/accounts/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/advertising/accounts/${FAKE_UUID}`);
     expectAuthGate(res.status, "GET advertising/accounts/:id");
   });
 
   test("GET /api/v1/advertising/accounts/:id returns 404 for unknown id", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/v1/advertising/accounts/${FAKE_UUID}`, {
       headers: bearerHeaders(),
     });
-    // Unknown / not-owned account returns 404; service-layer validation may
-    // also surface a 400 if the id is not a valid uuid for some platforms.
-    expect([400, 404]).toContain(res.status);
+    // FAKE_UUID is well-formed, so validation passes and the ownership
+    // lookup misses → 404.
+    expect(res.status).toBe(404);
   });
 
   test("DELETE /api/v1/advertising/accounts/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.delete(`/api/v1/advertising/accounts/${FAKE_UUID}`);
     expectAuthGate(res.status, "DELETE advertising/accounts/:id");
   });
 
   test("POST /api/v1/advertising/accounts/:id/media rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.post(
       `/api/v1/advertising/accounts/${FAKE_UUID}/media`,
       {
@@ -337,7 +315,6 @@ describe("Group E: advertising / accounts", () => {
   });
 
   test("POST /api/v1/advertising/accounts/:id/media rejects invalid body with 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/v1/advertising/accounts/${FAKE_UUID}/media`,
       { type: "audio", url: "not-a-url" },
@@ -347,7 +324,6 @@ describe("Group E: advertising / accounts", () => {
   });
 
   test("GET /api/v1/advertising/accounts/:id/media rejects missing status query", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       `/api/v1/advertising/accounts/${FAKE_UUID}/media`,
       {
@@ -358,41 +334,35 @@ describe("Group E: advertising / accounts", () => {
   });
 });
 
-describe("Group E: advertising / campaigns", () => {
+describeE2E("Group E: advertising / campaigns", () => {
   test("GET /api/v1/advertising/campaigns/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/advertising/campaigns/${FAKE_UUID}`);
     expectAuthGate(res.status, "GET advertising/campaigns/:id");
   });
 
   test("GET /api/v1/advertising/campaigns/:id returns 404 for unknown id", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(`/api/v1/advertising/campaigns/${FAKE_UUID}`, {
       headers: bearerHeaders(),
     });
-    expect([400, 404]).toContain(res.status);
+    expect(res.status).toBe(404);
   });
 
   test("PATCH /api/v1/advertising/campaigns/:id rejects invalid body with 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.patch(
       `/api/v1/advertising/campaigns/${FAKE_UUID}`,
       { budgetAmount: "not-a-number", startDate: "definitely-not-an-iso-date" },
       { headers: bearerHeaders() },
     );
-    // Invalid body short-circuits before the service layer; either a 400 from
-    // the schema or a 404 if the route's lookup runs first.
-    expect([400, 404]).toContain(res.status);
+    // The schema rejects the body before any campaign lookup runs.
+    expect(res.status).toBe(400);
   });
 
   test("DELETE /api/v1/advertising/campaigns/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.delete(`/api/v1/advertising/campaigns/${FAKE_UUID}`);
     expectAuthGate(res.status, "DELETE advertising/campaigns/:id");
   });
 
   test("GET /api/v1/advertising/campaigns/:id/analytics rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/analytics`,
     );
@@ -400,7 +370,6 @@ describe("Group E: advertising / campaigns", () => {
   });
 
   test("GET /api/v1/advertising/campaigns/:id/analytics rejects bad date range with 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.get(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/analytics?startDate=2024-12-31T00:00:00Z&endDate=2024-01-01T00:00:00Z`,
       { headers: bearerHeaders() },
@@ -411,7 +380,6 @@ describe("Group E: advertising / campaigns", () => {
   });
 
   test("GET /api/v1/advertising/campaigns/:id/creatives rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/creatives`,
     );
@@ -419,17 +387,16 @@ describe("Group E: advertising / campaigns", () => {
   });
 
   test("POST /api/v1/advertising/campaigns/:id/creatives rejects invalid body with 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/creatives`,
       { name: 0, type: "not-a-real-type" },
       { headers: bearerHeaders() },
     );
-    expect([400, 404]).toContain(res.status);
+    // The creative schema rejects the body before any campaign lookup runs.
+    expect(res.status).toBe(400);
   });
 
   test("POST /api/v1/advertising/campaigns/:id/pause rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.post(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/pause`,
     );
@@ -437,7 +404,6 @@ describe("Group E: advertising / campaigns", () => {
   });
 
   test("POST /api/v1/advertising/campaigns/:id/start rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.post(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/start`,
     );
@@ -445,7 +411,6 @@ describe("Group E: advertising / campaigns", () => {
   });
 
   test("POST /api/v1/advertising/campaigns/:id/start returns 404 for unknown campaign", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       `/api/v1/advertising/campaigns/${FAKE_UUID}/start`,
       undefined,
@@ -453,19 +418,18 @@ describe("Group E: advertising / campaigns", () => {
         headers: bearerHeaders(),
       },
     );
-    expect([400, 404]).toContain(res.status);
+    // FAKE_UUID is well-formed; the campaign lookup misses → 404.
+    expect(res.status).toBe(404);
   });
 });
 
-describe("Group E: advertising / creatives", () => {
+describeE2E("Group E: advertising / creatives", () => {
   test("GET /api/v1/advertising/creatives/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/advertising/creatives/${FAKE_UUID}`);
     expectAuthGate(res.status, "GET advertising/creatives/:id");
   });
 
   test("PATCH /api/v1/advertising/creatives/:id rejects invalid body with 400", async () => {
-    if (!shouldRun()) return;
     const res = await api.patch(
       `/api/v1/advertising/creatives/${FAKE_UUID}`,
       { media: [{ url: "not-a-url" }] },
@@ -475,15 +439,13 @@ describe("Group E: advertising / creatives", () => {
   });
 
   test("DELETE /api/v1/advertising/creatives/:id rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.delete(`/api/v1/advertising/creatives/${FAKE_UUID}`);
     expectAuthGate(res.status, "DELETE advertising/creatives/:id");
   });
 });
 
-describe("Group E: training / vertex tune Worker boundary", () => {
+describeE2E("Group E: training / vertex tune Worker boundary", () => {
   test("POST /api/training/vertex/tune rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/training/vertex/tune", {
       datasetUri: "gs://demo",
     });
@@ -491,39 +453,32 @@ describe("Group E: training / vertex tune Worker boundary", () => {
   });
 
   test("POST /api/training/vertex/tune returns 501 (node:fs blocker)", async () => {
-    if (!shouldRun()) return;
     const res = await api.post(
       "/api/training/vertex/tune",
       { datasetUri: "gs://demo" },
       { headers: bearerHeaders() },
     );
-    expect(NOT_IMPLEMENTED_OK_STATUSES).toContain(
-      res.status as (typeof NOT_IMPLEMENTED_OK_STATUSES)[number],
-    );
-    if (res.status === 501) {
-      const body = (await res.json()) as { error?: string; reason?: string };
-      expect(body.error).toBe("not_yet_migrated");
-    }
+    // Worker boundary stub (node:fs blocker) — exactly 501 until migrated.
+    expect(res.status).toBe(501);
+    const body = (await res.json()) as { error?: string; reason?: string };
+    expect(body.error).toBe("not_yet_migrated");
   });
 
   test("GET /api/training/vertex/tune rejects unauthenticated", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/training/vertex/tune");
     expectAuthGate(res.status, "GET training/vertex/tune");
   });
 });
 
-describe("Group E: session-cookie sanity check", () => {
+describeE2E("Group E: session-cookie sanity check", () => {
   test("can exchange API key for session cookie (sanity that base harness works)", async () => {
-    if (!shouldRun()) return;
-    sessionCookie = await exchangeApiKeyForSession();
-    expect(sessionCookie).toMatch(/^[^=]+=.+/);
+    const freshCookie = await exchangeApiKeyForSession();
+    expect(freshCookie).toMatch(/^[^=]+=.+/);
   });
 });
 
-describe("Group E: admin / docker control-plane forwarding", () => {
+describeE2E("Group E: admin / docker control-plane forwarding", () => {
   test("POST /api/v1/admin/docker-nodes/:nodeId/health-check forwards to the control plane", async () => {
-    if (!shouldRun()) return;
     const unauthed = await api.post(
       `/api/v1/admin/docker-nodes/${FAKE_UUID}/health-check`,
     );

--- a/packages/cloud/api/test/e2e/group-f-connectors.test.ts
+++ b/packages/cloud/api/test/e2e/group-f-connectors.test.ts
@@ -36,15 +36,23 @@
  *     env is absent we assert the correct rejection code instead of 200.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { api, getBaseUrl, isServerReachable } from "./_helpers/api";
 
-beforeAll(async () => {
-  await isServerReachable();
-});
+const serverReachable = await isServerReachable();
+if (!serverReachable) {
+  console.warn(
+    `[group-f-connectors] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker is absent.
+// (These tests need no API key — they assert unauthenticated contracts.)
+const describeE2E = describe.skipIf(!serverReachable);
 
 // No cleanup needed — these tests do not create persistent state.
-afterAll(() => {});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,7 +142,7 @@ async function buildWhatsAppSignature(
 // /api/eliza-app/connections
 // ---------------------------------------------------------------------------
 
-describe("GET /api/eliza-app/connections", () => {
+describeE2E("GET /api/eliza-app/connections", () => {
   test("no Authorization header → 401", async () => {
     const res = await api.get("/api/eliza-app/connections");
     expect(res.status).toBe(401);
@@ -160,8 +168,8 @@ describe("GET /api/eliza-app/connections", () => {
         headers: { Authorization: "Bearer bogus" },
       },
     );
-    // Auth gate fires before platform check
-    expect([400, 401]).toContain(res.status);
+    // Auth gate fires before the platform check.
+    expect(res.status).toBe(401);
   });
 });
 
@@ -169,7 +177,7 @@ describe("GET /api/eliza-app/connections", () => {
 // /api/eliza-app/connections/:platform/initiate
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza-app/connections/:platform/initiate", () => {
+describeE2E("POST /api/eliza-app/connections/:platform/initiate", () => {
   test("no Authorization header → 401", async () => {
     const res = await api.post(
       "/api/eliza-app/connections/google/initiate",
@@ -197,7 +205,8 @@ describe("POST /api/eliza-app/connections/:platform/initiate", () => {
       {},
       { headers: { Authorization: "Bearer bogus" } },
     );
-    expect([400, 401]).toContain(res.status);
+    // Session check fires before the unsupported-platform 400.
+    expect(res.status).toBe(401);
   });
 });
 
@@ -205,7 +214,7 @@ describe("POST /api/eliza-app/connections/:platform/initiate", () => {
 // /api/eliza-app/gateway/:agentId
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza-app/gateway/:agentId", () => {
+describeE2E("POST /api/eliza-app/gateway/:agentId", () => {
   // Public path — no auth gate.
 
   test("missing message body → 400", async () => {
@@ -241,7 +250,9 @@ describe("POST /api/eliza-app/gateway/:agentId", () => {
         body: "not-json{{",
       },
     );
-    expect([400, 500]).toContain(res.status);
+    // The handler parses the body itself; malformed JSON surfaces as its own
+    // 500 envelope (not a middleware 400).
+    expect(res.status).toBe(500);
   });
 });
 
@@ -249,7 +260,7 @@ describe("POST /api/eliza-app/gateway/:agentId", () => {
 // /api/eliza-app/user/me
 // ---------------------------------------------------------------------------
 
-describe("GET /api/eliza-app/user/me", () => {
+describeE2E("GET /api/eliza-app/user/me", () => {
   // Public path per auth.ts, but handler checks its own session token.
 
   test("no Authorization header → 401", async () => {
@@ -273,7 +284,7 @@ describe("GET /api/eliza-app/user/me", () => {
 // /api/eliza-app/webhook/* — forwards when configured; fail closed otherwise
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza-app/webhook/blooio", () => {
+describeE2E("POST /api/eliza-app/webhook/blooio", () => {
   test("without gateway URL → 503 WEBHOOK_GATEWAY_NOT_CONFIGURED", async () => {
     const res = await api.post("/api/eliza-app/webhook/blooio", {
       event: "test",
@@ -284,7 +295,7 @@ describe("POST /api/eliza-app/webhook/blooio", () => {
   });
 });
 
-describe("POST /api/eliza-app/webhook/discord", () => {
+describeE2E("POST /api/eliza-app/webhook/discord", () => {
   test("without Discord webhook handler URL → 503 DISCORD_WEBHOOK_HANDLER_NOT_CONFIGURED", async () => {
     const res = await api.post("/api/eliza-app/webhook/discord", {
       event: "test",
@@ -295,7 +306,7 @@ describe("POST /api/eliza-app/webhook/discord", () => {
   });
 });
 
-describe("POST /api/eliza-app/webhook/telegram", () => {
+describeE2E("POST /api/eliza-app/webhook/telegram", () => {
   test("without gateway URL → 503 WEBHOOK_GATEWAY_NOT_CONFIGURED", async () => {
     const res = await api.post("/api/eliza-app/webhook/telegram", {
       update_id: 1,
@@ -306,7 +317,7 @@ describe("POST /api/eliza-app/webhook/telegram", () => {
   });
 });
 
-describe("POST /api/eliza-app/webhook/twilio", () => {
+describeE2E("POST /api/eliza-app/webhook/twilio", () => {
   test("without gateway URL → 503 WEBHOOK_GATEWAY_NOT_CONFIGURED", async () => {
     const res = await api.post("/api/eliza-app/webhook/twilio", {
       MessageSid: "SM_test",
@@ -320,7 +331,7 @@ describe("POST /api/eliza-app/webhook/twilio", () => {
   });
 });
 
-describe("POST /api/eliza-app/webhook/whatsapp", () => {
+describeE2E("POST /api/eliza-app/webhook/whatsapp", () => {
   test("without gateway URL → 503 WEBHOOK_GATEWAY_NOT_CONFIGURED", async () => {
     const res = await api.post("/api/eliza-app/webhook/whatsapp", {
       object: "whatsapp_business_account",
@@ -335,7 +346,7 @@ describe("POST /api/eliza-app/webhook/whatsapp", () => {
 // /api/eliza/rooms/:roomId — legacy route contract
 // ---------------------------------------------------------------------------
 
-describe("GET/POST /api/eliza/rooms/:roomId (legacy route)", () => {
+describeE2E("GET/POST /api/eliza/rooms/:roomId (legacy route)", () => {
   test("any request → 501 unsupported route contract", async () => {
     const res = await api.get("/api/eliza/rooms/room-test-001");
     expect(res.status).toBe(501);
@@ -349,7 +360,7 @@ describe("GET/POST /api/eliza/rooms/:roomId (legacy route)", () => {
 // /api/eliza/rooms/:roomId/messages — legacy route contract
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza/rooms/:roomId/messages (legacy route)", () => {
+describeE2E("POST /api/eliza/rooms/:roomId/messages (legacy route)", () => {
   test("any request → 501 unsupported route contract", async () => {
     const res = await api.post("/api/eliza/rooms/room-test-001/messages", {
       text: "hello",
@@ -364,7 +375,7 @@ describe("POST /api/eliza/rooms/:roomId/messages (legacy route)", () => {
 // /api/eliza/rooms/:roomId/messages/stream — legacy route contract
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza/rooms/:roomId/messages/stream (legacy route)", () => {
+describeE2E("POST /api/eliza/rooms/:roomId/messages/stream (legacy route)", () => {
   test("any request → 501 unsupported route contract", async () => {
     const res = await api.post(
       "/api/eliza/rooms/room-test-001/messages/stream",
@@ -390,7 +401,7 @@ describe("POST /api/eliza/rooms/:roomId/messages/stream (legacy route)", () => {
 // /api/eliza/rooms/:roomId/welcome
 // ---------------------------------------------------------------------------
 
-describe("POST /api/eliza/rooms/:roomId/welcome", () => {
+describeE2E("POST /api/eliza/rooms/:roomId/welcome", () => {
   // Public path — but handler enforces its own auth (session or anon cookie).
 
   test("no auth → 401", async () => {
@@ -402,18 +413,16 @@ describe("POST /api/eliza/rooms/:roomId/welcome", () => {
   });
 
   test("missing text → 400", async () => {
-    // Even without auth, validation fires before auth when text is empty in
-    // some code paths — but in this handler auth check runs second. Either
-    // 400 or 401 is acceptable here; we assert the body is not 200.
+    // Empty-text validation fires before the auth check in this handler.
     const res = await api.post(
       "/api/eliza/rooms/room-welcome-test/welcome",
       {},
     );
-    expect([400, 401]).toContain(res.status);
+    expect(res.status).toBe(400);
   });
 });
 
-describe("DELETE /api/eliza/rooms/:roomId/welcome", () => {
+describeE2E("DELETE /api/eliza/rooms/:roomId/welcome", () => {
   test("no auth → 401", async () => {
     const res = await api.delete("/api/eliza/rooms/room-welcome-test/welcome");
     expect(res.status).toBe(401);
@@ -424,7 +433,7 @@ describe("DELETE /api/eliza/rooms/:roomId/welcome", () => {
 // /api/webhooks/blooio/:orgId
 // ---------------------------------------------------------------------------
 
-describe("GET /api/webhooks/blooio/:orgId (health probe)", () => {
+describeE2E("GET /api/webhooks/blooio/:orgId (health probe)", () => {
   test("returns 200 ok", async () => {
     const res = await api.get("/api/webhooks/blooio/test-org-blooio");
     expect(res.status).toBe(200);
@@ -433,7 +442,7 @@ describe("GET /api/webhooks/blooio/:orgId (health probe)", () => {
   });
 });
 
-describe("POST /api/webhooks/blooio/:orgId", () => {
+describeE2E("POST /api/webhooks/blooio/:orgId", () => {
   test("missing or invalid signature → 401 or 500 (no secret configured)", async () => {
     // Without SKIP_WEBHOOK_VERIFICATION, the handler tries to load the webhook
     // secret from the DB. In the test environment there is no DB row for
@@ -456,7 +465,10 @@ describe("POST /api/webhooks/blooio/:orgId", () => {
         body,
       },
     );
-    expect([401, 500]).toContain(res.status);
+    // No org/secret named test-org-blooio is seeded, so the verifier throws
+    // before signature comparison → the route's 500 envelope. (A seeded
+    // secret would make this a 401 signature-mismatch.)
+    expect(res.status).toBe(500);
   });
 
   test("invalid JSON body → 400", async () => {
@@ -474,7 +486,8 @@ describe("POST /api/webhooks/blooio/:orgId", () => {
         body: "not-json{{{{",
       },
     );
-    expect([400, 401, 500]).toContain(res.status);
+    // Same unseeded-org path: the verifier throws before JSON validation.
+    expect(res.status).toBe(500);
   });
 
   test("valid signed payload with SKIP_WEBHOOK_VERIFICATION → 200 or 500 (no DB)", async () => {
@@ -500,9 +513,11 @@ describe("POST /api/webhooks/blooio/:orgId", () => {
         body: bodyJson,
       },
     );
-    // Worker may not have the test secret configured, so either 200 (sig
-    // skipped via env) or 401/500 (no secret in DB / sig mismatch).
-    expect([200, 401, 500]).toContain(res.status);
+    // The e2e DB seeds no secret for test-org-blooio, so even a well-formed
+    // signature dies in the verifier's org lookup → 500. (With a seeded
+    // secret this is the 200 happy path; with SKIP_WEBHOOK_VERIFICATION the
+    // sig is skipped entirely.)
+    expect(res.status).toBe(500);
   });
 });
 
@@ -510,7 +525,7 @@ describe("POST /api/webhooks/blooio/:orgId", () => {
 // /api/webhooks/twilio/:orgId
 // ---------------------------------------------------------------------------
 
-describe("GET /api/webhooks/twilio/:orgId (health probe)", () => {
+describeE2E("GET /api/webhooks/twilio/:orgId (health probe)", () => {
   test("returns 200 ok", async () => {
     const res = await api.get("/api/webhooks/twilio/test-org-twilio");
     expect(res.status).toBe(200);
@@ -519,7 +534,7 @@ describe("GET /api/webhooks/twilio/:orgId (health probe)", () => {
   });
 });
 
-describe("POST /api/webhooks/twilio/:orgId", () => {
+describeE2E("POST /api/webhooks/twilio/:orgId", () => {
   test("no X-Twilio-Signature header → 401 or 500 (no auth token configured)", async () => {
     // Twilio webhook receives form-encoded data, not JSON.
     const formParams = new URLSearchParams({
@@ -538,8 +553,8 @@ describe("POST /api/webhooks/twilio/:orgId", () => {
         body: formParams.toString(),
       },
     );
-    // Without X-Twilio-Signature + no auth token in DB → 401 or 500.
-    expect([401, 500]).toContain(res.status);
+    // No auth token is seeded for test-org-twilio: the verifier throws → 500.
+    expect(res.status).toBe(500);
   });
 
   test("invalid/missing form fields → 400", async () => {
@@ -552,11 +567,8 @@ describe("POST /api/webhooks/twilio/:orgId", () => {
         body: "not=valid",
       },
     );
-    // Zod validation runs before sig check in this handler, so 400.
-    // If SKIP_WEBHOOK_VERIFICATION is set AND the body passes Zod but sig check
-    // is skipped, we'd still get 400 for the invalid fields. Without
-    // SKIP_WEBHOOK_VERIFICATION and without a DB token, 500 is also valid.
-    expect([400, 401, 500]).toContain(res.status);
+    // Zod validation runs before the signature check → exactly 400.
+    expect(res.status).toBe(400);
   });
 
   test("valid signed form payload with SKIP_WEBHOOK_VERIFICATION → 200/xml or 401/500", async () => {
@@ -580,13 +592,10 @@ describe("POST /api/webhooks/twilio/:orgId", () => {
       },
       body: formBody,
     });
-    // 200 with XML TwiML response when Worker has SKIP_WEBHOOK_VERIFICATION=true,
-    // or 401/500 when not configured.
-    expect([200, 401, 500]).toContain(res.status);
-    if (res.status === 200) {
-      const contentType = res.headers.get("content-type") ?? "";
-      expect(contentType).toContain("xml");
-    }
+    // Without SKIP_WEBHOOK_VERIFICATION and with no seeded auth token the
+    // verifier throws → 500. (SKIP_WEBHOOK_VERIFICATION=true would yield the
+    // 200 TwiML path.)
+    expect(res.status).toBe(500);
   });
 });
 
@@ -594,7 +603,7 @@ describe("POST /api/webhooks/twilio/:orgId", () => {
 // /api/webhooks/whatsapp/:orgId
 // ---------------------------------------------------------------------------
 
-describe("GET /api/webhooks/whatsapp/:orgId (Meta verification handshake)", () => {
+describeE2E("GET /api/webhooks/whatsapp/:orgId (Meta verification handshake)", () => {
   test("missing hub.mode query param → 403 (verification fails)", async () => {
     // Without hub.mode, hub.verify_token, hub.challenge the service
     // returns null → handler sends 403.
@@ -612,8 +621,8 @@ describe("GET /api/webhooks/whatsapp/:orgId (Meta verification handshake)", () =
   });
 });
 
-describe("POST /api/webhooks/whatsapp/:orgId", () => {
-  test("missing or invalid x-hub-signature-256 → 400 (bad orgId), 401 (no secret), or 500", async () => {
+describeE2E("POST /api/webhooks/whatsapp/:orgId", () => {
+  test("invalid signature with non-UUID orgId → 400 before signature handling", async () => {
     const body = JSON.stringify({
       object: "whatsapp_business_account",
       entry: [],
@@ -629,8 +638,11 @@ describe("POST /api/webhooks/whatsapp/:orgId", () => {
         body,
       },
     );
-    // 400 — orgId fails uuid validation; 401 — signature mismatch; 500 — verifier threw.
-    expect([400, 401, 500]).toContain(res.status);
+    // "test-org-wa" fails the route's UUID validation before any signature
+    // handling → exactly 400.
+    expect(res.status).toBe(400);
+    const errBody = (await res.json()) as { error?: string };
+    expect(errBody.error).toBe("Invalid organization ID");
   });
 
   test("invalid JSON body → 400", async () => {
@@ -645,7 +657,8 @@ describe("POST /api/webhooks/whatsapp/:orgId", () => {
         body: "not-json{{",
       },
     );
-    expect([400, 401, 500]).toContain(res.status);
+    // UUID validation still fires first — the malformed JSON is never read.
+    expect(res.status).toBe(400);
   });
 
   test("valid signed payload with SKIP_WEBHOOK_VERIFICATION → 200 or 400/401/500", async () => {
@@ -666,7 +679,8 @@ describe("POST /api/webhooks/whatsapp/:orgId", () => {
         body: bodyJson,
       },
     );
-    // 400 — orgId fails uuid validation; 401 — signature rejected; 500 — verifier threw.
-    expect([200, 400, 401, 500]).toContain(res.status);
+    // "test-org-wa" fails the route's UUID validation before any signature
+    // handling — even a well-formed signature → exactly 400.
+    expect(res.status).toBe(400);
   });
 });

--- a/packages/cloud/api/test/e2e/group-g-mcps.test.ts
+++ b/packages/cloud/api/test/e2e/group-g-mcps.test.ts
@@ -2,39 +2,36 @@
  * Group G — MCP integration bridges.
  *
  * Covers `/api/mcps/<provider>/:transport` for all 17 provider routes mounted
- * by `_router.generated.ts`. Built-in bridges (`time`, `weather`, `crypto`) run
- * `mcp-handler` on Workers; OAuth providers return 501 unless
- * `MCP_<PROVIDER>_STREAMABLE_HTTP_URL` is set to proxy an external streamable-http
- * server. Assertions accept either the Worker fallback envelope or real
- * `jsonrpc: "2.0"`.
+ * by `_router.generated.ts`, backed by one shared gateway
+ * (`src/lib/mcp/mcps-transport-gateway.ts`). Its contract is exact:
  *
- * Per-provider assertions (~3 each):
- *   1. Auth gate — request without auth. The mounted handler answers 501 for
- *      every method/path; the route is also on the public-path list in
- *      `auth.ts`, so the response must be the route's own answer (501
- *      fallback today, real bridge envelope later) — never the global
- *      `Unauthorized`.
- *   2. JSON-RPC envelope — POST a `tools/list` JSON-RPC request with a Bearer
- *      key (or unauthenticated when no key is bootstrapped). Response must be
- *      JSON. Either the 501 fallback body, or a `jsonrpc: "2.0"` envelope.
- *   3. Bad transport — request a garbage transport segment. Today every route
- *      uses `app.all("*")` and answers 501 regardless; a real bridge should
- *      answer 400/404. Both are accepted here.
+ *   - garbage `:transport`  → 404 `unsupported_transport` (every provider)
+ *   - `MCP_<PROVIDER>_STREAMABLE_HTTP_URL` set → proxy to that upstream
+ *     (env-keyed; only asserted loosely when an operator configured it)
+ *   - built-in providers (`time`, `weather`, `crypto`) → real Workers-safe
+ *     JSON-RPC transport: GET 405, POST tools/list 200 with a
+ *     `jsonrpc: "2.0"` result listing the provider's tools
+ *   - every other provider → 501 `not_yet_migrated` fallback envelope
  *
- * Skip behavior mirrors `agent-token-flow.test.ts`: if the Worker is not
- * reachable on `TEST_API_BASE_URL`, every test short-circuits cleanly. Auth
- * is intentionally optional — these MCP routes are public-path-prefixed, so
- * the suite runs even when `SKIP_DB_DEPENDENT=1` and `TEST_API_KEY` is unset.
+ * These routes are public-path-prefixed in `auth.ts`, so no response may be
+ * the global 401 — the suite runs even when `TEST_API_KEY` is unset.
+ *
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker every test
+ * in this file reports as a counted, named `skip` — never a silent pass.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import { api, getBaseUrl, isServerReachable } from "./_helpers/api";
 
-const PROVIDERS = [
+// Built-in bridges run a real JSON-RPC transport in the Worker itself.
+const BUILTIN_PROVIDERS = ["time", "weather", "crypto"] as const;
+
+// OAuth/vendor providers answer 501 until an operator sets
+// MCP_<PROVIDER>_STREAMABLE_HTTP_URL to proxy an external server.
+const PROXY_PROVIDERS = [
   "airtable",
   "asana",
-  "crypto",
   "dropbox",
   "github",
   "google",
@@ -45,18 +42,36 @@ const PROVIDERS = [
   "microsoft",
   "notion",
   "salesforce",
-  "time",
   "twitter",
-  "weather",
   "zoom",
 ] as const;
 
-// Standard MCP transports — any of these is a valid `:transport` value when
-// the bridges are unstubbed. We pick one for the JSON-RPC POST.
+// Expected tool names per built-in provider (mirrors BUILTIN_TOOLS in the
+// gateway) — proves the real transport answered, not a stub.
+const BUILTIN_TOOL_NAMES: Record<string, string[]> = {
+  time: ["get_current_time"],
+  weather: ["get_current_weather", "search_location"],
+  crypto: ["get_price", "get_market_data", "list_trending"],
+};
+
 const REAL_TRANSPORT = "mcp";
 
-let serverReachable = false;
-const optionalAuth: Record<string, string> = {};
+const serverReachable = await isServerReachable();
+if (!serverReachable) {
+  console.warn(
+    `[group-g-mcps] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker is absent.
+const describeE2E = describe.skipIf(!serverReachable);
+
+function upstreamConfigured(provider: string): boolean {
+  const slug = provider.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase();
+  return Boolean(process.env[`MCP_${slug}_STREAMABLE_HTTP_URL`]?.trim());
+}
 
 function jsonRpcToolsList(): Record<string, unknown> {
   return {
@@ -67,26 +82,6 @@ function jsonRpcToolsList(): Record<string, unknown> {
   };
 }
 
-function isFallbackEnvelope(body: unknown): boolean {
-  if (typeof body !== "object" || body === null) return false;
-  const b = body as { success?: unknown; error?: unknown };
-  return b.success === false && typeof b.error === "string";
-}
-
-function isJsonRpcEnvelope(body: unknown): boolean {
-  if (typeof body !== "object" || body === null) return false;
-  return (body as { jsonrpc?: unknown }).jsonrpc === "2.0";
-}
-
-function isJsonErrorEnvelope(body: unknown): boolean {
-  if (typeof body !== "object" || body === null) return false;
-  return typeof (body as { error?: unknown }).error === "string";
-}
-
-function isWranglerRestartBody(text: string): boolean {
-  return text.includes("worker restarted mid-request");
-}
-
 async function postToolsList(
   basePath: string,
 ): Promise<{ status: number; text: string }> {
@@ -95,12 +90,12 @@ async function postToolsList(
       headers: {
         Accept: "application/json, text/event-stream",
         "Content-Type": "application/json",
-        ...optionalAuth,
       },
     });
     const text = await res.text();
 
-    if (attempt === 0 && isWranglerRestartBody(text)) {
+    // wrangler dev can restart the worker mid-request once; retry.
+    if (attempt === 0 && text.includes("worker restarted mid-request")) {
       await new Promise((resolve) => setTimeout(resolve, 250));
       continue;
     }
@@ -111,82 +106,83 @@ async function postToolsList(
   throw new Error(`Retry loop exhausted for ${basePath}`);
 }
 
-beforeAll(async () => {
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-g-mcps] ${getBaseUrl()} did not respond to /api/health. ` +
-        "Tests will skip. Start the Worker (bun run dev:api → wrangler dev) " +
-        "or set TEST_API_BASE_URL to a reachable host.",
-    );
-  }
-  const key = process.env.TEST_API_KEY?.trim();
-  if (key) {
-    optionalAuth.Authorization = `Bearer ${key}`;
-  }
-});
-
-describe("Group G — MCP provider bridges", () => {
-  for (const provider of PROVIDERS) {
-    describe(`/api/mcps/${provider}/:transport`, () => {
+describeE2E("Group G — MCP provider bridges", () => {
+  for (const provider of BUILTIN_PROVIDERS) {
+    describe(`/api/mcps/${provider}/:transport (built-in)`, () => {
       const basePath = `/api/mcps/${provider}/${REAL_TRANSPORT}`;
 
-      test(`${provider}: unauthenticated request answers (no global 401)`, async () => {
-        if (!serverReachable) return;
+      test(`${provider}: GET is 405 from the bridge (no global 401)`, async () => {
         const res = await api.get(basePath);
-        // Accept either the current 501 fallback or a real bridge response. The
-        // route is on the public-path list, so the global auth middleware
-        // never owns the response — anything in this set proves that.
-        expect([200, 400, 404, 405, 501, 503]).toContain(res.status);
-        // Belt-and-braces: if it ever does return 401, surface the body so
-        // the regression is obvious.
-        if (res.status === 401 || res.status === 403) {
-          const body = await res.text();
-          throw new Error(
-            `Expected ${basePath} to be a public-path bridge, got ${res.status}: ${body.slice(0, 200)}`,
-          );
-        }
+        expect(res.status).toBe(405);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe("Method not allowed");
       });
 
-      test(`${provider}: POST tools/list returns JSON envelope (501 fallback or jsonrpc)`, async () => {
-        if (!serverReachable) return;
+      test(`${provider}: POST tools/list returns the real jsonrpc tool list`, async () => {
         const res = await postToolsList(basePath);
-        // 501 today for fallback routes. Real bridges can answer 200 or a JSON
-        // availability error when provider credentials are absent in CI.
-        expect([200, 400, 404, 405, 501, 503]).toContain(res.status);
-
-        const { text } = res;
-        // Body should be JSON. If the Worker ever proxies a non-JSON
-        // response, we want to see it.
-        let body: unknown;
-        try {
-          body = text.length === 0 ? {} : JSON.parse(text);
-        } catch {
-          throw new Error(
-            `Expected JSON body from ${basePath}, got non-JSON: ${text.slice(0, 200)}`,
-          );
-        }
-
-        // One of: fallback envelope, JSON-RPC 2.0 envelope, JSON error from a
-        // configured bridge, or empty 405-ish body.
-        const isFallback = isFallbackEnvelope(body);
-        const isRpc = isJsonRpcEnvelope(body);
-        const isJsonError = isJsonErrorEnvelope(body);
-        if (!isFallback && !isRpc && !isJsonError && res.status !== 405) {
-          throw new Error(
-            `Expected fallback, jsonrpc:"2.0", or JSON error envelope from ${basePath}, got status=${res.status} body=${text.slice(0, 200)}`,
-          );
-        }
+        expect(res.status).toBe(200);
+        const body = JSON.parse(res.text) as {
+          jsonrpc?: string;
+          id?: number;
+          result?: { tools?: Array<{ name?: string }> };
+        };
+        expect(body.jsonrpc).toBe("2.0");
+        expect(body.id).toBe(1);
+        const names = (body.result?.tools ?? []).map((tool) => tool.name);
+        expect(names).toEqual(BUILTIN_TOOL_NAMES[provider]);
       });
 
-      test(`${provider}: garbage :transport is rejected or stubbed`, async () => {
-        if (!serverReachable) return;
+      test(`${provider}: garbage :transport is 404 unsupported_transport`, async () => {
         const res = await api.get(`/api/mcps/${provider}/garbage-transport`);
-        // Today's fallback `app.all("*")` returns 501 for any transport string.
-        // A real bridge should answer 400/404 for unknown transports. Both
-        // are valid future behavior — the test forbids 200 success and the
-        // global 401, which would be regressions.
-        expect([400, 404, 405, 501, 503]).toContain(res.status);
+        expect(res.status).toBe(404);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe("unsupported_transport");
+      });
+    });
+  }
+
+  for (const provider of PROXY_PROVIDERS) {
+    describe(`/api/mcps/${provider}/:transport (proxy)`, () => {
+      const basePath = `/api/mcps/${provider}/${REAL_TRANSPORT}`;
+      const proxied = upstreamConfigured(provider);
+
+      test(`${provider}: unconfigured bridge answers 501 not_yet_migrated (no global 401)`, async () => {
+        const res = await api.get(basePath);
+        if (proxied) {
+          // Env-keyed: MCP_<PROVIDER>_STREAMABLE_HTTP_URL is set, so the
+          // response is whatever the operator's upstream answers — only the
+          // public-path guarantee (never the global 401) can be asserted.
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(501);
+        const body = (await res.json()) as { success?: boolean; error?: string };
+        expect(body.success).toBe(false);
+        expect(body.error).toBe("not_yet_migrated");
+      });
+
+      test(`${provider}: POST tools/list answers the 501 fallback envelope`, async () => {
+        const res = await postToolsList(basePath);
+        if (proxied) {
+          expect(res.status).not.toBe(401);
+          return;
+        }
+        expect(res.status).toBe(501);
+        const body = JSON.parse(res.text) as {
+          success?: boolean;
+          error?: string;
+          reason?: string;
+        };
+        expect(body.success).toBe(false);
+        expect(body.error).toBe("not_yet_migrated");
+        expect(body.reason).toContain("STREAMABLE_HTTP_URL");
+      });
+
+      test(`${provider}: garbage :transport is 404 unsupported_transport`, async () => {
+        const res = await api.get(`/api/mcps/${provider}/garbage-transport`);
+        expect(res.status).toBe(404);
+        const body = (await res.json()) as { error?: string };
+        expect(body.error).toBe("unsupported_transport");
       });
     });
   }

--- a/packages/cloud/api/test/e2e/group-g2-mcp-registry.test.ts
+++ b/packages/cloud/api/test/e2e/group-g2-mcp-registry.test.ts
@@ -5,13 +5,13 @@
  * monetizable user-MCP registry: list (own + public catalog), create, get one,
  * update, publish (enable -> live), unpublish (disable -> draft), and delete.
  *
- * Skip behavior mirrors the other DB-dependent groups (group-l, group-c): if
- * the Worker isn't reachable on TEST_API_BASE_URL the whole suite
- * short-circuits; auth-required tests additionally skip when TEST_API_KEY is
- * unset. Every created MCP is cleaned up in afterAll so reruns stay idempotent.
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass. Every created MCP is cleaned up in
+ * afterAll so reruns stay idempotent.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 
 import {
   api,
@@ -20,13 +20,26 @@ import {
   isServerReachable,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-const createdMcpIds: string[] = [];
-
-function shouldRunAuthed(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-g2-mcp-registry] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
 }
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-g2-mcp-registry] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+
+const createdMcpIds: string[] = [];
 
 function uniqueSlug(): string {
   return `e2e-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -76,24 +89,8 @@ async function createMcp(
   return body.mcp!;
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-g2-mcp-registry] ${getBaseUrl()} did not respond to /api/health. Tests will skip.`,
-    );
-    return;
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-g2-mcp-registry] TEST_API_KEY is not set; auth-required tests will skip.",
-    );
-  }
-});
-
 afterAll(async () => {
-  if (!shouldRunAuthed()) return;
+  if (!serverReachable || !hasTestApiKey) return;
   for (const id of createdMcpIds) {
     await api.delete(`/api/v1/mcps/${id}`, { headers: bearerHeaders() });
   }
@@ -119,25 +116,24 @@ afterAll(async () => {
 // affects the CRUD-write group below. Un-skipped (#9943) so the MCP-registry
 // auth/validation surface is actually exercised in CI instead of being entirely
 // skipped along with the broken writes.
-describe("Group G2 — MCP registry auth gates + validation", () => {
+describeE2E("Group G2 — MCP registry auth gates + validation", () => {
   test("auth gate: POST /api/v1/mcps without credentials is rejected", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/mcps", {
       name: "x",
       slug: uniqueSlug(),
       description: "x",
     });
-    expect([401, 403]).toContain(res.status);
+    // /api/v1/mcps is not in publicPathPrefixes → the global auth middleware
+    // rejects with 401.
+    expect(res.status).toBe(401);
   });
 
   test("auth gate: GET /api/v1/mcps without credentials is rejected", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/mcps");
-    expect([401, 403]).toContain(res.status);
+    expect(res.status).toBe(401);
   });
 
   test("create -> rejects an invalid body (400)", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/mcps",
       { name: "", slug: "Invalid Slug!", description: "" },
@@ -147,7 +143,6 @@ describe("Group G2 — MCP registry auth gates + validation", () => {
   });
 
   test("create -> rejects an external MCP missing its endpoint (400)", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/mcps",
       {
@@ -162,7 +157,6 @@ describe("Group G2 — MCP registry auth gates + validation", () => {
   });
 
   test("get one -> 404 for an unknown id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get(
       "/api/v1/mcps/00000000-0000-4000-8000-000000000000",
       { headers: bearerHeaders() },
@@ -171,7 +165,6 @@ describe("Group G2 — MCP registry auth gates + validation", () => {
   });
 
   test("registry catalog -> /api/mcp/registry returns platform + community entries", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/mcp/registry");
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -193,7 +186,6 @@ describe("Group G2 — MCP registry auth gates + validation", () => {
 // runs against a real Railway DB); see TODO(mcp) above.
 describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   test("create -> creates a draft MCP with computed revenue split", async () => {
-    if (!shouldRunAuthed()) return;
     const mcp = await createMcp({ creatorSharePercentage: 70 });
     expect(mcp.status).toBe("draft");
     expect(mcp.creator_share_percentage).toBe("70.00");
@@ -202,7 +194,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("get one -> returns the MCP with owner stats", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     const res = await api.get(`/api/v1/mcps/${created.id}`, {
       headers: bearerHeaders(),
@@ -219,7 +210,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("list (own) -> includes a created MCP", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     const res = await api.get("/api/v1/mcps?scope=own&limit=100", {
       headers: bearerHeaders(),
@@ -231,7 +221,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("update -> patches fields and recomputes the split", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     const res = await api.put(
       `/api/v1/mcps/${created.id}`,
@@ -246,7 +235,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("publish -> moves the MCP to live and into the public catalog", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     const pubRes = await api.post(
       `/api/v1/mcps/${created.id}/publish`,
@@ -266,7 +254,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("publish -> rejects an MCP with no tools", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp({ tools: [] });
     const res = await api.post(
       `/api/v1/mcps/${created.id}/publish`,
@@ -277,7 +264,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("unpublish -> removes the MCP from the public catalog", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     await api.post(`/api/v1/mcps/${created.id}/publish`, undefined, {
       headers: bearerHeaders(),
@@ -291,7 +277,6 @@ describe.skip("Group G2 — user MCP registry CRUD writes", () => {
   });
 
   test("delete -> removes the MCP and a subsequent get 404s", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createMcp();
     const delRes = await api.delete(`/api/v1/mcps/${created.id}`, {
       headers: bearerHeaders(),

--- a/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
+++ b/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
@@ -17,15 +17,17 @@
  *   packages/cloud/api/v1/apps/check-name/route.ts
  *
  * Mirrors the gate/cleanup shape of group-l-app-charges: a `serverReachable`
- * probe, a `hasTestApiKey` flag, a `shouldRunAuthed()` gate, a `createTestApp()`
+ * probe, a `hasTestApiKey` flag, a `describeE2E` skip gate, a `createTestApp()`
  * helper that POSTs with `skipGitHubRepo: true`, a `createdAppIds[]` ledger, and
  * an `afterAll` that DELETEs each created app with `?deleteGitHubRepo=false`.
  *
- * Every authed test early-returns when `!shouldRunAuthed()`, so with no server
- * (or no key) the whole group skips cleanly without a single failure.
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass. Cross-org tests additionally skip
+ * loudly when TEST_MEMBER_API_KEY is absent.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import {
   api,
   bearerHeaders,
@@ -34,9 +36,34 @@ import {
   memberBearerHeaders,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-let hasMemberApiKey = false;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+const hasMemberApiKey = Boolean(process.env.TEST_MEMBER_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-i-apps-lifecycle] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-i-apps-lifecycle] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
+}
+if (!hasMemberApiKey) {
+  console.warn(
+    "[group-i-apps-lifecycle] TEST_MEMBER_API_KEY is not set; cross-org " +
+      "tests will SKIP.",
+  );
+}
+
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
+// Cross-org assertions need the seeded member key; loud skip otherwise.
+const testCrossOrg = test.skipIf(!serverReachable || !hasTestApiKey || !hasMemberApiKey);
+
 const createdAppIds: string[] = [];
 const createdCharacterIds: string[] = [];
 
@@ -61,15 +88,6 @@ async function createTestCharacter(): Promise<string> {
 
 // A syntactically valid UUID that should never resolve to a real app.
 const MISSING_UUID = "00000000-0000-4000-8000-0000000000ff";
-
-function shouldRunAuthed(): boolean {
-  return serverReachable && hasTestApiKey;
-}
-
-/** Cross-org assertions need the seeded member key; skip them otherwise. */
-function shouldRunCrossOrg(): boolean {
-  return shouldRunAuthed() && hasMemberApiKey;
-}
 
 function uniqueName(prefix: string): string {
   return `${prefix} ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -140,30 +158,8 @@ async function getApp(id: string): Promise<AppDto | undefined> {
   return ((await res.json()) as GetAppResponse).app;
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  hasMemberApiKey = Boolean(process.env.TEST_MEMBER_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-i-apps-lifecycle] ${getBaseUrl()} did not respond to /api/health. Tests will skip.`,
-    );
-    return;
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-i-apps-lifecycle] TEST_API_KEY is not set; auth-required tests will skip.",
-    );
-  }
-  if (!hasMemberApiKey) {
-    console.warn(
-      "[group-i-apps-lifecycle] TEST_MEMBER_API_KEY is not set; cross-org tests will skip.",
-    );
-  }
-});
-
 afterAll(async () => {
-  if (!shouldRunAuthed()) return;
+  if (!serverReachable || !hasTestApiKey) return;
   for (const appId of createdAppIds) {
     await api.delete(`/api/v1/apps/${appId}?deleteGitHubRepo=false`, {
       headers: bearerHeaders(),
@@ -178,9 +174,8 @@ afterAll(async () => {
 
 // -------- POST /api/v1/apps (create) ---------------------------------------
 
-describe("POST /api/v1/apps", () => {
+describeE2E("POST /api/v1/apps", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/apps", {
       name: uniqueName("No Auth"),
       app_url: "https://example.com/app",
@@ -190,7 +185,6 @@ describe("POST /api/v1/apps", () => {
   });
 
   test("validation: 400 for an invalid app_url", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/apps",
       {
@@ -207,7 +201,6 @@ describe("POST /api/v1/apps", () => {
   });
 
   test("conflict: 409 with conflictType + suggestedName for a duplicate name", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
     const dupeName = created.name as string;
 
@@ -234,7 +227,6 @@ describe("POST /api/v1/apps", () => {
   });
 
   test("happy path: returns success + app + an eliza_ apiKey", async () => {
-    if (!shouldRunAuthed()) return;
     const name = uniqueName("Full Fields App");
     const res = await api.post(
       "/api/v1/apps",
@@ -273,7 +265,6 @@ describe("POST /api/v1/apps", () => {
   });
 
   test("monetization: create-time monetization fields persist (verified via GET)", async () => {
-    if (!shouldRunAuthed()) return;
     const app = await createTestApp({
       monetization_enabled: true,
       inference_markup_percentage: 25,
@@ -287,15 +278,13 @@ describe("POST /api/v1/apps", () => {
 
 // -------- GET /api/v1/apps (list) ------------------------------------------
 
-describe("GET /api/v1/apps", () => {
+describeE2E("GET /api/v1/apps", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/apps");
     expect(res.status).toBe(401);
   });
 
   test("happy path: returns the org's apps including a freshly created one", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
 
     const res = await api.get("/api/v1/apps", { headers: bearerHeaders() });
@@ -308,8 +297,7 @@ describe("GET /api/v1/apps", () => {
     expect(found?.name).toBe(created.name);
   });
 
-  test("org isolation: a member-org key does not see this org's app", async () => {
-    if (!shouldRunCrossOrg()) return;
+  testCrossOrg("org isolation: a member-org key does not see this org's app", async () => {
     const created = await createTestApp();
 
     const res = await api.get("/api/v1/apps", {
@@ -324,15 +312,13 @@ describe("GET /api/v1/apps", () => {
 
 // -------- GET /api/v1/apps/:id (detail) ------------------------------------
 
-describe("GET /api/v1/apps/:id", () => {
+describeE2E("GET /api/v1/apps/:id", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.get(`/api/v1/apps/${MISSING_UUID}`);
     expect(res.status).toBe(401);
   });
 
   test("validation: 404 for a non-existent app id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.get(`/api/v1/apps/${MISSING_UUID}`, {
       headers: bearerHeaders(),
     });
@@ -342,8 +328,7 @@ describe("GET /api/v1/apps/:id", () => {
     expect(body.error).toBe("App not found");
   });
 
-  test("cross-org: 403 when a member-org key requests this org's app", async () => {
-    if (!shouldRunCrossOrg()) return;
+  testCrossOrg("cross-org: 403 when a member-org key requests this org's app", async () => {
     const created = await createTestApp();
 
     const res = await api.get(`/api/v1/apps/${created.id}`, {
@@ -356,7 +341,6 @@ describe("GET /api/v1/apps/:id", () => {
   });
 
   test("happy path: full detail for an owned app", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
 
     const res = await api.get(`/api/v1/apps/${created.id}`, {
@@ -374,9 +358,8 @@ describe("GET /api/v1/apps/:id", () => {
 
 // -------- PUT / PATCH /api/v1/apps/:id (update) ----------------------------
 
-describe("PUT /api/v1/apps/:id", () => {
+describeE2E("PUT /api/v1/apps/:id", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.put(`/api/v1/apps/${MISSING_UUID}`, {
       description: "x",
     });
@@ -384,7 +367,6 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 
   test("validation: 400 for an invalid contact_email", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
     const res = await api.put(
       `/api/v1/apps/${created.id}`,
@@ -398,7 +380,6 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 
   test("validation: 404 for an unknown id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.put(
       `/api/v1/apps/${MISSING_UUID}`,
       { description: "x" },
@@ -407,8 +388,7 @@ describe("PUT /api/v1/apps/:id", () => {
     expect(res.status).toBe(404);
   });
 
-  test("cross-org: 403 when a member-org key updates this org's app", async () => {
-    if (!shouldRunCrossOrg()) return;
+  testCrossOrg("cross-org: 403 when a member-org key updates this org's app", async () => {
     const created = await createTestApp();
     const res = await api.put(
       `/api/v1/apps/${created.id}`,
@@ -421,7 +401,6 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 
   test("happy path: updates the name", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
     const newName = uniqueName("Renamed App");
 
@@ -444,7 +423,6 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 
   test("happy path: updates allowed_origins", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
     const origins = ["https://a.example.com", "https://b.example.com"];
 
@@ -461,8 +439,7 @@ describe("PUT /api/v1/apps/:id", () => {
     expect(fetched?.allowed_origins).toEqual(origins);
   });
 
-  test("happy path: sets linked_character_ids", async () => {
-    if (!shouldRunAuthed()) return;
+  test("happy path: sets linked_character_ids to owned characters", async () => {
     const created = await createTestApp();
     // Real, caller-owned characters — the update path enforces ownership, so
     // fabricated UUIDs correctly 404 ("Character not found").
@@ -484,8 +461,20 @@ describe("PUT /api/v1/apps/:id", () => {
     expect(fetched?.linked_character_ids).toEqual(characters);
   });
 
+  test("ownership guard: 404 when linking a nonexistent character", async () => {
+    const created = await createTestApp();
+
+    const res = await api.put(
+      `/api/v1/apps/${created.id}`,
+      { linked_character_ids: ["00000000-0000-4000-8000-000000000010"] },
+      { headers: bearerHeaders() },
+    );
+    // #10863: linked_character_ids enforces the same existence/ownership guard
+    // as PUT /apps/:id/characters — unknown character id → 404.
+    expect(res.status).toBe(404);
+  });
+
   test("validation: 400 for more than four linked_character_ids", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
     const tooMany = [
       "00000000-0000-4000-8000-000000000020",
@@ -507,7 +496,6 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 
   test("happy path: an empty-string website_url clears the field to null", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp({
       website_url: "https://example.com",
     });
@@ -527,9 +515,8 @@ describe("PUT /api/v1/apps/:id", () => {
   });
 });
 
-describe("PATCH /api/v1/apps/:id", () => {
+describeE2E("PATCH /api/v1/apps/:id", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.patch(`/api/v1/apps/${MISSING_UUID}`, {
       description: "x",
     });
@@ -537,7 +524,6 @@ describe("PATCH /api/v1/apps/:id", () => {
   });
 
   test("happy path: partial update of the description", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
 
     const res = await api.patch(
@@ -559,23 +545,20 @@ describe("PATCH /api/v1/apps/:id", () => {
 
 // -------- DELETE /api/v1/apps/:id ------------------------------------------
 
-describe("DELETE /api/v1/apps/:id", () => {
+describeE2E("DELETE /api/v1/apps/:id", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.delete(`/api/v1/apps/${MISSING_UUID}`);
     expect(res.status).toBe(401);
   });
 
   test("validation: 404 for an unknown id", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.delete(`/api/v1/apps/${MISSING_UUID}`, {
       headers: bearerHeaders(),
     });
     expect(res.status).toBe(404);
   });
 
-  test("cross-org: 403 when a member-org key deletes this org's app", async () => {
-    if (!shouldRunCrossOrg()) return;
+  testCrossOrg("cross-org: 403 when a member-org key deletes this org's app", async () => {
     const created = await createTestApp();
     const res = await api.delete(`/api/v1/apps/${created.id}`, {
       headers: memberBearerHeaders(),
@@ -589,7 +572,6 @@ describe("DELETE /api/v1/apps/:id", () => {
   });
 
   test("happy path: deletes then a follow-up GET is 404", async () => {
-    if (!shouldRunAuthed()) return;
     const suffix = uniqueName("Disposable");
     const res = await api.post(
       "/api/v1/apps",
@@ -625,9 +607,8 @@ describe("DELETE /api/v1/apps/:id", () => {
 
 // -------- POST /api/v1/apps/check-name -------------------------------------
 
-describe("POST /api/v1/apps/check-name", () => {
+describeE2E("POST /api/v1/apps/check-name", () => {
   test("auth gate: 401 without credentials", async () => {
-    if (!serverReachable) return;
     const res = await api.post("/api/v1/apps/check-name", {
       name: uniqueName("anything"),
     });
@@ -635,7 +616,6 @@ describe("POST /api/v1/apps/check-name", () => {
   });
 
   test("happy path: a fresh name is available", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/apps/check-name",
       { name: uniqueName("Fresh Name") },
@@ -653,7 +633,6 @@ describe("POST /api/v1/apps/check-name", () => {
   });
 
   test("happy path: a taken name reports unavailable with a conflictType", async () => {
-    if (!shouldRunAuthed()) return;
     const created = await createTestApp();
 
     const res = await api.post(
@@ -677,9 +656,8 @@ describe("POST /api/v1/apps/check-name", () => {
 
 // -------- Full round-trip --------------------------------------------------
 
-describe("Apps lifecycle round-trip", () => {
+describeE2E("Apps lifecycle round-trip", () => {
   test("create → list → get → update → delete → 404", async () => {
-    if (!shouldRunAuthed()) return;
 
     // create
     const created = await createTestApp();

--- a/packages/cloud/api/test/e2e/group-j-documents.test.ts
+++ b/packages/cloud/api/test/e2e/group-j-documents.test.ts
@@ -1,4 +1,17 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+/**
+ * Group J — /api/v1/documents (live e2e).
+ *
+ * Every status assertion pins the single status the Worker contract promises
+ * for the CI lane (wrangler dev + PGlite bridge — run-e2e-batches.mjs), which
+ * always binds object storage (`BLOB` in wrangler.toml). A target without the
+ * binding is a broken deployment and must FAIL, not pass through tolerance.
+ *
+ * Skip behavior: with REQUIRE_E2E_SERVER=0 and no reachable Worker (or no
+ * bootstrapped TEST_API_KEY) every test in this file reports as a counted,
+ * named `skip` — never a silent pass.
+ */
+
+import { describe, expect, test } from "bun:test";
 
 import {
   api,
@@ -8,37 +21,32 @@ import {
   url,
 } from "./_helpers/api";
 
-let serverReachable = false;
-let hasTestApiKey = false;
-
-function shouldRunAuthed(): boolean {
-  return serverReachable && hasTestApiKey;
+const serverReachable = await isServerReachable();
+const hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
+if (!serverReachable) {
+  console.warn(
+    `[group-j-documents] ${getBaseUrl()} did not respond to /api/health. ` +
+      "Tests will SKIP. Start the Worker (bun run dev:api → wrangler dev) " +
+      "or set TEST_API_BASE_URL to a reachable host.",
+  );
+}
+if (!hasTestApiKey) {
+  console.warn(
+    "[group-j-documents] TEST_API_KEY is not set; the preload could not " +
+      "bootstrap a test API key. Tests will SKIP.",
+  );
 }
 
-beforeAll(async () => {
-  hasTestApiKey = Boolean(process.env.TEST_API_KEY?.trim());
-  serverReachable = await isServerReachable();
-  if (!serverReachable) {
-    console.warn(
-      `[group-j-documents] ${getBaseUrl()} did not respond to /api/health. Tests will skip.`,
-    );
-  }
-  if (!hasTestApiKey) {
-    console.warn(
-      "[group-j-documents] TEST_API_KEY is not set; auth-gated tests will skip.",
-    );
-  }
-});
+// Loud, counted skip instead of a silent pass when the Worker/key is absent.
+const describeE2E = describe.skipIf(!serverReachable || !hasTestApiKey);
 
-describe("Group J - /api/v1/documents", () => {
+describeE2E("Group J - /api/v1/documents", () => {
   test("auth gate: missing credentials returns 401", async () => {
-    if (!serverReachable) return;
     const res = await api.get("/api/v1/documents");
     expect(res.status).toBe(401);
   });
 
   test("validation: missing text content returns 400", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/documents",
       { filename: "empty.txt" },
@@ -48,7 +56,6 @@ describe("Group J - /api/v1/documents", () => {
   });
 
   test("text document lifecycle: create, list, query, delete", async () => {
-    if (!shouldRunAuthed()) return;
     const marker = `documents-e2e-${crypto.randomUUID()}`;
     const create = await api.post(
       "/api/v1/documents",
@@ -91,7 +98,6 @@ describe("Group J - /api/v1/documents", () => {
   });
 
   test("file upload stores documents without the Node runtime", async () => {
-    if (!shouldRunAuthed()) return;
     const marker = `documents-file-${crypto.randomUUID()}`;
     const form = new FormData();
     form.append(
@@ -122,8 +128,7 @@ describe("Group J - /api/v1/documents", () => {
     }
   });
 
-  test("pre-upload route is live and supports cleanup when object storage is configured", async () => {
-    if (!shouldRunAuthed()) return;
+  test("pre-upload stores a pending blob and cleans it up", async () => {
     const form = new FormData();
     form.append(
       "files",
@@ -136,25 +141,23 @@ describe("Group J - /api/v1/documents", () => {
       body: form,
       signal: AbortSignal.timeout(30_000),
     });
-    expect(res.status).not.toBe(501);
-    expect([200, 503]).toContain(res.status);
-
-    if (res.status === 200) {
-      const body = (await res.json()) as {
-        files?: Array<{ blobUrl?: string }>;
-      };
-      const blobUrl = body.files?.[0]?.blobUrl;
-      expect(blobUrl).toBeTruthy();
-      const deleted = await api.delete("/api/v1/documents/pre-upload", {
-        headers: bearerHeaders(),
-        body: { blobUrl },
-      });
-      expect(deleted.status).toBe(200);
-    }
+    // The `BLOB` R2 binding is declared in wrangler.toml, so every
+    // wrangler-served target has object storage: the contract is 200. (The
+    // route's 503 exists only for a misconfigured deploy — that must fail.)
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      files?: Array<{ blobUrl?: string }>;
+    };
+    const blobUrl = body.files?.[0]?.blobUrl;
+    expect(blobUrl).toBeTruthy();
+    const deleted = await api.delete("/api/v1/documents/pre-upload", {
+      headers: bearerHeaders(),
+      body: { blobUrl },
+    });
+    expect(deleted.status).toBe(200);
   });
 
   test("submit route validates required character and file payload", async () => {
-    if (!shouldRunAuthed()) return;
     const res = await api.post(
       "/api/v1/documents/submit",
       {},


### PR DESCRIPTION
Closes the money/auth E2E row of #11419. `[cloud-money]`

## The regression (my earlier #11419 comment was wrong — corrected there)
PR #11271's stale-branch squash reverted 10 cloud e2e suites to older versions. Verified **byte-identical to squash `5b714c74e6`** at develop tip (md5), zero post-clobber commits. #11432 only restored group-k/l/m.

**What they lost:** the `REQUIRE_E2E_SERVER` fail-loud guard (`group-b`: tip 0, pre-clobber 1 + 2× "never a silent pass"). Without it, `REQUIRE_E2E_SERVER=1` CI runs **silently skip these billing/auth suites when the Worker is unreachable** instead of failing → money/auth e2e can green with zero real coverage, exactly during the launch promote.

## Fix
Restored from `5b714c74e6^` (pre-clobber), each guarded by a `tip==clobbered` md5 check before restoring (so nothing evolved is overwritten): **agent-token-flow, group-b-account-billing, group-c-agents, group-d-ai-media, group-e-agent-admin, group-f-connectors, group-g-mcps, group-g2-mcp-registry, group-i-apps-lifecycle, group-j-documents.** Helper `_helpers/api.ts` still exports `isServerReachable`/`getBaseUrl` (compat verified).

group-i's pre-clobber copy carried a duplicate `createdCharacterIds`/`createTestCharacter` (a latent TS2451/TS2393); removed the dup.

## Verified
`bun run --cwd packages/cloud/api typecheck` → **exit 0** (was 4 errors from the group-i dup). The `REQUIRE_E2E_SERVER` fail-loud guard is back in all restored suites. Test-only change; no Worker/source touched.