### PR TITLE
test(lifeops): #8833 keyless validation run green (9-state owner/agent matrix 20/20) + fix PA integration-lane global-setup repo-root

### DIFF
--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/README.md
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/README.md
@@ -1,0 +1,60 @@
+# #8833 — 2026-07-02 keyless validation run
+
+Fresh execution of **everything in the #8833 acceptance matrix that runs without
+live credentials/devices**, on branch `test/8833-lifeops-keyless-validation-matrix`
+(base `origin/develop` @ `d9d1a47ccd`, post-#11271-restore state). Net-new over
+the prior evidence in the parent directory:
+
+1. The consolidated **9-state OWNER/AGENT permission-matrix harness ran GREEN**
+   (`LIFEOPS_PERMISSION_MATRIX=1` → 20/20 on a real `AgentRuntime` + PGLite).
+   Every prior record on the issue only showed it *skipping*.
+2. The **keyless connector harness lanes** (real-PGLite runtime loops, #8801
+   pattern) ran green for telegram + discord; default keyless suites green for
+   google, whatsapp, imessage, slack, signal, x, phone/twilio.
+3. The **PA `test:integration` lane blocker** recorded on the issue
+   (2026-07-01 comment: `bunx tsdown` "No input files" at
+   `e2e-global-setup.ts:30`) is root-caused and **fixed** on this branch —
+   repo-root was resolved one level too far; verified by exercising the exact
+   missing-dist path (see `pa-integration-lane-globalsetup-fix.txt`).
+
+## Files
+
+| File | Command | Result |
+|---|---|---|
+| `owner-agent-permission-matrix.txt` | `LIFEOPS_PERMISSION_MATRIX=1 bunx vitest run --config packages/test/vitest/integration.config.ts plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts` | **20/20 pass** (167s) |
+| `owner-agent-permission-matrix-clean-skip.txt` | same, without the env var | 1 skipped — clean credential gate |
+| `pa-credential-free-permission-suites.txt` | `bun run --cwd plugins/plugin-personal-assistant test test/contracts.test.ts test/lifeops-access.test.ts test/owner-action-handler-permissions.test.ts test/owner-send-approval-worker.test.ts test/policy-memory-defaults.test.ts test/room-policy.test.ts` | 6 files / **53 pass** |
+| `core-execute-planned-tool-call.txt` | `bun run --cwd packages/core test src/runtime/__tests__/execute-planned-tool-call.test.ts` | **28/28 pass** (roleGate on the planned-tool path) |
+| `connector-keyless-suites.txt` | per-plugin keyless suites + `test:harness` lanes | all green (signal first-run flake re-run green ×3; see file) |
+| `view-state-suites.txt` | per-plugin `*View.test.tsx` state suites (loading/error/empty/populated) | 10/10 view plugins green (93 tests) |
+| `pa-integration-lane-globalsetup-fix.txt` | missing-dist repro of the `test:integration` global-setup failure | fixed — globalSetup builds app-core in-package; life-smoke **14/14** |
+
+## What this run proves (per the issue's item-2 state list)
+
+Executable without credentials — now all evidenced green:
+
+- **Owner-only actions deny non-owner** — planned-tool path (`roleGate`,
+  core 28/28) and direct-handler path (`hasLifeOpsAccess`, PA suites) and the
+  consolidated 9-state matrix incl. **multi-grant owner-selection** (20/20).
+- **Missing scope / revoked grant / connector-error → denied snapshot** —
+  `lifeops-access.test.ts` (Google capability matrix).
+- **Fail-closed policy defaults** — `policy-memory-defaults.test.ts` (no-rule
+  high-risk delete denies; send/read_aloud require approval; malformed denies).
+- **Approval routing + typed `DispatchResult`** — `contracts.test.ts`
+  (complete/retry/surface_degraded/fail) + `owner-send-approval-worker.test.ts`.
+- **Connector keyless loops** on a real runtime — telegram/discord harness
+  lanes; google/whatsapp/imessage/slack/signal/x/phone suites.
+- **View states** (loading/error/empty/populated) for all 10 split views.
+
+## What still needs an operator (not runnable here)
+
+No live credentials exist in this environment (env scan: no
+GOOGLE/GMAIL/SLACK/TELEGRAM/DISCORD/SIGNAL/WHATSAPP/TWILIO/health/finance vars;
+no OAuth grants in the state dir). An Android device is attached to the host but
+has no provisioned owner Google account/SIM for Health Connect / SMS-role /
+Usage Access flows, and iOS/macOS hardware is absent. The live OWNER/AGENT
+OAuth, connector send/read/sync, expired/revoked-grant, health/finance sandbox,
+and native-device rows are tracked in the successor operator issue (linked from
+the #8833 closing comment); the runbook is
+`plugins/plugin-personal-assistant/docs/LIFEOPS_LIVE_VALIDATION.md` +
+`docs/owner-agent-validation-matrix.md`.

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/connector-keyless-suites.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/connector-keyless-suites.txt
@@ -1,0 +1,46 @@
+Keyless connector suites — LifeOps-relevant connector plugins, no credentials.
+Worktree: test/8833-lifeops-keyless-validation-matrix (base origin/develop d9d1a47ccd, 2026-07-02).
+Default lanes = `bun run --cwd plugins/<plugin> test [files]`; harness lanes = `bun run test:harness`
+(real PGLite AgentRuntime connector loop, `*.harness.test.ts` — the #8801 / PR #10569 keyless pattern).
+
+===== plugin-google :: full suite =====
+ Test Files  2 passed (2)
+      Tests  21 passed (21)
+===== plugin-telegram :: test:harness (__tests__/keyless-harness.harness.test.ts, real-PGLite runtime) =====
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Duration  20.00s
+===== plugin-discord :: test:harness (__tests__/connector-loop.harness.test.ts, real-PGLite runtime) =====
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Duration  27.33s
+===== plugin-whatsapp :: __tests__ =====
+ Test Files  7 passed (7)
+      Tests  35 passed (35)
+===== plugin-imessage :: __tests__ =====
+ Test Files  4 passed (4)
+      Tests  100 passed (100)
+===== plugin-slack :: full suite =====
+ Test Files  5 passed (5)
+      Tests  34 passed (34)
+===== plugin-signal :: full suite =====
+First run (2026-07-02 ~13:45 PT, ~10 concurrent agents on the host):
+ FAIL  src/setup-routes.test.ts > Signal setup routes > cancels pairing, logs out, and removes only the requested account config
+ AssertionError: expected "vi.fn()" to be called at least once
+ Test Files  1 failed | 3 passed (4)
+      Tests  3 failed | 22 passed (25)
+Re-run (same tree, ~15:01 PT):
+ Test Files  4 passed (4)
+      Tests  25 passed (25)
+src/setup-routes.test.ts isolated x3 consecutive: 5 passed / 5 passed / 5 passed.
+Verdict: load flake, not a product defect — this suite has known re-import
+timing sensitivity under CI load (see commit 79396e4269 "give setup-routes
+re-import headroom under CI load"). Green on an idle host.
+===== plugin-x :: full suite =====
+ Test Files  18 passed | 1 skipped (19)
+      Tests  67 passed | 15 skipped (82)
+(15 skips = live-credential X API cases; skip-clean behavior is the designed
+credential gate.)
+===== plugin-phone :: src/twilio.test.ts src/providers/call-log.test.ts src/components/call-log-contract.test.ts =====
+ Test Files  3 passed (3)
+      Tests  13 passed (13)

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/core-execute-planned-tool-call.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/core-execute-planned-tool-call.txt
@@ -1,0 +1,10 @@
+$ node ../scripts/run-vitest.mjs run src/runtime/__tests__/execute-planned-tool-call.test.ts
+
+ RUN  v4.1.5 /home/shaw/eliza-worktrees/8833-lifeops-live-validation/packages/core
+
+
+ Test Files  1 passed (1)
+      Tests  28 passed (28)
+   Start at  13:45:09
+   Duration  2.46s (transform 1.41s, setup 0ms, import 1.89s, tests 49ms, environment 14ms)
+

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix-clean-skip.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix-clean-skip.txt
@@ -1,0 +1,11 @@
+
+ RUN  v4.1.5 /home/shaw/eliza-worktrees/8833-lifeops-live-validation
+
+(node:1750223) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+ Test Files  1 skipped (1)
+      Tests  1 skipped (1)
+   Start at  13:47:44
+   Duration  198.36s (transform 124.39s, setup 426ms, import 196.61s, tests 0ms, environment 6ms)
+

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix.txt
@@ -1,0 +1,11 @@
+
+ RUN  v4.1.5 /home/shaw/eliza-worktrees/8833-lifeops-live-validation
+
+(node:1714050) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+ Test Files  1 passed (1)
+      Tests  20 passed (20)
+   Start at  13:44:35
+   Duration  167.21s (transform 90.98s, setup 369ms, import 131.68s, tests 34.47s, environment 0ms)
+

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/pa-credential-free-permission-suites.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/pa-credential-free-permission-suites.txt
@@ -1,0 +1,32 @@
+$ node scripts/lint-default-packs.mjs
+[lint-default-packs] clean — 0 findings across default packs.
+$ vitest run --config vitest.config.ts test/contracts.test.ts test/lifeops-access.test.ts test/owner-action-handler-permissions.test.ts test/owner-send-approval-worker.test.ts test/policy-memory-defaults.test.ts test/room-policy.test.ts
+
+ RUN  v4.1.5 /home/shaw/eliza-worktrees/8833-lifeops-live-validation
+
+(node:1713175) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:1713254) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/index.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/decode.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/generated/decode-data-html.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/generated/decode-data-xml.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/decode_codepoint.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/encode.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/generated/encode-html.js" points to missing source files
+Sourcemap for "/home/shaw/eliza-worktrees/8833-lifeops-live-validation/node_modules/.bun/entities@4.5.0/node_modules/entities/lib/esm/escape.js" points to missing source files
+(node:1719321) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:1722958) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:1723154) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:1724236) Warning: `--localstorage-file` was provided without a valid path
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+ Test Files  6 passed (6)
+      Tests  53 passed (53)
+   Start at  13:44:30
+   Duration  62.45s (transform 36.21s, setup 1.55s, import 58.75s, tests 179ms, environment 1ms)
+

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/pa-integration-lane-globalsetup-fix.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/pa-integration-lane-globalsetup-fix.txt
@@ -1,0 +1,36 @@
+PA integration lane — e2e-global-setup repo-root bug fix verification.
+
+Bug (recorded on #8833, 2026-07-01 comment): `bun run --cwd
+plugins/plugin-personal-assistant test:integration` never reached assertions —
+`packages/app-core/test/e2e-global-setup.ts` resolved "repo root" as
+path.resolve(packageRoot, '..', '..', '..'), which from packages/app-core lands
+on the *parent of the checkout*. With dist/ missing it ran `bunx tsdown` there:
+  No input files, try "tsdown <your-file>" or create src/index.ts
+followed by the unhandled setup error at e2e-global-setup.ts:30.
+
+Fix: build @elizaos/app-core via its own package build (`bun run build`,
+cwd = packages/app-core). Commit on this branch:
+  fix(app-core): e2e-global-setup resolves repo root one level too far — build app-core in-package
+
+Verification (2026-07-02, worktree /home/shaw/eliza-worktrees/8833-lifeops-live-validation):
+exercised the exact failure path — moved packages/app-core/dist aside, then ran
+the lane that uses integration.config.ts (globalSetup line 184):
+
+$ bunx vitest run --config packages/test/vitest/integration.config.ts \
+    plugins/plugin-personal-assistant/test/life-smoke.integration.test.ts
+
+ RUN  v4.1.5 /home/shaw/eliza-worktrees/8833-lifeops-live-validation
+[e2e-global-setup] dist/ not found — building @elizaos/app-core…
+$ bun run build:dist
+$ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && ...
+[rewrite-dist-relative-imports] rewrote 122 file(s)
+
+ Test Files  1 passed (1)
+      Tests  14 passed (14)
+   Duration  69.65s
+EXIT=0
+
+globalSetup now rebuilds app-core in-package and the integration lane reaches
+its assertions (life-smoke 14/14). The owner-agent permission-matrix half of the
+same lane is covered separately (owner-agent-permission-matrix.txt: 20/20 with
+LIFEOPS_PERMISSION_MATRIX=1; clean 1-skip without it).

--- a/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/view-state-suites.txt
+++ b/.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/view-state-suites.txt
@@ -1,0 +1,30 @@
+===== plugin-goals :: test/GoalsView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  7 passed (7)
+===== plugin-inbox :: src/components/inbox/InboxView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  7 passed (7)
+===== plugin-health :: src/components/health/HealthView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  8 passed (8)
+===== plugin-calendar :: src/components/calendar/CalendarView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  8 passed (8)
+===== plugin-finances :: src/components/finances/FinancesView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+===== plugin-documents :: src/components/documents/DocumentsView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+===== plugin-blocker :: src/components/focus/FocusView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  8 passed (8)
+===== plugin-todos :: src/components/todos/TodosView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  15 passed (15)
+===== plugin-relationships :: src/components/relationships/RelationshipsView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+===== plugin-phone :: src/components/PhoneView.test.tsx =====
+ Test Files  1 passed (1)
+      Tests  13 passed (13)

--- a/packages/app-core/test/e2e-global-setup.ts
+++ b/packages/app-core/test/e2e-global-setup.ts
@@ -1,9 +1,9 @@
 /**
  * Vitest globalSetup for E2E tests.
  *
- * Runs `tsdown` before any E2E test file is loaded so that `dist/` is
- * always present — even when the test suite is invoked without a prior
- * manual build (e.g. `bun run test` in CI).
+ * Builds `@elizaos/app-core` before any E2E test file is loaded so that
+ * `dist/` is always present — even when the test suite is invoked without a
+ * prior manual build (e.g. `bun run test` in CI).
  */
 import { execSync } from "node:child_process";
 import fs from "node:fs";
@@ -14,8 +14,6 @@ const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
-// tsdown.config.ts lives at the repo root, not in app-core
-const repoRoot = path.resolve(packageRoot, "..", "..", "..");
 
 export function setup(): void {
   const distIndex = path.join(packageRoot, "dist", "index.js");
@@ -26,6 +24,8 @@ export function setup(): void {
   }
 
   // eslint-disable-next-line no-console
-  console.log("[e2e-global-setup] dist/ not found — running tsdown…");
-  execSync("bunx tsdown", { cwd: repoRoot, stdio: "inherit" });
+  console.log(
+    "[e2e-global-setup] dist/ not found — building @elizaos/app-core…",
+  );
+  execSync("bun run build", { cwd: packageRoot, stdio: "inherit" });
 }


### PR DESCRIPTION
## What

Two commits closing out the agent-executable half of #8833 (LifeOps split — live owner/agent connector and view validation):

1. **`fix(app-core)`: e2e-global-setup resolves repo root one level too far.**
   `path.resolve(packageRoot, '..', '..', '..')` from `packages/app-core` lands on the *parent of the checkout*, so a missing `dist/` made the integration lane run `bunx tsdown` in whatever directory contains the repo → `No input files, try "tsdown <your-file>"` → unhandled setup error at `e2e-global-setup.ts:30`. This is the exact blocker recorded on #8833 (2026-07-01 comment) that stopped `bun run --cwd plugins/plugin-personal-assistant test:integration` from ever reaching assertions. Fix: build `@elizaos/app-core` via its own package build (`bun run build`, cwd = package root).

2. **`docs(evidence)`: 2026-07-02 keyless validation run** under `.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/` — fresh execution of every #8833 acceptance row that runs without live credentials/devices. Net-new: the consolidated **9-state OWNER/AGENT permission-matrix harness ran GREEN (20/20)** with `LIFEOPS_PERMISSION_MATRIX=1` on a real `AgentRuntime` + PGLite — every prior record on the issue only shows it *skipping*.

## Evidence (PR_EVIDENCE.md)

- **Real test output, reviewed by hand** — committed in the evidence dir:
  - `owner-agent-permission-matrix.txt` — 20/20 pass (`LIFEOPS_PERMISSION_MATRIX=1`, 167s); `owner-agent-permission-matrix-clean-skip.txt` — 1 skipped without the env var (clean credential gate).
  - `pa-credential-free-permission-suites.txt` — contracts / lifeops-access / owner-action-handler-permissions / owner-send-approval-worker / policy-memory-defaults / room-policy: 6 files, 53 pass.
  - `core-execute-planned-tool-call.txt` — roleGate on the planned-tool path: 28/28.
  - `connector-keyless-suites.txt` — google 21, whatsapp 35, imessage 100, slack 34, x 67(+15 designed credential skips), phone/twilio 13; telegram + discord `test:harness` real-PGLite keyless loops 1/1 each; signal 25/25 on re-run (first-run 3-test failure was host-load flake; isolated file green ×3 consecutive — suite has known re-import timing sensitivity, cf. 79396e4269).
  - `view-state-suites.txt` — all 10 split-view plugins' state suites (loading/error/empty/populated) green, 93 tests.
  - `pa-integration-lane-globalsetup-fix.txt` — the fix exercised on its real failure path: `packages/app-core/dist` moved aside → globalSetup logs `dist/ not found — building @elizaos/app-core…` → builds in-package → `life-smoke.integration.test.ts` 14/14, exit 0.
- **Backend logs**: the globalSetup build log lines are captured verbatim in `pa-integration-lane-globalsetup-fix.txt`.
- **Screenshots / video**: N/A — no UI change; the view layer is covered by the committed component-state suite output plus the existing `audit:app` verdicts already recorded on #8833.
- **Real-LLM trajectories**: N/A — no agent/prompt/model behavior change; the harness under test is the permission gate (deny/allow), exercised on a real runtime without model calls by design.

## Verification

- `bunx biome check packages/app-core/test/e2e-global-setup.ts` — clean.
- `bun run --cwd packages/app-core typecheck` — green (after building the worktree's missing native-plugin dists; failures before that were environment-only, in files this PR does not touch).
- Only source change is `packages/app-core/test/e2e-global-setup.ts` (7+/7−); everything else is evidence markdown/txt.

## Boundary

This PR does **not** claim the live half of #8833: real OWNER/AGENT OAuth grants, connector send/read/sync, expired/revoked-scope states, health/finance sandboxes, and physical-device flows remain operator-gated — being carved into a successor issue per the reopen guidance on #8833.

Refs #8833

🤖 Generated with [Claude Code](https://claude.com/claude-code)
