### PR TITLE
ci(ui-e2e-gate): wire the orphaned slop-removal cloud e2e runner (ratchet red on develop)

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -154,6 +154,12 @@ jobs:
       - name: Credentials e2e
         run: bun run --cwd packages/ui test:credentials-e2e
 
+      # Cloud-surface unification (#11341): real mock cloud stack; every legacy
+      # /dashboard/* deep link redirects to /settings#<section>, and each
+      # canonical Settings section renders real data, desktop + mobile.
+      - name: Cloud settings surface (slop-removal) e2e
+        run: bun run --cwd packages/ui test:slop-removal-e2e
+
       - name: Upload UI fixture e2e artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -176,5 +182,6 @@ jobs:
             packages/ui/src/components/pages/__e2e__/output-suggestions
             packages/ui/src/cloud/applications/__e2e__/output-frontend-hosting
             packages/ui/src/cloud/organization/__e2e__/output-credentials
+            packages/ui/src/cloud/__e2e__/output-slop-removal
           retention-days: 14
           if-no-files-found: ignore

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
     "test:view-lifecycle-e2e": "bun run --cwd ../.. packages/ui/src/components/views/__e2e__/run-view-lifecycle-e2e.mjs",
     "test:frontend-hosting-e2e": "bun run --cwd ../.. packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs",
     "test:credentials-e2e": "bun run --cwd ../.. packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs",
+    "test:slop-removal-e2e": "bun run --cwd ../.. packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs",
     "lint": "bunx @biomejs/biome check src",
     "lint:fix": "bunx @biomejs/biome check --write src",
     "format": "bunx @biomejs/biome format src",


### PR DESCRIPTION
Found during #11628 verification (follow-up to #11646).

## Problem

The `packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` ratchet is **red on develop again**. #11646 (merged 2026-07-02 23:05:30Z) wired the credentials + frontend-hosting runners, but #11657 (merged 2026-07-02 23:04:19Z — one minute earlier, in-flight at the same time) added a third runner, `packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs`, with no `packages/ui` package.json script and no CI leg:

```
packages/ui/src/cloud/__e2e__/run-slop-removal-e2e.mjs: no packages/ui package.json script references it — add one (or delete the runner)
```

## Change (8 insertions, 2 files)

- `packages/ui/package.json`: add `test:slop-removal-e2e` (same `bun run --cwd ../.. <runner>` convention as the neighboring scripts).
- `.github/workflows/ui-e2e-gate.yml`: add a "Cloud settings surface (slop-removal) e2e" leg after the credentials leg, and add `output-slop-removal` to the artifact upload paths.

## Verification (all local, this branch on top of current develop)

| Check | Result |
| --- | --- |
| `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` | **1 pass / 0 fail** (was 0/1 on develop) |
| `bun run --cwd packages/ui test:slop-removal-e2e` (exact CI invocation) | exit 0, `ALL CHECKS PASSED`, **30/30** ✓ assertions |
| `bun run --cwd packages/ui test:credentials-e2e` (re-validated #11646 leg) | exit 0, `ALL GREEN`, **11/11** ✓ assertions |
| `bun run --cwd packages/ui test:frontend-hosting-e2e` (re-validated #11646 leg) | exit 0, `ALL GREEN`, **7/7** ✓ assertions |
| `actionlint .github/workflows/ui-e2e-gate.yml` | clean |

Committed evidence outputs (`output-slop-removal/`, RESULT.json, walkthrough.webm) were regenerated locally by these runs and deliberately restored to HEAD to keep the diff to the 8-line wiring change; the checked-in evidence from #11657 remains canonical.

No other orphaned runners: the ratchet enumerates every `run-*.mjs` under `packages/ui/src/**/__e2e__` and passes 1/1 with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)