### PR TITLE
ci: pin bun off canary on the cloud test lanes (unhang hosted bun install)

### DIFF
--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -5,7 +5,11 @@ inputs:
   bun-version:
     description: Bun version to install (pinned to avoid GitHub API rate-limit flakes).
     required: false
-    default: "canary"
+    # pinned: floating canary hangs `bun install` on hosted CI runners and
+    # writes lockfileVersion 2 which breaks --frozen-lockfile (#11184/#9454).
+    # Cloud Tests + cloud-e2e call this action without an override, so this
+    # default is what actually runs on those (queue-starved) lanes.
+    default: "1.3.14"
   setup-db:
     description: Start PGlite TCP server and run migrations.
     required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ concurrency:
 
 env:
   CI: "true"
-  BUN_VERSION: "canary"
+  # pinned: floating canary hangs `bun install` on hosted CI runners and writes
+  # lockfileVersion 2 which breaks --frozen-lockfile (#11184/#9454). This env
+  # drives the integration/unit/lint/cloud-live-e2e jobs' bun-version input.
+  BUN_VERSION: "1.3.14"
   NODE_VERSION: "24.15.0"
   NODE_NO_WARNINGS: "1"
   NODE_OPTIONS: "--max-old-space-size=8192"


### PR DESCRIPTION
## What

Pins bun to `1.3.14` (off floating `canary`) on the two roots that drive the queue-starved cloud CI lanes — the #1 launch bottleneck flagged on #11157.

## Diagnosis (read-only, evidence on #11157)

The stuck lanes — **Cloud Tests**, **cloud-e2e**, and `test.yml`'s integration/unit/lint/cloud-live-e2e jobs — all park on `cloud-setup-test-env` → `bun install`. This is **not** the control plane and **not** the robot fleet:
- Stuck jobs' runner = `GitHub Actions <id>` (**hosted**), not `hetzner-robot`.
- `repos/elizaOS/eliza/actions/runners`: 22 hetzner-robots online, ~17 idle — fleet not degraded.
- Backlog is hosted-runner concurrency draining: jobs queued ~09:xxZ only picked up runners ~19:26–19:34Z (runs 28580797563 / 28580700499), then hang on the bun-install step.

Floating `canary` hangs `bun install` on hosted runners and writes lockfileVersion 2 that breaks `--frozen-lockfile` — the **known #11184 / #9454 issue**, already pinned to `1.3.14` in `ci.yaml` but never here.

## Change (2 roots, matching the existing ci.yaml pin + comment)

1. **`cloud-setup-test-env/action.yml`** default `canary` → `1.3.14`. Cloud Tests + cloud-e2e call this action **without** a `bun-version` override, so the action DEFAULT is what actually runs on those lanes.
2. **`test.yml`** env `BUN_VERSION: canary` → `1.3.14` (drives its jobs' `bun-version` input).

Deliberately scoped to the cloud test lanes. The broader `canary → pin` sweep across the other ~86 workflow files is a separate, lower-urgency change — not worth landing blind 2 days pre-launch.

Claimed on #11157.