### PR TITLE
chore(app): sort iOS device test imports

### DIFF
--- a/packages/app/scripts/ios-device-lib.test.mjs
+++ b/packages/app/scripts/ios-device-lib.test.mjs
@@ -9,8 +9,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildCodesignPlan,
   buildPlistXml,
-  classifyConsoleExit,
   CONSOLE_SIGTRAP_SIGNATURE,
+  classifyConsoleExit,
   deriveSigningEntitlements,
   extractXctestrunAppPaths,
   findDeviceRecord,


### PR DESCRIPTION
## Summary

- Sorts the `ios-device-lib.test.mjs` import names in the order Biome expects.

## Why

Current `develop` fails `bun run verify` in `@elizaos/app#lint` on this file, which blocks unrelated rebased PR validation.

## Validation

- `bunx @biomejs/biome check packages/app/scripts/ios-device-lib.test.mjs`
- `bun run --cwd packages/app lint`
- `git diff --check`

## Evidence notes

No runtime, UI, model, native, or behavior change. This is a one-line lint hygiene fix for an existing test import list.
