### PR TITLE
fix(agent): aggregate action-map drift warnings into one line per map

### DIFF
--- a/packages/agent/src/runtime/prompt-compaction.test.ts
+++ b/packages/agent/src/runtime/prompt-compaction.test.ts
@@ -73,6 +73,26 @@ describe("validateIntentActionMap", () => {
     expect(joined).not.toMatch(/"TASKS"/);
   });
 
+  it("aggregates all missing actions into a single warn line, with per-action debug detail", () => {
+    const warned: string[] = [];
+    const debugs: string[] = [];
+    validateIntentActionMap([], {
+      warn: (m) => warned.push(m),
+      debug: (m) => debugs.push(m),
+    });
+    // One summary line, not one warn per missing (category, action) pair.
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toContain("INTENT_ACTION_MAP:");
+    expect(warned[0]).toContain("not registered");
+    expect(warned[0]).toContain("terminal: SHELL, RUNTIME");
+    expect(warned[0]).toContain("plugins not loaded in this config");
+    // Per-action detail is preserved at debug level (opt-in TASKS still skipped).
+    expect(
+      debugs.some((d) => d.includes('INTENT_ACTION_MAP["terminal"]')),
+    ).toBe(true);
+    expect(debugs.join("\n")).not.toMatch(/"TASKS"/);
+  });
+
   it("stays silent when every mapped action is registered", () => {
     const all = [
       ...new Set(Object.values(INTENT_ACTION_MAP).flatMap((s) => [...s])),

--- a/packages/agent/src/runtime/prompt-compaction.ts
+++ b/packages/agent/src/runtime/prompt-compaction.ts
@@ -176,14 +176,18 @@ export function hasIntent(prompt: string, keywords: RegExp): boolean {
 
 /**
  * Validate INTENT_ACTION_MAP against the runtime's registered actions.
- * Logs warnings for any mapped action names that don't exist in the runtime.
+ * Missing names are reported as ONE aggregated warn line per boot (grouped by
+ * category) — mirroring validateViewActionMap — so drift is caught at startup
+ * without per-action warn spam when several mapped plugins are absent.
+ * Per-action detail is still available at debug level.
  * Call once at startup after plugins are loaded.
  */
 export function validateIntentActionMap(
   registeredActions: string[],
-  logger?: { warn: (msg: string) => void },
+  logger?: { warn: (msg: string) => void; debug?: (msg: string) => void },
 ): void {
   const registered = new Set(registeredActions.map((a) => a.toUpperCase()));
+  const missingByCategory = new Map<string, string[]>();
   for (const [category, actions] of Object.entries(INTENT_ACTION_MAP)) {
     for (const action of actions) {
       if (!registered.has(action)) {
@@ -191,12 +195,25 @@ export function validateIntentActionMap(
         // isn't loaded — keep them mapped (for full param detail when present)
         // without emitting startup noise.
         if (OPTIONAL_PLUGIN_ACTIONS.has(action)) continue;
-        logger?.warn(
-          `[eliza] INTENT_ACTION_MAP["${category}"] references "${action}" which is not a registered action — may be renamed or removed upstream`,
+        logger?.debug?.(
+          `[eliza] INTENT_ACTION_MAP["${category}"] references "${action}" which is not a registered action`,
         );
+        const list = missingByCategory.get(category);
+        if (list) list.push(action);
+        else missingByCategory.set(category, [action]);
       }
     }
   }
+  if (missingByCategory.size === 0) return;
+  let total = 0;
+  const detail: string[] = [];
+  for (const [category, actions] of missingByCategory) {
+    total += actions.length;
+    detail.push(`${category}: ${actions.join(", ")}`);
+  }
+  logger?.warn(
+    `[eliza] INTENT_ACTION_MAP: ${total} referenced action${total === 1 ? "" : "s"} not registered (${detail.join("; ")}) — renamed/removed upstream, or provided by plugins not loaded in this config`,
+  );
 }
 
 /**

--- a/packages/agent/src/runtime/view-action-affinity.test.ts
+++ b/packages/agent/src/runtime/view-action-affinity.test.ts
@@ -97,6 +97,39 @@ describe("view-action-affinity", () => {
     expect(warnings.some((w) => w.includes("TASKS"))).toBe(false);
   });
 
+  it("aggregates all missing actions into a single warn line, with per-action debug detail", () => {
+    const warnings: string[] = [];
+    const debugs: string[] = [];
+    // Register nothing → every mapped action is "missing". Deployments without
+    // the optional wallet/polymarket/… plugins hit this shape at boot; the
+    // detector must not flood the log with one warn per (view, action) pair.
+    validateViewActionMap([], {
+      warn: (m) => warnings.push(m),
+      debug: (m) => debugs.push(m),
+    });
+    expect(warnings).toHaveLength(1);
+    // Summary carries the count, per-view grouping, and the not-loaded hint.
+    expect(warnings[0]).toContain("VIEW_ACTION_MAP:");
+    expect(warnings[0]).toContain("not registered");
+    expect(warnings[0]).toContain("wallet: WALLET, EVM_SWAP");
+    expect(warnings[0]).toContain("plugins not loaded in this config");
+    // Per-action detail is preserved at debug level.
+    const totalMapped = Object.values(VIEW_ACTION_MAP).reduce(
+      (n, a) => n + a.length,
+      0,
+    );
+    expect(debugs).toHaveLength(totalMapped);
+    expect(debugs.some((d) => d.includes('VIEW_ACTION_MAP["wallet"]'))).toBe(
+      true,
+    );
+  });
+
+  it("aggregated warn works when the logger has no debug method", () => {
+    const warnings: string[] = [];
+    validateViewActionMap([], { warn: (m) => warnings.push(m) });
+    expect(warnings).toHaveLength(1);
+  });
+
   it("does not warn when every mapped action is registered", () => {
     const allMapped = new Set<string>();
     for (const actions of Object.values(VIEW_ACTION_MAP)) {

--- a/packages/agent/src/runtime/view-action-affinity.ts
+++ b/packages/agent/src/runtime/view-action-affinity.ts
@@ -201,23 +201,41 @@ export function viewScopedActionNames(
 
 /**
  * Validate VIEW_ACTION_MAP against the runtime's registered actions, mirroring
- * validateIntentActionMap. Logs a warning for any mapped name that no longer
- * exists so drift is caught at startup rather than silently dropped.
+ * validateIntentActionMap. Missing names are reported as ONE aggregated warn
+ * line per boot (grouped by view) so drift is caught at startup without a
+ * per-action warn flood: most VIEW_ACTION_MAP actions belong to optional
+ * plugins (wallet, polymarket, hyperliquid, …) and a deployment that doesn't
+ * load them would otherwise emit dozens of boot warnings that bury real ones.
+ * Per-action detail is still available at debug level.
  */
 export function validateViewActionMap(
   registeredActions: string[],
-  logger?: { warn: (msg: string) => void },
+  logger?: { warn: (msg: string) => void; debug?: (msg: string) => void },
 ): void {
   const registered = new Set(registeredActions.map((a) => a.toUpperCase()));
+  const missingByView = new Map<string, string[]>();
   for (const [viewId, actions] of Object.entries(VIEW_ACTION_MAP)) {
     for (const action of actions) {
       if (!registered.has(action.toUpperCase())) {
-        logger?.warn(
-          `[eliza] VIEW_ACTION_MAP["${viewId}"] references "${action}" which is not a registered action — may be renamed or removed upstream`,
+        logger?.debug?.(
+          `[eliza] VIEW_ACTION_MAP["${viewId}"] references "${action}" which is not a registered action`,
         );
+        const list = missingByView.get(viewId);
+        if (list) list.push(action);
+        else missingByView.set(viewId, [action]);
       }
     }
   }
+  if (missingByView.size === 0) return;
+  let total = 0;
+  const detail: string[] = [];
+  for (const [viewId, actions] of missingByView) {
+    total += actions.length;
+    detail.push(`${viewId}: ${actions.join(", ")}`);
+  }
+  logger?.warn(
+    `[eliza] VIEW_ACTION_MAP: ${total} referenced action${total === 1 ? "" : "s"} not registered (${detail.join("; ")}) — renamed/removed upstream, or provided by plugins not loaded in this config`,
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #11799

## Problem

At boot, `validateViewActionMap` and `validateIntentActionMap` emit one Warn per missing (view, action) pair. Deployments that don't load the optional wallet/polymarket/hyperliquid/facewear plugins get ~35 consecutive Warn lines (observed on a live cloud container), burying real boot warnings. The map itself documents these entries as plugin-conditional ("a missing-plugin skip (no error)"), so this is expected absence, not drift.

## Change (aggregation design)

Both validators now:
- collect missing action names grouped by view/category
- emit **one aggregated Warn per map** with a total count, the per-group detail, and both possible causes:

```
[eliza] VIEW_ACTION_MAP: 35 referenced actions not registered (wallet: WALLET, EVM_SWAP, ...; polymarket: POLYMARKET_STATUS; ...) — renamed/removed upstream, or provided by plugins not loaded in this config
```

- demote the per-action lines to **debug** level (logger param widened to accept an optional `debug`, callers pass `runtime.logger` which already has it)

Aggregation was chosen over an optional-plugin allowlist because `VIEW_ACTION_MAP` can't reliably distinguish "plugin not loaded in this config" from "renamed upstream" at validate time; the existing `OPTIONAL_PLUGIN_ACTIONS` skip for TASKS in `validateIntentActionMap` is kept as-is. Drift detection is unchanged: every missing action is still named at startup, just on one line.

## Tests

- `view-action-affinity.test.ts`: new tests — single aggregated warn with per-view grouping + count + not-loaded hint, per-action debug detail count, and no-debug-method logger safety. Existing drift tests unchanged and green.
- `prompt-compaction.test.ts`: new test — single aggregated warn, per-category grouping, TASKS opt-in skip still honored at both warn and debug level.
- Ran: `view-action-affinity.test.ts`, `prompt-compaction.test.ts`, `view-id-drift.test.ts` → 79/79 pass. Full `src/runtime` suite: 246 passed, 0 test failures; 24 suite-level failures are pre-existing on this worktree baseline (missing esbuild dev dep in the worktree env, identical before/after my change — verified by running the suite on stashed baseline).
- Biome clean. Codex review: no issues flagged.

— [sol-orch]
