### PR TITLE
fix(ui): harden voice listener boot lifecycles

### DIFF
--- a/.github/issue-evidence/11576-voice-listener-safety/README.md
+++ b/.github/issue-evidence/11576-voice-listener-safety/README.md
@@ -1,0 +1,18 @@
+# Issue #11576 — Voice Listener Safety
+
+## Validation
+
+- `bun install` completed in the clean worktree to restore local test binaries.
+- `bun packages/shared/scripts/generate-keywords.mjs` generated the local i18n import needed by the UI test runner.
+- `bunx @biomejs/biome check --write packages/ui/src/hooks/useVoiceChat.ts packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx packages/ui/src/components/settings/VoiceConfigView.tsx packages/ui/src/components/settings/VoiceConfigView.test.tsx packages/ui/src/components/settings/VoiceSectionMount.tsx packages/ui/src/components/settings/VoiceSectionMount.test.tsx`
+- `bun run --cwd packages/ui test -- src/hooks/useVoiceChat.talkmode-listeners.test.tsx src/components/settings/VoiceConfigView.test.tsx src/components/settings/VoiceSectionMount.test.tsx` — 3 files, 8 tests passed.
+- `git diff --check`
+
+## Typecheck
+
+- `bun run --cwd packages/ui typecheck` still fails on existing unrelated `@elizaos/contracts` resolution and `AccountWithCredentialFlag` account-field errors. The #11576-specific `VoiceSectionMount.tsx` typing error observed during development was fixed and no longer appears in the final typecheck output.
+
+## UI Evidence
+
+- Visual screenshots/video: N/A — this change does not alter rendered layout, styling, copy, or interaction affordances. It fixes async listener registration/cleanup and boot error handling with jsdom lifecycle regressions.
+- Real LLM trajectories: N/A — no model, prompt, provider, action, or agent behavior changed.

--- a/packages/ui/src/components/settings/VoiceConfigView.test.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getSwabblePlugin } from "../../bridge/native-plugins";
+import { VoiceConfigView } from "./VoiceConfigView";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const appState = vi.hoisted(() => ({
+  value: {
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+    elizaCloudConnected: false,
+    elizaCloudVoiceProxyAvailable: false,
+    characterData: { name: "eliza" },
+    agentStatus: { agentName: "eliza" },
+  },
+}));
+
+const clientMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+const swabbleMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  isListening: vi.fn(),
+  addListener: vi.fn(),
+  updateConfig: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock("../../api", () => ({
+  client: clientMock,
+}));
+
+vi.mock("../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: null, agentProps: {} }),
+}));
+
+vi.mock("../../bridge/native-plugins", () => ({
+  getSwabblePlugin: vi.fn(() => swabbleMock),
+}));
+
+vi.mock("../../hooks/useDefaultProviderPresets", () => ({
+  useDefaultProviderPresets: () => ({
+    defaults: { tts: "edge", asr: "browser" },
+  }),
+}));
+
+vi.mock("./AdvancedToggle", () => ({
+  AdvancedToggle: () => null,
+}));
+
+vi.mock("./AdvancedToggle.hooks", () => ({
+  readPersistedAdvancedFlag: () => false,
+  useAdvancedSettingsEnabled: () => false,
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: <T,>(selector: (state: typeof appState.value) => T): T =>
+    selector(appState.value),
+}));
+
+describe("VoiceConfigView Swabble audio meter listener lifecycle", () => {
+  beforeEach(() => {
+    clientMock.getConfig.mockResolvedValue({
+      messages: { tts: { provider: "edge" } },
+    });
+    clientMock.updateConfig.mockResolvedValue(undefined);
+    swabbleMock.getConfig.mockResolvedValue({ config: null });
+    swabbleMock.isListening.mockResolvedValue({ listening: false });
+    swabbleMock.updateConfig.mockResolvedValue(undefined);
+    swabbleMock.start.mockResolvedValue({ started: true });
+    swabbleMock.stop.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("removes an audioLevel listener that resolves after unmount", async () => {
+    const addListener = deferred<{ remove: () => Promise<void> }>();
+    const remove = vi.fn().mockResolvedValue(undefined);
+    swabbleMock.addListener.mockReturnValue(addListener.promise);
+
+    const { unmount } = render(<VoiceConfigView />);
+
+    await waitFor(() =>
+      expect(swabbleMock.addListener).toHaveBeenCalledWith(
+        "audioLevel",
+        expect.any(Function),
+      ),
+    );
+
+    unmount();
+    addListener.resolve({ remove });
+
+    await waitFor(() => expect(remove).toHaveBeenCalledTimes(1));
+    expect(getSwabblePlugin).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/settings/VoiceConfigView.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.tsx
@@ -543,9 +543,10 @@ function WakeWordSection({
 
   useEffect(() => {
     let handle: { remove: () => Promise<void> } | null = null;
+    let cancelled = false;
     void (async () => {
       try {
-        handle = await getSwabblePlugin().addListener(
+        const nextHandle = await getSwabblePlugin().addListener(
           "audioLevel",
           (evt: { level: number }) => {
             // Write the meter directly to the DOM to avoid a React re-render of
@@ -557,11 +558,14 @@ function WakeWordSection({
             }
           },
         );
+        if (cancelled) void nextHandle.remove();
+        else handle = nextHandle;
       } catch {
         // Not available
       }
     })();
     return () => {
+      cancelled = true;
       if (handle) void handle.remove();
     };
   }, []);

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -148,4 +148,28 @@ describe("VoiceSectionMount — continuous-chat localStorage mirror", () => {
       expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe("vad-gated"),
     );
   });
+
+  it("renders defaults and keeps local mirrors coherent when boot reads fail", async () => {
+    const unhandledRejection = vi.fn();
+    window.addEventListener("unhandledrejection", unhandledRejection);
+    clientMock.getConfig.mockRejectedValue(new Error("config unavailable"));
+    clientMock.getLocalInferenceDeviceTier.mockRejectedValue(
+      new Error("tier unavailable"),
+    );
+
+    render(<VoiceSectionMount />);
+
+    const toggle = (await screen.findByTestId(
+      "voice-section-wake-toggle",
+    )) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    await waitFor(() => expect(clientMock.getConfig).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(clientMock.getLocalInferenceDeviceTier).toHaveBeenCalled(),
+    );
+    expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe("off");
+    expect(unhandledRejection).not.toHaveBeenCalled();
+
+    window.removeEventListener("unhandledrejection", unhandledRejection);
+  });
 });

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -100,17 +100,24 @@ export function VoiceSectionMount(): React.ReactElement {
   React.useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const config = await client.getConfig();
-      if (cancelled) return;
-      const loaded = readStoredVoicePrefs(config);
-      setPrefs(loaded);
-      // Seed the local mirrors so the capture hot path reads the server value.
-      if (loaded.vadAutoStop) saveVadAutoStop(loaded.vadAutoStop);
-      // The surfaces that implement continuous chat (ChatView,
-      // useShellController) read ONLY the localStorage mirror via
-      // loadContinuousChatMode — never `messages.voice.continuous` — so the
-      // server value must be seeded into it, same as vadAutoStop above.
-      saveContinuousChatMode(loaded.continuous);
+      try {
+        const config = await client.getConfig();
+        if (cancelled) return;
+        const loaded = readStoredVoicePrefs(config);
+        setPrefs(loaded);
+        // Seed the local mirrors so the capture hot path reads the server value.
+        if (loaded.vadAutoStop) saveVadAutoStop(loaded.vadAutoStop);
+        // The surfaces that implement continuous chat (ChatView,
+        // useShellController) read ONLY the localStorage mirror via
+        // loadContinuousChatMode — never `messages.voice.continuous` — so the
+        // server value must be seeded into it, same as vadAutoStop above.
+        saveContinuousChatMode(loaded.continuous);
+      } catch {
+        if (cancelled) return;
+        setPrefs(DEFAULT_VOICE_SECTION_PREFS);
+        saveVadAutoStop(DEFAULT_VAD_AUTO_STOP_PREFS);
+        saveContinuousChatMode(DEFAULT_VOICE_SECTION_PREFS.continuous);
+      }
     })();
     return () => {
       cancelled = true;
@@ -120,10 +127,16 @@ export function VoiceSectionMount(): React.ReactElement {
   React.useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const result = await client.getLocalInferenceDeviceTier();
-      if (cancelled) return;
-      setTier(result.tier);
-      setTierSummary(result.reason);
+      try {
+        const result = await client.getLocalInferenceDeviceTier();
+        if (cancelled) return;
+        setTier(result.tier);
+        setTierSummary(result.reason);
+      } catch {
+        if (cancelled) return;
+        setTier(null);
+        setTierSummary(undefined);
+      }
     })();
     return () => {
       cancelled = true;

--- a/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import type { PluginListenerHandle } from "@capacitor/core";
+import { Capacitor } from "@capacitor/core";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTalkModePlugin } from "../bridge/native-plugins";
+import { useVoiceChat } from "./useVoiceChat";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const talkModeMock = vi.hoisted(() => ({
+  addListener: vi.fn(),
+  checkPermissions: vi.fn(),
+  requestPermissions: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock("../bridge/native-plugins", () => ({
+  getTalkModePlugin: vi.fn(() => talkModeMock),
+}));
+
+describe("useVoiceChat TalkMode listener lifecycle", () => {
+  let isNativePlatformSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    isNativePlatformSpy = vi
+      .spyOn(Capacitor, "isNativePlatform")
+      .mockReturnValue(true);
+    talkModeMock.checkPermissions.mockResolvedValue({
+      microphone: "granted",
+      speechRecognition: "granted",
+    });
+    talkModeMock.requestPermissions.mockResolvedValue({
+      microphone: "granted",
+      speechRecognition: "granted",
+    });
+    talkModeMock.start.mockResolvedValue({ started: true });
+    talkModeMock.stop.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "speechSynthesis", {
+      configurable: true,
+      value: {
+        speaking: false,
+        pending: false,
+        cancel: vi.fn(),
+        getVoices: vi.fn(() => []),
+        speak: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    isNativePlatformSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("coalesces concurrent TalkMode listener setup into one removable handle set", async () => {
+    const listenerAdds = [
+      deferred<PluginListenerHandle>(),
+      deferred<PluginListenerHandle>(),
+      deferred<PluginListenerHandle>(),
+    ];
+    const removeFns = [
+      vi.fn().mockResolvedValue(undefined),
+      vi.fn().mockResolvedValue(undefined),
+      vi.fn().mockResolvedValue(undefined),
+    ];
+    talkModeMock.addListener.mockImplementation(() => {
+      const next = listenerAdds[talkModeMock.addListener.mock.calls.length - 1];
+      if (!next) throw new Error("unexpected listener registration");
+      return next.promise;
+    });
+    const { result, unmount } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+      }),
+    );
+
+    const firstStart = result.current.startListening("push-to-talk");
+    const secondStart = result.current.startListening("push-to-talk");
+
+    await waitFor(() =>
+      expect(talkModeMock.addListener).toHaveBeenCalledTimes(1),
+    );
+    listenerAdds[0]?.resolve({ remove: removeFns[0] });
+    await waitFor(() =>
+      expect(talkModeMock.addListener).toHaveBeenCalledTimes(2),
+    );
+    listenerAdds[1]?.resolve({ remove: removeFns[1] });
+    await waitFor(() =>
+      expect(talkModeMock.addListener).toHaveBeenCalledTimes(3),
+    );
+    listenerAdds[2]?.resolve({ remove: removeFns[2] });
+
+    await act(async () => {
+      await Promise.all([firstStart, secondStart]);
+    });
+
+    expect(getTalkModePlugin).toHaveBeenCalled();
+    expect(talkModeMock.addListener).toHaveBeenCalledTimes(3);
+    expect(
+      talkModeMock.addListener.mock.calls.map(([eventName]) => eventName),
+    ).toEqual(["transcript", "error", "stateChange"]);
+
+    unmount();
+
+    await waitFor(() => expect(removeFns[0]).toHaveBeenCalledTimes(1));
+    expect(removeFns[1]).toHaveBeenCalledTimes(1);
+    expect(removeFns[2]).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -267,6 +267,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     "browser" | "local-inference" | "talkmode" | null
   >(null);
   const talkModeHandlesRef = useRef<PluginListenerHandle[]>([]);
+  const ensureTalkModeListenersPromiseRef = useRef<Promise<void> | null>(null);
   const synthRef = useRef<SpeechSynthesis | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const playbackFrameTapRef = useRef<PlaybackFrameTap | null>(null);
@@ -691,60 +692,90 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   const ensureTalkModeListeners = useCallback(async () => {
     if (talkModeHandlesRef.current.length > 0) return;
+    if (ensureTalkModeListenersPromiseRef.current) {
+      return ensureTalkModeListenersPromiseRef.current;
+    }
 
-    const talkMode = getTalkModePlugin();
+    const promise = (async () => {
+      if (talkModeHandlesRef.current.length > 0) return;
 
-    const transcriptHandle = await talkMode.addListener(
-      "transcript",
-      (event: TalkModeTranscriptEvent) => {
-        const typedEvent = event as TalkModeTranscriptEvent & {
-          mode?: unknown;
-          speaker?: VoiceSpeakerMetadata;
-          turn?: Partial<VoiceTurn>;
-          source?: string;
-          confidence?: number;
-          metadata?: Record<string, unknown>;
-        };
-        applyTranscriptUpdate(event.transcript ?? "", event.isFinal === true, {
-          mode: normalizeActiveVoiceSessionMode(typedEvent.mode) ?? undefined,
-          speaker: typedEvent.speaker,
-          source: typedEvent.source,
-          confidence: typedEvent.confidence,
-          turn: typedEvent.turn,
-          metadata: typedEvent.metadata,
-        });
-      },
-    );
-    const errorHandle = await talkMode.addListener(
-      "error",
-      (event: TalkModeErrorEvent) => {
-        if (
-          sttBackendRef.current === "talkmode" ||
-          event.code === "not-allowed" ||
-          event.code === "service-not-allowed"
-        ) {
-          resetListeningState();
-          if (
-            event.code === "not-allowed" ||
-            event.code === "service-not-allowed"
-          ) {
-            setSupported(false);
-          }
-        }
-      },
-    );
-    const stateHandle = await talkMode.addListener(
-      "stateChange",
-      (event: TalkModeStateEvent) => {
-        if (
-          (event.state === "error" || event.state === "idle") &&
-          sttBackendRef.current === "talkmode"
-        ) {
-          resetListeningState();
-        }
-      },
-    );
-    talkModeHandlesRef.current = [transcriptHandle, errorHandle, stateHandle];
+      const talkMode = getTalkModePlugin();
+      const handles: PluginListenerHandle[] = [];
+
+      try {
+        const transcriptHandle = await talkMode.addListener(
+          "transcript",
+          (event: TalkModeTranscriptEvent) => {
+            const typedEvent = event as TalkModeTranscriptEvent & {
+              mode?: unknown;
+              speaker?: VoiceSpeakerMetadata;
+              turn?: Partial<VoiceTurn>;
+              source?: string;
+              confidence?: number;
+              metadata?: Record<string, unknown>;
+            };
+            applyTranscriptUpdate(
+              event.transcript ?? "",
+              event.isFinal === true,
+              {
+                mode:
+                  normalizeActiveVoiceSessionMode(typedEvent.mode) ?? undefined,
+                speaker: typedEvent.speaker,
+                source: typedEvent.source,
+                confidence: typedEvent.confidence,
+                turn: typedEvent.turn,
+                metadata: typedEvent.metadata,
+              },
+            );
+          },
+        );
+        handles.push(transcriptHandle);
+        const errorHandle = await talkMode.addListener(
+          "error",
+          (event: TalkModeErrorEvent) => {
+            if (
+              sttBackendRef.current === "talkmode" ||
+              event.code === "not-allowed" ||
+              event.code === "service-not-allowed"
+            ) {
+              resetListeningState();
+              if (
+                event.code === "not-allowed" ||
+                event.code === "service-not-allowed"
+              ) {
+                setSupported(false);
+              }
+            }
+          },
+        );
+        handles.push(errorHandle);
+        const stateHandle = await talkMode.addListener(
+          "stateChange",
+          (event: TalkModeStateEvent) => {
+            if (
+              (event.state === "error" || event.state === "idle") &&
+              sttBackendRef.current === "talkmode"
+            ) {
+              resetListeningState();
+            }
+          },
+        );
+        handles.push(stateHandle);
+        talkModeHandlesRef.current = handles;
+      } catch (error) {
+        await Promise.allSettled(handles.map((handle) => handle.remove()));
+        throw error;
+      }
+    })();
+
+    ensureTalkModeListenersPromiseRef.current = promise;
+    try {
+      await promise;
+    } finally {
+      if (ensureTalkModeListenersPromiseRef.current === promise) {
+        ensureTalkModeListenersPromiseRef.current = null;
+      }
+    }
   }, [applyTranscriptUpdate, resetListeningState]);
 
   const transcribeLocalInferenceAudio = useCallback(


### PR DESCRIPTION
## Summary

Fixes #11576.

- Coalesces concurrent TalkMode listener setup behind one in-flight promise so re-entrant `startListening` calls do not register duplicate transcript/error/state listeners.
- Removes partially registered TalkMode handles if setup fails mid-flight.
- Applies the Swabble wake-controller cancellation pattern to the voice settings `audioLevel` listener so late-resolving handles are removed after unmount.
- Wraps `VoiceSectionMount` boot config and local-inference tier reads in `try/catch`, falling back to defaults without unhandled rejections or stale local mirrors.
- Adds focused jsdom regressions for all three issue bullets.

## Evidence

- Evidence note: `.github/issue-evidence/11576-voice-listener-safety/README.md`
- `bun install`
- `bun packages/shared/scripts/generate-keywords.mjs`
- `bunx @biomejs/biome check --write packages/ui/src/hooks/useVoiceChat.ts packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx packages/ui/src/components/settings/VoiceConfigView.tsx packages/ui/src/components/settings/VoiceConfigView.test.tsx packages/ui/src/components/settings/VoiceSectionMount.tsx packages/ui/src/components/settings/VoiceSectionMount.test.tsx`
- `bun run --cwd packages/ui test -- src/hooks/useVoiceChat.talkmode-listeners.test.tsx src/components/settings/VoiceConfigView.test.tsx src/components/settings/VoiceSectionMount.test.tsx` — 3 files, 8 tests passed.
- `git diff --check`

## Known Non-Blocking Validation

- `bun run --cwd packages/ui typecheck` still fails on existing unrelated `@elizaos/contracts` resolution and `AccountWithCredentialFlag` account-field errors. During this patch, typecheck also caught one `VoiceSectionMount.tsx` fallback VAD typing issue; that was fixed and no longer appears in the final output.

## N/A Evidence

- Screenshots/video: N/A — no rendered layout, style, copy, or visible interaction change.
- Real-LLM trajectories: N/A — no model, prompt, provider, action, or agent behavior changed.
