### PR TITLE
chore(local-inference): non-Apple kokoro fast path — gitlink 114eee08e→2bdcef890 (Android/Windows)

### DIFF
--- a/.github/issue-evidence/kokoro-metal-perf/README.md
+++ b/.github/issue-evidence/kokoro-metal-perf/README.md
@@ -37,10 +37,33 @@ The baseline README hypothesized "conv ops falling back from Metal to CPU". Real
 
 `tools/kokoro/CMakeLists.txt` links `Accelerate.framework` into `kokoro_lib` (PUBLIC) on Apple; verified propagated into both `kokoro-tts` and the fused `libelizainference.dylib` (`otool -L`). Same math, same fp32 accumulation — only the summation order differs.
 
+## Non-Apple fallback (Android/Windows/Linux) — threaded + NEON portable path
+
+Follow-up (submodule commit `2bdcef890`, branch `kokoro-portable-fast`): the Accelerate speedup above is `#if __APPLE__` only — Android/Windows still ran the single-threaded scalar generator (261 s). `kokoro-layers.h` now has a third compile-time path, `KOKORO_USE_PORTABLE_FAST`, selected automatically on every non-Apple platform:
+
+- **Threading:** a small internal `std::thread` pool (no new deps; `min(hardware_concurrency, 16)`, override with `KOKORO_NUM_THREADS`) parallelizes `conv1d_forward` / `convtranspose1d_forward` over output channels and `linear_forward` / `lstm_cell_step` over gate/output rows. Each worker owns disjoint output rows — no atomics in the MAC loops. A 256k-MAC threshold keeps small per-step calls (sequential LSTM) off the pool.
+- **NEON (`__aarch64__` / `_M_ARM64`):** the innermost MACs are branch-free AXPY/dot kernels using `vfmaq_f32` (2×128-bit accumulators). Valid-tap ranges are hoisted out of the inner loops, killing the per-element bounds check of the reference loop. Non-NEON targets (x86) get the same branch-free loops, auto-vectorizable at `-O3`.
+- **Reference retained:** the pure scalar loops are unchanged as the ultimate fallback + numerical reference (`-DKOKORO_FORCE_SCALAR`); `-DKOKORO_NO_ACCELERATE` forces the portable path on Apple hosts for testing.
+
+**Correctness (executed natively on this M4 Max — arm64, so the NEON kernels are the exact code aarch64 Android runs):** `tools/kokoro/tests/test_kokoro_layers_portable` runs 23 parity checks fast-vs-scalar-reference on random input across all four primitives, including stride-6/10, dilation-3/5, K=1, T=1, out-of-bounds-tap and no-bias edges — **max |Δ| = 1.9e-5, all < 1e-4 (PASS)**. Cross-compile verified with NDK r29 clang for `aarch64-linux-android26` and `x86_64-linux-android26` (`-Wall -Wextra` clean; `llvm-objdump` shows 18 `fmla.4s` vector FMAs in the aarch64 object).
+
+**Microbench (same binary, M4 Max, 16 threads, NEON, real generator shapes):**
+
+| Primitive (real iSTFTNet shape) | scalar (ms) | portable-fast (ms) | speedup |
+|---|---:|---:|---:|
+| conv1d 256→256 T=2640 K=7 d=3 (stage-0 resblock) | 3,843.7 | 35.82 | 107.3× |
+| conv1d 128→128 T=15841 K=11 d=5 (stage-1 resblock) | 8,124.5 | 89.09 | 91.2× |
+| convtranspose 512→256 T=264 K=20 s=10 (ups[0]) | 1,212.6 | 65.27 | 18.6× |
+| convtranspose 256→128 T=2640 K=12 s=6 (ups[1]) | 1,579.7 | 169.21 | 9.3× |
+| LSTM I=512 H=512 × 264 steps (predictor-sized) | 998.6 | 217.66 | 4.6× |
+
+(Numbers are from the checked-in `portable-fast-parity-microbench.log` run; this host was carrying a concurrent agent-swarm load — an earlier idle-host run of the same binary measured 172.7× / 164.6× / 25.4× / 15.1× / 4.1× on the same rows. Ratios are the durable signal.) The generator's runtime is dominated by the resblock convs (~85 GMACs), so a ~100×-class conv speedup takes the 261 s non-Apple generator into the low single-digit seconds on comparable cores (phone cores are slower and fewer — expect tens of × end-to-end, to be measured on-device). `tools/kokoro/CMakeLists.txt` links `Threads::Threads` on non-Apple. Apple path untouched; `cmake --build build-desktop-metal --target kokoro-tts` rebuilt green after the change.
+
 ## Remaining work (true GPU port — optional now)
 
-The fork's Metal backend already supports every op an iSTFTNet ggml graph would need (`GGML_OP_IM2COL`, `GGML_OP_CONV_TRANSPOSE_1D`, `GGML_OP_PAD_REFLECT_1D`, `GGML_OP_SIN`/`COS`/`EXP` for the Snake activation and spec/phase heads, `GGML_OP_NORM`, and the custom `GGML_OP_ISTFT` / ELIZA-ISTFT-DISPATCH-V1 — see `ggml/src/ggml-metal/ggml-metal-device.m`). Building the generator as a ggml graph on Metal is now a latency/energy optimization, not a correctness/usability blocker: at RTF 0.15 on CPU/AMX the vocoder is comfortably real-time. Non-Apple hosts (Android/Windows) still take the scalar path and would benefit first from a ggml-graph port or a NEON/threaded fallback.
+The fork's Metal backend already supports every op an iSTFTNet ggml graph would need (`GGML_OP_IM2COL`, `GGML_OP_CONV_TRANSPOSE_1D`, `GGML_OP_PAD_REFLECT_1D`, `GGML_OP_SIN`/`COS`/`EXP` for the Snake activation and spec/phase heads, `GGML_OP_NORM`, and the custom `GGML_OP_ISTFT` / ELIZA-ISTFT-DISPATCH-V1 — see `ggml/src/ggml-metal/ggml-metal-device.m`). Building the generator as a ggml graph on Metal/Vulkan is now a latency/energy optimization on every platform: Apple runs Accelerate (RTF 0.15) and non-Apple runs the threaded+NEON portable path above.
 
 ## Files
 - `before-profile.log` / `before.wav` — baseline (scalar), RTF 64×.
 - `after-profile.log` / `after.wav` — Accelerate BLAS path, RTF 0.15, audio equivalent (corr 0.99959, identical transcript).
+- `portable-fast-parity-microbench.log` — non-Apple path: 23/23 parity PASS + the microbench table above.

--- a/.github/issue-evidence/kokoro-metal-perf/portable-fast-parity-microbench.log
+++ b/.github/issue-evidence/kokoro-metal-perf/portable-fast-parity-microbench.log
@@ -1,0 +1,36 @@
+# test_kokoro_layers_portable — M4 Max, clang -O3, native arm64 (NEON) run, 2026-07-02
+portable-fast path: NEON=1 threads=16
+
+== parity (fast vs scalar reference, tol 1e-04) ==
+conv1d  Cin=8 Cout=5 T=37 K=3 s=1 p=1 d=1 b=1              max|Δ| = 0.000e+00  PASS
+conv1d  Cin=16 Cout=16 T=100 K=7 s=1 p=15 d=5 b=1          max|Δ| = 0.000e+00  PASS
+conv1d  Cin=16 Cout=16 T=100 K=11 s=1 p=25 d=5 b=0         max|Δ| = 0.000e+00  PASS
+conv1d  Cin=22 Cout=32 T=264 K=12 s=6 p=3 d=1 b=1          max|Δ| = 0.000e+00  PASS
+conv1d  Cin=22 Cout=32 T=264 K=1 s=1 p=0 d=1 b=1           max|Δ| = 0.000e+00  PASS
+conv1d  Cin=64 Cout=22 T=200 K=7 s=1 p=3 d=1 b=1           max|Δ| = 0.000e+00  PASS
+conv1d  Cin=3 Cout=4 T=1 K=5 s=1 p=6 d=3 b=1               max|Δ| = 0.000e+00  PASS
+conv1d  Cin=1 Cout=1 T=9 K=3 s=2 p=0 d=1 b=0               max|Δ| = 0.000e+00  PASS
+conv1d  Cin=256 Cout=256 T=128 K=7 s=1 p=9 d=3 b=1         max|Δ| = 0.000e+00  PASS
+convtr  Cin=16 Cout=8 T=40 K=20 s=10 p=5 op=0 b=1          max|Δ| = 0.000e+00  PASS
+convtr  Cin=12 Cout=6 T=50 K=12 s=6 p=3 op=0 b=1           max|Δ| = 0.000e+00  PASS
+convtr  Cin=7 Cout=9 T=33 K=3 s=1 p=1 op=0 b=0             max|Δ| = 4.768e-07  PASS
+convtr  Cin=5 Cout=5 T=1 K=4 s=2 p=0 op=1 b=1              max|Δ| = 0.000e+00  PASS
+convtr  Cin=512 Cout=256 T=16 K=20 s=10 p=5 op=0 b=1       max|Δ| = 0.000e+00  PASS
+linear  in=128 out=1024 b=1                                max|Δ| = 5.722e-06  PASS
+linear  in=640 out=512 b=0                                 max|Δ| = 1.907e-05  PASS
+linear  in=3 out=2 b=1                                     max|Δ| = 2.980e-08  PASS
+lstm    I=16 H=8 b=1 (h)                                   max|Δ| = 2.980e-08  PASS
+lstm    I=16 H=8 b=1 (c)                                   max|Δ| = 5.960e-08  PASS
+lstm    I=64 H=48 b=0 (h)                                  max|Δ| = 8.941e-08  PASS
+lstm    I=64 H=48 b=0 (c)                                  max|Δ| = 2.384e-07  PASS
+lstm    I=512 H=512 b=1 (h)                                max|Δ| = 1.460e-06  PASS
+lstm    I=512 H=512 b=1 (c)                                max|Δ| = 2.086e-06  PASS
+
+== microbench (real iSTFTNet generator shapes) ==
+conv1d 256->256 T=2640 K=7 d=3 (stage0 resblock)     scalar    3843.7 ms   fast    35.82 ms    107.3x
+conv1d 128->128 T=15841 K=11 d=5 (stage1 resblock)   scalar    8124.5 ms   fast    89.09 ms     91.2x
+convtr 512->256 T=264 K=20 s=10 (ups[0])             scalar    1212.6 ms   fast    65.27 ms     18.6x
+convtr 256->128 T=2640 K=12 s=6 (ups[1])             scalar    1579.7 ms   fast   169.21 ms      9.3x
+lstm I=512 H=512 steps=264 (predictor-sized)         scalar     998.6 ms   fast   217.66 ms      4.6x
+
+ALL PARITY CHECKS PASSED (0 failures)


### PR DESCRIPTION
Follow-up to #11517. That PR landed the Apple Accelerate kokoro path (submodule `114eee08e`); this bumps the gitlink to `2bdcef890` to add the **portable non-Apple fast path** (Android/Windows) that landed after the merge.

- Non-Apple branch of the four hot vocoder primitives (Conv1d/ConvTranspose1d/Linear/LSTM gates): internal `std::thread` pool + NEON `vfmaq_f32` on aarch64 (auto-vectorizable scalar on x86). Apple Accelerate path **unchanged**; pure scalar loop retained as reference.
- Verified on real arm64: **23/23 parity checks** vs scalar (max |Δ| 1.9e-5), NDK r29 cross-compile clean (18 `fmla.4s` in the aarch64 object), microbench up to **107× on conv1d**.
- Fork: elizaOS/llama.cpp#38 (`perf/kokoro-accelerate-blas` @ `2bdcef890`).

Additive submodule bump only — no Milady-side source change. Evidence: `.github/issue-evidence/kokoro-metal-perf/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)