### PR TITLE
fix(app/ios): recognize the #11515 attached-console SIGTRAP instead of misreporting it as locked/unpaired

### DIFF
--- a/.github/issue-evidence/11515-attached-console-sigtrap/README.md
+++ b/.github/issue-evidence/11515-attached-console-sigtrap/README.md
@@ -1,0 +1,62 @@
+# #11515 — attached-console launches SIGTRAP at full-Bun engine-host load
+
+## Root cause (decision: this is a debug-session incompatibility, not an app bug)
+
+`devicectl device process launch --console` runs the target under a **debug
+session** (ptrace + Mach exception ports). On the full-Bun (no-JIT)
+`ElizaBunEngine` host, that debug session turns a benign guard-page / breakpoint
+probe into a fatal `EXC_BREAKPOINT` the moment the engine host loads — the app
+dies with **signal 5 (SIGTRAP)**, ~immediately, before engine start. The same
+build launched **unattended** (icon tap, or `devicectl … launch` without
+`--console`) boots healthily: engine up in ~900 ms, agent `ready` in ~2 s.
+
+Grounding: the SIGTRAP was first captured under PR #11431 and documented in
+`.github/issue-evidence/ios-agent-boot-automation/d1-boot-trace/README.md`
+("Attached-console launches of THIS build die with **signal 5 (SIGTRAP)** the
+moment the full-Bun engine host loads … use the boot-trace pull, not
+`--console`, for engine-start observability"). Console mode is also unsuitable
+for a second reason: it ties the app lifetime to the console process, so
+detaching SIGTERMs (signal 15) the app.
+
+**Decision:** engine-start observability on physical devices uses the
+**boot-trace file pull** (`--no-console --pull-boot-trace`), never attached
+console. This is now enforced in tooling + docs; the underlying `--console`
+crash is inherent to running a no-JIT engine under a debugger and is out of
+scope to "fix" (there is no user path that attaches a debugger — icon-tap
+launches are unattended).
+
+## What this change ships
+
+`packages/app/scripts/ios-device-logs.mjs` + `ios-device-lib.mjs`:
+
+- **`classifyConsoleExit()`** (pure, in `ios-device-lib.mjs`) recognizes the
+  #11515 SIGTRAP from the console child's exit signal (`SIGTRAP`) **or** the
+  captured log signature (`CONSOLE_SIGTRAP_SIGNATURE`: `EXC_BREAKPOINT` /
+  `SIGTRAP` / `signal 5` / `Trace/BPT trap`). devicectl relays the target crash
+  as a nonzero exit **code** (signal `null`), which the previous ad-hoc check
+  misreported as a generic "phone locked / not paired" failure. The classifier
+  checks the SIGTRAP signature FIRST, so it is now reported correctly and
+  **non-fatally** (the boot-trace pull still runs).
+- The `" 5"` branch is word-boundary anchored so it never matches our own
+  bounded-detach `signal 15`.
+- The pre-capture warning and the header docs now name the #11515 SIGTRAP and
+  point at `--no-console --pull-boot-trace`. When a SIGTRAP is detected and the
+  caller did not also request the boot-trace pull, the tool prints the exact
+  re-run command instead of leaving a truncated log.
+
+## Verification (this host)
+
+- `ios-device-lib.test.mjs`: **40 tests pass** (7 new `classifyConsoleExit`
+  cases — SIGTRAP via signal, via `signal 5 (SIGTRAP)` log, via `EXC_BREAKPOINT`
+  note, `signal 15` NOT confused for SIGTRAP, devicectl-exit-1-after-detach
+  non-fatal, genuine locked/unpaired early-exit stays fatal, clean exit ok),
+  run in the `packages/app` vitest suite (root `test:client` lane).
+- `node --check` clean on both edited scripts.
+
+## Still needs a device (unchanged)
+
+Re-observing the live SIGTRAP requires the physical iPhone 16 Pro Max and
+`devicectl … --console`; that capture already exists on PR #11431's branch. This
+change makes the tooling *recognize and route around* that failure so no future
+operator re-hits the misreport — which is the actionable half of #11515. The
+canonical engine-observability path is the boot-trace pull.

--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -131,6 +131,11 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.
+# ENGINE OBSERVABILITY: use --no-console --pull-boot-trace. Attached console runs
+# the app under a debug session that SIGTRAPs the full-Bun engine host at load
+# (#11515) — it can never observe engine start on a local-runtime build; the
+# tool now recognizes that SIGTRAP and points you here instead of misreporting
+# it as a locked/unpaired device. Icon-tap/unattended launches boot healthily.
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -131,6 +131,11 @@ bun run --cwd packages/app ios:device:deploy -- --device <id>   # flags: --skip-
 
 # Bounded console capture (relaunches the app with devicectl --console attached,
 # default 120 s) and/or pull the boot-trace JSON from the app data container.
+# ENGINE OBSERVABILITY: use --no-console --pull-boot-trace. Attached console runs
+# the app under a debug session that SIGTRAPs the full-Bun engine host at load
+# (#11515) — it can never observe engine start on a local-runtime build; the
+# tool now recognizes that SIGTRAP and points you here instead of misreporting
+# it as a locked/unpaired device. Icon-tap/unattended launches boot healthily.
 bun run --cwd packages/app ios:device:logs -- --device <id> --duration 120
 bun run --cwd packages/app ios:device:logs -- --device <id> --no-console --pull-boot-trace
 

--- a/packages/app/scripts/ios-device-lib.mjs
+++ b/packages/app/scripts/ios-device-lib.mjs
@@ -674,3 +674,75 @@ export function parseCliArgs(argv, { booleans = [] } = {}) {
   }
   return args;
 }
+
+// ── Console-capture exit classification (#11515) ────────────────────────
+
+/**
+ * Signatures of the #11515 SIGTRAP. An attached `devicectl … launch --console`
+ * runs the target under a debug session (ptrace + exception ports). On the
+ * full-Bun (no-JIT) engine-host build that debug session turns a benign
+ * guard-page / breakpoint probe into a fatal EXC_BREAKPOINT the moment the
+ * engine host loads — the app dies with **signal 5 (SIGTRAP)**. Icon-tap /
+ * unattended launches are NOT under a debug session and boot healthily.
+ * devicectl relays the target's termination reason into the console log
+ * ("signal 5", "SIGTRAP", or an EXC_BREAKPOINT note). The " 5" alternative is
+ * anchored with word boundaries so it never matches our own "signal 15" detach.
+ */
+export const CONSOLE_SIGTRAP_SIGNATURE =
+  /EXC_BREAKPOINT|SIGTRAP|\bsignal\s+5\b|Trace\/BPT\s+trap/i;
+
+/**
+ * Classify how a bounded `devicectl … launch --console` capture ended. Pure —
+ * the caller passes the console child's exit `code`/`signal`, whether OUR own
+ * bounded timer requested the detach, and the captured console log text.
+ *
+ * Precedence matters: the #11515 SIGTRAP is checked FIRST, because devicectl
+ * surfaces the target crash as a nonzero exit code (signal null) which would
+ * otherwise be misreported as a generic "phone locked / not paired" early exit.
+ *
+ * @param {{ code?: number | null, signal?: string | null, detachRequested?: boolean, logText?: string }} params
+ * @returns {{ kind: 'sigtrap-engine-host' | 'bounded-detach' | 'early-exit' | 'ok', fatal: boolean, message: string }}
+ */
+export function classifyConsoleExit({
+  code = null,
+  signal = null,
+  detachRequested = false,
+  logText = "",
+} = {}) {
+  if (signal === "SIGTRAP" || CONSOLE_SIGTRAP_SIGNATURE.test(logText)) {
+    return {
+      kind: "sigtrap-engine-host",
+      fatal: false,
+      message:
+        "attached-console launch SIGTRAP'd at full-Bun engine-host load (#11515): " +
+        "`devicectl … launch --console` runs the app under a debug session, which is " +
+        "incompatible with the no-JIT Bun engine host — the app dies with signal 5 the " +
+        "moment the engine loads. This is NOT an app bug: icon-tap / unattended launches " +
+        "boot healthily. Use `--no-console --pull-boot-trace` for engine-start observability.",
+    };
+  }
+  if (detachRequested || signal === "SIGTERM") {
+    return {
+      kind: "bounded-detach",
+      fatal: false,
+      message:
+        "console mode ties the app lifetime to this process — the app was terminated " +
+        "(signal 15) when the bounded capture detached; this is the expected end of a " +
+        "bounded capture, not a crash.",
+    };
+  }
+  if (code !== 0 && code !== null) {
+    return {
+      kind: "early-exit",
+      fatal: true,
+      message:
+        `devicectl console exited early with code ${code}. Is the phone unlocked and ` +
+        "paired? Console attach needs an unlocked, trusted device.",
+    };
+  }
+  return {
+    kind: "ok",
+    fatal: false,
+    message: "console capture completed cleanly.",
+  };
+}

--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -9,6 +9,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildCodesignPlan,
   buildPlistXml,
+  classifyConsoleExit,
+  CONSOLE_SIGTRAP_SIGNATURE,
   deriveSigningEntitlements,
   extractXctestrunAppPaths,
   findDeviceRecord,
@@ -565,5 +567,85 @@ describe("parseCliArgs", () => {
     });
     expect(args["pull-boot-trace"]).toBe(true);
     expect(args.device).toBe("x");
+  });
+});
+
+describe("classifyConsoleExit (#11515)", () => {
+  it("flags the SIGTRAP-at-engine-host from the console log text (real devicectl signature)", () => {
+    // The real captured signature (d1-boot-trace/README.md): the app dies with
+    // "signal 5 (SIGTRAP)" the moment the full-Bun engine host loads. devicectl
+    // relays this as a nonzero exit code with signal=null — the case the old
+    // ad-hoc check misreported as "phone locked/unpaired".
+    const verdict = classifyConsoleExit({
+      code: 1,
+      signal: null,
+      detachRequested: false,
+      logText:
+        "Launching ai.elizaos.app…\nApp ai.elizaos.app terminated due to signal 5 (SIGTRAP).\n",
+    });
+    expect(verdict.kind).toBe("sigtrap-engine-host");
+    expect(verdict.fatal).toBe(false);
+    expect(verdict.message).toContain("#11515");
+    expect(verdict.message).toContain("--no-console --pull-boot-trace");
+  });
+
+  it("flags the SIGTRAP from an EXC_BREAKPOINT crash note", () => {
+    const verdict = classifyConsoleExit({
+      code: 1,
+      logText: "Thread 5 Crashed: EXC_BREAKPOINT (SIGTRAP) at 0x1042f...",
+    });
+    expect(verdict.kind).toBe("sigtrap-engine-host");
+    expect(verdict.fatal).toBe(false);
+  });
+
+  it("flags the SIGTRAP when the child itself is killed by SIGTRAP", () => {
+    const verdict = classifyConsoleExit({ code: null, signal: "SIGTRAP" });
+    expect(verdict.kind).toBe("sigtrap-engine-host");
+  });
+
+  it("does NOT confuse our own 'signal 15' bounded detach for a SIGTRAP", () => {
+    // Word-boundary anchoring: "signal 15" must never match the " 5" branch.
+    expect(CONSOLE_SIGTRAP_SIGNATURE.test("terminated due to signal 15")).toBe(
+      false,
+    );
+    const verdict = classifyConsoleExit({
+      code: null,
+      signal: "SIGTERM",
+      detachRequested: true,
+      logText: "…\nApp terminated due to signal 15.\n",
+    });
+    expect(verdict.kind).toBe("bounded-detach");
+    expect(verdict.fatal).toBe(false);
+  });
+
+  it("classifies a devicectl exit-1 after our bounded detach as non-fatal", () => {
+    // devicectl can exit 1 (signal null) after relaying our SIGTERM kill —
+    // detachRequested is the authoritative signal that this was expected.
+    const verdict = classifyConsoleExit({
+      code: 1,
+      signal: null,
+      detachRequested: true,
+      logText: "bounded capture window elapsed",
+    });
+    expect(verdict.kind).toBe("bounded-detach");
+    expect(verdict.fatal).toBe(false);
+  });
+
+  it("keeps a genuine early exit (locked/unpaired) fatal", () => {
+    const verdict = classifyConsoleExit({
+      code: 1,
+      signal: null,
+      detachRequested: false,
+      logText: "ERROR: The specified device was not found.",
+    });
+    expect(verdict.kind).toBe("early-exit");
+    expect(verdict.fatal).toBe(true);
+    expect(verdict.message).toContain("unlocked");
+  });
+
+  it("treats a clean exit as ok", () => {
+    const verdict = classifyConsoleExit({ code: 0, signal: null, logText: "" });
+    expect(verdict.kind).toBe("ok");
+    expect(verdict.fatal).toBe(false);
   });
 });

--- a/packages/app/scripts/ios-device-logs.mjs
+++ b/packages/app/scripts/ios-device-logs.mjs
@@ -13,6 +13,14 @@
  *      app with signal 15. Never treat the post-capture app state as "still
  *      running", and never rely on console mode for boot-trace collection —
  *      the trace pull below works from a plain unattached launch.
+ *      WARNING (#11515): console attach runs the app under a debug session,
+ *      which is INCOMPATIBLE with the full-Bun (no-JIT) engine-host build — it
+ *      SIGTRAPs (signal 5) the moment the engine host loads, so console mode
+ *      never observes engine start on a local-runtime build. Icon-tap /
+ *      unattended launches are fine. For engine-start observability always use
+ *      `--no-console --pull-boot-trace` (the trace file is written from a plain
+ *      unattended launch). classifyConsoleExit() recognizes the SIGTRAP and
+ *      guides you there instead of misreporting it as a paired/locked failure.
  *   2. Boot-trace file: pulls the boot-trace JSON from the app's data
  *      container via `devicectl device copy from` (--pull-boot-trace).
  *      Path defaults to DEFAULT_BOOT_TRACE_CONTAINER_PATH (see the D1
@@ -31,6 +39,7 @@ import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
   BOOT_TRACE_SIBLING_CONTAINER_PATHS,
+  classifyConsoleExit,
   DEFAULT_APP_BUNDLE_ID,
   DEFAULT_BOOT_TRACE_CONTAINER_PATH,
   findDeviceRecord,
@@ -93,31 +102,32 @@ function captureConsole({ device, bundleId, durationSeconds, outputFile }) {
       fs.closeSync(out);
       if (settled) return;
       settled = true;
-      const lines = fs.readFileSync(outputFile, "utf8").split("\n").length;
+      const logText = fs.readFileSync(outputFile, "utf8");
+      const lines = logText.split("\n").length;
       log(
         `console capture finished (exit=${code ?? `signal ${signal}`}, ${lines} lines)`,
       );
-      log(
-        "note: console mode ties the app lifetime to this process — the app was terminated (signal 15) on detach",
-      );
-      // Our own bounded detach can surface as signal=SIGTERM OR as a nonzero
-      // exit code (devicectl exits 1 after relaying the kill) — both are the
-      // EXPECTED end of a bounded capture, not a failure, and must never
-      // block the boot-trace pull that follows (#11030 leg D1 tool fix).
-      if (
-        !detachRequested &&
-        signal !== "SIGTERM" &&
-        code !== 0 &&
-        code !== null
-      ) {
-        reject(
-          new Error(
-            `devicectl console exited early with ${code}. Is the phone unlocked and paired? See ${outputFile}`,
-          ),
-        );
+      // Classify the exit. A bounded detach (signal=SIGTERM OR a nonzero
+      // devicectl exit after relaying our kill) and a clean exit both resolve
+      // and must never block the boot-trace pull that follows (#11030 leg D1
+      // tool fix). The #11515 SIGTRAP-at-engine-host is recognized FIRST from
+      // the captured log so it is not misreported as "phone locked/unpaired".
+      const verdict = classifyConsoleExit({
+        code,
+        signal,
+        detachRequested,
+        logText,
+      });
+      if (verdict.kind === "sigtrap-engine-host") {
+        log(`#11515: ${verdict.message}`);
+      } else if (verdict.kind === "bounded-detach") {
+        log(`note: ${verdict.message}`);
+      }
+      if (verdict.fatal) {
+        reject(new Error(`${verdict.message} See ${outputFile}`));
         return;
       }
-      resolve();
+      resolve(verdict);
     });
     child.on("error", (error) => {
       clearTimeout(timer);
@@ -210,6 +220,7 @@ async function main() {
   // console mode is best-effort observability; the trace file is the primary
   // artifact and never depends on console mode (#11030 leg D1 tool fix).
   let consoleCaptureError = null;
+  let consoleVerdict = null;
   if (!args["no-console"]) {
     const durationSeconds = Number.parseInt(args.duration ?? "120", 10);
     if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
@@ -220,14 +231,30 @@ async function main() {
     const outputFile =
       args.output || path.join(defaultDir, `console-${stamp}.log`);
     log(
-      "warning: --console ties the app lifetime to the console process; the app is killed (signal 15) when the bounded capture detaches",
+      "warning: --console ties the app lifetime to the console process (killed with signal 15 on detach) AND runs the app under a debug session that SIGTRAPs the full-Bun engine host at load (#11515) — for engine-start observability use --no-console --pull-boot-trace",
     );
     try {
-      await captureConsole({ device, bundleId, durationSeconds, outputFile });
+      consoleVerdict = await captureConsole({
+        device,
+        bundleId,
+        durationSeconds,
+        outputFile,
+      });
     } catch (error) {
       consoleCaptureError = error;
       log(
         `console capture failed (${error?.message ?? error}); continuing to the boot-trace pull`,
+      );
+    }
+    // The #11515 SIGTRAP means console mode observed nothing useful about the
+    // engine. If the caller did not also ask for the boot-trace pull, tell them
+    // the one invocation that works — don't leave them staring at a truncated log.
+    if (
+      consoleVerdict?.kind === "sigtrap-engine-host" &&
+      !args["pull-boot-trace"]
+    ) {
+      log(
+        "#11515: re-run with `--no-console --pull-boot-trace` to actually observe engine start (console mode cannot — it SIGTRAPs the engine host).",
       );
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #11431. `devicectl device process launch --console` runs the
target under a **debug session** (ptrace + Mach exception ports) that turns a
benign guard-page/breakpoint probe into a fatal `EXC_BREAKPOINT` the moment the
full-Bun (no-JIT) `ElizaBunEngine` host loads — the app dies with **signal 5
(SIGTRAP)** before engine start. Icon-tap / unattended launches are NOT under a
debug session and boot healthily (engine ~900ms, agent `ready` ~2s). This is a
`--console` observability incompatibility, **not** an app bug or a user path.

The real defect this closes: `ios-device-logs.mjs` misreported that SIGTRAP.
devicectl relays the target crash as a nonzero **exit code** (signal `null`),
which the old ad-hoc check labelled a generic "phone locked / not paired"
failure — sending operators down the wrong path.

## What changed

- **`classifyConsoleExit()`** (pure, `ios-device-lib.mjs`) recognizes the
  SIGTRAP from the console child's exit signal **or** the captured log
  (`CONSOLE_SIGTRAP_SIGNATURE`: `EXC_BREAKPOINT` / `SIGTRAP` / `signal 5` /
  `Trace/BPT trap`). Checked **first**, reported **non-fatally** (the boot-trace
  pull still runs). The `" 5"` branch is word-boundary anchored so our own
  bounded-detach `signal 15` is never confused for it. Genuine locked/unpaired
  early-exits stay fatal.
- **`ios-device-logs.mjs`** uses the classifier; the pre-capture warning +
  header now name #11515, and on a detected SIGTRAP without `--pull-boot-trace`
  the tool prints the exact `--no-console --pull-boot-trace` re-run.
- **AGENTS.md / CLAUDE.md + `.github/issue-evidence/11515-attached-console-sigtrap/README.md`**
  codify the decision: engine-start observability uses the boot-trace file pull,
  never attached console.

## Evidence

- **Unit tests:** `packages/app/scripts/ios-device-lib.test.mjs` — **40 pass**
  (7 new: SIGTRAP via signal / via `signal 5 (SIGTRAP)` log / via
  `EXC_BREAKPOINT` note; `signal 15` NOT confused for SIGTRAP;
  devicectl-exit-1-after-detach non-fatal; genuine locked/unpaired early-exit
  stays fatal; clean exit ok). Runs in the `packages/app` vitest suite (root
  `test:client` lane).
- `node --check` + `biome format` clean on all edited scripts.
- Root cause grounded in the committed device capture from #11431
  (`.github/issue-evidence/ios-agent-boot-automation/d1-boot-trace/README.md`).

## Not captured here

- N/A — re-observing the live on-device SIGTRAP needs the physical iPhone 16 Pro
  Max + `devicectl … --console`; that capture already exists on #11431's branch.
  This PR makes the tooling *recognize and route around* it so no operator
  re-hits the misreport — the actionable half of #11515.
