### PR TITLE
fix(core): rewrite POST redirects to bodyless GET in ssrf fetch-guard

### DIFF
--- a/packages/core/src/network/fetch-guard.test.ts
+++ b/packages/core/src/network/fetch-guard.test.ts
@@ -250,3 +250,133 @@ describe("credential headers across redirects", () => {
 		await release();
 	});
 });
+
+/**
+ * Redirects are followed manually (`redirect: "manual"`), so the guard must
+ * also reproduce standard fetch method/body rewriting: on 303 (any non-GET/HEAD
+ * method) and on 301/302 for POST, the follow-up request is rewritten to a
+ * bodyless GET. Otherwise the request body — which may carry secrets — is
+ * re-sent on every hop, including cross-origin hops to an attacker, and the
+ * guard functionally deviates from the spec it claims to reproduce.
+ */
+describe("method + body across redirects", () => {
+	it("rewrites a POST to a bodyless GET and does not re-send the body cross-origin (302)", async () => {
+		const calls: Array<{
+			url: string;
+			method?: string;
+			body?: BodyInit | null;
+			contentType: string | null;
+		}> = [];
+		const fetchImpl = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				calls.push({
+					url: String(input),
+					method: init?.method,
+					body: init?.body,
+					contentType: new Headers(init?.headers).get("content-type"),
+				});
+				if (String(input).startsWith("https://api.example.com")) {
+					return new Response(null, {
+						status: 302,
+						headers: { location: "https://evil.example.net/collect" },
+					});
+				}
+				return new Response("ok", { status: 200 });
+			},
+		);
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://api.example.com/v1",
+			fetchImpl,
+			init: {
+				method: "POST",
+				body: '{"apiKey":"sk-secret"}',
+				headers: {
+					authorization: "Bearer t",
+					"content-type": "application/json",
+				},
+			},
+		});
+		expect(response.status).toBe(200);
+		expect(calls).toHaveLength(2);
+		// First hop carries the original POST + body.
+		expect(calls[0].method).toBe("POST");
+		expect(calls[0].body).toBe('{"apiKey":"sk-secret"}');
+		// Cross-origin hop must be a bodyless GET — no secret body leaked, and the
+		// content-type body header is dropped too.
+		expect(calls[1].url).toBe("https://evil.example.net/collect");
+		expect((calls[1].method ?? "GET").toUpperCase()).toBe("GET");
+		expect(calls[1].body ?? null).toBeNull();
+		expect(calls[1].contentType).toBeNull();
+		await release();
+	});
+
+	it("rewrites a same-origin 303 POST to a bodyless GET (spec 303 semantics)", async () => {
+		const calls: Array<{
+			url: string;
+			method?: string;
+			body?: BodyInit | null;
+		}> = [];
+		const fetchImpl = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				calls.push({
+					url: String(input),
+					method: init?.method,
+					body: init?.body,
+				});
+				if (String(input) === "https://api.example.com/submit") {
+					return new Response(null, {
+						status: 303,
+						headers: { location: "/result" },
+					});
+				}
+				return new Response("ok", { status: 200 });
+			},
+		);
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://api.example.com/submit",
+			fetchImpl,
+			init: { method: "POST", body: "payload=1" },
+		});
+		expect(response.status).toBe(200);
+		expect(calls).toHaveLength(2);
+		expect(calls[1].url).toBe("https://api.example.com/result");
+		expect((calls[1].method ?? "GET").toUpperCase()).toBe("GET");
+		expect(calls[1].body ?? null).toBeNull();
+		await release();
+	});
+
+	it("preserves method and body across a 307 redirect (method-preserving status)", async () => {
+		const calls: Array<{
+			url: string;
+			method?: string;
+			body?: BodyInit | null;
+		}> = [];
+		const fetchImpl = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				calls.push({
+					url: String(input),
+					method: init?.method,
+					body: init?.body,
+				});
+				if (String(input) === "https://api.example.com/old") {
+					return new Response(null, {
+						status: 307,
+						headers: { location: "/new" },
+					});
+				}
+				return new Response("ok", { status: 200 });
+			},
+		);
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://api.example.com/old",
+			fetchImpl,
+			init: { method: "POST", body: "keep-me" },
+		});
+		expect(response.status).toBe(200);
+		expect(calls).toHaveLength(2);
+		expect(calls[1].url).toBe("https://api.example.com/new");
+		expect(calls[1].method).toBe("POST");
+		expect(calls[1].body).toBe("keep-me");
+		await release();
+	});
+});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -68,6 +68,20 @@ const CROSS_ORIGIN_STRIPPED_HEADERS = [
 	"cookie",
 ] as const;
 
+/**
+ * Entity/body headers that describe a request body and must be dropped when a
+ * redirect rewrites the request to a bodyless GET (301/302 POST, any 303).
+ * Matches the WHATWG fetch "HTTP-redirect fetch" step that strips request-body
+ * headers alongside nulling the body.
+ */
+const REDIRECT_BODY_STRIPPED_HEADERS = [
+	"content-encoding",
+	"content-language",
+	"content-location",
+	"content-type",
+	"content-length",
+] as const;
+
 function stripCredentialHeaders(
 	headers: HeadersInit | undefined,
 ): HeadersInit | undefined {
@@ -79,6 +93,40 @@ function stripCredentialHeaders(
 		cleaned.delete(name);
 	}
 	return cleaned;
+}
+
+function stripBodyHeaders(
+	headers: HeadersInit | undefined,
+): HeadersInit | undefined {
+	if (!headers) {
+		return headers;
+	}
+	const cleaned = new Headers(headers);
+	for (const name of REDIRECT_BODY_STRIPPED_HEADERS) {
+		cleaned.delete(name);
+	}
+	return cleaned;
+}
+
+/**
+ * Whether a redirect at `status` from a request using `method` must be rewritten
+ * to a bodyless GET, per the WHATWG fetch redirect rules that standard fetch
+ * (browsers, undici) applies: 301/302 rewrite a POST to GET, and 303 rewrites
+ * any method except GET/HEAD to GET; the request body is dropped in all three.
+ * 307/308 preserve the method and body. Because this guard follows redirects
+ * manually, it must reproduce the same rewrite — otherwise a secret-bearing body
+ * is re-sent on every hop (including a cross-origin hop to an attacker) and the
+ * guard functionally deviates from the spec it claims to follow.
+ */
+function shouldRewriteToGet(status: number, method: string): boolean {
+	const upper = method.toUpperCase();
+	if ((status === 301 || status === 302) && upper === "POST") {
+		return true;
+	}
+	if (status === 303 && upper !== "GET" && upper !== "HEAD") {
+		return true;
+	}
+	return false;
 }
 
 type NodePinnedFetchDefaults = {
@@ -226,6 +274,11 @@ export async function fetchWithSsrfGuard(
 	let currentUrl = params.url;
 	let redirectCount = 0;
 	let hopHeaders = params.init?.headers;
+	// Method/body for the current hop. A redirect that the spec rewrites to a
+	// bodyless GET (301/302 POST, any 303) flips these; once dropped the body is
+	// never restored on later hops, matching standard fetch.
+	let hopMethod = params.init?.method;
+	let hopBodyDropped = false;
 
 	while (true) {
 		let parsedUrl: URL;
@@ -287,6 +340,8 @@ export async function fetchWithSsrfGuard(
 			const init: RequestInit = {
 				...(params.init ? { ...params.init } : {}),
 				...(hopHeaders ? { headers: hopHeaders } : {}),
+				...(hopMethod !== undefined ? { method: hopMethod } : {}),
+				...(hopBodyDropped ? { body: undefined } : {}),
 				redirect: "manual",
 				...(signal ? { signal } : {}),
 			};
@@ -321,6 +376,17 @@ export async function fetchWithSsrfGuard(
 					throw new Error("Redirect loop detected");
 				}
 				visited.add(nextUrl);
+				// 301/302 on a POST, and any 303, are rewritten to a bodyless GET
+				// (matches standard fetch redirect semantics). This both prevents a
+				// secret-bearing request body from being re-sent on the next hop —
+				// including a cross-origin hop to an attacker — and keeps GET-after-303
+				// callers working. Drop the body-describing headers with it. Once
+				// dropped the method/body stay rewritten for every later hop.
+				if (shouldRewriteToGet(response.status, hopMethod ?? "GET")) {
+					hopMethod = "GET";
+					hopBodyDropped = true;
+					hopHeaders = stripBodyHeaders(hopHeaders);
+				}
 				// A redirect hop that crosses origins must not carry the caller's
 				// credentials on the next request (matches standard fetch redirect
 				// semantics). Keep the stripped header state for later hops too;


### PR DESCRIPTION
## Problem

`fetchWithSsrfGuard` follows redirects manually (`redirect: "manual"`) and rebuilds each hop's `init` from `params.init`, so **`method` and `body` are re-sent on every hop**, including cross-origin hops.

`624325abd4` (#11693) fixed the header half of this exfil class — it strips `Authorization` / `Proxy-Authorization` / `Cookie` when a redirect crosses origins — but left the request body. So:

```ts
fetchWithSsrfGuard({
  url: "https://api.example.com/v1",
  init: { method: "POST", body: '{"apiKey":"sk-secret"}',
          headers: { authorization: "Bearer t" } },
});
```

against a compromised server that replies `302 Location: https://evil.example.net/collect` now strips the `Authorization` header (fixed) but **re-POSTs the full secret-bearing body to the attacker origin**.

It is also a functional deviation from the standard-fetch semantics the header fix cites: WHATWG "HTTP-redirect fetch" rewrites `301`/`302` on `POST` and **any** `303` to a bodyless `GET`. A server that 303s expecting `GET`-after-`POST` instead receives a re-`POST`.

The manual redirect loop predates the recent guard batch; #11693 closed the header half of the same exfil class and left this open.

## Fix

Reproduce the spec's redirect method/body rewrite in the manual loop (`packages/core/src/network/fetch-guard.ts`):

- `301`/`302` on `POST`, and `303` on any non-`GET`/`HEAD` method → switch method to `GET`, drop the body, and delete the body-describing headers (`content-type`/`content-length`/`content-encoding`/`content-language`/`content-location`).
- `307`/`308` still preserve method + body (method-preserving statuses).
- Once rewritten, the method/body stay rewritten for all later hops (matches standard fetch).

This closes both the cross-origin body exfil and the `GET`-after-`303` deviation for any body-sending caller. In-tree consumers are bodyless `GET`s, so their behavior is unchanged.

## Tests

New `describe("method + body across redirects")` in `fetch-guard.test.ts`:

- `302` POST → cross-origin hop is a bodyless `GET`, secret body **not** re-sent, content-type dropped.
- same-origin `303` POST → bodyless `GET`.
- `307` → method + body **preserved**.

```
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

Full network + media suite (`src/network/ src/media/fetch.test.ts`): `43 passed (43)`. `bun run --cwd packages/core typecheck` → exit 0.

## Evidence

- Reproduced on `origin/develop` tip: the two rewrite tests fail (`expected 'POST' to be 'GET'`) before the fix, pass after.
- N/A — no UI/model/trajectory surface; this is a pure network-guard code path exercised by the unit tests above.
