### PR TITLE
fix(advertising): gate updateCampaign on account approval — close the suspended-account spend leg (#11364)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
@@ -148,5 +148,14 @@ describe("campaign spend requires an approved (active) account (#11364)", () => 
         /not active/,
       );
     });
+
+    test(`updateCampaign is blocked when account is ${status} (no budget-increase spend)`, async () => {
+      track(spyOn(adCampaignsRepository, "findById").mockResolvedValue(makeCampaign()));
+      track(spyOn(adAccountsRepository, "findById").mockResolvedValue(makeAccount(status)));
+
+      await expect(
+        advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, { budgetAmount: 10_000 }),
+      ).rejects.toThrow(/not active/);
+    });
   }
 });

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -686,6 +686,12 @@ class AdvertisingService {
       throw new Error("Ad account not found");
     }
 
+    if (account.status !== "active") {
+      throw new Error(
+        `Ad account is not active (status: ${account.status}); it must be approved before running campaigns`,
+      );
+    }
+
     const credentials = await this.getCredentials(account);
     const provider = this.getProvider(account.platform);
 


### PR DESCRIPTION
Refs #11364. Follow-up closing the residual the #11516 verification flagged.

## Hole

#11516 (merged) gated `createCampaign` + `startCampaign` on `account.status === "active"` — but **`updateCampaign` stayed ungated**. Exploit: account approved → campaign created → account suspended for ToS → `PATCH /api/v1/advertising/campaigns/:id` with a `budgetAmount` increase still **deducts credits and pushes the raise live** to the ad platform. A suspended account could keep increasing spend.

## Fix

One fail-closed gate in `updateCampaign` after the account lookup (`packages/cloud/shared/src/lib/services/advertising/index.ts`), mirroring the createCampaign/startCampaign gates. `UpdateCampaignInput` is name/budget/dates/targeting only — pausing/stopping a campaign goes through separate methods — so the blanket gate blocks no legitimate wind-down action for suspended accounts.

## Verification
- `ad-account-approval.test.ts`: **15 pass / 0 fail** (3 new: updateCampaign blocked for pending/suspended/disconnected).
- Fail-without-fix proven: reverting only the source gate fails exactly the 3 new tests (12 pass / 3 fail).
- `packages/cloud/shared` `tsgo --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)