### PR TITLE
fix(orchestrator): don't post a completion per verify-retry lineage teardown (#11711)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -913,6 +913,75 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
+  it("does NOT synthesize a `stopped` for a session handed off to a successor (#11711)", async () => {
+    // The router's verify-retry / state-lost-respawn / account-failover paths
+    // re-dispatch a fresh session and tear down the old one — its teardown
+    // `stopped` is plumbing, not a user-facing terminal. The router stamps
+    // `handedOffToSuccessorSessionId` on the old session before teardown, so
+    // synthesis must skip it: the successor session posts the real completion.
+    // Without this, one task yielded one post per lineage generation (3 for a
+    // 2-retry lineage).
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        handedOffToSuccessorSessionId: "sess-retry-2",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-handed-off", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("STILL synthesizes a genuine user `stopped` (no handoff marker) — the #11689 invariant", async () => {
+    // A real cancel / no-output stop carries NO handoff marker, so it must NOT
+    // be swallowed by the #11711 skip — synthesis stays its only poster.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-user-stop", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      stopped: 1,
+      tasks: [{ sessionId: "sess-user-stop", status: "stopped" }],
+    });
+    await coordinator.stop();
+  });
+
   it("STILL fires swarm-complete for a custom-validator task_complete on a router-origin active session", async () => {
     // The app-verification / custom-validator result is synthesized by the
     // coordinator (dispatchCustomValidatorResult); the router never receives or

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -53,6 +53,14 @@ type RuntimeWithSendTarget = IAgentRuntime & {
 
 const ACPX_ROUTER_SOURCE = "sub_agent";
 const SUB_AGENT_ENTITY_NAMESPACE = "acpx:sub-agent";
+// Metadata key the router stamps on a session it hands off to a successor
+// (verify-retry, state-lost respawn, or account failover) before that session
+// is torn down. Its teardown `stopped` is handoff plumbing, not a user-facing
+// terminal — swarm-synthesis reads this key to skip posting it, so one task
+// yields one completion, not one per lineage generation (#11711). The value is
+// the successor's sessionId (for traceability); presence is what matters. Kept
+// as a matching local literal in swarm-coordinator-service.ts (no cross-import).
+const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 const QUESTION_FOR_TASK_CREATOR = "QUESTION_FOR_TASK_CREATOR";
 const AGENT_COORDINATION = "AGENT_COORDINATION";
 const SWARM_ROLE_ORDER = ["task", "worktree", "origin"] as const;
@@ -1554,6 +1562,9 @@ export class SubAgentRouter extends Service {
         sessionId: session.id,
         retrySessionId: result.sessionId,
       });
+      // Same handoff stamp as verify-retry (#11711): the old session's teardown
+      // `stopped` is plumbing, not a user-facing completion — the respawn posts.
+      await this.markSessionHandedOff(session.id, result.sessionId);
       return true;
     } catch (err) {
       this.log(
@@ -1600,6 +1611,31 @@ export class SubAgentRouter extends Service {
    * lineage of retries shares one budget. Mirrors the APP-create
    * verification-retry pattern.
    */
+  /**
+   * Stamp `handedOffToSuccessorSessionId` on a session the router is about to
+   * tear down after handing its work to a fresh successor (#11711), so
+   * swarm-synthesis skips the teardown `stopped` — the successor posts the real
+   * completion. Best-effort and NEVER throws: a missed stamp only risks the
+   * prior duplicate-post behavior, so it must not fail the handoff itself (the
+   * ACP transport may lack `updateSessionMetadata` in some stub/test contexts).
+   */
+  private async markSessionHandedOff(
+    oldSessionId: string,
+    successorSessionId: string,
+  ): Promise<void> {
+    const service =
+      this.acp ??
+      (this.runtime.getService("ACP_SUBPROCESS_SERVICE") as AcpService | null);
+    if (typeof service?.updateSessionMetadata !== "function") return;
+    try {
+      await service.updateSessionMetadata(oldSessionId, {
+        [HANDED_OFF_SUCCESSOR_META_KEY]: successorSessionId,
+      });
+    } catch {
+      // best-effort — see doc comment
+    }
+  }
+
   private async retryIncompleteBuild(
     session: SessionInfo,
     dead: DeadUrl[],
@@ -1694,6 +1730,11 @@ Do not report done until every referenced URL in the final page resolves without
         maxRetries,
         deadCount: dead.length,
       });
+      // Mark the old session as handed off BEFORE its teardown `stopped` fires
+      // so synthesis treats that stop as plumbing, not a second completion
+      // (#11711). Best-effort: a missed stamp only risks the prior duplicate
+      // post, never a dropped genuine terminal.
+      await this.markSessionHandedOff(session.id, result.sessionId);
       return true;
     } catch (err) {
       this.log(

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -154,6 +154,14 @@ const STREAMING_SESSION_EVENTS = new Set(["message", "reasoning", "plan"]);
 // inject, so the coordinator stays the sole poster for stop/cancel/no-output.
 const ROUTER_OWNED_TERMINAL_EVENTS = new Set(["task_complete", "error"]);
 
+// Metadata key the sub-agent-router stamps on a session it hands off to a
+// successor (verify-retry / state-lost respawn / account failover) before
+// tearing it down. That teardown `stopped` is handoff plumbing, not a
+// user-facing terminal — the successor session posts the real completion, so
+// synthesis must not post the old one (#11711). Matching local literal (no
+// import from sub-agent-router — see the ROUTER_ORIGIN_UUID_RE note).
+const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -840,6 +848,19 @@ export class SwarmCoordinatorService extends Service {
       sessionMeta = { metadata: {} };
     }
     const meta = sessionMeta.metadata;
+
+    // Handoff teardown (#11711): a session the router handed off to a successor
+    // (verify-retry, state-lost respawn, or account failover) is torn down with
+    // a `stopped` terminal that is plumbing, not a user-facing end state — the
+    // successor session posts the real completion. The router stamps the old
+    // session with `handedOffToSuccessorSessionId` before teardown; skip its
+    // terminal so one task yields ONE completion, not one per lineage
+    // generation. A genuine user stop carries no marker and still synthesizes
+    // (the #11689 invariant). Do NOT claim the dedupe slot — the successor's
+    // terminal must remain free to post.
+    if (readString(meta, HANDED_OFF_SUCCESSOR_META_KEY)) {
+      return;
+    }
 
     // Ownership rule (issue elizaOS/eliza#11634): the sub-agent-router owns the
     // completion→chat post for origin-routed sessions — it is origin-aware,


### PR DESCRIPTION
## Symptom

A user asked for one website and got **three** "completion" messages for the one task (plus a raw-format leak tracked separately). Live round-5 Discord trace: three `stopped` session events, each → `[swarm-synthesis] Generating synthesis` → `Routed result to discord`.

## Root cause

The sub-agent-router's verify-retry loop (`retryIncompleteBuild`) — and the `respawnStateLost` / account-failover paths — re-dispatch a **fresh successor session** when a `task_complete` references dead URLs, then tear down the old session. That teardown emits a `stopped` terminal event.

**#11689** deliberately keeps swarm-synthesis as the poster for `stopped` (the router never injects it, and a real user cancel must not go silent). But a teardown-stop of a session the router **just handed off** is not a user-facing terminal — it's plumbing. Synthesis couldn't tell the difference (the router's `verifyRetryHandedOffSessions` set is router-internal), so it fired a full synthesis post per lineage generation: **original + retry1 + retry2 = 3 posts for 1 task**.

## Fix

Make the handoff visible to synthesis across the service boundary (both services read session metadata; neither imports the other — matching the existing `ROUTER_ORIGIN_UUID_RE` local-literal convention):

- **Router** stamps `handedOffToSuccessorSessionId` (the successor's sessionId) on the **old** session's metadata before teardown, at both spawn methods (`retryIncompleteBuild`, `respawnStateLost` — which covers all three handoff call sites). A non-throwing best-effort helper (`markSessionHandedOff`) guards `updateSessionMetadata` existence, so a transport/stub without it never fails the handoff.
- **`runSwarmComplete`** skips a terminal that carries the marker, **without claiming the dedupe slot** — the successor session's terminal posts the real completion.
- A **genuine user stop carries no marker and still synthesizes** — the #11689 invariant.

## Tests

Two new regression tests in `swarm-coordinator-service.test.ts`, both directions:
- handed-off session (`handedOffToSuccessorSessionId` present) `stopped` → **does NOT** synthesize.
- genuine user `stopped` (no marker) → **STILL** synthesizes (#11689).

Verification:
- `swarm-coordinator-service.test.ts`: 43 passed (2 new).
- Router + capture suites: 136 passed together.
- **Full orchestrator suite: 1545 passed, 8 skipped, 0 failures.**
- `turbo typecheck --filter=@elizaos/plugin-agent-orchestrator`: 60/60.

Closes #11711

🤖 Generated with [Claude Code](https://claude.com/claude-code)