### PR TITLE
test(cloud): cover Eliza App insufficient-credits onboarding reply

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -857,6 +857,31 @@ describe("runOnboardingChat", () => {
       expect(result.reply).not.toContain("copied");
     });
 
+    test("insufficient-credits reply is deterministic and points at billing", async () => {
+      ensureElizaAppProvisioning.mockResolvedValue({
+        status: "insufficient_credits",
+        agentId: null,
+        bridgeUrl: null,
+        sandbox: null,
+      });
+      const result = await runOnboardingChat({
+        message: "My name is Sam",
+        platform: "blooio",
+        platformUserId: PHONE,
+        sessionId: PLATFORM_SESSION,
+        trustedPlatformIdentity: true,
+        authenticatedUser: { userId: "user-1", organizationId: "org-1" },
+      });
+      expect(result.provisioning.status).toBe("insufficient_credits");
+      expect(result.handoffComplete).toBe(false);
+      expect(generateText).not.toHaveBeenCalled();
+      expect(result.reply).toContain("You're out of credits, Sam.");
+      expect(result.reply).toContain("/dashboard/billing");
+      expect(result.reply).toContain("usage-based:");
+      expect(result.reply).not.toContain("You're live");
+      expect(result.reply).not.toContain("copied");
+    });
+
     test("login-required fallback reply always ends with the exact login link", async () => {
       const result = await runTrustedPhoneTurn("My name is Sam");
       expect(result.requiresLogin).toBe(true);


### PR DESCRIPTION
## Summary

Follow-up to #11679 after the main fix merged while review was in progress.

Adds a focused onboarding-chat regression test for the new insufficient_credits provisioning status so the user-facing money-state branch stays deterministic:

- no LLM generation for the billing state
- reply points at /dashboard/billing
- reply includes the usage-based pricing copy
- reply does not claim the agent is live or that transcript handoff copied

## Validation

- un run --cwd packages/cloud/shared test src/lib/services/eliza-app/onboarding-chat.test.ts — 39 pass / 0 fail / 212 assertions
- unx @biomejs/biome@2.5.2 check packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts --files-ignore-unknown=true
- git diff --check origin/develop...HEAD
- git diff --check

## Notes

#11679's provisioning test and the combined Eliza App pair were also run during review before this was split out; this PR only carries the missing user-facing reply assertion.