### PR TITLE
feat(cloud): add audio provider registry

### DIFF
--- a/.github/issue-evidence/11741-audio-provider-registry.md
+++ b/.github/issue-evidence/11741-audio-provider-registry.md
@@ -1,0 +1,38 @@
+# Issue #11741 - Audio Provider Registry
+
+## Summary
+
+Implemented a shared audio provider registry for cloud content generation and refactored `/api/v1/generate-music` to route through it while preserving existing Fal, ElevenLabs, and Suno behavior.
+
+## Provider Docs Reviewed
+
+- Fal Stable Audio: https://fal.ai/models/fal-ai/stable-audio
+- Fal MMAudio V2 text-to-audio: https://fal.ai/models/fal-ai/mmaudio-v2/text-to-audio
+- ElevenLabs sound effects: https://elevenlabs.io/docs/api-reference/text-to-sound-effects/convert
+- ElevenLabs sound effects overview: https://elevenlabs.io/docs/overview/capabilities/sound-effects
+
+## Explicit Deferrals
+
+- `fal-ai/stable-audio`: deferred until a supported catalog/pricing row is wired.
+- `fal-ai/mmaudio-v2`: deferred until route inputs and pricing distinguish SFX/video-audio use.
+- `elevenlabs/sound-effects`: deferred until a distinct catalog row and request shape are added.
+
+## Validation
+
+- `bun run install:light` - pass
+- `bun run --cwd packages/core build` - pass
+- `bunx @biomejs/biome check --write packages/cloud/shared/src/lib/providers/audio packages/cloud/api/v1/generate-music/route.ts packages/cloud/api/__tests__/generate-music-audio-registry.test.ts packages/cloud/shared/package.json` - pass
+- `bun test packages/cloud/shared/src/lib/providers/audio/audio-generation.test.ts` - pass, 3 tests
+- `bun test packages/cloud/api/__tests__/generate-music-audio-registry.test.ts` - pass, 4 tests
+- `bun run --cwd packages/cloud/shared typecheck` - pass
+- `bun run --cwd packages/cloud/api typecheck` - pass
+- `bun run --cwd packages/cloud/shared lint` - pass
+- `bun run --cwd packages/cloud/api lint` - pass
+- `git diff --check` - pass
+
+## Artifact Review
+
+- Mocked provider route tests cover success, unsupported model validation before credits/provider, provider failure refund, and post-settle persistence failure without refund.
+- Live generated audio: N/A - tracked separately by issue #11745.
+- Real LLM trajectories: N/A - route/provider plumbing change, no agent prompt/model trajectory changed.
+- UI screenshots/video/frontend logs: N/A - no UI surface changed.

--- a/packages/cloud/api/__tests__/generate-music-audio-registry.test.ts
+++ b/packages/cloud/api/__tests__/generate-music-audio-registry.test.ts
@@ -1,0 +1,251 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { registerAudioProvider } from "@/lib/providers/audio/registry";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
+import * as aiPricingDefsActual from "@/lib/services/ai-pricing-definitions";
+import * as contentSafetyActual from "@/lib/services/content-safety";
+import * as creditsActual from "@/lib/services/credits";
+import * as generationsActual from "@/lib/services/generations";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const MODEL = "fal-ai/minimax-music/v2.6";
+const COST = 0.25;
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitActual,
+  RateLimitPresets: { STRICT: { limit: 1, windowSeconds: 1 } },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  ...contentSafetyActual,
+  contentSafetyService: {
+    ...contentSafetyActual.contentSafetyService,
+    assertSafeForPublicUse: async () => undefined,
+  },
+}));
+
+const calculateMusicGenerationCostFromCatalog = mock(async () => ({
+  totalCost: COST,
+}));
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateMusicGenerationCostFromCatalog,
+}));
+
+const getSupportedMusicModelDefinition = mock(
+  (): ReturnType<
+    typeof aiPricingDefsActual.getSupportedMusicModelDefinition
+  > => ({
+    modelId: MODEL,
+    label: "MiniMax Music",
+    provider: "fal",
+    billingSource: "fal",
+    pageUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6",
+    defaultParameters: { durationSeconds: 60 },
+  }),
+);
+mock.module("@/lib/services/ai-pricing-definitions", () => ({
+  ...aiPricingDefsActual,
+  getSupportedMusicModelDefinition,
+  SUPPORTED_MUSIC_MODEL_IDS: [MODEL],
+}));
+
+const reserve = mock();
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: { ...creditsActual.creditsService, reserve },
+}));
+
+const generationsCreate = mock();
+mock.module("@/lib/services/generations", () => ({
+  ...generationsActual,
+  generationsService: {
+    ...generationsActual.generationsService,
+    create: generationsCreate,
+  },
+}));
+
+const providerGenerate = mock();
+registerAudioProvider({ billingSource: "fal", generate: providerGenerate });
+
+const musicRoute = (await import("../v1/generate-music/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module(
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    () => rateLimitActual,
+  );
+  mock.module("@/lib/services/content-safety", () => contentSafetyActual);
+  mock.module("@/lib/services/ai-pricing", () => aiPricingActual);
+  mock.module(
+    "@/lib/services/ai-pricing-definitions",
+    () => aiPricingDefsActual,
+  );
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module("@/lib/services/generations", () => generationsActual);
+});
+
+type AppCtx = { set: (k: string, v: unknown) => void };
+
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold;
+  let reconcileCalls = 0;
+  let lastActual = Number.NaN;
+  return {
+    startBalance,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get lastActual() {
+      return lastActual;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        lastActual = actualCost;
+        balance += hold - actualCost;
+      },
+    },
+  };
+}
+
+function post(body: Record<string, unknown> = {}) {
+  return musicRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: MODEL, prompt: "ambient intro", ...body }),
+    },
+    { FAL_KEY: "fal-test-key" } as never,
+  );
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  calculateMusicGenerationCostFromCatalog.mockClear();
+  getSupportedMusicModelDefinition.mockReset();
+  reserve.mockReset();
+  generationsCreate.mockReset();
+  providerGenerate.mockReset();
+
+  getSupportedMusicModelDefinition.mockReturnValue({
+    modelId: MODEL,
+    label: "MiniMax Music",
+    provider: "fal",
+    billingSource: "fal",
+    pageUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6",
+    defaultParameters: { durationSeconds: 60 },
+  });
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", "key-1");
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+});
+
+describe("generate-music audio registry", () => {
+  test("success uses registered provider and persists normalized audio", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    providerGenerate.mockResolvedValue({
+      requestId: "audio-req",
+      status: "completed",
+      audio: {
+        url: "https://cdn.test/out.mp3",
+        file_size: 1234,
+        content_type: "audio/mpeg",
+      },
+      raw: { provider: "fal" },
+    });
+    generationsCreate.mockResolvedValue({ id: "gen-1" });
+
+    const res = await post({ durationSeconds: 30 });
+
+    expect(res.status).toBe(200);
+    expect(providerGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          model: MODEL,
+          prompt: "ambient intro",
+          durationSeconds: 30,
+        }),
+        user: expect.objectContaining({ id: USER, organization_id: ORG }),
+      }),
+    );
+    expect(generationsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: ORG,
+        type: "music",
+        storage_url: "https://cdn.test/out.mp3",
+        file_size: BigInt(1234),
+        mime_type: "audio/mpeg",
+      }),
+    );
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBe(COST);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - COST, 10);
+  });
+
+  test("unsupported model validates before provider and credits", async () => {
+    getSupportedMusicModelDefinition.mockReturnValue(undefined);
+
+    const res = await post({ model: "fal-ai/stable-audio" });
+
+    expect(res.status).toBe(400);
+    expect(providerGenerate).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  test("provider failure before settle refunds the reservation", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    providerGenerate.mockRejectedValue(new Error("provider 503"));
+
+    const res = await post();
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(generationsCreate).not.toHaveBeenCalled();
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBe(0);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+
+  test("post-settle persistence failure does not refund delivered audio", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    providerGenerate.mockResolvedValue({
+      requestId: "audio-req",
+      audio: { url: "https://cdn.test/out.mp3", content_type: "audio/mpeg" },
+    });
+    generationsCreate.mockRejectedValue(new Error("db write failed"));
+
+    const res = await post();
+
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBe(COST);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - COST, 10);
+  });
+});

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -1,4 +1,3 @@
-import { createFalClient } from "@fal-ai/client";
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
@@ -7,6 +6,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { getAudioProvider } from "@/lib/providers/audio/registry";
 import { calculateMusicGenerationCostFromCatalog } from "@/lib/services/ai-pricing";
 import {
   getSupportedMusicModelDefinition,
@@ -18,9 +18,8 @@ import {
   InsufficientCreditsError,
 } from "@/lib/services/credits";
 import { generationsService } from "@/lib/services/generations";
-import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
+import type { AppEnv } from "@/types/cloud-worker-env";
 
 const DEFAULT_MUSIC_MODEL = "fal-ai/minimax-music/v2.6";
 const MAX_PROMPT_LENGTH = 4100;
@@ -56,300 +55,9 @@ const musicRequestSchema = z.object({
   extraInput: z.record(z.string(), z.unknown()).optional(),
 });
 
-type MusicRequest = z.infer<typeof musicRequestSchema>;
-
-interface MusicObject {
-  url?: string;
-  file_name?: string;
-  file_size?: number;
-  content_type?: string;
-}
-
-interface NormalizedMusicResult {
-  requestId?: string;
-  status?: string;
-  music: MusicObject;
-  raw?: unknown;
-}
-
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
-
-function envString(env: Bindings, key: string): string | null {
-  const value = env[key];
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function falKey(env: Bindings): string | null {
-  return envString(env, "FAL_KEY") ?? envString(env, "FAL_API_KEY");
-}
-
-function elevenLabsKey(env: Bindings): string | null {
-  return envString(env, "ELEVENLABS_API_KEY");
-}
-
-function sunoKey(env: Bindings): string | null {
-  return envString(env, "SUNO_API_KEY");
-}
-
-function sunoBaseUrl(env: Bindings): string {
-  return (envString(env, "SUNO_BASE_URL") ?? "https://api.suno.ai/v1").replace(
-    /\/+$/,
-    "",
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function numberValue(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
-function normalizeMusicObject(value: unknown): MusicObject | null {
-  if (!isRecord(value)) return null;
-  const url =
-    stringValue(value.url) ??
-    stringValue(value.audio_url) ??
-    stringValue(value.output_url) ??
-    stringValue(value.file_url);
-  if (!url) return null;
-  return {
-    url,
-    file_name: stringValue(value.file_name),
-    file_size: numberValue(value.file_size),
-    content_type: stringValue(value.content_type),
-  };
-}
-
-function normalizeMusicResult(
-  result: unknown,
-  requestId?: string,
-): NormalizedMusicResult {
-  if (!isRecord(result)) {
-    throw new Error("Music provider returned an invalid response");
-  }
-
-  const direct =
-    normalizeMusicObject(result.audio) ??
-    normalizeMusicObject(result.music) ??
-    normalizeMusicObject(result.file) ??
-    normalizeMusicObject(result.output) ??
-    normalizeMusicObject(result);
-  const fromArray = Array.isArray(result.audios)
-    ? normalizeMusicObject(result.audios[0])
-    : Array.isArray(result.data)
-      ? normalizeMusicObject(result.data[0])
-      : null;
-  const music = direct ?? fromArray;
-  if (!music?.url) {
-    throw new Error("Music provider returned no audio URL");
-  }
-
-  return {
-    requestId:
-      stringValue(result.requestId) ??
-      stringValue(result.request_id) ??
-      stringValue(result.id) ??
-      requestId,
-    status: stringValue(result.status),
-    music,
-    raw: result,
-  };
-}
-
-function contentTypeForOutputFormat(outputFormat: string | undefined): string {
-  if (!outputFormat) return "audio/mpeg";
-  if (outputFormat.startsWith("pcm_")) return "audio/L16";
-  if (outputFormat.startsWith("ulaw_")) return "audio/basic";
-  if (outputFormat.startsWith("wav_")) return "audio/wav";
-  if (outputFormat.startsWith("mp3_")) return "audio/mpeg";
-  return "application/octet-stream";
-}
-
-function extensionForContentType(contentType: string): string {
-  if (contentType.includes("wav")) return "wav";
-  if (contentType.includes("L16") || contentType.includes("pcm")) return "pcm";
-  if (contentType.includes("basic")) return "ulaw";
-  return "mp3";
-}
-
-function buildFalInput(request: MusicRequest): Record<string, unknown> {
-  const input: Record<string, unknown> = {
-    prompt: request.prompt,
-  };
-
-  if (request.lyrics !== undefined) input.lyrics = request.lyrics;
-  if (request.instrumental !== undefined)
-    input.is_instrumental = request.instrumental;
-  if (request.lyricsOptimizer !== undefined) {
-    input.lyrics_optimizer = request.lyricsOptimizer;
-  } else if (!request.lyrics && request.instrumental !== true) {
-    input.lyrics_optimizer = true;
-  }
-  if (request.referenceUrl) {
-    input.audio_url = request.referenceUrl;
-    input.reference_audio_url = request.referenceUrl;
-  }
-  if (request.durationSeconds) {
-    input.duration = request.durationSeconds;
-    input.duration_seconds = request.durationSeconds;
-    input.seconds_total = request.durationSeconds;
-  }
-  if (request.audio) {
-    input.audio_setting = {
-      ...(request.audio.sampleRate
-        ? { sample_rate: request.audio.sampleRate }
-        : {}),
-      ...(request.audio.bitrate ? { bitrate: request.audio.bitrate } : {}),
-      ...(request.audio.format ? { format: request.audio.format } : {}),
-    };
-  }
-
-  return {
-    ...input,
-    ...(request.extraInput ?? {}),
-  };
-}
-
-async function runFalMusic(
-  env: Bindings,
-  request: MusicRequest,
-): Promise<NormalizedMusicResult> {
-  const key = falKey(env);
-  if (!key) {
-    throw new Error("Fal music generation is not configured");
-  }
-
-  let requestId: string | undefined;
-  const fal = createFalClient({
-    credentials: key,
-    suppressLocalCredentialsWarning: true,
-  });
-  const result = await fal.subscribe(request.model, {
-    input: buildFalInput(request),
-    onEnqueue: (id) => {
-      requestId = id;
-    },
-  });
-  return normalizeMusicResult(result, requestId);
-}
-
-async function runElevenLabsMusic(
-  env: Bindings,
-  request: MusicRequest,
-  user: { id: string; organization_id?: string | null },
-): Promise<NormalizedMusicResult> {
-  const key = elevenLabsKey(env);
-  if (!key) {
-    throw new Error("ElevenLabs music generation is not configured");
-  }
-  if (!env.BLOB) {
-    throw new Error("R2 storage is not configured");
-  }
-
-  const outputFormat = request.outputFormat ?? "mp3_44100_128";
-  const url = new URL("https://api.elevenlabs.io/v1/music");
-  url.searchParams.set("output_format", outputFormat);
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "xi-api-key": key,
-    },
-    body: JSON.stringify({
-      prompt: request.prompt,
-      ...(request.durationSeconds
-        ? { music_length_ms: request.durationSeconds * 1000 }
-        : {}),
-      model_id: request.model.replace(/^elevenlabs\//, ""),
-      ...(request.seed !== undefined ? { seed: request.seed } : {}),
-      ...(request.extraInput ?? {}),
-    }),
-    signal: AbortSignal.timeout(120_000),
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(
-      `ElevenLabs music generation failed (${response.status}): ${text}`,
-    );
-  }
-
-  const contentType =
-    response.headers.get("content-type") ??
-    contentTypeForOutputFormat(outputFormat);
-  const bytes = await response.arrayBuffer();
-  const ext = extensionForContentType(contentType);
-  const organizationId = user.organization_id ?? "unknown";
-  const keyPath = `generations/music/${organizationId}/${user.id}/${crypto.randomUUID()}.${ext}`;
-  const stored = await putPublicObject(env, {
-    key: keyPath,
-    body: bytes,
-    contentType,
-    customMetadata: {
-      userId: user.id,
-      organizationId,
-      model: request.model,
-      source: "generate-music",
-    },
-  });
-
-  return {
-    music: {
-      url: stored.url,
-      file_name: keyPath.split("/").at(-1),
-      file_size: bytes.byteLength,
-      content_type: contentType,
-    },
-    raw: { r2Key: stored.key },
-  };
-}
-
-async function runSunoMusic(
-  env: Bindings,
-  request: MusicRequest,
-): Promise<NormalizedMusicResult> {
-  const key = sunoKey(env);
-  if (!key) {
-    throw new Error("Suno-compatible music generation is not configured");
-  }
-
-  const response = await fetch(`${sunoBaseUrl(env)}/generate`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${key}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      prompt: request.prompt,
-      ...(request.durationSeconds ? { duration: request.durationSeconds } : {}),
-      ...(request.lyrics ? { lyrics: request.lyrics } : {}),
-      ...(request.instrumental !== undefined
-        ? { instrumental: request.instrumental }
-        : {}),
-      ...(request.extraInput ?? {}),
-    }),
-    signal: AbortSignal.timeout(120_000),
-  });
-
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    throw new Error(
-      `Suno-compatible music generation failed (${response.status})`,
-    );
-  }
-  return normalizeMusicResult(data);
-}
 
 app.post("/", async (c) => {
   let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
@@ -443,12 +151,11 @@ app.post("/", async (c) => {
       throw error;
     }
 
-    const normalized =
-      provider === "fal"
-        ? await runFalMusic(c.env, request)
-        : provider === "elevenlabs"
-          ? await runElevenLabsMusic(c.env, request, user)
-          : await runSunoMusic(c.env, request);
+    const normalized = await getAudioProvider(provider).generate({
+      env: c.env,
+      request,
+      user,
+    });
 
     await reservation.reconcile(cost.totalCost);
     chargeSettled = true;
@@ -467,12 +174,12 @@ app.post("/", async (c) => {
         raw: normalized.raw,
       },
       status: "completed",
-      storage_url: normalized.music.url,
+      storage_url: normalized.audio.url,
       thumbnail_url: null,
-      file_size: normalized.music.file_size
-        ? BigInt(normalized.music.file_size)
+      file_size: normalized.audio.file_size
+        ? BigInt(normalized.audio.file_size)
         : undefined,
-      mime_type: normalized.music.content_type ?? "audio/mpeg",
+      mime_type: normalized.audio.content_type ?? "audio/mpeg",
       parameters: {
         durationSeconds,
         hasLyrics: Boolean(request.lyrics),
@@ -495,7 +202,7 @@ app.post("/", async (c) => {
       id: generation.id,
       requestId: normalized.requestId,
       status: normalized.status ?? "completed",
-      music: normalized.music,
+      music: normalized.audio,
       cost,
     });
   } catch (error) {

--- a/packages/cloud/shared/src/lib/providers/audio/audio-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/audio-generation.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { generateFalAudio } from "./fal-audio-generation";
+import { normalizeAudioResult } from "./normalize";
+import { DEFERRED_AUDIO_PROVIDERS, getAudioProvider } from "./registry";
+
+const subscribe = mock();
+
+mock.module("@fal-ai/client", () => ({
+  createFalClient: () => ({ subscribe }),
+}));
+
+beforeEach(() => {
+  subscribe.mockReset();
+});
+
+describe("audio provider registry", () => {
+  test("registers existing music providers and documents SFX deferrals", () => {
+    expect(getAudioProvider("fal").billingSource).toBe("fal");
+    expect(getAudioProvider("elevenlabs").billingSource).toBe("elevenlabs");
+    expect(getAudioProvider("suno").billingSource).toBe("suno");
+    expect(DEFERRED_AUDIO_PROVIDERS.map((entry) => entry.modelFamily)).toEqual([
+      "fal-ai/stable-audio",
+      "fal-ai/mmaudio-v2",
+      "elevenlabs/sound-effects",
+    ]);
+  });
+
+  test("normalizes common audio provider response shapes", () => {
+    expect(
+      normalizeAudioResult({
+        id: "req-1",
+        audios: [{ audio_url: "https://cdn.test/out.wav", file_size: 123 }],
+      }),
+    ).toMatchObject({
+      requestId: "req-1",
+      audio: { url: "https://cdn.test/out.wav", file_size: 123 },
+    });
+  });
+
+  test("fal provider passes music controls to fal input", async () => {
+    subscribe.mockResolvedValue({
+      request_id: "fal-req",
+      audio: { url: "https://fal.test/out.mp3", content_type: "audio/mpeg" },
+    });
+
+    const result = await generateFalAudio({
+      env: { FAL_KEY: "fal-test-key" } as never,
+      user: { id: "user-1", organization_id: "org-1" },
+      request: {
+        model: "fal-ai/minimax-music/v2.6",
+        prompt: "ambient intro",
+        durationSeconds: 30,
+        instrumental: true,
+        referenceUrl: "https://example.com/ref.wav",
+        audio: { format: "mp3", sampleRate: "44100", bitrate: "128000" },
+      },
+    });
+
+    expect(result.audio.url).toBe("https://fal.test/out.mp3");
+    expect(subscribe).toHaveBeenCalledWith(
+      "fal-ai/minimax-music/v2.6",
+      expect.objectContaining({
+        input: expect.objectContaining({
+          prompt: "ambient intro",
+          duration: 30,
+          duration_seconds: 30,
+          seconds_total: 30,
+          is_instrumental: true,
+          audio_url: "https://example.com/ref.wav",
+          reference_audio_url: "https://example.com/ref.wav",
+          audio_setting: {
+            format: "mp3",
+            sample_rate: "44100",
+            bitrate: "128000",
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
@@ -1,0 +1,92 @@
+import { putPublicObject } from "../../storage/r2-public-object";
+import { normalizeAudioResult } from "./normalize";
+import type { AudioProvider } from "./types";
+
+function contentTypeForOutputFormat(outputFormat: string | undefined): string {
+  if (!outputFormat) return "audio/mpeg";
+  if (outputFormat.startsWith("pcm_")) return "audio/L16";
+  if (outputFormat.startsWith("ulaw_")) return "audio/basic";
+  if (outputFormat.startsWith("wav_")) return "audio/wav";
+  if (outputFormat.startsWith("mp3_")) return "audio/mpeg";
+  return "application/octet-stream";
+}
+
+function extensionForContentType(contentType: string): string {
+  if (contentType.includes("wav")) return "wav";
+  if (contentType.includes("L16") || contentType.includes("pcm")) return "pcm";
+  if (contentType.includes("basic")) return "ulaw";
+  return "mp3";
+}
+
+export async function generateElevenLabsAudio(input: Parameters<AudioProvider["generate"]>[0]) {
+  const key = input.env.ELEVENLABS_API_KEY;
+  if (!key) {
+    throw new Error("ElevenLabs music generation is not configured");
+  }
+  if (!input.env.BLOB) {
+    throw new Error("R2 storage is not configured");
+  }
+
+  const outputFormat = input.request.outputFormat ?? "mp3_44100_128";
+  const url = new URL("https://api.elevenlabs.io/v1/music");
+  url.searchParams.set("output_format", outputFormat);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "xi-api-key": key,
+    },
+    body: JSON.stringify({
+      prompt: input.request.prompt,
+      ...(input.request.durationSeconds
+        ? { music_length_ms: input.request.durationSeconds * 1000 }
+        : {}),
+      model_id: input.request.model.replace(/^elevenlabs\//, ""),
+      ...(input.request.seed !== undefined ? { seed: input.request.seed } : {}),
+      ...(input.request.extraInput ?? {}),
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`ElevenLabs music generation failed (${response.status}): ${text}`);
+  }
+
+  const contentType =
+    response.headers.get("content-type") ?? contentTypeForOutputFormat(outputFormat);
+  const bytes = await response.arrayBuffer();
+  const ext = extensionForContentType(contentType);
+  const organizationId = input.user.organization_id ?? "unknown";
+  const keyPath = `generations/music/${organizationId}/${input.user.id}/${crypto.randomUUID()}.${ext}`;
+  const stored = await putPublicObject(input.env, {
+    key: keyPath,
+    body: bytes,
+    contentType,
+    customMetadata: {
+      userId: input.user.id,
+      organizationId,
+      model: input.request.model,
+      source: "generate-music",
+    },
+  });
+
+  return normalizeAudioResult({
+    audio: {
+      url: stored.url,
+      file_name: keyPath.split("/").at(-1),
+      file_size: bytes.byteLength,
+      content_type: contentType,
+    },
+    raw: { r2Key: stored.key },
+  });
+}
+
+export const elevenLabsAudioProvider: AudioProvider = {
+  billingSource: "elevenlabs",
+  generate: generateElevenLabsAudio,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts
@@ -1,0 +1,72 @@
+import { createFalClient } from "@fal-ai/client";
+import { getAiProviderConfigurationError } from "../language-model";
+import { normalizeAudioResult } from "./normalize";
+import type { AudioGenerationRequest, AudioProvider } from "./types";
+
+function buildFalInput(request: AudioGenerationRequest): Record<string, unknown> {
+  const input: Record<string, unknown> = {
+    prompt: request.prompt,
+  };
+
+  if (request.lyrics !== undefined) input.lyrics = request.lyrics;
+  if (request.instrumental !== undefined) input.is_instrumental = request.instrumental;
+  if (request.lyricsOptimizer !== undefined) {
+    input.lyrics_optimizer = request.lyricsOptimizer;
+  } else if (!request.lyrics && request.instrumental !== true) {
+    input.lyrics_optimizer = true;
+  }
+  if (request.referenceUrl) {
+    input.audio_url = request.referenceUrl;
+    input.reference_audio_url = request.referenceUrl;
+  }
+  if (request.durationSeconds) {
+    input.duration = request.durationSeconds;
+    input.duration_seconds = request.durationSeconds;
+    input.seconds_total = request.durationSeconds;
+  }
+  if (request.audio) {
+    input.audio_setting = {
+      ...(request.audio.sampleRate ? { sample_rate: request.audio.sampleRate } : {}),
+      ...(request.audio.bitrate ? { bitrate: request.audio.bitrate } : {}),
+      ...(request.audio.format ? { format: request.audio.format } : {}),
+    };
+  }
+
+  return {
+    ...input,
+    ...(request.extraInput ?? {}),
+  };
+}
+
+export async function generateFalAudio(input: Parameters<AudioProvider["generate"]>[0]) {
+  const key =
+    typeof input.env.FAL_KEY === "string" && input.env.FAL_KEY.trim()
+      ? input.env.FAL_KEY.trim()
+      : typeof input.env.FAL_API_KEY === "string" && input.env.FAL_API_KEY.trim()
+        ? input.env.FAL_API_KEY.trim()
+        : null;
+  if (!key) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  let requestId: string | undefined;
+  const fal = createFalClient({
+    credentials: key,
+    suppressLocalCredentialsWarning: true,
+  });
+  const result = await fal.subscribe(input.request.model, {
+    input: buildFalInput(input.request),
+    onEnqueue: (id) => {
+      requestId = id;
+    },
+  });
+  return normalizeAudioResult(result, requestId);
+}
+
+export const falAudioProvider: AudioProvider = {
+  billingSource: "fal",
+  generate: generateFalAudio,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud/shared/src/lib/providers/audio/normalize.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/normalize.ts
@@ -1,0 +1,62 @@
+import type { AudioGenerationResult, AudioObject } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeAudioObject(value: unknown): AudioObject | null {
+  if (!isRecord(value)) return null;
+  const url =
+    stringValue(value.url) ??
+    stringValue(value.audio_url) ??
+    stringValue(value.output_url) ??
+    stringValue(value.file_url);
+  if (!url) return null;
+  return {
+    url,
+    file_name: stringValue(value.file_name),
+    file_size: numberValue(value.file_size),
+    content_type: stringValue(value.content_type),
+  };
+}
+
+export function normalizeAudioResult(result: unknown, requestId?: string): AudioGenerationResult {
+  if (!isRecord(result)) {
+    throw new Error("Audio provider returned an invalid response");
+  }
+
+  const direct =
+    normalizeAudioObject(result.audio) ??
+    normalizeAudioObject(result.music) ??
+    normalizeAudioObject(result.file) ??
+    normalizeAudioObject(result.output) ??
+    normalizeAudioObject(result);
+  const fromArray = Array.isArray(result.audios)
+    ? normalizeAudioObject(result.audios[0])
+    : Array.isArray(result.data)
+      ? normalizeAudioObject(result.data[0])
+      : null;
+  const audio = direct ?? fromArray;
+  if (!audio?.url) {
+    throw new Error("Audio provider returned no audio URL");
+  }
+
+  return {
+    requestId:
+      stringValue(result.requestId) ??
+      stringValue(result.request_id) ??
+      stringValue(result.id) ??
+      requestId,
+    status: stringValue(result.status),
+    audio,
+    raw: result,
+  };
+}

--- a/packages/cloud/shared/src/lib/providers/audio/registry.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/registry.ts
@@ -1,0 +1,46 @@
+import { elevenLabsAudioProvider } from "./elevenlabs-audio-generation";
+import { falAudioProvider } from "./fal-audio-generation";
+import { sunoAudioProvider } from "./suno-audio-generation";
+import type { AudioProvider, AudioProviderId } from "./types";
+
+const PROVIDERS = new Map<AudioProviderId, AudioProvider>();
+
+export function registerAudioProvider(provider: AudioProvider) {
+  PROVIDERS.set(provider.billingSource, provider);
+}
+
+export function getAudioProvider(billingSource: AudioProviderId): AudioProvider {
+  const provider = PROVIDERS.get(billingSource);
+  if (!provider) {
+    throw new Error(`No audio provider registered for billing source: ${billingSource}`);
+  }
+  return provider;
+}
+
+export const DEFERRED_AUDIO_PROVIDERS = [
+  {
+    modelFamily: "fal-ai/stable-audio",
+    provider: "fal",
+    sourceUrl: "https://fal.ai/models/fal-ai/stable-audio",
+    rationale:
+      "Stable Audio is an SFX/music candidate, but no supported catalog/pricing row is wired yet.",
+  },
+  {
+    modelFamily: "fal-ai/mmaudio-v2",
+    provider: "fal",
+    sourceUrl: "https://fal.ai/models/fal-ai/mmaudio-v2/text-to-audio",
+    rationale:
+      "MMAudio is a text/video-to-audio candidate; defer until route inputs and pricing distinguish SFX/video-audio use.",
+  },
+  {
+    modelFamily: "elevenlabs/sound-effects",
+    provider: "elevenlabs",
+    sourceUrl: "https://elevenlabs.io/docs/api-reference/text-to-sound-effects/convert",
+    rationale:
+      "ElevenLabs sound effects needs a distinct catalog row and request shape before enabling.",
+  },
+] as const;
+
+registerAudioProvider(falAudioProvider);
+registerAudioProvider(elevenLabsAudioProvider);
+registerAudioProvider(sunoAudioProvider);

--- a/packages/cloud/shared/src/lib/providers/audio/suno-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/suno-audio-generation.ts
@@ -1,0 +1,52 @@
+import { normalizeAudioResult } from "./normalize";
+import type { AudioProvider } from "./types";
+
+function sunoBaseUrl(env: Parameters<AudioProvider["generate"]>[0]["env"]): string {
+  const configured =
+    typeof env.SUNO_BASE_URL === "string" && env.SUNO_BASE_URL.trim()
+      ? env.SUNO_BASE_URL.trim()
+      : null;
+  return (configured || "https://api.suno.ai/v1").replace(/\/+$/, "");
+}
+
+export async function generateSunoAudio(input: Parameters<AudioProvider["generate"]>[0]) {
+  const key =
+    typeof input.env.SUNO_API_KEY === "string" && input.env.SUNO_API_KEY.trim()
+      ? input.env.SUNO_API_KEY.trim()
+      : null;
+  if (!key) {
+    throw new Error("Suno-compatible music generation is not configured");
+  }
+
+  const response = await fetch(`${sunoBaseUrl(input.env)}/generate`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      prompt: input.request.prompt,
+      ...(input.request.durationSeconds ? { duration: input.request.durationSeconds } : {}),
+      ...(input.request.lyrics ? { lyrics: input.request.lyrics } : {}),
+      ...(input.request.instrumental !== undefined
+        ? { instrumental: input.request.instrumental }
+        : {}),
+      ...(input.request.extraInput ?? {}),
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`Suno-compatible music generation failed (${response.status})`);
+  }
+  return normalizeAudioResult(data);
+}
+
+export const sunoAudioProvider: AudioProvider = {
+  billingSource: "suno",
+  generate: generateSunoAudio,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud/shared/src/lib/providers/audio/types.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/types.ts
@@ -1,0 +1,52 @@
+import type { Bindings } from "../../../types/cloud-worker-env";
+
+export type AudioProviderId = "fal" | "elevenlabs" | "suno";
+
+export interface AudioGenerationRequest {
+  prompt: string;
+  model: string;
+  lyrics?: string;
+  lyricsOptimizer?: boolean;
+  instrumental?: boolean;
+  durationSeconds?: number;
+  referenceUrl?: string;
+  seed?: number;
+  outputFormat?: string;
+  audio?: {
+    format?: "mp3" | "wav" | "pcm" | "flac";
+    sampleRate?: "16000" | "24000" | "32000" | "44100";
+    bitrate?: "32000" | "64000" | "128000" | "256000";
+  };
+  extraInput?: Record<string, unknown>;
+}
+
+export interface AudioGenerationUser {
+  id: string;
+  organization_id?: string | null;
+}
+
+export interface AudioObject {
+  url?: string;
+  file_name?: string;
+  file_size?: number;
+  content_type?: string;
+}
+
+export interface AudioGenerationResult {
+  requestId?: string;
+  status?: string;
+  audio: AudioObject;
+  raw?: unknown;
+}
+
+export interface AudioProviderGenerateInput {
+  env: Bindings;
+  request: AudioGenerationRequest;
+  user: AudioGenerationUser;
+}
+
+export interface AudioProvider {
+  billingSource: AudioProviderId;
+  generate(input: AudioProviderGenerateInput): Promise<AudioGenerationResult>;
+  healthCheck?(): Promise<boolean>;
+}


### PR DESCRIPTION
## Summary
- add shared cloud audio provider types, normalization, registry, and Fal/ElevenLabs/Suno provider adapters
- refactor `/api/v1/generate-music` to delegate provider execution through the registry while keeping validation, billing, refunds, and persistence in the route
- document SFX deferrals for Stable Audio, MMAudio, and ElevenLabs sound effects with provider docs reviewed

## Evidence
- `.github/issue-evidence/11741-audio-provider-registry.md`

## Validation
- `bun run install:light` - pass; Bun rewrites unrelated lockfile metadata order locally, restored with no functional diff
- `bun test packages/cloud/shared/src/lib/providers/audio/audio-generation.test.ts` - pass, 3 tests
- `bun test packages/cloud/api/__tests__/generate-music-audio-registry.test.ts` - pass, 4 tests
- `bun run --cwd packages/cloud/shared typecheck` - pass
- `bun run --cwd packages/cloud/api typecheck` - pass
- `bun run --cwd packages/cloud/shared lint` - pass
- `bun run --cwd packages/cloud/api lint` - pass
- `git diff --check` - pass

Closes #11741