### PR TITLE
ci(cloud): publish STEWARD_PLATFORM_KEYS on deploy — the durable half of #11461

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -439,6 +439,12 @@ jobs:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
           VAST_BASE_URL: ${{ secrets.VAST_BASE_URL }}
+          # Platform key the Worker forwards as X-Steward-Platform-Key so per-org
+          # sandbox Steward tenants provision instead of collapsing onto the
+          # shared default tenant (#11461). publish_secret no-ops with a notice
+          # while unset, so this is safe before ops adds the GH env secret and
+          # keeps it published on every redeploy once they do.
+          STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
@@ -480,7 +486,8 @@ jobs:
             FAL_KEY \
             ELEVENLABS_API_KEY \
             VAST_API_KEY \
-            VAST_BASE_URL
+            VAST_BASE_URL \
+            STEWARD_PLATFORM_KEYS
           do
             publish_secret "$name"
           done


### PR DESCRIPTION
## What

Prod `GET /api/health/operational` returns `degraded`: `STEWARD_PLATFORM_KEYS` is unset, so `POST /api/v1/steward/tenants` 503s and per-org sandbox Steward tenants collapse onto the shared default `elizacloud` tenant. The Worker forwards this key as `X-Steward-Platform-Key` (required per `wrangler.toml:189`).

## Change

Add `STEWARD_PLATFORM_KEYS` to the deploy's **Publish Worker secrets** step — both the `env:` mapping (`${{ secrets.STEWARD_PLATFORM_KEYS }}`) and the `publish_secret` loop. This is exactly step 4 of the issue's fix ("durable: add it to the publish list so redeploys keep it published").

## Why it's safe to merge now (before ops sets the key)

`publish_secret()` is **conditional**:
```bash
local value="${!name:-}"
if [ -z "$value" ]; then echo "::notice::$name is not configured; skipping"; return 0; fi
```
So while the GH env secret is unset this is a **no-op with a notice** — zero deploy risk. Once ops adds `STEWARD_PLATFORM_KEYS` to the GH env secrets, every redeploy publishes it to the Worker automatically (closing the "44 secrets re-published but this one stayed unset" gap that reopened this).

## Scope

This is the **durable/code half**. The remaining operator step — obtaining the platform key that matches the upstream Steward deployment and adding it to the GH env secret (or a one-time `wrangler secret put`) — needs the key value, which is ops-owned. After that, `/api/health/operational` flips to `ok`.

YAML validated (`yaml.safe_load`). Live deploy verification is operator-side (needs Cloudflare creds).

Refs #11461

🤖 Generated with [Claude Code](https://claude.com/claude-code)