### PR TITLE
fix(orchestrator): make task-store session fallback pglite-safe

### DIFF
--- a/.github/issue-evidence/11778-task-store-pglite-fallback/README.md
+++ b/.github/issue-evidence/11778-task-store-pglite-fallback/README.md
@@ -1,0 +1,34 @@
+# Issue #11778 evidence: task-store pglite fallback
+
+## Summary
+
+`RuntimeDbTaskStore.findSession` now uses `CAST(document AS TEXT) AS document` for document reads, including the legacy full-table fallback used when older rows do not have session ids folded into `search_text`. This avoids the pglite/postgres failure shape `SELECT document FROM orchestrator_tasks` while preserving the legacy lookup path.
+
+## Regression coverage
+
+- Extended `PgliteLikeRejectingAdapter` so tests fail on both pglite-breaking shapes:
+  - `document LIKE`
+  - bare `SELECT document FROM orchestrator_tasks`
+- Added a #11778 test that simulates an older persisted row whose `search_text` lacks the session id, forcing the legacy fallback. The fallback resolves the session without issuing the rejected query.
+
+## Validation
+
+- `bun run install:light` - pass.
+- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts` - pass, 40 tests, 133 assertions.
+- Real `@electric-sql/pglite` smoke - pass. A task/session was persisted, `search_text` was manually rewritten to omit the session id, and `findSession("legacy-session-pglite")` returned:
+
+```json
+{"taskId":"955f78c1-2eb4-43eb-969f-9f2a366dafd2","sessionId":"legacy-session-pglite"}
+```
+
+- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` - pass.
+- `bun run --cwd packages/contracts build` - pass; prerequisite for typecheck.
+- `bun run --cwd packages/shared build:i18n` - pass; generates shared/core i18n prerequisite.
+- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` - pass.
+- `git diff --check` - pass.
+
+## N/A
+
+- App screenshots/video: N/A - backend task-store SQL lookup fix, no user-facing UI changed.
+- Real LLM trajectories: N/A - no prompt, model, evaluator, or agent planning behavior changed.
+- Backend service logs: N/A - this is a storage-layer query fix verified through unit coverage and a real pglite smoke; no long-running service was started.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -528,15 +528,19 @@ describe("FileTaskStore", () => {
 });
 
 /**
- * Emulates the pglite/postgres failure mode from #11641: the driver rejects a
- * `document LIKE ?` comparison against the JSON-bearing column (it does not
- * treat it as a plain-text haystack the way sqlite does). Every other query
- * shape behaves like {@link FakeSqlAdapter}. If `findSession` still emits
- * `document LIKE`, the lookup throws here — proving the portability fix.
+ * Emulates the pglite/postgres failure modes from #11641/#11778: the driver
+ * rejects a `document LIKE ?` comparison against the JSON-bearing column and
+ * the legacy bare full-table `SELECT document FROM orchestrator_tasks`
+ * fallback. Every other query shape behaves like {@link FakeSqlAdapter}. If
+ * `findSession` still emits either shape, the lookup throws here — proving the
+ * portability fix.
  */
 class PgliteLikeRejectingAdapter extends FakeSqlAdapter {
   override async all(sql: string, params: unknown[] = []): Promise<unknown[]> {
-    if (sql.includes("document LIKE")) {
+    if (
+      sql.includes("document LIKE") ||
+      /^SELECT\s+document\s+FROM\s+orchestrator_tasks\s*$/i.test(sql.trim())
+    ) {
       throw new Error(
         `Failed query: ${sql}\nparams: ${JSON.stringify(params)}`,
       );
@@ -568,6 +572,24 @@ describe("RuntimeDbTaskStore", () => {
     expect((await store.findSession("session-x"))?.session.activeTool).toBe(
       "edit",
     );
+  });
+
+  it("uses a portable legacy fallback when search_text does not contain the session id (#11778)", async () => {
+    const adapter = new PgliteLikeRejectingAdapter();
+    const store = new RuntimeDbTaskStore(adapter);
+    const { task } = await store.createTask(
+      createInput({ title: "legacy pglite" }),
+    );
+    await store.addSession(
+      sessionFor(task.id, { sessionId: "legacy-session" }),
+    );
+    const row = adapter.rows.get(task.id);
+    if (!row) throw new Error("expected persisted test row");
+    row.search_text = "legacy row written before session ids were indexed";
+
+    const found = await store.findSession("legacy-session");
+    expect(found?.taskId).toBe(task.id);
+    expect(found?.session.sessionId).toBe("legacy-session");
   });
 
   it("finds a session on a task even when other tasks exist, without substring LIKE false-positives", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -807,6 +807,8 @@ const TASK_INDEX_SQL = [
   "CREATE INDEX IF NOT EXISTS idx_orch_tasks_activity ON orchestrator_tasks(last_activity_at)",
 ];
 
+const TASK_DOCUMENT_SELECT_SQL = "CAST(document AS TEXT) AS document";
+
 /** SQL backend. Stores the whole document as a JSON column with indexed
  * columns for the list query, so all reads/writes are single-row operations.
  *
@@ -895,7 +897,7 @@ export class RuntimeDbTaskStore {
 
   private async loadOne(id: string): Promise<OrchestratorTaskDocument | null> {
     const rows = await this.exec().all(
-      "SELECT document FROM orchestrator_tasks WHERE id = ?",
+      `SELECT ${TASK_DOCUMENT_SELECT_SQL} FROM orchestrator_tasks WHERE id = ?`,
       [id],
     );
     return rows.length > 0 ? this.parseDoc(rows[0]) : null;
@@ -936,7 +938,7 @@ export class RuntimeDbTaskStore {
         ? `LIMIT ${Math.floor(filter.limit)}`
         : "";
     const rows = await this.exec().all(
-      `SELECT document FROM orchestrator_tasks ${where} ORDER BY last_activity_at DESC ${limit}`,
+      `SELECT ${TASK_DOCUMENT_SELECT_SQL} FROM orchestrator_tasks ${where} ORDER BY last_activity_at DESC ${limit}`,
       params,
     );
     return rows
@@ -1020,7 +1022,7 @@ export class RuntimeDbTaskStore {
     // resolve to the wrong session.
     const needle = `%${sessionId.toLowerCase()}%`;
     let rows = await this.exec().all(
-      "SELECT document FROM orchestrator_tasks WHERE search_text LIKE ?",
+      `SELECT ${TASK_DOCUMENT_SELECT_SQL} FROM orchestrator_tasks WHERE search_text LIKE ?`,
       [needle],
     );
     const match = this.matchSession(rows, sessionId);
@@ -1028,7 +1030,9 @@ export class RuntimeDbTaskStore {
     // Legacy fallback: rows persisted before session ids were added to
     // `search_text` won't match the prefilter. Only pay for a full scan when
     // the targeted lookup misses, so the steady-state hot path stays cheap.
-    rows = await this.exec().all("SELECT document FROM orchestrator_tasks");
+    rows = await this.exec().all(
+      `SELECT ${TASK_DOCUMENT_SELECT_SQL} FROM orchestrator_tasks`,
+    );
     return this.matchSession(rows, sessionId);
   }
 


### PR DESCRIPTION
## Summary

Fixes #11778 by making `RuntimeDbTaskStore.findSession`'s legacy fallback avoid the pglite-breaking bare `SELECT document FROM orchestrator_tasks` shape.

Changes:
- Introduces a shared `CAST(document AS TEXT) AS document` projection for document reads.
- Uses that projection for `loadOne`, list reads, `findSession` prefilter reads, and the legacy full-table fallback.
- Extends the pglite-like unit adapter to reject both old broken query shapes.
- Adds a regression test for legacy rows whose `search_text` does not include the session id.

## Evidence

Evidence bundle: `.github/issue-evidence/11778-task-store-pglite-fallback/README.md`

Validation run on the rebased branch:
- `bun run install:light` - pass
- `bun test plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts` - pass, 40 tests, 133 assertions
- Real `@electric-sql/pglite` smoke with a legacy `search_text` row - pass
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` - pass
- `bun run --cwd packages/contracts build` - pass
- `bun run --cwd packages/shared build:i18n` - pass
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` - pass
- `git diff --check origin/develop...HEAD` - pass

## N/A

- App screenshots/video: storage-layer SQL lookup fix; no UI changed.
- Real LLM trajectories: no prompt/model/evaluator behavior changed.
- Backend service logs: covered by unit regression and real pglite smoke; no long-running server route changed.
