### PR TITLE
fix(cloud): harden cloud files API edge cases

### DIFF
--- a/.github/issue-evidence/11743-cloud-files-crud.md
+++ b/.github/issue-evidence/11743-cloud-files-crud.md
@@ -6,6 +6,10 @@
 - Added additive `cloud_files` schema, migration, repository, and service.
 - Uploads write bytes to the existing Worker `BLOB` R2 binding under `cloud-files/<org>/<date>/<file-id>-<sha>.ext`, then persist metadata in `cloud_files`.
 - Delete is scoped by organization, soft-deletes the DB row, and deletes the R2 object only after no active record references the storage key.
+- Upload cleanup is covered: if R2 upload succeeds but DB metadata creation
+  fails, the service deletes the just-written object before rethrowing.
+- `/api/v1/files/:id` validates UUID shape before calling the service so
+  malformed IDs return a client validation error instead of leaking to the DB.
 - The local agent `/api/files` and content-addressed media store contract were not changed.
 
 ## Artifact review
@@ -23,7 +27,7 @@
 - `bunx @biomejs/biome check --write packages/cloud/api/v1/files packages/cloud/api/__tests__/cloud-files-route.test.ts packages/cloud/shared/src/db/schemas/cloud-files.ts packages/cloud/shared/src/db/repositories/cloud-files.ts packages/cloud/shared/src/lib/services/cloud-files.ts packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/shared/src/db/schemas/index.ts packages/cloud/shared/src/db/repositories/index.ts`
 - `bun run --cwd packages/cloud/shared typecheck`
 - `bun run --cwd packages/cloud/api typecheck`
-- `bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/api/__tests__/cloud-files-route.test.ts` - 9 pass / 0 fail
+- `bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/api/__tests__/cloud-files-route.test.ts` - 11 pass / 0 fail
 - `bun run --cwd packages/cloud/shared lint`
 - `bun run --cwd packages/cloud/api lint`
 - `git diff --check`

--- a/packages/cloud/api/__tests__/cloud-files-route.test.ts
+++ b/packages/cloud/api/__tests__/cloud-files-route.test.ts
@@ -7,6 +7,7 @@ import * as cloudFilesActual from "@/lib/services/cloud-files";
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const OTHER_ORG = "00000000-0000-4000-8000-0000000000cc";
 const USER = "00000000-0000-4000-8000-0000000000bb";
+const FILE_ID = "00000000-0000-4000-8000-0000000000dd";
 
 const requireUserOrApiKeyWithOrg = mock();
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -50,7 +51,7 @@ afterAll(() => {
 
 function fileRecord(overrides: Record<string, unknown> = {}) {
   return {
-    id: "file-1",
+    id: FILE_ID,
     organization_id: ORG,
     user_id: USER,
     api_key_id: null,
@@ -138,7 +139,7 @@ describe("/api/v1/files", () => {
       nextOffset: 6,
     });
     expect(body.files[0]).toMatchObject({
-      id: "file-1",
+      id: FILE_ID,
       filename: "hero.png",
       sizeBytes: 5,
       metadata: { folder: "campaigns" },
@@ -192,16 +193,20 @@ describe("/api/v1/files", () => {
 describe("/api/v1/files/:id", () => {
   test("gets a file only through the caller organization scope", async () => {
     get.mockImplementation(async (organizationId: string, id: string) => {
-      if (organizationId !== ORG || id !== "file-1") return undefined;
+      if (organizationId !== ORG || id !== FILE_ID) return undefined;
       return fileRecord();
     });
 
-    const res = await fileRouteWithParam.request("/file-1", {}, env() as never);
+    const res = await fileRouteWithParam.request(
+      `/${FILE_ID}`,
+      {},
+      env() as never,
+    );
 
     expect(res.status).toBe(200);
-    expect(get).toHaveBeenCalledWith(ORG, "file-1");
+    expect(get).toHaveBeenCalledWith(ORG, FILE_ID);
     const body = (await res.json()) as { file: { id: string } };
-    expect(body.file.id).toBe("file-1");
+    expect(body.file.id).toBe(FILE_ID);
   });
 
   test("returns 404 when a file belongs to another organization", async () => {
@@ -212,28 +217,43 @@ describe("/api/v1/files/:id", () => {
     });
     get.mockResolvedValue(undefined);
 
-    const res = await fileRouteWithParam.request("/file-1", {}, env() as never);
+    const res = await fileRouteWithParam.request(
+      `/${FILE_ID}`,
+      {},
+      env() as never,
+    );
 
     expect(res.status).toBe(404);
-    expect(get).toHaveBeenCalledWith(OTHER_ORG, "file-1");
+    expect(get).toHaveBeenCalledWith(OTHER_ORG, FILE_ID);
   });
 
   test("deletes through organization scope", async () => {
     deleteFile.mockResolvedValue(fileRecord());
 
     const res = await fileRouteWithParam.request(
-      "/file-1",
+      `/${FILE_ID}`,
       { method: "DELETE" },
       env() as never,
     );
 
     expect(res.status).toBe(200);
-    expect(deleteFile).toHaveBeenCalledWith(expect.any(Object), ORG, "file-1");
+    expect(deleteFile).toHaveBeenCalledWith(expect.any(Object), ORG, FILE_ID);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({
       success: true,
       deleted: true,
-      id: "file-1",
+      id: FILE_ID,
     });
+  });
+
+  test("rejects malformed file ids before service access", async () => {
+    const res = await fileRouteWithParam.request(
+      "/not-a-uuid",
+      {},
+      env() as never,
+    );
+
+    expect(res.status).toBe(400);
+    expect(get).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/files/[id]/route.ts
+++ b/packages/cloud/api/v1/files/[id]/route.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { z } from "zod";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -11,6 +12,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
+
+const fileIdSchema = z.string().uuid();
 
 function toClientFile(
   file: NonNullable<Awaited<ReturnType<typeof cloudFilesService.get>>>,
@@ -34,10 +37,8 @@ function toClientFile(
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const file = await cloudFilesService.get(
-      user.organization_id,
-      c.req.param("id")!,
-    );
+    const fileId = fileIdSchema.parse(c.req.param("id"));
+    const file = await cloudFilesService.get(user.organization_id, fileId);
     if (!file) return jsonError(c, 404, "File not found", "resource_not_found");
     return c.json({ success: true, file: toClientFile(file) });
   } catch (error) {
@@ -48,10 +49,11 @@ app.get("/", async (c) => {
 app.delete("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    const fileId = fileIdSchema.parse(c.req.param("id"));
     const deleted = await cloudFilesService.delete(
       c.env,
       user.organization_id,
-      c.req.param("id")!,
+      fileId,
     );
     if (!deleted)
       return jsonError(c, 404, "File not found", "resource_not_found");

--- a/packages/cloud/shared/src/lib/services/cloud-files.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-files.test.ts
@@ -78,6 +78,27 @@ describe("CloudFilesService", () => {
     expect(result.metadata).toEqual({ folder: "campaigns" });
   });
 
+  test("removes uploaded bytes if metadata creation fails", async () => {
+    const repository = makeRepository();
+    repository.create.mockRejectedValueOnce(new Error("insert failed"));
+    const env = makeEnv();
+    const service = new CloudFilesService(repository as never);
+
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    await expect(
+      service.upload(env as never, {
+        organizationId: ORG,
+        userId: USER,
+        file,
+      }),
+    ).rejects.toThrow("insert failed");
+
+    const putKey = env.BLOB.put.mock.calls[0]?.[0];
+    expect(putKey).toBeTruthy();
+    expect(env.BLOB.delete).toHaveBeenCalledWith(putKey);
+    expect(env.objects.size).toBe(0);
+  });
+
   test("soft delete removes the object after the last active reference", async () => {
     const repository = makeRepository();
     const env = makeEnv();

--- a/packages/cloud/shared/src/lib/services/cloud-files.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-files.ts
@@ -102,21 +102,31 @@ export class CloudFilesService {
       },
     });
 
-    return await this.repository.create({
-      id: objectId,
-      organization_id: input.organizationId,
-      user_id: input.userId ?? null,
-      api_key_id: input.apiKeyId ?? null,
-      source: "upload",
-      kind: kindFromMime(mimeType),
-      filename,
-      mime_type: mimeType,
-      size_bytes: BigInt(bytes.byteLength),
-      sha256,
-      storage_key: key,
-      storage_url: publicUrlForR2Key(env, key),
-      metadata: input.metadata ?? {},
-    });
+    try {
+      return await this.repository.create({
+        id: objectId,
+        organization_id: input.organizationId,
+        user_id: input.userId ?? null,
+        api_key_id: input.apiKeyId ?? null,
+        source: "upload",
+        kind: kindFromMime(mimeType),
+        filename,
+        mime_type: mimeType,
+        size_bytes: BigInt(bytes.byteLength),
+        sha256,
+        storage_key: key,
+        storage_url: publicUrlForR2Key(env, key),
+        metadata: input.metadata ?? {},
+      });
+    } catch (error) {
+      await env.BLOB.delete(key).catch((deleteError) => {
+        logger.warn("[CloudFiles] Failed to clean up object after metadata insert failure", {
+          storageKey: key,
+          error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+        });
+      });
+      throw error;
+    }
   }
 
   async recordGenerated(input: RecordGeneratedCloudFileInput): Promise<CloudFile> {


### PR DESCRIPTION
## Summary
- follow-up to #11758 / #11743 for cloud files edge cases
- validate file route IDs as UUIDs before service access
- delete uploaded R2 bytes when metadata creation fails to avoid orphaned objects
- extend focused route/service coverage and update issue evidence notes

## Validation
- `bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/api/__tests__/cloud-files-route.test.ts` (11 pass)
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `bunx @biomejs/biome check packages/cloud/api/v1/files packages/cloud/api/__tests__/cloud-files-route.test.ts packages/cloud/shared/src/db/schemas/cloud-files.ts packages/cloud/shared/src/db/repositories/cloud-files.ts packages/cloud/shared/src/lib/services/cloud-files.ts packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/shared/src/db/schemas/index.ts packages/cloud/shared/src/db/repositories/index.ts .github/issue-evidence/11743-cloud-files-crud.md`
- `git diff --check origin/develop..HEAD`

## Evidence
- N/A UI: backend API/storage hardening only.
- N/A live LLM: no agent/model path changed.
- Missing live cloud artifact: no live Cloudflare R2 + production-equivalent database credentials are available in this workspace, so the PR remains draft until a real upload/delete/metadata artifact can be captured.