### PR TITLE
fix(local-inference): store container-relative model paths + self-heal legacy absolute registry entries (#11669)

### DIFF
--- a/.github/issue-evidence/11669-registry-relative-self-heal.md
+++ b/.github/issue-evidence/11669-registry-relative-self-heal.md
@@ -1,0 +1,117 @@
+# Issue #11669 — container-relative registry paths + self-heal of legacy absolute rows
+
+## Root cause
+
+`local-inference/registry.json` persisted absolute paths into the iOS app data
+container. iOS rotates the data-container UUID on reinstall/update, so the
+persisted prefix dies while the model bytes migrate fine. #11371 made the
+canonical registry writer store container-relative rows and re-anchor legacy
+absolute rows at hydrate time, but three gaps remained:
+
+1. `plugin-local-inference` hydration never verified the re-anchored artifact
+   actually exists, and never rewrote the healed rows back to disk — the
+   legacy absolute strings lived in `registry.json` forever.
+2. `plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts` (the
+   on-device full-Bun loader path) resolved stored rows **verbatim** with
+   `existsSync`, so BOTH the new relative rows and legacy dead-container
+   absolute rows failed, and the bootstrap fell through to re-downloading a
+   model that was already fully present on disk.
+3. `plugin-aosp-local-inference` (Android) `mapExistingModelPath` handled
+   legacy absolute rows but not the new container-relative rows.
+
+## What changed
+
+- `plugin-local-inference/src/services/registry.ts`:
+  `listInstalledModels()` verifies the model artifact exists at the hydrated
+  path, drops rows whose file is genuinely absent (structured
+  `[LocalInferenceRegistry]` warn; readiness/UI then surface the real
+  not-downloaded state), and self-heals `registry.json` once — legacy rows are
+  rewritten in canonical relative form via the existing atomic tmp+rename
+  writer. Hydration no longer leaks a raw stored `bundleRoot`/`manifestPath`
+  string when resolution fails.
+- `plugin-capacitor-bridge/src/shared/local-inference-stored-path.ts` (new):
+  shared stored-path resolver — relative rows join the CURRENT root; legacy
+  absolute rows re-anchor by their `/local-inference/` suffix (plus the
+  simulator `/private/var` ↔ `/var` alias); every candidate is
+  exists-verified; traversal rows are rejected. The exists probe is injectable
+  so the iOS stdio bridge keeps probing through the mobile fs sandbox proxy.
+- `plugin-capacitor-bridge/src/ios/bridge.ts`: deduped its local copy of the
+  same logic into the shared resolver (behavior preserved).
+- `plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts`:
+  `resolveFromRegistry` / `resolveAssignedRegistryModel` resolve rows through
+  the shared resolver instead of verbatim `existsSync`.
+- `plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts`:
+  `mapExistingModelPath` maps container-relative rows against the parent of
+  `modelsDir` (the local-inference dir), keeping Android on the same format.
+
+## Regression evidence (container migration simulated by moving the root)
+
+- `plugins/plugin-local-inference/src/services/registry.test.ts` (8 tests)
+  - moved-root reanchor now ALSO asserts the on-disk rows are rewritten in
+    canonical relative form (self-heal persists once);
+  - legacy absolute row with no artifact under the current root → dropped
+    from the listing AND from `registry.json` (real not-downloaded state);
+  - relative row whose artifact was deleted → same;
+  - mixed registry: healthy row kept + healed relative, dead row dropped.
+- `plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts`
+  (10 tests): relative resolve, dead-container re-anchor using the exact path
+  shape from the issue, `/private/var` alias, traversal rejection, round-trip,
+  genuinely-absent → null.
+- `plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts`
+  (3 tests): `mobileDeviceBridge.status().modelPath` resolves a relative row,
+  re-anchors a dead-container absolute row, and reports null when the artifact
+  is genuinely absent.
+- `plugins/plugin-aosp-local-inference/__tests__/aosp-local-inference-bootstrap.test.ts`
+  (+2 tests): `readAssignedBundledModels` resolves container-relative rows and
+  returns null when the artifact is absent.
+
+## Anti-larp negative check
+
+Temporarily reverted the three source files to `origin/develop` and re-ran the
+new tests:
+
+- bootstrap registry-paths: **2/3 failed** (relative row + dead-container
+  re-anchor) — exactly the two bugs;
+- registry self-heal: **4/8 failed** (the four new heal/drop tests);
+- AOSP relative-row test: **failed**.
+
+Restored the fix; all green again.
+
+## Commands run
+
+```bash
+bunx vitest run --root plugins/plugin-local-inference
+# 224 passed / 1 failed (pre-existing env failure, also fails on pristine
+# origin/develop checkout: imagegen-backend-selector "Linux NVIDIA without
+# sd-cpp CUDA proof" — host has a cached CUDA proof; unrelated to this change)
+# 2272 tests passed, 13 skipped
+
+bunx vitest run --root plugins/plugin-capacitor-bridge
+# 7/8 files passed; the 2 failures in
+# mobile-device-bridge-bootstrap.serving-status.test.ts are pre-existing on
+# macOS (abstract \0 sockets are Linux-only; fails identically on pristine
+# origin/develop)
+
+bun run --cwd plugins/plugin-aosp-local-inference test   # 75 pass / 0 fail
+
+bun run --cwd plugins/plugin-local-inference typecheck   # pass
+bun run --cwd plugins/plugin-capacitor-bridge typecheck  # pass
+bun run --cwd plugins/plugin-aosp-local-inference typecheck  # pass
+
+bun run --cwd plugins/plugin-local-inference build       # pass
+bun run --cwd plugins/plugin-capacitor-bridge build      # pass
+bun run --cwd plugins/plugin-aosp-local-inference build  # pass
+
+bunx @biomejs/biome check <all touched files>            # clean
+```
+
+## Device verification status
+
+The container-migration failure mode is exercised directly by the moved-root
+regression tests above (write registry under root A, resolve under root B —
+the same state transition an iOS container-UUID rotation produces). A live
+iOS reinstall capture (install → download 6.5 GB bundle → `simctl install` a
+new build → verify the model loads from the migrated container) requires the
+full device bundle and was not run on this branch; that leg follows the
+`capture:ios-sim` lane from PR_EVIDENCE.md. No UI, prompt, or model behavior
+changed; server-side path resolution only.

--- a/plugins/plugin-aosp-local-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-aosp-local-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -448,6 +448,65 @@ describe("readAssignedBundledModels", () => {
 
     expect(readAssignedBundledModels(modelsDir).chat).toBe(defaultModel);
   });
+
+  it("resolves container-relative registry rows against the current device root (#11669)", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "aosp-assigned-relative-"));
+    const modelsDir = path.join(root, "local-inference", "models");
+    const defaultBundle = path.join(modelsDir, "eliza-1-2b.bundle", "text");
+    mkdirSync(defaultBundle, { recursive: true });
+    const defaultModel = path.join(defaultBundle, "eliza-1-2b-32k.gguf");
+    writeFileSync(defaultModel, "default");
+    writeFileSync(
+      path.join(root, "local-inference", "assignments.json"),
+      JSON.stringify({
+        version: 1,
+        assignments: { TEXT_SMALL: "eliza-1-2b" },
+      }),
+    );
+    writeFileSync(
+      path.join(root, "local-inference", "registry.json"),
+      JSON.stringify({
+        version: 1,
+        models: [
+          {
+            id: "eliza-1-2b",
+            path: "models/eliza-1-2b.bundle/text/eliza-1-2b-32k.gguf",
+            source: "eliza-download",
+          },
+        ],
+      }),
+    );
+
+    expect(readAssignedBundledModels(modelsDir).chat).toBe(defaultModel);
+  });
+
+  it("returns no chat model when the registry row's artifact is genuinely absent", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "aosp-assigned-missing-"));
+    const modelsDir = path.join(root, "local-inference", "models");
+    mkdirSync(modelsDir, { recursive: true });
+    writeFileSync(
+      path.join(root, "local-inference", "assignments.json"),
+      JSON.stringify({
+        version: 1,
+        assignments: { TEXT_SMALL: "eliza-1-2b" },
+      }),
+    );
+    writeFileSync(
+      path.join(root, "local-inference", "registry.json"),
+      JSON.stringify({
+        version: 1,
+        models: [
+          {
+            id: "eliza-1-2b",
+            path: "models/eliza-1-2b.bundle/text/eliza-1-2b-32k.gguf",
+            source: "eliza-download",
+          },
+        ],
+      }),
+    );
+
+    expect(readAssignedBundledModels(modelsDir).chat).toBeNull();
+  });
 });
 
 describe("removeAospGeneratedStagingDir", () => {

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -925,6 +925,18 @@ function mapExistingModelPath(raw: unknown, modelsDir: string): string | null {
   if (typeof raw !== "string" || raw.trim().length === 0) return null;
   const candidate = raw.trim();
   const normalized = candidate.replaceAll("\\", "/");
+  // Container-relative rows (the canonical registry format since #11669) are
+  // stored relative to the local-inference dir — the parent of modelsDir.
+  if (!path.isAbsolute(candidate) && !/^[A-Za-z]:[\\/]/.test(candidate)) {
+    const parts = normalized.split("/").filter(Boolean);
+    if (parts.length === 0 || parts.some((p) => p === "." || p === "..")) {
+      return null;
+    }
+    const mapped = path.join(path.dirname(modelsDir), ...parts);
+    return existsSync(mapped) ? mapped : null;
+  }
+  // Legacy absolute rows from a previous container/state root: re-anchor by
+  // the `/local-inference/models/` suffix.
   const marker = "/local-inference/models/";
   const markerIndex = normalized.lastIndexOf(marker);
   if (markerIndex >= 0) {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -25,6 +25,10 @@ import {
 	writeFileSync,
 } from "../shared/fs-proxy.ts";
 import { installMobileFsShim } from "../shared/fs-shim.ts";
+import {
+	resolveStoredModelPath,
+	toStoredModelPath,
+} from "../shared/local-inference-stored-path.ts";
 import { runModelGrind } from "./model-grind.ts";
 
 interface BridgeRequest {
@@ -1356,35 +1360,8 @@ function installedModelForCatalogEntry(
 	};
 }
 
-function isSubpath(target: string, root: string): boolean {
-	const relative = path.relative(root, target);
-	return (
-		relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
-	);
-}
-
-function normalizeStoredRelativeModelPath(input: string): string | null {
-	const normalized = input.trim().replaceAll("\\", "/");
-	if (
-		!normalized ||
-		normalized.includes("\0") ||
-		path.isAbsolute(normalized) ||
-		/^[A-Za-z]:[\\/]/.test(normalized) ||
-		normalized.startsWith("\\\\")
-	) {
-		return null;
-	}
-	const parts = normalized.split("/").filter(Boolean);
-	if (parts.length === 0) return null;
-	if (parts.some((part) => part === "." || part === "..")) return null;
-	return parts.join("/");
-}
-
 function toStoredInstalledModelPath(modelPath: string): string | null {
-	const root = path.resolve(localInferenceRootPath());
-	const resolved = path.resolve(modelPath);
-	if (!isSubpath(resolved, root)) return null;
-	return path.relative(root, resolved).split(path.sep).join("/");
+	return toStoredModelPath(modelPath, localInferenceRootPath());
 }
 
 function serializeInstalledModelEntry(
@@ -1500,32 +1477,10 @@ function scanGgufFiles(root: string): InstalledModelEntry[] {
 }
 
 function normalizeInstalledModelPath(rawPath: string): string | null {
-	const trimmed = rawPath.trim();
-	if (!trimmed || trimmed.includes("\0")) return null;
-	const currentRoot = localInferenceRootPath();
-	const candidates = new Set<string>();
-	const relativePath = normalizeStoredRelativeModelPath(trimmed);
-	if (relativePath) {
-		candidates.add(path.join(currentRoot, ...relativePath.split("/")));
-	}
-	candidates.add(trimmed);
-	candidates.add(trimmed.replace(/^\/private\/var\//, "/var/"));
-	const marker = "/local-inference/";
-	const markerIndex = trimmed.indexOf(marker);
-	if (markerIndex >= 0) {
-		const legacyRelativePath = normalizeStoredRelativeModelPath(
-			trimmed.slice(markerIndex + marker.length),
-		);
-		if (legacyRelativePath) {
-			candidates.add(path.join(currentRoot, ...legacyRelativePath.split("/")));
-		}
-	}
-	for (const candidate of candidates) {
-		try {
-			if (existsSync(candidate)) return candidate;
-		} catch {}
-	}
-	return null;
+	// Probe through the sandboxed fs proxy, not raw node:fs.
+	return resolveStoredModelPath(rawPath, localInferenceRootPath(), (p) =>
+		existsSync(p),
+	);
 }
 
 function readInstalledModels(): InstalledModelEntry[] {

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts
@@ -1,0 +1,117 @@
+// Regression for #11669: the bootstrap's registry-backed model resolution
+// must survive an app-container migration. Rows are stored relative to the
+// local-inference root; legacy rows hold absolute paths from a container
+// UUID that no longer exists after an iOS reinstall/update. Before this fix
+// `resolveFromRegistry` did a verbatim existsSync on the stored string, so
+// both formats failed and the loader fell through to re-downloading a model
+// that was already fully present on disk.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const savedStateDir = process.env.ELIZA_STATE_DIR;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	if (savedStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+	else process.env.ELIZA_STATE_DIR = savedStateDir;
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function useTempStateDir(): string {
+	const stateDir = mkdtempSync(
+		path.join(os.tmpdir(), "capacitor-bridge-registry-"),
+	);
+	tempDirs.push(stateDir);
+	process.env.ELIZA_STATE_DIR = stateDir;
+	return stateDir;
+}
+
+function writeLocalInferenceState(
+	stateDir: string,
+	storedModelPath: string,
+): void {
+	const root = path.join(stateDir, "local-inference");
+	mkdirSync(root, { recursive: true });
+	writeFileSync(
+		path.join(root, "assignments.json"),
+		JSON.stringify({
+			version: 1,
+			assignments: { TEXT_LARGE: "eliza-1-2b" },
+		}),
+	);
+	writeFileSync(
+		path.join(root, "registry.json"),
+		JSON.stringify({
+			version: 1,
+			models: [
+				{
+					id: "eliza-1-2b",
+					path: storedModelPath,
+					source: "eliza-download",
+				},
+			],
+		}),
+	);
+}
+
+function createModelArtifact(stateDir: string): string {
+	const modelPath = path.join(
+		stateDir,
+		"local-inference",
+		"models",
+		"eliza-1-2b.bundle",
+		"text",
+		"eliza-1-2b-128k.gguf",
+	);
+	mkdirSync(path.dirname(modelPath), { recursive: true });
+	writeFileSync(modelPath, "fake-gguf");
+	return modelPath;
+}
+
+describe("mobile device bridge registry model resolution (#11669)", () => {
+	it("resolves a container-relative registry row against the current state dir", async () => {
+		const stateDir = useTempStateDir();
+		const modelPath = createModelArtifact(stateDir);
+		writeLocalInferenceState(
+			stateDir,
+			"models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf",
+		);
+
+		const { mobileDeviceBridge } = await import(
+			"./mobile-device-bridge-bootstrap"
+		);
+		expect(mobileDeviceBridge.status().modelPath).toBe(modelPath);
+	});
+
+	it("re-anchors a legacy dead-container absolute row onto the current state dir", async () => {
+		const stateDir = useTempStateDir();
+		const modelPath = createModelArtifact(stateDir);
+		writeLocalInferenceState(
+			stateDir,
+			"/var/mobile/Containers/Data/Application/5ED497DF-9A29-487F-A422-333997764963/Library/Application Support/Eliza/local-inference/models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf",
+		);
+
+		const { mobileDeviceBridge } = await import(
+			"./mobile-device-bridge-bootstrap"
+		);
+		expect(mobileDeviceBridge.status().modelPath).toBe(modelPath);
+	});
+
+	it("reports no model when the artifact is genuinely absent", async () => {
+		const stateDir = useTempStateDir();
+		// Registry row exists but no artifact anywhere under the current root.
+		writeLocalInferenceState(
+			stateDir,
+			"models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf",
+		);
+
+		const { mobileDeviceBridge } = await import(
+			"./mobile-device-bridge-bootstrap"
+		);
+		expect(mobileDeviceBridge.status().modelPath).toBeNull();
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -37,6 +37,7 @@ import {
 	resolveStateDir,
 	type TextEmbeddingParams,
 } from "@elizaos/core";
+import { resolveStoredModelPath } from "./shared/local-inference-stored-path.ts";
 
 const DEVICE_BRIDGE_PATH = "/api/local-inference/device-bridge";
 const PROVIDER = "capacitor-llama";
@@ -745,8 +746,12 @@ function readTimeoutMs(envKey: string, fallback: number): number {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function localInferenceRoot(): string {
+	return path.join(resolveStateDir(), "local-inference");
+}
+
 function modelsDir(): string {
-	return path.join(resolveStateDir(), "local-inference", "models");
+	return path.join(localInferenceRoot(), "models");
 }
 
 function registryPath(): string {
@@ -802,9 +807,10 @@ function resolveFromRegistry(slot: string): string | null {
 
 	const models = readRegistryModels();
 	const matched = models.find((model) => model.id === assigned);
-	return typeof matched?.path === "string" && existsSync(matched.path)
-		? matched.path
-		: null;
+	if (typeof matched?.path !== "string") return null;
+	// Rows are stored relative to the local-inference root; legacy rows may
+	// hold absolute paths from a dead app container (#11669).
+	return resolveStoredModelPath(matched.path, localInferenceRoot());
 }
 
 function readRegistryModels(): RegistryModelEntry[] {
@@ -826,12 +832,15 @@ function resolveAssignedRegistryModel(slot: string): {
 
 	const models = readRegistryModels();
 	const matched = models.find((model) => model.id === assigned);
-	if (typeof matched?.path !== "string" || !existsSync(matched.path)) {
-		return null;
-	}
+	if (typeof matched?.path !== "string") return null;
+	const resolvedPath = resolveStoredModelPath(
+		matched.path,
+		localInferenceRoot(),
+	);
+	if (!resolvedPath) return null;
 	return {
 		id: assigned,
-		path: matched.path,
+		path: resolvedPath,
 		dimensions: matched.dimensions,
 		embeddingDimension: matched.embeddingDimension,
 		embeddingDimensions: matched.embeddingDimensions,

--- a/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts
@@ -1,0 +1,154 @@
+// Regression for #11669: registry.json rows must survive an iOS app-container
+// migration. Stored rows are container-relative; legacy absolute rows from a
+// dead container UUID are re-anchored by their `/local-inference/` suffix and
+// only accepted when the artifact really exists at the re-anchored location.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	normalizeStoredRelativeModelPath,
+	resolveStoredModelPath,
+	storedModelPathCandidates,
+	toStoredModelPath,
+} from "./local-inference-stored-path.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function makeRoot(prefix: string): string {
+	const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return path.join(dir, "local-inference");
+}
+
+function writeModel(root: string, relative: string): string {
+	const absolute = path.join(root, ...relative.split("/"));
+	mkdirSync(path.dirname(absolute), { recursive: true });
+	writeFileSync(absolute, "fake-gguf");
+	return absolute;
+}
+
+describe("normalizeStoredRelativeModelPath", () => {
+	it("normalizes relative rows and rejects traversal, absolute, and empty input", () => {
+		expect(normalizeStoredRelativeModelPath("models/a/b.gguf")).toBe(
+			"models/a/b.gguf",
+		);
+		expect(normalizeStoredRelativeModelPath("models\\a\\b.gguf")).toBe(
+			"models/a/b.gguf",
+		);
+		expect(normalizeStoredRelativeModelPath("models//a//b.gguf")).toBe(
+			"models/a/b.gguf",
+		);
+		expect(normalizeStoredRelativeModelPath("../escape.gguf")).toBeNull();
+		expect(normalizeStoredRelativeModelPath("models/../x.gguf")).toBeNull();
+		expect(normalizeStoredRelativeModelPath("/abs/x.gguf")).toBeNull();
+		expect(normalizeStoredRelativeModelPath("C:\\abs\\x.gguf")).toBeNull();
+		expect(normalizeStoredRelativeModelPath("")).toBeNull();
+	});
+});
+
+describe("toStoredModelPath", () => {
+	it("round-trips an absolute path under the root to relative and back", () => {
+		const root = makeRoot("stored-path-roundtrip-");
+		const absolute = writeModel(root, "models/eliza-1-2b.bundle/text/m.gguf");
+		const stored = toStoredModelPath(absolute, root);
+		expect(stored).toBe("models/eliza-1-2b.bundle/text/m.gguf");
+		expect(resolveStoredModelPath(stored ?? "", root)).toBe(absolute);
+	});
+
+	it("rejects paths outside the root and the root itself", () => {
+		const root = makeRoot("stored-path-outside-");
+		expect(toStoredModelPath("/somewhere/else/m.gguf", root)).toBeNull();
+		expect(toStoredModelPath(root, root)).toBeNull();
+	});
+});
+
+describe("resolveStoredModelPath", () => {
+	it("resolves a relative row against the current root", () => {
+		const root = makeRoot("stored-path-relative-");
+		const absolute = writeModel(root, "models/eliza-1-2b.bundle/text/m.gguf");
+		expect(
+			resolveStoredModelPath("models/eliza-1-2b.bundle/text/m.gguf", root),
+		).toBe(absolute);
+	});
+
+	it("re-anchors a legacy absolute row from a dead container onto the current root", () => {
+		const currentRoot = makeRoot("stored-path-current-");
+		const absolute = writeModel(
+			currentRoot,
+			"models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf",
+		);
+		// The dead-container path from the issue: the UUID no longer exists.
+		const legacy =
+			"/var/mobile/Containers/Data/Application/5ED497DF-9A29-487F-A422-333997764963/Library/Application Support/Eliza/local-inference/models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf";
+		expect(resolveStoredModelPath(legacy, currentRoot)).toBe(absolute);
+	});
+
+	it("returns null when the artifact is genuinely absent (real not-downloaded state)", () => {
+		const currentRoot = makeRoot("stored-path-missing-");
+		mkdirSync(currentRoot, { recursive: true });
+		expect(
+			resolveStoredModelPath(
+				"models/eliza-1-2b.bundle/text/m.gguf",
+				currentRoot,
+			),
+		).toBeNull();
+		expect(
+			resolveStoredModelPath(
+				"/dead/container/local-inference/models/m.gguf",
+				currentRoot,
+			),
+		).toBeNull();
+	});
+
+	it("accepts a live absolute row verbatim", () => {
+		const root = makeRoot("stored-path-verbatim-");
+		const absolute = writeModel(root, "models/m.gguf");
+		expect(resolveStoredModelPath(absolute, root)).toBe(absolute);
+	});
+
+	it("probes through an injected exists predicate", () => {
+		const probed: string[] = [];
+		const resolved = resolveStoredModelPath(
+			"models/m.gguf",
+			"/current/local-inference",
+			(candidate) => {
+				probed.push(candidate);
+				return true;
+			},
+		);
+		expect(resolved).toBe(
+			path.join("/current/local-inference", "models", "m.gguf"),
+		);
+		expect(probed).toEqual([
+			path.join("/current/local-inference", "models", "m.gguf"),
+		]);
+	});
+});
+
+describe("storedModelPathCandidates", () => {
+	it("adds the /private/var alias for simulator container paths", () => {
+		const candidates = storedModelPathCandidates(
+			"/private/var/containers/local-inference/models/m.gguf",
+			"/current/local-inference",
+		);
+		expect(candidates).toContain(
+			"/var/containers/local-inference/models/m.gguf",
+		);
+		expect(candidates).toContain(
+			path.join("/current/local-inference", "models", "m.gguf"),
+		);
+	});
+
+	it("never maps traversal rows into the root", () => {
+		expect(
+			storedModelPathCandidates("../../etc/passwd", "/current/local-inference"),
+		).toEqual([]);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/local-inference-stored-path.ts
@@ -1,0 +1,105 @@
+/**
+ * Stored registry model-path resolution shared by the iOS stdio bridge and
+ * the mobile device-bridge bootstrap.
+ *
+ * `local-inference/registry.json` rows persist model paths relative to the
+ * current `local-inference/` root because mobile app containers are
+ * re-created with a new absolute root on install/update (iOS rotates the
+ * data-container UUID; #11669). Legacy rows may still hold absolute paths
+ * from a dead container; those are re-anchored by their `/local-inference/`
+ * suffix and only accepted when the artifact actually exists on disk.
+ */
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+function looksAbsolute(input: string): boolean {
+	return (
+		path.isAbsolute(input) ||
+		/^[A-Za-z]:[\\/]/.test(input) ||
+		input.startsWith("\\\\")
+	);
+}
+
+/** Normalize a stored container-relative row to `a/b/c` form, or null. */
+export function normalizeStoredRelativeModelPath(input: string): string | null {
+	const normalized = input.trim().replaceAll("\\", "/");
+	if (!normalized || normalized.includes("\0") || looksAbsolute(normalized)) {
+		return null;
+	}
+	const parts = normalized.split("/").filter(Boolean);
+	if (parts.length === 0) return null;
+	if (parts.some((part) => part === "." || part === "..")) return null;
+	return parts.join("/");
+}
+
+/** Convert an absolute path under `currentRoot` to its stored relative form. */
+export function toStoredModelPath(
+	target: string,
+	currentRoot: string,
+): string | null {
+	const root = path.resolve(currentRoot);
+	const resolved = path.resolve(target);
+	const relative = path.relative(root, resolved);
+	if (
+		relative === "" ||
+		relative.startsWith("..") ||
+		path.isAbsolute(relative)
+	) {
+		return null;
+	}
+	return relative.split(path.sep).join("/");
+}
+
+/** Candidate absolute locations for a stored registry row, most likely first. */
+export function storedModelPathCandidates(
+	stored: string,
+	currentRoot: string,
+): string[] {
+	const trimmed = stored.trim();
+	if (!trimmed || trimmed.includes("\0")) return [];
+	const candidates = new Set<string>();
+	const relative = normalizeStoredRelativeModelPath(trimmed);
+	if (relative) {
+		candidates.add(path.join(currentRoot, ...relative.split("/")));
+	}
+	if (looksAbsolute(trimmed)) {
+		candidates.add(trimmed);
+		// The iOS simulator exposes the data root as both /private/var and /var.
+		candidates.add(trimmed.replace(/^\/private\/var\//, "/var/"));
+		const normalizedAbsolute = trimmed.replaceAll("\\", "/");
+		const marker = "/local-inference/";
+		const markerIndex = normalizedAbsolute.indexOf(marker);
+		if (markerIndex >= 0) {
+			const legacyRelative = normalizeStoredRelativeModelPath(
+				normalizedAbsolute.slice(markerIndex + marker.length),
+			);
+			if (legacyRelative) {
+				candidates.add(path.join(currentRoot, ...legacyRelative.split("/")));
+			}
+		}
+	}
+	return [...candidates];
+}
+
+/**
+ * Resolve a stored registry path against the CURRENT local-inference root,
+ * returning the first candidate that exists on disk. Returns null when the
+ * artifact is genuinely absent so callers surface a real not-downloaded
+ * state instead of loading against a dead container path.
+ *
+ * `exists` is injectable because the iOS stdio bridge must probe through the
+ * mobile fs sandbox proxy rather than raw `node:fs`.
+ */
+export function resolveStoredModelPath(
+	stored: string,
+	currentRoot: string,
+	exists: (candidate: string) => boolean = existsSync,
+): string | null {
+	for (const candidate of storedModelPathCandidates(stored, currentRoot)) {
+		try {
+			if (exists(candidate)) return candidate;
+		} catch {}
+	}
+	return null;
+}

--- a/plugins/plugin-local-inference/src/services/registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/registry.test.ts
@@ -140,6 +140,113 @@ describe("local inference registry removal", () => {
 		expect(listed[0]?.bundleRoot).toBe(currentBundleRoot);
 		expect(listed[0]?.manifestPath).toBe(currentManifestPath);
 		expect(fs.existsSync(listed[0]?.path ?? "")).toBe(true);
+
+		// Self-heal: the reanchored legacy row must be rewritten on disk in
+		// canonical container-relative form so the migration happens once.
+		const healed = readRawRegistry().models?.[0];
+		expect(healed?.path).toBe("models/eliza-1-2b/text/model.gguf");
+		expect(healed?.bundleRoot).toBe("models/eliza-1-2b");
+		expect(healed?.manifestPath).toBe(
+			"models/eliza-1-2b/eliza-1.manifest.json",
+		);
+	});
+
+	it("drops a legacy absolute row whose artifact does not exist under the current root", async () => {
+		useTempStateDir();
+		const previousStateDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-local-inference-dead-state-"),
+		);
+		tempDirs.push(previousStateDir);
+
+		// Registry points at a dead container and the model was NOT migrated:
+		// the real state is "not downloaded", so the row must not survive.
+		const legacyModelPath = path.join(
+			previousStateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+			"text",
+			"model.gguf",
+		);
+		fs.mkdirSync(path.dirname(registryPath()), { recursive: true });
+		fs.writeFileSync(
+			registryPath(),
+			JSON.stringify({
+				version: 1,
+				models: [installedModel("eliza-1-2b", legacyModelPath)],
+			}),
+		);
+
+		expect(await listInstalledModels()).toEqual([]);
+		expect(readRawRegistry().models).toEqual([]);
+	});
+
+	it("drops a relative row whose artifact was deleted from disk", async () => {
+		const stateDir = useTempStateDir();
+		const modelPath = path.join(
+			stateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+			"text",
+			"model.gguf",
+		);
+		fs.mkdirSync(path.dirname(modelPath), { recursive: true });
+		fs.writeFileSync(modelPath, "fake-model");
+		await upsertElizaModel(installedModel("eliza-1-2b", modelPath));
+		expect((await listInstalledModels()).map((m) => m.id)).toEqual([
+			"eliza-1-2b",
+		]);
+
+		fs.rmSync(modelPath);
+
+		expect(await listInstalledModels()).toEqual([]);
+		expect(readRawRegistry().models).toEqual([]);
+	});
+
+	it("keeps healthy rows while healing a mixed registry", async () => {
+		const stateDir = useTempStateDir();
+		const keptModelPath = path.join(
+			stateDir,
+			"local-inference",
+			"models",
+			"eliza-1-2b",
+			"text",
+			"model.gguf",
+		);
+		fs.mkdirSync(path.dirname(keptModelPath), { recursive: true });
+		fs.writeFileSync(keptModelPath, "fake-model");
+
+		const previousStateDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "eliza-local-inference-mixed-state-"),
+		);
+		tempDirs.push(previousStateDir);
+		const deadModelPath = path.join(
+			previousStateDir,
+			"local-inference",
+			"models",
+			"gone.gguf",
+		);
+
+		fs.mkdirSync(path.dirname(registryPath()), { recursive: true });
+		fs.writeFileSync(
+			registryPath(),
+			JSON.stringify({
+				version: 1,
+				models: [
+					installedModel("eliza-1-2b", keptModelPath),
+					installedModel("gone-model", deadModelPath),
+				],
+			}),
+		);
+
+		const listed = await listInstalledModels();
+		expect(listed.map((m) => m.id)).toEqual(["eliza-1-2b"]);
+		expect(listed[0]?.path).toBe(keptModelPath);
+
+		const rawModels = readRawRegistry().models;
+		expect(rawModels?.map((m) => m.id)).toEqual(["eliza-1-2b"]);
+		expect(rawModels?.[0]?.path).toBe("models/eliza-1-2b/text/model.gguf");
 	});
 
 	it("removes an Eliza-owned bundle directory and clears the registry entry", async () => {

--- a/plugins/plugin-local-inference/src/services/registry.ts
+++ b/plugins/plugin-local-inference/src/services/registry.ts
@@ -10,6 +10,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { logger } from "@elizaos/core";
 import { scanExternalModels } from "./external-scanner";
 import {
 	isWithinElizaRoot,
@@ -47,18 +48,113 @@ async function ensureRootDir(): Promise<void> {
 }
 
 async function readElizaOwned(): Promise<InstalledModel[]> {
+	return (await readElizaOwnedDetailed()).models;
+}
+
+async function readElizaOwnedDetailed(): Promise<{
+	models: InstalledModel[];
+	/** True when the on-disk rows are not in canonical relative form. */
+	needsRewrite: boolean;
+}> {
 	try {
 		const raw = await fs.readFile(registryPath(), "utf8");
 		const parsed = JSON.parse(raw) as RegistryFile;
 		if (parsed?.version !== 1 || !Array.isArray(parsed.models)) {
-			return [];
+			return { models: [], needsRewrite: false };
 		}
-		return parsed.models
-			.map(hydrateStoredElizaModel)
-			.filter((model): model is InstalledModel => Boolean(model));
+		let needsRewrite = false;
+		const models: InstalledModel[] = [];
+		for (const stored of parsed.models) {
+			const hydrated = hydrateStoredElizaModel(stored);
+			if (!hydrated) {
+				needsRewrite = true;
+				continue;
+			}
+			if (!storedRowIsCanonical(stored, hydrated)) needsRewrite = true;
+			models.push(hydrated);
+		}
+		return { models, needsRewrite };
 	} catch {
-		return [];
+		return { models: [], needsRewrite: false };
 	}
+}
+
+/**
+ * Self-healing read used by the list boundary: hydrate rows against the
+ * CURRENT local-inference root, drop rows whose model artifact is genuinely
+ * missing on disk (so callers surface a real not-downloaded state instead of
+ * loading a dead path), and rewrite the registry once when legacy
+ * absolute-path rows were migrated or dangling rows were dropped (#11669).
+ */
+async function readElizaOwnedHealed(): Promise<InstalledModel[]> {
+	const { models, needsRewrite } = await readElizaOwnedDetailed();
+	const present: InstalledModel[] = [];
+	let dropped = false;
+	for (const model of models) {
+		if (await modelArtifactPresent(model.path)) {
+			present.push(model);
+		} else {
+			dropped = true;
+			logger.warn(
+				`[LocalInferenceRegistry] Dropping registry entry "${model.id}": model file missing at ${model.path}; the model must be downloaded again`,
+			);
+		}
+	}
+	if (needsRewrite || dropped) {
+		try {
+			await writeElizaOwned(present);
+			logger.info(
+				`[LocalInferenceRegistry] Healed registry.json: ${present.length} model(s) persisted with container-relative paths`,
+			);
+		} catch (error) {
+			logger.warn(
+				`[LocalInferenceRegistry] Could not rewrite healed registry.json: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return present;
+}
+
+async function modelArtifactPresent(modelPath: string): Promise<boolean> {
+	try {
+		return (await fs.stat(modelPath)).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function storedRowIsCanonical(
+	stored: StoredInstalledModel,
+	hydrated: InstalledModel,
+): boolean {
+	if (stored.path !== toLocalInferenceStoredPath(hydrated.path)) return false;
+	if (
+		(stored.bundleRoot === undefined) !==
+		(hydrated.bundleRoot === undefined)
+	) {
+		return false;
+	}
+	if (
+		hydrated.bundleRoot &&
+		stored.bundleRoot !== toLocalInferenceStoredPath(hydrated.bundleRoot)
+	) {
+		return false;
+	}
+	if (
+		(stored.manifestPath === undefined) !==
+		(hydrated.manifestPath === undefined)
+	) {
+		return false;
+	}
+	if (
+		hydrated.manifestPath &&
+		stored.manifestPath !== toLocalInferenceStoredPath(hydrated.manifestPath)
+	) {
+		return false;
+	}
+	return true;
 }
 
 async function writeElizaOwned(models: InstalledModel[]): Promise<void> {
@@ -95,8 +191,15 @@ function hydrateStoredElizaModel(
 			? resolveLocalInferenceStoredPath(model.manifestPath)
 			: null;
 
+	// Build explicitly so a stored bundleRoot/manifestPath that failed to
+	// resolve is dropped instead of leaking its raw stored string through.
+	const {
+		bundleRoot: _bundleRoot,
+		manifestPath: _manifestPath,
+		...rest
+	} = model;
 	return {
-		...model,
+		...rest,
 		path: modelPath,
 		...(bundleRoot ? { bundleRoot } : {}),
 		...(manifestPath ? { manifestPath } : {}),
@@ -206,7 +309,7 @@ async function scanExternalModelsCached(): Promise<InstalledModel[]> {
  * arrive in bursts during active downloads.
  */
 export async function listInstalledModels(): Promise<InstalledModel[]> {
-	const owned = await readElizaOwned();
+	const owned = await readElizaOwnedHealed();
 	if (!externalScanEnabled()) return owned;
 
 	// Filter out Eliza-owned files that also survived a reboot of the local


### PR DESCRIPTION
Closes #11669

## Root cause

`local-inference/registry.json` persisted **absolute app-container paths**. iOS rotates the data-container UUID on every reinstall/update, so the persisted prefix dies while the model bytes migrate fine — the loader never finds the 6.5 GB bundle and the app wedges on "Loading Eliza-1 2B…".

#11371 (67c2b7be347, landed earlier today) made the canonical registry store **container-relative** rows and re-anchor legacy absolute rows at hydrate time — but left three gaps that this PR closes:

1. **No existence verification / no persisted heal** (`plugin-local-inference/src/services/registry.ts`): hydration re-anchored blindly, returning "installed" rows whose file may not exist, and the legacy absolute strings stayed in `registry.json` forever.
2. **The on-device full-Bun loader path was still broken** (`plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts`): `resolveFromRegistry` / `resolveAssignedRegistryModel` did a verbatim `existsSync(matched.path)` on the stored string — so **both** the new relative rows (`models/…` probed against cwd) **and** legacy dead-container absolute rows failed, and the bootstrap fell through to re-downloading a model already fully on disk.
3. **Android had the mirror-image gap** (`plugin-aosp-local-inference`): `mapExistingModelPath` handled legacy absolute rows via the `/local-inference/models/` suffix but not the new container-relative rows.

## Fix (platform-neutral)

- **`plugin-local-inference` registry:** `listInstalledModels()` verifies the model artifact exists at the hydrated path, drops rows whose file is genuinely absent (structured `[LocalInferenceRegistry]` warn → readiness/UI surface the real not-downloaded state; no silent fallback), and **self-heals `registry.json` once** — legacy absolute rows are rewritten in canonical container-relative form via the existing atomic tmp+rename writer. Also fixed hydration leaking the raw stored `bundleRoot`/`manifestPath` string when resolution fails.
- **New shared resolver** `plugin-capacitor-bridge/src/shared/local-inference-stored-path.ts`: relative rows join the CURRENT root; legacy absolute rows re-anchor by their `/local-inference/` suffix (plus the simulator `/private/var`↔`/var` alias); every candidate is exists-verified; traversal rejected. Exists-probe injectable so the iOS stdio bridge keeps probing through the mobile fs sandbox proxy.
- **`ios/bridge.ts`**: deduped its local copy of the same logic into the shared resolver (behavior preserved).
- **`mobile-device-bridge-bootstrap.ts`**: registry-backed model resolution goes through the shared resolver.
- **AOSP bootstrap (Android)**: `mapExistingModelPath` maps container-relative rows against the current device root.

## Tests (container migration simulated by moving the root between write and read)

| Suite | Coverage |
|---|---|
| `plugin-local-inference/src/services/registry.test.ts` (8) | moved-root reanchor **+ on-disk self-heal to relative form**; dangling legacy absolute row → dropped from listing **and** file; deleted-artifact relative row → dropped; mixed registry keeps healthy row while healing |
| `plugin-capacitor-bridge/src/shared/local-inference-stored-path.test.ts` (10, new) | relative resolve, dead-container re-anchor with the exact path shape from the issue, `/private/var` alias, traversal rejection, round-trip, absent → null |
| `plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.registry-paths.test.ts` (3, new) | `mobileDeviceBridge.status().modelPath` resolves relative rows, re-anchors dead-container rows, reports null when genuinely absent |
| `plugin-aosp-local-inference` bootstrap tests (+2) | `readAssignedBundledModels` resolves relative rows; absent artifact → null |

**Anti-larp negative check:** temporarily reverted the three source files to `origin/develop` and re-ran the new tests — bootstrap 2/3 failed, registry 4/8 failed, AOSP relative-row failed (exactly the fixed bugs). Restored; all green.

## Verification

- `bunx vitest run --root plugins/plugin-local-inference` → **2272 passed / 13 skipped**; 1 failure is pre-existing on pristine `origin/develop` on this host (imagegen CUDA-proof env test, unrelated).
- `bunx vitest run --root plugins/plugin-capacitor-bridge` → 48 passed; 2 failures pre-existing on macOS (abstract `\0` sockets are Linux-only; identical on pristine develop).
- `bun run --cwd plugins/plugin-aosp-local-inference test` → **75 pass / 0 fail**.
- `typecheck` + `build` pass for all three plugins; biome clean on all touched files.
- No regression in the adjacent #11517 sha-sidecar / #11452 / #11505 flat-bundle staging behavior: `downloader.test.ts`, `local-inference-routes.test.ts`, `ensure-local-artifacts.test.ts` all pass (40/40); the sidecars are path-adjacent files and unaffected.

## Evidence rows (PR_EVIDENCE.md)

- **Backend logs:** structured `[LocalInferenceRegistry]` warn/info fire on drop/heal (asserted paths exercised by the tests above); evidence doc `.github/issue-evidence/11669-registry-relative-self-heal.md`.
- **Real-LLM trajectories:** N/A — no agent/action/provider/prompt/model behavior change; server-side path resolution only.
- **Screenshots / video / frontend logs:** N/A — no UI change; the user-visible effect (model loads instead of wedging) is exercised by the moved-root regression tests.
- **On-device iOS leg:** honestly stated as **gated on this branch** — a live reinstall capture needs the full device bundle + 6.5 GB model download (`capture:ios-sim` lane). The container-UUID rotation state transition (same bytes, new root) is exercised directly by the moved-root tests; the original issue also confirmed a hand-`sed` of the UUID un-wedges the load with no other change, which is precisely the transformation the resolver now performs (exists-verified).
- **Domain artifacts:** healed `registry.json` contents asserted in-tests (canonical relative rows on disk after list; dangling rows removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
