### PR TITLE
ci(ui-e2e-gate): wire the two orphaned cloud e2e runners

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -143,6 +143,17 @@ jobs:
       - name: Proactive suggestions pipeline + UI e2e
         run: bun run --cwd packages/ui test:suggestions-e2e
 
+      # Frontend-hosting dashboard tab (#10690): real mock cloud stack
+      # publish → activate → rollback → delete lifecycle, desktop + mobile.
+      - name: Frontend hosting e2e
+        run: bun run --cwd packages/ui test:frontend-hosting-e2e
+
+      # Org Team Credential Pool tab (#11332/#11488): real mock cloud stack
+      # contribute (probe fail/pass) → masked list → toggle → invite/connect
+      # link → remove, desktop + mobile.
+      - name: Credentials e2e
+        run: bun run --cwd packages/ui test:credentials-e2e
+
       - name: Upload UI fixture e2e artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -163,5 +174,7 @@ jobs:
             packages/ui/src/components/pages/__e2e__/output-launcher
             packages/ui/src/components/pages/__e2e__/output-background
             packages/ui/src/components/pages/__e2e__/output-suggestions
+            packages/ui/src/cloud/applications/__e2e__/output-frontend-hosting
+            packages/ui/src/cloud/organization/__e2e__/output-credentials
           retention-days: 14
           if-no-files-found: ignore

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,8 @@
     "test:launcher-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-launcher-e2e.mjs",
     "test:connectors-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/__e2e__/run-connectors-e2e.mjs",
     "test:view-lifecycle-e2e": "bun run --cwd ../.. packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs",
+    "test:frontend-hosting-e2e": "bun run --cwd ../.. packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs",
+    "test:credentials-e2e": "bun run --cwd ../.. packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs",
     "lint": "bunx @biomejs/biome check src",
     "lint:fix": "bunx @biomejs/biome check --write src",
     "format": "bunx @biomejs/biome format src",


### PR DESCRIPTION
## Summary

Fixes a develop-red: `packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` (the ratchet ensuring every `packages/ui __e2e__` runner has a `package.json` script + CI leg) was FAILING 1/1 on pristine `origin/develop`, found while verifying the #11628 CI-coverage sweep.

Two runners landed with no wiring:
- `packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs` (#11488 org credentials tab)
- `packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs` (#10690 hosting work / #11425)

- Added `test:credentials-e2e` / `test:frontend-hosting-e2e` scripts to `packages/ui/package.json`, following the existing `test:<name>-e2e` convention.
- Added matching legs to `.github/workflows/ui-e2e-gate.yml`, after the existing runner legs, plus their output dirs to the artifact-upload path list. This workflow already triggers on `packages/ui/src/**` (#11628), so no path-filter changes were needed.

## Local runner results (real headless-Chromium runs, real mock cloud stack — PGlite + Hono + live key-probe stub)

- `bun run --cwd packages/ui test:frontend-hosting-e2e` → **ALL GREEN**. Publish → v1 live → v2 live → rollback confirm → rolled-back-to-v1 → delete confirm → after-delete, desktop + mobile, plus the cloud-inactive (502) → retry-recovers assertion. Orange-accent / darker-orange-hover / no-blue aesthetic assertions all passed.
- `bun run --cwd packages/ui test:credentials-e2e` → **ALL GREEN**. Empty state → contribute (probe FAIL then probe PASS) → masked list row → disable/enable toggle → invite & connect link → connect-link landing → remove-confirm → delete, desktop + mobile, with the same aesthetic assertions plus "plaintext key never appears in the DOM" and "server confirms pool is empty after remove".

Neither runner needed any fix — both were fully working, just CI-orphaned.

## Verification

- `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` → 1 pass / 0 fail (was failing on pristine develop before this change).
- `actionlint .github/workflows/ui-e2e-gate.yml` → clean.

## Test plan

- [x] Ratchet test passes locally
- [x] Both new runners executed locally end-to-end, ALL GREEN
- [x] actionlint clean on the modified workflow
- [ ] CI (rarely completes per repo convention; this local run is the merge gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)