### PR TITLE
test(scenarios): pay down actionCalled-only effect checks

### DIFF
--- a/.github/issue-evidence/11381-actioncalled-paydown/README.md
+++ b/.github/issue-evidence/11381-actioncalled-paydown/README.md
@@ -1,0 +1,21 @@
+# #11381 Action-Effect Ratchet Paydown Evidence
+
+## Scope
+
+- Added effect-proving final checks to a first slice of actionCalled-only
+  scenarios across keyless connector/status domains.
+- Lowered `packages/scenario-runner/src/action-effect-ratchet.test.ts`
+  `BASELINE` from `60` to `42`, matching the current static corpus count.
+
+## Local validation
+
+- Static ratchet-count script using the same AST logic as
+  `action-effect-ratchet.test.ts`: `count = 42`.
+- `bun run --cwd packages/scenario-runner test -- src/action-effect-ratchet.test.ts`
+- `git diff --check origin/develop...HEAD`
+
+## Remaining debt
+
+- 42 direct scenarios remain actionCalled-only and are listed by the static
+  ratchet logic. This PR is a ratcheted paydown slice, not full closure of
+  #11381.

--- a/.github/issue-evidence/11381-actioncalled-paydown/README.md
+++ b/.github/issue-evidence/11381-actioncalled-paydown/README.md
@@ -5,17 +5,17 @@
 - Added effect-proving final checks to a first slice of actionCalled-only
   scenarios across keyless connector/status domains.
 - Lowered `packages/scenario-runner/src/action-effect-ratchet.test.ts`
-  `BASELINE` from `60` to `42`, matching the current static corpus count.
+  `BASELINE` from `60` to `36`, matching the current static corpus count.
 
 ## Local validation
 
 - Static ratchet-count script using the same AST logic as
-  `action-effect-ratchet.test.ts`: `count = 42`.
+  `action-effect-ratchet.test.ts`: `count = 36`.
 - `bun run --cwd packages/scenario-runner test -- src/action-effect-ratchet.test.ts`
 - `git diff --check origin/develop...HEAD`
 
 ## Remaining debt
 
-- 42 direct scenarios remain actionCalled-only and are listed by the static
+- 36 direct scenarios remain actionCalled-only and are listed by the static
   ratchet logic. This PR is a ratcheted paydown slice, not full closure of
   #11381.

--- a/packages/scenario-runner/src/action-effect-ratchet.test.ts
+++ b/packages/scenario-runner/src/action-effect-ratchet.test.ts
@@ -133,7 +133,7 @@ const flagged = SCENARIO_ROOTS.flatMap(walkScenarioFiles)
 // Current debt (theme 3 of #9310 — down from the 104 the issue reported as the
 // corpus has been de-larped). Lower this as actionCalled-only scenarios are given
 // a real effect finalCheck (custom predicate / memory / connector). Never raise.
-const BASELINE = 60;
+const BASELINE = 42;
 
 describe("action-effect ratchet (#9310)", () => {
   it("finds the scenario corpus (guard is actually scanning)", () => {

--- a/packages/scenario-runner/src/action-effect-ratchet.test.ts
+++ b/packages/scenario-runner/src/action-effect-ratchet.test.ts
@@ -81,7 +81,8 @@ function finalCheckTypes(sourceFile: ts.SourceFile): string[] {
         for (const prop of el.properties) {
           if (!ts.isPropertyAssignment(prop)) continue;
           if (propName(prop.name) !== "type") continue;
-          if (ts.isStringLiteral(prop.initializer)) types.push(prop.initializer.text);
+          if (ts.isStringLiteral(prop.initializer))
+            types.push(prop.initializer.text);
         }
       }
       return;
@@ -133,7 +134,7 @@ const flagged = SCENARIO_ROOTS.flatMap(walkScenarioFiles)
 // Current debt (theme 3 of #9310 — down from the 104 the issue reported as the
 // corpus has been de-larped). Lower this as actionCalled-only scenarios are given
 // a real effect finalCheck (custom predicate / memory / connector). Never raise.
-const BASELINE = 42;
+const BASELINE = 36;
 
 describe("action-effect ratchet (#9310)", () => {
   it("finds the scenario corpus (guard is actually scanning)", () => {

--- a/packages/test/scenarios/_helpers/effect-assertions.ts
+++ b/packages/test/scenarios/_helpers/effect-assertions.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared helpers for effect-proving `custom` finalChecks (#11381, #9310
+ * theme 3). `actionCalled` proves a handler ran; these helpers make it cheap
+ * for a scenario to additionally read the captured action's result payload —
+ * the domain artifact the action claims to have produced or read — and fail
+ * with a precise diff when the effect is missing.
+ */
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+
+export function toRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function isSynthesizedReply(action: CapturedAction): boolean {
+  return toRecord(action.result?.data)?.source === "synthesized-reply";
+}
+
+/** Compact call summary for failure details. */
+export function describeCalls(ctx: ScenarioContext): string {
+  return (
+    ctx.actionsCalled
+      .map(
+        (a) =>
+          `${a.actionName}(success=${String(a.result?.success)}, data=${JSON.stringify(a.result?.data ?? null)?.slice(0, 200)})`,
+      )
+      .join(" | ") || "(no actions called)"
+  );
+}
+
+/**
+ * `result.data` of the first successful, non-synthesized call to
+ * `actionName` — or null when no such call (or no object payload) exists.
+ */
+export function successfulActionData(
+  ctx: ScenarioContext,
+  actionName: string | string[],
+): Record<string, unknown> | null {
+  const accepted = Array.isArray(actionName) ? actionName : [actionName];
+  for (const action of ctx.actionsCalled) {
+    if (!accepted.includes(action.actionName)) continue;
+    if (action.result?.success !== true) continue;
+    if (isSynthesizedReply(action)) continue;
+    const data = toRecord(action.result.data);
+    if (data) return data;
+  }
+  return null;
+}
+
+/** All successful, non-synthesized calls to `actionName`. */
+export function successfulCalls(
+  ctx: ScenarioContext,
+  actionName: string | string[],
+): CapturedAction[] {
+  const accepted = Array.isArray(actionName) ? actionName : [actionName];
+  return ctx.actionsCalled.filter(
+    (action) =>
+      accepted.includes(action.actionName) &&
+      action.result?.success === true &&
+      !isSynthesizedReply(action),
+  );
+}

--- a/packages/test/scenarios/_helpers/effect-assertions.ts
+++ b/packages/test/scenarios/_helpers/effect-assertions.ts
@@ -65,3 +65,47 @@ export function successfulCalls(
       !isSynthesizedReply(action),
   );
 }
+
+/**
+ * Lowercased JSON blob of every captured call to `actionName` — parameters,
+ * result data, and result text. The house pattern for "the action payload
+ * must carry the domain artifact" predicates (seeded tokens, computed times,
+ * op signals) that echo replies can never satisfy.
+ */
+export function callPayloadBlob(
+  ctx: ScenarioContext,
+  actionName: string | string[],
+): string {
+  const accepted = Array.isArray(actionName) ? actionName : [actionName];
+  const calls = ctx.actionsCalled.filter((action) =>
+    accepted.includes(action.actionName),
+  );
+  return JSON.stringify(
+    calls.map((call) => ({
+      parameters: call.parameters ?? null,
+      data: call.result?.data ?? null,
+      text: call.result?.text ?? null,
+    })),
+  ).toLowerCase();
+}
+
+/**
+ * Negative side-effect proof: fails with a precise message when ANY captured
+ * call (across every turn) hit one of `actionNames`. Turn-level
+ * `forbiddenActions` only guards its own turn; this closes the whole run.
+ */
+export function expectNoActionCalled(
+  ctx: ScenarioContext,
+  actionNames: readonly string[],
+): string | undefined {
+  const forbidden = new Set(actionNames);
+  const hits = ctx.actionsCalled.filter((action) =>
+    forbidden.has(action.actionName),
+  );
+  if (hits.length > 0) {
+    return `expected none of [${actionNames.join(", ")}] to fire, saw: ${describeCalls(
+      { actionsCalled: hits } as ScenarioContext,
+    )}`;
+  }
+  return undefined;
+}

--- a/packages/test/scenarios/agent-orchestrator/list-agents.scenario.ts
+++ b/packages/test/scenarios/agent-orchestrator/list-agents.scenario.ts
@@ -14,6 +14,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const TASKS = "TASKS";
 type R = AgentRuntime & {
@@ -140,6 +144,25 @@ export default scenario({
       actionName: TASKS,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): list_agents really read the ACP session
+      // store — a fresh runtime must surface an empty sessions array in the
+      // result payload, not just handler success.
+      type: "custom",
+      name: "acp-session-store-read-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, TASKS);
+        if (!data) {
+          return `no successful ${TASKS} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (!Array.isArray(data.sessions)) {
+          return `expected result.data.sessions array from the ACP session store, saw ${JSON.stringify(data.sessions ?? null)}`;
+        }
+        if (data.sessions.length !== 0) {
+          return `fresh ACP session store must be empty; saw ${data.sessions.length} session(s)`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/anthropic-proxy/proxy-status.scenario.ts
+++ b/packages/test/scenarios/anthropic-proxy/proxy-status.scenario.ts
@@ -1,7 +1,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
-import { describeCalls, successfulCalls, toRecord } from "../_helpers/effect-assertions.ts";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const PROXY_STATUS = "PROXY_STATUS";
 type R = AgentRuntime & {
@@ -111,7 +115,10 @@ export default scenario({
         if (values.available !== true) {
           return `expected values.available true (service loaded), saw ${JSON.stringify(values).slice(0, 200)}`;
         }
-        if (typeof values.mode !== "string" || typeof values.listening !== "boolean") {
+        if (
+          typeof values.mode !== "string" ||
+          typeof values.listening !== "boolean"
+        ) {
           return `expected live status fields {mode:string, listening:boolean}, saw ${JSON.stringify(values).slice(0, 200)}`;
         }
       },

--- a/packages/test/scenarios/anthropic-proxy/proxy-status.scenario.ts
+++ b/packages/test/scenarios/anthropic-proxy/proxy-status.scenario.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { describeCalls, successfulCalls, toRecord } from "../_helpers/effect-assertions.ts";
 
 const PROXY_STATUS = "PROXY_STATUS";
 type R = AgentRuntime & {
@@ -92,6 +93,28 @@ export default scenario({
       actionName: PROXY_STATUS,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): success only means the handler ran; the
+      // status contract is `values` carrying the live service's report —
+      // available:true plus the mode/listening fields read from
+      // AnthropicProxyService.getStatus(). A missing service or an empty
+      // status envelope fails here.
+      type: "custom",
+      name: "proxy-status-reports-live-service-state",
+      predicate: (ctx) => {
+        const call = successfulCalls(ctx, PROXY_STATUS)[0];
+        const values = toRecord(call?.result?.values);
+        if (!values) {
+          return `no ${PROXY_STATUS} result values; calls: ${describeCalls(ctx)}`;
+        }
+        if (values.available !== true) {
+          return `expected values.available true (service loaded), saw ${JSON.stringify(values).slice(0, 200)}`;
+        }
+        if (typeof values.mode !== "string" || typeof values.listening !== "boolean") {
+          return `expected live status fields {mode:string, listening:boolean}, saw ${JSON.stringify(values).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/benchmarks/osworld-action.scenario.ts
+++ b/packages/test/scenarios/benchmarks/osworld-action.scenario.ts
@@ -10,6 +10,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const TASK_INPUT = "Run the OSWorld benchmark step: save the open document.";
 const OSWORLD = "OSWORLD";
@@ -131,6 +135,24 @@ export default scenario({
       actionName: OSWORLD,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): OSWORLD is a bench-side router whose contract
+      // is the structured envelope it hands the OSWorld environment. The
+      // planner tool call carried `action: "screenshot"`; the handler must
+      // round-trip that exact op into `result.data.action`. A broken
+      // parameter pipeline (op dropped/renamed) fails here.
+      type: "custom",
+      name: "osworld-envelope-carries-parsed-op",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, OSWORLD);
+        if (!data) {
+          return `no successful ${OSWORLD} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.action !== "screenshot") {
+          return `expected result.data.action "screenshot" (the planner-issued op), saw ${JSON.stringify(data).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/commands/help-command.scenario.ts
+++ b/packages/test/scenarios/commands/help-command.scenario.ts
@@ -11,6 +11,7 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { initForRuntime, useRuntime } from "@elizaos/plugin-commands";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { describeCalls, successfulCalls } from "../_helpers/effect-assertions.ts";
 
 const HELP_COMMAND = "HELP_COMMAND";
 
@@ -76,6 +77,26 @@ export default scenario({
       actionName: HELP_COMMAND,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): /help's contract is the serialized live command
+      // registry. The reply must be the real formatted list containing the
+      // built-in commands the seed registered — an empty or unregistered
+      // registry (initForRuntime not run) fails here.
+      type: "custom",
+      name: "help-reply-lists-live-registry",
+      predicate: (ctx) => {
+        const call = successfulCalls(ctx, HELP_COMMAND)[0];
+        const reply = call?.result?.text ?? "";
+        if (!reply.includes("Available commands:")) {
+          return `expected the help reply to start the registry listing; calls: ${describeCalls(ctx)}`;
+        }
+        for (const builtin of ["/help", "/commands", "/status"]) {
+          if (!reply.includes(builtin)) {
+            return `expected built-in "${builtin}" in the serialized registry, reply: ${reply.slice(0, 300)}`;
+          }
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/commands/help-command.scenario.ts
+++ b/packages/test/scenarios/commands/help-command.scenario.ts
@@ -11,7 +11,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { initForRuntime, useRuntime } from "@elizaos/plugin-commands";
 import { scenario } from "@elizaos/scenario-runner/schema";
-import { describeCalls, successfulCalls } from "../_helpers/effect-assertions.ts";
+import {
+  describeCalls,
+  successfulCalls,
+} from "../_helpers/effect-assertions.ts";
 
 const HELP_COMMAND = "HELP_COMMAND";
 

--- a/packages/test/scenarios/computeruse/get-cursor-position.scenario.ts
+++ b/packages/test/scenarios/computeruse/get-cursor-position.scenario.ts
@@ -13,6 +13,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 process.env.COMPUTER_USE_ENABLED = "1";
 
@@ -190,6 +195,27 @@ export default scenario({
       actionName: COMPUTER_USE,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the param-resolution → service → result-mapping
+      // path must carry the device boundary's answer back out. The stub
+      // returns (640, 360) only for the `get_cursor_position` op, so a wrong
+      // op, dropped params, or broken result mapping all fail here.
+      type: "custom",
+      name: "cursor-position-round-trips-device-boundary",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, COMPUTER_USE);
+        if (!data) {
+          return `no successful ${COMPUTER_USE} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.computerUseAction !== "get_cursor_position") {
+          return `expected computerUseAction "get_cursor_position", saw ${JSON.stringify(data.computerUseAction)}`;
+        }
+        const cursor = toRecord(toRecord(data.result)?.cursorPosition);
+        if (cursor?.x !== 640 || cursor?.y !== 360) {
+          return `expected result.cursorPosition {x:640,y:360} from the stubbed device boundary, saw ${JSON.stringify(data.result).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/convo/echo-self-test.scenario.ts
+++ b/packages/test/scenarios/convo/echo-self-test.scenario.ts
@@ -152,5 +152,26 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      // Effect proof (#11381): the handler really received the inbound
+      // message content through the pipeline — its result text must be the
+      // exact echo of the user's utterance, not merely success=true.
+      type: "custom",
+      name: "echo-payload-roundtrip-effect",
+      predicate: (ctx) => {
+        const call = ctx.actionsCalled.find(
+          (action) =>
+            action.actionName === "ECHO_TEST" &&
+            action.result?.success === true,
+        );
+        if (!call) {
+          return "no successful ECHO_TEST call captured";
+        }
+        const expected = `Echo: ${ECHO_INPUT}`;
+        if (call.result?.text !== expected) {
+          return `expected the echoed message ${JSON.stringify(expected)} in result.text, saw ${JSON.stringify(call.result?.text ?? null)}`;
+        }
+      },
+    },
   ],
 });

--- a/packages/test/scenarios/convo/greeting-dynamic.scenario.ts
+++ b/packages/test/scenarios/convo/greeting-dynamic.scenario.ts
@@ -145,5 +145,26 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      // Effect proof (#11381): the handler really received the inbound
+      // greeting through the pipeline — its result text must embed the exact
+      // user utterance, not merely success=true.
+      type: "custom",
+      name: "greeting-payload-roundtrip-effect",
+      predicate: (ctx) => {
+        const call = ctx.actionsCalled.find(
+          (action) =>
+            action.actionName === "GREET_USER" &&
+            action.result?.success === true,
+        );
+        if (!call) {
+          return "no successful GREET_USER call captured";
+        }
+        const expected = `Hello there! Great to meet you. You said: "${GREETING_INPUT}"`;
+        if (call.result?.text !== expected) {
+          return `expected the greeting ${JSON.stringify(expected)} in result.text, saw ${JSON.stringify(call.result?.text ?? null)}`;
+        }
+      },
+    },
   ],
 });

--- a/packages/test/scenarios/facewear/smartglasses-status.scenario.ts
+++ b/packages/test/scenarios/facewear/smartglasses-status.scenario.ts
@@ -11,6 +11,7 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { describeCalls, toRecord } from "../_helpers/effect-assertions.ts";
 
 const SMARTGLASSES_STATUS = "SMARTGLASSES_STATUS";
 type R = AgentRuntime & {
@@ -138,6 +139,34 @@ export default scenario({
       actionName: SMARTGLASSES_STATUS,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the action really read the live
+      // SmartglassesService status snapshot — in a headless test that
+      // snapshot must report no connected device, and the counters the
+      // service tracks must be present in the result values.
+      type: "custom",
+      name: "smartglasses-status-snapshot-effect",
+      predicate: (ctx) => {
+        const call = ctx.actionsCalled.find(
+          (action) =>
+            action.actionName === SMARTGLASSES_STATUS &&
+            action.result?.success === true,
+        );
+        const values = toRecord(call?.result?.values);
+        if (!values) {
+          return `no successful ${SMARTGLASSES_STATUS} result values; calls: ${describeCalls(ctx)}`;
+        }
+        if (values.connected !== false) {
+          return `headless run has no BLE device, so status.connected must be false; saw ${JSON.stringify(values.connected ?? null)}`;
+        }
+        if (typeof values.audioChunksReceived !== "number") {
+          return `expected the service's audioChunksReceived counter in result values, saw ${JSON.stringify(values.audioChunksReceived ?? null)}`;
+        }
+        if (!toRecord(values.setup)) {
+          return `expected the derived setup summary in result values, saw ${JSON.stringify(values.setup ?? null)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/goals/owner-goals-create.scenario.ts
+++ b/packages/test/scenarios/goals/owner-goals-create.scenario.ts
@@ -15,6 +15,7 @@ import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { executeRawSql } from "../../../../plugins/plugin-goals/src/db/sql.ts";
+import { createOwnerGoalsService } from "../../../../plugins/plugin-goals/src/goals-runtime.ts";
 
 const GOAL_INPUT = "Add a goal to run a marathon next year.";
 const OWNER_GOALS = "OWNER_GOALS";
@@ -164,6 +165,31 @@ export default scenario({
       actionName: OWNER_GOALS,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the create action's result must carry the
+      // created goal record (goalCountDelta reads result.data.record.goal).
+      type: "goalCountDelta",
+      title: "Run a marathon",
+      delta: 1,
+    },
+    {
+      // Effect proof (#11381): the goal row really exists in the live goals
+      // store — read it back through the same repository the action wrote to.
+      type: "custom",
+      name: "goal-row-persisted-effect",
+      predicate: async (ctx) => {
+        const service = createOwnerGoalsService(ctx.runtime as AgentRuntime);
+        const goals = await service.listGoals();
+        const created = goals.find(
+          (record) => record.goal.title === "Run a marathon",
+        );
+        if (!created) {
+          const titles =
+            goals.map((record) => record.goal.title).join(", ") || "(none)";
+          return `goal "Run a marathon" not found in the goals store; stored titles: ${titles}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/health/owner-health-status.scenario.ts
+++ b/packages/test/scenarios/health/owner-health-status.scenario.ts
@@ -25,6 +25,11 @@ import {
   type RuntimeWithScenarioLlmFixtures,
   registerStrictActionRouteFixtures,
 } from "@elizaos/test-harness/action-route-fixtures";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const OWNER_HEALTH = "OWNER_HEALTH";
 const STATUS_INPUT = "Run OWNER_HEALTH to check my health backend status.";
@@ -119,6 +124,30 @@ export default scenario({
       actionName: OWNER_HEALTH,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the status op really ran the health-backend
+      // detection — with no connector configured it must surface the real
+      // "no backend" connector status in the result payload, not just
+      // handler success.
+      type: "custom",
+      name: "health-backend-detection-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, OWNER_HEALTH);
+        if (!data) {
+          return `no successful ${OWNER_HEALTH} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.subaction !== "status") {
+          return `expected result.data.subaction "status", saw ${String(data.subaction ?? "(missing)")}`;
+        }
+        const status = toRecord(data.status);
+        if (!status) {
+          return `expected the detected connector status in result.data.status; saw ${JSON.stringify(data).slice(0, 300)}`;
+        }
+        if (status.available !== false) {
+          return `keyless runtime has no health connector, so status.available must be false; saw ${JSON.stringify(status).slice(0, 300)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/hyperliquid/perpetual-market-status.scenario.ts
+++ b/packages/test/scenarios/hyperliquid/perpetual-market-status.scenario.ts
@@ -11,6 +11,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const PERPETUAL_MARKET = "PERPETUAL_MARKET";
 type R = AgentRuntime & {
@@ -20,6 +25,8 @@ type R = AgentRuntime & {
 };
 
 let restoreFetch: (() => void) | undefined;
+/** Number of /api/hyperliquid/status reads the bridge mock actually served. */
+let statusMockHits = 0;
 
 const STATUS_RESPONSE = {
   publicReadReady: true,
@@ -58,6 +65,7 @@ export default scenario({
       name: "hyperliquid-bridge-mock",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        statusMockHits = 0;
         const realFetch = globalThis.fetch;
         restoreFetch = () => {
           if (globalThis.fetch === hyperliquidMockFetch) {
@@ -76,6 +84,7 @@ export default scenario({
                 ? input.url
                 : input.toString();
           if (url.includes("/api/hyperliquid/status")) {
+            statusMockHits += 1;
             return new Response(JSON.stringify(STATUS_RESPONSE), {
               headers: { "Content-Type": "application/json" },
             });
@@ -195,6 +204,37 @@ export default scenario({
       actionName: PERPETUAL_MARKET,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the read really hit the bridge's status
+      // endpoint and surfaced the mock's readiness payload (public reads
+      // ready, keyless credential mode) in the action result — not just
+      // "the handler returned success".
+      type: "custom",
+      name: "hyperliquid-status-effect",
+      predicate: (ctx) => {
+        if (statusMockHits === 0) {
+          return "bridge mock never served /api/hyperliquid/status — the status read never touched the HTTP path";
+        }
+        const data = successfulActionData(ctx, PERPETUAL_MARKET);
+        if (!data) {
+          return `no successful ${PERPETUAL_MARKET} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.kind !== "status") {
+          return `expected result.data.kind "status", saw ${String(data.kind ?? "(missing)")}`;
+        }
+        const status = toRecord(data.status);
+        if (!status) {
+          return `expected result.data.status payload from the bridge, saw ${JSON.stringify(data).slice(0, 300)}`;
+        }
+        if (
+          status.publicReadReady !== true ||
+          status.credentialMode !== "none" ||
+          status.executionReady !== false
+        ) {
+          return `expected the mock's readiness (publicReadReady=true, credentialMode="none", executionReady=false); saw ${JSON.stringify(status).slice(0, 300)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/inbox/summarize-inboxes.scenario.ts
+++ b/packages/test/scenarios/inbox/summarize-inboxes.scenario.ts
@@ -12,6 +12,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const INBOX = "INBOX";
 type R = AgentRuntime & {
@@ -133,6 +138,40 @@ export default scenario({
       actionName: INBOX,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): summarize's contract is a per-platform rollup
+      // (`summary[]` — one {platform, count, latestAt} entry per fanned-out
+      // platform). A handler that "succeeds" without actually fanning out and
+      // building the rollup fails here.
+      type: "custom",
+      name: "inbox-summary-rollup-built",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, INBOX);
+        if (!data) {
+          return `no successful ${INBOX} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.subaction !== "summarize") {
+          return `expected subaction "summarize", saw ${JSON.stringify(data.subaction)}`;
+        }
+        const platforms = Array.isArray(data.platforms) ? data.platforms : [];
+        const summary = Array.isArray(data.summary) ? data.summary : null;
+        if (platforms.length === 0 || !summary) {
+          return `expected non-empty platforms + summary rollup, saw ${JSON.stringify(data).slice(0, 200)}`;
+        }
+        if (summary.length !== platforms.length) {
+          return `expected one summary entry per platform (${platforms.length}), saw ${summary.length}`;
+        }
+        for (const entry of summary) {
+          const record = toRecord(entry);
+          if (
+            typeof record?.platform !== "string" ||
+            typeof record?.count !== "number"
+          ) {
+            return `summary entry missing {platform, count}: ${JSON.stringify(entry).slice(0, 120)}`;
+          }
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/linear/search-issues.scenario.ts
+++ b/packages/test/scenarios/linear/search-issues.scenario.ts
@@ -10,6 +10,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const LINEAR = "LINEAR";
 type R = AgentRuntime & {
@@ -20,6 +24,8 @@ type R = AgentRuntime & {
 };
 
 let restoreFetch: (() => void) | undefined;
+/** GraphQL queries the Linear API mock actually served. */
+let linearMockQueries: string[] = [];
 
 export default scenario({
   lane: "pr-deterministic",
@@ -39,6 +45,7 @@ export default scenario({
       name: "linear-mock-and-config",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        linearMockQueries = [];
         // Scoped fetch interceptor: redirect @linear/sdk's calls to a mock.
         const realFetch = globalThis.fetch;
         restoreFetch = () => {
@@ -62,6 +69,7 @@ export default scenario({
             try {
               query = JSON.parse(String(init?.body ?? "{}")).query ?? "";
             } catch {}
+            linearMockQueries.push(query);
             const data: Record<string, unknown> = {};
             if (/issues/i.test(query)) {
               data.issues = {
@@ -203,6 +211,31 @@ export default scenario({
       actionName: LINEAR,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the search really queried the Linear GraphQL
+      // mock for issues and surfaced its empty result set (issues: [],
+      // count: 0) — not just "the handler returned success".
+      type: "custom",
+      name: "linear-search-effect",
+      predicate: (ctx) => {
+        const issuesQuery = linearMockQueries.find((query) =>
+          /issues/i.test(query),
+        );
+        if (!issuesQuery) {
+          return `Linear API mock never received an issues query; served ${linearMockQueries.length} query(ies)`;
+        }
+        const data = successfulActionData(ctx, LINEAR);
+        if (!data) {
+          return `no successful ${LINEAR} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (!Array.isArray(data.issues) || data.issues.length !== 0) {
+          return `mock workspace has no issues, so result.data.issues must be an empty array; saw ${JSON.stringify(data.issues ?? null).slice(0, 200)}`;
+        }
+        if (data.count !== 0) {
+          return `expected result.data.count 0 for the empty mock workspace, saw ${String(data.count ?? "(missing)")}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/local-inference/start-transcription.scenario.ts
+++ b/packages/test/scenarios/local-inference/start-transcription.scenario.ts
@@ -21,12 +21,21 @@ import {
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 const START_TRANSCRIPTION = "START_TRANSCRIPTION";
+const VOICE_CONTROL_STREAM = "voice-control";
 
 type R = AgentRuntime & {
   scenarioLlmFixtures?: {
     register: (...f: Array<Record<string, unknown>>) => void;
   };
 };
+
+type BusEvent = { stream?: string; data?: unknown };
+type SubscribableBus = {
+  subscribe?: (listener: (event: BusEvent) => void) => () => void;
+};
+
+/** Every event the live AGENT_EVENT bus emitted during the run. */
+const observedBusEvents: BusEvent[] = [];
 
 export default scenario({
   lane: "pr-deterministic",
@@ -52,6 +61,16 @@ export default scenario({
         // force-start it so the synchronous getService() in validate resolves.
         await runtime.registerService(AgentEventService);
         await runtime.getServiceLoadPromise(ServiceType.AGENT_EVENT);
+
+        // Tap the live bus (the same subscribe() the renderer uses) so the
+        // final check can prove the voice-control command actually crossed it.
+        observedBusEvents.length = 0;
+        const bus = runtime.getService(
+          ServiceType.AGENT_EVENT,
+        ) as SubscribableBus | null;
+        bus?.subscribe?.((event) => {
+          observedBusEvents.push(event);
+        });
 
         runtime.scenarioLlmFixtures?.register(
           {
@@ -152,6 +171,26 @@ export default scenario({
       actionName: START_TRANSCRIPTION,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the action's whole job is a one-way
+      // `voice-control` command on the AGENT_EVENT bus. The seed subscribed
+      // to the live bus; a `start` command must have actually been emitted —
+      // handler-returned success without the bus event fails here.
+      type: "custom",
+      name: "voice-control-start-emitted-on-bus",
+      predicate: () => {
+        const hit = observedBusEvents.find((event) => {
+          if (event.stream !== VOICE_CONTROL_STREAM) return false;
+          const data = event.data as
+            | { type?: string; command?: string }
+            | undefined;
+          return data?.type === "voice-control" && data?.command === "start";
+        });
+        if (!hit) {
+          return `no {type:"voice-control", command:"start"} event observed on the "${VOICE_CONTROL_STREAM}" stream; saw ${observedBusEvents.length} bus event(s): ${JSON.stringify(observedBusEvents.map((e) => e.stream)).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/music/routing-status.scenario.ts
+++ b/packages/test/scenarios/music/routing-status.scenario.ts
@@ -12,6 +12,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const MUSIC = "MUSIC";
 type R = AgentRuntime & {
@@ -130,6 +135,36 @@ export default scenario({
       actionName: MUSIC,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the set_routing/status subaction really read
+      // the AudioRouter state off the in-memory MusicService — the result must
+      // carry the router's status object (mode + empty active routes on a
+      // fresh runtime), not just handler success.
+      type: "custom",
+      name: "music-routing-status-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, MUSIC);
+        if (!data) {
+          return `no successful ${MUSIC} result data; calls: ${describeCalls(ctx)}`;
+        }
+        const status = toRecord(data.status);
+        if (!status) {
+          return `expected result.data.status from MusicService.getRoutingStatus(); saw ${JSON.stringify(data).slice(0, 300)}`;
+        }
+        if (typeof status.mode !== "string" || status.mode.length === 0) {
+          return `expected a routing mode string in status.mode, saw ${JSON.stringify(status.mode ?? null)}`;
+        }
+        if (!Array.isArray(status.activeRoutes)) {
+          return `expected status.activeRoutes array, saw ${JSON.stringify(status.activeRoutes ?? null)}`;
+        }
+        if (status.activeRoutes.length !== 0) {
+          return `fresh AudioRouter must report zero active routes; saw ${status.activeRoutes.length}`;
+        }
+        if (typeof status.zoneCount !== "number") {
+          return `expected numeric status.zoneCount, saw ${JSON.stringify(status.zoneCount ?? null)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/nostr/search-posts.scenario.ts
+++ b/packages/test/scenarios/nostr/search-posts.scenario.ts
@@ -22,6 +22,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const POST = "POST";
 
@@ -38,6 +42,8 @@ type R = AgentRuntime & {
 };
 
 let restoreWebSocket: (() => void) | undefined;
+/** REQ subscriptions the mock relay actually answered with EOSE. */
+let relayReqSubscriptions: string[] = [];
 
 /**
  * Minimal in-process Nostr relay over the WebSocket interface nostr-tools uses
@@ -73,6 +79,7 @@ class MockRelayWebSocket {
     if (!Array.isArray(message)) return;
     const [type, sub] = message as [string, string, ...unknown[]];
     if (type === "REQ") {
+      relayReqSubscriptions.push(sub);
       setTimeout(() => {
         this.onmessage?.({ data: JSON.stringify(["EOSE", sub]) });
       }, 0);
@@ -116,6 +123,7 @@ export default scenario({
       name: "nostr-mock-relay-and-config",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        relayReqSubscriptions = [];
 
         // Install the mock relay transport BEFORE plugin-nostr registers, so
         // SimplePool (constructed at service start) captures it as its
@@ -248,6 +256,32 @@ export default scenario({
       actionName: POST,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the search really flowed POST → nostr post
+      // connector → mock relay (a REQ subscription was answered) and the
+      // action surfaced the relay's empty result for the requested query —
+      // not just "the handler returned success".
+      type: "custom",
+      name: "nostr-search-effect",
+      predicate: (ctx) => {
+        if (relayReqSubscriptions.length === 0) {
+          return "mock relay never received a REQ subscription — the search never touched the Nostr transport";
+        }
+        const data = successfulActionData(ctx, POST);
+        if (!data) {
+          return `no successful ${POST} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.op !== "search" || data.source !== "nostr") {
+          return `expected result.data op "search" on source "nostr", saw op=${String(data.op)} source=${String(data.source)}`;
+        }
+        if (data.query !== "elizaos") {
+          return `expected the searched query "elizaos" in result.data.query, saw ${JSON.stringify(data.query ?? null)}`;
+        }
+        if (!Array.isArray(data.posts) || data.posts.length !== 0) {
+          return `mock relay returns zero events, so result.data.posts must be an empty array; saw ${JSON.stringify(data.posts ?? null).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/relationships/list-entities.scenario.ts
+++ b/packages/test/scenarios/relationships/list-entities.scenario.ts
@@ -26,6 +26,10 @@
  */
 import type { Action, AgentRuntime } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const KNOWLEDGE_GRAPH = "KNOWLEDGE_GRAPH";
 type R = AgentRuntime & {
@@ -100,6 +104,28 @@ export default scenario({
       actionName: KNOWLEDGE_GRAPH,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the list op really read the per-agent
+      // EntityStore — a fresh graph must surface an empty entities array in
+      // the result payload, not just handler success.
+      type: "custom",
+      name: "entity-store-read-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, KNOWLEDGE_GRAPH);
+        if (!data) {
+          return `no successful ${KNOWLEDGE_GRAPH} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.op !== "list") {
+          return `expected result.data.op "list", saw ${String(data.op ?? "(missing)")}`;
+        }
+        if (!Array.isArray(data.entities)) {
+          return `expected result.data.entities array from the EntityStore, saw ${JSON.stringify(data.entities ?? null)}`;
+        }
+        if (data.entities.length !== 0) {
+          return `fresh knowledge graph must have no entities; saw ${data.entities.length}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/remote-desktop/list-sessions.scenario.ts
+++ b/packages/test/scenarios/remote-desktop/list-sessions.scenario.ts
@@ -14,6 +14,10 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const REMOTE_DESKTOP = "REMOTE_DESKTOP";
 type R = AgentRuntime & {
@@ -142,6 +146,28 @@ export default scenario({
       actionName: REMOTE_DESKTOP,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the `list` subaction really read the
+      // RemoteSessionService store — a fresh runtime must yield an empty
+      // sessions array in the result payload, not just handler success.
+      type: "custom",
+      name: "remote-desktop-list-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, REMOTE_DESKTOP);
+        if (!data) {
+          return `no successful ${REMOTE_DESKTOP} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.subaction !== "list") {
+          return `expected result.data.subaction "list", saw ${String(data.subaction ?? "(missing)")}`;
+        }
+        if (!Array.isArray(data.sessions)) {
+          return `expected result.data.sessions array from the session store, saw ${JSON.stringify(data.sessions ?? null)}`;
+        }
+        if (data.sessions.length !== 0) {
+          return `fresh RemoteSessionService store must be empty; saw ${data.sessions.length} session(s)`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/shopify/list-products.scenario.ts
+++ b/packages/test/scenarios/shopify/list-products.scenario.ts
@@ -11,8 +11,16 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const SHOPIFY = "SHOPIFY";
+
+/** GraphQL request bodies the Admin API mock actually served. */
+let adminApiRequests: string[] = [];
 
 type R = AgentRuntime & {
   setSetting?: (k: string, v: string) => void;
@@ -39,10 +47,12 @@ export default scenario({
       name: "shopify-mock-and-config",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        adminApiRequests = [];
         // 1. In-process mock of the Shopify Admin GraphQL endpoint.
         const server = Bun.serve({
           port: 0,
-          async fetch() {
+          async fetch(request) {
+            adminApiRequests.push(await request.text());
             return new Response(
               JSON.stringify({
                 data: {
@@ -158,6 +168,32 @@ export default scenario({
       actionName: SHOPIFY,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the SHOPIFY products op really queried the
+      // Admin GraphQL mock (a products query hit the wire) and surfaced the
+      // mock's empty-store answer — not just "the handler returned success".
+      type: "custom",
+      name: "shopify-list-products-effect",
+      predicate: (ctx) => {
+        const productsQuery = adminApiRequests.find((body) =>
+          body.toLowerCase().includes("products"),
+        );
+        if (!productsQuery) {
+          return `Admin API mock never received a products query; served ${adminApiRequests.length} request(s): ${adminApiRequests
+            .map((body) => body.slice(0, 120))
+            .join(" | ")}`;
+        }
+        const call = successfulCalls(ctx, SHOPIFY).find(
+          (candidate) => toRecord(candidate.result?.data)?.op === "products",
+        );
+        if (!call) {
+          return `no successful SHOPIFY call routed the products op; calls: ${describeCalls(ctx)}`;
+        }
+        if (call.result?.text !== "No products found") {
+          return `expected the empty-store read ("No products found") in the action result, saw ${JSON.stringify(call.result?.text ?? null)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/suno/generate-music.scenario.ts
+++ b/packages/test/scenarios/suno/generate-music.scenario.ts
@@ -13,8 +13,16 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const MUSIC = "MUSIC";
+
+/** POST bodies the Suno API mock actually served. */
+let sunoMockRequests: string[] = [];
 type R = AgentRuntime & {
   setSetting?: (k: string, v: string) => void;
   scenarioLlmFixtures?: {
@@ -42,6 +50,7 @@ export default scenario({
       name: "suno-mock-and-config",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        sunoMockRequests = [];
 
         // Scoped fetch interceptor: redirect SunoProvider's REST calls to a mock.
         const realFetch = globalThis.fetch;
@@ -62,6 +71,7 @@ export default scenario({
                 ? input.url
                 : input.toString();
           if (url.includes("api.suno.ai")) {
+            sunoMockRequests.push(String(init?.body ?? ""));
             return new Response(
               JSON.stringify({
                 id: "suno-gen-1",
@@ -183,6 +193,35 @@ export default scenario({
       actionName: MUSIC,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the generate subaction really submitted the
+      // prompt to the Suno REST mock and surfaced the mock's pending
+      // generation (id suno-gen-1) in the action result — not just
+      // "the handler returned success".
+      type: "custom",
+      name: "suno-generation-submitted-effect",
+      predicate: (ctx) => {
+        const submitted = sunoMockRequests.find((body) =>
+          body.includes("lofi"),
+        );
+        if (!submitted) {
+          return `Suno API mock never received the generation prompt; served ${sunoMockRequests.length} request(s): ${sunoMockRequests
+            .map((body) => body.slice(0, 120))
+            .join(" | ")}`;
+        }
+        const data = successfulActionData(ctx, MUSIC);
+        if (!data) {
+          return `no successful ${MUSIC} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.subaction !== "generate") {
+          return `expected result.data.subaction "generate", saw ${String(data.subaction ?? "(missing)")}`;
+        }
+        const response = toRecord(data.response);
+        if (response?.id !== "suno-gen-1" || response.status !== "pending") {
+          return `expected the mock's submitted generation (id suno-gen-1, status pending) in result.data.response; saw ${JSON.stringify(data.response ?? null).slice(0, 200)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/task-coordinator/orchestrator-status.scenario.ts
+++ b/packages/test/scenarios/task-coordinator/orchestrator-status.scenario.ts
@@ -144,5 +144,25 @@ export default scenario({
       status: "success",
       minCount: 1,
     },
+    {
+      // Effect proof (#11381): the slash command's deterministic handler
+      // really produced its contractual status reply — the action's entire
+      // observable behavior — not merely success=true.
+      type: "custom",
+      name: "orchestrator-status-reply-effect",
+      predicate: (ctx) => {
+        const call = ctx.actionsCalled.find(
+          (action) =>
+            action.actionName === ORCHESTRATOR_STATUS_COMMAND_ACTION &&
+            action.result?.success === true,
+        );
+        if (!call) {
+          return `no successful ${ORCHESTRATOR_STATUS_COMMAND_ACTION} call captured`;
+        }
+        if (call.result?.text !== "Orchestrator is online.") {
+          return `expected the command's fixed status reply "Orchestrator is online." in result.text, saw ${JSON.stringify(call.result?.text ?? null)}`;
+        }
+      },
+    },
   ],
 });

--- a/packages/test/scenarios/tunnel/tunnel-status.scenario.ts
+++ b/packages/test/scenarios/tunnel/tunnel-status.scenario.ts
@@ -23,6 +23,10 @@ import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { LocalTunnelService } from "@elizaos/plugin-tunnel";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const TUNNEL = "TUNNEL";
 
@@ -177,6 +181,28 @@ export default scenario({
       actionName: TUNNEL,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the status sub-op really read the live
+      // LocalTunnelService's fresh state — an inactive tunnel with a named
+      // provider — not just "the handler returned success".
+      type: "custom",
+      name: "tunnel-status-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, TUNNEL);
+        if (!data) {
+          return `no successful TUNNEL result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (data.action !== "tunnel_status") {
+          return `expected result.data.action "tunnel_status", saw ${String(data.action ?? "(missing)")}`;
+        }
+        if (data.active !== false) {
+          return `fresh LocalTunnelService must report an inactive tunnel (active=false); saw active=${String(data.active)}`;
+        }
+        if (typeof data.provider !== "string" || data.provider.length === 0) {
+          return `expected the service's provider name in result.data.provider; saw ${JSON.stringify(data.provider ?? null)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/vision/set-mode.scenario.ts
+++ b/packages/test/scenarios/vision/set-mode.scenario.ts
@@ -10,6 +10,10 @@
 import type { AgentRuntime, Provider } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+} from "../_helpers/effect-assertions.ts";
 
 const VISION = "VISION";
 type R = AgentRuntime & {
@@ -151,6 +155,38 @@ export default scenario({
       actionName: VISION,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the set_mode op really flipped the live
+      // VisionService — the service's own getVisionMode() must report "off"
+      // after the turn, and the result payload must carry the applied mode.
+      type: "custom",
+      name: "vision-mode-applied-effect",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, VISION);
+        if (!data) {
+          return `no successful ${VISION} result data; calls: ${describeCalls(ctx)}`;
+        }
+        if (
+          data.op !== "set_mode" ||
+          String(data.visionMode).toLowerCase() !== "off"
+        ) {
+          return `expected result.data op "set_mode" with visionMode OFF, saw ${JSON.stringify(data).slice(0, 200)}`;
+        }
+        const runtime = ctx.runtime as {
+          getService?: (
+            type: string,
+          ) => { getVisionMode?: () => string } | null;
+        };
+        const service = runtime.getService?.("VISION");
+        if (!service || typeof service.getVisionMode !== "function") {
+          return "VisionService is not registered — cannot verify the live mode";
+        }
+        const liveMode = service.getVisionMode();
+        if (String(liveMode).toLowerCase() !== "off") {
+          return `live VisionService.getVisionMode() must be OFF after the turn, saw ${JSON.stringify(liveMode)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/wallet/token-info.scenario.ts
+++ b/packages/test/scenarios/wallet/token-info.scenario.ts
@@ -24,6 +24,8 @@ type R = AgentRuntime & {
 };
 
 let restoreFetch: (() => void) | undefined;
+/** URLs of DexScreener token-pair lookups the mock actually served. */
+let dexMockHits: string[] = [];
 
 const MOCK_PAIR = {
   chainId: "ethereum",
@@ -77,6 +79,7 @@ export default scenario({
       name: "wallet-mock-and-config",
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
+        dexMockHits = [];
 
         // Pin the DexScreener base URL so the interceptor target is stable,
         // regardless of any Eliza Cloud routing defaults.
@@ -109,6 +112,7 @@ export default scenario({
             url.includes("api.dexscreener.com") &&
             url.includes("/latest/dex/tokens/")
           ) {
+            dexMockHits.push(url);
             return new Response(JSON.stringify({ pairs: [MOCK_PAIR] }), {
               headers: { "Content-Type": "application/json" },
             });
@@ -229,6 +233,51 @@ export default scenario({
       actionName: WALLET,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the token-info pipeline really fetched the
+      // DexScreener pairs for the requested address and surfaced the mock's
+      // market data in the action result — not just "the handler returned
+      // success".
+      type: "custom",
+      name: "dexscreener-token-info-effect",
+      predicate: (ctx) => {
+        const hit = dexMockHits.find((url) =>
+          url.toLowerCase().includes(TOKEN_ADDRESS.toLowerCase()),
+        );
+        if (!hit) {
+          return `DexScreener mock never served a token-pair lookup for ${TOKEN_ADDRESS}; served: ${
+            dexMockHits.join(", ") || "(none)"
+          }`;
+        }
+        const call = ctx.actionsCalled.find(
+          (a) => a.actionName === WALLET && a.result?.success === true,
+        );
+        const data =
+          call?.result?.data && typeof call.result.data === "object"
+            ? (call.result.data as Record<string, unknown>)
+            : null;
+        if (!data) {
+          return "successful WALLET call carried no result.data";
+        }
+        if (data.subaction !== "token_info") {
+          return `expected result.data.subaction "token_info", saw ${String(data.subaction ?? "(missing)")}`;
+        }
+        const pairs = Array.isArray(data.pairs) ? data.pairs : [];
+        const pair =
+          pairs[0] && typeof pairs[0] === "object"
+            ? (pairs[0] as Record<string, unknown>)
+            : null;
+        const baseToken =
+          pair?.baseToken && typeof pair.baseToken === "object"
+            ? (pair.baseToken as Record<string, unknown>)
+            : null;
+        if (baseToken?.symbol !== "USDC" || pair?.priceUsd !== "1.00") {
+          return `expected result.data.pairs[0] to carry the mock's USDC pair (symbol USDC, priceUsd 1.00); saw ${JSON.stringify(
+            pair ?? "(no pairs)",
+          ).slice(0, 300)}`;
+        }
+      },
     },
   ],
 });


### PR DESCRIPTION
## Summary

Refs #11381.

Pays down a first tranche of the actionCalled-only scenario backlog by adding effect-proving final checks to connector/status scenarios and lowering the static ratchet in lockstep:

- adds reusable effect assertion helpers
- adds concrete custom/effect final checks across 18 scenario files
- lowers `action-effect-ratchet.test.ts` `BASELINE` from `60` to `42`
- records the current static ratchet count and remaining debt in evidence

This is a ratcheted paydown slice, not full closure of #11381; 42 direct scenarios remain actionCalled-only.

## Validation

- static ratchet-count script using the same AST logic as `action-effect-ratchet.test.ts`: `count = 42`
- `bun run --cwd packages/scenario-runner test -- src/action-effect-ratchet.test.ts`
- `git diff --check origin/develop...HEAD`

## Evidence

- `.github/issue-evidence/11381-actioncalled-paydown/README.md`

## Remaining Work

Continue converting the 42 remaining direct actionCalled-only scenarios to effect checks and lower the ratchet each time.
