### PR TITLE
fix(orchestrator): stopped handoff-marker check re-reads past a stale enrichment cache (#11711 residual)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -982,6 +982,103 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
+  it("re-reads the store for a `stopped` when the cached snapshot pre-dates the handoff stamp (#11711 residual)", async () => {
+    // Cache-staleness race: the earlier same-session `task_complete` (the one
+    // that triggered the verify-retry) warms the enrichment cache from the
+    // store BEFORE the router stamps `handedOffToSuccessorSessionId`. So the
+    // snapshot the following `stopped` reads from the cache lacks the marker.
+    // Without a fresh re-read, the teardown-stop is mistaken for a user stop
+    // and synthesized — the exact residual left after #11720. The `stopped`
+    // must re-read the store once, see the freshly-stamped marker, and skip.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        // Pre-stamp snapshot: NO handoff marker yet.
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // Warm the cache with the pre-stamp snapshot (mirrors the task_complete that
+    // triggered the retry populating the enrichment cache from the store).
+    acp.emit("sess-stale", "task_complete", { response: "turn done" });
+    await new Promise((r) => setTimeout(r, 0));
+    fired.mockClear();
+
+    // The router now stamps the marker on the store AFTER the cache was warmed.
+    acp.setSession({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        handedOffToSuccessorSessionId: "sess-stale-retry-2",
+      },
+    });
+
+    // The teardown `stopped` reads the STALE cache (no marker) first, then
+    // re-reads the store and finds the stamp — so it must NOT synthesize.
+    acp.emit("sess-stale", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("a fresh-re-read miss on a `stopped` fails open and still synthesizes (#11711 residual)", async () => {
+    // Fail-open guard: if the store re-read returns no session (miss/error),
+    // `getFreshSessionMetadata` yields `{}` — an unknown session must be treated
+    // as "not superseded" so a genuine user stop is never silenced.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // Warm the cache, then drop the session from the store so the re-read misses.
+    acp.emit("sess-openmiss", "task_complete", { response: "turn done" });
+    await new Promise((r) => setTimeout(r, 0));
+    fired.mockClear();
+    acp.setSession(undefined);
+
+    acp.emit("sess-openmiss", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fired).toHaveBeenCalledTimes(1);
+    expect(fired.mock.calls[0][0]).toMatchObject({
+      total: 1,
+      stopped: 1,
+      tasks: [{ sessionId: "sess-openmiss", status: "stopped" }],
+    });
+    await coordinator.stop();
+  });
+
   it("STILL fires swarm-complete for a custom-validator task_complete on a router-origin active session", async () => {
     // The app-verification / custom-validator result is synthesized by the
     // coordinator (dispatchCustomValidatorResult); the router never receives or

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -858,7 +858,28 @@ export class SwarmCoordinatorService extends Service {
     // generation. A genuine user stop carries no marker and still synthesizes
     // (the #11689 invariant). Do NOT claim the dedupe slot — the successor's
     // terminal must remain free to post.
+    //
+    // Cache-staleness re-read (#11711 residual): the enrichment cache is warmed
+    // from the store on the earlier SAME-session `task_complete` — the one that
+    // triggered the verify-retry — which lands BEFORE the router stamps the
+    // marker on that session. So the cached snapshot the `stopped` reads here
+    // can pre-date the stamp and miss the marker, and the teardown-stop would
+    // be mistaken for a user stop and synthesized. Only for `stopped`, and only
+    // when the cached snapshot lacks the marker, re-read the store once via
+    // `getFreshSessionMetadata` (which also refreshes the cache). Fail-open: an
+    // unreadable/missing session yields `{}`, so an unknown session is treated
+    // as "not superseded" and still synthesizes — a genuine stop is never
+    // silenced.
     if (readString(meta, HANDED_OFF_SUCCESSOR_META_KEY)) {
+      return;
+    }
+    if (
+      event === "stopped" &&
+      readString(
+        await this.getFreshSessionMetadata(sessionId),
+        HANDED_OFF_SUCCESSOR_META_KEY,
+      )
+    ) {
       return;
     }
 
@@ -1061,6 +1082,37 @@ export class SwarmCoordinatorService extends Service {
 
   private shouldEnrichEvent(event: string): boolean {
     return !STREAMING_SESSION_EVENTS.has(event);
+  }
+
+  /**
+   * Cache-bypassing session-metadata read used by the handoff-teardown skip
+   * (#11711 residual). The enrichment cache can hold a pre-stamp snapshot of a
+   * session the router just superseded — warmed by the earlier same-session
+   * `task_complete` that triggered the retry, before the router stamped
+   * `handedOffToSuccessorSessionId` — so the `stopped` decision must be able to
+   * see a marker written after the cache was populated. Refreshes the cache so
+   * downstream reads in this same turn observe the fresh snapshot. Returns `{}`
+   * on any miss/error so callers treat "unknown" as "not superseded" and default
+   * to synthesizing (never silences a genuine stop).
+   */
+  private async getFreshSessionMetadata(
+    sessionId: string,
+  ): Promise<Record<string, unknown>> {
+    try {
+      const session = await this.acp()?.getSession(sessionId);
+      if (session && isRecord(session.metadata)) {
+        const refreshed: EnrichmentMetadata = {
+          metadata: session.metadata,
+          ...(session.workdir ? { workdir: session.workdir } : {}),
+          ...(session.agentType ? { agentType: session.agentType } : {}),
+        };
+        this.enrichmentMetadataCache.set(sessionId, refreshed);
+        return session.metadata;
+      }
+    } catch {
+      // fall through to empty — fail open (treat unknown as not-superseded)
+    }
+    return {};
   }
 
   private async getEnrichmentMetadata(


### PR DESCRIPTION
## Rescoped: #11711 residual only (on top of #11720)

**Base fix:** [#11720](https://github.com/elizaOS/eliza/pull/11720) merged first and landed the marker plumbing for #11711 — the sub-agent-router stamps `handedOffToSuccessorSessionId` on the OLD session before teardown (verify-retry / state-lost respawn / account failover), and `runSwarmComplete` skips synthesis for a `stopped` whose session metadata carries that marker.

This PR is rescoped to carry **only the one residual race** that survives on `develop`.

### The race (cache staleness)

The coordinator reads the handoff marker from the **cached enrichment snapshot**. In the verify-retry trace the OLD session's earlier same-session `task_complete` — the one that *triggers* the retry — warms the enrichment cache from the store **before** the router stamps the marker. So the following `stopped`:

1. reads the **stale, pre-stamp** cached snapshot,
2. misses the marker,
3. and synthesizes a spurious completion post — the teardown-stop is mistaken for a genuine user stop.

(Confirmed on `develop` in the live verify-retry trace — see https://github.com/elizaOS/eliza/issues/11711#issuecomment-4871634564.)

### Fix

For `stopped` **only**, when the cached snapshot lacks the marker, do **one** `acp.getSession()` re-read (via `getFreshSessionMetadata`, which also refreshes the cache) before concluding a genuine stop.

**Fail-open semantics:** an unreadable/missing session yields `{}`, so an unknown session is treated as *not-superseded* and still synthesizes — the #11689 genuine-user-stop invariant is never silenced.

### Scope

Everything #11720 already covers is kept from `develop` (marker constant, router-side stamping, the basic marker-skip, both-direction tests). This diff carries only:

- **coordinator:** the fresh-re-read guard for `stopped` + the `getFreshSessionMetadata` helper
- **tests:** the cache-staleness regression (`task_complete` warms cache pre-stamp → `setSession` stamps marker → `stopped` → **no synthesis**) + a fail-open-on-miss test

### Gates

- `swarm-coordinator-service.test.ts`: **45 pass** (+2 new)
- Full plugin suite: **1295 pass / 15 fail** (pre-existing module-resolution baseline: `uuid`/`drizzle-orm`/`smithers-orchestrator` unresolvable in test env — **zero new**)
- Biome clean on touched files

**Diff:** 2 files, +149.