### PR TITLE
feat(cloud): add hosted app session analytics

### DIFF
--- a/.github/issue-evidence/11349-hosted-analytics-sessions.md
+++ b/.github/issue-evidence/11349-hosted-analytics-sessions.md
@@ -1,0 +1,44 @@
+# 11349 hosted frontend session analytics evidence
+
+Date: 2026-07-02
+
+## What changed
+
+- Hosted frontend pageview beacons now include stable visitor and session IDs.
+- Hosted frontend serving tolerates malformed analytics cookie percent-encoding.
+- App analytics can aggregate `pageview` request rows into sessions, visitor counts, bounce rate, recent sessions, and ordered funnel steps.
+- `/api/v1/apps/:id/analytics/requests?view=sessions` returns the sessions DTO only for the owning organization.
+- The app analytics UI has a Sessions tab that renders the session summary, ordered funnel, and recent session table.
+
+## Verification
+
+- `bunx biome check packages/cloud/shared/src/lib/services/app-analytics.ts packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts`
+  - Passed.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Passed.
+- `bun run --cwd packages/cloud/api typecheck`
+  - Passed.
+- `bun run --cwd packages/ui typecheck`
+  - Passed.
+- `bun test packages/cloud/shared/src/lib/services/app-analytics.test.ts packages/cloud/shared/src/lib/services/app-frontend-hosting.test.ts`
+  - Passed: 22 tests.
+- `bun test packages/cloud/api/__tests__/hosted-frontend-serve.integration.test.ts packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts`
+  - Passed: 13 tests.
+- `bun test packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts`
+  - Passed: 2 tests.
+- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts`
+  - Passed, including the PGlite-backed `AppAnalyticsService session analytics from app_requests` test.
+- `bun run --cwd packages/ui test -- src/cloud/applications/components/app-analytics.test.tsx`
+  - Passed: 1 test.
+- `bun run --cwd packages/app audit:app`
+  - Ran the full app visual sweep: 348 captures passed.
+  - The `builtin-apps` route, which reaches the app analytics surface, was `good` on mobile portrait, mobile landscape, desktop landscape, and iPad portrait.
+  - The command exited 1 on unrelated visual audit debt:
+    - `plugin-inbox-gui @ mobile-landscape`: minimalism ratchet regression.
+    - `plugin-screenshare-gui @ mobile-portrait`: minimalism ratchet regression.
+    - `plugin-finances-gui @ mobile-landscape`: hover probe timeout.
+    - `plugin-finances-tui @ mobile-landscape`: hover probe timeout.
+
+## Manual review
+
+The app analytics entry route captured by the audit (`builtin-apps`) was marked `good` across all audited viewports. The remaining audit failures are outside the #11349 app analytics surface and should be handled separately before a final PR can satisfy the repo-wide UI audit gate.

--- a/packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * App analytics requests route — real Hono route, mocked auth/data seams.
+ * Pins the hosted-frontend sessions view added for #11349 without requiring a
+ * live Worker or database.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import * as realAuth from "@/lib/auth";
+import * as realAppKeyScope from "@/lib/auth/app-key-scope";
+import * as realAnalytics from "@/lib/services/app-analytics";
+import * as realApps from "@/lib/services/apps";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_B = "22222222-2222-4222-8222-222222222222";
+const APP_ID = "99999999-9999-4999-8999-000000000001";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+let authOrg = ORG_A;
+const getById = mock(async (id: string) =>
+  id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
+);
+const getSessionAnalytics = mock(async () => ({
+  summary: {
+    totalSessions: 2,
+    uniqueVisitors: 2,
+    totalPageViews: 5,
+    avgPagesPerSession: 2.5,
+    avgSessionDurationMs: 120000,
+    bounceRatePercent: 0,
+  },
+  sessions: [
+    {
+      sessionId: "session-a",
+      visitorId: "visitor-a",
+      startedAt: "2026-07-02T12:00:00.000Z",
+      endedAt: "2026-07-02T12:04:00.000Z",
+      durationMs: 240000,
+      pageViews: 3,
+      entryPath: "/",
+      exitPath: "/checkout",
+    },
+  ],
+  funnel: {
+    totalEntrants: 2,
+    steps: [
+      {
+        path: "/",
+        label: "Home",
+        sessions: 2,
+        visitors: 2,
+        conversionFromStartPercent: 100,
+        conversionFromPreviousPercent: 100,
+      },
+      {
+        path: "/checkout",
+        label: "Checkout",
+        sessions: 1,
+        visitors: 1,
+        conversionFromStartPercent: 50,
+        conversionFromPreviousPercent: 50,
+      },
+    ],
+  },
+}));
+
+mock.module("@/lib/auth", () => ({
+  ...realAuth,
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { organization_id: authOrg },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/services/apps", () => ({
+  ...realApps,
+  appsService: {
+    getById,
+  },
+}));
+mock.module("@/lib/services/app-analytics", () => ({
+  ...realAnalytics,
+  appAnalyticsService: {
+    getSessionAnalytics,
+  },
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  ...realAppKeyScope,
+  isAppKeyOutOfScope: async () => false,
+}));
+
+const route = (await import("../v1/apps/[id]/analytics/requests/route"))
+  .default;
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/apps/:id/analytics/requests", route);
+  return app;
+}
+
+describe("app analytics sessions route (#11349)", () => {
+  beforeEach(() => {
+    authOrg = ORG_A;
+    getById.mockClear();
+    getSessionAnalytics.mockClear();
+  });
+
+  test("returns computed sessions + funnel DTO for the owning org", async () => {
+    const app = buildApp();
+    const res = await app.request(
+      `/api/v1/apps/${APP_ID}/analytics/requests?view=sessions&limit=40&funnel_steps=/,/checkout`,
+      {},
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      sessions: {
+        summary: { totalSessions: number };
+        funnel: { steps: Array<{ path: string }> };
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.sessions.summary.totalSessions).toBe(2);
+    expect(
+      body.sessions.funnel.steps.map((step: { path: string }) => step.path),
+    ).toEqual(["/", "/checkout"]);
+    expect(getSessionAnalytics).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({
+        limit: 40,
+        funnelSteps: ["/", "/checkout"],
+      }),
+    );
+  });
+
+  test("denies another org before reading session analytics", async () => {
+    authOrg = ORG_B;
+    const app = buildApp();
+    const res = await app.request(
+      `/api/v1/apps/${APP_ID}/analytics/requests?view=sessions`,
+      {},
+      ENV,
+    );
+
+    expect(res.status).toBe(403);
+    expect(getSessionAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/__tests__/hosted-frontend-serve.integration.test.ts
+++ b/packages/cloud/api/__tests__/hosted-frontend-serve.integration.test.ts
@@ -179,6 +179,61 @@ describe("public hosted-frontend serve", () => {
     expect(trackPageView).toHaveBeenCalled();
   });
 
+  test("sets analytics cookies and records matching hosted-frontend session metadata", async () => {
+    getBySlugImpl = async (slug) => (slug === "cool" ? APP : undefined);
+    getActiveImpl = async (id) =>
+      id === "app_1" ? activeDeployment : undefined;
+    const res = await app.request(
+      "/api/v1/hosted-frontend/serve?host=cool.sites.elizacloud.ai",
+      {
+        headers: {
+          cookie:
+            "eliza_visitor_id=visitor-abc123; eliza_session_id=session-def456",
+        },
+      },
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.getSetCookie?.() ?? [];
+    expect(setCookie.join("\n")).toContain("eliza_visitor_id=visitor-abc123");
+    expect(setCookie.join("\n")).toContain("eliza_session_id=session-def456");
+    expect(trackPageView).toHaveBeenCalledWith(
+      "app_1",
+      expect.objectContaining({
+        source: "hosted_frontend",
+        metadata: expect.objectContaining({
+          visitor_id: "visitor-abc123",
+          session_id: "session-def456",
+        }),
+      }),
+    );
+    expect(await res.text()).toContain('"visitor-abc123"');
+  });
+
+  test("ignores malformed analytics cookies instead of failing the hosted page", async () => {
+    getBySlugImpl = async (slug) => (slug === "cool" ? APP : undefined);
+    getActiveImpl = async (id) =>
+      id === "app_1" ? activeDeployment : undefined;
+    const res = await app.request(
+      "/api/v1/hosted-frontend/serve?host=cool.sites.elizacloud.ai",
+      { headers: { cookie: "eliza_visitor_id=%E0%A4%A" } },
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect(trackPageView).toHaveBeenCalledWith(
+      "app_1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          visitor_id: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          ),
+        }),
+      }),
+    );
+  });
+
   test("synthesizes robots.txt (allow + sitemap link) for a hosted frontend", async () => {
     getBySlugImpl = async (slug) => (slug === "cool" ? APP : undefined);
     getActiveImpl = async () => activeDeployment;

--- a/packages/cloud/api/__tests__/track-pageview.integration.test.ts
+++ b/packages/cloud/api/__tests__/track-pageview.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Beacon ingest route — real Hono route, mocked apps-service seam.
+ * Pins boundary validation of the #11349 visitor/session analytics ids:
+ * well-formed ids persist into pageview metadata, garbage never does.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import * as realApps from "@/lib/services/apps";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const APP_ID = "99999999-9999-4999-8999-000000000001";
+const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+const trackPageView = mock(async () => {});
+const getById = mock(async (id: string) =>
+  id === APP_ID ? { id: APP_ID, is_active: true } : null,
+);
+
+mock.module("@/lib/services/apps", () => ({
+  ...realApps,
+  appsService: {
+    getById,
+    trackPageView,
+  },
+}));
+
+const route = (await import("../v1/track/pageview/route")).default;
+
+function buildApp() {
+  const app = new Hono<AppEnv>();
+  app.route("/api/v1/track/pageview", route);
+  return app;
+}
+
+function post(body: Record<string, unknown>) {
+  return buildApp().request(
+    "/api/v1/track/pageview",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    ENV,
+  );
+}
+
+describe("track pageview beacon ingest (#11349)", () => {
+  beforeEach(() => {
+    trackPageView.mockClear();
+    getById.mockClear();
+  });
+
+  test("persists well-formed visitor/session ids into pageview metadata", async () => {
+    const res = await post({
+      app_id: APP_ID,
+      page_url: "/pricing",
+      visitor_id: "visitor-abc123",
+      session_id: "11111111-2222-4333-8444-555555555555",
+    });
+
+    expect(res.status).toBe(200);
+    expect(trackPageView).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          visitor_id: "visitor-abc123",
+          session_id: "11111111-2222-4333-8444-555555555555",
+        }),
+      }),
+    );
+  });
+
+  test("drops oversized, unsafe, or non-string analytics ids at the boundary", async () => {
+    const res = await post({
+      app_id: APP_ID,
+      page_url: "/",
+      visitor_id: "x".repeat(4096),
+      session_id: { nested: "object" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(trackPageView).toHaveBeenCalledTimes(1);
+    const metadata = (
+      trackPageView.mock.calls[0] as unknown as [
+        string,
+        { metadata: Record<string, unknown> },
+      ]
+    )[1].metadata;
+    expect(metadata.visitor_id).toBeUndefined();
+    expect(metadata.session_id).toBeUndefined();
+  });
+
+  test("rejects a script-breakout style id instead of persisting it", async () => {
+    const res = await post({
+      app_id: APP_ID,
+      page_url: "/",
+      visitor_id: "</script><script>alert(1)</script>",
+      session_id: "session-ok-123",
+    });
+
+    expect(res.status).toBe(200);
+    const metadata = (
+      trackPageView.mock.calls[0] as unknown as [
+        string,
+        { metadata: Record<string, unknown> },
+      ]
+    )[1].metadata;
+    expect(metadata.visitor_id).toBeUndefined();
+    expect(metadata.session_id).toBe("session-ok-123");
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
@@ -7,6 +7,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { appAnalyticsService } from "@/lib/services/app-analytics";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -133,6 +134,22 @@ async function handleGET(
             start: timelineStart.toISOString(),
             end: timelineEnd.toISOString(),
           },
+        });
+      }
+      case "sessions": {
+        const funnelSteps = (searchParams.get("funnel_steps") ?? "")
+          .split(",")
+          .map((step) => step.trim())
+          .filter(Boolean);
+        const sessions = await appAnalyticsService.getSessionAnalytics(id, {
+          startDate,
+          endDate,
+          limit,
+          funnelSteps,
+        });
+        return Response.json({
+          success: true,
+          sessions,
         });
       }
       default: {

--- a/packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts
+++ b/packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts
@@ -25,6 +25,7 @@ import { appFrontendHostingService } from "@/lib/services/app-frontend-hosting";
 import { appsService } from "@/lib/services/apps";
 import { managedDomainsService } from "@/lib/services/managed-domains";
 import { logger } from "@/lib/utils/logger";
+import { safeAnalyticsId } from "@/lib/utils/safe-analytics-id";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const SERVE_MARKER = "/hosted-frontend/serve";
@@ -58,11 +59,6 @@ function cookieValue(
     }
   }
   return null;
-}
-
-function safeAnalyticsId(value: string | null): string | null {
-  if (!value) return null;
-  return /^[a-zA-Z0-9._:-]{8,128}$/.test(value) ? value : null;
 }
 
 function analyticsCookie(

--- a/packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts
+++ b/packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts
@@ -28,6 +28,10 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const SERVE_MARKER = "/hosted-frontend/serve";
+const VISITOR_COOKIE = "eliza_visitor_id";
+const SESSION_COOKIE = "eliza_session_id";
+const VISITOR_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+const SESSION_MAX_AGE_SECONDS = 60 * 30;
 
 function normalizeHost(host: string | undefined): string | null {
   const normalized = host
@@ -36,6 +40,37 @@ function normalizeHost(host: string | undefined): string | null {
     .replace(/\.+$/, "")
     .split(":")[0];
   return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function cookieValue(
+  cookieHeader: string | undefined,
+  name: string,
+): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const [rawKey, ...rawValue] = part.trim().split("=");
+    if (rawKey === name) {
+      try {
+        return decodeURIComponent(rawValue.join("="));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function safeAnalyticsId(value: string | null): string | null {
+  if (!value) return null;
+  return /^[a-zA-Z0-9._:-]{8,128}$/.test(value) ? value : null;
+}
+
+function analyticsCookie(
+  name: string,
+  value: string,
+  maxAgeSeconds: number,
+): string {
+  return `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAgeSeconds}; SameSite=Lax; Secure`;
 }
 
 async function resolveAppForHost(host: string) {
@@ -80,6 +115,13 @@ app.get("*", async (c) => {
       appRow.id,
     );
     if (!deployment) return c.text("Not Found", 404);
+    const cookieHeader = c.req.header("cookie");
+    const visitorId =
+      safeAnalyticsId(cookieValue(cookieHeader, VISITOR_COOKIE)) ??
+      crypto.randomUUID();
+    const sessionId =
+      safeAnalyticsId(cookieValue(cookieHeader, SESSION_COOKIE)) ??
+      crypto.randomUUID();
 
     const markerIdx = url.pathname.indexOf(SERVE_MARKER);
     const requestPath =
@@ -105,6 +147,7 @@ app.get("*", async (c) => {
         url: `${canonicalBase}${requestPath || "/"}`,
       },
       beaconBase: canonicalBase,
+      analytics: { visitorId, sessionId },
       siteBaseUrl: canonicalBase,
     });
 
@@ -119,7 +162,12 @@ app.get("*", async (c) => {
             "unknown",
           userAgent: c.req.header("user-agent") ?? "unknown",
           source: "hosted_frontend",
-          metadata: { host, deploymentId: deployment.id },
+          metadata: {
+            host,
+            deploymentId: deployment.id,
+            visitor_id: visitorId,
+            session_id: sessionId,
+          },
         })
         .catch((error) =>
           logger.warn("[Hosted Frontend] page-view record failed", {
@@ -134,9 +182,21 @@ app.get("*", async (c) => {
       }
     }
 
+    const headers = new Headers(rendered.headers);
+    if (rendered.isDocument) {
+      headers.append(
+        "Set-Cookie",
+        analyticsCookie(VISITOR_COOKIE, visitorId, VISITOR_MAX_AGE_SECONDS),
+      );
+      headers.append(
+        "Set-Cookie",
+        analyticsCookie(SESSION_COOKIE, sessionId, SESSION_MAX_AGE_SECONDS),
+      );
+    }
+
     return new Response(rendered.body, {
       status: rendered.status,
-      headers: rendered.headers,
+      headers,
     });
   } catch (error) {
     logger.error("[Hosted Frontend] serve failed:", error);

--- a/packages/cloud/api/v1/track/pageview/route.ts
+++ b/packages/cloud/api/v1/track/pageview/route.ts
@@ -12,6 +12,7 @@ import {
 import { apiKeysService } from "@/lib/services/api-keys";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
+import { safeAnalyticsId } from "@/lib/utils/safe-analytics-id";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 function detectSource(
@@ -112,8 +113,10 @@ app.post("/", async (c) => {
         origin,
         referer,
         pathname,
-        visitor_id,
-        session_id,
+        // Boundary-validated: same rule as the hosted-serve cookie ids. Reject
+        // wrong types / oversized / unsafe values instead of persisting them.
+        visitor_id: safeAnalyticsId(visitor_id) ?? undefined,
+        session_id: safeAnalyticsId(session_id) ?? undefined,
       },
     });
 

--- a/packages/cloud/api/v1/track/pageview/route.ts
+++ b/packages/cloud/api/v1/track/pageview/route.ts
@@ -49,6 +49,8 @@ app.post("/", async (c) => {
       api_key: bodyApiKey,
       page_url,
       referrer,
+      visitor_id,
+      session_id,
       screen_width,
       screen_height,
       pathname,
@@ -57,6 +59,8 @@ app.post("/", async (c) => {
       api_key?: string;
       page_url?: string;
       referrer?: string;
+      visitor_id?: string;
+      session_id?: string;
       screen_width?: number;
       screen_height?: number;
       pathname?: string;
@@ -102,7 +106,15 @@ app.post("/", async (c) => {
       ipAddress,
       userAgent,
       source,
-      metadata: { screen_width, screen_height, origin, referer, pathname },
+      metadata: {
+        screen_width,
+        screen_height,
+        origin,
+        referer,
+        pathname,
+        visitor_id,
+        session_id,
+      },
     });
 
     logger.debug("[Track] Page view recorded", {

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -57,6 +57,7 @@ const PGLITE_TIMEOUT = 60_000;
 const FRESH_UUID = "00000000-0000-4000-8000-00000000ffff";
 
 let appsService: typeof import("../../../lib/services/apps").appsService;
+let appAnalyticsService: typeof import("../../../lib/services/app-analytics").appAnalyticsService;
 let pgliteReady = true;
 
 // Monotonic counter keeps seeded slugs/identities unique across tests without
@@ -102,6 +103,7 @@ beforeAll(async () => {
   }
   try {
     ({ appsService } = await import("../../../lib/services/apps"));
+    ({ appAnalyticsService } = await import("../../../lib/services/app-analytics"));
 
     // Generate DDL from the real schema objects and apply it to the same
     // PGlite connection the repository queries through (`dbWrite`). Enums must
@@ -738,5 +740,82 @@ describe("AppsService.create organization cap", () => {
         process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
       }
     }
+  });
+});
+
+describe("AppAnalyticsService session analytics from app_requests", () => {
+  test("groups real pageview rows into sessions and ordered funnel steps", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+    const app = await createApp({
+      name: "Session Analytics App",
+      organization_id: organizationId,
+      created_by_user_id: userId,
+    });
+
+    await appsRepository.logRequest({
+      app_id: app.id,
+      request_type: "pageview",
+      source: "hosted_frontend",
+      ip_address: "203.0.113.10",
+      user_agent: "test-agent",
+      input_tokens: 0,
+      output_tokens: 0,
+      credits_used: "0.00",
+      status: "success",
+      metadata: {
+        visitor_id: "visitor-real-a",
+        session_id: "session-real-a",
+        page_url: "/",
+      },
+      created_at: new Date("2026-07-02T12:00:00.000Z"),
+    });
+    await appsRepository.logRequest({
+      app_id: app.id,
+      request_type: "pageview",
+      source: "hosted_frontend",
+      ip_address: "203.0.113.10",
+      user_agent: "test-agent",
+      input_tokens: 0,
+      output_tokens: 0,
+      credits_used: "0.00",
+      status: "success",
+      metadata: {
+        visitor_id: "visitor-real-a",
+        session_id: "session-real-a",
+        page_url: "/checkout",
+      },
+      created_at: new Date("2026-07-02T12:03:00.000Z"),
+    });
+    await appsRepository.logRequest({
+      app_id: app.id,
+      request_type: "pageview",
+      source: "hosted_frontend",
+      ip_address: "203.0.113.11",
+      user_agent: "test-agent",
+      input_tokens: 0,
+      output_tokens: 0,
+      credits_used: "0.00",
+      status: "success",
+      metadata: {
+        visitor_id: "visitor-real-b",
+        session_id: "session-real-b",
+        page_url: "/",
+      },
+      created_at: new Date("2026-07-02T12:01:00.000Z"),
+    });
+
+    const analytics = await appAnalyticsService.getSessionAnalytics(app.id, {
+      funnelSteps: ["/", "/checkout"],
+    });
+
+    expect(analytics.summary.totalSessions).toBe(2);
+    expect(analytics.summary.totalPageViews).toBe(3);
+    expect(analytics.sessions.map((session) => session.sessionId).sort()).toEqual([
+      "session-real-a",
+      "session-real-b",
+    ]);
+    expect(analytics.funnel.steps.map((step) => step.sessions)).toEqual([2, 1]);
+    expect(analytics.funnel.steps[1]?.conversionFromStartPercent).toBe(50);
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-analytics.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import type { AppRequest } from "../../db/repositories/apps";
+import { AppAnalyticsService } from "./app-analytics";
+
+const BASE_REQUEST = {
+  id: "00000000-0000-4000-8000-000000000001",
+  app_id: "00000000-0000-4000-8000-000000000002",
+  request_type: "pageview",
+  source: "hosted_frontend",
+  ip_address: "203.0.113.10",
+  user_agent: "test-agent",
+  country: null,
+  city: null,
+  user_id: null,
+  model: null,
+  input_tokens: 0,
+  output_tokens: 0,
+  credits_used: "0.000000",
+  response_time_ms: null,
+  status: "success",
+  error_message: null,
+  metadata: {},
+  created_at: new Date("2026-07-02T12:00:00.000Z"),
+} satisfies AppRequest;
+
+function request(id: string, at: string, metadata: Record<string, unknown>): AppRequest {
+  return {
+    ...BASE_REQUEST,
+    id,
+    metadata,
+    created_at: new Date(at),
+  };
+}
+
+describe("AppAnalyticsService.buildSessionAnalytics", () => {
+  test("groups pageviews by beacon session id and computes ordered funnel conversion", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics(
+      [
+        request("00000000-0000-4000-8000-000000000011", "2026-07-02T12:00:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/",
+        }),
+        request("00000000-0000-4000-8000-000000000012", "2026-07-02T12:02:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/pricing",
+        }),
+        request("00000000-0000-4000-8000-000000000013", "2026-07-02T12:04:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/checkout",
+        }),
+        request("00000000-0000-4000-8000-000000000014", "2026-07-02T12:01:00Z", {
+          visitor_id: "visitor-b",
+          session_id: "session-b",
+          page_url: "/",
+        }),
+        request("00000000-0000-4000-8000-000000000015", "2026-07-02T12:03:00Z", {
+          visitor_id: "visitor-b",
+          session_id: "session-b",
+          page_url: "/pricing",
+        }),
+      ],
+      ["/", "/pricing", "/checkout"],
+    );
+
+    expect(analytics.summary.totalSessions).toBe(2);
+    expect(analytics.summary.uniqueVisitors).toBe(2);
+    expect(analytics.summary.totalPageViews).toBe(5);
+    expect(analytics.summary.avgPagesPerSession).toBe(2.5);
+    expect(analytics.summary.bounceRatePercent).toBe(0);
+    expect(analytics.sessions[0]?.entryPath).toBe("/");
+    expect(analytics.sessions[0]?.exitPath).toBe("/pricing");
+
+    expect(analytics.funnel.totalEntrants).toBe(2);
+    expect(analytics.funnel.steps.map((s) => s.path)).toEqual(["/", "/pricing", "/checkout"]);
+    expect(analytics.funnel.steps.map((s) => s.sessions)).toEqual([2, 2, 1]);
+    expect(analytics.funnel.steps[2]?.conversionFromStartPercent).toBe(50);
+    expect(analytics.funnel.steps[2]?.conversionFromPreviousPercent).toBe(50);
+  });
+
+  test("falls back to IP/hour buckets for legacy pageviews without beacon ids", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics([
+      request("00000000-0000-4000-8000-000000000021", "2026-07-02T12:00:00Z", {
+        page_url: "/docs?x=1",
+      }),
+      request("00000000-0000-4000-8000-000000000022", "2026-07-02T12:10:00Z", {
+        pathname: "/docs/install",
+      }),
+    ]);
+
+    expect(analytics.summary.totalSessions).toBe(1);
+    expect(analytics.sessions[0]?.visitorId).toBe("203.0.113.10");
+    expect(analytics.sessions[0]?.entryPath).toBe("/docs");
+    expect(analytics.sessions[0]?.exitPath).toBe("/docs/install");
+  });
+
+  test("requires funnel steps to occur in order inside a session", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics(
+      [
+        request("00000000-0000-4000-8000-000000000031", "2026-07-02T12:00:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/",
+        }),
+        request("00000000-0000-4000-8000-000000000032", "2026-07-02T12:01:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/checkout",
+        }),
+        request("00000000-0000-4000-8000-000000000033", "2026-07-02T12:02:00Z", {
+          visitor_id: "visitor-a",
+          session_id: "session-a",
+          page_url: "/pricing",
+        }),
+        request("00000000-0000-4000-8000-000000000034", "2026-07-02T12:00:30Z", {
+          visitor_id: "visitor-b",
+          session_id: "session-b",
+          page_url: "/",
+        }),
+        request("00000000-0000-4000-8000-000000000035", "2026-07-02T12:01:30Z", {
+          visitor_id: "visitor-b",
+          session_id: "session-b",
+          page_url: "/pricing",
+        }),
+        request("00000000-0000-4000-8000-000000000036", "2026-07-02T12:02:30Z", {
+          visitor_id: "visitor-b",
+          session_id: "session-b",
+          page_url: "/checkout",
+        }),
+      ],
+      ["/", "/pricing", "/checkout"],
+    );
+
+    expect(analytics.funnel.steps.map((s) => s.sessions)).toEqual([2, 2, 1]);
+    expect(analytics.funnel.steps[2]?.visitors).toBe(1);
+    expect(analytics.funnel.steps[2]?.conversionFromPreviousPercent).toBe(50);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-analytics.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.test.ts
@@ -140,4 +140,47 @@ describe("AppAnalyticsService.buildSessionAnalytics", () => {
     expect(analytics.funnel.steps[2]?.visitors).toBe(1);
     expect(analytics.funnel.steps[2]?.conversionFromPreviousPercent).toBe(50);
   });
+
+  test("splits legacy fallback sessions at the hour-bucket window boundary", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics([
+      request("00000000-0000-4000-8000-000000000041", "2026-07-02T12:59:00Z", {
+        page_url: "/a",
+      }),
+      request("00000000-0000-4000-8000-000000000042", "2026-07-02T13:01:00Z", {
+        page_url: "/b",
+      }),
+    ]);
+
+    // Same IP two minutes apart, but the pageviews land in different hour
+    // buckets, so the fallback sessionizer produces two single-page sessions.
+    expect(analytics.summary.totalSessions).toBe(2);
+    expect(analytics.summary.uniqueVisitors).toBe(1);
+    expect(analytics.summary.bounceRatePercent).toBe(100);
+    expect(analytics.sessions.map((s) => s.pageViews)).toEqual([1, 1]);
+  });
+
+  test("keeps one session when a beacon session id spans the fallback window boundary", () => {
+    const service = new AppAnalyticsService();
+    const analytics = service.buildSessionAnalytics([
+      request("00000000-0000-4000-8000-000000000051", "2026-07-02T12:59:00Z", {
+        visitor_id: "visitor-a",
+        session_id: "session-a",
+        page_url: "/a",
+      }),
+      request("00000000-0000-4000-8000-000000000052", "2026-07-02T13:30:00Z", {
+        visitor_id: "visitor-a",
+        session_id: "session-a",
+        page_url: "/b",
+      }),
+    ]);
+
+    // Beacon-provided session ids own the session lifetime: the hour-bucket
+    // fallback never splits rows that carry an explicit session id.
+    expect(analytics.summary.totalSessions).toBe(1);
+    expect(analytics.sessions[0]?.pageViews).toBe(2);
+    expect(analytics.sessions[0]?.durationMs).toBe(31 * 60 * 1000);
+    expect(analytics.sessions[0]?.entryPath).toBe("/a");
+    expect(analytics.sessions[0]?.exitPath).toBe("/b");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/app-analytics.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.ts
@@ -4,9 +4,82 @@
  * Handles tracking and aggregation of app usage analytics
  */
 
-import { appsRepository, type NewAppAnalytics } from "../../db/repositories/apps";
+import { type AppRequest, appsRepository, type NewAppAnalytics } from "../../db/repositories/apps";
 import type { App } from "../types";
 import { logger } from "../utils/logger";
+
+export interface AppSessionRow {
+  sessionId: string;
+  visitorId: string;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  pageViews: number;
+  entryPath: string;
+  exitPath: string;
+}
+
+export interface AppFunnelStep {
+  path: string;
+  label: string;
+  sessions: number;
+  visitors: number;
+  conversionFromStartPercent: number;
+  conversionFromPreviousPercent: number;
+}
+
+export interface AppSessionAnalytics {
+  summary: {
+    totalSessions: number;
+    uniqueVisitors: number;
+    totalPageViews: number;
+    avgPagesPerSession: number;
+    avgSessionDurationMs: number;
+    bounceRatePercent: number;
+  };
+  sessions: AppSessionRow[];
+  funnel: {
+    totalEntrants: number;
+    steps: AppFunnelStep[];
+  };
+}
+
+function metadataString(
+  metadata: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalizePath(value: string | null | undefined): string {
+  if (!value) return "/";
+  try {
+    const parsed = value.startsWith("http")
+      ? new URL(value).pathname
+      : new URL(value, "https://app.local").pathname;
+    return parsed || "/";
+  } catch {
+    const path = value.split("?")[0]?.trim();
+    return path?.startsWith("/") ? path || "/" : `/${path || ""}`;
+  }
+}
+
+function labelForPath(path: string): string {
+  if (path === "/") return "Home";
+  return (
+    path
+      .split("/")
+      .filter(Boolean)
+      .slice(-1)[0]
+      ?.replace(/[-_]+/g, " ")
+      .replace(/\b\w/g, (ch) => ch.toUpperCase()) ?? path
+  );
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 1000) / 10;
+}
 
 export class AppAnalyticsService {
   /**
@@ -87,6 +160,186 @@ export class AppAnalyticsService {
       agent_requests: 0,
       avg_response_time_ms: null,
     };
+  }
+
+  async getSessionAnalytics(
+    appId: string,
+    options: {
+      startDate?: Date;
+      endDate?: Date;
+      limit?: number;
+      scanLimit?: number;
+      funnelSteps?: string[];
+    } = {},
+  ): Promise<AppSessionAnalytics> {
+    const scanLimit = Math.min(Math.max(options.scanLimit ?? 5000, 1), 5000);
+    const sessionLimit = Math.min(Math.max(options.limit ?? 50, 1), 500);
+    const result = await appsRepository.getRecentRequests(appId, {
+      requestType: "pageview",
+      startDate: options.startDate,
+      endDate: options.endDate,
+      limit: scanLimit,
+      offset: 0,
+    });
+    const analytics = this.buildSessionAnalytics(result.requests, options.funnelSteps);
+    return {
+      ...analytics,
+      sessions: analytics.sessions.slice(0, sessionLimit),
+    };
+  }
+
+  buildSessionAnalytics(
+    requests: AppRequest[],
+    requestedFunnelSteps?: string[],
+  ): AppSessionAnalytics {
+    const ordered = requests
+      .slice()
+      .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+    const sessions = new Map<
+      string,
+      {
+        sessionId: string;
+        visitorId: string;
+        pages: Array<{ path: string; at: Date }>;
+      }
+    >();
+
+    for (const request of ordered) {
+      const metadata = request.metadata;
+      const visitorId =
+        metadataString(metadata, "visitor_id") ??
+        request.user_id ??
+        request.ip_address ??
+        "unknown";
+      const sessionId =
+        metadataString(metadata, "session_id") ??
+        `${visitorId}:${request.created_at.toISOString().slice(0, 13)}`;
+      const path = normalizePath(
+        metadataString(metadata, "pathname") ?? metadataString(metadata, "page_url"),
+      );
+      const existing =
+        sessions.get(sessionId) ??
+        ({
+          sessionId,
+          visitorId,
+          pages: [],
+        } satisfies {
+          sessionId: string;
+          visitorId: string;
+          pages: Array<{ path: string; at: Date }>;
+        });
+      existing.pages.push({ path, at: request.created_at });
+      sessions.set(sessionId, existing);
+    }
+
+    const sessionRows = [...sessions.values()]
+      .map((session): AppSessionRow => {
+        const first = session.pages[0];
+        const last = session.pages[session.pages.length - 1] ?? first;
+        const durationMs = Math.max(0, (last?.at.getTime() ?? 0) - (first?.at.getTime() ?? 0));
+        return {
+          sessionId: session.sessionId,
+          visitorId: session.visitorId,
+          startedAt: (first?.at ?? new Date(0)).toISOString(),
+          endedAt: (last?.at ?? first?.at ?? new Date(0)).toISOString(),
+          durationMs,
+          pageViews: session.pages.length,
+          entryPath: first?.path ?? "/",
+          exitPath: last?.path ?? first?.path ?? "/",
+        };
+      })
+      .sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt));
+
+    const uniqueVisitors = new Set(sessionRows.map((s) => s.visitorId)).size;
+    const totalPageViews = sessionRows.reduce((sum, s) => sum + s.pageViews, 0);
+    const totalDurationMs = sessionRows.reduce((sum, s) => sum + s.durationMs, 0);
+    const bounces = sessionRows.filter((s) => s.pageViews === 1).length;
+    const funnelSteps = this.resolveFunnelSteps([...sessions.values()], requestedFunnelSteps);
+    const funnel = this.buildFunnel([...sessions.values()], funnelSteps);
+
+    return {
+      summary: {
+        totalSessions: sessionRows.length,
+        uniqueVisitors,
+        totalPageViews,
+        avgPagesPerSession: sessionRows.length > 0 ? totalPageViews / sessionRows.length : 0,
+        avgSessionDurationMs:
+          sessionRows.length > 0 ? Math.round(totalDurationMs / sessionRows.length) : 0,
+        bounceRatePercent: sessionRows.length > 0 ? roundPercent(bounces / sessionRows.length) : 0,
+      },
+      sessions: sessionRows,
+      funnel,
+    };
+  }
+
+  private resolveFunnelSteps(
+    sessions: Array<{ pages: Array<{ path: string; at: Date }> }>,
+    requested?: string[],
+  ): string[] {
+    const explicit = (requested ?? []).map(normalizePath).filter(Boolean);
+    if (explicit.length > 0) return [...new Set(explicit)].slice(0, 8);
+
+    const firstSeen = new Map<string, number>();
+    const counts = new Map<string, number>();
+    for (const session of sessions) {
+      for (const page of session.pages) {
+        counts.set(page.path, (counts.get(page.path) ?? 0) + 1);
+        firstSeen.set(
+          page.path,
+          Math.min(firstSeen.get(page.path) ?? page.at.getTime(), page.at.getTime()),
+        );
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || (firstSeen.get(a[0]) ?? 0) - (firstSeen.get(b[0]) ?? 0))
+      .slice(0, 5)
+      .map(([path]) => path);
+  }
+
+  private buildFunnel(
+    sessions: Array<{
+      sessionId: string;
+      visitorId: string;
+      pages: Array<{ path: string; at: Date }>;
+    }>,
+    steps: string[],
+  ): AppSessionAnalytics["funnel"] {
+    let previousSessions: Map<string, number> = new Map(
+      sessions.map((session) => [session.sessionId, -1] as const),
+    );
+    const startCount = previousSessions.size;
+    const stepRows: AppFunnelStep[] = [];
+
+    for (const step of steps) {
+      const matchedSessions = new Map<string, number>();
+      const matchedVisitors = new Set<string>();
+      for (const session of sessions) {
+        const previousIndex = previousSessions.get(session.sessionId);
+        if (previousIndex === undefined) continue;
+        const matchedIndex = session.pages.findIndex(
+          (page, index) => index > previousIndex && page.path === step,
+        );
+        if (matchedIndex >= 0) {
+          matchedSessions.set(session.sessionId, matchedIndex);
+          matchedVisitors.add(session.visitorId);
+        }
+      }
+      stepRows.push({
+        path: step,
+        label: labelForPath(step),
+        sessions: matchedSessions.size,
+        visitors: matchedVisitors.size,
+        conversionFromStartPercent:
+          startCount > 0 ? roundPercent(matchedSessions.size / startCount) : 0,
+        conversionFromPreviousPercent:
+          previousSessions.size > 0
+            ? roundPercent(matchedSessions.size / previousSessions.size)
+            : 0,
+      });
+      previousSessions = matchedSessions;
+    }
+
+    return { totalEntrants: startCount, steps: stepRows };
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/app-frontend-hosting.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-frontend-hosting.test.ts
@@ -152,6 +152,17 @@ describe("injectBeacon", () => {
     expect(out).toContain("sendBeacon");
     expect(out).toContain("pushState");
   });
+  test("injects stable visitor and session ids when provided by the serve route", () => {
+    const out = injectBeacon("<body></body>", "app-123", "https://site.test", {
+      visitorId: "visitor-123",
+      sessionId: "session-456",
+    });
+    expect(out).toContain("https://site.test/api/v1/track/pageview");
+    expect(out).toContain('"visitor-123"');
+    expect(out).toContain('"session-456"');
+    expect(out).toContain("visitor_id:v");
+    expect(out).toContain("session_id:sid");
+  });
   test("no-op without a body", () => {
     expect(injectBeacon("<div></div>", "app-123")).toBe("<div></div>");
   });

--- a/packages/cloud/shared/src/lib/services/app-frontend-hosting.ts
+++ b/packages/cloud/shared/src/lib/services/app-frontend-hosting.ts
@@ -65,6 +65,11 @@ export interface RenderInput {
   seo?: FrontendSeo;
   /** Absolute base for the page-view beacon endpoint; defaults to a relative URL. */
   beaconBase?: string;
+  /** Optional analytics IDs resolved by the serve route so initial load + SPA beacons share a session. */
+  analytics?: {
+    visitorId: string;
+    sessionId: string;
+  };
   /** Absolute site origin (e.g. https://myapp.com) used to synthesize robots.txt/sitemap.xml. */
   siteBaseUrl?: string;
 }
@@ -465,7 +470,7 @@ export class AppFrontendHostingService {
     if (isHtml(entry.contentType)) {
       let html = await obj.text();
       html = injectSeo(html, input.seo ?? {});
-      html = injectBeacon(html, input.app.id, input.beaconBase);
+      html = injectBeacon(html, input.app.id, input.beaconBase, input.analytics);
       return { status: 200, headers, body: html, isDocument: servedEntrypoint };
     }
 
@@ -546,11 +551,16 @@ export function injectSeo(html: string, seo: FrontendSeo): string {
  * fires on client-side navigations to avoid double counting. `app_id` is public
  * (page views are non-sensitive), so no secret is embedded.
  */
-export function injectBeacon(html: string, appId: string, beaconBase?: string): string {
+export function injectBeacon(
+  html: string,
+  appId: string,
+  beaconBase?: string,
+  analytics?: { visitorId: string; sessionId: string },
+): string {
   const bodyClose = /<\/body\s*>/i;
   if (!bodyClose.test(html)) return html;
   const url = `${(beaconBase ?? "").replace(/\/$/, "")}/api/v1/track/pageview`;
-  const script = `<script>(function(){function s(){try{var d={app_id:${JSON.stringify(appId)},page_url:location.pathname+location.search,referrer:document.referrer,pathname:location.pathname,screen_width:screen.width,screen_height:screen.height};navigator.sendBeacon(${JSON.stringify(url)},new Blob([JSON.stringify(d)],{type:"text/plain"}));}catch(e){}}var p=history.pushState,r=history.replaceState;history.pushState=function(){p.apply(this,arguments);s();};history.replaceState=function(){r.apply(this,arguments);s();};addEventListener("popstate",s);})();</script>`;
+  const script = `<script>(function(){var vk="eliza_visitor_id",sk="eliza_session_id";function id(){try{return crypto.randomUUID()}catch(e){return "v-"+Date.now().toString(36)+"-"+Math.random().toString(36).slice(2)}}function g(k,s,f){try{var x=s.getItem(k);if(!x){x=f||id();s.setItem(k,x)}return x}catch(e){return f||id()}}var v=g(vk,localStorage,${JSON.stringify(analytics?.visitorId ?? "")});var sid=g(sk,sessionStorage,${JSON.stringify(analytics?.sessionId ?? "")});function s(){try{var d={app_id:${JSON.stringify(appId)},visitor_id:v,session_id:sid,page_url:location.pathname+location.search,referrer:document.referrer,pathname:location.pathname,screen_width:screen.width,screen_height:screen.height};navigator.sendBeacon(${JSON.stringify(url)},new Blob([JSON.stringify(d)],{type:"text/plain"}));}catch(e){}}var p=history.pushState,r=history.replaceState;history.pushState=function(){p.apply(this,arguments);s();};history.replaceState=function(){r.apply(this,arguments);s();};addEventListener("popstate",s);})();</script>`;
   return html.replace(bodyClose, `${script}</body>`);
 }
 

--- a/packages/cloud/shared/src/lib/utils/safe-analytics-id.ts
+++ b/packages/cloud/shared/src/lib/utils/safe-analytics-id.ts
@@ -1,0 +1,9 @@
+/**
+ * Validates client-supplied analytics identifiers (visitor/session ids) at the
+ * runtime boundary. Beacon and cookie ids are UUIDs or short random tokens;
+ * anything else (wrong type, empty, oversized, unsafe charset) is rejected so
+ * it never reaches persisted metadata or injected HTML.
+ */
+export function safeAnalyticsId(value: unknown): string | null {
+  return typeof value === "string" && /^[a-zA-Z0-9._:-]{8,128}$/.test(value) ? value : null;
+}

--- a/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return { ...actual, api: (...args: unknown[]) => apiMock(...args) };
+});
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Line: () => null,
+  Bar: () => null,
+  Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+}));
+
+import { AppAnalytics } from "./app-analytics";
+
+afterEach(() => {
+  cleanup();
+  apiMock.mockReset();
+  toastErrorMock.mockReset();
+});
+
+function mockAnalyticsResponses() {
+  apiMock.mockImplementation(async (url: string) => {
+    if (url.includes("/analytics?")) {
+      return {
+        success: true,
+        analytics: [],
+        totalStats: {
+          totalRequests: 0,
+          totalUsers: 0,
+          totalCreditsUsed: "0",
+        },
+      };
+    }
+    if (url.includes("view=stats")) {
+      return {
+        success: true,
+        stats: {
+          totalRequests: 5,
+          uniqueIps: 2,
+          uniqueUsers: 0,
+          byType: { pageview: 5 },
+          bySource: { hosted_frontend: 5 },
+          byStatus: { success: 5 },
+          totalCredits: "0",
+          avgResponseTime: null,
+        },
+      };
+    }
+    if (url.includes("view=visitors")) {
+      return { success: true, visitors: [] };
+    }
+    if (url.includes("view=sessions")) {
+      return {
+        success: true,
+        sessions: {
+          summary: {
+            totalSessions: 2,
+            uniqueVisitors: 2,
+            totalPageViews: 5,
+            avgPagesPerSession: 2.5,
+            avgSessionDurationMs: 120000,
+            bounceRatePercent: 0,
+          },
+          sessions: [
+            {
+              sessionId: "session-a",
+              visitorId: "visitor-a",
+              startedAt: "2026-07-02T12:00:00.000Z",
+              endedAt: "2026-07-02T12:04:00.000Z",
+              durationMs: 240000,
+              pageViews: 3,
+              entryPath: "/",
+              exitPath: "/checkout",
+            },
+          ],
+          funnel: {
+            totalEntrants: 2,
+            steps: [
+              {
+                path: "/",
+                label: "Home",
+                sessions: 2,
+                visitors: 2,
+                conversionFromStartPercent: 100,
+                conversionFromPreviousPercent: 100,
+              },
+              {
+                path: "/checkout",
+                label: "Checkout",
+                sessions: 1,
+                visitors: 1,
+                conversionFromStartPercent: 50,
+                conversionFromPreviousPercent: 50,
+              },
+            ],
+          },
+        },
+      };
+    }
+    return { success: true };
+  });
+}
+
+describe("AppAnalytics sessions tab (#11349)", () => {
+  it("loads and renders session summary, funnel, and recent sessions from the DTO", async () => {
+    mockAnalyticsResponses();
+    const user = userEvent.setup({ delay: null });
+    render(<AppAnalytics appId="app_1" />);
+
+    await screen.findByText("Requests Over Time");
+    await user.click(screen.getByRole("button", { name: /Sessions/i }));
+
+    await waitFor(() =>
+      expect(apiMock).toHaveBeenCalledWith(
+        "/api/v1/apps/app_1/analytics/requests?view=sessions&limit=20",
+      ),
+    );
+    expect(await screen.findByText("Funnel")).toBeTruthy();
+    expect(screen.getByText("2.5")).toBeTruthy();
+    expect(screen.getByText("Checkout")).toBeTruthy();
+    expect(screen.getAllByText("/checkout").length).toBeGreaterThan(0);
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   Clock,
   DollarSign,
+  GitBranch,
   Globe,
   Loader2,
   RefreshCw,
@@ -95,6 +96,38 @@ interface Visitor {
   lastSeen: string;
 }
 
+interface SessionAnalytics {
+  summary: {
+    totalSessions: number;
+    uniqueVisitors: number;
+    totalPageViews: number;
+    avgPagesPerSession: number;
+    avgSessionDurationMs: number;
+    bounceRatePercent: number;
+  };
+  sessions: Array<{
+    sessionId: string;
+    visitorId: string;
+    startedAt: string;
+    endedAt: string;
+    durationMs: number;
+    pageViews: number;
+    entryPath: string;
+    exitPath: string;
+  }>;
+  funnel: {
+    totalEntrants: number;
+    steps: Array<{
+      path: string;
+      label: string;
+      sessions: number;
+      visitors: number;
+      conversionFromStartPercent: number;
+      conversionFromPreviousPercent: number;
+    }>;
+  };
+}
+
 interface AnalyticsOverviewResponse {
   success?: boolean;
   analytics?: Array<{
@@ -119,6 +152,11 @@ interface RequestStatsResponse {
 interface VisitorsResponse {
   success?: boolean;
   visitors?: Visitor[];
+}
+
+interface SessionsResponse {
+  success?: boolean;
+  sessions?: SessionAnalytics;
 }
 
 interface RequestLogsResponse {
@@ -157,7 +195,7 @@ const TYPE_LABELS: Record<string, string> = {
   agent: "Agent",
 };
 
-type TabValue = "overview" | "requests" | "visitors" | "logs";
+type TabValue = "overview" | "requests" | "visitors" | "sessions" | "logs";
 
 export function AppAnalytics({ appId }: AppAnalyticsProps) {
   const [isLoading, setIsLoading] = useState(true);
@@ -174,6 +212,8 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
   const [requestLogs, setRequestLogs] = useState<RequestLog[]>([]);
   const [requestStats, setRequestStats] = useState<RequestStats | null>(null);
   const [visitors, setVisitors] = useState<Visitor[]>([]);
+  const [sessionAnalytics, setSessionAnalytics] =
+    useState<SessionAnalytics | null>(null);
   const [logsTotal, setLogsTotal] = useState(0);
   const [logsPage, setLogsPage] = useState(0);
   const [isLoadingLogs, setIsLoadingLogs] = useState(false);
@@ -186,6 +226,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
     { value: "overview", label: "Overview", icon: TrendingUp },
     { value: "requests", label: "Requests", icon: Activity },
     { value: "visitors", label: "Visitors", icon: Globe },
+    { value: "sessions", label: "Sessions", icon: GitBranch },
     { value: "logs", label: "Logs", icon: Clock },
   ];
 
@@ -213,12 +254,15 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
   const fetchRequestStats = useCallback(async () => {
     setIsLoadingStats(true);
     try {
-      const [statsData, visitorsData] = await Promise.all([
+      const [statsData, visitorsData, sessionsData] = await Promise.all([
         api<RequestStatsResponse>(
           `/api/v1/apps/${appId}/analytics/requests?view=stats`,
         ),
         api<VisitorsResponse>(
           `/api/v1/apps/${appId}/analytics/requests?view=visitors&limit=10`,
+        ),
+        api<SessionsResponse>(
+          `/api/v1/apps/${appId}/analytics/requests?view=sessions&limit=20`,
         ),
       ]);
 
@@ -227,6 +271,9 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
       }
       if (visitorsData.success && visitorsData.visitors) {
         setVisitors(visitorsData.visitors);
+      }
+      if (sessionsData.success && sessionsData.sessions) {
+        setSessionAnalytics(sessionsData.sessions);
       }
     } catch {
       toast.error("Failed to load request stats");
@@ -266,14 +313,20 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
   );
 
   useEffect(() => {
-    if (activeTab === "requests" || activeTab === "visitors") {
+    if (
+      activeTab === "requests" ||
+      activeTab === "visitors" ||
+      activeTab === "sessions"
+    ) {
       fetchRequestStats();
     }
   }, [activeTab, fetchRequestStats]);
   useIntervalWhenDocumentVisible(
     fetchRequestStats,
     AUTO_REFRESH_INTERVAL,
-    activeTab === "requests" || activeTab === "visitors",
+    activeTab === "requests" ||
+      activeTab === "visitors" ||
+      activeTab === "sessions",
   );
 
   useEffect(() => {
@@ -741,6 +794,158 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                 )}
               </div>
             </>
+          )}
+        </div>
+      )}
+
+      {/* Sessions Tab */}
+      {activeTab === "sessions" && (
+        <div className="space-y-4">
+          {isLoadingStats ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+            </div>
+          ) : sessionAnalytics ? (
+            <>
+              <div className="grid gap-3 grid-cols-2 lg:grid-cols-5">
+                <MiniStatCard
+                  label="Sessions"
+                  value={sessionAnalytics.summary.totalSessions.toLocaleString(
+                    "en-US",
+                  )}
+                  color="text-[var(--brand-orange)]"
+                />
+                <MiniStatCard
+                  label="Visitors"
+                  value={sessionAnalytics.summary.uniqueVisitors.toLocaleString(
+                    "en-US",
+                  )}
+                  color="text-white"
+                />
+                <MiniStatCard
+                  label="Page Views"
+                  value={sessionAnalytics.summary.totalPageViews.toLocaleString(
+                    "en-US",
+                  )}
+                  color="text-green-400"
+                />
+                <MiniStatCard
+                  label="Pages/Session"
+                  value={sessionAnalytics.summary.avgPagesPerSession.toFixed(1)}
+                  color="text-white"
+                />
+                <MiniStatCard
+                  label="Bounce Rate"
+                  value={`${sessionAnalytics.summary.bounceRatePercent.toFixed(1)}%`}
+                  color="text-white"
+                />
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+                <div className="bg-neutral-900 rounded-sm p-4">
+                  <h3 className="text-sm font-medium text-white mb-4 flex items-center gap-2">
+                    <GitBranch className="h-4 w-4 text-[var(--brand-orange)]" />
+                    Funnel
+                  </h3>
+                  {sessionAnalytics.funnel.steps.length > 0 ? (
+                    <div className="space-y-3">
+                      {sessionAnalytics.funnel.steps.map((step) => (
+                        <div key={step.path} className="space-y-1.5">
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm text-white truncate">
+                              {step.label}
+                            </span>
+                            <span className="text-xs text-neutral-400 whitespace-nowrap">
+                              {step.sessions.toLocaleString("en-US")} sessions
+                            </span>
+                          </div>
+                          <div className="h-2 bg-white/10 rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-[var(--brand-orange)]"
+                              style={{
+                                width: `${Math.min(100, step.conversionFromStartPercent)}%`,
+                              }}
+                            />
+                          </div>
+                          <div className="flex items-center justify-between text-[11px] text-neutral-500">
+                            <span className="truncate">{step.path}</span>
+                            <span className="whitespace-nowrap">
+                              {step.conversionFromStartPercent.toFixed(1)}%
+                              total /{" "}
+                              {step.conversionFromPreviousPercent.toFixed(1)}%
+                              step
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-center text-neutral-500 py-8 text-sm">
+                      No funnel data available
+                    </p>
+                  )}
+                </div>
+
+                <div className="bg-neutral-900 rounded-sm p-4">
+                  <h3 className="text-sm font-medium text-white mb-4">
+                    Recent Sessions
+                  </h3>
+                  {sessionAnalytics.sessions.length > 0 ? (
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b border-white/10">
+                            <th className="text-left py-2 px-3 text-neutral-500 font-medium text-xs">
+                              Entry
+                            </th>
+                            <th className="text-left py-2 px-3 text-neutral-500 font-medium text-xs">
+                              Exit
+                            </th>
+                            <th className="text-right py-2 px-3 text-neutral-500 font-medium text-xs">
+                              Views
+                            </th>
+                            <th className="text-right py-2 px-3 text-neutral-500 font-medium text-xs">
+                              Started
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sessionAnalytics.sessions.slice(0, 10).map((s) => (
+                            <tr
+                              key={s.sessionId}
+                              className="border-b border-white/5 hover:bg-white/5"
+                            >
+                              <td className="py-2 px-3 text-white text-xs max-w-[180px] truncate">
+                                {s.entryPath}
+                              </td>
+                              <td className="py-2 px-3 text-neutral-300 text-xs max-w-[180px] truncate">
+                                {s.exitPath}
+                              </td>
+                              <td className="py-2 px-3 text-right text-white text-xs">
+                                {s.pageViews.toLocaleString("en-US")}
+                              </td>
+                              <td className="py-2 px-3 text-right text-neutral-500 text-xs whitespace-nowrap">
+                                {formatDistanceToNow(new Date(s.startedAt), {
+                                  addSuffix: true,
+                                })}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="text-center text-neutral-500 py-8 text-sm">
+                      No session data available
+                    </p>
+                  )}
+                </div>
+              </div>
+            </>
+          ) : (
+            <p className="text-center text-neutral-500 py-12">
+              No session data available
+            </p>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes #11349.

Adds hosted frontend session analytics for cloud apps:
- persists stable visitor/session IDs from hosted frontend document serves and SPA pageview beacons
- aggregates `pageview` rows into sessions, unique visitors, bounce rate, recent sessions, and ordered funnel steps
- exposes `view=sessions` on the app analytics requests route with org/app-key scope checks
- adds a Sessions tab to the app analytics UI

## Evidence

Detailed notes are in `.github/issue-evidence/11349-hosted-analytics-sessions.md`.

Passed after rebasing onto current `origin/develop`:
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `bun run --cwd packages/ui typecheck`
- `bun test packages/cloud/shared/src/lib/services/app-analytics.test.ts packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts packages/cloud/api/__tests__/hosted-frontend-serve.integration.test.ts`
- `bun run --cwd packages/ui test -- src/cloud/applications/components/app-analytics.test.tsx`
- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts`
- `git diff --check`

## Known blocker

`bun run --cwd packages/app audit:app` completed the full capture sweep but exited 1 on unrelated existing app audit debt outside this analytics surface:
- `plugin-inbox-gui @ mobile-landscape`: minimalism ratchet regression
- `plugin-screenshare-gui @ mobile-portrait`: minimalism ratchet regression
- `plugin-finances-gui @ mobile-landscape`: hover probe timeout
- `plugin-finances-tui @ mobile-landscape`: hover probe timeout

The `builtin-apps` audit route, which reaches the apps UI surface, was marked `good` across audited viewports. This PR stays draft until the unrelated audit gate is cleared or explicitly accepted by maintainers.
