### PR TITLE
fix(mobile): stage flat bionic bundle in the mobile-device-bridge path too (#11335)

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.mtp.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.mtp.test.ts
@@ -1,9 +1,16 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	statSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	buildGemmaBionicPrompt,
 	buildLoadArgsFromRegistryModel,
+	deriveBionicBundleDir,
 } from "./mobile-device-bridge-bootstrap";
 
 function withTempBundle<T>(fn: (root: string) => T): T {
@@ -131,5 +138,51 @@ describe("buildGemmaBionicPrompt", () => {
 				prompt: "<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\n",
 			} as never),
 		).toBe("<start_of_turn>user\nhello<end_of_turn>\n<start_of_turn>model\n");
+	});
+});
+
+describe("deriveBionicBundleDir — flat-model bundle staging (#11335)", () => {
+	it("returns the bundle root for a canonical text/ layout", () => {
+		withTempBundle((root) => {
+			const textDir = path.join(root, "text");
+			mkdirSync(textDir, { recursive: true });
+			const model = path.join(textDir, "eliza-1-2b-128k.gguf");
+			writeFileSync(model, "gguf");
+			expect(deriveBionicBundleDir(model)).toBe(root);
+		});
+	});
+
+	it("stages a hardlinked text/ view for a flat models/ model (the WebView chat path)", () => {
+		withTempBundle((models) => {
+			const model = path.join(models, "eliza-1-2b-128k.gguf");
+			writeFileSync(model, "gguf-bytes");
+			mkdirSync(path.join(models, "asr"), { recursive: true }); // sibling voice dir
+
+			const bundle = deriveBionicBundleDir(model);
+			// Bundle root is under .bionic-bundles/<name>/ (matches BionicHostLoader).
+			expect(bundle).toBe(
+				path.join(models, ".bionic-bundles", "eliza-1-2b-128k"),
+			);
+			// The host globs <bundle>/text/*.gguf — the alias must exist and be
+			// the same file (hardlink → same inode; falls back to a symlink).
+			const view = path.join(bundle, "text", "eliza-1-2b-128k.gguf");
+			expect(existsSync(view)).toBe(true);
+			expect(statSync(view).ino).toBe(statSync(model).ino);
+		});
+	});
+
+	it("is idempotent and returns empty for a non-eliza-1 or missing model", () => {
+		withTempBundle((models) => {
+			const model = path.join(models, "eliza-1-4b-128k.gguf");
+			writeFileSync(model, "x");
+			const first = deriveBionicBundleDir(model);
+			expect(deriveBionicBundleDir(model)).toBe(first); // no EEXIST throw
+			// Non-eliza-1 flat names and missing paths fall back to host default.
+			writeFileSync(path.join(models, "random.gguf"), "x");
+			expect(deriveBionicBundleDir(path.join(models, "random.gguf"))).toBe("");
+			expect(
+				deriveBionicBundleDir(path.join(models, "eliza-1-none.gguf")),
+			).toBe("");
+		});
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -13,11 +13,13 @@ import { randomUUID } from "node:crypto";
 import {
 	createWriteStream,
 	existsSync,
+	linkSync,
 	mkdirSync,
 	readdirSync,
 	readFileSync,
 	renameSync,
 	statSync,
+	symlinkSync,
 	unlinkSync,
 } from "node:fs";
 import type { Server as HttpServer, IncomingMessage } from "node:http";
@@ -1223,11 +1225,55 @@ function bionicSocketName(): string | null {
 	return sock ? sock : null;
 }
 
+// A flat on-device model (…/models/eliza-1-2b-128k.gguf) is not the bundle
+// layout `libelizainference`'s eliza_pick_text_file() globs (<bundle>/text/
+// *.gguf), so a delegated generate fails with "bundle_dir does not exist". We
+// stage a hardlinked text/ view under `.bionic-bundles/<name>/` — matching the
+// BionicHostLoader path (bionic-host-loader.ts, #11335) so both delegated
+// entrypoints resolve the same bundle. This path (mobile-device-bridge) is the
+// one the WebView chat "(via bionic-host)" delegation actually uses.
+const FLAT_ELIZA_1_GGUF_RE = /^eliza-1-[a-z0-9_.-]+\.gguf$/i;
+const BIONIC_FLAT_BUNDLE_DIR = ".bionic-bundles";
+
 /** Bundle root the host's eliza_inference_create expects (…/text/<model>.gguf → …). */
-function deriveBionicBundleDir(modelPath: string): string {
+export function deriveBionicBundleDir(modelPath: string): string {
 	if (!modelPath) return "";
 	const dir = path.dirname(modelPath);
 	if (path.basename(dir) === "text") return path.dirname(dir);
+	if (!FLAT_ELIZA_1_GGUF_RE.test(path.basename(modelPath))) return "";
+	if (!existsSync(modelPath)) return "";
+
+	const modelName = path.basename(modelPath);
+	const bundleRoot = path.join(
+		dir,
+		BIONIC_FLAT_BUNDLE_DIR,
+		path.basename(modelName, path.extname(modelName)),
+	);
+	const textDir = path.join(bundleRoot, "text");
+	const stagedPath = path.join(textDir, modelName);
+	try {
+		mkdirSync(textDir, { recursive: true });
+		if (existsSync(stagedPath)) {
+			try {
+				if (statSync(modelPath).size === statSync(stagedPath).size) {
+					return bundleRoot;
+				}
+			} catch {
+				// Recreate a stale or broken alias below.
+			}
+			unlinkSync(stagedPath);
+		}
+		try {
+			linkSync(modelPath, stagedPath);
+		} catch {
+			symlinkSync(modelPath, stagedPath);
+		}
+		return bundleRoot;
+	} catch (err) {
+		logger.warn(
+			`[mobile-device-bridge] could not stage bionic bundle view for flat model "${modelPath}": ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
 	return "";
 }
 


### PR DESCRIPTION
## What

Completes #11335. The flat-model bundle staging (`58b2b138f3`) fixed **path 1** (`BionicHostLoader.deriveBundleDir` in `bionic-host-loader.ts`), but the WebView chat's `(via bionic-host)` delegation actually runs through **path 2** — `mobile-device-bridge-bootstrap.ts`'s own `deriveBionicBundleDir`, which still returned `""` for a flat `models/<model>.gguf`. So Android local chat kept failing on every turn:

```
[mobile-device-bridge] bionic host generate failed: [elizavoice-jni] eliza_inference_create returned null:
[libelizainference] bundle_dir does not exist: /data/user/0/ai.elizaos.app/files/eliza-1/bundle
```

`libelizainference`'s `eliza_pick_text_file()` globs `<bundle>/text/*.gguf` (`tools/omnivoice/src/eliza-inference-ffi.cpp`), so a flat model has no resolvable bundle and the host falls back to its nonexistent default. This mirrors path 1's fix into path 2 with the **same** `FLAT_ELIZA_1_GGUF_RE` guard + `.bionic-bundles/<name>/` scheme, so both delegated entrypoints resolve the **identical** bundle root (which also carries the sibling `asr/` + `tts/` for the voice route).

## Evidence

- **Device-reproduced** on a Pixel 6a (Mali-G78): with the routing fix (#11323) the handlers register `(via bionic-host)` and the request reaches the host, which then failed with the exact `bundle_dir does not exist` above — because path 2 sent an empty bundleDir. This PR stages `<models>/.bionic-bundles/<name>/text/<model>.gguf`, the layout the host globs.
- **Native contract confirmed** by reading the fused-lib source (`eliza_pick_text_file` → `eliza_find_ggufs(bundle_dir/"text")`).
- **Agent transport confirmed live** on-device (Capacitor `Agent.request` → `/api/health` 200) — the delegation path is reachable; only the bundle resolution was broken.
- **Unit tests** (`mobile-device-bridge-bootstrap.mtp.test.ts`, +3): canonical `text/` layout, flat staging (inode-verified same file), idempotency (no EEXIST), and non-eliza-1/missing fallthrough to host default. 10/10 green; touched file typechecks; biome clean.
- Full end-to-end UI turn capture is blocked by a **separate** app-process-restart instability on this device (the agent respawns every ~1-2 min under memory pressure before a cold GPU turn completes) — filed separately; not a regression from this change.

Refs #11335, #11323 (routing), #58b2b138f3 (path-1 fix this completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)