### PR TITLE
fix(voice): reject stale diarizer GGUF gate order

### DIFF
--- a/.github/issue-evidence/11377-diarizer-gguf-epoch/README.md
+++ b/.github/issue-evidence/11377-diarizer-gguf-epoch/README.md
@@ -1,0 +1,25 @@
+# #11377 Diarizer GGUF Epoch Evidence
+
+## Scope
+
+- Added `voice_diarizer.converter_epoch = 2` and
+  `voice_diarizer.lstm_gate_order = "IFGO"` to the diarizer converter output.
+- Taught the native GGUF metadata loader to parse the new diarizer keys.
+- Made `voice_diarizer_open` reject missing/pre-epoch GGUFs before tensor load,
+  so stale published artifacts fail closed instead of silently scrambling LSTM
+  gates into DER=1.000 over-segmentation.
+- Added `voice_diarizer_metadata_test`, a tiny metadata-only GGUF test that
+  verifies fresh and stale epoch/gate metadata are parsed distinctly without
+  requiring the large pyannote GGUF fixture.
+
+## Local validation
+
+- `cmake -B packages/native/plugins/voice-classifier-cpp/build -S packages/native/plugins/voice-classifier-cpp`
+- `cmake --build packages/native/plugins/voice-classifier-cpp/build -j`
+- `ctest --test-dir packages/native/plugins/voice-classifier-cpp/build --output-on-failure`
+- `git diff --check origin/develop...HEAD`
+
+## Evidence gaps
+
+- This does not republish `pyannote-segmentation-3.0.gguf`; the HuggingFace
+  artifact update still requires a maintainer token.

--- a/packages/native/plugins/voice-classifier-cpp/CMakeLists.txt
+++ b/packages/native/plugins/voice-classifier-cpp/CMakeLists.txt
@@ -98,6 +98,12 @@ target_link_libraries(voice_gguf_loader_test PRIVATE voice_classifier)
 target_compile_options(voice_gguf_loader_test PRIVATE -O2 -Wall -Wextra)
 add_test(NAME voice_gguf_loader_test COMMAND voice_gguf_loader_test)
 
+add_executable(voice_diarizer_metadata_test test/voice_diarizer_metadata_test.c)
+target_link_libraries(voice_diarizer_metadata_test PRIVATE voice_classifier)
+target_include_directories(voice_diarizer_metadata_test PRIVATE src)
+target_compile_options(voice_diarizer_metadata_test PRIVATE -O2 -Wall -Wextra)
+add_test(NAME voice_diarizer_metadata_test COMMAND voice_diarizer_metadata_test)
+
 # K3 — pyannote-3 forward parity gate. Loads the GGUF emitted by
 # scripts/voice_diarizer_to_gguf.py and asserts ≥ 99% per-frame label
 # agreement against the ONNX reference (labels precomputed into

--- a/packages/native/plugins/voice-classifier-cpp/scripts/voice_diarizer_to_gguf.py
+++ b/packages/native/plugins/voice-classifier-cpp/scripts/voice_diarizer_to_gguf.py
@@ -46,6 +46,8 @@ Output GGUF metadata
 - voice_diarizer.frames_per_window = 293
 - voice_diarizer.license           = "MIT"
 - voice_diarizer.upstream_commit   = pinned at conversion time
+- voice_diarizer.converter_epoch   = 2 (post-#9460 gate-order epoch)
+- voice_diarizer.lstm_gate_order   = "IFGO"
 - voice_diarizer.lstm_layers       = 4
 - voice_diarizer.lstm_hidden       = 128
 - voice_diarizer.linear0_out       = 128
@@ -62,11 +64,11 @@ The C-side forward pass (`voice_diarizer.c`) hardcodes these names:
   sincnet.norm1.weight, sincnet.norm1.bias                 # [60]
   sincnet.conv2.weight, sincnet.conv2.bias                 # [60, 60, 5]
   sincnet.norm2.weight, sincnet.norm2.bias                 # [60]
-  lstm.{L}.W_ih                                            # [4, 4*128, in_size]  (gates concatenated)
-  lstm.{L}.W_hh                                            # [4, 4*128, 128]
-  lstm.{L}.b_ih                                            # [4, 4*128]
-  lstm.{L}.b_hh                                            # [4, 4*128]
-   ↑ direction split: dir 0 = forward, dir 1 = backward; gates ordered IOFG (ONNX) → C re-packs as ICFO for cell math
+  lstm.{L}.W_ih                                            # [2, 4*128, in_size]  (directions, gates, input)
+  lstm.{L}.W_hh                                            # [2, 4*128, 128]
+  lstm.{L}.b_ih                                            # [2, 4*128]
+  lstm.{L}.b_hh                                            # [2, 4*128]
+   ↑ direction split: dir 0 = forward, dir 1 = backward; ONNX IOFC gates are re-packed at conversion time to IFGO, which the C cell reads directly.
   linear0.weight   [256, 128] (we store row-major: out_features × in_features)
   linear0.bias     [128]
   linear1.weight   [128, 128]
@@ -100,6 +102,8 @@ LSTM_LAYERS = 4
 LSTM_HIDDEN = 128
 LINEAR0_OUT = 128
 LINEAR1_OUT = 128
+CONVERTER_EPOCH = 2
+LSTM_GATE_ORDER = "IFGO"
 
 # Default upstream commit pinned to the onnx-community export used here.
 DEFAULT_UPSTREAM_COMMIT = "733a93b6473d019a773298e08cefa686894b1854"
@@ -294,6 +298,7 @@ def write_gguf(*, tensors: dict[str, np.ndarray], output_path: Path,
     writer.add_uint32("voice_diarizer.num_classes", NUM_CLASSES)
     writer.add_uint32("voice_diarizer.window_samples", WINDOW_SAMPLES)
     writer.add_uint32("voice_diarizer.frames_per_window", FRAMES_PER_WINDOW)
+    writer.add_uint32("voice_diarizer.converter_epoch", CONVERTER_EPOCH)
     writer.add_uint32("voice_diarizer.lstm_layers", LSTM_LAYERS)
     writer.add_uint32("voice_diarizer.lstm_hidden", LSTM_HIDDEN)
     writer.add_uint32("voice_diarizer.linear0_out", LINEAR0_OUT)
@@ -301,6 +306,7 @@ def write_gguf(*, tensors: dict[str, np.ndarray], output_path: Path,
     writer.add_string("voice_diarizer.variant", VOICE_DIARIZER_VARIANT)
     writer.add_string("voice_diarizer.license", LICENSE)
     writer.add_string("voice_diarizer.upstream_commit", upstream_commit)
+    writer.add_string("voice_diarizer.lstm_gate_order", LSTM_GATE_ORDER)
 
     # Powerset label table — surfaced by the C side as a 7-element string
     # array so the JS side can render labels without a hardcoded table.
@@ -324,6 +330,8 @@ def write_gguf(*, tensors: dict[str, np.ndarray], output_path: Path,
         "variant": VOICE_DIARIZER_VARIANT,
         "window_samples": WINDOW_SAMPLES,
         "frames_per_window": FRAMES_PER_WINDOW,
+        "converter_epoch": CONVERTER_EPOCH,
+        "lstm_gate_order": LSTM_GATE_ORDER,
     }
     return stats
 

--- a/packages/native/plugins/voice-classifier-cpp/src/voice_diarizer.c
+++ b/packages/native/plugins/voice-classifier-cpp/src/voice_diarizer.c
@@ -70,6 +70,8 @@
 #define DIAR_LINEAR0_OUT 128
 #define DIAR_LINEAR1_OUT 128
 #define DIAR_LEAKY_ALPHA 0.01f
+#define DIAR_GGUF_CONVERTER_EPOCH 2
+#define DIAR_LSTM_GATE_ORDER "IFGO"
 
 /* Cached pointers + buffer struct for one diarizer session. */
 struct voice_diarizer_session {
@@ -392,6 +394,33 @@ int voice_diarizer_open(const char *gguf, voice_diarizer_handle *out) {
         meta.sample_rate != VOICE_CLASSIFIER_SAMPLE_RATE_HZ) return -EINVAL;
     if (meta.num_classes != 0 &&
         meta.num_classes != VOICE_DIARIZER_NUM_CLASSES) return -EINVAL;
+    if (meta.window_samples != 0 &&
+        meta.window_samples != DIAR_WINDOW_SAMPLES) return -EINVAL;
+    if (meta.frames_per_window != 0 &&
+        meta.frames_per_window != DIAR_FRAMES_PER_WINDOW) return -EINVAL;
+    if (meta.lstm_layers != 0 &&
+        meta.lstm_layers != DIAR_LSTM_LAYERS) return -EINVAL;
+    if (meta.lstm_hidden != 0 &&
+        meta.lstm_hidden != DIAR_LSTM_HIDDEN) return -EINVAL;
+    if (meta.linear0_out != 0 &&
+        meta.linear0_out != DIAR_LINEAR0_OUT) return -EINVAL;
+    if (meta.linear1_out != 0 &&
+        meta.linear1_out != DIAR_LINEAR1_OUT) return -EINVAL;
+    if (meta.converter_epoch < DIAR_GGUF_CONVERTER_EPOCH) {
+        fprintf(stderr,
+                "[voice_diarizer] stale GGUF converter epoch %d; need >= %d with LSTM gates packed as %s\n",
+                meta.converter_epoch,
+                DIAR_GGUF_CONVERTER_EPOCH,
+                DIAR_LSTM_GATE_ORDER);
+        return -EINVAL;
+    }
+    if (strcmp(meta.lstm_gate_order, DIAR_LSTM_GATE_ORDER) != 0) {
+        fprintf(stderr,
+                "[voice_diarizer] unsupported LSTM gate order '%s'; expected %s\n",
+                meta.lstm_gate_order[0] ? meta.lstm_gate_order : "<missing>",
+                DIAR_LSTM_GATE_ORDER);
+        return -EINVAL;
+    }
 
     struct voice_diarizer_session *s =
         (struct voice_diarizer_session *)calloc(1, sizeof(*s));

--- a/packages/native/plugins/voice-classifier-cpp/src/voice_gguf_loader.c
+++ b/packages/native/plugins/voice-classifier-cpp/src/voice_gguf_loader.c
@@ -226,6 +226,17 @@ static int vc_gguf_load_state_cb(const char *key,
         free(str);
         return 1;
     }
+    if (vc_gguf_key_eq(key, s->want_prefix, "lstm_gate_order")) {
+        if (type != VC_GGUF_TYPE_STRING) return -1;
+        char *str = NULL;
+        const int rc = vc_gguf_read_string(f, &str);
+        if (rc != 0) return -1;
+        const size_t n = sizeof(s->out->lstm_gate_order) - 1;
+        strncpy(s->out->lstm_gate_order, str, n);
+        s->out->lstm_gate_order[n] = '\0';
+        free(str);
+        return 1;
+    }
     /* Wav2Small-specific uint32 keys: read into the matching field
      * and let the per-head opener validate against its expectation. */
     struct {
@@ -239,6 +250,13 @@ static int vc_gguf_load_state_cb(const char *key,
         { "ffn_dim",    &s->out->ffn_dim    },
         { "num_layers", &s->out->num_layers },
         { "num_heads",  &s->out->num_heads  },
+        { "converter_epoch",   &s->out->converter_epoch   },
+        { "window_samples",    &s->out->window_samples    },
+        { "frames_per_window", &s->out->frames_per_window },
+        { "lstm_layers",       &s->out->lstm_layers       },
+        { "lstm_hidden",       &s->out->lstm_hidden       },
+        { "linear0_out",       &s->out->linear0_out       },
+        { "linear1_out",       &s->out->linear1_out       },
     };
     for (size_t i = 0; i < sizeof(u32_extras) / sizeof(u32_extras[0]); ++i) {
         if (vc_gguf_key_eq(key, s->want_prefix, u32_extras[i].suffix)) {

--- a/packages/native/plugins/voice-classifier-cpp/src/voice_gguf_loader.h
+++ b/packages/native/plugins/voice-classifier-cpp/src/voice_gguf_loader.h
@@ -57,6 +57,17 @@ typedef struct voice_gguf_metadata {
     int ffn_dim;
     int num_layers;
     int num_heads;
+    /* Diarizer-specific metadata. Older GGUFs that predate the #9460
+     * converter-side LSTM gate reorder leave these zero/empty so the diarizer
+     * opener can fail closed instead of silently scrambling gates. */
+    int converter_epoch;
+    int window_samples;
+    int frames_per_window;
+    int lstm_layers;
+    int lstm_hidden;
+    int linear0_out;
+    int linear1_out;
+    char lstm_gate_order[16];
 } voice_gguf_metadata_t;
 
 /* GGUF GGML tensor data types — we only support F32 in the per-head

--- a/packages/native/plugins/voice-classifier-cpp/test/voice_diarizer_metadata_test.c
+++ b/packages/native/plugins/voice-classifier-cpp/test/voice_diarizer_metadata_test.c
@@ -1,0 +1,147 @@
+/*
+ * voice-classifier-cpp — diarizer GGUF metadata contract.
+ *
+ * Builds tiny metadata-only GGUF files and reads them through the internal
+ * loader. This pins the artifact epoch/gate-order keys that make stale
+ * pyannote GGUFs fail closed before the C diarizer can scramble LSTM gates.
+ */
+
+#define _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 700
+#include "voice_classifier/voice_classifier.h"
+#include "voice_gguf_loader.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define VC_GGUF_MAGIC "GGUF"
+#define VC_GGUF_VERSION 3
+#define DIAR_CONVERTER_EPOCH 2
+#define DIAR_WINDOW_SAMPLES 80000
+#define DIAR_FRAMES_PER_WINDOW 293
+#define DIAR_LSTM_LAYERS 4
+#define DIAR_LSTM_HIDDEN 128
+#define DIAR_LINEAR0_OUT 128
+#define DIAR_LINEAR1_OUT 128
+
+enum vc_gguf_type {
+    VC_GGUF_TYPE_UINT32 = 4,
+    VC_GGUF_TYPE_STRING = 8,
+};
+
+static void w_u32(FILE *f, uint32_t v) { fwrite(&v, sizeof(v), 1, f); }
+static void w_u64(FILE *f, uint64_t v) { fwrite(&v, sizeof(v), 1, f); }
+static void w_i64(FILE *f, int64_t v) { fwrite(&v, sizeof(v), 1, f); }
+
+static void w_str(FILE *f, const char *s) {
+    const uint64_t n = strlen(s);
+    w_u64(f, n);
+    fwrite(s, 1, n, f);
+}
+
+static void w_kv_u32(FILE *f, const char *key, uint32_t val) {
+    w_str(f, key);
+    w_u32(f, VC_GGUF_TYPE_UINT32);
+    w_u32(f, val);
+}
+
+static void w_kv_str(FILE *f, const char *key, const char *val) {
+    w_str(f, key);
+    w_u32(f, VC_GGUF_TYPE_STRING);
+    w_str(f, val);
+}
+
+static int write_diarizer_meta(const char *path,
+                               uint32_t converter_epoch,
+                               const char *gate_order) {
+    FILE *f = fopen(path, "wb");
+    if (!f) return -1;
+
+    fwrite(VC_GGUF_MAGIC, 1, 4, f);
+    w_u32(f, VC_GGUF_VERSION);
+    w_i64(f, 0);
+    w_i64(f, 11);
+
+    w_kv_u32(f, "voice_diarizer.sample_rate", VOICE_CLASSIFIER_SAMPLE_RATE_HZ);
+    w_kv_u32(f, "voice_diarizer.num_classes", VOICE_DIARIZER_NUM_CLASSES);
+    w_kv_u32(f, "voice_diarizer.window_samples", DIAR_WINDOW_SAMPLES);
+    w_kv_u32(f, "voice_diarizer.frames_per_window", DIAR_FRAMES_PER_WINDOW);
+    w_kv_u32(f, "voice_diarizer.converter_epoch", converter_epoch);
+    w_kv_u32(f, "voice_diarizer.lstm_layers", DIAR_LSTM_LAYERS);
+    w_kv_u32(f, "voice_diarizer.lstm_hidden", DIAR_LSTM_HIDDEN);
+    w_kv_u32(f, "voice_diarizer.linear0_out", DIAR_LINEAR0_OUT);
+    w_kv_u32(f, "voice_diarizer.linear1_out", DIAR_LINEAR1_OUT);
+    w_kv_str(f, "voice_diarizer.variant", "pyannote-segmentation-3.0");
+    w_kv_str(f, "voice_diarizer.lstm_gate_order", gate_order);
+
+    fclose(f);
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+    char tmpl[] = "/tmp/voice_diarizer_metadata_test_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) {
+        perror("mkstemp");
+        return 1;
+    }
+    close(fd);
+
+    if (write_diarizer_meta(tmpl, DIAR_CONVERTER_EPOCH, "IFGO") != 0) {
+        fprintf(stderr, "[voice-diarizer-metadata-test] cannot write tmp\n");
+        unlink(tmpl);
+        return 1;
+    }
+
+    voice_gguf_metadata_t meta;
+    int rc = voice_gguf_load_metadata(tmpl, "voice_diarizer", &meta);
+    if (rc != 0) {
+        fprintf(stderr, "[voice-diarizer-metadata-test] load returned %d\n", rc);
+        ++failures;
+    }
+    if (meta.converter_epoch != DIAR_CONVERTER_EPOCH) {
+        fprintf(stderr,
+                "[voice-diarizer-metadata-test] epoch=%d, expected %d\n",
+                meta.converter_epoch,
+                DIAR_CONVERTER_EPOCH);
+        ++failures;
+    }
+    if (strcmp(meta.lstm_gate_order, "IFGO") != 0) {
+        fprintf(stderr,
+                "[voice-diarizer-metadata-test] gate_order=%s, expected IFGO\n",
+                meta.lstm_gate_order);
+        ++failures;
+    }
+    if (meta.window_samples != DIAR_WINDOW_SAMPLES ||
+        meta.frames_per_window != DIAR_FRAMES_PER_WINDOW ||
+        meta.lstm_layers != DIAR_LSTM_LAYERS ||
+        meta.lstm_hidden != DIAR_LSTM_HIDDEN ||
+        meta.linear0_out != DIAR_LINEAR0_OUT ||
+        meta.linear1_out != DIAR_LINEAR1_OUT) {
+        fprintf(stderr,
+                "[voice-diarizer-metadata-test] diarizer shape metadata mismatch\n");
+        ++failures;
+    }
+
+    if (write_diarizer_meta(tmpl, 1, "IOFC") != 0) {
+        fprintf(stderr, "[voice-diarizer-metadata-test] cannot rewrite tmp\n");
+        unlink(tmpl);
+        return 1;
+    }
+    memset(&meta, 0, sizeof(meta));
+    rc = voice_gguf_load_metadata(tmpl, "voice_diarizer", &meta);
+    if (rc != 0 || meta.converter_epoch >= DIAR_CONVERTER_EPOCH ||
+        strcmp(meta.lstm_gate_order, "IOFC") != 0) {
+        fprintf(stderr,
+                "[voice-diarizer-metadata-test] stale metadata was not preserved for fail-fast validation\n");
+        ++failures;
+    }
+
+    unlink(tmpl);
+    printf("[voice-diarizer-metadata-test] failures=%d\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Refs #11377.

This does not republish the stale HuggingFace diarizer artifact, so it does not close the `needs-human` part of #11377. It hardens the native runtime so stale/pre-#9460 diarizer GGUFs fail closed instead of silently scrambling ONNX IOFC LSTM gates into the current IFGO C cell convention and surfacing as DER=1.000 over-segmentation.

Changes:

- diarizer converter now emits `voice_diarizer.converter_epoch = 2` and `voice_diarizer.lstm_gate_order = "IFGO"`
- shared GGUF metadata loader parses the new diarizer keys and shape fields
- `voice_diarizer_open` rejects missing/pre-epoch metadata and unsupported gate order before tensor load
- adds `voice_diarizer_metadata_test` with tiny metadata-only GGUF fixtures for fresh vs stale metadata

## Validation

- `cmake -B packages/native/plugins/voice-classifier-cpp/build -S packages/native/plugins/voice-classifier-cpp`
- `cmake --build packages/native/plugins/voice-classifier-cpp/build -j`
- `ctest --test-dir packages/native/plugins/voice-classifier-cpp/build --output-on-failure`
  - 8/8 tests passed; existing `voice_speaker_parity_test` skipped because the large speaker fixture is absent
- `git diff --check origin/develop...HEAD`

## Evidence

- `.github/issue-evidence/11377-diarizer-gguf-epoch/README.md`

## Remaining human step

The actual user-facing diarizer fix still requires re-baking and republishing `pyannote-segmentation-3.0.gguf` with the new metadata using the elizaOS HuggingFace write token, then bumping the manifest/sha. This PR makes stale artifacts fail fast until that republish lands.
