### PR TITLE
fix(cloud): conservative pricing fallback for uncatalogued models (#11532)

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #11532: an uncatalogued-but-servable model must never be UNDER-billed.
+ *
+ * When the exact pricing row is missing, `calculateTextCostFromCatalog` used to
+ * degrade the missing side to $0 — silently under-billing every request for a
+ * model absent from the catalog (new releases, ingest lag). The fix falls back
+ * to a CONSERVATIVE price instead: the provider's most expensive catalogued rate
+ * for the same family+chargeType (an upper bound that can only over-estimate),
+ * or the env default `AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M` when the
+ * provider has no rows at all. It only keeps $0 when neither source yields one.
+ *
+ * Both the pair lookup and the live gateway are mocked to MISS the requested
+ * model, so the fallback path is exercised end to end.
+ */
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+// The provider has OTHER catalogued language rows (not the requested model).
+// The fallback must select the MAX rate per charge type.
+const providerRows: Record<string, string[]> = {
+  input: ["0.000001", "0.000005"], // max input = 0.000005 /token
+  output: ["0.000010", "0.000030"], // max output = 0.000030 /token
+};
+
+function rawEntry(unitPrice: string, chargeType: string) {
+  return {
+    billing_source: "someprovider",
+    provider: "someprovider",
+    model: "some-other-catalogued-model",
+    product_family: "language",
+    charge_type: chargeType,
+    unit: "token",
+    unit_price: unitPrice,
+    dimensions: null,
+    source_kind: "test",
+    source_url: null,
+    fetched_at: null,
+    stale_after: null,
+    priority: 0,
+    is_override: false,
+    metadata: null,
+  };
+}
+
+let providerHasRows = true;
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    // The requested model is absent from both the pair lookup and the gateway.
+    listActiveEntriesForProviderModelPairs: async () => [],
+    // The provider-wide fallback query: rows only when providerHasRows.
+    listActiveEntries: async (f: { chargeType?: string }) =>
+      providerHasRows
+        ? (providerRows[f.chargeType ?? "input"] ?? []).map((p) =>
+            rawEntry(p, f.chargeType ?? "input"),
+          )
+        : [],
+  },
+}));
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog } = await import("./lookup");
+
+const ENV_KEYS = [
+  "AI_PRICING_FALLBACK_INPUT_USD_PER_M",
+  "AI_PRICING_FALLBACK_OUTPUT_USD_PER_M",
+] as const;
+
+beforeEach(() => {
+  providerHasRows = true;
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+afterEach(() => {
+  providerHasRows = true;
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+test("uncatalogued model bills at the provider's MAX catalogued rate, never $0 (#11532)", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "brand-new-unlisted-model",
+    provider: "someprovider",
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+  });
+
+  // base input = max input rate (0.000005) * 1e6 = 5 ; output = 0.000030 * 1e6 = 30
+  expect(result.baseInputCost).toBeCloseTo(5, 4);
+  expect(result.baseOutputCost).toBeCloseTo(30, 4);
+  // The whole point: NOT under-billed to $0.
+  expect(result.totalCost).toBeGreaterThan(0);
+});
+
+test("provider with zero catalogued rows falls back to the env default, never $0 (#11532)", async () => {
+  providerHasRows = false;
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "2"; // $2 / 1e6 tok = 0.000002/tok
+  process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "6"; // 0.000006/tok
+
+  const result = await calculateTextCostFromCatalog({
+    model: "unlisted-model",
+    provider: "provider-with-no-catalog",
+    inputTokens: 1_000_000,
+    outputTokens: 1_000_000,
+  });
+
+  expect(result.baseInputCost).toBeCloseTo(2, 4);
+  expect(result.baseOutputCost).toBeCloseTo(6, 4);
+  expect(result.totalCost).toBeGreaterThan(0);
+});
+
+test("no provider rows AND no env default → keeps the historical $0 (never fails the request)", async () => {
+  providerHasRows = false; // and no env set (beforeEach cleared it)
+
+  const result = await calculateTextCostFromCatalog({
+    model: "unlisted-model",
+    provider: "provider-with-no-catalog",
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  // Degrades to $0 rather than throwing — request stays servable.
+  expect(result.totalCost).toBe(0);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -212,6 +212,76 @@ function quantityForEntryUnit(
   }
 }
 
+/**
+ * Conservative per-token price for a token charge whose exact catalog row is
+ * missing (#11532). A servable request must never be *under-billed* just because
+ * its model id isn't catalogued yet (new releases, ingest lag). Order:
+ *
+ *   1. The provider's **most expensive** catalogued rate for the same
+ *      family+chargeType — an upper bound that can only over-estimate.
+ *   2. The env default `AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M`
+ *      (USD per million tokens → per-token) when the provider has no rows.
+ *
+ * Returns null only when neither source yields a positive price, in which case
+ * the caller keeps the historical $0 (logged loudly) rather than failing the
+ * request.
+ */
+async function resolveConservativeFallbackUnitPrice(params: {
+  billingSource?: PricingBillingSource;
+  provider: string;
+  productFamily: PricingProductFamily;
+  chargeType: "input" | "output";
+}): Promise<{ unitPrice: Decimal; source: string } | null> {
+  // 1) Provider's most-expensive catalogued rate for the same family+chargeType.
+  try {
+    const providerEntries = await aiPricingRepository.listActiveEntries({
+      billingSource: params.billingSource,
+      provider: params.provider,
+      productFamily: params.productFamily,
+      chargeType: params.chargeType,
+    });
+    let max: Decimal | null = null;
+    for (const raw of providerEntries) {
+      const price = asDecimal(aiEntryToPrepared(raw).unitPrice);
+      if (price.isFinite() && (!max || price.gt(max))) {
+        max = price;
+      }
+    }
+    if (max?.gt(0)) {
+      return { unitPrice: max, source: "provider-max" };
+    }
+  } catch (error) {
+    logger.warn("ai-pricing: provider-max fallback query failed", {
+      provider: params.provider,
+      productFamily: params.productFamily,
+      chargeType: params.chargeType,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // 2) Env-configured default (USD per million tokens → per-token).
+  const envKey =
+    params.chargeType === "input"
+      ? "AI_PRICING_FALLBACK_INPUT_USD_PER_M"
+      : "AI_PRICING_FALLBACK_OUTPUT_USD_PER_M";
+  const rawEnv = process.env[envKey]?.trim();
+  if (rawEnv) {
+    try {
+      const perMillion = new Decimal(rawEnv);
+      if (perMillion.isFinite() && perMillion.gt(0)) {
+        return { unitPrice: perMillion.div(1_000_000), source: envKey };
+      }
+    } catch {
+      logger.warn("ai-pricing: invalid pricing-fallback env value", {
+        envKey,
+        rawEnv,
+      });
+    }
+  }
+
+  return null;
+}
+
 export async function calculateTextCostFromCatalog(params: {
   model: string;
   provider: string;
@@ -220,6 +290,9 @@ export async function calculateTextCostFromCatalog(params: {
   outputTokens: number;
 }): Promise<TokenCostBreakdown> {
   const canonicalModel = canonicalModelId(params.model, params.provider);
+  const productFamily: PricingProductFamily = params.model.includes("embedding")
+    ? "embedding"
+    : "language";
   // Both lookups degrade to null on a catalog miss. A missing INPUT price used
   // to throw uncaught here (the OUTPUT lookup was already guarded), and the
   // throw propagated through calculateCost → the chat-completions reserve →
@@ -231,31 +304,72 @@ export async function calculateTextCostFromCatalog(params: {
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily,
     chargeType: "input",
   }).catch(() => null);
   const outputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily,
     chargeType: "output",
   }).catch(() => null);
 
+  // #11532: never under-bill a servable-but-uncatalogued model. On a miss, fall
+  // back to a conservative price (provider-max, else env default) instead of $0.
+  const inputFallback = inputEntry
+    ? null
+    : await resolveConservativeFallbackUnitPrice({
+        billingSource: params.billingSource,
+        provider: params.provider,
+        productFamily,
+        chargeType: "input",
+      });
+  const outputFallback = outputEntry
+    ? null
+    : await resolveConservativeFallbackUnitPrice({
+        billingSource: params.billingSource,
+        provider: params.provider,
+        productFamily,
+        chargeType: "output",
+      });
+
   if (!inputEntry) {
-    logger.warn("ai-pricing: input pricing unavailable; billing input at $0", {
-      canonicalModel,
-      provider: params.provider,
-      billingSource: params.billingSource,
-    });
+    logger.warn(
+      inputFallback
+        ? "ai-pricing: input pricing unavailable; using conservative fallback"
+        : "ai-pricing: input pricing unavailable and no fallback; billing input at $0",
+      {
+        canonicalModel,
+        provider: params.provider,
+        billingSource: params.billingSource,
+        fallbackSource: inputFallback?.source,
+      },
+    );
+  }
+  if (!outputEntry) {
+    logger.warn(
+      outputFallback
+        ? "ai-pricing: output pricing unavailable; using conservative fallback"
+        : "ai-pricing: output pricing unavailable and no fallback; billing output at $0",
+      {
+        canonicalModel,
+        provider: params.provider,
+        billingSource: params.billingSource,
+        fallbackSource: outputFallback?.source,
+      },
+    );
   }
 
-  const baseInputCost = inputEntry
-    ? asDecimal(inputEntry.unitPrice).mul(params.inputTokens)
-    : new Decimal(0);
-  const baseOutputCost = outputEntry
-    ? asDecimal(outputEntry.unitPrice).mul(params.outputTokens)
-    : new Decimal(0);
+  const inputUnitPrice = inputEntry
+    ? asDecimal(inputEntry.unitPrice)
+    : (inputFallback?.unitPrice ?? new Decimal(0));
+  const outputUnitPrice = outputEntry
+    ? asDecimal(outputEntry.unitPrice)
+    : (outputFallback?.unitPrice ?? new Decimal(0));
+
+  const baseInputCost = inputUnitPrice.mul(params.inputTokens);
+  const baseOutputCost = outputUnitPrice.mul(params.outputTokens);
 
   const inputTotals = applyPlatformMarkup(baseInputCost);
   const outputTotals = applyPlatformMarkup(baseOutputCost);


### PR DESCRIPTION
Fixes #11532 — money path, cc @lalalune.

## The under-bill bug

`calculateTextCostFromCatalog` (packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts) degraded **any catalog miss to $0**: when a servable model had no pricing row (brand-new releases, catalog ingest lag, provider aliases), both the input and output sides silently billed nothing. Every request for an uncatalogued model was free to the user while we paid the provider — a straight under-billing leak that scales with exactly the models people rush to try (new releases).

## The fix — conservative fallback, never under-bill

New `resolveConservativeFallbackUnitPrice`, threaded into `calculateTextCostFromCatalog`. On a miss for a charge type it now resolves, in order:

1. **Provider-max**: the provider's *most expensive* catalogued rate for the same `productFamily` + `chargeType` (via `aiPricingRepository.listActiveEntries`). An upper bound — it can only over-estimate, never under-bill.
2. **Env default**: `AI_PRICING_FALLBACK_INPUT_USD_PER_M` / `AI_PRICING_FALLBACK_OUTPUT_USD_PER_M` (USD per million tokens, converted to per-token) when the provider has no rows at all.
3. Only when **neither** yields a positive price does it keep the historical $0 — logged loudly with `fallbackSource` — so pricing never fails a servable request (preserves the #11532-adjacent guarantee the existing missing-pricing test asserts).

The warn logs now distinguish "using conservative fallback" (with the source) from "no fallback; billing at $0", so a true $0 degrade is visible and alertable.

## Test evidence

`packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts` (new) mocks the repo + gateway to MISS the requested model and asserts:

- uncatalogued model bills at the provider's **max** catalogued rate (input 0.000005/tok, output 0.000030/tok → base $5 / $30 on 1M tokens), total > $0
- provider with zero rows falls back to the **env defaults** ($2/M in, $6/M out → base $2 / $6), total > $0
- no rows AND no env → keeps the historical **$0 degrade** (request stays servable, never throws)

```
bun test src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
 5 pass
 0 fail
 12 expect() calls
Ran 5 tests across 2 files. [118.00ms]
```

Typecheck (`bun run --cwd packages/cloud/shared typecheck`): clean, zero errors in lookup.ts or the new test. Branch rebased onto current `origin/develop` (4dcb6d6dba).

Evidence notes: pure server-side billing-math change — no UI surface (screenshots/video N/A), no agent/prompt/model behavior change (trajectories N/A); the real path is exercised by the module-level tests above driving `calculateTextCostFromCatalog` end to end through the fallback resolver.

— nubs-cloud [cloud-frontdoor]