### PR TITLE
test(local-inference): make the vm_stat availability test host-independent

### DIFF
--- a/plugins/plugin-local-inference/src/services/system-memory.test.ts
+++ b/plugins/plugin-local-inference/src/services/system-memory.test.ts
@@ -61,17 +61,29 @@ describe("readSystemMemory", () => {
 	});
 
 	it("counts macOS reclaimable pages from vm_stat, not just Pages free", () => {
+		const totalBytes = 128 * 1024 ** 3; // the capture host: 128 GiB M4 Max
 		const mem = readSystemMemory(
 			() => null,
 			() => SAMPLE_VM_STAT,
+			() => totalBytes,
 		);
 		const pageSize = 16384;
 		const expected = (462_821 + 3_305_280 + 57_490 + 2_266) * pageSize; // free+inactive+spec+purgeable
-		// totalmem() on the test host caps the reading; below the cap the exact
-		// page math must hold.
-		expect(mem.freeBytes).toBe(Math.min(expected, mem.totalBytes));
+		expect(mem.totalBytes).toBe(totalBytes);
+		expect(mem.freeBytes).toBe(expected);
 		// The whole point: available is far more than the bare free-page count.
 		expect(mem.freeBytes).toBeGreaterThan(462_821 * pageSize * 5);
+	});
+
+	it("caps vm_stat availability at total memory", () => {
+		const totalBytes = 8 * 1024 ** 3;
+		const mem = readSystemMemory(
+			() => null,
+			() => SAMPLE_VM_STAT,
+			() => totalBytes,
+		);
+		expect(mem.freeBytes).toBe(totalBytes);
+		expect(mem.totalBytes).toBe(totalBytes);
 	});
 
 	it("falls back to os when vm_stat output is malformed", () => {

--- a/plugins/plugin-local-inference/src/services/system-memory.ts
+++ b/plugins/plugin-local-inference/src/services/system-memory.ts
@@ -107,10 +107,13 @@ function parseVmStatAvailableBytes(text: string): number | null {
  *   `/proc/meminfo` on Linux and returning null elsewhere.
  * @param readVmStat injectable vm_stat reader (tests). Defaults to running
  *   `/usr/bin/vm_stat` on macOS and returning null elsewhere.
+ * @param totalMem injectable total-memory source (tests). Defaults to
+ *   `os.totalmem`.
  */
 export function readSystemMemory(
 	read: MeminfoReader = defaultMeminfoReader,
 	readVmStat: VmStatReader = defaultVmStatReader,
+	totalMem: () => number = os.totalmem,
 ): SystemMemory {
 	const text = read();
 	if (text) {
@@ -123,10 +126,10 @@ export function readSystemMemory(
 	const vmStatText = readVmStat();
 	if (vmStatText) {
 		const availBytes = parseVmStatAvailableBytes(vmStatText);
-		const totalBytes = os.totalmem();
+		const totalBytes = totalMem();
 		if (availBytes !== null && totalBytes > 0) {
 			return { freeBytes: Math.min(availBytes, totalBytes), totalBytes };
 		}
 	}
-	return { freeBytes: os.freemem(), totalBytes: os.totalmem() };
+	return { freeBytes: os.freemem(), totalBytes: totalMem() };
 }


### PR DESCRIPTION
Follow-up to #11517 (merged). The new "counts macOS reclaimable pages from vm_stat" test asserted `freeBytes > ~38 GiB`, but `readSystemMemory` caps the vm_stat reading at the live host's `os.totalmem()` — so the test only passes on machines with more RAM than the capture host (128 GiB M4 Max). It fails deterministically on this 32 GiB Linux dev box and will fail on standard CI runners:

```
FAIL src/services/system-memory.test.ts > readSystemMemory > counts macOS reclaimable pages from vm_stat, not just Pages free
AssertionError: expected 33352902656 to be above 37915672576
```

Fix: make `totalmem` injectable (the same pattern the file already uses for the meminfo and vm_stat readers), pin it to 128 GiB in the test so the exact page math is asserted deterministically, and add an explicit cap test (`min(available, total)`).

## Verification (local, this branch on top of develop)
- `vitest run src/services/system-memory.test.ts` — 9/9 pass
- `bun run --cwd plugins/plugin-local-inference typecheck` — clean
- `biome check` on both files — clean

No runtime behavior change: the default parameter is `os.totalmem`, identical to the previous hardcoded call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)