### PR TITLE
test(#10722): native HTML5 drag-and-drop coverage (file-drop upload + plugin reorder)

### DIFF
--- a/.github/issue-evidence/10722-native-dnd/README.md
+++ b/.github/issue-evidence/10722-native-dnd/README.md
@@ -1,0 +1,75 @@
+# #10722 — Native HTML5 drag-and-drop coverage
+
+Native HTML5 drag-and-drop had **zero** automated coverage. This adds real
+jsdom tests that dispatch actual `dragstart` / `dragover` / `drop` DOM events
+carrying a populated `DataTransfer` and assert **semantic** outcomes (upload
+handler invoked with the right file / decoded content; card order actually
+changed and persisted) — not "no error".
+
+## Code under test (unchanged — test-only PR)
+
+- `packages/ui/src/components/pages/documents-upload.tsx` → `UploadZone.handleDrop`
+  (native file-drop upload).
+- `packages/ui/src/components/pages/DocumentsView.tsx` → `handleRootDrop` +
+  `handleFilesUpload` (the real validation / batching / bulk-upload path).
+- `packages/ui/src/components/pages/PluginsView.tsx` → `handleDragStart` /
+  `handleDragOver` / `handleDrop` reorder + localStorage persistence, rendering
+  `PluginCard` draggable rows.
+
+## New tests
+
+- `packages/ui/src/components/pages/documents-upload.dnd.test.tsx` (11 tests)
+  - **File drop → upload:** a real `drop` with `dataTransfer.files` invokes
+    `onFilesUpload` with the dropped `File` and the zone's live scope options.
+  - **Real upload path:** dropping a `.txt` on the DocumentsView root drives
+    `handleFilesUpload` → `client.uploadDocumentsBulk` is called with the file's
+    FileReader-decoded content (`"hello world"`), filename, and scope.
+  - **Edge cases:** multiple files batched into one request; wrong type
+    (`.exe`) rejected with the "No supported non-empty files" notice and **no**
+    network call; supported-but-empty (0-byte) file rejected; empty drop (no
+    files) is a no-op; drop while `uploading` ignored.
+  - **No double-upload:** a drop inside the zone calls `stopPropagation`, so an
+    outer drop target never fires (#10722 regression guard).
+- `packages/ui/src/components/pages/PluginsView.reorder.test.tsx` (5 tests)
+  - Cards render in the expected order at rest; dragging a card ahead of / behind
+    a sibling **actually changes the rendered order** and **persists** it to
+    `localStorage["pluginOrder"]`.
+  - The persisted list has **no duplicate and no `undefined`/`null` ids** (splice
+    correctness), verified across two successive reorders.
+  - A drop onto the same card (no movement) is a **no-op**: order unchanged and
+    nothing persisted.
+
+## Result
+
+```
+Test Files  2 passed (2)
+     Tests  16 passed (16)
+```
+
+(full per-test list in `test-output.txt`)
+
+## Mutation check (proof the tests are not vacuous)
+
+Temporarily breaking the reorder splice in `PluginsView.tsx`
+(`ids.splice(fromIdx, 1); ids.splice(toIdx, 0, srcId)` → skipped) made **3 of the
+5** reorder tests fail — the reorder/persistence assertions — while the
+"at-rest order" and "no-op self-drop" tests correctly stayed green. Source was
+restored; final tree is test-only.
+
+```
+❯ PluginsView.reorder.test.tsx (5 tests | 3 failed)
+  × reorders cards and persists the new order when a card is dropped ahead of another
+  × moves a card backward when dropped onto a later sibling
+  × survives a second reorder without duplicating or dropping any id
+```
+
+## Verification commands
+
+```
+bun run --cwd packages/ui test  (scoped to the two files) → 16/16 pass
+bun run --cwd packages/ui typecheck                       → clean
+bunx @biomejs/biome check <files>                         → clean
+```
+
+N/A rows: no product source changed (test-only), so no UI screenshots / video /
+real-LLM trajectories / device capture apply.

--- a/.github/issue-evidence/10722-native-dnd/test-output.txt
+++ b/.github/issue-evidence/10722-native-dnd/test-output.txt
@@ -1,0 +1,18 @@
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > forwards a single dropped file to onFilesUpload with the zone's scope options 257ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > forwards every file when multiple are dropped at once 33ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > ignores a drop that carries no files (empty drop) 28ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > ignores a drop while an upload is already in flight 24ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > stops a zone drop from bubbling into an outer drop target (no double-upload) 23ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > UploadZone — native file drop (handleDrop) > carries the newly selected scope into the drop options 81ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > DocumentsView — root file drop drives the real upload path > uploads a dropped .txt file with its decoded content via uploadDocumentsBulk 70ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > DocumentsView — root file drop drives the real upload path > batches multiple dropped files into one bulk upload request 66ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > DocumentsView — root file drop drives the real upload path > rejects an unsupported file type without any upload request 33ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > DocumentsView — root file drop drives the real upload path > rejects a supported-but-empty file (zero bytes) without an upload 24ms
+ ✓ src/components/pages/documents-upload.dnd.test.tsx > DocumentsView — root file drop drives the real upload path > does nothing when a drop carries no files at all 24ms
+ ✓ src/components/pages/PluginsView.reorder.test.tsx > PluginsView — native drag-to-reorder > renders the three connector plugins in alphabetical order at rest 210ms
+ ✓ src/components/pages/PluginsView.reorder.test.tsx > PluginsView — native drag-to-reorder > reorders cards and persists the new order when a card is dropped ahead of another 52ms
+ ✓ src/components/pages/PluginsView.reorder.test.tsx > PluginsView — native drag-to-reorder > moves a card backward when dropped onto a later sibling 38ms
+ ✓ src/components/pages/PluginsView.reorder.test.tsx > PluginsView — native drag-to-reorder > does not reorder or persist when a card is dropped onto itself (no movement) 26ms
+ ✓ src/components/pages/PluginsView.reorder.test.tsx > PluginsView — native drag-to-reorder > survives a second reorder without duplicating or dropping any id 43ms
+ Test Files  2 passed (2)
+      Tests  16 passed (16)

--- a/packages/ui/src/components/pages/PluginsView.reorder.test.tsx
+++ b/packages/ui/src/components/pages/PluginsView.reorder.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+//
+// Native HTML5 drag-to-reorder coverage for the plugin catalog (#10722). The
+// PluginCard rows are `draggable` and the reorder is driven entirely by native
+// dragstart → dragover → drop events wired through PluginListView. Before this
+// there was zero coverage, so a regression in the splice/persist logic (dropped
+// order, a duplicated id, an `undefined` slot, or a lost localStorage write)
+// would ship silently.
+//
+// These tests dispatch real drag events and assert the SEMANTIC outcome: the
+// rendered card order actually changes, the new order persists to
+// localStorage, the persisted list has no duplicate/undefined ids, and a drop
+// onto the same card is a no-op (nothing reordered, nothing persisted).
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginInfo } from "../../api";
+import { PluginsView } from "./PluginsView";
+
+const appMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+const clientMock = vi.hoisted(() => ({
+  onWsEvent: vi.fn(() => () => {}),
+  testPluginConnection: vi.fn(),
+  installRegistryPlugin: vi.fn(),
+  updateRegistryPlugin: vi.fn(),
+  uninstallRegistryPlugin: vi.fn(),
+  restartAndWait: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({
+  useApp: () => appMock.value,
+  useAppSelector: (sel: (value: Record<string, unknown>) => unknown) =>
+    sel(appMock.value),
+  useAppSelectorShallow: (sel: (value: Record<string, unknown>) => unknown) =>
+    sel(appMock.value),
+}));
+vi.mock("../../api", () => ({ client: clientMock }));
+
+function t(key: string, options?: { defaultValue?: string }) {
+  return options?.defaultValue ?? key;
+}
+
+function makeContext(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    plugins: [] as PluginInfo[],
+    pluginStatusFilter: "all",
+    pluginSearch: "",
+    pluginSettingsOpen: new Set<string>(),
+    pluginSaving: null,
+    pluginSaveSuccess: null,
+    loadPlugins: vi.fn(async () => {}),
+    ensurePluginsLoaded: vi.fn(async () => {}),
+    handlePluginToggle: vi.fn(async () => {}),
+    handlePluginConfigSave: vi.fn(async () => {}),
+    setActionNotice: vi.fn(),
+    setState: vi.fn(),
+    t,
+    ...overrides,
+  };
+}
+
+// Three sibling "connector"-group plugins with alphabetical names. With no
+// custom order yet, comparePlugins sorts ready plugins by name, so the initial
+// DOM order is [alpha, bravo, charlie].
+function makePlugin(id: string, name: string): PluginInfo {
+  return {
+    id,
+    name,
+    description: `${name} plugin`,
+    enabled: true,
+    configured: true,
+    envKey: null,
+    category: "feature",
+    group: "connector",
+    source: "bundled",
+    parameters: [],
+    validationErrors: [],
+    validationWarnings: [],
+    isActive: true,
+  } as PluginInfo;
+}
+
+/** A DataTransfer stand-in (jsdom has none) exposing what the handlers touch. */
+function makeDataTransfer() {
+  const store: Record<string, string> = {};
+  return {
+    dropEffect: "none",
+    effectAllowed: "all",
+    types: [] as string[],
+    setData: (key: string, value: string) => {
+      store[key] = value;
+    },
+    getData: (key: string) => store[key] ?? "",
+    setDragImage: () => {},
+  };
+}
+
+function orderInDom(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("[data-plugin-id]")).map((el) =>
+    el.getAttribute("data-plugin-id"),
+  ) as string[];
+}
+
+function card(container: HTMLElement, id: string): HTMLElement {
+  const el = container.querySelector(`[data-plugin-id="${id}"]`);
+  if (!el) throw new Error(`no card for ${id}`);
+  return el as HTMLElement;
+}
+
+/** Perform a full native drag of `srcId` and drop it onto `targetId`. */
+function dragAndDrop(container: HTMLElement, srcId: string, targetId: string) {
+  const dataTransfer = makeDataTransfer();
+  fireEvent.dragStart(card(container, srcId), { dataTransfer });
+  fireEvent.dragOver(card(container, targetId), { dataTransfer });
+  fireEvent.drop(card(container, targetId), { dataTransfer });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  clientMock.onWsEvent.mockClear();
+  appMock.value = makeContext({
+    plugins: [
+      makePlugin("alpha", "Alpha"),
+      makePlugin("bravo", "Bravo"),
+      makePlugin("charlie", "Charlie"),
+    ],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("PluginsView — native drag-to-reorder", () => {
+  it("renders the three connector plugins in alphabetical order at rest", () => {
+    const { container } = render(<PluginsView />);
+    expect(orderInDom(container)).toEqual(["alpha", "bravo", "charlie"]);
+  });
+
+  it("reorders cards and persists the new order when a card is dropped ahead of another", async () => {
+    const { container } = render(<PluginsView />);
+    expect(orderInDom(container)).toEqual(["alpha", "bravo", "charlie"]);
+
+    // Drag Charlie to the front (drop it onto Alpha).
+    dragAndDrop(container, "charlie", "alpha");
+
+    await waitFor(() =>
+      expect(orderInDom(container)).toEqual(["charlie", "alpha", "bravo"]),
+    );
+
+    // The order persisted to localStorage and is well-formed: every entry is a
+    // defined, unique id (no duplicate/undefined slot from a bad splice).
+    const stored = JSON.parse(
+      localStorage.getItem("pluginOrder") ?? "null",
+    ) as string[];
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.filter((id) => id == null)).toHaveLength(0);
+    expect(new Set(stored).size).toBe(stored.length);
+    // The three real plugins keep their new relative order in the persisted list.
+    expect(stored.filter((id) => id !== "__ui-showcase__")).toEqual([
+      "charlie",
+      "alpha",
+      "bravo",
+    ]);
+  });
+
+  it("moves a card backward when dropped onto a later sibling", async () => {
+    const { container } = render(<PluginsView />);
+
+    // Drag Alpha down onto Charlie.
+    dragAndDrop(container, "alpha", "charlie");
+
+    await waitFor(() =>
+      expect(orderInDom(container)).toEqual(["bravo", "charlie", "alpha"]),
+    );
+  });
+
+  it("does not reorder or persist when a card is dropped onto itself (no movement)", async () => {
+    const { container } = render(<PluginsView />);
+    expect(orderInDom(container)).toEqual(["alpha", "bravo", "charlie"]);
+
+    dragAndDrop(container, "bravo", "bravo");
+
+    // Give any state update a tick — nothing should have changed.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(orderInDom(container)).toEqual(["alpha", "bravo", "charlie"]);
+    // A no-op drop never writes a custom order.
+    expect(localStorage.getItem("pluginOrder")).toBeNull();
+  });
+
+  it("survives a second reorder without duplicating or dropping any id", async () => {
+    const { container } = render(<PluginsView />);
+
+    dragAndDrop(container, "charlie", "alpha"); // → charlie, alpha, bravo
+    await waitFor(() =>
+      expect(orderInDom(container)).toEqual(["charlie", "alpha", "bravo"]),
+    );
+
+    dragAndDrop(container, "bravo", "charlie"); // bravo to the front
+    await waitFor(() =>
+      expect(orderInDom(container)).toEqual(["bravo", "charlie", "alpha"]),
+    );
+
+    const stored = JSON.parse(
+      localStorage.getItem("pluginOrder") ?? "null",
+    ) as string[];
+    const real = stored.filter((id) => id !== "__ui-showcase__");
+    expect(real).toEqual(["bravo", "charlie", "alpha"]);
+    expect(new Set(stored).size).toBe(stored.length);
+    expect(stored.filter((id) => id == null)).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/pages/documents-upload.dnd.test.tsx
+++ b/packages/ui/src/components/pages/documents-upload.dnd.test.tsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+//
+// Native HTML5 file-drop coverage for the Knowledge/Documents upload surface
+// (#10722). Before this, the drag-and-drop upload path — the ONLY drag-drop
+// affordance on the shipped documents surface — had zero tests. These drive a
+// real `drop` DOM event carrying a populated `dataTransfer.files` and assert
+// the SEMANTIC outcome:
+//
+//   • UploadZone.handleDrop  → onFilesUpload fires with the dropped File(s) and
+//     the zone's live scope options; a same-node drop does not bubble into the
+//     DocumentsView root (stopPropagation), so it never double-uploads.
+//   • DocumentsView root drop → the real handleFilesUpload validation +
+//     batching path runs and client.uploadDocumentsBulk is called with the
+//     dropped file's decoded content. Wrong-type / empty / no-file drops are
+//     rejected before any network call.
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentUploadFile } from "./documents-upload.helpers";
+
+const appMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+const clientMock = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  uploadDocumentsBulk: vi.fn(),
+  searchDocuments: vi.fn(),
+}));
+
+vi.mock("../../state", () => ({
+  useApp: () => appMock.value,
+  useAppSelector: (sel: (value: Record<string, unknown>) => unknown) =>
+    sel(appMock.value),
+  useAppSelectorShallow: (sel: (value: Record<string, unknown>) => unknown) =>
+    sel(appMock.value),
+  useTranslation: () => ({ t: appMock.value.t }),
+}));
+vi.mock("../../api/client", () => ({ client: clientMock }));
+vi.mock("../../state/view-chat-binding", () => ({
+  useRegisterViewChatBinding: () => {},
+}));
+vi.mock("../../utils/desktop-dialogs", () => ({
+  confirmDesktopAction: vi.fn(async () => true),
+}));
+
+import { DocumentsView } from "./DocumentsView";
+import { UploadZone } from "./documents-upload";
+
+function t(key: string, options?: { defaultValue?: string }) {
+  return options?.defaultValue ?? key;
+}
+
+/**
+ * A minimal DataTransfer stand-in. jsdom does not implement DataTransfer, so we
+ * hand-build the shape the handlers actually read: `.files` (Array.from'd) and
+ * `.types` (`includes("Files")` on the root dragover gate), plus the mutable
+ * effect fields the drag handlers assign to.
+ */
+function makeDataTransfer(files: File[]) {
+  const store: Record<string, string> = {};
+  return {
+    files,
+    items: files.map((f) => ({
+      kind: "file",
+      type: f.type,
+      getAsFile: () => f,
+    })),
+    types: files.length > 0 ? ["Files"] : [],
+    dropEffect: "none",
+    effectAllowed: "all",
+    setData: (key: string, value: string) => {
+      store[key] = value;
+    },
+    getData: (key: string) => store[key] ?? "",
+    setDragImage: () => {},
+  };
+}
+
+function txtFile(name: string, body: string, type = "text/plain") {
+  return new File([body], name, { type }) as DocumentUploadFile;
+}
+
+beforeEach(() => {
+  appMock.value = { t, setActionNotice: vi.fn() };
+  clientMock.listDocuments.mockReset();
+  clientMock.uploadDocumentsBulk.mockReset();
+  clientMock.searchDocuments.mockReset();
+  clientMock.listDocuments.mockResolvedValue({ documents: [] });
+  clientMock.uploadDocumentsBulk.mockResolvedValue({
+    results: [{ index: 0, ok: true, filename: "notes.txt" }],
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("UploadZone — native file drop (handleDrop)", () => {
+  it("forwards a single dropped file to onFilesUpload with the zone's scope options", () => {
+    const onFilesUpload = vi.fn();
+    const { container } = render(
+      <UploadZone
+        onFilesUpload={onFilesUpload}
+        onTextUpload={vi.fn()}
+        onUrlUpload={vi.fn()}
+        uploading={false}
+        uploadStatus={null}
+      />,
+    );
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+    const file = txtFile("readme.md", "# hello", "text/markdown");
+
+    fireEvent.drop(zone, { dataTransfer: makeDataTransfer([file]) });
+
+    expect(onFilesUpload).toHaveBeenCalledTimes(1);
+    const [files, options] = onFilesUpload.mock.calls[0];
+    expect(files).toHaveLength(1);
+    expect((files[0] as File).name).toBe("readme.md");
+    // Default scope + AI image descriptions are the zone's live options.
+    expect(options).toEqual({
+      includeImageDescriptions: true,
+      scope: "user-private",
+    });
+  });
+
+  it("forwards every file when multiple are dropped at once", () => {
+    const onFilesUpload = vi.fn();
+    const { container } = render(
+      <UploadZone
+        onFilesUpload={onFilesUpload}
+        onTextUpload={vi.fn()}
+        onUrlUpload={vi.fn()}
+        uploading={false}
+        uploadStatus={null}
+      />,
+    );
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+    const files = [
+      txtFile("a.txt", "a"),
+      txtFile("b.txt", "b"),
+      txtFile("c.txt", "c"),
+    ];
+
+    fireEvent.drop(zone, { dataTransfer: makeDataTransfer(files) });
+
+    expect(onFilesUpload).toHaveBeenCalledTimes(1);
+    const dropped = onFilesUpload.mock.calls[0][0] as File[];
+    expect(dropped.map((f) => f.name)).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  it("ignores a drop that carries no files (empty drop)", () => {
+    const onFilesUpload = vi.fn();
+    const { container } = render(
+      <UploadZone
+        onFilesUpload={onFilesUpload}
+        onTextUpload={vi.fn()}
+        onUrlUpload={vi.fn()}
+        uploading={false}
+        uploadStatus={null}
+      />,
+    );
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+
+    fireEvent.drop(zone, { dataTransfer: makeDataTransfer([]) });
+
+    expect(onFilesUpload).not.toHaveBeenCalled();
+  });
+
+  it("ignores a drop while an upload is already in flight", () => {
+    const onFilesUpload = vi.fn();
+    const { container } = render(
+      <UploadZone
+        onFilesUpload={onFilesUpload}
+        onTextUpload={vi.fn()}
+        onUrlUpload={vi.fn()}
+        uploading={true}
+        uploadStatus={{ current: 1, total: 2, filename: "x" }}
+      />,
+    );
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+
+    fireEvent.drop(zone, {
+      dataTransfer: makeDataTransfer([txtFile("a.txt", "a")]),
+    });
+
+    expect(onFilesUpload).not.toHaveBeenCalled();
+  });
+
+  it("stops a zone drop from bubbling into an outer drop target (no double-upload)", () => {
+    const onFilesUpload = vi.fn();
+    const outerDrop = vi.fn();
+    const { container } = render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: test-only outer drop target
+      <div onDrop={outerDrop} data-testid="outer">
+        <UploadZone
+          onFilesUpload={onFilesUpload}
+          onTextUpload={vi.fn()}
+          onUrlUpload={vi.fn()}
+          uploading={false}
+          uploadStatus={null}
+        />
+      </div>,
+    );
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+
+    fireEvent.drop(zone, {
+      dataTransfer: makeDataTransfer([txtFile("a.txt", "a")]),
+    });
+
+    expect(onFilesUpload).toHaveBeenCalledTimes(1);
+    // event.stopPropagation() in handleDrop must keep the outer handler dark.
+    expect(outerDrop).not.toHaveBeenCalled();
+  });
+
+  it("carries the newly selected scope into the drop options", () => {
+    const onFilesUpload = vi.fn();
+    const { container, getByRole } = render(
+      <UploadZone
+        onFilesUpload={onFilesUpload}
+        onTextUpload={vi.fn()}
+        onUrlUpload={vi.fn()}
+        uploading={false}
+        uploadStatus={null}
+      />,
+    );
+    // Switch scope from the default (user-private) to Global before dropping.
+    fireEvent.click(getByRole("button", { name: "Global" }));
+
+    const zone = container.querySelector("fieldset") as HTMLFieldSetElement;
+    fireEvent.drop(zone, {
+      dataTransfer: makeDataTransfer([txtFile("a.txt", "a")]),
+    });
+
+    expect(onFilesUpload).toHaveBeenCalledTimes(1);
+    expect(onFilesUpload.mock.calls[0][1]).toEqual({
+      includeImageDescriptions: true,
+      scope: "global",
+    });
+  });
+});
+
+describe("DocumentsView — root file drop drives the real upload path", () => {
+  async function renderView() {
+    const utils = render(<DocumentsView />);
+    // Wait for the initial listDocuments load to settle so the root is stable.
+    await waitFor(() => expect(clientMock.listDocuments).toHaveBeenCalled());
+    const root = utils.getByTestId("documents-view");
+    return { ...utils, root };
+  }
+
+  it("uploads a dropped .txt file with its decoded content via uploadDocumentsBulk", async () => {
+    const { root } = await renderView();
+    const file = txtFile("notes.txt", "hello world");
+
+    fireEvent.drop(root, { dataTransfer: makeDataTransfer([file]) });
+
+    await waitFor(() =>
+      expect(clientMock.uploadDocumentsBulk).toHaveBeenCalledTimes(1),
+    );
+    const payload = clientMock.uploadDocumentsBulk.mock.calls[0][0] as {
+      documents: Array<{ content: string; filename: string; scope: string }>;
+    };
+    expect(payload.documents).toHaveLength(1);
+    expect(payload.documents[0]).toMatchObject({
+      content: "hello world",
+      filename: "notes.txt",
+      scope: "user-private",
+    });
+  });
+
+  it("batches multiple dropped files into one bulk upload request", async () => {
+    clientMock.uploadDocumentsBulk.mockResolvedValue({
+      results: [
+        { index: 0, ok: true, filename: "one.txt" },
+        { index: 1, ok: true, filename: "two.txt" },
+      ],
+    });
+    const { root } = await renderView();
+
+    fireEvent.drop(root, {
+      dataTransfer: makeDataTransfer([
+        txtFile("one.txt", "first"),
+        txtFile("two.txt", "second"),
+      ]),
+    });
+
+    await waitFor(() =>
+      expect(clientMock.uploadDocumentsBulk).toHaveBeenCalledTimes(1),
+    );
+    const payload = clientMock.uploadDocumentsBulk.mock.calls[0][0] as {
+      documents: Array<{ content: string; filename: string }>;
+    };
+    expect(payload.documents.map((d) => d.filename)).toEqual([
+      "one.txt",
+      "two.txt",
+    ]);
+    expect(payload.documents.map((d) => d.content)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("rejects an unsupported file type without any upload request", async () => {
+    const { root } = await renderView();
+
+    fireEvent.drop(root, {
+      dataTransfer: makeDataTransfer([
+        new File(["MZ"], "malware.exe", {
+          type: "application/octet-stream",
+        }) as DocumentUploadFile,
+      ]),
+    });
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "No supported non-empty files were selected.",
+        "info",
+        3000,
+      ),
+    );
+    expect(clientMock.uploadDocumentsBulk).not.toHaveBeenCalled();
+  });
+
+  it("rejects a supported-but-empty file (zero bytes) without an upload", async () => {
+    const { root } = await renderView();
+
+    fireEvent.drop(root, {
+      dataTransfer: makeDataTransfer([txtFile("empty.txt", "")]),
+    });
+
+    await waitFor(() =>
+      expect(appMock.value.setActionNotice).toHaveBeenCalledWith(
+        "No non-empty files were selected.",
+        "info",
+        3000,
+      ),
+    );
+    expect(clientMock.uploadDocumentsBulk).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when a drop carries no files at all", async () => {
+    const { root } = await renderView();
+
+    fireEvent.drop(root, { dataTransfer: makeDataTransfer([]) });
+
+    // Give any (incorrectly-armed) async path a tick to flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(clientMock.uploadDocumentsBulk).not.toHaveBeenCalled();
+    expect(appMock.value.setActionNotice).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Closes #10722. Native HTML5 drag-and-drop had **zero** automated coverage. This adds real jsdom tests that dispatch actual `dragstart` / `dragover` / `drop` DOM events carrying a populated `DataTransfer` and assert **semantic** outcomes — not "no error". **Test-only: no product source changed.**

## Real code under test

- `packages/ui/src/components/pages/documents-upload.tsx` → `UploadZone.handleDrop` (native file-drop upload)
- `packages/ui/src/components/pages/DocumentsView.tsx` → `handleRootDrop` + the real `handleFilesUpload` validation/batching path
- `packages/ui/src/components/pages/PluginsView.tsx` → `handleDragStart` / `handleDragOver` / `handleDrop` reorder + `localStorage` persistence over draggable `PluginCard` rows

## New tests (16, all passing)

**`documents-upload.dnd.test.tsx` (11)**
- A real `drop` with `dataTransfer.files` invokes `onFilesUpload` with the dropped `File` and the zone's live scope options.
- Dropping a `.txt` on the DocumentsView root drives `handleFilesUpload` → `client.uploadDocumentsBulk` is called with the FileReader-**decoded content** (`"hello world"`), filename and scope.
- Edge cases: multiple files batched into one request; wrong type (`.exe`) rejected with the "No supported non-empty files" notice and **no** network call; supported-but-empty (0-byte) rejected; empty drop no-op; drop-while-uploading ignored.
- A zone drop calls `stopPropagation`, so an outer drop target never fires (no double-upload — the #10722 regression guard).

**`PluginsView.reorder.test.tsx` (5)**
- Dragging a card ahead of / behind a sibling **actually changes the rendered order** and **persists** it to `localStorage["pluginOrder"]`.
- Persisted list has **no duplicate and no `undefined`/`null` ids** across two successive reorders.
- A self-drop (no movement) is a no-op: order unchanged, nothing persisted.

## Evidence

`.github/issue-evidence/10722-native-dnd/` (README + full per-test output).

**Mutation check (not vacuous):** breaking the reorder splice made **3/5** reorder tests fail while the at-rest and no-op tests correctly stayed green; source restored.

## Verification

- `bun run --cwd packages/ui test` (scoped) → **16/16 pass**
- `bun run --cwd packages/ui typecheck` → clean
- `biome check` → clean

N/A: no product source changed, so UI screenshots / video / real-LLM trajectories / device capture do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)