### PR TITLE
fix: enforce cloud files storage quota

### DIFF
--- a/.github/issue-evidence/11802-cloud-files-quota/README.md
+++ b/.github/issue-evidence/11802-cloud-files-quota/README.md
@@ -1,0 +1,48 @@
+# Issue #11802 — Cloud files quota and upload fan-out
+
+## Change
+
+- `CloudFilesService.upload` now reserves bytes against `org_storage_quota` before writing to R2.
+- Upload quota reservations are released if the R2 write or metadata insert fails.
+- Deleting the final active uploaded file reference removes the R2 object and releases the stored byte count.
+- `/api/v1/files` rejects multipart requests with more than 10 files before any storage writes.
+- `/api/v1/files` maps quota exhaustion to HTTP 413 with the same user-facing quota message as the storage object API.
+
+## Verification
+
+```bash
+bun install --ignore-scripts
+bun run --cwd packages/core build
+bun run --cwd packages/security build
+git fetch origin && git rebase origin/develop
+bun install
+bun test packages/cloud/api/__tests__/cloud-files-route.test.ts
+bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts
+bun run --cwd packages/cloud/api lint
+bun run --cwd packages/cloud/shared lint
+bun run --cwd packages/cloud/api typecheck
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api build
+git diff --check
+bun run verify
+```
+
+Results:
+
+- Rebased onto `origin/develop` at `05cd404a54`.
+- `bun install` completed after the rebase; generated artifact-download churn was removed from the tracked diff.
+- Cloud files route test: 9 tests passed.
+- Cloud files service test: 5 tests passed.
+- Cloud API lint, typecheck, and build: passed.
+- Cloud shared lint and typecheck: passed after building the local `@elizaos/security` workspace dependency.
+- `git diff --check`: passed.
+- `bun run verify`: failed before package checks in `audit:type-safety-ratchet`; current `?? ""` count in core/agent/app-core is `616 / 615`.
+
+## Evidence Matrix
+
+- Real request/response trace: covered by the Hono route test for file-count rejection and quota 413 mapping.
+- DB state / quota rows: covered by service tests asserting `tryReserveBytes` and `releaseBytes` calls for success, failure cleanup, quota rejection, and delete.
+- Auth / tenant isolation: existing route tests in the same file continue to assert authenticated organization scoping for list/get/delete.
+- Frontend screenshots/video: N/A - backend API and service change only.
+- Live model trajectories: N/A - no model-backed endpoint, prompt, provider, or agent behavior changed.
+- Migration up/down: N/A - no schema or migration change; this wires an existing `org_storage_quota` table into an unguarded route.

--- a/packages/cloud/api/__tests__/cloud-files-route.test.ts
+++ b/packages/cloud/api/__tests__/cloud-files-route.test.ts
@@ -174,6 +174,45 @@ describe("/api/v1/files", () => {
     expect(body.files[0].url).toBe("https://blob.test/cloud-files/key.png");
   });
 
+  test("rejects upload requests with too many files before storage writes", async () => {
+    const form = new FormData();
+    for (let index = 0; index < 11; index += 1) {
+      form.append(
+        "files",
+        new File(["hello"], `hero-${index}.png`, { type: "image/png" }),
+      );
+    }
+
+    const res = await filesRoute.request(
+      "/",
+      { method: "POST", body: form },
+      env() as never,
+    );
+
+    expect(res.status).toBe(413);
+    expect(upload).not.toHaveBeenCalled();
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("Too many files");
+  });
+
+  test("returns 413 when org storage quota cannot reserve upload bytes", async () => {
+    upload.mockRejectedValueOnce(
+      new cloudFilesActual.CloudFileQuotaExceededError(),
+    );
+    const form = new FormData();
+    form.append("file", new File(["hello"], "hero.png", { type: "image/png" }));
+
+    const res = await filesRoute.request(
+      "/",
+      { method: "POST", body: form },
+      env() as never,
+    );
+
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Storage quota exceeded for this organization");
+  });
+
   test("rejects malformed upload metadata as validation error", async () => {
     const form = new FormData();
     form.append("file", new File(["hello"], "hero.png", { type: "image/png" }));

--- a/packages/cloud/api/v1/files/route.ts
+++ b/packages/cloud/api/v1/files/route.ts
@@ -10,11 +10,15 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { cloudFilesService } from "@/lib/services/cloud-files";
+import {
+  CloudFileQuotaExceededError,
+  cloudFilesService,
+} from "@/lib/services/cloud-files";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+const MAX_UPLOAD_FILES = 10;
 
 const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(50),
@@ -136,6 +140,15 @@ app.post("/", async (c) => {
         400,
       );
     }
+    if (files.length > MAX_UPLOAD_FILES) {
+      return c.json(
+        {
+          success: false,
+          error: `Too many files in one request; maximum is ${MAX_UPLOAD_FILES}`,
+        },
+        413,
+      );
+    }
 
     const metadata = parseMetadata(form.get("metadata"));
     const apiKeyId = c.get("apiKeyId") as string | undefined;
@@ -150,15 +163,22 @@ app.post("/", async (c) => {
           413,
         );
       }
-      uploaded.push(
-        await cloudFilesService.upload(c.env, {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId,
-          file,
-          metadata,
-        }),
-      );
+      try {
+        uploaded.push(
+          await cloudFilesService.upload(c.env, {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId,
+            file,
+            metadata,
+          }),
+        );
+      } catch (error) {
+        if (error instanceof CloudFileQuotaExceededError) {
+          return c.json({ success: false, error: error.message }, 413);
+        }
+        throw error;
+      }
     }
 
     logger.info("[CloudFiles API] Uploaded files", {

--- a/packages/cloud/shared/src/lib/services/cloud-files.test.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-files.test.ts
@@ -15,6 +15,8 @@ function makeRepository() {
     id: "file-1",
     organization_id: ORG,
     storage_key: "cloud-files/key.png",
+    source: "upload",
+    size_bytes: 5n,
   }));
   const activeStorageKeyReferences = mock(async () => 0);
   return {
@@ -23,6 +25,13 @@ function makeRepository() {
     listByOrganization: mock(),
     softDeleteByOrgAndId,
     activeStorageKeyReferences,
+  };
+}
+
+function makeQuota() {
+  return {
+    tryReserveBytes: mock(async () => 5n),
+    releaseBytes: mock(async () => undefined),
   };
 }
 
@@ -52,8 +61,9 @@ function makeEnv() {
 describe("CloudFilesService", () => {
   test("uploads bytes to R2 and records org-scoped metadata", async () => {
     const repository = makeRepository();
+    const quota = makeQuota();
     const env = makeEnv();
-    const service = new CloudFilesService(repository as never);
+    const service = new CloudFilesService(repository as never, quota);
 
     const file = new File(["hello"], "hello.png", { type: "image/png" });
     const result = await service.upload(env as never, {
@@ -64,6 +74,8 @@ describe("CloudFilesService", () => {
     });
 
     expect(env.BLOB.put).toHaveBeenCalledTimes(1);
+    expect(quota.tryReserveBytes).toHaveBeenCalledWith(ORG, 5n);
+    expect(quota.releaseBytes).not.toHaveBeenCalled();
     expect(repository.create).toHaveBeenCalledTimes(1);
     const createArg = repository.create.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(createArg.organization_id).toBe(ORG);
@@ -81,8 +93,9 @@ describe("CloudFilesService", () => {
   test("removes uploaded bytes if metadata creation fails", async () => {
     const repository = makeRepository();
     repository.create.mockRejectedValueOnce(new Error("insert failed"));
+    const quota = makeQuota();
     const env = makeEnv();
-    const service = new CloudFilesService(repository as never);
+    const service = new CloudFilesService(repository as never, quota);
 
     const file = new File(["hello"], "hello.png", { type: "image/png" });
     await expect(
@@ -96,13 +109,37 @@ describe("CloudFilesService", () => {
     const putKey = env.BLOB.put.mock.calls[0]?.[0];
     expect(putKey).toBeTruthy();
     expect(env.BLOB.delete).toHaveBeenCalledWith(putKey);
+    expect(quota.releaseBytes).toHaveBeenCalledWith(ORG, 5n);
     expect(env.objects.size).toBe(0);
+  });
+
+  test("rejects uploads when org storage quota cannot reserve bytes", async () => {
+    const repository = makeRepository();
+    const quota = makeQuota();
+    quota.tryReserveBytes.mockResolvedValueOnce(null);
+    const env = makeEnv();
+    const service = new CloudFilesService(repository as never, quota);
+
+    const file = new File(["hello"], "hello.png", { type: "image/png" });
+    await expect(
+      service.upload(env as never, {
+        organizationId: ORG,
+        userId: USER,
+        file,
+      }),
+    ).rejects.toThrow("Storage quota exceeded for this organization");
+
+    expect(quota.tryReserveBytes).toHaveBeenCalledWith(ORG, 5n);
+    expect(env.BLOB.put).not.toHaveBeenCalled();
+    expect(repository.create).not.toHaveBeenCalled();
+    expect(quota.releaseBytes).not.toHaveBeenCalled();
   });
 
   test("soft delete removes the object after the last active reference", async () => {
     const repository = makeRepository();
+    const quota = makeQuota();
     const env = makeEnv();
-    const service = new CloudFilesService(repository as never);
+    const service = new CloudFilesService(repository as never, quota);
 
     const result = await service.delete(env as never, ORG, "file-1");
 
@@ -110,6 +147,7 @@ describe("CloudFilesService", () => {
     expect(repository.softDeleteByOrgAndId).toHaveBeenCalledWith(ORG, "file-1");
     expect(repository.activeStorageKeyReferences).toHaveBeenCalledWith(ORG, "cloud-files/key.png");
     expect(env.BLOB.delete).toHaveBeenCalledWith("cloud-files/key.png");
+    expect(quota.releaseBytes).toHaveBeenCalledWith(ORG, 5n);
   });
 
   test("mime kind classifier covers managed media families", () => {

--- a/packages/cloud/shared/src/lib/services/cloud-files.ts
+++ b/packages/cloud/shared/src/lib/services/cloud-files.ts
@@ -5,6 +5,7 @@ import {
   type CloudFilesRepository,
   cloudFilesRepository,
 } from "../../db/repositories/cloud-files";
+import { orgStorageQuotaRepository } from "../../db/repositories/org-storage-quota";
 import type { Bindings } from "../../types/cloud-worker-env";
 import { publicUrlForR2Key } from "../storage/r2-public-object";
 import { logger } from "../utils/logger";
@@ -22,6 +23,18 @@ export interface CloudFileStorage {
     },
   ): Promise<unknown>;
   delete(key: string): Promise<unknown>;
+}
+
+export interface CloudFileQuotaRepository {
+  tryReserveBytes(organizationId: string, bytes: bigint): Promise<bigint | null>;
+  releaseBytes(organizationId: string, bytes: bigint): Promise<void>;
+}
+
+export class CloudFileQuotaExceededError extends Error {
+  constructor() {
+    super("Storage quota exceeded for this organization");
+    this.name = "CloudFileQuotaExceededError";
+  }
 }
 
 export interface UploadCloudFileInput {
@@ -57,7 +70,10 @@ export interface CloudFileListInput {
 }
 
 export class CloudFilesService {
-  constructor(private readonly repository: CloudFilesRepository = cloudFilesRepository) {}
+  constructor(
+    private readonly repository: CloudFilesRepository = cloudFilesRepository,
+    private readonly quotaRepository: CloudFileQuotaRepository = orgStorageQuotaRepository,
+  ) {}
 
   async list(input: CloudFileListInput) {
     return await this.repository.listByOrganization(input.organizationId, {
@@ -92,17 +108,24 @@ export class CloudFilesService {
       `${objectId}-${sha256.slice(0, 16)}${extension}`,
     ].join("/");
 
-    await env.BLOB.put(key, bytes, {
-      httpMetadata: { contentType: mimeType },
-      customMetadata: {
-        organizationId: input.organizationId,
-        userId: input.userId ?? "",
-        sha256,
-        source: "upload",
-      },
-    });
+    const sizeBytes = BigInt(bytes.byteLength);
+    const reserved = await this.quotaRepository.tryReserveBytes(input.organizationId, sizeBytes);
+    if (reserved === null) {
+      throw new CloudFileQuotaExceededError();
+    }
 
+    let wroteObject = false;
     try {
+      await env.BLOB.put(key, bytes, {
+        httpMetadata: { contentType: mimeType },
+        customMetadata: {
+          organizationId: input.organizationId,
+          userId: input.userId ?? "",
+          sha256,
+          source: "upload",
+        },
+      });
+      wroteObject = true;
       return await this.repository.create({
         id: objectId,
         organization_id: input.organizationId,
@@ -112,19 +135,22 @@ export class CloudFilesService {
         kind: kindFromMime(mimeType),
         filename,
         mime_type: mimeType,
-        size_bytes: BigInt(bytes.byteLength),
+        size_bytes: sizeBytes,
         sha256,
         storage_key: key,
         storage_url: publicUrlForR2Key(env, key),
         metadata: input.metadata ?? {},
       });
     } catch (error) {
-      await env.BLOB.delete(key).catch((deleteError) => {
-        logger.warn("[CloudFiles] Failed to clean up object after metadata insert failure", {
-          storageKey: key,
-          error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+      if (wroteObject) {
+        await env.BLOB.delete(key).catch((deleteError) => {
+          logger.warn("[CloudFiles] Failed to clean up object after metadata insert failure", {
+            storageKey: key,
+            error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+          });
         });
-      });
+      }
+      await this.quotaRepository.releaseBytes(input.organizationId, sizeBytes);
       throw error;
     }
   }
@@ -157,13 +183,18 @@ export class CloudFilesService {
     );
     if (activeReferences > 0) return deleted;
 
-    await env.BLOB.delete(deleted.storage_key).catch((error) => {
+    try {
+      await env.BLOB.delete(deleted.storage_key);
+      if (deleted.source === "upload") {
+        await this.quotaRepository.releaseBytes(organizationId, deleted.size_bytes);
+      }
+    } catch (error) {
       logger.warn("[CloudFiles] Failed to delete object after file deletion", {
         id,
         storageKey: deleted.storage_key,
         error: error instanceof Error ? error.message : String(error),
       });
-    });
+    }
     return deleted;
   }
 }


### PR DESCRIPTION
## Summary
- enforce org storage quota reservations before `/api/v1/files` writes uploads to R2
- release reserved bytes on R2/metadata failures and after final uploaded file deletion
- cap multipart upload fan-out at 10 files and map quota exhaustion to HTTP 413

Fixes #11802

## Evidence
- `.github/issue-evidence/11802-cloud-files-quota/README.md`

## Verification
- `bun install --ignore-scripts`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/security build`
- `git fetch origin && git rebase origin/develop`
- `bun install`
- `bun test packages/cloud/api/__tests__/cloud-files-route.test.ts`
- `bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts`
- `bun run --cwd packages/cloud/api lint`
- `bun run --cwd packages/cloud/shared lint`
- `bun run --cwd packages/cloud/api typecheck`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api build`
- `git diff --check`

## Known failure
- `bun run verify` currently fails before package checks in `audit:type-safety-ratchet`: core/agent/app-core `?? ""` count is `616 / 615`.