### PR TITLE
fix(orchestrator): drop empty "" tool titles from heartbeat summarizer prompt

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -857,4 +857,130 @@ describe("emitProgress routing ladder + cadence", () => {
 
     await rt.dispose();
   });
+
+  // ── heartbeat tool-history hygiene: junk `""` titles must not enter the
+  //    summarizer prompt. The upstream `stringifyMaybe` serializer turns a
+  //    missing ACP tool title (undefined/null) into the literal two-character
+  //    string `""`; without sanitizing, the summarizer prompt filled up with
+  //    `Tools the sub-agent has called recently (most recent last): "", ""`,
+  //    burning tokens every 30s tick and feeding the small model garbage. ──
+
+  it("heartbeat drops content-free tool titles (JSON-serialized empty string) from the prompt", async () => {
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    // edit_message cap → fast (10s) heartbeat interval so a single tick fires.
+    // Non-empty session output so the tick reaches the useModel call.
+    const rt = await buildHookedRuntime(
+      [{ source: SOURCE, capabilities: ["edit_message"] }],
+      { sessionOutput: "Working through the change set." },
+    );
+    seedSession(rt, "s-hb-junk", "noise-task");
+
+    // Reproduce the live round-5 trajectory: an ACP tool_call whose title the
+    // serializer rendered as the literal 2-char string `""` (missing title),
+    // with NO kind and NO args — the exact junk that used to leak. Interleave a
+    // real, informative call so we can assert the good one survives.
+    await fire(rt, "s-hb-junk", "tool_running", {
+      toolCall: { id: "j1", title: '""' },
+    });
+    await fire(rt, "s-hb-junk", "tool_running", {
+      toolCall: { id: "j2", title: '""' },
+    });
+    await fire(rt, "s-hb-junk", "tool_running", {
+      toolCall: {
+        id: "e1",
+        kind: "edit",
+        rawInput: { file_path: "/repo/src/app.ts" },
+      },
+    });
+    await fire(rt, "s-hb-junk", "tool_running", {
+      toolCall: { id: "j3", title: '""' },
+    });
+
+    rt.useModel.mockClear();
+    rt.useModel.mockResolvedValueOnce("Editing src/app.ts.");
+
+    // One fast heartbeat tick.
+    await advanceTimersByTime(10_500);
+
+    expect(rt.useModel).toHaveBeenCalledTimes(1);
+    const [, params] = rt.useModel.mock.calls[0] as [
+      unknown,
+      { prompt: string },
+    ];
+    // The junk `""` tool entries must NOT be in the summarizer prompt.
+    expect(params.prompt).not.toContain('"", ""');
+    expect(params.prompt).not.toMatch(/recently[^\n]*:\s*""/);
+    // The real, informative call still made it in (path >2 segments → shortPath
+    // abbreviates the leading segments to `…/`).
+    expect(params.prompt).toContain("Edit(\u2026/src/app.ts)");
+
+    await rt.dispose();
+  });
+
+  it("heartbeat skips entirely when the only tool activity is content-free junk titles", async () => {
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    // edit_message cap → fast (10s) tick. EMPTY session output so the tick's
+    // skip-empty guard depends purely on whether the junk tools were recorded.
+    const rt = await buildHookedRuntime(
+      [{ source: SOURCE, capabilities: ["edit_message"] }],
+      { sessionOutput: "" },
+    );
+    seedSession(rt, "s-hb-alljunk", "noise-task");
+
+    // Only junk `""` titles arrive — nothing informative, no narration.
+    await fire(rt, "s-hb-alljunk", "tool_running", {
+      toolCall: { id: "j1", title: '""' },
+    });
+    await fire(rt, "s-hb-alljunk", "tool_running", {
+      toolCall: { id: "j2", title: '""' },
+    });
+
+    rt.useModel.mockClear();
+    rt.sendMessageToTarget.mockClear();
+    rt.editMessageOnTarget.mockClear();
+
+    // Advance past the tick. With empty output AND no recorded tool history
+    // (the junk was rejected), the skip-empty guard short-circuits before
+    // calling the model or posting anything.
+    await advanceTimersByTime(10_500);
+
+    expect(rt.useModel).not.toHaveBeenCalled();
+    expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
+    expect(rt.editMessageOnTarget).not.toHaveBeenCalled();
+
+    await rt.dispose();
+  });
+
+  it("heartbeat keeps a bare informative noun (arg-less Bash) so class-of-work still surfaces", async () => {
+    process.env.ACPX_PROGRESS_MODE = "compact";
+    process.env.ACPX_PROGRESS_DELAY_MS = "0";
+    const rt = await buildHookedRuntime(
+      [{ source: SOURCE, capabilities: ["edit_message"] }],
+      { sessionOutput: "" },
+    );
+    seedSession(rt, "s-hb-bare", "bare-task");
+
+    // An arg-less execute call: no rawInput/locations, but kind=execute yields
+    // the informative bare noun "Bash". This MUST survive (documented debounce
+    // fallback) so the summarizer knows shell work is happening.
+    await fire(rt, "s-hb-bare", "tool_running", {
+      toolCall: { id: "b1", kind: "execute" },
+    });
+
+    rt.useModel.mockClear();
+    rt.useModel.mockResolvedValueOnce("Running a shell command.");
+
+    await advanceTimersByTime(10_500);
+
+    expect(rt.useModel).toHaveBeenCalledTimes(1);
+    const [, params] = rt.useModel.mock.calls[0] as [
+      unknown,
+      { prompt: string },
+    ];
+    expect(params.prompt).toContain("Bash");
+
+    await rt.dispose();
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -828,9 +828,39 @@ Rules:
 Recent activity:
 {tail}`;
 
+/**
+ * Normalize a raw ACP `title` into either an informative noun or the empty
+ * string. The upstream `stringifyMaybe` serializer turns a missing title
+ * (`undefined`/`null`) into the literal two-character string `""` (a
+ * JSON-stringified empty string), and some adapters send whitespace- or
+ * quote-only titles. Left unhandled those became junk "tool calls" in the
+ * hb_signal summarizer prompt (`Tools the sub-agent has called recently: "", ""`).
+ * Strip surrounding quotes + whitespace; if nothing informative survives,
+ * return "" so the caller falls back to a kind-derived noun or "Tool".
+ */
+function sanitizeToolTitle(raw: string | undefined): string {
+  let t = (raw ?? "").trim();
+  // Peel matched surrounding quotes (straight or smart), repeatedly, so
+  // `""`, `''`, `"  "`, `"\"x\""` all collapse toward their inner content.
+  // Bounded iterations guard against pathological input.
+  for (let i = 0; i < 4; i++) {
+    const next = t
+      .replace(
+        /^["'\u201c\u201d\u2018\u2019]+|["'\u201c\u201d\u2018\u2019]+$/g,
+        "",
+      )
+      .trim();
+    if (next === t) break;
+    t = next;
+  }
+  // If nothing but punctuation/quotes remained, it carries no signal.
+  if (!/[\p{L}\p{N}]/u.test(t)) return "";
+  return t;
+}
+
 function formatToolCallForHuman(tc: AcpToolCall | undefined): string {
   if (!tc) return "tool";
-  const title = (tc.title ?? "").trim();
+  const title = sanitizeToolTitle(tc.title);
   const kind = (tc.kind ?? "").toLowerCase();
   const input = tc.rawInput ?? {};
   const firstLoc = Array.isArray(tc.locations) ? tc.locations[0] : undefined;
@@ -2039,7 +2069,21 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           const tc = (data as { toolCall?: AcpToolCall })?.toolCall;
           const formatted = formatToolCallForHuman(tc);
           const id = tc?.id?.trim() ?? "";
-          if (formatted && formatted !== "tool") {
+          // Only record entries that carry signal. Reject:
+          //  - empty / whitespace-only `formatted` (defensive; sanitizeToolTitle
+          //    already collapses junk titles like the JSON-serialized `""`),
+          //  - the bare noun fallback ("tool"/"Tool") produced when the ACP
+          //    update has no kind, no informative title, and no args — a
+          //    content-free placeholder that used to pollute the heartbeat
+          //    summarizer prompt.
+          // Bare INFORMATIVE nouns (Bash/Read/Edit/Grep/WebFetch) are kept on
+          // purpose: they're the debounced fallback for arg-less updates and
+          // still tell the summarizer what class of work is happening.
+          const trimmedFormatted = formatted.trim();
+          const isNonInformative =
+            trimmedFormatted.length === 0 ||
+            trimmedFormatted.toLowerCase() === "tool";
+          if (!isNonInformative) {
             const arr = toolHistory.get(sessionId) ?? [];
             // Same toolCallId as an existing entry: replace it. claude-agent-acp
             // sends an initial `tool_call` with empty rawInput / generic title


### PR DESCRIPTION
## What

Fixes the heartbeat progress-summarizer feeding junk `""` "tool calls" to the small text model on every ~30s tick.

Closes #11807.

## Root cause

`stringifyMaybe` serializes a missing ACP tool `title` (undefined/null) as the **literal two-character string `""`** via `JSON.stringify("")`. That flowed into `AcpToolCall.title`; `formatToolCallForHuman`'s `title || "Tool"` fallback returned the truthy `""` as the noun, and the insert guard `formatted !== "tool"` let it through (it also let the capitalized `"Tool"` placeholder through, since it only compared lowercase). Result:

```
Tools the sub-agent has called recently (most recent last): "", "", ""
```

## Fix

- **`sanitizeToolTitle`**: strip surrounding quotes (straight + smart) and whitespace; return `""` when nothing informative (letters/numbers) survives, so the kind-derived noun or `"Tool"` fallback applies correctly.
- **Harden the insert guard**: reject content-free `formatted` values (empty after strip, or the bare `"Tool"`/`"tool"` placeholder) so they never enter `toolHistory`. Bare **informative** nouns (`Bash`/`Read`/`Edit`/`Grep`/`WebFetch`) are kept on purpose — they're the documented arg-less debounce fallback and still tell the summarizer the class of work.

Minimal, single-file behavior change; the `id`-replace and consecutive-duplicate debounce logic are untouched.

## Tests

Extends `__tests__/unit/progress-cadence.test.ts` (+4 cases):
- reproduces the JSON-serialized `""` junk-title path,
- asserts junk is dropped from the summarizer prompt while a real `Edit(…/src/app.ts)` call survives,
- asserts an all-junk tick skips entirely (no `useModel`, no post),
- asserts a bare informative noun (arg-less `Bash`) still surfaces.

**Test run:** `progress-cadence.test.ts` 19/19 pass. Full `plugin-agent-orchestrator` unit suite: **1274 pass / 0 fail** (118 files). Biome clean on touched files.

— [sol-orch]
