### PR TITLE
test(cloud): fix stale sandbox-quota assertions blocking clean develop CI (#11023)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -294,13 +294,16 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
     // advisory lock — so the check and the write are atomic (no TOCTOU).
     expect(transaction).toHaveBeenCalledTimes(1);
     expect(executeCalls).toBe(1);
-    // The count scoped to this org AND to non-terminal statuses only.
+    // The count scoped to this org AND to the quota-counted statuses. The
+    // filter uses inArray → the status values are query PARAMS, not inline
+    // literals; and the quota count is intentionally BROADER than the reuse
+    // guard (it counts every resource-holding non-terminal status).
     expect(capturedSelectWhere).toBeDefined();
-    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL).sql;
+    const { sql, params } = new PgDialect().sqlToQuery(capturedSelectWhere as SQL);
     expect(sql).toContain("organization_id");
-    expect(sql).toContain("'pending'");
-    expect(sql).toContain("'provisioning'");
-    expect(sql).toContain("'running'");
+    for (const status of ["pending", "provisioning", "running", "stopped", "sleeping"]) {
+      expect(params).toContain(status);
+    }
   });
 
   test("a fresh create AT the cap is refused with AgentQuotaExceededError and NO insert (fleet-DoS closed)", async () => {
@@ -379,13 +382,15 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
     // serialize creates with DIFFERENT images against one org's quota, and the
     // strict org→image order keeps this path deadlock-free vs createAgent.
     expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v1"]);
-    // The quota count scoped to the org + non-terminal statuses ran under the lock.
+    // The quota count scoped to the org + quota-counted statuses ran under the
+    // lock. inArray parameterizes the status values (params, not inline SQL),
+    // and the count is intentionally BROADER than the reuse guard.
     expect(capturedSelectWhere).toBeDefined();
-    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL).sql;
+    const { sql, params } = new PgDialect().sqlToQuery(capturedSelectWhere as SQL);
     expect(sql).toContain("organization_id");
-    expect(sql).toContain("'pending'");
-    expect(sql).toContain("'provisioning'");
-    expect(sql).toContain("'running'");
+    for (const status of ["pending", "provisioning", "running", "stopped", "sleeping"]) {
+      expect(params).toContain(status);
+    }
   });
 
   test("a distinct-image create AT the cap is refused with AgentQuotaExceededError and NO insert", async () => {


### PR DESCRIPTION
**Found via a full develop-head test sweep** (verifying develop is green before the money-wave promote). The #11023 sandbox-quota tests were failing on develop tip — **the code is correct, the test was stale.**

### Cause
The forceCreate per-org quota count uses `inArray(agentSandboxes.status, QUOTA_COUNTED_STATUSES)`, which:
1. **parameterizes** the status values (they go into the query `params`, not inline `.sql`), and
2. was intentionally **broadened** to count every resource-holding non-terminal status: `pending, provisioning, running, stopped, sleeping` (the code comment: "intentionally BROADER than the reuse-guard SELECTs").

Two assertions still expected the old form — inline `'pending'`/`'provisioning'`/`'running'` literals in the rendered `.sql`, only 3 statuses — so they failed. Fixed both to render `{sql, params}` and assert the full quota-counted status set in `params`.

### Evidence
- `eliza-sandbox-create-idempotency.test.ts`: **11 pass / 0 fail** (was 9/2) on develop tip.
- Zero code change — the quota service is untouched and correct.

### Develop-head status (for the promote decision, cc @lalalune / [cloud-money])
Full local sweep of the launch-critical lanes on develop tip:
- `cloud-api` unit: **566/0/1** ✅
- `plugin-cloud-apps`: **249/0** ✅
- `cloud-shared`: was 3 red → **this PR fixes 2**; the last one (`app-frontend-deployments` 'pglite applied' guard) is a **PGlite-under-Bun local init failure** (@electric-sql/pglite 0.4.6 execProtocolStream), an env issue that passes in CI against real Postgres — not a code regression.

With this, the launch-critical develop test lanes are green (modulo the known local-PGlite env quirk) — addressing the '3-days-CI-unverified' caveat on the money-wave promote.

— `[cloud-frontdoor]`