### PR TITLE
fix(orchestrator): don't synthesize the teardown stopped that follows a router-ceded terminal (#11689 residual)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -916,11 +916,16 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
-  it("a router-owned task_complete does NOT consume the session's synthesis slot (later stopped still fires)", async () => {
-    // ACP sessions are reused across turns. A router-owned task_complete is
-    // skipped here, but must NOT mark the session synthesized — otherwise a
-    // later `stopped` (which the router never posts) would be swallowed by the
-    // dedupe guard and go silent.
+  it("does NOT synthesize the teardown `stopped` that follows a router-owned task_complete (#11689 residual)", async () => {
+    // Every planner-spawned one-shot (TASKS op=create → runPromptAndClose /
+    // runPromptViaSmithers in actions/tasks.ts) emits task_complete on
+    // success, then in its `finally` ALWAYS stops the session:
+    // AcpService.closeSession emits a `stopped` carrying response=lastOutput
+    // (raw agent output), and the runner emits a second explicit `stopped`.
+    // The router posts the real completion; both teardown stops are lifecycle
+    // plumbing of that SAME ceded terminal. Synthesizing them posted a
+    // spurious "<label> stopped." / sanitized raw-output message to the origin
+    // channel seconds after every routed completion.
     const acp = makeAcpStub({
       agentType: "codex",
       workdir: "/tmp/wd",
@@ -940,14 +945,98 @@ describe("SwarmCoordinatorService", () => {
     const fired = vi.fn(async () => {});
     coordinator.setSwarmCompleteCallback(fired);
 
-    // Turn 1: router-owned completion — skipped, slot NOT consumed.
-    acp.emit("sess-reuse", "task_complete", { response: "deployed" });
-    await new Promise((r) => setTimeout(r, 0));
+    // Router-owned completion — ceded to the router, no synthesis.
+    acp.emit("sess-oneshot", "task_complete", { response: "deployed" });
+    await flushChains();
     expect(fired).not.toHaveBeenCalled();
 
-    // Turn 2: same session stops — router does not post this, so synthesis must.
+    // Deterministic teardown from the one-shot runner's finally block:
+    // closeSession's stopped (raw lastOutput) + the explicit stopped.
+    acp.emit("sess-oneshot", "stopped", {
+      sessionId: "sess-oneshot",
+      response: "[tool output: raw transcript]\ndeployed",
+    });
+    acp.emit("sess-oneshot", "stopped", { sessionId: "sess-oneshot" });
+    await flushChains();
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("does NOT leak a teardown `stopped` after a router-owned error the router suppresses (failover/state-lost)", async () => {
+    // The router deliberately suppresses state-lost / account-failover errors
+    // while it respawns under cap — but the one-shot runner stops the session
+    // BEFORE the router stamps `handedOffToSuccessorSessionId`, so the
+    // teardown `stopped` used to synthesize a terminal "<label> stopped."
+    // mid-respawn. The ceded-terminal marker must catch it without depending
+    // on the handoff stamp having landed yet.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    acp.emit("sess-failover", "error", {
+      failureKind: "session_state_lost",
+      message: "Sub-agent state was lost (process exited without persisting).",
+    });
+    acp.emit("sess-failover", "stopped", { sessionId: "sess-failover" });
+    await flushChains();
+
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("a `stopped` AFTER the session resumes still synthesizes (cession is per-turn; sessions are reused)", async () => {
+    // ACP sessions are reused across follow-up turns. The ceded-terminal
+    // marker belongs to the PREVIOUS turn only: once the session resumes (any
+    // non-terminal event), a later stop — which the router never posts — must
+    // synthesize again or a genuine mid-turn user stop would go silent.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: makeRouterStub(true),
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // Turn 1: router-owned completion — ceded (marker set).
+    acp.emit("sess-reuse", "task_complete", { response: "deployed" });
+    await flushChains();
+    expect(fired).not.toHaveBeenCalled();
+
+    // Turn 2 begins: session resumes — cession marker cleared.
+    acp.emit("sess-reuse", "tool_running", { toolCall: { title: "Bash" } });
+    await flushChains();
+
+    // User stops mid-turn 2: router does not post stops, synthesis must.
     acp.emit("sess-reuse", "stopped", {});
-    await new Promise((r) => setTimeout(r, 0));
+    await flushChains();
+
     expect(fired).toHaveBeenCalledTimes(1);
     expect(fired.mock.calls[0][0]).toMatchObject({
       stopped: 1,
@@ -1087,11 +1176,14 @@ describe("SwarmCoordinatorService", () => {
     const fired = vi.fn(async () => {});
     coordinator.setSwarmCompleteCallback(fired);
 
-    // Warm the cache with the pre-stamp snapshot (mirrors the task_complete that
-    // triggered the retry populating the enrichment cache from the store).
-    acp.emit("sess-stale", "task_complete", { response: "turn done" });
+    // Warm the cache with the pre-stamp snapshot via a NON-terminal enriched
+    // event. (A router-owned task_complete would ALSO record an in-memory
+    // ceded-terminal marker that short-circuits the stopped before the
+    // re-read; this test isolates the store-backed handoff path, which is the
+    // layer that survives a coordinator restart or a resumed-then-handed-off
+    // session where the in-memory marker is gone.)
+    acp.emit("sess-stale", "tool_running", { toolCall: { title: "Bash" } });
     await new Promise((r) => setTimeout(r, 0));
-    fired.mockClear();
 
     // The router now stamps the marker on the store AFTER the cache was warmed.
     acp.setSession({
@@ -1138,10 +1230,12 @@ describe("SwarmCoordinatorService", () => {
     const fired = vi.fn(async () => {});
     coordinator.setSwarmCompleteCallback(fired);
 
-    // Warm the cache, then drop the session from the store so the re-read misses.
-    acp.emit("sess-openmiss", "task_complete", { response: "turn done" });
+    // Warm the cache via a non-terminal enriched event (a router-owned
+    // task_complete would record the in-memory ceded-terminal marker and skip
+    // the stopped before the re-read runs), then drop the session from the
+    // store so the re-read misses.
+    acp.emit("sess-openmiss", "tool_running", { toolCall: { title: "Bash" } });
     await new Promise((r) => setTimeout(r, 0));
-    fired.mockClear();
     acp.setSession(undefined);
 
     acp.emit("sess-openmiss", "stopped", {});
@@ -1322,13 +1416,12 @@ describe("SwarmCoordinatorService", () => {
     await coordinator.stop();
   });
 
-  it("still fires the `stopped` when it races a router-owned terminal on the same session (no swallow)", async () => {
-    // Regression (codex review, #11634): a router-owned task_complete/error and
-    // a `stopped` emitted back-to-back for one router-origin session. The
-    // router owns (and skips synthesis for) the task_complete but NEVER posts
-    // `stopped`, so synthesis must still deliver the stop. Per-session
-    // serialization guarantees the router-owned skip does not consume the slot
-    // AND the `stopped` is not swallowed by a claim/release race.
+  it("suppresses the `stopped` racing a router-owned terminal on the same session (same-tick teardown)", async () => {
+    // A router-owned task_complete and its teardown `stopped` emitted
+    // back-to-back in one tick — the exact sequence the one-shot runner's
+    // `finally` produces on EVERY routed success. Per-session serialization
+    // guarantees the `stopped` observes the cession the task_complete
+    // recorded, so no spurious "<label> stopped." post races through.
     const acp = makeAcpStub({
       agentType: "codex",
       workdir: "/tmp/wd",
@@ -1348,17 +1441,13 @@ describe("SwarmCoordinatorService", () => {
     const fired = vi.fn(async () => {});
     coordinator.setSwarmCompleteCallback(fired);
 
-    // Router-owned task_complete (skipped) immediately followed by a stopped
-    // (must post) — same tick, racing the metadata await.
+    // Router-owned task_complete (ceded) immediately followed by the teardown
+    // stopped — same tick, racing the metadata await.
     acp.emit("sess-race-router", "task_complete", { response: "deployed" });
     acp.emit("sess-race-router", "stopped", {});
     await flushChains();
 
-    expect(fired).toHaveBeenCalledTimes(1);
-    expect(fired.mock.calls[0][0]).toMatchObject({
-      stopped: 1,
-      tasks: [{ sessionId: "sess-race-router", status: "stopped" }],
-    });
+    expect(fired).not.toHaveBeenCalled();
     await coordinator.stop();
   });
 

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -283,6 +283,21 @@ export class SwarmCoordinatorService extends Service {
   private swarmCompleteCallback: SwarmCompleteCallback | null = null;
   private readonly inFlightDecisionSessions = new Set<string>();
   private readonly synthesizedCompletionSessions = new Set<string>();
+  // Sessions whose latest terminal event was ceded to the sub-agent-router
+  // (the router-owned skip in `runSwarmComplete`). The one-shot runners
+  // (runPromptAndClose / runPromptViaSmithers in actions/tasks.ts) ALWAYS stop
+  // the session right after the terminal — `closeSession` emits a `stopped`
+  // carrying the raw lastOutput, then the runner emits a second explicit
+  // `stopped` — so on EVERY routed completion a teardown `stopped` trails the
+  // ceded terminal. That stop is lifecycle plumbing of the SAME turn, not a
+  // user-facing end state: without this marker, synthesis posted a spurious
+  // "<label> stopped." / sanitized raw-output message to the origin channel
+  // seconds after the router's real completion post (#11689 residual), and
+  // leaked a terminal stop mid-respawn on error paths the router deliberately
+  // suppresses (before the #11711 handoff stamp lands). Cleared when the
+  // session resumes (a genuine stop on a later turn must still post), on
+  // legacy-task eviction, and on stop().
+  private readonly routerCededTerminalSessions = new Set<string>();
   // Per-session serialization chain for terminal-event synthesis. AcpService
   // invokes session-event listeners SYNCHRONOUSLY without awaiting them, so two
   // terminal events emitted back-to-back for the SAME session (e.g. a
@@ -389,6 +404,7 @@ export class SwarmCoordinatorService extends Service {
     this.swarmCompleteCallback = null;
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
+    this.routerCededTerminalSessions.clear();
     this.terminalCompletionChains.clear();
     this.enrichmentMetadataCache.clear();
     for (const timer of this.legacyTaskEvictionTimers.values()) {
@@ -705,6 +721,11 @@ export class SwarmCoordinatorService extends Service {
     // turn's stale snapshot — so this must run BEFORE enrichment below.
     if (!this.isTerminalEvent(event)) {
       this.cancelLegacyTaskEviction(sessionId);
+      // Session resumed: the ceded-terminal marker belongs to the PREVIOUS
+      // turn. A genuine user stop on this new turn — which the router never
+      // posts — must synthesize again, so the marker must not outlive the turn
+      // whose teardown it suppresses.
+      this.routerCededTerminalSessions.delete(sessionId);
     }
 
     const enrichedData = this.shouldEnrichEvent(event)
@@ -876,6 +897,29 @@ export class SwarmCoordinatorService extends Service {
     if (readString(meta, HANDED_OFF_SUCCESSOR_META_KEY)) {
       return;
     }
+
+    // Teardown-stop of a router-ceded terminal (#11689 residual): the one-shot
+    // runners (runPromptAndClose / runPromptViaSmithers) unconditionally stop
+    // the session right after emitting task_complete / error, so on EVERY
+    // routed one-shot the ceded terminal is followed — deterministically, not
+    // as a rare race — by one `stopped` from closeSession (carrying the raw
+    // lastOutput as `response`) plus a second explicit one. The router posted
+    // (or, for suppressed failover errors, deliberately withheld pending
+    // respawn) the real outcome for this turn; synthesizing its teardown stop
+    // double-posts "<label> stopped." / raw output into the origin channel.
+    // Checked BEFORE the store re-read below (no stamp is needed — this covers
+    // the error path where teardown lands before the router stamps anything).
+    // Per-session terminal serialization (`maybeFireSwarmComplete`) guarantees
+    // a same-tick stopped observes the cession. A genuine user stop has no
+    // preceding ceded terminal on the current turn (the marker clears when the
+    // session resumes), so it still synthesizes.
+    if (
+      event === "stopped" &&
+      this.routerCededTerminalSessions.has(sessionId)
+    ) {
+      return;
+    }
+
     if (
       event === "stopped" &&
       readString(
@@ -907,11 +951,16 @@ export class SwarmCoordinatorService extends Service {
     // This ownership check runs BEFORE the `synthesizedCompletionSessions`
     // dedupe guard, and a router-owned skip does NOT consume the slot: ACP
     // sessions are reused across follow-up turns, so a router-owned turn must
-    // not claim the session's synthesis slot — otherwise a later `stopped` on
-    // the SAME session (which the router does not post) would be swallowed. The
-    // double-synthesis race this ordering would otherwise open is closed by
-    // `maybeFireSwarmComplete`, which serializes all terminal events for a
-    // session so the second observes the first's completed decision.
+    // not claim the session's synthesis slot — otherwise a `stopped` on a
+    // LATER turn of the SAME session (which the router does not post) would be
+    // swallowed. Instead the skip records the cession in
+    // `routerCededTerminalSessions`, so THIS turn's teardown `stopped` — which
+    // the one-shot runners emit unconditionally right after the terminal — is
+    // recognized as plumbing and skipped above, while the marker is cleared as
+    // soon as the session resumes. The double-synthesis race this ordering
+    // would otherwise open is closed by `maybeFireSwarmComplete`, which
+    // serializes all terminal events for a session so the second observes the
+    // first's completed decision.
     //
     // Exempt coordinator-generated validated completions: the app-verification
     // / custom-validator path (dispatchCustomValidatorResult) synthesizes a
@@ -926,6 +975,7 @@ export class SwarmCoordinatorService extends Service {
       sessionHasRouterOrigin(meta) &&
       this.isRouterActive()
     ) {
+      this.routerCededTerminalSessions.add(sessionId);
       return;
     }
 
@@ -1060,6 +1110,7 @@ export class SwarmCoordinatorService extends Service {
       this.legacyTaskEvictionTimers.delete(sessionId);
       this.tasks.delete(sessionId);
       this.synthesizedCompletionSessions.delete(sessionId);
+      this.routerCededTerminalSessions.delete(sessionId);
       this.enrichmentMetadataCache.delete(sessionId);
     }, LEGACY_TASK_EVICTION_GRACE_MS);
     this.legacyTaskEvictionTimers.set(sessionId, timer);


### PR DESCRIPTION
## Problem

Since fd2e343bec (#11689), **every routed one-shot completion posts a spurious second message** to the origin channel: the router posts the real completion, then seconds later swarm synthesis posts `<label> stopped.` (or a sanitized chunk of the session's raw `lastOutput`) to the same room, threaded to the user's message.

Mechanism, on current `develop`:

1. Every planner-spawned one-shot (`TASKS op=create` → `runPromptAndClose` / `runPromptViaSmithers`, `actions/tasks.ts`) emits `task_complete` on success, then in its `finally` **always** calls `service.stopSession` → `AcpService.closeSession` emits a `stopped` carrying `response = lastOutput` (raw agent output), plus a second explicit `stopped`. This sequence is deterministic — it happens on **every** routed success, not as a rare race.
2. #11689's router-owned `task_complete` skip in `SwarmCoordinatorService.runSwarmComplete` deliberately returns **without** claiming the `synthesizedCompletionSessions` dedupe slot (so a later genuine stop on a reused session isn't swallowed), and `stopped` is deliberately not router-owned (`shouldInject` in `sub-agent-router.ts` excludes it).
3. So the teardown `stopped` falls through every guard and synthesizes. `server-helpers-swarm.ts` posts it unconditionally (`swarm_synthesis` is EPHEMERAL, so the roomId+text delivery dedupe is bypassed) to `originRoomId` with `replyToExternalMessageId` — i.e. the user's Discord channel.

The same mechanism **leaks a terminal `stopped` mid-respawn** on error paths the router deliberately suppresses (account failover / state-lost): `tasks.ts` stops the session **before** the router stamps `handedOffToSuccessorSessionId`, so the #11720/#11721 handoff skips can't catch it (they help cache staleness, not a not-yet-stamped store).

Pre-#11689 the top-of-function dedupe claim made these teardown stops invisible; the commit converted the #11634 duplicate-completion into a spurious stop-post instead of eliminating the double post. Tests at `swarm-coordinator-service.test.ts` pinned the wrong behavior as expected (modeled as a rare user-stop race, but the one-shot runners produce the identical sequence deterministically on every routed success).

## Fix

Track the cession in memory: when the router-owned skip cedes a `task_complete`/`error`, record the session in a new `routerCededTerminalSessions` set. A subsequent `stopped` on a ceded session is recognized as teardown plumbing of that same turn and skipped — without claiming the synthesis dedupe slot.

The marker is strictly turn-scoped, so nothing goes silent:

- **Cleared when the session resumes** (any non-terminal event): a genuine user stop on a later turn of a reused session still synthesizes.
- **Cleared on legacy-task eviction and `stop()`**: bounded memory; an idle-session stop after the grace window behaves exactly as before.
- **A genuine user stop with no preceding ceded terminal** (mid-turn cancel / no-output stop) hits no marker and still synthesizes — the #11689 invariant is preserved.
- **Custom-validator (app-verification) completions** are unaffected: they synthesize and claim the dedupe slot as before.
- The check runs **before** the #11711 store re-read, so it also covers the suppressed-failover leak where teardown lands before the router stamps the handoff marker. The store-backed handoff skips are kept — they cover a restarted coordinator / resumed-then-handed-off session where the in-memory marker is gone.

Per-session terminal serialization (`maybeFireSwarmComplete`) guarantees a same-tick teardown `stopped` observes the cession recorded by the terminal that preceded it.

## Tests

Reproduced first (all three fail on unfixed `develop`, with the exact spurious payload `completionSummary: "build-site stopped."` targeted at the origin room):

- `does NOT synthesize the teardown stopped that follows a router-owned task_complete (#11689 residual)` — the deterministic one-shot success sequence (`task_complete` → closeSession `stopped` w/ raw lastOutput → explicit `stopped`) produces zero synthesis.
- `does NOT leak a teardown stopped after a router-owned error the router suppresses (failover/state-lost)` — no terminal `<label> stopped.` mid-respawn.
- `suppresses the stopped racing a router-owned terminal on the same session (same-tick teardown)` — rewrites the old race test that pinned the wrong behavior.
- `a stopped AFTER the session resumes still synthesizes (cession is per-turn; sessions are reused)` — preserves the reuse guarantee the old test at :842 guarded.
- The two #11711 tests now warm the enrichment cache via a non-terminal event so they keep exercising the store-backed handoff re-read layer (previously warmed via a router-owned `task_complete`, which now also sets the in-memory marker).

Unchanged and still green: genuine user `stopped` with no preceding terminal posts; router-inactive/no-origin sessions still synthesize; custom-validator completions still post.

## Verification

```
plugins/plugin-agent-orchestrator: bun run test:unit  → 118 files, 1273 tests passed
plugins/plugin-agent-orchestrator: bun run typecheck  → clean
packages/agent server-helpers-swarm.test.ts           → 13 passed
```

Refs #11689 (fd2e343bec), #11634, #11711, #11720, #11721.
