### PR TITLE
fix(orchestrator): stop verify-failed completions from shadowing the successful retry as origin best result

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
@@ -84,6 +84,10 @@ function makeRuntime(
   } as unknown as IAgentRuntime;
 }
 
+function mockCallCount(fn: unknown): number {
+  return (fn as { mock: { calls: unknown[] } }).mock.calls.length;
+}
+
 function sessionInfo(
   id: string,
   metadata: Record<string, unknown>,
@@ -195,7 +199,7 @@ describe("origin-result capture on task_complete early returns", () => {
       response: "479",
       stopReason: "end_turn",
     });
-    const deliveriesAfterFirst = vi.mocked(runtime.emitEvent).mock.calls.length;
+    const deliveriesAfterFirst = mockCallCount(runtime.emitEvent);
     expect(deliveriesAfterFirst).toBeGreaterThan(0);
     const afterFirst = router.bestResultFor("disc-dedupe-1\0codex");
     expect(afterFirst?.text).toContain("479");
@@ -206,9 +210,7 @@ describe("origin-result capture on task_complete early returns", () => {
       response: "479001600 (the full answer)",
       stopReason: "end_turn",
     });
-    expect(vi.mocked(runtime.emitEvent).mock.calls.length).toBe(
-      deliveriesAfterFirst,
-    );
+    expect(mockCallCount(runtime.emitEvent)).toBe(deliveriesAfterFirst);
     const best = router.bestResultFor("disc-dedupe-1\0codex");
     expect(best?.text).toContain("479001600");
     await router.stop();

--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-early-return-capture.test.ts
@@ -12,7 +12,11 @@
  *
  * These tests drive the REAL handleEvent (private, invoked directly) with a
  * fake ACP service, plus the REAL TASKS action cap branch, and pin:
- *  1. verify-retry handoff still captures the completion for the origin;
+ *  1. verify-retry handoff does NOT capture the verify-FAILED completion —
+ *     the router just judged that build incomplete, so recording its (dead-URL
+ *     annotated, systematically longer) narration would let longest-wins
+ *     shadow the successful retry's shorter clean answer and relay the failure
+ *     at the spawn cap (see origin-result-verify-failed-shadow.test.ts);
  *  2. lineage dedupe still lets a LONGER late completion win (longest-wins);
  *  3. the spawn-cap fallback is an honest "attempted N times" message, not
  *     the misleading "still working" that conflates capped-and-failed with
@@ -118,13 +122,18 @@ async function startRouter(
 }
 
 describe("origin-result capture on task_complete early returns", () => {
-  it("verify-retry handoff records the completion for the origin before returning", async () => {
+  it("verify-retry handoff does NOT record the verify-FAILED completion", async () => {
     // A completion that claims a DEAD loopback URL (nothing listens on the
     // discard port) with explicit deploy/live intent in the task → the
     // verifier flags it dead → retryIncompleteBuild spawns a retry → the
-    // handler takes the verify-retry early return. Before the fix, that
-    // return skipped recordOriginResult and the completion was lost: at the
-    // spawn cap the user got the generic fallback instead of this result.
+    // handler takes the verify-retry early return. That suppressed completion
+    // is a build the router itself judged INCOMPLETE: it must not become the
+    // origin's relayable best result, or its (dead-URL annotated,
+    // systematically longer) narration shadows the successful retry's shorter
+    // clean answer under longest-wins and gets relayed — planner-only
+    // verification directive included — verbatim to the user at the spawn cap
+    // (35a9e8163a / #11514 regression). With nothing clean captured, the cap
+    // falls back to the honest "attempted N times" message instead.
     const deadUrl = "http://127.0.0.1:9/apps/game/index.html";
     const sessions = new Map<string, Record<string, unknown>>([
       [
@@ -155,13 +164,8 @@ describe("origin-result capture on task_complete early returns", () => {
     expect(acp.spawnSession).toHaveBeenCalledTimes(1);
     expect(runtime.emitEvent).not.toHaveBeenCalled();
 
-    // …and the completion was still captured for the origin (the loopback
-    // URL itself is redacted from narration by design, so assert on the
-    // narration body + the honest verification annotation).
-    const best = router.bestResultFor("disc-verify-1\0codex");
-    expect(best).toBeDefined();
-    expect(best?.text).toContain("The game is built and live at");
-    expect(best?.text).toContain("NOT reachable");
+    // …and the verify-FAILED completion was NOT captured for the origin.
+    expect(router.bestResultFor("disc-verify-1\0codex")).toBeUndefined();
     await router.stop();
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Verify-FAILED completions must not become the origin's relayable best result.
+ *
+ * 35a9e8163a (#11514) added captureOriginResultForCompletion on the router's
+ * task_complete early returns so a finished deliverable survives to the spawn
+ * cap. But the verify-retry handoff records a completion the router itself has
+ * just judged a FAILED build (deadUrls > 0): the narration carries the
+ * dead-URL verification annotation, which systematically makes it LONGER than
+ * a clean success text, so recordOriginResult's longest-wins keeps the failure
+ * and the successful retry's shorter completion can never displace it. At the
+ * per-origin spawn cap, tasks.ts then relays that failed text — the dead-URL
+ * claim plus the planner-only "[verification: … do NOT tell the user the app
+ * is live …]" directive — verbatim to the user as the final answer.
+ * Longest-wins is not correctness-wins: a known-failed result is not a
+ * deliverable.
+ *
+ * These tests drive the REAL handleEvent (fake ACP service) through the exact
+ * two-attempt lineage and pin:
+ *  1. the verify-retry handoff does NOT record the verify-failed completion;
+ *  2. after the successful retry completes, bestResultFor is the retry's
+ *     clean result, never the shadowing failure;
+ *  3. the TASKS spawn-cap branch never relays the verification-failure text.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tasksAction } from "../actions/tasks.ts";
+import {
+  SubAgentRouter,
+  sanitizeSuccessorMetadata,
+} from "../services/sub-agent-router.ts";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MSG = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+
+/** A REAL local app host whose deploy state the test controls: 404 until the
+ *  build "lands" (attempt 1's dead URL), 200 HTML afterwards (attempt 2's
+ *  verified live URL) — the exact liveness transition of a failed build
+ *  followed by a successful verify-retry. */
+async function startAppHost(): Promise<{
+  url: string;
+  markBuilt: () => void;
+  close: () => Promise<void>;
+}> {
+  let built = false;
+  const server: Server = createServer((_req, res) => {
+    if (!built) {
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("not found");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end("<html><body>game</body></html>");
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/apps/game/index.html`,
+    markBuilt: () => {
+      built = true;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+type EventHandler = (sessionId: string, event: string, data: unknown) => void;
+
+type RouterInternals = {
+  handleEvent(sessionId: string, event: string, data: unknown): Promise<void>;
+};
+
+function makeFakeAcp(sessions: Map<string, Record<string, unknown>>) {
+  let handler: EventHandler | undefined;
+  const spawnSession = vi.fn(async () => ({ sessionId: "retry-1" }));
+  const service = {
+    onSessionEvent(cb: EventHandler) {
+      handler = cb;
+      return () => {
+        handler = undefined;
+      };
+    },
+    getSession: vi.fn(async (sessionId: string) => sessions.get(sessionId)),
+    getSessions: vi.fn(async () => [...sessions.values()]),
+    getChangedPaths: vi.fn(() => [] as string[]),
+    spawnSession,
+    stopSession: vi.fn(async () => undefined),
+    updateSessionMetadata: vi.fn(async () => undefined),
+  };
+  return { service, spawnSession, emit: handler };
+}
+
+function makeRuntime(
+  acp: ReturnType<typeof makeFakeAcp>["service"],
+  router?: SubAgentRouter,
+  settings: Record<string, string> = {},
+): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Tester" },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getSetting: (key: string) => settings[key],
+    getService: (type: string) => {
+      if (type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE")
+        return acp;
+      if (type === "ACPX_SUB_AGENT_ROUTER") return router;
+      return undefined;
+    },
+    createEntity: vi.fn(async () => true),
+    addParticipant: vi.fn(async () => true),
+    createMemory: vi.fn(async () => MSG),
+    emitEvent: vi.fn(async () => undefined),
+    useModel: vi.fn(async () => "{}"),
+  } as unknown as IAgentRuntime;
+}
+
+function sessionInfo(
+  id: string,
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    id,
+    agentType: "codex",
+    name: "Ada",
+    workdir: "/tmp/orchestrator-verify-shadow-test",
+    status: "ready",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata,
+  };
+}
+
+/** Origin metadata as TASKS op=spawn_agent stamps it (connector id optional —
+ *  dashboard/web spawns only carry the spawn-root message id). */
+function originMeta(
+  msgId: string,
+  appUrl: string,
+  connectorId?: string,
+): Record<string, unknown> {
+  return {
+    roomId: ROOM,
+    taskRoomId: ROOM,
+    messageId: msgId,
+    ...(connectorId ? { originConnectorMessageId: connectorId } : {}),
+    spawnRootMessageId: msgId,
+    source: "discord",
+    label: "build game",
+    initialTask: `Deploy the game and give me the live url ${appUrl}`,
+  };
+}
+
+async function startRouter(
+  sessions: Map<string, Record<string, unknown>>,
+  settings: Record<string, string> = {},
+): Promise<{
+  router: SubAgentRouter;
+  internals: RouterInternals;
+  acp: ReturnType<typeof makeFakeAcp>;
+  runtime: IAgentRuntime;
+}> {
+  const acp = makeFakeAcp(sessions);
+  const runtime = makeRuntime(acp.service, undefined, settings);
+  const router = new SubAgentRouter(runtime);
+  await router.start(); // binds the fake ACP synchronously via getService
+  return {
+    router,
+    internals: router as unknown as RouterInternals,
+    acp,
+    runtime,
+  };
+}
+
+/** Drive the REAL two-attempt lineage against a REAL local app host:
+ *  attempt 1 completes while the claimed URL 404s → verify-retry handoff;
+ *  the retry "deploys" (host flips to 200) and attempt 2 (the successor,
+ *  real metadata shape from retryIncompleteBuild) completes verified. */
+async function runFailedThenCleanLineage(
+  msgId: string,
+  connectorId?: string,
+): Promise<{
+  router: SubAgentRouter;
+  runtime: IAgentRuntime;
+  acp: ReturnType<typeof makeFakeAcp>;
+  betweenAttempts: { text: string; deliverable?: string } | undefined;
+  originKey: string;
+}> {
+  const host = await startAppHost();
+  try {
+    const meta = originMeta(msgId, host.url, connectorId);
+    const sessions = new Map<string, Record<string, unknown>>([
+      ["sess-fail", sessionInfo("sess-fail", { ...meta })],
+    ]);
+    const { router, internals, acp, runtime } = await startRouter(sessions, {
+      ELIZA_URL_VERIFY_SETTLE_MS: "0",
+    });
+
+    // Attempt 1: a VERBOSE completion claiming the still-404 URL. The
+    // verifier flags it (annotation appended → even longer),
+    // retryIncompleteBuild spawns the retry, and the handler takes the
+    // verify-retry handoff early return.
+    await internals.handleEvent("sess-fail", "task_complete", {
+      response: `The game is fully built and deployed. I created index.html, style.css and game.js, wired up the scoreboard and the restart button, and the app is now live at ${host.url} — open it in your browser to play.`,
+      stopReason: "end_turn",
+    });
+    expect(acp.spawnSession).toHaveBeenCalledTimes(1);
+    expect(runtime.emitEvent).not.toHaveBeenCalled();
+
+    const originKey = `${connectorId ?? msgId}\0codex`;
+    const betweenAttempts = router.bestResultFor(originKey);
+
+    // The retry actually deploys the files: the claimed URL goes live.
+    host.markBuilt();
+
+    // Attempt 2: the retry successor completes; the verifier re-probes the
+    // task URL, gets a real 200, and the completion flows through the normal
+    // claim → record → delivery path.
+    sessions.set(
+      "retry-1",
+      sessionInfo("retry-1", {
+        ...sanitizeSuccessorMetadata(meta),
+        buildVerifyRetryCount: 1,
+        keepAliveAfterComplete: false,
+        retryOfSessionId: "sess-fail",
+      }),
+    );
+    await internals.handleEvent("retry-1", "task_complete", {
+      response: `Recreated the missing files; the game is live at ${host.url}`,
+      stopReason: "end_turn",
+    });
+    expect(vi.mocked(runtime.emitEvent).mock.calls.length).toBeGreaterThan(0);
+
+    return { router, runtime, acp, betweenAttempts, originKey };
+  } finally {
+    await host.close();
+  }
+}
+
+describe("verify-failed completion must not shadow the successful retry", () => {
+  it("does not record the verify-failed completion as the origin best result", async () => {
+    const { router, betweenAttempts, originKey } =
+      await runFailedThenCleanLineage(MSG, "disc-shadow-1");
+    // The router itself judged attempt 1 a failed build (dead URL) — it must
+    // not have become the origin's relayable best result.
+    expect(betweenAttempts).toBeUndefined();
+    // And the retained result after the retry is the retry's CLEAN completion:
+    // no dead-URL verification annotation, no planner-only directive.
+    const best = router.bestResultFor(originKey);
+    expect(best).toBeDefined();
+    expect(best?.text).not.toContain("NOT reachable");
+    expect(best?.text).not.toContain("[verification:");
+    await router.stop();
+  });
+});
+
+describe("spawn-cap relay after a verify-failed attempt (TASKS spawn_agent)", () => {
+  let savedCap: string | undefined;
+  beforeEach(() => {
+    savedCap = process.env.ELIZA_MAX_SPAWNS_PER_ORIGIN;
+    delete process.env.ELIZA_MAX_SPAWNS_PER_ORIGIN;
+  });
+  afterEach(() => {
+    if (savedCap === undefined) delete process.env.ELIZA_MAX_SPAWNS_PER_ORIGIN;
+    else process.env.ELIZA_MAX_SPAWNS_PER_ORIGIN = savedCap;
+  });
+
+  function capMessage(msgId: string): Memory {
+    return {
+      id: msgId,
+      roomId: ROOM,
+      entityId: "22222222-2222-4222-8222-222222222222",
+      content: { text: "build me a game", metadata: {} },
+    } as unknown as Memory;
+  }
+
+  async function runCappedSpawn(
+    router: SubAgentRouter,
+    msgId: string,
+  ): Promise<string> {
+    const { service } = makeFakeAcp(new Map());
+    const runtime = makeRuntime(service, router, {
+      // Hermetic: ignore any ambient adapter pin + skip task-room minting.
+      ELIZA_AGENT_SELECTION_STRATEGY: "dynamic",
+      ELIZA_ORCHESTRATOR_TASK_ROOMS: "0",
+    });
+    let replyText = "";
+    await tasksAction.handler(
+      runtime,
+      capMessage(msgId),
+      undefined as unknown as State,
+      {
+        parameters: {
+          action: "spawn_agent",
+          agentType: "codex",
+          task: "build me a game",
+        },
+      },
+      async (content) => {
+        if (typeof content.text === "string") replyText = content.text;
+        return [];
+      },
+    );
+    return replyText;
+  }
+
+  it("never relays the verification-failure text as the final answer", async () => {
+    // Connector-less origin: the cap key and the router's origin-result key
+    // both collapse to the user message id (#8875).
+    const msgId = "55555555-5555-4555-8555-555555555555";
+    const { router, originKey } = await runFailedThenCleanLineage(msgId);
+
+    router.noteSpawnForOrigin(originKey);
+    router.noteSpawnForOrigin(originKey);
+    router.noteSpawnForOrigin(originKey); // default cap = 3 → next spawn capped
+
+    const replyText = await runCappedSpawn(router, msgId);
+    // The user must never receive the dead-URL completion the router judged a
+    // failed build (nor its planner-only verification directive).
+    expect(replyText).not.toContain("NOT reachable");
+    expect(replyText).not.toContain("[verification:");
+    expect(replyText.length).toBeGreaterThan(0);
+    await router.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/origin-result-verify-failed-shadow.test.ts
@@ -116,6 +116,10 @@ function makeRuntime(
   } as unknown as IAgentRuntime;
 }
 
+function mockCallCount(fn: unknown): number {
+  return (fn as { mock: { calls: unknown[] } }).mock.calls.length;
+}
+
 function sessionInfo(
   id: string,
   metadata: Record<string, unknown>,
@@ -229,7 +233,7 @@ async function runFailedThenCleanLineage(
       response: `Recreated the missing files; the game is live at ${host.url}`,
       stopReason: "end_turn",
     });
-    expect(vi.mocked(runtime.emitEvent).mock.calls.length).toBeGreaterThan(0);
+    expect(mockCallCount(runtime.emitEvent)).toBeGreaterThan(0);
 
     return { router, runtime, acp, betweenAttempts, originKey };
   } finally {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -534,7 +534,11 @@ export class SubAgentRouter extends Service {
     return this.bestResultForOrigin.get(originKey);
   }
 
-  /** Keep the LONGEST non-empty result for an origin (full 479001600 wins over truncated 479). */
+  /** Keep the LONGEST non-empty result for an origin (full 479001600 wins over
+   *  truncated 479). Longest-wins presumes every recorded result is relayable —
+   *  handleEvent gates verify-FAILED completions out upstream
+   *  (captureOriginResultForCompletion) so a failed build's verbose narration
+   *  can never shadow a successful retry's shorter answer. */
   recordOriginResult(
     originKey: string,
     result: { text: string; deliverable?: string },
@@ -555,19 +559,31 @@ export class SubAgentRouter extends Service {
   /**
    * Capture a completed task's deliverable for its origin BEFORE any early
    * return (verify-retry handoff, stale-continuation suppression, lineage
-   * dedupe). Those paths return before the main recordOriginResult call
-   * further down, so without this bestResultFor() is undefined when the spawn
-   * cap later fires — a real finished deliverable is lost and the user sees a
-   * generic cap message instead of the answer. recordOriginResult is monotonic
-   * (longest-wins), so recording here AND later is always safe. Keys exactly
-   * like the main call site (#8875).
+   * dedupe). Those paths return before the main capture further down, so
+   * without this bestResultFor() is undefined when the spawn cap later fires —
+   * a real finished deliverable is lost and the user sees a generic cap
+   * message instead of the answer. Keys exactly like tasks.ts's
+   * spawnOriginKey derivation (#8875).
+   *
+   * EXCEPT verify-FAILED completions (`deadUrls` non-empty): the router
+   * itself just judged that build incomplete, so its narration — stamped with
+   * the dead-URL annotation, which systematically out-lengths a clean success
+   * text — is not a deliverable. Recording it would let longest-wins retain
+   * the failure over the successful retry's shorter completion, and the spawn
+   * cap would then relay the failed build (planner-only verification
+   * directive included) verbatim to the user as the final answer.
+   * Longest-wins is only monotonic for results that are actually relayable;
+   * a known-failed completion is skipped, and the cap's honest "attempted N
+   * times" fallback covers the case where nothing clean ever lands.
    */
   private captureOriginResultForCompletion(
     origin: OriginInfo,
     session: SessionInfo,
     text: string,
     deliverable: string | undefined,
+    deadUrls: readonly DeadUrl[],
   ): void {
+    if (deadUrls.length > 0) return;
     const originResultKey =
       origin.parentConnectorMessageId ?? origin.spawnRootMessageId;
     if (!originResultKey) return;
@@ -1137,6 +1153,7 @@ export class SubAgentRouter extends Service {
           session,
           text,
           deliverable,
+          deadUrls,
         );
         rollbackRoundTrip();
         return;
@@ -1152,6 +1169,7 @@ export class SubAgentRouter extends Service {
           session,
           text,
           deliverable,
+          deadUrls,
         );
         rollbackRoundTrip();
         return;
@@ -1198,6 +1216,7 @@ export class SubAgentRouter extends Service {
           session,
           text,
           deliverable,
+          deadUrls,
         );
         rollbackRoundTrip();
         return;
@@ -1223,22 +1242,18 @@ export class SubAgentRouter extends Service {
       text = `${header}\n${deliverable}`;
     }
     if (event === "task_complete") {
-      // Remember the best (longest) result for this root origin so the spawn
-      // cap (tasks.ts) can relay it instead of re-spawning when a weak model's
-      // later completion for the SAME user request comes back truncated/blocked.
-      // Key on the stable root id — the connector message id when present, else
-      // the user message id the router stamps onto each synthetic re-spawn
-      // inbound as `spawnRootMessageId` (dashboard/web has no connector id).
-      // This MUST match tasks.ts's `spawnOriginKey` derivation so record +
-      // enforce agree on every transport (#8875).
-      const originResultKey =
-        origin.parentConnectorMessageId ?? origin.spawnRootMessageId;
-      if (originResultKey) {
-        this.recordOriginResult(`${originResultKey}\0${session.agentType}`, {
-          text,
-          deliverable,
-        });
-      }
+      // Remember the best (longest) CLEAN result for this root origin so the
+      // spawn cap (tasks.ts) can relay it instead of re-spawning when a weak
+      // model's later completion for the SAME user request comes back
+      // truncated/blocked. Key contract (#8875) and the verify-failed gate
+      // live in captureOriginResultForCompletion.
+      this.captureOriginResultForCompletion(
+        origin,
+        session,
+        text,
+        deliverable,
+        deadUrls,
+      );
       // Strip the planner-only `[sub-agent: …]` header before previewing so
       // the notification body shows the actual result (e.g. "PR opened"),
       // not the relay/do-not-respawn directive. The header can now be long


### PR DESCRIPTION
## Defect

35a9e8163a (#11514) added `captureOriginResultForCompletion` on the router's `task_complete` early returns so a finished deliverable survives to the per-origin spawn cap. But the verify-retry handoff records a completion the router **itself just judged a failed build** (`deadUrls.length > 0`), and `recordOriginResult` is pure longest-wins — no verification-status gate. The #11514 justification ("recordOriginResult is monotonic so recording here is always safe") is wrong for known-failed results: longest-wins is not correctness-wins.

Failure path (refs on pre-fix `develop`):

1. Build attempt 1 emits `task_complete` referencing a URL that fails liveness verification. `annotateUnverifiedUrls` stamps the narration with the dead-URL failure annotation (`sub-agent-router.ts` ~2988) — which systematically makes the failed text **longer** than a clean success text.
2. `retryIncompleteBuild` spawns attempt 2, and the verify-retry handoff records the failed completion for the origin (`sub-agent-router.ts:1135`; same-shaped captures at 1150/1196). `sanitizeSuccessorMetadata` preserves the origin keys byte-for-byte, so both attempts record under the SAME origin-result key.
3. Attempt 2 succeeds with a shorter deliverable. `recordOriginResult` (`if (prev && candidate.length <= prevLen) return;`) keeps the longer verify-FAILED text — the successful retry can never displace it.
4. When the per-origin spawn cap fires, `tasks.ts` (~1199-1211) relays `best.deliverable ?? best.text` verbatim: the user receives the dead-URL completion the router judged a failed build — including the planner-only `[verification: … do NOT tell the user the app is live …]` directive — as the final answer.

## Fix

Gate verify-FAILED completions (`deadUrls.length > 0`) out of origin-result capture at every site. A known-failed build is not a relayable deliverable; with nothing clean captured, the spawn cap's honest "attempted N times" fallback covers the case where no clean completion ever lands. The main-path record now routes through the same helper, so the #8875 key contract and the gate live in one place. `recordOriginResult` stays longest-wins for the results that are actually relayable.

## Tests (real path, no mocks of the thing under test)

New `origin-result-verify-failed-shadow.test.ts` drives the **real** `handleEvent` and the **real** `TASKS` spawn-cap branch through the exact two-attempt lineage against a **real local HTTP app host** whose deploy state transitions 404 → 200 (attempt 1's dead URL, then the retry's verified-live URL; real `safeFetch` probes both ways). The retry successor session uses the byte-identical metadata shape `retryIncompleteBuild` produces (`sanitizeSuccessorMetadata` + `buildVerifyRetryCount`/`retryOfSessionId`).

RED on pre-fix develop — reproduced at the exact user-facing symptom:

```
FAIL … > does not record the verify-failed completion as the origin best result
  expected undefined, received the verify-FAILED annotated narration as bestResultFor

FAIL … > never relays the verification-failure text as the final answer
AssertionError: expected '[sub-agent: build game (codex) — task…' not to contain 'NOT reachable'
+ [verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell
+ the user the app is live; report the real status and that the build likely did not complete]
+   -  → HTTP 404
```

GREEN after the fix. The #11514 test that pinned the old behavior (verify-retry handoff records the failed completion) is updated to pin the corrected semantics, with the rationale in-line; its other pins (lineage-dedupe longest-wins for clean completions, honest cap fallback, deliverable relay at the cap) are unchanged and still pass.

```
Test Files  151 passed | 4 skipped (155)
     Tests  1576 passed | 8 skipped (1584)
```

`bun run typecheck` exit 0; `bun run lint:check` clean (plugin scope).

## Evidence

- Real-LLM trajectory: N/A — deterministic router bookkeeping (which completion is retained/relayed), no model/prompt/action-selection behavior change; the regression test drives the real completion pipeline end to end including real HTTP liveness probes.
- Screenshots/video: N/A — no UI surface.
- Backend logs: the tests exercise the real `[verify] probe … → HTTP 404` / `re-dispatched sub-agent after failed verification` router log path.
- Domain artifact: `bestResultFor()` state inspected before/after each attempt in the tests — failed capture absent, clean retry result retained, spawn-cap reply free of the failure annotation.
