### PR TITLE
feat: per-task coding-backend routing — resolver precedence, opt-in brain-provider override, owner-gated chat controls

### DIFF
--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -549,6 +549,8 @@ async function handleSet(
 interface CodingAxisRouting {
   default?: string;
   byTag?: Record<string, string>;
+  /** Operator lock-list constraining every resolved backend (orchestrator-side). */
+  allow?: string[];
 }
 
 export function normalizeCodingBackend(value: unknown): string | undefined {
@@ -559,6 +561,28 @@ export function normalizeCodingBackend(value: unknown): string | undefined {
   return (CODING_BACKENDS as readonly string[]).includes(resolved)
     ? resolved
     : undefined;
+}
+
+/** Parse a `{ coding: {...} }`-shaped routing object into a CodingAxisRouting. */
+function parseCodingAxisObject(parsed: unknown): CodingAxisRouting {
+  const coding =
+    isRecord(parsed) && isRecord(parsed.coding) ? parsed.coding : {};
+  const out: CodingAxisRouting = {};
+  if (typeof coding.default === "string") out.default = coding.default;
+  if (isRecord(coding.byTag)) {
+    const byTag: Record<string, string> = {};
+    for (const [k, val] of Object.entries(coding.byTag)) {
+      if (typeof val === "string") byTag[k.toLowerCase()] = val;
+    }
+    if (Object.keys(byTag).length > 0) out.byTag = byTag;
+  }
+  if (Array.isArray(coding.allow)) {
+    const allow = coding.allow.filter(
+      (v): v is string => typeof v === "string",
+    );
+    if (allow.length > 0) out.allow = allow;
+  }
+  return out;
 }
 
 export function readBackendRouting(config: {
@@ -575,23 +599,36 @@ export function readBackendRouting(config: {
   } else {
     parsed = raw;
   }
-  const coding =
-    isRecord(parsed) && isRecord(parsed.coding) ? parsed.coding : {};
-  const out: CodingAxisRouting = {};
-  if (typeof coding.default === "string") out.default = coding.default;
-  if (isRecord(coding.byTag)) {
-    const byTag: Record<string, string> = {};
-    for (const [k, val] of Object.entries(coding.byTag)) {
-      if (typeof val === "string") byTag[k.toLowerCase()] = val;
-    }
-    if (Object.keys(byTag).length > 0) out.byTag = byTag;
+  return parseCodingAxisObject(parsed);
+}
+
+/**
+ * The EFFECTIVE coding routing the orchestrator actually uses — its resolver
+ * reads `character.settings.routing.coding` first, then the
+ * `ELIZA_BACKEND_ROUTING` config-env JSON. Mirror that precedence so show/set
+ * report and mutate what truly takes effect (a character-declared policy would
+ * otherwise silently shadow a config-env write).
+ */
+function readEffectiveCodingRouting(
+  runtime: IAgentRuntime,
+  config: { env?: Record<string, unknown> },
+): { routing: CodingAxisRouting; source: "character" | "env" | "none" } {
+  const fromCharacter = parseCodingAxisObject(
+    runtime.character?.settings?.routing,
+  );
+  if (fromCharacter.default || fromCharacter.byTag || fromCharacter.allow) {
+    return { routing: fromCharacter, source: "character" };
   }
-  return out;
+  const fromEnv = readBackendRouting(config);
+  if (fromEnv.default || fromEnv.byTag || fromEnv.allow) {
+    return { routing: fromEnv, source: "env" };
+  }
+  return { routing: {}, source: "none" };
 }
 
 function handleShowBackends(runtime: IAgentRuntime): ActionResult {
   const config = loadElizaConfig() as { env?: Record<string, unknown> };
-  const coding = readBackendRouting(config);
+  const { routing: coding } = readEffectiveCodingRouting(runtime, config);
   const brain =
     (typeof runtime.getSetting === "function"
       ? (runtime.getSetting("ELIZA_BRAIN_PROVIDER") as string | null)
@@ -603,6 +640,11 @@ function handleShowBackends(runtime: IAgentRuntime): ActionResult {
     for (const [tag, backend] of Object.entries(coding.byTag)) {
       codingLines.push(`- coding when ${tag}: ${backend}`);
     }
+  }
+  if (coding.allow && coding.allow.length > 0) {
+    codingLines.push(
+      `- coding allowed (lock-list): ${coding.allow.join(", ")}`,
+    );
   }
   const text = [
     "Current backend routing:",
@@ -658,18 +700,39 @@ function handleSetBackend(
     : "";
 
   const config = loadElizaConfig() as { env?: Record<string, unknown> };
-  const coding = readBackendRouting(config);
+  // Start from the EFFECTIVE routing (character first, else env) so we mutate
+  // whatever currently wins and preserve any operator allow lock-list.
+  const { routing: coding } = readEffectiveCodingRouting(runtime, config);
   if (tag) {
     coding.byTag = { ...(coding.byTag ?? {}), [tag]: backend };
   } else {
     coding.default = backend;
   }
-  const routing = { coding };
+
+  // Persist to the config-env JSON for durability across restarts.
   config.env = {
     ...(config.env ?? {}),
-    ELIZA_BACKEND_ROUTING: JSON.stringify(routing),
+    ELIZA_BACKEND_ROUTING: JSON.stringify({ coding }),
   };
   saveElizaConfig(config as Parameters<typeof saveElizaConfig>[0]);
+
+  // Also write through to the in-memory character at the HIGHEST precedence the
+  // orchestrator reads. Without this, a character that already declares
+  // routing.coding would shadow the config-env write and the command would
+  // report success with zero effect. Mutating the live character makes the
+  // change effective on the next spawn with no restart, shadow-proof.
+  const character = runtime.character as
+    | { settings?: { routing?: { coding?: CodingAxisRouting } } }
+    | undefined;
+  if (character) {
+    character.settings ??= {};
+    const settings = character.settings as {
+      routing?: { coding?: CodingAxisRouting };
+    };
+    settings.routing ??= {};
+    settings.routing.coding = coding;
+  }
+
   const scope = tag ? `${tag} coding tasks` : "coding tasks (default)";
   return ok(
     `Routing ${scope} to \`${backend}\`. Takes effect on the next sub-agent spawn — no restart.`,

--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -49,8 +49,31 @@ export const SETTINGS_OPS = [
   "toggle_training",
   "set_owner_name",
   "set",
+  "show_backends",
+  "set_backend",
 ] as const;
 export type SettingsOp = (typeof SETTINGS_OPS)[number];
+
+// Coding sub-agent adapters the orchestrator can route to. Mirrors
+// KNOWN_ADAPTER_TYPES in plugin-agent-orchestrator (kept as a literal here so
+// @elizaos/agent does not depend on the orchestrator plugin).
+const CODING_BACKENDS = [
+  "elizaos",
+  "pi-agent",
+  "claude",
+  "codex",
+  "opencode",
+] as const;
+const CODING_BACKEND_ALIASES: Record<string, string> = {
+  "eliza-os": "elizaos",
+  eliza: "elizaos",
+  pi: "pi-agent",
+  "open-code": "opencode",
+  "claude-code": "claude",
+  openai: "codex",
+  "openai-codex": "codex",
+};
+const DIFFICULTY_TAGS = ["simple", "moderate", "hard"] as const;
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -515,6 +538,145 @@ async function handleSet(
   );
 }
 
+// ── op: show_backends / set_backend ──────────────────────────────────────
+//
+// Owner-facing control over which backend handles coding sub-agents (per
+// difficulty) and the chat brain — the "driver agent" routing surface. Coding
+// routing is persisted as the `ELIZA_BACKEND_ROUTING` config-env JSON the
+// orchestrator reads fresh per spawn; the brain provider is `ELIZA_BRAIN_PROVIDER`
+// (read by the runtime's useModel override). Both take effect with no restart.
+
+interface CodingAxisRouting {
+  default?: string;
+  byTag?: Record<string, string>;
+}
+
+export function normalizeCodingBackend(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim().toLowerCase().replace(/_/g, "-");
+  if (!v) return undefined;
+  const resolved = CODING_BACKEND_ALIASES[v] ?? v;
+  return (CODING_BACKENDS as readonly string[]).includes(resolved)
+    ? resolved
+    : undefined;
+}
+
+export function readBackendRouting(config: {
+  env?: Record<string, unknown>;
+}): CodingAxisRouting {
+  const raw = config.env?.ELIZA_BACKEND_ROUTING;
+  let parsed: unknown;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = undefined;
+    }
+  } else {
+    parsed = raw;
+  }
+  const coding =
+    isRecord(parsed) && isRecord(parsed.coding) ? parsed.coding : {};
+  const out: CodingAxisRouting = {};
+  if (typeof coding.default === "string") out.default = coding.default;
+  if (isRecord(coding.byTag)) {
+    const byTag: Record<string, string> = {};
+    for (const [k, val] of Object.entries(coding.byTag)) {
+      if (typeof val === "string") byTag[k.toLowerCase()] = val;
+    }
+    if (Object.keys(byTag).length > 0) out.byTag = byTag;
+  }
+  return out;
+}
+
+function handleShowBackends(runtime: IAgentRuntime): ActionResult {
+  const config = loadElizaConfig() as { env?: Record<string, unknown> };
+  const coding = readBackendRouting(config);
+  const brain =
+    (typeof runtime.getSetting === "function"
+      ? (runtime.getSetting("ELIZA_BRAIN_PROVIDER") as string | null)
+      : null) ?? null;
+  const codingLines = [
+    `- coding default: ${coding.default ?? "(operator pin / planner choice)"}`,
+  ];
+  if (coding.byTag && Object.keys(coding.byTag).length > 0) {
+    for (const [tag, backend] of Object.entries(coding.byTag)) {
+      codingLines.push(`- coding when ${tag}: ${backend}`);
+    }
+  }
+  const text = [
+    "Current backend routing:",
+    ...codingLines,
+    `- chat brain: ${brain || "(boot default)"}`,
+  ].join("\n");
+  return ok(text, {
+    op: "show_backends",
+    coding,
+    brain,
+  });
+}
+
+function handleSetBackend(
+  runtime: IAgentRuntime,
+  params: Record<string, unknown>,
+): ActionResult {
+  const axisRaw =
+    typeof params.axis === "string" ? params.axis.trim().toLowerCase() : "";
+  const axis = axisRaw === "brain" ? "brain" : "coding";
+
+  if (axis === "brain") {
+    const provider = trimToString(params.backend, 64);
+    if (!provider) {
+      return fail(
+        "SETTINGS_BACKEND_INVALID",
+        "set_backend for the brain needs a `backend` provider id (e.g. anthropic, openai, cerebras).",
+      );
+    }
+    const config = loadElizaConfig() as { env?: Record<string, unknown> };
+    config.env = { ...(config.env ?? {}), ELIZA_BRAIN_PROVIDER: provider };
+    saveElizaConfig(config as Parameters<typeof saveElizaConfig>[0]);
+    // Immediate effect: the runtime's useModel override reads this via getSetting.
+    runtime.setSetting?.("ELIZA_BRAIN_PROVIDER", provider);
+    return ok(
+      `Chat brain provider set to \`${provider}\`. It takes effect on the next message (it falls back to the default if that provider has no loaded handler).`,
+      { op: "set_backend", axis: "brain", provider },
+    );
+  }
+
+  const backend = normalizeCodingBackend(params.backend);
+  if (!backend) {
+    return fail(
+      "SETTINGS_BACKEND_INVALID",
+      `set_backend for coding needs a known \`backend\`. One of: ${CODING_BACKENDS.join(", ")}.`,
+      { provided: params.backend ?? null },
+    );
+  }
+  const tagRaw =
+    typeof params.tag === "string" ? params.tag.trim().toLowerCase() : "";
+  const tag = (DIFFICULTY_TAGS as readonly string[]).includes(tagRaw)
+    ? tagRaw
+    : "";
+
+  const config = loadElizaConfig() as { env?: Record<string, unknown> };
+  const coding = readBackendRouting(config);
+  if (tag) {
+    coding.byTag = { ...(coding.byTag ?? {}), [tag]: backend };
+  } else {
+    coding.default = backend;
+  }
+  const routing = { coding };
+  config.env = {
+    ...(config.env ?? {}),
+    ELIZA_BACKEND_ROUTING: JSON.stringify(routing),
+  };
+  saveElizaConfig(config as Parameters<typeof saveElizaConfig>[0]);
+  const scope = tag ? `${tag} coding tasks` : "coding tasks (default)";
+  return ok(
+    `Routing ${scope} to \`${backend}\`. Takes effect on the next sub-agent spawn — no restart.`,
+    { op: "set_backend", axis: "coding", backend, tag: tag || null },
+  );
+}
+
 // ── Action ───────────────────────────────────────────────────────────────
 
 export const settingsAction: Action = {
@@ -533,13 +695,22 @@ export const settingsAction: Action = {
     "REMEMBER_NAME",
     "SAVE_NAME",
     "SET_NAME",
+    // Backend routing control
+    "SET_BACKEND",
+    "SET_CODING_BACKEND",
+    "SET_BRAIN_BACKEND",
+    "SHOW_BACKENDS",
+    "ROUTE_BACKEND",
   ],
   description:
     "Owner-only polymorphic settings mutation. Dispatches on `action` to update " +
     "AI provider, toggle a capability, toggle/configure auto-training, set " +
-    "the owner display name, or write to the world's settings registry.",
+    "the owner display name, write to the world's settings registry, show the " +
+    "current backend routing (show_backends), or change which backend handles " +
+    "coding sub-agents / the chat brain (set_backend) — e.g. 'use codex for " +
+    "simple tasks and claude for hard ones', 'switch the brain to cerebras'.",
   descriptionCompressed:
-    "owner settings action: AI provider|capability|auto-train|display name|world registry",
+    "owner settings action: AI provider|capability|auto-train|display name|world registry|backend routing",
 
   validate: async () => true,
 
@@ -603,6 +774,27 @@ export const settingsAction: Action = {
       schema: { type: "string" as const },
     },
     {
+      name: "axis",
+      description:
+        "[set_backend] Which backend to change: 'coding' (the coding sub-agent, default) or 'brain' (the chat/planner model).",
+      required: false,
+      schema: { type: "string" as const, enum: ["coding", "brain"] },
+    },
+    {
+      name: "backend",
+      description:
+        "[set_backend] The backend to route to. For coding: elizaos, pi-agent, claude, codex, or opencode. For brain: a loaded provider id (e.g. anthropic, openai, cerebras).",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "tag",
+      description:
+        "[set_backend, coding only] Optional difficulty this routing applies to: 'simple', 'moderate', or 'hard'. Omit to set the default coding backend for all difficulties.",
+      required: false,
+      schema: { type: "string" as const, enum: [...DIFFICULTY_TAGS] },
+    },
+    {
       name: "key",
       description: "[set] Setting registry key.",
       required: false,
@@ -637,6 +829,10 @@ export const settingsAction: Action = {
         return handleSetOwnerName(params);
       case "set":
         return handleSet(runtime, message.entityId, params);
+      case "show_backends":
+        return handleShowBackends(runtime);
+      case "set_backend":
+        return handleSetBackend(runtime, params);
       default:
         return fail(
           "SETTINGS_INVALID",

--- a/packages/agent/src/actions/settings-backends.test.ts
+++ b/packages/agent/src/actions/settings-backends.test.ts
@@ -57,4 +57,26 @@ describe("readBackendRouting", () => {
       readBackendRouting({ env: { ELIZA_BACKEND_ROUTING: "{not json" } }),
     ).toEqual({});
   });
+
+  it("carries the operator allow lock-list", () => {
+    const routing = readBackendRouting({
+      env: {
+        ELIZA_BACKEND_ROUTING: JSON.stringify({
+          coding: { default: "claude", allow: ["claude", "codex"] },
+        }),
+      },
+    });
+    expect(routing.allow).toEqual(["claude", "codex"]);
+  });
+
+  it("drops non-string entries from allow", () => {
+    const routing = readBackendRouting({
+      env: {
+        ELIZA_BACKEND_ROUTING: JSON.stringify({
+          coding: { allow: ["claude", 42, null, "codex"] },
+        }),
+      },
+    });
+    expect(routing.allow).toEqual(["claude", "codex"]);
+  });
 });

--- a/packages/agent/src/actions/settings-backends.test.ts
+++ b/packages/agent/src/actions/settings-backends.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCodingBackend,
+  readBackendRouting,
+} from "./settings-actions.ts";
+
+describe("normalizeCodingBackend", () => {
+  it("accepts known coding backends", () => {
+    for (const b of ["elizaos", "pi-agent", "claude", "codex", "opencode"]) {
+      expect(normalizeCodingBackend(b)).toBe(b);
+    }
+  });
+
+  it("resolves aliases", () => {
+    expect(normalizeCodingBackend("openai")).toBe("codex");
+    expect(normalizeCodingBackend("claude-code")).toBe("claude");
+    expect(normalizeCodingBackend("eliza")).toBe("elizaos");
+    expect(normalizeCodingBackend("open_code")).toBe("opencode");
+    expect(normalizeCodingBackend("PI")).toBe("pi-agent");
+  });
+
+  it("rejects unknown / empty / non-string", () => {
+    expect(normalizeCodingBackend("gpt-9000")).toBeUndefined();
+    expect(normalizeCodingBackend("")).toBeUndefined();
+    expect(normalizeCodingBackend(undefined)).toBeUndefined();
+    expect(normalizeCodingBackend(42)).toBeUndefined();
+  });
+});
+
+describe("readBackendRouting", () => {
+  it("returns empty routing for missing config", () => {
+    expect(readBackendRouting({})).toEqual({});
+    expect(readBackendRouting({ env: {} })).toEqual({});
+  });
+
+  it("parses a JSON-string ELIZA_BACKEND_ROUTING", () => {
+    const routing = readBackendRouting({
+      env: {
+        ELIZA_BACKEND_ROUTING: JSON.stringify({
+          coding: { default: "codex", byTag: { Hard: "claude" } },
+        }),
+      },
+    });
+    expect(routing.default).toBe("codex");
+    expect(routing.byTag).toEqual({ hard: "claude" });
+  });
+
+  it("parses an object ELIZA_BACKEND_ROUTING", () => {
+    const routing = readBackendRouting({
+      env: { ELIZA_BACKEND_ROUTING: { coding: { default: "opencode" } } },
+    });
+    expect(routing.default).toBe("opencode");
+  });
+
+  it("ignores malformed JSON", () => {
+    expect(
+      readBackendRouting({ env: { ELIZA_BACKEND_ROUTING: "{not json" } }),
+    ).toEqual({});
+  });
+});

--- a/packages/agent/src/actions/settings-backends.test.ts
+++ b/packages/agent/src/actions/settings-backends.test.ts
@@ -1,8 +1,41 @@
+import { satisfiesRoleGate } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   normalizeCodingBackend,
   readBackendRouting,
+  settingsAction,
 } from "./settings-actions.ts";
+
+describe("owner gate on SETTINGS (show_backends / set_backend)", () => {
+  // show_backends/set_backend are ops of the SETTINGS action, whose roleGate
+  // core enforces structurally (satisfiesRoleGate in execute-planned-tool-call)
+  // before the handler runs. Pair the declared gate with the enforcing
+  // predicate so a gate regression on either side fails here.
+  it("declares an OWNER-minimum role gate", () => {
+    expect(settingsAction.roleGate).toEqual({ minRole: "OWNER" });
+  });
+
+  it("denies every non-owner role under the enforcing predicate", () => {
+    expect(satisfiesRoleGate(undefined, settingsAction.roleGate)).toBe(false);
+    for (const roles of [[], ["GUEST"], ["USER"], ["MEMBER"], ["ADMIN"]]) {
+      expect(
+        satisfiesRoleGate(
+          roles as Parameters<typeof satisfiesRoleGate>[0],
+          settingsAction.roleGate,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("allows the owner", () => {
+    expect(
+      satisfiesRoleGate(
+        ["OWNER"] as Parameters<typeof satisfiesRoleGate>[0],
+        settingsAction.roleGate,
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("normalizeCodingBackend", () => {
   it("accepts known coding backends", () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4643,6 +4643,25 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 	}
 
+	/**
+	 * The runtime-selected text-model provider, or undefined to use the default
+	 * (highest-priority) handler. Read from `ELIZA_BRAIN_PROVIDER` so an owner
+	 * action that mutates `character.settings` (and/or persists it to config)
+	 * flips the chat brain on the next model call with no restart. Returns
+	 * undefined when the setting is empty OR names a provider that has no
+	 * registered text handler, so a stale or mistyped value never strands the
+	 * brain — it simply falls back to the default provider.
+	 */
+	private resolveTextProviderOverride(): string | undefined {
+		const raw = this.getSetting("ELIZA_BRAIN_PROVIDER");
+		const override = typeof raw === "string" ? raw.trim() : "";
+		if (!override) return undefined;
+		const hasHandler = TEXT_GENERATION_MODEL_KEYS.some((key) =>
+			this.models.get(key)?.some((m) => m.provider === override),
+		);
+		return hasHandler ? override : undefined;
+	}
+
 	private resolveModelRegistration(
 		modelType: ModelTypeName | string,
 		provider?: string,
@@ -5097,10 +5116,25 @@ export class AgentRuntime implements IAgentRuntime {
 				? this.pinnedEmbeddingProvider
 				: provider;
 
-		const resolvedModels = this.resolveModelRegistrations(
-			requestedModelKey,
-			requestedProvider,
-		);
+		// Runtime preferred-provider override: when the caller did not pin a
+		// provider and this is a text-generation model, honor the runtime-selected
+		// provider (ELIZA_BRAIN_PROVIDER). This lets an owner flip the chat brain
+		// between loaded providers with no restart. It is a hint only — if that
+		// provider resolves no handlers for this model the default chain is used
+		// instead (see resolveTextProviderOverride), so the override can never
+		// strand the brain. Unset → byte-identical to prior behavior.
+		const providerOverride =
+			provider === undefined &&
+			TEXT_GENERATION_MODEL_KEYS.includes(requestedModelKey)
+				? this.resolveTextProviderOverride()
+				: undefined;
+		const overrideResolved = providerOverride
+			? this.resolveModelRegistrations(requestedModelKey, providerOverride)
+			: [];
+		const resolvedModels =
+			overrideResolved.length > 0
+				? overrideResolved
+				: this.resolveModelRegistrations(requestedModelKey, requestedProvider);
 		if (resolvedModels.length === 0) {
 			this.throwNoModelHandler(requestedModelKey);
 		}

--- a/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
+++ b/packages/core/src/runtime/__tests__/brain-provider-override.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+/**
+ * Phase 5 — request-time chat-brain provider override.
+ *
+ * `useModel(TEXT_LARGE)` with no pinned provider normally returns the
+ * highest-priority registered handler. The `ELIZA_BRAIN_PROVIDER` setting lets
+ * an owner flip the brain between loaded providers at runtime. It must:
+ *  - flip to the named provider when that provider has a handler,
+ *  - be a no-op (highest-priority pick) when unset,
+ *  - SAFELY fall back to the default when the named provider has no handler
+ *    (a stale/typo'd value must never strand the brain),
+ *  - never override an explicitly-pinned provider.
+ */
+function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "BrainOverrideAgent",
+			bio: "test",
+			settings,
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+/** Register a TEXT_LARGE handler that just echoes which provider answered. */
+function registerEcho(
+	runtime: AgentRuntime,
+	provider: string,
+	priority: number,
+): void {
+	runtime.registerModel(
+		ModelType.TEXT_LARGE,
+		async () => `answered-by:${provider}`,
+		provider,
+		priority,
+	);
+}
+
+describe("brain provider override (ELIZA_BRAIN_PROVIDER)", () => {
+	it("uses the highest-priority provider when the override is unset", async () => {
+		const runtime = makeRuntime();
+		registerEcho(runtime, "anthropic", 10);
+		registerEcho(runtime, "cerebras", 0);
+		const out = await runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hi" });
+		expect(out).toBe("answered-by:anthropic");
+	});
+
+	it("flips to the named provider when set and that provider has a handler", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cerebras" });
+		registerEcho(runtime, "anthropic", 10);
+		registerEcho(runtime, "cerebras", 0);
+		const out = await runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hi" });
+		expect(out).toBe("answered-by:cerebras");
+	});
+
+	it("falls back to the default when the named provider has NO handler", async () => {
+		// The override names a provider that was never registered — must NOT throw,
+		// must use the default highest-priority pick instead.
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "ghost-provider" });
+		registerEcho(runtime, "anthropic", 10);
+		const out = await runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hi" });
+		expect(out).toBe("answered-by:anthropic");
+	});
+
+	it("never overrides an explicitly pinned provider", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cerebras" });
+		registerEcho(runtime, "anthropic", 10);
+		registerEcho(runtime, "cerebras", 0);
+		// caller pins anthropic explicitly → override must not apply.
+		const out = await runtime.useModel(
+			ModelType.TEXT_LARGE,
+			{ prompt: "hi" },
+			"anthropic",
+		);
+		expect(out).toBe("answered-by:anthropic");
+	});
+
+	it("ignores a blank override value", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "   " });
+		registerEcho(runtime, "anthropic", 10);
+		registerEcho(runtime, "cerebras", 0);
+		const out = await runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hi" });
+		expect(out).toBe("answered-by:anthropic");
+	});
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
@@ -132,8 +132,10 @@ describe("resolveCodingBackend precedence", () => {
         ?.agentType,
     ).toBe("codex");
     expect(
-      resolveCodingBackend({ runtime: fakeRuntime({}), explicit: "claude-code" })
-        ?.agentType,
+      resolveCodingBackend({
+        runtime: fakeRuntime({}),
+        explicit: "claude-code",
+      })?.agentType,
     ).toBe("claude");
   });
 
@@ -178,7 +180,10 @@ describe("resolveCodingBackend precedence", () => {
   it("6. returns undefined when no signal resolves a known backend", () => {
     expect(resolveCodingBackend({ runtime: fakeRuntime({}) })).toBeUndefined();
     expect(
-      resolveCodingBackend({ runtime: fakeRuntime({}), plannerGuess: "garbage" }),
+      resolveCodingBackend({
+        runtime: fakeRuntime({}),
+        plannerGuess: "garbage",
+      }),
     ).toBeUndefined();
   });
 
@@ -237,7 +242,11 @@ describe("resolveCodingBackend operator allow lock-list", () => {
       settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
     });
     expect(
-      resolveCodingBackend({ runtime, explicit: "codex", plannerGuess: "claude" }),
+      resolveCodingBackend({
+        runtime,
+        explicit: "codex",
+        plannerGuess: "claude",
+      }),
     ).toBeUndefined();
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/coding-backend-routing.test.ts
@@ -1,0 +1,243 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readCodingRouting,
+  resolveCodingBackend,
+} from "../services/coding-backend-routing.js";
+
+// Env keys resolvePinnedAdapter consults — cleared so tests control the pin
+// purely through the fake runtime's getSetting.
+const PIN_ENV_KEYS = [
+  "BENCHMARK_TASK_AGENT",
+  "ELIZA_ACP_DEFAULT_AGENT",
+  "ELIZA_DEFAULT_AGENT_TYPE",
+  "ELIZA_AGENT_SELECTION_STRATEGY",
+  "ELIZA_BACKEND_ROUTING",
+];
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of PIN_ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const k of PIN_ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+function fakeRuntime(opts: {
+  routing?: unknown;
+  settings?: Record<string, string>;
+}): IAgentRuntime {
+  return {
+    character: { settings: { routing: opts.routing } },
+    getSetting: (key: string) => opts.settings?.[key] ?? null,
+  } as unknown as IAgentRuntime;
+}
+
+describe("readCodingRouting", () => {
+  it("returns undefined for missing / non-object routing", () => {
+    expect(readCodingRouting(fakeRuntime({}))).toBeUndefined();
+    expect(
+      readCodingRouting(fakeRuntime({ routing: "nonsense" })),
+    ).toBeUndefined();
+    expect(readCodingRouting(fakeRuntime({ routing: [] }))).toBeUndefined();
+  });
+
+  it("parses a valid coding axis and lowercases byTag keys", () => {
+    const axis = readCodingRouting(
+      fakeRuntime({
+        routing: {
+          coding: { default: "codex", byTag: { Hard: "claude" } },
+        },
+      }),
+    );
+    expect(axis?.default).toBe("codex");
+    expect(axis?.byTag).toEqual({ hard: "claude" });
+  });
+
+  it("parses an allow lock-list", () => {
+    const axis = readCodingRouting(
+      fakeRuntime({
+        routing: { coding: { default: "claude", allow: ["claude", "codex"] } },
+      }),
+    );
+    expect(axis?.allow).toEqual(["claude", "codex"]);
+  });
+
+  it("drops an axis with no usable fields", () => {
+    expect(
+      readCodingRouting(fakeRuntime({ routing: { coding: { byTag: {} } } })),
+    ).toBeUndefined();
+  });
+
+  it("falls back to ELIZA_BACKEND_ROUTING env JSON when the character has none", () => {
+    process.env.ELIZA_BACKEND_ROUTING = JSON.stringify({
+      coding: { default: "codex", byTag: { hard: "claude" } },
+    });
+    const axis = readCodingRouting(fakeRuntime({}));
+    expect(axis?.default).toBe("codex");
+    expect(axis?.byTag).toEqual({ hard: "claude" });
+  });
+
+  it("reads the env coding axis even when the character declares OTHER routing keys", () => {
+    // Per-axis: an unrelated character routing key must not shadow env coding.
+    process.env.ELIZA_BACKEND_ROUTING = JSON.stringify({
+      coding: { default: "codex" },
+    });
+    const axis = readCodingRouting(
+      fakeRuntime({ routing: { brain: { default: "claude" } } }),
+    );
+    expect(axis?.default).toBe("codex");
+  });
+
+  it("prefers character routing over the env JSON", () => {
+    process.env.ELIZA_BACKEND_ROUTING = JSON.stringify({
+      coding: { default: "opencode" },
+    });
+    const axis = readCodingRouting(
+      fakeRuntime({ routing: { coding: { default: "codex" } } }),
+    );
+    expect(axis?.default).toBe("codex");
+  });
+
+  it("ignores malformed ELIZA_BACKEND_ROUTING JSON", () => {
+    process.env.ELIZA_BACKEND_ROUTING = "{not valid";
+    expect(readCodingRouting(fakeRuntime({}))).toBeUndefined();
+  });
+});
+
+describe("resolveCodingBackend precedence", () => {
+  it("1. explicit user ask wins over character routing and pin", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { default: "codex", byTag: { hard: "claude" } } },
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    const r = resolveCodingBackend({
+      runtime,
+      explicit: "claude",
+      tag: "simple",
+      plannerGuess: "opencode",
+    });
+    expect(r).toEqual({ agentType: "claude", source: "explicit" });
+  });
+
+  it("normalizes explicit aliases (openai -> codex, claude-code -> claude)", () => {
+    expect(
+      resolveCodingBackend({ runtime: fakeRuntime({}), explicit: "openai" })
+        ?.agentType,
+    ).toBe("codex");
+    expect(
+      resolveCodingBackend({ runtime: fakeRuntime({}), explicit: "claude-code" })
+        ?.agentType,
+    ).toBe("claude");
+  });
+
+  it("2. character byTag wins over character default and pin", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { default: "codex", byTag: { hard: "claude" } } },
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    const r = resolveCodingBackend({
+      runtime,
+      tag: "hard",
+      plannerGuess: "elizaos",
+    });
+    expect(r).toEqual({ agentType: "claude", source: "character:byTag" });
+  });
+
+  it("3. character default applies when the tag has no mapping", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { default: "codex", byTag: { hard: "claude" } } },
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    const r = resolveCodingBackend({ runtime, tag: "simple" });
+    expect(r).toEqual({ agentType: "codex", source: "character:default" });
+  });
+
+  it("4. operator pin wins over the planner's heuristic guess", () => {
+    const runtime = fakeRuntime({
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    const r = resolveCodingBackend({ runtime, plannerGuess: "claude" });
+    expect(r).toEqual({ agentType: "opencode", source: "pin" });
+  });
+
+  it("5. planner guess used when nothing more authoritative applies", () => {
+    const r = resolveCodingBackend({
+      runtime: fakeRuntime({}),
+      plannerGuess: "claude",
+    });
+    expect(r).toEqual({ agentType: "claude", source: "planner" });
+  });
+
+  it("6. returns undefined when no signal resolves a known backend", () => {
+    expect(resolveCodingBackend({ runtime: fakeRuntime({}) })).toBeUndefined();
+    expect(
+      resolveCodingBackend({ runtime: fakeRuntime({}), plannerGuess: "garbage" }),
+    ).toBeUndefined();
+  });
+
+  it("ignores an unknown explicit backend and falls through to the pin", () => {
+    const runtime = fakeRuntime({
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "codex" },
+    });
+    const r = resolveCodingBackend({ runtime, explicit: "gpt-9000" });
+    expect(r).toEqual({ agentType: "codex", source: "pin" });
+  });
+
+  it("a non-fixed selection strategy disables the pin", () => {
+    const runtime = fakeRuntime({
+      settings: {
+        ELIZA_ACP_DEFAULT_AGENT: "opencode",
+        ELIZA_AGENT_SELECTION_STRATEGY: "dynamic",
+      },
+    });
+    const r = resolveCodingBackend({ runtime, plannerGuess: "claude" });
+    expect(r).toEqual({ agentType: "claude", source: "planner" });
+  });
+});
+
+describe("resolveCodingBackend operator allow lock-list", () => {
+  it("rejects an explicit ask outside the allow-list and falls through", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { default: "claude", allow: ["claude", "codex"] } },
+    });
+    // user asks for opencode, but operator locked to claude|codex → skipped,
+    // resolution continues to the allowed character default.
+    const r = resolveCodingBackend({ runtime, explicit: "opencode" });
+    expect(r).toEqual({ agentType: "claude", source: "character:default" });
+  });
+
+  it("allows an explicit ask that is inside the allow-list", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { default: "claude", allow: ["claude", "codex"] } },
+    });
+    const r = resolveCodingBackend({ runtime, explicit: "codex" });
+    expect(r).toEqual({ agentType: "codex", source: "explicit" });
+  });
+
+  it("constrains the pin to the allow-list too", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { allow: ["claude"] } },
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    // pin=opencode is disallowed; planner guess claude is allowed.
+    const r = resolveCodingBackend({ runtime, plannerGuess: "claude" });
+    expect(r).toEqual({ agentType: "claude", source: "planner" });
+  });
+
+  it("returns undefined when nothing satisfies the allow-list", () => {
+    const runtime = fakeRuntime({
+      routing: { coding: { allow: ["elizaos"] } },
+      settings: { ELIZA_ACP_DEFAULT_AGENT: "opencode" },
+    });
+    expect(
+      resolveCodingBackend({ runtime, explicit: "codex", plannerGuess: "claude" }),
+    ).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -44,6 +44,7 @@ import {
   type OrchestratorTaskType,
 } from "../services/acceptance-criteria.js";
 import { augmentTaskWithDeployGuidance } from "../services/app-deploy-guidance.js";
+import { resolveCodingBackendLogged } from "../services/coding-backend-routing.js";
 import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import type { OrchestratorTaskStatus } from "../services/orchestrator-task-types.js";
@@ -52,7 +53,6 @@ import {
   runDurableTask,
   shouldUseSmithersTaskRunner,
 } from "../services/smithers-task-integration";
-import { resolveCodingBackendLogged } from "../services/coding-backend-routing.js";
 import {
   KNOWN_ADAPTER_TYPES,
   normalizeTaskAgentAdapter,

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -52,9 +52,11 @@ import {
   runDurableTask,
   shouldUseSmithersTaskRunner,
 } from "../services/smithers-task-integration";
+import { resolveCodingBackendLogged } from "../services/coding-backend-routing.js";
 import {
+  KNOWN_ADAPTER_TYPES,
+  normalizeTaskAgentAdapter,
   type ResolvedWorkdirRoute,
-  resolvePinnedAdapter,
   resolveSpawnWorkdir,
 } from "../services/task-agent-routing.js";
 import { requireTaskAgentAccess } from "../services/task-policy.js";
@@ -223,13 +225,26 @@ function taskParts(
     .filter(Boolean);
 }
 
+/**
+ * A leading `backend:` prefix is an explicit per-subtask backend override (e.g.
+ * "claude: refactor X"). It only counts when the prefix is a KNOWN adapter —
+ * otherwise the colon is ordinary text ("Fix: the login bug", "Note: ...", a
+ * bare URL) and the whole part is the task. This keeps the prefix a structural
+ * backend selector rather than a regex that turns any leading word into a
+ * spawn target (which would crash on an unknown command and amounts to picking
+ * a backend from arbitrary message text).
+ */
 function parseAgentPrefix(
   part: string,
   fallbackAgentType: string,
 ): { task: string; agentType: string } {
   const match = part.match(/^([a-z][a-z0-9_-]{1,32})\s*:\s*(.+)$/i);
   if (!match) return { task: part, agentType: fallbackAgentType };
-  return { agentType: match[1] ?? fallbackAgentType, task: match[2] ?? part };
+  const candidate = normalizeTaskAgentAdapter(match[1]);
+  if (!candidate || !KNOWN_ADAPTER_TYPES.has(candidate)) {
+    return { task: part, agentType: fallbackAgentType };
+  }
+  return { agentType: candidate, task: match[2] ?? part };
 }
 
 function labelFrom(task: string, index: number): string {
@@ -668,13 +683,18 @@ async function runCreate(
     return errorResult("TOO_MANY_AGENTS", msg);
   }
 
-  // Operator pin wins over planner-supplied agentType — see runSpawnAgent.
-  // Per-task `framework:` prefixes set by the user (e.g. "claude: do X")
-  // still override the pin inside the parseAgentPrefix step below.
-  const pinnedAgentType = resolvePinnedAdapter(runtime);
+  // Backend routing (see resolveCodingBackend): explicit ask > character policy
+  // > operator pin > planner guess. Per-task `framework:` prefixes (e.g.
+  // "claude: do X") still override this per-part in the parseAgentPrefix step
+  // below — they are the most explicit per-subtask signal.
+  const routedBase = resolveCodingBackendLogged({
+    runtime,
+    explicit: pickString(params, content, "requestedBackend"),
+    tag: pickString(params, content, "taskComplexity"),
+    plannerGuess: pickString(params, content, "agentType"),
+  });
   const baseAgentType =
-    pinnedAgentType ??
-    pickString(params, content, "agentType") ??
+    routedBase?.agentType ??
     String(
       (await service.resolveAgentType?.({
         task: tasks[0],
@@ -1044,17 +1064,19 @@ async function runSpawnAgent(
       message,
       state,
     );
-    // Operator-pinned adapter (ELIZA_DEFAULT_AGENT_TYPE +
-    // ELIZA_AGENT_SELECTION_STRATEGY=fixed) is a deployment policy and
-    // wins over the planner's `agentType` choice. The planner only sees
-    // descriptions of available adapters and routinely guesses one based on
-    // context tokens; the operator's explicit pin is authoritative. When no
-    // pin is configured, fall back to the planner's choice and finally to
-    // the service's dynamic resolver.
-    const pinnedAgentType = resolvePinnedAdapter(runtime);
-    const explicitAgentType = pickString(params, content, "agentType");
-    const agentType = (pinnedAgentType ??
-      explicitAgentType ??
+    // Backend routing (see resolveCodingBackend): an explicit user ask wins,
+    // then declared `character.routing.coding` policy, then the operator pin
+    // (ELIZA_ACP_DEFAULT_AGENT), then the planner's heuristic `agentType` guess.
+    // The pin no longer unconditionally overrides — declaring character routing
+    // or naming a backend now takes effect, while a bare planner guess still
+    // sits below the pin (it routinely guesses from context tokens).
+    const routed = resolveCodingBackendLogged({
+      runtime,
+      explicit: pickString(params, content, "requestedBackend"),
+      tag: pickString(params, content, "taskComplexity"),
+      plannerGuess: pickString(params, content, "agentType"),
+    });
+    const agentType = (routed?.agentType ??
       (await service.resolveAgentType?.({
         task,
         workdir: pickString(params, content, "workdir"),
@@ -1217,7 +1239,7 @@ async function runSpawnAgent(
         // anchored to ONE user request across the whole loop, on every
         // transport — including connector-less dashboard/web). (#8875)
         ...(spawnRootMessageId ? { spawnRootMessageId } : {}),
-        requestedType: explicitAgentType ?? agentType,
+        requestedType: agentType,
         messageId: message.id,
         roomId: swarmRoomMetadata.taskRoomId,
         ...swarmRoomMetadata,
@@ -3244,7 +3266,7 @@ export const tasksAction: Action & {
     {
       name: "agentType",
       description:
-        "Agent type (elizaos, pi-agent, opencode, codex, or claude) for create / spawn_agent / control.resume. Defaults to ELIZA_ACP_DEFAULT_AGENT, normally elizaos.",
+        "Heuristic backend guess (elizaos, pi-agent, opencode, codex, or claude) for create / spawn_agent / control.resume. This is a weak hint — it loses to the operator default/pin and to character routing. To honor an EXPLICIT user request use requestedBackend instead.",
       required: false,
       schema: { type: "string" as const },
     },
@@ -3254,6 +3276,26 @@ export const tasksAction: Action & {
         "Set true when the user wants the app to EARN MONEY / charge for access — e.g. 'people pay $1 to chat with X', 'charge per message', 'a paid app', 'monetized', a paywall, or per-use pricing. Judge the user's INTENT, not specific keywords. When true the sub-agent gets the monetized Eliza Cloud contract (register for an appId, inference markup, OAuth + affiliate billing) instead of a free static page. Leave unset for a normal free app or non-app task.",
       required: false,
       schema: { type: "boolean" as const },
+    },
+    {
+      name: "requestedBackend",
+      description:
+        "Set ONLY when the user EXPLICITLY named a coding backend for THIS task (e.g. 'use codex', 'have claude build it') — one of elizaos, pi-agent, opencode, codex, claude. Leave unset if the user did not name one; never guess. Unlike agentType this overrides the configured default/pin.",
+      required: false,
+      schema: {
+        type: "string" as const,
+        enum: ["elizaos", "pi-agent", "opencode", "codex", "claude"],
+      },
+    },
+    {
+      name: "taskComplexity",
+      description:
+        "Your honest assessment of this coding task's difficulty: 'simple' (small/routine), 'moderate', or 'hard' (large, subtle, multi-file, or architectural). Used only to route to whichever backend the character configured for that difficulty (character.routing.coding.byTag). Judge the task itself — do not echo words from the user.",
+      required: false,
+      schema: {
+        type: "string" as const,
+        enum: ["simple", "moderate", "hard"],
+      },
     },
     {
       name: "agents",

--- a/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
@@ -68,9 +68,7 @@ export interface CodingBackendResolution {
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && !Array.isArray(value)
-  );
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** Coerce an unknown into a valid `BackendAxisRouting`, dropping bad fields. */
@@ -86,9 +84,7 @@ function parseAxis(value: unknown): BackendAxisRouting | undefined {
     if (Object.keys(byTag).length > 0) axis.byTag = byTag;
   }
   if (Array.isArray(value.allow)) {
-    const allow = value.allow.filter(
-      (v): v is string => typeof v === "string",
-    );
+    const allow = value.allow.filter((v): v is string => typeof v === "string");
     if (allow.length > 0) axis.allow = allow;
   }
   return axis.default || axis.byTag || axis.allow ? axis : undefined;

--- a/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-backend-routing.ts
@@ -1,0 +1,211 @@
+/**
+ * Coding-backend routing — resolves WHICH coding sub-agent backend (claude /
+ * codex / opencode / elizaos / pi-agent) handles a spawn, from explicit user
+ * intent, declared character policy, operator pin, and the planner's guess.
+ *
+ * This replaces the old "operator pin always wins, planner's per-task choice is
+ * silently discarded" behaviour at the spawn chokepoints. The pin is demoted to
+ * one input among several with a defined precedence:
+ *
+ *   1. explicit   — the user named a backend THIS turn (a `framework:` prefix in
+ *                   the task text, or the planner's `requestedBackend` field,
+ *                   which it only fills when the user explicitly asked).
+ *   2. character  — the agent author DECLARED routing in
+ *                   `character.settings.routing.coding` — `byTag[tag]` first
+ *                   (an opaque difficulty tag the planner emits), then `default`.
+ *   3. pin        — the operator's `ELIZA_ACP_DEFAULT_AGENT` deployment default.
+ *   4. planner    — the planner's heuristic `agentType` guess (kept last because
+ *                   it routinely guesses from context tokens — the reason the pin
+ *                   historically overrode it).
+ *
+ * Selection is identity-only: it returns a backend id, never a credential.
+ * Credential materialization stays in the account/provider substrate. There is
+ * NO inspection of message text here — `explicit` is a structurally-extracted
+ * field (a validated `requestedBackend` or `framework:` prefix, resolved by the
+ * caller), and difficulty arrives as an opaque model-emitted tag, so routing
+ * stays general, not a keyword heuristic.
+ *
+ * @module services/coding-backend-routing
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { readConfigEnvKey } from "./config-env.js";
+import {
+  KNOWN_ADAPTER_TYPES,
+  normalizeTaskAgentAdapter,
+  resolvePinnedAdapter,
+} from "./task-agent-routing.js";
+
+/** Routing policy for the coding sub-agent backend axis. */
+export interface BackendAxisRouting {
+  /** Backend chosen when no tag matches and nothing more specific applies. */
+  default?: string;
+  /** Map an opaque routing tag (e.g. "simple" / "hard") to a backend id. */
+  byTag?: Record<string, string>;
+  /**
+   * Optional operator lock-list. When set, ANY resolved backend (explicit,
+   * byTag, default, pin, or planner) must be a member or it is rejected and
+   * resolution falls through to the caller's own default. Unset = no
+   * restriction (every known backend is allowed). This is how an operator
+   * confines a deployment to a subset of backends even though an explicit user
+   * request can otherwise override the pin.
+   */
+  allow?: string[];
+}
+
+/** Where a resolved backend came from — surfaced in logs/trajectories. */
+export type CodingBackendSource =
+  | "explicit"
+  | "character:byTag"
+  | "character:default"
+  | "pin"
+  | "planner";
+
+export interface CodingBackendResolution {
+  agentType: string;
+  source: CodingBackendSource;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  );
+}
+
+/** Coerce an unknown into a valid `BackendAxisRouting`, dropping bad fields. */
+function parseAxis(value: unknown): BackendAxisRouting | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const axis: BackendAxisRouting = {};
+  if (typeof value.default === "string") axis.default = value.default;
+  if (isPlainObject(value.byTag)) {
+    const byTag: Record<string, string> = {};
+    for (const [tag, backend] of Object.entries(value.byTag)) {
+      if (typeof backend === "string") byTag[tag.toLowerCase()] = backend;
+    }
+    if (Object.keys(byTag).length > 0) axis.byTag = byTag;
+  }
+  if (Array.isArray(value.allow)) {
+    const allow = value.allow.filter(
+      (v): v is string => typeof v === "string",
+    );
+    if (allow.length > 0) axis.allow = allow;
+  }
+  return axis.default || axis.byTag || axis.allow ? axis : undefined;
+}
+
+/** Pull the `coding` axis out of a routing object (`{ coding: {...} }`). */
+function parseCodingAxis(raw: unknown): BackendAxisRouting | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  return parseAxis(raw.coding);
+}
+
+/**
+ * Resolve the coding routing axis from, in order: the character's declared
+ * `settings.routing.coding`, then the `ELIZA_BACKEND_ROUTING` config-env JSON's
+ * `coding` axis (the same structured-config mechanism `TASK_AGENT_WORKDIR_ROUTES`
+ * uses — a deployment-level override that works even when the character builder
+ * does not forward arbitrary `settings` keys). Resolved PER AXIS: a character
+ * that declares unrelated routing keys does not shadow an env-declared coding
+ * policy. Both sources are validated; this is declared policy, never
+ * message-text inspection.
+ */
+export function readCodingRouting(
+  runtime: IAgentRuntime | undefined,
+): BackendAxisRouting | undefined {
+  const fromCharacter = parseCodingAxis(runtime?.character?.settings?.routing);
+  if (fromCharacter) return fromCharacter;
+
+  const rawEnv = readConfigEnvKey("ELIZA_BACKEND_ROUTING")?.trim();
+  if (!rawEnv) return undefined;
+  try {
+    return parseCodingAxis(JSON.parse(rawEnv));
+  } catch (err) {
+    logger.warn(
+      `[backend-routing] failed to parse ELIZA_BACKEND_ROUTING: ${
+        (err as Error).message
+      }`,
+    );
+    return undefined;
+  }
+}
+
+/** Normalize a candidate to a known adapter id, or `undefined` if unusable. */
+function asKnownAdapter(value: string | undefined): string | undefined {
+  const normalized = normalizeTaskAgentAdapter(value);
+  return normalized && KNOWN_ADAPTER_TYPES.has(normalized)
+    ? normalized
+    : undefined;
+}
+
+/**
+ * Resolve the coding backend for a spawn. Returns `undefined` only when nothing
+ * applies (no explicit ask, no declared policy, no pin, no usable planner
+ * guess) — the caller then falls back to its dynamic resolver / hard default.
+ *
+ * When the operator declares an `allow` lock-list, every candidate (including an
+ * explicit user ask) is constrained to it; a disallowed candidate is skipped so
+ * resolution continues down the precedence chain instead of escaping the lock.
+ */
+export function resolveCodingBackend(args: {
+  runtime: IAgentRuntime | undefined;
+  /** Backend the user named THIS turn (framework prefix or `requestedBackend`). */
+  explicit?: string;
+  /** Opaque difficulty tag the planner emitted (keys `routing.coding.byTag`). */
+  tag?: string;
+  /** The planner's heuristic `agentType` guess (lowest precedence). */
+  plannerGuess?: string;
+}): CodingBackendResolution | undefined {
+  const coding = readCodingRouting(args.runtime);
+  const allow = coding?.allow
+    ?.map((v) => asKnownAdapter(v))
+    .filter((v): v is string => Boolean(v));
+  const allowed = (backend: string | undefined): string | undefined =>
+    backend && (!allow?.length || allow.includes(backend))
+      ? backend
+      : undefined;
+
+  const explicit = allowed(asKnownAdapter(args.explicit));
+  if (explicit) return { agentType: explicit, source: "explicit" };
+
+  if (coding) {
+    const tag = args.tag?.trim().toLowerCase();
+    if (tag && coding.byTag) {
+      const byTag = allowed(asKnownAdapter(coding.byTag[tag]));
+      if (byTag) return { agentType: byTag, source: "character:byTag" };
+    }
+    const fallback = allowed(asKnownAdapter(coding.default));
+    if (fallback) return { agentType: fallback, source: "character:default" };
+  }
+
+  const pin = allowed(resolvePinnedAdapter(args.runtime));
+  if (pin) return { agentType: pin, source: "pin" };
+
+  const guess = allowed(asKnownAdapter(args.plannerGuess));
+  if (guess) return { agentType: guess, source: "planner" };
+
+  return undefined;
+}
+
+/** Resolve + log the routing decision in one step (keeps spawn callers terse). */
+export function resolveCodingBackendLogged(args: {
+  runtime: IAgentRuntime | undefined;
+  explicit?: string;
+  tag?: string;
+  plannerGuess?: string;
+}): CodingBackendResolution | undefined {
+  const resolved = resolveCodingBackend(args);
+  if (resolved) {
+    // Only surface the tag when it actually drove the decision (byTag); on any
+    // other source the tag was an unused input and printing it misreads in
+    // trajectories as if difficulty influenced routing.
+    const tagSuffix =
+      resolved.source === "character:byTag" && args.tag
+        ? `, tag=${args.tag}`
+        : "";
+    logger.info(
+      `[backend-routing] coding → ${resolved.agentType} (${resolved.source}${tagSuffix})`,
+    );
+  }
+  return resolved;
+}

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -5,7 +5,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { readConfigEnvKey } from "./config-env.js";
 
-const KNOWN_ADAPTER_TYPES = new Set([
+export const KNOWN_ADAPTER_TYPES = new Set([
   "elizaos",
   "pi-agent",
   "claude",


### PR DESCRIPTION
Closes #11581

## What

Per-task coding-backend routing, end to end:

1. **`resolveCodingBackend`** (plugin-agent-orchestrator) — a pure identity-only resolver used at both spawn chokepoints (`runCreate` / `runSpawnAgent`) with precedence **explicit > character policy > pin > planner guess**. Previously the resolution was `pinnedAgentType ?? explicit ?? serviceResolver ?? "codex"`, so the operator pin (`ELIZA_ACP_DEFAULT_AGENT`) always won and the planner's per-task choice was silently discarded — "use codex for this" could not work. Routing is structural, never message-text inspection:
   - **explicit** — a validated `requestedBackend` planner field (only set when the user explicitly named a backend), or a `framework:` prefix now validated against `KNOWN_ADAPTER_TYPES` (so "Fix: the bug" no longer spawns a bogus `fix` backend)
   - **character** — `routing.coding` declared in `character.settings` or the `ELIZA_BACKEND_ROUTING` config-env JSON, keyed by an opaque model-emitted difficulty tag (`taskComplexity: simple|moderate|hard`)
   - **pin** — the operator deployment default, demoted from always-wins to a default
   - **planner** — the heuristic `agentType` guess, kept last (it routinely guesses from context tokens)
   - optional operator **`allow`** lock-list constrains every candidate, including an explicit ask
2. **`ELIZA_BRAIN_PROVIDER`** (core) — opt-in `useModel` text-provider override so an owner can flip the chat brain between loaded providers with no restart. Applied only when the caller did not pin a provider AND it is a text-generation model; validated against registered handlers; if the named provider resolves no handlers the default chain is used — the override can never strand the brain. **Unset ⇒ byte-identical behavior** (the code path collapses to exactly the prior `resolveModelRegistrations(key, requestedProvider)` call).
3. **`show_backends` / `set_backend`** (agent) — owner-gated chat ops on the SETTINGS action (`roleGate: { minRole: "OWNER" }`, enforced structurally by core's `satisfiesRoleGate` in `execute-planned-tool-call` before any handler runs). They read and write the EFFECTIVE precedence — character `routing.coding` first, then the `ELIZA_BACKEND_ROUTING` config-env JSON — so a set can never be silently shadowed by a character-declared policy; writes persist to config-env for durability AND write through to the live character for immediate, restart-free effect.

Backward compatible by construction: with no routing declared and no override set, the pin wins exactly as before and `useModel` resolution is unchanged.

## Why

"use codex for this task", "route simple coding tasks to codex and hard ones to claude", and "switch the brain to cerebras" were all structurally impossible: the pin unconditionally overrode the planner, no routing contract existed, and every change was an env edit + restart. See #11581.

## Evidence

- **Resolver precedence tests (21)** — every precedence level, the `allow` lock-list (including a disallowed explicit ask falling through), unknown-backend rejection, malformed `ELIZA_BACKEND_ROUTING`, `framework:` prefix validation:
  `bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/coding-backend-routing.test.ts` → `Tests 21 passed (21)`
- **Core override tests (5)** — flip-when-set, **unset ⇒ default pick (no-op)**, unknown-provider safe fallback, explicit pin never overridden, blank value ignored:
  `bun run --cwd packages/core test -- src/runtime/__tests__/brain-provider-override.test.ts` → `Tests 5 passed (5)`
- **Owner-gate + settings tests (12)** — the SETTINGS gate paired with core's enforcing predicate: NONE/GUEST/USER/MEMBER/ADMIN all denied, OWNER allowed; backend normalization/aliases; routing-config parsing incl. `allow`:
  `bun run --cwd packages/agent test -- src/actions/settings-backends.test.ts` → `Tests 12 passed (12)`
- **Regression** — full orchestrator suite `Tests 1461 passed | 8 skipped`; core useModel-path suites (model-provider-failover, use-model-provider-fallback, action-model-routing ×2, streaming, pii-swap, secret-swap, brain-override) `Tests 79 passed (79)`; agent actions dir `Tests 34 passed (34)`.
- **Typecheck** — `bun run --cwd packages/core typecheck`, `--cwd packages/agent typecheck`, `--cwd plugins/plugin-agent-orchestrator typecheck` all clean.
- **Lint** — biome clean on every touched file under each package's own config (the pre-existing whole-file `runtime.ts` format drift on develop is untouched).
- **Live trajectories** — the exact routing train was live-verified on a running Discord deployment before porting to develop: explicit ("use codex ...") / byTag (simple→codex, hard→claude via `taskComplexity`) / default each spawned the matching backend, removing the config cleanly reverted to the pin, `set_backend`/`show_backends` round-tripped owner-only, and the brain flip took effect on the next message. Scenario-runner capture vs a live model: N/A here — the deciding inputs (`requestedBackend`/`taskComplexity` fields, roleGate, provider registrations) are structural and the full matrix is deterministically covered by the 38 feature tests above.

## Notes for review

- `runSpawnAgent` metadata `requestedType` now records the resolved backend (was `explicitAgentType ?? agentType`, where the explicit value could be the planner's raw guess).
- The brain axis of `set_backend` writes `ELIZA_BRAIN_PROVIDER` via `runtime.setSetting` + config-env; the coding axis writes `ELIZA_BACKEND_ROUTING` + the in-memory character at the highest precedence the orchestrator reads.
