### PR TITLE
test(scenario-runner): classify the #11610 active-view scenario — un-red the coverage gate

### DIFF
--- a/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
+++ b/packages/scenario-runner/src/__tests__/deterministic-action-coverage.test.ts
@@ -652,6 +652,10 @@ const STRICT_LLM_ROUTING_SCENARIOS: Record<
     actionNames: ["APP", "VIEWS"],
     minMessageTurns: REQUIRED_APP_CONTROL_NL_TURNS.length,
   },
+  "deterministic-active-view-agent-surface": {
+    actionNames: ["VIEWS"],
+    minMessageTurns: 2,
+  },
   "deterministic-agent-skills-actions": {
     actionNames: [
       "SKILL",
@@ -1196,11 +1200,15 @@ describe("deterministic action coverage", () => {
         continue;
       }
       // `_helpers/strict-llm-action-fixtures.ts` re-exports the canonical
-      // template from `@elizaos/test-harness`; read that file for the fixture
-      // literals (RESPONSE_HANDLER / ACTION_PLANNER / register call).
-      const fixtureSource = source.includes("registerStrictActionRouteFixtures")
-        ? `${source}\n${readFileSync(resolve(repoRoot, "packages/test/harness/action-route-fixtures.ts"), "utf8")}`
-        : source;
+      // template from `@elizaos/test-harness`; scenarios may also import the
+      // stage1/planner fixture builders from that harness directly. Either
+      // way, read the harness file for the fixture literals
+      // (RESPONSE_HANDLER / ACTION_PLANNER / register call).
+      const fixtureSource =
+        source.includes("registerStrictActionRouteFixtures") ||
+        source.includes("stage1ResponseHandlerFixture")
+          ? `${source}\n${readFileSync(resolve(repoRoot, "packages/test/harness/action-route-fixtures.ts"), "utf8")}`
+          : source;
 
       const messageTurns = messageTurnCount(scenario);
       if (messageTurns < spec.minMessageTurns) {


### PR DESCRIPTION
The 'every deterministic message scenario is classified' gate has been red on develop since #11610 landed: `deterministic-active-view-agent-surface` declares its RESPONSE_HANDLER/ACTION_PLANNER fixtures via the harness `stage1ResponseHandlerFixture` builder imported directly from `@elizaos/test-harness`, which the strict-spec source scan didn't follow — the scenario fit neither bucket.

- Registers it in `STRICT_LLM_ROUTING_SCENARIOS` (`VIEWS`, 2 message turns).
- The fixture-literal scan now follows direct `stage1ResponseHandlerFixture` imports into the harness source, same as the existing `registerStrictActionRouteFixtures` re-export path.

## Evidence
- `bunx vitest run src/__tests__/deterministic-action-coverage.test.ts` → **17/17** (16/17 red on develop tip, the classification case).
- Surfaced by the #11708 review (pre-existing breakage, explicitly not that PR's fault).
- UI/video/trajectory rows: N/A — test-gate classification metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)