### PR TITLE
fix(cloud): block container metadata egress

### DIFF
--- a/.github/issue-evidence/11691-metadata-egress-guard.md
+++ b/.github/issue-evidence/11691-metadata-egress-guard.md
@@ -1,0 +1,125 @@
+# Issue #11691 — container metadata egress guard
+
+## Summary
+
+Hardened newly bootstrapped Hetzner container nodes against tenant-container reads
+of cloud-init user-data through the cloud metadata endpoint.
+
+Changes made:
+
+- Added a boot-persistent `eliza-container-egress-guard.service` to
+  `buildContainerNodeUserData()` that installs a `DOCKER-USER` iptables drop for
+  `169.254.169.254/32`.
+- Apply the guard immediately after Docker starts and before the shared tenant
+  bridge network, registry login/logout, or pre-pull work runs.
+- Stopped treating broad GitHub tokens (`GITHUB_TOKEN`, `GH_TOKEN`, `CR_PAT`) as
+  container-node pull credentials. Nodes now use the dedicated registry pull env
+  vars only: `CONTAINERS_REGISTRY_TOKEN`, `ELIZA_APP_IMAGE_REGISTRY_TOKEN`, or
+  `GHCR_TOKEN`.
+
+## Validation
+
+### Targeted tests
+
+Command:
+
+```bash
+bun test packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.test.ts
+```
+
+Result:
+
+- Pass: 15
+- Fail: 0
+- Expect calls: 30
+
+Covered assertions:
+
+- User-data includes the metadata endpoint drop in `DOCKER-USER`.
+- Guard service is enabled before tenant network creation.
+- No registry token configured still performs stale-credential `docker logout`.
+- Dedicated registry token still performs `docker login`.
+- Broad `GITHUB_TOKEN` is not embedded in user-data and does not trigger login.
+
+### Typecheck
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/shared typecheck
+```
+
+Result: pass (`tsgo --noEmit`).
+
+### Lint
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/shared lint
+```
+
+Result: pass (`biome check .`, 1312 files checked).
+
+### Root verify
+
+Commands:
+
+```bash
+git fetch origin && git rebase origin/develop
+bun install
+bun run verify
+```
+
+Result: fail after build/typecheck on an unrelated `audit:test-realness`
+baseline issue:
+
+- `test-realness-audit` reported `todoTest must stay at 0, found 1`.
+- The failure points at an existing `test.todo` under the vendored opencode tree,
+  outside this change's cloud bootstrap path:
+  `plugins/plugin-agent-orchestrator/vendor/opencode/packages/opencode/test/session/instruction.test.ts`.
+- Before that failure, the root build/typecheck lane completed: 483 successful
+  Turbo tasks, followed by passing build/typecheck dependency audits,
+  `audit-tee-secret-leak`, and `audit-scripts`.
+
+During the first root verify run, `audit:type-safety-ratchet` failed because the
+repo baseline had drifted to 79 `as unknown as` casts against a budget of 75.
+The warmup eviction e2e fixture now removes four unsafe casts and supplies the
+current `ShellController` shape directly. A focused rerun of
+`bun run audit:type-safety-ratchet` passed at the required baseline:
+`as unknown as: 75 / 75`.
+
+### Package test sweep
+
+Command:
+
+```bash
+bun run --cwd packages/cloud/shared test
+```
+
+Result: fail with unrelated existing package-suite drift:
+
+- Pass: 2496
+- Skip: 52
+- Fail: 13
+- Expect calls: 6818
+
+Failures were outside the touched files:
+
+- `0164_pooled_credentials migration up (#11332) > is registered in the drizzle journal`
+- `AppFrontendHosting — DB invariants + GC + failure cleanup (#10690 review) > pglite applied`
+- `container billing gate + row-lock guard` (2 failures, missing `settled_at` in PGlite schema)
+- `updateCampaign` advertising reconciliation fixture failures (7 failures; ad account inactive fixture)
+- `reconcile() — settle reserved vs actual` (2 failures; missing settlement column/query path)
+
+The touched bootstrap tests passed during this full package run as well.
+
+## Evidence Matrix
+
+- Real cloud node: N/A - this change is a deterministic cloud-init generation
+  hardening; no Hetzner node credentials were available in this environment.
+- Backend logs: N/A - no API/runtime path changed; behavior is generated
+  bootstrap script content.
+- DB rows/migrations: N/A - no schema or repository behavior changed.
+- UI screenshots/video: N/A - no UI change.
+- Model trajectories: N/A - no model, prompt, action, or provider behavior changed.

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -75,14 +75,7 @@ export const containersEnv = {
   /** Token used for Docker registry pulls on container nodes. */
   registryToken(): string | undefined {
     const env = getCloudAwareEnv();
-    return pick(
-      env.CONTAINERS_REGISTRY_TOKEN,
-      env.ELIZA_APP_IMAGE_REGISTRY_TOKEN,
-      env.GHCR_TOKEN,
-      env.GITHUB_TOKEN,
-      env.GH_TOKEN,
-      env.CR_PAT,
-    );
+    return pick(env.CONTAINERS_REGISTRY_TOKEN, env.ELIZA_APP_IMAGE_REGISTRY_TOKEN, env.GHCR_TOKEN);
   },
 
   /** Filesystem path to a Docker registry token for container node pulls. */

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts
@@ -28,6 +28,14 @@ const baseInput = {
 };
 
 describe("buildContainerNodeUserData — ghcr access", () => {
+  test("blocks Docker container egress to the cloud metadata endpoint on every boot", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData(baseInput);
+    expect(userData).toContain("eliza-container-egress-guard.service");
+    expect(userData).toContain("iptables -C DOCKER-USER -d 169.254.169.254/32 -j DROP");
+    expect(userData).toContain("iptables -I DOCKER-USER 1 -d 169.254.169.254/32 -j DROP");
+  });
+
   test("clears stale ghcr creds (logout) when no registry token is configured", () => {
     clearRegistryEnv();
     const userData = buildContainerNodeUserData(baseInput);
@@ -45,6 +53,16 @@ describe("buildContainerNodeUserData — ghcr access", () => {
     expect(userData).not.toContain("docker logout");
   });
 
+  test("does not treat broad GitHub tokens as node pull credentials", () => {
+    clearRegistryEnv();
+    process.env.GITHUB_TOKEN = "ghp_write_capable_token";
+    process.env.GITHUB_ACTOR = "robot";
+    const userData = buildContainerNodeUserData(baseInput);
+    expect(userData).toContain("docker logout 'ghcr.io' >/dev/null 2>&1 || true");
+    expect(userData).not.toContain("docker login");
+    expect(userData).not.toContain("ghp_write_capable_token");
+  });
+
   test("ghcr-access step runs after the bridge network and before the pre-pull", () => {
     clearRegistryEnv();
     const userData = buildContainerNodeUserData(baseInput);
@@ -54,5 +72,18 @@ describe("buildContainerNodeUserData — ghcr access", () => {
     expect(networkIdx).toBeGreaterThanOrEqual(0);
     expect(accessIdx).toBeGreaterThan(networkIdx);
     expect(pullIdx).toBeGreaterThan(accessIdx);
+  });
+
+  test("metadata egress guard is applied before tenant network setup", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData(baseInput);
+    const dockerIdx = userData.indexOf("systemctl enable --now docker");
+    const guardIdx = userData.indexOf(
+      "systemctl enable --now eliza-container-egress-guard.service",
+    );
+    const networkIdx = userData.indexOf("docker network create");
+    expect(dockerIdx).toBeGreaterThanOrEqual(0);
+    expect(guardIdx).toBeGreaterThan(dockerIdx);
+    expect(networkIdx).toBeGreaterThan(guardIdx);
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-bootstrap.ts
@@ -18,6 +18,7 @@
  */
 
 import { containersEnv } from "../../config/containers-env";
+import { CLOUD_METADATA_IP } from "../app-firewall-utils";
 import { validateDockerPlatform } from "../docker-sandbox-utils";
 import { getImageRegistryHost } from "./hetzner-client/registry";
 
@@ -130,6 +131,28 @@ write_files:
     content: |
       ${sshKey}
     append: true
+  - path: /usr/local/sbin/eliza-container-egress-guard.sh
+    permissions: '0755'
+    content: |
+      #!/bin/sh
+      set -eu
+      iptables -N DOCKER-USER 2>/dev/null || true
+      iptables -C DOCKER-USER -d ${CLOUD_METADATA_IP}/32 -j DROP 2>/dev/null || iptables -I DOCKER-USER 1 -d ${CLOUD_METADATA_IP}/32 -j DROP
+  - path: /etc/systemd/system/eliza-container-egress-guard.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Block Docker container access to cloud metadata endpoint
+      Requires=docker.service
+      After=docker.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/eliza-container-egress-guard.sh
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
 
 runcmd:
   - chage -M 99999 -E -1 root || true
@@ -137,6 +160,8 @@ runcmd:
   - chmod 0700 /data/containers /data/agents
   - curl -fsSL https://get.docker.com | sh
   - systemctl enable --now docker
+  - systemctl daemon-reload
+  - systemctl enable --now eliza-container-egress-guard.service
   - docker network inspect '${sanitizeShellSingleQuoted(network)}' >/dev/null 2>&1 || docker network create --driver bridge '${sanitizeShellSingleQuoted(network)}'
 ${registryAccessCommands}
 ${prePullCommands}${registerSection}

--- a/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
@@ -17,7 +17,13 @@ import type { UseChatSendDeps } from "../../../state/useChatSend";
 import { useChatSend } from "../../../state/useChatSend";
 import { ContinuousChatOverlay } from "../ContinuousChatOverlay";
 import type { ShellMessage } from "../shell-state";
-import type { ShellController } from "../useShellController";
+import type { ConversationNav, ShellController } from "../useShellController";
+
+declare global {
+  interface Window {
+    __setModelReady?: (ready: boolean) => void;
+  }
+}
 
 // ── Scripted server (the boundary) ─────────────────────────────────────────
 // Mirrors the real agent's warm-up behavior: the runtime-ready hold expires →
@@ -25,14 +31,20 @@ import type { ShellController } from "../useShellController";
 
 const serverThread: ConversationMessage[] = [];
 let modelReady = false;
-(
-  window as unknown as { __setModelReady?: (ready: boolean) => void }
-).__setModelReady = (ready: boolean) => {
+window.__setModelReady = (ready: boolean) => {
   console.log(`[fixture] modelReady -> ${ready}`);
   modelReady = ready;
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const CONVERSATION: Conversation = {
+  id: "conv-1",
+  roomId: "room-1",
+  title: "New Chat",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+} as Conversation;
 
 client.sendConversationMessageStream = (async (
   _convId: string,
@@ -57,19 +69,12 @@ client.sendConversationMessageStream = (async (
 }) as typeof client.sendConversationMessageStream;
 client.sendWsMessage = (() => {}) as typeof client.sendWsMessage;
 client.getBaseUrl = (() => "") as typeof client.getBaseUrl;
-client.abortConversationTurn = (async () => ({
+client.abortConversationTurn = async (roomId, reason = "ui-abort") => ({
   aborted: false,
-})) as unknown as typeof client.abortConversationTurn;
-client.renameConversation = (async () =>
-  ({})) as unknown as typeof client.renameConversation;
-
-const CONVERSATION: Conversation = {
-  id: "conv-1",
-  roomId: "room-1",
-  title: "New Chat",
-  createdAt: new Date().toISOString(),
-  updatedAt: new Date().toISOString(),
-} as Conversation;
+  roomId,
+  reason,
+});
+client.renameConversation = async () => ({ conversation: CONVERSATION });
 
 // ── Harness ────────────────────────────────────────────────────────────────
 
@@ -167,22 +172,50 @@ function Harness(): React.JSX.Element {
     [sendChatText],
   );
 
-  const controller = {
+  const conversationNav = React.useMemo<ConversationNav>(
+    () => ({
+      hasPrev: false,
+      hasNext: false,
+      goPrev: () => {},
+      goNext: () => {},
+      activeId: "conv-1",
+      index: 0,
+    }),
+    [],
+  );
+
+  const controller: ShellController = {
     phase: "summoned",
     responding: chatSending,
     turnStatus: chatSending ? { kind: "thinking" as const } : null,
     messages,
     canSend: true,
     recording: false,
+    waveformMode: "idle",
+    analyser: null,
+    open: () => {},
+    close: () => {},
+    isOpen: true,
     handsFree: false,
     transcript: "",
     speaking: false,
+    speak: () => {},
+    stopSpeaking: () => {},
     agentVoiceMuted: false,
     needsAudioUnlock: false,
     transcriptionMode: false,
+    captureVision: () => {},
+    visionCapturing: false,
     toggleTranscriptionMode: () => {},
     stopTranscriptionAndMic: () => {},
-    modelStatus: { kind: "ready" },
+    modelStatus: {
+      kind: "ready",
+      blocksSend: false,
+      percent: null,
+      etaMs: null,
+      modelName: null,
+      errors: [],
+    },
     send,
     toggleRecording: () => {},
     toggleHandsFree: () => {},
@@ -198,7 +231,8 @@ function Harness(): React.JSX.Element {
     navigateToViews: () => {},
     clearConversation: () => {},
     stop: () => {},
-  } as unknown as ShellController;
+    conversationNav,
+  };
 
   return (
     <div


### PR DESCRIPTION
Fixes #11691

## Summary
- Install a boot-persistent DOCKER-USER egress guard on container nodes to drop tenant-container traffic to 169.254.169.254 before tenant network/pre-pull work.
- Stop using broad GitHub tokens (GITHUB_TOKEN/GH_TOKEN/CR_PAT) as node registry pull credentials; keep dedicated pull-token envs.
- Extend bootstrap tests and restore the root type-safety ratchet by removing unsafe casts from the warmup e2e fixture.

## Validation
- bun test packages/cloud/shared/src/lib/services/containers/node-bootstrap.test.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/registry.test.ts
- bun run --cwd packages/cloud/shared typecheck
- bun run --cwd packages/cloud/shared lint
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/ui lint
- bun run audit:type-safety-ratchet
- git fetch origin && git rebase origin/develop
- bun install
- bun run verify (fails after 483/483 Turbo tasks on unrelated nested opencode submodule test.todo; see evidence)
- bun run --cwd packages/cloud/shared test (known unrelated package-suite failures; see evidence)

## Evidence
- .github/issue-evidence/11691-metadata-egress-guard.md
