### PR TITLE
fix(cloud): gate MCP proxy invoke on owner-or-public (cross-org IDOR) (#11838)

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -106,6 +106,33 @@ test("unreachable upstream (502) refunds the upfront debit (#11637)", async () =
   expect(refundCredits).toHaveBeenCalledTimes(1);
 });
 
+test("non-owner org CANNOT invoke another org's PRIVATE MCP — 404, no billing (#11838)", async () => {
+  // user is org1 (beforeEach); the MCP is private and owned by org2.
+  getById.mockResolvedValue({
+    ...EXTERNAL_MCP,
+    is_public: false,
+    organization_id: "org2",
+  });
+  const res = await post();
+  expect(res.status).toBe(404);
+  expect(reserveAndDeductCredits).not.toHaveBeenCalled();
+  expect(safeFetch).not.toHaveBeenCalled();
+});
+
+test("non-owner org CAN invoke a PUBLIC MCP — monetization model preserved (#11838)", async () => {
+  getById.mockResolvedValue({
+    ...EXTERNAL_MCP,
+    is_public: true,
+    organization_id: "org2",
+  });
+  safeFetch.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  );
+  const res = await post();
+  expect(res.status).toBe(200);
+  expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
+});
+
 test("unsafe/blocked external endpoint (400) refunds (#11637)", async () => {
   assertSafeOutboundUrl.mockRejectedValue(new Error("SSRF blocked"));
   const res = await post();

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -161,6 +161,20 @@ app.post("/", async (c) => {
     return c.json({ error: "MCP is not available" }, 404);
   }
 
+  // Owner-or-public gate (mirrors the GET handler): getById is unscoped and the
+  // catalog hides private MCPs, so without this a non-owner org could INVOKE
+  // another org's private live MCP — hitting the owner's backend/credentials
+  // while the caller is billed (cross-tenant IDOR, #11838). Public MCPs stay
+  // invokable by anyone (the monetization model); private MCPs are owner-only.
+  const { allowed } = resolveMcpProxyView({
+    mcpOrganizationId: mcp.organization_id,
+    mcpIsPublic: mcp.is_public,
+    viewerOrganizationId: user.organization_id,
+  });
+  if (!allowed) {
+    return c.json({ error: "MCP not found" }, 404);
+  }
+
   const creditsRequired = Number(mcp.credits_per_request || "1");
   let affiliateOwnerId: string | undefined;
   let affiliateCodeId: string | undefined;


### PR DESCRIPTION
Closes #11838. `[cloud-money]` — cross-tenant IDOR found by a Fable-5 IDOR hunt (hand-verified inline; the workflow was Opus-tainted so I traced the route myself).

**Bug (MED):** GET `/api/mcp/proxy/[mcpId]` gates on `resolveMcpProxyView` (owner-or-public), but the **POST/invoke** handler fetched `getById(mcpId)` unscoped and checked only existence + `status`, so org B could invoke org A's **private** live MCP — hitting A's backend/credentials while B is billed.

**Fix:** apply the same `resolveMcpProxyView` gate in POST before billing. Public MCPs stay open (monetization model); private MCPs owner-only.

**Proof:** non-owner+private → **404, no billing** (red without the gate: request proceeds, 500); non-owner+public → **200, billed**. 10/0 green, typecheck + biome clean. Security path — do not self-merge.