### PR TITLE
fix(android): don't advertise a dead bionic-host path when the fused-voice JNI bridge is absent

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1543,7 +1543,28 @@ public class ElizaAgentService extends Service {
             // delegate inference over an abstract-namespace UDS to the in-process
             // ElizaBionicInferenceServer, which runs libelizainference on the Mali
             // GPU. The musl agent never tries to load the native lib itself.
-            boolean delegateToBionicHost = fusedInferenceBundled && abiGgmlVulkan.isFile();
+            // The bionic host is served through the fused-voice JNI bridge
+            // (libelizavoicejni.so, ElizaVoiceNative → ElizaBionicInferenceServer).
+            // That bridge is only built by the app's externalNativeBuild when the
+            // staged libelizainference.so carries the fused-voice symbols; a build
+            // whose prebuilt lib lacks them silently ships WITHOUT the bridge (see
+            // build.gradle). Requiring it here means we never advertise a
+            // bionic-host serving path the server cannot actually stand up — the
+            // musl agent would otherwise register capacitor-llama handlers "(via
+            // bionic-host)" against a socket that never binds, and every turn
+            // would fail with a cryptic "bionic socket error: connect ENOENT".
+            boolean bionicJniBridgeBundled =
+                resolveBundledNativeLib(abiDir, "libelizavoicejni.so").isFile();
+            boolean delegateToBionicHost =
+                fusedInferenceBundled && abiGgmlVulkan.isFile() && bionicJniBridgeBundled;
+            if (fusedInferenceBundled && abiGgmlVulkan.isFile() && !bionicJniBridgeBundled) {
+                Log.w(TAG, "agent/" + abiDir.getName()
+                    + ": fused Vulkan libs are staged but libelizavoicejni.so is absent "
+                    + "(this build skipped the fused-voice JNI bridge); on-device GPU "
+                    + "inference via the bionic host is UNAVAILABLE. Rebuild with "
+                    + "stage-elizavoice-lib.mjs to re-enable. Falling back to the "
+                    + "non-delegated inference path.");
+            }
             if (delegateToBionicHost) {
                 agentEnv.put("ELIZA_BIONIC_HOST_DELEGATED", "1");
                 agentEnv.put("ELIZA_BIONIC_INFERENCE_SOCK", BIONIC_INFERENCE_SOCKET_NAME);
@@ -1571,7 +1592,24 @@ public class ElizaAgentService extends Service {
                     bionicInferenceServer =
                         new ElizaBionicInferenceServer(BIONIC_INFERENCE_SOCKET_NAME, defaultBundleDir);
                 }
-                bionicInferenceServer.start();
+                // Guard the start: a failure here (e.g. the fused-voice native
+                // libs failing to dlopen) must NOT leave the delegation env set,
+                // or the musl agent registers dead "(via bionic-host)" handlers
+                // against a socket that never binds and every turn fails. On
+                // failure, retract the delegation so the caller falls through to
+                // the non-delegated inference path below. UnsatisfiedLinkError is
+                // an Error, not an Exception, so catch Throwable here.
+                try {
+                    bionicInferenceServer.start();
+                } catch (Throwable startError) {
+                    Log.e(TAG, "ElizaBionicInferenceServer.start() failed; disabling "
+                        + "bionic-host delegation for this launch: " + startError.getMessage(),
+                        startError);
+                    bionicInferenceServer = null;
+                    agentEnv.remove("ELIZA_BIONIC_HOST_DELEGATED");
+                    agentEnv.remove("ELIZA_BIONIC_INFERENCE_SOCK");
+                    delegateToBionicHost = false;
+                }
             }
             if (!delegateToBionicHost && nativeLlamaBundled
                     && !env.containsKey("ELIZA_LOCAL_LLAMA")) {


### PR DESCRIPTION
## The bug (found while device-verifying #11335 on a Pixel 6a)

On-device GPU inference is served through `libelizavoicejni.so` (the fused-voice JNI bridge → `ElizaVoiceNative` → `ElizaBionicInferenceServer`). That bridge is only built by the app's `externalNativeBuild` when the staged `libelizainference.so` carries the fused-voice symbols; a build whose lib lacks them **silently ships without the bridge** (`build.gradle` logs a warning and skips it "so the APK still builds").

But `delegateToBionicHost` was decided purely on `libelizainference.so` + `libggml-vulkan.so` being present — **not** on the JNI bridge it depends on. So on such a build the agent still:
- set `ELIZA_BIONIC_HOST_DELEGATED=1`, and
- called `bionicInferenceServer.start()`, which threw an **uncaught** `UnsatisfiedLinkError` (`libelizavoicejni.so not found`).

**On-device result (Pixel 6a, develop APK):** the musl agent registered `capacitor-llama` TEXT handlers `(via bionic-host)` against a socket that never bound, so every chat turn failed with `bionic socket error: connect ENOENT`, surfaced to the user as **"Sorry, I'm having a provider issue."** i.e. **local chat is broken on any build lacking the JNI bridge** — which is every clean/CI/release build (see the build-race note below). The #11335 device turn only succeeded because the OCR-branch APK happened to bundle `libelizavoicejni.so` (4 entries); the develop APK bundles **0**.

## The fix (this PR) — fail-safe + fail-loud

`ElizaAgentService`:
1. **Require `libelizavoicejni.so` in the delegation gate.** When the fused Vulkan libs are present but the bridge is absent, log a clear, actionable warning and fall back to the non-delegated inference path instead of advertising a dead one.
2. **Guard `start()` with `catch (Throwable)`** (UnsatisfiedLinkError is an `Error`). On any failure: retract the delegation env, null the server, set `delegateToBionicHost = false` so the caller cleanly takes the fallback path — never dead `(via bionic-host)` handlers.

Verified: `:app:compileDebugJavaWithJavac` clean; all downstream uses of `delegateToBionicHost` (fallback env at L1614, GPU-offload at L1632, launch-details at L2020) handle the reassignment correctly.

## Deeper root cause (documented, NOT fixed here — see #<followup>)

*Why* is the bridge absent on clean builds? The `elizavoiceReady` gate in `build.gradle` reads `jniLibs/arm64-v8a/libelizainference.so` at gradle **configure** time, but `copyForkLlamaLib` stages that lib at **execution** time — *after* configure. So on a clean checkout / CI / release build, jniLibs is empty at configure → `elizavoiceReady=false` → bridge skipped → **every clean build ships a broken on-device-inference APK**. I prototyped enabling the gate from the staging *source* (`-Peliza.mtp.android.libdir`/env/state-dir), which correctly makes configure decide "build the bridge" — but it then converts the original graceful-skip into a **hard CMake failure** when the fork submodule header (`eliza-inference-ffi.h`) or the lib isn't present, which is precisely why the original design skips it. The proper fix needs a build-DAG guarantee (externalNativeBuild depends on copyForkLlamaLib + the fork submodule) validated on real CI — filed as a follow-up rather than shipping a build regression. **This PR's runtime guard makes the current behavior fail-safe regardless.**

## Evidence
- APK JNI-lib diff: OCR-branch APK = 4 `libelizavoicejni.so` entries, develop APK = 0 (confirmed with `unzip -l`).
- Device logcat: `UnsatisfiedLinkError: library "libelizavoicejni.so" not found at ElizaVoiceNative.ensureLoaded → ElizaBionicInferenceServer.start → ElizaAgentService.startAgentProcess`.
- Java compile: `:app:compileDebugJavaWithJavac` BUILD SUCCESSFUL.

Refs #11335, #11506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)