### PR TITLE
fix(inbox): expose triage queue filters in action schema

### DIFF
--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -876,6 +876,21 @@ export const inboxAction: Action & {
       description: "Explicit owner confirmation for sending reply/approve.",
       schema: { type: "boolean" as const },
     },
+    {
+      name: "classification",
+      description:
+        "Optional triage queue filter for persisted items: ignore | info | notify | needs_reply | urgent. When set on triage, reads the queue without classifying fresh messages.",
+      schema: {
+        type: "string" as const,
+        enum: ["ignore", "info", "notify", "needs_reply", "urgent"],
+      },
+    },
+    {
+      name: "includeSnoozed",
+      description:
+        "When true, include snoozed triage queue entries in triage reads.",
+      schema: { type: "boolean" as const },
+    },
   ],
   examples,
   handler: async (

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -158,6 +158,14 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       }
     });
 
+    it("exposes triage queue filter parameters to routed tool calls", () => {
+      const parameterNames = new Set(
+        (inboxAction.parameters ?? []).map((parameter) => parameter.name),
+      );
+      expect(parameterNames).toContain("classification");
+      expect(parameterNames).toContain("includeSnoozed");
+    });
+
     it("rejects calls with no subaction selector", async () => {
       const result = await callInbox(makeRuntime(), makeMessage(), {});
       expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

Follow-up to #11580 / #11383. The merged triage path already supports `classification` and `includeSnoozed` in `InboxActionParameters`, and the implementation uses `classification` to serve persisted queue reads without cross-channel fetch + LLM classification. This exposes both fields in the public INBOX action parameter schema so routed tool calls can use that optimized read path.

## Validation

- `bun run --cwd plugins/plugin-inbox test -- test/inbox-action.test.ts`
- `bun run --cwd plugins/plugin-inbox typecheck`
- `bunx biome check plugins/plugin-inbox/src/actions/inbox.ts plugins/plugin-inbox/test/inbox-action.test.ts --files-ignore-unknown=true`
- `git diff --check origin/develop...HEAD && git diff --check`

Refs #11383