### PR TITLE
fix(local-inference/ios): GPU memory admission — fit eliza-1-2b in the A18 working-set (#11612)

### DIFF
--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/memory-admission.test.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/__tests__/memory-admission.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractLayerCount,
+	isConstrainedMobilePlatform,
+	MOBILE_N_UBATCH,
+	MobileMemoryAdmissionError,
+	planMobileGpuAdmission,
+} from "../memory-admission";
+
+const MIB = 1024 * 1024;
+const GIB_8 = 8 * 1024 * MIB;
+
+describe("planMobileGpuAdmission", () => {
+	it("admits the measured A18 configuration at full offload (#11612 fit math)", () => {
+		// iPhone 16 Pro Max: weights 4722 MiB, 36 layers, 8 GiB physical RAM.
+		const admission = planMobileGpuAdmission({
+			weightsBytes: 4722 * MIB,
+			layerCount: 36,
+			totalRamBytes: GIB_8,
+		});
+		expect(admission.fullOffload).toBe(true);
+		expect(admission.nGpuLayers).toBe(999);
+		expect(admission.nUbatch).toBe(MOBILE_N_UBATCH);
+		expect(admission.nBatch).toBe(MOBILE_N_UBATCH);
+		// Budget = 2/3 of physical RAM (jetsam working set) → 5461 MiB on 8 GiB.
+		expect(admission.budgetMib).toBe(5461);
+		// Compute buffer at n_ubatch 256 ≈ 260 MiB (1037 MiB measured at 1024).
+		expect(admission.computeMib).toBe(260);
+		// Total wired fit stays under the working set: 4722 + 260 + 64 < 5461.
+		expect(
+			admission.weightsMib + admission.computeMib + admission.kvMib,
+		).toBeLessThan(admission.budgetMib);
+	});
+
+	it("rejects the pre-fix configuration: n_ubatch 1024 compute buffer overflows the working set", () => {
+		// Regression pin for the original OOM: 4722 + 1037 + KV > 5461 —
+		// the plan at n_ubatch 256 must be strictly under budget while the
+		// same weights with the old 1037 MiB compute buffer are over it.
+		const admission = planMobileGpuAdmission({
+			weightsBytes: 4722 * MIB,
+			layerCount: 36,
+			totalRamBytes: GIB_8,
+		});
+		const oldComputeMib = 1037;
+		expect(
+			admission.weightsMib + oldComputeMib + admission.kvMib,
+		).toBeGreaterThan(admission.budgetMib);
+	});
+
+	it("reduces n_gpu_layers proportionally when weights alone exceed the budget", () => {
+		const admission = planMobileGpuAdmission({
+			weightsBytes: 6000 * MIB,
+			layerCount: 36,
+			totalRamBytes: GIB_8,
+		});
+		expect(admission.fullOffload).toBe(false);
+		expect(admission.nGpuLayers).toBeGreaterThan(0);
+		expect(admission.nGpuLayers).toBeLessThan(36);
+		// The wired fraction of the weights must fit the budget.
+		const wiredWeightsMib =
+			(admission.weightsMib / admission.layerCount) * admission.nGpuLayers;
+		expect(
+			wiredWeightsMib + admission.computeMib + admission.kvMib,
+		).toBeLessThanOrEqual(admission.budgetMib);
+	});
+
+	it("falls back to the eliza-1 layer count when GGUF metadata is unreadable", () => {
+		const admission = planMobileGpuAdmission({
+			weightsBytes: 6000 * MIB,
+			layerCount: null,
+			totalRamBytes: GIB_8,
+		});
+		expect(admission.layerCount).toBe(36);
+	});
+
+	it("throws MobileMemoryAdmissionError when not even zero offload fits", () => {
+		expect(() =>
+			planMobileGpuAdmission({
+				weightsBytes: 4722 * MIB,
+				layerCount: 36,
+				totalRamBytes: 256 * MIB,
+			}),
+		).toThrow(MobileMemoryAdmissionError);
+	});
+});
+
+describe("extractLayerCount", () => {
+	it("reads <arch>.block_count from GGUF metadata", () => {
+		expect(extractLayerCount({ "gemma3.block_count": 36 })).toBe(36);
+		expect(extractLayerCount({ "llama.block_count": "48" })).toBe(48);
+	});
+
+	it("returns null for missing or invalid metadata", () => {
+		expect(extractLayerCount(null)).toBeNull();
+		expect(extractLayerCount({})).toBeNull();
+		expect(
+			extractLayerCount({ "gemma3.block_count": "not-a-number" }),
+		).toBeNull();
+		expect(extractLayerCount({ "gemma3.block_count": 0 })).toBeNull();
+	});
+});
+
+describe("isConstrainedMobilePlatform", () => {
+	it("is true only for ELIZA_PLATFORM=ios|android", () => {
+		expect(isConstrainedMobilePlatform({ ELIZA_PLATFORM: "ios" })).toBe(true);
+		expect(isConstrainedMobilePlatform({ ELIZA_PLATFORM: "Android" })).toBe(
+			true,
+		);
+		expect(isConstrainedMobilePlatform({ ELIZA_PLATFORM: "darwin" })).toBe(
+			false,
+		);
+		expect(isConstrainedMobilePlatform({})).toBe(false);
+	});
+});

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/index.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/index.ts
@@ -43,7 +43,8 @@ import {
 	isLocalInferenceUnavailableError,
 } from "../..";
 import { type Config, validateConfig } from "./environment";
-import { initCapacitorLlama } from "./loader";
+import { initCapacitorLlama, releaseAllCapacitorLlama } from "./loader";
+import { resolveMobileGpuAdmission } from "./memory-admission";
 import {
 	applyStructuredPlan,
 	extractToolCalls,
@@ -471,24 +472,66 @@ class LocalAIManager {
 
 		const spec = slot === "medium" ? MODEL_SPECS.medium : MODEL_SPECS.small;
 		const modelPath = slot === "medium" ? this.mediumModelPath : this.modelPath;
-		const ctx = await initCapacitorLlama({
-			model: modelPath,
-			n_ctx: spec.contextSize,
-			n_gpu_layers: 999,
-			// Gemma-aware RAM defaults (epic #9033): keep mmap on so the Gemma-4
-			// Per-Layer-Embeddings tensor pages from disk (never `--no-mmap`),
-			// and pin windowed SWA KV (`swa_full=false`, the dominant KV saving
-			// on Gemma's mostly-sliding-window attention). Both are the current
-			// effective defaults; setting them explicitly keeps a binding
-			// default flip from silently regressing Gemma RAM.
-			use_mmap: true,
-			swa_full: false,
-		});
+		// GPU-OOM memory admission (#11612): on constrained mobile
+		// (ELIZA_PLATFORM=ios|android) shrink n_ubatch/n_batch to 256 and
+		// compute n_gpu_layers against the jetsam working-set budget instead
+		// of hardcoding full offload. Fit math (iPhone 16 Pro Max, A18,
+		// 8 GiB): weights 4722 MiB + compute 1037→~260 MiB (n_ubatch
+		// 1024→256) + KV 36 MiB ≈ 5018 MiB < the ~5461 MiB (2/3 of physical
+		// RAM) working set — full offload retained. Desktop keeps binding
+		// defaults + n_gpu_layers 999. Details: memory-admission.ts.
+		const admission = await resolveMobileGpuAdmission(modelPath);
+		let ctx: CapacitorLlamaContext;
+		try {
+			ctx = await initCapacitorLlama({
+				model: modelPath,
+				n_ctx: spec.contextSize,
+				n_gpu_layers: admission ? admission.nGpuLayers : 999,
+				...(admission
+					? { n_batch: admission.nBatch, n_ubatch: admission.nUbatch }
+					: {}),
+				// Gemma-aware RAM defaults (epic #9033): keep mmap on so the Gemma-4
+				// Per-Layer-Embeddings tensor pages from disk (never `--no-mmap`),
+				// and pin windowed SWA KV (`swa_full=false`, the dominant KV saving
+				// on Gemma's mostly-sliding-window attention). Both are the current
+				// effective defaults; setting them explicitly keeps a binding
+				// default flip from silently regressing Gemma RAM.
+				use_mmap: true,
+				swa_full: false,
+			});
+		} catch (err) {
+			// Unload-on-failure (#11612): a failed/partial load must not leave
+			// wired GPU buffers mapped — that footprint alone gets the process
+			// jetsammed on the next allocation.
+			if (admission) await releaseAllCapacitorLlama();
+			throw err;
+		}
 		const entry: ContextEntry = { ctx, systemPrompt };
 		if (slot === "medium") this.mediumCtx = entry;
 		else this.smallCtx = entry;
 		this.activeModelConfig = spec;
 		return entry;
+	}
+
+	/**
+	 * Release a cached text context (unload-on-failure, #11612). A decode
+	 * failure on mobile (e.g. Metal ret=-3 GPU OOM) leaves multi-GiB wired
+	 * buffers mapped; keeping the dead handle resident guarantees a jetsam
+	 * kill on the next allocation. Drop the slot and release the native ctx.
+	 */
+	private async releaseSlot(slot: "small" | "medium"): Promise<void> {
+		const existing = slot === "medium" ? this.mediumCtx : this.smallCtx;
+		if (slot === "medium") this.mediumCtx = null;
+		else this.smallCtx = null;
+		if (!existing) return;
+		try {
+			await existing.ctx.release();
+		} catch (err) {
+			logger.warn(
+				{ err: err instanceof Error ? err.message : String(err) },
+				"[plugin-local-ai] Failed releasing context after generation failure",
+			);
+		}
 	}
 
 	async initialize(
@@ -553,8 +596,20 @@ class LocalAIManager {
 		};
 		const fullParams = applyStructuredPlan(baseParams, plan);
 
+		// Unload-on-failure (#11612): a failed decode must release the model
+		// instead of leaving it mapped (multi-GiB wired weights → jetsam).
+		const slot = modelType === ModelType.TEXT_LARGE ? "medium" : "small";
+		const runCompletion = async () => {
+			try {
+				return await entry.ctx.completion(fullParams);
+			} catch (err) {
+				await this.releaseSlot(slot);
+				throw err;
+			}
+		};
+
 		if (plan.kind === "tools") {
-			const result = await entry.ctx.completion(fullParams);
+			const result = await runCompletion();
 			const toolCalls = extractToolCalls(result);
 			const text = stripThinkTags(result.content || result.text);
 			return {
@@ -565,7 +620,7 @@ class LocalAIManager {
 		}
 
 		if (plan.kind === "schema" || plan.kind === "json_object") {
-			const result = await entry.ctx.completion(fullParams);
+			const result = await runCompletion();
 			const text = stripThinkTags(result.content || result.text);
 			return {
 				text,
@@ -591,11 +646,15 @@ class LocalAIManager {
 					typeof streamParams.onStreamChunk === "function"
 						? (delta) => streamParams.onStreamChunk?.(delta)
 						: undefined,
+				onError: () => {
+					// Unload-on-failure (#11612), streaming path.
+					void this.releaseSlot(slot);
+				},
 				postProcess: stripThinkTags,
 			});
 		}
 
-		const result = await entry.ctx.completion(fullParams);
+		const result = await runCompletion();
 		const text = stripThinkTags(result.content || result.text);
 		return {
 			text,

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/loader.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/loader.ts
@@ -31,6 +31,8 @@ interface MobileCapacitorModule {
 	releaseAllLlama(): Promise<void>;
 	setContextLimit(limit: number): Promise<void>;
 	toggleNativeLog(enabled: boolean): Promise<void>;
+	/** GGUF metadata probe without loading the model (llama-cpp-capacitor). */
+	loadLlamaModelInfo?(model: string): Promise<object>;
 }
 
 let cachedMobileModule: MobileCapacitorModule | null = null;
@@ -92,6 +94,28 @@ export async function initCapacitorLlama(
 			"retired; desktop/server inference runs through the fused libelizainference " +
 			"engine (LocalInferenceEngine / desktopFusedFfiBackendRuntime), not this loader.",
 	);
+}
+
+/**
+ * Mobile-only: read GGUF metadata (layer count etc.) without loading the
+ * model. Returns `null` on desktop or when the binding lacks the probe —
+ * callers fall back to conservative defaults (memory-admission.ts).
+ */
+export async function loadCapacitorLlamaModelInfo(
+	model: string,
+): Promise<Record<string, unknown> | null> {
+	if (detectBackend() !== "mobile") return null;
+	try {
+		const mod = await loadMobileCapacitor();
+		if (typeof mod.loadLlamaModelInfo !== "function") return null;
+		return (await mod.loadLlamaModelInfo(model)) as Record<string, unknown>;
+	} catch (err) {
+		logger.debug(
+			{ err: err instanceof Error ? err.message : String(err) },
+			"[capacitor-llama] loadLlamaModelInfo unavailable",
+		);
+		return null;
+	}
 }
 
 /** Mobile-only: release every context. No-op on desktop. */

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/memory-admission.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/memory-admission.ts
@@ -1,0 +1,195 @@
+/**
+ * GPU-OOM memory admission for the mobile Capacitor-llama load path (#11612).
+ *
+ * Why this exists — measured on iPhone 16 Pro Max (A18, 8 GiB physical RAM):
+ *
+ *   weights (Metal, full 36-layer offload) : 4722 MiB
+ *   compute buffer (default n_ubatch=1024) : 1037 MiB
+ *   KV cache (swa_full=false, 128k SWA)    :   36 MiB
+ *   ------------------------------------------------
+ *   total                                  ≈ 5795 MiB
+ *
+ * iOS grants a foreground process ≈ 2/3 of physical RAM before jetsam
+ * (`os_proc_available_memory()` on a fresh 8 GiB A18 reports ~5461 MiB
+ * = 8192 × 2/3). 5795 > 5461 → Metal returns ret=-3 mid-decode and the
+ * process is jetsammed with the ~4.7 GiB of wired weights still mapped.
+ *
+ * Two-part fix, gated to constrained mobile (`ELIZA_PLATFORM=ios|android`)
+ * only — desktop keeps binding defaults and full offload:
+ *
+ *   1. Shrink the micro-batch: `n_ubatch=256` (with `n_batch=256`, llama.cpp
+ *      requires n_ubatch ≤ n_batch). Compute buffer scales ~linearly with
+ *      n_ubatch: 1037 × (256/1024) ≈ 260 MiB, so
+ *      4722 + 260 + 36 ≈ 5018 MiB < 5461 MiB — full-GPU speed retained.
+ *   2. Admission guard: if (weights + compute + KV) still exceeds the
+ *      working-set budget, reduce `n_gpu_layers` so only the fitting
+ *      fraction of layers is Metal-wired. CPU-resident layers stay
+ *      mmap-backed *clean* pages (evictable, not counted against the jetsam
+ *      footprint the way wired Metal buffers are), so lowering
+ *      `n_gpu_layers` genuinely lowers the fatal footprint.
+ *
+ * The JS runtime on device cannot call `os_proc_available_memory()`
+ * directly (no binding export), so the budget derives from physical RAM
+ * (`os.totalmem()`) × the empirical 2/3 iOS working-set fraction. Android's
+ * low-memory-killer budget is comparable in practice, and this path only
+ * runs on `ELIZA_PLATFORM=ios|android`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import { logger } from "@elizaos/core";
+import { loadCapacitorLlamaModelInfo } from "./loader";
+
+const MIB = 1024 * 1024;
+
+/** Micro-batch for constrained-mobile loads (see fit math above). */
+export const MOBILE_N_UBATCH = 256;
+
+/**
+ * Compute-buffer cost per n_ubatch element: 1037 MiB measured at
+ * n_ubatch=1024 (eliza-1-4b on A18) → ≈1.013 MiB per element.
+ */
+const COMPUTE_MIB_PER_UBATCH = 1037 / 1024;
+
+/**
+ * KV-cache allowance. Measured 36 MiB with `swa_full=false` on the mostly
+ * sliding-window eliza-1 attention stack; 64 MiB leaves slack for the
+ * non-SWA global layers growing with context.
+ */
+const KV_MIB = 64;
+
+/** Layer count fallback when GGUF metadata is unreachable (eliza-1-4b = 36). */
+const DEFAULT_LAYER_COUNT = 36;
+
+/** Fill at most this fraction of the working-set budget (mmap/runtime slack). */
+const ADMISSION_SAFETY = 0.97;
+
+/** iOS jetsam working-set fraction of physical RAM (8192 MiB → ~5461 MiB). */
+const MOBILE_WORKING_SET_FRACTION = 2 / 3;
+
+/** True on the constrained-mobile platforms this admission logic targets. */
+export function isConstrainedMobilePlatform(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	const platform = env.ELIZA_PLATFORM?.trim().toLowerCase();
+	return platform === "android" || platform === "ios";
+}
+
+/** Thrown when not even a zero-offload load fits the working-set budget. */
+export class MobileMemoryAdmissionError extends Error {
+	constructor(readonly admission: MobileGpuAdmission) {
+		super(
+			`[capacitor-llama] Model does not fit the mobile working-set budget: ` +
+				`weights ${admission.weightsMib} MiB + compute ${admission.computeMib} MiB ` +
+				`+ KV ${admission.kvMib} MiB exceeds budget ${admission.budgetMib} MiB ` +
+				`even at n_gpu_layers=0. Refusing to load (would be jetsammed).`,
+		);
+		this.name = "MobileMemoryAdmissionError";
+	}
+}
+
+export interface MobileGpuAdmission {
+	/** 999 = full offload (llama.cpp convention), else the fitting layer count. */
+	nGpuLayers: number;
+	nBatch: number;
+	nUbatch: number;
+	/** Per-process working-set budget (MiB). */
+	budgetMib: number;
+	weightsMib: number;
+	computeMib: number;
+	kvMib: number;
+	layerCount: number;
+	fullOffload: boolean;
+}
+
+/**
+ * Pure fit computation — exported for tests. Throws
+ * `MobileMemoryAdmissionError` when nothing fits.
+ */
+export function planMobileGpuAdmission(input: {
+	weightsBytes: number;
+	layerCount?: number | null;
+	totalRamBytes?: number;
+}): MobileGpuAdmission {
+	const totalRamBytes = input.totalRamBytes ?? os.totalmem();
+	const budgetMib = Math.floor(
+		(totalRamBytes / MIB) * MOBILE_WORKING_SET_FRACTION,
+	);
+	const weightsMib = Math.ceil(input.weightsBytes / MIB);
+	const computeMib = Math.ceil(COMPUTE_MIB_PER_UBATCH * MOBILE_N_UBATCH);
+	const layerCount =
+		input.layerCount && input.layerCount > 0
+			? input.layerCount
+			: DEFAULT_LAYER_COUNT;
+	// MiB of weights the GPU may wire after compute + KV are reserved.
+	const usableForWeightsMib =
+		Math.floor(budgetMib * ADMISSION_SAFETY) - computeMib - KV_MIB;
+
+	const base = {
+		nBatch: MOBILE_N_UBATCH,
+		nUbatch: MOBILE_N_UBATCH,
+		budgetMib,
+		weightsMib,
+		computeMib,
+		kvMib: KV_MIB,
+		layerCount,
+	};
+
+	if (weightsMib <= usableForWeightsMib) {
+		return { ...base, nGpuLayers: 999, fullOffload: true };
+	}
+	if (usableForWeightsMib <= 0) {
+		throw new MobileMemoryAdmissionError({
+			...base,
+			nGpuLayers: 0,
+			fullOffload: false,
+		});
+	}
+	// Partial offload: wire only the fitting fraction of layers.
+	const perLayerMib = weightsMib / layerCount;
+	const nGpuLayers = Math.min(
+		layerCount,
+		Math.floor(usableForWeightsMib / perLayerMib),
+	);
+	return { ...base, nGpuLayers, fullOffload: false };
+}
+
+/** Extract `<arch>.block_count` from GGUF metadata, else null. */
+export function extractLayerCount(
+	metadata: Record<string, unknown> | null,
+): number | null {
+	if (!metadata) return null;
+	for (const [key, value] of Object.entries(metadata)) {
+		if (!key.endsWith(".block_count")) continue;
+		const parsed = typeof value === "string" ? Number(value) : value;
+		if (typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0) {
+			return Math.floor(parsed);
+		}
+	}
+	return null;
+}
+
+/**
+ * Resolve the admission plan for a model file on constrained mobile.
+ * Returns `null` off-mobile (desktop keeps binding defaults + full offload).
+ */
+export async function resolveMobileGpuAdmission(
+	modelPath: string,
+): Promise<MobileGpuAdmission | null> {
+	if (!isConstrainedMobilePlatform()) return null;
+	const weightsBytes = fs.statSync(modelPath).size;
+	const metadata = await loadCapacitorLlamaModelInfo(modelPath);
+	const admission = planMobileGpuAdmission({
+		weightsBytes,
+		layerCount: extractLayerCount(metadata),
+	});
+	logger.info(
+		{
+			modelPath,
+			...admission,
+			fitMib: admission.weightsMib + admission.computeMib + admission.kvMib,
+		},
+		"[capacitor-llama] Mobile GPU memory admission",
+	);
+	return admission;
+}

--- a/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
+++ b/plugins/plugin-local-inference/src/adapters/capacitor-llama/text-streaming.ts
@@ -91,6 +91,8 @@ export interface StreamCapacitorPromptArgs {
 	estimateUsage: (prompt: string, fullText: string) => TokenUsage;
 	onChunk?: (delta: string) => void;
 	onComplete?: (info: { fullText: string; usage: TokenUsage }) => void;
+	/** Fired once when the underlying completion fails (e.g. GPU OOM, #11612). */
+	onError?: (err: unknown) => void;
 	postProcess?: (raw: string) => string;
 }
 
@@ -159,6 +161,7 @@ export function streamCapacitorPrompt(
 				return result;
 			} catch (err) {
 				promptError = err;
+				args.onError?.(err);
 				throw err;
 			} finally {
 				promptDone = true;

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/LlamaBridgeImpl.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/LlamaBridgeImpl.swift
@@ -61,6 +61,9 @@ private func c_llama_model_load_from_file(
 @_silgen_name("llama_model_free")
 private func c_llama_model_free(_ model: LlamaModelPtr)
 
+@_silgen_name("llama_model_n_layer")
+private func c_llama_model_n_layer(_ model: LlamaModelPtr) -> Int32
+
 @_silgen_name("llama_model_default_params")
 private func c_llama_model_default_params() -> LlamaModelParamsBag
 
@@ -650,8 +653,53 @@ public final class LlamaBridgeImpl {
 
     private static func mobileBatchSizes(contextSize: UInt32) -> (logical: UInt32, physical: UInt32) {
         let logical = max(UInt32(1), min(contextSize, UInt32(4096)))
-        let physicalLimit: UInt32 = Self.isRunningInSimulator ? 512 : 1024
+        // #11612 GPU-OOM fix: the Metal compute buffer scales ~linearly with
+        // the physical micro-batch (n_ubatch). Measured on iPhone 16 Pro Max
+        // (A18): 1037 MiB at n_ubatch=1024, which pushed weights (4722 MiB,
+        // full offload) + compute + KV (36 MiB) ≈ 5795 MiB past the ~5461 MiB
+        // jetsam working set (2/3 of 8 GiB) → decode ret=-3 + jetsam. At 256
+        // the compute buffer is ~260 MiB: 4722 + 260 + 36 ≈ 5018 MiB fits
+        // with full-GPU speed retained. Prefill still chunks by the logical
+        // batch; llama.cpp splits it into n_ubatch slices internally.
+        let physicalLimit: UInt32 = Self.isRunningInSimulator ? 512 : 256
         return (logical, max(UInt32(1), min(logical, physicalLimit)))
+    }
+
+    /// Per-element Metal compute-buffer cost for the physical micro-batch:
+    /// 1037 MiB measured at n_ubatch=1024 on the mobile 4b tier (A18), plus
+    /// ~5% slack → ~1.05 MiB per element.
+    private static let computeBytesPerUbatchElement: UInt64 = 1_100_000
+
+    /// Wire-cost estimate for one loaded context at `ctx` tokens: KV +
+    /// per-token scratch, the n_ubatch-scaled compute buffer, and fixed
+    /// runtime overhead (Metal heaps, tokenizer, batch buffers, mmap page-in
+    /// slack). Weights are added by the caller — they are only wired for the
+    /// GPU-offloaded fraction of layers.
+    private static func nonWeightBytes(contextSize: UInt32) -> UInt64 {
+        let perTokenBytes: UInt64 = 64 * 1024
+        let computeBytes =
+            UInt64(Self.mobileBatchSizes(contextSize: contextSize).physical)
+            * Self.computeBytesPerUbatchElement
+        let runtimeOverheadBytes: UInt64 = 256 * 1024 * 1024
+        return UInt64(contextSize) * perTokenBytes + computeBytes + runtimeOverheadBytes
+    }
+
+    /// Read the transformer layer count from a GGUF via a CPU-only,
+    /// mmap-backed metadata load (no Metal wiring; clean pages only). Used
+    /// exclusively on the degraded partial-offload path, so the extra load
+    /// is paid only when the model already failed full-offload admission.
+    private static func probeLayerCount(path: String) -> Int32? {
+        var params = c_llama_model_default_params()
+        withUnsafeMutablePointer(to: &params) { ptr in
+            shim_model_params_set_n_gpu_layers(ptr, 0)
+            Self.forceModelCpuOnly(ptr)
+        }
+        guard let model = path.withCString({ cpath in
+            c_llama_model_load_from_file(cpath, params)
+        }) else { return nil }
+        defer { c_llama_model_free(model) }
+        let layers = c_llama_model_n_layer(model)
+        return layers > 0 ? layers : nil
     }
 
     /// Synchronously loads a GGUF and returns either a context_id or an error.
@@ -683,33 +731,60 @@ public final class LlamaBridgeImpl {
 
         // #11612: a load that exceeds the per-process jetsam budget kills the
         // app (and on constrained devices can wedge the OS). Estimate the
-        // footprint up front, shrink the context/KV first, and fail cleanly
-        // with a memory error when even the minimum context cannot fit.
+        // footprint up front — GPU-wired weights + KV/scratch + the
+        // n_ubatch-scaled Metal compute buffer + fixed overhead — then admit
+        // in order of least harm: shrink the context/KV first, next reduce
+        // the GPU layer offload (CPU-resident layers stay mmap-backed clean
+        // pages, which do not count against the jetsam footprint the way
+        // wired Metal buffers do), and only fail when not even a zero-offload
+        // load fits. Fit math (iPhone 16 Pro Max, A18, 8 GiB → ~5461 MiB
+        // headroom): weights 4722 + compute ~260 (n_ubatch 256) + KV 36
+        // ≈ 5018 MiB → full offload admitted.
+        let canUseGPU = useGPU && shim_has_metal() && !Self.isRunningInSimulator
         var resolvedContextSize = contextSize
+        var nGpuLayers: Int32 = canUseGPU ? 999 : 0
         let headroom = Self.jetsamHeadroomBytes()
         if headroom > 0 {
             let modelBytes = Self.fileSizeBytes(path)
             let drafterBytes = draftModelPath.map { Self.fileSizeBytes($0) } ?? 0
-            // ~64 KiB of KV cache + compute scratch per context token is a
-            // conservative envelope for the mobile (2b/4b) tiers with f16 KV
-            let perTokenBytes: UInt64 = 64 * 1024
-            // Metal heaps, tokenizer, batch buffers, and mmap page-in slack
-            let runtimeOverheadBytes: UInt64 = 512 * 1024 * 1024
             let minContext: UInt32 = 1024
-            func requiredBytes(_ ctx: UInt32) -> UInt64 {
-                modelBytes + drafterBytes + UInt64(ctx) * perTokenBytes + runtimeOverheadBytes
+            // When the GPU is off, weights are never wired — mmap pages them
+            // lazily and the OS can evict them — so only the wired fraction
+            // of the weights counts toward the budget.
+            func requiredBytes(_ ctx: UInt32, wiredWeightBytes: UInt64) -> UInt64 {
+                wiredWeightBytes + drafterBytes + Self.nonWeightBytes(contextSize: ctx)
             }
-            while requiredBytes(resolvedContextSize) > headroom && resolvedContextSize / 2 >= minContext {
+            let fullWeightBytes = canUseGPU ? modelBytes : 0
+            while requiredBytes(resolvedContextSize, wiredWeightBytes: fullWeightBytes) > headroom
+                && resolvedContextSize / 2 >= minContext {
                 resolvedContextSize /= 2
             }
-            if requiredBytes(resolvedContextSize) > headroom {
-                let needMB = requiredBytes(resolvedContextSize) / (1024 * 1024)
-                let haveMB = headroom / (1024 * 1024)
-                return .failure(
-                    "llama_load_model: insufficient memory: \(path) needs ~\(needMB) MB "
-                    + "(ctx \(resolvedContextSize)) but only \(haveMB) MB is available before "
-                    + "the OS memory limit. Close other apps or use a smaller model."
-                )
+            if requiredBytes(resolvedContextSize, wiredWeightBytes: fullWeightBytes) > headroom {
+                let fixedBytes = requiredBytes(resolvedContextSize, wiredWeightBytes: 0)
+                if canUseGPU && headroom > fixedBytes && modelBytes > 0 {
+                    // Partial offload: wire only the fitting fraction of
+                    // layers. Layer count comes from a CPU-only metadata
+                    // probe of the same GGUF (exact, no guessed constants).
+                    let weightBudget = headroom - fixedBytes
+                    let layerCount = Self.probeLayerCount(path: path) ?? 36
+                    let fitting = Int32(
+                        (Double(weightBudget) / Double(modelBytes)) * Double(layerCount)
+                    )
+                    nGpuLayers = max(0, min(layerCount, fitting))
+                    NSLog(
+                        "[LlamaBridgeImpl] memory budget: reduced n_gpu_layers 999 -> \(nGpuLayers)/\(layerCount) "
+                        + "(weights \(modelBytes / 1024 / 1024) MB > budget \(weightBudget / 1024 / 1024) MB, "
+                        + "headroom \(headroom / 1024 / 1024) MB, ctx \(resolvedContextSize))"
+                    )
+                } else {
+                    let needMB = requiredBytes(resolvedContextSize, wiredWeightBytes: fullWeightBytes) / (1024 * 1024)
+                    let haveMB = headroom / (1024 * 1024)
+                    return .failure(
+                        "llama_load_model: insufficient memory: \(path) needs ~\(needMB) MB "
+                        + "(ctx \(resolvedContextSize)) but only \(haveMB) MB is available before "
+                        + "the OS memory limit. Close other apps or use a smaller model."
+                    )
+                }
             }
             if resolvedContextSize != contextSize {
                 NSLog(
@@ -722,8 +797,6 @@ public final class LlamaBridgeImpl {
         let resolvedThreads = threads ?? min(4, Int32(ProcessInfo.processInfo.activeProcessorCount))
 
         var modelParams = c_llama_model_default_params()
-        let canUseGPU = useGPU && shim_has_metal() && !Self.isRunningInSimulator
-        let nGpuLayers: Int32 = canUseGPU ? 999 : 0
         withUnsafeMutablePointer(to: &modelParams) { ptr in
             shim_model_params_set_n_gpu_layers(ptr, nGpuLayers)
             if !canUseGPU {

--- a/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
+++ b/plugins/plugin-native-llama/src/capacitor-llama-adapter.ts
@@ -660,7 +660,12 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
       ...(isEmbedding ? {} : { swa_full: false }),
       embedding: isEmbedding,
       n_batch: options.mobileSpeculative ? 128 : 512,
-      n_ubatch: options.mobileSpeculative ? 64 : 512,
+      // #11612: the GPU compute buffer scales ~linearly with n_ubatch
+      // (~1.01 MiB per element measured on A18). 256 keeps it ~260 MiB so
+      // full-offload weights (4722 MiB on the 4b tier) + compute + KV stay
+      // under the ~5461 MiB iOS jetsam working set. n_ubatch ≤ n_batch is
+      // preserved (llama.cpp splits the logical batch internally).
+      n_ubatch: options.mobileSpeculative ? 64 : 256,
       ...(options.draftModelPath
         ? {
             draft_model: options.draftModelPath,
@@ -678,10 +683,22 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
       ...(options.disableThinking ? { reasoning: false } : {}),
     };
 
-    await plugin.initContext({
-      contextId: this.contextId,
-      params,
-    });
+    try {
+      await plugin.initContext({
+        contextId: this.contextId,
+        params,
+      });
+    } catch (err) {
+      // Unload-on-failure (#11612): a failed/partial init must not leave
+      // wired GPU buffers mapped — on iOS that footprint alone gets the
+      // process jetsammed on the next allocation.
+      try {
+        await plugin.releaseContext({ contextId: this.contextId });
+      } catch {
+        // Native side may have already cleaned up the failed context.
+      }
+      throw err;
+    }
 
     // Fork builds expose a separate `setSpecType` bridge that configures
     // the MTP drafter after the main context is up. Stock builds lack
@@ -994,6 +1011,21 @@ export class CapacitorLlamaAdapter implements LlamaAdapter {
     }
 
     if (completionState.error) {
+      // Unload-on-failure (#11612): a failed decode (e.g. Metal ret=-3 GPU
+      // OOM) must release the model instead of leaving multi-GiB wired
+      // buffers mapped until jetsam kills the process. The next generate
+      // reloads lazily via the loader's ensure-loaded path.
+      try {
+        await this.unload();
+      } catch (unloadErr) {
+        console.warn(
+          "[capacitor-llama] failed to unload after generation error",
+          {
+            error:
+              unloadErr instanceof Error ? unloadErr.message : String(unloadErr),
+          },
+        );
+      }
       yield {
         kind: "error",
         message: completionState.error.message,


### PR DESCRIPTION
Final layer of #11612. The crash-loop + bf16 kernel fixes are already on develop (#11746). Real-device retest then hit **GPU OOM**: eliza-1-2b fully offloaded (`n_gpu_layers:999`) + a 1 GB compute buffer (`n_ubatch:1024`) ≈ 5.8 GB > the A18 Pro's ~5.46 GB Metal working-set → `llama_decode ret=-3` + jetsam.

## Fix (both the TS adapter and the LIVE native path)
The `plugin-local-inference/src/adapters/capacitor-llama` file is stubbed out of the iOS agent bundle — the load that actually jetsams runs through `LlamaBridgeImpl.swift` + `plugin-native-llama`. Fixed **both**:
- **`n_ubatch/n_batch: 256`** on mobile (`ELIZA_PLATFORM=ios|android`) — compute buffer 1037 → ~260 MiB.
- **Memory admission**: computed `n_gpu_layers` vs the working-set budget (`os_proc_available_memory` on iOS / `os.totalmem()×2/3`), ctx-shrink → layer-reduction → clean `MobileMemoryAdmissionError` (never OOM the GPU). Desktop untouched (full offload).
- **Unload-on-failure**: release the model on load/decode failure so it doesn't stay mapped and jetsam later.

## Fit math (iPhone 16 Pro Max, A18)
Before: 4722 (weights) + 1037 (compute) + 36 (KV) ≈ **5795 MiB** → OOM. After: 4722 + ~260 + 36 ≈ **5018 MiB < 5461** → full 36-layer GPU offload retained, ~440 MiB headroom. Pinned in `memory-admission.test.ts`.

## Verification
`plugin-local-inference` typecheck clean; `plugin-native-llama` tsc + 39/39 vitest green; biome clean; Swift compiled into the shipped dylib. **On-device reply capture on MoonCycles is operator-gated** — the phone re-locked after a reboot; the fixed `.app` is built and installs the moment it's unlocked (one-command replay in the #11612 evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)