### PR TITLE
fix(android): land the 4 emulator-leg local-inference defect fixes from the #10727 lifecycle run

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -352,6 +352,9 @@ const loadOptionalPlugin = async (packageName: string): Promise<unknown> => {
     if (packageName === "@elizaos/plugin-video") {
       return await import(/* @vite-ignore */ "@elizaos/plugin-video");
     }
+    if (packageName === "@elizaos/plugin-vision") {
+      return await import(/* @vite-ignore */ "@elizaos/plugin-vision");
+    }
     if (packageName === "@elizaos/plugin-background-runner") {
       return await import(
         /* @vite-ignore */ "@elizaos/plugin-background-runner"
@@ -515,6 +518,18 @@ const CORE_STATIC_PLUGIN_REGISTRATIONS: readonly CoreStaticPluginRegistration[] 
       phase: "deferred",
       required: false,
       load: () => getOptionalPlugin("@elizaos/plugin-video"),
+    },
+    {
+      // MOBILE_CORE_PLUGINS lists plugin-vision (screen understanding on
+      // mobile — GET_SCREEN, the renderer-pulled screen-capture bridge, and
+      // the #11111 ML Kit OCR bridge routes), but without a static
+      // registration the mobile agent bundle could never resolve it: the
+      // renderer OCR poller polled /api/vision/ocr-requests into a 404
+      // forever (verified live on emulator-5554).
+      packageName: "@elizaos/plugin-vision",
+      phase: "deferred",
+      required: false,
+      load: () => getOptionalPlugin("@elizaos/plugin-vision"),
     },
     {
       packageName: "@elizaos/plugin-background-runner",

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1523,7 +1523,28 @@ function mirrorCapacitorWebPayloadIntoAndroidDir() {
     hasSyncedPublic &&
     fs.existsSync(targetAssets) &&
     fs.realpathSync(syncedAssets) === fs.realpathSync(targetAssets);
-  if (hasSyncedPublic && !sameTree) {
+  // STALE-MIRROR GUARD: with the unified tree (android.path =
+  // ../app-core/platforms/android, #8387) cap sync writes the fresh
+  // capacitor.plugins.json straight into androidDir — but a leftover legacy
+  // appDir/android tree (with its own assets/public) makes hasSyncedPublic
+  // true and !sameTree, so this mirror used to STOMP the freshly synced
+  // manifest with a months-old copy. That silently dropped every
+  // newer native plugin (ML Kit OCR, ScreenCapture, mobile-agent-bridge, …)
+  // from auto-registration: "not implemented on android" at runtime
+  // (verified live on emulator-5554). Only mirror when the synced manifest is
+  // at least as fresh as the target's.
+  const syncedManifest = path.join(syncedAssets, "capacitor.plugins.json");
+  const targetManifest = path.join(targetAssets, "capacitor.plugins.json");
+  const syncedIsStale =
+    fs.existsSync(syncedManifest) &&
+    fs.existsSync(targetManifest) &&
+    fs.statSync(syncedManifest).mtimeMs < fs.statSync(targetManifest).mtimeMs;
+  if (syncedIsStale && !sameTree) {
+    console.log(
+      `[mobile-build] Skipping Capacitor web-payload mirror: ${path.relative(repoRoot, syncedAssets)} is a stale legacy tree (its capacitor.plugins.json is older than the freshly synced ${path.relative(repoRoot, targetManifest)}).`,
+    );
+  }
+  if (hasSyncedPublic && !sameTree && !syncedIsStale) {
     fs.mkdirSync(targetAssets, { recursive: true });
     rmRecursive(targetPublic);
     fs.cpSync(syncedPublic, targetPublic, { recursive: true });

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -5619,6 +5619,14 @@ export const allActionsSpec = {
 			],
 		},
 		{
+			name: "DUPLICATE_AD_CAMPAIGN",
+			description:
+				"Duplicate a Cloud advertising campaign config and creatives into a new draft. Requires structured campaignId; optional name sets the copy name.",
+			parameters: [],
+			descriptionCompressed: "Duplicate an ad campaign into a draft copy.",
+			similes: ["COPY_AD_CAMPAIGN", "CLONE_AD_CAMPAIGN"],
+		},
+		{
 			name: "ELEVATED_COMMAND",
 			description: "Set elevated permission mode",
 			parameters: [
@@ -6235,6 +6243,20 @@ export const allActionsSpec = {
 			],
 		},
 		{
+			name: "GET_AD_CAMPAIGN_ATTRIBUTION",
+			description:
+				"Fetch the signed conversion pixel and webhook install instructions for an Eliza Cloud advertising campaign by campaign id.",
+			parameters: [],
+			descriptionCompressed:
+				"Fetch signed conversion pixel/webhook install instructions for a campaign.",
+			similes: [
+				"GET_CONVERSION_PIXEL",
+				"GET_ATTRIBUTION_PIXEL",
+				"GET_CAMPAIGN_WEBHOOK",
+				"INSTALL_CONVERSION_TRACKING",
+			],
+		},
+		{
 			name: "GET_APP",
 			description:
 				"Show details about one specific Eliza Cloud app the user owns (URL, deployment status, credits used, earnings, users). Use when the user asks about a particular app by name or id.",
@@ -6682,14 +6704,14 @@ export const allActionsSpec = {
 				{
 					name: "classification",
 					description:
-						"Optional triage queue filter for persisted items: ignore | info | notify | needs_reply | urgent. When set on triage, reads the queue without classifying fresh messages.",
+						"Optional triage queue filter for returned persisted items: ignore | info | notify | needs_reply | urgent. Fresh messages are still classified first.",
 					required: false,
 					schema: {
 						type: "string",
 						enum: ["ignore", "info", "notify", "needs_reply", "urgent"],
 					},
 					descriptionCompressed:
-						"Optional triage queue filter for persisted items: ignore | info | notify | needs_reply | urgent. When set on triage, reads the queue without classifying...",
+						"Optional triage queue filter for returned persisted items: ignore | info | notify | needs_reply | urgent. Fresh msgs are still classified first.",
 				},
 				{
 					name: "includeSnoozed",
@@ -8648,6 +8670,19 @@ export const allActionsSpec = {
 						},
 					},
 				},
+			],
+		},
+		{
+			name: "SET_AD_CAMPAIGN_DAYPARTING",
+			description:
+				"Set a Cloud advertising campaign's dayparting delivery schedule. Requires structured campaignId and dayparting { timezone, windows } parameters.",
+			parameters: [],
+			descriptionCompressed:
+				"Set dayparting delivery windows for an ad campaign.",
+			similes: [
+				"SCHEDULE_AD_CAMPAIGN",
+				"SET_AD_DELIVERY_WINDOWS",
+				"UPDATE_AD_DAYPARTING",
 			],
 		},
 		{

--- a/packages/prompts/specs/actions/plugins.generated.json
+++ b/packages/prompts/specs/actions/plugins.generated.json
@@ -1932,6 +1932,13 @@
       ]
     },
     {
+      "name": "DUPLICATE_AD_CAMPAIGN",
+      "description": "Duplicate a Cloud advertising campaign config and creatives into a new draft. Requires structured campaignId; optional name sets the copy name.",
+      "parameters": [],
+      "descriptionCompressed": "Duplicate an ad campaign into a draft copy.",
+      "similes": ["COPY_AD_CAMPAIGN", "CLONE_AD_CAMPAIGN"]
+    },
+    {
       "name": "ELEVATED_COMMAND",
       "description": "Set elevated permission mode",
       "parameters": [
@@ -2457,6 +2464,18 @@
       ]
     },
     {
+      "name": "GET_AD_CAMPAIGN_ATTRIBUTION",
+      "description": "Fetch the signed conversion pixel and webhook install instructions for an Eliza Cloud advertising campaign by campaign id.",
+      "parameters": [],
+      "descriptionCompressed": "Fetch signed conversion pixel/webhook install instructions for a campaign.",
+      "similes": [
+        "GET_CONVERSION_PIXEL",
+        "GET_ATTRIBUTION_PIXEL",
+        "GET_CAMPAIGN_WEBHOOK",
+        "INSTALL_CONVERSION_TRACKING"
+      ]
+    },
+    {
       "name": "GET_APP",
       "description": "Show details about one specific Eliza Cloud app the user owns (URL, deployment status, credits used, earnings, users). Use when the user asks about a particular app by name or id.",
       "parameters": [],
@@ -2839,7 +2858,7 @@
         },
         {
           "name": "classification",
-          "description": "Optional triage queue filter for persisted items: ignore | info | notify | needs_reply | urgent. When set on triage, reads the queue without classifying fresh messages.",
+          "description": "Optional triage queue filter for returned persisted items: ignore | info | notify | needs_reply | urgent. Fresh messages are still classified first.",
           "required": false,
           "schema": {
             "type": "string",
@@ -4518,6 +4537,17 @@
             }
           }
         }
+      ]
+    },
+    {
+      "name": "SET_AD_CAMPAIGN_DAYPARTING",
+      "description": "Set a Cloud advertising campaign's dayparting delivery schedule. Requires structured campaignId and dayparting { timezone, windows } parameters.",
+      "parameters": [],
+      "descriptionCompressed": "Set dayparting delivery windows for an ad campaign.",
+      "similes": [
+        "SCHEDULE_AD_CAMPAIGN",
+        "SET_AD_DELIVERY_WINDOWS",
+        "UPDATE_AD_DAYPARTING"
       ]
     },
     {

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.native-base.test.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.native-base.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// Android WebView / WebKit throw "Failed to construct 'URL': Invalid URL" when
+// resolving a relative path against a non-special-scheme base such as the
+// on-device native IPC base `eliza-local-agent://ipc`. (Node/jsdom's WHATWG URL
+// accepts that resolution, which is why the crash never reproduced in unit
+// tests.) The overlay used to build its SSE URL with an unguarded
+// `new URL(path, baseUrl)` at effect time, which crashed the entire app shell
+// at boot on Android on-device builds. This suite emulates the WebView parser
+// and pins the degrade-to-polling behavior.
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { clientMock, openEventSourceMock, mockState } = vi.hoisted(() => ({
+  clientMock: {
+    getBaseUrl: vi.fn(() => "eliza-local-agent://ipc"),
+    getRestAuthToken: vi.fn(() => null),
+    getComputerUseApprovals: vi.fn(async () => ({
+      mode: "full_control",
+      pendingCount: 0,
+      pendingApprovals: [],
+    })),
+    respondToComputerUseApproval: vi.fn(),
+  },
+  openEventSourceMock: vi.fn(() => ({
+    close: vi.fn(),
+    onmessage: null,
+    onerror: null,
+  })),
+  mockState: {
+    setActionNotice: vi.fn(),
+    t: (_key: string, vars?: { defaultValue?: string }) =>
+      vars?.defaultValue ?? "",
+  },
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("../../utils/event-source", () => ({
+  openEventSource: openEventSourceMock,
+}));
+
+vi.mock("../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => true,
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: <T,>(selector: (state: typeof mockState) => T): T =>
+    selector(mockState),
+}));
+
+import { ComputerUseApprovalOverlay } from "./ComputerUseApprovalOverlay";
+
+const RealURL = globalThis.URL;
+
+/** WebView-like URL: throws when the base is not an http(s)/file/ws special scheme. */
+class WebViewLikeURL extends RealURL {
+  constructor(url: string | URL, base?: string | URL) {
+    if (
+      base !== undefined &&
+      !/^(?:https?|file|ws|wss|ftp):/i.test(String(base))
+    ) {
+      throw new TypeError("Failed to construct 'URL': Invalid URL");
+    }
+    super(url, base);
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", WebViewLikeURL);
+  clientMock.getBaseUrl.mockReturnValue("eliza-local-agent://ipc");
+  clientMock.getComputerUseApprovals.mockClear();
+  openEventSourceMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe("ComputerUseApprovalOverlay on native IPC base (Android WebView URL parser)", () => {
+  it("renders without crashing and degrades to polling instead of opening SSE", async () => {
+    expect(() => render(<ComputerUseApprovalOverlay />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(clientMock.getComputerUseApprovals).toHaveBeenCalled();
+    });
+    expect(openEventSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("still opens the SSE stream on a plain http base", async () => {
+    clientMock.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
+    render(<ComputerUseApprovalOverlay />);
+
+    await waitFor(() => {
+      expect(openEventSourceMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:31337/api/computer-use/approvals/stream",
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
@@ -21,13 +21,23 @@ const POLL_MS = 1500;
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-function approvalStreamUrl(): string {
+function approvalStreamUrl(): string | null {
   const baseUrl = client.getBaseUrl();
   const restToken = client.getRestAuthToken();
-  const url = new URL(
-    "/api/computer-use/approvals/stream",
-    baseUrl || window.location.origin,
-  );
+  let url: URL;
+  try {
+    url = new URL(
+      "/api/computer-use/approvals/stream",
+      baseUrl || window.location.origin,
+    );
+  } catch {
+    // Non-http native IPC bases (eliza-local-agent://ipc) are not valid URL
+    // bases on Android WebView / WebKit — resolving a path against a
+    // non-special scheme throws, which crashed the whole shell at boot on
+    // on-device builds. EventSource cannot reach those bases anyway, so
+    // degrade to the polling path.
+    return null;
+  }
   if (restToken) {
     url.searchParams.set("token", restToken);
   }
@@ -94,9 +104,10 @@ export function ComputerUseApprovalOverlay() {
     };
 
     // On-device runtimes use the native IPC base, which EventSource cannot
-    // open; openEventSource returns null there so we fall straight through to
-    // polling instead of throwing a synchronous SecurityError.
-    eventSource = openEventSource(approvalStreamUrl());
+    // open; approvalStreamUrl/openEventSource return null there so we fall
+    // straight through to polling instead of throwing.
+    const streamUrl = approvalStreamUrl();
+    eventSource = streamUrl ? openEventSource(streamUrl) : null;
     if (eventSource) {
       eventSource.onmessage = (event) => {
         if (cancelled) {

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -32,12 +32,14 @@
 import {
   createWriteStream,
   existsSync,
+  linkSync,
   mkdirSync,
   readdirSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
+  symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -472,6 +474,39 @@ function readPositiveIntEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+type AospKvCacheTypeName = "f16" | "tbq3_0" | "tbq4_0" | "qjl1_256" | "q4_polar";
+
+const AOSP_KV_CACHE_TYPE_NAMES: readonly AospKvCacheTypeName[] = [
+  "f16",
+  "tbq3_0",
+  "tbq4_0",
+  "qjl1_256",
+  "q4_polar",
+];
+
+/**
+ * Chat KV-cache type override (`ELIZA_LLAMA_KV_TYPE_K` / `_V`). The fork
+ * KV-quant defaults (qjl1_256 / q4_polar) are eliza-1's memory optimization,
+ * but some fused-lib builds reject a quantized V cache without flash_attn
+ * ("V cache quantization requires flash_attn" → llm_stream_open fails) — the
+ * env knob lets a device profile pin f16 without a rebuild.
+ */
+function readKvCacheTypeEnv(
+  name: string,
+  fallback: AospKvCacheTypeName,
+): AospKvCacheTypeName {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (!raw) return fallback;
+  const match = AOSP_KV_CACHE_TYPE_NAMES.find((candidate) => candidate === raw);
+  if (!match) {
+    logger.warn(
+      `[aosp-local-inference] ${name}="${raw}" is not a recognised KV cache type (accepted: ${AOSP_KV_CACHE_TYPE_NAMES.join(", ")}); using ${fallback}`,
+    );
+    return fallback;
+  }
+  return match;
+}
+
 function readNonNegativeIntEnv(name: string): number | null {
   const raw = process.env[name]?.trim();
   if (!raw) return null;
@@ -687,8 +722,8 @@ export function buildAospLoadModelArgs(
       useGpu: gpuLayers > 0,
       gpuLayers,
       kvCacheType: {
-        k: "qjl1_256",
-        v: "q4_polar",
+        k: readKvCacheTypeEnv("ELIZA_LLAMA_KV_TYPE_K", "qjl1_256"),
+        v: readKvCacheTypeEnv("ELIZA_LLAMA_KV_TYPE_V", "q4_polar"),
       },
     };
   }
@@ -2091,6 +2126,44 @@ function resolveAospFusedKokoroConfig(): AospFusedKokoroConfig | null {
   return { libPath, bundleRoot, kokoroGgufPath, kokoroVoicePath };
 }
 
+/**
+ * The fused lib resolves the chat GGUF strictly as `<bundleRoot>/text/*.gguf`,
+ * but Android first-run staging lays the curated model FLAT under `models/`.
+ * Mirror the bionic host's hardlink-bundle shim (`deriveBundleDir` in
+ * plugin-local-inference's bionic-host-loader) so the fused musl loader
+ * accepts the flat layout: hardlink (or symlink) the flat GGUF into
+ * `<bundleRoot>/text/` without copying the multi-GB model bytes. Best-effort —
+ * on failure the fused create/tokenize surfaces its own loud
+ * "no text GGUF found" diagnostic (verified live on emulator-5554).
+ */
+function ensureFusedTextBundleLayout(
+  modelPath: string,
+  bundleRoot: string,
+): void {
+  try {
+    if (!modelPath.endsWith(".gguf") || !existsSync(modelPath)) return;
+    if (path.basename(path.dirname(modelPath)) === "text") return;
+    const textDir = path.join(bundleRoot, "text");
+    const target = path.join(textDir, path.basename(modelPath));
+    if (existsSync(target)) return;
+    mkdirSync(textDir, { recursive: true });
+    try {
+      linkSync(modelPath, target);
+    } catch {
+      symlinkSync(modelPath, target);
+    }
+    writeAospLlamaDebugLog("bootstrap:fusedText:flatBundleShim", {
+      modelPath,
+      target,
+    });
+  } catch (err) {
+    writeAospLlamaDebugLog("bootstrap:fusedText:flatBundleShimFailed", {
+      modelPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 function resolveBundleRootFromModelPath(modelPath: string): string {
   const parts = modelPath.replaceAll("\\", "/").split("/");
   const bundleIndex = parts.findIndex((part) => part.endsWith(".bundle"));
@@ -2151,13 +2224,15 @@ function readFfiStringAndFree(
 }
 
 function readFfiPointer(
-  ffi: BunFfiModule,
+  _ffi: BunFfiModule,
   ptrBuffer: Buffer,
   offset = 0,
 ): bigint {
-  const viaFfi = ffi.read?.ptr?.(ptrBuffer, offset);
-  if (typeof viaFfi === "bigint") return viaFfi;
-  if (typeof viaFfi === "number") return BigInt(viaFfi);
+  // NOTE: never hand the Buffer to `ffi.read.ptr` — bun's `read.ptr` takes a
+  // raw Pointer NUMBER and throws "Expected a pointer" for a Buffer (verified
+  // on-device, bun 1.3.14). That throw masked every native error diagnostic
+  // on the fused-lib error paths. The out-param bytes live in JS memory, so a
+  // DataView read is always correct.
   const view = new DataView(
     ptrBuffer.buffer,
     ptrBuffer.byteOffset,
@@ -2500,6 +2575,8 @@ interface AospFusedTextLoaderState {
   gpuLayers?: number;
   contextSize: number | null;
   draftModelPath: string | null;
+  /** Set after a one-time f16 retry when the build rejects KV-quant. */
+  kvQuantRejected?: boolean;
 }
 
 /**
@@ -2727,6 +2804,10 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
       // context is created lazily on the first load; its bundle root is
       // derived from the resolved model path so the loader does not need a
       // pre-staged bundle at boot.
+      ensureFusedTextBundleLayout(
+        args.modelPath,
+        state?.bundleRoot ?? resolveBundleRootFromModelPath(args.modelPath),
+      );
       if (!state) {
         const bundleRoot = resolveBundleRootFromModelPath(args.modelPath);
         const errCreate = Buffer.alloc(8);
@@ -2835,14 +2916,48 @@ export async function tryBuildAospFusedTextLoader(): Promise<AospLoader | null> 
         disableThinking: false,
         contextSize: active.contextSize,
       };
-      const result = await streamGenerate(active.binding, {
-        ctx: active.ctx,
-        config,
-        promptTokens,
-        ...(args.signal ? { signal: args.signal } : {}),
-        ...(args.onTextChunk ? { onTextChunk: args.onTextChunk } : {}),
-      });
-      return result.text;
+      const runStream = async () => {
+        const result = await streamGenerate(active.binding, {
+          ctx: active.ctx,
+          config,
+          promptTokens,
+          ...(args.signal ? { signal: args.signal } : {}),
+          ...(args.onTextChunk ? { onTextChunk: args.onTextChunk } : {}),
+        });
+        return result.text;
+      };
+      try {
+        return await runStream();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // Some fused-lib builds reject a quantized V cache without flash_attn
+        // ("V cache quantization requires flash_attn" → llm_stream_open fails
+        // to init the llama context). Retry ONCE with f16 KV so local text
+        // inference stays alive, and log loudly — the eliza-1 KV-quant memory
+        // optimization is disabled for the rest of this load.
+        const kvQuantRejection =
+          /flash_attn|failed to init llama context/i.test(message);
+        if (active.kvQuantRejected || !kvQuantRejection) {
+          throw err;
+        }
+        active.kvQuantRejected = true;
+        logger.warn(
+          `[aosp-local-inference] fused llm_stream_open rejected the KV-quant cache config (${message}); retrying with f16 KV cache — eliza-1 KV-quant memory optimization DISABLED for this model load. Set ELIZA_LLAMA_KV_TYPE_K/V=f16 to silence this retry, or ship a fused lib with flash_attn wired for quantized V cache.`,
+        );
+        writeAospLlamaDebugLog("bootstrap:fusedText:kvQuantRejected", {
+          message,
+        });
+        active.binding = createAospStreamingLlmBinding({
+          ctx: active.ctx,
+          symbols: active.symbols as unknown as AospFusedLlmSymbols,
+          helpers: active.helpers,
+          ...(typeof active.gpuLayers === "number"
+            ? { gpuLayers: active.gpuLayers }
+            : {}),
+          kvCacheTypes: { cacheTypeK: "f16", cacheTypeV: "f16" },
+        });
+        return await runStream();
+      }
     },
 
     async embed(args): Promise<{ embedding: number[]; tokens: number }> {

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -474,7 +474,12 @@ function readPositiveIntEnv(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-type AospKvCacheTypeName = "f16" | "tbq3_0" | "tbq4_0" | "qjl1_256" | "q4_polar";
+type AospKvCacheTypeName =
+  | "f16"
+  | "tbq3_0"
+  | "tbq4_0"
+  | "qjl1_256"
+  | "q4_polar";
 
 const AOSP_KV_CACHE_TYPE_NAMES: readonly AospKvCacheTypeName[] = [
   "f16",


### PR DESCRIPTION
## What

Cherry-picks the four real defect fixes discovered (and verified live on emulator-5554) during the #10727 Android local-inference lifecycle leg, off the draft PR #11731 residuals branch so they land independently of that UI workstream:

- **fix(ui): ComputerUseApprovalOverlay hard-crash** — `new URL(path, "eliza-local-agent://ipc")` throws on Android WebView for non-special-scheme bases; the error boundary killed the whole shell at boot. (Same signature as the iOS #11030 error card.) + regression test.
- **fix(aosp-local-inference): unmask fused-lib FFI errors** — bun `read.ptr` given a Buffer masked every native error as "Expected a pointer"; also accepts flat first-run model layout and survives KV-quant rejection with a loud one-time f16 retry (`ELIZA_LLAMA_KV_TYPE_K/V`).
- **fix(agent): register @elizaos/plugin-vision in the static plugin map** — listed in MOBILE_CORE_PLUGINS but missing from CORE_STATIC_PLUGIN_REGISTRATIONS, so the renderer OCR poller 404-looped forever on mobile.
- **fix(mobile-build): stale legacy-tree mirror stomped the freshly synced `capacitor.plugins.json`** — cap sync found 33 plugins, the shipped APK carried 15; ML Kit OCR (#11111), ScreenCapture etc. silently "not implemented on android". Mirror is now guarded on manifest mtime.

Plus a biome format pass on the touched aosp file and the regenerated `action-docs.ts` / `plugins.generated.json` (known develop drift, regenerated by the prompts build — see the generated-docs drift pattern).

## Why now

These fixes gate the on-device Android lifecycle evidence for #10727 / #10726 (the emulator leg's text-gen/STT/OCR proofs all sit on top of them), but they were stranded on the draft PR #11731 branch. Identical patches will drop out of #11731 harmlessly when it lands.

## Verification (local — develop CI is concurrency-cancel churny)

- `bun run --cwd plugins/plugin-aosp-local-inference test` → **75/75 pass**
- `bun run --cwd packages/ui test -- src/components/shell/ComputerUseApprovalOverlay.native-base.test.tsx` → **2/2 pass**
- `bun run --cwd packages/agent typecheck` → clean (after building workspace dists)
- `node --check packages/app-core/scripts/run-mobile-build.mjs` → OK; `biome check` clean on touched files (pre-existing repo-wide findings out of scope)
- Live on-device provenance: `.github/issue-evidence/xplatform-android-emu/` (emulator-5554 run — before/after renderer-crash screenshots, chat reply via local eliza-1, agent logs), posted on #10727.

Refs #10727, #10726, #11111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)