### PR TITLE
fix(cloud): hoist throwable prompt prep above credit deduction in app-automation generators (money leak x4)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-automation-credit-order.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-automation-credit-order.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for the deduct-before-throwable-prep money leak in the
+ * telegram/discord/twitter app-automation generators (#11685).
+ *
+ * The bug: `generateAnnouncement` / `generateReply` / `generateAppTweet`
+ * charged credits FIRST, then awaited `getCharacterPromptContext` (a DB read)
+ * BEFORE entering the refunding try block around `generateText`. A throw in
+ * that deduct→fetch window (DB error/timeout on the character lookup)
+ * propagated out with the charge committed and no refund — and these run on
+ * schedulers/auto-reply loops, so a transient DB failure leaked a post-cost
+ * per invocation.
+ *
+ * The fix hoists all throwable prep above the deduction, so these tests pin:
+ * when the character-context fetch rejects, `deductCredits` is NEVER called
+ * (no charge for a generation that never ran). Each test also asserts the
+ * rejection is the context error itself — proving the context fetch (the
+ * armed hazard) is what fired, not some earlier failure.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+interface RecordedCall {
+  organizationId: string;
+  amount: number;
+  description: string;
+  metadata?: Record<string, unknown>;
+}
+
+const deductCalls: RecordedCall[] = [];
+const refundCalls: RecordedCall[] = [];
+
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits: async (params: RecordedCall) => {
+      deductCalls.push(params);
+      return { success: true, newBalance: 100, transaction: null };
+    },
+    refundCredits: async (params: RecordedCall) => {
+      refundCalls.push(params);
+      return { transaction: {}, newBalance: 100 };
+    },
+  },
+}));
+
+const CONTEXT_DB_ERROR = "character context DB read failed";
+
+mock.module("../character-prompt-helper", () => ({
+  getCharacterPromptContext: async () => {
+    throw new Error(CONTEXT_DB_ERROR);
+  },
+  buildCharacterSystemPrompt: () => "IN CHARACTER",
+}));
+
+const { telegramAppAutomationService } = await import("../telegram-automation/app-automation");
+const { discordAppAutomationService } = await import("../discord-automation/app-automation");
+const { twitterAppAutomationService } = await import("../twitter-automation/app-automation");
+
+const ORG_ID = "00000000-0000-4000-8000-00000000b001";
+
+/** Minimal app fixture: only the fields the generators read. */
+function makeApp(
+  automationField: string,
+): Parameters<typeof telegramAppAutomationService.generateAnnouncement>[1] {
+  return {
+    id: "00000000-0000-4000-8000-00000000b002",
+    name: "Test App",
+    description: "An app under test",
+    app_url: "https://test-app.example",
+    website_url: "https://test-app.example",
+    [automationField]: { enabled: true, agentCharacterId: "char-under-test" },
+  } as unknown as Parameters<typeof telegramAppAutomationService.generateAnnouncement>[1];
+}
+
+beforeEach(() => {
+  deductCalls.length = 0;
+  refundCalls.length = 0;
+});
+
+describe("app-automation generators never charge before throwable prep (#11685)", () => {
+  test("telegram generateAnnouncement: context fetch rejects -> no deduction taken", async () => {
+    await expect(
+      telegramAppAutomationService.generateAnnouncement(ORG_ID, makeApp("telegram_automation")),
+    ).rejects.toThrow(CONTEXT_DB_ERROR);
+
+    expect(deductCalls).toHaveLength(0);
+    expect(refundCalls).toHaveLength(0);
+  });
+
+  test("telegram generateReply: context fetch rejects -> no deduction taken", async () => {
+    await expect(
+      telegramAppAutomationService.generateReply(
+        ORG_ID,
+        makeApp("telegram_automation"),
+        "what does this app do?",
+        "tester",
+      ),
+    ).rejects.toThrow(CONTEXT_DB_ERROR);
+
+    expect(deductCalls).toHaveLength(0);
+    expect(refundCalls).toHaveLength(0);
+  });
+
+  test("discord generateAnnouncement: context fetch rejects -> no deduction taken", async () => {
+    await expect(
+      discordAppAutomationService.generateAnnouncement(ORG_ID, makeApp("discord_automation")),
+    ).rejects.toThrow(CONTEXT_DB_ERROR);
+
+    expect(deductCalls).toHaveLength(0);
+    expect(refundCalls).toHaveLength(0);
+  });
+
+  test("twitter generateAppTweet: context fetch rejects -> no deduction taken", async () => {
+    await expect(
+      twitterAppAutomationService.generateAppTweet(
+        ORG_ID,
+        makeApp("twitter_automation"),
+        "promotional",
+      ),
+    ).rejects.toThrow(CONTEXT_DB_ERROR);
+
+    expect(deductCalls).toHaveLength(0);
+    expect(refundCalls).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/discord-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/app-automation.ts
@@ -172,19 +172,9 @@ class DiscordAppAutomationService {
   }
 
   async generateAnnouncement(organizationId: string, app: App): Promise<string> {
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: DISCORD_POST_COST,
-      description: `Discord AI announcement: ${app.name}`,
-      metadata: { appId: app.id, type: "discord_announcement" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${DISCORD_POST_COST.toFixed(4)}`,
-      );
-    }
-
+    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
+    // the deduction: nothing may throw between the charge and the refunding try,
+    // or the user is charged for a generation that never ran (#11685).
     const config = app.discord_automation as DiscordAutomationConfig;
     const vibeStyle = config?.vibeStyle || "professional and engaging";
 
@@ -235,6 +225,19 @@ Website: ${app.website_url || app.app_url}
 Write in a ${vibeStyle} style. Keep it concise and engaging.
 Use appropriate emojis sparingly (1-2 max). Do not use excessive formatting.
 Maximum ${MAX_ANNOUNCEMENT_LENGTH} characters. Do not include the URL in your response - it will be added automatically.`;
+
+    const deduction = await creditsService.deductCredits({
+      organizationId,
+      amount: DISCORD_POST_COST,
+      description: `Discord AI announcement: ${app.name}`,
+      metadata: { appId: app.id, type: "discord_announcement" },
+    });
+
+    if (!deduction.success) {
+      throw new Error(
+        `Insufficient credits for AI generation. Required: $${DISCORD_POST_COST.toFixed(4)}`,
+      );
+    }
 
     try {
       const result = await generateText({

--- a/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/telegram-automation/app-automation.ts
@@ -172,19 +172,9 @@ class TelegramAppAutomationService {
   }
 
   async generateAnnouncement(organizationId: string, app: App): Promise<string> {
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TELEGRAM_POST_COST,
-      description: `Telegram AI announcement: ${app.name}`,
-      metadata: { appId: app.id, type: "telegram_announcement" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
-      );
-    }
-
+    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
+    // the deduction: nothing may throw between the charge and the refunding try,
+    // or the user is charged for a generation that never ran (#11685).
     const config = app.telegram_automation as TelegramAutomationConfig;
     const vibeStyle = config?.vibeStyle || "professional and engaging";
 
@@ -235,6 +225,19 @@ Write in a ${vibeStyle} style. Keep it concise and engaging.
 Use appropriate emojis sparingly. Do not use hashtags excessively.
 Maximum 500 characters.`;
 
+    const deduction = await creditsService.deductCredits({
+      organizationId,
+      amount: TELEGRAM_POST_COST,
+      description: `Telegram AI announcement: ${app.name}`,
+      metadata: { appId: app.id, type: "telegram_announcement" },
+    });
+
+    if (!deduction.success) {
+      throw new Error(
+        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
+      );
+    }
+
     try {
       const result = await generateText({
         model: openai("gpt-5-mini"),
@@ -262,19 +265,7 @@ Maximum 500 characters.`;
     userMessage: string,
     userName?: string,
   ): Promise<string> {
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TELEGRAM_POST_COST,
-      description: `Telegram AI reply: ${app.name}`,
-      metadata: { appId: app.id, type: "telegram_reply" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
-      );
-    }
-
+    // Throwable prep stays ahead of the deduction — see generateAnnouncement (#11685).
     const config = app.telegram_automation as TelegramAutomationConfig;
     const vibeStyle = config?.vibeStyle || "helpful and friendly";
 
@@ -310,6 +301,19 @@ Website: ${app.website_url || app.app_url}
 Respond in a ${vibeStyle} style. Be helpful and concise.
 If asked about features not related to the app, politely redirect to the app's purpose.
 Maximum 300 characters.`;
+
+    const deduction = await creditsService.deductCredits({
+      organizationId,
+      amount: TELEGRAM_POST_COST,
+      description: `Telegram AI reply: ${app.name}`,
+      metadata: { appId: app.id, type: "telegram_reply" },
+    });
+
+    if (!deduction.success) {
+      throw new Error(
+        `Insufficient credits for AI generation. Required: $${TELEGRAM_POST_COST.toFixed(4)}`,
+      );
+    }
 
     try {
       const result = await generateText({

--- a/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/app-automation.ts
@@ -142,19 +142,9 @@ class TwitterAppAutomationService {
     app: App,
     type: "promotional" | "engagement" | "educational" | "announcement" = "promotional",
   ): Promise<GeneratedTweet> {
-    const deduction = await creditsService.deductCredits({
-      organizationId,
-      amount: TWITTER_POST_COST,
-      description: `Twitter AI tweet: ${app.name}`,
-      metadata: { appId: app.id, type: "twitter_tweet" },
-    });
-
-    if (!deduction.success) {
-      throw new Error(
-        `Insufficient credits for AI generation. Required: $${TWITTER_POST_COST.toFixed(4)}`,
-      );
-    }
-
+    // All throwable prep (character-context DB fetch, prompt build) runs BEFORE
+    // the deduction: nothing may throw between the charge and the refunding try,
+    // or the user is charged for a generation that never ran (#11685).
     const config = app.twitter_automation as TwitterAutomationConfig | null;
     const vibeStyle = config?.vibeStyle ?? "professional yet approachable";
     const topics = config?.topics?.join(", ") ?? "";
@@ -230,6 +220,19 @@ Requirements:
 - Match the vibe style specified
 
 Return ONLY the tweet text, nothing else.`;
+
+    const deduction = await creditsService.deductCredits({
+      organizationId,
+      amount: TWITTER_POST_COST,
+      description: `Twitter AI tweet: ${app.name}`,
+      metadata: { appId: app.id, type: "twitter_tweet" },
+    });
+
+    if (!deduction.success) {
+      throw new Error(
+        `Insufficient credits for AI generation. Required: $${TWITTER_POST_COST.toFixed(4)}`,
+      );
+    }
 
     try {
       const twModel = "anthropic/claude-sonnet-4.6";


### PR DESCRIPTION
Closes #11685

## The leak (x4 sites, same class as #11680)

The telegram/discord/twitter app-automation generators charged credits, then performed a throwable async DB fetch (`getCharacterPromptContext`) **before** entering the refunding `try` around `generateText`. A throw in that deduct→fetch window (DB error/timeout on the character lookup) propagated out with the charge committed and **no refund** — the only refund lives in the `catch` around the later `generateText` call.

| site | deduct | unprotected fetch |
|---|---|---|
| `telegram-automation/app-automation.ts` `generateAnnouncement` | ✔ | ✔ |
| `telegram-automation/app-automation.ts` `generateReply` | ✔ | ✔ |
| `discord-automation/app-automation.ts` `generateAnnouncement` | ✔ | ✔ |
| `twitter-automation/app-automation.ts` `generateAppTweet` | ✔ | ✔ |

These run on schedulers/auto-reply loops, so a transient DB failure leaked `TELEGRAM_POST_COST`/`DISCORD_POST_COST`/`TWITTER_POST_COST` per invocation, silently, for any app with `agentCharacterId` configured.

## The fix

Hoist the character-context fetch + prompt construction (all throwable prep) **above** `deductCredits` in all four sites, so nothing throwable sits between the charge and the refunding `try`. No ordering dependency: the prompt prep does not read the deduction result. Post-fix, the only awaited call after the charge is `generateText`, which the existing refund already wraps. The insufficient-credits check and refund paths are byte-identical — the deduction block simply moved down.

## Evidence

**Red before** (fixes stashed, test against develop's code — all 4 fail: a deduction was taken for a generation that never ran):

```
error: expect(received).toHaveLength(expected)
Expected length: 0
Received length: 1        <- deductCalls: charged despite the context fetch throwing
(fail) telegram generateAnnouncement: context fetch rejects -> no deduction taken
(fail) telegram generateReply: context fetch rejects -> no deduction taken
(fail) discord generateAnnouncement: context fetch rejects -> no deduction taken
(fail) twitter generateAppTweet: context fetch rejects -> no deduction taken
 0 pass / 4 fail
```

**Green after:**

```
 4 pass / 0 fail — 12 expect() calls
```

Each test arms `getCharacterPromptContext` to reject and asserts (a) the method rejects with exactly that error — proving the armed hazard is what fired — and (b) `deductCredits` was never called, so there is no charge and nothing to refund.

- `bun run --cwd packages/cloud/shared typecheck` → exit 0
- `biome check` on all 4 files → clean
- UI/screenshots/trajectories: N/A — server-side credit-ordering control flow; the model call itself is unreached in the fixed error path.

— [cloud-security]

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
