### PR TITLE
test(scenarios): effect proofs for ainex/finances/selfcontrol — action-effect ratchet 36 → 25 (#11381)

### DIFF
--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/README.md
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/README.md
@@ -1,0 +1,38 @@
+# #11381 tail — round-4 salvage landing (BASELINE 36 → 25)
+
+Rescued from `rescue/11381-actioncalled-paydown-r4-local` (round-4 salvage
+commit `dd9a1aa3e7`, cut off by the credit wall before PR #11575 merged):
+11 more actionCalled-only scenarios given real effect finalChecks —
+`ainex/stand`, `finances/owner-finances-dashboard`, and 9 `selfcontrol/*`
+scenarios. `action-effect-ratchet.test.ts` `BASELINE` lowered 36 → 25 in
+lockstep.
+
+## Artifacts (all real command output / runner reports)
+
+- `ratchet-enumeration-red-baseline0.txt` — ratchet run with `BASELINE=0`:
+  RED, enumerates exactly the 25 remaining offenders on this branch.
+- `ratchet-green-baseline25.txt` — `bun run --cwd packages/scenario-runner
+  test -- src/action-effect-ratchet.test.ts` at `BASELINE=25`: 2/2 pass.
+- `ainex-stand-deterministic-green.matrix.json` — full scenario-runner report:
+  `ainex.stand` (lane `pr-deterministic`) run keyless
+  (`SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1`) with the new
+  bridge-effect predicate — passed.
+- `finances-dashboard-deterministic-green.matrix.json` — same lane:
+  `finances.owner-finances-dashboard` with the new composite-read predicate —
+  passed; the captured action result shows the real `data.dashboard`
+  payload the predicate reads.
+- `finances-fail-without-fix-red.matrix.json` — fail-without-fix proof:
+  predicate temporarily pointed at `dashboard.spendingWRONGFIELD` → scenario
+  goes RED with `expected dashboard.spending {transactionCount, windowDays}
+  numbers from the app_finances read, saw {...real payload...}`; flip
+  reverted before commit.
+
+## Lane notes
+
+- The 9 `selfcontrol/*` conversions are `lane: "live-only"` scenarios (they
+  need a real blocker device); their new `custom` predicates are validated
+  statically by the ratchet enumeration (they no longer count as
+  actionCalled-only) and use the same `_helpers/effect-assertions.ts`
+  helpers exercised green in the two deterministic runs above.
+- Remaining debt after this tail: **25** direct actionCalled-only scenarios
+  (list in `ratchet-enumeration-red-baseline0.txt`).

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ainex-stand-deterministic-green.matrix.json
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ainex-stand-deterministic-green.matrix.json
@@ -1,0 +1,107 @@
+{
+  "runId": "050e3c55-1e4f-45d5-a1c4-15f757218565",
+  "startedAtIso": "2026-07-03T00:04:56.294Z",
+  "completedAtIso": "2026-07-03T00:05:23.094Z",
+  "providerName": "deterministic-llm-proxy",
+  "scenarios": [
+    {
+      "id": "ainex.stand",
+      "title": "AiNex: stand the robot up against a mocked websocket bridge",
+      "domain": "ainex",
+      "tags": [
+        "smoke",
+        "ainex",
+        "connector",
+        "robot"
+      ],
+      "status": "passed",
+      "durationMs": 3507,
+      "turns": [
+        {
+          "name": "stand",
+          "kind": "message",
+          "text": "Stand up, AiNex.",
+          "responseText": "AiNex is standing.",
+          "actionsCalled": [
+            {
+              "actionName": "AINEX_STAND",
+              "parameters": {
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {},
+                "text": "AiNex is standing.",
+                "raw": {
+                  "success": true,
+                  "text": "AiNex is standing.",
+                  "data": {}
+                }
+              }
+            }
+          ],
+          "durationMs": 3298,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "actionCalled",
+          "type": "actionCalled",
+          "status": "passed",
+          "detail": "AINEX_STAND succeeded 1x (1 total call(s))"
+        },
+        {
+          "label": "stand-command-crossed-the-bridge",
+          "type": "custom",
+          "status": "passed",
+          "detail": "predicate returned undefined"
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "AINEX_STAND",
+          "parameters": {
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {},
+            "text": "AiNex is standing.",
+            "raw": {
+              "success": true,
+              "text": "AiNex is standing.",
+              "data": {}
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "deterministic-llm-proxy"
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-ainex",
+    "matrixJson": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-ainex/matrix.json",
+    "viewerIndex": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-ainex/viewer/index.html",
+    "viewerData": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-ainex/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/finances-dashboard-deterministic-green.matrix.json
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/finances-dashboard-deterministic-green.matrix.json
@@ -1,0 +1,197 @@
+{
+  "runId": "c41670e9-b4ba-4348-b7f9-6474ba4c2b27",
+  "startedAtIso": "2026-07-03T00:05:39.701Z",
+  "completedAtIso": "2026-07-03T00:06:11.425Z",
+  "providerName": "deterministic-llm-proxy",
+  "scenarios": [
+    {
+      "id": "finances.owner-finances-dashboard",
+      "title": "Finances: OWNER_FINANCES returns the payments dashboard",
+      "domain": "finances",
+      "tags": [
+        "smoke",
+        "finances",
+        "owner-finances",
+        "payments"
+      ],
+      "status": "passed",
+      "durationMs": 2897,
+      "turns": [
+        {
+          "name": "read-finances-dashboard",
+          "kind": "message",
+          "text": "Pull up my finances dashboard for the last 30 days.",
+          "responseText": "Here is your finances dashboard for the last 30 days.",
+          "actionsCalled": [
+            {
+              "actionName": "OWNER_FINANCES",
+              "parameters": {
+                "parameters": {
+                  "action": "dashboard"
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "dashboard": {
+                    "sources": [],
+                    "recurring": [],
+                    "recurringPlaybookHits": [],
+                    "spending": {
+                      "windowDays": 30,
+                      "fromDate": "2026-06-03T00:06:10.598Z",
+                      "toDate": "2026-07-03T00:06:10.598Z",
+                      "totalSpendUsd": 0,
+                      "totalIncomeUsd": 0,
+                      "netUsd": 0,
+                      "transactionCount": 0,
+                      "recurringSpendUsd": 0,
+                      "topCategories": [],
+                      "topMerchants": []
+                    },
+                    "upcomingBills": [],
+                    "gmailSubscriptionAuditId": null,
+                    "generatedAt": "2026-07-03T00:06:10.600Z"
+                  }
+                },
+                "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+                "raw": {
+                  "success": true,
+                  "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+                  "data": {
+                    "dashboard": {
+                      "sources": [],
+                      "recurring": [],
+                      "recurringPlaybookHits": [],
+                      "spending": {
+                        "windowDays": 30,
+                        "fromDate": "2026-06-03T00:06:10.598Z",
+                        "toDate": "2026-07-03T00:06:10.598Z",
+                        "totalSpendUsd": 0,
+                        "totalIncomeUsd": 0,
+                        "netUsd": 0,
+                        "transactionCount": 0,
+                        "recurringSpendUsd": 0,
+                        "topCategories": [],
+                        "topMerchants": []
+                      },
+                      "upcomingBills": [],
+                      "gmailSubscriptionAuditId": null,
+                      "generatedAt": "2026-07-03T00:06:10.600Z"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 2778,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "actionCalled",
+          "type": "actionCalled",
+          "status": "passed",
+          "detail": "OWNER_FINANCES succeeded 1x (1 total call(s))"
+        },
+        {
+          "label": "finances-dashboard-composite-read",
+          "type": "custom",
+          "status": "passed",
+          "detail": "predicate returned undefined"
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "OWNER_FINANCES",
+          "parameters": {
+            "parameters": {
+              "action": "dashboard"
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "dashboard": {
+                "sources": [],
+                "recurring": [],
+                "recurringPlaybookHits": [],
+                "spending": {
+                  "windowDays": 30,
+                  "fromDate": "2026-06-03T00:06:10.598Z",
+                  "toDate": "2026-07-03T00:06:10.598Z",
+                  "totalSpendUsd": 0,
+                  "totalIncomeUsd": 0,
+                  "netUsd": 0,
+                  "transactionCount": 0,
+                  "recurringSpendUsd": 0,
+                  "topCategories": [],
+                  "topMerchants": []
+                },
+                "upcomingBills": [],
+                "gmailSubscriptionAuditId": null,
+                "generatedAt": "2026-07-03T00:06:10.600Z"
+              }
+            },
+            "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+            "raw": {
+              "success": true,
+              "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+              "data": {
+                "dashboard": {
+                  "sources": [],
+                  "recurring": [],
+                  "recurringPlaybookHits": [],
+                  "spending": {
+                    "windowDays": 30,
+                    "fromDate": "2026-06-03T00:06:10.598Z",
+                    "toDate": "2026-07-03T00:06:10.598Z",
+                    "totalSpendUsd": 0,
+                    "totalIncomeUsd": 0,
+                    "netUsd": 0,
+                    "transactionCount": 0,
+                    "recurringSpendUsd": 0,
+                    "topCategories": [],
+                    "topMerchants": []
+                  },
+                  "upcomingBills": [],
+                  "gmailSubscriptionAuditId": null,
+                  "generatedAt": "2026-07-03T00:06:10.600Z"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [],
+      "providerName": "deterministic-llm-proxy"
+    }
+  ],
+  "totals": {
+    "passed": 1,
+    "failed": 0,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 1,
+  "failedCount": 0,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances",
+    "matrixJson": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances/matrix.json",
+    "viewerIndex": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances/viewer/index.html",
+    "viewerData": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/finances-fail-without-fix-red.matrix.json
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/finances-fail-without-fix-red.matrix.json
@@ -1,0 +1,202 @@
+{
+  "runId": "75ac4451-a277-4cf6-aff7-7219fc0c53aa",
+  "startedAtIso": "2026-07-03T00:06:38.111Z",
+  "completedAtIso": "2026-07-03T00:07:04.758Z",
+  "providerName": "deterministic-llm-proxy",
+  "scenarios": [
+    {
+      "id": "finances.owner-finances-dashboard",
+      "title": "Finances: OWNER_FINANCES returns the payments dashboard",
+      "domain": "finances",
+      "tags": [
+        "smoke",
+        "finances",
+        "owner-finances",
+        "payments"
+      ],
+      "status": "failed",
+      "durationMs": 1604,
+      "turns": [
+        {
+          "name": "read-finances-dashboard",
+          "kind": "message",
+          "text": "Pull up my finances dashboard for the last 30 days.",
+          "responseText": "Here is your finances dashboard for the last 30 days.",
+          "actionsCalled": [
+            {
+              "actionName": "OWNER_FINANCES",
+              "parameters": {
+                "parameters": {
+                  "action": "dashboard"
+                },
+                "actionContext": {
+                  "previousResults": []
+                }
+              },
+              "result": {
+                "success": true,
+                "data": {
+                  "dashboard": {
+                    "sources": [],
+                    "recurring": [],
+                    "recurringPlaybookHits": [],
+                    "spending": {
+                      "windowDays": 30,
+                      "fromDate": "2026-06-03T00:07:03.942Z",
+                      "toDate": "2026-07-03T00:07:03.943Z",
+                      "totalSpendUsd": 0,
+                      "totalIncomeUsd": 0,
+                      "netUsd": 0,
+                      "transactionCount": 0,
+                      "recurringSpendUsd": 0,
+                      "topCategories": [],
+                      "topMerchants": []
+                    },
+                    "upcomingBills": [],
+                    "gmailSubscriptionAuditId": null,
+                    "generatedAt": "2026-07-03T00:07:03.943Z"
+                  }
+                },
+                "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+                "raw": {
+                  "success": true,
+                  "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+                  "data": {
+                    "dashboard": {
+                      "sources": [],
+                      "recurring": [],
+                      "recurringPlaybookHits": [],
+                      "spending": {
+                        "windowDays": 30,
+                        "fromDate": "2026-06-03T00:07:03.942Z",
+                        "toDate": "2026-07-03T00:07:03.943Z",
+                        "totalSpendUsd": 0,
+                        "totalIncomeUsd": 0,
+                        "netUsd": 0,
+                        "transactionCount": 0,
+                        "recurringSpendUsd": 0,
+                        "topCategories": [],
+                        "topMerchants": []
+                      },
+                      "upcomingBills": [],
+                      "gmailSubscriptionAuditId": null,
+                      "generatedAt": "2026-07-03T00:07:03.943Z"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "durationMs": 1515,
+          "failedAssertions": []
+        }
+      ],
+      "finalChecks": [
+        {
+          "label": "actionCalled",
+          "type": "actionCalled",
+          "status": "passed",
+          "detail": "OWNER_FINANCES succeeded 1x (1 total call(s))"
+        },
+        {
+          "label": "finances-dashboard-composite-read",
+          "type": "custom",
+          "status": "failed",
+          "detail": "expected dashboard.spending {transactionCount, windowDays} numbers from the app_finances read, saw {\"windowDays\":30,\"fromDate\":\"2026-06-03T00:07:03.942Z\",\"toDate\":\"2026-07-03T00:07:03.943Z\",\"totalSpendUsd\":0,\"totalIncomeUsd\":0,\"netUsd\":0,\"transactionCount\":0,\"recurringSpendUsd\":0,\"topCategories\":[]"
+        }
+      ],
+      "actionsCalled": [
+        {
+          "actionName": "OWNER_FINANCES",
+          "parameters": {
+            "parameters": {
+              "action": "dashboard"
+            },
+            "actionContext": {
+              "previousResults": []
+            }
+          },
+          "result": {
+            "success": true,
+            "data": {
+              "dashboard": {
+                "sources": [],
+                "recurring": [],
+                "recurringPlaybookHits": [],
+                "spending": {
+                  "windowDays": 30,
+                  "fromDate": "2026-06-03T00:07:03.942Z",
+                  "toDate": "2026-07-03T00:07:03.943Z",
+                  "totalSpendUsd": 0,
+                  "totalIncomeUsd": 0,
+                  "netUsd": 0,
+                  "transactionCount": 0,
+                  "recurringSpendUsd": 0,
+                  "topCategories": [],
+                  "topMerchants": []
+                },
+                "upcomingBills": [],
+                "gmailSubscriptionAuditId": null,
+                "generatedAt": "2026-07-03T00:07:03.943Z"
+              }
+            },
+            "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+            "raw": {
+              "success": true,
+              "text": "Spent $0.00 in the last 30 days across 0 transactions.\nNo recurring charges detected yet. Import transactions to start tracking.\nNo payment sources connected. Add one (CSV import) to see your spending.",
+              "data": {
+                "dashboard": {
+                  "sources": [],
+                  "recurring": [],
+                  "recurringPlaybookHits": [],
+                  "spending": {
+                    "windowDays": 30,
+                    "fromDate": "2026-06-03T00:07:03.942Z",
+                    "toDate": "2026-07-03T00:07:03.943Z",
+                    "totalSpendUsd": 0,
+                    "totalIncomeUsd": 0,
+                    "netUsd": 0,
+                    "transactionCount": 0,
+                    "recurringSpendUsd": 0,
+                    "topCategories": [],
+                    "topMerchants": []
+                  },
+                  "upcomingBills": [],
+                  "gmailSubscriptionAuditId": null,
+                  "generatedAt": "2026-07-03T00:07:03.943Z"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "failedAssertions": [
+        {
+          "label": "finances-dashboard-composite-read",
+          "detail": "expected dashboard.spending {transactionCount, windowDays} numbers from the app_finances read, saw {\"windowDays\":30,\"fromDate\":\"2026-06-03T00:07:03.942Z\",\"toDate\":\"2026-07-03T00:07:03.943Z\",\"totalSpendUsd\":0,\"totalIncomeUsd\":0,\"netUsd\":0,\"transactionCount\":0,\"recurringSpendUsd\":0,\"topCategories\":[]"
+        }
+      ],
+      "providerName": "deterministic-llm-proxy"
+    }
+  ],
+  "totals": {
+    "passed": 0,
+    "failed": 1,
+    "skipped": 0,
+    "flakyPassed": 0,
+    "costUsd": 0,
+    "finalChecksSkipped": 0
+  },
+  "totalCount": 1,
+  "passedCount": 0,
+  "failedCount": 1,
+  "skippedCount": 0,
+  "flakyPassedCount": 0,
+  "totalCostUsd": 0,
+  "artifactPaths": {
+    "runDir": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances-red",
+    "matrixJson": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances-red/matrix.json",
+    "viewerIndex": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances-red/viewer/index.html",
+    "viewerData": "/tmp/claude-1000/-home-shaw-milady-eliza/da253a81-b404-4458-8364-46d9209b4b08/scratchpad/11381-finances-red/viewer/data.js"
+  }
+}

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-enumeration-red-baseline0.txt
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-enumeration-red-baseline0.txt
@@ -1,0 +1,35 @@
+Error: actionCalled-only scenarios grew to 25 (baseline 0). A finalChecks array that is entirely 'actionCalled' proves the handler ran, not that it produced the right effect — add a 'custom'/'memoryWriteOccurred'/'connectorDispatchOccurred' check that reads the produced state. New offenders:
+packages/test/scenarios/calendar/calendar.cancel.simple.scenario.ts
+packages/test/scenarios/calendar/calendar.create.with-prep-buffer.scenario.ts
+packages/test/scenarios/calendar/calendar.reminder.10min-before.scenario.ts
+packages/test/scenarios/calendar/calendar.reminder.1hr-before.scenario.ts
+packages/test/scenarios/calendar/calendar.reminder.on-the-dot.scenario.ts
+packages/test/scenarios/calendar/calendar.reschedule.conflict-detection.scenario.ts
+packages/test/scenarios/calendar/calendar.reschedule.simple.scenario.ts
+packages/test/scenarios/cross-cutting/cross.ambiguity.agent-asks-clarifying-question.scenario.ts
+packages/test/scenarios/cross-cutting/cross.multi-turn.memory-across-turns.scenario.ts
+packages/test/scenarios/cross-cutting/cross.negative.question-calls-no-action.scenario.ts
+packages/test/scenarios/lifeops.habits/habits.week-spanning-behavior.scenario.ts
+packages/test/scenarios/lifeops.hygiene/hygiene.brush-teeth-streak-recovery.scenario.ts
+packages/test/scenarios/relationships/relationships.status-goals.set.scenario.ts
+packages/test/scenarios/relationships/rolodex.search.scenario.ts
+packages/test/scenarios/relationships/rolodex.update-notes.scenario.ts
+packages/test/scenarios/reminders/reminder.alarm.sets-macos-alarm.scenario.ts
+packages/test/scenarios/remote/remote.mobile-controls-mac.scenario.ts
+packages/test/scenarios/remote/remote.pair.local-no-code.scenario.ts
+packages/test/scenarios/remote/remote.sso-cloud.gmail-login.scenario.ts
+packages/test/scenarios/selfcontrol/selfcontrol.block-websites.followup-after-detour.scenario.ts
+packages/test/scenarios/selfcontrol/selfcontrol.integration-with-todos.auto-block.scenario.ts
+packages/test/scenarios/selfcontrol/selfcontrol.self-set-enforcement.ask-before.scenario.ts
+packages/test/scenarios/selfcontrol/selfcontrol.self-set-enforcement.enforces-yes.scenario.ts
+packages/test/scenarios/selfcontrol/selfcontrol.self-set-enforcement.respects-no.scenario.ts
+packages/test/scenarios/social.x/x.refuse-banworthy-action.scenario.ts
+ ❯ src/action-effect-ratchet.test.ts:148:13
+    146|     if (flagged.length > BASELINE) {
+    147|       const overflow = flagged.slice(BASELINE);
+    148|       throw new Error(
+       |             ^
+    149|         `actionCalled-only scenarios grew to ${flagged.length} (baseli…
+    150|           `A finalChecks array that is entirely 'actionCalled' proves …
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+ Test Files  1 failed (1)

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-green-baseline25.txt
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-green-baseline25.txt
@@ -1,0 +1,6 @@
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)
+   Start at  17:08:00
+   Duration  1.54s (transform 267ms, setup 0ms, import 1.30s, tests 9ms, environment 0ms)
+

--- a/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-green-baseline25.txt
+++ b/.github/issue-evidence/11381-actioncalled-paydown/tail-r5/ratchet-green-baseline25.txt
@@ -3,4 +3,3 @@
       Tests  2 passed (2)
    Start at  17:08:00
    Duration  1.54s (transform 267ms, setup 0ms, import 1.30s, tests 9ms, environment 0ms)
-

--- a/packages/scenario-runner/src/action-effect-ratchet.test.ts
+++ b/packages/scenario-runner/src/action-effect-ratchet.test.ts
@@ -134,7 +134,7 @@ const flagged = SCENARIO_ROOTS.flatMap(walkScenarioFiles)
 // Current debt (theme 3 of #9310 — down from the 104 the issue reported as the
 // corpus has been de-larped). Lower this as actionCalled-only scenarios are given
 // a real effect finalCheck (custom predicate / memory / connector). Never raise.
-const BASELINE = 36;
+const BASELINE = 25;
 
 describe("action-effect ratchet (#9310)", () => {
   it("finds the scenario corpus (guard is actually scanning)", () => {

--- a/packages/test/scenarios/ainex/stand.scenario.ts
+++ b/packages/test/scenarios/ainex/stand.scenario.ts
@@ -15,6 +15,7 @@ import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { WebSocketServer } from "ws";
+import { describeCalls } from "../_helpers/effect-assertions.ts";
 
 const AINEX_STAND = "AINEX_STAND";
 type R = AgentRuntime & {
@@ -22,6 +23,14 @@ type R = AgentRuntime & {
     register: (...f: Array<Record<string, unknown>>) => void;
   };
 };
+
+type BridgeCommandFrame = {
+  command?: string;
+  payload?: Record<string, unknown>;
+};
+
+/** Every CommandEnvelope the mock bridge actually received over the wire. */
+const observedBridgeCommands: BridgeCommandFrame[] = [];
 
 export default scenario({
   lane: "pr-deterministic",
@@ -46,10 +55,14 @@ export default scenario({
         // Every CommandEnvelope is answered with an ok ResponseEnvelope keyed
         // back by request_id. `profile.describe` returns no profile, so the
         // service falls back to the hardcoded Hiwonder descriptor (no throw).
+        observedBridgeCommands.length = 0;
         const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
         wss.on("connection", (socket) => {
           socket.on("message", (raw: Buffer | string) => {
-            let frame: { type?: string; request_id?: string } = {};
+            let frame: {
+              type?: string;
+              request_id?: string;
+            } & BridgeCommandFrame = {};
             try {
               frame = JSON.parse(
                 typeof raw === "string" ? raw : raw.toString("utf8"),
@@ -62,6 +75,10 @@ export default scenario({
               typeof frame.request_id !== "string"
             )
               return;
+            observedBridgeCommands.push({
+              command: frame.command,
+              payload: frame.payload,
+            });
             socket.send(
               JSON.stringify({
                 type: "response",
@@ -187,6 +204,27 @@ export default scenario({
       actionName: AINEX_STAND,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): AINEX_STAND's whole job is one wire command —
+      // `action.play {name:"stand"}` — to the bridge. The seed records every
+      // CommandEnvelope the mock bridge receives; a handler that "succeeds"
+      // without the envelope crossing the socket (or with the wrong action
+      // group) fails here.
+      type: "custom",
+      name: "stand-command-crossed-the-bridge",
+      predicate: (ctx) => {
+        const hit = observedBridgeCommands.find(
+          (frame) =>
+            frame.command === "action.play" && frame.payload?.name === "stand",
+        );
+        if (!hit) {
+          return (
+            `mock bridge never received action.play {name:"stand"}; got ${JSON.stringify(observedBridgeCommands).slice(0, 300)}; ` +
+            `calls: ${describeCalls(ctx)}`
+          );
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/finances/owner-finances-dashboard.scenario.ts
+++ b/packages/test/scenarios/finances/owner-finances-dashboard.scenario.ts
@@ -17,6 +17,11 @@
 import type { AgentRuntime } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulActionData,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 const FINANCES_INPUT = "Pull up my finances dashboard for the last 30 days.";
 const OWNER_FINANCES = "OWNER_FINANCES";
@@ -159,6 +164,35 @@ export default scenario({
       actionName: OWNER_FINANCES,
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the dashboard contract is the composite
+      // payload assembled off the migrated `app_finances` tables —
+      // `data.dashboard` with a numeric spending rollup plus the recurring
+      // and sources collections. A handler that "succeeds" without actually
+      // reading the back-end (missing/partial composite) fails here.
+      type: "custom",
+      name: "finances-dashboard-composite-read",
+      predicate: (ctx) => {
+        const data = successfulActionData(ctx, OWNER_FINANCES);
+        const dashboard = toRecord(data?.dashboard);
+        if (!dashboard) {
+          return `no ${OWNER_FINANCES} result data.dashboard; calls: ${describeCalls(ctx)}`;
+        }
+        const spending = toRecord(dashboard.spending);
+        if (
+          typeof spending?.transactionCount !== "number" ||
+          typeof spending?.windowDays !== "number"
+        ) {
+          return `expected dashboard.spending {transactionCount, windowDays} numbers from the app_finances read, saw ${JSON.stringify(dashboard.spending).slice(0, 200)}`;
+        }
+        if (
+          !Array.isArray(dashboard.recurring) ||
+          !Array.isArray(dashboard.sources)
+        ) {
+          return `expected dashboard.recurring + dashboard.sources arrays, saw keys ${Object.keys(dashboard).join(",")}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.ios-capacitor.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.ios-capacitor.scenario.ts
@@ -38,13 +38,13 @@ export default scenario({
     {
       // Effect proof (#11381): the blocker-planning fallback must carry the
       // two requested apps through the param-resolution pipeline — an
-      // APP_BLOCK call whose payload names neither Instagram nor TikTok
+      // APP_BLOCK call whose payload does not name both Instagram and TikTok
       // proves only that some handler ran, not that this request reached it.
       type: "custom",
       name: "ios-block-payload-names-requested-apps",
       predicate: (ctx) => {
         const blob = callPayloadBlob(ctx, "APP_BLOCK");
-        if (!blob.includes("instagram") && !blob.includes("tiktok")) {
+        if (!blob.includes("instagram") || !blob.includes("tiktok")) {
           return `expected the app-block payload to carry the requested apps (instagram/tiktok), saw: ${blob.slice(0, 300)}`;
         }
       },

--- a/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.ios-capacitor.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.ios-capacitor.scenario.ts
@@ -1,4 +1,5 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { callPayloadBlob } from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -33,6 +34,20 @@ export default scenario({
       type: "actionCalled",
       actionName: "APP_BLOCK",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the blocker-planning fallback must carry the
+      // two requested apps through the param-resolution pipeline — an
+      // APP_BLOCK call whose payload names neither Instagram nor TikTok
+      // proves only that some handler ran, not that this request reached it.
+      type: "custom",
+      name: "ios-block-payload-names-requested-apps",
+      predicate: (ctx) => {
+        const blob = callPayloadBlob(ctx, "APP_BLOCK");
+        if (!blob.includes("instagram") && !blob.includes("tiktok")) {
+          return `expected the app-block payload to carry the requested apps (instagram/tiktok), saw: ${blob.slice(0, 300)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.mobile.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.mobile.scenario.ts
@@ -1,4 +1,5 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { callPayloadBlob } from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -33,6 +34,20 @@ export default scenario({
       type: "actionCalled",
       actionName: "WEBSITE_BLOCK",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the routed call must actually carry the two
+      // requested apps through the param-resolution -> blocker pipeline —
+      // a call whose payload names neither Instagram nor TikTok proves only
+      // that some handler ran, not that this request reached it.
+      type: "custom",
+      name: "mobile-block-payload-names-requested-apps",
+      predicate: (ctx) => {
+        const blob = callPayloadBlob(ctx, "WEBSITE_BLOCK");
+        if (!blob.includes("instagram") && !blob.includes("tiktok")) {
+          return `expected the block payload to carry the requested apps (instagram/tiktok), saw: ${blob.slice(0, 300)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.mobile.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.block-apps.mobile.scenario.ts
@@ -38,13 +38,13 @@ export default scenario({
     {
       // Effect proof (#11381): the routed call must actually carry the two
       // requested apps through the param-resolution -> blocker pipeline —
-      // a call whose payload names neither Instagram nor TikTok proves only
-      // that some handler ran, not that this request reached it.
+      // a call whose payload does not name both Instagram and TikTok proves
+      // only that some handler ran, not that this request reached it.
       type: "custom",
       name: "mobile-block-payload-names-requested-apps",
       predicate: (ctx) => {
         const blob = callPayloadBlob(ctx, "WEBSITE_BLOCK");
-        if (!blob.includes("instagram") && !blob.includes("tiktok")) {
+        if (!blob.includes("instagram") || !blob.includes("tiktok")) {
           return `expected the block payload to carry the requested apps (instagram/tiktok), saw: ${blob.slice(0, 300)}`;
         }
       },

--- a/packages/test/scenarios/selfcontrol/selfcontrol.block-websites.manual-indefinite.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.block-websites.manual-indefinite.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -66,9 +71,37 @@ export default scenario({
       minCount: 1,
     },
     {
-      type: "actionCalled",
-      actionName: "WEBSITE_BLOCK",
-      minCount: 1,
+      // Effect proof (#11381): turn 1 must have ACTIVATED an indefinite
+      // block — a successful result carrying x.com with durationMinutes:null
+      // and no scheduled end — and turn 2 must have actually torn it down
+      // (the unblock result {active:false, canUnblockEarly:true}). Handler
+      // success without those persisted outcomes fails here.
+      type: "custom",
+      name: "manual-block-activated-then-removed",
+      predicate: (ctx) => {
+        const calls = successfulCalls(ctx, "WEBSITE_BLOCK");
+        const activated = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return (
+            data !== null &&
+            data.durationMinutes === null &&
+            data.endsAt === null &&
+            Array.isArray(data.websites) &&
+            data.websites.join(",").includes("x.com") &&
+            !("active" in data)
+          );
+        });
+        if (!activated) {
+          return `no indefinite x.com block activation captured; calls: ${describeCalls(ctx)}`;
+        }
+        const removed = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return data?.active === false && data?.canUnblockEarly === true;
+        });
+        if (!removed) {
+          return `no unblock effect ({active:false, canUnblockEarly:true}) captured; calls: ${describeCalls(ctx)}`;
+        }
+      },
     },
   ],
   cleanup: [

--- a/packages/test/scenarios/selfcontrol/selfcontrol.harsh-mode.no-bypass.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.harsh-mode.no-bypass.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -37,7 +42,13 @@ export default scenario({
       // De-echoed (#9310): the old keywords were echoes of the turn text
       // ("block" even matched turn 2's "unblock"). The reply must confirm the
       // committed, non-overridable state in derived words.
-      responseIncludesAny: ["locked", "blocked", "enforced", "no early", "committed"],
+      responseIncludesAny: [
+        "locked",
+        "blocked",
+        "enforced",
+        "no early",
+        "committed",
+      ],
       responseJudge: {
         minimumScore: 0.7,
         rubric:
@@ -83,6 +94,38 @@ export default scenario({
       actionName: "WEBSITE_BLOCK",
       status: "success",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): turn 1 must have ACTIVATED the harsh block —
+      // a successful result with a non-empty website list and a concrete
+      // scheduled end — and no call anywhere in the run may carry the
+      // unblock effect ({active:false, canUnblockEarly:true}). The bypass
+      // attempt succeeding would fail here even if turn-level gates missed.
+      type: "custom",
+      name: "harsh-block-activated-and-never-lifted",
+      predicate: (ctx) => {
+        const activated = successfulCalls(ctx, "WEBSITE_BLOCK").find((call) => {
+          const data = toRecord(call.result?.data);
+          return (
+            data !== null &&
+            typeof data.endsAt === "string" &&
+            Array.isArray(data.websites) &&
+            data.websites.length > 0 &&
+            !("active" in data)
+          );
+        });
+        if (!activated) {
+          return `no timed harsh block activation captured; calls: ${describeCalls(ctx)}`;
+        }
+        const lifted = ctx.actionsCalled.find((call) => {
+          if (call.actionName !== "WEBSITE_BLOCK") return false;
+          const data = toRecord(call.result?.data);
+          return data?.active === false && data?.canUnblockEarly === true;
+        });
+        if (lifted) {
+          return `harsh block was lifted early during the protected window: ${JSON.stringify(lifted.result?.data).slice(0, 200)}`;
+        }
+      },
     },
   ],
   cleanup: [

--- a/packages/test/scenarios/selfcontrol/selfcontrol.nighttime-wind-down.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.nighttime-wind-down.scenario.ts
@@ -1,4 +1,5 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import { expectNoActionCalled } from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -47,6 +48,16 @@ export default scenario({
       type: "actionCalled",
       actionName: "REPLY",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the clarification contract is a NEGATIVE
+      // side-effect guarantee — no block of any kind may be enforced
+      // anywhere in the run while the agent is still asking which apps to
+      // include. Turn-level forbiddenActions only guards its own turn.
+      type: "custom",
+      name: "no-block-enforced-while-clarifying",
+      predicate: (ctx) =>
+        expectNoActionCalled(ctx, ["APP_BLOCK", "WEBSITE_BLOCK", "BLOCK"]),
     },
   ],
 });

--- a/packages/test/scenarios/selfcontrol/selfcontrol.override-requires-auth.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.override-requires-auth.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -38,6 +43,21 @@ export default scenario({
       type: "actionCalled",
       actionName: "LIST_ACTIVE_BLOCKS",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): "checks active block state" means the
+      // list_active handler actually read the live rule store — its result
+      // must carry the rules array (empty on a fresh runtime). A handler
+      // that "succeeds" without the store read fails here.
+      type: "custom",
+      name: "active-blocks-read-before-answering",
+      predicate: (ctx) => {
+        const call = successfulCalls(ctx, "LIST_ACTIVE_BLOCKS")[0];
+        const data = toRecord(call?.result?.data);
+        if (!data || !Array.isArray(data.rules)) {
+          return `expected LIST_ACTIVE_BLOCKS to return the live rules array; calls: ${describeCalls(ctx)}`;
+        }
+      },
     },
   ],
 });

--- a/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.ambiguous-x.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.ambiguous-x.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -48,6 +53,38 @@ export default scenario({
       type: "actionCalled",
       actionName: "WEBSITE_BLOCK",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): turn 1 must have ACTIVATED the 30-minute
+      // x.com block, and the ambiguous "unblock x" turn must have reached
+      // the unblock path's outcome — a result carrying active:false (either
+      // the removal or the no-active no-op). Routing into a clarifying
+      // question instead of the unblock handler fails here.
+      type: "custom",
+      name: "timed-block-then-unblock-outcome",
+      predicate: (ctx) => {
+        const calls = successfulCalls(ctx, "WEBSITE_BLOCK");
+        const activated = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return (
+            data !== null &&
+            data.durationMinutes === 30 &&
+            Array.isArray(data.websites) &&
+            data.websites.join(",").includes("x.com") &&
+            !("active" in data)
+          );
+        });
+        if (!activated) {
+          return `no 30-minute x.com block activation captured; calls: ${describeCalls(ctx)}`;
+        }
+        const unblockOutcome = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return data?.active === false;
+        });
+        if (!unblockOutcome) {
+          return `no unblock outcome (result carrying active:false) captured; calls: ${describeCalls(ctx)}`;
+        }
+      },
     },
   ],
   cleanup: [

--- a/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.before-scheduled-end.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.before-scheduled-end.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -46,9 +51,37 @@ export default scenario({
       minCount: 1,
     },
     {
-      type: "actionCalled",
-      actionName: "WEBSITE_BLOCK",
-      minCount: 1,
+      // Effect proof (#11381): turn 1 must have ACTIVATED a 30-minute timed
+      // block (durationMinutes:30 with a concrete scheduled end), and turn 2
+      // must have actually removed it early — the unblock result
+      // {active:false, canUnblockEarly:true}. Handler success without both
+      // persisted outcomes fails here.
+      type: "custom",
+      name: "timed-block-activated-then-removed-early",
+      predicate: (ctx) => {
+        const calls = successfulCalls(ctx, "WEBSITE_BLOCK");
+        const activated = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return (
+            data !== null &&
+            data.durationMinutes === 30 &&
+            typeof data.endsAt === "string" &&
+            Array.isArray(data.websites) &&
+            data.websites.join(",").includes("x.com") &&
+            !("active" in data)
+          );
+        });
+        if (!activated) {
+          return `no 30-minute x.com block activation captured; calls: ${describeCalls(ctx)}`;
+        }
+        const removed = calls.find((call) => {
+          const data = toRecord(call.result?.data);
+          return data?.active === false && data?.canUnblockEarly === true;
+        });
+        if (!removed) {
+          return `no early-unblock effect ({active:false, canUnblockEarly:true}) captured; calls: ${describeCalls(ctx)}`;
+        }
+      },
     },
   ],
   cleanup: [

--- a/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.no-active-block.scenario.ts
+++ b/packages/test/scenarios/selfcontrol/selfcontrol.unblock-websites.no-active-block.scenario.ts
@@ -1,4 +1,9 @@
 import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  describeCalls,
+  successfulCalls,
+  toRecord,
+} from "../_helpers/effect-assertions.ts";
 
 export default scenario({
   lane: "live-only",
@@ -36,6 +41,23 @@ export default scenario({
       type: "actionCalled",
       actionName: "WEBSITE_BLOCK",
       minCount: 1,
+    },
+    {
+      // Effect proof (#11381): the unblock handler must have actually read
+      // the live block state and reported the clean no-op — the result
+      // {active:false, canUnblockEarly:false}. A reply-only "nothing is
+      // blocked" without the state read fails here.
+      type: "custom",
+      name: "unblock-noop-reads-empty-block-state",
+      predicate: (ctx) => {
+        const noop = successfulCalls(ctx, "WEBSITE_BLOCK").find((call) => {
+          const data = toRecord(call.result?.data);
+          return data?.active === false && data?.canUnblockEarly === false;
+        });
+        if (!noop) {
+          return `no clean no-op outcome ({active:false, canUnblockEarly:false}) captured; calls: ${describeCalls(ctx)}`;
+        }
+      },
     },
   ],
   cleanup: [


### PR DESCRIPTION
## What

Follow-up tail to merged #11575, landing the round-4 salvage rescued from `rescue/11381-actioncalled-paydown-r4-local` (cut off by the credit wall before that PR merged): **11 more actionCalled-only scenarios get real effect finalChecks**, and `packages/scenario-runner/src/action-effect-ratchet.test.ts` `BASELINE` drops **36 → 25** in lockstep.

- `ainex/stand.scenario.ts` (pr-deterministic) — proves the stand command actually reaches the bridge with the right posture payload, not just that the handler ran.
- `finances/owner-finances-dashboard.scenario.ts` (pr-deterministic) — proves `data.dashboard` is the real composite read off the `app_finances` tables (`spending.transactionCount`/`windowDays` numbers + `recurring`/`sources` arrays).
- 9 × `selfcontrol/*.scenario.ts` (live-only lane) — payload-carries-requested-apps/sites proofs, negative "no block enforced while the agent is still clarifying" guarantees, auth/commitment state reads via the shared `_helpers/effect-assertions.ts` helpers.

## Evidence (PR_EVIDENCE.md) — committed under `.github/issue-evidence/11381-actioncalled-paydown/tail-r5/`

- **Real test output, reviewed by hand**:
  - `ratchet-green-baseline25.txt` — `bun run --cwd packages/scenario-runner test -- src/action-effect-ratchet.test.ts` 2/2 pass at `BASELINE=25`.
  - `ratchet-enumeration-red-baseline0.txt` — same test at `BASELINE=0`: RED, enumerating exactly the 25 remaining offenders (the counting method the ratchet itself uses).
- **Real scenario-runner reports** (keyless deterministic lane, `SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1`):
  - `ainex-stand-deterministic-green.matrix.json` — passed with the new predicate.
  - `finances-dashboard-deterministic-green.matrix.json` — passed; captured action result shows the real dashboard payload the predicate reads.
- **Fail-without-fix proof**: `finances-fail-without-fix-red.matrix.json` — predicate temporarily pointed at `dashboard.spendingWRONGFIELD` → run goes RED with the predicate's own message quoting the real payload; flip reverted before commit.
- **Screenshots / video**: N/A — test-corpus + evidence change only, no UI surface.
- **Real-LLM trajectories**: N/A — no agent/prompt/model behavior change; scenarios exercised on the deterministic keyless lane by design (the live-only selfcontrol lane needs a physical blocker device and is validated statically by the ratchet enumeration).

## Verification

- `bunx biome check` clean on all touched files.
- Ratchet suite green in-package (`packages/scenario-runner`).
- Both touched pr-deterministic scenarios run green end-to-end on the keyless lane.

Refs #11381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
