### PR TITLE
fix(cloud): #11512 HIGH cashable credit-mint — idempotent reconcile refund/charge + settler first-call-wins (supersedes #11539)

### DIFF
--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1594,14 +1594,17 @@ async function handleStreamingRequest(
   let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
     null;
 
+  // First-call-wins EVEN on throw (#11512): the settlement promise is cached
+  // unconditionally, so a rejected settlement can never be re-run by a later
+  // callback (onAbort/onError racing a thrown onFinish). Resetting on throw
+  // let a second call re-invoke reconcile after its org refund had already
+  // committed — a second full refund, i.e. minted cashable credit. Subsequent
+  // callers observe the same resolution or the same rejection.
   const settleStreamingOnce = (
     factory: () => Promise<CreditReconciliationResult | null>,
   ): Promise<CreditReconciliationResult | null> => {
     if (!streamingSettlementPromise) {
-      streamingSettlementPromise = factory().catch((error) => {
-        streamingSettlementPromise = null;
-        throw error;
-      });
+      streamingSettlementPromise = factory();
     }
     return streamingSettlementPromise;
   };

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Reconcile double-refund mint — REAL path (#11512).
+ *
+ * On the monetized-app inference path (`/v1/chat/completions`, `/v1/messages`)
+ * `AppCreditsService.reconcileCredits` COMMITS the org refund before its
+ * throw-prone post-refund writes (`reverseCreatorEarnings`, the apps-counter
+ * update). The settler (`createCreditReservationSettler`) used to reset its
+ * once-guard on throw, so the route's multi-site fallback
+ * `settleReservation?.(0)` re-invoked reconcile after such a mid-reconcile
+ * throw and issued a SECOND committed refund — org credited
+ * ≈ 2×reserved − actual, i.e. minted, cashable credit.
+ *
+ * These tests drive the CHANGED code end-to-end against in-process PGlite:
+ * a real reservation (`reserveInferenceCredits` → org debit), a real reconcile
+ * (org refund/charge rows in `credit_transactions`, creator-earnings ledger,
+ * apps counters), with the only fault injection being a dependency DB blip
+ * (`redeemableEarningsService.reduceEarnings` throwing once — the post-refund
+ * write). Both fix layers are proven:
+ *   (B) the settler never re-invokes reconcile after a rejection, and
+ *   (A) even a re-invoked reconcile (any other retry vector) dedupes its
+ *       org refund/charge on the synthetic `reconcile-refund:`/
+ *       `reconcile-charge:` stripe_payment_intent_id key (unique index).
+ *
+ * The synthetic key is derived from the SERVER-GENERATED reservation deduct
+ * transaction id (credit_transactions.id) — NEVER a client-controlled value
+ * (Idempotency-Key header / metadata.idempotencyKey / x-request-id). The
+ * stripe_payment_intent_id unique index is GLOBAL, not org-scoped, so a
+ * client-controlled key would let Org A and Org B sending the SAME key
+ * cross-dedupe: Org B silently loses a legit refund, or its overage charge
+ * is silently skipped. The cross-tenant tests below pin that down.
+ *
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails
+ * to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports (see
+// app-credits-idempotency.test.ts for the full rationale).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  appUsers,
+  userDatabaseStatusEnum,
+} from "../../../db/schemas/apps";
+import { creditTransactions } from "../../../db/schemas/credit-transactions";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+import { runWithRequestContext } from "../../runtime/request-context";
+import { createCreditReservationSettler } from "../../utils/credit-reservation";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let appCreditsService: typeof import("../app-credits").appCreditsService;
+let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const INITIAL_ORG_BALANCE = 100;
+
+async function seed(): Promise<{
+  appId: string;
+  payerUserId: string;
+  payerOrgId: string;
+  creatorUserId: string;
+}> {
+  const [payerOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Payer", slug: uniq("payer"), credit_balance: "100.000000" })
+    .returning();
+  const [payer] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("payer-u"), organization_id: payerOrg.id })
+    .returning();
+  const [creatorOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Creator", slug: uniq("creator") })
+    .returning();
+  const [creator] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("creator-u"), organization_id: creatorOrg.id })
+    .returning();
+  const [app] = await dbWrite
+    .insert(apps)
+    .values({
+      name: "Monetized App",
+      slug: uniq("app"),
+      organization_id: creatorOrg.id,
+      created_by_user_id: creator.id,
+      app_url: "https://placeholder.invalid",
+      monetization_enabled: true,
+      inference_markup_percentage: 100,
+    })
+    .returning();
+  return {
+    appId: app.id,
+    payerUserId: payer.id,
+    payerOrgId: payerOrg.id,
+    creatorUserId: creator.id,
+  };
+}
+
+async function orgBalance(orgId: string): Promise<number> {
+  const [row] = await dbWrite.select().from(organizations).where(eq(organizations.id, orgId));
+  return Number(row?.credit_balance ?? Number.NaN);
+}
+
+async function creatorBalance(userId: string): Promise<number> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return Number(row?.available_balance ?? 0);
+}
+
+async function orgTransactions(
+  orgId: string,
+  type: "refund" | "debit",
+): Promise<(typeof creditTransactions.$inferSelect)[]> {
+  return dbWrite
+    .select()
+    .from(creditTransactions)
+    .where(and(eq(creditTransactions.organization_id, orgId), eq(creditTransactions.type, type)));
+}
+
+/**
+ * Make the NEXT `reduceEarnings` call throw (the post-refund write blip that
+ * strands reconcile mid-flight); later calls run the real implementation.
+ * Returns a call counter + restore.
+ */
+function injectReduceEarningsBlipOnce(): { calls: () => number; restore: () => void } {
+  const original = redeemableEarningsService.reduceEarnings.bind(redeemableEarningsService);
+  let calls = 0;
+  redeemableEarningsService.reduceEarnings = (async (params: Parameters<typeof original>[0]) => {
+    calls += 1;
+    if (calls === 1) {
+      throw new Error("injected post-refund write blip");
+    }
+    return original(params);
+  }) as typeof original;
+  return {
+    calls: () => calls,
+    restore: () => {
+      redeemableEarningsService.reduceEarnings = original;
+    },
+  };
+}
+
+beforeAll(async () => {
+  try {
+    ({ appCreditsService } = await import("../app-credits"));
+    ({ redeemableEarningsService } = await import("../redeemable-earnings"));
+    const schema = {
+      organizations,
+      users,
+      apps,
+      appUsers,
+      appEarnings,
+      appEarningsTransactions,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      creditTransactions,
+      appDeploymentStatusEnum,
+      appReviewStatusEnum,
+      userDatabaseStatusEnum,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[app-credits-reconcile-double-refund.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("reconcile refund-then-throw + settler re-invoke (#11512)", () => {
+  test("pglite applied (loud, never silent no-op)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test("settler fallback after mid-reconcile throw applies exactly ONE refund (no mint)", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+
+    // The route shape: reserve the estimate, wrap the reservation in the
+    // shared settler, settle from multiple sites.
+    const reservation = await appCreditsService.reserveInferenceCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      description: "inference",
+      idempotencyKey: "req-11512-settler",
+    });
+    // 100% markup: reserve debits 2×0.03 = 0.06; creator earns 0.03 upfront.
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(INITIAL_ORG_BALANCE - 0.06, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.03, 6);
+
+    const settle = createCreditReservationSettler(reservation);
+
+    const blip = injectReduceEarningsBlipOnce();
+    try {
+      // First settle: actual 0.01 < estimate 0.03 → refund branch. The org
+      // refund of 0.04 COMMITS, then the post-refund write throws.
+      await expect(settle(0.01)).rejects.toThrow("injected post-refund write blip");
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(INITIAL_ORG_BALANCE - 0.06 + 0.04, 6);
+
+      // The route's fallback catch: `await settleReservation?.(0)`. Before the
+      // fix this re-invoked reconcile(0) and issued a SECOND committed refund
+      // (0.06 — the full reservation), leaving the org at 100.04 > 100:
+      // minted, cashable credit. Now it re-awaits the same rejection.
+      await expect(settle(0)).rejects.toThrow("injected post-refund write blip");
+      // …and a third pile-on call (onAbort/onError racing) is just as inert.
+      await expect(settle(0)).rejects.toThrow("injected post-refund write blip");
+    } finally {
+      blip.restore();
+    }
+
+    // reconcile ran exactly once: one post-refund write attempt, no re-invoke.
+    expect(blip.calls()).toBe(1);
+
+    // Exactly ONE refund applied — balance is the single-refund amount, not
+    // the minted 2× (100 − 0.06 + 0.04 = 99.98; the mint would be 100.04).
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    const refunds = await orgTransactions(payerOrgId, "refund");
+    expect(refunds).toHaveLength(1);
+    // Keyed on the SERVER-generated reservation txid, not the client key.
+    expect(reservation.reservationTransactionId).toBeTruthy();
+    expect(refunds[0]?.stripe_payment_intent_id).toBe(
+      `reconcile-refund:${reservation.reservationTransactionId}`,
+    );
+
+    // Creator earnings were NOT double-reversed: the (single) reversal attempt
+    // threw before applying, so the deduct-time 0.03 stands untouched.
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.03, 6);
+  });
+
+  test("re-invoked reconcile after the throw dedupes the refund and completes the reversal", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+
+    const reservation = await appCreditsService.reserveInferenceCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      description: "inference",
+      idempotencyKey: "req-11512-retry",
+    });
+
+    const blip = injectReduceEarningsBlipOnce();
+    try {
+      // First reconcile: refund commits (0.04), post-refund write throws.
+      await expect(reservation.reconcile(0.01)).rejects.toThrow("injected post-refund write blip");
+
+      // A DIRECT re-invoke (any non-settler retry vector). Layer A: the org
+      // refund dedupes on the `reconcile-refund:` key — no second credit —
+      // while the creator reversal now completes.
+      const retried = await reservation.reconcile(0.01);
+      expect(retried.adjustmentType).toBe("refund");
+    } finally {
+      blip.restore();
+    }
+    expect(blip.calls()).toBe(2);
+
+    // Org: 100 − 0.06 + 0.04, refunded exactly once across both invocations.
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await orgTransactions(payerOrgId, "refund")).toHaveLength(1);
+
+    // Creator: 0.03 deduct-time credit − 0.02 reversal, applied exactly once.
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+  });
+
+  test("reconcile refund replay (no fault) refunds the org exactly once — keyed on the reservation txid", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId } = await seed();
+
+    const deduction = await appCreditsService.deductCredits({
+      appId,
+      userId: payerUserId,
+      baseCost: 0.03,
+      description: "inference (estimate)",
+    });
+    const reservationTxId = deduction.transactionId;
+    expect(reservationTxId).toBeTruthy();
+
+    // Direct-reconcile shape with the deduct row's SERVER-generated
+    // transaction id threaded through (as reserveInferenceCredits does).
+    const runReconcile = () =>
+      appCreditsService.reconcileCredits({
+        appId,
+        userId: payerUserId,
+        estimatedBaseCost: 0.03,
+        actualBaseCost: 0.01,
+        description: "inference (reconcile refund)",
+        reservationTransactionId: reservationTxId,
+      });
+
+    await runReconcile();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+
+    // Full settlement replay of the SAME reservation: the refund must dedupe
+    // (before #11512 the org was credited 0.04 again → 100.02).
+    await runReconcile();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    const refunds = await orgTransactions(payerOrgId, "refund");
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0]?.stripe_payment_intent_id).toBe(`reconcile-refund:${reservationTxId}`);
+  });
+
+  test("client-controlled keys (metadata.idempotencyKey / ALS request key) never become the dedup key", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId } = await seed();
+
+    // A reconcile that carries ONLY client-controlled identifiers — the
+    // Idempotency-Key echoed into metadata AND the request-ALS key — must not
+    // mint a synthetic stripe_payment_intent_id from either of them: that
+    // unique index is GLOBAL, so a client key would collide across orgs
+    // (see the cross-tenant tests below for the resulting money loss).
+    await runWithRequestContext({ idempotencyKey: "client-chosen-key" }, async () => {
+      await appCreditsService.deductCredits({
+        appId,
+        userId: payerUserId,
+        baseCost: 0.03,
+        description: "inference (estimate)",
+        metadata: { idempotencyKey: "client-chosen-key" },
+      });
+      await appCreditsService.reconcileCredits({
+        appId,
+        userId: payerUserId,
+        estimatedBaseCost: 0.03,
+        actualBaseCost: 0.01,
+        description: "inference (reconcile refund)",
+        metadata: { idempotencyKey: "client-chosen-key" },
+      });
+    });
+
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    const refunds = await orgTransactions(payerOrgId, "refund");
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0]?.stripe_payment_intent_id).toBeNull();
+  });
+
+  test("overage-charge replay debits the org exactly once (symmetric key)", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId } = await seed();
+
+    const deduction = await appCreditsService.deductCredits({
+      appId,
+      userId: payerUserId,
+      baseCost: 0.01,
+      description: "inference (estimate)",
+    });
+    const reservationTxId = deduction.transactionId;
+    expect(reservationTxId).toBeTruthy();
+
+    const reconcileOverage = () =>
+      appCreditsService.reconcileCredits({
+        appId,
+        userId: payerUserId,
+        estimatedBaseCost: 0.01,
+        actualBaseCost: 0.03,
+        description: "inference (reconcile overage)",
+        reservationTransactionId: reservationTxId,
+      });
+
+    // 100 − 0.02 (estimate) − 0.04 (overage) = 99.94.
+    await reconcileOverage();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.94, 6);
+
+    // Replay: the overage charge dedupes — the org is NOT debited again.
+    await reconcileOverage();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.94, 6);
+    const overageRows = (await orgTransactions(payerOrgId, "debit")).filter(
+      (row) => row.stripe_payment_intent_id === `reconcile-charge:${reservationTxId}`,
+    );
+    expect(overageRows).toHaveLength(1);
+  });
+});
+
+describe("cross-tenant isolation: shared client Idempotency-Key (#11512 revision)", () => {
+  /**
+   * Two DIFFERENT orgs send the SAME client Idempotency-Key (trivially
+   * attacker-chosen, or a shared/misconfigured proxy echoing one
+   * x-request-id). Because credit_transactions.stripe_payment_intent_id is a
+   * GLOBAL unique index, keying the reconcile legs on any client-derived
+   * value made Org B's refund dedupe against Org A's row (Org B loses its
+   * refund) and Org B's overage charge silently skip (platform loses
+   * revenue). Keyed on the server-generated reservation txid, each org's
+   * settlement is independent.
+   */
+  const SHARED_CLIENT_KEY = "shared-proxy-idempotency-key";
+
+  test("both orgs get their own reconcile REFUND — no cross-dedup", async () => {
+    if (!pgliteReady) return;
+    const tenantA = await seed();
+    const tenantB = await seed();
+
+    const reserveAndSettle = async (tenant: Awaited<ReturnType<typeof seed>>) =>
+      runWithRequestContext({ idempotencyKey: SHARED_CLIENT_KEY }, async () => {
+        const reservation = await appCreditsService.reserveInferenceCredits({
+          appId: tenant.appId,
+          userId: tenant.payerUserId,
+          estimatedBaseCost: 0.03,
+          description: "inference",
+          idempotencyKey: SHARED_CLIENT_KEY,
+        });
+        const settle = createCreditReservationSettler(reservation);
+        const result = await settle(0.01);
+        expect(result?.adjustmentType).toBe("refund");
+        return reservation;
+      });
+
+    const reservationA = await reserveAndSettle(tenantA);
+    const reservationB = await reserveAndSettle(tenantB);
+    expect(reservationA.reservationTransactionId).toBeTruthy();
+    expect(reservationB.reservationTransactionId).toBeTruthy();
+    expect(reservationA.reservationTransactionId).not.toBe(reservationB.reservationTransactionId);
+
+    // BOTH orgs land on their own single-refund balance:
+    // 100 − 0.06 (reserve) + 0.04 (refund) = 99.98. With client-key keying,
+    // Org B's refund deduped against Org A's row → Org B stuck at 99.94
+    // (its legit refund silently lost).
+    expect(await orgBalance(tenantA.payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await orgBalance(tenantB.payerOrgId)).toBeCloseTo(99.98, 6);
+
+    const refundsA = await orgTransactions(tenantA.payerOrgId, "refund");
+    const refundsB = await orgTransactions(tenantB.payerOrgId, "refund");
+    expect(refundsA).toHaveLength(1);
+    expect(refundsB).toHaveLength(1);
+    expect(refundsA[0]?.stripe_payment_intent_id).toBe(
+      `reconcile-refund:${reservationA.reservationTransactionId}`,
+    );
+    expect(refundsB[0]?.stripe_payment_intent_id).toBe(
+      `reconcile-refund:${reservationB.reservationTransactionId}`,
+    );
+
+    // Layer A intact per reservation: a re-settle of Org B's SAME
+    // reservation still dedupes (no second refund).
+    await reservationB.reconcile(0.01);
+    expect(await orgBalance(tenantB.payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await orgTransactions(tenantB.payerOrgId, "refund")).toHaveLength(1);
+  });
+
+  test("both orgs are charged their own reconcile OVERAGE — no cross-skip", async () => {
+    if (!pgliteReady) return;
+    const tenantA = await seed();
+    const tenantB = await seed();
+
+    const reserveAndSettle = async (tenant: Awaited<ReturnType<typeof seed>>) =>
+      runWithRequestContext({ idempotencyKey: SHARED_CLIENT_KEY }, async () => {
+        const reservation = await appCreditsService.reserveInferenceCredits({
+          appId: tenant.appId,
+          userId: tenant.payerUserId,
+          estimatedBaseCost: 0.01,
+          description: "inference",
+          idempotencyKey: SHARED_CLIENT_KEY,
+        });
+        const settle = createCreditReservationSettler(reservation);
+        const result = await settle(0.03);
+        expect(result?.adjustmentType).toBe("overage");
+        return reservation;
+      });
+
+    const reservationA = await reserveAndSettle(tenantA);
+    const reservationB = await reserveAndSettle(tenantB);
+
+    // BOTH orgs pay their own overage: 100 − 0.02 (reserve) − 0.04 (overage)
+    // = 99.94. With client-key keying, Org B's charge deduped against Org A's
+    // row → Org B kept 99.98 (the platform silently lost the overage).
+    expect(await orgBalance(tenantA.payerOrgId)).toBeCloseTo(99.94, 6);
+    expect(await orgBalance(tenantB.payerOrgId)).toBeCloseTo(99.94, 6);
+
+    const chargeA = (await orgTransactions(tenantA.payerOrgId, "debit")).filter(
+      (row) =>
+        row.stripe_payment_intent_id ===
+        `reconcile-charge:${reservationA.reservationTransactionId}`,
+    );
+    const chargeB = (await orgTransactions(tenantB.payerOrgId, "debit")).filter(
+      (row) =>
+        row.stripe_payment_intent_id ===
+        `reconcile-charge:${reservationB.reservationTransactionId}`,
+    );
+    expect(chargeA).toHaveLength(1);
+    expect(chargeB).toHaveLength(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -255,6 +255,18 @@ export interface AppCreditReconciliationParams {
   metadata?: Record<string, unknown>;
   /** Optional: pass pre-fetched app to avoid N+1 query */
   app?: App;
+  /**
+   * SERVER-GENERATED id of the reservation's deduct transaction
+   * (credit_transactions.id, a DB UUID). When present, the reconcile
+   * refund/charge legs are made idempotent by keying their synthetic
+   * stripePaymentIntentId on it (`reconcile-refund:<id>` /
+   * `reconcile-charge:<id>`), so a re-invoked settle of the SAME reservation
+   * dedupes on the credit_transactions unique index instead of moving money
+   * twice (#11512). MUST never be a client-supplied value: that unique index
+   * is global (not org-scoped), so a client-controlled key would let one
+   * org's settle dedupe away another org's refund or overage charge.
+   */
+  reservationTransactionId?: string | null;
 }
 
 /**
@@ -456,6 +468,11 @@ export class AppCreditsService {
           description,
           metadata: withChargeIdempotencyKey(metadata, idempotencyKey),
           app,
+          // Server-generated key for the reconcile legs' idempotent ledger
+          // writes (#11512) — the deduct row's own transaction id, never the
+          // client idempotencyKey (globally-unique index ⇒ a client key would
+          // collide across orgs).
+          reservationTransactionId,
         });
 
         return mapAppReconciliationToCreditResult(
@@ -692,22 +709,39 @@ export class AppCreditsService {
       description,
       metadata: rawMetadata,
       app: providedApp,
+      reservationTransactionId,
     } = params;
 
     // Validate metadata size and depth
     const metadata = validateMetadata(rawMetadata, "reconcileCredits");
 
-    // Request-stable idempotency key (threaded via withChargeIdempotencyKey).
-    // The reconcile refund is otherwise NON-idempotent, and the reservation
-    // settler resets its first-call-wins guard on throw — so if a refund
-    // commits then a post-refund write throws (DB blip), the route's fallback
-    // settle re-invokes reconcile and a SECOND full refund mints credit
-    // (#11512). Keying the refund on this stable id makes the re-invoke dedupe
-    // on the credit_transactions unique index instead of double-crediting.
-    const reconcileIdempotencyKey =
-      typeof (metadata as Record<string, unknown> | undefined)?.idempotencyKey === "string"
-        ? ((metadata as Record<string, unknown>).idempotencyKey as string)
-        : undefined;
+    // #11512: idempotency key for the org-credit legs below, threaded as a
+    // synthetic, namespaced stripePaymentIntentId. creditsService dedupes on
+    // the credit_transactions.stripe_payment_intent_id unique index, so a
+    // re-invoked reconcile (a settle retry after a mid-reconcile throw, where
+    // the org refund already COMMITTED before reverseCreatorEarnings / the
+    // apps-counter update threw) returns the first transaction as a no-op
+    // instead of refunding or charging the org a second time.
+    //
+    // The key MUST be SERVER-GENERATED. That unique index is GLOBAL — not
+    // org-scoped — so a client-controlled key (Idempotency-Key header,
+    // x-request-id, metadata.idempotencyKey) would let Org A's reconcile
+    // dedupe away Org B's refund or overage charge when both send the same
+    // key: a cross-tenant collision where the user silently loses a legit
+    // refund and the platform silently skips an overage charge. We therefore
+    // key on the reservation's own deduct-transaction id
+    // (credit_transactions.id, a DB-generated UUID): stable across
+    // re-settles of the SAME reservation, globally unique across
+    // reservations and orgs. Same pattern as the org-credits path's
+    // `recon:<txid>:<phase>` keys (#10846). The `reconcile-refund:` /
+    // `reconcile-charge:` prefixes keep the synthetic keys disjoint from
+    // real Stripe intent ids (`pi_…`) and those `recon:` keys. When no
+    // reservation transaction id is available (the apps/[id]/chat
+    // direct-reconcile paths), we pass NO key — the prior non-idempotent
+    // behavior, backstopped by those routes' settle-started flags and the
+    // settler's first-call-wins guard (createCreditReservationSettler) — and
+    // NEVER fall back to a client-supplied value.
+    const chargeKey = reservationTransactionId || null;
 
     const baseCostDifference = actualBaseCost - estimatedBaseCost;
 
@@ -774,12 +808,10 @@ export class AppCreditsService {
         organizationId,
         amount: refundAmount,
         description: `App reconciliation refund (${app.name ?? appId})`,
-        // Idempotent on the request-stable key: a second settle of the same
-        // reservation (e.g. after the settler's guard reset on a mid-settle
-        // throw) dedupes to the first refund instead of minting (#11512).
-        ...(reconcileIdempotencyKey && {
-          stripePaymentIntentId: `reconcile-refund:${reconcileIdempotencyKey}`,
-        }),
+        // Idempotent per reservation (#11512): a re-invoked reconcile must not
+        // credit the org a second refund (2×reserved − actual = minted,
+        // cashable credit).
+        stripePaymentIntentId: chargeKey ? `reconcile-refund:${chargeKey}` : undefined,
         metadata: {
           appId,
           userId,
@@ -851,6 +883,9 @@ export class AppCreditsService {
       organizationId,
       amount: additionalCharge,
       description: `App reconciliation charge (${app.name ?? appId})`,
+      // Symmetric idempotency (#11512): a re-invoked reconcile must not debit
+      // the overage from the org twice.
+      stripePaymentIntentId: chargeKey ? `reconcile-charge:${chargeKey}` : undefined,
       metadata: {
         appId,
         userId,

--- a/packages/cloud/shared/src/lib/utils/credit-reservation.test.ts
+++ b/packages/cloud/shared/src/lib/utils/credit-reservation.test.ts
@@ -80,21 +80,41 @@ describe("createCreditReservationSettler", () => {
     expect(r2).toEqual(fakeResult);
   });
 
-  test("allows retry after reconcile throws", async () => {
+  test("#11512: throw does NOT reset the guard — reconcile never re-runs", async () => {
+    // reconcileCredits commits the org refund BEFORE its throw-prone
+    // post-refund writes. If a rejected settle reset the once-guard, the
+    // route's fallback settleReservation?.(0) re-invoked reconcile and issued
+    // a SECOND committed refund (2×reserved − actual = minted cashable
+    // credit). First-call-wins must hold across rejection too.
     let calls = 0;
-    const reservation = makeReservation(async (cost) => {
+    const reservation = makeReservation(async () => {
       calls++;
-      if (calls === 1) throw new Error("transient");
-      return fakeResult;
+      if (calls === 1) throw new Error("post-refund write blip");
+      return fakeResult; // would be a second refund — must be unreachable
     });
 
     const settle = createCreditReservationSettler(reservation);
 
-    await expect(settle(0.001)).rejects.toThrow("transient");
-    // After failure the once-guard resets, so a second call retries
-    const result = await settle(0.001);
-    expect(calls).toBe(2);
-    expect(result).toEqual(fakeResult);
+    await expect(settle(0.001)).rejects.toThrow("post-refund write blip");
+    // The route's multi-site fallback call: same rejection, NO re-invoke.
+    await expect(settle(0)).rejects.toThrow("post-refund write blip");
+    expect(calls).toBe(1);
+  });
+
+  test("#11512: concurrent call during an eventually-rejecting settle shares the rejection", async () => {
+    let calls = 0;
+    const reservation = makeReservation(async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 10));
+      throw new Error("late failure");
+    });
+
+    const settle = createCreditReservationSettler(reservation);
+    const [r1, r2] = await Promise.allSettled([settle(0.001), settle(0)]);
+
+    expect(calls).toBe(1);
+    expect(r1.status).toBe("rejected");
+    expect(r2.status).toBe("rejected");
   });
 
   // Streaming-path invariants (cloud-api v1/chat/completions/route.ts).

--- a/packages/cloud/shared/src/lib/utils/credit-reservation.ts
+++ b/packages/cloud/shared/src/lib/utils/credit-reservation.ts
@@ -1,5 +1,27 @@
 import type { CreditReconciliationResult, CreditReservation } from "../services/credits";
 
+/**
+ * Wrap a credit reservation's `reconcile` in a strict first-call-wins settler.
+ *
+ * Routes call the settler from several sites for ONE reservation (onFinish
+ * success, onFinish catch, onAbort, onError, and the route's outer-catch
+ * `settleReservation?.(0)` fallback), so it must guarantee `reconcile` runs at
+ * most once per reservation.
+ *
+ * #11512: the guard must hold EVEN WHEN `reconcile` REJECTS. The app-credits
+ * reconcile path (`AppCreditsService.reconcileCredits`) commits the org refund
+ * BEFORE its throw-prone post-refund writes (`reverseCreatorEarnings`, the
+ * apps-counter update). The previous implementation nulled the cached promise
+ * in its catch, so a rejected settle let the route's fallback call re-invoke
+ * `reconcile` — issuing a SECOND committed refund and minting cashable org
+ * credit. Instead the in-flight promise is cached unconditionally: subsequent
+ * callers re-await it and observe the same resolution (same result, no
+ * re-charge) or the same rejection (same error, no re-refund). A failed
+ * reconcile is surfaced to every caller and backstopped by the
+ * idempotency-keyed ledger writes (the `reconcile-refund:` /
+ * `reconcile-charge:` keys in `reconcileCredits`) — never silently retried
+ * into a double settlement.
+ */
 export function createCreditReservationSettler(
   reservation: CreditReservation | undefined,
 ): (actualCost: number) => Promise<CreditReconciliationResult | null> {
@@ -8,17 +30,10 @@ export function createCreditReservationSettler(
   return async (actualCost: number) => {
     if (!reservation) return null;
 
-    if (settlePromise) {
-      return (await settlePromise) ?? null;
+    if (!settlePromise) {
+      settlePromise = reservation.reconcile(actualCost);
     }
 
-    settlePromise = reservation.reconcile(actualCost);
-
-    try {
-      return (await settlePromise) ?? null;
-    } catch (error) {
-      settlePromise = null;
-      throw error;
-    }
+    return (await settlePromise) ?? null;
   };
 }


### PR DESCRIPTION
Closes #11512. **Built + verified by Fable-5 ultracode workflows (implement → independent adversarial verify), which caught and fixed a cross-tenant defect mid-review.**

## The mint (HIGH, cashable, monetized-app `/v1/chat/completions` + `/v1/messages`)
`createCreditReservationSettler` (+ #11472's `settleStreamingOnce`) reset their cached promise on throw → the route's multi-site fallback (`route.ts:1345` etc.) **re-invoked reconcile** → a second committed refund → org credited `≈2×reserved−actual` = minted cashable credit. Systemic under DB blips on the post-refund writes (`reverseCreatorEarnings`/apps update).

## Fix — two layers (defense in depth)
**Layer A — idempotent reconcile refund/charge.** `reconcileCredits` now passes a synthetic namespaced `stripePaymentIntentId` (`reconcile-refund:${id}` / `reconcile-charge:${id}`) so the credit-transactions unique-index dedup makes a second refund/charge a no-op.
**Layer B — settler first-call-wins on throw.** `createCreditReservationSettler` + `settleStreamingOnce` cache the promise unconditionally (no null-on-throw) → reconcile runs exactly once; later callers re-await the same resolution/rejection.

## ⚠️ The key is the SERVER-generated reservation txid — NOT the client value (this supersedes #11539)
The adversarial verify caught that keying on the **client-controlled** value (Idempotency-Key / x-request-id) against the **global** `credit_transactions.stripe_payment_intent_id` unique index causes a **cross-tenant collision**: two orgs sending the same key dedupe against each other → one org silently loses a legit refund (or the platform loses an overage charge). So the key is derived **exclusively** from the server-generated reservation deduct-transaction id (`credit_transactions.id`, threaded as `reservationTransactionId`), mirroring the org-credit path's `recon:${txid}:${phase}` (#10846).

**🚨 #11539 (already merged to develop) uses the client-key keying on the refund leg — so the cross-tenant collision is LIVE on develop's refund leg right now.** This branch supersedes it; **merge promptly** (or revert #11539 first). cc @lalalune / [cloud-money].

## Evidence (Fable-5, real PGlite — read `app-credits-reconcile-double-refund.test.ts`)
- **8/8 green**, incl. **2 cross-tenant PGlite proofs** (Org A + Org B, same client Idempotency-Key → both get their own refund at 99.98 / both pay their own overage at 99.94; keys asserted per-reservation) + a negative proof that a client key never becomes the dedup key.
- **Red proven twice:** revert the fix files → the mint reproduces (6/8 fail); use the old client-key keying → the cross-tenant loss reproduces (6/8 fail).
- 9 sibling credit suites green per-file; biome clean; zero typecheck errors in changed files.

## Verification status (honest)
The 3-lens adversarial pass (correctness / regression / idempotency-collision) **HELD on correctness + regression** on the pre-revision commit (each independently re-ran the tests + proved RED). The revision-specific **cross-tenant re-verify is queued** — the Fable-5 verifier hit its session/credit limit mid-run; I'll attach the independent cross-tenant verdict as soon as quota resets. Self-verification (red/green ×2, 8/8) is strong, but I'm flagging that the independent cross-tenant lens hasn't re-signed the revised commit yet.

— `[cloud-frontdoor]`