### PR TITLE
fix(ci): arm-apps-daemon wires CONTAINERS_SSH_KEY — unblocks the first real app-deploy E2E (#11607)

### DIFF
--- a/.github/issue-evidence/11607-arm-apps-daemon-ssh-key.md
+++ b/.github/issue-evidence/11607-arm-apps-daemon-ssh-key.md
@@ -1,0 +1,56 @@
+# Issue #11607 evidence - arm-apps-daemon container SSH key
+
+## Change
+
+- `.github/workflows/arm-apps-daemon.yml` now resolves container SSH key material from `CONTAINERS_SSH_KEY` or the same target deploy key, normalizes it to the base64 format consumed by `docker-ssh.ts`, forwards it through `ssh-action`, and upserts `CONTAINERS_SSH_KEY` into `/opt/eliza/cloud/.env.local`.
+- `packages/scripts/cloud/admin/arm-apps-daemon.mjs` keeps local arming behavior in parity by supporting `--node-ssh-key-base64` in addition to `--node-ssh-key-path`.
+- `packages/scripts/cloud/admin/daemons/arm-apps-daemon-workflow.test.ts` guards the workflow wiring that regressed.
+
+## Verification
+
+```bash
+bun install
+```
+
+Result: passed, no dependency changes.
+
+```bash
+bun test packages/scripts/cloud/admin/daemons/arm-apps-daemon-workflow.test.ts packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+```
+
+Result: 13 pass, 0 fail.
+
+```bash
+bunx @biomejs/biome check .github/workflows/arm-apps-daemon.yml packages/scripts/cloud/admin/arm-apps-daemon.mjs packages/scripts/cloud/admin/daemons/arm-apps-daemon-workflow.test.ts
+```
+
+Result: passed.
+
+```bash
+actionlint .github/workflows/arm-apps-daemon.yml
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+bun run verify
+```
+
+Result: failed before package typecheck/lint on the repo-wide type-safety ratchet. The exceeded counts are unrelated to this workflow/admin-script change:
+
+- `as unknown as`: 77 current > 76 baseline
+- ``?? 0`` in core/agent/app-core: 376 current > 375 baseline
+
+The command also reported that the non-null assertion baseline can shrink from 518 to 515.
+
+## N/A
+
+- UI screenshots/video: N/A - workflow/admin script only.
+- Real-LLM trajectories: N/A - no agent/action/prompt/model behavior changed.
+- Backend/frontend logs from staging run: N/A - this change is a GitHub Actions wiring fix and was verified with static workflow guards plus `actionlint`; it has not been manually dispatched against production secrets from this local environment.

--- a/.github/workflows/arm-apps-daemon.yml
+++ b/.github/workflows/arm-apps-daemon.yml
@@ -91,6 +91,7 @@ jobs:
       # `[ -n "$DEPLOY_HOST" ]` check reports the right missing-secret error.
       DEPLOY_HOST: ${{ (github.event.inputs.target == 'apps-worker' && secrets.ELIZA_APPS_WORKER_HOST) || (github.event.inputs.target == 'cp-daemon' && secrets.ELIZA_PROVISIONING_HOST) || '' }}
       DEPLOY_SSH_KEY: ${{ (github.event.inputs.target == 'apps-worker' && secrets.ELIZA_APPS_WORKER_SSH_KEY) || (github.event.inputs.target == 'cp-daemon' && secrets.ELIZA_PROVISIONING_SSH_KEY) || '' }}
+      CONTAINERS_SSH_KEY_INPUT: ${{ secrets.CONTAINERS_SSH_KEY || (github.event.inputs.target == 'apps-worker' && secrets.ELIZA_APPS_WORKER_SSH_KEY) || (github.event.inputs.target == 'cp-daemon' && secrets.ELIZA_PROVISIONING_SSH_KEY) || '' }}
       SYSTEMD_UNIT: ${{ github.event.inputs.target == 'apps-worker' && 'eliza-apps-worker.service' || 'eliza-provisioning-worker.service' }}
       BASE_DOMAIN: ${{ vars.APPS_BASE_DOMAIN }}
       APP_NODE: ${{ github.event.inputs.app_node }}
@@ -104,6 +105,7 @@ jobs:
           KEY_SECRET="${{ github.event.inputs.target == 'apps-worker' && 'ELIZA_APPS_WORKER_SSH_KEY' || 'ELIZA_PROVISIONING_SSH_KEY' }}"
           [ -n "$DEPLOY_HOST" ] || { echo "::error::missing secret $HOST_SECRET on the '${{ github.event.inputs.environment }}' environment (target=${{ github.event.inputs.target }})"; fail=1; }
           [ -n "$DEPLOY_SSH_KEY" ] || { echo "::error::missing secret $KEY_SECRET"; fail=1; }
+          [ -n "$CONTAINERS_SSH_KEY_INPUT" ] || { echo "::error::missing container SSH key material: set secret CONTAINERS_SSH_KEY or $KEY_SECRET"; fail=1; }
           [ -n "$BASE_DOMAIN" ] || { echo "::error::set vars.APPS_BASE_DOMAIN on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
           [ -n "$APP_NODE" ] || { echo "::error::app_node input is required (id:ip:capacity)"; fail=1; }
           # Derive the Caddy admin URL from the app node IP (2nd colon field).
@@ -111,6 +113,27 @@ jobs:
           echo "$NODE_IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::app_node must be id:ip:capacity with a valid IPv4"; fail=1; }
           echo "CADDY_ADMIN=http://$NODE_IP:2019" >> "$GITHUB_ENV"
           [ "$fail" = 0 ] || exit 1
+
+      - name: Prepare container SSH key
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          cleanup() { rm -f "$tmp"; }
+          trap cleanup EXIT
+
+          # docker-ssh.ts consumes CONTAINERS_SSH_KEY as base64. Accept either
+          # a dedicated already-base64 CONTAINERS_SSH_KEY secret or the raw
+          # target deploy key used by appleboy/ssh-action, then forward one
+          # single-line base64 value to the remote upsert script.
+          if printf '%s' "$CONTAINERS_SSH_KEY_INPUT" | base64 -d >"$tmp" 2>/dev/null && grep -q 'BEGIN .*PRIVATE KEY' "$tmp"; then
+            containers_ssh_key_b64="$(printf '%s' "$CONTAINERS_SSH_KEY_INPUT" | tr -d '\r\n')"
+          else
+            containers_ssh_key_b64="$(printf '%s' "$CONTAINERS_SSH_KEY_INPUT" | base64 -w0)"
+          fi
+
+          [ -n "$containers_ssh_key_b64" ] || { echo "::error::container SSH key resolved to an empty value"; exit 1; }
+          echo "::add-mask::$containers_ssh_key_b64"
+          echo "CONTAINERS_SSH_KEY_B64=$containers_ssh_key_b64" >> "$GITHUB_ENV"
 
       # OPTIONAL: pull the tenant admin DSN straight from the apps-shared
       # terraform output so the password never appears in a workflow input or in
@@ -149,7 +172,7 @@ jobs:
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 5m
           # Only the values; the upsert logic is fixed here (mirrors arm-apps-daemon.mjs).
-          envs: APP_NODE,BASE_DOMAIN,CADDY_ADMIN,TENANT_ADMIN_DSN,EGRESS_PROXY,SYSTEMD_UNIT
+          envs: APP_NODE,BASE_DOMAIN,CADDY_ADMIN,TENANT_ADMIN_DSN,EGRESS_PROXY,SYSTEMD_UNIT,CONTAINERS_SSH_KEY_B64
           script: |
             set -euo pipefail
             F=/opt/eliza/cloud/.env.local
@@ -175,13 +198,14 @@ jobs:
             upsert APPS_CONTAINERS_ENABLED 1
             upsert CONTAINERS_DOCKER_NODES "$APP_NODE"
             upsert CONTAINERS_SSH_USER deploy
+            upsert CONTAINERS_SSH_KEY "$CONTAINERS_SSH_KEY_B64"
             upsert APPS_CADDY_ADMIN_URL "$CADDY_ADMIN"
             upsert CONTAINERS_PUBLIC_BASE_DOMAIN "$BASE_DOMAIN"
             upsert APPS_TENANT_ADMIN_DSN "$TENANT_ADMIN_DSN"
             upsert CONTAINERS_EGRESS_PROXY_URL "$EGRESS_PROXY"
 
             echo "--- apps env now on the box (secrets redacted) ---"
-            sudo grep -E '^(APPS_|CONTAINERS_(DOCKER_NODES|SSH_USER|PUBLIC_BASE_DOMAIN|EGRESS_PROXY_URL))' "$F" \
+            sudo grep -E '^(APPS_|CONTAINERS_(DOCKER_NODES|SSH_USER|SSH_KEY|PUBLIC_BASE_DOMAIN|EGRESS_PROXY_URL))' "$F" \
               | sed -E 's/(DSN|KEY)=.*/\1=<redacted>/'
 
             # Restart whichever daemon we armed: the dedicated apps-worker on the

--- a/packages/scripts/cloud/admin/arm-apps-daemon.mjs
+++ b/packages/scripts/cloud/admin/arm-apps-daemon.mjs
@@ -24,6 +24,7 @@
  *     --caddy-admin http://167.233.112.155:2019 \
  *     --tenant-admin-dsn 'postgresql://postgres:***@10.30.1.10:5432/postgres?sslmode=require' \
  *     --node-ssh-key-path /home/deploy/.ssh/apps-node \   # key the APP NODE's deploy user accepts
+ *     # or --node-ssh-key-base64 <base64-private-key>     # writes CONTAINERS_SSH_KEY
  *     [--node-ssh-user deploy] [--egress-proxy http://127.0.0.1:3128] [--dry-run]
  *     [--target cp-daemon|apps-worker]      # which unit to restart (default cp-daemon)
  *
@@ -90,6 +91,7 @@ const desired = {
   APPS_CONTAINERS_ENABLED: "1",
   CONTAINERS_DOCKER_NODES: args["app-node"],
   CONTAINERS_SSH_USER: args["node-ssh-user"] || "deploy",
+  CONTAINERS_SSH_KEY: args["node-ssh-key-base64"],
   CONTAINERS_SSH_KEY_PATH: args["node-ssh-key-path"],
   APPS_CADDY_ADMIN_URL: args["caddy-admin"],
   CONTAINERS_PUBLIC_BASE_DOMAIN: args["base-domain"],
@@ -137,7 +139,7 @@ F=${ENV_PATH}
 cp -n "$F" "$F.bak.arm-apps" 2>/dev/null || true
 ${upserts}
 echo "--- apps env now on the box ---"
-grep -E '^(APPS_|CONTAINERS_(DOCKER_NODES|SSH_USER|SSH_KEY_PATH|PUBLIC_BASE_DOMAIN|EGRESS_PROXY_URL))' "$F" | sed -E 's/(DSN|KEY)=.*/\\1=<redacted>/'
+grep -E '^(APPS_|CONTAINERS_(DOCKER_NODES|SSH_USER|SSH_KEY|SSH_KEY_PATH|PUBLIC_BASE_DOMAIN|EGRESS_PROXY_URL))' "$F" | sed -E 's/(DSN|KEY)=.*/\\1=<redacted>/'
 sudo systemctl restart ${SYSTEMD_UNIT}
 sleep 2
 echo "--- daemon status ---"

--- a/packages/scripts/cloud/admin/daemons/arm-apps-daemon-workflow.test.ts
+++ b/packages/scripts/cloud/admin/daemons/arm-apps-daemon-workflow.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../../..");
+const workflowPath = path.join(
+  repoRoot,
+  ".github/workflows/arm-apps-daemon.yml",
+);
+const scriptPath = path.join(
+  repoRoot,
+  "packages/scripts/cloud/admin/arm-apps-daemon.mjs",
+);
+
+const workflow = readFileSync(workflowPath, "utf8");
+const localScript = readFileSync(scriptPath, "utf8");
+
+describe("arm-apps-daemon.yml container SSH key wiring", () => {
+  it("sources container SSH key material from the dedicated secret or the target deploy key", () => {
+    expect(workflow).toContain("CONTAINERS_SSH_KEY_INPUT:");
+    expect(workflow).toContain("secrets.CONTAINERS_SSH_KEY");
+    expect(workflow).toContain("secrets.ELIZA_APPS_WORKER_SSH_KEY");
+    expect(workflow).toContain("secrets.ELIZA_PROVISIONING_SSH_KEY");
+  });
+
+  it("fails preflight when no container SSH key material is available", () => {
+    expect(workflow).toContain('[ -n "$CONTAINERS_SSH_KEY_INPUT" ]');
+    expect(workflow).toContain("missing container SSH key material");
+  });
+
+  it("normalizes raw or already-base64 key material to a single-line base64 env value", () => {
+    expect(workflow).toContain("Prepare container SSH key");
+    expect(workflow).toContain('base64 -d >"$tmp"');
+    expect(workflow).toContain("base64 -w0");
+    expect(workflow).toContain(
+      "CONTAINERS_SSH_KEY_B64=$containers_ssh_key_b64",
+    );
+  });
+
+  it("forwards the normalized key through ssh-action and writes CONTAINERS_SSH_KEY remotely", () => {
+    const envsLine = workflow
+      .split("\n")
+      .find(
+        (line) =>
+          line.trim().startsWith("envs:") &&
+          line.includes("CONTAINERS_SSH_KEY_B64"),
+      );
+    expect(envsLine).toBeDefined();
+    expect(workflow).toContain(
+      'upsert CONTAINERS_SSH_KEY "$CONTAINERS_SSH_KEY_B64"',
+    );
+  });
+
+  it("shows CONTAINERS_SSH_KEY only through the redacted grep output", () => {
+    expect(workflow).toContain("SSH_KEY");
+    expect(workflow).toContain("sed -E 's/(DSN|KEY)=.*/\\1=<redacted>/'");
+  });
+});
+
+describe("arm-apps-daemon.mjs container SSH key parity", () => {
+  it("lets local arming write CONTAINERS_SSH_KEY as base64 or CONTAINERS_SSH_KEY_PATH", () => {
+    expect(localScript).toContain("--node-ssh-key-base64");
+    expect(localScript).toContain(
+      'CONTAINERS_SSH_KEY: args["node-ssh-key-base64"]',
+    );
+    expect(localScript).toContain(
+      'CONTAINERS_SSH_KEY_PATH: args["node-ssh-key-path"]',
+    );
+  });
+});


### PR DESCRIPTION
Closes #11607. **Top launch blocker** — the only unproven launch chain (app-deploy).

## Problem
The staging apps-worker's `container_provision` fails ×3 (`Apps container backend not configured — need CONTAINERS_DOCKER_NODES + CONTAINERS_SSH_KEY/_PATH`), so the first real app-deploy E2E (#10823) can't complete even though `app_deploy` succeeds. Root cause: `arm-apps-daemon.yml` never wrote `CONTAINERS_SSH_KEY` to the daemon's env.

## Fix
- `.github/workflows/arm-apps-daemon.yml`: resolves container SSH key material from `CONTAINERS_SSH_KEY` (or the same target deploy key), normalizes to the base64 format `docker-ssh.ts` consumes, forwards it through the ssh-action, and **upserts `CONTAINERS_SSH_KEY` into `/opt/eliza/cloud/.env.local`** during arm.
- `packages/scripts/cloud/admin/arm-apps-daemon.mjs`: adds `--node-ssh-key-base64` (parity with the workflow path).
- `arm-apps-daemon-workflow.test.ts`: guards the wiring that regressed (**6/6 pass**; biome + the yaml validate clean).

Authored via a Fable-5 workflow, cherry-picked onto current develop (the workflow branch was stale-based). 

## Remaining for the E2E (coordinated on #11607)
The workflow now wires the key, but the staging box also needs the **key material + `CONTAINERS_DOCKER_NODES=167.233.72.66:20`** placed by [cloud-security] (who holds the apps-node SSH-key custody) OR the `CONTAINERS_SSH_KEY` secret set so a fresh arm wires it. Once that's on the box I re-drive `container_provision` → live `production_url` → #10823 green. — `[cloud-frontdoor]`