### PR TITLE
fix(orchestrator): swarm synthesis skips router-owned sessions — one completion poster per session

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -11,7 +11,9 @@ import {
 import {
   extractShortToolDeliverable,
   extractSubResources,
+  hasRouterOriginMetadata,
   normalizeUrlsInText,
+  readOrigin,
   redactLoopbackUrls,
   SubAgentRouter,
 } from "../../src/services/sub-agent-router.js";
@@ -2649,6 +2651,83 @@ describe("SubAgentRouter parent-agent dispatch", () => {
         string,
       ];
       expect(second[1]).toContain("round-trip cap");
+    } finally {
+      await router.stop();
+    }
+  });
+});
+
+/**
+ * #11634: swarm synthesis skips sessions the router owns, using
+ * hasRouterOriginMetadata as the skip predicate. If the predicate ever
+ * diverges from readOrigin's null-decision, a session could get two
+ * completion posters (predicate false, readOrigin non-null) or NONE
+ * (predicate true, readOrigin null). Pin the lockstep over the metadata
+ * shapes spawn paths actually produce.
+ */
+describe("hasRouterOriginMetadata / readOrigin lockstep (#11634)", () => {
+  const metadataCases: Array<Record<string, unknown> | undefined> = [
+    undefined,
+    {},
+    { roomId: ROOM },
+    { taskRoomId: ROOM },
+    { taskRoomId: ROOM, originRoomId: WORKTREE_ROOM },
+    { taskRoomId: ROOM, sourceRoomId: WORKTREE_ROOM, source: "discord" },
+    // originRoomId/sourceRoomId alone never satisfy readOrigin (it requires a
+    // resolvable taskRoomId), so the predicate must reject them too.
+    { originRoomId: ROOM },
+    { sourceRoomId: ROOM },
+    // Non-UUID room ids are rejected by the router's pickUuid.
+    { roomId: "task-room-7" },
+    { roomId: "task-room-7", originRoomId: "origin-room-7" },
+    { taskRoomId: ROOM, originRoomId: "not-a-uuid" },
+    { label: "dashboard-task", source: "api" },
+  ];
+
+  it("returns true exactly when readOrigin resolves an origin", () => {
+    for (const meta of metadataCases) {
+      const session = makeSession({
+        metadata: meta as SessionInfo["metadata"],
+      });
+      expect(hasRouterOriginMetadata(meta), JSON.stringify(meta)).toBe(
+        readOrigin(session) !== null,
+      );
+    }
+  });
+
+  it("rejects null/undefined metadata", () => {
+    expect(hasRouterOriginMetadata(undefined)).toBe(false);
+    expect(hasRouterOriginMetadata(null)).toBe(false);
+  });
+});
+
+/**
+ * #11634: the coordinator consults isBoundToAcp() before skipping an
+ * origin-routed session, so a disabled or unbound router hands completion
+ * posting back to swarm synthesis instead of silencing the session.
+ */
+describe("SubAgentRouter.isBoundToAcp (#11634)", () => {
+  it("reports bound after start and unbound after stop", async () => {
+    const acp = makeAcpService(makeSession());
+    const { runtime } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      expect(router.isBoundToAcp()).toBe(true);
+    } finally {
+      await router.stop();
+    }
+    expect(router.isBoundToAcp()).toBe(false);
+  });
+
+  it("reports unbound when disabled via ACPX_SUB_AGENT_ROUTER_DISABLED", async () => {
+    const acp = makeAcpService(makeSession());
+    const { runtime } = makeRuntime({
+      acp: acp.service,
+      setting: { ACPX_SUB_AGENT_ROUTER_DISABLED: "1" },
+    });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      expect(router.isBoundToAcp()).toBe(false);
     } finally {
       await router.stop();
     }

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -18,6 +18,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../../src/services/acp-service.ts";
+import { SubAgentRouter } from "../../src/services/sub-agent-router.ts";
 import {
   SWARM_COORDINATOR_SERVICE_TYPE,
   SwarmCoordinatorService,
@@ -735,5 +736,168 @@ describe("SwarmCoordinatorService", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+});
+
+/**
+ * Ownership rule for completion posting (#11634): a session spawned with
+ * chat-origin routing (router origin metadata stamped at spawn — UUID
+ * taskRoomId/roomId) is posted to its origin channel by the SubAgentRouter.
+ * Swarm synthesis must SKIP those sessions while a live router owns them —
+ * otherwise one session gets two parallel completion posters (double-post)
+ * and synthesis leaks transient errors the router deliberately suppresses
+ * (e.g. a session_state_lost it already respawned). Synthesis remains the
+ * sole poster for sessions with no origin routing (dashboard/API-spawned)
+ * and for every session when the router is disabled or unbound.
+ */
+describe("swarm-synthesis ownership rule (#11634)", () => {
+  const TASK_ROOM = "11111111-2222-3333-4444-555555555555";
+  const ORIGIN_ROOM = "22222222-3333-4444-5555-666666666666";
+  const originMetadata = {
+    label: "build-site",
+    initialTask: "build the landing page",
+    roomId: TASK_ROOM,
+    originRoomId: ORIGIN_ROOM,
+    originConnectorMessageId: "discord-msg-42",
+    source: "discord",
+  };
+  const boundRouter = { isBoundToAcp: () => true };
+  const unboundRouter = { isBoundToAcp: () => false };
+
+  it("skips synthesis for an origin-routed session when the router is live", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: originMetadata,
+    });
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        [SubAgentRouter.serviceType]: boundRouter,
+      }),
+    );
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((e) => received.push(e));
+
+    acp.emit("sess-owned", "task_complete", { response: "built it: url" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The router is the sole completion poster for this session.
+    expect(fired).not.toHaveBeenCalled();
+    // The dashboard/ws event stream and legacy task context are unaffected.
+    expect(received.at(-1)).toMatchObject({
+      type: "task_complete",
+      sessionId: "sess-owned",
+    });
+    expect(coordinator.tasks.get("sess-owned")).toMatchObject({
+      status: "completed",
+    });
+    await coordinator.stop();
+  });
+
+  it("does not leak router-suppressed state-lost errors to the origin channel", async () => {
+    // The live trajectory in #11634: the dead session's transient error was
+    // posted to the channel by synthesis even though the router had already
+    // respawned the session and suppresses the stale event.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: originMetadata,
+    });
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        [SubAgentRouter.serviceType]: boundRouter,
+      }),
+    );
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-lost", "error", {
+      message:
+        "Sub-agent state was lost (process exited without persisting). No automatic action taken.",
+      failureKind: "session_state_lost",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("still posts synthesis for sessions with no origin routing (dashboard/API-spawned)", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      // No UUID roomId/taskRoomId: the router skips this session
+      // ("session has no origin metadata"), so synthesis must post.
+      metadata: { label: "swarm-task", initialTask: "run the batch" },
+    });
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        [SubAgentRouter.serviceType]: boundRouter,
+      }),
+    );
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-dashboard", "task_complete", { response: "done" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      completed: 1,
+      tasks: [{ sessionId: "sess-dashboard", status: "completed" }],
+    });
+    await coordinator.stop();
+  });
+
+  it("keeps synthesis as the poster when the router is unbound or disabled", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: originMetadata,
+    });
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({
+        [AcpService.serviceType]: acp,
+        [SubAgentRouter.serviceType]: unboundRouter,
+      }),
+    );
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-no-router", "task_complete", { response: "done" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0].tasks[0]).toMatchObject({
+      sessionId: "sess-no-router",
+      roomId: ORIGIN_ROOM,
+      replyToExternalMessageId: "discord-msg-42",
+    });
+    await coordinator.stop();
+  });
+
+  it("keeps synthesis as the poster when no router service is registered", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: originMetadata,
+    });
+    const coordinator = await SwarmCoordinatorService.start(
+      makeRuntime({ [AcpService.serviceType]: acp }),
+    );
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-absent-router", "task_complete", { response: "done" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -663,6 +663,18 @@ export class SubAgentRouter extends Service {
     );
   }
 
+  /**
+   * Whether the router is live on the ACP session-event stream and will post
+   * terminal events for origin-routed sessions. Swarm synthesis
+   * (SwarmCoordinatorService.maybeFireSwarmComplete) consults this before
+   * skipping an origin-routed session, so a disabled router
+   * (ACPX_SUB_AGENT_ROUTER_DISABLED) or a failed bind restores synthesis as
+   * the completion poster instead of silencing those sessions (#11634).
+   */
+  isBoundToAcp(): boolean {
+    return !!this.unsubscribe;
+  }
+
   async stop(): Promise<void> {
     this.stopped = true;
     if (this.bindRetryTimer) {
@@ -1979,9 +1991,27 @@ export function spawnRootIdFromMeta(
   );
 }
 
+/**
+ * Whether session metadata carries the router's origin routing (stamped at
+ * spawn by tasks.ts) — i.e. this router will own origin-channel posting for
+ * the session's terminal events. True exactly when {@link readOrigin} returns
+ * non-null for the same metadata (readOrigin's guard delegates here, and the
+ * equivalence is pinned by unit tests). Swarm synthesis uses this to skip
+ * origin-routed sessions so one session never gets two parallel completion
+ * posters (#11634).
+ */
+export function hasRouterOriginMetadata(
+  meta: Record<string, unknown> | undefined | null,
+): boolean {
+  if (!meta) return false;
+  // readOrigin resolves roomId with a fallback to taskRoomId, so a resolvable
+  // taskRoomId is necessary AND sufficient for it to return non-null.
+  return Boolean(pickUuid(meta.taskRoomId) ?? pickUuid(meta.roomId));
+}
+
 export function readOrigin(session: SessionInfo): OriginInfo | null {
   const meta = session.metadata as Record<string, unknown> | undefined;
-  if (!meta) return null;
+  if (!meta || !hasRouterOriginMetadata(meta)) return null;
   const taskRoomId = pickUuid(meta.taskRoomId) ?? pickUuid(meta.roomId);
   const roomId =
     pickUuid(meta.originRoomId) ?? pickUuid(meta.sourceRoomId) ?? taskRoomId;

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -56,6 +56,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { logger, Service } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { OrchestratorTaskService } from "./orchestrator-task-service.js";
+import { hasRouterOriginMetadata, SubAgentRouter } from "./sub-agent-router.js";
 import { sanitizeCompletionRelay } from "./transcript-sanitizer.js";
 import { TERMINAL_SESSION_STATUSES } from "./types.js";
 
@@ -680,6 +681,24 @@ export class SwarmCoordinatorService extends Service {
       sessionMeta = { metadata: {} };
     }
     const meta = sessionMeta.metadata;
+    // Ownership rule (#11634): a session spawned with chat-origin routing is
+    // posted to its origin channel by the SubAgentRouter — origin-aware,
+    // loop-capped, dedupe-keyed, respawn-aware. Firing synthesis for it too
+    // gave one session two parallel completion posters (double-post) and
+    // leaked transient errors the router deliberately suppresses (e.g. a
+    // session_state_lost it already respawned). Skip origin-routed sessions
+    // while a live router owns them; synthesis stays the sole completion
+    // poster for sessions with no origin routing (dashboard/API-spawned) and
+    // for every session when the router is disabled or unbound. The predicate
+    // reads the SAME input the router's readOrigin decision does — the
+    // session metadata, not the event payload — so the two posters cannot
+    // disagree about ownership and drop a completion between them.
+    if (hasRouterOriginMetadata(meta) && this.routerOwnsOriginSessions()) {
+      logger.debug(
+        `[SwarmCoordinator] skipping swarm-complete synthesis for router-owned session ${sessionId} (${event})`,
+      );
+      return;
+    }
     const label =
       readString(record, "label") ?? readString(meta, "label") ?? sessionId;
     const agentType =
@@ -759,6 +778,22 @@ export class SwarmCoordinatorService extends Service {
         }`,
       );
     }
+  }
+
+  /**
+   * Whether a live SubAgentRouter owns origin-channel posting for
+   * origin-routed sessions. False when the router service is absent, disabled
+   * via ACPX_SUB_AGENT_ROUTER_DISABLED, or not (yet) bound to the ACP event
+   * stream — in all of those cases synthesis must keep posting so terminal
+   * events still reach the user.
+   */
+  private routerOwnsOriginSessions(): boolean {
+    const router = this.runtime.getService?.(SubAgentRouter.serviceType) as {
+      isBoundToAcp?: () => boolean;
+    } | null;
+    return typeof router?.isBoundToAcp === "function"
+      ? router.isBoundToAcp()
+      : false;
   }
 
   private completionStatusForEvent(


### PR DESCRIPTION
## Summary
- Ownership rule from #11634: a session spawned with chat-origin routing (the router's origin metadata stamped at spawn) gets its terminal events posted by the `SubAgentRouter` ONLY. `SwarmCoordinatorService.maybeFireSwarmComplete` now skips those sessions, so one coding task no longer produces both a synthesis post and the planner's completion reply (the double-post), and transient errors the router deliberately suppresses (e.g. a `session_state_lost` it already respawned) no longer leak to the origin channel.
- Synthesis remains the completion poster for sessions with **no** origin routing (dashboard/API-spawned swarm tasks — exactly the gap synthesis exists to cover) and for **every** session when the router is absent, disabled via `ACPX_SUB_AGENT_ROUTER_DISABLED`, or not bound to the ACP stream (new `SubAgentRouter.isBoundToAcp()` accessor), so nothing goes silent under degraded configs.
- The skip predicate `hasRouterOriginMetadata` reads the SAME input as the router's own `readOrigin` decision (session metadata, not the event payload), and `readOrigin`'s guard now delegates to it — the two posters cannot disagree about ownership and drop a completion between them. The equivalence is pinned by a unit-test matrix over the metadata shapes spawn paths produce.

Fixes #11634

## Acceptance criteria from the issue
- chat-origin coding task: no synthesis post; the router-fed planner reply is the only completion message — test "skips synthesis for an origin-routed session when the router is live"
- no state-lost leak when the router respawns under cap — test "does not leak router-suppressed state-lost errors to the origin channel" (the exact live-trajectory message from the issue)
- state-lost with cap EXHAUSTED still reaches the user once via the router's terminal narration — that path is untouched by this PR
- API/dashboard-spawned session with no origin metadata: synthesis still posts — test "still posts synthesis for sessions with no origin routing"
- unit tests for the skip predicate both ways — plus unbound-router / absent-router fallback tests and the readOrigin↔predicate lockstep matrix

## Verification
- `bun run --cwd plugins/plugin-agent-orchestrator test` (vitest: swarm-coordinator-service, sub-agent-router suites)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check`

## Evidence Notes
- Live trajectory: the failing behavior (1 task → 4 messages: ack, leaked state-lost scare, synthesis narration post, planner completion) is captured with timestamps in #11634 from a self-hosted develop node. The fix is deterministic ownership routing — no model prompt/provider/action behavior changes; the planner path and the router's narration are untouched, only the duplicate poster is gated — verified by unit tests on both sides of the predicate and both router liveness states.
- N/A screenshots/video: no UI surface changed.
- N/A DB artifacts: no persistence or migrations changed.
