### PR TITLE
fix(cloud-api): retry pending document blob cleanup

### DIFF
--- a/packages/cloud/api/__tests__/documents-preupload-delete-retry.test.ts
+++ b/packages/cloud/api/__tests__/documents-preupload-delete-retry.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as loggerActual from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const requireUserOrApiKeyWithOrg =
+  mock<() => Promise<{ id: string; organization_id: string }>>();
+const loggerWarn = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    warn: loggerWarn,
+  },
+}));
+
+mock.module("../v1/documents/_worker-documents", () => ({
+  publicBlobUrl: (_c: unknown, key: string) =>
+    `https://blob.elizacloud.ai/${key}`,
+  r2KeyFromBlobUrl: (blobUrl: string) => {
+    try {
+      const key = new URL(blobUrl).pathname.replace(/^\/+/, "");
+      return key.startsWith("documents-pre-upload/") ? key : null;
+    } catch {
+      return null;
+    }
+  },
+  sanitizeFilename: (filename: string) => filename,
+  validateDocumentFiles: () => null,
+}));
+
+const [{ default: preUploadRoute }, { deletePendingDocumentBlob }] =
+  await Promise.all([
+    import("../v1/documents/pre-upload/route"),
+    import("../v1/documents/_pending-blob-cleanup"),
+  ]);
+
+const app = new Hono<AppEnv>().route(
+  "/api/v1/documents/pre-upload",
+  preUploadRoute,
+);
+
+function deleteRequest(blobUrl: string): Request {
+  return new Request("https://api.example.test/api/v1/documents/pre-upload", {
+    method: "DELETE",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer eliza_test",
+    },
+    body: JSON.stringify({ blobUrl }),
+  });
+}
+
+describe("DELETE /api/v1/documents/pre-upload cleanup", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockReset();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    loggerWarn.mockReset();
+  });
+
+  test("retries a transient R2 delete failure after URL ownership is validated", async () => {
+    const deleteBlob = mock()
+      .mockRejectedValueOnce(new Error("r2 transient 503"))
+      .mockResolvedValueOnce(undefined);
+    const env = {
+      BLOB: {
+        get: mock(),
+        put: mock(),
+        delete: deleteBlob,
+      },
+      CACHE_ENABLED: "false",
+      NODE_ENV: "test",
+    } as unknown as AppEnv["Bindings"];
+
+    const res = await app.fetch(
+      deleteRequest(
+        "https://blob.elizacloud.ai/documents-pre-upload/user-1/pending.txt",
+      ),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown;
+    expect(body).toEqual({ success: true });
+    expect(deleteBlob).toHaveBeenCalledTimes(2);
+    expect(deleteBlob).toHaveBeenCalledWith(
+      "documents-pre-upload/user-1/pending.txt",
+    );
+    expect(loggerWarn).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps missing object storage as a loud deployment 503", async () => {
+    const res = await app.fetch(
+      deleteRequest(
+        "https://blob.elizacloud.ai/documents-pre-upload/user-1/pending.txt",
+      ),
+      {
+        CACHE_ENABLED: "false",
+        NODE_ENV: "test",
+      } as unknown as AppEnv["Bindings"],
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      success: false,
+      error: "Object storage is not configured",
+    });
+  });
+});
+
+describe("deletePendingDocumentBlob", () => {
+  beforeEach(() => {
+    loggerWarn.mockReset();
+  });
+
+  test("throws after exhausting the retry budget", async () => {
+    const deleteBlob = mock(() => Promise.reject(new Error("r2 unavailable")));
+
+    await expect(
+      deletePendingDocumentBlob(
+        {
+          get: mock(),
+          put: mock(),
+          delete: deleteBlob,
+        } as unknown as AppEnv["Bindings"]["BLOB"],
+        "documents-pre-upload/user-1/pending.txt",
+      ),
+    ).rejects.toThrow("r2 unavailable");
+
+    expect(deleteBlob).toHaveBeenCalledTimes(3);
+    expect(loggerWarn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cloud/api/v1/documents/_pending-blob-cleanup.ts
+++ b/packages/cloud/api/v1/documents/_pending-blob-cleanup.ts
@@ -1,0 +1,37 @@
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const DELETE_RETRY_DELAYS_MS = [100, 250] as const;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function deletePendingDocumentBlob(
+  bucket: AppEnv["Bindings"]["BLOB"],
+  key: string,
+): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= DELETE_RETRY_DELAYS_MS.length + 1;
+    attempt++
+  ) {
+    try {
+      await bucket.delete(key);
+      return;
+    } catch (error) {
+      lastError = error;
+      const nextDelay = DELETE_RETRY_DELAYS_MS[attempt - 1];
+      if (nextDelay === undefined) break;
+      logger.warn("[Documents] Pending blob delete failed; retrying", {
+        key,
+        attempt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await delay(nextDelay);
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/cloud/api/v1/documents/pre-upload/route.ts
+++ b/packages/cloud/api/v1/documents/pre-upload/route.ts
@@ -7,6 +7,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { deletePendingDocumentBlob } from "../_pending-blob-cleanup";
 import {
   publicBlobUrl,
   r2KeyFromBlobUrl,
@@ -98,7 +99,7 @@ app.delete("/", async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 
-    await c.env.BLOB.delete(key);
+    await deletePendingDocumentBlob(c.env.BLOB, key);
     return c.json({ success: true });
   } catch (error) {
     return failureResponse(c, error);

--- a/packages/cloud/api/v1/documents/submit/route.ts
+++ b/packages/cloud/api/v1/documents/submit/route.ts
@@ -7,6 +7,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { deletePendingDocumentBlob } from "../_pending-blob-cleanup";
 import {
   createDocumentRecord,
   type PendingDocumentFile,
@@ -74,7 +75,7 @@ app.post("/", async (c) => {
         size: file.size,
         text: await object.text(),
       });
-      await c.env.BLOB.delete(key);
+      await deletePendingDocumentBlob(c.env.BLOB, key);
       results.push({ blobUrl: file.blobUrl, status: "success", document });
     }
 


### PR DESCRIPTION
## Summary
- Add a small retry helper for pending document R2 blob cleanup.
- Use it for `/api/v1/documents/pre-upload` DELETE cleanup and `/api/v1/documents/submit` post-import cleanup.
- Keep missing `BLOB` binding as a loud 503 deployment error; only retry transient delete failures after auth and blob ownership validation.

Fixes #11676.

## Evidence
- `bun test packages/cloud/api/__tests__/documents-preupload-delete-retry.test.ts` — 3 pass
- `bunx @biomejs/biome check --config-path biome.json --files-ignore-unknown=true packages/cloud/api/v1/documents/_pending-blob-cleanup.ts packages/cloud/api/v1/documents/pre-upload/route.ts packages/cloud/api/v1/documents/submit/route.ts packages/cloud/api/__tests__/documents-preupload-delete-retry.test.ts` — pass
- `bun run --cwd packages/cloud/api typecheck` — pass
- `bun run --cwd packages/cloud/api build` — pass
- `bun run --cwd packages/cloud/api test` — all 103 isolated unit files passed after local `packages/core` build
- `bun run --cwd packages/cloud/api test:e2e` — full cloud API e2e passed before rebase; Group J documents showed pre-upload POST 200 and DELETE 200
- `E2E_ONLY=group-j-documents bun run --cwd packages/cloud/api test:e2e` after rebase to `origin/develop` — 6 pass, including `DELETE /api/v1/documents/pre-upload 200 OK`

## N/A
- UI screenshots/video: N/A — cloud API route resilience only, no user-facing UI change.
- Model trajectories: N/A — no model/action/provider/prompt behavior change.
