### PR TITLE
fix(app): keep plugin audit density within ratchet

### DIFF
--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-07-02T12:29:25.739Z",
+  "updatedAt": "2026-07-02T23:03:00.368Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -43,15 +43,15 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 76,
+    "asUnknownAs": 75,
     "asAny": 0,
     "explicitAny": 124,
     "tsSuppress": 0,
-    "nonNullAssertion": 518,
+    "nonNullAssertion": 515,
     "nullishEmptyString": 615,
     "nullishEmptyArray": 581,
     "nullishEmptyObject": 377,
     "nullishZero": 375
   },
-  "filesScanned": 9991
+  "filesScanned": 10028
 }

--- a/plugins/plugin-inbox/src/components/inbox/InboxView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxView.tsx
@@ -293,15 +293,21 @@ export function InboxView(props: InboxViewProps = {}): ReactNode {
     [items, load, activeList],
   );
 
-  const filters: InboxChannelFilter[] = useMemo(
-    () =>
-      INBOX_CHANNELS.map((channel) => ({
-        channel,
-        label: INBOX_CHANNEL_LABELS[channel],
-        active: activeChannels.has(channel),
-      })),
-    [activeChannels],
-  );
+  const filters: InboxChannelFilter[] = useMemo(() => {
+    const visibleChannels =
+      state.kind === "ready" && state.data.connected.length > 0
+        ? INBOX_CHANNELS.filter(
+            (channel) =>
+              state.data.connected.includes(channel) ||
+              activeChannels.has(channel),
+          )
+        : INBOX_CHANNELS;
+    return visibleChannels.map((channel) => ({
+      channel,
+      label: INBOX_CHANNEL_LABELS[channel],
+      active: activeChannels.has(channel),
+    }));
+  }, [state, activeChannels]);
 
   const snapshot: InboxSnapshot = useMemo(() => {
     const status: InboxStatus =

--- a/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
+++ b/plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx
@@ -234,28 +234,44 @@ export function ScreenshareSpatialView({
       )}
 
       <Divider label="connect" />
-      <Field
-        label="Remote server URL"
-        value={snapshot.remote?.baseUrl ?? ""}
-        placeholder="Server URL"
-        agent="input-remote-base"
-        onChange={(value) => onAction?.(`remote-base:${value}`)}
-      />
-      <Field
-        label="Remote session id"
-        value={snapshot.remote?.sessionId ?? ""}
-        placeholder="Session"
-        agent="input-remote-session"
-        onChange={(value) => onAction?.(`remote-session:${value}`)}
-      />
-      <Field
-        label="Remote session token"
-        value={snapshot.remote?.token ?? ""}
-        placeholder="Token"
-        kind="password"
-        agent="input-remote-token"
-        onChange={(value) => onAction?.(`remote-token:${value}`)}
-      />
+      <HStack gap={1}>
+        <Field
+          label="Remote server URL"
+          value={snapshot.remote?.baseUrl ?? ""}
+          placeholder="Server URL"
+          agent="input-remote-base"
+          grow={1}
+          onChange={(value) => onAction?.(`remote-base:${value}`)}
+        />
+        <Field
+          label="Remote session id"
+          value={snapshot.remote?.sessionId ?? ""}
+          placeholder="Session"
+          agent="input-remote-session"
+          grow={1}
+          onChange={(value) => onAction?.(`remote-session:${value}`)}
+        />
+      </HStack>
+      <HStack gap={1} align="end">
+        <Field
+          label="Remote session token"
+          value={snapshot.remote?.token ?? ""}
+          placeholder="Token"
+          kind="password"
+          agent="input-remote-token"
+          grow={1}
+          onChange={(value) => onAction?.(`remote-token:${value}`)}
+        />
+        <Button
+          variant="outline"
+          tone="default"
+          agent="refresh"
+          disabled={snapshot.loading}
+          onPress={dispatch("refresh")}
+        >
+          Refresh
+        </Button>
+      </HStack>
       <HStack gap={1} wrap>
         <Button
           grow={1}
@@ -266,15 +282,6 @@ export function ScreenshareSpatialView({
           onPress={dispatch("connect")}
         >
           Connect
-        </Button>
-        <Button
-          variant="outline"
-          tone="default"
-          agent="refresh"
-          disabled={snapshot.loading}
-          onPress={dispatch("refresh")}
-        >
-          Refresh
         </Button>
       </HStack>
     </Card>


### PR DESCRIPTION
## Summary

- Compact the inbox GUI channel filters so the loaded view only shows connected channels, while preserving active selections.
- Compact the screenshare remote connection controls so mobile portrait stays above the floating chat overlay without dropping actions.
- Refresh the type-safety ratchet baseline to the current counts after #11594 merged.

## Why

While validating #11594, `bun run --cwd packages/app audit:app` failed the minimalism ratchet for `plugin-inbox-gui` mobile-landscape and `plugin-screenshare-gui` mobile-portrait. The merged #11594 branch did not include these layout fixes, so this PR carries them separately.

## Validation

- `bun run --cwd packages/app audit:app` on rebased head: 349/349 passed; broken=0, minimalism-budget-failures=0, minimalism-ratchet-failures=0, hover-probe-failures=0, density-probe-failures=0.
- Manual review filled for the touched inbox/screenshare GUI viewports under `packages/app/aesthetic-audit-output/manual-review/`.
- `bun run audit:type-safety-ratchet` passed.
- `bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true packages/scripts/type-safety-ratchet-baseline.json plugins/plugin-inbox/src/components/inbox/InboxView.tsx plugins/plugin-screenshare/src/components/ScreenshareSpatialView.tsx` passed.
- `git diff --check origin/develop...HEAD` passed.

Note: `plugin-trajectory-logger-gui` mobile-landscape still reports the pre-existing non-blocking `needs-work` overlay note in the app audit (`overlay overlaps "open" (127px²)`), but there are no ratchet, hover, density, or broken-view failures.