### PR TITLE
fix(cloud): harden credential pool followups

### DIFF
--- a/.github/issue-evidence/11586-credential-pool-followups.md
+++ b/.github/issue-evidence/11586-credential-pool-followups.md
@@ -37,11 +37,9 @@ Branch: `fix/11586-credential-pool-followups`
 - `bun install`
   - Passed after rebasing onto `origin/develop`; no lockfile change remained.
 - `bun run verify`
-  - Failed before package typecheck/lint on the repo-wide type-safety ratchet:
-    - `as unknown as`: 77 current > 76 baseline.
-    - `?? {}` in core/agent/app-core: 380 current > 377 baseline.
-    - `?? 0` in core/agent/app-core: 376 current > 375 baseline.
-  - The reported files are outside this change set.
+  - Passed after rebasing onto `origin/develop` at `390c89e6fe4`.
+  - Workspace phase: 483 successful tasks.
+  - Final dist-path check: 28 consumer configs checked.
 
 ## Evidence Matrix
 

--- a/.github/issue-evidence/11586-credential-pool-followups.md
+++ b/.github/issue-evidence/11586-credential-pool-followups.md
@@ -1,0 +1,49 @@
+# Issue #11586 — credential-pool follow-ups
+
+Date: 2026-07-02
+Branch: `fix/11586-credential-pool-followups`
+
+## What Changed
+
+- Added org-scoped repository WHERE paths for pooled credential read/update/delete and pool metadata writes.
+- Wired Worker chat completions to select org pooled direct-provider keys for supported direct models, with strict fallback to platform env on pool miss.
+- Added 401/403/429 provider outcome writeback to pooled credential health.
+- Applied `RATE_LIMIT_MULTIPLIER` to the Hono/Cloudflare limiter in non-production only.
+- Mapped `pooled_credential` audit denials to `secret.access`.
+
+## Human Follow-Up Split
+
+- Staging-only provisioning proof was split to #11622 (`needs-human`) because it requires deployed staging access and logs/artifacts from the real provisioning topology.
+
+## Verification
+
+- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/pooled-credentials.ts packages/cloud/shared/src/lib/services/team-credential-pool/service.ts packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/providers/language-model.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts packages/cloud/api/src/middleware/org-membership.ts packages/cloud/api/__tests__/org-credentials-routes.test.ts packages/cloud/api/v1/chat/completions/route.ts`
+  - Passed.
+- `bun test packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts`
+  - Passed: 36 tests, 136 assertions.
+- `bun test packages/cloud/api/__tests__/org-credentials-routes.test.ts`
+  - Passed: 12 tests, 34 assertions.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Passed.
+- `bun run --cwd packages/cloud/api typecheck`
+  - Passed.
+- `bun test packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts`
+  - Passed: streaming provider-error reservation tests.
+- `git diff --check`
+  - Passed.
+- `bun install`
+  - Passed after rebasing onto `origin/develop`; no lockfile change remained.
+- `bun run verify`
+  - Failed before package typecheck/lint on the repo-wide type-safety ratchet:
+    - `as unknown as`: 77 current > 76 baseline.
+    - `?? {}` in core/agent/app-core: 380 current > 377 baseline.
+    - `?? 0` in core/agent/app-core: 376 current > 375 baseline.
+  - The reported files are outside this change set.
+
+## Evidence Matrix
+
+- UI screenshots/video: N/A — backend/provider/middleware changes only.
+- Real-LLM trajectories: N/A — no agent prompt/action/model behavior change; provider selection is covered by direct provider-request tests.
+- Backend logs: N/A locally — route tests exercise the code paths without a deployed service log sink.
+- Domain artifacts: covered by DB-backed pooled credential tests that inspect rows, ciphertext preservation, usage rollups, and health metadata.
+- Staging provisioning proof: N/A for this PR; split to #11622.

--- a/.github/issue-evidence/11586-credential-pool-followups.md
+++ b/.github/issue-evidence/11586-credential-pool-followups.md
@@ -9,6 +9,7 @@ Branch: `fix/11586-credential-pool-followups`
 - Wired Worker chat completions to select org pooled direct-provider keys for supported direct models, with strict fallback to platform env on pool miss.
 - Added 401/403/429 provider outcome writeback to pooled credential health.
 - Suppressed affiliate markup/earnings on zero-rated pooled BYO-key completions while still recording pool usage.
+- Kept monetized app-credit billing ahead of pooled BYO-key no-op reservations so contributed provider keys cannot bypass app-owner pricing.
 - Added source-condition package exports/imports needed for cloud source typechecks to resolve `@elizaos/app-core/account-pool` and `@elizaos/agent/utils/atomic-json`.
 - Applied `RATE_LIMIT_MULTIPLIER` to the Hono/Cloudflare limiter in non-production only.
 - Mapped `pooled_credential` audit denials to `secret.access`.
@@ -30,7 +31,7 @@ Branch: `fix/11586-credential-pool-followups`
 - `bun run --cwd packages/cloud/api typecheck`
   - Passed.
 - `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts`
-  - Passed: 10 tests, 74 assertions, including pooled BYO-key success suppressing affiliate markup while recording pool use.
+  - Passed: 11 tests, 76 assertions, including pooled BYO-key success suppressing affiliate markup while recording pool use and pooled BYO-key not bypassing monetized app billing.
 - `git diff --check`
   - Passed.
 - `bun install`

--- a/.github/issue-evidence/11586-credential-pool-followups.md
+++ b/.github/issue-evidence/11586-credential-pool-followups.md
@@ -8,6 +8,8 @@ Branch: `fix/11586-credential-pool-followups`
 - Added org-scoped repository WHERE paths for pooled credential read/update/delete and pool metadata writes.
 - Wired Worker chat completions to select org pooled direct-provider keys for supported direct models, with strict fallback to platform env on pool miss.
 - Added 401/403/429 provider outcome writeback to pooled credential health.
+- Suppressed affiliate markup/earnings on zero-rated pooled BYO-key completions while still recording pool usage.
+- Added source-condition package exports/imports needed for cloud source typechecks to resolve `@elizaos/app-core/account-pool` and `@elizaos/agent/utils/atomic-json`.
 - Applied `RATE_LIMIT_MULTIPLIER` to the Hono/Cloudflare limiter in non-production only.
 - Mapped `pooled_credential` audit denials to `secret.access`.
 
@@ -17,18 +19,18 @@ Branch: `fix/11586-credential-pool-followups`
 
 ## Verification
 
-- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/pooled-credentials.ts packages/cloud/shared/src/lib/services/team-credential-pool/service.ts packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/providers/language-model.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts packages/cloud/api/src/middleware/org-membership.ts packages/cloud/api/__tests__/org-credentials-routes.test.ts packages/cloud/api/v1/chat/completions/route.ts`
+- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/pooled-credentials.ts packages/cloud/shared/src/lib/services/team-credential-pool/service.ts packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/providers/language-model.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts packages/cloud/api/src/middleware/org-membership.ts packages/cloud/api/__tests__/org-credentials-routes.test.ts packages/cloud/api/v1/chat/completions/route.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts packages/agent/package.json packages/agent/src/auth/credentials.ts packages/app-core/package.json packages/app-core/src/services/account-pool.ts packages/app-core/src/services/account-usage.ts packages/app-core/src/services/coding-account-bridge.ts`
   - Passed.
-- `bun test packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts`
+- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts`
   - Passed: 36 tests, 136 assertions.
-- `bun test packages/cloud/api/__tests__/org-credentials-routes.test.ts`
+- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/api/__tests__/org-credentials-routes.test.ts`
   - Passed: 12 tests, 34 assertions.
 - `bun run --cwd packages/cloud/shared typecheck`
   - Passed.
 - `bun run --cwd packages/cloud/api typecheck`
   - Passed.
-- `bun test packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts`
-  - Passed: streaming provider-error reservation tests.
+- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts`
+  - Passed: 10 tests, 74 assertions, including pooled BYO-key success suppressing affiliate markup while recording pool use.
 - `git diff --check`
   - Passed.
 - `bun install`

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -149,6 +149,21 @@
       "import": "./dist/auth/*.js",
       "default": "./dist/auth/*.js"
     },
+    "./utils/atomic-json": {
+      "types": "./src/utils/atomic-json.ts",
+      "eliza-source": {
+        "types": "./src/utils/atomic-json.ts",
+        "import": "./src/utils/atomic-json.ts",
+        "default": "./src/utils/atomic-json.ts"
+      },
+      "bun": {
+        "types": "./src/utils/atomic-json.ts",
+        "import": "./src/utils/atomic-json.ts",
+        "default": "./src/utils/atomic-json.ts"
+      },
+      "import": "./dist/utils/atomic-json.js",
+      "default": "./dist/utils/atomic-json.js"
+    },
     "./services/app-session-gate": {
       "eliza-source": {
         "types": "./src/services/app-session-gate.ts",

--- a/packages/agent/src/auth/credentials.ts
+++ b/packages/agent/src/auth/credentials.ts
@@ -19,7 +19,7 @@ import {
   resolveStateDir,
   resolveUserPath,
 } from "@elizaos/core";
-import type { SubscriptionCredentialSource } from "@elizaos/shared";
+import type { SubscriptionCredentialSource } from "@elizaos/shared/contracts/first-run-options";
 import {
   type AccountCredentialRecord,
   deleteAccount,
@@ -297,7 +297,7 @@ function hasCodexCliSubscriptionAuth(): boolean {
   }
 }
 
-export type { SubscriptionCredentialSource } from "@elizaos/shared";
+export type { SubscriptionCredentialSource } from "@elizaos/shared/contracts/first-run-options";
 
 /**
  * Per-account subscription status row used by the dashboard / API.

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -97,7 +97,17 @@
       "default": "./dist/agent-bridge.js"
     },
     "./account-pool": {
-      "types": "./dist/account-pool.d.ts",
+      "types": "./src/account-pool.ts",
+      "eliza-source": {
+        "types": "./src/account-pool.ts",
+        "import": "./src/account-pool.ts",
+        "default": "./src/account-pool.ts"
+      },
+      "bun": {
+        "types": "./src/account-pool.ts",
+        "import": "./src/account-pool.ts",
+        "default": "./src/account-pool.ts"
+      },
       "import": "./dist/account-pool.js",
       "default": "./dist/account-pool.js"
     },

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -45,7 +45,7 @@ import type {
   LinkedAccountProviderId,
   LinkedAccountsConfig,
   LinkedAccountUsage,
-} from "@elizaos/shared";
+} from "@elizaos/shared/contracts/service-routing";
 import {
   pollAnthropicUsage,
   pollCodexUsage,

--- a/packages/app-core/src/services/account-usage.ts
+++ b/packages/app-core/src/services/account-usage.ts
@@ -16,7 +16,7 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
-import type { LinkedAccountUsage } from "@elizaos/shared";
+import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
 
 /**
  * Snapshot returned by the provider usage probes. Mirrors

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -44,7 +44,7 @@ import { logger, resolveStateDir } from "@elizaos/core";
 import type {
   LinkedAccountProviderId,
   LinkedAccountUsage,
-} from "@elizaos/shared";
+} from "@elizaos/shared/contracts/service-routing";
 import type { AccountPool, Strategy } from "./account-pool.js";
 
 const CODING_AGENT_SELECTOR_BRIDGE_SYMBOL: unique symbol = Symbol.for(

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -240,7 +240,10 @@ export async function adoptRotatedCodexTokens(
     // Only adopt when the CLI's copy is NEWER than the canonical record. An
     // older materialized copy (e.g. the account was re-linked via OAuth after
     // that session ran) would clobber a fresh login with dead tokens.
-    const materializedAt = Date.parse(parsed.last_refresh ?? "");
+    const materializedAt =
+      typeof parsed.last_refresh === "string"
+        ? Date.parse(parsed.last_refresh)
+        : Number.NaN;
     if (
       !Number.isFinite(materializedAt) ||
       materializedAt <= record.updatedAt
@@ -280,7 +283,12 @@ function materializeCodexHome(accountId: string, accessToken: string): string {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
   const record = loadAccount("openai-codex", accountId);
-  const refreshToken = record?.credentials.refresh ?? "";
+  const refreshToken = record?.credentials.refresh;
+  if (!refreshToken) {
+    throw new Error(
+      `openai-codex account "${accountId}" is missing a refresh token`,
+    );
+  }
   const chatgptAccountId = record?.organizationId;
   // Codex's chatgpt-mode auth loader requires `tokens.id_token`; omitting it
   // fails with "Authentication required" even when access_token is valid (an

--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -34,6 +34,7 @@ import { estimateTokens } from "@/lib/pricing";
 import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as aiBillingRecordsActual from "@/lib/services/ai-billing-records";
+import * as teamCredentialPoolActual from "@/lib/services/team-credential-pool";
 
 // The REAL settler — explicitly NOT mocked. This is the component under test.
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
@@ -105,6 +106,16 @@ mock.module("@/lib/services/ai-billing-records", () => ({
   },
 }));
 
+const poolRecordUse = mock(async () => {});
+const poolRecordProviderFailure = mock(async () => {});
+mock.module("@/lib/services/team-credential-pool", () => ({
+  ...teamCredentialPoolActual,
+  getTeamPoolRegistry: () => ({
+    recordUse: poolRecordUse,
+    recordProviderFailure: poolRecordProviderFailure,
+  }),
+}));
+
 // Import the route AFTER the mocks so it binds to the stubs.
 const { __streamingCreditTestHooks } = await import(
   "../v1/chat/completions/route"
@@ -118,6 +129,10 @@ afterAll(() => {
   mock.module(
     "@/lib/services/ai-billing-records",
     () => aiBillingRecordsActual,
+  );
+  mock.module(
+    "@/lib/services/team-credential-pool",
+    () => teamCredentialPoolActual,
   );
 });
 
@@ -174,7 +189,18 @@ const REQUEST = {
 /** Invoke handleStreamingRequest with the test's settler and a fixed shape. */
 function callStreaming(
   settleReservation: (actualCost: number) => Promise<unknown> | unknown,
-  options: { estimatedInputTokens?: number; signal?: AbortSignal } = {},
+  options: {
+    affiliateCode?: string | null;
+    estimatedInputTokens?: number;
+    pooledCredential?: {
+      organizationId: string;
+      credentialId: string;
+      providerId: "openai-api" | "anthropic-api" | "cerebras-api";
+      apiKey: string;
+      label: string;
+    } | null;
+    signal?: AbortSignal;
+  } = {},
 ) {
   return handleStreamingRequest(
     MODEL,
@@ -183,7 +209,7 @@ function callStreaming(
     REQUEST,
     { id: USER, organization_id: ORG },
     null,
-    null,
+    options.affiliateCode ?? null,
     "idem-1",
     "req-1",
     null,
@@ -196,7 +222,7 @@ function callStreaming(
     undefined,
     {} as never,
     "gateway" as never,
-    null,
+    options.pooledCredential ?? null,
   );
 }
 
@@ -205,6 +231,8 @@ beforeEach(() => {
   billUsage.mockClear();
   recordUsageAnalytics.mockClear();
   aiBillingRecord.mockClear();
+  poolRecordUse.mockClear();
+  poolRecordProviderFailure.mockClear();
   streamTextImpl = null;
 });
 
@@ -444,6 +472,64 @@ describe("streaming chat — client abort settles delivered usage", () => {
 });
 
 describe("streaming chat — success settles once, no double-refund", () => {
+  test("pooled BYO-key success suppresses affiliate markup while recording pool use", async () => {
+    const settle = mock(async () => null);
+    let onFinishPromise: Promise<unknown> | undefined;
+
+    streamTextImpl = (config) => {
+      const onFinish = config.onFinish as
+        | ((event: {
+            text: string;
+            usage: {
+              inputTokens: number;
+              outputTokens: number;
+              totalTokens: number;
+            };
+          }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-delta", id: "text-1", text: "pooled ok" };
+          onFinishPromise = Promise.resolve(
+            onFinish?.({
+              text: "pooled ok",
+              usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            }),
+          );
+          yield { type: "finish", finishReason: "stop" };
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, {
+      affiliateCode: "SHOULD_NOT_PAY",
+      pooledCredential: {
+        organizationId: ORG,
+        credentialId: "pooled-credential-1",
+        providerId: "openai-api",
+        apiKey: "sk-pooled",
+        label: "Team OpenAI key",
+      },
+    });
+    const body = await res.text();
+    expect(onFinishPromise).toBeDefined();
+    await onFinishPromise;
+
+    expect(body).toContain("pooled ok");
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(
+      (billUsage.mock.calls[0][0] as { affiliateCode?: string | null })
+        .affiliateCode,
+    ).toBe(null);
+    expect(settle).toHaveBeenCalledTimes(1);
+    expect(poolRecordUse).toHaveBeenCalledWith({
+      organizationId: ORG,
+      credentialId: "pooled-credential-1",
+      userId: USER,
+    });
+  });
+
   test("settler reconciles to actual cost exactly once; a stray onError cannot re-refund", async () => {
     const ledger = makeLedgerReservation(100, 0.015);
     const settle = createCreditReservationSettler(ledger.reservation);

--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -117,10 +117,11 @@ mock.module("@/lib/services/team-credential-pool", () => ({
 }));
 
 // Import the route AFTER the mocks so it binds to the stubs.
-const { __streamingCreditTestHooks } = await import(
+const { __billingBranchTestHooks, __streamingCreditTestHooks } = await import(
   "../v1/chat/completions/route"
 );
 const { handleStreamingRequest } = __streamingCreditTestHooks;
+const { shouldUsePooledNoopReservation } = __billingBranchTestHooks;
 
 afterAll(() => {
   mock.module("ai", () => aiActual);
@@ -472,6 +473,29 @@ describe("streaming chat — client abort settles delivered usage", () => {
 });
 
 describe("streaming chat — success settles once, no double-refund", () => {
+  test("pooled BYO key does not bypass monetized app billing reservation", () => {
+    const pooledCredential = {
+      organizationId: ORG,
+      credentialId: "pooled-credential-1",
+      providerId: "openai-api" as const,
+      apiKey: "sk-pooled",
+      label: "Team OpenAI key",
+    };
+
+    expect(
+      shouldUsePooledNoopReservation({
+        pooledCredential,
+        useMonetizedAppBilling: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUsePooledNoopReservation({
+        pooledCredential,
+        useMonetizedAppBilling: true,
+      }),
+    ).toBe(false);
+  });
+
   test("pooled BYO-key success suppresses affiliate markup while recording pool use", async () => {
     const settle = mock(async () => null);
     let onFinishPromise: Promise<unknown> | undefined;

--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -196,6 +196,7 @@ function callStreaming(
     undefined,
     {} as never,
     "gateway" as never,
+    null,
   );
 }
 

--- a/packages/cloud/api/__tests__/org-credentials-routes.test.ts
+++ b/packages/cloud/api/__tests__/org-credentials-routes.test.ts
@@ -358,11 +358,14 @@ describe("PATCH/DELETE /api/organizations/credentials/:id — RBAC + IDOR", () =
     // The denial is audited (assertOrgMembership emits a denied event).
     const { dbWrite } = await import("@/db/client");
     const audited = await dbWrite.execute(
-      `SELECT actor_id, result, metadata FROM auth_events
+      `SELECT actor_id, action, result, metadata FROM auth_events
        WHERE result = 'denied' AND resource_type = 'pooled_credential' AND resource_id = '${credentialByMemberA}';`,
     );
     expect(audited.rows.length).toBeGreaterThanOrEqual(1);
     expect((audited.rows[0] as { actor_id: string }).actor_id).toBe(MEMBER_B);
+    expect((audited.rows[0] as { action: string }).action).toBe(
+      "secret.access",
+    );
   });
 
   test("a non-contributor member cannot DELETE someone else's key", async () => {

--- a/packages/cloud/api/src/middleware/org-membership.ts
+++ b/packages/cloud/api/src/middleware/org-membership.ts
@@ -29,6 +29,7 @@ const RESOURCE_TYPE_TO_ACTION: Record<string, AuditAction> = {
   api_key: "api_key.use",
   agent: "agent.config.update",
   container: "agent.config.update",
+  pooled_credential: "secret.access",
   secret: "secret.access",
   workflow: "agent.config.update",
 };

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -841,6 +841,13 @@ async function recordPooledInferenceFailure(
   });
 }
 
+function shouldUsePooledNoopReservation(params: {
+  pooledCredential: PooledInferenceCredential | null;
+  useMonetizedAppBilling: boolean;
+}): boolean {
+  return Boolean(params.pooledCredential && !params.useMonetizedAppBilling);
+}
+
 // ============================================================================
 // Main Handler
 // ============================================================================
@@ -1130,9 +1137,10 @@ export async function handleChatCompletionsPOST(
       | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
       | null = null;
 
-    if (pooledCredential) {
-      reservation = creditsService.createAnonymousReservation();
-    } else if (useAppCredits && appId && monetizedApp) {
+    const useMonetizedAppBilling = Boolean(
+      useAppCredits && appId && monetizedApp,
+    );
+    if (useAppCredits && appId && monetizedApp) {
       const { totalCost } = await calculateCost(
         normalizedModel,
         provider,
@@ -1177,6 +1185,13 @@ export async function handleChatCompletionsPOST(
         }
         throw error;
       }
+    } else if (
+      shouldUsePooledNoopReservation({
+        pooledCredential,
+        useMonetizedAppBilling,
+      })
+    ) {
+      reservation = creditsService.createAnonymousReservation();
     } else {
       // Organization credits path. #9899 Tier-2: when optimistic billing is
       // enabled AND this org's balance comfortably clears SAFE_BALANCE_THRESHOLD,
@@ -1332,7 +1347,12 @@ export async function handleChatCompletionsPOST(
 
     // Optimistic path debits the actual cost off the response path; otherwise the
     // reservation settler reconciles the upfront hold. Same (actualCost) shape.
-    if (pooledCredential) {
+    if (
+      shouldUsePooledNoopReservation({
+        pooledCredential,
+        useMonetizedAppBilling,
+      })
+    ) {
       settleReservation = async () => null;
     } else if (optimisticSettler) {
       settleReservation = optimisticSettler;
@@ -2372,4 +2392,8 @@ export const __nativeToolingTestHooks = {
  */
 export const __streamingCreditTestHooks = {
   handleStreamingRequest,
+} as const;
+
+export const __billingBranchTestHooks = {
+  shouldUsePooledNoopReservation,
 } as const;

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1684,6 +1684,7 @@ async function handleStreamingRequest(
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
   const billingPrompt = buildChatPromptForBilling(request);
+  const billingAffiliateCode = pooledCredential ? null : affiliateCode;
   let deliveredText = "";
   let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
     null;
@@ -1714,7 +1715,7 @@ async function handleStreamingRequest(
           provider,
           user,
           apiKey,
-          affiliateCode,
+          affiliateCode: billingAffiliateCode,
           appId,
           requestId,
           idempotencyKey,
@@ -1765,7 +1766,7 @@ async function handleStreamingRequest(
             billingSource,
             requestId,
             appId,
-            affiliateCode,
+            affiliateCode: billingAffiliateCode,
             streaming: true,
           });
           const billing = await billUsage(billingContext, usage);
@@ -2122,6 +2123,7 @@ async function handleNonStreamingRequest(
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
+  const billingAffiliateCode = pooledCredential ? null : affiliateCode;
 
   const safeParamsNonStream = getSafeModelParams(model, {
     temperature: request.temperature,
@@ -2191,7 +2193,7 @@ async function handleNonStreamingRequest(
           billingSource,
           requestId,
           appId,
-          affiliateCode,
+          affiliateCode: billingAffiliateCode,
           streaming: false,
         });
         const billing = await billUsage(billingContext, result.usage);

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -53,7 +53,9 @@ import {
   getAiProviderConfigurationError,
   getLanguageModel,
   hasLanguageModelProviderConfigured,
+  type PooledLanguageModelCredential,
   resolveAiProviderSource,
+  resolvePooledDirectProviderForModel,
 } from "@/lib/providers/language-model";
 import {
   type AIUsage,
@@ -91,6 +93,10 @@ import {
   resolveInferenceBillingLedger,
 } from "@/lib/services/inference-billing-ledger";
 import { getCachedGatewayModelById } from "@/lib/services/model-catalog";
+import {
+  getTeamPoolRegistry,
+  type SelectedPooledCredential,
+} from "@/lib/services/team-credential-pool";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
@@ -100,6 +106,12 @@ const ROUTE_MAX_DURATION = 800;
 
 // Minimum tokens to reserve for actual response generation when CoT is active
 const MIN_RESPONSE_TOKENS = 4096;
+
+interface PooledInferenceCredential extends PooledLanguageModelCredential {
+  organizationId: string;
+  credentialId: string;
+  label: string;
+}
 
 function buildProviderReconciliationMetadata(
   provider: string,
@@ -770,6 +782,65 @@ function getRecoverableProviderErrorStatus(error: unknown): number | null {
   return null;
 }
 
+function toPooledInferenceCredential(
+  organizationId: string,
+  selected: SelectedPooledCredential,
+): PooledInferenceCredential {
+  return {
+    organizationId,
+    credentialId: selected.credentialId,
+    providerId: selected.providerId,
+    apiKey: selected.apiKey,
+    label: selected.label,
+  };
+}
+
+async function selectPooledInferenceCredential(params: {
+  model: string;
+  organizationId: string;
+  sessionKey: string;
+}): Promise<PooledInferenceCredential | null> {
+  const providerId = resolvePooledDirectProviderForModel(params.model);
+  if (!providerId) return null;
+  const selected = await getTeamPoolRegistry().selectCredential({
+    organizationId: params.organizationId,
+    providerId,
+    sessionKey: params.sessionKey,
+  });
+  return selected
+    ? toPooledInferenceCredential(params.organizationId, selected)
+    : null;
+}
+
+async function recordPooledInferenceSuccess(
+  pooledCredential: PooledInferenceCredential | null,
+  userId: string,
+): Promise<void> {
+  if (!pooledCredential) return;
+  await getTeamPoolRegistry().recordUse({
+    organizationId: pooledCredential.organizationId,
+    credentialId: pooledCredential.credentialId,
+    userId,
+  });
+}
+
+async function recordPooledInferenceFailure(
+  pooledCredential: PooledInferenceCredential | null,
+  error: unknown,
+): Promise<void> {
+  if (!pooledCredential) return;
+  const status =
+    getRecoverableProviderErrorStatus(error) ?? getErrorStatusCode(error);
+  if (![401, 403, 429].includes(status)) return;
+  await getTeamPoolRegistry().recordProviderFailure({
+    organizationId: pooledCredential.organizationId,
+    credentialId: pooledCredential.credentialId,
+    providerId: pooledCredential.providerId,
+    status,
+    detail: error instanceof Error ? error.message : String(error),
+  });
+}
+
 // ============================================================================
 // Main Handler
 // ============================================================================
@@ -915,8 +986,13 @@ export async function handleChatCompletionsPOST(
     // by dedicated agents) to the bare Cerebras id so pricing, routing, and
     // billing all agree and route to cerebras-direct instead of OpenRouter.
     const model = canonicalizeCerebrasModelId(request.model);
+    const pooledCredential = await selectPooledInferenceCredential({
+      model,
+      organizationId: user.organization_id,
+      sessionKey: apiKey?.id ?? user.id,
+    });
 
-    if (!hasLanguageModelProviderConfigured(model)) {
+    if (!pooledCredential && !hasLanguageModelProviderConfigured(model)) {
       return addCorsHeaders(
         Response.json(
           {
@@ -933,7 +1009,9 @@ export async function handleChatCompletionsPOST(
 
     const provider = getProviderFromModel(model);
     const normalizedModel = normalizeModelName(model);
-    const billingSource = resolveAiProviderSource(model) ?? "gateway";
+    const billingSource = pooledCredential
+      ? "gateway"
+      : (resolveAiProviderSource(model) ?? "gateway");
     const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
     const cotOptions =
       cotBudget != null
@@ -1052,7 +1130,9 @@ export async function handleChatCompletionsPOST(
       | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
       | null = null;
 
-    if (useAppCredits && appId && monetizedApp) {
+    if (pooledCredential) {
+      reservation = creditsService.createAnonymousReservation();
+    } else if (useAppCredits && appId && monetizedApp) {
       const { totalCost } = await calculateCost(
         normalizedModel,
         provider,
@@ -1252,7 +1332,9 @@ export async function handleChatCompletionsPOST(
 
     // Optimistic path debits the actual cost off the response path; otherwise the
     // reservation settler reconciles the upfront hold. Same (actualCost) shape.
-    if (optimisticSettler) {
+    if (pooledCredential) {
+      settleReservation = async () => null;
+    } else if (optimisticSettler) {
       settleReservation = optimisticSettler;
     } else {
       if (!reservation) {
@@ -1316,6 +1398,7 @@ export async function handleChatCompletionsPOST(
           effectiveMaxTokens,
           webSearchOptions,
           billingSource,
+          pooledCredential,
         )
       : await handleNonStreamingRequest(
           model,
@@ -1336,6 +1419,7 @@ export async function handleChatCompletionsPOST(
           effectiveMaxTokens,
           webSearchOptions,
           billingSource,
+          pooledCredential,
           options.executionCtx,
         );
     // Emit per-step pre-forward timing as a readable header (#9899). Debug-only
@@ -1593,6 +1677,7 @@ async function handleStreamingRequest(
   effectiveMaxTokens: number | undefined,
   webSearchOptions: ReturnType<typeof buildProviderNativeWebSearchTools>,
   billingSource: PricingBillingSource,
+  pooledCredential: PooledInferenceCredential | null,
 ) {
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
@@ -1657,7 +1742,7 @@ async function handleStreamingRequest(
   });
 
   const result = streamText({
-    model: getLanguageModel(model),
+    model: getLanguageModel(model, pooledCredential ?? undefined),
     system: systemPrompt,
     messages,
     ...webSearchOptions,
@@ -1685,6 +1770,7 @@ async function handleStreamingRequest(
           });
           const billing = await billUsage(billingContext, usage);
           const reconciliation = await settleReservation(billing.totalCost);
+          await recordPooledInferenceSuccess(pooledCredential, user.id);
 
           const usageRecord = await recordUsageAnalytics(
             billingContext,
@@ -1763,6 +1849,7 @@ async function handleStreamingRequest(
     // later onFinish/onAbort cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
       await refundStreamingReservationOnce();
+      await recordPooledInferenceFailure(pooledCredential, error);
       logger.error(
         "[Chat Completions] Stream provider error — reservation refunded",
         {
@@ -1952,6 +2039,7 @@ async function handleStreamingRequest(
           await settleStreamingAbortOnce([]);
         } else {
           await refundStreamingReservationOnce();
+          await recordPooledInferenceFailure(pooledCredential, error);
         }
         const status =
           getRecoverableProviderErrorStatus(error) ?? getErrorStatusCode(error);
@@ -2027,6 +2115,7 @@ async function handleNonStreamingRequest(
   effectiveMaxTokens: number | undefined,
   webSearchOptions: ReturnType<typeof buildProviderNativeWebSearchTools>,
   billingSource: PricingBillingSource,
+  pooledCredential: PooledInferenceCredential | null,
   executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined,
 ) {
   const provider = getProviderFromModel(model);
@@ -2048,7 +2137,7 @@ async function handleNonStreamingRequest(
 
   try {
     const result = await generateText({
-      model: getLanguageModel(model),
+      model: getLanguageModel(model, pooledCredential ?? undefined),
       system: systemPrompt,
       messages,
       ...webSearchOptions,
@@ -2107,6 +2196,7 @@ async function handleNonStreamingRequest(
         });
         const billing = await billUsage(billingContext, result.usage);
         const reconciliation = await settleReservation(billing.totalCost);
+        await recordPooledInferenceSuccess(pooledCredential, user.id);
 
         const usageRecord = await recordUsageAnalytics(
           billingContext,
@@ -2232,6 +2322,7 @@ async function handleNonStreamingRequest(
     );
   } catch (error) {
     await settleReservation?.(0);
+    await recordPooledInferenceFailure(pooledCredential, error);
     throw error;
   }
 }

--- a/packages/cloud/shared/src/db/repositories/pooled-credentials.ts
+++ b/packages/cloud/shared/src/db/repositories/pooled-credentials.ts
@@ -52,6 +52,20 @@ export class PooledCredentialsRepository {
     return rows[0];
   }
 
+  async findByIdForOrganization(
+    id: string,
+    organizationId: string,
+  ): Promise<PooledCredential | undefined> {
+    const rows = await dbRead
+      .select()
+      .from(pooledCredentials)
+      .where(
+        and(eq(pooledCredentials.id, id), eq(pooledCredentials.organization_id, organizationId)),
+      )
+      .limit(1);
+    return rows[0];
+  }
+
   async listByOrganization(organizationId: string): Promise<PooledCredential[]> {
     return await dbRead
       .select()
@@ -127,6 +141,22 @@ export class PooledCredentialsRepository {
     id: string,
     state: PooledCredentialPoolState,
   ): Promise<PooledCredential | undefined> {
+    return this.updatePoolStateWhere(id, undefined, state);
+  }
+
+  async updatePoolStateForOrganization(
+    id: string,
+    organizationId: string,
+    state: PooledCredentialPoolState,
+  ): Promise<PooledCredential | undefined> {
+    return this.updatePoolStateWhere(id, organizationId, state);
+  }
+
+  private async updatePoolStateWhere(
+    id: string,
+    organizationId: string | undefined,
+    state: PooledCredentialPoolState,
+  ): Promise<PooledCredential | undefined> {
     const set: Record<string, unknown> = { updated_at: new Date() };
     if (state.label !== undefined) set.label = state.label;
     if (state.enabled !== undefined) set.enabled = state.enabled;
@@ -138,15 +168,37 @@ export class PooledCredentialsRepository {
     const rows = await dbWrite
       .update(pooledCredentials)
       .set(set)
-      .where(eq(pooledCredentials.id, id))
+      .where(
+        organizationId
+          ? and(eq(pooledCredentials.id, id), eq(pooledCredentials.organization_id, organizationId))
+          : eq(pooledCredentials.id, id),
+      )
       .returning();
     return rows[0];
   }
 
   async delete(id: string): Promise<PooledCredential | undefined> {
+    return this.deleteWhere(id);
+  }
+
+  async deleteForOrganization(
+    id: string,
+    organizationId: string,
+  ): Promise<PooledCredential | undefined> {
+    return this.deleteWhere(id, organizationId);
+  }
+
+  private async deleteWhere(
+    id: string,
+    organizationId?: string,
+  ): Promise<PooledCredential | undefined> {
     const rows = await dbWrite
       .delete(pooledCredentials)
-      .where(eq(pooledCredentials.id, id))
+      .where(
+        organizationId
+          ? and(eq(pooledCredentials.id, id), eq(pooledCredentials.organization_id, organizationId))
+          : eq(pooledCredentials.id, id),
+      )
       .returning();
     return rows[0];
   }

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { rateLimitConfigVerdict } from "./rate-limit-hono-cloudflare";
+import { applyRateLimitMultiplier, rateLimitConfigVerdict } from "./rate-limit-hono-cloudflare";
 
 // #9853 P1.1 — production must never silently serve with rate limiting OFF.
 describe("rateLimitConfigVerdict", () => {
@@ -60,5 +60,38 @@ describe("rateLimitConfigVerdict", () => {
         }),
       ).toBe("warn-disabled");
     }
+  });
+});
+
+describe("applyRateLimitMultiplier", () => {
+  const config = { windowMs: 60_000, maxRequests: 10 };
+
+  test("non-production RATE_LIMIT_MULTIPLIER scales maxRequests", () => {
+    expect(
+      applyRateLimitMultiplier(config, {
+        NODE_ENV: "development",
+        RATE_LIMIT_MULTIPLIER: "25",
+      } as never),
+    ).toEqual({ windowMs: 60_000, maxRequests: 250 });
+  });
+
+  test("invalid or sub-1 multiplier is ignored", () => {
+    for (const RATE_LIMIT_MULTIPLIER of ["0", "-2", "nope"]) {
+      expect(
+        applyRateLimitMultiplier(config, {
+          NODE_ENV: "development",
+          RATE_LIMIT_MULTIPLIER,
+        } as never),
+      ).toEqual(config);
+    }
+  });
+
+  test("production never scales limits", () => {
+    expect(
+      applyRateLimitMultiplier(config, {
+        NODE_ENV: "production",
+        RATE_LIMIT_MULTIPLIER: "100",
+      } as never),
+    ).toEqual(config);
   });
 });

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -130,6 +130,15 @@ function applyRateLimitHeaders(c: Context, headers: Record<string, string>): voi
   }
 }
 
+export function applyRateLimitMultiplier(config: RateLimitConfig, env: Bindings): RateLimitConfig {
+  const m = multiplier(env);
+  if (m === 1) return config;
+  return {
+    ...config,
+    maxRequests: config.maxRequests * m,
+  };
+}
+
 export async function checkUpstash(
   redis: CompatibleRedis,
   key: string,
@@ -171,19 +180,27 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
       return;
     }
 
+    const effectiveConfig = applyRateLimitMultiplier(config, env);
+
     if (
       (env.RATE_LIMIT_DISABLED === "true" || env.PLAYWRIGHT_TEST_AUTH === "true") &&
       env.NODE_ENV !== "production"
     ) {
       await next();
-      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "disabled"));
+      applyRateLimitHeaders(
+        c,
+        rateLimitHeaders(effectiveConfig, fallOpenResult(effectiveConfig), "disabled"),
+      );
       return;
     }
 
     const redis = getRedis(env);
     if (!redis) {
       await next();
-      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "fall-open"));
+      applyRateLimitHeaders(
+        c,
+        rateLimitHeaders(effectiveConfig, fallOpenResult(effectiveConfig), "fall-open"),
+      );
       return;
     }
 
@@ -192,7 +209,12 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     let policy = "redis";
 
     try {
-      result = await checkUpstash(redis, key, config.windowMs, config.maxRequests);
+      result = await checkUpstash(
+        redis,
+        key,
+        effectiveConfig.windowMs,
+        effectiveConfig.maxRequests,
+      );
     } catch (error) {
       // Rate limiting is protective middleware. If its backing store is down
       // or unreachable in local Worker dev, requests should fall open instead
@@ -200,11 +222,11 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
       logger.warn("[RateLimit] Redis unavailable; falling open", {
         error: error instanceof Error ? error.message : String(error),
       });
-      result = fallOpenResult(config);
+      result = fallOpenResult(effectiveConfig);
       policy = "redis-unavailable";
     }
 
-    const headers = rateLimitHeaders(config, result, policy);
+    const headers = rateLimitHeaders(effectiveConfig, result, policy);
 
     if (!result.allowed) {
       return c.json(
@@ -212,8 +234,8 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
           success: false,
           error: "Too many requests",
           code: "rate_limit_exceeded" as const,
-          message: `Rate limit exceeded. Maximum ${config.maxRequests} requests per ${Math.ceil(
-            config.windowMs / 1000,
+          message: `Rate limit exceeded. Maximum ${effectiveConfig.maxRequests} requests per ${Math.ceil(
+            effectiveConfig.windowMs / 1000,
           )} seconds.`,
           retryAfter: result.retryAfter,
         },

--- a/packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts
@@ -57,6 +57,16 @@ function tooManyRequests(): Response {
   });
 }
 
+function authorizationHeader(init?: RequestInit): string | null {
+  const headers = init?.headers;
+  if (!headers) return null;
+  if (headers instanceof Headers) return headers.get("authorization");
+  if (Array.isArray(headers)) {
+    return headers.find(([name]) => name.toLowerCase() === "authorization")?.[1] ?? null;
+  }
+  return headers.authorization ?? headers.Authorization ?? null;
+}
+
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
 });
@@ -82,6 +92,28 @@ describe("getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallbac
 
     expect(result.text).toBe("from-cerebras");
     expect(hosts).toEqual(["cerebras"]);
+  });
+
+  test("a pooled Cerebras credential is used instead of the platform env key", async () => {
+    const authHeaders: Array<string | null> = [];
+    globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      hosts.push(hostOf(url));
+      authHeaders.push(authorizationHeader(init));
+      return completion("gemma-4-31b", "from-pooled-cerebras");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("gemma-4-31b", {
+        providerId: "cerebras-api",
+        apiKey: "pooled-cerebras-key",
+      }),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("from-pooled-cerebras");
+    expect(hosts).toEqual(["cerebras"]);
+    expect(authHeaders).toEqual(["Bearer pooled-cerebras-key"]);
   });
 
   test("a 429 surfaces (cerebras-only) and is never routed to OpenRouter", async () => {

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -10,6 +10,7 @@ import {
   isGroqNativeModel,
   isVastNativeModel,
 } from "../models";
+import type { PooledDirectProvider } from "../services/team-credential-pool/provider-map";
 import { logger } from "../utils/logger";
 import { RETRYABLE_UPSTREAM_STATUSES } from "./failover";
 import { toBitRouterModelId } from "./model-id-translation";
@@ -161,6 +162,50 @@ function getAnthropicClient() {
   }
 
   return anthropicClient;
+}
+
+export interface PooledLanguageModelCredential {
+  providerId: PooledDirectProvider;
+  apiKey: string;
+}
+
+export function resolvePooledDirectProviderForModel(model: string): PooledDirectProvider | null {
+  if (isCerebrasNativeModel(model)) return "cerebras-api";
+  if (isOpenAINativeModel(model) && !requiresGatewayRouting(model)) return "openai-api";
+  if (isAnthropicNativeModel(model)) return "anthropic-api";
+  return null;
+}
+
+function getPooledLanguageModel(model: string, credential: PooledLanguageModelCredential) {
+  const providerId = resolvePooledDirectProviderForModel(model);
+  if (!providerId || providerId !== credential.providerId) return null;
+
+  if (providerId === "cerebras-api") {
+    return withRateLimitFailFast(
+      createOpenAI({
+        apiKey: credential.apiKey,
+        baseURL: "https://api.cerebras.ai/v1",
+      }).chat(normalizeCerebrasModelId(model)),
+    );
+  }
+
+  if (providerId === "openai-api") {
+    const baseURL = getProviderKey("OPENAI_BASE_URL") ?? undefined;
+    const client = createOpenAI({
+      apiKey: credential.apiKey,
+      ...(baseURL ? { baseURL } : {}),
+    });
+    const modelId = normalizeOpenAIModelId(model);
+    return baseURL ? client.chat(modelId) : client.languageModel(modelId);
+  }
+
+  if (providerId === "anthropic-api") {
+    return createAnthropic({ apiKey: credential.apiKey }).languageModel(
+      normalizeAnthropicModelId(model),
+    );
+  }
+
+  return null;
 }
 
 function getVercelAIGatewayClient() {
@@ -418,7 +463,12 @@ export function hasTextEmbeddingProviderConfigured(): boolean {
   return Boolean(getProviderKey("OPENAI_API_KEY") || getVercelAIGatewayApiKey());
 }
 
-export function getLanguageModel(model: string) {
+export function getLanguageModel(model: string, credential?: PooledLanguageModelCredential) {
+  if (credential) {
+    const pooledModel = getPooledLanguageModel(model, credential);
+    if (pooledModel) return pooledModel;
+  }
+
   if (isGroqNativeModel(model)) {
     return getGroqClient().languageModel(getGroqApiModelId(model));
   }

--- a/packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts
@@ -51,8 +51,10 @@ let svc: typeof import("../team-credential-pool/service");
 let registryMod: typeof import("../team-credential-pool/registry");
 
 const ORG_A = "11111111-1111-4111-8111-111111111111";
+const ORG_B = "22222222-2222-4222-8222-222222222222";
 const OWNER_A = "aaaaaaaa-1111-4111-8111-111111111111";
 const MEMBER_A = "aaaaaaaa-2222-4222-8222-222222222222";
+const OWNER_B = "bbbbbbbb-1111-4111-8111-111111111111";
 
 const AUDIT = {
   actorType: "user" as const,
@@ -120,7 +122,10 @@ beforeAll(async () => {
     );
     await apply();
 
-    await dbWrite.insert(organizations).values([{ id: ORG_A, name: "Org A", slug: "org-a" }]);
+    await dbWrite.insert(organizations).values([
+      { id: ORG_A, name: "Org A", slug: "org-a" },
+      { id: ORG_B, name: "Org B", slug: "org-b" },
+    ]);
     await dbWrite.insert(users).values([
       {
         id: OWNER_A,
@@ -135,6 +140,13 @@ beforeAll(async () => {
         organization_id: ORG_A,
         role: "member",
         steward_user_id: `steward-${MEMBER_A}`,
+      },
+      {
+        id: OWNER_B,
+        email: "owner@b.test",
+        organization_id: ORG_B,
+        role: "owner",
+        steward_user_id: `steward-${OWNER_B}`,
       },
     ]);
   } catch (error) {
@@ -318,6 +330,44 @@ describe("selection — real AccountPool rotation + health", () => {
     expect(seen.has(credBeta)).toBe(true);
   });
 
+  test("Worker provider outcome writeback marks 429 and 401 credentials unhealthy", async () => {
+    const registry = new registryMod.TeamPoolRegistry();
+
+    await registry.recordProviderFailure({
+      organizationId: ORG_A,
+      credentialId: credBeta,
+      providerId: "anthropic-api",
+      status: 429,
+      detail: "429 from Worker inference",
+    });
+    const betaAfter429 = await repo.findById(credBeta);
+    expect(betaAfter429?.health).toBe("rate-limited");
+    expect(betaAfter429?.health_detail?.until).toBeGreaterThan(Date.now());
+    expect(betaAfter429?.health_detail?.lastError).toBe("429 from Worker inference");
+
+    await registry.recordProviderFailure({
+      organizationId: ORG_A,
+      credentialId: credGamma,
+      providerId: "anthropic-api",
+      status: 401,
+      detail: "401 from Worker inference",
+    });
+    const gammaAfter401 = await repo.findById(credGamma);
+    expect(gammaAfter401?.health).toBe("needs-reauth");
+    expect(gammaAfter401?.health_detail?.lastError).toBe("401 from Worker inference");
+
+    // Preserve the fixture state expected by the keep-alive test below: beta is
+    // rate-limited, but its cool-off has already passed.
+    await repo.updatePoolState(credBeta, {
+      health: "rate-limited",
+      health_detail: {
+        until: Date.now() - 1_000,
+        lastChecked: Date.now(),
+        lastError: "expired test cool-off",
+      },
+    });
+  });
+
   test("writeAccount (401 → needs-reauth) updates metadata only, ciphertext untouched", async () => {
     const before = await repo.findById(credGamma);
     if (!before) throw new Error("gamma missing");
@@ -426,6 +476,43 @@ describe("selection — real AccountPool rotation + health", () => {
     expect(rollups.find((r) => r.user_id === OWNER_A)?.calls).toBe(1);
     expect((await repo.usageTotalsForDay(ORG_A, day)).get(credAlpha)).toBe(3);
     expect((await repo.findById(credAlpha))?.last_used_at).not.toBeNull();
+  });
+
+  test("wrong-org service calls cannot update or delete a known credential id", async () => {
+    const before = await repo.findById(credAlpha);
+    if (!before) throw new Error("alpha missing");
+    const secretId = before.secret_id;
+
+    expect(
+      await repo.updatePoolStateForOrganization(credAlpha, ORG_B, {
+        enabled: false,
+      }),
+    ).toBeUndefined();
+    expect(await repo.deleteForOrganization(credAlpha, ORG_B)).toBeUndefined();
+
+    await expect(
+      svc.updatePooledCredential({
+        credentialId: credAlpha,
+        organizationId: ORG_B,
+        enabled: false,
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      svc.removePooledCredential({
+        credentialId: credAlpha,
+        organizationId: ORG_B,
+        audit: {
+          actorType: "user",
+          actorId: OWNER_B,
+          source: "team-credential-pool.test",
+        },
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+
+    const after = await repo.findById(credAlpha);
+    expect(after?.organization_id).toBe(ORG_A);
+    expect(after?.enabled).toBe(true);
+    expect(await secretRow(secretId)).toBeDefined();
   });
 
   test("remove deletes the pool row AND its vault secret", async () => {

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/pool-deps.ts
@@ -92,12 +92,16 @@ export class DrizzleAccountPoolDeps implements AccountPoolDeps {
     // Pool-owned columns ONLY. The pool spreads `...account` from a snapshot
     // that may be stale; persisting label/enabled/priority here would clobber
     // a concurrent admin PATCH (e.g. re-enable a just-disabled credential).
-    const updated = await pooledCredentialsRepository.updatePoolState(account.id, {
-      health: account.health,
-      health_detail: account.healthDetail ?? null,
-      usage: account.usage ?? null,
-      last_used_at: account.lastUsedAt ? new Date(account.lastUsedAt) : null,
-    });
+    const updated = await pooledCredentialsRepository.updatePoolStateForOrganization(
+      account.id,
+      this.organizationId,
+      {
+        health: account.health,
+        health_detail: account.healthDetail ?? null,
+        usage: account.usage ?? null,
+        last_used_at: account.lastUsedAt ? new Date(account.lastUsedAt) : null,
+      },
+    );
     if (!updated) {
       // Row deleted underneath us (e.g. contributor removed it) — drop it
       // from the snapshot instead of resurrecting stale state.
@@ -111,8 +115,12 @@ export class DrizzleAccountPoolDeps implements AccountPoolDeps {
 
   async deleteAccount(providerId: PoolProviderId, accountId: string): Promise<void> {
     const row =
-      this.rowsById.get(accountId) ?? (await pooledCredentialsRepository.findById(accountId));
-    const deleted = await pooledCredentialsRepository.delete(accountId);
+      this.rowsById.get(accountId) ??
+      (await pooledCredentialsRepository.findByIdForOrganization(accountId, this.organizationId));
+    const deleted = await pooledCredentialsRepository.deleteForOrganization(
+      accountId,
+      this.organizationId,
+    );
     delete this.snapshot[poolRecordKey(providerId, accountId)];
     this.rowsById.delete(accountId);
     const secretId = row?.secret_id;

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/registry.ts
@@ -177,13 +177,54 @@ export class TeamPoolRegistry {
         userId: params.userId,
         day,
       });
-      await pooledCredentialsRepository.updatePoolState(params.credentialId, {
-        last_used_at: new Date(),
-      });
+      await pooledCredentialsRepository.updatePoolStateForOrganization(
+        params.credentialId,
+        params.organizationId,
+        {
+          last_used_at: new Date(),
+        },
+      );
     } catch (err) {
       logger.warn("[TeamPoolRegistry] usage attribution failed", {
         organizationId: params.organizationId,
         credentialId: params.credentialId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Feed direct Worker/provider failures back into the org pool. Only statuses
+   * that tell us something about the selected credential mutate pool health:
+   * auth failures need reauth, and 429s cool off the credential briefly.
+   */
+  async recordProviderFailure(params: {
+    organizationId: string;
+    credentialId: string;
+    providerId: PooledDirectProvider;
+    status: number;
+    detail?: string;
+  }): Promise<void> {
+    if (![401, 403, 429].includes(params.status)) return;
+    try {
+      const entry = await this.getOrgPool(params.organizationId);
+      if (!entry) return;
+      const detail = params.detail ?? `provider returned ${params.status}`;
+      if (params.status === 429) {
+        await entry.pool.markRateLimited(params.credentialId, Date.now() + 60_000, detail, {
+          providerId: params.providerId,
+        });
+      } else {
+        await entry.pool.markNeedsReauth(params.credentialId, detail, {
+          providerId: params.providerId,
+        });
+      }
+    } catch (err) {
+      logger.warn("[TeamPoolRegistry] provider failure writeback failed", {
+        organizationId: params.organizationId,
+        credentialId: params.credentialId,
+        providerId: params.providerId,
+        status: params.status,
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/packages/cloud/shared/src/lib/services/team-credential-pool/service.ts
+++ b/packages/cloud/shared/src/lib/services/team-credential-pool/service.ts
@@ -193,8 +193,13 @@ export async function listPooledCredentials(
   );
 }
 
-export async function getPooledCredential(id: string): Promise<PooledCredential | undefined> {
-  return pooledCredentialsRepository.findById(id);
+export async function getPooledCredential(
+  id: string,
+  organizationId?: string,
+): Promise<PooledCredential | undefined> {
+  return organizationId
+    ? pooledCredentialsRepository.findByIdForOrganization(id, organizationId)
+    : pooledCredentialsRepository.findById(id);
 }
 
 export interface UpdatePooledCredentialParams {
@@ -208,11 +213,15 @@ export interface UpdatePooledCredentialParams {
 export async function updatePooledCredential(
   params: UpdatePooledCredentialParams,
 ): Promise<PooledCredentialSummary> {
-  const updated = await pooledCredentialsRepository.updatePoolState(params.credentialId, {
-    ...(params.enabled !== undefined ? { enabled: params.enabled } : {}),
-    ...(params.priority !== undefined ? { priority: params.priority } : {}),
-    ...(params.label !== undefined ? { label: params.label } : {}),
-  });
+  const updated = await pooledCredentialsRepository.updatePoolStateForOrganization(
+    params.credentialId,
+    params.organizationId,
+    {
+      ...(params.enabled !== undefined ? { enabled: params.enabled } : {}),
+      ...(params.priority !== undefined ? { priority: params.priority } : {}),
+      ...(params.label !== undefined ? { label: params.label } : {}),
+    },
+  );
   if (!updated) {
     throw new TeamCredentialPoolError("Credential not found", 404);
   }
@@ -225,7 +234,10 @@ export async function removePooledCredential(params: {
   organizationId: string;
   audit: AuditContext;
 }): Promise<void> {
-  const row = await pooledCredentialsRepository.delete(params.credentialId);
+  const row = await pooledCredentialsRepository.deleteForOrganization(
+    params.credentialId,
+    params.organizationId,
+  );
   if (!row) {
     throw new TeamCredentialPoolError("Credential not found", 404);
   }


### PR DESCRIPTION
## Summary

Closes #11586.

- Adds org-scoped pooled-credential repository mutations and pool metadata writes.
- Wires Worker chat completions to select org pooled direct-provider keys with strict platform-env fallback on pool miss, zero credit reservation for BYO pooled calls, usage attribution on success, and 401/403/429 health writeback on provider failure.
- Suppresses affiliate markup/earnings on zero-rated pooled BYO-key completions while preserving usage analytics and pool-use attribution.
- Keeps monetized app-credit billing ahead of pooled BYO-key no-op reservations so contributed provider keys cannot bypass app-owner pricing.
- Applies RATE_LIMIT_MULTIPLIER to the Hono/Cloudflare limiter in non-production.
- Maps pooled_credential org-membership denials to secret.access.
- Adds source-condition export/import fixes needed for cloud source typechecks around app-core account-pool and agent atomic-json.
- Removes two app-core empty-string fallback patterns so the current type-safety ratchet remains green after rebasing.

## Human follow-up

- Split staging-only provisioning proof to #11622 (needs-human), because it requires deployed staging access/logs to prove the real provisioning topology receives pooled env injection.

## Verification

- `bun install` after rebasing onto `origin/develop` at `390c89e6fe4`.
- `git diff --check`.
- `bunx @biomejs/biome check <changed files>`.
- `bun run --cwd packages/cloud/shared typecheck`.
- `bun run --cwd packages/cloud/api typecheck`.
- `bun run audit:type-safety-ratchet`.
- `bun run verify` — passed after rebase; 483 successful workspace tasks; 28 dist-path consumer configs checked.
- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/shared/src/lib/services/__tests__/team-credential-pool.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts` — 36 pass, 136 assertions.
- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/api/__tests__/org-credentials-routes.test.ts` — 12 pass, 34 assertions.
- `bun test --coverage-reporter=lcov --conditions eliza-source packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts` — 11 pass, 76 assertions.

## Evidence

- `.github/issue-evidence/11586-credential-pool-followups.md`