### PR TITLE
fix(cloud): serve cloud file blob URLs

### DIFF
--- a/packages/cloud/api/src/blob-host.test.ts
+++ b/packages/cloud/api/src/blob-host.test.ts
@@ -73,6 +73,26 @@ describe("serveBlobHostRequest", () => {
     expect(await res?.text()).toBe("PNGBYTES");
   });
 
+  test("serves cloud file upload URLs while forcing active types to download", async () => {
+    const key = "cloud-files/org-1/2026-07-03/file-1-abc123.svg";
+    const { env } = makeEnv({
+      [key]: {
+        body: "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>",
+        contentType: "image/svg+xml",
+      },
+    });
+    const [request, url] = req(`https://blob.elizacloud.ai/${key}`);
+
+    const res = await serveBlobHostRequest(request, url, env);
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("content-type")).toBe("image/svg+xml");
+    expect(res?.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res?.headers.get("content-disposition")).toBe("attachment");
+    expect(res?.headers.get("content-security-policy")).toContain("sandbox");
+    expect(await res?.text()).toContain("<svg");
+  });
+
   test("respects R2_PUBLIC_HOST for the per-env host (staging)", async () => {
     const { env } = makeEnv(
       { "avatars/eliza.png": { body: "AVATAR" } },

--- a/packages/cloud/api/src/blob-host.ts
+++ b/packages/cloud/api/src/blob-host.ts
@@ -45,6 +45,9 @@ export const PUBLIC_BLOB_PREFIXES: readonly string[] = [
   // App promotion imagery (social cards/banners/screenshots) —
   // app-promotion-assets service; fetched by URL for moderation + posting.
   "promotion-assets/",
+  // Org-scoped cloud file uploads — cloud-files service mints unguessable
+  // public-by-URL handles after auth-gated upload/list/get.
+  "cloud-files/",
   // Affiliate character avatar/reference images — affiliate-images service;
   // URLs become character avatar/reference URLs.
   "affiliate/",


### PR DESCRIPTION
## Summary
- Add the new `cloud-files/` R2 keyspace to the blob-host public-by-URL allowlist.
- Add a regression test proving a cloud file upload URL resolves through `blob.elizacloud.ai`.
- Use an SVG fixture in the regression so active uploads still prove `nosniff`, sandbox CSP, and `Content-Disposition: attachment`.

## Why
#11758 added org-scoped `/api/v1/files` uploads that store objects under `cloud-files/<org>/<date>/...` and return `publicUrlForR2Key(...)`. The blob host only serves allowlisted public prefixes, so those newly returned URLs would 404 until `cloud-files/` is allowed.

## Validation
- `bun --config=.codex-no-coverage-bunfig.toml test packages/cloud/api/src/blob-host.test.ts packages/cloud/shared/src/lib/services/cloud-files.test.ts packages/cloud/api/__tests__/cloud-files-route.test.ts` - 23 pass / 0 fail, 127 assertions
- `bunx @biomejs/biome@2.5.2 check packages/cloud/api/src/blob-host.ts packages/cloud/api/src/blob-host.test.ts` - pass
- `git diff --check origin/develop...HEAD` - pass

## Notes
- `bun run --cwd packages/cloud/api typecheck` was attempted in the sparse Windows review checkout, but remains blocked by unrelated missing optional/cloud deps (`stripe`, `nanoid`, `@fal-ai/server-proxy`, Solana/KMS/MCP packages, etc.). The changed files are covered by the focused Bun test run above.

Follow-up to #11758 / #11743.