### PR TITLE
fix(cloud): keep /v1/messages payload conversion inside the refunding try (#11795)

### DIFF
--- a/.github/issue-evidence/11795-messages-conversion-refund-gap.md
+++ b/.github/issue-evidence/11795-messages-conversion-refund-gap.md
@@ -1,0 +1,35 @@
+# Issue #11795 - /v1/messages conversion refund gap
+
+## Scope
+
+`POST /api/v1/messages` reserved credits and created a reservation settler, then
+converted Anthropic request payload fields (`messages`, `tools`, `tool_choice`,
+safe model params) before entering the `try` block whose `catch` refunds with
+`settleReservation(0)`.
+
+`convertTools` can throw while converting a malformed tool schema. Before this
+fix, that throw could happen after reservation and before the refunding catch,
+stranding the debit.
+
+## Fix
+
+Moved all post-reserve payload conversion into the existing refunding `try`
+block in `packages/cloud/api/v1/messages/route.ts`.
+
+## Validation
+
+- `bun test packages/cloud/api/__tests__/messages-iac-fast-path.test.ts`
+  - 4 pass / 0 fail.
+  - New route-level regression forces tool schema conversion to throw after
+    `reserveCredits` and `createCreditReservationSettler`; it asserts
+    `settleReservation(0)` is called exactly once and the provider is never
+    invoked.
+- `bun run --cwd packages/cloud/api typecheck` - passed.
+- `bunx @biomejs/biome check packages/cloud/api/__tests__/messages-iac-fast-path.test.ts packages/cloud/api/v1/messages/route.ts` - passed.
+- `git diff --check` - passed.
+
+## Not Captured
+
+- Live provider trajectory: N/A - this regression is a pre-provider conversion
+  failure path; the test asserts the provider is not called.
+- Screenshots/video: N/A - backend money-path fix, no UI.

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -137,9 +137,13 @@ mock.module("@/lib/utils/request-timeout", () => ({
 }));
 
 const generateText = mock();
+const jsonSchemaMock = mock((schema: unknown) =>
+  (aiActual.jsonSchema as (schema: unknown) => unknown)(schema),
+);
 mock.module("ai", () => ({
   ...aiActual,
   generateText,
+  jsonSchema: jsonSchemaMock,
 }));
 
 const messagesRoute = (await import("../v1/messages/route")).default;
@@ -162,6 +166,7 @@ beforeEach(() => {
   getAuthorizedMonetizedAppForUser.mockReset();
   createCreditReservationSettler.mockReset();
   generateText.mockReset();
+  jsonSchemaMock.mockReset();
 
   resolveInferenceAuthContext.mockResolvedValue({
     kind: "authorized",
@@ -188,9 +193,15 @@ beforeEach(() => {
   generateText.mockImplementation(() => {
     throw new Error("model-call-stub");
   });
+  jsonSchemaMock.mockImplementation((schema: unknown) =>
+    (aiActual.jsonSchema as (schema: unknown) => unknown)(schema),
+  );
 });
 
-function postMessages(extraHeaders: Record<string, string> = {}) {
+function postMessages(
+  extraHeaders: Record<string, string> = {},
+  bodyOverrides: Record<string, unknown> = {},
+) {
   return messagesRoute.request("/", {
     method: "POST",
     headers: {
@@ -202,6 +213,7 @@ function postMessages(extraHeaders: Record<string, string> = {}) {
       model: "claude-3-5-sonnet-20241022",
       max_tokens: 16,
       messages: [{ role: "user", content: "hello" }],
+      ...bodyOverrides,
     }),
   });
 }
@@ -303,5 +315,35 @@ describe("/v1/messages IAC fast path", () => {
     expect(createCreditReservationSettler).toHaveBeenCalledWith(appReservation);
     expect(settleAppReservation).toHaveBeenCalledWith(0.002);
     expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("refunds the reservation when post-reserve payload conversion throws", async () => {
+    const settleReservation = mock(async () => null);
+    createCreditReservationSettler.mockReturnValueOnce(settleReservation);
+    jsonSchemaMock.mockImplementationOnce(() => {
+      throw new Error("bad-tool-schema");
+    });
+
+    const response = await postMessages(
+      {},
+      {
+        tools: [
+          {
+            name: "bad_tool",
+            description: "malformed schema",
+            input_schema: { type: "object" },
+          },
+        ],
+      },
+    );
+
+    expect(response.status).toBe(500);
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(createCreditReservationSettler).toHaveBeenCalledTimes(1);
+    expect(settleReservation).toHaveBeenCalledTimes(1);
+    expect(settleReservation).toHaveBeenCalledWith(0);
+    expect(generateText).not.toHaveBeenCalled();
+    const body = (await response.json()) as { error?: { message?: string } };
+    expect(body.error?.message).toContain("bad-tool-schema");
   });
 });

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -685,17 +685,21 @@ app.post("/", async (c) => {
 
   settleReservation = createCreditReservationSettler(reservation);
 
-  const messages = anthropicMessagesToModelMessages(request.messages);
-  const tools = convertTools(request.tools);
-  const toolChoice = mapToolChoice(request.tool_choice);
-  const safeParams = getSafeModelParams(model, {
-    temperature: request.temperature,
-    topP: request.top_p,
-    topK: request.top_k,
-    stopSequences: request.stop_sequences,
-  });
-
   try {
+    // Payload conversion is throwable (convertTools rejects a malformed-but-
+    // valid `tools` array); keep it inside the settle-refunding try so a
+    // conversion throw refunds the reservation instead of stranding the debit
+    // the caller was just charged (refund-gap class, #11795).
+    const messages = anthropicMessagesToModelMessages(request.messages);
+    const tools = convertTools(request.tools);
+    const toolChoice = mapToolChoice(request.tool_choice);
+    const safeParams = getSafeModelParams(model, {
+      temperature: request.temperature,
+      topP: request.top_p,
+      topK: request.top_k,
+      stopSequences: request.stop_sequences,
+    });
+
     if (request.stream) {
       return await handleStream(
         model,


### PR DESCRIPTION
Closes #11795. `[cloud-money]` — refund-gap class (same as #11684/#11690), found by a Fable-5 class-hunt that verified chat/completions, chat, apps/chat, domains, voice, image, x, a2a all CLEAN.

**Bug:** `v1/messages/route.ts` takes the reservation + arms the settler, then runs `convertTools`/`anthropicMessagesToModelMessages`/`mapToolChoice`/`getSafeModelParams` **before** the try whose catch refunds (`settleReservation?.(0)`). `convertTools` throws on a malformed `tools` array → 500 with the debit stranded.

**Fix:** move the 4 conversions inside the existing refunding try — the identical pattern chat/completions uses. Code-motion only (can only add refunds), typecheck + biome clean.

**Test:** route-level billing regression (mock reserve + convertTools-throw → assert settle(0)) tracked as fast-follow — the existing messages harness covers `handleStream`, not the route conversion path. Money path — do not self-merge.