### PR TITLE
feat(cloud-sdk): affiliateCode option sends X-Affiliate-Code on inference calls

### DIFF
--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -51,9 +51,11 @@ const checkout = await cloud.createAppCreditsCheckout({
 
 // 4. Run inference billed to the app's credits via the `appId` option
 //    (sends the `X-App-Id` header). Omit `appId` to bill the caller's own credits.
+//    Add `affiliateCode` to attribute the call to an affiliate for revenue share
+//    (sends `X-Affiliate-Code`; read by the credit-billed inference routes).
 const reply = await cloud.createChatCompletion(
   { model: "anthropic/claude-sonnet-4.5", messages: [{ role: "user", content: "hi" }] },
-  { appId: "app_123" },
+  { appId: "app_123", affiliateCode: "aff_xyz" },
 );
 ```
 
@@ -78,9 +80,12 @@ The generated URL is
 Use `/app-auth/authorize`; do not use `/authorize`.
 
 `waitForCliLogin(sessionId, { timeoutMs?, intervalMs?, signal? })` and the
-`{ appId }` option on `createChatCompletion` / `createResponse` /
-`createEmbeddings` / `generateImage` exist so browser apps don't have to
-hand-roll the polling loop or a raw `fetch` to send `X-App-Id`.
+`{ appId, affiliateCode }` options on `createChatCompletion` / `createResponse` /
+`createEmbeddings` / `generateImage` / `transcribeAudio` exist so browser apps
+don't have to hand-roll the polling loop or a raw `fetch` to send `X-App-Id` /
+`X-Affiliate-Code`. `appId` bills the app and credits the creator markup;
+`affiliateCode` credits the affiliate's revenue share. Both are per-call and
+sent only when set.
 
 > Browser note: `startCliLogin` / `pollCliLogin` are CORS-friendly (token auth,
 > no cookies). `pairWithToken` is server/agent-only — it sets an `Origin` header

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -399,6 +399,48 @@ describe("ElizaCloudClient web sign-in + app-credits affordances", () => {
     expect(requests[0].headers["x-app-id"]).toBeUndefined();
   });
 
+  it("sends X-Affiliate-Code (with X-App-Id) for affiliate revenue share", async () => {
+    const { client, requests } = createClientRecorder({
+      choices: [{ message: { role: "assistant", content: "hi" } }],
+    });
+
+    await client.createChatCompletion(
+      {
+        model: "anthropic/claude-sonnet-4.5",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { appId: "app-123", affiliateCode: "aff-xyz" },
+    );
+
+    expect(requests[0].headers["x-app-id"]).toBe("app-123");
+    expect(requests[0].headers["x-affiliate-code"]).toBe("aff-xyz");
+  });
+
+  it("sends X-Affiliate-Code without an appId", async () => {
+    const { client, requests } = createClientRecorder({ choices: [] });
+    await client.createChatCompletion(
+      {
+        model: "anthropic/claude-sonnet-4.5",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { affiliateCode: "aff-xyz" },
+    );
+    expect(requests[0].headers["x-app-id"]).toBeUndefined();
+    expect(requests[0].headers["x-affiliate-code"]).toBe("aff-xyz");
+  });
+
+  it("omits X-Affiliate-Code when no affiliateCode is given", async () => {
+    const { client, requests } = createClientRecorder({ choices: [] });
+    await client.createChatCompletion(
+      {
+        model: "anthropic/claude-sonnet-4.5",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { appId: "app-123" },
+    );
+    expect(requests[0].headers["x-affiliate-code"]).toBeUndefined();
+  });
+
   it("waitForCliLogin polls until authenticated and returns the key", async () => {
     const statuses = ["pending", "pending", "authenticated"];
     let call = 0;

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -192,13 +192,28 @@ export interface InferenceCallOptions {
    * the caller's own org/personal credits.
    */
   appId?: string;
+  /**
+   * Attribute this request to an affiliate for revenue share by sending the
+   * `X-Affiliate-Code` header. Read by the credit-billed inference routes
+   * (chat/completions, embeddings, voice); routes without affiliate billing
+   * ignore it. Omit when no affiliate applies.
+   */
+  affiliateCode?: string;
 }
 
-/** Build the request options that carry the `X-App-Id` header, if an app id is set. */
-function appIdRequestOptions(appId?: string): {
+/**
+ * Build the request headers for an inference call: `X-App-Id` (app billing +
+ * creator markup) and `X-Affiliate-Code` (affiliate revenue share). Each is
+ * sent only when set, so a plain call carries neither.
+ */
+function inferenceRequestOptions(options: InferenceCallOptions): {
   headers?: Record<string, string>;
 } {
-  return appId ? { headers: { "X-App-Id": appId } } : {};
+  const headers: Record<string, string> = {};
+  if (options.appId) headers["X-App-Id"] = options.appId;
+  if (options.affiliateCode)
+    headers["X-Affiliate-Code"] = options.affiliateCode;
+  return Object.keys(headers).length > 0 ? { headers } : {};
 }
 
 function withPathParams(
@@ -397,7 +412,7 @@ export class ElizaCloudClient {
     return this.v1.post<ResponsesCreateResponse>(
       "/responses",
       request,
-      appIdRequestOptions(options.appId),
+      inferenceRequestOptions(options),
     );
   }
 
@@ -408,7 +423,7 @@ export class ElizaCloudClient {
     return this.v1.post<ChatCompletionResponse>(
       "/chat/completions",
       request,
-      appIdRequestOptions(options.appId),
+      inferenceRequestOptions(options),
     );
   }
 
@@ -419,7 +434,7 @@ export class ElizaCloudClient {
     return this.v1.post<EmbeddingsResponse>(
       "/embeddings",
       request,
-      appIdRequestOptions(options.appId),
+      inferenceRequestOptions(options),
     );
   }
 
@@ -430,7 +445,7 @@ export class ElizaCloudClient {
     return this.v1.post<GenerateImageResponse>(
       "/generate-image",
       request,
-      appIdRequestOptions(options.appId),
+      inferenceRequestOptions(options),
     );
   }
 
@@ -453,7 +468,7 @@ export class ElizaCloudClient {
       form.append("languageCode", request.languageCode);
     }
     return this.v1.request<VoiceSttResponse>("POST", "/voice/stt", {
-      ...appIdRequestOptions(options.appId),
+      ...inferenceRequestOptions(options),
       body: form,
     });
   }


### PR DESCRIPTION
Closes #11537

## What

Adds an optional `affiliateCode` to `InferenceCallOptions` in `@elizaos/cloud-sdk`. When set, the SDK sends the `X-Affiliate-Code` header on `createResponse` / `createChatCompletion` / `createEmbeddings` / `generateImage` / `transcribeAudio` — the header the cloud API already reads for affiliate revenue share (`chat/completions/route.ts:1036`, `embeddings/route.ts:429`, `voice/stt/route.ts:275`, `messages/route.ts:608`, …) and that the CORS allow-list already permits (`cors-constants.ts:38`).

Before this, a monetized app had to hand-roll a raw `fetch` to attribute an inference call to an affiliate, even though the SDK ships affiliate-management methods (`getAffiliateCode` / `linkAffiliateCode`).

- `appIdRequestOptions(appId)` → `inferenceRequestOptions(options)` builds both `X-App-Id` and `X-Affiliate-Code`; each sent only when set, a plain call carries neither.
- README documents `affiliateCode` next to `appId`.
- Additive, backward-compatible: option is optional, no signature changes.

## Testing

```
$ bun run --cwd packages/cloud/sdk test
 65 pass, 19 skip, 0 fail (84 tests, 9 files)

$ bun test src/client.test.ts -t "Affiliate"
 3 pass, 0 fail
  - sends X-Affiliate-Code (with X-App-Id) for affiliate revenue share
  - sends X-Affiliate-Code without an appId
  - omits X-Affiliate-Code when no affiliateCode is given

$ bun run --cwd packages/cloud/sdk typecheck   # tsgo --noEmit: clean
$ bun run --cwd packages/cloud/sdk lint        # biome: 29 files, no fixes
```

## Evidence

- Unit tests assert the real header on the wire via the recorded fetch: with `affiliateCode` the request carries `x-affiliate-code`; without it, the header is absent (and `x-app-id` behavior is unchanged).
- Server-side reads verified on develop at the file:line references above — the SDK now emits exactly the header those routes read.
- N/A - screenshots/video: SDK-only change, no UI surface.
- N/A - model trajectories: no agent/prompt/model behavior change; pure HTTP client option.
