### PR TITLE
chore(cloud-api): biome format promote route (unblocks repo-wide lint)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -53,7 +53,15 @@ const PromotionConfigSchema = z.object({
     .optional(),
   advertising: z
     .object({
-      platform: z.enum(["meta", "google", "tiktok", "snap", "x-twitter", "reddit", "linkedin"]),
+      platform: z.enum([
+        "meta",
+        "google",
+        "tiktok",
+        "snap",
+        "x-twitter",
+        "reddit",
+        "linkedin",
+      ]),
       adAccountId: z.string().uuid(),
       budget: z.number().positive().max(10000),
       budgetType: z.enum(["daily", "lifetime"]),


### PR DESCRIPTION
One-file `biome check --write` on `packages/cloud/api/v1/apps/[id]/promote/route.ts`. The ads/campaign merges (#11740/#11767/#11759/#11779) left it unformatted, which reds `@elizaos/cloud-api#lint` (a plain `biome check`, not `--write`) and therefore fails `bun run verify` on every branch, including pristine develop.

Verification: `bunx @biomejs/biome check .` in `packages/cloud/api` → `Checked 820 files. No fixes applied.` (was: 1 format error).

Evidence rows: N/A — formatting-only, no behavior change; lint output above is the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)