### PR TITLE
fix(orchestrator): portable findSession fallback + never poison session recording on pglite (#11778)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -545,6 +545,27 @@ class PgliteLikeRejectingAdapter extends FakeSqlAdapter {
   }
 }
 
+/**
+ * Emulates the pglite/postgres failure mode from #11778: the driver rejects the
+ * BARE full-table scan `SELECT document FROM orchestrator_tasks` (no WHERE) that
+ * the legacy `findSession` fallback used to emit — same driver-quirk family as
+ * #11641. It counts how many times that bare form is issued so a test can assert
+ * the fallback no longer emits it. Any query carrying a `WHERE` clause behaves
+ * normally, so the `search_text LIKE ?`-shaped fallback survives.
+ */
+class PgliteBareScanRejectingAdapter extends FakeSqlAdapter {
+  bareScanCount = 0;
+  override async all(sql: string, params: unknown[] = []): Promise<unknown[]> {
+    if (/^\s*SELECT document FROM orchestrator_tasks\s*$/i.test(sql)) {
+      this.bareScanCount++;
+      throw new Error(
+        `Failed query: ${sql}\nparams: ${JSON.stringify(params)}`,
+      );
+    }
+    return super.all(sql, params);
+  }
+}
+
 describe("RuntimeDbTaskStore", () => {
   it("resolves a session without a `document LIKE` query so pglite/postgres do not fail (#11641)", async () => {
     // On pglite the old `SELECT document FROM orchestrator_tasks WHERE document
@@ -616,6 +637,76 @@ describe("RuntimeDbTaskStore", () => {
     ).toBe(false);
     // Never the pglite-breaking document LIKE either.
     expect(seenSql.some((s) => /document LIKE/.test(s))).toBe(false);
+  });
+
+  it("resolves a legacy session via the fallback WITHOUT the bare full-table scan pglite rejects (#11778)", async () => {
+    // #11778: the legacy fallback issued a bare `SELECT document FROM
+    // orchestrator_tasks` (no WHERE) that pglite/postgres reject, killing the
+    // whole session's event-record path. The fallback must now route through
+    // the portable `WHERE search_text LIKE ?` shape and never emit the bare
+    // scan — even for a legacy row whose session id is NOT in `search_text`.
+    const adapter = new PgliteBareScanRejectingAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(createInput({ title: "legacy" }));
+    await store.addSession(
+      sessionFor(task.id, { sessionId: "legacy-session" }),
+    );
+
+    // Simulate a pre-#11667 row: the session lives in the document but its id
+    // was never folded into search_text, so the indexed prefilter misses and
+    // the fallback path is exercised.
+    for (const row of adapter.rows.values()) {
+      row.search_text = "stale text without the session id";
+    }
+
+    const found = await store.findSession("legacy-session");
+    expect(found?.taskId).toBe(task.id);
+    expect(found?.session.sessionId).toBe("legacy-session");
+    // The bare full-table scan pglite rejects was never issued.
+    expect(adapter.bareScanCount).toBe(0);
+  });
+
+  it("returns null (never throws) when the fallback scan degrades, so session event-recording is not poisoned (#11778)", async () => {
+    // If a driver quirk still throws on the fallback query, `findSession` must
+    // degrade to a clean `null` rather than an exception. A throw here sits on
+    // the `onSessionEvent → resolveTaskId → findSession` hot path and makes
+    // OrchestratorTaskService suppress ALL further event records for the
+    // session, silently losing its telemetry (#11778's live symptom).
+    //
+    // Model the #11778 scenario precisely: the prefilter (session-id needle)
+    // runs fine; only the fallback scan (the always-true `%` needle, reached
+    // because the session id is not yet in search_text) degrades.
+    class FallbackScanRejectAdapter extends FakeSqlAdapter {
+      override async all(
+        sql: string,
+        params: unknown[] = [],
+      ): Promise<unknown[]> {
+        if (
+          sql.includes("search_text LIKE ?") &&
+          Array.isArray(params) &&
+          params[0] === "%"
+        ) {
+          throw new Error(
+            `Failed query: ${sql}\nparams: ${JSON.stringify(params)}`,
+          );
+        }
+        return super.all(sql, params);
+      }
+    }
+    const adapter = new FallbackScanRejectAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(createInput({ title: "degraded" }));
+    await store.addSession(sessionFor(task.id, { sessionId: "sess-degraded" }));
+
+    // Force the fallback path: strip the session id from search_text so the
+    // prefilter misses and the (rejecting) fallback runs.
+    for (const row of adapter.rows.values()) {
+      row.search_text = "stale text without the session id";
+    }
+
+    // The fallback throws, but the caller sees null, not an exception —
+    // recording stays alive for subsequent events.
+    await expect(store.findSession("sess-degraded")).resolves.toBeNull();
   });
 
   it("round-trips tasks, sessions, and deletes through a SQL adapter", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -1018,18 +1018,49 @@ export class RuntimeDbTaskStore {
     // JSON-parse those. The authoritative decision is still the JS
     // `sessions.find(...)` below, so a substring false-positive can never
     // resolve to the wrong session.
+    //
+    // Both the prefilter AND the legacy fallback below use this one portable
+    // `WHERE search_text LIKE ?` query shape (see #11778) — never a bare
+    // full-table `SELECT document FROM orchestrator_tasks`, which pglite/
+    // postgres reject.
     const needle = `%${sessionId.toLowerCase()}%`;
-    let rows = await this.exec().all(
+    const rows = await this.exec().all(
       "SELECT document FROM orchestrator_tasks WHERE search_text LIKE ?",
       [needle],
     );
     const match = this.matchSession(rows, sessionId);
     if (match) return match;
     // Legacy fallback: rows persisted before session ids were added to
-    // `search_text` won't match the prefilter. Only pay for a full scan when
-    // the targeted lookup misses, so the steady-state hot path stays cheap.
-    rows = await this.exec().all("SELECT document FROM orchestrator_tasks");
-    return this.matchSession(rows, sessionId);
+    // `search_text` won't match the prefilter, so scan the rest. Two hardening
+    // rules apply here, both learned from #11641/#11778:
+    //
+    //   1. Route the fallback through the SAME `WHERE search_text LIKE ?`
+    //      query SHAPE the prefilter uses (an always-true `%` needle), rather
+    //      than a bare `SELECT document FROM orchestrator_tasks`. The bare
+    //      full-table select is the exact statement pglite/postgres rejected in
+    //      #11778 (`Failed query: SELECT document FROM orchestrator_tasks
+    //      params:`), in the same driver-quirk family as #11641's `document
+    //      LIKE`. Reusing the proven-portable prefilter shape keeps every read
+    //      on this method to one query form that all three backends accept.
+    //
+    //   2. Never let a fallback failure POISON the caller. `findSession` sits
+    //      on the session-event hot path (`onSessionEvent → resolveTaskId →
+    //      findSession`); if a driver quirk still throws here, the service
+    //      suppresses ALL further event records for that session and the whole
+    //      session's orchestration telemetry is silently lost (#11778's live
+    //      symptom). A missed lookup is a clean `null`, not an exception, so a
+    //      degraded fallback degrades to "session not found yet" instead of
+    //      killing recording. The authoritative decision is still the JS
+    //      `sessions.find(...)` in `matchSession`.
+    try {
+      const fallbackRows = await this.exec().all(
+        "SELECT document FROM orchestrator_tasks WHERE search_text LIKE ?",
+        ["%"],
+      );
+      return this.matchSession(fallbackRows, sessionId);
+    } catch {
+      return null;
+    }
   }
 
   private matchSession(rows: unknown[], sessionId: string) {


### PR DESCRIPTION
Fixes #11778.

## Root cause

The legacy `findSession` full-scan fallback (`orchestrator-task-store.ts`) issued a bare `SELECT document FROM orchestrator_tasks` (no `WHERE`) that pglite/postgres reject:

```
Failed query: SELECT document FROM orchestrator_tasks
params:
```

Same driver-quirk family as #11641. The trigger sequence: a freshly spawned session's `ready` event fires **before** its id is folded into `search_text`, so the indexed prefilter (added in #11667) misses → the fallback full-scan runs → throws → `OrchestratorTaskService.onSessionEvent` catches it and suppresses **all** further event records for that session. The whole session's orchestration telemetry is silently lost (observed on 3 sessions in one live round-5 trajectory).

## Fix

Two minimal, portable hardening changes to the fallback only — no schema change, no migration, no spawn-ordering change:

**1. Portable fallback query shape.** Route the fallback through the SAME `WHERE search_text LIKE ?` shape the prefilter uses (an always-true `%` needle), instead of the bare full-table select pglite/postgres reject. `search_text` is a plain indexed `TEXT` column that `listTasks` already `LIKE`-matches on every backend without incident, and `persist()` always writes a non-null value there. Every read on `findSession` is now one query form all three backends (sqlite/pglite/postgres) accept.

**2. Never poison the caller.** Wrap the fallback in `try/catch` and return `null` on failure. `findSession` sits on the session-event hot path (`onSessionEvent → resolveTaskId → findSession`); if a driver quirk still throws, a clean `null` degrades to "session not found yet" for that one event instead of an exception that kills recording for the session's entire lifetime. The authoritative decision is still the JS `sessions.find(...)` in `matchSession`, so correctness is unchanged.

*Why not the persist-before-spawn race close?* That would need touching the spawn ordering across the service; the fallback fix is smaller, backend-agnostic, and defends the telemetry path even if the race recurs for any other reason.

## Tests

Added to `orchestrator-task-store.test.ts`, mirroring the existing #11641 `PgliteLikeRejectingAdapter` approach:

- **`PgliteBareScanRejectingAdapter`** — rejects the bare `SELECT document FROM orchestrator_tasks`. A legacy session (id absent from `search_text`) still resolves via the fallback, and the bare scan is asserted to never run (`bareScanCount === 0`).
- **Degradation guard** — even if the fallback scan throws, `findSession` resolves to `null`, never an exception, so event-recording is not poisoned.

**Suite:** `npx vitest run __tests__/unit/orchestrator-task-store.test.ts` → **40 passed**, 1 pre-existing env failure (drizzle-orm module resolution), **zero new**. Full `__tests__/unit` sweep: 16 env failures (smithers-orchestrator / drizzle-orm / opencode-config / provision-workspace module resolution) — within the documented 15-19 baseline, **zero new**. Biome clean. Manual self-review (codex hung past the 5-min cap).

— [sol-orch]
