### PR TITLE
feat(discord): add multi-account Discord voice targets

### DIFF
--- a/plugins/plugin-discord/__tests__/audio-lanes.test.ts
+++ b/plugins/plugin-discord/__tests__/audio-lanes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_DISCORD_AUDIO_LANES,
+	DISCORD_AUDIO_LANE_MUSIC,
+	DISCORD_AUDIO_LANE_TTS,
+	getDiscordAudioLaneConfig,
+	normalizeDiscordAudioLane,
+} from "../audio-lanes";
+
+describe("Discord audio lanes", () => {
+	it("normalizes blank lanes to TTS", () => {
+		expect(normalizeDiscordAudioLane(undefined)).toBe(DISCORD_AUDIO_LANE_TTS);
+		expect(normalizeDiscordAudioLane("")).toBe(DISCORD_AUDIO_LANE_TTS);
+		expect(normalizeDiscordAudioLane(" MUSIC ")).toBe(DISCORD_AUDIO_LANE_MUSIC);
+	});
+
+	it("loads default priorities instead of flattening every lane", () => {
+		const lanes = new Map(
+			Object.entries(DEFAULT_DISCORD_AUDIO_LANES).map(([lane, config]) => [
+				lane,
+				config,
+			]),
+		);
+
+		expect(
+			getDiscordAudioLaneConfig(lanes, DISCORD_AUDIO_LANE_TTS).priority,
+		).toBe(100);
+		expect(
+			getDiscordAudioLaneConfig(lanes, DISCORD_AUDIO_LANE_MUSIC).priority,
+		).toBe(50);
+		expect(getDiscordAudioLaneConfig(lanes, "custom").priority).toBe(25);
+	});
+});

--- a/plugins/plugin-discord/__tests__/discord-audio-sink.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-audio-sink.test.ts
@@ -1,0 +1,66 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { DISCORD_AUDIO_LANE_MUSIC } from "../audio-lanes";
+import { DiscordVoiceTargetAudioSink } from "../discord-audio-sink";
+import type { DiscordVoiceTarget } from "../voice-target-registry";
+
+function createTarget(
+	overrides?: Partial<DiscordVoiceTarget>,
+): DiscordVoiceTarget {
+	return {
+		id: "account:guild:voice",
+		accountId: "account",
+		botId: "bot",
+		guildId: "guild",
+		channelId: "voice",
+		channelName: "Voice",
+		play: vi.fn(async () => ({
+			finished: Promise.resolve(),
+			cancelled: Promise.resolve(),
+			abort: vi.fn(),
+		})),
+		stop: vi.fn(async () => {}),
+		getStatus: vi.fn(() => "connected"),
+		getLaneConfig: vi.fn(() => ({
+			lane: DISCORD_AUDIO_LANE_MUSIC,
+			priority: 50,
+			canPause: true,
+			interruptible: true,
+			volume: 1,
+		})),
+		...overrides,
+	};
+}
+
+describe("DiscordVoiceTargetAudioSink", () => {
+	it("proxies playback and lane stops to the registered voice target", async () => {
+		const target = createTarget();
+		const sink = new DiscordVoiceTargetAudioSink(target);
+		const stream = new PassThrough();
+
+		await sink.play(stream, { lane: DISCORD_AUDIO_LANE_MUSIC });
+		await sink.stop(DISCORD_AUDIO_LANE_MUSIC);
+
+		expect(target.play).toHaveBeenCalledWith(stream, {
+			lane: DISCORD_AUDIO_LANE_MUSIC,
+		});
+		expect(target.stop).toHaveBeenCalledWith(DISCORD_AUDIO_LANE_MUSIC);
+	});
+
+	it("stops active target playback when destroyed", async () => {
+		const target = createTarget();
+		const sink = new DiscordVoiceTargetAudioSink(target);
+
+		sink.destroy();
+		await Promise.resolve();
+		sink.destroy();
+		await sink.stop(DISCORD_AUDIO_LANE_MUSIC);
+
+		expect(target.stop).toHaveBeenCalledTimes(1);
+		expect(target.stop).toHaveBeenCalledWith(undefined);
+		expect(sink.status).toBe("disconnected");
+		await expect(sink.play(new PassThrough())).rejects.toThrow(
+			"has been destroyed",
+		);
+	});
+});

--- a/plugins/plugin-discord/__tests__/voice-target-registry.test.ts
+++ b/plugins/plugin-discord/__tests__/voice-target-registry.test.ts
@@ -1,0 +1,63 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { DISCORD_AUDIO_LANE_MUSIC } from "../audio-lanes";
+import { DiscordVoiceTargetRegistry } from "../voice-target-registry";
+
+function createChannel(id: string, guildId = "guild-1") {
+	return {
+		id,
+		name: `channel-${id}`,
+		guild: {
+			id: guildId,
+			name: `guild-${guildId}`,
+		},
+	};
+}
+
+describe("DiscordVoiceTargetRegistry", () => {
+	it("registers, finds, and unregisters account-scoped voice targets", async () => {
+		const registry = new DiscordVoiceTargetRegistry();
+		const play = vi.fn(async () => ({
+			finished: Promise.resolve(),
+			cancelled: Promise.resolve(),
+			abort: vi.fn(),
+		}));
+		const stop = vi.fn(async () => {});
+
+		const target = registry.register({
+			accountId: "music",
+			botId: "bot-1",
+			channel: createChannel("voice-1") as never,
+			play,
+			stop,
+			getStatus: () => "connected",
+			getLaneConfig: () => ({
+				lane: DISCORD_AUDIO_LANE_MUSIC,
+				priority: 50,
+				canPause: true,
+				interruptible: true,
+				volume: 1,
+			}),
+		});
+
+		expect(registry.get(target.id)).toBe(target);
+		expect(
+			registry.find({
+				accountId: "music",
+				guildId: "guild-1",
+				channelId: "voice-1",
+			}),
+		).toBe(target);
+
+		await target.play(new PassThrough(), { lane: DISCORD_AUDIO_LANE_MUSIC });
+		await target.stop(DISCORD_AUDIO_LANE_MUSIC);
+
+		expect(play).toHaveBeenCalledWith(expect.any(PassThrough), {
+			lane: DISCORD_AUDIO_LANE_MUSIC,
+		});
+		expect(stop).toHaveBeenCalledWith(DISCORD_AUDIO_LANE_MUSIC);
+
+		registry.unregister("music", "guild-1", "voice-1");
+		expect(registry.get(target.id)).toBeNull();
+	});
+});

--- a/plugins/plugin-discord/audio-lanes.ts
+++ b/plugins/plugin-discord/audio-lanes.ts
@@ -1,0 +1,81 @@
+export const DISCORD_AUDIO_LANE_TTS = "tts";
+export const DISCORD_AUDIO_LANE_MUSIC = "music";
+export const DISCORD_AUDIO_LANE_SFX = "sfx";
+export const DISCORD_AUDIO_LANE_AMBIENT = "ambient";
+
+export type DiscordAudioLane =
+	| typeof DISCORD_AUDIO_LANE_TTS
+	| typeof DISCORD_AUDIO_LANE_MUSIC
+	| typeof DISCORD_AUDIO_LANE_SFX
+	| typeof DISCORD_AUDIO_LANE_AMBIENT
+	| (string & {});
+
+export interface DiscordAudioLaneConfig {
+	lane: DiscordAudioLane;
+	priority: number;
+	canPause: boolean;
+	interruptible: boolean;
+	volume: number;
+	duckVolume?: number;
+}
+
+export type DiscordAudioLaneConfigMap = Record<string, DiscordAudioLaneConfig>;
+
+export const DEFAULT_DISCORD_AUDIO_LANES: DiscordAudioLaneConfigMap = {
+	[DISCORD_AUDIO_LANE_TTS]: {
+		lane: DISCORD_AUDIO_LANE_TTS,
+		priority: 100,
+		canPause: false,
+		interruptible: false,
+		volume: 1,
+	},
+	[DISCORD_AUDIO_LANE_MUSIC]: {
+		lane: DISCORD_AUDIO_LANE_MUSIC,
+		priority: 50,
+		canPause: true,
+		interruptible: true,
+		volume: 1,
+		duckVolume: 0.2,
+	},
+	[DISCORD_AUDIO_LANE_SFX]: {
+		lane: DISCORD_AUDIO_LANE_SFX,
+		priority: 30,
+		canPause: false,
+		interruptible: true,
+		volume: 1,
+	},
+	[DISCORD_AUDIO_LANE_AMBIENT]: {
+		lane: DISCORD_AUDIO_LANE_AMBIENT,
+		priority: 20,
+		canPause: false,
+		interruptible: true,
+		volume: 0.5,
+		duckVolume: 0.1,
+	},
+};
+
+export function normalizeDiscordAudioLane(
+	lane?: DiscordAudioLane | null,
+): DiscordAudioLane {
+	const normalized = typeof lane === "string" ? lane.trim().toLowerCase() : "";
+	return normalized || DISCORD_AUDIO_LANE_TTS;
+}
+
+export function getDiscordAudioLaneConfig(
+	lanes: ReadonlyMap<string, DiscordAudioLaneConfig>,
+	lane?: DiscordAudioLane | null,
+): DiscordAudioLaneConfig {
+	const normalized = normalizeDiscordAudioLane(lane);
+	const existing = lanes.get(normalized);
+	if (existing) {
+		return existing;
+	}
+
+	return {
+		lane: normalized,
+		priority: 25,
+		canPause: false,
+		interruptible: true,
+		volume: 1,
+	};
+}

--- a/plugins/plugin-discord/audio-sink.ts
+++ b/plugins/plugin-discord/audio-sink.ts
@@ -1,0 +1,51 @@
+import { EventEmitter } from "node:events";
+import type { Readable } from "node:stream";
+import type { DiscordAudioLane } from "./audio-lanes";
+
+export type DiscordAudioSinkStatus =
+	| "connected"
+	| "disconnected"
+	| "reconnecting";
+
+export interface DiscordAudioPlaybackHandle {
+	finished: Promise<void>;
+	cancelled: Promise<void>;
+	abort(): void;
+}
+
+export interface DiscordAudioSinkPlayOptions {
+	lane?: DiscordAudioLane;
+	interrupt?: boolean;
+	mix?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface IDiscordAudioSink {
+	readonly id: string;
+	readonly status: DiscordAudioSinkStatus;
+	play(
+		stream: Readable,
+		options?: DiscordAudioSinkPlayOptions,
+	): Promise<DiscordAudioPlaybackHandle>;
+	stop(lane?: DiscordAudioLane): Promise<void>;
+	destroy(): void;
+	on(
+		event: "statusChange",
+		listener: (status: DiscordAudioSinkStatus) => void,
+	): this;
+	on(event: "error", listener: (error: Error) => void): this;
+}
+
+export abstract class DiscordAudioSinkBase
+	extends EventEmitter
+	implements IDiscordAudioSink
+{
+	abstract readonly id: string;
+	abstract get status(): DiscordAudioSinkStatus;
+	abstract play(
+		stream: Readable,
+		options?: DiscordAudioSinkPlayOptions,
+	): Promise<DiscordAudioPlaybackHandle>;
+	abstract stop(lane?: DiscordAudioLane): Promise<void>;
+	abstract destroy(): void;
+}

--- a/plugins/plugin-discord/discord-audio-sink.ts
+++ b/plugins/plugin-discord/discord-audio-sink.ts
@@ -1,0 +1,74 @@
+import type { Readable } from "node:stream";
+import { logger } from "@elizaos/core";
+import type { DiscordAudioLane } from "./audio-lanes";
+import {
+	type DiscordAudioPlaybackHandle,
+	DiscordAudioSinkBase,
+	type DiscordAudioSinkPlayOptions,
+	type DiscordAudioSinkStatus,
+} from "./audio-sink";
+import type { DiscordVoiceTarget } from "./voice-target-registry";
+
+export class DiscordVoiceTargetAudioSink extends DiscordAudioSinkBase {
+	readonly id: string;
+	private target: DiscordVoiceTarget;
+	private destroyed = false;
+
+	constructor(target: DiscordVoiceTarget) {
+		super();
+		this.target = target;
+		this.id = `discord:${target.id}`;
+	}
+
+	get status(): DiscordAudioSinkStatus {
+		return this.destroyed ? "disconnected" : this.target.getStatus();
+	}
+
+	async play(
+		stream: Readable,
+		options?: DiscordAudioSinkPlayOptions,
+	): Promise<DiscordAudioPlaybackHandle> {
+		if (this.destroyed) {
+			throw new Error(`Discord audio sink ${this.id} has been destroyed`);
+		}
+		try {
+			return await this.target.play(stream, options);
+		} catch (error) {
+			const normalized =
+				error instanceof Error ? error : new Error(String(error));
+			this.emit("error", normalized);
+			throw normalized;
+		}
+	}
+
+	async stop(lane?: DiscordAudioLane): Promise<void> {
+		if (this.destroyed) {
+			return;
+		}
+		try {
+			await this.target.stop(lane);
+		} catch (error) {
+			const normalized =
+				error instanceof Error ? error : new Error(String(error));
+			logger.warn(
+				{
+					src: "plugin:discord:audio-sink",
+					targetId: this.target.id,
+					error: normalized.message,
+				},
+				"Failed to stop Discord audio sink",
+			);
+			this.emit("error", normalized);
+		}
+	}
+
+	destroy(): void {
+		if (this.destroyed) {
+			return;
+		}
+		this.destroyed = true;
+		void this.stop();
+		this.emit("statusChange", "disconnected");
+		this.removeAllListeners();
+	}
+}

--- a/plugins/plugin-discord/discord-audio-sink.ts
+++ b/plugins/plugin-discord/discord-audio-sink.ts
@@ -45,6 +45,10 @@ export class DiscordVoiceTargetAudioSink extends DiscordAudioSinkBase {
 		if (this.destroyed) {
 			return;
 		}
+		await this.stopTarget(lane);
+	}
+
+	private async stopTarget(lane?: DiscordAudioLane): Promise<void> {
 		try {
 			await this.target.stop(lane);
 		} catch (error) {
@@ -67,7 +71,7 @@ export class DiscordVoiceTargetAudioSink extends DiscordAudioSinkBase {
 			return;
 		}
 		this.destroyed = true;
-		void this.stop();
+		void this.stopTarget();
 		this.emit("statusChange", "disconnected");
 		this.removeAllListeners();
 	}

--- a/plugins/plugin-discord/index.ts
+++ b/plugins/plugin-discord/index.ts
@@ -182,6 +182,23 @@ export {
 	shouldEmitDiscordReactionNotification,
 	validateMessageAllowed,
 } from "./allowlist";
+export {
+	DEFAULT_DISCORD_AUDIO_LANES,
+	DISCORD_AUDIO_LANE_AMBIENT,
+	DISCORD_AUDIO_LANE_MUSIC,
+	DISCORD_AUDIO_LANE_SFX,
+	DISCORD_AUDIO_LANE_TTS,
+	type DiscordAudioLane,
+	type DiscordAudioLaneConfig,
+	getDiscordAudioLaneConfig,
+	normalizeDiscordAudioLane,
+} from "./audio-lanes";
+export type {
+	DiscordAudioPlaybackHandle,
+	DiscordAudioSinkPlayOptions,
+	DiscordAudioSinkStatus,
+	IDiscordAudioSink,
+} from "./audio-sink";
 // Channel configuration types (comprehensive config schema)
 // Re-export config types that were in accounts.ts for backward compatibility
 export type {
@@ -334,3 +351,8 @@ export {
 	searchDiscordMessages,
 	sendDiscordViaDesktopCdp,
 } from "./user-account-scraper";
+export type {
+	DiscordVoicePlaybackOptions,
+	DiscordVoiceTarget,
+	DiscordVoiceTargetRegistration,
+} from "./voice-target-registry";

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -58,7 +58,9 @@ import {
  *    to use the generic emitEvent overload.
  */
 import {
+	ActivityType,
 	type AttachmentBuilder,
+	type BaseGuildVoiceChannel,
 	type Channel,
 	type Collection,
 	ChannelType as DiscordChannelType,
@@ -92,9 +94,11 @@ import {
 	type ResolvedDiscordAccount,
 	resolveDefaultDiscordAccountId,
 } from "./accounts";
+import type { IDiscordAudioSink } from "./audio-sink";
 import type { ICompatRuntime } from "./compat";
 import { DISCORD_SERVICE_NAME } from "./constants";
 import type { ChannelDebouncer } from "./debouncer";
+import { DiscordVoiceTargetAudioSink } from "./discord-audio-sink";
 import {
 	handleGuildCreate as handleGuildCreateExtracted,
 	isGuildOnlyCommand,
@@ -143,6 +147,11 @@ import {
 	splitMessage,
 } from "./utils";
 import { VoiceManager } from "./voice";
+import {
+	type DiscordVoiceTarget,
+	type DiscordVoiceTargetRegistration,
+	DiscordVoiceTargetRegistry,
+} from "./voice-target-registry";
 
 const DISCORD_SNOWFLAKE_PATTERN = /^\d{15,20}$/;
 type MessageConnectorRegistration = Parameters<
@@ -164,6 +173,13 @@ type DiscordAccountServiceFacade = IDiscordService &
 		addAllowedChannel(channelId: string): boolean;
 		removeAllowedChannel(channelId: string): boolean;
 		getAllowedChannels(): string[];
+		registerVoiceTarget(target: DiscordVoiceTargetRegistration): void;
+		unregisterVoiceTarget(
+			accountId: string,
+			guildId: string,
+			channelId: string,
+		): void;
+		isVoiceChannelClaimed(guildId: string, channelId: string): boolean;
 	};
 
 // Forward Content.metadata onto the persisted Memory (e.g. `transient: true`
@@ -478,6 +494,8 @@ export class DiscordService extends Service implements IDiscordService {
 	public accountId: string = DEFAULT_ACCOUNT_ID;
 	private defaultAccountId = DEFAULT_ACCOUNT_ID;
 	private readonly accountPool = new DiscordAccountClientPool();
+	private readonly voiceTargets = new DiscordVoiceTargetRegistry();
+	private readonly audioSinks = new Map<string, IDiscordAudioSink>();
 	client: DiscordJsClient | null = null;
 	character: Character;
 	discordSettings: DiscordSettings;
@@ -1004,6 +1022,194 @@ export class DiscordService extends Service implements IDiscordService {
 		return requested === defaultAccountId ? (this.client ?? null) : null;
 	}
 
+	public getVoiceTargets(query?: {
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}): DiscordVoiceTarget[] {
+		const targets = this.voiceTargets.list();
+		if (!query) {
+			return targets;
+		}
+		return targets.filter((target) => {
+			if (
+				query.accountId &&
+				target.accountId !== normalizeAccountId(query.accountId)
+			) {
+				return false;
+			}
+			if (query.guildId && target.guildId !== query.guildId) {
+				return false;
+			}
+			if (query.channelId && target.channelId !== query.channelId) {
+				return false;
+			}
+			return true;
+		});
+	}
+
+	public getVoiceTarget(query: {
+		targetId?: string | null;
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}): DiscordVoiceTarget | null {
+		if (query.targetId) {
+			return this.voiceTargets.get(query.targetId);
+		}
+		return this.voiceTargets.find({
+			accountId: query.accountId
+				? normalizeAccountId(query.accountId)
+				: undefined,
+			guildId: query.guildId,
+			channelId: query.channelId,
+		});
+	}
+
+	public getAudioSink(query: {
+		targetId?: string | null;
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}): IDiscordAudioSink | null {
+		const target = this.getVoiceTarget(query);
+		if (!target) {
+			return null;
+		}
+		const existing = this.audioSinks.get(target.id);
+		if (existing) {
+			return existing;
+		}
+		const sink = new DiscordVoiceTargetAudioSink(target);
+		this.audioSinks.set(target.id, sink);
+		return sink;
+	}
+
+	public async setListeningActivity(
+		activity: string,
+		options?: { accountId?: string | null; url?: string },
+	): Promise<boolean> {
+		const accountId = normalizeAccountId(
+			options?.accountId ?? this.defaultAccountId,
+		);
+		const client = this.getClient(accountId);
+		if (!client?.isReady() || !client.user) {
+			this.runtime.logger.warn(
+				{ src: "plugin:discord", agentId: this.runtime.agentId, accountId },
+				"Cannot set Discord listening activity before client is ready",
+			);
+			return false;
+		}
+		await client.user.setActivity(activity, {
+			type: ActivityType.Listening,
+			url: options?.url,
+		});
+		return true;
+	}
+
+	public async clearActivity(options?: {
+		accountId?: string | null;
+	}): Promise<boolean> {
+		const accountId = normalizeAccountId(
+			options?.accountId ?? this.defaultAccountId,
+		);
+		const client = this.getClient(accountId);
+		if (!client?.isReady() || !client.user) {
+			this.runtime.logger.warn(
+				{ src: "plugin:discord", agentId: this.runtime.agentId, accountId },
+				"Cannot clear Discord activity before client is ready",
+			);
+			return false;
+		}
+		client.user.setPresence({ activities: [] });
+		return true;
+	}
+
+	public async setVoiceChannelStatus(
+		channelId: string,
+		status: string,
+		options?: { accountId?: string | null },
+	): Promise<boolean> {
+		const accountId = normalizeAccountId(
+			options?.accountId ?? this.defaultAccountId,
+		);
+		const client = this.getClient(accountId);
+		if (!client?.isReady()) {
+			this.runtime.logger.warn(
+				{ src: "plugin:discord", agentId: this.runtime.agentId, accountId },
+				"Cannot set Discord voice channel status before client is ready",
+			);
+			return false;
+		}
+
+		const channel = await client.channels.fetch(channelId);
+		if (!channel?.isVoiceBased?.()) {
+			this.runtime.logger.warn(
+				{
+					src: "plugin:discord",
+					agentId: this.runtime.agentId,
+					accountId,
+					channelId,
+				},
+				"Discord channel is not a voice channel",
+			);
+			return false;
+		}
+
+		const voiceChannel = channel as BaseGuildVoiceChannel;
+		const normalizedStatus = status.trim().slice(0, 500);
+		await client.rest.put(`/channels/${voiceChannel.id}/voice-status`, {
+			body: {
+				status: normalizedStatus || null,
+			},
+		});
+		return true;
+	}
+
+	private registerVoiceTarget(target: DiscordVoiceTargetRegistration): void {
+		this.voiceTargets.register({
+			...target,
+			accountId: normalizeAccountId(target.accountId),
+		});
+		this.runtime.logger.debug(
+			{
+				src: "plugin:discord",
+				agentId: this.runtime.agentId,
+				accountId: target.accountId,
+				guildId: target.channel.guild.id,
+				channelId: target.channel.id,
+			},
+			"Registered Discord voice target",
+		);
+	}
+
+	private unregisterVoiceTarget(
+		accountId: string,
+		guildId: string,
+		channelId: string,
+	): void {
+		const normalizedAccountId = normalizeAccountId(accountId);
+		const target = this.voiceTargets.find({
+			accountId: normalizedAccountId,
+			guildId,
+			channelId,
+		});
+		if (target) {
+			this.audioSinks.get(target.id)?.destroy();
+			this.audioSinks.delete(target.id);
+		}
+		this.voiceTargets.unregister(normalizedAccountId, guildId, channelId);
+	}
+
+	private isVoiceChannelClaimed(guildId: string, channelId: string): boolean {
+		return this.voiceTargets
+			.list()
+			.some(
+				(target) =>
+					target.guildId === guildId && target.channelId === channelId,
+			);
+	}
+
 	public getAccountLabel(accountId?: string | null): string {
 		const state = this.getAccountState(accountId);
 		return state?.account.name ?? state?.accountId ?? this.defaultAccountId;
@@ -1137,6 +1343,15 @@ export class DiscordService extends Service implements IDiscordService {
 			removeAllowedChannel: (channelId: string) =>
 				parent.removeAllowedChannel(channelId, state?.accountId),
 			getAllowedChannels: () => parent.getAllowedChannels(state?.accountId),
+			registerVoiceTarget: (target: DiscordVoiceTargetRegistration) =>
+				parent.registerVoiceTarget(target),
+			unregisterVoiceTarget: (
+				targetAccountId: string,
+				guildId: string,
+				channelId: string,
+			) => parent.unregisterVoiceTarget(targetAccountId, guildId, channelId),
+			isVoiceChannelClaimed: (guildId: string, channelId: string) =>
+				parent.isVoiceChannelClaimed(guildId, channelId),
 			resolveDiscordEntityId: (userId: string) =>
 				parent.resolveDiscordEntityId(userId),
 			getChannelType: (channel: Channel) => parent.getChannelType(channel),
@@ -2654,10 +2869,20 @@ export class DiscordService extends Service implements IDiscordService {
 		readyClient: DiscordJsClient<true>,
 	) {
 		const state = this.requireAccountState(accountId);
-		return onReadyExtracted(
-			this.createAccountServiceFacade(state),
-			readyClient,
-		);
+		await onReadyExtracted(this.createAccountServiceFacade(state), readyClient);
+		const voiceChannelIds = String(
+			this.runtime.getSetting("DISCORD_VOICE_CHANNEL_ID") ?? "",
+		)
+			.split(",")
+			.map((id) => id.trim())
+			.filter(Boolean);
+		if (voiceChannelIds.length > 0 && state.voiceManager) {
+			const guilds = await readyClient.guilds.fetch();
+			for (const [, guild] of guilds) {
+				const fullGuild = await guild.fetch();
+				await state.voiceManager.scanGuild(fullGuild);
+			}
+		}
 	}
 
 	/**
@@ -3333,6 +3558,7 @@ export class DiscordService extends Service implements IDiscordService {
 		for (const state of states) {
 			try {
 				state.voiceManager?.stop();
+				this.voiceTargets.unregisterAccount(state.accountId);
 			} catch (error) {
 				this.runtime.logger.warn(
 					`Discord voice cleanup failed: ${
@@ -3362,6 +3588,12 @@ export class DiscordService extends Service implements IDiscordService {
 				state.client = null;
 			}
 		}
+
+		for (const sink of this.audioSinks.values()) {
+			sink.destroy();
+		}
+		this.audioSinks.clear();
+		this.voiceTargets.clear();
 
 		this.accountPool.clear();
 		this.clientReadyPromise = null;

--- a/plugins/plugin-discord/types.ts
+++ b/plugins/plugin-discord/types.ts
@@ -21,6 +21,14 @@ import type {
 	User,
 	VoiceState,
 } from "discord.js";
+import type {
+	DiscordAudioSinkPlayOptions,
+	IDiscordAudioSink,
+} from "./audio-sink";
+import type {
+	DiscordVoicePlaybackOptions,
+	DiscordVoiceTarget,
+} from "./voice-target-registry";
 
 /**
  * Discord-specific event types
@@ -218,7 +226,41 @@ export interface IDiscordService {
 		message: Message,
 		options?: BuildMemoryFromMessageOptions,
 	) => Promise<Memory | null>;
+	getVoiceTargets?: (query?: {
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}) => DiscordVoiceTarget[];
+	getVoiceTarget?: (query: {
+		targetId?: string | null;
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}) => DiscordVoiceTarget | null;
+	getAudioSink?: (query: {
+		targetId?: string | null;
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}) => IDiscordAudioSink | null;
+	setListeningActivity?: (
+		activity: string,
+		options?: { accountId?: string | null; url?: string },
+	) => Promise<boolean>;
+	clearActivity?: (options?: { accountId?: string | null }) => Promise<boolean>;
+	setVoiceChannelStatus?: (
+		channelId: string,
+		status: string,
+		options?: { accountId?: string | null },
+	) => Promise<boolean>;
 }
+
+export type {
+	DiscordAudioSinkPlayOptions,
+	DiscordVoicePlaybackOptions,
+	DiscordVoiceTarget,
+	IDiscordAudioSink,
+};
 
 export const DISCORD_SERVICE_NAME = "discord";
 

--- a/plugins/plugin-discord/voice-target-registry.ts
+++ b/plugins/plugin-discord/voice-target-registry.ts
@@ -1,0 +1,137 @@
+import type { Readable } from "node:stream";
+import type { BaseGuildVoiceChannel } from "discord.js";
+import type { DiscordAudioLane, DiscordAudioLaneConfig } from "./audio-lanes";
+import type {
+	DiscordAudioPlaybackHandle,
+	DiscordAudioSinkPlayOptions,
+	DiscordAudioSinkStatus,
+} from "./audio-sink";
+
+export interface DiscordVoicePlaybackOptions
+	extends DiscordAudioSinkPlayOptions {
+	lane?: DiscordAudioLane;
+}
+
+export interface DiscordVoiceTarget {
+	id: string;
+	accountId: string;
+	botId: string;
+	botAlias?: string;
+	guildId: string;
+	guildName?: string;
+	channelId: string;
+	channelName: string;
+	play(
+		stream: Readable,
+		options?: DiscordVoicePlaybackOptions,
+	): Promise<DiscordAudioPlaybackHandle>;
+	stop(lane?: DiscordAudioLane): Promise<void>;
+	getStatus(): DiscordAudioSinkStatus;
+	getLaneConfig(lane?: DiscordAudioLane): DiscordAudioLaneConfig;
+}
+
+export interface DiscordVoiceTargetRegistration {
+	accountId: string;
+	botId: string;
+	botAlias?: string;
+	channel: BaseGuildVoiceChannel;
+	play(
+		stream: Readable,
+		options?: DiscordVoicePlaybackOptions,
+	): Promise<DiscordAudioPlaybackHandle>;
+	stop(lane?: DiscordAudioLane): Promise<void>;
+	getStatus(): DiscordAudioSinkStatus;
+	getLaneConfig(lane?: DiscordAudioLane): DiscordAudioLaneConfig;
+}
+
+export class DiscordVoiceTargetRegistry {
+	private readonly targets = new Map<string, DiscordVoiceTarget>();
+
+	register(registration: DiscordVoiceTargetRegistration): DiscordVoiceTarget {
+		const { channel } = registration;
+		const id = DiscordVoiceTargetRegistry.makeId(
+			registration.accountId,
+			channel.guild.id,
+			channel.id,
+		);
+		const target: DiscordVoiceTarget = {
+			id,
+			accountId: registration.accountId,
+			botId: registration.botId,
+			botAlias: registration.botAlias,
+			guildId: channel.guild.id,
+			guildName: channel.guild.name,
+			channelId: channel.id,
+			channelName: channel.name,
+			play: registration.play,
+			stop: registration.stop,
+			getStatus: registration.getStatus,
+			getLaneConfig: registration.getLaneConfig,
+		};
+		this.targets.set(id, target);
+		return target;
+	}
+
+	unregister(accountId: string, guildId: string, channelId: string): void {
+		this.targets.delete(
+			DiscordVoiceTargetRegistry.makeId(accountId, guildId, channelId),
+		);
+	}
+
+	unregisterAccount(accountId: string): void {
+		for (const [id, target] of this.targets) {
+			if (target.accountId === accountId) {
+				this.targets.delete(id);
+			}
+		}
+	}
+
+	get(targetId: string): DiscordVoiceTarget | null {
+		return this.targets.get(targetId) ?? null;
+	}
+
+	find(query: {
+		accountId?: string | null;
+		guildId?: string | null;
+		channelId?: string | null;
+	}): DiscordVoiceTarget | null {
+		if (query.accountId && query.guildId && query.channelId) {
+			return (
+				this.targets.get(
+					DiscordVoiceTargetRegistry.makeId(
+						query.accountId,
+						query.guildId,
+						query.channelId,
+					),
+				) ?? null
+			);
+		}
+
+		return (
+			this.list().find((target) => {
+				if (query.accountId && target.accountId !== query.accountId) {
+					return false;
+				}
+				if (query.guildId && target.guildId !== query.guildId) {
+					return false;
+				}
+				if (query.channelId && target.channelId !== query.channelId) {
+					return false;
+				}
+				return true;
+			}) ?? null
+		);
+	}
+
+	list(): DiscordVoiceTarget[] {
+		return Array.from(this.targets.values());
+	}
+
+	clear(): void {
+		this.targets.clear();
+	}
+
+	static makeId(accountId: string, guildId: string, channelId: string): string {
+		return `${accountId}:${guildId}:${channelId}`;
+	}
+}

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -28,6 +28,17 @@ import {
 	type VoiceState,
 } from "discord.js";
 import prism from "prism-media";
+import {
+	DEFAULT_DISCORD_AUDIO_LANES,
+	type DiscordAudioLane,
+	type DiscordAudioLaneConfig,
+	getDiscordAudioLaneConfig,
+	normalizeDiscordAudioLane,
+} from "./audio-lanes";
+import type {
+	DiscordAudioPlaybackHandle,
+	DiscordAudioSinkStatus,
+} from "./audio-sink";
 // See service.ts for detailed documentation on Discord ID handling.
 // Key point: Discord snowflake IDs (e.g., "1253563208833433701") are NOT valid UUIDs.
 // Use stringToUuid() to convert them, not asUUID() which would throw an error.
@@ -46,6 +57,22 @@ const DECODE_FRAME_SIZE = 1024;
 const DECODE_SAMPLE_RATE = 16000;
 
 type DiscordVoiceModule = typeof import("@discordjs/voice");
+
+interface LanePlayerState {
+	player: AudioPlayer;
+	lane: DiscordAudioLane;
+	guildId: string;
+	channelId: string;
+	finished: () => void;
+	cancelled: () => void;
+	abortController: AbortController;
+	volume?: {
+		setVolume(volume: number): void;
+		volume?: number;
+	};
+	originalVolume?: number;
+	duckedBy?: DiscordAudioLane;
+}
 
 let discordVoiceModulePromise: Promise<DiscordVoiceModule> | null = null;
 
@@ -303,8 +330,37 @@ export class VoiceManager extends EventEmitter {
 	private runtime: ICompatRuntime;
 	private accountId: string;
 	private resolveDiscordEntityId?: (userId: string) => UUID;
+	private registerVoiceTarget?: (target: {
+		accountId: string;
+		botId: string;
+		botAlias?: string;
+		channel: BaseGuildVoiceChannel;
+		play: (
+			stream: Readable,
+			options?: {
+				lane?: DiscordAudioLane;
+				interrupt?: boolean;
+				mix?: boolean;
+				signal?: AbortSignal;
+			},
+		) => Promise<DiscordAudioPlaybackHandle>;
+		stop: (lane?: DiscordAudioLane) => Promise<void>;
+		getStatus: () => DiscordAudioSinkStatus;
+		getLaneConfig: (lane?: DiscordAudioLane) => DiscordAudioLaneConfig;
+	}) => void;
+	private unregisterVoiceTarget?: (
+		accountId: string,
+		guildId: string,
+		channelId: string,
+	) => void;
+	private isVoiceChannelClaimed?: (
+		guildId: string,
+		channelId: string,
+	) => boolean;
 	private streams: Map<string, Readable> = new Map();
 	private connections: Map<string, VoiceConnection> = new Map();
+	private audioLanes = new Map<string, DiscordAudioLaneConfig>();
+	private lanePlayers = new Map<string, LanePlayerState>();
 	private activeMonitors: Map<
 		string,
 		{ channel: BaseGuildVoiceChannel; monitor: AudioMonitor }
@@ -327,6 +383,30 @@ export class VoiceManager extends EventEmitter {
 	constructor(
 		service: Pick<IDiscordService, "accountId" | "client"> & {
 			resolveDiscordEntityId?: (userId: string) => UUID;
+			registerVoiceTarget?: (target: {
+				accountId: string;
+				botId: string;
+				botAlias?: string;
+				channel: BaseGuildVoiceChannel;
+				play: (
+					stream: Readable,
+					options?: {
+						lane?: DiscordAudioLane;
+						interrupt?: boolean;
+						mix?: boolean;
+						signal?: AbortSignal;
+					},
+				) => Promise<DiscordAudioPlaybackHandle>;
+				stop: (lane?: DiscordAudioLane) => Promise<void>;
+				getStatus: () => DiscordAudioSinkStatus;
+				getLaneConfig: (lane?: DiscordAudioLane) => DiscordAudioLaneConfig;
+			}) => void;
+			unregisterVoiceTarget?: (
+				accountId: string,
+				guildId: string,
+				channelId: string,
+			) => void;
+			isVoiceChannelClaimed?: (guildId: string, channelId: string) => boolean;
 		},
 		runtime: ICompatRuntime,
 	) {
@@ -335,7 +415,13 @@ export class VoiceManager extends EventEmitter {
 		this.runtime = runtime;
 		this.accountId = service.accountId ?? "default";
 		this.resolveDiscordEntityId = service.resolveDiscordEntityId;
+		this.registerVoiceTarget = service.registerVoiceTarget;
+		this.unregisterVoiceTarget = service.unregisterVoiceTarget;
+		this.isVoiceChannelClaimed = service.isVoiceChannelClaimed;
 		this.ready = false;
+		for (const lane of Object.values(DEFAULT_DISCORD_AUDIO_LANES)) {
+			this.audioLanes.set(lane.lane, lane);
+		}
 
 		if (this.client) {
 			this.client.on("voiceManagerReady", () => {
@@ -434,6 +520,11 @@ export class VoiceManager extends EventEmitter {
 
 		this.connections.clear();
 		this.streams.clear();
+		for (const state of this.lanePlayers.values()) {
+			this.cleanupAudioPlayer(state.player);
+			state.abortController.abort();
+		}
+		this.lanePlayers.clear();
 		this.userStates.clear();
 		this.processingVoice = false;
 		this.cleanupAudioPlayer(this.activeAudioPlayer);
@@ -501,7 +592,15 @@ export class VoiceManager extends EventEmitter {
 		const oldConnection = this.getVoiceConnection(channel.guildId as string);
 		if (oldConnection) {
 			try {
+				const oldChannelId = oldConnection.joinConfig.channelId;
 				oldConnection.destroy();
+				if (oldChannelId) {
+					this.unregisterVoiceTarget?.(
+						this.accountId,
+						channel.guild.id,
+						oldChannelId,
+					);
+				}
 				// Remove all associated streams and monitors
 				this.streams.clear();
 				this.activeMonitors.clear();
@@ -592,9 +691,19 @@ export class VoiceManager extends EventEmitter {
 						);
 						connection.destroy();
 						this.connections.delete(channel.id);
+						this.unregisterVoiceTarget?.(
+							this.accountId,
+							channel.guild.id,
+							channel.id,
+						);
 					}
 				} else if (newState.status === VoiceConnectionStatus.Destroyed) {
 					this.connections.delete(channel.id);
+					this.unregisterVoiceTarget?.(
+						this.accountId,
+						channel.guild.id,
+						channel.id,
+					);
 					void this.stopVoiceTranscription(channel.id, "normal_completion");
 				} else if (
 					!this.connections.has(channel.id) &&
@@ -626,6 +735,27 @@ export class VoiceManager extends EventEmitter {
 
 			// Store the connection
 			this.connections.set(channel.id, connection);
+			const botId = this.client?.user?.id;
+			if (botId) {
+				this.registerVoiceTarget?.({
+					accountId: this.accountId,
+					botId,
+					botAlias: this.accountId,
+					channel,
+					play: (stream, options) =>
+						this.playAudio(stream, {
+							...options,
+							guildId: channel.guild.id,
+							channelId: channel.id,
+						}),
+					stop: (lane) => this.stopAudio(channel.guild.id, lane),
+					getStatus: () =>
+						this.getVoiceConnection(channel.guild.id)
+							? "connected"
+							: "disconnected",
+					getLaneConfig: (lane) => this.getAudioLaneConfig(lane),
+				});
+			}
 
 			// Voice-channel transcription (DISCORD_VOICE_TRANSCRIPTS / /transcribe)
 			if (this.isVoiceTranscriptionEnabled(channel.id)) {
@@ -1036,6 +1166,8 @@ export class VoiceManager extends EventEmitter {
 			connection.destroy();
 			this.connections.delete(channel.id);
 		}
+		this.unregisterVoiceTarget?.(this.accountId, channel.guild.id, channel.id);
+		void this.stopAudio(channel.guild.id);
 
 		// Stop monitoring all members in this channel
 		for (const [memberId, monitorInfo] of this.activeMonitors) {
@@ -1516,13 +1648,22 @@ export class VoiceManager extends EventEmitter {
 		let chosenChannel: BaseGuildVoiceChannel | null = null;
 
 		try {
-			const channelId = this.runtime.getSetting(
-				"DISCORD_VOICE_CHANNEL_ID",
-			) as string;
-			if (channelId) {
-				const channel = await guild.channels.fetch(channelId);
-				if (channel?.isVoiceBased?.()) {
+			const channelIds = String(
+				this.runtime.getSetting("DISCORD_VOICE_CHANNEL_ID") ?? "",
+			)
+				.split(",")
+				.map((channelId) => channelId.trim())
+				.filter(Boolean);
+			for (const channelId of channelIds) {
+				const channel = await guild.channels.fetch(channelId).catch(() => null);
+				if (
+					channel?.isVoiceBased?.() &&
+					channel.guild.id === guild.id &&
+					!this.getVoiceConnection(guild.id) &&
+					!this.isVoiceChannelClaimed?.(guild.id, channel.id)
+				) {
 					chosenChannel = channel as BaseGuildVoiceChannel;
+					break;
 				}
 			}
 
@@ -1571,6 +1712,274 @@ export class VoiceManager extends EventEmitter {
 				},
 				"Error selecting or joining a voice channel",
 			);
+		}
+	}
+
+	registerAudioLane(config: DiscordAudioLaneConfig): void {
+		this.audioLanes.set(normalizeDiscordAudioLane(config.lane), {
+			...config,
+			lane: normalizeDiscordAudioLane(config.lane),
+		});
+	}
+
+	getAudioLaneConfig(lane?: DiscordAudioLane | null): DiscordAudioLaneConfig {
+		return getDiscordAudioLaneConfig(this.audioLanes, lane);
+	}
+
+	private getLanePlayerKey(
+		guildId: string,
+		lane?: DiscordAudioLane | null,
+	): string {
+		return `${guildId}:${normalizeDiscordAudioLane(lane)}`;
+	}
+
+	private stopLanePlayer(
+		guildId: string,
+		lane?: DiscordAudioLane | null,
+		options?: { cancel?: boolean },
+	): void {
+		const normalizedLane = normalizeDiscordAudioLane(lane);
+		const key = this.getLanePlayerKey(guildId, normalizedLane);
+		const state = this.lanePlayers.get(key);
+		if (!state) {
+			return;
+		}
+		this.lanePlayers.delete(key);
+		this.cleanupAudioPlayer(state.player);
+		if (options?.cancel !== false && !state.abortController.signal.aborted) {
+			state.abortController.abort();
+			state.cancelled();
+		}
+		this.restoreDuckedLanes(guildId, normalizedLane);
+	}
+
+	private applyLanePriority(
+		guildId: string,
+		nextLane: DiscordAudioLane,
+		mix: boolean,
+	): void {
+		const nextConfig = this.getAudioLaneConfig(nextLane);
+		for (const state of this.lanePlayers.values()) {
+			if (state.guildId !== guildId || state.lane === nextLane) {
+				continue;
+			}
+			const activeConfig = this.getAudioLaneConfig(state.lane);
+			if (
+				nextConfig.priority <= activeConfig.priority ||
+				!activeConfig.interruptible
+			) {
+				continue;
+			}
+
+			if (mix && activeConfig.duckVolume !== undefined && state.volume) {
+				state.originalVolume = state.volume.volume ?? activeConfig.volume;
+				state.duckedBy = nextLane;
+				state.volume.setVolume(activeConfig.duckVolume);
+				this.emit("audio:ducked", {
+					guildId,
+					lane: state.lane,
+					by: nextLane,
+				});
+				continue;
+			}
+
+			this.stopLanePlayer(guildId, state.lane);
+			this.emit("audio:interrupted", {
+				guildId,
+				lane: state.lane,
+				by: nextLane,
+			});
+		}
+	}
+
+	private restoreDuckedLanes(
+		guildId: string,
+		finishedLane: DiscordAudioLane,
+	): void {
+		for (const state of this.lanePlayers.values()) {
+			if (
+				state.guildId !== guildId ||
+				state.duckedBy !== finishedLane ||
+				!state.volume ||
+				state.originalVolume === undefined
+			) {
+				continue;
+			}
+			state.volume.setVolume(state.originalVolume);
+			state.originalVolume = undefined;
+			state.duckedBy = undefined;
+			this.emit("audio:restored", { guildId, lane: state.lane });
+		}
+	}
+
+	async playAudio(
+		audioStream: Readable,
+		options?: {
+			guildId?: string;
+			channelId?: string;
+			lane?: DiscordAudioLane;
+			interrupt?: boolean;
+			mix?: boolean;
+			signal?: AbortSignal;
+		},
+	): Promise<DiscordAudioPlaybackHandle> {
+		const guildId = options?.guildId;
+		if (!guildId) {
+			throw new Error("Discord voice playback requires a guildId");
+		}
+		const connection = this.getVoiceConnection(guildId);
+		if (!connection) {
+			throw new Error(`No Discord voice connection for guild ${guildId}`);
+		}
+
+		const lane = normalizeDiscordAudioLane(options?.lane);
+		const laneConfig = this.getAudioLaneConfig(lane);
+		const key = this.getLanePlayerKey(guildId, lane);
+		if (options?.interrupt !== false) {
+			this.stopLanePlayer(guildId, lane);
+		}
+		this.applyLanePriority(guildId, lane, options?.mix ?? false);
+
+		const {
+			createAudioPlayer,
+			createAudioResource,
+			demuxProbe,
+			NoSubscriberBehavior,
+			StreamType,
+		} = await loadDiscordVoiceModule();
+
+		const abortController = new AbortController();
+		const abortFromParent = () => abortController.abort();
+		if (options?.signal) {
+			if (options.signal.aborted) {
+				abortController.abort();
+			} else {
+				options.signal.addEventListener("abort", abortFromParent, {
+					once: true,
+				});
+			}
+		}
+
+		const audioPlayer = createAudioPlayer({
+			behaviors: {
+				noSubscriber: NoSubscriberBehavior.Pause,
+			},
+		});
+		let resourceStream = audioStream;
+		let inputType = StreamType.Arbitrary;
+		try {
+			const probe = await demuxProbe(audioStream);
+			resourceStream = probe.stream;
+			inputType = probe.type;
+		} catch (error) {
+			this.runtime.logger.debug(
+				{
+					src: "plugin:discord:service:voice",
+					agentId: this.runtime.agentId,
+					guildId,
+					lane,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Discord audio stream probe failed; using arbitrary stream type",
+			);
+		}
+
+		const resource = createAudioResource(resourceStream, {
+			inputType,
+			inlineVolume: true,
+		});
+		resource.volume?.setVolume(laneConfig.volume);
+
+		const subscription = connection.subscribe(audioPlayer);
+		if (!subscription) {
+			throw new Error("Failed to subscribe Discord audio player");
+		}
+
+		let finishedResolver!: () => void;
+		let cancelledResolver!: () => void;
+		const finished = new Promise<void>((resolve) => {
+			finishedResolver = resolve;
+		});
+		const cancelled = new Promise<void>((resolve) => {
+			cancelledResolver = resolve;
+		});
+
+		const state: LanePlayerState = {
+			player: audioPlayer,
+			lane,
+			guildId,
+			channelId: options?.channelId ?? connection.joinConfig.channelId ?? "",
+			finished: finishedResolver,
+			cancelled: cancelledResolver,
+			abortController,
+			volume: resource.volume,
+		};
+		this.lanePlayers.set(key, state);
+
+		const cleanupParentAbort = () => {
+			options?.signal?.removeEventListener("abort", abortFromParent);
+		};
+		abortController.signal.addEventListener(
+			"abort",
+			() => {
+				this.stopLanePlayer(guildId, lane, { cancel: false });
+				cleanupParentAbort();
+				cancelledResolver();
+			},
+			{ once: true },
+		);
+
+		audioPlayer.on("error", (error: Error) => {
+			this.runtime.logger.error(
+				{
+					src: "plugin:discord:service:voice",
+					agentId: this.runtime.agentId,
+					guildId,
+					lane,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Discord audio lane playback error",
+			);
+			this.stopLanePlayer(guildId, lane, { cancel: false });
+			cleanupParentAbort();
+			cancelledResolver();
+			this.emit("audio:error", { guildId, lane, error });
+		});
+		audioPlayer.on(
+			"stateChange",
+			(_oldState: unknown, newState: { status: string }) => {
+				if (newState.status !== "idle") {
+					return;
+				}
+				this.stopLanePlayer(guildId, lane, { cancel: false });
+				cleanupParentAbort();
+				finishedResolver();
+				this.emit("audio:finished", { guildId, lane });
+			},
+		);
+
+		audioPlayer.play(resource);
+		this.emit("audio:started", { guildId, lane });
+
+		return {
+			finished,
+			cancelled,
+			abort: () => abortController.abort(),
+		};
+	}
+
+	async stopAudio(guildId: string, lane?: DiscordAudioLane): Promise<void> {
+		if (lane) {
+			this.stopLanePlayer(guildId, lane);
+			this.emit("audio:stopped", { guildId, lane });
+			return;
+		}
+
+		for (const state of [...this.lanePlayers.values()]) {
+			if (state.guildId === guildId) {
+				this.stopLanePlayer(guildId, state.lane);
+				this.emit("audio:stopped", { guildId, lane: state.lane });
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- add Discord audio lane defaults/contracts and a voice target registry
- wire VoiceManager to register account-scoped targets and lane-aware playback
- expose service APIs for voice targets, audio sinks, listening activity, and voice channel status
- add focused tests for lane defaults, target registry behavior, and sink destroy cleanup

## Validation

Refreshed 2026-07-03 on current `origin/develop`:

- `bunx vitest run plugins/plugin-discord/__tests__/audio-lanes.test.ts plugins/plugin-discord/__tests__/voice-target-registry.test.ts plugins/plugin-discord/__tests__/discord-audio-sink.test.ts`
- `bun run --cwd plugins/plugin-discord typecheck`
- `bunx @biomejs/biome check plugins/plugin-discord/index.ts plugins/plugin-discord/service.ts plugins/plugin-discord/types.ts plugins/plugin-discord/voice.ts plugins/plugin-discord/audio-lanes.ts plugins/plugin-discord/audio-sink.ts plugins/plugin-discord/discord-audio-sink.ts plugins/plugin-discord/voice-target-registry.ts plugins/plugin-discord/__tests__/audio-lanes.test.ts plugins/plugin-discord/__tests__/voice-target-registry.test.ts plugins/plugin-discord/__tests__/discord-audio-sink.test.ts`
- `git diff --check origin/develop..HEAD`

## Evidence blocker

This remains a draft until the Discord connector evidence required by `plugins/plugin-discord/CLAUDE.md` is captured: a real or sandbox Discord round-trip, raw inbound/outbound payloads, logs, screenshot/recording, multi-account voice target behavior, and the agent trajectory. This workspace does not currently have `DISCORD_API_TOKEN`, `DISCORD_APPLICATION_ID`, `DISCORD_TEST_CHANNEL_ID`, `DISCORD_BOT_TOKENS`, or `DISCORD_VOICE_CHANNEL_ID` configured.

## Notes

- Ported the PR #36 concepts into the 2.x service/account architecture rather than copying the 1.x actions/providers shape.
- This adds lane-aware priority playback and per-account voice target routing; true concurrent DSP mixing remains separate work.
- Review follow-up fixed sink cleanup so unregistering/destroying a target-backed audio sink stops active playback instead of leaving the target running.