### PR TITLE
test(core): port the fine-grained #11504 stage-1 reply regression suite

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -726,6 +726,179 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("keeps a bare unfenced code-body Stage 1 reply verbatim (#11504)", async () => {
+		// gemma-4-31b answers HumanEval-style prompts with a bare Python body: no
+		// markdown fence, no chat prose, nested blocks at 8+ space indentation.
+		// The old unanchored repeated-character heuristic flagged the indentation
+		// run as junk and replaced the whole solution with a deferral, dropping
+		// the eliza-harness humaneval score to 0.40 vs 1.00 on raw harnesses.
+		const bareCode = [
+			"def has_close_elements(numbers: List[float], threshold: float) -> bool:",
+			"    for i in range(len(numbers)):",
+			"        for j in range(i + 1, len(numbers)):",
+			"            if abs(numbers[i] - numbers[j]) < threshold:",
+			"                return True",
+			"    return False",
+		].join("\n");
+		const runtime = makeRuntime([
+			stage1Response({ contexts: ["simple"], replyText: bareCode }),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "Complete this Python function: def has_close_elements(numbers: List[float], threshold: float) -> bool: check if any two numbers are closer than threshold.",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(bareCode);
+		}
+		expect(useModelCalls(runtime).length).toBe(1);
+	});
+
+	it("keeps a fenced code block reply even with a prose lead-in (#11504)", async () => {
+		// The old fence exemption only fired when the reply STARTED with ``` — a
+		// prose sentence before the fence re-exposed the reply to the repeated-run
+		// check, which flagged the nested indentation inside the block.
+		const reply = [
+			"Here's the implementation:",
+			"",
+			"```python",
+			"def first_positive(xs):",
+			"    for x in xs:",
+			"        if x > 0:",
+			"            return x",
+			"    return None",
+			"```",
+		].join("\n");
+		const runtime = makeRuntime([
+			stage1Response({ contexts: ["simple"], replyText: reply }),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "Write a Python function that returns the first positive number in a list.",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(reply);
+		}
+	});
+
+	it("keeps a pretty-printed JSON structured reply (#11504)", async () => {
+		// 4-space pretty-printing nests to 8+ consecutive spaces, which the old
+		// unanchored repeated-run check classified as junk.
+		const reply = JSON.stringify(
+			{ user: { name: "Ada", roles: ["admin", "ops"], active: true } },
+			null,
+			4,
+		);
+		const runtime = makeRuntime([
+			stage1Response({ contexts: ["simple"], replyText: reply }),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "Show me the user record as JSON, pretty-printed.",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(reply);
+		}
+	});
+
+	it("keeps prose containing a separator or emphasis run (#11504)", async () => {
+		// "=====" separators and stretched words are legitimate content; only a
+		// reply that is NOTHING BUT repeated-character runs is degenerate output.
+		for (const reply of [
+			"Results:\n=====\nAll 20 checks passed.",
+			"Sooooo happy this worked out for you!",
+		]) {
+			const runtime = makeRuntime([
+				stage1Response({ contexts: ["simple"], replyText: reply }),
+			]);
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text: "How did the checks go?" }),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			});
+			expect(result.kind).toBe("direct_reply");
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(reply);
+			}
+		}
+	});
+
+	it("still defers empty, whitespace, refusal-stub, and degenerate-run replies (#11504)", async () => {
+		for (const badReply of [
+			"",
+			"   ",
+			"I am not sure.",
+			"I'm not sure how to answer that.",
+			"I don't know.",
+			"I'm sorry, I can't help with that.",
+			"aaaaa bbbbb",
+			"!!!!!\n!!!!!",
+		]) {
+			const runtime = makeRuntime([
+				stage1Response({ contexts: ["simple"], replyText: badReply }),
+			]);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text: "What is 2+2?" }),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			});
+
+			expect(result.kind).toBe("direct_reply");
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(
+					"I'm not sure how to answer that.",
+				);
+			}
+		}
+	});
+
+	it("keeps a refusal that continues into content and a bare social apology (#11504)", async () => {
+		// Refusal-plus-content carries an answer; apology-only is a legitimate
+		// conversational reply. Neither is an unusable stub.
+		for (const reply of [
+			"I'm not sure, but my best guess is 42.",
+			"Sorry about that.",
+			"Sorry.",
+		]) {
+			const runtime = makeRuntime([
+				stage1Response({ contexts: ["simple"], replyText: reply }),
+			]);
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage({ text: "What's the answer?" }),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			});
+			expect(result.kind).toBe("direct_reply");
+			if (result.kind === "direct_reply") {
+				expect(result.result.responseContent?.text).toBe(reply);
+			}
+		}
+	});
+
 	it("uses a compact response-handler schema for direct channels", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3067,10 +3067,50 @@ direct/private rules:
 Return exactly one JSON object for {{handleResponseToolName}}. No prose, markdown, or thinking.
 `;
 
+/**
+ * Answer-free refusal stubs, matched against the WHOLE normalized reply after
+ * an optional leading apology ("I'm sorry, but …") is stripped. A refusal that
+ * continues into content ("I'm not sure, but my best guess is …") never
+ * matches, and a bare social apology ("Sorry.") is a legitimate reply, not a
+ * refusal.
+ */
+const STAGE1_BARE_REFUSAL_STUBS: ReadonlySet<string> = new Set([
+	"i am not sure",
+	"i'm not sure",
+	"i am not sure how to answer that",
+	"i'm not sure how to answer that",
+	"i don't know",
+	"i do not know",
+	"i can't help with that",
+	"i cannot help with that",
+	"i can't answer that",
+	"i cannot answer that",
+	"i am unable to help with that",
+	"i am unable to answer that",
+]);
+
+function isBareRefusalStage1Reply(trimmed: string): boolean {
+	const normalized = trimmed
+		.toLowerCase()
+		.replace(/[’‘]/gu, "'")
+		.replace(/\s+/gu, " ")
+		.replace(/[.!?]+$/u, "")
+		.trim();
+	const withoutApology = normalized.replace(
+		/^(?:i am sorry|i'm sorry|sorry|my apologies|i apologize)[,.!]?\s*(?:but\s+)?/u,
+		"",
+	);
+	return STAGE1_BARE_REFUSAL_STUBS.has(withoutApology);
+}
+
 function isUnusableStage1Reply(reply: string | undefined): boolean {
 	const trimmed = typeof reply === "string" ? reply.trim() : "";
 	if (!trimmed) return true;
 	if (/^```[a-z0-9_-]*\s+/iu.test(trimmed)) return false;
+	// A bare refusal stub carries no answer — defer instead of shipping it
+	// (#11504 asked to tighten the unusable signal to actual refusals/empties).
+	// Refusal-plus-content and bare social apologies never match.
+	if (isBareRefusalStage1Reply(trimmed)) return true;
 	if (/^[\s{}[\]":,]+$/.test(trimmed)) return true;
 	if (/^\d+$/.test(trimmed)) return true;
 	// Degenerate single-character spam: the WHOLE reply is one code point
@@ -3081,6 +3121,12 @@ function isUnusableStage1Reply(reply: string | undefined): boolean {
 	// valid replies to "I'm not sure how to answer that." (#11504).
 	const nonWhitespace = [...trimmed.replace(/\s+/gu, "")];
 	if (nonWhitespace.length >= 5 && new Set(nonWhitespace).size === 1) {
+		return true;
+	}
+	// Multi-token degenerate spam: EVERY whitespace-separated token is a single
+	// character repeated 5+ times ("aaaaa bbbbb"). Checked per token — an
+	// alternation regex over the whole reply backtracks catastrophically.
+	if (trimmed.split(/\s+/u).every((token) => /^(\S)\1{4,}$/u.test(token))) {
 		return true;
 	}
 	if (/^[A-Z]{2,8}$/.test(trimmed)) {


### PR DESCRIPTION
Refs #11504

## What

Ports the six finer-grained regression tests from the closed PR #11553 (`fix/11504-stage1-code-reply`, head `b1b27f2`) atop the merged #11555 fix (`c532e3b565`) for `isUnusableStage1Reply`:

1. keeps a bare unfenced code-body Stage 1 reply verbatim
2. keeps a fenced code block reply even with a prose lead-in
3. keeps a pretty-printed JSON structured reply
4. keeps prose containing a separator or emphasis run (`=====`, "Sooooo happy ...")
5. still defers empty, whitespace, refusal-stub, and degenerate-run replies
6. keeps a refusal that continues into content and a bare social apology

None are exact duplicates of #11555's single broad test ("delivers bare-code and structured Stage 1 replies verbatim") — the payloads, user prompts, and the defer/keep boundary cases (5, 6) differ, and the per-case test names isolate failures.

## Coverage gap the port exposed (and the minimal fix)

Running the ported suite against the merged implementation **failed** test 5 on four sub-cases — real gaps in the merged heuristic, both fixed in `packages/core/src/services/message.ts`:

- **Bare refusal stubs delivered verbatim.** `"I am not sure."`, `"I don't know."`, `"I'm sorry, I can't help with that."` were kept as the user-facing answer. #11504's ask was to *"tighten the 'unusable' signal to actual refusals/empties"* — the merged fix removed the over-broad repeated-run check but never classified refusals. Ported #11553's whole-reply-anchored `isBareRefusalStage1Reply` (optional leading apology stripped; refusal-plus-content like "I'm not sure, but my best guess is 42." and bare social apologies like "Sorry." are kept — test 6 pins that boundary).
- **Multi-token degenerate spam kept.** `"aaaaa bbbbb"` slips the merged whole-reply single-code-point check (two distinct code points). Added #11553's per-token check (every whitespace-separated token is one character repeated 5+ times, checked per token to avoid catastrophic backtracking) **alongside** the existing set-based check — nothing the merged heuristic already caught is weakened (e.g. `"aa aaa"` still defers via the set-based check; `"!!!!!\n!!!!!"` defers via both).

## Verification (local, this branch)

- `bunx vitest run src/__tests__/message-runtime-stage1.test.ts` — **81 passed (81)** (75 pre-existing + 6 ported)
- Pre-fix adversarial run: the 6 ported tests against unmodified develop → **1 failed | 5 passed** (failure: `expected 'I am not sure.' to be 'I'm not sure how to answer that.'`) — proving the port catches the gap
- All 18 core test files importing `services/message` (message-loop set + action-catalog/planner/voice/stress/media suites) — **18 files, 113 tests passed**
- Full `packages/core` suite — result posted as a PR comment
- `bun run typecheck` in `packages/core` — exit 0
- `bunx biome check` on both changed files — clean

`isUnusableStage1Reply` / the deferral string are not referenced outside these two files (checked repo-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
