### PR TITLE
fix(orchestrator): sanitize successor-session roomId at handoff (root cause of #11711/#11720/#11722/#11728)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { readOrigin } from "../services/sub-agent-router.ts";
+import {
+  readOrigin,
+  SUCCESSOR_ROOM_INHERITED_META_KEY,
+  sanitizeSuccessorMetadata,
+} from "../services/sub-agent-router.ts";
 import type { SessionInfo } from "../services/types.ts";
 
 const ORIGIN_ROOM = "11111111-1111-4111-8111-111111111111";
 const TASK_ROOM = "22222222-2222-4222-8222-222222222222";
 const MSG = "33333333-3333-4333-8333-333333333333";
+const SOURCE_ROOM = "44444444-4444-4444-8444-444444444444";
 
 function session(metadata: Record<string, unknown>): SessionInfo {
   return {
@@ -46,5 +51,90 @@ describe("sub-agent Discord reply routing", () => {
 
     expect(origin?.roomId).toBe(ORIGIN_ROOM);
     expect(origin?.taskRoomId).toBe(ORIGIN_ROOM);
+  });
+});
+
+describe("successor-session metadata sanitization (verify-retry / respawn)", () => {
+  it("re-points the forwarded roomId from the task room to the resolvable origin room", () => {
+    // This is the shape TASKS op=spawn_agent stamps: top-level roomId ===
+    // taskRoomId (the minted task-room UUID), with the real chat room on
+    // originRoomId. Forwarding {...meta} wholesale to a verify-retry successor
+    // used to inherit roomId=taskRoomId, which has no live connector channel.
+    const meta: Record<string, unknown> = {
+      originRoomId: ORIGIN_ROOM,
+      taskRoomId: TASK_ROOM,
+      roomId: TASK_ROOM,
+      messageId: MSG,
+      source: "discord",
+      label: "build game",
+      initialTask: "do the thing",
+      buildVerifyRetryCount: 1,
+    };
+
+    const sanitized = sanitizeSuccessorMetadata(meta);
+
+    // Top-level roomId now points at the resolvable, user-facing room — the
+    // same one readOrigin routes to — so downstream emitProgress / synthesis
+    // land on a live channel without individually compensating.
+    expect(sanitized.roomId).toBe(ORIGIN_ROOM);
+    // Explicitly marked as an inherited-and-sanitized target.
+    expect(sanitized[SUCCESSOR_ROOM_INHERITED_META_KEY]).toBe(true);
+    // Fields that MUST carry over are preserved byte-for-byte.
+    expect(sanitized.originRoomId).toBe(ORIGIN_ROOM);
+    expect(sanitized.taskRoomId).toBe(TASK_ROOM);
+    expect(sanitized.source).toBe("discord");
+    expect(sanitized.label).toBe("build game");
+    expect(sanitized.initialTask).toBe("do the thing");
+    expect(sanitized.buildVerifyRetryCount).toBe(1);
+
+    // The sanitized metadata routes through readOrigin identically — the fix
+    // agrees with, rather than diverges from, the origin resolution.
+    const origin = readOrigin(session(sanitized));
+    expect(origin?.roomId).toBe(ORIGIN_ROOM);
+    expect(origin?.taskRoomId).toBe(TASK_ROOM);
+  });
+
+  it("prefers sourceRoomId when no originRoomId is present", () => {
+    const sanitized = sanitizeSuccessorMetadata({
+      sourceRoomId: SOURCE_ROOM,
+      taskRoomId: TASK_ROOM,
+      roomId: TASK_ROOM,
+      source: "discord",
+    });
+    expect(sanitized.roomId).toBe(SOURCE_ROOM);
+    expect(sanitized[SUCCESSOR_ROOM_INHERITED_META_KEY]).toBe(true);
+  });
+
+  it("marks but does not re-point when roomId already equals the resolvable room", () => {
+    // Task rooms opted out (origin === task room): nothing to re-point, but the
+    // successor is still flagged so it's distinguishable from a first spawn.
+    const sanitized = sanitizeSuccessorMetadata({
+      originRoomId: ORIGIN_ROOM,
+      taskRoomId: ORIGIN_ROOM,
+      roomId: ORIGIN_ROOM,
+      source: "discord",
+    });
+    expect(sanitized.roomId).toBe(ORIGIN_ROOM);
+    expect(sanitized[SUCCESSOR_ROOM_INHERITED_META_KEY]).toBe(true);
+  });
+
+  it("leaves metadata untouched when nothing resolvable can be derived", () => {
+    // No UUID room keys at all — no worse than the prior wholesale copy.
+    const meta = { source: "discord", label: "x", initialTask: "y" };
+    const sanitized = sanitizeSuccessorMetadata(meta);
+    expect(sanitized).toEqual(meta);
+    expect(sanitized[SUCCESSOR_ROOM_INHERITED_META_KEY]).toBeUndefined();
+  });
+
+  it("does not mutate the input metadata object", () => {
+    const meta: Record<string, unknown> = {
+      originRoomId: ORIGIN_ROOM,
+      taskRoomId: TASK_ROOM,
+      roomId: TASK_ROOM,
+    };
+    const sanitized = sanitizeSuccessorMetadata(meta);
+    expect(meta.roomId).toBe(TASK_ROOM);
+    expect(meta[SUCCESSOR_ROOM_INHERITED_META_KEY]).toBeUndefined();
+    expect(sanitized).not.toBe(meta);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -61,6 +61,15 @@ const SUB_AGENT_ENTITY_NAMESPACE = "acpx:sub-agent";
 // the successor's sessionId (for traceability); presence is what matters. Kept
 // as a matching local literal in swarm-coordinator-service.ts (no cross-import).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+// Metadata marker the router stamps on a successor session (verify-retry,
+// state-lost respawn, account failover) when it re-points the forwarded
+// `roomId` away from the origin session's raw value. Presence tells downstream
+// consumers (emitProgress, swarm synthesis, coordinator enrichment) the
+// routing keys were sanitized at handoff, not copied from a fresh spawn — a
+// hook for future consumers that want to distinguish an inherited target from
+// a first-class one without re-deriving it. Exported as a matching literal in
+// the tests (no cross-import). See sanitizeSuccessorMetadata below.
+export const SUCCESSOR_ROOM_INHERITED_META_KEY = "successorRoomInherited";
 const QUESTION_FOR_TASK_CREATOR = "QUESTION_FOR_TASK_CREATOR";
 const AGENT_COORDINATION = "AGENT_COORDINATION";
 const SWARM_ROLE_ORDER = ["task", "worktree", "origin"] as const;
@@ -1547,13 +1556,15 @@ export class SubAgentRouter extends Service {
         workdir: session.workdir,
         initialTask: originalTask,
         approvalPreset: session.approvalPreset,
-        // Carry the original metadata forward verbatim — origin routing keys
-        // (roomId/source/...) plus the unchanged `initialTask` — so the
-        // replacement reports back to the same user thread. retryOfSessionId
-        // records the lineage; keepAliveAfterComplete:false mirrors the
-        // verify-retry recovery.
+        // Carry the original metadata forward — origin routing keys
+        // (originRoomId/taskRoomId/source/...) plus the unchanged `initialTask`
+        // — so the replacement reports back to the same user thread, but
+        // SANITIZE the top-level `roomId` to the resolvable origin room instead
+        // of the inherited task-room UUID (see sanitizeSuccessorMetadata).
+        // retryOfSessionId records the lineage; keepAliveAfterComplete:false
+        // mirrors the verify-retry recovery.
         metadata: {
-          ...carriedMeta,
+          ...sanitizeSuccessorMetadata(carriedMeta),
           keepAliveAfterComplete: false,
           retryOfSessionId: session.id,
         },
@@ -1711,10 +1722,13 @@ Do not report done until every referenced URL in the final page resolves without
         initialTask: retryTask,
         approvalPreset: session.approvalPreset,
         // Carry the original metadata forward — origin routing keys
-        // (roomId/source/...) plus the unchanged `initialTask` — and bump
-        // the shared retry counter so the lineage stays bounded.
+        // (originRoomId/taskRoomId/source/...) plus the unchanged `initialTask`
+        // — but SANITIZE the top-level `roomId` first so the successor routes
+        // narration/synthesis to the resolvable origin room, not the inherited
+        // task-room UUID (see sanitizeSuccessorMetadata). Then bump the shared
+        // retry counter so the lineage stays bounded.
         metadata: {
-          ...meta,
+          ...sanitizeSuccessorMetadata(meta),
           buildVerifyRetryCount: nextRetry,
           keepAliveAfterComplete: false,
           retryOfSessionId: session.id,
@@ -2060,6 +2074,62 @@ export function readOrigin(session: SessionInfo): OriginInfo | null {
     spawnRootMessageId: spawnRootIdFromMeta(meta),
     label: pickLabel(meta) ?? session.name ?? session.id,
     source: typeof meta.source === "string" ? meta.source : undefined,
+  };
+}
+
+/**
+ * Sanitize the metadata forwarded to a successor session (verify-retry,
+ * state-lost respawn, account failover) so its routing keys stay resolvable.
+ *
+ * ROOT CAUSE this fixes: TASKS op=spawn_agent stamps `metadata.roomId =
+ * swarmRoomMetadata.taskRoomId` (a freshly minted task-room UUID from
+ * `ensureDistinctTaskRoom`) while carrying the real user-facing chat room on
+ * `originRoomId`. `readOrigin` already prefers `originRoomId ?? sourceRoomId ??
+ * taskRoomId` for the reply room, but every consumer that reads the RAW
+ * top-level `metadata.roomId` (index.ts's session-event hook + emitProgress,
+ * swarm synthesis, coordinator enrichment) sees the task-room UUID. On a fresh
+ * spawn that's tolerable because those paths compensate; but when the router
+ * FORWARDS `{...meta}` wholesale to a successor, the successor inherits a
+ * top-level `roomId` that maps to no live connector channel (live evidence:
+ * task room 8d413ae5 failing while synthesis resolved working room 7b0ef393),
+ * and every downstream site has to individually re-derive the working room.
+ *
+ * Fix at the source: re-point the forwarded top-level `roomId` to the SAME
+ * room the origin router actually routes to (origin.roomId), and stamp
+ * SUCCESSOR_ROOM_INHERITED_META_KEY so consumers can tell the target was
+ * inherited-and-sanitized rather than freshly spawned. Everything else
+ * (`originRoomId`, `sourceRoomId`, `taskRoomId`, `swarmRooms`, `source`,
+ * `label`, retry counters, `initialTask`, …) is preserved byte-for-byte, so
+ * `readOrigin` and the swarm-room fan-out are unchanged. When the origin can't
+ * be read (no room metadata at all) the metadata is returned untouched — no
+ * worse than the prior wholesale copy.
+ *
+ * The downstream compensations that landed as defense-in-depth (#11720
+ * handoff marker, #11728 emitProgress target resolution) remain correct and
+ * are NOT superseded: they now agree with, rather than paper over, the
+ * forwarded `roomId`.
+ */
+export function sanitizeSuccessorMetadata(
+  meta: Record<string, unknown>,
+): Record<string, unknown> {
+  const taskRoomId = pickUuid(meta.taskRoomId) ?? pickUuid(meta.roomId);
+  // Same precedence as readOrigin: the resolvable, user-facing room the origin
+  // router routes replies/narration to.
+  const routingRoomId =
+    pickUuid(meta.originRoomId) ?? pickUuid(meta.sourceRoomId) ?? taskRoomId;
+  // Nothing resolvable to re-point to — leave the metadata exactly as it was.
+  if (!routingRoomId) return { ...meta };
+  const currentRoomId = pickUuid(meta.roomId);
+  // Already pointed at the resolvable room (e.g. task rooms opted out, or the
+  // origin room IS the task room): no re-point needed, but still mark it so a
+  // successor is distinguishable from a first spawn.
+  if (currentRoomId === routingRoomId) {
+    return { ...meta, [SUCCESSOR_ROOM_INHERITED_META_KEY]: true };
+  }
+  return {
+    ...meta,
+    roomId: routingRoomId,
+    [SUCCESSOR_ROOM_INHERITED_META_KEY]: true,
   };
 }
 


### PR DESCRIPTION
Fixes the root cause behind #11711, #11720, #11722 and #11728 (tracked in #11780).

## Problem

`TASKS op=spawn_agent` stamps `metadata.roomId = swarmRoomMetadata.taskRoomId` — a **minted** task-room UUID from `ensureDistinctTaskRoom` with no live connector-channel mapping — while carrying the real user-facing chat room on `originRoomId`. `readOrigin()` already prefers `originRoomId ?? sourceRoomId ?? taskRoomId`, but every consumer of the **raw top-level `metadata.roomId`** (index.ts session-event hook → emitProgress, swarm synthesis `routeSynthesisToConnector`, coordinator enrichment) sees the task-room UUID.

That's tolerable on a fresh spawn (those paths re-derive the channel), but `SubAgentRouter.retryIncompleteBuild` / `respawnStateLost` / account-failover forward the origin metadata **wholesale** (`{...meta}`), so the successor inherits `roomId = taskRoomId` — an unresolvable room. Downstream then throws `Could not resolve Discord channel ID for room …` on every narration tick + heartbeat, and each consumer compensates individually.

**Live evidence:** task room `8d413ae5` failing to route while synthesis independently resolved working room `7b0ef393` for the same task.

## Fix

New `sanitizeSuccessorMetadata(meta)` (pure, exported):
- Re-points the forwarded top-level `roomId` to the resolvable origin room (`originRoomId ?? sourceRoomId ?? taskRoomId` — same precedence as `readOrigin`).
- Stamps `successorRoomInherited: true` so consumers can distinguish an inherited-and-sanitized target from a fresh spawn.
- Preserves every must-carry field byte-for-byte (`originRoomId`, `taskRoomId`, `sourceRoomId`, `swarmRooms`, `source`, `label`, retry counters, `initialTask`).
- No-resolvable-room → returns metadata untouched (no worse than the prior wholesale copy).

Both `retryIncompleteBuild` and `respawnStateLost` route their forwarded metadata through it.

The downstream defense-in-depth from #11720 (handoff marker) and #11728 (emitProgress target resolution) is **unchanged** — it now agrees with the forwarded `roomId` rather than papering over it.

## Tests

Extends `sub-agent-discord-routing.test.ts` (+5):
- re-points task-room → origin room, marks inherited, preserves must-carry fields, round-trips cleanly through `readOrigin`
- prefers `sourceRoomId` when no `originRoomId`
- marks-but-doesn't-re-point when `roomId` already equals the resolvable room (task-rooms opted out)
- passthrough when nothing resolvable can be derived
- does not mutate the input object

`plugin-agent-orchestrator` unit suite: 16 failing tests, all pre-existing env-baseline (`smithers-orchestrator` ×10, `drizzle-orm` ×1, missing cerebras/gemma model env ×5). Verified by stashing this change and re-running the same files on `origin/develop` — identical 14 failures in those files, `sub-agent-discord-routing` green both ways. **Zero new failures.** Biome clean on touched files.

Do not merge without maintainer review.

— [sol-orch]
