### PR TITLE
fix(orchestrator): resolve emitProgress channel like the synthesis router; fail soft (#11726)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -118,6 +118,7 @@ interface BuiltRuntime {
   // Mutable session metadata the hook reads via acp.getSession().
   sessions: Map<string, { metadata: Record<string, unknown>; status: string }>;
   sessionOutput: Map<string, string>;
+  logger: { debug: Mock; warn: Mock; info: Mock; error: Mock };
 }
 
 /**
@@ -127,7 +128,22 @@ interface BuiltRuntime {
  */
 async function buildHookedRuntime(
   connectors: MockConnector[],
-  opts?: { sessionOutput?: string },
+  opts?: {
+    sessionOutput?: string;
+    // When provided, the mock runtime exposes `getRoom`, letting the hook's
+    // resolveEmitTarget enrich the outbound target with channelId/serverId the
+    // same way the swarm-synthesis completion router does. Maps roomId -> room
+    // (or null for an unresolvable room).
+    rooms?: Map<
+      string,
+      {
+        id: string;
+        channelId?: string;
+        serverId?: string;
+        source: string;
+      } | null
+    >;
+  },
 ): Promise<BuiltRuntime> {
   const sessions = new Map<
     string,
@@ -202,6 +218,10 @@ async function buildHookedRuntime(
   const services = new Map<string, unknown>();
   services.set(AcpService.serviceType, acpStub);
 
+  const getRoom = opts?.rooms
+    ? vi.fn(async (roomId: string) => opts.rooms?.get(roomId) ?? null)
+    : undefined;
+
   const runtime = {
     agentId: "agent-0000-0000-0000-000000000000",
     character: {
@@ -210,6 +230,7 @@ async function buildHookedRuntime(
       style: { chat: ["casual", "terse"] },
     },
     logger,
+    ...(getRoom ? { getRoom } : {}),
     getSetting: () => undefined,
     getService: (type: string) => services.get(type) ?? null,
     // init() awaits this for each of the 4 service types before registering the
@@ -263,6 +284,7 @@ async function buildHookedRuntime(
     },
     sessions,
     sessionOutput,
+    logger,
   };
 }
 
@@ -678,6 +700,160 @@ describe("emitProgress routing ladder + cadence", () => {
       rt.sendMessageToTarget.mock.calls.length +
       rt.editMessageOnTarget.mock.calls.length;
     expect(postsAfterMore).toBe(1);
+
+    await rt.dispose();
+  });
+
+  // ── emitProgress room→channel resolution (issue: verify-retry successor
+  //    sessions inherit a roomId whose Discord channel no longer resolves) ──
+
+  it("threads the resolved channelId/serverId onto the outbound target when getRoom resolves the room", async () => {
+    // The completion/synthesis router resolves the connector channel via
+    // getRoom and sends with an explicit channelId; emitProgress must do the
+    // same so the Discord connector sends directly instead of re-deriving the
+    // channel from the (possibly stale) roomId and throwing.
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const rooms = new Map<
+      string,
+      {
+        id: string;
+        channelId?: string;
+        serverId?: string;
+        source: string;
+      } | null
+    >([
+      [
+        ROOM,
+        {
+          id: ROOM,
+          channelId: "9876543210", // discord snowflake
+          serverId: "1234509876",
+          source: SOURCE,
+        },
+      ],
+    ]);
+    const rt = await buildHookedRuntime(
+      [{ source: SOURCE, capabilities: [] }],
+      { rooms },
+    );
+    seedSession(rt, "s-resolve", "build-site");
+
+    await fire(rt, "s-resolve", "message", { text: "Reading the spec." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target] = rt.sendMessageToTarget.mock.calls[0] as [
+      { source: string; roomId: string; channelId?: string; serverId?: string },
+      unknown,
+    ];
+    // The connector-resolvable channel + server are threaded through so the
+    // Discord SendHandler uses target.channelId directly.
+    expect(target.source).toBe(SOURCE);
+    expect(target.roomId).toBe(ROOM);
+    expect(target.channelId).toBe("9876543210");
+    expect(target.serverId).toBe("1234509876");
+
+    await rt.dispose();
+  });
+
+  it("falls back to room.id as channelId when the room has no channelId", async () => {
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const rooms = new Map<
+      string,
+      {
+        id: string;
+        channelId?: string;
+        serverId?: string;
+        source: string;
+      } | null
+    >([[ROOM, { id: ROOM, source: SOURCE }]]);
+    const rt = await buildHookedRuntime(
+      [{ source: SOURCE, capabilities: [] }],
+      { rooms },
+    );
+    seedSession(rt, "s-resolve-fallback", "build-site");
+
+    await fire(rt, "s-resolve-fallback", "message", { text: "Working." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target] = rt.sendMessageToTarget.mock.calls[0] as [
+      { channelId?: string; serverId?: string },
+      unknown,
+    ];
+    // channelId ?? id → room id; no serverId on the room → omitted.
+    expect(target.channelId).toBe(ROOM);
+    expect(target.serverId).toBeUndefined();
+
+    await rt.dispose();
+  });
+
+  it("still sends with a bare {source, roomId} target when getRoom is unavailable", async () => {
+    // No getRoom on the runtime (older connectors / non-room surfaces): the
+    // resolver must fall back to the bare target — no worse than before.
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    seedSession(rt, "s-no-getroom", "build-site");
+
+    await fire(rt, "s-no-getroom", "message", { text: "Working." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target] = rt.sendMessageToTarget.mock.calls[0] as [
+      { source: string; roomId: string; channelId?: string },
+      unknown,
+    ];
+    expect(target.source).toBe(SOURCE);
+    expect(target.roomId).toBe(ROOM);
+    expect(target.channelId).toBeUndefined();
+
+    await rt.dispose();
+  });
+
+  it("warns at most once per session when the outbound send keeps failing, then drops to debug", async () => {
+    // A truly unresolvable room makes every send throw. The hook must WARN once
+    // then DEBUG on subsequent emits so a stuck session doesn't spam the log on
+    // every narration tick + heartbeat.
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    seedSession(rt, "s-failsoft", "build-site");
+    // Every outbound send throws the connector's resolution error.
+    rt.sendMessageToTarget.mockRejectedValue(
+      new Error(`Could not resolve Discord channel ID for room ${ROOM}`),
+    );
+
+    const emitWarns = () =>
+      rt.logger.warn.mock.calls.filter((c) => c[1] === "emitProgress failed")
+        .length;
+    const emitDebugs = () =>
+      rt.logger.debug.mock.calls.filter(
+        (c) => c[1] === "emitProgress failed (repeat)",
+      ).length;
+
+    // First failing emit → exactly one WARN.
+    await fire(rt, "s-failsoft", "message", { text: "Attempt one." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    expect(emitWarns()).toBe(1);
+    expect(emitDebugs()).toBe(0);
+
+    // Subsequent failing emits for the SAME session → DEBUG only, WARN unchanged.
+    await fire(rt, "s-failsoft", "message", { text: "Attempt two." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    await fire(rt, "s-failsoft", "message", { text: "Attempt three." });
+    await advanceTimersByTime(1_600);
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(emitWarns()).toBe(1);
+    expect(emitDebugs()).toBeGreaterThanOrEqual(1);
 
     await rt.dispose();
   });

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -16,6 +16,7 @@ import type {
   ServiceClass,
   TargetInfo,
   ThreadHandle,
+  UUID,
 } from "@elizaos/core";
 import {
   createUniqueUuid,
@@ -1000,6 +1001,17 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   // request after the window still gets its own.
   const roomAckAt = new Map<string, number>();
   const ACK_ROOM_DEDUP_MS = 60_000;
+  // Resolved outbound target (channelId/serverId) cache, keyed by
+  // `${source}::${roomId}`. emitProgress is a hot recursive path; resolving the
+  // room's connector channel once per (source,roomId) avoids a getRoom lookup on
+  // every narration tick. See resolveEmitTarget below.
+  const emitTargetCacheByKey = new Map<string, EmitTarget>();
+  // Sessions that have already logged an emitProgress failure at WARN. A single
+  // unresolvable room (a stale/task-room UUID forwarded onto a verify-retry
+  // successor session that has no live connector channel) would otherwise emit a
+  // WARN on every narration tick + heartbeat. Warn once per session, then drop to
+  // debug so the log doesn't spam. Bounded like the other per-session sets.
+  const emitFailedSessions = new Set<string>();
   // Cache threads by (source, roomId, label) so a rate-limit retry, a
   // mid-flight crash recovery, or a follow-up spawn for the same logical
   // project reuses the existing thread instead of creating a duplicate.
@@ -1330,7 +1342,63 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     delayedProgressFirstSeenAt.delete(sessionId);
   }
 
-  // emitProgress is the single hot path for sub-agent narration + heartbeat.
+  // Resolve the outbound connector target for a `{ source, roomId }` pair the
+  // SAME way the swarm-synthesis completion router does
+  // (packages/agent/.../server-helpers-swarm.ts routeSynthesisToConnector):
+  // look the room up and thread its `channelId` (falling back to the room id)
+  // plus `serverId` onto the target. This matters because the orchestrator
+  // takes `source`/`roomId` from `session.metadata`, and a verify-retry
+  // successor session (SubAgentRouter.retryIncompleteBuild) inherits the
+  // ORIGINAL session's `metadata.roomId`. That inherited roomId can be a
+  // stale/task-room UUID with no live connector-channel mapping — so a
+  // roomId-only target makes the Discord connector re-derive the channel from
+  // the room and throw "Could not resolve Discord channel ID for room …",
+  // spamming an Error+Warn on every narration tick. Supplying `channelId`
+  // up front lets the connector send directly (target.channelId short-circuits
+  // the room→channel derivation) and lands on the live room the synthesis
+  // router already routes to. Cached per (source,roomId): the hot narration
+  // path must not pay a getRoom lookup every tick. On any resolution miss we
+  // fall back to the bare `{ source, roomId }` — no worse than before.
+  type EmitTarget = {
+    source: string;
+    roomId: `${string}-${string}-${string}-${string}-${string}`;
+    channelId?: string;
+    serverId?: string;
+  };
+  async function resolveEmitTarget(target: {
+    source: string;
+    roomId: `${string}-${string}-${string}-${string}-${string}`;
+  }): Promise<EmitTarget> {
+    const key = `${target.source}::${target.roomId}`;
+    const cached = emitTargetCacheByKey.get(key);
+    if (cached) return cached;
+    let resolved: EmitTarget = { source: target.source, roomId: target.roomId };
+    try {
+      if (typeof runtime.getRoom === "function") {
+        const room = await runtime.getRoom(target.roomId as UUID);
+        if (room) {
+          resolved = {
+            source: target.source,
+            roomId: target.roomId,
+            // Mirror routeSynthesisToConnector: prefer the connector channel id,
+            // fall back to the room id when the room is its own channel.
+            channelId: room.channelId ?? room.id,
+            ...(room.serverId ? { serverId: room.serverId } : {}),
+          };
+        }
+      }
+    } catch {
+      // best-effort resolution — fall back to the bare target below
+    }
+    emitTargetCacheByKey.set(key, resolved);
+    if (emitTargetCacheByKey.size > 512) {
+      const oldest = emitTargetCacheByKey.keys().next().value;
+      if (oldest !== undefined) emitTargetCacheByKey.delete(oldest);
+    }
+    return resolved;
+  }
+
+  // emitProgress is the single hot path for sub-agent narration + hb_signal.
   // Routing ladder (capability-aware):
   //   1. THREAD exists (or can be created) → all narration goes in thread.
   //      This is the ANTI-POLLUTION key: thread messages never enter the
@@ -1400,6 +1468,13 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       return;
     }
     try {
+      // Resolve the outbound connector target (channelId/serverId) up front so
+      // every send below routes the same way the swarm-synthesis completion
+      // router does — landing on the live connector channel even when the room
+      // id was inherited (verify-retry) from a session whose room no longer
+      // maps to a channel. Cached per (source,roomId); the original `target`
+      // is still used for state keys (source/roomId are unchanged by resolve).
+      const sendTarget = await resolveEmitTarget(target);
       // ── post into the per-session thread when supported ──
       if (state?.thread && typeof runtime.postToThreadOnTarget === "function") {
         if (state.lastText === displayText) return;
@@ -1410,7 +1485,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // (subtle) reason this can't use a `[...]` character class.
         const threadText = stripProgressLabelPrefix(displayText);
         await runtime.postToThreadOnTarget(
-          target,
+          sendTarget,
           state.thread,
           transientContent(threadText, "sub_agent_progress"),
         );
@@ -1425,7 +1500,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       ) {
         if (state.lastText === displayText) return;
         await runtime.editMessageOnTarget(
-          target,
+          sendTarget,
           state.mainMessageId,
           transientContent(displayText, "sub_agent_progress"),
         );
@@ -1533,7 +1608,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         }
       }
       const sent = await runtime.sendMessageToTarget(
-        target,
+        sendTarget,
         transientContent(initialText, "sub_agent_progress"),
       );
       const platformId = (sent?.metadata as Record<string, unknown> | undefined)
@@ -1561,7 +1636,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // message text. Skip it in "ack" mode — the plain ACK already conveys
         // "working on it" and the rocket reads as noise next to it.
         if (canReact && progressPolicy.mode !== "ack") {
-          void bestEffortReact(target, platformId, "🚀");
+          void bestEffortReact(sendTarget, platformId, "🚀");
         }
         // Resolve the per-(source,roomId,label) thread. Cache hit ⇒ reuse
         // (rate-limit retry / spawn-after-crash for the same logical project
@@ -1577,7 +1652,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           let thread = threadCacheByKey.get(cacheKey);
           if (!thread) {
             try {
-              thread = await runtime.createThreadOnTarget(target, {
+              thread = await runtime.createThreadOnTarget(sendTarget, {
                 parentMessageId: platformId,
                 name: sessionLabel,
               });
@@ -1618,7 +1693,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             ) {
               try {
                 await runtime.postToThreadOnTarget(
-                  target,
+                  sendTarget,
                   thread,
                   transientContent(displayText, "sub_agent_progress"),
                 );
@@ -1635,14 +1710,27 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       // Release the first-post claim on failure so a retry can post the ACK
       // (on success it was already released once state was recorded).
       firstPostInFlight.delete(sessionId);
-      runtime.logger?.warn?.(
-        {
-          src: "@elizaos/plugin-agent-orchestrator",
-          sessionId,
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "emitProgress failed",
-      );
+      // Fail-soft on repeat. A single unresolvable room (a stale/task-room
+      // UUID inherited by a verify-retry successor session) would otherwise
+      // WARN on every narration tick + heartbeat for the life of the session.
+      // WARN once per session so the failure is still visible, then drop to
+      // DEBUG for subsequent emits so the log doesn't spam.
+      const alreadyWarned = emitFailedSessions.has(sessionId);
+      const logFields = {
+        src: "@elizaos/plugin-agent-orchestrator",
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      };
+      if (alreadyWarned) {
+        runtime.logger?.debug?.(logFields, "emitProgress failed (repeat)");
+      } else {
+        emitFailedSessions.add(sessionId);
+        if (emitFailedSessions.size > 512) {
+          const oldest = emitFailedSessions.values().next().value;
+          if (oldest !== undefined) emitFailedSessions.delete(oldest);
+        }
+        runtime.logger?.warn?.(logFields, "emitProgress failed");
+      }
     }
   }
 
@@ -1653,6 +1741,16 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   ): Promise<void> {
     const state = progressBySession.get(sessionId);
     if (!state) return;
+    // Resolve the connector channel the same way emitProgress does so the
+    // completion edit/reaction lands on the live channel (cached; a no-op when
+    // the target already carries a channelId or the room is unresolvable).
+    const sendTarget = target.roomId
+      ? await resolveEmitTarget({
+          source: target.source,
+          roomId:
+            target.roomId as `${string}-${string}-${string}-${string}-${string}`,
+        })
+      : target;
     const completionText =
       progressPolicy.mode === "threaded"
         ? `✅ [${state.label}] ${summary}`
@@ -1668,7 +1766,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       if (state.canEdit && typeof runtime.editMessageOnTarget === "function") {
         try {
           await runtime.editMessageOnTarget(
-            target,
+            sendTarget,
             state.mainMessageId,
             transientContent(completionText, "sub_agent_complete"),
           );
@@ -1681,7 +1779,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // actually sees the outcome.
         try {
           await runtime.sendMessageToTarget(
-            target,
+            sendTarget,
             transientContent(completionText, "sub_agent_complete"),
           );
         } catch {
@@ -1690,7 +1788,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
       }
     }
     if (state.canReact) {
-      void bestEffortReact(target, state.mainMessageId, "✅");
+      void bestEffortReact(sendTarget, state.mainMessageId, "✅");
     }
   }
 
@@ -1700,8 +1798,15 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   ): Promise<void> {
     const state = progressBySession.get(sessionId);
     if (!state) return;
+    const sendTarget = target.roomId
+      ? await resolveEmitTarget({
+          source: target.source,
+          roomId:
+            target.roomId as `${string}-${string}-${string}-${string}-${string}`,
+        })
+      : target;
     if (state.canReact) {
-      void bestEffortReact(target, state.mainMessageId, "❌");
+      void bestEffortReact(sendTarget, state.mainMessageId, "❌");
       return;
     }
     // No reaction support and no edit: post a terminal failure message so
@@ -1711,7 +1816,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     if (!state.canEdit && !suppressFailurePost) {
       try {
         await runtime.sendMessageToTarget(
-          target,
+          sendTarget,
           transientContent(
             progressPolicy.mode === "threaded"
               ? `❌ [${state.label}] failed`
@@ -1899,6 +2004,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           const terminalState = progressBySession.get(sessionId);
           progressBySession.delete(sessionId);
           firstPostInFlight.delete(sessionId);
+          emitFailedSessions.delete(sessionId);
           // Do NOT clear ackedSessions here. Sub-agents (notably opencode /
           // gpt-oss) emit trailing `message` events AFTER `task_complete`;
           // clearing the marker let those late events re-enter the spawn-ack


### PR DESCRIPTION
Closes #11726

## Problem

`emitProgress` (sub-agent narration + heartbeat hot path in `plugins/plugin-agent-orchestrator/src/index.ts`) resolved its outbound target purely from `session.metadata.roomId`/`source` and sent a bare `{ source, roomId }` — no `channelId`/`serverId`.

On a **verify-retry successor session** (`SubAgentRouter.retryIncompleteBuild` forwards `metadata: {...meta, buildVerifyRetryCount...}`), the successor **inherits the original session's `roomId`**, which can be a stale/task-room UUID with no live Discord channel mapping. The Discord connector then re-derives the channel from the room, fails, and throws `Could not resolve Discord channel ID for room <uuid>` **on every narration tick + heartbeat** (Error from the connector + a per-emit Warn from the orchestrator = log spam) — while the user's conversation continued fine in a *different* room that swarm-synthesis routed to successfully.

### Live evidence (develop `fd2e343b`)
```
Error  Error sending message to {"source":"discord","roomId":"8d413ae5-…"}: Could not resolve Discord channel ID for room 8d413ae5-…
Warn   [@ELIZAOS/PLUGIN-AGENT-ORCHESTRATOR] emitProgress failed (sessionId=8f7dd9f5-…, err=Could not resolve Discord channel ID for room 8d413ae5-…)
```
Session `8f7dd9f5` was a verify-retry successor of `09b38654`; the live conversation was in room `7b0ef393` (`[swarm-synthesis] Routed result to discord room 7b0ef393` succeeded).

## Root cause

The working completion path (`packages/agent/src/api/server-helpers-swarm.ts` `routeSynthesisToConnector`) resolves the room via `getRoom` and sends with an explicit `channelId: room.channelId ?? room.id` **plus** `serverId`; the Discord `SendHandler` short-circuits on `target.channelId`. `emitProgress` never did this, so it forced the connector to re-derive the channel from an unmapped room. Two defects: (1) wrong/insufficient resolution; (2) noisy per-emit failure.

## Fix

1. **Correct resolution** — add `resolveEmitTarget()` that enriches `{ source, roomId }` with `channelId: room.channelId ?? room.id` (+ `serverId`) via `getRoom`, exactly like `routeSynthesisToConnector`. Cached per `(source, roomId)` (hot path); falls back to the bare target when `getRoom` is unavailable or the room is genuinely unresolvable — **no worse than today**. Applied to `emitProgress` and the completion edit/reaction in `markTaskComplete`/`markTaskFailed`.
2. **Fail soft** — Warn **once** per session on a failed emit, then drop to `debug` for subsequent emits so a stuck session can't spam the log. Cleared on terminal cleanup; bounded like the other per-session sets.

## Tests

4 new cases in `progress-cadence.test.ts`:
- channelId + serverId threaded onto the outbound target when `getRoom` resolves the room
- `room.id` fallback when the room has no channelId (serverId omitted)
- bare `{ source, roomId }` when `getRoom` is unavailable (older/non-room surfaces)
- warn-once-then-debug when the send keeps failing

**Gate results:**
- `progress-cadence.test.ts`: 12 → **16 tests, all pass**.
- Full `plugin-agent-orchestrator` unit suite: **1243 passed / 19 failed**. The 19 failures are pre-existing and env-driven (`bridge-routes`, `model-chooser-contract`, `opencode-spawn-config-auto-detect`, `originating-request-routing`) — verified **identical (19)** on clean `origin/develop` with this change stashed. **Zero new failures.**
- Biome clean.

## Scope

Touches only `plugins/plugin-agent-orchestrator/src/index.ts` and `plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts`. No forbidden files touched.

— [sol-orch]
