### PR TITLE
feat: add elizaos-plugin-true402 to the third-party plugin registry

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-true402.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-true402.json
@@ -1,0 +1,19 @@
+{
+  "package": "elizaos-plugin-true402",
+  "repository": "github:true402/elizaos-plugin-true402",
+  "kind": "plugin",
+  "description": "Pre-trade rug/honeypot guard for Base tokens — real buy/sell simulation plus liquidity and ownership checks, pay-per-call over x402 (USDC on Base). No accounts, no API keys; free daily trial.",
+  "homepage": "https://true402.dev",
+  "version": "0.1.1",
+  "tags": [
+    "x402",
+    "base",
+    "usdc",
+    "token-safety",
+    "rug-check",
+    "honeypot",
+    "defi",
+    "micropayments",
+    "trading"
+  ]
+}


### PR DESCRIPTION
Adds **elizaos-plugin-true402** to `packages/registry/entries/third-party/`.

## What it does
A pre-trade **rug/honeypot guard for Base tokens**: before an agent buys, snipes, or approves a token, it runs a real **buy/sell simulation on-chain** (gas-free `eth_call` with state override — proves the token is actually sellable, which static scans can't), plus liquidity-depth and ownership/mint/proxy checks, and returns one `AVOID / CAUTION / OK` verdict with reasons.

## Payments & pricing
Pay-per-call over **x402** (USDC on Base, gas sponsored via EIP-3009) — no accounts, no API keys; the agent's wallet is the identity. Token safety $0.005 · full token report $0.01 · address safety $0.005 · deployer reputation $0.008. The safety checks include a small **free daily trial** (keyless), so the plugin works out of the box with no wallet configured.

## Links
- npm: https://www.npmjs.com/package/elizaos-plugin-true402 (published, `elizaos` keyword set)
- Repo: https://github.com/true402/elizaos-plugin-true402
- Live service + docs: https://true402.dev · OpenAPI: https://true402.dev/openapi.json
- Try the underlying check with zero setup: `npx @true402.dev/rugcheck 0x<token>`

## Checklist
- [x] Package published to npm as `elizaos-plugin-true402` (unscoped, not `@elizaos/*`)
- [x] `keywords` include `elizaos`
- [x] Entry file added at `packages/registry/entries/third-party/elizaos-plugin-true402.json` (schema-conformant)
- [ ] `generated-registry.json` regeneration left to maintainers (as in prior registry PRs) — happy to add it if preferred