### PR TITLE
fix(cloud): attribute affiliate on charged monetized-app + pooled-key calls (#11814)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -201,6 +201,7 @@ function callStreaming(
       label: string;
     } | null;
     signal?: AbortSignal;
+    useMonetizedAppBilling?: boolean;
   } = {},
 ) {
   return handleStreamingRequest(
@@ -224,6 +225,7 @@ function callStreaming(
     {} as never,
     "gateway" as never,
     options.pooledCredential ?? null,
+    options.useMonetizedAppBilling ?? false,
   );
 }
 
@@ -552,6 +554,63 @@ describe("streaming chat — success settles once, no double-refund", () => {
       credentialId: "pooled-credential-1",
       userId: USER,
     });
+  });
+
+  test("charged monetized-app + pooled call still attributes the affiliate (#11814)", async () => {
+    const settle = mock(async () => null);
+    let onFinishPromise: Promise<unknown> | undefined;
+
+    streamTextImpl = (config) => {
+      const onFinish = config.onFinish as
+        | ((event: {
+            text: string;
+            usage: {
+              inputTokens: number;
+              outputTokens: number;
+              totalTokens: number;
+            };
+          }) => Promise<unknown> | unknown)
+        | undefined;
+
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-delta", id: "text-1", text: "pooled ok" };
+          onFinishPromise = Promise.resolve(
+            onFinish?.({
+              text: "pooled ok",
+              usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            }),
+          );
+          yield { type: "finish", finishReason: "stop" };
+        })(),
+      };
+    };
+
+    const res = await callStreaming(settle, {
+      affiliateCode: "SHOULD_PAY",
+      // Monetized-app request reserves REAL app credits, so it is NOT zero-rated
+      // even with a pooled key — the affiliate must still be attributed. Only a
+      // zero-rated pooled call (pooledCredential && !useMonetizedAppBilling)
+      // suppresses the affiliate (#11814).
+      useMonetizedAppBilling: true,
+      pooledCredential: {
+        organizationId: ORG,
+        credentialId: "pooled-credential-1",
+        providerId: "openai-api",
+        apiKey: "sk-pooled",
+        label: "Team OpenAI key",
+      },
+    });
+    const body = await res.text();
+    expect(onFinishPromise).toBeDefined();
+    await onFinishPromise;
+
+    expect(body).toContain("pooled ok");
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(
+      (billUsage.mock.calls[0][0] as { affiliateCode?: string | null })
+        .affiliateCode,
+    ).toBe("SHOULD_PAY");
   });
 
   test("settler reconciles to actual cost exactly once; a stray onError cannot re-refund", async () => {

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1419,6 +1419,7 @@ export async function handleChatCompletionsPOST(
           webSearchOptions,
           billingSource,
           pooledCredential,
+          useMonetizedAppBilling,
         )
       : await handleNonStreamingRequest(
           model,
@@ -1440,6 +1441,7 @@ export async function handleChatCompletionsPOST(
           webSearchOptions,
           billingSource,
           pooledCredential,
+          useMonetizedAppBilling,
           options.executionCtx,
         );
     // Emit per-step pre-forward timing as a readable header (#9899). Debug-only
@@ -1698,13 +1700,15 @@ async function handleStreamingRequest(
   webSearchOptions: ReturnType<typeof buildProviderNativeWebSearchTools>,
   billingSource: PricingBillingSource,
   pooledCredential: PooledInferenceCredential | null,
+  useMonetizedAppBilling: boolean,
 ) {
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
   const billingPrompt = buildChatPromptForBilling(request);
-  const billingAffiliateCode = pooledCredential ? null : affiliateCode;
+  const billingAffiliateCode =
+    pooledCredential && !useMonetizedAppBilling ? null : affiliateCode;
   let deliveredText = "";
   let streamingSettlementPromise: Promise<CreditReconciliationResult | null> | null =
     null;
@@ -2137,13 +2141,15 @@ async function handleNonStreamingRequest(
   webSearchOptions: ReturnType<typeof buildProviderNativeWebSearchTools>,
   billingSource: PricingBillingSource,
   pooledCredential: PooledInferenceCredential | null,
+  useMonetizedAppBilling: boolean,
   executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined,
 ) {
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
   const toolChoice = mapToolChoice(request.tool_choice);
   const experimentalOutput = mapResponseFormat(request.response_format);
-  const billingAffiliateCode = pooledCredential ? null : affiliateCode;
+  const billingAffiliateCode =
+    pooledCredential && !useMonetizedAppBilling ? null : affiliateCode;
 
   const safeParamsNonStream = getSafeModelParams(model, {
     temperature: request.temperature,


### PR DESCRIPTION
Closes #11814 (follow-up to #11626). `[cloud-money]`

**Bug (LOW, under-credit):** `billingAffiliateCode = pooledCredential ? null : affiliateCode` (chat/completions :1707 streaming, :2146 non-stream) nulls the affiliate whenever a pooled key exists — broader than zero-rating (`shouldUsePooledNoopReservation = pooledCredential && !useMonetizedAppBilling`). A **charged** monetized-app call where the org holds a pooled key bills the user real app credits yet drops the affiliate attribution/markup; the non-pooled path credits it. Opposite direction to a mint (why the mint-focused pre-merge + my post-merge review both missed it — I corrected my #11626 "clean" verdict).

**Fix:** thread `useMonetizedAppBilling` into both handlers; gate the affiliate-null on `pooledCredential && !useMonetizedAppBilling`.

**Proof:** new regression test — **12/0 green** with the fix; **red without** it (`affiliateCode` null vs `SHOULD_PAY`). typecheck + biome clean.

@lalalune — your #11626 design; PR'd (not self-merged) per the offer. Money path.