### PR TITLE
test(cloud): make the insufficient-credits no-LLM assertion non-vacuous (follow-up to #11688)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -858,6 +858,11 @@ describe("runOnboardingChat", () => {
     });
 
     test("insufficient-credits reply is deterministic and points at billing", async () => {
+      // With a live Cerebras client configured, only the deterministic
+      // early-return keeps the model out of the money-state reply; without
+      // this key the not-called assertion below is vacuously true.
+      cloudEnv = { CEREBRAS_API_KEY: "test-key" };
+      generateText.mockResolvedValue({ text: "model-improvised billing copy" });
       ensureElizaAppProvisioning.mockResolvedValue({
         status: "insufficient_credits",
         agentId: null,


### PR DESCRIPTION
## Summary

Post-merge review of #11688 mutation-checked the new insufficient-credits onboarding test:

- Removing the `fallbackReply` billing branch (`onboarding-chat.ts:386`) → test reds. Good.
- Removing the deterministic early-return in `generateOnboardingReply` (`onboarding-chat.ts:444`) → **all 39 tests still pass.** The `expect(generateText).not.toHaveBeenCalled()` assertion is vacuously true because the suite's `beforeEach` resets `cloudEnv = {}`, so `getCerebrasClient()` returns null and the fallback path is taken with or without the guard.

This one-test change sets `CEREBRAS_API_KEY` in the test (same pattern as the sanitizer tests at lines ~951-977) and gives `generateText` a return value, so the only thing keeping the model out of the money-state reply is the early-return under test.

## Validation (local, develop tip e59ddaf5338)

- `bun test --isolate src/lib/services/eliza-app/onboarding-chat.test.ts` → 39 pass / 0 fail / 213 assertions
- Mutation check re-run: with the `generateOnboardingReply` early-return removed, exactly this test reds (38 pass / 1 fail). Restored source untouched.
- `bunx biome check` on the touched file → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)