### PR TITLE
ci(cloud-deploy): per-env deploy-job concurrency so prod deploys can't be cancelled mid-flight (#11640)

### DIFF
--- a/.github/issue-evidence/11640-cloud-deploy-job-concurrency.md
+++ b/.github/issue-evidence/11640-cloud-deploy-job-concurrency.md
@@ -1,0 +1,51 @@
+# Issue #11640: Cloud Deploy Job Concurrency
+
+PR: #11653
+Date: 2026-07-02
+
+## Scope
+
+`cloud-cf-deploy.yml` already serialized branch deploy workflow runs, but the
+individual deploy jobs still needed job-level groups so a production API Worker,
+Console, or App deploy cannot be cancelled mid-flight by a newer promote. This
+PR adds job-level concurrency to:
+
+- `deploy-api`
+- `deploy-console`
+- `deploy-app`
+
+The existing `migrate-db` job-level concurrency remains unchanged.
+
+## Validation
+
+```text
+python3 - <<'PY'
+import yaml
+from pathlib import Path
+data = yaml.safe_load(Path(".github/workflows/cloud-cf-deploy.yml").read_text())
+for name in ["migrate-db", "deploy-api", "deploy-console", "deploy-app"]:
+    concurrency = data["jobs"][name].get("concurrency")
+    print(name, concurrency)
+    if not concurrency:
+        raise SystemExit(f"{name} missing concurrency")
+PY
+```
+
+Confirmed:
+
+- `migrate-db`: `cloud-db-migrate-<production|staging>`, `cancel-in-progress: false`
+- `deploy-api`: `cloud-cf-deploy-api-<production|staging>`, `cancel-in-progress: false`
+- `deploy-console`: `cloud-cf-deploy-console-<pr-N|production|staging>`, PR previews cancel in progress, branch deploys do not
+- `deploy-app`: `cloud-cf-deploy-app-<pr-N|production|staging>`, PR previews cancel in progress, branch deploys do not
+
+```text
+git diff --check origin/develop...HEAD
+=> clean
+```
+
+## N/A
+
+- Local workflow execution: N/A - GitHub Actions deployment concurrency cannot be faithfully executed locally.
+- UI screenshots/video: N/A - workflow-only deploy behavior.
+- Live model trajectory: N/A - no model, prompt, or agent behavior changed.
+- Migration evidence: N/A - no schema or migration changed.

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -179,6 +179,15 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
+    # A production Worker deploy must never be cancelled mid-flight by a newer
+    # main promote (#11640): the workflow-level group did not protect the
+    # in-flight job, so rapid promotes cancelled every Worker deploy and prod
+    # ran stale code. Job-level concurrency groups are repo-wide, so a per-env
+    # group with cancel-in-progress:false serializes deploys ACROSS runs (queue,
+    # never cancel) — same protection migrate-db already has.
+    concurrency:
+      group: cloud-cf-deploy-api-${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
+      cancel-in-progress: false
     # Keep the deploy fleet configurable while Cloud ops converges on the
     # reliable runner pool. Set CLOUD_CF_DEPLOY_RUNNER_JSON to a JSON runs-on
     # array such as ["self-hosted","Linux","X64","hetzner-robot"] to use the
@@ -495,6 +504,12 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-console:
     name: Deploy Console (Pages · elizacloud.ai)
+    # Per-env (or per-PR) job concurrency so a newer main promote queues behind
+    # the in-flight prod Pages deploy instead of cancelling it (#11640); PR
+    # previews keep a per-PR group that DOES dedupe (cancel-in-progress).
+    concurrency:
+      group: cloud-cf-deploy-console-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # Keep the deploy fleet configurable while Cloud ops converges on the
     # reliable runner pool. Set CLOUD_CF_DEPLOY_RUNNER_JSON to a JSON runs-on
     # array such as ["self-hosted","Linux","X64","hetzner-robot"] to use the
@@ -850,6 +865,12 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
+    # Per-env (or per-PR) job concurrency so a newer main promote queues behind
+    # the in-flight prod Pages deploy instead of cancelling it (#11640); PR
+    # previews keep a per-PR group that DOES dedupe (cancel-in-progress).
+    concurrency:
+      group: cloud-cf-deploy-app-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging') }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     # Keep the deploy fleet configurable while Cloud ops converges on the
     # reliable runner pool. Set CLOUD_CF_DEPLOY_RUNNER_JSON to a JSON runs-on
     # array such as ["self-hosted","Linux","X64","hetzner-robot"] to use the


### PR DESCRIPTION
Closes #11640. `[cloud-money]` / deploy lane.

## Bug (launch-critical)
`migrate-db` has a job-level `cloud-db-migrate-<env>` concurrency group (`cancel-in-progress:false`), but **the deploy jobs don't** — they inherited only the workflow-level group, which didn't protect the in-flight job. With rapid develop→main promotes, every newer main run preempted the running **Deploy API Worker** job → **no Worker deploy completed since 19:13Z**, so prod ran stale code (only Pages/console updated). Evidence on the issue: `Deploy API Worker` cancelled on 854455dd + 1fb1c538×2.

## Fix
Per-job, per-env `concurrency` (job-level groups are repo-wide → serialize the same job across runs, queue never cancel):
- `deploy-api` → `cloud-cf-deploy-api-<production|staging>`, `cancel-in-progress:false`
- `deploy-console` / `deploy-app` → `…-<pr-N|production|staging>`, `cancel-in-progress` only for PR previews

Distinct group per job so the three deploys still parallelize within a run; PR previews still dedupe.

## Verification
Can't run a workflow locally, so: **YAML validated** (`yaml.safe_load` parses; all 4 jobs carry `concurrency`), groups confirmed distinct per job, and the pattern mirrors the already-working `migrate-db` protection + the workflow-level env resolution. Prove-out is the next promote completing a Worker deploy.

Touches the multi-agent-contested `cloud-cf-deploy.yml` — flagging rather than self-merging; resolve any conflict to develop's version. cc @standujar (deploy/ops)