### PR TITLE
fix(core): response-handler multi-line field parsing + fail-closed raw-transcript guard at send boundary (#11712)

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { parseActionParams } from "../actions";
 import type { Action, ActionResult, IAgentRuntime, Memory } from "../index";
 import {
+	parseMessageHandlerOutput,
+	routeMessageHandlerOutput,
+} from "../runtime/message-handler";
+import {
+	extractReplyTextFromTranscript,
+	looksLikeRawFieldTranscript,
+} from "../runtime/response-field-transcript";
+import {
 	actionResultsSuppressPostActionContinuation,
 	applyDirectCurrentCandidateBackstopToMessageHandler,
 	BUILTIN_RESPONSE_HANDLER_EVALUATORS,
@@ -85,6 +93,60 @@ describe("sub-agent completion relay — never promoted to tooling (false 'hit a
 			},
 		} as unknown as Memory;
 		expect(gate?.shouldRun(contextFor(fresh))).toBe(true);
+	});
+});
+
+describe("raw field-transcript leak — #11712 (text-mode HANDLE_RESPONSE)", () => {
+	// Live regression: a cli-inference / claude-sdk warm session in text mode
+	// echoed the field set back as a plain-text keyed transcript instead of JSON.
+	// The multi-line replyText (embedded blank line between the URL and the
+	// "built it out..." prose) broke naive segmentation, so the WHOLE raw
+	// transcript fell through as the reply and was shipped verbatim to discord.
+	const LEAKED = `shouldRespond: RESPOND
+
+replyText: it's live \u2600\ufe0f https://sol.shad0w.xyz/apps/aurora/
+
+built it out at /workspace/apps, aurora's got the modern design + interactive bits you asked for. go click around and tell me what's ugly.
+
+contexts: simple
+
+topics: website build, aurora
+
+emotion: none`;
+
+	it("parses the raw text-mode transcript to the clean replyText and routes it as a final_reply (no raw skeleton shipped)", () => {
+		const parsed = parseMessageHandlerOutput(LEAKED);
+		expect(parsed).not.toBeNull();
+		if (parsed === null) throw new Error("expected a parsed transcript");
+		// Route it exactly as the runtime would.
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("final_reply");
+		if (route.type !== "final_reply") throw new Error("expected final_reply");
+		// The reply is the intended replyText VALUE, not the raw transcript.
+		expect(route.reply).not.toContain("shouldRespond:");
+		expect(route.reply).not.toMatch(/^replyText:/m);
+		expect(route.reply).toContain("https://sol.shad0w.xyz/apps/aurora/");
+		expect(route.reply).toContain("\u2600\ufe0f");
+		expect(route.reply).toContain("built it out at /workspace/apps");
+	});
+
+	it("the send-boundary guard extracts replyText if a raw transcript still reaches it", () => {
+		expect(looksLikeRawFieldTranscript(LEAKED)).toBe(true);
+		const recovered = extractReplyTextFromTranscript(LEAKED);
+		expect(recovered).not.toBeNull();
+		expect(recovered).not.toContain("shouldRespond:");
+		expect(recovered).toContain("https://sol.shad0w.xyz/apps/aurora/");
+	});
+
+	it("leaves a normal reply untouched (guard does not false-positive)", () => {
+		expect(looksLikeRawFieldTranscript("it's live, go check it out")).toBe(
+			false,
+		);
+		expect(
+			looksLikeRawFieldTranscript(
+				"Here is the plan:\n1. build the page\n2. deploy it",
+			),
+		).toBe(false);
 	});
 });
 

--- a/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
+++ b/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { parseMessageHandlerOutput } from "../message-handler";
+import {
+	extractReplyTextFromTranscript,
+	looksLikeRawFieldTranscript,
+	parseFieldTranscript,
+	splitTranscriptList,
+} from "../response-field-transcript";
+
+// The EXACT leaked transcript from issue #11712 (round-5 discord test). The
+// replyText value spans multiple lines with an embedded blank line between the
+// URL line and the "built it out..." line — the prime segmentation killer.
+const LEAKED_TRANSCRIPT = `shouldRespond: RESPOND
+
+replyText: it's live ☀️ https://sol.shad0w.xyz/apps/aurora/
+
+built it out at /workspace/apps, aurora's got the modern design + interactive bits you asked for. go click around and tell me what's ugly.
+
+contexts: simple
+
+topics: website build, aurora
+
+emotion: none`;
+
+const EXPECTED_REPLY = `it's live ☀️ https://sol.shad0w.xyz/apps/aurora/
+
+built it out at /workspace/apps, aurora's got the modern design + interactive bits you asked for. go click around and tell me what's ugly.`;
+
+describe("response field transcript — parseFieldTranscript", () => {
+	it("segments the exact leaked #11712 transcript, preserving the multi-line replyText with its embedded blank line, URL, and emoji", () => {
+		const parsed = parseFieldTranscript(LEAKED_TRANSCRIPT);
+		expect(parsed).not.toBeNull();
+		expect(parsed?.fields.shouldRespond).toBe("RESPOND");
+		expect(parsed?.fields.replyText).toBe(EXPECTED_REPLY);
+		// The value keeps the embedded blank line, the ☀️ emoji, and the URL.
+		expect(parsed?.fields.replyText).toContain("☀️");
+		expect(parsed?.fields.replyText).toContain(
+			"https://sol.shad0w.xyz/apps/aurora/",
+		);
+		expect(parsed?.fields.replyText).toContain("\n\n");
+		expect(parsed?.fields.contexts).toBe("simple");
+		expect(parsed?.fields.topics).toBe("website build, aurora");
+		expect(parsed?.fields.emotion).toBe("none");
+	});
+
+	it("terminates a field value only at the next known-field line, not at a blank line", () => {
+		const t = `replyText: line one
+
+line two after a blank
+
+line three
+
+contexts: simple`;
+		const parsed = parseFieldTranscript(t);
+		expect(parsed?.fields.replyText).toBe(
+			"line one\n\nline two after a blank\n\nline three",
+		);
+		expect(parsed?.fields.contexts).toBe("simple");
+	});
+
+	it("does not split on a colon that appears inside a value (e.g. a ratio)", () => {
+		const t = `replyText: the ratio is 3:1 and the time is 10:30
+
+contexts: simple`;
+		const parsed = parseFieldTranscript(t);
+		expect(parsed?.fields.replyText).toBe(
+			"the ratio is 3:1 and the time is 10:30",
+		);
+		expect(parsed?.fields.contexts).toBe("simple");
+	});
+
+	it("returns null when there are no known field lines (plain prose)", () => {
+		expect(
+			parseFieldTranscript("just a normal reply, nothing keyed"),
+		).toBeNull();
+		expect(parseFieldTranscript("")).toBeNull();
+		expect(parseFieldTranscript(null)).toBeNull();
+	});
+
+	it("first occurrence of a field wins (de-dup)", () => {
+		const t = `replyText: first
+
+replyText: second`;
+		const parsed = parseFieldTranscript(t);
+		expect(parsed?.fields.replyText).toBe("first");
+	});
+});
+
+describe("response field transcript — extractReplyTextFromTranscript", () => {
+	it("recovers the intended reply from the leaked transcript", () => {
+		expect(extractReplyTextFromTranscript(LEAKED_TRANSCRIPT)).toBe(
+			EXPECTED_REPLY,
+		);
+	});
+
+	it("returns null for non-transcript prose and for empty replyText", () => {
+		expect(extractReplyTextFromTranscript("hi there")).toBeNull();
+		expect(
+			extractReplyTextFromTranscript("shouldRespond: RESPOND\n\nreplyText: "),
+		).toBeNull();
+	});
+});
+
+describe("response field transcript — looksLikeRawFieldTranscript (send-boundary guard)", () => {
+	it("flags text that leads with shouldRespond:", () => {
+		expect(looksLikeRawFieldTranscript(LEAKED_TRANSCRIPT)).toBe(true);
+		expect(looksLikeRawFieldTranscript("shouldRespond: IGNORE")).toBe(true);
+	});
+
+	it("flags text containing a replyText: line", () => {
+		expect(looksLikeRawFieldTranscript("some preamble\nreplyText: hello")).toBe(
+			true,
+		);
+	});
+
+	it("does NOT flag normal replies without field markers", () => {
+		expect(looksLikeRawFieldTranscript("it's live ☀️ go check it out")).toBe(
+			false,
+		);
+		expect(
+			looksLikeRawFieldTranscript(
+				"Here is the plan:\n1. do a thing\n2. do another thing",
+			),
+		).toBe(false);
+		expect(looksLikeRawFieldTranscript("")).toBe(false);
+		expect(looksLikeRawFieldTranscript(null)).toBe(false);
+	});
+});
+
+describe("response field transcript — splitTranscriptList", () => {
+	it("splits comma- and newline-separated values, collapsing none/empty", () => {
+		expect(splitTranscriptList("website build, aurora")).toEqual([
+			"website build",
+			"aurora",
+		]);
+		expect(splitTranscriptList("simple")).toEqual(["simple"]);
+		expect(splitTranscriptList("none")).toEqual([]);
+		expect(splitTranscriptList("")).toEqual([]);
+		expect(splitTranscriptList(undefined)).toEqual([]);
+	});
+});
+
+describe("parseMessageHandlerOutput — text-mode transcript path (#11712)", () => {
+	it("parses the exact leaked transcript to the correct replyText instead of falling through as raw", () => {
+		const result = parseMessageHandlerOutput(LEAKED_TRANSCRIPT);
+		expect(result).not.toBeNull();
+		expect(result?.processMessage).toBe("RESPOND");
+		expect(result?.plan.reply).toBe(EXPECTED_REPLY);
+		// It must NOT be the raw transcript.
+		expect(result?.plan.reply).not.toContain("shouldRespond:");
+		expect(result?.plan.contexts).toEqual(["simple"]);
+		expect(result?.extract?.topics).toEqual(["website build", "aurora"]);
+	});
+
+	it("still returns the canonical JSON parse for JSON input (untouched)", () => {
+		const json = JSON.stringify({
+			shouldRespond: "RESPOND",
+			replyText: "plain json reply",
+			contexts: ["simple"],
+		});
+		const result = parseMessageHandlerOutput(json);
+		expect(result?.plan.reply).toBe("plain json reply");
+		expect(result?.plan.contexts).toEqual(["simple"]);
+	});
+
+	it("returns null for plain prose with no field markers (falls through to plain-text handling)", () => {
+		expect(parseMessageHandlerOutput("just a normal reply")).toBeNull();
+	});
+});

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -7,6 +7,10 @@ import type {
 import type { AgentContext } from "../types/contexts";
 import { normalizeTopics } from "./builtin-field-evaluators";
 import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
+import {
+	parseFieldTranscript,
+	splitTranscriptList,
+} from "./response-field-transcript";
 
 export type V5MessageHandlerOutput = MessageHandlerResult;
 
@@ -48,7 +52,14 @@ export function parseMessageHandlerOutput(
 ): V5MessageHandlerOutput | null {
 	const parsed = parseJsonObject<Record<string, unknown>>(raw);
 	if (!parsed) {
-		return null;
+		// Some providers (cli-inference / claude-sdk warm sessions in text mode)
+		// echo the field set back as a plain-text keyed transcript instead of
+		// JSON: `shouldRespond: RESPOND\n\nreplyText: ...`. Recover the fields
+		// with the transcript grammar (multi-line values with embedded blank
+		// lines terminate only at the next `^<knownField>:` line). Without this
+		// the whole raw transcript falls through the tolerant plain-text path and
+		// is shipped verbatim to the user channel (#11712).
+		return parseMessageHandlerFieldTranscript(raw);
 	}
 
 	const processMessage = normalizeMessageHandlerAction(parsed.shouldRespond);
@@ -65,6 +76,60 @@ export function parseMessageHandlerOutput(
 	);
 
 	const extract = parseExtract(parsed);
+
+	const normalizedPlan: V5MessageHandlerOutput["plan"] = {
+		contexts,
+		reply: replyRaw,
+	};
+	if (candidateActions.length > 0) {
+		normalizedPlan.candidateActions = candidateActions;
+	}
+
+	return {
+		processMessage,
+		plan: normalizedPlan,
+		thought: "",
+		...(extract ? { extract } : {}),
+	};
+}
+
+/**
+ * Parse the plain-text keyed field transcript into a MessageHandlerResult.
+ * Mirrors the JSON path in {@link parseMessageHandlerOutput} but sources the
+ * fields from {@link parseFieldTranscript}. Returns null when the text is not a
+ * recognizable transcript (no known field lines) so the caller can fall through
+ * to the tolerant plain-text handler.
+ */
+function parseMessageHandlerFieldTranscript(
+	raw: string,
+): V5MessageHandlerOutput | null {
+	const transcript = parseFieldTranscript(raw);
+	if (!transcript) return null;
+	const { fields } = transcript;
+
+	// Require at least the routing field plus a reply-bearing field before we
+	// treat the text as a structured transcript. A lone stray `topics:` line in
+	// otherwise-prose output should NOT be reinterpreted as an envelope.
+	const hasShouldRespond = typeof fields.shouldRespond === "string";
+	const hasReplyText = typeof fields.replyText === "string";
+	if (!hasShouldRespond && !hasReplyText) return null;
+
+	const processMessage = normalizeMessageHandlerAction(fields.shouldRespond);
+	const contexts = splitTranscriptList(fields.contexts);
+	const replyRaw =
+		typeof fields.replyText === "string"
+			? stripJsonStructuralJunkReply(fields.replyText)
+			: undefined;
+	const candidateActions = normalizeStringHints(
+		splitTranscriptList(fields.candidateActionNames),
+		12,
+	);
+
+	const extract = parseExtract({
+		facts: splitTranscriptList(fields.facts),
+		addressedTo: splitTranscriptList(fields.addressedTo),
+		topics: splitTranscriptList(fields.topics),
+	});
 
 	const normalizedPlan: V5MessageHandlerOutput["plan"] = {
 		contexts,

--- a/packages/core/src/runtime/response-field-transcript.ts
+++ b/packages/core/src/runtime/response-field-transcript.ts
@@ -1,0 +1,196 @@
+/**
+ * response-field-transcript — tolerant parser + detector for the plain-text
+ * "keyed field transcript" shape that models occasionally emit instead of the
+ * canonical JSON HANDLE_RESPONSE envelope.
+ *
+ * The response-handler prompts the model with a set of named fields
+ * (`shouldRespond`, `replyText`, `contexts`, `topics`, `emotion`, ...). The
+ * canonical path is a JSON object (native tool call or JSON-as-text). But some
+ * providers — notably cli-inference / claude-sdk warm sessions in *text mode* —
+ * echo the field set back as a colon-delimited transcript:
+ *
+ *   shouldRespond: RESPOND
+ *
+ *   replyText: it's live https://example/
+ *
+ *   built it out at /workspace, go click around.
+ *
+ *   contexts: simple
+ *
+ *   topics: website build, aurora
+ *
+ *   emotion: none
+ *
+ * Two properties make this hard and were the root cause of issue #11712:
+ *   1. A field VALUE can span multiple lines and can contain embedded blank
+ *      lines (see `replyText` above — a URL line, a blank line, then more
+ *      prose). Naive "split on blank line" segmentation drops the tail of the
+ *      value or, worse, fails to recognise the shape at all so the WHOLE raw
+ *      transcript falls through as the reply and is sent verbatim to the user.
+ *   2. Because the JSON parser rejects it, the tolerant plain-text fallback
+ *      treated the transcript as a "simple reply" and shipped the raw
+ *      `shouldRespond: RESPOND\n\nreplyText: ...` block to the channel.
+ *
+ * The grammar here segments on the rule: **a field's value terminates only at
+ * the next line that starts with `^<knownField>:`, never at a blank line.**
+ * That preserves multi-line values with embedded blank lines.
+ */
+
+/**
+ * Canonical field names the response-handler emits. Kept in sync with the
+ * builtin field evaluators (see ./builtin-field-evaluators.ts). Used to anchor
+ * segmentation: only these names delimit a new field, so a `value:` that
+ * happens to appear inside prose (e.g. "the ratio is 3:1") does not split a
+ * field.
+ */
+export const RESPONSE_HANDLER_FIELD_NAMES = [
+	"shouldRespond",
+	"contexts",
+	"intents",
+	"candidateActionNames",
+	"replyText",
+	"facts",
+	"relationships",
+	"addressedTo",
+	"topics",
+	"emotion",
+] as const;
+
+export type ResponseHandlerFieldName =
+	(typeof RESPONSE_HANDLER_FIELD_NAMES)[number];
+
+const FIELD_NAME_SET = new Set<string>(RESPONSE_HANDLER_FIELD_NAMES);
+
+/**
+ * Anchored regex that matches a line which STARTS a known field:
+ * `^<knownField>:`. Case-sensitive on the field name (the model emits the
+ * canonical camelCase); a leading whitespace tolerance covers the odd
+ * bullet/indent. Capture group 1 = field name, group 2 = inline value (rest of
+ * the line after the colon).
+ */
+const FIELD_LINE = new RegExp(
+	`^\\s{0,3}(${RESPONSE_HANDLER_FIELD_NAMES.join("|")})\\s*:\\s?(.*)$`,
+);
+
+/**
+ * Cheap skeleton detector for the fail-closed send-boundary guard. Returns true
+ * when `text` looks like a raw field transcript that must NOT be shipped to a
+ * user channel. Intentionally cheap: regex only, no full parse.
+ *
+ * Matches when the text either:
+ *  - starts (after optional leading whitespace) with `shouldRespond:`, or
+ *  - contains a line beginning with `replyText:`.
+ *
+ * Both are hallmarks of the leaked HANDLE_RESPONSE transcript. Normal replies
+ * never contain a line that starts with `replyText:` or lead with
+ * `shouldRespond:`.
+ */
+export function looksLikeRawFieldTranscript(text: unknown): boolean {
+	if (typeof text !== "string" || text.length === 0) return false;
+	if (/^\s*shouldRespond\s*:/.test(text)) return true;
+	if (/(^|\n)\s*replyText\s*:/.test(text)) return true;
+	return false;
+}
+
+export interface ParsedFieldTranscript {
+	/** Map of field name → raw multi-line value string (trimmed of edge whitespace). */
+	fields: Partial<Record<ResponseHandlerFieldName, string>>;
+	/** Number of distinct known fields found (used to gauge confidence). */
+	fieldCount: number;
+}
+
+/**
+ * Parse a keyed field transcript into a map of field name → value string.
+ *
+ * Segmentation rule: scan line by line. A line matching `^<knownField>:` opens
+ * a new field; its value is the inline remainder plus every subsequent line up
+ * to (but not including) the next `^<knownField>:` line. Blank lines inside a
+ * value are preserved (then trimmed at the value edges). This is what lets a
+ * multi-line `replyText` with an embedded blank line survive intact.
+ *
+ * Returns null when no known field line is found (the text is not a transcript
+ * — let the caller fall through to its plain-text handling).
+ */
+export function parseFieldTranscript(
+	raw: string | null | undefined,
+): ParsedFieldTranscript | null {
+	if (typeof raw !== "string") return null;
+	const text = raw.replace(/\r\n/g, "\n");
+	const lines = text.split("\n");
+
+	const fields: Partial<Record<ResponseHandlerFieldName, string>> = {};
+	let currentField: ResponseHandlerFieldName | null = null;
+	let buffer: string[] = [];
+	let foundAny = false;
+
+	const flush = () => {
+		if (currentField !== null) {
+			// Only set the first occurrence of a field (first-wins, matches the
+			// registry de-dup contract). Trim edge whitespace / blank lines but
+			// keep embedded blanks.
+			if (fields[currentField] === undefined) {
+				fields[currentField] = buffer
+					.join("\n")
+					.replace(/^\n+|\n+$/g, "")
+					.trim();
+			}
+		}
+		buffer = [];
+	};
+
+	for (const line of lines) {
+		const match = FIELD_LINE.exec(line);
+		if (match && FIELD_NAME_SET.has(match[1])) {
+			// New field boundary — close the previous field first.
+			flush();
+			currentField = match[1] as ResponseHandlerFieldName;
+			foundAny = true;
+			const inline = match[2] ?? "";
+			buffer = inline.length > 0 ? [inline] : [];
+		} else if (currentField !== null) {
+			// Continuation line of the current field value (including blank lines).
+			buffer.push(line);
+		}
+		// Lines before the first field marker are preamble; ignore them.
+	}
+	flush();
+
+	if (!foundAny) return null;
+	const fieldCount = Object.keys(fields).length;
+	return { fields, fieldCount };
+}
+
+/**
+ * Extract just the `replyText` value from a raw field transcript, if present.
+ * Convenience wrapper used by the fail-closed send-boundary guard: given a
+ * leaked transcript, recover the intended user-facing reply. Returns null when
+ * the text is not a transcript or has no non-empty replyText.
+ */
+export function extractReplyTextFromTranscript(
+	raw: string | null | undefined,
+): string | null {
+	const parsed = parseFieldTranscript(raw);
+	if (!parsed) return null;
+	const reply = parsed.fields.replyText;
+	if (typeof reply !== "string") return null;
+	const trimmed = reply.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Comma-splitter for list-shaped field values in a transcript (`contexts`,
+ * `topics`, `candidateActionNames`, `intents`, `addressedTo`, `facts`). The
+ * JSON path carries real arrays; the text transcript carries a comma- or
+ * newline-separated string. `none`/`n/a`/empty collapse to [].
+ */
+export function splitTranscriptList(value: string | undefined): string[] {
+	if (typeof value !== "string") return [];
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	const lowered = trimmed.toLowerCase();
+	if (lowered === "none" || lowered === "n/a" || lowered === "[]") return [];
+	return trimmed
+		.split(/[\n,]/)
+		.map((item) => item.trim())
+		.filter(Boolean);
+}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -109,6 +109,10 @@ import {
 } from "../runtime/planner-loop";
 import { privateActionAllowedOnTurn } from "../runtime/private-action-gate";
 import {
+	extractReplyTextFromTranscript,
+	looksLikeRawFieldTranscript,
+} from "../runtime/response-field-transcript";
+import {
 	buildResponseGrammar,
 	buildSpanSamplerPlan,
 	withGuidedDecodeProviderOptions,
@@ -4598,6 +4602,11 @@ function synthesizeSimpleReplyFromPlainText(
 		})();
 	if (looksLikeIncompleteStructuredOutput) return null;
 	if (containsEmbeddedJsonObject(replyText)) return null;
+	// Never treat a raw HANDLE_RESPONSE field transcript as a plain-text reply
+	// (#11712). If the structured-transcript parser upstream didn't claim it,
+	// route to the failure path rather than shipping the `shouldRespond:/
+	// replyText:/...` skeleton to the user channel.
+	if (looksLikeRawFieldTranscript(replyText)) return null;
 	return {
 		processMessage: "RESPOND",
 		thought:
@@ -6267,10 +6276,28 @@ export async function runV5MessageRuntimeStage1(args: {
 			// instead of a blank/garbled bubble, but keep a valid-but-terse answer
 			// (e.g. "144" to a math question).
 			let reply = route.reply;
+			// Fail-closed guard (#11712): never ship the raw HANDLE_RESPONSE field
+			// transcript to a user channel. If the reply still carries the
+			// `shouldRespond:/replyText:/...` skeleton (a parse fell through
+			// somewhere upstream), extract the intended replyText value; if that
+			// can't be recovered, drop it and let the unusable-reply deferral below
+			// take over. Cheap: regex check only, no full parse on the common path.
+			if (looksLikeRawFieldTranscript(reply)) {
+				const recovered = extractReplyTextFromTranscript(reply);
+				args.runtime.logger?.warn?.(
+					{
+						src: "service:message",
+						agentId: args.runtime.agentId,
+						recovered: recovered !== null,
+					},
+					"[message] Blocked raw response-handler field transcript at send boundary; extracting replyText",
+				);
+				reply = recovered ?? "";
+			}
 			if (
-				isUnusableStage1Reply(route.reply) &&
+				isUnusableStage1Reply(reply) &&
 				!isTerseReplyWorthKeeping({
-					reply: route.reply,
+					reply,
 					messageText: getUserMessageText(args.message),
 				})
 			) {


### PR DESCRIPTION
## What

Fixes #11712 — a raw `RESPONSE_HANDLER` field transcript (`shouldRespond:/replyText:/contexts:/topics:/emotion:`) was shipped verbatim to discord when the field parse fell through.

## Confirmed root cause

**A soft-fail fallthrough at the plain-text reply synthesizer** (both of the issue's suspected shapes are real and interlocking; this is the mechanism that reached the channel).

When a provider (this turn: `cli-inference` / claude-sdk warm session in **text mode**) echoes the HANDLE_RESPONSE field set back as a plain-text keyed transcript instead of JSON:

1. `parseMessageHandlerOutput(raw)` ran `parseJsonObject` → failed → returned `null`. No transcript parser existed, so the structured fields were never recovered.
2. The parse chain fell through to `synthesizeSimpleReplyFromPlainText(raw)`. That function only rejects things that lead with `{`/`[` or contain an embedded JSON object — the plain-text transcript matched neither, so it was treated as a **simple reply** and the whole raw `shouldRespond: RESPOND\n\nreplyText: …` skeleton was returned as `plan.reply` and sent.

The multi-line `replyText` value (embedded blank line between the URL line and the `built it out…` line) is *why* no naive line-parser could have recovered it — but the shipped-to-user mechanism was the raw-text substitution in the tolerant fallback, not a crash.

## Fix (defense in depth, 3 layers)

1. **New `packages/core/src/runtime/response-field-transcript.ts`** — a tolerant grammar for the keyed transcript. Segmentation rule: *a field value terminates only at the next line matching `^<knownField>:`, never at a blank line.* This preserves multi-line values with embedded blank lines, the URL, and the ☀️ emoji. Only the canonical field names delimit a field, so a `3:1` ratio inside prose does not split a value.
2. **`parseMessageHandlerOutput`** now falls back to parsing the transcript into the same `MessageHandlerResult` shape as the JSON path (instead of returning `null`), so the intended `replyText` is routed as a normal `final_reply`.
3. **Fail-closed guards** so the skeleton can never reach a user channel even if a future path regresses:
   - `synthesizeSimpleReplyFromPlainText` refuses any text that `looksLikeRawFieldTranscript`.
   - The Stage-1 send boundary extracts the `replyText` value (or drops with a `warn`) if a raw transcript still arrives.

## Tests

- `response-field-transcript.test.ts` (14): segmentation of the **exact leaked #11712 transcript** (multi-line `replyText`, embedded blank line, ☀️ + URL preserved), colon-in-value tolerance, first-wins de-dup, `looksLikeRawFieldTranscript` guard (no false positives on normal prose), `extractReplyTextFromTranscript`, list splitting.
- `message-routing-live-regression.test.ts` (+3): the raw transcript now parses to a clean `final_reply` with the intended reply (no `shouldRespond:` skeleton); the send-boundary guard recovers `replyText`; normal replies pass through untouched.

Gate results (targeted core suites): `response-field-transcript` 14/14, `message-routing-live-regression` 37/37, `message-handler` 21/21, `message-handler-output` 8/8, `message-handler-bogus-candidates` 38/38, plus message-service suites (`shortcut-gate`, `stage1-retry`, `handler-abort`, `generate-text-result`, `provider-error-hygiene`, `direct-action-heuristics`) 44/44 — zero new failures. Biome clean on all touched files.

— [sol-orch]
