### PR TITLE
fix(cloud): add Atlas video provider

### DIFF
--- a/.github/issue-evidence/10689-atlas-video-provider.md
+++ b/.github/issue-evidence/10689-atlas-video-provider.md
@@ -20,11 +20,40 @@ bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generati
 ```
 
 Expected coverage:
-- Atlas request body uses `generateVideo` payload fields and image/reference aliases.
+- Atlas request body uses documented `generateVideo` payload fields, including
+  image/reference aliases and `generate_audio` for route-level `audio`.
 - Atlas inline output normalization returns a usable `video/*` object.
 - Missing `ATLASCLOUD_API_KEY` fails before upstream dispatch.
 - Every supported Atlas video model has an Atlas `video:generation` pricing row.
 - The checked-in media model roster indexes the wired Atlas video model IDs.
+
+Additional review validation, 2026-07-03:
+
+```bash
+bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts \
+  packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts \
+  packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts \
+  packages/cloud/shared/src/lib/services/media-model-roster.test.ts
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api typecheck
+bunx @biomejs/biome check packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts \
+  packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts \
+  packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts \
+  packages/cloud/shared/src/lib/providers/video/registry.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/providers/atlascloud.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts \
+  packages/cloud/shared/src/lib/services/media-model-roster.ts \
+  packages/cloud/api/v1/generate-video/route.ts
+git diff --check origin/develop..HEAD
+```
+
+Result: deterministic tests passed (`12 pass`, `1 skip` for the credential-gated
+live Atlas lane), both package typechecks passed, targeted Biome passed, and
+diff whitespace check passed.
 
 ## Live evidence
 

--- a/.github/issue-evidence/10689-atlas-video-provider.md
+++ b/.github/issue-evidence/10689-atlas-video-provider.md
@@ -1,0 +1,43 @@
+# #10689 Atlas Cloud video provider
+
+## Scope
+
+Agent-actionable slice:
+- Add Atlas Cloud as a `/api/v1/generate-video` provider through the existing video registry.
+- Add supported Atlas video model definitions and `video:generation` pricing rows.
+- Keep the FAL video provider path unchanged.
+- Add deterministic provider/pricing tests plus a credential-gated live lane.
+
+## Deterministic evidence
+
+Run from repo root:
+
+```bash
+bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts \
+  packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts \
+  packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts \
+  packages/cloud/shared/src/lib/services/media-model-roster.test.ts
+```
+
+Expected coverage:
+- Atlas request body uses `generateVideo` payload fields and image/reference aliases.
+- Atlas inline output normalization returns a usable `video/*` object.
+- Missing `ATLASCLOUD_API_KEY` fails before upstream dispatch.
+- Every supported Atlas video model has an Atlas `video:generation` pricing row.
+- The checked-in media model roster indexes the wired Atlas video model IDs.
+
+## Live evidence
+
+N/A from this workspace: no Atlas Cloud production API key or spend budget was available.
+
+Human/operator command when credentials are available:
+
+```bash
+TEST_LANE=post-merge ATLASCLOUD_API_KEY=<redacted> \
+  bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts
+```
+
+Required manual review after the live lane:
+- Open the returned video URL and confirm the media plays.
+- Attach the generated video artifact or URL, provider request id, route logs, billing row, and generated `generations` row.
+- Add the model matrix required by #10689 for each Atlas model enabled in production.

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -77,10 +77,16 @@ app.post("/", async (c) => {
     const apiKeys = {
       FAL_KEY: envString(c.env.FAL_KEY),
       FAL_API_KEY: envString(c.env.FAL_API_KEY),
+      ATLASCLOUD_API_KEY: envString(c.env.ATLASCLOUD_API_KEY),
+      ATLASCLOUD_BASE_URL: envString(c.env.ATLASCLOUD_BASE_URL),
     };
     if (provider.isConfigured && !provider.isConfigured(apiKeys)) {
       const providerName =
-        definition.provider === "fal" ? "Fal" : definition.provider;
+        definition.billingSource === "atlascloud"
+          ? "Atlas Cloud"
+          : definition.provider === "fal"
+            ? "Fal"
+            : definition.provider;
       return jsonError(
         c,
         503,

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { generateAtlasCloudVideo } from "./atlascloud-video-generation";
+
+const liveEnabled =
+  process.env.TEST_LANE === "post-merge" || process.env.ATLASCLOUD_VIDEO_LIVE_TEST === "1";
+
+describe("Atlas Cloud video provider live", () => {
+  test.skipIf(!liveEnabled)("generates a real Atlas-hosted video", async () => {
+    const apiKey = process.env.ATLASCLOUD_API_KEY;
+    if (!apiKey) {
+      throw new Error("ATLASCLOUD_API_KEY is required when Atlas video live tests are enabled");
+    }
+
+    const result = await generateAtlasCloudVideo({
+      model: process.env.ATLASCLOUD_VIDEO_MODEL ?? "vidu/q3-turbo/text-to-video",
+      prompt: "A five second product-style shot of a matte orange cube rotating on a white table",
+      durationSeconds: 5,
+      resolution: "720p",
+      audio: false,
+      apiKeys: {
+        ATLASCLOUD_API_KEY: apiKey,
+        ATLASCLOUD_BASE_URL: process.env.ATLASCLOUD_BASE_URL,
+      },
+    });
+
+    expect(result.video.url).toMatch(/^https?:\/\//);
+    expect(result.video.content_type ?? "video/mp4").toMatch(/^video\//);
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  atlasCloudVideoProvider,
+  buildAtlasVideoInput,
+  firstAtlasVideoOutput,
+  generateAtlasCloudVideo,
+} from "./atlascloud-video-generation";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Atlas Cloud video provider", () => {
+  test("maps Cloud video request fields to Atlas input aliases", () => {
+    expect(
+      buildAtlasVideoInput({
+        model: "vidu/image-to-video-2.0",
+        prompt: "animate the product photo",
+        referenceUrl: "https://example.com/source.png",
+        durationSeconds: 4,
+        resolution: "720p",
+        audio: false,
+        apiKeys: { ATLASCLOUD_API_KEY: "atlas-key" },
+      }),
+    ).toEqual({
+      model: "vidu/image-to-video-2.0",
+      prompt: "animate the product photo",
+      image_url: "https://example.com/source.png",
+      image: "https://example.com/source.png",
+      duration: 4,
+      resolution: "720p",
+      audio: false,
+    });
+  });
+
+  test("normalizes string and object Atlas outputs", () => {
+    expect(firstAtlasVideoOutput(["https://cdn.atlas/video.mp4"])).toEqual({
+      url: "https://cdn.atlas/video.mp4",
+      content_type: "video/mp4",
+    });
+    expect(
+      firstAtlasVideoOutput([
+        {
+          url: "https://cdn.atlas/video.webm",
+          width: 1280,
+          height: 720,
+          filename: "video.webm",
+          size: 1234,
+          mime_type: "video/webm",
+        },
+      ]),
+    ).toEqual({
+      url: "https://cdn.atlas/video.webm",
+      width: 1280,
+      height: 720,
+      file_name: "video.webm",
+      file_size: 1234,
+      content_type: "video/webm",
+    });
+  });
+
+  test("generates through the registered Atlas provider with inline output", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(
+        JSON.stringify({
+          data: {
+            id: "atlas-prediction",
+            status: "completed",
+            outputs: ["https://cdn.atlas/video.mp4"],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const result = await generateAtlasCloudVideo({
+      model: "vidu/q3-turbo/text-to-video",
+      prompt: "a lighthouse",
+      durationSeconds: 5,
+      apiKeys: {
+        ATLASCLOUD_API_KEY: "atlas-key",
+        ATLASCLOUD_BASE_URL: "https://atlas.test/",
+      },
+    });
+
+    expect(atlasCloudVideoProvider.billingSource).toBe("atlascloud");
+    expect(atlasCloudVideoProvider.isConfigured?.({ ATLASCLOUD_API_KEY: " atlas-key " })).toBe(
+      true,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://atlas.test/api/v1/model/generateVideo");
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(calls[0]?.init?.headers).toEqual({
+      authorization: "Bearer atlas-key",
+      "content-type": "application/json",
+    });
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+      model: "vidu/q3-turbo/text-to-video",
+      prompt: "a lighthouse",
+      duration: 5,
+    });
+    expect(result).toEqual({
+      requestId: "atlas-prediction",
+      video: { url: "https://cdn.atlas/video.mp4", content_type: "video/mp4" },
+      timings: null,
+    });
+  });
+
+  test("rejects missing Atlas credentials before calling upstream", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as typeof fetch;
+
+    await expect(
+      generateAtlasCloudVideo({
+        model: "vidu/q3-turbo/text-to-video",
+        prompt: "a lighthouse",
+        apiKeys: {},
+      }),
+    ).rejects.toThrow("AI services are not configured on this deployment");
+    expect(atlasCloudVideoProvider.isConfigured?.({})).toBe(false);
+    expect(called).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
@@ -31,7 +31,7 @@ describe("Atlas Cloud video provider", () => {
       image: "https://example.com/source.png",
       duration: 4,
       resolution: "720p",
-      audio: false,
+      generate_audio: false,
     });
   });
 

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
@@ -1,0 +1,174 @@
+import { getAiProviderConfigurationError } from "../language-model";
+import type {
+  GeneratedVideo,
+  GeneratedVideoObject,
+  VideoGenerationRequest,
+  VideoProvider,
+} from "./types";
+
+const ATLAS_POLL_INTERVAL_MS = 2_000;
+const ATLAS_POLL_TIMEOUT_MS = 180_000;
+
+function atlasBaseUrl(request: VideoGenerationRequest): string {
+  return (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai").replace(/\/+$/, "");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+interface AtlasPrediction {
+  id?: string;
+  status?: string;
+  outputs?: unknown;
+  error?: string;
+  urls?: { get?: string };
+}
+
+function parsePrediction(payload: Record<string, unknown>): AtlasPrediction {
+  const data = isRecord(payload.data) ? payload.data : payload;
+  return {
+    id: stringValue(data.id),
+    status: stringValue(data.status),
+    outputs: data.outputs,
+    error: stringValue(data.error),
+    urls: isRecord(data.urls) ? { get: stringValue(data.urls.get) } : undefined,
+  };
+}
+
+function normalizeVideoObject(value: unknown): GeneratedVideoObject | null {
+  if (typeof value === "string" && value.trim()) {
+    return { url: value.trim(), content_type: "video/mp4" };
+  }
+  if (!isRecord(value)) return null;
+  const url = stringValue(value.url);
+  if (!url) return null;
+  return {
+    url,
+    width: numberValue(value.width),
+    height: numberValue(value.height),
+    file_name: stringValue(value.file_name) ?? stringValue(value.filename),
+    file_size: numberValue(value.file_size) ?? numberValue(value.size),
+    content_type: stringValue(value.content_type) ?? stringValue(value.mime_type) ?? "video/mp4",
+  };
+}
+
+export function firstAtlasVideoOutput(outputs: unknown): GeneratedVideoObject | null {
+  if (!Array.isArray(outputs)) return null;
+  for (const output of outputs) {
+    const video = normalizeVideoObject(output);
+    if (video) return video;
+  }
+  return null;
+}
+
+export function buildAtlasVideoInput(request: VideoGenerationRequest): Record<string, unknown> {
+  const input: Record<string, unknown> = {
+    model: request.model,
+    prompt: request.prompt,
+  };
+  if (request.referenceUrl) {
+    input.image_url = request.referenceUrl;
+    input.image = request.referenceUrl;
+  }
+  if (request.durationSeconds) {
+    input.duration = request.durationSeconds;
+  }
+  if (request.resolution) {
+    input.resolution = request.resolution;
+  }
+  if (request.audio !== undefined) {
+    input.audio = request.audio;
+  }
+  return input;
+}
+
+const TERMINAL_OK = new Set(["completed", "succeeded", "success"]);
+const TERMINAL_FAIL = new Set(["failed", "error", "canceled", "cancelled"]);
+
+export async function generateAtlasCloudVideo(
+  request: VideoGenerationRequest,
+): Promise<GeneratedVideo> {
+  const apiKey = request.apiKeys.ATLASCLOUD_API_KEY;
+  if (!apiKey) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  const baseUrl = atlasBaseUrl(request);
+  const authHeader = { authorization: `Bearer ${apiKey}` };
+  const submitResponse = await fetch(`${baseUrl}/api/v1/model/generateVideo`, {
+    method: "POST",
+    headers: { ...authHeader, "content-type": "application/json" },
+    body: JSON.stringify(buildAtlasVideoInput(request)),
+  });
+
+  const submitPayload = (await submitResponse.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!submitResponse.ok) {
+    const message =
+      stringValue(submitPayload.msg) ??
+      stringValue(submitPayload.message) ??
+      `Atlas video generation failed: ${submitResponse.status}`;
+    throw new Error(message);
+  }
+
+  const submitted = parsePrediction(submitPayload);
+  const inlineVideo = firstAtlasVideoOutput(submitted.outputs);
+  if (inlineVideo) {
+    return { requestId: submitted.id, video: inlineVideo, timings: null };
+  }
+
+  const predictionId = submitted.id;
+  if (!predictionId) {
+    throw new Error("Atlas video provider returned no prediction id");
+  }
+  const pollUrl = submitted.urls?.get ?? `${baseUrl}/api/v1/model/prediction/${predictionId}`;
+  const deadline = Date.now() + ATLAS_POLL_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
+
+    const pollResponse = await fetch(pollUrl, { headers: authHeader });
+    const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!pollResponse.ok) {
+      throw new Error(`Atlas prediction poll failed: ${pollResponse.status}`);
+    }
+
+    const prediction = parsePrediction(pollPayload);
+    const status = (prediction.status ?? "").toLowerCase();
+    if (TERMINAL_FAIL.has(status)) {
+      throw new Error(
+        `Atlas video generation failed${prediction.error ? `: ${prediction.error}` : ""}`,
+      );
+    }
+    if (TERMINAL_OK.has(status)) {
+      const video = firstAtlasVideoOutput(prediction.outputs);
+      if (!video) {
+        throw new Error("Atlas video provider completed without an output video");
+      }
+      return { requestId: prediction.id ?? predictionId, video, timings: null };
+    }
+  }
+
+  throw new Error("Atlas video generation timed out");
+}
+
+export const atlasCloudVideoProvider: VideoProvider = {
+  billingSource: "atlascloud",
+  isConfigured(apiKeys) {
+    return (
+      typeof apiKeys.ATLASCLOUD_API_KEY === "string" && apiKeys.ATLASCLOUD_API_KEY.trim() !== ""
+    );
+  },
+  generate: generateAtlasCloudVideo,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
@@ -86,7 +86,7 @@ export function buildAtlasVideoInput(request: VideoGenerationRequest): Record<st
     input.resolution = request.resolution;
   }
   if (request.audio !== undefined) {
-    input.audio = request.audio;
+    input.generate_audio = request.audio;
   }
   return input;
 }

--- a/packages/cloud/shared/src/lib/providers/video/registry.ts
+++ b/packages/cloud/shared/src/lib/providers/video/registry.ts
@@ -1,4 +1,5 @@
 import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import { atlasCloudVideoProvider } from "./atlascloud-video-generation";
 import { falVideoProvider } from "./fal-video-generation";
 import type { VideoProvider } from "./types";
 
@@ -17,3 +18,4 @@ export function getVideoProvider(billingSource: PricingBillingSource): VideoProv
 }
 
 registerVideoProvider(falVideoProvider);
+registerVideoProvider(atlasCloudVideoProvider);

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -130,8 +130,8 @@ export interface SupportedImageModelDefinition {
 
 export interface SupportedVideoModelDefinition {
   modelId: string;
-  provider: "fal";
-  billingSource: "fal";
+  provider: string;
+  billingSource: PricingBillingSource;
   label: string;
   pageUrl: string;
   pricingParser:
@@ -143,7 +143,8 @@ export interface SupportedVideoModelDefinition {
     | "hailuo_pro"
     | "wan"
     | "pixverse"
-    | "seedance";
+    | "seedance"
+    | "atlascloud_snapshot";
   defaultParameters: {
     durationSeconds: number;
     resolution?: string;
@@ -308,6 +309,32 @@ export const SUPPORTED_IMAGE_MODELS: SupportedImageModelDefinition[] = [
 export const DEFAULT_IMAGE_MODEL_ID = "google/nano-banana-2/text-to-image";
 
 export const SUPPORTED_VIDEO_MODELS: SupportedVideoModelDefinition[] = [
+  {
+    modelId: "vidu/q3-turbo/text-to-video",
+    provider: "vidu",
+    billingSource: "atlascloud",
+    label: "Vidu Q3 Turbo Text-to-Video",
+    pageUrl: "https://www.atlascloud.ai/models/vidu/q3-turbo/text-to-video",
+    pricingParser: "atlascloud_snapshot",
+    defaultParameters: {
+      durationSeconds: 5,
+      resolution: "720p",
+      audio: false,
+    },
+  },
+  {
+    modelId: "vidu/image-to-video-2.0",
+    provider: "vidu",
+    billingSource: "atlascloud",
+    label: "Vidu Image-to-Video 2.0",
+    pageUrl: "https://www.atlascloud.ai/models/vidu/image-to-video-2.0",
+    pricingParser: "atlascloud_snapshot",
+    defaultParameters: {
+      durationSeconds: 4,
+      resolution: "720p",
+      audio: false,
+    },
+  },
   {
     modelId: "fal-ai/veo3",
     provider: "fal",

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -461,13 +461,15 @@ export async function calculateImageGenerationCostFromCatalog(params: {
 
 export async function calculateVideoGenerationCostFromCatalog(params: {
   model: string;
-  billingSource?: "fal";
+  billingSource?: PricingBillingSource;
   durationSeconds?: number;
   dimensions?: Record<string, unknown>;
 }): Promise<FlatOperationCost> {
+  const definition = getSupportedVideoModelDefinition(params.model);
+  const provider = definition?.provider ?? inferProviderFromCanonicalModel(params.model);
   const entry = await resolvePreparedPricingEntry({
-    billingSource: params.billingSource ?? "fal",
-    provider: "fal",
+    billingSource: params.billingSource ?? definition?.billingSource,
+    provider,
     model: params.model,
     productFamily: "video",
     chargeType: "generation",

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/atlascloud.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/atlascloud.ts
@@ -1,6 +1,8 @@
 import {
   SUPPORTED_IMAGE_MODELS,
+  SUPPORTED_VIDEO_MODELS,
   type SupportedImageModelDefinition,
+  type SupportedVideoModelDefinition,
 } from "../../ai-pricing-definitions";
 import { getCachedExternalEntries } from "../cache";
 import { EXTERNAL_CACHE_TTL_MS, type PreparedPricingEntry } from "../types";
@@ -20,6 +22,14 @@ const ATLAS_IMAGE_PRICE_BY_MODEL: Record<string, number> = {
   "google/nano-banana-2/text-to-image": 0.03,
   // Qwen Image 2.0 (Alibaba).
   "qwen/qwen-image-2.0/text-to-image": 0.02,
+};
+
+const ATLAS_VIDEO_PRICE_BY_MODEL: Record<string, number> = {
+  // Vidu Q3 Turbo Text-to-Video Atlas page lists $0.04/sec, currently discounted to $0.034/sec.
+  // Bill the undiscounted rate to avoid undercharging when a promotion ends.
+  "vidu/q3-turbo/text-to-video": 0.04,
+  // Vidu Image-to-Video 2.0 Atlas page lists $0.075/sec.
+  "vidu/image-to-video-2.0": 0.075,
 };
 
 function buildAtlasImageEntry(
@@ -57,8 +67,43 @@ function buildAtlasImageSnapshotEntries(): PreparedPricingEntry[] {
   );
 }
 
+function buildAtlasVideoEntry(
+  model: SupportedVideoModelDefinition,
+  unitPrice: number,
+): PreparedPricingEntry {
+  const fetchedAt = new Date();
+  return {
+    billingSource: "atlascloud",
+    provider: model.provider,
+    model: model.modelId,
+    productFamily: "video",
+    chargeType: "generation",
+    unit: "second",
+    unitPrice,
+    dimensions: model.defaultParameters,
+    sourceKind: "atlascloud_catalog",
+    sourceUrl: model.pageUrl,
+    fetchedAt,
+    staleAfter: new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS),
+    metadata: {
+      tier: "manual_override_recommended",
+      note: "Manual Atlas Cloud video pricing seed. Refresh with account-specific pricing before production if needed.",
+    },
+  };
+}
+
+function buildAtlasVideoSnapshotEntries(): PreparedPricingEntry[] {
+  return SUPPORTED_VIDEO_MODELS.filter((model) => model.billingSource === "atlascloud").flatMap(
+    (model) => {
+      const unitPrice = ATLAS_VIDEO_PRICE_BY_MODEL[model.modelId];
+      if (unitPrice === undefined) return [];
+      return [buildAtlasVideoEntry(model, unitPrice)];
+    },
+  );
+}
+
 export async function fetchAtlasCloudCatalogEntries(): Promise<PreparedPricingEntry[]> {
   return await getCachedExternalEntries("atlascloud", async () => {
-    return buildAtlasImageSnapshotEntries();
+    return [...buildAtlasImageSnapshotEntries(), ...buildAtlasVideoSnapshotEntries()];
   });
 }

--- a/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -332,7 +332,7 @@ export function parseFalPricingEntries(
 export async function fetchFalCatalogEntries(): Promise<PreparedPricingEntry[]> {
   return await getCachedExternalEntries("fal", async () => {
     const entryArrays = await Promise.all(
-      SUPPORTED_VIDEO_MODELS.map(async (model) => {
+      SUPPORTED_VIDEO_MODELS.filter((model) => model.billingSource === "fal").map(async (model) => {
         try {
           const html = await fetchText(model.pageUrl);
           const paragraph = extractFalPricingParagraph(html);

--- a/packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { SUPPORTED_VIDEO_MODELS } from "../ai-pricing-definitions";
+import type { PreparedPricingEntry } from "./types";
+
+const { fetchAtlasCloudCatalogEntries } = await import("./providers/atlascloud");
+
+async function collectAtlasVideoGenerationRows(): Promise<PreparedPricingEntry[]> {
+  const rows = await fetchAtlasCloudCatalogEntries();
+  return rows.filter(
+    (row) =>
+      row.billingSource === "atlascloud" &&
+      row.productFamily === "video" &&
+      row.chargeType === "generation",
+  );
+}
+
+test("every supported Atlas video model has a video:generation pricing row", async () => {
+  const atlasVideoModels = SUPPORTED_VIDEO_MODELS.filter(
+    (model) => model.billingSource === "atlascloud",
+  );
+  const rows = await collectAtlasVideoGenerationRows();
+
+  expect(atlasVideoModels.length).toBeGreaterThan(0);
+  for (const model of atlasVideoModels) {
+    const row = rows.find((candidate) => candidate.model === model.modelId);
+    expect(row).toBeDefined();
+    expect(row?.unit).toBe("second");
+    expect(row?.provider).toBe(model.provider);
+    expect(row?.unitPrice ?? 0).toBeGreaterThan(0);
+    expect(row?.sourceUrl).toBe(model.pageUrl);
+  }
+});

--- a/packages/cloud/shared/src/lib/services/media-model-roster.ts
+++ b/packages/cloud/shared/src/lib/services/media-model-roster.ts
@@ -232,6 +232,20 @@ export const MEDIA_MODEL_ROSTER: readonly MediaModelRosterEntry[] = [
       "These adjacent FAL video families are already explicit supported video models with parser coverage.",
   },
   {
+    family: "Atlas-hosted Vidu video",
+    provider: "atlascloud",
+    surfaces: ["video"],
+    status: "wired",
+    sourceUrls: [
+      "https://www.atlascloud.ai/docs/en/models/video",
+      "https://www.atlascloud.ai/models/vidu/q3-turbo/text-to-video",
+      "https://www.atlascloud.ai/models/vidu/image-to-video-2.0",
+    ],
+    wiredModelIds: ["vidu/q3-turbo/text-to-video", "vidu/image-to-video-2.0"],
+    rationale:
+      "Vidu text-to-video and image-to-video are routed through the Atlas Cloud async video provider with snapshot per-second pricing.",
+  },
+  {
     family: "Google Nano Banana image generation",
     provider: "atlascloud",
     surfaces: ["image"],


### PR DESCRIPTION
## Summary

- add an Atlas Cloud video provider behind the existing video provider registry
- wire `/api/v1/generate-video` to pass Atlas credentials for Atlas-backed video models
- add Atlas-hosted Vidu video model definitions, per-second pricing rows, and media roster coverage
- add deterministic provider/pricing tests plus a credential-gated live Atlas video lane

## Evidence

- `bun run install:light`
- `bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts packages/cloud/shared/src/lib/providers/video/fal-video-generation.test.ts packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts packages/cloud/shared/src/lib/services/media-model-roster.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts packages/cloud/shared/src/lib/providers/video/registry.ts packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts packages/cloud/shared/src/lib/services/ai-pricing/providers/atlascloud.ts packages/cloud/shared/src/lib/services/ai-pricing/providers/fal.ts packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts packages/cloud/shared/src/lib/services/ai-pricing/video-generation-pricing.test.ts packages/cloud/shared/src/lib/services/media-model-roster.ts packages/cloud/api/v1/generate-video/route.ts`
- `git diff --check`

Evidence note: `.github/issue-evidence/10689-atlas-video-provider.md`

## Live evidence

N/A - no Atlas Cloud production API key or spend budget was available in this workspace. The live lane is included and skips by default; run it with `TEST_LANE=post-merge ATLASCLOUD_API_KEY=<redacted> bun test packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.real.test.ts`.

Fixes part of #10689. The remaining closure gate is live Atlas model-matrix evidence with generated video artifacts.