### PR TITLE
fix(local-inference): Linux+NVIDIA image-gen reaches CUDA — trust the loader's capability gate (#10727)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -769,11 +769,13 @@ async function getFusedEmbeddingHandle(cfg: DesktopEmbeddingConfig): Promise<{
 function makeFusedEmbeddingHandler(): EmbeddingHandler {
 	return async (_runtime, params) => {
 		const text = extractEmbeddingText(params);
-		// A failed probe degrades to the conservative embedding preset. Log WHY
-		// so a broken probe on an accelerated box is visible, not silent (#10727).
+		// When the probe fails, resolveDesktopEmbeddingConfig(undefined) uses the
+		// `performance` preset (gpuLayers: auto — inert on a CPU-only fused lib).
+		// Log WHY so a broken probe on an accelerated box is visible, not silent
+		// (#10727) — the tier is then chosen without hardware evidence.
 		const hardware = await probeHardware().catch((error) => {
 			logger.warn(
-				`[ensureLocalInferenceHandler] hardware probe failed; embedding preset falls back to the conservative default: ${
+				`[ensureLocalInferenceHandler] hardware probe failed; embedding tier chosen without hardware evidence (performance preset, gpuLayers: auto): ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.test.ts
@@ -119,12 +119,18 @@ describe("selectImageGenBackends — platform policy", () => {
 		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
 	});
 
-	it("gates Linux NVIDIA CUDA on real sd-cpp evidence", () => {
-		// GPU vendor alone is NOT evidence the installed binary has CUDA.
+	it("proposes CUDA first on Linux NVIDIA and lets the loader gate it (#10727)", () => {
+		const cudaThenCpu = [
+			{ backendId: "sd-cpp", accelerator: "cuda" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		];
+		// GPU vendor alone now proposes CUDA first — the sd-cpp LOADER is the
+		// single source of capability truth and falls through to CPU if the binary
+		// can't prove CUDA. The old positive gate ran every NVIDIA box on CPU.
 		expect(
 			selectImageGenBackends(profile({ platform: "linux", gpu: "nvidia" })),
-		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
-		// cudaCapable evidence promotes CUDA ahead of the CPU fallback.
+		).toEqual(cudaThenCpu);
+		// Positive evidence still proposes CUDA first.
 		expect(
 			selectImageGenBackends(
 				profile({
@@ -133,11 +139,7 @@ describe("selectImageGenBackends — platform policy", () => {
 					sdCpp: { cudaCapable: true },
 				}),
 			),
-		).toEqual([
-			{ backendId: "sd-cpp", accelerator: "cuda" },
-			{ backendId: "sd-cpp", accelerator: "cpu" },
-		]);
-		// an accelerators list that includes cuda is equivalent evidence.
+		).toEqual(cudaThenCpu);
 		expect(
 			selectImageGenBackends(
 				profile({
@@ -146,10 +148,18 @@ describe("selectImageGenBackends — platform policy", () => {
 					sdCpp: { accelerators: ["cuda"] },
 				}),
 			),
-		).toEqual([
-			{ backendId: "sd-cpp", accelerator: "cuda" },
-			{ backendId: "sd-cpp", accelerator: "cpu" },
-		]);
+		).toEqual(cudaThenCpu);
+		// Explicit evidence the binary CANNOT do CUDA demotes to CPU-only — no
+		// wasted CUDA load attempt.
+		expect(
+			selectImageGenBackends(
+				profile({
+					platform: "linux",
+					gpu: "nvidia",
+					sdCpp: { cudaCapable: false, accelerators: ["cpu"] },
+				}),
+			),
+		).toEqual([{ backendId: "sd-cpp", accelerator: "cpu" }]);
 	});
 
 	it("falls back to sd-cpp CPU for an unknown platform", () => {
@@ -200,20 +210,41 @@ describe("imageGenGpuVendorFromProbeBackend (#10727 silent-CPU-fallback fix)", (
 		expect(imageGenGpuVendorFromProbeBackend(undefined)).toBeUndefined();
 	});
 
-	it("threading the probe's NVIDIA signal reaches CUDA instead of silent CPU (the real caller path)", () => {
+	it("threading the probe's NVIDIA signal reaches CUDA on the EXACT real-caller profile shape", () => {
 		// Regression guard for the bug: service.ts hardcoded `gpu: undefined`, so
-		// selectImageGenBackends fell through to CPU on every Linux/Windows box —
-		// even NVIDIA, whose backend the probe detects via nvidia-smi. Drive the
-		// SAME mapper the real caller now uses, not a synthetic `gpu:"nvidia"`.
+		// selectImageGenBackends fell to CPU on every Linux/Windows NVIDIA box.
+		// Build the profile the way loadImageGenBackend does — vendor from the
+		// mapper, and crucially NO `sdCpp` field (the real caller never sets it).
+		// Against the pre-fix positive gate this Linux assertion returned
+		// [{sd-cpp, cpu}] and would (correctly) fail.
 		const gpu = imageGenGpuVendorFromProbeBackend("cuda");
-		const linux = selectImageGenBackends(
-			profile({ platform: "linux", gpu, sdCpp: { cudaCapable: true } }),
+		expect(selectImageGenBackends(profile({ platform: "linux", gpu }))).toEqual(
+			[
+				{ backendId: "sd-cpp", accelerator: "cuda" },
+				{ backendId: "sd-cpp", accelerator: "cpu" },
+			],
 		);
-		expect(linux[0]).toEqual({ backendId: "sd-cpp", accelerator: "cuda" });
-		expect(linux.some((c) => c.accelerator === "cuda")).toBe(true);
+		expect(selectImageGenBackends(profile({ platform: "win32", gpu }))).toEqual(
+			[
+				{ backendId: "tensorrt", accelerator: "tensorrt" },
+				{ backendId: "sd-cpp", accelerator: "cuda" },
+				{ backendId: "sd-cpp", accelerator: "cpu" },
+			],
+		);
+	});
 
-		const win = selectImageGenBackends(profile({ platform: "win32", gpu }));
-		expect(win[0]).toEqual({ backendId: "tensorrt", accelerator: "tensorrt" });
+	it("leaves macOS unaffected when the mapper reports apple (darwin ignores gpu)", () => {
+		// The doc comment claims 'macOS still gets mflux/Metal'; prove it by
+		// running the mapper's metal->apple output through the selector on darwin.
+		const gpu = imageGenGpuVendorFromProbeBackend("metal");
+		expect(
+			selectImageGenBackends(
+				profile({ platform: "darwin", arch: "arm64", gpu }),
+			),
+		).toEqual([
+			{ backendId: "mflux", accelerator: "metal" },
+			{ backendId: "sd-cpp", accelerator: "cpu" },
+		]);
 	});
 
 	it("keeps AMD/Intel (probe reports null today) on the platform default", () => {

--- a/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
+++ b/plugins/plugin-local-inference/src/services/imagegen/backend-selector.ts
@@ -16,10 +16,11 @@
  *     mflux is skipped on Intel Macs.
  *   - **iOS**: `coreml` only. There is no sd-cpp on iOS — Core ML is
  *     the only sanctioned acceleration path.
- *   - **Linux + NVIDIA**: `sd-cpp` CUDA only when the sd-cpp probe,
- *     binary manifest, help, or version output proves CUDA support.
- *     Otherwise use `sd-cpp` CPU and let the loader emit an explicit
- *     CUDA-missing fallback error if CUDA was requested elsewhere.
+ *   - **Linux + NVIDIA**: `sd-cpp` CUDA → `sd-cpp` CPU. CUDA is proposed
+ *     first and the loader's own capability probe gates it (throwing
+ *     ImageGenBackendUnavailableError → clean CPU fall-through when the binary
+ *     can't prove CUDA). Only demoted to CPU-only when the profile carries
+ *     explicit evidence the binary CANNOT do CUDA.
  *   - **Linux + AMD/Intel**: `sd-cpp --vulkan` → `sd-cpp` (CPU fallback).
  *   - **Linux + CPU**: `sd-cpp` (CPU).
  *   - **Windows + NVIDIA**: `tensorrt` → `sd-cpp` (CUDA) → `sd-cpp` (CPU).
@@ -211,15 +212,25 @@ export function selectImageGenBackends(
 	// accelerator order.
 	if (profile.platform === "linux") {
 		if (profile.gpu === "nvidia") {
-			const sdCppCudaCapable =
-				profile.sdCpp?.cudaCapable === true ||
-				profile.sdCpp?.accelerators?.includes("cuda") === true;
-			return sdCppCudaCapable
-				? [
+			// Propose CUDA first and let the sd-cpp loader be the single source of
+			// capability truth: `loadSdCppImageGenBackend` probes the binary and
+			// throws ImageGenBackendUnavailableError (→ clean fall-through to CPU)
+			// when it can't prove CUDA. The old gate required POSITIVE evidence in
+			// `profile.sdCpp`, which the real caller never populates, so every
+			// Linux NVIDIA box silently ran on CPU (#10727). We only demote to
+			// CPU-only when the profile carries explicit evidence the binary CANNOT
+			// do CUDA — the same trust-the-loader contract the AMD/Intel branch
+			// below and the win32 branch above already use.
+			const sdCppKnownIncapable =
+				profile.sdCpp !== undefined &&
+				profile.sdCpp.cudaCapable !== true &&
+				profile.sdCpp.accelerators?.includes("cuda") !== true;
+			return sdCppKnownIncapable
+				? [{ backendId: "sd-cpp", accelerator: "cpu" }]
+				: [
 						{ backendId: "sd-cpp", accelerator: "cuda" },
 						{ backendId: "sd-cpp", accelerator: "cpu" },
-					]
-				: [{ backendId: "sd-cpp", accelerator: "cpu" }];
+					];
 		}
 		if (profile.gpu === "amd" || profile.gpu === "intel") {
 			return [

--- a/plugins/plugin-local-inference/src/services/service.test.ts
+++ b/plugins/plugin-local-inference/src/services/service.test.ts
@@ -22,8 +22,10 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 	};
 });
 
+import { logger } from "@elizaos/core";
 import { ActiveModelCoordinator } from "./active-model";
 import { localInferenceEngine } from "./engine";
+import * as hardwareModule from "./hardware";
 import {
 	readRoutingPreferences,
 	writeRoutingPreferences,
@@ -219,5 +221,55 @@ describe("LocalInferenceService activation prewarm", () => {
 				TEXT_LARGE: "manual",
 			},
 		});
+	});
+});
+
+describe("LocalInferenceService image-gen GPU vendor detection (#10727)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Guards the SERVICE wiring (not just the pure mapper): loadImageGenBackend
+	// must feed the real probe's GPU vendor into the profile, so a Linux/Windows
+	// NVIDIA box reaches CUDA. If this seam is reverted to `gpu: undefined` these
+	// assertions go red.
+	it("maps a probed NVIDIA (cuda) host to the 'nvidia' image-gen vendor", async () => {
+		vi.spyOn(hardwareModule, "probeHardware").mockResolvedValue({
+			totalRamGb: 32,
+			freeRamGb: 16,
+			gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 24 },
+			cpuCores: 16,
+			cpuFeatures: {},
+			platform: "linux",
+			arch: "x64",
+			appleSilicon: false,
+			recommendedBucket: "performance",
+			source: "os-fallback",
+			openvino: { present: false, devices: [] },
+		} as Awaited<ReturnType<typeof hardwareModule.probeHardware>>);
+		const service = new LocalInferenceService();
+		const vendor = await (
+			service as unknown as {
+				detectImageGenGpuVendor(): Promise<string | undefined>;
+			}
+		).detectImageGenGpuVendor();
+		expect(vendor).toBe("nvidia");
+	});
+
+	it("degrades to the platform default (undefined) and WARNS when the probe fails", async () => {
+		vi.spyOn(hardwareModule, "probeHardware").mockRejectedValue(
+			new Error("nvidia-smi timed out"),
+		);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const service = new LocalInferenceService();
+		const vendor = await (
+			service as unknown as {
+				detectImageGenGpuVendor(): Promise<string | undefined>;
+			}
+		).detectImageGenGpuVendor();
+		expect(vendor).toBeUndefined();
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("image-gen GPU probe failed"),
+		);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -666,6 +666,15 @@ export class LocalInferenceService {
 			} catch (err) {
 				if (!isImageGenUnavailable(err)) throw err;
 				errors.push(err.message);
+				// Surface an accelerated→next degrade (e.g. CUDA/TensorRT/Metal
+				// unavailable → we fall through toward CPU). Otherwise a box with a
+				// real GPU that silently lands on CPU image-gen leaves no trace —
+				// the exact #10727 failure mode, one layer below selection.
+				if (choice.accelerator && choice.accelerator !== "cpu") {
+					logger.warn(
+						`[LocalInferenceService] image-gen ${choice.backendId}/${choice.accelerator} unavailable, falling through: ${err.message}`,
+					);
+				}
 			}
 		}
 		throw new Error(


### PR DESCRIPTION
## Summary

Follow-up to **#11654** (merged), which threaded the probed GPU vendor into the image-gen profile but — as a 5-lens adversarial review caught — only genuinely helped **Windows** NVIDIA. On **Linux + NVIDIA** (the most common accelerated target for #10727) it was still a no-op: `selectImageGenBackends` gated the CUDA head on `profile.sdCpp?.cudaCapable`, positive capability evidence the real caller (`loadImageGenBackend`) never populates, so a Linux NVIDIA box still returned `[{sd-cpp, cpu}]` — byte-identical to the pre-fix `gpu: undefined` output — and silently ran image-gen on CPU. The merged regression test masked this by hand-injecting `sdCpp: { cudaCapable: true }`.

## What changed

- **Linux + NVIDIA now proposes CUDA first** and lets the sd-cpp **loader** be the single source of capability truth: `loadSdCppImageGenBackend` already probes the binary (`probeSdCppCapabilitiesFromBinary`) and throws `ImageGenBackendUnavailableError` → clean CPU fall-through when CUDA is unproven. Only demote to CPU-only when the profile carries **explicit evidence the binary CANNOT do CUDA**. This is the same trust-the-loader contract the `win32` and the Linux `amd`/`intel` branches already use — the old positive gate was an inconsistent outlier.
- **Fall-through logging**: each accelerated→next image-gen degrade now `logger.warn`s (backend + accelerator + reason), so a GPU box that lands on CPU is visible — the #10727 failure mode one layer below selection.
- **SEV-4 message correctness**: the embedding probe-failure warn said "conservative default"; the real fallback is `EMBEDDING_PRESETS.performance` (gpuLayers auto). Corrected.

## Evidence (macOS M4 Max, on current develop)

- **Tests — 39 pass** across `backend-selector.test.ts`, `service.test.ts`, `hardware.test.ts`, `embedding-presets.test.ts`. The headline test now drives the **EXACT real-caller profile shape** (no synthetic `sdCpp`) and asserts CUDA-first on Linux **and** Windows — it would (correctly) fail against the merged code. Added a **mocked-probe service-seam test** guarding the wiring (revert `gpu` threading → red) and a **macOS-unaffected** composed test.
- `tsc -p plugins/plugin-local-inference` — 0 errors in changed files; biome clean.
- Adversarially re-reviewed: the negative-gate is exactly the panel's recommended fix ("try sd-cpp/cuda first and rely on the existing ImageGenBackendUnavailableError fall-through, as win32 already does").

## Still deferred (device-gated)

AMD/Intel Vulkan image-gen/embedding acceleration needs both a published Vulkan fused-lib set AND a real-GPU host to verify graceful degradation — routed to a follow-up, not shipped blind.

Refs #10727.
