### PR TITLE
fix(cloud): partial-settle aborted /v1/messages streams — stop full-refunding delivered tokens (#11513)

### DIFF
--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -21,6 +21,7 @@ mock.module("@/lib/pricing", () => ({
     outputCost: 0.001,
     totalCost: 0.002,
   }),
+  estimateTokens: (text: string) => Math.ceil(text.length / 4),
   getProviderFromModel: () => "anthropic",
   getSafeModelParams: () => ({}),
   normalizeModelName: (model: string) => model,

--- a/packages/cloud/api/__tests__/messages-streaming-abort-billing.test.ts
+++ b/packages/cloud/api/__tests__/messages-streaming-abort-billing.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Money-leak reproduction tests for POST /api/v1/messages streaming aborts
+ * (#11513 — ports the /v1/chat/completions partial-settle fix from #11472).
+ *
+ * A credit reservation is a ~1.5x upfront hold that MUST be settled. Before
+ * the fix, a client abort mid-stream settled the reservation to 0 — a FULL
+ * refund — even though the tokens already streamed to the client were really
+ * generated and really billed to us by the provider (under-collection on
+ * every aborted stream). These tests drive the REAL credit-reservation
+ * settler (`createCreditReservationSettler`, not a mock) against a
+ * ledger-backed reservation and assert:
+ *
+ *   1. onAbort after delivered text deltas settles the reservation to
+ *      estimated-input + delivered-output cost (> 0), with billUsage called
+ *      exactly once — not a settleReservation(0) full refund.
+ *   2. A request-signal abort surfacing as an AbortError throw in the outer
+ *      stream catch (SDK onAbort never invoked) takes the same partial-settle
+ *      path.
+ *   3. onAbort racing the outer catch single-flights the settlement: one
+ *      reconcile, one billUsage, one analytics record.
+ *   4. A provider failure WITHOUT a request abort still refunds to 0 and
+ *      never bills (aborts are the only non-finish path that pays).
+ *
+ * `streamText`, `getLanguageModel`, and the billing-price lookup are mocked at
+ * the module boundary; the settler and reservation math are real.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Spread the real module so other test files importing from "ai" are not
+// stranded by the process-wide registry replacement; restore in afterAll.
+const aiActual = require("ai") as Record<string, unknown>;
+
+import { estimateTokens } from "@/lib/pricing";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+
+// The REAL settler — explicitly NOT mocked. This is the component under test.
+import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+
+// --- mock the AI SDK streamText (the only external boundary we drive) --------
+let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const streamText = mock((config: Record<string, unknown>) => {
+  if (!streamTextImpl) throw new Error("streamTextImpl not set");
+  return streamTextImpl(config);
+});
+mock.module("ai", () => ({
+  ...aiActual,
+  streamText,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getLanguageModel: () => ({}) as never,
+}));
+
+const INPUT_TOKEN_COST = 0.001;
+const OUTPUT_TOKEN_COST = 0.01;
+const billUsage = mock(async (_context: unknown, usage: unknown) => {
+  const record =
+    usage && typeof usage === "object"
+      ? (usage as {
+          inputTokens?: number;
+          promptTokens?: number;
+          outputTokens?: number;
+          completionTokens?: number;
+          totalTokens?: number;
+        })
+      : {};
+  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
+  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  const inputCost = inputTokens * INPUT_TOKEN_COST;
+  const outputCost = outputTokens * OUTPUT_TOKEN_COST;
+  return {
+    inputCost,
+    outputCost,
+    totalCost: inputCost + outputCost,
+    baseInputCost: inputCost,
+    baseOutputCost: outputCost,
+    baseTotalCost: inputCost + outputCost,
+    platformMarkup: 0,
+    inputTokens,
+    outputTokens,
+    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+    markupApplied: true,
+  };
+});
+const recordUsageAnalytics = mock(async () => ({ id: "usage-1" }));
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  billUsage,
+  recordUsageAnalytics,
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs.
+const { __streamingCreditTestHooks } = await import("../v1/messages/route");
+const { handleStream } = __streamingCreditTestHooks;
+
+afterAll(() => {
+  mock.module("ai", () => aiActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+});
+
+/**
+ * A faithful in-memory credit ledger. reserve() debits the ~1.5x hold up front;
+ * reconcile(actualCost) refunds (hold - actualCost) back. reconcile(0) therefore
+ * returns the full hold → balance restored to the pre-request value.
+ */
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold; // upfront hold debited
+  let reconcileCalls = 0;
+  const actualCosts: number[] = [];
+  return {
+    startBalance,
+    hold,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get actualCosts() {
+      return actualCosts;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        actualCosts.push(actualCost);
+        balance += hold - actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+const MODEL = "openai/gpt-oss-120b";
+const REQUEST = {
+  model: MODEL,
+  messages: [{ role: "user", content: "hello" }],
+  max_tokens: 256,
+  stream: true,
+} as never;
+
+/** Invoke handleStream with the test's settler and a fixed shape. */
+function callStream(
+  settleReservation: (actualCost: number) => Promise<unknown> | unknown,
+  options: { estimatedInputTokens?: number; signal?: AbortSignal } = {},
+) {
+  return handleStream(
+    MODEL,
+    undefined,
+    [{ role: "user", content: "hello" }] as never,
+    REQUEST,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    Date.now(),
+    options.estimatedInputTokens ?? 1,
+    {} as never,
+    undefined as never,
+    undefined,
+    options.signal,
+    30_000,
+    settleReservation as never,
+    "gateway" as never,
+  );
+}
+
+beforeEach(() => {
+  streamText.mockClear();
+  billUsage.mockClear();
+  recordUsageAnalytics.mockClear();
+  streamTextImpl = null;
+});
+
+describe("streaming /v1/messages — client abort settles delivered usage", () => {
+  test("abort after text deltas reconciles to prompt plus delivered-output cost, not 0", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    // Sanity: the upfront hold has already debited the balance.
+    expect(ledger.balance).toBe(100 - 0.015);
+
+    const estimatedInputTokens = 12;
+    const deliveredText = "partial response already sent";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+    expect(expectedCost).toBeGreaterThan(0);
+
+    let onAbortPromise: Promise<unknown> | undefined;
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          yield { type: "abort", reason: "client disconnected" };
+        })(),
+      };
+    };
+
+    const res = await callStream(settle, { estimatedInputTokens });
+    const body = await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    expect(body).toContain(deliveredText);
+    // The delivered tokens were BILLED (partial settle), not full-refunded.
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+    // The analytics record carries the aborted marker path (isSuccessful:false).
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("request-signal abort surfacing in the outer catch settles partial usage", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+
+    // SDK onAbort never invoked — only the AbortError throw in the fullStream
+    // loop. The outer catch must take the abort-partial-settle branch.
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield {
+          type: "text-delta",
+          id: "text-1",
+          text: deliveredText,
+        };
+        controller.abort();
+        throw new DOMException("The operation was aborted.", "AbortError");
+      })(),
+    });
+
+    const res = await callStream(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
+    const body = await res.text();
+
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - expectedCost, 10);
+  });
+
+  test("onAbort plus aborted-signal outer catch single-flights partial settlement", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const controller = new AbortController();
+    const estimatedInputTokens = 8;
+    const deliveredText = "sent before disconnect";
+    let onAbortPromise: Promise<unknown> | undefined;
+
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta",
+            id: "text-1",
+            text: deliveredText,
+          };
+          controller.abort();
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          throw new DOMException("The operation was aborted.", "AbortError");
+        })(),
+      };
+    };
+
+    const res = await callStream(settle, {
+      estimatedInputTokens,
+      signal: controller.signal,
+    });
+    await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+
+    // Both the onAbort callback and the outer catch fired; the settlement
+    // composed once: one reconcile, one billUsage, one analytics record.
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(ledger.actualCosts[0]).toBeGreaterThan(0);
+  });
+
+  test("provider failure without request abort refunds to 0 and does not bill", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const deliveredText = "sent before provider failure";
+
+    streamTextImpl = () => ({
+      fullStream: (async function* () {
+        yield {
+          type: "text-delta",
+          id: "text-1",
+          text: deliveredText,
+        };
+        throw new DOMException("upstream connection aborted", "AbortError");
+      })(),
+    });
+
+    const res = await callStream(settle);
+    const body = await res.text();
+
+    expect(body).toContain(deliveredText);
+    expect(body).toContain('"type":"error"');
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(recordUsageAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -15,11 +15,13 @@ import {
   type JSONValue,
   jsonSchema,
   type ModelMessage,
+  type StepResult,
   streamText,
   type TextPart,
   type ToolCallPart,
   type ToolContent,
   type ToolResultPart,
+  type ToolSet,
   type UserModelMessage,
 } from "ai";
 import { Hono } from "hono";
@@ -30,6 +32,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   calculateCost,
+  estimateTokens,
   getProviderFromModel,
   getSafeModelParams,
   normalizeModelName,
@@ -45,6 +48,7 @@ import {
 } from "@/lib/providers/language-model";
 import { getRequestIdempotencyKey } from "@/lib/runtime/request-context";
 import {
+  type AIUsage,
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
@@ -894,6 +898,166 @@ async function handleNonStream(
   }
 }
 
+function firstFiniteNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Aggregate the usage the provider already reported for FINISHED steps of an
+ * aborted stream. Mirrors /v1/chat/completions: on a client abort the SDK
+ * exposes the completed steps; their usage is the floor for what we bill.
+ */
+function summarizeFinishedStepUsage(
+  steps: readonly StepResult<ToolSet>[],
+): AIUsage | null {
+  let sawUsage = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let cacheReadInputTokens = 0;
+  let cacheWriteInputTokens = 0;
+
+  for (const step of steps) {
+    const usage = step.usage;
+    const stepInputTokens = firstFiniteNumber(usage.inputTokens) ?? 0;
+    const stepOutputTokens = firstFiniteNumber(usage.outputTokens) ?? 0;
+    const stepTotalTokens =
+      firstFiniteNumber(usage.totalTokens) ??
+      stepInputTokens + stepOutputTokens;
+    const stepCacheReadTokens =
+      firstFiniteNumber(
+        usage.inputTokenDetails?.cacheReadTokens,
+        usage.cachedInputTokens,
+      ) ?? 0;
+    const stepCacheWriteTokens =
+      firstFiniteNumber(usage.inputTokenDetails?.cacheWriteTokens) ?? 0;
+
+    if (
+      stepInputTokens > 0 ||
+      stepOutputTokens > 0 ||
+      stepTotalTokens > 0 ||
+      stepCacheReadTokens > 0 ||
+      stepCacheWriteTokens > 0
+    ) {
+      sawUsage = true;
+    }
+
+    inputTokens += stepInputTokens;
+    outputTokens += stepOutputTokens;
+    totalTokens += stepTotalTokens;
+    cacheReadInputTokens += stepCacheReadTokens;
+    cacheWriteInputTokens += stepCacheWriteTokens;
+  }
+
+  if (!sawUsage) return null;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    cacheReadInputTokens,
+    cacheWriteInputTokens,
+  };
+}
+
+/**
+ * Partial settlement for a client-aborted stream (#11513, ports the merged
+ * /v1/chat/completions fix from #11472). The tokens already delivered to the
+ * client were really generated and really cost us provider spend — a
+ * `settleReservation(0)` full refund here is under-collection. Bill
+ * max(estimated input, finished-step input) + max(delivered-text estimate,
+ * finished-step output) and settle the reservation at that cost. If billing
+ * itself fails, fall back to a full refund so the hold is never leaked.
+ */
+async function settleStreamingAbortReservation(params: {
+  model: string;
+  provider: string;
+  user: { id: string; organization_id: string };
+  apiKey: { id: string } | null;
+  affiliateCode: string | null;
+  startTime: number;
+  billingSource: PricingBillingSource;
+  estimatedInputTokens: number;
+  deliveredText: string;
+  steps: readonly StepResult<ToolSet>[];
+  settleReservation: (
+    actualCost: number,
+  ) => Promise<CreditReconciliationResult | null>;
+}): Promise<CreditReconciliationResult | null> {
+  const finishedStepUsage = summarizeFinishedStepUsage(params.steps);
+  const deliveredOutputTokens = estimateTokens(params.deliveredText);
+  const inputTokens = Math.max(
+    params.estimatedInputTokens,
+    finishedStepUsage?.inputTokens ?? 0,
+  );
+  const outputTokens = Math.max(
+    deliveredOutputTokens,
+    finishedStepUsage?.outputTokens ?? 0,
+  );
+  const totalTokens = Math.max(
+    inputTokens + outputTokens,
+    finishedStepUsage?.totalTokens ?? 0,
+  );
+
+  try {
+    const billingContext = {
+      organizationId: params.user.organization_id,
+      userId: params.user.id,
+      apiKeyId: params.apiKey?.id,
+      model: params.model,
+      provider: params.provider,
+      billingSource: params.billingSource,
+      affiliateCode: params.affiliateCode,
+    };
+    const billing = await billUsage(billingContext, {
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      cacheReadInputTokens: finishedStepUsage?.cacheReadInputTokens,
+      cacheWriteInputTokens: finishedStepUsage?.cacheWriteInputTokens,
+    });
+    const reconciliation = await params.settleReservation(billing.totalCost);
+
+    await recordUsageAnalytics(billingContext, billing, {
+      type: "chat",
+      isSuccessful: false,
+      errorMessage: "client_aborted_stream",
+      content: params.deliveredText,
+      latencyMs: Date.now() - params.startTime,
+    });
+
+    logger.info(
+      "[Messages API] Stream aborted; reservation partially settled",
+      {
+        model: params.model,
+        inputTokens: billing.inputTokens,
+        outputTokens: billing.outputTokens,
+        totalCost: billing.totalCost,
+        deliveredChars: params.deliveredText.length,
+        finishedSteps: params.steps.length,
+      },
+    );
+
+    return reconciliation;
+  } catch (error) {
+    logger.error(
+      "[Messages API] Stream abort partial settlement failed; refunding reservation",
+      {
+        model: params.model,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return await params.settleReservation(0);
+  }
+}
+
 async function handleStream(
   model: string,
   systemPrompt: string | undefined,
@@ -922,6 +1086,49 @@ async function handleStream(
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
 
+  // Text already delivered to the client — the floor for abort billing.
+  let deliveredText = "";
+  // Single-flight settlement composition (mirrors /v1/chat/completions):
+  // onFinish / onAbort / onError / the outer stream catch can all race on a
+  // client disconnect; only the first settlement factory may run. The
+  // underlying settler is itself first-call-wins idempotent, but the abort
+  // path also bills + records analytics — that work must not run twice.
+  let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
+    null;
+
+  const settleStreamingOnce = (
+    factory: () => Promise<CreditReconciliationResult | null>,
+  ): Promise<CreditReconciliationResult | null> => {
+    if (!streamingSettlementPromise) {
+      streamingSettlementPromise = factory().catch((error) => {
+        streamingSettlementPromise = null;
+        throw error;
+      });
+    }
+    return streamingSettlementPromise;
+  };
+
+  const refundStreamingReservationOnce = () =>
+    settleStreamingOnce(async () => await settleReservation(0));
+
+  const settleStreamingAbortOnce = (steps: readonly StepResult<ToolSet>[]) =>
+    settleStreamingOnce(
+      async () =>
+        await settleStreamingAbortReservation({
+          model,
+          provider,
+          user,
+          apiKey,
+          affiliateCode,
+          startTime,
+          billingSource,
+          estimatedInputTokens,
+          deliveredText,
+          steps,
+          settleReservation,
+        }),
+    );
+
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
     cotBudget != null
@@ -948,51 +1155,65 @@ async function handleStream(
     ...(toolChoice ? { toolChoice } : {}),
     ...cotOptions,
     onFinish: async ({ text, totalUsage }) => {
-      try {
-        const billing = await billUsage(
-          {
-            organizationId: user.organization_id,
-            userId: user.id,
-            apiKeyId: apiKey?.id,
-            model,
-            provider,
-            billingSource,
-            affiliateCode,
-          },
-          totalUsage,
-        );
-        await settleReservation(billing.totalCost);
+      await settleStreamingOnce(async () => {
+        try {
+          const billing = await billUsage(
+            {
+              organizationId: user.organization_id,
+              userId: user.id,
+              apiKeyId: apiKey?.id,
+              model,
+              provider,
+              billingSource,
+              affiliateCode,
+            },
+            totalUsage,
+          );
+          const reconciliation = await settleReservation(billing.totalCost);
 
-        await recordUsageAnalytics(
-          {
-            organizationId: user.organization_id,
-            userId: user.id,
-            apiKeyId: apiKey?.id,
-            model,
-            provider,
-            billingSource,
-          },
-          billing,
-          { type: "chat", content: text },
-        );
+          await recordUsageAnalytics(
+            {
+              organizationId: user.organization_id,
+              userId: user.id,
+              apiKeyId: apiKey?.id,
+              model,
+              provider,
+              billingSource,
+            },
+            billing,
+            { type: "chat", content: text },
+          );
 
-        logger.info("[Messages API] Streaming complete", {
-          durationMs: Date.now() - startTime,
-          inputTokens: billing.inputTokens,
-          outputTokens: billing.outputTokens,
-        });
-      } catch (error) {
-        await settleReservation(0);
-        logger.error("[Messages API] onFinish billing error", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+          logger.info("[Messages API] Streaming complete", {
+            durationMs: Date.now() - startTime,
+            inputTokens: billing.inputTokens,
+            outputTokens: billing.outputTokens,
+          });
+
+          return reconciliation;
+        } catch (error) {
+          const reconciliation = await settleReservation(0);
+          logger.error("[Messages API] onFinish billing error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return reconciliation;
+        }
+      });
     },
-    onAbort: async () => {
-      await settleReservation(0);
+    // A client abort after tokens were streamed is NOT free (#11513): the
+    // delivered tokens were really generated and really billed to us by the
+    // provider. Settle the reservation at the delivered input+output cost
+    // instead of full-refunding it (which under-collected on every abort).
+    onAbort: async ({
+      steps,
+    }: {
+      readonly steps: readonly StepResult<ToolSet>[];
+    }) => {
+      await settleStreamingAbortOnce(steps);
       logger.info("[Messages API] Stream aborted before completion", {
         model,
         estimatedInputTokens,
+        deliveredOutputTokens: estimateTokens(deliveredText),
       });
     },
     // A provider error during streaming (e.g. cerebras 429/5xx) fires onError —
@@ -1001,7 +1222,7 @@ async function handleStream(
     // non-streaming error path's settleReservation(0); the settler is
     // idempotent (first-call-wins) so this cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
-      await settleReservation(0);
+      await refundStreamingReservationOnce();
       logger.error(
         "[Messages API] Stream provider error — reservation refunded",
         {
@@ -1010,7 +1231,10 @@ async function handleStream(
         },
       );
     },
-  });
+    // The explicit `steps: readonly StepResult<ToolSet>[]` onAbort annotation
+    // doesn't unify with this call's narrower inferred tools generic; cast the
+    // config the same way /v1/chat/completions does.
+  } as Parameters<typeof streamText>[0]);
 
   const encoder = new TextEncoder();
 
@@ -1135,6 +1359,7 @@ async function handleStream(
                   delta: { type: "text_delta", text: part.text },
                 }),
               );
+              deliveredText += part.text;
               break;
             }
 
@@ -1241,10 +1466,17 @@ async function handleStream(
         // doesn't await) onError — e.g. a fullStream `error` part re-thrown here,
         // or a controller.enqueue throw on client disconnect racing ahead of
         // onAbort. Settle the reservation here too so the upfront hold is never
-        // leaked (a permanent overcharge). The settler is first-call-wins
-        // idempotent, so this cannot double-refund if onError already won the
-        // race. Mirrors the /v1/chat/completions backstop.
-        await settleReservation(0);
+        // leaked (a permanent overcharge). When the request signal actually
+        // aborted, bill the delivered tokens (#11513) instead of refunding;
+        // otherwise release the hold to 0. The single-flight guard + the
+        // first-call-wins settler make this race-safe with onAbort/onError.
+        // Mirrors the /v1/chat/completions backstop.
+        const streamAborted = abortSignal?.aborted === true;
+        if (streamAborted) {
+          await settleStreamingAbortOnce([]);
+        } else {
+          await refundStreamingReservationOnce();
+        }
         const message = error instanceof Error ? error.message : String(error);
         logger.error("[Messages API] Stream error", { error: message });
         controller.enqueue(
@@ -1270,3 +1502,16 @@ async function handleStream(
 }
 
 export default app;
+
+/**
+ * Test-only seam for the streaming credit-settlement behavior (the aborted
+ * stream partial-settle repro in
+ * `__tests__/messages-streaming-abort-billing.test.ts`). Exposes the internal
+ * streaming handler so a test can drive it with a mocked `streamText` (forcing
+ * a client abort mid-stream) and a REAL credit-reservation settler, then
+ * assert the reservation settles to the delivered token cost instead of a
+ * full refund. The `__` prefix + `TestHooks` suffix mark it as non-public.
+ */
+export const __streamingCreditTestHooks = {
+  handleStream,
+} as const;


### PR DESCRIPTION
## Summary

Fixes #11513 (money — under-collection). An aborted streaming request on `POST /api/v1/messages` settled its upfront credit reservation to **0** — a full refund — in both the `streamText` `onAbort` callback and the outer stream catch. The tokens already streamed to the client were really generated and really billed to us by the provider, so every client abort leaked the delivered-token cost. This ports the partial-settle pattern already merged for `/v1/chat/completions` in #11472.

## Changes — `packages/cloud/api/v1/messages/route.ts`

- Accumulate `deliveredText` from the SSE `text-delta` loop.
- New `settleStreamingAbortReservation()` + `summarizeFinishedStepUsage()` (messages-route equivalents of the chat route's non-exported helpers): on abort, bill `max(estimatedInputTokens, finished-step input)` + `max(estimateTokens(deliveredText), finished-step output)` via `billUsage`, settle the reservation at that cost, and record analytics with the `client_aborted_stream` marker (`isSuccessful: false`). If billing itself fails, fall back to a full refund so the hold is never leaked.
- Wired at **both** abort seams: the streaming `onAbort` (receives finished `steps`) and the abort-capable outer stream catch, gated on `abortSignal?.aborted === true`. Non-abort provider errors still refund to 0.
- Single-flight `settleStreamingOnce` guard composed over the existing settler so `onFinish` / `onAbort` / `onError` / outer-catch races cannot double-bill or double-record. The shared `createCreditReservationSettler` is **untouched** (that's #11512, [cloud-money] lane) — the guard composes on top of its first-call-wins idempotency.
- Also updated `__tests__/messages-iac-fast-path.test.ts`'s wholesale `@/lib/pricing` mock to include `estimateTokens` (the route's new import otherwise fails that test's module load).

## Test — `packages/cloud/api/__tests__/messages-streaming-abort-billing.test.ts`

Mirrors `chat-completions-streaming-credit-leak.test.ts`: drives the route's real streaming handler (via a `__streamingCreditTestHooks` seam) with a mocked `streamText` boundary and the **real** `createCreditReservationSettler` against a ledger-backed reservation:

1. `onAbort` after delivered text deltas settles to estimated-input + delivered-output cost (> 0, exact), `billUsage` called once — not a full refund.
2. Request-signal abort surfacing as an `AbortError` throw in the outer catch (SDK `onAbort` never invoked) takes the same partial-settle path.
3. `onAbort` racing the outer catch single-flights: one reconcile, one `billUsage`, one analytics record.
4. Provider failure **without** a request abort still refunds to 0 and never bills.

```
bun test __tests__/messages-streaming-abort-billing.test.ts

 4 pass
 0 fail
 28 expect() calls
Ran 4 tests across 1 file. [1015.00ms]
```

## Mutation check

Reverted both abort settlements to `settleReservation(0)` and re-ran:

```
error: expect(received).toHaveBeenCalledTimes(expected)
(fail) streaming /v1/messages — client abort settles delivered usage > abort after text deltas reconciles to prompt plus delivered-output cost, not 0
(fail) streaming /v1/messages — client abort settles delivered usage > request-signal abort surfacing in the outer catch settles partial usage
(fail) streaming /v1/messages — client abort settles delivered usage > onAbort plus aborted-signal outer catch single-flights partial settlement
 1 pass
 3 fail
```

(The surviving test is the intentional non-abort refund path.) Fix restored → 4/4 green.

## Verification

- `bunx biome check --write` clean on changed files.
- Package typecheck (`tsgo --noEmit`): no errors in changed files; the only errors on latest develop are pre-existing in `../shared/src/lib/services/team-credential-pool/*` (introduced by #11487, missing `@elizaos/app-core/account-pool` local build artifact — untouched here).
- Full `bun test __tests__` on this branch: 14 pre-existing local failures vs **21** on a clean develop baseline (stash/run/pop) — strictly fewer, none new, none in the changed surface; the chat-completions streaming-credit-leak suite and this new suite both pass in full-suite order.

[cloud-security]
---
**Adversarial review (independent Fable agent):** `correct-with-nits`, closes the leak, test is mutation-worthy. The only findings are **nits that are parity with the merged #11472** (an onError-wins-race and tool-call-delta accounting corner) — both err toward under-collection (favor the user), not over-charging, and match the chat route exactly. Shared `createCreditReservationSettler` untouched (#11512 lane). Money-path → @lalalune for merge; not self-merged.
