### PR TITLE
fix(core): keep pinned fetch transport failures closed

### DIFF
--- a/packages/core/src/network/fetch-guard.fail-closed.test.ts
+++ b/packages/core/src/network/fetch-guard.fail-closed.test.ts
@@ -17,6 +17,9 @@ describe("fetchWithSsrfGuard when the pinned transport cannot load (Node runtime
 
 	it("keeps failing closed on subsequent guarded fetches (no poisoned success)", async () => {
 		await expect(
+			fetchWithSsrfGuard({ url: "https://example.org/first" }),
+		).rejects.toThrow(/Refusing to fall back to unpinned fetch/i);
+		await expect(
 			fetchWithSsrfGuard({ url: "https://example.org/other" }),
 		).rejects.toThrow(/Refusing to fall back to unpinned fetch/i);
 	});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -114,9 +114,9 @@ async function loadNodePinnedFetchDefaults(): Promise<NodePinnedFetchDefaults | 
 	try {
 		return await nodePinnedFetchDefaults;
 	} catch (error) {
-		// Do not memoize the failure as a permanent null — allow a retry on the
-		// next guarded fetch in case the failure was transient.
-		nodePinnedFetchDefaults = undefined;
+		// Keep the rejected import memoized. In a Node-like runtime the pinned
+		// transport is the DNS-rebinding defense; once it is known unavailable,
+		// guarded fetches must keep failing closed for this process.
 		logger.error(
 			{ error },
 			"[FetchGuard] Failed to load the pinned DNS transport on a Node-like runtime; failing closed",


### PR DESCRIPTION
## What

Follow-up to #11693 after local Windows review found the existing pinned-transport fail-closed test could pass the first mocked import failure, then resolve a later guarded fetch when Bun reloaded the real `node-pinned-fetch` module.

This keeps the rejected pinned transport import memoized for the process. In a Node-like runtime, the pinned transport is the DNS-rebinding defense; once it is known unavailable, guarded fetches should keep failing closed instead of retrying into live network behavior during the same process.

The test now proves the repeated failure inside the same test so it exercises the sticky path directly.

## Validation

- `git diff --check origin/develop...HEAD` => clean
- `bun test packages/core/src/network/fetch-guard.fail-closed.test.ts packages/core/src/security/redact.test.ts packages/core/src/security/spawn-env-policy.test.ts packages/core/src/network/fetch-guard.test.ts packages/core/src/network/ssrf.test.ts packages/core/src/security/secret-swap.test.ts` => 62 pass / 0 fail
- `bunx @biomejs/biome@2.5.2 check packages/core/src/network/fetch-guard.ts packages/core/src/network/fetch-guard.fail-closed.test.ts --files-ignore-unknown=true` => clean
- `bun run --cwd packages/core typecheck` => clean

No UI/model/device surface; screenshots, recordings, and live trajectories are N/A for this pure SSRF guard fail-closed behavior.
