### PR TITLE
fix(cloud): fail-closed last-resort inference pricing — uncatalogued model can never bill $0 (#11635)

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
@@ -12,8 +12,9 @@
  *   3. A provider with no catalogued entries falls back to the env-configured
  *      defaults AI_PRICING_FALLBACK_INPUT_USD_PER_M /
  *      AI_PRICING_FALLBACK_OUTPUT_USD_PER_M.
- *   4. With no catalog and no env default, the request stays servable at $0
- *      (last resort; covered in lookup-missing-pricing.test.ts as well).
+ *   4. With no catalog and no env default, the request stays servable at a
+ *      non-zero hardcoded frontier-max last resort — never $0 (#11635; also
+ *      covered in lookup-missing-pricing.test.ts).
  *   5. Reserve (estimated tokens) and settle (actual tokens) resolve the same
  *      fallback rate, so billing stays consistent across the request.
  */
@@ -178,7 +179,7 @@ test("env-configured default applies when the provider has no catalogued entries
   expect(result.totalCost).toBe(12.5 * 1.2);
 });
 
-test("invalid env default is ignored (falls through to $0 last resort)", async () => {
+test("invalid env default is ignored (falls through to the non-zero last resort, #11635)", async () => {
   process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "not-a-number";
   process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "-4";
 
@@ -189,10 +190,13 @@ test("invalid env default is ignored (falls through to $0 last resort)", async (
     outputTokens: 1_000,
   });
 
-  expect(result.totalCost).toBe(0);
+  // Invalid env is still ignored, but the last resort is now the hardcoded
+  // frontier-max rate, never $0 (#11635).
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeLessThan(0.1);
 });
 
-test("no catalog and no env default keeps the request servable at $0", async () => {
+test("no catalog and no env default keeps the request servable at a non-zero last resort (#11635)", async () => {
   const result = await calculateTextCostFromCatalog({
     model: "mystery-model-1",
     provider: "someprovider",
@@ -200,7 +204,8 @@ test("no catalog and no env default keeps the request servable at $0", async () 
     outputTokens: 1_000,
   });
 
-  expect(result.inputCost).toBe(0);
-  expect(result.outputCost).toBe(0);
-  expect(result.totalCost).toBe(0);
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeLessThan(0.1);
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
@@ -14,7 +14,9 @@
  * (`lastResortTokenUnitPrice`), keyed by product family, and still never throws.
  * (Provider-max / env-default tiers are covered in lookup-fallback-pricing.test.ts.)
  */
-import { expect, mock, test } from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
+
+const warnSpy = mock(() => {});
 
 mock.module("../../../db/repositories/ai-pricing", () => ({
   aiPricingRepository: {
@@ -22,11 +24,20 @@ mock.module("../../../db/repositories/ai-pricing", () => ({
     listActiveEntries: async () => [],
   },
 }));
+mock.module("../../utils/logger", () => ({
+  logger: {
+    warn: warnSpy,
+  },
+}));
 mock.module("./providers/gateway", () => ({
   fetchEntriesForSource: async () => [],
 }));
 
 const { calculateTextCostFromCatalog } = await import("./lookup");
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
 
 test("missing language pricing bills a non-zero last-resort rate, never $0 (#11635)", async () => {
   const result = await calculateTextCostFromCatalog({
@@ -42,6 +53,26 @@ test("missing language pricing bills a non-zero last-resort rate, never $0 (#116
   expect(result.outputCost).toBeGreaterThan(0);
   expect(result.totalCost).toBeGreaterThan(0);
   expect(result.totalCost).toBeLessThan(0.1); // sane: not an absurd rate
+  expect(warnSpy.mock.calls).toContainEqual([
+    "ai-pricing: input pricing unavailable; billing at fallback rate",
+    {
+      canonicalModel: "someprovider/totally-uncatalogued-model",
+      provider: "someprovider",
+      billingSource: undefined,
+      fallbackSource: "last_resort",
+      fallbackUnitPrice: 0.000005,
+    },
+  ]);
+  expect(warnSpy.mock.calls).toContainEqual([
+    "ai-pricing: output pricing unavailable; billing at fallback rate",
+    {
+      canonicalModel: "someprovider/totally-uncatalogued-model",
+      provider: "someprovider",
+      billingSource: undefined,
+      fallbackSource: "last_resort",
+      fallbackUnitPrice: 0.000025,
+    },
+  ]);
 });
 
 test("missing embedding pricing bills the cheaper embedding last-resort rate, non-zero (#11635)", async () => {

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
@@ -1,21 +1,18 @@
 /**
- * Regression: a missing INPUT price must degrade to $0, not throw a 500.
+ * Regression: a missing price must (1) NOT throw a 500 and (2) NEVER bill $0.
  *
- * `calculateTextCostFromCatalog` previously left the input-price lookup
- * unguarded while the output lookup was `.catch(() => null)`. A catalog miss on
- * the input row therefore threw `Pricing unavailable for language:input <model>`
- * uncaught, which propagated through `calculateCost` → the chat-completions
- * credit reserve → a 500 / masked "bridge unreachable". This is especially easy
- * to hit with embedding models (input-only, and embedded on every turn) or any
- * model whose input row simply isn't catalogued yet.
+ * `calculateTextCostFromCatalog` once left the input-price lookup unguarded, so
+ * a catalog miss threw `Pricing unavailable for language:input <model>` → a 500
+ * / masked "bridge unreachable". That was fixed by degrading a miss to a
+ * fallback rate — but the last-resort tier was `?? 0`, so a servable model with
+ * no catalog row AND no `AI_PRICING_FALLBACK_*` env default billed **$0** = free
+ * inference / uncollected revenue (#11635).
  *
  * Both seams (persisted repo + live gateway) are mocked empty so EVERY lookup
- * misses — the worst case. With no provider catalog entries and no
- * AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M env defaults, the last-resort
- * behavior bills the missing side at $0 instead of failing the request.
- * (When the provider HAS catalogued entries, or the env defaults are set, the
- * miss bills at a conservative fallback rate instead — covered in
- * lookup-fallback-pricing.test.ts.)
+ * misses — the worst case — and no env fallback is set, so the last-resort tier
+ * is exercised. Post-#11635 it bills a conservative non-zero frontier-max rate
+ * (`lastResortTokenUnitPrice`), keyed by product family, and still never throws.
+ * (Provider-max / env-default tiers are covered in lookup-fallback-pricing.test.ts.)
  */
 import { expect, mock, test } from "bun:test";
 
@@ -31,7 +28,7 @@ mock.module("./providers/gateway", () => ({
 
 const { calculateTextCostFromCatalog } = await import("./lookup");
 
-test("missing input pricing degrades to $0 instead of throwing a 500", async () => {
+test("missing language pricing bills a non-zero last-resort rate, never $0 (#11635)", async () => {
   const result = await calculateTextCostFromCatalog({
     model: "totally-uncatalogued-model",
     provider: "someprovider",
@@ -39,13 +36,15 @@ test("missing input pricing degrades to $0 instead of throwing a 500", async () 
     outputTokens: 500,
   });
 
-  // Before the fix this rejected with "Pricing unavailable for language:input …".
-  expect(result.inputCost).toBe(0);
-  expect(result.outputCost).toBe(0);
-  expect(result.totalCost).toBe(0);
+  // Never throws (the original 500-degradation) AND never $0 (the #11635 fix):
+  // 1000in@$5/M + 500out@$25/M ≈ $0.0175 base + markup — a small, sane amount.
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeLessThan(0.1); // sane: not an absurd rate
 });
 
-test("missing input pricing for an input-only embedding model does not throw", async () => {
+test("missing embedding pricing bills the cheaper embedding last-resort rate, non-zero (#11635)", async () => {
   const result = await calculateTextCostFromCatalog({
     model: "uncatalogued-embedding-model",
     provider: "someprovider",
@@ -53,6 +52,10 @@ test("missing input pricing for an input-only embedding model does not throw", a
     outputTokens: 0,
   });
 
-  expect(result.inputCost).toBe(0);
-  expect(result.totalCost).toBe(0);
+  // Non-zero (never free) but keyed to the embedding family ($0.2/M), so 800
+  // tokens is a tiny amount — proving the family keying picked the cheap rate,
+  // not the $5/M language default.
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeLessThan(0.001);
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -205,7 +205,7 @@ function lastResortTokenUnitPrice(
 
 type FallbackTokenRate = {
   unitPrice: number;
-  source: "provider_max_catalog" | "env_default";
+  source: "provider_max_catalog" | "env_default" | "last_resort";
   referenceModel?: string;
 };
 
@@ -219,9 +219,10 @@ type FallbackTokenRate = {
  * catalogued token rate for the same product family/charge type (an upper
  * bound over any plausible real price from that provider), or an
  * env-configured default (AI_PRICING_FALLBACK_{INPUT,OUTPUT}_USD_PER_M) when
- * the provider has no catalogued entries at all. Both reserve (pre-flight
- * estimate) and settle (actual usage) resolve through this same path, so both
- * sides of a request bill at the same rate.
+ * the provider has no catalogued entries at all, or a hardcoded last-resort
+ * rate when neither source exists. Both reserve (pre-flight estimate) and
+ * settle (actual usage) resolve through this same path, so both sides of a
+ * request bill at the same rate.
  */
 async function resolveFallbackTokenRate(params: {
   billingSource?: PricingBillingSource;
@@ -293,7 +294,10 @@ async function resolveFallbackTokenRate(params: {
     return { unitPrice: envUnitPrice, source: "env_default" };
   }
 
-  return null;
+  return {
+    unitPrice: lastResortTokenUnitPrice(params.productFamily, params.chargeType),
+    source: "last_resort",
+  };
 }
 
 function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): FlatOperationCost {
@@ -409,7 +413,7 @@ export async function calculateTextCostFromCatalog(params: {
       canonicalModel,
       provider: params.provider,
       billingSource: params.billingSource,
-      fallbackSource: fallback?.source ?? "none_zero",
+      fallbackSource: fallback?.source ?? "none",
       fallbackUnitPrice: fallback?.unitPrice ?? 0,
       ...(fallback?.referenceModel ? { fallbackReferenceModel: fallback.referenceModel } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -179,6 +179,30 @@ function envFallbackTokenUnitPrice(chargeType: "input" | "output"): number | nul
   return usdPerMillion / 1_000_000;
 }
 
+/**
+ * Fail-closed last-resort per-token rate (USD/token) for a servable but
+ * uncatalogued model with no provider-max catalog entry AND no env fallback
+ * (#11635). The request still serves — it just can never bill $0. Deliberately
+ * conservative (frontier-max) so an unpriced model over-bills rather than gives
+ * away free inference; a real catalog entry (cheaper) supersedes this on the
+ * next lookup, and the loud log points the catalog gap.
+ */
+const LAST_RESORT_USD_PER_MILLION: Partial<
+  Record<PricingProductFamily, { input: number; output: number }>
+> = {
+  language: { input: 5, output: 25 },
+  embedding: { input: 0.2, output: 0.2 },
+};
+const DEFAULT_LAST_RESORT_USD_PER_MILLION = { input: 5, output: 25 };
+
+function lastResortTokenUnitPrice(
+  productFamily: PricingProductFamily,
+  chargeType: "input" | "output",
+): number {
+  const family = LAST_RESORT_USD_PER_MILLION[productFamily] ?? DEFAULT_LAST_RESORT_USD_PER_MILLION;
+  return family[chargeType] / 1_000_000;
+}
+
 type FallbackTokenRate = {
   unitPrice: number;
   source: "provider_max_catalog" | "env_default";
@@ -345,9 +369,10 @@ export async function calculateTextCostFromCatalog(params: {
   // the catalog (notably embedding models, which are input-only and run every
   // turn). A servable request must never fail purely on a missing price — but
   // it must not be under-billed at $0 either. On a miss, bill the missing side
-  // at a conservative fallback rate (provider max → env default → $0 last
-  // resort; see resolveFallbackTokenRate) and log loudly so the catalog gap
-  // gets priced.
+  // at a conservative fallback rate (provider max → env default → a non-zero
+  // hardcoded frontier-max last resort, NEVER $0; see resolveFallbackTokenRate
+  // + lastResortTokenUnitPrice, #11635) and log loudly so the catalog gap gets
+  // priced.
   const inputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
@@ -398,10 +423,10 @@ export async function calculateTextCostFromCatalog(params: {
 
   const inputUnitPrice = inputEntry
     ? asDecimal(inputEntry.unitPrice)
-    : asDecimal(inputFallback?.unitPrice ?? 0);
+    : asDecimal(inputFallback?.unitPrice ?? lastResortTokenUnitPrice(productFamily, "input"));
   const outputUnitPrice = outputEntry
     ? asDecimal(outputEntry.unitPrice)
-    : asDecimal(outputFallback?.unitPrice ?? 0);
+    : asDecimal(outputFallback?.unitPrice ?? lastResortTokenUnitPrice(productFamily, "output"));
 
   const baseInputCost = inputUnitPrice.mul(params.inputTokens);
   const baseOutputCost = outputUnitPrice.mul(params.outputTokens);


### PR DESCRIPTION
Closes #11635. `[cloud-money]`

## Bug
The inference pricing fallback ladder is **provider-max → env-default → last-resort**. The last-resort tier was `?? 0` (`ai-pricing/lookup.ts`): a *servable* model with no catalog row **and** no `AI_PRICING_FALLBACK_*` env default billed **$0** on both reserve and settle → free inference / silently uncollected revenue. This contradicts the function's own comment ("must not be under-billed at $0 either").

## Fix
`lookup.ts`: a per-product-family `lastResortTokenUnitPrice` returning a conservative **frontier-max** rate (language $5/M in, $25/M out; embedding $0.2/M), keyed off the same `productFamily` used for the catalog lookup. Replaces the two `?? 0`. Fail-closed: the request still serves — it just can never bill $0; a real (cheaper) catalog entry supersedes it next lookup, and the existing loud log still flags the gap.

## Proof (red-before / green-after)
Both suites that *codified* the $0 behavior updated to assert non-zero + sane:
- `bun test src/lib/services/ai-pricing/lookup-missing-pricing.test.ts lookup-fallback-pricing.test.ts` → **green** with the fix.
- **Red without the fix:** stashing `lookup.ts` → the new `#11635` tests fail on `expect(inputCost).toBeGreaterThan(0)` (they bill $0). Confirmed.
- Embedding case asserts the cheaper family rate was chosen (< $0.001 for 800 tokens), proving the `productFamily` keying.
- `typecheck` exit 0; `biome check` clean on all 3 files.

**Note (not introduced here):** the 2 `fetchEntriesForSource provider-outage resilience` failures in this dir fail **identically on develop tip** (a gateway `mock.module` leak across sibling test files) — orthogonal to this change.

Money path — do not self-merge.