### PR TITLE
fix(feed): add missing /api/moderation/reports route (ReportModal 404) (#11707)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -704,6 +704,8 @@ dev-desktop.pid
 reports/
 !packages/cloud/api/v1/reports/
 !packages/cloud/api/v1/reports/**
+!packages/feed/apps/web/src/app/api/moderation/reports/
+!packages/feed/apps/web/src/app/api/moderation/reports/**
 docs/*
 !docs/ELIZA_1_BUNDLE_EXTRAS.json
 !docs/tee-architecture-implementation-plan.md

--- a/packages/feed/apps/web/src/app/api/moderation/reports/route.test.ts
+++ b/packages/feed/apps/web/src/app/api/moderation/reports/route.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Unit tests for /api/moderation/reports
+ *
+ * Mirrors the mocking style of the sibling route tests
+ * (e.g. api/chats/unread-count/__tests__/route.test.ts): stub @feed/api,
+ * @feed/db and @feed/shared so the route logic can be exercised without a
+ * real database or auth stack.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockAuthenticate = mock();
+const mockRequirePermission = mock();
+const mockEvaluateReport = mock();
+
+const mockReportCreate = mock();
+const mockReportFindMany = mock();
+const mockReportCount = mock();
+const mockUserFindUnique = mock();
+const mockPostFindUnique = mock();
+
+// Re-use the real zod schemas so validation behaviour is covered end-to-end.
+mock.module("@feed/api", () => ({
+  authenticate: mockAuthenticate,
+  requirePermission: mockRequirePermission,
+  evaluateReport: mockEvaluateReport,
+  successResponse: (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status }),
+  withErrorHandling:
+    (handler: (...args: unknown[]) => unknown) =>
+    async (...args: unknown[]) => {
+      try {
+        return await handler(...args);
+      } catch (error) {
+        const name = (error as { name?: string })?.name;
+        // Mirror the real error-handler status mapping used by the routes.
+        if (name === "AuthenticationError") {
+          return new Response(
+            JSON.stringify({ error: (error as Error).message }),
+            { status: 401 },
+          );
+        }
+        if (name === "AuthorizationError") {
+          return new Response(
+            JSON.stringify({ error: (error as Error).message }),
+            { status: 403 },
+          );
+        }
+        if (name === "ZodError") {
+          return new Response(
+            JSON.stringify({ error: "Validation failed" }),
+            { status: 400 },
+          );
+        }
+        throw error;
+      }
+    },
+}));
+
+mock.module("@feed/db", () => ({
+  db: {
+    report: {
+      create: mockReportCreate,
+      findMany: mockReportFindMany,
+      count: mockReportCount,
+    },
+    user: { findUnique: mockUserFindUnique },
+    post: { findUnique: mockPostFindUnique },
+  },
+}));
+
+// generateSnowflakeId + logger are the only @feed/shared runtime deps the route
+// touches beyond the zod schemas, which we keep real.
+const actualShared = await import("@feed/shared");
+mock.module("@feed/shared", () => ({
+  ...actualShared,
+  generateSnowflakeId: async () => "snowflake-1",
+  logger: { error: () => {}, info: () => {}, warn: () => {} },
+}));
+
+const { POST, GET } = await import("./route");
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/moderation/reports", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function getRequest(query = ""): Request {
+  return new Request(`http://localhost/api/moderation/reports${query}`);
+}
+
+class AuthenticationError extends Error {
+  name = "AuthenticationError";
+}
+class AuthorizationError extends Error {
+  name = "AuthorizationError";
+}
+
+beforeEach(() => {
+  mockAuthenticate.mockReset();
+  mockRequirePermission.mockReset();
+  mockEvaluateReport.mockReset();
+  mockReportCreate.mockReset();
+  mockReportFindMany.mockReset();
+  mockReportCount.mockReset();
+  mockUserFindUnique.mockReset();
+  mockPostFindUnique.mockReset();
+  mockEvaluateReport.mockResolvedValue(undefined);
+});
+
+describe("POST /api/moderation/reports", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockAuthenticate.mockRejectedValue(new AuthenticationError("no auth"));
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "harassment",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+    expect(res.status).toBe(401);
+    expect(mockReportCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a user report and feeds the evaluation pipeline", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "u2" });
+    mockReportCreate.mockImplementation(async ({ data }: { data: unknown }) => ({
+      ...(data as Record<string, unknown>),
+    }));
+
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "harassment",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.report.reporterId).toBe("reporter-1");
+    expect(body.report.reportedUserId).toBe("u2");
+    expect(body.report.reportedPostId).toBeNull();
+    expect(body.report.status).toBe("pending");
+    expect(body.report.priority).toBe("normal");
+    expect(mockEvaluateReport).toHaveBeenCalledWith("snowflake-1");
+  });
+
+  it("assigns high priority to severe categories", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "u2" });
+    mockReportCreate.mockImplementation(async ({ data }: { data: unknown }) => ({
+      ...(data as Record<string, unknown>),
+    }));
+
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "violence",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+
+    const body = await res.json();
+    expect(body.report.priority).toBe("high");
+  });
+
+  it("creates a post report", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockPostFindUnique.mockResolvedValue({ id: "p9" });
+    mockReportCreate.mockImplementation(async ({ data }: { data: unknown }) => ({
+      ...(data as Record<string, unknown>),
+    }));
+
+    const res = (await POST(
+      postRequest({
+        reportType: "post",
+        reportedPostId: "p9",
+        category: "spam",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.report.reportedPostId).toBe("p9");
+    expect(body.report.reportedUserId).toBeNull();
+    expect(body.report.priority).toBe("low");
+  });
+
+  it("rejects self-reports", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "u2" });
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "harassment",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+    expect(res.status).toBe(400);
+    expect(mockReportCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when reported user does not exist", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockUserFindUnique.mockResolvedValue(null);
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "ghost",
+        category: "harassment",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+    expect(res.status).toBe(404);
+    expect(mockReportCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when reported post does not exist", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockPostFindUnique.mockResolvedValue(null);
+    const res = (await POST(
+      postRequest({
+        reportType: "post",
+        reportedPostId: "ghost",
+        category: "spam",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on invalid payload (reason too short)", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "harassment",
+        reason: "short",
+      }),
+    )) as Response;
+    expect(res.status).toBe(400);
+    expect(mockReportCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on unknown category enum", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "not_a_category",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+    expect(res.status).toBe(400);
+  });
+
+  it("still succeeds when the evaluation pipeline throws", async () => {
+    mockAuthenticate.mockResolvedValue({ userId: "reporter-1" });
+    mockUserFindUnique.mockResolvedValue({ id: "u2" });
+    mockReportCreate.mockImplementation(async ({ data }: { data: unknown }) => ({
+      ...(data as Record<string, unknown>),
+    }));
+    mockEvaluateReport.mockRejectedValue(new Error("AI down"));
+
+    const res = (await POST(
+      postRequest({
+        reportType: "user",
+        reportedUserId: "u2",
+        category: "harassment",
+        reason: "this is a long enough reason",
+      }),
+    )) as Response;
+
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("GET /api/moderation/reports", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockRequirePermission.mockRejectedValue(
+      new AuthenticationError("no auth"),
+    );
+    const res = (await GET(getRequest())) as Response;
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when missing view_reports permission", async () => {
+    mockRequirePermission.mockRejectedValue(
+      new AuthorizationError("Permission required: view_reports"),
+    );
+    const res = (await GET(getRequest())) as Response;
+    expect(res.status).toBe(403);
+  });
+
+  it("lists reports with pagination for permitted admins", async () => {
+    mockRequirePermission.mockResolvedValue({
+      userId: "admin-1",
+      permissions: ["view_reports"],
+    });
+    mockReportFindMany.mockResolvedValue([{ id: "r1" }, { id: "r2" }]);
+    mockReportCount.mockResolvedValue(2);
+
+    const res = (await GET(
+      getRequest("?status=pending&limit=10"),
+    )) as Response;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reports).toHaveLength(2);
+    expect(body.pagination.total).toBe(2);
+    expect(body.pagination.limit).toBe(10);
+    // status filter must be forwarded to the query.
+    const call = mockReportFindMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(call.where.status).toBe("pending");
+  });
+
+  it("requires the view_reports permission specifically", async () => {
+    mockRequirePermission.mockResolvedValue({ userId: "admin-1" });
+    mockReportFindMany.mockResolvedValue([]);
+    mockReportCount.mockResolvedValue(0);
+
+    await GET(getRequest());
+
+    expect(mockRequirePermission.mock.calls[0][1]).toBe("view_reports");
+  });
+});

--- a/packages/feed/apps/web/src/app/api/moderation/reports/route.ts
+++ b/packages/feed/apps/web/src/app/api/moderation/reports/route.ts
@@ -1,0 +1,313 @@
+/**
+ * Moderation Reports API
+ *
+ * @route POST /api/moderation/reports - Submit a user/post report
+ * @route GET  /api/moderation/reports - List reports (admin, permission-gated)
+ * @access POST: Authenticated | GET: Admin (view_reports)
+ *
+ * @description
+ * POST lets any authenticated user file a report against a user or a post.
+ * Reports are persisted to the `Report` table and handed to the existing
+ * report-evaluation pipeline for AI triage. GET exposes a permission-gated
+ * (`view_reports`) list for admins with filtering + pagination.
+ *
+ * @openapi
+ * /api/moderation/reports:
+ *   post:
+ *     tags:
+ *       - Moderation
+ *     summary: Submit a report
+ *     description: Files a report against a user or post
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - reportType
+ *               - category
+ *               - reason
+ *             properties:
+ *               reportType:
+ *                 type: string
+ *                 enum: [user, post]
+ *               reportedUserId:
+ *                 type: string
+ *               reportedPostId:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *                 enum:
+ *                   - spam
+ *                   - harassment
+ *                   - hate_speech
+ *                   - violence
+ *                   - misinformation
+ *                   - inappropriate
+ *                   - impersonation
+ *                   - self_harm
+ *                   - other
+ *               reason:
+ *                 type: string
+ *                 minLength: 10
+ *                 maxLength: 2000
+ *               evidence:
+ *                 type: string
+ *                 format: uri
+ *     responses:
+ *       201:
+ *         description: Report submitted successfully
+ *       400:
+ *         description: Invalid report payload
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Reported user or post not found
+ *   get:
+ *     tags:
+ *       - Moderation
+ *     summary: List reports
+ *     description: Permission-gated list of reports (view_reports)
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [pending, reviewing, resolved, dismissed]
+ *       - in: query
+ *         name: category
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: priority
+ *         schema:
+ *           type: string
+ *           enum: [low, normal, high, critical]
+ *       - in: query
+ *         name: reportType
+ *         schema:
+ *           type: string
+ *           enum: [user, post]
+ *     responses:
+ *       200:
+ *         description: Reports retrieved successfully
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Missing view_reports permission
+ *
+ * @example
+ * ```typescript
+ * await fetch('/api/moderation/reports', {
+ *   method: 'POST',
+ *   headers: { 'Authorization': `Bearer ${token}` },
+ *   body: JSON.stringify({
+ *     reportType: 'user',
+ *     reportedUserId: '123',
+ *     category: 'harassment',
+ *     reason: 'Repeated abusive DMs...',
+ *   }),
+ * });
+ * ```
+ */
+
+import {
+  authenticate,
+  evaluateReport,
+  requirePermission,
+  successResponse,
+  withErrorHandling,
+} from "@feed/api";
+import { db } from "@feed/db";
+import {
+  CreateReportSchema,
+  GetReportsSchema,
+  generateSnowflakeId,
+  logger,
+} from "@feed/shared";
+import type { NextRequest } from "next/server";
+
+/**
+ * Map a report category to a triage priority, mirroring the agent report path
+ * (packages/a2a/src/executors/feed-executor.ts).
+ */
+function priorityForCategory(category: string): "low" | "normal" | "high" {
+  if (["hate_speech", "violence", "self_harm"].includes(category)) {
+    return "high";
+  }
+  if (category === "spam") {
+    return "low";
+  }
+  return "normal";
+}
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const authUser = await authenticate(request);
+
+  const body = await request.json();
+  const { reportType, reportedUserId, reportedPostId, category, reason, evidence } =
+    CreateReportSchema.parse(body);
+
+  // The report target must match the declared report type so we don't persist
+  // a "post" report that only carries a user id (or vice versa).
+  if (reportType === "post" && !reportedPostId) {
+    return successResponse(
+      { success: false, error: "reportedPostId is required for post reports" },
+      400,
+    );
+  }
+  if (reportType === "user" && !reportedUserId) {
+    return successResponse(
+      { success: false, error: "reportedUserId is required for user reports" },
+      400,
+    );
+  }
+
+  // Prevent users from reporting themselves.
+  if (reportType === "user" && reportedUserId === authUser.userId) {
+    return successResponse(
+      { success: false, error: "You cannot report yourself" },
+      400,
+    );
+  }
+
+  // Validate the target actually exists so we don't create dangling reports.
+  if (reportType === "user" && reportedUserId) {
+    const target = await db.user.findUnique({
+      where: { id: reportedUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      return successResponse(
+        { success: false, error: "Reported user not found" },
+        404,
+      );
+    }
+  }
+
+  if (reportType === "post" && reportedPostId) {
+    const post = await db.post.findUnique({
+      where: { id: reportedPostId },
+      select: { id: true },
+    });
+    if (!post) {
+      return successResponse(
+        { success: false, error: "Reported post not found" },
+        404,
+      );
+    }
+  }
+
+  const report = await db.report.create({
+    data: {
+      id: await generateSnowflakeId(),
+      reporterId: authUser.userId,
+      reportedUserId: reportType === "user" ? reportedUserId : null,
+      reportedPostId: reportType === "post" ? reportedPostId : null,
+      reportType,
+      category,
+      reason,
+      evidence: evidence ?? null,
+      priority: priorityForCategory(category),
+      status: "pending",
+      updatedAt: new Date(),
+    },
+  });
+
+  // Hand off to the existing AI report-evaluation pipeline. This is best-effort:
+  // a failure to evaluate must not fail the user's submission (the report row
+  // is already persisted and can be evaluated later by an admin action).
+  void evaluateReport(report.id).catch((error) => {
+    logger.error(
+      "Report evaluation failed",
+      { reportId: report.id, error: String(error) },
+      "ModerationReports",
+    );
+  });
+
+  return successResponse({ success: true, report }, 201);
+});
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  // Permission-gated: unauthenticated -> 401 (via authenticate), non-admin or
+  // missing view_reports -> 403.
+  await requirePermission(request, "view_reports");
+
+  const { searchParams } = new URL(request.url);
+  const {
+    limit,
+    offset,
+    status,
+    category,
+    priority,
+    reportType,
+    reporterId,
+    reportedUserId,
+    reportedPostId,
+    sortBy,
+    sortOrder,
+  } = GetReportsSchema.parse({
+    limit: searchParams.get("limit") ?? "50",
+    offset: searchParams.get("offset") ?? "0",
+    status: searchParams.get("status") ?? undefined,
+    category: searchParams.get("category") ?? undefined,
+    priority: searchParams.get("priority") ?? undefined,
+    reportType: searchParams.get("reportType") ?? undefined,
+    reporterId: searchParams.get("reporterId") ?? undefined,
+    reportedUserId: searchParams.get("reportedUserId") ?? undefined,
+    reportedPostId: searchParams.get("reportedPostId") ?? undefined,
+    sortBy: searchParams.get("sortBy") ?? undefined,
+    sortOrder: searchParams.get("sortOrder") ?? undefined,
+  });
+
+  const where = {
+    ...(status ? { status } : {}),
+    ...(category ? { category } : {}),
+    ...(priority ? { priority } : {}),
+    ...(reportType ? { reportType } : {}),
+    ...(reporterId ? { reporterId } : {}),
+    ...(reportedUserId ? { reportedUserId } : {}),
+    ...(reportedPostId ? { reportedPostId } : {}),
+  };
+
+  const orderByColumn =
+    sortBy === "updated"
+      ? "updatedAt"
+      : sortBy === "priority"
+        ? "priority"
+        : "createdAt";
+
+  const [reports, total] = await Promise.all([
+    db.report.findMany({
+      where,
+      orderBy: { [orderByColumn]: sortOrder },
+      take: limit,
+      skip: offset,
+    }),
+    db.report.count({ where }),
+  ]);
+
+  return successResponse({
+    reports,
+    pagination: {
+      limit,
+      offset,
+      total,
+    },
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #11707. The feed `ReportModal` (`packages/feed/apps/web/src/components/moderation/ReportModal.tsx:128`) POSTs to `/api/moderation/reports`, but the route file never existed — `apps/web/src/app/api/moderation/` only had `appeal/`, `blocks/`, `mutes/`. Every user report submitted from the UI 404'd.

Everything *around* the route already existed (per the issue): `CreateReportSchema`/`GetReportsSchema` validation, the `Report` pgTable + relations, the `report-evaluation` pipeline, and the `view_reports`/`resolve_reports` admin permissions. Only the HTTP route was missing. This PR adds it, mirroring the sibling moderation routes exactly.

## Changes

- **`POST /api/moderation/reports`**: authenticated (401 unauth via `authenticate`), validates with `CreateReportSchema`, enforces `reportType` ↔ target consistency, blocks self-reports, verifies the reported user/post exists (404 otherwise), inserts a `Report` row (snowflake id + priority derived from category, mirroring the agent report path in `feed-executor.ts`), then hands off to the existing `evaluateReport()` pipeline **best-effort** — a pipeline failure never fails the user's submission (the row is already persisted).
- **`GET /api/moderation/reports`**: permission-gated via `requirePermission(request, "view_reports")` → **401** unauth, **403** without permission; filters + paginates via `GetReportsSchema`. This makes the existing `packages/testing/integration/api-endpoints.integration.test.ts` → `GET /api/moderation/reports - requires auth` (expects **401**) pass instead of returning **404**.
- **`.gitignore`**: the global `reports/` ignore rule was silently swallowing the new route directory (the same trap is already negated for `packages/cloud/api/v1/reports/`). Added a matching negation so the route is tracked.
- **Tests**: 14 route-level unit cases (auth 401/403, validation 400, priority mapping, target-existence 404, self-report rejection, and evaluation-pipeline resilience), mirroring the mocking style of sibling route tests.

## Acceptance criteria

- [x] `POST /api/moderation/reports`: authenticated (401 unauth), validates with `CreateReportSchema`, inserts a `reports` row, feeds the report-evaluation pipeline.
- [x] `GET /api/moderation/reports`: 401 unauth; permission-gated (`view_reports`) list via `GetReportsSchema`.
- [x] The integration expectation (`GET /api/moderation/reports - requires auth` → 401) now passes (route returns 401 instead of 404).

## Testing

- `bun test apps/web/src/app/api/moderation/reports/route.test.ts` → **14 pass / 0 fail**.
- Typecheck (`apps/web`) introduces **zero** new errors vs baseline (the only failure, `@serwist/next/typings`, is pre-existing baseline noise unrelated to this change — verified identical with the new files removed).
- Route mirrors `appeal/`, `blocks/`, `mutes/` for auth guard, validation, db access, and response shapes.

Refs #11380, #11567.

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>