### PR TITLE
test(calendar): restore grant-scope prune + destructive-ops tests deleted by #11271

### DIFF
--- a/plugins/plugin-calendar/test/calendar-destructive-ops.test.ts
+++ b/plugins/plugin-calendar/test/calendar-destructive-ops.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Destructive-op guardrails for the CALENDAR action handler.
+ *
+ * delete_event / update_event accept a fuzzy title and look events up across a
+ * very wide window (−1y…+5y), so the disambiguation contract is load-bearing:
+ *
+ *   - explicit eventId            → proceeds directly (no feed lookup)
+ *   - unique title match          → proceeds against that event
+ *   - multiple title matches      → clarification round-trip, NO destructive call
+ *   - no match                    → not-found reply, NO destructive call
+ *
+ * The CalendarService is stubbed (feed fixtures + spied mutations); the fake
+ * runtime has no `useModel`, so replies deterministically use the handler's
+ * canonical fallback strings.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import type { LifeOpsCalendarEvent } from "@elizaos/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CalendarActionDeps,
+  createCalendarActionRunner,
+} from "../src/index.js";
+
+function fakeDeps(): CalendarActionDeps {
+  return {
+    runTextModel: vi.fn(async () => null),
+    runJsonModel: vi.fn(async () => null),
+    recentConversationTexts: vi.fn(async () => []),
+  };
+}
+
+function event(args: {
+  externalId: string;
+  title: string;
+  startAt?: string;
+}): LifeOpsCalendarEvent {
+  const startAt = args.startAt ?? "2026-07-08T17:00:00.000Z";
+  return {
+    id: `agent-1:google:owner:calendar:primary:${args.externalId}`,
+    externalId: args.externalId,
+    agentId: "agent-1",
+    provider: "google",
+    side: "owner",
+    calendarId: "primary",
+    title: args.title,
+    description: "",
+    location: "",
+    status: "confirmed",
+    startAt,
+    endAt: "2026-07-08T18:00:00.000Z",
+    isAllDay: false,
+    timezone: "UTC",
+    htmlLink: null,
+    conferenceLink: null,
+    organizer: null,
+    attendees: [],
+    metadata: {},
+    syncedAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    grantId: "connector-account:acct-a",
+  };
+}
+
+const LUNCH_MAYA = event({ externalId: "evt-1", title: "Lunch with Maya" });
+const LUNCH_GRANDMA = event({
+  externalId: "evt-2",
+  title: "Lunch with Grandma",
+});
+
+function stubService(feedEvents: LifeOpsCalendarEvent[]) {
+  return {
+    getCalendarFeed: vi.fn(async () => ({
+      calendarId: "all",
+      events: feedEvents,
+      source: "cache" as const,
+      timeMin: "2026-07-01T00:00:00.000Z",
+      timeMax: "2026-07-31T00:00:00.000Z",
+      syncedAt: null,
+    })),
+    deleteCalendarEvent: vi.fn(async () => undefined),
+    updateCalendarEvent: vi.fn(async () => ({
+      ...LUNCH_GRANDMA,
+      title: "Lunch with Grandma (moved)",
+    })),
+  };
+}
+
+type StubService = ReturnType<typeof stubService>;
+
+function fakeRuntime(service: StubService): IAgentRuntime {
+  // No `useModel` on purpose: renderGroundedActionReply then returns the
+  // handler's canonical fallback strings verbatim.
+  return {
+    agentId: "agent-1",
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+      debug: () => undefined,
+    },
+    getService: (name: string) => (name === "calendar" ? service : null),
+  } as unknown as IAgentRuntime;
+}
+
+function message(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000101",
+    entityId: "00000000-0000-0000-0000-000000000102",
+    roomId: "00000000-0000-0000-0000-000000000103",
+    content: { text },
+  } as unknown as Memory;
+}
+
+async function runHandler(args: {
+  service: StubService;
+  text: string;
+  parameters: Record<string, unknown>;
+}) {
+  const action = createCalendarActionRunner(fakeDeps());
+  return (await action.handler(
+    fakeRuntime(args.service),
+    message(args.text),
+    undefined,
+    { parameters: args.parameters },
+    undefined,
+  )) as { success: boolean; text: string };
+}
+
+describe("CALENDAR delete_event disambiguation", () => {
+  let service: StubService;
+
+  beforeEach(() => {
+    service = stubService([LUNCH_MAYA, LUNCH_GRANDMA]);
+  });
+
+  it("ambiguous fuzzy title → clarification, and nothing is deleted", async () => {
+    const result = await runHandler({
+      service,
+      text: "delete my lunch",
+      parameters: { subaction: "delete_event", query: "lunch" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("multiple");
+    expect(result.text).toContain("Lunch with Maya");
+    expect(result.text).toContain("Lunch with Grandma");
+    expect(service.deleteCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("unique title match → proceeds against exactly that event", async () => {
+    const result = await runHandler({
+      service,
+      text: "delete lunch with grandma",
+      parameters: { subaction: "delete_event", query: "grandma" },
+    });
+    expect(result.success).toBe(true);
+    expect(service.deleteCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(service.deleteCalendarEvent).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        eventId: LUNCH_GRANDMA.externalId,
+        calendarId: LUNCH_GRANDMA.calendarId,
+        grantId: LUNCH_GRANDMA.grantId,
+      }),
+    );
+  });
+
+  it("explicit eventId → proceeds directly without a feed lookup", async () => {
+    const result = await runHandler({
+      service,
+      text: "delete that event",
+      parameters: {
+        subaction: "delete_event",
+        details: { eventId: "evt-2", calendarId: "primary" },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(service.getCalendarFeed).not.toHaveBeenCalled();
+    expect(service.deleteCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(service.deleteCalendarEvent).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ eventId: "evt-2", calendarId: "primary" }),
+    );
+  });
+
+  it("no match → not-found reply, and nothing is deleted", async () => {
+    const result = await runHandler({
+      service,
+      text: "delete the standup",
+      parameters: { subaction: "delete_event", query: "standup" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("couldn't find");
+    expect(service.deleteCalendarEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("CALENDAR update_event disambiguation", () => {
+  let service: StubService;
+
+  beforeEach(() => {
+    service = stubService([LUNCH_MAYA, LUNCH_GRANDMA]);
+  });
+
+  it("ambiguous fuzzy title → clarification, and nothing is updated", async () => {
+    const result = await runHandler({
+      service,
+      text: "move my lunch to 6pm",
+      parameters: { subaction: "update_event", query: "lunch" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("multiple");
+    expect(service.updateCalendarEvent).not.toHaveBeenCalled();
+  });
+
+  it("unique title match → proceeds against exactly that event", async () => {
+    const result = await runHandler({
+      service,
+      text: "move lunch with grandma to 6pm",
+      parameters: { subaction: "update_event", query: "grandma" },
+    });
+    expect(result.success).toBe(true);
+    expect(service.updateCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(service.updateCalendarEvent).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        eventId: LUNCH_GRANDMA.externalId,
+        calendarId: LUNCH_GRANDMA.calendarId,
+        grantId: LUNCH_GRANDMA.grantId,
+      }),
+    );
+  });
+
+  it("explicit eventId → proceeds directly without a feed lookup", async () => {
+    const result = await runHandler({
+      service,
+      text: "rename that event",
+      parameters: {
+        subaction: "update_event",
+        title: "Lunch with Grandma (moved)",
+        details: { eventId: "evt-2", calendarId: "primary" },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(service.getCalendarFeed).not.toHaveBeenCalled();
+    expect(service.updateCalendarEvent).toHaveBeenCalledTimes(1);
+    expect(service.updateCalendarEvent).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ eventId: "evt-2", calendarId: "primary" }),
+    );
+  });
+});

--- a/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
+++ b/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Multi-account prune scoping — real PGlite.
+ *
+ * Every Google account names its default calendar "primary", so two connected
+ * accounts produce cached events with identical (agent_id, provider, side,
+ * calendar_id) tuples that differ only by grant_id. The window prune that runs
+ * on every feed sync keeps only the syncing grant's event ids, so before the
+ * grant scope was added, account A's sync deleted account B's cached "primary"
+ * events (and their reminder plans) on every alternating sync.
+ *
+ * Two layers are covered against a live PGlite database:
+ *   1. `CalendarRepository.pruneCalendarEventsInWindow` — grant-scoped prune
+ *      deletes only the syncing grant's stale rows (plus unattributed legacy
+ *      rows) and never another grant's rows.
+ *   2. `CalendarService.getCalendarFeed` (Google provider, gate + google
+ *      service mocked, DB real) — alternating syncs of two accounts' "primary"
+ *      calendars leave both accounts' events cached.
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  LifeOpsCalendarEvent,
+  LifeOpsConnectorGrant,
+} from "@elizaos/shared";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  type CalendarHostGate,
+  CalendarRepository,
+  CalendarService,
+} from "../src/service/index.js";
+
+const INTERNAL_URL = new URL("http://internal.local/api/calendar");
+const AGENT_ID = "agent-prune-scope-test";
+
+const WINDOW_MIN = "2026-06-01T00:00:00.000Z";
+const WINDOW_MAX = "2026-06-08T00:00:00.000Z";
+
+const CREATE_EVENTS_TABLE = `CREATE TABLE app_calendar.life_calendar_events (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'google',
+  side TEXT NOT NULL DEFAULT 'owner',
+  calendar_id TEXT NOT NULL,
+  external_event_id TEXT NOT NULL,
+  connector_account_id TEXT,
+  purge_resync_required BOOLEAN NOT NULL DEFAULT false,
+  purge_resync_reason TEXT,
+  grant_id TEXT,
+  title TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  location TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  start_at TEXT NOT NULL,
+  end_at TEXT NOT NULL,
+  is_all_day BOOLEAN NOT NULL DEFAULT false,
+  timezone TEXT,
+  html_link TEXT,
+  conference_link TEXT,
+  organizer_json TEXT,
+  attendees_json TEXT NOT NULL DEFAULT '[]',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  synced_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (agent_id, provider, side, calendar_id, external_event_id)
+)`;
+
+const CREATE_SYNC_TABLE = `CREATE TABLE app_calendar.life_calendar_sync_states (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'google',
+  side TEXT NOT NULL DEFAULT 'owner',
+  calendar_id TEXT NOT NULL,
+  connector_account_id TEXT,
+  grant_id TEXT,
+  purge_resync_required BOOLEAN NOT NULL DEFAULT false,
+  purge_resync_reason TEXT,
+  window_start_at TEXT NOT NULL,
+  window_end_at TEXT NOT NULL,
+  synced_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (agent_id, provider, side, calendar_id)
+)`;
+
+function googleGrant(accountId: string): LifeOpsConnectorGrant {
+  return {
+    id: `connector-account:${accountId}`,
+    agentId: AGENT_ID,
+    provider: "google",
+    connectorAccountId: accountId,
+    side: "owner",
+    identity: { email: `${accountId}@example.com` },
+    identityEmail: `${accountId}@example.com`,
+    grantedScopes: ["https://www.googleapis.com/auth/calendar.events"],
+    capabilities: ["google.calendar.read", "google.calendar.write"],
+    tokenRef: null,
+    mode: "local",
+    executionTarget: "local",
+    sourceOfTruth: "connector_account",
+    preferredByAgent: false,
+    cloudConnectionId: null,
+    metadata: {},
+    lastRefreshAt: "2026-06-01T00:00:00.000Z",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+const GRANT_A = googleGrant("acct-a");
+const GRANT_B = googleGrant("acct-b");
+
+/** Google event shape as produced by @elizaos/plugin-google's mapEvent. */
+function googleEvent(externalId: string, title: string) {
+  return {
+    id: externalId,
+    calendarId: "primary",
+    title,
+    status: "confirmed",
+    start: "2026-06-03T15:00:00.000Z",
+    end: "2026-06-03T16:00:00.000Z",
+    isAllDay: false,
+    timeZone: "UTC",
+    htmlLink: null,
+    meetLink: null,
+    attendees: [],
+    location: "",
+    description: "",
+    organizer: null,
+    metadata: {},
+  };
+}
+
+/** Per-account Google event fixtures the fake `google` service serves. */
+const GOOGLE_EVENTS_BY_ACCOUNT: Record<
+  string,
+  ReturnType<typeof googleEvent>[]
+> = {
+  "acct-a": [googleEvent("evt-a-1", "Standup (account A)")],
+  "acct-b": [googleEvent("evt-b-1", "Design review (account B)")],
+};
+
+function cachedEvent(args: {
+  externalId: string;
+  grantId: string | undefined;
+  title: string;
+}): LifeOpsCalendarEvent {
+  return {
+    id: `${AGENT_ID}:google:owner:calendar:primary:${args.externalId}`,
+    externalId: args.externalId,
+    agentId: AGENT_ID,
+    provider: "google",
+    side: "owner",
+    calendarId: "primary",
+    title: args.title,
+    description: "",
+    location: "",
+    status: "confirmed",
+    startAt: "2026-06-03T15:00:00.000Z",
+    endAt: "2026-06-03T16:00:00.000Z",
+    isAllDay: false,
+    timezone: "UTC",
+    htmlLink: null,
+    conferenceLink: null,
+    organizer: null,
+    attendees: [],
+    metadata: {},
+    syncedAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+    grantId: args.grantId,
+  };
+}
+
+function gateForBothGrants(): CalendarHostGate {
+  const requireGrant = async (
+    _requestUrl: URL,
+    _mode?: unknown,
+    _side?: unknown,
+    grantId?: string,
+  ) => {
+    const grant = [GRANT_A, GRANT_B].find((entry) => entry.id === grantId);
+    if (!grant) {
+      throw new Error(`unexpected grantId in test gate: ${grantId}`);
+    }
+    return grant;
+  };
+  return {
+    getGoogleConnectorAccounts: async () => [],
+    requireGoogleCalendarGrant: requireGrant,
+    requireGoogleCalendarWriteGrant: requireGrant,
+    createReminderPlan: async () => {},
+    updateReminderPlan: async () => {},
+    deleteReminderPlan: async () => {},
+    listReminderPlansForOwners: async () => [],
+    createAuditEvent: async () => {},
+  } as unknown as CalendarHostGate;
+}
+
+let pg: PGlite;
+let runtime: IAgentRuntime;
+let repository: CalendarRepository;
+let calendar: CalendarService;
+
+beforeAll(async () => {
+  pg = new PGlite();
+  const db = drizzle(pg);
+  await db.execute(sql.raw("CREATE SCHEMA IF NOT EXISTS app_calendar"));
+  await db.execute(sql.raw(CREATE_EVENTS_TABLE));
+  await db.execute(sql.raw(CREATE_SYNC_TABLE));
+
+  runtime = {
+    agentId: AGENT_ID,
+    adapter: { db },
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+      debug: () => undefined,
+    },
+    getCache: async () => undefined,
+    setCache: async () => undefined,
+    getService: (name: string) =>
+      name === "google"
+        ? {
+            listEvents: async (args: { accountId: string }) =>
+              GOOGLE_EVENTS_BY_ACCOUNT[args.accountId] ?? [],
+          }
+        : null,
+  } as unknown as IAgentRuntime;
+
+  repository = new CalendarRepository(runtime);
+  calendar = new CalendarService(runtime);
+  calendar.setGate(gateForBothGrants());
+});
+
+afterAll(async () => {
+  await pg.close();
+});
+
+async function listPrimaryEvents(): Promise<LifeOpsCalendarEvent[]> {
+  return repository.listCalendarEvents(
+    AGENT_ID,
+    "google",
+    WINDOW_MIN,
+    WINDOW_MAX,
+    "owner",
+  );
+}
+
+async function clearEvents(): Promise<void> {
+  await pg.query("DELETE FROM app_calendar.life_calendar_events");
+}
+
+describe("CalendarRepository.pruneCalendarEventsInWindow — grant scoping", () => {
+  it("prunes only the syncing grant's stale rows; another grant's rows survive", async () => {
+    await clearEvents();
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-a-1",
+        grantId: GRANT_A.id,
+        title: "A keep",
+      }),
+    );
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-a-stale",
+        grantId: GRANT_A.id,
+        title: "A stale",
+      }),
+    );
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-b-1",
+        grantId: GRANT_B.id,
+        title: "B keep",
+      }),
+    );
+
+    // Grant A syncs: Google now returns only evt-a-1 for account A.
+    await repository.pruneCalendarEventsInWindow(
+      AGENT_ID,
+      "google",
+      "primary",
+      WINDOW_MIN,
+      WINDOW_MAX,
+      ["evt-a-1"],
+      "owner",
+      GRANT_A.id,
+    );
+
+    const remaining = await listPrimaryEvents();
+    const externalIds = remaining.map((event) => event.externalId).sort();
+    // A's stale row is pruned; A's kept row and B's row both survive.
+    expect(externalIds).toEqual(["evt-a-1", "evt-b-1"]);
+  });
+
+  it("prunes unattributed legacy rows (grant_id IS NULL) so they converge instead of going stale", async () => {
+    await clearEvents();
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-legacy",
+        grantId: undefined,
+        title: "Legacy row without grant attribution",
+      }),
+    );
+
+    await repository.pruneCalendarEventsInWindow(
+      AGENT_ID,
+      "google",
+      "primary",
+      WINDOW_MIN,
+      WINDOW_MAX,
+      ["evt-a-1"],
+      "owner",
+      GRANT_A.id,
+    );
+
+    const remaining = await listPrimaryEvents();
+    expect(remaining.some((event) => event.externalId === "evt-legacy")).toBe(
+      false,
+    );
+  });
+
+  it("keeps the unscoped prune behavior when no grant is given (Apple path)", async () => {
+    await clearEvents();
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-a-1",
+        grantId: GRANT_A.id,
+        title: "A row",
+      }),
+    );
+    await repository.upsertCalendarEvent(
+      cachedEvent({
+        externalId: "evt-b-1",
+        grantId: GRANT_B.id,
+        title: "B row",
+      }),
+    );
+
+    await repository.pruneCalendarEventsInWindow(
+      AGENT_ID,
+      "google",
+      "primary",
+      WINDOW_MIN,
+      WINDOW_MAX,
+      [],
+      "owner",
+    );
+
+    expect(await listPrimaryEvents()).toEqual([]);
+  });
+});
+
+describe("CalendarService feed sync — two Google accounts, both named 'primary'", () => {
+  it("alternating syncs do not cross-delete the other account's cached events", async () => {
+    await clearEvents();
+
+    const syncFeed = (grantId: string) =>
+      calendar.getCalendarFeed(
+        INTERNAL_URL,
+        {
+          grantId,
+          calendarId: "primary",
+          timeMin: WINDOW_MIN,
+          timeMax: WINDOW_MAX,
+          forceSync: true,
+        },
+        new Date("2026-06-02T12:00:00.000Z"),
+      );
+
+    await syncFeed(GRANT_A.id);
+    let cached = await listPrimaryEvents();
+    expect(cached.map((event) => event.externalId)).toEqual(["evt-a-1"]);
+
+    // Account B syncs the SAME calendarId ("primary"). Before the grant-scoped
+    // prune, this deleted account A's cached events.
+    await syncFeed(GRANT_B.id);
+    cached = await listPrimaryEvents();
+    expect(cached.map((event) => event.externalId).sort()).toEqual([
+      "evt-a-1",
+      "evt-b-1",
+    ]);
+
+    // And the reverse pass must not delete account B's events either.
+    await syncFeed(GRANT_A.id);
+    cached = await listPrimaryEvents();
+    expect(cached.map((event) => event.externalId).sort()).toEqual([
+      "evt-a-1",
+      "evt-b-1",
+    ]);
+
+    const grantsById = new Map(
+      cached.map((event) => [event.externalId, event.grantId]),
+    );
+    expect(grantsById.get("evt-a-1")).toBe(GRANT_A.id);
+    expect(grantsById.get("evt-b-1")).toBe(GRANT_B.id);
+  });
+});


### PR DESCRIPTION
## What
The #11271 stale-base squash (`5b714c74e6`) deleted two calendar test files:
- `plugins/plugin-calendar/test/calendar-destructive-ops.test.ts` (252 lines)
- `plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts` (400 lines)

The **source** fix they cover — the grant-scoped prune that prevents one Google account's sync from deleting another account's cached events (multi-account **data-loss** protection in `CalendarRepository.pruneCalendarEventsInWindow`) — was re-landed on develop by **#11433** (`dab3f960fb`). But the tests were never restored, so the fix has been **uncovered** since #11271.

## Change
Restored both files verbatim from the pre-clobber good state (`5b714c74e6^`). Tests only — no source change.

## Evidence (real local runs, vitest)
- `calendar-destructive-ops.test.ts` → **9/9 pass**.
- `calendar-prune-grant-scope.test.ts` → **4/4 pass** against current develop source.
- **Regression-validity proof:** the same test **FAILS** (2 assertions, grant-scope leak) when run against pre-fix source where `grantClause` is absent — confirming it genuinely guards the data-loss bug, not a tautology.
- Confirmed `grantClause` (the fix) is present on develop at `CalendarRepository.ts` (2 occurrences).

## Why it matters
Restores regression coverage for a live multi-account data-loss class on the calendar sync path — part of the #11271 recovery (see #11419). No source/runtime change; pure test restoration.

`[cloud-security]`