### PR TITLE
fix(cloud): add video provider registry

### DIFF
--- a/.github/issue-evidence/11744-video-provider-registry.md
+++ b/.github/issue-evidence/11744-video-provider-registry.md
@@ -1,0 +1,29 @@
+# Issue #11744 - Video Provider Registry Evidence
+
+## What Changed
+
+- Moved FAL video generation request mapping, response normalization, credential checks, and invocation behind `packages/cloud/shared/src/lib/providers/video`.
+- Updated `/api/v1/generate-video` to select a video provider by pricing catalog `billingSource` while preserving existing FAL model IDs and response shape.
+- Kept credit reservation/refund behavior in the route and added coverage for unsupported model rejection plus missing provider credentials.
+
+## Manual Review
+
+- Reviewed `packages/cloud/api/v1/generate-video/route.ts` and confirmed FAL-specific request construction no longer lives inline in the route.
+- Reviewed `packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts` and confirmed the moved normalizer still accepts both `video` and `videos[0]` provider payloads.
+- Reviewed `bun.lock`; the only retained lockfile delta is adding `@fal-ai/client` to the `packages/cloud/shared` workspace dependency block.
+
+## Validation
+
+- `bun run --cwd packages/core build`
+- `bun run --cwd packages/security build`
+- `bun test packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts`
+- `bun test packages/cloud/api/__tests__/generate-video-credit-leak.test.ts`
+- `bun run --cwd packages/cloud/shared typecheck`
+- `bun run --cwd packages/cloud/api typecheck`
+- `bunx @biomejs/biome check --write packages/cloud/api/__tests__/generate-video-credit-leak.test.ts packages/cloud/api/v1/generate-video/route.ts packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts packages/cloud/shared/src/lib/providers/video/registry.ts packages/cloud/shared/src/lib/providers/video/types.ts packages/cloud/shared/package.json`
+
+## N/A
+
+- Live FAL provider calls and generated video artifacts: N/A - explicitly out of scope for #11744 and tracked by the live-evidence child issue.
+- UI screenshots/video: N/A - this is a cloud API/shared provider refactor with no dashboard UI changes.
+- Live LLM trajectories: N/A - no agent prompt/model behavior changed.

--- a/bun.lock
+++ b/bun.lock
@@ -730,6 +730,7 @@
         "@elizaos/plugin-sql": "workspace:*",
         "@elizaos/security": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "@fal-ai/client": "^1.10.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.1",
         "@sendgrid/mail": "^8.1.6",

--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -65,10 +65,13 @@ mock.module("@/lib/services/ai-pricing", () => ({
 
 mock.module("@/lib/services/ai-pricing-definitions", () => ({
   ...aiPricingDefsActual,
-  getSupportedVideoModelDefinition: () => ({
-    provider: "fal",
-    billingSource: "fal",
-  }),
+  getSupportedVideoModelDefinition: (model: string) =>
+    model === MODEL
+      ? {
+          provider: "fal",
+          billingSource: "fal",
+        }
+      : undefined,
   SUPPORTED_VIDEO_MODEL_IDS: [MODEL],
 }));
 
@@ -147,7 +150,17 @@ const validResult = {
   video: { url: "https://fal.media/out.mp4", content_type: "video/mp4" },
 };
 
-function post() {
+interface ErrorResponseBody {
+  error?: string;
+  details?: {
+    supportedModels?: string[];
+  };
+}
+
+function post(
+  body: Record<string, unknown> = { model: MODEL, prompt: "a cat" },
+  env: Record<string, unknown> = { FAL_KEY: "fal-test-key" },
+) {
   return videoRoute.request(
     "/",
     {
@@ -156,9 +169,9 @@ function post() {
         Authorization: "Bearer eliza_test_key",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ model: MODEL, prompt: "a cat" }),
+      body: JSON.stringify(body),
     },
-    { FAL_KEY: "fal-test-key" } as unknown as Record<string, unknown>,
+    env,
   );
 }
 
@@ -176,6 +189,29 @@ beforeEach(() => {
       organization: { id: ORG, name: "Org", is_active: true },
       is_active: true,
     };
+  });
+});
+
+describe("generate-video — model/provider validation", () => {
+  test("unsupported models are rejected before provider or credit work", async () => {
+    const res = await post({ model: "not-a-video-model", prompt: "a cat" });
+
+    expect(res.status).toBe(400);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    const body = (await res.json()) as ErrorResponseBody;
+    expect(body.error).toBe("Unsupported video model: not-a-video-model");
+    expect(body.details?.supportedModels).toEqual([MODEL]);
+  });
+
+  test("missing FAL credentials are rejected before credit reservation", async () => {
+    const res = await post({ model: MODEL, prompt: "a cat" }, {});
+
+    expect(res.status).toBe(503);
+    expect(reserve).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    const body = (await res.json()) as ErrorResponseBody;
+    expect(body.error).toBe("Fal video generation is not configured");
   });
 });
 

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -1,4 +1,3 @@
-import { createFalClient } from "@fal-ai/client";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
@@ -11,6 +10,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { getVideoProvider } from "@/lib/providers/video/registry";
 import {
   calculateVideoGenerationCostFromCatalog,
   getDefaultVideoBillingDimensions,
@@ -26,7 +26,7 @@ import {
 } from "@/lib/services/credits";
 import { generationsService } from "@/lib/services/generations";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
+import type { AppEnv } from "@/types/cloud-worker-env";
 
 const DEFAULT_VIDEO_MODEL = "fal-ai/veo3";
 const MAX_PROMPT_LENGTH = 4000;
@@ -41,133 +41,12 @@ const videoRequestSchema = z.object({
   voiceControl: z.boolean().optional(),
 });
 
-type VideoRequest = z.infer<typeof videoRequestSchema>;
-
-interface FalVideoObject {
-  url?: string;
-  width?: number;
-  height?: number;
-  file_name?: string;
-  file_size?: number;
-  content_type?: string;
-}
-
-interface NormalizedFalVideoResult {
-  requestId?: string;
-  video: FalVideoObject;
-  seed?: number;
-  timings?: Record<string, number> | null;
-  hasNsfwConcepts?: boolean[];
-}
-
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
-function falKey(env: Bindings): string | null {
-  const key = env.FAL_KEY ?? env.FAL_API_KEY;
-  return typeof key === "string" && key.trim() ? key.trim() : null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function numberValue(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function booleanArrayValue(value: unknown): boolean[] | undefined {
-  return Array.isArray(value) &&
-    value.every((item) => typeof item === "boolean")
-    ? value
-    : undefined;
-}
-
-function recordNumberMap(
-  value: unknown,
-): Record<string, number> | null | undefined {
-  if (value === null) return null;
-  if (!isRecord(value)) return undefined;
-
-  const out: Record<string, number> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (typeof item === "number" && Number.isFinite(item)) {
-      out[key] = item;
-    }
-  }
-  return out;
-}
-
-function normalizeVideoObject(value: unknown): FalVideoObject | null {
-  if (!isRecord(value)) return null;
-  const url = stringValue(value.url);
-  if (!url) return null;
-  return {
-    url,
-    width: numberValue(value.width),
-    height: numberValue(value.height),
-    file_name: stringValue(value.file_name),
-    file_size: numberValue(value.file_size),
-    content_type: stringValue(value.content_type),
-  };
-}
-
-function normalizeFalResult(
-  result: unknown,
-  requestId?: string,
-): NormalizedFalVideoResult {
-  if (!isRecord(result)) {
-    throw new Error("fal.ai returned an invalid video response");
-  }
-
-  const video =
-    normalizeVideoObject(result.video) ??
-    (Array.isArray(result.videos)
-      ? normalizeVideoObject(result.videos[0])
-      : null);
-  if (!video?.url) {
-    throw new Error("fal.ai returned no video URL");
-  }
-
-  return {
-    requestId:
-      stringValue(result.requestId) ??
-      stringValue(result.request_id) ??
-      requestId,
-    video,
-    seed: numberValue(result.seed),
-    timings: recordNumberMap(result.timings) ?? null,
-    hasNsfwConcepts: booleanArrayValue(result.has_nsfw_concepts),
-  };
-}
-
-function buildFalInput(request: VideoRequest): Record<string, unknown> {
-  const input: Record<string, unknown> = { prompt: request.prompt };
-  if (request.referenceUrl) {
-    input.image_url = request.referenceUrl;
-  }
-  if (request.durationSeconds) {
-    input.duration = request.durationSeconds;
-    input.duration_seconds = request.durationSeconds;
-  }
-  if (request.resolution) {
-    input.resolution = request.resolution;
-  }
-  if (request.audio !== undefined) {
-    input.audio = request.audio;
-    input.generate_audio = request.audio;
-  }
-  if (request.voiceControl !== undefined) {
-    input.voice_control = request.voiceControl;
-  }
-  return input;
+function envString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 app.post("/", async (c) => {
@@ -194,12 +73,18 @@ app.post("/", async (c) => {
       );
     }
 
-    const key = falKey(c.env);
-    if (!key) {
+    const provider = getVideoProvider(definition.billingSource);
+    const apiKeys = {
+      FAL_KEY: envString(c.env.FAL_KEY),
+      FAL_API_KEY: envString(c.env.FAL_API_KEY),
+    };
+    if (provider.isConfigured && !provider.isConfigured(apiKeys)) {
+      const providerName =
+        definition.provider === "fal" ? "Fal" : definition.provider;
       return jsonError(
         c,
         503,
-        "Fal video generation is not configured",
+        `${providerName} video generation is not configured`,
         "internal_error",
       );
     }
@@ -233,7 +118,7 @@ app.post("/", async (c) => {
     };
     const cost = await calculateVideoGenerationCostFromCatalog({
       model: request.model,
-      billingSource: "fal",
+      billingSource: definition.billingSource,
       durationSeconds,
       dimensions,
     });
@@ -259,19 +144,11 @@ app.post("/", async (c) => {
       throw error;
     }
 
-    let requestId: string | undefined;
-    const fal = createFalClient({
-      credentials: key,
-      suppressLocalCredentialsWarning: true,
+    const generated = await provider.generate({
+      ...request,
+      apiKeys,
     });
-    const result = await fal.subscribe(request.model, {
-      input: buildFalInput(request),
-      onEnqueue: (id) => {
-        requestId = id;
-      },
-    });
-    const normalized = normalizeFalResult(result, requestId);
-    if (normalized.hasNsfwConcepts?.some(Boolean)) {
+    if (generated.hasNsfwConcepts?.some(Boolean)) {
       throw new ApiError(
         400,
         "validation_error",
@@ -296,18 +173,18 @@ app.post("/", async (c) => {
       provider: definition.provider,
       prompt: request.prompt,
       result: {
-        requestId: normalized.requestId,
-        seed: normalized.seed,
-        timings: normalized.timings,
+        requestId: generated.requestId,
+        seed: generated.seed,
+        timings: generated.timings,
         billingSource: definition.billingSource,
       },
       status: "completed",
-      storage_url: normalized.video.url,
-      thumbnail_url: normalized.video.url,
-      file_size: normalized.video.file_size
-        ? BigInt(normalized.video.file_size)
+      storage_url: generated.video.url,
+      thumbnail_url: generated.video.url,
+      file_size: generated.video.file_size
+        ? BigInt(generated.video.file_size)
         : undefined,
-      mime_type: normalized.video.content_type ?? "video/mp4",
+      mime_type: generated.video.content_type ?? "video/mp4",
       parameters: {
         referenceUrl: request.referenceUrl,
         durationSeconds,
@@ -316,24 +193,24 @@ app.post("/", async (c) => {
         voiceControl: request.voiceControl,
       },
       dimensions: {
-        width: normalized.video.width,
-        height: normalized.video.height,
+        width: generated.video.width,
+        height: generated.video.height,
         duration: durationSeconds,
       },
       cost: String(cost.totalCost),
       credits: String(cost.totalCost),
-      job_id: normalized.requestId,
+      job_id: generated.requestId,
       completed_at: new Date(),
     });
 
     return c.json({
       success: true,
       id: generation.id,
-      requestId: normalized.requestId,
-      video: normalized.video,
-      seed: normalized.seed,
-      timings: normalized.timings,
-      has_nsfw_concepts: normalized.hasNsfwConcepts,
+      requestId: generated.requestId,
+      video: generated.video,
+      seed: generated.seed,
+      timings: generated.timings,
+      has_nsfw_concepts: generated.hasNsfwConcepts,
       cost,
     });
   } catch (error) {

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -57,6 +57,7 @@
     "@elizaos/plugin-sql": "workspace:*",
     "@elizaos/security": "workspace:*",
     "@elizaos/shared": "workspace:*",
+    "@fal-ai/client": "^1.10.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.1",
     "@sendgrid/mail": "^8.1.6",

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const subscribe = mock();
+const createFalClient = mock(() => ({ subscribe }));
+
+mock.module("@fal-ai/client", () => ({
+  createFalClient,
+}));
+
+const { buildFalVideoInput, falVideoProvider, generateFalVideo, normalizeFalVideoResult } =
+  await import("./fal-video-generation");
+
+describe("FAL video provider", () => {
+  test("maps Cloud video request fields to FAL input aliases", () => {
+    expect(
+      buildFalVideoInput({
+        model: "fal-ai/veo3",
+        prompt: "city timelapse",
+        referenceUrl: "https://example.com/ref.png",
+        durationSeconds: 8,
+        resolution: "1080p",
+        audio: true,
+        voiceControl: false,
+        apiKeys: { FAL_KEY: "fal-key" },
+      }),
+    ).toEqual({
+      prompt: "city timelapse",
+      image_url: "https://example.com/ref.png",
+      duration: 8,
+      duration_seconds: 8,
+      resolution: "1080p",
+      audio: true,
+      generate_audio: true,
+      voice_control: false,
+    });
+  });
+
+  test("normalizes FAL video responses with request id fallback", () => {
+    expect(
+      normalizeFalVideoResult(
+        {
+          videos: [
+            {
+              url: "https://fal.media/out.mp4",
+              width: 1920,
+              height: 1080,
+              file_name: "out.mp4",
+              file_size: 1234,
+              content_type: "video/mp4",
+            },
+          ],
+          seed: 99,
+          timings: { inference: 1.25 },
+          has_nsfw_concepts: [false],
+        },
+        "queued-id",
+      ),
+    ).toEqual({
+      requestId: "queued-id",
+      video: {
+        url: "https://fal.media/out.mp4",
+        width: 1920,
+        height: 1080,
+        file_name: "out.mp4",
+        file_size: 1234,
+        content_type: "video/mp4",
+      },
+      seed: 99,
+      timings: { inference: 1.25 },
+      hasNsfwConcepts: [false],
+    });
+  });
+
+  test("generates through the registered FAL provider", async () => {
+    createFalClient.mockClear();
+    subscribe.mockClear();
+    subscribe.mockImplementation(async (_model, options) => {
+      options.onEnqueue("queued-id");
+      return {
+        request_id: "result-id",
+        video: { url: "https://fal.media/out.mp4" },
+      };
+    });
+
+    const result = await generateFalVideo({
+      model: "fal-ai/veo3",
+      prompt: "a lighthouse",
+      durationSeconds: 5,
+      apiKeys: { FAL_API_KEY: "fal-key" },
+    });
+
+    expect(falVideoProvider.billingSource).toBe("fal");
+    expect(falVideoProvider.isConfigured?.({ FAL_KEY: " fal-key " })).toBe(true);
+    expect(createFalClient).toHaveBeenCalledWith({
+      credentials: "fal-key",
+      suppressLocalCredentialsWarning: true,
+    });
+    expect(subscribe).toHaveBeenCalledWith("fal-ai/veo3", {
+      input: {
+        prompt: "a lighthouse",
+        duration: 5,
+        duration_seconds: 5,
+      },
+      onEnqueue: expect.any(Function),
+    });
+    expect(result).toEqual({
+      requestId: "result-id",
+      video: { url: "https://fal.media/out.mp4" },
+      timings: null,
+      hasNsfwConcepts: undefined,
+      seed: undefined,
+    });
+  });
+
+  test("rejects missing FAL credentials before calling upstream", async () => {
+    createFalClient.mockClear();
+
+    await expect(
+      generateFalVideo({
+        model: "fal-ai/veo3",
+        prompt: "a lighthouse",
+        apiKeys: {},
+      }),
+    ).rejects.toThrow("AI services are not configured on this deployment");
+    expect(falVideoProvider.isConfigured?.({})).toBe(false);
+    expect(createFalClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts
@@ -1,0 +1,132 @@
+import { createFalClient } from "@fal-ai/client";
+import { getAiProviderConfigurationError } from "../language-model";
+import type {
+  GeneratedVideo,
+  GeneratedVideoObject,
+  VideoGenerationRequest,
+  VideoProvider,
+} from "./types";
+
+function falKey(apiKeys: Record<string, string | undefined>): string | null {
+  const key = apiKeys.FAL_KEY ?? apiKeys.FAL_API_KEY;
+  return typeof key === "string" && key.trim() ? key.trim() : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function booleanArrayValue(value: unknown): boolean[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "boolean")
+    ? value
+    : undefined;
+}
+
+function recordNumberMap(value: unknown): Record<string, number> | null | undefined {
+  if (value === null) return null;
+  if (!isRecord(value)) return undefined;
+
+  const out: Record<string, number> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "number" && Number.isFinite(item)) {
+      out[key] = item;
+    }
+  }
+  return out;
+}
+
+function normalizeVideoObject(value: unknown): GeneratedVideoObject | null {
+  if (!isRecord(value)) return null;
+  const url = stringValue(value.url);
+  if (!url) return null;
+  return {
+    url,
+    width: numberValue(value.width),
+    height: numberValue(value.height),
+    file_name: stringValue(value.file_name),
+    file_size: numberValue(value.file_size),
+    content_type: stringValue(value.content_type),
+  };
+}
+
+export function normalizeFalVideoResult(result: unknown, requestId?: string): GeneratedVideo {
+  if (!isRecord(result)) {
+    throw new Error("fal.ai returned an invalid video response");
+  }
+
+  const video =
+    normalizeVideoObject(result.video) ??
+    (Array.isArray(result.videos) ? normalizeVideoObject(result.videos[0]) : null);
+  if (!video?.url) {
+    throw new Error("fal.ai returned no video URL");
+  }
+
+  return {
+    requestId: stringValue(result.requestId) ?? stringValue(result.request_id) ?? requestId,
+    video,
+    seed: numberValue(result.seed),
+    timings: recordNumberMap(result.timings) ?? null,
+    hasNsfwConcepts: booleanArrayValue(result.has_nsfw_concepts),
+  };
+}
+
+export function buildFalVideoInput(request: VideoGenerationRequest): Record<string, unknown> {
+  const input: Record<string, unknown> = { prompt: request.prompt };
+  if (request.referenceUrl) {
+    input.image_url = request.referenceUrl;
+  }
+  if (request.durationSeconds) {
+    input.duration = request.durationSeconds;
+    input.duration_seconds = request.durationSeconds;
+  }
+  if (request.resolution) {
+    input.resolution = request.resolution;
+  }
+  if (request.audio !== undefined) {
+    input.audio = request.audio;
+    input.generate_audio = request.audio;
+  }
+  if (request.voiceControl !== undefined) {
+    input.voice_control = request.voiceControl;
+  }
+  return input;
+}
+
+export async function generateFalVideo(request: VideoGenerationRequest): Promise<GeneratedVideo> {
+  const key = falKey(request.apiKeys);
+  if (!key) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  let requestId: string | undefined;
+  const fal = createFalClient({
+    credentials: key,
+    suppressLocalCredentialsWarning: true,
+  });
+  const result = await fal.subscribe(request.model, {
+    input: buildFalVideoInput(request),
+    onEnqueue: (id) => {
+      requestId = id;
+    },
+  });
+  return normalizeFalVideoResult(result, requestId);
+}
+
+export const falVideoProvider: VideoProvider = {
+  billingSource: "fal",
+  isConfigured(apiKeys) {
+    return Boolean(falKey(apiKeys));
+  },
+  generate: generateFalVideo,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud/shared/src/lib/providers/video/registry.ts
+++ b/packages/cloud/shared/src/lib/providers/video/registry.ts
@@ -1,0 +1,19 @@
+import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import { falVideoProvider } from "./fal-video-generation";
+import type { VideoProvider } from "./types";
+
+const PROVIDERS = new Map<PricingBillingSource, VideoProvider>();
+
+export function registerVideoProvider(provider: VideoProvider) {
+  PROVIDERS.set(provider.billingSource, provider);
+}
+
+export function getVideoProvider(billingSource: PricingBillingSource): VideoProvider {
+  const provider = PROVIDERS.get(billingSource);
+  if (!provider) {
+    throw new Error(`No video provider registered for billing source: ${billingSource}`);
+  }
+  return provider;
+}
+
+registerVideoProvider(falVideoProvider);

--- a/packages/cloud/shared/src/lib/providers/video/types.ts
+++ b/packages/cloud/shared/src/lib/providers/video/types.ts
@@ -1,0 +1,36 @@
+import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+
+export interface VideoGenerationRequest {
+  model: string;
+  prompt: string;
+  referenceUrl?: string;
+  durationSeconds?: number;
+  resolution?: string;
+  audio?: boolean;
+  voiceControl?: boolean;
+  apiKeys: Record<string, string | undefined>;
+}
+
+export interface GeneratedVideoObject {
+  url: string;
+  width?: number;
+  height?: number;
+  file_name?: string;
+  file_size?: number;
+  content_type?: string;
+}
+
+export interface GeneratedVideo {
+  requestId?: string;
+  video: GeneratedVideoObject;
+  seed?: number;
+  timings?: Record<string, number> | null;
+  hasNsfwConcepts?: boolean[];
+}
+
+export interface VideoProvider {
+  billingSource: PricingBillingSource;
+  isConfigured?(apiKeys: Record<string, string | undefined>): boolean;
+  generate(req: VideoGenerationRequest): Promise<GeneratedVideo>;
+  healthCheck?(): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary

- Move FAL video input mapping, response normalization, credential checks, and invocation into a shared video provider implementation.
- Add a shared video provider registry keyed by pricing `billingSource` and route `/api/v1/generate-video` through it.
- Extend the generate-video regression suite to cover unsupported model rejection and missing provider credentials before credit reservation.

Closes #11744.
Part of #10688.

## Evidence

See `.github/issue-evidence/11744-video-provider-registry.md`.

Validation run:

- `git fetch origin && git rebase origin/develop` - up to date; fetch reported an unrelated local-inference submodule access warning.
- `bun install --ignore-scripts` - no lockfile changes after sync.
- `bun run --cwd packages/core build` - pass.
- `bun run --cwd packages/security build` - pass.
- `bun test packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts` - pass, 4 tests.
- `bun test packages/cloud/api/__tests__/generate-video-credit-leak.test.ts` - pass, 5 tests.
- `bun run --cwd packages/cloud/shared typecheck` - pass.
- `bun run --cwd packages/cloud/api typecheck` - pass.
- `bunx @biomejs/biome check --write packages/cloud/api/__tests__/generate-video-credit-leak.test.ts packages/cloud/api/v1/generate-video/route.ts packages/cloud/shared/src/lib/providers/video/fal-video-generation.ts packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts packages/cloud/shared/src/lib/providers/video/registry.ts packages/cloud/shared/src/lib/providers/video/types.ts packages/cloud/shared/package.json` - pass.
- `git diff --check HEAD~1..HEAD` - pass.

`bun run verify` was attempted after sync. It passed the type-safety ratchet and entered the workspace Turbo typecheck/lint run, then exited with code 139 after reporting stale type errors in `packages/cloud/api/__tests__/generate-video-credit-leak.test.ts`. Those assertions are included in this PR commit and `bun run --cwd packages/cloud/api typecheck` now passes on the final tree.

## N/A

- Live FAL provider call and generated video artifact review: N/A - no provider credentials available in this environment; tracked separately by #11745.
- UI screenshots/video: N/A - no UI surface changed.
- Live LLM trajectories: N/A - no agent prompt/model behavior changed.
