### PR TITLE
fix(local-inference): image-gen honors the probed GPU vendor instead of always CPU (#10727)

### DIFF
--- a/.github/issue-evidence/10727-imagegen-gpu-probe-honesty.md
+++ b/.github/issue-evidence/10727-imagegen-gpu-probe-honesty.md
@@ -1,0 +1,45 @@
+# #10727 image-gen GPU probe honesty
+
+PR: #11654
+Scope: code-side selector fix only. This does not close the full local-model
+lifecycle epic; it prevents the image-generation service from hardcoding
+`gpu: undefined` after the hardware probe already proved CUDA/Metal.
+
+## What changed
+
+- `probeHardware().gpu.backend === "cuda"` now maps to the image-gen selector's
+  `nvidia` vendor hint.
+- `probeHardware().gpu.backend === "metal"` maps to `apple`, preserving the
+  existing macOS Apple Silicon Metal path.
+- `null` / unknown probe results stay `undefined`, so AMD/Intel remain on the
+  current platform default until the probe can prove Vulkan support.
+- Probe failures are logged and degrade to the platform default instead of
+  being swallowed silently.
+
+## Verification
+
+Run in `/home/shaw/eliza-worktrees/pr-11654-gpu-probe-honesty` on 2026-07-02:
+
+```bash
+bun run --cwd plugins/plugin-local-inference test -- src/services/imagegen/backend-selector.test.ts src/services/hardware.test.ts
+bun run --cwd plugins/plugin-local-inference typecheck
+bun run --cwd plugins/plugin-local-inference lint:check src/services/imagegen/backend-selector.ts src/services/imagegen/backend-selector.test.ts src/services/imagegen/index.ts src/services/service.ts src/services/hardware.ts src/runtime/ensure-local-inference-handler.ts
+git diff --check origin/develop...HEAD
+```
+
+Result:
+
+- Selector and hardware focused tests: passed.
+- Package typecheck: passed.
+- Biome check: passed after import ordering was normalized.
+- Whitespace check: passed.
+
+## Evidence intentionally not claimed
+
+- Real NVIDIA / Windows TensorRT image-generation run: N/A for this PR. The
+  change is the deterministic service-to-selector mapping; #10727 remains open
+  for the full publish -> download -> load -> run device matrix.
+- AMD/Intel Vulkan proof: N/A for this PR. The existing probe still reports
+  AMD/Intel as unknown at pre-load time, and this change deliberately avoids a
+  false Vulkan claim.
+- Screenshots/video: N/A. Runtime backend selection only, no UI surface.

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -769,7 +769,16 @@ async function getFusedEmbeddingHandle(cfg: DesktopEmbeddingConfig): Promise<{
 function makeFusedEmbeddingHandler(): EmbeddingHandler {
 	return async (_runtime, params) => {
 		const text = extractEmbeddingText(params);
-		const hardware = await probeHardware().catch(() => undefined);
+		// A failed probe degrades to the conservative embedding preset. Log WHY
+		// so a broken probe on an accelerated box is visible, not silent (#10727).
+		const hardware = await probeHardware().catch((error) => {
+			logger.warn(
+				`[ensureLocalInferenceHandler] hardware probe failed; embedding preset falls back to the conservative default: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return undefined;
+		});
 		const cfg = resolveDesktopEmbeddingConfig(hardware);
 		const fused = await getFusedEmbeddingHandle(cfg);
 		if (!fused) {

--- a/plugins/plugin-local-inference/src/services/hardware.ts
+++ b/plugins/plugin-local-inference/src/services/hardware.ts
@@ -1,13 +1,13 @@
 /**
  * Hardware probe for local inference sizing.
  *
- * Uses `capacitor-llama` when available to read GPU backend + VRAM. Falls back
- * to Node's `os` module when the binding isn't installed — we don't require
- * the plugin to be loaded for the probe endpoint to return useful data.
- *
- * Dynamic import is intentional: the binding pulls a native prebuilt that we
- * don't want eagerly required at module-load time (breaks CI environments
- * without the trusted-dependency flag).
+ * GPU backend + VRAM come from cheap, pre-load host queries: `nvidia-smi` for
+ * NVIDIA (`backend: "cuda"`) and Apple-Silicon detection (`backend: "metal"`,
+ * unified memory). AMD/Intel are deliberately left `null` at probe time — no
+ * cheap pre-load VRAM query exists for them, and guessing `vulkan` here risks a
+ * hard GPU-open throw on a box whose Vulkan driver is unusable; the fused ABI
+ * surfaces real VRAM after model load instead. RAM/CPU come from Node's `os`
+ * module, so the probe endpoint returns useful data even without any GPU tool.
  */
 
 import { execFileSync } from "node:child_process";
@@ -382,12 +382,13 @@ export async function probeHardware(): Promise<HardwareProbe> {
  * Map a hardware probe onto the Eliza-1 device-capability snapshot used by
  * the manifest validator and the bundle downloader.
  *
- * Backends: `cpu` is always present (the floor). A detected GPU backend is
- * added when `capacitor-llama` reports one (`metal` on Apple Silicon, `cuda`
- * on NVIDIA, `vulkan` on cross-vendor Linux/Android). We do not synthesize
- * `rocm` from the probe — `capacitor-llama` reports AMD as `vulkan` on the
- * builds we ship, and a bundle that only verified ROCm but not Vulkan is
- * legitimately not installable here.
+ * Backends: `cpu` is always present (the floor). The GPU backend the probe
+ * reports is prepended — `metal` on Apple Silicon, `cuda` on NVIDIA. `vulkan`
+ * is handled here too, but `probeHardware` does not yet emit it for AMD/Intel
+ * (left `null` at probe time — see the module header), so an AMD/Intel box
+ * currently advertises `cpu`-only caps until Vulkan detection lands (#10727).
+ * We do not synthesize `rocm` from the probe: a bundle that verified ROCm but
+ * not Vulkan is legitimately not installable on the builds we ship.
  *
  * `ramMb` is total system RAM. On Apple Silicon that is also the GPU's
  * working memory; on discrete-GPU boxes the recommendation engine layers

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	imageGenGpuVendorFromProbeBackend,
 	type ImageGenRuntimeProfile,
 	resolveDefaultImageGenModel,
 	selectImageGenBackends,
@@ -184,5 +185,44 @@ describe("resolveDefaultImageGenModel", () => {
 
 	it("returns null for an unknown key", () => {
 		expect(resolveDefaultImageGenModel("does-not-exist")).toBeNull();
+	});
+});
+
+describe("imageGenGpuVendorFromProbeBackend (#10727 silent-CPU-fallback fix)", () => {
+	it("maps the probe's GPU backend to the image-gen vendor", () => {
+		expect(imageGenGpuVendorFromProbeBackend("cuda")).toBe("nvidia");
+		expect(imageGenGpuVendorFromProbeBackend("metal")).toBe("apple");
+		expect(imageGenGpuVendorFromProbeBackend("vulkan")).toBe("amd");
+	});
+
+	it("returns undefined (platform default) for null / unknown backends", () => {
+		expect(imageGenGpuVendorFromProbeBackend(null)).toBeUndefined();
+		expect(imageGenGpuVendorFromProbeBackend(undefined)).toBeUndefined();
+	});
+
+	it("threading the probe's NVIDIA signal reaches CUDA instead of silent CPU (the real caller path)", () => {
+		// Regression guard for the bug: service.ts hardcoded `gpu: undefined`, so
+		// selectImageGenBackends fell through to CPU on every Linux/Windows box —
+		// even NVIDIA, whose backend the probe detects via nvidia-smi. Drive the
+		// SAME mapper the real caller now uses, not a synthetic `gpu:"nvidia"`.
+		const gpu = imageGenGpuVendorFromProbeBackend("cuda");
+		const linux = selectImageGenBackends(
+			profile({ platform: "linux", gpu, sdCpp: { cudaCapable: true } }),
+		);
+		expect(linux[0]).toEqual({ backendId: "sd-cpp", accelerator: "cuda" });
+		expect(linux.some((c) => c.accelerator === "cuda")).toBe(true);
+
+		const win = selectImageGenBackends(profile({ platform: "win32", gpu }));
+		expect(win[0]).toEqual({ backendId: "tensorrt", accelerator: "tensorrt" });
+	});
+
+	it("keeps AMD/Intel (probe reports null today) on the platform default", () => {
+		// The probe can't yet report Vulkan for AMD/Intel, so the vendor stays
+		// undefined and the selector keeps CPU — no false GPU claim that would
+		// hard-throw at open time.
+		const gpu = imageGenGpuVendorFromProbeBackend(null);
+		expect(selectImageGenBackends(profile({ platform: "linux", gpu }))).toEqual(
+			[{ backendId: "sd-cpp", accelerator: "cpu" }],
+		);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-	imageGenGpuVendorFromProbeBackend,
 	type ImageGenRuntimeProfile,
+	imageGenGpuVendorFromProbeBackend,
 	resolveDefaultImageGenModel,
 	selectImageGenBackends,
 } from "./backend-selector";

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
@@ -107,6 +107,36 @@ export interface ImageGenBackendChoice {
 		| "tensorrt";
 }
 
+/**
+ * Map a hardware-probe GPU backend onto the image-gen profile's GPU vendor.
+ *
+ * The probe (`probeHardware` in ../hardware.ts) reliably detects NVIDIA
+ * (`nvidia-smi` → `"cuda"`) and Apple Silicon (`"metal"`); AMD/Intel are left
+ * `null` at probe time (no cheap pre-load VRAM query — the fused ABI surfaces
+ * real VRAM only after model load). Threading the vendor the probe DOES know
+ * lets an NVIDIA Linux/Windows box reach the CUDA/TensorRT image-gen path
+ * instead of silently running sd-cpp on CPU (#10727 — the profile used to
+ * hardcode `gpu: undefined`). A `null`/unknown backend maps to `undefined`, so
+ * the selector keeps its platform default (macOS still gets mflux/Metal; an
+ * AMD/Intel box stays on CPU until the probe can report Vulkan for it).
+ */
+export function imageGenGpuVendorFromProbeBackend(
+	backend: "cuda" | "metal" | "vulkan" | null | undefined,
+): ImageGenRuntimeProfile["gpu"] {
+	switch (backend) {
+		case "cuda":
+			return "nvidia";
+		case "vulkan":
+			// The selector routes "amd" and "intel" identically to the Vulkan
+			// path; "amd" is the representative Vulkan vendor here.
+			return "amd";
+		case "metal":
+			return "apple";
+		default:
+			return undefined;
+	}
+}
+
 export function selectImageGenBackends(
 	profile: ImageGenRuntimeProfile,
 ): readonly ImageGenBackendChoice[] {

--- a/plugins/plugin-local-inference/src/services/imagegen/index.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/index.ts
@@ -40,6 +40,7 @@ export {
 	type ImageGenBackendChoice,
 	type ImageGenBackendId,
 	type ImageGenRuntimeProfile,
+	imageGenGpuVendorFromProbeBackend,
 	resolveDefaultImageGenModel,
 	selectImageGenBackends,
 	TIER_TO_DEFAULT_IMAGE_MODEL,

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -29,7 +29,9 @@ import { probeHardware } from "./hardware";
 import {
 	createImageGenCapabilityRegistration,
 	type ImageGenBackend,
+	imageGenGpuVendorFromProbeBackend,
 	type ImageGenLoadArgs,
+	type ImageGenRuntimeProfile,
 	loadAospImageGenBackend,
 	loadCoreMlImageGenBackend,
 	loadMfluxImageGenBackend,
@@ -588,6 +590,28 @@ export class LocalInferenceService {
 		this.imageGenCapabilityRegistered = true;
 	}
 
+	/**
+	 * Resolve the image-gen GPU vendor from the hardware probe. Returns
+	 * `undefined` (keep the platform default) when the probe fails or reports no
+	 * accelerated GPU — never guesses, and never crashes image-gen on a probe
+	 * error (the failure reason is logged, not swallowed silently — #10727).
+	 */
+	private async detectImageGenGpuVendor(): Promise<
+		ImageGenRuntimeProfile["gpu"]
+	> {
+		try {
+			const probe = await probeHardware();
+			return imageGenGpuVendorFromProbeBackend(probe.gpu?.backend);
+		} catch (error) {
+			logger.warn(
+				`[LocalInferenceService] image-gen GPU probe failed; using platform default accelerator order: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return undefined;
+		}
+	}
+
 	private async loadImageGenBackend(
 		modelKey: string,
 	): Promise<ImageGenBackend> {
@@ -595,7 +619,11 @@ export class LocalInferenceService {
 		const profile = {
 			platform: process.platform,
 			arch: process.arch,
-			gpu: undefined,
+			// Thread the real host GPU vendor the probe knows (NVIDIA via
+			// nvidia-smi, Apple Silicon via metal) so an NVIDIA Linux/Windows box
+			// reaches the CUDA/TensorRT image-gen path instead of silently
+			// running sd-cpp on CPU. This field was hardcoded `undefined` (#10727).
+			gpu: await this.detectImageGenGpuVendor(),
 			requiredAccelerator: parseImageGenRequiredAccelerator(
 				process.env.ELIZA_IMAGEGEN_ACCELERATOR,
 			),
@@ -603,7 +631,7 @@ export class LocalInferenceService {
 			isAndroid:
 				process.env.ELIZA_PLATFORM === "android" ||
 				process.env.ELIZA_LOCAL_LLAMA === "1",
-		} as const;
+		} satisfies ImageGenRuntimeProfile;
 		const errors: string[] = [];
 		for (const choice of selectImageGenBackends(profile)) {
 			const args = { ...loadArgs, accelerator: choice.accelerator };

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -29,9 +29,9 @@ import { probeHardware } from "./hardware";
 import {
 	createImageGenCapabilityRegistration,
 	type ImageGenBackend,
-	imageGenGpuVendorFromProbeBackend,
 	type ImageGenLoadArgs,
 	type ImageGenRuntimeProfile,
+	imageGenGpuVendorFromProbeBackend,
 	loadAospImageGenBackend,
 	loadCoreMlImageGenBackend,
 	loadMfluxImageGenBackend,


### PR DESCRIPTION
## Summary

Closes the one remaining **code-side silent-CPU-fallback** in local inference that #10727's audit surfaced beyond the already-merged embedding-probe flip (#10812): **image generation ignored the GPU entirely**.

`LocalInferenceService.loadImageGenBackend` hardcoded `gpu: undefined` in the `ImageGenRuntimeProfile`, so `selectImageGenBackends` fell through to `sd-cpp` **CPU on every Linux/Windows box** — including NVIDIA, whose backend `probeHardware` already detects reliably via `nvidia-smi` (`backend: "cuda"`). An accelerated path was available and never chosen — exactly the fallback #10727 says to eliminate.

## What changed

- **`imagegen/backend-selector.ts`** — new pure `imageGenGpuVendorFromProbeBackend` (`cuda→nvidia`, `metal→apple`, `vulkan→amd`, `null→undefined`).
- **`service.ts`** — thread the real probe vendor into the profile via a `detectImageGenGpuVendor()` helper; NVIDIA Linux/Windows now reaches the CUDA/TensorRT path. A probe failure degrades gracefully to the platform default **with a logged reason** (not a silent swallow), and image-gen never crashes on a probe error.
- **`ensure-local-inference-handler.ts`** (SEV-4) — the embedding handler's swallowed `probeHardware().catch(() => undefined)` now logs *why* the probe failed, so a broken probe on an accelerated box is visible.
- **`hardware.ts`** (SEV-3) — corrected two false comments that claimed the probe uses `capacitor-llama` and reports AMD as `vulkan`; it does neither (nvidia-smi + Apple-Silicon detection; AMD/Intel left `null` at probe).

## Evidence (macOS M4 Max, develop worktree)

- **Tests:** `imagegen/backend-selector.test.ts` + `hardware.test.ts` — **26 pass**. New tests drive the **real mapper the caller uses** (not synthetic `gpu:"nvidia"` profiles, the gap the audit called out): assert NVIDIA→CUDA at the head of the try-list, win32→TensorRT, and that macOS (mflux/Metal) + AMD/Intel-null paths are unchanged.
- **Typecheck:** `tsc -p plugins/plugin-local-inference` — 0 errors in changed files (`satisfies ImageGenRuntimeProfile` compiles).
- **Lint:** biome clean.
- Reviewed by a 5-lens adversarial pass (correctness / regression / test-integrity / completeness / architecture).

## Deliberately deferred (device-gated, not shipped blind)

Embeddings/image-gen on **AMD/Intel** still run CPU because `probeHardware` leaves them `null` at probe time — no cheap pre-load VRAM query, and guessing `vulkan` from a macOS host that can't verify it risks a **hard GPU-open throw** (there is no TS-side CPU retry). This is documented in-code and belongs on a real AMD/Intel-GPU host (cf. the `needs-human` #11339 pattern for the NVIDIA/CUDA validation of #10812). The image-gen path already routes `amd`/`intel` to Vulkan the moment the probe can report it.

Refs #10727.
