### PR TITLE
fix(cloud): refund MCP proxy upfront debit on every post-debit failure, not just non-ok HTTP (#11637)

### DIFF
--- a/.github/issue-evidence/11637-mcp-proxy-refund.md
+++ b/.github/issue-evidence/11637-mcp-proxy-refund.md
@@ -1,0 +1,54 @@
+# Issue #11637: MCP Proxy Post-Debit Refunds
+
+PR: #11652
+Date: 2026-07-02
+
+## Scope
+
+The MCP metered proxy debits the caller before forwarding to the MCP endpoint.
+This fix refunds that upfront debit on every covered post-debit failure branch:
+
+- unsafe external endpoint
+- missing container load balancer
+- endpoint misconfiguration
+- invalid JSON request body
+- unreachable upstream / fetch failure
+- non-ok upstream response
+
+Successful upstream responses still keep the debit and record usage without a
+second deduction.
+
+## Verification
+
+```text
+bun test packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+=> 6 pass, 0 fail, 14 expect() calls
+```
+
+Expected coverage:
+
+- 502 unreachable upstream refunds once.
+- 400 unsafe endpoint refunds once.
+- 503 container unavailable refunds once.
+- 400 invalid JSON body refunds once.
+- non-ok upstream response refunds once.
+- successful upstream response does not refund.
+
+Additional static checks:
+
+```text
+bunx @biomejs/biome check .github/issue-evidence/11637-mcp-proxy-refund.md packages/cloud/api/mcp/proxy/[mcpId]/route.ts packages/cloud/api/__tests__/mcp-proxy-refund.test.ts --files-ignore-unknown=true
+=> clean
+
+git diff --check origin/develop...HEAD
+=> clean
+
+bun run --cwd packages/cloud/api typecheck
+=> passed
+```
+
+## N/A
+
+- UI screenshots/video: N/A - backend route money-path behavior only.
+- Live model trajectory: N/A - no model/prompt/action behavior changed.
+- Migration evidence: N/A - no schema or migration changed.

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression (#11637): the MCP metered proxy debits the caller upfront, so
+ * EVERY post-debit failure must refund — not only a non-ok HTTP status. Before
+ * the fix an unreachable upstream / unsafe endpoint / down container returned
+ * 502/400/503 while keeping the money = a silent over-charge.
+ *
+ * Drives the real route handler with mocked deps and asserts `refundCredits` is
+ * called on each failure branch and NOT on success. Red on develop tip (only
+ * the non-ok branch refunded); green after the fix.
+ */
+import { beforeEach, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+// mock.module is process-global — spread the real auth module so only
+// requireUserOrApiKeyWithOrg is overridden (mirrors agent-mcp-billing.test.ts).
+const requireUserOrApiKeyWithOrg = mock();
+const realAuth = await import("@/lib/auth/workers-hono-auth");
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const assertSafeOutboundUrl = mock();
+mock.module("@/lib/security/outbound-url", () => ({ assertSafeOutboundUrl }));
+
+const safeFetch = mock();
+mock.module("@/lib/security/safe-fetch", () => ({ safeFetch }));
+
+mock.module("@/lib/services/affiliates", () => ({
+  affiliatesService: { getReferrer: async () => null },
+}));
+
+const containersGetById = mock();
+mock.module("@/lib/services/containers", () => ({
+  containersService: { getById: containersGetById },
+}));
+
+const reserveAndDeductCredits = mock();
+const refundCredits = mock();
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { reserveAndDeductCredits, refundCredits },
+}));
+
+const getById = mock();
+mock.module("@/lib/services/user-mcps", () => ({
+  userMcpsService: {
+    getById,
+    recordUsageWithoutDeduction: mock(async () => {}),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
+}));
+
+const mcpRoute = (await import("../mcp/proxy/[mcpId]/route")).default;
+const app = new Hono();
+app.route("/:mcpId", mcpRoute);
+
+function post() {
+  return app.request("/test-mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ method: "tools/call", params: { name: "t" } }),
+  });
+}
+
+const EXTERNAL_MCP = {
+  id: "test-mcp",
+  name: "Test MCP",
+  status: "live",
+  credits_per_request: "5",
+  endpoint_type: "external",
+  external_endpoint: "https://mcp.example.test/rpc",
+  organization_id: "org1",
+};
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: "u1",
+    organization_id: "org1",
+  });
+  getById.mockResolvedValue({ ...EXTERNAL_MCP });
+  reserveAndDeductCredits.mockResolvedValue({
+    success: true,
+    transaction: { id: "tx1" },
+    newBalance: 95,
+  });
+  refundCredits.mockReset();
+  refundCredits.mockResolvedValue({ newBalance: 100 });
+  assertSafeOutboundUrl.mockResolvedValue(
+    new URL("https://mcp.example.test/rpc"),
+  );
+  safeFetch.mockReset();
+  containersGetById.mockReset();
+});
+
+test("unreachable upstream (502) refunds the upfront debit (#11637)", async () => {
+  safeFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+  const res = await post();
+  expect(res.status).toBe(502);
+  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
+  expect(refundCredits).toHaveBeenCalledTimes(1);
+});
+
+test("unsafe/blocked external endpoint (400) refunds (#11637)", async () => {
+  assertSafeOutboundUrl.mockRejectedValue(new Error("SSRF blocked"));
+  const res = await post();
+  expect(res.status).toBe(400);
+  expect(refundCredits).toHaveBeenCalledTimes(1);
+});
+
+test("container-unavailable (503) refunds (#11637)", async () => {
+  getById.mockResolvedValue({
+    id: "test-mcp",
+    name: "Container MCP",
+    status: "live",
+    credits_per_request: "5",
+    endpoint_type: "container",
+    container_id: "c1",
+    organization_id: "org1",
+  });
+  containersGetById.mockResolvedValue(null); // no load_balancer_url
+  const res = await post();
+  expect(res.status).toBe(503);
+  expect(refundCredits).toHaveBeenCalledTimes(1);
+});
+
+test("non-ok upstream status refunds (existing behavior preserved)", async () => {
+  safeFetch.mockResolvedValue(new Response("upstream error", { status: 500 }));
+  const res = await post();
+  expect(res.status).toBe(500);
+  expect(refundCredits).toHaveBeenCalledTimes(1);
+});
+
+test("successful call does NOT refund", async () => {
+  safeFetch.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  );
+  const res = await post();
+  expect(res.status).toBe(200);
+  expect(refundCredits).not.toHaveBeenCalled();
+});

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -57,11 +57,13 @@ const mcpRoute = (await import("../mcp/proxy/[mcpId]/route")).default;
 const app = new Hono();
 app.route("/:mcpId", mcpRoute);
 
-function post() {
+function post(
+  body = JSON.stringify({ method: "tools/call", params: { name: "t" } }),
+) {
   return app.request("/test-mcp", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ method: "tools/call", params: { name: "t" } }),
+    body,
   });
 }
 
@@ -81,6 +83,7 @@ beforeEach(() => {
     organization_id: "org1",
   });
   getById.mockResolvedValue({ ...EXTERNAL_MCP });
+  reserveAndDeductCredits.mockClear();
   reserveAndDeductCredits.mockResolvedValue({
     success: true,
     transaction: { id: "tx1" },
@@ -123,6 +126,13 @@ test("container-unavailable (503) refunds (#11637)", async () => {
   containersGetById.mockResolvedValue(null); // no load_balancer_url
   const res = await post();
   expect(res.status).toBe(503);
+  expect(refundCredits).toHaveBeenCalledTimes(1);
+});
+
+test("invalid JSON body (400) refunds after the upfront debit (#11637)", async () => {
+  const res = await post("{not json");
+  expect(res.status).toBe(400);
+  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
   expect(refundCredits).toHaveBeenCalledTimes(1);
 });
 

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -219,6 +219,35 @@ app.post("/", async (c) => {
     );
   }
 
+  // The caller was debited upfront; ANY post-debit failure (unsafe/misconfigured
+  // endpoint, unreachable upstream, container down, non-ok status) must return
+  // the money — otherwise a momentarily-down MCP silently over-charges the org
+  // (#11637). Refund on every failure branch, not only a non-ok HTTP status.
+  const refundPrecharge = async (
+    reason: string,
+    status?: number,
+  ): Promise<void> => {
+    await creditsService
+      .refundCredits({
+        organizationId: user.organization_id,
+        amount: totalCreditsRequired / CREDITS_PER_DOLLAR,
+        description: `MCP refund: ${mcp.name} (failed)`,
+        metadata: {
+          mcp_id: mcp.id,
+          reason,
+          ...(status !== undefined && { status }),
+        },
+      })
+      .catch((refundError: Error | string) => {
+        logger.error("[MCP Proxy] Failed to refund credits", {
+          mcpId,
+          reason,
+          error:
+            typeof refundError === "string" ? refundError : refundError.message,
+        });
+      });
+  };
+
   let targetUrl: string;
   // External (user-configured) endpoints are fetched through safeFetch below,
   // which re-validates AND pins the resolved IP for the actual request (closing
@@ -237,6 +266,7 @@ app.post("/", async (c) => {
         mcpId,
         error: error instanceof Error ? error.message : String(error),
       });
+      await refundPrecharge("unsafe_endpoint");
       return c.json({ error: "Unsafe external MCP endpoint" }, 400);
     }
     targetUrl = parsed.toString();
@@ -247,10 +277,12 @@ app.post("/", async (c) => {
       mcp.organization_id,
     );
     if (!container?.load_balancer_url) {
+      await refundPrecharge("container_unavailable");
       return c.json({ error: "MCP container not available" }, 503);
     }
     targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
   } else {
+    await refundPrecharge("endpoint_misconfigured");
     return c.json({ error: "MCP endpoint not configured" }, 500);
   }
 
@@ -295,6 +327,7 @@ app.post("/", async (c) => {
       targetUrl,
       error: error instanceof Error ? error.message : String(error),
     });
+    await refundPrecharge("upstream_unreachable");
     return c.json({ error: "Failed to reach MCP endpoint" }, 502);
   }
 
@@ -327,24 +360,7 @@ app.post("/", async (c) => {
         });
       });
   } else {
-    await creditsService
-      .refundCredits({
-        organizationId: user.organization_id,
-        amount: totalCreditsRequired / CREDITS_PER_DOLLAR,
-        description: `MCP refund: ${mcp.name} (failed)`,
-        metadata: {
-          mcp_id: mcp.id,
-          reason: "mcp_call_failed",
-          status: mcpResponse.status,
-        },
-      })
-      .catch((refundError: Error | string) => {
-        logger.error("[MCP Proxy] Failed to refund credits", {
-          mcpId,
-          error:
-            typeof refundError === "string" ? refundError : refundError.message,
-        });
-      });
+    await refundPrecharge("mcp_call_failed", mcpResponse.status);
   }
 
   const responseBody = await mcpResponse.text();

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -286,7 +286,17 @@ app.post("/", async (c) => {
     return c.json({ error: "MCP endpoint not configured" }, 500);
   }
 
-  const proxyBody = await parseJsonBody(c.req.raw);
+  let proxyBody: McpProxyJson;
+  try {
+    proxyBody = await parseJsonBody(c.req.raw);
+  } catch (error) {
+    logger.warn("[MCP Proxy] Invalid JSON request body", {
+      mcpId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await refundPrecharge("invalid_json");
+    return c.json({ error: "Invalid MCP request body" }, 400);
+  }
   const toolName = toolNameFromRpcBody(proxyBody);
 
   const proxyRequestInit: RequestInit = {


### PR DESCRIPTION
Closes #11637. `[cloud-money]`

## Bug (MED, money — user over-charged)
`mcp/proxy/[mcpId]/route.ts` debits the caller upfront (`reserveAndDeductCredits`) but only refunded on a **non-ok HTTP status**. Every other post-debit failure kept the money → a live external MCP that's momentarily down silently over-charges the org:
- unsafe/blocked external endpoint → 400
- container has no load balancer → 503
- endpoint misconfigured → 500
- upstream unreachable / DNS / connection-refused → 502

## Fix
A `refundPrecharge(reason, status?)` helper right after the debit, called on all four early-return failure branches; the non-ok HTTP branch now routes through the same helper. Refund = the exact upfront debit amount.

## Proof (red-before / green-after)
New `__tests__/mcp-proxy-refund.test.ts` drives the **real route** with mocked deps:
- `bun test __tests__/mcp-proxy-refund.test.ts` → **5/5 green** (refund fires on 502/400/503/non-ok; NOT on success).
- **Red without the fix:** stashing the route → the 3 new failure-path tests fail (refund never called). Confirmed.
- typecheck + biome clean.

Money path — do not self-merge.