### PR TITLE
docs: document missing cloud env keys + eliza-code model provider guide

### DIFF
--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -135,6 +135,19 @@ CEREBRAS_API_KEY=your_cerebras_api_key_here
 # Get from: https://fal.ai/dashboard/keys
 # Format: "key_id:key_secret"
 FAL_KEY=your_fal_key_here
+# FAL_API_KEY is accepted as an alias for FAL_KEY by the image / video / music
+# generation routes. Set one of the two.
+# FAL_API_KEY=your_fal_key_here
+
+# AtlasCloud API Key — bills the gpt-image-2 / seedream / nano-banana-2 /
+# qwen-image image models (see ai-pricing-definitions.ts). Read by the v1
+# generate-image routes; only needed if you expose AtlasCloud-billed models.
+# ATLASCLOUD_API_KEY=your_atlascloud_key
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai
+
+# Birdeye API Key — token/market price data for the defi/price proxy handler.
+# Optional; the defi price proxy paths fail without it.
+# BIRDEYE_API_KEY=your_birdeye_key
 
 # ============================================================================
 # VOICE SERVICES
@@ -243,6 +256,20 @@ STRIPE_MEDIUM_PACK_PRICE_ID=price_xxx
 STRIPE_MEDIUM_PACK_PRODUCT_ID=prod_xxx
 STRIPE_LARGE_PACK_PRICE_ID=price_xxx
 STRIPE_LARGE_PACK_PRODUCT_ID=prod_xxx
+
+# ============================================================================
+# CRYPTO PAYMENTS (OxaPay)
+# ============================================================================
+# Merchant API key — required only if crypto checkout is enabled; invoice
+# creation and webhook verification both fail without it.
+# OXAPAY_MERCHANT_API_KEY=your_oxapay_merchant_key
+#
+# Optional comma-separated allowlist of OxaPay webhook source IPs.
+# OXAPAY_WEBHOOK_IPS=1.2.3.4,5.6.7.8
+#
+# Where OxaPay settles payment_request invoices. Defaults to
+# NEXT_PUBLIC_APP_URL + /api/v1/oxapay/webhook; set explicitly if that differs.
+# OXAPAY_PAYMENT_REQUESTS_CALLBACK_URL=https://your-cloud-host/api/v1/oxapay/webhook
 
 # ============================================================================
 # CACHE (For caching, rate limiting, SSE events, distributed locks)
@@ -858,6 +885,11 @@ ELIZA_APP_WHATSAPP_PHONE_NUMBER=
 # Create a dedicated org + user in the platform for this purpose.
 # WAIFU_SERVICE_ORG_ID=uuid-of-waifu-service-org
 # WAIFU_SERVICE_USER_ID=uuid-of-waifu-service-user
+#
+# Org that owns waifu-bridge-provisioned users. Bridge user provisioning fails
+# without it unless WAIFU_BRIDGE_ALLOW_ORG_AUTO_CREATE=true explicitly opts in
+# to auto-creating the org.
+# WAIFU_BRIDGE_ORG_ID=uuid-of-the-waifu-bridge-org
 #
 # Outbound webhooks + metering: Eliza Cloud -> waifu.fun credit/inference
 # receivers. These are SENT BY us (HMAC-signed over `timestamp.body`); the

--- a/packages/examples/code/MODEL_PROVIDERS.md
+++ b/packages/examples/code/MODEL_PROVIDERS.md
@@ -1,0 +1,89 @@
+# eliza-code model providers
+
+`eliza-code` (the `elizaos` coding sub-agent the orchestrator spawns over ACP)
+runs the eliza runtime, so its coding model is whatever model **provider** the
+runtime resolves at boot (`src/lib/model-provider.ts` → `resolveModelProvider`).
+You select the provider with env vars — no code change. Any
+**OpenAI-Chat-Completions-compatible** endpoint works out of the box.
+
+## How provider resolution works
+
+`resolveModelProvider(env)`:
+
+1. Explicit override: `ELIZA_CODE_PROVIDER` (or its alias
+   `ELIZA_CODE_MODEL_PROVIDER`) — `anthropic`/`claude` or `openai`/`codex`.
+2. Else auto-detect: `OPENAI_API_KEY` → `openai`; `ELIZA_OPENCODE_API_KEY` →
+   `openai`; `ANTHROPIC_API_KEY` → `anthropic`.
+
+`applyOpencodeProviderEnv(env)` maps the `ELIZA_OPENCODE_*` knobs onto the
+`OPENAI_*` ones the provider plugin reads (and pins
+`ELIZA_CODE_PROVIDER=openai` when it inherits the opencode key), so the
+orchestrator only has to forward `ELIZA_OPENCODE_*` to the spawned sub-agent
+(the `ELIZA_` prefix is on the forward allow-list). Explicit `OPENAI_*` values
+always win — the mapping only fills unset vars.
+
+| `ELIZA_OPENCODE_*` | maps to | meaning |
+|---|---|---|
+| `ELIZA_OPENCODE_BASE_URL` | `OPENAI_BASE_URL` | the API endpoint |
+| `ELIZA_OPENCODE_API_KEY` | `OPENAI_API_KEY` | bearer token |
+| `ELIZA_OPENCODE_MODEL_POWERFUL` | `OPENAI_LARGE_MODEL` | the "large" model id |
+| `ELIZA_OPENCODE_MODEL_FAST` | `OPENAI_SMALL_MODEL` / `OPENAI_MEDIUM_MODEL` | the "fast" model id |
+
+## Examples
+
+### Cerebras (fast, OpenAI-compatible)
+
+```bash
+ELIZA_OPENCODE_BASE_URL=https://api.cerebras.ai/v1
+ELIZA_OPENCODE_API_KEY=${CEREBRAS_API_KEY}
+ELIZA_OPENCODE_MODEL_POWERFUL=zai-glm-4.7
+ELIZA_OPENCODE_MODEL_FAST=zai-glm-4.7
+```
+
+### Surplus Intelligence (Claude / GPT / others via one OpenAI-compatible endpoint)
+
+[Surplus](https://surplusintelligence.ai) proxies many models (Claude Opus,
+GPT-5.x, Gemini, GLM, DeepSeek, …) behind one OpenAI-Chat-Completions endpoint,
+billed per-request via x402 micropayments. Because it speaks the OpenAI shape,
+eliza-code uses it with zero code change — just point the `ELIZA_OPENCODE_*`
+knobs at it:
+
+```bash
+ELIZA_OPENCODE_BASE_URL=https://api.surplusintelligence.ai/v1
+ELIZA_OPENCODE_API_KEY=${SURPLUS_API_KEY}        # an inf_... key
+ELIZA_OPENCODE_MODEL_POWERFUL=claude-opus-4.8     # e.g. claude-opus-4.8, gpt-5.5, …
+ELIZA_OPENCODE_MODEL_FAST=claude-opus-4.8
+```
+
+List available models: `GET https://api.surplusintelligence.ai/v1/models`.
+
+> Billing note: Surplus uses the **x402** payment protocol. A model call returns
+> `insufficient_balance` until the account is funded **and** `insufficient_allowance`
+> until the spending allowance is approved — both must be set in the Surplus
+> dashboard before requests succeed. Rate limit and auth are separate (a valid
+> `inf_` key still rate-limits independently of payment).
+
+### Direct Anthropic API
+
+```bash
+ELIZA_CODE_PROVIDER=anthropic
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}            # a real sk-ant-api... key
+# (optional) ANTHROPIC_LARGE_MODEL / ANTHROPIC_SMALL_MODEL
+```
+
+### Direct OpenAI API
+
+```bash
+OPENAI_API_KEY=${OPENAI_API_KEY}
+OPENAI_LARGE_MODEL=gpt-5.5
+OPENAI_SMALL_MODEL=gpt-5.5-mini
+```
+
+## Choosing the coding backend at the orchestrator level
+
+Which sub-agent the orchestrator spawns (and therefore whether eliza-code is
+used at all) is the **agent type**, set by `ELIZA_ACP_DEFAULT_AGENT`
+(`elizaos` = eliza-code, or `pi-agent` / `opencode` / `codex` / `claude`), or
+per-task via the resolver in `@elizaos/plugin-agent-orchestrator`
+(`src/services/task-agent-routing.ts`). The provider config above only applies
+when the `elizaos` (eliza-code) agent type is selected.


### PR DESCRIPTION
## What

Two small docs-only additions, zero runtime change:

1. **`packages/cloud/shared/.env.example`** — adds keys the cloud code reads but the example file never documented. Every key was verified against a current reader on `develop` before being added:
   - `FAL_API_KEY` — accepted as an alias for `FAL_KEY` (`packages/cloud/api/v1/generate-image/route.ts:143`, `generate-video/route.ts:68`, `generate-music/route.ts:85`, `fal-image-generation.ts:84`)
   - `ATLASCLOUD_API_KEY` / `ATLASCLOUD_BASE_URL` — read by the v1 generate-image routes (`generate-image/route.ts:140-141`, `atlascloud-image-generation.ts:79,115`); bills the gpt-image-2 / seedream / nano-banana-2 / qwen-image models per `ai-pricing-definitions.ts`
   - `BIRDEYE_API_KEY` — `proxy/birdeye-handler.ts:52` (defi/price proxy)
   - `OXAPAY_MERCHANT_API_KEY` / `OXAPAY_WEBHOOK_IPS` / `OXAPAY_PAYMENT_REQUESTS_CALLBACK_URL` — `payment-adapters/oxapay.ts:61,77,116`, `v1/oxapay/webhook/route.ts:42`; the adapter throws without the merchant key
   - `WAIFU_BRIDGE_ORG_ID` — `lib/auth/waifu-bridge.ts:102,144`; provisioning fails without it unless `WAIFU_BRIDGE_ALLOW_ORG_AUTO_CREATE=true`

2. **`packages/examples/code/MODEL_PROVIDERS.md`** — documents how eliza-code picks its coding model: `resolveModelProvider` / `applyOpencodeProviderEnv` (`packages/examples/code/src/lib/model-provider.ts`), the `ELIZA_OPENCODE_*` → `OPENAI_*` mapping, ready-to-use configs (Cerebras / Surplus / direct Anthropic / direct OpenAI), and the orchestrator-level agent-type selection (`ELIZA_ACP_DEFAULT_AGENT`, `task-agent-routing.ts`). README only names the file in a tree diagram today; nothing else documents this.

## What was deliberately dropped

- the multi-key rotation convention (`<NAME>_API_KEYS` / `_2`..`_16`): the resolver `getProviderKeys` exists in `provider-env.ts` but has **zero callers** on current develop — documenting it would describe dead code
- `WAIFU_WEBHOOK_SECRET` / `WAIFU_WEBHOOK_URL` / `WAIFU_API_BASE_URL` / `WAIFU_CORE_URL`: superseded by the canonical `ELIZA_CLOUD_*` names already documented in the file (WAIFU_* are deprecated migration aliases)

## Evidence

- every added key greps to a live reader (paths + lines above)
- all values in the diff are placeholders (`your_*_key`, `uuid-of-*`, example IPs/URLs) — no real secrets
- doc claims re-verified against current source: provider alias `ELIZA_CODE_MODEL_PROVIDER` + `claude`/`codex` values, `ELIZA_` env forward allow-list (`acp-service.ts:2683`), agent types (`tasks.ts:3256`)
- docs-only: no `.ts` touched, `bun run verify` not applicable to comment-only env example + a new markdown file

🤖 Generated with [Claude Code](https://claude.com/claude-code)