### PR TITLE
fix(core): don't promote a sub-agent completion relay to tooling (false 'hit a snag')

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { parseActionParams } from "../actions";
-import type { Action, ActionResult, IAgentRuntime } from "../index";
+import type { Action, ActionResult, IAgentRuntime, Memory } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
 	applyDirectCurrentCandidateBackstopToMessageHandler,
+	BUILTIN_RESPONSE_HANDLER_EVALUATORS,
 	extractPlannerActionNames,
 	findWebLookupActionName,
 	findWebLookupActionNames,
@@ -21,6 +22,71 @@ const logger = {
 	warn: vi.fn(),
 	error: vi.fn(),
 };
+
+describe("sub-agent completion relay — never promoted to tooling (false 'hit a snag')", () => {
+	// Live regression: a coding sub-agent's completion relay echoes the original
+	// task text ("[sub-agent: Build and deploy a simple dice roller web app] …
+	// live at <url>"). The core.simple_registered_action_request promotion ran
+	// inferDirectCurrentRequest on that text, read it as fresh coding work, and
+	// promoted the turn to requiresTool — forcing a TASKS tool the relay can't
+	// satisfy → required_tool_misses exhaustion → a SUCCESSFUL build reported a
+	// false "hit a snag" instead of relaying the live URL. The relay is owned by
+	// the sub-agent-completion evaluator and must only deliver the result.
+	const gate = BUILTIN_RESPONSE_HANDLER_EVALUATORS.find(
+		(evaluator) => evaluator.name === "core.simple_registered_action_request",
+	);
+	const actions = [
+		{ name: "REPLY" },
+		{
+			name: "TASKS",
+			tags: ["domain:coding", "resource:agent-task", "capability:delegate"],
+		},
+	] as unknown as Action[];
+	const contextFor = (message: Memory) =>
+		({
+			message,
+			messageHandler: {
+				processMessage: "RESPOND",
+				plan: { requiresTool: false, contexts: [] },
+			},
+			runtime: { actions },
+		}) as never;
+	const relayText =
+		"[sub-agent: Build and deploy a simple dice roller web app] Done — it's live at https://example.test/apps/dice-roller/";
+
+	it("does not promote a successful completion relay (metadata.subAgent)", () => {
+		expect(gate).toBeDefined();
+		const relay = {
+			content: {
+				text: relayText,
+				source: "sub_agent",
+				metadata: { subAgent: true },
+			},
+		} as unknown as Memory;
+		expect(gate?.shouldRun(contextFor(relay))).toBe(false);
+	});
+
+	it("does not promote a relay identified only by source or text prefix", () => {
+		const bySource = {
+			content: { text: relayText, source: "acpx:sub-agent-router" },
+		} as unknown as Memory;
+		expect(gate?.shouldRun(contextFor(bySource))).toBe(false);
+		const byPrefix = {
+			content: { text: relayText, source: "discord" },
+		} as unknown as Memory;
+		expect(gate?.shouldRun(contextFor(byPrefix))).toBe(false);
+	});
+
+	it("still promotes a genuine fresh coding request to tooling", () => {
+		const fresh = {
+			content: {
+				text: "Build and deploy a simple dice roller web app",
+				source: "discord",
+			},
+		} as unknown as Memory;
+		expect(gate?.shouldRun(contextFor(fresh))).toBe(true);
+	});
+});
 
 describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () => {
 	// Live regression: the Stage-1 model sometimes answers in plain prose instead

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3007,6 +3007,14 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 			shouldRun: ({ message, messageHandler, runtime }) => {
 				if (messageHandler.processMessage !== "RESPOND") return false;
 				if (messageHandler.plan.requiresTool === true) return false;
+				// A sub-agent completion relay is owned by the sub-agent-completion
+				// evaluator — its only job is to deliver the finished result. Its text
+				// echoes the original task ("[sub-agent: Build and deploy a dice
+				// roller…]"), which the action-inference below reads as fresh coding
+				// work and promotes to requiresTool — forcing a TASKS tool the relay
+				// can't satisfy → required_tool_misses exhaustion → a SUCCESSFUL build
+				// reports a false "hit a snag". Never promote a relay turn to tooling.
+				if (isSubAgentCompletionArtifact(message)) return false;
 				const nonSimpleContexts = (messageHandler.plan.contexts ?? []).filter(
 					(context) => context !== SIMPLE_CONTEXT_ID,
 				);


### PR DESCRIPTION
# fix(core): don't promote a sub-agent completion relay to tooling (false 'hit a snag')

## What happened (observed live)

A coding sub-agent finished a build successfully (dice-roller deployed, URL serving 200), but the user received a **failure message** ("Hit a snag") instead of the live URL.

## Root cause

A sub-agent completion relay echoes the original task text:

```
[sub-agent: Build and deploy a simple dice roller web app] Done — it's live at https://…
```

The `core.simple_registered_action_request` response-handler evaluator (`packages/core/src/services/message.ts`) runs `inferDirectCurrentRequestCandidateActions` on that text, reads "Build and deploy … web app" as **fresh coding work**, and promotes the turn to `requiresTool` with a `TASKS` candidate. The relay turn can't satisfy a TASKS tool → `required_tool_misses` exhaustion → the turn falls to the failure path → a **successful** build is reported as a failure.

## Fix (structural, on message metadata)

The relay is owned by the sub-agent-completion evaluator; its only job is to deliver the finished result. The promotion gate now skips sub-agent completion artifacts, reusing the existing `isSubAgentCompletionArtifact` helper (matches `metadata.subAgent === true`, `acpx:sub-agent-router` source, or the `[sub-agent:` text prefix) — the same helper the recent-conversation and prior-dialogue filters already use. No new heuristics, no text regex on the reply.

## Regression test

`packages/core/src/__tests__/message-routing-live-regression.test.ts` — new describe block with 3 cases:

- a successful completion relay (`metadata.subAgent`) is **not** promoted to tooling
- relays identified only by `acpx:sub-agent-router` source or the `[sub-agent:` text prefix are **not** promoted
- a genuine fresh coding request from a user **is still promoted** (promotion path unregressed)

Pre-fix, the two relay cases fail exactly as the live incident predicts (`shouldRun` returns `true`); post-fix all pass.

## Verification

```
bun run --cwd packages/core test -- src/__tests__/message-routing-live-regression.test.ts
  Test Files  1 passed (1)
       Tests  34 passed (34)

message-related suites (7 files): 130 passed (130)

bun run --cwd packages/core typecheck   # clean
```

## Evidence

- Pre-fix failing run (bug proof on current develop): 2 failed / 32 passed — the relay was promoted (`expected true to be false`) while the fresh-request control passed.
- Post-fix: 34/34 in the touched file, 130/130 across all message suites, typecheck clean.
- Live incident: successful dice-roller deploy (HTTP 200 on the app URL) relayed to the user as "Hit a snag".
