### PR TITLE
fix(cloud): server-generate billing requestId so affiliate dedupe can't be client-forced (#11588)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -50,6 +50,9 @@ const aiActual = require("ai") as Record<string, unknown>;
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
 const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const CLIENT_REQUEST_ID = "req-optimistic-test";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // --- per-test knobs the mocks read by reference -----------------------------
 let billingEnabled = true;
@@ -183,7 +186,7 @@ function makeRequest(): Request {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-request-id": "req-optimistic-test",
+      "x-request-id": CLIENT_REQUEST_ID,
     },
     body: JSON.stringify({
       model: "gpt-4o-mini",
@@ -219,6 +222,24 @@ describe("chat/completions optimistic-billing route decision (#9899/#10066)", ()
     expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
     // The synchronous reserve write (the latency we are removing) is skipped.
     expect(reserveCredits).not.toHaveBeenCalled();
+  });
+
+  test("billing requestId is server-generated, not copied from x-request-id", async () => {
+    await drive();
+
+    const pendingCalls = writePendingInferenceCharge.mock
+      .calls as unknown as Array<[{ requestId: string }, number]>;
+    const settlerCalls = createOptimisticDebitSettler.mock
+      .calls as unknown as Array<[{ requestId: string }]>;
+    const pending = pendingCalls[0]?.[0];
+    const settler = settlerCalls[0]?.[0];
+    expect(pending).toBeDefined();
+    expect(settler).toBeDefined();
+    if (!pending || !settler) throw new Error("billing path was not reached");
+
+    expect(pending.requestId).toMatch(UUID_RE);
+    expect(pending.requestId).not.toBe(CLIENT_REQUEST_ID);
+    expect(settler.requestId).toBe(pending.requestId);
   });
 
   test("balance below SAFE_BALANCE_THRESHOLD falls back to the synchronous reserve", async () => {

--- a/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
@@ -43,6 +43,9 @@ const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
 const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
 const EMBEDDING = [0.0125, -0.5, 0.333333];
+const CLIENT_REQUEST_ID = "req-emb-optimistic";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // The fixed total the mocked calculateCost returns — what the backstop must
 // record (proving the route no longer writes estimatedCostUsd: 0).
 const BACKSTOP_COST = 0.0123;
@@ -56,8 +59,10 @@ let backstopPersists = true;
 
 // --- spies on the two terminal billing paths --------------------------------
 const writePendingInferenceCharge = mock(
-  (_charge: { estimatedCostUsd: number }, _now: number): Promise<boolean> =>
-    Promise.resolve(backstopPersists),
+  (
+    _charge: { requestId: string; estimatedCostUsd: number },
+    _now: number,
+  ): Promise<boolean> => Promise.resolve(backstopPersists),
 );
 const reserveCredits = mock(async () => ({
   reservedAmount: 0,
@@ -190,7 +195,7 @@ function post(body: unknown, ctx?: ExecutionContext) {
       headers: {
         Authorization: "Bearer eliza_test_key",
         "Content-Type": "application/json",
-        "x-request-id": "req-emb-optimistic",
+        "x-request-id": CLIENT_REQUEST_ID,
       },
       body: JSON.stringify(body),
     },
@@ -222,6 +227,30 @@ describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#1010
     expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
     expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
     expect(reserveCredits).not.toHaveBeenCalled();
+  });
+
+  test("billing requestId is server-generated, not copied from x-request-id", async () => {
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+    await Promise.all(scheduled);
+
+    expect(res.status).toBe(200);
+    const pendingCalls = writePendingInferenceCharge.mock
+      .calls as unknown as Array<[{ requestId: string }, number]>;
+    const settlerCalls = createOptimisticDebitSettler.mock
+      .calls as unknown as Array<[{ requestId: string }]>;
+    const pending = pendingCalls[0]?.[0];
+    const settler = settlerCalls[0]?.[0];
+    expect(pending).toBeDefined();
+    expect(settler).toBeDefined();
+    if (!pending || !settler) throw new Error("billing path was not reached");
+
+    expect(pending.requestId).toMatch(UUID_RE);
+    expect(pending.requestId).not.toBe(CLIENT_REQUEST_ID);
+    expect(settler.requestId).toBe(pending.requestId);
   });
 
   test("backstop records the REAL input-token cost estimate (not 0) so a dropped settle is recoverable", async () => {

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -796,7 +796,16 @@ export async function handleChatCompletionsPOST(
   options: ChatCompletionsHandlerOptions = {},
 ) {
   const startTime = Date.now();
-  const requestId = req.headers.get("x-request-id") || crypto.randomUUID();
+  // #11588: the billing requestId feeds the affiliate-earnings dedupe sourceId
+  // (getAffiliateEarningsSourceId → `ai_billing:<op>:<requestId>`, deduped on
+  // addEarnings) while the org charge is unconditional. It MUST NOT be
+  // client-controllable, or a caller pinning `x-request-id` across two billed
+  // requests could suppress the second affiliate credit while still being
+  // charged the markup. Server-generate it (stable for this request, so the
+  // #11460/#11472 abort-vs-finish single-flight dedupe is preserved). The
+  // client's retry-idempotency mechanism stays the explicit `idempotency-key`
+  // header.
+  const requestId = crypto.randomUUID();
   const idempotencyKey = req.headers.get("idempotency-key") || requestId;
   const routeTimeoutMs = getRouteTimeoutMs(ROUTE_MAX_DURATION);
   let settleReservation:

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -209,7 +209,10 @@ app.post("/", async (c) => {
     // today). On the optimistic path the reservation's `reconcile` IS the
     // actual-cost debit, and settleBilling invokes it through the single
     // first-call-wins settler.
-    const requestId = c.req.header("x-request-id") || crypto.randomUUID();
+    // #11588: server-generate the billing requestId — it feeds the affiliate
+    // dedupe sourceId and must not be client-controllable (see the fuller note
+    // in v1/chat/completions/route.ts).
+    const requestId = crypto.randomUUID();
     const orgId = user.organization_id;
     let reservation: Awaited<ReturnType<typeof reserveCredits>> | undefined;
     let optimisticReady = false;


### PR DESCRIPTION
Fixes #11588.

## Bug (MED, money out — affiliate)
On `/v1/chat/completions` and `/v1/embeddings` the billing `requestId` derived from the client `x-request-id` header:
```ts
const requestId = req.headers.get("x-request-id") || crypto.randomUUID();
```
That `requestId` feeds the affiliate-earnings dedupe key — `getAffiliateEarningsSourceId` → `ai_billing:<op>:<requestId>` → `addEarnings({ dedupeBySourceId: true })` (ai-billing.ts:85-94, 268/346) — while the org **charge** (`totalCost += affiliateEarnings`) is **unconditional**. So two distinct billed requests sent with the **same** pinned `x-request-id` charge the org the affiliate markup twice, but the second `addEarnings` hits the existing `(user_id,'earning','affiliate',source_id)` ledger row and returns `deduplicated:true` → the affiliate is **silently never credited the second markup**. A caller can pin the header to skim, or to suppress a competitor affiliate's credit.

## Fix
Server-generate `requestId` (`crypto.randomUUID()`) on both routes so the dedupe key is not client-controllable. It's still captured **once per request**, so the #11460/#11472 abort-vs-finish single-flight dedupe (which relies on abort-settle and onFinish sharing one sourceId) is preserved. The client's retry-idempotency mechanism is unchanged — it's the explicit `idempotency-key` header (`idempotencyKey = header ?? requestId`), which still works.

## Evidence
- Existing affiliate/billing money suites green after the change (no regression to the `getAffiliateEarningsSourceId`/`dedupeBySourceId` contract the fix relies on):
```
bun test ai-billing-anon-affiliate.test.ts ai-billing-usage.test.ts
 8 pass / 0 fail  (incl. "paying org affiliate earnings use deterministic request sourceId for dedupe")
```
- Biome clean on both files.
- **Test gap flagged honestly:** a dedicated route-level regression ("two requests reusing one `x-request-id` → affiliate credited twice; same-request abort+finish → credited once") requires driving `handleChatCompletionsPOST` all the way through the model+settle path to reach `billUsage` (the only `requestId`-bearing spy) — heavier harness than the existing chat-completions tests expose at the reserve boundary. The fix itself is a 1-line-per-route header decoupling verifiable by the diff + the existing deterministic-sourceId dedup contract test. I'll add the full route-level regression as a fast-follow (or route it to Fable). Marking this so a reviewer weighs it rather than assuming it's covered.

Money lane → @lalalune; not self-merged.
