### PR TITLE
fix(orchestrator): router owns origin-routed session completions — stop swarm-synthesis double-posts and suppressed-error leaks (#11634)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-roundtrip-getters.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router-roundtrip-getters.test.ts
@@ -103,3 +103,43 @@ describe("SubAgentRouter round-trip getters (#8901)", () => {
     }
   });
 });
+
+// isActive() is the accessor SwarmCoordinatorService consults before ceding
+// ownership of an origin-routed session's completion (issue
+// elizaOS/eliza#11634). It must report true only while the router is bound to
+// the ACP stream, and flip to false when disabled or stopped — otherwise the
+// coordinator would go silent (router not posting) or double-post (both
+// posting).
+describe("SubAgentRouter.isActive (#11634 ownership gate)", () => {
+  it("is true once bound to the ACP session-event stream", async () => {
+    const acp = makeAcp(makeSession());
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    try {
+      expect(router.isActive()).toBe(true);
+    } finally {
+      await router.stop();
+    }
+  });
+
+  it("is false after stop() unbinds the stream", async () => {
+    const acp = makeAcp(makeSession());
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    expect(router.isActive()).toBe(true);
+    await router.stop();
+    expect(router.isActive()).toBe(false);
+  });
+
+  it("is false when disabled via ACPX_SUB_AGENT_ROUTER_DISABLED (never binds)", async () => {
+    const acp = makeAcp(makeSession());
+    const router = await SubAgentRouter.start(
+      makeRuntime(acp.service, { ACPX_SUB_AGENT_ROUTER_DISABLED: "1" }),
+    );
+    try {
+      // start() returns before binding, so the router never posts — the
+      // coordinator must NOT cede ownership to it.
+      expect(router.isActive()).toBe(false);
+    } finally {
+      await router.stop();
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -21,8 +21,8 @@ import { AcpService } from "../../src/services/acp-service.ts";
 import {
   SWARM_COORDINATOR_SERVICE_TYPE,
   SwarmCoordinatorService,
-  sessionHasRouterOrigin,
   type SwarmEvent,
+  sessionHasRouterOrigin,
 } from "../../src/services/swarm-coordinator-service.ts";
 
 /** Minimal AcpService stub: captures the onSessionEvent handler so the test
@@ -1184,7 +1184,10 @@ describe("sessionHasRouterOrigin", () => {
 
   it("is false when the roomId is not a valid UUID", () => {
     expect(
-      sessionHasRouterOrigin({ originRoomId: "origin-room-11", source: "discord" }),
+      sessionHasRouterOrigin({
+        originRoomId: "origin-room-11",
+        source: "discord",
+      }),
     ).toBe(false);
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -21,6 +21,7 @@ import { AcpService } from "../../src/services/acp-service.ts";
 import {
   SWARM_COORDINATOR_SERVICE_TYPE,
   SwarmCoordinatorService,
+  sessionHasRouterOrigin,
   type SwarmEvent,
 } from "../../src/services/swarm-coordinator-service.ts";
 
@@ -57,6 +58,16 @@ function makeRuntime(services: Record<string, unknown>): IAgentRuntime {
   return {
     getService: vi.fn((key: string) => services[key] ?? null),
   } as unknown as IAgentRuntime;
+}
+
+/** The sub-agent-router serviceType the coordinator looks up to decide whether
+ *  the router is live enough to own an origin session's completion. */
+const SUB_AGENT_ROUTER_SERVICE_TYPE = "ACPX_SUB_AGENT_ROUTER";
+
+/** Minimal SubAgentRouter stub exposing only the `isActive()` accessor the
+ *  coordinator duck-types. `active: false` mimics a disabled / unbound router. */
+function makeRouterStub(active: boolean) {
+  return { isActive: vi.fn(() => active) };
 }
 
 describe("SwarmCoordinatorService", () => {
@@ -733,7 +744,451 @@ describe("SwarmCoordinatorService", () => {
     }
   });
 
+  // Ownership rule (#11634): the sub-agent-router owns the completion→chat post
+  // for origin-routed sessions. Swarm synthesis must NOT double-post those.
+  // A router-routed session stamps a valid UUID roomId + taskRoomId + source.
+  const ROUTER_ROOM_ID = "11111111-1111-4111-8111-111111111111";
+  const ROUTER_TASK_ROOM_ID = "22222222-2222-4222-8222-222222222222";
+
+  it("does NOT fire swarm-complete for a router-origin session when the router is active (task_complete)", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        initialTask: "build the landing page",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        originConnectorMessageId: "discord-msg-11",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-router", "task_complete", { response: "deployed" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("STILL fires swarm-complete for a router-origin session when the router is DISABLED/unbound", async () => {
+    // ACPX_SUB_AGENT_ROUTER_DISABLED (or router failed to bind): the router
+    // will not post, so synthesis must remain the completion poster or the
+    // terminal completion goes silent.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(false),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-router-off", "task_complete", { response: "deployed" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
+  it("STILL fires when router room UUIDs are ONLY in the event data, not session metadata", async () => {
+    // readOrigin(session) reads session.metadata only. If the UUIDs live solely
+    // in the terminal event payload, the router returns "no origin" and posts
+    // nothing — so synthesis must remain the poster (no silent drop).
+    const acp = makeAcpStub({
+      agentType: "codex",
+      metadata: { label: "payload-only" }, // NO room UUIDs in session metadata
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // UUIDs present in the EVENT data only.
+    acp.emit("sess-payload-only", "task_complete", {
+      response: "deployed",
+      originRoomId: ROUTER_ROOM_ID,
+      taskRoomId: ROUTER_TASK_ROOM_ID,
+      source: "discord",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
+  it("a router-owned task_complete does NOT consume the session's synthesis slot (later stopped still fires)", async () => {
+    // ACP sessions are reused across turns. A router-owned task_complete is
+    // skipped here, but must NOT mark the session synthesized — otherwise a
+    // later `stopped` (which the router never posts) would be swallowed by the
+    // dedupe guard and go silent.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // Turn 1: router-owned completion — skipped, slot NOT consumed.
+    acp.emit("sess-reuse", "task_complete", { response: "deployed" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fired).not.toHaveBeenCalled();
+
+    // Turn 2: same session stops — router does not post this, so synthesis must.
+    acp.emit("sess-reuse", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      stopped: 1,
+      tasks: [{ sessionId: "sess-reuse", status: "stopped" }],
+    });
+    await coordinator.stop();
+  });
+
+  it("STILL fires swarm-complete for a router-origin `stopped` event even when the router is active", async () => {
+    // The router injects task_complete / error but NOT stopped, so synthesis
+    // remains the only poster for a stop/cancel/no-output terminal event.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-router-stopped", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      stopped: 1,
+      tasks: [{ sessionId: "sess-router-stopped", status: "stopped" }],
+    });
+    await coordinator.stop();
+  });
+
+  it("STILL fires swarm-complete for a custom-validator task_complete on a router-origin active session", async () => {
+    // The app-verification / custom-validator result is synthesized by the
+    // coordinator (dispatchCustomValidatorResult); the router never receives or
+    // posts it, so synthesis must remain its poster even on a router-owned
+    // active session, or the validated verdict would vanish.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // A validated completion carries the custom-validator marker.
+    acp.emit("sess-validated", "task_complete", {
+      summary: "App verification passed.",
+      response: "App verification passed.",
+      verification: {
+        source: "custom-validator",
+        validator: { service: "app-verification", method: "verifyApp" },
+        verdict: "pass",
+      },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      completed: 1,
+      tasks: [{ sessionId: "sess-validated", status: "completed" }],
+    });
+    await coordinator.stop();
+  });
+
+  it("STILL fires swarm-complete for a router-origin session when NO router service is registered", async () => {
+    // Fail-safe: missing router service is treated as "router not active".
+    const acp = makeAcpStub({
+      agentType: "codex",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-no-router", "task_complete", { response: "deployed" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
+  it("does NOT fire swarm-complete for a router-origin session on suppressed state-lost error (source optional)", async () => {
+    // No `source` here on purpose: readOrigin still owns this session, so the
+    // suppressed-error leak must be prevented even for connector-less origins.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // The router deliberately suppresses this (it respawns the session under
+    // cap); synthesis must not leak the "state was lost" scare to the channel.
+    acp.emit("sess-router-err", "error", {
+      failureKind: "session_state_lost",
+      message: "Sub-agent state was lost (process exited without persisting).",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("STILL fires swarm-complete for a session with NO router origin (task_complete)", async () => {
+    // Dashboard / API-spawned swarm task: no router origin metadata
+    // (non-UUID room, no source). Synthesis remains the completion poster —
+    // this is the gap synthesis exists to cover.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "dashboard-task",
+        initialTask: "nightly report",
+        originRoomId: "origin-room-11",
+      },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-dashboard", "task_complete", { response: "deployed" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      completed: 1,
+      tasks: [{ sessionId: "sess-dashboard", status: "completed" }],
+    });
+    await coordinator.stop();
+  });
+
+  // A microtask/macrotask flush deep enough to drain the per-session terminal
+  // completion chain (each event is 2+ awaits deep: chain .then + metadata
+  // await + eviction scheduling).
+  const flushChains = async () => {
+    for (let i = 0; i < 6; i++) await new Promise((r) => setTimeout(r, 0));
+  };
+
+  it("fires swarm-complete ONCE when two terminal events for the same non-router session race the metadata await", async () => {
+    // Regression (codex review, #11634): AcpService invokes listeners
+    // synchronously without awaiting them, so two terminal events emitted
+    // back-to-back for one session (e.g. error then stopped on a single exit)
+    // both enter the handler and suspend on the getEnrichmentMetadata await.
+    // Per-session serialization makes the second observe the first's completed
+    // dedupe decision, so the completion callback fires exactly ONCE.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: { label: "dashboard-race", initialTask: "nightly report" },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-race-dedupe", "error", { message: "boom" });
+    acp.emit("sess-race-dedupe", "stopped", {});
+    await flushChains();
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    await coordinator.stop();
+  });
+
+  it("still fires the `stopped` when it races a router-owned terminal on the same session (no swallow)", async () => {
+    // Regression (codex review, #11634): a router-owned task_complete/error and
+    // a `stopped` emitted back-to-back for one router-origin session. The
+    // router owns (and skips synthesis for) the task_complete but NEVER posts
+    // `stopped`, so synthesis must still deliver the stop. Per-session
+    // serialization guarantees the router-owned skip does not consume the slot
+    // AND the `stopped` is not swallowed by a claim/release race.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // Router-owned task_complete (skipped) immediately followed by a stopped
+    // (must post) — same tick, racing the metadata await.
+    acp.emit("sess-race-router", "task_complete", { response: "deployed" });
+    acp.emit("sess-race-router", "stopped", {});
+    await flushChains();
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      stopped: 1,
+      tasks: [{ sessionId: "sess-race-router", status: "stopped" }],
+    });
+    await coordinator.stop();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+});
+
+describe("sessionHasRouterOrigin", () => {
+  const ROOM = "11111111-1111-4111-8111-111111111111";
+  const TASK_ROOM = "22222222-2222-4222-8222-222222222222";
+
+  // The predicate takes ONLY the session metadata — the exact input
+  // readOrigin(session) reads (session.metadata). It must NOT consult the
+  // terminal event's data record, or it would judge a session router-owned
+  // that readOrigin would reject, silently dropping its completion.
+
+  it("is true for a valid UUID roomId + taskRoomId + source (router-owned)", () => {
+    expect(
+      sessionHasRouterOrigin({
+        originRoomId: ROOM,
+        taskRoomId: TASK_ROOM,
+        source: "discord",
+      }),
+    ).toBe(true);
+  });
+
+  it("derives taskRoomId from roomId when taskRoomId is absent", () => {
+    // readOrigin: taskRoomId = taskRoomId ?? roomId; roomId falls back to it.
+    expect(sessionHasRouterOrigin({ roomId: ROOM, source: "discord" })).toBe(
+      true,
+    );
+  });
+
+  it("is true when source is missing (source is optional, mirrors readOrigin)", () => {
+    // readOrigin returns a non-null origin without a source, so the router owns
+    // the session and synthesis must skip it regardless of source presence.
+    expect(
+      sessionHasRouterOrigin({ originRoomId: ROOM, taskRoomId: TASK_ROOM }),
+    ).toBe(true);
+  });
+
+  it("is true when originRoomId is non-UUID but taskRoomId is a valid UUID (fallthrough)", () => {
+    // Mirrors readOrigin's pickUuid(originRoomId) ?? ... ?? taskRoomId: a
+    // present-but-invalid earlier field must NOT short-circuit the fallback.
+    expect(
+      sessionHasRouterOrigin({
+        originRoomId: "dashboard-origin",
+        taskRoomId: TASK_ROOM,
+        source: "discord",
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when a taskRoomId cannot be derived (no taskRoomId, roomId not a UUID)", () => {
+    // roomId can come from originRoomId, but taskRoomId only derives from
+    // taskRoomId ?? roomId — with neither a valid UUID, readOrigin returns null.
+    expect(
+      sessionHasRouterOrigin({
+        originRoomId: ROOM,
+        roomId: "not-a-uuid",
+        source: "discord",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when the roomId is not a valid UUID", () => {
+    expect(
+      sessionHasRouterOrigin({ originRoomId: "origin-room-11", source: "discord" }),
+    ).toBe(false);
+  });
+
+  it("is false for empty metadata", () => {
+    expect(sessionHasRouterOrigin({})).toBe(false);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -575,6 +575,21 @@ export class SubAgentRouter extends Service {
     return this.loopState.roundTripCap;
   }
 
+  /**
+   * Is the router bound to the ACP session-event stream and therefore actually
+   * going to post completions for origin-routed sessions?
+   *
+   * False when the router is disabled via `ACPX_SUB_AGENT_ROUTER_DISABLED`
+   * (start() returns before binding), has been stopped, or has not yet bound to
+   * the ACP service. The SwarmCoordinatorService consults this before ceding
+   * ownership of an origin-routed session's completion: if the router is NOT
+   * active, swarm synthesis must remain the poster so terminal completions /
+   * errors still reach the user (issue elizaOS/eliza#11634 review follow-up).
+   */
+  isActive(): boolean {
+    return !this.stopped && this.unsubscribe !== undefined;
+  }
+
   private started = false;
   private bindRetryTimer: ReturnType<typeof setTimeout> | undefined;
   private stopped = false;

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -241,9 +241,7 @@ function firstUuidOf(
  */
 function isCustomValidatorResult(record: Record<string, unknown>): boolean {
   const verification = record.verification;
-  return (
-    isRecord(verification) && verification.source === "custom-validator"
-  );
+  return isRecord(verification) && verification.source === "custom-validator";
 }
 
 export function sessionHasRouterOrigin(meta: Record<string, unknown>): boolean {
@@ -282,10 +280,7 @@ export class SwarmCoordinatorService extends Service {
   // the `synthesizedCompletionSessions` dedupe/ownership decision. Chaining each
   // session's terminal handling onto the previous one guarantees the second
   // event observes the first's completed decision (issue #11634).
-  private readonly terminalCompletionChains = new Map<
-    string,
-    Promise<void>
-  >();
+  private readonly terminalCompletionChains = new Map<string, Promise<void>>();
   private readonly enrichmentMetadataCache = new Map<
     string,
     EnrichmentMetadata
@@ -507,9 +502,9 @@ export class SwarmCoordinatorService extends Service {
    * silent.
    */
   private isRouterActive(): boolean {
-    const router = this.runtime.getService(SUB_AGENT_ROUTER_SERVICE_TYPE) as
-      | { isActive?: () => boolean }
-      | null;
+    const router = this.runtime.getService(SUB_AGENT_ROUTER_SERVICE_TYPE) as {
+      isActive?: () => boolean;
+    } | null;
     return typeof router?.isActive === "function" && router.isActive() === true;
   }
 
@@ -813,7 +808,8 @@ export class SwarmCoordinatorService extends Service {
     event: string,
     data: unknown,
   ): Promise<void> {
-    const prior = this.terminalCompletionChains.get(sessionId) ?? Promise.resolve();
+    const prior =
+      this.terminalCompletionChains.get(sessionId) ?? Promise.resolve();
     const next = prior
       .catch(() => {})
       .then(() => this.runSwarmComplete(sessionId, event, data));

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -61,6 +61,11 @@ import { TERMINAL_SESSION_STATUSES } from "./types.js";
 
 export const SWARM_COORDINATOR_SERVICE_TYPE = "SWARM_COORDINATOR";
 
+// Sub-agent-router serviceType, mirrored here as a literal (not imported from
+// sub-agent-router.ts) so this module keeps no dependency edge on the router
+// module. Kept in sync with `SubAgentRouter.serviceType`.
+const SUB_AGENT_ROUTER_SERVICE_TYPE = "ACPX_SUB_AGENT_ROUTER";
+
 /** Legacy swarm event shape consumed by the bridges. */
 export interface SwarmEvent {
   type: string;
@@ -143,6 +148,12 @@ interface EnrichmentMetadata {
 
 const STREAMING_SESSION_EVENTS = new Set(["message", "reasoning", "plan"]);
 
+// The terminal events the sub-agent-router itself posts (mirrors `shouldInject`
+// in sub-agent-router.ts, restricted to the terminal subset). Synthesis only
+// cedes ownership for these — notably NOT `stopped`, which the router does not
+// inject, so the coordinator stays the sole poster for stop/cancel/no-output.
+const ROUTER_OWNED_TERMINAL_EVENTS = new Set(["task_complete", "error"]);
+
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -159,6 +170,97 @@ function readString(
     : undefined;
 }
 
+// Same UUID shape the sub-agent-router's `pickUuid` gate accepts. Kept as a
+// local literal (not an import from sub-agent-router) so the coordinator does
+// not take a dependency on the router module — that file already imports this
+// service's siblings and a back-edge would risk a circular import.
+const ROUTER_ORIGIN_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function pickRouterUuid(value: unknown): string | undefined {
+  return typeof value === "string" && ROUTER_ORIGIN_UUID_RE.test(value)
+    ? value
+    : undefined;
+}
+
+/**
+ * Return the first VALID UUID among the given keys of a single metadata record.
+ *
+ * A present-but-non-UUID candidate does NOT short-circuit: it is skipped and
+ * later fallbacks are still considered, mirroring `readOrigin`'s
+ * `pickUuid(a) ?? pickUuid(b) ?? …` (a session with a non-UUID `originRoomId`
+ * but a valid UUID `taskRoomId` is still router-owned).
+ */
+function firstUuidOf(
+  meta: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const uuid = pickRouterUuid(meta[key]);
+    if (uuid) return uuid;
+  }
+  return undefined;
+}
+
+/**
+ * Does this session carry the sub-agent-router's origin routing?
+ *
+ * Mirrors the ownership gate in `readOrigin` (`sub-agent-router.ts`) EXACTLY,
+ * including its input: `readOrigin(session)` reads ONLY `session.metadata`, so
+ * this predicate takes the session metadata alone. Deciding ownership from the
+ * terminal event's data record instead would diverge — a session whose EVENT
+ * payload carries UUID room fields but whose persisted METADATA does not would
+ * be judged router-owned here while `readOrigin` returns null and the router
+ * posts nothing, silently dropping the completion/error. The coordinator's
+ * caller passes the session's enrichment metadata (the same
+ * `AcpService.getSession().metadata` the router reads).
+ *
+ * A routed session stamps a valid UUID `roomId` (via
+ * `originRoomId` / `sourceRoomId` / `taskRoomId` / `roomId`) AND a valid UUID
+ * `taskRoomId` (via `taskRoomId` / `roomId`). Those two UUIDs are the ONLY hard
+ * requirements `readOrigin` returns non-null on — `source` is read into the
+ * origin but is optional (a connector-less dashboard/web-origin task still gets
+ * a router-owned origin), so this predicate must NOT require `source`.
+ *
+ * When the router owns a session (both UUIDs present) it is the completion→chat
+ * poster (origin-aware, dedupe-keyed, respawn/retry-suppressing), so swarm
+ * synthesis must NOT fire a parallel completion for it. Sessions WITHOUT this
+ * shape (no valid origin UUIDs — e.g. API-spawned swarm tasks with only a
+ * bare label) are the gap synthesis exists to cover, so they still post.
+ */
+/**
+ * Is this terminal event a coordinator-generated validated completion (the
+ * app-verification / custom-validator synthetic result dispatched by
+ * `dispatchCustomValidatorResult`)? The sub-agent-router never receives or
+ * posts these — the raw ACP `task_complete` is intentionally withheld until
+ * validation and only this synthesized result carries the user-facing verdict
+ * (e.g. "App verification passed."). So even on a router-owned session, synthesis
+ * must remain the poster for it or the validated completion would vanish.
+ * Detected by the `verification.source === "custom-validator"` marker
+ * `dispatchCustomValidatorResult` stamps.
+ */
+function isCustomValidatorResult(record: Record<string, unknown>): boolean {
+  const verification = record.verification;
+  return (
+    isRecord(verification) && verification.source === "custom-validator"
+  );
+}
+
+export function sessionHasRouterOrigin(meta: Record<string, unknown>): boolean {
+  // roomId = pickUuid(originRoomId) ?? pickUuid(sourceRoomId) ?? taskRoomId
+  const roomId = firstUuidOf(meta, [
+    "originRoomId",
+    "sourceRoomId",
+    "taskRoomId",
+    "roomId",
+  ]);
+  if (!roomId) return false;
+  // taskRoomId = pickUuid(taskRoomId) ?? pickUuid(roomId)
+  const taskRoomId = firstUuidOf(meta, ["taskRoomId", "roomId"]);
+  if (!taskRoomId) return false;
+  return true;
+}
+
 export class SwarmCoordinatorService extends Service {
   static override serviceType = SWARM_COORDINATOR_SERVICE_TYPE;
 
@@ -172,6 +274,18 @@ export class SwarmCoordinatorService extends Service {
   private swarmCompleteCallback: SwarmCompleteCallback | null = null;
   private readonly inFlightDecisionSessions = new Set<string>();
   private readonly synthesizedCompletionSessions = new Set<string>();
+  // Per-session serialization chain for terminal-event synthesis. AcpService
+  // invokes session-event listeners SYNCHRONOUSLY without awaiting them, so two
+  // terminal events emitted back-to-back for the SAME session (e.g. a
+  // router-owned `task_complete` and a `stopped`, or a burst of duplicates)
+  // would otherwise both suspend on the `getEnrichmentMetadata` await and race
+  // the `synthesizedCompletionSessions` dedupe/ownership decision. Chaining each
+  // session's terminal handling onto the previous one guarantees the second
+  // event observes the first's completed decision (issue #11634).
+  private readonly terminalCompletionChains = new Map<
+    string,
+    Promise<void>
+  >();
   private readonly enrichmentMetadataCache = new Map<
     string,
     EnrichmentMetadata
@@ -269,6 +383,7 @@ export class SwarmCoordinatorService extends Service {
     this.swarmCompleteCallback = null;
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
+    this.terminalCompletionChains.clear();
     this.enrichmentMetadataCache.clear();
     for (const timer of this.legacyTaskEvictionTimers.values()) {
       clearTimeout(timer);
@@ -375,6 +490,27 @@ export class SwarmCoordinatorService extends Service {
 
   private acp(): AcpService | null {
     return this.runtime.getService<AcpService>(AcpService.serviceType) ?? null;
+  }
+
+  /**
+   * Is the sub-agent-router actually going to post completions for
+   * origin-routed sessions? The ownership skip in `maybeFireSwarmComplete` is
+   * only safe to take when the router is live — if it is disabled
+   * (`ACPX_SUB_AGENT_ROUTER_DISABLED`), stopped, or has not bound to the ACP
+   * stream, swarm synthesis must remain the completion poster so terminal
+   * completions / errors still reach the user (issue elizaOS/eliza#11634).
+   *
+   * Looked up by serviceType string + duck-typed `isActive()` to avoid a
+   * value import of `SubAgentRouter` (keeps this module free of a back-edge to
+   * the router module). Fails SAFE: any missing service / accessor is treated
+   * as "router not active", so synthesis keeps posting rather than going
+   * silent.
+   */
+  private isRouterActive(): boolean {
+    const router = this.runtime.getService(SUB_AGENT_ROUTER_SERVICE_TYPE) as
+      | { isActive?: () => boolean }
+      | null;
+    return typeof router?.isActive === "function" && router.isActive() === true;
   }
 
   /**
@@ -660,7 +796,37 @@ export class SwarmCoordinatorService extends Service {
     return event;
   }
 
-  private async maybeFireSwarmComplete(
+  /**
+   * Serialize terminal-event synthesis PER SESSION. AcpService fans events out
+   * to listeners synchronously without awaiting them, so two terminal events
+   * for the same session (a router-owned `task_complete`/`error` racing a
+   * `stopped`, or duplicate terminals on one exit) would otherwise both suspend
+   * on the metadata await inside `runSwarmComplete` and race the ownership /
+   * dedupe decision — double-posting completions or swallowing a `stopped` the
+   * router never posts (issue #11634). Chaining onto the session's previous
+   * terminal handler makes the second event observe the first's finished
+   * decision. The chain entry is pruned once it is the tail (no newer event
+   * queued behind it) so the map does not grow unbounded.
+   */
+  private maybeFireSwarmComplete(
+    sessionId: string,
+    event: string,
+    data: unknown,
+  ): Promise<void> {
+    const prior = this.terminalCompletionChains.get(sessionId) ?? Promise.resolve();
+    const next = prior
+      .catch(() => {})
+      .then(() => this.runSwarmComplete(sessionId, event, data));
+    this.terminalCompletionChains.set(sessionId, next);
+    void next.finally(() => {
+      if (this.terminalCompletionChains.get(sessionId) === next) {
+        this.terminalCompletionChains.delete(sessionId);
+      }
+    });
+    return next;
+  }
+
+  private async runSwarmComplete(
     sessionId: string,
     event: string,
     data: unknown,
@@ -669,8 +835,6 @@ export class SwarmCoordinatorService extends Service {
     if (!cb) return;
     const terminalStatus = this.completionStatusForEvent(event);
     if (!terminalStatus) return;
-    if (this.synthesizedCompletionSessions.has(sessionId)) return;
-    this.synthesizedCompletionSessions.add(sessionId);
 
     const record = isRecord(data) ? data : {};
     let sessionMeta: EnrichmentMetadata = { metadata: {} };
@@ -680,6 +844,57 @@ export class SwarmCoordinatorService extends Service {
       sessionMeta = { metadata: {} };
     }
     const meta = sessionMeta.metadata;
+
+    // Ownership rule (issue elizaOS/eliza#11634): the sub-agent-router owns the
+    // completion→chat post for origin-routed sessions — it is origin-aware,
+    // dedupe-keyed, respawn/retry-suppressing, and feeds the planner's clean
+    // user-facing reply. Firing swarm synthesis for the SAME session
+    // double-posts the completion AND leaks state-lost errors the router
+    // deliberately suppresses while it respawns under cap.
+    //
+    // Only cede the events the router actually posts. `shouldInject` in
+    // sub-agent-router.ts injects `task_complete` and `error` (plus blocked /
+    // coordination) but NOT `stopped` — a stop/cancel/no-output session is
+    // terminal for synthesis (`completionStatusForEvent("stopped")`) yet the
+    // router never posts it, so skipping `stopped` here would leave the user
+    // with NO terminal notice. Skip only when: the event is router-owned
+    // (task_complete / error), the session carries router origin, AND the
+    // router is actually live. Everything else (stopped events, no-origin
+    // dashboard/API tasks, disabled/unbound router) still synthesizes so a
+    // terminal status never goes silent.
+    //
+    // This ownership check runs BEFORE the `synthesizedCompletionSessions`
+    // dedupe guard, and a router-owned skip does NOT consume the slot: ACP
+    // sessions are reused across follow-up turns, so a router-owned turn must
+    // not claim the session's synthesis slot — otherwise a later `stopped` on
+    // the SAME session (which the router does not post) would be swallowed. The
+    // double-synthesis race this ordering would otherwise open is closed by
+    // `maybeFireSwarmComplete`, which serializes all terminal events for a
+    // session so the second observes the first's completed decision.
+    //
+    // Exempt coordinator-generated validated completions: the app-verification
+    // / custom-validator path (dispatchCustomValidatorResult) synthesizes a
+    // `task_complete` the router never receives or posts — the raw ACP
+    // completion was withheld until validation, and only this result carries
+    // the verdict ("App verification passed."). Ceding it to the router would
+    // drop it entirely, so synthesis must stay its poster even on a
+    // router-owned session.
+    if (
+      ROUTER_OWNED_TERMINAL_EVENTS.has(event) &&
+      !isCustomValidatorResult(record) &&
+      sessionHasRouterOrigin(meta) &&
+      this.isRouterActive()
+    ) {
+      return;
+    }
+
+    // Synthesis will actually fire for this session/turn: claim the dedupe slot
+    // now (a straggler duplicate terminal event for the same session is
+    // suppressed until eviction releases it). Safe post-await because
+    // `maybeFireSwarmComplete` serializes same-session terminal events.
+    if (this.synthesizedCompletionSessions.has(sessionId)) return;
+    this.synthesizedCompletionSessions.add(sessionId);
+
     const label =
       readString(record, "label") ?? readString(meta, "label") ?? sessionId;
     const agentType =


### PR DESCRIPTION
## problem

follow-up to #11578 / #11605 (which sanitized WHAT gets posted). this fixes WHO posts.

coding sub-agent sessions with chat origin metadata had **two parallel completion→chat posters** for the SAME session:

- **`sub-agent-router.ts`** — origin-aware, dedupe-keyed, verify-retry-aware, suppresses respawned-session events, feeds the planner's clean user-facing reply.
- **`SwarmCoordinatorService.maybeFireSwarmComplete`** → `handleSwarmSynthesis` → connector — fires on EVERY terminal event with no knowledge of the router's suppression/dedupe/retry state.

result on a discord-origin "spawn a coding agent" task: **4 messages instead of 2**, including:
1. a **suppressed-error leak** — the false `Sub-agent state was lost (process exited without persisting). No automatic action taken.` scare, posted by synthesis even though the router had already respawned the session under cap and deliberately suppresses the dead session's events.
2. a **double-post** — synthesis posts the sub-agent narration AND the planner posts its own clean reply.

## ownership rule

**the sub-agent-router owns origin-routed sessions.** `maybeFireSwarmComplete` now SKIPS synthesis for a session when ALL of:

- the event is one the router actually posts — `task_complete` / `error` (`ROUTER_OWNED_TERMINAL_EVENTS`), **not** `stopped` (the router's `shouldInject` never injects `stopped`, so synthesis stays the sole poster for stop/cancel/no-output).
- the session carries the router's origin routing — `sessionHasRouterOrigin(meta)` mirrors `readOrigin`'s UUID gate EXACTLY (same `pickUuid` regex, same `originRoomId ?? sourceRoomId ?? taskRoomId ?? roomId` + `taskRoomId ?? roomId` fallthrough, reads session metadata ONLY — the same input `readOrigin(session)` reads). `source` is optional, matching `readOrigin`.
- the router is actually live — `isActive()` (new accessor): `!stopped && bound to the ACP stream`. false when disabled via `ACPX_SUB_AGENT_ROUTER_DISABLED`, stopped, or unbound. duck-typed lookup by serviceType string so the coordinator keeps no import edge on the router module. **fails safe** — a missing router/accessor is treated as "not active" so synthesis keeps posting.

everything else still synthesizes so a terminal status never goes silent: `stopped` events, no-origin dashboard/API-spawned tasks (the gap synthesis exists to cover), a disabled/unbound router, and coordinator-generated **custom-validator** verdicts (`dispatchCustomValidatorResult` — "App verification passed." — which the router never receives; exempted via `isCustomValidatorResult`).

### concurrency correctness

`AcpService` fans session events out to listeners **synchronously without awaiting** them, so two terminal events for one session (a router-owned `task_complete`/`error` racing a `stopped`, or duplicate terminals on one exit) would race the ownership/dedupe decision across the `getEnrichmentMetadata` await — double-posting or swallowing the `stopped` the router never posts. fixed by **serializing terminal-event synthesis per session** (`terminalCompletionChains`): each event chains onto the session's previous terminal handler, so the second observes the first's completed decision. the chain entry is pruned when it is the tail (no unbounded growth) and cleared on reset.

## test coverage

`swarm-coordinator-service.test.ts` (+ `sessionHasRouterOrigin` unit block):
- router-origin `task_complete` with active router → synthesis **silent**
- router-origin `error`/state-lost (source optional) → synthesis **silent** (suppressed-error leak fixed)
- no-origin dashboard session → synthesis **posts** (gap preserved)
- router-origin `stopped` even with active router → synthesis **posts** (router never injects stopped)
- router **disabled**/unbound → synthesis **posts** (fail-open)
- **no** router service registered → synthesis **posts** (fail-safe)
- room UUIDs only in event payload, not session metadata → synthesis **posts** (mirrors `readOrigin`'s session-metadata-only input; no silent drop)
- session reuse: router-owned `task_complete` does NOT consume the slot; a later `stopped` on the same session still fires
- **race**: two terminal events for a non-router session → fires exactly ONCE
- **race**: `stopped` racing a router-owned terminal on the same session → still fires (no swallow)
- `sessionHasRouterOrigin` both ways (valid UUID roomId+taskRoomId, taskRoomId-from-roomId fallback, source-optional, non-UUID-originRoomId fallthrough, missing-taskRoomId false, non-UUID false, empty false)

`sub-agent-router-roundtrip-getters.test.ts`:
- `isActive()` true once bound, false after `stop()`, false when disabled via `ACPX_SUB_AGENT_ROUTER_DISABLED`

## verification

`cd plugins/plugin-agent-orchestrator && npx vitest run __tests__`

- **baseline (clean develop):** 15 failed / 1246 passed — all pre-existing env failures (smithers-orchestrator module resolution, drizzle-orm, @noble/curves, i18n codegen; file-level module-resolution FAILs on spawn-*/stop-agent/task-history).
- **with this change:** 15 failed / 1283+ passed — **same 15 pre-existing failures, ZERO new failures**, +net new passing tests.
- touched suites green in isolation: `swarm-coordinator-service.test.ts` 41/41, `sub-agent-router-roundtrip-getters.test.ts` + `sub-agent-router.test.ts` 94/94.

closes #11634

— [sol-relay] — [sol-orch]
