### PR TITLE
fix: serialize advertising spend cap checks

### DIFF
--- a/.github/issue-evidence/11800-ad-spend-cap/README.md
+++ b/.github/issue-evidence/11800-ad-spend-cap/README.md
@@ -1,0 +1,34 @@
+# Issue #11800 - Advertising Account Spend Cap Concurrency
+
+## Summary
+
+Fixed account-level advertising spend cap write-skew by serializing cap-sensitive
+allocation changes per ad account and by locking the account row during serve
+spend checks.
+
+## Verification
+
+- `bun install --ignore-scripts` - pass during initial setup
+- `bun install` - pass after rebasing onto `origin/develop`; artifact sync
+  side effects were removed from the branch because they are unrelated to this
+  fix
+- `bun run --cwd packages/core build` - pass
+- `bun run --cwd packages/security build` - pass
+- `bunx @biomejs/biome check --write packages/cloud/shared/src/db/repositories/ad-accounts.ts packages/cloud/shared/src/db/repositories/ad-campaigns.ts packages/cloud/shared/src/db/repositories/ad-slots.ts packages/cloud/shared/src/lib/services/advertising/index.ts packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts` - pass, no fixes applied
+- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts` - pass, 14 tests
+- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts` - pass, 20 tests
+- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-inventory.test.ts` - pass
+- `bun run --cwd packages/cloud/shared lint` - pass
+- `bun run --cwd packages/cloud/shared typecheck` - pass
+- `git diff --check` - pass
+- `bun run verify` - fails before workspace lint/typecheck on the existing repo
+  `audit:type-safety-ratchet` baseline: ``?? ""`` is `616 / 615` (confirmed
+  both before and after rebase).
+
+## Evidence Notes
+
+- Frontend screenshots/video: N/A - backend repository/service concurrency fix.
+- Real LLM trajectories: N/A - no agent, prompt, model, or provider behavior.
+- Domain artifacts: focused tests exercise credit deduction/refund behavior,
+  provider rollback after a cap race, cap setter rejection, and PGlite inventory
+  serve debit paths.

--- a/packages/cloud/shared/src/db/repositories/ad-accounts.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-accounts.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql, sum } from "drizzle-orm";
 import { db } from "../client";
 import {
   type AdAccount,
@@ -7,8 +7,14 @@ import {
   adAccounts,
   type NewAdAccount,
 } from "../schemas/ad-accounts";
+import { adCampaigns } from "../schemas/ad-campaigns";
 
 export type { AdAccount, AdAccountStatus, AdPlatform, NewAdAccount };
+
+export type AccountSpendCapUpdateResult =
+  | { status: "updated"; account: AdAccount }
+  | { status: "cap_exceeded"; allocated: number; cap: number }
+  | { status: "not_found" };
 
 /**
  * Repository for ad account database operations.
@@ -73,6 +79,45 @@ export class AdAccountsRepository {
       .where(eq(adAccounts.id, id))
       .returning();
     return updated;
+  }
+
+  async updateSpendCapWithAllocationCheck(
+    id: string,
+    organizationId: string,
+    spendCapCredits: string | null,
+  ): Promise<AccountSpendCapUpdateResult> {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`ad_account_spend_cap:${id}`}))`,
+      );
+
+      const [account] = await tx
+        .select({ id: adAccounts.id })
+        .from(adAccounts)
+        .where(and(eq(adAccounts.id, id), eq(adAccounts.organization_id, organizationId)))
+        .limit(1);
+      if (!account) return { status: "not_found" };
+
+      if (spendCapCredits) {
+        const [result] = await tx
+          .select({ total: sum(adCampaigns.credits_allocated) })
+          .from(adCampaigns)
+          .where(eq(adCampaigns.ad_account_id, id));
+        const allocated = Number(result?.total ?? 0);
+        const cap = Number(spendCapCredits);
+        if (allocated > cap + 1e-9) {
+          return { status: "cap_exceeded", allocated, cap };
+        }
+      }
+
+      const [updated] = await tx
+        .update(adAccounts)
+        .set({ spend_cap_credits: spendCapCredits, updated_at: new Date() })
+        .where(and(eq(adAccounts.id, id), eq(adAccounts.organization_id, organizationId)))
+        .returning();
+      if (!updated) return { status: "not_found" };
+      return { status: "updated", account: updated };
+    });
   }
 
   async updateStatus(id: string, status: AdAccountStatus): Promise<AdAccount | undefined> {

--- a/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-campaigns.ts
@@ -1,6 +1,6 @@
 import { and, count, desc, eq, ne, sql, sum } from "drizzle-orm";
 import { db } from "../client";
-import { type AdPlatform } from "../schemas/ad-accounts";
+import { type AdPlatform, adAccounts } from "../schemas/ad-accounts";
 import {
   type AdCampaign,
   adCampaigns,
@@ -11,6 +11,12 @@ import {
 } from "../schemas/ad-campaigns";
 
 export type { AdCampaign, BudgetType, CampaignObjective, CampaignStatus, NewAdCampaign };
+
+export type AccountSpendCapAllocationResult =
+  | { status: "created"; campaign: AdCampaign }
+  | { status: "updated"; campaign: AdCampaign }
+  | { status: "cap_exceeded"; allocated: number; cap: number }
+  | { status: "conflict" };
 
 /**
  * Repository for ad campaign database operations.
@@ -75,6 +81,44 @@ export class AdCampaignsRepository {
   async create(data: NewAdCampaign): Promise<AdCampaign> {
     const [campaign] = await db.insert(adCampaigns).values(data).returning();
     return campaign;
+  }
+
+  async createWithAccountSpendCapCheck(
+    data: NewAdCampaign,
+    allocationCredits: number,
+  ): Promise<AccountSpendCapAllocationResult> {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`ad_account_spend_cap:${data.ad_account_id}`}))`,
+      );
+
+      const [account] = await tx
+        .select({ spendCapCredits: adAccounts.spend_cap_credits })
+        .from(adAccounts)
+        .where(
+          and(
+            eq(adAccounts.id, data.ad_account_id as string),
+            eq(adAccounts.organization_id, data.organization_id as string),
+          ),
+        )
+        .limit(1);
+      if (!account) return { status: "conflict" };
+
+      if (account.spendCapCredits) {
+        const [result] = await tx
+          .select({ total: sum(adCampaigns.credits_allocated) })
+          .from(adCampaigns)
+          .where(eq(adCampaigns.ad_account_id, data.ad_account_id as string));
+        const allocated = Number(result?.total ?? 0) + allocationCredits;
+        const cap = Number(account.spendCapCredits);
+        if (allocated > cap + 1e-9) {
+          return { status: "cap_exceeded", allocated, cap };
+        }
+      }
+
+      const [campaign] = await tx.insert(adCampaigns).values(data).returning();
+      return { status: "created", campaign };
+    });
   }
 
   async update(id: string, data: Partial<NewAdCampaign>): Promise<AdCampaign | undefined> {
@@ -163,6 +207,54 @@ export class AdCampaignsRepository {
       )
       .returning();
     return updated;
+  }
+
+  async claimAllocationChangeWithAccountSpendCapCheck(
+    id: string,
+    organizationId: string,
+    adAccountId: string,
+    expectedAllocated: string,
+    newAllocatedCredits: number,
+    data: Partial<NewAdCampaign>,
+  ): Promise<AccountSpendCapAllocationResult> {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`ad_account_spend_cap:${adAccountId}`}))`,
+      );
+
+      const [account] = await tx
+        .select({ spendCapCredits: adAccounts.spend_cap_credits })
+        .from(adAccounts)
+        .where(and(eq(adAccounts.id, adAccountId), eq(adAccounts.organization_id, organizationId)))
+        .limit(1);
+      if (!account) return { status: "conflict" };
+
+      if (account.spendCapCredits) {
+        const [result] = await tx
+          .select({ total: sum(adCampaigns.credits_allocated) })
+          .from(adCampaigns)
+          .where(and(eq(adCampaigns.ad_account_id, adAccountId), ne(adCampaigns.id, id)));
+        const allocated = Number(result?.total ?? 0) + newAllocatedCredits;
+        const cap = Number(account.spendCapCredits);
+        if (allocated > cap + 1e-9) {
+          return { status: "cap_exceeded", allocated, cap };
+        }
+      }
+
+      const [updated] = await tx
+        .update(adCampaigns)
+        .set({ ...data, updated_at: new Date() })
+        .where(
+          and(
+            eq(adCampaigns.id, id),
+            eq(adCampaigns.organization_id, organizationId),
+            eq(adCampaigns.credits_allocated, expectedAllocated),
+          ),
+        )
+        .returning();
+      if (!updated) return { status: "conflict" };
+      return { status: "updated", campaign: updated };
+    });
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/ad-slots.ts
+++ b/packages/cloud/shared/src/db/repositories/ad-slots.ts
@@ -181,6 +181,19 @@ export class AdSlotsRepository {
           .returning();
         if (!event) return null; // replay — already served
 
+        // Serialize account-level spend-cap checks across all campaigns that
+        // belong to the same ad account. The conditional campaign update below
+        // still owns the campaign budget gate; this lock closes the multi-row
+        // account-cap write-skew window.
+        await tx.execute(sql`
+          SELECT cap_account.id
+          FROM ${adAccounts} cap_account
+          INNER JOIN ${adCampaigns} cap_campaign
+            ON cap_campaign.ad_account_id = cap_account.id
+          WHERE cap_campaign.id = ${input.campaignId}
+          FOR UPDATE
+        `);
+
         // Debit the advertiser's pre-funded campaign budget atomically. The
         // earlier eligibility query is only a candidate picker; this conditional
         // update is the money gate that prevents concurrent serves from

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts
@@ -165,30 +165,37 @@ describe("campaign spend requires an approved (active) account (#11364)", () => 
 describe("spend caps (#11364)", () => {
   test("setAccountSpendCap rejects lowering below already allocated campaign exposure", async () => {
     track(spyOn(adAccountsRepository, "findById").mockResolvedValue(makeAccount("active")));
-    track(spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockResolvedValue(75));
-    const update = track(spyOn(adAccountsRepository, "update").mockResolvedValue(undefined));
+    const update = track(
+      spyOn(adAccountsRepository, "updateSpendCapWithAllocationCheck").mockResolvedValue({
+        status: "cap_exceeded",
+        allocated: 75,
+        cap: 50,
+      }),
+    );
 
     await expect(advertisingService.setAccountSpendCap(ACCOUNT_ID, ORG_ID, 50)).rejects.toThrow(
       /already has 75.00 allocated credits/,
     );
 
-    expect(update).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(ACCOUNT_ID, ORG_ID, "50.00");
   });
 
   test("setAccountSpendCap persists a nullable cap for an org-owned account", async () => {
     track(spyOn(adAccountsRepository, "findById").mockResolvedValue(makeAccount("active")));
-    track(spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockResolvedValue(25));
     const update = track(
-      spyOn(adAccountsRepository, "update").mockResolvedValue({
-        ...makeAccount("active"),
-        spend_cap_credits: "50.00",
+      spyOn(adAccountsRepository, "updateSpendCapWithAllocationCheck").mockResolvedValue({
+        status: "updated",
+        account: {
+          ...makeAccount("active"),
+          spend_cap_credits: "50.00",
+        },
       }),
     );
 
     const account = await advertisingService.setAccountSpendCap(ACCOUNT_ID, ORG_ID, 50);
 
     expect(account.spend_cap_credits).toBe("50.00");
-    expect(update).toHaveBeenCalledWith(ACCOUNT_ID, { spend_cap_credits: "50.00" });
+    expect(update).toHaveBeenCalledWith(ACCOUNT_ID, ORG_ID, "50.00");
   });
 
   test("createCampaign rejects a campaign cap below the marked-up budget before credit debit", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -279,6 +279,52 @@ describe("updateCampaign — reconciles the credit hold on a budget change", () 
     expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(110, 9);
   });
 
+  test("#11800 budget INCREASE refunds and reverts provider if serialized account cap check loses a race", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    track(spyOn(adCampaignsRepository, "sumCreditsAllocatedByAdAccount").mockResolvedValue(0));
+    const deduct = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const provider = stubProvider();
+    const providerUpdate = track(spyOn(provider, "updateCampaign"));
+    track(spyOn(advertisingService, "getProvider").mockReturnValue(provider));
+    track(
+      spyOn(
+        adCampaignsRepository,
+        "claimAllocationChangeWithAccountSpendCapCheck",
+      ).mockResolvedValue({
+        status: "cap_exceeded",
+        allocated: 220,
+        cap: 150,
+      }),
+    );
+
+    await expect(
+      advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, {
+        budgetAmount: 200,
+      }),
+    ).rejects.toThrow("Ad account spend cap would be exceeded");
+
+    expect(deduct).toHaveBeenCalledTimes(1);
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect((deduct.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(110, 9);
+    expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(110, 9);
+    expect(providerUpdate).toHaveBeenCalledTimes(2);
+    expect(providerUpdate.mock.calls[0]?.[2]).toMatchObject({ budgetAmount: 200 });
+    expect(providerUpdate.mock.calls[1]?.[2]).toEqual({ budgetAmount: 100 });
+  });
+
   test("a name-only update charges and refunds nothing", async () => {
     track(
       spyOn(adCampaignsRepository, "findById").mockResolvedValue(

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -795,30 +795,28 @@ class AdvertisingService {
     if (!account || account.organization_id !== organizationId) {
       throw new Error("Ad account not found");
     }
-    const normalized = this.normalizeSpendCapCredits(spendCapCredits);
-    if (normalized) {
-      const allocated = await adCampaignsRepository.sumCreditsAllocatedByAdAccount(accountId);
-      const cap = Number(normalized);
-      if (allocated > cap + 1e-9) {
-        throw ValidationError(
-          `Ad account already has ${allocated.toFixed(
-            2,
-          )} allocated credits, which exceeds the requested ${cap.toFixed(2)} cap`,
-        );
-      }
-    }
-    const updated = await adAccountsRepository.update(accountId, {
-      spend_cap_credits: normalized,
-    });
-    if (!updated) {
+    const normalized = this.normalizeSpendCapCredits(spendCapCredits) ?? null;
+    const result = await adAccountsRepository.updateSpendCapWithAllocationCheck(
+      accountId,
+      organizationId,
+      normalized,
+    );
+    if (result.status === "not_found") {
       throw new Error("Ad account not found");
+    }
+    if (result.status === "cap_exceeded") {
+      throw ValidationError(
+        `Ad account already has ${result.allocated.toFixed(
+          2,
+        )} allocated credits, which exceeds the requested ${result.cap.toFixed(2)} cap`,
+      );
     }
     logger.info("[Advertising] Ad account spend cap updated", {
       accountId,
       organizationId,
       spendCapCredits: normalized,
     });
-    return updated;
+    return result.account;
   }
 
   async disconnectAccount(accountId: string, organizationId: string): Promise<void> {
@@ -1162,34 +1160,48 @@ class AdvertisingService {
     let campaign: AdCampaign | null = null;
     try {
       // Create campaign record
-      campaign = await adCampaignsRepository.create({
-        organization_id: input.organizationId,
-        ad_account_id: input.adAccountId,
-        external_campaign_id: result.externalCampaignId,
-        name: input.name,
-        platform: account.platform,
-        objective: input.objective,
-        status: "pending",
-        budget_type: input.budgetType,
-        budget_amount: String(input.budgetAmount),
-        budget_currency: input.budgetCurrency || "USD",
-        credits_allocated: String(budgetCredits),
-        spend_cap_credits: campaignSpendCap,
-        start_date: input.startDate,
-        end_date: input.endDate,
-        targeting: targeting ? this.toDbTargeting(targeting) : {},
-        app_id: input.appId,
-        metadata: {
-          ...(input.bidStrategy ? { bid_strategy: input.bidStrategy } : {}),
-          ...(input.optimizationGoal ? { optimization_goal: input.optimizationGoal } : {}),
-          ...(dayparting
-            ? {
-                dayparting,
-                dayparting_provider_synced_at: new Date().toISOString(),
-              }
-            : {}),
+      const allocation = await adCampaignsRepository.createWithAccountSpendCapCheck(
+        {
+          organization_id: input.organizationId,
+          ad_account_id: input.adAccountId,
+          external_campaign_id: result.externalCampaignId,
+          name: input.name,
+          platform: account.platform,
+          objective: input.objective,
+          status: "pending",
+          budget_type: input.budgetType,
+          budget_amount: String(input.budgetAmount),
+          budget_currency: input.budgetCurrency || "USD",
+          credits_allocated: String(budgetCredits),
+          spend_cap_credits: campaignSpendCap,
+          start_date: input.startDate,
+          end_date: input.endDate,
+          targeting: targeting ? this.toDbTargeting(targeting) : {},
+          app_id: input.appId,
+          metadata: {
+            ...(input.bidStrategy ? { bid_strategy: input.bidStrategy } : {}),
+            ...(input.optimizationGoal ? { optimization_goal: input.optimizationGoal } : {}),
+            ...(dayparting
+              ? {
+                  dayparting,
+                  dayparting_provider_synced_at: new Date().toISOString(),
+                }
+              : {}),
+          },
         },
-      });
+        budgetCredits,
+      );
+      if (allocation.status === "cap_exceeded") {
+        throw ValidationError(
+          `Ad account spend cap would be exceeded: ${allocation.allocated.toFixed(
+            2,
+          )} credits requested against ${allocation.cap.toFixed(2)} cap`,
+        );
+      }
+      if (allocation.status !== "created") {
+        throw new Error("Ad account changed concurrently; please retry");
+      }
+      campaign = allocation.campaign;
 
       // Record budget allocation transaction
       await adTransactionsRepository.create({
@@ -1457,6 +1469,61 @@ class AdvertisingService {
           metadata: { type: "ad_budget_decrease_refund", campaignId },
         });
       }
+    } else if (budgetCreditDelta > 0 && newCreditsAllocated !== undefined) {
+      const allocation = await adCampaignsRepository.claimAllocationChangeWithAccountSpendCapCheck(
+        campaignId,
+        organizationId,
+        account.id,
+        campaign.credits_allocated,
+        newCreditsAllocated,
+        updateData,
+      );
+      if (allocation.status === "cap_exceeded") {
+        await provider
+          .updateCampaign(credentials, campaign.external_campaign_id, {
+            budgetAmount: Number(campaign.budget_amount),
+          })
+          .catch((revertError) => {
+            logger.error("[Advertising] Failed to revert provider budget after account cap race", {
+              campaignId,
+              error: revertError instanceof Error ? revertError.message : String(revertError),
+            });
+          });
+        await creditsService.refundCredits({
+          organizationId,
+          amount: budgetCreditDelta,
+          description: `Ad budget increase refund (account cap exceeded): ${campaign.name}`,
+          metadata: { type: "ad_budget_increase_refund", campaignId },
+        });
+        throw ValidationError(
+          `Ad account spend cap would be exceeded: ${allocation.allocated.toFixed(
+            2,
+          )} credits requested against ${allocation.cap.toFixed(2)} cap`,
+        );
+      }
+      if (allocation.status !== "updated") {
+        await provider
+          .updateCampaign(credentials, campaign.external_campaign_id, {
+            budgetAmount: Number(campaign.budget_amount),
+          })
+          .catch((revertError) => {
+            logger.error(
+              "[Advertising] Failed to revert provider budget after concurrent campaign update",
+              {
+                campaignId,
+                error: revertError instanceof Error ? revertError.message : String(revertError),
+              },
+            );
+          });
+        await creditsService.refundCredits({
+          organizationId,
+          amount: budgetCreditDelta,
+          description: `Ad budget increase refund (concurrent update): ${campaign.name}`,
+          metadata: { type: "ad_budget_increase_refund", campaignId },
+        });
+        throw new Error("Campaign budget changed concurrently; please retry");
+      }
+      updated = allocation.campaign;
     } else {
       updated = await adCampaignsRepository.update(campaignId, updateData);
     }


### PR DESCRIPTION
Fixes #11800

## Summary
- serialize account spend-cap allocation checks with per-account transaction advisory locks for campaign create, budget increases, and cap updates
- lock the ad account row during serve debits so concurrent campaigns cannot write-skew the account cap
- add service coverage for a provider-accepted budget increase that loses the serialized cap race and verifies refund + provider revert

## Evidence
- `.github/issue-evidence/11800-ad-spend-cap/README.md`

## Verification
- `bun install` - pass after rebase; artifact sync side effects removed from branch
- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts` - pass, 14 tests
- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-account-approval.test.ts` - pass, 20 tests
- `bun test packages/cloud/shared/src/lib/services/__tests__/ad-inventory.test.ts` - pass
- `bun run --cwd packages/cloud/shared lint` - pass
- `bun run --cwd packages/cloud/shared typecheck` - pass
- `git diff --check` - pass
- `bun run verify` - fails before workspace lint/typecheck on existing `audit:type-safety-ratchet`: ``?? ""`` is `616 / 615`

## Evidence N/A
- Frontend screenshots/video: N/A - backend concurrency fix
- Real LLM trajectories: N/A - no agent, prompt, model, or provider behavior changed