### PR TITLE
test(cloud): mock ad accounts as active in credit-reconciliation suite — un-red develop after #11619 gate

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -195,6 +195,7 @@ describe("updateCampaign — reconciles the credit hold on a budget change", () 
         id: "acct-1",
         organization_id: ORG_ID,
         platform: "meta",
+        status: "active",
       } as never),
     );
     // getCredentials is private + hits the secrets vault; stub it out.
@@ -322,6 +323,7 @@ describe("updateCampaign — budget DECREASE refunds only unused + is atomic (#1
         id: "acct-1",
         organization_id: ORG_ID,
         platform: "meta",
+        status: "active",
       } as never),
     );
     track(


### PR DESCRIPTION
## What

#11619 gated `updateCampaign` on `account.status === "active"` (closing the suspended-account spend leg from #11364) but did not update the mocks in `packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts`, which stub `adAccountsRepository.findById` without a `status` field.

Since that merge, **7 of the suite's 13 tests fail on develop** with:

```
error: Ad account is not active (status: undefined); it must be approved before running campaigns
      at updateCampaign (packages/cloud/shared/src/lib/services/advertising/index.ts:696)
```

— the gate throws before the credit-hold reconciliation logic under test is ever reached.

## Fix

Add `status: "active"` to the two `beforeEach` account mocks so the suite exercises budget-change hold reconciliation again. The approval gate itself remains covered by `ad-account-approval.test.ts` (15 tests, unchanged).

## Evidence

On `origin/develop` @ `80ba667fd0` (pre-fix):

```
bun test packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
 6 pass
 7 fail   # all: 'Ad account is not active (status: undefined)'
```

With this fix (same base):

```
bun test .../ad-campaign-credit-reconciliation.test.ts .../ad-account-approval.test.ts .../ad-inventory.test.ts .../ad-tag-token.test.ts
 48 pass
 0 fail
```

Frontend/video/screenshot/trajectory evidence: N/A — test-only change to existing unit-test mocks; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)