### PR TITLE
fix(cloud): force monetization off on app backup restore — close review-gate bypass (#11834)

### DIFF
--- a/packages/cloud/api/v1/apps/backup/restore/route.ts
+++ b/packages/cloud/api/v1/apps/backup/restore/route.ts
@@ -4,8 +4,9 @@
  * POST /api/v1/apps/backup/restore  { backup, name? }
  *
  * Creates a NEW app in the caller's org from a backup snapshot (new slug + new
- * API key) and reapplies its monetization + config. The returned api key is
- * shown once.
+ * API key) and reapplies its config + monetization pricing. Monetization is
+ * always restored disabled (the new app is review_status=draft and must pass
+ * review to monetize — #11834). The returned api key is shown once.
  */
 
 import { Hono } from "hono";
@@ -61,7 +62,11 @@ app.post("/", async (c) => {
       );
     }
 
-    const { app: restored, apiKey } = await appBackupService.restoreApp(
+    const {
+      app: restored,
+      apiKey,
+      warnings,
+    } = await appBackupService.restoreApp(
       user.organization_id,
       user.id,
       parsed.data.backup as unknown as AppBackup,
@@ -73,6 +78,7 @@ app.post("/", async (c) => {
         success: true,
         app: { id: restored.id, name: restored.name, slug: restored.slug },
         apiKey,
+        ...(warnings.length > 0 ? { warnings } : {}),
       },
       201,
     );

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -1606,4 +1606,6 @@ export interface RestoreAppBackupResponse {
   success: boolean;
   app: { id: string; name: string; slug: string };
   apiKey: string;
+  /** e.g. monetization was disabled on restore pending review (#11834). */
+  warnings?: string[];
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/app-backup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-backup.test.ts
@@ -2,7 +2,8 @@
  * App config backup/restore (#10204 "backing up") — real Drizzle schema, PGlite.
  *
  * Exports a secret-free config snapshot of an app and restores it as a NEW app
- * (new slug + new API key) with monetization reapplied. Fails loudly (via the
+ * (new slug + new API key) with monetization pricing reapplied but monetization
+ * FORCED OFF (draft apps must pass review to monetize, #11834). Fails loudly (via the
  * `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a
  * silent skip.
  */
@@ -171,15 +172,24 @@ describe("App config backup/restore", () => {
     expect(JSON.stringify(backup)).not.toContain("api_key");
     expect(JSON.stringify(backup)).not.toContain(source.id);
 
-    // Restore → a NEW app with the config + monetization reapplied.
-    const { app: restored, apiKey } = await appBackupService.restoreApp(orgId, userId, backup);
+    // Restore → a NEW app with the config + monetization pricing reapplied.
+    const {
+      app: restored,
+      apiKey,
+      warnings,
+    } = await appBackupService.restoreApp(orgId, userId, backup);
     expect(restored.id).not.toBe(source.id);
     expect(restored.slug).not.toBe(source.slug);
     expect(apiKey).toBeTruthy();
     expect(restored.name).toContain("My Monetized App");
 
     const restoredFresh = await appsService.getById(restored.id);
-    expect(restoredFresh?.monetization_enabled).toBe(true);
+    // Review-gate (#11834): even though the backup says enabled=true, the
+    // restored app is a fresh draft — monetization must be FORCED OFF and the
+    // caller warned. Pricing is persisted so re-enabling after review is easy.
+    expect(restoredFresh?.monetization_enabled).toBe(false);
+    expect(restoredFresh?.review_status).toBe("draft");
+    expect(warnings).toEqual([expect.stringContaining("Monetization was disabled on restore")]);
     expect(Number(restoredFresh?.inference_markup_percentage)).toBe(25);
     expect(Number(restoredFresh?.purchase_share_percentage)).toBe(40);
     expect(restoredFresh?.allowed_origins).toEqual(["https://myapp.example.com"]);

--- a/packages/cloud/shared/src/lib/services/app-backup.ts
+++ b/packages/cloud/shared/src/lib/services/app-backup.ts
@@ -4,7 +4,9 @@
  * Exports a portable, secret-free snapshot of an app's configuration so a
  * user/agent can back it up and recreate the app later (the "backing up" part of
  * the app lifecycle). Restore creates a NEW app from the snapshot (new slug + new
- * API key) and reapplies monetization + config. Frontend deployments are
+ * API key) and reapplies config + monetization pricing — monetization itself is
+ * always restored DISABLED because the new app starts at review_status=draft and
+ * must pass review before it can collect money. Frontend deployments are
  * immutable R2 artifacts referenced by content hash — the snapshot records the
  * active deployment's hash so the user can redeploy; the bytes are not embedded.
  */
@@ -79,17 +81,25 @@ export class AppBackupService {
 
   /**
    * Create a NEW app from a backup snapshot (new slug + API key) and reapply its
-   * config + monetization. Returns the new app and its (one-time) API key.
+   * config + monetization pricing. Returns the new app, its (one-time) API key,
+   * and any warnings.
+   *
+   * The backup's `monetization.enabled` flag is deliberately NOT honored: the
+   * restored app is a NEW app with `review_status=draft`, and enabling
+   * monetization requires the same approved-review gate as
+   * PUT /apps/:id/monetization. Trusting the client-supplied blob here would
+   * let anyone monetize an unapproved app (#11834).
    */
   async restoreApp(
     organizationId: string,
     userId: string,
     backup: AppBackup,
     overrideName?: string,
-  ): Promise<{ app: App; apiKey: string }> {
+  ): Promise<{ app: App; apiKey: string; warnings: string[] }> {
     if (backup.version !== APP_BACKUP_VERSION) {
       throw new Error(`Unsupported backup version: ${backup.version}`);
     }
+    const warnings: string[] = [];
     const created = await appsService.create({
       name: overrideName?.trim() || `${backup.app.name} (restored)`,
       description: backup.app.description ?? undefined,
@@ -110,7 +120,9 @@ export class AppBackupService {
       promotional_assets: backup.promotional_assets ?? null,
     });
 
-    // Reapply monetization settings (create() does not carry them).
+    // Reapply monetization PRICING (create() does not carry it), but always
+    // force monetization OFF: the enabled flag must come from the review flow,
+    // never from a client-supplied backup blob (#11834).
     if (
       backup.monetization.enabled ||
       backup.monetization.inference_markup_percentage > 0 ||
@@ -118,7 +130,7 @@ export class AppBackupService {
     ) {
       try {
         await appCreditsService.updateMonetizationSettings(created.app.id, {
-          monetizationEnabled: backup.monetization.enabled,
+          monetizationEnabled: false,
           inferenceMarkupPercentage: backup.monetization.inference_markup_percentage,
           purchaseSharePercentage: backup.monetization.purchase_share_percentage,
         });
@@ -128,13 +140,18 @@ export class AppBackupService {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      if (backup.monetization.enabled) {
+        warnings.push(
+          "Monetization was disabled on restore — submit the restored app for review to re-enable it.",
+        );
+      }
     }
 
     logger.info("[AppBackup] restored app from backup", {
       newAppId: created.app.id,
       sourceName: backup.app.name,
     });
-    return created;
+    return { ...created, warnings };
   }
 }
 


### PR DESCRIPTION
## The bypass (#11834, HIGH, money)

`POST /api/v1/apps/backup/restore` created a NEW app (which starts at `review_status = draft`) and then blindly reapplied the client-supplied backup blob's `monetization.enabled` flag via `appCreditsService.updateMonetizationSettings(...)` — with no review gate. The backup blob is arbitrary client input (nothing binds it to an app that ever passed review), so anyone could POST `{"backup": {..., "monetization": {"enabled": true, ...}}}` and get a fresh, unapproved app that is already collecting money. This bypasses the review gate that `PUT /apps/:id/monetization` enforces (and that #11828 adds to create).

## The fix (mirrors the #11828 create-time gate)

In `AppBackupService.restoreApp` (`packages/cloud/shared/src/lib/services/app-backup.ts`):

- Still PERSIST the pricing fields from the backup (`inference_markup_percentage`, `purchase_share_percentage`) so re-enabling after review is a one-click flip.
- FORCE `monetizationEnabled: false` — the enabled flag must come from the review flow, never from a client-supplied blob.
- When the backup asked for `enabled: true`, return a warning: `"Monetization was disabled on restore — submit the restored app for review to re-enable it."`

Surfacing (mirrors the `warnings` array in `apps/route.ts` create):

- `restoreApp` now returns `{ app, apiKey, warnings }`.
- The restore route includes `warnings` in the 201 response when non-empty.
- SDK `RestoreAppBackupResponse` gains an optional `warnings?: string[]` (additive, backward compatible).

## Test (real PGlite, extends the existing suite)

`packages/cloud/shared/src/lib/services/__tests__/app-backup.test.ts`: the round-trip test now creates a monetized source app, exports it (backup snapshot has `monetization.enabled = true`), restores it, and asserts the restored app has `monetization_enabled = false`, `review_status = "draft"`, the warning present, and pricing (25% markup / 40% share) persisted.

Verified locally: `bun test src/lib/services/__tests__/app-backup.test.ts` → 3 pass / 0 fail; `tsgo --noEmit` clean for `cloud/shared`, `cloud/api`, `cloud/sdk`; biome check clean on all touched files.

## Notes for reviewers

- Money path: do NOT merge without a fleet money-review.
- Deliberately did not 403 the whole restore (unlike create in #11828): restore's job is to recreate config, and failing the entire restore because the source app was monetized would break legitimate backups. Disabling + warning preserves the data and the gate.
- Closes #11834.

[cloud-audit]
