### PR TITLE
fix(benchmarks): point SWE-bench metadata at README

### DIFF
--- a/.github/issue-evidence/11346-swebench-readme-metadata/README.md
+++ b/.github/issue-evidence/11346-swebench-readme-metadata/README.md
@@ -6,7 +6,9 @@ Host: Linux container, Python 3.12.3
 ## Change
 
 `packages/benchmarks/swe_bench/pyproject.toml` now points `project.readme` at
-the existing `README.md` file instead of the deleted `RESEARCH.md` file.
+the existing `README.md` file instead of the deleted `RESEARCH.md` file. The
+README's stale reference back to `RESEARCH.md` was also removed so the packaged
+long description does not point readers at a missing file.
 
 ## Validation
 
@@ -44,6 +46,33 @@ git diff --check
 ```
 
 Result: passed.
+
+## Additional Windows reviewer follow-up
+
+After review, the top-level SWE-bench README still referenced the deleted
+`RESEARCH.md`; that stale sentence was removed so the packaged long
+description is self-contained.
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import tomllib
+root = Path('packages/benchmarks/swe_bench')
+config = tomllib.loads((root / 'pyproject.toml').read_text())
+readme = root / config['project']['readme']
+print(f"readme={readme}")
+print(f"exists={readme.exists()}")
+if not readme.exists():
+    raise SystemExit(1)
+PY
+rg -n "RESEARCH\\.md" packages/benchmarks/swe_bench
+python -m build packages/benchmarks/swe_bench --sdist --wheel --outdir %TEMP%/eliza-swebench-build-11620
+git diff --check
+```
+
+Result on Windows/Python 3.12.10: metadata readme exists, no remaining
+`RESEARCH.md` references under `packages/benchmarks/swe_bench`, package build
+successfully produced the sdist and wheel, and `git diff --check` passed.
 
 ## Evidence not applicable to this PR
 

--- a/.github/issue-evidence/11346-swebench-readme-metadata/README.md
+++ b/.github/issue-evidence/11346-swebench-readme-metadata/README.md
@@ -1,0 +1,55 @@
+# Issue #11346 SWE-bench README metadata evidence
+
+Date: 2026-07-02
+Host: Linux container, Python 3.12.3
+
+## Change
+
+`packages/benchmarks/swe_bench/pyproject.toml` now points `project.readme` at
+the existing `README.md` file instead of the deleted `RESEARCH.md` file.
+
+## Validation
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import tomllib
+root = Path('packages/benchmarks/swe_bench')
+config = tomllib.loads((root/'pyproject.toml').read_text())
+readme = root / config['project']['readme']
+print(f"readme={readme}")
+print(f"exists={readme.exists()}")
+if not readme.exists():
+    raise SystemExit(1)
+PY
+```
+
+Result: `readme=packages/benchmarks/swe_bench/README.md`, `exists=True`.
+
+```bash
+python3 -m pytest packages/benchmarks/swe_bench/tests -q
+```
+
+Result: 131 passed in 22.49s.
+
+```bash
+python3 -m build packages/benchmarks/swe_bench --sdist --wheel --outdir /tmp/eliza-swebench-build
+```
+
+Result: successfully built `elizaos_swe_bench-2.0.0.tar.gz` and
+`elizaos_swe_bench-2.0.0-py3-none-any.whl`.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Evidence not applicable to this PR
+
+- Real-model benchmark trajectory: N/A - this PR fixes Python package metadata
+  for the SWE-bench harness and does not change benchmark execution, prompts,
+  providers, scoring, or model behavior.
+- Screenshots/video: N/A - no UI surface changed.
+- Docker SWE-bench evaluation run: N/A - the change is packaging metadata only;
+  the package build and unit suite exercise the broken metadata path directly.

--- a/packages/benchmarks/swe_bench/README.md
+++ b/packages/benchmarks/swe_bench/README.md
@@ -1,8 +1,8 @@
 # SWE-bench
 
 elizaOS's SWE-bench Lite harness. The canonical single-shot flow lives in
-`cli.py` (entry: `python -m benchmarks.swe_bench …`). See `RESEARCH.md`
-for design notes and historical results.
+`cli.py` (entry: `python -m benchmarks.swe_bench …`). Design notes and
+historical context live in this README.
 
 ## Head-to-head comparison: elizaOS vs opencode
 

--- a/packages/benchmarks/swe_bench/pyproject.toml
+++ b/packages/benchmarks/swe_bench/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "elizaos-swe-bench"
 version = "2.0.0"
 description = "SWE-bench benchmark for ElizaOS Python agents"
-readme = "RESEARCH.md"
+readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Summary
- fixes the SWE-bench Python package metadata so `project.readme` points at the existing `README.md` instead of deleted `RESEARCH.md`
- adds issue evidence for the metadata/package build validation

## Validation
- `python3 - <<'PY' ... PY` metadata check: `README.md` exists
- `python3 -m pytest packages/benchmarks/swe_bench/tests -q` (131 passed)
- `python3 -m build packages/benchmarks/swe_bench --sdist --wheel --outdir /tmp/eliza-swebench-build`
- `git diff --check`

## Evidence
- `.github/issue-evidence/11346-swebench-readme-metadata/README.md`

## Issue
Progress toward #11346. This does not close the full benchmark-matrix issue; it removes a packaging/readiness break in the SWE-bench harness metadata.
