### PR TITLE
fix(core): RFC 5987 filename ext-value, path-extension mis-split, direct-message prompt missing 'topics'

### DIFF
--- a/packages/core/src/actions/__tests__/to-tool.test.ts
+++ b/packages/core/src/actions/__tests__/to-tool.test.ts
@@ -9,6 +9,8 @@ import {
 	buildPlannerToolsFromActions,
 	buildPlannerToolsFromTieredActions,
 	CORE_PLANNER_TERMINALS,
+	createHandleResponseTool,
+	HANDLE_RESPONSE_SCHEMA,
 } from "../to-tool.ts";
 
 function makeAction(overrides: Partial<Action>): Action {
@@ -405,5 +407,27 @@ describe("buildPlannerToolsFromTieredActions", () => {
 			"IGNORE",
 			"STOP",
 		]);
+	});
+});
+
+describe("createHandleResponseTool descriptions", () => {
+	it("mentions every schema-required field in both channel variants", () => {
+		const required = HANDLE_RESPONSE_SCHEMA.required ?? [];
+		expect(required).toContain("topics");
+
+		const standard = createHandleResponseTool().description;
+		const direct = createHandleResponseTool({
+			directMessage: true,
+		}).description;
+
+		for (const field of required) {
+			// The strict tool schema requires each of these fields, so the
+			// instruction list in the description must tell the model to fill
+			// them — the direct-message variant used to omit `topics`.
+			expect(standard, `standard description missing '${field}'`).toContain(
+				field,
+			);
+			expect(direct, `direct description missing '${field}'`).toContain(field);
+		}
 	});
 });

--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -144,7 +144,7 @@ const HANDLE_RESPONSE_DESCRIPTION =
 	"Stage 1: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, topics, addressedTo, emotion. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";
 
 const HANDLE_RESPONSE_DIRECT_DESCRIPTION =
-	"Stage 1 direct-message: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, addressedTo, emotion. Usually RESPOND unless explicit stop. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";
+	"Stage 1 direct-message: handle turn. Call exactly once before action tools. Fill registered fields: shouldRespond, contexts, intents, replyText, candidateActionNames, facts, relationships, topics, addressedTo, emotion. Usually RESPOND unless explicit stop. Trivial reply: contexts=['simple'], replyText whole answer. Tool/planning path: choose non-simple contexts or candidateActionNames and use brief replyText ack.";
 
 /**
  * Build the Stage 1 tool definition. Pass `directMessage: true` for DM /

--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -19,4 +19,42 @@ describe("fetchRemoteMedia", () => {
 		expect(sawAbortSignal).toBe(true);
 		expect(result.contentType).toBe("image/png");
 	});
+
+	function fetchWithContentDisposition(contentDisposition: string) {
+		return fetchRemoteMedia({
+			url: "https://example.com/files/42",
+			lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+			fetchImpl: async () =>
+				new Response(Buffer.from("hello"), {
+					headers: {
+						"content-type": "text/plain",
+						"content-disposition": contentDisposition,
+					},
+				}),
+		});
+	}
+
+	it("decodes RFC 5987 filename* with an empty language tag", async () => {
+		const result = await fetchWithContentDisposition(
+			"attachment; filename*=UTF-8''na%C3%AFve.txt",
+		);
+		expect(result.fileName).toBe("naïve.txt");
+	});
+
+	it("decodes RFC 5987 filename* with a language tag", async () => {
+		// Previously the charset/language prefix leaked into the filename
+		// ("UTF-8'en'naïve file.txt") because only the empty-language
+		// `charset''value` form was stripped.
+		const result = await fetchWithContentDisposition(
+			"attachment; filename*=UTF-8'en'na%C3%AFve%20file.txt",
+		);
+		expect(result.fileName).toBe("naïve file.txt");
+	});
+
+	it("falls back to plain filename= parsing", async () => {
+		const result = await fetchWithContentDisposition(
+			'attachment; filename="report.txt"',
+		);
+		expect(result.fileName).toBe("report.txt");
+	});
 });

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -73,7 +73,14 @@ function parseContentDispositionFileName(
 	const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
 	if (starMatch?.[1]) {
 		const cleaned = stripQuotes(starMatch[1].trim());
-		const encoded = cleaned.split("''").slice(1).join("''") || cleaned;
+		// RFC 5987 ext-value is `charset'language'value` where the language
+		// tag is optional but both single quotes are mandatory, e.g.
+		// `UTF-8''na%C3%AFve.txt` or `UTF-8'en'na%C3%AFve.txt`. Strip the
+		// charset/language prefix whether or not a language tag is present;
+		// splitting on `''` only handled the empty-language form and leaked
+		// `UTF-8'en'` into the filename otherwise.
+		const extValueMatch = /^([^']*)'([^']*)'([\s\S]*)$/.exec(cleaned);
+		const encoded = extValueMatch ? extValueMatch[3] : cleaned;
 		try {
 			return getBasename(decodeURIComponent(encoded));
 		} catch {

--- a/packages/core/src/media/mime.test.ts
+++ b/packages/core/src/media/mime.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { detectMime, getFileExtension } from "./mime.ts";
+
+describe("getFileExtension", () => {
+	it("extracts the extension from plain paths and URLs", () => {
+		expect(getFileExtension("photo.JPG")).toBe(".jpg");
+		expect(getFileExtension("/tmp/archive.tar.gz")).toBe(".gz");
+		expect(getFileExtension("https://example.com/song.mp3")).toBe(".mp3");
+		expect(getFileExtension("https://example.com/a/b/photo.PNG?raw=1")).toBe(
+			".png",
+		);
+	});
+
+	it("returns undefined for extensionless URL pathnames", () => {
+		// Previously returned "./download" (the whole pathname).
+		expect(getFileExtension("https://example.com/download")).toBeUndefined();
+		expect(getFileExtension("https://example.com/")).toBeUndefined();
+	});
+
+	it("ignores dots in directory names", () => {
+		// Previously returned ".2/notes" / ".name/readme".
+		expect(getFileExtension("https://example.com/v1.2/notes")).toBeUndefined();
+		expect(getFileExtension("/home/user.name/README")).toBeUndefined();
+		expect(getFileExtension("/releases/v1.2/notes.txt")).toBe(".txt");
+	});
+
+	it("returns undefined for a trailing dot", () => {
+		// Previously returned "." for "archive.".
+		expect(getFileExtension("archive.")).toBeUndefined();
+	});
+
+	it("keeps extension-based mime detection working through detectMime", async () => {
+		await expect(
+			detectMime({ filePath: "https://example.com/notes.csv" }),
+		).resolves.toBe("text/csv");
+		// A dotted directory must not smuggle a bogus extension into detection.
+		await expect(
+			detectMime({
+				filePath: "https://example.com/v1.2/notes",
+				headerMime: "text/markdown",
+			}),
+		).resolves.toBe("text/markdown");
+	});
+});

--- a/packages/core/src/media/mime.ts
+++ b/packages/core/src/media/mime.ts
@@ -128,18 +128,22 @@ async function sniffMime(
  */
 export function getFileExtension(filePath?: string | null): string | undefined {
 	if (!filePath) return undefined;
+	let candidate = filePath;
 	try {
 		if (/^https?:\/\//i.test(filePath)) {
-			const url = new URL(filePath);
-			const ext = url.pathname.split(".").pop()?.toLowerCase();
-			return ext ? `.${ext}` : undefined;
+			candidate = new URL(filePath).pathname;
 		}
 	} catch {
 		// fall back to plain path parsing
 	}
-	const parts = filePath.split(".");
-	if (parts.length < 2) return undefined;
-	return `.${parts.pop()?.toLowerCase()}`;
+	// Only the last path segment can carry an extension; splitting the whole
+	// path on "." would treat a dot in a directory name (or a dotless URL
+	// pathname) as an extension boundary and return garbage like ".2/notes".
+	const base = candidate.split(/[\\/]/).pop() ?? "";
+	const dotIndex = base.lastIndexOf(".");
+	if (dotIndex === -1) return undefined;
+	const ext = base.slice(dotIndex + 1).toLowerCase();
+	return ext ? `.${ext}` : undefined;
 }
 
 /**


### PR DESCRIPTION
Three provable `@elizaos/core` bugs (actions + media), each with a mutation-checked unit test.

| # | bug | fix |
|---|---|---|
| 1 | **`media/fetch.ts`** — RFC 5987 `Content-Disposition` `filename*` with a language tag (`UTF-8'en'na%C3%AFve.txt`) leaked `UTF-8'en'` **into the filename** — it split on `''`, which only handles the empty-language form | parse the `charset'lang'value` structure with a regex, take the value group (both quotes mandatory, language optional per RFC 5987) |
| 2 | **`media/mime.ts`** — extension extraction split the **whole path** on `.`, so a dot in a directory name (or a dotless URL pathname) returned garbage like `.2/notes` | take the last path segment (`split(/[\\/]/).pop()`) first, then its last dot |
| 3 | **`actions/to-tool.ts`** — the direct-message stage-1 prompt omitted the schema-**required** field `topics` (the standard variant lists it), so the model was never instructed to fill a field the response schema requires | add `topics`; test derives every schema-required field and asserts BOTH channel variants mention each |

### Evidence
- **Mutation-checked** (each fix reverted in isolation reds only its own test): fix 1 → 1/4 fail; fix 2 → 3/5 fail; fix 3 → 1/14 fail. All restored → **23/23 green** across the 3 test files.
- Biome clean; scoped strictly to `core/src/actions` + `core/src/media` + their tests.

### Provenance
Authored end-to-end by a Fable-5 agent; it hit its session cap **after writing the fixes + tests but before committing**, so the main loop preserved the uncommitted work, independently ran the tests (23/23), mutation-checked all three, and committed/pushed. No logic authored by the main loop.

### N/A rows
- Live-LLM trajectory: **partial N/A** — fixes 1 & 2 are pure string/path parsing (asserted against the real functions with the exact adversarial inputs). Fix 3 changes a prompt to include a schema-required field; its correctness is a structural schema↔prompt consistency check (asserted), not a model-behavior change.
- Screenshots: N/A (no UI surface).

— `[phone-ui]`