### PR TITLE
fix(cloud): app-chat holds sweep through the settle lane — stop the #11493 double-refund + markup over-refund (#11683)

### DIFF
--- a/packages/cloud/shared/src/lib/providers/_http.ts
+++ b/packages/cloud/shared/src/lib/providers/_http.ts
@@ -48,9 +48,14 @@ interface UpstreamErrorBody {
  */
 const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
 
-const DEFAULT_MAX_RETRIES = 3;
+/**
+ * Exported (with {@link PROVIDER_MAX_BACKOFF_DELAY_MS}) so the stale-reservation
+ * sweep can derive its grace window from the real worst-case in-flight time of
+ * this retry ladder instead of hardcoding a number that drifts (#11683).
+ */
+export const PROVIDER_DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_DELAY_MS = 400;
-const MAX_BACKOFF_DELAY_MS = 8_000;
+export const PROVIDER_MAX_BACKOFF_DELAY_MS = 8_000;
 
 export interface ProviderRetryOptions {
   /** Max RETRY attempts after the first try (so total tries = maxRetries + 1). */
@@ -82,14 +87,14 @@ function computeBackoffMs(attempt: number, baseDelayMs: number, retryAfter: stri
   if (retryAfter) {
     const asNumber = Number(retryAfter);
     if (Number.isFinite(asNumber) && asNumber >= 0) {
-      return Math.min(asNumber * 1000, MAX_BACKOFF_DELAY_MS);
+      return Math.min(asNumber * 1000, PROVIDER_MAX_BACKOFF_DELAY_MS);
     }
     const asDate = Date.parse(retryAfter);
     if (!Number.isNaN(asDate)) {
-      return Math.min(Math.max(asDate - Date.now(), 0), MAX_BACKOFF_DELAY_MS);
+      return Math.min(Math.max(asDate - Date.now(), 0), PROVIDER_MAX_BACKOFF_DELAY_MS);
     }
   }
-  const exp = Math.min(baseDelayMs * 2 ** attempt, MAX_BACKOFF_DELAY_MS);
+  const exp = Math.min(baseDelayMs * 2 ** attempt, PROVIDER_MAX_BACKOFF_DELAY_MS);
   // Full jitter so concurrent callers don't synchronize their retries.
   return Math.floor(Math.random() * exp);
 }
@@ -112,7 +117,9 @@ export async function providerFetchWithTimeout(
   label: ProviderLabel,
   retry?: ProviderRetryOptions,
 ): Promise<Response> {
-  const maxRetries = isReplayable(options) ? (retry?.maxRetries ?? DEFAULT_MAX_RETRIES) : 0;
+  const maxRetries = isReplayable(options)
+    ? (retry?.maxRetries ?? PROVIDER_DEFAULT_MAX_RETRIES)
+    : 0;
   const baseDelayMs = retry?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   const callerSignal = options.signal ?? null;
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Stale-reservation sweep vs the app-chat settle lane — REAL path (#11683,
+ * hardens #11493).
+ *
+ * Two live money defects, both introduced by the #11493 sweep:
+ *
+ * 1. DOUBLE-REFUND (cashable mint): the sweep settled app-chat holds through
+ *    the GENERIC reservation lane, whose refund is keyed
+ *    `recon:<holdId>:refund`, while the route's late settle
+ *    (`appCreditsService.reconcileCredits`) refunds under
+ *    `reconcile-refund:<holdId>` (#11512). Disjoint keys ⇒ no cross-dedup.
+ *    The sweep ran every minute with a 20-minute grace, but the provider HTTP
+ *    retry ladder keeps a hold legitimately in flight far longer
+ *    (PROVIDER_DEFAULT_MAX_RETRIES ⇒ 4 tries × ≤790s per try × 2 providers
+ *    ≈ 106 min), so the sweep refunded a still-in-flight hold and the late
+ *    settle refunded it AGAIN — org credited ≈ 2×reserved − actual.
+ *
+ * 2. MARKUP OVER-REFUND: the app-chat hold amount is the markup-INCLUSIVE
+ *    totalCost and the creator's markup earnings are committed at deduct
+ *    time, but the generic sweep settled against the base-only
+ *    estimated_cost — refunding the buffer PLUS the whole markup to the
+ *    consumer while leaving the creator's deduct-time earnings unreversed
+ *    (unbacked redeemable earnings). The #11493 fixture only modeled
+ *    markup = 0, so this never tripped.
+ *
+ * These tests drive the REAL code end-to-end against in-process PGlite:
+ * a real route-shaped app-chat hold (`deductCredits` with the
+ * `app_chat_reservation_v1` marker metadata, exactly as
+ * `v1/apps/[id]/chat/route.ts` writes it), the real
+ * `creditsService.sweepStaleReservations()`, and the real late settle
+ * (`appCreditsService.reconcileCredits` with the server-generated reservation
+ * transaction id — the actual settle lane, NOT the generic
+ * `creditsService.reconcile` the #11493 test used, which is why the defect
+ * slipped through). No mocks anywhere on the money path.
+ *
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails
+ * to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports (see
+// app-credits-idempotency.test.ts for the full rationale).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  appUsers,
+  userDatabaseStatusEnum,
+} from "../../../db/schemas/apps";
+import { creditTransactions } from "../../../db/schemas/credit-transactions";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let appCreditsService: typeof import("../app-credits").appCreditsService;
+let creditsService: typeof import("../credits").creditsService;
+let RESERVATION_SWEEP_GRACE_MS: number;
+
+const APP_CHAT_RESERVATION_SETTLEMENT_MARKER = "app_chat_reservation_v1";
+const OLD_SWEEP_GRACE_MS = 20 * 60 * 1000;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const INITIAL_ORG_BALANCE = 100;
+
+async function seed(): Promise<{
+  appId: string;
+  payerUserId: string;
+  payerOrgId: string;
+  creatorUserId: string;
+}> {
+  const [payerOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Payer", slug: uniq("payer"), credit_balance: "100.000000" })
+    .returning();
+  const [payer] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("payer-u"), organization_id: payerOrg.id })
+    .returning();
+  const [creatorOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Creator", slug: uniq("creator") })
+    .returning();
+  const [creator] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("creator-u"), organization_id: creatorOrg.id })
+    .returning();
+  const [app] = await dbWrite
+    .insert(apps)
+    .values({
+      name: "Monetized App",
+      slug: uniq("app"),
+      organization_id: creatorOrg.id,
+      created_by_user_id: creator.id,
+      app_url: "https://placeholder.invalid",
+      monetization_enabled: true,
+      inference_markup_percentage: 100,
+    })
+    .returning();
+  return {
+    appId: app.id,
+    payerUserId: payer.id,
+    payerOrgId: payerOrg.id,
+    creatorUserId: creator.id,
+  };
+}
+
+/**
+ * Open an app-chat hold EXACTLY as `v1/apps/[id]/chat/route.ts` does — the
+ * same `deductCredits` call with the same marker metadata — then backdate the
+ * hold row so the sweep's grace window logic sees the requested age.
+ */
+async function openRouteShapedHold(params: {
+  appId: string;
+  userId: string;
+  estimatedBaseCost: number;
+  reservedBaseCost: number;
+  ageMs: number;
+}): Promise<string> {
+  const { appId, userId, estimatedBaseCost, reservedBaseCost, ageMs } = params;
+  const deduction = await appCreditsService.deductCredits({
+    appId,
+    userId,
+    baseCost: reservedBaseCost,
+    description: "Chat: test-model",
+    metadata: {
+      type: "app_chat_reservation",
+      settlement_marker: APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
+      model: "test-model",
+      provider: "test-provider",
+      billingSource: "test",
+      estimatedInputTokens: 10,
+      estimatedOutputTokens: 100,
+      estimated_cost: estimatedBaseCost,
+      reserved_amount: reservedBaseCost,
+      safetyMultiplier: 1.5,
+      reservation_buffer: 1.5,
+    },
+  });
+  expect(deduction.success).toBe(true);
+  const holdId = deduction.transactionId;
+  if (!holdId) throw new Error("deductCredits returned no transaction id");
+  await dbWrite
+    .update(creditTransactions)
+    .set({ created_at: new Date(Date.now() - ageMs) })
+    .where(eq(creditTransactions.id, holdId));
+  return holdId;
+}
+
+async function orgBalance(orgId: string): Promise<number> {
+  const [row] = await dbWrite.select().from(organizations).where(eq(organizations.id, orgId));
+  return Number(row?.credit_balance ?? Number.NaN);
+}
+
+async function creatorBalance(userId: string): Promise<number> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return Number(row?.available_balance ?? 0);
+}
+
+async function appCreatorEarningsCounter(appId: string): Promise<number> {
+  const [row] = await dbWrite.select().from(apps).where(eq(apps.id, appId));
+  return Number(row?.total_creator_earnings ?? Number.NaN);
+}
+
+async function refundRows(orgId: string): Promise<(typeof creditTransactions.$inferSelect)[]> {
+  return dbWrite
+    .select()
+    .from(creditTransactions)
+    .where(
+      and(eq(creditTransactions.organization_id, orgId), eq(creditTransactions.type, "refund")),
+    );
+}
+
+async function holdSettledAt(holdId: string): Promise<Date | null> {
+  const [row] = await dbWrite
+    .select()
+    .from(creditTransactions)
+    .where(eq(creditTransactions.id, holdId));
+  return row?.settled_at ?? null;
+}
+
+beforeAll(async () => {
+  try {
+    ({ appCreditsService } = await import("../app-credits"));
+    ({ creditsService, RESERVATION_SWEEP_GRACE_MS } = await import("../credits"));
+    const schema = {
+      organizations,
+      users,
+      apps,
+      appUsers,
+      appEarnings,
+      appEarningsTransactions,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      creditTransactions,
+      appDeploymentStatusEnum,
+      appReviewStatusEnum,
+      userDatabaseStatusEnum,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[app-chat-sweep-double-refund.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("stale-reservation sweep vs app-chat settle lane (#11683)", () => {
+  test("pglite applied (loud, never silent no-op)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test("default sweep grace covers the provider retry-ladder in-flight window", () => {
+    // 4 tries × 790s + backoff, × 2 providers ≈ 106 min; the grace must sit
+    // ABOVE it (and far above the old 20-minute value that caused the mint).
+    expect(RESERVATION_SWEEP_GRACE_MS).toBeGreaterThanOrEqual(2 * 60 * 60 * 1000);
+    expect(RESERVATION_SWEEP_GRACE_MS).toBeGreaterThan(OLD_SWEEP_GRACE_MS);
+  });
+
+  test("a hold in-flight past the OLD 20-min grace is NOT swept; the late settle refunds exactly once", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+
+    // Route shape: estimate 0.02 base, ×1.5 buffer → 0.03 reserved base;
+    // 100% markup → hold debits 0.06 and the creator earns 0.03 upfront.
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 25 * 60 * 1000, // past the OLD grace, inside the retry ladder
+    });
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(INITIAL_ORG_BALANCE - 0.06, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.03, 6);
+
+    // DEFAULT sweep (the cron's call shape): the request is legitimately still
+    // in flight — the sweep must leave the hold alone. Before this fix the
+    // 20-minute default grace swept (and refunded) it here.
+    await creditsService.sweepStaleReservations();
+    expect(await holdSettledAt(holdId)).toBeNull();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(INITIAL_ORG_BALANCE - 0.06, 6);
+    expect(await refundRows(payerOrgId)).toHaveLength(0);
+
+    // The request completes; the route settles through the REAL lane. Exactly
+    // one refund: actual 0.01 base < 0.03 reserved base → 0.04 total refund.
+    await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.01,
+      description: "late app-chat settle",
+      reservationTransactionId: holdId,
+    });
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+    const refunds = await refundRows(payerOrgId);
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0]?.stripe_payment_intent_id).toBe(`reconcile-refund:${holdId}`);
+    expect(await holdSettledAt(holdId)).toBeTruthy();
+  });
+
+  test("markup>0 hold: sweep settles through the app-credits lane (correct markup math + earnings reversal) and the late settle is a dedup no-op", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000, // genuinely stranded: older than the new grace
+    });
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.94, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.03, 6);
+    expect(await appCreatorEarningsCounter(appId)).toBeCloseTo(0.03, 6);
+
+    // DEFAULT sweep: assumes actual == the 0.02 base estimate and settles in
+    // BASE-cost space: refund = (0.03 − 0.02) × 2 (100% markup) = 0.02, and
+    // the creator's earnings are reversed by the 0.01 markup delta. The old
+    // generic lane refunded |hold| − estimated_cost = 0.06 − 0.02 = 0.04
+    // (over-refunding the whole markup) and reversed NOTHING.
+    const stats = await creditsService.sweepStaleReservations();
+    expect(stats.settled).toBe(1);
+    expect(stats.refunds).toBe(1);
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.96, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.02, 6);
+    expect(await appCreatorEarningsCounter(appId)).toBeCloseTo(0.02, 6);
+    expect(await holdSettledAt(holdId)).toBeTruthy();
+    const sweptRefunds = await refundRows(payerOrgId);
+    expect(sweptRefunds).toHaveLength(1);
+    // The sweep now shares the settle lane's idempotency key — this is the
+    // cross-dedup that was missing (#11493 keyed it `recon:<holdId>:refund`).
+    expect(sweptRefunds[0]?.stripe_payment_intent_id).toBe(`reconcile-refund:${holdId}`);
+
+    // The provider finally answers and the route's late settle fires with the
+    // REAL actual cost. Before this fix it refunded 0.04 MORE under its own
+    // key (org up to 100.02 — minted, cashable credit) and double-reversed
+    // nothing/earnings inconsistently. Now: full dedup no-op on the org
+    // refund, the earnings reversal, and the apps counter.
+    await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.01,
+      description: "late app-chat settle after sweep",
+      reservationTransactionId: holdId,
+    });
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.96, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.02, 6);
+    expect(await appCreatorEarningsCounter(appId)).toBeCloseTo(0.02, 6);
+    expect(await refundRows(payerOrgId)).toHaveLength(1);
+  });
+
+  test("settled-first hold: the sweep skips it (settled_at fence)", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+
+    const holdId = await openRouteShapedHold({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.02,
+      reservedBaseCost: 0.03,
+      ageMs: 3 * 60 * 60 * 1000,
+    });
+
+    // Settle lane wins the race: refund 0.04, creator reversed 0.02.
+    await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      estimatedBaseCost: 0.03,
+      actualBaseCost: 0.01,
+      description: "settle before sweep",
+      reservationTransactionId: holdId,
+    });
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+
+    // The sweep must not touch the settled hold — no second refund.
+    await creditsService.sweepStaleReservations();
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(99.98, 6);
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+    expect(await refundRows(payerOrgId)).toHaveLength(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -430,7 +430,15 @@ describe("reserveInferenceCredits — holds app inference cost before model work
     expect(result?.adjustmentType).toBe("overage");
     expect(addEarnings).toHaveBeenCalledTimes(2);
     expect(addEarnings.mock.calls[0][0].sourceId).toBe("req-3:inference_markup:deduct");
-    expect(addEarnings.mock.calls[1][0].sourceId).toBe("req-3:inference_markup:reconcile_charge");
+    // #11683: the reconcile legs key on the SERVER-generated reservation
+    // deduct-transaction id, not the request key — the route's late settle and
+    // the stale-reservation sweep run in different request contexts, and only
+    // a reservation-derived key lets their earnings movements cross-dedupe.
+    // Still distinct from the deduct leg's key, so the estimate credit and the
+    // overage top-up never collide (#10847).
+    expect(addEarnings.mock.calls[1][0].sourceId).toBe(
+      "reconcile:tx-2:inference_markup:reconcile_charge",
+    );
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -921,7 +921,17 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
   );
 
   test(
-    "sweep covers marker-aware app-chat holds and refunds only the stale buffer",
+    // #11683: app-chat holds must settle through appCreditsService.reconcileCredits
+    // (the lane the route's late settle uses, keyed `reconcile-refund:<holdId>`),
+    // NEVER the generic lane below (keyed `recon:<holdId>:refund`) — the disjoint
+    // keys let a swept-but-still-in-flight hold be refunded twice, and the
+    // generic base-only math over-refunded the markup. This minimal fixture has
+    // no users/apps rows for the app-credits lane to resolve, so the sweep must
+    // leave the hold untouched (skipped, retried next sweep) rather than settle
+    // it generically. The full app-credits-lane sweep proof (markup math,
+    // cross-writer dedup with the real settle lane) lives in
+    // app-chat-sweep-double-refund.test.ts.
+    "sweep never settles app-chat holds through the generic lane",
     async () => {
       if (!pgliteReady) return;
       await seedOrg("8.5");
@@ -933,45 +943,31 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       });
 
       expect(stats.scanned).toBe(1);
-      expect(stats.settled).toBe(1);
-      expect(stats.refunds).toBe(1);
-      expect(await getBalance()).toBeCloseTo(9, 6);
-      expect(await getReservationSettledAt(reservationId)).toBeTruthy();
-      expect(await settlementRowsForReservation(reservationId)).toEqual([
-        {
-          amount: "0.500000",
-          type: "refund",
-          stripe_payment_intent_id: `recon:${reservationId}:refund`,
-        },
-      ]);
-
-      const late = await creditsService.reconcile({
-        organizationId: ORG_ID,
-        reservedAmount: 1.5,
-        actualCost: 0,
-        description: "late app-chat refund after sweep",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
-      });
-
-      expect(late.adjustmentType).toBe("none");
-      expect(await getBalance()).toBeCloseTo(9, 6);
-      expect(await countByType("refund")).toBe(1);
+      expect(stats.settled).toBe(0);
+      expect(stats.refunds).toBe(0);
+      expect(stats.skipped).toBe(1);
+      // No generically-keyed money row, no settle claim, balance untouched.
+      expect(await getBalance()).toBeCloseTo(8.5, 6);
+      expect(await getReservationSettledAt(reservationId)).toBeNull();
+      expect(await settlementRowsForReservation(reservationId)).toEqual([]);
+      expect(await countByType("refund")).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "sweep settles monetized app-chat holds markup-inclusively — exactly one refund, org nets the marked-up estimate",
+    "sweep does not settle monetized app-chat holds through the generic lane",
     async () => {
       if (!pgliteReady) return;
       // Production monetized shape (#11592): base estimate $1.00, 1.5x buffer
       // -> reserved base $1.50, 20% creator markup -> $1.80 org hold
-      // (`computeInferenceCharge`), creator earnings recorded at deduct time.
-      // The sweep must settle the org to $1.20 (estimate + markup, what a
-      // normal settle at the estimate charges), i.e. refund $0.60 — NOT to
-      // the bare $1.00 base estimate: refunding $0.80 would hand the markup
-      // on the estimate back to the org while the creator keeps the earnings,
-      // so the platform would eat the whole markup.
+      // (`computeInferenceCharge`), creator earnings recorded at deduct time;
+      // #11683 requires the sweep to use the app-credits settle lane, not the
+      // generic `recon:<holdId>:refund` lane. This synthetic fixture does not
+      // create the users/apps tables that appCreditsService needs, so the safe
+      // behavior is to skip and retry later, leaving the hold open. The real
+      // app-credits-lane proof for markup math and late-settle dedup lives in
+      // app-chat-sweep-double-refund.test.ts.
       await seedOrg("8.2"); // org had 10, paid the 1.8 hold
       const reservationId = await insertAppChatReservation(1.8, 25 * 60 * 1000, {
         estimated_cost: 1.0,
@@ -988,44 +984,19 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       });
 
       expect(stats.scanned).toBe(1);
-      expect(stats.settled).toBe(1);
-      expect(stats.refunds).toBe(1);
-      expect(await getBalance()).toBeCloseTo(8.8, 6);
-      expect(await getReservationSettledAt(reservationId)).toBeTruthy();
-      expect(await settlementRowsForReservation(reservationId)).toEqual([
-        {
-          amount: "0.600000",
-          type: "refund",
-          stripe_payment_intent_id: `recon:${reservationId}:refund`,
-        },
-      ]);
-
-      // Idempotent: a re-sweep skips the settled hold entirely, and a late
-      // full-refund settle after the sweep is a no-op — exactly one refund.
-      const again = await creditsService.sweepStaleReservations({
-        graceMs: 20 * 60 * 1000,
-        batchSize: 10,
-      });
-      expect(again.scanned).toBe(0);
-      expect(again.settled).toBe(0);
-
-      const late = await creditsService.reconcile({
-        organizationId: ORG_ID,
-        reservedAmount: 1.8,
-        actualCost: 0,
-        description: "late app-chat refund after sweep",
-        metadata: { user_id: USER_ID, reservation_transaction_id: reservationId },
-      });
-
-      expect(late.adjustmentType).toBe("none");
-      expect(await getBalance()).toBeCloseTo(8.8, 6);
-      expect(await countByType("refund")).toBe(1);
+      expect(stats.settled).toBe(0);
+      expect(stats.skipped).toBe(1);
+      expect(stats.refunds).toBe(0);
+      expect(await getBalance()).toBeCloseTo(8.2, 6);
+      expect(await getReservationSettledAt(reservationId)).toBeNull();
+      expect(await settlementRowsForReservation(reservationId)).toEqual([]);
+      expect(await countByType("refund")).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "sweep settles an app-chat hold without a usable base pair exact-cost instead of guessing",
+    "sweep skips an app-chat hold without a usable base pair instead of guessing",
     async () => {
       if (!pgliteReady) return;
       await seedOrg("8.2");
@@ -1040,11 +1011,12 @@ describe("CreditsService reservation settlement marker (#11169)", () => {
       });
 
       expect(stats.scanned).toBe(1);
-      expect(stats.settled).toBe(1);
-      expect(stats.noops).toBe(1);
+      expect(stats.settled).toBe(0);
+      expect(stats.skipped).toBe(1);
+      expect(stats.noops).toBe(0);
       expect(stats.refunds).toBe(0);
       expect(await getBalance()).toBeCloseTo(8.2, 6);
-      expect(await getReservationSettledAt(reservationId)).toBeTruthy();
+      expect(await getReservationSettledAt(reservationId)).toBeNull();
       expect(await settlementRowsForReservation(reservationId)).toEqual([]);
     },
     PGLITE_TIMEOUT,

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -746,6 +746,23 @@ export class AppCreditsService {
     // NEVER fall back to a client-supplied value.
     const chargeKey = reservationTransactionId || null;
 
+    // #11683: the creator-earnings legs below must dedupe across ALL writers
+    // that can settle the SAME reservation — the route's late settle and the
+    // stale-reservation sweep run in different request contexts, so the ALS
+    // request key (and any client-echoed metadata.idempotencyKey) differs
+    // between them and the reversal/top-up would double-apply even though the
+    // org-credit leg deduped on `reconcile-refund:<id>`/`reconcile-charge:<id>`.
+    // Key the earnings legs on the same server-generated reservation deduct
+    // transaction id (threaded as metadata.idempotencyKey, which
+    // recordCreatorEarnings/reverseCreatorEarnings prefer over the ALS key);
+    // the movement leg still disambiguates reconcile_refund vs
+    // reconcile_charge. Unkeyed callers keep the prior request-scoped dedup.
+    const earningsLegMetadata = (extra: Record<string, unknown>): Record<string, unknown> => ({
+      ...extra,
+      ...settlementMetadata,
+      ...(chargeKey && { idempotencyKey: `reconcile:${chargeKey}` }),
+    });
+
     const baseCostDifference = actualBaseCost - estimatedBaseCost;
 
     // Resolve the user's organization once — every branch below charges or
@@ -855,14 +872,13 @@ export class AppCreditsService {
             userId,
             creatorEarningsReduction,
             "reconcile_refund",
-            {
+            earningsLegMetadata({
               type: "reconciliation_refund",
               baseCostDifference,
               estimatedBaseCost,
               actualBaseCost,
               description,
-              ...settlementMetadata,
-            },
+            }),
           );
         } catch (reversalError) {
           logger.error(
@@ -1000,12 +1016,11 @@ export class AppCreditsService {
           "inference_markup",
           creatorMarkupDifference,
           "reconcile_charge",
-          {
+          earningsLegMetadata({
             type: "reconciliation_adjustment",
             baseCostDifference,
             description,
-            ...settlementMetadata,
-          },
+          }),
           app,
         );
 

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -17,7 +17,9 @@ import { CacheInvalidation } from "../cache/invalidation";
 import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { canSendLowCreditsEmail, markLowCreditsEmailSent } from "../email/utils/rate-limiter";
 import { calculateCost, getProviderFromModel } from "../pricing";
+import { PROVIDER_DEFAULT_MAX_RETRIES, PROVIDER_MAX_BACKOFF_DELAY_MS } from "../providers/_http";
 import { logger } from "../utils/logger";
+import { getRouteTimeoutMs } from "../utils/request-timeout";
 import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { emailService } from "./email";
 import { organizationsService } from "./organizations";
@@ -42,6 +44,29 @@ export const RESERVATION_SETTLEMENT_MARKER = "credit_reservation_v1";
 export const APP_CHAT_RESERVATION_SETTLEMENT_MARKER = "app_chat_reservation_v1";
 /** Default estimated output tokens when not specified */
 export const DEFAULT_OUTPUT_TOKENS = 500;
+
+/**
+ * Grace window for the stale-reservation sweep, derived from the WORST-CASE
+ * legitimately-in-flight metered request (#11683). The provider HTTP layer
+ * retries each call up to PROVIDER_DEFAULT_MAX_RETRIES times (tries = retries
+ * + 1), each try holding a fresh per-attempt timeout of up to
+ * getRouteTimeoutMs(800) — 800s being the largest metered route budget
+ * (`v1/apps/[id]/chat` ROUTE_MAX_DURATION) — with capped backoff between
+ * tries, and `withProviderFallback` can run that whole ladder once per
+ * provider (primary + fallback). The prior fixed 20-minute grace sat INSIDE
+ * that window, so the sweep refunded holds whose settle was still coming and
+ * the settle lane then refunded again under its own idempotency key. A truly
+ * stranded hold now waits ~2h for its backstop refund — the safe trade
+ * (correctness > refund latency).
+ */
+const SWEEP_MAX_ROUTE_DURATION_SECONDS = 800;
+const SWEEP_PROVIDERS_PER_REQUEST = 2;
+const SWEEP_SETTLE_MARGIN_MS = 20 * 60 * 1000;
+export const RESERVATION_SWEEP_GRACE_MS =
+  SWEEP_PROVIDERS_PER_REQUEST *
+    ((PROVIDER_DEFAULT_MAX_RETRIES + 1) * getRouteTimeoutMs(SWEEP_MAX_ROUTE_DURATION_SECONDS) +
+      PROVIDER_DEFAULT_MAX_RETRIES * PROVIDER_MAX_BACKOFF_DELAY_MS) +
+  SWEEP_SETTLE_MARGIN_MS;
 
 // ============================================================================
 // Types
@@ -202,38 +227,18 @@ function metadataNumber(value: unknown): number | null {
 }
 
 /**
- * Org-charge a stale hold settles to during the stranded-reservation sweep
- * (#11592).
- *
- * Generic reservation rows (`credit_reservation_v1`) store `estimated_cost`
- * in ORG-CHARGE units — the same unit as the row amount — so the sweep
- * settles to it directly (missing estimate ⇒ exact-cost, no refund).
- *
- * App-chat holds (`app_chat_reservation_v1`) store BASE-cost numbers
- * (`estimated_cost` = unbuffered base, `reserved_amount` = buffered base —
- * see apps/[id]/chat/route.ts), while the row amount is the ORG charge:
- * buffered base PLUS the creator markup (`computeInferenceCharge` via
- * `appCreditsService.deductCredits`). Settling the org to the bare base
- * estimate would hand the markup back to the org while the creator's
- * earnings — recorded at deduct time — stay put, so the platform would eat
- * the full creator markup on every swept monetized hold. Instead scale the
- * org charge by estimated/reserved: the org nets exactly what a normal
- * settle at the estimated cost would charge (base × (1 + markup)). Holds
- * without a usable base pair settle exact-cost, and the result is clamped
- * to the held amount so corrupt metadata can never turn the sweep into a
- * surprise overage charge.
+ * Org-charge a generic stale hold settles to during the stranded-reservation
+ * sweep. Generic reservation rows (`credit_reservation_v1`) store
+ * `estimated_cost` in ORG-CHARGE units — the same unit as the row amount — so
+ * the sweep settles to it directly (missing estimate means exact-cost, no
+ * refund). App-chat rows are routed through `sweepAppChatReservation` before
+ * this helper because their estimates are in base-cost units and must use the
+ * app-credits settle lane for markup and creator-earnings reconciliation.
  */
 function staleHoldSettleCost(reservedAmount: number, metadata: Record<string, unknown>): number {
   const estimate =
     metadataNumber(metadata.estimated_cost) ?? metadataNumber(metadata.estimatedCost);
-  if (metadata.type !== "app_chat_reservation") {
-    return estimate ?? reservedAmount;
-  }
-  const reservedBase = metadataNumber(metadata.reserved_amount);
-  if (estimate === null || reservedBase === null || reservedBase <= 0) {
-    return reservedAmount;
-  }
-  return Math.min(reservedAmount, Math.max(0, reservedAmount * (estimate / reservedBase)));
+  return estimate ?? reservedAmount;
 }
 
 function toCreditTransaction(row: CreditMutationRow): CreditTransaction {
@@ -1699,7 +1704,7 @@ export class CreditsService {
     batchSize?: number;
     maxBatches?: number;
   }): Promise<ReservationSweepStats> {
-    const graceMs = opts?.graceMs ?? 20 * 60 * 1000;
+    const graceMs = opts?.graceMs ?? RESERVATION_SWEEP_GRACE_MS;
     const batchSize = opts?.batchSize ?? 200;
     const maxBatches = opts?.maxBatches ?? 50;
     const stats: ReservationSweepStats = {
@@ -1750,12 +1755,33 @@ export class CreditsService {
       for (const row of rows) {
         const reservedAmount = Math.abs(parseNumeric(row.amount, "reservation_amount"));
         const reservationMetadata = parseMetadata(row.metadata);
-        const actualCost = staleHoldSettleCost(reservedAmount, reservationMetadata);
         const description = (row.description ?? "Credit reservation").replace(
           /\s+\(reserved\)$/,
           "",
         );
         try {
+          // App-chat holds must settle through the app-credits lane — the SAME
+          // lane the route's late settle uses — never the generic reconcile
+          // below (#11683): the generic lane keys its refund on
+          // `recon:<holdId>:refund` while the route settles under
+          // `reconcile-refund:<holdId>` (#11512), so the two writers never
+          // cross-deduped and a swept-but-still-in-flight hold was refunded
+          // TWICE (minted, cashable credit). The hold amount is also the
+          // markup-INCLUSIVE totalCost with the creator's earnings committed
+          // at deduct time — settling it against the base-only estimated_cost
+          // over-refunded the markup and left unbacked redeemable earnings.
+          if (
+            reservationMetadata.type === "app_chat_reservation" &&
+            reservationMetadata.settlement_marker === APP_CHAT_RESERVATION_SETTLEMENT_MARKER
+          ) {
+            await this.sweepAppChatReservation(
+              { id: row.id, description },
+              reservationMetadata,
+              stats,
+            );
+            continue;
+          }
+          const actualCost = staleHoldSettleCost(reservedAmount, reservationMetadata);
           const settlement = await this.reconcileReservationTransaction({
             organizationId: row.organization_id,
             reservationTransactionId: row.id,
@@ -1810,6 +1836,93 @@ export class CreditsService {
       logger.warn("[Credits] Swept stale credit reservations", stats);
     }
     return stats;
+  }
+
+  /**
+   * Settle one stale APP-CHAT hold (`app_chat_reservation_v1`) through
+   * `appCreditsService.reconcileCredits` (#11683). Assumes actual == the
+   * base-cost estimate the route recorded (same semantic as the generic lane),
+   * but reconciles in base-cost space so the markup math and the creator
+   * earnings reversal are correct, and keys the refund on
+   * `reconcile-refund:<holdId>` — the same key the route's late settle uses —
+   * so whichever writer runs second is a no-op.
+   */
+  private async sweepAppChatReservation(
+    row: { id: string; description: string },
+    reservationMetadata: Record<string, unknown>,
+    stats: ReservationSweepStats,
+  ): Promise<void> {
+    const appId = typeof reservationMetadata.appId === "string" ? reservationMetadata.appId : null;
+    const userId =
+      typeof reservationMetadata.userId === "string" ? reservationMetadata.userId : null;
+    // What was actually debited, in BASE-cost space (the route's buffered base
+    // estimate). `reserved_amount`/`baseCost` are both written by the app-chat
+    // deduct; the hold row's `amount` is markup-inclusive and must NOT be used
+    // as a base cost.
+    const reservedBaseCost =
+      metadataNumber(reservationMetadata.reserved_amount) ??
+      metadataNumber(reservationMetadata.baseCost);
+    if (!appId || !userId || reservedBaseCost === null) {
+      stats.skipped++;
+      logger.error("[Credits] Stale app-chat reservation is missing reconcile inputs — skipping", {
+        reservationTransactionId: row.id,
+        hasAppId: appId !== null,
+        hasUserId: userId !== null,
+        hasReservedBaseCost: reservedBaseCost !== null,
+      });
+      return;
+    }
+    const assumedActualBaseCost =
+      metadataNumber(reservationMetadata.estimated_cost) ??
+      metadataNumber(reservationMetadata.estimatedCost) ??
+      reservedBaseCost;
+
+    // Lazy import: app-credits statically imports this module, so a static
+    // import here would create a module cycle.
+    const { appCreditsService } = await import("./app-credits");
+    const result = await appCreditsService.reconcileCredits({
+      appId,
+      userId,
+      estimatedBaseCost: reservedBaseCost,
+      actualBaseCost: assumedActualBaseCost,
+      description: row.description,
+      metadata: { settlement_source: "stale_reservation_sweep" },
+      reservationTransactionId: row.id,
+    });
+
+    if (result.action === "refund" && result.reconciled) {
+      stats.settled++;
+      stats.refunds++;
+      return;
+    }
+    if (result.action === "charge") {
+      stats.settled++;
+      if (result.reconciled) {
+        stats.overages++;
+      } else {
+        stats.uncollectedOverages++;
+      }
+      return;
+    }
+    // action === "none": either a below-threshold settle (row marked settled —
+    // a noop) or reconcileCredits could not resolve the user/app and left the
+    // hold open (skipped; retried next sweep and already error-logged).
+    const settledRows = await sqlRows<{ id: string }>(
+      dbWrite,
+      sql`
+        SELECT id
+        FROM credit_transactions
+        WHERE id = ${row.id}
+          AND settled_at IS NOT NULL
+        LIMIT 1
+      `,
+    );
+    if (settledRows.length > 0) {
+      stats.settled++;
+      stats.noops++;
+    } else {
+      stats.skipped++;
+    }
   }
 
   // ============================================================================


### PR DESCRIPTION
Closes #11683. Hardens lalalune's #11493 (stranded-reservation sweep) — the sweep itself is the right backstop; this fixes two money defects in how it settles the app-chat lane. Verified live on develop tip (`261b5b4887`) before writing a line. #11169/#11592 were closed by #11493, so #11683 is the tracking issue.

## Defect 1 — sweep double-refund of in-flight app-chat holds (cashable mint)

Two writers can settle the same app-chat hold, under **disjoint idempotency keys**:

| writer | refund key |
|---|---|
| sweep → generic lane (`reconcileReservationTransaction`) | `recon:<holdId>:refund` (`credits.ts:1273`) |
| route late settle (`appCreditsService.reconcileCredits`) | `reconcile-refund:<holdId>` (#11512, `app-credits.ts:837`) |

No cross-dedup — and the sweep fires while the request is still legitimately in flight: it runs **every minute** (`* * * * *` fanout) with a **20-min grace**, but the provider retry ladder legitimately holds an app-chat request open for up to ≈ `2 providers × (4 tries × 790s + backoff)` ≈ **106 min** (`_http.ts DEFAULT_MAX_RETRIES=3`, `AbortSignal.timeout(getRouteTimeoutMs(800))` per try, `withProviderFallback`). Sequence: sweep refunds at T+20min under `recon:`, provider completes at T+40min, route settles and refunds AGAIN under `reconcile-refund:` ⇒ org credited ≈ 2×reserved − actual — minted, cashable credit.

The #11493 regression test missed it because its "late settle" used the generic `creditsService.reconcile` (which shares the `recon:` key) instead of the real app-chat settle lane.

## Defect 2 — markup over-refund + unbacked creator earnings

The app-chat hold amount is the markup-**inclusive** `totalCost`, with creator earnings committed at deduct time (`app-credits.ts:541-608`); the sweep settled it against the base-only `estimated_cost` (`credits.ts:1716-1721`) ⇒ refunds the buffer **plus the whole markup** to the consumer, and never reverses the creator's earnings ⇒ unbacked redeemable earnings. The #11493 fixture only models markup = 0.

## Fix

1. **Grace derived from the retry ladder** (can't drift): `RESERVATION_SWEEP_GRACE_MS = 2 providers × (4 tries × getRouteTimeoutMs(800) + backoff) + 20min margin ≈ 2.1h`, sourced from the now-exported `PROVIDER_DEFAULT_MAX_RETRIES` / `PROVIDER_MAX_BACKOFF_DELAY_MS`. A truly stranded hold waits ~2h for its backstop refund — correctness > refund latency.
2. **App-chat rows sweep through the settle lane**: `sweepStaleReservations` routes `app_chat_reservation_v1` marker rows through `appCreditsService.reconcileCredits` (assume actual == the recorded base estimate, same semantic as the generic lane) so both writers share the `reconcile-refund:<holdId>` key **and** the settle uses the correct markup math + creator-earnings reversal. Generic rows stay on the existing generic lane, untouched.
3. **Earnings legs cross-dedupe too**: the reconcile-leg creator-earnings movements now key on the server-generated reservation txid (`reconcile:<holdId>:inference_markup:<leg>`) instead of the per-request ALS key — the sweep and the late settle run in different request contexts, so without this the org-credit leg deduped (#11512) but the earnings reversal double-applied. Unkeyed callers (direct app-chat/generate-image reconciles) keep prior behavior. Same server-generated-key principle as #11512 — never a client value.

## Test evidence (real PGlite, no mocks on the money path)

New `app-chat-sweep-double-refund.test.ts` — real `deductCredits` route-shaped holds (`app_chat_reservation_v1` metadata exactly as `v1/apps/[id]/chat/route.ts` writes it), real `sweepStaleReservations()`, real settle-lane `reconcileCredits`:

- **grace**: default grace ≥ 2h; a hold in-flight past the OLD 20-min grace is NOT swept, and the late settle then refunds exactly once (**fails on develop**: the hold gets swept + double-refunded);
- **markup>0 stranded hold**: sweep refunds the correct markup-inclusive delta (0.02, not the 0.04 base-only over-refund), reverses creator earnings (0.03 → 0.02), keys the refund `reconcile-refund:<holdId>`; the late settle is a full dedup no-op — org balance, creator balance, apps counter, and refund-row count all unchanged (**fails on develop**: sweep refunds 0.04 under `recon:`, late settle refunds 0.04 more ⇒ org 100.02 > 100 mint);
- **settled-first** hold is fenced from the sweep;
- updated `credits-reconcile.test.ts`: the generic lane never settles app-chat rows.

Runs (this branch):
- `bun test src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts` → **5 pass / 0 fail**
- negative control (develop's `credits.ts`/`app-credits.ts`/`_http.ts` restored, new tests kept) → **3 fail / 2 pass**, failing exactly on the defect assertions
- `credits-reconcile.test.ts` → 28 pass; `app-credits-reconcile-double-refund` + `app-credits-idempotency` → 14 pass; `app-credits-ledger` → 26 pass (one expectation updated for the reconcile-leg key change, intent preserved); `_http.test.ts` → 8 pass; app-chat route suites (`apps-chat-nonstreaming-settle-guard`, `apps-chat-stream-refund`, `apps-chat-streaming-nobody-guard`) → 17 pass
- `biome check` clean on all touched files; `tsgo --noEmit` clean for touched files (remaining diagnostics are the documented transitive `plugin-elizacloud` noise)

## ⚠️ Money-path — maintainer review requested

This touches the credit-reservation settle path and @lalalune's just-merged #11493. Not self-merging; please review the lane-routing decision (sweep → `appCreditsService.reconcileCredits` for marker rows) and the derived grace. Evidence note: backend/DB artifacts are the PGlite ledgers asserted in the tests above; UI/video/trajectory rows are N/A — cron + billing internals, no user-facing surface or model behavior change.

— [cloud-security]
