### PR TITLE
feat(cloud): add LinkedIn Ads provider

### DIFF
--- a/.github/issue-evidence/11663-linkedin-ads-provider.md
+++ b/.github/issue-evidence/11663-linkedin-ads-provider.md
@@ -1,0 +1,89 @@
+# Issue #11663 - LinkedIn Ads Provider
+
+## Scope
+
+- Added `linkedin` as an advertising platform in shared schemas (`AdPlatformSchema`), DB typing
+  (`AdPlatform`, LinkedIn `organization_urn` metadata), credit spend markup, the provider
+  registry, and the app promotion route platform validation.
+- Added a real LinkedIn Marketing API provider (`providers/linkedin.ts`) using the versioned
+  REST gateway (`api.linkedin.com/rest`, `LinkedIn-Version` + `X-Restli-Protocol-Version: 2.0.0`
+  headers, OAuth2 bearer tokens):
+  - account discovery via the `adAccounts` search finder (Rest.li structured query)
+  - campaign creation as campaign group + paused campaign (`x-restli-id` id extraction),
+    with objective mapping, daily/total budget mapping, worldwide-default geo targeting
+    (`urn:li:geo` URNs pass through; free-text locations fail loudly), and auto-bid
+    `costType`/`optimizationTargetType` mapping per the documented allowable combinations
+  - campaign update/pause/activate/delete via Rest.li `PARTIAL_UPDATE` patches
+    (`PENDING_DELETION` for non-draft deletes)
+  - media upload through the Images/Videos APIs (`initializeUpload` -> byte upload ->
+    `finalizeUpload` for multi-part video), owner resolved from the ad account's
+    organization `reference`
+  - creative creation as an inline dark post (`creatives?action=createInline`) with
+    CTA label + landing page mapping
+  - analytics via the `adAnalytics` analytics finder (CAMPAIGN pivot, explicit `fields`)
+  - OAuth2 `refresh_token` grant against `www.linkedin.com/oauth/v2/accessToken`
+- #11621 bid controls map to LinkedIn `costType`/`optimizationTargetType`
+  (`cpm`->CPM, `cpc`->CPC, `cpa`->CPM+MAX_CONVERSION; goals reach/clicks/conversions ->
+  MAX_IMPRESSION/MAX_CLICK/MAX_CONVERSION; objective-default auto-bid otherwise) and never
+  emit a manual `unitCost`.
+- Added a credential-gated live lane in `linkedin.real.test.ts` that logs a loud SKIP when
+  `LINKEDIN_ADS_ACCESS_TOKEN` is absent.
+
+## Official Docs Reviewed (fixtures lifted from these pages)
+
+- Ad accounts: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts
+- Campaign groups: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups
+- Campaigns: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns
+- Creatives (inline dark posts): https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives
+- Images API: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api
+- Reporting (adAnalytics): https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting
+- Objective/bid combinations: https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ad-budget-pricing-type-combinations
+
+Test fixtures (account search response, ad account fetch, image GET, adAnalytics elements,
+`x-restli-id` header ids, `urn:li:sponsoredCreative:120491345`) are copied from the sample
+responses on those pages, not invented.
+
+## Verification
+
+- `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts`
+  - 16 pass / 0 fail (78 expect() calls). Covers account discovery + validation, campaign
+    create mapping (daily + lifetime budgets), bid-control mapping, geo-targeting
+    validation (fail-fast before any platform call), Rest.li partial updates for
+    pause/activate/delete, budget-field-aware updates, inline creative payload,
+    media status, analytics summation, and API error propagation.
+  - Service integration block drives `advertisingService.createCampaign` with the REAL
+    LinkedIn provider and a mocked `fetch`:
+    - #11619 approval gate: a `pending` LinkedIn account is rejected before content
+      safety, credits, or any LinkedIn API call.
+    - #11621 bid metadata: `bid_strategy`/`optimization_goal` persist to campaign
+      metadata and the provider payload carries `costType: CPC` +
+      `optimizationTargetType: MAX_CLICK`.
+    - Fail-closed money path: a LinkedIn 403 on campaign-group create fails the service
+      call, persists nothing, and refunds the full charge (0.5 + 50 * 1.1 credits) once.
+- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts ad-campaign-bid-strategy.test.ts ad-campaign-dayparting.test.ts ad-campaign-credit-reconciliation.test.ts ad-audience-segments.test.ts ad-conversion-attribution.test.ts`
+  - 58 pass / 0 fail across 6 files (existing suites unaffected by the platform addition).
+- `bun test packages/cloud/api/__tests__/advertising-*.test.ts` - 14 pass / 0 fail.
+- `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts`
+  - 2 skip with a loud `[LinkedInAdsRealTest] SKIPPED: set LINKEDIN_ADS_ACCESS_TOKEN ...`
+    warning (no live credentials in this environment).
+- `bun run --cwd packages/cloud/shared typecheck` - passed (after
+  `node packages/shared/scripts/generate-keywords.mjs --target ts`, environmental).
+- `bun run --cwd packages/cloud/api typecheck` - passed.
+- `bunx biome check` on all touched files - clean.
+
+## Manual Review
+
+- Compared every provider URL, header, Rest.li query encoding, request body, and response
+  parsing against the Microsoft Learn LinkedIn Marketing API pages listed above.
+- Reviewed mocked `fetch` call URLs, `X-RestLi-Method` headers, and JSON payload assertions
+  in `linkedin.test.ts` by hand.
+
+## Not Captured
+
+- Live LinkedIn Marketing API run: N/A in this environment - LinkedIn Ads API access
+  requires a LinkedIn developer application with the Advertising API product approved plus
+  a member token with `rw_ads`; no such operator credentials are provisioned. The live lane
+  runs when `LINKEDIN_ADS_ACCESS_TOKEN` (and optionally `LINKEDIN_ADS_ACCOUNT_ID`,
+  `LINKEDIN_ADS_CLIENT_ID`/`LINKEDIN_ADS_CLIENT_SECRET` for token refresh) are set.
+- Screenshots/video: N/A - no UI rendering change.
+- Real-LLM trajectories: N/A - no agent/action/prompt/model behavior change.

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -53,7 +53,7 @@ const PromotionConfigSchema = z.object({
     .optional(),
   advertising: z
     .object({
-      platform: z.enum(["meta", "google", "tiktok"]),
+      platform: z.enum(["meta", "google", "tiktok", "linkedin"]),
       adAccountId: z.string().uuid(),
       budget: z.number().positive().max(10000),
       budgetType: z.enum(["daily", "lifetime"]),

--- a/packages/cloud/shared/src/db/schemas/ad-accounts.ts
+++ b/packages/cloud/shared/src/db/schemas/ad-accounts.ts
@@ -7,7 +7,7 @@ import { users } from "./users";
 /**
  * Ad platform type.
  */
-export type AdPlatform = "meta" | "google" | "tiktok";
+export type AdPlatform = "meta" | "google" | "tiktok" | "linkedin";
 
 /**
  * Ad account status.
@@ -65,6 +65,8 @@ export const adAccounts = pgTable(
         timezone?: string;
         // TikTok-specific
         advertiser_id?: string;
+        // LinkedIn-specific
+        organization_urn?: string;
         // Common
         permissions?: string[];
         last_sync_at?: string;

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -16,6 +16,7 @@ import { type ContentSafetyReview, contentSafetyService } from "../content-safet
 import { creditsService } from "../credits";
 import { secretsService } from "../secrets";
 import { googleAdsProvider } from "./providers/google";
+import { linkedinAdsProvider } from "./providers/linkedin";
 import { metaAdsProvider } from "./providers/meta";
 import { tiktokAdsProvider } from "./providers/tiktok";
 import { DaypartingScheduleSchema } from "./schemas";
@@ -52,6 +53,7 @@ const providers: Record<AdPlatform, AdProvider | null> = {
   meta: metaAdsProvider,
   google: googleAdsProvider,
   tiktok: tiktokAdsProvider,
+  linkedin: linkedinAdsProvider,
 };
 
 class AdvertisingService {

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.real.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { logger } from "../../../utils/logger";
+import { linkedinAdsProvider } from "./linkedin";
+
+const hasCredentials = Boolean(process.env.LINKEDIN_ADS_ACCESS_TOKEN);
+
+if (!hasCredentials) {
+  logger.warn(
+    "[LinkedInAdsRealTest] SKIPPED: set LINKEDIN_ADS_ACCESS_TOKEN (rw_ads scope) to run the live LinkedIn Marketing API lane",
+  );
+}
+
+describe("linkedinAdsProvider live credentials", () => {
+  (hasCredentials ? test : test.skip)(
+    "discovers live LinkedIn ad accounts with an OAuth2 access token",
+    async () => {
+      const accounts = await linkedinAdsProvider.listAdAccounts({
+        accessToken: process.env.LINKEDIN_ADS_ACCESS_TOKEN as string,
+      });
+
+      expect(accounts.length).toBeGreaterThan(0);
+      expect(accounts[0]?.id).toMatch(/^\d+$/);
+    },
+  );
+
+  (hasCredentials && process.env.LINKEDIN_ADS_ACCOUNT_ID ? test : test.skip)(
+    "reads live campaign analytics for the configured ad account",
+    async () => {
+      const validation = await linkedinAdsProvider.validateCredentials({
+        accessToken: process.env.LINKEDIN_ADS_ACCESS_TOKEN as string,
+      });
+      expect(validation.valid).toBe(true);
+    },
+  );
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -1,0 +1,697 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  adAccountsRepository,
+  adCampaignsRepository,
+  adTransactionsRepository,
+} from "../../../../db/repositories";
+import { advertisingService } from "../index";
+import type { CreateCampaignInput } from "../types";
+import { linkedinAdsProvider, mapBidControlsToLinkedInCampaign } from "./linkedin";
+
+const originalFetch = globalThis.fetch;
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+const calls: FetchCall[] = [];
+let queue: Array<{ status?: number; body: unknown; headers?: Record<string, string> }> = [];
+
+function enqueue(
+  body: unknown,
+  options: { status?: number; headers?: Record<string, string> } = {},
+) {
+  queue.push({ body, status: options.status ?? 200, headers: options.headers });
+}
+
+function requestBody(call: FetchCall): Record<string, unknown> {
+  return JSON.parse(String(call.init?.body)) as Record<string, unknown>;
+}
+
+function requestHeaders(call: FetchCall): Record<string, string> {
+  return (call.init?.headers ?? {}) as Record<string, string>;
+}
+
+const credentials = { accessToken: "linkedin-token" };
+
+// Fixtures below are lifted from the LinkedIn Marketing API reference:
+// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts
+// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns
+// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api
+// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting
+const ACCOUNT_SEARCH_FIXTURE = {
+  elements: [
+    {
+      test: false,
+      currency: "USD",
+      id: 507404993,
+      name: "Dunder Mifflin Account",
+      reference: "urn:li:organization:2414183",
+      servingStatuses: ["BILLING_HOLD"],
+      status: "ACTIVE",
+      type: "BUSINESS",
+    },
+  ],
+  metadata: { nextPageToken: "DgGerr1iVQreCJVjZDOW_grcp63nueBDipsS4DJpvJo" },
+};
+
+const AD_ACCOUNT_FIXTURE = {
+  test: false,
+  currency: "USD",
+  id: 507404993,
+  name: "Dunder Mifflin Account",
+  reference: "urn:li:organization:2414183",
+  servingStatuses: ["RUNNABLE"],
+  status: "ACTIVE",
+  type: "BUSINESS",
+};
+
+const IMAGE_GET_FIXTURE = {
+  owner: "urn:li:organization:5583111",
+  downloadUrl:
+    "https://media.licdn-ei.com/dms/image/C4E10AQFn10iWtKexVA/image-shrink_1280/0/1675963270302/imagecreatedfirst?e=1676584800&v=beta&t=zuE2bQG5S-pY2R1v-FNJu15Pbs2K_Z02Q4naeM2kh00",
+  id: "urn:li:image:C4E10AQFn10iWtKexVA",
+  downloadUrlExpiresAt: 1679083200000,
+  status: "AVAILABLE",
+};
+
+const ANALYTICS_FIXTURE = {
+  elements: [
+    {
+      pivotValues: ["urn:li:sponsoredCampaign:145282384"],
+      dateRange: {
+        start: { month: 5, year: 2024, day: 28 },
+        end: { month: 5, year: 2024, day: 28 },
+      },
+      landingPageClicks: 0,
+      costInLocalCurrency: "0.0",
+      impressions: 6,
+      shares: 0,
+      externalWebsiteConversions: 0,
+      reactions: 0,
+    },
+    {
+      pivotValues: ["urn:li:sponsoredCampaign:145282384"],
+      dateRange: {
+        start: { month: 5, year: 2024, day: 29 },
+        end: { month: 5, year: 2024, day: 29 },
+      },
+      landingPageClicks: 11,
+      costInLocalCurrency: "19.91833",
+      impressions: 165,
+      shares: 0,
+      externalWebsiteConversions: 0,
+      reactions: 0,
+    },
+  ],
+  paging: { count: 10, links: [], start: 0 },
+};
+
+function makeCreateInput(over: Partial<CreateCampaignInput> = {}): CreateCampaignInput {
+  return {
+    organizationId: "00000000-0000-4000-8000-000000000001",
+    adAccountId: "00000000-0000-4000-8000-000000000002",
+    name: "Launch campaign",
+    objective: "traffic",
+    budgetType: "daily",
+    budgetAmount: 42,
+    budgetCurrency: "USD",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  queue = [];
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    const next = queue.shift() ?? { body: {}, status: 200 };
+    return new Response(JSON.stringify(next.body), {
+      status: next.status ?? 200,
+      headers: { "content-type": "application/json", ...next.headers },
+    });
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("linkedinAdsProvider", () => {
+  test("discovers active LinkedIn ad accounts with versioned Rest.li headers", async () => {
+    enqueue(ACCOUNT_SEARCH_FIXTURE);
+
+    const accounts = await linkedinAdsProvider.listAdAccounts(credentials);
+
+    expect(accounts).toEqual([{ id: "507404993", name: "Dunder Mifflin Account" }]);
+    expect(calls[0]?.url).toBe(
+      "https://api.linkedin.com/rest/adAccounts?q=search&search=(status:(values:List(ACTIVE)))&pageSize=1000",
+    );
+    const headers = requestHeaders(calls[0] as FetchCall);
+    expect(headers.Authorization).toBe("Bearer linkedin-token");
+    expect(headers["LinkedIn-Version"]).toBe(process.env.LINKEDIN_ADS_API_VERSION ?? "202606");
+    expect(headers["X-Restli-Protocol-Version"]).toBe("2.0.0");
+  });
+
+  test("validates credentials through account discovery", async () => {
+    enqueue(ACCOUNT_SEARCH_FIXTURE);
+    await expect(linkedinAdsProvider.validateCredentials(credentials)).resolves.toEqual({
+      valid: true,
+      accountId: "507404993",
+      accountName: "Dunder Mifflin Account",
+    });
+
+    enqueue({ elements: [] });
+    await expect(linkedinAdsProvider.validateCredentials(credentials)).resolves.toEqual({
+      valid: false,
+      error: "No LinkedIn ad accounts found or invalid credentials",
+    });
+  });
+
+  test("creates a paused campaign under a new campaign group with mapped objective, budget, and auto-bid", async () => {
+    enqueue({}, { status: 201, headers: { "x-restli-id": "603407684" } });
+    enqueue({}, { status: 201, headers: { "x-restli-id": "145282384" } });
+
+    const result = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput({ startDate: new Date("2026-07-01T00:00:00Z") }),
+    );
+
+    expect(result).toEqual({
+      success: true,
+      externalCampaignId: "507404993/603407684/145282384",
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaignGroups",
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaigns",
+    ]);
+
+    const groupBody = requestBody(calls[0] as FetchCall);
+    expect(groupBody).toMatchObject({
+      account: "urn:li:sponsoredAccount:507404993",
+      name: "Launch campaign Group",
+      status: "ACTIVE",
+      runSchedule: { start: Date.parse("2026-07-01T00:00:00Z") },
+    });
+
+    const campaignBody = requestBody(calls[1] as FetchCall);
+    expect(campaignBody).toMatchObject({
+      account: "urn:li:sponsoredAccount:507404993",
+      campaignGroup: "urn:li:sponsoredCampaignGroup:603407684",
+      name: "Launch campaign",
+      type: "SPONSORED_UPDATES",
+      objectiveType: "WEBSITE_VISIT",
+      costType: "CPC",
+      optimizationTargetType: "MAX_CLICK",
+      dailyBudget: { amount: "42.00", currencyCode: "USD" },
+      status: "PAUSED",
+      targetingCriteria: {
+        include: {
+          and: [{ or: { "urn:li:adTargetingFacet:locations": ["urn:li:geo:92000000"] } }],
+        },
+      },
+    });
+    expect(campaignBody.unitCost).toBeUndefined();
+  });
+
+  test("maps bid controls onto LinkedIn costType and optimizationTargetType", () => {
+    expect(mapBidControlsToLinkedInCampaign({ objective: "traffic", bidStrategy: "cpm" })).toEqual({
+      costType: "CPM",
+      optimizationTargetType: "MAX_CLICK",
+    });
+    expect(mapBidControlsToLinkedInCampaign({ objective: "traffic", bidStrategy: "cpc" })).toEqual({
+      costType: "CPC",
+      optimizationTargetType: "MAX_CLICK",
+    });
+    expect(
+      mapBidControlsToLinkedInCampaign({ objective: "conversions", bidStrategy: "cpa" }),
+    ).toEqual({
+      costType: "CPM",
+      optimizationTargetType: "MAX_CONVERSION",
+    });
+    expect(
+      mapBidControlsToLinkedInCampaign({ objective: "traffic", optimizationGoal: "reach" }),
+    ).toEqual({
+      costType: "CPC",
+      optimizationTargetType: "MAX_IMPRESSION",
+    });
+    expect(mapBidControlsToLinkedInCampaign({ objective: "awareness" })).toEqual({
+      costType: "CPM",
+      optimizationTargetType: "MAX_IMPRESSION",
+    });
+    expect(mapBidControlsToLinkedInCampaign({ objective: "leads" })).toEqual({
+      costType: "CPC",
+      optimizationTargetType: "MAX_LEAD",
+    });
+  });
+
+  test("uses a lifetime total budget and requires an end date for it", async () => {
+    const noEnd = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput({ budgetType: "lifetime" }),
+    );
+    expect(noEnd.success).toBe(false);
+    expect(noEnd.error).toContain("end date");
+    expect(calls.length).toBe(0);
+
+    enqueue({}, { status: 201, headers: { "x-restli-id": "603407684" } });
+    enqueue({}, { status: 201, headers: { "x-restli-id": "145282384" } });
+    const result = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput({
+        budgetType: "lifetime",
+        startDate: new Date("2026-07-01T00:00:00Z"),
+        endDate: new Date("2026-08-01T00:00:00Z"),
+      }),
+    );
+    expect(result.success).toBe(true);
+    expect(requestBody(calls[0] as FetchCall)).toMatchObject({
+      totalBudget: { amount: "42.00", currencyCode: "USD" },
+      runSchedule: {
+        start: Date.parse("2026-07-01T00:00:00Z"),
+        end: Date.parse("2026-08-01T00:00:00Z"),
+      },
+    });
+    expect(requestBody(calls[1] as FetchCall)).toMatchObject({
+      totalBudget: { amount: "42.00", currencyCode: "USD" },
+    });
+    expect(requestBody(calls[1] as FetchCall).dailyBudget).toBeUndefined();
+  });
+
+  test("rejects non-geo location targeting before touching the platform", async () => {
+    const result = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput({ targeting: { locations: ["San Francisco"] } }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("urn:li:geo");
+    expect(calls.length).toBe(0);
+
+    enqueue({}, { status: 201, headers: { "x-restli-id": "603407684" } });
+    enqueue({}, { status: 201, headers: { "x-restli-id": "145282384" } });
+    const geoResult = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput({ targeting: { locations: ["urn:li:geo:103644278", "101174742"] } }),
+    );
+    expect(geoResult.success).toBe(true);
+    expect(requestBody(calls[1] as FetchCall).targetingCriteria).toEqual({
+      include: {
+        and: [
+          {
+            or: {
+              "urn:li:adTargetingFacet:locations": ["urn:li:geo:103644278", "urn:li:geo:101174742"],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  test("pauses, activates, and deletes campaigns via Rest.li partial updates", async () => {
+    enqueue({}, { status: 204 });
+    await expect(
+      linkedinAdsProvider.pauseCampaign(credentials, "507404993/603407684/145282384"),
+    ).resolves.toMatchObject({ success: true });
+
+    enqueue({}, { status: 204 });
+    await expect(
+      linkedinAdsProvider.activateCampaign(credentials, "507404993/603407684/145282384"),
+    ).resolves.toMatchObject({ success: true });
+
+    enqueue({}, { status: 204 });
+    enqueue({}, { status: 204 });
+    await expect(
+      linkedinAdsProvider.deleteCampaign(credentials, "507404993/603407684/145282384"),
+    ).resolves.toEqual({ success: true });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaigns/145282384",
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaigns/145282384",
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaigns/145282384",
+      "https://api.linkedin.com/rest/adAccounts/507404993/adCampaignGroups/603407684",
+    ]);
+    expect(requestBody(calls[0] as FetchCall)).toEqual({ patch: { $set: { status: "PAUSED" } } });
+    expect(requestBody(calls[1] as FetchCall)).toEqual({ patch: { $set: { status: "ACTIVE" } } });
+    expect(requestBody(calls[2] as FetchCall)).toEqual({
+      patch: { $set: { status: "PENDING_DELETION" } },
+    });
+    expect(requestBody(calls[3] as FetchCall)).toEqual({
+      patch: { $set: { status: "PENDING_DELETION" } },
+    });
+    for (const call of calls) {
+      expect(requestHeaders(call)["X-RestLi-Method"]).toBe("PARTIAL_UPDATE");
+    }
+  });
+
+  test("updates the budget field the live campaign actually uses", async () => {
+    enqueue({ id: 145282384, dailyBudget: { amount: "18", currencyCode: "USD" } });
+    enqueue({}, { status: 204 });
+
+    const result = await linkedinAdsProvider.updateCampaign(
+      credentials,
+      "507404993/603407684/145282384",
+      { name: "Renamed", budgetAmount: 30 },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      externalCampaignId: "507404993/603407684/145282384",
+    });
+    expect(calls[0]?.init?.method ?? "GET").toBe("GET");
+    expect(requestBody(calls[1] as FetchCall)).toEqual({
+      patch: {
+        $set: {
+          name: "Renamed",
+          dailyBudget: { amount: "30.00", currencyCode: "USD" },
+        },
+      },
+    });
+  });
+
+  test("creates an inline dark-post creative attributed to the account's organization", async () => {
+    enqueue(AD_ACCOUNT_FIXTURE);
+    enqueue({}, { status: 201, headers: { "x-restli-id": "urn:li:sponsoredCreative:120491345" } });
+
+    const result = await linkedinAdsProvider.createCreative(
+      credentials,
+      "507404993",
+      "507404993/603407684/145282384",
+      {
+        campaignId: "campaign-local",
+        name: "Creative",
+        type: "image",
+        headline: "Try it",
+        primaryText: "Build faster",
+        callToAction: "download",
+        destinationUrl: "https://example.test/landing",
+        media: [
+          {
+            id: "00000000-0000-4000-8000-000000000001",
+            source: "upload",
+            url: "https://cdn.example.com/ad.png",
+            providerAssetId: "urn:li:image:C4E10AQFn10iWtKexVA",
+            type: "image",
+            order: 0,
+          },
+        ],
+      },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      externalCreativeId: "urn:li:sponsoredCreative:120491345",
+    });
+    expect(calls[0]?.url).toBe("https://api.linkedin.com/rest/adAccounts/507404993");
+    expect(calls[1]?.url).toBe(
+      "https://api.linkedin.com/rest/adAccounts/507404993/creatives?action=createInline",
+    );
+    expect(requestBody(calls[1] as FetchCall)).toEqual({
+      creative: {
+        inlineContent: {
+          post: {
+            adContext: {
+              dscAdAccount: "urn:li:sponsoredAccount:507404993",
+              dscStatus: "ACTIVE",
+            },
+            author: "urn:li:organization:2414183",
+            commentary: "Build faster",
+            visibility: "PUBLIC",
+            lifecycleState: "PUBLISHED",
+            isReshareDisabledByAuthor: true,
+            contentCallToActionLabel: "DOWNLOAD",
+            contentLandingPage: "https://example.test/landing",
+            content: {
+              media: {
+                title: "Try it",
+                id: "urn:li:image:C4E10AQFn10iWtKexVA",
+              },
+            },
+          },
+        },
+        campaign: "urn:li:sponsoredCampaign:145282384",
+        intendedStatus: "ACTIVE",
+        name: "Creative",
+      },
+    });
+  });
+
+  test("requires an uploaded provider asset before creating a creative", async () => {
+    const result = await linkedinAdsProvider.createCreative(
+      credentials,
+      "507404993",
+      "507404993/603407684/145282384",
+      {
+        campaignId: "campaign-local",
+        name: "Creative",
+        type: "image",
+        media: [
+          {
+            id: "00000000-0000-4000-8000-000000000001",
+            source: "upload",
+            url: "https://cdn.example.com/ad.png",
+            type: "image",
+            order: 0,
+          },
+        ],
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("providerAssetId");
+    expect(calls.length).toBe(0);
+  });
+
+  test("reads media processing status from the images API", async () => {
+    enqueue(IMAGE_GET_FIXTURE);
+
+    const status = await linkedinAdsProvider.getMediaStatus?.(credentials, "507404993", {
+      providerAssetResourceName: "urn:li:image:C4E10AQFn10iWtKexVA",
+    });
+
+    expect(calls[0]?.url).toBe(
+      "https://api.linkedin.com/rest/images/urn%3Ali%3Aimage%3AC4E10AQFn10iWtKexVA",
+    );
+    expect(status).toMatchObject({
+      success: true,
+      status: "AVAILABLE",
+      ready: true,
+      providerAssetId: "urn:li:image:C4E10AQFn10iWtKexVA",
+    });
+  });
+
+  test("sums adAnalytics rows into campaign metrics", async () => {
+    enqueue(ANALYTICS_FIXTURE);
+
+    const result = await linkedinAdsProvider.getCampaignMetrics(
+      credentials,
+      "507404993/603407684/145282384",
+      {
+        start: new Date("2024-05-28T00:00:00Z"),
+        end: new Date("2024-05-29T00:00:00Z"),
+      },
+    );
+
+    expect(calls[0]?.url).toBe(
+      "https://api.linkedin.com/rest/adAnalytics?q=analytics&pivot=CAMPAIGN&timeGranularity=ALL" +
+        "&dateRange=(start:(year:2024,month:5,day:28),end:(year:2024,month:5,day:29))" +
+        "&campaigns=List(urn%3Ali%3AsponsoredCampaign%3A145282384)" +
+        "&fields=impressions,clicks,landingPageClicks,costInLocalCurrency,externalWebsiteConversions,oneClickLeads,pivotValues",
+    );
+    expect(result.success).toBe(true);
+    expect(result.metrics?.spend).toBeCloseTo(19.91833, 5);
+    expect(result.metrics?.impressions).toBe(171);
+    expect(result.metrics?.clicks).toBe(11);
+    expect(result.metrics?.conversions).toBe(0);
+    expect(result.metrics?.ctr).toBeCloseTo(11 / 171, 6);
+    expect(result.metrics?.cpc).toBeCloseTo(19.91833 / 11, 5);
+    expect(result.metrics?.cpm).toBeCloseTo((19.91833 / 171) * 1000, 4);
+  });
+
+  test("propagates LinkedIn API errors as failed results without partial success", async () => {
+    enqueue(
+      { message: "Not enough permissions to access: adCampaignGroups.CREATE", status: 403 },
+      { status: 403 },
+    );
+
+    const result = await linkedinAdsProvider.createCampaign(
+      credentials,
+      "507404993",
+      makeCreateInput(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Not enough permissions");
+    expect(calls.length).toBe(1);
+  });
+});
+
+describe("advertisingService with the LinkedIn provider", () => {
+  const ORG_ID = "00000000-0000-4000-8000-000000000001";
+  const ACCOUNT_ID = "00000000-0000-4000-8000-000000000002";
+
+  const spies: Array<{ mockRestore: () => void }> = [];
+  function track<T extends { mockRestore: () => void }>(s: T): T {
+    spies.push(s);
+    return s;
+  }
+
+  afterEach(() => {
+    for (const s of spies.splice(0)) s.mockRestore();
+  });
+
+  test("account approval gate (#11619) blocks LinkedIn campaign creation before any charge or API call", async () => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: ACCOUNT_ID,
+        organization_id: ORG_ID,
+        platform: "linkedin",
+        external_account_id: "507404993",
+        status: "pending",
+      } as never),
+    );
+    const { contentSafetyService } = await import("../../content-safety");
+    const { creditsService } = await import("../../credits");
+    const safety = track(spyOn(contentSafetyService, "assertSafeForPublicUse"));
+    const deduct = track(spyOn(creditsService, "deductCredits"));
+
+    await expect(
+      advertisingService.createCampaign({
+        organizationId: ORG_ID,
+        adAccountId: ACCOUNT_ID,
+        name: "LinkedIn launch",
+        objective: "traffic",
+        budgetType: "daily",
+        budgetAmount: 50,
+      }),
+    ).rejects.toThrow(/must be approved/);
+
+    expect(safety).not.toHaveBeenCalled();
+    expect(deduct).not.toHaveBeenCalled();
+    expect(calls.length).toBe(0);
+  });
+
+  test("bid controls (#11621) persist in metadata and reach the real LinkedIn provider payload", async () => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: ACCOUNT_ID,
+        organization_id: ORG_ID,
+        platform: "linkedin",
+        external_account_id: "507404993",
+        status: "active",
+      } as never),
+    );
+    const { contentSafetyService } = await import("../../content-safety");
+    const { creditsService } = await import("../../credits");
+    track(spyOn(contentSafetyService, "assertSafeForPublicUse").mockResolvedValue({} as never));
+    track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+        transaction: { id: "tx-1" },
+      } as never),
+    );
+    track(
+      spyOn(
+        advertisingService as unknown as { getCredentials: () => Promise<unknown> },
+        "getCredentials",
+      ).mockResolvedValue({ accessToken: "linkedin-token" } as never),
+    );
+    const createRow = track(
+      spyOn(adCampaignsRepository, "create").mockImplementation(
+        async (data) => ({ ...(data as Record<string, unknown>), id: "campaign-row-1" }) as never,
+      ),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    enqueue({}, { status: 201, headers: { "x-restli-id": "603407684" } });
+    enqueue({}, { status: 201, headers: { "x-restli-id": "145282384" } });
+
+    const campaign = await advertisingService.createCampaign({
+      organizationId: ORG_ID,
+      adAccountId: ACCOUNT_ID,
+      name: "LinkedIn launch",
+      objective: "traffic",
+      budgetType: "daily",
+      budgetAmount: 50,
+      bidStrategy: "cpc",
+      optimizationGoal: "clicks",
+    });
+
+    expect(createRow.mock.calls[0]?.[0]).toMatchObject({
+      platform: "linkedin",
+      external_campaign_id: "507404993/603407684/145282384",
+      metadata: {
+        bid_strategy: "cpc",
+        optimization_goal: "clicks",
+      },
+    });
+    expect(campaign).toMatchObject({ external_campaign_id: "507404993/603407684/145282384" });
+
+    // The real provider request carried the mapped bid controls.
+    const campaignCall = calls.find((call) => call.url.endsWith("/adCampaigns"));
+    expect(campaignCall).toBeDefined();
+    expect(requestBody(campaignCall as FetchCall)).toMatchObject({
+      costType: "CPC",
+      optimizationTargetType: "MAX_CLICK",
+    });
+  });
+
+  test("provider failure fails the service call closed and refunds all charged credits", async () => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: ACCOUNT_ID,
+        organization_id: ORG_ID,
+        platform: "linkedin",
+        external_account_id: "507404993",
+        status: "active",
+      } as never),
+    );
+    const { contentSafetyService } = await import("../../content-safety");
+    const { creditsService } = await import("../../credits");
+    track(spyOn(contentSafetyService, "assertSafeForPublicUse").mockResolvedValue({} as never));
+    track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+        transaction: { id: "tx-1" },
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(
+      spyOn(
+        advertisingService as unknown as { getCredentials: () => Promise<unknown> },
+        "getCredentials",
+      ).mockResolvedValue({ accessToken: "linkedin-token" } as never),
+    );
+    const createRow = track(spyOn(adCampaignsRepository, "create"));
+
+    enqueue(
+      { message: "Not enough permissions to access: adCampaignGroups.CREATE", status: 403 },
+      { status: 403 },
+    );
+
+    await expect(
+      advertisingService.createCampaign({
+        organizationId: ORG_ID,
+        adAccountId: ACCOUNT_ID,
+        name: "LinkedIn launch",
+        objective: "traffic",
+        budgetType: "daily",
+        budgetAmount: 50,
+      }),
+    ).rejects.toThrow(/Not enough permissions/);
+
+    expect(createRow).not.toHaveBeenCalled();
+    // createCampaign charge + budget allocation are both refunded in one call.
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(refund.mock.calls[0]?.[0]).toMatchObject({
+      organizationId: ORG_ID,
+      amount: 0.5 + 50 * 1.1,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -1,0 +1,806 @@
+// LinkedIn Marketing API integration (versioned REST) -
+// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns
+
+import { logger } from "../../../utils/logger";
+import { downloadAdMedia, mediaFileName } from "../media-utils";
+import type {
+  AdAccountCredentials,
+  AdProvider,
+  AdProviderCampaignResult,
+  AdProviderCreativeResult,
+  AdProviderMediaStatusResult,
+  AdProviderMediaUploadResult,
+  AdProviderMetricsResult,
+  AdProviderValidationResult,
+  CampaignMetrics,
+  CreateCampaignInput,
+  CreateCreativeInput,
+  UpdateCampaignInput,
+  UploadMediaInput,
+} from "../types";
+
+const LINKEDIN_API_BASE_URL = "https://api.linkedin.com/rest";
+const LINKEDIN_OAUTH_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken";
+// "Worldwide" geo URN — the default include location when no targeting is given
+// (LinkedIn requires at least one location facet on every campaign).
+const LINKEDIN_WORLDWIDE_GEO = "urn:li:geo:92000000";
+
+function linkedinVersion(): string {
+  return process.env.LINKEDIN_ADS_API_VERSION ?? "202606";
+}
+
+interface LinkedInErrorBody {
+  message?: string;
+  code?: string;
+  serviceErrorCode?: number;
+  status?: number;
+}
+
+interface LinkedInCollection<T> {
+  elements?: T[];
+  metadata?: { nextPageToken?: string | null };
+  paging?: { start?: number; count?: number };
+}
+
+interface LinkedInAdAccount {
+  id: number | string;
+  name?: string | null;
+  status?: string;
+  currency?: string | null;
+  reference?: string | null;
+}
+
+interface LinkedInCampaign {
+  id?: number | string;
+  dailyBudget?: { amount: string; currencyCode: string };
+  totalBudget?: { amount: string; currencyCode: string };
+  status?: string;
+}
+
+interface LinkedInImageUploadInit {
+  value?: {
+    uploadUrl?: string;
+    uploadUrlExpiresAt?: number;
+    image?: string;
+  };
+}
+
+interface LinkedInVideoUploadInit {
+  value?: {
+    uploadInstructions?: Array<{ uploadUrl: string; firstByte: number; lastByte: number }>;
+    video?: string;
+    uploadToken?: string;
+  };
+}
+
+interface LinkedInMediaAsset {
+  id?: string;
+  status?: string;
+  downloadUrl?: string;
+}
+
+interface LinkedInAnalyticsElement {
+  impressions?: number;
+  clicks?: number;
+  landingPageClicks?: number;
+  costInLocalCurrency?: string | number;
+  externalWebsiteConversions?: number;
+  oneClickLeads?: number;
+}
+
+interface LinkedInRequestResult<T> {
+  body: T;
+  restliId?: string;
+}
+
+/**
+ * Performs a Rest.li 2.0.0 request against the versioned LinkedIn API.
+ * `rawQuery` is appended verbatim because Rest.li structured query syntax
+ * (`q=search&search=(status:(values:List(ACTIVE)))`) must keep its parens,
+ * colons, and commas unencoded while URN values inside List() stay encoded.
+ */
+async function linkedinRequest<T>(
+  endpoint: string,
+  credentials: AdAccountCredentials,
+  options: RequestInit & { rawQuery?: string } = {},
+): Promise<LinkedInRequestResult<T>> {
+  const url = `${LINKEDIN_API_BASE_URL}${endpoint}${options.rawQuery ? `?${options.rawQuery}` : ""}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${credentials.accessToken}`,
+      "LinkedIn-Version": linkedinVersion(),
+      "X-Restli-Protocol-Version": "2.0.0",
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+  const text = await response.text();
+  let body: T | LinkedInErrorBody = {} as T;
+  if (text) {
+    try {
+      body = JSON.parse(text) as T;
+    } catch {
+      body = {} as T;
+    }
+  }
+  if (!response.ok) {
+    const error = body as LinkedInErrorBody;
+    throw new Error(error.message || `LinkedIn API error: ${response.status}`);
+  }
+  return {
+    body: body as T,
+    restliId:
+      response.headers.get("x-restli-id") ?? response.headers.get("x-linkedin-id") ?? undefined,
+  };
+}
+
+function sponsoredAccountUrn(accountId: string): string {
+  return `urn:li:sponsoredAccount:${accountId}`;
+}
+
+function encodeUrn(urn: string): string {
+  return urn.replaceAll(":", "%3A");
+}
+
+function moneyAmount(amount: number): string {
+  return amount.toFixed(2);
+}
+
+function mapObjectiveToLinkedIn(objective: string): string {
+  const mapping: Record<string, string> = {
+    awareness: "BRAND_AWARENESS",
+    traffic: "WEBSITE_VISIT",
+    engagement: "ENGAGEMENT",
+    leads: "LEAD_GENERATION",
+    // LinkedIn has no app-install objective; route app promotion to site visits.
+    app_promotion: "WEBSITE_VISIT",
+    sales: "WEBSITE_CONVERSION",
+    conversions: "WEBSITE_CONVERSION",
+  };
+  return mapping[objective] || "WEBSITE_VISIT";
+}
+
+// Auto-bidding target per objective, per the allowable-combinations table:
+// https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ad-budget-pricing-type-combinations
+const AUTO_BID_BY_OBJECTIVE: Record<string, string> = {
+  BRAND_AWARENESS: "MAX_IMPRESSION",
+  WEBSITE_VISIT: "MAX_CLICK",
+  ENGAGEMENT: "MAX_CLICK",
+  LEAD_GENERATION: "MAX_LEAD",
+  WEBSITE_CONVERSION: "MAX_CONVERSION",
+  JOB_APPLICANT: "MAX_CLICK",
+  VIDEO_VIEW: "MAX_VIDEO_VIEW",
+};
+
+/**
+ * Maps the platform-neutral campaign bid controls (#11621) onto LinkedIn's
+ * costType / optimizationTargetType pair. Auto-bidding targets are always used
+ * so campaigns never require a manual unitCost:
+ *   - bidStrategy cpm/cpc selects how LinkedIn charges (costType CPM/CPC)
+ *   - bidStrategy cpa has no LinkedIn cost type; it maps to conversion
+ *     optimization (MAX_CONVERSION) charged by impressions (CPM)
+ *   - optimizationGoal reach/clicks/conversions overrides the optimization
+ *     target (MAX_IMPRESSION/MAX_CLICK/MAX_CONVERSION)
+ */
+export function mapBidControlsToLinkedInCampaign(
+  input: Pick<CreateCampaignInput, "bidStrategy" | "optimizationGoal" | "objective">,
+): { costType: string; optimizationTargetType: string } {
+  const objectiveType = mapObjectiveToLinkedIn(input.objective);
+  let costType: string;
+  if (input.bidStrategy === "cpm" || input.bidStrategy === "cpa") {
+    costType = "CPM";
+  } else if (input.bidStrategy === "cpc") {
+    costType = "CPC";
+  } else {
+    costType = objectiveType === "BRAND_AWARENESS" ? "CPM" : "CPC";
+  }
+
+  let optimizationTargetType: string;
+  if (input.optimizationGoal === "reach") {
+    optimizationTargetType = "MAX_IMPRESSION";
+  } else if (input.optimizationGoal === "clicks") {
+    optimizationTargetType = "MAX_CLICK";
+  } else if (input.optimizationGoal === "conversions") {
+    optimizationTargetType = "MAX_CONVERSION";
+  } else if (input.bidStrategy === "cpa") {
+    optimizationTargetType = "MAX_CONVERSION";
+  } else {
+    optimizationTargetType = AUTO_BID_BY_OBJECTIVE[objectiveType] ?? "MAX_CLICK";
+  }
+  return { costType, optimizationTargetType };
+}
+
+function mapCtaToLinkedIn(cta?: string): string {
+  const mapping: Record<string, string> = {
+    learn_more: "LEARN_MORE",
+    shop_now: "VIEW_NOW",
+    sign_up: "SIGN_UP",
+    download: "DOWNLOAD",
+    contact_us: "REQUEST_DEMO",
+    get_offer: "UNLOCK_FULL_DOCUMENT",
+    book_now: "REGISTER",
+    watch_more: "VIEW_NOW",
+    apply_now: "APPLY",
+    subscribe: "SUBSCRIBE",
+  };
+  return mapping[cta || "learn_more"] || "LEARN_MORE";
+}
+
+/**
+ * LinkedIn campaigns must target at least one location. Location entries pass
+ * through as urn:li:geo URNs (numeric ids are wrapped); anything else fails
+ * loudly instead of guessing a geo mapping. No targeting means Worldwide.
+ */
+function buildTargetingCriteria(input: CreateCampaignInput): Record<string, unknown> {
+  const locations = (input.targeting?.locations ?? []).map((location) => {
+    const trimmed = location.trim();
+    if (trimmed.startsWith("urn:li:geo:")) return trimmed;
+    if (/^\d+$/.test(trimmed)) return `urn:li:geo:${trimmed}`;
+    throw new Error(
+      `LinkedIn location targeting requires urn:li:geo URNs or numeric geo ids; got "${location}"`,
+    );
+  });
+  return {
+    include: {
+      and: [
+        {
+          or: {
+            "urn:li:adTargetingFacet:locations": locations.length
+              ? locations
+              : [LINKEDIN_WORLDWIDE_GEO],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function splitExternalCampaignId(externalCampaignId: string): {
+  accountId: string;
+  campaignGroupId: string;
+  campaignId: string;
+} {
+  const [accountId, campaignGroupId, campaignId] = externalCampaignId.split("/");
+  if (!accountId || !campaignGroupId || !campaignId) {
+    throw new Error(
+      "LinkedIn campaign operations require a composite accountId/campaignGroupId/campaignId id",
+    );
+  }
+  return { accountId, campaignGroupId, campaignId };
+}
+
+async function partialUpdate(
+  endpoint: string,
+  credentials: AdAccountCredentials,
+  set: Record<string, unknown>,
+): Promise<void> {
+  await linkedinRequest(endpoint, credentials, {
+    method: "POST",
+    headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
+    body: JSON.stringify({ patch: { $set: set } }),
+  });
+}
+
+async function setCampaignStatus(
+  credentials: AdAccountCredentials,
+  externalCampaignId: string,
+  status: "ACTIVE" | "PAUSED" | "PENDING_DELETION",
+): Promise<void> {
+  const { accountId, campaignId } = splitExternalCampaignId(externalCampaignId);
+  await partialUpdate(
+    `/adAccounts/${encodeURIComponent(accountId)}/adCampaigns/${encodeURIComponent(campaignId)}`,
+    credentials,
+    { status },
+  );
+}
+
+async function getAdAccount(
+  credentials: AdAccountCredentials,
+  accountId: string,
+): Promise<LinkedInAdAccount> {
+  const { body } = await linkedinRequest<LinkedInAdAccount>(
+    `/adAccounts/${encodeURIComponent(accountId)}`,
+    credentials,
+  );
+  return body;
+}
+
+/**
+ * Resolves the organization URN that posts/media are attributed to: the
+ * explicit page override if given, else the ad account's `reference`.
+ */
+async function resolveOrganizationUrn(
+  credentials: AdAccountCredentials,
+  accountId: string,
+  pageId?: string,
+): Promise<string> {
+  if (pageId) {
+    return pageId.startsWith("urn:") ? pageId : `urn:li:organization:${pageId}`;
+  }
+  const account = await getAdAccount(credentials, accountId);
+  if (!account.reference) {
+    throw new Error(
+      "LinkedIn ad account has no organization reference; set one in Campaign Manager or pass pageId",
+    );
+  }
+  return account.reference;
+}
+
+function analyticsDate(date: Date): string {
+  return `(year:${date.getUTCFullYear()},month:${date.getUTCMonth() + 1},day:${date.getUTCDate()})`;
+}
+
+function sumAnalytics(elements: LinkedInAnalyticsElement[]): CampaignMetrics {
+  let spend = 0;
+  let impressions = 0;
+  let clicks = 0;
+  let conversions = 0;
+  for (const element of elements) {
+    spend += Number(element.costInLocalCurrency ?? 0) || 0;
+    impressions += element.impressions ?? 0;
+    clicks += element.clicks ?? element.landingPageClicks ?? 0;
+    conversions += (element.externalWebsiteConversions ?? 0) + (element.oneClickLeads ?? 0);
+  }
+  return {
+    spend,
+    impressions,
+    clicks,
+    conversions,
+    ctr: impressions > 0 ? clicks / impressions : 0,
+    cpc: clicks > 0 ? spend / clicks : 0,
+    cpm: impressions > 0 ? (spend / impressions) * 1000 : 0,
+  };
+}
+
+export const linkedinAdsProvider: AdProvider = {
+  platform: "linkedin",
+
+  async validateCredentials(
+    credentials: AdAccountCredentials,
+  ): Promise<AdProviderValidationResult> {
+    const accounts = await this.listAdAccounts(credentials).catch((error) => {
+      logger.error("[LinkedInAds] Validation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    });
+    if (accounts.length === 0) {
+      return { valid: false, error: "No LinkedIn ad accounts found or invalid credentials" };
+    }
+    return { valid: true, accountId: accounts[0].id, accountName: accounts[0].name };
+  },
+
+  async refreshToken(refreshToken: string): Promise<{
+    accessToken: string;
+    refreshToken?: string;
+    expiresAt?: Date;
+  }> {
+    const clientId = process.env.LINKEDIN_ADS_CLIENT_ID;
+    const clientSecret = process.env.LINKEDIN_ADS_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+      throw new Error("LinkedIn Ads client credentials are not configured");
+    }
+    const response = await fetch(LINKEDIN_OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }).toString(),
+    });
+    const json = (await response.json()) as {
+      access_token?: string;
+      expires_in?: number;
+      refresh_token?: string;
+      error_description?: string;
+    };
+    if (!response.ok || !json.access_token) {
+      throw new Error(json.error_description || "Failed to refresh LinkedIn token");
+    }
+    return {
+      accessToken: json.access_token,
+      refreshToken: json.refresh_token,
+      expiresAt: json.expires_in ? new Date(Date.now() + json.expires_in * 1000) : undefined,
+    };
+  },
+
+  async listAdAccounts(
+    credentials: AdAccountCredentials,
+  ): Promise<Array<{ id: string; name: string }>> {
+    const { body } = await linkedinRequest<LinkedInCollection<LinkedInAdAccount>>(
+      "/adAccounts",
+      credentials,
+      { rawQuery: "q=search&search=(status:(values:List(ACTIVE)))&pageSize=1000" },
+    );
+    return (body.elements ?? []).map((account) => ({
+      id: String(account.id),
+      name: account.name || String(account.id),
+    }));
+  },
+
+  async createCampaign(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    input: CreateCampaignInput,
+  ): Promise<AdProviderCampaignResult> {
+    try {
+      const accountUrn = sponsoredAccountUrn(accountId);
+      const currency = input.budgetCurrency || "USD";
+      const start = (input.startDate ?? new Date()).getTime();
+      const end = input.endDate?.getTime();
+      if (input.budgetType === "lifetime" && end === undefined) {
+        throw new Error("LinkedIn lifetime (total) budgets require an end date");
+      }
+      // Validate everything that can fail BEFORE creating the campaign group,
+      // so invalid input never leaves an orphan group on the platform.
+      const targetingCriteria = buildTargetingCriteria(input);
+      const { costType, optimizationTargetType } = mapBidControlsToLinkedInCampaign(input);
+
+      const groupResult = await linkedinRequest<Record<string, never>>(
+        `/adAccounts/${encodeURIComponent(accountId)}/adCampaignGroups`,
+        credentials,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            account: accountUrn,
+            name: `${input.name} Group`,
+            runSchedule: { start, ...(end !== undefined ? { end } : {}) },
+            status: "ACTIVE",
+            ...(input.budgetType === "lifetime"
+              ? { totalBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } }
+              : {}),
+          }),
+        },
+      );
+      const campaignGroupId = groupResult.restliId;
+      if (!campaignGroupId) throw new Error("LinkedIn campaign group create returned no id");
+
+      const budget =
+        input.budgetType === "lifetime"
+          ? { totalBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } }
+          : { dailyBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } };
+
+      const campaignResult = await linkedinRequest<Record<string, never>>(
+        `/adAccounts/${encodeURIComponent(accountId)}/adCampaigns`,
+        credentials,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            account: accountUrn,
+            campaignGroup: `urn:li:sponsoredCampaignGroup:${campaignGroupId}`,
+            name: input.name,
+            type: "SPONSORED_UPDATES",
+            objectiveType: mapObjectiveToLinkedIn(input.objective),
+            costType,
+            optimizationTargetType,
+            creativeSelection: "OPTIMIZED",
+            audienceExpansionEnabled: false,
+            offsiteDeliveryEnabled: false,
+            locale: { country: "US", language: "en" },
+            runSchedule: { start, ...(end !== undefined ? { end } : {}) },
+            targetingCriteria,
+            status: "PAUSED",
+            ...budget,
+          }),
+        },
+      );
+      const campaignId = campaignResult.restliId;
+      if (!campaignId) throw new Error("LinkedIn campaign create returned no id");
+
+      return {
+        success: true,
+        externalCampaignId: `${accountId}/${campaignGroupId}/${campaignId}`,
+      };
+    } catch (error) {
+      logger.error("[LinkedInAds] Campaign creation failed", {
+        accountId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async updateCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+    input: UpdateCampaignInput,
+  ): Promise<AdProviderCampaignResult> {
+    try {
+      const { accountId, campaignId } = splitExternalCampaignId(externalCampaignId);
+      const set: Record<string, unknown> = {};
+      if (input.name) set.name = input.name;
+      if (input.startDate || input.endDate) {
+        set.runSchedule = {
+          ...(input.startDate ? { start: input.startDate.getTime() } : {}),
+          ...(input.endDate ? { end: input.endDate.getTime() } : {}),
+        };
+      }
+      if (input.budgetAmount !== undefined) {
+        // Patch whichever budget field the live campaign actually uses.
+        const { body: campaign } = await linkedinRequest<LinkedInCampaign>(
+          `/adAccounts/${encodeURIComponent(accountId)}/adCampaigns/${encodeURIComponent(campaignId)}`,
+          credentials,
+        );
+        const budgetField =
+          campaign.totalBudget && !campaign.dailyBudget ? "totalBudget" : "dailyBudget";
+        const currencyCode =
+          campaign.dailyBudget?.currencyCode ?? campaign.totalBudget?.currencyCode ?? "USD";
+        set[budgetField] = { amount: moneyAmount(input.budgetAmount), currencyCode };
+      }
+      if (Object.keys(set).length > 0) {
+        await partialUpdate(
+          `/adAccounts/${encodeURIComponent(accountId)}/adCampaigns/${encodeURIComponent(campaignId)}`,
+          credentials,
+          set,
+        );
+      }
+      return { success: true, externalCampaignId };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async pauseCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<AdProviderCampaignResult> {
+    try {
+      await setCampaignStatus(credentials, externalCampaignId, "PAUSED");
+      return { success: true, externalCampaignId };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async activateCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<AdProviderCampaignResult> {
+    try {
+      await setCampaignStatus(credentials, externalCampaignId, "ACTIVE");
+      return { success: true, externalCampaignId };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async deleteCampaign(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const { accountId, campaignGroupId } = splitExternalCampaignId(externalCampaignId);
+      // Non-DRAFT entities are deleted by moving them to PENDING_DELETION.
+      await setCampaignStatus(credentials, externalCampaignId, "PENDING_DELETION");
+      await partialUpdate(
+        `/adAccounts/${encodeURIComponent(accountId)}/adCampaignGroups/${encodeURIComponent(campaignGroupId)}`,
+        credentials,
+        { status: "PENDING_DELETION" },
+      );
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async createCreative(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    externalCampaignId: string,
+    input: CreateCreativeInput,
+  ): Promise<AdProviderCreativeResult> {
+    try {
+      const { campaignId } = splitExternalCampaignId(externalCampaignId);
+      const primaryMedia = [...input.media].sort((left, right) => left.order - right.order)[0];
+      if (!primaryMedia?.providerAssetId) {
+        return {
+          success: false,
+          error:
+            "LinkedIn creatives require media.providerAssetId from a prior LinkedIn media upload",
+        };
+      }
+      const author = await resolveOrganizationUrn(credentials, accountId, input.pageId);
+
+      const result = await linkedinRequest<Record<string, never>>(
+        `/adAccounts/${encodeURIComponent(accountId)}/creatives`,
+        credentials,
+        {
+          rawQuery: "action=createInline",
+          method: "POST",
+          body: JSON.stringify({
+            creative: {
+              inlineContent: {
+                post: {
+                  adContext: {
+                    dscAdAccount: sponsoredAccountUrn(accountId),
+                    dscStatus: "ACTIVE",
+                  },
+                  author,
+                  commentary:
+                    input.primaryText || input.description || input.headline || input.name,
+                  visibility: "PUBLIC",
+                  lifecycleState: "PUBLISHED",
+                  isReshareDisabledByAuthor: true,
+                  ...(input.destinationUrl
+                    ? {
+                        contentCallToActionLabel: mapCtaToLinkedIn(input.callToAction),
+                        contentLandingPage: input.destinationUrl,
+                      }
+                    : {}),
+                  content: {
+                    media: {
+                      ...(input.headline ? { title: input.headline } : {}),
+                      id: primaryMedia.providerAssetId,
+                    },
+                  },
+                },
+              },
+              campaign: `urn:li:sponsoredCampaign:${campaignId}`,
+              intendedStatus: "ACTIVE",
+              name: input.name,
+            },
+          }),
+        },
+      );
+      if (!result.restliId) throw new Error("LinkedIn creative create returned no id");
+      return { success: true, externalCreativeId: result.restliId };
+    } catch (error) {
+      logger.error("[LinkedInAds] Creative creation failed", {
+        accountId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async uploadMedia(
+    credentials: AdAccountCredentials,
+    accountId: string,
+    input: UploadMediaInput,
+  ): Promise<AdProviderMediaUploadResult> {
+    try {
+      const owner = await resolveOrganizationUrn(credentials, accountId);
+      const media = await downloadAdMedia(input.url, {
+        fileName: mediaFileName({ name: input.name, url: input.url, contentType: input.mimeType }),
+      });
+      const bytes = media.bytes.slice().buffer as ArrayBuffer;
+
+      if (input.type === "image") {
+        const init = await linkedinRequest<LinkedInImageUploadInit>("/images", credentials, {
+          rawQuery: "action=initializeUpload",
+          method: "POST",
+          body: JSON.stringify({ initializeUploadRequest: { owner } }),
+        });
+        const uploadUrl = init.body.value?.uploadUrl;
+        const imageUrn = init.body.value?.image;
+        if (!uploadUrl || !imageUrn) {
+          throw new Error("LinkedIn image upload initialization returned no upload URL");
+        }
+        const upload = await fetch(uploadUrl, {
+          method: "PUT",
+          headers: { Authorization: `Bearer ${credentials.accessToken}` },
+          body: bytes,
+        });
+        if (!upload.ok) throw new Error(`LinkedIn image upload failed: ${upload.status}`);
+        return {
+          success: true,
+          providerAssetId: imageUrn,
+          providerAssetUrl: input.url,
+          providerAssetResourceName: imageUrn,
+          metadata: { fileName: media.fileName },
+        };
+      }
+
+      const init = await linkedinRequest<LinkedInVideoUploadInit>("/videos", credentials, {
+        rawQuery: "action=initializeUpload",
+        method: "POST",
+        body: JSON.stringify({
+          initializeUploadRequest: {
+            owner,
+            fileSizeBytes: bytes.byteLength,
+            uploadCaptions: false,
+            uploadThumbnail: false,
+          },
+        }),
+      });
+      const videoUrn = init.body.value?.video;
+      const uploadToken = init.body.value?.uploadToken ?? "";
+      const instructions = init.body.value?.uploadInstructions ?? [];
+      if (!videoUrn || instructions.length === 0) {
+        throw new Error("LinkedIn video upload initialization returned no upload instructions");
+      }
+      const uploadedPartIds: string[] = [];
+      for (const instruction of instructions) {
+        const part = await fetch(instruction.uploadUrl, {
+          method: "PUT",
+          headers: { Authorization: `Bearer ${credentials.accessToken}` },
+          body: bytes.slice(instruction.firstByte, instruction.lastByte + 1),
+        });
+        if (!part.ok) throw new Error(`LinkedIn video part upload failed: ${part.status}`);
+        const etag = part.headers.get("etag");
+        if (!etag) throw new Error("LinkedIn video part upload returned no ETag");
+        uploadedPartIds.push(etag);
+      }
+      await linkedinRequest("/videos", credentials, {
+        rawQuery: "action=finalizeUpload",
+        method: "POST",
+        body: JSON.stringify({
+          finalizeUploadRequest: { video: videoUrn, uploadToken, uploadedPartIds },
+        }),
+      });
+      return {
+        success: true,
+        providerAssetId: videoUrn,
+        providerAssetUrl: input.url,
+        providerAssetResourceName: videoUrn,
+        metadata: { fileName: media.fileName, parts: uploadedPartIds.length },
+      };
+    } catch (error) {
+      logger.error("[LinkedInAds] Media upload failed", {
+        accountId,
+        type: input.type,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async getMediaStatus(
+    credentials: AdAccountCredentials,
+    _accountId: string,
+    input: { providerAssetResourceName: string },
+  ): Promise<AdProviderMediaStatusResult> {
+    try {
+      const urn = input.providerAssetResourceName;
+      const endpoint = urn.startsWith("urn:li:video:") ? "/videos" : "/images";
+      const { body } = await linkedinRequest<LinkedInMediaAsset>(
+        `${endpoint}/${encodeUrn(urn)}`,
+        credentials,
+      );
+      const status = body.status ?? "UNKNOWN";
+      return {
+        success: true,
+        providerAssetId: urn,
+        providerAssetUrl: body.downloadUrl,
+        providerAssetResourceName: urn,
+        status,
+        ready: status === "AVAILABLE",
+      };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
+  async getCampaignMetrics(
+    credentials: AdAccountCredentials,
+    externalCampaignId: string,
+    dateRange?: { start: Date; end: Date },
+  ): Promise<AdProviderMetricsResult> {
+    try {
+      const { campaignId } = splitExternalCampaignId(externalCampaignId);
+      const end = dateRange?.end ?? new Date();
+      const start = dateRange?.start ?? new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const campaignUrn = encodeUrn(`urn:li:sponsoredCampaign:${campaignId}`);
+      const rawQuery = [
+        "q=analytics",
+        "pivot=CAMPAIGN",
+        "timeGranularity=ALL",
+        `dateRange=(start:${analyticsDate(start)},end:${analyticsDate(end)})`,
+        `campaigns=List(${campaignUrn})`,
+        "fields=impressions,clicks,landingPageClicks,costInLocalCurrency,externalWebsiteConversions,oneClickLeads,pivotValues",
+      ].join("&");
+      const { body } = await linkedinRequest<LinkedInCollection<LinkedInAnalyticsElement>>(
+        "/adAnalytics",
+        credentials,
+        { rawQuery },
+      );
+      return { success: true, metrics: sumAnalytics(body.elements ?? []) };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+};

--- a/packages/cloud/shared/src/lib/services/advertising/schemas.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const AdPlatformSchema = z.enum(["meta", "google", "tiktok"]);
+export const AdPlatformSchema = z.enum(["meta", "google", "tiktok", "linkedin"]);
 
 export const CampaignObjectiveSchema = z.enum([
   "awareness",

--- a/packages/cloud/shared/src/lib/services/advertising/types.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/types.ts
@@ -440,6 +440,7 @@ export const AD_CREDIT_RATES = {
     meta: 1.1,
     google: 1.1,
     tiktok: 1.1,
+    linkedin: 1.1,
   },
 
   // Analytics/reports


### PR DESCRIPTION
Closes #11663. Refs #11361.

## What

Adds **`linkedin`** as a cloud advertising platform, wired end-to-end into the existing `AdProvider` contract — same shape as the sibling X/Twitter (#11662) and Reddit (#11661) lanes:

- `AdPlatform` (DB typing + `organization_urn` metadata), `AdPlatformSchema`, spend markup (`1.1`), provider registry, and the app-promotion route platform enum.
- New `packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts` against the **versioned LinkedIn Marketing API** (`api.linkedin.com/rest`, `LinkedIn-Version` + `X-Restli-Protocol-Version: 2.0.0`, OAuth2 bearer):
  - **Account discovery/validation** via the `adAccounts` search finder (Rest.li structured query, raw-query builder so parens/colons stay unencoded).
  - **Campaign create** = campaign group + **paused** campaign (`x-restli-id` extraction), objective mapping, daily/total budget mapping (lifetime requires an end date — validated fail-fast), geo targeting (`urn:li:geo` URNs pass through, numeric ids wrapped, free-text fails loudly **before** any platform call, Worldwide default).
  - **#11621 bid controls** → `costType`/`optimizationTargetType` per the documented allowable-combinations table (`cpm`→CPM, `cpc`→CPC, `cpa`→CPM+MAX_CONVERSION; reach/clicks/conversions→MAX_IMPRESSION/MAX_CLICK/MAX_CONVERSION; objective-default auto-bid otherwise; never a manual `unitCost`).
  - **Update/pause/activate** via Rest.li `PARTIAL_UPDATE` patches (budget patch targets whichever of dailyBudget/totalBudget the live campaign uses); **delete** via `PENDING_DELETION` for campaign then group.
  - **Media upload** through the Images/Videos APIs (`initializeUpload` → byte PUT → `finalizeUpload` for multipart video), owner resolved from the ad account's organization `reference`; `getMediaStatus` maps `AVAILABLE`→ready.
  - **Creative create** as an inline dark post (`creatives?action=createInline`) with CTA label + landing-page mapping; requires a prior provider asset (fail-closed otherwise).
  - **Analytics** via the `adAnalytics` analytics finder (CAMPAIGN pivot, explicit `fields`, costInLocalCurrency/externalWebsiteConversions/oneClickLeads mapping).
  - OAuth2 `refresh_token` grant (`LINKEDIN_ADS_CLIENT_ID`/`LINKEDIN_ADS_CLIENT_SECRET`).

## Tests

`linkedin.test.ts` — **16 pass / 0 fail (78 asserts)**, fixtures **lifted from the Microsoft Learn LinkedIn Marketing API sample responses** (account search, ad account fetch, image GET, adAnalytics rows, `urn:li:sponsoredCreative:120491345`), not invented. Includes a service-integration block that drives `advertisingService.createCampaign` with the **real registered provider** (mocked `fetch`):

- **#11619 approval gate applies automatically**: a `pending` LinkedIn account is rejected before content safety, credits, or any LinkedIn call.
- **#11621 bid metadata applies automatically**: `bid_strategy`/`optimization_goal` persist to campaign metadata and the provider payload carries `costType: CPC` + `optimizationTargetType: MAX_CLICK`.
- **Money path fail-closed**: LinkedIn 403 → service throws, persists nothing, refunds the full charge (`0.5 + 50×1.1`) exactly once.

`linkedin.real.test.ts` — credential-gated live lane; **loud-skips** (`[LinkedInAdsRealTest] SKIPPED: set LINKEDIN_ADS_ACCESS_TOKEN ...`) without credentials.

## Verification (local = merge gate)

- `bun test .../providers/linkedin.test.ts` — 16 pass / 0 fail (re-run green after rebase onto latest develop)
- Existing ad suites: 6 service files — 58 pass / 0 fail; 3 API route files — 14 pass / 0 fail
- `bun run --cwd packages/cloud/shared typecheck` ✅ · `bun run --cwd packages/cloud/api typecheck` ✅ · biome clean on touched files
- Evidence: `.github/issue-evidence/11663-linkedin-ads-provider.md` (docs reviewed, fixture provenance, N/A items with reasons)

Live-credential evidence is deferred until operator LinkedIn Ads API credentials are provisioned (the real lane is in place), matching the issue's post-merge live-lane acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)