### PR TITLE
fix(shared): duration boundary rollover, $-safe name replacement, Unicode name tokenization

### DIFF
--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatByteSize, formatUptime, formatUsd } from "./format";
+import {
+  formatByteSize,
+  formatDurationMs,
+  formatUptime,
+  formatUsd,
+} from "./format";
 
 /**
  * Shared display formatters (uptime / byte size / USD). These render values in
@@ -34,6 +39,39 @@ describe("formatByteSize", () => {
     expect(formatByteSize(1024 ** 3)).toBe("1.0 GB");
     expect(formatByteSize(1024 ** 4)).toBe("1.0 TB");
     expect(formatByteSize(1536, { precision: 2 })).toBe("1.50 KB");
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("renders compact units and handles invalid input", () => {
+    expect(formatDurationMs(undefined)).toBe("—");
+    expect(formatDurationMs(-1)).toBe("—");
+    expect(formatDurationMs(Number.NaN)).toBe("—");
+    expect(formatDurationMs(0)).toBe("0s");
+    expect(formatDurationMs(30_000)).toBe("30s");
+    expect(formatDurationMs(90_000)).toBe("2m");
+    expect(formatDurationMs(7_200_000)).toBe("2h");
+    expect(formatDurationMs(5_400_000)).toBe("1.5h");
+    expect(formatDurationMs(172_800_000)).toBe("2d");
+  });
+
+  it("rolls values that round up to a unit boundary into the next unit", () => {
+    // 59.5s rounds to 60 → must display as minutes, never "60s".
+    expect(formatDurationMs(59_500)).toBe("1m");
+    expect(formatDurationMs(59_400)).toBe("59s");
+    // 59.983m rounds to 60 → must display as hours, never "60m".
+    expect(formatDurationMs(3_599_000)).toBe("1h");
+    expect(formatDurationMs(3_540_000)).toBe("59m");
+    // 23.99h renders as 24.0 after toFixed(1) → must display as days, never "24h".
+    expect(formatDurationMs(86_399_000)).toBe("1d");
+    expect(formatDurationMs(85_000_000)).toBe("23.6h");
+  });
+
+  it("passes the rolled-over value to the translator", () => {
+    const t = (key: string, vars?: Record<string, string | number>) =>
+      `${key}:${vars?.value}`;
+    expect(formatDurationMs(59_500, { t })).toBe("format.duration.minutes:1");
+    expect(formatDurationMs(30_000, { t })).toBe("format.duration.seconds:30");
   });
 });
 

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -188,19 +188,25 @@ export function formatDurationMs(
 ): string {
   const { fallback = "—", t } = options;
   if (ms == null || !Number.isFinite(ms) || ms < 0) return fallback;
-  if (ms < 60_000) {
-    const value = Math.round(ms / 1000);
-    return t ? t("format.duration.seconds", { value }) : `${value}s`;
+  // Round within each unit FIRST, and only keep the unit when the rounded
+  // value stays below the next unit's threshold — otherwise values just
+  // under a boundary render as nonsense like "60s" / "60m" / "24h"
+  // (e.g. 59_500 ms must be "1m", not "60s").
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) {
+    return t ? t("format.duration.seconds", { value: seconds }) : `${seconds}s`;
   }
-  if (ms < 3_600_000) {
-    const value = Math.round(ms / 60_000);
-    return t ? t("format.duration.minutes", { value }) : `${value}m`;
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) {
+    return t ? t("format.duration.minutes", { value: minutes }) : `${minutes}m`;
   }
-  if (ms < 86_400_000) {
-    const hours = ms / 3_600_000;
-    const value =
-      hours === Math.floor(hours) ? hours : Number(hours.toFixed(1));
-    return t ? t("format.duration.hours", { value }) : `${value}h`;
+  const hours = ms / 3_600_000;
+  const hoursValue =
+    hours === Math.floor(hours) ? hours : Number(hours.toFixed(1));
+  if (hoursValue < 24) {
+    return t
+      ? t("format.duration.hours", { value: hoursValue })
+      : `${hoursValue}h`;
   }
   const days = ms / 86_400_000;
   const value = days === Math.floor(days) ? days : Number(days.toFixed(1));

--- a/packages/shared/src/utils/name-tokens.test.ts
+++ b/packages/shared/src/utils/name-tokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { replaceNameTokens, tokenizeNameOccurrences } from "./name-tokens";
+
+/**
+ * Character-name token helpers. `replaceNameTokens` expands `{{name}}` /
+ * `{{agentName}}` into the literal name; `tokenizeNameOccurrences` reverses
+ * it during rename so every text field keeps propagating. Both run on
+ * user-entered names, so `$`-sequences and non-ASCII names must round-trip.
+ */
+
+describe("replaceNameTokens", () => {
+  it("replaces both token spellings with the name", () => {
+    expect(replaceNameTokens("Hi {{name}}, aka {{agentName}}.", "Momo")).toBe(
+      "Hi Momo, aka Momo.",
+    );
+  });
+
+  it("inserts names containing $-sequences literally", () => {
+    // "$$" is a String.replace substitution pattern for a single "$";
+    // the raw name must survive unmangled.
+    expect(replaceNameTokens("hello {{name}}", "Cash$$")).toBe("hello Cash$$");
+    // "$&" would re-insert the matched token itself.
+    expect(replaceNameTokens("hello {{name}}", "M$&M")).toBe("hello M$&M");
+    expect(replaceNameTokens("yo {{agentName}}", "A$AP")).toBe("yo A$AP");
+  });
+});
+
+describe("tokenizeNameOccurrences", () => {
+  it("tokenizes whole-word occurrences only, case-sensitively", () => {
+    expect(tokenizeNameOccurrences("Momo says Momos love Momo.", "Momo")).toBe(
+      "{{name}} says Momos love {{name}}.",
+    );
+    expect(tokenizeNameOccurrences("momo stays", "Momo")).toBe("momo stays");
+  });
+
+  it("is idempotent and non-destructive on empty/short names", () => {
+    expect(tokenizeNameOccurrences("{{name}} waves", "Momo")).toBe(
+      "{{name}} waves",
+    );
+    expect(tokenizeNameOccurrences("A big cat", "A")).toBe("A big cat");
+    expect(tokenizeNameOccurrences("", "Momo")).toBe("");
+  });
+
+  it("tokenizes non-ASCII names (\\b is ASCII-only and must not be relied on)", () => {
+    expect(tokenizeNameOccurrences("小美 loves tea. Ask 小美!", "小美")).toBe(
+      "{{name}} loves tea. Ask {{name}}!",
+    );
+    expect(tokenizeNameOccurrences("Émile said hi", "Émile")).toBe(
+      "{{name}} said hi",
+    );
+    // Still whole-word for non-ASCII: no match inside a longer CJK run.
+    expect(tokenizeNameOccurrences("小美人 is different", "小美")).toBe(
+      "小美人 is different",
+    );
+    expect(tokenizeNameOccurrences("Émilee is different", "Émile")).toBe(
+      "Émilee is different",
+    );
+  });
+});

--- a/packages/shared/src/utils/name-tokens.ts
+++ b/packages/shared/src/utils/name-tokens.ts
@@ -3,9 +3,12 @@
  * actual character name. Handles legacy persisted templates from first-run setup.
  */
 export function replaceNameTokens(text: string, name: string): string {
+  // Use a replacer function so `$`-sequences in the name (e.g. "Cash$$",
+  // "$&") are inserted literally instead of being interpreted as
+  // String.replace substitution patterns.
   return text
-    .replace(/\{\{name\}\}/g, name)
-    .replace(/\{\{agentName\}\}/g, name);
+    .replace(/\{\{name\}\}/g, () => name)
+    .replace(/\{\{agentName\}\}/g, () => name);
 }
 
 /**
@@ -30,6 +33,12 @@ export function tokenizeNameOccurrences(text: string, name: string): string {
   const trimmed = name.trim();
   if (trimmed.length < 2) return text;
   const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`\\b${escaped}\\b`, "g");
+  // `\b` only understands ASCII `[A-Za-z0-9_]`, so non-ASCII names
+  // (e.g. "小美", "Émile") would never match — use Unicode-aware
+  // letter/number lookarounds as the whole-word boundary instead.
+  const pattern = new RegExp(
+    `(?<![\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`,
+    "gu",
+  );
   return text.replace(pattern, "{{name}}");
 }


### PR DESCRIPTION
## What

Three surgical fixes to pure utilities in `@elizaos/shared` (`packages/shared/src/utils/`), each with a mutation-checked unit test. These helpers are re-exported by `@elizaos/ui` and consumed across dashboard views and the character editor, so wrong output here surfaces everywhere.

## Bug 1 — `formatDurationMs` renders impossible values at unit boundaries (`utils/format.ts`)

Unit selection ran on raw ms **before** rounding, so values just under a boundary rounded up into nonsense:

| Input (ms) | Before | After |
|---|---|---|
| `59_500` | `"60s"` | `"1m"` |
| `3_599_000` | `"60m"` | `"1h"` |
| `86_399_000` | `"24h"` | `"1d"` |
| `59_400` / `3_540_000` / `85_000_000` | `"59s"` / `"59m"` / `"23.6h"` | unchanged |

Fix: round within each unit first and cascade to the next unit when the rounded value reaches its threshold. The i18n `t` callback now also receives the rolled-over value (`format.duration.minutes` with `value: 1`, never `format.duration.seconds` with `value: 60`).

## Bug 2 — `replaceNameTokens` mangles names containing `$` (`utils/name-tokens.ts`)

The character name was passed to `String.replace` as a plain replacement string, so `$`-substitution patterns were interpreted:

- `replaceNameTokens("hello {{name}}", "Cash$$")` → `"hello Cash$"` (`$$` collapses to one `$`)
- a name containing `$&` re-inserted the literal `{{name}}` token into the output

Names are free-form user input on the character-editor path. Fix: pass a replacer function `() => name` so the name is inserted verbatim.

## Bug 3 — `tokenizeNameOccurrences` never tokenizes non-ASCII names (`utils/name-tokens.ts`)

JS `\b` only treats `[A-Za-z0-9_]` as word chars, so for names like `小美` or `Émile` no boundary exists at either edge and the rename-propagation regex **never matched** — `tokenizeNameOccurrences("小美 loves tea", "小美")` returned the input unchanged. The package explicitly supports zh-CN/ko/vi/tl character languages (`character-language.ts`), and `packages/ui/src/character/character-draft-helpers.ts` calls this on every rename. Fix: Unicode-aware lookarounds `(?<![\p{L}\p{N}_])name(?![\p{L}\p{N}_])` with the `u` flag. ASCII whole-word semantics are preserved (`Momo` matches, `Momos` doesn't) and extended to non-ASCII (`小美人`/`Émilee` correctly not tokenized); idempotency on already-tokenized text is unchanged.

## Evidence

- **Tests**: `packages/shared/src/utils/format.test.ts` (new `formatDurationMs` suite incl. boundary + translator cases) and new `packages/shared/src/utils/name-tokens.test.ts` (both token helpers, `$`-sequences, CJK/accented names, whole-word negatives, idempotency). Targeted run: 12/12 green.
- **Mutation checks**: each fix reverted in isolation → its test(s) fail (bug 1: 2 failures; bug 2: 1 failure; bug 3: 1 failure); restored → green. Confirms every test pins its fix.
- **Full package**: `vitest run` in `packages/shared` → 83 files, 1049/1049 pass; `typecheck` (tsgo) clean; biome clean on touched files.
- **Scope**: only `packages/shared/src/utils/{format,name-tokens}{,.test}.ts` touched. `packages/ui` copies are pure re-exports of these symbols, so consumers pick up the fixes automatically.
- Real-LLM trajectories / screenshots / video: **N/A** — pure deterministic string-formatting utilities with no model, UI, or I/O path; behavior fully pinned by unit tests above.

---
**Authored end-to-end by a Fable-5 agent** (find + fix + tests + mutation-checks + push, single pass). Independently re-verified by the main loop: 4-file PR diff (merge-base), **12/12 tests pass** on a fresh run, and formatDurationMs mutation reproduced independently (revert format.ts → 2 fail; restore → 7 pass). — `[phone-ui]`