### PR TITLE
fix: validate scheduled task input before persistence

### DIFF
--- a/.github/issue-evidence/11791-scheduled-task-validation/README.md
+++ b/.github/issue-evidence/11791-scheduled-task-validation/README.md
@@ -1,0 +1,44 @@
+# Issue #11791 — scheduled-task structural validation
+
+## Change
+
+- Added shared pre-persistence validation for `ScheduledTask` inputs in `@elizaos/plugin-scheduling`.
+- Validation now rejects malformed required fields, trigger variants, unregistered gates, malformed built-in gate params, unregistered completion checks, invalid output destinations, escalation channel/ladder shape, and invalid inline pipeline children before any row is written.
+- REST schedule returns HTTP 400 for validation errors.
+- PA `SCHEDULED_TASKS` create returns `INVALID_SCHEDULED_TASK` with issue details instead of throwing.
+- PA integration config now includes the scheduled-task action integration file so this path is exercised by the package integration lane.
+
+## Verification
+
+```bash
+bun run --cwd plugins/plugin-scheduling build
+bun run --cwd plugins/plugin-scheduling typecheck
+bun run --cwd plugins/plugin-scheduling lint
+bunx vitest run --config plugins/plugin-scheduling/vitest.config.ts src/scheduled-task/runner.test.ts src/routes/scheduled-tasks.test.ts --reporter=dot
+bun run --cwd plugins/plugin-personal-assistant lint:default-packs
+bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts --reporter=dot
+git diff --check
+bun install
+bun run verify
+```
+
+Results:
+
+- Scheduling focused runner/REST tests: 2 files passed, 67 tests passed.
+- PA scheduled-task action integration: 1 file passed, 4 tests passed.
+- PA default-pack lint: clean, 0 findings.
+- Scheduling build, typecheck, lint, and `git diff --check`: passed.
+- Post-rebase `bun install`: completed; artifact sync restored tracked side effects before PR.
+
+## Known Non-Blocking Verification Output
+
+`bun run verify` was run after rebasing on `origin/develop` and failed at `audit:type-safety-ratchet` before package typecheck/lint. The ratchet reports current `?? ""` usage in core/agent/app-core as `616 / 615`, with top contributors in `packages/core/src/services/message.ts`, `packages/agent/src/api/wallet-evm-balance.ts`, and other files outside this change.
+
+`bun run --cwd plugins/plugin-personal-assistant typecheck` was run and failed on pre-existing package-wide issues outside this change, including unresolved workspace package types such as `@elizaos/shared`, `@elizaos/agent`, and multiple stale `../contracts/index.js` exports. The failure list is broad and not in the touched files.
+
+## Evidence Matrix
+
+- Real LLM trajectories: N/A - this change validates structural scheduled-task input after model/action output; no prompt/model behavior changed.
+- Backend logs: N/A - focused unit/integration tests directly assert the backend persistence boundary and response shape.
+- Frontend screenshots/video: N/A - no UI surface changed.
+- Domain artifacts: covered by tests asserting rejected malformed runner, REST, and PA action inputs leave scheduled-task storage empty.

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -50,6 +50,7 @@ import type {
   ScheduledTaskSubjectKind,
   ScheduledTaskTrigger,
 } from "../lifeops/scheduled-task/index.js";
+import { ScheduledTaskValidationError } from "../lifeops/scheduled-task/index.js";
 import { getScheduledTaskRunner } from "../lifeops/scheduled-task/service.js";
 import { OWNER_OPERATION_VALIDATE } from "./life.js";
 
@@ -616,36 +617,56 @@ async function handleCreate(
       ? { pendingPromptRoomId: scope.roomId }
       : {}),
   };
-  const created = await scope.runner.schedule({
-    kind,
-    promptInstructions,
-    trigger,
-    priority,
-    ...(params.contextRequest ? { contextRequest: params.contextRequest } : {}),
-    ...(params.shouldFire ? { shouldFire: params.shouldFire } : {}),
-    ...(params.completionCheck
-      ? { completionCheck: params.completionCheck }
-      : {}),
-    ...(params.escalation ? { escalation: params.escalation } : {}),
-    ...(params.output
-      ? { output: params.output }
-      : scope.roomId
-        ? {
-            output: {
-              destination: "channel",
-              target: `in_app:${scope.roomId}`,
-            },
-          }
+  let created: ScheduledTask;
+  try {
+    created = await scope.runner.schedule({
+      kind,
+      promptInstructions,
+      trigger,
+      priority,
+      ...(params.contextRequest
+        ? { contextRequest: params.contextRequest }
         : {}),
-    ...(params.pipeline ? { pipeline: params.pipeline } : {}),
-    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-    ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
-    respectsGlobalPause: params.respectsGlobalPause ?? true,
-    source: params.source ?? "user_chat",
-    createdBy: scope.agentId,
-    ownerVisible: params.ownerVisible ?? true,
-    ...(subject ? { subject } : {}),
-  });
+      ...(params.shouldFire ? { shouldFire: params.shouldFire } : {}),
+      ...(params.completionCheck
+        ? { completionCheck: params.completionCheck }
+        : {}),
+      ...(params.escalation ? { escalation: params.escalation } : {}),
+      ...(params.output
+        ? { output: params.output }
+        : scope.roomId
+          ? {
+              output: {
+                destination: "channel",
+                target: `in_app:${scope.roomId}`,
+              },
+            }
+          : {}),
+      ...(params.pipeline ? { pipeline: params.pipeline } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      ...(params.idempotencyKey
+        ? { idempotencyKey: params.idempotencyKey }
+        : {}),
+      respectsGlobalPause: params.respectsGlobalPause ?? true,
+      source: params.source ?? "user_chat",
+      createdBy: scope.agentId,
+      ownerVisible: params.ownerVisible ?? true,
+      ...(subject ? { subject } : {}),
+    });
+  } catch (error) {
+    if (error instanceof ScheduledTaskValidationError) {
+      return {
+        success: false,
+        text: `Scheduled task validation failed: ${error.issues.join("; ")}`,
+        data: {
+          subaction: "create",
+          error: "INVALID_SCHEDULED_TASK",
+          issues: error.issues,
+        },
+      };
+    }
+    throw error;
+  }
   return {
     success: true,
     text: `Scheduled ${kind} task ${created.taskId}.`,

--- a/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts
@@ -123,6 +123,50 @@ describe("SCHEDULED_TASK action", () => {
     );
   });
 
+  it("rejects malformed LLM-supplied gate structure before writing a row (#11791)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+
+    const result = await scheduledTaskAction.handler?.(
+      runtime,
+      ownerMessage(runtime.agentId, "schedule a gated reminder"),
+      undefined,
+      {
+        parameters: {
+          subaction: "create",
+          kind: "reminder",
+          promptInstructions: "drink a glass of water",
+          trigger: { kind: "manual" },
+          priority: "medium",
+          shouldFire: {
+            gates: [{ kind: "not_registered", params: {} }],
+          },
+        },
+      },
+      undefined,
+      [],
+    );
+
+    expect(result?.success).toBe(false);
+    expect((result?.data as { error?: string } | undefined)?.error).toBe(
+      "INVALID_SCHEDULED_TASK",
+    );
+    expect(
+      JSON.stringify((result?.data as { issues?: string[] }).issues),
+    ).toContain("not_registered");
+
+    const listed = await scheduledTaskAction.handler?.(
+      runtime,
+      ownerMessage(runtime.agentId, "list scheduled tasks"),
+      undefined,
+      { parameters: { subaction: "list" } },
+      undefined,
+      [],
+    );
+    const tasks = (listed?.data as { tasks?: ScheduledTask[] }).tasks ?? [];
+    expect(tasks).toHaveLength(0);
+  });
+
   it("get returns NOT_FOUND for an unknown taskId", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;

--- a/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     ...baseConfig.test,
     include: [
       `${packageRootFromRepo}/src/**/*.integration.test.{ts,tsx}`,
+      `${packageRootFromRepo}/test/scheduled-task-action.integration.test.ts`,
       `${packageRootFromRepo}/test/global-pause.integration.test.ts`,
     ],
     exclude: [

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
@@ -144,6 +144,32 @@ describe("scheduled-tasks REST handler", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("POST schedule returns 400 for unknown gates before persistence (#11791)", async () => {
+    const runner = makeRunner();
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "drink water",
+        trigger: { kind: "manual" },
+        priority: "low",
+        respectsGlobalPause: true,
+        source: "user_chat",
+        createdBy: "tester",
+        ownerVisible: true,
+        shouldFire: { gates: [{ kind: "not_registered" }] },
+      },
+    });
+    await handler(ctx);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("not_registered");
+    expect(await runner.list()).toHaveLength(0);
+  });
+
   it("GET /api/lifeops/scheduled-tasks lists tasks", async () => {
     const runner = makeRunner();
     await runner.schedule({

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -29,6 +29,7 @@ import {
   scheduledTaskInputSchema,
   scheduledTaskSnoozePayloadSchema,
 } from "../scheduled-task/schema.js";
+import { ScheduledTaskValidationError } from "../scheduled-task/validation.js";
 
 /**
  * Minimal generic route context. A host adapts its own request/response
@@ -216,10 +217,18 @@ export function makeScheduledTasksRouteHandler(
         );
         return true;
       }
-      const task = await runner.schedule(
-        parsed.data as Omit<ScheduledTask, "taskId" | "state">,
-      );
-      json(res, { task }, 201);
+      try {
+        const task = await runner.schedule(
+          parsed.data as Omit<ScheduledTask, "taskId" | "state">,
+        );
+        json(res, { task }, 201);
+      } catch (err) {
+        if (err instanceof ScheduledTaskValidationError) {
+          error(res, err.message, 400);
+          return true;
+        }
+        throw err;
+      }
       return true;
     }
 

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -163,3 +163,8 @@ export {
   DEFAULT_TASK_EXECUTION_PROFILE,
   TASK_EXECUTION_PROFILES,
 } from "./types.js";
+export {
+  type ScheduledTaskValidationDeps,
+  ScheduledTaskValidationError,
+  validateScheduledTaskInput,
+} from "./validation.js";

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -55,6 +55,7 @@ import type {
   SubjectStoreView,
   TaskGateContribution,
 } from "./types.js";
+import { ScheduledTaskValidationError } from "./validation.js";
 
 // ---------------------------------------------------------------------------
 // Test harness
@@ -219,6 +220,83 @@ describe("ScheduledTaskRunner — schedule + idempotency", () => {
           (l.reason ?? "").includes("pipeline.onSkip overrides"),
       ),
     ).toBe(true);
+  });
+
+  it("rejects unknown shouldFire gates before persistence (#11791)", async () => {
+    const h = makeHarness();
+    await expect(
+      h.runner.schedule(
+        baseInput({
+          shouldFire: {
+            gates: [{ kind: "not_registered", params: {} }],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ScheduledTaskValidationError);
+    expect(await h.runner.list()).toHaveLength(0);
+  });
+
+  it("rejects malformed built-in gate params before persistence (#11791)", async () => {
+    const h = makeHarness();
+    await expect(
+      h.runner.schedule(
+        baseInput({
+          shouldFire: {
+            gates: [
+              {
+                kind: "weekday_only",
+                params: { weekdays: ["monday"] },
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toThrow(/weekdays must contain integers 0\.\.6/);
+    expect(await h.runner.list()).toHaveLength(0);
+  });
+
+  it("rejects unknown completion checks and invalid output kinds before persistence (#11791)", async () => {
+    const h = makeHarness();
+    await expect(
+      h.runner.schedule(
+        baseInput({
+          completionCheck: { kind: "made_up_check" },
+        }),
+      ),
+    ).rejects.toThrow(
+      /completionCheck\.kind "made_up_check" is not registered/,
+    );
+    await expect(
+      h.runner.schedule(
+        baseInput({
+          output: { destination: "invalid_output" } as never,
+        }),
+      ),
+    ).rejects.toThrow(/output\.destination "invalid_output" is invalid/);
+    expect(await h.runner.list()).toHaveLength(0);
+  });
+
+  it("rejects invalid inline pipeline children before any parent or child write (#11791)", async () => {
+    const h = makeHarness();
+    await expect(
+      h.runner.schedule(
+        baseInput({
+          pipeline: {
+            onComplete: [
+              baseInput({
+                promptInstructions: "bad child",
+                completionCheck: {
+                  kind: "not_registered_child_check",
+                },
+              }) as never,
+            ],
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      /pipeline\.onComplete\[0\]\.completionCheck\.kind "not_registered_child_check" is not registered/,
+    );
+    expect(await h.runner.list()).toHaveLength(0);
   });
 });
 

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -54,6 +54,10 @@ import {
   type TaskExecutionProfile,
   type TerminalState,
 } from "./types.js";
+import {
+  ScheduledTaskValidationError,
+  validateScheduledTaskInput,
+} from "./validation.js";
 
 /**
  * Typed error thrown by `runner.schedule()` when an `escalation.steps[].channelKey`
@@ -683,6 +687,11 @@ export function createScheduledTaskRunner(
         input.idempotencyKey,
       );
       if (existing) return existing;
+    }
+
+    const validationIssues = validateScheduledTaskInput(input, deps);
+    if (validationIssues.length > 0) {
+      throw new ScheduledTaskValidationError(validationIssues);
     }
 
     // A11: channel-key validation against the runtime ChannelRegistry.

--- a/plugins/plugin-scheduling/src/scheduled-task/schema.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/schema.ts
@@ -95,14 +95,12 @@ const scheduledTaskTriggerSchema = z.discriminatedUnion("kind", [
 
 const scheduledTaskShouldFireSchema = z.object({
   compose: z.enum(["all", "any", "first_deny"]).optional(),
-  gates: z
-    .array(
-      z.object({
-        kind: z.string().min(1),
-        params: z.unknown().optional(),
-      }),
-    )
-    .min(1),
+  gates: z.array(
+    z.object({
+      kind: z.string().min(1),
+      params: z.unknown().optional(),
+    }),
+  ),
 });
 
 const scheduledTaskCompletionCheckSchema = z.object({

--- a/plugins/plugin-scheduling/src/scheduled-task/validation.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/validation.ts
@@ -1,0 +1,523 @@
+import type { CompletionCheckRegistry } from "./completion-check-registry.js";
+import type { EscalationLadderRegistry } from "./escalation.js";
+import type { TaskGateRegistry } from "./gate-registry.js";
+import {
+  type ScheduledTask,
+  type ScheduledTaskInput,
+  type ScheduledTaskKind,
+  type ScheduledTaskOutputDestination,
+  type ScheduledTaskPriority,
+  type ScheduledTaskRef,
+  type ScheduledTaskSource,
+  type ScheduledTaskSubjectKind,
+  TASK_EXECUTION_PROFILES,
+} from "./types.js";
+
+export class ScheduledTaskValidationError extends Error {
+  readonly code = "scheduled_task_validation_failed";
+
+  constructor(
+    readonly issues: string[],
+    readonly path = "task",
+  ) {
+    super(`${path}: ${issues.join("; ")}`);
+    this.name = "ScheduledTaskValidationError";
+  }
+}
+
+export interface ScheduledTaskValidationDeps {
+  gates: TaskGateRegistry;
+  completionChecks: CompletionCheckRegistry;
+  ladders: EscalationLadderRegistry;
+  channelKeys?: () => ReadonlySet<string>;
+}
+
+const TERMINAL_STATES = new Set([
+  "completed",
+  "skipped",
+  "expired",
+  "failed",
+  "dismissed",
+]);
+
+const TASK_KINDS = new Set<ScheduledTaskKind>([
+  "reminder",
+  "checkin",
+  "followup",
+  "approval",
+  "recap",
+  "watcher",
+  "output",
+  "custom",
+]);
+
+const TASK_PRIORITIES = new Set<ScheduledTaskPriority>([
+  "low",
+  "medium",
+  "high",
+]);
+
+const TASK_SOURCES = new Set<ScheduledTaskSource>([
+  "default_pack",
+  "user_chat",
+  "first_run",
+  "plugin",
+]);
+
+const SUBJECT_KINDS = new Set<ScheduledTaskSubjectKind>([
+  "entity",
+  "relationship",
+  "thread",
+  "document",
+  "calendar_event",
+  "self",
+]);
+
+const OUTPUT_DESTINATIONS = new Set<ScheduledTaskOutputDestination>([
+  "in_app_card",
+  "channel",
+  "apple_notes",
+  "gmail_draft",
+  "memory",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidIso(value: unknown): boolean {
+  return isNonEmptyString(value) && !Number.isNaN(new Date(value).getTime());
+}
+
+function validateTrigger(
+  trigger: Record<string, unknown>,
+  path: string,
+): string[] {
+  const issues: string[] = [];
+  switch (trigger.kind) {
+    case "once":
+      if (!isValidIso(trigger.atIso)) {
+        issues.push(`${path}.trigger.atIso must be an ISO timestamp`);
+      }
+      break;
+    case "cron":
+      if (!isNonEmptyString(trigger.expression)) {
+        issues.push(`${path}.trigger.expression must be a non-empty string`);
+      }
+      if (trigger.tz !== undefined && !isNonEmptyString(trigger.tz)) {
+        issues.push(`${path}.trigger.tz must be a non-empty string`);
+      }
+      break;
+    case "interval":
+      if (!isPositiveInteger(trigger.everyMinutes)) {
+        issues.push(`${path}.trigger.everyMinutes must be a positive integer`);
+      }
+      if (trigger.from !== undefined && !isValidIso(trigger.from)) {
+        issues.push(`${path}.trigger.from must be an ISO timestamp`);
+      }
+      if (trigger.until !== undefined && !isValidIso(trigger.until)) {
+        issues.push(`${path}.trigger.until must be an ISO timestamp`);
+      }
+      break;
+    case "relative_to_anchor":
+      if (!isNonEmptyString(trigger.anchorKey)) {
+        issues.push(`${path}.trigger.anchorKey must be a non-empty string`);
+      }
+      if (
+        typeof trigger.offsetMinutes !== "number" ||
+        !Number.isInteger(trigger.offsetMinutes)
+      ) {
+        issues.push(`${path}.trigger.offsetMinutes must be an integer`);
+      }
+      break;
+    case "during_window":
+      if (!isNonEmptyString(trigger.windowKey)) {
+        issues.push(`${path}.trigger.windowKey must be a non-empty string`);
+      }
+      break;
+    case "event":
+      if (!isNonEmptyString(trigger.eventKind)) {
+        issues.push(`${path}.trigger.eventKind must be a non-empty string`);
+      }
+      break;
+    case "manual":
+      break;
+    case "after_task":
+      if (
+        !isNonEmptyString(trigger.taskId) ||
+        !TERMINAL_STATES.has(trigger.outcome as never)
+      ) {
+        issues.push(
+          `${path}.trigger.after_task requires a non-empty taskId and terminal outcome`,
+        );
+      }
+      break;
+    default:
+      issues.push(`${path}.trigger.kind is invalid`);
+  }
+  return issues;
+}
+
+function validateKnownGateParams(
+  kind: string,
+  params: unknown,
+  path: string,
+): string[] {
+  if (params === undefined) return [];
+  if (!isRecord(params)) return [`${path}.params must be an object`];
+  switch (kind) {
+    case "weekday_only": {
+      const weekdays = params.weekdays;
+      if (weekdays === undefined) return [];
+      if (!Array.isArray(weekdays)) {
+        return [`${path}.params.weekdays must be an array`];
+      }
+      return weekdays.every(
+        (day) =>
+          typeof day === "number" &&
+          Number.isInteger(day) &&
+          day >= 0 &&
+          day <= 6,
+      )
+        ? []
+        : [`${path}.params.weekdays must contain integers 0..6`];
+    }
+    case "late_evening_skip": {
+      const afterHour = params.afterHour;
+      if (afterHour === undefined) return [];
+      return typeof afterHour === "number" &&
+        Number.isInteger(afterHour) &&
+        afterHour >= 0 &&
+        afterHour <= 23
+        ? []
+        : [`${path}.params.afterHour must be an integer 0..23`];
+    }
+    case "quiet_hours": {
+      const bypass = params.highPriorityBypass;
+      if (bypass === undefined) return [];
+      return typeof bypass === "boolean"
+        ? []
+        : [`${path}.params.highPriorityBypass must be boolean`];
+    }
+    case "personal_baseline_sufficient": {
+      const minSamples = params.minSamples;
+      if (minSamples === undefined) return [];
+      return isPositiveInteger(minSamples) && minSamples <= 10_000
+        ? []
+        : [`${path}.params.minSamples must be an integer 1..10000`];
+    }
+    default:
+      return [];
+  }
+}
+
+function validateKnownCompletionParams(
+  kind: string,
+  params: unknown,
+  path: string,
+): string[] {
+  if (params === undefined) return [];
+  if (!isRecord(params)) return [`${path}.params must be an object`];
+  const issues: string[] = [];
+  const lookback = params.lookbackMinutes;
+  const requireSince = params.requireSinceTaskFired;
+  if (lookback !== undefined && !isPositiveInteger(lookback)) {
+    issues.push(`${path}.params.lookbackMinutes must be a positive integer`);
+  }
+  if (requireSince !== undefined && typeof requireSince !== "boolean") {
+    issues.push(`${path}.params.requireSinceTaskFired must be boolean`);
+  }
+  if (
+    kind === "health_signal_observed" &&
+    (typeof params.signalKind !== "string" ||
+      params.signalKind.trim().length === 0)
+  ) {
+    issues.push(`${path}.params.signalKind must be a non-empty string`);
+  }
+  return issues;
+}
+
+function stripServerManaged(
+  task: ScheduledTask,
+): Omit<ScheduledTask, "taskId" | "state"> {
+  const { taskId: _taskId, state: _state, ...rest } = task;
+  return rest;
+}
+
+function validateTaskRef(
+  ref: ScheduledTaskRef,
+  deps: ScheduledTaskValidationDeps,
+  path: string,
+  depth: number,
+  seen: WeakSet<object>,
+): string[] {
+  if (typeof ref === "string") {
+    return ref.trim().length > 0 ? [] : [`${path} must be a non-empty task id`];
+  }
+  if (!isRecord(ref)) return [`${path} must be a task id or task input`];
+  if (seen.has(ref)) return [`${path} must not contain a cyclic task ref`];
+  const input =
+    "taskId" in ref || "state" in ref
+      ? stripServerManaged(ref as ScheduledTask)
+      : (ref as ScheduledTaskInput);
+  return validateScheduledTaskInput(input, deps, {
+    path,
+    depth: depth + 1,
+    seen,
+  });
+}
+
+export function validateScheduledTaskInput(
+  input: ScheduledTaskInput,
+  deps: ScheduledTaskValidationDeps,
+  opts: { path?: string; depth?: number; seen?: WeakSet<object> } = {},
+): string[] {
+  const path = opts.path ?? "task";
+  const depth = opts.depth ?? 0;
+  const seen = opts.seen ?? new WeakSet<object>();
+  const issues: string[] = [];
+
+  if (depth > 8) {
+    return [`${path}.pipeline nesting exceeds 8 levels`];
+  }
+  if (!isRecord(input)) {
+    return [`${path} must be an object`];
+  }
+  if (seen.has(input)) {
+    return [`${path} must not contain cyclic pipeline refs`];
+  }
+  seen.add(input);
+
+  if (!TASK_KINDS.has(input.kind)) {
+    issues.push(`${path}.kind is invalid`);
+  }
+  if (!isNonEmptyString(input.promptInstructions)) {
+    issues.push(`${path}.promptInstructions must be a non-empty string`);
+  }
+  if (!TASK_PRIORITIES.has(input.priority)) {
+    issues.push(`${path}.priority is invalid`);
+  }
+  if (!TASK_SOURCES.has(input.source)) {
+    issues.push(`${path}.source is invalid`);
+  }
+  if (!isNonEmptyString(input.createdBy)) {
+    issues.push(`${path}.createdBy must be a non-empty string`);
+  }
+  if (typeof input.ownerVisible !== "boolean") {
+    issues.push(`${path}.ownerVisible must be boolean`);
+  }
+  if (typeof input.respectsGlobalPause !== "boolean") {
+    issues.push(`${path}.respectsGlobalPause must be boolean`);
+  }
+
+  if (!input.trigger || !isRecord(input.trigger)) {
+    issues.push(`${path}.trigger must be an object`);
+  } else {
+    issues.push(...validateTrigger(input.trigger, path));
+  }
+
+  if (input.subject !== undefined) {
+    if (!isRecord(input.subject)) {
+      issues.push(`${path}.subject must be an object`);
+    } else {
+      if (!SUBJECT_KINDS.has(input.subject.kind as never)) {
+        issues.push(`${path}.subject.kind is invalid`);
+      }
+      if (!isNonEmptyString(input.subject.id)) {
+        issues.push(`${path}.subject.id must be a non-empty string`);
+      }
+    }
+  }
+
+  if (
+    input.idempotencyKey !== undefined &&
+    !isNonEmptyString(input.idempotencyKey)
+  ) {
+    issues.push(`${path}.idempotencyKey must be a non-empty string`);
+  }
+
+  if (input.shouldFire !== undefined) {
+    if (!isRecord(input.shouldFire)) {
+      issues.push(`${path}.shouldFire must be an object`);
+    } else {
+      const { compose, gates } = input.shouldFire;
+      if (
+        compose !== undefined &&
+        compose !== "all" &&
+        compose !== "any" &&
+        compose !== "first_deny"
+      ) {
+        issues.push(`${path}.shouldFire.compose is invalid`);
+      }
+      if (!Array.isArray(gates)) {
+        issues.push(`${path}.shouldFire.gates must be an array`);
+      } else {
+        gates.forEach((gate, index) => {
+          const gatePath = `${path}.shouldFire.gates[${index}]`;
+          if (!isRecord(gate) || typeof gate.kind !== "string") {
+            issues.push(`${gatePath}.kind must be a non-empty string`);
+            return;
+          }
+          const kind = gate.kind.trim();
+          if (!kind) {
+            issues.push(`${gatePath}.kind must be a non-empty string`);
+          } else if (!deps.gates.get(kind)) {
+            issues.push(`${gatePath}.kind "${kind}" is not registered`);
+          }
+          issues.push(...validateKnownGateParams(kind, gate.params, gatePath));
+        });
+      }
+    }
+  }
+
+  if (input.completionCheck !== undefined) {
+    const check = input.completionCheck;
+    if (!isRecord(check) || typeof check.kind !== "string") {
+      issues.push(`${path}.completionCheck.kind must be a non-empty string`);
+    } else {
+      const kind = check.kind.trim();
+      if (!kind) {
+        issues.push(`${path}.completionCheck.kind must be a non-empty string`);
+      } else if (!deps.completionChecks.get(kind)) {
+        issues.push(`${path}.completionCheck.kind "${kind}" is not registered`);
+      }
+      if (
+        check.followupAfterMinutes !== undefined &&
+        !isPositiveInteger(check.followupAfterMinutes)
+      ) {
+        issues.push(
+          `${path}.completionCheck.followupAfterMinutes must be a positive integer`,
+        );
+      }
+      issues.push(
+        ...validateKnownCompletionParams(
+          kind,
+          check.params,
+          `${path}.completionCheck`,
+        ),
+      );
+    }
+  }
+
+  if (input.escalation !== undefined) {
+    if (!isRecord(input.escalation)) {
+      issues.push(`${path}.escalation must be an object`);
+    } else {
+      const { ladderKey, steps } = input.escalation;
+      if (
+        ladderKey !== undefined &&
+        (typeof ladderKey !== "string" || !deps.ladders.get(ladderKey))
+      ) {
+        issues.push(
+          `${path}.escalation.ladderKey "${String(ladderKey)}" is not registered`,
+        );
+      }
+      if (steps !== undefined) {
+        if (!Array.isArray(steps)) {
+          issues.push(`${path}.escalation.steps must be an array`);
+        } else {
+          const registeredChannels = deps.channelKeys?.();
+          steps.forEach((step, index) => {
+            const stepPath = `${path}.escalation.steps[${index}]`;
+            if (!isRecord(step)) {
+              issues.push(`${stepPath} must be an object`);
+              return;
+            }
+            if (!isNonNegativeInteger(step.delayMinutes)) {
+              issues.push(
+                `${stepPath}.delayMinutes must be a non-negative integer`,
+              );
+            }
+            if (
+              typeof step.channelKey !== "string" ||
+              step.channelKey.trim().length === 0
+            ) {
+              issues.push(`${stepPath}.channelKey must be a non-empty string`);
+            } else if (
+              registeredChannels &&
+              !registeredChannels.has(step.channelKey)
+            ) {
+              issues.push(
+                `${stepPath}.channelKey "${step.channelKey}" is not registered`,
+              );
+            }
+            if (
+              step.intensity !== undefined &&
+              step.intensity !== "soft" &&
+              step.intensity !== "normal" &&
+              step.intensity !== "urgent"
+            ) {
+              issues.push(`${stepPath}.intensity is invalid`);
+            }
+          });
+        }
+      }
+    }
+  }
+
+  if (input.output !== undefined) {
+    if (!isRecord(input.output)) {
+      issues.push(`${path}.output must be an object`);
+    } else {
+      if (!OUTPUT_DESTINATIONS.has(input.output.destination as never)) {
+        issues.push(
+          `${path}.output.destination "${String(input.output.destination)}" is invalid`,
+        );
+      }
+      if (
+        input.output.persistAs !== undefined &&
+        input.output.persistAs !== "task_metadata" &&
+        input.output.persistAs !== "external_only"
+      ) {
+        issues.push(`${path}.output.persistAs is invalid`);
+      }
+    }
+  }
+
+  if (
+    input.executionProfile !== undefined &&
+    !TASK_EXECUTION_PROFILES.includes(input.executionProfile)
+  ) {
+    issues.push(`${path}.executionProfile is invalid`);
+  }
+
+  if (input.pipeline !== undefined) {
+    if (!isRecord(input.pipeline)) {
+      issues.push(`${path}.pipeline must be an object`);
+    } else {
+      for (const key of ["onComplete", "onSkip", "onFail"] as const) {
+        const refs = input.pipeline[key];
+        if (refs === undefined) continue;
+        if (!Array.isArray(refs)) {
+          issues.push(`${path}.pipeline.${key} must be an array`);
+          continue;
+        }
+        refs.forEach((ref, index) => {
+          issues.push(
+            ...validateTaskRef(
+              ref,
+              deps,
+              `${path}.pipeline.${key}[${index}]`,
+              depth,
+              seen,
+            ),
+          );
+        });
+      }
+    }
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- add shared ScheduledTask input validation before runner persistence
- surface validation errors as REST 400s and PA action INVALID_SCHEDULED_TASK responses
- cover runner, REST, PA action, and default-pack validation paths

Fixes #11791

## Evidence
- `.github/issue-evidence/11791-scheduled-task-validation/README.md`

## Verification
- `bun install`
- `bun run --cwd plugins/plugin-scheduling build`
- `bun run --cwd plugins/plugin-scheduling typecheck`
- `bun run --cwd plugins/plugin-scheduling lint`
- `bunx vitest run --config plugins/plugin-scheduling/vitest.config.ts src/scheduled-task/runner.test.ts src/routes/scheduled-tasks.test.ts --reporter=dot`
- `bun run --cwd plugins/plugin-personal-assistant lint:default-packs`
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/test/scheduled-task-action.integration.test.ts --reporter=dot`
- `git diff --check HEAD`

## Known failing verification
- `bun run verify` currently fails before package checks at `audit:type-safety-ratchet`: core/agent/app-core `?? ""` count is `616 / 615`, with reported files outside this PR.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` fails on broad pre-existing package-wide unresolved workspace types / stale contract exports outside this PR.

## UI / media
- N/A - backend scheduled-task validation only; no UI, media, model, prompt, or live connector behavior changed.
