### PR TITLE
test(cloud): fix stale eliza-sandbox mock (coding-containers red, CI-hidden)

### DIFF
--- a/packages/cloud/api/v1/coding-containers/route.test.ts
+++ b/packages/cloud/api/v1/coding-containers/route.test.ts
@@ -49,6 +49,9 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     getAgent: mock(async () => undefined),
     updateAgentEnvironment,
   },
+  // #11095 added this export; route.ts imports it, so the mock must provide it
+  // or the whole module (and this test file) fails to load.
+  AgentQuotaExceededError: class AgentQuotaExceededError extends Error {},
 }));
 
 mock.module("@/lib/services/provisioning-jobs", () => ({


### PR DESCRIPTION
`coding-containers/route.test.ts` fails to **load** on develop — its `mock.module` of `@/lib/services/eliza-sandbox` doesn't export `AgentQuotaExceededError` (added by #11095), so bun errors `Export named AgentQuotaExceededError not found` and the file goes red. The Cloud Tests CI lane has been queue-starved since 06-29 so it shipped unseen. Add a stub class to the mock. **Verified: 5 pass / 0 fail.** Found via a local run of the launch-critical suites (part of proving the 3 days of CI-unverified merges are green). — nubs-cloud [cloud-frontdoor]