### PR TITLE
docs(evidence): #11377 diarizer re-bake confirm matrix — published artifact healthy, converter/reader gate-order inversion mapped

### DIFF
--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/README.md
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/README.md
@@ -1,0 +1,105 @@
+# #11377 — diarizer re-bake confirm: full artifact × reader gate-order matrix
+
+Re-bake + `speakeriso:real` confirm requested by the triage thread on #11377,
+plus a standalone-reader probe that completes the 2×2 gate-order matrix. The
+result **confirms the DER-1.000 mechanism (LSTM gate-order skew) but inverts
+the triage's direction**: the published HF artifact is IOFC-packed and
+*matches* the production fused lib; the stale side is the llama.cpp fork's
+vendored `voice_diarizer.c` (IOFC reader) relative to
+`packages/native/plugins/voice-classifier-cpp` (IFGO reader + converter).
+
+## Environment
+
+- Host: macOS arm64 (M4 Max), develop @ `82001b07534`.
+- Fused lib: `libelizainference.dylib` (ABI v12) built from the
+  `elizaOS/llama.cpp` fork at `2bdcef890` — exactly the commit develop pins for
+  `plugins/plugin-local-inference/native/llama.cpp` (submodule clean).
+  Its vendored `tools/omnivoice/src/voice-classifiers/voice_classifier/voice_diarizer.c`
+  reads LSTM gates in **IOFC** order (fork commit `00f1fd5e3`, the original
+  C-side #9460 fix; never re-synced after the reorder moved converter-side).
+- Reference reader: `packages/native/plugins/voice-classifier-cpp` built at
+  develop tip — reads **IFGO** (matches the current converter's
+  `_reorder_iofc_to_ifgo`).
+- ONNX source: ungated `onnx-community/pyannote-segmentation-3.0`
+  (`onnx/model.onnx`, snapshot `733a93b6…`), no HF token.
+
+## Artifacts (sha256 in `artifact-shas.txt`)
+
+| artifact | packing | source | sha256 (8) |
+| --- | --- | --- | --- |
+| published `pyannote-segmentation-3.0.gguf` (HF `elizaos/eliza-1` `voice/diarizer/`, == manifest pin in `packages/shared/src/local-inference/voice-models.ts`, == live HF `x-linked-etag`) | **IOFC** | int8 ONNX (variant string `pyannote-segmentation-3.0-int8`) | `30983eba` |
+| fresh bake, develop converter `voice_diarizer_to_gguf.py` | **IFGO** | fp32 ONNX | `7f4cd30f` |
+| fresh bake, PR #11569 converter (adds `converter_epoch=2` + `lstm_gate_order="IFGO"`) | **IFGO** | fp32 ONNX | `100a5dbf` |
+| probe bake, reorder disabled (raw ONNX order) | **IOFC** | fp32 ONNX | `d0d6c1e5` |
+
+Tensor forensics (`published-tensor-forensics.txt`): every LSTM tensor of the
+published GGUF matches the raw-ONNX **IOFC** packing within int8-dequant noise
+(max |diff| ≤ 0.039; biases exact), and mismatches IFGO by ~8–12. All
+non-LSTM tensors (SincNet, heads) match the current converter's layout.
+
+## `speakeriso:real` matrix — fused lib (fork IOFC reader)
+
+Full bench: 8-turn af_bella/am_michael Kokoro dialogue, 600 ms gaps, real
+WeSpeaker encoder + real fused diarizer, CPU.
+
+| lane | diarizer GGUF | DER | dropped-short | overlap probe | verdict |
+| --- | --- | --- | --- | --- | --- |
+| A | published `30983eba` (IOFC) | **0.209** | 358 ms | localSpeakerCount=2 | **PASS** |
+| B | fresh develop bake `7f4cd30f` (IFGO) | **1.000** | 74 560 ms | localSpeakerCount=3, hasOverlap | FAIL — exact #11377 signature |
+| C | probe bake `d0d6c1e5` (IOFC fp32) | **0.211** | 273 ms | localSpeakerCount=2 | PASS |
+| D | PR #11569 bake `100a5dbf` (IFGO+epoch2) | **1.000** | 74 560 ms | localSpeakerCount=3, hasOverlap | FAIL (loads fine — current loader skips unknown keys) |
+
+Encoder attribution is 6/6 (acc 1.000, margin 0.818) in every lane.
+
+## Standalone probe — packages lib (IFGO reader), `diar_probe.c`
+
+Single 5 s window (turn-01.wav, one speaker), per-frame label transitions:
+
+| artifact | transitions / 293 frames | label histogram |
+| --- | --- | --- |
+| published (IOFC) | **159** — micro-segment flood, all 7 powerset classes lit | scrambled |
+| fresh IFGO | **2** — silence→speaker, clean | correct |
+| probe IOFC fp32 | **170** | scrambled |
+| fresh IFGO+epoch2 | **2** | correct |
+
+## Conclusion
+
+- The DER-1.000 over-segmentation signature is **purely artifact×reader
+  gate-order skew** — reproduced bit-for-bit in both skew directions; forward
+  pass is correct on both readers when the packing matches.
+- The published artifact + develop-pinned fused lib **agree (IOFC) and pass
+  (DER 0.209)** — shipped desktop/mobile diarization is not broken by the
+  published artifact today. int8-source cost is negligible (0.209 vs 0.211).
+- **Republishing an IFGO re-bake before syncing the fork would flip every
+  production fused lib to DER 1.000** (lane B/D is exactly that future).
+  Required sequence: (1) sync the fork's vendored `voice_diarizer.c` to IFGO +
+  port the #11569 fail-closed guard, (2) rebuild + repin fused libs,
+  (3) republish the epoch-2 IFGO artifact + bump the manifest sha.
+
+## Repro
+
+```bash
+# bake (no token; ONNX source is ungated)
+python3 packages/native/plugins/voice-classifier-cpp/scripts/voice_diarizer_to_gguf.py \
+  --output /tmp/pyannote-segmentation-3.0-fresh.gguf
+
+# bench (per lane, swap ELIZA_DIARIZ_GGUF)
+cd plugins/plugin-local-inference
+ELIZA_INFERENCE_LIBRARY=<fused libelizainference> \
+ELIZA_DIARIZ_GGUF=<artifact under test> \
+ELIZA_SPEAKER_GGUF=<wespeaker-resnet34-lm.gguf> \
+ELIZA_KOKORO_MODEL_DIR=<eliza-1 bundle>/tts/kokoro \
+NODE_OPTIONS='--experimental-sqlite' bun scripts/speaker-isolation-real.ts
+
+# standalone IFGO-reader probe
+cmake -B build -S packages/native/plugins/voice-classifier-cpp && cmake --build build -j
+cc -O2 -I packages/native/plugins/voice-classifier-cpp/include diar_probe.c \
+   build/libvoice_classifier.a -o diar_probe -lm
+./diar_probe <gguf> <16k-mono-pcm16.wav>
+```
+
+PR #11569 guard verified against real artifacts (its branch, built locally,
+8/8 ctest green): published `30983eba` → rejected
+(`stale GGUF converter epoch 0; need >= 2`), develop bake `7f4cd30f` →
+rejected (no epoch key), epoch-2 bake `100a5dbf` → accepted, full tensor load
+OK.

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/artifact-shas.txt
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/artifact-shas.txt
@@ -1,0 +1,4 @@
+100a5dbfd480b0cd6b0e01f0a9974ba836412721dfa0e36b7c1bb5a041abfbde  pyannote-segmentation-3.0-fresh-ifgo-epoch2.gguf
+7f4cd30f2df470c97a1d6aada5bd60f15166ec69d5d363cb8aadba1a77c891d0  pyannote-segmentation-3.0-fresh-ifgo.gguf
+d0d6c1e561799842785e3bb9eedbe0db154e3c6263e6c40aa49dfbddcffd316e  pyannote-segmentation-3.0-fresh-iofc.gguf
+30983eba41c0a99ab7eada564739ae8be74faeb21a31da759c870b5173cbd8a5  /Users/shawwalters/.eliza/local-inference/models/voice/diarizer/pyannote-segmentation-3.0.gguf

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/diar_probe.c
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/diar_probe.c
@@ -1,0 +1,60 @@
+/* Probe: open a diarizer GGUF, run voice_diarizer_segment on a 5s window from
+ * a 16 kHz mono PCM16 wav, print per-frame label histogram + transition count.
+ * Gate-scrambled weights -> micro-segment flood (many transitions, phantom
+ * multi-speaker labels). Correct weights -> few transitions. */
+#include "voice_classifier/voice_classifier.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define WINDOW_SAMPLES 80000
+#define MAX_FRAMES 512
+
+static int read_wav(const char *path, float *out, int max_samples) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    unsigned char hdr[12];
+    if (fread(hdr, 1, 12, f) != 12 || memcmp(hdr, "RIFF", 4) || memcmp(hdr + 8, "WAVE", 4)) { fclose(f); return -1; }
+    unsigned char ch[8];
+    long data_off = -1; unsigned data_len = 0;
+    while (fread(ch, 1, 8, f) == 8) {
+        unsigned len = ch[4] | (ch[5] << 8) | (ch[6] << 16) | ((unsigned)ch[7] << 24);
+        if (!memcmp(ch, "data", 4)) { data_off = ftell(f); data_len = len; break; }
+        fseek(f, (long)((len + 1) & ~1u), SEEK_CUR);
+    }
+    if (data_off < 0) { fclose(f); return -1; }
+    int n = (int)(data_len / 2);
+    if (n > max_samples) n = max_samples;
+    int16_t *buf = malloc((size_t)n * 2);
+    if (fread(buf, 2, (size_t)n, f) != (size_t)n) { free(buf); fclose(f); return -1; }
+    fclose(f);
+    for (int i = 0; i < n; ++i) out[i] = (float)buf[i] / 32768.0f;
+    for (int i = n; i < max_samples; ++i) out[i] = 0.0f;
+    free(buf);
+    return n;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s <gguf> <wav>\n", argv[0]); return 2; }
+    voice_diarizer_handle h = NULL;
+    int rc = voice_diarizer_open(argv[1], &h);
+    if (rc != 0) { fprintf(stderr, "open rc=%d\n", rc); return 1; }
+    static float pcm[WINDOW_SAMPLES];
+    if (read_wav(argv[2], pcm, WINDOW_SAMPLES) <= 0) { fprintf(stderr, "bad wav\n"); return 1; }
+    int8_t labels[MAX_FRAMES];
+    size_t cap = MAX_FRAMES;
+    rc = voice_diarizer_segment(h, pcm, WINDOW_SAMPLES, labels, &cap);
+    if (rc != 0) { fprintf(stderr, "segment rc=%d\n", rc); return 1; }
+    int hist[VOICE_DIARIZER_NUM_CLASSES] = {0};
+    int transitions = 0;
+    for (int t = 0; t < cap; ++t) {
+        if (labels[t] >= 0 && labels[t] < VOICE_DIARIZER_NUM_CLASSES) hist[(int)labels[t]] += 1;
+        if (t > 0 && labels[t] != labels[t - 1]) transitions += 1;
+    }
+    printf("frames=%zu transitions=%d hist=[", cap, transitions);
+    for (int c = 0; c < VOICE_DIARIZER_NUM_CLASSES; ++c) printf("%s%d", c ? "," : "", hist[c]);
+    printf("]\n");
+    voice_diarizer_close(h);
+    return 0;
+}

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/published-tensor-forensics.txt
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/published-tensor-forensics.txt
@@ -1,0 +1,38 @@
+published tensor count: 35
+missing from published: []
+extra in published: []
+classifier.bias              best=IFGO     IFGO=0 IOFC=0
+classifier.weight            best=IFGO     IFGO=0.009656 IFGO.T=3.246 IOFC=0.009656 IOFC.T=3.246
+linear0.bias                 best=IFGO     IFGO=0 IOFC=0
+linear0.weight               best=IFGO     IFGO=0.03775 IFGO.T=9.892 IOFC=0.03775 IOFC.T=9.892
+linear1.bias                 best=IFGO     IFGO=0 IOFC=0
+linear1.weight               best=IFGO     IFGO=0.02557 IFGO.T=6.598 IOFC=0.02557 IOFC.T=6.598
+lstm.0.W_hh                  best=IOFC     IFGO=8.236 IOFC=0.02652
+lstm.0.W_ih                  best=IOFC     IFGO=12.4 IOFC=0.03869
+lstm.0.b_hh                  best=IOFC     IFGO=2.103 IFGO.T=2.25 IOFC=0 IOFC.T=2.681
+lstm.0.b_ih                  best=IOFC     IFGO=2.151 IFGO.T=2.184 IOFC=0 IOFC.T=2.642
+lstm.1.W_hh                  best=IOFC     IFGO=7.504 IOFC=0.02181
+lstm.1.W_ih                  best=IOFC     IFGO=10.29 IOFC=0.02811
+lstm.1.b_hh                  best=IOFC     IFGO=2.745 IFGO.T=2.911 IOFC=0 IOFC.T=3.352
+lstm.1.b_ih                  best=IOFC     IFGO=2.755 IFGO.T=3.037 IOFC=0 IOFC.T=3.115
+lstm.2.W_hh                  best=IOFC     IFGO=8.844 IOFC=0.02627
+lstm.2.W_ih                  best=IOFC     IFGO=8.819 IOFC=0.03139
+lstm.2.b_hh                  best=IOFC     IFGO=2.409 IFGO.T=3.275 IOFC=0 IOFC.T=3.09
+lstm.2.b_ih                  best=IOFC     IFGO=2.371 IFGO.T=3.295 IOFC=0 IOFC.T=3.023
+lstm.3.W_hh                  best=IOFC     IFGO=10.05 IOFC=0.03284
+lstm.3.W_ih                  best=IOFC     IFGO=10.16 IOFC=0.03865
+lstm.3.b_hh                  best=IOFC     IFGO=4.207 IFGO.T=3.877 IOFC=0 IOFC.T=4.28
+lstm.3.b_ih                  best=IOFC     IFGO=4.232 IFGO.T=3.929 IOFC=0 IOFC.T=4.42
+sincnet.conv0.weight         best=IFGO     IFGO=0.003936 IOFC=0.003936
+sincnet.conv1.bias           best=IFGO     IFGO=0 IOFC=0
+sincnet.conv1.weight         best=IFGO     IFGO=0.03117 IOFC=0.03117
+sincnet.conv2.bias           best=IFGO     IFGO=0 IOFC=0
+sincnet.conv2.weight         best=IFGO     IFGO=0.03945 IOFC=0.03945
+sincnet.norm0.bias           best=IFGO     IFGO=0 IOFC=0
+sincnet.norm0.weight         best=IFGO     IFGO=0 IOFC=0
+sincnet.norm1.bias           best=IFGO     IFGO=0 IOFC=0
+sincnet.norm1.weight         best=IFGO     IFGO=0 IOFC=0
+sincnet.norm2.bias           best=IFGO     IFGO=0 IOFC=0
+sincnet.norm2.weight         best=IFGO     IFGO=0 IOFC=0
+sincnet.norm_in.bias         best=IFGO     IFGO=0 IOFC=0
+sincnet.norm_in.weight       best=IFGO     IFGO=0 IOFC=0

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-A-published-iofc.json
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-A-published-iofc.json
@@ -1,0 +1,129 @@
+{
+	"schemaVersion": 1,
+	"generatedAt": "2026-07-02T21:17:54.082Z",
+	"host": "darwin-arm64",
+	"lib": "/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib",
+	"diarizGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/diarizer/pyannote-segmentation-3.0.gguf",
+	"speakerGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
+	"thresholds": {
+		"minAccuracy": 0.8,
+		"maxDer": 0.6
+	},
+	"attribution": {
+		"scored": 6,
+		"correct": 6,
+		"accuracy": 1,
+		"intraMean": 0.16156001436258177,
+		"interMean": 0.9797653087401397,
+		"margin": 0.818205294377558,
+		"perTurn": [
+			{
+				"id": "turn-03",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.20738247779699748,
+				"distanceToNearestOther": 1.0016068914472878
+			},
+			{
+				"id": "turn-04",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.14791372673837944,
+				"distanceToNearestOther": 0.9793492395986751
+			},
+			{
+				"id": "turn-05",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.16652357563572295,
+				"distanceToNearestOther": 1.0071049153411324
+			},
+			{
+				"id": "turn-06",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.13747552817222486,
+				"distanceToNearestOther": 0.973614542404049
+			},
+			{
+				"id": "turn-07",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.19453925316067588,
+				"distanceToNearestOther": 0.9631769423660261
+			},
+			{
+				"id": "turn-08",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.11552552467149002,
+				"distanceToNearestOther": 0.9537393212836681
+			}
+		]
+	},
+	"mfccAccuracy": 0.5,
+	"der": {
+		"der": 0.20894660894660894,
+		"missedMs": 7240,
+		"falseAlarmMs": 0,
+		"confusionMs": 0,
+		"totalReferenceMs": 34650,
+		"mapping": {
+			"A": "A",
+			"B": "B"
+		}
+	},
+	"hypothesis": [
+		{
+			"speaker": "A",
+			"startMs": 939,
+			"endMs": 4556
+		},
+		{
+			"speaker": "B",
+			"startMs": 6109,
+			"endMs": 10000
+		},
+		{
+			"speaker": "A",
+			"startMs": 11314,
+			"endMs": 14727
+		},
+		{
+			"speaker": "B",
+			"startMs": 16314,
+			"endMs": 20000
+		},
+		{
+			"speaker": "A",
+			"startMs": 21638,
+			"endMs": 25000
+		},
+		{
+			"speaker": "B",
+			"startMs": 26792,
+			"endMs": 30000
+		},
+		{
+			"speaker": "A",
+			"startMs": 31399,
+			"endMs": 34420
+		},
+		{
+			"speaker": "B",
+			"startMs": 35836,
+			"endMs": 39061
+		}
+	],
+	"droppedShortMs": 358,
+	"overlap": {
+		"localSpeakerCount": 2,
+		"hasOverlap": true
+	}
+}

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-A-published-iofc.md
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-A-published-iofc.md
@@ -1,0 +1,17 @@
+# Speaker-isolation benchmark — two real Kokoro voices, real diarizer + encoder (CPU)
+
+Voices: af_bella (A) / am_michael (B), 8-turn dialogue, 600 ms gaps.
+
+- encoder attribution: **6/6** (accuracy 1.000, margin 0.818)
+- diarizer DER: **0.209** (missed 7240 ms, false-alarm 0 ms, confusion 0 ms, dropped-short 358 ms)
+- #9427 mean-MFCC attributor (model-free comparison): accuracy 0.500
+- overlap probe: localSpeakerCount=2, hasOverlap=true
+
+| turn | speaker | attributed | dist(own) | dist(other) | correct |
+| --- | --- | --- | ---: | ---: | --- |
+| turn-03 | A | A | 0.207 | 1.002 | ✓ |
+| turn-04 | B | B | 0.148 | 0.979 | ✓ |
+| turn-05 | A | A | 0.167 | 1.007 | ✓ |
+| turn-06 | B | B | 0.137 | 0.974 | ✓ |
+| turn-07 | A | A | 0.195 | 0.963 | ✓ |
+| turn-08 | B | B | 0.116 | 0.954 | ✓ |

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-B-fresh-ifgo.json
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-B-fresh-ifgo.json
@@ -1,0 +1,85 @@
+{
+	"schemaVersion": 1,
+	"generatedAt": "2026-07-02T21:20:33.914Z",
+	"host": "darwin-arm64",
+	"lib": "/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib",
+	"diarizGguf": "/private/tmp/fix-11377-scratch/pyannote-segmentation-3.0-fresh-ifgo.gguf",
+	"speakerGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
+	"thresholds": {
+		"minAccuracy": 0.8,
+		"maxDer": 0.6
+	},
+	"attribution": {
+		"scored": 6,
+		"correct": 6,
+		"accuracy": 1,
+		"intraMean": 0.16156001436258177,
+		"interMean": 0.9797653087401397,
+		"margin": 0.818205294377558,
+		"perTurn": [
+			{
+				"id": "turn-03",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.20738247779699748,
+				"distanceToNearestOther": 1.0016068914472878
+			},
+			{
+				"id": "turn-04",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.14791372673837944,
+				"distanceToNearestOther": 0.9793492395986751
+			},
+			{
+				"id": "turn-05",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.16652357563572295,
+				"distanceToNearestOther": 1.0071049153411324
+			},
+			{
+				"id": "turn-06",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.13747552817222486,
+				"distanceToNearestOther": 0.973614542404049
+			},
+			{
+				"id": "turn-07",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.19453925316067588,
+				"distanceToNearestOther": 0.9631769423660261
+			},
+			{
+				"id": "turn-08",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.11552552467149002,
+				"distanceToNearestOther": 0.9537393212836681
+			}
+		]
+	},
+	"mfccAccuracy": 0.5,
+	"der": {
+		"der": 1,
+		"missedMs": 34650,
+		"falseAlarmMs": 0,
+		"confusionMs": 0,
+		"totalReferenceMs": 34650,
+		"mapping": {}
+	},
+	"hypothesis": [],
+	"droppedShortMs": 74560,
+	"overlap": {
+		"localSpeakerCount": 3,
+		"hasOverlap": true
+	}
+}

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-B-fresh-ifgo.md
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-B-fresh-ifgo.md
@@ -1,0 +1,17 @@
+# Speaker-isolation benchmark — two real Kokoro voices, real diarizer + encoder (CPU)
+
+Voices: af_bella (A) / am_michael (B), 8-turn dialogue, 600 ms gaps.
+
+- encoder attribution: **6/6** (accuracy 1.000, margin 0.818)
+- diarizer DER: **1.000** (missed 34650 ms, false-alarm 0 ms, confusion 0 ms, dropped-short 74560 ms)
+- #9427 mean-MFCC attributor (model-free comparison): accuracy 0.500
+- overlap probe: localSpeakerCount=3, hasOverlap=true
+
+| turn | speaker | attributed | dist(own) | dist(other) | correct |
+| --- | --- | --- | ---: | ---: | --- |
+| turn-03 | A | A | 0.207 | 1.002 | ✓ |
+| turn-04 | B | B | 0.148 | 0.979 | ✓ |
+| turn-05 | A | A | 0.167 | 1.007 | ✓ |
+| turn-06 | B | B | 0.137 | 0.974 | ✓ |
+| turn-07 | A | A | 0.195 | 0.963 | ✓ |
+| turn-08 | B | B | 0.116 | 0.954 | ✓ |

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-C-fresh-iofc.json
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-C-fresh-iofc.json
@@ -1,0 +1,129 @@
+{
+	"schemaVersion": 1,
+	"generatedAt": "2026-07-02T21:22:45.183Z",
+	"host": "darwin-arm64",
+	"lib": "/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib",
+	"diarizGguf": "/private/tmp/fix-11377-scratch/pyannote-segmentation-3.0-fresh-iofc.gguf",
+	"speakerGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
+	"thresholds": {
+		"minAccuracy": 0.8,
+		"maxDer": 0.6
+	},
+	"attribution": {
+		"scored": 6,
+		"correct": 6,
+		"accuracy": 1,
+		"intraMean": 0.16156001436258177,
+		"interMean": 0.9797653087401397,
+		"margin": 0.818205294377558,
+		"perTurn": [
+			{
+				"id": "turn-03",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.20738247779699748,
+				"distanceToNearestOther": 1.0016068914472878
+			},
+			{
+				"id": "turn-04",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.14791372673837944,
+				"distanceToNearestOther": 0.9793492395986751
+			},
+			{
+				"id": "turn-05",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.16652357563572295,
+				"distanceToNearestOther": 1.0071049153411324
+			},
+			{
+				"id": "turn-06",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.13747552817222486,
+				"distanceToNearestOther": 0.973614542404049
+			},
+			{
+				"id": "turn-07",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.19453925316067588,
+				"distanceToNearestOther": 0.9631769423660261
+			},
+			{
+				"id": "turn-08",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.11552552467149002,
+				"distanceToNearestOther": 0.9537393212836681
+			}
+		]
+	},
+	"mfccAccuracy": 0.5,
+	"der": {
+		"der": 0.2106782106782107,
+		"missedMs": 7300,
+		"falseAlarmMs": 0,
+		"confusionMs": 0,
+		"totalReferenceMs": 34650,
+		"mapping": {
+			"A": "A",
+			"B": "B"
+		}
+	},
+	"hypothesis": [
+		{
+			"speaker": "A",
+			"startMs": 939,
+			"endMs": 4556
+		},
+		{
+			"speaker": "B",
+			"startMs": 6092,
+			"endMs": 10000
+		},
+		{
+			"speaker": "A",
+			"startMs": 11314,
+			"endMs": 14693
+		},
+		{
+			"speaker": "B",
+			"startMs": 16314,
+			"endMs": 20000
+		},
+		{
+			"speaker": "A",
+			"startMs": 21638,
+			"endMs": 25000
+		},
+		{
+			"speaker": "B",
+			"startMs": 26809,
+			"endMs": 30000
+		},
+		{
+			"speaker": "A",
+			"startMs": 31399,
+			"endMs": 34386
+		},
+		{
+			"speaker": "B",
+			"startMs": 35836,
+			"endMs": 39061
+		}
+	],
+	"droppedShortMs": 273,
+	"overlap": {
+		"localSpeakerCount": 2,
+		"hasOverlap": true
+	}
+}

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-C-fresh-iofc.md
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-C-fresh-iofc.md
@@ -1,0 +1,17 @@
+# Speaker-isolation benchmark — two real Kokoro voices, real diarizer + encoder (CPU)
+
+Voices: af_bella (A) / am_michael (B), 8-turn dialogue, 600 ms gaps.
+
+- encoder attribution: **6/6** (accuracy 1.000, margin 0.818)
+- diarizer DER: **0.211** (missed 7300 ms, false-alarm 0 ms, confusion 0 ms, dropped-short 273 ms)
+- #9427 mean-MFCC attributor (model-free comparison): accuracy 0.500
+- overlap probe: localSpeakerCount=2, hasOverlap=true
+
+| turn | speaker | attributed | dist(own) | dist(other) | correct |
+| --- | --- | --- | ---: | ---: | --- |
+| turn-03 | A | A | 0.207 | 1.002 | ✓ |
+| turn-04 | B | B | 0.148 | 0.979 | ✓ |
+| turn-05 | A | A | 0.167 | 1.007 | ✓ |
+| turn-06 | B | B | 0.137 | 0.974 | ✓ |
+| turn-07 | A | A | 0.195 | 0.963 | ✓ |
+| turn-08 | B | B | 0.116 | 0.954 | ✓ |

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-D-fresh-ifgo-epoch2.json
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-D-fresh-ifgo-epoch2.json
@@ -1,0 +1,85 @@
+{
+	"schemaVersion": 1,
+	"generatedAt": "2026-07-02T21:23:58.157Z",
+	"host": "darwin-arm64",
+	"lib": "/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib",
+	"diarizGguf": "/private/tmp/fix-11377-scratch/pyannote-segmentation-3.0-fresh-ifgo-epoch2.gguf",
+	"speakerGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
+	"thresholds": {
+		"minAccuracy": 0.8,
+		"maxDer": 0.6
+	},
+	"attribution": {
+		"scored": 6,
+		"correct": 6,
+		"accuracy": 1,
+		"intraMean": 0.16156001436258177,
+		"interMean": 0.9797653087401397,
+		"margin": 0.818205294377558,
+		"perTurn": [
+			{
+				"id": "turn-03",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.20738247779699748,
+				"distanceToNearestOther": 1.0016068914472878
+			},
+			{
+				"id": "turn-04",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.14791372673837944,
+				"distanceToNearestOther": 0.9793492395986751
+			},
+			{
+				"id": "turn-05",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.16652357563572295,
+				"distanceToNearestOther": 1.0071049153411324
+			},
+			{
+				"id": "turn-06",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.13747552817222486,
+				"distanceToNearestOther": 0.973614542404049
+			},
+			{
+				"id": "turn-07",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.19453925316067588,
+				"distanceToNearestOther": 0.9631769423660261
+			},
+			{
+				"id": "turn-08",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.11552552467149002,
+				"distanceToNearestOther": 0.9537393212836681
+			}
+		]
+	},
+	"mfccAccuracy": 0.5,
+	"der": {
+		"der": 1,
+		"missedMs": 34650,
+		"falseAlarmMs": 0,
+		"confusionMs": 0,
+		"totalReferenceMs": 34650,
+		"mapping": {}
+	},
+	"hypothesis": [],
+	"droppedShortMs": 74560,
+	"overlap": {
+		"localSpeakerCount": 3,
+		"hasOverlap": true
+	}
+}

--- a/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-D-fresh-ifgo-epoch2.md
+++ b/.github/issue-evidence/11377-diarizer-rebake-confirm/speaker-isolation-D-fresh-ifgo-epoch2.md
@@ -1,0 +1,17 @@
+# Speaker-isolation benchmark — two real Kokoro voices, real diarizer + encoder (CPU)
+
+Voices: af_bella (A) / am_michael (B), 8-turn dialogue, 600 ms gaps.
+
+- encoder attribution: **6/6** (accuracy 1.000, margin 0.818)
+- diarizer DER: **1.000** (missed 34650 ms, false-alarm 0 ms, confusion 0 ms, dropped-short 74560 ms)
+- #9427 mean-MFCC attributor (model-free comparison): accuracy 0.500
+- overlap probe: localSpeakerCount=3, hasOverlap=true
+
+| turn | speaker | attributed | dist(own) | dist(other) | correct |
+| --- | --- | --- | ---: | ---: | --- |
+| turn-03 | A | A | 0.207 | 1.002 | ✓ |
+| turn-04 | B | B | 0.148 | 0.979 | ✓ |
+| turn-05 | A | A | 0.167 | 1.007 | ✓ |
+| turn-06 | B | B | 0.137 | 0.974 | ✓ |
+| turn-07 | A | A | 0.195 | 0.963 | ✓ |
+| turn-08 | B | B | 0.116 | 0.954 | ✓ |


### PR DESCRIPTION
Evidence-only: the 4-lane DER matrix (published/fresh-IFGO/fresh-IOFC/epoch-2 bakes against the pinned fused lib), tensor forensics, probe source, artifact SHAs, and README with exact repro commands, backing https://github.com/elizaOS/eliza/issues/11377#issuecomment-4870649868.

Headline: the published HF diarizer GGUF + shipped fused lib AGREE (DER 0.209); the current converter's IFGO output is what the fork's vendored IOFC reader scrambles (DER 1.000). The previously-planned re-bake+republish would have broken production — the corrected mandatory operator sequence (fork reader sync → fused-lib repin → THEN republish) is on the issue.

Refs #11377 #11569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)