### PR TITLE
ci(ui-e2e-gate): wire the warmup-eviction runner leg — ratchet red on develop again (#11698 landed script-only)

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -125,6 +125,12 @@ jobs:
       - name: Fused wake integration e2e
         run: bun run --cwd packages/ui test:fused-wake-integration-e2e
 
+      # Warm-up eviction (#11670): a user message sent while the local model
+      # 503s during warm-up must survive the post-turn reconcile, show a
+      # retryable failed turn, and deliver exactly once on Retry.
+      - name: Warm-up message eviction e2e
+        run: bun run --cwd packages/ui test:warmup-eviction-e2e
+
       # Launcher grid (#10722): genuine CDP long-press pointer drag-to-reorder
       # (section 2b) → onReorder → persisted LAUNCHER_STORAGE_KEY order +
       # reorder telemetry + no duplicate ids. The jsdom Launcher.gestures suite
@@ -183,5 +189,6 @@ jobs:
             packages/ui/src/cloud/applications/__e2e__/output-frontend-hosting
             packages/ui/src/cloud/organization/__e2e__/output-credentials
             packages/ui/src/cloud/__e2e__/output-slop-removal
+            packages/ui/src/components/shell/__e2e__/output-warmup-eviction
           retention-days: 14
           if-no-files-found: ignore


### PR DESCRIPTION
Found during #11628 verification — third strike in the same race. Follow-up to #11646 and #11702.

## Problem

The `packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` ratchet is **red on develop again**: #11698 (warm-up eviction fix, merged 2026-07-02 ~23:5xZ) added `packages/ui/src/components/shell/__e2e__/run-warmup-eviction-e2e.mjs` **with** a `test:warmup-eviction-e2e` package script but **without** any workflow leg:

```
packages/ui/src/components/shell/__e2e__/run-warmup-eviction-e2e.mjs: script "test:warmup-eviction-e2e" is not invoked by any .github/workflows/*.yml — wire a leg (ui-fixture-e2e.yml) or delete the runner with justification
```

## Change (7 insertions, 1 file)

`.github/workflows/ui-e2e-gate.yml`: add a "Warm-up message eviction e2e" leg next to its shell-family siblings (after fused-wake), and add `output-warmup-eviction` to the artifact upload paths. The package script already exists on develop — no package.json change needed.

## Verification (local, this branch = develop + this commit)

| Check | Result |
| --- | --- |
| `bun test packages/scripts/__tests__/ui-e2e-runner-coverage.test.ts` | **1 pass / 0 fail** (red on develop without this) |
| `bun run --cwd packages/ui test:warmup-eviction-e2e` (exact CI invocation) | exit 0, `PASS`, **8/8** ✓ assertions (optimistic bubble survives reconcile, retryable failed turn, exactly-once delivery on Retry, no page errors) |
| `actionlint .github/workflows/ui-e2e-gate.yml` | clean |

Regenerated `output-warmup-eviction/` evidence from the local run was restored to HEAD; the checked-in evidence from #11698 remains canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)