### PR TITLE
fix(core): refresh model pricing/context tables + env overrides for new ids

### DIFF
--- a/packages/core/src/features/trajectories/pricing.test.ts
+++ b/packages/core/src/features/trajectories/pricing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	computeCallCostUsd,
 	isLocalProvider,
@@ -18,8 +18,14 @@ describe("PRICE_TABLE_ID", () => {
 
 describe("MODEL_PRICES_USD_PER_M_TOKENS", () => {
 	it("covers all required hosted providers", () => {
-		// Anthropic — the three ship models from CLAUDE.md
+		// Anthropic — the current public families plus the prior Opus
+		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-8"]?.provider).toBe(
+			"anthropic",
+		);
 		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-7"]?.provider).toBe(
+			"anthropic",
+		);
+		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-sonnet-5"]?.provider).toBe(
 			"anthropic",
 		);
 		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-sonnet-4-6"]?.provider).toBe(
@@ -59,19 +65,31 @@ describe("MODEL_PRICES_USD_PER_M_TOKENS", () => {
 	});
 
 	it("preserves the documented Anthropic rate card", () => {
-		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-7"]).toEqual({
+		// Opus-tier is $5/$25 per MTok (platform.claude.com pricing,
+		// captured 2026-07-02); cacheRead = 0.1x input, cacheWrite = 1.25x.
+		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-8"]).toEqual({
 			provider: "anthropic",
-			input: 15.0,
-			output: 75.0,
-			cacheRead: 1.5,
-			cacheWrite: 18.75,
+			input: 5.0,
+			output: 25.0,
+			cacheRead: 0.5,
+			cacheWrite: 6.25,
+		});
+		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-7"]).toEqual(
+			MODEL_PRICES_USD_PER_M_TOKENS["claude-opus-4-8"],
+		);
+		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-sonnet-5"]).toEqual({
+			provider: "anthropic",
+			input: 3.0,
+			output: 15.0,
+			cacheRead: 0.3,
+			cacheWrite: 3.75,
 		});
 		expect(MODEL_PRICES_USD_PER_M_TOKENS["claude-haiku-4-5"]).toEqual({
 			provider: "anthropic",
-			input: 0.8,
-			output: 4.0,
-			cacheRead: 0.08,
-			cacheWrite: 1.0,
+			input: 1.0,
+			output: 5.0,
+			cacheRead: 0.1,
+			cacheWrite: 1.25,
 		});
 	});
 });
@@ -102,6 +120,28 @@ describe("lookupModelPrice", () => {
 });
 
 describe("lookupModelContextWindow", () => {
+	it("resolves the current Anthropic families to their documented windows", () => {
+		expect(
+			lookupModelContextWindow("claude-opus-4-8")?.contextWindowTokens,
+		).toBe(1_000_000);
+		expect(
+			lookupModelContextWindow("claude-sonnet-5")?.contextWindowTokens,
+		).toBe(1_000_000);
+		expect(
+			lookupModelContextWindow("claude-haiku-4-5")?.contextWindowTokens,
+		).toBe(200_000);
+	});
+
+	it("resolves versioned Anthropic ids through the substring fallback", () => {
+		const result = lookupModelContextWindow("claude-sonnet-5-20260203");
+		expect(result?.matchedKey).toBe("claude-sonnet-5");
+		expect(result?.contextWindowTokens).toBe(1_000_000);
+	});
+
+	it("returns null for a truly unknown id (default-window fallback stays with the caller)", () => {
+		expect(lookupModelContextWindow("claude-unknown-test-9")).toBeNull();
+	});
+
 	it("returns the live-verified Cerebras Gemma 4 31B context window", () => {
 		// 131072 is the hard paid-tier ceiling (live probe 2026-07-02:
 		// >131072 -> context_length_exceeded; context_length param rejected).
@@ -188,27 +228,37 @@ describe("computeCallCostUsd", () => {
 	});
 
 	it("computes input+output for an Anthropic Opus call", () => {
-		// 1k input + 1k output on claude-opus-4-7.
-		// input  = 1000   * $15.00/M = $0.015
-		// output = 1000   * $75.00/M = $0.075
-		// total  = $0.09
-		const cost = computeCallCostUsd("claude-opus-4-7", {
+		// 1k input + 1k output on claude-opus-4-8.
+		// input  = 1000   * $5.00/M  = $0.005
+		// output = 1000   * $25.00/M = $0.025
+		// total  = $0.03
+		const cost = computeCallCostUsd("claude-opus-4-8", {
 			promptTokens: 1000,
 			completionTokens: 1000,
 			totalTokens: 2000,
 		});
-		expect(cost).toBeCloseTo(0.09, 6);
+		expect(cost).toBeCloseTo(0.03, 6);
+	});
+
+	it("computes input+output for an Anthropic Sonnet 5 call", () => {
+		// 1M input * $3/M + 1M output * $15/M = $18
+		const cost = computeCallCostUsd("claude-sonnet-5", {
+			promptTokens: 1_000_000,
+			completionTokens: 1_000_000,
+			totalTokens: 2_000_000,
+		});
+		expect(cost).toBeCloseTo(18.0, 6);
 	});
 
 	it("applies cache-read discount and cache-write surcharge for Anthropic", () => {
-		// claude-haiku-4-5: input $0.80, output $4.00, cacheRead $0.08,
-		//                   cacheWrite $1.00 (per 1M).
+		// claude-haiku-4-5: input $1.00, output $5.00, cacheRead $0.10,
+		//                   cacheWrite $1.25 (per 1M).
 		// 1000 prompt = 200 fresh + 700 cacheRead + 100 cacheWrite
-		//   fresh:      200  * $0.80 / 1M  = $0.00016
-		//   cacheRead:  700  * $0.08 / 1M  = $0.000056
-		//   cacheWrite: 100  * $1.00 / 1M  = $0.0001
-		//   completion:  50  * $4.00 / 1M  = $0.0002
-		// total = $0.000516
+		//   fresh:      200  * $1.00 / 1M  = $0.0002
+		//   cacheRead:  700  * $0.10 / 1M  = $0.00007
+		//   cacheWrite: 100  * $1.25 / 1M  = $0.000125
+		//   completion:  50  * $5.00 / 1M  = $0.00025
+		// total = $0.000645
 		const cost = computeCallCostUsd("claude-haiku-4-5", {
 			promptTokens: 1000,
 			completionTokens: 50,
@@ -216,7 +266,7 @@ describe("computeCallCostUsd", () => {
 			cacheCreationInputTokens: 100,
 			totalTokens: 1050,
 		});
-		expect(cost).toBeCloseTo(0.000516, 9);
+		expect(cost).toBeCloseTo(0.000645, 9);
 	});
 
 	it("falls back to the input rate when cacheRead is 0 (Cerebras gpt-oss)", () => {
@@ -287,9 +337,119 @@ describe("computeCallCostUsd", () => {
 			cacheCreationInputTokens: 0,
 			totalTokens: 200,
 		});
-		// non-cached = 0, cacheRead = 200 * $0.08/M = $0.000016, completion = 0.
-		expect(cost).toBeCloseTo(0.000016, 9);
+		// non-cached = 0, cacheRead = 200 * $0.10/M = $0.00002, completion = 0.
+		expect(cost).toBeCloseTo(0.00002, 9);
 		expect(cost).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe("env overrides (MODEL_PRICES_JSON / MODEL_CONTEXT_WINDOWS_JSON)", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("prices an id absent from the static table via MODEL_PRICES_JSON", () => {
+		vi.stubEnv(
+			"MODEL_PRICES_JSON",
+			JSON.stringify({
+				"acme-frontier-9000": { input: 4.0, output: 20.0 },
+			}),
+		);
+		const warn = vi.fn();
+		const cost = computeCallCostUsd(
+			"acme-frontier-9000",
+			{
+				promptTokens: 1_000_000,
+				completionTokens: 1_000_000,
+				totalTokens: 2_000_000,
+			},
+			{ provider: "unknown", logger: { warn } },
+		);
+		expect(cost).toBeCloseTo(24.0, 6);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("env price entry wins over a static entry with the same key", () => {
+		vi.stubEnv(
+			"MODEL_PRICES_JSON",
+			JSON.stringify({
+				"claude-haiku-4-5": { input: 2.0, output: 8.0 },
+			}),
+		);
+		const cost = computeCallCostUsd("claude-haiku-4-5", {
+			promptTokens: 1_000_000,
+			completionTokens: 1_000_000,
+			totalTokens: 2_000_000,
+		});
+		expect(cost).toBeCloseTo(10.0, 6);
+	});
+
+	it("env price keys participate in the substring fallback (versioned ids)", () => {
+		vi.stubEnv(
+			"MODEL_PRICES_JSON",
+			JSON.stringify({ "acme-frontier-9000": { input: 1.0, output: 2.0 } }),
+		);
+		const result = lookupModelPrice("acme-frontier-9000-20260101");
+		expect(result?.matchedKey).toBe("acme-frontier-9000");
+	});
+
+	it("resolves an arbitrary id's context window via MODEL_CONTEXT_WINDOWS_JSON", () => {
+		vi.stubEnv(
+			"MODEL_CONTEXT_WINDOWS_JSON",
+			JSON.stringify({ "acme-frontier-9000": 500_000 }),
+		);
+		expect(lookupModelContextWindow("acme-frontier-9000")).toEqual({
+			matchedKey: "acme-frontier-9000",
+			contextWindowTokens: 500_000,
+		});
+	});
+
+	it("env context window wins over a static entry with the same key", () => {
+		vi.stubEnv(
+			"MODEL_CONTEXT_WINDOWS_JSON",
+			JSON.stringify({ "claude-haiku-4-5": 400_000 }),
+		);
+		expect(
+			lookupModelContextWindow("claude-haiku-4-5")?.contextWindowTokens,
+		).toBe(400_000);
+	});
+
+	it("malformed override JSON degrades safely (static table still serves, no throw)", () => {
+		vi.stubEnv("MODEL_PRICES_JSON", "{not json");
+		vi.stubEnv("MODEL_CONTEXT_WINDOWS_JSON", "[1,2,3]");
+		expect(() => lookupModelPrice("claude-opus-4-8")).not.toThrow();
+		expect(lookupModelPrice("claude-opus-4-8")?.price.input).toBe(5.0);
+		expect(
+			lookupModelContextWindow("claude-opus-4-8")?.contextWindowTokens,
+		).toBe(1_000_000);
+	});
+
+	it("invalid entries are skipped while valid siblings apply", () => {
+		vi.stubEnv(
+			"MODEL_PRICES_JSON",
+			JSON.stringify({
+				"bad-entry": { input: "five" },
+				"good-entry": { input: 1.0, output: 2.0 },
+			}),
+		);
+		expect(lookupModelPrice("bad-entry")).toBeNull();
+		expect(lookupModelPrice("good-entry")?.price.output).toBe(2.0);
+	});
+
+	it("a truly unknown id still degrades to cost 0 + warn and no window", () => {
+		vi.stubEnv(
+			"MODEL_PRICES_JSON",
+			JSON.stringify({ "some-other-model": { input: 1.0, output: 2.0 } }),
+		);
+		const warn = vi.fn();
+		const cost = computeCallCostUsd(
+			"claude-unknown-test-9",
+			{ promptTokens: 1000, completionTokens: 1000, totalTokens: 2000 },
+			{ provider: "anthropic", logger: { warn } },
+		);
+		expect(cost).toBe(0);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(lookupModelContextWindow("claude-unknown-test-9")).toBeNull();
 	});
 });
 

--- a/packages/core/src/features/trajectories/pricing.ts
+++ b/packages/core/src/features/trajectories/pricing.ts
@@ -16,6 +16,8 @@
  * table is auditable. Update both the entry and the corresponding source
  * comment if a provider changes their rate card.
  */
+import { logger } from "../../logger";
+import { readEnv } from "../../utils/read-env";
 import type {
 	TokenUsageForCost,
 	TrajectoryRuntimeLogger,
@@ -31,7 +33,7 @@ export type { TokenUsageForCost } from "./pricing-types";
  * so consumers can disambiguate cost numbers computed against different
  * snapshots.
  */
-export const PRICE_TABLE_ID = "eliza-v1-2026-07-01" as const;
+export const PRICE_TABLE_ID = "eliza-v1-2026-07-02" as const;
 export type PriceTableId = typeof PRICE_TABLE_ID;
 
 /**
@@ -84,13 +86,32 @@ export const MODEL_PRICES_USD_PER_M_TOKENS: Record<
 	ModelPriceUsdPerMTokens
 > = {
 	// ---- Anthropic ----------------------------------------------------------
-	// Source: https://www.anthropic.com/pricing (captured 2026-05-11)
+	// Source: https://platform.claude.com/docs/en/about-claude/models/overview
+	// + https://platform.claude.com/docs/en/pricing (captured 2026-07-02).
+	// Opus-tier is $5/$25 per MTok; cacheRead is 0.1x input, cacheWrite is
+	// 1.25x input (5-minute TTL) per the published prompt-caching multipliers.
+	"claude-opus-4-8": {
+		provider: "anthropic",
+		input: 5.0,
+		output: 25.0,
+		cacheRead: 0.5,
+		cacheWrite: 6.25,
+	},
 	"claude-opus-4-7": {
 		provider: "anthropic",
-		input: 15.0,
-		output: 75.0,
-		cacheRead: 1.5,
-		cacheWrite: 18.75,
+		input: 5.0,
+		output: 25.0,
+		cacheRead: 0.5,
+		cacheWrite: 6.25,
+	},
+	// Sonnet 5 sticker rate is $3/$15 per MTok (an introductory $2/$10 runs
+	// through 2026-08-31; we bill the standard tier — see the pricing page).
+	"claude-sonnet-5": {
+		provider: "anthropic",
+		input: 3.0,
+		output: 15.0,
+		cacheRead: 0.3,
+		cacheWrite: 3.75,
 	},
 	"claude-sonnet-4-6": {
 		provider: "anthropic",
@@ -101,10 +122,10 @@ export const MODEL_PRICES_USD_PER_M_TOKENS: Record<
 	},
 	"claude-haiku-4-5": {
 		provider: "anthropic",
-		input: 0.8,
-		output: 4.0,
-		cacheRead: 0.08,
-		cacheWrite: 1.0,
+		input: 1.0,
+		output: 5.0,
+		cacheRead: 0.1,
+		cacheWrite: 1.25,
 	},
 
 	// ---- OpenAI -------------------------------------------------------------
@@ -269,9 +290,13 @@ export const MODEL_PRICES_USD_PER_M_TOKENS: Record<
  */
 export const MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
 	// ---- Anthropic ----------------------------------------------------------
-	// Source: https://docs.anthropic.com/en/docs/about-claude/models (captured 2026-05-11)
-	"claude-opus-4-7": 200_000,
-	"claude-sonnet-4-6": 200_000,
+	// Source: https://platform.claude.com/docs/en/about-claude/models/overview
+	// (captured 2026-07-02). Opus 4.7+, Sonnet 4.6, and Sonnet 5 ship a 1M
+	// input context window at standard pricing; Haiku 4.5 remains 200k.
+	"claude-opus-4-8": 1_000_000,
+	"claude-opus-4-7": 1_000_000,
+	"claude-sonnet-5": 1_000_000,
+	"claude-sonnet-4-6": 1_000_000,
 	"claude-haiku-4-5": 200_000,
 
 	// ---- OpenAI -------------------------------------------------------------
@@ -308,6 +333,145 @@ export const MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
 };
 
 /**
+ * Operator-supplied table overrides, read from the environment.
+ *
+ * New model ids ship faster than this file. Rather than forcing a code change
+ * (and a release) to price or size a model we have not enumerated yet,
+ * operators can supply per-id entries via two env vars:
+ *
+ *   - `MODEL_PRICES_JSON` — JSON object mapping model id → price entry:
+ *     `{"my-model": {"input": 5, "output": 25, "cacheRead": 0.5,
+ *     "cacheWrite": 6.25, "provider": "anthropic"}}`. `input` and `output`
+ *     (USD per 1M tokens) are required; `cacheRead` / `cacheWrite` default
+ *     to 0 (= bill at the input rate, matching the static-table convention)
+ *     and `provider` defaults to `"unknown"`.
+ *   - `MODEL_CONTEXT_WINDOWS_JSON` — JSON object mapping model id → context
+ *     window in tokens: `{"my-model": 1000000}`.
+ *
+ * Overrides are merged BEFORE the static tables in both lookups, so an env
+ * entry wins over a static entry with the same key and env keys participate
+ * in the same longest-substring fallback as static keys. Malformed JSON or
+ * invalid entries are skipped with a warning — a bad override must never
+ * crash the runtime, and unknown ids keep the safe degraded behavior
+ * (cost 0 + warn, default context window).
+ *
+ * Parses are memoized per raw env string so hot-path lookups stay cheap while
+ * tests (and long-lived processes with mutated env) still observe changes.
+ */
+interface EnvOverrideCache<T> {
+	raw: string | undefined;
+	value: Record<string, T>;
+}
+
+function parseJsonObject(
+	raw: string | undefined,
+	envName: string,
+): Record<string, unknown> | null {
+	if (!raw) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+		logger.warn(
+			`[pricing] ${envName} must be a JSON object of model-id keys — override ignored`,
+		);
+	} catch (error) {
+		logger.warn(
+			{ error: error instanceof Error ? error.message : String(error) },
+			`[pricing] ${envName} is not valid JSON — override ignored`,
+		);
+	}
+	return null;
+}
+
+function isNonNegativeFinite(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+let priceOverridesCache: EnvOverrideCache<ModelPriceUsdPerMTokens> | null =
+	null;
+
+function getPriceOverrides(): Record<string, ModelPriceUsdPerMTokens> {
+	const raw = readEnv("MODEL_PRICES_JSON");
+	if (priceOverridesCache && priceOverridesCache.raw === raw) {
+		return priceOverridesCache.value;
+	}
+	const value: Record<string, ModelPriceUsdPerMTokens> = {};
+	const parsed = parseJsonObject(raw, "MODEL_PRICES_JSON");
+	if (parsed) {
+		for (const [modelId, entry] of Object.entries(parsed)) {
+			const record =
+				entry && typeof entry === "object" && !Array.isArray(entry)
+					? (entry as Record<string, unknown>)
+					: null;
+			if (
+				!record ||
+				!isNonNegativeFinite(record.input) ||
+				!isNonNegativeFinite(record.output)
+			) {
+				logger.warn(
+					{ modelId },
+					"[pricing] MODEL_PRICES_JSON entry needs numeric input/output — entry skipped",
+				);
+				continue;
+			}
+			value[modelId] = {
+				provider:
+					typeof record.provider === "string"
+						? (record.provider as ProviderName)
+						: "unknown",
+				input: record.input,
+				output: record.output,
+				cacheRead: isNonNegativeFinite(record.cacheRead)
+					? record.cacheRead
+					: 0,
+				cacheWrite: isNonNegativeFinite(record.cacheWrite)
+					? record.cacheWrite
+					: 0,
+			};
+		}
+	}
+	priceOverridesCache = { raw, value };
+	return value;
+}
+
+let contextWindowOverridesCache: EnvOverrideCache<number> | null = null;
+
+function getContextWindowOverrides(): Record<string, number> {
+	const raw = readEnv("MODEL_CONTEXT_WINDOWS_JSON");
+	if (contextWindowOverridesCache && contextWindowOverridesCache.raw === raw) {
+		return contextWindowOverridesCache.value;
+	}
+	const value: Record<string, number> = {};
+	const parsed = parseJsonObject(raw, "MODEL_CONTEXT_WINDOWS_JSON");
+	if (parsed) {
+		for (const [modelId, tokens] of Object.entries(parsed)) {
+			if (!isNonNegativeFinite(tokens) || tokens < 1) {
+				logger.warn(
+					{ modelId },
+					"[pricing] MODEL_CONTEXT_WINDOWS_JSON entry needs a positive token count — entry skipped",
+				);
+				continue;
+			}
+			value[modelId] = Math.floor(tokens);
+		}
+	}
+	contextWindowOverridesCache = { raw, value };
+	return value;
+}
+
+/** Merge env overrides over a static table (env wins on key conflicts). */
+function withOverrides<T>(
+	table: Record<string, T>,
+	overrides: Record<string, T>,
+): Record<string, T> {
+	return Object.keys(overrides).length === 0
+		? table
+		: { ...table, ...overrides };
+}
+
+/**
  * Result of a context-window lookup. Carries the matched table key so callers
  * can surface "matched as family X" diagnostics if needed — mirrors
  * `PriceLookupResult`.
@@ -341,18 +505,22 @@ export function lookupModelContextWindow(
 	modelName: string | undefined,
 ): ContextWindowLookupResult | null {
 	if (!modelName) return null;
-	const exact = MODEL_CONTEXT_WINDOW_TOKENS[modelName];
+	const table = withOverrides(
+		MODEL_CONTEXT_WINDOW_TOKENS,
+		getContextWindowOverrides(),
+	);
+	const exact = table[modelName];
 	if (typeof exact === "number") {
 		return { matchedKey: modelName, contextWindowTokens: exact };
 	}
 
 	const normalized = modelName.toLowerCase();
-	const candidates = Object.keys(MODEL_CONTEXT_WINDOW_TOKENS)
+	const candidates = Object.keys(table)
 		.filter((k) => normalized.includes(k.toLowerCase()))
 		.sort((a, b) => b.length - a.length);
 	const match = candidates[0];
 	if (!match) return null;
-	const tokens = MODEL_CONTEXT_WINDOW_TOKENS[match];
+	const tokens = table[match];
 	if (typeof tokens !== "number") return null;
 	return { matchedKey: match, contextWindowTokens: tokens };
 }
@@ -392,16 +560,20 @@ export function lookupModelPrice(
 	modelName: string | undefined,
 ): PriceLookupResult | null {
 	if (!modelName) return null;
-	const exact = MODEL_PRICES_USD_PER_M_TOKENS[modelName];
+	const table = withOverrides(
+		MODEL_PRICES_USD_PER_M_TOKENS,
+		getPriceOverrides(),
+	);
+	const exact = table[modelName];
 	if (exact) return { matchedKey: modelName, price: exact };
 
 	const normalized = modelName.toLowerCase();
-	const candidates = Object.keys(MODEL_PRICES_USD_PER_M_TOKENS)
+	const candidates = Object.keys(table)
 		.filter((k) => normalized.includes(k.toLowerCase()))
 		.sort((a, b) => b.length - a.length);
 	const match = candidates[0];
 	if (!match) return null;
-	const price = MODEL_PRICES_USD_PER_M_TOKENS[match];
+	const price = table[match];
 	if (!price) return null;
 	return { matchedKey: match, price };
 }

--- a/packages/core/src/runtime/__tests__/model-input-budget.test.ts
+++ b/packages/core/src/runtime/__tests__/model-input-budget.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatMessage, ToolDefinition } from "../../types/model";
 import {
 	buildModelInputBudget,
@@ -125,13 +125,36 @@ describe("buildModelInputBudget", () => {
 			expect(budget.compactionThresholdTokens).toBe(32_000 - 10_000);
 		});
 
-		it("scales reserve to 40k for Claude (200k * 0.20)", () => {
+		it("scales reserve to 40k for Claude Haiku (200k * 0.20)", () => {
 			const budget = buildModelInputBudget({
 				messages: [userMessageOfChars(100)],
-				modelName: "claude-opus-4-7",
+				modelName: "claude-haiku-4-5",
 			});
 			expect(budget.reserveTokens).toBe(40_000);
 			expect(budget.compactionThresholdTokens).toBe(200_000 - 40_000);
+		});
+
+		it("resolves the current 1M-window Claude families (opus / sonnet)", () => {
+			for (const modelName of ["claude-opus-4-8", "claude-sonnet-5"]) {
+				const budget = buildModelInputBudget({
+					messages: [userMessageOfChars(100)],
+					modelName,
+				});
+				expect(budget.contextWindowTokens).toBe(1_000_000);
+				expect(budget.resolvedModelKey).toBe(modelName);
+				expect(budget.reserveTokens).toBe(200_000); // 1M * 0.20
+				expect(budget.compactionThresholdTokens).toBe(800_000);
+			}
+		});
+
+		it("falls back to the 128k default for an unknown id without throwing", () => {
+			const budget = buildModelInputBudget({
+				messages: [userMessageOfChars(100)],
+				modelName: "claude-unknown-test-9",
+			});
+			expect(budget.contextWindowTokens).toBe(DEFAULT_CONTEXT_WINDOW_TOKENS);
+			expect(budget.resolvedModelKey).toBeNull();
+			expect(budget.reserveTokens).toBe(DEFAULT_COMPACTION_RESERVE_TOKENS);
 		});
 
 		it("respects an explicit reserveTokens override even when modelName resolves", () => {
@@ -218,6 +241,36 @@ describe("buildModelInputBudget", () => {
 				modelName: "some-unknown-model-99",
 			});
 			expect(budget.reserveTokens).toBe(DEFAULT_COMPACTION_RESERVE_TOKENS);
+		});
+	});
+
+	describe("env-override context windows (MODEL_CONTEXT_WINDOWS_JSON)", () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		it("resolves an id absent from the static table via the env override", () => {
+			vi.stubEnv(
+				"MODEL_CONTEXT_WINDOWS_JSON",
+				JSON.stringify({ "acme-frontier-9000": 500_000 }),
+			);
+			const budget = buildModelInputBudget({
+				messages: [userMessageOfChars(100)],
+				modelName: "acme-frontier-9000",
+			});
+			expect(budget.contextWindowTokens).toBe(500_000);
+			expect(budget.resolvedModelKey).toBe("acme-frontier-9000");
+			expect(budget.reserveTokens).toBe(100_000); // 500k * 0.20
+		});
+
+		it("malformed env JSON degrades to the default window without throwing", () => {
+			vi.stubEnv("MODEL_CONTEXT_WINDOWS_JSON", "{oops");
+			const budget = buildModelInputBudget({
+				messages: [userMessageOfChars(100)],
+				modelName: "claude-unknown-test-9",
+			});
+			expect(budget.contextWindowTokens).toBe(DEFAULT_CONTEXT_WINDOW_TOKENS);
+			expect(budget.resolvedModelKey).toBeNull();
 		});
 	});
 

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -516,8 +516,8 @@ describe("JsonFileTrajectoryRecorder", () => {
 		const model = trajectory?.stages[0]?.model;
 		expect(typeof model?.priceTableId).toBe("string");
 		expect((model?.priceTableId ?? "").length).toBeGreaterThan(0);
-		// Anthropic Opus: 1000 input * $15/M + 500 output * $75/M = $0.0525
-		expect(model?.costUsd).toBeCloseTo(0.0525, 6);
+		// Anthropic Opus: 1000 input * $5/M + 500 output * $25/M = $0.0175
+		expect(model?.costUsd).toBeCloseTo(0.0175, 6);
 	});
 
 	it("annotates cost=0 with no warning for local-provider steps", async () => {


### PR DESCRIPTION
Closes #11527

## What

The trajectory pricing + context-window tables in `packages/core/src/features/trajectories/pricing.ts` stopped at `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5`. Current ids (`claude-opus-4-8`, `claude-sonnet-5`) missed both lookups: `computeCallCostUsd` returned 0 (cost under-reported) and the context window fell back to `DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000` instead of the real 1M/200k — compacting healthy traffic ~8x too early.

## Fix

1. **Table refresh** (sources cited inline, captured 2026-07-02 from platform.claude.com model/pricing docs; `PRICE_TABLE_ID` bumped to `eliza-v1-2026-07-02`):
   - prices: `claude-opus-4-8` + `claude-opus-4-7` $5/$25, `claude-sonnet-5` + `claude-sonnet-4-6` $3/$15, `claude-haiku-4-5` $1/$5; cacheRead = 0.1x input, cacheWrite = 1.25x input (5-min TTL multipliers)
   - context windows: opus-4-8 / opus-4-7 / sonnet-5 / sonnet-4-6 → 1,000,000; haiku-4-5 → 200,000
2. **Generic env overrides** — new ids ship faster than this file, so operators can now price/size ANY id without a code change:
   - `MODEL_PRICES_JSON` — `{"my-model": {"input": 5, "output": 25, "cacheRead": 0.5, "cacheWrite": 6.25}}`
   - `MODEL_CONTEXT_WINDOWS_JSON` — `{"my-model": 1000000}`
   - merged BEFORE the static tables in both lookups (env wins on key conflict; env keys join the longest-substring fallback so versioned ids resolve); parses memoized per raw string; malformed JSON / invalid entries skipped with a `[pricing]` warn — never crash
3. **Safe-unknown behavior kept**: a truly unknown id still returns cost 0 + one warn and the default 128k window.

## Verification (all real output)

Repro on develop before the fix:
```
opus-4-8 cost (1M in + 1M out): 0        → after: 30
opus-4-8 window lookup: null             → after: { matchedKey: "claude-opus-4-8", contextWindowTokens: 1000000 }
opus-4-8 budget window: 128000           → after: 1000000
env-override id cost: 24 / window 500000 (MODEL_PRICES_JSON / MODEL_CONTEXT_WINDOWS_JSON)
unknown id: cost 0 + warn, budget window 128000 (no throw)
```

Tests (`bunx vitest run src/features/trajectories/pricing.test.ts src/runtime/__tests__/model-input-budget.test.ts src/runtime/__tests__/trajectory-recorder.test.ts` in `packages/core`):
```
Test Files  3 passed (3)
Tests  101 passed (101)
```
New coverage: current-id pricing + windows, versioned-id substring resolution, env-override id resolution (fresh id, key-conflict wins, substring), malformed-JSON degradation, invalid-entry skip, unknown-id safe degradation through both `computeCallCostUsd` and `buildModelInputBudget`.

Typecheck: `bun run --cwd packages/core typecheck` — clean.

Evidence rows N/A: UI screenshots/video (no UI surface), live-LLM trajectory (pure price/window arithmetic on recorded usage — deterministic unit paths exercised directly above).