### PR TITLE
fix(cloud): serve public R2 objects on the blob host — the worker wildcard shadowed them everywhere

### DIFF
--- a/packages/cloud/api/src/blob-host.test.ts
+++ b/packages/cloud/api/src/blob-host.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The blob host (`R2_PUBLIC_HOST`) must serve public R2 objects from the
+ * worker itself: the wildcard `*.elizacloud.ai/*` route shadows any R2 custom
+ * domain, so before this handler every minted public URL (avatars, image
+ * generations, voice samples) 404'd on the JSON router — and OpenAI's
+ * moderation-by-URL failed image generation closed on every env.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { serveBlobHostRequest } from "./blob-host";
+
+function makeEnv(
+  objects: Record<string, { body: string; contentType?: string }>,
+  publicHost?: string,
+) {
+  const bucket = {
+    async get(key: string) {
+      const hit = objects[key];
+      if (!hit) return null;
+      return {
+        size: hit.body.length,
+        httpEtag: `"etag-${key}"`,
+        httpMetadata: { contentType: hit.contentType ?? "image/png" },
+        async text() {
+          return hit.body;
+        },
+      };
+    },
+    async put() {
+      return undefined;
+    },
+    async delete() {
+      return undefined;
+    },
+  };
+  return {
+    BLOB: bucket,
+    ...(publicHost ? { R2_PUBLIC_HOST: publicHost } : {}),
+  };
+}
+
+function req(url: string, method = "GET"): [Request, URL] {
+  return [new Request(url, { method }), new URL(url)];
+}
+
+describe("serveBlobHostRequest", () => {
+  test("serves an existing object with its content-type on the default blob host", async () => {
+    const env = makeEnv({
+      "generations/images/org/user/img.png": { body: "PNGBYTES" },
+    });
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/generations/images/org/user/img.png",
+    );
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-type")).toBe("image/png");
+    expect(res?.headers.get("cache-control")).toContain("public");
+    expect(await res?.text()).toBe("PNGBYTES");
+  });
+
+  test("respects R2_PUBLIC_HOST for the per-env host (staging)", async () => {
+    const env = makeEnv(
+      { "avatars/eliza.png": { body: "AVATAR" } },
+      "blob-staging.elizacloud.ai",
+    );
+
+    const [hitReq, hitUrl] = req(
+      "https://blob-staging.elizacloud.ai/avatars/eliza.png",
+    );
+    const hit = await serveBlobHostRequest(hitReq, hitUrl, env);
+    expect(hit?.status).toBe(200);
+
+    // The default host is NOT served when the env pins a different one —
+    // those requests fall through to normal routing.
+    const [missReq, missUrl] = req(
+      "https://blob.elizacloud.ai/avatars/eliza.png",
+    );
+    expect(await serveBlobHostRequest(missReq, missUrl, env)).toBeNull();
+  });
+
+  test("404s a missing key with the router's JSON error shape", async () => {
+    const env = makeEnv({});
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/generations/nope.png",
+    );
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(404);
+    expect(await res?.json()).toMatchObject({ code: "resource_not_found" });
+  });
+
+  test("HEAD returns headers without a body (falls back to get when head is absent)", async () => {
+    const env = makeEnv({ "a/b.png": { body: "12345" } });
+    const [request, url] = req("https://blob.elizacloud.ai/a/b.png", "HEAD");
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-length")).toBe("5");
+    expect(await res?.text()).toBe("");
+  });
+
+  test("rejects writes", async () => {
+    const env = makeEnv({ "a/b.png": { body: "x" } });
+    const [request, url] = req("https://blob.elizacloud.ai/a/b.png", "PUT");
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(405);
+    expect(res?.headers.get("allow")).toBe("GET, HEAD");
+  });
+
+  test("ignores non-blob hosts entirely", async () => {
+    const env = makeEnv({ "a/b.png": { body: "x" } });
+    const [request, url] = req("https://api.elizacloud.ai/a/b.png");
+
+    expect(await serveBlobHostRequest(request, url, env)).toBeNull();
+  });
+
+  test("decodes URL-encoded keys", async () => {
+    const env = makeEnv({ "media/user/1 - fichier été.png": { body: "OK" } });
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/media/user/1%20-%20fichier%20%C3%A9t%C3%A9.png",
+    );
+
+    const res = await serveBlobHostRequest(request, url, env);
+    expect(res?.status).toBe(200);
+  });
+});

--- a/packages/cloud/api/src/blob-host.test.ts
+++ b/packages/cloud/api/src/blob-host.test.ts
@@ -4,17 +4,25 @@
  * domain, so before this handler every minted public URL (avatars, image
  * generations, voice samples) 404'd on the JSON router — and OpenAI's
  * moderation-by-URL failed image generation closed on every env.
+ *
+ * SECURITY: `env.BLOB` is also the private heavy-payload offload store
+ * (`@/lib/storage/object-namespace`), so the handler serves ONLY keys under
+ * `PUBLIC_BLOB_PREFIXES` — everything else must 404 without touching the
+ * bucket, even when the object exists.
  */
 
 import { describe, expect, test } from "bun:test";
-import { serveBlobHostRequest } from "./blob-host";
+import { ObjectNamespaces } from "@/lib/storage/object-namespace";
+import { PUBLIC_BLOB_PREFIXES, serveBlobHostRequest } from "./blob-host";
 
 function makeEnv(
   objects: Record<string, { body: string; contentType?: string }>,
   publicHost?: string,
 ) {
+  const reads: string[] = [];
   const bucket = {
     async get(key: string) {
+      reads.push(key);
       const hit = objects[key];
       if (!hit) return null;
       return {
@@ -34,8 +42,11 @@ function makeEnv(
     },
   };
   return {
-    BLOB: bucket,
-    ...(publicHost ? { R2_PUBLIC_HOST: publicHost } : {}),
+    env: {
+      BLOB: bucket,
+      ...(publicHost ? { R2_PUBLIC_HOST: publicHost } : {}),
+    },
+    reads,
   };
 }
 
@@ -45,7 +56,7 @@ function req(url: string, method = "GET"): [Request, URL] {
 
 describe("serveBlobHostRequest", () => {
   test("serves an existing object with its content-type on the default blob host", async () => {
-    const env = makeEnv({
+    const { env } = makeEnv({
       "generations/images/org/user/img.png": { body: "PNGBYTES" },
     });
     const [request, url] = req(
@@ -57,11 +68,13 @@ describe("serveBlobHostRequest", () => {
     expect(res?.status).toBe(200);
     expect(res?.headers.get("content-type")).toBe("image/png");
     expect(res?.headers.get("cache-control")).toContain("public");
+    expect(res?.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res?.headers.get("content-disposition")).toBe("inline");
     expect(await res?.text()).toBe("PNGBYTES");
   });
 
   test("respects R2_PUBLIC_HOST for the per-env host (staging)", async () => {
-    const env = makeEnv(
+    const { env } = makeEnv(
       { "avatars/eliza.png": { body: "AVATAR" } },
       "blob-staging.elizacloud.ai",
     );
@@ -81,7 +94,7 @@ describe("serveBlobHostRequest", () => {
   });
 
   test("404s a missing key with the router's JSON error shape", async () => {
-    const env = makeEnv({});
+    const { env } = makeEnv({});
     const [request, url] = req(
       "https://blob.elizacloud.ai/generations/nope.png",
     );
@@ -93,19 +106,26 @@ describe("serveBlobHostRequest", () => {
   });
 
   test("HEAD returns headers without a body (falls back to get when head is absent)", async () => {
-    const env = makeEnv({ "a/b.png": { body: "12345" } });
-    const [request, url] = req("https://blob.elizacloud.ai/a/b.png", "HEAD");
+    const { env } = makeEnv({ "avatars/a/b.png": { body: "12345" } });
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/avatars/a/b.png",
+      "HEAD",
+    );
 
     const res = await serveBlobHostRequest(request, url, env);
 
     expect(res?.status).toBe(200);
     expect(res?.headers.get("content-length")).toBe("5");
+    expect(res?.headers.get("x-content-type-options")).toBe("nosniff");
     expect(await res?.text()).toBe("");
   });
 
   test("rejects writes", async () => {
-    const env = makeEnv({ "a/b.png": { body: "x" } });
-    const [request, url] = req("https://blob.elizacloud.ai/a/b.png", "PUT");
+    const { env } = makeEnv({ "avatars/a/b.png": { body: "x" } });
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/avatars/a/b.png",
+      "PUT",
+    );
 
     const res = await serveBlobHostRequest(request, url, env);
 
@@ -114,19 +134,116 @@ describe("serveBlobHostRequest", () => {
   });
 
   test("ignores non-blob hosts entirely", async () => {
-    const env = makeEnv({ "a/b.png": { body: "x" } });
-    const [request, url] = req("https://api.elizacloud.ai/a/b.png");
+    const { env } = makeEnv({ "avatars/a/b.png": { body: "x" } });
+    const [request, url] = req("https://api.elizacloud.ai/avatars/a/b.png");
 
     expect(await serveBlobHostRequest(request, url, env)).toBeNull();
   });
 
-  test("decodes URL-encoded keys", async () => {
-    const env = makeEnv({ "media/user/1 - fichier été.png": { body: "OK" } });
+  test("decodes URL-encoded keys under a public prefix", async () => {
+    const { env } = makeEnv({
+      "avatars/user/1 - fichier été.png": { body: "OK" },
+    });
     const [request, url] = req(
-      "https://blob.elizacloud.ai/media/user/1%20-%20fichier%20%C3%A9t%C3%A9.png",
+      "https://blob.elizacloud.ai/avatars/user/1%20-%20fichier%20%C3%A9t%C3%A9.png",
     );
 
     const res = await serveBlobHostRequest(request, url, env);
     expect(res?.status).toBe(200);
+  });
+
+  test("404s every private offload namespace even when the object exists — without reading the bucket", async () => {
+    for (const namespace of Object.values(ObjectNamespaces)) {
+      const key = `${namespace}/org-1/2026-07-02/obj-1/body.json`;
+      const { env, reads } = makeEnv({
+        [key]: { body: '{"private":true}', contentType: "application/json" },
+      });
+
+      for (const method of ["GET", "HEAD"]) {
+        const [request, url] = req(`https://blob.elizacloud.ai/${key}`, method);
+        const res = await serveBlobHostRequest(request, url, env);
+        expect(res?.status).toBe(404);
+      }
+      expect(reads).toEqual([]);
+    }
+  });
+
+  test("404s non-allowlisted prefixes that mint URLs only as opaque handles", async () => {
+    // documents-pre-upload/ blobUrls are round-trip tokens (the server reads
+    // them via the binding); media/ has no live writer. Neither is public.
+    for (const key of [
+      "documents-pre-upload/user-1/123-abc-doc.txt",
+      "media/user/file.png",
+    ]) {
+      const { env, reads } = makeEnv({ [key]: { body: "PRIVATE" } });
+      const [request, url] = req(`https://blob.elizacloud.ai/${key}`);
+
+      const res = await serveBlobHostRequest(request, url, env);
+
+      expect(res?.status).toBe(404);
+      expect(await res?.json()).toMatchObject({ code: "resource_not_found" });
+      expect(reads).toEqual([]);
+    }
+  });
+
+  test("allowlist prefixes all end with a slash so sibling namespaces cannot match", () => {
+    // e.g. "generations/" must not accidentally allow "generation-artifacts/…".
+    for (const prefix of PUBLIC_BLOB_PREFIXES) {
+      expect(prefix.endsWith("/")).toBe(true);
+    }
+  });
+
+  test("serves SVG under a public prefix as a download with nosniff", async () => {
+    const { env } = makeEnv({
+      "avatars/users/org/user/pic.svg": {
+        body: "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>",
+        contentType: "image/svg+xml",
+      },
+    });
+    const [request, url] = req(
+      "https://blob.elizacloud.ai/avatars/users/org/user/pic.svg",
+    );
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res?.headers.get("content-disposition")).toBe("attachment");
+    expect(res?.headers.get("content-security-policy")).toContain("sandbox");
+  });
+
+  test("forces HTML and unknown content types to download", async () => {
+    const { env } = makeEnv({
+      "generations/images/org/user/evil.html": {
+        body: "<script>alert(1)</script>",
+        contentType: "text/html",
+      },
+      "generations/images/org/user/blob.bin": {
+        body: "BYTES",
+        contentType: "application/octet-stream",
+      },
+    });
+
+    for (const name of ["evil.html", "blob.bin"]) {
+      const [request, url] = req(
+        `https://blob.elizacloud.ai/generations/images/org/user/${name}`,
+      );
+      const res = await serveBlobHostRequest(request, url, env);
+      expect(res?.status).toBe(200);
+      expect(res?.headers.get("content-disposition")).toBe("attachment");
+      expect(res?.headers.get("x-content-type-options")).toBe("nosniff");
+    }
+  });
+
+  test("404s malformed percent-encoding instead of throwing", async () => {
+    const { env, reads } = makeEnv({});
+    // `%A` truncated escape → decodeURIComponent throws URIError.
+    const [request, url] = req("https://blob.elizacloud.ai/avatars/%E0%A4%A");
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(404);
+    expect(await res?.json()).toMatchObject({ code: "resource_not_found" });
+    expect(reads).toEqual([]);
   });
 });

--- a/packages/cloud/api/src/blob-host.ts
+++ b/packages/cloud/api/src/blob-host.ts
@@ -4,7 +4,7 @@
  *
  * Every public URL the cloud mints for an R2 object points at this host
  * (`publicUrlForR2Key`, `uploadToBlob` — avatars, image/music generations,
- * voice-clone samples, document previews). The host was meant to serve the
+ * voice-clone samples). The host was meant to serve the
  * bucket directly, but the wildcard `*.elizacloud.ai/*` Worker route shadows
  * it — same disease the feed host has (see FEED_ALIAS_HOST) — so every such
  * URL 404'd on this worker's JSON router, and anything that CONSUMES those
@@ -13,12 +13,50 @@
  * "Content safety moderation is unavailable" on every env.
  *
  * This handler makes the worker itself serve the bucket for that host:
- * GET/HEAD → `env.BLOB`. Whole-bucket public reads match the documented
- * design ("R2 objects are public via the bucket's public host" — blob.ts);
- * writes stay API-only.
+ * GET/HEAD → `env.BLOB` — but ONLY for keys under a public-by-URL prefix
+ * (`PUBLIC_BLOB_PREFIXES`). The same bucket also stores private heavy-payload
+ * offloads (`object-namespace.ts`: conversation message bodies, phone/Twilio
+ * payloads, sandbox backups, deploy logs, …) that must never be reachable
+ * unauthenticated. Writes stay API-only.
  */
 
 import type { AppEnv } from "@/types/cloud-worker-env";
+
+/**
+ * Deny-by-default allowlist of public-by-URL key prefixes.
+ *
+ * INVARIANT: a prefix belongs here only when its writer intentionally mints an
+ * unauthenticated public URL on `R2_PUBLIC_HOST` for keys under it (verify the
+ * writer AND the consumer before adding one). Everything else in `env.BLOB` is
+ * private — the bucket doubles as the heavy-payload offload store
+ * (`@/lib/storage/object-namespace`) — and must return the JSON 404.
+ */
+export const PUBLIC_BLOB_PREFIXES: readonly string[] = [
+  // User + character avatars — putPublicObject (v1/user/avatar,
+  // my-agents/characters/avatar); URLs stored on records and rendered in UI.
+  "avatars/",
+  // Image/music generation outputs — putPublicObject (v1/generate-image,
+  // apps/[id]/generate-image, v1/generate-music); URLs returned to callers and
+  // fetched by OpenAI moderation-by-URL.
+  "generations/",
+  // Voice-clone sample uploads — v1/voice/clone mints public URLs fetched by
+  // the voice provider.
+  "voice-samples/",
+  // App promotion imagery (social cards/banners/screenshots) —
+  // app-promotion-assets service; fetched by URL for moderation + posting.
+  "promotion-assets/",
+  // Affiliate character avatar/reference images — affiliate-images service;
+  // URLs become character avatar/reference URLs.
+  "affiliate/",
+  // Built-in static avatar sets hardcoded in the UI (default-user-avatar.ts,
+  // default-avatar.ts, eliza-avatar.tsx).
+  "cloud-avatars/",
+  "cloud-agent-samples/",
+];
+
+function isPublicBlobKey(key: string): boolean {
+  return PUBLIC_BLOB_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
 
 /** The only bindings this handler reads — narrow so tests need no casts. */
 type BlobHostBindings = Pick<AppEnv["Bindings"], "BLOB" | "R2_PUBLIC_HOST">;
@@ -78,8 +116,15 @@ export async function serveBlobHostRequest(
     );
   }
 
-  const key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
-  if (!key) return notFound();
+  let key: string;
+  try {
+    key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  } catch {
+    // Malformed percent-encoding (e.g. `%E0%A4%A`) — treat as a bad key, not
+    // a worker error.
+    return notFound();
+  }
+  if (!key || !isPublicBlobKey(key)) return notFound();
 
   const bucket: BlobBucketLike = env.BLOB;
 
@@ -100,12 +145,29 @@ export async function serveBlobHostRequest(
   return new Response(body, { status: 200, headers: objectHeaders(object) });
 }
 
+/**
+ * MIME types safe to render inline on this origin. Everything else — notably
+ * `image/svg+xml`, HTML/XML, and unknown/active types — is forced to download
+ * so it can never execute script here (stored-XSS defence). Mirrors the
+ * media-store convention in `packages/agent/src/api/media-store.ts` (cloud/api
+ * cannot import across that boundary, so the logic lives locally).
+ */
+function isInlineSafeContentType(contentType: string): boolean {
+  const mime = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  if (mime === "image/svg+xml") return false;
+  return (
+    mime.startsWith("image/") ||
+    mime.startsWith("audio/") ||
+    mime.startsWith("video/") ||
+    mime === "application/pdf"
+  );
+}
+
 function objectHeaders(object: BlobObjectLike): Headers {
   const headers = new Headers();
-  headers.set(
-    "content-type",
-    object.httpMetadata?.contentType || "application/octet-stream",
-  );
+  const contentType =
+    object.httpMetadata?.contentType || "application/octet-stream";
+  headers.set("content-type", contentType);
   if (typeof object.size === "number") {
     headers.set("content-length", String(object.size));
   }
@@ -116,5 +178,18 @@ function objectHeaders(object: BlobObjectLike): Headers {
   // client caching is safe; an hour keeps accidental key reuse recoverable.
   headers.set("cache-control", "public, max-age=3600");
   headers.set("access-control-allow-origin", "*");
+  // Stored-XSS defence: never let a mislabelled object be sniffed to HTML, and
+  // force active/unknown types (SVG, HTML/XML, octet-stream, …) to download
+  // instead of rendering on this origin. The sandboxed CSP applies when the
+  // URL is navigated to as a document.
+  headers.set("x-content-type-options", "nosniff");
+  headers.set(
+    "content-disposition",
+    isInlineSafeContentType(contentType) ? "inline" : "attachment",
+  );
+  headers.set(
+    "content-security-policy",
+    "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+  );
   return headers;
 }

--- a/packages/cloud/api/src/blob-host.ts
+++ b/packages/cloud/api/src/blob-host.ts
@@ -1,0 +1,120 @@
+/**
+ * Public R2 object serving for the blob host (`blob.elizacloud.ai` /
+ * `R2_PUBLIC_HOST`).
+ *
+ * Every public URL the cloud mints for an R2 object points at this host
+ * (`publicUrlForR2Key`, `uploadToBlob` — avatars, image/music generations,
+ * voice-clone samples, document previews). The host was meant to serve the
+ * bucket directly, but the wildcard `*.elizacloud.ai/*` Worker route shadows
+ * it — same disease the feed host has (see FEED_ALIAS_HOST) — so every such
+ * URL 404'd on this worker's JSON router, and anything that CONSUMES those
+ * URLs broke with it: OpenAI's moderation-by-URL cannot download generated
+ * images, so image generation fails closed with
+ * "Content safety moderation is unavailable" on every env.
+ *
+ * This handler makes the worker itself serve the bucket for that host:
+ * GET/HEAD → `env.BLOB`. Whole-bucket public reads match the documented
+ * design ("R2 objects are public via the bucket's public host" — blob.ts);
+ * writes stay API-only.
+ */
+
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+/** The only bindings this handler reads — narrow so tests need no casts. */
+type BlobHostBindings = Pick<AppEnv["Bindings"], "BLOB" | "R2_PUBLIC_HOST">;
+
+const DEFAULT_BLOB_HOST = "blob.elizacloud.ai";
+
+/**
+ * The slice of the native Workers R2 API this handler reads. The shared
+ * `RuntimeR2Bucket` type is deliberately narrow (put/get/delete for route
+ * code); the real binding also exposes `head`, streaming `body`, `size` and
+ * `httpEtag`. Everything here is optional so the shared type stays assignable
+ * and the handler degrades per capability (test shims included).
+ */
+interface BlobObjectLike {
+  body?: ReadableStream | null;
+  size?: number;
+  httpEtag?: string;
+  httpMetadata?: { contentType?: string };
+  arrayBuffer?(): Promise<ArrayBuffer>;
+  text?(): Promise<string>;
+}
+
+interface BlobBucketLike {
+  get(key: string): Promise<BlobObjectLike | null>;
+  head?(key: string): Promise<BlobObjectLike | null>;
+}
+
+function configuredBlobHost(env: BlobHostBindings): string {
+  const host = env.R2_PUBLIC_HOST;
+  return typeof host === "string" && host.trim().length > 0
+    ? host.trim().toLowerCase()
+    : DEFAULT_BLOB_HOST;
+}
+
+function notFound(): Response {
+  return Response.json(
+    { success: false, error: "Not found", code: "resource_not_found" },
+    { status: 404 },
+  );
+}
+
+export async function serveBlobHostRequest(
+  request: Request,
+  url: URL,
+  env: BlobHostBindings,
+): Promise<Response | null> {
+  if (url.hostname.toLowerCase() !== configuredBlobHost(env)) return null;
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return Response.json(
+      {
+        success: false,
+        error: "Method not allowed",
+        code: "method_not_allowed",
+      },
+      { status: 405, headers: { allow: "GET, HEAD" } },
+    );
+  }
+
+  const key = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  if (!key) return notFound();
+
+  const bucket: BlobBucketLike = env.BLOB;
+
+  if (request.method === "HEAD") {
+    const head = bucket.head ? await bucket.head(key) : await bucket.get(key);
+    if (!head) return notFound();
+    return new Response(null, { status: 200, headers: objectHeaders(head) });
+  }
+
+  const object = await bucket.get(key);
+  if (!object) return notFound();
+
+  const body =
+    object.body ??
+    (object.arrayBuffer
+      ? await object.arrayBuffer()
+      : ((await object.text?.()) ?? null));
+  return new Response(body, { status: 200, headers: objectHeaders(object) });
+}
+
+function objectHeaders(object: BlobObjectLike): Headers {
+  const headers = new Headers();
+  headers.set(
+    "content-type",
+    object.httpMetadata?.contentType || "application/octet-stream",
+  );
+  if (typeof object.size === "number") {
+    headers.set("content-length", String(object.size));
+  }
+  if (object.httpEtag) {
+    headers.set("etag", object.httpEtag);
+  }
+  // Objects are keyed by timestamp/uuid and never rewritten in place, so
+  // client caching is safe; an hour keeps accidental key reuse recoverable.
+  headers.set("cache-control", "public, max-age=3600");
+  headers.set("access-control-allow-origin", "*");
+  return headers;
+}

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -15,6 +15,7 @@ import "./worker-polyfills";
 import type { Hono } from "hono";
 import { makeCronHandler } from "@/lib/cron/cloudflare-cron";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { serveBlobHostRequest } from "./blob-host";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;
 const AGENT_ID_RE =
@@ -349,6 +350,8 @@ export default {
 
     const frontendAliasResponse = proxyFrontendAliasRequest(request, url, env);
     if (frontendAliasResponse) return frontendAliasResponse;
+    const blobResponse = await serveBlobHostRequest(request, url, env);
+    if (blobResponse) return blobResponse;
     const agentProxyResponse = proxyGeneratedAgentRequest(request, env, url);
     if (agentProxyResponse) return agentProxyResponse;
     const frontendRedirect = redirectFrontendHost(url, env);

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -257,6 +257,10 @@ routes = [
   { pattern = "staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "app-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "api-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
+  # Public R2 objects for staging. Without this explicit route the host falls
+  # into [env.production]'s *.elizacloud.ai wildcard and the PROD worker serves
+  # the PROD bucket for staging-minted URLs.
+  { pattern = "blob-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
 ]
 
 [env.staging.define]
@@ -335,7 +339,7 @@ SAFE_BALANCE_THRESHOLD = ""
 # backstop (current). Off until soaked; cutover is an ops flip (#9899).
 INFERENCE_BILLING_LEDGER = ""
 FORCE_REDIS_EVENTS = "false"
-R2_PUBLIC_HOST = "blob.elizacloud.ai"
+R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
 SQL_HEAVY_PAYLOAD_MIN_BYTES = "0"
 SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES = "512"


### PR DESCRIPTION
## What

**Every public R2 URL the cloud mints is currently a 404 — prod included.** `curl -I https://blob.elizacloud.ai/avatars/eliza.png` → 404 (JSON, from the worker router). Image generation fails closed on every env because OpenAI's moderation-by-URL can't download the generated output.

## How it surfaced

The content-safety observability shipped in #11457 named it on the first post-deploy failure: the staging image-gen 503 wasn't a rejected OpenAI key — the log now reads `[ContentSafety] Moderation unavailable (400 Bad Request) … "Failed to download image from file_url: https://blob.elizacloud.ai/generations/images/…"`. Probing that URL (and prod's own avatars) showed the whole blob host answering with the **cloud-api worker's JSON banner**: the wildcard `*.elizacloud.ai/*` Worker route shadows any R2 custom domain, so the entire public-URL surface (`publicUrlForR2Key`, `uploadToBlob` — avatars, image/music generations, voice-clone samples, document previews) dead-ends on the router 404. Exactly the disease the feed host already worked around (`FEED_ALIAS_HOST` comment).

## Fix

Worker-side, so it holds regardless of route/domain configuration:

1. **`src/blob-host.ts`** — GET/HEAD on the env's `R2_PUBLIC_HOST` serve `env.BLOB` directly: content-type/etag/size from object metadata, `public, max-age=3600`, JSON 404 in the router's error shape, 405 on writes. Whole-bucket public reads match the documented design ("R2 objects are public via the bucket's public host" — `blob.ts`).
2. **Staging env drift** — `[env.staging]`'s `R2_PUBLIC_HOST` was `blob.elizacloud.ai` (the **prod** host) while staging writes to `eliza-cloud-blob-staging`: staging-minted URLs pointed at a bucket that never has the object. Now `blob-staging.elizacloud.ai`, plus an explicit staging route for that host — without it the host falls into `[env.production]`'s wildcard and the **prod** worker serves the **prod** bucket for staging URLs.

## Verify after deploy

- `curl -I https://blob.elizacloud.ai/avatars/eliza.png` → 200 `image/png` (prod)
- staging image-gen e2e: `generates an image` goes green (moderation can finally download the output)

## Test

7 unit cases on the handler (serve + content-type, per-env host pinning with fall-through for foreign hosts, JSON 404 shape, HEAD without body, 405 writes, URL-decoded keys) — 7/7. `cloud/api` typecheck clean apart from the pre-existing `agents/route.ts` develop error; biome clean.