### PR TITLE
fix(android): build elizavoice bridge after staging

### DIFF
--- a/.github/issue-evidence/11714-android-elizavoice-build.md
+++ b/.github/issue-evidence/11714-android-elizavoice-build.md
@@ -1,0 +1,198 @@
+# Issue #11714 — Android elizavoice JNI build gate
+
+## Summary
+
+Fixed the clean-build race where the Android `libelizavoicejni.so` bridge was
+registered only when `src/main/jniLibs/arm64-v8a/libelizainference.so` already
+existed during Gradle configuration.
+
+Changes made:
+
+- The Android app-core template now probes the configured arm64 source library
+  first: `-Peliza.mtp.android.libdir`, `ELIZA_MTP_ANDROID_LIBDIR`, then the
+  default `${ELIZA_STATE_DIR:-~/.eliza}/local-inference/bin/mtp/android-arm64-{vulkan,cpu}`
+  locations.
+- If that source binary exports the fused voice ABI, Gradle enables the
+  `elizavoice-jni` CMake bridge even on a clean checkout where `jniLibs` is
+  still empty.
+- `externalNativeBuild*`, `configureCMake*`, and `buildCMake*` tasks now depend
+  on `copyForkLlamaLib`, so CMake links after the source `.so` has been staged
+  into `jniLibs`.
+- If the binary requires the bridge but the llama.cpp omnivoice header is
+  missing, Gradle fails loudly with a submodule checkout instruction instead of
+  silently shipping an APK without `libelizavoicejni.so`.
+- Cloud/smoke skip builds still bypass the bridge and the fused library copy via
+  `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1` / `-PelizaCloudBuild=true`.
+
+## Validation
+
+### App-core Gradle skip-mode configuration
+
+Command:
+
+```bash
+ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:tasks --dry-run
+```
+
+Directory:
+
+```bash
+packages/app-core/platforms/android
+```
+
+Result: pass.
+
+Observed log:
+
+```text
+[elizavoice-jni] skipped for cloud/smoke build
+:app:tasks SKIPPED
+BUILD SUCCESSFUL
+```
+
+### App-core fail-loud missing-header path
+
+Command:
+
+```bash
+./gradlew :app:tasks --dry-run
+```
+
+Directory:
+
+```bash
+packages/app-core/platforms/android
+```
+
+Result: expected fail in this workspace because the existing local
+`plugins/plugin-local-inference/native/llama.cpp` submodule has unrelated
+deleted `tools/omnivoice/**` files.
+
+Observed error:
+
+```text
+[elizavoice-jni] .../app/src/main/jniLibs/arm64-v8a/libelizainference.so exports the fused-voice ABI, but .../plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h is missing. Run git submodule update --init --recursive so the llama.cpp omnivoice headers are checked out.
+```
+
+### Source-lib probe path
+
+Command:
+
+```bash
+tmpdir=$(mktemp -d /tmp/eliza-11714-libdir.XXXXXX)
+printf '%s\n' \
+  eliza_inference_wakeword_supported \
+  eliza_inference_speaker_supported \
+  eliza_inference_diariz_supported \
+  > "$tmpdir/libelizainference.so"
+ELIZA_MTP_ANDROID_LIBDIR="$tmpdir" ./gradlew :app:tasks --dry-run
+```
+
+Directory:
+
+```bash
+packages/app-core/platforms/android
+```
+
+Initial result before submodule checkout: expected fail in this workspace
+because the header checkout was missing, and the error proved the new
+configuration-time probe reads the configured source library instead of the old
+`jniLibs` location:
+
+```text
+[elizavoice-jni] /tmp/eliza-11714-libdir.qxEpe0/libelizainference.so exports the fused-voice ABI, but .../plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h is missing.
+```
+
+After running:
+
+```bash
+git submodule update --init --recursive plugins/plugin-local-inference/native/llama.cpp
+```
+
+the same source-lib probe command passes Gradle configuration:
+
+```text
+:app:tasks SKIPPED
+BUILD SUCCESSFUL
+```
+
+### Native task graph with bridge enabled
+
+Command:
+
+```bash
+tmpdir=$(mktemp -d /tmp/eliza-11714-libdir.XXXXXX)
+printf '%s\n' \
+  eliza_inference_wakeword_supported \
+  eliza_inference_speaker_supported \
+  eliza_inference_diariz_supported \
+  > "$tmpdir/libelizainference.so"
+ELIZA_MTP_ANDROID_LIBDIR="$tmpdir" ./gradlew :app:externalNativeBuildDebug --dry-run
+```
+
+Directory:
+
+```bash
+packages/app-core/platforms/android
+```
+
+Result: pass. The dry-run task graph shows `copyForkLlamaLib` before the app
+CMake configure/build tasks:
+
+```text
+:app:copyForkLlamaLib SKIPPED
+:app:preBuild SKIPPED
+:app:preDebugBuild SKIPPED
+:app:configureCMakeDebug[arm64-v8a] SKIPPED
+:app:buildCMakeDebug[arm64-v8a] SKIPPED
+:app:externalNativeBuildDebug SKIPPED
+BUILD SUCCESSFUL
+```
+
+Command:
+
+```bash
+ELIZA_MTP_ANDROID_LIBDIR="$tmpdir" ./gradlew :app:assembleDebug --dry-run
+```
+
+Result: pass. The assemble dry-run includes `:app:copyForkLlamaLib SKIPPED`
+before the app CMake tasks and completes with `BUILD SUCCESSFUL`.
+
+### Generated app Android project
+
+Command:
+
+```bash
+ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:tasks --dry-run
+```
+
+Directory:
+
+```bash
+packages/app/android
+```
+
+Result: fail before the `:app` Gradle file is configured, due unrelated
+generated-project drift:
+
+```text
+Configuring project ':elizaos-capacitor-mlkit-text' without an existing directory is not allowed.
+The configured projectDirectory '/home/shaw/milady/plugins/plugin-native-mlkit-text/android' does not exist
+```
+
+`packages/app/android` is ignored/generated; the tracked fix is in the
+`packages/app-core/platforms/android` template.
+
+## Evidence Matrix
+
+- Android device/APK capture: N/A - no real Android fused `libelizainference.so`
+  artifact was available in this workspace. The Gradle source-probe, missing
+  header fail-loud path, header-present configuration path, and native task
+  graph ordering were validated above; CI/release with the real fused artifact
+  should perform the full APK packaging/device check.
+- UI screenshots/video: N/A - no UI changed.
+- Model trajectories: N/A - no model, prompt, provider, or action behavior
+  changed.
+- Backend logs: N/A - build-system change only.
+- Domain artifacts: Gradle output above proves the source-lib probe and
+  fail-loud header guard.

--- a/.github/issue-evidence/11714-android-elizavoice-build.md
+++ b/.github/issue-evidence/11714-android-elizavoice-build.md
@@ -196,3 +196,32 @@ The configured projectDirectory '/home/shaw/milady/plugins/plugin-native-mlkit-t
 - Backend logs: N/A - build-system change only.
 - Domain artifacts: Gradle output above proves the source-lib probe and
   fail-loud header guard.
+
+## Review follow-up: white-label repo-root pin
+
+`patchAndroidGradle()` in `packages/app-core/scripts/run-mobile-build.mjs`
+rewrites the first `def elizaRepoRoot = ...` line to the absolute checkout root
+for white-label builds (`ELIZA_ANDROID_USE_APP_DIR=1`), because the relative
+`../../../..` walk overshoots when the android project lives outside the eliza
+tree. The original PR head introduced a second variable
+(`elizaRepoRootForVoiceBuild`) for the header gate that the pin regex did not
+match, so a white-label build with a resolvable fused source lib would have
+hard-failed the new header check with a misleading "run git submodule update"
+message even with the submodule checked out.
+
+Fixed by hoisting a single `def elizaRepoRoot` shared by the CMake include-dir
+argument and the header gate; the existing non-global regex now pins both
+consumers. Simulated the mjs replace against the updated template: the pin
+lands on the hoisted definition and zero relative-walk definitions remain.
+
+Re-validated all four lanes after the change (this reviewer's M4 Max,
+`packages/app-core/platforms/android`, Gradle 9.5.0, dry-run):
+
+- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:tasks --dry-run` →
+  `[elizavoice-jni] skipped for cloud/smoke build`, BUILD SUCCESSFUL.
+- Synthetic 3-token source lib via `ELIZA_MTP_ANDROID_LIBDIR` + header present →
+  `:app:externalNativeBuildDebug --dry-run` shows `:app:copyForkLlamaLib` before
+  `configureCMakeDebug[arm64-v8a]` / `buildCMakeDebug[arm64-v8a]`, BUILD SUCCESSFUL.
+- Same source lib + header missing → configuration fails loudly naming the
+  configured source lib, BUILD FAILED (expected).
+- No source configured, empty jniLibs → graceful warn skip, BUILD SUCCESSFUL.

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -1,6 +1,12 @@
 apply plugin: 'com.android.application'
 
-def elizaRepoRootForVoiceBuild = rootProject.projectDir.toPath().resolve('../../../..').normalize().toFile()
+// Single repo-root resolution shared by the elizavoice header gate and the
+// CMake include-dir argument. patchAndroidGradle() in run-mobile-build.mjs
+// rewrites the elizaRepoRoot definition below to the absolute checkout root
+// for white-label builds (ELIZA_ANDROID_USE_APP_DIR=1), where the android
+// project lives outside the eliza tree and the relative walk overshoots.
+// Keep the variable name and single definition, or that pin silently misses.
+def elizaRepoRoot = rootProject.projectDir.toPath().resolve('../../../..').normalize().toFile()
 
 def resolveElizaVoiceArm64SourceDir = {
     def fromProp = project.findProperty("eliza.mtp.android.libdir")
@@ -65,7 +71,6 @@ android {
         // CMake. arm64-v8a only in Phase 3a (other ABIs build a no-op stub).
         externalNativeBuild {
             cmake {
-                def elizaRepoRoot = rootProject.projectDir.toPath().resolve('../../../..').normalize().toFile()
                 arguments "-DELIZAVOICE_FFI_INCLUDE_DIR=${new File(elizaRepoRoot, 'plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include').absolutePath}"
             }
         }
@@ -78,7 +83,7 @@ android {
     // decide from -Peliza.mtp.android.libdir / ELIZA_MTP_ANDROID_LIBDIR (or the
     // state-dir default), then the externalNativeBuild tasks depend on
     // copyForkLlamaLib below so CMake sees the staged .so before linking.
-    def elizavoiceHeader = new File(elizaRepoRootForVoiceBuild, 'plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h')
+    def elizavoiceHeader = new File(elizaRepoRoot, 'plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h')
     def elizavoicePrebuilt = resolveElizaVoiceProbePrebuilt()
     def elizavoicePrebuiltText = elizavoicePrebuilt.exists()
         ? new String(elizavoicePrebuilt.readBytes(), "ISO-8859-1")

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -1,5 +1,28 @@
 apply plugin: 'com.android.application'
 
+def elizaRepoRootForVoiceBuild = rootProject.projectDir.toPath().resolve('../../../..').normalize().toFile()
+
+def resolveElizaVoiceArm64SourceDir = {
+    def fromProp = project.findProperty("eliza.mtp.android.libdir")
+    if (fromProp) return fromProp.toString()
+    def fromEnv = System.getenv("ELIZA_MTP_ANDROID_LIBDIR")
+    if (fromEnv) return fromEnv
+    def stateDir = System.getenv('ELIZA_STATE_DIR') ?: "${System.getProperty('user.home')}/.eliza"
+    def candidates = ['vulkan', 'cpu'].collect { backend ->
+        "${stateDir}/local-inference/bin/mtp/android-arm64-${backend}"
+    }
+    return candidates.find { new File(it).isDirectory() }
+}
+
+def resolveElizaVoiceProbePrebuilt = {
+    def sourceDir = resolveElizaVoiceArm64SourceDir()
+    if (sourceDir) {
+        def sourcePrebuilt = new File(sourceDir.toString(), 'libelizainference.so')
+        if (sourcePrebuilt.isFile()) return sourcePrebuilt
+    }
+    return file("src/main/jniLibs/arm64-v8a/libelizainference.so")
+}
+
 android {
     namespace "ai.elizaos.app"
     compileSdk rootProject.ext.compileSdkVersion
@@ -48,16 +71,31 @@ android {
         }
     }
 
-    // Only wire the Phase 3a elizavoice-jni native build when the prebuilt
-    // libelizainference.so actually exports the fused-voice FFI entrypoints
-    // (wakeword/speaker/diariz). That .so is rebuilt out-of-band by
-    // stage-elizavoice-lib.mjs; when it predates those symbols the bridge fails
-    // to link and would block the entire APK. Skip it instead — the Java
-    // ElizaVoiceNative.ensureLoaded() already degrades to "unavailable" when the
-    // bridge .so is absent. Re-enables automatically once the .so is rebuilt.
-    def elizavoicePrebuilt = file("src/main/jniLibs/arm64-v8a/libelizainference.so")
-    def elizavoiceReady = elizavoicePrebuilt.exists() &&
-        new String(elizavoicePrebuilt.readBytes(), "ISO-8859-1").contains("eliza_inference_wakeword_supported")
+    // Only wire the Phase 3a elizavoice-jni native build when the configured
+    // fused lib source exports the fused-voice FFI entrypoints. This probe must
+    // not read only src/main/jniLibs: copyForkLlamaLib stages that directory at
+    // task execution time, after Gradle configuration. Clean builds therefore
+    // decide from -Peliza.mtp.android.libdir / ELIZA_MTP_ANDROID_LIBDIR (or the
+    // state-dir default), then the externalNativeBuild tasks depend on
+    // copyForkLlamaLib below so CMake sees the staged .so before linking.
+    def elizavoiceHeader = new File(elizaRepoRootForVoiceBuild, 'plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/include/eliza-inference-ffi.h')
+    def elizavoicePrebuilt = resolveElizaVoiceProbePrebuilt()
+    def elizavoicePrebuiltText = elizavoicePrebuilt.exists()
+        ? new String(elizavoicePrebuilt.readBytes(), "ISO-8859-1")
+        : ""
+    def elizavoiceRequiredBinaryTokens = [
+        "eliza_inference_wakeword_supported",
+        "eliza_inference_speaker_supported",
+        "eliza_inference_diariz_supported"
+    ]
+    def elizavoiceBridgeSkipped = project.findProperty('elizaCloudBuild') == 'true' ||
+        System.getenv('ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB') == '1'
+    def elizavoiceReady = !elizavoiceBridgeSkipped &&
+        elizavoicePrebuilt.exists() &&
+        elizavoiceRequiredBinaryTokens.every { elizavoicePrebuiltText.contains(it) }
+    if (elizavoiceReady && !elizavoiceHeader.exists()) {
+        throw new GradleException("[elizavoice-jni] ${elizavoicePrebuilt} exports the fused-voice ABI, but ${elizavoiceHeader} is missing. Run git submodule update --init --recursive so the llama.cpp omnivoice headers are checked out.")
+    }
     if (elizavoiceReady) {
         externalNativeBuild {
             cmake {
@@ -65,6 +103,8 @@ android {
                 version "3.22.1"
             }
         }
+    } else if (elizavoiceBridgeSkipped) {
+        logger.lifecycle("[elizavoice-jni] skipped for cloud/smoke build")
     } else {
         logger.warn("[elizavoice-jni] prebuilt libelizainference.so lacks fused-voice symbols (wakeword/speaker/diariz); skipping Phase 3a JNI bridge so the APK still builds. Rebuild via stage-elizavoice-lib.mjs to re-enable.")
     }
@@ -315,6 +355,11 @@ task copyForkLlamaLib {
 
 afterEvaluate {
     tasks.matching { it.name == 'preBuild' }.all { it.dependsOn copyForkLlamaLib }
+    tasks.matching {
+        it.name.startsWith('externalNativeBuild') ||
+            it.name.startsWith('configureCMake') ||
+            it.name.startsWith('buildCMake')
+    }.all { it.dependsOn copyForkLlamaLib }
 }
 
 // Optional app thinning: keep assets/agent/ by default so stock


### PR DESCRIPTION
Fixes #11714

## Summary
- Probe the configured Android arm64 fused-library source during Gradle configuration instead of only checking `jniLibs`, so clean builds can enable the elizavoice JNI bridge before staging runs.
- Make CMake/native build tasks depend on `copyForkLlamaLib`, ensuring `libelizainference.so` is staged before `libelizavoicejni.so` links.
- Fail loudly when a bridge-capable source binary is present but the llama.cpp omnivoice header checkout is missing, while preserving the cloud/smoke skip path.

## Validation
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `git diff --check`
- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:tasks --dry-run` in `packages/app-core/platforms/android`
- `./gradlew :app:tasks --dry-run` in `packages/app-core/platforms/android` (expected fail-loud path in this workspace because the local llama.cpp submodule has unrelated deleted `tools/omnivoice/**` files)
- `ELIZA_MTP_ANDROID_LIBDIR=/tmp/eliza-11714-libdir.qxEpe0 ./gradlew :app:tasks --dry-run` in `packages/app-core/platforms/android` (expected fail-loud path naming the configured source lib)
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/app-core lint`

## Evidence
- `.github/issue-evidence/11714-android-elizavoice-build.md`

## Notes
- The generated `packages/app/android` project currently fails before `:app` configuration due unrelated generated-project drift resolving `:elizaos-capacitor-mlkit-text` outside the repo; the tracked fix is in the app-core Android template.
