### PR TITLE
fix(elizaos,scenario-runner): capture $-pattern corruption, git+ssh repo URLs, list-lane default parity

### DIFF
--- a/packages/elizaos/src/commands/plugins.test.ts
+++ b/packages/elizaos/src/commands/plugins.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { submitPluginToRegistry } from "./plugins.js";
 
 let tempDirs: string[] = [];
@@ -39,6 +39,32 @@ describe("submitPluginToRegistry", () => {
     await expect(
       submitPluginToRegistry(dir, { base: "main", dryRun: true }),
     ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["git+ssh://git@github.com/acme/plugin-weather.git"],
+    ["ssh://git@github.com/acme/plugin-weather.git"],
+    ["git://github.com/acme/plugin-weather.git"],
+  ])("normalizes the npm repository url form %s", async (repositoryUrl) => {
+    const dir = makePluginPackage({
+      name: "@acme/plugin-weather",
+      version: "1.0.0",
+      keywords: ["elizaos", "plugin"],
+      repository: { type: "git", url: repositoryUrl },
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await submitPluginToRegistry(dir, { base: "main", dryRun: true });
+      const printed = logSpy.mock.calls.at(-1)?.[0];
+      expect(typeof printed).toBe("string");
+      const parsed = JSON.parse(printed as string) as {
+        metadata: { repository: string };
+      };
+      expect(parsed.metadata.repository).toBe("github:acme/plugin-weather");
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it("rejects PR submission when no writable registry repository is configured", async () => {

--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -258,6 +258,8 @@ function normalizeGithubRepo(value: string | null | undefined): string | null {
   }
   input = input
     .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/^ssh:\/\/git@github\.com[:/]/, "")
+    .replace(/^git:\/\/github\.com\//, "")
     .replace(/^git@github\.com:/, "")
     .replace(/\.git$/, "")
     .replace(/\/tree\/.*$/, "")

--- a/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
+++ b/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { listScenarioMetadata } from "../loader";
+
+let tempDirs: string[] = [];
+
+function makeScenarioDir(
+  files: Record<string, { id: string; lane?: string }>,
+): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "scenario-lane-filter-"));
+  tempDirs.push(dir);
+  for (const [fileName, { id, lane }] of Object.entries(files)) {
+    writeFileSync(
+      path.join(dir, fileName),
+      [
+        "export default {",
+        `  id: "${id}",`,
+        `  title: "${id}",`,
+        '  domain: "loader-test",',
+        ...(lane ? [`  lane: "${lane}",`] : []),
+        "  turns: [],",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  }
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("listScenarioMetadata lane filtering", () => {
+  it("includes scenarios without a declared lane when filtering by the default lane", async () => {
+    // A scenario that declares no lane IS a live-only scenario
+    // (DEFAULT_SCENARIO_LANE). `list --lane live-only` must therefore agree
+    // with `run --lane live-only`, which resolves the lane via scenarioLane().
+    const dir = makeScenarioDir({
+      "undeclared.scenario.ts": { id: "lane-undeclared" },
+      "deterministic.scenario.ts": {
+        id: "lane-deterministic",
+        lane: "pr-deterministic",
+      },
+    });
+
+    const liveOnly = await listScenarioMetadata(
+      dir,
+      undefined,
+      undefined,
+      false,
+      "live-only",
+    );
+    expect(liveOnly.map((scenario) => scenario.id)).toEqual([
+      "lane-undeclared",
+    ]);
+  });
+
+  it("still filters declared lanes exactly", async () => {
+    const dir = makeScenarioDir({
+      "undeclared.scenario.ts": { id: "lane-undeclared" },
+      "deterministic.scenario.ts": {
+        id: "lane-deterministic",
+        lane: "pr-deterministic",
+      },
+    });
+
+    const deterministic = await listScenarioMetadata(
+      dir,
+      undefined,
+      undefined,
+      false,
+      "pr-deterministic",
+    );
+    expect(deterministic.map((scenario) => scenario.id)).toEqual([
+      "lane-deterministic",
+    ]);
+
+    const unfiltered = await listScenarioMetadata(dir);
+    expect(unfiltered.map((scenario) => scenario.id).sort()).toEqual([
+      "lane-deterministic",
+      "lane-undeclared",
+    ]);
+  });
+});

--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -205,6 +205,77 @@ describe("scenario executor api turn captures", () => {
     expect(report.turns[1]?.responseText).not.toContain("token-abc");
   });
 
+  it("inserts captured values containing replacement patterns ($&, $$, $`) literally", async () => {
+    const rawToken = "pre$&mid$$post$`";
+    const runtime = createRuntime([], {
+      routes: [
+        {
+          type: "POST",
+          path: "/mint",
+          handler: async (_req: RouteRequest, res: RouteResponse) => {
+            res.status(200).json({ secret: rawToken });
+          },
+        },
+        {
+          type: "POST",
+          path: "/echo",
+          handler: async (req: RouteRequest, res: RouteResponse) => {
+            const body = req.body ?? {};
+            res.status(200).json({ echoed: body.secret });
+          },
+        },
+      ],
+    });
+
+    const report = await runScenario(
+      {
+        id: "api-capture-dollar-patterns",
+        title: "API capture dollar patterns",
+        domain: "executor",
+        turns: [
+          {
+            kind: "api",
+            name: "mint",
+            method: "POST",
+            path: "/mint",
+            expectedStatus: 200,
+            captures: { secret: "secret" },
+          },
+          {
+            kind: "api",
+            name: "echo",
+            method: "POST",
+            path: "/echo",
+            body: { secret: "{{capture:secret}}" },
+            expectedStatus: 200,
+            assertResponse(status, body) {
+              const record =
+                body && typeof body === "object"
+                  ? (body as Record<string, unknown>)
+                  : {};
+              if (status !== 200) return `expected status 200, saw ${status}`;
+              if (record.echoed !== rawToken) {
+                return `expected captured value ${JSON.stringify(
+                  rawToken,
+                )} inserted literally, saw ${JSON.stringify(record.echoed)}`;
+              }
+              return undefined;
+            },
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.turns.map((turn) => turn.failedAssertions)).toEqual([[], []]);
+    expect(report.status).toBe("passed");
+  });
+
   it("redacts configured API response fields only in persisted turn reports", async () => {
     const runtime = createRuntime([], {
       routes: [

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1085,7 +1085,11 @@ async function resolveTemplateString(args: {
         `[executor] unsupported scenario template token ${fullMatch}`,
       );
     }
-    resolved = resolved.replace(fullMatch, replacement);
+    const literalReplacement = replacement;
+    // Replace via callback so `$` sequences in captured values (`$&`, `$$`,
+    // `` $` ``) are inserted literally instead of being expanded as
+    // replacement patterns.
+    resolved = resolved.replace(fullMatch, () => literalReplacement);
   }
   return resolved;
 }

--- a/packages/scenario-runner/src/loader.ts
+++ b/packages/scenario-runner/src/loader.ts
@@ -9,10 +9,11 @@ import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import {
+  DEFAULT_SCENARIO_LANE,
   type ScenarioDefinition,
   type ScenarioLane,
-  scenario as validateScenarioDefinition,
   scenarioLane,
+  scenario as validateScenarioDefinition,
 } from "@elizaos/scenario-runner/schema";
 import ts from "typescript";
 
@@ -461,7 +462,12 @@ export async function listScenarioMetadata(
       }
     }
     const result = await loadScenarioMetadataFile(file);
-    if (laneFilter && result.lane !== laneFilter) continue;
+    // Apply the default lane exactly like `scenarioLane()` does on the run
+    // path (loadAllScenarios): a scenario with no declared lane IS a
+    // live-only scenario, so `list --lane live-only` must include it.
+    if (laneFilter && (result.lane ?? DEFAULT_SCENARIO_LANE) !== laneFilter) {
+      continue;
+    }
     if (result.status === "pending" && !includePending) continue;
     const candidates = [
       result,


### PR DESCRIPTION
## What

Three real, unit-provable logic bugs in the `elizaos` CLI and the scenario/eval harness, each fixed minimally with a mutation-checked unit test.

### 1. scenario-runner executor — `{{capture:...}}` corrupts values containing `$` patterns
`packages/scenario-runner/src/executor.ts` (`resolveTemplateString`) substituted tokens with `String.replace(fullMatch, replacement)` using a **string** replacement, so JS replacement patterns in captured API values were expanded instead of inserted.

- **Concrete failure:** an api turn captures `secret = "pre$&mid$$post$` + "`" + `"` from a response; the next turn's body `{"secret": "{{capture:secret}}"}` is sent as `pre{{capture:secret}}mid$post…` — `$&` re-inserts the matched token, `$$` collapses to `$`, `` $` `` splices in preceding text. Any captured token/signature containing `$` silently corrupts the follow-up request.
- **Fix:** replace via callback (`() => literalReplacement`) so the value is inserted literally. (The sibling `resolveScenarioTemplates` already used the callback form and was unaffected.)
- **Test:** `executor.test.ts` → "inserts captured values containing replacement patterns ($&, $$, $`) literally" — mint/echo loopback routes, asserts the echoed value round-trips byte-identical.

### 2. elizaos CLI — `plugins submit` rejects npm-standard `git+ssh://` / `git://` repository URLs
`packages/elizaos/src/commands/plugins.ts` (`normalizeGithubRepo`) handled `https://`, `git+https://`, and `git@github.com:` but returned `null` for `git+ssh://git@github.com/owner/repo.git` (the form npm's docs use) and `git://github.com/owner/repo.git`: after stripping `git+`, `"ssh://git@github.com/owner/repo".split("/")` yields owner `"ssh:"` / repo `""`.

- **Concrete failure:** a valid `package.json` with `"repository": {"url": "git+ssh://git@github.com/acme/plugin-weather.git"}` (no homepage, no git remote) fails `plugins submit` with `Could not infer a GitHub repository. Add repository.url to package.json.` — the field it demands is already set.
- **Fix:** additionally strip `^ssh://git@github.com[:/]` and `^git://github.com/`.
- **Test:** `plugins.test.ts` → `it.each` over the three URL forms, drives real `submitPluginToRegistry --dry-run` in a temp package dir and asserts the emitted metadata is `github:acme/plugin-weather`.

### 3. scenario-runner loader — `list --lane live-only` drops every scenario without a declared lane
`packages/scenario-runner/src/loader.ts` (`listScenarioMetadata`) filtered on the raw declared lane (`result.lane !== laneFilter`), while the **run** path (`loadAllScenarios`) resolves lanes via `scenarioLane()`, which applies `DEFAULT_SCENARIO_LANE = "live-only"`.

- **Concrete failure:** for a corpus of scenarios that declare no `lane` (the documented default is live-only), `eliza-scenarios list <dir> --lane live-only` prints **nothing** while `eliza-scenarios run <dir> --lane live-only` runs all of them — list and run disagree about the same lane.
- **Fix:** `(result.lane ?? DEFAULT_SCENARIO_LANE) !== laneFilter`, matching the run path exactly.
- **Test:** `__tests__/loader-lane-filter.test.ts` — temp scenario dir with one undeclared-lane and one `pr-deterministic` file; asserts live-only listing includes the undeclared one, plus a guard that declared-lane filtering and unfiltered listing are unchanged.

## Evidence

| Item | Result |
|---|---|
| Unit tests (real code paths, no mocks of the unit under test) | `scenario-runner`: 31/31 (executor 29 + lane filter 2); `elizaos`: 6/6 — all via `bunx vitest run` |
| Mutation checks | Each fix reverted **in isolation** → only its own test(s) fail (executor 1 failed/28 skipped; plugins 3 failed; loader 1 failed/1 passed) → restored → green |
| Lint | `bunx biome check --write` clean on all 6 touched files |
| Base sync | Branch fast-forwarded to `origin/develop` (`ae766c9274`) before final test pass + push |
| Live-LLM trajectories | N/A — pure deterministic string/URL/filter logic in the CLI + harness; no agent/action/prompt/model behavior changed |
| Screenshots / video / UI capture | N/A — no user-facing UI surface; CLI/harness logic only |
| Device/platform capture | N/A — non-device change |

Scope kept surgical: only `packages/elizaos/src` + `packages/scenario-runner/src` and their tests; no money, contested, or device paths touched.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (find + fix + tests + mutation-checks + push, single pass). Independently re-verified by the main loop: 6-file merge-base diff, 37/37 tests pass fresh, and the executor.ts $-corruption mutation reproduced (revert -> 1 fail; restore -> 29 pass). -- [phone-ui]