### PR TITLE
ci(ui-e2e-gate): trigger on all of packages/ui/src — fixture runners bundle the whole tree

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -16,15 +16,9 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
-      - "packages/ui/src/components/shell/**"
-      - "packages/ui/src/components/pages/**"
-      - "packages/ui/src/components/chat/widgets/**"
-      - "packages/ui/src/components/views/**"
-      - "packages/ui/src/agent-surface/**"
-      - "packages/ui/src/state/**"
-      - "packages/ui/src/voice/**"
-      - "packages/ui/src/testing/**"
-      - "packages/ui/src/hooks/**"
+      # The fixture runners esbuild-bundle from the full packages/ui/src tree,
+      # so any source change there can reach a bundled runner.
+      - "packages/ui/src/**"
       - "packages/ui/package.json"
       # The proactive-suggestions e2e drives these server modules for real.
       - "packages/agent/src/services/proactive-interaction-*.ts"
@@ -35,15 +29,7 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - "packages/ui/src/components/shell/**"
-      - "packages/ui/src/components/pages/**"
-      - "packages/ui/src/components/chat/widgets/**"
-      - "packages/ui/src/components/views/**"
-      - "packages/ui/src/agent-surface/**"
-      - "packages/ui/src/state/**"
-      - "packages/ui/src/voice/**"
-      - "packages/ui/src/testing/**"
-      - "packages/ui/src/hooks/**"
+      - "packages/ui/src/**"
       - "packages/ui/package.json"
       - "packages/agent/src/services/proactive-interaction-*.ts"
       - "packages/agent/src/api/views-routes.ts"


### PR DESCRIPTION
## Why

The pre-#11271 `ui-fixture-e2e.yml` (superseded; its restore PR #11563 was closed) triggered on **all** of `packages/ui/src/**`. The current `ui-e2e-gate.yml` — which has carried all 14 fixture-runner legs since 19b40d12ae — triggers only on an enumerated subset (`components/shell`, `components/pages`, `components/chat/widgets`, `components/views`, `agent-surface`, `state`, `voice`, `testing`, `hooks`).

Gap: changes under e.g. `packages/ui/src/cloud/**`, `components/settings/**`, `bridge/**`, `components/composites/**` skip the gate entirely, even though the bundled fixture runners esbuild-bundle from the **full** source tree — a regression in a shared component reachable from any runner can land unguarded. This carries the only useful delta from superseded #11563.

## Change

Replace the enumerated `packages/ui/src/*` entries with a single `packages/ui/src/**` in **both** the `pull_request` and `push` paths lists. Kept unchanged: `packages/ui/package.json`, all `packages/agent/*` server-module paths (proactive-suggestions e2e), and the workflow self-path. Net: 4 insertions, 18 deletions, one file.

## Verification

- `actionlint .github/workflows/ui-e2e-gate.yml` → clean (0 findings).
- Ratchet `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts`: does **not** assert on the trigger paths list (it checks runner→script→workflow wiring), so no test update needed. It currently fails 1/1 **on pristine origin/develop and identically with this change** (verified both ways): two runners added by the cloud-ui PRs (#11488 org-credentials, frontend-hosting #10690 work) — `packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs` and `packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs` — have no `packages/ui` package.json script. Pre-existing on develop, orthogonal to this diff (which touches only workflow trigger paths); those runners' dirs weren't even in the old trigger list, which is exactly the gap this PR closes. Wiring them needs its own PR (scripts + legs + running the runners).
- Superset check: every removed glob is under `packages/ui/src/**` — no path that triggered before stops triggering.

Refs #11419

🤖 Generated with [Claude Code](https://claude.com/claude-code)