### PR TITLE
fix(ci): retry Cloudflare secret publication

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -457,7 +457,17 @@ jobs:
               echo "::notice::$name is not configured; skipping"
               return 0
             fi
-            printf '%s' "$value" | bunx wrangler secret put "$name" ${{ steps.env.outputs.wrangler_args }}
+            for attempt in 1 2 3; do
+              if printf '%s' "$value" | bunx wrangler secret put "$name" ${{ steps.env.outputs.wrangler_args }}; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::wrangler secret put $name failed on attempt $attempt; retrying in 10s"
+                sleep 10
+              fi
+            done
+            echo "::error::wrangler secret put $name failed after 3 attempts"
+            return 1
           }
 
           for name in \


### PR DESCRIPTION
## Summary

- Retry each configured `wrangler secret put` up to three times in `cloud-cf-deploy.yml`.
- Preserve the existing empty-secret skip behavior and still fail the job when all attempts fail.

## Why

The latest real `develop` failure I found was Cloud CF Deploy run `28622452784` on `3ec7f96c`. The `Deploy API Worker` job failed while publishing Worker secrets: Wrangler reported `A fetch request failed` / `ERROR fetch failed` during `wrangler secret put` after successfully uploading the previous secret. That is a transient network-sensitive operation, so a single Cloudflare fetch blip should not fail the deploy.

The same run also showed an earlier `group-j-documents.test.ts` 503 cleanup assertion, but the deploy continued and the final hard failure was the secret publication fetch error. This PR addresses that recurring workflow resilience hole narrowly.

## Validation

- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check origin/develop...HEAD`
- Text check confirmed the retry wrapper and final failure path are present.