### PR TITLE
fix(cloud): gate + cap the standard-auth compat agent create — stop unbounded creates (#11678)

### DIFF
--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -21,6 +21,17 @@ const requireServiceKey = mock(() => ({
 }));
 const authenticateWaifuBridge = mock(async () => null);
 
+// create route (compat/agents/route.ts) does its own inline compat auth via
+// these seams instead of compat/_lib/auth.
+const validateServiceKey = mock(async () => ({
+  organizationId: "org-1",
+  userId: "svc-user-1",
+}));
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
 const checkAgentCreditGate = mock(async () => ({
   allowed: false,
   balance: 0,
@@ -57,6 +68,31 @@ const provision = mock(async () => ({
 
 const snapshot = mock(async () => undefined);
 
+const createdSandboxRow = {
+  id: "agent-new",
+  agent_name: "Agent One",
+  status: "pending",
+  node_id: null,
+  database_status: "pending",
+  error_message: null,
+  last_heartbeat_at: null,
+  agent_config: {},
+  created_at: "2026-07-02T00:00:00.000Z",
+  updated_at: "2026-07-02T00:00:00.000Z",
+};
+
+const createAgent = mock(
+  async (_params: {
+    organizationId: string;
+    userId: string;
+    agentName: string;
+    maxNonTerminalAgents?: number;
+  }) => ({
+    agent: createdSandboxRow,
+    idempotent: false,
+  }),
+);
+
 // launch/route.ts calls launchManagedElizaAgent (which itself wraps provision),
 // not elizaSandboxService.provision directly — mock it at that seam.
 const launchManagedElizaAgent = mock(async () => ({
@@ -72,10 +108,48 @@ const prepareManagedElizaEnvironment = mock(async () => ({
   environmentVars: {},
 }));
 
-class AgentQuotaExceededError extends Error {}
+class AgentQuotaExceededError extends Error {
+  readonly count: number;
+  readonly max: number;
+  constructor(count = 20, max = 20) {
+    super(
+      `Agent quota exceeded: your organization already has ${count} active agents (limit ${max}).`,
+    );
+    this.name = "AgentQuotaExceededError";
+    this.count = count;
+    this.max = max;
+  }
+}
 
 mock.module("../compat/_lib/auth", () => ({
   requireCompatAuth,
+}));
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  validateServiceKey,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-agent-config", () => ({
+  stripReservedElizaConfigKeys: (config: Record<string, unknown> | undefined) =>
+    config,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentProvisionOnce: mock(async () => ({ job: { id: "job-1" } })),
+  },
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth: mock(async () => ({ ok: true })),
+  provisioningWorkerFailureBody: () => ({
+    success: false,
+    error: "provisioning worker unavailable",
+  }),
 }));
 
 mock.module("@/lib/auth", () => ({
@@ -102,6 +176,7 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     getAgentForWrite,
     provision,
     snapshot,
+    createAgent,
   },
 }));
 
@@ -130,6 +205,7 @@ const { default: restartRoute } = await import(
 const { default: launchRoute } = await import(
   "../compat/agents/[id]/launch/route"
 );
+const { default: agentsRoute } = await import("../compat/agents/route");
 
 describe("compat agent resume/restart/launch credit gate", () => {
   const app = new Hono();
@@ -277,5 +353,124 @@ describe("compat agent resume/restart/launch credit gate", () => {
       organizationId: "org-1",
       userId: "user-1",
     });
+  });
+});
+
+describe("compat agent create credit + quota gate (elizaOS/eliza#11678)", () => {
+  const app = new Hono();
+  app.route("/api/compat/agents", agentsRoute);
+
+  const createRequest = (headers: Record<string, string> = {}) =>
+    new Request("https://api.example.test/api/compat/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ agentName: "Agent One" }),
+    });
+
+  beforeEach(() => {
+    authenticateWaifuBridge.mockClear();
+    authenticateWaifuBridge.mockResolvedValue(null);
+    validateServiceKey.mockClear();
+    validateServiceKey.mockResolvedValue({
+      organizationId: "org-1",
+      userId: "svc-user-1",
+    });
+    requireUserOrApiKeyWithOrg.mockClear();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    checkAgentCreditGate.mockClear();
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+    createAgent.mockClear();
+    createAgent.mockResolvedValue({
+      agent: createdSandboxRow,
+      idempotent: false,
+    });
+  });
+
+  test("blocks a standard-auth compat create with 402 before any row is minted when the org has insufficient credits", async () => {
+    const response = await app.fetch(createRequest(), {});
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Insufficient credits",
+    });
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  test("caps a funded standard-auth compat create with the balance-tiered maxNonTerminalAgents", async () => {
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const response = await app.fetch(createRequest(), {});
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { agentId: "agent-new" },
+    });
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    // $5 balance → the 20-agent tier (getMaxNonTerminalAgentsForOrg).
+    expect(createAgent.mock.calls[0]?.[0]).toMatchObject({
+      organizationId: "org-1",
+      userId: "user-1",
+      agentName: "Agent One",
+      maxNonTerminalAgents: 20,
+    });
+    // Compat stays multi-agent-per-org: the reuse guard must remain OFF.
+    expect(
+      (createAgent.mock.calls[0]?.[0] as Record<string, unknown>)
+        .reuseExistingNonTerminal,
+    ).toBeUndefined();
+  });
+
+  test("maps AgentQuotaExceededError from a standard-auth create to 429", async () => {
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    createAgent.mockImplementationOnce(async () => {
+      throw new AgentQuotaExceededError(20, 20);
+    });
+
+    const response = await app.fetch(createRequest(), {});
+
+    expect(response.status).toBe(429);
+    const body = (await response.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("Agent quota exceeded");
+  });
+
+  test("does not gate or cap trusted service-key (S2S) creates", async () => {
+    const response = await app.fetch(
+      createRequest({ "X-Service-Key": "svc-key" }),
+      {},
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { agentId: "agent-new" },
+    });
+    expect(validateServiceKey).toHaveBeenCalled();
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(
+      (createAgent.mock.calls[0]?.[0] as Record<string, unknown>)
+        .maxNonTerminalAgents,
+    ).toBeUndefined();
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -473,4 +473,29 @@ describe("compat agent create credit + quota gate (elizaOS/eliza#11678)", () => 
     ).toBeUndefined();
     expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
   });
+
+  test("does not gate or cap trusted service-jwt (waifu-bridge S2S) creates", async () => {
+    authenticateWaifuBridge.mockResolvedValue({
+      user: { id: "waifu-user-1", organization_id: "org-1" },
+    });
+
+    const response = await app.fetch(
+      createRequest({ Authorization: "Bearer waifu-jwt" }),
+      {},
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { agentId: "agent-new" },
+    });
+    expect(authenticateWaifuBridge).toHaveBeenCalled();
+    // Trusted bridge path: no credit gate, no quota cap (waifu-core must not break).
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(
+      (createAgent.mock.calls[0]?.[0] as Record<string, unknown>)
+        .maxNonTerminalAgents,
+    ).toBeUndefined();
+  });
 });

--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -19,7 +19,15 @@ const requireServiceKey = mock(() => ({
   organizationId: "org-1",
   userId: "user-1",
 }));
-const authenticateWaifuBridge = mock(async () => null);
+type WaifuBridgeAuth = {
+  user: {
+    id: string;
+    organization_id: string;
+  };
+} | null;
+const authenticateWaifuBridge = mock(
+  async (): Promise<WaifuBridgeAuth> => null,
+);
 
 // create route (compat/agents/route.ts) does its own inline compat auth via
 // these seams instead of compat/_lib/auth.

--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -22,8 +22,13 @@ import {
 import { validateServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { authenticateWaifuBridge } from "@/lib/auth/waifu-bridge";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { stripReservedElizaConfigKeys } from "@/lib/services/eliza-agent-config";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  AgentQuotaExceededError,
+  elizaSandboxService,
+} from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
   checkProvisioningWorkerHealth,
@@ -102,7 +107,7 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   try {
-    const { user } = await requireCompatAuth(c);
+    const { user, authMethod } = await requireCompatAuth(c);
     const body = await c.req.json();
 
     const parsed = createAgentSchema.safeParse(body);
@@ -122,6 +127,32 @@ app.post("/", async (c) => {
     const sanitizedConfig = stripReservedElizaConfigKeys(
       parsed.data.agentConfig,
     );
+    // Credit + quota gate for STANDARD (Steward / API-key) callers only —
+    // without it any $0-balance user could loop this endpoint and mint
+    // unbounded agent_sandboxes rows via the uncapped createAgent fast path
+    // (elizaOS/eliza#11678). Trusted S2S callers (service_key / service_jwt,
+    // e.g. the waifu bridge) legitimately create many agents per org and stay
+    // ungated + uncapped, matching the sandbox service's trusted fast path.
+    let maxNonTerminalAgents: number | undefined;
+    if (authMethod === "standard") {
+      const creditCheck = await checkAgentCreditGate(user.organization_id);
+      if (!creditCheck.allowed) {
+        logger.warn("[compat] Agent creation blocked: insufficient credits", {
+          orgId: user.organization_id,
+          balance: creditCheck.balance,
+        });
+        return c.json(
+          errorEnvelope(
+            creditCheck.error ?? "Insufficient credits to create an agent",
+          ),
+          402,
+        );
+      }
+      // Balance-tiered per-org ceiling (#11023), enforced atomically inside
+      // createAgent under the org advisory lock.
+      maxNonTerminalAgents = getMaxNonTerminalAgentsForOrg(creditCheck.balance);
+    }
+
     const autoProvision =
       (c.env as { WAIFU_AUTO_PROVISION?: string }).WAIFU_AUTO_PROVISION ===
       "true";
@@ -145,13 +176,30 @@ app.post("/", async (c) => {
 
     // Compat is a multi-agent-per-org flow (each call mints a distinct agent),
     // so the reuse guard stays off and createAgent always reports a fresh row.
-    const { agent } = await elizaSandboxService.createAgent({
-      organizationId: user.organization_id,
-      userId: user.id,
-      agentName: parsed.data.agentName,
-      agentConfig: sanitizedConfig,
-      environmentVars: parsed.data.environmentVars,
-    });
+    // Standard callers are still bounded by `maxNonTerminalAgents` (undefined
+    // for S2S keeps the trusted uncapped path).
+    let created: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
+    try {
+      created = await elizaSandboxService.createAgent({
+        organizationId: user.organization_id,
+        userId: user.id,
+        agentName: parsed.data.agentName,
+        agentConfig: sanitizedConfig,
+        environmentVars: parsed.data.environmentVars,
+        maxNonTerminalAgents,
+      });
+    } catch (error) {
+      if (error instanceof AgentQuotaExceededError) {
+        logger.warn("[compat] Agent creation blocked: per-org quota exceeded", {
+          orgId: user.organization_id,
+          count: error.count,
+          max: error.max,
+        });
+        return c.json(errorEnvelope(error.message), 429);
+      }
+      throw error;
+    }
+    const { agent } = created;
 
     logger.info("[compat] Agent created", {
       agentId: agent.id,


### PR DESCRIPTION
Fixes #11678.

## Bug (MED, security/DoS — unbounded compat agent create)
`POST /api/compat/agents` called `elizaSandboxService.createAgent({...})` with **no `maxNonTerminalAgents`**, landing on the **uncapped fast path** in `shared/src/lib/services/eliza-sandbox.ts` (no advisory lock, no `assertOrgAgentQuota`, no credit gate). An ordinary `authMethod: "standard"` user on a $0 balance could loop the endpoint and mint unbounded `agent_sandboxes` rows — the #11023 unbounded-create class, through the compat front door. Compat **resume/restart/launch** were credit-gated in #11152; **CREATE was missed**, and the sibling `POST /api/v1/eliza/agents` / `/api/v1/coding-containers` were already bounded.

## Fix (`packages/cloud/api/compat/agents/route.ts`)
Mirrors the hardened `POST /api/v1/eliza/agents`, gated on `authMethod === "standard"` **only**:
1. `checkAgentCreditGate(user.organization_id)` → on `!allowed`, **402** with the compat `errorEnvelope(creditCheck.error)` body (same shape/status the existing compat resume/restart/launch gates use) — before any row is minted.
2. Pass `maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(creditCheck.balance)` into `createAgent` (balance-tiered ceiling, enforced atomically under the org advisory lock) and map `AgentQuotaExceededError` → **429**.

**Deliberately unchanged:** `service_key` / `service_jwt` (waifu bridge) S2S callers skip the gate and pass `maxNonTerminalAgents: undefined` (trusted fast path); `reuseExistingNonTerminal` stays **off** (compat is multi-agent-per-org); auto-provision worker-health check + reserved `__agent*` key stripping untouched.

## Tests (`__tests__/compat-agent-credit-gate.test.ts`, extended)
```
bun test __tests__/compat-agent-credit-gate.test.ts
 11 pass / 0 fail  (49 expect() calls)
```
New create cases: standard + insufficient credits → **402** (`createAgent` not called); funded standard ($5 → tier 20) → `createAgent` called with `maxNonTerminalAgents: 20`, reuse undefined, 201; `AgentQuotaExceededError` → **429**; **both** S2S paths (`X-Service-Key` **and** `service_jwt` waifu-bridge) → ungated + uncapped, 201.

**Mutation-checked:** removing the `maxNonTerminalAgents` arg turns the cap test red (9→ fail), restore → green. Independently reverting `route.ts` to develop fails the 3 new standard-auth gate tests while the two S2S tests stay green (behavior-preservation pins).

Biome clean on both files. (Pre-existing, unrelated: `packages/cloud/api` package `typecheck` reports 5 errors in `shared/.../team-credential-pool/registry.ts` on clean `origin/develop` too — none in the touched files.)

Nit acknowledged from review: the 429 body is `errorEnvelope(message)` (compat convention, matching the sibling compat gates) rather than v1's machine-readable `code: agent_quota_exceeded` + `currentAgents/maxAgents` — kept for compat-client contract consistency.

Security lane → not self-merged. [cloud-security]
