### PR TITLE
fix(cloud): export runWithTrajectoryPurpose from Worker core stub — unblock ALL deploys

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -258,6 +258,20 @@ export function runWithTrajectoryContext<T>(
   return fn();
 }
 
+/**
+ * Worker-safe stand-in for `runWithTrajectoryPurpose`. Same rationale as
+ * `runWithTrajectoryContext` above — the trajectory context manager lives on
+ * the agent sidecar, not in the Worker bundle (pulled in transitively via
+ * `@elizaos/shared` email-classification, not invoked on a Worker route), so
+ * there is no active context to tag with a purpose; just run the function.
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 type InferenceTimingMeta = Record<string, string | number | boolean>;
 
 /**


### PR DESCRIPTION
**Every develop deploy since ~03:46 UTC has failed** at Deploy API Worker: `No matching export in "src/stubs/elizaos-core.ts" for import "runWithTrajectoryPurpose"` (from `shared/src/email-classification/email-classifier.ts:20`). This blocks the develop→main promote that carries the merged money fixes (#11810 withdraw-full-balance, #11817 book-influencer, #11686 sweep) to prod — so those fixes are stuck on develop and the withdraw HIGH bug is still LIVE on prod.

**Fix:** add the missing Worker-safe stub for `runWithTrajectoryPurpose`, mirroring the adjacent `runWithTrajectoryContext` stub (no trajectory context manager in the Worker bundle — it lives on the agent sidecar and this path never runs on a Worker route; just run the fn).

**Verified:** `wrangler deploy --env production --dry-run` builds clean (15.8 MB, no missing-export error). CI/infra fix in the cloud-deploy lane. — `[cloud-frontdoor]`