### PR TITLE
fix(cloud): bill uncatalogued models at conservative fallback rate, not $0

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Uncatalogued-but-servable models must bill at a conservative fallback rate.
+ *
+ * A model id can be servable before its price lands in the pricing catalog
+ * (newly released ids, catalog ingest lag). Failing the request at billing was
+ * the original bug; degrading to $0 (the interim behavior) silently
+ * under-bills. The contract under test:
+ *
+ *   1. Catalogued models bill at their exact catalog rate — unchanged.
+ *   2. An unknown model from a catalogued provider bills at that provider's
+ *      MOST EXPENSIVE catalogued token rate (upper bound — never under-bills).
+ *   3. A provider with no catalogued entries falls back to the env-configured
+ *      defaults AI_PRICING_FALLBACK_INPUT_USD_PER_M /
+ *      AI_PRICING_FALLBACK_OUTPUT_USD_PER_M.
+ *   4. With no catalog and no env default, the request stays servable at $0
+ *      (last resort; covered in lookup-missing-pricing.test.ts as well).
+ *   5. Reserve (estimated tokens) and settle (actual tokens) resolve the same
+ *      fallback rate, so billing stays consistent across the request.
+ */
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+const USD_PER_M = 1_000_000;
+
+function catalogRow(
+  model: string,
+  chargeType: "input" | "output",
+  usdPerMillion: number,
+) {
+  return {
+    billing_source: "bitrouter",
+    provider: "anthropic",
+    model,
+    product_family: "language",
+    charge_type: chargeType,
+    unit: "token",
+    unit_price: String(usdPerMillion / USD_PER_M),
+    dimensions: {},
+    source_kind: "bitrouter_catalog",
+    source_url: "https://example.test/catalog",
+    fetched_at: new Date(),
+    stale_after: null,
+    priority: 200,
+    is_override: false,
+    metadata: {},
+  };
+}
+
+// Current-generation public models with their per-million-token USD rates.
+const seedCatalog = [
+  catalogRow("anthropic/claude-opus-4-8", "input", 5),
+  catalogRow("anthropic/claude-opus-4-8", "output", 25),
+  catalogRow("anthropic/claude-sonnet-5", "input", 3),
+  catalogRow("anthropic/claude-sonnet-5", "output", 15),
+  catalogRow("anthropic/claude-haiku-4-5", "input", 1),
+  catalogRow("anthropic/claude-haiku-4-5", "output", 5),
+];
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: async (filters: {
+      billingSource: string;
+      productFamily: string;
+      chargeType: string;
+      pairs: readonly { provider: string; model: string }[];
+    }) =>
+      seedCatalog.filter(
+        (row) =>
+          row.billing_source === filters.billingSource &&
+          row.product_family === filters.productFamily &&
+          row.charge_type === filters.chargeType &&
+          filters.pairs.some(
+            (p) => p.provider === row.provider && p.model === row.model,
+          ),
+      ),
+    listActiveEntries: async (filters?: {
+      billingSource?: string;
+      provider?: string;
+      productFamily?: string;
+      chargeType?: string;
+    }) =>
+      seedCatalog.filter(
+        (row) =>
+          (!filters?.billingSource ||
+            row.billing_source === filters.billingSource) &&
+          (!filters?.provider || row.provider === filters.provider) &&
+          (!filters?.productFamily ||
+            row.product_family === filters.productFamily) &&
+          (!filters?.chargeType || row.charge_type === filters.chargeType),
+      ),
+  },
+}));
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog } = await import("./lookup");
+const { __clearPersistedPricingCache } = await import("./cache");
+
+beforeEach(() => {
+  __clearPersistedPricingCache();
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+});
+
+afterEach(() => {
+  delete process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M;
+  delete process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M;
+});
+
+test("catalogued current-generation models bill at their exact catalog rate", async () => {
+  // Expected values are Decimal-exact (catalog rate × 1M tokens, +20% markup),
+  // written as literals because JS float math (e.g. 3 * 1.2) drifts.
+  const cases = [
+    // [model, inputCost, outputCost, totalCost, baseTotalCost]
+    ["claude-opus-4-8", 6, 30, 36, 30],
+    ["claude-sonnet-5", 3.6, 18, 21.6, 18],
+    ["claude-haiku-4-5", 1.2, 6, 7.2, 6],
+  ] as const;
+
+  for (const [
+    model,
+    inputCost,
+    outputCost,
+    totalCost,
+    baseTotalCost,
+  ] of cases) {
+    const result = await calculateTextCostFromCatalog({
+      model,
+      provider: "anthropic",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+
+    expect(result.inputCost).toBe(inputCost);
+    expect(result.outputCost).toBe(outputCost);
+    expect(result.totalCost).toBe(totalCost);
+    expect(result.baseTotalCost).toBe(baseTotalCost);
+  }
+});
+
+test("unknown model from a catalogued provider bills at the provider's most expensive rate", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "claude-unknown-test-9",
+    provider: "anthropic",
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+  });
+
+  // Provider max = the $5/M-in $25/M-out entry. Never $0, never a throw.
+  expect(result.inputCost).toBe(5 * 1.2);
+  expect(result.outputCost).toBe(25 * 1.2);
+  expect(result.totalCost).toBe(30 * 1.2);
+  expect(result.totalCost).toBeGreaterThan(0);
+});
+
+test("reserve-style and settle-style calls resolve the same fallback rate", async () => {
+  // Pre-flight reserve estimates tokens; settle uses actual usage. Both flow
+  // through calculateTextCostFromCatalog, so the resolved rate must be equal.
+  const reserve = await calculateTextCostFromCatalog({
+    model: "claude-unknown-test-9",
+    provider: "anthropic",
+    inputTokens: 2_000,
+    outputTokens: 500,
+  });
+  const settle = await calculateTextCostFromCatalog({
+    model: "claude-unknown-test-9",
+    provider: "anthropic",
+    inputTokens: 1_234,
+    outputTokens: 987,
+  });
+
+  // Provider-max rate: $5/M input, $25/M output (Decimal-exact base costs).
+  expect(reserve.baseInputCost).toBe(0.01); // 2_000 × 5e-6
+  expect(reserve.baseOutputCost).toBe(0.0125); // 500 × 25e-6
+  expect(settle.baseInputCost).toBe(0.00617); // 1_234 × 5e-6
+  expect(settle.baseOutputCost).toBe(0.024675); // 987 × 25e-6
+});
+
+test("env-configured default applies when the provider has no catalogued entries", async () => {
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "2.5";
+  process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "10";
+
+  const result = await calculateTextCostFromCatalog({
+    model: "mystery-model-1",
+    provider: "someprovider",
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+  });
+
+  expect(result.baseInputCost).toBe(2.5);
+  expect(result.baseOutputCost).toBe(10);
+  expect(result.totalCost).toBe(12.5 * 1.2);
+});
+
+test("invalid env default is ignored (falls through to $0 last resort)", async () => {
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "not-a-number";
+  process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "-4";
+
+  const result = await calculateTextCostFromCatalog({
+    model: "mystery-model-1",
+    provider: "someprovider",
+    inputTokens: 1_000,
+    outputTokens: 1_000,
+  });
+
+  expect(result.totalCost).toBe(0);
+});
+
+test("no catalog and no env default keeps the request servable at $0", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "mystery-model-1",
+    provider: "someprovider",
+    inputTokens: 1_000,
+    outputTokens: 1_000,
+  });
+
+  expect(result.inputCost).toBe(0);
+  expect(result.outputCost).toBe(0);
+  expect(result.totalCost).toBe(0);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
@@ -10,14 +10,19 @@
  * model whose input row simply isn't catalogued yet.
  *
  * Both seams (persisted repo + live gateway) are mocked empty so EVERY lookup
- * misses — the worst case. The fix bills the missing side at $0 (mirroring the
- * existing output handling) instead of failing the request.
+ * misses — the worst case. With no provider catalog entries and no
+ * AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M env defaults, the last-resort
+ * behavior bills the missing side at $0 instead of failing the request.
+ * (When the provider HAS catalogued entries, or the env defaults are set, the
+ * miss bills at a conservative fallback rate instead — covered in
+ * lookup-fallback-pricing.test.ts.)
  */
 import { expect, mock, test } from "bun:test";
 
 mock.module("../../../db/repositories/ai-pricing", () => ({
   aiPricingRepository: {
     listActiveEntriesForProviderModelPairs: async () => [],
+    listActiveEntries: async () => [],
   },
 }));
 mock.module("./providers/gateway", () => ({

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -1,4 +1,3 @@
-import Decimal from "decimal.js";
 import { aiPricingRepository } from "../../../db/repositories/ai-pricing";
 import type { PricingDimensions } from "../../../db/schemas/ai-pricing";
 import { expandPersistedPricingProviderKeys } from "../../providers/model-id-translation";
@@ -157,6 +156,122 @@ async function resolvePreparedPricingEntry(params: {
   );
 }
 
+const FALLBACK_RATE_ENV_BY_CHARGE_TYPE: Record<"input" | "output", string> = {
+  input: "AI_PRICING_FALLBACK_INPUT_USD_PER_M",
+  output: "AI_PRICING_FALLBACK_OUTPUT_USD_PER_M",
+};
+
+/** Env-configured default rate (USD per million tokens) → per-token unit price. */
+function envFallbackTokenUnitPrice(chargeType: "input" | "output"): number | null {
+  const envName = FALLBACK_RATE_ENV_BY_CHARGE_TYPE[chargeType];
+  const raw = process.env[envName];
+  if (raw === undefined || raw.trim() === "") {
+    return null;
+  }
+  const usdPerMillion = Number(raw);
+  if (!Number.isFinite(usdPerMillion) || usdPerMillion < 0) {
+    logger.warn("ai-pricing: ignoring invalid fallback-rate env value", {
+      envName,
+      value: raw,
+    });
+    return null;
+  }
+  return usdPerMillion / 1_000_000;
+}
+
+type FallbackTokenRate = {
+  unitPrice: number;
+  source: "provider_max_catalog" | "env_default";
+  referenceModel?: string;
+};
+
+/**
+ * Conservative fallback rate for a servable model with no catalog row.
+ *
+ * A model id can be servable before its price lands in the catalog (newly
+ * released ids, catalog ingest lag). Failing the request at billing — or
+ * billing it at $0 — are both wrong: the first drops a servable request, the
+ * second under-bills. Instead, bill at the provider's MOST EXPENSIVE
+ * catalogued token rate for the same product family/charge type (an upper
+ * bound over any plausible real price from that provider), or an
+ * env-configured default (AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M) when
+ * the provider has no catalogued entries at all. Both reserve (pre-flight
+ * estimate) and settle (actual usage) resolve through this same path, so both
+ * sides of a request bill at the same rate.
+ */
+async function resolveFallbackTokenRate(params: {
+  billingSource?: PricingBillingSource;
+  provider: string;
+  canonicalModel: string;
+  productFamily: PricingProductFamily;
+  chargeType: "input" | "output";
+}): Promise<FallbackTokenRate | null> {
+  const logicalProvider = providerForPricingCandidate(params.canonicalModel, params.provider);
+  const providerKeys = expandPersistedPricingProviderKeys(logicalProvider);
+  const sources = normalizeBillingSourceCandidates(params.billingSource, params.provider);
+
+  let best: PreparedPricingEntry | null = null;
+  const consider = (entry: PreparedPricingEntry) => {
+    if (entry.unit !== "token") return;
+    if (!Number.isFinite(entry.unitPrice) || entry.unitPrice <= 0) return;
+    if (!best || entry.unitPrice > best.unitPrice) {
+      best = entry;
+    }
+  };
+
+  for (const source of sources) {
+    for (const providerKey of providerKeys) {
+      // Same short-TTL cache as the exact-model read: this runs on the billing
+      // hot path only when the exact lookup already missed.
+      const cacheKey = `fallback|${source ?? ""}|${params.productFamily}|${params.chargeType}|${providerKey}`;
+      const persisted = await getCachedPersistedEntries(cacheKey, () =>
+        aiPricingRepository.listActiveEntries({
+          billingSource: source,
+          provider: providerKey,
+          productFamily: params.productFamily,
+          chargeType: params.chargeType,
+        }),
+      ).catch((error: unknown) => {
+        logger.warn("ai-pricing: fallback catalog read failed", {
+          provider: providerKey,
+          billingSource: source,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [];
+      });
+      for (const row of persisted) {
+        consider(aiEntryToPrepared(row));
+      }
+    }
+
+    // Live catalog entries count too; fetchEntriesForSource degrades to [] on
+    // upstream failure and is cached, so this adds no new failure mode.
+    const live = await fetchEntriesForSource(source);
+    for (const entry of live) {
+      if (!providerKeys.includes(entry.provider)) continue;
+      if (entry.productFamily !== params.productFamily) continue;
+      if (entry.chargeType !== params.chargeType) continue;
+      consider(entry);
+    }
+  }
+
+  if (best !== null) {
+    const chosen: PreparedPricingEntry = best;
+    return {
+      unitPrice: chosen.unitPrice,
+      source: "provider_max_catalog",
+      referenceModel: chosen.model,
+    };
+  }
+
+  const envUnitPrice = envFallbackTokenUnitPrice(params.chargeType);
+  if (envUnitPrice !== null) {
+    return { unitPrice: envUnitPrice, source: "env_default" };
+  }
+
+  return null;
+}
+
 function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): FlatOperationCost {
   const baseCost = asDecimal(entry.unitPrice).mul(quantity);
   const markedUp = applyPlatformMarkup(baseCost);
@@ -220,42 +335,76 @@ export async function calculateTextCostFromCatalog(params: {
   outputTokens: number;
 }): Promise<TokenCostBreakdown> {
   const canonicalModel = canonicalModelId(params.model, params.provider);
+  const productFamily: PricingProductFamily = params.model.includes("embedding")
+    ? "embedding"
+    : "language";
   // Both lookups degrade to null on a catalog miss. A missing INPUT price used
   // to throw uncaught here (the OUTPUT lookup was already guarded), and the
   // throw propagated through calculateCost → the chat-completions reserve →
   // a 500 / masked "bridge unreachable" on any model whose input row isn't in
   // the catalog (notably embedding models, which are input-only and run every
-  // turn). Mirror the output handling — bill the missing side at $0 rather than
-  // failing the request — but log loudly so the catalog gap gets priced.
+  // turn). A servable request must never fail purely on a missing price — but
+  // it must not be under-billed at $0 either. On a miss, bill the missing side
+  // at a conservative fallback rate (provider max → env default → $0 last
+  // resort; see resolveFallbackTokenRate) and log loudly so the catalog gap
+  // gets priced.
   const inputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily,
     chargeType: "input",
   }).catch(() => null);
   const outputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily,
     chargeType: "output",
   }).catch(() => null);
 
-  if (!inputEntry) {
-    logger.warn("ai-pricing: input pricing unavailable; billing input at $0", {
+  // Resolve a fallback only for a side that actually bills tokens: a
+  // zero-token side costs $0 at any rate, and skipping it keeps input-only
+  // embedding traffic from warning on every turn about its unused output row.
+  const resolveMissingSide = async (
+    chargeType: "input" | "output",
+    tokens: number,
+  ): Promise<FallbackTokenRate | null> => {
+    if (tokens <= 0) {
+      return null;
+    }
+    const fallback = await resolveFallbackTokenRate({
+      billingSource: params.billingSource,
+      provider: params.provider,
+      canonicalModel,
+      productFamily,
+      chargeType,
+    });
+    logger.warn(`ai-pricing: ${chargeType} pricing unavailable; billing at fallback rate`, {
       canonicalModel,
       provider: params.provider,
       billingSource: params.billingSource,
+      fallbackSource: fallback?.source ?? "none_zero",
+      fallbackUnitPrice: fallback?.unitPrice ?? 0,
+      ...(fallback?.referenceModel ? { fallbackReferenceModel: fallback.referenceModel } : {}),
     });
-  }
+    return fallback;
+  };
 
-  const baseInputCost = inputEntry
-    ? asDecimal(inputEntry.unitPrice).mul(params.inputTokens)
-    : new Decimal(0);
-  const baseOutputCost = outputEntry
-    ? asDecimal(outputEntry.unitPrice).mul(params.outputTokens)
-    : new Decimal(0);
+  const inputFallback = inputEntry ? null : await resolveMissingSide("input", params.inputTokens);
+  const outputFallback = outputEntry
+    ? null
+    : await resolveMissingSide("output", params.outputTokens);
+
+  const inputUnitPrice = inputEntry
+    ? asDecimal(inputEntry.unitPrice)
+    : asDecimal(inputFallback?.unitPrice ?? 0);
+  const outputUnitPrice = outputEntry
+    ? asDecimal(outputEntry.unitPrice)
+    : asDecimal(outputFallback?.unitPrice ?? 0);
+
+  const baseInputCost = inputUnitPrice.mul(params.inputTokens);
+  const baseOutputCost = outputUnitPrice.mul(params.outputTokens);
 
   const inputTotals = applyPlatformMarkup(baseInputCost);
   const outputTotals = applyPlatformMarkup(baseOutputCost);


### PR DESCRIPTION
Closes #11532

## Problem

A chat request for any model id absent from the ai-pricing catalog fails or mis-bills at the billing pre-flight:

- `resolvePreparedPricingEntry` (`packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts`) throws `Pricing unavailable for <model>` on a catalog miss. The chat pre-flight (`packages/cloud/api/v1/chat/completions/route.ts` → `calculateCost` / `reserveCredits`) awaits that chain, so a servable request historically 500'd purely because its price wasn't catalogued yet — newly released ids, or current models during catalog ingest lag.
- Current `develop` catches the throw on the text path but degrades the missing side to **$0**, silently **under-billing** every uncatalogued-model request.

## Fix (generic — works for any unknown model id)

`calculateTextCostFromCatalog` now bills a catalog miss at a conservative fallback rate instead of $0, via `resolveFallbackTokenRate`:

1. **Provider max** — the provider's most expensive catalogued token rate for the same product family/charge type (persisted + live catalog, same provider-key expansion and billing-source candidates as the exact lookup). Upper bound over any plausible real price for that provider → never under-bills.
2. **Env default** — `AI_PRICING_FALLBACK_INPUT_USD_PER_M` / `AI_PRICING_FALLBACK_OUTPUT_USD_PER_M` (USD per million tokens) when the provider has no catalogued entries at all.
3. **$0 last resort** — no catalog, no env default: the request stays servable (unchanged prior behavior).

Every miss logs a warn with the resolved fallback source/rate (and reference model for provider-max) so ops can add the real price. Fallback resolution is skipped for a zero-token side, so input-only embedding traffic doesn't warn every turn about its unused output row.

**Catalogued models are untouched** — the exact-lookup path is byte-for-byte the same; the fallback only runs after both persisted and live lookups miss.

**Reserve/settle consistency** — both the pre-flight reserve (`reserveCredits` → `creditsService.reserve` → `calculateCost`) and the post-response settle (`billUsage` → `calculateCost`) resolve through `calculateTextCostFromCatalog`, so both sides of a request bill at the same fallback rate. The provider-wide fallback read reuses the same short-TTL persisted-pricing cache as the exact-model read.

## Verification

Confirmed pre-fix failure mode first (new test file on unmodified develop):

```
2 pass  4 fail   ← unknown id billed $0; env defaults ignored
```

Post-fix, `packages/cloud/shared`:

```
$ bun test src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts \
           src/lib/services/ai-pricing/lookup-missing-pricing.test.ts \
           src/lib/services/ai-pricing/openrouter-fallback.test.ts \
           src/lib/services/ai-pricing/cache.test.ts \
           src/lib/services/ai-pricing/dimensions.test.ts \
           src/lib/pricing.test.ts src/lib/pricing-reasoning-detection.test.ts \
           src/lib/promotion-pricing.test.ts \
           src/lib/services/ai-pricing-bitrouter-units.test.ts \
           src/lib/services/ai-pricing-variant-indexing.test.ts
 123 pass, 0 fail (274 expect() calls)

$ bun run typecheck   # tsgo --noEmit
 exit 0
```

New coverage (`lookup-fallback-pricing.test.ts`):

- current public models (`claude-opus-4-8`, `claude-sonnet-5`, `claude-haiku-4-5`) bill at their exact catalog rates — unchanged behavior locked in
- unknown id (`claude-unknown-test-9`) from a catalogued provider bills at the provider's most expensive rate (never $0, never throws)
- reserve-style (estimated tokens) and settle-style (actual tokens) calls resolve the same fallback rate
- env-configured default applies when the provider has no catalogued entries
- invalid env values are ignored; no-catalog + no-env stays servable at $0

Note: `gateway.test.ts` + `image-generation-pricing.test.ts` fail when the whole `ai-pricing/` dir runs in one `bun test` process on unmodified develop too (cross-file `mock.module` leakage; both pass in isolation) — pre-existing, not introduced here.
