### PR TITLE
fix(cloud-files): roll back partial multipart uploads

### DIFF
--- a/packages/cloud/api/__tests__/cloud-files-route.test.ts
+++ b/packages/cloud/api/__tests__/cloud-files-route.test.ts
@@ -213,6 +213,60 @@ describe("/api/v1/files", () => {
     expect(body.error).toBe("Storage quota exceeded for this organization");
   });
 
+  test("rolls back earlier multipart uploads when a later file exceeds quota", async () => {
+    upload
+      .mockResolvedValueOnce(fileRecord({ id: FILE_ID }))
+      .mockRejectedValueOnce(
+        new cloudFilesActual.CloudFileQuotaExceededError(),
+      );
+    deleteFile.mockResolvedValueOnce(fileRecord({ id: FILE_ID }));
+    const form = new FormData();
+    form.append(
+      "files",
+      new File(["first"], "first.png", { type: "image/png" }),
+    );
+    form.append(
+      "files",
+      new File(["second"], "second.png", { type: "image/png" }),
+    );
+
+    const routeEnv = env();
+    const res = await filesRoute.request(
+      "/",
+      { method: "POST", body: form },
+      routeEnv as never,
+    );
+
+    expect(res.status).toBe(413);
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(deleteFile).toHaveBeenCalledWith(routeEnv, ORG, FILE_ID);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Storage quota exceeded for this organization");
+  });
+
+  test("rejects oversized multipart requests before any storage writes", async () => {
+    const form = new FormData();
+    form.append(
+      "files",
+      new File(["first"], "first.png", { type: "image/png" }),
+    );
+    form.append(
+      "files",
+      new File(["x".repeat(50 * 1024 * 1024 + 1)], "huge.png", {
+        type: "image/png",
+      }),
+    );
+
+    const res = await filesRoute.request(
+      "/",
+      { method: "POST", body: form },
+      env() as never,
+    );
+
+    expect(res.status).toBe(413);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
   test("rejects malformed upload metadata as validation error", async () => {
     const form = new FormData();
     form.append("file", new File(["hello"], "hero.png", { type: "image/png" }));

--- a/packages/cloud/api/v1/files/route.ts
+++ b/packages/cloud/api/v1/files/route.ts
@@ -149,10 +149,6 @@ app.post("/", async (c) => {
         413,
       );
     }
-
-    const metadata = parseMetadata(form.get("metadata"));
-    const apiKeyId = c.get("apiKeyId") as string | undefined;
-    const uploaded = [];
     for (const file of files) {
       if (file.size > MAX_UPLOAD_BYTES) {
         return c.json(
@@ -163,6 +159,14 @@ app.post("/", async (c) => {
           413,
         );
       }
+    }
+
+    const metadata = parseMetadata(form.get("metadata"));
+    const apiKeyId = c.get("apiKeyId") as string | undefined;
+    const uploaded: Array<
+      Awaited<ReturnType<typeof cloudFilesService.upload>>
+    > = [];
+    for (const file of files) {
       try {
         uploaded.push(
           await cloudFilesService.upload(c.env, {
@@ -174,6 +178,24 @@ app.post("/", async (c) => {
           }),
         );
       } catch (error) {
+        for (let index = uploaded.length - 1; index >= 0; index -= 1) {
+          const uploadedFile = uploaded[index];
+          await cloudFilesService
+            .delete(c.env, user.organization_id, uploadedFile.id)
+            .catch((deleteError) => {
+              logger.warn(
+                "[CloudFiles API] Failed to roll back multipart upload after failure",
+                {
+                  organizationId: user.organization_id,
+                  fileId: uploadedFile.id,
+                  error:
+                    deleteError instanceof Error
+                      ? deleteError.message
+                      : String(deleteError),
+                },
+              );
+            });
+        }
         if (error instanceof CloudFileQuotaExceededError) {
           return c.json({ success: false, error: error.message }, 413);
         }


### PR DESCRIPTION
## Summary
- Prevalidate all files in a multipart `/api/v1/files` upload before any storage write.
- Roll back files already created in the same multipart request if a later file fails, including quota exhaustion.
- Add route coverage for quota failure after a prior successful file and oversized multipart prevalidation.

Follow-up to #11813 / #11802. #11813 was merged before this fix could be pushed; without this, a multi-file request can return 413 for a later file while leaving earlier files and quota reservations committed.

## Verification
- `bun test packages/cloud/api/__tests__/cloud-files-route.test.ts` -> 11 tests passed
- `bun test packages/cloud/shared/src/lib/services/cloud-files.test.ts` -> 5 tests passed
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/api typecheck` -> passed
- `bun run --cwd packages/cloud/shared typecheck` -> passed
- `bunx @biomejs/biome check packages/cloud/api/v1/files/route.ts packages/cloud/api/__tests__/cloud-files-route.test.ts packages/cloud/shared/src/lib/services/cloud-files.ts packages/cloud/shared/src/lib/services/cloud-files.test.ts` -> passed
- `git diff --check origin/develop..HEAD` -> passed

## Evidence
- Backend route tests cover request/response behavior and rollback service call.
- Frontend screenshots/video: N/A - backend API behavior only.
- Real LLM trajectories: N/A - no model, prompt, or agent behavior changed.