### PR TITLE
feat(local-inference): hosted Gemma-4 MTP drafter for eliza-1-4b (closes #11390)

### DIFF
--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/convert-hf-to-gguf.log
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/convert-hf-to-gguf.log
@@ -1,0 +1,95 @@
+INFO:hf-to-gguf:Loading model: model
+INFO:hf-to-gguf:Model architecture: Gemma4AssistantForCausalLM
+INFO:hf-to-gguf:gguf: indexing model part 'model.safetensors'
+INFO:gguf.gguf_writer:gguf: This GGUF file is for Little Endian only
+INFO:hf-to-gguf:Exporting model...
+INFO:hf-to-gguf:rope_freqs.weight,                torch.float32 --> F32, shape = {256}
+INFO:hf-to-gguf:token_embd.weight,                torch.bfloat16 --> F16, shape = {256, 262144}
+INFO:hf-to-gguf:blk.0.attn_norm.weight,           torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.0.layer_output_scale.weight,  torch.bfloat16 --> F32, shape = {1}
+INFO:hf-to-gguf:blk.0.ffn_down.weight,            torch.bfloat16 --> F16, shape = {2048, 256}
+INFO:hf-to-gguf:blk.0.ffn_gate.weight,            torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.0.ffn_up.weight,              torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.0.post_attention_norm.weight, torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.0.post_ffw_norm.weight,       torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.0.ffn_norm.weight,            torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.0.attn_output.weight,         torch.bfloat16 --> F16, shape = {1024, 256}
+INFO:hf-to-gguf:blk.0.attn_q_norm.weight,         torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.0.attn_q.weight,              torch.bfloat16 --> F16, shape = {256, 1024}
+INFO:hf-to-gguf:blk.1.attn_norm.weight,           torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.1.layer_output_scale.weight,  torch.bfloat16 --> F32, shape = {1}
+INFO:hf-to-gguf:blk.1.ffn_down.weight,            torch.bfloat16 --> F16, shape = {2048, 256}
+INFO:hf-to-gguf:blk.1.ffn_gate.weight,            torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.1.ffn_up.weight,              torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.1.post_attention_norm.weight, torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.1.post_ffw_norm.weight,       torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.1.ffn_norm.weight,            torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.1.attn_output.weight,         torch.bfloat16 --> F16, shape = {1024, 256}
+INFO:hf-to-gguf:blk.1.attn_q_norm.weight,         torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.1.attn_q.weight,              torch.bfloat16 --> F16, shape = {256, 1024}
+INFO:hf-to-gguf:blk.2.attn_norm.weight,           torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.2.layer_output_scale.weight,  torch.bfloat16 --> F32, shape = {1}
+INFO:hf-to-gguf:blk.2.ffn_down.weight,            torch.bfloat16 --> F16, shape = {2048, 256}
+INFO:hf-to-gguf:blk.2.ffn_gate.weight,            torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.2.ffn_up.weight,              torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.2.post_attention_norm.weight, torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.2.post_ffw_norm.weight,       torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.2.ffn_norm.weight,            torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.2.attn_output.weight,         torch.bfloat16 --> F16, shape = {1024, 256}
+INFO:hf-to-gguf:blk.2.attn_q_norm.weight,         torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.2.attn_q.weight,              torch.bfloat16 --> F16, shape = {256, 1024}
+INFO:hf-to-gguf:blk.3.attn_norm.weight,           torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.3.layer_output_scale.weight,  torch.bfloat16 --> F32, shape = {1}
+INFO:hf-to-gguf:blk.3.ffn_down.weight,            torch.bfloat16 --> F16, shape = {2048, 256}
+INFO:hf-to-gguf:blk.3.ffn_gate.weight,            torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.3.ffn_up.weight,              torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:blk.3.post_attention_norm.weight, torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.3.post_ffw_norm.weight,       torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.3.ffn_norm.weight,            torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:blk.3.attn_output.weight,         torch.bfloat16 --> F16, shape = {2048, 256}
+INFO:hf-to-gguf:blk.3.attn_q_norm.weight,         torch.bfloat16 --> F32, shape = {512}
+INFO:hf-to-gguf:blk.3.attn_q.weight,              torch.bfloat16 --> F16, shape = {256, 2048}
+INFO:hf-to-gguf:output_norm.weight,               torch.bfloat16 --> F32, shape = {256}
+INFO:hf-to-gguf:nextn.post_projection.weight,     torch.bfloat16 --> F16, shape = {256, 2560}
+INFO:hf-to-gguf:nextn.pre_projection.weight,      torch.bfloat16 --> F16, shape = {5120, 256}
+INFO:hf-to-gguf:Set meta model
+INFO:hf-to-gguf:Set model parameters
+INFO:hf-to-gguf:gguf: context length = 131072
+INFO:hf-to-gguf:gguf: embedding length = 256
+INFO:hf-to-gguf:gguf: feed forward length = 2048
+INFO:hf-to-gguf:gguf: head count = 4
+INFO:hf-to-gguf:gguf: key-value head count = 2
+WARNING:hf-to-gguf:Unknown RoPE type: proportional
+INFO:hf-to-gguf:gguf: rope scaling type = NONE
+INFO:hf-to-gguf:gguf: rope theta = 1000000.0
+INFO:hf-to-gguf:gguf: rope theta swa = 10000.0
+INFO:hf-to-gguf:gguf: rms norm epsilon = 1e-06
+INFO:hf-to-gguf:gguf: file type = 1
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.context_length', overwriting it with new value 131072 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.head_count', overwriting it with new value 4 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.layer_norm_rms_epsilon', overwriting it with new value 1e-06 of type FLOAT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.key_length', overwriting it with new value 256 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.value_length', overwriting it with new value 256 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.rope.freq_base', overwriting it with new value 1000000.0 of type FLOAT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.head_count_kv', overwriting it with new value 2 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.key_length', overwriting it with new value 512 of type UINT32
+WARNING:gguf.gguf_writer:Duplicated key name 'gemma4-assistant.attention.value_length', overwriting it with new value 512 of type UINT32
+INFO:hf-to-gguf:Set model quantization version
+INFO:hf-to-gguf:Set model tokenizer
+INFO:hf-to-gguf:Token '<|tool_call>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<tool_call|>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<|tool_response>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<tool_response|>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<|"|>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<|channel>' is set to USER_DEFINED
+INFO:hf-to-gguf:Token '<channel|>' is set to USER_DEFINED
+INFO:gguf.vocab:Adding 514906 merge(s).
+INFO:gguf.vocab:Setting special token type bos to 2
+INFO:gguf.vocab:Setting special token type eos to 1
+INFO:gguf.vocab:Setting special token type unk to 3
+INFO:gguf.vocab:Setting special token type pad to 0
+INFO:gguf.vocab:Setting special token type mask to 4
+INFO:gguf.gguf_writer:Writing the following files:
+INFO:gguf.gguf_writer:/private/tmp/claude-501/-Users-shawwalters-eliza-workspace-milady-eliza/57726691-214c-40f9-bc80-cc4cdb2cab61/scratchpad/g4a4b/drafter-4b.gguf: n_tensors = 49, total_size = 156.0M
+Writing:   0%|          | 0.00/156M [00:00<?, ?byte/s]Writing:  86%|████████▌ | 134M/156M [00:00<00:00, 273Mbyte/s]Writing: 100%|██████████| 156M/156M [00:00<00:00, 172Mbyte/s]
+INFO:hf-to-gguf:Model successfully exported to /private/tmp/claude-501/-Users-shawwalters-eliza-workspace-milady-eliza/57726691-214c-40f9-bc80-cc4cdb2cab61/scratchpad/g4a4b/drafter-4b.gguf

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/draft-acceptance-bench.txt
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/draft-acceptance-bench.txt
@@ -1,0 +1,45 @@
+gemma4-assistant E4B drafter (f16, converted from google/gemma-4-E4B-it-assistant)
+target: /tmp/vision/gemma4/bundles/4b/text/eliza-1-4b-128k.gguf (eliza-1-4b, gemma4, n_embd 2560, Q8_0)
+host: Apple M4 Max, Metal, llama-server (fork build-desktop-metal @ 58c0391eb), greedy (temperature 0), n_predict 96, --cache-ram 0
+
+=== 3-prompt set (same prompts/methodology as the published 2b numbers) ===
+
+baseline (no drafter):
+  counting-to-twenty : predicted_n=41 tok/s= 54.62
+  quick-brown-fox    : predicted_n= 8 tok/s= 69.51
+  weekdays           : predicted_n=21 tok/s= 53.51
+
+-md drafter --spec-type draft-mtp --spec-draft-n-max 1 (catalog shipped window):
+  counting-to-twenty : predicted_n=41 tok/s= 87.02  draft_n=20 accepted=20  (1.59x, 100%)
+  quick-brown-fox    : predicted_n= 8 tok/s= 77.47  draft_n= 5 accepted= 3  (1.11x,  60%)
+  weekdays           : predicted_n=21 tok/s= 68.92  draft_n=13 accepted= 7  (1.29x,  54%)
+
+aggregate acceptance: 30/38 = 0.79 ; mean tok/s speedup ~1.33x
+greedy outputs byte-identical to baseline on all three prompts
+(server lane emits "seventeen" correctly — the fused-lane tie-flip is
+batched-verify numerics, not a drafter defect).
+
+=== extended 8-prompt set (structured + free-form prose) ===
+
+  prompt                baseline     MTP          draft_n accepted acc    speedup
+  counting-to-twenty    57.26 tok/s  77.44 tok/s  20      20       1.000  1.35x
+  quick-brown-fox       73.36        64.98         5       3       0.600  0.89x
+  weekdays              60.43        64.55        13       7       0.538  1.07x
+  twelve-months         55.76        74.17        18      12       0.667  1.33x
+  why-sky-is-blue       58.89        57.08        35      15       0.429  0.97x
+  autumn-haiku          56.37        53.96        16       5       0.313  0.96x
+  eight-planets         52.07        70.13        35      29       0.829  1.35x
+  hash-table-summary    51.53        59.26        30      10       0.333  1.15x
+
+aggregate acceptance: 101/172 = 0.587
+aggregate decode speedup (sum tokens / sum decode time): 279 tok in 5.01s -> 4.30s = 1.17x
+
+Read: the E4B drafter is strongly positive on structured/list-like generations
+(0.67-1.0 acceptance, 1.3-1.4x) and roughly break-even on short free-form prose
+at draft window 1. Net-positive in aggregate on both prompt sets. Same shape as
+the 2b tier, whose published 0.84 figure is on the 3-prompt structured set.
+
+Full logs: server-baseline.log / server-mtp.log (3-prompt),
+server-baseline-8.log / server-mtp-8.log (8-prompt), prompts.txt.
+"common_speculative_init: adding speculative implementation 'draft-mtp'"
+present in both MTP server logs.

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/drafter-gguf-metadata.txt
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/drafter-gguf-metadata.txt
@@ -1,0 +1,96 @@
+# /private/tmp/claude-501/-Users-shawwalters-eliza-workspace-milady-eliza/57726691-214c-40f9-bc80-cc4cdb2cab61/scratchpad/g4a4b/drafter-4b.gguf: v3 tensors=49 kv=42
+general.architecture = gemma4-assistant
+general.type = model
+general.sampling.top_k = 64
+general.sampling.top_p = 0.949999988079071
+general.sampling.temp = 1.0
+general.name = Model
+general.size_label = 78M
+gemma4-assistant.block_count = 4
+gemma4-assistant.context_length = 131072
+gemma4-assistant.embedding_length = 256
+gemma4-assistant.feed_forward_length = 2048
+gemma4-assistant.attention.head_count = 4
+gemma4-assistant.attention.head_count_kv = 2
+gemma4-assistant.rope.freq_base = 1000000.0
+gemma4-assistant.rope.freq_base_swa = 10000.0
+gemma4-assistant.attention.layer_norm_rms_epsilon = 9.999999974752427e-07
+gemma4-assistant.attention.key_length = 512
+gemma4-assistant.attention.value_length = 512
+general.file_type = 1
+gemma4-assistant.attention.sliding_window = 512
+gemma4-assistant.attention.shared_kv_layers = 4
+gemma4-assistant.embedding_length_per_layer_input = 0
+gemma4-assistant.attention.sliding_window_pattern = [1, 1, 1, 0]
+gemma4-assistant.attention.key_length_swa = 256
+gemma4-assistant.attention.value_length_swa = 256
+gemma4-assistant.rope.dimension_count = 512
+gemma4-assistant.rope.dimension_count_swa = 256
+gemma4-assistant.embedding_length_out = 2560
+gemma4-assistant.nextn_predict_layers = 1
+general.quantization_version = 2
+tokenizer.ggml.model = gemma4
+tokenizer.ggml.bos_token_id = 2
+tokenizer.ggml.eos_token_id = 1
+tokenizer.ggml.unknown_token_id = 3
+tokenizer.ggml.padding_token_id = 0
+tokenizer.ggml.mask_token_id = 4
+tokenizer.ggml.add_space_prefix = 0
+tokenizer.ggml.add_bos_token = 1
+T rope_freqs.weight [256] type=0
+T token_embd.weight [256, 262144] type=1
+T blk.0.attn_norm.weight [256] type=0
+T blk.0.layer_output_scale.weight [1] type=0
+T blk.0.ffn_down.weight [2048, 256] type=1
+T blk.0.ffn_gate.weight [256, 2048] type=1
+T blk.0.ffn_up.weight [256, 2048] type=1
+T blk.0.post_attention_norm.weight [256] type=0
+T blk.0.post_ffw_norm.weight [256] type=0
+T blk.0.ffn_norm.weight [256] type=0
+T blk.0.attn_output.weight [1024, 256] type=1
+T blk.0.attn_q_norm.weight [256] type=0
+T blk.0.attn_q.weight [256, 1024] type=1
+T blk.1.attn_norm.weight [256] type=0
+T blk.1.layer_output_scale.weight [1] type=0
+T blk.1.ffn_down.weight [2048, 256] type=1
+T blk.1.ffn_gate.weight [256, 2048] type=1
+T blk.1.ffn_up.weight [256, 2048] type=1
+T blk.1.post_attention_norm.weight [256] type=0
+T blk.1.post_ffw_norm.weight [256] type=0
+T blk.1.ffn_norm.weight [256] type=0
+T blk.1.attn_output.weight [1024, 256] type=1
+T blk.1.attn_q_norm.weight [256] type=0
+T blk.1.attn_q.weight [256, 1024] type=1
+T blk.2.attn_norm.weight [256] type=0
+T blk.2.layer_output_scale.weight [1] type=0
+T blk.2.ffn_down.weight [2048, 256] type=1
+T blk.2.ffn_gate.weight [256, 2048] type=1
+T blk.2.ffn_up.weight [256, 2048] type=1
+T blk.2.post_attention_norm.weight [256] type=0
+T blk.2.post_ffw_norm.weight [256] type=0
+T blk.2.ffn_norm.weight [256] type=0
+T blk.2.attn_output.weight [1024, 256] type=1
+T blk.2.attn_q_norm.weight [256] type=0
+T blk.2.attn_q.weight [256, 1024] type=1
+T blk.3.attn_norm.weight [256] type=0
+T blk.3.layer_output_scale.weight [1] type=0
+T blk.3.ffn_down.weight [2048, 256] type=1
+T blk.3.ffn_gate.weight [256, 2048] type=1
+T blk.3.ffn_up.weight [256, 2048] type=1
+T blk.3.post_attention_norm.weight [256] type=0
+T blk.3.post_ffw_norm.weight [256] type=0
+T blk.3.ffn_norm.weight [256] type=0
+T blk.3.attn_output.weight [2048, 256] type=1
+T blk.3.attn_q_norm.weight [512] type=0
+T blk.3.attn_q.weight [256, 2048] type=1
+T output_norm.weight [256] type=0
+T nextn.post_projection.weight [256, 2560] type=1
+T nextn.pre_projection.weight [5120, 256] type=1
+Traceback (most recent call last):
+  File "/private/tmp/claude-501/-Users-shawwalters-eliza-workspace-milady-eliza/1922753a-a0a5-43ed-9312-34c30cea32cf/scratchpad/ggufkv.py", line 30, in <module>
+    read_gguf(p, show_tensors='--tensors' in sys.argv and not p.startswith('--'))
+    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/private/tmp/claude-501/-Users-shawwalters-eliza-workspace-milady-eliza/1922753a-a0a5-43ed-9312-34c30cea32cf/scratchpad/ggufkv.py", line 3, in read_gguf
+    with open(path,'rb') as f:
+         ~~~~^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: '--tensors'

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-bench.txt
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-bench.txt
@@ -1,0 +1,54 @@
+gemma4-assistant E4B drafter — FUSED PRODUCT-PATH proof (libelizainference.dylib) — 4b tier
+============================================================================================
+This is the desktop product path — NOT llama-server. The harness
+(fused-ffi-harness-4b.ts) drives the plugin's own bun:ffi binding
+(src/services/voice/ffi-bindings.ts loadElizaInferenceFfi) against
+build-desktop-metal/bin/libelizainference.dylib built from the develop-pinned
+fork commit 58c0391eb (2bdcef890 + the two #11612 Metal fixes):
+eliza_inference_llm_stream_open with mtp_drafter_path set -> the fused
+separate-drafter DRAFT_MTP engine (LLAMA_CONTEXT_TYPE_MTP draft context,
+ctx_other = target context, shared KV / target tok_embd).
+
+host    : Apple M4 Max, Metal, bun, greedy (temperature 0), maxTokens 96, ctx 4096
+target  : /tmp/vision/gemma4/bundles/4b/text/eliza-1-4b-128k.gguf
+          (gemma4, n_embd 2560, 42 layers, Q8_0,
+           sha256 fb8f0c032de00b18c710824af3c7e5777c71e5fb60b13f13575f0a9e92ddecd0
+           == the manifest files.text entry — verified after download)
+drafter : /tmp/mtp/bundles/4b/mtp/drafter-4b.gguf (gemma4-assistant, 49 tensors,
+          block_count 4, embedding_length 256 -> out 2560, f16,
+          converted from google/gemma-4-E4B-it-assistant,
+          sha256 e4585e558a74e4548d0c712ce1188919c6f42beadb893c7397a34db883988db3)
+window  : draftMin=1 draftMax=1 (the shipped catalog window)
+
+capability probes: llmStreamSupported=true llmMtpSupported=true tokenizeSupported=true
+drafter load     : clean — no tensor/KV mismatch; "common_speculative_init: adding
+                   speculative implementation 'draft-mtp'"
+
+prompt                       baseline      MTP           drafted accepted acceptance
+counting-to-twenty           30.6 tok/s    56.0 tok/s    20      20       1.000
+weekdays                     38.4 tok/s    40.1 tok/s    11       9       0.818
+                                                         ------  ------   -----
+TOTAL                                                    31      29       0.935
+wall speedup (prefill+decode): 1306ms -> 697ms (1.87x) on counting;
+520ms -> 498ms (1.04x) on weekdays.
+
+output coherence: both MTP outputs coherent; weekdays output is byte-identical
+to the greedy baseline.
+
+HONEST FLAG — same deterministic one-token tie-flip as the 2b capture, on the
+same counting prompt: the fused MTP run emits "... fifteen, sixteen,, eighteen ..."
+(skips "seventeen", n=39 vs 40). All tokens after the flip match the baseline
+exactly, so draft-rollback/KV retraction is correct; this is the target's own
+batched-verify logits (n_tokens=2 Metal kernels) flipping a near-tie argmax vs
+single-token decode — the known speculative-decode numerics artifact documented
+in the 2b fused-ffi-bench.txt, not a drafter tensor/KV mapping defect. The
+llama-server lane on the SAME weights emits "seventeen" correctly with 20/20
+acceptance (see draft-acceptance-bench-4b.txt), confirming the drafter mapping
+is sound.
+
+teardown: streams + ctx close cleanly ("[harness] clean shutdown"); the known
+GGML Metal residency-set assert fires later in __cxa_finalize at process exit,
+after all inference work completed — exit-time only, upstream teardown-order
+issue, unrelated to MTP (same as the 2b capture).
+
+Full log: fused-ffi-run-4b.txt. Harness: fused-ffi-harness-4b.ts.

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-harness.ts
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-harness.ts
@@ -1,0 +1,114 @@
+/**
+ * Fused-lib product-path proof harness for the gemma4-assistant MTP drafter — 4b tier.
+ *
+ * Drives the EXACT desktop text path: libelizainference.dylib ABI
+ * `eliza_inference_llm_stream_open` with `mtp_drafter_path` set (the
+ * separate-drafter MTP engine, ctx_other shared-KV), via the plugin's own
+ * `loadElizaInferenceFfi` binding — no mocks, no llama-server.
+ *
+ * Target : /tmp/vision/gemma4/bundles/4b/text/eliza-1-4b-128k.gguf (gemma4, n_embd 2560)
+ * Drafter: /tmp/mtp/bundles/4b/mtp/drafter-4b.gguf (gemma4-assistant, E4B, out 2560)
+ */
+import { loadElizaInferenceFfi } from "/private/tmp/eliza-11390/plugins/plugin-local-inference/src/services/voice/ffi-bindings";
+
+const LIB =
+	"/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib";
+const BUNDLE_ROOT = "/tmp/vision/gemma4/bundles/4b";
+const DRAFTER = "/tmp/mtp/bundles/4b/mtp/drafter-4b.gguf";
+const MAX_TOKENS = 96;
+
+const PROMPTS = [
+	"Count from one to twenty, writing each number as a word separated by commas.",
+	"List the seven days of the week in order, one per line.",
+];
+
+function gemmaPrompt(user: string): string {
+	return `<start_of_turn>user\n${user}<end_of_turn>\n<start_of_turn>model\n`;
+}
+
+const ffi = loadElizaInferenceFfi(LIB);
+console.log(`[harness] lib=${LIB}`);
+console.log(
+	`[harness] abi=${ffi.abiVersion?.() ?? "?"} llmStreamSupported=${ffi.llmStreamSupported?.()} llmMtpSupported=${ffi.llmMtpSupported?.()} tokenizeSupported=${ffi.tokenizeSupported?.()}`,
+);
+
+const ctx = ffi.create(BUNDLE_ROOT);
+console.log(`[harness] fused ctx created over bundle root ${BUNDLE_ROOT}`);
+
+interface RunResult {
+	text: string;
+	nGenerated: number;
+	ms: number;
+	drafted: number;
+	accepted: number;
+}
+
+function run(user: string, mtp: boolean): RunResult {
+	const tokens = ffi.tokenize({ ctx, text: gemmaPrompt(user) });
+	const stream = ffi.llmStreamOpen({
+		ctx,
+		config: {
+			maxTokens: MAX_TOKENS,
+			temperature: 0, // greedy so baseline and MTP outputs must match
+			topP: 1,
+			topK: 0,
+			repeatPenalty: 1,
+			slotId: -1,
+			promptCacheKey: null,
+			draftMin: mtp ? 1 : 0,
+			draftMax: mtp ? 1 : 0,
+			draftModelPath: mtp ? DRAFTER : null,
+			gpuLayers: -1,
+			contextSize: 4096,
+		},
+	});
+	let text = "";
+	let nGenerated = 0;
+	let drafted = 0;
+	let accepted = 0;
+	const t0 = performance.now();
+	try {
+		ffi.llmStreamPrefill({ stream, tokens });
+		for (;;) {
+			const step = ffi.llmStreamNext({ stream, maxTokensPerStep: 32 });
+			text += step.text;
+			nGenerated += step.tokens.length;
+			drafted += step.drafterDrafted;
+			accepted += step.drafterAccepted;
+			if (step.done || nGenerated >= MAX_TOKENS) break;
+		}
+	} finally {
+		ffi.llmStreamClose({ stream });
+	}
+	const ms = performance.now() - t0;
+	return { text, nGenerated, ms, drafted, accepted };
+}
+
+let totDrafted = 0;
+let totAccepted = 0;
+for (const p of PROMPTS) {
+	console.log(`\n=== prompt: ${JSON.stringify(p)}`);
+	const base = run(p, false);
+	console.log(
+		`[baseline] n=${base.nGenerated} ${(base.nGenerated / (base.ms / 1000)).toFixed(1)} tok/s (prefill+decode ${base.ms.toFixed(0)}ms)`,
+	);
+	console.log(`[baseline] text: ${JSON.stringify(base.text)}`);
+	const mtp = run(p, true);
+	totDrafted += mtp.drafted;
+	totAccepted += mtp.accepted;
+	console.log(
+		`[mtp]      n=${mtp.nGenerated} ${(mtp.nGenerated / (mtp.ms / 1000)).toFixed(1)} tok/s (prefill+decode ${mtp.ms.toFixed(0)}ms) drafted=${mtp.drafted} accepted=${mtp.accepted} acceptance=${mtp.drafted > 0 ? (mtp.accepted / mtp.drafted).toFixed(3) : "n/a"}`,
+	);
+	console.log(`[mtp]      text: ${JSON.stringify(mtp.text)}`);
+	console.log(
+		`[check]    greedy outputs identical: ${mtp.text === base.text}`,
+	);
+}
+
+console.log(
+	`\n[TOTAL] drafted=${totDrafted} accepted=${totAccepted} acceptance=${totDrafted > 0 ? (totAccepted / totDrafted).toFixed(3) : "n/a"}`,
+);
+
+ffi.destroy(ctx);
+ffi.close();
+console.log("[harness] clean shutdown");

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-run.txt
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/fused-ffi-run.txt
@@ -1,0 +1,2501 @@
+[harness] lib=/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/build-desktop-metal/bin/libelizainference.dylib
+[harness] abi=? llmStreamSupported=true llmMtpSupported=true tokenizeSupported=true
+[harness] fused ctx created over bundle root /tmp/vision/gemma4/bundles/4b
+
+=== prompt: "Count from one to twenty, writing each number as a word separated by commas."
+ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
+ggml_metal_library_init: using embedded compiled metal library
+ggml_metal_library_init: loaded in 0.008 sec
+ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
+ggml_metal_device_init: GPU name:   MTL0 (Apple M4 Max)
+ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
+ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
+ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
+ggml_metal_device_init: simdgroup reduction   = true
+ggml_metal_device_init: simdgroup matrix mul. = true
+ggml_metal_device_init: has unified memory    = true
+ggml_metal_device_init: has bfloat            = true
+ggml_metal_device_init: has tensor            = false
+ggml_metal_device_init: use residency sets    = true
+ggml_metal_device_init: use shared buffers    = true
+ggml_metal_device_init: use managed buffers   = false
+ggml_metal_device_init: recommendedMaxWorkingSetSize  = 115448.73 MB
+llama_model_loader: loaded meta data with 44 key-value pairs and 720 tensors from /tmp/vision/gemma4/bundles/4b/text/eliza-1-4b-128k.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = gemma4
+llama_model_loader: - kv   1:                               general.type str              = model
+llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 64
+llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+llama_model_loader: - kv   5:                         general.size_label str              = 7.5B
+llama_model_loader: - kv   6:                            general.license str              = apache-2.0
+llama_model_loader: - kv   7:                       general.license.link str              = https://ai.google.dev/gemma/docs/gemm...
+llama_model_loader: - kv   8:                               general.tags arr[str,1]       = ["any-to-any"]
+llama_model_loader: - kv   9:                         gemma4.block_count u32              = 42
+llama_model_loader: - kv  10:                      gemma4.context_length u32              = 131072
+llama_model_loader: - kv  11:                    gemma4.embedding_length u32              = 2560
+llama_model_loader: - kv  12:                 gemma4.feed_forward_length u32              = 10240
+llama_model_loader: - kv  13:                gemma4.attention.head_count u32              = 8
+llama_model_loader: - kv  14:             gemma4.attention.head_count_kv u32              = 2
+llama_model_loader: - kv  15:                      gemma4.rope.freq_base f32              = 1000000.000000
+llama_model_loader: - kv  16:                  gemma4.rope.freq_base_swa f32              = 10000.000000
+llama_model_loader: - kv  17:    gemma4.attention.layer_norm_rms_epsilon f32              = 0.000001
+llama_model_loader: - kv  18:                gemma4.attention.key_length u32              = 512
+llama_model_loader: - kv  19:              gemma4.attention.value_length u32              = 512
+llama_model_loader: - kv  20:             gemma4.final_logit_softcapping f32              = 30.000000
+llama_model_loader: - kv  21:            gemma4.attention.sliding_window u32              = 512
+llama_model_loader: - kv  22:          gemma4.attention.shared_kv_layers u32              = 18
+llama_model_loader: - kv  23:    gemma4.embedding_length_per_layer_input u32              = 256
+llama_model_loader: - kv  24:    gemma4.attention.sliding_window_pattern arr[bool,42]     = [true, true, true, true, true, false,...
+llama_model_loader: - kv  25:            gemma4.attention.key_length_swa u32              = 256
+llama_model_loader: - kv  26:          gemma4.attention.value_length_swa u32              = 256
+llama_model_loader: - kv  27:                gemma4.rope.dimension_count u32              = 512
+llama_model_loader: - kv  28:            gemma4.rope.dimension_count_swa u32              = 256
+llama_model_loader: - kv  29:                       tokenizer.ggml.model str              = gemma4
+llama_model_loader: - kv  30:                      tokenizer.ggml.tokens arr[str,262144]  = ["<pad>", "<eos>", "<bos>", "<unk>", ...
+llama_model_loader: - kv  31:                      tokenizer.ggml.scores arr[f32,262144]  = [-1000.000000, -1000.000000, -1000.00...
+llama_model_loader: - kv  32:                  tokenizer.ggml.token_type arr[i32,262144]  = [3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  33:                      tokenizer.ggml.merges arr[str,514906]  = ["\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n \n", ...
+llama_model_loader: - kv  34:                tokenizer.ggml.bos_token_id u32              = 2
+llama_model_loader: - kv  35:                tokenizer.ggml.eos_token_id u32              = 1
+llama_model_loader: - kv  36:            tokenizer.ggml.unknown_token_id u32              = 3
+llama_model_loader: - kv  37:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  38:               tokenizer.ggml.mask_token_id u32              = 4
+llama_model_loader: - kv  39:                    tokenizer.chat_template str              = {%- macro format_parameters(propertie...
+llama_model_loader: - kv  40:            tokenizer.ggml.add_space_prefix bool             = false
+llama_model_loader: - kv  41:               tokenizer.ggml.add_bos_token bool             = true
+llama_model_loader: - kv  42:               general.quantization_version u32              = 2
+llama_model_loader: - kv  43:                          general.file_type u32              = 7
+llama_model_loader: - type  f32:  339 tensors
+llama_model_loader: - type q8_0:  380 tensors
+llama_model_loader: - type bf16:    1 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = Q8_0
+print_info: file size   = 7.46 GiB (8.53 BPW) 
+llama_prepare_model_devices: using device MTL0 (Apple M4 Max) (unknown id) - 110100 MiB free
+init_tokenizer: initializing tokenizer for type 2
+load: 0 unused tokens
+load: control token: 258883 '<audio|>' is not marked as EOG
+load: control token: 258881 '<|audio|>' is not marked as EOG
+load: control token: 258880 '<|image|>' is not marked as EOG
+load: control token: 256000 '<|audio>' is not marked as EOG
+load: control token: 255999 '<|image>' is not marked as EOG
+load: control token:    105 '<|turn>' is not marked as EOG
+load: control token: 258882 '<image|>' is not marked as EOG
+load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token:     46 '<|tool>' is not marked as EOG
+load: control token:      3 '<unk>' is not marked as EOG
+load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token: 258884 '<|video|>' is not marked as EOG
+load: control token:     47 '<tool|>' is not marked as EOG
+load: control token:      4 '<mask>' is not marked as EOG
+load: control token:      2 '<bos>' is not marked as EOG
+load: control token:     98 '<|think|>' is not marked as EOG
+load: control token:      0 '<pad>' is not marked as EOG
+load: printing all EOG tokens:
+load:   - 1 ('<eos>')
+load:   - 50 ('<|tool_response>')
+load:   - 106 ('<turn|>')
+load:   - 212 ('</s>')
+load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
+load: special tokens cache size = 24
+load: token to piece cache size = 1.9445 MB
+print_info: arch                  = gemma4
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 131072
+print_info: n_embd                = 2560
+print_info: n_embd_inp            = 2560
+print_info: n_layer               = 42
+print_info: n_head                = 8
+print_info: n_head_kv             = 2
+print_info: n_rot                 = 512
+print_info: n_swa                 = 512
+print_info: is_swa_any            = 1
+print_info: n_embd_head_k         = 512
+print_info: n_embd_head_v         = 512
+print_info: n_gqa                 = 4
+print_info: n_embd_k_gqa          = [512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024]
+print_info: n_embd_v_gqa          = [512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024, 512, 512, 512, 512, 512, 1024]
+print_info: f_norm_eps            = 0.0e+00
+print_info: f_norm_rms_eps        = 1.0e-06
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 1.0e+00
+print_info: f_attn_value_scale    = 0.0000
+print_info: n_ff                  = 10240
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 1
+print_info: pooling type          = -1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 1000000.0
+print_info: freq_scale_train      = 1
+print_info: freq_base_swa         = 10000.0
+print_info: freq_scale_swa        = 1
+print_info: n_embd_head_k_swa     = 256
+print_info: n_embd_head_v_swa     = 256
+print_info: n_rot_swa             = 256
+print_info: n_ctx_orig_yarn       = 131072
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = E4B
+print_info: model params          = 7.52 B
+print_info: general.name          = n/a
+print_info: vocab type            = BPE
+print_info: n_vocab               = 262144
+print_info: n_merges              = 514906
+print_info: BOS token             = 2 '<bos>'
+print_info: EOS token             = 1 '<eos>'
+print_info: UNK token             = 3 '<unk>'
+print_info: PAD token             = 0 '<pad>'
+print_info: MASK token            = 4 '<mask>'
+print_info: LF token              = 107 '
+'
+print_info: EOG token             = 1 '<eos>'
+print_info: EOG token             = 50 '<|tool_response>'
+print_info: EOG token             = 106 '<turn|>'
+print_info: max token length      = 93
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: layer   0 assigned to device MTL0, is_swa = 1
+load_tensors: layer   1 assigned to device MTL0, is_swa = 1
+load_tensors: layer   2 assigned to device MTL0, is_swa = 1
+load_tensors: layer   3 assigned to device MTL0, is_swa = 1
+load_tensors: layer   4 assigned to device MTL0, is_swa = 1
+load_tensors: layer   5 assigned to device MTL0, is_swa = 0
+load_tensors: layer   6 assigned to device MTL0, is_swa = 1
+load_tensors: layer   7 assigned to device MTL0, is_swa = 1
+load_tensors: layer   8 assigned to device MTL0, is_swa = 1
+load_tensors: layer   9 assigned to device MTL0, is_swa = 1
+load_tensors: layer  10 assigned to device MTL0, is_swa = 1
+load_tensors: layer  11 assigned to device MTL0, is_swa = 0
+load_tensors: layer  12 assigned to device MTL0, is_swa = 1
+load_tensors: layer  13 assigned to device MTL0, is_swa = 1
+load_tensors: layer  14 assigned to device MTL0, is_swa = 1
+load_tensors: layer  15 assigned to device MTL0, is_swa = 1
+load_tensors: layer  16 assigned to device MTL0, is_swa = 1
+load_tensors: layer  17 assigned to device MTL0, is_swa = 0
+load_tensors: layer  18 assigned to device MTL0, is_swa = 1
+load_tensors: layer  19 assigned to device MTL0, is_swa = 1
+load_tensors: layer  20 assigned to device MTL0, is_swa = 1
+load_tensors: layer  21 assigned to device MTL0, is_swa = 1
+load_tensors: layer  22 assigned to device MTL0, is_swa = 1
+load_tensors: layer  23 assigned to device MTL0, is_swa = 0
+load_tensors: layer  24 assigned to device MTL0, is_swa = 1
+load_tensors: layer  25 assigned to device MTL0, is_swa = 1
+load_tensors: layer  26 assigned to device MTL0, is_swa = 1
+load_tensors: layer  27 assigned to device MTL0, is_swa = 1
+load_tensors: layer  28 assigned to device MTL0, is_swa = 1
+load_tensors: layer  29 assigned to device MTL0, is_swa = 0
+load_tensors: layer  30 assigned to device MTL0, is_swa = 1
+load_tensors: layer  31 assigned to device MTL0, is_swa = 1
+load_tensors: layer  32 assigned to device MTL0, is_swa = 1
+load_tensors: layer  33 assigned to device MTL0, is_swa = 1
+load_tensors: layer  34 assigned to device MTL0, is_swa = 1
+load_tensors: layer  35 assigned to device MTL0, is_swa = 0
+load_tensors: layer  36 assigned to device MTL0, is_swa = 1
+load_tensors: layer  37 assigned to device MTL0, is_swa = 1
+load_tensors: layer  38 assigned to device MTL0, is_swa = 1
+load_tensors: layer  39 assigned to device MTL0, is_swa = 1
+load_tensors: layer  40 assigned to device MTL0, is_swa = 1
+load_tensors: layer  41 assigned to device MTL0, is_swa = 0
+load_tensors: layer  42 assigned to device MTL0, is_swa = 0
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor per_layer_token_embd.weight
+create_tensor: loading tensor per_layer_model_proj.weight
+create_tensor: loading tensor per_layer_proj_norm.weight
+create_tensor: loading tensor output_norm.weight
+create_tensor: loading tensor blk.0.attn_norm.weight
+create_tensor: loading tensor blk.0.attn_q.weight
+create_tensor: loading tensor blk.0.attn_k.weight
+create_tensor: loading tensor blk.0.attn_v.weight
+create_tensor: loading tensor blk.0.attn_output.weight
+create_tensor: loading tensor blk.0.attn_q_norm.weight
+create_tensor: loading tensor blk.0.attn_k_norm.weight
+create_tensor: loading tensor blk.0.post_attention_norm.weight
+create_tensor: loading tensor blk.0.layer_output_scale.weight
+create_tensor: loading tensor blk.0.ffn_norm.weight
+create_tensor: loading tensor blk.0.ffn_gate.weight
+create_tensor: loading tensor blk.0.ffn_up.weight
+create_tensor: loading tensor blk.0.ffn_down.weight
+create_tensor: loading tensor blk.0.post_ffw_norm.weight
+create_tensor: loading tensor blk.0.inp_gate.weight
+create_tensor: loading tensor blk.0.proj.weight
+create_tensor: loading tensor blk.0.post_norm.weight
+create_tensor: loading tensor blk.1.attn_norm.weight
+create_tensor: loading tensor blk.1.attn_q.weight
+create_tensor: loading tensor blk.1.attn_k.weight
+create_tensor: loading tensor blk.1.attn_v.weight
+create_tensor: loading tensor blk.1.attn_output.weight
+create_tensor: loading tensor blk.1.attn_q_norm.weight
+create_tensor: loading tensor blk.1.attn_k_norm.weight
+create_tensor: loading tensor blk.1.post_attention_norm.weight
+create_tensor: loading tensor blk.1.layer_output_scale.weight
+create_tensor: loading tensor blk.1.ffn_norm.weight
+create_tensor: loading tensor blk.1.ffn_gate.weight
+create_tensor: loading tensor blk.1.ffn_up.weight
+create_tensor: loading tensor blk.1.ffn_down.weight
+create_tensor: loading tensor blk.1.post_ffw_norm.weight
+create_tensor: loading tensor blk.1.inp_gate.weight
+create_tensor: loading tensor blk.1.proj.weight
+create_tensor: loading tensor blk.1.post_norm.weight
+create_tensor: loading tensor blk.2.attn_norm.weight
+create_tensor: loading tensor blk.2.attn_q.weight
+create_tensor: loading tensor blk.2.attn_k.weight
+create_tensor: loading tensor blk.2.attn_v.weight
+create_tensor: loading tensor blk.2.attn_output.weight
+create_tensor: loading tensor blk.2.attn_q_norm.weight
+create_tensor: loading tensor blk.2.attn_k_norm.weight
+create_tensor: loading tensor blk.2.post_attention_norm.weight
+create_tensor: loading tensor blk.2.layer_output_scale.weight
+create_tensor: loading tensor blk.2.ffn_norm.weight
+create_tensor: loading tensor blk.2.ffn_gate.weight
+create_tensor: loading tensor blk.2.ffn_up.weight
+create_tensor: loading tensor blk.2.ffn_down.weight
+create_tensor: loading tensor blk.2.post_ffw_norm.weight
+create_tensor: loading tensor blk.2.inp_gate.weight
+create_tensor: loading tensor blk.2.proj.weight
+create_tensor: loading tensor blk.2.post_norm.weight
+create_tensor: loading tensor blk.3.attn_norm.weight
+create_tensor: loading tensor blk.3.attn_q.weight
+create_tensor: loading tensor blk.3.attn_k.weight
+create_tensor: loading tensor blk.3.attn_v.weight
+create_tensor: loading tensor blk.3.attn_output.weight
+create_tensor: loading tensor blk.3.attn_q_norm.weight
+create_tensor: loading tensor blk.3.attn_k_norm.weight
+create_tensor: loading tensor blk.3.post_attention_norm.weight
+create_tensor: loading tensor blk.3.layer_output_scale.weight
+create_tensor: loading tensor blk.3.ffn_norm.weight
+create_tensor: loading tensor blk.3.ffn_gate.weight
+create_tensor: loading tensor blk.3.ffn_up.weight
+create_tensor: loading tensor blk.3.ffn_down.weight
+create_tensor: loading tensor blk.3.post_ffw_norm.weight
+create_tensor: loading tensor blk.3.inp_gate.weight
+create_tensor: loading tensor blk.3.proj.weight
+create_tensor: loading tensor blk.3.post_norm.weight
+create_tensor: loading tensor blk.4.attn_norm.weight
+create_tensor: loading tensor blk.4.attn_q.weight
+create_tensor: loading tensor blk.4.attn_k.weight
+create_tensor: loading tensor blk.4.attn_v.weight
+create_tensor: loading tensor blk.4.attn_output.weight
+create_tensor: loading tensor blk.4.attn_q_norm.weight
+create_tensor: loading tensor blk.4.attn_k_norm.weight
+create_tensor: loading tensor blk.4.post_attention_norm.weight
+create_tensor: loading tensor blk.4.layer_output_scale.weight
+create_tensor: loading tensor blk.4.ffn_norm.weight
+create_tensor: loading tensor blk.4.ffn_gate.weight
+create_tensor: loading tensor blk.4.ffn_up.weight
+create_tensor: loading tensor blk.4.ffn_down.weight
+create_tensor: loading tensor blk.4.post_ffw_norm.weight
+create_tensor: loading tensor blk.4.inp_gate.weight
+create_tensor: loading tensor blk.4.proj.weight
+create_tensor: loading tensor blk.4.post_norm.weight
+create_tensor: loading tensor blk.5.attn_norm.weight
+create_tensor: loading tensor blk.5.attn_q.weight
+create_tensor: loading tensor blk.5.attn_k.weight
+create_tensor: loading tensor blk.5.attn_v.weight
+create_tensor: loading tensor blk.5.attn_output.weight
+create_tensor: loading tensor blk.5.attn_q_norm.weight
+create_tensor: loading tensor blk.5.attn_k_norm.weight
+create_tensor: loading tensor blk.5.post_attention_norm.weight
+create_tensor: loading tensor blk.5.layer_output_scale.weight
+create_tensor: loading tensor rope_freqs.weight
+create_tensor: loading tensor blk.5.ffn_norm.weight
+create_tensor: loading tensor blk.5.ffn_gate.weight
+create_tensor: loading tensor blk.5.ffn_up.weight
+create_tensor: loading tensor blk.5.ffn_down.weight
+create_tensor: loading tensor blk.5.post_ffw_norm.weight
+create_tensor: loading tensor blk.5.inp_gate.weight
+create_tensor: loading tensor blk.5.proj.weight
+create_tensor: loading tensor blk.5.post_norm.weight
+create_tensor: loading tensor blk.6.attn_norm.weight
+create_tensor: loading tensor blk.6.attn_q.weight
+create_tensor: loading tensor blk.6.attn_k.weight
+create_tensor: loading tensor blk.6.attn_v.weight
+create_tensor: loading tensor blk.6.attn_output.weight
+create_tensor: loading tensor blk.6.attn_q_norm.weight
+create_tensor: loading tensor blk.6.attn_k_norm.weight
+create_tensor: loading tensor blk.6.post_attention_norm.weight
+create_tensor: loading tensor blk.6.layer_output_scale.weight
+create_tensor: loading tensor blk.6.ffn_norm.weight
+create_tensor: loading tensor blk.6.ffn_gate.weight
+create_tensor: loading tensor blk.6.ffn_up.weight
+create_tensor: loading tensor blk.6.ffn_down.weight
+create_tensor: loading tensor blk.6.post_ffw_norm.weight
+create_tensor: loading tensor blk.6.inp_gate.weight
+create_tensor: loading tensor blk.6.proj.weight
+create_tensor: loading tensor blk.6.post_norm.weight
+create_tensor: loading tensor blk.7.attn_norm.weight
+create_tensor: loading tensor blk.7.attn_q.weight
+create_tensor: loading tensor blk.7.attn_k.weight
+create_tensor: loading tensor blk.7.attn_v.weight
+create_tensor: loading tensor blk.7.attn_output.weight
+create_tensor: loading tensor blk.7.attn_q_norm.weight
+create_tensor: loading tensor blk.7.attn_k_norm.weight
+create_tensor: loading tensor blk.7.post_attention_norm.weight
+create_tensor: loading tensor blk.7.layer_output_scale.weight
+create_tensor: loading tensor blk.7.ffn_norm.weight
+create_tensor: loading tensor blk.7.ffn_gate.weight
+create_tensor: loading tensor blk.7.ffn_up.weight
+create_tensor: loading tensor blk.7.ffn_down.weight
+create_tensor: loading tensor blk.7.post_ffw_norm.weight
+create_tensor: loading tensor blk.7.inp_gate.weight
+create_tensor: loading tensor blk.7.proj.weight
+create_tensor: loading tensor blk.7.post_norm.weight
+create_tensor: loading tensor blk.8.attn_norm.weight
+create_tensor: loading tensor blk.8.attn_q.weight
+create_tensor: loading tensor blk.8.attn_k.weight
+create_tensor: loading tensor blk.8.attn_v.weight
+create_tensor: loading tensor blk.8.attn_output.weight
+create_tensor: loading tensor blk.8.attn_q_norm.weight
+create_tensor: loading tensor blk.8.attn_k_norm.weight
+create_tensor: loading tensor blk.8.post_attention_norm.weight
+create_tensor: loading tensor blk.8.layer_output_scale.weight
+create_tensor: loading tensor blk.8.ffn_norm.weight
+create_tensor: loading tensor blk.8.ffn_gate.weight
+create_tensor: loading tensor blk.8.ffn_up.weight
+create_tensor: loading tensor blk.8.ffn_down.weight
+create_tensor: loading tensor blk.8.post_ffw_norm.weight
+create_tensor: loading tensor blk.8.inp_gate.weight
+create_tensor: loading tensor blk.8.proj.weight
+create_tensor: loading tensor blk.8.post_norm.weight
+create_tensor: loading tensor blk.9.attn_norm.weight
+create_tensor: loading tensor blk.9.attn_q.weight
+create_tensor: loading tensor blk.9.attn_k.weight
+create_tensor: loading tensor blk.9.attn_v.weight
+create_tensor: loading tensor blk.9.attn_output.weight
+create_tensor: loading tensor blk.9.attn_q_norm.weight
+create_tensor: loading tensor blk.9.attn_k_norm.weight
+create_tensor: loading tensor blk.9.post_attention_norm.weight
+create_tensor: loading tensor blk.9.layer_output_scale.weight
+create_tensor: loading tensor blk.9.ffn_norm.weight
+create_tensor: loading tensor blk.9.ffn_gate.weight
+create_tensor: loading tensor blk.9.ffn_up.weight
+create_tensor: loading tensor blk.9.ffn_down.weight
+create_tensor: loading tensor blk.9.post_ffw_norm.weight
+create_tensor: loading tensor blk.9.inp_gate.weight
+create_tensor: loading tensor blk.9.proj.weight
+create_tensor: loading tensor blk.9.post_norm.weight
+create_tensor: loading tensor blk.10.attn_norm.weight
+create_tensor: loading tensor blk.10.attn_q.weight
+create_tensor: loading tensor blk.10.attn_k.weight
+create_tensor: loading tensor blk.10.attn_v.weight
+create_tensor: loading tensor blk.10.attn_output.weight
+create_tensor: loading tensor blk.10.attn_q_norm.weight
+create_tensor: loading tensor blk.10.attn_k_norm.weight
+create_tensor: loading tensor blk.10.post_attention_norm.weight
+create_tensor: loading tensor blk.10.layer_output_scale.weight
+create_tensor: loading tensor blk.10.ffn_norm.weight
+create_tensor: loading tensor blk.10.ffn_gate.weight
+create_tensor: loading tensor blk.10.ffn_up.weight
+create_tensor: loading tensor blk.10.ffn_down.weight
+create_tensor: loading tensor blk.10.post_ffw_norm.weight
+create_tensor: loading tensor blk.10.inp_gate.weight
+create_tensor: loading tensor blk.10.proj.weight
+create_tensor: loading tensor blk.10.post_norm.weight
+create_tensor: loading tensor blk.11.attn_norm.weight
+create_tensor: loading tensor blk.11.attn_q.weight
+create_tensor: loading tensor blk.11.attn_k.weight
+create_tensor: loading tensor blk.11.attn_v.weight
+create_tensor: loading tensor blk.11.attn_output.weight
+create_tensor: loading tensor blk.11.attn_q_norm.weight
+create_tensor: loading tensor blk.11.attn_k_norm.weight
+create_tensor: loading tensor blk.11.post_attention_norm.weight
+create_tensor: loading tensor blk.11.layer_output_scale.weight
+create_tensor: loading tensor blk.11.ffn_norm.weight
+create_tensor: loading tensor blk.11.ffn_gate.weight
+create_tensor: loading tensor blk.11.ffn_up.weight
+create_tensor: loading tensor blk.11.ffn_down.weight
+create_tensor: loading tensor blk.11.post_ffw_norm.weight
+create_tensor: loading tensor blk.11.inp_gate.weight
+create_tensor: loading tensor blk.11.proj.weight
+create_tensor: loading tensor blk.11.post_norm.weight
+create_tensor: loading tensor blk.12.attn_norm.weight
+create_tensor: loading tensor blk.12.attn_q.weight
+create_tensor: loading tensor blk.12.attn_k.weight
+create_tensor: loading tensor blk.12.attn_v.weight
+create_tensor: loading tensor blk.12.attn_output.weight
+create_tensor: loading tensor blk.12.attn_q_norm.weight
+create_tensor: loading tensor blk.12.attn_k_norm.weight
+create_tensor: loading tensor blk.12.post_attention_norm.weight
+create_tensor: loading tensor blk.12.layer_output_scale.weight
+create_tensor: loading tensor blk.12.ffn_norm.weight
+create_tensor: loading tensor blk.12.ffn_gate.weight
+create_tensor: loading tensor blk.12.ffn_up.weight
+create_tensor: loading tensor blk.12.ffn_down.weight
+create_tensor: loading tensor blk.12.post_ffw_norm.weight
+create_tensor: loading tensor blk.12.inp_gate.weight
+create_tensor: loading tensor blk.12.proj.weight
+create_tensor: loading tensor blk.12.post_norm.weight
+create_tensor: loading tensor blk.13.attn_norm.weight
+create_tensor: loading tensor blk.13.attn_q.weight
+create_tensor: loading tensor blk.13.attn_k.weight
+create_tensor: loading tensor blk.13.attn_v.weight
+create_tensor: loading tensor blk.13.attn_output.weight
+create_tensor: loading tensor blk.13.attn_q_norm.weight
+create_tensor: loading tensor blk.13.attn_k_norm.weight
+create_tensor: loading tensor blk.13.post_attention_norm.weight
+create_tensor: loading tensor blk.13.layer_output_scale.weight
+create_tensor: loading tensor blk.13.ffn_norm.weight
+create_tensor: loading tensor blk.13.ffn_gate.weight
+create_tensor: loading tensor blk.13.ffn_up.weight
+create_tensor: loading tensor blk.13.ffn_down.weight
+create_tensor: loading tensor blk.13.post_ffw_norm.weight
+create_tensor: loading tensor blk.13.inp_gate.weight
+create_tensor: loading tensor blk.13.proj.weight
+create_tensor: loading tensor blk.13.post_norm.weight
+create_tensor: loading tensor blk.14.attn_norm.weight
+create_tensor: loading tensor blk.14.attn_q.weight
+create_tensor: loading tensor blk.14.attn_k.weight
+create_tensor: loading tensor blk.14.attn_v.weight
+create_tensor: loading tensor blk.14.attn_output.weight
+create_tensor: loading tensor blk.14.attn_q_norm.weight
+create_tensor: loading tensor blk.14.attn_k_norm.weight
+create_tensor: loading tensor blk.14.post_attention_norm.weight
+create_tensor: loading tensor blk.14.layer_output_scale.weight
+create_tensor: loading tensor blk.14.ffn_norm.weight
+create_tensor: loading tensor blk.14.ffn_gate.weight
+create_tensor: loading tensor blk.14.ffn_up.weight
+create_tensor: loading tensor blk.14.ffn_down.weight
+create_tensor: loading tensor blk.14.post_ffw_norm.weight
+create_tensor: loading tensor blk.14.inp_gate.weight
+create_tensor: loading tensor blk.14.proj.weight
+create_tensor: loading tensor blk.14.post_norm.weight
+create_tensor: loading tensor blk.15.attn_norm.weight
+create_tensor: loading tensor blk.15.attn_q.weight
+create_tensor: loading tensor blk.15.attn_k.weight
+create_tensor: loading tensor blk.15.attn_v.weight
+create_tensor: loading tensor blk.15.attn_output.weight
+create_tensor: loading tensor blk.15.attn_q_norm.weight
+create_tensor: loading tensor blk.15.attn_k_norm.weight
+create_tensor: loading tensor blk.15.post_attention_norm.weight
+create_tensor: loading tensor blk.15.layer_output_scale.weight
+create_tensor: loading tensor blk.15.ffn_norm.weight
+create_tensor: loading tensor blk.15.ffn_gate.weight
+create_tensor: loading tensor blk.15.ffn_up.weight
+create_tensor: loading tensor blk.15.ffn_down.weight
+create_tensor: loading tensor blk.15.post_ffw_norm.weight
+create_tensor: loading tensor blk.15.inp_gate.weight
+create_tensor: loading tensor blk.15.proj.weight
+create_tensor: loading tensor blk.15.post_norm.weight
+create_tensor: loading tensor blk.16.attn_norm.weight
+create_tensor: loading tensor blk.16.attn_q.weight
+create_tensor: loading tensor blk.16.attn_k.weight
+create_tensor: loading tensor blk.16.attn_v.weight
+create_tensor: loading tensor blk.16.attn_output.weight
+create_tensor: loading tensor blk.16.attn_q_norm.weight
+create_tensor: loading tensor blk.16.attn_k_norm.weight
+create_tensor: loading tensor blk.16.post_attention_norm.weight
+create_tensor: loading tensor blk.16.layer_output_scale.weight
+create_tensor: loading tensor blk.16.ffn_norm.weight
+create_tensor: loading tensor blk.16.ffn_gate.weight
+create_tensor: loading tensor blk.16.ffn_up.weight
+create_tensor: loading tensor blk.16.ffn_down.weight
+create_tensor: loading tensor blk.16.post_ffw_norm.weight
+create_tensor: loading tensor blk.16.inp_gate.weight
+create_tensor: loading tensor blk.16.proj.weight
+create_tensor: loading tensor blk.16.post_norm.weight
+create_tensor: loading tensor blk.17.attn_norm.weight
+create_tensor: loading tensor blk.17.attn_q.weight
+create_tensor: loading tensor blk.17.attn_k.weight
+create_tensor: loading tensor blk.17.attn_v.weight
+create_tensor: loading tensor blk.17.attn_output.weight
+create_tensor: loading tensor blk.17.attn_q_norm.weight
+create_tensor: loading tensor blk.17.attn_k_norm.weight
+create_tensor: loading tensor blk.17.post_attention_norm.weight
+create_tensor: loading tensor blk.17.layer_output_scale.weight
+create_tensor: loading tensor blk.17.ffn_norm.weight
+create_tensor: loading tensor blk.17.ffn_gate.weight
+create_tensor: loading tensor blk.17.ffn_up.weight
+create_tensor: loading tensor blk.17.ffn_down.weight
+create_tensor: loading tensor blk.17.post_ffw_norm.weight
+create_tensor: loading tensor blk.17.inp_gate.weight
+create_tensor: loading tensor blk.17.proj.weight
+create_tensor: loading tensor blk.17.post_norm.weight
+create_tensor: loading tensor blk.18.attn_norm.weight
+create_tensor: loading tensor blk.18.attn_q.weight
+create_tensor: loading tensor blk.18.attn_k.weight
+create_tensor: loading tensor blk.18.attn_v.weight
+create_tensor: loading tensor blk.18.attn_output.weight
+create_tensor: loading tensor blk.18.attn_q_norm.weight
+create_tensor: loading tensor blk.18.attn_k_norm.weight
+create_tensor: loading tensor blk.18.post_attention_norm.weight
+create_tensor: loading tensor blk.18.layer_output_scale.weight
+create_tensor: loading tensor blk.18.ffn_norm.weight
+create_tensor: loading tensor blk.18.ffn_gate.weight
+create_tensor: loading tensor blk.18.ffn_up.weight
+create_tensor: loading tensor blk.18.ffn_down.weight
+create_tensor: loading tensor blk.18.post_ffw_norm.weight
+create_tensor: loading tensor blk.18.inp_gate.weight
+create_tensor: loading tensor blk.18.proj.weight
+create_tensor: loading tensor blk.18.post_norm.weight
+create_tensor: loading tensor blk.19.attn_norm.weight
+create_tensor: loading tensor blk.19.attn_q.weight
+create_tensor: loading tensor blk.19.attn_k.weight
+create_tensor: loading tensor blk.19.attn_v.weight
+create_tensor: loading tensor blk.19.attn_output.weight
+create_tensor: loading tensor blk.19.attn_q_norm.weight
+create_tensor: loading tensor blk.19.attn_k_norm.weight
+create_tensor: loading tensor blk.19.post_attention_norm.weight
+create_tensor: loading tensor blk.19.layer_output_scale.weight
+create_tensor: loading tensor blk.19.ffn_norm.weight
+create_tensor: loading tensor blk.19.ffn_gate.weight
+create_tensor: loading tensor blk.19.ffn_up.weight
+create_tensor: loading tensor blk.19.ffn_down.weight
+create_tensor: loading tensor blk.19.post_ffw_norm.weight
+create_tensor: loading tensor blk.19.inp_gate.weight
+create_tensor: loading tensor blk.19.proj.weight
+create_tensor: loading tensor blk.19.post_norm.weight
+create_tensor: loading tensor blk.20.attn_norm.weight
+create_tensor: loading tensor blk.20.attn_q.weight
+create_tensor: loading tensor blk.20.attn_k.weight
+create_tensor: loading tensor blk.20.attn_v.weight
+create_tensor: loading tensor blk.20.attn_output.weight
+create_tensor: loading tensor blk.20.attn_q_norm.weight
+create_tensor: loading tensor blk.20.attn_k_norm.weight
+create_tensor: loading tensor blk.20.post_attention_norm.weight
+create_tensor: loading tensor blk.20.layer_output_scale.weight
+create_tensor: loading tensor blk.20.ffn_norm.weight
+create_tensor: loading tensor blk.20.ffn_gate.weight
+create_tensor: loading tensor blk.20.ffn_up.weight
+create_tensor: loading tensor blk.20.ffn_down.weight
+create_tensor: loading tensor blk.20.post_ffw_norm.weight
+create_tensor: loading tensor blk.20.inp_gate.weight
+create_tensor: loading tensor blk.20.proj.weight
+create_tensor: loading tensor blk.20.post_norm.weight
+create_tensor: loading tensor blk.21.attn_norm.weight
+create_tensor: loading tensor blk.21.attn_q.weight
+create_tensor: loading tensor blk.21.attn_k.weight
+create_tensor: loading tensor blk.21.attn_v.weight
+create_tensor: loading tensor blk.21.attn_output.weight
+create_tensor: loading tensor blk.21.attn_q_norm.weight
+create_tensor: loading tensor blk.21.attn_k_norm.weight
+create_tensor: loading tensor blk.21.post_attention_norm.weight
+create_tensor: loading tensor blk.21.layer_output_scale.weight
+create_tensor: loading tensor blk.21.ffn_norm.weight
+create_tensor: loading tensor blk.21.ffn_gate.weight
+create_tensor: loading tensor blk.21.ffn_up.weight
+create_tensor: loading tensor blk.21.ffn_down.weight
+create_tensor: loading tensor blk.21.post_ffw_norm.weight
+create_tensor: loading tensor blk.21.inp_gate.weight
+create_tensor: loading tensor blk.21.proj.weight
+create_tensor: loading tensor blk.21.post_norm.weight
+create_tensor: loading tensor blk.22.attn_norm.weight
+create_tensor: loading tensor blk.22.attn_q.weight
+create_tensor: loading tensor blk.22.attn_k.weight
+create_tensor: loading tensor blk.22.attn_v.weight
+create_tensor: loading tensor blk.22.attn_output.weight
+create_tensor: loading tensor blk.22.attn_q_norm.weight
+create_tensor: loading tensor blk.22.attn_k_norm.weight
+create_tensor: loading tensor blk.22.post_attention_norm.weight
+create_tensor: loading tensor blk.22.layer_output_scale.weight
+create_tensor: loading tensor blk.22.ffn_norm.weight
+create_tensor: loading tensor blk.22.ffn_gate.weight
+create_tensor: loading tensor blk.22.ffn_up.weight
+create_tensor: loading tensor blk.22.ffn_down.weight
+create_tensor: loading tensor blk.22.post_ffw_norm.weight
+create_tensor: loading tensor blk.22.inp_gate.weight
+create_tensor: loading tensor blk.22.proj.weight
+create_tensor: loading tensor blk.22.post_norm.weight
+create_tensor: loading tensor blk.23.attn_norm.weight
+create_tensor: loading tensor blk.23.attn_q.weight
+create_tensor: loading tensor blk.23.attn_k.weight
+create_tensor: loading tensor blk.23.attn_v.weight
+create_tensor: loading tensor blk.23.attn_output.weight
+create_tensor: loading tensor blk.23.attn_q_norm.weight
+create_tensor: loading tensor blk.23.attn_k_norm.weight
+create_tensor: loading tensor blk.23.post_attention_norm.weight
+create_tensor: loading tensor blk.23.layer_output_scale.weight
+create_tensor: loading tensor blk.23.ffn_norm.weight
+create_tensor: loading tensor blk.23.ffn_gate.weight
+create_tensor: loading tensor blk.23.ffn_up.weight
+create_tensor: loading tensor blk.23.ffn_down.weight
+create_tensor: loading tensor blk.23.post_ffw_norm.weight
+create_tensor: loading tensor blk.23.inp_gate.weight
+create_tensor: loading tensor blk.23.proj.weight
+create_tensor: loading tensor blk.23.post_norm.weight
+create_tensor: loading tensor blk.24.attn_norm.weight
+create_tensor: loading tensor blk.24.attn_q.weight
+create_tensor: loading tensor blk.24.attn_k.weight
+create_tensor: loading tensor blk.24.attn_v.weight
+create_tensor: loading tensor blk.24.attn_output.weight
+create_tensor: loading tensor blk.24.attn_q_norm.weight
+create_tensor: loading tensor blk.24.attn_k_norm.weight
+create_tensor: loading tensor blk.24.post_attention_norm.weight
+create_tensor: loading tensor blk.24.layer_output_scale.weight
+create_tensor: loading tensor blk.24.ffn_norm.weight
+create_tensor: loading tensor blk.24.ffn_gate.weight
+create_tensor: loading tensor blk.24.ffn_up.weight
+create_tensor: loading tensor blk.24.ffn_down.weight
+create_tensor: loading tensor blk.24.post_ffw_norm.weight
+create_tensor: loading tensor blk.24.inp_gate.weight
+create_tensor: loading tensor blk.24.proj.weight
+create_tensor: loading tensor blk.24.post_norm.weight
+create_tensor: loading tensor blk.25.attn_norm.weight
+create_tensor: loading tensor blk.25.attn_q.weight
+create_tensor: loading tensor blk.25.attn_k.weight
+create_tensor: loading tensor blk.25.attn_v.weight
+create_tensor: loading tensor blk.25.attn_output.weight
+create_tensor: loading tensor blk.25.attn_q_norm.weight
+create_tensor: loading tensor blk.25.attn_k_norm.weight
+create_tensor: loading tensor blk.25.post_attention_norm.weight
+create_tensor: loading tensor blk.25.layer_output_scale.weight
+create_tensor: loading tensor blk.25.ffn_norm.weight
+create_tensor: loading tensor blk.25.ffn_gate.weight
+create_tensor: loading tensor blk.25.ffn_up.weight
+create_tensor: loading tensor blk.25.ffn_down.weight
+create_tensor: loading tensor blk.25.post_ffw_norm.weight
+create_tensor: loading tensor blk.25.inp_gate.weight
+create_tensor: loading tensor blk.25.proj.weight
+create_tensor: loading tensor blk.25.post_norm.weight
+create_tensor: loading tensor blk.26.attn_norm.weight
+create_tensor: loading tensor blk.26.attn_q.weight
+create_tensor: loading tensor blk.26.attn_k.weight
+create_tensor: loading tensor blk.26.attn_v.weight
+create_tensor: loading tensor blk.26.attn_output.weight
+create_tensor: loading tensor blk.26.attn_q_norm.weight
+create_tensor: loading tensor blk.26.attn_k_norm.weight
+create_tensor: loading tensor blk.26.post_attention_norm.weight
+create_tensor: loading tensor blk.26.layer_output_scale.weight
+create_tensor: loading tensor blk.26.ffn_norm.weight
+create_tensor: loading tensor blk.26.ffn_gate.weight
+create_tensor: loading tensor blk.26.ffn_up.weight
+create_tensor: loading tensor blk.26.ffn_down.weight
+create_tensor: loading tensor blk.26.post_ffw_norm.weight
+create_tensor: loading tensor blk.26.inp_gate.weight
+create_tensor: loading tensor blk.26.proj.weight
+create_tensor: loading tensor blk.26.post_norm.weight
+create_tensor: loading tensor blk.27.attn_norm.weight
+create_tensor: loading tensor blk.27.attn_q.weight
+create_tensor: loading tensor blk.27.attn_k.weight
+create_tensor: loading tensor blk.27.attn_v.weight
+create_tensor: loading tensor blk.27.attn_output.weight
+create_tensor: loading tensor blk.27.attn_q_norm.weight
+create_tensor: loading tensor blk.27.attn_k_norm.weight
+create_tensor: loading tensor blk.27.post_attention_norm.weight
+create_tensor: loading tensor blk.27.layer_output_scale.weight
+create_tensor: loading tensor blk.27.ffn_norm.weight
+create_tensor: loading tensor blk.27.ffn_gate.weight
+create_tensor: loading tensor blk.27.ffn_up.weight
+create_tensor: loading tensor blk.27.ffn_down.weight
+create_tensor: loading tensor blk.27.post_ffw_norm.weight
+create_tensor: loading tensor blk.27.inp_gate.weight
+create_tensor: loading tensor blk.27.proj.weight
+create_tensor: loading tensor blk.27.post_norm.weight
+create_tensor: loading tensor blk.28.attn_norm.weight
+create_tensor: loading tensor blk.28.attn_q.weight
+create_tensor: loading tensor blk.28.attn_k.weight
+create_tensor: loading tensor blk.28.attn_v.weight
+create_tensor: loading tensor blk.28.attn_output.weight
+create_tensor: loading tensor blk.28.attn_q_norm.weight
+create_tensor: loading tensor blk.28.attn_k_norm.weight
+create_tensor: loading tensor blk.28.post_attention_norm.weight
+create_tensor: loading tensor blk.28.layer_output_scale.weight
+create_tensor: loading tensor blk.28.ffn_norm.weight
+create_tensor: loading tensor blk.28.ffn_gate.weight
+create_tensor: loading tensor blk.28.ffn_up.weight
+create_tensor: loading tensor blk.28.ffn_down.weight
+create_tensor: loading tensor blk.28.post_ffw_norm.weight
+create_tensor: loading tensor blk.28.inp_gate.weight
+create_tensor: loading tensor blk.28.proj.weight
+create_tensor: loading tensor blk.28.post_norm.weight
+create_tensor: loading tensor blk.29.attn_norm.weight
+create_tensor: loading tensor blk.29.attn_q.weight
+create_tensor: loading tensor blk.29.attn_k.weight
+create_tensor: loading tensor blk.29.attn_v.weight
+create_tensor: loading tensor blk.29.attn_output.weight
+create_tensor: loading tensor blk.29.attn_q_norm.weight
+create_tensor: loading tensor blk.29.attn_k_norm.weight
+create_tensor: loading tensor blk.29.post_attention_norm.weight
+create_tensor: loading tensor blk.29.layer_output_scale.weight
+create_tensor: loading tensor blk.29.ffn_norm.weight
+create_tensor: loading tensor blk.29.ffn_gate.weight
+create_tensor: loading tensor blk.29.ffn_up.weight
+create_tensor: loading tensor blk.29.ffn_down.weight
+create_tensor: loading tensor blk.29.post_ffw_norm.weight
+create_tensor: loading tensor blk.29.inp_gate.weight
+create_tensor: loading tensor blk.29.proj.weight
+create_tensor: loading tensor blk.29.post_norm.weight
+create_tensor: loading tensor blk.30.attn_norm.weight
+create_tensor: loading tensor blk.30.attn_q.weight
+create_tensor: loading tensor blk.30.attn_k.weight
+create_tensor: loading tensor blk.30.attn_v.weight
+create_tensor: loading tensor blk.30.attn_output.weight
+create_tensor: loading tensor blk.30.attn_q_norm.weight
+create_tensor: loading tensor blk.30.attn_k_norm.weight
+create_tensor: loading tensor blk.30.post_attention_norm.weight
+create_tensor: loading tensor blk.30.layer_output_scale.weight
+create_tensor: loading tensor blk.30.ffn_norm.weight
+create_tensor: loading tensor blk.30.ffn_gate.weight
+create_tensor: loading tensor blk.30.ffn_up.weight
+create_tensor: loading tensor blk.30.ffn_down.weight
+create_tensor: loading tensor blk.30.post_ffw_norm.weight
+create_tensor: loading tensor blk.30.inp_gate.weight
+create_tensor: loading tensor blk.30.proj.weight
+create_tensor: loading tensor blk.30.post_norm.weight
+create_tensor: loading tensor blk.31.attn_norm.weight
+create_tensor: loading tensor blk.31.attn_q.weight
+create_tensor: loading tensor blk.31.attn_k.weight
+create_tensor: loading tensor blk.31.attn_v.weight
+create_tensor: loading tensor blk.31.attn_output.weight
+create_tensor: loading tensor blk.31.attn_q_norm.weight
+create_tensor: loading tensor blk.31.attn_k_norm.weight
+create_tensor: loading tensor blk.31.post_attention_norm.weight
+create_tensor: loading tensor blk.31.layer_output_scale.weight
+create_tensor: loading tensor blk.31.ffn_norm.weight
+create_tensor: loading tensor blk.31.ffn_gate.weight
+create_tensor: loading tensor blk.31.ffn_up.weight
+create_tensor: loading tensor blk.31.ffn_down.weight
+create_tensor: loading tensor blk.31.post_ffw_norm.weight
+create_tensor: loading tensor blk.31.inp_gate.weight
+create_tensor: loading tensor blk.31.proj.weight
+create_tensor: loading tensor blk.31.post_norm.weight
+create_tensor: loading tensor blk.32.attn_norm.weight
+create_tensor: loading tensor blk.32.attn_q.weight
+create_tensor: loading tensor blk.32.attn_k.weight
+create_tensor: loading tensor blk.32.attn_v.weight
+create_tensor: loading tensor blk.32.attn_output.weight
+create_tensor: loading tensor blk.32.attn_q_norm.weight
+create_tensor: loading tensor blk.32.attn_k_norm.weight
+create_tensor: loading tensor blk.32.post_attention_norm.weight
+create_tensor: loading tensor blk.32.layer_output_scale.weight
+create_tensor: loading tensor blk.32.ffn_norm.weight
+create_tensor: loading tensor blk.32.ffn_gate.weight
+create_tensor: loading tensor blk.32.ffn_up.weight
+create_tensor: loading tensor blk.32.ffn_down.weight
+create_tensor: loading tensor blk.32.post_ffw_norm.weight
+create_tensor: loading tensor blk.32.inp_gate.weight
+create_tensor: loading tensor blk.32.proj.weight
+create_tensor: loading tensor blk.32.post_norm.weight
+create_tensor: loading tensor blk.33.attn_norm.weight
+create_tensor: loading tensor blk.33.attn_q.weight
+create_tensor: loading tensor blk.33.attn_k.weight
+create_tensor: loading tensor blk.33.attn_v.weight
+create_tensor: loading tensor blk.33.attn_output.weight
+create_tensor: loading tensor blk.33.attn_q_norm.weight
+create_tensor: loading tensor blk.33.attn_k_norm.weight
+create_tensor: loading tensor blk.33.post_attention_norm.weight
+create_tensor: loading tensor blk.33.layer_output_scale.weight
+create_tensor: loading tensor blk.33.ffn_norm.weight
+create_tensor: loading tensor blk.33.ffn_gate.weight
+create_tensor: loading tensor blk.33.ffn_up.weight
+create_tensor: loading tensor blk.33.ffn_down.weight
+create_tensor: loading tensor blk.33.post_ffw_norm.weight
+create_tensor: loading tensor blk.33.inp_gate.weight
+create_tensor: loading tensor blk.33.proj.weight
+create_tensor: loading tensor blk.33.post_norm.weight
+create_tensor: loading tensor blk.34.attn_norm.weight
+create_tensor: loading tensor blk.34.attn_q.weight
+create_tensor: loading tensor blk.34.attn_k.weight
+create_tensor: loading tensor blk.34.attn_v.weight
+create_tensor: loading tensor blk.34.attn_output.weight
+create_tensor: loading tensor blk.34.attn_q_norm.weight
+create_tensor: loading tensor blk.34.attn_k_norm.weight
+create_tensor: loading tensor blk.34.post_attention_norm.weight
+create_tensor: loading tensor blk.34.layer_output_scale.weight
+create_tensor: loading tensor blk.34.ffn_norm.weight
+create_tensor: loading tensor blk.34.ffn_gate.weight
+create_tensor: loading tensor blk.34.ffn_up.weight
+create_tensor: loading tensor blk.34.ffn_down.weight
+create_tensor: loading tensor blk.34.post_ffw_norm.weight
+create_tensor: loading tensor blk.34.inp_gate.weight
+create_tensor: loading tensor blk.34.proj.weight
+create_tensor: loading tensor blk.34.post_norm.weight
+create_tensor: loading tensor blk.35.attn_norm.weight
+create_tensor: loading tensor blk.35.attn_q.weight
+create_tensor: loading tensor blk.35.attn_k.weight
+create_tensor: loading tensor blk.35.attn_v.weight
+create_tensor: loading tensor blk.35.attn_output.weight
+create_tensor: loading tensor blk.35.attn_q_norm.weight
+create_tensor: loading tensor blk.35.attn_k_norm.weight
+create_tensor: loading tensor blk.35.post_attention_norm.weight
+create_tensor: loading tensor blk.35.layer_output_scale.weight
+create_tensor: loading tensor blk.35.ffn_norm.weight
+create_tensor: loading tensor blk.35.ffn_gate.weight
+create_tensor: loading tensor blk.35.ffn_up.weight
+create_tensor: loading tensor blk.35.ffn_down.weight
+create_tensor: loading tensor blk.35.post_ffw_norm.weight
+create_tensor: loading tensor blk.35.inp_gate.weight
+create_tensor: loading tensor blk.35.proj.weight
+create_tensor: loading tensor blk.35.post_norm.weight
+create_tensor: loading tensor blk.36.attn_norm.weight
+create_tensor: loading tensor blk.36.attn_q.weight
+create_tensor: loading tensor blk.36.attn_k.weight
+create_tensor: loading tensor blk.36.attn_v.weight
+create_tensor: loading tensor blk.36.attn_output.weight
+create_tensor: loading tensor blk.36.attn_q_norm.weight
+create_tensor: loading tensor blk.36.attn_k_norm.weight
+create_tensor: loading tensor blk.36.post_attention_norm.weight
+create_tensor: loading tensor blk.36.layer_output_scale.weight
+create_tensor: loading tensor blk.36.ffn_norm.weight
+create_tensor: loading tensor blk.36.ffn_gate.weight
+create_tensor: loading tensor blk.36.ffn_up.weight
+create_tensor: loading tensor blk.36.ffn_down.weight
+create_tensor: loading tensor blk.36.post_ffw_norm.weight
+create_tensor: loading tensor blk.36.inp_gate.weight
+create_tensor: loading tensor blk.36.proj.weight
+create_tensor: loading tensor blk.36.post_norm.weight
+create_tensor: loading tensor blk.37.attn_norm.weight
+create_tensor: loading tensor blk.37.attn_q.weight
+create_tensor: loading tensor blk.37.attn_k.weight
+create_tensor: loading tensor blk.37.attn_v.weight
+create_tensor: loading tensor blk.37.attn_output.weight
+create_tensor: loading tensor blk.37.attn_q_norm.weight
+create_tensor: loading tensor blk.37.attn_k_norm.weight
+create_tensor: loading tensor blk.37.post_attention_norm.weight
+create_tensor: loading tensor blk.37.layer_output_scale.weight
+create_tensor: loading tensor blk.37.ffn_norm.weight
+create_tensor: loading tensor blk.37.ffn_gate.weight
+create_tensor: loading tensor blk.37.ffn_up.weight
+create_tensor: loading tensor blk.37.ffn_down.weight
+create_tensor: loading tensor blk.37.post_ffw_norm.weight
+create_tensor: loading tensor blk.37.inp_gate.weight
+create_tensor: loading tensor blk.37.proj.weight
+create_tensor: loading tensor blk.37.post_norm.weight
+create_tensor: loading tensor blk.38.attn_norm.weight
+create_tensor: loading tensor blk.38.attn_q.weight
+create_tensor: loading tensor blk.38.attn_k.weight
+create_tensor: loading tensor blk.38.attn_v.weight
+create_tensor: loading tensor blk.38.attn_output.weight
+create_tensor: loading tensor blk.38.attn_q_norm.weight
+create_tensor: loading tensor blk.38.attn_k_norm.weight
+create_tensor: loading tensor blk.38.post_attention_norm.weight
+create_tensor: loading tensor blk.38.layer_output_scale.weight
+create_tensor: loading tensor blk.38.ffn_norm.weight
+create_tensor: loading tensor blk.38.ffn_gate.weight
+create_tensor: loading tensor blk.38.ffn_up.weight
+create_tensor: loading tensor blk.38.ffn_down.weight
+create_tensor: loading tensor blk.38.post_ffw_norm.weight
+create_tensor: loading tensor blk.38.inp_gate.weight
+create_tensor: loading tensor blk.38.proj.weight
+create_tensor: loading tensor blk.38.post_norm.weight
+create_tensor: loading tensor blk.39.attn_norm.weight
+create_tensor: loading tensor blk.39.attn_q.weight
+create_tensor: loading tensor blk.39.attn_k.weight
+create_tensor: loading tensor blk.39.attn_v.weight
+create_tensor: loading tensor blk.39.attn_output.weight
+create_tensor: loading tensor blk.39.attn_q_norm.weight
+create_tensor: loading tensor blk.39.attn_k_norm.weight
+create_tensor: loading tensor blk.39.post_attention_norm.weight
+create_tensor: loading tensor blk.39.layer_output_scale.weight
+create_tensor: loading tensor blk.39.ffn_norm.weight
+create_tensor: loading tensor blk.39.ffn_gate.weight
+create_tensor: loading tensor blk.39.ffn_up.weight
+create_tensor: loading tensor blk.39.ffn_down.weight
+create_tensor: loading tensor blk.39.post_ffw_norm.weight
+create_tensor: loading tensor blk.39.inp_gate.weight
+create_tensor: loading tensor blk.39.proj.weight
+create_tensor: loading tensor blk.39.post_norm.weight
+create_tensor: loading tensor blk.40.attn_norm.weight
+create_tensor: loading tensor blk.40.attn_q.weight
+create_tensor: loading tensor blk.40.attn_k.weight
+create_tensor: loading tensor blk.40.attn_v.weight
+create_tensor: loading tensor blk.40.attn_output.weight
+create_tensor: loading tensor blk.40.attn_q_norm.weight
+create_tensor: loading tensor blk.40.attn_k_norm.weight
+create_tensor: loading tensor blk.40.post_attention_norm.weight
+create_tensor: loading tensor blk.40.layer_output_scale.weight
+create_tensor: loading tensor blk.40.ffn_norm.weight
+create_tensor: loading tensor blk.40.ffn_gate.weight
+create_tensor: loading tensor blk.40.ffn_up.weight
+create_tensor: loading tensor blk.40.ffn_down.weight
+create_tensor: loading tensor blk.40.post_ffw_norm.weight
+create_tensor: loading tensor blk.40.inp_gate.weight
+create_tensor: loading tensor blk.40.proj.weight
+create_tensor: loading tensor blk.40.post_norm.weight
+create_tensor: loading tensor blk.41.attn_norm.weight
+create_tensor: loading tensor blk.41.attn_q.weight
+create_tensor: loading tensor blk.41.attn_k.weight
+create_tensor: loading tensor blk.41.attn_v.weight
+create_tensor: loading tensor blk.41.attn_output.weight
+create_tensor: loading tensor blk.41.attn_q_norm.weight
+create_tensor: loading tensor blk.41.attn_k_norm.weight
+create_tensor: loading tensor blk.41.post_attention_norm.weight
+create_tensor: loading tensor blk.41.layer_output_scale.weight
+create_tensor: loading tensor blk.41.ffn_norm.weight
+create_tensor: loading tensor blk.41.ffn_gate.weight
+create_tensor: loading tensor blk.41.ffn_up.weight
+create_tensor: loading tensor blk.41.ffn_down.weight
+create_tensor: loading tensor blk.41.post_ffw_norm.weight
+create_tensor: loading tensor blk.41.inp_gate.weight
+create_tensor: loading tensor blk.41.proj.weight
+create_tensor: loading tensor blk.41.post_norm.weight
+done_getting_tensors: tensor 'token_embd.weight' (q8_0) (and 1 others) cannot be used with preferred buffer type CPU_REPACK, using CPU instead
+ggml_metal_log_allocated_size: allocated buffer, size =  7644.11 MiB, ( 7644.56 / 110100.48)
+load_tensors: offloading output layer to GPU
+load_tensors: offloading 41 repeating layers to GPU
+load_tensors: offloaded 43/43 layers to GPU
+load_tensors:   CPU_Mapped model buffer size =  3536.00 MiB
+load_tensors:  MTL0_Mapped model buffer size =  7644.10 MiB
+.....................................................
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: layer   4: filtered
+llama_kv_cache: layer   5: dev = MTL0
+llama_kv_cache: layer   6: filtered
+llama_kv_cache: layer   7: filtered
+llama_kv_cache: layer   8: filtered
+llama_kv_cache: layer   9: filtered
+llama_kv_cache: layer  10: filtered
+llama_kv_cache: layer  11: dev = MTL0
+llama_kv_cache: layer  12: filtered
+llama_kv_cache: layer  13: filtered
+llama_kv_cache: layer  14: filtered
+llama_kv_cache: layer  15: filtered
+llama_kv_cache: layer  16: filtered
+llama_kv_cache: layer  17: dev = MTL0
+llama_kv_cache: layer  18: filtered
+llama_kv_cache: layer  19: filtered
+llama_kv_cache: layer  20: filtered
+llama_kv_cache: layer  21: filtered
+llama_kv_cache: layer  22: filtered
+llama_kv_cache: layer  23: dev = MTL0
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: filtered
+llama_kv_cache: - layer  25: filtered
+llama_kv_cache: - layer  26: filtered
+llama_kv_cache: - layer  27: filtered
+llama_kv_cache: - layer  28: filtered
+llama_kv_cache: - layer  29: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  30: filtered
+llama_kv_cache: - layer  31: filtered
+llama_kv_cache: - layer  32: filtered
+llama_kv_cache: - layer  33: filtered
+llama_kv_cache: - layer  34: filtered
+llama_kv_cache: - layer  35: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  36: filtered
+llama_kv_cache: - layer  37: filtered
+llama_kv_cache: - layer  38: filtered
+llama_kv_cache: - layer  39: filtered
+llama_kv_cache: - layer  40: filtered
+llama_kv_cache: - layer  41: reuse layer 23, is_swa = 0
+llama_kv_cache:       MTL0 KV buffer size =    64.00 MiB
+llama_kv_cache: size =   64.00 MiB (  4096 cells,   4 layers,  1/1 seqs), K (f16):   32.00 MiB, V (f16):   32.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 512
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 512
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: dev = MTL0
+llama_kv_cache: layer   1: dev = MTL0
+llama_kv_cache: layer   2: dev = MTL0
+llama_kv_cache: layer   3: dev = MTL0
+llama_kv_cache: layer   4: dev = MTL0
+llama_kv_cache: layer   5: filtered
+llama_kv_cache: layer   6: dev = MTL0
+llama_kv_cache: layer   7: dev = MTL0
+llama_kv_cache: layer   8: dev = MTL0
+llama_kv_cache: layer   9: dev = MTL0
+llama_kv_cache: layer  10: dev = MTL0
+llama_kv_cache: layer  11: filtered
+llama_kv_cache: layer  12: dev = MTL0
+llama_kv_cache: layer  13: dev = MTL0
+llama_kv_cache: layer  14: dev = MTL0
+llama_kv_cache: layer  15: dev = MTL0
+llama_kv_cache: layer  16: dev = MTL0
+llama_kv_cache: layer  17: filtered
+llama_kv_cache: layer  18: dev = MTL0
+llama_kv_cache: layer  19: dev = MTL0
+llama_kv_cache: layer  20: dev = MTL0
+llama_kv_cache: layer  21: dev = MTL0
+llama_kv_cache: layer  22: dev = MTL0
+llama_kv_cache: layer  23: filtered
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  25: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  26: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  27: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  28: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  29: filtered
+llama_kv_cache: - layer  30: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  31: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  32: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  33: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  34: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  35: filtered
+llama_kv_cache: - layer  36: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  37: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  38: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  39: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  40: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  41: filtered
+llama_kv_cache:       MTL0 KV buffer size =   160.00 MiB
+llama_kv_cache: size =  160.00 MiB (  4096 cells,  20 layers,  1/1 seqs), K (f16):   80.00 MiB, V (f16):   80.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 5768
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   538.50 MiB
+sched_reserve:        CPU compute buffer size =    47.02 MiB
+sched_reserve: graph nodes  = 1867
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 22.74 ms, sched copies = 1
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32_4', name = 'kernel_unary_f32_f32_4_op=10_cnt=0'
+ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_4_op=10_cnt=0            0x1093997f0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_cpy_f32_f16', name = 'kernel_cpy_f32_f16'
+ggml_metal_library_compile_pipeline: loaded kernel_cpy_f32_f16                            0x109399ff0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_rms_norm_mul_f32_4', name = 'kernel_rms_norm_mul_f32_4'
+ggml_metal_library_compile_pipeline: loaded kernel_rms_norm_mul_f32_4                     0x10939a7f0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mm_q8_0_f32', name = 'kernel_mul_mm_q8_0_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mm_q8_0_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1      0x10939b2f0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_rms_norm_f32_4', name = 'kernel_rms_norm_f32_4'
+ggml_metal_library_compile_pipeline: loaded kernel_rms_norm_f32_4                         0x10939baf0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_rope_neox_f32', name = 'kernel_rope_neox_f32_imrope=0'
+ggml_metal_library_compile_pipeline: loaded kernel_rope_neox_f32_imrope=0                 0x10939bdf0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_set_rows_f16_i64', name = 'kernel_set_rows_f16_i64'
+ggml_metal_library_compile_pipeline: loaded kernel_set_rows_f16_i64                       0x10939c0f0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mm_bf16_f32', name = 'kernel_mul_mm_bf16_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mm_bf16_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1      0x10939c6f0 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_blk', name = 'kernel_flash_attn_ext_blk_nqptg=8_ncpsg=64'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_blk_nqptg=8_ncpsg=64      0x769540000 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk256_dv256', name = 'kernel_flash_attn_ext_f16_dk256_dv256_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=512_ns20=512_nsg=4'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk256_dv256_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=512_ns20=512_nsg=4      0x769540300 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_rms_norm_mul_add_f32_4', name = 'kernel_rms_norm_mul_add_f32_4'
+ggml_metal_library_compile_pipeline: loaded kernel_rms_norm_mul_add_f32_4                 0x769540600 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_cpy_f32_f32', name = 'kernel_cpy_f32_f32'
+ggml_metal_library_compile_pipeline: loaded kernel_cpy_f32_f32                            0x769540900 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_geglu_f32', name = 'kernel_geglu_f32'
+ggml_metal_library_compile_pipeline: loaded kernel_geglu_f32                              0x769540c00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32_4', name = 'kernel_unary_f32_f32_4_op=103_cnt=1'
+ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_4_op=103_cnt=1           0x769540f00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=0_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=0_cb=0      0x769541200 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=0_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=0_cb=0      0x769541500 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32', name = 'kernel_bin_fuse_f32_f32_f32_op=2_nf=1_rb=0_cb=1'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_op=2_nf=1_rb=0_cb=1      0x769541800 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk512_dv512', name = 'kernel_flash_attn_ext_f16_dk512_dv512_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=1024_ns20=1024_nsg=8'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk512_dv512_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=1024_ns20=1024_nsg=8      0x769541b00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_get_rows_f32', name = 'kernel_get_rows_f32'
+ggml_metal_library_compile_pipeline: loaded kernel_get_rows_f32                           0x769541e00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_q8_0_f32', name = 'kernel_mul_mv_q8_0_f32_nsg=4_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_q8_0_f32_nsg=4_ne12=1_r2=1_r3=1      0x769542100 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=1_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=1_cb=0      0x769542400 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=1_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=1_cb=0      0x769542700 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32', name = 'kernel_bin_fuse_f32_f32_f32_op=2_nf=1_rb=1_cb=1'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_op=2_nf=1_rb=1_cb=1      0x769542a00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32_4', name = 'kernel_unary_f32_f32_4_op=100_cnt=0'
+ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_4_op=100_cnt=0           0x769542d00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32_4', name = 'kernel_unary_f32_f32_4_op=10_cnt=1'
+ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_4_op=10_cnt=1            0x769543000 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_bf16_f32_4', name = 'kernel_mul_mv_bf16_f32_4_nsg=4_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_bf16_f32_4_nsg=4_ne12=1_r2=1_r3=1      0x769543300 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_vec_f16_dk256_dv256', name = 'kernel_flash_attn_ext_vec_f16_dk256_dv256_mask=1_sink=0_bias=0_scap=0_kvpad=0_ns10=512_ns20=512_nsg=1_nwg=32'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_vec_f16_dk256_dv256_mask=1_sink=0_bias=0_scap=0_kvpad=0_ns10=512_ns20=512_nsg=1_nwg=32      0x769543600 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_vec_reduce', name = 'kernel_flash_attn_ext_vec_reduce_dv=256_nwg=32'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_vec_reduce_dv=256_nwg=32      0x769543900 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_vec_f16_dk512_dv512', name = 'kernel_flash_attn_ext_vec_f16_dk512_dv512_mask=1_sink=0_bias=0_scap=0_kvpad=0_ns10=1024_ns20=1024_nsg=1_nwg=32'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_vec_f16_dk512_dv512_mask=1_sink=0_bias=0_scap=0_kvpad=0_ns10=1024_ns20=1024_nsg=1_nwg=32      0x769543c00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_vec_reduce', name = 'kernel_flash_attn_ext_vec_reduce_dv=512_nwg=32'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_vec_reduce_dv=512_nwg=32      0x769984000 | th_max = 1024 | th_width =   32
+[baseline] n=40 30.6 tok/s (prefill+decode 1306ms)
+[baseline] text: "One, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, eighteen, nineteen, twenty."
+llama_context: constructing llama_context
+llama_context: n_rs_seq=1 requested but model arch does not support recurrent partial rollback; clamping to 0
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: layer   4: filtered
+llama_kv_cache: layer   5: dev = MTL0
+llama_kv_cache: layer   6: filtered
+llama_kv_cache: layer   7: filtered
+llama_kv_cache: layer   8: filtered
+llama_kv_cache: layer   9: filtered
+llama_kv_cache: layer  10: filtered
+llama_kv_cache: layer  11: dev = MTL0
+llama_kv_cache: layer  12: filtered
+llama_kv_cache: layer  13: filtered
+llama_kv_cache: layer  14: filtered
+llama_kv_cache: layer  15: filtered
+llama_kv_cache: layer  16: filtered
+llama_kv_cache: layer  17: dev = MTL0
+llama_kv_cache: layer  18: filtered
+llama_kv_cache: layer  19: filtered
+llama_kv_cache: layer  20: filtered
+llama_kv_cache: layer  21: filtered
+llama_kv_cache: layer  22: filtered
+llama_kv_cache: layer  23: dev = MTL0
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: filtered
+llama_kv_cache: - layer  25: filtered
+llama_kv_cache: - layer  26: filtered
+llama_kv_cache: - layer  27: filtered
+llama_kv_cache: - layer  28: filtered
+llama_kv_cache: - layer  29: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  30: filtered
+llama_kv_cache: - layer  31: filtered
+llama_kv_cache: - layer  32: filtered
+llama_kv_cache: - layer  33: filtered
+llama_kv_cache: - layer  34: filtered
+llama_kv_cache: - layer  35: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  36: filtered
+llama_kv_cache: - layer  37: filtered
+llama_kv_cache: - layer  38: filtered
+llama_kv_cache: - layer  39: filtered
+llama_kv_cache: - layer  40: filtered
+llama_kv_cache: - layer  41: reuse layer 23, is_swa = 0
+llama_kv_cache:       MTL0 KV buffer size =    64.00 MiB
+llama_kv_cache: size =   64.00 MiB (  4096 cells,   4 layers,  1/1 seqs), K (f16):   32.00 MiB, V (f16):   32.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 512
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 512
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: dev = MTL0
+llama_kv_cache: layer   1: dev = MTL0
+llama_kv_cache: layer   2: dev = MTL0
+llama_kv_cache: layer   3: dev = MTL0
+llama_kv_cache: layer   4: dev = MTL0
+llama_kv_cache: layer   5: filtered
+llama_kv_cache: layer   6: dev = MTL0
+llama_kv_cache: layer   7: dev = MTL0
+llama_kv_cache: layer   8: dev = MTL0
+llama_kv_cache: layer   9: dev = MTL0
+llama_kv_cache: layer  10: dev = MTL0
+llama_kv_cache: layer  11: filtered
+llama_kv_cache: layer  12: dev = MTL0
+llama_kv_cache: layer  13: dev = MTL0
+llama_kv_cache: layer  14: dev = MTL0
+llama_kv_cache: layer  15: dev = MTL0
+llama_kv_cache: layer  16: dev = MTL0
+llama_kv_cache: layer  17: filtered
+llama_kv_cache: layer  18: dev = MTL0
+llama_kv_cache: layer  19: dev = MTL0
+llama_kv_cache: layer  20: dev = MTL0
+llama_kv_cache: layer  21: dev = MTL0
+llama_kv_cache: layer  22: dev = MTL0
+llama_kv_cache: layer  23: filtered
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  25: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  26: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  27: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  28: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  29: filtered
+llama_kv_cache: - layer  30: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  31: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  32: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  33: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  34: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  35: filtered
+llama_kv_cache: - layer  36: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  37: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  38: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  39: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  40: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  41: filtered
+llama_kv_cache:       MTL0 KV buffer size =   160.00 MiB
+llama_kv_cache: size =  160.00 MiB (  4096 cells,  20 layers,  1/1 seqs), K (f16):   80.00 MiB, V (f16):   80.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 5768
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   538.50 MiB
+sched_reserve:        CPU compute buffer size =    47.02 MiB
+sched_reserve: graph nodes  = 1867
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 72.48 ms, sched copies = 1
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_ext_q8_0_f32_r1_2', name = 'kernel_mul_mv_ext_q8_0_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_ext_q8_0_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1      0x769984300 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_ext_bf16_f32_r1_2', name = 'kernel_mul_mv_ext_bf16_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_ext_bf16_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1      0x769984600 | th_max = 1024 | th_width =   32
+llama_model_loader: loaded meta data with 42 key-value pairs and 49 tensors from /tmp/mtp/bundles/4b/mtp/drafter-4b.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = gemma4-assistant
+llama_model_loader: - kv   1:                               general.type str              = model
+llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 64
+llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+llama_model_loader: - kv   5:                               general.name str              = Model
+llama_model_loader: - kv   6:                         general.size_label str              = 78M
+llama_model_loader: - kv   7:               gemma4-assistant.block_count u32              = 4
+llama_model_loader: - kv   8:            gemma4-assistant.context_length u32              = 131072
+llama_model_loader: - kv   9:          gemma4-assistant.embedding_length u32              = 256
+llama_model_loader: - kv  10:       gemma4-assistant.feed_forward_length u32              = 2048
+llama_model_loader: - kv  11:      gemma4-assistant.attention.head_count u32              = 4
+llama_model_loader: - kv  12:   gemma4-assistant.attention.head_count_kv u32              = 2
+llama_model_loader: - kv  13:            gemma4-assistant.rope.freq_base f32              = 1000000.000000
+llama_model_loader: - kv  14:        gemma4-assistant.rope.freq_base_swa f32              = 10000.000000
+llama_model_loader: - kv  15: gemma4-assistant.attention.layer_norm_rms_epsilon f32              = 0.000001
+llama_model_loader: - kv  16:      gemma4-assistant.attention.key_length u32              = 512
+llama_model_loader: - kv  17:    gemma4-assistant.attention.value_length u32              = 512
+llama_model_loader: - kv  18:                          general.file_type u32              = 1
+llama_model_loader: - kv  19:  gemma4-assistant.attention.sliding_window u32              = 512
+llama_model_loader: - kv  20: gemma4-assistant.attention.shared_kv_layers u32              = 4
+llama_model_loader: - kv  21: gemma4-assistant.embedding_length_per_layer_input u32              = 0
+llama_model_loader: - kv  22: gemma4-assistant.attention.sliding_window_pattern arr[bool,4]      = [true, true, true, false]
+llama_model_loader: - kv  23:  gemma4-assistant.attention.key_length_swa u32              = 256
+llama_model_loader: - kv  24: gemma4-assistant.attention.value_length_swa u32              = 256
+llama_model_loader: - kv  25:      gemma4-assistant.rope.dimension_count u32              = 512
+llama_model_loader: - kv  26:  gemma4-assistant.rope.dimension_count_swa u32              = 256
+llama_model_loader: - kv  27:      gemma4-assistant.embedding_length_out u32              = 2560
+llama_model_loader: - kv  28:      gemma4-assistant.nextn_predict_layers u32              = 1
+llama_model_loader: - kv  29:               general.quantization_version u32              = 2
+llama_model_loader: - kv  30:                       tokenizer.ggml.model str              = gemma4
+llama_model_loader: - kv  31:                      tokenizer.ggml.tokens arr[str,262144]  = ["<pad>", "<eos>", "<bos>", "<unk>", ...
+llama_model_loader: - kv  32:                      tokenizer.ggml.scores arr[f32,262144]  = [-1000.000000, -1000.000000, -1000.00...
+llama_model_loader: - kv  33:                  tokenizer.ggml.token_type arr[i32,262144]  = [3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  34:                      tokenizer.ggml.merges arr[str,514906]  = ["\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n \n", ...
+llama_model_loader: - kv  35:                tokenizer.ggml.bos_token_id u32              = 2
+llama_model_loader: - kv  36:                tokenizer.ggml.eos_token_id u32              = 1
+llama_model_loader: - kv  37:            tokenizer.ggml.unknown_token_id u32              = 3
+llama_model_loader: - kv  38:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  39:               tokenizer.ggml.mask_token_id u32              = 4
+llama_model_loader: - kv  40:            tokenizer.ggml.add_space_prefix bool             = false
+llama_model_loader: - kv  41:               tokenizer.ggml.add_bos_token bool             = true
+llama_model_loader: - type  f32:   26 tensors
+llama_model_loader: - type  f16:   23 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = F16
+print_info: file size   = 148.77 MiB (16.00 BPW) 
+llama_prepare_model_devices: using device MTL0 (Apple M4 Max) (unknown id) - 100930 MiB free
+init_tokenizer: initializing tokenizer for type 2
+load: 0 unused tokens
+load: control token: 258883 '<audio|>' is not marked as EOG
+load: control token: 258881 '<|audio|>' is not marked as EOG
+load: control token: 258880 '<|image|>' is not marked as EOG
+load: control token: 256000 '<|audio>' is not marked as EOG
+load: control token: 255999 '<|image>' is not marked as EOG
+load: control token:    105 '<|turn>' is not marked as EOG
+load: control token: 258882 '<image|>' is not marked as EOG
+load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token:     46 '<|tool>' is not marked as EOG
+load: control token:      3 '<unk>' is not marked as EOG
+load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token:     47 '<tool|>' is not marked as EOG
+load: control token:      4 '<mask>' is not marked as EOG
+load: control token:      2 '<bos>' is not marked as EOG
+load: control token:     98 '<|think|>' is not marked as EOG
+load: control token:      0 '<pad>' is not marked as EOG
+load: printing all EOG tokens:
+load:   - 1 ('<eos>')
+load:   - 50 ('<|tool_response>')
+load:   - 106 ('<turn|>')
+load:   - 212 ('</s>')
+load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
+load: special tokens cache size = 23
+load: token to piece cache size = 1.9445 MB
+print_info: arch                  = gemma4-assistant
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 131072
+print_info: n_embd                = 256
+print_info: n_embd_inp            = 2560
+print_info: n_layer               = 4
+print_info: n_head                = 4
+print_info: n_head_kv             = 2
+print_info: n_rot                 = 512
+print_info: n_swa                 = 512
+print_info: is_swa_any            = 1
+print_info: n_embd_head_k         = 512
+print_info: n_embd_head_v         = 512
+print_info: n_gqa                 = 2
+print_info: n_embd_k_gqa          = [512, 512, 512, 1024]
+print_info: n_embd_v_gqa          = [512, 512, 512, 1024]
+print_info: f_norm_eps            = 0.0e+00
+print_info: f_norm_rms_eps        = 1.0e-06
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 1.0e+00
+print_info: f_attn_value_scale    = 0.0000
+print_info: n_ff                  = 2048
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 1
+print_info: pooling type          = -1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 1000000.0
+print_info: freq_scale_train      = 1
+print_info: freq_base_swa         = 10000.0
+print_info: freq_scale_swa        = 1
+print_info: n_embd_head_k_swa     = 256
+print_info: n_embd_head_v_swa     = 256
+print_info: n_rot_swa             = 256
+print_info: n_ctx_orig_yarn       = 131072
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = E2B
+print_info: model params          = 77.99 M
+print_info: general.name          = Model
+print_info: vocab type            = BPE
+print_info: n_vocab               = 262144
+print_info: n_merges              = 514906
+print_info: BOS token             = 2 '<bos>'
+print_info: EOS token             = 1 '<eos>'
+print_info: UNK token             = 3 '<unk>'
+print_info: PAD token             = 0 '<pad>'
+print_info: MASK token            = 4 '<mask>'
+print_info: LF token              = 107 '
+'
+print_info: EOG token             = 1 '<eos>'
+print_info: EOG token             = 50 '<|tool_response>'
+print_info: EOG token             = 106 '<turn|>'
+print_info: max token length      = 93
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: layer   0 assigned to device MTL0, is_swa = 1
+load_tensors: layer   1 assigned to device MTL0, is_swa = 1
+load_tensors: layer   2 assigned to device MTL0, is_swa = 1
+load_tensors: layer   3 assigned to device MTL0, is_swa = 0
+load_tensors: layer   4 assigned to device MTL0, is_swa = 0
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor output_norm.weight
+create_tensor: loading tensor nextn.post_projection.weight
+create_tensor: loading tensor nextn.pre_projection.weight
+create_tensor: loading tensor blk.0.attn_norm.weight
+create_tensor: loading tensor blk.0.attn_q.weight
+create_tensor: loading tensor blk.0.attn_output.weight
+create_tensor: loading tensor blk.0.attn_q_norm.weight
+create_tensor: loading tensor blk.0.post_attention_norm.weight
+create_tensor: loading tensor blk.0.layer_output_scale.weight
+create_tensor: loading tensor blk.0.ffn_norm.weight
+create_tensor: loading tensor blk.0.ffn_gate.weight
+create_tensor: loading tensor blk.0.ffn_up.weight
+create_tensor: loading tensor blk.0.ffn_down.weight
+create_tensor: loading tensor blk.0.post_ffw_norm.weight
+create_tensor: loading tensor blk.1.attn_norm.weight
+create_tensor: loading tensor blk.1.attn_q.weight
+create_tensor: loading tensor blk.1.attn_output.weight
+create_tensor: loading tensor blk.1.attn_q_norm.weight
+create_tensor: loading tensor blk.1.post_attention_norm.weight
+create_tensor: loading tensor blk.1.layer_output_scale.weight
+create_tensor: loading tensor blk.1.ffn_norm.weight
+create_tensor: loading tensor blk.1.ffn_gate.weight
+create_tensor: loading tensor blk.1.ffn_up.weight
+create_tensor: loading tensor blk.1.ffn_down.weight
+create_tensor: loading tensor blk.1.post_ffw_norm.weight
+create_tensor: loading tensor blk.2.attn_norm.weight
+create_tensor: loading tensor blk.2.attn_q.weight
+create_tensor: loading tensor blk.2.attn_output.weight
+create_tensor: loading tensor blk.2.attn_q_norm.weight
+create_tensor: loading tensor blk.2.post_attention_norm.weight
+create_tensor: loading tensor blk.2.layer_output_scale.weight
+create_tensor: loading tensor blk.2.ffn_norm.weight
+create_tensor: loading tensor blk.2.ffn_gate.weight
+create_tensor: loading tensor blk.2.ffn_up.weight
+create_tensor: loading tensor blk.2.ffn_down.weight
+create_tensor: loading tensor blk.2.post_ffw_norm.weight
+create_tensor: loading tensor blk.3.attn_norm.weight
+create_tensor: loading tensor blk.3.attn_q.weight
+create_tensor: loading tensor blk.3.attn_output.weight
+create_tensor: loading tensor blk.3.attn_q_norm.weight
+create_tensor: loading tensor blk.3.post_attention_norm.weight
+create_tensor: loading tensor blk.3.layer_output_scale.weight
+create_tensor: loading tensor rope_freqs.weight
+create_tensor: loading tensor blk.3.ffn_norm.weight
+create_tensor: loading tensor blk.3.ffn_gate.weight
+create_tensor: loading tensor blk.3.ffn_up.weight
+create_tensor: loading tensor blk.3.ffn_down.weight
+create_tensor: loading tensor blk.3.post_ffw_norm.weight
+done_getting_tensors: tensor 'token_embd.weight' (f16) (and 0 others) cannot be used with preferred buffer type CPU_REPACK, using CPU instead
+ggml_metal_log_allocated_size: allocated buffer, size =   148.78 MiB, ( 9318.59 / 110100.48)
+load_tensors: offloading output layer to GPU
+load_tensors: offloading 3 repeating layers to GPU
+load_tensors: offloaded 5/5 layers to GPU
+load_tensors:   CPU_Mapped model buffer size =   128.00 MiB
+load_tensors:  MTL0_Mapped model buffer size =   148.77 MiB
+..........
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: sharing with sibling layer 41
+llama_kv_cache: size =   16.00 MiB (  4096 cells,   1 layers,  1/1 seqs), K (f16):    8.00 MiB, V (f16):    8.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 0
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 0
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: sharing with sibling layer 40
+llama_kv_cache: layer   1: sharing with sibling layer 40
+llama_kv_cache: layer   2: sharing with sibling layer 40
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: size =   24.00 MiB (  4096 cells,   3 layers,  1/1 seqs), K (f16):   12.00 MiB, V (f16):   12.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 0
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 0
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 1024
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   518.00 MiB
+sched_reserve:        CPU compute buffer size =    26.01 MiB
+sched_reserve: graph nodes  = 128
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 86.37 ms, sched copies = 1
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_concat', name = 'kernel_concat'
+ggml_metal_library_compile_pipeline: loaded kernel_concat                                 0x769984900 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_ext_f16_f32_r1_2', name = 'kernel_mul_mv_ext_f16_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_ext_f16_f32_r1_2_nsg=2_nxpsg=16_ne12=1_r2=1_r3=1      0x769984c00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_f16_f32_4', name = 'kernel_mul_mv_f16_f32_4_nsg=2_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_f16_f32_4_nsg=2_ne12=1_r2=1_r3=1      0x769984f00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_f16_f32_4', name = 'kernel_mul_mv_f16_f32_4_nsg=4_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_f16_f32_4_nsg=4_ne12=1_r2=1_r3=1      0x769985200 | th_max = 1024 | th_width =   32
+common_speculative_init: adding speculative implementation 'draft-mtp'
+set_embeddings_pre_norm: value = 1
+set_embeddings_pre_norm: value = 1
+set_embeddings: value = 0
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mm_f16_f32', name = 'kernel_mul_mm_f16_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mm_f16_f32_bci=0_bco=1_ne12=1_ne13=1_r2=1_r3=1      0x769985500 | th_max = 1024 | th_width =   32
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+[mtp]      n=39 56.0 tok/s (prefill+decode 697ms) drafted=20 accepted=20 acceptance=1.000
+[mtp]      text: "One, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen, fifteen, sixteen,, eighteen, nineteen, twenty."
+[check]    greedy outputs identical: false
+
+=== prompt: "List the seven days of the week in order, one per line."
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: layer   4: filtered
+llama_kv_cache: layer   5: dev = MTL0
+llama_kv_cache: layer   6: filtered
+llama_kv_cache: layer   7: filtered
+llama_kv_cache: layer   8: filtered
+llama_kv_cache: layer   9: filtered
+llama_kv_cache: layer  10: filtered
+llama_kv_cache: layer  11: dev = MTL0
+llama_kv_cache: layer  12: filtered
+llama_kv_cache: layer  13: filtered
+llama_kv_cache: layer  14: filtered
+llama_kv_cache: layer  15: filtered
+llama_kv_cache: layer  16: filtered
+llama_kv_cache: layer  17: dev = MTL0
+llama_kv_cache: layer  18: filtered
+llama_kv_cache: layer  19: filtered
+llama_kv_cache: layer  20: filtered
+llama_kv_cache: layer  21: filtered
+llama_kv_cache: layer  22: filtered
+llama_kv_cache: layer  23: dev = MTL0
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: filtered
+llama_kv_cache: - layer  25: filtered
+llama_kv_cache: - layer  26: filtered
+llama_kv_cache: - layer  27: filtered
+llama_kv_cache: - layer  28: filtered
+llama_kv_cache: - layer  29: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  30: filtered
+llama_kv_cache: - layer  31: filtered
+llama_kv_cache: - layer  32: filtered
+llama_kv_cache: - layer  33: filtered
+llama_kv_cache: - layer  34: filtered
+llama_kv_cache: - layer  35: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  36: filtered
+llama_kv_cache: - layer  37: filtered
+llama_kv_cache: - layer  38: filtered
+llama_kv_cache: - layer  39: filtered
+llama_kv_cache: - layer  40: filtered
+llama_kv_cache: - layer  41: reuse layer 23, is_swa = 0
+llama_kv_cache:       MTL0 KV buffer size =    64.00 MiB
+llama_kv_cache: size =   64.00 MiB (  4096 cells,   4 layers,  1/1 seqs), K (f16):   32.00 MiB, V (f16):   32.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 512
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 512
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: dev = MTL0
+llama_kv_cache: layer   1: dev = MTL0
+llama_kv_cache: layer   2: dev = MTL0
+llama_kv_cache: layer   3: dev = MTL0
+llama_kv_cache: layer   4: dev = MTL0
+llama_kv_cache: layer   5: filtered
+llama_kv_cache: layer   6: dev = MTL0
+llama_kv_cache: layer   7: dev = MTL0
+llama_kv_cache: layer   8: dev = MTL0
+llama_kv_cache: layer   9: dev = MTL0
+llama_kv_cache: layer  10: dev = MTL0
+llama_kv_cache: layer  11: filtered
+llama_kv_cache: layer  12: dev = MTL0
+llama_kv_cache: layer  13: dev = MTL0
+llama_kv_cache: layer  14: dev = MTL0
+llama_kv_cache: layer  15: dev = MTL0
+llama_kv_cache: layer  16: dev = MTL0
+llama_kv_cache: layer  17: filtered
+llama_kv_cache: layer  18: dev = MTL0
+llama_kv_cache: layer  19: dev = MTL0
+llama_kv_cache: layer  20: dev = MTL0
+llama_kv_cache: layer  21: dev = MTL0
+llama_kv_cache: layer  22: dev = MTL0
+llama_kv_cache: layer  23: filtered
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  25: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  26: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  27: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  28: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  29: filtered
+llama_kv_cache: - layer  30: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  31: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  32: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  33: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  34: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  35: filtered
+llama_kv_cache: - layer  36: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  37: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  38: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  39: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  40: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  41: filtered
+llama_kv_cache:       MTL0 KV buffer size =   160.00 MiB
+llama_kv_cache: size =  160.00 MiB (  4096 cells,  20 layers,  1/1 seqs), K (f16):   80.00 MiB, V (f16):   80.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 5768
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   538.50 MiB
+sched_reserve:        CPU compute buffer size =    47.02 MiB
+sched_reserve: graph nodes  = 1867
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 302.35 ms, sched copies = 1
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk256_dv256', name = 'kernel_flash_attn_ext_f16_dk256_dv256_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=0_ns10=512_ns20=512_nsg=4'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk256_dv256_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=0_ns10=512_ns20=512_nsg=4      0x769985800 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk512_dv512', name = 'kernel_flash_attn_ext_f16_dk512_dv512_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=0_ns10=1024_ns20=1024_nsg=8'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk512_dv512_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=0_ns10=1024_ns20=1024_nsg=8      0x769985b00 | th_max = 1024 | th_width =   32
+[baseline] n=20 38.4 tok/s (prefill+decode 520ms)
+[baseline] text: "Sunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday<end_of_turn>"
+llama_context: constructing llama_context
+llama_context: n_rs_seq=1 requested but model arch does not support recurrent partial rollback; clamping to 0
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: layer   4: filtered
+llama_kv_cache: layer   5: dev = MTL0
+llama_kv_cache: layer   6: filtered
+llama_kv_cache: layer   7: filtered
+llama_kv_cache: layer   8: filtered
+llama_kv_cache: layer   9: filtered
+llama_kv_cache: layer  10: filtered
+llama_kv_cache: layer  11: dev = MTL0
+llama_kv_cache: layer  12: filtered
+llama_kv_cache: layer  13: filtered
+llama_kv_cache: layer  14: filtered
+llama_kv_cache: layer  15: filtered
+llama_kv_cache: layer  16: filtered
+llama_kv_cache: layer  17: dev = MTL0
+llama_kv_cache: layer  18: filtered
+llama_kv_cache: layer  19: filtered
+llama_kv_cache: layer  20: filtered
+llama_kv_cache: layer  21: filtered
+llama_kv_cache: layer  22: filtered
+llama_kv_cache: layer  23: dev = MTL0
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: filtered
+llama_kv_cache: - layer  25: filtered
+llama_kv_cache: - layer  26: filtered
+llama_kv_cache: - layer  27: filtered
+llama_kv_cache: - layer  28: filtered
+llama_kv_cache: - layer  29: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  30: filtered
+llama_kv_cache: - layer  31: filtered
+llama_kv_cache: - layer  32: filtered
+llama_kv_cache: - layer  33: filtered
+llama_kv_cache: - layer  34: filtered
+llama_kv_cache: - layer  35: reuse layer 23, is_swa = 0
+llama_kv_cache: - layer  36: filtered
+llama_kv_cache: - layer  37: filtered
+llama_kv_cache: - layer  38: filtered
+llama_kv_cache: - layer  39: filtered
+llama_kv_cache: - layer  40: filtered
+llama_kv_cache: - layer  41: reuse layer 23, is_swa = 0
+llama_kv_cache:       MTL0 KV buffer size =    64.00 MiB
+llama_kv_cache: size =   64.00 MiB (  4096 cells,   4 layers,  1/1 seqs), K (f16):   32.00 MiB, V (f16):   32.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 512
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 512
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: dev = MTL0
+llama_kv_cache: layer   1: dev = MTL0
+llama_kv_cache: layer   2: dev = MTL0
+llama_kv_cache: layer   3: dev = MTL0
+llama_kv_cache: layer   4: dev = MTL0
+llama_kv_cache: layer   5: filtered
+llama_kv_cache: layer   6: dev = MTL0
+llama_kv_cache: layer   7: dev = MTL0
+llama_kv_cache: layer   8: dev = MTL0
+llama_kv_cache: layer   9: dev = MTL0
+llama_kv_cache: layer  10: dev = MTL0
+llama_kv_cache: layer  11: filtered
+llama_kv_cache: layer  12: dev = MTL0
+llama_kv_cache: layer  13: dev = MTL0
+llama_kv_cache: layer  14: dev = MTL0
+llama_kv_cache: layer  15: dev = MTL0
+llama_kv_cache: layer  16: dev = MTL0
+llama_kv_cache: layer  17: filtered
+llama_kv_cache: layer  18: dev = MTL0
+llama_kv_cache: layer  19: dev = MTL0
+llama_kv_cache: layer  20: dev = MTL0
+llama_kv_cache: layer  21: dev = MTL0
+llama_kv_cache: layer  22: dev = MTL0
+llama_kv_cache: layer  23: filtered
+llama_kv_cache: layer  24: does not have KV cache
+llama_kv_cache: layer  25: does not have KV cache
+llama_kv_cache: layer  26: does not have KV cache
+llama_kv_cache: layer  27: does not have KV cache
+llama_kv_cache: layer  28: does not have KV cache
+llama_kv_cache: layer  29: does not have KV cache
+llama_kv_cache: layer  30: does not have KV cache
+llama_kv_cache: layer  31: does not have KV cache
+llama_kv_cache: layer  32: does not have KV cache
+llama_kv_cache: layer  33: does not have KV cache
+llama_kv_cache: layer  34: does not have KV cache
+llama_kv_cache: layer  35: does not have KV cache
+llama_kv_cache: layer  36: does not have KV cache
+llama_kv_cache: layer  37: does not have KV cache
+llama_kv_cache: layer  38: does not have KV cache
+llama_kv_cache: layer  39: does not have KV cache
+llama_kv_cache: layer  40: does not have KV cache
+llama_kv_cache: layer  41: does not have KV cache
+llama_kv_cache: reusing layers:
+llama_kv_cache: - layer   0: no reuse
+llama_kv_cache: - layer   1: no reuse
+llama_kv_cache: - layer   2: no reuse
+llama_kv_cache: - layer   3: no reuse
+llama_kv_cache: - layer   4: no reuse
+llama_kv_cache: - layer   5: no reuse
+llama_kv_cache: - layer   6: no reuse
+llama_kv_cache: - layer   7: no reuse
+llama_kv_cache: - layer   8: no reuse
+llama_kv_cache: - layer   9: no reuse
+llama_kv_cache: - layer  10: no reuse
+llama_kv_cache: - layer  11: no reuse
+llama_kv_cache: - layer  12: no reuse
+llama_kv_cache: - layer  13: no reuse
+llama_kv_cache: - layer  14: no reuse
+llama_kv_cache: - layer  15: no reuse
+llama_kv_cache: - layer  16: no reuse
+llama_kv_cache: - layer  17: no reuse
+llama_kv_cache: - layer  18: no reuse
+llama_kv_cache: - layer  19: no reuse
+llama_kv_cache: - layer  20: no reuse
+llama_kv_cache: - layer  21: no reuse
+llama_kv_cache: - layer  22: no reuse
+llama_kv_cache: - layer  23: no reuse
+llama_kv_cache: - layer  24: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  25: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  26: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  27: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  28: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  29: filtered
+llama_kv_cache: - layer  30: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  31: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  32: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  33: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  34: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  35: filtered
+llama_kv_cache: - layer  36: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  37: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  38: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  39: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  40: reuse layer 22, is_swa = 1
+llama_kv_cache: - layer  41: filtered
+llama_kv_cache:       MTL0 KV buffer size =   160.00 MiB
+llama_kv_cache: size =  160.00 MiB (  4096 cells,  20 layers,  1/1 seqs), K (f16):   80.00 MiB, V (f16):   80.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 5768
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   538.50 MiB
+sched_reserve:        CPU compute buffer size =    47.02 MiB
+sched_reserve: graph nodes  = 1867
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 72.19 ms, sched copies = 1
+llama_model_loader: loaded meta data with 42 key-value pairs and 49 tensors from /tmp/mtp/bundles/4b/mtp/drafter-4b.gguf (version GGUF V3 (latest))
+llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
+llama_model_loader: - kv   0:                       general.architecture str              = gemma4-assistant
+llama_model_loader: - kv   1:                               general.type str              = model
+llama_model_loader: - kv   2:                     general.sampling.top_k i32              = 64
+llama_model_loader: - kv   3:                     general.sampling.top_p f32              = 0.950000
+llama_model_loader: - kv   4:                      general.sampling.temp f32              = 1.000000
+llama_model_loader: - kv   5:                               general.name str              = Model
+llama_model_loader: - kv   6:                         general.size_label str              = 78M
+llama_model_loader: - kv   7:               gemma4-assistant.block_count u32              = 4
+llama_model_loader: - kv   8:            gemma4-assistant.context_length u32              = 131072
+llama_model_loader: - kv   9:          gemma4-assistant.embedding_length u32              = 256
+llama_model_loader: - kv  10:       gemma4-assistant.feed_forward_length u32              = 2048
+llama_model_loader: - kv  11:      gemma4-assistant.attention.head_count u32              = 4
+llama_model_loader: - kv  12:   gemma4-assistant.attention.head_count_kv u32              = 2
+llama_model_loader: - kv  13:            gemma4-assistant.rope.freq_base f32              = 1000000.000000
+llama_model_loader: - kv  14:        gemma4-assistant.rope.freq_base_swa f32              = 10000.000000
+llama_model_loader: - kv  15: gemma4-assistant.attention.layer_norm_rms_epsilon f32              = 0.000001
+llama_model_loader: - kv  16:      gemma4-assistant.attention.key_length u32              = 512
+llama_model_loader: - kv  17:    gemma4-assistant.attention.value_length u32              = 512
+llama_model_loader: - kv  18:                          general.file_type u32              = 1
+llama_model_loader: - kv  19:  gemma4-assistant.attention.sliding_window u32              = 512
+llama_model_loader: - kv  20: gemma4-assistant.attention.shared_kv_layers u32              = 4
+llama_model_loader: - kv  21: gemma4-assistant.embedding_length_per_layer_input u32              = 0
+llama_model_loader: - kv  22: gemma4-assistant.attention.sliding_window_pattern arr[bool,4]      = [true, true, true, false]
+llama_model_loader: - kv  23:  gemma4-assistant.attention.key_length_swa u32              = 256
+llama_model_loader: - kv  24: gemma4-assistant.attention.value_length_swa u32              = 256
+llama_model_loader: - kv  25:      gemma4-assistant.rope.dimension_count u32              = 512
+llama_model_loader: - kv  26:  gemma4-assistant.rope.dimension_count_swa u32              = 256
+llama_model_loader: - kv  27:      gemma4-assistant.embedding_length_out u32              = 2560
+llama_model_loader: - kv  28:      gemma4-assistant.nextn_predict_layers u32              = 1
+llama_model_loader: - kv  29:               general.quantization_version u32              = 2
+llama_model_loader: - kv  30:                       tokenizer.ggml.model str              = gemma4
+llama_model_loader: - kv  31:                      tokenizer.ggml.tokens arr[str,262144]  = ["<pad>", "<eos>", "<bos>", "<unk>", ...
+llama_model_loader: - kv  32:                      tokenizer.ggml.scores arr[f32,262144]  = [-1000.000000, -1000.000000, -1000.00...
+llama_model_loader: - kv  33:                  tokenizer.ggml.token_type arr[i32,262144]  = [3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, ...
+llama_model_loader: - kv  34:                      tokenizer.ggml.merges arr[str,514906]  = ["\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n \n", ...
+llama_model_loader: - kv  35:                tokenizer.ggml.bos_token_id u32              = 2
+llama_model_loader: - kv  36:                tokenizer.ggml.eos_token_id u32              = 1
+llama_model_loader: - kv  37:            tokenizer.ggml.unknown_token_id u32              = 3
+llama_model_loader: - kv  38:            tokenizer.ggml.padding_token_id u32              = 0
+llama_model_loader: - kv  39:               tokenizer.ggml.mask_token_id u32              = 4
+llama_model_loader: - kv  40:            tokenizer.ggml.add_space_prefix bool             = false
+llama_model_loader: - kv  41:               tokenizer.ggml.add_bos_token bool             = true
+llama_model_loader: - type  f32:   26 tensors
+llama_model_loader: - type  f16:   23 tensors
+print_info: file format = GGUF V3 (latest)
+print_info: file type   = F16
+print_info: file size   = 148.77 MiB (16.00 BPW) 
+llama_prepare_model_devices: using device MTL0 (Apple M4 Max) (unknown id) - 98738 MiB free
+init_tokenizer: initializing tokenizer for type 2
+load: 0 unused tokens
+load: control token: 258883 '<audio|>' is not marked as EOG
+load: control token: 258881 '<|audio|>' is not marked as EOG
+load: control token: 258880 '<|image|>' is not marked as EOG
+load: control token: 256000 '<|audio>' is not marked as EOG
+load: control token: 255999 '<|image>' is not marked as EOG
+load: control token:    105 '<|turn>' is not marked as EOG
+load: control token: 258882 '<image|>' is not marked as EOG
+load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token:     46 '<|tool>' is not marked as EOG
+load: control token:      3 '<unk>' is not marked as EOG
+load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
+load: control token:     47 '<tool|>' is not marked as EOG
+load: control token:      4 '<mask>' is not marked as EOG
+load: control token:      2 '<bos>' is not marked as EOG
+load: control token:     98 '<|think|>' is not marked as EOG
+load: control token:      0 '<pad>' is not marked as EOG
+load: printing all EOG tokens:
+load:   - 1 ('<eos>')
+load:   - 50 ('<|tool_response>')
+load:   - 106 ('<turn|>')
+load:   - 212 ('</s>')
+load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
+load: special tokens cache size = 23
+load: token to piece cache size = 1.9445 MB
+print_info: arch                  = gemma4-assistant
+print_info: vocab_only            = 0
+print_info: no_alloc              = 0
+print_info: n_ctx_train           = 131072
+print_info: n_embd                = 256
+print_info: n_embd_inp            = 2560
+print_info: n_layer               = 4
+print_info: n_head                = 4
+print_info: n_head_kv             = 2
+print_info: n_rot                 = 512
+print_info: n_swa                 = 512
+print_info: is_swa_any            = 1
+print_info: n_embd_head_k         = 512
+print_info: n_embd_head_v         = 512
+print_info: n_gqa                 = 2
+print_info: n_embd_k_gqa          = [512, 512, 512, 1024]
+print_info: n_embd_v_gqa          = [512, 512, 512, 1024]
+print_info: f_norm_eps            = 0.0e+00
+print_info: f_norm_rms_eps        = 1.0e-06
+print_info: f_clamp_kqv           = 0.0e+00
+print_info: f_max_alibi_bias      = 0.0e+00
+print_info: f_logit_scale         = 0.0e+00
+print_info: f_attn_scale          = 1.0e+00
+print_info: f_attn_value_scale    = 0.0000
+print_info: n_ff                  = 2048
+print_info: n_expert              = 0
+print_info: n_expert_used         = 0
+print_info: n_expert_groups       = 0
+print_info: n_group_used          = 0
+print_info: causal attn           = 1
+print_info: pooling type          = -1
+print_info: rope type             = 2
+print_info: rope scaling          = linear
+print_info: freq_base_train       = 1000000.0
+print_info: freq_scale_train      = 1
+print_info: freq_base_swa         = 10000.0
+print_info: freq_scale_swa        = 1
+print_info: n_embd_head_k_swa     = 256
+print_info: n_embd_head_v_swa     = 256
+print_info: n_rot_swa             = 256
+print_info: n_ctx_orig_yarn       = 131072
+print_info: rope_yarn_log_mul     = 0.0000
+print_info: rope_finetuned        = unknown
+print_info: model type            = E2B
+print_info: model params          = 77.99 M
+print_info: general.name          = Model
+print_info: vocab type            = BPE
+print_info: n_vocab               = 262144
+print_info: n_merges              = 514906
+print_info: BOS token             = 2 '<bos>'
+print_info: EOS token             = 1 '<eos>'
+print_info: UNK token             = 3 '<unk>'
+print_info: PAD token             = 0 '<pad>'
+print_info: MASK token            = 4 '<mask>'
+print_info: LF token              = 107 '
+'
+print_info: EOG token             = 1 '<eos>'
+print_info: EOG token             = 50 '<|tool_response>'
+print_info: EOG token             = 106 '<turn|>'
+print_info: max token length      = 93
+load_tensors: loading model tensors, this can take a while... (mmap = true, direct_io = false)
+load_tensors: layer   0 assigned to device MTL0, is_swa = 1
+load_tensors: layer   1 assigned to device MTL0, is_swa = 1
+load_tensors: layer   2 assigned to device MTL0, is_swa = 1
+load_tensors: layer   3 assigned to device MTL0, is_swa = 0
+load_tensors: layer   4 assigned to device MTL0, is_swa = 0
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor token_embd.weight
+create_tensor: loading tensor output_norm.weight
+create_tensor: loading tensor nextn.post_projection.weight
+create_tensor: loading tensor nextn.pre_projection.weight
+create_tensor: loading tensor blk.0.attn_norm.weight
+create_tensor: loading tensor blk.0.attn_q.weight
+create_tensor: loading tensor blk.0.attn_output.weight
+create_tensor: loading tensor blk.0.attn_q_norm.weight
+create_tensor: loading tensor blk.0.post_attention_norm.weight
+create_tensor: loading tensor blk.0.layer_output_scale.weight
+create_tensor: loading tensor blk.0.ffn_norm.weight
+create_tensor: loading tensor blk.0.ffn_gate.weight
+create_tensor: loading tensor blk.0.ffn_up.weight
+create_tensor: loading tensor blk.0.ffn_down.weight
+create_tensor: loading tensor blk.0.post_ffw_norm.weight
+create_tensor: loading tensor blk.1.attn_norm.weight
+create_tensor: loading tensor blk.1.attn_q.weight
+create_tensor: loading tensor blk.1.attn_output.weight
+create_tensor: loading tensor blk.1.attn_q_norm.weight
+create_tensor: loading tensor blk.1.post_attention_norm.weight
+create_tensor: loading tensor blk.1.layer_output_scale.weight
+create_tensor: loading tensor blk.1.ffn_norm.weight
+create_tensor: loading tensor blk.1.ffn_gate.weight
+create_tensor: loading tensor blk.1.ffn_up.weight
+create_tensor: loading tensor blk.1.ffn_down.weight
+create_tensor: loading tensor blk.1.post_ffw_norm.weight
+create_tensor: loading tensor blk.2.attn_norm.weight
+create_tensor: loading tensor blk.2.attn_q.weight
+create_tensor: loading tensor blk.2.attn_output.weight
+create_tensor: loading tensor blk.2.attn_q_norm.weight
+create_tensor: loading tensor blk.2.post_attention_norm.weight
+create_tensor: loading tensor blk.2.layer_output_scale.weight
+create_tensor: loading tensor blk.2.ffn_norm.weight
+create_tensor: loading tensor blk.2.ffn_gate.weight
+create_tensor: loading tensor blk.2.ffn_up.weight
+create_tensor: loading tensor blk.2.ffn_down.weight
+create_tensor: loading tensor blk.2.post_ffw_norm.weight
+create_tensor: loading tensor blk.3.attn_norm.weight
+create_tensor: loading tensor blk.3.attn_q.weight
+create_tensor: loading tensor blk.3.attn_output.weight
+create_tensor: loading tensor blk.3.attn_q_norm.weight
+create_tensor: loading tensor blk.3.post_attention_norm.weight
+create_tensor: loading tensor blk.3.layer_output_scale.weight
+create_tensor: loading tensor rope_freqs.weight
+create_tensor: loading tensor blk.3.ffn_norm.weight
+create_tensor: loading tensor blk.3.ffn_gate.weight
+create_tensor: loading tensor blk.3.ffn_up.weight
+create_tensor: loading tensor blk.3.ffn_down.weight
+create_tensor: loading tensor blk.3.post_ffw_norm.weight
+done_getting_tensors: tensor 'token_embd.weight' (f16) (and 0 others) cannot be used with preferred buffer type CPU_REPACK, using CPU instead
+ggml_metal_log_allocated_size: allocated buffer, size =   148.78 MiB, (11510.38 / 110100.48)
+load_tensors: offloading output layer to GPU
+load_tensors: offloading 3 repeating layers to GPU
+load_tensors: offloaded 5/5 layers to GPU
+load_tensors:   CPU_Mapped model buffer size =   128.00 MiB
+load_tensors:  MTL0_Mapped model buffer size =   148.77 MiB
+..........
+llama_context: constructing llama_context
+llama_context: n_seq_max     = 1
+llama_context: n_ctx         = 4096
+llama_context: n_ctx_seq     = 4096
+llama_context: n_batch       = 512
+llama_context: n_ubatch      = 512
+llama_context: causal_attn   = 1
+llama_context: flash_attn    = auto
+llama_context: kv_unified    = false
+llama_context: freq_base     = 1000000.0
+llama_context: freq_scale    = 1
+llama_context: n_rs_seq      = 0
+llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
+ggml_metal_init: allocating
+ggml_metal_init: found device: Apple M4 Max
+ggml_metal_init: picking default device: Apple M4 Max
+ggml_metal_init: use fusion         = true
+ggml_metal_init: use concurrency    = true
+ggml_metal_init: use graph optimize = true
+set_abort_callback: call
+llama_context:        CPU  output buffer size =     1.00 MiB
+llama_kv_cache_iswa: using full-size SWA cache (ref: https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
+llama_kv_cache_iswa: creating non-SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: filtered
+llama_kv_cache: layer   1: filtered
+llama_kv_cache: layer   2: filtered
+llama_kv_cache: layer   3: sharing with sibling layer 41
+llama_kv_cache: size =   16.00 MiB (  4096 cells,   1 layers,  1/1 seqs), K (f16):    8.00 MiB, V (f16):    8.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 0
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 0
+llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
+llama_kv_cache: layer   0: sharing with sibling layer 40
+llama_kv_cache: layer   1: sharing with sibling layer 40
+llama_kv_cache: layer   2: sharing with sibling layer 40
+llama_kv_cache: layer   3: filtered
+llama_kv_cache: size =   24.00 MiB (  4096 cells,   3 layers,  1/1 seqs), K (f16):   12.00 MiB, V (f16):   12.00 MiB
+llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 0
+llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 0
+llama_context: enumerating backends
+llama_context: backend_ptrs.size() = 3
+sched_reserve: reserving ...
+sched_reserve: max_nodes = 1024
+sched_reserve: reserving full memory module
+sched_reserve: worst-case: n_tokens = 512, n_seqs = 1, n_outputs = 1
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: Flash Attention was auto, set to enabled
+sched_reserve: resolving fused Gated Delta Net support:
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+sched_reserve: fused Gated Delta Net (autoregressive) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =   16, n_seqs =  1, n_outputs =   16
+sched_reserve: fused Gated Delta Net (chunked) enabled
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+graph_reserve: reserving a graph for ubatch with n_tokens =    1, n_seqs =  1, n_outputs =    1
+graph_reserve: reserving a graph for ubatch with n_tokens =  512, n_seqs =  1, n_outputs =  512
+sched_reserve:       MTL0 compute buffer size =   518.00 MiB
+sched_reserve:        CPU compute buffer size =    26.01 MiB
+sched_reserve: graph nodes  = 128
+sched_reserve: graph splits = 2
+sched_reserve: reserve took 15.45 ms, sched copies = 1
+set_embeddings_pre_norm: value = 1
+set_embeddings_pre_norm: value = 1
+set_embeddings: value = 0
+common_speculative_init: adding speculative implementation 'draft-mtp'
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+set_embeddings: value = 0
+[mtp]      n=20 40.1 tok/s (prefill+decode 498ms) drafted=11 accepted=9 acceptance=0.818
+[mtp]      text: "Sunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday<end_of_turn>"
+[check]    greedy outputs identical: true
+
+[TOTAL] drafted=31 accepted=29 acceptance=0.935
+[harness] clean shutdown
+/Users/shawwalters/eliza-workspace/milady/eliza/plugins/plugin-local-inference/native/llama.cpp/ggml/src/ggml-metal/ggml-metal-device.m:710: GGML_ASSERT([rsets->data count] == 0) failed
+WARNING: Using native backtrace. Set GGML_BACKTRACE_LLDB for more info.
+WARNING: GGML_BACKTRACE_LLDB may cause native MacOS Terminal.app to crash.
+See: https://github.com/ggml-org/llama.cpp/pull/17869
+0   libggml-base.0.12.0.dylib           0x0000000140105490 ggml_print_backtrace + 276
+1   libggml-base.0.12.0.dylib           0x000000014017eaa0 ggml_abort + 156
+2   libggml-metal.0.12.0.dylib          0x00000001412a648c ggml_metal_device_init + 0
+3   libggml-metal.0.12.0.dylib          0x00000001412a6e94 ggml_metal_device_free + 24
+4   libggml-metal.0.12.0.dylib          0x00000001412a8e68 _ZNSt3__16vectorINS_10unique_ptrI17ggml_metal_device25ggml_metal_device_deleterEENS_9allocatorIS4_EEED1B9nqe210106Ev + 72
+5   libsystem_c.dylib                   0x000000018e5b542c __cxa_finalize_ranges + 480
+6   libsystem_c.dylib                   0x000000018e5b51ec exit + 44
+7   bun                                 0x0000000105086734 bun + 10217268
+8   bun                                 0x000000010532a844 bun + 12986436
+9   bun                                 0x000000010584a334 bun + 18359092
+10  bun                                 0x0000000104a894e0 bun + 3937504
+11  bun                                 0x00000001050fd9cc bun + 10705356
+12  bun                                 0x0000000105117f8c bun + 10813324
+13  bun                                 0x00000001050d5abc bun + 10541756
+14  bun                                 0x0000000105094f6c bun + 10276716
+15  bun                                 0x0000000105086670 bun + 10217072
+16  bun                                 0x0000000105085d0c bun + 10214668
+17  dyld                                0x000000018e339d54 start + 7184

--- a/.github/issue-evidence/gemma4-assistant-mtp/4b/prompts.txt
+++ b/.github/issue-evidence/gemma4-assistant-mtp/4b/prompts.txt
@@ -1,0 +1,8 @@
+Count from one to twenty, writing each number as a word separated by commas.
+Complete the sentence and stop: The quick brown fox
+List the seven days of the week in order, one per line.
+List the twelve months of the year in order, separated by commas.
+Explain in two sentences why the sky is blue.
+Write a haiku about autumn leaves.
+Name the first eight planets from the Sun in order.
+Summarize what a hash table is in one sentence.

--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -80,9 +80,11 @@ describe("Eliza-1 runtime quant metadata", () => {
 
   it("advertises Gemma MTP metadata only for tiers with hosted drafter GGUFs", () => {
     expect(ELIZA_1_MTP_TIER_IDS).toEqual(ELIZA_1_TIER_IDS);
-    // 2b hosts the gemma4-assistant drafter at bundles/2b/mtp/drafter-2b.gguf
-    // (converted from google/gemma-4-E2B-it-assistant, 2026-07-02).
-    expect(ELIZA_1_HOSTED_MTP_TIER_IDS).toEqual(["eliza-1-2b"]);
+    // 2b/4b host the gemma4-assistant drafters at
+    // bundles/<tier>/mtp/drafter-<tier>.gguf (converted from
+    // google/gemma-4-E2B-it-assistant / google/gemma-4-E4B-it-assistant,
+    // 2026-07-02).
+    expect(ELIZA_1_HOSTED_MTP_TIER_IDS).toEqual(["eliza-1-2b", "eliza-1-4b"]);
     const hosted: ReadonlySet<string> = new Set(ELIZA_1_HOSTED_MTP_TIER_IDS);
     for (const id of ELIZA_1_MTP_TIER_IDS) {
       const entry = MODEL_CATALOG.find((model) => model.id === id);

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -68,13 +68,18 @@ export const ELIZA_1_MTP_TIER_IDS = [
  * (arch `gemma4-assistant`, f16, embedding_length_out=1536; sha256
  * 0495d34e08d0…, manifest `files.mtp` + `lineage.drafter` + `evals.mtp`
  * populated — acceptance 0.84, speedup ~1.53x greedy on M4 Max Metal at
- * `--spec-draft-n-max 1`). The remaining tiers still only expose legacy
- * `dflash/` paths; add a tier here only once its `mtp/drafter-<tier>.gguf`
- * is actually hosted, so the runtime and downloader never advertise or
- * fetch missing MTP artifacts.
+ * `--spec-draft-n-max 1`). `bundles/4b/mtp/drafter-4b.gguf` hosts the
+ * drafter converted from `google/gemma-4-E4B-it-assistant` (arch
+ * `gemma4-assistant`, f16, embedding_length_out=2560; sha256 e4585e558a74…,
+ * manifest populated — acceptance 0.79, speedup ~1.33x greedy on M4 Max
+ * Metal at `--spec-draft-n-max 1`). The remaining tiers (9b/27b) still only
+ * expose legacy `dflash/` paths; add a tier here only once its
+ * `mtp/drafter-<tier>.gguf` is actually hosted, so the runtime and
+ * downloader never advertise or fetch missing MTP artifacts.
  */
 export const ELIZA_1_HOSTED_MTP_TIER_IDS = [
   "eliza-1-2b",
+  "eliza-1-4b",
 ] as const satisfies ReadonlyArray<Eliza1TierId>;
 
 function hostedMtpDrafterAvailableForTier(id: Eliza1TierId): boolean {

--- a/plugins/plugin-local-inference/__tests__/imagegen-backend-selector.test.ts
+++ b/plugins/plugin-local-inference/__tests__/imagegen-backend-selector.test.ts
@@ -44,10 +44,21 @@ describe("WS3 backend-selector", () => {
 		]);
 	});
 
-	it("Linux NVIDIA without sd-cpp CUDA proof → sd-cpp CPU only", () => {
+	it("Linux NVIDIA without contrary sd-cpp evidence → sd-cpp CUDA then CPU", () => {
+		// #10727: trust the loader unless the profile carries explicit evidence
+		// the binary CANNOT do CUDA (mirrors src/services/imagegen/backend-selector.test.ts).
 		expect(ids({ platform: "linux", arch: "x64", gpu: "nvidia" })).toEqual([
+			"sd-cpp:cuda",
 			"sd-cpp:cpu",
 		]);
+		expect(
+			ids({
+				platform: "linux",
+				arch: "x64",
+				gpu: "nvidia",
+				sdCpp: { cudaCapable: false, accelerators: ["cpu"] },
+			}),
+		).toEqual(["sd-cpp:cpu"]);
 	});
 
 	it("required CUDA accelerator does not fall back to CPU", () => {

--- a/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
@@ -140,32 +140,34 @@ describe("WS2 mmproj routing", () => {
 		expect(resolved.modelPath).toBe(bundle.textPath);
 	});
 
-	it("resolves the bundled gemma4-assistant drafter for the hosted MTP tier (2b)", async () => {
-		const tier = "2b";
-		// bundles/2b/mtp/drafter-2b.gguf is hosted (gemma4-assistant, converted
-		// from google/gemma-4-E2B-it-assistant) and the catalog advertises
-		// runtime.mtp for eliza-1-2b, so the resolver must wire the on-disk
-		// drafter with the catalog's draft window.
-		const catalog = findCatalogModel(`eliza-1-${tier}`);
-		expect(catalog?.runtime?.mtp?.specType).toBe("draft-mtp");
-		const bundle = makeTempBundle({ hasMmproj: true, hasMtp: true, tier });
-		const installed = installedModel({
-			id: `eliza-1-${tier}`,
-			bundleRoot: bundle.bundleRoot,
-			path: bundle.textPath,
+	for (const tier of ["2b", "4b"] as const) {
+		it(`resolves the bundled gemma4-assistant drafter for the hosted MTP tier (${tier})`, async () => {
+			// bundles/<tier>/mtp/drafter-<tier>.gguf is hosted (gemma4-assistant,
+			// converted from google/gemma-4-E2B-it-assistant /
+			// google/gemma-4-E4B-it-assistant) and the catalog advertises
+			// runtime.mtp for the tier, so the resolver must wire the on-disk
+			// drafter with the catalog's draft window.
+			const catalog = findCatalogModel(`eliza-1-${tier}`);
+			expect(catalog?.runtime?.mtp?.specType).toBe("draft-mtp");
+			const bundle = makeTempBundle({ hasMmproj: true, hasMtp: true, tier });
+			const installed = installedModel({
+				id: `eliza-1-${tier}`,
+				bundleRoot: bundle.bundleRoot,
+				path: bundle.textPath,
+			});
+			const resolved = await resolveLocalInferenceLoadArgs(installed);
+			expect(resolved.modelPath).toBe(bundle.textPath);
+			expect(resolved.draftModelPath).toBe(
+				pathJoin(bundle.bundleRoot, "mtp", `drafter-${tier}.gguf`),
+			);
+			expect(resolved.draftMin).toBe(catalog?.runtime?.mtp?.draftMin);
+			expect(resolved.draftMax).toBe(catalog?.runtime?.mtp?.draftMax);
 		});
-		const resolved = await resolveLocalInferenceLoadArgs(installed);
-		expect(resolved.modelPath).toBe(bundle.textPath);
-		expect(resolved.draftModelPath).toBe(
-			pathJoin(bundle.bundleRoot, "mtp", `drafter-${tier}.gguf`),
-		);
-		expect(resolved.draftMin).toBe(catalog?.runtime?.mtp?.draftMin);
-		expect(resolved.draftMax).toBe(catalog?.runtime?.mtp?.draftMax);
-	});
+	}
 
 	it("ignores an on-disk MTP drafter for tiers without a hosted Gemma drafter", async () => {
-		const tier = "4b";
-		// The active HF tree does not host `mtp/drafter-4b.gguf`, so the catalog
+		const tier = "9b";
+		// The active HF tree does not host `mtp/drafter-9b.gguf`, so the catalog
 		// must not enable speculative decoding just because a local file with
 		// that shape exists.
 		expect(findCatalogModel(`eliza-1-${tier}`)?.runtime?.mtp).toBeUndefined();

--- a/plugins/plugin-local-inference/src/services/catalog.test.ts
+++ b/plugins/plugin-local-inference/src/services/catalog.test.ts
@@ -130,9 +130,11 @@ describe("local inference catalog", () => {
 			ELIZA_1_HOSTED_MTP_TIER_IDS,
 		);
 		expect(ELIZA_1_MTP_TIER_IDS).toEqual(ELIZA_1_TIER_IDS);
-		// 2b hosts the gemma4-assistant drafter at bundles/2b/mtp/drafter-2b.gguf
-		// (converted from google/gemma-4-E2B-it-assistant, 2026-07-02).
-		expect(ELIZA_1_HOSTED_MTP_TIER_IDS).toEqual(["eliza-1-2b"]);
+		// 2b/4b host the gemma4-assistant drafters at
+		// bundles/<tier>/mtp/drafter-<tier>.gguf (converted from
+		// google/gemma-4-E2B-it-assistant / google/gemma-4-E4B-it-assistant,
+		// 2026-07-02).
+		expect(ELIZA_1_HOSTED_MTP_TIER_IDS).toEqual(["eliza-1-2b", "eliza-1-4b"]);
 		for (const id of ELIZA_1_MTP_TIER_IDS) {
 			const model = findCatalogModel(id);
 			expect(model?.companionModelIds, `${id} companions`).toBeUndefined();

--- a/plugins/plugin-local-inference/src/services/fused-eliza1-no-regression.test.ts
+++ b/plugins/plugin-local-inference/src/services/fused-eliza1-no-regression.test.ts
@@ -51,7 +51,9 @@ describe("fused eliza-1 no-regression (C4)", () => {
 	it("the catalog tier under test really is a fused-eliza1 tier", () => {
 		expect(FUSED_TIER).toBeTruthy();
 		expect(FUSED_TIER.runtimeClass).toBe("fused-eliza1");
-		expect(FUSED_TIER.runtime?.mtp).toBeUndefined();
+		// 4b hosts the gemma4-assistant separate drafter (2026-07-02).
+		expect(FUSED_TIER.runtime?.mtp?.specType).toBe("draft-mtp");
+		expect(FUSED_TIER.runtime?.mtp?.drafterFile).toBe("mtp/drafter-4b.gguf");
 	});
 
 	it("decideBackend routes a fused Eliza-1 tier to the fused llama-cpp runtime", () => {
@@ -109,7 +111,7 @@ describe("fused eliza-1 no-regression (C4)", () => {
 		// kernel settings.
 		const forwarded = ffi.loaded[0];
 		expect(forwarded.catalog).toBe(FUSED_TIER);
-		expect(forwarded.catalog?.runtime?.mtp).toBeUndefined();
+		expect(forwarded.catalog?.runtime?.mtp?.specType).toBe("draft-mtp");
 		expect(forwarded.overrides?.bundleRoot).toBe(bundleRoot);
 		expect(forwarded.overrides?.draftModelPath).toBe(
 			`${bundleRoot}/text/eliza-1-4b-mtp.gguf`,


### PR DESCRIPTION
## What

Wires the **eliza-1-4b** tier into the hosted Gemma-4 MTP separate-drafter path (issue #11390; the 2b tier shipped in #11517).

The drafter is now **published**: HF `elizaos/eliza-1` `bundles/4b/mtp/drafter-4b.gguf` ([HF commit `aecac19b97ec`](https://huggingface.co/elizaos/eliza-1/commit/aecac19b97ecbe5f8bbd05401be586e8b28cad71)) — arch `gemma4-assistant`, f16, 49 tensors, `embedding_length_out=2560` (== the eliza-1-4b backbone `n_embd`), `nextn_predict_layers=1`, sha256 `e4585e558a74e4548d0c712ce1188919c6f42beadb893c7397a34db883988db3`. Converted from `google/gemma-4-E4B-it-assistant` with the fork converter at the develop-pinned submodule commit `58c0391eb`. The bundle manifest (`files.mtp`, `lineage.drafter`, `evals.mtp`) and `checksums/SHA256SUMS` were updated additively and validated with the repo's `parseManifestOrThrow` + `validateManifest`.

Repo changes:
- `packages/shared/src/local-inference/catalog.ts`: add `"eliza-1-4b"` to `ELIZA_1_HOSTED_MTP_TIER_IDS` (components.mtp + runtime.mtp draft window derive from the list).
- Shared + plugin catalog tests updated for the two hosted tiers.
- `fused-eliza1-no-regression.test.ts`: 4b now legitimately advertises `runtime.mtp` (draft-mtp, `mtp/drafter-4b.gguf`).
- `mmproj-routing.test.ts`: drafter resolution covered for both hosted tiers (2b, 4b); the "no hosted drafter" case moves to 9b.
- Drive-by: `__tests__/imagegen-backend-selector.test.ts` linux-nvidia expectation aligned with the shipped #10727 policy (pre-existing failure on develop; the `src/services` sibling suite already asserts the new policy).

## Evidence (all runs executed and reviewed by hand on this M4 Max)

`.github/issue-evidence/gemma4-assistant-mtp/4b/`:

- **Fused product path** (`libelizainference.dylib` via the plugin's own `loadElizaInferenceFfi`, greedy, draft window 1 — the shipped catalog window): capability probes `llmMtpSupported=true`, drafter loads clean ("adding speculative implementation 'draft-mtp'"), **acceptance 29/31 = 0.935**, counting prompt 30.6 → 56.0 tok/s (**1.87× wall**), weekdays byte-identical output. `fused-ffi-bench.txt`, full log `fused-ffi-run.txt`.
- **llama-server lane** (same 3-prompt set/methodology as the published 2b numbers): **acceptance 30/38 = 0.79, mean tok/s speedup ~1.33×** (54.6→87.0 on counting), greedy outputs byte-identical on all three prompts. Extended 8-prompt set (structured + free-form prose): 101/172 = 0.587 acceptance, 1.17× aggregate decode speedup. `draft-acceptance-bench.txt`.
- Target verified before benching: downloaded `bundles/4b/text/eliza-1-4b-128k.gguf`, sha256 matches manifest (`fb8f0c03…`), GGUF header `general.architecture=gemma4`, `embedding_length=2560`, Q8_0.
- Drafter GGUF metadata dump: `drafter-gguf-metadata.txt` (arch/dims/nextn as above). Converter log: `convert-hf-to-gguf.log`.

Known artifact (documented in the bench, same as the 2b capture): a deterministic one-token near-tie argmax flip on the counting prompt in the fused lane (batched-verify numerics); the server lane on the same weights emits the token correctly with 20/20 acceptance, confirming the drafter tensor/KV mapping is sound.

## Verification

- `bun run --cwd packages/shared test` — 83 files / 1049 tests green.
- `bun run --cwd plugins/plugin-local-inference test` — full suite green (2293 tests).
- `bun run verify` — green locally.

Evidence rows N/A: no UI-facing change (catalog constant + tests); trajectories N/A — no agent/prompt behavior change, the measured model runs above are the domain artifact.

Closes #11390. 9b/27b drafters remain tracked by #11389 (training-cluster-gated); Linux/Android acceptance capture folds into the device-matrix lane (#11734 / #11339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
