### PR TITLE
fix(cloud): refund social-media credits when credential resolution or reply provider throws (money leak)

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/index.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/index.ts
@@ -342,19 +342,23 @@ class SocialMediaService {
             error: `Platform ${platform} is not supported`,
           };
 
-        const credentials = await this.getCredentialsForPlatform(
-          organizationId,
-          platform,
-          credentialIds?.[platform],
-        );
-        if (!credentials)
-          return {
-            platform,
-            success: false,
-            error: `No credentials found for ${platform}`,
-          };
-
+        // Everything after the deduction must stay inside this try: a thrown
+        // credential error (e.g. "Token expired." from a failed OAuth refresh)
+        // must resolve to {success:false} so the per-platform refund below
+        // runs, instead of rejecting the whole Promise.all and skipping it.
         try {
+          const credentials = await this.getCredentialsForPlatform(
+            organizationId,
+            platform,
+            credentialIds?.[platform],
+          );
+          if (!credentials)
+            return {
+              platform,
+              success: false,
+              error: `No credentials found for ${platform}`,
+            };
+
           return await provider.createPost(credentials, content, platformOptions);
         } catch (error) {
           const errorMessage = extractErrorMessage(error);
@@ -514,7 +518,19 @@ class SocialMediaService {
 
     if (!deduction.success) return { platform, success: false, error: "Insufficient credits" };
 
-    const result = await provider.replyToPost(credentials, postId, content, options);
+    // A provider that THROWS (vs returning {success:false}) must still hit the
+    // refund below — otherwise the user is charged for a reply that never posted.
+    let result: PostResult;
+    try {
+      result = await provider.replyToPost(credentials, postId, content, options);
+    } catch (error) {
+      const errorMessage = extractErrorMessage(error);
+      logger.error("[SocialMedia] Reply failed", {
+        platform,
+        error: errorMessage,
+      });
+      result = { platform, success: false, error: errorMessage };
+    }
 
     if (!result.success) {
       await creditsService.refundCredits({

--- a/packages/cloud/shared/src/lib/services/social-media/social-media.credit-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/social-media.credit-refund.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression tests for the charge-then-throw money leak in
+ * `socialMediaService.createPost` / `replyToPost` (#11680).
+ *
+ * The bug: `createPost` deducted credits for ALL platforms up front, then
+ * awaited `getCredentialsForPlatform` OUTSIDE the per-platform try. That
+ * method THROWS ("Token expired. …") when a stored OAuth token is expired and
+ * the refresh fails, which rejected the whole `Promise.all` — so the
+ * per-platform refund (which only inspects settled `{success:false}` results)
+ * never ran. One revoked credential = user charged for every platform,
+ * nothing posted, no refund. Same class in `replyToPost`: the provider call
+ * was unwrapped, so a THROWN provider error (vs a returned `{success:false}`)
+ * skipped the refund.
+ *
+ * These tests drive the real `createPost`/`replyToPost` control flow and pin:
+ *  - a thrown credential error resolves to `{success:false}` and is refunded
+ *    (net charge 0 on total failure),
+ *  - partial-refund accounting is exact (only failed platforms refunded),
+ *  - a throwing reply provider still triggers the refund.
+ */
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+interface RecordedCall {
+  organizationId: string;
+  amount: number;
+  description: string;
+  metadata?: Record<string, unknown>;
+}
+
+const deductCalls: RecordedCall[] = [];
+const refundCalls: RecordedCall[] = [];
+
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits: async (params: RecordedCall) => {
+      deductCalls.push(params);
+      return { success: true, newBalance: 100, transaction: null };
+    },
+    refundCredits: async (params: RecordedCall) => {
+      refundCalls.push(params);
+      return { transaction: {}, newBalance: 100 };
+    },
+  },
+}));
+
+// Alert fan-out is env-gated fire-and-forget; stub it so tests never touch the network.
+mock.module("./alerts", () => ({
+  alertOnPostFailure: async () => {},
+}));
+
+const { socialMediaService } = await import("./index");
+const { blueskyProvider } = await import("./providers/bluesky");
+const { twitterProvider } = await import("./providers/twitter");
+
+const ORG_ID = "00000000-0000-4000-8000-00000000a001";
+const USER_ID = "00000000-0000-4000-8000-00000000a002";
+const POST_CREDIT_COST = 0.01;
+const TOKEN_EXPIRED = "Token expired. Please reconnect your account.";
+
+const spies: Array<{ mockRestore: () => void }> = [];
+
+beforeEach(() => {
+  deductCalls.length = 0;
+  refundCalls.length = 0;
+});
+
+afterEach(() => {
+  while (spies.length > 0) spies.pop()?.mockRestore();
+});
+
+describe("createPost refund on thrown credential error (#11680)", () => {
+  test("refunds every platform when credential resolution throws — net charge is 0", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async () => {
+        throw new Error(TOKEN_EXPIRED);
+      },
+    );
+    spies.push(credsSpy);
+
+    const result = await socialMediaService.createPost({
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      content: { text: "hello world" },
+      platforms: ["twitter", "linkedin"],
+    });
+
+    // The thrown cred error must resolve to per-platform failures, not reject.
+    expect(result.totalPlatforms).toBe(2);
+    expect(result.successCount).toBe(0);
+    expect(result.failureCount).toBe(2);
+    for (const r of result.results) {
+      expect(r.success).toBe(false);
+      expect(r.error).toContain("Token expired");
+    }
+
+    // Charged for 2 platforms, refunded for 2 platforms — net 0.
+    expect(deductCalls).toHaveLength(1);
+    expect(deductCalls[0]?.amount).toBeCloseTo(2 * POST_CREDIT_COST, 10);
+    expect(refundCalls).toHaveLength(1);
+    expect(refundCalls[0]?.amount).toBeCloseTo(2 * POST_CREDIT_COST, 10);
+
+    const netCharge = deductCalls[0].amount - refundCalls[0].amount;
+    expect(netCharge).toBeCloseTo(0, 10);
+  });
+
+  test("refunds ONLY the failed platform when another platform succeeds", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async (_orgId, platform) => {
+        if (platform === "twitter") throw new Error(TOKEN_EXPIRED);
+        return { platform, handle: "tester.bsky.social", appPassword: "app-pass" };
+      },
+    );
+    const postSpy = spyOn(blueskyProvider, "createPost").mockImplementation(async () => ({
+      platform: "bluesky" as const,
+      success: true,
+      postId: "post-123",
+    }));
+    spies.push(credsSpy, postSpy);
+
+    const result = await socialMediaService.createPost({
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      content: { text: "hello world" },
+      platforms: ["twitter", "bluesky"],
+    });
+
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.successful[0]?.platform).toBe("bluesky");
+    expect(result.failed[0]?.platform).toBe("twitter");
+
+    // Charged 2x, refunded exactly 1x — partial-refund accounting preserved.
+    expect(deductCalls).toHaveLength(1);
+    expect(deductCalls[0]?.amount).toBeCloseTo(2 * POST_CREDIT_COST, 10);
+    expect(refundCalls).toHaveLength(1);
+    expect(refundCalls[0]?.amount).toBeCloseTo(1 * POST_CREDIT_COST, 10);
+    expect(refundCalls[0]?.metadata?.failedPlatforms).toEqual(["twitter"]);
+  });
+});
+
+describe("replyToPost refund on thrown provider error (#11680)", () => {
+  test("refunds the reply charge when the provider throws instead of returning {success:false}", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async () => ({ platform: "twitter" as const, accessToken: "tok" }),
+    );
+    const replySpy = spyOn(twitterProvider, "replyToPost").mockImplementation(async () => {
+      throw new Error("Twitter API 500: upstream unavailable");
+    });
+    spies.push(credsSpy, replySpy);
+
+    const result = await socialMediaService.replyToPost(ORG_ID, "twitter", "orig-post-1", {
+      text: "reply text",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("upstream unavailable");
+
+    expect(deductCalls).toHaveLength(1);
+    expect(deductCalls[0]?.amount).toBeCloseTo(POST_CREDIT_COST, 10);
+    expect(refundCalls).toHaveLength(1);
+    expect(refundCalls[0]?.amount).toBeCloseTo(POST_CREDIT_COST, 10);
+  });
+});


### PR DESCRIPTION
Closes #11680

## The leak

`socialMediaService.createPost` deducts credits for **all** requested platforms up front, then awaited `getCredentialsForPlatform` **outside** the per-platform `try`. `getCredentialsForPlatform` **throws** `"Token expired. …"` whenever a stored OAuth token is expired and the refresh fails (revoked grant, provider outage). The throw rejected the whole `Promise.all`, so the per-platform refund — which only inspects settled `{success:false}` results — never ran:

- user charged for **every** platform,
- **nothing posted** (healthy platforms' results discarded by the rejection),
- **no refund**.

Live surface: `POST /api/v1/apps/[id]/promote` → `app-promotion.ts:498` → `socialMediaService.createPost`. Any org with one expired/revoked social credential silently loses `platforms.length × POST_CREDIT_COST` per attempt.

Same class in `replyToPost`: the provider call was unwrapped, so a **thrown** provider error (vs a returned `{success:false}`) skipped the refund.

## The fix

- `createPost`: the whole per-platform body (credential fetch + provider call) now lives inside the per-platform `try`, so a thrown cred error resolves to `{platform, success:false, error}` and flows to the existing refund block. Partial-refund accounting unchanged — refund only failed platforms.
- `replyToPost`: provider call wrapped in try/catch; a throw becomes `{success:false}` and hits the same refund.

No behavior change on any success path; error strings surface via the existing `extractErrorMessage`.

## Evidence

**Red before** (fix stashed, test against develop's code — all 3 fail exactly as diagnosed):

```
error: Token expired. Please reconnect your account.
      at (social-media/index.ts:345:40)   <- cred fetch outside try
      at createPost (social-media/index.ts:336:17)  <- Promise.all rejects
(fail) createPost refund on thrown credential error (#11680) > refunds every platform ...
(fail) createPost refund on thrown credential error (#11680) > refunds ONLY the failed platform ...
error: Twitter API 500: upstream unavailable
      at replyToPost (social-media/index.ts:517:35)  <- unwrapped provider call
(fail) replyToPost refund on thrown provider error (#11680) ...
 0 pass / 3 fail
```

**Green after:**

```
[SocialMedia] Post failed { platform: "twitter", error: "Token expired. Please reconnect your account." }
[SocialMedia] Reply failed { platform: "twitter", error: "Twitter API 500: upstream unavailable" }
 3 pass / 0 fail — 27 expect() calls
```

Tests pin: net charge **0** on total failure (deduct 0.02 / refund 0.02), **exact** partial refund (deduct 0.02 / refund 0.01, `failedPlatforms:["twitter"]`), and reply-throw refund (deduct 0.01 / refund 0.01). They drive the real `createPost`/`replyToPost` control flow; only the credit ledger calls, the credential resolver (armed to throw — the condition under test), and the provider singletons are stubbed.

- `bun run --cwd packages/cloud/shared typecheck` → exit 0
- `biome check` on both files → clean
- UI/screenshots/trajectories: N/A — server-side credit-accounting control flow; no UI, no model in the loop.

— [cloud-security]

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
