### PR TITLE
refactor(cloud): one canonical insufficient-credits 402 body for every credit-gated route

### DIFF
--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -67,6 +67,12 @@ const launchManagedElizaAgent = mock(async () => ({
   issuedAt: "2026-07-02T00:00:00.000Z",
   connection: { host: "agent-1.example.test" },
 }));
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+
+class AgentQuotaExceededError extends Error {}
 
 mock.module("../compat/_lib/auth", () => ({
   requireCompatAuth,
@@ -90,6 +96,7 @@ mock.module("@/lib/services/agent-billing-gate", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentQuotaExceededError,
   elizaSandboxService: {
     getAgent,
     getAgentForWrite,
@@ -100,6 +107,7 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
 
 mock.module("@/lib/services/eliza-managed-launch", () => ({
   launchManagedElizaAgent,
+  prepareManagedElizaEnvironment,
   ManagedElizaLaunchError: class ManagedElizaLaunchError extends Error {
     status = 400;
   },
@@ -151,6 +159,7 @@ describe("compat agent resume/restart/launch credit gate", () => {
     provision.mockClear();
     snapshot.mockClear();
     launchManagedElizaAgent.mockClear();
+    prepareManagedElizaEnvironment.mockClear();
   });
 
   test("blocks compat resume before provisioning when the org has insufficient credits", async () => {

--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -31,10 +31,12 @@ const enqueueAgentProvision = mock(async () => ({
 }));
 const triggerImmediate = mock(async () => undefined);
 
-const checkAgentCreditGate = mock(async () => ({
-  allowed: true,
-  balance: 100,
-}));
+const checkAgentCreditGate = mock(
+  async (): Promise<{ allowed: boolean; balance: number; error?: string }> => ({
+    allowed: true,
+    balance: 100,
+  }),
+);
 const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
 const prepareManagedElizaEnvironment = mock(async () => ({
   changed: false,
@@ -191,6 +193,32 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(json.success).toBe(true);
     expect(json.data.jobId).toBe("job-1");
     expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+
+  test("insufficient credits -> 402 with the canonical flat body (no nested details)", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits. Please add funds.",
+    });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(402);
+    // Exact-match on purpose: this is the one insufficient-credits wire shape
+    // shared by every credit-gated route (insufficientCredits402).
+    expect(await res.json()).toEqual({
+      success: false,
+      code: "insufficient_credits",
+      error: "Insufficient credits. Please add funds.",
+      requiredBalance: 0.1,
+      currentBalance: 0,
+    });
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 
   test("forceCreate:true bypasses the reuse guard → createAgent called with reuseExistingNonTerminal:false (mints a SEPARATE agent)", async () => {

--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -208,9 +208,16 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     });
 
     expect(res.status).toBe(402);
+    const body = (await res.json()) as {
+      success: false;
+      code: "insufficient_credits";
+      error: string;
+      requiredBalance: number;
+      currentBalance: number;
+    };
     // Exact-match on purpose: this is the one insufficient-credits wire shape
     // shared by every credit-gated route (insufficientCredits402).
-    expect(await res.json()).toEqual({
+    expect(body).toEqual({
       success: false,
       code: "insufficient_credits",
       error: "Insufficient credits. Please add funds.",

--- a/packages/cloud/api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/route.ts
@@ -13,8 +13,8 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { containersEnv } from "@/lib/config/containers-env";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
@@ -104,23 +104,12 @@ app.post("/", async (c) => {
     // returned above are unaffected — this only fences the first provision.)
     const creditCheck = await checkAgentCreditGate(session.organizationId);
     if (!creditCheck.allowed) {
-      logger.warn(
-        "[eliza-app provisioning-agent] provision blocked: insufficient credits",
-        {
-          orgId: session.organizationId,
-          balance: creditCheck.balance,
-          required: AGENT_PRICING.MINIMUM_DEPOSIT,
-        },
-      );
       return c.json(
-        {
-          success: false,
-          code: "insufficient_credits",
-          error:
-            creditCheck.error ?? "Insufficient credits to provision an agent",
-          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-          currentBalance: creditCheck.balance,
-        },
+        insufficientCredits402(
+          creditCheck,
+          "[eliza-app provisioning-agent] provision blocked: insufficient credits",
+          { orgId: session.organizationId },
+        ),
         402,
       );
     }

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
@@ -30,6 +30,8 @@ const checkAgentCreditGate = mock(async () => ({
   error: "Insufficient credits",
 }));
 
+class AgentQuotaExceededError extends Error {}
+
 mock.module("@/lib/auth/service-key-hono-worker", () => ({
   requireServiceKey,
   validateServiceKey,
@@ -53,6 +55,7 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentQuotaExceededError,
   elizaSandboxService: {
     getAgentById,
     getAgentForWrite,

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
@@ -15,12 +15,12 @@ import { Hono } from "hono";
 import { agentBillingRepository } from "@/db/repositories/agent-billing";
 import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { logger } from "@/lib/utils/logger";
@@ -39,19 +39,12 @@ app.post("/", async (c) => {
 
     const creditCheck = await checkAgentCreditGate(agent.organization_id);
     if (!creditCheck.allowed) {
-      logger.warn("[service-api] Restart blocked: insufficient credits", {
-        agentId,
-        orgId: agent.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
       return c.json(
-        {
-          success: false,
-          error: creditCheck.error,
-          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-          currentBalance: creditCheck.balance,
-        },
+        insufficientCredits402(
+          creditCheck,
+          "[service-api] Restart blocked: insufficient credits",
+          { agentId, orgId: agent.organization_id },
+        ),
         402,
       );
     }

--- a/packages/cloud/api/v1/agents/[agentId]/resume/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/resume/route.test.ts
@@ -20,6 +20,8 @@ const checkAgentCreditGate = mock(async () => ({
   error: "Insufficient credits",
 }));
 
+class AgentQuotaExceededError extends Error {}
+
 mock.module("@/lib/auth/service-key-hono-worker", () => ({
   requireServiceKey,
 }));
@@ -35,6 +37,7 @@ mock.module("@/lib/services/agent-billing-gate", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentQuotaExceededError,
   elizaSandboxService: {
     getAgentById,
     provision,

--- a/packages/cloud/api/v1/agents/[agentId]/resume/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/resume/route.ts
@@ -9,8 +9,8 @@ import { Hono } from "hono";
 import { agentBillingRepository } from "@/db/repositories/agent-billing";
 import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -26,19 +26,12 @@ app.post("/", async (c) => {
 
     const creditCheck = await checkAgentCreditGate(agent.organization_id);
     if (!creditCheck.allowed) {
-      logger.warn("[service-api] Resume blocked: insufficient credits", {
-        agentId,
-        orgId: agent.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
       return c.json(
-        {
-          success: false,
-          error: creditCheck.error,
-          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-          currentBalance: creditCheck.balance,
-        },
+        insufficientCredits402(
+          creditCheck,
+          "[service-api] Resume blocked: insufficient credits",
+          { agentId, orgId: agent.organization_id },
+        ),
         402,
       );
     }

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -69,6 +69,8 @@ const provisionAgent = mock(
 );
 const enqueueAgentProvision = mock(async () => ({ id: "job-1" }));
 
+class AgentQuotaExceededError extends Error {}
+
 mock.module("@/lib/auth/service-key-hono-worker", () => ({
   requireServiceKey,
   validateServiceKey: requireServiceKey,
@@ -109,6 +111,7 @@ mock.module("@/lib/services/characters/characters", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentQuotaExceededError,
   elizaSandboxService: {
     createAgent,
     provision: provisionAgent,

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -725,6 +725,7 @@ describe("service agent provisioning route", () => {
     expect(response.status).toBe(402);
     await expect(response.json()).resolves.toMatchObject({
       success: false,
+      code: "insufficient_credits",
       error: "Insufficient credits",
       requiredBalance: 0.1,
       currentBalance: 0,

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -21,8 +21,8 @@ import {
 } from "@/lib/api/cloud-worker-errors";
 import { toCompatStatus } from "@/lib/api/compat-envelope";
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { charactersService } from "@/lib/services/characters/characters";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
@@ -320,29 +320,18 @@ app.post("/", async (c) => {
       }
 
       const creditCheck = await checkAgentCreditGate(ownerOrganizationId);
-      const creditError =
-        typeof (creditCheck as { error?: unknown }).error === "string"
-          ? (creditCheck as { error: string }).error
-          : "insufficient credits";
       if (!creditCheck.allowed) {
-        logger.warn(
-          "[service-api] Provisioning blocked: insufficient credits",
-          {
-            orgId: ownerOrganizationId,
-            serviceOrgId: identity.organizationId,
-            walletOwned: Boolean(walletAccount),
-            balance: creditCheck.balance,
-            required: AGENT_PRICING.MINIMUM_DEPOSIT,
-          },
-        );
         await charactersService.delete(character.id);
         return c.json(
-          {
-            success: false,
-            error: creditError,
-            requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-            currentBalance: creditCheck.balance,
-          },
+          insufficientCredits402(
+            creditCheck,
+            "[service-api] Provisioning blocked: insufficient credits",
+            {
+              orgId: ownerOrganizationId,
+              serviceOrgId: identity.organizationId,
+              walletOwned: Boolean(walletAccount),
+            },
+          ),
           402,
         );
       }

--- a/packages/cloud/api/v1/coding-containers/route.test.ts
+++ b/packages/cloud/api/v1/coding-containers/route.test.ts
@@ -39,6 +39,7 @@ mock.module("@/lib/services/agent-billing-gate", () => ({
 
 mock.module("@/lib/eliza-agent-web-ui", () => ({
   getAgentBaseDomain: () => "elizacloud.ai",
+  getElizaAgentDirectWebUiUrl: () => null,
   getElizaAgentPublicWebUiUrl: (sandbox: { id: string }) =>
     `https://${sandbox.id}.elizacloud.ai`,
 }));
@@ -62,9 +63,6 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     getAgent: mock(async () => undefined),
     updateAgentEnvironment,
   },
-  // #11095 added this export; route.ts imports it, so the mock must provide it
-  // or the whole module (and this test file) fails to load.
-  AgentQuotaExceededError: class AgentQuotaExceededError extends Error {},
 }));
 
 mock.module("@/lib/services/provisioning-jobs", () => ({
@@ -221,8 +219,15 @@ describe("coding containers route", () => {
     );
 
     expect(response.status).toBe(402);
+    const body = (await response.json()) as {
+      success: false;
+      code: "insufficient_credits";
+      error: string;
+      currentBalance: number;
+      requiredBalance: number;
+    };
     // Exact-match on purpose: the canonical insufficientCredits402 wire shape.
-    expect(await response.json()).toEqual({
+    expect(body).toEqual({
       success: false,
       code: "insufficient_credits",
       error: "Insufficient credits",

--- a/packages/cloud/api/v1/coding-containers/route.test.ts
+++ b/packages/cloud/api/v1/coding-containers/route.test.ts
@@ -43,7 +43,20 @@ mock.module("@/lib/eliza-agent-web-ui", () => ({
     `https://${sandbox.id}.elizacloud.ai`,
 }));
 
+// The route imports this class for its instanceof quota branch; the mocked
+// module must export it or the route module fails to load.
+class AgentQuotaExceededError extends Error {
+  constructor(
+    readonly count: number,
+    readonly max: number,
+  ) {
+    super(`Agent quota exceeded: ${count}/${max}`);
+    this.name = "AgentQuotaExceededError";
+  }
+}
+
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentQuotaExceededError,
   elizaSandboxService: {
     createCodingContainerAgent,
     getAgent: mock(async () => undefined),
@@ -208,14 +221,14 @@ describe("coding containers route", () => {
     );
 
     expect(response.status).toBe(402);
-    expect(await response.json()).toEqual(
-      expect.objectContaining({
-        success: false,
-        code: "insufficient_credits",
-        currentBalance: 0,
-        requiredBalance: 0.1,
-      }),
-    );
+    // Exact-match on purpose: the canonical insufficientCredits402 wire shape.
+    expect(await response.json()).toEqual({
+      success: false,
+      code: "insufficient_credits",
+      error: "Insufficient credits",
+      currentBalance: 0,
+      requiredBalance: 0.1,
+    });
     expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     // The gate must short-circuit BEFORE any paid compute is provisioned.
     expect(createCodingContainerAgent).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -54,10 +54,10 @@ import { Hono } from "hono";
 import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import {
   buildCodingContainerCreatePayload,
   buildCodingContainerSessionResponse,
@@ -216,22 +216,12 @@ async function createCodingContainer(
   // so this is the only real gate. ──
   const creditCheck = await checkAgentCreditGate(user.organization_id);
   if (!creditCheck.allowed) {
-    logger.warn(
-      "[CodingContainers API] provision blocked: insufficient credits",
-      {
-        orgId: user.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      },
-    );
     return c.json(
-      {
-        success: false,
-        code: "insufficient_credits",
-        error: creditCheck.error,
-        requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-        currentBalance: creditCheck.balance,
-      },
+      insufficientCredits402(
+        creditCheck,
+        "[CodingContainers API] provision blocked: insufficient credits",
+        { orgId: user.organization_id },
+      ),
       402,
     );
   }

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -3,12 +3,12 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { containersEnv } from "@/lib/config/containers-env";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import {
   getElizaAgentDirectWebUiUrl,
   getElizaAgentPublicWebUiUrl,
 } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -206,28 +206,13 @@ async function __hono_POST(
         // use pairing to get free compute the resume gate would have blocked.
         const creditCheck = await checkAgentCreditGate(user.organization_id);
         if (!creditCheck.allowed) {
-          logger.warn(
+          const body = insufficientCredits402(
+            creditCheck,
             "[pairing-token] auto-resume blocked: insufficient credits",
-            {
-              agentId,
-              orgId: user.organization_id,
-              balance: creditCheck.balance,
-              required: AGENT_PRICING.MINIMUM_DEPOSIT,
-            },
+            { agentId, orgId: user.organization_id },
           );
           return applyCorsHeaders(
-            Response.json(
-              {
-                success: false,
-                code: "insufficient_credits",
-                error:
-                  creditCheck.error ??
-                  "Insufficient credits to resume this agent",
-                requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-                currentBalance: creditCheck.balance,
-              },
-              { status: 402 },
-            ),
+            Response.json(body, { status: 402 }),
             CORS_METHODS,
           );
         }

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -3,9 +3,9 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { containersEnv } from "@/lib/config/containers-env";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { assertSafeOutboundUrl } from "@/lib/security/outbound-url";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -153,22 +153,13 @@ async function __hono_POST(
     // ── Credit gate: require minimum deposit before provisioning ──────
     const creditCheck = await checkAgentCreditGate(user.organization_id);
     if (!creditCheck.allowed) {
-      logger.warn("[agent-api] Provision blocked: insufficient credits", {
-        agentId,
-        orgId: user.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
+      const body = insufficientCredits402(
+        creditCheck,
+        "[agent-api] Provision blocked: insufficient credits",
+        { agentId, orgId: user.organization_id },
+      );
       return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            error: creditCheck.error,
-            requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-            currentBalance: creditCheck.balance,
-          },
-          { status: 402 },
-        ),
+        Response.json(body, { status: 402 }),
         CORS_METHODS,
       );
     }

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/resume/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/resume/route.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { assertSafeOutboundUrl } from "@/lib/security/outbound-url";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -95,22 +95,13 @@ async function __hono_POST(
     // ── Credit gate: require minimum deposit before resuming ──────────
     const creditCheck = await checkAgentCreditGate(user.organization_id);
     if (!creditCheck.allowed) {
-      logger.warn("[agent-api] Resume blocked: insufficient credits", {
-        agentId,
-        orgId: user.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
+      const body = insufficientCredits402(
+        creditCheck,
+        "[agent-api] Resume blocked: insufficient credits",
+        { agentId, orgId: user.organization_id },
+      );
       return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            error: creditCheck.error,
-            requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-            currentBalance: creditCheck.balance,
-          },
-          { status: 402 },
-        ),
+        Response.json(body, { status: 402 }),
         CORS_METHODS,
       );
     }

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/wake/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/wake/route.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -88,22 +88,13 @@ async function __hono_POST(
     // Credit gate: waking provisions paid compute.
     const creditCheck = await checkAgentCreditGate(user.organization_id);
     if (!creditCheck.allowed) {
-      logger.warn("[agent-api] Wake blocked: insufficient credits", {
-        agentId,
-        orgId: user.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
+      const body = insufficientCredits402(
+        creditCheck,
+        "[agent-api] Wake blocked: insufficient credits",
+        { agentId, orgId: user.organization_id },
+      );
       return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            error: creditCheck.error,
-            requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-            currentBalance: creditCheck.balance,
-          },
-          { status: 402 },
-        ),
+        Response.json(body, { status: 402 }),
         CORS_METHODS,
       );
     }

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -16,10 +16,10 @@ import {
 } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
-import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
+import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import {
   stripReservedElizaConfigKeys,
   withReusedElizaCharacterOwnership,
@@ -355,19 +355,13 @@ app.post("/", async (c) => {
     const creditCheck = await checkAgentCreditGate(user.organization_id);
     orgBalanceForQuota = creditCheck.balance;
     if (!creditCheck.allowed) {
-      logger.warn("[agent-api] Agent creation blocked: insufficient credits", {
-        orgId: user.organization_id,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
-      throw new ApiError(
+      return c.json(
+        insufficientCredits402(
+          creditCheck,
+          "[agent-api] Agent creation blocked: insufficient credits",
+          { orgId: user.organization_id },
+        ),
         402,
-        "insufficient_credits",
-        creditCheck.error ?? "Insufficient credits",
-        {
-          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
-          currentBalance: creditCheck.balance,
-        },
       );
     }
 

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { AGENT_PRICING } from "../constants/agent-pricing";
 import { logger } from "../utils/logger";
-import {
-  insufficientCredits402,
-  insufficientCreditsBody,
-} from "./agent-billing-gate-402";
+import { insufficientCredits402, insufficientCreditsBody } from "./agent-billing-gate-402";
 
 describe("insufficientCreditsBody", () => {
   test("builds the canonical 402 wire shape — exact fields, nothing else", () => {
@@ -49,14 +46,11 @@ describe("insufficientCredits402", () => {
 
     expect(body).toStrictEqual(insufficientCreditsBody(creditCheck));
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[agent-api] Resume blocked: insufficient credits",
-      {
-        agentId: "agent-1",
-        orgId: "org-1",
-        balance: 0.05,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      },
-    );
+    expect(warnSpy).toHaveBeenCalledWith("[agent-api] Resume blocked: insufficient credits", {
+      agentId: "agent-1",
+      orgId: "org-1",
+      balance: 0.05,
+      required: AGENT_PRICING.MINIMUM_DEPOSIT,
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { AGENT_PRICING } from "../constants/agent-pricing";
 import { logger } from "../utils/logger";
 import { insufficientCredits402, insufficientCreditsBody } from "./agent-billing-gate-402";
@@ -30,6 +30,10 @@ describe("insufficientCreditsBody", () => {
 
 describe("insufficientCredits402", () => {
   const warnSpy = spyOn(logger, "warn").mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
 
   afterEach(() => {
     warnSpy.mockClear();

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { AGENT_PRICING } from "../constants/agent-pricing";
+import { logger } from "../utils/logger";
+import {
+  insufficientCredits402,
+  insufficientCreditsBody,
+} from "./agent-billing-gate-402";
+
+describe("insufficientCreditsBody", () => {
+  test("builds the canonical 402 wire shape — exact fields, nothing else", () => {
+    const body = insufficientCreditsBody({
+      balance: 0.02,
+      error: "Insufficient credits. Please add funds.",
+    });
+
+    expect(body).toStrictEqual({
+      success: false,
+      code: "insufficient_credits",
+      error: "Insufficient credits. Please add funds.",
+      requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+      currentBalance: 0.02,
+    });
+  });
+
+  test("falls back to a generic message when the gate result has no error", () => {
+    const body = insufficientCreditsBody({ balance: 0 });
+
+    expect(body.error).toBe("Insufficient credits");
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("insufficient_credits");
+  });
+});
+
+describe("insufficientCredits402", () => {
+  const warnSpy = spyOn(logger, "warn").mockImplementation(() => undefined);
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  test("warns with the route's line + gate numbers and returns the canonical body", () => {
+    const creditCheck = { balance: 0.05, error: "Insufficient credits." };
+
+    const body = insufficientCredits402(
+      creditCheck,
+      "[agent-api] Resume blocked: insufficient credits",
+      { agentId: "agent-1", orgId: "org-1" },
+    );
+
+    expect(body).toStrictEqual(insufficientCreditsBody(creditCheck));
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[agent-api] Resume blocked: insufficient credits",
+      {
+        agentId: "agent-1",
+        orgId: "org-1",
+        balance: 0.05,
+        required: AGENT_PRICING.MINIMUM_DEPOSIT,
+      },
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical 402 response for a failed agent credit gate.
+ *
+ * Companion to `checkAgentCreditGate` (./agent-billing-gate.ts). Every route
+ * that denies on the gate serializes this one body, so the insufficient-credits
+ * wire shape cannot drift between routes. Kept in its own module (type-only
+ * import of the gate) so route unit tests that mock the db-backed gate module
+ * still exercise the real body shape.
+ */
+
+import { AGENT_PRICING } from "../constants/agent-pricing";
+import { logger } from "../utils/logger";
+import type { CreditGateResult } from "./agent-billing-gate";
+
+export interface InsufficientCreditsBody {
+  success: false;
+  code: "insufficient_credits";
+  error: string;
+  requiredBalance: number;
+  currentBalance: number;
+}
+
+/** Build the canonical 402 body from a denied `checkAgentCreditGate` result. */
+export function insufficientCreditsBody(
+  creditCheck: Pick<CreditGateResult, "balance" | "error">,
+): InsufficientCreditsBody {
+  return {
+    success: false,
+    code: "insufficient_credits",
+    error: creditCheck.error ?? "Insufficient credits",
+    requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+    currentBalance: creditCheck.balance,
+  };
+}
+
+/**
+ * Warn with the route's log line (plus the gate numbers) and return the
+ * canonical 402 body. Routes own the transport — Hono `c.json`,
+ * `Response.json` + CORS headers — and must send it with status 402.
+ */
+export function insufficientCredits402(
+  creditCheck: Pick<CreditGateResult, "balance" | "error">,
+  warn: string,
+  logContext: Record<string, unknown>,
+): InsufficientCreditsBody {
+  logger.warn(warn, {
+    ...logContext,
+    balance: creditCheck.balance,
+    required: AGENT_PRICING.MINIMUM_DEPOSIT,
+  });
+  return insufficientCreditsBody(creditCheck);
+}

--- a/packages/cloud/shared/src/lib/services/agent-billing-gate.ts
+++ b/packages/cloud/shared/src/lib/services/agent-billing-gate.ts
@@ -2,7 +2,8 @@
  * Agent billing gate — pre-provisioning credit check.
  *
  * Ensures an organization has more than the minimum running balance before
- * allowing agent creation, provisioning, or resume.
+ * allowing agent creation, provisioning, or resume. Routes serialize denials
+ * with the canonical 402 body from ./agent-billing-gate-402.ts.
  */
 
 import { organizationsRepository } from "../../db/repositories";


### PR DESCRIPTION
## Debt theme: the insufficient-credits 402 block was copy-pasted ~10x with wire drift

Follow-up to the tech-debt sweep over recently merged cloud PRs (#11240, #11227 flagged the two newest copies). The credit-gate denial — `logger.warn` + a 402 `{ success:false, error, requiredBalance, currentBalance }` body — was pasted into 10 routes, and the copies had drifted into **three different wire shapes** for the same condition:

| shape | routes |
|---|---|
| flat, no `code` | v1/agents (create), v1/agents resume + restart, v1/eliza/agents provision + resume + wake |
| flat + `code: "insufficient_credits"` | eliza-app/provisioning-agent, v1/eliza pairing-token, v1/coding-containers |
| `ApiError` → balances nested under `details` | v1/eliza/agents (create) |

### Fix (one helper, one shape)

`packages/cloud/shared/src/lib/services/agent-billing-gate-402.ts`, beside `checkAgentCreditGate`:

- `insufficientCreditsBody(creditCheck)` — the canonical body
- `insufficientCredits402(creditCheck, warn, logContext)` — the route's warn line (+ gate numbers) and the body

All 10 sites now return the identical flat body: `{ success: false, code: "insufficient_credits", error, requiredBalance, currentBalance }`, HTTP 402, `success:false` unchanged everywhere.

**Canonical-shape call:** kept `code` (additive for the 6 routes that lacked it; removing it could break the 3+1 routes' existing consumers, it matches the repo's `ApiError.toJSON()` contract, and the cloud SDK branches on `code`). The one wire **change** is the v1/eliza/agents create route: balances move from `details.{requiredBalance,currentBalance}` to the flat fields — grepped the repo: nothing reads `details.requiredBalance` (no UI/SDK consumer).

The helper lives in a light sibling module (type-only import of the gate) rather than inside `agent-billing-gate.ts`: every route unit test wholesale-mocks the db-backed gate module, so the body builder must not live there or the tests would have to re-implement the shape in their mocks. This way the 402 assertions in route tests exercise the **real** canonical body while the gate itself stays mocked.

### Intentionally not migrated

- `compat/agents/[id]/{launch,resume,restart}` — the compat surface deliberately returns its own `errorEnvelope(...)` contract (no balances); still gate on `checkAgentCreditGate`, left as-is.

### Also fixed

- `v1/coding-containers/route.test.ts` failed to load on develop (`SyntaxError: Export named 'AgentQuotaExceededError' not found`) — the eliza-sandbox mock was missing an export the route imports. Mock now provides it; the file's 5 tests run again.

### Tests

New/extended:
- `agent-billing-gate-402.test.ts` — exact body shape (`toStrictEqual`), error fallback, warn payload (3 tests)
- `eliza-agents-create-idempotency.test.ts` — new test locking the create route's 402 to the canonical **flat** body (exact match, proves the details→flat de-drift)
- `coding-containers/route.test.ts` — 402 assertion upgraded from `objectContaining` to exact full-body match
- `v1/agents/route.test.ts` — asserts the new `code` field

```
packages/cloud/shared:  bun test src/lib/services/agent-billing-gate-402.test.ts  → 3 pass, 0 fail
packages/cloud/api (per-file, isolated runner semantics):
  v1/coding-containers/route.test.ts                       → 5 pass, 0 fail (was 0 pass / load error on develop)
  v1/agents/route.test.ts                                  → 12 pass, 0 fail
  v1/agents/[agentId]/resume/route.test.ts                 → 2 pass, 0 fail
  v1/agents/[agentId]/restart/route.test.ts                → 3 pass, 0 fail
  v1/eliza/agents/[agentId]/pairing-token/route.test.ts    → 9 pass, 0 fail
  __tests__/compat-agent-credit-gate.test.ts               → 6 pass, 0 fail
  __tests__/eliza-agents-create-idempotency.test.ts        → 9 pass, 0 fail
  __tests__/eliza-agents-orphan-cleanup.test.ts            → 5 pass, 0 fail
  __tests__/provisioning-agent-default-image.test.ts       → 4 pass, 0 fail
typecheck: packages/cloud/api clean (exit 0); packages/cloud/shared no findings on touched files
lint: packages/cloud/api biome clean; shared touched files clean
grep: zero `requiredBalance`/`MINIMUM_DEPOSIT` literals left in route code — the block cannot be pasted back without reviewers seeing a new shape
```

Net −51 lines.
