### PR TITLE
fix(plugin-cli-inference): declare @openai/codex-sdk so the codex-sdk route survives clean installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3165,6 +3165,9 @@
         "typescript": "^6.0.3",
         "vitest": "^4.0.0",
       },
+      "optionalDependencies": {
+        "@openai/codex-sdk": "0.80.0",
+      },
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
@@ -7638,6 +7641,8 @@
     "@openai/codex-linux-arm64": ["@openai/codex@0.133.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-uKXYYSJ3mY16sp4hcG/4BMNRjva/ZS4oARiI1+7k8+NiuoAhdCGWNe5u4KJ3sMuL3tp/IXcmc6B56EFX1+WDBQ=="],
 
     "@openai/codex-linux-x64": ["@openai/codex@0.133.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-9YfyqrfUj/UZ2+aXE4zBz47t6RXbVni95ZorGsNh857vxYK/asVpUtR2cymo9lB3JaI4mQaKFfV/t7IRItqkuA=="],
+
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.80.0", "", {}, "sha512-4+/bZOSjJAPsuM6yceQoVbNUK7UTS03QMKxCrFClObxD1j6n5oh7OSJniyff2MmF0DI7yHnf9omzfFL7RoLWnQ=="],
 
     "@openai/codex-win32-arm64": ["@openai/codex@0.133.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-mRzND0PSGHRoLk0X41GTSoc3tFjZSF4HgDlfjU5fiQcWVi0/kLb7Ku6/tPFT/X2hOLa3YdJkbIcHC0Hc9ni80g=="],
 

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -42,6 +42,9 @@
       ]
     }
   },
+  "optionalDependencies": {
+    "@openai/codex-sdk": "0.80.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@elizaos/core": "workspace:*",


### PR DESCRIPTION
## Problem

`plugins/plugin-cli-inference/src/codex-sdk-session.ts` lazy-imports `@openai/codex-sdk` for the `ELIZA_CHAT_VIA_CLI=codex-sdk` warm-thread brain route:

```ts
const SDK_PACKAGE = "@openai/codex-sdk";
async function loadCodex(): Promise<CodexModule> {
  const codex: unknown = await import(SDK_PACKAGE);
  ...
```

No package.json in the repo declared it and it was absent from `bun.lock`, so on a clean install the route dies at first use:

```
$ node -e 'import("@openai/codex-sdk")'   # from plugins/plugin-cli-inference on develop
FAILS: ERR_MODULE_NOT_FOUND Cannot find package '@openai/codex-sdk'
```

The route only ever worked on machines where the package happened to be present for other reasons.

## Fix

Declare `@openai/codex-sdk@0.80.0` as an **optionalDependency** of `@elizaos/plugin-cli-inference` (the package that imports it):

- optional matches the guarded, route-gated lazy import — the plugin is inert unless `ELIZA_CHAT_VIA_CLI=codex-sdk`, and an install failure of the SDK on an exotic platform shouldn't hard-fail the whole workspace install; it is still installed by default so the route works out of the box.
- pinned `0.80.0` — the version the route was live-verified with; the plugin docs already reference the SDK's bundled codex 0.80.0 and compensate for its staleness via `ELIZA_CLI_CODEX_BIN` (`codexPathOverride`).
- declaring it also lands it in `externalsFromPackageJson`, so the plugin build treats it as a proper external.

Lockfile delta is minimal: the workspace entry + the one resolved-package line.

## Evidence

- Repro on unfixed develop (worktree at `219137d10a`): `import("@openai/codex-sdk")` from the plugin dir → `ERR_MODULE_NOT_FOUND Cannot find package '@openai/codex-sdk'`.
- After fix: `bun install` resolves and installs `@openai/codex-sdk@0.80.0` at `plugins/plugin-cli-inference/node_modules/@openai/codex-sdk`; dynamic import from the plugin resolves to the locked install and the `isCodexModule` shape guard passes (`typeof Codex === "function"`).
- `bun install --frozen-lockfile` → `Checked 4859 installs across 5102 packages (no changes)`.
- `bun run --cwd plugins/plugin-cli-inference test` → 6 files, **91/91 passed** (includes the 12 fake-SDK `codex-sdk-session` tests).
- `bun run --cwd plugins/plugin-cli-inference typecheck` → clean.
- `bun run --cwd plugins/plugin-cli-inference build` → dist keeps the variable dynamic import (`await import(SDK_PACKAGE)`), resolved at runtime from the now-declared dep.
- N/A — live-LLM trajectory: dependency declaration only, no code/prompt/model behavior change; the codex-sdk route itself is already live-verified on a ChatGPT/Codex sub (see plugin CLAUDE.md "Status").

Note: `@anthropic-ai/claude-agent-sdk` (the `claude-sdk` peer route in the same plugin) has the same missing-declaration issue; left out of scope here to keep this atomic.
