### PR TITLE
fix(ui): stop the login widget showing twice during onboarding

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -106,6 +106,7 @@ import {
 } from "./state";
 import { goHome } from "./state/shell-surface-store";
 import { isShellPaintable } from "./state/startup-coordinator";
+import { firstRunOwnsLoginSurface } from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
@@ -1746,6 +1747,7 @@ export function App() {
   const {
     startupError,
     startupCoordinator,
+    firstRunComplete,
     retryStartup,
     tab,
     setTab,
@@ -1763,6 +1765,7 @@ export function App() {
   } = useAppSelectorShallow((s) => ({
     startupError: s.startupError,
     startupCoordinator: s.startupCoordinator,
+    firstRunComplete: s.firstRunComplete,
     retryStartup: s.retryStartup,
     tab: s.tab,
     setTab: s.setTab,
@@ -2361,7 +2364,7 @@ export function App() {
   if (
     isShellPaintableNow &&
     !isPopout &&
-    startupCoordinator.phase !== "first-run-required"
+    !firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)
   ) {
     if (authState.phase === "server_unavailable") {
       return (

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { firstRunOwnsLoginSurface } from "./top-level-auth-gate";
+
+describe("firstRunOwnsLoginSurface — top-level LoginView vs in-chat onboarding", () => {
+  it("yields the login surface while the coordinator is in first-run-required", () => {
+    // Unchanged from before the fix: the original bypass condition.
+    expect(firstRunOwnsLoginSurface("first-run-required", false)).toBe(true);
+    expect(firstRunOwnsLoginSurface("first-run-required", undefined)).toBe(
+      true,
+    );
+    expect(firstRunOwnsLoginSurface("first-run-required", true)).toBe(true);
+  });
+
+  it("ALSO yields when onboarding is incomplete but the coordinator has advanced past first-run-required (the double-login window)", () => {
+    // The bug: the coordinator moved to a provisioning/hydrating/ready phase
+    // while the in-chat conductor's cloud-OAuth block is still up
+    // (firstRunComplete === false). Both login surfaces used to mount.
+    for (const phase of ["hydrating", "ready", "starting-runtime"]) {
+      expect(firstRunOwnsLoginSurface(phase, false)).toBe(true);
+    }
+  });
+
+  it("does NOT yield for a normal unauthenticated session (onboarding done)", () => {
+    // firstRunComplete === true → the top-level LoginView must still render for
+    // a genuine unauthenticated session.
+    for (const phase of ["ready", "hydrating", "agentReady"]) {
+      expect(firstRunOwnsLoginSurface(phase, true)).toBe(false);
+    }
+  });
+
+  it("does NOT yield while first-run state is still loading (undefined/null)", () => {
+    // Only an EXPLICIT false suppresses the gate — an unknown state must not,
+    // or a normal session could be locked out of the top-level login.
+    expect(firstRunOwnsLoginSurface("ready", undefined)).toBe(false);
+    expect(firstRunOwnsLoginSurface("ready", null)).toBe(false);
+  });
+});

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether onboarding owns the sign-in surface, so App's top-level `LoginView`
+ * auth gate must yield.
+ *
+ * The in-chat first-run conductor seeds the Cloud OAuth block while onboarding
+ * runs, so it is the login surface during first-run. App's top-level
+ * `LoginView` must NOT also mount then — or the user sees the login widget
+ * TWICE during onboarding.
+ *
+ * The gate was bypassed only for `startupCoordinator.phase ===
+ * "first-run-required"`, but the conductor stays active on a SEPARATE signal
+ * (`firstRunComplete === false`). When the two disagree — the coordinator has
+ * advanced past `first-run-required` while onboarding is still incomplete (e.g.
+ * a cloud pick moved startup into a provisioning/hydrating phase while the
+ * conductor's cloud-OAuth block is still up) — both login surfaces mounted.
+ *
+ * Yield whenever EITHER signal says onboarding is active. Only an explicit
+ * `firstRunComplete === false` counts as active: a loading (`undefined` / not
+ * yet known) or completed (`true`) state must NOT suppress the gate, so a
+ * normal unauthenticated session still gets the top-level login.
+ */
+export function firstRunOwnsLoginSurface(
+  coordinatorPhase: string,
+  firstRunComplete: boolean | null | undefined,
+): boolean {
+  return (
+    coordinatorPhase === "first-run-required" || firstRunComplete === false
+  );
+}


### PR DESCRIPTION
## Symptom

During onboarding the user sees the **login widget twice** (reported alongside the stale-build onboarding review).

## Root cause

Two independent sign-in surfaces can mount at once during first-run:
- the **in-chat first-run conductor** seeds the Cloud OAuth block (`first-run:cloud-oauth`) — active whenever `firstRunComplete === false`;
- App's **top-level `LoginView`** auth gate — rendered when `authState.phase === "unauthenticated"` unless bypassed.

The top-level gate was bypassed **only** for `startupCoordinator.phase === "first-run-required"`. But the conductor stays active on the **separate** `firstRunComplete === false` signal. When the two disagree — the coordinator advances past `first-run-required` (e.g. a cloud pick moves startup into a provisioning / hydrating phase) while the conductor's cloud-OAuth block is still up — **both** login surfaces mount.

## Fix

Extract a pure predicate `firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)` (`packages/ui/src/state/top-level-auth-gate.ts`) and gate the top-level `LoginView` on it. It yields whenever **either** signal says onboarding is active, so the in-chat conductor is the sole login surface during first-run.

Safety: only an **explicit** `firstRunComplete === false` suppresses the gate. A loading (`undefined`/`null`) or completed (`true`) state does **not** — so a normal unauthenticated session still gets the top-level login and no one is locked out.

## Tests

- Truth-table unit test (`top-level-auth-gate.test.ts`, 4 cases): the original `first-run-required` bypass preserved; the new incomplete-but-advanced double-login window now yields; a completed session still shows login; a loading state does not suppress.
- `App.chat-overlay-first-run.test.tsx` unaffected (composition contract intact).
- `packages/ui` typecheck clean; biome clean on all three touched files.

Context: surfaced by the Android onboarding review (symptom 4, "login widget twice"). This is the defensive code-level fix; the exact live overlap window is startup-phase-timing dependent, but the two-signal disagreement is real in the source and the guard closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)