### PR TITLE
fix(core): extractFirstSentence abbreviation check when preceded by punctuation

### DIFF
--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -21,6 +21,33 @@ describe("extractFirstSentence", () => {
 		expect(r.rest).toBe("He waved.");
 	});
 
+	it("does not split at abbreviations preceded by quotes/parens/asterisks", () => {
+		// Regression from the [\w.]+ tightening: `(?:^|\s)` required start-of-string
+		// or whitespace immediately before the token, so '"Dr' / '(Mr' / '*Dr'
+		// never matched the abbreviation list and the first-sentence / TTS
+		// early-emit path chopped mid-name ('He cited "Dr.'). The old \b regex
+		// handled these.
+		const quoted = extractFirstSentence(
+			'He cited "Dr. Smith" as the source. Next sentence.',
+		);
+		expect(quoted.first).toBe('He cited "Dr. Smith" as the source.');
+		expect(quoted.rest).toBe("Next sentence.");
+
+		const paren = extractFirstSentence("(Mr. Jones agreed. Everyone left.)");
+		expect(paren.first).toBe("(Mr. Jones agreed.");
+		expect(paren.rest).toBe("Everyone left.)");
+
+		const emphasized = extractFirstSentence("*Dr. Smith* arrived. He waved.");
+		expect(emphasized.first).toBe("*Dr. Smith* arrived.");
+		expect(emphasized.rest).toBe("He waved.");
+
+		const quotedDotted = extractFirstSentence(
+			'He said "etc." and moved on. Fine.',
+		);
+		expect(quotedDotted.first).toBe('He said "etc." and moved on.');
+		expect(quotedDotted.rest).toBe("Fine.");
+	});
+
 	it("splits normal sentences at the first real boundary", () => {
 		const r = extractFirstSentence("Hello world. Next one.");
 		expect(r.first).toBe("Hello world.");

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -45,7 +45,12 @@ export function extractFirstSentence(text: string): {
 				// "e.g" — the "e.g"/"i.e" list entries were dead and those got split
 				// mid-token (the first-sentence / TTS early-emit path chopped "e.g."
 				// into "e."). Strip a trailing dot before comparing to the list.
-				const lastWordMatch = preText.match(/(?:^|\s)([\w.]+)$/);
+				// No prefix anchor: leftmost matching captures the maximal trailing
+				// [\w.] run, and any other char (space, quote, paren, asterisk, dash)
+				// or start-of-string delimits it — a (?:^|\s) anchor rejected
+				// punctuation-preceded abbreviations ('"Dr' / '(Mr') that the
+				// original \b handled, chopping mid-name.
+				const lastWordMatch = preText.match(/([\w.]+)$/);
 
 				let isAbbreviation = false;
 				if (lastWordMatch) {


### PR DESCRIPTION
## Problem

ebd520367d (#11573) fixed `extractFirstSentence`'s dead `e.g`/`i.e` abbreviation entries by matching `[\w.]+` instead of `\w+`, but anchored the preceding-word match with `(?:^|\s)` — requiring start-of-string or whitespace immediately before the token. The original `\b(\w+)$` treated any non-word char as a boundary, so abbreviations preceded by punctuation now fail the abbreviation check and the sentence boundary fires at the abbreviation's period:

```
extractFirstSentence('He cited "Dr. Smith" as the source. Next sentence.')
→ first: 'He cited "Dr.'          // chopped mid-name
extractFirstSentence('(Mr. Jones agreed. Everyone left.)')
→ first: '(Mr.'
```

Consumer impact: the cloud-TTS first-sentence early-emit path (`services/message.ts`, `hasFirstSentence`/`extractFirstSentence` on the raw stream) speaks the truncated fragment as the first sentence — the only guard is `first.length > 5`, which `'He cited "Dr.'` passes — and streaming split decisions land at the wrong point.

## Fix

Drop the prefix anchor: `preText.match(/([\w.]+)$/)`. Leftmost-match semantics already capture the maximal trailing `[\w.]` run, and any other character (space, quote, paren, asterisk, dash, bracket) or start-of-string delimits it — restoring the original `\b` boundary behavior for punctuation-preceded abbreviations while keeping #11573's dotted-abbreviation fix (an enumerated char class like `[\s("'\[*_—-]` would just move the hole).

## Evidence

Failing test first (on develop head 16b69a6edf):

```
FAIL src/utils/text-splitting.test.ts > does not split at abbreviations preceded by quotes/parens/asterisks
Expected: "He cited "Dr. Smith" as the source."
Received: "He cited "Dr."
```

Post-fix, real output:

```
'He cited "Dr. Smith" as the source. Next sentence.' → first='He cited "Dr. Smith" as the source.' rest='Next sentence.'
'(Mr. Jones agreed. Everyone left.)'                 → first='(Mr. Jones agreed.' rest='Everyone left.)'
'He said "etc." and moved on. Fine.'                 → first='He said "etc." and moved on.' rest='Fine.'
'*Dr. Smith* arrived. He waved.'                     → first='*Dr. Smith* arrived.' rest='He waved.'
'See e.g. the docs. Then continue.'                  → first='See e.g. the docs.' (no regression of #11573)
'Use the flag, i.e. the toggle. Done.'               → first='Use the flag, i.e. the toggle.' (no regression)
'Hello world. Next one.'                             → first='Hello world.' rest='Next one.'
```

- `vitest run src/utils/text-splitting.test.ts`: 5/5 pass (new punctuation-preceded regression test + the #11573 dotted-abbreviation tests kept green)
- `vitest run src/utils/`: 23 files, 144/144 pass
- `bun run --cwd packages/core typecheck`: clean

N/A - screenshots/video/trajectories: pure-function text utility; behavior fully evidenced by executed before/after output above.
