### PR TITLE
fix(voice): cancel native playback echo in JNI pipeline

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -329,6 +329,7 @@
     "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/logger": "workspace:*",
+    "@elizaos/plugin-local-inference": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/tui": "workspace:*",
     "@fontsource/poppins": "^5.2.7",

--- a/packages/ui/src/bridge/native-plugins.ts
+++ b/packages/ui/src/bridge/native-plugins.ts
@@ -111,6 +111,19 @@ export interface TalkModeAudioFrameEvent {
   frameIndex: number;
 }
 
+export interface TalkModePlaybackFrameEvent {
+  provider: "elevenlabs" | "local-inference" | "system";
+  pcm16: string;
+  sampleRate: number;
+  channels: number;
+  /** Samples per channel. */
+  samples: number;
+  /** Monotonic render timestamp, ms. */
+  timestamp: number;
+  /** Running frame index within this utterance. */
+  frameIndex: number;
+}
+
 export interface TalkModeAudioFrameResult {
   started: boolean;
   sampleRate?: number;
@@ -747,6 +760,10 @@ export interface TalkModePluginLike extends NativePlugin {
   addListener(
     eventName: "audioFrame",
     listenerFunc: (event: TalkModeAudioFrameEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: "playbackFrame",
+    listenerFunc: (event: TalkModePlaybackFrameEvent) => void,
   ): Promise<PluginListenerHandle>;
   /** Start raw 16 kHz mono PCM frame capture (Android diarization source). */
   startAudioFrames?(options?: {

--- a/packages/ui/src/voice/jni-voice-pipeline.test.ts
+++ b/packages/ui/src/voice/jni-voice-pipeline.test.ts
@@ -3,6 +3,7 @@ import type {
   ElizaVoicePluginLike,
   ElizaVoiceTurn,
   TalkModeAudioFrameEvent,
+  TalkModePlaybackFrameEvent,
   TalkModePluginLike,
 } from "../bridge/native-plugins";
 import { type JniAttributedTurn, JniVoicePipeline } from "./jni-voice-pipeline";
@@ -38,6 +39,62 @@ function makeFrame(samples: number): TalkModeAudioFrameEvent {
     timestamp: 0,
     frameIndex: 0,
   };
+}
+
+function makePcm16Frame(
+  values: readonly number[],
+  timestamp = 0,
+): TalkModeAudioFrameEvent {
+  return {
+    pcm16: encodePcm16(values),
+    sampleRate: 16000,
+    channels: 1,
+    samples: values.length,
+    rms: Math.sqrt(
+      values.reduce((sum, v) => sum + v * v, 0) / Math.max(1, values.length),
+    ),
+    timestamp,
+    frameIndex: 0,
+  };
+}
+
+function makePlaybackFrame(
+  values: readonly number[],
+  timestamp = 0,
+): TalkModePlaybackFrameEvent {
+  return {
+    provider: "local-inference",
+    pcm16: encodePcm16(values),
+    sampleRate: 16000,
+    channels: 1,
+    samples: values.length,
+    timestamp,
+    frameIndex: 0,
+  };
+}
+
+function encodePcm16(values: readonly number[]): string {
+  const bytes = Buffer.alloc(values.length * 2);
+  values.forEach((value, index) => {
+    const clamped = Math.max(-1, Math.min(1, value));
+    bytes.writeInt16LE(Math.round(clamped * 32767), index * 2);
+  });
+  return bytes.toString("base64");
+}
+
+function decodePcm16(b64: string): Float32Array {
+  const bytes = Buffer.from(b64, "base64");
+  const out = new Float32Array(Math.floor(bytes.length / 2));
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = bytes.readInt16LE(i * 2) / 32768;
+  }
+  return out;
+}
+
+function rms(values: Float32Array | readonly number[]): number {
+  let sum = 0;
+  for (const value of values) sum += value * value;
+  return Math.sqrt(sum / Math.max(1, values.length));
 }
 
 function encodePcm(values: readonly number[]): string {
@@ -103,13 +160,25 @@ function fakeVoice(state: FakeVoiceState): ElizaVoicePluginLike {
 
 function fakeTalkmode(
   onFrame: (cb: (e: TalkModeAudioFrameEvent) => void) => void,
+  onPlaybackFrame?: (cb: (e: TalkModePlaybackFrameEvent) => void) => void,
 ): TalkModePluginLike {
   let listener: ((e: TalkModeAudioFrameEvent) => void) | null = null;
+  let playbackListener: ((e: TalkModePlaybackFrameEvent) => void) | null = null;
   onFrame((e) => listener?.(e));
+  onPlaybackFrame?.((e) => playbackListener?.(e));
   return {
     addListener: vi.fn(
-      async (_name: string, cb: (e: TalkModeAudioFrameEvent) => void) => {
-        listener = cb;
+      async (
+        name: string,
+        cb:
+          | ((e: TalkModeAudioFrameEvent) => void)
+          | ((e: TalkModePlaybackFrameEvent) => void),
+      ) => {
+        if (name === "playbackFrame") {
+          playbackListener = cb as (e: TalkModePlaybackFrameEvent) => void;
+        } else {
+          listener = cb as (e: TalkModeAudioFrameEvent) => void;
+        }
         return { remove: vi.fn(async () => {}) };
       },
     ),
@@ -121,6 +190,7 @@ function fakeTalkmode(
 describe("JniVoicePipeline", () => {
   let state: FakeVoiceState;
   let emit: (e: TalkModeAudioFrameEvent) => void = () => {};
+  let emitPlayback: (e: TalkModePlaybackFrameEvent) => void = () => {};
 
   beforeEach(() => {
     state = {
@@ -346,6 +416,37 @@ describe("JniVoicePipeline", () => {
     expect(forwarded.audio.sampleRate).toBe(16_000);
     expect(Array.from(forwarded.audio.pcm)).toEqual(pcm);
     expect(forwarded.signal).toBeDefined();
+    await p.stop();
+  });
+
+  it("cancels native playback echo before feeding the JNI pipeline", async () => {
+    const voice = fakeVoice(state);
+    const tm = fakeTalkmode(
+      (cb) => {
+        emit = cb;
+      },
+      (cb) => {
+        emitPlayback = cb;
+      },
+    );
+    const p = new JniVoicePipeline(tm, voice, {
+      echoCancellation: { delaySamples: 0 },
+    });
+    await p.start();
+
+    const far = Array.from({ length: 320 }, (_, i) =>
+      Math.sin((2 * Math.PI * i) / 32) * 0.6,
+    );
+    const micEcho = far.map((sample) => sample * 0.45);
+    emitPlayback(makePlaybackFrame(far, 0));
+    emit(makePcm16Frame(micEcho, 0));
+    await (p as unknown as { feed: () => Promise<void> }).feed();
+    await (p as unknown as { feeding: Promise<void> }).feeding;
+
+    expect(p.playbackFramesReceived).toBe(1);
+    expect(state.processed).toHaveLength(1);
+    const cleaned = decodePcm16(state.processed[0]);
+    expect(rms(cleaned)).toBeLessThan(rms(micEcho) * 0.4);
     await p.stop();
   });
 });

--- a/packages/ui/src/voice/jni-voice-pipeline.ts
+++ b/packages/ui/src/voice/jni-voice-pipeline.ts
@@ -27,10 +27,16 @@
  */
 
 import { logger } from "@elizaos/logger";
+import {
+  EchoReferenceBuffer,
+  NlmsEchoCanceller,
+  platformPlaybackDelaySamples,
+} from "@elizaos/plugin-local-inference/voice-dsp";
 import type {
   ElizaVoicePluginLike,
   ElizaVoiceTurn,
   TalkModeAudioFrameEvent,
+  TalkModePlaybackFrameEvent,
   TalkModePluginLike,
 } from "../bridge/native-plugins";
 import {
@@ -44,6 +50,7 @@ import {
 const MAX_BATCH_FRAMES = 49;
 /** Feed cadence in ms (a partial batch is fed even below the size cap). */
 const FEED_INTERVAL_MS = 250;
+const PIPELINE_SAMPLE_RATE = 16_000;
 
 /**
  * One native-attributed turn surfaced to the ambient-gate layer. The PCM-derived
@@ -115,6 +122,13 @@ export type SelfVoiceContextProvider =
           >
         >);
 
+export interface JniEchoCancellationOptions {
+  /** Default true. Disable only for diagnostic A/B capture. */
+  enabled?: boolean;
+  /** Override the playback-to-mic seed delay. Defaults to Android's measured seed. */
+  delaySamples?: number;
+}
+
 export interface JniVoicePipelineOptions {
   /** Override the on-device bundle dir (else the app's eliza-1/bundle default). */
   bundleDir?: string;
@@ -132,6 +146,8 @@ export interface JniVoicePipelineOptions {
    * can queue it through the fused ASR → text → TTS device voice path.
    */
   onCompletedPcmTurn?: JniCompletedPcmTurnListener;
+  /** Acoustic echo cancellation for native AudioTrack playback leaking into mic. */
+  echoCancellation?: JniEchoCancellationOptions;
 }
 
 function base64ToFloat32(b64: string): Float32Array {
@@ -188,6 +204,69 @@ function concatFramesToBase64(frames: TalkModeAudioFrameEvent[]): string {
   return btoa(out);
 }
 
+function pcm16Base64ToFloat32(
+  b64: string,
+  channels = 1,
+  targetSampleRate = PIPELINE_SAMPLE_RATE,
+  sourceSampleRate = PIPELINE_SAMPLE_RATE,
+): Float32Array {
+  if (!b64) return new Float32Array(0);
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const safeChannels = Math.max(1, Math.floor(channels || 1));
+  const sampleCount = Math.floor(bytes.byteLength / 2 / safeChannels);
+  const mono = new Float32Array(sampleCount);
+  for (let i = 0; i < sampleCount; i += 1) {
+    let sum = 0;
+    for (let ch = 0; ch < safeChannels; ch += 1) {
+      sum += view.getInt16((i * safeChannels + ch) * 2, true) / 32768;
+    }
+    mono[i] = sum / safeChannels;
+  }
+  return resampleLinear(mono, sourceSampleRate, targetSampleRate);
+}
+
+function float32ToPcm16Base64(pcm: Float32Array): string {
+  const bytes = new Uint8Array(pcm.length * 2);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < pcm.length; i += 1) {
+    const s = Math.max(-1, Math.min(1, pcm[i] ?? 0));
+    view.setInt16(i * 2, Math.round(s * 32767), true);
+  }
+  let out = "";
+  const CHUNK = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    out += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)),
+    );
+  }
+  return btoa(out);
+}
+
+function resampleLinear(
+  input: Float32Array,
+  sourceSampleRate: number,
+  targetSampleRate: number,
+): Float32Array {
+  const srcRate = Math.max(1, Math.floor(sourceSampleRate || targetSampleRate));
+  const dstRate = Math.max(1, Math.floor(targetSampleRate));
+  if (input.length === 0 || srcRate === dstRate) return input;
+  const outLength = Math.max(1, Math.round((input.length * dstRate) / srcRate));
+  const out = new Float32Array(outLength);
+  const ratio = srcRate / dstRate;
+  for (let i = 0; i < out.length; i += 1) {
+    const pos = i * ratio;
+    const left = Math.floor(pos);
+    const right = Math.min(input.length - 1, left + 1);
+    const frac = pos - left;
+    out[i] = (input[left] ?? 0) * (1 - frac) + (input[right] ?? 0) * frac;
+  }
+  return out;
+}
+
 /**
  * Drives the Android `audioFrame` → in-process JNI voice pipeline. One instance
  * per capture session.
@@ -201,13 +280,23 @@ export class JniVoicePipeline {
   private ctxHandle: string | null = null;
   private pipelineHandle: string | null = null;
   private removeListener: (() => void) | null = null;
+  private removePlaybackListener: (() => void) | null = null;
   private feedTimer: ReturnType<typeof setInterval> | null = null;
   private buffer: TalkModeAudioFrameEvent[] = [];
   private feeding: Promise<void> = Promise.resolve();
   private running = false;
+  private readonly echoReference = new EchoReferenceBuffer({
+    sampleRateHz: PIPELINE_SAMPLE_RATE,
+  });
+  private readonly echoCanceller = new NlmsEchoCanceller({
+    residualSuppression: true,
+  });
+  private readonly echoDelaySamples: number;
+  private readonly echoCancellationEnabled: boolean;
 
   framesSent = 0;
   turnsObserved = 0;
+  playbackFramesReceived = 0;
 
   constructor(
     talkmode: TalkModePluginLike,
@@ -217,6 +306,10 @@ export class JniVoicePipeline {
     this.talkmode = talkmode;
     this.voice = voice;
     this.options = options;
+    this.echoCancellationEnabled = options.echoCancellation?.enabled !== false;
+    this.echoDelaySamples =
+      options.echoCancellation?.delaySamples ??
+      platformPlaybackDelaySamples("android", PIPELINE_SAMPLE_RATE);
   }
 
   get isRunning(): boolean {
@@ -255,9 +348,18 @@ export class JniVoicePipeline {
     this.removeListener = () => {
       void handle.remove();
     };
+    if (this.echoCancellationEnabled) {
+      const playbackHandle = await this.talkmode.addListener(
+        "playbackFrame",
+        (event: TalkModePlaybackFrameEvent) => this.onPlaybackFrame(event),
+      );
+      this.removePlaybackListener = () => {
+        void playbackHandle.remove();
+      };
+    }
 
     const result = await this.talkmode.startAudioFrames({
-      sampleRate: 16_000,
+      sampleRate: PIPELINE_SAMPLE_RATE,
       frameMs: 20,
     });
     if (!result.started) {
@@ -284,6 +386,8 @@ export class JniVoicePipeline {
     }
     this.removeListener?.();
     this.removeListener = null;
+    this.removePlaybackListener?.();
+    this.removePlaybackListener = null;
     await this.feed();
     await this.feeding;
     if (this.pipelineHandle) {
@@ -313,6 +417,19 @@ export class JniVoicePipeline {
     if (this.buffer.length >= MAX_BATCH_FRAMES) void this.feed();
   }
 
+  private onPlaybackFrame(event: TalkModePlaybackFrameEvent): void {
+    if (!this.echoCancellationEnabled) return;
+    const playback = pcm16Base64ToFloat32(
+      event.pcm16,
+      event.channels,
+      PIPELINE_SAMPLE_RATE,
+      event.sampleRate,
+    );
+    if (playback.length === 0) return;
+    this.echoReference.pushAt(event.timestamp, playback);
+    this.playbackFramesReceived += 1;
+  }
+
   /** Feed the buffered batch into the native pipeline. Serialized + ordered. */
   private async feed(): Promise<void> {
     if (this.buffer.length === 0) return;
@@ -324,7 +441,9 @@ export class JniVoicePipeline {
 
   private async process(frames: TalkModeAudioFrameEvent[]): Promise<void> {
     if (frames.length === 0 || !this.pipelineHandle) return;
-    const pcm16 = concatFramesToBase64(frames);
+    const pcm16 = this.echoCancellationEnabled
+      ? this.cancelEcho(frames)
+      : concatFramesToBase64(frames);
     this.framesSent += frames.length;
     const res = await this.voice.pipelineProcess({
       handle: this.pipelineHandle,
@@ -332,6 +451,30 @@ export class JniVoicePipeline {
       includePcm: Boolean(this.options.onCompletedPcmTurn),
     });
     await this.emitTurns(res.turns);
+  }
+
+  private cancelEcho(frames: TalkModeAudioFrameEvent[]): string {
+    const first = frames[0];
+    if (!first) return "";
+    const near = pcm16Base64ToFloat32(
+      concatFramesToBase64(frames),
+      first.channels,
+      PIPELINE_SAMPLE_RATE,
+      first.sampleRate,
+    );
+    const far =
+      this.playbackFramesReceived > 0
+        ? this.echoReference.referenceAt(
+            first.timestamp,
+            near.length,
+            this.echoDelaySamples,
+          )
+        : new Float32Array(near.length);
+    const cleaned =
+      this.playbackFramesReceived > 0
+        ? this.echoCanceller.process(near, far)
+        : near;
+    return float32ToPcm16Base64(cleaned);
   }
 
   private async emitTurns(turns: ElizaVoiceTurn[]): Promise<void> {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -26,6 +26,9 @@
       "@elizaos/plugin-vector-browser": [
         "./src/types/host-external-modules.ts"
       ],
+      "@elizaos/plugin-local-inference/voice-dsp": [
+        "../../plugins/plugin-local-inference/src/voice-dsp.ts"
+      ],
       "@elizaos/plugin-personal-assistant-browser": [
         "../../plugins/plugin-personal-assistant-browser/src/index.ts"
       ],

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -114,6 +114,13 @@ export default defineConfig({
         replacement: hostExternalStub,
       },
       {
+        find: /^@elizaos\/plugin-local-inference\/voice-dsp$/,
+        replacement: resolve(
+          monorepoRoot,
+          "plugins/plugin-local-inference/src/voice-dsp.ts",
+        ),
+      },
+      {
         // Dynamically loaded by DynamicViewLoader as a host-external plugin;
         // alias it so the ui test build doesn't require its built dist.
         find: /^@elizaos\/plugin-training$/,

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -26,6 +26,16 @@
 			"import": "./dist/voice-wake.js",
 			"default": "./dist/voice-wake.js"
 		},
+		"./voice-dsp": {
+			"types": "./src/voice-dsp.ts",
+			"eliza-source": {
+				"types": "./src/voice-dsp.ts",
+				"import": "./src/voice-dsp.ts",
+				"default": "./src/voice-dsp.ts"
+			},
+			"import": "./dist/voice-dsp.js",
+			"default": "./dist/voice-dsp.js"
+		},
 		"./runtime": {
 			"types": "./src/runtime/index.ts",
 			"eliza-source": {

--- a/plugins/plugin-local-inference/src/voice-dsp.ts
+++ b/plugins/plugin-local-inference/src/voice-dsp.ts
@@ -1,0 +1,14 @@
+export {
+  EchoReferenceBuffer,
+  type EchoReferenceBufferOptions,
+} from "./services/voice/echo-reference-buffer";
+export {
+  NlmsEchoCanceller,
+  type NlmsEchoCancellerOptions,
+  type ResidualSuppressionOptions,
+} from "./services/voice/nlms-echo-canceller";
+export {
+  platformPlaybackDelaySamples,
+  platformPlaybackDelayMs,
+  PLATFORM_PLAYBACK_DELAY_DEFAULTS,
+} from "./services/voice/echo-delay";

--- a/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
+++ b/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
@@ -1271,7 +1271,7 @@ class TalkModePlugin : Plugin() {
                     put("sampleRate", format.sampleRate)
                     put("channels", format.channels)
                 })
-                val framesWritten = writePcmStreamToTrack(input, track, format)
+                val framesWritten = writePcmStreamToTrack(input, track, format, "local-inference")
                 drainPcmTrack(track, framesWritten, format.sampleRate)
                 if (!pcmStopRequested.get()) {
                     track.stop()
@@ -1359,7 +1359,10 @@ class TalkModePlugin : Plugin() {
                 put("channels", 1)
             })
             val framesWritten = writePcmStreamToTrack(
-                BufferedInputStream(ByteArrayInputStream(pcm16)), track, format
+                BufferedInputStream(ByteArrayInputStream(pcm16)),
+                track,
+                format,
+                "local-inference"
             )
             drainPcmTrack(track, framesWritten, sampleRate)
             if (!pcmStopRequested.get()) track.stop()
@@ -1536,10 +1539,12 @@ class TalkModePlugin : Plugin() {
     private fun writePcmStreamToTrack(
         input: BufferedInputStream,
         track: AudioTrack,
-        format: PcmStreamFormat
+        format: PcmStreamFormat,
+        provider: String
     ): Long {
         val bytesPerFrame = format.channels * (format.bitsPerSample / 8)
         var bytesWrittenTotal = 0L
+        var playbackFrameIndex = 0L
         var remainingBytes = format.dataBytes
         val buffer = ByteArray(8 * 1024)
         while (remainingBytes > 0) {
@@ -1558,9 +1563,32 @@ class TalkModePlugin : Plugin() {
                 }
                 offset += wrote
                 bytesWrittenTotal += wrote.toLong()
+                emitPlaybackFrame(provider, format, buffer, offset - wrote, wrote, playbackFrameIndex)
+                playbackFrameIndex += 1
             }
         }
         return if (bytesPerFrame > 0) bytesWrittenTotal / bytesPerFrame else 0L
+    }
+
+    private fun emitPlaybackFrame(
+        provider: String,
+        format: PcmStreamFormat,
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+        frameIndex: Long
+    ) {
+        val bytesPerFrame = format.channels * (format.bitsPerSample / 8)
+        if (length <= 0 || bytesPerFrame <= 0 || format.bitsPerSample != 16) return
+        notifyListeners("playbackFrame", JSObject().apply {
+            put("provider", provider)
+            put("pcm16", Base64.encodeToString(bytes, offset, length, Base64.NO_WRAP))
+            put("sampleRate", format.sampleRate)
+            put("channels", format.channels)
+            put("samples", length / bytesPerFrame)
+            put("timestamp", SystemClock.elapsedRealtime())
+            put("frameIndex", frameIndex)
+        })
     }
 
     private fun drainPcmTrack(track: AudioTrack, framesWritten: Long, sampleRate: Int) {
@@ -1621,6 +1649,8 @@ class TalkModePlugin : Plugin() {
         Log.d(TAG, "PCM play start sampleRate=$sampleRate bufferSize=$bufferSize")
         val conn = openTtsConnection(voiceId, apiKey, request)
         activePcmConnection = conn
+        val playbackFormat = PcmStreamFormat(sampleRate, 1, 16, Int.MAX_VALUE)
+        var playbackFrameIndex = 0L
         try {
             val payload = ElevenLabsPayload.buildRequestPayload(request)
             conn.outputStream.use { it.write(payload.toByteArray()) }
@@ -1653,6 +1683,15 @@ class TalkModePlugin : Plugin() {
                             throw IllegalStateException("AudioTrack write failed: $wrote")
                         }
                         offset += wrote
+                        emitPlaybackFrame(
+                            "elevenlabs",
+                            playbackFormat,
+                            buffer,
+                            offset - wrote,
+                            wrote,
+                            playbackFrameIndex
+                        )
+                        playbackFrameIndex += 1
                     }
                 }
             }

--- a/plugins/plugin-native-talkmode/src/definitions.ts
+++ b/plugins/plugin-native-talkmode/src/definitions.ts
@@ -271,6 +271,29 @@ export interface TalkModeAudioFrameEvent {
   frameIndex: number;
 }
 
+/**
+ * One frame of PCM actually written to native playback.
+ *
+ * Native AudioTrack output is invisible to Web Audio, so Android mirrors the
+ * rendered far-end samples through this event for JNI ambient-path AEC.
+ */
+export interface TalkModePlaybackFrameEvent {
+  /** Playback provider that produced the audio. */
+  provider: "elevenlabs" | "local-inference" | "system";
+  /** Base64-encoded little-endian signed 16-bit PCM. */
+  pcm16: string;
+  /** Sample rate of this playback chunk in Hz. */
+  sampleRate: number;
+  /** Channel count in this playback chunk. */
+  channels: number;
+  /** Samples per channel in this playback chunk. */
+  samples: number;
+  /** Monotonic render timestamp for this chunk, ms. */
+  timestamp: number;
+  /** Running frame index within this utterance. */
+  frameIndex: number;
+}
+
 /** Options for {@link TalkModePlugin.startAudioFrames}. */
 export interface AudioFrameOptions {
   /**
@@ -468,6 +491,14 @@ export interface TalkModePlugin {
   addListener(
     eventName: "audioFrame",
     listenerFunc: (event: TalkModeAudioFrameEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Add listener for native playback PCM frames used as echo reference.
+   */
+  addListener(
+    eventName: "playbackFrame",
+    listenerFunc: (event: TalkModePlaybackFrameEvent) => void,
   ): Promise<PluginListenerHandle>;
 
   /**


### PR DESCRIPTION
## Summary
- emits typed Android `playbackFrame` events from native `AudioTrack.write` for local-inference and ElevenLabs PCM playback
- exports the existing pure DSP AEC primitives through `@elizaos/plugin-local-inference/voice-dsp` and reuses them in `JniVoicePipeline`
- applies timestamp-aligned NLMS echo cancellation before `ElizaVoice.pipelineProcess`, so the normal Android JNI ambient mic path no longer feeds raw agent TTS echo into native VAD/diarization
- adds a focused unit test proving matching far-end playback echo is attenuated before the fake JNI pipeline sees PCM

Refs #11372. #11373 still needs real target-device ERLE/audio evidence.

## Verification
- `bun run --cwd packages/ui test -- src/voice/jni-voice-pipeline.test.ts` — 8/8 passed
- `bun run --cwd plugins/plugin-native-talkmode build` — passed
- `git diff --check origin/develop...HEAD` — passed

## Verification caveat
- Attempted `bun run --cwd packages/ui typecheck` in this clean worktree with temporary links to the installed main checkout dependencies. It failed before this slice on existing workspace dependency-resolution errors for modules such as `drizzle-orm`, `pg`, and plugin-sql transitive source imports. The focused UI test and TalkMode package build both ran successfully with the same dependency-link setup.

## Evidence notes
- Native/audio path change; no app UI screenshots captured here.
- Real Android acoustic-loop verification remains required for #11373: capture playbackFrame delivery, JNI-path ERLE on/off, double-talk behavior, and reviewed audio artifacts on device.
