### PR TITLE
refactor(orchestrator): drop regex-on-task-text for deferUserReply

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -199,7 +199,11 @@ describe("TASKS:spawn_agent", () => {
     ]);
   });
 
-  it("suppresses the spawn acknowledgement when the user requested a deferred reply", async () => {
+  it("does NOT defer from task text alone — deferral is structural, not regex", async () => {
+    // The planner emits the structured `deferUserReply` flag when the user asks
+    // for no interim reply; the orchestrator no longer regex-scans the task text
+    // for "reply only after …" phrasings (that was message-text inspection,
+    // which the project bans). The next test covers the structural path.
     const svc = serviceMock();
     const cb = callback();
     const result = await spawnAgentAction.handler(
@@ -214,9 +218,8 @@ describe("TASKS:spawn_agent", () => {
     );
 
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe("");
-    expect(result?.data).toMatchObject({ deferredUserReply: true });
-    expect(cb).not.toHaveBeenCalled();
+    // No structured flag → not deferred, even though the text says "reply only after".
+    expect(result?.data).not.toMatchObject({ deferredUserReply: true });
   });
 
   it("honors explicit deferUserReply from planner parameters", async () => {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -194,16 +194,6 @@ function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function requestsDeferredUserReply(text: string): boolean {
-  const normalized = text.toLowerCase();
-  return (
-    /\b(?:reply|respond)\s+only\s+after\b/.test(normalized) ||
-    /\b(?:reply|respond)\s+only\s+when\b/.test(normalized) ||
-    /\bdo\s+not\s+(?:reply|respond)\s+until\b/.test(normalized) ||
-    /\bdon't\s+(?:reply|respond)\s+until\b/.test(normalized)
-  );
-}
-
 function readOp(params: Record<string, unknown>): TaskOp | null {
   const raw = [
     params.action,
@@ -1095,9 +1085,10 @@ async function runSpawnAgent(
       "keepAliveAfterComplete",
     );
     const extraMetadata = additionalSessionMetadata(params, content);
+    // Structural only: the planner emits deferUserReply when the user asked for
+    // no interim reply. No regex over the task text (the model judges intent).
     const deferUserReply =
-      pickBoolean(params, content, "deferUserReply") === true ||
-      requestsDeferredUserReply(task);
+      pickBoolean(params, content, "deferUserReply") === true;
     const label = pickString(params, content, "label") ?? task.slice(0, 80);
     const originConnectorMessageId = connectorMessageIdFromMemory(
       message,


### PR DESCRIPTION
## What

Removes the `requestsDeferredUserReply` regex helper from the orchestrator's `TASKS:spawn_agent` path. The deferred-user-reply decision is now driven solely by the structural `deferUserReply` boolean the planner emits.

## Why

`deferUserReply` was computed as:

```ts
pickBoolean(params, content, "deferUserReply") === true || requestsDeferredUserReply(task);
```

where the helper ran 4 regexes over the task text ("reply only after", "reply only when", "do not reply until", "don't reply until"). That is message-text inspection driving a behavior decision — the exact regex-on-LLM-text pattern the project bans (structural signals from the trajectory/planner, not regex over model text). The evaluator/planner rule is: fixes and behavior gates must be structural.

The structural signal already exists: the `deferUserReply` action parameter is documented in the TASKS schema ("suppress the immediate visible acknowledgement when the user explicitly requested no interim reply") and the planner emits it when the user asks for no interim reply.

## Fallback when the planner omits the field

Safe default is `false` — the normal spawn acknowledgement is posted. Nothing is lost: the sub-agent completion router still posts the final result either way. The regex only ever suppressed an interim ack; a missed suppression is a harmless extra ack, while a false-positive regex hit silently swallowed acks on tasks that merely *mentioned* reply timing.

## Tests

- Updated: `does NOT defer from task text alone — deferral is structural, not regex` — task text containing "Reply only after verification" no longer sets `deferredUserReply`.
- Existing sibling test `honors explicit deferUserReply from planner parameters` covers the structural path.

## Verification

- `bunx vitest run __tests__/unit/spawn-agent.test.ts` — 13/13 passed
- full plugin suite `bun run test` — 143 files passed, 1433 tests passed, 8 skipped
- `bun run typecheck` (tsgo --noEmit) — clean
- `bunx biome check` on touched files — clean

Evidence note: behavior-level change is the removal of a text-based gate; the structural path is exercised by the unit suite above. No UI/trajectory surface changed (N/A — planner schema and completion routing untouched).
