### PR TITLE
fix(feed,benchmarks): restore 7 files clobbered by #11271 — broken imports + orphaned tests (#11419)

### DIFF
--- a/packages/benchmarks/interrupt-bench/tests/honest-scoring.test.ts
+++ b/packages/benchmarks/interrupt-bench/tests/honest-scoring.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Honest-scoring regression tests (#9310 §3.11).
+ *
+ * Guards the two audit findings:
+ *   1. Empty/missing axes must never score a free 1.0 — an axis without
+ *      checks scores 0, an unmeasurable axis is excluded from normalization.
+ *   2. Scheduled tasks are created only by an explicit `schedule_followup`
+ *      threadOp — never inferred from instruction text by a hardcoded oracle
+ *      regex (the old `(meeting|carol|bob).*(friday|...)` shortcut).
+ */
+
+import { describe, expect, it } from "vitest";
+import { runScenario } from "../src/evaluator.ts";
+import { loadScenarios } from "../src/scenarios.ts";
+import { scoreScenario } from "../src/scorer.ts";
+import { SimulatorState } from "../src/state.ts";
+import { Trace } from "../src/trace.ts";
+import type { Scenario } from "../src/types.ts";
+
+function emptyExpectationsScenario(): Scenario {
+  return {
+    id: "T0-empty-expectations",
+    category: "T",
+    interruptionType: "addition",
+    weight: 1,
+    setup: {
+      agentId: "agent-test",
+      rooms: [{ id: "dm-alice", kind: "dm", owner: "alice" }],
+      users: [{ id: "alice", role: "OWNER" }],
+      openThreads: [],
+      scheduledTasks: [],
+      memory: [],
+    },
+    script: [{ t: 0, channel: "dm-alice", sender: "alice", text: "hi" }],
+    expectedFinalState: {
+      threads: [],
+      scheduledTasks: [],
+      repliesByChannel: {},
+    },
+    expectedTrace: {
+      stage1Calls: { min: 1, max: 2 },
+      boundaryViolations: 0,
+    },
+    responseRubric: { judgePrompt: "n/a", passRequiredForBonus: false },
+  };
+}
+
+describe("empty axes are never a free 1.0", () => {
+  it("scores an all-empty scenario near zero instead of ~0.9", () => {
+    const scenario = emptyExpectationsScenario();
+    const result = scoreScenario({
+      scenario,
+      finalState: SimulatorState.fromSetup(scenario.setup),
+      trace: new Trace(() => 0),
+      durationMs: 0,
+      mode: "scripted",
+    });
+
+    // state: no expectations → 0, not 1.
+    expect(result.axes.state.raw).toBe(0);
+    expect(result.axes.state.notes[0]).toContain("no state expectations");
+    // routing: no expectations and no replies → excluded, not 1.
+    expect(result.axes.routing.excluded).toBe(true);
+    expect(result.axes.routing.weighted).toBe(0);
+    // intent: not defined → excluded from normalization, not 1.
+    expect(result.axes.intent.excluded).toBe(true);
+    expect(result.axes.intent.weighted).toBe(0);
+    // latency: nothing ran → 0, not 1.
+    expect(result.axes.latency.raw).toBe(0);
+    // Only the boundary axis legitimately passes (0 violations ≤ 0 allowed):
+    // 0.15 / (0.3 + 0.1 + 0.15 + 0.05) = 0.25 — far below the old free-pass
+    // ~0.9 that empty axes used to produce.
+    expect(result.score).toBeCloseTo(0.25, 5);
+  });
+
+  it("renormalizes over included axes so a fully-passing run still scores 1", async () => {
+    const scenario = loadScenarios().find(
+      (s) => s.id === "A1-fragmented-email-draft",
+    );
+    expect(scenario).toBeDefined();
+    if (!scenario) throw new Error("A1 not found");
+    const result = await runScenario(scenario, { mode: "scripted" });
+    expect(result.score).toBe(1);
+  });
+});
+
+describe("scheduling has no text oracle", () => {
+  it("a create op with oracle-matching text does NOT schedule a task", async () => {
+    const scenario = loadScenarios().find(
+      (s) => s.id === "A4-stream-with-retraction",
+    );
+    expect(scenario).toBeDefined();
+    if (!scenario) throw new Error("A4 not found");
+
+    // Provider mimics an agent that creates a thread whose instruction would
+    // have satisfied the removed regex oracle, but never emits the explicit
+    // schedule_followup op. Under honest semantics no task is scheduled and
+    // the state axis must fail.
+    const result = await runScenario(scenario, {
+      mode: "scripted",
+      scripted: () => ({
+        parsed: {
+          shouldRespond: "RESPOND",
+          contexts: [],
+          intents: [],
+          candidateActionNames: [],
+          replyText: "On it.",
+          facts: [],
+          relationships: [],
+          addressedTo: [],
+          threadOps: [
+            {
+              type: "create",
+              workThreadId: null,
+              sourceWorkThreadIds: [],
+              sourceRef: null,
+              instruction: "meeting with carol friday at 10am",
+              reason: "test",
+            },
+          ],
+        },
+        latencyMs: 50,
+      }),
+    });
+
+    expect(result.axes.state.raw).toBeLessThan(1);
+    expect(
+      result.axes.state.notes.some((n) => n.includes("scheduledTask mismatch")),
+    ).toBe(true);
+  });
+
+  it("the explicit schedule_followup op schedules the task (ideal agent passes A4)", async () => {
+    const scenario = loadScenarios().find(
+      (s) => s.id === "A4-stream-with-retraction",
+    );
+    expect(scenario).toBeDefined();
+    if (!scenario) throw new Error("A4 not found");
+    const result = await runScenario(scenario, { mode: "scripted" });
+    expect(result.axes.state.raw).toBe(1);
+    expect(result.score).toBe(1);
+  });
+});

--- a/packages/benchmarks/orchestrator_lifecycle/events.py
+++ b/packages/benchmarks/orchestrator_lifecycle/events.py
@@ -1,0 +1,192 @@
+"""Typed lifecycle-event extraction for the orchestrator lifecycle benchmark.
+
+The bench server returns, per turn, the action names the agent's planner
+actually selected (``MessageResponse.actions``) plus the planner-supplied
+parameters (``MessageResponse.params``). This module normalizes both into a
+small set of typed lifecycle events the evaluator asserts on:
+
+    spawn         a subagent / task-agent was created
+    send          input or updated instructions were forwarded to a task agent
+    pause         the task was paused
+    resume        the task was resumed / continued / reopened
+    cancel        the task or agent was cancelled / stopped
+    status_query  the live task/agent registry was consulted
+    share         a task artifact / result was surfaced
+
+The name table is derived from the runtime's real orchestrator action surface
+(`plugins/plugin-agent-orchestrator/src/actions/tasks.ts` — the Pattern C
+``TASKS`` parent action and its legacy leaf-action similes). The op table maps
+the ``TASKS`` sub-operation values (``action`` / ``op`` / ``subaction`` /
+``operation`` params) to the same events.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+LIFECYCLE_EVENTS: tuple[str, ...] = (
+    "spawn",
+    "send",
+    "pause",
+    "resume",
+    "cancel",
+    "status_query",
+    "share",
+)
+
+# Action name (planner-selected, incl. legacy leaf similes) -> event.
+ACTION_NAME_EVENTS: dict[str, str] = {
+    # spawn
+    "CREATE_AGENT_TASK": "spawn",
+    "CREATE_TASK": "spawn",
+    "START_CODING_TASK": "spawn",
+    "LAUNCH_CODING_TASK": "spawn",
+    "RUN_CODING_TASK": "spawn",
+    "START_AGENT_TASK": "spawn",
+    "SPAWN_AND_PROVISION": "spawn",
+    "LAUNCH_TASK": "spawn",
+    "CREATE_SUBTASK": "spawn",
+    "SPAWN_AGENT": "spawn",
+    "SPAWN_CODING_AGENT": "spawn",
+    "START_CODING_AGENT": "spawn",
+    "LAUNCH_CODING_AGENT": "spawn",
+    "CREATE_CODING_AGENT": "spawn",
+    "SPAWN_CODER": "spawn",
+    "RUN_CODING_AGENT": "spawn",
+    "SPAWN_SUB_AGENT": "spawn",
+    "START_TASK_AGENT": "spawn",
+    "CREATE_AGENT": "spawn",
+    # send
+    "SEND_TO_AGENT": "send",
+    "SEND_TO_CODING_AGENT": "send",
+    "MESSAGE_CODING_AGENT": "send",
+    "INPUT_TO_AGENT": "send",
+    "RESPOND_TO_AGENT": "send",
+    "TELL_CODING_AGENT": "send",
+    "MESSAGE_AGENT": "send",
+    "TELL_TASK_AGENT": "send",
+    # cancel / stop
+    "CANCEL_TASK": "cancel",
+    "STOP_TASK": "cancel",
+    "ABORT_TASK": "cancel",
+    "KILL_TASK": "cancel",
+    "STOP_SUBTASK": "cancel",
+    "STOP_AGENT": "cancel",
+    "STOP_CODING_AGENT": "cancel",
+    "KILL_CODING_AGENT": "cancel",
+    "TERMINATE_AGENT": "cancel",
+    "END_CODING_SESSION": "cancel",
+    "CANCEL_AGENT": "cancel",
+    "CANCEL_TASK_AGENT": "cancel",
+    "STOP_SUB_AGENT": "cancel",
+    # pause / resume
+    "PAUSE_TASK": "pause",
+    "RESUME_TASK": "resume",
+    "CONTINUE_TASK": "resume",
+    "REOPEN_TASK": "resume",
+    "RESUME_CODING_TASK": "resume",
+    "REOPEN_CODING_TASK": "resume",
+    "UNARCHIVE_CODING_TASK": "resume",
+    # status queries
+    "LIST_AGENTS": "status_query",
+    "LIST_CODING_AGENTS": "status_query",
+    "SHOW_CODING_AGENTS": "status_query",
+    "GET_ACTIVE_AGENTS": "status_query",
+    "LIST_SESSIONS": "status_query",
+    "SHOW_CODING_SESSIONS": "status_query",
+    "SHOW_TASK_AGENTS": "status_query",
+    "LIST_SUB_AGENTS": "status_query",
+    "SHOW_TASK_STATUS": "status_query",
+    "TASK_HISTORY": "status_query",
+    "LIST_TASK_HISTORY": "status_query",
+    "GET_TASK_HISTORY": "status_query",
+    "SHOW_TASKS": "status_query",
+    "COUNT_TASKS": "status_query",
+    "TASK_STATUS_HISTORY": "status_query",
+    # share / surface results
+    "TASK_SHARE": "share",
+    "SHARE_TASK_RESULT": "share",
+    "SHOW_TASK_ARTIFACT": "share",
+    "VIEW_TASK_OUTPUT": "share",
+}
+
+# TASKS sub-operation value (from action/op/subaction/operation params) -> event.
+OPERATION_EVENTS: dict[str, str] = {
+    "create": "spawn",
+    "spawn_agent": "spawn",
+    "send": "send",
+    "cancel": "cancel",
+    "stop": "cancel",
+    "stop_agent": "cancel",
+    "pause": "pause",
+    "resume": "resume",
+    "continue": "resume",
+    "reopen": "resume",
+    "list_agents": "status_query",
+    "list": "status_query",
+    "history": "status_query",
+    "status": "status_query",
+    "share": "share",
+}
+
+# Param keys whose values identify a TASKS sub-operation.
+_OPERATION_KEYS = frozenset({"action", "op", "subaction", "operation"})
+
+# Bridge params that carry response plumbing, not planner-selected operations.
+# The trajectory snapshot in particular contains full prior steps and would
+# leak events from earlier turns into the current one.
+_IGNORED_PARAM_KEYS = frozenset(
+    {
+        "_eliza_trajectory_snapshot",
+        "_eliza_trajectory_snapshot_error",
+        "eliza_metadata",
+        "usage",
+    }
+)
+
+
+def _collect_operation_values(value: object, found: list[str]) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            key_str = str(key)
+            if key_str in _IGNORED_PARAM_KEYS:
+                continue
+            if key_str in _OPERATION_KEYS and isinstance(child, str):
+                found.append(child.strip().lower())
+            _collect_operation_values(child, found)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for child in value:
+            _collect_operation_values(child, found)
+
+
+def extract_lifecycle_events(
+    actions: Sequence[str],
+    params: Mapping[str, object] | None = None,
+) -> list[str]:
+    """Normalize a turn's planner actions + params into typed lifecycle events.
+
+    Unmapped action names (REPLY, IGNORE, providers, …) and unmapped operation
+    values contribute nothing — there is no fallback that turns prose or
+    unknown data into an event.
+    """
+    events: list[str] = []
+
+    def add(event: str) -> None:
+        if event not in events:
+            events.append(event)
+
+    for name in actions:
+        mapped = ACTION_NAME_EVENTS.get(str(name).strip().upper())
+        if mapped:
+            add(mapped)
+
+    if params:
+        operations: list[str] = []
+        _collect_operation_values(params, operations)
+        for op in operations:
+            mapped = OPERATION_EVENTS.get(op)
+            if mapped:
+                add(mapped)
+
+    return events

--- a/packages/benchmarks/orchestrator_lifecycle/events.py
+++ b/packages/benchmarks/orchestrator_lifecycle/events.py
@@ -129,8 +129,12 @@ OPERATION_EVENTS: dict[str, str] = {
     "share": "share",
 }
 
-# Param keys whose values identify a TASKS sub-operation.
-_OPERATION_KEYS = frozenset({"action", "op", "subaction", "operation"})
+# Param keys whose values identify a TASKS sub-operation. `controlAction`
+# is the real runtime param for TASKS control ops (action=control,
+# controlAction=pause|resume|stop|continue|reopen — see core action docs).
+_OPERATION_KEYS = frozenset(
+    {"action", "op", "subaction", "operation", "controlaction"}
+)
 
 # Bridge params that carry response plumbing, not planner-selected operations.
 # The trajectory snapshot in particular contains full prior steps and would
@@ -151,7 +155,7 @@ def _collect_operation_values(value: object, found: list[str]) -> None:
             key_str = str(key)
             if key_str in _IGNORED_PARAM_KEYS:
                 continue
-            if key_str in _OPERATION_KEYS and isinstance(child, str):
+            if key_str.lower() in _OPERATION_KEYS and isinstance(child, str):
                 found.append(child.strip().lower())
             _collect_operation_values(child, found)
         return

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_events.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_events.py
@@ -22,6 +22,13 @@ def test_pattern_c_tasks_action_uses_operation_params() -> None:
     assert extract_lifecycle_events(
         ["TASKS"], {"action": "control", "operation": "pause"}
     ) == ["pause"]
+    # The real runtime control param is `controlAction` (action=control).
+    assert extract_lifecycle_events(
+        ["TASKS"], {"action": "control", "controlAction": "pause"}
+    ) == ["pause"]
+    assert extract_lifecycle_events(
+        ["TASKS"], {"action": "control", "controlAction": "resume"}
+    ) == ["resume"]
     # Nested per-action param dicts (BENCHMARK_ACTIONS style) are scanned too.
     assert extract_lifecycle_events(
         [], {"BENCHMARK_ACTIONS": [{"action": "resume"}, {"action": "send"}]}

--- a/packages/benchmarks/orchestrator_lifecycle/tests/test_events.py
+++ b/packages/benchmarks/orchestrator_lifecycle/tests/test_events.py
@@ -1,0 +1,54 @@
+"""Tests for typed lifecycle-event extraction from bridge responses."""
+
+from __future__ import annotations
+
+from benchmarks.orchestrator_lifecycle.events import extract_lifecycle_events
+
+
+def test_leaf_action_names_map_to_events() -> None:
+    assert extract_lifecycle_events(["CANCEL_TASK"]) == ["cancel"]
+    assert extract_lifecycle_events(["PAUSE_TASK"]) == ["pause"]
+    assert extract_lifecycle_events(["RESUME_TASK"]) == ["resume"]
+    assert extract_lifecycle_events(["SPAWN_AGENT"]) == ["spawn"]
+    assert extract_lifecycle_events(["LIST_AGENTS"]) == ["status_query"]
+    assert extract_lifecycle_events(["TASK_SHARE"]) == ["share"]
+    assert extract_lifecycle_events(["SEND_TO_AGENT"]) == ["send"]
+
+
+def test_pattern_c_tasks_action_uses_operation_params() -> None:
+    # The runtime's TASKS parent action carries the operation in params.
+    assert extract_lifecycle_events(["TASKS"], {"action": "cancel"}) == ["cancel"]
+    assert extract_lifecycle_events(["TASKS"], {"op": "create"}) == ["spawn"]
+    assert extract_lifecycle_events(
+        ["TASKS"], {"action": "control", "operation": "pause"}
+    ) == ["pause"]
+    # Nested per-action param dicts (BENCHMARK_ACTIONS style) are scanned too.
+    assert extract_lifecycle_events(
+        [], {"BENCHMARK_ACTIONS": [{"action": "resume"}, {"action": "send"}]}
+    ) == ["resume", "send"]
+
+
+def test_unmapped_names_and_prose_produce_no_events() -> None:
+    assert extract_lifecycle_events(["REPLY"]) == []
+    assert extract_lifecycle_events(["REPLY", "IGNORE"], {"text": "cancelled"}) == []
+    assert extract_lifecycle_events([], {"note": "I paused and cancelled it"}) == []
+
+
+def test_trajectory_snapshot_params_are_ignored() -> None:
+    # The bridge attaches the full prior trajectory to params; events from
+    # earlier turns must not leak into the current turn.
+    params = {
+        "_eliza_trajectory_snapshot": {
+            "steps": [{"actions": ["CANCEL_TASK"], "params": {"action": "cancel"}}]
+        },
+        "eliza_metadata": {"action": "pause"},
+        "usage": {"action": "resume"},
+    }
+    assert extract_lifecycle_events(["REPLY"], params) == []
+
+
+def test_events_deduplicate_and_preserve_order() -> None:
+    events = extract_lifecycle_events(
+        ["CANCEL_TASK", "STOP_TASK"], {"action": "cancel", "op": "history"}
+    )
+    assert events == ["cancel", "status_query"]

--- a/packages/benchmarks/three-agent-dialogue/__tests__/verification.test.ts
+++ b/packages/benchmarks/three-agent-dialogue/__tests__/verification.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the honest verification module (#9310 §3.11).
+ *
+ * The old verification scored synthetic runs identically to real ones:
+ * transcripts were counted from the ground-truth prompt (a tautology),
+ * emotion was keyword-matched against the ground-truth prompt, and the
+ * gt-fallback ASR made every synthetic turn look transcribed. These tests
+ * pin the honest semantics: only real TTS + real ASR turns are scored.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  computeVerification,
+  detectEmotionFromText,
+  type TurnOutcome,
+} from "../runner/verification.ts";
+
+const THRESHOLDS = {
+  minNonEmptyTranscripts: 1,
+  minAudioDurationSec: 1.0,
+  minDistinctSpeakers: 3,
+  emotionDetectedMinFraction: 0.8,
+};
+
+function turn(over: Partial<TurnOutcome> & { turnIdx: number }): TurnOutcome {
+  return {
+    speaker: "alice",
+    gtText: "I am excited to talk about this wonderful idea.",
+    asrText: null,
+    ttsReal: false,
+    asrReal: false,
+    detectedEmotion: null,
+    expectedEmotion: "joy",
+    ...over,
+  };
+}
+
+function realTurn(turnIdx: number, speaker: string): TurnOutcome {
+  const asrText = "I'm excited to explore this wonderful question together.";
+  return turn({
+    turnIdx,
+    speaker,
+    asrText,
+    ttsReal: true,
+    asrReal: true,
+    detectedEmotion: detectEmotionFromText(asrText),
+  });
+}
+
+describe("computeVerification", () => {
+  it("scores an all-real run and passes when thresholds are met", () => {
+    const result = computeVerification({
+      turns: [realTurn(0, "alice"), realTurn(1, "bob"), realTurn(2, "cleo")],
+      thresholds: THRESHOLDS,
+      mixDurationSec: 5,
+      mixNonBlank: true,
+      distinctSpeakers: 3,
+      smokeRequested: false,
+    });
+    expect(result.mode).toBe("real");
+    expect(result.scored).toBe(true);
+    expect(result.pass).toBe(true);
+    expect(result.transcriptNotNull).toBe(true);
+    expect(result.emotionDetectedFraction).toBe(1);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("a real run with broken ASR fails the transcript check", () => {
+    const broken = [
+      realTurn(0, "alice"),
+      realTurn(1, "bob"),
+      realTurn(2, "cleo"),
+    ].map((t) => ({ ...t, asrText: null, asrReal: false }));
+    const result = computeVerification({
+      turns: broken,
+      thresholds: THRESHOLDS,
+      mixDurationSec: 5,
+      mixNonBlank: true,
+      distinctSpeakers: 3,
+      smokeRequested: false,
+    });
+    // No real ASR at all → the run is not scoreable and must fail.
+    expect(result.scored).toBe(false);
+    expect(result.pass).toBe(false);
+  });
+
+  it("demotes any synthetic turn to synthetic-smoke and skips scored checks", () => {
+    const result = computeVerification({
+      turns: [
+        realTurn(0, "alice"),
+        turn({ turnIdx: 1, speaker: "bob" }), // synthetic
+        realTurn(2, "cleo"),
+      ],
+      thresholds: THRESHOLDS,
+      mixDurationSec: 5,
+      mixNonBlank: true,
+      distinctSpeakers: 3,
+      smokeRequested: true,
+    });
+    expect(result.mode).toBe("synthetic-smoke");
+    expect(result.scored).toBe(false);
+    expect(result.realTurns).toBe(2);
+    expect(result.syntheticTurns).toBe(1);
+    expect(result.skippedChecks.length).toBeGreaterThan(0);
+    // Smoke was requested and structural checks hold → structural pass.
+    expect(result.pass).toBe(true);
+  });
+
+  it("a FULL synthetic run fails with an explicit not-scored failure", () => {
+    const result = computeVerification({
+      turns: [
+        turn({ turnIdx: 0 }),
+        turn({ turnIdx: 1, speaker: "bob" }),
+        turn({ turnIdx: 2, speaker: "cleo" }),
+      ],
+      thresholds: THRESHOLDS,
+      mixDurationSec: 5,
+      mixNonBlank: true,
+      distinctSpeakers: 3,
+      smokeRequested: false,
+    });
+    expect(result.scored).toBe(false);
+    expect(result.pass).toBe(false);
+    expect(
+      result.failures.some((f) => f.includes("synthetic TTS/ASR path")),
+    ).toBe(true);
+    // Ground-truth text must earn no transcript/emotion credit.
+    expect(result.transcriptNotNull).toBe(false);
+    expect(result.emotionDetectedFraction).toBe(0);
+  });
+
+  it("structural failures fail even a requested smoke run", () => {
+    const result = computeVerification({
+      turns: [turn({ turnIdx: 0 })],
+      thresholds: THRESHOLDS,
+      mixDurationSec: 0.2,
+      mixNonBlank: false,
+      distinctSpeakers: 1,
+      smokeRequested: true,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.failures.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/feed/tools/chroma/specs/helpers/page-helpers.health.test.ts
+++ b/packages/feed/tools/chroma/specs/helpers/page-helpers.health.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Health-probe semantics for the chroma e2e helpers (bun test).
+ *
+ * Regression guard for the "<500 means healthy" bug: the old probe hit `/`
+ * and accepted ANY non-5xx response, so a 404-ing, half-booted, or entirely
+ * wrong server counted as healthy and the suite ran against garbage.
+ * Healthy means `/api/health` answers 2xx with `{ status: "ok" }`.
+ *
+ * Run: bun run test:unit (from tools/chroma)
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+
+type Mode = "ok" | "degraded" | "no-health-route" | "server-error";
+let mode: Mode = "ok";
+
+const server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/health") {
+      if (mode === "ok") {
+        return Response.json({
+          status: "ok",
+          timestamp: new Date().toISOString(),
+          env: "test",
+        });
+      }
+      if (mode === "degraded") return Response.json({ status: "degraded" });
+      if (mode === "server-error")
+        return new Response("boom", { status: 500 });
+      return new Response("Not Found", { status: 404 });
+    }
+    // Root answers 200 like any half-booted or wrong frontend would.
+    return new Response("<html>not the feed app</html>", {
+      headers: { "Content-Type": "text/html" },
+    });
+  },
+});
+
+// BASE_URL is captured at module load, so set the env before importing.
+process.env.PLAYWRIGHT_BASE_URL = `http://127.0.0.1:${server.port}`;
+const { isServerHealthy, waitForServerHealthy } = await import(
+  "./page-helpers"
+);
+
+let serverStopped = false;
+afterAll(() => {
+  if (!serverStopped) server.stop(true);
+});
+
+describe("isServerHealthy", () => {
+  test("healthy when /api/health answers 200 with status ok", async () => {
+    mode = "ok";
+    expect(await isServerHealthy()).toBe(true);
+  });
+
+  test("unhealthy when /api/health is missing even though / serves 200", async () => {
+    mode = "no-health-route";
+    expect(await isServerHealthy()).toBe(false);
+  });
+
+  test("unhealthy when /api/health reports a non-ok status body", async () => {
+    mode = "degraded";
+    expect(await isServerHealthy()).toBe(false);
+  });
+
+  test("unhealthy when /api/health answers 5xx", async () => {
+    mode = "server-error";
+    expect(await isServerHealthy()).toBe(false);
+  });
+});
+
+describe("waitForServerHealthy", () => {
+  test("resolves true once the readiness endpoint is healthy", async () => {
+    mode = "ok";
+    expect(await waitForServerHealthy(2, 10)).toBe(true);
+  });
+
+  test("resolves false when the readiness endpoint never turns healthy", async () => {
+    mode = "no-health-route";
+    expect(await waitForServerHealthy(2, 10)).toBe(false);
+  });
+
+  test("resolves false when nothing is listening", async () => {
+    server.stop(true);
+    serverStopped = true;
+    expect(await waitForServerHealthy(2, 10)).toBe(false);
+  });
+});

--- a/packages/feed/tools/e2e-gate.mjs
+++ b/packages/feed/tools/e2e-gate.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Gate runner for the Feed browser e2e lanes (tools/e2e, tools/chroma).
+ *
+ * The old inline `sh -c ... exit 0` gate made a skipped lane
+ * indistinguishable from a green run. This runner makes skipping VISIBLE:
+ *
+ * - RUN_FEED_E2E=1  → run the wrapped Playwright command, propagate its exit.
+ * - otherwise       → print a loud skip banner + a machine-readable
+ *                     `FEED_E2E_RESULT=skipped` line, and exit 0 locally but
+ *                     exit 3 (distinct "skipped-but-required" code) when CI
+ *                     or FEED_E2E_STRICT=1 is set, so CI can never read a
+ *                     skipped lane as a pass.
+ */
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const sep = args.indexOf("--");
+if (sep === -1 || sep === args.length - 1) {
+  console.error(
+    "usage: e2e-gate.mjs --suite <name> [--requires <text>] -- <command...>",
+  );
+  process.exit(2);
+}
+const opts = args.slice(0, sep);
+const command = args.slice(sep + 1);
+
+function opt(name) {
+  const i = opts.indexOf(name);
+  return i === -1 ? "" : (opts[i + 1] ?? "");
+}
+const suite = opt("--suite") || "feed-e2e";
+const requires = opt("--requires");
+
+if (process.env.RUN_FEED_E2E === "1") {
+  const result = spawnSync(command[0], command.slice(1), { stdio: "inherit" });
+  process.exit(result.status ?? 1);
+}
+
+const strict =
+  process.env.FEED_E2E_STRICT === "1" ||
+  process.env.CI === "true" ||
+  process.env.CI === "1";
+const exitCode = strict ? 3 : 0;
+
+const banner = [
+  "=".repeat(72),
+  `[feed-e2e] SKIPPED (not a pass): ${suite}`,
+  "[feed-e2e] This browser e2e lane did NOT run.",
+  requires ? `[feed-e2e] Requires: ${requires}` : "",
+  "[feed-e2e] Run it with: RUN_FEED_E2E=1 bun run test",
+  `FEED_E2E_RESULT=skipped suite=${suite} strict=${strict ? "1" : "0"} exit=${exitCode}`,
+  "=".repeat(72),
+].filter(Boolean);
+console.error(banner.join("\n"));
+
+if (process.env.GITHUB_ACTIONS === "true") {
+  console.log(
+    `::warning title=${suite} skipped::RUN_FEED_E2E!=1 — browser e2e lane did not run (exit ${exitCode})`,
+  );
+}
+process.exit(exitCode);

--- a/packages/feed/tools/e2e/tests/helpers/page-helpers.health.test.ts
+++ b/packages/feed/tools/e2e/tests/helpers/page-helpers.health.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Health-probe semantics for the browser e2e helpers (bun test).
+ *
+ * Regression guard for the "<500 means healthy" bug: the old probe hit `/`
+ * and accepted ANY non-5xx response, so a 404-ing, half-booted, or entirely
+ * wrong server counted as healthy and the suite ran against garbage.
+ * Healthy means `/api/health` answers 2xx with `{ status: "ok" }`.
+ *
+ * Run: bun run test:unit (from tools/e2e)
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+
+type Mode = "ok" | "degraded" | "no-health-route" | "server-error";
+let mode: Mode = "ok";
+
+const server = Bun.serve({
+  port: 0,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/health") {
+      if (mode === "ok") {
+        return Response.json({
+          status: "ok",
+          timestamp: new Date().toISOString(),
+          env: "test",
+        });
+      }
+      if (mode === "degraded") return Response.json({ status: "degraded" });
+      if (mode === "server-error")
+        return new Response("boom", { status: 500 });
+      return new Response("Not Found", { status: 404 });
+    }
+    // Root answers 200 like any half-booted or wrong frontend would.
+    return new Response("<html>not the feed app</html>", {
+      headers: { "Content-Type": "text/html" },
+    });
+  },
+});
+
+// BASE_URL is captured at module load, so set the env before importing.
+process.env.PLAYWRIGHT_BASE_URL = `http://127.0.0.1:${server.port}`;
+const { isServerHealthy, waitForServerHealthy } = await import(
+  "./page-helpers"
+);
+
+let serverStopped = false;
+afterAll(() => {
+  if (!serverStopped) server.stop(true);
+});
+
+describe("isServerHealthy", () => {
+  test("healthy when /api/health answers 200 with status ok", async () => {
+    mode = "ok";
+    expect(await isServerHealthy()).toBe(true);
+  });
+
+  test("unhealthy when /api/health is missing even though / serves 200", async () => {
+    mode = "no-health-route";
+    expect(await isServerHealthy()).toBe(false);
+  });
+
+  test("unhealthy when /api/health reports a non-ok status body", async () => {
+    mode = "degraded";
+    expect(await isServerHealthy()).toBe(false);
+  });
+
+  test("unhealthy when /api/health answers 5xx", async () => {
+    mode = "server-error";
+    expect(await isServerHealthy()).toBe(false);
+  });
+});
+
+describe("waitForServerHealthy", () => {
+  test("resolves true once the readiness endpoint is healthy", async () => {
+    mode = "ok";
+    expect(await waitForServerHealthy(2, 10)).toBe(true);
+  });
+
+  test("resolves false when the readiness endpoint never turns healthy", async () => {
+    mode = "no-health-route";
+    expect(await waitForServerHealthy(2, 10)).toBe(false);
+  });
+
+  test("resolves false when nothing is listening", async () => {
+    server.stop(true);
+    serverStopped = true;
+    expect(await waitForServerHealthy(2, 10)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Restores the 7 `packages/feed` + `packages/benchmarks` files clobbered by the #11271 stale-base mega-revert, per the blob-level audit on #11419. All 7 restored byte-identical from the pre-clobber parent `dc1a63b103` (= `5b714c74e6^`), then verified against the current `develop` tip. One post-restore fix from codex review (see below).

## Per-file breakdown

### 🔴 Live functional breakage on develop

**1. `packages/benchmarks/orchestrator_lifecycle/events.py`**
- `runner.py:228` calls `extract_lifecycle_events(actions, params)` from `.events` (import at `runner.py:37`). The module was deleted, so the bench dies at import time.
- Verified: `python3 -c "from benchmarks.orchestrator_lifecycle import runner"` → OK after restore (ImportError before).

**2. `packages/feed/tools/e2e-gate.mjs`**
- Both `packages/feed/tools/chroma/package.json` and `packages/feed/tools/e2e/package.json` invoke `node ../e2e-gate.mjs --suite ... -- <playwright cmd>` in their `test` scripts. The gate script was deleted, so both lanes die at spawn — and the whole point of this script was making skipped lanes VISIBLE (`FEED_E2E_RESULT=skipped`, exit 3 under CI/strict) instead of silently exiting 0.
- Verified: `node --check` clean; CLI args in both package.json scripts match the gate's `--suite/--requires/--` interface.

**3. `packages/feed/tools/chroma/specs/helpers/page-helpers.health.test.ts`**
**4. `packages/feed/tools/e2e/tests/helpers/page-helpers.health.test.ts`**
- Referenced by each package's `test:unit` script (`bun test <path>`); scripts pointed at deleted files.

### 🟡 Orphaned test coverage

**5. `packages/benchmarks/orchestrator_lifecycle/tests/test_events.py`** — tests for the extractor above (action-name mapping, pattern-C `TASKS` operation params, trajectory-snapshot leak guard, prose-produces-no-events).
**6. `packages/benchmarks/interrupt-bench/tests/honest-scoring.test.ts`** — the #9310 §3.11 honest-scoring guard.
**7. `packages/benchmarks/three-agent-dialogue/__tests__/verification.test.ts`** — `computeVerification`/`detectEmotionFromText` coverage; imports still resolve against current `runner/verification.ts` exports.

## Post-restore fix (codex review finding)

Codex review (gpt-5.5) flagged a real gap in the restored extractor: the runtime's actual `TASKS` control op carries the child operation in **`controlAction`** (`action=control, controlAction=pause|resume|stop|continue|reopen`, per `packages/core/src/generated/action-docs.ts`), which wasn't in `_OPERATION_KEYS` — so genuine pause/resume turns would score as missing behavior. Added `controlaction` to the key set (keys now matched case-insensitively) + 2 regression tests. Second commit, kept separate from the byte-identical restore.

## Verification

- `python3 -m pytest packages/benchmarks/orchestrator_lifecycle/tests/ -q` → **26 passed** (incl. 5+2 in test_events.py)
- `bun test specs/helpers/page-helpers.health.test.ts` (chroma) → **7 pass, 0 fail**
- `bun test tests/helpers/page-helpers.health.test.ts` (e2e) → **7 pass, 0 fail**
- `bun x vitest run tests/honest-scoring.test.ts` (interrupt-bench) → **4 passed**
- `bun x vitest run __tests__/verification.test.ts` (three-agent-dialogue) → **5 passed**
- `node --check packages/feed/tools/e2e-gate.mjs` → clean
- `bun x biome check` on the 5 touched TS/MJS files → clean, no fixes

Closes the feed + benchmarks rows of the #11419 audit. Does not touch any other rows.

— [sol-orch]
