### PR TITLE
fix(plugin-local-inference): retry timed-out boot GPU probe once for RTD3 cold wake + real-hardware degradation evidence (#11339)

### DIFF
--- a/.github/issue-evidence/11339-cuda-embedding-probe/README.md
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/README.md
@@ -1,0 +1,94 @@
+# #11339 — CUDA embedding hardware-probe validation (RTX 5080 Laptop, driver 595.71.05)
+
+Host: `BEAST` — Linux x86_64, 24 cores, 30.7 GB RAM, NVIDIA GeForce RTX 5080
+Laptop GPU 16 GB (PCI `0000:02:00.0`), driver/GSP firmware **595.71.05**,
+RTD3 fine-grained runtime PM enabled.
+
+## What happened on this host (root cause, `logs/00-kernel-gpu-wedge.log`)
+
+During this validation campaign the GPU **really failed** — not simulated:
+
+1. Under host RAM pressure (~4.6 GB free), the driver's runtime-suspend loop
+   repeatedly failed with `NVRM ... Out of memory [NV_ERR_NO_MEMORY]` while
+   cycling D3cold wake/suspend (`Enabling HDA controller` every ~30 s).
+2. At `15:08:21` the GSP unload timed out
+   (`kflcnWaitForHaltRiscv_GA102: Timeout waiting for RISC-V to halt`,
+   `gpuPowerManagementEnter: GSP unload failed at suspend`,
+   `can't suspend (nv_pmops_runtime_suspend returned -5)`).
+3. The device's kernel runtime-PM state is now `error`
+   (`/sys/bus/pci/devices/0000:02:00.0/power/runtime_status` → `error`);
+   every `nvidia-smi` fails **fast** with exit 6:
+   `Unable to determine the device handle for GPU0: ... Unknown Error`.
+   Recovery requires a driver rebind or reboot (root); it does not self-heal.
+
+This turned the lane into a live fire drill for exactly the property #11339
+demands: **graceful CPU degradation when CUDA is present but unusable.**
+
+## Captures
+
+| Log | What it proves |
+| --- | --- |
+| `logs/00-kernel-gpu-wedge.log` | Kernel NVRM trace of the real GPU failure + `nvidia-smi` exit 6 + PM `error` state. |
+| `logs/01-probe-hardware.log` | `probeHardware()` (the exact probe `configureLocalEmbeddingPlugin()` awaits at boot) on the wedged host: `gpu: null` → `selectEmbeddingTierFromHardware()` → `fallback` → CPU preset (`gpuLayers: 0`). No crash — the selection degrades. Captured while free RAM was 4.6 GB (the pressure that triggered the wedge). |
+| `logs/02-embed-throughput-cpu-lib.log` | REAL gte-small load + embeddings through the fused `libelizainference` (CPU-only staged lib), `harness/embed-throughput.ts`. Positive per-layer proof: `load_tensors: layer N assigned to device CPU` for all layers. 64 embeds → **21.3 embeddings/sec, 46.9 ms/embed, dim 384, norm 1.0** (first run, cold page cache: 4.3/sec). |
+| `logs/03-embed-cuda-lib-broken-driver.log` | REAL detected-but-unusable degradation: the **CUDA-built** fused lib (linked against `libggml-cuda` / `libcudart` / `libcuda`) loading gte-small with the default full-offload request (`n_gpu_layers=99`) on the wedged driver. `ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected` → **every layer falls back to `assigned to device CPU`** → embeddings still produced (7.6 embeddings/sec), exit 0, **no crash**. |
+
+Harnesses (run from repo root, see file headers):
+
+```
+bun --conditions=eliza-source .github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
+ELIZA_INFERENCE_LIBRARY=<lib> bun --conditions=eliza-source .github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
+```
+
+`embed-throughput.ts` drives the same modules the desktop TEXT_EMBEDDING
+handler (`makeFusedEmbeddingHandler`) uses: `resolveFusedLibraryPath` →
+`loadElizaInferenceFfi` → `ffi.create(<embed bundle>)` →
+`eliza_inference_embed` (MEAN pooling), with the gte-small GGUF staged the way
+`resolveFusedEmbedBundleRoot` stages it.
+
+## Probe fix shipped with this evidence
+
+`plugins/plugin-local-inference/src/services/gpu-detect.ts` — the boot probe
+runs `nvidia-smi` with a 3 s timeout and caches the result for the process
+lifetime. On RTD3 laptops the first `nvidia-smi` after GPU sleep must
+cold-wake the card, which can exceed 3 s — a timeout-killed first call would
+cache `gpu: null` and wrongly demote embeddings to the CPU tier permanently.
+The probe now retries **once** with a 15 s deadline when (and only when) the
+first call was killed by its timeout (`error.code === "ETIMEDOUT"`, verified
+identical on Node 25.2 and Bun 1.4). Fast nonzero exits (this host's PM-error
+state) and ENOENT are *not* retried — they are real "no usable GPU" answers.
+Contract pinned in `src/services/gpu-detect.test.ts` (7 tests, including the
+exact exit-6 shape this host produced).
+
+## Validation finding (out of scope to fix here)
+
+The preset/env `gpuLayers` is **not threaded into the fused desktop embed
+load**: `resolveDesktopEmbeddingConfig()` computes `gpuLayers` (from
+`LOCAL_EMBEDDING_GPU_LAYERS` / the tier preset) but `getFusedEmbeddingHandle()`
+never passes it — the native `eliza_inference_embed`
+(`native/llama.cpp/tools/omnivoice/src/eliza-inference-ffi.cpp`) hard-codes
+`eliza_load_llm_model_locked(ctx, /* n_gpu_layers= */ -1, ...)`, which resolves
+via `ELIZA_LLM_USE_GPU` (default **true** → 99 layers). Consequences:
+
+- the CPU-tier selection (`gpuLayers: 0`) does not actually pin the fused
+  desktop embed load to CPU — degradation currently relies on ggml's own
+  device fallback (which log 03 proves works when CUDA init fails), and
+- an operator's `LOCAL_EMBEDDING_GPU_LAYERS=0` is silently ignored on this
+  path (`ELIZA_LLM_USE_GPU=0` is the knob that actually reaches the load).
+
+Fixing this needs an additive fused-lib ABI change (per-ctx embed gpu-layers
+setter) + rebuild of shipped libs — tracked as a follow-up on the issue.
+
+## Blocked residual (requires reboot of this host)
+
+The **accelerated** capture — gte-small layers assigned to CUDA + CPU-vs-CUDA
+embeddings/sec — cannot be produced while the driver is in PM `error` state.
+Re-capture after reboot with:
+
+```
+ELIZA_INFERENCE_LIBRARY=plugins/plugin-local-inference/native/llama.cpp/build-desktop-cuda/bin/libelizainference.so \
+  bun --conditions=eliza-source .github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
+```
+
+Expected: `load_tensors: layer N assigned to device CUDA0` lines and a large
+throughput multiple over the 21.3 embeddings/sec CPU baseline.

--- a/.github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
@@ -37,23 +37,23 @@ const MODEL = "gte-small_fp16.gguf";
 const POOLING_MEAN = 1;
 
 function stageEmbedBundle(): string {
-	const modelsDir = path.join(resolveStateDir(), "models");
-	const modelPath = path.join(modelsDir, MODEL);
-	if (!existsSync(modelPath)) {
-		throw new Error(`embedding GGUF missing: ${modelPath}`);
-	}
-	const root = path.join(modelsDir, ".eliza-embed-bundle");
-	const textDir = path.join(root, "text");
-	const staged = path.join(textDir, MODEL);
-	mkdirSync(textDir, { recursive: true });
-	if (!existsSync(staged)) {
-		try {
-			linkSync(modelPath, staged);
-		} catch {
-			symlinkSync(modelPath, staged);
-		}
-	}
-	return root;
+  const modelsDir = path.join(resolveStateDir(), "models");
+  const modelPath = path.join(modelsDir, MODEL);
+  if (!existsSync(modelPath)) {
+    throw new Error(`embedding GGUF missing: ${modelPath}`);
+  }
+  const root = path.join(modelsDir, ".eliza-embed-bundle");
+  const textDir = path.join(root, "text");
+  const staged = path.join(textDir, MODEL);
+  mkdirSync(textDir, { recursive: true });
+  if (!existsSync(staged)) {
+    try {
+      linkSync(modelPath, staged);
+    } catch {
+      symlinkSync(modelPath, staged);
+    }
+  }
+  return root;
 }
 
 const bundleRoot = stageEmbedBundle();
@@ -61,49 +61,59 @@ const libPath = resolveFusedLibraryPath(bundleRoot);
 if (!libPath) throw new Error("no fused libelizainference resolved");
 console.log(`[harness] lib under test: ${libPath}`);
 console.log(`[harness] embed bundle root: ${bundleRoot}`);
-console.log(`[harness] ELIZA_LLM_USE_GPU=${process.env.ELIZA_LLM_USE_GPU ?? "(unset — defaults to GPU offload, n_gpu_layers=99)"}`);
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: evidence harness records the native knob under test.
+const elizaLlmUseGpu = process.env.ELIZA_LLM_USE_GPU;
+console.log(
+  `[harness] ELIZA_LLM_USE_GPU=${elizaLlmUseGpu ?? "(unset — defaults to GPU offload, n_gpu_layers=99)"}`,
+);
 
 const ffi = loadElizaInferenceFfi(libPath);
 if (ffi.embedSupported?.() !== true || typeof ffi.embed !== "function") {
-	throw new Error("lib does not wire eliza_inference_embed (pre-v9 ABI?)");
+  throw new Error("lib does not wire eliza_inference_embed (pre-v9 ABI?)");
 }
 const ctx = ffi.create(bundleRoot);
 
 // First embed triggers the real model load (eliza_load_llm_model_locked) —
 // time it separately. llama.cpp prints device/buffer assignment to stderr.
 const loadStart = performance.now();
-const first = ffi.embed({ ctx, text: "warmup: the quick brown fox", pooling: POOLING_MEAN });
+const first = ffi.embed({
+  ctx,
+  text: "warmup: the quick brown fox",
+  pooling: POOLING_MEAN,
+});
 const loadMs = performance.now() - loadStart;
 const norm = Math.sqrt(first.reduce((s, v) => s + v * v, 0));
 console.log(
-	`[harness] first embed (includes model load): ${loadMs.toFixed(0)} ms; ` +
-		`dim=${first.length} norm=${norm.toFixed(4)} head=[${Array.from(first.slice(0, 8))
-			.map((v) => v.toFixed(4))
-			.join(", ")}]`,
+  `[harness] first embed (includes model load): ${loadMs.toFixed(0)} ms; ` +
+    `dim=${first.length} norm=${norm.toFixed(4)} head=[${Array.from(
+      first.slice(0, 8),
+    )
+      .map((v) => v.toFixed(4))
+      .join(", ")}]`,
 );
 
 const texts: string[] = [];
 for (let i = 0; i < 64; i++) {
-	texts.push(
-		`Document ${i}: elizaOS runs local embeddings through the fused libelizainference ` +
-			`FFI over a dedicated gte-small bundle; this sentence exists to give the encoder ` +
-			`a realistic mixed-length workload for throughput measurement (${"x".repeat(i % 17)}).`,
-	);
+  texts.push(
+    `Document ${i}: elizaOS runs local embeddings through the fused libelizainference ` +
+      `FFI over a dedicated gte-small bundle; this sentence exists to give the encoder ` +
+      `a realistic mixed-length workload for throughput measurement (${"x".repeat(i % 17)}).`,
+  );
 }
 const batchStart = performance.now();
 let dims = 0;
 for (const text of texts) {
-	const v = ffi.embed({ ctx, text, pooling: POOLING_MEAN });
-	dims = v.length;
+  const v = ffi.embed({ ctx, text, pooling: POOLING_MEAN });
+  dims = v.length;
 }
 const batchMs = performance.now() - batchStart;
 const perEmbed = batchMs / texts.length;
 const totalChars = texts.reduce((s, t) => s + t.length, 0);
 console.log(
-	`[harness] ${texts.length} embeds in ${batchMs.toFixed(0)} ms — ` +
-		`${((texts.length / batchMs) * 1000).toFixed(1)} embeddings/sec, ` +
-		`${perEmbed.toFixed(1)} ms/embed, dim=${dims}, ` +
-		`~${(((totalChars / 4) / batchMs) * 1000).toFixed(0)} tok/s (chars/4 estimate)`,
+  `[harness] ${texts.length} embeds in ${batchMs.toFixed(0)} ms — ` +
+    `${((texts.length / batchMs) * 1000).toFixed(1)} embeddings/sec, ` +
+    `${perEmbed.toFixed(1)} ms/embed, dim=${dims}, ` +
+    `~${((totalChars / 4 / batchMs) * 1000).toFixed(0)} tok/s (chars/4 estimate)`,
 );
 
 ffi.destroy(ctx);

--- a/.github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #11339 evidence harness — step 2: REAL fused embedding load + throughput.
+ *
+ * Drives the exact modules the desktop TEXT_EMBEDDING handler
+ * (`makeFusedEmbeddingHandler` in
+ * plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts)
+ * uses at runtime:
+ *
+ *   resolveFusedLibraryPath()  -> the fused `libelizainference` on disk
+ *   loadElizaInferenceFfi()    -> bun:ffi handle over the lib
+ *   ffi.create(bundleRoot)     -> context anchored at the isolated embed bundle
+ *   ffi.embed({ctx,text,pooling}) -> eliza_inference_embed (gte-small, MEAN pooling)
+ *
+ * The bundle staging below mirrors `resolveFusedEmbedBundleRoot()` (hardlink of
+ * the dedicated gte-small GGUF as the sole `<root>/text/` entry).
+ *
+ * llama.cpp's model-load log lines (device/buffer assignment, e.g.
+ * "load_tensors: ...") print to stderr — capture them; they are the positive
+ * offload/CPU proof the issue demands (not the absence of a banner).
+ *
+ * Select the library under test with ELIZA_INFERENCE_LIBRARY:
+ *   - CPU-only staged lib:   ~/.local/state/eliza/local-inference/lib/libelizainference.so
+ *   - CUDA desktop build:    plugins/plugin-local-inference/native/llama.cpp/build-desktop-cuda/bin/libelizainference.so
+ *
+ * Run from the repo root:
+ *   ELIZA_INFERENCE_LIBRARY=<lib> bun --conditions=eliza-source \
+ *     .github/issue-evidence/11339-cuda-embedding-probe/harness/embed-throughput.ts
+ */
+import { existsSync, linkSync, mkdirSync, symlinkSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { resolveStateDir } from "@elizaos/core";
+import { resolveFusedLibraryPath } from "../../../../plugins/plugin-local-inference/src/services/desktop-fused-ffi-backend-runtime";
+import { loadElizaInferenceFfi } from "../../../../plugins/plugin-local-inference/src/services/voice/ffi-bindings";
+
+const MODEL = "gte-small_fp16.gguf";
+const POOLING_MEAN = 1;
+
+function stageEmbedBundle(): string {
+	const modelsDir = path.join(resolveStateDir(), "models");
+	const modelPath = path.join(modelsDir, MODEL);
+	if (!existsSync(modelPath)) {
+		throw new Error(`embedding GGUF missing: ${modelPath}`);
+	}
+	const root = path.join(modelsDir, ".eliza-embed-bundle");
+	const textDir = path.join(root, "text");
+	const staged = path.join(textDir, MODEL);
+	mkdirSync(textDir, { recursive: true });
+	if (!existsSync(staged)) {
+		try {
+			linkSync(modelPath, staged);
+		} catch {
+			symlinkSync(modelPath, staged);
+		}
+	}
+	return root;
+}
+
+const bundleRoot = stageEmbedBundle();
+const libPath = resolveFusedLibraryPath(bundleRoot);
+if (!libPath) throw new Error("no fused libelizainference resolved");
+console.log(`[harness] lib under test: ${libPath}`);
+console.log(`[harness] embed bundle root: ${bundleRoot}`);
+console.log(`[harness] ELIZA_LLM_USE_GPU=${process.env.ELIZA_LLM_USE_GPU ?? "(unset — defaults to GPU offload, n_gpu_layers=99)"}`);
+
+const ffi = loadElizaInferenceFfi(libPath);
+if (ffi.embedSupported?.() !== true || typeof ffi.embed !== "function") {
+	throw new Error("lib does not wire eliza_inference_embed (pre-v9 ABI?)");
+}
+const ctx = ffi.create(bundleRoot);
+
+// First embed triggers the real model load (eliza_load_llm_model_locked) —
+// time it separately. llama.cpp prints device/buffer assignment to stderr.
+const loadStart = performance.now();
+const first = ffi.embed({ ctx, text: "warmup: the quick brown fox", pooling: POOLING_MEAN });
+const loadMs = performance.now() - loadStart;
+const norm = Math.sqrt(first.reduce((s, v) => s + v * v, 0));
+console.log(
+	`[harness] first embed (includes model load): ${loadMs.toFixed(0)} ms; ` +
+		`dim=${first.length} norm=${norm.toFixed(4)} head=[${Array.from(first.slice(0, 8))
+			.map((v) => v.toFixed(4))
+			.join(", ")}]`,
+);
+
+const texts: string[] = [];
+for (let i = 0; i < 64; i++) {
+	texts.push(
+		`Document ${i}: elizaOS runs local embeddings through the fused libelizainference ` +
+			`FFI over a dedicated gte-small bundle; this sentence exists to give the encoder ` +
+			`a realistic mixed-length workload for throughput measurement (${"x".repeat(i % 17)}).`,
+	);
+}
+const batchStart = performance.now();
+let dims = 0;
+for (const text of texts) {
+	const v = ffi.embed({ ctx, text, pooling: POOLING_MEAN });
+	dims = v.length;
+}
+const batchMs = performance.now() - batchStart;
+const perEmbed = batchMs / texts.length;
+const totalChars = texts.reduce((s, t) => s + t.length, 0);
+console.log(
+	`[harness] ${texts.length} embeds in ${batchMs.toFixed(0)} ms — ` +
+		`${((texts.length / batchMs) * 1000).toFixed(1)} embeddings/sec, ` +
+		`${perEmbed.toFixed(1)} ms/embed, dim=${dims}, ` +
+		`~${(((totalChars / 4) / batchMs) * 1000).toFixed(0)} tok/s (chars/4 estimate)`,
+);
+
+ffi.destroy(ctx);
+ffi.close();
+console.log("[harness] done");

--- a/.github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
@@ -10,11 +10,12 @@
  * Run from the repo root:
  *   bun --conditions=eliza-source .github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
  */
-import { probeHardware } from "@elizaos/plugin-local-inference/services";
+
 import {
-	selectEmbeddingPresetFromHardware,
-	selectEmbeddingTierFromHardware,
+  selectEmbeddingPresetFromHardware,
+  selectEmbeddingTierFromHardware,
 } from "@elizaos/plugin-local-inference/runtime/embedding-presets";
+import { probeHardware } from "@elizaos/plugin-local-inference/services";
 
 const hardware = await probeHardware();
 console.log("=== probeHardware() typed output ===");

--- a/.github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #11339 evidence harness — step 1: the REAL typed hardware probe.
+ *
+ * Runs the exact `probeHardware()` that `configureLocalEmbeddingPlugin()`
+ * (packages/agent/src/runtime/eliza.ts) awaits at boot, then feeds the typed
+ * probe into the exact `selectEmbeddingTierFromHardware()` /
+ * `selectEmbeddingPresetFromHardware()` selection that #10812 flipped to be
+ * hardware-probe driven.
+ *
+ * Run from the repo root:
+ *   bun --conditions=eliza-source .github/issue-evidence/11339-cuda-embedding-probe/harness/probe-hardware.ts
+ */
+import { probeHardware } from "@elizaos/plugin-local-inference/services";
+import {
+	selectEmbeddingPresetFromHardware,
+	selectEmbeddingTierFromHardware,
+} from "@elizaos/plugin-local-inference/runtime/embedding-presets";
+
+const hardware = await probeHardware();
+console.log("=== probeHardware() typed output ===");
+console.log(JSON.stringify(hardware, null, 2));
+
+const tier = selectEmbeddingTierFromHardware(hardware);
+const preset = selectEmbeddingPresetFromHardware(hardware);
+console.log("\n=== selectEmbeddingTierFromHardware(hardware) ===");
+console.log(tier);
+console.log("\n=== selectEmbeddingPresetFromHardware(hardware) ===");
+console.log(JSON.stringify(preset, null, 2));

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/00-kernel-gpu-wedge.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/00-kernel-gpu-wedge.log
@@ -1,0 +1,18 @@
+Jul 02 15:05:15 BEAST kernel: nvidia 0000:02:00.0: Enabling HDA controller
+Jul 02 15:05:38 BEAST kernel: NVRM: nvCheckOkFailedNoLog: Check failed: Out of memory [NV_ERR_NO_MEMORY] (0x00000051) returned from _memdescAllocInternal(pMemDesc) @ mem_desc.c:1336
+Jul 02 15:06:21 BEAST kernel: nvidia 0000:02:00.0: Enabling HDA controller
+Jul 02 15:06:43 BEAST kernel: NVRM: nvCheckOkFailedNoLog: Check failed: Out of memory [NV_ERR_NO_MEMORY] (0x00000051) returned from _memdescAllocInternal(pMemDesc) @ mem_desc.c:1336
+Jul 02 15:07:51 BEAST kernel: nvidia 0000:02:00.0: Enabling HDA controller
+Jul 02 15:08:20 BEAST kernel: NVRM: nvCheckOkFailedNoLog: Check failed: Out of memory [NV_ERR_NO_MEMORY] (0x00000051) returned from _memdescAllocInternal(pMemDesc) @ mem_desc.c:1336
+Jul 02 15:08:21 BEAST kernel: NVRM: _threadNodeCheckTimeout: _threadNodeCheckTimeout: currentTime: f82490ba13e80 >= f8247fea25440
+Jul 02 15:08:21 BEAST kernel: NVRM: _threadNodeCheckTimeout: _threadNodeCheckTimeout: Timeout was set to: 4000 msecs!
+Jul 02 15:08:21 BEAST kernel: NVRM: _threadNodeCheckTimeout: _threadNodeCheckTimeout: currentTime: f82490ba13e80 >= f8247fea25440
+Jul 02 15:08:21 BEAST kernel: NVRM: _threadNodeCheckTimeout: _threadNodeCheckTimeout: Timeout was set to: 4000 msecs!
+Jul 02 15:08:21 BEAST kernel: NVRM: kflcnWaitForHaltRiscv_GA102: Timeout waiting for RISC-V to halt
+Jul 02 15:08:21 BEAST kernel: NVRM: gpuPowerManagementEnter: GSP unload failed at suspend (bootMode 0x1, newLevel 0x3): 0x65
+Jul 02 15:08:21 BEAST kernel: nvidia 0000:02:00.0: can't suspend (nv_pmops_runtime_suspend [nvidia] returned -5)
+Jul 02 15:11:54 BEAST kernel: NVRM: Error in service of callback 
+Unable to determine the device handle for GPU0: 0000:02:00.0: Unknown Error
+No devices were found
+nvidia-smi exit=6 (captured Thu Jul  2 05:13:28 PM PDT 2026)
+error

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/00-kernel-gpu-wedge.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/00-kernel-gpu-wedge.log
@@ -11,7 +11,7 @@ Jul 02 15:08:21 BEAST kernel: NVRM: _threadNodeCheckTimeout: _threadNodeCheckTim
 Jul 02 15:08:21 BEAST kernel: NVRM: kflcnWaitForHaltRiscv_GA102: Timeout waiting for RISC-V to halt
 Jul 02 15:08:21 BEAST kernel: NVRM: gpuPowerManagementEnter: GSP unload failed at suspend (bootMode 0x1, newLevel 0x3): 0x65
 Jul 02 15:08:21 BEAST kernel: nvidia 0000:02:00.0: can't suspend (nv_pmops_runtime_suspend [nvidia] returned -5)
-Jul 02 15:11:54 BEAST kernel: NVRM: Error in service of callback 
+Jul 02 15:11:54 BEAST kernel: NVRM: Error in service of callback
 Unable to determine the device handle for GPU0: 0000:02:00.0: Unknown Error
 No devices were found
 nvidia-smi exit=6 (captured Thu Jul  2 05:13:28 PM PDT 2026)

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/01-probe-hardware.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/01-probe-hardware.log
@@ -1,0 +1,55 @@
+=== probeHardware() typed output ===
+{
+  "totalRamGb": 30.7,
+  "freeRamGb": 4.6,
+  "freeDiskGb": 542.7,
+  "gpu": null,
+  "cpuCores": 24,
+  "platform": "linux",
+  "arch": "x64",
+  "appleSilicon": false,
+  "recommendedBucket": "mid",
+  "source": "os-fallback",
+  "openvino": {
+    "runtimeAvailable": false,
+    "devices": [],
+    "gpu": {
+      "renderNodes": [
+        "/dev/dri/renderD129",
+        "/dev/dri/renderD128"
+      ],
+      "computeRuntimeReady": false,
+      "missingLinuxPackages": [
+        "intel-opencl-icd",
+        "libigc2",
+        "libigdfcl2"
+      ]
+    },
+    "npu": {
+      "accelNodes": [
+        "/dev/accel/accel0"
+      ]
+    },
+    "recommendedAsrDevice": null,
+    "warnings": [
+      "OpenVINO GPU needs Intel Compute Runtime packages: intel-opencl-icd, libigc2, libigdfcl2",
+      "Intel accelerator nodes are present, but OpenVINO Runtime was not found; source setupvars.sh or set OpenVINO_DIR."
+    ]
+  }
+}
+
+=== selectEmbeddingTierFromHardware(hardware) ===
+fallback
+
+=== selectEmbeddingPresetFromHardware(hardware) ===
+{
+  "tier": "fallback",
+  "label": "Efficient (CPU)",
+  "description": "gte-small local embeddings for Intel Macs and low-RAM machines",
+  "model": "gte-small_fp16.gguf",
+  "modelRepo": "ChristianAzinn/gte-small-gguf",
+  "dimensions": 384,
+  "gpuLayers": 0,
+  "contextSize": 512,
+  "downloadSizeMB": 64
+}

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/02-embed-throughput-cpu-lib.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/02-embed-throughput-cpu-lib.log
@@ -1,0 +1,484 @@
+[harness] lib under test: /home/shaw/.local/state/eliza/local-inference/lib/libelizainference.so
+[harness] embed bundle root: /home/shaw/.local/state/eliza/models/.eliza-embed-bundle
+[harness] ELIZA_LLM_USE_GPU=(unset — defaults to GPU offload, n_gpu_layers=99)
+llama_model_loader: loaded meta data with 23 key-value pairs and 197 tensors from /home/shaw/.local/state/eliza/models/.eliza-embed-bundle/text/gte-small_fp16.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = bert
+llama_model_loader: - kv   1:                               general.name str              = gte-small
+llama_model_loader: - kv   2:                           bert.block_count u32              = 12
+llama_model_loader: - kv   3:                        bert.context_length u32              = 512
+llama_model_loader: - kv   4:                      bert.embedding_length u32              = 384
+llama_model_loader: - kv   5:                   bert.feed_forward_length u32              = 1536
+llama_model_loader: - kv   6:                  bert.attention.head_count u32              = 12
+llama_model_loader: - kv   7:          bert.attention.layer_norm_epsilon f32              = 0.000000
+llama_model_loader: - kv   8:                          general.file_type u32              = 1
+llama_model_loader: - kv   9:                      bert.attention.causal bool             = false
+llama_model_loader: - kv  10:                          bert.pooling_type u32              = 1
+llama_model_loader: - kv  11:            tokenizer.ggml.token_type_count u32              = 2
+llama_model_loader: - kv  12:                tokenizer.ggml.bos_token_id u32              = 101
+llama_model_loader: - kv  13:                tokenizer.ggml.eos_token_id u32              = 102
+llama_model_loader: - kv  14:                       tokenizer.ggml.model str              = bert
+llama_model_loader: - kv  15:                      tokenizer.ggml.tokens arr[str,30522]   = ["[PAD]", "[unused0]", "[unused1]", "...
+llama_model_loader: - kv  16:                      tokenizer.ggml.scores arr[f32,30522]   = [-1000.000000, -1000.000000, -1000.00...
+llama_model_loader: - kv  17:                  tokenizer.ggml.token_type arr[i32,30522]   = [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  18:            tokenizer.ggml.unknown_token_id u32              = 100
+llama_model_loader: - kv  19:          tokenizer.ggml.seperator_token_id u32              = 102
+llama_model_loader: - kv  20:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  21:                tokenizer.ggml.cls_token_id u32              = 101
+llama_model_loader: - kv  22:               tokenizer.ggml.mask_token_id u32              = 103
+llama_model_loader: - type  f32:  123 tensors
+llama_model_loader: - type  f16:   74 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = F16
+print_info: file size   = 63.46 MiB (16.03 BPW) 
+init_tokenizer: initializing tokenizer for type 3
+load: 0 unused tokens
+load: control token:    101 '[CLS]' is not marked as EOG
+load: control token:    103 '[MASK]' is not marked as EOG
+load: control token:    100 '[UNK]' is not marked as EOG
+load: control token:    102 '[SEP]' is not marked as EOG
+load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+load: printing all EOG tokens:
+load:   - 0 ('[PAD]')
+load:   - 102 ('[SEP]')
+load: special tokens cache size = 5
+load: token to piece cache size = 0.2032 MB
+print_info: arch                  = bert
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 512
+print_info: n_embd_inp            = 384
+print_info: n_embd                = 384
+print_info: n_embd_out            = 384
+print_info: n_layer               = 12
+print_info: n_layer_all           = 12
+print_info: n_head                = 12
+print_info: n_head_kv             = 12
+print_info: n_rot                 = 32
+print_info: n_swa                 = 0
+print_info: is_swa_any            = 0
+print_info: n_embd_head_k         = 32
+print_info: n_embd_head_v         = 32
+print_info: n_gqa                 = 1
+print_info: n_embd_k_gqa          = 384
+print_info: n_embd_v_gqa          = 384
+print_info: f_norm_eps            = 1.0e-12
+print_info: f_norm_rms_eps        = 0.0e+00
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 0.0e+00
+print_info: f_attn_value_scale    = 0.0000
+print_info: n_ff                  = 1536
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 0
+print_info: pooling type          = 1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 10000.0
+print_info: freq_scale_train      = 1
+print_info: n_ctx_orig_yarn       = 512
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = 33M
+print_info: model params          = 33.21 M
+print_info: general.name          = gte-small
+print_info: vocab type            = WPM
+print_info: n_vocab               = 30522
+print_info: n_merges              = 0
+print_info: BOS token             = 101 '[CLS]'
+print_info: EOS token             = 102 '[SEP]'
+print_info: UNK token             = 100 '[UNK]'
+print_info: SEP token             = 102 '[SEP]'
+print_info: PAD token             = 0 '[PAD]'
+print_info: MASK token            = 103 '[MASK]'
+print_info: LF token              = 0 '[PAD]'
+print_info: FIM PAD token         = 0 '[PAD]'
+print_info: EOG token             = 0 '[PAD]'
+print_info: EOG token             = 102 '[SEP]'
+print_info: max token length      = 21
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: layer   0 assigned to device CPU, is_swa = 0
+load_tensors: layer   1 assigned to device CPU, is_swa = 0
+load_tensors: layer   2 assigned to device CPU, is_swa = 0
+load_tensors: layer   3 assigned to device CPU, is_swa = 0
+load_tensors: layer   4 assigned to device CPU, is_swa = 0
+load_tensors: layer   5 assigned to device CPU, is_swa = 0
+load_tensors: layer   6 assigned to device CPU, is_swa = 0
+load_tensors: layer   7 assigned to device CPU, is_swa = 0
+load_tensors: layer   8 assigned to device CPU, is_swa = 0
+load_tensors: layer   9 assigned to device CPU, is_swa = 0
+load_tensors: layer  10 assigned to device CPU, is_swa = 0
+load_tensors: layer  11 assigned to device CPU, is_swa = 0
+load_tensors: layer  12 assigned to device CPU, is_swa = 0
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor token_types.weight
+create_tensor: loading tensor position_embd.weight
+create_tensor: loading tensor token_embd_norm.weight
+create_tensor: loading tensor token_embd_norm.bias
+create_tensor: loading tensor blk.0.attn_q.weight
+create_tensor: loading tensor blk.0.attn_k.weight
+create_tensor: loading tensor blk.0.attn_v.weight
+create_tensor: loading tensor blk.0.attn_q.bias
+create_tensor: loading tensor blk.0.attn_k.bias
+create_tensor: loading tensor blk.0.attn_v.bias
+create_tensor: loading tensor blk.0.attn_output.weight
+create_tensor: loading tensor blk.0.attn_output.bias
+create_tensor: loading tensor blk.0.attn_output_norm.weight
+create_tensor: loading tensor blk.0.attn_output_norm.bias
+create_tensor: loading tensor blk.0.ffn_up.weight
+create_tensor: loading tensor blk.0.ffn_up.bias
+create_tensor: loading tensor blk.0.ffn_down.weight
+create_tensor: loading tensor blk.0.ffn_down.bias
+create_tensor: loading tensor blk.0.layer_output_norm.weight
+create_tensor: loading tensor blk.0.layer_output_norm.bias
+create_tensor: loading tensor blk.1.attn_q.weight
+create_tensor: loading tensor blk.1.attn_k.weight
+create_tensor: loading tensor blk.1.attn_v.weight
+create_tensor: loading tensor blk.1.attn_q.bias
+create_tensor: loading tensor blk.1.attn_k.bias
+create_tensor: loading tensor blk.1.attn_v.bias
+create_tensor: loading tensor blk.1.attn_output.weight
+create_tensor: loading tensor blk.1.attn_output.bias
+create_tensor: loading tensor blk.1.attn_output_norm.weight
+create_tensor: loading tensor blk.1.attn_output_norm.bias
+create_tensor: loading tensor blk.1.ffn_up.weight
+create_tensor: loading tensor blk.1.ffn_up.bias
+create_tensor: loading tensor blk.1.ffn_down.weight
+create_tensor: loading tensor blk.1.ffn_down.bias
+create_tensor: loading tensor blk.1.layer_output_norm.weight
+create_tensor: loading tensor blk.1.layer_output_norm.bias
+create_tensor: loading tensor blk.2.attn_q.weight
+create_tensor: loading tensor blk.2.attn_k.weight
+create_tensor: loading tensor blk.2.attn_v.weight
+create_tensor: loading tensor blk.2.attn_q.bias
+create_tensor: loading tensor blk.2.attn_k.bias
+create_tensor: loading tensor blk.2.attn_v.bias
+create_tensor: loading tensor blk.2.attn_output.weight
+create_tensor: loading tensor blk.2.attn_output.bias
+create_tensor: loading tensor blk.2.attn_output_norm.weight
+create_tensor: loading tensor blk.2.attn_output_norm.bias
+create_tensor: loading tensor blk.2.ffn_up.weight
+create_tensor: loading tensor blk.2.ffn_up.bias
+create_tensor: loading tensor blk.2.ffn_down.weight
+create_tensor: loading tensor blk.2.ffn_down.bias
+create_tensor: loading tensor blk.2.layer_output_norm.weight
+create_tensor: loading tensor blk.2.layer_output_norm.bias
+create_tensor: loading tensor blk.3.attn_q.weight
+create_tensor: loading tensor blk.3.attn_k.weight
+create_tensor: loading tensor blk.3.attn_v.weight
+create_tensor: loading tensor blk.3.attn_q.bias
+create_tensor: loading tensor blk.3.attn_k.bias
+create_tensor: loading tensor blk.3.attn_v.bias
+create_tensor: loading tensor blk.3.attn_output.weight
+create_tensor: loading tensor blk.3.attn_output.bias
+create_tensor: loading tensor blk.3.attn_output_norm.weight
+create_tensor: loading tensor blk.3.attn_output_norm.bias
+create_tensor: loading tensor blk.3.ffn_up.weight
+create_tensor: loading tensor blk.3.ffn_up.bias
+create_tensor: loading tensor blk.3.ffn_down.weight
+create_tensor: loading tensor blk.3.ffn_down.bias
+create_tensor: loading tensor blk.3.layer_output_norm.weight
+create_tensor: loading tensor blk.3.layer_output_norm.bias
+create_tensor: loading tensor blk.4.attn_q.weight
+create_tensor: loading tensor blk.4.attn_k.weight
+create_tensor: loading tensor blk.4.attn_v.weight
+create_tensor: loading tensor blk.4.attn_q.bias
+create_tensor: loading tensor blk.4.attn_k.bias
+create_tensor: loading tensor blk.4.attn_v.bias
+create_tensor: loading tensor blk.4.attn_output.weight
+create_tensor: loading tensor blk.4.attn_output.bias
+create_tensor: loading tensor blk.4.attn_output_norm.weight
+create_tensor: loading tensor blk.4.attn_output_norm.bias
+create_tensor: loading tensor blk.4.ffn_up.weight
+create_tensor: loading tensor blk.4.ffn_up.bias
+create_tensor: loading tensor blk.4.ffn_down.weight
+create_tensor: loading tensor blk.4.ffn_down.bias
+create_tensor: loading tensor blk.4.layer_output_norm.weight
+create_tensor: loading tensor blk.4.layer_output_norm.bias
+create_tensor: loading tensor blk.5.attn_q.weight
+create_tensor: loading tensor blk.5.attn_k.weight
+create_tensor: loading tensor blk.5.attn_v.weight
+create_tensor: loading tensor blk.5.attn_q.bias
+create_tensor: loading tensor blk.5.attn_k.bias
+create_tensor: loading tensor blk.5.attn_v.bias
+create_tensor: loading tensor blk.5.attn_output.weight
+create_tensor: loading tensor blk.5.attn_output.bias
+create_tensor: loading tensor blk.5.attn_output_norm.weight
+create_tensor: loading tensor blk.5.attn_output_norm.bias
+create_tensor: loading tensor blk.5.ffn_up.weight
+create_tensor: loading tensor blk.5.ffn_up.bias
+create_tensor: loading tensor blk.5.ffn_down.weight
+create_tensor: loading tensor blk.5.ffn_down.bias
+create_tensor: loading tensor blk.5.layer_output_norm.weight
+create_tensor: loading tensor blk.5.layer_output_norm.bias
+create_tensor: loading tensor blk.6.attn_q.weight
+create_tensor: loading tensor blk.6.attn_k.weight
+create_tensor: loading tensor blk.6.attn_v.weight
+create_tensor: loading tensor blk.6.attn_q.bias
+create_tensor: loading tensor blk.6.attn_k.bias
+create_tensor: loading tensor blk.6.attn_v.bias
+create_tensor: loading tensor blk.6.attn_output.weight
+create_tensor: loading tensor blk.6.attn_output.bias
+create_tensor: loading tensor blk.6.attn_output_norm.weight
+create_tensor: loading tensor blk.6.attn_output_norm.bias
+create_tensor: loading tensor blk.6.ffn_up.weight
+create_tensor: loading tensor blk.6.ffn_up.bias
+create_tensor: loading tensor blk.6.ffn_down.weight
+create_tensor: loading tensor blk.6.ffn_down.bias
+create_tensor: loading tensor blk.6.layer_output_norm.weight
+create_tensor: loading tensor blk.6.layer_output_norm.bias
+create_tensor: loading tensor blk.7.attn_q.weight
+create_tensor: loading tensor blk.7.attn_k.weight
+create_tensor: loading tensor blk.7.attn_v.weight
+create_tensor: loading tensor blk.7.attn_q.bias
+create_tensor: loading tensor blk.7.attn_k.bias
+create_tensor: loading tensor blk.7.attn_v.bias
+create_tensor: loading tensor blk.7.attn_output.weight
+create_tensor: loading tensor blk.7.attn_output.bias
+create_tensor: loading tensor blk.7.attn_output_norm.weight
+create_tensor: loading tensor blk.7.attn_output_norm.bias
+create_tensor: loading tensor blk.7.ffn_up.weight
+create_tensor: loading tensor blk.7.ffn_up.bias
+create_tensor: loading tensor blk.7.ffn_down.weight
+create_tensor: loading tensor blk.7.ffn_down.bias
+create_tensor: loading tensor blk.7.layer_output_norm.weight
+create_tensor: loading tensor blk.7.layer_output_norm.bias
+create_tensor: loading tensor blk.8.attn_q.weight
+create_tensor: loading tensor blk.8.attn_k.weight
+create_tensor: loading tensor blk.8.attn_v.weight
+create_tensor: loading tensor blk.8.attn_q.bias
+create_tensor: loading tensor blk.8.attn_k.bias
+create_tensor: loading tensor blk.8.attn_v.bias
+create_tensor: loading tensor blk.8.attn_output.weight
+create_tensor: loading tensor blk.8.attn_output.bias
+create_tensor: loading tensor blk.8.attn_output_norm.weight
+create_tensor: loading tensor blk.8.attn_output_norm.bias
+create_tensor: loading tensor blk.8.ffn_up.weight
+create_tensor: loading tensor blk.8.ffn_up.bias
+create_tensor: loading tensor blk.8.ffn_down.weight
+create_tensor: loading tensor blk.8.ffn_down.bias
+create_tensor: loading tensor blk.8.layer_output_norm.weight
+create_tensor: loading tensor blk.8.layer_output_norm.bias
+create_tensor: loading tensor blk.9.attn_q.weight
+create_tensor: loading tensor blk.9.attn_k.weight
+create_tensor: loading tensor blk.9.attn_v.weight
+create_tensor: loading tensor blk.9.attn_q.bias
+create_tensor: loading tensor blk.9.attn_k.bias
+create_tensor: loading tensor blk.9.attn_v.bias
+create_tensor: loading tensor blk.9.attn_output.weight
+create_tensor: loading tensor blk.9.attn_output.bias
+create_tensor: loading tensor blk.9.attn_output_norm.weight
+create_tensor: loading tensor blk.9.attn_output_norm.bias
+create_tensor: loading tensor blk.9.ffn_up.weight
+create_tensor: loading tensor blk.9.ffn_up.bias
+create_tensor: loading tensor blk.9.ffn_down.weight
+create_tensor: loading tensor blk.9.ffn_down.bias
+create_tensor: loading tensor blk.9.layer_output_norm.weight
+create_tensor: loading tensor blk.9.layer_output_norm.bias
+create_tensor: loading tensor blk.10.attn_q.weight
+create_tensor: loading tensor blk.10.attn_k.weight
+create_tensor: loading tensor blk.10.attn_v.weight
+create_tensor: loading tensor blk.10.attn_q.bias
+create_tensor: loading tensor blk.10.attn_k.bias
+create_tensor: loading tensor blk.10.attn_v.bias
+create_tensor: loading tensor blk.10.attn_output.weight
+create_tensor: loading tensor blk.10.attn_output.bias
+create_tensor: loading tensor blk.10.attn_output_norm.weight
+create_tensor: loading tensor blk.10.attn_output_norm.bias
+create_tensor: loading tensor blk.10.ffn_up.weight
+create_tensor: loading tensor blk.10.ffn_up.bias
+create_tensor: loading tensor blk.10.ffn_down.weight
+create_tensor: loading tensor blk.10.ffn_down.bias
+create_tensor: loading tensor blk.10.layer_output_norm.weight
+create_tensor: loading tensor blk.10.layer_output_norm.bias
+create_tensor: loading tensor blk.11.attn_q.weight
+create_tensor: loading tensor blk.11.attn_k.weight
+create_tensor: loading tensor blk.11.attn_v.weight
+create_tensor: loading tensor blk.11.attn_q.bias
+create_tensor: loading tensor blk.11.attn_k.bias
+create_tensor: loading tensor blk.11.attn_v.bias
+create_tensor: loading tensor blk.11.attn_output.weight
+create_tensor: loading tensor blk.11.attn_output.bias
+create_tensor: loading tensor blk.11.attn_output_norm.weight
+create_tensor: loading tensor blk.11.attn_output_norm.bias
+create_tensor: loading tensor blk.11.ffn_up.weight
+create_tensor: loading tensor blk.11.ffn_up.bias
+create_tensor: loading tensor blk.11.ffn_down.weight
+create_tensor: loading tensor blk.11.ffn_down.bias
+create_tensor: loading tensor blk.11.layer_output_norm.weight
+create_tensor: loading tensor blk.11.layer_output_norm.bias
+done_getting_tensors: tensor 'token_embd.weight' (f16) (and 196 others) cannot be used with preferred buffer type CPU_REPACK, using CPU instead
+load_tensors:   CPU_Mapped model buffer size =    63.46 MiB
+.................................................
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 512
+llama_context: n_ctx_seq     = 512
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 0
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 10000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_outputs_max = 512
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     0.12 MiB
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 1
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 1576
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:        CPU compute buffer size =     5.76 MiB
+sched_reserve: graph nodes  = 397
+sched_reserve: graph splits = 1
+sched_reserve: reserve took 20.49 ms, sched copies = 1
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+[harness] first embed (includes model load): 387 ms; dim=384 norm=1.0000 head=[-0.0783, -0.0172, 0.0554, -0.0067, 0.0559, 0.0296, 0.0482, 0.0495]
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+[harness] 64 embeds in 3004 ms — 21.3 embeddings/sec, 46.9 ms/embed, dim=384, ~1227 tok/s (chars/4 estimate)
+~llama_context:        CPU compute buffer size is   5.7578 MiB, matches expectation of   5.7578 MiB
+[harness] done

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/02-embed-throughput-cpu-lib.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/02-embed-throughput-cpu-lib.log
@@ -30,7 +30,7 @@ llama_model_loader: - type  f32:  123 tensors
 llama_model_loader: - type  f16:   74 tensors
 print_info: file format = GGUF V3 (latest)
 print_info: file type   = F16
-print_info: file size   = 63.46 MiB (16.03 BPW) 
+print_info: file size   = 63.46 MiB (16.03 BPW)
 init_tokenizer: initializing tokenizer for type 3
 load: 0 unused tokens
 load: control token:    101 '[CLS]' is not marked as EOG

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/03-embed-cuda-lib-broken-driver.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/03-embed-cuda-lib-broken-driver.log
@@ -1,0 +1,482 @@
+[harness] lib under test: /home/shaw/eliza-worktrees/validate-11339/plugins/plugin-local-inference/native/llama.cpp/build-desktop-cuda/bin/libelizainference.so
+[harness] embed bundle root: /home/shaw/.local/state/eliza/models/.eliza-embed-bundle
+[harness] ELIZA_LLM_USE_GPU=(unset — defaults to GPU offload, n_gpu_layers=99)
+ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected
+llama_model_loader: loaded meta data with 23 key-value pairs and 197 tensors from /home/shaw/.local/state/eliza/models/.eliza-embed-bundle/text/gte-small_fp16.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = bert
+llama_model_loader: - kv   1:                               general.name str              = gte-small
+llama_model_loader: - kv   2:                           bert.block_count u32              = 12
+llama_model_loader: - kv   3:                        bert.context_length u32              = 512
+llama_model_loader: - kv   4:                      bert.embedding_length u32              = 384
+llama_model_loader: - kv   5:                   bert.feed_forward_length u32              = 1536
+llama_model_loader: - kv   6:                  bert.attention.head_count u32              = 12
+llama_model_loader: - kv   7:          bert.attention.layer_norm_epsilon f32              = 0.000000
+llama_model_loader: - kv   8:                          general.file_type u32              = 1
+llama_model_loader: - kv   9:                      bert.attention.causal bool             = false
+llama_model_loader: - kv  10:                          bert.pooling_type u32              = 1
+llama_model_loader: - kv  11:            tokenizer.ggml.token_type_count u32              = 2
+llama_model_loader: - kv  12:                tokenizer.ggml.bos_token_id u32              = 101
+llama_model_loader: - kv  13:                tokenizer.ggml.eos_token_id u32              = 102
+llama_model_loader: - kv  14:                       tokenizer.ggml.model str              = bert
+llama_model_loader: - kv  15:                      tokenizer.ggml.tokens arr[str,30522]   = ["[PAD]", "[unused0]", "[unused1]", "...
+llama_model_loader: - kv  16:                      tokenizer.ggml.scores arr[f32,30522]   = [-1000.000000, -1000.000000, -1000.00...
+llama_model_loader: - kv  17:                  tokenizer.ggml.token_type arr[i32,30522]   = [3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  18:            tokenizer.ggml.unknown_token_id u32              = 100
+llama_model_loader: - kv  19:          tokenizer.ggml.seperator_token_id u32              = 102
+llama_model_loader: - kv  20:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  21:                tokenizer.ggml.cls_token_id u32              = 101
+llama_model_loader: - kv  22:               tokenizer.ggml.mask_token_id u32              = 103
+llama_model_loader: - type  f32:  123 tensors
+llama_model_loader: - type  f16:   74 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = F16
+print_info: file size   = 63.46 MiB (16.03 BPW) 
+init_tokenizer: initializing tokenizer for type 3
+load: 0 unused tokens
+load: control token:    101 '[CLS]' is not marked as EOG
+load: control token:    103 '[MASK]' is not marked as EOG
+load: control token:    100 '[UNK]' is not marked as EOG
+load: control token:    102 '[SEP]' is not marked as EOG
+load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+load: printing all EOG tokens:
+load:   - 0 ('[PAD]')
+load:   - 102 ('[SEP]')
+load: special tokens cache size = 5
+load: token to piece cache size = 0.2032 MB
+print_info: arch                  = bert
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 512
+print_info: n_embd                = 384
+print_info: n_embd_inp            = 384
+print_info: n_layer               = 12
+print_info: n_head                = 12
+print_info: n_head_kv             = 12
+print_info: n_rot                 = 32
+print_info: n_swa                 = 0
+print_info: is_swa_any            = 0
+print_info: n_embd_head_k         = 32
+print_info: n_embd_head_v         = 32
+print_info: n_gqa                 = 1
+print_info: n_embd_k_gqa          = 384
+print_info: n_embd_v_gqa          = 384
+print_info: f_norm_eps            = 1.0e-12
+print_info: f_norm_rms_eps        = 0.0e+00
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 0.0e+00
+print_info: f_attn_value_scale    = 0.0000
+print_info: n_ff                  = 1536
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 0
+print_info: pooling type          = 1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 10000.0
+print_info: freq_scale_train      = 1
+print_info: n_ctx_orig_yarn       = 512
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = 33M
+print_info: model params          = 33.21 M
+print_info: general.name          = gte-small
+print_info: vocab type            = WPM
+print_info: n_vocab               = 30522
+print_info: n_merges              = 0
+print_info: BOS token             = 101 '[CLS]'
+print_info: EOS token             = 102 '[SEP]'
+print_info: UNK token             = 100 '[UNK]'
+print_info: SEP token             = 102 '[SEP]'
+print_info: PAD token             = 0 '[PAD]'
+print_info: MASK token            = 103 '[MASK]'
+print_info: LF token              = 0 '[PAD]'
+print_info: FIM PAD token         = 0 '[PAD]'
+print_info: EOG token             = 0 '[PAD]'
+print_info: EOG token             = 102 '[SEP]'
+print_info: max token length      = 21
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: layer   0 assigned to device CPU, is_swa = 0
+load_tensors: layer   1 assigned to device CPU, is_swa = 0
+load_tensors: layer   2 assigned to device CPU, is_swa = 0
+load_tensors: layer   3 assigned to device CPU, is_swa = 0
+load_tensors: layer   4 assigned to device CPU, is_swa = 0
+load_tensors: layer   5 assigned to device CPU, is_swa = 0
+load_tensors: layer   6 assigned to device CPU, is_swa = 0
+load_tensors: layer   7 assigned to device CPU, is_swa = 0
+load_tensors: layer   8 assigned to device CPU, is_swa = 0
+load_tensors: layer   9 assigned to device CPU, is_swa = 0
+load_tensors: layer  10 assigned to device CPU, is_swa = 0
+load_tensors: layer  11 assigned to device CPU, is_swa = 0
+load_tensors: layer  12 assigned to device CPU, is_swa = 0
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor token_types.weight
+create_tensor: loading tensor position_embd.weight
+create_tensor: loading tensor token_embd_norm.weight
+create_tensor: loading tensor token_embd_norm.bias
+create_tensor: loading tensor blk.0.attn_q.weight
+create_tensor: loading tensor blk.0.attn_k.weight
+create_tensor: loading tensor blk.0.attn_v.weight
+create_tensor: loading tensor blk.0.attn_q.bias
+create_tensor: loading tensor blk.0.attn_k.bias
+create_tensor: loading tensor blk.0.attn_v.bias
+create_tensor: loading tensor blk.0.attn_output.weight
+create_tensor: loading tensor blk.0.attn_output.bias
+create_tensor: loading tensor blk.0.attn_output_norm.weight
+create_tensor: loading tensor blk.0.attn_output_norm.bias
+create_tensor: loading tensor blk.0.ffn_up.weight
+create_tensor: loading tensor blk.0.ffn_up.bias
+create_tensor: loading tensor blk.0.ffn_down.weight
+create_tensor: loading tensor blk.0.ffn_down.bias
+create_tensor: loading tensor blk.0.layer_output_norm.weight
+create_tensor: loading tensor blk.0.layer_output_norm.bias
+create_tensor: loading tensor blk.1.attn_q.weight
+create_tensor: loading tensor blk.1.attn_k.weight
+create_tensor: loading tensor blk.1.attn_v.weight
+create_tensor: loading tensor blk.1.attn_q.bias
+create_tensor: loading tensor blk.1.attn_k.bias
+create_tensor: loading tensor blk.1.attn_v.bias
+create_tensor: loading tensor blk.1.attn_output.weight
+create_tensor: loading tensor blk.1.attn_output.bias
+create_tensor: loading tensor blk.1.attn_output_norm.weight
+create_tensor: loading tensor blk.1.attn_output_norm.bias
+create_tensor: loading tensor blk.1.ffn_up.weight
+create_tensor: loading tensor blk.1.ffn_up.bias
+create_tensor: loading tensor blk.1.ffn_down.weight
+create_tensor: loading tensor blk.1.ffn_down.bias
+create_tensor: loading tensor blk.1.layer_output_norm.weight
+create_tensor: loading tensor blk.1.layer_output_norm.bias
+create_tensor: loading tensor blk.2.attn_q.weight
+create_tensor: loading tensor blk.2.attn_k.weight
+create_tensor: loading tensor blk.2.attn_v.weight
+create_tensor: loading tensor blk.2.attn_q.bias
+create_tensor: loading tensor blk.2.attn_k.bias
+create_tensor: loading tensor blk.2.attn_v.bias
+create_tensor: loading tensor blk.2.attn_output.weight
+create_tensor: loading tensor blk.2.attn_output.bias
+create_tensor: loading tensor blk.2.attn_output_norm.weight
+create_tensor: loading tensor blk.2.attn_output_norm.bias
+create_tensor: loading tensor blk.2.ffn_up.weight
+create_tensor: loading tensor blk.2.ffn_up.bias
+create_tensor: loading tensor blk.2.ffn_down.weight
+create_tensor: loading tensor blk.2.ffn_down.bias
+create_tensor: loading tensor blk.2.layer_output_norm.weight
+create_tensor: loading tensor blk.2.layer_output_norm.bias
+create_tensor: loading tensor blk.3.attn_q.weight
+create_tensor: loading tensor blk.3.attn_k.weight
+create_tensor: loading tensor blk.3.attn_v.weight
+create_tensor: loading tensor blk.3.attn_q.bias
+create_tensor: loading tensor blk.3.attn_k.bias
+create_tensor: loading tensor blk.3.attn_v.bias
+create_tensor: loading tensor blk.3.attn_output.weight
+create_tensor: loading tensor blk.3.attn_output.bias
+create_tensor: loading tensor blk.3.attn_output_norm.weight
+create_tensor: loading tensor blk.3.attn_output_norm.bias
+create_tensor: loading tensor blk.3.ffn_up.weight
+create_tensor: loading tensor blk.3.ffn_up.bias
+create_tensor: loading tensor blk.3.ffn_down.weight
+create_tensor: loading tensor blk.3.ffn_down.bias
+create_tensor: loading tensor blk.3.layer_output_norm.weight
+create_tensor: loading tensor blk.3.layer_output_norm.bias
+create_tensor: loading tensor blk.4.attn_q.weight
+create_tensor: loading tensor blk.4.attn_k.weight
+create_tensor: loading tensor blk.4.attn_v.weight
+create_tensor: loading tensor blk.4.attn_q.bias
+create_tensor: loading tensor blk.4.attn_k.bias
+create_tensor: loading tensor blk.4.attn_v.bias
+create_tensor: loading tensor blk.4.attn_output.weight
+create_tensor: loading tensor blk.4.attn_output.bias
+create_tensor: loading tensor blk.4.attn_output_norm.weight
+create_tensor: loading tensor blk.4.attn_output_norm.bias
+create_tensor: loading tensor blk.4.ffn_up.weight
+create_tensor: loading tensor blk.4.ffn_up.bias
+create_tensor: loading tensor blk.4.ffn_down.weight
+create_tensor: loading tensor blk.4.ffn_down.bias
+create_tensor: loading tensor blk.4.layer_output_norm.weight
+create_tensor: loading tensor blk.4.layer_output_norm.bias
+create_tensor: loading tensor blk.5.attn_q.weight
+create_tensor: loading tensor blk.5.attn_k.weight
+create_tensor: loading tensor blk.5.attn_v.weight
+create_tensor: loading tensor blk.5.attn_q.bias
+create_tensor: loading tensor blk.5.attn_k.bias
+create_tensor: loading tensor blk.5.attn_v.bias
+create_tensor: loading tensor blk.5.attn_output.weight
+create_tensor: loading tensor blk.5.attn_output.bias
+create_tensor: loading tensor blk.5.attn_output_norm.weight
+create_tensor: loading tensor blk.5.attn_output_norm.bias
+create_tensor: loading tensor blk.5.ffn_up.weight
+create_tensor: loading tensor blk.5.ffn_up.bias
+create_tensor: loading tensor blk.5.ffn_down.weight
+create_tensor: loading tensor blk.5.ffn_down.bias
+create_tensor: loading tensor blk.5.layer_output_norm.weight
+create_tensor: loading tensor blk.5.layer_output_norm.bias
+create_tensor: loading tensor blk.6.attn_q.weight
+create_tensor: loading tensor blk.6.attn_k.weight
+create_tensor: loading tensor blk.6.attn_v.weight
+create_tensor: loading tensor blk.6.attn_q.bias
+create_tensor: loading tensor blk.6.attn_k.bias
+create_tensor: loading tensor blk.6.attn_v.bias
+create_tensor: loading tensor blk.6.attn_output.weight
+create_tensor: loading tensor blk.6.attn_output.bias
+create_tensor: loading tensor blk.6.attn_output_norm.weight
+create_tensor: loading tensor blk.6.attn_output_norm.bias
+create_tensor: loading tensor blk.6.ffn_up.weight
+create_tensor: loading tensor blk.6.ffn_up.bias
+create_tensor: loading tensor blk.6.ffn_down.weight
+create_tensor: loading tensor blk.6.ffn_down.bias
+create_tensor: loading tensor blk.6.layer_output_norm.weight
+create_tensor: loading tensor blk.6.layer_output_norm.bias
+create_tensor: loading tensor blk.7.attn_q.weight
+create_tensor: loading tensor blk.7.attn_k.weight
+create_tensor: loading tensor blk.7.attn_v.weight
+create_tensor: loading tensor blk.7.attn_q.bias
+create_tensor: loading tensor blk.7.attn_k.bias
+create_tensor: loading tensor blk.7.attn_v.bias
+create_tensor: loading tensor blk.7.attn_output.weight
+create_tensor: loading tensor blk.7.attn_output.bias
+create_tensor: loading tensor blk.7.attn_output_norm.weight
+create_tensor: loading tensor blk.7.attn_output_norm.bias
+create_tensor: loading tensor blk.7.ffn_up.weight
+create_tensor: loading tensor blk.7.ffn_up.bias
+create_tensor: loading tensor blk.7.ffn_down.weight
+create_tensor: loading tensor blk.7.ffn_down.bias
+create_tensor: loading tensor blk.7.layer_output_norm.weight
+create_tensor: loading tensor blk.7.layer_output_norm.bias
+create_tensor: loading tensor blk.8.attn_q.weight
+create_tensor: loading tensor blk.8.attn_k.weight
+create_tensor: loading tensor blk.8.attn_v.weight
+create_tensor: loading tensor blk.8.attn_q.bias
+create_tensor: loading tensor blk.8.attn_k.bias
+create_tensor: loading tensor blk.8.attn_v.bias
+create_tensor: loading tensor blk.8.attn_output.weight
+create_tensor: loading tensor blk.8.attn_output.bias
+create_tensor: loading tensor blk.8.attn_output_norm.weight
+create_tensor: loading tensor blk.8.attn_output_norm.bias
+create_tensor: loading tensor blk.8.ffn_up.weight
+create_tensor: loading tensor blk.8.ffn_up.bias
+create_tensor: loading tensor blk.8.ffn_down.weight
+create_tensor: loading tensor blk.8.ffn_down.bias
+create_tensor: loading tensor blk.8.layer_output_norm.weight
+create_tensor: loading tensor blk.8.layer_output_norm.bias
+create_tensor: loading tensor blk.9.attn_q.weight
+create_tensor: loading tensor blk.9.attn_k.weight
+create_tensor: loading tensor blk.9.attn_v.weight
+create_tensor: loading tensor blk.9.attn_q.bias
+create_tensor: loading tensor blk.9.attn_k.bias
+create_tensor: loading tensor blk.9.attn_v.bias
+create_tensor: loading tensor blk.9.attn_output.weight
+create_tensor: loading tensor blk.9.attn_output.bias
+create_tensor: loading tensor blk.9.attn_output_norm.weight
+create_tensor: loading tensor blk.9.attn_output_norm.bias
+create_tensor: loading tensor blk.9.ffn_up.weight
+create_tensor: loading tensor blk.9.ffn_up.bias
+create_tensor: loading tensor blk.9.ffn_down.weight
+create_tensor: loading tensor blk.9.ffn_down.bias
+create_tensor: loading tensor blk.9.layer_output_norm.weight
+create_tensor: loading tensor blk.9.layer_output_norm.bias
+create_tensor: loading tensor blk.10.attn_q.weight
+create_tensor: loading tensor blk.10.attn_k.weight
+create_tensor: loading tensor blk.10.attn_v.weight
+create_tensor: loading tensor blk.10.attn_q.bias
+create_tensor: loading tensor blk.10.attn_k.bias
+create_tensor: loading tensor blk.10.attn_v.bias
+create_tensor: loading tensor blk.10.attn_output.weight
+create_tensor: loading tensor blk.10.attn_output.bias
+create_tensor: loading tensor blk.10.attn_output_norm.weight
+create_tensor: loading tensor blk.10.attn_output_norm.bias
+create_tensor: loading tensor blk.10.ffn_up.weight
+create_tensor: loading tensor blk.10.ffn_up.bias
+create_tensor: loading tensor blk.10.ffn_down.weight
+create_tensor: loading tensor blk.10.ffn_down.bias
+create_tensor: loading tensor blk.10.layer_output_norm.weight
+create_tensor: loading tensor blk.10.layer_output_norm.bias
+create_tensor: loading tensor blk.11.attn_q.weight
+create_tensor: loading tensor blk.11.attn_k.weight
+create_tensor: loading tensor blk.11.attn_v.weight
+create_tensor: loading tensor blk.11.attn_q.bias
+create_tensor: loading tensor blk.11.attn_k.bias
+create_tensor: loading tensor blk.11.attn_v.bias
+create_tensor: loading tensor blk.11.attn_output.weight
+create_tensor: loading tensor blk.11.attn_output.bias
+create_tensor: loading tensor blk.11.attn_output_norm.weight
+create_tensor: loading tensor blk.11.attn_output_norm.bias
+create_tensor: loading tensor blk.11.ffn_up.weight
+create_tensor: loading tensor blk.11.ffn_up.bias
+create_tensor: loading tensor blk.11.ffn_down.weight
+create_tensor: loading tensor blk.11.ffn_down.bias
+create_tensor: loading tensor blk.11.layer_output_norm.weight
+create_tensor: loading tensor blk.11.layer_output_norm.bias
+done_getting_tensors: tensor 'token_embd.weight' (f16) (and 196 others) cannot be used with preferred buffer type CPU_REPACK, using CPU instead
+load_tensors:   CPU_Mapped model buffer size =    63.46 MiB
+.................................................
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 512
+llama_context: n_ctx_seq     = 512
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 0
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 10000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     0.12 MiB
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 1
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 1576
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:        CPU compute buffer size =     7.13 MiB
+sched_reserve: graph nodes  = 398
+sched_reserve: graph splits = 1
+sched_reserve: reserve took 6.51 ms, sched copies = 1
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+[harness] first embed (includes model load): 232 ms; dim=384 norm=1.0000 head=[-0.0783, -0.0172, 0.0554, -0.0067, 0.0559, 0.0296, 0.0482, 0.0495]
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+set_embeddings: value = 1
+decode: cannot decode batches with this context (calling encode() instead)
+[harness] 64 embeds in 8376 ms — 7.6 embeddings/sec, 130.9 ms/embed, dim=384, ~440 tok/s (chars/4 estimate)
+~llama_context:        CPU compute buffer size is   7.1328 MiB, matches expectation of   7.1328 MiB
+[harness] done

--- a/.github/issue-evidence/11339-cuda-embedding-probe/logs/03-embed-cuda-lib-broken-driver.log
+++ b/.github/issue-evidence/11339-cuda-embedding-probe/logs/03-embed-cuda-lib-broken-driver.log
@@ -31,7 +31,7 @@ llama_model_loader: - type  f32:  123 tensors
 llama_model_loader: - type  f16:   74 tensors
 print_info: file format = GGUF V3 (latest)
 print_info: file type   = F16
-print_info: file size   = 63.46 MiB (16.03 BPW) 
+print_info: file size   = 63.46 MiB (16.03 BPW)
 init_tokenizer: initializing tokenizer for type 3
 load: 0 unused tokens
 load: control token:    101 '[CLS]' is not marked as EOG

--- a/plugins/plugin-local-inference/src/services/gpu-detect.test.ts
+++ b/plugins/plugin-local-inference/src/services/gpu-detect.test.ts
@@ -1,0 +1,160 @@
+/**
+ * detectGpu() probe semantics — issue #11339.
+ *
+ * The boot-time probe result is cached for the process lifetime, so a wrong
+ * first answer permanently demotes embedding selection. These tests pin the
+ * retry contract:
+ *
+ *   - a timeout-killed first call (RTD3 cold wake in flight) retries ONCE
+ *     with the extended deadline;
+ *   - a fast nonzero exit (driver in runtime-PM `error` state — observed on
+ *     an RTX 5080 Laptop after a failed GSP suspend, `nvidia-smi` exit 6) is
+ *     a real "no usable GPU" answer and is NOT retried;
+ *   - a missing binary (ENOENT) is NOT retried.
+ */
+import type { SpawnSyncReturns } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	__resetGpuDetectionCacheForTests,
+	__setGpuDetectionSpawnSyncForTests,
+	detectGpu,
+} from "./gpu-detect.js";
+
+interface RecordedCall {
+	command: string;
+	args: string[];
+	timeout: number | undefined;
+}
+
+function result(
+	overrides: Partial<SpawnSyncReturns<string>>,
+): SpawnSyncReturns<string> {
+	return {
+		pid: 4242,
+		output: [],
+		stdout: "",
+		stderr: "",
+		status: 0,
+		signal: null,
+		...overrides,
+	};
+}
+
+function timedOut(): SpawnSyncReturns<string> {
+	const error = new Error(
+		"spawnSync nvidia-smi ETIMEDOUT",
+	) as NodeJS.ErrnoException;
+	error.code = "ETIMEDOUT";
+	return result({ status: null, signal: "SIGTERM", error });
+}
+
+function enoent(): SpawnSyncReturns<string> {
+	const error = new Error("spawn nvidia-smi ENOENT") as NodeJS.ErrnoException;
+	error.code = "ENOENT";
+	return result({ status: null, error });
+}
+
+/** The exact shape this host produced with the driver in PM `error` state. */
+function unknownErrorExit6(): SpawnSyncReturns<string> {
+	return result({
+		status: 6,
+		stderr:
+			"Unable to determine the device handle for GPU0: 0000:02:00.0: Unknown Error\nNo devices were found\n",
+	});
+}
+
+function gpuCsv(): SpawnSyncReturns<string> {
+	return result({ stdout: "NVIDIA GeForce RTX 5080 Laptop GPU, 16303\n" });
+}
+
+/**
+ * Install a scripted nvidia-smi runner: call N returns `script[N]`
+ * (the last entry repeats). Returns the recorded call list.
+ */
+function scriptRunner(script: SpawnSyncReturns<string>[]): RecordedCall[] {
+	const calls: RecordedCall[] = [];
+	__setGpuDetectionSpawnSyncForTests((command, args, options) => {
+		calls.push({
+			command,
+			args,
+			timeout: options && "timeout" in options ? options.timeout : undefined,
+		});
+		return script[Math.min(calls.length - 1, script.length - 1)];
+	});
+	return calls;
+}
+
+afterEach(() => {
+	__resetGpuDetectionCacheForTests();
+});
+
+describe("detectGpu probe retry (issue #11339)", () => {
+	it("returns the GPU on a clean first call without retrying", () => {
+		const calls = scriptRunner([gpuCsv()]);
+		const detection = detectGpu({ force: true });
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe("nvidia-smi");
+		expect(calls[0].timeout).toBe(3_000);
+		expect(detection.nvidiaPresent).toBe(true);
+		expect(detection.gpu?.name).toBe("NVIDIA GeForce RTX 5080 Laptop GPU");
+		expect(detection.gpu?.totalMemoryMiB).toBe(16303);
+	});
+
+	it("retries once with the extended deadline after a timeout kill (RTD3 cold wake)", () => {
+		const calls = scriptRunner([timedOut(), gpuCsv()]);
+		const detection = detectGpu({ force: true });
+		expect(calls).toHaveLength(2);
+		expect(calls[0].timeout).toBe(3_000);
+		expect(calls[1].timeout).toBe(15_000);
+		expect(detection.nvidiaPresent).toBe(true);
+		expect(detection.gpu?.name).toBe("NVIDIA GeForce RTX 5080 Laptop GPU");
+	});
+
+	it("gives up after the single retry also times out — never a third call", () => {
+		const calls = scriptRunner([timedOut(), timedOut()]);
+		const detection = detectGpu({ force: true });
+		expect(calls).toHaveLength(2);
+		expect(detection).toEqual({
+			nvidiaPresent: false,
+			gpu: null,
+			profile: null,
+		});
+	});
+
+	it("does NOT retry a fast nonzero exit (driver in runtime-PM error state)", () => {
+		const calls = scriptRunner([unknownErrorExit6()]);
+		const detection = detectGpu({ force: true });
+		expect(calls).toHaveLength(1);
+		expect(detection).toEqual({
+			nvidiaPresent: false,
+			gpu: null,
+			profile: null,
+		});
+	});
+
+	it("does NOT retry a missing nvidia-smi binary (ENOENT)", () => {
+		const calls = scriptRunner([enoent()]);
+		const detection = detectGpu({ force: true });
+		expect(calls).toHaveLength(1);
+		expect(detection).toEqual({
+			nvidiaPresent: false,
+			gpu: null,
+			profile: null,
+		});
+	});
+
+	it("caches the post-retry success so later calls skip the probe", () => {
+		const calls = scriptRunner([timedOut(), gpuCsv()]);
+		detectGpu({ force: true });
+		const second = detectGpu();
+		expect(calls).toHaveLength(2);
+		expect(second.nvidiaPresent).toBe(true);
+	});
+
+	it("force re-probes through the cache", () => {
+		const calls = scriptRunner([gpuCsv()]);
+		detectGpu({ force: true });
+		detectGpu({ force: true });
+		expect(calls).toHaveLength(2);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/gpu-detect.ts
+++ b/plugins/plugin-local-inference/src/services/gpu-detect.ts
@@ -61,7 +61,20 @@ let spawnSyncForTests:
  * without an NVIDIA GPU.
  *
  * The probe runs `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`
- * with a 3-second timeout so a misbehaving driver cannot stall boot.
+ * with a 3-second timeout so a misbehaving driver cannot stall boot. When the
+ * first call is killed by that timeout, the probe retries once with an
+ * extended deadline: on RTD3 laptops (GPU runtime-suspended to D3cold) the
+ * first `nvidia-smi` after GPU sleep must cold-wake the card, which can take
+ * longer than 3 s. Without the retry the boot-time probe would report
+ * `gpu: null`, cache it, and wrongly demote embeddings to the CPU tier for
+ * the process lifetime. The killed first invocation already initiated the
+ * kernel's runtime-resume, so the retry normally answers quickly.
+ *
+ * A probe that fails FAST with a nonzero exit is NOT retried — that is a real
+ * "no usable GPU" answer. Observed on an RTX 5080 Laptop whose driver entered
+ * runtime-PM `error` state after a failed suspend (GSP unload timeout under
+ * host RAM pressure, issue #11339): `nvidia-smi` exits 6 immediately and the
+ * probe correctly degrades embedding selection to the CPU tier.
  */
 export function detectGpu(opts: { force?: boolean } = {}): GpuDetectionResult {
 	if (cached && !opts.force) return cached;
@@ -88,17 +101,54 @@ export function __setGpuDetectionSpawnSyncForTests(
 	spawnSyncForTests = runner;
 }
 
-function probe(): GpuDetectionResult {
-	const run = spawnSyncForTests ?? spawnSync;
-	const result = run(
-		"nvidia-smi",
-		["--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
-		{
+const PROBE_TIMEOUT_MS = 3_000;
+/**
+ * Deadline for the single retry after a timed-out first call. RTD3 cold wake
+ * usually completes within a few seconds once the resume is in flight; 15 s
+ * gives headroom for a memory-pressured host without letting a truly hung
+ * driver stall boot indefinitely (worst case 3 s + 15 s, once per process —
+ * the result is cached).
+ */
+const COLD_WAKE_RETRY_TIMEOUT_MS = 15_000;
+
+const NVIDIA_SMI_ARGS = [
+	"--query-gpu=name,memory.total",
+	"--format=csv,noheader,nounits",
+];
+
+function runNvidiaSmi(timeoutMs: number): SpawnSyncReturns<string> {
+	if (spawnSyncForTests) {
+		return spawnSyncForTests("nvidia-smi", NVIDIA_SMI_ARGS, {
 			encoding: "utf8",
-			timeout: 3000,
+			timeout: timeoutMs,
 			stdio: ["ignore", "pipe", "pipe"],
-		},
-	);
+		});
+	}
+	return spawnSync("nvidia-smi", NVIDIA_SMI_ARGS, {
+		encoding: "utf8",
+		timeout: timeoutMs,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
+/**
+ * `true` when the spawn was killed by its own timeout. Both Node and Bun
+ * report a `spawnSync` timeout as `error.code === "ETIMEDOUT"` (verified on
+ * Node 25.2 and Bun 1.4). A missing binary (ENOENT) or a completed run with
+ * a failure exit code is not a timeout and must not be retried.
+ */
+function wasKilledByTimeout(result: SpawnSyncReturns<string>): boolean {
+	const { error } = result;
+	return error !== undefined && "code" in error && error.code === "ETIMEDOUT";
+}
+
+function probe(): GpuDetectionResult {
+	let result = runNvidiaSmi(PROBE_TIMEOUT_MS);
+	if (wasKilledByTimeout(result)) {
+		// RTD3 cold wake: the first call woke the GPU but was killed before the
+		// driver answered. Retry once — the wake is already in progress.
+		result = runNvidiaSmi(COLD_WAKE_RETRY_TIMEOUT_MS);
+	}
 	if (result.error || result.status !== 0) {
 		return EMPTY_RESULT;
 	}


### PR DESCRIPTION
## What

Validation lane for #11339 (CUDA embedding hardware-probe flip, RTX 5080 Laptop 16 GB, driver 595.71.05, Linux x64) — plus the probe bug it flushed out.

### Probe fix

`detectGpu()` runs `nvidia-smi` with a 3 s timeout and caches the result for the process lifetime. On RTD3 laptops the first `nvidia-smi` after GPU runtime-suspend must cold-wake the card, which can exceed 3 s — the timeout-killed probe cached `gpu: null` and permanently demoted embedding selection to the CPU tier. The probe now retries exactly once with a 15 s deadline **only** when the first call was killed by its own timeout (`error.code === "ETIMEDOUT"` — verified empirically as the signature on both Node 25.2 and Bun 1.4). Fast nonzero exits and ENOENT are NOT retried — they are real "no usable GPU" answers.

New `gpu-detect.test.ts` pins the contract (7 tests): clean first call, timeout→retry→success (3 s then 15 s deadlines asserted), timeout→timeout→give up (never a third call), exit-6 fast failure not retried (the exact `Unknown Error` shape this host produced), ENOENT not retried, cache + force semantics.

### Real-hardware evidence (`.github/issue-evidence/11339-cuda-embedding-probe/`)

During the campaign this host's GPU **really failed** — driver runtime-suspend died under RAM pressure (`NV_ERR_NO_MEMORY` loop → GSP unload timeout → runtime-PM `error` state; kernel NVRM trace committed). That made the "CUDA present but unusable" criterion a live test, not a simulation:

- `logs/01-probe-hardware.log` — the exact boot probe (`probeHardware()` → `selectEmbeddingTierFromHardware()`) on the wedged host: `gpu: null` → `fallback` tier → CPU preset. No crash.
- `logs/02-embed-throughput-cpu-lib.log` — REAL gte-small load through the fused `libelizainference` FFI: positive `load_tensors: layer N assigned to device CPU` lines for every layer, 64 real embeds, **21.3 embeddings/sec, 46.9 ms/embed, dim 384, norm 1.0**.
- `logs/03-embed-cuda-lib-broken-driver.log` — the **CUDA-built** fused lib (linked `libggml-cuda`/`libcudart`/`libcuda`) requesting full offload against the broken driver: `ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected` → every layer degrades to `assigned to device CPU` → embeddings still produced (7.6 embeddings/sec), exit 0, **no crash**. This is the issue's criterion (c) exercised on genuinely unusable CUDA.

### Validation finding (documented, not fixed here)

The preset/env `gpuLayers` is **not threaded into the fused desktop embed load**: `resolveDesktopEmbeddingConfig()` computes it, but `getFusedEmbeddingHandle()` never passes it and the native `eliza_inference_embed` hard-codes `n_gpu_layers = -1` → `ELIZA_LLM_USE_GPU` (default true → 99 layers). CPU-tier selection therefore does not pin the fused desktop embed to CPU (degradation relies on ggml device fallback — proven working in log 03), and `LOCAL_EMBEDDING_GPU_LAYERS=0` is silently ignored on this path. Fixing needs an additive fused-lib ABI change + lib rebuilds; detailed in the evidence README and on the issue.

### Blocked residual

The accelerated capture (layers on CUDA0 + CPU-vs-CUDA embeddings/sec) is impossible while the driver is in PM `error` state — it needs a reboot of this host (no root available to rebind). Recapture command documented in the evidence README. **This PR therefore refs (not closes) #11339.**

## Verification

- `bunx vitest run src/services/gpu-detect.test.ts src/services/hardware.test.ts src/services/__tests__/gpu-autotune.test.ts src/runtime/embedding-presets.test.ts` — 58/58 pass (post-rebase re-run of the two touched files: 17/17).
- `bunx tsc --noEmit -p plugins/plugin-local-inference/tsconfig.json` — clean.
- `bunx biome check` on touched source files — clean.
- Rebased on `origin/develop` (7e4cede61d), no conflicts.

Evidence rows per PR_EVIDENCE.md: real domain artifacts (kernel logs, probe JSON, llama.cpp load logs, embedding vectors + throughput) committed and hand-reviewed. Frontend screenshots/video: N/A — no UI surface; server-side probe + native embed path only. Real-LLM trajectories: N/A — no agent/prompt/model-behavior change; TEXT_EMBEDDING path exercised directly via its real FFI modules.

Refs #11339

🤖 Generated with [Claude Code](https://claude.com/claude-code)