### PR TITLE
fix(core): parseKeyValueXml prefix-tag corruption + extractFirstSentence dead abbrevs + secrets settingUpdated

### DIFF
--- a/packages/core/src/__tests__/structured-parser.test.ts
+++ b/packages/core/src/__tests__/structured-parser.test.ts
@@ -14,4 +14,17 @@ describe("parseKeyValueXml", () => {
 			actions: ["send", "reply"],
 		});
 	});
+
+	it("does not treat a prefix-extended tag in a value as a nested open", () => {
+		// Regression: findMatchingXmlClose matched any tag STARTING with the name
+		// (`<textarea>` while closing `<text>`), inflating depth so the close was
+		// never found — the field was dropped and a bogus key promoted.
+		const parsed = parseKeyValueXml(
+			`<response><text>see <textarea>x</textarea> ok</text><thought>t</thought></response>`,
+		);
+		expect(parsed).toEqual({
+			text: "see <textarea>x</textarea> ok",
+			thought: "t",
+		});
+	});
 });

--- a/packages/core/src/features/secrets/setup/service.test.ts
+++ b/packages/core/src/features/secrets/setup/service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime.ts";
+import type { Memory, UUID } from "../../../types/index.ts";
+import type { SetupConfig, SetupSetting } from "./config.ts";
+import { SetupService } from "./service.ts";
+
+function setting(name: string, over: Partial<SetupSetting> = {}): SetupSetting {
+	return {
+		name,
+		description: `${name} description`,
+		secret: true,
+		public: false,
+		required: true,
+		dependsOn: [],
+		value: null,
+		...over,
+	};
+}
+
+const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
+
+function seedSession(svc: SetupService, config: SetupConfig): void {
+	// The session map is private; inject a minimal session directly (a null
+	// secretsService is fine — processMessage still updates local state and
+	// reaches the settingUpdated branch under test).
+	(svc as unknown as { sessions: Map<UUID, unknown> }).sessions.set(ROOM, {
+		worldId: "22222222-2222-2222-2222-222222222222" as UUID,
+		userId: "33333333-3333-3333-3333-333333333333" as UUID,
+		roomId: ROOM,
+		config,
+		currentSettingKey: "openai",
+		startedAt: 0,
+		lastActivityAt: 0,
+		platform: "other",
+		mode: "conversational",
+	});
+}
+
+describe("SetupService.processMessage — settingUpdated message", () => {
+	it("substitutes {{settingName}} in a CUSTOM settingUpdated message", async () => {
+		const svc = new SetupService(createMockRuntime());
+		const config: SetupConfig = {
+			settings: {
+				openai: setting("OpenAI Key"),
+				anthropic: setting("Anthropic Key"),
+			},
+			// Custom message with the documented template variable.
+			messages: { settingUpdated: "Saved your {{settingName}} securely." },
+		};
+		seedSession(svc, config);
+
+		const result = await svc.processMessage(ROOM, {
+			content: { text: "sk-test-value" },
+		} as Memory);
+
+		// Before the fix, `.replace` bound only to the DEFAULT, so a custom
+		// message shipped the raw placeholder.
+		expect(result.response).toContain("Saved your OpenAI Key securely.");
+		expect(result.response).not.toContain("{{settingName}}");
+	});
+
+	it("reports the just-answered key as updatedKey, not the next one", async () => {
+		const svc = new SetupService(createMockRuntime());
+		const config: SetupConfig = {
+			settings: {
+				openai: setting("OpenAI Key"),
+				anthropic: setting("Anthropic Key"),
+			},
+		};
+		seedSession(svc, config);
+
+		const result = await svc.processMessage(ROOM, {
+			content: { text: "sk-test-value" },
+		} as Memory);
+
+		// currentSettingKey was reassigned to the next key before the return;
+		// the reported key must still be the one just answered.
+		expect(result.updatedKey).toBe("openai");
+	});
+});

--- a/packages/core/src/features/secrets/setup/service.ts
+++ b/packages/core/src/features/secrets/setup/service.ts
@@ -547,10 +547,21 @@ export class SetupService extends Service {
 						nextSetting.usageDescription || nextSetting.description,
 					);
 
+				// Parenthesize like askMessage above: without this the `.replace`
+				// binds only to the DEFAULT, so a custom `messages.settingUpdated`
+				// containing {{settingName}} shipped the raw placeholder.
+				const settingUpdatedMessage = (
+					session.config.messages?.settingUpdated ||
+					DEFAULT_SETUP_MESSAGES.settingUpdated
+				).replace("{{settingName}}", currentSetting.name);
+
 				return {
 					shouldRespond: true,
-					response: `${session.config.messages?.settingUpdated || DEFAULT_SETUP_MESSAGES.settingUpdated.replace("{{settingName}}", currentSetting.name)}\n\n${askMessage}`,
-					updatedKey: session.currentSettingKey,
+					response: `${settingUpdatedMessage}\n\n${askMessage}`,
+					// The key just answered — session.currentSettingKey was reassigned
+					// to nextKey above, so report the local captured before the ask
+					// (matches the completion branch, which returns currentSettingKey).
+					updatedKey: currentSettingKey,
 				};
 			}
 		}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -849,7 +849,12 @@ function findMatchingXmlClose(
 		if (nextOpen !== -1 && nextOpen < nextClose) {
 			const nestedTag = readXmlStartTag(input, nextOpen);
 			if (!nestedTag) return -1;
-			if (!nestedTag.selfClosing) {
+			// Only a tag whose name EXACTLY matches nests depth. `indexOf(`<${tag}`)`
+			// also matches prefix-extensions (e.g. `<textarea>` while closing
+			// `<text>`), which used to inflate depth so the real close was never
+			// found — the field was dropped and a bogus key promoted. On a mismatch
+			// just skip past this open tag and keep scanning.
+			if (nestedTag.tag === tag && !nestedTag.selfClosing) {
 				depth += 1;
 			}
 			cursor = nestedTag.end + 1;

--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { extractFirstSentence } from "./text-splitting.ts";
+
+describe("extractFirstSentence", () => {
+	it("does not split inside dotted abbreviations (e.g. / i.e.)", () => {
+		// Regression: `\w` excludes ".", so the preceding-word match extracted only
+		// "g" from "e.g" and the "e.g"/"i.e" abbreviation entries were dead — the
+		// first-sentence / TTS early-emit path chopped replies at "e."/"i.".
+		const eg = extractFirstSentence("See e.g. the docs. Then continue.");
+		expect(eg.first).toBe("See e.g. the docs.");
+		expect(eg.rest).toBe("Then continue.");
+
+		const ie = extractFirstSentence("Use the flag, i.e. the toggle. Done.");
+		expect(ie.first).toBe("Use the flag, i.e. the toggle.");
+		expect(ie.rest).toBe("Done.");
+	});
+
+	it("still honors the name-title abbreviations (Mr./Dr.)", () => {
+		const r = extractFirstSentence("Mr. Smith arrived. He waved.");
+		expect(r.first).toBe("Mr. Smith arrived.");
+		expect(r.rest).toBe("He waved.");
+	});
+
+	it("splits normal sentences at the first real boundary", () => {
+		const r = extractFirstSentence("Hello world. Next one.");
+		expect(r.first).toBe("Hello world.");
+		expect(r.rest).toBe("Next one.");
+	});
+
+	it("returns the whole text when there is no boundary", () => {
+		const r = extractFirstSentence("No boundary here");
+		expect(r.first).toBe("No boundary here");
+		expect(r.rest).toBe("");
+	});
+});

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -40,11 +40,16 @@ export function extractFirstSentence(text: string): {
 				// Potential boundary. Check prior context for abbreviations.
 				// We look at the word preceding the punctuation.
 				const preText = text.substring(0, i);
-				const lastWordMatch = preText.match(/\b(\w+)$/);
+				// Include "." in the preceding word so dotted abbreviations match.
+				// \w excludes ".", so the old \b(\w+)$ extracted only "g" from
+				// "e.g" — the "e.g"/"i.e" list entries were dead and those got split
+				// mid-token (the first-sentence / TTS early-emit path chopped "e.g."
+				// into "e."). Strip a trailing dot before comparing to the list.
+				const lastWordMatch = preText.match(/(?:^|\s)([\w.]+)$/);
 
 				let isAbbreviation = false;
 				if (lastWordMatch) {
-					const lastWord = lastWordMatch[1];
+					const lastWord = lastWordMatch[1].replace(/\.$/, "");
 					// Case insensitive check
 					if (
 						abbreviations.some(


### PR DESCRIPTION
Fixes #11572. Three provable `@elizaos/core` correctness bugs surfaced by a Fable-5 hunt of the quiet (non-money/cloud) lanes — each small, surgical, and **mutation-checked**.

| # | bug | fix |
|---|---|---|
| 1 | **`parseKeyValueXml` drops a field + promotes a bogus key** — `findMatchingXmlClose` uses `indexOf(\`<${tag}\`)`, which matches any tag *starting with* the name, so `<textarea>` inside a `<text>` value inflates depth → close never found → `text` dropped, `textarea` promoted. Hits **live cloud evaluators** (room-title, helpers) on model output. | bump depth only on **exact** tag-name match |
| 2 | **`extractFirstSentence` never matches its own `e.g`/`i.e`** — `\b(\w+)$` excludes `.`, extracting `"g"` from `"e.g"`; the abbreviation entries are dead → the first-sentence / **TTS early-emit** path chops replies at `"e."` | capture `[\w.]+`, strip a trailing dot before comparing |
| 3 | **secrets-setup `settingUpdated`** ships literal `{{settingName}}` for custom messages (`.replace` bound to the default only) **and** returns the *next* key as `updatedKey` (read after reassignment) | parenthesize like the `askSetting` branch; return the just-answered key |

### Evidence
- **Mutation-checked tests** for all three (reverting each fix reds its test — verified individually):
  - `structured-parser.test.ts`: prefix-extended tag in a value round-trips (`{text, thought}`, no `textarea` key).
  - `text-splitting.test.ts` (new): `e.g.`/`i.e.` don't split; `Mr.`/`Dr.` still don't; normal sentences do.
  - `secrets/setup/service.test.ts` (new): custom `settingUpdated` substitutes the name; `updatedKey` is the answered key.
- **Regression sweep: 482 tests / 74 files green** (`__tests__/`, `utils/`, `features/secrets/`).
- Also removed 3 stale **gitignored** `.js` build artifacts under `core/src` that shadow the `.ts` (a `parseKeyValueXml` import without extension was resolving to a stale build — the known core-src-stale-`.js` trap; the fix looked broken until I cleared them).

### N/A rows
- Live-LLM trajectory: **partial N/A** — bugs 1 & 2 are on the model-output *parsing* path (deterministic string logic), asserted directly against the real functions with the exact adversarial inputs (`<textarea>` in a value; `"e.g."`); no model behavior changed. Bug 3 is UI-message plumbing.
- Screenshots: N/A (no UI surface).

Authored via a Fable-5 hunt (found + specified) + mutation-checked implementation. A companion voice-UI batch (listener-leak / re-entrancy / error-handling) is coming separately.