### PR TITLE
perf(#11352): commit real Pixel 6a eliza-1-2b resource baselines (documented, non-gating)

### DIFF
--- a/.github/issue-evidence/11352-pixel6a-baseline/README.md
+++ b/.github/issue-evidence/11352-pixel6a-baseline/README.md
@@ -1,0 +1,95 @@
+# #11352 — Pixel 6a local-model resource baseline (eliza-1-2b Q4)
+
+First **post-model-load** on-device resource capture for the epic #10724 Scope C
+(local-model RAM / tok-s on real devices). The prior committed device numbers
+(#10724 `android-memory-baseline`, PSS 220 MB) were the **shell floor** —
+captured before any agent or inference loaded. This adds the numbers with the
+model resident and during generation.
+
+These are recorded as **documented baselines**, not PR-gating budgets. The
+`deviceClasses.*` entries in `budgets.json` stay `null`; the numbers below live
+in a non-gating `budgets.json → measuredBaselines` block plus `BASELINE.md`.
+Reason: this is a **single, thermally-throttled run** — the issue itself says
+gate only "until per-device baselines are stable," and one run is not stable
+enough to fail a PR on. Promotion to a gate needs multi-run stability on a
+quiet, cool device.
+
+## Device / build under test
+
+| | |
+|---|---|
+| Device | **Pixel 6a** (Google Tensor GS101, Mali-G78 MP20), Android 16, physical |
+| RAM | ~5.7 GB usable (memory-constrained class) |
+| Model | **eliza-1-2b Q4** — 1.2 GB GGUF |
+| Inference host | **bionic Vulkan host** (native arm64, GPU-resident weights) |
+
+## Memory — `adb shell dumpsys meminfo <pkg>`
+
+`glMtrack` is the GL mtrack line = Vulkan model weights resident in GPU memory.
+
+| State | TOTAL PSS | TOTAL RSS | GL mtrack | SWAP PSS |
+|---|---:|---:|---:|---:|
+| **Idle** (agent up, model resident, no active turn) | **2.50 GB** | 2.39 GB | 2.25 GB | 195 MB |
+| **Chat-active** (during generation) | **2.60 GB** | 2.46 GB | 2.25 GB | 217 MB |
+| **Delta** (active − idle) | ~100 MB | ~70 MB | 0 | +22 MB |
+
+- Memory is **dominated by resident weights**, not per-turn work: GL mtrack holds
+  ~2.25 GB constant idle→active, and the active-minus-idle delta is only
+  ~100 MB PSS / ~70 MB RSS.
+- Measured idle total RSS (2.39 GB / 2390 MB) **already exceeds** the provisional
+  `maxSteadyRssMb` cap (2300 MB) for this class — concrete evidence that the
+  provisional GGUF-derived ceilings must not be promoted to a gate before real
+  multi-run baselines exist.
+
+## Throughput — decode tokens/sec
+
+| Source | Metric | tok/s |
+|---|---|---:|
+| bionic Vulkan host (`GENERATE_STREAM`) | decode, **warm** | **4.8** |
+| bionic Vulkan host (`GENERATE_STREAM`) | decode, **cold** (first turn incl. model load) | ~3.1 |
+| `llama-bench` (same libs) | pp32 (prefill) | 2.60 |
+| `llama-bench` (same libs) | tg32 (decode) | 6.85 |
+
+## Capture method
+
+- **Memory:** `adb shell dumpsys meminfo <pkg>` at two states — idle (agent
+  booted, model loaded, no in-flight turn) and chat-active (sampled during a
+  live generation). TOTAL PSS/RSS + the GL mtrack and SWAP PSS lines read
+  directly from App Summary.
+- **Warm/cold decode tok/s:** timed `GENERATE_STREAM` round-trips through the
+  bionic Vulkan host — cold = first turn (includes model load), warm = steady
+  subsequent turns.
+- **llama-bench:** run against the same Vulkan libs the host loads, `pp32` /
+  `tg32`, as an independent throughput cross-check.
+
+## Finding — model tier selection on the 6a class
+
+The **eliza-1-2b E2B variant (4.9 GB)** tripped the Android **lowmemorykiller**
+on this 5.7 GB device — the OS reclaimed the app under memory pressure. **Q4
+(1.2 GB)** runs resident without being killed and is the correct 6a-class tier.
+Larger tiers need a higher-RAM device class.
+
+## Still hardware-gated (NOT captured here)
+
+Everything below needs the self-hosted arm64 device pool and/or a power meter,
+and is genuinely not represented above. The issue stays **open** for these:
+
+- **Battery / power draw** for idle / chat / voice / background-scheduled-task —
+  power-meter-gated (physical-device-only per the issue). This is the primary
+  blocker to closing #11352.
+- **TTFT distribution** — only a single run exists; no p50/p90 distribution.
+- **Prefill tok/s (isolated)** — not separated from decode in this capture.
+- **Thermal timeline** — no per-sample `getCurrentThermalStatus` log over a
+  sustained run; the run was thermally throttled but not traced.
+- **iOS** — no iPhone / iOS-sim numbers for either tier.
+- **eliza-1-4b tier** — not captured on any device class.
+- **Multi-run stability** — need ≥3 quiet, cool-device runs (p50 floor for
+  throughput, p90/peak for ceilings) before any of these is promoted from the
+  `measuredBaselines` block into a gating `deviceClasses` budget.
+
+## Files touched
+
+- `packages/benchmarks/mobile-resource/budgets.json` — added non-gating
+  `measuredBaselines` block (gate `deviceClasses` unchanged, still `null`).
+- `packages/benchmarks/mobile-resource/BASELINE.md` — measured-baselines table
+  row for android-phone / eliza-1-2b.

--- a/packages/benchmarks/mobile-resource/BASELINE.md
+++ b/packages/benchmarks/mobile-resource/BASELINE.md
@@ -36,14 +36,24 @@ ceiling sits deliberately close to flag tiers that approach it.
 
 ## Measured baselines
 
-_None yet — populate as device runs land._
+First real device capture landed for `android-phone` / `eliza-1-2b` (Pixel 6a,
+issue #11352). It is a **single, thermally-throttled run** — recorded here and
+in `budgets.json → measuredBaselines` (a non-gating block), but deliberately
+**not** promoted into the gating `deviceClasses` budgets (which stay `null`)
+until ≥3 stable runs on a quiet, cool device land. Full method + gaps:
+`.github/issue-evidence/11352-pixel6a-baseline/README.md`.
 
-| Device class   | Tier           | Workload        | decode tok/s (p50) | prefill tok/s (p50) | TTFT (p90) | peak RSS | battery drain | commit |
-| -------------- | -------------- | --------------- | ------------------ | ------------------- | ---------- | -------- | ------------- | ------ |
-| ios-phone      | eliza-1-2b     | single-turn     | —                  | —                   | —          | —        | —             | —      |
-| ios-phone      | eliza-1-2b     | sustained-chat  | —                  | —                   | —          | —        | —             | —      |
-| android-phone  | eliza-1-2b     | single-turn     | —                  | —                   | —          | —        | —             | —      |
-| android-phone  | eliza-1-2b     | sustained-chat  | —                  | —                   | —          | —        | —             | —      |
+| Device class   | Tier           | Workload        | decode tok/s        | prefill tok/s | TTFT | peak RSS (chat) | steady RSS (idle) | battery drain | commit |
+| -------------- | -------------- | --------------- | ------------------- | ------------- | ---- | --------------- | ----------------- | ------------- | ------ |
+| ios-phone      | eliza-1-2b     | single-turn     | —                   | —             | —    | —               | —                 | —             | —      |
+| ios-phone      | eliza-1-2b     | sustained-chat  | —                   | —             | —    | —               | —                 | —             | —      |
+| android-phone  | eliza-1-2b     | single-turn     | 4.8 warm / 3.1 cold | not isolated  | —    | 2600 MB PSS     | 2500 MB PSS       | —             | #11352 |
+| android-phone  | eliza-1-2b     | sustained-chat  | 4.8 warm            | not isolated  | —    | 2600 MB PSS     | 2500 MB PSS       | —             | #11352 |
+
+Pixel 6a / eliza-1-2b Q4 (1.2 GB GGUF), bionic Vulkan host. Memory dominated by
+resident weights (GL mtrack ~2.25 GB constant); per-turn delta only ~100 MB PSS
+/ ~70 MB RSS. llama-bench on the same libs: pp32 2.60 t/s, tg32 6.85 t/s. TTFT,
+prefill, battery, and thermal remain uncaptured (see the evidence README).
 
 ## Notes / known gaps
 

--- a/packages/benchmarks/mobile-resource/budgets.json
+++ b/packages/benchmarks/mobile-resource/budgets.json
@@ -40,5 +40,35 @@
         "maxBatteryDrainPct": null
       }
     }
+  },
+  "measuredBaselines": {
+    "_comment": "REAL on-device captures, documented for reference (issue #11352). NOT consumed by the budget gate: the runner (run-workbench.mjs) reads only `deviceClasses.*` + `leakGrowthMbThreshold`, so nothing here can fail a PR. These are single-run, thermally-throttled captures — recorded per BASELINE.md discipline but intentionally NOT promoted into the gating `deviceClasses` budgets (which stay null) until multi-run stability on a quiet, cool device lands. Only keys with a genuine measurement are present; TTFT/battery/thermal/prefill are omitted because they were not honestly captured (power draw is power-meter-gated). Memory values are MB from `adb shell dumpsys meminfo <pkg>` (PSS/RSS); `glMtrackMb` is the GL mtrack line = Vulkan model weights resident in GPU memory. Throughput is decode tokens/sec from the bionic Vulkan host (GENERATE_STREAM), plus llama-bench on the same libs.",
+    "android-phone": {
+      "eliza-1-2b": {
+        "device": "Google Pixel 6a (Tensor GS101, Mali-G78 MP20, Android 16, ~5.7 GB usable RAM)",
+        "model": "eliza-1-2b Q4 (1.2 GB GGUF) via the bionic Vulkan host",
+        "capturedAt": "2026-07-02",
+        "runs": 1,
+        "stableForGating": false,
+        "memoryMb": {
+          "idle": { "totalPss": 2500, "totalRss": 2390, "glMtrack": 2250, "swapPss": 195 },
+          "chatActive": { "totalPss": 2600, "totalRss": 2460, "glMtrack": 2250, "swapPss": 217 },
+          "deltaActiveMinusIdle": { "totalPss": 100, "totalRss": 70 }
+        },
+        "decodeTokensPerSecond": { "warm": 4.8, "cold": 3.1 },
+        "llamaBenchTokensPerSecond": { "pp32": 2.60, "tg32": 6.85 },
+        "notMeasured": {
+          "ttftMs": "single-run only; distribution not captured",
+          "prefillTokensPerSecond": "not isolated in this capture",
+          "batteryDrainPct": "power-meter gated (idle / chat / voice / background)",
+          "thermalTimeline": "physical thermal-log capture pending"
+        },
+        "findings": [
+          "The eliza-1-2b E2B variant (4.9 GB) tripped lowmemorykiller on the 5.7 GB device; Q4 (1.2 GB) is the 6a-class tier.",
+          "Memory is dominated by resident weights: GL mtrack holds ~2.25 GB constant idle→active; per-turn delta is only ~100 MB PSS / ~70 MB RSS.",
+          "Measured idle total RSS (2390 MB) already exceeds the provisional `maxSteadyRssMb` cap (2300 MB) for this class — another reason not to naively promote provisional ceilings to a gate before multi-run baselines exist."
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

Commits the **real** Pixel 6a device baselines captured for eliza-1-2b Q4 as **documented baselines** — partially satisfying #11352's acceptance line "commit the captured numbers as real baselines" without flipping the mobile-resource-workbench PR-gating lane (a single throttled run isn't stable enough to gate, and the issue explicitly says gate "until per-device baselines are stable").

## Captured numbers (Pixel 6a, Tensor GS101 / Mali-G78, Android 16, ~5.7 GB RAM; eliza-1-2b Q4 1.2 GB GGUF, bionic Vulkan host)

| State | TOTAL PSS | TOTAL RSS | GL mtrack | SWAP PSS |
|---|---:|---:|---:|---:|
| Idle | 2.50 GB | 2.39 GB | 2.25 GB | 195 MB |
| Chat-active | 2.60 GB | 2.46 GB | 2.25 GB | 217 MB |
| Delta (active−idle) | ~100 MB | ~70 MB | 0 | +22 MB |

Decode: **4.8 tok/s warm**, ~3.1 cold (first turn incl. load). llama-bench same libs: pp32 2.60, tg32 6.85 t/s.

**Finding:** the eliza-1-2b E2B variant (4.9 GB) tripped lowmemorykiller on the 5.7 GB device; Q4 (1.2 GB) is the 6a-class tier. Memory is dominated by resident weights (GL mtrack ~2.25 GB constant), not per-turn work.

## How (schema-respecting, non-gating)

The runner (`run-workbench.mjs`) reads only `budgets.deviceClasses.*` + `leakGrowthMbThreshold`. So:
- Real numbers go in a **new non-gating `budgets.json → measuredBaselines` block** (clearly commented) + the `BASELINE.md` measured-baselines table.
- The gating `deviceClasses` budgets stay **`null`** — nothing here can fail a PR.

## Validation

- `node --test packages/benchmarks/mobile-resource/metrics.test.mjs` → 7/7 pass
- `budgets.json` parses; `loadBudgets()` returns unchanged gate budgets; `measuredBaselines` populated
- Data + docs only (no `.ts`) → typecheck N/A

## Still hardware/power-meter-gated (#11352 stays OPEN)

Battery / power draw (idle / chat / voice / background), TTFT distribution, isolated prefill tok/s, thermal timeline, iOS, eliza-1-4b tier, and multi-run stability before promotion to a gate. Evidence + full gap list: `.github/issue-evidence/11352-pixel6a-baseline/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)