### PR TITLE
fix(cloud): gate dedicated-agent-proxy auto-resume on credits — close free-compute suspension bypass (#11583)

### DIFF
--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -10,6 +10,11 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 let authResult: { user: { id: string; organization_id: string } } | "throw" =
   "throw";
 let sandboxResult: Record<string, unknown> | null = null;
+let creditGateResult: { allowed: boolean; balance: number; error?: string } = {
+  allowed: true,
+  balance: 100,
+};
+let enqueueCalls = 0;
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   runWithCloudBindingsAsync: (_b: unknown, fn: () => Promise<unknown>) => fn(),
@@ -25,14 +30,20 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
 }));
 mock.module("@/lib/services/provisioning-jobs", () => ({
   provisioningJobService: {
-    enqueueAgentProvisionOnce: async () => ({
-      job: { id: "job-1" },
-      created: true,
-    }),
+    enqueueAgentProvisionOnce: async () => {
+      enqueueCalls++;
+      return {
+        job: { id: "job-1" },
+        created: true,
+      };
+    },
   },
 }));
 mock.module("@/lib/services/provisioning-worker-health", () => ({
   checkProvisioningWorkerHealth: async () => ({ ok: true }),
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: async () => creditGateResult,
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: { warn() {}, error() {}, info() {}, debug() {} },
@@ -75,6 +86,8 @@ beforeEach(() => {
   captured = null;
   authResult = "throw";
   sandboxResult = null;
+  creditGateResult = { allowed: true, balance: 100 };
+  enqueueCalls = 0;
 });
 
 describe("dedicated-agent-proxy — unified auth", () => {
@@ -132,6 +145,35 @@ describe("dedicated-agent-proxy — unified auth", () => {
     expect(res.status).toBe(202);
     expect(res.headers.get("Retry-After")).toBe("5");
     expect(captured).toBeNull();
+  });
+
+  test("owner of a NON-RUNNING agent WITH sufficient credits → 202 and enqueues the resume (#11583)", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, status: "stopped" };
+    creditGateResult = { allowed: true, balance: 100 };
+    const r = makeRequest("cloud-token");
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(202);
+    expect(enqueueCalls).toBe(1); // paying org is not blocked
+  });
+
+  test("owner of a SUSPENDED / zero-balance agent → 402 and NO re-provision (free-compute suspension bypass closed, #11583)", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    // active-billing suspends a non-paying org's agent to `stopped`; without the
+    // gate, hitting the agent subdomain would re-provision it for free.
+    sandboxResult = { ...runningDedicated, status: "stopped" };
+    creditGateResult = {
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits.",
+    };
+    const r = makeRequest("cloud-token");
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("insufficient_credits");
+    expect(enqueueCalls).toBe(0); // no free compute
+    expect(captured).toBeNull(); // nothing proxied to the container
   });
 
   // A browser `new WebSocket()` can't set headers, so the app passes the cloud

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -32,6 +32,8 @@
 
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { checkProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health";
@@ -123,6 +125,32 @@ async function resumeAndRespond(
   let jobId: string | undefined;
   let alreadyInProgress = false;
   if (RESUMABLE_STATUSES.has(sandbox.status)) {
+    // A suspended / zero-balance org must NOT get free compute by hitting its
+    // own agent subdomain. Gate the auto-resume on credits, mirroring the
+    // pairing-token endpoint (#11224/#11227). Without this, billing suspension
+    // (active-billing sets status='stopped') is defeated: every proxied request
+    // would re-provision the container for free — the daemon executor does no
+    // credit re-check, so this HTTP call-site is the only gate. (#11583)
+    const creditCheck = await checkAgentCreditGate(orgId);
+    if (!creditCheck.allowed) {
+      logger.warn("[dedicated-proxy] auto-resume blocked: insufficient credits", {
+        agentId,
+        orgId,
+        balance: creditCheck.balance,
+        required: AGENT_PRICING.MINIMUM_DEPOSIT,
+      });
+      return Response.json(
+        {
+          success: false,
+          code: "insufficient_credits",
+          error:
+            creditCheck.error ?? "Insufficient credits to resume this agent",
+          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+          currentBalance: creditCheck.balance,
+        },
+        { status: 402 },
+      );
+    }
     const workerHealth = await checkProvisioningWorkerHealth();
     if (workerHealth.ok) {
       try {

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -33,8 +33,8 @@
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
-import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { checkProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health";
 import { logger } from "@/lib/utils/logger";
@@ -133,12 +133,15 @@ async function resumeAndRespond(
     // credit re-check, so this HTTP call-site is the only gate. (#11583)
     const creditCheck = await checkAgentCreditGate(orgId);
     if (!creditCheck.allowed) {
-      logger.warn("[dedicated-proxy] auto-resume blocked: insufficient credits", {
-        agentId,
-        orgId,
-        balance: creditCheck.balance,
-        required: AGENT_PRICING.MINIMUM_DEPOSIT,
-      });
+      logger.warn(
+        "[dedicated-proxy] auto-resume blocked: insufficient credits",
+        {
+          agentId,
+          orgId,
+          balance: creditCheck.balance,
+          required: AGENT_PRICING.MINIMUM_DEPOSIT,
+        },
+      );
       return Response.json(
         {
           success: false,


### PR DESCRIPTION
Closes #11583.

## The hole (found by the [cloud-security] final money/security deep-audit, adversarially verified)
The dedicated-agent proxy (`packages/cloud/api/src/dedicated-agent-proxy.ts`) auto-resumes any non-running agent a validated owner hits at `<agentId>.elizacloud.ai`, but **never checked credits**. So billing suspension was defeated:
1. `active-billing.ts` suspends a non-paying org's agent → `status='stopped'`.
2. The owner's app still points at the agent subdomain; every request re-enters `resumeAndRespond` → `enqueueAgentProvisionOnce` → **free re-provision**.
3. The daemon executor does no credit re-check, so this HTTP call-site was the only possible gate — and it was missing.

Same `#11224` free-compute-wake class the pairing-token endpoint already gates (I shipped that in **#11227**); this is the sibling path that was still open.

## Fix
Add `checkAgentCreditGate(orgId)` inside the `RESUMABLE_STATUSES` block **before** enqueueing, returning `402 insufficient_credits` — mirroring `pairing-token/route.ts`. A paying org is unaffected.

## Evidence
`bun test dedicated-agent-proxy.test.ts` → **9/9 pass**:
- **suspended / zero-balance org → 402, `enqueueAgentProvisionOnce` NOT called, nothing proxied** (bypass closed)
- paying org (credits OK) → 202 + enqueue (not blocked)
- all 6 existing unified-auth invariants still green

## Notes
Found in the same audit sweep: the compat-`autoProvision` candidate was **refuted** (WAIFU_AUTO_PROVISION off in prod), so no false positive shipped. **Money-path (free compute) → please review + merge; not self-merged.** `[cloud-security]`