### PR TITLE
fix(scripts): sync trajectory-validate cost table with current model pricing

### DIFF
--- a/packages/scripts/__tests__/trajectory-validate.test.ts
+++ b/packages/scripts/__tests__/trajectory-validate.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import fs from "node:fs/promises";
-import path from "node:path";
 import { computeCallCostUsd } from "../lib/cost-table";
 import {
   compareTrajectories,
@@ -10,20 +8,6 @@ import {
   validateTrajectoryJsonReport,
   validateTrajectoryMarkdownReport,
 } from "../lib/trajectory-validate";
-
-async function readScenario(name: string): Promise<{
-  expect: { stages?: string[]; contexts?: string[]; tools?: string[] };
-}> {
-  const raw = await fs.readFile(
-    path.join(
-      process.cwd(),
-      "research/native-tool-calling/scenarios",
-      `${name}.json`,
-    ),
-    "utf8",
-  );
-  return JSON.parse(raw);
-}
 
 function modelStage(args: {
   stageId: string;
@@ -190,10 +174,9 @@ function completeTrajectory(
 }
 
 describe("trajectory structural validation", () => {
-  test("accepts a complete trajectory and scenario stage expectations", async () => {
-    const scenario = await readScenario("single-tool");
+  test("accepts a complete trajectory and scenario stage expectations", () => {
     const result = validateTrajectory(completeTrajectory(), {
-      expectedStages: scenario.expect.stages,
+      expectedStages: ["messageHandler", "planner", "tool", "evaluation"],
       expectedContexts: ["web"],
       requireMessageArrays: true,
     });
@@ -292,5 +275,75 @@ describe("trajectory structural validation", () => {
     expect(comparison.delta.totalCacheReadTokens).toBe(-1000);
     expect(comparison.estimatedBatchingDelta.stages).toBe(-1);
     expect(comparison.cacheHitRateA).toBeGreaterThan(comparison.cacheHitRateB);
+  });
+});
+
+describe("cost table matches canonical @elizaos/core pricing", () => {
+  const oneMInput = {
+    promptTokens: 1_000_000,
+    completionTokens: 0,
+    totalTokens: 1_000_000,
+  };
+  const oneMOutput = {
+    promptTokens: 0,
+    completionTokens: 1_000_000,
+    totalTokens: 1_000_000,
+  };
+
+  const anthropicRates: Array<[model: string, input: number, output: number]> =
+    [
+      ["claude-opus-4-8", 5, 25],
+      ["claude-opus-4-7", 5, 25],
+      ["claude-sonnet-5", 3, 15],
+      ["claude-sonnet-4-6", 3, 15],
+      ["claude-haiku-4-5", 1, 5],
+    ];
+  for (const [model, input, output] of anthropicRates) {
+    test(`${model} bills $${input}/M input, $${output}/M output`, () => {
+      expect(computeCallCostUsd(model, oneMInput)).toBeCloseTo(input, 6);
+      expect(computeCallCostUsd(model, oneMOutput)).toBeCloseTo(output, 6);
+    });
+  }
+
+  test("versioned claude ids resolve to their family entry", () => {
+    expect(
+      computeCallCostUsd("claude-haiku-4-5-20251001", oneMInput),
+    ).toBeCloseTo(1, 6);
+    expect(computeCallCostUsd("claude-opus-4-7-1", oneMInput)).toBeCloseTo(
+      5,
+      6,
+    );
+  });
+
+  test("anthropic cache reads bill 0.1x input; cache writes 1.25x input", () => {
+    const allCacheRead = {
+      promptTokens: 1_000_000,
+      completionTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+      totalTokens: 1_000_000,
+    };
+    expect(computeCallCostUsd("claude-opus-4-7", allCacheRead)).toBeCloseTo(
+      0.5,
+      6,
+    );
+    expect(computeCallCostUsd("claude-haiku-4-5", allCacheRead)).toBeCloseTo(
+      0.1,
+      6,
+    );
+
+    const allCacheWrite = {
+      promptTokens: 1_000_000,
+      completionTokens: 0,
+      cacheCreationInputTokens: 1_000_000,
+      totalTokens: 1_000_000,
+    };
+    expect(computeCallCostUsd("claude-opus-4-7", allCacheWrite)).toBeCloseTo(
+      6.25,
+      6,
+    );
+    expect(computeCallCostUsd("claude-haiku-4-5", allCacheWrite)).toBeCloseTo(
+      1.25,
+      6,
+    );
   });
 });

--- a/packages/scripts/lib/cost-table.ts
+++ b/packages/scripts/lib/cost-table.ts
@@ -1,119 +1,18 @@
 /**
- * Per-model price table and helpers for computing per-call USD cost.
+ * Cost helpers for the offline trajectory tooling (`trajectory.ts`,
+ * `run-cerebras.ts`, `lib/trajectory-validate.ts`).
  *
- * Source of truth for the trajectory recorder + the trajectory CLI. Mirrors
- * the price table in PLAN.md §18.7. The numbers are per 1,000,000 tokens
- * (the standard unit pricing providers publish).
- *
- * `cacheRead` is the discount applied when the input was served from cache.
- * `cacheWrite` is the surcharge for writing the prompt into cache (Anthropic
- * specifically charges this; OpenAI does not). When a provider does not
- * differentiate, set the cache rates to 0 — `computeCallCostUsd` will fall
- * back to the regular input rate.
+ * The per-model price table has ONE canonical home:
+ * `packages/core/src/features/trajectories/pricing.ts` (versioned via
+ * `PRICE_TABLE_ID`). It is re-exported here from source — the same pattern
+ * other scripts in this directory use for core imports — so the offline
+ * validator always prices calls with the exact table the trajectory
+ * recorder used to write `cost_usd`.
  */
-
-export interface ModelPriceUsdPerMTokens {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-}
-
-export interface TokenUsageForCost {
-  promptTokens?: number;
-  completionTokens?: number;
-  cacheReadInputTokens?: number;
-  cacheCreationInputTokens?: number;
-  totalTokens?: number;
-}
-
-export const MODEL_PRICES_USD_PER_M_TOKENS: Record<
-  string,
-  ModelPriceUsdPerMTokens
-> = {
-  // Cerebras (served at https://api.cerebras.ai/v1)
-  "gemma-4-31b": { input: 0.99, output: 1.49, cacheRead: 0, cacheWrite: 0 },
-  "gpt-oss-120b": { input: 0.5, output: 0.8, cacheRead: 0, cacheWrite: 0 },
-  "gpt-oss-20b": { input: 0.1, output: 0.3, cacheRead: 0, cacheWrite: 0 },
-
-  // Anthropic
-  "claude-opus-4-7": {
-    input: 15.0,
-    output: 75.0,
-    cacheRead: 1.5,
-    cacheWrite: 18.75,
-  },
-  "claude-sonnet-4-6": {
-    input: 3.0,
-    output: 15.0,
-    cacheRead: 0.3,
-    cacheWrite: 3.75,
-  },
-  "claude-haiku-4-5": {
-    input: 0.8,
-    output: 4.0,
-    cacheRead: 0.08,
-    cacheWrite: 1.0,
-  },
-
-  // OpenAI (current ship targets per CLAUDE.md)
-  "gpt-5.5": { input: 1.25, output: 10.0, cacheRead: 0.125, cacheWrite: 0 },
-  "gpt-5.5-mini": { input: 0.25, output: 2.0, cacheRead: 0.025, cacheWrite: 0 },
-};
-
-/**
- * Look up the price entry for a model name. Falls back to a partial match
- * when an exact key is missing — the adapter sometimes emits a versioned
- * model id (e.g. `claude-haiku-4-5-20251001`) where the price table only
- * stores the family key (`claude-haiku-4-5`).
- */
-export function lookupModelPrice(
-  modelName: string | undefined,
-): ModelPriceUsdPerMTokens | null {
-  if (!modelName) return null;
-  const exact = MODEL_PRICES_USD_PER_M_TOKENS[modelName];
-  if (exact) return exact;
-
-  const normalized = modelName.toLowerCase();
-  const match = Object.keys(MODEL_PRICES_USD_PER_M_TOKENS)
-    .filter((k) => normalized.includes(k.toLowerCase()))
-    .sort((a, b) => b.length - a.length)[0];
-  return match ? (MODEL_PRICES_USD_PER_M_TOKENS[match] ?? null) : null;
-}
-
-/**
- * Compute the USD cost of a single model call given its model name and
- * token usage breakdown. Returns 0 when the model is unknown — cost
- * computation must never be a hard error in the recorder.
- *
- * Cache-read tokens are billed at the cacheRead rate when set, otherwise
- * the regular input rate. Cache-creation tokens are billed at cacheWrite
- * (Anthropic's surcharge) on top of the regular input portion that paid
- * for them. Non-cached input is billed at the input rate.
- */
-export function computeCallCostUsd(
-  modelName: string | undefined,
-  usage: TokenUsageForCost | undefined,
-): number {
-  if (!usage) return 0;
-  const price = lookupModelPrice(modelName);
-  if (!price) return 0;
-
-  const cacheRead = usage.cacheReadInputTokens ?? 0;
-  const cacheWrite = usage.cacheCreationInputTokens ?? 0;
-  const totalPrompt = usage.promptTokens ?? 0;
-  const nonCachedInput = Math.max(0, totalPrompt - cacheRead - cacheWrite);
-  const completion = usage.completionTokens ?? 0;
-
-  const inputCost = (nonCachedInput / 1_000_000) * price.input;
-  const cacheReadCost =
-    (cacheRead / 1_000_000) * (price.cacheRead || price.input);
-  const cacheWriteCost =
-    (cacheWrite / 1_000_000) * (price.cacheWrite || price.input);
-  const outputCost = (completion / 1_000_000) * price.output;
-
-  return inputCost + cacheReadCost + cacheWriteCost + outputCost;
-}
+export {
+  computeCallCostUsd,
+  type TokenUsageForCost,
+} from "../../core/src/features/trajectories/pricing";
 
 /**
  * Format a cost value for terminal display. Always 4 fractional digits so


### PR DESCRIPTION
## Problem

`packages/scripts/lib/cost-table.ts` held a stale duplicate model price table used by the offline trajectory tooling (`trajectory.ts` validate/aggregate, `run-cerebras.ts`, `lib/trajectory-validate.ts`):

- `claude-opus-4-7` priced at **$15/$75** per MTok — real rate is **$5/$25**
- `claude-haiku-4-5` at $0.8/$4 — real rate is $1/$5 (cacheRead 0.1x, cacheWrite 1.25x input)
- `claude-opus-4-8` and `claude-sonnet-5` missing entirely

The validator recomputes `cost_usd` from its own table (`lib/trajectory-validate.ts` → "does not match price table" error), so any trajectory recorded with core's canonical table (PR #11529, `packages/core/src/features/trajectories/pricing.ts`) failed validation on every Anthropic stage — and the aggregate/stats cost roll-ups were 3x inflated for opus.

This is a residual found during the #11527/#11529 review.

## Fix

- `lib/cost-table.ts` now **re-exports `computeCallCostUsd` from the canonical core module** (`../../core/src/features/trajectories/pricing`) instead of carrying a copy — the same core-src import pattern already used by `capability-router-fixture-server.ts` and `run-autonomy-cerebras-loops.ts`. Only the terminal `formatUsd` helper stays local. The two tables can no longer drift.
- Extended `__tests__/trajectory-validate.test.ts` to pin the current Anthropic ids: $5/$25 `claude-opus-4-8`/`claude-opus-4-7`, $3/$15 `claude-sonnet-5`/`claude-sonnet-4-6`, $1/$5 `claude-haiku-4-5`, versioned-id family fallback (`claude-haiku-4-5-20251001`), and the 0.1x cacheRead / 1.25x cacheWrite multipliers.
- Un-broke the first structural test (failing on develop): it read `research/native-tool-calling/scenarios/single-tool.json`, which was deleted in cleanup commit `8850b1a24c`; the stage expectations are now inline.

Note: the old table's `gpt-oss-20b` entry is not in the canonical core table and had no repo consumer; unlisted ids can be priced via the core `MODEL_PRICES_JSON` env override.

## Verification

- `bun run trajectory:inspect:test` — **11 pass / 0 fail** (baseline on develop: 3 pass / 1 fail — the deleted-fixture ENOENT)
- CLI end-to-end: `bun packages/scripts/trajectory.ts validate` on a synthetic `claude-opus-4-7` trajectory with 1M input tokens
  - `costUsd: 5.0` (canonical) → **no cost error**
  - `costUsd: 15.0` (old stale rate) → **`error $.stages[0].model.costUsd: does not match price table: expected 5`**
- `bun packages/scripts/trajectory.ts` and `bun packages/scripts/run-cerebras.ts` both boot with the new core-src import chain
- Targeted `tsc --noEmit` (bundler resolution, matching bun) over `cost-table.ts` + `trajectory-validate.ts` + the test incl. the transitive core pricing/logger graph — clean
- `bunx @biomejs/biome check` on both changed files — clean; `bun run audit:scripts` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)