### PR TITLE
fix: fail closed on unresolved sender role

### DIFF
--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -3,6 +3,7 @@ import {
 	CANONICAL_ROLE_RANK,
 	canModifyRole,
 	getEntityRole,
+	hasRoleAccess,
 	isAgentSelf,
 	matchEntityToConnectorAdminWhitelist,
 	normalizeRole,
@@ -71,6 +72,31 @@ describe("isAgentSelf", () => {
 		);
 		expect(isAgentSelf(undefined, { entityId: "agent-1" } as Memory)).toBe(
 			false,
+		);
+	});
+});
+
+describe("hasRoleAccess", () => {
+	it("fails closed to USER rank when a real sender role cannot be resolved", async () => {
+		const runtime = {
+			agentId: "agent-1",
+			getRoom: async () => null,
+			getWorld: async () => null,
+		} as unknown as IAgentRuntime;
+		const message = {
+			entityId: "guest-1",
+			roomId: "missing-room",
+			content: {},
+		} as Memory;
+
+		await expect(hasRoleAccess(runtime, message, "OWNER")).resolves.toBe(false);
+		await expect(hasRoleAccess(runtime, message, "ADMIN")).resolves.toBe(false);
+		await expect(hasRoleAccess(runtime, message, "USER")).resolves.toBe(true);
+	});
+
+	it("keeps local no-context calls lenient", async () => {
+		await expect(hasRoleAccess(undefined, undefined, "OWNER")).resolves.toBe(
+			true,
 		);
 	});
 });

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -938,11 +938,7 @@ export async function hasRoleAccess(
 
 	try {
 		const result = await checkSenderRole(context.runtime, context.message);
-		if (!result) {
-			return true;
-		}
-
-		const senderRank = ROLE_RANK[result.role] ?? 0;
+		const senderRank = result ? (ROLE_RANK[result.role] ?? 0) : ROLE_RANK.USER;
 		const requiredRank = ROLE_RANK[requiredRole] ?? 0;
 		return senderRank >= requiredRank;
 	} catch {


### PR DESCRIPTION
## Summary
- fail closed to USER rank when `hasRoleAccess` has a real sender but cannot resolve the sender role
- preserve existing leniency for no-runtime/no-sender local calls
- add regression coverage for OWNER/ADMIN denial and USER allowance on unresolved role lookup

Fixes #11501

## Verification
- `bun run --cwd packages/core test -- src/roles.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core lint`

## Evidence Notes
- N/A screenshots/video: core authorization logic only; no UI surface changed.
- N/A live LLM trajectory: no model prompt/action/provider behavior changed.
- N/A DB artifacts: no persistence or migrations changed.