### PR TITLE
fix(core): security — hasRoleAccess fails closed on unresolved sender role

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -629,6 +629,32 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("keeps a real answer that merely CONTAINS a repeated-character run", async () => {
+		// The junk check flags a reply that IS a glitch run ("aaaaa"), anchored.
+		// A real answer containing a run — aligned `df -h` columns, a "-----"
+		// divider, an "XXXXXXXX" placeholder — must not be blanked to the
+		// generic deferral.
+		for (const goodReply of [
+			"Filesystem      Size  Used Avail Use%\n/dev/sda1       387G  381G  5.8G  99%",
+			"Results\n--------\nAll checks passed.",
+			"Use the placeholder XXXXXXXX until the key arrives.",
+		]) {
+			const runtime = makeRuntime([
+				stage1Response({ contexts: ["simple"], replyText: goodReply }),
+			]);
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text: "how full is the disk?" }),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000007" as UUID,
+			});
+			expect(result.kind).toBe("direct_reply");
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(goodReply);
+			}
+		}
+	});
+
 	it("uses a compact response-handler schema for direct channels", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -9,6 +9,10 @@ import {
 	makeMessage,
 } from "./test-helpers.ts";
 
+// Fixed sender entity for the `run` helper. Pass it as `owner` to makeFakeRuntime
+// when a test needs the sender treated as admin/owner (admin-only ops).
+const TEST_SENDER = "00000000-0000-4000-8000-0000000000ff" as never;
+
 async function run(
 	fake: ReturnType<typeof makeFakeRuntime>,
 	userText: string,
@@ -21,8 +25,7 @@ async function run(
 		text: userText,
 	});
 	// Use a distinct entity for the message so it's not "from self"
-	const userEntity = "00000000-0000-4000-8000-0000000000ff" as never;
-	message.entityId = userEntity;
+	message.entityId = TEST_SENDER;
 	const { cb, calls } = captureCallback();
 	const opts: HandlerOptions = {
 		parameters: { op, ...extraParams } as never,
@@ -186,7 +189,10 @@ describe("personalityAction — subactions write structured state", () => {
 describe("personalityAction — profiles", () => {
 	let fake: ReturnType<typeof makeFakeRuntime>;
 	beforeEach(async () => {
-		fake = makeFakeRuntime();
+		// load_profile / save_profile are admin-only; make the test sender the
+		// canonical owner so hasRoleAccess grants admin (it now fails CLOSED on an
+		// unresolved role — the old "no world → admin" leniency is gone).
+		fake = makeFakeRuntime({ owner: TEST_SENDER });
 		await initStore(fake);
 	});
 

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
@@ -105,16 +105,16 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 			return null;
 		},
 		// hasRoleAccess uses these
-		getSetting: () => undefined,
+		// hasRoleAccess reads the canonical-owner config here: when `owner` is set
+		// it is exposed as ELIZA_ADMIN_ENTITY_ID so a message from that entity
+		// resolves to OWNER (>= ADMIN). Correct way to grant admin now that
+		// hasRoleAccess fails CLOSED on an unresolved role (no longer treats
+		// "no world context" as admin).
+		getSetting: (key: string) =>
+			key === "ELIZA_ADMIN_ENTITY_ID" && owner ? owner : undefined,
 		_test_owner: owner,
 		_test_admins: admins,
 	} as unknown as IAgentRuntime;
-
-	// Make hasRoleAccess succeed by registering the entity as owner/admin via
-	// world state — but for unit tests we'd rather bypass entirely. The real
-	// hasRoleAccess returns true when there's no world context. Our stub has
-	// no world context so it returns true (lenient default) — which is what we
-	// want for happy-path tests. For admin-deny tests we'll override.
 
 	const store = new PersonalityStore(runtime);
 	// initialize() loads profiles; do it synchronously-ish via a hack

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -3,6 +3,7 @@ import {
 	CANONICAL_ROLE_RANK,
 	canModifyRole,
 	getEntityRole,
+	hasRoleAccess,
 	isAgentSelf,
 	matchEntityToConnectorAdminWhitelist,
 	normalizeRole,
@@ -72,6 +73,66 @@ describe("isAgentSelf", () => {
 		expect(isAgentSelf(undefined, { entityId: "agent-1" } as Memory)).toBe(
 			false,
 		);
+	});
+});
+
+describe("hasRoleAccess — fail-closed on unresolved role", () => {
+	// A message with a real entity/room but no resolvable world (deleted or
+	// inaccessible world, or a source that yields no world id) makes
+	// checkSenderRole return null. That path used to `return true` (fail-OPEN) —
+	// a guest whose world resolution failed cleared the OWNER gate and reached
+	// owner-gated capabilities (e.g. SHELL). It must fail closed to USER rank
+	// (matching the pre-handler default), denying ADMIN/OWNER while still
+	// allowing basic USER actions.
+	const makeRuntime = (settings: Record<string, string> = {}) =>
+		({
+			agentId: "agent-1",
+			getRoom: async () => null,
+			getWorld: async () => null,
+			getEntityById: async () => null,
+			getComponents: async () => [],
+			getMemories: async () => [],
+			getRelationships: async () => [],
+			getSetting: (key: string) => settings[key],
+			character: {},
+		}) as unknown as IAgentRuntime;
+	const guestMessage = {
+		entityId: "guest-entity-1",
+		roomId: "room-1",
+		content: { text: "run df -h on the server", source: "test" },
+	} as unknown as Memory;
+
+	it("denies OWNER and ADMIN when the sender role cannot be resolved", async () => {
+		const runtime = makeRuntime();
+		expect(await hasRoleAccess(runtime, guestMessage, "OWNER")).toBe(false);
+		expect(await hasRoleAccess(runtime, guestMessage, "ADMIN")).toBe(false);
+	});
+
+	it("still allows USER (matches the pre-handler ['USER'] default) and GUEST", async () => {
+		const runtime = makeRuntime();
+		expect(await hasRoleAccess(runtime, guestMessage, "USER")).toBe(true);
+		expect(await hasRoleAccess(runtime, guestMessage, "GUEST")).toBe(true);
+	});
+
+	it("still allows the canonical owner through the OWNER gate", async () => {
+		const runtime = makeRuntime({ ELIZA_ADMIN_ENTITY_ID: "owner-entity-1" });
+		const ownerMessage = {
+			entityId: "owner-entity-1",
+			roomId: "room-1",
+			content: { text: "run df -h on the server", source: "test" },
+		} as unknown as Memory;
+		expect(await hasRoleAccess(runtime, ownerMessage, "OWNER")).toBe(true);
+		expect(await hasRoleAccess(runtime, ownerMessage, "ADMIN")).toBe(true);
+	});
+
+	it("still allows the agent itself", async () => {
+		const runtime = makeRuntime();
+		const selfMessage = {
+			entityId: "agent-1",
+			roomId: "room-1",
+			content: { text: "internal", source: "test" },
+		} as unknown as Memory;
+		expect(await hasRoleAccess(runtime, selfMessage, "OWNER")).toBe(true);
 	});
 });
 

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -911,8 +911,10 @@ async function isCanonicalOwner(
  * Check whether the sender has at least the given role in the elizaOS
  * role hierarchy (OWNER > ADMIN > USER > GUEST).
  *
- * When there is no world context (for example local API calls), allow through
- * so local-only usage follows the same lenient path as plugin role gating.
+ * When there is no access context at all (no runtime / no sender entity — for
+ * example local API calls), allow through so local-only usage follows the same
+ * lenient path as plugin role gating. But when there IS a real sender whose
+ * role simply cannot be resolved, fail CLOSED to USER rank — see below.
  */
 export async function hasRoleAccess(
 	runtime: IAgentRuntime | undefined,
@@ -939,7 +941,16 @@ export async function hasRoleAccess(
 	try {
 		const result = await checkSenderRole(context.runtime, context.message);
 		if (!result) {
-			return true;
+			// Fail CLOSED. When the sender's role cannot be resolved (missing or
+			// inaccessible world, no world id on the message), treat them as USER —
+			// the same default the pre-handler tool-call gate uses. Returning `true`
+			// here was fail-OPEN: a real sender whose world resolution failed
+			// cleared an OWNER gate and reached owner-gated capabilities (e.g.
+			// SHELL). Defaulting to USER denies privileged (ADMIN/OWNER) actions to
+			// an unresolvable sender while still allowing basic USER actions.
+			const senderRank = ROLE_RANK.USER;
+			const requiredRank = ROLE_RANK[requiredRole] ?? 0;
+			return senderRank >= requiredRank;
 		}
 
 		const senderRank = ROLE_RANK[result.role] ?? 0;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3065,7 +3065,13 @@ function isUnusableStage1Reply(reply: string | undefined): boolean {
 	if (/^```[a-z0-9_-]*\s+/iu.test(trimmed)) return false;
 	if (/^[\s{}[\]":,]+$/.test(trimmed)) return true;
 	if (/^\d+$/.test(trimmed)) return true;
-	if (/(.)\1{4,}/u.test(trimmed)) return true;
+	// A reply that is ENTIRELY 5+ of the same glyph = a model-glitch reply
+	// ("aaaaaa", "......"). ANCHORED (like the siblings above): the run must be
+	// the whole reply, not merely present inside it — a real answer that happens
+	// to contain a run (a "XXXXXXXX" placeholder, a "--------" divider, aligned
+	// `df -h` columns) is legitimate and must not be blanked to "I'm not sure how
+	// to answer that." `\S` also keeps a pure-whitespace string from matching.
+	if (/^(\S)\1{4,}$/u.test(trimmed)) return true;
 	if (/^[A-Z]{2,8}$/.test(trimmed)) {
 		const allowed = new Set(["OK", "YES", "NO", "STOP"]);
 		return !allowed.has(trimmed);
@@ -4923,7 +4929,13 @@ function plannerErrorLooksTransient(error: unknown): boolean {
 		error instanceof Error
 			? `${error.name} ${error.message} ${String(error.cause ?? "")}`
 			: String(error ?? "");
-	return /\b(?:429|rate[\s_-]*limit|too many requests|temporarily unavailable|overloaded|timeout|timed out|econnreset|etimedout|50[234]|failed after \d+ attempts)\b/i.test(
+	// The trailing three ("empty completion", "model emitted no decision", "no
+	// assistant message") are the CLI/SDK brains' "provider returned nothing
+	// usable" errors. They are recoverable per-turn hiccups (a cold-start blip,
+	// one bad SDK turn), so treat them as transient → a deterministic fallback
+	// tool call, instead of re-throwing and crashing the whole turn with a raw
+	// exception the user sees.
+	return /\b(?:429|rate[\s_-]*limit|too many requests|temporarily unavailable|overloaded|timeout|timed out|econnreset|etimedout|50[234]|failed after \d+ attempts|empty completion|model emitted no decision|no assistant message)\b/i.test(
 		message,
 	);
 }


### PR DESCRIPTION
## Summary

Security hardening from live-branch triage: `hasRoleAccess` failed **OPEN** — a sender whose role could not be resolved (`checkSenderRole` → `null`: missing/inaccessible world, or no world id on the message) cleared the `OWNER` gate and reached owner-gated capabilities (e.g. SHELL, documents admin ops, personality persist).

Fixes #11501.

## The hole (proven on develop first)

The regression test was written and run against unmodified develop before the fix:

```
FAIL src/roles.test.ts > hasRoleAccess — fail-closed on unresolved role
  > denies OWNER and ADMIN when the sender role cannot be resolved
AssertionError: expected true to be false
```

## The fix

`hasRoleAccess` now fails **CLOSED** to USER rank when the sender's role is unresolvable — the exact default the pre-handler tool-call gate already uses (`resolveToolCallUserRoles` → `USER` on lookup failure in `runtime/execute-planned-tool-call.ts`), so the two gates are now consistent:

- unresolvable sender: **denied** ADMIN/OWNER, still allowed USER/GUEST
- canonical owner (`ELIZA_ADMIN_ENTITY_ID`): still passes OWNER (new test)
- agent-self: still passes (new test)
- no access context at all (no runtime / no sender entity — local API path): unchanged lenient behavior, now documented precisely

The personality profile tests relied on the old fail-open leniency for their admin-only ops (their own comment said so); they now grant real admin via the canonical-owner path instead of the accidental fail-open — the gate was not weakened for them.

## Bundled from the same audit tranche (both coherent one-liners in `services/message.ts`)

- `isUnusableStage1Reply` repeated-char junk check **anchored** (`^(\S)\1{4,}$`): it was un-anchored, so a real answer merely *containing* a run — aligned `df -h` columns, a `--------` divider, an `XXXXXXXX` placeholder — was blanked to "I'm not sure how to answer that." (answer-drop observed live). New stage-1 test covers keep-the-real-answer.
- `plannerErrorLooksTransient` treats the CLI/SDK "empty completion" / "model emitted no decision" / "no assistant message" errors as transient so the turn takes a deterministic fallback instead of crashing with a raw exception.

Not ported (entangled with live-branch-only code, noted for completeness): live-info request heuristics (`looksLikeLiveInfoRequest` does not exist on develop) and the character.system clobber guard.

## Verification

- `bunx vitest run src/roles.test.ts` — 20/20 (4 new: null-role denied OWNER+ADMIN, USER/GUEST still allowed, canonical owner still passes, agent-self still passes)
- `bunx vitest run src/features/advanced-capabilities/personality src/roles.test.ts src/__tests__/message-runtime-stage1.test.ts` — 148/148
- `bunx vitest run src/features/documents src/features/plugin-manager` (other `hasRoleAccess` consumers) — 70/70
- `bunx vitest run src/__tests__` (full message-loop/planner/routing suites) — 300/300 across 40 files
- `bun run --cwd packages/core typecheck` — clean

Origin: adversarial audit of the live deployment; the fix has been running live there since 2026-07-01.
