### PR TITLE
fix: add LinkedIn ads provider

### DIFF
--- a/.github/issue-evidence/11663-linkedin-ads-provider.md
+++ b/.github/issue-evidence/11663-linkedin-ads-provider.md
@@ -1,0 +1,51 @@
+# Issue #11663 - LinkedIn Ads Provider
+
+## Summary
+
+Implemented the `linkedin` advertising provider for the Cloud advertising service:
+
+- LinkedIn Marketing API account discovery and credential validation.
+- Paused campaign creation under an existing or newly created campaign group.
+- Campaign update, pause, activate, and archive lifecycle operations through Rest.li patch bodies.
+- Text ad creative creation.
+- Image upload initialization, binary upload, and media library registration.
+- Campaign analytics mapping from LinkedIn `adAnalytics` rows into Cloud campaign metrics.
+- Platform validation updates for shared schemas and the app promotion route.
+
+## Official API References
+
+- LinkedIn Marketing API overview: https://learn.microsoft.com/en-us/linkedin/marketing/?view=li-lms-2026-06
+- Ad accounts: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2026-06
+- Campaign groups: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2026-06
+- Campaigns: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2026-06
+- Creatives: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2026-06
+- Ads reporting: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-06
+- Images API: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api?view=li-lms-2026-06
+
+## Verification
+
+- `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts`
+  - Result: 8 pass, 1 skipped live test.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Result: pass.
+- `bun run --cwd packages/cloud/api typecheck`
+  - Result: pass.
+- `bunx biome check packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts packages/cloud/shared/src/lib/services/advertising/index.ts packages/cloud/shared/src/lib/services/advertising/types.ts packages/cloud/shared/src/lib/services/advertising/schemas.ts packages/cloud/shared/src/db/schemas/ad-accounts.ts 'packages/cloud/api/v1/apps/[id]/promote/route.ts'`
+  - Result: pass.
+- `git diff --check`
+  - Result: pass.
+
+## Live Lane
+
+`packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts` is gated by `LINKEDIN_ADS_LIVE_TEST=1` and fails loudly if that flag is set without `LINKEDIN_ADS_ACCESS_TOKEN`.
+
+Live LinkedIn credentials were not available in this environment, so no production LinkedIn account was touched and no live campaign was created.
+
+## Evidence Matrix
+
+- Real provider mocked tests: complete.
+- Live provider lane: present, skipped because credentials are unavailable.
+- Backend logs: N/A - mocked provider tests assert outbound requests directly; no server was run.
+- Frontend screenshots/video: N/A - no UI rendering changed.
+- Real LLM trajectories: N/A - no model, prompt, action, or provider behavior changed.
+- Domain artifacts: N/A - no real LinkedIn account credentials were available, so no provider-side account, campaign, creative, or image asset was created.

--- a/.github/issue-evidence/11663-linkedin-ads-provider.md
+++ b/.github/issue-evidence/11663-linkedin-ads-provider.md
@@ -5,7 +5,7 @@
 Implemented the `linkedin` advertising provider for the Cloud advertising service:
 
 - LinkedIn Marketing API account discovery and credential validation.
-- Paused campaign creation under an existing or newly created campaign group.
+- Paused campaign creation under an existing or newly created campaign group, including required LinkedIn campaign fields for locale, cost type, targeting criteria, offsite delivery, and political intent.
 - Campaign update, pause, activate, and archive lifecycle operations through Rest.li patch bodies.
 - Text ad creative creation.
 - Image upload initialization, binary upload, and media library registration.
@@ -25,7 +25,7 @@ Implemented the `linkedin` advertising provider for the Cloud advertising servic
 ## Verification
 
 - `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts`
-  - Result: 8 pass, 1 skipped live test.
+  - Result: 9 pass, 1 skipped live test.
 - `bun run --cwd packages/cloud/shared typecheck`
   - Result: pass.
 - `bun run --cwd packages/cloud/api typecheck`

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -53,7 +53,7 @@ const PromotionConfigSchema = z.object({
     .optional(),
   advertising: z
     .object({
-      platform: z.enum(["meta", "google", "tiktok"]),
+      platform: z.enum(["meta", "google", "tiktok", "linkedin"]),
       adAccountId: z.string().uuid(),
       budget: z.number().positive().max(10000),
       budgetType: z.enum(["daily", "lifetime"]),

--- a/packages/cloud/shared/src/db/schemas/ad-accounts.ts
+++ b/packages/cloud/shared/src/db/schemas/ad-accounts.ts
@@ -7,7 +7,7 @@ import { users } from "./users";
 /**
  * Ad platform type.
  */
-export type AdPlatform = "meta" | "google" | "tiktok";
+export type AdPlatform = "meta" | "google" | "tiktok" | "linkedin";
 
 /**
  * Ad account status.
@@ -65,6 +65,10 @@ export const adAccounts = pgTable(
         timezone?: string;
         // TikTok-specific
         advertiser_id?: string;
+        // LinkedIn-specific
+        campaign_group_ids?: string[];
+        organization_urns?: string[];
+        linkedin_version?: string;
         // Common
         permissions?: string[];
         last_sync_at?: string;

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -16,6 +16,7 @@ import { type ContentSafetyReview, contentSafetyService } from "../content-safet
 import { creditsService } from "../credits";
 import { secretsService } from "../secrets";
 import { googleAdsProvider } from "./providers/google";
+import { linkedinAdsProvider } from "./providers/linkedin";
 import { metaAdsProvider } from "./providers/meta";
 import { tiktokAdsProvider } from "./providers/tiktok";
 import { DaypartingScheduleSchema } from "./schemas";
@@ -52,6 +53,7 @@ const providers: Record<AdPlatform, AdProvider | null> = {
   meta: metaAdsProvider,
   google: googleAdsProvider,
   tiktok: tiktokAdsProvider,
+  linkedin: linkedinAdsProvider,
 };
 
 class AdvertisingService {

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { linkedinAdsProvider } from "./linkedin";
+
+const liveEnabled = process.env.LINKEDIN_ADS_LIVE_TEST === "1";
+
+describe("linkedinAdsProvider live", () => {
+  test.skipIf(!liveEnabled)(
+    "lists real LinkedIn ad accounts with a live Marketing API token",
+    async () => {
+      const accessToken = process.env.LINKEDIN_ADS_ACCESS_TOKEN;
+      if (!accessToken) {
+        throw new Error(
+          "LINKEDIN_ADS_LIVE_TEST=1 requires LINKEDIN_ADS_ACCESS_TOKEN for live provider verification",
+        );
+      }
+
+      const accounts = await linkedinAdsProvider.listAdAccounts({ accessToken });
+
+      expect(Array.isArray(accounts)).toBe(true);
+      expect(accounts.length).toBeGreaterThan(0);
+      expect(accounts[0]?.id).toMatch(/\S/);
+      expect(accounts[0]?.name).toMatch(/\S/);
+    },
+  );
+
+  test.skipIf(liveEnabled)(
+    "skips live LinkedIn Marketing API verification unless LINKEDIN_ADS_LIVE_TEST=1",
+    () => {
+      expect(process.env.LINKEDIN_ADS_LIVE_TEST).not.toBe("1");
+    },
+  );
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { linkedinAdsProvider } from "./linkedin";
+
+vi.mock("../media-utils", () => ({
+  downloadAdMedia: vi.fn(async (url: string) => ({
+    url,
+    bytes: new Uint8Array([1, 2, 3]),
+    base64: "AQID",
+    contentType: "image/png",
+    fileName: "asset.png",
+  })),
+  mediaFileName: vi.fn(() => "asset.png"),
+}));
+
+const credentials = { accessToken: "linkedin-token" };
+const originalFetch = globalThis.fetch;
+
+function fetchMock() {
+  return fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit & { restliId?: string } = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("content-type", "application/json");
+  if (init.restliId) headers.set("x-restli-id", init.restliId);
+  return new Response(JSON.stringify(body), {
+    ...init,
+    status: init.status ?? 200,
+    headers,
+  });
+}
+
+function nextRequest(index: number) {
+  const mock = fetchMock();
+  return {
+    url: new URL(mock.mock.calls[index][0] as string),
+    init: mock.mock.calls[index][1] as RequestInit,
+    body: JSON.parse(String((mock.mock.calls[index][1] as RequestInit).body ?? "{}")),
+  };
+}
+
+describe("linkedinAdsProvider", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("lists ad accounts with LinkedIn Marketing headers", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        elements: [{ id: 12345, name: "elizaOS Ads", status: "ACTIVE" }],
+      }),
+    );
+
+    await expect(linkedinAdsProvider.listAdAccounts(credentials)).resolves.toEqual([
+      { id: "12345", name: "elizaOS Ads" },
+    ]);
+
+    const request = nextRequest(0);
+    expect(request.url.pathname).toBe("/rest/adAccounts");
+    expect(request.url.searchParams.get("q")).toBe("search");
+    expect(request.init.headers).toMatchObject({
+      Authorization: "Bearer linkedin-token",
+      "Linkedin-Version": "202606",
+      "X-Restli-Protocol-Version": "2.0.0",
+    });
+  });
+
+  test("creates a paused campaign under an existing campaign group", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ elements: [{ id: 77, status: "ACTIVE" }] }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 201, restliId: "888" }));
+
+    const result = await linkedinAdsProvider.createCampaign(credentials, "12345", {
+      organizationId: "org-1",
+      adAccountId: "ad-account-1",
+      name: "Launch campaign",
+      objective: "traffic",
+      budgetType: "daily",
+      budgetAmount: 50,
+      budgetCurrency: "USD",
+      startDate: new Date("2026-01-02T00:00:00Z"),
+    });
+
+    expect(result).toEqual({
+      success: true,
+      externalCampaignId: "12345/77/888",
+    });
+
+    const groupSearch = nextRequest(0);
+    expect(groupSearch.url.pathname).toBe("/rest/adAccounts/12345/adCampaignGroups");
+    expect(groupSearch.url.searchParams.get("search")).toBe(
+      "(status:(values:List(ACTIVE,DRAFT,PAUSED)))",
+    );
+
+    const create = nextRequest(1);
+    expect(create.url.pathname).toBe("/rest/adAccounts/12345/adCampaigns");
+    expect(create.body).toMatchObject({
+      account: "urn:li:sponsoredAccount:12345",
+      campaignGroup: "urn:li:sponsoredCampaignGroup:77",
+      creativeSelection: "OPTIMIZED",
+      dailyBudget: { amount: "50.00", currencyCode: "USD" },
+      name: "Launch campaign",
+      objectiveType: "WEBSITE_VISITS",
+      status: "PAUSED",
+      type: "TEXT_AD",
+    });
+  });
+
+  test("creates a paused campaign group when none exists", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ elements: [] }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 201, restliId: "77" }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 201, restliId: "888" }));
+
+    await expect(
+      linkedinAdsProvider.createCampaign(credentials, "12345", {
+        organizationId: "org-1",
+        adAccountId: "ad-account-1",
+        name: "Launch campaign",
+        objective: "awareness",
+        budgetType: "lifetime",
+        budgetAmount: 500,
+      }),
+    ).resolves.toEqual({
+      success: true,
+      externalCampaignId: "12345/77/888",
+    });
+
+    const groupCreate = nextRequest(1);
+    expect(groupCreate.url.pathname).toBe("/rest/adAccounts/12345/adCampaignGroups");
+    expect(groupCreate.body).toMatchObject({
+      name: "elizaOS Campaigns",
+      status: "PAUSED",
+    });
+
+    const campaignCreate = nextRequest(2);
+    expect(campaignCreate.body).toMatchObject({
+      objectiveType: "BRAND_AWARENESS",
+      totalBudget: { amount: "500.00", currencyCode: "USD" },
+      status: "PAUSED",
+    });
+  });
+
+  test("patches lifecycle state through LinkedIn Rest.li partial updates", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(jsonResponse({}));
+
+    await expect(linkedinAdsProvider.pauseCampaign(credentials, "12345/77/888")).resolves.toEqual({
+      success: true,
+      externalCampaignId: "12345/77/888",
+    });
+    await linkedinAdsProvider.activateCampaign(credentials, "12345/77/888");
+    await linkedinAdsProvider.deleteCampaign(credentials, "12345/77/888");
+
+    expect(nextRequest(0).body).toEqual({ patch: { $set: { status: "PAUSED" } } });
+    expect(nextRequest(1).body).toEqual({ patch: { $set: { status: "ACTIVE" } } });
+    expect(nextRequest(2).body).toEqual({ patch: { $set: { status: "ARCHIVED" } } });
+  });
+
+  test("creates a text ad creative", async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({}, { status: 201, restliId: "999" }));
+
+    await expect(
+      linkedinAdsProvider.createCreative(credentials, "12345", "12345/77/888", {
+        campaignId: "campaign-row-1",
+        name: "Creative one",
+        type: "image",
+        headline: "Meet elizaOS",
+        primaryText: "Build autonomous agents.",
+        destinationUrl: "https://elizaos.ai",
+        media: [],
+      }),
+    ).resolves.toEqual({ success: true, externalCreativeId: "999" });
+
+    const request = nextRequest(0);
+    expect(request.url.pathname).toBe("/rest/adAccounts/12345/creatives");
+    expect(request.body).toEqual({
+      campaign: "urn:li:sponsoredCampaign:888",
+      name: "Creative one",
+      status: "PAUSED",
+      type: "TEXT_AD",
+      variables: {
+        clickUri: "https://elizaos.ai",
+        data: {
+          "com.linkedin.ads.TextAdCreativeVariables": {
+            title: "Meet elizaOS",
+            text: "Build autonomous agents.",
+          },
+        },
+      },
+    });
+  });
+
+  test("uploads image assets into the LinkedIn media library", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          value: {
+            uploadUrl: "https://www.linkedin.com/dms-uploads/image",
+            image: "urn:li:image:abc",
+            uploadUrlExpiresAt: 123,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 201 }));
+
+    await expect(
+      linkedinAdsProvider.uploadMedia?.(credentials, "12345", {
+        name: "asset",
+        type: "image",
+        url: "https://cdn.example.com/asset.png",
+        mimeType: "image/png",
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      providerAssetId: "urn:li:image:abc",
+      providerAssetResourceName: "urn:li:image:abc",
+    });
+
+    const initialize = nextRequest(0);
+    expect(initialize.url.pathname).toBe("/rest/images");
+    expect(initialize.url.searchParams.get("action")).toBe("initializeUpload");
+    expect(initialize.body).toEqual({
+      initializeUploadRequest: {
+        owner: "urn:li:sponsoredAccount:12345",
+        mediaLibraryMetadata: {
+          associatedAccount: "urn:li:sponsoredAccount:12345",
+          assetName: "asset.png",
+        },
+      },
+    });
+
+    const upload = fetchMock().mock.calls[1];
+    expect(upload[0]).toBe("https://www.linkedin.com/dms-uploads/image");
+    expect(upload[1]).toMatchObject({
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer linkedin-token",
+        "Content-Type": "image/png",
+      },
+    });
+  });
+
+  test("maps LinkedIn analytics rows into campaign metrics", async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({
+        elements: [
+          {
+            costInLocalCurrency: "12.50",
+            impressions: 100,
+            landingPageClicks: 7,
+            externalWebsiteConversions: 2,
+          },
+          {
+            costInLocalCurrency: "1.25",
+            impressions: 10,
+            landingPageClicks: 1,
+            externalWebsiteConversions: 0,
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      linkedinAdsProvider.getCampaignMetrics(credentials, "12345/77/888", {
+        start: new Date("2026-01-01T00:00:00Z"),
+        end: new Date("2026-01-31T00:00:00Z"),
+      }),
+    ).resolves.toEqual({
+      success: true,
+      metrics: {
+        spend: 13.75,
+        impressions: 110,
+        clicks: 8,
+        conversions: 2,
+      },
+    });
+
+    const request = nextRequest(0);
+    expect(request.url.pathname).toBe("/rest/adAnalytics");
+    expect(request.url.searchParams.get("campaigns")).toBe("List(urn:li:sponsoredCampaign:888)");
+    expect(request.url.searchParams.get("dateRange")).toBe(
+      "(start:(year:2026,month:1,day:1),end:(year:2026,month:1,day:31))",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -101,13 +101,76 @@ describe("linkedinAdsProvider", () => {
     expect(create.url.pathname).toBe("/rest/adAccounts/12345/adCampaigns");
     expect(create.body).toMatchObject({
       account: "urn:li:sponsoredAccount:12345",
+      audienceExpansionEnabled: false,
       campaignGroup: "urn:li:sponsoredCampaignGroup:77",
+      connectedTelevisionOnly: false,
+      costType: "CPC",
       creativeSelection: "OPTIMIZED",
       dailyBudget: { amount: "50.00", currencyCode: "USD" },
+      locale: { country: "US", language: "en" },
       name: "Launch campaign",
       objectiveType: "WEBSITE_VISITS",
+      offsiteDeliveryEnabled: false,
+      optimizationTargetType: "NONE",
+      politicalIntent: "NOT_DECLARED",
       status: "PAUSED",
+      targetingCriteria: {
+        include: {
+          and: [
+            {
+              or: {
+                "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278"],
+              },
+            },
+            {
+              or: {
+                "urn:li:adTargetingFacet:interfaceLocales": ["urn:li:locale:en_US"],
+              },
+            },
+          ],
+        },
+      },
       type: "TEXT_AD",
+    });
+  });
+
+  test("uses LinkedIn geo URNs and language targeting when supplied", async () => {
+    fetchMock()
+      .mockResolvedValueOnce(jsonResponse({ elements: [{ id: 77, status: "ACTIVE" }] }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 201, restliId: "888" }));
+
+    await linkedinAdsProvider.createCampaign(credentials, "12345", {
+      organizationId: "org-1",
+      adAccountId: "ad-account-1",
+      name: "Localized launch",
+      objective: "traffic",
+      budgetType: "daily",
+      budgetAmount: 50,
+      targeting: {
+        locations: ["urn:li:geo:101174742", "not-a-linkedin-urn"],
+        languages: ["fr_FR"],
+      },
+    });
+
+    const create = nextRequest(1);
+    expect(create.body).toMatchObject({
+      locale: { country: "FR", language: "fr" },
+      targetingCriteria: {
+        include: {
+          and: [
+            {
+              or: {
+                "urn:li:adTargetingFacet:locations": ["urn:li:geo:101174742"],
+              },
+            },
+            {
+              or: {
+                "urn:li:adTargetingFacet:interfaceLocales": ["urn:li:locale:fr_FR"],
+              },
+            },
+          ],
+        },
+      },
     });
   });
 
@@ -183,8 +246,8 @@ describe("linkedinAdsProvider", () => {
     expect(request.url.pathname).toBe("/rest/adAccounts/12345/creatives");
     expect(request.body).toEqual({
       campaign: "urn:li:sponsoredCampaign:888",
+      intendedStatus: "PAUSED",
       name: "Creative one",
-      status: "PAUSED",
       type: "TEXT_AD",
       variables: {
         clickUri: "https://elizaos.ai",

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -216,6 +216,15 @@ function buildLinkedInCampaignPayload(
   input: CreateCampaignInput,
 ): Record<string, unknown> {
   const currencyCode = input.budgetCurrency || "USD";
+  const locations =
+    input.targeting?.locations?.map((location) => location.trim()).filter(Boolean) ?? [];
+  const linkedInLocations = locations.filter((location) => location.startsWith("urn:li:geo:"));
+  const [rawLanguage = "en", rawCountry = "US"] = (
+    input.targeting?.languages?.[0] ?? "en_US"
+  ).split(/[-_]/);
+  const language = rawLanguage.toLowerCase();
+  const country = rawCountry.toUpperCase();
+  const locale = `${language}_${country}`;
   const budget = {
     amount: input.budgetAmount.toFixed(2),
     currencyCode,
@@ -223,15 +232,43 @@ function buildLinkedInCampaignPayload(
 
   return {
     account: sponsoredAccountUrn(accountId),
+    audienceExpansionEnabled: false,
     campaignGroup: campaignGroupUrn(campaignGroupId),
+    connectedTelevisionOnly: false,
+    costType: "CPC",
     creativeSelection: "OPTIMIZED",
+    locale: {
+      country,
+      language,
+    },
     name: input.name,
     objectiveType: mapObjectiveToLinkedIn(input.objective),
+    offsiteDeliveryEnabled: false,
+    optimizationTargetType: "NONE",
+    politicalIntent: "NOT_DECLARED",
     runSchedule: {
       start: (input.startDate ?? new Date()).getTime(),
       ...(input.endDate ? { end: input.endDate.getTime() } : {}),
     },
     status: "PAUSED",
+    targetingCriteria: {
+      include: {
+        and: [
+          {
+            or: {
+              "urn:li:adTargetingFacet:locations": linkedInLocations.length
+                ? linkedInLocations
+                : ["urn:li:geo:103644278"],
+            },
+          },
+          {
+            or: {
+              "urn:li:adTargetingFacet:interfaceLocales": [`urn:li:locale:${locale}`],
+            },
+          },
+        ],
+      },
+    },
     type: "TEXT_AD",
     ...(input.budgetType === "daily" ? { dailyBudget: budget } : { totalBudget: budget }),
     unitCost: { amount: "1.00", currencyCode },
@@ -432,8 +469,8 @@ export const linkedinAdsProvider: AdProvider = {
           method: "POST",
           body: JSON.stringify({
             campaign: campaignUrn(campaign.campaignId),
+            intendedStatus: "PAUSED",
             name: input.name,
-            status: "PAUSED",
             type: "TEXT_AD",
             variables: {
               clickUri: input.destinationUrl,

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -1,0 +1,621 @@
+// LinkedIn Marketing API integration - https://learn.microsoft.com/linkedin/marketing
+
+import { logger } from "../../../utils/logger";
+import { downloadAdMedia, mediaFileName } from "../media-utils";
+import type {
+  AdAccountCredentials,
+  AdProvider,
+  AdProviderCampaignResult,
+  AdProviderCreativeResult,
+  AdProviderMediaUploadResult,
+  AdProviderMetricsResult,
+  AdProviderValidationResult,
+  CampaignMetrics,
+  CreateCampaignInput,
+  CreateCreativeInput,
+  GetMediaStatusInput,
+  UpdateCampaignInput,
+  UploadMediaInput,
+} from "../types";
+
+const LINKEDIN_ADS_BASE_URL = "https://api.linkedin.com/rest";
+const LINKEDIN_VERSION = process.env.LINKEDIN_MARKETING_VERSION || "202606";
+
+interface LinkedInListResponse<T> {
+  elements?: T[];
+}
+
+interface LinkedInAdAccount {
+  id: number | string;
+  name?: string;
+  status?: string;
+}
+
+interface LinkedInCampaignGroup {
+  id?: number | string;
+  name?: string;
+  status?: string;
+}
+
+interface LinkedInAnalyticsRow {
+  costInLocalCurrency?: string;
+  impressions?: number;
+  landingPageClicks?: number;
+  externalWebsiteConversions?: number;
+}
+
+interface LinkedInImageInitializeResponse {
+  value?: {
+    uploadUrl?: string;
+    image?: string;
+    uploadUrlExpiresAt?: number;
+  };
+}
+
+interface LinkedInImageStatusResponse {
+  id?: string;
+  status?: string;
+  downloadUrl?: string;
+}
+
+interface LinkedInRequestResult<T> {
+  data: T;
+  restliId?: string;
+}
+
+async function linkedinRequest<T>(
+  endpoint: string,
+  accessToken: string,
+  options: RequestInit & { params?: Record<string, string> } = {},
+): Promise<LinkedInRequestResult<T>> {
+  const url = new URL(
+    endpoint.startsWith("http") ? endpoint : `${LINKEDIN_ADS_BASE_URL}${endpoint}`,
+  );
+  for (const [key, value] of Object.entries(options.params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString(), {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      "Linkedin-Version": LINKEDIN_VERSION,
+      "X-Restli-Protocol-Version": "2.0.0",
+      ...options.headers,
+    },
+  });
+
+  const text = await response.text();
+  const data = text ? (JSON.parse(text) as T) : ({} as T);
+
+  if (!response.ok) {
+    const errorData = data as Record<string, unknown>;
+    const message =
+      typeof errorData.message === "string"
+        ? errorData.message
+        : `LinkedIn Marketing API error: ${response.status}`;
+    throw new Error(message);
+  }
+
+  return {
+    data: data as T,
+    restliId: response.headers.get("x-restli-id") ?? undefined,
+  };
+}
+
+function mapObjectiveToLinkedIn(objective: string): string {
+  const mapping: Record<string, string> = {
+    awareness: "BRAND_AWARENESS",
+    traffic: "WEBSITE_VISITS",
+    engagement: "ENGAGEMENT",
+    leads: "LEAD_GENERATION",
+    app_promotion: "WEBSITE_VISITS",
+    sales: "WEBSITE_CONVERSIONS",
+    conversions: "WEBSITE_CONVERSIONS",
+  };
+  return mapping[objective] || "WEBSITE_VISITS";
+}
+
+function campaignUrn(campaignId: string): string {
+  return campaignId.startsWith("urn:li:sponsoredCampaign:")
+    ? campaignId
+    : `urn:li:sponsoredCampaign:${campaignId}`;
+}
+
+function campaignGroupUrn(groupId: string): string {
+  return groupId.startsWith("urn:li:sponsoredCampaignGroup:")
+    ? groupId
+    : `urn:li:sponsoredCampaignGroup:${groupId}`;
+}
+
+function sponsoredAccountUrn(accountId: string): string {
+  return accountId.startsWith("urn:li:sponsoredAccount:")
+    ? accountId
+    : `urn:li:sponsoredAccount:${accountId}`;
+}
+
+function splitLinkedInCampaignId(
+  fallbackAccountId: string,
+  externalCampaignId: string,
+): { accountId: string; campaignGroupId?: string; campaignId: string } {
+  const parts = externalCampaignId.split("/");
+  if (parts.length === 3 && parts[0] && parts[1] && parts[2]) {
+    return { accountId: parts[0], campaignGroupId: parts[1], campaignId: parts[2] };
+  }
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    return { accountId: parts[0], campaignId: parts[1] };
+  }
+  return { accountId: fallbackAccountId, campaignId: externalCampaignId };
+}
+
+function linkedInDate(date: Date): { year: number; month: number; day: number } {
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+function linkedInPatch(set: Record<string, unknown>): { patch: { $set: Record<string, unknown> } } {
+  return { patch: { $set: set } };
+}
+
+function firstLinkedInId(...values: Array<number | string | undefined>): string | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+    if (typeof value === "string" && value.trim()) {
+      return value.startsWith("urn:li:") ? value.split(":").pop() : value.trim();
+    }
+  }
+  return undefined;
+}
+
+async function getOrCreateCampaignGroup(
+  credentials: AdAccountCredentials,
+  accountId: string,
+): Promise<string> {
+  const existing = await linkedinRequest<LinkedInListResponse<LinkedInCampaignGroup>>(
+    `/adAccounts/${accountId}/adCampaignGroups`,
+    credentials.accessToken,
+    {
+      method: "GET",
+      params: {
+        q: "search",
+        search: "(status:(values:List(ACTIVE,DRAFT,PAUSED)))",
+        pageSize: "1",
+      },
+    },
+  );
+  const existingId = firstLinkedInId(existing.data.elements?.[0]?.id);
+  if (existingId) return existingId;
+
+  const created = await linkedinRequest<Record<string, unknown>>(
+    `/adAccounts/${accountId}/adCampaignGroups`,
+    credentials.accessToken,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        name: "elizaOS Campaigns",
+        runSchedule: { start: Date.now() },
+        status: "PAUSED",
+      }),
+    },
+  );
+
+  const createdId = firstLinkedInId(created.restliId, created.data.id as string | undefined);
+  if (!createdId) {
+    throw new Error("LinkedIn campaign group creation returned no campaign group id");
+  }
+  return createdId;
+}
+
+function buildLinkedInCampaignPayload(
+  accountId: string,
+  campaignGroupId: string,
+  input: CreateCampaignInput,
+): Record<string, unknown> {
+  const currencyCode = input.budgetCurrency || "USD";
+  const budget = {
+    amount: input.budgetAmount.toFixed(2),
+    currencyCode,
+  };
+
+  return {
+    account: sponsoredAccountUrn(accountId),
+    campaignGroup: campaignGroupUrn(campaignGroupId),
+    creativeSelection: "OPTIMIZED",
+    name: input.name,
+    objectiveType: mapObjectiveToLinkedIn(input.objective),
+    runSchedule: {
+      start: (input.startDate ?? new Date()).getTime(),
+      ...(input.endDate ? { end: input.endDate.getTime() } : {}),
+    },
+    status: "PAUSED",
+    type: "TEXT_AD",
+    ...(input.budgetType === "daily" ? { dailyBudget: budget } : { totalBudget: budget }),
+    unitCost: { amount: "1.00", currencyCode },
+  };
+}
+
+export const linkedinAdsProvider: AdProvider = {
+  platform: "linkedin",
+
+  async validateCredentials(
+    credentials: AdAccountCredentials,
+  ): Promise<AdProviderValidationResult> {
+    const accounts = await this.listAdAccounts(credentials).catch((error) => {
+      logger.error("[LinkedInAds] Validation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    });
+
+    const account = accounts[0];
+    if (!account) {
+      return {
+        valid: false,
+        error: "No LinkedIn ad accounts found or invalid credentials",
+      };
+    }
+
+    return {
+      valid: true,
+      accountId: account.id,
+      accountName: account.name,
+    };
+  },
+
+  async listAdAccounts(
+    credentials: AdAccountCredentials,
+  ): Promise<Array<{ id: string; name: string }>> {
+    const response = await linkedinRequest<LinkedInListResponse<LinkedInAdAccount>>(
+      "/adAccounts",
+      credentials.accessToken,
+      {
+        method: "GET",
+        params: { q: "search", pageSize: "1000" },
+      },
+    );
+
+    return (response.data.elements ?? []).map((account) => {
+      const id = String(account.id);
+      return {
+        id,
+        name: account.name || `LinkedIn Ad Account ${id}`,
+      };
+    });
+  },
+
+  async createCampaign(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    input: CreateCampaignInput,
+  ): Promise<AdProviderCampaignResult> {
+    try {
+      logger.info("[LinkedInAds] Creating campaign", {
+        accountId,
+        name: input.name,
+        objective: input.objective,
+      });
+
+      const campaignGroupId = await getOrCreateCampaignGroup(credentials, accountId);
+      const response = await linkedinRequest<Record<string, unknown>>(
+        `/adAccounts/${accountId}/adCampaigns`,
+        credentials.accessToken,
+        {
+          method: "POST",
+          body: JSON.stringify(buildLinkedInCampaignPayload(accountId, campaignGroupId, input)),
+        },
+      );
+
+      const campaignId = firstLinkedInId(response.restliId, response.data.id as string | undefined);
+      if (!campaignId) {
+        return { success: false, error: "LinkedIn campaign creation returned no campaign id" };
+      }
+
+      logger.info("[LinkedInAds] Campaign created", {
+        accountId,
+        campaignGroupId,
+        campaignId,
+      });
+
+      return {
+        success: true,
+        externalCampaignId: `${accountId}/${campaignGroupId}/${campaignId}`,
+      };
+    } catch (error) {
+      logger.error("[LinkedInAds] Campaign creation failed", {
+        accountId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "LinkedIn campaign creation failed",
+      };
+    }
+  },
+
+  async updateCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+    input: UpdateCampaignInput,
+  ): Promise<AdProviderCampaignResult> {
+    const { accountId, campaignId } = splitLinkedInCampaignId("", externalCampaignId);
+    const updateFields: Record<string, unknown> = {};
+    if (input.name) updateFields.name = input.name;
+    if (input.budgetAmount) {
+      updateFields.dailyBudget = {
+        amount: input.budgetAmount.toFixed(2),
+        currencyCode: "USD",
+      };
+    }
+    if (input.startDate || input.endDate) {
+      updateFields.runSchedule = {
+        ...(input.startDate ? { start: input.startDate.getTime() } : {}),
+        ...(input.endDate ? { end: input.endDate.getTime() } : {}),
+      };
+    }
+
+    await linkedinRequest(
+      `/adAccounts/${accountId}/adCampaigns/${campaignId}`,
+      credentials.accessToken,
+      {
+        method: "POST",
+        body: JSON.stringify(linkedInPatch(updateFields)),
+      },
+    );
+
+    return { success: true, externalCampaignId };
+  },
+
+  async pauseCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<AdProviderCampaignResult> {
+    const { accountId, campaignId } = splitLinkedInCampaignId("", externalCampaignId);
+    await linkedinRequest(
+      `/adAccounts/${accountId}/adCampaigns/${campaignId}`,
+      credentials.accessToken,
+      {
+        method: "POST",
+        body: JSON.stringify(linkedInPatch({ status: "PAUSED" })),
+      },
+    );
+    return { success: true, externalCampaignId };
+  },
+
+  async activateCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<AdProviderCampaignResult> {
+    const { accountId, campaignId } = splitLinkedInCampaignId("", externalCampaignId);
+    await linkedinRequest(
+      `/adAccounts/${accountId}/adCampaigns/${campaignId}`,
+      credentials.accessToken,
+      {
+        method: "POST",
+        body: JSON.stringify(linkedInPatch({ status: "ACTIVE" })),
+      },
+    );
+    return { success: true, externalCampaignId };
+  },
+
+  async deleteCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const { accountId, campaignId } = splitLinkedInCampaignId("", externalCampaignId);
+    await linkedinRequest(
+      `/adAccounts/${accountId}/adCampaigns/${campaignId}`,
+      credentials.accessToken,
+      {
+        method: "POST",
+        body: JSON.stringify(linkedInPatch({ status: "ARCHIVED" })),
+      },
+    );
+    return { success: true };
+  },
+
+  async createCreative(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    externalCampaignId: string,
+    input: CreateCreativeInput,
+  ): Promise<AdProviderCreativeResult> {
+    try {
+      const campaign = splitLinkedInCampaignId(accountId, externalCampaignId);
+      const response = await linkedinRequest<Record<string, unknown>>(
+        `/adAccounts/${campaign.accountId}/creatives`,
+        credentials.accessToken,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            campaign: campaignUrn(campaign.campaignId),
+            name: input.name,
+            status: "PAUSED",
+            type: "TEXT_AD",
+            variables: {
+              clickUri: input.destinationUrl,
+              data: {
+                "com.linkedin.ads.TextAdCreativeVariables": {
+                  title: input.headline || input.name,
+                  text: input.primaryText || input.description || input.name,
+                },
+              },
+            },
+          }),
+        },
+      );
+
+      const creativeId = firstLinkedInId(response.restliId, response.data.id as string | undefined);
+      if (!creativeId) {
+        return { success: false, error: "LinkedIn creative creation returned no creative id" };
+      }
+
+      return { success: true, externalCreativeId: creativeId };
+    } catch (error) {
+      logger.error("[LinkedInAds] Creative creation failed", {
+        accountId,
+        externalCampaignId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "LinkedIn creative creation failed",
+      };
+    }
+  },
+
+  async uploadMedia(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    input: UploadMediaInput,
+  ): Promise<AdProviderMediaUploadResult> {
+    if (input.type !== "image") {
+      return { success: false, error: "LinkedIn media upload currently supports image assets" };
+    }
+
+    try {
+      const fileName = mediaFileName({
+        name: input.name,
+        url: input.url,
+        contentType: input.mimeType,
+        fallbackExtension: "png",
+      });
+      const media = await downloadAdMedia(input.url, {
+        allowedContentTypes: ["image/jpeg", "image/png", "image/gif"],
+        fileName,
+      });
+
+      const initialize = await linkedinRequest<LinkedInImageInitializeResponse>(
+        "/images",
+        credentials.accessToken,
+        {
+          method: "POST",
+          params: { action: "initializeUpload" },
+          body: JSON.stringify({
+            initializeUploadRequest: {
+              owner: sponsoredAccountUrn(accountId),
+              mediaLibraryMetadata: {
+                associatedAccount: sponsoredAccountUrn(accountId),
+                assetName: fileName,
+              },
+            },
+          }),
+        },
+      );
+
+      const uploadUrl = initialize.data.value?.uploadUrl;
+      const imageUrn = initialize.data.value?.image;
+      if (!uploadUrl || !imageUrn) {
+        return {
+          success: false,
+          error: "LinkedIn image upload initialization returned no upload URL",
+        };
+      }
+
+      const uploadBody = new ArrayBuffer(media.bytes.byteLength);
+      new Uint8Array(uploadBody).set(media.bytes);
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${credentials.accessToken}`,
+          "Content-Type": media.contentType,
+        },
+        body: uploadBody,
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error(`LinkedIn image binary upload failed: ${uploadResponse.status}`);
+      }
+
+      return {
+        success: true,
+        providerAssetId: imageUrn,
+        providerAssetResourceName: imageUrn,
+        providerAssetUrl: media.url,
+        metadata: {
+          fileName,
+          uploadUrlExpiresAt: initialize.data.value?.uploadUrlExpiresAt,
+        },
+      };
+    } catch (error) {
+      logger.error("[LinkedInAds] Media upload failed", {
+        accountId,
+        type: input.type,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "LinkedIn media upload failed",
+      };
+    }
+  },
+
+  async getMediaStatus(
+    credentials: AdAccountCredentials,
+    _accountId: string,
+    input: GetMediaStatusInput,
+  ) {
+    const response = await linkedinRequest<LinkedInImageStatusResponse>(
+      `/images/${encodeURIComponent(input.providerAssetResourceName)}`,
+      credentials.accessToken,
+      { method: "GET" },
+    );
+    return {
+      success: true,
+      providerAssetId: response.data.id ?? input.providerAssetResourceName,
+      providerAssetUrl: response.data.downloadUrl,
+      providerAssetResourceName: response.data.id ?? input.providerAssetResourceName,
+      status: response.data.status,
+      ready: response.data.status === "AVAILABLE",
+    };
+  },
+
+  async getCampaignMetrics(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+    dateRange?: { start: Date; end: Date },
+  ): Promise<AdProviderMetricsResult> {
+    const { campaignId } = splitLinkedInCampaignId("", externalCampaignId);
+    const start = dateRange?.start ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const end = dateRange?.end;
+    const response = await linkedinRequest<LinkedInListResponse<LinkedInAnalyticsRow>>(
+      "/adAnalytics",
+      credentials.accessToken,
+      {
+        method: "GET",
+        params: {
+          q: "analytics",
+          pivot: "CAMPAIGN",
+          timeGranularity: "ALL",
+          campaigns: `List(${campaignUrn(campaignId)})`,
+          dateRange: `(start:(${Object.entries(linkedInDate(start))
+            .map(([key, value]) => `${key}:${value}`)
+            .join(",")})${
+            end
+              ? `,end:(${Object.entries(linkedInDate(end))
+                  .map(([key, value]) => `${key}:${value}`)
+                  .join(",")})`
+              : ""
+          })`,
+          fields:
+            "externalWebsiteConversions,dateRange,impressions,landingPageClicks,costInLocalCurrency,pivotValues",
+        },
+      },
+    );
+
+    const totals = (response.data.elements ?? []).reduce<CampaignMetrics>(
+      (acc, row) => ({
+        spend: acc.spend + Number.parseFloat(row.costInLocalCurrency ?? "0"),
+        impressions: acc.impressions + (row.impressions ?? 0),
+        clicks: acc.clicks + (row.landingPageClicks ?? 0),
+        conversions: acc.conversions + (row.externalWebsiteConversions ?? 0),
+      }),
+      { spend: 0, impressions: 0, clicks: 0, conversions: 0 },
+    );
+
+    return { success: true, metrics: totals };
+  },
+};

--- a/packages/cloud/shared/src/lib/services/advertising/schemas.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const AdPlatformSchema = z.enum(["meta", "google", "tiktok"]);
+export const AdPlatformSchema = z.enum(["meta", "google", "tiktok", "linkedin"]);
 
 export const CampaignObjectiveSchema = z.enum([
   "awareness",

--- a/packages/cloud/shared/src/lib/services/advertising/types.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/types.ts
@@ -440,6 +440,7 @@ export const AD_CREDIT_RATES = {
     meta: 1.1,
     google: 1.1,
     tiktok: 1.1,
+    linkedin: 1.1,
   },
 
   // Analytics/reports


### PR DESCRIPTION
## Summary
- add LinkedIn as a supported Cloud advertising platform
- implement account discovery, paused campaign creation, lifecycle patches, text creative creation, image media-library upload, and analytics mapping
- add mocked provider coverage plus a gated live test lane for real LinkedIn credentials

## Evidence
- Evidence file: `.github/issue-evidence/11663-linkedin-ads-provider.md`
- Official API references used:
  - https://learn.microsoft.com/en-us/linkedin/marketing/?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-06
  - https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api?view=li-lms-2026-06

## Tests
- `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `bunx biome check packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts packages/cloud/shared/src/lib/services/advertising/index.ts packages/cloud/shared/src/lib/services/advertising/types.ts packages/cloud/shared/src/lib/services/advertising/schemas.ts packages/cloud/shared/src/db/schemas/ad-accounts.ts 'packages/cloud/api/v1/apps/[id]/promote/route.ts'`\n- `git diff --check`\n\nCloses #11663