### PR TITLE
feat(orchestrator): structural appMonetized planner field for monetized-app routing

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -7,6 +7,79 @@ import {
 } from "../../src/services/app-deploy-guidance.js";
 
 describe("app-deploy-guidance", () => {
+  // The planner's `monetized` signal is the STRUCTURAL fix for the normie
+  // phrasings the keyword regex misses ("people pay $1 to chat with X"). It must
+  // produce the monetized Eliza Cloud contract regardless of target, and even
+  // when the build-verb gate (isAppBuildTask) would otherwise drop the task.
+  describe("monetized signal (structural, not keyword)", () => {
+    const cloud = { target: "eliza-cloud" as const };
+    const home = {
+      target: "agent-home" as const,
+      agentHomeAppsDir: "/data/apps",
+      agentHomeBaseUrl: "https://example.test",
+    };
+    // The two flagship normie phrasings the regex does NOT catch.
+    const NORMIE = [
+      "build me an app where people pay $1 to chat with a grimes-style AI",
+      "an app spending $1 to talk to a drake style ai",
+    ];
+
+    it("regex alone misses these normie phrasings (documents the gap)", () => {
+      for (const p of NORMIE) expect(isMonetizedAppTask(p)).toBe(false);
+    });
+
+    it("eliza-cloud: signal forces the edad/register monetized contract", () => {
+      for (const p of NORMIE) {
+        const out = augmentTaskWithDeployGuidance(p, cloud, {
+          monetized: true,
+        });
+        expect(out).toContain("App Deployment (Eliza Cloud)");
+        expect(out).toContain("packages/examples/cloud/edad");
+        expect(out).toContain("POST /api/v1/apps");
+        expect(out).toContain("x-affiliate-code");
+      }
+    });
+
+    it("eliza-cloud: signal forces the contract even when the build-verb gate misses", () => {
+      // "an app spending $1 …" has no build verb → isAppBuildTask is false.
+      expect(isAppBuildTask(NORMIE[1])).toBe(false);
+      const out = augmentTaskWithDeployGuidance(NORMIE[1], cloud, {
+        monetized: true,
+      });
+      expect(out).toContain("packages/examples/cloud/edad");
+    });
+
+    it("agent-home: signal turns the weak conditional into a firm directive", () => {
+      const plain = augmentTaskWithDeployGuidance(NORMIE[0], home);
+      expect(plain).toContain("If the app must earn money");
+      expect(plain).not.toContain("THIS APP IS MONETIZED");
+
+      const monetized = augmentTaskWithDeployGuidance(NORMIE[0], home, {
+        monetized: true,
+      });
+      expect(monetized).toContain("THIS APP IS MONETIZED");
+      expect(monetized).toContain("packages/examples/cloud/edad");
+      expect(monetized).toContain("x-app-id");
+    });
+
+    it("no signal + no keyword → free-app contract, NOT monetized (no regression)", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "build me a free web app tip calculator",
+        cloud,
+      );
+      expect(out).toContain("App Deployment (Eliza Cloud)");
+      expect(out).not.toContain("packages/examples/cloud/edad");
+    });
+
+    it("signal only ADDS detection — a keyword match still works without it", () => {
+      const out = buildAppDeployGuidance(
+        cloud,
+        "build a monetized app that charges $2 per use",
+      );
+      expect(out).toContain("packages/examples/cloud/edad");
+    });
+  });
+
   describe("isAppBuildTask", () => {
     it("matches hosted web-surface builds", () => {
       expect(isAppBuildTask("build me a website about cats")).toBe(true);

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -733,6 +733,8 @@ async function runCreate(
       // itself; the helper is gated + idempotent so non-app tasks pass through.
       const taskWithRouteHints = augmentTaskWithDeployGuidance(
         taskWithResolvedRoute(task, route, sessionWorkdir, swarmRoomMetadata),
+        undefined,
+        { monetized: pickBoolean(params, content, "appMonetized") === true },
       );
       const session = await service.spawnSession({
         agentType,
@@ -1204,6 +1206,7 @@ async function runSpawnAgent(
       workdir: effectiveWorkdir,
       isolateWorkdir,
       initialTask: taskWithRouteHints,
+      monetized: pickBoolean(params, content, "appMonetized") === true,
       memoryContent,
       approvalPreset,
       metadata: {
@@ -3252,6 +3255,13 @@ export const tasksAction: Action & {
         "Agent type (elizaos, pi-agent, opencode, codex, or claude) for create / spawn_agent / control.resume. Defaults to ELIZA_ACP_DEFAULT_AGENT, normally elizaos.",
       required: false,
       schema: { type: "string" as const },
+    },
+    {
+      name: "appMonetized",
+      description:
+        "Set true when the user wants the app to EARN MONEY / charge for access — e.g. 'people pay $1 to chat with X', 'charge per message', 'a paid app', 'monetized', a paywall, or per-use pricing. Judge the user's INTENT, not specific keywords. When true the sub-agent gets the monetized Eliza Cloud contract (register for an appId, inference markup, OAuth + affiliate billing) instead of a free static page. Leave unset for a normal free app or non-app task.",
+      required: false,
+      schema: { type: "boolean" as const },
     },
     {
       name: "agents",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -683,7 +683,9 @@ export class AcpService extends Service {
     // non-app tasks; applied only to the initial task, never to follow-up sends.
     const initialTask =
       opts.initialTask && opts.initialTask.trim().length > 0
-        ? augmentTaskWithDeployGuidance(opts.initialTask)
+        ? augmentTaskWithDeployGuidance(opts.initialTask, undefined, {
+            monetized: opts.monetized,
+          })
         : opts.initialTask;
 
     if (this.transportMode === "native") {

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -105,9 +105,13 @@ export function resolveAppDeployConfig(): AppDeployConfig {
   return { target: "eliza-cloud" };
 }
 
-function elizaCloudGuidance(task?: string): string {
+function elizaCloudGuidance(task?: string, monetized?: boolean): string {
   const lines = ["--- App Deployment (Eliza Cloud) ---"];
-  if (isMonetizedAppTask(task)) {
+  // The planner's `monetized` judgment is the primary signal (it understands
+  // "people pay $1 to chat" as monetization where a keyword regex does not);
+  // the regex remains only as a fallback so detection can never REGRESS. The
+  // signal only ever ADDS monetization detection, never removes it.
+  if (monetized === true || isMonetizedAppTask(task)) {
     lines.push(
       "START FROM THE TEMPLATE — do NOT build the Cloud SDK / registration / OAuth-proxy / Dockerfile from scratch. A complete, working, already-deployed monetized chat app is in THIS checkout at `packages/examples/cloud/edad`. Copy it as your starting point: `cp -r packages/examples/cloud/edad <your-app-dir>`, then ADAPT only the app-specific bits.",
       "- CHANGE only: `public/index.html` (the SYSTEM_PROMPT constant, the MODEL constant, the <title>/brand/meta text, the input placeholder, the TOKEN_KEY/STATE_KEY localStorage prefixes), the art in `public/` (SVGs, favicon, og-image), and the markup % you set at registration.",
@@ -129,9 +133,22 @@ function elizaCloudGuidance(task?: string): string {
   return lines.join("\n");
 }
 
-function agentHomeGuidance(config: AppDeployConfig, _task?: string): string {
+function agentHomeGuidance(
+  config: AppDeployConfig,
+  _task?: string,
+  monetized?: boolean,
+): string {
   const dir = config.agentHomeAppsDir ?? "";
   const base = config.agentHomeBaseUrl ?? "";
+  // The monetization line is a self-gating conditional by default ("if the app
+  // must earn money …"), but when the planner has JUDGED this task as monetized
+  // it becomes a firm directive — a normie "people pay $1 to chat" must not be
+  // built as a free static page. Structural: driven by the model's intent
+  // signal, not by keyword-matching the task text.
+  const monetizeLine =
+    monetized === true
+      ? "- THIS APP IS MONETIZED: it must charge per use, so a static page is NOT enough. Register it with Eliza Cloud and follow the `build-monetized-app` skill (Cloud SDK app registration → an `appId`, an inference markup, Eliza Cloud OAuth, and a same-origin proxy that forwards to `/api/v1/messages` with `x-app-id` + `x-affiliate-code` — the org-balance billing path). Start from the working reference at `packages/examples/cloud/edad`. Report the live monetized URL only after a real billed message round-trips."
+      : "- If the app must earn money / be monetized: also register it with Eliza Cloud — follow the `build-monetized-app` skill (Cloud SDK registration, an inference markup, per-call billing). Otherwise do not involve Eliza Cloud.";
   // A capability note, NOT an assertion that the current task is an app — it is
   // always available and the agent applies it by judgment. So it must stay
   // correct for a request to BUILD a new app, to EDIT an existing one, OR for a
@@ -142,7 +159,7 @@ function agentHomeGuidance(config: AppDeployConfig, _task?: string): string {
     `- Published apps are plain static files under \`${dir}/<slug>/\` (index.html plus any css/js — there is NO per-app build step), served live at \`${base}/apps/<slug>/\`.`,
     `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL.`,
     `- To EDIT an existing app: the \`<slug>\` is the app's existing folder name under \`${dir}/\` — read its files there, modify them in place, then re-open \`${base}/apps/<slug>/\` to confirm. Do not create a new slug for an edit.`,
-    "- If the app must earn money / be monetized: also register it with Eliza Cloud — follow the `build-monetized-app` skill (Cloud SDK registration, an inference markup, per-call billing). Otherwise do not involve Eliza Cloud.",
+    monetizeLine,
     "- Do NOT run `deploy.sh` (operator-only; only for a new Next.js backend route). Static apps need no build/restart.",
     "If your task is not a web app, ignore this section.",
   ].join("\n");
@@ -167,11 +184,12 @@ export function viewPluginGuidance(
 export function buildAppDeployGuidance(
   config?: AppDeployConfig,
   task?: string,
+  monetized?: boolean,
 ): string {
   const resolved = config ?? resolveAppDeployConfig();
   return resolved.target === "agent-home"
-    ? agentHomeGuidance(resolved, task)
-    : elizaCloudGuidance(task);
+    ? agentHomeGuidance(resolved, task, monetized)
+    : elizaCloudGuidance(task, monetized);
 }
 
 function isCloudDeployTarget(config: AppDeployConfig): boolean {
@@ -193,6 +211,7 @@ function extractViewPluginSourceDir(task: string): string | undefined {
 export function augmentTaskWithDeployGuidance(
   task: string,
   config?: AppDeployConfig,
+  opts?: { monetized?: boolean },
 ): string {
   // Idempotent: if a deploy block is already present, no-op.
   if (
@@ -204,6 +223,8 @@ export function augmentTaskWithDeployGuidance(
     return task;
   }
   const resolved = config ?? resolveAppDeployConfig();
+  // The planner's monetization judgment (model intent, not a keyword match).
+  const monetized = opts?.monetized === true;
   // View/plugin tasks are a distinct surface (#8918) with their own cloud-vs-local
   // sandbox contract — they are NOT hosted web apps, so they must be routed before
   // the agent-home app note (which would otherwise wrongly tell the agent to
@@ -222,10 +243,14 @@ export function augmentTaskWithDeployGuidance(
   // got no apps-dir context and could not find or edit the deployed app. Letting
   // the model decide from an always-present note is both cleaner and general.
   if (resolved.target === "agent-home") {
-    return `${task.trimEnd()}\n\n${agentHomeGuidance(resolved, task)}`;
+    return `${task.trimEnd()}\n\n${agentHomeGuidance(resolved, task, monetized)}`;
   }
-  if (!isAppBuildTask(task)) {
+  // Force the deploy contract for a monetized task even when isAppBuildTask
+  // misses it — a monetized request ("an app where people pay $1 to chat …") is
+  // by definition an app build, but its phrasing may lack a build verb. The
+  // planner's monetized signal is the structural override for that gate.
+  if (!monetized && !isAppBuildTask(task)) {
     return task;
   }
-  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(resolved, task)}`;
+  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(resolved, task, monetized)}`;
 }

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -81,6 +81,13 @@ export interface SpawnOptions {
    */
   isolateWorkdir?: boolean;
   initialTask?: string;
+  /**
+   * The planner judged this an app the user wants to MONETIZE (charge for use).
+   * Threaded into the deploy-guidance injection so the sub-agent gets the
+   * monetized Eliza Cloud contract rather than a free static page. Model intent,
+   * not a keyword match — see app-deploy-guidance.augmentTaskWithDeployGuidance.
+   */
+  monetized?: boolean;
   env?: Record<string, string>;
   metadata?: Record<string, unknown>;
   credentials?: unknown;


### PR DESCRIPTION
# structural appMonetized planner field for monetized-app routing

## problem

A normie "build an app where people pay $1 to chat with a grimes-style AI" never gets the monetized Eliza Cloud contract. `MONETIZED_APP_RE` (even in its current broadened form) only matches developer vocabulary — "monetized", "charges $2 per use", "paywall" — and the pay/spend/cost-a-dollar phrasing real users actually type falls through to a **free static page**:

```
"build me an app where people pay $1 to chat with a grimes-style AI"  -> regex: false
"an app spending $1 to talk to a drake style ai"                      -> regex: false
"make an app that costs a dollar per message"                         -> regex: false
```

Worse, the verbless phrasing ("an app spending $1 ...") also misses the `isAppBuildTask` build-verb gate, so under the eliza-cloud target it gets **no deploy contract at all**.

## fix — structural, not more keywords

Per the project rule (structural signals, not regex on LLM text — same rationale as #11518, which dropped the `deferUserReply` regex helper for the structural planner flag), this adds an `appMonetized` planner field: **the model judges monetization intent**, and the orchestrator routes on the structured boolean.

- `tasks.ts`: new `appMonetized` boolean parameter on the TASKS schema; threaded through both spawn chokepoints (`runCreate`'s pre-augment and `runSpawnAgent` → `spawnSession`).
- `types.ts`: `SpawnOptions.monetized`.
- `acp-service.ts`: passes `opts.monetized` into the initial-task deploy-guidance injection.
- `app-deploy-guidance.ts`: when the signal is set it
  - forces the edad/register monetized contract under the eliza-cloud target, **even when the build-verb gate would otherwise drop the task**, and
  - upgrades the agent-home note from the weak "if it must earn money ..." conditional to a firm "THIS APP IS MONETIZED — register with Eliza Cloud" directive.

The keyword regex stays untouched, only as a fallback — the signal only ever **adds** monetization detection, so detection can never regress and a free app is unaffected (`monetized` unset ⇒ byte-identical behavior to today).

No doc changes: the `build-monetized-app` skill references were already fixed by #10335 and are current on develop.

## verification

```
$ bunx vitest run __tests__/unit/app-deploy-guidance.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)          # incl. 6 new structural-signal tests + both flagship normie phrasings

$ bun run test          # plugins/plugin-agent-orchestrator
 Test Files  144 passed | 4 skipped (148)
      Tests  1443 passed | 8 skipped (1451)

$ bun run typecheck     # tsgo --noEmit: clean
$ bun run lint:check    # biome: 269 files, no fixes
```

New tests pin: the regex gap (documents both normie phrasings as regex-misses), signal ⇒ edad/register contract on eliza-cloud, signal overrides the build-verb gate, agent-home weak-conditional ⇒ firm directive, no-signal/no-keyword ⇒ free contract unchanged, keyword-only still works without the signal.
