### PR TITLE
fix(cloud-apps): [cloud-money] BOOK_INFLUENCER guards — pending TTL + no stacking, currency-cued budget, ambiguity-aware influencer resolution

### DIFF
--- a/plugins/plugin-cloud-apps/AGENTS.md
+++ b/plugins/plugin-cloud-apps/AGENTS.md
@@ -26,12 +26,15 @@ stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
 src/
   index.ts               Plugin registration: the actions[] array + CLOUD_APPS provider.
   client.ts              getCloudClient (SDK construction), resolveCloudApiKey/BaseUrl/SiteBaseUrl,
-                         app-reference resolution (matchAppByReference/resolveApp — id → exact
-                         name/slug → whole-word-in-sentence → fragment; ties = ambiguous),
+                         reference resolution (generic matchByReference + matchAppByReference/
+                         resolveApp — id → exact name/slug → whole-word-in-sentence → fragment;
+                         ties = ambiguous; BOOK_INFLUENCER reuses it for profiles),
                          and the app formatters (formatAppLine/formatAppDetail).
   safety.ts              Two-phase confirm state machine for destructive/paid actions:
                          readStructuredConfirmation (planner boolean, NEVER prose parsing),
                          persist/find/deleteCloudAppConfirmation (task-backed, room-scoped),
+                         CONFIRM_TTL_MS + pendingExpired (shared 15-min pending TTL; expired
+                         pendings refuse the bare confirm and are re-stated/re-quoted),
                          confirmationPrompt, buildConnectorCta (label+https URL only — never a
                          secret/amount). CloudAppConfirmationAction is the gated-action union.
   deploy-gate.ts         runDeployGate: poll deploy status → READY, then reachability-probe the

--- a/plugins/plugin-cloud-apps/CLAUDE.md
+++ b/plugins/plugin-cloud-apps/CLAUDE.md
@@ -26,12 +26,15 @@ stays empty. Construction lives in `src/client.ts` (`getCloudClient`).
 src/
   index.ts               Plugin registration: the actions[] array + CLOUD_APPS provider.
   client.ts              getCloudClient (SDK construction), resolveCloudApiKey/BaseUrl/SiteBaseUrl,
-                         app-reference resolution (matchAppByReference/resolveApp — id → exact
-                         name/slug → whole-word-in-sentence → fragment; ties = ambiguous),
+                         reference resolution (generic matchByReference + matchAppByReference/
+                         resolveApp — id → exact name/slug → whole-word-in-sentence → fragment;
+                         ties = ambiguous; BOOK_INFLUENCER reuses it for profiles),
                          and the app formatters (formatAppLine/formatAppDetail).
   safety.ts              Two-phase confirm state machine for destructive/paid actions:
                          readStructuredConfirmation (planner boolean, NEVER prose parsing),
                          persist/find/deleteCloudAppConfirmation (task-backed, room-scoped),
+                         CONFIRM_TTL_MS + pendingExpired (shared 15-min pending TTL; expired
+                         pendings refuse the bare confirm and are re-stated/re-quoted),
                          confirmationPrompt, buildConnectorCta (label+https URL only — never a
                          secret/amount). CloudAppConfirmationAction is the gated-action union.
   deploy-gate.ts         runDeployGate: poll deploy status → READY, then reachability-probe the

--- a/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import type { CreateBookingInput } from "@elizaos/cloud-sdk";
+import type {
+  CreateBookingInput,
+  InfluencerProfileDto,
+} from "@elizaos/cloud-sdk";
 import {
   captureCallback,
   FakeElizaCloudClient,
@@ -7,6 +10,7 @@ import {
   makeMessage,
   resetSdk,
   setCreateBooking,
+  setListInfluencers,
   unkeyedRuntime,
 } from "./helpers";
 
@@ -17,6 +21,42 @@ mock.module("@elizaos/cloud-sdk", () => ({
 const { bookInfluencerAction } = await import(
   "../src/actions/book-influencer.ts"
 );
+const { CONFIRM_TTL_MS, persistCloudAppConfirmation } = await import(
+  "../src/safety.ts"
+);
+
+function profile(id: string, displayName: string): InfluencerProfileDto {
+  return {
+    id,
+    display_name: displayName,
+    niche: null,
+    bio: null,
+    platforms: [],
+    status: "active",
+  };
+}
+
+/** Install a booking tracker: counts calls and captures the last input. */
+function trackBookings(): {
+  calls: CreateBookingInput[];
+} {
+  const calls: CreateBookingInput[] = [];
+  setCreateBooking((i) => {
+    calls.push(i);
+    return Promise.resolve({
+      success: true,
+      booking: {
+        id: "bk",
+        advertiser_org_id: "o",
+        influencer_profile_id: i.profileId,
+        amount: String(i.amount),
+        status: "offered",
+        brief: i.brief,
+      },
+    });
+  });
+  return { calls };
+}
 
 describe("BOOK_INFLUENCER (two-phase money confirm)", () => {
   beforeEach(() => resetSdk());
@@ -164,5 +204,300 @@ describe("BOOK_INFLUENCER (two-phase money confirm)", () => {
     );
     expect(res.success).toBe(false);
     expect(res.data).toMatchObject({ reason: "no_pending_confirmation" });
+  });
+});
+
+describe("BOOK_INFLUENCER pending-stacking + TTL guards", () => {
+  beforeEach(() => resetSdk());
+
+  it("a second ask while one is pending re-prompts; a later confirm funds only the FIRST ask", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      undefined,
+    );
+
+    // Second first-phase ask (different influencer + amount) must NOT stack a
+    // second pending — it re-prompts for the one already waiting.
+    const second = captureCallback();
+    const res = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("actually hire Mallory for $500"),
+      undefined,
+      { profileId: "inf_2", influencer: "Mallory", amount: 500, brief: "x" },
+      second.fn,
+    );
+    expect(res.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_1",
+      amount: 200,
+    });
+    expect(res.userFacingText).toContain("still waiting");
+    expect(calls.length).toBe(0);
+
+    // The bare confirm funds the booking the user was actually shown.
+    const done = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(done.success).toBe(true);
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toMatchObject({ profileId: "inf_1", amount: 200 });
+  });
+
+  it("a confirm against an aged pending refuses, funds nothing, and deletes the pending", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    await persistCloudAppConfirmation(runtime, {
+      roomId: String(runtime.agentId),
+      action: "BOOK_INFLUENCER",
+      appId: "inf_1",
+      appName: "Nova",
+      amount: 200,
+      brief: "post about us",
+      intentCreatedAt: new Date(
+        Date.now() - CONFIRM_TTL_MS - 1000,
+      ).toISOString(),
+    });
+
+    const res = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(res.success).toBe(false);
+    expect(res.data).toMatchObject({
+      reason: "confirmation_expired",
+      booked: false,
+    });
+    expect(calls.length).toBe(0);
+
+    // The stale pending is gone: a second bare confirm finds nothing to fund.
+    const again = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(again.data).toMatchObject({ reason: "no_pending_confirmation" });
+    expect(calls.length).toBe(0);
+  });
+
+  it("a fresh ask replaces a stale pending (at most one pending per room)", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    await persistCloudAppConfirmation(runtime, {
+      roomId: String(runtime.agentId),
+      action: "BOOK_INFLUENCER",
+      appId: "inf_old",
+      appName: "Old Guy",
+      amount: 999,
+      brief: "stale",
+      intentCreatedAt: new Date(
+        Date.now() - CONFIRM_TTL_MS - 1000,
+      ).toISOString(),
+    });
+
+    const ask = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      undefined,
+    );
+    expect(ask.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_1",
+    });
+
+    const done = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(done.success).toBe(true);
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toMatchObject({ profileId: "inf_1", amount: 200 });
+  });
+});
+
+describe("BOOK_INFLUENCER budget parsing (currency cue required)", () => {
+  beforeEach(() => resetSdk());
+
+  it('a bare number in the message is NOT a budget ("book Nova, she has 80000 followers")', async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    setListInfluencers(() =>
+      Promise.resolve({ success: true, profiles: [profile("inf_1", "Nova")] }),
+    );
+
+    const ask = captureCallback();
+    const res = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("book Nova, she has 80000 followers"),
+      undefined,
+      { influencer: "Nova" },
+      ask.fn,
+    );
+    expect(res.success).toBe(false);
+    expect(res.data).toMatchObject({ reason: "missing_input" });
+    expect(res.userFacingText).toContain("budget");
+    expect(calls.length).toBe(0);
+
+    // Nothing was persisted: a bare confirm has nothing to fund.
+    const confirm = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(confirm.data).toMatchObject({ reason: "no_pending_confirmation" });
+    expect(calls.length).toBe(0);
+  });
+
+  it('cue\'d text amounts parse: "$50", "50 bucks", "50 usd"', async () => {
+    setListInfluencers(() =>
+      Promise.resolve({ success: true, profiles: [profile("inf_1", "Nova")] }),
+    );
+    for (const [text, expected] of [
+      ["hire Nova for $50", 50],
+      ["hire Nova for 50 bucks", 50],
+      ["hire Nova for 50 usd", 50],
+      ["hire Nova for 12.50 dollars", 12.5],
+    ] as const) {
+      const res = await bookInfluencerAction.handler(
+        keyedRuntime(),
+        makeMessage(text),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(res.data).toMatchObject({
+        confirmationRequired: true,
+        amount: expected,
+      });
+    }
+  });
+
+  it("reads the nested options.parameters amount first (real planner path)", async () => {
+    const res = await bookInfluencerAction.handler(
+      keyedRuntime(),
+      makeMessage("book Nova"),
+      undefined,
+      {
+        parameters: {
+          profileId: "inf_1",
+          influencer: "Nova",
+          amount: 75,
+          brief: "post",
+        },
+      },
+      undefined,
+    );
+    expect(res.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_1",
+      amount: 75,
+    });
+  });
+});
+
+describe("BOOK_INFLUENCER influencer resolution (ambiguity-aware)", () => {
+  beforeEach(() => resetSdk());
+
+  it("an ambiguous reference asks to disambiguate instead of booking a lookalike", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    setListInfluencers(() =>
+      Promise.resolve({
+        success: true,
+        profiles: [profile("inf_a", "Nova Cat"), profile("inf_b", "Nova Dog")],
+      }),
+    );
+
+    const res = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("book Nova for $100"),
+      undefined,
+      { influencer: "Nova", amount: 100 },
+      undefined,
+    );
+    expect(res.success).toBe(false);
+    expect(res.data).toMatchObject({
+      reason: "ambiguous",
+      candidates: ["Nova Cat", "Nova Dog"],
+    });
+    expect(res.userFacingText).toContain("Nova Cat");
+    expect(res.userFacingText).toContain("Nova Dog");
+    expect(calls.length).toBe(0);
+
+    // No pending was staged for either candidate.
+    const confirm = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(confirm.data).toMatchObject({ reason: "no_pending_confirmation" });
+    expect(calls.length).toBe(0);
+  });
+
+  it("an adversarial substring profile cannot capture the booking (whole-word beats fragment)", async () => {
+    // Old first-match `ref.includes(name)` resolution: a profile named "Pro"
+    // captured "hire Nova to promote my app…" via the "pro" inside "promote".
+    setListInfluencers(() =>
+      Promise.resolve({
+        success: true,
+        profiles: [profile("inf_bad", "Pro"), profile("inf_good", "Nova")],
+      }),
+    );
+    const res = await bookInfluencerAction.handler(
+      keyedRuntime(),
+      makeMessage("hire Nova to promote my app for $200"),
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(res.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_good",
+      amount: 200,
+    });
+  });
+
+  it("exact display-name match still resolves directly", async () => {
+    setListInfluencers(() =>
+      Promise.resolve({
+        success: true,
+        profiles: [profile("inf_1", "Nova"), profile("inf_2", "Mallory")],
+      }),
+    );
+    const res = await bookInfluencerAction.handler(
+      keyedRuntime(),
+      makeMessage("book her"),
+      undefined,
+      { influencer: "nova", amount: 40 },
+      undefined,
+    );
+    expect(res.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_1",
+      amount: 40,
+    });
   });
 });

--- a/plugins/plugin-cloud-apps/__tests__/safety.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/safety.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildConnectorCta,
+  CONFIRM_TTL_MS,
   confirmationPrompt,
+  pendingExpired,
   readStructuredConfirmation,
 } from "../src/safety.ts";
 
@@ -90,5 +92,67 @@ describe("buildConnectorCta", () => {
   it("rejects non-http(s) URLs (no creds/money smuggling)", () => {
     expect(() => buildConnectorCta("x", "javascript:alert(1)")).toThrow();
     expect(() => buildConnectorCta("x", "not a url")).toThrow();
+  });
+});
+
+describe("pendingExpired (shared confirm TTL)", () => {
+  const base = {
+    taskId: "task-1",
+    metadata: {
+      roomId: "room-1",
+      action: "BOOK_INFLUENCER" as const,
+      appId: "inf_1",
+      appName: "Nova",
+      amount: 200,
+    },
+  };
+
+  it("a fresh pending is not expired", () => {
+    const pending = {
+      ...base,
+      metadata: {
+        ...base.metadata,
+        intentCreatedAt: new Date().toISOString(),
+      },
+    };
+    expect(pendingExpired(pending)).toBe(false);
+  });
+
+  it("a pending older than CONFIRM_TTL_MS is expired", () => {
+    const pending = {
+      ...base,
+      metadata: {
+        ...base.metadata,
+        intentCreatedAt: new Date(
+          Date.now() - CONFIRM_TTL_MS - 1000,
+        ).toISOString(),
+      },
+    };
+    expect(pendingExpired(pending)).toBe(true);
+  });
+
+  it("a pending with no/invalid intentCreatedAt never expires (no timestamp to age)", () => {
+    expect(pendingExpired(base)).toBe(false);
+    expect(
+      pendingExpired({
+        ...base,
+        metadata: { ...base.metadata, intentCreatedAt: "not-a-date" },
+      }),
+    ).toBe(false);
+  });
+
+  it("a BUY_APP_DOMAIN recovery retry never expires (no new charge at stake)", () => {
+    const pending = {
+      ...base,
+      metadata: {
+        ...base.metadata,
+        action: "BUY_APP_DOMAIN" as const,
+        recovery: true,
+        intentCreatedAt: new Date(
+          Date.now() - CONFIRM_TTL_MS * 10,
+        ).toISOString(),
+      },
+    };
+    expect(pendingExpired(pending)).toBe(false);
   });
 });

--- a/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
+++ b/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
@@ -8,8 +8,18 @@
  *      pending prompt, it funds the escrowed booking via `client.createBooking`
  *      (the advertiser's own org credits are debited into escrow; released to the
  *      influencer on approval, refunded on rejection — no external keys).
+ *
+ * Guardrails shared with the other gated actions:
+ *   - at most ONE pending booking per room (a fresh pending re-prompts; a stale
+ *     one is replaced), and a pending older than CONFIRM_TTL_MS refuses the
+ *     bare confirm (safety.ts),
+ *   - a budget needs an explicit currency cue — a bare number in the message is
+ *     never treated as dollars,
+ *   - influencer names resolve through the ambiguity-aware matcher (client.ts);
+ *     ties ask the user instead of booking a lookalike profile.
  */
 
+import type { InfluencerProfileDto } from "@elizaos/cloud-sdk";
 import type {
   Action,
   ActionResult,
@@ -19,11 +29,18 @@ import type {
   State,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
-import { getCloudClient, resolveCloudApiKey } from "../client.js";
 import {
+  getCloudClient,
+  matchByReference,
+  type ReferenceMatch,
+  resolveCloudApiKey,
+} from "../client.js";
+import {
+  CONFIRM_TTL_MS,
   confirmationRoomId,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
+  pendingExpired,
   persistCloudAppConfirmation,
   readStructuredConfirmation,
 } from "../safety.js";
@@ -49,12 +66,41 @@ function usd(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
-function parseAmount(
-  rec: Record<string, unknown>,
-  body: string,
-): number | null {
-  if (typeof rec.amount === "number" && rec.amount > 0) return rec.amount;
-  const m = /\$?\s*(\d+(?:\.\d+)?)\s*(?:dollars?|usd)?\b/i.exec(body);
+/**
+ * The planner-extracted USD budget: `options.parameters.amount` first (the real
+ * planner path nests validated args, same as readStructuredConfirmation), then
+ * the top-level `amount` (direct handler calls / scenario turns).
+ */
+function optionAmount(options: unknown): number | null {
+  if (!options || typeof options !== "object") return null;
+  const opts = options as Record<string, unknown>;
+  const nested =
+    opts.parameters && typeof opts.parameters === "object"
+      ? (opts.parameters as Record<string, unknown>)
+      : undefined;
+  for (const rec of [nested, opts]) {
+    const v = rec?.amount;
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+    if (typeof v === "string") {
+      const n = Number(v.replace(/[$,]/g, "").trim());
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse the USD budget: planner option first, else an amount in the text WITH
+ * an explicit currency cue ("$50", "50 dollars", "50 usd", "50 bucks"). A bare
+ * number is NOT a budget — "book Nova, she has 80000 followers" must never
+ * stage an $80,000 escrow.
+ */
+function parseAmount(options: unknown, body: string): number | null {
+  const fromOptions = optionAmount(options);
+  if (fromOptions !== null) return fromOptions;
+  const m =
+    /\$\s*(\d+(?:\.\d+)?)/.exec(body) ??
+    /(\d+(?:\.\d+)?)\s*(?:dollars?|usd|bucks?)\b/i.exec(body);
   if (m) {
     const n = Number(m[1]);
     if (Number.isFinite(n) && n > 0) return n;
@@ -172,6 +218,19 @@ export const bookInfluencerAction: Action = {
           data: { booked: false, canceled: true },
         };
       }
+      if (pendingExpired(pending)) {
+        const msg =
+          `That booking request for ${pending.metadata.appName} is more than ${Math.round(CONFIRM_TTL_MS / 60000)} minutes old, so I didn't fund anything. ` +
+          `Ask me to book ${pending.metadata.appName} again and I'll re-confirm the details.`;
+        await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+        return {
+          success: false,
+          text: `Pending booking of ${pending.metadata.appName} expired before confirmation.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: { reason: "confirmation_expired", booked: false },
+        };
+      }
       try {
         const result = await client.createBooking({
           profileId: pending.metadata.appId,
@@ -222,15 +281,47 @@ export const bookInfluencerAction: Action = {
     }
 
     // ---- Phase 1: first ask — resolve target + persist a pending confirmation ----
+    // Never stack pendings: while a fresh one is waiting, re-prompt for it so a
+    // later bare confirm can only ever fund the booking the user was shown.
+    if (pending && !pendingExpired(pending)) {
+      const stillMsg =
+        `The booking of ${pending.metadata.appName}${
+          typeof pending.metadata.amount === "number"
+            ? ` for ${usd(pending.metadata.amount)}`
+            : ""
+        } is still waiting for confirmation. ` +
+        `Reply with a clear confirmation or cancellation.`;
+      await callback?.({ text: stillMsg, actions: ["BOOK_INFLUENCER"] });
+      return {
+        success: true,
+        text: `Awaiting structured confirmation to book ${pending.metadata.appName}.`,
+        userFacingText: stillMsg,
+        verifiedUserFacing: true,
+        data: {
+          booked: false,
+          confirmationRequired: true,
+          profileId: pending.metadata.appId,
+          amount: pending.metadata.amount,
+        },
+      };
+    }
+    if (pending) {
+      // Expired leftover: purge it so at most one pending booking exists per
+      // room and a stale ask can never come back to life.
+      await deleteCloudAppConfirmation(runtime, pending.taskId);
+    }
+
     const rec = readOpt(options);
     const body = message.content?.text ?? "";
-    const amount = parseAmount(rec, body);
+    const amount = parseAmount(options, body);
     const brief =
       typeof rec.brief === "string" && rec.brief.trim()
         ? rec.brief.trim()
         : "Promote our product";
 
-    // Resolve the influencer profile: id directly, or by display name via browse.
+    // Resolve the influencer profile: id directly, or by name via the same
+    // ambiguity-aware matcher the app actions use (exact id → exact name →
+    // whole-word-in-sentence → fragment; ties = ambiguous, ask the user).
     let profileId =
       typeof rec.profileId === "string" && rec.profileId.trim()
         ? rec.profileId.trim()
@@ -242,15 +333,44 @@ export const bookInfluencerAction: Action = {
         (typeof rec.influencer === "string" && rec.influencer.trim()) ||
         body.trim();
       if (ref) {
-        const { profiles } = await client.listInfluencers();
-        const match = profiles.find(
-          (p) =>
-            p.display_name.toLowerCase() === ref.toLowerCase() ||
-            ref.toLowerCase().includes(p.display_name.toLowerCase()),
-        );
-        if (match) {
-          profileId = match.id;
-          profileName = match.display_name;
+        let match: ReferenceMatch<InfluencerProfileDto>;
+        try {
+          const { profiles } = await client.listInfluencers();
+          match = matchByReference(profiles, ref, (p) => ({
+            id: p.id,
+            names: [p.display_name],
+          }));
+        } catch (err) {
+          logger.warn(
+            `[BOOK_INFLUENCER] listInfluencers failed while resolving "${ref}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          await callback?.({
+            text: ERROR_MESSAGE,
+            actions: ["BOOK_INFLUENCER"],
+          });
+          return {
+            success: false,
+            text: "Failed to resolve influencer.",
+            userFacingText: ERROR_MESSAGE,
+            error: err instanceof Error ? err : new Error(String(err)),
+            data: { reason: "error" },
+          };
+        }
+        if (match.item) {
+          profileId = match.item.id;
+          profileName = match.item.display_name;
+        } else if (match.candidates.length > 1) {
+          const names = match.candidates.map((p) => p.display_name);
+          const msg = `Which influencer do you mean? "${ref}" matches ${names.length}: ${names.join(", ")}. Reply with the exact name so I book the right one.`;
+          await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+          return {
+            success: false,
+            text: `Ambiguous influencer reference "${ref}" (${names.length} matches).`,
+            userFacingText: msg,
+            data: { reason: "ambiguous", reference: ref, candidates: names },
+          };
         }
       }
     }

--- a/plugins/plugin-cloud-apps/src/actions/buy-app-domain.ts
+++ b/plugins/plugin-cloud-apps/src/actions/buy-app-domain.ts
@@ -66,11 +66,12 @@ import {
 import { invalidateAppsCache } from "../providers/cloud-apps.js";
 import {
   buildConnectorCta,
+  CONFIRM_TTL_MS,
   type ConnectorCta,
   confirmationRoomId,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
-  type PendingCloudAppConfirmation,
+  pendingExpired,
   persistCloudAppConfirmation,
   readStructuredConfirmation,
 } from "../safety.js";
@@ -87,26 +88,12 @@ const NO_PENDING_CONFIRMATION_MESSAGE =
   "I don't have a pending domain purchase to confirm for this room. Tell me which domain to buy first, and I'll quote the price and ask for confirmation.";
 const CANCELED_MESSAGE = "Canceled. No domain was purchased.";
 
-/** A quoted price is honored for this long; after that we re-quote. */
-export const CONFIRM_TTL_MS = 15 * 60 * 1000;
+// A quoted price is honored for CONFIRM_TTL_MS; after that we re-quote. The
+// TTL + expiry check now live in safety.ts so every gated action shares them.
+export { CONFIRM_TTL_MS } from "../safety.js";
 
 function usd(n: number): string {
   return `$${n.toFixed(2)}`;
-}
-
-function pendingExpired(
-  pending: PendingCloudAppConfirmation,
-  now: number = Date.now(),
-): boolean {
-  // A recovery retry completes with no new charge — there is no stale PRICE
-  // to protect, and expiring it would strand a paid, unattached domain.
-  if (pending.metadata.recovery === true) return false;
-  const at =
-    typeof pending.metadata.intentCreatedAt === "string"
-      ? Date.parse(pending.metadata.intentCreatedAt)
-      : Number.NaN;
-  if (!Number.isFinite(at)) return false;
-  return now - at > CONFIRM_TTL_MS;
 }
 
 function domainsCta(

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -189,18 +189,18 @@ function containsAsWholeWord(haystack: string, needle: string): boolean {
 }
 
 /**
- * Specificity score for how well the lowercased reference `lower` targets an
- * app's name/slug. 0 = no match; higher = more specific:
- *   - the name/slug appears in the reference as WHOLE WORDS (a sentence naming
- *     the app) — scored by the matched name length, so a longer, more specific
+ * Specificity score for how well the lowercased reference `lower` targets one
+ * of an item's `names`. 0 = no match; higher = more specific:
+ *   - the name appears in the reference as WHOLE WORDS (a sentence naming the
+ *     item) — scored by the matched name length, so a longer, more specific
  *     name ("Prod API Backup", 15) beats a prefix ("Prod API", 8).
- *   - otherwise the reference is a substring the user typed of the name/slug (a
+ *   - otherwise the reference is a substring the user typed of the name (a
  *     fragment like "acme") — always scored below any whole-word match.
  */
-function referenceScore(lower: string, app: AppDto): number {
+function referenceScore(lower: string, names: string[]): number {
   let best = 0;
-  for (const field of [app.name, app.slug]) {
-    const f = (field ?? "").toLowerCase();
+  for (const field of names) {
+    const f = field.toLowerCase();
     if (!f) continue;
     if (f.length >= 3 && containsAsWholeWord(lower, f)) {
       best = Math.max(best, 1000 + f.length);
@@ -212,48 +212,87 @@ function referenceScore(lower: string, app: AppDto): number {
 }
 
 /**
- * Resolve an app from a free-text reference against a list, ambiguity-aware.
+ * Result of {@link matchByReference}: a single confident match, or — when the
+ * reference is ambiguous (several items match equally well) — no match plus
+ * the tied `candidates`, so a destructive/money action can ask the user to
+ * disambiguate instead of silently acting on the wrong target.
+ */
+export interface ReferenceMatch<T> {
+  item: T | null;
+  candidates: T[];
+}
+
+/**
+ * Resolve an item (app, influencer profile, …) from a free-text reference
+ * against a list, ambiguity-aware. `identify` maps each item to its stable id
+ * plus the human names it answers to (name, slug, display name, …).
  *
  * Match priority:
  *   1. exact id
- *   2. exact (case-insensitive) name or slug
+ *   2. exact (case-insensitive) name
  *   3. best-scoring fuzzy match ({@link referenceScore}) — a whole-word
  *      name-in-sentence beats a typed fragment, and a longer name beats a
- *      shorter prefix. When two or more apps tie for the top score the result
- *      is AMBIGUOUS: `app` is null and `candidates` holds the tied apps.
+ *      shorter prefix. When two or more items tie for the top score the result
+ *      is AMBIGUOUS: `item` is null and `candidates` holds the tied items.
  *
  * Never silently returns the first of several equally-good matches — the old
  * raw-substring `find()` let a one-message "delete Prod API Backup" resolve to
- * (and tear down) the wrong "Prod API" app, and "delete my chatbot helper"
- * match an app named "Bot" via the "bot" inside "chatbot".
+ * (and tear down) the wrong "Prod API" app, "delete my chatbot helper" match
+ * an app named "Bot" via the "bot" inside "chatbot", and an adversarially
+ * named influencer profile capture someone else's booking.
+ */
+export function matchByReference<T>(
+  items: T[],
+  reference: string,
+  identify: (item: T) => {
+    id: string;
+    names: Array<string | null | undefined>;
+  },
+): ReferenceMatch<T> {
+  const ref = reference.trim();
+  if (!ref) return { item: null, candidates: [] };
+  const lower = ref.toLowerCase();
+
+  const namesOf = (item: T): string[] =>
+    identify(item).names.filter(
+      (n): n is string => typeof n === "string" && n.length > 0,
+    );
+
+  const byId = items.find((item) => identify(item).id === ref);
+  if (byId) return { item: byId, candidates: [byId] };
+
+  const exact = items.filter((item) =>
+    namesOf(item).some((n) => n.toLowerCase() === lower),
+  );
+  if (exact.length === 1) return { item: exact[0], candidates: exact };
+  if (exact.length > 1) return { item: null, candidates: exact };
+
+  const scored = items
+    .map((item) => ({ item, score: referenceScore(lower, namesOf(item)) }))
+    .filter((s) => s.score > 0);
+  if (scored.length === 0) return { item: null, candidates: [] };
+
+  const max = Math.max(...scored.map((s) => s.score));
+  const top = scored.filter((s) => s.score === max).map((s) => s.item);
+  return top.length === 1
+    ? { item: top[0], candidates: top }
+    : { item: null, candidates: top };
+}
+
+/**
+ * Resolve an app from a free-text reference against a list, ambiguity-aware.
+ * App-typed wrapper over {@link matchByReference} (id → exact name/slug →
+ * whole-word-in-sentence → fragment; ties = ambiguous).
  */
 export function matchAppByReference(
   apps: AppDto[],
   reference: string,
 ): AppReferenceMatch {
-  const ref = reference.trim();
-  if (!ref) return { app: null, candidates: [] };
-  const lower = ref.toLowerCase();
-
-  const byId = apps.find((a) => a.id === ref);
-  if (byId) return { app: byId, candidates: [byId] };
-
-  const exact = apps.filter(
-    (a) => a.name.toLowerCase() === lower || a.slug.toLowerCase() === lower,
-  );
-  if (exact.length === 1) return { app: exact[0], candidates: exact };
-  if (exact.length > 1) return { app: null, candidates: exact };
-
-  const scored = apps
-    .map((a) => ({ app: a, score: referenceScore(lower, a) }))
-    .filter((s) => s.score > 0);
-  if (scored.length === 0) return { app: null, candidates: [] };
-
-  const max = Math.max(...scored.map((s) => s.score));
-  const top = scored.filter((s) => s.score === max).map((s) => s.app);
-  return top.length === 1
-    ? { app: top[0], candidates: top }
-    : { app: null, candidates: top };
+  const match = matchByReference(apps, reference, (a) => ({
+    id: a.id,
+    names: [a.name, a.slug],
+  }));
+  return { app: match.item, candidates: match.candidates };
 }
 
 /**

--- a/plugins/plugin-cloud-apps/src/safety.ts
+++ b/plugins/plugin-cloud-apps/src/safety.ts
@@ -90,6 +90,34 @@ export interface PendingCloudAppConfirmation {
   metadata: CloudAppConfirmationMetadata;
 }
 
+/**
+ * A pending money confirmation is honored for this long; after that the gated
+ * action refuses a bare confirm and asks the user to re-state the intent.
+ * Shared by every gated action so a stale pending can never fund a
+ * booking/purchase the user has long forgotten about.
+ */
+export const CONFIRM_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * True when a pending confirmation is older than {@link CONFIRM_TTL_MS}.
+ *
+ * A BUY_APP_DOMAIN recovery retry never expires: it completes with no new
+ * charge — there is no stale price to protect, and expiring it would strand a
+ * paid, unattached domain.
+ */
+export function pendingExpired(
+  pending: PendingCloudAppConfirmation,
+  now: number = Date.now(),
+): boolean {
+  if (pending.metadata.recovery === true) return false;
+  const at =
+    typeof pending.metadata.intentCreatedAt === "string"
+      ? Date.parse(pending.metadata.intentCreatedAt)
+      : Number.NaN;
+  if (!Number.isFinite(at)) return false;
+  return now - at > CONFIRM_TTL_MS;
+}
+
 export function readStructuredConfirmation(options?: unknown): boolean | null {
   if (!options || typeof options !== "object") return null;
   const opts = options as Record<string, unknown>;


### PR DESCRIPTION
## [cloud-money] Three confirmed MED money bugs in `BOOK_INFLUENCER` (plugins/plugin-cloud-apps)

`BOOK_INFLUENCER` funds a real escrow from the org's credits on confirm. Its two-phase confirm was missing three guards every sibling gated action already has:

### 1. Pending-stacking + no TTL → a bare confirm could fund a stale/second escrow
Phase 1 persisted a new confirmation **without checking the existing pending** (unlike `delete-app.ts` / `withdraw-app-earnings.ts` / `buy-app-domain.ts`, which re-prompt), and pendings had **no TTL** — they lived forever. A user who asked, walked away for a day, and later sent a bare "confirm" (or stacked a second ask) could fund an escrow they were never currently shown.

**Fix (mirrors the siblings):**
- Phase 1 with a **fresh** pending → re-prompts for the waiting confirmation; nothing new is persisted.
- Phase 1 with a **stale** pending → the leftover is deleted and replaced (**at most one pending per room**).
- Phase 2 against an **aged** pending → refuses, deletes the pending, asks to re-state (`confirmation_expired`).
- `CONFIRM_TTL_MS` + `pendingExpired` extracted from `buy-app-domain.ts` into `safety.ts` so **all** gated actions share one TTL machine (`buy-app-domain.ts` re-exports `CONFIRM_TTL_MS` for compat; the BUY_APP_DOMAIN recovery-never-expires special case is preserved and unit-tested).

### 2. Bare-number budget → any number in the message became USD
`parseAmount` matched `/\$?\s*(\d+...)\s*(?:dollars?|usd)?\b/` — the `$` and unit were both optional, so **any bare number** was a budget. "book Nova, she has 80000 followers" staged an $80,000 escrow ask.

**Fix:** a body amount requires an explicit currency cue — `/\$\s*(\d+(?:\.\d+)?)/` or `/(\d+(?:\.\d+)?)\s*(?:dollars?|usd|bucks?)\b/i` — and the planner amount is read from the nested `options.parameters` first (the real planner path, same nested-param pattern as `readStructuredConfirmation`/withdraw), then top level.

### 3. First-match-substring influencer resolution → wrong/adversarial profile captures the booking
Resolution was `profiles.find(exact || ref.includes(display_name))` — first match wins. A profile named "Pro" captured "hire Nova to **pro**mote my app for $200"; two similarly named profiles silently resolved to whichever listed first.

**Fix:** reuse the plugin's ambiguity-aware matching (the same machinery as `matchAppByReference`): generalized `matchByReference` in `client.ts` — exact id → exact name → whole-word-in-sentence → fragment; **ties = ambiguous** and the action asks the user to disambiguate instead of booking a lookalike. `matchAppByReference` is now a typed wrapper over it (behavior unchanged — `reference-resolution.test.ts` untouched and green).

## Tests (real two-phase machine; only the SDK boundary faked, per plugin convention)
- stacked 2nd ask re-prompts; the later confirm funds **only the first** ask (exactly 1 `createBooking`)
- confirm against an aged pending refuses (`confirmation_expired`), funds nothing, and deletes the pending (second confirm → `no_pending_confirmation`)
- a fresh ask replaces a stale pending (≤1 pending/room); confirm funds the new ask, never the stale $999 one
- bare `80000` without a currency cue ≠ budget (`missing_input`, nothing persisted)
- cued amounts parse: `$50`, `50 bucks`, `50 usd`, `12.50 dollars`
- nested `options.parameters.amount` read first (real planner path)
- ambiguous "Nova" vs {Nova Cat, Nova Dog} asks to disambiguate, books nothing
- adversarial substring profile ("Pro") cannot capture "hire Nova to promote…"
- exact display-name still resolves; `pendingExpired` TTL unit tests incl. the BUY_APP_DOMAIN recovery exemption

## Verification
- `bun test plugins/plugin-cloud-apps` → **273 pass / 0 fail** (28 files; baseline before this change: 260 pass / 0 fail)
- `bunx @biomejs/biome check plugins/plugin-cloud-apps` → clean
- `bun run --cwd plugins/plugin-cloud-apps typecheck` (tsgo) → clean

## Evidence
- Real-LLM trajectories: N/A — no prompt/description text driving planner behavior changed in a way a live trajectory would exercise beyond the deterministic confirm machine; the two-phase machine itself runs for real in the suite (`__tests__/helpers.ts` fakes only the SDK), and the existing `test/scenarios/cloud-apps-structured-confirm.scenario.ts` lane covers the structured-confirm path.
- UI screenshots/video: N/A — connector-agnostic action, no UI surface changed.
- Domain artifacts: the pending confirmation tasks (create/re-prompt/expire/replace/delete) and the `createBooking` inputs incl. the stable `influencer-confirm-<taskId>` idempotency key are asserted directly in the suite.

Flagging for money-path review. Sibling precedents: quote TTL + re-prompt in `buy-app-domain.ts` (#10938-era hardening), pending re-prompt in `delete-app.ts` / `withdraw-app-earnings.ts`.

[cloud-money]