### PR TITLE
fix(cloud): reject zero pricing fallback env

### DIFF
--- a/.github/issue-evidence/11635-fallback-zero-env.md
+++ b/.github/issue-evidence/11635-fallback-zero-env.md
@@ -1,0 +1,28 @@
+# #11635 fallback zero-env follow-up
+
+Follow-up after #11647 merged the non-zero last-resort fallback for uncatalogued inference pricing.
+
+## Residual fixed
+
+`AI_PRICING_FALLBACK_INPUT_USD_PER_M=0` or `AI_PRICING_FALLBACK_OUTPUT_USD_PER_M=0` was still accepted as a configured fallback, which could turn an operator typo into $0 billing again. Zero is now treated as invalid/unset, so the hardcoded non-zero last-resort rate applies.
+
+## Local validation
+
+```text
+bun test packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+9 pass / 0 fail
+```
+
+```text
+bunx @biomejs/biome@2.5.2 check packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+Checked 3 files. No fixes applied.
+```
+
+```text
+git diff --check origin/develop...HEAD
+clean
+```
+
+## Evidence notes
+
+No screenshots or screen recording: this is backend pricing logic with no UI surface. The focused regression test exercises the real cost calculation path and asserts the zero-env case still bills non-zero.

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts
@@ -196,6 +196,23 @@ test("invalid env default is ignored (falls through to the non-zero last resort,
   expect(result.totalCost).toBeLessThan(0.1);
 });
 
+test("zero env default is ignored so it cannot reopen $0 free inference (#11635)", async () => {
+  process.env.AI_PRICING_FALLBACK_INPUT_USD_PER_M = "0";
+  process.env.AI_PRICING_FALLBACK_OUTPUT_USD_PER_M = "0";
+
+  const result = await calculateTextCostFromCatalog({
+    model: "mystery-model-1",
+    provider: "someprovider",
+    inputTokens: 1_000,
+    outputTokens: 1_000,
+  });
+
+  expect(result.inputCost).toBeGreaterThan(0);
+  expect(result.outputCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeGreaterThan(0);
+  expect(result.totalCost).toBeLessThan(0.1);
+});
+
 test("no catalog and no env default keeps the request servable at a non-zero last resort (#11635)", async () => {
   const result = await calculateTextCostFromCatalog({
     model: "mystery-model-1",

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -169,7 +169,7 @@ function envFallbackTokenUnitPrice(chargeType: "input" | "output"): number | nul
     return null;
   }
   const usdPerMillion = Number(raw);
-  if (!Number.isFinite(usdPerMillion) || usdPerMillion < 0) {
+  if (!Number.isFinite(usdPerMillion) || usdPerMillion <= 0) {
     logger.warn("ai-pricing: ignoring invalid fallback-rate env value", {
       envName,
       value: raw,


### PR DESCRIPTION
Follow-up for #11635 after #11647 merged the non-zero last-resort fallback.

## Residual
`AI_PRICING_FALLBACK_INPUT_USD_PER_M=0` or `AI_PRICING_FALLBACK_OUTPUT_USD_PER_M=0` was still treated as a valid configured fallback. That means an operator typo could bypass the new last-resort floor and bill a missing token side at $0 again.

## Fix
Treat zero the same as other invalid fallback env values (`<= 0`), so the existing hardcoded non-zero last-resort rate applies.

## Evidence
- `bun test packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts` -> 9 pass / 0 fail.
- `bunx @biomejs/biome@2.5.2 check packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-fallback-pricing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts` -> clean.
- `git diff --check origin/develop...HEAD` -> clean.
- Evidence note: `.github/issue-evidence/11635-fallback-zero-env.md`.

Screenshots/video/log walkthrough: N/A, backend pricing logic only; regression test exercises the real calculation path.