### PR TITLE
[codex] Add press release domain model

### DIFF
--- a/.github/issue-evidence/11818-pr-domain-model.md
+++ b/.github/issue-evidence/11818-pr-domain-model.md
@@ -1,0 +1,39 @@
+# #11818 PR Domain Model Evidence
+
+Date: 2026-07-03
+Branch: `fix/11818-pr-domain-model`
+
+## Scope
+
+Implemented the Cloud-owned PR / press distribution foundation:
+
+- Drizzle schema + migration for `press_releases`, `press_release_distributions`, `press_media_contacts`, and `press_coverage`.
+- Repository for release/distribution/contact/coverage persistence.
+- Service state machine for `draft -> ready -> submitted -> distributed|failed|cancelled`.
+- Validation for required title/body, future embargoes, HTTP(S) assets, idempotent create/submit keys, and organization scoping.
+
+## Verification
+
+- `bun x @biomejs/biome check packages/cloud/shared/src/db/schemas/press-releases.ts packages/cloud/shared/src/db/repositories/press-releases.ts packages/cloud/shared/src/lib/services/press-releases.ts packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts packages/cloud/shared/src/db/schemas/index.ts packages/cloud/shared/src/db/repositories/index.ts`
+  - Result: passed.
+- `bun run --cwd packages/cloud/shared typecheck`
+  - Result: passed.
+- `bun test packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts`
+  - Result: passed, 9 tests.
+
+## DB Artifacts Reviewed
+
+The PGlite test pushes the real Drizzle schemas and inspects rows from:
+
+- `press_releases`
+- `press_release_distributions`
+- `press_media_contacts`
+- `press_coverage`
+
+The final test, `real DB rows are available for reviewer-verifiable evidence`, reads the inserted `press_releases` row and asserts the organization id, status, and body content. Other tests verify distribution rows, coverage upsert idempotency, and tenant-scoped contact listing.
+
+## N/A
+
+- Live provider logs: N/A - #11818 intentionally does not call an external newswire provider. Provider selection and live distribution are split to #11820/#11821.
+- Screenshots/video: N/A - backend domain-model slice with no UI surface.
+- Real-LLM trajectories: N/A - no model/action/prompt behavior changed in this slice.

--- a/packages/cloud/shared/src/db/migrations/0171_press_release_domain.sql
+++ b/packages/cloud/shared/src/db/migrations/0171_press_release_domain.sql
@@ -1,0 +1,81 @@
+-- PR / press distribution domain model (#11818).
+
+CREATE TABLE IF NOT EXISTS "press_releases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+	"created_by_user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+	"title" text NOT NULL,
+	"summary" text,
+	"body" text NOT NULL,
+	"boilerplate" text,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"target_audience" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"target_regions" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"assets" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"embargo_at" timestamp,
+	"submitted_at" timestamp,
+	"distributed_at" timestamp,
+	"failed_reason" text,
+	"idempotency_key" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "press_releases_org_idx" ON "press_releases" ("organization_id");
+CREATE INDEX IF NOT EXISTS "press_releases_status_idx" ON "press_releases" ("status");
+CREATE INDEX IF NOT EXISTS "press_releases_created_idx" ON "press_releases" ("created_at");
+CREATE UNIQUE INDEX IF NOT EXISTS "press_releases_idempotency_key_uidx" ON "press_releases" ("idempotency_key");
+
+CREATE TABLE IF NOT EXISTS "press_release_distributions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+	"press_release_id" uuid NOT NULL REFERENCES "press_releases"("id") ON DELETE CASCADE,
+	"provider" text NOT NULL,
+	"external_distribution_id" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"idempotency_key" text,
+	"request_payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"provider_response" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"error_message" text,
+	"submitted_at" timestamp,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "press_release_distributions_org_idx" ON "press_release_distributions" ("organization_id");
+CREATE INDEX IF NOT EXISTS "press_release_distributions_release_idx" ON "press_release_distributions" ("press_release_id");
+CREATE INDEX IF NOT EXISTS "press_release_distributions_provider_idx" ON "press_release_distributions" ("provider");
+CREATE UNIQUE INDEX IF NOT EXISTS "press_release_distributions_idempotency_key_uidx" ON "press_release_distributions" ("idempotency_key");
+
+CREATE TABLE IF NOT EXISTS "press_media_contacts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+	"created_by_user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+	"name" text NOT NULL,
+	"outlet" text NOT NULL,
+	"email" text,
+	"beat" text,
+	"region" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "press_media_contacts_org_idx" ON "press_media_contacts" ("organization_id");
+CREATE INDEX IF NOT EXISTS "press_media_contacts_status_idx" ON "press_media_contacts" ("status");
+
+CREATE TABLE IF NOT EXISTS "press_coverage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+	"press_release_id" uuid NOT NULL REFERENCES "press_releases"("id") ON DELETE CASCADE,
+	"distribution_id" uuid REFERENCES "press_release_distributions"("id") ON DELETE SET NULL,
+	"url" text NOT NULL,
+	"title" text,
+	"outlet" text,
+	"published_at" timestamp,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "press_coverage_org_idx" ON "press_coverage" ("organization_id");
+CREATE INDEX IF NOT EXISTS "press_coverage_release_idx" ON "press_coverage" ("press_release_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "press_coverage_release_url_uidx" ON "press_coverage" ("press_release_id", "url");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1191,6 +1191,13 @@
       "when": 1781655600000,
       "tag": "0170_ad_spend_caps",
       "breakpoints": true
+    },
+    {
+      "idx": 170,
+      "version": "7",
+      "when": 1781742000000,
+      "tag": "0171_press_release_domain",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/index.ts
+++ b/packages/cloud/shared/src/db/repositories/index.ts
@@ -109,6 +109,7 @@ export * from "./org-rate-limit-overrides";
 export * from "./org-storage-quota";
 export * from "./organization-invites";
 export * from "./organizations";
+export * from "./press-releases";
 export * from "./provider-health";
 // ============================================
 // Referrals & Rewards

--- a/packages/cloud/shared/src/db/repositories/press-releases.ts
+++ b/packages/cloud/shared/src/db/repositories/press-releases.ts
@@ -1,0 +1,189 @@
+import { and, desc, eq } from "drizzle-orm";
+import { dbRead, dbWrite } from "../client";
+import {
+  type NewPressCoverage,
+  type NewPressMediaContact,
+  type NewPressRelease,
+  type NewPressReleaseDistribution,
+  type PressCoverage,
+  type PressDistributionStatus,
+  type PressMediaContact,
+  type PressRelease,
+  type PressReleaseAsset,
+  type PressReleaseDistribution,
+  type PressReleaseStatus,
+  type PressReleaseTargetAudience,
+  pressCoverage,
+  pressMediaContacts,
+  pressReleaseDistributions,
+  pressReleases,
+} from "../schemas/press-releases";
+
+export type {
+  NewPressCoverage,
+  NewPressMediaContact,
+  NewPressRelease,
+  NewPressReleaseDistribution,
+  PressCoverage,
+  PressMediaContact,
+  PressRelease,
+  PressReleaseAsset,
+  PressReleaseDistribution,
+  PressReleaseTargetAudience,
+};
+
+export class PressReleasesRepository {
+  findReleaseById(id: string): Promise<PressRelease | undefined> {
+    return dbRead.query.pressReleases.findFirst({ where: eq(pressReleases.id, id) });
+  }
+
+  findReleaseByIdForOrg(id: string, organizationId: string): Promise<PressRelease | undefined> {
+    return dbRead.query.pressReleases.findFirst({
+      where: and(eq(pressReleases.id, id), eq(pressReleases.organization_id, organizationId)),
+    });
+  }
+
+  findReleaseByIdempotencyKey(key: string): Promise<PressRelease | undefined> {
+    return dbRead.query.pressReleases.findFirst({
+      where: eq(pressReleases.idempotency_key, key),
+    });
+  }
+
+  listReleasesForOrg(organizationId: string, limit = 100): Promise<PressRelease[]> {
+    return dbRead.query.pressReleases.findMany({
+      where: eq(pressReleases.organization_id, organizationId),
+      orderBy: [desc(pressReleases.created_at)],
+      limit,
+    });
+  }
+
+  async createRelease(data: NewPressRelease): Promise<PressRelease> {
+    const [row] = await dbWrite.insert(pressReleases).values(data).returning();
+    return row;
+  }
+
+  async updateReleaseDraft(
+    id: string,
+    organizationId: string,
+    data: Partial<NewPressRelease>,
+  ): Promise<PressRelease | undefined> {
+    const [row] = await dbWrite
+      .update(pressReleases)
+      .set({ ...data, updated_at: new Date() })
+      .where(
+        and(
+          eq(pressReleases.id, id),
+          eq(pressReleases.organization_id, organizationId),
+          eq(pressReleases.status, "draft"),
+        ),
+      )
+      .returning();
+    return row;
+  }
+
+  async transitionRelease(
+    id: string,
+    organizationId: string,
+    from: PressReleaseStatus,
+    to: PressReleaseStatus,
+    extra: Partial<NewPressRelease> = {},
+  ): Promise<PressRelease | undefined> {
+    const [row] = await dbWrite
+      .update(pressReleases)
+      .set({ ...extra, status: to, updated_at: new Date() })
+      .where(
+        and(
+          eq(pressReleases.id, id),
+          eq(pressReleases.organization_id, organizationId),
+          eq(pressReleases.status, from),
+        ),
+      )
+      .returning();
+    return row;
+  }
+
+  findDistributionById(id: string): Promise<PressReleaseDistribution | undefined> {
+    return dbRead.query.pressReleaseDistributions.findFirst({
+      where: eq(pressReleaseDistributions.id, id),
+    });
+  }
+
+  findDistributionByIdempotencyKey(key: string): Promise<PressReleaseDistribution | undefined> {
+    return dbRead.query.pressReleaseDistributions.findFirst({
+      where: eq(pressReleaseDistributions.idempotency_key, key),
+    });
+  }
+
+  listDistributionsForRelease(
+    pressReleaseId: string,
+    organizationId: string,
+  ): Promise<PressReleaseDistribution[]> {
+    return dbRead.query.pressReleaseDistributions.findMany({
+      where: and(
+        eq(pressReleaseDistributions.press_release_id, pressReleaseId),
+        eq(pressReleaseDistributions.organization_id, organizationId),
+      ),
+      orderBy: [desc(pressReleaseDistributions.created_at)],
+    });
+  }
+
+  async createDistribution(data: NewPressReleaseDistribution): Promise<PressReleaseDistribution> {
+    const [row] = await dbWrite.insert(pressReleaseDistributions).values(data).returning();
+    return row;
+  }
+
+  async transitionDistribution(
+    id: string,
+    from: PressDistributionStatus,
+    to: PressDistributionStatus,
+    extra: Partial<NewPressReleaseDistribution> = {},
+  ): Promise<PressReleaseDistribution | undefined> {
+    const [row] = await dbWrite
+      .update(pressReleaseDistributions)
+      .set({ ...extra, status: to, updated_at: new Date() })
+      .where(and(eq(pressReleaseDistributions.id, id), eq(pressReleaseDistributions.status, from)))
+      .returning();
+    return row;
+  }
+
+  async createContact(data: NewPressMediaContact): Promise<PressMediaContact> {
+    const [row] = await dbWrite.insert(pressMediaContacts).values(data).returning();
+    return row;
+  }
+
+  listContactsForOrg(organizationId: string): Promise<PressMediaContact[]> {
+    return dbRead.query.pressMediaContacts.findMany({
+      where: eq(pressMediaContacts.organization_id, organizationId),
+      orderBy: [desc(pressMediaContacts.created_at)],
+    });
+  }
+
+  async recordCoverage(data: NewPressCoverage): Promise<PressCoverage> {
+    const [row] = await dbWrite
+      .insert(pressCoverage)
+      .values(data)
+      .onConflictDoUpdate({
+        target: [pressCoverage.press_release_id, pressCoverage.url],
+        set: {
+          title: data.title,
+          outlet: data.outlet,
+          published_at: data.published_at,
+          metadata: data.metadata,
+        },
+      })
+      .returning();
+    return row;
+  }
+
+  listCoverageForRelease(pressReleaseId: string, organizationId: string): Promise<PressCoverage[]> {
+    return dbRead.query.pressCoverage.findMany({
+      where: and(
+        eq(pressCoverage.press_release_id, pressReleaseId),
+        eq(pressCoverage.organization_id, organizationId),
+      ),
+      orderBy: [desc(pressCoverage.created_at)],
+    });
+  }
+}
+
+export const pressReleasesRepository = new PressReleasesRepository();

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -75,6 +75,7 @@ export * from "./organizations";
 export * from "./phone-gateway-devices";
 export * from "./platform-credentials";
 export * from "./pooled-credentials";
+export * from "./press-releases";
 export * from "./provider-health";
 export * from "./redeemable-earnings";
 export * from "./referrals";

--- a/packages/cloud/shared/src/db/schemas/press-releases.ts
+++ b/packages/cloud/shared/src/db/schemas/press-releases.ts
@@ -1,0 +1,191 @@
+/**
+ * PR / press distribution domain model (#11818).
+ *
+ * This stores the Cloud-owned release draft, distribution attempts, media
+ * contacts, and coverage artifacts. External newswire/provider execution is a
+ * later slice; this schema gives those providers an idempotent state machine to
+ * attach to without inventing their own persistence.
+ */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+export type PressReleaseStatus =
+  | "draft"
+  | "ready"
+  | "submitted"
+  | "distributed"
+  | "failed"
+  | "cancelled";
+
+export type PressDistributionStatus =
+  | "pending"
+  | "submitted"
+  | "distributed"
+  | "failed"
+  | "cancelled";
+
+export type MediaContactStatus = "active" | "inactive";
+
+export interface PressReleaseAsset {
+  url: string;
+  mimeType?: string;
+  label?: string;
+}
+
+export interface PressReleaseTargetAudience {
+  niches?: string[];
+  regions?: string[];
+  languages?: string[];
+  outletTypes?: string[];
+}
+
+export const pressReleases = pgTable(
+  "press_releases",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    created_by_user_id: uuid("created_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+
+    title: text("title").notNull(),
+    summary: text("summary"),
+    body: text("body").notNull(),
+    boilerplate: text("boilerplate"),
+    status: text("status").$type<PressReleaseStatus>().notNull().default("draft"),
+    target_audience: jsonb("target_audience")
+      .$type<PressReleaseTargetAudience>()
+      .notNull()
+      .default({}),
+    target_regions: jsonb("target_regions").$type<string[]>().notNull().default([]),
+    assets: jsonb("assets").$type<PressReleaseAsset[]>().notNull().default([]),
+    embargo_at: timestamp("embargo_at"),
+    submitted_at: timestamp("submitted_at"),
+    distributed_at: timestamp("distributed_at"),
+    failed_reason: text("failed_reason"),
+    idempotency_key: text("idempotency_key"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    org_idx: index("press_releases_org_idx").on(table.organization_id),
+    status_idx: index("press_releases_status_idx").on(table.status),
+    created_idx: index("press_releases_created_idx").on(table.created_at),
+    idempotency_key_uidx: uniqueIndex("press_releases_idempotency_key_uidx").on(
+      table.idempotency_key,
+    ),
+  }),
+);
+
+export const pressReleaseDistributions = pgTable(
+  "press_release_distributions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    press_release_id: uuid("press_release_id")
+      .notNull()
+      .references(() => pressReleases.id, { onDelete: "cascade" }),
+
+    provider: text("provider").notNull(),
+    external_distribution_id: text("external_distribution_id"),
+    status: text("status").$type<PressDistributionStatus>().notNull().default("pending"),
+    idempotency_key: text("idempotency_key"),
+    request_payload: jsonb("request_payload")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    provider_response: jsonb("provider_response")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    error_message: text("error_message"),
+    submitted_at: timestamp("submitted_at"),
+    completed_at: timestamp("completed_at"),
+
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    org_idx: index("press_release_distributions_org_idx").on(table.organization_id),
+    release_idx: index("press_release_distributions_release_idx").on(table.press_release_id),
+    provider_idx: index("press_release_distributions_provider_idx").on(table.provider),
+    idempotency_key_uidx: uniqueIndex("press_release_distributions_idempotency_key_uidx").on(
+      table.idempotency_key,
+    ),
+  }),
+);
+
+export const pressMediaContacts = pgTable(
+  "press_media_contacts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    created_by_user_id: uuid("created_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+
+    name: text("name").notNull(),
+    outlet: text("outlet").notNull(),
+    email: text("email"),
+    beat: text("beat"),
+    region: text("region"),
+    status: text("status").$type<MediaContactStatus>().notNull().default("active"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+
+    created_at: timestamp("created_at").defaultNow().notNull(),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    org_idx: index("press_media_contacts_org_idx").on(table.organization_id),
+    status_idx: index("press_media_contacts_status_idx").on(table.status),
+  }),
+);
+
+export const pressCoverage = pgTable(
+  "press_coverage",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    press_release_id: uuid("press_release_id")
+      .notNull()
+      .references(() => pressReleases.id, { onDelete: "cascade" }),
+    distribution_id: uuid("distribution_id").references(() => pressReleaseDistributions.id, {
+      onDelete: "set null",
+    }),
+
+    url: text("url").notNull(),
+    title: text("title"),
+    outlet: text("outlet"),
+    published_at: timestamp("published_at"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+
+    created_at: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    org_idx: index("press_coverage_org_idx").on(table.organization_id),
+    release_idx: index("press_coverage_release_idx").on(table.press_release_id),
+    url_uidx: uniqueIndex("press_coverage_release_url_uidx").on(table.press_release_id, table.url),
+  }),
+);
+
+export type PressRelease = InferSelectModel<typeof pressReleases>;
+export type NewPressRelease = InferInsertModel<typeof pressReleases>;
+export type PressReleaseDistribution = InferSelectModel<typeof pressReleaseDistributions>;
+export type NewPressReleaseDistribution = InferInsertModel<typeof pressReleaseDistributions>;
+export type PressMediaContact = InferSelectModel<typeof pressMediaContacts>;
+export type NewPressMediaContact = InferInsertModel<typeof pressMediaContacts>;
+export type PressCoverage = InferSelectModel<typeof pressCoverage>;
+export type NewPressCoverage = InferInsertModel<typeof pressCoverage>;

--- a/packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts
@@ -1,0 +1,337 @@
+/**
+ * PR / press distribution domain model (#11818) — real Drizzle schema, in-process PGlite.
+ *
+ * This exercises the Cloud-owned lifecycle before any external newswire provider
+ * exists: draft persistence, idempotent creates/submissions, tenant scoping,
+ * embargo/asset validation, submission/distribution/failure transitions, media
+ * contacts, and coverage upsert artifacts.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  pressCoverage,
+  pressMediaContacts,
+  pressReleaseDistributions,
+  pressReleases,
+} from "../../../db/schemas/press-releases";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let service: typeof import("../press-releases").pressReleaseService;
+
+let seq = 0;
+const uniq = (prefix: string) =>
+  `${prefix}-${(seq += 1)}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function seedOrgUser() {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "PR Org", slug: uniq("pr-org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("pr-user"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+async function seedReadyRelease() {
+  const actor = await seedOrgUser();
+  const created = await service.createRelease({
+    organizationId: actor.orgId,
+    userId: actor.userId,
+    title: "Eliza Cloud launches press distribution",
+    body: "Eliza Cloud now supports a press release domain workflow.",
+    summary: "Launch summary",
+    targetRegions: ["US", "US", "EU"],
+    assets: [{ url: "https://example.com/press-kit.png", mimeType: "image/png" }],
+  });
+  expect(created.ok).toBe(true);
+  const ready = await service.markReady(created.release!.id, actor.orgId);
+  expect(ready.ok).toBe(true);
+  return { ...actor, releaseId: created.release!.id };
+}
+
+beforeAll(async () => {
+  try {
+    ({ pressReleaseService: service } = await import("../press-releases"));
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        pressReleases,
+        pressReleaseDistributions,
+        pressMediaContacts,
+        pressCoverage,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[press-releases.test] PGlite/pushSchema unavailable.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("press release domain service (#11818)", () => {
+  test("pglite applied (loud)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test("creates, lists, and marks a release ready with normalized target regions", async () => {
+    if (!pgliteReady) return;
+    const actor = await seedOrgUser();
+    const created = await service.createRelease({
+      organizationId: actor.orgId,
+      userId: actor.userId,
+      title: "  Product Hunt launch  ",
+      body: "  We launched an agent-first cloud.  ",
+      targetRegions: ["US", "EU", "US", ""],
+      idempotencyKey: uniq("release-key"),
+    });
+
+    expect(created.ok).toBe(true);
+    expect(created.release?.title).toBe("Product Hunt launch");
+    expect(created.release?.target_regions).toEqual(["US", "EU"]);
+    expect(created.release?.status).toBe("draft");
+
+    const ready = await service.markReady(created.release!.id, actor.orgId);
+    expect(ready.ok).toBe(true);
+    expect(ready.release?.status).toBe("ready");
+
+    const listed = await service.listReleases(actor.orgId);
+    expect(listed.map((release) => release.id)).toContain(created.release!.id);
+  });
+
+  test("create idempotency returns the same release and blocks cross-org key reuse", async () => {
+    if (!pgliteReady) return;
+    const owner = await seedOrgUser();
+    const other = await seedOrgUser();
+    const key = uniq("release-key");
+
+    const first = await service.createRelease({
+      organizationId: owner.orgId,
+      userId: owner.userId,
+      title: "Same key",
+      body: "The same client key should resume this row.",
+      idempotencyKey: key,
+    });
+    const retry = await service.createRelease({
+      organizationId: owner.orgId,
+      userId: owner.userId,
+      title: "Different title ignored",
+      body: "Different body ignored",
+      idempotencyKey: key,
+    });
+    const stolen = await service.createRelease({
+      organizationId: other.orgId,
+      userId: other.userId,
+      title: "Cross org",
+      body: "This must fail.",
+      idempotencyKey: key,
+    });
+
+    expect(first.ok).toBe(true);
+    expect(retry.ok).toBe(true);
+    expect(retry.release?.id).toBe(first.release?.id);
+    expect(stolen.ok).toBe(false);
+    expect(stolen.error).toBe("Idempotency key already used");
+  });
+
+  test("rejects empty content, past embargoes, and unsafe asset URLs", async () => {
+    if (!pgliteReady) return;
+    const actor = await seedOrgUser();
+
+    expect(
+      await service.createRelease({
+        organizationId: actor.orgId,
+        userId: actor.userId,
+        title: "",
+        body: "Body",
+      }),
+    ).toMatchObject({ ok: false, error: "Title is required" });
+
+    expect(
+      await service.createRelease({
+        organizationId: actor.orgId,
+        userId: actor.userId,
+        title: "Past embargo",
+        body: "Body",
+        embargoAt: new Date(Date.now() - 60_000),
+      }),
+    ).toMatchObject({ ok: false, error: "Embargo must be in the future" });
+
+    expect(
+      await service.createRelease({
+        organizationId: actor.orgId,
+        userId: actor.userId,
+        title: "Bad asset",
+        body: "Body",
+        assets: [{ url: "file:///tmp/kit.png" }],
+      }),
+    ).toMatchObject({ ok: false, error: "Asset URL must be HTTP(S)" });
+  });
+
+  test("draft updates are tenant-scoped and freeze after ready", async () => {
+    if (!pgliteReady) return;
+    const owner = await seedOrgUser();
+    const other = await seedOrgUser();
+    const created = await service.createRelease({
+      organizationId: owner.orgId,
+      userId: owner.userId,
+      title: "Editable",
+      body: "Before edit",
+    });
+
+    const denied = await service.updateDraft(created.release!.id, other.orgId, {
+      title: "Cross org edit",
+    });
+    expect(denied.ok).toBe(false);
+
+    const edited = await service.updateDraft(created.release!.id, owner.orgId, {
+      body: "After edit",
+    });
+    expect(edited.ok).toBe(true);
+    expect(edited.release?.body).toBe("After edit");
+
+    await service.markReady(created.release!.id, owner.orgId);
+    const frozen = await service.updateDraft(created.release!.id, owner.orgId, {
+      body: "Too late",
+    });
+    expect(frozen.ok).toBe(false);
+  });
+
+  test("submission is idempotent and drives submitted → distributed with coverage artifacts", async () => {
+    if (!pgliteReady) return;
+    const seeded = await seedReadyRelease();
+    const key = uniq("distribution-key");
+
+    const submitted = await service.recordSubmission({
+      releaseId: seeded.releaseId,
+      organizationId: seeded.orgId,
+      provider: "sandbox-newswire",
+      requestPayload: { channels: ["tech"] },
+      externalDistributionId: "dist-123",
+      providerResponse: { status: "accepted" },
+      idempotencyKey: key,
+    });
+    expect(submitted.ok).toBe(true);
+    expect(submitted.release?.status).toBe("submitted");
+    expect(submitted.distribution?.status).toBe("submitted");
+
+    const retry = await service.recordSubmission({
+      releaseId: seeded.releaseId,
+      organizationId: seeded.orgId,
+      provider: "sandbox-newswire",
+      idempotencyKey: key,
+    });
+    expect(retry.ok).toBe(true);
+    expect(retry.distribution?.id).toBe(submitted.distribution?.id);
+
+    const distributed = await service.markDistributed({
+      distributionId: submitted.distribution!.id,
+      organizationId: seeded.orgId,
+      providerResponse: { status: "distributed" },
+    });
+    expect(distributed.ok).toBe(true);
+    expect(distributed.release?.status).toBe("distributed");
+
+    const coverage = await service.recordCoverage({
+      organizationId: seeded.orgId,
+      releaseId: seeded.releaseId,
+      distributionId: submitted.distribution!.id,
+      url: "https://example-news.test/eliza-cloud",
+      title: "Eliza Cloud adds PR workflow",
+      outlet: "Example News",
+      publishedAt: new Date("2026-07-03T12:00:00.000Z"),
+    });
+    expect(coverage.outlet).toBe("Example News");
+
+    const updatedCoverage = await service.recordCoverage({
+      organizationId: seeded.orgId,
+      releaseId: seeded.releaseId,
+      distributionId: submitted.distribution!.id,
+      url: "https://example-news.test/eliza-cloud",
+      title: "Updated headline",
+      outlet: "Example News",
+    });
+    expect(updatedCoverage.id).toBe(coverage.id);
+    expect(updatedCoverage.title).toBe("Updated headline");
+  });
+
+  test("failed distribution records provider error and prevents cancellation after submit", async () => {
+    if (!pgliteReady) return;
+    const seeded = await seedReadyRelease();
+    const submitted = await service.recordSubmission({
+      releaseId: seeded.releaseId,
+      organizationId: seeded.orgId,
+      provider: "sandbox-newswire",
+    });
+
+    const cancelled = await service.cancelRelease(seeded.releaseId, seeded.orgId);
+    expect(cancelled.ok).toBe(false);
+
+    const failed = await service.markFailed({
+      distributionId: submitted.distribution!.id,
+      organizationId: seeded.orgId,
+      error: "Provider rejected embargo",
+    });
+    expect(failed.ok).toBe(true);
+    expect(failed.release?.status).toBe("failed");
+    expect(failed.distribution?.error_message).toBe("Provider rejected embargo");
+  });
+
+  test("media contacts persist by organization", async () => {
+    if (!pgliteReady) return;
+    const owner = await seedOrgUser();
+    const other = await seedOrgUser();
+
+    await service.createContact({
+      organizationId: owner.orgId,
+      userId: owner.userId,
+      name: "A Reporter",
+      outlet: "Example News",
+      email: "reporter@example.test",
+      beat: "AI",
+      region: "US",
+    });
+    await service.createContact({
+      organizationId: other.orgId,
+      userId: other.userId,
+      name: "Other Reporter",
+      outlet: "Other News",
+    });
+
+    const ownerContacts = await service.listContacts(owner.orgId);
+    expect(ownerContacts).toHaveLength(1);
+    expect(ownerContacts[0].outlet).toBe("Example News");
+  });
+
+  test("real DB rows are available for reviewer-verifiable evidence", async () => {
+    if (!pgliteReady) return;
+    const seeded = await seedReadyRelease();
+    const [releaseRow] = await dbWrite
+      .select()
+      .from(pressReleases)
+      .where(eq(pressReleases.id, seeded.releaseId));
+
+    expect(releaseRow.organization_id).toBe(seeded.orgId);
+    expect(releaseRow.status).toBe("ready");
+    expect(releaseRow.body).toContain("press release domain workflow");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/press-releases.ts
+++ b/packages/cloud/shared/src/lib/services/press-releases.ts
@@ -1,0 +1,397 @@
+/**
+ * PR / press distribution domain service (#11818).
+ *
+ * Owns Cloud's press-release lifecycle before any external newswire provider is
+ * selected. Provider integrations attach distribution attempts to this service
+ * in later slices; until then the state machine fails closed instead of
+ * pretending a release was distributed.
+ */
+
+import {
+  type NewPressRelease,
+  type PressCoverage,
+  type PressMediaContact,
+  type PressRelease,
+  type PressReleaseAsset,
+  type PressReleaseDistribution,
+  type PressReleaseTargetAudience,
+  pressReleasesRepository,
+} from "../../db/repositories/press-releases";
+
+export interface PressReleaseResult {
+  ok: boolean;
+  release?: PressRelease;
+  distribution?: PressReleaseDistribution;
+  error?: string;
+}
+
+export interface PressDistributionResult {
+  ok: boolean;
+  release?: PressRelease;
+  distribution?: PressReleaseDistribution;
+  error?: string;
+}
+
+function cleanText(value: string | undefined | null): string {
+  return (value ?? "").trim();
+}
+
+function normalizeStringList(values: string[] | undefined): string[] {
+  return [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))];
+}
+
+function validateEmbargo(embargoAt?: Date | null): string | undefined {
+  if (!embargoAt) return undefined;
+  if (Number.isNaN(embargoAt.getTime())) return "Embargo timestamp is invalid";
+  if (embargoAt.getTime() <= Date.now()) return "Embargo must be in the future";
+  return undefined;
+}
+
+function validateAssets(assets: PressReleaseAsset[] | undefined): string | undefined {
+  for (const asset of assets ?? []) {
+    const url = cleanText(asset.url);
+    if (!url) return "Asset URL is required";
+    try {
+      const parsed = new URL(url);
+      if (!["https:", "http:"].includes(parsed.protocol)) return "Asset URL must be HTTP(S)";
+    } catch {
+      return "Asset URL is invalid";
+    }
+  }
+  return undefined;
+}
+
+export class PressReleaseService {
+  async createRelease(input: {
+    organizationId: string;
+    userId: string;
+    title: string;
+    body: string;
+    summary?: string;
+    boilerplate?: string;
+    targetAudience?: PressReleaseTargetAudience;
+    targetRegions?: string[];
+    assets?: PressReleaseAsset[];
+    embargoAt?: Date | null;
+    idempotencyKey?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<PressReleaseResult> {
+    const title = cleanText(input.title);
+    const body = cleanText(input.body);
+    if (!title) return { ok: false, error: "Title is required" };
+    if (!body) return { ok: false, error: "Body is required" };
+    const embargoError = validateEmbargo(input.embargoAt);
+    if (embargoError) return { ok: false, error: embargoError };
+    const assetError = validateAssets(input.assets);
+    if (assetError) return { ok: false, error: assetError };
+
+    if (input.idempotencyKey) {
+      const existing = await pressReleasesRepository.findReleaseByIdempotencyKey(
+        input.idempotencyKey,
+      );
+      if (existing) {
+        if (existing.organization_id !== input.organizationId) {
+          return { ok: false, error: "Idempotency key already used" };
+        }
+        return { ok: true, release: existing };
+      }
+    }
+
+    const release = await pressReleasesRepository.createRelease({
+      organization_id: input.organizationId,
+      created_by_user_id: input.userId,
+      title,
+      body,
+      summary: cleanText(input.summary) || null,
+      boilerplate: cleanText(input.boilerplate) || null,
+      target_audience: input.targetAudience ?? {},
+      target_regions: normalizeStringList(input.targetRegions),
+      assets: input.assets ?? [],
+      embargo_at: input.embargoAt ?? null,
+      idempotency_key: input.idempotencyKey ?? null,
+      metadata: input.metadata ?? {},
+    });
+    return { ok: true, release };
+  }
+
+  getRelease(id: string, organizationId: string): Promise<PressRelease | undefined> {
+    return pressReleasesRepository.findReleaseByIdForOrg(id, organizationId);
+  }
+
+  listReleases(organizationId: string): Promise<PressRelease[]> {
+    return pressReleasesRepository.listReleasesForOrg(organizationId);
+  }
+
+  async updateDraft(
+    id: string,
+    organizationId: string,
+    patch: {
+      title?: string;
+      body?: string;
+      summary?: string | null;
+      boilerplate?: string | null;
+      targetAudience?: PressReleaseTargetAudience;
+      targetRegions?: string[];
+      assets?: PressReleaseAsset[];
+      embargoAt?: Date | null;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<PressReleaseResult> {
+    const set: Partial<NewPressRelease> = {};
+    if (patch.title !== undefined) {
+      const title = cleanText(patch.title);
+      if (!title) return { ok: false, error: "Title is required" };
+      set.title = title;
+    }
+    if (patch.body !== undefined) {
+      const body = cleanText(patch.body);
+      if (!body) return { ok: false, error: "Body is required" };
+      set.body = body;
+    }
+    if (patch.summary !== undefined) set.summary = cleanText(patch.summary) || null;
+    if (patch.boilerplate !== undefined) set.boilerplate = cleanText(patch.boilerplate) || null;
+    if (patch.targetAudience !== undefined) set.target_audience = patch.targetAudience;
+    if (patch.targetRegions !== undefined) {
+      set.target_regions = normalizeStringList(patch.targetRegions);
+    }
+    if (patch.assets !== undefined) {
+      const assetError = validateAssets(patch.assets);
+      if (assetError) return { ok: false, error: assetError };
+      set.assets = patch.assets;
+    }
+    if (patch.embargoAt !== undefined) {
+      const embargoError = validateEmbargo(patch.embargoAt);
+      if (embargoError) return { ok: false, error: embargoError };
+      set.embargo_at = patch.embargoAt;
+    }
+    if (patch.metadata !== undefined) set.metadata = patch.metadata;
+
+    const release = await pressReleasesRepository.updateReleaseDraft(id, organizationId, set);
+    return release ? { ok: true, release } : { ok: false, error: "Draft press release not found" };
+  }
+
+  async markReady(id: string, organizationId: string): Promise<PressReleaseResult> {
+    const release = await this.getRelease(id, organizationId);
+    if (!release) return { ok: false, error: "Press release not found" };
+    if (release.status === "ready") return { ok: true, release };
+    if (release.status !== "draft") return { ok: false, error: "Press release is not editable" };
+    if (!cleanText(release.title) || !cleanText(release.body)) {
+      return { ok: false, error: "Title and body are required" };
+    }
+    const moved = await pressReleasesRepository.transitionRelease(
+      id,
+      organizationId,
+      "draft",
+      "ready",
+    );
+    return moved
+      ? { ok: true, release: moved }
+      : { ok: false, error: "Press release changed state" };
+  }
+
+  async recordSubmission(input: {
+    releaseId: string;
+    organizationId: string;
+    provider: string;
+    requestPayload?: Record<string, unknown>;
+    externalDistributionId?: string;
+    providerResponse?: Record<string, unknown>;
+    idempotencyKey?: string;
+  }): Promise<PressDistributionResult> {
+    const provider = cleanText(input.provider);
+    if (!provider) return { ok: false, error: "Provider is required" };
+
+    if (input.idempotencyKey) {
+      const existing = await pressReleasesRepository.findDistributionByIdempotencyKey(
+        input.idempotencyKey,
+      );
+      if (existing) {
+        if (existing.organization_id !== input.organizationId) {
+          return { ok: false, error: "Idempotency key already used" };
+        }
+        const release = await this.getRelease(existing.press_release_id, input.organizationId);
+        return { ok: true, release, distribution: existing };
+      }
+    }
+
+    const release = await this.getRelease(input.releaseId, input.organizationId);
+    if (!release) return { ok: false, error: "Press release not found" };
+    if (!["ready", "submitted"].includes(release.status)) {
+      return { ok: false, error: "Press release is not ready for submission" };
+    }
+
+    const distribution = await pressReleasesRepository.createDistribution({
+      organization_id: input.organizationId,
+      press_release_id: input.releaseId,
+      provider,
+      external_distribution_id: input.externalDistributionId ?? null,
+      status: "submitted",
+      idempotency_key: input.idempotencyKey ?? null,
+      request_payload: input.requestPayload ?? {},
+      provider_response: input.providerResponse ?? {},
+      submitted_at: new Date(),
+    });
+
+    const submittedRelease =
+      release.status === "submitted"
+        ? release
+        : await pressReleasesRepository.transitionRelease(
+            input.releaseId,
+            input.organizationId,
+            "ready",
+            "submitted",
+            {
+              submitted_at: new Date(),
+            },
+          );
+    return submittedRelease
+      ? { ok: true, release: submittedRelease, distribution }
+      : { ok: false, error: "Submission could not be finalized" };
+  }
+
+  async markDistributed(input: {
+    distributionId: string;
+    organizationId: string;
+    providerResponse?: Record<string, unknown>;
+  }): Promise<PressDistributionResult> {
+    const distribution = await pressReleasesRepository.findDistributionById(input.distributionId);
+    if (!distribution || distribution.organization_id !== input.organizationId) {
+      return { ok: false, error: "Distribution not found" };
+    }
+    const movedDistribution =
+      distribution.status === "distributed"
+        ? distribution
+        : await pressReleasesRepository.transitionDistribution(
+            distribution.id,
+            "submitted",
+            "distributed",
+            {
+              provider_response: input.providerResponse ?? distribution.provider_response,
+              completed_at: new Date(),
+            },
+          );
+    if (!movedDistribution) return { ok: false, error: "Distribution is not submitted" };
+
+    const release =
+      (await pressReleasesRepository.transitionRelease(
+        distribution.press_release_id,
+        input.organizationId,
+        "submitted",
+        "distributed",
+        { distributed_at: new Date() },
+      )) ?? (await this.getRelease(distribution.press_release_id, input.organizationId));
+    return { ok: true, release, distribution: movedDistribution };
+  }
+
+  async markFailed(input: {
+    distributionId: string;
+    organizationId: string;
+    error: string;
+    providerResponse?: Record<string, unknown>;
+  }): Promise<PressDistributionResult> {
+    const distribution = await pressReleasesRepository.findDistributionById(input.distributionId);
+    if (!distribution || distribution.organization_id !== input.organizationId) {
+      return { ok: false, error: "Distribution not found" };
+    }
+    const movedDistribution =
+      distribution.status === "failed"
+        ? distribution
+        : await pressReleasesRepository.transitionDistribution(
+            distribution.id,
+            "submitted",
+            "failed",
+            {
+              error_message: cleanText(input.error) || "Distribution failed",
+              provider_response: input.providerResponse ?? distribution.provider_response,
+              completed_at: new Date(),
+            },
+          );
+    if (!movedDistribution) return { ok: false, error: "Distribution is not submitted" };
+
+    const release =
+      (await pressReleasesRepository.transitionRelease(
+        distribution.press_release_id,
+        input.organizationId,
+        "submitted",
+        "failed",
+        { failed_reason: movedDistribution.error_message ?? "Distribution failed" },
+      )) ?? (await this.getRelease(distribution.press_release_id, input.organizationId));
+    return { ok: true, release, distribution: movedDistribution };
+  }
+
+  async cancelRelease(id: string, organizationId: string): Promise<PressReleaseResult> {
+    const release = await this.getRelease(id, organizationId);
+    if (!release) return { ok: false, error: "Press release not found" };
+    if (release.status === "cancelled") return { ok: true, release };
+    if (!["draft", "ready"].includes(release.status)) {
+      return { ok: false, error: "Submitted press releases cannot be cancelled here" };
+    }
+    const moved =
+      (await pressReleasesRepository.transitionRelease(id, organizationId, "draft", "cancelled")) ??
+      (await pressReleasesRepository.transitionRelease(id, organizationId, "ready", "cancelled"));
+    return moved
+      ? { ok: true, release: moved }
+      : { ok: false, error: "Press release changed state" };
+  }
+
+  createContact(input: {
+    organizationId: string;
+    userId?: string;
+    name: string;
+    outlet: string;
+    email?: string;
+    beat?: string;
+    region?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<PressMediaContact> {
+    const name = cleanText(input.name);
+    const outlet = cleanText(input.outlet);
+    if (!name || !outlet) {
+      throw new Error("Contact name and outlet are required");
+    }
+    return pressReleasesRepository.createContact({
+      organization_id: input.organizationId,
+      created_by_user_id: input.userId ?? null,
+      name,
+      outlet,
+      email: cleanText(input.email) || null,
+      beat: cleanText(input.beat) || null,
+      region: cleanText(input.region) || null,
+      metadata: input.metadata ?? {},
+    });
+  }
+
+  listContacts(organizationId: string): Promise<PressMediaContact[]> {
+    return pressReleasesRepository.listContactsForOrg(organizationId);
+  }
+
+  async recordCoverage(input: {
+    organizationId: string;
+    releaseId: string;
+    distributionId?: string;
+    url: string;
+    title?: string;
+    outlet?: string;
+    publishedAt?: Date;
+    metadata?: Record<string, unknown>;
+  }): Promise<PressCoverage> {
+    const release = await this.getRelease(input.releaseId, input.organizationId);
+    if (!release) throw new Error("Press release not found");
+    return pressReleasesRepository.recordCoverage({
+      organization_id: input.organizationId,
+      press_release_id: input.releaseId,
+      distribution_id: input.distributionId ?? null,
+      url: input.url,
+      title: cleanText(input.title) || null,
+      outlet: cleanText(input.outlet) || null,
+      published_at: input.publishedAt ?? null,
+      metadata: input.metadata ?? {},
+    });
+  }
+
+  listCoverage(releaseId: string, organizationId: string): Promise<PressCoverage[]> {
+    return pressReleasesRepository.listCoverageForRelease(releaseId, organizationId);
+  }
+}
+
+export const pressReleaseService = new PressReleaseService();


### PR DESCRIPTION
## Summary
- add Cloud PR/press release domain tables for releases, distribution attempts, media contacts, and coverage
- add repository + service state machine for draft -> ready -> submitted -> distributed/failed/cancelled
- validate required content, future embargoes, HTTP(S) assets, idempotent create/submit keys, and org scoping
- add PGlite tests and checked-in #11818 evidence

Fixes #11818.
Parent: #11362.

## Validation
- `bun x @biomejs/biome check packages/cloud/shared/src/db/schemas/press-releases.ts packages/cloud/shared/src/db/repositories/press-releases.ts packages/cloud/shared/src/lib/services/press-releases.ts packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts packages/cloud/shared/src/db/schemas/index.ts packages/cloud/shared/src/db/repositories/index.ts .github/issue-evidence/11818-pr-domain-model.md`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/shared db:check-migrations`
- `bun test packages/cloud/shared/src/lib/services/__tests__/press-releases.test.ts` — 9 tests passed against in-process PGlite

## Evidence
- `.github/issue-evidence/11818-pr-domain-model.md`

## N/A
- Live provider logs: N/A - this slice intentionally does not call an external newswire provider. Provider selection and live distribution are split to #11820/#11821.
- Screenshots/video: N/A - backend domain-model slice with no UI surface.
- Real-LLM trajectories: N/A - no model/action/prompt behavior changed.
