### PR TITLE
fix(app-deploy): forward registry push cred + per-org image-namespace allowlist extension

### DIFF
--- a/packages/cloud/api/v1/coding-containers/route.test.ts
+++ b/packages/cloud/api/v1/coding-containers/route.test.ts
@@ -90,6 +90,16 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
+// Per-org namespace extension (the DB seam). Default: no grant — the platform
+// env allowlist alone decides, exactly the pre-extension behavior.
+const getOrgImageNamespaces = mock(
+  async (_orgId: string): Promise<string[]> => [],
+);
+
+mock.module("@/lib/services/org-image-namespaces", () => ({
+  getOrgImageNamespaces,
+}));
+
 const { default: app } = await import("./route");
 
 async function postCodingContainer(image: string): Promise<Response> {
@@ -125,6 +135,8 @@ describe("coding containers route", () => {
     enqueueAgentProvisionOnce.mockClear();
     getJobForOrg.mockClear();
     triggerImmediate.mockClear();
+    getOrgImageNamespaces.mockClear();
+    getOrgImageNamespaces.mockResolvedValue([]);
     delete process.env.CONTAINER_IMAGE_REQUIRE_DIGEST;
   });
 
@@ -252,5 +264,47 @@ describe("coding containers route", () => {
     expect(response.status).toBe(200);
     expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(createCodingContainerAgent).toHaveBeenCalledTimes(1);
+  });
+
+  // Per-org namespace extension (the normie 403 fix, #8434 lane): an image
+  // outside the platform env allowlist deploys ONLY when the caller's org
+  // carries an operator grant for that namespace; every other org still 403s.
+  test("rejects an off-allowlist image with 403 when the org has no namespace grant", async () => {
+    const response = await postCodingContainer("ghcr.io/nubscarson/my-app:v1");
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "CODING_CONTAINER_IMAGE_NOT_ALLOWED",
+      }),
+    );
+    // The org extension WAS consulted (for the caller's org) and denied.
+    expect(getOrgImageNamespaces).toHaveBeenCalledWith("org-1");
+    expect(createCodingContainerAgent).not.toHaveBeenCalled();
+  });
+
+  test("allows an image under the org's operator-granted namespace", async () => {
+    getOrgImageNamespaces.mockResolvedValueOnce(["ghcr.io/nubscarson/*"]);
+
+    const response = await postCodingContainer("ghcr.io/nubscarson/my-app:v1");
+
+    expect(response.status).toBe(200);
+    expect(getOrgImageNamespaces).toHaveBeenCalledWith("org-1");
+    expect(createCodingContainerAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dockerImage: "ghcr.io/nubscarson/my-app:v1",
+        organizationId: "org-1",
+      }),
+    );
+  });
+
+  test("a platform-allowlisted image never consults the org extension (fast path)", async () => {
+    const response = await postCodingContainer(
+      "ghcr.io/dexploarer/bnancy:latest",
+    );
+
+    expect(response.status).toBe(200);
+    expect(getOrgImageNamespaces).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -71,6 +71,7 @@ import {
   AgentQuotaExceededError,
   elizaSandboxService,
 } from "@/lib/services/eliza-sandbox";
+import { getOrgImageNamespaces } from "@/lib/services/org-image-namespaces";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
   checkProvisioningWorkerHealth,
@@ -154,8 +155,17 @@ async function createCodingContainer(
   payload: CodingContainerCreatePayload,
 ): Promise<Response> {
   // ── SECURITY: image allowlist gate ───────────────────────────────────
+  // Platform-wide env allowlist first; on deny, the org's OWN operator-granted
+  // namespace extension (organizations.settings.allowed_image_namespaces) —
+  // additive and fail-closed, scoped to this org only.
   const allowlist = containersEnv.codingContainerImageAllowlist();
-  if (!isCodingContainerImageAllowed(payload.image, allowlist)) {
+  const imageAllowed =
+    isCodingContainerImageAllowed(payload.image, allowlist) ||
+    isCodingContainerImageAllowed(
+      payload.image,
+      await getOrgImageNamespaces(user.organization_id),
+    );
+  if (!imageAllowed) {
     logger.warn("[CodingContainers API] image rejected by allowlist", {
       orgId: user.organization_id,
       image: payload.image,
@@ -174,7 +184,8 @@ async function createCodingContainer(
           `Image '${payload.image}' is not in the coding-container allowlist. ` +
           `Permitted images: ${permitted}. ` +
           `To run another image, ask an operator to add its GHCR namespace to ` +
-          `CODING_CONTAINER_IMAGE_ALLOWLIST.`,
+          `CODING_CONTAINER_IMAGE_ALLOWLIST, or to grant it to your organization ` +
+          `(settings.allowed_image_namespaces).`,
         permittedImages: allowlist,
       },
       403,

--- a/packages/cloud/api/v1/containers/route.test.ts
+++ b/packages/cloud/api/v1/containers/route.test.ts
@@ -98,6 +98,16 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
+// Per-org namespace extension (the DB seam). Default: no grant — the platform
+// env allowlist alone decides, exactly the pre-extension behavior.
+const getOrgImageNamespaces = mock(
+  async (_orgId: string): Promise<string[]> => [],
+);
+
+mock.module("@/lib/services/org-image-namespaces", () => ({
+  getOrgImageNamespaces,
+}));
+
 const { default: containersRoute } = await import("./route");
 
 const app = new Hono<{ Variables: TestVariables }>();
@@ -174,6 +184,8 @@ describe("containers route", () => {
     codingContainerImageAllowlist.mockClear();
     requireDigestPinnedImages.mockReset();
     requireDigestPinnedImages.mockReturnValue(false);
+    getOrgImageNamespaces.mockClear();
+    getOrgImageNamespaces.mockResolvedValue([]);
     auditEmit.mockClear();
   });
 
@@ -296,5 +308,66 @@ describe("containers route", () => {
     // No duplicate provisioning, and no quota burn for an already-live deploy.
     expect(createContainer).not.toHaveBeenCalled();
     expect(checkQuota).not.toHaveBeenCalled();
+  });
+
+  // Per-org namespace extension (the normie 403 fix, #8434 lane): an image
+  // outside the platform env allowlist deploys ONLY when the caller's org
+  // carries an operator grant for that namespace; every other org still 403s.
+  test("rejects an off-allowlist image with 403 when the org has no namespace grant", async () => {
+    getActiveByProjectName.mockResolvedValue(null);
+
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "App",
+        image: "ghcr.io/nubscarson/my-app:v1",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { code: string };
+    expect(body.code).toBe("CONTAINER_IMAGE_NOT_ALLOWED");
+    // The org extension WAS consulted (for the caller's org) and denied.
+    expect(getOrgImageNamespaces).toHaveBeenCalledWith("org-1");
+    expect(createContainer).not.toHaveBeenCalled();
+  });
+
+  test("provisions an image under the org's operator-granted namespace", async () => {
+    getActiveByProjectName.mockResolvedValue(null);
+    checkQuota.mockResolvedValue({ allowed: true });
+    createContainer.mockResolvedValue(summaryContainer());
+    getOrgImageNamespaces.mockResolvedValueOnce(["ghcr.io/nubscarson/*"]);
+
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "App",
+        image: "ghcr.io/nubscarson/my-app:v1",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(getOrgImageNamespaces).toHaveBeenCalledWith("org-1");
+    expect(createContainer).toHaveBeenCalledTimes(1);
+  });
+
+  test("a platform-allowlisted image never consults the org extension (fast path)", async () => {
+    getActiveByProjectName.mockResolvedValue(null);
+    checkQuota.mockResolvedValue({ allowed: true });
+    createContainer.mockResolvedValue(summaryContainer());
+
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "App",
+        image: "ghcr.io/elizaos/app:latest",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(getOrgImageNamespaces).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/containers/route.ts
+++ b/packages/cloud/api/v1/containers/route.ts
@@ -50,6 +50,7 @@ import {
   type ContainerSummary,
   HetznerClientError,
 } from "@/lib/services/containers/hetzner-client/types";
+import { getOrgImageNamespaces } from "@/lib/services/org-image-namespaces";
 import { findReservedEnvKeys } from "@/lib/services/reserved-env-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -263,9 +264,18 @@ app.post("/", async (c) => {
     }
 
     // SECURITY: gate the image on the shared container image allowlist so an
-    // org cannot run an arbitrary image on the shared node pool.
+    // org cannot run an arbitrary image on the shared node pool. When the
+    // platform-wide list denies, consult the org's OWN operator-granted
+    // namespace extension (organizations.settings.allowed_image_namespaces) —
+    // additive and fail-closed, so one org's grant never widens another's gate.
     const allowlist = containersEnv.codingContainerImageAllowlist();
-    if (!isCodingContainerImageAllowed(body.image, allowlist)) {
+    const imageAllowed =
+      isCodingContainerImageAllowed(body.image, allowlist) ||
+      isCodingContainerImageAllowed(
+        body.image,
+        await getOrgImageNamespaces(user.organization_id),
+      );
+    if (!imageAllowed) {
       logger.warn("[Containers API] image rejected by allowlist", {
         organizationId: user.organization_id,
         image: body.image,

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -199,6 +199,103 @@ describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
   });
 });
 
+// Per-org namespace extension — the normie app-deploy 403 fix (#8434 lane): a
+// user's OWN registry namespace (ghcr.io/<their-login>/*) can be granted by an
+// operator on the ORG record (settings.allowed_image_namespaces) instead of
+// widening the platform-wide env allowlist for every tenant. Additive and
+// fail-closed: consulted only after the env allowlist denies, only when the
+// deploy carries an organizationId, and a failing lookup denies.
+describe("resolveImageRef: per-org namespace extension", () => {
+  const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
+  const ORG_IMAGE = "ghcr.io/nubscarson/my-app:v1";
+
+  function depsWithOrgNamespaces(
+    lookup: (orgId: string) => Promise<string[]>,
+  ): AppDeployRunnerDeps {
+    return {
+      resolveImage: undefined,
+      orgImageNamespaces: lookup,
+    } as unknown as AppDeployRunnerDeps;
+  }
+
+  test("an operator-granted org namespace passes for THAT org", async () => {
+    const seen: string[] = [];
+    const deps = depsWithOrgNamespaces(async (orgId) => {
+      seen.push(orgId);
+      return ["ghcr.io/nubscarson/*"];
+    });
+    const img = await resolveImageRef(deps, {
+      ...baseApp,
+      organizationId: "org-1",
+      metadata: { imageTag: ORG_IMAGE },
+    });
+    expect(img).toBe(ORG_IMAGE);
+    expect(seen).toEqual(["org-1"]);
+  });
+
+  test("an org WITHOUT the grant still rejects the same image (no cross-tenant widening)", async () => {
+    const deps = depsWithOrgNamespaces(async () => []);
+    await expect(
+      resolveImageRef(deps, {
+        ...baseApp,
+        organizationId: "org-2",
+        metadata: { imageTag: ORG_IMAGE },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("the grant does not open OTHER namespaces for the granted org", async () => {
+    const deps = depsWithOrgNamespaces(async () => ["ghcr.io/nubscarson/*"]);
+    await expect(
+      resolveImageRef(deps, {
+        ...baseApp,
+        organizationId: "org-1",
+        metadata: { imageTag: "docker.io/evil/pwn:latest" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("no organizationId → no lookup, still rejected (unchanged legacy path)", async () => {
+    let called = false;
+    const deps = depsWithOrgNamespaces(async () => {
+      called = true;
+      return ["ghcr.io/nubscarson/*"];
+    });
+    await expect(
+      resolveImageRef(deps, { ...baseApp, metadata: { imageTag: ORG_IMAGE } }),
+    ).rejects.toThrow(/is not permitted/);
+    expect(called).toBe(false);
+  });
+
+  test("a throwing lookup fails CLOSED (deny), never propagates", async () => {
+    const deps = depsWithOrgNamespaces(async () => {
+      throw new Error("db down");
+    });
+    await expect(
+      resolveImageRef(deps, {
+        ...baseApp,
+        organizationId: "org-1",
+        metadata: { imageTag: ORG_IMAGE },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("an env-allowlisted image never consults the org lookup (fast path)", async () => {
+    let called = false;
+    const deps = depsWithOrgNamespaces(async () => {
+      called = true;
+      return [];
+    });
+    const img = await resolveImageRef(deps, {
+      ...baseApp,
+      organizationId: "org-1",
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+    });
+    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
+    expect(called).toBe(false);
+  });
+});
+
 // #9853 follow-up — an app deploy is the THIRD shared-node image path (alongside
 // the /v1/containers and /v1/coding-containers routes). When the opt-in
 // digest-pin gate (CONTAINER_IMAGE_REQUIRE_DIGEST) is armed, all three must

--- a/packages/cloud/shared/src/lib/services/__tests__/org-image-namespaces.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/org-image-namespaces.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { isCodingContainerImageAllowed } from "../coding-containers";
+import {
+  getOrgImageNamespaces,
+  normalizeOrgImageNamespaces,
+} from "../org-image-namespaces";
+
+// The per-org extension is a SECOND chance after the platform-wide env
+// allowlist denies — so its normalization is itself a security gate: any entry
+// it accepts becomes runnable-image surface for that org. Everything not a
+// single-namespace registry glob must be dropped (fail-closed), never widened.
+describe("normalizeOrgImageNamespaces (shape gate)", () => {
+  test("accepts single-namespace registry globs", () => {
+    expect(
+      normalizeOrgImageNamespaces([
+        "ghcr.io/nubscarson/*",
+        "docker.io/some-org/*",
+      ]),
+    ).toEqual(["ghcr.io/nubscarson/*", "docker.io/some-org/*"]);
+  });
+
+  test("lowercases + trims entries (GitHub logins can be mixed-case)", () => {
+    expect(normalizeOrgImageNamespaces(["  ghcr.io/NubsCarson/*  "])).toEqual([
+      "ghcr.io/nubscarson/*",
+    ]);
+  });
+
+  test("drops gate-opening entries: bare *, whole-registry, exact refs, deep paths", () => {
+    expect(
+      normalizeOrgImageNamespaces([
+        "*", // would disable the gate entirely
+        "ghcr.io/*", // whole registry
+        "ghcr.io/nubscarson/app:v1", // exact ref, not a namespace glob
+        "ghcr.io/nubscarson/deep/nested/*", // multi-segment path
+        "nubscarson/*", // no registry host (dotless)
+        "ghcr.io//*", // empty namespace
+      ]),
+    ).toEqual([]);
+  });
+
+  test("drops non-string members and non-array values", () => {
+    expect(normalizeOrgImageNamespaces([42, null, { evil: true }])).toEqual([]);
+    expect(normalizeOrgImageNamespaces("ghcr.io/nubscarson/*")).toEqual([]);
+    expect(normalizeOrgImageNamespaces(undefined)).toEqual([]);
+    expect(normalizeOrgImageNamespaces(null)).toEqual([]);
+  });
+
+  test("dedupes and caps a pathological list", () => {
+    const raw = Array.from(
+      { length: 100 },
+      (_, i) => `ghcr.io/user-${i % 50}/*`,
+    );
+    const out = normalizeOrgImageNamespaces(raw);
+    expect(out.length).toBe(32);
+    expect(new Set(out).size).toBe(out.length);
+  });
+
+  test("accepted entries drive the REAL gate: org namespace passes, others still deny", () => {
+    const orgList = normalizeOrgImageNamespaces(["ghcr.io/nubscarson/*"]);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/nubscarson/my-app:v1", orgList),
+    ).toBe(true);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/evil/pwn:latest", orgList),
+    ).toBe(false);
+    // the dropped wildcard could never re-open the gate
+    expect(
+      isCodingContainerImageAllowed(
+        "docker.io/evil/pwn",
+        normalizeOrgImageNamespaces(["*"]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("getOrgImageNamespaces (fail-closed wrapper)", () => {
+  test("normalizes the settings value read for the org", async () => {
+    const out = await getOrgImageNamespaces("org-1", async (orgId) => {
+      expect(orgId).toBe("org-1");
+      return ["ghcr.io/NubsCarson/*", "ghcr.io/*"];
+    });
+    expect(out).toEqual(["ghcr.io/nubscarson/*"]);
+  });
+
+  test("returns [] for a missing/unset settings key", async () => {
+    expect(await getOrgImageNamespaces("org-1", async () => undefined)).toEqual(
+      [],
+    );
+  });
+
+  test("returns [] when the read throws (deny, never propagate)", async () => {
+    expect(
+      await getOrgImageNamespaces("org-1", async () => {
+        throw new Error("db down");
+      }),
+    ).toEqual([]);
+  });
+
+  test("returns [] for an empty org id without reading", async () => {
+    let called = false;
+    const out = await getOrgImageNamespaces("", async () => {
+      called = true;
+      return ["ghcr.io/nubscarson/*"];
+    });
+    expect(out).toEqual([]);
+    expect(called).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/org-image-namespaces.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/org-image-namespaces.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isCodingContainerImageAllowed } from "../coding-containers";
-import {
-  getOrgImageNamespaces,
-  normalizeOrgImageNamespaces,
-} from "../org-image-namespaces";
+import { getOrgImageNamespaces, normalizeOrgImageNamespaces } from "../org-image-namespaces";
 
 // The per-org extension is a SECOND chance after the platform-wide env
 // allowlist denies — so its normalization is itself a security gate: any entry
@@ -11,12 +8,10 @@ import {
 // single-namespace registry glob must be dropped (fail-closed), never widened.
 describe("normalizeOrgImageNamespaces (shape gate)", () => {
   test("accepts single-namespace registry globs", () => {
-    expect(
-      normalizeOrgImageNamespaces([
-        "ghcr.io/nubscarson/*",
-        "docker.io/some-org/*",
-      ]),
-    ).toEqual(["ghcr.io/nubscarson/*", "docker.io/some-org/*"]);
+    expect(normalizeOrgImageNamespaces(["ghcr.io/nubscarson/*", "docker.io/some-org/*"])).toEqual([
+      "ghcr.io/nubscarson/*",
+      "docker.io/some-org/*",
+    ]);
   });
 
   test("lowercases + trims entries (GitHub logins can be mixed-case)", () => {
@@ -46,10 +41,7 @@ describe("normalizeOrgImageNamespaces (shape gate)", () => {
   });
 
   test("dedupes and caps a pathological list", () => {
-    const raw = Array.from(
-      { length: 100 },
-      (_, i) => `ghcr.io/user-${i % 50}/*`,
-    );
+    const raw = Array.from({ length: 100 }, (_, i) => `ghcr.io/user-${i % 50}/*`);
     const out = normalizeOrgImageNamespaces(raw);
     expect(out.length).toBe(32);
     expect(new Set(out).size).toBe(out.length);
@@ -57,18 +49,11 @@ describe("normalizeOrgImageNamespaces (shape gate)", () => {
 
   test("accepted entries drive the REAL gate: org namespace passes, others still deny", () => {
     const orgList = normalizeOrgImageNamespaces(["ghcr.io/nubscarson/*"]);
-    expect(
-      isCodingContainerImageAllowed("ghcr.io/nubscarson/my-app:v1", orgList),
-    ).toBe(true);
-    expect(
-      isCodingContainerImageAllowed("ghcr.io/evil/pwn:latest", orgList),
-    ).toBe(false);
+    expect(isCodingContainerImageAllowed("ghcr.io/nubscarson/my-app:v1", orgList)).toBe(true);
+    expect(isCodingContainerImageAllowed("ghcr.io/evil/pwn:latest", orgList)).toBe(false);
     // the dropped wildcard could never re-open the gate
     expect(
-      isCodingContainerImageAllowed(
-        "docker.io/evil/pwn",
-        normalizeOrgImageNamespaces(["*"]),
-      ),
+      isCodingContainerImageAllowed("docker.io/evil/pwn", normalizeOrgImageNamespaces(["*"])),
     ).toBe(false);
   });
 });
@@ -83,9 +68,7 @@ describe("getOrgImageNamespaces (fail-closed wrapper)", () => {
   });
 
   test("returns [] for a missing/unset settings key", async () => {
-    expect(await getOrgImageNamespaces("org-1", async () => undefined)).toEqual(
-      [],
-    );
+    expect(await getOrgImageNamespaces("org-1", async () => undefined)).toEqual([]);
   });
 
   test("returns [] when the read throws (deny, never propagate)", async () => {

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -59,6 +59,7 @@ import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
+import { getOrgImageNamespaces } from "./org-image-namespaces";
 import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 import type { UserDatabaseService } from "./user-database";
 
@@ -89,6 +90,12 @@ export interface AppDeployRunnerDeps {
     /** The app's git repo (apps.github_repo) — the build pipeline's context. */
     repoUrl?: string;
   }) => Promise<string | undefined> | string | undefined;
+  /**
+   * Per-org image-namespace extension lookup (operator-granted namespaces from
+   * `organizations.settings.allowed_image_namespaces`). Injected for tests;
+   * defaults to the DB-backed {@link getOrgImageNamespaces}.
+   */
+  orgImageNamespaces?: (organizationId: string) => Promise<string[]>;
   /** App listen port. Default 3000. */
   port?: number;
 }
@@ -114,7 +121,14 @@ export function toNewContainer(row: NewAppContainerRow): NewContainer {
 
 export async function resolveImageRef(
   deps: AppDeployRunnerDeps,
-  app: { id: string; name: string; metadata: Record<string, unknown>; repoUrl?: string },
+  app: {
+    id: string;
+    name: string;
+    metadata: Record<string, unknown>;
+    repoUrl?: string;
+    /** Owning org — enables its per-org image-namespace extension when set. */
+    organizationId?: string;
+  },
 ): Promise<string> {
   const fromResolver = deps.resolveImage ? await deps.resolveImage(app) : undefined;
   const fromMetadata =
@@ -145,13 +159,25 @@ export async function resolveImageRef(
   // cannot run an arbitrary off-namespace image. Fail-closed: empty allowlist
   // denies. The default allowlist covers the first-party elizaOS namespace, so
   // the stamped template image / APP_DEFAULT_IMAGE under it pass unchanged.
+  // When the platform allowlist denies, the owning org's operator-granted
+  // namespace extension (organizations.settings.allowed_image_namespaces) is
+  // consulted — additive, fail-closed, scoped to that org only. This is the
+  // path that lets a user's own `ghcr.io/<login>/*` app image deploy without
+  // widening the platform-wide list for every tenant.
   const allowlist = containersEnv.appsDeployImageAllowlist();
-  if (!isCodingContainerImageAllowed(image, allowlist)) {
+  let imageAllowed = isCodingContainerImageAllowed(image, allowlist);
+  if (!imageAllowed && app.organizationId) {
+    const lookup = deps.orgImageNamespaces ?? getOrgImageNamespaces;
+    const orgNamespaces = await lookup(app.organizationId).catch(() => []);
+    imageAllowed = isCodingContainerImageAllowed(image, orgNamespaces);
+  }
+  if (!imageAllowed) {
     const permitted = allowlist.length > 0 ? allowlist.join(", ") : "(none configured)";
     throw new Error(
       `Image '${image}' is not permitted for app ${app.id}: it is outside the ` +
         `allowed image namespaces (${permitted}). Set app.metadata.imageTag to an ` +
-        `allowlisted image, or widen APPS_DEPLOY_IMAGE_ALLOWLIST.`,
+        `allowlisted image, widen APPS_DEPLOY_IMAGE_ALLOWLIST, or ask an operator ` +
+        `to grant the namespace to your organization (settings.allowed_image_namespaces).`,
     );
   }
   // SECURITY (opt-in, default OFF): when the digest-pin gate is armed, reject a
@@ -203,6 +229,7 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
       name: app.name,
       metadata: deployMetadata,
       repoUrl: app.github_repo ?? undefined,
+      organizationId: app.organization_id,
     });
     const containerName = containerNameForApp(appId);
 

--- a/packages/cloud/shared/src/lib/services/org-image-namespaces.ts
+++ b/packages/cloud/shared/src/lib/services/org-image-namespaces.ts
@@ -88,13 +88,10 @@ export async function getOrgImageNamespaces(
   try {
     return normalizeOrgImageNamespaces(await readSettings(organizationId));
   } catch (error) {
-    logger.warn(
-      "[OrgImageNamespaces] settings read failed; denying org extension",
-      {
-        organizationId,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    );
+    logger.warn("[OrgImageNamespaces] settings read failed; denying org extension", {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return [];
   }
 }

--- a/packages/cloud/shared/src/lib/services/org-image-namespaces.ts
+++ b/packages/cloud/shared/src/lib/services/org-image-namespaces.ts
@@ -1,0 +1,100 @@
+/**
+ * Per-org container-image namespace extension for the shared image allowlist
+ * gate (`isCodingContainerImageAllowed`).
+ *
+ * WHY: the env allowlists (`CODING_CONTAINER_IMAGE_ALLOWLIST` /
+ * `APPS_DEPLOY_IMAGE_ALLOWLIST`) are platform-wide, so a normal user's own
+ * registry namespace (e.g. `ghcr.io/<their-github-login>/*`) 403s on every
+ * container/app deploy unless an operator widens the GLOBAL list for everyone.
+ * This module adds the missing per-tenant dimension: an operator grants ONE org
+ * its own namespace(s) without widening the gate for any other org.
+ *
+ * SOURCE: `organizations.settings.allowed_image_namespaces` (JSONB, string[]).
+ * The key is OPERATOR-MANAGED — there is deliberately no self-serve route that
+ * writes it (org settings are only written by internal services today). An org
+ * granting itself namespaces would defeat the gate, so any future
+ * org-facing settings write path must keep this key admin-only.
+ *
+ * FAIL-CLOSED, defense-in-depth:
+ *  - a missing org / missing key / DB error yields [] (deny, never throw);
+ *  - entries must be single-namespace registry globs
+ *    (`<registry-host>/<namespace>/*`) — a bare `*`, a whole-registry
+ *    `ghcr.io/*`, or any malformed entry is dropped, so even a corrupted or
+ *    maliciously-written settings row cannot open the gate beyond one
+ *    namespace per entry;
+ *  - the list is capped so a pathological row cannot bloat the gate.
+ */
+
+import { eq } from "drizzle-orm";
+import { dbRead } from "../../db/client";
+import { organizations } from "../../db/schemas/organizations";
+import { logger } from "../utils/logger";
+
+/** settings key read from `organizations.settings` (operator-managed). */
+export const ORG_IMAGE_NAMESPACES_SETTINGS_KEY = "allowed_image_namespaces";
+
+/** Upper bound on accepted entries per org (a settings row is not a CSV dump). */
+const MAX_ORG_IMAGE_NAMESPACES = 32;
+
+/**
+ * The only accepted entry shape: `<registry-host>/<namespace>/*` — a
+ * dotted (optionally ported) registry host, exactly one namespace segment,
+ * and a trailing `/*`. Structurally forbids `*`, `ghcr.io/*`, exact image
+ * refs, and multi-segment paths, keeping each entry scoped to one namespace.
+ */
+const ORG_IMAGE_NAMESPACE_RE =
+  /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+(?::\d+)?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/\*$/;
+
+/**
+ * Normalize + shape-validate a raw settings value into allowlist entries.
+ * Pure and fail-closed: anything that is not a well-formed namespace glob is
+ * dropped, never widened. Exported for direct testing.
+ */
+export function normalizeOrgImageNamespaces(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const entries: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    const entry = item.trim().toLowerCase();
+    if (!ORG_IMAGE_NAMESPACE_RE.test(entry)) continue;
+    if (!entries.includes(entry)) entries.push(entry);
+    if (entries.length >= MAX_ORG_IMAGE_NAMESPACES) break;
+  }
+  return entries;
+}
+
+/** The DB seam — narrow settings read, injectable for tests. */
+async function readOrgSettings(organizationId: string): Promise<unknown> {
+  const [org] = await dbRead
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+  return (org?.settings as Record<string, unknown> | null | undefined)?.[
+    ORG_IMAGE_NAMESPACES_SETTINGS_KEY
+  ];
+}
+
+/**
+ * The org's operator-granted image-namespace allowlist extension. Merged
+ * (additively) into the env allowlist at the image-gate call sites; [] for an
+ * unknown org, an unset key, or any read failure — the gate stays fail-closed.
+ */
+export async function getOrgImageNamespaces(
+  organizationId: string,
+  readSettings: (organizationId: string) => Promise<unknown> = readOrgSettings,
+): Promise<string[]> {
+  if (!organizationId) return [];
+  try {
+    return normalizeOrgImageNamespaces(await readSettings(organizationId));
+  } catch (error) {
+    logger.warn(
+      "[OrgImageNamespaces] settings read failed; denying org extension",
+      {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return [];
+  }
+}

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -250,5 +250,22 @@ describe("app-deploy-guidance", () => {
         "Eliza Cloud",
       );
     });
+    // The push step of the container flow: an anonymous ghcr.io push always
+    // 403s, so BOTH cloud branches must carry the docker-login contract (env
+    // var NAMES only — never values) and the explicit report-the-missing-
+    // credential instruction instead of a silent/vague failure.
+    it("both Cloud branches carry the registry login contract by env-var name", () => {
+      for (const task of [
+        "build a monetized app that charges $2 per use",
+        "build a website about cats",
+      ]) {
+        const out = buildAppDeployGuidance({ target: "eliza-cloud" }, task);
+        expect(out).toContain("docker login ghcr.io");
+        expect(out).toContain("ELIZA_APP_IMAGE_REGISTRY_USERNAME");
+        expect(out).toContain("ELIZA_APP_IMAGE_REGISTRY_TOKEN");
+        expect(out).toContain("GHCR_TOKEN");
+        expect(out).toContain("registry push credential is missing");
+      }
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -69,6 +69,19 @@ describe("shouldForwardEnv", () => {
     expect(shouldForwardEnv("AWS_SECRET_ACCESS_KEY")).toBe(false);
     expect(shouldForwardEnv("GITHUB_TOKEN")).toBe(false);
   });
+
+  // The app-deploy contract's docker push needs a registry login — without a
+  // forwarded credential every ghcr.io push 403s before deploy is attempted.
+  // Only the DEDICATED registry-scoped names pass (a packages:write PAT); the
+  // broad host tokens (GITHUB_TOKEN above, GH_TOKEN, CR_PAT — repo-scoped)
+  // stay denied.
+  it("forwards the registry-scoped push credential, not the broad host tokens", () => {
+    expect(shouldForwardEnv("GHCR_USERNAME")).toBe(true);
+    expect(shouldForwardEnv("GHCR_TOKEN")).toBe(true);
+    expect(isEnvForwardableToSubAgent("GHCR_TOKEN")).toBe(true);
+    expect(shouldForwardEnv("GH_TOKEN")).toBe(false);
+    expect(shouldForwardEnv("CR_PAT")).toBe(false);
+  });
 });
 
 // The effective per-var decision buildEnv applies: deny-list BEFORE allowlist.
@@ -164,5 +177,23 @@ describe("forwardableSubAgentEnv", () => {
     expect(out.ELIZA_VAULT_PASSPHRASE).toBeUndefined();
     expect(out.DISCORD_BOT_TOKEN).toBeUndefined();
     expect("MISSING" in out).toBe(false);
+  });
+
+  // The projection an app-build spawn actually sees: the registry push pair
+  // (both the dedicated GHCR_* names and the canonical ELIZA_APP_IMAGE_* names)
+  // rides along; the host's repo-scoped GITHUB_TOKEN does not.
+  it("projects the registry push credential but never the repo-scoped host token", () => {
+    const out = forwardableSubAgentEnv({
+      GHCR_USERNAME: "pusher",
+      GHCR_TOKEN: "ghp-registry-scoped",
+      ELIZA_APP_IMAGE_REGISTRY_USERNAME: "pusher",
+      ELIZA_APP_IMAGE_REGISTRY_TOKEN: "ghp-registry-scoped",
+      GITHUB_TOKEN: "ghp-repo-scoped",
+    });
+    expect(out.GHCR_USERNAME).toBe("pusher");
+    expect(out.GHCR_TOKEN).toBe("ghp-registry-scoped");
+    expect(out.ELIZA_APP_IMAGE_REGISTRY_USERNAME).toBe("pusher");
+    expect(out.ELIZA_APP_IMAGE_REGISTRY_TOKEN).toBe("ghp-registry-scoped");
+    expect(out.GITHUB_TOKEN).toBeUndefined();
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -81,6 +81,9 @@ describe("shouldForwardEnv", () => {
     expect(isEnvForwardableToSubAgent("GHCR_TOKEN")).toBe(true);
     expect(shouldForwardEnv("GH_TOKEN")).toBe(false);
     expect(shouldForwardEnv("CR_PAT")).toBe(false);
+    expect(isEnvForwardableToSubAgent("GITHUB_TOKEN")).toBe(false);
+    expect(isEnvForwardableToSubAgent("GH_TOKEN")).toBe(false);
+    expect(isEnvForwardableToSubAgent("CR_PAT")).toBe(false);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-env-deny.test.ts
@@ -15,6 +15,20 @@ describe("isDeniedSubAgentEnvKey (customCredentials deny-list)", () => {
     }
   });
 
+  it("denies broad GitHub host tokens but allows dedicated registry credentials", () => {
+    for (const key of ["GITHUB_TOKEN", "GH_TOKEN", "CR_PAT"]) {
+      expect(isDeniedSubAgentEnvKey(key)).toBe(true);
+    }
+    for (const key of [
+      "GHCR_USERNAME",
+      "GHCR_TOKEN",
+      "ELIZA_APP_IMAGE_REGISTRY_USERNAME",
+      "ELIZA_APP_IMAGE_REGISTRY_TOKEN",
+    ]) {
+      expect(isDeniedSubAgentEnvKey(key)).toBe(false);
+    }
+  });
+
   it("allows ordinary keys a caller may legitimately forward via customCredentials", () => {
     for (const key of [
       "OPENAI_API_KEY",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -188,6 +188,10 @@ const DENY_ENV_PATTERNS = [
   // hand a child process a credential that re-authorizes arbitrary host command
   // execution with zero legitimate use for it.
   /TERMINAL_RUN_TOKEN/i,
+  // Repo-scoped GitHub host credentials must not be injected into sub-agents,
+  // including through customCredentials. Registry push uses the dedicated
+  // GHCR_* or ELIZA_APP_IMAGE_REGISTRY_* names instead.
+  /^(?:GITHUB_TOKEN|GH_TOKEN|CR_PAT)$/i,
 ];
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2705,6 +2705,16 @@ export function shouldForwardEnv(key: string): boolean {
       "OPENCODE_DISABLE_AUTOUPDATE",
       "OPENCODE_DISABLE_TERMINAL_TITLE",
       "CODEX_HOME",
+      // Container-registry PUSH credential for app-image builds (docker login
+      // ghcr.io before the deploy contract's docker push). Narrow by design:
+      // these are the dedicated registry-scoped names (a packages:write PAT),
+      // mirrored cloud-side by containersEnv.registryUsername()/registryToken().
+      // The broad GITHUB_TOKEN / GH_TOKEN / CR_PAT stay DENIED — a repo-scoped
+      // host token must never ride into a sub-agent. The canonical
+      // ELIZA_APP_IMAGE_REGISTRY_USERNAME/_TOKEN pair already forwards via the
+      // ELIZA_ prefix above.
+      "GHCR_USERNAME",
+      "GHCR_TOKEN",
     ].includes(key)
   );
 }

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -144,6 +144,11 @@ function elizaCloudGuidance(task?: string, monetized?: boolean): string {
     );
   }
   lines.push(
+    // The container flow pushes a built image to a registry, and an anonymous
+    // push always 403s. The credential env-var names are the contract here
+    // (values are forwarded by the spawn env allowlist when the operator set
+    // them); absence must surface as a NAMED blocker, not a vague failure.
+    '- If you build a container image, log in BEFORE pushing: `printf \'%s\' "$ELIZA_APP_IMAGE_REGISTRY_TOKEN" | docker login ghcr.io -u "$ELIZA_APP_IMAGE_REGISTRY_USERNAME" --password-stdin` (fallback pair: `GHCR_USERNAME` / `GHCR_TOKEN`). If neither pair is set in your env, STOP and report exactly that — the registry push credential is missing (name the vars) — instead of attempting an anonymous push or reporting a vague failure.',
     "- Report ONLY the verified live Cloud URL. If you could not deploy or verify it, say that plainly — never report an unverified or guessed URL.",
   );
   return lines.join("\n");


### PR DESCRIPTION
Closes #11636. Refs #8434 (launch lane).

The code-fixable half of the normie app-deploy 403 — a normal user's "build me an app" flow currently dies twice before any deploy: the spawned builder's `docker push ghcr.io/...` is always anonymous (403), and even a pushed image is rejected by the platform image allowlist (403 `CONTAINER_IMAGE_NOT_ALLOWED`) because permitting one user's namespace meant widening the gate for every tenant.

## What this changes

**1. Registry push credential reaches the sub-agent (orchestrator)** — `shouldForwardEnv` (acp-service.ts) now forwards the DEDICATED registry-scoped pair `GHCR_USERNAME` / `GHCR_TOKEN` (the same names `containersEnv.registryUsername()/registryToken()` already read cloud-side for pulls). Deliberately narrow:
- `GITHUB_TOKEN` stays denied (pinned contract, repo-scoped host secret) — as do `GH_TOKEN` / `CR_PAT`.
- The canonical `ELIZA_APP_IMAGE_REGISTRY_USERNAME/_TOKEN` pair already forwards via the `ELIZA_` prefix and misses every `DENY_ENV_PATTERNS` regex — both naming schemes work.

**2. The deploy contract tells the builder to log in (orchestrator)** — `elizaCloudGuidance` (app-deploy-guidance.ts) adds one line to both cloud branches: `docker login ghcr.io` via `--password-stdin` referencing the env-var NAMES only, plus "if neither pair is set, STOP and report the missing registry credential plainly" — a named blocker instead of a silent/vague failure.

**3. Per-org image-namespace extension (cloud)** — new `org-image-namespaces.ts` reads `organizations.settings.allowed_image_namespaces` (operator-managed; no self-serve route writes org settings today) and merges it into the image gate at all three call-sites (`/v1/containers`, `/v1/coding-containers`, apps-deploy runner). An operator can now grant ONE org its own `ghcr.io/<login>/*` without widening the platform-wide env allowlist for anyone else. Fail-closed by construction:
- consulted only AFTER the platform env allowlist denies (allowlisted images never touch the DB);
- entries must be single-namespace registry globs (`<registry-host>/<namespace>/*`) — a bare `*`, whole-registry `ghcr.io/*`, exact refs, deep paths, and non-strings are dropped, so even a corrupted/maliciously-written settings row cannot open the gate beyond one namespace per entry;
- unknown org / unset key / DB error / throwing lookup → `[]` (deny), capped at 32 entries;
- `isCodingContainerImageAllowed` and the digest-pin gate are unchanged.

## Tests (all real, run locally, re-run after rebasing onto latest develop)

- `plugins/plugin-agent-orchestrator` vitest — **42 pass**: GHCR pair forwarded, `GITHUB_TOKEN`/`GH_TOKEN`/`CR_PAT` still denied (incl. the `forwardableSubAgentEnv` projection), docker-login contract present in both cloud guidance branches.
- `packages/cloud/shared` bun test — **38 pass**: shape-gate normalization (wildcard/whole-registry/exact-ref/deep-path/non-string all dropped, dedupe+cap), fail-closed wrapper, and the apps-deploy runner matrix: granted org passes, ungranted org still rejected, grant does not open other namespaces, no-orgId legacy path unchanged, throwing lookup denies, allowlisted image never consults the lookup.
- `packages/cloud/api` isolated unit runner (the CI lane) — **17 pass** across both route suites: off-allowlist image still 403s with no grant, passes with the org grant, platform-allowlisted image never touches the org lookup.
- Typecheck: `plugin-agent-orchestrator`, `cloud/shared`, `cloud/api` all exit 0.

```
[cloud-api unit] all 2 file(s) passed (isolated)
38 pass / 0 fail (cloud-shared)
Test Files 2 passed — Tests 42 passed (orchestrator)
```

## What remains INFRA-ONLY (no PR can do this) — filed as its own issue, linked to #8434

1. **Mint the actual secret**: a `packages:write`-scoped GHCR PAT, set as `ELIZA_APP_IMAGE_REGISTRY_USERNAME/_TOKEN` (or `GHCR_USERNAME/GHCR_TOKEN`) in every self-hosted bot's parent env AND in the cloud env for node pulls (`containersEnv.registryToken()` chain).
2. **Live config**: append the needed namespace to `CODING_CONTAINER_IMAGE_ALLOWLIST` on the cloud deployment for the immediate unblock, or set the per-org grant this PR adds; decide the long-term per-user namespace policy.
3. **Public URL**: confirm `CONTAINERS_PUBLIC_BASE_DOMAIN` + wildcard DNS on the apps data plane (without it `app-url.ts` stamps no URL even after a successful deploy).
4. **Structural end-state**: arm build-from-repo (#9768) so the platform builds+pushes with its own creds and the sub-agent push disappears entirely.

## Evidence notes

- Backend-only change; no UI surface → screenshots/video N/A.
- Live-LLM trajectory N/A — the added guidance line is injected verbatim at the spawn chokepoint (asserted by unit test); the 403s this fixes are HTTP-gate behavior, fully covered by the route/service tests above, including the denied-access paths.
