### PR TITLE
feat(local-inference): Gemma-aware RAM/config defaults (#9033)

### DIFF
--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -64,6 +64,12 @@ describe("Eliza-1 runtime quant metadata", () => {
       expect(entry?.runtime?.optimizations?.requiresKernel).not.toContain(
         "polarquant",
       );
+      // Gemma-aware RAM defaults (#9033 / llama.cpp#21690): the Gemma-4 KV
+      // context-checkpoint ring is bounded to 1 and decode is single-slot
+      // (-np 1) so server KV cannot grow unbounded on the single-user
+      // on-device runtime.
+      expect(entry?.runtime?.optimizations?.ctxCheckpoints).toBe(1);
+      expect(entry?.runtime?.optimizations?.parallel).toBe(1);
       if (hostedMtpTiers.has(id)) {
         expect(entry?.runtime?.mtp?.specType).toBe("draft-mtp");
       } else {

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -437,14 +437,21 @@ function runtimeForTier(
   const runtime: CatalogModel["runtime"] = {
     preferredBackend: "llama-cpp",
     optimizations: {
-      parallel: 4,
+      // Gemma-aware RAM defaults (epic #9033). Eliza-1 is Gemma-4-based and
+      // hits llama.cpp/#21690: the server KV context-checkpoint ring grows
+      // unbounded on Gemma (a handful of ~16K-prompt turns filled ~64 GB in
+      // the upstream repro). The on-device Eliza-1 runtime is single-user, so
+      // pin single-slot decode (`-np 1`) and bound the checkpoint ring to 1 —
+      // this is pure config, not a kernel change, and only touches the
+      // Gemma-4 Eliza-1 tiers built here (never other models).
+      parallel: 1,
       flashAttention: true,
       requiresKernel,
       // OpenVINO is the right backend for ASR/Whisper on Intel hosts but
       // never for autoregressive text. The text path uses optimized
       // llama.cpp kernels plus native MTP heads.
       unsupportedKernels: ["openvino"],
-      ctxCheckpoints: 4,
+      ctxCheckpoints: 1,
       ctxCheckpointInterval: 4096,
     },
   };

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/compat-behavior.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/compat-behavior.test.ts
@@ -157,6 +157,18 @@ describe("local-ai compat adapter behavior", () => {
 		expect(onStreamChunk.mock.calls.map(([chunk]) => chunk).join("")).toBe(
 			"hello",
 		);
+
+		// Gemma-aware RAM defaults (#9033): this is the first text-context load,
+		// so the fresh initCapacitorLlama call carries the pinned defaults —
+		// mmap on (lever 3: PLE pages from disk) and windowed SWA KV
+		// (lever 2: swa_full=false, the dominant KV saving on Gemma-4).
+		expect(mocks.initCapacitorLlama).toHaveBeenCalled();
+		const initParams = mocks.initCapacitorLlama.mock.calls[0]?.[0] as {
+			use_mmap?: boolean;
+			swa_full?: boolean;
+		};
+		expect(initParams.use_mmap).toBe(true);
+		expect(initParams.swa_full).toBe(false);
 	});
 
 	it("sends a desktop-safe prompt and forwards sampler controls", async () => {

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/index.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/index.ts
@@ -475,7 +475,14 @@ class LocalAIManager {
 			model: modelPath,
 			n_ctx: spec.contextSize,
 			n_gpu_layers: 999,
+			// Gemma-aware RAM defaults (epic #9033): keep mmap on so the Gemma-4
+			// Per-Layer-Embeddings tensor pages from disk (never `--no-mmap`),
+			// and pin windowed SWA KV (`swa_full=false`, the dominant KV saving
+			// on Gemma's mostly-sliding-window attention). Both are the current
+			// effective defaults; setting them explicitly keeps a binding
+			// default flip from silently regressing Gemma RAM.
 			use_mmap: true,
+			swa_full: false,
 		});
 		const entry: ContextEntry = { ctx, systemPrompt };
 		if (slot === "medium") this.mediumCtx = entry;

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.test.ts
@@ -244,6 +244,40 @@ describe("CapacitorLlamaAdapter context-id allocation (issue #7681)", () => {
     expect(state.initContextCalls[0].params.flash_attn).toBe(false);
   });
 
+  it("applies Gemma-aware RAM defaults on a text (Eliza-1) load: mmap on, windowed SWA KV (#9033)", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
+
+    const adapter = new CapacitorLlamaAdapter();
+    await adapter.load({ modelPath: "/tmp/eliza-1-2b-128k.gguf" });
+
+    expect(state.initContextCalls).toHaveLength(1);
+    const params = state.initContextCalls[0].params;
+    // Lever 3: never force --no-mmap for Gemma (PLE pages from disk).
+    expect(params.use_mmap).toBe(true);
+    // Lever 2: windowed SWA KV is the dominant KV saving on Gemma-4.
+    expect(params.swa_full).toBe(false);
+  });
+
+  it("does NOT pin swa_full on an embedding (non-Gemma) load", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
+
+    const adapter = new CapacitorLlamaAdapter();
+    await adapter.load({ modelPath: "/tmp/bge-small-en-v1.5.gguf" });
+
+    expect(state.initContextCalls).toHaveLength(1);
+    const params = state.initContextCalls[0].params;
+    expect(params.embedding).toBe(true);
+    // Gemma-only lever; embedding contexts have no SWA layers, so the knob
+    // is left at the binding default rather than pinned.
+    expect(params.swa_full).toBeUndefined();
+    // mmap-on is safe/universal and stays on.
+    expect(params.use_mmap).toBe(true);
+  });
+
   it("allows Android callers to opt into GPU params explicitly", async () => {
     vi.resetModules();
     const state = installMockPlugin();

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -638,14 +638,27 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
     // there). Real devices report isSimulator=false and keep Metal.
     const nativeGpuEnabled =
       resolveNativeGpuEnabled(options.useGpu) && !(await this.isIosSimulator());
+    const isEmbedding = looksLikeEmbeddingModelPath(options.modelPath);
     const params: NativeContextParams & Record<string, unknown> = {
       model: options.modelPath,
       n_ctx: options.contextSize ?? 4096,
       n_gpu_layers: nativeGpuEnabled ? 99 : 0,
       n_threads: options.maxThreads ?? 0,
+      // Never force `--no-mmap` for Gemma (epic #9033 lever 3): the Gemma-4
+      // Per-Layer Embeddings tensor (`per_layer_tok_embd`, ~2.8B params on
+      // E2B) is paged from disk by the OS when mmap is on, instead of being
+      // resident. `--no-mmap` would fault it all into RAM at load.
       use_mmap: true,
       flash_attn: nativeGpuEnabled,
-      embedding: looksLikeEmbeddingModelPath(options.modelPath),
+      // Windowed SWA KV (epic #9033 lever 2): keep `swa_full=false` so the
+      // interleaved sliding-window layers size their KV to `n_swa + n_ubatch`
+      // rather than the full context — the dominant KV saving on Gemma-4's
+      // mostly-SWA attention stack. This is llama.cpp's default; we pin it
+      // explicitly on the text path so a runtime/binding default flip can't
+      // silently regress Gemma RAM. Embedding contexts (non-Gemma, no SWA)
+      // are left untouched.
+      ...(isEmbedding ? {} : { swa_full: false }),
+      embedding: isEmbedding,
       n_batch: options.mobileSpeculative ? 128 : 512,
       n_ubatch: options.mobileSpeculative ? 64 : 512,
       ...(options.draftModelPath


### PR DESCRIPTION
## What

Lands the concrete **Gemma-aware RAM/config defaults** the Gemma-4 cutover epic (#9033) flags as *"pure config, not new kernels"*, gated to the Gemma-4 Eliza-1 tiers so no other model regresses.

| Lever | Before | After | Status |
|---|---|---|---|
| **1. Bound ctx-checkpoints + `-np 1`** (llama.cpp#21690, Gemma-only unbounded server KV growth) | `ctxCheckpoints: 4`, `parallel: 4` | `ctxCheckpoints: 1`, `parallel: 1` | **changed** |
| **2. Windowed SWA KV (`swa_full=false`)** — dominant KV saving on Gemma's mostly-sliding-window attention | unset (relied on binding default) | pinned `swa_full: false` on text load | **changed (made explicit)** |
| **3. Never `--no-mmap` for Gemma** (PLE `per_layer_tok_embd` pages from disk) | `use_mmap: true`; catalog never sets `noMmap` | unchanged | **verified already correct** |

Lever 1 lives in the shared catalog `runtimeForTier`, which only builds the eliza-1 (Gemma-4) tier runtime — so it is inherently Gemma-gated. Lever 2 is gated to the non-embedding text path (embedding contexts have no SWA layers and are left at the binding default).

## Files
- `packages/shared/src/local-inference/catalog.ts` — Lever 1 (+ test).
- `plugins/plugin-native-llama/src/capacitor-llama-adapter.ts` — Lever 2/3 on the on-device text load (+ test).
- `plugins/plugin-local-inference/src/adapters/capacitor-llama/index.ts` — Lever 2/3 on the compat adapter text load (+ test).

## Evidence
- `catalog.test.ts`: asserts `ctxCheckpoints === 1` and `parallel === 1` for every eliza-1 tier.
- `capacitor-llama-adapter.test.ts`: text (Eliza-1) load has `use_mmap === true` + `swa_full === false`; embedding load is left untouched (`swa_full` undefined).
- `compat-behavior.test.ts`: first text-context load carries mmap-on + `swa_full=false`.
- Typecheck (`packages/shared`, `plugin-native-llama`, `plugin-local-inference`) clean; biome clean (one pre-existing unrelated warning).

Not in scope (genuinely multi-day / native): PLE-CPU-pin on GPU backends (`-ot` tensor override), kernel re-opt, CoreML/MLX/LiteRT backend integration, per-platform hardware capture. Tracked by the epic's open successors (#11386/#11389/#11390/#11391/#10726/#10727).

🤖 Generated with [Claude Code](https://claude.com/claude-code)