### PR TITLE
fix(orchestrator): portable orchestrator_tasks session lookup on pglite + decouple spawn success from event-recording (#11641)

### DIFF
--- a/.github/issue-evidence/11641-orchestrator-pglite-session-lookup.md
+++ b/.github/issue-evidence/11641-orchestrator-pglite-session-lookup.md
@@ -1,0 +1,40 @@
+# #11641 orchestrator pglite session lookup
+
+PR: #11667
+
+## Scope
+
+Fixes the pglite/postgres failure where the orchestrator task store attempted
+to locate a session with `document LIKE ?` against the serialized task document.
+The fix uses the indexed `search_text` column as the portable prefilter, keeps
+the JavaScript `sessions.find(...)` match authoritative, and leaves a full-scan
+fallback only for legacy rows whose `search_text` does not yet include session
+ids.
+
+The service path also decouples a successful ACP spawn from durable
+event-recording degradation, so `POST /tasks/{id}/agents` can return a coherent
+2xx detail with the live session instead of a false 500.
+
+## Verification
+
+Run in `/home/shaw/eliza-worktrees/pr-11667-orchestrator-pglite` on 2026-07-02:
+
+```bash
+bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/orchestrator-task-store.test.ts __tests__/unit/orchestrator-task-service.test.ts
+./node_modules/.bin/tsgo --noEmit -p plugins/plugin-agent-orchestrator/tsconfig.json
+bun run --cwd plugins/plugin-agent-orchestrator lint:check src/services/orchestrator-task-store.ts src/services/orchestrator-task-service.ts __tests__/unit/orchestrator-task-store.test.ts __tests__/unit/orchestrator-task-service.test.ts
+git diff --check origin/develop...HEAD
+git diff --check
+```
+
+Result:
+
+- Focused unit tests: 2 files / 100 tests passed.
+- Typecheck: passed.
+- Biome: passed after formatting the new tests.
+- Whitespace checks: passed.
+
+## N/A
+
+- Screenshots/video: N/A — backend persistence and API response semantics only.
+- Live model trajectory: N/A — no model prompt/action/provider behavior changes.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1333,3 +1333,90 @@ describe("OrchestratorTaskService — aggregation and bulk controls", () => {
     expect((await service.getStatus()).pausedTaskCount).toBe(0);
   });
 });
+
+describe("OrchestratorTaskService — store degradation resilience (#11641)", () => {
+  /** Runtime that hands back the same logger it wires in, so a test can assert
+   * on warn calls. */
+  function runtimeWithLogger(acp?: FakeAcp): {
+    runtime: IAgentRuntime;
+    warn: ReturnType<typeof vi.fn>;
+  } {
+    const warn = vi.fn();
+    const rt = {
+      getService: () => acp ?? null,
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    } as never as IAgentRuntime;
+    return { runtime: rt, warn };
+  }
+
+  it("spawnAgentForTask returns a 2xx-shaped detail when the spawn succeeds but recording the session fails", async () => {
+    // Live symptom: on pglite the session INSERT/lookup path threw, so
+    // POST /tasks/:id/agents returned 500 even though acp.spawnSession
+    // succeeded and the agent was doing work. The API consumer saw a false
+    // failure and could double-spawn. The spawn success must decouple from the
+    // durable recording.
+    const acp = new FakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { runtime, warn } = runtimeWithLogger(acp);
+    const service = new OrchestratorTaskService(runtime, { store });
+    await service.start();
+    const task = await service.createTask(createInput());
+
+    // Break the durable session write exactly as a degraded adapter would.
+    vi.spyOn(store, "addSession").mockRejectedValueOnce(
+      new Error("Failed query: INSERT INTO orchestrator_tasks ..."),
+    );
+
+    const detail = await service.spawnAgentForTask(task.id);
+
+    // Not null (that would be a 404) and not a throw (that would be a 500) —
+    // the caller gets a real detail carrying the just-spawned session.
+    expect(detail).not.toBeNull();
+    expect(detail?.sessions).toHaveLength(1);
+    expect(detail?.sessions[0]?.sessionId).toBe("session-1");
+    // The recording failure is logged (once), not swallowed silently.
+    expect(
+      warn.mock.calls.some((c) =>
+        String(c[0]).includes("spawn succeeded but recording the session failed"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns once per session when event-recording keeps failing, not once per event", async () => {
+    // A persistently degraded store (e.g. findSession throwing on pglite)
+    // used to re-fire the failed-query warn on EVERY session event forever.
+    // The service must warn once per session and stay quiet after.
+    const acp = new FakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { runtime, warn } = runtimeWithLogger(acp);
+    const service = new OrchestratorTaskService(runtime, { store });
+    await service.start();
+    const task = await service.createTask(createInput());
+    const detail = must(
+      await service.spawnAgentForTask(task.id),
+      "expected spawn detail",
+    );
+    const sessionId = must(detail.sessions[0], "session").sessionId;
+
+    // Force the event-record path to fail for this session on every event by
+    // making the addEvent write throw (simulating the degraded store).
+    vi.spyOn(store, "addEvent").mockRejectedValue(
+      new Error("Failed query: SELECT document FROM orchestrator_tasks ..."),
+    );
+    // Also drop the cached mapping so resolveTaskId hits the store each time
+    // (worst case), proving the guard is keyed on sessionId not luck.
+    // (resolveTaskId is cached from spawn; addEvent throwing is enough to
+    // exercise the once-per-session warn.)
+
+    const before = warn.mock.calls.length;
+    await drive(acp, sessionId, "ready");
+    await drive(acp, sessionId, "tool_running", { toolCall: { title: "edit" } });
+    await drive(acp, sessionId, "tool_running", { toolCall: { title: "read" } });
+    await drive(acp, sessionId, "message", { text: "hi" });
+
+    const recordWarns = warn.mock.calls
+      .slice(before)
+      .filter((c) => String(c[0]).includes("failed to record session event"));
+    expect(recordWarns).toHaveLength(1);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1377,7 +1377,9 @@ describe("OrchestratorTaskService — store degradation resilience (#11641)", ()
     // The recording failure is logged (once), not swallowed silently.
     expect(
       warn.mock.calls.some((c) =>
-        String(c[0]).includes("spawn succeeded but recording the session failed"),
+        String(c[0]).includes(
+          "spawn succeeded but recording the session failed",
+        ),
       ),
     ).toBe(true);
   });
@@ -1410,8 +1412,12 @@ describe("OrchestratorTaskService — store degradation resilience (#11641)", ()
 
     const before = warn.mock.calls.length;
     await drive(acp, sessionId, "ready");
-    await drive(acp, sessionId, "tool_running", { toolCall: { title: "edit" } });
-    await drive(acp, sessionId, "tool_running", { toolCall: { title: "read" } });
+    await drive(acp, sessionId, "tool_running", {
+      toolCall: { title: "edit" },
+    });
+    await drive(acp, sessionId, "tool_running", {
+      toolCall: { title: "read" },
+    });
     await drive(acp, sessionId, "message", { text: "hi" });
 
     const recordWarns = warn.mock.calls

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -527,7 +527,98 @@ describe("FileTaskStore", () => {
   });
 });
 
+/**
+ * Emulates the pglite/postgres failure mode from #11641: the driver rejects a
+ * `document LIKE ?` comparison against the JSON-bearing column (it does not
+ * treat it as a plain-text haystack the way sqlite does). Every other query
+ * shape behaves like {@link FakeSqlAdapter}. If `findSession` still emits
+ * `document LIKE`, the lookup throws here — proving the portability fix.
+ */
+class PgliteLikeRejectingAdapter extends FakeSqlAdapter {
+  override async all(sql: string, params: unknown[] = []): Promise<unknown[]> {
+    if (sql.includes("document LIKE")) {
+      throw new Error(
+        `Failed query: ${sql}\nparams: ${JSON.stringify(params)}`,
+      );
+    }
+    return super.all(sql, params);
+  }
+}
+
 describe("RuntimeDbTaskStore", () => {
+  it("resolves a session without a `document LIKE` query so pglite/postgres do not fail (#11641)", async () => {
+    // On pglite the old `SELECT document FROM orchestrator_tasks WHERE document
+    // LIKE ?` threw, spamming a failed-query warn on every session event and
+    // 500-ing POST /tasks/:id/agents. This adapter reproduces that rejection;
+    // the lookup must still resolve the session via the portable scan.
+    const adapter = new PgliteLikeRejectingAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(createInput({ title: "pglite" }));
+    await store.addSession(sessionFor(task.id, { sessionId: "session-x" }));
+
+    const found = await store.findSession("session-x");
+    expect(found?.taskId).toBe(task.id);
+    expect(found?.session.sessionId).toBe("session-x");
+
+    // A miss is a clean null, not a throw, on the same rejecting adapter.
+    expect(await store.findSession("no-such-session")).toBeNull();
+
+    // And updateSession (which resolves via findSession) also survives.
+    await store.updateSession("session-x", { activeTool: "edit" });
+    expect((await store.findSession("session-x"))?.session.activeTool).toBe(
+      "edit",
+    );
+  });
+
+  it("finds a session on a task even when other tasks exist, without substring LIKE false-positives", async () => {
+    // The JS `sessions.find` is the authoritative match — a sessionId that
+    // happens to appear as a substring of another task's document must not
+    // resolve to the wrong task.
+    const adapter = new PgliteLikeRejectingAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const a = await store.createTask(createInput({ title: "task a" }));
+    const b = await store.createTask(createInput({ title: "task b" }));
+    await store.addSession(sessionFor(a.task.id, { sessionId: "sess-aaa" }));
+    await store.addSession(sessionFor(b.task.id, { sessionId: "sess-bbb" }));
+
+    expect((await store.findSession("sess-aaa"))?.taskId).toBe(a.task.id);
+    expect((await store.findSession("sess-bbb"))?.taskId).toBe(b.task.id);
+  });
+
+  it("prefilters findSession on the indexed search_text column, not a full document scan (#11641 P2)", async () => {
+    // A live session's lookup must NOT scan+parse every task document on the
+    // hot event path. It resolves via the indexed `search_text` prefilter, so
+    // an unqualified `SELECT document FROM orchestrator_tasks` (the full-table
+    // fallback) never runs for a session that exists.
+    const seenSql: string[] = [];
+    const adapter = new FakeSqlAdapter();
+    const capturing = {
+      execute: (sql: string, params?: unknown[]) => adapter.execute(sql, params),
+      all: (sql: string, params?: unknown[]) => {
+        seenSql.push(sql);
+        return adapter.all(sql, params);
+      },
+    };
+    const store = new RuntimeDbTaskStore(capturing);
+    const { task } = await store.createTask(createInput({ title: "hot path" }));
+    await store.addSession(sessionFor(task.id, { sessionId: "live-session" }));
+
+    seenSql.length = 0;
+    const found = await store.findSession("live-session");
+    expect(found?.taskId).toBe(task.id);
+
+    // The targeted, indexed prefilter ran...
+    expect(
+      seenSql.some((s) => /search_text LIKE/.test(s)),
+    ).toBe(true);
+    // ...and the unbounded full-table scan fallback did NOT.
+    expect(
+      seenSql.some((s) => /FROM orchestrator_tasks\s*$/.test(s.trim())),
+    ).toBe(false);
+    // Never the pglite-breaking document LIKE either.
+    expect(seenSql.some((s) => /document LIKE/.test(s))).toBe(false);
+  });
+
   it("round-trips tasks, sessions, and deletes through a SQL adapter", async () => {
     const adapter = new FakeSqlAdapter();
     const store = new RuntimeDbTaskStore(adapter);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -593,7 +593,8 @@ describe("RuntimeDbTaskStore", () => {
     const seenSql: string[] = [];
     const adapter = new FakeSqlAdapter();
     const capturing = {
-      execute: (sql: string, params?: unknown[]) => adapter.execute(sql, params),
+      execute: (sql: string, params?: unknown[]) =>
+        adapter.execute(sql, params),
       all: (sql: string, params?: unknown[]) => {
         seenSql.push(sql);
         return adapter.all(sql, params);
@@ -608,9 +609,7 @@ describe("RuntimeDbTaskStore", () => {
     expect(found?.taskId).toBe(task.id);
 
     // The targeted, indexed prefilter ran...
-    expect(
-      seenSql.some((s) => /search_text LIKE/.test(s)),
-    ).toBe(true);
+    expect(seenSql.some((s) => /search_text LIKE/.test(s))).toBe(true);
     // ...and the unbounded full-table scan fallback did NOT.
     expect(
       seenSql.some((s) => /FROM orchestrator_tasks\s*$/.test(s.trim())),

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -607,6 +607,11 @@ export class OrchestratorTaskService extends Service {
   protected override readonly runtime: RuntimeLike;
   private readonly store: OrchestratorTaskStore;
   private readonly sessionTaskIndex = new Map<string, string>();
+  // Session ids whose event-recording has already logged a failure. A
+  // degraded store (e.g. #11641's pglite lookup) would otherwise re-warn on
+  // EVERY session event (`ready`, `tool_running`, ...) forever — one line per
+  // event, per session. We warn once per session and stay silent after.
+  private readonly recordFailureWarned = new Set<string>();
   // Tasks with an auto-goal-verify pass in flight. ACP can emit `task_complete`
   // from two sites for one turn; without this guard both runs read the same
   // attempt counter across the model `await` and double-send a correction.
@@ -761,11 +766,18 @@ export class OrchestratorTaskService extends Service {
       await this.applySessionEvent(taskId, sessionId, event, data);
       this.emitChange(taskId);
     } catch (err) {
-      this.log("warn", "failed to record session event", {
-        sessionId,
-        event,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      // Warn once per session, not once per event. A persistently degraded
+      // store would fire this on every `ready`/`tool_running`/... otherwise,
+      // flooding the log for the life of the session (#11641).
+      if (!this.recordFailureWarned.has(sessionId)) {
+        this.recordFailureWarned.add(sessionId);
+        this.log("warn", "failed to record session event", {
+          sessionId,
+          event,
+          error: err instanceof Error ? err.message : String(err),
+          note: "further event-record failures for this session are suppressed",
+        });
+      }
     }
   }
 
@@ -1629,8 +1641,10 @@ export class OrchestratorTaskService extends Service {
     const doc = await this.store.getTask(taskId);
     if (!doc) return false;
     await this.stopActiveSessions(doc);
-    for (const session of doc.sessions)
+    for (const session of doc.sessions) {
       this.sessionTaskIndex.delete(session.sessionId);
+      this.recordFailureWarned.delete(session.sessionId);
+    }
     return this.store.deleteTask(taskId);
   }
 
@@ -2731,10 +2745,39 @@ export class OrchestratorTaskService extends Service {
       createdAt: ts,
       updatedAt: ts,
     };
-    await this.store.addSession(session);
+    // The ACP spawn above already SUCCEEDED — the session is live and doing
+    // work. Everything from here on is durable book-keeping. If the store is
+    // degraded (e.g. #11641's pglite lookup failure) a throw here would bubble
+    // a 500 to `POST /tasks/{id}/agents` even though the spawn worked, making
+    // API consumers think it failed and possibly double-spawn. So record the
+    // session best-effort and, on failure, still return a coherent detail that
+    // reflects the live session instead of throwing.
+    // Seed the in-memory index unconditionally so `resolveTaskId` resolves this
+    // session's events even if the durable write below degrades.
     this.sessionTaskIndex.set(result.sessionId, taskId);
-    await this.advanceTaskStatus(taskId, "active");
-    return this.getTask(taskId);
+    try {
+      await this.store.addSession(session);
+      await this.advanceTaskStatus(taskId, "active");
+      return this.getTask(taskId);
+    } catch (err) {
+      this.log("warn", "spawn succeeded but recording the session failed", {
+        taskId,
+        sessionId: result.sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Return a detail that includes the just-spawned session so the caller
+      // sees a 2xx with the real session info. Prefer a fresh read (the
+      // addSession may have partially landed); fall back to the pre-spawn doc
+      // with the new session appended so the response is never a false 404.
+      const refreshed = await this.getTask(taskId).catch(() => null);
+      if (refreshed?.sessions?.some((s) => s.sessionId === result.sessionId)) {
+        return refreshed;
+      }
+      return toTaskThreadDetail({
+        ...doc,
+        sessions: [...doc.sessions, session],
+      });
+    }
   }
 
   /**

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -256,7 +256,13 @@ function buildSearchText(doc: OrchestratorTaskDocument): string {
     t.originalRequest,
     t.summary ?? "",
     ...t.acceptanceCriteria,
-    ...doc.sessions.map((s) => `${s.label} ${s.framework} ${s.workdir}`),
+    // Session ids are included so `findSession` can prefilter on the indexed
+    // `search_text` column instead of substring-scanning the whole JSON
+    // `document` (which is both a full-table hot-path scan and the query that
+    // fails on pglite — see RuntimeDbTaskStore.findSession, #11641).
+    ...doc.sessions.map(
+      (s) => `${s.label} ${s.framework} ${s.workdir} ${s.sessionId}`,
+    ),
   ]
     .join(" ")
     .toLowerCase();
@@ -997,10 +1003,36 @@ export class RuntimeDbTaskStore {
 
   async findSession(sessionId: string) {
     await this.ensureInitialized();
-    const rows = await this.exec().all(
-      "SELECT document FROM orchestrator_tasks WHERE document LIKE ?",
-      [`%${sessionId}%`],
+    // Portable, targeted session-id lookup. The old `WHERE document LIKE ?`
+    // used the serialized JSON `document` column as a text haystack, which:
+    //   * fails outright on pglite/postgres — the drizzle/pglite driver does
+    //     not treat that JSON-bearing column comparison as a plain-text `LIKE`
+    //     the way sqlite does, so `SELECT document FROM orchestrator_tasks
+    //     WHERE document LIKE $1` throws on every session event (#11641); and
+    //   * scanned/serialized the ENTIRE document per event on the hot path.
+    //
+    // We instead prefilter on `search_text` — a plain, indexed TEXT column that
+    // `listTasks` already matches with `LIKE` on every backend (sqlite/pglite/
+    // postgres) without incident. `buildSearchText` now folds each session's
+    // id into that column, so the DB narrows to candidate rows and we only
+    // JSON-parse those. The authoritative decision is still the JS
+    // `sessions.find(...)` below, so a substring false-positive can never
+    // resolve to the wrong session.
+    const needle = `%${sessionId.toLowerCase()}%`;
+    let rows = await this.exec().all(
+      "SELECT document FROM orchestrator_tasks WHERE search_text LIKE ?",
+      [needle],
     );
+    const match = this.matchSession(rows, sessionId);
+    if (match) return match;
+    // Legacy fallback: rows persisted before session ids were added to
+    // `search_text` won't match the prefilter. Only pay for a full scan when
+    // the targeted lookup misses, so the steady-state hot path stays cheap.
+    rows = await this.exec().all("SELECT document FROM orchestrator_tasks");
+    return this.matchSession(rows, sessionId);
+  }
+
+  private matchSession(rows: unknown[], sessionId: string) {
     for (const row of rows) {
       const doc = this.parseDoc(row);
       const session = doc?.sessions.find((s) => s.sessionId === sessionId);


### PR DESCRIPTION
Fixes #11641.

## Root cause

`RuntimeDbTaskStore.findSession` resolved a `sessionId → task` via:

```sql
SELECT document FROM orchestrator_tasks WHERE document LIKE ?
```

`document` is the column that stores the whole serialized-JSON task document. On **pglite/postgres** the drizzle driver does not treat a `LIKE` against that JSON-bearing column as a plain-text comparison the way sqlite does, so the query throws:

```
Failed query: SELECT document FROM orchestrator_tasks WHERE document LIKE $1
```

`findSession` runs on the session-event hot path (`onSessionEvent → resolveTaskId → findSession`) and on `updateSession`, so on a self-hosted pglite node this produced the two reported symptoms:

1. **Per-event warn spam** — every `ready`/`tool_running`/… event re-fired the failing query, logging one `failed to record session event` warn per event, forever.
2. **False 500 on `POST /tasks/{id}/agents`** — the spawn itself succeeded (`acp.spawnSession` returned, the agent came up and did work), but a store throw on the recording path bubbled a 500 to the API caller, so consumers saw a false failure and could double-spawn.

Discord-origin flows were masked only because those task docs also live in the file store.

## Fix (three minimal parts)

**1. Portable, targeted session lookup.** `findSession` now prefilters on the indexed `search_text` column instead of the JSON `document` column:

```sql
SELECT document FROM orchestrator_tasks WHERE search_text LIKE ?
```

`search_text` is a plain `TEXT` column that `listTasks` already `LIKE`-matches on every backend (sqlite/pglite/postgres) without incident. `buildSearchText` now folds each session's id into that column so the DB narrows to candidate rows, and the authoritative decision remains the JS `sessions.find(...)` — a substring false-positive can never resolve to the wrong session. A full-table-scan fallback runs **only** when the targeted prefilter misses (legacy rows persisted before session ids were added to `search_text`), keeping the steady-state event path cheap.

*Why this over the alternatives:* `document::text LIKE ?` fixes pglite but fails to parse on sqlite; a dedicated indexed `session_id` column would need a schema migration for a lookup this rare; an unqualified full scan (my first draft) fixes correctness but reintroduces a per-event full-table scan + JSON-parse on the hot path (flagged by review). The `search_text` prefilter is the smallest change that is correct **and** cheap on all three adapters.

**2. Decouple the API response from durable recording.** In `spawnAgentForTask`, once `acp.spawnSession` succeeds the in-memory session index is seeded unconditionally and the durable `addSession`/`advanceTaskStatus` becomes best-effort. If the store degrades, it returns a coherent `2xx` detail that carries the just-spawned session (fresh read, or the pre-spawn doc with the new session appended) instead of throwing a 500 or a false 404.

**3. Rate-limit the failed-record warn** to once per `sessionId` via a `Set` on the service (cleared on task delete), ending the per-event spam.

## Tests

Added to `orchestrator-task-store.test.ts` and `orchestrator-task-service.test.ts`:

- `findSession` resolves a session against a **pglite-LIKE-rejecting adapter** (reproduces the driver throw on `document LIKE`) — no throw, clean `null` on miss, `updateSession` survives.
- Cross-task false-positive isolation (`sessions.find` is authoritative).
- Indexed-prefilter guard: the hot lookup uses `search_text LIKE`, never the unqualified full-table scan, never `document LIKE`.
- `spawnAgentForTask` returns a 2xx-shaped detail (not null, not throw) when the spawn succeeds but `addSession` fails.
- Warn fires **once per session**, not once per event, under a persistently failing record path.

**Suite:** `cd plugins/plugin-agent-orchestrator && npx vitest run __tests__` → **1270 passed**, 15 pre-existing env failures (drizzle-orm / opencode-config / smithers / provision-workspace module resolution), **zero new failures**. codex-reviewed (gpt-5.5, `--uncommitted`): no introduced correctness issues.

[sol-forge] — [sol-orch]
