### PR TITLE
feat(core): vendor-neutral model-gateway config (ELIZA_MODEL_GATEWAY_URL/TOKEN) with fail-closed strict mode (#11536 E1)

### DIFF
--- a/packages/core/src/features/documents/config.ts
+++ b/packages/core/src/features/documents/config.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { applyModelGateway, resolveModelGateway } from "../../model-gateway.ts";
 import type { IAgentRuntime } from "../../types";
 import {
 	type ModelConfig,
@@ -67,7 +68,20 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 				: getSetting("OPENAI_EMBEDDING_DIMENSIONS")) ||
 			(resolvedEmbeddingProvider === "local" ? "384" : "1536");
 
-		const openaiApiKey = getSetting("OPENAI_API_KEY");
+		const rawOpenaiApiKey = getSetting("OPENAI_API_KEY");
+		const rawOpenaiBaseURL = getSetting("OPENAI_BASE_URL");
+
+		// Vendor-neutral model-gateway (#11536 E1): when ELIZA_MODEL_GATEWAY_URL is
+		// set it takes precedence at the same layer that consumes OPENAI_BASE_URL /
+		// OPENAI_API_KEY, so every OpenAI-compatible client (llm.ts embed + text)
+		// inherits gateway mode. Strict mode throws if a raw provider key is present
+		// while gateway mode is on. When gateway mode is on the raw OpenAI key is
+		// scrubbed so it never travels to the gateway.
+		const gateway = resolveModelGateway(getSetting);
+		const { baseURL: openaiBaseURL, apiKey: openaiApiKey } = applyModelGateway(
+			{ baseURL: rawOpenaiBaseURL, apiKey: rawOpenaiApiKey },
+			gateway,
+		);
 
 		const config = ModelConfigSchema.parse({
 			EMBEDDING_PROVIDER: resolvedEmbeddingProvider,
@@ -78,7 +92,7 @@ export function validateModelConfig(runtime?: IAgentRuntime): ModelConfig {
 			OPENROUTER_API_KEY: getSetting("OPENROUTER_API_KEY"),
 			GOOGLE_API_KEY: getSetting("GOOGLE_API_KEY"),
 
-			OPENAI_BASE_URL: getSetting("OPENAI_BASE_URL"),
+			OPENAI_BASE_URL: openaiBaseURL,
 			ANTHROPIC_BASE_URL: getSetting("ANTHROPIC_BASE_URL"),
 			OPENROUTER_BASE_URL: getSetting("OPENROUTER_BASE_URL"),
 			GOOGLE_BASE_URL: getSetting("GOOGLE_BASE_URL"),

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -35,9 +35,6 @@ export * from "./entities";
 // and exported from both barrels. @elizaos/shared re-exports it from the core
 // barrel so browser consumers resolve the same canonical truthy set.
 export * from "./env-utils";
-// Vendor-neutral model-gateway resolution (#11536 E1). Pure string logic, no
-// Node deps, so it is browser-safe and exported from both barrels.
-export * from "./model-gateway";
 export * from "./features/advanced-memory";
 export { AutonomyService } from "./features/autonomy/index";
 export {
@@ -87,6 +84,9 @@ export * from "./lifeops-passive-connectors";
 export * from "./logger";
 export * from "./memory";
 export * from "./messaging/interactions";
+// Vendor-neutral model-gateway resolution (#11536 E1). Pure string logic, no
+// Node deps, so it is browser-safe and exported from both barrels.
+export * from "./model-gateway";
 export * from "./prompts";
 export * from "./roles";
 export * from "./runtime";

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -35,6 +35,9 @@ export * from "./entities";
 // and exported from both barrels. @elizaos/shared re-exports it from the core
 // barrel so browser consumers resolve the same canonical truthy set.
 export * from "./env-utils";
+// Vendor-neutral model-gateway resolution (#11536 E1). Pure string logic, no
+// Node deps, so it is browser-safe and exported from both barrels.
+export * from "./model-gateway";
 export * from "./features/advanced-memory";
 export { AutonomyService } from "./features/autonomy/index";
 export {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -64,6 +64,7 @@ export * from "./database";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 export * from "./env-utils";
+export * from "./model-gateway";
 export {
 	roleAction,
 	updateRoleAction,

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -64,7 +64,6 @@ export * from "./database";
 export * from "./database/inMemoryAdapter";
 export * from "./entities";
 export * from "./env-utils";
-export * from "./model-gateway";
 export {
 	roleAction,
 	updateRoleAction,
@@ -157,6 +156,7 @@ export * from "./media";
 export * from "./memory";
 export * from "./messaging/interactions";
 export * from "./mobile-device-bridge-hooks";
+export * from "./model-gateway";
 // Export network utilities (SSRF protection, secure fetch)
 export * from "./network";
 export { getOptimizationRootDir } from "./optimization-root-dir";

--- a/packages/core/src/model-gateway.test.ts
+++ b/packages/core/src/model-gateway.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyModelGateway,
+	ELIZA_MODEL_GATEWAY_STRICT,
+	ELIZA_MODEL_GATEWAY_TOKEN,
+	ELIZA_MODEL_GATEWAY_URL,
+	MODEL_GATEWAY_STRICT_KEY,
+	MODEL_GATEWAY_TOKEN_KEY,
+	MODEL_GATEWAY_URL_KEY,
+	ModelGatewayStrictError,
+	resolveModelGateway,
+} from "./model-gateway.ts";
+
+/**
+ * Build a getSetting accessor over a plain record so tests never touch
+ * process.env. resolveModelGateway only cares about the string values it reads
+ * back, matching the runtime getSetting contract.
+ */
+function settingsFrom(
+	values: Record<string, string | undefined>,
+): (key: string) => string | undefined {
+	return (key: string) => values[key];
+}
+
+describe("canonical env var names (shared contract with E2 sibling #11651)", () => {
+	// The env var NAMES are the cross-layer contract shared with
+	// plugins/plugin-agent-orchestrator/src/services/model-gateway.ts. They must
+	// stay exactly these strings so both the core-runtime layer (here) and the
+	// spawned-sub-agent layer resolve the same variables.
+	it("pins the canonical env var strings", () => {
+		expect(MODEL_GATEWAY_URL_KEY).toBe("ELIZA_MODEL_GATEWAY_URL");
+		expect(MODEL_GATEWAY_TOKEN_KEY).toBe("ELIZA_MODEL_GATEWAY_TOKEN");
+		expect(MODEL_GATEWAY_STRICT_KEY).toBe("ELIZA_MODEL_GATEWAY_STRICT");
+	});
+
+	it("keeps the backwards-compatible aliases pointing at the canonical names", () => {
+		expect(ELIZA_MODEL_GATEWAY_URL).toBe(MODEL_GATEWAY_URL_KEY);
+		expect(ELIZA_MODEL_GATEWAY_TOKEN).toBe(MODEL_GATEWAY_TOKEN_KEY);
+		expect(ELIZA_MODEL_GATEWAY_STRICT).toBe(MODEL_GATEWAY_STRICT_KEY);
+	});
+});
+
+describe("resolveModelGateway", () => {
+	it("is disabled and inert when no gateway URL is set", () => {
+		const resolution = resolveModelGateway(settingsFrom({}));
+		expect(resolution.enabled).toBe(false);
+		expect(resolution.strict).toBe(false);
+		expect(resolution.baseURL).toBeUndefined();
+		expect(resolution.apiKey).toBeUndefined();
+	});
+
+	it("treats a blank/whitespace gateway URL as unset (disabled)", () => {
+		const resolution = resolveModelGateway(
+			settingsFrom({ [ELIZA_MODEL_GATEWAY_URL]: "   " }),
+		);
+		expect(resolution.enabled).toBe(false);
+		expect(resolution.baseURL).toBeUndefined();
+	});
+
+	describe("gateway URL / token precedence", () => {
+		it("makes the gateway URL the effective base URL and gateway token the effective api key", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+					[ELIZA_MODEL_GATEWAY_TOKEN]: "agent-scoped-token",
+				}),
+			);
+			expect(resolution.enabled).toBe(true);
+			expect(resolution.baseURL).toBe("https://broker.example/v1");
+			expect(resolution.apiKey).toBe("agent-scoped-token");
+		});
+
+		it("trims surrounding whitespace on URL and token", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_URL]: "  https://broker.example/v1  ",
+					[ELIZA_MODEL_GATEWAY_TOKEN]: "  tok  ",
+				}),
+			);
+			expect(resolution.baseURL).toBe("https://broker.example/v1");
+			expect(resolution.apiKey).toBe("tok");
+		});
+
+		it("overrides raw OPENAI_BASE_URL / OPENAI_API_KEY at the same resolution layer", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					OPENAI_BASE_URL: "https://api.openai.com/v1",
+					OPENAI_API_KEY: "sk-raw-should-not-win",
+					[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+					[ELIZA_MODEL_GATEWAY_TOKEN]: "gw-token",
+				}),
+			);
+			const applied = applyModelGateway(
+				{
+					baseURL: "https://api.openai.com/v1",
+					apiKey: "sk-raw-should-not-win",
+				},
+				resolution,
+			);
+			expect(applied.baseURL).toBe("https://broker.example/v1");
+			expect(applied.apiKey).toBe("gw-token");
+		});
+
+		it("gateway with no token yields an undefined effective api key (gateway may inject upstream itself)", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+				}),
+			);
+			expect(resolution.enabled).toBe(true);
+			expect(resolution.apiKey).toBeUndefined();
+		});
+	});
+
+	describe("strict mode fail-closed", () => {
+		it("throws ModelGatewayStrictError naming the offending var when a raw provider key is present", () => {
+			const call = () =>
+				resolveModelGateway(
+					settingsFrom({
+						[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+						[ELIZA_MODEL_GATEWAY_STRICT]: "1",
+						OPENAI_API_KEY: "sk-leaked",
+					}),
+				);
+			expect(call).toThrow(ModelGatewayStrictError);
+			expect(call).toThrow(/OPENAI_API_KEY/);
+			expect(call).toThrow(new RegExp(ELIZA_MODEL_GATEWAY_STRICT));
+		});
+
+		it("names every offending raw provider key", () => {
+			let error: ModelGatewayStrictError | undefined;
+			try {
+				resolveModelGateway(
+					settingsFrom({
+						[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+						[ELIZA_MODEL_GATEWAY_STRICT]: "true",
+						OPENAI_API_KEY: "sk-leaked",
+						ANTHROPIC_API_KEY: "sk-ant-leaked",
+					}),
+				);
+			} catch (caught) {
+				error = caught as ModelGatewayStrictError;
+			}
+			expect(error).toBeInstanceOf(ModelGatewayStrictError);
+			expect(error?.offendingVars).toEqual([
+				"OPENAI_API_KEY",
+				"ANTHROPIC_API_KEY",
+			]);
+			expect(error?.message).toContain("OPENAI_API_KEY");
+			expect(error?.message).toContain("ANTHROPIC_API_KEY");
+		});
+
+		it("does not throw in strict mode when no raw provider keys are present", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+					[ELIZA_MODEL_GATEWAY_TOKEN]: "gw-token",
+					[ELIZA_MODEL_GATEWAY_STRICT]: "1",
+				}),
+			);
+			expect(resolution.enabled).toBe(true);
+			expect(resolution.strict).toBe(true);
+			expect(resolution.baseURL).toBe("https://broker.example/v1");
+			expect(resolution.apiKey).toBe("gw-token");
+		});
+
+		it("does NOT fail closed when strict mode is on but gateway mode is off", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_STRICT]: "1",
+					OPENAI_API_KEY: "sk-raw",
+				}),
+			);
+			// No gateway URL => not gateway mode => strict has nothing to enforce.
+			expect(resolution.enabled).toBe(false);
+			expect(resolution.strict).toBe(true);
+		});
+
+		it("non-strict: gateway silently wins even when a raw provider key is present (no throw)", () => {
+			const resolution = resolveModelGateway(
+				settingsFrom({
+					[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+					[ELIZA_MODEL_GATEWAY_TOKEN]: "gw-token",
+					OPENAI_API_KEY: "sk-raw-still-present",
+				}),
+			);
+			expect(resolution.enabled).toBe(true);
+			expect(resolution.strict).toBe(false);
+			expect(resolution.baseURL).toBe("https://broker.example/v1");
+			expect(resolution.apiKey).toBe("gw-token");
+		});
+	});
+});
+
+describe("applyModelGateway (scrubber)", () => {
+	it("passes raw creds through unchanged when gateway mode is off", () => {
+		const resolution = resolveModelGateway(settingsFrom({}));
+		const applied = applyModelGateway(
+			{ baseURL: "https://api.openai.com/v1", apiKey: "sk-raw" },
+			resolution,
+		);
+		expect(applied.baseURL).toBe("https://api.openai.com/v1");
+		expect(applied.apiKey).toBe("sk-raw");
+	});
+
+	it("SCRUBS the raw provider key when gateway mode is on (resolved config carries no raw key material)", () => {
+		const resolution = resolveModelGateway(
+			settingsFrom({
+				[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+				[ELIZA_MODEL_GATEWAY_TOKEN]: "gw-token",
+			}),
+		);
+		const applied = applyModelGateway(
+			{ baseURL: "https://api.openai.com/v1", apiKey: "sk-raw-secret" },
+			resolution,
+		);
+		// Base URL is the gateway; api key is the gateway token, never the raw key.
+		expect(applied.baseURL).toBe("https://broker.example/v1");
+		expect(applied.apiKey).toBe("gw-token");
+		expect(applied.apiKey).not.toBe("sk-raw-secret");
+		// Exhaustively confirm no raw key material survives anywhere in the pair.
+		expect(JSON.stringify(applied)).not.toContain("sk-raw-secret");
+	});
+
+	it("scrubs the raw key even when the gateway has no token (api key becomes undefined, never the raw key)", () => {
+		const resolution = resolveModelGateway(
+			settingsFrom({
+				[ELIZA_MODEL_GATEWAY_URL]: "https://broker.example/v1",
+			}),
+		);
+		const applied = applyModelGateway(
+			{ baseURL: "https://api.openai.com/v1", apiKey: "sk-raw-secret" },
+			resolution,
+		);
+		expect(applied.apiKey).toBeUndefined();
+		expect(JSON.stringify(applied)).not.toContain("sk-raw-secret");
+	});
+
+	it("falls back to the raw base URL only when the gateway resolution omits one (defensive)", () => {
+		// applyModelGateway prefers resolution.baseURL; when enabled it is always
+		// defined, but the ?? fallback keeps callers safe if that ever changes.
+		const applied = applyModelGateway(
+			{ baseURL: "https://api.openai.com/v1", apiKey: "sk-raw" },
+			{
+				enabled: true,
+				strict: false,
+				baseURL: undefined,
+				apiKey: "gw-token",
+			},
+		);
+		expect(applied.baseURL).toBe("https://api.openai.com/v1");
+		expect(applied.apiKey).toBe("gw-token");
+		expect(applied.apiKey).not.toBe("sk-raw");
+	});
+});

--- a/packages/core/src/model-gateway.ts
+++ b/packages/core/src/model-gateway.ts
@@ -1,0 +1,210 @@
+/**
+ * Vendor-neutral model-gateway resolution (issue #11536, phase E1).
+ *
+ * A credential broker can front all OpenAI-compatible model traffic behind a
+ * single gateway so that raw provider keys never reach the model client. When
+ * `ELIZA_MODEL_GATEWAY_URL` is set it takes precedence as the effective base
+ * URL for every consumer that currently reads `OPENAI_BASE_URL`, and
+ * `ELIZA_MODEL_GATEWAY_TOKEN` becomes the effective api key in place of
+ * `OPENAI_API_KEY`. This is deliberately vendor-neutral: the gateway only has
+ * to be OpenAI-compatible, it is NOT bound to any specific broker.
+ *
+ * Two behaviours matter for security:
+ *
+ * 1. When gateway mode is on, raw provider keys are SCRUBBED from the resolved
+ *    OpenAI-compatible client config rather than carried alongside the gateway
+ *    token. A gateway that receives a request should never also be handed the
+ *    upstream key.
+ * 2. In strict mode (`ELIZA_MODEL_GATEWAY_STRICT` truthy) the presence of any
+ *    raw provider key is treated as a misconfiguration and we FAIL CLOSED with
+ *    an error naming the offending variable. This prevents an operator from
+ *    silently bypassing the broker by leaving a raw key in the environment.
+ *
+ * Pure string logic with no Node-only dependencies, so it is safe in the
+ * browser bundle and exported from both the node and browser barrels.
+ *
+ * SIBLING LAYER (#11536 E2): plugins/plugin-agent-orchestrator/src/services/
+ * model-gateway.ts (PR #11651, merged) covers the SPAWNED SUB-AGENT env path
+ * (rewrites a child process env so Codex/Claude-Code point at the gateway).
+ * This module is the CORE-RUNTIME resolution layer (documents config, llm.ts,
+ * inference-provider) and is intentionally independent: packages/core must not
+ * depend on a plugin, so the two shared env-var-name constants are DUPLICATED
+ * here on purpose rather than imported. The env var NAMES are the canonical
+ * contract shared across both layers and MUST stay identical.
+ */
+
+import { isTruthyEnvValue } from "./env-utils.ts";
+
+/**
+ * Vendor-neutral gateway env var: the OpenAI-compatible base URL that fronts
+ * all model traffic when broker/gateway mode is enabled.
+ *
+ * Canonical name mirrors `MODEL_GATEWAY_URL_KEY` in the sibling E2 module
+ * (plugins/plugin-agent-orchestrator, #11651) for cross-layer greppability.
+ * Duplicated (not imported) to keep the packages/core -> plugin dependency
+ * direction clean.
+ */
+export const MODEL_GATEWAY_URL_KEY = "ELIZA_MODEL_GATEWAY_URL";
+
+/**
+ * Vendor-neutral gateway env var: the agent-scoped bearer token the gateway
+ * expects. An unmodified OpenAI SDK sends this as the api key.
+ *
+ * Canonical name mirrors `MODEL_GATEWAY_TOKEN_KEY` in the sibling E2 module.
+ */
+export const MODEL_GATEWAY_TOKEN_KEY = "ELIZA_MODEL_GATEWAY_TOKEN";
+
+/**
+ * Fail-closed strict-mode env var (E1-only; the E2 sub-agent module has no
+ * strict mode). When truthy, refuse to run if a raw provider key is present
+ * while gateway mode is on.
+ */
+export const MODEL_GATEWAY_STRICT_KEY = "ELIZA_MODEL_GATEWAY_STRICT";
+
+/**
+ * Backwards-compatible aliases (kept so existing importers/tests keep working).
+ * Prefer the `*_KEY` names above, which mirror the sibling E2 module (#11651).
+ */
+export const ELIZA_MODEL_GATEWAY_URL = MODEL_GATEWAY_URL_KEY;
+export const ELIZA_MODEL_GATEWAY_TOKEN = MODEL_GATEWAY_TOKEN_KEY;
+export const ELIZA_MODEL_GATEWAY_STRICT = MODEL_GATEWAY_STRICT_KEY;
+
+/**
+ * Raw provider keys that must never coexist with the gateway token when
+ * strict mode is on, and that are scrubbed from OpenAI-compatible client
+ * config when gateway mode is on. Kept small and explicit on purpose.
+ *
+ * This is the CORE-RUNTIME subset relevant to the OpenAI-compatible client
+ * paths here. The sibling E2 module maintains a broader
+ * `MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS` list (#11651) because a spawned
+ * sub-agent env can carry additional credential sources (CODEX_API_KEY,
+ * CLAUDE_CODE_OAUTH_TOKEN, ELIZA_-prefixed keys, etc.) that don't apply to the
+ * in-process model client resolved here.
+ */
+export const RAW_PROVIDER_KEY_VARS = [
+	"OPENAI_API_KEY",
+	"ANTHROPIC_API_KEY",
+] as const;
+
+export type RawProviderKeyVar = (typeof RAW_PROVIDER_KEY_VARS)[number];
+
+/**
+ * Minimal accessor shape. Callers pass their existing setting resolver (which
+ * may layer runtime settings over `process.env`) so gateway resolution honours
+ * the exact same precedence as the raw vars it replaces.
+ */
+export type GetSettingFn = (key: string) => string | undefined;
+
+export interface ModelGatewayResolution {
+	/** Whether gateway mode is active (i.e. a gateway URL was provided). */
+	enabled: boolean;
+	/** Whether strict fail-closed mode is enabled. */
+	strict: boolean;
+	/** Effective base URL for OpenAI-compatible clients (undefined = unchanged). */
+	baseURL: string | undefined;
+	/** Effective api key for OpenAI-compatible clients (undefined = unchanged). */
+	apiKey: string | undefined;
+}
+
+const trimToUndefined = (value: string | undefined): string | undefined => {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/**
+ * Error thrown when strict gateway mode detects a raw provider key that would
+ * bypass the broker. Named so callers can distinguish it from generic config
+ * errors if they want to.
+ */
+export class ModelGatewayStrictError extends Error {
+	readonly offendingVars: RawProviderKeyVar[];
+
+	constructor(offendingVars: RawProviderKeyVar[]) {
+		super(
+			`Model gateway strict mode is enabled (${ELIZA_MODEL_GATEWAY_STRICT}) ` +
+				`but raw provider key(s) are set: ${offendingVars.join(", ")}. ` +
+				`Remove them so all model traffic flows through the gateway ` +
+				`(${ELIZA_MODEL_GATEWAY_URL}/${ELIZA_MODEL_GATEWAY_TOKEN}), ` +
+				`or disable strict mode.`,
+		);
+		this.name = "ModelGatewayStrictError";
+		this.offendingVars = offendingVars;
+	}
+}
+
+/**
+ * Resolve model-gateway settings from a getSetting accessor.
+ *
+ * @throws ModelGatewayStrictError when strict mode is on, gateway mode is on,
+ *   and one or more raw provider keys are present.
+ */
+export function resolveModelGateway(
+	getSetting: GetSettingFn,
+): ModelGatewayResolution {
+	const gatewayURL = trimToUndefined(getSetting(ELIZA_MODEL_GATEWAY_URL));
+	const gatewayToken = trimToUndefined(getSetting(ELIZA_MODEL_GATEWAY_TOKEN));
+	const strict = isTruthyEnvValue(getSetting(ELIZA_MODEL_GATEWAY_STRICT));
+	const enabled = gatewayURL !== undefined;
+
+	if (!enabled) {
+		return {
+			enabled: false,
+			strict,
+			baseURL: undefined,
+			apiKey: undefined,
+		};
+	}
+
+	if (strict) {
+		const offendingVars = RAW_PROVIDER_KEY_VARS.filter(
+			(key) => trimToUndefined(getSetting(key)) !== undefined,
+		);
+		if (offendingVars.length > 0) {
+			throw new ModelGatewayStrictError([...offendingVars]);
+		}
+	}
+
+	return {
+		enabled: true,
+		strict,
+		baseURL: gatewayURL,
+		// When gateway mode is on, the gateway token (if any) is the effective
+		// api key. Raw provider keys are intentionally NOT used here.
+		apiKey: gatewayToken,
+	};
+}
+
+/**
+ * Shape of an OpenAI-compatible base URL + api key pair, as consumed by the
+ * resolved model config.
+ */
+export interface OpenAiCompatibleCreds {
+	baseURL: string | undefined;
+	apiKey: string | undefined;
+}
+
+/**
+ * Apply gateway resolution to a raw OpenAI-compatible base URL / api key pair.
+ *
+ * When gateway mode is on:
+ *   - the gateway URL overrides the base URL,
+ *   - the gateway token overrides the api key,
+ *   - the incoming raw api key is scrubbed (dropped) so it never travels with
+ *     the gateway request.
+ *
+ * When gateway mode is off, the inputs are returned unchanged.
+ */
+export function applyModelGateway(
+	raw: OpenAiCompatibleCreds,
+	resolution: ModelGatewayResolution,
+): OpenAiCompatibleCreds {
+	if (!resolution.enabled) {
+		return { baseURL: raw.baseURL, apiKey: raw.apiKey };
+	}
+	return {
+		baseURL: resolution.baseURL ?? raw.baseURL,
+		// Scrub the raw provider key: gateway mode never carries it forward.
+		apiKey: resolution.apiKey,
+	};
+}

--- a/packages/core/src/testing/inference-provider.ts
+++ b/packages/core/src/testing/inference-provider.ts
@@ -7,6 +7,7 @@
 
 import z from "zod";
 import { logger } from "../logger";
+import { resolveModelGateway } from "../model-gateway.ts";
 
 /** Default Ollama endpoint */
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
@@ -92,10 +93,33 @@ function checkCloudProvider(
 	);
 
 	if (matchedEnvVar) {
-		const endpoint =
-			config.name === "openai" && matchedEnvVar === "CEREBRAS_API_KEY"
-				? process.env.OPENAI_BASE_URL?.trim() || CEREBRAS_OPENAI_BASE_URL
-				: config.endpoint;
+		// Vendor-neutral model-gateway (#11536 E1): when gateway mode is on, the
+		// OpenAI-compatible endpoint is the gateway URL, matching the resolution
+		// layer that config.ts applies to OPENAI_BASE_URL for the real runtime.
+		// This is a detector, not the runtime: authoritative fail-closed strict
+		// enforcement lives in features/documents/config.ts. Here we only want the
+		// gateway URL as the effective endpoint, so a strict-mode throw (raw key
+		// present) must not crash provider detection.
+		let gatewayBaseURL: string | undefined;
+		try {
+			gatewayBaseURL = resolveModelGateway((key) => process.env[key]).baseURL;
+		} catch {
+			// Strict-mode misconfig surfaces at the real runtime resolution layer;
+			// fall back to the gateway URL directly for detection purposes.
+			gatewayBaseURL = process.env.ELIZA_MODEL_GATEWAY_URL?.trim() || undefined;
+		}
+		let endpoint: string;
+		if (config.name === "openai" && gatewayBaseURL) {
+			endpoint = gatewayBaseURL;
+		} else if (
+			config.name === "openai" &&
+			matchedEnvVar === "CEREBRAS_API_KEY"
+		) {
+			endpoint =
+				process.env.OPENAI_BASE_URL?.trim() || CEREBRAS_OPENAI_BASE_URL;
+		} else {
+			endpoint = config.endpoint;
+		}
 		return {
 			name: config.name,
 			available: true,


### PR DESCRIPTION
## What

Implements phase **E1** of #11536: a vendor-neutral model-gateway config layer so a single OpenAI-compatible gateway (credential broker) can front all model traffic, and raw provider keys never reach the model client.

## Sibling layer (E2)

**PR #11651 (merged)** landed the E2 slice under `plugins/plugin-agent-orchestrator/src/services/model-gateway.ts` — the **spawned sub-agent env** path (rewrites a child process env so Codex/Claude-Code point at the gateway). This PR is the complementary **core-runtime resolution layer** (documents config → `llm.ts`, inference-provider) — the paths #11651 leaves untouched.

The two layers share the canonical **env-var-name contract** (`ELIZA_MODEL_GATEWAY_URL` / `ELIZA_MODEL_GATEWAY_TOKEN`). This module mirrors #11651's exported constant names (`MODEL_GATEWAY_URL_KEY` / `MODEL_GATEWAY_TOKEN_KEY`) for cross-layer greppability but **duplicates rather than imports** them — `packages/core` must not depend on a plugin (dependency direction). A test pins the shared strings so the contract can't drift.

## How

New `packages/core/src/model-gateway.ts`:

- **Precedence at the same layer as the raw vars.** `ELIZA_MODEL_GATEWAY_URL` takes precedence as the effective base URL and `ELIZA_MODEL_GATEWAY_TOKEN` as the effective api key at the exact resolution point that consumes `OPENAI_BASE_URL` / `OPENAI_API_KEY`. Every OpenAI-compatible client inherits gateway mode automatically. Vendor-neutral: the gateway only has to be OpenAI-compatible.
- **Scrubber.** When gateway mode is on, the raw provider key is dropped from the resolved OpenAI-compatible config so it never travels alongside the gateway token.
- **Fail-closed strict mode** (E1-only; the E2 sub-agent module has no strict mode). `ELIZA_MODEL_GATEWAY_STRICT=1` + a raw provider key present while gateway mode is on → hard error (`ModelGatewayStrictError`) naming the offending variable. Non-strict: gateway silently wins.

### Choke points wired
- `packages/core/src/features/documents/config.ts` — applies gateway resolution to the resolved `ModelConfig` (`OPENAI_BASE_URL` / `OPENAI_API_KEY`), which feeds both `createOpenAI` call sites in `llm.ts` (text generation + embeddings). Strict-mode throw propagates through the existing error handling.
- `packages/core/src/testing/inference-provider.ts` — openai provider endpoint detection uses the gateway URL when gateway mode is on (defensive: a strict-mode misconfig does not crash detection; authoritative enforcement lives in the runtime config layer).
- Exported from both node + browser barrels (pure string logic, no Node deps).

## Tests

`packages/core/src/model-gateway.test.ts` (17 tests) next to the module per repo convention:
- canonical env-var-name contract + alias pinning (shared with #11651)
- gateway URL/token precedence (incl. overriding raw `OPENAI_BASE_URL`/`OPENAI_API_KEY`, whitespace trimming, no-token case)
- strict-mode fail-closed names the offending var(s); does not fail-closed when gateway mode is off; non-strict path silently wins
- scrubber: resolved config carries **no** raw key material when gateway mode is on (incl. no-token case)

Targeted suites green: 37 passing (model-gateway 17, inference-timing 12, live-provider 8), zero new failures. Pre-existing failures in `features/documents/*` are an unrelated missing optional dep (`mammoth`) in the worktree, confirmed on the clean baseline. Biome clean on all touched files. Rebased on latest `develop` (includes #11651).

## Scope

Core runtime only. Does **not** touch `packages/cloud/**` (PR #11528's lane), `packages/app`, `packages/ui`, binaries, or lockfiles.

Part of #11536. Sibling: #11651.

[sol-forge] — [sol-orch]
