### PR TITLE
fix(mobile-smoke): accept in-process bionic-host serving in the local-inference readiness gate (#11498)

### DIFF
--- a/packages/app/scripts/lib/local-inference-readiness.mjs
+++ b/packages/app/scripts/lib/local-inference-readiness.mjs
@@ -1,0 +1,53 @@
+// Pure readiness predicate for the mobile-local-chat-smoke full-turn gate.
+// Extracted from mobile-local-chat-smoke.mjs so the decision is unit-testable
+// (#11498). Takes the raw JSON snapshots from the three local-inference status
+// endpoints and decides whether a full turn can be served, and via which path.
+//
+// Ready when ANY of:
+//   1. hub.active.status === "ready"            (desktop/hub-activated model)
+//   2. device.connected && device.modelPath      (paired cross-process device)
+//   3. capacitor-llama provider servingVia === "bionic-host"
+//      (Android in-process GPU host: handlers bound via bionic-host AND the
+//      host socket accepts connections — surfaced by
+//      GET /api/local-inference/providers)
+//
+// hub.active.status === "error" is a hard failure, not "keep polling".
+
+/**
+ * @param {{ hub?: object|null, device?: object|null, providers?: object|null }} snapshot
+ * @returns {{ ready: boolean, via: "hub-active"|"device-bridge"|"bionic-host"|null, error: string|null }}
+ */
+export function evaluateLocalInferenceReadiness({ hub, device, providers }) {
+  const activeStatus = String(hub?.active?.status ?? "");
+  if (activeStatus === "error") {
+    const activeError = String(hub?.active?.error ?? "");
+    return {
+      ready: false,
+      via: null,
+      error: `Local inference hub is in error state: ${activeError || "unknown"}`,
+    };
+  }
+
+  if (activeStatus === "ready") {
+    return { ready: true, via: "hub-active", error: null };
+  }
+
+  const deviceConnected = device?.connected === true;
+  const deviceModelPath =
+    typeof device?.modelPath === "string" && device.modelPath.trim().length > 0;
+  if (deviceConnected && deviceModelPath) {
+    return { ready: true, via: "device-bridge", error: null };
+  }
+
+  const providerList = Array.isArray(providers?.providers)
+    ? providers.providers
+    : [];
+  const capacitorLlama = providerList.find(
+    (provider) => provider?.id === "capacitor-llama",
+  );
+  if (capacitorLlama?.servingVia === "bionic-host") {
+    return { ready: true, via: "bionic-host", error: null };
+  }
+
+  return { ready: false, via: null, error: null };
+}

--- a/packages/app/scripts/lib/local-inference-readiness.test.mjs
+++ b/packages/app/scripts/lib/local-inference-readiness.test.mjs
@@ -1,0 +1,107 @@
+// #11498: the mobile-local-chat-smoke readiness gate must accept the Android
+// in-process bionic-host serving path (capacitor-llama servingVia) alongside
+// the hub-active and paired-device-bridge branches — and still fail loudly
+// when nothing can serve.
+import { describe, expect, it } from "vitest";
+import { evaluateLocalInferenceReadiness } from "./local-inference-readiness.mjs";
+
+const capacitorLlama = (overrides = {}) => ({
+  id: "capacitor-llama",
+  servingVia: null,
+  ...overrides,
+});
+
+describe("evaluateLocalInferenceReadiness (#11498)", () => {
+  it("is NOT ready when every snapshot is missing (endpoints 404 on device)", () => {
+    expect(
+      evaluateLocalInferenceReadiness({ hub: null, device: null, providers: null }),
+    ).toEqual({ ready: false, via: null, error: null });
+  });
+
+  it("accepts hub.active.status === 'ready' (desktop hub activation)", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: { active: { status: "ready" } },
+      device: null,
+      providers: null,
+    });
+    expect(result).toEqual({ ready: true, via: "hub-active", error: null });
+  });
+
+  it("accepts a paired device bridge with a loaded model path", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: { active: { status: "idle" } },
+      device: { connected: true, modelPath: "/data/models/eliza-1-2b.gguf" },
+      providers: null,
+    });
+    expect(result).toEqual({ ready: true, via: "device-bridge", error: null });
+  });
+
+  it("rejects a connected device bridge without a model path", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: null,
+      device: { connected: true, modelPath: "   " },
+      providers: null,
+    });
+    expect(result.ready).toBe(false);
+  });
+
+  it("accepts the in-process bionic-host serving signal (the #11498 path)", () => {
+    // Exact on-device shape: hub idle, device disconnected, bionic serving.
+    const result = evaluateLocalInferenceReadiness({
+      hub: { active: { status: "idle" } },
+      device: { connected: false, modelPath: null },
+      providers: {
+        providers: [capacitorLlama({ servingVia: "bionic-host" })],
+      },
+    });
+    expect(result).toEqual({ ready: true, via: "bionic-host", error: null });
+  });
+
+  it("does NOT treat a present-but-not-serving capacitor-llama provider as ready", () => {
+    for (const servingVia of [null, undefined, "device-bridge"]) {
+      const result = evaluateLocalInferenceReadiness({
+        hub: { active: { status: "idle" } },
+        device: { connected: false },
+        providers: { providers: [capacitorLlama({ servingVia })] },
+      });
+      // servingVia==="device-bridge" implies device.connected, which the
+      // device snapshot above contradicts — the gate keys on the device
+      // branch for that path, so this stays not-ready.
+      expect(result.ready).toBe(false);
+    }
+  });
+
+  it("ignores servingVia on providers other than capacitor-llama", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: null,
+      device: null,
+      providers: {
+        providers: [{ id: "eliza-local-inference", servingVia: "bionic-host" }],
+      },
+    });
+    expect(result.ready).toBe(false);
+  });
+
+  it("surfaces hub error state as a hard failure, not keep-polling", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: { active: { status: "error", error: "bundle_dir does not exist" } },
+      device: null,
+      providers: {
+        providers: [capacitorLlama({ servingVia: "bionic-host" })],
+      },
+    });
+    expect(result.ready).toBe(false);
+    expect(result.error).toBe(
+      "Local inference hub is in error state: bundle_dir does not exist",
+    );
+  });
+
+  it("hub error without a message reports 'unknown'", () => {
+    const result = evaluateLocalInferenceReadiness({
+      hub: { active: { status: "error" } },
+      device: null,
+      providers: null,
+    });
+    expect(result.error).toBe("Local inference hub is in error state: unknown");
+  });
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { evaluateLocalInferenceReadiness } from "./lib/local-inference-readiness.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -2214,21 +2215,22 @@ async function requireLocalInferenceReady(baseUrl, authToken) {
 
     lastSnapshot = localInferenceSummary({ hub, device, providers });
 
-    const activeStatus = String(hub?.active?.status ?? "");
-    const activeError = String(hub?.active?.error ?? "");
-    if (activeStatus === "error") {
-      throw new Error(
-        `Local inference hub is in error state: ${activeError || "unknown"}`,
-      );
+    // Three accepted serving paths (see local-inference-readiness.mjs):
+    // hub-active (desktop), device-bridge (paired cross-process device), and
+    // bionic-host (Android in-process GPU host, #11498). Anything else keeps
+    // polling and fails loudly after the attempt budget.
+    const readiness = evaluateLocalInferenceReadiness({
+      hub,
+      device,
+      providers,
+    });
+    if (readiness.error) {
+      throw new Error(readiness.error);
     }
-
-    const activeReady = activeStatus === "ready";
-    const deviceConnected = device?.connected === true;
-    const deviceModelPath =
-      typeof device?.modelPath === "string" &&
-      device.modelPath.trim().length > 0;
-
-    if (activeReady || (deviceConnected && deviceModelPath)) {
+    if (readiness.ready) {
+      console.log(
+        `[local-chat-smoke] Local inference ready via ${readiness.via}.`,
+      );
       return { hub, device, providers };
     }
 

--- a/packages/shared/src/local-inference/providers-types.ts
+++ b/packages/shared/src/local-inference/providers-types.ts
@@ -76,4 +76,13 @@ export interface ProviderStatus {
   enableState: ProviderEnableState;
   /** Registered model types this provider has handlers for, right now. */
   registeredSlots: string[];
+  /**
+   * capacitor-llama only: which live path serves the handlers right now.
+   * "bionic-host" is the in-process Android GPU host (handlers bound via
+   * bionic-host AND the host socket accepts connections); "device-bridge" is
+   * a paired cross-process device; null/absent = nothing can serve (#11498).
+   */
+  servingVia?: "bionic-host" | "device-bridge" | null;
+  /** capacitor-llama only: the trigger that bound the handlers, if any. */
+  registeredTrigger?: "bionic-host" | "device-bridge" | null;
 }

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
@@ -1,0 +1,120 @@
+// #11498: getMobileDeviceBridgeServingStatus must report the in-process
+// bionic host as serving ONLY when the capacitor-llama handlers were actually
+// bound via the bionic-host trigger AND the host's abstract UDS accepts a
+// connection right now — never from env configuration or plugin presence
+// alone. This is the signal the mobile-local-chat-smoke readiness gate and
+// GET /api/local-inference/providers (servingVia) rely on.
+import net from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// SERVICE_ENABLED is read at module load, so enable the bridge before importing.
+process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+
+const ENV_KEYS = [
+	"ELIZA_LOCAL_LLAMA",
+	"ELIZA_BIONIC_HOST_DELEGATED",
+	"ELIZA_BIONIC_INFERENCE_SOCK",
+	"ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD",
+];
+const saved: Record<string, string | undefined> = {};
+
+function fakeRuntime() {
+	return {
+		registerModel: vi.fn(),
+		getModel: vi.fn(() => undefined),
+	};
+}
+
+/** Fresh module instance so registeredModelTrigger starts null per test. */
+async function freshBootstrap() {
+	vi.resetModules();
+	process.env.ELIZA_DEVICE_BRIDGE_ENABLED = "1";
+	return import("./mobile-device-bridge-bootstrap");
+}
+
+/** Listen on the Linux abstract-namespace UDS the bionic host would own. */
+function listenOnAbstractSocket(name: string): Promise<net.Server> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer((socket) => socket.destroy());
+		server.on("error", reject);
+		server.listen({ path: `\0${name}` }, () => resolve(server));
+	});
+}
+
+function closeServer(server: net.Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("getMobileDeviceBridgeServingStatus — true bionic serving signal (#11498)", () => {
+	beforeEach(() => {
+		for (const k of ENV_KEYS) {
+			saved[k] = process.env[k];
+			delete process.env[k];
+		}
+		// Registration pre-warms model downloads; keep the unit test offline.
+		process.env.ELIZA_DISABLE_MODEL_AUTO_DOWNLOAD = "1";
+	});
+	afterEach(() => {
+		for (const k of ENV_KEYS) {
+			if (saved[k] === undefined) delete process.env[k];
+			else process.env[k] = saved[k];
+		}
+	});
+
+	it("reports nothing serving before any handler registration", async () => {
+		const mod = await freshBootstrap();
+		const status = await mod.getMobileDeviceBridgeServingStatus();
+		expect(status).toEqual({
+			registeredTrigger: null,
+			bionicHostServing: false,
+		});
+	});
+
+	it("bionic env set + live socket but handlers NOT registered is NOT serving", async () => {
+		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-unreg";
+		const server = await listenOnAbstractSocket("eliza-test-serving-unreg");
+		try {
+			const mod = await freshBootstrap();
+			const status = await mod.getMobileDeviceBridgeServingStatus();
+			expect(status.registeredTrigger).toBeNull();
+			expect(status.bionicHostServing).toBe(false);
+		} finally {
+			await closeServer(server);
+		}
+	});
+
+	it("handlers bound via bionic-host AND a live host socket IS serving", async () => {
+		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-live";
+		const server = await listenOnAbstractSocket("eliza-test-serving-live");
+		try {
+			const mod = await freshBootstrap();
+			const runtime = fakeRuntime();
+			await expect(
+				mod.ensureMobileDeviceBridgeInferenceHandlers(runtime as never),
+			).resolves.toBe(true);
+			const status = await mod.getMobileDeviceBridgeServingStatus();
+			expect(status).toEqual({
+				registeredTrigger: "bionic-host",
+				bionicHostServing: true,
+			});
+		} finally {
+			await closeServer(server);
+		}
+	});
+
+	it("handlers bound via bionic-host but the host socket is DOWN is NOT serving", async () => {
+		process.env.ELIZA_BIONIC_HOST_DELEGATED = "1";
+		process.env.ELIZA_BIONIC_INFERENCE_SOCK = "eliza-test-serving-dead";
+		// Nothing listens on the socket: the probe must fail, not larp readiness.
+		const mod = await freshBootstrap();
+		const runtime = fakeRuntime();
+		await expect(
+			mod.ensureMobileDeviceBridgeInferenceHandlers(runtime as never),
+		).resolves.toBe(true);
+		const status = await mod.getMobileDeviceBridgeServingStatus();
+		expect(status.registeredTrigger).toBe("bionic-host");
+		expect(status.bionicHostServing).toBe(false);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -46,6 +46,13 @@ const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const DEFAULT_LOAD_TIMEOUT_MS = DEFAULT_NATIVE_REQUEST_TIMEOUT_MS;
 const SERVICE_ENABLED = process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1";
 const registeredRuntimes = new WeakSet<AgentRuntime>();
+/**
+ * The trigger that actually bound the capacitor-llama handlers, or null while
+ * nothing registered them. "bionic-host" is the true in-process serving signal
+ * the readiness surfaces key on (#11498): it is set ONLY by
+ * registerMobileDeviceBridgeModels, never by mere plugin presence.
+ */
+let registeredModelTrigger: "bionic-host" | "device-bridge" | null = null;
 const KNOWN_EMBEDDING_DIMENSIONS: Record<string, number> = {
 	"eliza-1-embedding": 1024,
 	// 2B reuses the text backbone for embeddings (--pooling last), so its dim is the
@@ -1720,6 +1727,53 @@ export function getMobileDeviceBridgeStatus(): MobileDeviceBridgeStatus {
 	return mobileDeviceBridge.status();
 }
 
+export interface MobileDeviceBridgeServingStatus {
+	/** Which path bound the capacitor-llama handlers (null = not registered). */
+	registeredTrigger: "bionic-host" | "device-bridge" | null;
+	/**
+	 * True ONLY when the handlers were bound via the in-process bionic host
+	 * AND its abstract UDS accepts a connection right now — i.e. the host can
+	 * actually serve a generate/embed call (#11498). Never true from mere
+	 * plugin presence or env configuration alone.
+	 */
+	bionicHostServing: boolean;
+}
+
+const BIONIC_PROBE_TIMEOUT_MS = readTimeoutMs(
+	"ELIZA_BIONIC_PROBE_TIMEOUT_MS",
+	2_000,
+);
+
+/** True when the bionic host's abstract UDS accepts a connection right now. */
+function probeBionicHostSocket(socketName: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const sock = net.connect({ path: `\0${socketName}` });
+		const finish = (ok: boolean) => {
+			clearTimeout(timer);
+			sock.destroy();
+			resolve(ok);
+		};
+		const timer = setTimeout(() => finish(false), BIONIC_PROBE_TIMEOUT_MS);
+		sock.on("connect", () => finish(true));
+		sock.on("error", () => finish(false));
+	});
+}
+
+/**
+ * The true "in-process bionic host can serve" signal for readiness surfaces
+ * (GET /api/local-inference/providers → capacitor-llama.servingVia). The
+ * mobile-local-chat-smoke readiness gate accepts this as its third branch
+ * alongside hub.active.status==="ready" and device.connected (#11498).
+ */
+export async function getMobileDeviceBridgeServingStatus(): Promise<MobileDeviceBridgeServingStatus> {
+	const socketName = bionicSocketName();
+	const bionicHostServing =
+		registeredModelTrigger === "bionic-host" &&
+		socketName !== null &&
+		(await probeBionicHostSocket(socketName));
+	return { registeredTrigger: registeredModelTrigger, bionicHostServing };
+}
+
 export async function loadMobileDeviceBridgeModel(
 	modelPath: string,
 	modelId?: string,
@@ -1946,6 +2000,7 @@ function registerMobileDeviceBridgeModels(
 		`[mobile-device-bridge] Registered ${PROVIDER} handlers for TEXT_SMALL / TEXT_LARGE${embeddingModelPath ? " / TEXT_EMBEDDING" : ""} at priority ${LOCAL_INFERENCE_PRIORITY} (via ${trigger})`,
 	);
 	registeredRuntimes.add(runtime);
+	registeredModelTrigger = trigger;
 	return true;
 }
 

--- a/plugins/plugin-local-inference/src/local-inference-routes.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.test.ts
@@ -19,6 +19,12 @@ function freshActiveState() {
 
 function createRouteTestMocks() {
 	const state = { active: freshActiveState() };
+	const servingState = {
+		status: {
+			registeredTrigger: null as "bionic-host" | "device-bridge" | null,
+			bionicHostServing: false,
+		},
+	};
 	return {
 		bridgeMock: {
 			getMobileDeviceBridgeStatus: vi.fn(() => ({
@@ -26,6 +32,12 @@ function createRouteTestMocks() {
 				connected: false,
 				devices: [],
 			})),
+			getMobileDeviceBridgeServingStatus: vi.fn(async () => ({
+				...servingState.status,
+			})),
+			setServingStatus: (status: (typeof servingState)["status"]) => {
+				servingState.status = status;
+			},
 			loadMobileDeviceBridgeModel: vi.fn(),
 			unloadMobileDeviceBridgeModel: vi.fn(),
 		},
@@ -110,6 +122,22 @@ vi.mock("@elizaos/plugin-capacitor-bridge", () => ({
 	unloadMobileDeviceBridgeModel:
 		getRouteTestMocks().bridgeMock.unloadMobileDeviceBridgeModel,
 }));
+
+// getMobileDeviceBridgeApi imports this deep subpath (the bare entry is
+// stubbed on mobile), so the providers-route tests must mock it here.
+vi.mock(
+	"@elizaos/plugin-capacitor-bridge/mobile-device-bridge-bootstrap",
+	() => ({
+		getMobileDeviceBridgeStatus:
+			getRouteTestMocks().bridgeMock.getMobileDeviceBridgeStatus,
+		getMobileDeviceBridgeServingStatus:
+			getRouteTestMocks().bridgeMock.getMobileDeviceBridgeServingStatus,
+		loadMobileDeviceBridgeModel:
+			getRouteTestMocks().bridgeMock.loadMobileDeviceBridgeModel,
+		unloadMobileDeviceBridgeModel:
+			getRouteTestMocks().bridgeMock.unloadMobileDeviceBridgeModel,
+	}),
+);
 
 vi.mock("@elizaos/plugin-aosp-local-inference", () => ({
 	activateAospLocalInferenceModel:
@@ -341,6 +369,88 @@ describe("local inference chat status", () => {
 			loadedCacheTypeK: "qjl1_256",
 			loadedCacheTypeV: "q4_polar",
 		});
+	});
+});
+
+describe("GET /api/local-inference/providers — bionic-host serving signal (#11498)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-local-routes-"));
+		process.env.ELIZA_STATE_DIR = tempStateDir;
+		bridgeMock.setServingStatus({
+			registeredTrigger: null,
+			bionicHostServing: false,
+		});
+	});
+
+	afterEach(() => {
+		if (tempStateDir) {
+			rmSync(tempStateDir, { recursive: true, force: true });
+			tempStateDir = null;
+		}
+		if (originalStateDir === undefined) {
+			delete process.env.ELIZA_STATE_DIR;
+		} else {
+			process.env.ELIZA_STATE_DIR = originalStateDir;
+		}
+	});
+
+	async function fetchCapacitorLlamaProvider() {
+		const req = makeJsonRequest("GET", "/api/local-inference/providers");
+		const res = makeJsonResponse();
+		await expect(
+			handleLocalInferenceRoutes(req, res, { current: null }),
+		).resolves.toBe(true);
+		expect(res.statusCode).toBe(200);
+		const body = res.json() as {
+			providers: Array<{ id: string } & Record<string, unknown>>;
+		};
+		const provider = body.providers.find((p) => p.id === "capacitor-llama");
+		expect(provider).toBeDefined();
+		return provider as Record<string, unknown>;
+	}
+
+	it("reports nothing serving when neither the bionic host nor a device bridge is live", async () => {
+		const provider = await fetchCapacitorLlamaProvider();
+		expect(provider.servingVia).toBeNull();
+		expect(provider.registeredTrigger).toBeNull();
+		expect(provider.enableState).toMatchObject({ enabled: false });
+	});
+
+	it("reports servingVia=bionic-host ONLY when handlers are bound via bionic-host AND the host serves", async () => {
+		bridgeMock.setServingStatus({
+			registeredTrigger: "bionic-host",
+			bionicHostServing: true,
+		});
+		const provider = await fetchCapacitorLlamaProvider();
+		expect(provider.servingVia).toBe("bionic-host");
+		expect(provider.registeredTrigger).toBe("bionic-host");
+		expect(provider.enableState).toMatchObject({
+			enabled: true,
+			reason: "In-process bionic host serving",
+		});
+	});
+
+	it("handlers bound via bionic-host with a dead host is NOT serving (no plugin-present larp)", async () => {
+		bridgeMock.setServingStatus({
+			registeredTrigger: "bionic-host",
+			bionicHostServing: false,
+		});
+		const provider = await fetchCapacitorLlamaProvider();
+		expect(provider.servingVia).toBeNull();
+		expect(provider.registeredTrigger).toBe("bionic-host");
+		expect(provider.enableState).toMatchObject({ enabled: false });
+	});
+
+	it("keeps the paired device-bridge signal when the bridge is connected", async () => {
+		bridgeMock.getMobileDeviceBridgeStatus.mockReturnValue({
+			enabled: true,
+			connected: true,
+			devices: [],
+		});
+		const provider = await fetchCapacitorLlamaProvider();
+		expect(provider.servingVia).toBe("device-bridge");
+		expect(provider.enableState).toMatchObject({ enabled: true });
 	});
 });
 

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -67,11 +67,18 @@ type DownloadState =
 
 type MobileDeviceBridgeApi = {
 	getMobileDeviceBridgeStatus: () => MobileDeviceBridgeStatus;
+	getMobileDeviceBridgeServingStatus: () => Promise<MobileDeviceBridgeServingStatus>;
 	loadMobileDeviceBridgeModel: (
 		modelPath: string,
 		modelId: string,
 	) => Promise<void>;
 	unloadMobileDeviceBridgeModel: () => Promise<void>;
+};
+
+type MobileDeviceBridgeServingStatus = {
+	registeredTrigger: "bionic-host" | "device-bridge" | null;
+	/** True only when handlers are bound via bionic-host AND the host socket serves. */
+	bionicHostServing: boolean;
 };
 
 type MobileDeviceBridgeStatus = {
@@ -1369,6 +1376,20 @@ export async function handleLocalInferenceRoutes(
 		const bridge = await getMobileDeviceBridgeApi()
 			.then((api) => api.getMobileDeviceBridgeStatus())
 			.catch(() => getMobileDeviceBridgeStatusUnavailable());
+		// In-process bionic-host serving signal (#11498): on Android the
+		// capacitor-llama handlers can be bound directly to the in-process GPU
+		// host (no paired cross-process device), in which case bridge.connected
+		// stays false even though the provider serves every turn. Surface that
+		// as servingVia so readiness gates don't reject a working path.
+		const serving = await getMobileDeviceBridgeApi()
+			.then((api) => api.getMobileDeviceBridgeServingStatus())
+			.catch(
+				(): MobileDeviceBridgeServingStatus => ({
+					registeredTrigger: null,
+					bionicHostServing: false,
+				}),
+			);
+		const bionicServing = serving.bionicHostServing === true;
 		const installed = await installedSnapshot();
 		sendJson(res, {
 			providers: [
@@ -1380,12 +1401,20 @@ export async function handleLocalInferenceRoutes(
 					supportedSlots: ["TEXT_SMALL", "TEXT_LARGE", "TEXT_EMBEDDING"],
 					configureHref: null,
 					enableState: {
-						enabled: bridge.connected,
-						reason: bridge.connected
-							? "Device bridge connected"
-							: "Waiting for device bridge",
+						enabled: bridge.connected === true || bionicServing,
+						reason: bionicServing
+							? "In-process bionic host serving"
+							: bridge.connected
+								? "Device bridge connected"
+								: "Waiting for device bridge",
 					},
 					registeredSlots: ["TEXT_SMALL", "TEXT_LARGE", "TEXT_EMBEDDING"],
+					servingVia: bionicServing
+						? ("bionic-host" as const)
+						: bridge.connected
+							? ("device-bridge" as const)
+							: null,
+					registeredTrigger: serving.registeredTrigger,
 				},
 				{
 					id: LOCAL_INFERENCE_PROVIDER_ID,

--- a/plugins/plugin-local-inference/vitest.config.ts
+++ b/plugins/plugin-local-inference/vitest.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
 			"@elizaos/agent": fileURLToPath(
 				new URL("../../packages/agent/src/index.ts", import.meta.url),
 			),
+			// Deep subpath must precede the bare alias — the bare entry
+			// prefix-matches and would rewrite this to `src/index.ts/<subpath>`.
+			"@elizaos/plugin-capacitor-bridge/mobile-device-bridge-bootstrap":
+				fileURLToPath(
+					new URL(
+						"../plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts",
+						import.meta.url,
+					),
+				),
 			"@elizaos/plugin-capacitor-bridge": fileURLToPath(
 				new URL("../plugin-capacitor-bridge/src/index.ts", import.meta.url),
 			),


### PR DESCRIPTION
## Summary

Fixes #11498 by teaching the Android local-chat smoke readiness gate to accept the in-process bionic-host serving path, without treating plugin/env presence as readiness.

Changes:
- Adds a pure `evaluateLocalInferenceReadiness()` predicate used by `mobile-local-chat-smoke.mjs`.
- Exposes `capacitor-llama.servingVia` / `registeredTrigger` from `/api/local-inference/providers`.
- Adds `getMobileDeviceBridgeServingStatus()` that reports bionic readiness only when handlers were actually registered via `bionic-host` and the bionic abstract UDS accepts a connection.
- Covers the hub-active, paired device bridge, true bionic-host, and not-ready/error cases.

## Evidence

Focused checks run after rebasing onto current `origin/develop` (`e2b277b506`):

```bash
bunx vitest run packages/app/scripts/lib/local-inference-readiness.test.mjs
# 1 passed, 9 tests passed

bun run --cwd plugins/plugin-local-inference test -- src/local-inference-routes.test.ts
# 1 passed, 12 tests passed

bunx vitest run plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.serving-status.test.ts
# 1 passed, 4 tests passed

git diff --check origin/develop...HEAD
# clean
```

## Evidence matrix

- Android device screenshot/video: N/A - this PR fixes the smoke harness readiness precondition; the actual Pixel full-turn capture is the downstream hardware lane tracked by #11335 and the process-stability blocker in #11506.
- Real LLM trajectory: N/A - no model prompt/action/provider behavior changes; this is readiness/status plumbing for an existing on-device local inference path.
- Backend/device logs: N/A for this PR - the live bionic-host error and routing context are documented on #11335; this change adds the code path needed for that harness to proceed once the device process remains stable.
