### PR TITLE
fix(examples/edad): complete oauth sign-in (code exchange) + read persisted history back

### DIFF
--- a/packages/examples/cloud/edad/README.md
+++ b/packages/examples/cloud/edad/README.md
@@ -7,22 +7,43 @@ Shipped live at **https://eliza.nubs.site/apps/edad/** by RemilioNubilio.
 ## Why this pattern exists
 
 - Keeps users on the miniapp's domain end-to-end (branding, UX continuity, embeddable elsewhere)
-- Users sign in to Eliza Cloud once and chat with their own org credit balance — no per-app credit pool to top up
-- App creator earns the inference markup % on every reply via `recordCreatorEarnings`; affiliate code adds a separate share
+- Users sign in with Eliza Cloud once; the app gets their **identity** (not a Cloud token) and mints its own session
+- App creator earns the inference markup % on every reply; the affiliate code adds a separate share
 - No character registration, no anonymous session management — lean proxy + minimal frontend
 
-## How it works
+## Auth & billing model (read this)
+
+Eliza Cloud's app OAuth returns a **single-use authorization code** (`eac_…`) on the
+redirect — never a durable user token. By design a third-party app can learn a
+user's *identity* but cannot hold their Cloud JWT. So this app:
+
+1. redeems the code **once, server-side**, at `GET /api/v1/app-auth/session` to get the user's identity, then
+2. mints its **own** signed session token (`app-session.ts`) the browser reuses, and
+3. proxies `/api/v1/messages` using the **app owner's** `ELIZAOS_CLOUD_API_KEY` (server-side only) plus `x-app-id` + `x-affiliate-code`.
+
+Because the call carries `x-app-id` for a monetization-enabled app, Cloud bills
+the app's **monetized credit pool** with the creator inference markup and credits
+the affiliate — the owner key never reaches the browser, and the single-use code
+is never reused.
 
 ```
-browser                                  app backend                         eliza cloud
-┌──────────────────┐                    ┌──────────────────┐                ┌───────────────────┐
-│ index.html       │ POST /api/messages │ server.ts        │ /api/v1/messages│ debits user's    │
-│ + chat UI JS     │───────────────────▶│ adds x-app-id    │───────────────▶│ org balance      │
-│                  │                    │ + x-affiliate-   │                │ adds markup → me │
-│ Steward JWT      │                    │   code header    │                │ creator earnings │
-│ (OAuth required) │                    │ + Authorization  │                │ + affiliate share│
-└──────────────────┘                    └──────────────────┘                └───────────────────┘
+browser                                  app backend                          eliza cloud
+┌──────────────────┐  POST /api/auth/    ┌──────────────────┐  GET /app-auth/   ┌───────────────────┐
+│ ?code=eac_… ─────┼─── exchange ───────▶│ redeem code →    │── session ───────▶│ consume code →    │
+│ (single-use)     │                     │ identity, mint   │   (Bearer code)   │ return identity   │
+│                  │                     │ app session      │◀──────────────────│                   │
+│ x-app-session ───┼── POST /api/messages▶│ owner key +      │  /api/v1/messages │ app-pool billing  │
+│ (our token)      │                     │ x-app-id + aff.  │── (owner bearer) ─▶│ + markup → creator│
+└──────────────────┘                     └──────────────────┘                   │ + affiliate share │
+                                                                                 └───────────────────┘
 ```
+
+> Note: a "user pays from their **own** org balance" variant would require the
+> app to present the user's Steward JWT, which the app-OAuth code flow
+> deliberately does not hand out. This template uses the supported app-credit-pool
+> path above. The full live OAuth round-trip needs a deployed app + a real Cloud
+> sign-in to exercise end to end; the session logic and auth gating are covered by
+> `test.ts`.
 
 ## Files
 
@@ -39,8 +60,10 @@ browser                                  app backend                         eli
 
 ```bash
 ELIZA_APP_ID=<uuid of app registered via POST /api/v1/apps>
+ELIZAOS_CLOUD_API_KEY=eliza_...     # the app OWNER's Cloud key — the server's upstream bearer (never sent to the browser)
 ELIZA_CLOUD_URL=https://www.elizacloud.ai
 ELIZA_AFFILIATE_CODE=AFF-XXXXXX     # your affiliate code — drives per-call affiliate share earnings
+EDAD_SESSION_SECRET=<random>        # OPTIONAL — signs app session tokens; defaults to ELIZAOS_CLOUD_API_KEY
 DATABASE_URL=postgres://...         # OPTIONAL — when set, chat history persists (see below)
 ```
 
@@ -55,9 +78,9 @@ silent no-op — the proxy runs stateless anywhere. This makes edad a single app
 that exercises the **whole** platform: monetized inference + container deploy +
 per-tenant DB + per-app auth + custom domain.
 
-There is **no operator-paid fallback**. The proxy rejects requests without a Steward JWT with 401. Reasoning:
+There is **no anonymous fallback**. The proxy rejects requests without a valid app session with 401 — users must sign in with Eliza Cloud first. Reasoning:
 
-- The whole point of monetization is that creators + affiliates earn a real cut of the *user's* credits. An operator-paid path bypassed that math entirely (the user "chats on the house" and nothing flows to anyone).
+- The whole point of monetization is that creators + affiliates earn a real cut of every billed reply. An anonymous path bypassed that math entirely (the user "chats on the house" and nothing is attributed to anyone).
 - One auth path is simpler to reason about than two; eliminates the awkward "chatting on the house" UI state.
 - Free-tier promo is better expressed as a welcome-credit grant on the user's org (cloud already does this — new orgs get $5 on first sync).
 
@@ -75,12 +98,12 @@ chat-in-place approach used here:
 | per-user character | no — the system prompt is sent per request |
 | cold-start friction | medium (OAuth sign-in required up front) |
 | monetization lever | `X-Affiliate-Code` header on every `/api/v1/messages` + creator markup % on the app |
-| existing users | chat right there with their own org credits |
+| existing users | chat right there after a one-click sign-in |
 | brand continuity | preserved (users never leave the app's domain) |
 
 A signup-funnel pattern trades brand continuity for lower cold-start friction
 (anonymous sessions, free intro messages); chat-in-place keeps users on a
-branded domain and bills their own org credits from the first message.
+branded domain and bills the app's monetized credit pool from the first message.
 
 ## Deploy checklist
 
@@ -89,9 +112,9 @@ branded domain and bills their own org credits from the first message.
 1. Register app via `POST https://www.elizacloud.ai/api/v1/apps` with `{ name, app_url, skipGitHubRepo: true }` → get `app_id` back
 2. (Optional) bump `inference_markup_percentage` on the app row to a value > 0 so you earn the markup share on every chat
 3. Go to https://www.elizacloud.ai/dashboard/affiliates → create affiliate code, set affiliate markup %
-4. Set `ELIZA_APP_ID` and `ELIZA_AFFILIATE_CODE` env vars on the host
+4. Set `ELIZA_APP_ID`, `ELIZAOS_CLOUD_API_KEY`, and `ELIZA_AFFILIATE_CODE` env vars on the host
 5. Run the bundled Bun server (`bun run server.ts`); it serves `public/` and the `/api/*` routes itself (no separate route handler to mount)
-6. Users hit your site → sign in with Eliza Cloud → chat → app creator earns markup; affiliate earns affiliate share; user spends their own org credits
+6. Users hit your site → sign in with Eliza Cloud → chat → app creator earns markup; affiliate earns affiliate share; billing hits the app's monetized credit pool
 
 ### Option B — standalone container on Eliza Cloud
 
@@ -126,10 +149,11 @@ curl -X POST https://www.elizacloud.ai/api/v1/containers \
     "port": 3000,
     "cpu": 256,
     "memory": 512,
-    "ecr_image_uri": "<account>.dkr.ecr.<region>.amazonaws.com/edad-chat:latest",
+    "image": "ghcr.io/<owner>/edad-chat:latest",
     "health_check_path": "/health",
     "environment_vars": {
       "ELIZA_APP_ID": "<your-app-uuid>",
+      "ELIZAOS_CLOUD_API_KEY": "<your-cloud-key>",
       "ELIZA_AFFILIATE_CODE": "<your-affiliate-code>",
       "ELIZA_CLOUD_URL": "https://www.elizacloud.ai"
     }

--- a/packages/examples/cloud/edad/app-session.ts
+++ b/packages/examples/cloud/edad/app-session.ts
@@ -1,0 +1,74 @@
+/**
+ * App-side session tokens for the edad reference app.
+ *
+ * Eliza Cloud's app OAuth flow returns a SINGLE-USE authorization code
+ * (`eac_…`) on the redirect, not a durable bearer. That code is redeemed ONCE,
+ * server-side, at `GET /api/v1/app-auth/session` (which consumes it and returns
+ * the signed-in user's identity). To keep the user signed in across requests
+ * without re-redeeming a spent code, the app mints its OWN short-lived session
+ * token here, signed with a server secret, and the browser presents it on each
+ * call. This token authenticates the user TO THIS APP; upstream inference is
+ * billed with the app owner's Cloud key + `x-app-id` (the app-credit-pool
+ * monetization path), never with this token.
+ *
+ * Format: `<base64url(JSON{uid,exp})>.<base64url(HMAC_SHA256(payload))>`.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const DEFAULT_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+
+function b64url(buf: Buffer | string): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function sign(payload: string, secret: string): string {
+  return b64url(createHmac("sha256", secret).update(payload).digest());
+}
+
+export function mintAppSession(
+  userId: string,
+  secret: string,
+  ttlMs: number = DEFAULT_TTL_MS,
+  nowMs: number = Date.now(),
+): string {
+  if (!secret) throw new Error("app session secret is required");
+  const payload = b64url(JSON.stringify({ uid: userId, exp: nowMs + ttlMs }));
+  return `${payload}.${sign(payload, secret)}`;
+}
+
+/**
+ * Verify a session token and return its userId, or null if it is malformed, has
+ * a bad signature, or is expired. Constant-time signature compare.
+ */
+export function verifyAppSession(
+  token: string | null | undefined,
+  secret: string,
+  nowMs: number = Date.now(),
+): string | null {
+  if (!token || !secret) return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const payload = token.slice(0, dot);
+  const provided = token.slice(dot + 1);
+  const expected = sign(payload, secret);
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64").toString("utf8"),
+    ) as { uid?: unknown; exp?: unknown };
+    if (typeof decoded.uid !== "string" || typeof decoded.exp !== "number") {
+      return null;
+    }
+    if (decoded.exp <= nowMs) return null;
+    return decoded.uid;
+  } catch {
+    return null;
+  }
+}

--- a/packages/examples/cloud/edad/public/index.html
+++ b/packages/examples/cloud/edad/public/index.html
@@ -135,8 +135,35 @@ function refreshAuthUI() {
   if (signedIn) {
     els.logoutBtn.textContent = "sign out";
     setNotice("");
+    loadHistory();
   } else if (cfg && !cfg.app_id) {
     setNotice("eDad isn't registered with eliza cloud yet. Tell the owner to set ELIZA_APP_ID.", "warn");
+  }
+}
+
+let historyLoaded = false;
+// Hydrate the chat with this user's persisted history once per sign-in. No-op
+// when the app has no DB (server returns an empty list) or already loaded.
+async function loadHistory() {
+  if (historyLoaded || !isSignedIn()) return;
+  historyLoaded = true;
+  try {
+    const res = await fetch(API_BASE + "/history/", {
+      headers: { "x-app-session": getToken() },
+    });
+    if (!res.ok) return;
+    const data = await res.json().catch(() => null);
+    const messages = data && Array.isArray(data.messages) ? data.messages : [];
+    for (const m of messages) {
+      if (!m || (m.role !== "user" && m.role !== "assistant")) continue;
+      const text = typeof m.content === "string" ? m.content : "";
+      if (!text) continue;
+      history.push({ role: m.role, content: text });
+      addMessage(m.role, text);
+    }
+  } catch {
+    // history is a nicety — never block the chat on a failed load.
+    historyLoaded = false;
   }
 }
 
@@ -183,9 +210,11 @@ async function loadConfig() {
   }
 }
 
-function handleOAuthCallback() {
+async function handleOAuthCallback() {
   const params = new URLSearchParams(location.search);
-  const token = params.get("token");
+  // Eliza Cloud redirects back with a SINGLE-USE authorization code (`code`),
+  // not a durable token. We redeem it once, server-side, for an app session.
+  const code = params.get("code");
   const state = params.get("state");
   const err = params.get("error");
 
@@ -195,25 +224,43 @@ function handleOAuthCallback() {
     return;
   }
 
-  if (!token) return;
+  if (!code) return;
 
   const expected = ss(STATE_KEY);
   ssSet(STATE_KEY, "");
+  // Strip the code from the URL immediately — it is single-use, so a reload
+  // must not try to redeem it again.
+  cleanUrl();
   if (!expected || state !== expected) {
     setNotice("sign-in failed: state mismatch. try again, champ.", "error");
-    cleanUrl();
     return;
   }
 
-  lsSet(TOKEN_KEY, token);
-  cleanUrl();
-  setNotice("signed in with eliza cloud. chat away.", "ok");
-  setTimeout(() => setNotice(""), 3500);
+  try {
+    const res = await fetch(API_BASE + "/auth/exchange", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data || !data.session) {
+      setNotice("sign-in didn't finish: " + ((data && data.error && data.error.message) || "try again"), "error");
+      return;
+    }
+    lsSet(TOKEN_KEY, data.session);
+    setNotice("signed in with eliza cloud. chat away.", "ok");
+    setTimeout(() => setNotice(""), 3500);
+    refreshAuthUI();
+  } catch {
+    setNotice("sign-in didn't finish — couldn't reach the server. try again.", "error");
+  }
 }
 
 function cleanUrl() {
   const url = new URL(location.href);
-  url.searchParams.delete("token");
+  // `code` is the single-use OAuth param Cloud redirects with — strip it so a
+  // reload can't try to redeem a spent code (and re-trigger a state error).
+  url.searchParams.delete("code");
   url.searchParams.delete("state");
   url.searchParams.delete("error");
   url.searchParams.delete("error_description");
@@ -239,6 +286,7 @@ function startLogin() {
 
 function logout() {
   lsSet(TOKEN_KEY, "");
+  historyLoaded = false;
   refreshAuthUI();
   setNotice("signed out.", "ok");
   setTimeout(() => setNotice(""), 2000);
@@ -260,7 +308,7 @@ async function send(text) {
   try {
     const headers = { "content-type": "application/json" };
     const token = getToken();
-    if (token) headers["x-user-token"] = token;
+    if (token) headers["x-app-session"] = token;
 
     const res = await fetch(API_BASE + "/messages/", {
       method: "POST",

--- a/packages/examples/cloud/edad/public/index.html
+++ b/packages/examples/cloud/edad/public/index.html
@@ -248,6 +248,7 @@ async function handleOAuthCallback() {
       return;
     }
     lsSet(TOKEN_KEY, data.session);
+    historyLoaded = false;
     setNotice("signed in with eliza cloud. chat away.", "ok");
     setTimeout(() => setNotice(""), 3500);
     refreshAuthUI();

--- a/packages/examples/cloud/edad/public/index.html
+++ b/packages/examples/cloud/edad/public/index.html
@@ -91,6 +91,8 @@ Tone rules:
 
 You are not a therapist and you're not a life coach. You're the dad who believed in them, now over text.`;
 
+const GREETING_TEXT = "well look who finally came around, champ. pull up a chair. what's on your mind?";
+
 const els = {
   messages: document.getElementById("messages"),
   composer: document.getElementById("composer"),
@@ -194,6 +196,12 @@ function addMessage(role, text) {
   return p;
 }
 
+function resetConversation() {
+  history.length = 0;
+  els.messages.innerHTML = "";
+  addMessage("assistant", GREETING_TEXT);
+}
+
 function randomState() {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
@@ -249,6 +257,7 @@ async function handleOAuthCallback() {
     }
     lsSet(TOKEN_KEY, data.session);
     historyLoaded = false;
+    resetConversation();
     setNotice("signed in with eliza cloud. chat away.", "ok");
     setTimeout(() => setNotice(""), 3500);
     refreshAuthUI();
@@ -288,6 +297,7 @@ function startLogin() {
 function logout() {
   lsSet(TOKEN_KEY, "");
   historyLoaded = false;
+  resetConversation();
   refreshAuthUI();
   setNotice("signed out.", "ok");
   setTimeout(() => setNotice(""), 2000);
@@ -332,7 +342,7 @@ async function send(text) {
       if (res.status === 401) {
         msg = "dad needs you to sign in with eliza cloud. click the button up top, kiddo.";
         // token might be expired — nuke it
-        if (getToken()) { lsSet(TOKEN_KEY, ""); refreshAuthUI(); }
+        if (getToken()) { lsSet(TOKEN_KEY, ""); resetConversation(); refreshAuthUI(); }
       }
       if (res.status === 402) msg = "dad's wallet is empty. top up at elizacloud.ai, champ.";
       placeholder.textContent = msg;

--- a/packages/examples/cloud/edad/server.ts
+++ b/packages/examples/cloud/edad/server.ts
@@ -5,21 +5,32 @@
  *   GET  /                  → public/index.html
  *   GET  /style.css, etc.   → public/* static
  *   GET  /api/config        → non-secret OAuth config (app_id, cloud_url)
+ *   POST /api/auth/exchange → redeem the OAuth `code`, mint an app session
  *   POST /api/messages      → forwarded to ELIZA_CLOUD_URL via @elizaos/cloud-sdk
+ *   GET  /api/history       → this user's persisted chat history
  *   GET  /health            → "ok" for ECS health probes
  *
- * Auth: the browser obtains a Steward JWT via OAuth and sends it on every
- * /api/messages call as `x-user-token`. The server forwards that as the
- * SDK's bearer token, so the upstream debits the signed-in user's org
- * credit balance — keeping the monetization story honest.
+ * Auth (the supported Eliza Cloud app-OAuth model):
+ *   1. The browser sends the user to `/app-auth/authorize`; Cloud redirects back
+ *      with a SINGLE-USE `code` (`eac_…`), not a durable token.
+ *   2. The browser POSTs that code to /api/auth/exchange ONCE. The server
+ *      redeems it server-side at `GET /api/v1/app-auth/session` (which consumes
+ *      the code and returns the user's identity), then mints its OWN signed app
+ *      session token (see app-session.ts) that the browser reuses thereafter.
+ *   3. /api/messages validates that app session (identifying the user) and
+ *      forwards upstream using the app OWNER's Cloud key (`ELIZAOS_CLOUD_API_KEY`)
+ *      plus `x-app-id` + `x-affiliate-code`. Billing therefore hits the app's
+ *      monetized credit pool (creator inference markup) and credits the
+ *      affiliate — the owner key never leaves the server.
  *
- * The SDK forwards `x-app-id` and `x-affiliate-code` as default headers
- * (when configured) so upstream attributes the inference markup to the
- * app creator and the affiliate share to the affiliate code holder.
+ * (An earlier version read a `?token=` param and forwarded it as the upstream
+ * bearer. Cloud never returns `token` and the redeemed code is single-use, so
+ * that flow could never complete a sign-in — this is the corrected design.)
  */
 
 import { join } from "node:path";
 import { CloudApiError, ElizaCloudClient } from "@elizaos/cloud-sdk";
+import { mintAppSession, verifyAppSession } from "./app-session.ts";
 import { dbReady, getHistory, initDb, saveTurn, userRef } from "./db.ts";
 
 const PORT = Number(process.env.PORT ?? 3000);
@@ -30,6 +41,13 @@ const CLOUD_URL = (
 ).replace(/\/+$/, "");
 const AFFILIATE_CODE = process.env.ELIZA_AFFILIATE_CODE ?? "";
 const APP_ID = process.env.ELIZA_APP_ID ?? "";
+// The app owner's Cloud key — used SERVER-SIDE only as the upstream bearer so
+// inference bills the app's monetized credit pool. Never sent to the browser.
+const OWNER_CLOUD_KEY =
+  process.env.ELIZAOS_CLOUD_API_KEY ?? process.env.ELIZA_CLOUD_API_KEY ?? "";
+// Secret for signing app session tokens. Defaults to the owner key so a single
+// configured secret suffices; set EDAD_SESSION_SECRET to rotate independently.
+const SESSION_SECRET = process.env.EDAD_SESSION_SECRET ?? OWNER_CLOUD_KEY;
 
 // Sticky headers attached to every upstream call. Empty values are
 // intentionally omitted: passing an unknown affiliate code makes upstream
@@ -89,11 +107,14 @@ function extractReplyText(result: unknown): string {
 
 async function forwardMessages(
   req: Request,
-  userToken: string,
+  userId: string,
 ): Promise<Response> {
+  // Upstream bearer is the app OWNER's Cloud key (server-side only). The signed
+  // app session already authenticated `userId` to this app; upstream billing
+  // goes to the app's monetized credit pool via STICKY_HEADERS' x-app-id.
   const cloud = new ElizaCloudClient({
     baseUrl: CLOUD_URL,
-    bearerToken: userToken,
+    bearerToken: OWNER_CLOUD_KEY,
     defaultHeaders: STICKY_HEADERS,
   });
 
@@ -104,7 +125,7 @@ async function forwardMessages(
     // across sessions. No-op when the app has no DB (see db.ts); wrapped so a
     // persistence error never affects the reply the user gets back.
     if (dbReady()) {
-      const ref = userRef(userToken);
+      const ref = userRef(userId);
       await saveTurn(ref, "user", extractUserText(json));
       await saveTurn(ref, "assistant", extractReplyText(result));
     }
@@ -142,8 +163,22 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
     );
   }
 
-  const userToken = req.headers.get("x-user-token")?.trim();
-  if (!userToken) {
+  // Redeem the single-use OAuth code for an app session. The code is consumed
+  // server-side (so a browser reload can't burn it) and we mint our own token.
+  if (
+    segments.length === 2 &&
+    segments[0] === "auth" &&
+    segments[1] === "exchange" &&
+    req.method === "POST"
+  ) {
+    return handleAuthExchange(req);
+  }
+
+  const userId = verifyAppSession(
+    req.headers.get("x-app-session")?.trim(),
+    SESSION_SECRET,
+  );
+  if (!userId) {
     return jsonError(
       401,
       "not_signed_in",
@@ -156,7 +191,7 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
     segments[0] === "messages" &&
     req.method === "POST"
   ) {
-    return forwardMessages(req, userToken);
+    return forwardMessages(req, userId);
   }
 
   // Signed-in user's persisted chat history from this app's per-tenant DB.
@@ -166,7 +201,7 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
     segments[0] === "history" &&
     req.method === "GET"
   ) {
-    const messages = dbReady() ? await getHistory(userRef(userToken)) : [];
+    const messages = dbReady() ? await getHistory(userRef(userId)) : [];
     return Response.json(
       { messages, db_enabled: dbReady() },
       { headers: { "cache-control": "no-store" } },
@@ -174,6 +209,76 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
   }
 
   return jsonError(404, "not_found", "unknown route");
+}
+
+/**
+ * POST /api/auth/exchange — body `{ code }`. Redeem the single-use `eac_` code
+ * at Cloud's `GET /api/v1/app-auth/session` (which consumes it and returns the
+ * user's identity), then mint a signed app session token for the browser.
+ */
+async function handleAuthExchange(req: Request): Promise<Response> {
+  if (!SESSION_SECRET || !APP_ID) {
+    return jsonError(
+      500,
+      "not_configured",
+      "this app is missing its Cloud key / app id — the operator must set ELIZAOS_CLOUD_API_KEY and ELIZA_APP_ID.",
+    );
+  }
+  let code = "";
+  try {
+    const body = (await req.json()) as { code?: unknown };
+    code = typeof body.code === "string" ? body.code.trim() : "";
+  } catch {
+    return jsonError(400, "bad_request", "expected a JSON body with `code`.");
+  }
+  if (!code) {
+    return jsonError(400, "missing_code", "no authorization code provided.");
+  }
+  let res: Response;
+  try {
+    res = await fetch(`${CLOUD_URL}/api/v1/app-auth/session`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${code}`, "x-app-id": APP_ID },
+    });
+  } catch {
+    return jsonError(
+      502,
+      "upstream_unreachable",
+      "couldn't reach eliza cloud to finish sign-in. try again in a sec.",
+    );
+  }
+  if (!res.ok) {
+    return jsonError(
+      401,
+      "exchange_failed",
+      "sign-in code was invalid or already used. try signing in again.",
+    );
+  }
+  const session = (await res.json().catch(() => null)) as {
+    user?: { id?: unknown; email?: unknown; name?: unknown };
+  } | null;
+  const userId =
+    session && typeof session.user?.id === "string" ? session.user.id : "";
+  if (!userId) {
+    return jsonError(
+      502,
+      "exchange_failed",
+      "cloud returned no user identity.",
+    );
+  }
+  return Response.json(
+    {
+      session: mintAppSession(userId, SESSION_SECRET),
+      user: {
+        id: userId,
+        email:
+          typeof session?.user?.email === "string" ? session.user.email : null,
+        name:
+          typeof session?.user?.name === "string" ? session.user.name : null,
+      },
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
 }
 
 async function serveStatic(

--- a/packages/examples/cloud/edad/server.ts
+++ b/packages/examples/cloud/edad/server.ts
@@ -217,7 +217,7 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
  * user's identity), then mint a signed app session token for the browser.
  */
 async function handleAuthExchange(req: Request): Promise<Response> {
-  if (!SESSION_SECRET || !APP_ID) {
+  if (!OWNER_CLOUD_KEY || !SESSION_SECRET || !APP_ID) {
     return jsonError(
       500,
       "not_configured",

--- a/packages/examples/cloud/edad/test.ts
+++ b/packages/examples/cloud/edad/test.ts
@@ -1,6 +1,8 @@
 const port = 30_000 + Math.floor(Math.random() * 10_000);
 const baseUrl = `http://127.0.0.1:${port}`;
 
+const SESSION_SECRET = "test-session-secret";
+
 const proc = Bun.spawn(["bun", "run", "server.ts"], {
   cwd: import.meta.dir,
   env: {
@@ -8,6 +10,8 @@ const proc = Bun.spawn(["bun", "run", "server.ts"], {
     ELIZA_AFFILIATE_CODE: "AFF-TEST",
     ELIZA_APP_ID: "00000000-0000-4000-8000-000000000000",
     ELIZA_CLOUD_URL: "https://elizacloud.ai",
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_owner_key",
+    EDAD_SESSION_SECRET: SESSION_SECRET,
     PORT: String(port),
   },
   stderr: "pipe",
@@ -78,6 +82,58 @@ try {
     body.cloud_url !== "https://elizacloud.ai"
   ) {
     throw new Error(`Unexpected config body: ${JSON.stringify(body)}`);
+  }
+
+  // ── App-session helper round-trip (pure, no network) ──────────────────────
+  const { mintAppSession, verifyAppSession } = await import("./app-session.ts");
+  const minted = mintAppSession("user-123", SESSION_SECRET);
+  if (verifyAppSession(minted, SESSION_SECRET) !== "user-123") {
+    throw new Error("app-session: valid token did not verify to its user id");
+  }
+  if (verifyAppSession(minted, "wrong-secret") !== null) {
+    throw new Error("app-session: token verified under the WRONG secret");
+  }
+  if (verifyAppSession(`${minted}tamper`, SESSION_SECRET) !== null) {
+    throw new Error("app-session: tampered token verified");
+  }
+  const expired = mintAppSession("u", SESSION_SECRET, -1);
+  if (verifyAppSession(expired, SESSION_SECRET) !== null) {
+    throw new Error("app-session: expired token verified");
+  }
+
+  // ── Auth gating: messages/history require a valid app session ──────────────
+  const noAuth = await fetch(`${baseUrl}/api/messages/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  if (noAuth.status !== 401) {
+    throw new Error(
+      `messages without a session should 401, got ${noAuth.status}`,
+    );
+  }
+  const forged = await fetch(`${baseUrl}/api/messages/`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-app-session": "forged.token",
+    },
+    body: "{}",
+  });
+  if (forged.status !== 401) {
+    throw new Error(
+      `messages with a forged session should 401, got ${forged.status}`,
+    );
+  }
+
+  // ── Exchange route: rejects a missing code (without contacting cloud) ──────
+  const noCode = await fetch(`${baseUrl}/api/auth/exchange`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  if (noCode.status !== 400) {
+    throw new Error(`exchange without a code should 400, got ${noCode.status}`);
   }
 
   console.log("eDad local smoke test passed");

--- a/packages/examples/cloud/edad/test.ts
+++ b/packages/examples/cloud/edad/test.ts
@@ -136,6 +136,64 @@ try {
     throw new Error(`exchange without a code should 400, got ${noCode.status}`);
   }
 
+  // ── Misconfiguration: a session secret alone must not enable sign-in ───────
+  const misconfiguredPort = port + 1;
+  const misconfiguredBaseUrl = `http://127.0.0.1:${misconfiguredPort}`;
+  const misconfigured = Bun.spawn(["bun", "run", "server.ts"], {
+    cwd: import.meta.dir,
+    env: {
+      ...process.env,
+      ELIZA_AFFILIATE_CODE: "AFF-TEST",
+      ELIZA_APP_ID: "00000000-0000-4000-8000-000000000000",
+      ELIZA_CLOUD_API_KEY: "",
+      ELIZA_CLOUD_URL: "https://elizacloud.ai",
+      ELIZAOS_CLOUD_API_KEY: "",
+      EDAD_SESSION_SECRET: SESSION_SECRET,
+      PORT: String(misconfiguredPort),
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const misconfiguredReaders = [
+    collect(misconfigured.stdout).catch(() => {}),
+    collect(misconfigured.stderr).catch(() => {}),
+  ];
+  try {
+    const misconfiguredStarted = Date.now();
+    let misconfiguredReady = false;
+    while (!misconfiguredReady && Date.now() - misconfiguredStarted < 10_000) {
+      try {
+        const health = await fetch(`${misconfiguredBaseUrl}/health`);
+        misconfiguredReady =
+          health.status === 200 && (await health.text()) === "ok";
+      } catch {
+        await Bun.sleep(100);
+      }
+    }
+    if (!misconfiguredReady) {
+      throw new Error(
+        `misconfigured eDad server did not start on ${misconfiguredBaseUrl}\n${output}`,
+      );
+    }
+    const noOwnerKey = await fetch(
+      `${misconfiguredBaseUrl}/api/auth/exchange`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code: "eac_test" }),
+      },
+    );
+    if (noOwnerKey.status !== 500) {
+      throw new Error(
+        `exchange without an owner Cloud key should 500, got ${noOwnerKey.status}`,
+      );
+    }
+  } finally {
+    misconfigured.kill();
+    await misconfigured.exited.catch(() => {});
+    await Promise.all(misconfiguredReaders);
+  }
+
   console.log("eDad local smoke test passed");
 } finally {
   proc.kill();

--- a/packages/examples/cloud/edad/test.ts
+++ b/packages/examples/cloud/edad/test.ts
@@ -1,16 +1,76 @@
 const port = 30_000 + Math.floor(Math.random() * 10_000);
 const baseUrl = `http://127.0.0.1:${port}`;
+const cloudPort = port + 2;
+const cloudBaseUrl = `http://127.0.0.1:${cloudPort}`;
 
 const SESSION_SECRET = "test-session-secret";
+const APP_ID = "00000000-0000-4000-8000-000000000000";
+const OWNER_KEY = "eliza_test_owner_key";
+const AFFILIATE_CODE = "AFF-TEST";
+
+const cloudRequests: Array<{
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}> = [];
+
+const fakeCloud = Bun.serve({
+  port: cloudPort,
+  hostname: "127.0.0.1",
+  async fetch(req) {
+    const url = new URL(req.url);
+    const headers = Object.fromEntries(req.headers.entries());
+    const record: {
+      path: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: unknown;
+    } = { path: url.pathname, method: req.method, headers };
+    cloudRequests.push(record);
+
+    if (url.pathname === "/api/v1/app-auth/session" && req.method === "GET") {
+      if (
+        req.headers.get("authorization") !== "Bearer eac_good" ||
+        req.headers.get("x-app-id") !== APP_ID
+      ) {
+        return Response.json({ error: "bad exchange" }, { status: 401 });
+      }
+      return Response.json({
+        user: {
+          id: "cloud-user-1",
+          email: "cloud-user@example.test",
+          name: "Cloud User",
+        },
+      });
+    }
+
+    if (url.pathname === "/api/v1/messages" && req.method === "POST") {
+      record.body = await req.json().catch(() => null);
+      if (
+        req.headers.get("authorization") !== `Bearer ${OWNER_KEY}` ||
+        req.headers.get("x-app-id") !== APP_ID ||
+        req.headers.get("x-affiliate-code") !== AFFILIATE_CODE
+      ) {
+        return Response.json({ error: "bad proxy headers" }, { status: 401 });
+      }
+      return Response.json({
+        content: [{ type: "text", text: "fake cloud reply" }],
+      });
+    }
+
+    return Response.json({ error: "not found" }, { status: 404 });
+  },
+});
 
 const proc = Bun.spawn(["bun", "run", "server.ts"], {
   cwd: import.meta.dir,
   env: {
     ...process.env,
-    ELIZA_AFFILIATE_CODE: "AFF-TEST",
-    ELIZA_APP_ID: "00000000-0000-4000-8000-000000000000",
-    ELIZA_CLOUD_URL: "https://elizacloud.ai",
-    ELIZAOS_CLOUD_API_KEY: "eliza_test_owner_key",
+    ELIZA_AFFILIATE_CODE: AFFILIATE_CODE,
+    ELIZA_APP_ID: APP_ID,
+    ELIZA_CLOUD_URL: cloudBaseUrl,
+    ELIZAOS_CLOUD_API_KEY: OWNER_KEY,
     EDAD_SESSION_SECRET: SESSION_SECRET,
     PORT: String(port),
   },
@@ -77,9 +137,9 @@ try {
   };
 
   if (
-    body.affiliate_code !== "AFF-TEST" ||
-    body.app_id !== "00000000-0000-4000-8000-000000000000" ||
-    body.cloud_url !== "https://elizacloud.ai"
+    body.affiliate_code !== AFFILIATE_CODE ||
+    body.app_id !== APP_ID ||
+    body.cloud_url !== cloudBaseUrl
   ) {
     throw new Error(`Unexpected config body: ${JSON.stringify(body)}`);
   }
@@ -136,6 +196,82 @@ try {
     throw new Error(`exchange without a code should 400, got ${noCode.status}`);
   }
 
+  // ── Successful OAuth code exchange mints an app session ───────────────────
+  const exchange = await fetch(`${baseUrl}/api/auth/exchange`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code: "eac_good" }),
+  });
+  if (exchange.status !== 200) {
+    throw new Error(
+      `exchange with a good code should 200, got ${exchange.status}`,
+    );
+  }
+  const exchanged = (await exchange.json()) as {
+    session?: string;
+    user?: { id?: string; email?: string | null; name?: string | null };
+  };
+  if (!exchanged.session || exchanged.user?.id !== "cloud-user-1") {
+    throw new Error(`unexpected exchange body: ${JSON.stringify(exchanged)}`);
+  }
+  if (verifyAppSession(exchanged.session, SESSION_SECRET) !== "cloud-user-1") {
+    throw new Error("exchange returned an app session that does not verify");
+  }
+  const sessionExchange = cloudRequests.find(
+    (r) => r.path === "/api/v1/app-auth/session",
+  );
+  if (
+    sessionExchange?.headers.authorization !== "Bearer eac_good" ||
+    sessionExchange.headers["x-app-id"] !== APP_ID
+  ) {
+    throw new Error(
+      `exchange did not call cloud with the expected headers: ${JSON.stringify(sessionExchange)}`,
+    );
+  }
+
+  const history = await fetch(`${baseUrl}/api/history/`, {
+    headers: { "x-app-session": exchanged.session },
+  });
+  if (history.status !== 200) {
+    throw new Error(
+      `history with a valid app session should 200, got ${history.status}`,
+    );
+  }
+
+  const message = await fetch(`${baseUrl}/api/messages/`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-app-session": exchanged.session,
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    }),
+  });
+  if (message.status !== 200) {
+    throw new Error(
+      `message with a valid app session should 200, got ${message.status}`,
+    );
+  }
+  const reply = (await message.json()) as {
+    content?: Array<{ text?: string }>;
+  };
+  if (reply.content?.[0]?.text !== "fake cloud reply") {
+    throw new Error(`unexpected message reply: ${JSON.stringify(reply)}`);
+  }
+  const upstreamMessage = cloudRequests.find(
+    (r) => r.path === "/api/v1/messages",
+  );
+  if (
+    upstreamMessage?.headers.authorization !== `Bearer ${OWNER_KEY}` ||
+    upstreamMessage.headers["x-app-id"] !== APP_ID ||
+    upstreamMessage.headers["x-affiliate-code"] !== AFFILIATE_CODE
+  ) {
+    throw new Error(
+      `message did not proxy with owner/app/affiliate headers: ${JSON.stringify(upstreamMessage)}`,
+    );
+  }
+
   // ── Misconfiguration: a session secret alone must not enable sign-in ───────
   const misconfiguredPort = port + 1;
   const misconfiguredBaseUrl = `http://127.0.0.1:${misconfiguredPort}`;
@@ -143,10 +279,10 @@ try {
     cwd: import.meta.dir,
     env: {
       ...process.env,
-      ELIZA_AFFILIATE_CODE: "AFF-TEST",
-      ELIZA_APP_ID: "00000000-0000-4000-8000-000000000000",
+      ELIZA_AFFILIATE_CODE: AFFILIATE_CODE,
+      ELIZA_APP_ID: APP_ID,
       ELIZA_CLOUD_API_KEY: "",
-      ELIZA_CLOUD_URL: "https://elizacloud.ai",
+      ELIZA_CLOUD_URL: cloudBaseUrl,
       ELIZAOS_CLOUD_API_KEY: "",
       EDAD_SESSION_SECRET: SESSION_SECRET,
       PORT: String(misconfiguredPort),
@@ -199,4 +335,5 @@ try {
   proc.kill();
   await proc.exited.catch(() => {});
   await Promise.all(outputReaders);
+  fakeCloud.stop(true);
 }


### PR DESCRIPTION
Closes #11541

## Problem

The edad reference monetized app (the template deploy guidance tells app builders to copy) had two dead paths:

1. **OAuth sign-in never completed.** The frontend read a `?token=` query param, but Eliza Cloud's app-OAuth redirect returns a single-use authorization code as `?code=` (an `eac_…` value), never a token. `handleOAuthCallback` early-returned on every real sign-in — and even if read, the single-use code can't authenticate `/api/v1/messages` (wrong auth class, consumed on first use). Every app built from this template inherited the dead auth loop.
2. **Persisted history was write-only.** `db.ts` saved every turn and `GET /api/history` served it, but the frontend never fetched it.

## Fix (the supported app-OAuth model, end to end)

- Frontend reads `?code=` + `?state=`, validates state, strips the single-use code from the URL immediately (so a reload can't re-redeem a spent code), and POSTs it once to a new `POST /api/auth/exchange` route. The exchange fetch uses the same relative `API_BASE` as every other call, so it works under a path prefix.
- The server redeems the code at Cloud's `GET /api/v1/app-auth/session` (public-allowlisted in `packages/cloud/api/src/middleware/auth.ts`; `looksLikeAppAuthCode` consumes the Bearer code and returns the user identity), then mints the app's OWN signed session token (`app-session.ts`: HMAC-SHA256, expiring, constant-time verify).
- `/api/messages` + `/api/history` authenticate that app session and proxy upstream with the app owner's `ELIZAOS_CLOUD_API_KEY` (server-side only) plus sticky `x-app-id` + `x-affiliate-code`, so billing hits the app's monetized credit pool with the creator markup + affiliate share. The owner key never reaches the browser; the single-use code is never reused.
- UI hydrates persisted history once per sign-in via `GET /api/history` (resets on sign-out; no-op without a DB).
- README reconciled to the implemented app-credit-pool model (it previously described an unbuildable "user pays from their own org" flow — that would need the user's Steward JWT, which the app-OAuth code flow deliberately does not hand a third-party app). Deploy curl fixed: `image` instead of `ecr_image_uri` (the route 400s on the latter) + the now-required `ELIZAOS_CLOUD_API_KEY` in the container env.

## Evidence

`test.ts` now covers the session helper (mint/verify/tamper/expiry) and auth gating (401 without/with a forged session, 400 on a code-less exchange):

```
$ bun run test
eDad local smoke test passed
$ bun run typecheck   # tsgo --noEmit
(clean)
$ biome check packages/examples/cloud/edad/
Checked 6 files. No fixes applied.
```

Param handling in the final code (no `?token=` reads remain):

```
public/index.html:217:  const code = params.get("code");
public/index.html:240:    const res = await fetch(API_BASE + "/auth/exchange", {
public/index.html:263:  url.searchParams.delete("code");
public/index.html:151:    const res = await fetch(API_BASE + "/history/", {
server.ts:239:    res = await fetch(`${CLOUD_URL}/api/v1/app-auth/session`, {
```

The full live OAuth round-trip needs a deployed app + a real Cloud sign-in; the redeem contract was verified against the current `v1/app-auth/session` route (single-use `eac_` Bearer → identity) and the auth-gate allowlist. N/A — screenshots/video: example app, no repo UI surface changed.
