### PR TITLE
fix(cloud): analytics + api-keys query gates resolve the real session

### DIFF
--- a/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/analytics/lib/auth-query.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The analytics + api-keys query gates must resolve the session the same way
+// the rest of the console does. Gating on the raw Steward SDK context (whose
+// MemoryStorage session is empty on every full page load) left the gate
+// permanently disabled for a signed-in user — analytics stuck on its loading
+// skeleton, keys never fetched. These tests reproduce the page-reload reality:
+// ONLY a persisted localStorage JWT, no Steward provider mounted.
+
+import { useAuthenticatedQueryGate as useApiKeysGate } from "../../api-keys/auth-gate";
+import { useAuthenticatedQueryGate as useAnalyticsGate } from "./auth-query";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
+}
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+let storage: Storage;
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe.each([
+  ["analytics", useAnalyticsGate],
+  ["api-keys", useApiKeysGate],
+])("%s query gate — session from persisted JWT only (page-reload reality)", (_name, useGate) => {
+  it("enables the query and exposes the user id when a valid JWT is persisted", () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) + 600 }),
+    );
+
+    const { result } = renderHook(() => useGate());
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.userId).toBe("u1");
+  });
+
+  it("stays disabled with no persisted session", () => {
+    const { result } = renderHook(() => useGate());
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it("stays disabled for an expired token", () => {
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+    );
+
+    const { result } = renderHook(() => useGate());
+    expect(result.current.enabled).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/analytics/lib/auth-query.ts
+++ b/packages/ui/src/cloud/analytics/lib/auth-query.ts
@@ -1,16 +1,17 @@
 /**
  * Auth-query gate for the app-hosted cloud analytics view.
  *
- * Ported from `@elizaos/cloud-frontend/src/lib/data/auth-query.ts`, rewired onto
- * the cloud shell's `LocalStewardAuthContext` (provided by `StewardAuthProvider`
- * for every authenticated cloud route) instead of cloud-frontend's
- * `useSessionAuth`. Same contract: react-query reads are gated until a Steward
- * session is ready + authenticated, and the query key is scoped by user id so a
- * sign-out / account switch doesn't serve another user's cached data.
+ * Ported from `@elizaos/cloud-frontend/src/lib/data/auth-query.ts`. Resolves the
+ * session through the console-wide `useSessionAuth` (Steward SDK context OR the
+ * persisted localStorage JWT) — NOT the raw Steward SDK context: that context
+ * lives in MemoryStorage and reads empty on every full page load, so gating on
+ * it left the analytics queries permanently `enabled: false` (stuck on the
+ * loading skeleton, no data call ever fired) for a genuinely signed-in user.
+ * Same class as the admin-gate / MCPs fixes. The query key stays scoped by user
+ * id so a sign-out / account switch doesn't serve another user's cached data.
  */
 
-import { useContext } from "react";
-import { LocalStewardAuthContext } from "../../shell/StewardProvider";
+import { useSessionAuth } from "../../public-pages/lib/use-session-auth";
 
 export interface AuthenticatedQueryGate {
   enabled: boolean;
@@ -18,20 +19,17 @@ export interface AuthenticatedQueryGate {
 }
 
 /**
- * Resolve the analytics query gate from the cloud Steward session. When no
- * provider is mounted (e.g. SSR or a misconfigured Steward URL where
- * `StewardAuthProvider` renders children directly), the context is null and the
- * gate stays disabled rather than firing unauthenticated requests.
+ * Resolve the analytics query gate from the console-wide session. Stays
+ * disabled until the session is ready + authenticated, so it never fires
+ * unauthenticated requests.
  */
 export function useAuthenticatedQueryGate(
   enabled = true,
 ): AuthenticatedQueryGate {
-  const auth = useContext(LocalStewardAuthContext);
-  const ready = auth ? !auth.isLoading : false;
-  const authenticated = auth?.isAuthenticated ?? false;
+  const session = useSessionAuth();
   return {
-    enabled: enabled && ready && authenticated,
-    userId: auth?.user?.id ?? null,
+    enabled: enabled && session.ready && session.authenticated,
+    userId: session.user?.id ?? null,
   };
 }
 

--- a/packages/ui/src/cloud/api-keys/auth-gate.ts
+++ b/packages/ui/src/cloud/api-keys/auth-gate.ts
@@ -1,36 +1,33 @@
 /**
  * Authenticated-query gate for the API-keys cloud domain.
  *
- * The cloud-frontend version read auth from its own `useSessionAuth` +
- * `useAuthenticatedQueryGate`. In the app the canonical auth context is the
- * Steward runtime context exposed by the cloud shell
- * ({@link LocalStewardAuthContext}); this gate adapts it to the same
- * `{ enabled, userId }` shape the ported react-query hooks expect, so the keys
- * list only fetches once a Steward session is present and the query key is
- * partitioned per user.
+ * Resolves the session through the console-wide `useSessionAuth` (Steward SDK
+ * context OR the persisted localStorage JWT) — NOT the raw Steward SDK context:
+ * that context lives in MemoryStorage and reads empty on every full page load,
+ * so gating on it left the keys list permanently `enabled: false` for a
+ * genuinely signed-in user (same class as the admin-gate / MCPs / analytics
+ * fixes). The query key stays partitioned per user so a sign-out / account
+ * switch can't surface the previous user's cached keys.
  */
 
-import { useContext } from "react";
-import { LocalStewardAuthContext } from "../shell/StewardProvider";
+import { useSessionAuth } from "../public-pages/lib/use-session-auth";
 
 export interface AuthenticatedQueryGate {
-  /** Whether the gated query may run (a Steward session has resolved). */
+  /** Whether the gated query may run (a session has resolved). */
   enabled: boolean;
   /** The authenticated user id, used to partition cached query data. */
   userId: string | null;
 }
 
 /**
- * Read the current Steward auth session and derive the query gate. Returns
+ * Read the current session and derive the query gate. Returns
  * `{ enabled: false }` until the session resolves to an authenticated user.
  */
 export function useAuthenticatedQueryGate(): AuthenticatedQueryGate {
-  const auth = useContext(LocalStewardAuthContext);
-  const ready = auth ? !auth.isLoading : false;
-  const authenticated = auth?.isAuthenticated ?? false;
+  const session = useSessionAuth();
   return {
-    enabled: ready && authenticated,
-    userId: auth?.user?.id ?? null,
+    enabled: session.ready && session.authenticated,
+    userId: session.user?.id ?? null,
   };
 }
 


### PR DESCRIPTION
## What

Found by the full staging e2e: with #11456 deployed, `/dashboard/analytics` no longer 404s (route registration fixed) — but it then renders a **permanent loading skeleton**, and no data call ever fires. Same root cause as the admin-gate / MCPs fixes, in two more gates that #11456 didn't touch.

## Root cause

`analytics/lib/auth-query.ts` and `api-keys/auth-gate.ts` both gated their react-query reads on the **raw Steward SDK context** (`useContext(LocalStewardAuthContext)`). That context lives in the SDK's MemoryStorage and reads **empty on every full page load**, so `enabled` stayed `false` for a genuinely signed-in user → the analytics queries never ran (stuck skeleton) and the api-keys list never fetched.

Live evidence (staging, real session): analytics DOM = `<div aria-busy="true" aria-label="Loading analytics" role="status">` skeleton, and **zero** `/api/v1` analytics calls in the network trace.

## Fix

Both gates now resolve through the console-wide `useSessionAuth` (SDK context **OR** persisted localStorage JWT), identical to the admin-gate/MCPs fixes. Audited the rest of the class: `monetization/auth-gate.ts` already ORs in the localStorage fallback, and the `account-security` / `api-explorer` / `instances` domains each ship their own `useSessionAuth` with the fallback — all unaffected.

## Test

New `auth-query.test.tsx` drives **both** gates in the page-reload reality (session present only as a persisted JWT, no Steward provider mounted): `enabled` + `userId` resolve; disabled when absent or expired. 6/6. `packages/ui` typecheck unchanged (4 pre-existing errors, none mine); biome clean.

## e2e status (this PR closes the last console gap)

Full authenticated staging walk (guest session): admin (correct "Access Denied" for non-admin ✓), MCPs ✓, organization/billing/apps/api-explorer/approvals/agents/security all render real data ✓, `/join` provisions an agent end-to-end ✓. Analytics was the one remaining stuck surface → this fix. (Image-gen still 503 pending #11508 blob-host — separate.)