### PR TITLE
fix(orchestrator): hold a stopped decision until the router's in-flight terminal handling settles (#11720 residual)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -995,6 +995,40 @@ describe("SubAgentRouter", () => {
       expect(posted?.content?.text).not.toContain("::1");
     });
 
+    it("registers in-flight terminal handling at emit that settles only after the handoff stamp (#11720 residual)", async () => {
+      // The autonomous teardown `stopped` follows a task_complete within
+      // milliseconds, while the router is still probing the claimed URLs and
+      // spawning the verify-retry successor. The settlement handle must exist
+      // IMMEDIATELY (registered synchronously at emit) and must not resolve
+      // until handleEvent finished — i.e. until `handedOffToSuccessorSessionId`
+      // has been written to the store — so swarm-synthesis can hold its
+      // `stopped` decision on it and then observe the stamp.
+      session = sessionWithTask(`build a calculator at ${DEAD_URL}`);
+      acp = makeAcpService(session);
+      const { runtime, spawnSession } = makeRuntime({ acp: acp.service });
+      const router = await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "task_complete", {
+        response: `Done — the app is live at ${DEAD_URL}`,
+      });
+      // Synchronously after emit (no ticks): the in-flight handling is
+      // already observable — the teardown `stopped` can never miss it.
+      const settled = router.terminalHandlingSettled(SESSION_ID);
+      // The stamp cannot exist yet: the probe + successor spawn are async.
+      expect(session.metadata?.handedOffToSuccessorSessionId).toBeUndefined();
+
+      await settled;
+
+      // Settlement implies the whole handoff decision completed: successor
+      // spawned and the old session stamped.
+      expect(spawnSession).toHaveBeenCalledTimes(1);
+      expect(session.metadata?.handedOffToSuccessorSessionId).toBe(
+        "retry-session-id",
+      );
+      // Fully settled and self-pruned: a later call resolves immediately.
+      await router.terminalHandlingSettled(SESSION_ID);
+    });
+
     it("suppresses later original-session errors after handing off to a verification retry", async () => {
       session = sessionWithTask(`build a calculator at ${DEAD_URL}`);
       acp = makeAcpService(session);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -19,6 +19,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../../src/services/acp-service.ts";
 import {
+  STOPPED_ROUTER_HANDLING_WAIT_MS,
   SWARM_COORDINATOR_SERVICE_TYPE,
   SwarmCoordinatorService,
   type SwarmEvent,
@@ -1076,6 +1077,128 @@ describe("SwarmCoordinatorService", () => {
       stopped: 1,
       tasks: [{ sessionId: "sess-openmiss", status: "stopped" }],
     });
+    await coordinator.stop();
+  });
+
+  it("holds a `stopped` decision until the router's in-flight terminal handling settles (#11720 residual)", async () => {
+    // LIVE ordering — the one the #11721 test does NOT encode: the autonomous
+    // prompt-driven teardown emits `stopped` within milliseconds of
+    // `task_complete`, while the router is still probing the claimed URLs and
+    // spawning the verify-retry successor. The handoff stamp is written
+    // SECONDS later, so at `stopped`-time NO store read (however fresh) can
+    // observe it. The decision must wait for the router's same-session
+    // terminal handling to settle, THEN re-read, see the late stamp, and skip.
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        // NO handoff marker — the router has not decided yet.
+      },
+    });
+    let settleRouter!: () => void;
+    const inFlight = new Promise<void>((resolve) => {
+      settleRouter = resolve;
+    });
+    const router = {
+      isActive: vi.fn(() => true),
+      terminalHandlingSettled: vi.fn((sessionId: string) =>
+        sessionId === "sess-live-race" ? inFlight : Promise.resolve(),
+      ),
+    };
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: router,
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    // The task_complete that triggers the verify-retry: warms the enrichment
+    // cache with the pre-stamp snapshot; router-owned, so synthesis skips it.
+    acp.emit("sess-live-race", "task_complete", {
+      response: "done — live at https://dead.example/app/",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    fired.mockClear();
+
+    // The teardown `stopped` lands while the router is STILL deciding — the
+    // stamp does not exist anywhere yet.
+    acp.emit("sess-live-race", "stopped", {});
+    await new Promise((r) => setTimeout(r, 0));
+    // Decision must be held pending the router settle — not synthesized from
+    // the (necessarily) marker-less store.
+    expect(fired).not.toHaveBeenCalled();
+    expect(router.terminalHandlingSettled).toHaveBeenCalledWith(
+      "sess-live-race",
+    );
+
+    // The router finishes: spawns the successor, stamps the marker, settles.
+    acp.setSession({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+        handedOffToSuccessorSessionId: "sess-live-race-r2",
+      },
+    });
+    settleRouter();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The held decision re-read the store, saw the stamp, and skipped.
+    expect(fired).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  it("fails open when the router's terminal handling exceeds the wait bound — the stop still synthesizes", async () => {
+    // A wedged router handler (hung probe, stuck spawn) must not silence a
+    // stop forever: past STOPPED_ROUTER_HANDLING_WAIT_MS the decision proceeds
+    // with whatever the store holds (previous behavior: possible duplicate
+    // post, never a swallowed terminal).
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: {
+        label: "build-site",
+        originRoomId: ROUTER_ROOM_ID,
+        taskRoomId: ROUTER_TASK_ROOM_ID,
+        source: "discord",
+      },
+    });
+    const router = {
+      isActive: vi.fn(() => true),
+      terminalHandlingSettled: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const runtime = makeRuntime({
+      [AcpService.serviceType]: acp,
+      [SUB_AGENT_ROUTER_SERVICE_TYPE]: router,
+    });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const fired = vi.fn(async () => {});
+    coordinator.setSwarmCompleteCallback(fired);
+
+    vi.useFakeTimers();
+    try {
+      acp.emit("sess-wedged", "stopped", {});
+      await vi.advanceTimersByTimeAsync(STOPPED_ROUTER_HANDLING_WAIT_MS + 1);
+
+      expect(fired).toHaveBeenCalledTimes(1);
+      expect(fired.mock.calls[0][0]).toMatchObject({
+        total: 1,
+        stopped: 1,
+        tasks: [{ sessionId: "sess-wedged", status: "stopped" }],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
     await coordinator.stop();
   });
 

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -61,6 +61,16 @@ const SUB_AGENT_ENTITY_NAMESPACE = "acpx:sub-agent";
 // the successor's sessionId (for traceability); presence is what matters. Kept
 // as a matching local literal in swarm-coordinator-service.ts (no cross-import).
 const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
+// The events whose router handling can DECIDE a handoff — verify-retry
+// (task_complete with dead URLs), state-lost respawn, and account failover
+// (error) — and stamp HANDED_OFF_SUCCESSOR_META_KEY on the outgoing session.
+// Their in-flight handling is tracked per session (see trackTerminalHandling)
+// so swarm-synthesis can hold a teardown `stopped` decision until the stamp
+// is either written or ruled out (#11720 residual).
+const HANDOFF_DECIDING_EVENTS: ReadonlySet<string> = new Set([
+  "task_complete",
+  "error",
+]);
 // Metadata marker the router stamps on a successor session (verify-retry,
 // state-lost respawn, account failover) when it re-points the forwarded
 // `roomId` away from the origin session's raw value. Presence tells downstream
@@ -481,6 +491,9 @@ export class SubAgentRouter extends Service {
   private readonly parentAgentBuffers = new Map<string, string>();
   private readonly parentAgentDispatchCounts = new Map<string, number>();
   private readonly verifyRetryHandedOffSessions = new Set<string>();
+  // In-flight handling of handoff-deciding events (task_complete / error),
+  // registered SYNCHRONOUSLY at emit time. See trackTerminalHandling.
+  private readonly terminalHandlingBySession = new Map<string, Promise<void>>();
   // The two runaway-loop backstops (per-session round-trip cap + per-lineage
   // state_lost respawn cap) and the cross-session completion-dedupe compare-
   // and-set are consolidated into one pure, fuzz-tested reducer. Every counter
@@ -661,13 +674,14 @@ export class SubAgentRouter extends Service {
       if (acp && typeof acp.onSessionEvent === "function") {
         this.acp = acp;
         this.unsubscribe = acp.onSessionEvent((sid, event, data) => {
-          this.handleEvent(sid, event, data).catch((err) => {
+          const handled = this.handleEvent(sid, event, data).catch((err) => {
             this.log("error", "router event failed", {
               sessionId: sid,
               event,
               error: err instanceof Error ? err.message : String(err),
             });
           });
+          this.trackTerminalHandling(sid, event, handled);
         });
       }
     }
@@ -695,6 +709,46 @@ export class SubAgentRouter extends Service {
     );
   }
 
+  /**
+   * Track the router's in-flight handling of a handoff-deciding event
+   * (task_complete / error) per session — SYNCHRONOUSLY at emit time, before
+   * the handler's first await. The autonomous prompt-driven teardown emits
+   * `stopped` within milliseconds of `task_complete`, while `handleEvent` is
+   * still verifying claimed URLs and spawning the verify-retry successor; the
+   * `handedOffToSuccessorSessionId` stamp only lands seconds later (#11720
+   * residual). Registering the settlement here lets swarm-synthesis hold its
+   * `stopped` decision until the handoff decision — and its stamp — is
+   * complete, instead of re-reading a store that cannot contain the marker
+   * yet. Entries self-prune on settlement, so the map is bounded by in-flight
+   * sessions; `handled` never rejects (the subscriber attaches a catch).
+   */
+  private trackTerminalHandling(
+    sessionId: string,
+    event: SessionEventName,
+    handled: Promise<void>,
+  ): void {
+    if (!HANDOFF_DECIDING_EVENTS.has(event)) return;
+    const prior = this.terminalHandlingBySession.get(sessionId);
+    const next = prior ? prior.then(() => handled) : handled;
+    this.terminalHandlingBySession.set(sessionId, next);
+    void next.finally(() => {
+      if (this.terminalHandlingBySession.get(sessionId) === next) {
+        this.terminalHandlingBySession.delete(sessionId);
+      }
+    });
+  }
+
+  /**
+   * Settlement of the router's in-flight handoff-deciding event handling for
+   * a session; resolves immediately when none is in flight (a genuine user
+   * stop never waits). Consulted — duck-typed, bounded, fail-open — by
+   * SwarmCoordinatorService before it decides whether a `stopped` is a
+   * handoff teardown or a real user-facing terminal. Never rejects.
+   */
+  terminalHandlingSettled(sessionId: string): Promise<void> {
+    return this.terminalHandlingBySession.get(sessionId) ?? Promise.resolve();
+  }
+
   async stop(): Promise<void> {
     this.stopped = true;
     if (this.bindRetryTimer) {
@@ -709,6 +763,7 @@ export class SubAgentRouter extends Service {
     this.parentAgentBuffers.clear();
     this.parentAgentDispatchCounts.clear();
     this.verifyRetryHandedOffSessions.clear();
+    this.terminalHandlingBySession.clear();
     this.loopState = createRouterLoopState({
       roundTripCap: this.loopState.roundTripCap,
       stateLostRespawnCap: this.loopState.stateLostRespawnCap,

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -164,6 +164,14 @@ const HANDED_OFF_SUCCESSOR_META_KEY = "handedOffToSuccessorSessionId";
 
 const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
 
+// Upper bound on how long a `stopped` decision waits for the router's
+// in-flight same-session terminal handling (task_complete / error) to settle
+// before failing open and synthesizing (#11720 residual). Sized for the
+// verify-retry worst case — sequential 4s URL probes plus the successor
+// subprocess spawn — with slack. A genuine user stop has no in-flight
+// handling, so it never waits at all.
+export const STOPPED_ROUTER_HANDLING_WAIT_MS = 60_000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -873,14 +881,25 @@ export class SwarmCoordinatorService extends Service {
     if (readString(meta, HANDED_OFF_SUCCESSOR_META_KEY)) {
       return;
     }
-    if (
-      event === "stopped" &&
-      readString(
-        await this.getFreshSessionMetadata(sessionId),
-        HANDED_OFF_SUCCESSOR_META_KEY,
-      )
-    ) {
-      return;
+    if (event === "stopped") {
+      // #11720 residual: the autonomous prompt-driven teardown emits `stopped`
+      // within milliseconds of `task_complete`, while the router is STILL
+      // deciding that completion — URL-verification probes and the successor
+      // spawn take seconds — so at this point NO store read, however fresh,
+      // can observe a handoff stamp that has not been written yet. Hold the
+      // decision until the router's in-flight same-session terminal handling
+      // settles (bounded, fail-open), THEN do the #11711 fresh re-read. A
+      // genuine user stop has no in-flight terminal handling, so it never
+      // waits and still synthesizes immediately (the #11689 invariant).
+      await this.waitForRouterTerminalHandling(sessionId);
+      if (
+        readString(
+          await this.getFreshSessionMetadata(sessionId),
+          HANDED_OFF_SUCCESSOR_META_KEY,
+        )
+      ) {
+        return;
+      }
     }
 
     // Ownership rule (issue elizaOS/eliza#11634): the sub-agent-router owns the
@@ -1113,6 +1132,43 @@ export class SwarmCoordinatorService extends Service {
       // fall through to empty — fail open (treat unknown as not-superseded)
     }
     return {};
+  }
+
+  /**
+   * Wait — bounded, fail-open — for the router's in-flight handling of this
+   * session's handoff-deciding terminal events (task_complete / error) to
+   * settle before the `stopped` decision reads the store (#11720 residual).
+   * The router registers that handling synchronously at emit time, so the
+   * teardown `stopped` that follows within milliseconds always observes it;
+   * the handoff stamp it may write (seconds later, after URL probes + the
+   * successor spawn) is then visible to {@link getFreshSessionMetadata}.
+   *
+   * Duck-typed like {@link isRouterActive} to avoid a value-import back-edge
+   * to the router module. Degrades safely: a router without the accessor, an
+   * errored settle, or a wait past {@link STOPPED_ROUTER_HANDLING_WAIT_MS}
+   * falls back to the previous behavior (possible duplicate post) — never to
+   * a silenced genuine stop.
+   */
+  private async waitForRouterTerminalHandling(
+    sessionId: string,
+  ): Promise<void> {
+    const router = this.runtime.getService(SUB_AGENT_ROUTER_SERVICE_TYPE) as {
+      terminalHandlingSettled?: (sessionId: string) => Promise<void>;
+    } | null;
+    if (typeof router?.terminalHandlingSettled !== "function") return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        router.terminalHandlingSettled(sessionId),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, STOPPED_ROUTER_HANDLING_WAIT_MS);
+        }),
+      ]);
+    } catch {
+      // fail-open — an errored settle must not silence a genuine stop
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private async getEnrichmentMetadata(


### PR DESCRIPTION
## Problem

Residual of #11720 (`722aed2843`), not closed by #11721 (`71769068c5`): the handoff marker is stamped **seconds after** the old session's teardown `stopped` has already been emitted and processed, so the coordinator still synthesizes one completion post per verify-retry lineage generation — the exact `original + retry1 + retry2 = 3 completions` behavior #11720 set out to fix.

### Mechanics (live ordering)

1. A spawn-with-`initialTask` session completes: `AcpService` emits `task_complete`, and the prompt's `.finally` teardown (`closeInitialTaskSession` → `closeSession`, `keepAliveAfterComplete` defaulting falsy) emits `stopped` **within milliseconds** (acp-service.ts).
2. `emitSessionEvent` fans out synchronously without awaiting handlers; the router's `task_complete` handler yields at its first await while the emitter proceeds.
3. That handler then runs `annotateUnverifiedUrls` (real HTTP probes of every claimed URL — multi-second when one is dead), spawns the successor (`spawnSession`, a full subprocess spawn), and only **then** stamps `handedOffToSuccessorSessionId` (sub-agent-router.ts:1751; state-lost path :1578 has the same shape but stamps before its own `stopSession`, so only the autonomous prompt-driven teardown has the hole).
4. Meanwhile the coordinator's per-session terminal chain (which serializes only its **own** handlers) processes `task_complete` (router-owned skip, no dedupe-slot claim per #11689) and then `stopped`: the cached snapshot has no marker, and #11721's `getFreshSessionMetadata` re-read reads a store that **genuinely does not contain the stamp yet** → fail-open → synthesizes `"<label> stopped."`.
5. The stamp lands seconds later — a no-op. Every retry generation repeats this.

The #11721 regression test calls `acp.setSession` with the marker **before** emitting `stopped` — encoding the lucky ordering, so tests passed while the live ordering failed.

## Fix (structural)

No store read at `stopped`-time, however fresh, can observe a stamp that has not been written — the decision has to wait for the *decision-maker*, not re-read harder:

- **`SubAgentRouter`** now registers its in-flight handling of handoff-deciding events (`task_complete` / `error`) per session, **synchronously at emit time** (before the handler's first await), so the teardown `stopped` that follows within milliseconds can always observe it. Exposed as `terminalHandlingSettled(sessionId)`; entries self-prune on settlement, `stop()` clears the map.
- **`SwarmCoordinatorService`**'s `stopped` decision awaits that settlement — duck-typed like the existing `isRouterActive()` (no value-import back-edge), bounded by `STOPPED_ROUTER_HANDLING_WAIT_MS` (60s), fail-open — **then** performs the #11711/#11721 fresh re-read, which now observes the stamp.

Invariants preserved:
- **#11689**: a genuine user stop has no in-flight terminal handling → resolved promise → zero wait, still synthesizes immediately.
- **Fail-open everywhere**: router absent / accessor missing / settle errored / wait past the bound → previous behavior (possible duplicate post), never a silenced genuine stop.
- Subprocess teardown is **not** delayed (deliberately rejected alternative: holding `closeInitialTaskSession` on handler settlement would keep the old session counted against `maxSessions` while the successor spawns, newly failing retries at the session cap).

## Tests

- `swarm-coordinator-service.test.ts` — **"holds a `stopped` decision until the router's in-flight terminal handling settles"**: encodes the LIVE ordering (`task_complete` → `stopped` → *then* stamp → *then* settle) and asserts no synthesis. **Red on unfixed code** with exactly the live failure: `completionSummary: "build-site stopped."` posted once.
- `swarm-coordinator-service.test.ts` — **fail-open bound test**: a never-settling router handler + fake timers past `STOPPED_ROUTER_HANDLING_WAIT_MS` → the stop still synthesizes.
- `sub-agent-router.test.ts` — settlement handle exists synchronously at emit, is pending before the probe/spawn complete, and resolves only after `handedOffToSuccessorSessionId` is written and the successor spawned; self-prunes after settlement.
- Existing #11720/#11721/#11689 tests unchanged and green (the marker-before-stopped test, the genuine-user-stop test, the fresh-re-read test, and the fail-open-miss test now double as guards that the wait degrades safely for routers without the accessor).

## Verification (real output)

Red (pre-fix, live-ordering test only):
```
Tests  1 failed | 46 passed (47)
  × holds a `stopped` decision until the router's in-flight terminal handling settles (#11720 residual)
    → expected "spy" to not be called at all, but actually been called once:
      completionSummary: "build-site stopped."
```

Green (post-fix, rebased on latest develop):
```
plugins/plugin-agent-orchestrator __tests__/unit  Test Files 118 passed (118)  Tests 1274 passed (1274)
swarm-coordinator-service + sub-agent-router      Test Files 2 passed (2)      Tests 137 passed (137)
tsgo --noEmit -p tsconfig.json                    exit 0
biome check (4 changed files)                     clean
```

Frontend/video/trajectory evidence: N/A — coordinator/router event-ordering fix with no UI surface and no model-behavior change; the regression tests drive the real `SwarmCoordinatorService`/`SubAgentRouter` code paths, including a real dead-URL probe (`127.0.0.1:1`) and successor spawn in the router test.

Refs: #11720 (`722aed2843`), #11721 (`71769068c5`), #11711, #11689.
