### PR TITLE
docs(cloud): cover all priced media models in roster

### DIFF
--- a/.github/issue-evidence/11742-media-model-roster.md
+++ b/.github/issue-evidence/11742-media-model-roster.md
@@ -4,7 +4,7 @@
 
 - Added `packages/cloud/shared/src/lib/services/media-model-roster.ts` as the checked-in FAL/Google media model roster.
 - Marked currently routed families as `wired` and every non-routed candidate as `deferred` with an explicit rationale.
-- Added `media-model-roster.test.ts` to prove source/rationale completeness and ensure every wired model id remains indexed in the supported pricing definitions.
+- Added `media-model-roster.test.ts` to prove source/rationale completeness, ensure every wired model id remains indexed in the supported pricing definitions, and ensure every supported image/video/music pricing model is represented in the roster.
 
 ## Reviewed Sources
 
@@ -17,7 +17,7 @@
 
 ## Roster Decisions
 
-- Wired: FAL FLUX image, FAL Veo video, FAL Kling video, FAL Hailuo video, FAL MiniMax Music, adjacent FAL Wan/PixVerse/Seedance video, and Atlas-hosted Google Nano Banana image generation.
+- Wired: FAL FLUX image, Atlas-hosted GPT Image 2 / Seedream / Google Nano Banana / Qwen image generation, FAL Veo video, FAL Kling video, FAL Hailuo video, FAL MiniMax Music, ElevenLabs Music, Suno-compatible music, and adjacent FAL Wan/PixVerse/Seedance video.
 - Deferred: Recraft, Ideogram, Luma, Runway, Stable Audio, MMAudio, direct Google Imagen 4, direct Google Veo, and direct Gemini Omni/media routes.
 
 ## Validation

--- a/packages/cloud/shared/src/lib/services/media-model-roster.test.ts
+++ b/packages/cloud/shared/src/lib/services/media-model-roster.test.ts
@@ -7,10 +7,15 @@ describe("media model roster", () => {
 
     const requiredFamilies = [
       "FLUX",
+      "Atlas-hosted GPT Image 2",
+      "Atlas-hosted Seedream",
+      "Atlas-hosted Qwen Image",
       "Recraft",
       "Ideogram",
       "Kling",
       "MiniMax / Hailuo",
+      "ElevenLabs Music",
+      "Suno-compatible music",
       "Luma",
       "Runway",
       "Stable Audio",
@@ -51,6 +56,17 @@ describe("media model roster", () => {
           (entry.surfaces.includes("music") && indexes.music.has(modelId));
         expect(isIndexed, `${entry.family}: ${modelId}`).toBe(true);
       }
+    }
+  });
+
+  test("catalogs every supported media pricing model", () => {
+    const indexes = mediaRosterModelIndexes();
+    const wiredModelIds = new Set(
+      MEDIA_MODEL_ROSTER.flatMap((entry) => [...(entry.wiredModelIds ?? [])]),
+    );
+
+    for (const modelId of [...indexes.image, ...indexes.video, ...indexes.music]) {
+      expect(wiredModelIds.has(modelId), modelId).toBe(true);
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/media-model-roster.ts
+++ b/packages/cloud/shared/src/lib/services/media-model-roster.ts
@@ -6,7 +6,7 @@ import {
 
 export type MediaRosterStatus = "wired" | "deferred" | "rejected";
 export type MediaRosterSurface = "image" | "video" | "music" | "audio";
-export type MediaRosterProvider = "fal" | "atlascloud" | "google";
+export type MediaRosterProvider = "fal" | "atlascloud" | "google" | "elevenlabs" | "suno";
 
 export interface MediaModelRosterEntry {
   family: string;
@@ -31,6 +31,36 @@ export const MEDIA_MODEL_ROSTER: readonly MediaModelRosterEntry[] = [
     wiredModelIds: ["fal-ai/flux/schnell", "fal-ai/flux/dev"],
     rationale:
       "FLUX.1 Schnell and Dev are priced and routed through the existing FAL image provider.",
+  },
+  {
+    family: "Atlas-hosted GPT Image 2",
+    provider: "atlascloud",
+    surfaces: ["image"],
+    status: "wired",
+    sourceUrls: ["https://www.atlascloud.ai/models/list"],
+    wiredModelIds: ["openai/gpt-image-2/text-to-image"],
+    rationale:
+      "GPT Image 2 is an Atlas Cloud image-generation model with an existing pricing definition and Atlas image provider route.",
+  },
+  {
+    family: "Atlas-hosted Seedream",
+    provider: "atlascloud",
+    surfaces: ["image"],
+    status: "wired",
+    sourceUrls: ["https://www.atlascloud.ai/models/list", "https://fal.ai/pricing"],
+    wiredModelIds: ["bytedance/seedream-v5.0-lite"],
+    rationale:
+      "Seedream is part of the current hosted image roster and is already indexed as an Atlas Cloud text-to-image model.",
+  },
+  {
+    family: "Atlas-hosted Qwen Image",
+    provider: "atlascloud",
+    surfaces: ["image"],
+    status: "wired",
+    sourceUrls: ["https://www.atlascloud.ai/models/list"],
+    wiredModelIds: ["qwen/qwen-image-2.0/text-to-image"],
+    rationale:
+      "Qwen Image 2.0 is already priced and routed through the Atlas Cloud image provider, so it belongs in the checked-in roster.",
   },
   {
     family: "Recraft",
@@ -86,6 +116,26 @@ export const MEDIA_MODEL_ROSTER: readonly MediaModelRosterEntry[] = [
     ],
     rationale:
       "Hailuo 2.3 video and MiniMax Music 2.6 have supported pricing definitions; music is cataloged for pricing while video is routed.",
+  },
+  {
+    family: "ElevenLabs Music",
+    provider: "elevenlabs",
+    surfaces: ["music"],
+    status: "wired",
+    sourceUrls: ["https://elevenlabs.io/docs/api-reference/music/compose"],
+    wiredModelIds: ["elevenlabs/music_v1"],
+    rationale:
+      "ElevenLabs Music v1 is in the music pricing definitions and is routed by the existing generate-music provider branch.",
+  },
+  {
+    family: "Suno-compatible music",
+    provider: "suno",
+    surfaces: ["music"],
+    status: "wired",
+    sourceUrls: ["https://docs.sunoapi.org/suno-api/generate-music/"],
+    wiredModelIds: ["suno/default"],
+    rationale:
+      "The Suno-compatible provider remains a supported music-generation option with explicit fallback pricing.",
   },
   {
     family: "Luma",


### PR DESCRIPTION
## Summary
- Extend the media model roster from #11751 so every currently supported image/video/music pricing model is cataloged.
- Add Atlas-hosted GPT Image 2, Seedream, Qwen Image, ElevenLabs Music, and Suno-compatible music entries.
- Add a regression test that fails if a supported pricing model is missing from the roster.

## Evidence
- `bun test packages/cloud/shared/src/lib/services/media-model-roster.test.ts` — 3 pass / 0 fail, 167 assertions.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/media-model-roster.ts packages/cloud/shared/src/lib/services/media-model-roster.test.ts` — pass.
- `git diff --check origin/develop..HEAD` — pass.

## N/A
- Live media generation: N/A - catalog/test-only follow-up to #11751; live generated artifacts remain tracked by #11745.
- UI screenshots/video: N/A - no UI changed.
- Live LLM trajectories: N/A - no agent prompt/model behavior changed.
