### PR TITLE
fix(cloud): wallet signup makes the creator OWNER of the org it creates

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-owner-role.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-owner-role.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Wallet signup must make the creator the OWNER of the org it creates.
+ *
+ * Surfaced by the #11488 credentials-tab visual e2e: a fresh SIWE/wallet
+ * signup created its own organization but landed as a plain "member" (the
+ * users.role schema default) — unable to invite teammates, manage members, or
+ * manage the org credential pool in an org where they are the only human.
+ * The anonymous-migration signup path (session.ts) already sets "owner";
+ * these tests pin the wallet paths (EVM + Solana) to the same semantics,
+ * against a REAL PGlite DB — no repository mocking.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+const PGLITE_TIMEOUT = 120_000;
+
+const EVM_ADDRESS = `0x${"ab".repeat(20)}`;
+const SOLANA_ADDRESS = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+
+let pgliteReady = true;
+let pgliteError: unknown;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let walletSignup: typeof import("../wallet-signup");
+
+beforeAll(async () => {
+  try {
+    const dbClient = await import("../../../db/client");
+    closeDb = dbClient.closeDatabaseConnectionsForTests;
+    const { organizations } = await import("../../../db/schemas/organizations");
+    const { users } = await import("../../../db/schemas/users");
+    const { pushSchema } = await import("../../../db/push-schema-for-tests");
+    const { apply } = await pushSchema(
+      { organizations, users } as never,
+      dbClient.dbWrite as never,
+    );
+    await apply();
+    walletSignup = await import("../wallet-signup");
+  } catch (err) {
+    pgliteReady = false;
+    pgliteError = err;
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDb?.();
+});
+
+describe("wallet signup org role", () => {
+  test("PGlite harness is up (fail loudly, never skip silently)", () => {
+    if (!pgliteReady) throw pgliteError;
+    expect(pgliteReady).toBe(true);
+  });
+
+  test(
+    "fresh EVM wallet signup creates the org with the user as OWNER",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      const { user, isNewAccount } = await walletSignup.findOrCreateUserByWalletAddress(
+        EVM_ADDRESS,
+        {
+          grantInitialCredits: false,
+        },
+      );
+      expect(isNewAccount).toBe(true);
+      expect(user.organization_id).toBeTruthy();
+      expect(user.role).toBe("owner");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "returning EVM wallet keeps the same owner user (no re-create)",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      const first = await walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, {
+        grantInitialCredits: false,
+      });
+      const again = await walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS, {
+        grantInitialCredits: false,
+      });
+      expect(again.isNewAccount).toBe(false);
+      expect(again.user.id).toBe(first.user.id);
+      expect(again.user.role).toBe("owner");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "fresh Solana wallet signup creates the org with the user as OWNER",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+      const { user, isNewAccount } = await walletSignup.findOrCreateSolanaUserByWalletAddress(
+        SOLANA_ADDRESS,
+        { grantInitialCredits: false },
+      );
+      expect(isNewAccount).toBe(true);
+      expect(user.organization_id).toBeTruthy();
+      expect(user.role).toBe("owner");
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -158,6 +158,11 @@ export async function findOrCreateUserByWalletAddress(
       wallet_chain_type: "evm",
       wallet_verified: true,
       organization_id: org.id,
+      // The signup creates this org for the wallet — its creator manages it
+      // (matches the anonymous-migration path in session.ts). Without this the
+      // sole member of a fresh wallet org is a plain "member" and can never
+      // invite teammates or manage the org they own.
+      role: "owner",
     });
     const user: UserWithOrganization = { ...created, organization: org };
     return {
@@ -241,6 +246,8 @@ export async function findOrCreateSolanaUserByWalletAddress(
       wallet_chain_type: "solana",
       wallet_verified: true,
       organization_id: org.id,
+      // Creator of the fresh wallet org manages it — see the EVM path above.
+      role: "owner",
     });
     const user: UserWithOrganization = { ...created, organization: org };
     return {


### PR DESCRIPTION
## What

A fresh SIWE/wallet signup creates its own organization but lands as a plain `member` (the `users.role` schema default). The sole human in a fresh wallet org therefore cannot invite teammates, manage members, or manage the org credential pool — every owner/admin-gated route in their own org 403s.

The anonymous-migration signup path (`session.ts`) already sets `role: 'owner'`. This aligns the EVM and Solana wallet paths (`wallet-signup.ts`) to the same semantics.

## How it surfaced

Driving the #11488 credentials-tab visual e2e against the real mock cloud stack: headless SIWE signup → `GET /api/v1/user` → `role: member` → all owner-gated controls missing in the user's own single-member org.

## Evidence

- `bun test --isolate src/lib/services/__tests__/wallet-signup-owner-role.test.ts` → **4 pass / 0 fail** against a REAL PGlite DB (pushSchema + real repositories, no mocks): fresh EVM signup → owner; returning EVM wallet unchanged; fresh Solana signup → owner; loud PGlite-harness guard (never a vacuous skip).
- Pre-fix, the same live SIWE flow returned `role: member` (reproduced above); the schema default makes the red case deterministic.
- Screenshots/video: N/A — backend auth semantics, no UI change (the rendered proof lands with #11488's evidence run, which this unblocks).
- Real-LLM trajectory: N/A — no agent/model behavior.

Refs #11332 #11488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)