### PR TITLE
feat(eliza-code): TUI opencode-parity batch — markdown, streaming, cancel, tool trace, input polish (#11294)

### DIFF
--- a/.github/issue-evidence/11294-tui-queue-and-send-capture.ts
+++ b/.github/issue-evidence/11294-tui-queue-and-send-capture.ts
@@ -1,0 +1,153 @@
+// Evidence capture for PR (#11294 batch): drives the REAL App handlers against
+// a deferred-turn runtime stub (same harness as src/turn-queue.test.ts) and
+// renders the REAL MainScreen through @elizaos/tui's VirtualTerminal.
+// Run: bun evidence-frames.ts   (from packages/examples/code)
+import { stripVTControlCharacters } from "node:util";
+import type { AgentRuntime } from "@elizaos/core";
+import { TUI } from "@elizaos/tui";
+import { VirtualTerminal } from "@elizaos/tui/testing";
+import { App } from "./src/App.js";
+import { ChatPane } from "./src/components/ChatPane.js";
+import { MainScreen } from "./src/components/MainScreen.js";
+import { StatusBar } from "./src/components/StatusBar.js";
+import { TaskPane } from "./src/components/TaskPane.js";
+import { getAgentClient } from "./src/lib/agent-client.js";
+import { useStore } from "./src/lib/store.js";
+
+process.env.ELIZA_CODE_DISABLE_SESSION_PERSISTENCE = "1";
+
+const COLS = 80;
+
+function makeScreen() {
+  const terminal = new VirtualTerminal(COLS, 26);
+  const tui = new TUI(terminal);
+  const chatPane = new ChatPane({ onSubmit: async () => {}, tui });
+  chatPane.syncFocus(true);
+  const screen = new MainScreen(
+    terminal,
+    new StatusBar(),
+    chatPane,
+    new TaskPane({ runtime: {} as unknown as AgentRuntime, tui }),
+  );
+  return { screen, chatPane };
+}
+
+function printFrame(title: string, lines: string[]) {
+  console.log(`\n===== ${title} =====`);
+  for (const line of lines) {
+    console.log(`|${stripVTControlCharacters(line)}`);
+  }
+}
+
+interface DeferredTurn {
+  resolve: () => void;
+}
+
+function makeApp() {
+  const turns: DeferredTurn[] = [];
+  const runtime = Object.assign(Object.create(null) as AgentRuntime, {
+    agentId: "evidence",
+    character: { name: "Eliza" },
+    getService: () => null,
+    ensureConnection: async () => {},
+    messageService: {
+      handleMessage: async (
+        _rt: unknown,
+        message: { content?: { text?: string } },
+        callback: (content: { text: string }) => Promise<unknown>,
+        options?: { abortSignal?: AbortSignal },
+      ) => {
+        await new Promise<void>((resolve, reject) => {
+          turns.push({ resolve });
+          options?.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              const err = new Error("aborted");
+              err.name = "AbortError";
+              reject(err);
+            },
+            { once: true },
+          );
+        });
+        await callback({
+          text: `Done. Here's the summary for **${message.content?.text}**.`,
+        });
+        return { didRespond: true, responseMessages: [] };
+      },
+    },
+  });
+  getAgentClient().setRuntime(runtime);
+  const app = new App(runtime);
+  return {
+    // biome-ignore lint/complexity/useLiteralKeys: private hook
+    send: (text: string): Promise<void> => app["handleSendMessage"](text),
+    // biome-ignore lint/complexity/useLiteralKeys: private hook
+    consume: (data: string): boolean => app["consumeGlobalInput"](data),
+    turns,
+  };
+}
+
+async function waitFor(cond: () => boolean) {
+  const deadline = Date.now() + 2000;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+useStore.setState({
+  focusedPane: "chat",
+  inputValue: "",
+  rooms: [],
+  pendingSubmissions: [],
+  isLoading: false,
+  isAgentTyping: false,
+});
+
+const { screen, chatPane } = makeScreen();
+const { send, consume, turns } = makeApp();
+useStore.getState().createRoom("Demo");
+
+// --- Frame 1: turn running, second submission queued -----------------------
+const turnA = send("refactor the session store");
+await waitFor(() => turns.length === 1);
+await send("also add tests for the edge cases please");
+printFrame(
+  "Frame 1 — Enter during a running turn queues the message (loading row shows the count)",
+  screen.render(COLS),
+);
+
+// --- Frame 2: type-ahead composer stays visible mid-turn --------------------
+for (const ch of "and update the README") chatPane.handleInput(ch);
+printFrame(
+  "Frame 2 — typing ahead mid-turn keeps the composer visible (footer: Enter queues)",
+  screen.render(COLS),
+);
+for (let i = 0; i < "and update the README".length; i++)
+  chatPane.handleInput("\x7f");
+
+// --- Frame 3: abort discards the queue --------------------------------------
+consume("\x03"); // first Ctrl+C: abort
+await turnA;
+printFrame(
+  "Frame 3 — Esc/Ctrl+C aborts the turn and discards the queued message",
+  screen.render(COLS),
+);
+
+// --- Frame 4: queued message drains on normal completion --------------------
+useStore.setState({ rooms: [], pendingSubmissions: [] });
+useStore.getState().createRoom("Demo 2");
+const turnB = send("first task");
+await waitFor(() => turns.length === 2);
+await send("second task, queued");
+turns[1]?.resolve();
+await turnB;
+await waitFor(() => turns.length === 3);
+turns[2]?.resolve();
+await waitFor(() => !useStore.getState().isLoading);
+printFrame(
+  "Frame 4 — queued submission fires as its own turn after the first completes (markdown-rendered replies)",
+  screen.render(COLS),
+);
+
+process.exit(0);

--- a/.github/issue-evidence/11294-tui-queue-and-send-frames.txt
+++ b/.github/issue-evidence/11294-tui-queue-and-send-frames.txt
@@ -1,0 +1,120 @@
+# 11294 — eliza-code TUI queue-and-send + Ctrl+C fallthrough: rendered frames
+
+Produced by driving the REAL App handlers (handleSendMessage / consumeGlobalInput)
+against a deferred-turn runtime stub and rendering the REAL MainScreen through
+@elizaos/tui's VirtualTerminal at 80 cols (chalk off-TTY -> plain text; ANSI
+stripped with node:util stripVTControlCharacters). Capture script:
+11294-tui-queue-and-send-capture.ts (run from packages/examples/code with
+`bun <script>`). Each line is prefixed with `|` to preserve leading whitespace.
+
+===== Frame 1 — Enter during a running turn queues the message (loading row shows the count) =====
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ Demo (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 … | ? │
+|└────────────────────────────────────────────────────────────────────────────┘
+| Chat: Demo (3)
+| You 17:08
+|   refactor the session store                                                
+| Eliza 17:08
+|   
+| Queued (1): also add tests for the edge cases please — sends when the
+| current turn finishes. Esc/Ctrl+C aborts and discards the queue.
+|  ⠋ Processing (Esc/Ctrl+C abort)                                            
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ Processing... Esc/Ctrl+C abort • 1 queued                                  │
+|└────────────────────────────────────────────────────────────────────────────┘
+|Enter: queue • Esc/Ctrl+C: abort • PgUp/PgDn: scroll
+
+===== Frame 2 — typing ahead mid-turn keeps the composer visible (footer: Enter queues) =====
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ Demo (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 … | ? │
+|└────────────────────────────────────────────────────────────────────────────┘
+| Chat: Demo (3)
+| You 17:08
+|   refactor the session store                                                
+| Eliza 17:08
+|   
+| Queued (1): also add tests for the edge cases please — sends when the
+| current turn finishes. Esc/Ctrl+C aborts and discards the queue.
+|  ⠋ Processing (Esc/Ctrl+C abort)                                            
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ >  and update the README
+|└────────────────────────────────────────────────────────────────────────────┘
+|Enter: queue • Esc/Ctrl+C: abort • PgUp/PgDn: scroll
+
+===== Frame 3 — Esc/Ctrl+C aborts the turn and discards the queued message =====
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ Demo (1/1) | ...te/tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 | ? │
+|└────────────────────────────────────────────────────────────────────────────┘
+| Chat: Demo (4)
+| You 17:08
+|   refactor the session store                                                
+| Queued (1): also add tests for the edge cases please — sends when the
+| current turn finishes. Esc/Ctrl+C aborts and discards the queue.
+| Turn aborted.
+| Discarded 1 queued message.
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ >  
+|└────────────────────────────────────────────────────────────────────────────┘
+|Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help
+
+===== Frame 4 — queued submission fires as its own turn after the first completes (markdown-rendered replies) =====
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ Demo 2 (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 | ? │
+|└────────────────────────────────────────────────────────────────────────────┘
+| Chat: Demo 2 (5)
+| You 17:08
+|   first task                                                                
+| Eliza 17:08
+|   Done. Here's the summary for first task.                                  
+| Queued (1): second task, queued — sends when the current turn finishes.
+| Esc/Ctrl+C aborts and discards the queue.
+| You 17:08
+|   second task, queued                                                       
+| Eliza 17:08
+|   Done. Here's the summary for second task, queued.                         
+|
+|
+|
+|
+|
+|
+|
+|
+|┌────────────────────────────────────────────────────────────────────────────┐
+|│ >  
+|└────────────────────────────────────────────────────────────────────────────┘
+|Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help

--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -734,9 +734,13 @@ export class App {
   private abortCurrentTurn(): boolean {
     const controller = this.activeTurnAbortController;
     if (!controller) return false;
-    if (!controller.signal.aborted) {
-      controller.abort();
+    if (controller.signal.aborted) {
+      // Abort was already requested but the turn hasn't unwound yet (e.g. a
+      // provider that ignores the signal). Let the keystroke fall through so
+      // a second Ctrl+C reaches the quit handler instead of being eaten here.
+      return false;
     }
+    controller.abort();
     this.tui.requestRender();
     return true;
   }

--- a/packages/examples/code/src/App.ts
+++ b/packages/examples/code/src/App.ts
@@ -1084,7 +1084,8 @@ Dir: /cd [path], /pwd
 UI: /clear, /copy
 Help: /help, ?
 
-Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
+Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit
+During a turn: Enter queues the message, Esc/Ctrl+C aborts (queued messages are discarded), second Ctrl+C quits`,
         );
         this.tui.requestRender();
         return true;
@@ -1176,11 +1177,17 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
       }
     }
 
+    // Queue-and-send (opencode behavior): a submission made while a turn is
+    // running is buffered and fired when the turn completes, instead of
+    // spawning a second concurrent turn.
     if (this.activeTurnAbortController) {
+      const queueLength = state.enqueuePendingSubmission(text);
       state.addMessage(
         state.currentRoomId,
         "system",
-        "A turn is already running. Press Esc or Ctrl+C to abort it.",
+        `Queued (${queueLength}): ${submissionPreview(text)} — sends when the current turn finishes. Esc/Ctrl+C aborts and discards the queue.`,
+        state.currentTaskId ?? undefined,
+        "tool",
       );
       this.tui.requestRender();
       return;
@@ -1275,9 +1282,38 @@ Shortcuts: Tab panes, Ctrl+< > resize tasks, Ctrl+N new chat, Ctrl+C quit`,
       }
       state.setLoading(false);
       state.setAgentTyping(false);
+      // Drain the queue-and-send buffer. Abort means "stop everything", so an
+      // aborted turn discards whatever was queued behind it; any other
+      // completion (success or error) sends the next queued submission.
+      if (turnAbortController.signal.aborted) {
+        const discarded = state.clearPendingSubmissions();
+        if (discarded > 0) {
+          state.addMessage(
+            roomId,
+            "system",
+            `Discarded ${discarded} queued message${discarded === 1 ? "" : "s"}.`,
+          );
+        }
+      } else {
+        const next = state.takeNextPendingSubmission();
+        if (next !== undefined) {
+          // New microtask: don't run the next turn inside this finally block.
+          // handleSendMessage never rejects (it catches everything), so void
+          // is safe here.
+          queueMicrotask(() => {
+            void this.handleSendMessage(next);
+          });
+        }
+      }
       this.tui.requestRender();
     }
   }
+}
+
+/** One-line, length-capped echo of a queued submission for the system notice. */
+function submissionPreview(text: string, maxLength = 48): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= maxLength ? flat : `${flat.slice(0, maxLength - 1)}…`;
 }
 
 function isAbortError(err: unknown): boolean {

--- a/packages/examples/code/src/components/ChatPane.ts
+++ b/packages/examples/code/src/components/ChatPane.ts
@@ -384,10 +384,15 @@ export class ChatPane implements Focusable {
         height - headerHeight - helpHeight - inputChromeHeight - 1,
       ),
     );
-    const composerLines = state.isLoading
-      ? []
-      : this.renderComposerLines(editorWidth, composerMaxLines);
-    const inputBodyHeight = state.isLoading ? 1 : composerLines.length;
+    // While a turn is running the input row shows a loading notice — unless
+    // the user is typing ahead (queue-and-send), in which case the composer
+    // stays visible so they can see what they're about to queue.
+    const composerVisible =
+      !state.isLoading || this.editor.getText().length > 0;
+    const composerLines = composerVisible
+      ? this.renderComposerLines(editorWidth, composerMaxLines)
+      : [];
+    const inputBodyHeight = composerVisible ? composerLines.length : 1;
     const inputHeight = inputChromeHeight + inputBodyHeight;
     const messageAreaHeight = Math.max(
       1,
@@ -465,8 +470,10 @@ export class ChatPane implements Focusable {
 
     output.push(topBorder);
 
-    if (state.isLoading) {
-      const loadingText = "Processing... Esc/Ctrl+C abort";
+    if (!composerVisible) {
+      const queuedCount = state.pendingSubmissions.length;
+      const queuedSuffix = queuedCount > 0 ? ` • ${queuedCount} queued` : "";
+      const loadingText = `Processing... Esc/Ctrl+C abort${queuedSuffix}`;
       const available = Math.max(1, innerWidth - 1);
       const visibleText =
         loadingText.length > available
@@ -492,9 +499,11 @@ export class ChatPane implements Focusable {
 
     const helpText = !this.focused
       ? "Tab: focus"
-      : state.inputValue.startsWith("/")
-        ? "Enter: run • Tab: complete • Esc: clear • ?: help"
-        : "Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help";
+      : state.isLoading
+        ? "Enter: queue • Esc/Ctrl+C: abort • PgUp/PgDn: scroll"
+        : state.inputValue.startsWith("/")
+          ? "Enter: run • Tab: complete • Esc: clear • ?: help"
+          : "Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help";
     output.push(truncateToWidth(chalk.dim(helpText), width));
 
     return output;

--- a/packages/examples/code/src/components/narrow-terminal.test.ts
+++ b/packages/examples/code/src/components/narrow-terminal.test.ts
@@ -57,6 +57,7 @@ function resetChatStore(): void {
     inputValue: "",
     isLoading: false,
     isAgentTyping: false,
+    pendingSubmissions: [],
   });
 }
 
@@ -239,6 +240,42 @@ describe("eliza-code TUI at cockpit phone width", () => {
     const wideLoading = wideLines.find((line) => line.includes("Processing"));
     expect(wideLoading).toContain("Esc/Ctrl+C abort");
     expect(visibleWidth(wideLoading ?? "")).toBeLessThanOrEqual(80);
+  });
+
+  test("ChatPane keeps the type-ahead composer visible while a turn is running", () => {
+    const { chatPane } = makeScreen(PHONE_COLS);
+    chatPane.syncFocus(true);
+    useStore.getState().setLoading(true);
+
+    // Typing during the turn (queue-and-send) must be visible, not swallowed
+    // behind the "Processing" row.
+    typeIntoChat(chatPane, "queued follow-up");
+
+    const lines = chatPane.renderContent(PHONE_COLS, 24);
+    const rendered = plainText(lines);
+    expect(plainText(inputFrameLines(lines))).toContain("queued follow-up");
+    expect(rendered).not.toContain("Processing...");
+    expect(rendered).toContain("Enter: queue");
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(PHONE_COLS);
+    }
+  });
+
+  test("ChatPane loading row shows the queued-submission count", () => {
+    const { chatPane } = makeScreen(80);
+    chatPane.syncFocus(true);
+    useStore.getState().setLoading(true);
+    useStore.setState({ pendingSubmissions: ["next thing", "and another"] });
+
+    const wideLines = chatPane.renderContent(80, 24);
+    const wideLoading = wideLines.find((line) => line.includes("Processing"));
+    expect(wideLoading).toContain("2 queued");
+
+    // Narrow terminals clip the suffix instead of overflowing (#11043 guard).
+    const phoneLines = chatPane.renderContent(PHONE_COLS, 24);
+    for (const line of phoneLines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(PHONE_COLS);
+    }
   });
 
   test("ChatPane uses the TUI loader while the assistant is typing", () => {

--- a/packages/examples/code/src/lib/store.ts
+++ b/packages/examples/code/src/lib/store.ts
@@ -78,6 +78,12 @@ interface ElizaCodeState {
   isLoading: boolean;
   inputValue: string;
   isAgentTyping: boolean;
+  /**
+   * Submissions typed while a turn is in flight (queue-and-send). Drained
+   * FIFO when the turn completes; discarded when the turn is aborted.
+   * Ephemeral — never persisted to the session file.
+   */
+  pendingSubmissions: string[];
 
   // Session initialized flag
   sessionLoaded: boolean;
@@ -124,6 +130,12 @@ interface ElizaCodeState {
   setLoading: (loading: boolean) => void;
   setInputValue: (value: string) => void;
   setAgentTyping: (typing: boolean) => void;
+  /** Buffer a submission typed during a running turn. Returns the queue length. */
+  enqueuePendingSubmission: (text: string) => number;
+  /** Pop the oldest queued submission (FIFO), if any. */
+  takeNextPendingSubmission: () => string | undefined;
+  /** Drop all queued submissions. Returns how many were discarded. */
+  clearPendingSubmissions: () => number;
 
   // Session Actions
   loadSessionState: () => Promise<void>;
@@ -194,6 +206,7 @@ export const useStore = create<ElizaCodeState>((set, get) => ({
   isLoading: false,
   inputValue: "",
   isAgentTyping: false,
+  pendingSubmissions: [],
   sessionLoaded: false,
 
   // Room Actions
@@ -434,6 +447,27 @@ export const useStore = create<ElizaCodeState>((set, get) => ({
 
   setAgentTyping: (typing: boolean) => {
     set({ isAgentTyping: typing });
+  },
+
+  enqueuePendingSubmission: (text: string) => {
+    const next = [...get().pendingSubmissions, text];
+    set({ pendingSubmissions: next });
+    return next.length;
+  },
+
+  takeNextPendingSubmission: () => {
+    const [head, ...rest] = get().pendingSubmissions;
+    if (head === undefined) return undefined;
+    set({ pendingSubmissions: rest });
+    return head;
+  },
+
+  clearPendingSubmissions: () => {
+    const count = get().pendingSubmissions.length;
+    if (count > 0) {
+      set({ pendingSubmissions: [] });
+    }
+    return count;
   },
 
   // Session Actions

--- a/packages/examples/code/src/turn-queue.test.ts
+++ b/packages/examples/code/src/turn-queue.test.ts
@@ -4,6 +4,8 @@
 // * Enter during a running turn buffers the submission (no second concurrent
 //   turn) and fires it when the turn completes — opencode behavior.
 // * Aborting a turn discards the queue ("stop everything").
+// * A second Ctrl+C while an aborted turn is still unwinding quits the app
+//   instead of being eaten; Ctrl+C when idle quits on the first press.
 //
 // Pattern follows global-input.test.ts: construct a real App around a minimal
 // runtime stub and drive the real private handlers.
@@ -88,6 +90,56 @@ function makeQueueApp() {
     consume: (data: string): boolean => app["consumeGlobalInput"](data),
     sentTexts: () => sentTexts,
     turns,
+  };
+}
+
+/**
+ * App wired to a runtime that wedges: handleMessage never settles and ignores
+ * the abort signal entirely — the worst case a slow/broken provider produces.
+ */
+function makeWedgedApp() {
+  let turnStarted = false;
+  const runtime = Object.assign(Object.create(null) as AgentRuntime, {
+    agentId: "test",
+    character: { name: "Eliza" },
+    getService: () => null,
+    ensureConnection: async () => {},
+    messageService: {
+      handleMessage: async () => {
+        turnStarted = true;
+        await new Promise(() => {});
+      },
+    },
+  });
+
+  getAgentClient().setRuntime(runtime);
+  const app = new App(runtime);
+  return {
+    app,
+    // biome-ignore lint/complexity/useLiteralKeys: private test hook
+    send: (text: string): Promise<void> => app["handleSendMessage"](text),
+    // biome-ignore lint/complexity/useLiteralKeys: private test hook
+    consume: (data: string): boolean => app["consumeGlobalInput"](data),
+    turnStarted: () => turnStarted,
+  };
+}
+
+/** Stub out session persistence and App.stop; returns spies + restore. */
+function instrumentQuit(app: App): {
+  stopped: () => boolean;
+  restore: () => void;
+} {
+  let stopped = false;
+  const originalSave = useStore.getState().saveSessionState;
+  useStore.setState({ saveSessionState: async () => {} });
+  (app as { stop: () => void }).stop = () => {
+    stopped = true;
+  };
+  return {
+    stopped: () => stopped,
+    restore: () => {
+      useStore.setState({ saveSessionState: originalSave });
+    },
   };
 }
 
@@ -213,5 +265,43 @@ describe("eliza-code queue-and-send (#11294)", () => {
 
     turns[0]?.resolve();
     await turnA;
+  });
+});
+
+describe("eliza-code abort-key fallthrough (#11294)", () => {
+  it("quits on the second Ctrl+C while an aborted turn is still unwinding", async () => {
+    const { app, send, consume, turnStarted } = makeWedgedApp();
+    const quit = instrumentQuit(app);
+    try {
+      useStore.getState().createRoom("Wedge test");
+      void send("hang forever");
+      await waitFor(turnStarted, "wedged turn to start");
+
+      // First Ctrl+C: consumed, requests the abort — must NOT quit.
+      expect(consume("\x03")).toBe(true);
+      expect(quit.stopped()).toBe(false);
+
+      // Esc after the abort request falls through without quitting.
+      expect(consume("\x1b")).toBe(false);
+      expect(quit.stopped()).toBe(false);
+
+      // Second Ctrl+C: the turn never unwound (provider ignores the signal),
+      // so the keystroke falls through to the quit handler.
+      expect(consume("\x03")).toBe(true);
+      expect(quit.stopped()).toBe(true);
+    } finally {
+      quit.restore();
+    }
+  });
+
+  it("quits on the first Ctrl+C when no turn is running", () => {
+    const { app, consume } = makeQueueApp();
+    const quit = instrumentQuit(app);
+    try {
+      expect(consume("\x03")).toBe(true);
+      expect(quit.stopped()).toBe(true);
+    } finally {
+      quit.restore();
+    }
   });
 });

--- a/packages/examples/code/src/turn-queue.test.ts
+++ b/packages/examples/code/src/turn-queue.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment node
+//
+// Queue-and-send + abort-key semantics for the eliza-code TUI (#11294):
+// * Enter during a running turn buffers the submission (no second concurrent
+//   turn) and fires it when the turn completes — opencode behavior.
+// * Aborting a turn discards the queue ("stop everything").
+//
+// Pattern follows global-input.test.ts: construct a real App around a minimal
+// runtime stub and drive the real private handlers.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { App } from "./App.js";
+import { getAgentClient, resetAgentClient } from "./lib/agent-client.js";
+import { useStore } from "./lib/store.js";
+import type { Message } from "./types.js";
+
+function makeAbortError(): Error {
+  const err = new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+async function waitFor(cond: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (!cond()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function roomMessages(roomId: string): Message[] {
+  return (
+    useStore.getState().rooms.find((room) => room.id === roomId)?.messages ?? []
+  );
+}
+
+interface DeferredTurn {
+  text: string;
+  resolve: () => void;
+}
+
+/**
+ * App wired to a runtime whose turns block until the test resolves them, so a
+ * second submission can arrive while the first turn is verifiably in flight.
+ * Turns honor the abort signal (reject with AbortError).
+ */
+function makeQueueApp() {
+  const sentTexts: string[] = [];
+  const turns: DeferredTurn[] = [];
+  const runtime = Object.assign(Object.create(null) as AgentRuntime, {
+    agentId: "test",
+    character: { name: "Eliza" },
+    getService: () => null,
+    ensureConnection: async () => {},
+    messageService: {
+      handleMessage: async (
+        _runtime: unknown,
+        message: { content?: { text?: string } },
+        callback: (content: { text: string }) => Promise<unknown>,
+        options?: { abortSignal?: AbortSignal },
+      ) => {
+        const text = message.content?.text ?? "";
+        sentTexts.push(text);
+        await new Promise<void>((resolve, reject) => {
+          turns.push({ text, resolve });
+          options?.abortSignal?.addEventListener(
+            "abort",
+            () => reject(makeAbortError()),
+            { once: true },
+          );
+        });
+        await callback({ text: `echo: ${text}` });
+        return { didRespond: true, responseMessages: [] };
+      },
+    },
+  });
+
+  getAgentClient().setRuntime(runtime);
+  const app = new App(runtime);
+  return {
+    app,
+    // biome-ignore lint/complexity/useLiteralKeys: private test hook
+    send: (text: string): Promise<void> => app["handleSendMessage"](text),
+    // biome-ignore lint/complexity/useLiteralKeys: private test hook
+    consume: (data: string): boolean => app["consumeGlobalInput"](data),
+    sentTexts: () => sentTexts,
+    turns,
+  };
+}
+
+beforeEach(() => {
+  useStore.setState({
+    focusedPane: "chat",
+    inputValue: "",
+    rooms: [],
+    pendingSubmissions: [],
+    isLoading: false,
+    isAgentTyping: false,
+  });
+  resetAgentClient();
+});
+
+describe("eliza-code queue-and-send (#11294)", () => {
+  it("queues a submission made during a running turn and sends it when the turn completes", async () => {
+    const { send, sentTexts, turns } = makeQueueApp();
+    const room = useStore.getState().createRoom("Queue test");
+
+    const turnA = send("first question");
+    await waitFor(() => turns.length === 1, "first turn to start");
+
+    // Second submission while the turn runs: buffered, NOT sent concurrently.
+    await send("second question");
+    expect(sentTexts()).toEqual(["first question"]);
+    expect(useStore.getState().pendingSubmissions).toEqual(["second question"]);
+    const queuedNotice = roomMessages(room.id)
+      .filter((message) => message.role === "system")
+      .at(-1);
+    expect(queuedNotice?.content).toContain("Queued (1): second question");
+
+    // Turn A completes → the queued submission fires as its own turn.
+    turns[0]?.resolve();
+    await turnA;
+    await waitFor(() => turns.length === 2, "queued turn to start");
+    expect(sentTexts()).toEqual(["first question", "second question"]);
+    expect(useStore.getState().pendingSubmissions).toEqual([]);
+
+    turns[1]?.resolve();
+    await waitFor(
+      () => !useStore.getState().isLoading && turns.length === 2,
+      "queued turn to finish",
+    );
+
+    const finalMessages = roomMessages(room.id);
+    expect(finalMessages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "system",
+      "user",
+      "assistant",
+    ]);
+    expect(finalMessages[1]?.content).toBe("echo: first question");
+    expect(finalMessages[3]?.content).toBe("second question");
+    expect(finalMessages[4]?.content).toBe("echo: second question");
+  });
+
+  it("drains multiple queued submissions in FIFO order", async () => {
+    const { send, sentTexts, turns } = makeQueueApp();
+    useStore.getState().createRoom("FIFO test");
+
+    const turnA = send("one");
+    await waitFor(() => turns.length === 1, "first turn to start");
+    await send("two");
+    await send("three");
+    expect(useStore.getState().pendingSubmissions).toEqual(["two", "three"]);
+
+    turns[0]?.resolve();
+    await turnA;
+    await waitFor(() => turns.length === 2, "second turn to start");
+    turns[1]?.resolve();
+    await waitFor(() => turns.length === 3, "third turn to start");
+    turns[2]?.resolve();
+    await waitFor(
+      () => !useStore.getState().isLoading && turns.length === 3,
+      "all turns to finish",
+    );
+
+    expect(sentTexts()).toEqual(["one", "two", "three"]);
+    expect(useStore.getState().pendingSubmissions).toEqual([]);
+  });
+
+  it("discards queued submissions when the turn is aborted", async () => {
+    const { send, sentTexts, consume, turns } = makeQueueApp();
+    const room = useStore.getState().createRoom("Abort-discard test");
+
+    const turnA = send("running turn");
+    await waitFor(() => turns.length === 1, "turn to start");
+    await send("queued behind it");
+    expect(useStore.getState().pendingSubmissions).toEqual([
+      "queued behind it",
+    ]);
+
+    expect(consume("\x03")).toBe(true);
+    await turnA;
+
+    expect(useStore.getState().pendingSubmissions).toEqual([]);
+    const systemLines = roomMessages(room.id)
+      .filter((message) => message.role === "system")
+      .map((message) => message.content);
+    expect(systemLines).toContain("Turn aborted.");
+    expect(systemLines).toContain("Discarded 1 queued message.");
+
+    // Give a drain (if one were wrongly scheduled) a chance to fire.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(sentTexts()).toEqual(["running turn"]);
+  });
+
+  it("still runs slash commands immediately during a turn instead of queueing them", async () => {
+    const { send, turns } = makeQueueApp();
+    const room = useStore.getState().createRoom("Slash-during-turn test");
+
+    const turnA = send("busy turn");
+    await waitFor(() => turns.length === 1, "turn to start");
+
+    await send("/pwd");
+    expect(useStore.getState().pendingSubmissions).toEqual([]);
+    const lastSystem = roomMessages(room.id)
+      .filter((message) => message.role === "system")
+      .at(-1);
+    expect(lastSystem?.content).not.toContain("Queued");
+
+    turns[0]?.resolve();
+    await turnA;
+  });
+});


### PR DESCRIPTION
Batch PR for the remaining items of the #11294 eliza-code TUI opencode-parity punch-list. Refs #11294 (tracking issue stays open for the re-scan items — do not auto-close).

## State of the punch-list on current `develop` (verified before implementing)

The swarm had already landed most of the list. Verified item-by-item against the `origin/develop` tip (read the current source, not just the log):

| # | Item | Status | Where |
|---|------|--------|-------|
| 1 | Markdown rendering in ChatPane | **already done — skipped** | #11307 (`Markdown` component, `MARKDOWN_MIN_WIDTH = 40` plain fallback keeps the #11043 narrow guard) |
| 2 | Real token streaming + `Loader` | **already done — skipped** | #11453 (`onStreamChunk` wired in `agent-client.ts`; tui `Loader` replaces "Eliza typing…") |
| 3 | Cancel/interrupt a running turn | **residual fixed here** | #11445 shipped abort via `abortSignal` + Esc/Ctrl+C; **but** every keypress while the turn promise was pending was eaten by `abortCurrentTurn()`, so a provider that ignores the signal made the app unquittable. This PR: a keystroke after the abort was already requested falls through — **second Ctrl+C quits**, Esc reaches the composer. Idle Ctrl+C still quits on first press. |
| 4 | Live tool-call visibility (+N/-M) | **already done — skipped** | `ACTION_STARTED`/`ACTION_COMPLETED` events → `tool-transcript.ts` (`edit <path> +12/-3`, shell exit codes) |
| 5 | Enter during a turn → queue-and-send | **implemented here** | was a "turn already running" rejection notice; now buffers + sends on completion (details below) |
| 6 | Input-history recall | **already done — skipped** | #11459 (`editor.addToHistory` on submit) |
| 7 | ANSI-safe borders | **already done — skipped** | #11459 (`padEndVisible` / `padToVisibleWidth` via `visibleWidth`/`truncateToWidth`) |
| 8 | Scrollback PgUp/PgDn/Home/End + pinned viewport | **already done — skipped** | #11459 (pin while scrolled, jump on submit) |
| 9 | Multiline composer (min(lines, 6)) | **already done — skipped** | `COMPOSER_MAX_LINES = 6` + `windowAroundCursor` |
| 10 | Unknown-slash guard | **already done — skipped** | #11459 ("Unknown command: /x — type /help"; `//` escape; `1/2` still goes to the model) |
| 11 | `--version` from package.json | **already done — skipped** | #11459 (`cli-version.test.ts`) |
| — | `/copy` via OSC 52, status-bar model/provider | **already done — skipped** | #11479, #11476 |

## What this PR ships

### Item 5 — queue-and-send (opencode behavior)

- `store`: ephemeral `pendingSubmissions` FIFO + `enqueuePendingSubmission` / `takeNextPendingSubmission` / `clearPendingSubmissions` (never persisted to the session file).
- `App.handleSendMessage`: while a turn is in flight, a submission is buffered with a dim `Queued (n): <preview>` transcript notice instead of being rejected. When the turn completes (success **or** error) the next queued submission fires as its own turn, FIFO. **Abort discards the queue** ("stop everything") with a `Discarded n queued message(s).` line. Slash commands still execute immediately mid-turn.
- `ChatPane`: typing ahead during a turn keeps the composer visible (before, keystrokes went into an invisible editor behind the `Processing…` row); the loading row shows `• n queued`; the footer switches to `Enter: queue • Esc/Ctrl+C: abort` while loading. The #11043 narrow-terminal width guard holds on every new path (asserted at 39/43/47/60/80 cols).

### Item 3 residual — second Ctrl+C quits a wedged abort

`abortCurrentTurn()` returned `true` for as long as `activeTurnAbortController` existed, even after the signal was already aborted — a hung provider stream meant Ctrl+C could never quit. Now an Esc/Ctrl+C arriving after the abort request falls through to the normal handlers: second Ctrl+C hits the quit path, Esc reaches the composer.

## Evidence (rendered frames)

Terminal UI → screenshots/video rows: **N/A — terminal UI, rendered frames attached inline** (also committed to `.github/issue-evidence/11294-tui-queue-and-send-frames.txt` with the capture script). All frames were produced by driving the **real** `App` handlers (`handleSendMessage` / `consumeGlobalInput`) against a deferred-turn runtime stub and rendering the **real** `MainScreen` through `@elizaos/tui`'s `VirtualTerminal` at 80 cols (ANSI stripped for readability; capture script in the evidence dir, run with `bun` from `packages/examples/code`).

**Frame 1 — Enter during a running turn queues (transcript notice + loading-row count):**

```
┌────────────────────────────────────────────────────────────────────────────┐
│ Demo (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 … | ? │
└────────────────────────────────────────────────────────────────────────────┘
 Chat: Demo (3)
 You 17:08
   refactor the session store                                                
 Eliza 17:08
   
 Queued (1): also add tests for the edge cases please — sends when the
 current turn finishes. Esc/Ctrl+C aborts and discards the queue.
  ⠋ Processing (Esc/Ctrl+C abort)                                            











┌────────────────────────────────────────────────────────────────────────────┐
│ Processing... Esc/Ctrl+C abort • 1 queued                                  │
└────────────────────────────────────────────────────────────────────────────┘
Enter: queue • Esc/Ctrl+C: abort • PgUp/PgDn: scroll
```

**Frame 2 — typing ahead mid-turn keeps the composer visible:**

```
┌────────────────────────────────────────────────────────────────────────────┐
│ Demo (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 … | ? │
└────────────────────────────────────────────────────────────────────────────┘
 Chat: Demo (3)
 You 17:08
   refactor the session store                                                
 Eliza 17:08
   
 Queued (1): also add tests for the edge cases please — sends when the
 current turn finishes. Esc/Ctrl+C aborts and discards the queue.
  ⠋ Processing (Esc/Ctrl+C abort)                                            











┌────────────────────────────────────────────────────────────────────────────┐
│ >  and update the README
└────────────────────────────────────────────────────────────────────────────┘
Enter: queue • Esc/Ctrl+C: abort • PgUp/PgDn: scroll
```

**Frame 3 — Esc/Ctrl+C aborts the turn and discards the queue:**

```
┌────────────────────────────────────────────────────────────────────────────┐
│ Demo (1/1) | ...te/tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 | ? │
└────────────────────────────────────────────────────────────────────────────┘
 Chat: Demo (4)
 You 17:08
   refactor the session store                                                
 Queued (1): also add tests for the edge cases please — sends when the
 current turn finishes. Esc/Ctrl+C aborts and discards the queue.
 Turn aborted.
 Discarded 1 queued message.












┌────────────────────────────────────────────────────────────────────────────┐
│ >  
└────────────────────────────────────────────────────────────────────────────┘
Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help
```

**Frame 4 — queued submission fires as its own turn after the first completes:**

```
┌────────────────────────────────────────────────────────────────────────────┐
│ Demo 2 (1/1) | .../tmp/fix-11294/packages/examples/codeTasks r0 c0 f0 x0 | ? │
└────────────────────────────────────────────────────────────────────────────┘
 Chat: Demo 2 (5)
 You 17:08
   first task                                                                
 Eliza 17:08
   Done. Here's the summary for first task.                                  
 Queued (1): second task, queued — sends when the current turn finishes.
 Esc/Ctrl+C aborts and discards the queue.
 You 17:08
   second task, queued                                                       
 Eliza 17:08
   Done. Here's the summary for second task, queued.                         








┌────────────────────────────────────────────────────────────────────────────┐
│ >  
└────────────────────────────────────────────────────────────────────────────┘
Enter: send • PgUp/PgDn: scroll • Esc: clear • ?: help
```

The second-Ctrl+C-quits path can't be shown as a frame (it exits the app); it is proven by the wedged-runtime test below (`handleMessage` never settles and ignores the abort signal; first Ctrl+C consumed without quitting, Esc falls through, second Ctrl+C quits).

## Tests

New (10 tests, all driving the real `App`/`ChatPane`):

- `src/turn-queue.test.ts` — no concurrent send while a turn runs (asserted on the runtime's received messages, not UI strings); FIFO drain across 3 turns; discard-on-abort (plus a delayed re-check that nothing drains after abort); slash-command immediacy mid-turn; wedged-runtime second-Ctrl+C-quits + Esc fallthrough; idle first-press quit.
- `src/components/narrow-terminal.test.ts` — type-ahead composer visible mid-turn at 43 cols (and `Processing…` row gone); queued-count suffix on the loading row at 80 cols + width invariant at 43 cols.

Full package suite + gates (run on the rebased tip):

```
bun test src   → 57 pass, 0 fail (363 expect() calls, 15 files)   [was 49 on develop]
bun run typecheck (tsgo --noEmit) → clean
bunx biome check → clean on all touched files
```

No existing test was weakened; `packages/tui` untouched.

- Real-LLM trajectories: N/A — no agent/prompt/model behavior change; this is TUI input/turn-lifecycle plumbing, exercised by the real-App tests above.
- Backend/frontend logs: N/A — terminal UI; the rendered frames + transcript lines above are the observable surface.

Refs #11294

🤖 Generated with [Claude Code](https://claude.com/claude-code)