### PR TITLE
chore(registry): bump plugin-raven-verify to 0.2.0

### DIFF
--- a/packages/registry/entries/third-party/plugin-raven-verify.json
+++ b/packages/registry/entries/third-party/plugin-raven-verify.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "Pre-action Solana token verification via Raven — signed, scope-bounded on-chain evidence receipts (checks performed, checks NOT performed, coverage gaps, ed25519 signature). Reports evidence, not a safe/unsafe verdict.",
   "homepage": "https://ravenattest.com",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tags": [
     "solana",
     "token",


### PR DESCRIPTION
One-line version bump for the third-party registry entry merged in #9614, reflecting a substantive release.

**What changed in 0.2.0** ([release PR](https://github.com/billybotticelli4u-collab/plugin-raven-verify/pull/1)):

- The plugin now **verifies receipts locally, in-code**, before reporting — ed25519 signature over the domain-separated envelope, payload hash, receiptId, byte-exact disclaimer — with key trust and freshness reported independently. Previously it reported signature material and left verification to the reader; this closes that gap in the direction the entry's description promises.
- Switched to `/receipt/v1` (receipt-v1, the canonical primitive); the receipt carries the resolved token program as a signed field, so the `SOLANA_RPC_URL` requirement is gone.
- Ships an **offline golden-vector conformance suite** (including a real production-signed receipt) — `npm test` on a clean clone re-verifies everything with no network and no key. CI + branch protection now enforce it on the plugin repo.

No changes to the entry's keys or scoping — description and shape are exactly as reviewed in #9614 ("reports evidence, not a safe/unsafe verdict"); only `version` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)