### PR TITLE
fix(cloud): gate ensureElizaAppProvisioning on credits (return insufficient_credits, don't 500 onboarding) (#11499)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -383,6 +383,9 @@ function fallbackReply(args: {
   if (args.provisioning.status === "error") {
     return `I hit a provisioning issue, ${name}. Your control panel has the latest status, and the team can inspect it there.`;
   }
+  if (args.provisioning.status === "insufficient_credits") {
+    return `You're out of credits, ${name}. ${ELIZA_APP_PRICING_SUMMARY} Add credits at ${onboardingAppPath("/dashboard/billing")} and I'll start your private agent.`;
+  }
   return `Good, ${name}. Your private Eliza container is provisioning now. Keep chatting here while it starts up.`;
 }
 
@@ -432,6 +435,13 @@ async function generateOnboardingReply(args: {
   // generated ones so the SMS-safety invariant holds on every reply path
   // (session names captured before sanitization could carry non-ASCII).
   if (!args.preferredNameCaptured) {
+    return sanitizeReplyText(fallbackReply(args));
+  }
+
+  // Out-of-credits is a money-state reply: keep it deterministic (exact
+  // billing link, no invented amounts) instead of letting the model
+  // improvise billing copy.
+  if (args.provisioning.status === "insufficient_credits") {
     return sanitizeReplyText(fallbackReply(args));
   }
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts
@@ -9,6 +9,7 @@ const enqueueAgentProvision = mock();
 const deleteSandbox = mock();
 const hasElizaAppInitialFreeCredits = mock();
 const addCredits = mock();
+const checkAgentCreditGate = mock();
 
 const deleteSandboxSpy = spyOn(agentSandboxesRepository, "delete").mockImplementation(
   (...args) => deleteSandbox(...args) as never,
@@ -74,6 +75,10 @@ mock.module("../provisioning-jobs", () => ({
   },
 }));
 
+mock.module("../agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
 afterAll(() => {
   listByOrganizationSpy.mockRestore();
   createAgentSpy.mockRestore();
@@ -92,6 +97,7 @@ describe("ensureElizaAppProvisioning", () => {
     deleteSandbox.mockReset();
     hasElizaAppInitialFreeCredits.mockReset();
     addCredits.mockReset();
+    checkAgentCreditGate.mockReset();
   });
 
   test("grants starter credits before provisioning a new Eliza App agent", async () => {
@@ -101,6 +107,7 @@ describe("ensureElizaAppProvisioning", () => {
       transaction: { id: "credit-tx-1" },
       newBalance: 5,
     });
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
     createAgent.mockResolvedValue({
       agent: { id: "agent-1", status: "provisioning", bridge_url: null },
       idempotent: false,
@@ -123,6 +130,9 @@ describe("ensureElizaAppProvisioning", () => {
       },
       stripePaymentIntentId: "eliza-app-initial-free-credits:org-1",
     });
+    // Fresh org: the starter grant lands before the gate runs, so the gate
+    // sees the $5 balance and provisioning proceeds.
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(createAgent).toHaveBeenCalledWith({
       organizationId: "org-1",
       userId: "user-1",
@@ -146,6 +156,7 @@ describe("ensureElizaAppProvisioning", () => {
   test("reuses an in-flight sandbox without enqueuing a second provision job", async () => {
     hasElizaAppInitialFreeCredits.mockResolvedValue(true);
     listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
     createAgent.mockResolvedValue({
       agent: { id: "agent-1", status: "provisioning", bridge_url: null },
       idempotent: true,
@@ -168,6 +179,7 @@ describe("ensureElizaAppProvisioning", () => {
   test("deletes the just-created sandbox when the provision enqueue throws", async () => {
     hasElizaAppInitialFreeCredits.mockResolvedValue(true);
     listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
     createAgent.mockResolvedValue({
       agent: { id: "agent-1", status: "pending", bridge_url: null },
       idempotent: false,
@@ -203,10 +215,45 @@ describe("ensureElizaAppProvisioning", () => {
     expect(addCredits).not.toHaveBeenCalled();
     expect(createAgent).not.toHaveBeenCalled();
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    // The existing-sandbox early return sits before the credit gate, so a
+    // drained org with a live sandbox still gets it back untouched.
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       status: "running",
       agentId: "agent-1",
       bridgeUrl: "https://agent.example",
+    });
+  });
+
+  test("returns insufficient_credits without provisioning when a drained org fails the credit gate", async () => {
+    // Returning drained org: the one-time starter grant was already consumed,
+    // so ensureElizaAppStarterCredits is a no-op and the gate sees the real
+    // (empty) balance.
+    hasElizaAppInitialFreeCredits.mockResolvedValue(true);
+    listByOrganization.mockResolvedValue([]);
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: false,
+      balance: 0.05,
+      error:
+        "Insufficient credits. A balance greater than $0.10 is required to create or run Eliza agents.",
+    });
+
+    const result = await ensureElizaAppProvisioning({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(addCredits).not.toHaveBeenCalled();
+    // The denial must return a status, not throw — runOnboardingChat has no
+    // enclosing try/catch, so a throwing gate would 500 the onboarding turn.
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "insufficient_credits",
+      agentId: null,
+      bridgeUrl: null,
+      sandbox: null,
     });
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts
@@ -3,6 +3,7 @@ import { creditTransactionsRepository } from "../../../db/repositories/credit-tr
 import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
 import { containersEnv } from "../../config/containers-env";
 import { logger } from "../../utils/logger";
+import { checkAgentCreditGate } from "../agent-billing-gate";
 import { creditsService } from "../credits";
 import { elizaSandboxService } from "../eliza-sandbox";
 import { provisioningJobService } from "../provisioning-jobs";
@@ -90,6 +91,27 @@ export async function ensureElizaAppProvisioning(params: {
   const existing = await getElizaAppProvisioningStatus(params.organizationId);
   if (existing.sandbox) {
     return existing;
+  }
+
+  // Every other create/provision/resume path runs the credit gate before
+  // createAgent; this onboarding entry point must too. Fresh orgs just
+  // received the starter grant above so they pass, and an org with a live
+  // sandbox already returned early — the gate only blocks NEW provisioning
+  // for a drained returning org. Return a non-provisioning status instead of
+  // throwing: runOnboardingChat has no enclosing try/catch, so a throw here
+  // would 500 the whole onboarding turn.
+  const creditGate = await checkAgentCreditGate(params.organizationId);
+  if (!creditGate.allowed) {
+    logger.warn("[eliza-app provisioning] Credit gate blocked provisioning", {
+      orgId: params.organizationId,
+      balance: creditGate.balance,
+    });
+    return {
+      status: "insufficient_credits",
+      agentId: null,
+      bridgeUrl: null,
+      sandbox: null,
+    };
   }
 
   const { agent: sandbox, idempotent } = await elizaSandboxService.createAgent({


### PR DESCRIPTION
Closes #11499.

## The gap

`ensureElizaAppProvisioning` (`packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts`) was the only provisioning entry point that skipped the otherwise-universal `checkAgentCreditGate` — every other create/provision/resume/wake/restart path runs the gate before `createAgent`. It is reached from the public onboarding chat (`runOnboardingChat`, `onboarding-chat.ts`), so a drained returning org (starter grant already consumed, no live sandbox) could still mint a container. And because `runOnboardingChat` has no enclosing try/catch, a *throwing* gate would have 500'd the whole onboarding turn — hence the return-a-status design below.

## Fix (as prescribed by @lalalune on #11499)

**`provisioning.ts`** — after `ensureElizaAppStarterCredits` (so fresh orgs get the $5 grant and pass the $0.10 `MINIMUM_DEPOSIT` gate) and after the existing-sandbox early return (so an org with a live sandbox still gets it back untouched), call `checkAgentCreditGate(organizationId)` before `createAgent`. On `!allowed`, log a warn and **return** `{ status: "insufficient_credits", agentId: null, bridgeUrl: null, sandbox: null }` instead of throwing. The reuse guard and the enqueue-throw cleanup are unchanged.

**`onboarding-chat.ts`** — mapped the new status in the reply path:
- `fallbackReply`: new branch → "You're out of credits… Add credits at `<app>/dashboard/billing` and I'll start your private agent." (reuses `ELIZA_APP_PRICING_SUMMARY` + the existing `onboardingAppPath` helper).
- `generateOnboardingReply`: early deterministic return for `insufficient_credits` (money-state copy stays exact — the model never improvises billing links/amounts).

**Type note:** `ElizaAppProvisioningStatus.status` is typed `string` (not a literal union), and every consumer does plain `===` checks (`"running"`, `"error"`, `"none"`) — no exhaustive switch anywhere, so the new value is additive-safe. `publicElizaAppProvisioningPayload` passes it through and already omits the null `agentId`/`bridgeUrl`, so the wire payload for a denial is `{ status: "insufficient_credits" }` — consistent with the canonical `insufficient_credits` code used by the 402 body and cron agent-billing.

## Tests (`provisioning.test.ts`)

- **New:** drained returning org (grant already consumed → starter credits no-op, no sandbox, gate `!allowed`) → `createAgent`/`enqueueAgentProvision`/`addCredits` NOT called, result is exactly the `insufficient_credits` status.
- **Extended:** fresh-org test now mocks the gate `allowed` and asserts it was called — grant lands before the gate, so fresh orgs still provision.
- **Extended:** existing-sandbox test asserts the gate is NOT called — a drained org with a live sandbox still gets it back (early return sits before the gate).
- Gate mocked via the file's existing `mock.module` pattern (`../agent-billing-gate`), reset in `beforeEach` like the other mocks.

## Files

- `packages/cloud/shared/src/lib/services/eliza-app/provisioning.ts`
- `packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts`
- `packages/cloud/shared/src/lib/services/eliza-app/provisioning.test.ts`

## Caveat

Local typecheck/tests couldn't run (box at 100% disk, worktree has no node_modules); static-verified by grep (export exists, `CreditGateResult.allowed`/`.balance` shape matches usage, no exhaustive status switches, `onboarding-chat.test.ts` fully mocks `./provisioning` so the new import chain doesn't leak there). **CI must confirm** typecheck + `provisioning.test.ts`.

@lalalune — this is your prescribed approach from #11499 verbatim; flagging for your review. Not self-merging.

— [cloud-security]
