### PR TITLE
fix(core): stop transcript guard from rewriting replies that quote a transcript

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -150,6 +150,67 @@ emotion: none`;
 	});
 });
 
+describe("reply that QUOTES a field transcript — diagnosis workflow (follow-up to #11712)", () => {
+	// Live regression: a user pastes a leaked `shouldRespond:/replyText:`
+	// transcript into discord and asks the bot to diagnose it (this repo's own
+	// daily workflow). Stage 1 answers correctly in the canonical JSON envelope;
+	// the replyText is diagnostic prose that QUOTES the transcript. The
+	// send-boundary guard used to fire on the quoted `replyText:` line and
+	// silently replace the whole diagnosis with only the text after the QUOTED
+	// marker — the actual answer was destroyed with just a logger.warn.
+	const DIAGNOSIS = `the bug is in your parser — when the model emits:
+
+shouldRespond: RESPOND
+
+replyText: it works
+
+the blank line inside the value is where naive blank-line segmentation breaks. terminate values only at the next known-field line.`;
+
+	it("routes the canonical JSON envelope to final_reply and the guard leaves the quoting diagnosis intact", () => {
+		const envelope = JSON.stringify({
+			shouldRespond: "RESPOND",
+			replyText: DIAGNOSIS,
+			contexts: ["simple"],
+		});
+		const parsed = parseMessageHandlerOutput(envelope);
+		expect(parsed).not.toBeNull();
+		if (parsed === null) throw new Error("expected a parsed envelope");
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("final_reply");
+		if (route.type !== "final_reply") throw new Error("expected final_reply");
+		expect(route.reply).toBe(DIAGNOSIS);
+		// The exact send-boundary predicate: false ⇒ the reply ships as-is
+		// instead of being rewritten to extractReplyTextFromTranscript output.
+		expect(looksLikeRawFieldTranscript(route.reply)).toBe(false);
+		// And the rewrite the old guard performed would have destroyed the answer:
+		expect(extractReplyTextFromTranscript(DIAGNOSIS)).not.toContain(
+			"the bug is in your parser",
+		);
+	});
+
+	it("does not claim bare quoting prose on the text-mode path (preamble survives)", () => {
+		// Same diagnosis arriving as PLAIN TEXT (no JSON envelope): the transcript
+		// parser must NOT claim it — claiming discards every preamble line and
+		// ships only the quote's tail ("it works…"). Null falls through to the
+		// tolerant plain-text reply synthesizer, which now also declines to treat
+		// quoting prose as a raw transcript, so the full diagnosis ships.
+		expect(parseMessageHandlerOutput(DIAGNOSIS)).toBeNull();
+		expect(looksLikeRawFieldTranscript(DIAGNOSIS)).toBe(false);
+	});
+
+	it("still blocks and recovers the GENUINE leak at the send boundary (fail-closed preserved)", () => {
+		const leak = `shouldRespond: RESPOND
+
+replyText: it's live https://example.test/apps/aurora/
+
+contexts: simple`;
+		expect(looksLikeRawFieldTranscript(leak)).toBe(true);
+		expect(extractReplyTextFromTranscript(leak)).toBe(
+			"it's live https://example.test/apps/aurora/",
+		);
+	});
+});
+
 describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () => {
 	// Live regression: the Stage-1 model sometimes answers in plain prose instead
 	// of the structured field envelope. That path (synthesizeSimpleReplyFromPlainText)

--- a/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
+++ b/packages/core/src/runtime/__tests__/response-field-transcript.test.ts
@@ -107,10 +107,15 @@ describe("response field transcript — looksLikeRawFieldTranscript (send-bounda
 		expect(looksLikeRawFieldTranscript("shouldRespond: IGNORE")).toBe(true);
 	});
 
-	it("flags text containing a replyText: line", () => {
-		expect(looksLikeRawFieldTranscript("some preamble\nreplyText: hello")).toBe(
-			true,
-		);
+	it("flags text that leads with replyText: (reply-bearing echo without routing field)", () => {
+		expect(looksLikeRawFieldTranscript("replyText: hello")).toBe(true);
+		expect(looksLikeRawFieldTranscript("\n\n  replyText: hello")).toBe(true);
+	});
+
+	it("flags an echo that leads with a secondary field before the hallmark", () => {
+		expect(
+			looksLikeRawFieldTranscript("contexts: simple\nreplyText: hello"),
+		).toBe(true);
 	});
 
 	it("does NOT flag normal replies without field markers", () => {
@@ -124,6 +129,101 @@ describe("response field transcript — looksLikeRawFieldTranscript (send-bounda
 		).toBe(false);
 		expect(looksLikeRawFieldTranscript("")).toBe(false);
 		expect(looksLikeRawFieldTranscript(null)).toBe(false);
+	});
+});
+
+// A reply that QUOTES a transcript is content, not a leak. This repo's own
+// daily workflow: a user pastes a leaked `shouldRespond:/replyText:` transcript
+// into chat and asks the bot to diagnose it. The diagnosis legitimately carries
+// quoted field lines; the guard must not rewrite it (previously the send
+// boundary replaced the whole diagnosis with the QUOTED replyText value,
+// silently dropping the actual answer).
+const QUOTING_DIAGNOSIS = `the bug is in your parser — when the model emits:
+
+shouldRespond: RESPOND
+
+replyText: it works
+
+the blank line inside the value is where naive blank-line segmentation breaks. terminate values only at the next known-field line.`;
+
+const FENCED_QUOTING_DIAGNOSIS = `here's the transcript that leaked:
+
+\`\`\`
+shouldRespond: RESPOND
+
+replyText: it works
+\`\`\`
+
+that skeleton is the raw HANDLE_RESPONSE envelope — your text-mode provider echoed the field set instead of JSON.`;
+
+describe("response field transcript — replies that QUOTE a transcript are not leaks", () => {
+	it("does NOT flag a diagnosis that opens with prose and quotes field lines", () => {
+		expect(looksLikeRawFieldTranscript(QUOTING_DIAGNOSIS)).toBe(false);
+	});
+
+	it("does NOT flag a reply whose quoted transcript sits inside a code fence", () => {
+		expect(looksLikeRawFieldTranscript(FENCED_QUOTING_DIAGNOSIS)).toBe(false);
+	});
+
+	it("does NOT flag a reply that LEADS with a fenced transcript quote", () => {
+		expect(
+			looksLikeRawFieldTranscript(
+				"```\nshouldRespond: RESPOND\nreplyText: hi\n```\nthat's the leak — fence it off in your parser.",
+			),
+		).toBe(false);
+	});
+
+	it("still flags the genuine leak even when its replyText mentions a fence", () => {
+		expect(
+			looksLikeRawFieldTranscript(
+				"shouldRespond: RESPOND\n\nreplyText: wrap it in ``` fences",
+			),
+		).toBe(true);
+	});
+
+	it("parseMessageHandlerOutput does NOT claim quoting prose (falls through with preamble intact)", () => {
+		// Claiming it would drop every line before the quoted `replyText:` and
+		// ship only the quote's tail ("it works\n\nthe blank line…").
+		expect(parseMessageHandlerOutput(QUOTING_DIAGNOSIS)).toBeNull();
+		expect(parseMessageHandlerOutput(FENCED_QUOTING_DIAGNOSIS)).toBeNull();
+	});
+
+	it("extractReplyTextFromTranscript is never consulted for quoting prose at the send boundary (guard=false), preserving the diagnosis", () => {
+		// The send boundary only rewrites when looksLikeRawFieldTranscript is
+		// true; assert the exact guard predicate the boundary uses.
+		expect(looksLikeRawFieldTranscript(QUOTING_DIAGNOSIS)).toBe(false);
+		expect(looksLikeRawFieldTranscript(FENCED_QUOTING_DIAGNOSIS)).toBe(false);
+	});
+});
+
+describe("response field transcript — fenced field lines never split a value", () => {
+	it("keeps a fenced quoted transcript inside the replyText value of a REAL leak", () => {
+		// Text-mode echo whose replyText value itself quotes an envelope inside a
+		// code fence (the bot diagnosing a transcript, answered in text mode).
+		// The fenced `contexts:`/`replyText:` lines are content — the value must
+		// terminate only at the next UNFENCED known-field line (`emotion:`).
+		const t = `shouldRespond: RESPOND
+
+replyText: the parser bug is here:
+
+\`\`\`
+contexts: simple
+replyText: it works
+\`\`\`
+
+fields split only at unfenced field lines.
+
+emotion: none`;
+		const parsed = parseFieldTranscript(t);
+		expect(parsed?.fields.shouldRespond).toBe("RESPOND");
+		expect(parsed?.fields.replyText).toContain("the parser bug is here:");
+		expect(parsed?.fields.replyText).toContain("contexts: simple");
+		expect(parsed?.fields.replyText).toContain(
+			"fields split only at unfenced field lines.",
+		);
+		// The fenced `contexts:` line did NOT open a contexts field.
+		expect(parsed?.fields.contexts).toBeUndefined();
+		expect(parsed?.fields.emotion).toBe("none");
 	});
 });
 

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -8,6 +8,7 @@ import type { AgentContext } from "../types/contexts";
 import { normalizeTopics } from "./builtin-field-evaluators";
 import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
 import {
+	looksLikeRawFieldTranscript,
 	parseFieldTranscript,
 	splitTranscriptList,
 } from "./response-field-transcript";
@@ -103,12 +104,22 @@ export function parseMessageHandlerOutput(
 function parseMessageHandlerFieldTranscript(
 	raw: string,
 ): V5MessageHandlerOutput | null {
+	// Only claim text whose own skeleton IS the envelope: it must lead with a
+	// known field line (outside any code fence) and carry a hallmark field
+	// (`shouldRespond:` / `replyText:`) at the top level. Prose that merely
+	// QUOTES field lines — e.g. the model diagnosing a leaked transcript the
+	// user pasted — must fall through to the tolerant plain-text handler
+	// INTACT; claiming it here would drop every line before the quoted
+	// `replyText:` and ship only the quote's tail as the answer.
+	if (!looksLikeRawFieldTranscript(raw)) return null;
 	const transcript = parseFieldTranscript(raw);
 	if (!transcript) return null;
 	const { fields } = transcript;
 
-	// Require at least the routing field plus a reply-bearing field before we
-	// treat the text as a structured transcript. A lone stray `topics:` line in
+	// Require at least one hallmark field before treating the text as a
+	// structured transcript: the routing field (`shouldRespond:` may
+	// legitimately stand alone, e.g. an IGNORE echo with no reply) or the
+	// reply-bearing field (`replyText:`). A lone stray `topics:` line in
 	// otherwise-prose output should NOT be reinterpreted as an envelope.
 	const hasShouldRespond = typeof fields.shouldRespond === "string";
 	const hasReplyText = typeof fields.replyText === "string";

--- a/packages/core/src/runtime/response-field-transcript.ts
+++ b/packages/core/src/runtime/response-field-transcript.ts
@@ -73,22 +73,49 @@ const FIELD_LINE = new RegExp(
 );
 
 /**
+ * A fenced-code-block delimiter line (``` or ~~~, optionally indented). Field
+ * lines inside a fence are QUOTED content — e.g. a reply diagnosing a leaked
+ * transcript the user pasted — never envelope structure.
+ */
+const FENCE_LINE = /^\s{0,3}(?:`{3,}|~{3,})/;
+
+/**
  * Cheap skeleton detector for the fail-closed send-boundary guard. Returns true
- * when `text` looks like a raw field transcript that must NOT be shipped to a
- * user channel. Intentionally cheap: regex only, no full parse.
+ * when `text` IS a raw field transcript that must NOT be shipped to a user
+ * channel — as opposed to a composed reply that merely QUOTES one.
+ * Intentionally cheap: line scan + regex, no full parse.
  *
- * Matches when the text either:
- *  - starts (after optional leading whitespace) with `shouldRespond:`, or
- *  - contains a line beginning with `replyText:`.
- *
- * Both are hallmarks of the leaked HANDLE_RESPONSE transcript. Normal replies
- * never contain a line that starts with `replyText:` or lead with
- * `shouldRespond:`.
+ * Structural rule: a genuine text-mode envelope echo IS the message — its
+ * first substantive line (outside code fences) is a known field line, and a
+ * hallmark field (`shouldRespond:` / `replyText:`) appears at the top level.
+ * A reply that opens with prose (e.g. a diagnosis of a transcript the user
+ * pasted, which legitimately quotes `replyText:` lines) or whose field lines
+ * sit inside a code fence is CONTENT, not a leak — flagging it would make the
+ * send boundary silently replace the whole answer with the quoted replyText
+ * value, destroying the diagnosis.
  */
 export function looksLikeRawFieldTranscript(text: unknown): boolean {
 	if (typeof text !== "string" || text.length === 0) return false;
-	if (/^\s*shouldRespond\s*:/.test(text)) return true;
-	if (/(^|\n)\s*replyText\s*:/.test(text)) return true;
+	let inFence = false;
+	let leadsWithFieldLine = false;
+	for (const line of text.replace(/\r\n/g, "\n").split("\n")) {
+		if (FENCE_LINE.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence || line.trim().length === 0) continue;
+		const match = FIELD_LINE.exec(line);
+		if (!leadsWithFieldLine) {
+			// The first substantive unfenced line decides authorship: prose means
+			// the model composed a reply (which may quote a transcript); a known
+			// field line means the output is the envelope skeleton itself.
+			if (!match) return false;
+			leadsWithFieldLine = true;
+		}
+		if (match && (match[1] === "shouldRespond" || match[1] === "replyText")) {
+			return true;
+		}
+	}
 	return false;
 }
 
@@ -107,6 +134,11 @@ export interface ParsedFieldTranscript {
  * to (but not including) the next `^<knownField>:` line. Blank lines inside a
  * value are preserved (then trimmed at the value edges). This is what lets a
  * multi-line `replyText` with an embedded blank line survive intact.
+ *
+ * Fence rule: field lines inside a fenced code block (``` / ~~~) are QUOTED
+ * content, never boundaries — a replyText value that quotes an envelope inside
+ * a fence (the agent diagnosing a leaked transcript) keeps the whole fenced
+ * block instead of being split at the quoted `contexts:`/`replyText:` lines.
  *
  * Returns null when no known field line is found (the text is not a transcript
  * — let the caller fall through to its plain-text handling).
@@ -138,8 +170,15 @@ export function parseFieldTranscript(
 		buffer = [];
 	};
 
+	let inFence = false;
 	for (const line of lines) {
-		const match = FIELD_LINE.exec(line);
+		if (FENCE_LINE.test(line)) {
+			// Fence delimiters toggle quoted mode and belong to the current value.
+			inFence = !inFence;
+			if (currentField !== null) buffer.push(line);
+			continue;
+		}
+		const match = inFence ? null : FIELD_LINE.exec(line);
 		if (match && FIELD_NAME_SET.has(match[1])) {
 			// New field boundary — close the previous field first.
 			flush();
@@ -148,7 +187,8 @@ export function parseFieldTranscript(
 			const inline = match[2];
 			buffer = inline && inline.length > 0 ? [inline] : [];
 		} else if (currentField !== null) {
-			// Continuation line of the current field value (including blank lines).
+			// Continuation line of the current field value (including blank lines
+			// and any fenced quoted content).
 			buffer.push(line);
 		}
 		// Lines before the first field marker are preamble; ignore them.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6281,7 +6281,12 @@ export async function runV5MessageRuntimeStage1(args: {
 			// `shouldRespond:/replyText:/...` skeleton (a parse fell through
 			// somewhere upstream), extract the intended replyText value; if that
 			// can't be recovered, drop it and let the unusable-reply deferral below
-			// take over. Cheap: regex check only, no full parse on the common path.
+			// take over. Cheap: line scan only, no full parse on the common path.
+			// Replies that merely QUOTE a transcript — prose preamble before the
+			// first field line, or field lines inside a code fence (the agent
+			// diagnosing a transcript the user pasted) — are exempt: the detector
+			// fires only when the skeleton IS the reply, so a legitimate diagnosis
+			// is never rewritten down to its quoted replyText tail.
 			if (looksLikeRawFieldTranscript(reply)) {
 				const recovered = extractReplyTextFromTranscript(reply);
 				args.runtime.logger?.warn?.(


### PR DESCRIPTION
## Defect

Follow-up to 35e6a667bd (#11712). The fail-closed raw-transcript guard and the text-mode transcript parser silently rewrote **legitimate replies that QUOTE a `shouldRespond:/replyText:` transcript**, dropping the actual answer:

- **Send boundary** (`packages/core/src/services/message.ts` `final_reply` guard): `looksLikeRawFieldTranscript(reply)` matched `/(^|\n)\s*replyText\s*:/` **anywhere** in the reply — including quoted lines and lines inside code fences. A user pastes a leaked transcript into Discord and asks the bot to diagnose it (this repo's own daily workflow); Stage 1 answers correctly in the canonical JSON envelope with `replyText` = diagnostic prose that quotes the transcript. The guard fired on the quoted `replyText:` line and replaced the whole reply with `extractReplyTextFromTranscript()` output — only the text **after the QUOTED marker** — destroying the entire diagnosis with nothing but a `logger.warn`.
- **Text-mode path** (`packages/core/src/runtime/message-handler.ts` `parseMessageHandlerFieldTranscript`): claimed any non-JSON prose containing a `replyText:` line and discarded every preamble line ("lines before the first field marker are preamble; ignore them") — same silent content loss for plain-prose answers that quote a transcript.
- The comment above the claim check said "routing field **plus** reply-bearing field" but the code was OR (`!hasShouldRespond && !hasReplyText`).

## Fix (structural, not contains-check)

A genuine text-mode envelope echo **IS** the message — its first substantive line (outside code fences) is a known field line, with a `shouldRespond:`/`replyText:` hallmark at top level. A reply that opens with prose, or whose field lines sit inside a code fence, **QUOTES** a transcript and is content:

- `looksLikeRawFieldTranscript` is now a fence-aware line scan implementing that rule. Quoting replies ship intact at the send boundary and through the plain-text synthesizer; the genuine #11712 leak shape (leading skeleton) is still detected, blocked, and recovered.
- `parseFieldTranscript` treats field lines inside ``` / ~~~ fences as value content, so a real leak whose `replyText` value quotes an envelope in a fence is no longer split at the quoted lines.
- `parseMessageHandlerFieldTranscript` is gated on the same detector, so prose-with-preamble falls through to the tolerant plain-text handler with the full answer intact.
- Comment/code OR-vs-AND mismatch resolved in favor of documented-correct OR: a lone `shouldRespond: IGNORE` echo must remain claimable; the comment now says so explicitly.

Trade-off made explicit: a hypothetical leak prefixed by scaffold prose would now ship as visible (ugly but complete) text instead of being rewritten — visible skeleton beats silent destruction of a correct answer, and the observed #11712 leak shape (leading skeleton) remains fully fail-closed.

## Reproduction / evidence

Re-confirmed on develop tip `16b69a6edf` before the fix — 6 new tests failed exactly as the defect describes:

```
FAIL  looksLikeRawFieldTranscript(QUOTING_DIAGNOSIS)  → expected false, got true
FAIL  looksLikeRawFieldTranscript(FENCED_QUOTING_DIAGNOSIS) → expected false, got true
FAIL  parseMessageHandlerOutput(QUOTING_DIAGNOSIS)    → expected null, got claimed
      transcript whose plan.reply = "it works\n\nthe blank line…" (diagnosis preamble dropped)
FAIL  fenced field lines split the replyText value of a real leak
```

After the fix:

- `packages/core/src/runtime/__tests__/response-field-transcript.test.ts` — 22/22 (all 16 pre-existing #11712 regression tests untouched and green, + new quoting/fence coverage)
- `packages/core/src/__tests__/message-routing-live-regression.test.ts` — new end-to-end scenario: canonical JSON envelope quoting a transcript → `routeMessageHandlerOutput` → `final_reply` → guard predicate false → diagnosis ships verbatim; plus fail-closed regression for the genuine leak
- Affected suites (12 files: message-handler, json-output, response-handler field registry/evaluators, message service abort/stage1-retry/shortcut/voice gates): **222/222 green**
- Full `packages/core` suite: **2670 passed / 11 skipped**; the single failure (`link-extraction.test.ts`, live example.com fetch) reproduces on clean HEAD with this change stashed — pre-existing and unrelated
- `bun run --cwd packages/core typecheck` clean

N/A — UI/screenshots/video: runtime parser/guard change, no user-facing surface beyond message text integrity, fully covered by the routing-level tests above.
N/A — live-LLM trajectory: the defect is deterministic post-model-output plumbing; the failing-then-passing tests drive the exact routed path (`parseMessageHandlerOutput` → `routeMessageHandlerOutput` → send-boundary predicate) with the confirmed real-world payload shape.
