### PR TITLE
fix(orchestrator): sanitize sub-agent completion relay — swarm synthesis raw finalText, exec-record JSON, unborn-HEAD change-set (#11578)

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -45,6 +45,46 @@ describe("handleSwarmSynthesis", () => {
     expect(routed).toEqual(["https://example.com/apps/breath-ring/"]);
   });
 
+  it("strips captured tool-output envelopes from the completionSummary, preserving evidence URLs (#11578)", async () => {
+    const routed: string[] = [];
+
+    await handleSwarmSynthesis(
+      { runtime },
+      {
+        tasks: [
+          {
+            sessionId: "pty-leak",
+            label: "app",
+            agentType: "codex",
+            originalTask: "build a small app",
+            // finalText carrying the orchestrator's own envelope block; this is
+            // the round-3 raw-transcript leak in issue elizaOS/eliza#11578.
+            completionSummary:
+              "Deployed the app.\n" +
+              "[tool output: bash]\n$ npm run build\n… raw build log …\n[/tool output]\n" +
+              "Live at https://example.com/apps/leaky/",
+            workdir: "/workspace/shared-apps",
+          },
+        ],
+        total: 1,
+        completed: 1,
+        stopped: 0,
+        errored: 0,
+      },
+      async (text) => {
+        routed.push(text);
+      },
+    );
+
+    expect(routed).toHaveLength(1);
+    const text = routed[0];
+    expect(text).toContain("Deployed the app.");
+    expect(text).toContain("https://example.com/apps/leaky/");
+    expect(text).not.toContain("[tool output:");
+    expect(text).not.toContain("[/tool output]");
+    expect(text).not.toContain("npm run build");
+  });
+
   it("uses the child completion as the visible answer when validation passes", async () => {
     const routed: string[] = [];
 

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -16,6 +16,7 @@ import {
   stringToUuid,
   type UUID,
 } from "@elizaos/core";
+import { sanitizeCompletionRelay } from "@elizaos/plugin-agent-orchestrator";
 import { generateChatResponse as generateChatResponseFromChatRoutes } from "./chat-routes.ts";
 import { resolveClientChatAdminEntityId } from "./client-chat-admin.ts";
 import { beginDelivery } from "./delivery-dedupe.ts";
@@ -486,6 +487,13 @@ async function buildTaskResultLine(task: {
   workdir?: string;
 }): Promise<string> {
   const validationSummary = task.validationSummary?.trim();
+  // Defense-in-depth for issue elizaOS/eliza#11578: strip any captured
+  // `[tool output: …]` envelope blocks from the completionSummary before it is
+  // relayed VERBATIM to the connector. The coordinator now sanitizes at the
+  // source, but payloads can arrive from other coordinator builds, so we strip
+  // again here. sanitizeCompletionRelay preserves prose and plain URLs, and
+  // preserveEvidenceUrls still re-appends any evidence URL below.
+  const completionSummary = sanitizeCompletionRelay(task.completionSummary);
   // Claude Code persists final assistant messages in per-workdir jsonl. That
   // path is Claude-specific; for Codex and other agents the coordinator's
   // completionSummary is already the captured user-facing output.
@@ -497,10 +505,10 @@ async function buildTaskResultLine(task: {
         : finalText;
     }
   }
-  if (task.completionSummary) {
+  if (completionSummary) {
     return validationSummary
-      ? preserveEvidenceUrls(task.completionSummary, validationSummary)
-      : task.completionSummary;
+      ? preserveEvidenceUrls(completionSummary, validationSummary)
+      : completionSummary;
   }
   if (validationSummary) return validationSummary;
   const portMatch = task.originalTask.match(/port\s+(\d+)/i);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-normalize-tool-output.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-normalize-tool-output.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for normalizeToolOutput's exec-record handling (issue #11578 FIX B).
+ *
+ * Codex emits exec records ({ call_id, command, exit_code, stdout, … }). The
+ * old fallback JSON.stringify'd them into the captured `[tool output: …]`
+ * envelope, leaking the raw record to the user. normalizeToolOutput now renders
+ * a compact `$ <command> → exit <code>` one-liner for any record carrying
+ * call_id + command, and NEVER JSON.stringify's such a record.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeToolOutput } from "../../src/services/acp-service.ts";
+
+describe("normalizeToolOutput — exec records (#11578)", () => {
+  it("renders a one-liner for a codex exec record (array command)", () => {
+    const record = {
+      call_id: "call_abc",
+      turn_id: "turn_1",
+      process_id: 42,
+      command: ["bash", "-lc", "npm run build"],
+      exit_code: 0,
+      duration: 1234,
+      parsed_cmd: [],
+    };
+    const out = normalizeToolOutput(record);
+    expect(out).toBe("$ bash -lc npm run build → exit 0");
+    expect(out).not.toContain("call_id");
+    expect(out).not.toContain("{");
+  });
+
+  it("renders a one-liner for a string command with non-zero exit", () => {
+    const record = { call_id: "c1", command: "ls /nope", exit_code: 2 };
+    expect(normalizeToolOutput(record)).toBe("$ ls /nope → exit 2");
+  });
+
+  it("appends a capped stdout/stderr tail when present", () => {
+    const record = {
+      call_id: "c2",
+      command: "echo hi",
+      exit_code: 0,
+      stdout: "hi there",
+    };
+    const out = normalizeToolOutput(record);
+    expect(out).toBe("$ echo hi → exit 0\nhi there");
+  });
+
+  it("caps a long stdout tail to 200 chars", () => {
+    const record = {
+      call_id: "c3",
+      command: "cat big",
+      exit_code: 0,
+      stdout: "A".repeat(500),
+    };
+    const out = normalizeToolOutput(record);
+    const tail = out.split("\n")[1];
+    expect(tail.length).toBe(201); // 200 chars + ellipsis
+    expect(tail.endsWith("…")).toBe(true);
+  });
+
+  it("parses a STRINGIFIED exec record back to a one-liner", () => {
+    const stringified = JSON.stringify({
+      call_id: "c4",
+      command: ["git", "status"],
+      exit_code: 0,
+    });
+    expect(normalizeToolOutput(stringified)).toBe("$ git status → exit 0");
+  });
+
+  it("does NOT treat a plain object without call_id as an exec record", () => {
+    const record = { command: "echo hi", exit_code: 0 };
+    // No call_id → falls through to the normal extract/stringify path.
+    const out = normalizeToolOutput(record);
+    expect(out).not.toContain("→ exit");
+  });
+
+  it("leaves ordinary string output untouched", () => {
+    expect(normalizeToolOutput("just some text")).toBe("just some text");
+  });
+
+  it("renders `?` exit when exit_code is missing", () => {
+    const record = { call_id: "c5", command: "true" };
+    expect(normalizeToolOutput(record)).toBe("$ true → exit ?");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -459,6 +459,62 @@ describe("SwarmCoordinatorService", () => {
     });
     await coordinator.stop();
   });
+
+  it("sanitizes captured tool-output envelopes out of completionSummary (#11578)", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: { label: "leaky-task", originRoomId: "origin-room-leak" },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // The ACP turn finalText carries the orchestrator's own captured
+    // `[tool output: …]` envelope blocks; they must NOT reach the payload.
+    const leakyResponse =
+      "Deployed the site.\n" +
+      "[tool output: bash]\n$ npm run build\n… lots of raw log …\n[/tool output]\n" +
+      "Live at https://example.com/app/";
+    acp.emit("sess-leak", "task_complete", { response: leakyResponse });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    const summary = fired.mock.calls[0][0].tasks[0].completionSummary;
+    expect(summary).toContain("Deployed the site.");
+    expect(summary).toContain("https://example.com/app/");
+    expect(summary).not.toContain("[tool output:");
+    expect(summary).not.toContain("[/tool output]");
+    expect(summary).not.toContain("npm run build");
+    await coordinator.stop();
+  });
+
+  it("falls back to the default summary when the response was ONLY tool output (#11578)", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: { label: "dump-only", originRoomId: "origin-room-dump" },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-dump", "task_complete", {
+      response: "[tool output: bash]\nonly a raw dump\n[/tool output]",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0].tasks[0].completionSummary).toBe(
+      "Task completed.",
+    );
+    await coordinator.stop();
+  });
+
   it("caches session metadata per session so streaming events do not re-hit getSession", async () => {
     const acp = makeAcpStub({
       agentType: "codex",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the shared relay sanitizer (issue elizaOS/eliza#11578).
+ *
+ * The swarm-synthesis relay path posted sub-agent finalText VERBATIM to the
+ * connector, leaking the orchestrator's own `[tool output: …]` envelope blocks
+ * to the user. This module centralizes stripping them; these tests pin the
+ * robustness cases (empty titles, unterminated blocks, multiple blocks, long
+ * remnants) that the router-private copy did not cover.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_RELAY_CHARS,
+  elideLongBlocks,
+  sanitizeCompletionRelay,
+  stripToolTranscript,
+} from "../../src/services/transcript-sanitizer.ts";
+
+describe("stripToolTranscript", () => {
+  it("strips a normal well-formed envelope block, keeping prose", () => {
+    const input =
+      "Done building the app.\n" +
+      "[tool output: bash]\n$ ls\nfile.txt\n[/tool output]\n" +
+      "All set.";
+    const out = stripToolTranscript(input);
+    expect(out).toContain("Done building the app.");
+    expect(out).toContain("All set.");
+    expect(out).not.toContain("[tool output:");
+    expect(out).not.toContain("[/tool output]");
+    expect(out).not.toContain("file.txt");
+  });
+
+  it("strips an empty-title envelope block", () => {
+    const input =
+      'prefix\n[tool output: ""]\nsecret body\n[/tool output]\nsuffix';
+    const out = stripToolTranscript(input);
+    expect(out).toContain("prefix");
+    expect(out).toContain("suffix");
+    expect(out).not.toContain("secret body");
+    expect(out).not.toContain("tool output");
+  });
+
+  it("strips a bare-colon empty-title envelope block", () => {
+    const input = "a\n[tool output:]\nbody\n[/tool output]\nb";
+    const out = stripToolTranscript(input);
+    expect(out).toBe("a\n\nb");
+  });
+
+  it("strips MULTIPLE envelope blocks", () => {
+    const input =
+      "start\n" +
+      "[tool output: one]\naaa\n[/tool output]\n" +
+      "middle\n" +
+      "[tool output: two]\nbbb\n[/tool output]\n" +
+      "end";
+    const out = stripToolTranscript(input);
+    expect(out).toContain("start");
+    expect(out).toContain("middle");
+    expect(out).toContain("end");
+    expect(out).not.toContain("aaa");
+    expect(out).not.toContain("bbb");
+    expect(out).not.toContain("[tool output:");
+  });
+
+  it("strips an UNTERMINATED trailing block to end of string", () => {
+    const input =
+      "here is the result\n[tool output: truncated]\nhalf a body that never closes";
+    const out = stripToolTranscript(input);
+    expect(out).toBe("here is the result");
+    expect(out).not.toContain("[tool output:");
+    expect(out).not.toContain("half a body");
+  });
+
+  it("preserves prose and plain URLs", () => {
+    const input =
+      "PR opened: https://github.com/elizaos/eliza/pull/123 — see the diff.";
+    const out = stripToolTranscript(input);
+    expect(out).toBe(input.trim());
+    expect(out).toContain("https://github.com/elizaos/eliza/pull/123");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripToolTranscript("")).toBe("");
+  });
+});
+
+describe("elideLongBlocks", () => {
+  it("passes short text through unchanged", () => {
+    expect(elideLongBlocks("short", 2000)).toBe("short");
+  });
+
+  it("elides a remnant over the cap into a length marker", () => {
+    const big = "x".repeat(DEFAULT_MAX_RELAY_CHARS + 500);
+    const out = elideLongBlocks(big);
+    expect(out).toBe(`[output elided — ${big.length} chars]`);
+    expect(out.length).toBeLessThan(60);
+  });
+
+  it("keeps text exactly at the cap", () => {
+    const exact = "y".repeat(DEFAULT_MAX_RELAY_CHARS);
+    expect(elideLongBlocks(exact)).toBe(exact);
+  });
+});
+
+describe("sanitizeCompletionRelay", () => {
+  it("strips envelopes then elides an oversized remnant", () => {
+    const remnant = "z".repeat(DEFAULT_MAX_RELAY_CHARS + 100);
+    const input = `${remnant}\n[tool output: t]\nbody\n[/tool output]`;
+    const out = sanitizeCompletionRelay(input);
+    expect(out).toBe(`[output elided — ${remnant.length} chars]`);
+  });
+
+  it("returns empty when the whole payload was tool output", () => {
+    const input = "[tool output: t]\nonly a tool dump\n[/tool output]";
+    expect(sanitizeCompletionRelay(input)).toBe("");
+  });
+
+  it("returns empty for nullish input", () => {
+    expect(sanitizeCompletionRelay(undefined)).toBe("");
+    expect(sanitizeCompletionRelay(null)).toBe("");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
@@ -246,3 +246,61 @@ describe("workspace-diff — real git capture", () => {
     ).toContain("UNVERIFIED: missing missing.txt");
   });
 });
+
+// FIX C (issue elizaOS/eliza#11578): a fresh repo with zero commits has an
+// UNBORN HEAD, so `git diff HEAD` throws and the caller fell back to the weak
+// narration path (rounds 1/2 never produced a change set). Diffing against the
+// empty-tree hash surfaces the whole working tree; untracked files (shell
+// writes) are also merged so scaffolding shows up without tool-path tracking.
+describe("workspace-diff — unborn HEAD + untracked (#11578)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wsdiff-unborn-"));
+    git(dir, ["init", "-q"]);
+    git(dir, ["config", "user.email", "t@t.t"]);
+    git(dir, ["config", "user.name", "t"]);
+    // NO initial commit — HEAD is unborn.
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns a change set on an unborn HEAD for a shell-written file", async () => {
+    writeFileSync(join(dir, "app.js"), "console.log('hi');\n");
+    const cs = await captureChangeSet(dir);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("app.js");
+  });
+
+  it("includes several untracked files scaffolded on an unborn HEAD", async () => {
+    writeFileSync(join(dir, "index.html"), "<h1>hi</h1>\n");
+    writeFileSync(join(dir, "style.css"), "body{}\n");
+    writeFileSync(join(dir, "app.js"), "console.log(1);\n");
+    const cs = await captureChangeSet(dir);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toEqual(
+      expect.arrayContaining(["index.html", "style.css", "app.js"]),
+    );
+  });
+
+  it("does NOT auto-scoop untracked clutter once HEAD is born (invariant preserved)", async () => {
+    writeFileSync(join(dir, "seed.txt"), "seed\n");
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-q", "-m", "seed"]);
+    // HEAD is now born. A stray untracked file with NO tool path must NOT be
+    // scooped up — the born-HEAD path stays session-scoped (tracked + toolPaths).
+    writeFileSync(join(dir, "stray.txt"), "clutter\n");
+    const cs = await captureChangeSet(dir);
+    expect(cs).toBeUndefined();
+    // But a tool-path-tracked write on born HEAD still surfaces.
+    const cs2 = await captureChangeSet(dir, undefined, ["stray.txt"]);
+    expect(cs2?.changedFiles).toContain("stray.txt");
+  });
+
+  it("returns undefined on an unborn HEAD with no files", async () => {
+    const cs = await captureChangeSet(dir);
+    expect(cs).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -33,6 +33,14 @@ import {
 // side-effect of evaluating that module. Without this the entire
 // `/api/coding-agents/*` surface 404s on the node bundle.
 export { codingAgentRouteRegistration } from "./register-routes.js";
+// Shared relay sanitizer (issue elizaOS/eliza#11578). Re-exported from the
+// package root so packages/agent's swarm-synthesis path can strip captured
+// tool-output envelopes with the SAME implementation the sub-agent router uses.
+export {
+  elideLongBlocks,
+  sanitizeCompletionRelay,
+  stripToolTranscript,
+} from "./services/transcript-sanitizer.js";
 
 import {
   createTerminalUnsupportedTasksAction,

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2956,15 +2956,66 @@ function captureTerminalToolOutput(
   return `[tool output: ${title}]\n${truncated}\n${TOOL_OUTPUT_END_MARKER}`;
 }
 
-function normalizeToolOutput(rawOutput: unknown): string {
+// Exported for unit coverage of the exec-record one-liner path (issue #11578).
+export function normalizeToolOutput(rawOutput: unknown): string {
   if (typeof rawOutput === "string") {
     const trimmed = rawOutput.trim();
     const parsed = parseJsonRecord(trimmed);
+    // A stringified exec record (Codex) parsed back to an object: render the
+    // one-liner instead of echoing the raw JSON string (issue #11578 FIX B).
+    const execLine = execRecordOneLiner(parsed);
+    if (execLine) return execLine;
     return extractToolOutputText(parsed)?.trim() || trimmed;
   }
   if (rawOutput === undefined || rawOutput === null) return "";
+  // Codex exec records (keys: call_id, command, exit_code, …) reached this
+  // fallback and got JSON.stringify'd into the envelope, leaking the raw record
+  // to the user (issue elizaOS/eliza#11578 FIX B). Detect the shape and render
+  // a compact `$ <command> → exit <code>` one-liner instead; NEVER stringify a
+  // record carrying call_id.
+  const execLine = execRecordOneLiner(rawOutput);
+  if (execLine) return execLine;
   const extracted = extractToolOutputText(rawOutput);
   return extracted?.trim() || JSON.stringify(rawOutput).trim();
+}
+
+/**
+ * Render a Codex exec record (`{ call_id, command, exit_code, … }`) as a compact
+ * one-liner: `$ <command joined> → exit <exit_code>` plus a capped stdout/stderr
+ * tail when present. Returns undefined for anything that is not an exec record
+ * (must have BOTH call_id AND command), so non-record output is unaffected.
+ */
+function execRecordOneLiner(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const hasCallId = "call_id" in record && record.call_id != null;
+  const rawCommand = record.command;
+  if (!hasCallId || rawCommand == null) return undefined;
+
+  const command = Array.isArray(rawCommand)
+    ? rawCommand.map((part) => String(part)).join(" ")
+    : String(rawCommand);
+  const exitCode =
+    typeof record.exit_code === "number" || typeof record.exit_code === "string"
+      ? String(record.exit_code)
+      : "?";
+  let line = `$ ${command.trim()} → exit ${exitCode}`;
+
+  const tail = execRecordOutputTail(record);
+  if (tail) line = `${line}\n${tail}`;
+  return line;
+}
+
+/** Extract a capped (≤200 char) stdout/stderr tail from an exec record. */
+function execRecordOutputTail(record: Record<string, unknown>): string {
+  const candidates = [record.stdout, record.stderr, record.output]
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  if (candidates.length === 0) return "";
+  const joined = candidates.join("\n").trim();
+  return joined.length > 200 ? `${joined.slice(0, 200)}…` : joined;
 }
 
 function parseJsonRecord(text: string): Record<string, unknown> | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -32,6 +32,7 @@ import {
   deliverScreenshots,
 } from "./screenshot-delivery.js";
 import { SsrfBlockedError, safeFetch } from "./ssrf-guard.js";
+import { stripToolTranscript } from "./transcript-sanitizer.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
 import {
   captureChangeSet,
@@ -2421,18 +2422,13 @@ function normalizeFinishReason(
   }
 }
 
-function stripToolTranscript(text: string): string {
-  // Remove the orchestrator's OWN captured tool-output envelope blocks
-  // ("[tool output: <title>]\n<output>\n[/tool output]", emitted by
-  // captureTerminalToolOutput in acp-service). These are our structured
-  // markers, not model prose, so dropping them keeps raw tool results from
-  // leaking into the user-facing completion narration — distinct from
-  // matching semantic LLM output, which we do not do.
-  return text
-    .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
+// The envelope-stripping logic moved to the shared transcript-sanitizer so the
+// swarm-synthesis relay path (issue elizaOS/eliza#11578) sanitizes with the
+// SAME implementation instead of its own missing copy. stripToolTranscript is
+// re-imported (see the top-of-file import) and behaves identically here for the
+// well-formed case the router already handled; it additionally hardens against
+// empty-title and unterminated blocks, which the router never emitted but which
+// leaked on the synthesis path.
 
 // Maximum size of a captured tool-output block we will relay verbatim. Above
 // this, the deliverable is a multi-KB transcript and stays on the

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -56,6 +56,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { logger, Service } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { OrchestratorTaskService } from "./orchestrator-task-service.js";
+import { sanitizeCompletionRelay } from "./transcript-sanitizer.js";
 import { TERMINAL_SESSION_STATUSES } from "./types.js";
 
 export const SWARM_COORDINATOR_SERVICE_TYPE = "SWARM_COORDINATOR";
@@ -708,11 +709,25 @@ export class SwarmCoordinatorService extends Service {
       readString(record, "originConnectorMessageId") ??
       readString(meta, "originConnectorMessageId") ??
       null;
-    const completionSummary =
+    // The raw `response` here is the ACP turn's finalText, which CONTAINS the
+    // orchestrator's own `[tool output: …]` envelope blocks appended by
+    // captureTerminalToolOutput. This synthesis path posts completionSummary
+    // VERBATIM to the connector (server-helpers-swarm.buildTaskResultLine →
+    // routeSynthesisToConnector → Discord) with NO downstream stripping — the
+    // round-3 raw-transcript leak in issue elizaOS/eliza#11578. Sanitize at the
+    // SOURCE with the same shared stripper the sub-agent router uses, so the
+    // envelopes never enter the callback payload. If nothing survives (the
+    // deliverable WAS the tool output), fall back to the existing default.
+    const rawSummary =
       readString(record, "response") ??
       readString(record, "summary") ??
       readString(record, "message") ??
-      readString(record, "text") ??
+      readString(record, "text");
+    const sanitizedSummary = rawSummary
+      ? sanitizeCompletionRelay(rawSummary)
+      : "";
+    const completionSummary =
+      sanitizedSummary ||
       (terminalStatus === "completed"
         ? "Task completed."
         : `${label} ${terminalStatus}.`);

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared sanitizer for sub-agent completion relay text.
+ *
+ * The orchestrator captures raw tool results into structured envelope blocks
+ * ("[tool output: <title>]\n<body>\n[/tool output]", emitted by
+ * captureTerminalToolOutput in acp-service). Those markers are OURS, not model
+ * prose, and must never reach a user-facing surface (Discord, etc.). This
+ * module centralizes stripping them so every relay path — the sub-agent router
+ * AND the swarm-synthesis path (issue elizaOS/eliza#11578) — shares one robust
+ * implementation instead of a router-private copy the synthesis path lacked.
+ */
+
+/** The closing marker captureTerminalToolOutput appends to every block. */
+const TOOL_OUTPUT_END_MARKER = "[/tool output]";
+
+/**
+ * Default hard cap for any single remnant of text after envelope stripping.
+ * A deliverable above this is a multi-KB transcript dump, not a user answer, so
+ * we elide it rather than relaying it verbatim. Mirrors the 2KB verbatim cap
+ * the router already applies to captured deliverables.
+ */
+export const DEFAULT_MAX_RELAY_CHARS = 2000;
+
+/**
+ * Remove the orchestrator's OWN captured tool-output envelope blocks from relay
+ * text. Robust to:
+ *  - well-formed blocks with a title
+ *  - empty-title blocks: `[tool output: ]` / `[tool output:]`
+ *  - MULTIPLE blocks in one string
+ *  - an UNTERMINATED trailing block: a dangling `[tool output:` with no closing
+ *    `[/tool output]` (a truncated capture) is stripped from the marker to end.
+ *
+ * Preserves all surrounding prose and plain URLs (envelopes carry an explicit
+ * `[/tool output]` fence or run to end-of-string; prose between blocks is
+ * untouched). This matches the router's historical stripToolTranscript output
+ * for the well-formed case so its existing tests stay green.
+ */
+export function stripToolTranscript(text: string): string {
+  if (!text) return "";
+  return (
+    text
+      // Well-formed and empty-title blocks (non-greedy body up to the fence).
+      .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
+      // Unterminated trailing block: dangling opener with no closing fence.
+      // Only fires if a `[tool output:` marker remains AFTER the pass above,
+      // which means it was never closed — strip it to end of string.
+      .replace(/\[tool output:[\s\S]*$/g, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+/**
+ * Hard-cap any oversized text remnant. If `text` exceeds `maxChars`, replace it
+ * entirely with a short elision marker recording the original length. Applied
+ * AFTER envelope stripping as defense-in-depth: even a remnant that is not a
+ * recognized envelope (raw JSON, an unfenced dump) is bounded before relay.
+ */
+export function elideLongBlocks(
+  text: string,
+  maxChars: number = DEFAULT_MAX_RELAY_CHARS,
+): string {
+  if (!text) return "";
+  if (text.length <= maxChars) return text;
+  return `[output elided — ${text.length} chars]`;
+}
+
+/**
+ * Full relay-sanitization pipeline: strip envelope blocks, then hard-cap the
+ * remainder. Returns "" when nothing survives (callers substitute their own
+ * default, e.g. "Task completed.").
+ */
+export function sanitizeCompletionRelay(
+  text: string | undefined | null,
+  maxChars: number = DEFAULT_MAX_RELAY_CHARS,
+): string {
+  if (!text) return "";
+  return elideLongBlocks(stripToolTranscript(text), maxChars);
+}
+
+export { TOOL_OUTPUT_END_MARKER };

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -16,6 +16,12 @@ const MAX_DIFF_CHARS = 6_000;
 const MAX_CHANGED_FILES = 60;
 const MAX_FILE_DIFFS = 12;
 
+// The canonical git empty-tree object hash. On an unborn HEAD (a fresh repo
+// with zero commits), `git diff HEAD` throws because HEAD resolves to nothing;
+// diffing against the empty tree yields the whole working tree as "added"
+// instead (issue elizaOS/eliza#11578 FIX C).
+const EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
 function outputToString(value: unknown): string | undefined {
   if (typeof value === "string") return value;
   if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
@@ -151,6 +157,30 @@ function parseNameStatus(out: string | undefined): string[] {
   return files;
 }
 
+/** Parse `git ls-files --others` output (one path per line) into a path list. */
+function parseLsFiles(out: string | undefined): string[] {
+  return (out ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Resolve the base ref for the completion diff. Prefers the captured baseline
+ * sha; otherwise HEAD — but when HEAD is unborn (a fresh repo with zero commits)
+ * `git rev-parse --verify HEAD` fails, so we fall back to the empty-tree hash so
+ * the diff still sees the entire working tree as added (issue #11578 FIX C).
+ */
+async function resolveDiffBase(
+  workdir: string,
+  baselineSha?: string,
+): Promise<string> {
+  const trimmed = baselineSha?.trim();
+  if (trimmed) return trimmed;
+  const head = await git(workdir, ["rev-parse", "--verify", "--quiet", "HEAD"]);
+  return head?.trim() ? "HEAD" : EMPTY_TREE_HASH;
+}
+
 /** Normalize a tool-call file path to workdir-relative POSIX form. */
 function toWorkdirRelative(workdir: string, file: string): string {
   const trimmed = file.trim();
@@ -210,7 +240,20 @@ export async function captureChangeSet(
   if (!(await isWorkTree(workdir))) {
     return captureToolPathOnlyChangeSet(workdir, toolPaths);
   }
-  const base = baselineSha?.trim() ? baselineSha.trim() : "HEAD";
+  // Resolve the diff base. When no explicit baseline sha was captured we use
+  // HEAD — but on an unborn HEAD (zero commits) `git diff HEAD` throws and the
+  // caller previously fell back to the weak narration path (issue #11578
+  // round-1/2). Substitute the empty-tree hash so a fresh repo still surfaces
+  // its whole working tree as a change set.
+  const base = await resolveDiffBase(workdir, baselineSha);
+  // `base === EMPTY_TREE_HASH` iff HEAD was unborn (a FRESH repo, no baseline).
+  // That is the only case where we merge `git ls-files --others`: a fresh repo
+  // has no accumulated prior-session clutter, so surfacing every untracked file
+  // is correct. In the normal born-HEAD case we deliberately DO NOT scoop up
+  // untracked files (that would regress the shared-workspace clutter invariant
+  // pinned by the workspace-diff tests) — tracked diff + tool paths stay scoped
+  // to this session.
+  const unbornHead = base === EMPTY_TREE_HASH;
 
   // Exclude files already dirty at spawn (pre-existing churn the agent didn't
   // touch) UNLESS the agent explicitly wrote them via a tool call this session.
@@ -227,10 +270,21 @@ export async function captureChangeSet(
   ).filter((file) => !dirtyAtSpawn.has(file));
   const agentWritten = [...agentWrittenSet];
 
-  const changedFiles = [...new Set([...tracked, ...agentWritten])].slice(
-    0,
-    MAX_CHANGED_FILES,
-  );
+  // On an unborn HEAD only: include untracked files so shell-driven creates
+  // (mkdir/cp/redirect) that never went through the edit/write tool path still
+  // surface. `git diff <empty-tree>` sees only files git already knows about,
+  // so a freshly scaffolded, never-added file would otherwise be invisible
+  // (issue #11578 FIX C). Scoped to unborn HEAD to preserve the born-HEAD
+  // clutter invariant above.
+  const untracked = unbornHead
+    ? parseLsFiles(
+        await git(workdir, ["ls-files", "--others", "--exclude-standard"]),
+      ).filter((file) => !dirtyAtSpawn.has(file))
+    : [];
+
+  const changedFiles = [
+    ...new Set([...tracked, ...untracked, ...agentWritten]),
+  ].slice(0, MAX_CHANGED_FILES);
   if (changedFiles.length === 0) return undefined;
 
   // Real stat from git for the same filtered file set rendered to the user.


### PR DESCRIPTION
Fixes the coding sub-agent (codex ACP) transcript leak into Discord: `[tool output: …]` envelope blocks, raw exec-record JSON, and file bodies reaching the user. Two prior attempts took a weaker path; this fixes all three confirmed root causes with tests.

## Leak paths fixed

- **A — swarm synthesis posted raw finalText verbatim (the round-3 leak).** `maybeFireSwarmComplete` derived `completionSummary` from the ACP turn's `response` (finalText), which contains the orchestrator's own `[tool output: …]` envelope blocks appended by `captureTerminalToolOutput`. `buildTaskResultLine` → `routeSynthesisToConnector` → Discord relayed it with **no stripping**, unlike the sub-agent-router twin. Fix: extracted the router's private `stripToolTranscript` into a shared `services/transcript-sanitizer.ts` (hardened against empty-title `[tool output: ""]`, unterminated/dangling blocks, and multiple blocks, plus a `elideLongBlocks` hard cap ≈2000 chars). Sanitize at the **source** in the coordinator, and again **defense-in-depth** in `buildTaskResultLine` (evidence URLs preserved). The router re-uses the shared stripper — behavior unchanged, its tests stay green.
- **B — exec-record JSON stringify.** `normalizeToolOutput` fell back to `JSON.stringify` for codex exec records (`call_id`, `command`, `exit_code`, …), dumping the raw record into an envelope. Fix: detect the exec-record shape (has `call_id` **and** `command`) and render a one-liner `$ <command> → exit <code>` (+ capped stdout/stderr tail); never stringify a record carrying `call_id`.
- **C — change-set capture failed on unborn HEAD.** `captureChangeSet` threw on `git diff HEAD` in a repo with zero commits → caller caught → weak narration path (why rounds 1/2 leaked). Fix: diff against the empty-tree hash on unborn HEAD, and — **unborn HEAD only**, to preserve the born-HEAD shared-workspace clutter invariant — merge `git ls-files --others --exclude-standard` so shell-written scaffolding produces a change set.

## Follow-up (not in this PR)
The synthesis path **double-posts** alongside the planner's own clean reply (live round-3: user got the raw-envelope message *and* a clean "done ✅" for one task). That's a router-vs-synthesis ownership design question, deliberately left out of this fix.

## Tests (+27, all green; no regressions vs baseline)
- sanitizer: normal / empty-title / multi-block / unterminated envelopes; preserves prose + URLs; elides >2000-char remnant
- `maybeFireSwarmComplete`: envelope-laden `response` → clean `completionSummary`; tool-only response → `"Task completed."` fallback
- `buildTaskResultLine` (via `handleSwarmSynthesis`): envelopes stripped, evidence URL preserved
- `normalizeToolOutput`: exec-record → one-liner (array/string command, capped tail, stringified record, non-record untouched)
- `captureChangeSet`: unborn HEAD + shell-written files → change set; untracked included only on unborn HEAD; born-HEAD clutter invariant preserved

Orchestrator suite: **996 passing** (was 969; +27 mine). The 15 pre-existing failures are unrelated environment/dependency issues (drizzle-orm, @noble/curves, i18n codegen) — identical count with and without this change.

`[sol-relay] — [sol-orch]`
