### PR TITLE
fix(android): stop FGS restart crash loop after LMK

### DIFF
--- a/.github/issue-evidence/11506-fgs-restart-crash.md
+++ b/.github/issue-evidence/11506-fgs-restart-crash.md
@@ -1,0 +1,29 @@
+# Issue #11506 FGS Restart Crash
+
+Branch: `fix/11506-fgs-restart-crash`
+
+Scope:
+
+- Handles Android 12+ `ForegroundServiceStartNotAllowedException` during a background sticky restart of `ElizaAgentService`.
+- Stops the service cleanly instead of crash-looping when AMS restarts it after a low-memory kill with no foreground activity.
+- Records `fgs-start-denied` and `service-start-refused-fgs-denied` diagnostic events so the path is visible in `agent-restart-diagnostics.jsonl`.
+- Adds an Android instrumentation assertion that only the real framework foreground-start denial is swallowed; unrelated `IllegalStateException` failures still throw.
+
+Root-cause evidence already captured on #11506:
+
+- Pixel 6a on-device forensics classified the original churn as primary LMK `LOW_MEMORY` kills at roughly 3.2-3.3 GB RSS plus a secondary foreground-service restart crash cascade.
+- Evidence branch: `evidence/11506-restart-repro`.
+- Issue comments include exit-info dumps, dropbox crash stacks, pid/meminfo timelines, filtered logcat, screenshots, and the later fresh-`develop` stability/re-extraction checks.
+
+Validation:
+
+- `git fetch origin && git rebase origin/develop` - passed.
+- `bun run install:light` - passed in the clean PR worktree to install Capacitor/Gradle workspace dependencies without artifact sync.
+- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestJavaWithJavac` from `packages/app-core/platforms/android` - passed: build successful, 528 actionable tasks executed. `:app:testDebugUnitTest` is `NO-SOURCE`; `:app:compileDebugAndroidTestJavaWithJavac` compiled the new instrumentation assertion.
+- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:lintDebug` from `packages/app-core/platforms/android` - failed on pre-existing Android resource lint errors, first failure `app/src/main/res/values/styles.xml:32 android:windowSplashScreenBackground requires API level 31 (current min is 26) [NewApi]`; not introduced by this branch.
+- `git diff --check origin/develop...HEAD` - run before PR.
+
+N/A evidence:
+
+- Live LLM trajectories: N/A - Android service lifecycle fix, no model/prompt behavior changed.
+- UI screenshots/video for this code branch: N/A - user-visible restart behavior requires the physical Pixel 6a LMK repro already captured in the issue/evidence branch.

--- a/packages/app-core/platforms/android/app/src/androidTest/java/ai/elizaos/app/ElizaAgentWatchdogPolicyInstrumentedTest.java
+++ b/packages/app-core/platforms/android/app/src/androidTest/java/ai/elizaos/app/ElizaAgentWatchdogPolicyInstrumentedTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.app.ForegroundServiceStartNotAllowedException;
+import android.os.Build;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
@@ -109,5 +112,28 @@ public class ElizaAgentWatchdogPolicyInstrumentedTest {
         assertFalse(fatal.allowed);
         assertEquals(5, fatal.nextRestartAttempts);
         assertEquals(0L, fatal.delayMs);
+    }
+
+    @Test
+    public void foregroundStartDenialMatchesOnlyTheAndroid12Denial() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // The real framework exception (API 31+): the exact throwable
+            // Service.startForeground() raises on a denied background start.
+            assertTrue(ElizaAgentWatchdogPolicy.isForegroundStartDenial(
+                new ForegroundServiceStartNotAllowedException("denied")
+            ));
+        }
+
+        // Plain IllegalStateException (the pre-31 startForeground failure
+        // shape, and any unrelated state bug) must NOT be swallowed.
+        assertFalse(ElizaAgentWatchdogPolicy.isForegroundStartDenial(
+            new IllegalStateException(
+                "Service.startForeground() not allowed due to mAllowStartForeground false"
+            )
+        ));
+        assertFalse(ElizaAgentWatchdogPolicy.isForegroundStartDenial(
+            new RuntimeException("unrelated")
+        ));
+        assertFalse(ElizaAgentWatchdogPolicy.isForegroundStartDenial(null));
     }
 }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -174,6 +174,7 @@ public class ElizaAgentService extends Service {
     private volatile ElizaBionicInferenceServer bionicInferenceServer;
     private Thread startWorker;
     private volatile boolean shuttingDown;
+    private volatile boolean foregroundStartDenied;
     private volatile boolean detachedAgentMode;
     private volatile long detachedLaunchStartedAtMs;
     private int restartAttempts;
@@ -615,14 +616,34 @@ public class ElizaAgentService extends Service {
 
         Notification notification = buildNotification("Eliza agent", "Starting…");
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-            );
-        } else {
-            startForeground(NOTIFICATION_ID, notification);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                );
+            } else {
+                startForeground(NOTIFICATION_ID, notification);
+            }
+        } catch (IllegalStateException error) {
+            if (!ElizaAgentWatchdogPolicy.isForegroundStartDenial(error)) {
+                throw error;
+            }
+            // Android 12+ denied the FGS start: AMS restarted the sticky
+            // service with no foreground activity (the post-LMK-kill path in
+            // #11506). Crashing here loops: AMS restarts the sticky service
+            // and the denial repeats. Stop cleanly instead; the next real
+            // (foreground) launch restarts the service, and a surviving
+            // detached agent process is left untouched for it to adopt.
+            Map<String, String> details = new LinkedHashMap<>();
+            details.put("exception", error.getClass().getName());
+            appendDiagnosticEvent("fgs-start-denied", details);
+            Log.w(TAG, "startForeground() denied (background sticky restart); "
+                + "stopping service cleanly instead of crash-looping.", error);
+            foregroundStartDenied = true;
+            shuttingDown = true;
+            stopSelf();
         }
     }
 
@@ -634,6 +655,13 @@ public class ElizaAgentService extends Service {
         details.put("flags", String.valueOf(flags));
         details.put("startId", String.valueOf(startId));
         appendDiagnosticEvent("service-onStartCommand", details);
+        if (foregroundStartDenied) {
+            // onCreate could not enter the foreground (background sticky
+            // restart on Android 12+) and already called stopSelf(); refuse
+            // the pending start so AMS does not re-deliver it.
+            appendDiagnosticEvent("service-start-refused-fgs-denied", details);
+            return START_NOT_STICKY;
+        }
         if (ACTION_STOP.equals(action)) {
             shuttingDown = true;
             appendDiagnosticEvent("service-stop-intent", details);

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -658,8 +658,12 @@ public class ElizaAgentService extends Service {
         if (foregroundStartDenied) {
             // onCreate could not enter the foreground (background sticky
             // restart on Android 12+) and already called stopSelf(); refuse
-            // the pending start so AMS does not re-deliver it.
+            // the pending start so AMS does not re-deliver it. Stop this
+            // delivered start explicitly too: a startService() racing the
+            // teardown would otherwise leave this instance running as a
+            // started service that never entered the foreground.
             appendDiagnosticEvent("service-start-refused-fgs-denied", details);
+            stopSelf(startId);
             return START_NOT_STICKY;
         }
         if (ACTION_STOP.equals(action)) {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentWatchdogPolicy.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentWatchdogPolicy.java
@@ -87,4 +87,18 @@ final class ElizaAgentWatchdogPolicy {
         long delayMs = 1000L * (1L << restartAttempts);
         return new RestartDecision(true, restartAttempts + 1, delayMs);
     }
+
+    /**
+     * True when {@code error} is Android 12+'s
+     * {@code android.app.ForegroundServiceStartNotAllowedException}: the OS
+     * restarted the sticky service with no foreground activity (e.g. after an
+     * LMK kill) and then denied {@code startForeground()}. Matched by class
+     * name so this policy class stays framework-free and the check is safe on
+     * minSdk 26 runtimes where the class does not exist.
+     */
+    static boolean isForegroundStartDenial(Throwable error) {
+        return error != null
+            && "android.app.ForegroundServiceStartNotAllowedException"
+                .equals(error.getClass().getName());
+    }
 }


### PR DESCRIPTION
## Summary
- Handles Android 12+ `ForegroundServiceStartNotAllowedException` when AMS restarts the sticky `ElizaAgentService` from background after an LMK kill.
- Stops the service cleanly instead of entering an AMS restart -> `startForeground()` denial -> crash loop.
- Records diagnostic events for the denied foreground-start path and keeps unrelated `IllegalStateException` failures fatal.

Addresses the secondary crash cascade in #11506.

## Evidence
- Evidence note: `.github/issue-evidence/11506-fgs-restart-crash.md`
- On-device root-cause evidence is already linked from #11506 and stored on `evidence/11506-restart-repro`: Pixel 6a LMK `LOW_MEMORY` kills at ~3.2-3.3 GB RSS plus secondary foreground-service restart crash cascade.
- `git fetch origin && git rebase origin/develop` - passed.
- `bun run install:light` - passed in clean PR worktree.
- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:testDebugUnitTest :app:compileDebugAndroidTestJavaWithJavac` from `packages/app-core/platforms/android` - passed: build successful, 528 actionable tasks executed.
- `git diff --check origin/develop...HEAD` - passed.

## Known Existing Blocker
- `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:lintDebug` currently fails on pre-existing Android resource API-level lint errors, first failure `app/src/main/res/values/styles.xml:32 android:windowSplashScreenBackground requires API level 31 (current min is 26) [NewApi]`; this branch does not touch resources.

## N/A Evidence
- Live LLM trajectories: N/A - Android service lifecycle fix, no model/prompt behavior changed.
- New UI screenshots/video for this branch: N/A - user-visible restart behavior requires the physical Pixel 6a LMK repro already captured in #11506 / evidence branch.
