### PR TITLE
fix(ui): first-click Cloud sign-in with a stale Steward token + honest 'Active' copy for coding-plan subscriptions

### DIFF
--- a/packages/ui/src/components/settings/ProviderSwitcher.active-summary.test.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.active-summary.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+//
+// Honest "Active" copy in the AI Model summary row. Selecting a coding-plan
+// subscription (e.g. "Claude Subscription") does NOT move the main chat
+// inference — `applySubscriptionProviderConfig` (packages/agent/src/api/
+// provider-switch-config.ts) records it for the task-agent orchestrator and
+// only sets a runtime `model.primary` for the Codex plan. A bare "Active"
+// summary next to "Claude Subscription" therefore misled users into thinking
+// chat had switched to Claude. These tests lock the qualified copy.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { Cloud, KeyRound } from "lucide-react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ActiveProviderSummary } from "./ProviderSwitcher";
+import type { ProviderListEntry } from "./useProviderEntries";
+
+const t = (key: string, vars?: Record<string, unknown>) =>
+  typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
+
+function makeEntry(overrides: Partial<ProviderListEntry>): ProviderListEntry {
+  return {
+    id: "__cloud__",
+    icon: Cloud,
+    label: "Eliza Cloud",
+    category: "cloud",
+    status: { tone: "ok", label: "Connected" },
+    current: true,
+    ...overrides,
+  };
+}
+
+describe("ActiveProviderSummary — honest active-state copy", () => {
+  afterEach(cleanup);
+
+  it("labels a coding-plan subscription 'Active for coding agents' with the chat clarifier", () => {
+    render(
+      <ActiveProviderSummary
+        entry={makeEntry({
+          id: "anthropic-subscription",
+          icon: KeyRound,
+          label: "Claude Subscription",
+          category: "subscription",
+        })}
+        t={t}
+      />,
+    );
+
+    expect(screen.getByText("Claude Subscription")).toBeTruthy();
+    expect(screen.getByText("Active for coding agents")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Powers coding agents & workflows only — chat replies keep using the Intelligence provider above.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Active")).toBeNull();
+  });
+
+  it("keeps the plain 'Active' for the Codex plan (it may drive runtime inference)", () => {
+    render(
+      <ActiveProviderSummary
+        entry={makeEntry({
+          id: "openai-subscription",
+          icon: KeyRound,
+          label: "ChatGPT Subscription",
+          category: "subscription",
+        })}
+        t={t}
+      />,
+    );
+
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.queryByText("Active for coding agents")).toBeNull();
+  });
+
+  it("keeps the plain 'Active' for intelligence providers (Cloud/local)", () => {
+    render(<ActiveProviderSummary entry={makeEntry({})} t={t} />);
+
+    expect(screen.getByText("Eliza Cloud")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    expect(screen.queryByText("Active for coding agents")).toBeNull();
+    expect(
+      screen.queryByText(/chat replies keep using the Intelligence provider/),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/ui/src/components/settings/ProviderSwitcher.tsx
@@ -311,8 +311,20 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
  * The provider currently routing this agent's intelligence, surfaced as a single
  * anchored row above the chip cloud so "what's powering me right now" is answered
  * without scanning every chip for the filled/active state.
+ *
+ * Honesty note: most coding-plan subscriptions (Claude Subscription, Gemini/
+ * z.ai/Kimi/DeepSeek coding plans) can be the "current" selection WITHOUT
+ * routing the main chat inference — `applySubscriptionProviderConfig`
+ * (packages/agent/src/api/provider-switch-config.ts) records them for the
+ * task-agent orchestrator and only sets a runtime `model.primary` for the
+ * Codex plan (`openai-codex`). A bare "Active" here therefore read as "this
+ * now powers chat", which is false for Claude. Those entries get a qualified
+ * label + note so the summary states what the selection actually does; the
+ * Codex plan (which really can power the runtime) keeps the plain label.
+ *
+ * @internal Exported for testing only.
  */
-function ActiveProviderSummary({
+export function ActiveProviderSummary({
   entry,
   t,
 }: {
@@ -320,6 +332,10 @@ function ActiveProviderSummary({
   t: (key: string, vars?: Record<string, unknown>) => string;
 }) {
   const Icon = entry.icon;
+  // Mirrors the `runtimeApplicable` rule in provider-switch-config.ts: of the
+  // subscription selections only openai-codex may drive runtime inference.
+  const codingAgentsOnly =
+    entry.category === "subscription" && entry.id !== "openai-subscription";
   return (
     <SettingsRow
       label={
@@ -331,9 +347,21 @@ function ActiveProviderSummary({
           {entry.label}
         </span>
       }
+      description={
+        codingAgentsOnly
+          ? t("providerswitcher.codingSubscriptionChatNote", {
+              defaultValue:
+                "Powers coding agents & workflows only — chat replies keep using the Intelligence provider above.",
+            })
+          : undefined
+      }
       control={
         <span className="text-xs text-accent">
-          {t("providerswitcher.activeProvider", { defaultValue: "Active" })}
+          {codingAgentsOnly
+            ? t("providerswitcher.activeProviderCodingAgents", {
+                defaultValue: "Active for coding agents",
+              })
+            : t("providerswitcher.activeProvider", { defaultValue: "Active" })}
         </span>
       }
     />

--- a/packages/ui/src/state/cloud-steward-login.test.ts
+++ b/packages/ui/src/state/cloud-steward-login.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hasStewardLoginLauncher,
+  hasUsableStoredStewardToken,
   launchStewardLogin,
   registerStewardLoginLauncher,
 } from "./cloud-steward-login";
@@ -123,6 +124,27 @@ describe("cloud-steward-login seam", () => {
   it("throws when no launcher is registered and no token is stored", async () => {
     await expect(launchStewardLogin()).rejects.toThrow(
       /Steward login surface is not mounted/,
+    );
+  });
+
+  it("hasUsableStoredStewardToken mirrors the short-circuit rules", () => {
+    // No token stored.
+    expect(hasUsableStoredStewardToken()).toBe(false);
+    // Still-valid JWT — usable.
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(600));
+    expect(hasUsableStoredStewardToken()).toBe(true);
+    // Expired JWT — NOT usable (would only be drained + rethrown launcher-less).
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    expect(hasUsableStoredStewardToken()).toBe(false);
+    // Within the safety margin — NOT usable.
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(5));
+    expect(hasUsableStoredStewardToken()).toBe(false);
+    // Opaque device-code token (no decodable exp) — treated usable.
+    localStorage.setItem(STEWARD_TOKEN_KEY, "opaque-device-code-token");
+    expect(hasUsableStoredStewardToken()).toBe(true);
+    // Checking must never drain the stored value.
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(
+      "opaque-device-code-token",
     );
   });
 

--- a/packages/ui/src/state/cloud-steward-login.ts
+++ b/packages/ui/src/state/cloud-steward-login.ts
@@ -81,6 +81,18 @@ export function hasStewardLoginLauncher(): boolean {
 }
 
 /**
+ * Whether a stored Steward token exists AND can short-circuit sign-in (see
+ * {@link launchStewardLogin}). Callers use this to decide if the Steward
+ * branch can complete without a mounted launcher: a stored-but-stale JWT
+ * cannot (launching would just clear it and throw when nothing is mounted),
+ * so they should fall back to the legacy device-code flow instead.
+ */
+export function hasUsableStoredStewardToken(): boolean {
+  const existing = readStoredStewardToken()?.trim();
+  return Boolean(existing && isStoredStewardTokenUsable(existing));
+}
+
+/**
  * Drive the Cloud=Steward sign-in. If a *still-valid* session token is already
  * stored we resolve immediately; otherwise we invoke the registered launcher.
  * A stored-but-expired Steward JWT must NOT short-circuit — doing so produces a

--- a/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-stale-login.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+//
+// Sign-in first-click dead-end regression. With a stored-but-EXPIRED Steward
+// JWT and NO mounted Steward launcher (registerStewardLoginLauncher has no
+// production caller today, so the dashboard always runs launcher-less),
+// handleCloudLogin used to enter the Steward branch anyway: launchStewardLogin
+// drained the stale token and then threw "the Steward login surface is not
+// mounted", so the FIRST click surfaced a sign-in error and only the SECOND
+// click (token now gone) reached the working device-code flow. These tests
+// lock the fix: the first click drains the stale token and proceeds straight
+// to the device-code flow, while a still-usable token and a mounted launcher
+// keep their existing Steward-branch behavior.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../api";
+import { registerStewardLoginLauncher } from "./cloud-steward-login";
+import { useCloudState } from "./useCloudState";
+
+const STEWARD_TOKEN_KEY = "steward_session_token";
+const NOT_MOUNTED_ERROR = /Steward login surface is not mounted/;
+const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
+
+/** Build a minimal (unsigned) JWT whose payload carries the given `exp`. */
+function makeJwt(expSecondsFromNow: number | null): string {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  const header = enc({ alg: "none", typ: "JWT" });
+  const payload = enc(
+    expSecondsFromNow === null
+      ? {}
+      : { exp: Math.floor(Date.now() / 1000) + expSecondsFromNow },
+  );
+  return `${header}.${payload}.sig`;
+}
+
+function makeParams() {
+  return {
+    setActionNotice: vi.fn(),
+    loadWalletConfig: vi.fn(async () => {}),
+    t: (key: string) => key,
+  };
+}
+
+describe("useCloudState — handleCloudLogin with a stale Steward token and no launcher", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realFetch = globalThis.fetch;
+  let cloudLoginSpy: ReturnType<typeof vi.spyOn>;
+  let cloudLoginDirectSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    // The mount-time token-lifecycle refresh fires on stored-token presence;
+    // fail it so the stale token stays in place for the click under test.
+    fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, json: async () => ({}) });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    // Whichever legacy entry point the environment resolves to (agent proxy vs
+    // direct cloud auth), report a controlled failure so the login flow stops
+    // deterministically without starting the browser-poll interval.
+    cloudLoginSpy = vi.spyOn(client, "cloudLogin").mockResolvedValue({
+      ok: false,
+      sessionId: "",
+      browserUrl: "",
+      error: DEVICE_CODE_SENTINEL,
+    });
+    cloudLoginDirectSpy = vi.spyOn(client, "cloudLoginDirect").mockResolvedValue({
+      ok: false,
+      sessionId: "",
+      browserUrl: "",
+      error: DEVICE_CODE_SENTINEL,
+    });
+    vi.spyOn(client, "getCloudStatus").mockResolvedValue({
+      connected: false,
+      enabled: false,
+    } as Awaited<ReturnType<typeof client.getCloudStatus>>);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  const deviceCodeCalls = () =>
+    cloudLoginSpy.mock.calls.length + cloudLoginDirectSpy.mock.calls.length;
+
+  it("first click falls through to the device-code flow instead of throwing 'not mounted'", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin();
+    });
+
+    // The FIRST click must reach the legacy device-code flow…
+    expect(deviceCodeCalls()).toBe(1);
+    // …surface only that flow's outcome (never the launcher-missing throw)…
+    expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
+    expect(result.current.elizaCloudLoginError).not.toMatch(NOT_MOUNTED_ERROR);
+    // …and drain the stale token so it cannot shadow later authed calls.
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
+  it("a still-usable stored token keeps the Steward short-circuit (no device-code call)", async () => {
+    const valid = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, valid);
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin();
+    });
+
+    expect(deviceCodeCalls()).toBe(0);
+    expect(result.current.elizaCloudLoginError ?? "").not.toMatch(
+      NOT_MOUNTED_ERROR,
+    );
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(valid);
+  });
+
+  it("a mounted launcher still owns the stale-token re-auth (no device-code call)", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    const launcher = vi.fn(async () => ({ token: makeJwt(3600) }));
+    const unregister = registerStewardLoginLauncher(launcher);
+    try {
+      const { result } = renderHook(() => useCloudState(makeParams()));
+      await act(async () => {
+        await result.current.handleCloudLogin();
+      });
+
+      await waitFor(() => expect(launcher).toHaveBeenCalledTimes(1));
+      expect(deviceCodeCalls()).toBe(0);
+      expect(result.current.elizaCloudLoginError ?? "").not.toMatch(
+        NOT_MOUNTED_ERROR,
+      );
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -44,6 +44,7 @@ import {
 import { scrubPersistedAgentProfileTokens } from "./agent-profiles";
 import {
   hasStewardLoginLauncher,
+  hasUsableStoredStewardToken,
   launchStewardLogin,
 } from "./cloud-steward-login";
 import { scrubPersistedActiveServerToken } from "./persistence";
@@ -476,8 +477,16 @@ export function useCloudState({
       // Steward sign-in (passkey / email / OAuth / wallet) instead of the
       // legacy device-code browser window. Same identity on web (same-origin
       // cookie + localStorage JWT) and native (Bearer-from-localStorage).
-      const existingStewardToken = readStoredStewardToken()?.trim();
-      if (existingStewardToken || hasStewardLoginLauncher()) {
+      //
+      // Only take this branch when it can complete on THIS click: a still-usable
+      // stored token (launchStewardLogin short-circuits on it) or a mounted
+      // launcher. A stored-but-EXPIRED JWT with no launcher mounted used to
+      // enter the branch anyway; launchStewardLogin drained the stale token and
+      // then threw "the Steward login surface is not mounted", so the first
+      // click dead-ended on an error and only the second click (token now gone)
+      // reached the working device-code flow. Instead, drain the stale token
+      // below and fall through to the device-code flow on the same click.
+      if (hasUsableStoredStewardToken() || hasStewardLoginLauncher()) {
         closePrePoppedWindow();
         try {
           await launchStewardLogin();
@@ -512,6 +521,13 @@ export function useCloudState({
           completeLogin();
         }
         return loginCompletion;
+      }
+
+      // A stored-but-stale Steward JWT with no launcher mounted: drain it so it
+      // cannot shadow the device-code credentials in subsequent authed calls
+      // (this mirrors what launchStewardLogin would have done before throwing).
+      if (readStoredStewardToken()?.trim()) {
+        clearStoredStewardToken();
       }
 
       // Legacy device-code fallback (retired for Cloud; preserved for the


### PR DESCRIPTION
Two agent-fixable app demo blockers in `@elizaos/ui`, surfaced by the recent Fable app-flow audit and confirmed against the real code before fixing. Both are conservative, surgical, and confined to `packages/ui/src` + tests. No routing/money/cloud-Worker changes.

## Blocker 1 — sign-in first-click dead-end (expired Steward JWT)

**Before:** with a stored-but-EXPIRED Steward JWT in localStorage, `handleCloudLogin` (`useCloudState.ts`) entered the in-app Steward-launcher branch (`existingStewardToken || hasStewardLoginLauncher()`); `launchStewardLogin` cleared the stale token and then threw `"Eliza Cloud sign-in is unavailable: the Steward login surface is not mounted."` The user saw a sign-in ERROR on the first click; only the second click (token now drained) reached the working device-code flow. `registerStewardLoginLauncher` has **zero non-test callers repo-wide** (verified: only `dist/*.d.ts` typings match), so the launcher branch could never complete — it only produced this error.

**After:** the Steward branch is taken only when it can complete on this click — a still-usable stored token (short-circuit) or a mounted launcher. A stale token with no launcher is drained (so it can't shadow the device-code credentials in later authed calls) and the SAME click falls through to `cloudLoginDirect`/`cloudLogin`. New seam helper `hasUsableStoredStewardToken()` in `cloud-steward-login.ts` mirrors `launchStewardLogin`'s exact short-circuit rules (opaque tokens usable, 10s expiry margin). The launcher registration API is untouched for whoever mounts it later.

**Tests:** `useCloudState.steward-stale-login.test.tsx` — (a) first click reaches the device-code flow, surfaces that flow's outcome (never the "not mounted" throw), and drains the stale token; (b) a still-valid token keeps the Steward short-circuit (no device-code call); (c) a mounted launcher still owns stale-token re-auth (no device-code call). Plus `hasUsableStoredStewardToken` rule coverage added to `cloud-steward-login.test.ts` (its locked "throws when no launcher" contract unchanged and still green), and the existing `useCloudState.steward-refresh.test.tsx` (#10231) still green.
**Mutation check:** restoring the old branch condition reds the first-click test (`deviceCodeCalls 0 ≠ 1`); fix restored, green again.

## Blocker 2 — misleading "Claude Subscription" in Settings → AI Model

**Routing verified (unchanged, by design):** `applySubscriptionProviderConfig` (`packages/agent/src/api/provider-switch-config.ts:617-645`) records the selection as `agents.defaults.subscriptionProvider` for the task-agent orchestrator and sets a runtime `model.primary` **only** for `openai-codex` — Anthropic subscription tokens are TOS-restricted to Claude Code CLI, so selecting "Claude Subscription" never moves main chat inference.

**Before:** the panel already carried honest copy (warn banner "Powers task agents only (Claude Code CLI)…", group heading "Code orchestrator & workflows"), but the `ActiveProviderSummary` row at the top of the **Intelligence** group — whose stated job is "what's powering me right now" — showed `Claude Subscription · Active`, contradicting the banner and implying chat had switched to Claude.

**After (copy only, no behavior change):** coding-plan subscription entries (Claude, Gemini/z.ai/Kimi/DeepSeek plans) show **"Active for coding agents"** with the clarifier *"Powers coding agents & workflows only — chat replies keep using the Intelligence provider above."* The Codex plan (which really can drive runtime inference) and Cloud/local entries keep the plain "Active". The gate mirrors the `runtimeApplicable` rule in `provider-switch-config.ts` and is commented as such.

**Tests:** `ProviderSwitcher.active-summary.test.tsx` — qualified copy for a coding-plan entry, plain "Active" for Codex and for Cloud/local. `ActiveProviderSummary` exported `@internal` for testing (existing repo pattern).
**Mutation check:** forcing the gate to `false` reds the Claude-entry test; fix restored, green again.

**Open question (product, not shipped here):** whether a coding subscription should appear in the Intelligence summary at all, and whether selecting one should ever re-route chat — left for nubs; this PR only makes the UI state the truth of the current routing.

## Evidence

| Item | Result |
|---|---|
| Unit/renderHook tests | 6 files / 75 tests PASS (`bunx vitest run` in packages/ui) |
| Mutation checks | both fixes: revert → test reds → restore → green |
| Typecheck (`tsgo --noEmit`) | clean except pre-existing unrelated `iwer` TS2307 in `src/spatial/__e2e__/immersive-fixture.ts` (worktree install state; file untouched) |
| Lint | `biome check --write` clean on all 6 touched files |
| Full-page before/after screenshots + video | N/A — hands-on demo in 2 days; fix 1 is a login-flow branch fix locked by renderHook regression tests, fix 2 is settings copy locked by component tests; live walkthrough happens in the demo verification pass |
| Live-LLM trajectory | N/A — no agent/action/prompt/model behavior changed (UI login flow + settings copy only) |

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (find + fix + tests + mutation-checks + push, single pass; transcript verified 100% claude-fable-5, zero taint). Independently re-verified by the main loop: 6-file merge-base diff, 16/16 tests pass fresh across all 3 files, and the sign-in fix's mutation reproduced (revert branch -> first-click test reds; restore -> green). Both fixes are copy/branch-logic only -- NO inference-routing, money, or cloud-Worker changes. Surfaced by the app-flow demo-readiness audit (#11157). -- [phone-ui]