### PR TITLE
refactor(cloud): dedupe the app-chat settle-error refund into one shared helper (#11218 follow-up)

### DIFF
--- a/packages/cloud/api/__tests__/apps-chat-nonstreaming-settle-guard.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-nonstreaming-settle-guard.test.ts
@@ -10,11 +10,13 @@
  * only after return, that throw reaches the settle catch as "never settled" and
  * the guard refunds the FULL hold a second time — double-credit.
  *
- * The helper tests (apps-chat-stream-refund.test.ts) drive
- * `reconcileNonStreamingSettleError` with a pre-computed boolean, so they stay
- * green even if the route's flag ordering regresses. This suite drives the REAL
+ * The helper tests (apps-chat-stream-refund.test.ts) drive the shared
+ * `reconcileChatSettleError` with a pre-computed boolean, so they stay green
+ * even if the route's flag ordering regresses. This suite drives the REAL
  * route with a credits seam that models the real non-transactional internals
- * (refund committed, then throw), asserting the refund COUNT end to end.
+ * (refund committed, then throw), asserting the refund COUNT end to end —
+ * plus the streaming branch, so BOTH route call sites are proven to reach the
+ * one shared helper with their own skipRefund flag and ledger tags.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -159,14 +161,14 @@ const { default: chatRoute } = await import("../v1/apps/[id]/chat/route");
 const app = new Hono();
 app.route("/api/v1/apps/:id/chat", chatRoute);
 
-async function postChat(): Promise<Response> {
+async function postChat(stream = false): Promise<Response> {
   return await app.request(`/api/v1/apps/${APP_ID}/chat`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       model: "openai/gpt-oss-120b",
       messages: [{ role: "user", content: "hello" }],
-      stream: false,
+      stream,
     }),
   });
 }
@@ -263,5 +265,82 @@ describe("non-streaming settle double-credit guard (#11218)", () => {
         (c) => c.metadata?.refundReason === "non_streaming_settle_error",
       ),
     ).toBe(false);
+  });
+});
+
+// SSE provider body helpers for the streaming branch.
+function sseResponse(build: (c: ReadableStreamDefaultController) => void) {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        build(controller);
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+const encoder = new TextEncoder();
+
+async function waitFor(cond: () => boolean, ms = 2000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!cond() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("streaming settle-error refund routes through the same shared helper (#10837)", () => {
+  test("stream fails MID-DELIVERY → exactly one full refund, tagged streaming:true", async () => {
+    providerResponseImpl = () =>
+      sseResponse((controller) => {
+        controller.enqueue(
+          encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'),
+        );
+        controller.error(new Error("provider stream reset"));
+      });
+
+    const response = await postChat(true);
+    expect(response.status).toBe(200);
+    // Body EOF = the background catch ran to completion (it closes the writer
+    // after the refund).
+    const body = await response.text();
+    expect(body).toContain("Stream interrupted. Credits refunded.");
+
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(refundCommits).toHaveLength(1);
+    expect(reconcileCalls[0].actualBaseCost).toBe(0);
+    expect(reconcileCalls[0].metadata).toMatchObject({
+      error: true,
+      streaming: true,
+    });
+  });
+
+  test("stream COMPLETED then accounting threw → NO refund (skipRefund keeps the charge)", async () => {
+    providerResponseImpl = () =>
+      sseResponse((controller) => {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"choices":[{"delta":{"content":"hi"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      });
+    // Post-delivery accounting (the 2nd calculateCost call) throws.
+    settleCostImpl = async () => {
+      throw new Error("pricing catalog unavailable");
+    };
+
+    const response = await postChat(true);
+    expect(response.status).toBe(200);
+    await response.text();
+
+    // The writer closes BEFORE the accounting runs — wait for the background
+    // accounting to reach calculateCost and its catch to settle.
+    await waitFor(() => calculateCostCalls === 2);
+    await new Promise((r) => setTimeout(r, 25));
+
+    expect(reconcileCredits).not.toHaveBeenCalled();
+    expect(refundCommits).toHaveLength(0);
   });
 });

--- a/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
@@ -1,37 +1,52 @@
 /**
- * Money-leak guard for POST /api/v1/apps/:id/chat streaming (#10837).
+ * Money-leak guard for POST /api/v1/apps/:id/chat settle errors
+ * (#10837 streaming, #11169 part 1 non-streaming).
  *
- * A streaming app-chat reserves credits up front, forwards the whole provider
- * response, closes the writer, and only THEN runs calculateCost +
- * reconcileCredits. Before this fix, if that post-stream accounting threw (a
- * transient DB/pricing error), the catch unconditionally full-refunded — free
- * inference, systemically so across concurrent streams during a DB blip.
+ * An app-chat request reserves credits up front, and only AFTER delivering
+ * (stream forwarded / provider body read) runs calculateCost +
+ * reconcileCredits. Both delivery paths share ONE settle-error refund —
+ * `reconcileChatSettleError` — gated by a per-site `skipRefund` flag:
+ * refunding a fully-delivered stream or an already-invoked settle would hand
+ * out free inference / double-credit, systemically so during a DB blip.
  *
- * This drives the REAL `reconcileStreamProcessingError` (the exact code the
- * route runs) against a spy credit service, asserting the refund decision.
+ * This drives the REAL `reconcileChatSettleError` (the exact code the route
+ * runs) with each call site's exact parameterization (mirrored from
+ * route.ts) against a spy credit service, asserting the refund decision and
+ * the ledger description/metadata each site sends. The route-level suite
+ * (apps-chat-nonstreaming-settle-guard.test.ts) drives the real route.
  */
 import { describe, expect, mock, test } from "bun:test";
 import {
-  reconcileNonStreamingSettleError,
-  reconcileStreamProcessingError,
-  type StreamRefundCredits,
+  type ChatSettleCredits,
+  reconcileChatSettleError,
 } from "../v1/apps/[id]/chat/stream-refund";
 
 function makeCredits() {
-  const calls: Array<{ estimatedBaseCost: number; actualBaseCost: number }> =
-    [];
+  const calls: Array<{
+    estimatedBaseCost: number;
+    actualBaseCost: number;
+    description: string;
+    metadata?: Record<string, unknown>;
+  }> = [];
   const reconcileCredits = mock(
-    async (args: { estimatedBaseCost: number; actualBaseCost: number }) => {
+    async (args: {
+      estimatedBaseCost: number;
+      actualBaseCost: number;
+      description: string;
+      metadata?: Record<string, unknown>;
+    }) => {
       calls.push({
         estimatedBaseCost: args.estimatedBaseCost,
         actualBaseCost: args.actualBaseCost,
+        description: args.description,
+        metadata: args.metadata,
       });
       return null;
     },
   );
   return { calls, reconcileCredits } satisfies {
     calls: unknown;
-    reconcileCredits: StreamRefundCredits["reconcileCredits"];
+    reconcileCredits: ChatSettleCredits["reconcileCredits"];
   };
 }
 
@@ -39,14 +54,52 @@ const base = {
   appId: "app-1",
   userId: "user-1",
   reservedBaseCost: 0.05,
-  errorMessage: "transient pg timeout",
 };
 
-describe("reconcileStreamProcessingError (#10837)", () => {
+/** The streaming call site's exact parameterization (route.ts). */
+function streamingSiteParams(streamCompleted: boolean, userId = base.userId) {
+  return {
+    ...base,
+    userId,
+    skipRefund: streamCompleted,
+    skipRefundLog:
+      "[App Chat] Post-stream accounting failed AFTER full delivery; keeping reserved charge (NOT refunding)",
+    refundLog:
+      "[App Chat] Stream processing failed before delivery, refunding reserved",
+    refundDescription: "Refund due to stream error",
+    refundMetadata: { error: true, streaming: true },
+    errorMessage: "transient pg timeout",
+  };
+}
+
+/** The non-streaming call site's exact parameterization (route.ts). */
+function nonStreamingSiteParams(settleStarted: boolean) {
+  const model = "openai/gpt-oss-120b";
+  return {
+    ...base,
+    skipRefund: settleStarted,
+    skipRefundLog:
+      "[App Chat] Non-streaming throw at/after the settle reconcile; NOT refunding (movement may have committed — sweep recovers a stranded hold)",
+    refundLog:
+      "[App Chat] Non-streaming settle never started after debit; refunding reserved hold (#11169)",
+    refundDescription: `Chat refund (non-streaming settle failed): ${model}`,
+    refundMetadata: {
+      error: true,
+      streaming: false,
+      model,
+      provider: "openai",
+      billingSource: "openai",
+      refundReason: "non_streaming_settle_error",
+    },
+    errorMessage: "provider body was not valid JSON",
+  };
+}
+
+describe("reconcileChatSettleError — streaming site (#10837)", () => {
   test("stream COMPLETED then accounting threw → keep the reserved charge, NO refund", async () => {
     const credits = makeCredits();
-    const result = await reconcileStreamProcessingError(
-      { ...base, streamCompleted: true },
+    const result = await reconcileChatSettleError(
+      streamingSiteParams(true),
       credits,
     );
     expect(result.refunded).toBe(false);
@@ -56,8 +109,8 @@ describe("reconcileStreamProcessingError (#10837)", () => {
 
   test("stream FAILED before delivery → full refund (actualBaseCost 0)", async () => {
     const credits = makeCredits();
-    const result = await reconcileStreamProcessingError(
-      { ...base, streamCompleted: false },
+    const result = await reconcileChatSettleError(
+      streamingSiteParams(false),
       credits,
     );
     expect(result.refunded).toBe(true);
@@ -65,6 +118,8 @@ describe("reconcileStreamProcessingError (#10837)", () => {
     expect(credits.calls[0]).toEqual({
       estimatedBaseCost: 0.05,
       actualBaseCost: 0,
+      description: "Refund due to stream error",
+      metadata: { error: true, streaming: true },
     });
   });
 
@@ -72,8 +127,8 @@ describe("reconcileStreamProcessingError (#10837)", () => {
     const credits = makeCredits();
     const results = await Promise.all(
       Array.from({ length: 20 }, (_, i) =>
-        reconcileStreamProcessingError(
-          { ...base, userId: `user-${i}`, streamCompleted: true },
+        reconcileChatSettleError(
+          streamingSiteParams(true, `user-${i}`),
           credits,
         ),
       ),
@@ -85,22 +140,10 @@ describe("reconcileStreamProcessingError (#10837)", () => {
   test("mixed batch: only the pre-delivery failures are refunded", async () => {
     const credits = makeCredits();
     await Promise.all([
-      reconcileStreamProcessingError(
-        { ...base, streamCompleted: true },
-        credits,
-      ),
-      reconcileStreamProcessingError(
-        { ...base, streamCompleted: false },
-        credits,
-      ),
-      reconcileStreamProcessingError(
-        { ...base, streamCompleted: true },
-        credits,
-      ),
-      reconcileStreamProcessingError(
-        { ...base, streamCompleted: false },
-        credits,
-      ),
+      reconcileChatSettleError(streamingSiteParams(true), credits),
+      reconcileChatSettleError(streamingSiteParams(false), credits),
+      reconcileChatSettleError(streamingSiteParams(true), credits),
+      reconcileChatSettleError(streamingSiteParams(false), credits),
     ]);
     // 2 delivered (no refund) + 2 pre-delivery failures (refund) = exactly 2 refunds.
     expect(credits.reconcileCredits).toHaveBeenCalledTimes(2);
@@ -108,26 +151,16 @@ describe("reconcileStreamProcessingError (#10837)", () => {
   });
 });
 
-const nonStreamBase = {
-  appId: "app-1",
-  userId: "user-1",
-  reservedBaseCost: 0.05,
-  model: "openai/gpt-oss-120b",
-  provider: "openai",
-  billingSource: "openai",
-  errorMessage: "provider body was not valid JSON",
-};
-
-describe("reconcileNonStreamingSettleError (#11169 part 1)", () => {
+describe("reconcileChatSettleError — non-streaming site (#11169 part 1)", () => {
   test("throw BEFORE the settle reconcile was invoked → full refund (actualBaseCost 0)", async () => {
     const credits = makeCredits();
-    const result = await reconcileNonStreamingSettleError(
-      { ...nonStreamBase, settleStarted: false },
+    const result = await reconcileChatSettleError(
+      nonStreamingSiteParams(false),
       credits,
     );
     expect(result.refunded).toBe(true);
     expect(credits.reconcileCredits).toHaveBeenCalledTimes(1);
-    expect(credits.calls[0]).toEqual({
+    expect(credits.calls[0]).toMatchObject({
       estimatedBaseCost: 0.05,
       actualBaseCost: 0,
     });
@@ -135,8 +168,8 @@ describe("reconcileNonStreamingSettleError (#11169 part 1)", () => {
 
   test("throw at/after the settle reconcile (incl. from INSIDE it — movement may have committed) → NO refund (no double-credit)", async () => {
     const credits = makeCredits();
-    const result = await reconcileNonStreamingSettleError(
-      { ...nonStreamBase, settleStarted: true },
+    const result = await reconcileChatSettleError(
+      nonStreamingSiteParams(true),
       credits,
     );
     expect(result.refunded).toBe(false);
@@ -144,21 +177,45 @@ describe("reconcileNonStreamingSettleError (#11169 part 1)", () => {
   });
 
   test("the refund is tagged non-streaming (streaming:false) so it's distinguishable in the ledger", async () => {
-    const metaCalls: Array<Record<string, unknown> | undefined> = [];
-    const credits = {
-      reconcileCredits: mock(
-        async (args: { metadata?: Record<string, unknown> }) => {
-          metaCalls.push(args.metadata);
-          return null;
-        },
-      ),
-    } as unknown as StreamRefundCredits;
-    await reconcileNonStreamingSettleError(
-      { ...nonStreamBase, settleStarted: false },
-      credits,
-    );
-    expect(metaCalls[0]).toMatchObject({
+    const credits = makeCredits();
+    await reconcileChatSettleError(nonStreamingSiteParams(false), credits);
+    expect(credits.calls[0].metadata).toMatchObject({
       streaming: false,
+      refundReason: "non_streaming_settle_error",
+    });
+  });
+});
+
+describe("reconcileChatSettleError — shared contract", () => {
+  test("both sites route through the ONE helper: skipRefund decides, the ledger tags stay per-site", async () => {
+    const credits = makeCredits();
+    const [streamKept, streamRefunded, settleKept, settleRefunded] =
+      await Promise.all([
+        reconcileChatSettleError(streamingSiteParams(true), credits),
+        reconcileChatSettleError(streamingSiteParams(false), credits),
+        reconcileChatSettleError(nonStreamingSiteParams(true), credits),
+        reconcileChatSettleError(nonStreamingSiteParams(false), credits),
+      ]);
+
+    // skipRefund=true keeps the charge on BOTH sites; skipRefund=false
+    // refunds the full hold on BOTH sites.
+    expect(streamKept.refunded).toBe(false);
+    expect(settleKept.refunded).toBe(false);
+    expect(streamRefunded.refunded).toBe(true);
+    expect(settleRefunded.refunded).toBe(true);
+    expect(credits.reconcileCredits).toHaveBeenCalledTimes(2);
+    expect(credits.calls.every((c) => c.actualBaseCost === 0)).toBe(true);
+
+    // Each refund carries its own site's ledger identity.
+    const streaming = credits.calls.find((c) => c.metadata?.streaming === true);
+    const nonStreaming = credits.calls.find(
+      (c) => c.metadata?.streaming === false,
+    );
+    expect(streaming?.description).toBe("Refund due to stream error");
+    expect(nonStreaming?.description).toBe(
+      "Chat refund (non-streaming settle failed): openai/gpt-oss-120b",
+    );
+    expect(nonStreaming?.metadata).toMatchObject({
       refundReason: "non_streaming_settle_error",
     });
   });

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -46,10 +46,7 @@ import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { reservationOutputTokens } from "./chat-reservation";
-import {
-  reconcileNonStreamingSettleError,
-  reconcileStreamProcessingError,
-} from "./stream-refund";
+import { reconcileChatSettleError } from "./stream-refund";
 
 const ROUTE_MAX_DURATION = 800;
 
@@ -622,10 +619,16 @@ async function handlePOST(
           // Refund the reserved charge ONLY when the stream failed before the
           // client got the full answer. If it already completed and only the
           // post-stream accounting threw, keeping the charge avoids handing out
-          // free inference. (See reconcileStreamProcessingError.)
-          const { refunded } = await reconcileStreamProcessingError(
+          // free inference. (See reconcileChatSettleError.)
+          const { refunded } = await reconcileChatSettleError(
             {
-              streamCompleted,
+              skipRefund: streamCompleted,
+              skipRefundLog:
+                "[App Chat] Post-stream accounting failed AFTER full delivery; keeping reserved charge (NOT refunding)",
+              refundLog:
+                "[App Chat] Stream processing failed before delivery, refunding reserved",
+              refundDescription: "Refund due to stream error",
+              refundMetadata: { error: true, streaming: true },
               appId,
               userId: user.id,
               reservedBaseCost,
@@ -665,7 +668,7 @@ async function handlePOST(
     // Non-streaming response. Everything below runs AFTER the upfront hold was
     // debited, so a throw here — a truncated body failing providerResponse.json(),
     // or calculateCost erroring — would strand the reserved hold (the streaming
-    // branch is covered by reconcileStreamProcessingError; this one was not,
+    // branch is covered by the same settle-error refund; this one was not,
     // #11169). Full-refund on any failure BEFORE the settle completes; once
     // reconcileCredits has settled, a later throw must NOT refund (the charge is
     // real), mirroring the streaming branch's streamCompleted gating.
@@ -752,15 +755,25 @@ async function handlePOST(
       // not transactional), so re-refunding would mint credits — the
       // stranded-reservation sweep recovers that rare window instead. `.catch`
       // so a refund failure can't mask the original error. (#11218)
-      await reconcileNonStreamingSettleError(
+      await reconcileChatSettleError(
         {
-          settleStarted: nonStreamingSettleStarted,
+          skipRefund: nonStreamingSettleStarted,
+          skipRefundLog:
+            "[App Chat] Non-streaming throw at/after the settle reconcile; NOT refunding (movement may have committed — sweep recovers a stranded hold)",
+          refundLog:
+            "[App Chat] Non-streaming settle never started after debit; refunding reserved hold (#11169)",
+          refundDescription: `Chat refund (non-streaming settle failed): ${model}`,
+          refundMetadata: {
+            error: true,
+            streaming: false,
+            model,
+            provider,
+            billingSource,
+            refundReason: "non_streaming_settle_error",
+          },
           appId,
           userId: user.id,
           reservedBaseCost,
-          model,
-          provider,
-          billingSource,
           errorMessage,
         },
         appCreditsService,

--- a/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
@@ -1,11 +1,11 @@
 import { logger } from "@/lib/utils/logger";
 
 /**
- * The credit-reconcile surface {@link reconcileStreamProcessingError} needs.
+ * The credit-reconcile surface {@link reconcileChatSettleError} needs.
  * Structural so the helper (and its test) don't import the whole app-credits
  * service or the DB it wires up. `appCreditsService` is assignable to this.
  */
-export interface StreamRefundCredits {
+export interface ChatSettleCredits {
   reconcileCredits(args: {
     appId: string;
     userId: string;
@@ -17,127 +17,87 @@ export interface StreamRefundCredits {
 }
 
 /**
- * Money-critical (#10837): on a streaming error, refund the upfront reservation
- * ONLY when the client did NOT receive the full answer.
+ * Money-critical: when app-chat processing throws AFTER the upfront hold was
+ * debited, refund the full reserved amount ONLY when `skipRefund` is false.
+ * One refund decision shared by both delivery paths — the guard flag, log
+ * lines, and ledger description/metadata differ per call site and are passed
+ * in; the refund mechanics must not diverge. Returns whether a refund was
+ * issued so the caller can react (e.g. notify a streaming client).
  *
- * A streaming app-chat request reserves credits up front (`deductCredits`), then
- * forwards the whole provider response and closes the writer, and only THEN runs
- * `calculateCost` + `reconcileCredits`. If that post-stream accounting throws
- * (e.g. a transient Postgres / pricing-catalog error during a DB incident), the
- * user has already received the entire answer — refunding the reservation would
- * hand out FREE inference, and systemically so when the blip hits many
- * concurrent streams at once.
+ * Streaming call site (#10837): a streaming request reserves credits up front
+ * (`deductCredits`), forwards the whole provider response and closes the
+ * writer, and only THEN runs `calculateCost` + `reconcileCredits`. If that
+ * post-stream accounting throws (e.g. a transient Postgres / pricing-catalog
+ * error during a DB incident), the user has already received the entire
+ * answer — refunding the reservation would hand out FREE inference, and
+ * systemically so when the blip hits many concurrent streams at once. So the
+ * site passes `skipRefund: streamCompleted`: refund only when the stream
+ * failed before delivery, and notify the client only in that
+ * mid-delivery-failure case.
  *
- * So we refund only when `streamCompleted` is false (the stream failed before
- * delivery); when it is true we keep the reserved charge that `deductCredits`
- * already applied. Returns whether a refund was issued so the caller notifies
- * the client only in the mid-delivery-failure case.
- */
-export async function reconcileStreamProcessingError(
-  params: {
-    streamCompleted: boolean;
-    appId: string;
-    userId: string;
-    reservedBaseCost: number;
-    errorMessage: string;
-  },
-  credits: StreamRefundCredits,
-): Promise<{ refunded: boolean }> {
-  const { streamCompleted, appId, userId, reservedBaseCost, errorMessage } =
-    params;
-
-  if (streamCompleted) {
-    logger.error(
-      "[App Chat] Post-stream accounting failed AFTER full delivery; keeping reserved charge (NOT refunding)",
-      { appId, userId, reservedBaseCost, error: errorMessage },
-    );
-    return { refunded: false };
-  }
-
-  logger.error(
-    "[App Chat] Stream processing failed before delivery, refunding reserved",
-    { appId, userId, reservedBaseCost, error: errorMessage },
-  );
-  await credits.reconcileCredits({
-    appId,
-    userId,
-    estimatedBaseCost: reservedBaseCost,
-    actualBaseCost: 0, // Refund full reserved amount
-    description: "Refund due to stream error",
-    metadata: { error: true, streaming: true },
-  });
-  return { refunded: true };
-}
-
-/**
- * Money-critical (#11169 part 1): the NON-streaming app-chat path debits the
+ * Non-streaming call site (#11169 part 1): the non-streaming path debits the
  * upfront hold, then reads the provider body + runs `calculateCost` +
- * `reconcileCredits`. If the body-read or cost-calc throws AFTER the debit, the
- * route's outer catch returns 500 WITHOUT refunding — stranding the reserved
- * hold. Refund it: the caller received no billable answer and no settle was
- * ever attempted.
- *
- * `settleStarted` is true once `reconcileCredits` has been INVOKED — not once
- * it returned. `reconcileCredits` is not transactional: it commits its
- * org-balance movement (refund or extra charge) before its earnings/counter
- * writes, and that movement carries no idempotency key. A throw from inside it
- * may therefore have already moved money, so refunding blindly would
+ * `reconcileCredits`. If the body-read or cost-calc throws AFTER the debit,
+ * the route's outer catch returns 500 WITHOUT refunding — stranding the
+ * reserved hold. Refund it: the caller received no billable answer and no
+ * settle was ever attempted. The site passes `skipRefund: settleStarted`,
+ * true once `reconcileCredits` has been INVOKED — not once it returned.
+ * `reconcileCredits` is not transactional: it commits its org-balance
+ * movement (refund or extra charge) before its earnings/counter writes, and
+ * that movement carries no idempotency key. A throw from inside it may
+ * therefore have already moved money, so refunding blindly would
  * double-credit the org (mint credits during a DB blip, systemically across
- * concurrent requests). Mirror of the streaming branch, which flips
+ * concurrent requests) — mirroring the streaming site, which flips
  * `streamCompleted` before ITS settle for the same reason. A hold stranded by
  * that rare window is recovered by the stranded-reservation sweep
  * (#11169 part 3).
  */
-export async function reconcileNonStreamingSettleError(
+export async function reconcileChatSettleError(
   params: {
-    settleStarted: boolean;
+    /** True when the reserved charge must be KEPT — log and skip the refund. */
+    skipRefund: boolean;
+    /** Logged (error level) when `skipRefund` keeps the charge. */
+    skipRefundLog: string;
+    /** Logged (error level) when the hold is refunded. */
+    refundLog: string;
+    /** Ledger description for the refund reconcile. */
+    refundDescription: string;
+    /** Ledger metadata for the refund reconcile. */
+    refundMetadata: Record<string, unknown>;
     appId: string;
     userId: string;
     reservedBaseCost: number;
-    model: string;
-    provider: string;
-    billingSource: string;
     errorMessage: string;
   },
-  credits: StreamRefundCredits,
+  credits: ChatSettleCredits,
 ): Promise<{ refunded: boolean }> {
   const {
-    settleStarted,
+    skipRefund,
+    skipRefundLog,
+    refundLog,
+    refundDescription,
+    refundMetadata,
     appId,
     userId,
     reservedBaseCost,
-    model,
-    provider,
-    billingSource,
     errorMessage,
   } = params;
 
-  if (settleStarted) {
-    logger.error(
-      "[App Chat] Non-streaming throw at/after the settle reconcile; NOT refunding (movement may have committed — sweep recovers a stranded hold)",
-      { appId, userId, reservedBaseCost, error: errorMessage },
-    );
+  const logContext = { appId, userId, reservedBaseCost, error: errorMessage };
+
+  if (skipRefund) {
+    logger.error(skipRefundLog, logContext);
     return { refunded: false };
   }
 
-  logger.error(
-    "[App Chat] Non-streaming settle never started after debit; refunding reserved hold (#11169)",
-    { appId, userId, reservedBaseCost, error: errorMessage },
-  );
+  logger.error(refundLog, logContext);
   await credits.reconcileCredits({
     appId,
     userId,
     estimatedBaseCost: reservedBaseCost,
     actualBaseCost: 0, // Full refund — nothing was billed.
-    description: `Chat refund (non-streaming settle failed): ${model}`,
-    metadata: {
-      error: true,
-      streaming: false,
-      model,
-      provider,
-      billingSource,
-      refundReason: "non_streaming_settle_error",
-    },
+    description: refundDescription,
+    metadata: refundMetadata,
   });
   return { refunded: true };
 }


### PR DESCRIPTION
Follow-up to #11218 (deepscan MAJOR, rule #2 — one function per purpose). **Stacked on #11473** (base = `nubs/apps-chat-nonstream-settle-fence`): that PR is the money-critical fence fix that gives `reconcileNonStreamingSettleError` its live route call site; this PR is the pure structural dedupe on top. Retargets to `develop` automatically when #11473 merges.

## What

`reconcileNonStreamingSettleError` was a near-copy of `reconcileStreamProcessingError` in the same file (`v1/apps/[id]/chat/stream-refund.ts`): identical shape — boolean guard flag → log-and-keep `{refunded:false}` | log → `credits.reconcileCredits({actualBaseCost: 0, ...})` → `{refunded:true}` — differing only in the flag name, log strings, and ledger description/metadata.

Collapsed into ONE helper, `reconcileChatSettleError({ skipRefund, skipRefundLog, refundLog, refundDescription, refundMetadata, appId, userId, reservedBaseCost, errorMessage }, credits)`:

- streaming site passes `skipRefund: streamCompleted` + metadata `{error: true, streaming: true}`
- non-streaming site passes `skipRefund: nonStreamingSettleStarted` + metadata `{error: true, streaming: false, model, provider, billingSource, refundReason: "non_streaming_settle_error"}`

**Pure dedupe — zero refund-semantics change.** Log strings, ledger descriptions, and metadata are byte-identical for both paths; both original doc comments (#10837 stream-delivery rationale, #11169/#11218 settle-fence rationale) are preserved on the shared helper. `StreamRefundCredits` renamed `ChatSettleCredits` to match.

## Tests

- `apps-chat-stream-refund.test.ts` — drives the shared helper with each call site's exact parameterization (all prior cases kept: completed-stream keep, pre-delivery refund, 20-concurrent systemic-leak guard, mixed batch, settle-started keep, ledger tag), plus a new shared-contract case asserting both sites route through the ONE helper with correct `skipRefund` outcomes and per-site ledger identity.
- `apps-chat-nonstreaming-settle-guard.test.ts` — the real-route suite gains two streaming cases, so BOTH route call sites are proven end to end: mid-delivery failure → exactly one full refund tagged `streaming:true` + client "Stream interrupted. Credits refunded."; completed stream + accounting throw → NO refund.

## Verification

```
$ cd packages/cloud/api && bun test __tests__/apps-chat-stream-refund.test.ts __tests__/apps-chat-nonstreaming-settle-guard.test.ts
 14 pass / 0 fail (54 expect() calls, 2 files)

$ bun run --cwd packages/cloud/api typecheck   # tsgo --noEmit
 clean (0 errors)

$ bunx biome check <4 changed files>
 Checked 4 files. No fixes applied.
```

Full `bun test __tests__` for the package: 173 pass / 57 fail / 34 errors — the identical 57/34 fail at the base commit (env-dependent suites: stripe queue, containers, oxapay, pglite); this branch adds +3 passing tests and no new failures.

Skipped (noted follow-up): the sibling nit of extracting the ~60-line non-streaming settle block from `chat/route.ts` into a `settleNonStreamingChat` helper — it overlaps the exact region #11473 fences and would balloon a pure-dedupe diff with behavior-change risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
