### PR TITLE
perf(loadperf): gate steady-state idle RSS of the booted keyless agent

### DIFF
--- a/.github/issue-evidence/10724-steady-rss-gate/README.md
+++ b/.github/issue-evidence/10724-steady-rss-gate/README.md
@@ -1,0 +1,50 @@
+# #10724 — steady-state RSS regression gate for the booted keyless agent
+
+Scope B (backend/agent) guardrail. `loadperf/boot-kpi.mjs` already gates cold
+`readyMs` and boot **peak** RSS, but had no gate on the **steady-state idle RSS**
+a booted agent carries once boot churn subsides — a distinct regression class
+(boot scratch never released, slow idle growth) that the peak number hides.
+
+## What shipped
+
+`boot-kpi.mjs` now, after `ready`, holds the idle keyless/headless agent for a
+settle window (`LOADPERF_STEADY_SETTLE_MS`, default 12 s), samples `/proc/<pid>`
+VmRSS, and reports **`steadyRssMb`** = median of the window's tail (last 60 %,
+after GC/scratch churn). Gated against `budgets.json → boot.steadyRssMb` (1500 MB).
+A `null` budget records without gating; `--attach` reports `null` (no child pid).
+
+## Real measurement (this host)
+
+Prod path (`bun run dist/entry.js start`, keyless/headless), `--runs=2`, 12 s
+settle, heavily CPU-contended host (loadavg 51 / 24 cpus — RSS is
+contention-insensitive):
+
+```
+peak RSS:    1057.6 MB   (budget 1600 MB — PASS)
+steady RSS:  1069.0 MB   (budget 1500 MB — PASS)   <-- new gate
+ready median: 14655 ms   (budget 25000 ms — PASS)
+health.ready: true
+```
+
+Steady sits slightly **above** boot-peak because RSS keeps climbing during
+post-ready warmup (lazy provider/embedding load, GC not yet run) — the exact
+resident tail the boot-peak sample misses, which is why the separate metric
+earns its keep. Full recorded result: `boot-kpi-result.json`.
+
+## Budget rationale
+
+`steadyRssMb ≤ 1500 MB` = ~40 % headroom over the measured 1069 MB and above the
+historical ~1272 MB peak reading, so it catches a real resident regression
+(~430 MB idle leak) without flaking on host variance. Ratchet down as
+idle-footprint optimizations land.
+
+## Repro
+
+```bash
+bun run --cwd packages/app-core build       # build the shipped entry the KPI measures
+node packages/benchmarks/loadperf/boot-kpi.mjs --runs=2
+# or the whole harness:
+node packages/benchmarks/loadperf/run-all.mjs --no-frontend
+```
+
+Screenshots/video: N/A — a CI/benchmark gate, no UI/runtime visual surface.

--- a/.github/issue-evidence/10724-steady-rss-gate/boot-kpi-result.json
+++ b/.github/issue-evidence/10724-steady-rss-gate/boot-kpi-result.json
@@ -1,0 +1,115 @@
+{
+  "kpi": "boot",
+  "recordedAt": "2026-07-02T22:02:59.414Z",
+  "git": {
+    "branch": "perf/steady-rss-gate",
+    "commit": "bc0dd00640",
+    "dirty": true
+  },
+  "summary": {
+    "mode": "spawn",
+    "baseUrl": "http://127.0.0.1:31356",
+    "runs": 2,
+    "requestedRuns": 2,
+    "readyMs": 14655,
+    "readyMsRuns": [
+      14393,
+      14917
+    ],
+    "readyMsP95": 14917,
+    "readyMsMin": 14393,
+    "readyMsMax": 14917,
+    "peakRssBytes": 1109000192,
+    "peakRssMb": 1057.6,
+    "steadyRssBytes": 1120927744,
+    "steadyRssMb": 1069,
+    "steadySettleMs": 12000,
+    "healthReady": true,
+    "readySanityFloorMs": 3000,
+    "contention": {
+      "cpuCount": 24,
+      "loadAvg1": 51.68,
+      "siblingProcs": 19,
+      "heavy": true
+    },
+    "bootPhases": {
+      "totalMs": 6814,
+      "laps": [
+        {
+          "name": "pre-resolve-setup",
+          "ms": 3685
+        },
+        {
+          "name": "register-sql",
+          "ms": 1053
+        },
+        {
+          "name": "static-plugins-blocking-import",
+          "ms": 808
+        },
+        {
+          "name": "svc:runtime.initialize",
+          "ms": 618
+        },
+        {
+          "name": "resolve-plugins-blocking-import",
+          "ms": 543
+        },
+        {
+          "name": "svc:roles-register",
+          "ms": 93
+        },
+        {
+          "name": "svc:connector-setup",
+          "ms": 12
+        },
+        {
+          "name": "svc:pre-init",
+          "ms": 1
+        },
+        {
+          "name": "svc:boot-prep",
+          "ms": 0
+        }
+      ]
+    }
+  },
+  "checks": [
+    {
+      "name": "coldReadyMs",
+      "value": 14655,
+      "budget": 25000,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "peakRssMb",
+      "value": 1057.625,
+      "budget": 1600,
+      "unit": "MB",
+      "pass": true
+    },
+    {
+      "name": "steadyRssMb",
+      "value": 1069,
+      "budget": 1500,
+      "unit": "MB",
+      "pass": true
+    },
+    {
+      "name": "healthReady",
+      "value": 1,
+      "budget": 1,
+      "unit": "bool",
+      "pass": true
+    },
+    {
+      "name": "readyMsSanityFloor",
+      "value": 14655,
+      "budget": 3000,
+      "unit": "ms",
+      "pass": true
+    }
+  ],
+  "pass": true
+}

--- a/packages/benchmarks/loadperf/BASELINE.md
+++ b/packages/benchmarks/loadperf/BASELINE.md
@@ -84,6 +84,27 @@ all artifacts of measuring a 3-generation layered watch dist; disregard.
 - The original "70 ms PASS" was a false positive from the permissive readiness
   check. Budgets: cold `readyMs` ≤ 25 000, peak RSS ≤ 1600 MB.
 
+### Steady-state RSS (idle resident cost — new)
+
+`peakRssMb` is the boot-time high-water mark; a booted agent that never releases
+boot scratch (or slowly grows at idle) is a **separate** regression class the
+peak number hides. After `ready`, the KPI now holds the idle process for a
+settle window (`LOADPERF_STEADY_SETTLE_MS`, default 12 s), samples `/proc` VmRSS,
+and reports **`steadyRssMb`** = the median of the window's tail (last 60 %), the
+resident cost the headless keyless agent actually carries once boot churn
+subsides.
+
+- **Measured** (prod `entry.js start`, keyless/headless, `--runs=2`, 12 s settle,
+  on a heavily CPU-contended host — RSS is contention-insensitive): peak RSS
+  **1057.6 MB**, **steady RSS 1069 MB**. Steady sits slightly *above* boot-peak
+  because RSS keeps climbing during post-ready warmup (lazy provider/embedding
+  load, GC not yet run) — the exact resident tail the boot-peak sample misses.
+- **Budget: `steadyRssMb` ≤ 1500 MB** — ~40 % headroom over the measured 1069 MB
+  and above the historical ~1272 MB peak reading, so it catches a real resident
+  regression (a ~430 MB idle leak) without flaking on host variance. Ratchet it
+  down as idle-footprint optimizations land. A `null` budget records the number
+  without gating; `--attach` mode reports `null` (no child pid to sample).
+
 ### Boot profile (quiesced, `ELIZA_BOOT_PROFILE=1`)
 
 Boot `bun run dist/entry.js start` with `ELIZA_BOOT_PROFILE=1` to print `[boot-profile]`

--- a/packages/benchmarks/loadperf/README.md
+++ b/packages/benchmarks/loadperf/README.md
@@ -19,7 +19,7 @@ serves). Budget keys live in `budgets.json`.
 | KPI | Script | What it measures | Needs |
 | --- | --- | --- | --- |
 | bundle | `bundle-kpi.mjs` | on-disk bundle size: initial entry, total assets, largest chunk, duplicate-lib waste | `packages/app/dist` |
-| boot | `boot-kpi.mjs` | cold-start `readyMs` + peak RSS of the headless agent | spawns dev-server (or `--attach`) |
+| boot | `boot-kpi.mjs` | cold-start `readyMs` + peak RSS + steady-state idle RSS of the headless keyless agent | spawns dev-server (or `--attach`) |
 | frontend | `frontend-kpi.mjs` | FCP / LCP / CLS, JS transferred, request count, long-task time | `playwright` + a browser |
 | statesync | `statesync-kpi.mjs` | broadcast skew p50/p95, desync events, reconnect time | a running WS server |
 

--- a/packages/benchmarks/loadperf/boot-kpi.mjs
+++ b/packages/benchmarks/loadperf/boot-kpi.mjs
@@ -2,8 +2,10 @@
  * Boot KPI.
  *
  * Measures cold-start of the agent + dashboard API: spawn the dev-server
- * headless, poll GET /api/health until ready, and record wall-clock readyMs
- * plus peak RSS (sampled from /proc/<pid>/status VmRSS while booting).
+ * headless, poll GET /api/health until ready, and record wall-clock readyMs,
+ * peak RSS (sampled from /proc/<pid>/status VmRSS while booting), and
+ * steady-state RSS (median of a post-ready idle settle window — the resident
+ * cost the headless agent carries once boot churn subsides).
  *
  * Default: spawn a fresh child and measure cold boot.
  *   node packages/benchmarks/loadperf/boot-kpi.mjs
@@ -65,6 +67,21 @@ const RUNS = ATTACH ? 1 : Math.max(1, Math.trunc(RUNS_REQUESTED));
 // is physically impossible for a genuine boot and signals a stale server / an
 // early-liveness 200 that slipped past the readiness check — fail loudly.
 const READY_SANITY_FLOOR_MS = 3000;
+
+// Steady-state RSS: peak RSS captures the boot-time high-water mark, but a
+// booted agent that never releases boot scratch (or slowly grows at idle) is a
+// separate regression class the peak number hides. After `ready`, we hold the
+// idle process for a settle window, sample RSS, and report the MEDIAN of the
+// window's tail (post-GC-settle) as steadyRssMb — the resident cost a headless
+// agent actually carries once boot churn subsides. Off during --attach (no pid).
+const STEADY_SETTLE_MS = Math.max(
+  0,
+  Math.trunc(Number(process.env.LOADPERF_STEADY_SETTLE_MS ?? 12_000)),
+);
+const STEADY_SAMPLE_MS = Math.max(
+  100,
+  Math.trunc(Number(process.env.LOADPERF_STEADY_SAMPLE_MS ?? 500)),
+);
 
 const API_PORT = Number(process.env.ELIZA_API_PORT ?? 31337);
 const BASE_URL = (
@@ -134,9 +151,11 @@ function detectContention() {
   return { cpuCount, loadAvg1, siblingProcs, heavy };
 }
 
-function checkBudgets(readyMs, peakRssBytes) {
+function checkBudgets(readyMs, peakRssBytes, steadyRssBytes) {
   const b = loadBudgets().boot;
   const peakRssMb = peakRssBytes == null ? null : peakRssBytes / (1024 * 1024);
+  const steadyRssMb =
+    steadyRssBytes == null ? null : steadyRssBytes / (1024 * 1024);
   const checks = [
     { name: "coldReadyMs", value: readyMs, budget: b.coldReadyMs, unit: "ms" },
   ];
@@ -148,6 +167,16 @@ function checkBudgets(readyMs, peakRssBytes) {
       unit: "MB",
     });
   }
+  // steadyRssMb is only checked when the budget is set AND we measured a value.
+  // A null budget (no baseline yet) records the number without gating.
+  if (steadyRssMb != null && b.steadyRssMb != null) {
+    checks.push({
+      name: "steadyRssMb",
+      value: steadyRssMb,
+      budget: b.steadyRssMb,
+      unit: "MB",
+    });
+  }
   return checks.map((c) => ({ ...c, pass: c.value <= c.budget }));
 }
 
@@ -155,7 +184,13 @@ async function measureAttached() {
   const { readyMs, health } = await waitForReady(BASE_URL, {
     timeoutMs: BOOT_TIMEOUT_MS,
   });
-  return { readyMs, peakRssBytes: null, health, mode: "attach" };
+  return {
+    readyMs,
+    peakRssBytes: null,
+    steadyRssBytes: null,
+    health,
+    mode: "attach",
+  };
 }
 
 // Resolve the agent's state dir the same way @elizaos/core does, so we can read
@@ -238,6 +273,10 @@ async function measureSpawned() {
     }
   })();
 
+  let childExited = false;
+  child.once("exit", () => {
+    childExited = true;
+  });
   const exited = new Promise((_, reject) => {
     child.once("exit", (code, signal) => {
       reject(
@@ -258,9 +297,28 @@ async function measureSpawned() {
     const rssAtReady = readRssBytes(child.pid);
     if (rssAtReady != null && rssAtReady > peakRssBytes)
       peakRssBytes = rssAtReady;
+    // Stop counting boot peak at `ready`; steady-state is measured separately so
+    // a post-ready settle sample can never inflate the boot high-water mark.
+    sampling = false;
+    await sampler;
+    // Hold the idle process for the settle window, sampling RSS. steadyRss is
+    // the median of the window's tail (last 60%), after boot-time GC/scratch
+    // churn subsides — the resident cost the headless agent actually carries.
+    const steadySamples = [];
+    if (STEADY_SETTLE_MS > 0) {
+      const settleDeadline = Date.now() + STEADY_SETTLE_MS;
+      while (Date.now() < settleDeadline && !childExited) {
+        const rss = readRssBytes(child.pid);
+        if (rss != null) steadySamples.push(rss);
+        await sleep(STEADY_SAMPLE_MS);
+      }
+    }
+    const tail = steadySamples.slice(Math.floor(steadySamples.length * 0.4));
+    const steadyRssBytes = tail.length > 0 ? median(tail) : null;
     return {
       readyMs: ready.readyMs,
       peakRssBytes: peakRssBytes || null,
+      steadyRssBytes,
       health: ready.health,
       mode: "spawn",
     };
@@ -333,14 +391,23 @@ async function main() {
   const mode = runs[0].mode;
   const readyMsRuns = runs.map((r) => r.readyMs);
   const rssRuns = runs.map((r) => r.peakRssBytes).filter((v) => v != null);
-  // The median is the canonical readyMs; peak RSS is the worst observed.
+  const steadyRssRuns = runs
+    .map((r) => r.steadyRssBytes)
+    .filter((v) => v != null);
+  // The median is the canonical readyMs; peak + steady RSS are the worst observed.
   const medianReadyMs = median(readyMsRuns);
   const peakRssBytes = rssRuns.length > 0 ? Math.max(...rssRuns) : null;
-  const checks = checkBudgets(medianReadyMs, peakRssBytes);
+  const steadyRssBytes =
+    steadyRssRuns.length > 0 ? Math.max(...steadyRssRuns) : null;
+  const checks = checkBudgets(medianReadyMs, peakRssBytes, steadyRssBytes);
   const peakRssMb =
     peakRssBytes == null
       ? null
       : Number((peakRssBytes / (1024 * 1024)).toFixed(1));
+  const steadyRssMb =
+    steadyRssBytes == null
+      ? null
+      : Number((steadyRssBytes / (1024 * 1024)).toFixed(1));
 
   // Honesty gates — these are PASS/FAIL conditions, not budget tunables. They
   // make a stale-server / early-liveness false positive fail the run loudly.
@@ -374,6 +441,9 @@ async function main() {
       readyMsMax: Math.max(...readyMsRuns),
       peakRssBytes,
       peakRssMb,
+      steadyRssBytes,
+      steadyRssMb,
+      steadySettleMs: STEADY_SETTLE_MS,
       healthReady,
       readySanityFloorMs: READY_SANITY_FLOOR_MS,
       contention,
@@ -408,6 +478,9 @@ async function main() {
       console.log(`ready:       ${ms(medianReadyMs)}`);
     }
     console.log(`peak RSS:    ${peakRssMb == null ? "—" : `${peakRssMb} MB`}`);
+    console.log(
+      `steady RSS:  ${steadyRssMb == null ? "—" : `${steadyRssMb} MB`}${STEADY_SETTLE_MS > 0 ? ` (${Math.round(STEADY_SETTLE_MS / 1000)}s settle)` : " (settle off)"}`,
+    );
     console.log(
       `health.ready:${healthReady === true ? " true" : ` ${healthReady}`}`,
     );

--- a/packages/benchmarks/loadperf/budgets.json
+++ b/packages/benchmarks/loadperf/budgets.json
@@ -11,7 +11,8 @@
   "boot": {
     "coldReadyMs": 25000,
     "warmReadyMs": 12000,
-    "peakRssMb": 1600
+    "peakRssMb": 1600,
+    "steadyRssMb": 1500
   },
   "frontend": {
     "fcpMs": 2500,

--- a/packages/benchmarks/loadperf/run-all.mjs
+++ b/packages/benchmarks/loadperf/run-all.mjs
@@ -170,6 +170,9 @@ function renderMarkdown(ran, results) {
       lines.push(
         `- peak RSS: ${s.peakRssMb == null ? "—" : `${s.peakRssMb} MB`}`,
       );
+      lines.push(
+        `- steady RSS: ${s.steadyRssMb == null ? "—" : `${s.steadyRssMb} MB`}`,
+      );
     } else if (r.kpi === "frontend") {
       lines.push(
         `- FCP: ${ms(s.fcpMs)}  LCP: ${ms(s.lcpMs)}  CLS: ${(s.cls ?? 0).toFixed?.(3) ?? s.cls}`,


### PR DESCRIPTION
Refs #10724 (Memory/CPU/battery epic — scope B backend/agent guardrail).

## Summary
`loadperf/boot-kpi.mjs` already gates cold `readyMs` and boot **peak** RSS, but had no gate on the **steady-state idle RSS** a booted agent carries once boot churn subsides — a distinct regression class (boot scratch never released, slow idle growth) the peak high-water mark hides.

After `ready`, the KPI now holds the idle keyless/headless agent for a settle window (`LOADPERF_STEADY_SETTLE_MS`, default 12s), samples `/proc/<pid>` VmRSS, and reports **`steadyRssMb`** = median of the window's tail (last 60%, post-GC-settle). Gated against `budgets.json → boot.steadyRssMb` (1500 MB). A `null` budget records without gating; `--attach` reports `null` (no child pid). Boot-peak sampling stops at `ready`, so a settle sample can never inflate the boot high-water mark.

## Validation (real, this host)
Prod path (`bun run dist/entry.js start`, keyless/headless), `--runs=2`, 12s settle, heavily CPU-contended host (RSS is contention-insensitive):

```
peak RSS:    1057.6 MB   (budget 1600 MB — PASS)
steady RSS:  1069.0 MB   (budget 1500 MB — PASS)   <- new gate
ready median: 14655 ms   (budget 25000 ms — PASS)
health.ready: true
```

Steady sits slightly **above** boot-peak because RSS keeps climbing during post-ready warmup (lazy provider/embedding load, GC not yet run) — the exact resident tail the boot-peak sample misses, which is why the separate metric earns its keep.

- `node --check` + `biome check` on touched files: pass.
- Budget `steadyRssMb ≤ 1500 MB` = ~40% headroom over measured 1069 MB, above the historical ~1272 MB peak reading — catches a ~430 MB idle-leak regression without flaking. Ratchet down as idle-footprint wins land.

Evidence + recorded result JSON: `.github/issue-evidence/10724-steady-rss-gate/`.

Screenshots/video: N/A — a CI/benchmark gate, no UI/runtime visual surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)