### PR TITLE
fix(voice): diarizer IFGO cutover — fork reader sync pin + epoch-2 artifact republish (#11377)

### DIFF
--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/README.md
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/README.md
@@ -1,0 +1,88 @@
+# #11377 — diarizer IFGO cutover: reader sync + epoch-2 republish + pin bump
+
+Executes the corrected operator plan from the #11377 rebake-confirm thread
+(sibling bundle: `11377-diarizer-rebake-confirm/`). The DER-1.000 signature was
+proven to be pure artifact × reader LSTM gate-order skew: the published HF
+artifact was IOFC (epoch-less) matching the fork's vendored IOFC reader, while
+the packages-side converter + reader had moved to IFGO (+ the #11569
+fail-closed epoch guard). This change cuts everything over to IFGO in the
+required order.
+
+## What shipped
+
+1. **Fork reader sync** — elizaOS/llama.cpp#40 (metadata parsing + contract
+   test, MERGED) then elizaOS/llama.cpp#41 (MERGED): vendored
+   `tools/omnivoice/.../voice_diarizer.c` flipped to **IFGO** gate unpack +
+   ported the #11569 fail-closed guard (`converter_epoch >= 2` and
+   `lstm_gate_order == "IFGO"` required; epoch-less/IOFC artifacts rejected
+   loudly before tensor load). Contract test
+   `omnivoice-test-diarizer-metadata` → `failures=0`.
+2. **Epoch-2 IFGO artifact republished** — baked with the post-#11569
+   `voice_diarizer_to_gguf.py` from ungated
+   `onnx-community/pyannote-segmentation-3.0` (snapshot `733a93b6…`);
+   **bit-identical to the rebake-confirm session's bake**
+   (sha `100a5dbf…`, deterministic). Uploaded to HF `elizaos/eliza-1` as a NEW
+   file `voice/diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf`
+   (HF commit `a89e5615ad616f7bf6c4982cd9eed2805b90370f`); the old
+   `pyannote-segmentation-3.0.gguf` (`30983eba…`) is kept for older fused
+   libs; `voice/diarizer/SHA256SUMS` added additively covering both.
+   Round-trip download sha verified (`artifact-shas.txt`).
+3. **This PR** — submodule pin bump to fork commit `dda200ab0` (descendant of
+   develop's prior pin `58c0391eb`, so the #11612 Metal nil-pipeline +
+   has_bfloat fixes are retained), diarizer `0.3.0` manifest entry in
+   `packages/shared/src/local-inference/voice-models.ts`, probe-list updates,
+   this evidence bundle.
+
+## Environment
+
+macOS arm64 (M4 Max), CPU+Metal. Fused `libelizainference.dylib` built from
+fork commit `dda200ab0` (`cmake -DLLAMA_BUILD_OMNIVOICE=ON -DOMNIVOICE_SHARED=ON
+-DCMAKE_BUILD_TYPE=Release`, target `elizainference`). Baseline lib built the
+same way from `58c0391eb` (develop's prior pin). Real Kokoro corpus
+(af_bella/am_michael, 8 turns, 600 ms gaps), real WeSpeaker encoder, real
+fused diarizer — `speakeriso:real` (`scripts/speaker-isolation-real.ts`),
+`SPEAKER_ISO_REQUIRE=1`.
+
+## Results
+
+| lane | lib | diarizer GGUF | result |
+| --- | --- | --- | --- |
+| fixed pairing | IFGO lib (`dda200ab0`) | epoch-2 IFGO `100a5dbf` | **DER 0.211**, attribution 6/6 (margin 0.818), overlap probe localSpeakerCount=2 — **PASS** (`speakeriso-fixed-pairing.txt`) |
+| guard | IFGO lib (`dda200ab0`) | published IOFC `30983eba` | **REJECTED LOUDLY**: `[voice_diarizer] stale GGUF converter epoch 0; need >= 2 with LSTM gates packed as IFGO` → typed `VoiceLifecycleError` rc=-22, bench exit 1 — no silent scramble (`speakeriso-guard-rejects-published-iofc.txt`) |
+| kokoro smoke | IFGO lib | — | synth OK: 91800 samples @24 kHz, envelope-cv 1.229 (real speech). TTFA 6230–6894 ms exceeds the 700 ms mobile budget — **pre-existing on the baseline pin lib too (4876 ms, same cold-load failure), not a regression**; audio metrics identical across libs (`kokoro-smoke-new-lib.txt` vs `kokoro-smoke-baseline-pin-lib.txt`). Diff `58c0391eb..dda200ab0` touches only `tools/omnivoice` voice-classifier files — zero Kokoro code. |
+| asr smoke | IFGO lib | — | **PASS**, real transcript in 861 ms over Metal (`asr-smoke-new-lib-tail.txt`) |
+
+DER matrix vs the rebake-confirm bundle: skewed pairings 1.000 → fixed IFGO
+pairing **0.211** (identical to the IOFC/IOFC control lanes A/C at 0.209/0.211
+— the forward pass is equivalent; the skew was the only bug). The overlap
+probe deliberately plays both voices simultaneously; `localSpeakerCount=2,
+hasOverlap=true` matches passing lanes A/C exactly (the failure signature was
+`localSpeakerCount=3`).
+
+## Repro
+
+```bash
+# bake (deterministic; no token — ONNX source is ungated)
+python3 packages/native/plugins/voice-classifier-cpp/scripts/voice_diarizer_to_gguf.py \
+  --output /tmp/pyannote-segmentation-3.0-ifgo-epoch2.gguf   # sha 100a5dbf…
+
+# fused lib from the pinned fork commit
+git -C <llama.cpp fork> checkout dda200ab0
+cmake -B build-fused -S . -DLLAMA_BUILD_OMNIVOICE=ON -DOMNIVOICE_SHARED=ON \
+  -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_TOOLS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build-fused --target elizainference -j
+
+# bench (fixed pairing → PASS; swap ELIZA_DIARIZ_GGUF to the published
+# 30983eba artifact → loud guard rejection)
+cd plugins/plugin-local-inference
+SPEAKER_ISO_REQUIRE=1 \
+ELIZA_INFERENCE_LIBRARY=<build-fused>/bin/libelizainference.dylib \
+ELIZA_DIARIZ_GGUF=<epoch-2 bake> \
+ELIZA_SPEAKER_GGUF=<wespeaker-resnet34-lm.gguf> \
+ELIZA_KOKORO_MODEL_DIR=<eliza-1 bundle>/tts/kokoro \
+NODE_OPTIONS='--experimental-sqlite' bun scripts/speaker-isolation-real.ts
+
+# fork contract test
+cmake --build build-11377 --target omnivoice-test-diarizer-metadata -j
+./build-11377/bin/omnivoice-test-diarizer-metadata   # failures=0
+```

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/artifact-shas.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/artifact-shas.txt
@@ -1,0 +1,3 @@
+100a5dbfd480b0cd6b0e01f0a9974ba836412721dfa0e36b7c1bb5a041abfbde  /private/tmp/artifacts-11377/pyannote-segmentation-3.0-ifgo-epoch2.gguf
+100a5dbfd480b0cd6b0e01f0a9974ba836412721dfa0e36b7c1bb5a041abfbde  /private/tmp/artifacts-11377/hf-roundtrip.gguf
+30983eba41c0a99ab7eada564739ae8be74faeb21a31da759c870b5173cbd8a5  /Users/shawwalters/.eliza/local-inference/models/voice/diarizer/pyannote-segmentation-3.0.gguf

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/asr-smoke-new-lib-tail.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/asr-smoke-new-lib-tail.txt
@@ -1,0 +1,30 @@
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_pad_mask=1_ncpsg=64      0xc19ffaa00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_blk', name = 'kernel_flash_attn_ext_blk_nqptg=8_ncpsg=64'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_blk_nqptg=8_ncpsg=64      0xc19ffad00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk64_dv64', name = 'kernel_flash_attn_ext_f16_dk64_dv64_mask=1_sinks=0_bias=0_scap=0_kvpad=1_bcm=1_ns10=64_ns20=64_nsg=4'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk64_dv64_mask=1_sinks=0_bias=0_scap=0_kvpad=1_bcm=1_ns10=64_ns20=64_nsg=4      0xc19ffb000 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_norm_f32_4', name = 'kernel_norm_f32_4'
+ggml_metal_library_compile_pipeline: loaded kernel_norm_f32_4                             0xc19ffb300 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=0_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=2_nf=1_rb=0_cb=0      0xc19ffb600 | th_max = 1024 | th_width =   32
+audio slice encoded in 49 ms
+decoding audio batch 1/1, n_tokens_batch = 225
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_flash_attn_ext_f16_dk128_dv128', name = 'kernel_flash_attn_ext_f16_dk128_dv128_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=1024_ns20=1024_nsg=4'
+ggml_metal_library_compile_pipeline: loaded kernel_flash_attn_ext_f16_dk128_dv128_mask=1_sinks=0_bias=0_scap=0_kvpad=0_bcm=1_ns10=1024_ns20=1024_nsg=4      0xc19ffb900 | th_max = 1024 | th_width =   32
+audio decoded (batch 1/1) in 1 ms
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_get_rows_f32', name = 'kernel_get_rows_f32'
+ggml_metal_library_compile_pipeline: loaded kernel_get_rows_f32                           0xc19ffbc00 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_bin_fuse_f32_f32_f32_4', name = 'kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=1_cb=0'
+ggml_metal_library_compile_pipeline: loaded kernel_bin_fuse_f32_f32_f32_4_op=0_nf=1_rb=1_cb=0      0xc192e4000 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_q4_K_f32', name = 'kernel_mul_mv_q4_K_f32_nsg=2_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_q4_K_f32_nsg=2_ne12=1_r2=1_r3=1      0xc192e4300 | th_max = 1024 | th_width =   32
+ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_mul_mv_q6_K_f32', name = 'kernel_mul_mv_q6_K_f32_nsg=2_ne12=1_r2=1_r3=1'
+ggml_metal_library_compile_pipeline: loaded kernel_mul_mv_q6_K_f32_nsg=2_ne12=1_r2=1_r3=1      0xc192e4600 | th_max = 1024 | th_width =   32
+[asr-real-smoke] (861ms) "If you go into different cultures, they have different concepts of creation. They have their own creation story and of what an afterlife is, where you go, what you do, who you're gonna be with. People who say, "Well.""
+[asr-real-smoke] words=39 sentences≈3
+[asr-real-smoke] PASS
+ggml_metal_free: deallocating
+~llama_context:       MTL0 compute buffer size is 300.7500 MiB, matches expectation of 300.7500 MiB
+~llama_context:        CPU compute buffer size is  20.0195 MiB, matches expectation of  20.0195 MiB
+~llama_context:        CPU compute buffer size is   0.0000 MiB, matches expectation of   0.0000 MiB
+ggml_metal_free: deallocating

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/kokoro-smoke-baseline-pin-lib.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/kokoro-smoke-baseline-pin-lib.txt
@@ -1,0 +1,10 @@
+[kokoro] default voice af_same preset not staged at /Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle/tts/kokoro/voices/af_same.bin — falling back to af_bella. Run packages/training/scripts/voice/samantha_lora/RUNBOOK.md to produce a real Samantha preset.
+[kokoro-real-smoke] lib=/private/tmp/llama-baseline-58c/build-fused/bin/libelizainference.dylib (ABI v12)
+[kokoro-real-smoke] model=kokoro-82m-v1_0-Q4_K_M.gguf voice=af_bella
+ Info       [voice/kokoro] runtime backend=ffi reason="model layout default → ffi (in-process fused libelizainference)"
+[kokoro] using phonemizer=phonemizer
+ Info       [KokoroFfiRuntime] loaded Eliza-1 voice af_bella from /Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle/tts/kokoro/voices/af_bella.bin
+[kokoro-real-smoke] synthesized 91800 samples @ 24000Hz (3.83s), TTFA=4876ms
+[kokoro-real-smoke] envelope-cv 1.229 (speech ≫0.4, noise ≈0)
+[kokoro-real-smoke] WARN: ELIZA_ASR_BUNDLE not set — audio CORRECTNESS is UNVERIFIED (non-empty PCM only). Set it to a dir with asr/eliza-1-asr.gguf + -mmproj.gguf to gate intelligibility (WER).
+[kokoro-real-smoke] FAIL: TTFA 4876ms exceeds the mobile budget 700ms

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/kokoro-smoke-new-lib.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/kokoro-smoke-new-lib.txt
@@ -1,0 +1,10 @@
+[kokoro] default voice af_same preset not staged at /Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle/tts/kokoro/voices/af_same.bin — falling back to af_bella. Run packages/training/scripts/voice/samantha_lora/RUNBOOK.md to produce a real Samantha preset.
+[kokoro-real-smoke] lib=/private/tmp/llama-cpp-11377/build-fused/bin/libelizainference.dylib (ABI v12)
+[kokoro-real-smoke] model=kokoro-82m-v1_0-Q4_K_M.gguf voice=af_bella
+ Info       [voice/kokoro] runtime backend=ffi reason="model layout default → ffi (in-process fused libelizainference)"
+[kokoro] using phonemizer=phonemizer
+ Info       [KokoroFfiRuntime] loaded Eliza-1 voice af_bella from /Users/shawwalters/.eliza/local-inference/models/eliza-1-2b.bundle/tts/kokoro/voices/af_bella.bin
+[kokoro-real-smoke] synthesized 91800 samples @ 24000Hz (3.83s), TTFA=6230ms
+[kokoro-real-smoke] envelope-cv 1.229 (speech ≫0.4, noise ≈0)
+[kokoro-real-smoke] WARN: ELIZA_ASR_BUNDLE not set — audio CORRECTNESS is UNVERIFIED (non-empty PCM only). Set it to a dir with asr/eliza-1-asr.gguf + -mmproj.gguf to gate intelligibility (WER).
+[kokoro-real-smoke] FAIL: TTFA 6230ms exceeds the mobile budget 700ms

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/speaker-isolation-fixed-pairing.json
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/speaker-isolation-fixed-pairing.json
@@ -1,0 +1,129 @@
+{
+	"schemaVersion": 1,
+	"generatedAt": "2026-07-03T03:18:21.562Z",
+	"host": "darwin-arm64",
+	"lib": "/private/tmp/llama-cpp-11377/build-fused/bin/libelizainference.dylib",
+	"diarizGguf": "/private/tmp/artifacts-11377/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+	"speakerGguf": "/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
+	"thresholds": {
+		"minAccuracy": 0.8,
+		"maxDer": 0.6
+	},
+	"attribution": {
+		"scored": 6,
+		"correct": 6,
+		"accuracy": 1,
+		"intraMean": 0.16156001436258177,
+		"interMean": 0.9797653087401397,
+		"margin": 0.818205294377558,
+		"perTurn": [
+			{
+				"id": "turn-03",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.20738247779699748,
+				"distanceToNearestOther": 1.0016068914472878
+			},
+			{
+				"id": "turn-04",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.14791372673837944,
+				"distanceToNearestOther": 0.9793492395986751
+			},
+			{
+				"id": "turn-05",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.16652357563572295,
+				"distanceToNearestOther": 1.0071049153411324
+			},
+			{
+				"id": "turn-06",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.13747552817222486,
+				"distanceToNearestOther": 0.973614542404049
+			},
+			{
+				"id": "turn-07",
+				"speaker": "A",
+				"attributed": "A",
+				"correct": true,
+				"distanceToOwn": 0.19453925316067588,
+				"distanceToNearestOther": 0.9631769423660261
+			},
+			{
+				"id": "turn-08",
+				"speaker": "B",
+				"attributed": "B",
+				"correct": true,
+				"distanceToOwn": 0.11552552467149002,
+				"distanceToNearestOther": 0.9537393212836681
+			}
+		]
+	},
+	"mfccAccuracy": 0.5,
+	"der": {
+		"der": 0.2106782106782107,
+		"missedMs": 7300,
+		"falseAlarmMs": 0,
+		"confusionMs": 0,
+		"totalReferenceMs": 34650,
+		"mapping": {
+			"A": "A",
+			"B": "B"
+		}
+	},
+	"hypothesis": [
+		{
+			"speaker": "A",
+			"startMs": 939,
+			"endMs": 4556
+		},
+		{
+			"speaker": "B",
+			"startMs": 6092,
+			"endMs": 10000
+		},
+		{
+			"speaker": "A",
+			"startMs": 11314,
+			"endMs": 14693
+		},
+		{
+			"speaker": "B",
+			"startMs": 16314,
+			"endMs": 20000
+		},
+		{
+			"speaker": "A",
+			"startMs": 21638,
+			"endMs": 25000
+		},
+		{
+			"speaker": "B",
+			"startMs": 26809,
+			"endMs": 30000
+		},
+		{
+			"speaker": "A",
+			"startMs": 31399,
+			"endMs": 34386
+		},
+		{
+			"speaker": "B",
+			"startMs": 35836,
+			"endMs": 39061
+		}
+	],
+	"droppedShortMs": 273,
+	"overlap": {
+		"localSpeakerCount": 2,
+		"hasOverlap": true
+	}
+}

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/speaker-isolation-fixed-pairing.md
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/speaker-isolation-fixed-pairing.md
@@ -1,0 +1,17 @@
+# Speaker-isolation benchmark — two real Kokoro voices, real diarizer + encoder (CPU)
+
+Voices: af_bella (A) / am_michael (B), 8-turn dialogue, 600 ms gaps.
+
+- encoder attribution: **6/6** (accuracy 1.000, margin 0.818)
+- diarizer DER: **0.211** (missed 7300 ms, false-alarm 0 ms, confusion 0 ms, dropped-short 273 ms)
+- #9427 mean-MFCC attributor (model-free comparison): accuracy 0.500
+- overlap probe: localSpeakerCount=2, hasOverlap=true
+
+| turn | speaker | attributed | dist(own) | dist(other) | correct |
+| --- | --- | --- | ---: | ---: | --- |
+| turn-03 | A | A | 0.207 | 1.002 | ✓ |
+| turn-04 | B | B | 0.148 | 0.979 | ✓ |
+| turn-05 | A | A | 0.167 | 1.007 | ✓ |
+| turn-06 | B | B | 0.137 | 0.974 | ✓ |
+| turn-07 | A | A | 0.195 | 0.963 | ✓ |
+| turn-08 | B | B | 0.116 | 0.954 | ✓ |

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/speakeriso-fixed-pairing.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/speakeriso-fixed-pairing.txt
@@ -1,0 +1,11 @@
+[speaker-isolation] lib=/private/tmp/llama-cpp-11377/build-fused/bin/libelizainference.dylib
+[speaker-isolation] diarizer=/private/tmp/artifacts-11377/pyannote-segmentation-3.0-ifgo-epoch2.gguf
+[speaker-isolation] speaker-encoder=/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf
+[speaker-isolation] timeline: 8 turns, 40.0s, speakers A/B
+[speaker-isolation] encoder attribution: 6/6 correct (acc 1.000, intra 0.162, inter 0.980, margin 0.818)
+[speaker-isolation] mfcc attributor (#9427): best-mapping accuracy 0.500 (1 clusters)
+[speaker-isolation] diarizer DER 0.211 (missed 7300ms, falseAlarm 0ms, confusion 0ms / ref 34650ms; dropped-short 273ms)
+[speaker-isolation] overlap probe: localSpeakerCount=2 hasOverlap=true
+[speaker-isolation] report: /private/tmp/eliza-11377/plugins/plugin-local-inference/voice-bench-output/speaker-isolation.json
+[speaker-isolation] report: /private/tmp/eliza-11377/plugins/plugin-local-inference/voice-bench-output/speaker-isolation.md
+[speaker-isolation] PASS (accuracy ≥ 0.8, margin > 0, DER ≤ 0.6)

--- a/.github/issue-evidence/11377-diarizer-ifgo-cutover/speakeriso-guard-rejects-published-iofc.txt
+++ b/.github/issue-evidence/11377-diarizer-ifgo-cutover/speakeriso-guard-rejects-published-iofc.txt
@@ -1,0 +1,20 @@
+[speaker-isolation] lib=/private/tmp/llama-cpp-11377/build-fused/bin/libelizainference.dylib
+[speaker-isolation] diarizer=/Users/shawwalters/.eliza/local-inference/models/voice/diarizer/pyannote-segmentation-3.0.gguf
+[speaker-isolation] speaker-encoder=/Users/shawwalters/.eliza/local-inference/models/voice/speaker-encoder/wespeaker-resnet34-lm.gguf
+[speaker-isolation] timeline: 8 turns, 40.0s, speakers A/B
+[voice_diarizer] stale GGUF converter epoch 0; need >= 2 with LSTM gates packed as IFGO
+2544 | 			const handle = open(ctx, ggufArg.ptr, err.ptr);
+2545 | 			if (isNullPointer(handle)) {
+2546 | 				const message =
+2547 | 					takeError(err.buf) ??
+2548 | 					"[ffi-bindings] eliza_inference_diariz_open returned NULL with no diagnostic";
+2549 | 				throw new VoiceLifecycleError("kernel-missing", message);
+                 ^
+VoiceLifecycleError: [libelizainference] diariz_open: standalone diarizer failed to load /Users/shawwalters/.eliza/local-inference/models/voice/diarizer/pyannote-segmentation-3.0.gguf (errno-style rc=-22)
+ code: "kernel-missing"
+
+      at diarizOpen (/private/tmp/eliza-11377/plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts:2549:11)
+      at load (/private/tmp/eliza-11377/plugins/plugin-local-inference/src/services/voice/speaker/diarizer-fused.ts:100:27)
+      at /private/tmp/eliza-11377/plugins/plugin-local-inference/scripts/speaker-isolation-real.ts:104:38
+
+Bun v1.3.14 (macOS arm64)

--- a/packages/app-core/scripts/voice-attribution-smoke.ts
+++ b/packages/app-core/scripts/voice-attribution-smoke.ts
@@ -102,6 +102,12 @@ const M = {
     "voice/speaker-encoder/wespeaker-resnet34-lm.gguf",
   ),
   dia: firstExisting(
+    // epoch-2 IFGO bake first (#11377) — the IFGO fused reader rejects the
+    // legacy epoch-less IOFC artifact below.
+    "pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+    "diariz/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+    "diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+    "voice/diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
     "pyannote-segmentation-3.0.gguf",
     "diariz/pyannote-segmentation-3.0.gguf",
     "diarizer/pyannote-segmentation-3.0.gguf",

--- a/packages/shared/src/local-inference/voice-models.ts
+++ b/packages/shared/src/local-inference/voice-models.ts
@@ -317,6 +317,31 @@ export const VOICE_MODEL_VERSIONS: ReadonlyArray<VoiceModelVersion> = [
   },
   {
     id: "diarizer",
+    version: "0.3.0",
+    parentVersion: "0.2.0",
+    publishedToHfAt: "2026-07-03T03:24:18Z",
+    hfRepo: "elizaos/eliza-1",
+    hfRevision: "a89e5615ad616f7bf6c4982cd9eed2805b90370f",
+    preferredBackend: "ffi",
+    deprecatedBackends: ["onnx"],
+    ggufAssets: [
+      {
+        filename: "voice/diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+        sha256:
+          "100a5dbfd480b0cd6b0e01f0a9974ba836412721dfa0e36b7c1bb5a041abfbde",
+        sizeBytes: 5_976_032,
+        quant: "gguf-fp32",
+      },
+    ],
+    evalDeltas: { netImprovement: true },
+    changelogEntry:
+      "0.3.0 — epoch-2 IFGO re-bake (#11377): converter_epoch=2 + lstm_gate_order=IFGO metadata; " +
+      "pairs with the IFGO fused reader (fail-closed guard rejects gate-order skew). " +
+      "New filename; 0.2.0 IOFC artifact kept on HF for older fused libs.",
+    minBundleVersion: "0.0.0",
+  },
+  {
+    id: "diarizer",
     version: "0.2.0",
     parentVersion: "0.1.0",
     publishedToHfAt: "2026-05-19T00:00:00Z",

--- a/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
+++ b/plugins/plugin-local-inference/src/services/voice/workbench-real-services.ts
@@ -603,6 +603,18 @@ export async function createRealVoiceWorkbenchRuntimeFromEnv(
 		"diarizer GGUF",
 		firstExisting(
 			nonEmpty(env.ELIZA_DIARIZ_GGUF),
+			// epoch-2 IFGO bake first (#11377) — the IFGO fused reader rejects
+			// the legacy epoch-less IOFC artifact below.
+			path.join(bundle, "diariz", "pyannote-segmentation-3.0-ifgo-epoch2.gguf"),
+			path.join(
+				bundle,
+				"diarizer",
+				"pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+			),
+			path.join(
+				bundle,
+				"voice/diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf",
+			),
 			path.join(bundle, "diariz", "pyannote-segmentation-3.0.gguf"),
 			path.join(bundle, "diarizer", "pyannote-segmentation-3.0.gguf"),
 			path.join(bundle, "voice/diarizer/pyannote-segmentation-3.0.gguf"),


### PR DESCRIPTION
## Summary

Closes #11377 (diarizer DER 1.000 on the `speakeriso:real` bench).

The rebake-confirm evidence on the issue proved the DER-1.000 over-segmentation signature is pure **LSTM gate-order skew** between diarizer GGUF artifact and reader — the fork's vendored fused reader was still IOFC while the packages-side converter/reader moved to IFGO (+ the #11569 fail-closed epoch guard). This PR executes the corrected operator plan in the safe order:

1. **Fork reader sync** (already merged fork-side): elizaOS/llama.cpp#40 (diarizer epoch/gate-order metadata parsing + contract test) then elizaOS/llama.cpp#41 (IFGO gate-unpack flip + the #11569 fail-closed guard ported into the vendored `voice_diarizer.c`: `converter_epoch >= 2` and `lstm_gate_order == "IFGO"` required, epoch-less/IOFC artifacts rejected loudly before tensor load).
2. **Epoch-2 IFGO artifact republished** to HF `elizaos/eliza-1` as a NEW file `voice/diarizer/pyannote-segmentation-3.0-ifgo-epoch2.gguf` (sha `100a5dbf…`, bit-identical to the rebake-confirm session's deterministic bake; HF commit `a89e5615`). The old `pyannote-segmentation-3.0.gguf` (`30983eba…`) stays published so older fused libs keep working. `voice/diarizer/SHA256SUMS` added additively.
3. **This PR**: submodule gitlink bump `58c0391eb` → `dda200ab0` (a direct descendant — the #11612 Metal nil-pipeline/has_bfloat fixes are retained), diarizer `0.3.0` entry in `VOICE_MODEL_VERSIONS`, epoch-2 filename preferred in the workbench/attribution-smoke probe lists, evidence bundle.

## Evidence (all real runs on M4 Max — `.github/issue-evidence/11377-diarizer-ifgo-cutover/`)

| lane | result |
| --- | --- |
| IFGO lib × epoch-2 bake | **DER 0.211**, attribution 6/6 (margin 0.818), overlap probe localSpeakerCount=2 — PASS (was 1.000 in the skewed pairing) |
| IFGO lib × published IOFC `30983eba` | **rejected loudly**: `stale GGUF converter epoch 0; need >= 2 with LSTM gates packed as IFGO` → typed `VoiceLifecycleError`, bench exit 1 — no silent scramble |
| kokoro smoke | audio identical to baseline-pin lib (envelope-cv 1.229, 91800 samples); TTFA >700 ms budget fails on the **baseline pin lib too** (4876 ms) — pre-existing cold-load issue, not a regression; the fork diff touches zero Kokoro code |
| asr smoke | PASS — real transcript in 861 ms over Metal |
| fork contract test | `omnivoice-test-diarizer-metadata` → `failures=0` (epoch-2 IFGO clears guard to tensor stage; explicit IOFC / epoch-less / epoch-1 rejected with exact messages, stderr-captured) |

## Verification

- `bun run verify` → exit 0 (full repo, local)
- `packages/shared` voice-models tests 15/15; `plugin-local-inference` voice-models-routes + voice-model-updater 43/43
- Rebased onto `origin/develop` (13f8727fa97) pre-open

## Test evidence rows

- Real-LLM trajectories: N/A — no agent/action/prompt/model-routing behavior change; the change is a native voice-classifier reader + artifact pin.
- Video/screenshots: N/A — no UI surface; bench logs + JSON reports attached in the evidence bundle.
- Backend logs: attached (bench + guard rejection logs in the evidence bundle).
- Domain artifacts: HF commit `a89e5615` (new GGUF + SHA256SUMS), round-trip sha verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)