### PR TITLE
fix(ui): Help settings deep-links land on the right section + agent split/tile keeps every view

### DIFF
--- a/packages/ui/src/components/pages/help/HelpView.test.tsx
+++ b/packages/ui/src/components/pages/help/HelpView.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Help's deep links must survive the tab switch. The settings-section links
+// ("Open AI Model settings" → the ai-model section) previously wrote the
+// section into `window.location.hash` and then called `setTab("settings")` —
+// but setTab pushes the bare `/settings` path, clearing the fragment BEFORE
+// SettingsView mounts and reads it, so the user always landed on the generic
+// Settings hub instead of the promised section. The fix routes the section
+// through the `eliza:navigate:view` `subview` channel (the same sanctioned path
+// the agent + slash-command flows use; App.tsx maps it to SettingsView's
+// `initialSection`). These tests pin that contract.
+
+const appMock = vi.hoisted(() => ({
+  value: {} as Record<string, unknown>,
+}));
+
+vi.mock("../../../state", () => ({
+  useAppSelector: (sel: (value: Record<string, unknown>) => unknown) =>
+    sel(appMock.value),
+}));
+
+vi.mock("../../../agent-surface", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+// Structural wrapper only — pass the body through without the agent surface.
+vi.mock("../../views/ShellViewAgentSurface", () => ({
+  ShellViewAgentSurface: ({ children }: { children?: React.ReactNode }) =>
+    children,
+}));
+
+vi.mock("../../composites/chat", () => ({
+  ChatEmptyStateWithRecommendations: () => null,
+}));
+
+const startTutorial = vi.hoisted(() => vi.fn());
+vi.mock("../tutorial/tutorial-controller", () => ({
+  startTutorial,
+}));
+
+import { HelpView } from "./HelpView";
+
+function openEntry(question: string): void {
+  fireEvent.click(screen.getByRole("button", { name: question }));
+}
+
+describe("HelpView deep links", () => {
+  let setTab: ReturnType<typeof vi.fn>;
+  let navigateEvents: CustomEvent[];
+  const captureNavigate = (event: Event) => {
+    navigateEvents.push(event as CustomEvent);
+  };
+
+  beforeEach(() => {
+    setTab = vi.fn();
+    appMock.value = { setTab };
+    navigateEvents = [];
+    window.addEventListener("eliza:navigate:view", captureNavigate);
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    window.removeEventListener("eliza:navigate:view", captureNavigate);
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("routes a settings-section link through the navigate-view subview channel", () => {
+    render(<HelpView />);
+    openEntry("How do I change the AI model?");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open AI Model settings/ }),
+    );
+
+    expect(navigateEvents).toHaveLength(1);
+    expect(navigateEvents[0].detail).toEqual({
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: "ai-model",
+    });
+    // The navigate-view handler owns the tab switch; Help must not race it
+    // with its own setTab (the old path's pushState cleared the section).
+    expect(setTab).not.toHaveBeenCalled();
+  });
+
+  it("does not smuggle the section through the URL fragment", () => {
+    render(<HelpView />);
+    openEntry("How do I change the AI model?");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Open AI Model settings/ }),
+    );
+
+    // The old implementation wrote `#ai-model` here; setTab's pushState then
+    // wiped it before SettingsView could read it. The section now travels in
+    // the event detail, so the fragment stays untouched.
+    expect(window.location.hash).toBe("");
+  });
+
+  it("keeps plain tab links on the direct setTab path", () => {
+    render(<HelpView />);
+    openEntry("How do I get to Settings?");
+    fireEvent.click(screen.getByRole("button", { name: /Open Settings/ }));
+
+    expect(setTab).toHaveBeenCalledWith("settings");
+    expect(navigateEvents).toHaveLength(0);
+  });
+
+  it("starts the tutorial and returns to chat for tour links", () => {
+    render(<HelpView />);
+    openEntry("What is Eliza?");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Take the 90-second tour/ }),
+    );
+
+    expect(startTutorial).toHaveBeenCalledTimes(1);
+    expect(setTab).toHaveBeenCalledWith("chat");
+  });
+});

--- a/packages/ui/src/components/pages/help/HelpView.tsx
+++ b/packages/ui/src/components/pages/help/HelpView.tsx
@@ -176,12 +176,24 @@ function HelpViewBody(): React.ReactElement {
         return;
       }
       if (link.settingsSection) {
-        try {
-          window.location.hash = link.settingsSection;
-        } catch {
-          /* ignore */
+        // Deep-link the target section through the `eliza:navigate:view`
+        // `subview` channel — the same path the agent + slash-command flows use
+        // (App.tsx routes it into SettingsView's `initialSection`). Setting
+        // `window.location.hash` before `setTab` never survived: setTab pushes
+        // the bare `/settings` path, which clears the fragment BEFORE
+        // SettingsView mounts and reads it — so the user landed on the generic
+        // Settings hub instead of the promised section.
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(
+            new CustomEvent("eliza:navigate:view", {
+              detail: {
+                viewId: "settings",
+                viewPath: "/settings",
+                subview: link.settingsSection,
+              },
+            }),
+          );
         }
-        setTab("settings");
         return;
       }
       if (link.tab) setTab(link.tab);

--- a/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
@@ -209,6 +209,74 @@ describe("agent view-switch raw WS frame to DOM navigate event", () => {
     teardown();
   });
 
+  it("forwards the split/tile layout fields so a multi-view action keeps every view", () => {
+    // Mirrors broadcastWs(...) for POST /api/views/:id/navigate with
+    // action:"tile-views" — the server spreads `layoutPayload`
+    // (views/layout/placement, views-routes.ts) into the frame. Dropping any
+    // of them here degrades an agent "tile A and B" to a single view.
+    clientMock.deliverFrame(
+      JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "browser",
+        viewPath: "/apps/browser",
+        viewLabel: "Browser",
+        viewType: "gui",
+        action: "tile-views",
+        views: ["browser", "wallet"],
+        layout: "horizontal",
+        placement: "left",
+      }),
+    );
+
+    expect(navHandler).toHaveBeenCalledTimes(1);
+    const detail = (navHandler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.action).toBe("tile-views");
+    expect(detail.views).toEqual(["browser", "wallet"]);
+    expect(detail.layout).toBe("horizontal");
+    expect(detail.placement).toBe("left");
+    teardown();
+  });
+
+  it("sanitizes untrusted layout fields (non-string views entries, wrong types)", () => {
+    clientMock.deliverFrame(
+      JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "browser",
+        viewPath: "/apps/browser",
+        viewType: "gui",
+        action: "split-view",
+        views: ["browser", 7, "", null, "wallet"],
+        layout: 42,
+        placement: ["top"],
+      }),
+    );
+
+    expect(navHandler).toHaveBeenCalledTimes(1);
+    const detail = (navHandler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.views).toEqual(["browser", "wallet"]);
+    expect(detail.layout).toBeUndefined();
+    expect(detail.placement).toBeUndefined();
+    teardown();
+  });
+
+  it("omits the layout fields on a plain single-view frame", () => {
+    clientMock.deliverFrame(
+      JSON.stringify({
+        type: "shell:navigate:view",
+        viewId: "settings",
+        viewPath: "/settings",
+        viewType: "gui",
+      }),
+    );
+
+    expect(navHandler).toHaveBeenCalledTimes(1);
+    const detail = (navHandler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.views).toBeUndefined();
+    expect(detail.layout).toBeUndefined();
+    expect(detail.placement).toBeUndefined();
+    teardown();
+  });
+
   it("routes an xr view frame through the same type dispatch", () => {
     clientMock.deliverFrame(
       JSON.stringify({

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -458,6 +458,27 @@ export function bindReadyPhase(
           ? data.subview
           : undefined;
       const alwaysOnTop = data.alwaysOnTop === true;
+      // Multi-view layout fields for the split-view / tile-views actions. The
+      // server broadcasts `views`/`layout`/`placement` (views-routes.ts
+      // layoutPayload); dropping them here made an agent "split A and B"
+      // degrade to a single view — createNavigateViewHandler saw only
+      // `viewId` and laid out one pane.
+      const layoutViews = Array.isArray(data.views)
+        ? data.views.filter(
+            (value): value is string =>
+              typeof value === "string" && value.length > 0,
+          )
+        : undefined;
+      const views =
+        layoutViews && layoutViews.length > 0 ? layoutViews : undefined;
+      const layout =
+        typeof data.layout === "string" && data.layout.length > 0
+          ? data.layout
+          : undefined;
+      const placement =
+        typeof data.placement === "string" && data.placement.length > 0
+          ? data.placement
+          : undefined;
       window.dispatchEvent(
         new CustomEvent("eliza:navigate:view", {
           detail: {
@@ -467,6 +488,9 @@ export function bindReadyPhase(
             viewType,
             action,
             subview,
+            views,
+            layout,
+            placement,
             alwaysOnTop,
           },
         }),


### PR DESCRIPTION
Two demo-blocking view/navigation bugs in @elizaos/ui, found by tracing the deep-link plumbing end to end, each fixed minimally and pinned by mutation-checked tests. Branch: `fix/ui-view-polish` off `origin/develop`.

## Bug 1 — Help's "Open … settings" deep-links dead-end on the generic Settings hub

**Before:** Open Help → expand "How do I change the AI model?" → tap **Open AI Model settings →** → you land on the generic Settings hub. The section is silently lost. Every Help entry with a `settingsSection` (ai-model ×6, runtime ×2) had the same dead-end.

**Root cause:** `HelpView.navigate` wrote the section into `window.location.hash`, then called `setTab("settings")`. `setTab` (`useNavigationState`) does `history.pushState(null, "", "/settings")` — a full URL replacement with no fragment — clearing the hash *before* `SettingsView` mounts and reads it (`readSettingsHashSection()` in its `useState` initializer). Hash-routing mode clobbered it identically (`#ai-model` → `#/settings`). App.tsx's navigate handler even documents that the generic path nav "would drop the requested section" — which is exactly what Help was doing.

**After:** the link dispatches `eliza:navigate:view` with `{ viewId: "settings", viewPath: "/settings", subview: "<section>" }` — the sanctioned channel the agent and slash-command flows already use; App.tsx maps it to `SettingsView`'s `initialSection`. Plain-tab links ("Open Settings", "Open Launcher") and the tutorial link are untouched.

**Tests** (`HelpView.test.tsx`, new, 4 passing): subview dispatch shape; URL fragment stays clean; plain-tab path still uses `setTab`; tutorial path still starts the tour + returns to chat. **Mutation check:** reverting the fix reds 2/4.

## Bug 2 — WS navigate bridge drops `views`/`layout`/`placement`: agent split/tile degrades to one view

**Before:** ask the agent to "tile the browser and wallet" → only one view opens. The server (`packages/agent/src/api/views-routes.ts`) broadcasts `views: string[]`, `layout`, `placement` in the `shell:navigate:view` frame for the documented `split-view` / `tile-views` actions, but the client bridge (`startup-phase-hydrate.ts`) forwarded only viewId/viewPath/viewLabel/viewType/action/subview/alwaysOnTop. `createNavigateViewHandler` then saw `detail.views === undefined` and laid out a single pane from `viewId` alone; the layout/placement hints were discarded.

**After:** the bridge forwards all three fields with the same untrusted-input sanitization the rest of the frame gets (string-array filter, non-empty-string gates).

**Tests** (`startup-phase-hydrate.navigate-frame.test.ts`, +3 in the existing raw-WS-frame harness, 12 passing): tile-views frame forwards views/layout/placement; wrong-typed entries are sanitized; plain single-view frames omit the fields; the 9 pre-existing frame tests stay green. **Mutation check:** reverting the fix reds 2/12.

## Verification

- `bunx vitest run` (packages/ui) on both files: **16/16 pass**.
- Mutation-checked: each fix reverted → its tests red → restored → green.
- `biome check --write` on all 4 files: clean. `tsgo --noEmit`: no errors in touched files (one pre-existing, unrelated `iwer` dev-dep error in `spatial/__e2e__`, present without this change).
- Scope: 2 source files + 2 test files, all under `packages/ui/src`. No money/cloud-Worker surfaces, no `useCloudState.ts`/`ProviderSwitcher.tsx`.

**Evidence rows:** unit/component tests + mutation results above. Video walkthrough / before-after screenshots: N/A — headless workflow agent (no display); both behaviors are pinned by DOM-level component tests that assert the exact user-facing navigation contract (event detail, URL fragment, tab switch). Real-LLM trajectories: N/A — no agent/action/prompt/model behavior changed; this is client-side navigation plumbing.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (find + fix + tests + mutation-checks + push; transcript verified 100% claude-fable-5). Independently re-verified: 4-file merge-base diff, 16/16 tests fresh, HelpView mutation reproduced (revert → 2/4 red; restore → green). Conservative view/nav fixes; no money/cloud/routing changes. Part of the app demo-readiness push (#11157). — [phone-ui]