### PR TITLE
feat(plugin-anthropic-proxy): export getStainlessHeaders + DEFAULT_TOOL_RENAMES/DEFAULT_REVERSE_MAP for programmatic use

### DIFF
--- a/plugins/plugin-anthropic-proxy/__tests__/entry-exports.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/entry-exports.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Guards the programmatic export surface requested in
+ * https://github.com/elizaOS/eliza/issues/11496 — downstream consumers embed
+ * the proxy's request-transformation pieces directly and need these reachable
+ * from the package entry (no deep imports, no vendored copies).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_REVERSE_MAP,
+  DEFAULT_TOOL_RENAMES,
+  getStainlessHeaders,
+} from "../index.js";
+
+describe("package entry exports (#11496)", () => {
+  it("exports getStainlessHeaders returning the CC identity header set", () => {
+    const headers = getStainlessHeaders();
+    expect(headers["user-agent"]).toMatch(/^claude-cli\//);
+    expect(headers["x-app"]).toBe("cli");
+    expect(headers["x-stainless-lang"]).toBe("js");
+    expect(headers["x-stainless-runtime"]).toBe("node");
+  });
+
+  it("exports the default fingerprint rename dictionaries", () => {
+    expect(DEFAULT_TOOL_RENAMES.length).toBeGreaterThan(0);
+    expect(DEFAULT_REVERSE_MAP.length).toBeGreaterThan(0);
+    for (const pair of DEFAULT_TOOL_RENAMES) {
+      expect(pair).toHaveLength(2);
+      expect(typeof pair[0]).toBe("string");
+      expect(typeof pair[1]).toBe("string");
+    }
+    for (const pair of DEFAULT_REVERSE_MAP) {
+      expect(pair).toHaveLength(2);
+      expect(typeof pair[0]).toBe("string");
+      expect(typeof pair[1]).toBe("string");
+    }
+  });
+});

--- a/plugins/plugin-anthropic-proxy/index.ts
+++ b/plugins/plugin-anthropic-proxy/index.ts
@@ -22,12 +22,17 @@ import {
 
 export { computeBillingFingerprint } from "./src/proxy/billing-fingerprint.js";
 export {
+  DEFAULT_REVERSE_MAP,
+  DEFAULT_TOOL_RENAMES,
+} from "./src/proxy/constants.js";
+export {
   type ProcessBodyConfig,
   processBody,
 } from "./src/proxy/process-body.js";
 export { reverseMap } from "./src/proxy/reverse-map.js";
 export type { ProxyServerOptions, ProxyStats } from "./src/proxy/server.js";
 export { ProxyServer } from "./src/proxy/server.js";
+export { getStainlessHeaders } from "./src/proxy/stainless-headers.js";
 export {
   ANTHROPIC_PROXY_SERVICE_NAME,
   AnthropicProxyService,


### PR DESCRIPTION
Closes #11496

## What

Re-export three request-transformation symbols from `@elizaos/plugin-anthropic-proxy`'s main entry (`index.ts`) so downstream consumers can import them programmatically instead of maintaining a vendored copy:

- `getStainlessHeaders` — from `src/proxy/stainless-headers.ts`
- `DEFAULT_TOOL_RENAMES`, `DEFAULT_REVERSE_MAP` — from `src/proxy/constants.ts`

## Why (scoping)

Per the maintainer's in-thread confirmation, the remaining ask was narrowed to exactly these three symbols:

> re-export `getStainlessHeaders` (from `src/proxy/stainless-headers.ts`) and `DEFAULT_TOOL_RENAMES` + `DEFAULT_REVERSE_MAP` (from `src/proxy/constants.ts`)

This unblocks @mcowger dropping their vendored copy. The `DEFAULT_*` maps alias the `ELIZA_*` fingerprint constants; the consumer asked for the `DEFAULT_*` names, so those are what we surface (their types — `ReadonlyArray<readonly [string, string]>` — flow through automatically; there is no named alias type to export). No restructuring beyond the added re-exports.

The plugin's `package.json` `.` export maps to `dist/node/index.node.js`, whose source entry `index.node.ts` does `export * from "./index"`, so the new re-exports are reachable from the published package root.

## Verification

- `bun run typecheck` — clean
- `bun run build` — Node + Browser + CJS + d.ts all emit
- `bun run test` — **8 files / 54 passed** (includes a new guard test `__tests__/entry-exports.test.ts` asserting the three symbols import from the package entry)
- Built-output import check against `dist/node/index.node.js` (ESM) and `dist/cjs/index.node.cjs` (CJS):
  ```
  ESM: {"getStainlessHeaders":"function","DEFAULT_TOOL_RENAMES":"array(18)","DEFAULT_REVERSE_MAP":"array(34)"}
  headers sample: claude-cli/2.1.97 (external, cli) | Linux
  CJS: function true true
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)