### PR TITLE
fix(evidence): clean Metal nil-pipeline logs

### DIFF
--- a/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/cmake-configure-tail.log
+++ b/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/cmake-configure-tail.log
@@ -1,7 +1,7 @@
 -- Looking for dgemm_ - found
 -- Found BLAS: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework
 -- BLAS found, Libraries: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework
--- BLAS found, Includes: 
+-- BLAS found, Includes:
 -- Including BLAS backend
 -- Metal framework found
 -- Including METAL backend

--- a/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/eliza1-metal-generation.txt
+++ b/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/eliza1-metal-generation.txt
@@ -7,5 +7,3 @@ assistant
 
 The capital of France is **Paris**.
 > EOF by user
-
-

--- a/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/eliza1-metal-run-summary.log
+++ b/.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/eliza1-metal-run-summary.log
@@ -1,5 +1,5 @@
 # system_info (MTL backend compiled in)
-0.00.675.048 I system_info: n_threads = 12 (n_threads_batch = 12) / 16 | MTL : EMBED_LIBRARY = 1 | CPU : NEON = 1 | ARM_FMA = 1 | FP16_VA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | SME = 1 | ACCELERATE = 1 | REPACK = 1 | 
+0.00.675.048 I system_info: n_threads = 12 (n_threads_batch = 12) / 16 | MTL : EMBED_LIBRARY = 1 | CPU : NEON = 1 | ARM_FMA = 1 | FP16_VA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | SME = 1 | ACCELERATE = 1 | REPACK = 1 |
 
 # perf
 0.00.772.693 I common_perf_print:    sampling time =       3.27 ms


### PR DESCRIPTION
## Summary
- clean whitespace in the #11612 Metal nil-pipeline evidence logs already merged to `develop`
- makes `git diff --check` pass for the checked-in evidence files

## Validation
- `git diff --check` from the follow-up branch
- diff is limited to three files under `.github/issue-evidence/11612-ios-metal-null-pipeline/mac-metal-regression/`

## Notes
No runtime, submodule, UI, native code, or benchmark behavior changes. This only removes trailing whitespace / final blank-line noise from evidence artifacts.