### PR TITLE
refactor(orchestrator): structural-only control action + task-policy cold-import de-flake (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/control-resume-clears-paused.test.ts
@@ -296,3 +296,59 @@ describe("TASKS control pause/resume symmetry (#11216 follow-up)", () => {
     expect(detail?.status).toBe("active");
   });
 });
+
+describe("TASKS control is structural — no regex over message text (#11028)", () => {
+  // The planner emits `controlAction` when the user asks to pause/stop/resume;
+  // the orchestrator no longer scans the message text for control phrasings.
+  // "let's stop using axios" or "make it so" in ordinary prose must not
+  // stop/resume a running session.
+  it("does not infer stop from message text without a structured controlAction", async () => {
+    const { acp, runtime } = await harness();
+    acp.live = [liveSession("live-3")];
+
+    const result = await tasksAction.handler(
+      runtime,
+      memory({ text: "let's stop using axios and switch to fetch" }),
+      state,
+      opts({ action: "control" }),
+      callback(),
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain("No task-control action was specified");
+    expect(acp.stopped).toEqual([]);
+  });
+
+  it("does not infer resume from slang in message text", async () => {
+    const { acp, runtime } = await harness();
+    acp.live = [liveSession("live-4")];
+    const sentBefore = acp.sent.length;
+
+    const result = await tasksAction.handler(
+      runtime,
+      memory({ text: "make it so — do it, yeah i'm down" }),
+      state,
+      opts({ action: "control" }),
+      callback(),
+    );
+
+    expect(result?.success).toBe(false);
+    expect(acp.sent.length).toBe(sentBefore);
+  });
+
+  it("still honors the structured controlAction param", async () => {
+    const { acp, runtime } = await harness();
+    acp.live = [liveSession("live-5")];
+
+    const result = await tasksAction.handler(
+      runtime,
+      memory({ text: "nothing control-like in this text" }),
+      state,
+      opts({ action: "control", controlAction: "stop", sessionId: "live-5" }),
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    expect(acp.stopped).toEqual(["live-5"]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
@@ -29,23 +29,37 @@ const discordMessage = {
   content: { source: "discord" },
 } as unknown as Memory;
 
-describe("requireTaskAgentAccess — policy merge", () => {
-  it("keeps the built-in Discord ADMIN gate when only another connector is overridden", async () => {
-    const result = await requireTaskAgentAccess(
-      runtimeWith({ connectors: { slack: "ADMIN" } }),
-      discordMessage,
-      "create",
-    );
-    // Discord still requires ADMIN despite the slack-only override.
-    expect(result.requiredRole).toBe("ADMIN");
-  });
+// resolveSenderRole dynamically imports @elizaos/core on first use; that cold
+// import transforms the whole core package under vitest and can exceed the 5s
+// default timeout (it crossed it when core gained the generated pricing/context
+// tables). The timeout covers the one-time import, not the logic under test.
+const COLD_CORE_IMPORT_TIMEOUT_MS = 30_000;
 
-  it("still requires Discord ADMIN under the default policy (no override)", async () => {
-    const result = await requireTaskAgentAccess(
-      runtimeWith(undefined),
-      discordMessage,
-      "interact",
-    );
-    expect(result.requiredRole).toBe("ADMIN");
-  });
+describe("requireTaskAgentAccess — policy merge", () => {
+  it(
+    "keeps the built-in Discord ADMIN gate when only another connector is overridden",
+    async () => {
+      const result = await requireTaskAgentAccess(
+        runtimeWith({ connectors: { slack: "ADMIN" } }),
+        discordMessage,
+        "create",
+      );
+      // Discord still requires ADMIN despite the slack-only override.
+      expect(result.requiredRole).toBe("ADMIN");
+    },
+    COLD_CORE_IMPORT_TIMEOUT_MS,
+  );
+
+  it(
+    "still requires Discord ADMIN under the default policy (no override)",
+    async () => {
+      const result = await requireTaskAgentAccess(
+        runtimeWith(undefined),
+        discordMessage,
+        "interact",
+      );
+      expect(result.requiredRole).toBe("ADMIN");
+    },
+    COLD_CORE_IMPORT_TIMEOUT_MS,
+  );
 });

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2068,10 +2068,11 @@ async function runHistory(
 
 // ── action: control (TASK_CONTROL) ──────────────────────────────────────────
 
-function inferControlAction(
-  text: string,
-  value?: string,
-): ControlAction | null {
+// Structural only: the planner emits `controlAction` (or the legacy top-level
+// action value) when the user asks to pause/stop/resume — the model judges
+// intent. No regex over message text: hardcoded phrasings ("make it so",
+// "hold on") misfire on ordinary prose (#11028).
+function normalizeControlAction(value?: string): ControlAction | null {
   const normalized = value?.trim().toLowerCase();
   if (
     normalized === "pause" ||
@@ -2083,14 +2084,6 @@ function inferControlAction(
   ) {
     return normalized;
   }
-  if (/\barchive\b/i.test(text)) return "archive";
-  if (/\breopen\b/i.test(text)) return "reopen";
-  if (/\bpause\b|\bhold on\b|\bthat's not right\b/i.test(text)) return "pause";
-  if (/\bstop\b|\bcancel\b|\bkill\b/i.test(text)) return "stop";
-  if (/\bresume\b|\bmake it so\b|\bdo it\b|\byea(h)? i'm down\b/i.test(text)) {
-    return "resume";
-  }
-  if (/\bcontinue\b|\bgo ahead\b/i.test(text)) return "continue";
   return null;
 }
 
@@ -2131,8 +2124,7 @@ async function runControl(
     topLevelAction && normalizedTopLevelAction !== "control"
       ? topLevelAction
       : undefined;
-  const action = inferControlAction(
-    text,
+  const action = normalizeControlAction(
     textValue(params.controlAction) ??
       textValue(content.controlAction) ??
       legacyControlAction,


### PR DESCRIPTION
Two residuals from the #11028 orchestrator audit.

## 1. Control actions are structural — no regex over message text
`inferControlAction` still fell back to hardcoded English phrasings over the raw message text (`\bstop\b`, \"make it so\", \"hold on\", \"yeah i'm down\") when the planner didn't emit `controlAction`. That misfires on ordinary prose — \"let's **stop** using axios\" reads as a stop command. This drops the text scan entirely: the structured `controlAction` param (or the legacy top-level action value) is the only source, mirroring #11518's `deferUserReply` change. With nothing structural, the action returns the existing `INVALID_OPERATION` guidance enumerating valid values, which steers the planner to re-call with the param.

New regression tests drive the real `tasksAction.handler` + `OrchestratorTaskService` harness: control-phrased prose no longer stops/resumes sessions; the structured param still does.

## 2. task-policy tests: absorb the cold @elizaos/core import
`resolveSenderRole` dynamically imports `@elizaos/core` on first use. Under vitest that cold import transforms the whole core package (~8s measured on this host) and crossed the 5s default test timeout once core gained the generated pricing/context tables (#11529) — both task-policy tests time out on any cold run of current develop. Explicit 30s timeout with a comment; the logic under test is unchanged and still asserted.

## Verification
- `bunx vitest run __tests__/unit/control-resume-clears-paused.test.ts __tests__/unit/archive-reopen-lifecycle.test.ts` — 14 passed (3 new).
- `bunx vitest run __tests__/unit/task-policy.test.ts` — 2 passed, twice in a row (was 1-2 timeouts per cold run before).
- Full plugin suite green modulo one unrelated load-flake (`verify-incidental-narration-url`) that passes in isolation.
- `turbo typecheck lint --filter=@elizaos/plugin-agent-orchestrator` — green.

Refs #11028

🤖 Generated with [Claude Code](https://claude.com/claude-code)