### PR TITLE
test(app): fix 4 first-run e2e specs left red by #11509's runtime-chip removal

### DIFF
--- a/packages/app/test/ui-smoke/first-run-startup.spec.ts
+++ b/packages/app/test/ui-smoke/first-run-startup.spec.ts
@@ -48,8 +48,9 @@ async function captureFirstRunRestoreEvidence(page: Page): Promise<void> {
 }
 
 // A full-capability host (real API base + Electrobun window marker) so the local
-// finish path would be reachable; the in-chat conductor seeds the same three
-// runtime choices (Cloud / On this device / Bring your own keys) regardless.
+// finish path would be reachable; the in-chat conductor seeds the same two
+// runtime choices (Cloud / On this device) regardless ("Bring your own keys" is
+// a provider sub-choice, not a runtime location — removed as a chip in #11509).
 async function injectFullCapabilityHost(page: Page): Promise<void> {
   await page.addInitScript(() => {
     (window as unknown as Record<string, unknown>).__ELIZA_APP_API_BASE__ =
@@ -116,10 +117,12 @@ test("in-chat first-run renders without a render loop and lets the runtime be ch
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
   const local = page.getByTestId("choice-__first_run__:runtime:local");
-  const other = page.getByTestId("choice-__first_run__:runtime:other");
   await expect(cloud).toBeVisible({ timeout: 15_000 });
   await expect(local).toBeVisible();
-  await expect(other).toBeVisible();
+  // The old runtime:other ("Bring your own keys") chip was removed in #11509.
+  await expect(
+    page.getByTestId("choice-__first_run__:runtime:other"),
+  ).toHaveCount(0);
 
   // Local advances to the provider step (on-device vs Eliza Cloud vs other) —
   // the re-render churn on the newer step that previously froze.

--- a/packages/app/test/ui-smoke/runtime-configurability.spec.ts
+++ b/packages/app/test/ui-smoke/runtime-configurability.spec.ts
@@ -8,9 +8,11 @@ import {
 
 // "Local, Cloud, etc. all work out of the box and are successfully
 // configurable." Runtime/provider setup now lives in the chat transcript:
-// Cloud (Eliza Cloud managed), Local (this device), and Bring your own keys.
-// This spec drives Local → provider to prove every runtime is reachable and
-// configurable, not just displayed.
+// Cloud (Eliza Cloud managed) and Local (this device). "Bring your own keys" is
+// NOT a runtime location — it is a provider sub-choice one step later
+// (provider:other), reached after picking Local (removed as a runtime chip in
+// #11509). This spec drives Local → provider to prove every runtime is reachable
+// and configurable, not just displayed.
 
 async function fulfillJson(
   route: Route,
@@ -70,7 +72,7 @@ async function expectInChatFirstRun(page: Page): Promise<void> {
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
 }
 
-test("in-chat first-run exposes cloud, local, and bring-your-own-keys runtimes and Local is configurable", async ({
+test("in-chat first-run exposes cloud and local runtimes and Local is configurable", async ({
   page,
 }) => {
   await installRenderTelemetryGuard(page);
@@ -85,10 +87,14 @@ test("in-chat first-run exposes cloud, local, and bring-your-own-keys runtimes a
 
   const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
   const local = page.getByTestId("choice-__first_run__:runtime:local");
-  const other = page.getByTestId("choice-__first_run__:runtime:other");
   await expect(cloud).toBeVisible({ timeout: 15_000 });
   await expect(local).toBeVisible();
-  await expect(other).toBeVisible();
+  // Only Cloud and Local are runtime locations (#11509). The old third chip
+  // (runtime:other = "Bring your own keys") was removed — it conflated the
+  // inference-provider axis with the location axis. BYOK lives one step down.
+  await expect(
+    page.getByTestId("choice-__first_run__:runtime:other"),
+  ).toHaveCount(0);
 
   // Local is configurable: selecting it advances to the provider step,
   // where the on-device default, Eliza Cloud inference, and other are offered.

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -838,26 +838,26 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "onboarding-runtime",
     title: "Onboarding runtime choice",
     expectation:
-      "The chat transcript asks how the agent should run, with Eliza Cloud, on-device, and bring-your-own-keys options.",
+      "The chat transcript asks how the agent should run, with Eliza Cloud and on-device options (Bring your own keys is a provider sub-choice, not a location — #11509).",
     async run({ page }) {
       await expect(
         page.getByText("First, where should your agent run?", { exact: false }),
       ).toBeVisible({ timeout: 15_000 });
       const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
       const local = page.getByTestId("choice-__first_run__:runtime:local");
-      const other = page.getByTestId("choice-__first_run__:runtime:other");
       await expect(cloud).toBeVisible();
       await expect(local).toBeVisible();
-      await expect(other).toBeVisible();
+      await expect(
+        page.getByTestId("choice-__first_run__:runtime:other"),
+      ).toHaveCount(0);
       return {
         assertions: [
-          "Runtime question visible (Eliza Cloud vs local vs own keys)",
-          "runtime cloud / local / other choices all visible",
+          "Runtime question visible (Eliza Cloud vs local)",
+          "runtime cloud / local choices visible; no runtime:other chip",
         ],
         dom: await domMarkers(page, {
           cloud: '[data-testid="choice-__first_run__:runtime:cloud"]',
           local: '[data-testid="choice-__first_run__:runtime:local"]',
-          other: '[data-testid="choice-__first_run__:runtime:other"]',
         }),
       };
     },

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -198,9 +198,10 @@ test.describe("walkthrough capture smoke", () => {
     await expect(
       page.getByTestId("choice-__first_run__:runtime:local"),
     ).toBeVisible();
+    // runtime:other ("Bring your own keys") was removed as a location in #11509.
     await expect(
       page.getByTestId("choice-__first_run__:runtime:other"),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await captureState(page, testInfo, "walkthrough-01-onboarding.png");
 
     firstRun.setComplete(true);

--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -7,7 +7,9 @@ and standalone runtime chooser are no longer part of the shipped UI.
 The current first-run flow is seeded by `use-first-run-conductor.ts` as inline
 chat choices:
 
-- `choice-__first_run__:runtime:{cloud|local|other}`
+- `choice-__first_run__:runtime:{cloud|local}` (the runtime location is a clean
+  two-option chooser as of #11509; "Bring your own keys" is not a location — it
+  lives on the provider axis below. Remote lives in Settings → Runtime post-#9952.)
 - `choice-__first_run__:provider:{on-device|elizacloud|other}`
 - `choice-__first_run__:tutorial:{start|skip}`
 


### PR DESCRIPTION
## What

PR #11509 ("clean two-option onboarding chooser", commit `d534de09f3`) removed the third runtime chip — `runtime:other` = **"Bring your own keys"** — from the in-chat first-run conductor, because it put an inference-provider concept on the runtime-**location** axis. But four `packages/app/test/ui-smoke` specs still assert that chip is **visible**, so they are **guaranteed-red on develop**:

- `runtime-configurability.spec.ts`
- `first-run-startup.spec.ts`
- `walkthrough/walkthrough-capture-smoke.spec.ts`
- `walkthrough/journey.ts` (journey step 02, `onboarding-runtime`)

Each now asserts the chip is **absent** (`toHaveCount(0)`) instead of visible. Stale header/expectation comments and the option list in `IN_CHAT_ONBOARDING_DESIGN.md` are corrected to the shipped **Cloud / Local** chooser.

## Why it's correct

The live conductor seeds only two runtime chips — `use-first-run-conductor.ts:108-113`:
```
runtime:cloud=Eliza Cloud (managed)
runtime:local=On this device
```
BYOK stays reachable one step later as `provider:other` ("Other / configure in Settings"). The handler at `use-first-run-conductor.ts:480` rejects any runtime id other than `cloud|local`, and the **unit** tests already assert a stale `runtime:other` pick is consumed as a no-op (`use-first-run-conductor.test.ts:294`, `.fuzz.test.ts:157`) — those are correct and left unchanged. This PR only aligns the **e2e visibility** assertions with that shipped behavior.

## Testing

- `biome check` clean on all 4 touched specs.
- Grep confirms no remaining `toBeVisible()` / locator on `choice-__first_run__:runtime:other` anywhere in `test/ui-smoke`; the only remaining references are the new `toHaveCount(0)` absence checks and the correct no-op unit tests.
- Full Playwright `test:e2e` run: **N/A in this environment** (needs a full app build + browser); the change is a pure test-assertion alignment to already-merged #11509 behavior, and the assertion now matches the conductor source cited above. Reviewer CI exercises the specs.

## Context

Surfaced by an on-device onboarding review: a Pixel 6a running a build from before #11509 merged still shows the old three-option chooser ("Bring your own keys"), which is a stale-build artifact — the fix is on develop but these specs were left red behind it.

Refs #11509

🤖 Generated with [Claude Code](https://claude.com/claude-code)