### PR TITLE
fix(cloud): register 0168_cloud_files migration in _journal.json + registration gate

### DIFF
--- a/.github/issue-evidence/11758-cloud-files-migration-journal.md
+++ b/.github/issue-evidence/11758-cloud-files-migration-journal.md
@@ -1,0 +1,62 @@
+# #11758 follow-up — register 0168_cloud_files in the migration journal
+
+## Defect
+
+PR #11758 (org-scoped `/api/v1/files`, closes #11743) added
+`packages/cloud/shared/src/db/migrations/0168_cloud_files.sql` but did NOT
+register it in `migrations/meta/_journal.json`. The deploy pipeline's
+migrate-db step applies only journal entries, so the `cloud_files` table
+would never be created in staging/prod and every `/api/v1/files` request
+would 500 against the missing table. Same failure class as #11493.
+
+`drizzle-kit check` does not catch this (verified on develop @ 126166cecc:
+"Everything's fine" with the file unregistered) — it only validates
+collisions among registered entries.
+
+## Fix
+
+- `_journal.json`: entry `{ idx: 166, tag: "0168_cloud_files" }`.
+- New gate: `src/db/migration-journal-registration.test.ts` — every
+  non-`.down` migration `.sql` must have a matching journal tag (and vice
+  versa), idx contiguous, tags unique.
+
+## Fail-without-fix proof (real run)
+
+Gate test against develop's unregistered journal:
+
+```
+(fail) migrations/meta/_journal.json registration > every migration .sql file is registered in the journal
+ 2 pass / 1 fail   (error names 0168_cloud_files)
+```
+
+With the journal entry: `3 pass / 0 fail`.
+
+## Migration applies for real (PGlite, raw SQL verbatim)
+
+```
+0168_cloud_files.sql applied OK
+re-apply idempotent OK
+insert OK
+rows after org cascade delete: 0
+ALL MIGRATION CHECKS PASSED
+```
+
+## Drive-by: develop-red test fix
+
+`src/db/repositories/__tests__/app-frontend-deployments.test.ts` has been
+red on develop since #10863 added `appReviewStatusEnum` to the apps schema
+(pushSchema failed: `type "app_review_status" does not exist`). Added the
+enum to the test's schema set.
+
+## Validation (local, all real)
+
+- `bun test --isolate src/db/repositories/__tests__/ src/lib/services/cloud-files.test.ts src/db/migration-journal-registration.test.ts` — 49 pass / 0 fail
+- `bun run --cwd packages/cloud/shared db:check-migrations` — Everything's fine
+- `bun run --cwd packages/cloud/shared typecheck` — clean
+- `bun run --cwd packages/cloud/api typecheck` — clean
+- Biome on changed files — clean
+
+## N/A
+
+- UI screenshots/video: N/A — migration-journal + test-only change, no UI surface.
+- Real-LLM trajectories: N/A — no agent/action/provider/prompt/model behavior changed.

--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Migration ↔ journal registration gate.
+ *
+ * The deploy pipeline applies ONLY the migrations listed in
+ * `migrations/meta/_journal.json` — a `.sql` file that is not registered
+ * there never runs, so the code that depends on it ships against a stale
+ * schema and fails at runtime in staging/prod. This has now happened twice
+ * (#11493, and #11758's `0168_cloud_files.sql`), and `drizzle-kit check`
+ * does NOT catch it (it only validates collisions among registered
+ * entries). This suite is the missing gate.
+ *
+ * Rules enforced:
+ *  - every `NNNN_name.sql` file (except `.down.sql` rollbacks) has exactly
+ *    one journal entry whose tag is the filename stem, and vice versa;
+ *  - journal `idx` values are contiguous from 0 (drizzle's migrator relies
+ *    on ordering);
+ *  - tags are unique.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+function journalEntries(): JournalEntry[] {
+  const raw = readFileSync(join(MIGRATIONS_DIR, "meta", "_journal.json"), "utf8");
+  return (JSON.parse(raw) as { entries: JournalEntry[] }).entries;
+}
+
+function migrationFileStems(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql") && !name.endsWith(".down.sql"))
+    .map((name) => name.slice(0, -".sql".length))
+    .sort();
+}
+
+describe("migrations/meta/_journal.json registration", () => {
+  test("every migration .sql file is registered in the journal", () => {
+    const stems = migrationFileStems();
+    const tags = new Set(journalEntries().map((e) => e.tag));
+    const unregistered = stems.filter((stem) => !tags.has(stem));
+    expect(
+      unregistered,
+      `Unregistered migration file(s): ${unregistered.join(", ")} — add a _journal.json entry or the deploy pipeline will never apply them`,
+    ).toEqual([]);
+  });
+
+  test("every journal entry has a matching .sql file", () => {
+    const stems = new Set(migrationFileStems());
+    const missing = journalEntries()
+      .map((e) => e.tag)
+      .filter((tag) => !stems.has(tag));
+    expect(missing, `Journal entries without a migration file: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  test("journal idx values are contiguous from 0 and tags are unique", () => {
+    const entries = journalEntries();
+    expect(entries.map((e) => e.idx)).toEqual(entries.map((_, i) => i));
+    expect(new Set(entries.map((e) => e.tag)).size).toBe(entries.length);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1170,6 +1170,13 @@
       "when": 1781396460000,
       "tag": "0168_ad_accounts_pending_default",
       "breakpoints": true
+    },
+    {
+      "idx": 167,
+      "version": "7",
+      "when": 1781482800000,
+      "tag": "0168_cloud_files",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/app-frontend-deployments.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/app-frontend-deployments.test.ts
@@ -28,7 +28,12 @@ import { and, eq } from "drizzle-orm";
 import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../../lib/storage/r2-runtime-binding";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { appFrontendDeployments } from "../../schemas/app-frontend-deployments";
-import { appDeploymentStatusEnum, apps, userDatabaseStatusEnum } from "../../schemas/apps";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  userDatabaseStatusEnum,
+} from "../../schemas/apps";
 import { organizations } from "../../schemas/organizations";
 import { users } from "../../schemas/users";
 import { appFrontendDeploymentsRepository } from "../app-frontend-deployments";
@@ -113,6 +118,7 @@ beforeAll(async () => {
       apps,
       appFrontendDeployments,
       appDeploymentStatusEnum,
+      appReviewStatusEnum,
       userDatabaseStatusEnum,
     };
     const { apply } = await pushSchema(schema as never, dbWrite as never);


### PR DESCRIPTION
## Summary

Follow-up to #11758 (org-scoped `/api/v1/files`, closes #11743): the merged PR added `packages/cloud/shared/src/db/migrations/0168_cloud_files.sql` but never registered it in `migrations/meta/_journal.json`. The deploy pipeline's migrate-db step applies **journal entries only**, so the `cloud_files` table would never be created in staging/prod and every `/api/v1/files` request would 500 against the missing table — the same failure class as #11493. `drizzle-kit check` does not catch this (verified: it reports "Everything's fine" on develop with the file unregistered).

- Register `{ idx: 167, tag: "0168_cloud_files" }` in `_journal.json` — after #11731's `0168_ad_accounts_pending_default` at idx 166 (two files share the `0168` numeric prefix; tags, not prefixes, are drizzle's migration identity, and `0168_cloud_files` has never been applied anywhere so ordering after it is safe).
- Add the missing gate: `src/db/migration-journal-registration.test.ts` — every non-`.down` migration `.sql` file must have a matching journal tag (and vice versa), journal `idx` contiguous from 0, tags unique. This class has now bitten twice; the gate makes it impossible to merge silently.
- Drive-by: `src/db/repositories/__tests__/app-frontend-deployments.test.ts` has been red on develop since #10863 added `appReviewStatusEnum` to the apps schema (`pushSchema` failed with `type "app_review_status" does not exist`); added the enum to the test's schema set.

Complements the other #11758 follow-ups (#11763 edge cases, #11764 blob-host prefix — already merged) — no file overlap with either.

## Fail-without-fix proof

Gate test against develop's journal (fix reverted):

```
(fail) migrations/meta/_journal.json registration > every migration .sql file is registered in the journal
 2 pass / 1 fail   — error names 0168_cloud_files
```

With the journal entry: `3 pass / 0 fail`.

## Migration applies for real (PGlite, raw SQL verbatim)

```
0168_cloud_files.sql applied OK
re-apply idempotent OK
insert OK
rows after org cascade delete: 0
ALL MIGRATION CHECKS PASSED
```

## Validation (local runs post-rebase onto d2e14b86de, all real)

- `bun test --isolate src/db/repositories/__tests__/ src/lib/services/cloud-files.test.ts src/db/migration-journal-registration.test.ts` — **49 pass / 0 fail** (includes the previously-red app-frontend-deployments suite and #11758's cloud-files tests)
- `bun run --cwd packages/cloud/shared db:check-migrations` — Everything's fine
- `bun run --cwd packages/cloud/shared typecheck` — clean
- `bun run --cwd packages/cloud/api typecheck` — clean
- Biome on changed files — clean

Evidence: `.github/issue-evidence/11758-cloud-files-migration-journal.md`

- UI screenshots/video: N/A — migration-journal + test-only change, no UI surface.
- Real-LLM trajectories: N/A — no agent/action/provider/prompt/model behavior changed.

Refs #11758, #11743, #10688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)