### PR TITLE
fix(cloud): bind x402 settle to a platform-owned payTo — stop unauthenticated gas-wallet drain (#11574)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-facilitator.test.ts
@@ -134,7 +134,14 @@ const requirements = {
   payTo: PAY_TO,
 };
 
+// The facilitator sponsors gas, so it only settles to a platform-owned payTo:
+// the configured recipient env or its own signer address. Configure PAY_TO as
+// the platform recipient here so the legitimate settle tests below pass the
+// guard; the attacker test uses a DIFFERENT payTo that is not platform-owned.
+process.env.X402_RECIPIENT_ADDRESS = PAY_TO;
+
 function primeEvmFacilitator() {
+  process.env.X402_RECIPIENT_ADDRESS = PAY_TO;
   writeContract.mockClear();
   writeContract.mockResolvedValue(TX_HASH);
   waitForTransactionReceipt.mockClear();
@@ -266,4 +273,113 @@ test("settle succeeds only after the EVM receipt proves the required transfer", 
     timeout: 300_000,
   });
   expect(parseEventLogs).toHaveBeenCalledTimes(1);
+});
+
+// #11574: gas-drain via the unauthenticated /api/v1/x402/settle route. An
+// attacker relays their OWN valid EIP-3009 transfer — their funds, their
+// recipient, a self-consistent payTo (authorization.to === requirements.payTo)
+// so verify() passes — and the platform would sponsor the gas for free. The
+// payTo binding must reject it BEFORE any on-chain write / gas spend.
+const ATTACKER_PAY_TO = "0x9999999999999999999999999999999999999999";
+
+function attackerPaymentPayload() {
+  return {
+    x402Version: 2,
+    accepted: {
+      scheme: "exact",
+      network: NETWORK,
+      asset: ASSET,
+      amount: "100",
+      payTo: ATTACKER_PAY_TO,
+    },
+    payload: {
+      signature: SIGNATURE,
+      authorization: {
+        from: PAYER,
+        to: ATTACKER_PAY_TO,
+        value: "100",
+        validAfter: "0",
+        validBefore: String(Math.floor(Date.now() / 1000) + 300),
+        nonce: NONCE,
+      },
+    },
+  };
+}
+
+const attackerRequirements = {
+  scheme: "exact",
+  network: NETWORK,
+  asset: ASSET,
+  amount: "100",
+  payTo: ATTACKER_PAY_TO,
+};
+
+test("settle rejects a non-platform payTo without spending gas (writeContract never called)", async () => {
+  const { verifyTypedData, readContract } = primeEvmFacilitator();
+
+  const result = await x402FacilitatorService.settle(
+    attackerPaymentPayload(),
+    attackerRequirements,
+  );
+
+  expect(result).toEqual({
+    success: false,
+    transaction: "",
+    network: NETWORK,
+    errorReason: "payto_not_platform_owned",
+  });
+  // The whole point: the platform gas wallet is never touched.
+  expect(writeContract).not.toHaveBeenCalled();
+  expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+  // Rejected up front — no verification / RPC work either.
+  expect(verifyTypedData).not.toHaveBeenCalled();
+  expect(readContract).not.toHaveBeenCalled();
+});
+
+test("settle to the facilitator's own signer address is allowed and reaches writeContract", async () => {
+  primeEvmFacilitator();
+  // No configured recipient env → the platform allowlist falls back to the
+  // facilitator's own signer address (mirrors resolvePaymentRecipient()).
+  delete process.env.X402_RECIPIENT_ADDRESS;
+
+  const signerPayload = {
+    x402Version: 2,
+    accepted: {
+      scheme: "exact",
+      network: NETWORK,
+      asset: ASSET,
+      amount: "100",
+      payTo: FACILITATOR,
+    },
+    payload: {
+      signature: SIGNATURE,
+      authorization: {
+        from: PAYER,
+        to: FACILITATOR,
+        value: "100",
+        validAfter: "0",
+        validBefore: String(Math.floor(Date.now() / 1000) + 300),
+        nonce: NONCE,
+      },
+    },
+  };
+  parseEventLogs.mockReturnValue([
+    { address: ASSET, args: { from: PAYER, to: FACILITATOR, value: 100n } },
+  ]);
+
+  const result = await x402FacilitatorService.settle(signerPayload, {
+    scheme: "exact",
+    network: NETWORK,
+    asset: ASSET,
+    amount: "100",
+    payTo: FACILITATOR,
+  });
+
+  expect(result).toEqual({
+    success: true,
+    transaction: TX_HASH,
+    network: NETWORK,
+    payer: PAYER,
+  });
+  expect(writeContract).toHaveBeenCalledTimes(1);
 });

--- a/packages/cloud/shared/src/lib/services/x402-facilitator.ts
+++ b/packages/cloud/shared/src/lib/services/x402-facilitator.ts
@@ -620,6 +620,46 @@ class X402FacilitatorService {
   }
 
   /**
+   * Platform-owned recipient allowlist for a network. The facilitator SPONSORS
+   * GAS on settlement (`walletClient.writeContract` for EVM, the SVM fee-payer
+   * for Solana), so it must only ever settle payments whose funds land in a
+   * platform-controlled wallet. Mirrors `resolvePaymentRecipient()` in
+   * `x402-payment-requests.ts`: the configured recipient env for the network
+   * family, plus the facilitator's own signer address.
+   */
+  private getPlatformRecipients(network: string): string[] {
+    const env = getCloudAwareEnv();
+    const recipients: string[] = [];
+    if (isSolanaNetwork(network)) {
+      const configured = (
+        env.X402_SOLANA_RECIPIENT_ADDRESS ?? env.SOLANA_PAYOUT_WALLET_ADDRESS
+      )?.trim();
+      if (configured) recipients.push(configured);
+      const signer = this.svmScheme?.getSigners(network)[0];
+      if (signer) recipients.push(signer);
+    } else {
+      const configured = env.X402_RECIPIENT_ADDRESS?.trim();
+      if (configured) recipients.push(configured);
+      if (this.account) recipients.push(this.account.address);
+    }
+    return recipients;
+  }
+
+  /**
+   * True when `payTo` is a platform-owned recipient (see getPlatformRecipients).
+   * EVM addresses are compared case-insensitively; Solana base58 addresses
+   * exactly (the file lowercases EVM addresses everywhere else too).
+   */
+  private isPlatformOwnedRecipient(network: string, payTo: string): boolean {
+    const recipients = this.getPlatformRecipients(network);
+    if (isSolanaNetwork(network)) {
+      return recipients.includes(payTo);
+    }
+    const target = payTo.toLowerCase();
+    return recipients.some((addr) => addr.toLowerCase() === target);
+  }
+
+  /**
    * Return supported schemes, networks, and signer addresses.
    */
   getSupported(): SupportedResponse {
@@ -1030,6 +1070,31 @@ class X402FacilitatorService {
     paymentRequirements: PaymentRequirements,
   ): Promise<SettleResult> {
     await this.initialize();
+
+    // SECURITY (#11574): settlement SPONSORS GAS from the platform wallet, so it
+    // must only ever pay a PLATFORM-OWNED recipient. The unauthenticated
+    // /api/v1/x402/settle route passes a fully client-supplied
+    // `paymentRequirements`, and verify() only checks payTo self-consistency
+    // (payload ↔ requirements), never that payTo belongs to the platform.
+    // Without this gate an attacker relays their own valid EIP-3009 transfer
+    // (their funds, their recipient, self-consistent payTo) at net-zero cost and
+    // the platform sponsors the gas → gas-wallet drain. The topup + stored
+    // payment-request paths resolve payTo from platform config, so they pass.
+    const settleNetwork = isSolanaNetwork(paymentRequirements.network)
+      ? paymentRequirements.network
+      : paymentPayload.accepted.network;
+    if (!this.isPlatformOwnedRecipient(settleNetwork, paymentRequirements.payTo)) {
+      logger.warn("[x402-facilitator] Rejected settle to non-platform recipient", {
+        payTo: paymentRequirements.payTo,
+        network: settleNetwork,
+      });
+      return {
+        success: false,
+        transaction: "",
+        network: paymentRequirements.network,
+        errorReason: "payto_not_platform_owned",
+      };
+    }
 
     if (
       isSolanaNetwork(paymentRequirements.network) ||


### PR DESCRIPTION
Fixes #11574.

## Problem (unauthenticated — platform gas-wallet drain)

`POST /api/v1/x402/settle` is unauthenticated (`auth.ts:73` allowlists the `/api/v1/x402` prefix) and passes a fully client-supplied `paymentRequirements` into `x402FacilitatorService.settle()`. The facilitator sponsors gas from the platform wallet (`walletClient.writeContract`), and its `payTo` checks (`:734/:776/:852/:990`) only verify payload↔requirements **self-consistency** — never that `payTo` is platform-owned. So an attacker relays their own valid EIP-3009 `transferWithAuthorization` (their funds, their recipient, self-consistent payTo) at net-zero cost and the platform sponsors the gas → gas-wallet drain (rate limiting only caps throughput).

## Fix

Add a **platform payTo allowlist** at the top of `settle()` — after `initialize()`, **before** the Solana branch and any EVM `verify`/`writeContract`. Reject with the route's error shape (`errorReason: "payto_not_platform_owned"` → 400) unless `paymentRequirements.payTo` is platform-owned.

`getPlatformRecipients(network)` mirrors `resolvePaymentRecipient()` in `x402-payment-requests.ts` **byte-for-byte**: the configured recipient env for the network family (`X402_RECIPIENT_ADDRESS` for EVM; `X402_SOLANA_RECIPIENT_ADDRESS ?? SOLANA_PAYOUT_WALLET_ADDRESS` for Solana) plus the facilitator's own signer address. EVM compares case-insensitively; Solana base58 exactly. Combined with the existing `authorization.to === payTo` self-consistency checks, this guarantees settled funds actually land in a platform wallet.

Placed at the shared `settle()` chokepoint so it protects the vulnerable unauthenticated route **and** leaves every legitimate caller passing — verified by auditing all 4 callers:
- unauthenticated `/x402/settle` route → **fixed** (the drain vector);
- `topup-handler.ts` → payTo = `resolvePaymentRecipient` (platform-owned, passes);
- `x402-payment-requests.ts` stored-request settle → payTo from the stored row = `resolvePaymentRecipient` (passes);
- `withX402Payment` middleware → grep-confirmed mounted nowhere (dormant); its `payTo` is a server constant, not client input.

## Design note
This facilitator is the platform's **own** gas-sponsoring facilitator for collecting platform/creator revenue — there is no funded model in the codebase for sponsoring gas to arbitrary third-party recipients. So "allowlist to platform wallets" is the correct fix, not "charge the caller for gas upfront." If a public paid facilitator is ever wanted, that's a different (gas-fee-charging) design that would replace this guard. Today nothing legitimate passes a non-platform payTo, so there is no false-reject.

## Test (real, regression-proven, asserts the chain-write boundary)

`x402-facilitator.test.ts`: an attacker settle with a non-platform `payTo` returns `payto_not_platform_owned` and triggers **zero** `writeContract` / `waitForTransactionReceipt` / `verifyTypedData` / `readContract` calls; a paired legit settle to the platform signer still reaches `writeContract` once. Verified **red pre-fix** (stash-reverted the guard → attacker payload reaches the chain-write boundary), **7/7 green post-fix**. typecheck + biome clean.

Money/security path — flagging for @lalalune review; not self-merging. Found by the round-6 deepscan (first-ever scan of the x402 settle surface); tracked in #8434.

— [cloud-security]
