### PR TITLE
fix(cloud): align audio SFX provider edge cases

### DIFF
--- a/.github/issue-evidence/11741-audio-sfx-provider-registry.md
+++ b/.github/issue-evidence/11741-audio-sfx-provider-registry.md
@@ -12,7 +12,7 @@
 - Reviewed `packages/cloud/api/v1/generate-music/route.ts` and confirmed it delegates provider-specific work to the shared audio provider registry.
 - Reviewed `packages/cloud/api/v1/generate-sfx/route.ts` and confirmed credit reservations are refunded when validation or provider execution fails.
 - Reviewed `packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts` and confirmed the binary audio response is persisted through the configured storage adapter.
-- Reviewed `packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts` and confirmed both FAL queue result shapes are normalized before returning to the API route.
+- Reviewed `packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts` and confirmed both object-shaped FAL queue results and direct Stable Audio string URL results are normalized before returning to the API route.
 - Reviewed `packages/cloud/shared/src/lib/services/ai-pricing/providers/sfx.ts` and confirmed the Stable Audio fallback uses the current FAL public price of `$0.20` per audio generation.
 
 ## Validation
@@ -20,7 +20,7 @@
 - `bun run --cwd packages/core build`
 - `bun run --cwd packages/security build`
 - `bun test --isolate --reporter=dots --coverage-reporter=lcov packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.test.ts packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts packages/cloud/shared/src/lib/services/media-model-roster.test.ts packages/cloud/api/__tests__/generate-sfx-route.test.ts`
-  - Result: 20 passing tests, 0 failures, 235 assertions.
+  - Result: 21 passing tests, 0 failures.
 - `bun run --cwd packages/cloud/shared typecheck`
 - `bun run --cwd packages/cloud/api typecheck`
 - `bunx @biomejs/biome check packages/cloud/api/__tests__/generate-sfx-route.test.ts packages/cloud/api/v1/generate-image/route.ts packages/cloud/api/v1/generate-music/route.ts packages/cloud/api/v1/generate-sfx/route.ts packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.test.ts packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts packages/cloud/shared/src/lib/providers/audio/registry.ts packages/cloud/shared/src/lib/providers/audio/types.ts packages/cloud/shared/src/lib/providers/fal-queue.ts packages/cloud/shared/src/lib/providers/image/fal-image-generation.ts packages/cloud/shared/src/lib/services/ai-pricing/providers/sfx.ts packages/cloud/shared/src/lib/services/media-model-roster.ts packages/cloud/shared/src/lib/services/media-model-roster.test.ts`

--- a/packages/cloud/api/__tests__/generate-sfx-route.test.ts
+++ b/packages/cloud/api/__tests__/generate-sfx-route.test.ts
@@ -240,8 +240,8 @@ describe("generate-sfx — validation gates (no money moves)", () => {
   });
 
   test("duration above the per-model cap → 400", async () => {
-    // ElevenLabs SFX caps at 22s.
-    const res = await post({ prompt: "x", model: MODEL, durationSeconds: 30 });
+    // ElevenLabs SFX caps at 30s.
+    const res = await post({ prompt: "x", model: MODEL, durationSeconds: 31 });
     expect(res.status).toBe(400);
     expect(reserve).not.toHaveBeenCalled();
   });

--- a/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts
@@ -114,6 +114,7 @@ describe("generateElevenLabsAudio — sfx", () => {
     expect(req.path).toBe("/v1/sound-generation");
     expect(req.body).toMatchObject({
       text: "glass shattering",
+      model_id: "eleven_text_to_sound_v2",
       duration_seconds: 3,
       prompt_influence: 0.7,
     });

--- a/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.ts
@@ -89,6 +89,7 @@ async function generateElevenLabsSfx(request: AudioGenRequest): Promise<Generate
     },
     body: JSON.stringify({
       text: request.prompt,
+      model_id: "eleven_text_to_sound_v2",
       ...(request.durationSeconds ? { duration_seconds: request.durationSeconds } : {}),
       ...(request.promptInfluence !== undefined
         ? { prompt_influence: request.promptInfluence }

--- a/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.test.ts
@@ -132,6 +132,22 @@ describe("generateFalAudio — sfx", () => {
     expect(result.contentType).toBe("audio/wav");
   });
 
+  test("normalizes Stable Audio direct string audio URL output", async () => {
+    state.responseBody = {
+      audio: `${base}/media/stable-audio.wav`,
+      seed: 123,
+    };
+
+    const result = await generateFalAudio({
+      kind: "sfx",
+      model: "fal-ai/stable-audio-25/text-to-audio",
+      prompt: "x",
+      apiKeys,
+    });
+    if (result.source !== "hosted") throw new Error("expected hosted");
+    expect(result.url).toBe(`${base}/media/stable-audio.wav`);
+  });
+
   test("completed job without audio throws", async () => {
     state.responseBody = { detail: "nothing here" };
 

--- a/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.ts
@@ -21,6 +21,10 @@ interface AudioObject {
 }
 
 function normalizeAudioObject(value: unknown): AudioObject | null {
+  const directUrl = stringValue(value);
+  if (directUrl) {
+    return { url: directUrl };
+  }
   if (!isRecord(value)) return null;
   const url =
     stringValue(value.url) ??

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -553,7 +553,7 @@ export const SUPPORTED_SFX_MODELS: SupportedSfxModelDefinition[] = [
     pageUrl: "https://elevenlabs.io/docs/api-reference/text-to-sound-effects/convert",
     defaultParameters: {
       durationSeconds: 5,
-      maxDurationSeconds: 22,
+      maxDurationSeconds: 30,
     },
   },
   {


### PR DESCRIPTION
## Summary
- follow-up to merged #11765 / #11741
- normalize FAL Stable Audio direct string URL outputs in addition to object-shaped file outputs
- send the documented ElevenLabs `eleven_text_to_sound_v2` SFX model id explicitly
- update the ElevenLabs SFX duration cap to the current documented 30 seconds and adjust evidence/tests

## Validation
- `bun test --isolate --reporter=dots --coverage-reporter=lcov packages/cloud/shared/src/lib/providers/audio/fal-audio-generation.test.ts packages/cloud/shared/src/lib/providers/audio/elevenlabs-audio-generation.test.ts packages/cloud/shared/src/lib/services/media-model-roster.test.ts packages/cloud/api/__tests__/generate-sfx-route.test.ts` - 21 pass, 236 assertions
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- targeted `bunx @biomejs/biome check ...`
- `git diff --check origin/develop..HEAD`

## Evidence
- N/A UI: backend/provider route hardening only.
- N/A live LLM: no agent prompt/model behavior changed.
- Live generated audio/SFX artifacts remain tracked by #11745 because live provider credentials and spend are required.