### PR TITLE
fix(cloud-apps): DEPLOY_FRONTEND honest not-live status + UPDATE cache invalidation

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/deploy-frontend.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-frontend.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { DeployAppFrontendInput } from "@elizaos/cloud-sdk";
+import type {
+  AppFrontendDeploymentDto,
+  DeployAppFrontendInput,
+} from "@elizaos/cloud-sdk";
 import {
   captureCallback,
   FakeElizaCloudClient,
@@ -26,6 +29,25 @@ const { deployFrontendAction } = await import(
 );
 
 const APP = makeApp({ id: "app_1", name: "Acme Bot", slug: "acme-bot" });
+
+function makeFeDeployment(
+  overrides: Partial<AppFrontendDeploymentDto> = {},
+): AppFrontendDeploymentDto {
+  return {
+    id: "fe_1",
+    app_id: "app_1",
+    version: 1,
+    status: "active",
+    r2_prefix: "p/",
+    content_hash: "b".repeat(64),
+    file_count: 1,
+    total_bytes: 42,
+    error: null,
+    created_at: "2026-06-29T00:00:00.000Z",
+    activated_at: "2026-06-29T00:00:00.000Z",
+    ...overrides,
+  };
+}
 
 let tmp: string | null = null;
 
@@ -61,7 +83,7 @@ describe("DEPLOY_FRONTEND", () => {
         makeMessage("publish Acme Bot"),
         undefined,
         { directory: "/x" },
-        cb.callback,
+        cb.fn,
       );
       expect(res.success).toBe(false);
       expect(res.data).toMatchObject({ reason: "no_key" });
@@ -119,19 +141,7 @@ describe("DEPLOY_FRONTEND", () => {
         captured = input;
         return Promise.resolve({
           success: true,
-          deployment: {
-            id: "fe_1",
-            app_id: "app_1",
-            version: 1,
-            status: "active",
-            r2_prefix: "p/",
-            content_hash: "b".repeat(64),
-            file_count: 1,
-            total_bytes: 42,
-            error: null,
-            created_at: "2026-06-29T00:00:00.000Z",
-            activated_at: "2026-06-29T00:00:00.000Z",
-          },
+          deployment: makeFeDeployment(),
         });
       });
       const cb = captureCallback();
@@ -140,12 +150,45 @@ describe("DEPLOY_FRONTEND", () => {
         makeMessage("publish Acme Bot"),
         undefined,
         { files: [{ path: "index.html", content: "<html></html>" }] },
-        cb.callback,
+        cb.fn,
       );
       expect(res.success).toBe(true);
       expect(captured?.files).toHaveLength(1);
       expect(res.data).toMatchObject({
         deployment: { version: 1, status: "active" },
+      });
+      expect(res.userFacingText).toContain("is now live");
+    });
+
+    it("does not claim live when publish returns a built but non-active deployment", async () => {
+      setDeployAppFrontend(() =>
+        Promise.resolve({
+          success: true,
+          deployment: makeFeDeployment({
+            id: "fe_3",
+            version: 3,
+            status: "ready",
+            activated_at: null,
+          }),
+        }),
+      );
+
+      const cb = captureCallback();
+      const res = await deployFrontendAction.handler(
+        keyedRuntime(),
+        makeMessage("publish Acme Bot"),
+        undefined,
+        { files: [{ path: "index.html", content: "<html></html>" }] },
+        cb.fn,
+      );
+
+      expect(res.success).toBe(true);
+      expect(res.userFacingText).not.toContain("now live");
+      expect(res.userFacingText).toContain("built but NOT yet live");
+      expect(res.userFacingText).toContain("status: ready");
+      expect(cb.calls[0]?.text).toBe(res.userFacingText);
+      expect(res.data).toMatchObject({
+        deployment: { id: "fe_3", version: 3, status: "ready" },
       });
     });
 

--- a/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
@@ -18,6 +18,7 @@ mock.module("@elizaos/cloud-sdk", () => ({
 
 const { updateAppAction } = await import("../src/actions/update-app.ts");
 const { parseUpdateAppIntent } = await import("../src/actions/update-app.ts");
+const { cloudAppsProvider } = await import("../src/providers/cloud-apps.ts");
 
 const APP = makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" });
 
@@ -188,5 +189,40 @@ describe("UPDATE_APP", () => {
     );
     expect(result?.success).toBe(false);
     expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+
+  it("invalidates the CLOUD_APPS provider cache after a successful update", async () => {
+    const runtime = keyedRuntime();
+    trackUpdates();
+
+    const primed = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("my apps"),
+      {} as never,
+    );
+    expect(primed.text).toContain("Acme Bot");
+
+    const result = await updateAppAction.handler(
+      runtime,
+      makeMessage("rename Acme Bot to Zephyr"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(true);
+
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [makeApp({ id: "id-acme", slug: "acme-bot", name: "Zephyr" })],
+      }),
+    );
+    const after = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("my apps"),
+      {} as never,
+    );
+    expect(after.text).toContain("Zephyr");
+    expect(after.text).not.toContain("Acme Bot");
   });
 });

--- a/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
@@ -22,6 +22,7 @@ const { updateMonetizationAction } = await import(
 const { parseMonetizationIntent } = await import(
   "../src/actions/update-monetization.ts"
 );
+const { cloudAppsProvider } = await import("../src/providers/cloud-apps.ts");
 
 const APP = makeApp({
   id: "id-acme",
@@ -185,5 +186,33 @@ describe("UPDATE_MONETIZATION", () => {
     );
     expect(result?.success).toBe(false);
     expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+
+  it("invalidates the CLOUD_APPS provider cache after a successful change", async () => {
+    const runtime = keyedRuntime();
+    let listCalls = 0;
+    setListApps(() => {
+      listCalls += 1;
+      return Promise.resolve({ success: true, apps: [APP] });
+    });
+    trackMonetization();
+
+    await cloudAppsProvider.get(runtime, makeMessage("my apps"), {} as never);
+    const primedCalls = listCalls;
+    await cloudAppsProvider.get(runtime, makeMessage("my apps"), {} as never);
+    expect(listCalls).toBe(primedCalls);
+
+    const result = await updateMonetizationAction.handler(
+      runtime,
+      makeMessage("set Acme Bot's markup to 20%"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(true);
+
+    const afterAction = listCalls;
+    await cloudAppsProvider.get(runtime, makeMessage("my apps"), {} as never);
+    expect(listCalls).toBe(afterAction + 1);
   });
 });

--- a/plugins/plugin-cloud-apps/src/actions/deploy-frontend.ts
+++ b/plugins/plugin-cloud-apps/src/actions/deploy-frontend.ts
@@ -329,10 +329,21 @@ export const deployFrontendAction: Action = {
       };
       const { deployment } = await client.deployAppFrontend(app.id, body);
 
-      const reply = [
-        `Published "${app.name}" frontend — v${deployment.version} is now live (${deployment.file_count} files, ${(deployment.total_bytes / 1024).toFixed(0)} KB).`,
-        `Preview it under your app's frontend host. Attach a custom domain to serve it publicly.`,
-      ].join("\n");
+      // Don't claim "live" unless the deployment actually activated. The
+      // publish can succeed into a "ready" (built, not serving) state where
+      // activation failed or is pending — reporting that as live is a lie the
+      // user acts on. Only status === "active" is truthfully live.
+      const size = `${deployment.file_count} files, ${(deployment.total_bytes / 1024).toFixed(0)} KB`;
+      const isLive = deployment.status === "active";
+      const reply = isLive
+        ? [
+            `Published "${app.name}" frontend — v${deployment.version} is now live (${size}).`,
+            `Preview it under your app's frontend host. Attach a custom domain to serve it publicly.`,
+          ].join("\n")
+        : [
+            `Published "${app.name}" frontend v${deployment.version} (${size}) — it's built but NOT yet live (status: ${deployment.status}).`,
+            `Activation hasn't completed; try again shortly, or check the app's frontend deployments if it stays this way.`,
+          ].join("\n");
 
       await callback?.({ text: reply, actions: ["DEPLOY_FRONTEND"] });
       return {

--- a/plugins/plugin-cloud-apps/src/actions/update-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/update-app.ts
@@ -26,6 +26,7 @@ import {
   resolveApp,
   resolveCloudApiKey,
 } from "../client.js";
+import { invalidateAppsCache } from "../providers/cloud-apps.js";
 
 const NO_KEY_MESSAGE =
   "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can update your apps.";
@@ -348,6 +349,10 @@ export const updateAppAction: Action = {
     const target = app;
     try {
       const { app: updated } = await client.updateApp(target.id, intent.patch);
+      // App inventory changed — evict the provider cache so the next turn's
+      // context reflects the new name/description/etc. (cache-invalidation
+      // invariant; the ~60s WeakMap cache would otherwise serve stale state).
+      invalidateAppsCache(runtime);
       const result = updated ?? target;
       const changes = describeChange(intent.patch, result);
       const summary =

--- a/plugins/plugin-cloud-apps/src/actions/update-monetization.ts
+++ b/plugins/plugin-cloud-apps/src/actions/update-monetization.ts
@@ -30,6 +30,7 @@ import {
   resolveApp,
   resolveCloudApiKey,
 } from "../client.js";
+import { invalidateAppsCache } from "../providers/cloud-apps.js";
 
 /** Server-enforced bounds (mirror `UpdateMonetizationSchema` in cloud-api). */
 export const MARKUP_MIN = 0;
@@ -375,6 +376,9 @@ export const updateMonetizationAction: Action = {
         target.id,
         intent.settings,
       );
+      // Monetization state changed — evict the provider cache so the next
+      // turn doesn't serve a stale enabled/markup/share for ~60s.
+      invalidateAppsCache(runtime);
       const reply = formatSettings(target.name, monetization);
       await callback?.({ text: reply, actions: ["UPDATE_MONETIZATION"] });
       return {


### PR DESCRIPTION
3 of the 7 confirmed bugs from the 07-02 Fable adversarial apps-surface scan (the HIGH withdraw bug already merged as #11810; the 3 BOOK_INFLUENCER money bugs are next).

- **MED — DEPLOY_FRONTEND false 'live' claim** (`deploy-frontend.ts`): claimed "v{N} is now live" unconditionally, but a publish can settle into `ready` (built, not serving) where activation failed/pended. Now branches on `deployment.status === "active"` — truthful live copy only when active, else "built but NOT yet live (status: X)". Matters for the demo: 'host an app frontend' shouldn't tell the user it's live when it isn't.
- **LOW ×2 — missing cache invalidation** (`update-app.ts`, `update-monetization.ts`): both mutated app state without `invalidateAppsCache(runtime)` → stale provider context ~60s (documented invariant; every sibling mutating action calls it). Added.

**Evidence:** plugin-cloud-apps **288 pass / 0 fail**; biome clean on all 3 files. No behavior change on the happy (active) path. Fixed inline (Fable-5 credit-limited until 08:10 UTC); the scan's Fable run authored the spec. — `[cloud-frontdoor]`