### PR TITLE
fix(cloud): settle swept app-chat holds markup-inclusively — sweep refunded the creator markup to the org (#11592 residual)

### DIFF
--- a/.github/issue-evidence/11592-app-chat-sweep-markup.md
+++ b/.github/issue-evidence/11592-app-chat-sweep-markup.md
@@ -1,0 +1,90 @@
+# Issue #11592 — swept app-chat holds settle markup-inclusively
+
+## Scope
+
+Issue #11592's core (app-chat stranded holds never swept) was fixed by the
+merged #11493, verified on develop tip before this change:
+
+- app-chat holds are stamped `settlement_marker = app_chat_reservation_v1`
+  (`apps/[id]/chat/route.ts`) and the hold transaction id is threaded through
+  every settle/refund site;
+- `sweepStaleReservations` matches both marker shapes, claims via a
+  compare-and-set on `settled_at`, and refunds under the idempotent
+  `recon:<txid>:refund` key;
+- the cron route is registered (`api/cron/sweep-credit-reservations`) and
+  fans out on the `* * * * *` schedule present in `wrangler.toml`;
+- `bun test --isolate --conditions eliza-source` on the 4 money suites from
+  #11493's evidence: 68 pass / 0 fail on develop tip.
+
+**Residual bug fixed here — unit mismatch in the sweep's settle target.**
+The sweep settles a stale hold to `metadata.estimated_cost`. For generic
+reservations that is org-charge units (correct). For app-chat holds it is the
+UNBUFFERED BASE cost, while the row amount is the org charge — buffered base
+PLUS creator markup (`computeInferenceCharge` via
+`appCreditsService.deductCredits`), and the creator's earnings are recorded
+at deduct time. So sweeping a stranded MONETIZED app-chat hold refunded the
+org the markup too, while the creator kept the earnings: the platform ate the
+full creator markup on every swept monetized hold. The pre-existing test
+masked this by modeling `reserved_amount == row amount` (markup = 0).
+
+Fix: for `app_chat_reservation` rows, settle the org to
+`row amount × (estimated_cost / reserved_amount)` — exactly what a normal
+settle at the estimated cost charges (base × (1 + markup)). Markup-0 holds
+collapse to the previous math; holds without a usable base pair settle
+exact-cost; the result is clamped to the held amount so corrupt metadata can
+never become a surprise overage charge.
+
+Remaining scope (documented, not silently dropped): the sweep still does not
+reverse the creator-earnings share of the BUFFER delta
+(`(reservedBase − estimatedBase) × markup`, $0.10 in the test shape) — that
+requires app-earnings machinery (`appCreditsService`) which `creditsService`
+cannot import (dependency direction). Platform-absorbed, bounded, rare-path;
+flagged for [cloud-money] on the PR.
+
+## Red / green proof (real PGlite)
+
+New test: monetized shape — $1.00 base estimate, 1.5× buffer, 20% markup →
+$1.80 hold; sweep must refund $0.60 (org nets $1.20), exactly once.
+
+Pre-fix (develop `credits.ts`, new test only):
+
+```text
+error: expect(received).toBeCloseTo(expected, precision)
+Expected: 8.8
+Received: 9
+Received difference: 0.1999999999999993
+(fail) CreditsService reservation settlement marker (#11169) > sweep settles
+monetized app-chat holds markup-inclusively — exactly one refund, org nets
+the marked-up estimate
+```
+
+(balance 9.0 = the org was over-refunded $0.80, pocketing the markup)
+
+Post-fix, full suite:
+
+```text
+bun test --isolate --conditions eliza-source \
+  packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+=> Ran 30 tests across 1 file. 0 fail
+```
+
+The new tests assert: exactly one refund row (`recon:<txid>:refund`,
+`0.600000`), `settled_at` claimed, a re-sweep scans 0 rows, a late
+full-refund settle after the sweep is a no-op (`adjustmentType: "none"`,
+refund count stays 1) — no double-refund; plus the missing-base-pair hold
+settles exact-cost (no refund, no guess).
+
+## Lint / typecheck
+
+```text
+biome check packages/cloud/shared/src/lib/services/credits.ts \
+  packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+=> Checked 2 files. No fixes applied.
+
+bun run --cwd packages/cloud/shared typecheck | grep -E "credits|error TS"
+=> no errors for the touched files
+```
+
+## UI / Media
+
+N/A — backend money-path cron/settlement fix; no user-facing UI surface.

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -95,7 +95,11 @@ async function insertReservation(
   return (res.rows[0] as { id: string }).id;
 }
 
-async function insertAppChatReservation(amount: number, ageMs = 0): Promise<string> {
+async function insertAppChatReservation(
+  amount: number,
+  ageMs = 0,
+  metadataOverrides: Record<string, unknown> = {},
+): Promise<string> {
   const createdAt = new Date(Date.now() - ageMs).toISOString();
   const metadata = {
     appId: "app-chat-test",
@@ -109,6 +113,7 @@ async function insertAppChatReservation(amount: number, ageMs = 0): Promise<stri
     estimated_cost: amount / 1.5,
     reserved_amount: amount,
     totalCost: amount,
+    ...metadataOverrides,
   };
   const res = await dbWrite.execute(
     `INSERT INTO credit_transactions (
@@ -951,6 +956,96 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       expect(late.adjustmentType).toBe("none");
       expect(await getBalance()).toBeCloseTo(9, 6);
       expect(await countByType("refund")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "sweep settles monetized app-chat holds markup-inclusively — exactly one refund, org nets the marked-up estimate",
+    async () => {
+      if (!pgliteReady) return;
+      // Production monetized shape (#11592): base estimate $1.00, 1.5x buffer
+      // -> reserved base $1.50, 20% creator markup -> $1.80 org hold
+      // (`computeInferenceCharge`), creator earnings recorded at deduct time.
+      // The sweep must settle the org to $1.20 (estimate + markup, what a
+      // normal settle at the estimate charges), i.e. refund $0.60 — NOT to
+      // the bare $1.00 base estimate: refunding $0.80 would hand the markup
+      // on the estimate back to the org while the creator keeps the earnings,
+      // so the platform would eat the whole markup.
+      await seedOrg("8.2"); // org had 10, paid the 1.8 hold
+      const reservationId = await insertAppChatReservation(1.8, 25 * 60 * 1000, {
+        estimated_cost: 1.0,
+        reserved_amount: 1.5,
+        totalCost: 1.8,
+        baseCost: 1.5,
+        creatorMarkup: 0.3,
+        markupPercentage: 20,
+      });
+
+      const stats = await creditsService.sweepStaleReservations({
+        graceMs: 20 * 60 * 1000,
+        batchSize: 10,
+      });
+
+      expect(stats.scanned).toBe(1);
+      expect(stats.settled).toBe(1);
+      expect(stats.refunds).toBe(1);
+      expect(await getBalance()).toBeCloseTo(8.8, 6);
+      expect(await getReservationSettledAt(reservationId)).toBeTruthy();
+      expect(await settlementRowsForReservation(reservationId)).toEqual([
+        {
+          amount: "0.600000",
+          type: "refund",
+          stripe_payment_intent_id: `recon:${reservationId}:refund`,
+        },
+      ]);
+
+      // Idempotent: a re-sweep skips the settled hold entirely, and a late
+      // full-refund settle after the sweep is a no-op — exactly one refund.
+      const again = await creditsService.sweepStaleReservations({
+        graceMs: 20 * 60 * 1000,
+        batchSize: 10,
+      });
+      expect(again.scanned).toBe(0);
+      expect(again.settled).toBe(0);
+
+      const late = await creditsService.reconcile({
+        organizationId: ORG_ID,
+        reservedAmount: 1.8,
+        actualCost: 0,
+        description: "late app-chat refund after sweep",
+        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
+      });
+
+      expect(late.adjustmentType).toBe("none");
+      expect(await getBalance()).toBeCloseTo(8.8, 6);
+      expect(await countByType("refund")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "sweep settles an app-chat hold without a usable base pair exact-cost instead of guessing",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("8.2");
+      const reservationId = await insertAppChatReservation(1.8, 25 * 60 * 1000, {
+        estimated_cost: null,
+        reserved_amount: null,
+      });
+
+      const stats = await creditsService.sweepStaleReservations({
+        graceMs: 20 * 60 * 1000,
+        batchSize: 10,
+      });
+
+      expect(stats.scanned).toBe(1);
+      expect(stats.settled).toBe(1);
+      expect(stats.noops).toBe(1);
+      expect(stats.refunds).toBe(0);
+      expect(await getBalance()).toBeCloseTo(8.2, 6);
+      expect(await getReservationSettledAt(reservationId)).toBeTruthy();
+      expect(await settlementRowsForReservation(reservationId)).toEqual([]);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -201,6 +201,41 @@ function metadataNumber(value: unknown): number | null {
   return null;
 }
 
+/**
+ * Org-charge a stale hold settles to during the stranded-reservation sweep
+ * (#11592).
+ *
+ * Generic reservation rows (`credit_reservation_v1`) store `estimated_cost`
+ * in ORG-CHARGE units — the same unit as the row amount — so the sweep
+ * settles to it directly (missing estimate ⇒ exact-cost, no refund).
+ *
+ * App-chat holds (`app_chat_reservation_v1`) store BASE-cost numbers
+ * (`estimated_cost` = unbuffered base, `reserved_amount` = buffered base —
+ * see apps/[id]/chat/route.ts), while the row amount is the ORG charge:
+ * buffered base PLUS the creator markup (`computeInferenceCharge` via
+ * `appCreditsService.deductCredits`). Settling the org to the bare base
+ * estimate would hand the markup back to the org while the creator's
+ * earnings — recorded at deduct time — stay put, so the platform would eat
+ * the full creator markup on every swept monetized hold. Instead scale the
+ * org charge by estimated/reserved: the org nets exactly what a normal
+ * settle at the estimated cost would charge (base × (1 + markup)). Holds
+ * without a usable base pair settle exact-cost, and the result is clamped
+ * to the held amount so corrupt metadata can never turn the sweep into a
+ * surprise overage charge.
+ */
+function staleHoldSettleCost(reservedAmount: number, metadata: Record<string, unknown>): number {
+  const estimate =
+    metadataNumber(metadata.estimated_cost) ?? metadataNumber(metadata.estimatedCost);
+  if (metadata.type !== "app_chat_reservation") {
+    return estimate ?? reservedAmount;
+  }
+  const reservedBase = metadataNumber(metadata.reserved_amount);
+  if (estimate === null || reservedBase === null || reservedBase <= 0) {
+    return reservedAmount;
+  }
+  return Math.min(reservedAmount, Math.max(0, reservedAmount * (estimate / reservedBase)));
+}
+
 function toCreditTransaction(row: CreditMutationRow): CreditTransaction {
   if (!row.id || !row.organization_id || !row.amount || !row.type || !row.created_at) {
     throw new Error("[CreditsService] Credit mutation did not return a transaction row");
@@ -1715,10 +1750,7 @@ export class CreditsService {
       for (const row of rows) {
         const reservedAmount = Math.abs(parseNumeric(row.amount, "reservation_amount"));
         const reservationMetadata = parseMetadata(row.metadata);
-        const actualCost =
-          metadataNumber(reservationMetadata.estimated_cost) ??
-          metadataNumber(reservationMetadata.estimatedCost) ??
-          reservedAmount;
+        const actualCost = staleHoldSettleCost(reservedAmount, reservationMetadata);
         const description = (row.description ?? "Credit reservation").replace(
           /\s+\(reserved\)$/,
           "",


### PR DESCRIPTION
## Summary

Refs #11592 (auto-closed by #11493's merge — the core "stranded app-chat holds are never swept" gap IS fixed there and verified below). This PR fixes the **residual money bug in the merged sweep's app-chat settle math** plus real-PGlite proof that a stranded hold is swept **exactly once** (no double-refund).

### Verified already fixed on develop (no duplication here)

- App-chat holds carry `settlement_marker = app_chat_reservation_v1` (`apps/[id]/chat/route.ts:326`) and the hold txid is threaded through every settle/refund site.
- `sweepStaleReservations` matches both marker shapes, claims via compare-and-set on `settled_at`, refunds under the idempotent `recon:<txid>:refund` key (#11512/#10846 pattern).
- Cron registered (`api/cron/sweep-credit-reservations`) and fanned out on the `* * * * *` schedule in `wrangler.toml`.
- The three formerly-misleading comments now describe a sweep that exists.
- 68 pass / 0 fail on the 4 money suites from #11493's evidence, re-run locally on develop tip.

### The residual bug (fixed here): unit mismatch → platform eats the creator markup

The sweep settles a stale hold to `metadata.estimated_cost`. For **generic** reservations that's org-charge units — correct. For **app-chat** holds it's the **unbuffered BASE cost** (no markup), while the row amount is the org charge: buffered base **plus creator markup** (`computeInferenceCharge` via `appCreditsService.deductCredits`) — and the creator's earnings are recorded **at deduct time**.

Concretely ($1.00 base estimate, 1.5× buffer, 20% markup → $1.80 hold, $0.30 creator earnings):

| | org refund | org nets | creator keeps | platform |
|---|---|---|---|---|
| pre-fix sweep | **$0.80** | $1.00 (no markup at all) | $0.30 | **eats the full markup** |
| this PR | **$0.60** | $1.20 = estimate × (1+markup) | $0.30 | eats only the buffer-delta share ($0.10) |
| normal settle at estimate | $0.60 | $1.20 | $0.20 | $0 |

Fix: for `app_chat_reservation` rows, settle the org to `amount × (estimated_cost / reserved_amount)` — exactly what a normal settle at the estimated cost charges. Markup-0 (non-monetized) holds collapse to the previous math byte-for-byte; holds without a usable base pair settle exact-cost; result clamped to the held amount so corrupt metadata can never become a surprise overage charge. The pre-existing test masked the bug by modeling `reserved_amount == row amount` (markup = 0).

## Red / green (real PGlite, no mocks)

Pre-fix (develop `credits.ts` + the new test):

```
Expected: 8.8
Received: 9        // org over-refunded $0.80, pocketing the markup
(fail) sweep settles monetized app-chat holds markup-inclusively — exactly one refund…
```

Post-fix: `bun test --isolate --conditions eliza-source packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts` → **Ran 30 tests, 0 fail**.

New tests assert the exactly-once contract: single `recon:<txid>:refund` row (`0.600000`), `settled_at` claimed, re-sweep scans 0, late full-refund settle after the sweep is a no-op (refund count stays 1) — plus missing-base-pair holds settle exact-cost instead of guessing.

Biome: 2 files, no fixes. Typecheck: no errors for touched files. Evidence: `.github/issue-evidence/11592-app-chat-sweep-markup.md`.

## Remaining scope (explicit, needs [cloud-money])

The sweep still doesn't reverse the creator-earnings share of the **buffer delta** (`(reservedBase − estimatedBase) × markup`, $0.10 above): that requires `appCreditsService` earnings machinery, which `creditsService` can't import (dependency direction — app-credits already imports credits). Platform-absorbed, bounded, rare-path (mid-settle-throw strands only). If wanted, the cron route (which can import both services) could route app-chat rows through `appCreditsService.reconcileCredits` instead — a design call for the money lane, not snuck in here.

Money path → requesting **[cloud-money]** / @lalalune review. Tracked in #8434.

— [cloud-security]
