### PR TITLE
fix(ui/voice): listener-safety batch — talk-mode double-registration, swabble audioLevel leak, unguarded voice-settings fetches

### DIFF
--- a/packages/ui/src/components/settings/VoiceConfigView.audio-level-listener.test.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.audio-level-listener.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * FIX 2 — WakeWordSection audioLevel listener leak (VoiceConfigView.tsx).
+ *
+ * The mic-meter effect awaited `getSwabblePlugin().addListener("audioLevel")`
+ * inside a void async IIFE with no cancelled flag: when the section unmounted
+ * before the promise resolved, cleanup saw `handle === null` and the native
+ * listener leaked (kept firing into a dead meter ref forever). The fix mirrors
+ * useWakeController: a `cancelled` flag set in cleanup, and a post-await
+ * `if (cancelled) void h.remove()` on the freshly resolved handle.
+ */
+
+const h = vi.hoisted(() => {
+  const state = {
+    audioLevelResolvers: [] as Array<() => void>,
+    removeCalls: 0,
+  };
+  const swabblePlugin = {
+    getConfig: () => Promise.resolve({ config: null }),
+    isListening: () => Promise.resolve({ listening: false }),
+    updateConfig: () => Promise.resolve({}),
+    start: () => Promise.resolve({ started: true }),
+    stop: () => Promise.resolve({ stopped: true }),
+    addListener: (_event: string, _cb: (ev: unknown) => void) => {
+      // Deferred on purpose — the tests control when the native bridge
+      // "responds", so they can unmount while the call is still in flight.
+      return new Promise<{ remove: () => Promise<void> }>((resolve) => {
+        state.audioLevelResolvers.push(() =>
+          resolve({
+            remove: () => {
+              state.removeCalls += 1;
+              return Promise.resolve();
+            },
+          }),
+        );
+      });
+    },
+  };
+  return { state, swabblePlugin };
+});
+
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    sel: (value: Record<string, unknown>) => unknown,
+    // biome-ignore lint/suspicious/noExplicitAny: test shim over the app store
+  ): any =>
+    sel({
+      t: (_key: string, options?: { defaultValue?: string }) =>
+        options?.defaultValue ?? _key,
+      characterData: { name: "eliza" },
+      agentStatus: { agentName: "eliza" },
+    }),
+}));
+
+vi.mock("../../bridge/native-plugins", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../bridge/native-plugins")>()),
+  getSwabblePlugin: () => h.swabblePlugin as never,
+}));
+
+import { WakeWordSection } from "./VoiceConfigView";
+
+describe("WakeWordSection audioLevel listener lifecycle (FIX 2)", () => {
+  beforeEach(() => {
+    h.state.audioLevelResolvers.length = 0;
+    h.state.removeCalls = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("removes the native listener when addListener resolves after unmount", async () => {
+    const { unmount } = render(<WakeWordSection />);
+
+    // The meter effect has asked the native bridge for a listener…
+    await waitFor(() =>
+      expect(h.state.audioLevelResolvers.length).toBeGreaterThanOrEqual(1),
+    );
+
+    // …but the section unmounts before the bridge responds.
+    unmount();
+    expect(h.state.removeCalls).toBe(0);
+
+    // The late resolution must be removed immediately, not leaked.
+    for (const resolve of h.state.audioLevelResolvers.splice(0)) resolve();
+    await waitFor(() => expect(h.state.removeCalls).toBe(1));
+  });
+
+  it("removes a fully-registered listener on unmount (control case)", async () => {
+    const { unmount } = render(<WakeWordSection />);
+
+    await waitFor(() =>
+      expect(h.state.audioLevelResolvers.length).toBeGreaterThanOrEqual(1),
+    );
+    for (const resolve of h.state.audioLevelResolvers.splice(0)) resolve();
+    // Let the effect store the resolved handle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(h.state.removeCalls).toBe(0);
+
+    unmount();
+    await waitFor(() => expect(h.state.removeCalls).toBe(1));
+  });
+});

--- a/packages/ui/src/components/settings/VoiceConfigView.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.tsx
@@ -488,7 +488,9 @@ function ModelSizeButton({
   );
 }
 
-function WakeWordSection({
+// Exported for tests (VoiceConfigView.audio-level-listener.test.tsx); only
+// VoiceConfigView renders it in production.
+export function WakeWordSection({
   serverConfig,
 }: {
   serverConfig?: Partial<SwabbleConfig> | null;
@@ -543,9 +545,10 @@ function WakeWordSection({
 
   useEffect(() => {
     let handle: { remove: () => Promise<void> } | null = null;
+    let cancelled = false;
     void (async () => {
       try {
-        handle = await getSwabblePlugin().addListener(
+        const h = await getSwabblePlugin().addListener(
           "audioLevel",
           (evt: { level: number }) => {
             // Write the meter directly to the DOM to avoid a React re-render of
@@ -557,11 +560,20 @@ function WakeWordSection({
             }
           },
         );
+        // The effect may have been cleaned up while addListener was still in
+        // flight — the cleanup saw `handle === null`, so remove the native
+        // listener here or it leaks (same pattern as useWakeController).
+        if (cancelled) {
+          void h.remove();
+          return;
+        }
+        handle = h;
       } catch {
         // Not available
       }
     })();
     return () => {
+      cancelled = true;
       if (handle) void handle.remove();
     };
   }, []);

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -38,6 +38,10 @@ vi.mock("./VoiceProfileSection", () => ({
   VoiceProfileSection: () => null,
 }));
 
+import {
+  DEFAULT_VAD_AUTO_STOP_PREFS,
+  DEFAULT_VOICE_SECTION_PREFS,
+} from "./VoiceSection.helpers";
 import { VoiceSectionMount } from "./VoiceSectionMount";
 
 const WAKE_KEY = "eliza:voice:wake-word-enabled";
@@ -147,5 +151,61 @@ describe("VoiceSectionMount — continuous-chat localStorage mirror", () => {
     await waitFor(() =>
       expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe("vad-gated"),
     );
+  });
+});
+
+const VAD_KEY = "eliza:voice:vad-auto-stop";
+
+describe("VoiceSectionMount — mount fetch failures fall back to defaults (listener-safety batch)", () => {
+  const unhandled: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    unhandled.length = 0;
+    process.on("unhandledRejection", onUnhandledRejection);
+    clientMock.updateConfig.mockResolvedValue({});
+    // Both mount-time fetches blow up: previously each ran in a bare void
+    // async IIFE, so this surfaced as an unhandled rejection and left the
+    // vadAutoStop / continuous-chat localStorage mirrors unseeded.
+    clientMock.getConfig.mockRejectedValue(new Error("config fetch down"));
+    clientMock.getLocalInferenceDeviceTier.mockRejectedValue(
+      new Error("tier probe down"),
+    );
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    cleanup();
+  });
+
+  it("renders defaults, seeds the local mirrors, and raises no unhandled rejection", async () => {
+    render(<VoiceSectionMount />);
+
+    // Defaults still render: the section is usable without the server.
+    await screen.findByTestId("voice-section-wake-toggle");
+    await screen.findByTestId("voice-section-continuous-row");
+    expect(screen.queryByTestId("voice-section-persist-error")).toBeNull();
+
+    // The capture hot path reads ONLY these localStorage mirrors, so a failed
+    // config fetch must still seed them with the defaults.
+    await waitFor(() => {
+      expect(window.localStorage.getItem(CONTINUOUS_KEY)).toBe(
+        DEFAULT_VOICE_SECTION_PREFS.continuous,
+      );
+      expect(
+        JSON.parse(window.localStorage.getItem(VAD_KEY) ?? "null"),
+      ).toEqual(DEFAULT_VAD_AUTO_STOP_PREFS);
+    });
+
+    // Let both rejected fetches fully settle, then confirm neither escaped as
+    // an unhandled rejection.
+    await waitFor(() =>
+      expect(clientMock.getLocalInferenceDeviceTier).toHaveBeenCalled(),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(unhandled).toEqual([]);
   });
 });

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -100,7 +100,15 @@ export function VoiceSectionMount(): React.ReactElement {
   React.useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const config = await client.getConfig();
+      let config: Record<string, unknown> = {};
+      try {
+        config = await client.getConfig();
+      } catch {
+        // Config fetch failed (offline / server error) — fall back to the
+        // defaults readStoredVoicePrefs derives from an empty config so the
+        // localStorage mirrors below are still seeded (an unhandled rejection
+        // here would leave the capture hot path with no value at all).
+      }
       if (cancelled) return;
       const loaded = readStoredVoicePrefs(config);
       setPrefs(loaded);
@@ -120,10 +128,15 @@ export function VoiceSectionMount(): React.ReactElement {
   React.useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const result = await client.getLocalInferenceDeviceTier();
-      if (cancelled) return;
-      setTier(result.tier);
-      setTierSummary(result.reason);
+      try {
+        const result = await client.getLocalInferenceDeviceTier();
+        if (cancelled) return;
+        setTier(result.tier);
+        setTierSummary(result.reason);
+      } catch {
+        // Tier probe failed — keep the null-tier default (VoiceSection renders
+        // without the tier banner) instead of surfacing an unhandled rejection.
+      }
     })();
     return () => {
       cancelled = true;

--- a/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.talkmode-listeners.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * FIX 1 — ensureTalkModeListeners re-entrancy (useVoiceChat.ts).
+ *
+ * talkModeHandlesRef is only assigned after all three `addListener` awaits
+ * resolve, so two overlapping ensureTalkModeListeners calls would both pass
+ * the `handles.length > 0` guard and register SIX native listeners — the
+ * first three leaked forever (double transcripts, un-removable). The fix
+ * serializes registration through an in-flight-promise ref
+ * (talkModeListenersRegistrationRef); this suite drives two concurrent
+ * startListening calls against a deferred fake TalkMode plugin and asserts
+ * exactly three listeners are registered and all of them are removable.
+ */
+
+const h = vi.hoisted(() => {
+  const state = {
+    /** Event name of every addListener call, in order. */
+    addListenerEvents: [] as string[],
+    /** Deferred resolvers — the test releases addListener results manually. */
+    resolvers: [] as Array<() => void>,
+    /** Total remove() calls across all handles ever returned. */
+    removeCalls: 0,
+  };
+  const talkModePlugin = {
+    addListener: (event: string, _cb: (ev: unknown) => void) => {
+      state.addListenerEvents.push(event);
+      return new Promise<{ remove: () => Promise<void> }>((resolve) => {
+        state.resolvers.push(() =>
+          resolve({
+            remove: () => {
+              state.removeCalls += 1;
+              return Promise.resolve();
+            },
+          }),
+        );
+      });
+    },
+    checkPermissions: () =>
+      Promise.resolve({
+        microphone: "granted",
+        speechRecognition: "granted",
+      }),
+    requestPermissions: () =>
+      Promise.resolve({
+        microphone: "granted",
+        speechRecognition: "granted",
+      }),
+    start: () => Promise.resolve({ started: true }),
+    stop: () => Promise.resolve(),
+  };
+  return { state, talkModePlugin };
+});
+
+// Make shouldPreferNativeTalkMode() true in jsdom (no Capacitor native
+// platform here) by pretending to be an Electrobun renderer.
+vi.mock("../bridge/electrobun-rpc", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../bridge/electrobun-rpc")>()),
+  getElectrobunRendererRpc: () => ({}) as never,
+}));
+
+vi.mock("../bridge/native-plugins", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../bridge/native-plugins")>()),
+  getTalkModePlugin: () => h.talkModePlugin as never,
+}));
+
+import { useVoiceChat } from "./useVoiceChat";
+
+/** Release deferred addListener resolutions until no new ones appear. */
+async function releaseAllListenerRegistrations(): Promise<void> {
+  // Enough rounds to drain even a (buggy) double-registration pass, so a
+  // regression fails on the count assertion instead of hanging the test.
+  for (let round = 0; round < 12; round += 1) {
+    for (const resolve of h.state.resolvers.splice(0)) resolve();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+describe("useVoiceChat talk-mode listener registration (FIX 1)", () => {
+  beforeEach(() => {
+    h.state.addListenerEvents.length = 0;
+    h.state.resolvers.length = 0;
+    h.state.removeCalls = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("serializes concurrent registration passes — exactly three listeners, all removable", async () => {
+    const { result, unmount } = renderHook(() =>
+      useVoiceChat({ onTranscript: vi.fn() }),
+    );
+
+    // Two overlapping starts: both pass the enabledRef guard (neither has
+    // finished), so both reach ensureTalkModeListeners while the first
+    // registration pass is still blocked on its deferred addListener.
+    const starts: Array<Promise<void>> = [];
+    act(() => {
+      starts.push(result.current.startListening("push-to-talk"));
+      starts.push(result.current.startListening("push-to-talk"));
+    });
+
+    await waitFor(() =>
+      expect(h.state.addListenerEvents.length).toBeGreaterThanOrEqual(1),
+    );
+    // Give the second caller ample time to (incorrectly) begin its own pass.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    // Only ONE pass may be in flight: a single pending "transcript"
+    // registration. Without the in-flight ref this is already
+    // ["transcript", "transcript"].
+    expect(h.state.addListenerEvents).toEqual(["transcript"]);
+
+    await act(async () => {
+      await releaseAllListenerRegistrations();
+      await Promise.all(starts);
+    });
+
+    // Exactly three listeners — not six.
+    expect(h.state.addListenerEvents).toEqual([
+      "transcript",
+      "error",
+      "stateChange",
+    ]);
+    expect(result.current.isListening).toBe(true);
+    expect(result.current.captureMode).toBe("push-to-talk");
+
+    // A later start with listeners already registered must not re-register.
+    await act(async () => {
+      await result.current.stopListening();
+    });
+    await act(async () => {
+      const again = result.current.startListening("push-to-talk");
+      await releaseAllListenerRegistrations();
+      await again;
+    });
+    expect(h.state.addListenerEvents).toEqual([
+      "transcript",
+      "error",
+      "stateChange",
+    ]);
+
+    // Every registered handle is removable via removeTalkModeListeners
+    // (unmount cleanup) — nothing leaked outside talkModeHandlesRef.
+    unmount();
+    await waitFor(() => expect(h.state.removeCalls).toBe(3));
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -267,6 +267,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     "browser" | "local-inference" | "talkmode" | null
   >(null);
   const talkModeHandlesRef = useRef<PluginListenerHandle[]>([]);
+  // In-flight talk-mode listener registration. talkModeHandlesRef is only
+  // assigned after all three addListener awaits resolve, so two overlapping
+  // ensureTalkModeListeners calls would otherwise both pass the length guard
+  // and register six listeners (the first three leaked, transcripts doubled).
+  const talkModeListenersRegistrationRef = useRef<Promise<void> | null>(null);
   const synthRef = useRef<SpeechSynthesis | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const playbackFrameTapRef = useRef<PlaybackFrameTap | null>(null);
@@ -691,60 +696,79 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   const ensureTalkModeListeners = useCallback(async () => {
     if (talkModeHandlesRef.current.length > 0) return;
+    // A registration pass is already in flight — await it instead of starting
+    // a second one (which would double-register every listener).
+    const pending = talkModeListenersRegistrationRef.current;
+    if (pending) return pending;
 
-    const talkMode = getTalkModePlugin();
+    const registration = (async () => {
+      const talkMode = getTalkModePlugin();
 
-    const transcriptHandle = await talkMode.addListener(
-      "transcript",
-      (event: TalkModeTranscriptEvent) => {
-        const typedEvent = event as TalkModeTranscriptEvent & {
-          mode?: unknown;
-          speaker?: VoiceSpeakerMetadata;
-          turn?: Partial<VoiceTurn>;
-          source?: string;
-          confidence?: number;
-          metadata?: Record<string, unknown>;
-        };
-        applyTranscriptUpdate(event.transcript ?? "", event.isFinal === true, {
-          mode: normalizeActiveVoiceSessionMode(typedEvent.mode) ?? undefined,
-          speaker: typedEvent.speaker,
-          source: typedEvent.source,
-          confidence: typedEvent.confidence,
-          turn: typedEvent.turn,
-          metadata: typedEvent.metadata,
-        });
-      },
-    );
-    const errorHandle = await talkMode.addListener(
-      "error",
-      (event: TalkModeErrorEvent) => {
-        if (
-          sttBackendRef.current === "talkmode" ||
-          event.code === "not-allowed" ||
-          event.code === "service-not-allowed"
-        ) {
-          resetListeningState();
+      const transcriptHandle = await talkMode.addListener(
+        "transcript",
+        (event: TalkModeTranscriptEvent) => {
+          const typedEvent = event as TalkModeTranscriptEvent & {
+            mode?: unknown;
+            speaker?: VoiceSpeakerMetadata;
+            turn?: Partial<VoiceTurn>;
+            source?: string;
+            confidence?: number;
+            metadata?: Record<string, unknown>;
+          };
+          applyTranscriptUpdate(
+            event.transcript ?? "",
+            event.isFinal === true,
+            {
+              mode:
+                normalizeActiveVoiceSessionMode(typedEvent.mode) ?? undefined,
+              speaker: typedEvent.speaker,
+              source: typedEvent.source,
+              confidence: typedEvent.confidence,
+              turn: typedEvent.turn,
+              metadata: typedEvent.metadata,
+            },
+          );
+        },
+      );
+      const errorHandle = await talkMode.addListener(
+        "error",
+        (event: TalkModeErrorEvent) => {
           if (
+            sttBackendRef.current === "talkmode" ||
             event.code === "not-allowed" ||
             event.code === "service-not-allowed"
           ) {
-            setSupported(false);
+            resetListeningState();
+            if (
+              event.code === "not-allowed" ||
+              event.code === "service-not-allowed"
+            ) {
+              setSupported(false);
+            }
           }
-        }
-      },
-    );
-    const stateHandle = await talkMode.addListener(
-      "stateChange",
-      (event: TalkModeStateEvent) => {
-        if (
-          (event.state === "error" || event.state === "idle") &&
-          sttBackendRef.current === "talkmode"
-        ) {
-          resetListeningState();
-        }
-      },
-    );
-    talkModeHandlesRef.current = [transcriptHandle, errorHandle, stateHandle];
+        },
+      );
+      const stateHandle = await talkMode.addListener(
+        "stateChange",
+        (event: TalkModeStateEvent) => {
+          if (
+            (event.state === "error" || event.state === "idle") &&
+            sttBackendRef.current === "talkmode"
+          ) {
+            resetListeningState();
+          }
+        },
+      );
+      talkModeHandlesRef.current = [transcriptHandle, errorHandle, stateHandle];
+    })();
+    // Stored synchronously (before the first await inside the registration
+    // yields) so a concurrent caller reuses this pass instead of re-adding.
+    talkModeListenersRegistrationRef.current = registration;
+    try {
+      await registration;
+    } finally {
+      talkModeListenersRegistrationRef.current = null;
+    }
   }, [applyTranscriptUpdate, resetListeningState]);
 
   const transcribeLocalInferenceAudio = useCallback(


### PR DESCRIPTION
Closes #11576. Three listener-safety bugs in the voice UI (`@elizaos/ui`), each with a jsdom + @testing-library test in the style of the existing `useVoiceChat.*.test.tsx` siblings, and each mutation-verified (fix reverted → test fails → fix restored).

## Fix 1 — `useVoiceChat.ts`: `ensureTalkModeListeners` re-entrancy (code in fdb900de64, test in this commit)
`talkModeHandlesRef` is only assigned after all three `addListener` awaits resolve, so two overlapping calls both passed the length guard and registered SIX native listeners — the first three leaked forever (doubled transcripts, un-removable). The committed fix serializes registration through an in-flight-promise ref (`talkModeListenersRegistrationRef`, stored synchronously before the first await yields).

**Test** (`useVoiceChat.talkmode-listeners.test.tsx`): drives two concurrent `startListening("push-to-talk")` calls through the real hook path against a deferred fake TalkMode plugin (native preference forced via mocked `getElectrobunRendererRpc`). Asserts a single in-flight pass (`["transcript"]`, not `["transcript","transcript"]`), exactly **3** `addListener` calls after release (not 6), no re-registration on a later sequential start, and all 3 handles removed on unmount.
**Mutation:** guard disabled → `AssertionError: expected [ 'transcript', 'transcript' ] to deeply equal [ 'transcript' ]`. Restored → green.

## Fix 2 — `VoiceConfigView.tsx` (`WakeWordSection`): audioLevel listener leaked on unmount-before-resolve
`handle = await getSwabblePlugin().addListener("audioLevel", …)` ran in a void async IIFE with no cancelled flag; unmounting while the bridge call was in flight left cleanup seeing `handle === null` → the native listener leaked, firing tens-of-Hz mic frames into a dead ref forever. Now mirrors the correct sibling `useWakeController.ts:176-190`: `cancelled` flag set in cleanup + post-await `if (cancelled) { void h.remove(); return; }`. `WakeWordSection` gains a named export for the test (comment marks it test-only).

**Test** (`VoiceConfigView.audio-level-listener.test.tsx`): deferred fake Swabble plugin; render → unmount before `addListener` resolves → resolve → `remove()` called exactly once. Control case: fully-registered handle removed on unmount.
**Mutation:** guard removed → `expected +0 to be 1` (leak reproduced). Restored → green.

## Fix 3 — `VoiceSectionMount.tsx`: unguarded mount fetches → unhandled rejection + unseeded voice prefs
Both mount effects (`await client.getConfig()`, `await client.getLocalInferenceDeviceTier()`) ran in bare void async IIFEs — any failure (offline/server error) surfaced as an unhandled rejection AND left the `vadAutoStop` / `continuousChatMode` localStorage mirrors unseeded (the capture hot path reads ONLY those mirrors). Each awaited call is now try/caught: `getConfig` failure falls back to `readStoredVoicePrefs({})` defaults so the mirrors are still seeded; tier failure keeps the null-tier default. Cancelled guards kept.

**Test** (appended to `VoiceSectionMount.test.tsx`, reusing its existing client-mock harness): both fetches `mockRejected` → section renders defaults (wake toggle + continuous row, no persist-error alert), `eliza:voice:continuous-chat-mode` seeded `"off"`, `eliza:voice:vad-auto-stop` seeded with `DEFAULT_VAD_AUTO_STOP_PREFS`, and a `process.on("unhandledRejection")` capture stays empty after settle.
**Mutation:** try/catches stripped → `expected null to be 'off'` (mirror never seeded). Restored → green; the 5 pre-existing tests in the file still pass.

## Evidence
- Tests: `bunx vitest run` over the 3 files → **3 files / 9 tests passed** on the final tree.
- Mutation checks: all 3 documented above (revert → red, restore → green).
- Lint: `biome check --write` clean on all 6 touched files.
- Typecheck: `bun run --cwd packages/ui typecheck` — only the pre-existing, unrelated `spatial/__e2e__/immersive-fixture.ts` TS2307 (`iwer`) failure; nothing in touched files.
- Screenshots/video: **N/A** — no rendered-pixel change; all three fixes are unmount/error-path lifecycle behavior with no reachable visual state (the failure modes are a leaked invisible native listener, a console unhandled-rejection, and unseeded localStorage), covered by the component tests above.
- Real-LLM trajectories: **N/A** — no agent/action/provider/prompt/model behavior touched; pure client-side listener lifecycle.
- Native device capture: **N/A** — the native bridge boundary is exercised via the plugin getters the production code itself calls (`getTalkModePlugin`/`getSwabblePlugin`), with controlled promise timing that a real device cannot deterministically reproduce (unmount racing an in-flight `addListener`).

Touched files (only): `packages/ui/src/hooks/useVoiceChat.ts` (fix 1, pre-committed), `useVoiceChat.talkmode-listeners.test.tsx` (new), `components/settings/VoiceConfigView.tsx`, `VoiceConfigView.audio-level-listener.test.tsx` (new), `VoiceSectionMount.tsx`, `VoiceSectionMount.test.tsx`.

[cloud-security]
---
**Authored end-to-end by a Fable-5 agent** (edits + tests + mutation-checks + push). Independently re-verified by the main loop: the 6-file PR diff is clean (merge-base), all **9 tests pass** on a fresh `vitest run`, and fix #1's mutation was reproduced independently (disable the in-flight guard → `['transcript','transcript'] != ['transcript']`, restore → green). — `[phone-ui]`
