### PR TITLE
fix(cloud): partial-settle aborted /v1/messages streams instead of full-refund (#11513)

### DIFF
--- a/.github/issue-evidence/11513-messages-abort-partial-settle.md
+++ b/.github/issue-evidence/11513-messages-abort-partial-settle.md
@@ -1,0 +1,58 @@
+# Issue #11513 Evidence: /v1/messages Abort Partial Settlement
+
+Date: 2026-07-02
+
+## Scope
+
+Fixes #11513: `/api/v1/messages` streaming client abort no longer calls
+`settleReservation(0)` (full refund) after output has already been delivered.
+The route now settles the reservation against the prompt estimate plus
+delivered text-delta tokens — the same mechanism #11455/#11472 shipped for
+`/api/v1/chat/completions` — on both the `onAbort` callback path and the
+stream-catch backstop (request signal aborted). Provider-error paths still
+release the hold to `0`, and the terminal settlement is single-flighted so
+racing abort paths cannot double-bill or double-record.
+
+## Verification
+
+- Red (route at `origin/develop` + test seam only), proving the leak:
+  - `bun test __tests__/messages-abort-partial-settle.test.ts`
+  - 2 pass, 3 fail — all three abort tests fail with
+    `expect(ledger.actualCosts[0]).toBeGreaterThan(0)` receiving `0` and
+    `billUsage` never called: the aborted stream refunded the full hold and
+    billed nothing.
+- Green (with the fix):
+  - `bun test __tests__/messages-abort-partial-settle.test.ts`
+  - 5 pass, 0 fail, 31 assertions. Covers onAbort partial settlement,
+    request-signal abort on the catch path, onAbort + catch single-flight,
+    fullStream provider error full refund, and onError provider full refund.
+    The credit-reservation settler (`createCreditReservationSettler`) is REAL
+    and driven against a ledger-backed reservation; only the AI SDK
+    `streamText` and the `billUsage`/`recordUsageAnalytics` boundary are
+    mocked.
+- Related suites (unchanged behavior stays green):
+  - `bun test __tests__/messages-iac-fast-path.test.ts` — 3 pass, 0 fail.
+  - `bun test __tests__/chat-completions-streaming-credit-leak.test.ts` — 9 pass, 0 fail.
+  - `bun test __tests__/chat-stream-credit-leak.test.ts` — 6 pass, 0 fail.
+  - `bun test __tests__/chat-completions-optimistic-billing.test.ts` — 5 pass, 0 fail.
+- `bun run --cwd packages/cloud/api typecheck` — pass.
+- `bunx @biomejs/biome check packages/cloud/api/v1/messages/route.ts
+  packages/cloud/api/__tests__/messages-abort-partial-settle.test.ts
+  packages/cloud/api/__tests__/messages-iac-fast-path.test.ts` — pass, no fixes.
+- `bun run --cwd packages/cloud/api codegen` — idempotent, no router changes.
+
+## Delivered-cost measure on abort
+
+The AI SDK emits no `finish` part (and therefore no exact usage) when a stream
+aborts, so the delivered output is billed from the accumulated `text-delta`
+text via `estimateTokens`, floored by any finished-step usage the SDK did
+report (`summarizeFinishedStepUsage`). This is the identical best-available
+measure `/v1/chat/completions` uses (#11455).
+
+## N/A
+
+- UI screenshots/video: N/A - backend billing/stream settlement route only.
+- Native/mobile capture: N/A - no native surface changed.
+- Live LLM trajectory: N/A - no prompt/model behavior changed; the regression
+  is reservation settlement on client abort. The provider boundary is mocked
+  in the focused unit test and the credit reservation settler is real.

--- a/packages/cloud/api/__tests__/messages-abort-partial-settle.test.ts
+++ b/packages/cloud/api/__tests__/messages-abort-partial-settle.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Money-leak reproduction tests for POST /api/v1/messages streaming (#11513).
+ *
+ * A credit reservation is a ~1.5x upfront hold that MUST be settled — to actual
+ * usage on success, to the delivered partial cost on client abort, or released
+ * to 0 on provider failure. Before the fix, a client abort settled the
+ * reservation to 0 (full refund) even though the platform had already paid the
+ * upstream provider for the prompt and every token streamed before the
+ * disconnect — an uncollected-revenue leak. /v1/chat/completions was fixed in
+ * #11455/#11472; this suite locks the same behavior into /v1/messages.
+ *
+ * These tests drive the REAL credit-reservation settler
+ * (`createCreditReservationSettler`, not a mock) against a ledger-backed
+ * reservation and assert:
+ *
+ *   1. A client abort after text deltas settles to prompt + delivered-output
+ *      cost — NOT 0 — via the `onAbort` callback path.
+ *   2. The same partial settlement happens on the stream-catch path (request
+ *      signal aborted, enqueue/iteration throw racing ahead of onAbort).
+ *   3. onAbort + the catch backstop racing each other single-flight the
+ *      settlement (billed and recorded exactly once).
+ *   4. A provider error (no client abort) still refunds the hold in full and
+ *      bills nothing.
+ *
+ * `streamText`, `getLanguageModel`, and the billing boundary are mocked at the
+ * module seam; the settler and reservation math are real.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Spread the real module so other test files importing from "ai" are not
+// stranded by the process-wide registry replacement; restore in afterAll.
+const aiActual = require("ai") as Record<string, unknown>;
+
+import { estimateTokens } from "@/lib/pricing";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+
+// The REAL settler — explicitly NOT mocked. This is the component under test.
+import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+
+// --- mock the AI SDK streamText (the only external boundary we drive) --------
+let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const streamText = mock((config: Record<string, unknown>) => {
+  if (!streamTextImpl) throw new Error("streamTextImpl not set");
+  return streamTextImpl(config);
+});
+mock.module("ai", () => ({
+  ...aiActual,
+  streamText,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getLanguageModel: () => ({}) as never,
+}));
+
+const INPUT_TOKEN_COST = 0.001;
+const OUTPUT_TOKEN_COST = 0.01;
+const billUsage = mock(async (_context: unknown, usage: unknown) => {
+  const record =
+    usage && typeof usage === "object"
+      ? (usage as {
+          inputTokens?: number;
+          promptTokens?: number;
+          outputTokens?: number;
+          completionTokens?: number;
+          totalTokens?: number;
+        })
+      : {};
+  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
+  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  const inputCost = inputTokens * INPUT_TOKEN_COST;
+  const outputCost = outputTokens * OUTPUT_TOKEN_COST;
+  return {
+    inputCost,
+    outputCost,
+    totalCost: inputCost + outputCost,
+    baseInputCost: inputCost,
+    baseOutputCost: outputCost,
+    baseTotalCost: inputCost + outputCost,
+    platformMarkup: 0,
+    inputTokens,
+    outputTokens,
+    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+    markupApplied: true,
+  };
+});
+const recordUsageAnalytics = mock(async () => ({ id: "usage-1" }));
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  billUsage,
+  recordUsageAnalytics,
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs.
+const { __messagesStreamingCreditTestHooks } = await import(
+  "../v1/messages/route"
+);
+const { handleStream } = __messagesStreamingCreditTestHooks;
+
+afterAll(() => {
+  mock.module("ai", () => aiActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+});
+
+/**
+ * A faithful in-memory credit ledger. reserve() debits the ~1.5x hold up front;
+ * reconcile(actualCost) refunds (hold - actualCost) back. reconcile(0) therefore
+ * returns the full hold → balance restored to the pre-request value.
+ */
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold; // upfront hold debited
+  let reconcileCalls = 0;
+  const actualCosts: number[] = [];
+  return {
+    startBalance,
+    hold,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get actualCosts() {
+      return actualCosts;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        actualCosts.push(actualCost);
+        balance += hold - actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+const MODEL = "openai/gpt-oss-120b";
+const REQUEST = {
+  model: MODEL,
+  max_tokens: 256,
+  messages: [{ role: "user", content: "hello" }],
+  stream: true,
+} as never;
+
+/** Invoke handleStream with the test's settler and a fixed request shape. */
+function callStreaming(
+  settleReservation: (actualCost: number) => Promise<unknown> | unknown,
+  options: { estimatedInputTokens?: number; signal?: AbortSignal } = {},
+) {
+  return handleStream(
+    MODEL,
+    undefined,
+    [{ role: "user", content: [{ type: "text", text: "hello" }] }] as never,
+    REQUEST,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    Date.now(),
+    options.estimatedInputTokens ?? 1,
+    {} as never,
+    undefined,
+    undefined,
+    options.signal,
+    30_000,
+    settleReservation as never,
+    "gateway" as never,
+  );
+}
+
+beforeEach(() => {
+  streamText.mockClear();
+  billUsage.mockClear();
+  recordUsageAnalytics.mockClear();
+  streamTextImpl = null;
+});
+
+describe("streaming messages — client abort settles delivered usage (#11513)", () => {
+  test("abort after text deltas reconciles to prompt plus delivered-output cost, not 0", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const estimatedInputTokens = 12;
+    const deliveredText = "partial response already sent";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+    expect(expectedCost).toBeGreaterThan(0);
+
+    let onAbortPromise: Promise<unknown> | undefined;
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-start", id: "text-1" };
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          yield { type: "abort", reason: "client disconnected" };
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, { estimatedInputTokens });
+    const body = await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("request-signal abort after text deltas settles partial usage on the catch path", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield { type: "text-start", id: "text-1" };
+        yield {
+          type: "text-delta",
+          id: "text-1",
+          text: deliveredText,
+        };
+        controller.abort();
+        throw new DOMException("The operation was aborted.", "AbortError");
+      })(),
+    });
+
+    const res = await callStreaming(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
+    const body = await res.text();
+
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+  });
+
+  test("onAbort plus cancelled-controller catch single-flights partial settlement", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    let onAbortPromise: Promise<unknown> | undefined;
+
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-start", id: "text-1" };
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          controller.abort();
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          throw new DOMException("The operation was aborted.", "AbortError");
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
+    await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
+  });
+});
+
+describe("streaming messages — provider failure still refunds in full", () => {
+  test("fullStream error without a client abort releases the reservation to 0 and bills nothing", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    expect(ledger.balance).toBe(100 - 0.015);
+
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield { type: "error", error: new Error("provider returned 503") };
+      })(),
+    });
+
+    const res = await callStreaming(settle);
+    const body = await res.text();
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(recordUsageAnalytics).not.toHaveBeenCalled();
+    expect(body).toContain('"type":"error"');
+  });
+
+  test("onError provider failure releases the reservation to 0", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    const err = new Error("provider returned 429");
+    let onErrorPromise: Promise<unknown> | undefined;
+    streamTextImpl = (config) => {
+      const onError = config.onError as
+        | ((e: { error: unknown }) => Promise<unknown>)
+        | undefined;
+      onErrorPromise = Promise.resolve(onError?.({ error: err }));
+      return {
+        fullStream: (async function* () {
+          yield { type: "error", error: err };
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle);
+    await res.text();
+    await onErrorPromise;
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(billUsage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -21,6 +21,7 @@ mock.module("@/lib/pricing", () => ({
     outputCost: 0.001,
     totalCost: 0.002,
   }),
+  estimateTokens: (text: string) => Math.ceil(text.length / 4),
   getProviderFromModel: () => "anthropic",
   getSafeModelParams: () => ({}),
   normalizeModelName: (model: string) => model,

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -15,11 +15,13 @@ import {
   type JSONValue,
   jsonSchema,
   type ModelMessage,
+  type StepResult,
   streamText,
   type TextPart,
   type ToolCallPart,
   type ToolContent,
   type ToolResultPart,
+  type ToolSet,
   type UserModelMessage,
 } from "ai";
 import { Hono } from "hono";
@@ -30,6 +32,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   calculateCost,
+  estimateTokens,
   getProviderFromModel,
   getSafeModelParams,
   normalizeModelName,
@@ -45,6 +48,7 @@ import {
 } from "@/lib/providers/language-model";
 import { getRequestIdempotencyKey } from "@/lib/runtime/request-context";
 import {
+  type AIUsage,
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
@@ -894,6 +898,187 @@ async function handleNonStream(
   }
 }
 
+/**
+ * The abort-settlement helpers only read `usage` off the SDK's finished steps.
+ * `StepResult` is invariant in its tools generic, so this structural view lets
+ * the streamText callback's concrete `StepResult<convertedTools>[]` flow in
+ * without a cast (`usage` itself does not depend on the tools generic).
+ */
+type FinishedStepUsageSource = {
+  readonly usage: StepResult<ToolSet>["usage"];
+};
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function summarizeFinishedStepUsage(
+  steps: readonly FinishedStepUsageSource[],
+): AIUsage | null {
+  let sawUsage = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let cacheReadInputTokens = 0;
+  let cacheWriteInputTokens = 0;
+
+  for (const step of steps) {
+    const usage = step.usage;
+    const stepInputTokens = firstNumber(usage.inputTokens) ?? 0;
+    const stepOutputTokens = firstNumber(usage.outputTokens) ?? 0;
+    const stepTotalTokens =
+      firstNumber(usage.totalTokens) ?? stepInputTokens + stepOutputTokens;
+    const stepCacheReadTokens =
+      firstNumber(
+        usage.inputTokenDetails?.cacheReadTokens,
+        usage.cachedInputTokens,
+      ) ?? 0;
+    const stepCacheWriteTokens =
+      firstNumber(usage.inputTokenDetails?.cacheWriteTokens) ?? 0;
+
+    if (
+      stepInputTokens > 0 ||
+      stepOutputTokens > 0 ||
+      stepTotalTokens > 0 ||
+      stepCacheReadTokens > 0 ||
+      stepCacheWriteTokens > 0
+    ) {
+      sawUsage = true;
+    }
+
+    inputTokens += stepInputTokens;
+    outputTokens += stepOutputTokens;
+    totalTokens += stepTotalTokens;
+    cacheReadInputTokens += stepCacheReadTokens;
+    cacheWriteInputTokens += stepCacheWriteTokens;
+  }
+
+  if (!sawUsage) return null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cacheReadInputTokens,
+    cacheWriteInputTokens,
+  };
+}
+
+/**
+ * Settles a streaming reservation after a client abort to the cost of what was
+ * actually delivered (prompt + streamed output) instead of refunding the whole
+ * hold. Port of the /v1/chat/completions abort partial settlement
+ * (#11455/#11472): the platform already paid the upstream provider for the
+ * delivered tokens, so a `settleReservation(0)` full refund leaks that cost as
+ * uncollected revenue.
+ *
+ * The SDK reports no exact usage on abort (no `finish` part arrives), so the
+ * delivered output is billed from the accumulated text-delta text via
+ * `estimateTokens`, floored by any finished-step usage the SDK did report —
+ * the same best-available measure the chat completions route uses. Falls back
+ * to a full refund only when the partial billing itself fails (the settler is
+ * first-call-wins idempotent, so that fallback can never double-refund).
+ */
+async function settleStreamingAbortReservation(params: {
+  model: string;
+  provider: string;
+  user: { id: string; organization_id: string };
+  apiKey: { id: string } | null;
+  affiliateCode: string | null;
+  billingSource: PricingBillingSource;
+  estimatedInputTokens: number;
+  deliveredText: string;
+  steps: readonly FinishedStepUsageSource[];
+  settleReservation: (
+    actualCost: number,
+  ) => Promise<CreditReconciliationResult | null>;
+}): Promise<CreditReconciliationResult | null> {
+  const finishedStepUsage = summarizeFinishedStepUsage(params.steps);
+  const deliveredOutputTokens = estimateTokens(params.deliveredText);
+  const inputTokens = Math.max(
+    params.estimatedInputTokens,
+    finishedStepUsage?.inputTokens ?? 0,
+  );
+  const outputTokens = Math.max(
+    deliveredOutputTokens,
+    finishedStepUsage?.outputTokens ?? 0,
+  );
+  const totalTokens = Math.max(
+    inputTokens + outputTokens,
+    finishedStepUsage?.totalTokens ?? 0,
+  );
+
+  try {
+    const billing = await billUsage(
+      {
+        organizationId: params.user.organization_id,
+        userId: params.user.id,
+        apiKeyId: params.apiKey?.id,
+        model: params.model,
+        provider: params.provider,
+        billingSource: params.billingSource,
+        affiliateCode: params.affiliateCode,
+      },
+      {
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        cacheReadInputTokens: finishedStepUsage?.cacheReadInputTokens,
+        cacheWriteInputTokens: finishedStepUsage?.cacheWriteInputTokens,
+      },
+    );
+    const reconciliation = await params.settleReservation(billing.totalCost);
+
+    await recordUsageAnalytics(
+      {
+        organizationId: params.user.organization_id,
+        userId: params.user.id,
+        apiKeyId: params.apiKey?.id,
+        model: params.model,
+        provider: params.provider,
+        billingSource: params.billingSource,
+      },
+      billing,
+      {
+        type: "chat",
+        isSuccessful: false,
+        errorMessage: "client_aborted_stream",
+        content: params.deliveredText,
+      },
+    );
+
+    logger.info(
+      "[Messages API] Stream aborted; reservation partially settled",
+      {
+        model: params.model,
+        inputTokens: billing.inputTokens,
+        outputTokens: billing.outputTokens,
+        totalCost: billing.totalCost,
+        deliveredChars: params.deliveredText.length,
+        finishedSteps: params.steps.length,
+      },
+    );
+
+    return reconciliation;
+  } catch (error) {
+    logger.error(
+      "[Messages API] Stream abort partial settlement failed; refunding reservation",
+      {
+        model: params.model,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return await params.settleReservation(0);
+  }
+}
+
 async function handleStream(
   model: string,
   systemPrompt: string | undefined,
@@ -921,6 +1106,48 @@ async function handleStream(
 ) {
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+  let deliveredText = "";
+  let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
+    null;
+
+  // Single-flights the terminal settlement across onFinish/onAbort/onError and
+  // the stream-catch backstop. The settler itself is first-call-wins
+  // idempotent, but the abort path bills usage + records analytics BEFORE
+  // settling, so racing paths must share one settlement promise or an abort
+  // could be billed/recorded twice. Mirrors /v1/chat/completions (#11472).
+  const settleStreamingOnce = (
+    factory: () => Promise<CreditReconciliationResult | null>,
+  ): Promise<CreditReconciliationResult | null> => {
+    if (!streamingSettlementPromise) {
+      streamingSettlementPromise = factory().catch((error) => {
+        streamingSettlementPromise = null;
+        throw error;
+      });
+    }
+    return streamingSettlementPromise;
+  };
+
+  const refundStreamingReservationOnce = () =>
+    settleStreamingOnce(async () => await settleReservation(0));
+
+  const settleStreamingAbortOnce = (
+    steps: readonly FinishedStepUsageSource[],
+  ) =>
+    settleStreamingOnce(
+      async () =>
+        await settleStreamingAbortReservation({
+          model,
+          provider,
+          user,
+          apiKey,
+          affiliateCode,
+          billingSource,
+          estimatedInputTokens,
+          deliveredText,
+          steps,
+          settleReservation,
+        }),
+    );
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -948,60 +1175,70 @@ async function handleStream(
     ...(toolChoice ? { toolChoice } : {}),
     ...cotOptions,
     onFinish: async ({ text, totalUsage }) => {
-      try {
-        const billing = await billUsage(
-          {
-            organizationId: user.organization_id,
-            userId: user.id,
-            apiKeyId: apiKey?.id,
-            model,
-            provider,
-            billingSource,
-            affiliateCode,
-          },
-          totalUsage,
-        );
-        await settleReservation(billing.totalCost);
+      await settleStreamingOnce(async () => {
+        try {
+          const billing = await billUsage(
+            {
+              organizationId: user.organization_id,
+              userId: user.id,
+              apiKeyId: apiKey?.id,
+              model,
+              provider,
+              billingSource,
+              affiliateCode,
+            },
+            totalUsage,
+          );
+          const reconciliation = await settleReservation(billing.totalCost);
 
-        await recordUsageAnalytics(
-          {
-            organizationId: user.organization_id,
-            userId: user.id,
-            apiKeyId: apiKey?.id,
-            model,
-            provider,
-            billingSource,
-          },
-          billing,
-          { type: "chat", content: text },
-        );
+          await recordUsageAnalytics(
+            {
+              organizationId: user.organization_id,
+              userId: user.id,
+              apiKeyId: apiKey?.id,
+              model,
+              provider,
+              billingSource,
+            },
+            billing,
+            { type: "chat", content: text },
+          );
 
-        logger.info("[Messages API] Streaming complete", {
-          durationMs: Date.now() - startTime,
-          inputTokens: billing.inputTokens,
-          outputTokens: billing.outputTokens,
-        });
-      } catch (error) {
-        await settleReservation(0);
-        logger.error("[Messages API] onFinish billing error", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+          logger.info("[Messages API] Streaming complete", {
+            durationMs: Date.now() - startTime,
+            inputTokens: billing.inputTokens,
+            outputTokens: billing.outputTokens,
+          });
+
+          return reconciliation;
+        } catch (error) {
+          const reconciliation = await settleReservation(0);
+          logger.error("[Messages API] onFinish billing error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return reconciliation;
+        }
+      });
     },
-    onAbort: async () => {
-      await settleReservation(0);
+    // A client abort mid-stream must NOT release the whole hold: the upstream
+    // provider was already paid for the prompt + every token delivered before
+    // the disconnect. Settle to that partial cost instead (#11513); provider
+    // errors below still refund in full.
+    onAbort: async ({ steps }) => {
+      await settleStreamingAbortOnce(steps);
       logger.info("[Messages API] Stream aborted before completion", {
         model,
         estimatedInputTokens,
+        deliveredOutputTokens: estimateTokens(deliveredText),
       });
     },
     // A provider error during streaming (e.g. cerebras 429/5xx) fires onError —
     // NOT onFinish or onAbort. Without this the upfront credit reservation is
     // never reconciled and the user is billed for zero output. Mirrors the
-    // non-streaming error path's settleReservation(0); the settler is
-    // idempotent (first-call-wins) so this cannot double-refund.
+    // non-streaming error path's settleReservation(0); the settlement is
+    // single-flighted (and the settler idempotent) so this cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
-      await settleReservation(0);
+      await refundStreamingReservationOnce();
       logger.error(
         "[Messages API] Stream provider error — reservation refunded",
         {
@@ -1135,6 +1372,7 @@ async function handleStream(
                   delta: { type: "text_delta", text: part.text },
                 }),
               );
+              deliveredText += part.text;
               break;
             }
 
@@ -1241,10 +1479,19 @@ async function handleStream(
         // doesn't await) onError — e.g. a fullStream `error` part re-thrown here,
         // or a controller.enqueue throw on client disconnect racing ahead of
         // onAbort. Settle the reservation here too so the upfront hold is never
-        // leaked (a permanent overcharge). The settler is first-call-wins
-        // idempotent, so this cannot double-refund if onError already won the
-        // race. Mirrors the /v1/chat/completions backstop.
-        await settleReservation(0);
+        // leaked (a permanent overcharge). When the request signal is aborted
+        // this is the client-abort path, so settle to the delivered partial
+        // cost (#11513) instead of refunding the full hold; otherwise it is a
+        // provider failure and the hold is released to 0. Settlement is
+        // single-flighted, so this cannot double-bill or double-refund if
+        // onAbort/onError already won the race. Mirrors the
+        // /v1/chat/completions backstop.
+        const streamAborted = abortSignal?.aborted === true;
+        if (streamAborted) {
+          await settleStreamingAbortOnce([]);
+        } else {
+          await refundStreamingReservationOnce();
+        }
         const message = error instanceof Error ? error.message : String(error);
         logger.error("[Messages API] Stream error", { error: message });
         controller.enqueue(
@@ -1268,5 +1515,18 @@ async function handleStream(
     },
   });
 }
+
+/**
+ * Test-only seam for the streaming credit-settlement behavior (the abort
+ * money-leak repro in `__tests__/messages-abort-partial-settle.test.ts`).
+ * Exposes the internal streaming handler so a test can drive it with a mocked
+ * `streamText` and a REAL credit-reservation settler, then assert an aborted
+ * stream settles to the delivered partial cost instead of a full refund.
+ * The `__` prefix + `TestHooks` suffix mark it as non-public. Mirrors
+ * `__streamingCreditTestHooks` in ../chat/completions/route.ts.
+ */
+export const __messagesStreamingCreditTestHooks = {
+  handleStream,
+} as const;
 
 export default app;


### PR DESCRIPTION
## The leak

`POST /api/v1/messages` (the Anthropic-compatible endpoint Claude Code / Anthropic SDK clients use) full-refunded aborted streams: both `onAbort` and the stream-catch backstop in `packages/cloud/api/v1/messages/route.ts` called `settleReservation(0)`, releasing the entire upfront credit hold even after output had already been streamed to the client. The platform had already paid the upstream provider for the prompt + every delivered token, so each mid-stream disconnect was uncollected revenue. `/v1/chat/completions` was fixed for exactly this in #11455 (+ single-flight hardening in #11472); `/v1/messages` never got the same partial-settle.

## The fix (a port of #11455/#11472, same billing path)

- Accumulate delivered `text-delta` output during the stream.
- On client abort — the `onAbort` callback AND the stream-catch backstop when the request signal is aborted — bill `max(estimated input, finished-step input)` + `max(estimateTokens(deliveredText), finished-step output)` via the shared `billUsage`, settle the reservation to that partial cost with the same first-call-wins idempotent settler (`createCreditReservationSettler`), and record the usage as `client_aborted_stream` (`isSuccessful: false`).
- Single-flight the terminal settlement across `onFinish`/`onAbort`/`onError`/catch (mirrors #11472) — the settler is idempotent, but the abort path bills + records analytics *before* settling, so racing paths must share one settlement promise.
- Provider errors (`onError`, or the catch path without an aborted signal) still refund the hold in full; if the partial billing itself throws, the helper falls back to a full refund (idempotent, cannot double-refund).

The abort-settle helper is a faithful local port rather than a cross-route import: the chat route's helper is private, chat-specific (chat billing context/audit-record/log prefixes), and these two routes already deliberately keep parallel local helpers (`convertTools`, `mapToolChoice`, ...). The *money path* — `billUsage` → idempotent settler → `recordUsageAnalytics` — is the identical shared code.

**Honest delivered-cost measure:** the AI SDK emits no `finish` part (hence no exact usage) on abort, so delivered output is billed from the accumulated text-delta text via `estimateTokens`, floored by any finished-step usage the SDK did report — the same best-available measure #11455 uses for chat completions, commented as such in the code.

## Test proof (red → green)

New `packages/cloud/api/__tests__/messages-abort-partial-settle.test.ts`, mirroring the #11455 harness (`chat-completions-streaming-credit-leak.test.ts`): drives the REAL `createCreditReservationSettler` against a ledger-backed reservation through an exported `__messagesStreamingCreditTestHooks.handleStream` seam; only `streamText` and the `billUsage`/analytics boundary are mocked.

**Red** — route at `origin/develop` (+ test seam only):
```
2 pass, 3 fail
error: expect(ledger.actualCosts[0]).toBeGreaterThan(0)  Expected: > 0  Received: 0
error: expect(billUsage).toHaveBeenCalledTimes(1)        Received number of calls: 0
```
All three abort tests fail: the aborted stream settled $0 and billed nothing.

**Green** — with this fix:
```
5 pass, 0 fail, 31 expect() calls
```
Covers: onAbort partial settlement (exact expected cost + ledger balance), request-signal abort on the catch path, onAbort + catch racing single-flights (billed/recorded exactly once), fullStream provider error refunds in full and bills nothing, onError provider failure refunds in full.

Related suites stay green (each run isolated, as `test:unit` does):
- `messages-iac-fast-path.test.ts` — 3 pass
- `chat-completions-streaming-credit-leak.test.ts` — 9 pass
- `chat-stream-credit-leak.test.ts` — 6 pass
- `chat-completions-optimistic-billing.test.ts` — 5 pass

## Checks

- `bun run --cwd packages/cloud/api typecheck` — **pass**
- `bunx biome check` on all touched files — **pass, no diagnostics**
- `bun run --cwd packages/cloud/api codegen` — idempotent, no router changes

Evidence: `.github/issue-evidence/11513-messages-abort-partial-settle.md`

Closes #11513

**Money path — do not self-merge.**

[cloud-security]

🤖 Generated with Claude Fable 5