### PR TITLE
fix(cloud): export runWithTrajectoryPurpose from Worker core stub — unbreaks develop Worker deploy (#11845)

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -18,6 +18,21 @@ function throwingExport(name: string): (...args: unknown[]) => never {
   return () => unavailable(name);
 }
 
+/**
+ * Worker-safe pass-through for core's `runWithTrajectoryPurpose`. The Worker
+ * build has no AsyncLocalStorage trajectory-context manager (node-only), so we
+ * just invoke the fn directly — trajectory-purpose tracking is a no-op in the
+ * Worker. Added because #11580 imports it into email-classifier.ts, which the
+ * Worker build bundles; without this export the Deploy API Worker step fails
+ * with "No matching export ... for import runWithTrajectoryPurpose".
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 function readEnvValue(
   env: Record<string, string | undefined>,
   keys: readonly string[],


### PR DESCRIPTION
Closes #11845. `[cloud-money]`

**Break:** #11580 added `runWithTrajectoryPurpose` to email-classifier.ts (Worker-bundled), but the core stub `packages/cloud/api/src/stubs/elizaos-core.ts` didn't export it → **Cloud CF Deploy 'Deploy API Worker' fails** (`No matching export ...`, run 28641940713). Every develop→staging Worker deploy is broken.

**Fix:** Worker-safe pass-through export (`(_purpose, fn) => fn()`; no trajectory manager in workerd).

**Proof:** `wrangler deploy --dry-run` — bundle now resolves `runWithTrajectoryPurpose` (advances past the exact failing import). The remaining `@fal-ai/client` resolve error in a local dry-run is an install:light artifact (dep is in package.json + bun.lock; resolved on CI — which is why the CI failure was *only* runWithTrajectoryPurpose). Biome clean. Collision-checked: no open PR touches this stub.