### PR TITLE
fix(orchestrator): gateway mode leaked raw provider key to opencode sub-agents via OPENCODE_CONFIG_CONTENT

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-env.test.ts
@@ -144,6 +144,18 @@ const MANAGED_ENV_KEYS = [
   "CLAUDE_CODE_OAUTH_TOKEN",
   "OPENAI_BASE_URL",
   "ANTHROPIC_BASE_URL",
+  // Host vars that steer buildOpencodeSpawnConfig — cleared so the opencode
+  // spawn tests are deterministic on any developer/CI machine.
+  "ELIZA_LLM_PROVIDER",
+  "ELIZA_OPENCODE_BASE_URL",
+  "ELIZA_OPENCODE_LOCAL",
+  "ELIZA_OPENCODE_MODEL_POWERFUL",
+  "ELIZA_OPENCODE_MODEL_FAST",
+  "OPENCODE_MODEL",
+  "OPENCODE_SMALL_MODEL",
+  "OPENCODE_CONFIG_CONTENT",
+  "CEREBRAS_BASE_URL",
+  "CEREBRAS_MODEL",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -193,7 +205,7 @@ function allLoggedText(logger: MockLogger): string {
 }
 
 async function spawnAndCaptureEnv(
-  agentType: "claude" | "codex",
+  agentType: "claude" | "codex" | "opencode",
 ): Promise<{ env: NodeJS.ProcessEnv; logger: MockLogger }> {
   const { runtime: rt, logger } = runtime();
   const service = new AcpService(rt);
@@ -306,6 +318,23 @@ describe("applyModelGatewayEnv (pure env rewrite)", () => {
     expectNoRawKeyInDump(env);
   });
 
+  it("scrubs composite env values that embed a raw provider key (fail closed)", () => {
+    const env: NodeJS.ProcessEnv = {
+      CEREBRAS_API_KEY: RAW_CEREBRAS_KEY,
+      // A composite carrier: a JSON config blob embedding the raw key, the
+      // shape buildOpencodeAcpEnv writes (guards any future merge step that
+      // smuggles a raw value inside a non-excluded var).
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        provider: { cerebras: { options: { apiKey: RAW_CEREBRAS_KEY } } },
+      }),
+      PATH: "/usr/bin",
+    };
+    applyModelGatewayEnv(env, { url: GATEWAY_URL, token: GATEWAY_TOKEN });
+    expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+    expectNoRawKeyInDump(env);
+  });
+
   it("covers every provider credential buildEnv can carry (frozen contract)", () => {
     expect([...MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS]).toEqual([
       "OPENAI_API_KEY",
@@ -350,6 +379,31 @@ describe("gateway mode ON — spawned sub-agent env", () => {
     expect(env.CEREBRAS_API_KEY).toBeUndefined();
     expect(env.ELIZA_OPENCODE_API_KEY).toBeUndefined();
 
+    expectNoRawKeyInDump(env);
+  });
+
+  it("opencode spawn: OPENCODE_CONFIG_CONTENT routes through the gateway, raw keys excluded", async () => {
+    setRawProviderKeys();
+    enableGateway();
+    const { env } = await spawnAndCaptureEnv("opencode");
+
+    // The runtime-built opencode config must point the child at the gateway —
+    // same transport contract as OPENAI_BASE_URL / ANTHROPIC_BASE_URL for the
+    // codex/claude children — not directly at Cerebras/Eliza Cloud.
+    expect(env.OPENCODE_CONFIG_CONTENT).toBeDefined();
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}");
+    const provider = config.provider?.["eliza-gateway"];
+    expect(provider?.options?.baseURL).toBe(GATEWAY_URL);
+    expect(provider?.options?.apiKey).toBe(GATEWAY_TOKEN);
+    expect(env.OPENCODE_CONFIG_CONTENT).not.toContain("cerebras.ai");
+
+    expect(env.OPENAI_BASE_URL).toBe(GATEWAY_URL);
+    expect(env.ANTHROPIC_BASE_URL).toBe(GATEWAY_URL);
+    expect(env.CEREBRAS_API_KEY).toBeUndefined();
+    expect(env.ELIZA_OPENCODE_API_KEY).toBeUndefined();
+
+    // The stated invariant: a child env dump contains no raw provider key —
+    // including inside composite values like the JSON spawn config.
     expectNoRawKeyInDump(env);
   });
 
@@ -441,6 +495,22 @@ describe("gateway mode OFF — byte-identical legacy env", () => {
     const dump = JSON.stringify(env);
     expect(dump).not.toContain(GATEWAY_URL);
     expect(dump).not.toContain(GATEWAY_TOKEN);
+    expect(allLoggedText(logger)).not.toContain("model-gateway mode engaged");
+  });
+
+  it("both vars unset: opencode config keeps the direct provider wiring untouched", async () => {
+    setRawProviderKeys();
+    const { env, logger } = await spawnAndCaptureEnv("opencode");
+
+    // Legacy cerebras-api auto-detect: direct base URL, raw key embedded
+    // (ELIZA_OPENCODE_API_KEY wins over CEREBRAS_API_KEY), no gateway wiring.
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}");
+    expect(config.provider?.cerebras?.options?.baseURL).toBe(
+      "https://api.cerebras.ai/v1",
+    );
+    expect(config.provider?.cerebras?.options?.apiKey).toBe(RAW_OPENCODE_KEY);
+    expect(env.OPENAI_BASE_URL).toBeUndefined();
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(allLoggedText(logger)).not.toContain("model-gateway mode engaged");
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -1,5 +1,5 @@
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpencodeSpawnConfig } from "../../src/services/opencode-config.js";
 
 function runtime(settings: Record<string, string | undefined> = {}) {
@@ -7,6 +7,39 @@ function runtime(settings: Record<string, string | undefined> = {}) {
     getSetting: vi.fn((key: string) => settings[key]),
   } as unknown as IAgentRuntime;
 }
+
+const GATEWAY_URL = "https://gateway.test.invalid/v1";
+const GATEWAY_TOKEN = "gw-lease-token-abc123";
+
+// buildOpencodeSpawnConfig reads gateway mode from host config
+// (resolveModelGatewayConfig → config-env/process.env), not the env argument —
+// save/clear the vars around every test so the auto-detect suite stays
+// hermetic on a machine with gateway vars set, and the gateway suite below
+// can opt in explicitly.
+const MANAGED_ENV_KEYS = [
+  "ELIZA_MODEL_GATEWAY_URL",
+  "ELIZA_MODEL_GATEWAY_TOKEN",
+  "ELIZA_CONFIG_PATH",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of MANAGED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  process.env.ELIZA_CONFIG_PATH =
+    "/nonexistent/opencode-config-test/eliza.json";
+});
+
+afterEach(() => {
+  for (const key of MANAGED_ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe("buildOpencodeSpawnConfig", () => {
   it("returns null when no provider or opencode model is configured", () => {
@@ -117,5 +150,68 @@ describe("buildOpencodeSpawnConfig", () => {
     });
     const config = JSON.parse(result?.configContent ?? "{}");
     expect(config.permission?.webfetch).toBe("allow");
+  });
+});
+
+describe("buildOpencodeSpawnConfig (model-gateway mode, #11536 E2)", () => {
+  beforeEach(() => {
+    process.env.ELIZA_MODEL_GATEWAY_URL = GATEWAY_URL;
+    process.env.ELIZA_MODEL_GATEWAY_TOKEN = GATEWAY_TOKEN;
+  });
+
+  it("routes through the gateway and never embeds a raw provider key", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      CEREBRAS_API_KEY: "csk-raw-DO-NOT-LEAK",
+    });
+    expect(result?.providerId).toBe("eliza-gateway");
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.provider["eliza-gateway"].options.baseURL).toBe(GATEWAY_URL);
+    expect(config.provider["eliza-gateway"].options.apiKey).toBe(GATEWAY_TOKEN);
+    expect(result?.configContent).not.toContain("csk-raw-DO-NOT-LEAK");
+    expect(result?.configContent).not.toContain("cerebras.ai");
+  });
+
+  it("never embeds a runtime-settings key either (env deletion alone would miss it)", () => {
+    const result = buildOpencodeSpawnConfig(
+      runtime({ CEREBRAS_API_KEY: "csk-runtime-raw-DO-NOT-LEAK" }),
+      {},
+    );
+    expect(result?.providerId).toBe("eliza-gateway");
+    expect(result?.configContent).not.toContain("csk-runtime-raw-DO-NOT-LEAK");
+  });
+
+  it("beats a custom base URL — a spawn cannot bypass the gateway", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_BASE_URL: "https://api.cerebras.ai/v1",
+      ELIZA_OPENCODE_API_KEY: "csk-raw-DO-NOT-LEAK",
+    });
+    expect(result?.providerId).toBe("eliza-gateway");
+    expect(result?.configContent).not.toContain("cerebras.ai");
+    expect(result?.configContent).not.toContain("csk-raw-DO-NOT-LEAK");
+  });
+
+  it("works with no raw provider key on the host (keys live gateway-side)", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {});
+    expect(result?.providerId).toBe("eliza-gateway");
+    // Model default mirrors the direct cerebras-api chain: transport +
+    // credentials change, the model does not.
+    expect(result?.model).toBe("eliza-gateway/gemma-4-31b");
+  });
+
+  it("passes configured model names through to the gateway unchanged", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
+      ELIZA_OPENCODE_MODEL_FAST: "gemma-4-31b",
+    });
+    expect(result?.model).toBe("eliza-gateway/gpt-oss-120b");
+    expect(result?.smallModel).toBe("eliza-gateway/gemma-4-31b");
+  });
+
+  it("stays off when only one gateway var is set", () => {
+    delete process.env.ELIZA_MODEL_GATEWAY_TOKEN;
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      CEREBRAS_API_KEY: "csk-test",
+    });
+    expect(result?.providerId).toBe("cerebras");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/model-gateway.ts
@@ -6,9 +6,13 @@
  * process env, per config-env conventions). In gateway mode a spawned
  * sub-agent's env points `OPENAI_BASE_URL` (Codex CLI) and
  * `ANTHROPIC_BASE_URL` (Claude Code via claude-agent-acp) at the gateway,
- * with the gateway token injected as the api-key env for both paths. Raw
- * provider credentials are actively excluded — deleted before the token is
- * assigned — so a sub-agent env dump contains no raw provider credential.
+ * with the gateway token injected as the api-key env for both paths. OpenCode
+ * routes through the gateway too: in gateway mode `buildOpencodeSpawnConfig`
+ * (opencode-config.ts) builds a gateway-pointed provider config instead of
+ * embedding a raw provider key into `OPENCODE_CONFIG_CONTENT`. Raw provider
+ * credentials are actively excluded — deleted before the token is assigned,
+ * and any composite env value still embedding a raw key is dropped whole —
+ * so a sub-agent env dump contains no raw provider credential.
  * With either var unset the child env is byte-identical to non-gateway
  * behavior.
  *
@@ -63,17 +67,42 @@ export function resolveModelGatewayConfig(): ModelGatewayConfig | undefined {
 }
 
 /**
+ * Real provider keys are 20+ chars; a raw value shorter than this is not
+ * treated as a credential by the composite-value sweep below, so a
+ * misconfigured 1–2 char "key" cannot substring-match (and delete) half the
+ * child env.
+ */
+const MIN_SWEPT_RAW_VALUE_LENGTH = 8;
+
+/**
  * Rewrite a fully-assembled sub-agent env for gateway mode. Must run LAST in
  * `AcpService.buildEnv` so no earlier merge step can reintroduce a raw
  * provider key: the raw keys are deleted first, then the gateway token is
  * assigned, so raw values are gone from the env — not merely shadowed.
+ *
+ * The invariant is "no raw provider key VALUE anywhere in the child env",
+ * not "the named keys are absent" — so after deleting the named keys, any
+ * remaining env var whose value embeds one of their raw values (a composite
+ * carrier, e.g. a JSON config blob like `OPENCODE_CONFIG_CONTENT`) is
+ * dropped whole. Fail closed: a misconfigured child beats a leaked key.
+ * (The opencode path never trips this in practice — in gateway mode
+ * `buildOpencodeSpawnConfig` builds a gateway-pointed config with no raw
+ * key; this sweep is the backstop for future merge steps.)
  */
 export function applyModelGatewayEnv(
   env: NodeJS.ProcessEnv,
   gateway: ModelGatewayConfig,
 ): void {
+  const rawValues: string[] = [];
   for (const key of MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS) {
+    const value = env[key];
+    if (typeof value === "string" && value.length >= MIN_SWEPT_RAW_VALUE_LENGTH)
+      rawValues.push(value);
     delete env[key];
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== "string") continue;
+    if (rawValues.some((raw) => value.includes(raw))) delete env[key];
   }
   env.OPENAI_BASE_URL = gateway.url;
   env.ANTHROPIC_BASE_URL = gateway.url;

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
+import { resolveModelGatewayConfig } from "./model-gateway.js";
 
 const ELIZA_CLOUD_OPENAI_BASE = "https://elizacloud.ai/api/v1";
 const OPENCODE_LOCAL_DEFAULT_BASE_URL = "http://localhost:11434/v1";
@@ -145,6 +146,30 @@ export function buildOpencodeSpawnConfig(
     setting(runtime, env, "ELIZA_OPENCODE_MODEL_POWERFUL") ||
     setting(runtime, env, "OPENCODE_MODEL");
   const fast = setting(runtime, env, "ELIZA_OPENCODE_MODEL_FAST");
+
+  // Gateway mode (#11536 E2) — checked BEFORE any provider-credential read so
+  // no raw key (env, runtime settings, or config-env; `setting()` falls back
+  // to all three) can be embedded into OPENCODE_CONFIG_CONTENT, and the
+  // opencode child cannot bypass the gateway by talking to Cerebras / Eliza
+  // Cloud / a custom base URL directly. Provider auto-detection and custom
+  // base URLs are deliberately ignored here: gateway mode centralizes egress.
+  // Model names pass through unchanged (the gateway routes by model name),
+  // defaulting to the same chain the direct cerebras-api path uses, so
+  // flipping the gateway on changes transport + credentials, never the model.
+  const gateway = resolveModelGatewayConfig();
+  if (gateway) {
+    return providerConfig(
+      "eliza-gateway",
+      "Eliza Model Gateway",
+      OPENCODE_OPENAI_COMPATIBLE_NPM,
+      gateway.url,
+      gateway.token,
+      powerful ||
+        setting(runtime, env, "CEREBRAS_MODEL") ||
+        CEREBRAS_DEFAULT_MODEL,
+      fast,
+    );
+  }
 
   if (llmProvider === "cloud") {
     const cloudKey = readConfigCloudKey("apiKey");


### PR DESCRIPTION
# Gateway mode leaked the raw provider key to opencode sub-agents (and opencode bypassed the gateway)

## Defect

86bc107ca2 (#11651, gateway mode for #11536 E2) states the invariant: with `ELIZA_MODEL_GATEWAY_URL` + `ELIZA_MODEL_GATEWAY_TOKEN` set, **a child env dump contains no raw provider key**. An `agentType: "opencode"` spawn broke that invariant twice over:

1. **Raw key leak.** `AcpService.buildEnv`'s opencode block calls `buildOpencodeAcpEnv` → `buildOpencodeSpawnConfig` (`opencode-config.ts`), which embeds the raw `CEREBRAS_API_KEY` / `ELIZA_OPENCODE_API_KEY` / Eliza Cloud key as `provider.*.options.apiKey` inside the JSON assigned to `env.OPENCODE_CONFIG_CONTENT`. `applyModelGatewayEnv` (`model-gateway.ts`) runs after it and deletes only the seven named env keys — it never touches `OPENCODE_CONFIG_CONTENT` — so the raw key rides into the child env inside the JSON blob.
2. **Gateway bypass.** The same config points the opencode child's `baseURL` straight at `api.cerebras.ai` / Eliza Cloud, so its model traffic skips the gateway entirely.

Deleting the key env vars earlier would not have fixed this: `opencode-config`'s `setting()` falls back to runtime settings and config-env, so the key gets embedded regardless of env deletion order (multi-account pool rotation also injects `CEREBRAS_API_KEY` for opencode through this same read). `model-gateway-env.test.ts` only exercised `agentType: "claude" | "codex"`, which is why the gap was invisible.

## Fix (structural)

- **`buildOpencodeSpawnConfig` checks `resolveModelGatewayConfig()` FIRST** — before any credential read from any source. In gateway mode it returns a gateway-pointed `@ai-sdk/openai-compatible` provider config (`baseURL` = gateway URL, `apiKey` = gateway token): there is nothing raw to leak, and the opencode child's traffic goes through the gateway — the same transport contract `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` gives the codex/claude children. Provider auto-detection and custom base URLs are deliberately ignored in gateway mode (gateway centralizes egress); model names pass through unchanged, defaulting to the same chain the direct cerebras-api path uses.
- **`applyModelGatewayEnv` now enforces the stated invariant literally**: raw values captured from the named keys are swept out of every remaining env value, so any composite carrier (a JSON blob like `OPENCODE_CONFIG_CONTENT`) that still embeds a raw key is dropped whole. Fail-closed backstop for future merge steps; the opencode path never trips it now that the config is gateway-built.

Off-mode behavior is byte-identical: the gateway branch is dead code when either var is unset, and a new off-mode spawn test pins the legacy direct-cerebras wiring (raw key embedded, no gateway URLs) exactly as before.

## Evidence

**Defect re-confirmed — new tests against the previous code (7 fail):**

```
FAIL  model-gateway-env.test.ts > gateway mode ON — spawned sub-agent env >
      opencode spawn: OPENCODE_CONFIG_CONTENT routes through the gateway, raw keys excluded
AssertionError: expected undefined to be 'https://gateway.test.invalid/v1'
  (child env kept the direct-cerebras config with the raw key instead)

FAIL  model-gateway-env.test.ts > applyModelGatewayEnv (pure env rewrite) >
      scrubs composite env values that embed a raw provider key (fail closed)
+ Received: "{\"provider\":{\"cerebras\":{\"options\":{\"apiKey\":\"csk-raw-cerebras-DO-NOT-LEAK\"}}}}"
  (raw key survived applyModelGatewayEnv inside OPENCODE_CONFIG_CONTENT)

+ 5 gateway-branch buildOpencodeSpawnConfig failures (bypass / base-URL / runtime-settings-key / keyless / model pass-through)
Tests  7 failed | 27 passed (34)
```

**After the fix (same two files):**

```
Test Files  2 passed (2)
     Tests  34 passed (34)
```

**Full plugin suite + typecheck + lint:**

```
bun run --cwd plugins/plugin-agent-orchestrator test:unit
  Test Files  118 passed (118)
       Tests  1290 passed (1290)
bun run --cwd plugins/plugin-agent-orchestrator typecheck  → exit 0
bunx biome check <4 changed files> → clean
```

New coverage: `model-gateway-env.test.ts` now spawns `agentType: "opencode"` in gateway ON (gateway-routed `OPENCODE_CONFIG_CONTENT`, no raw key anywhere in the env dump including composite values) and OFF (legacy wiring pinned byte-identical) modes, plus the composite-value sweep; `opencode-spawn-config-auto-detect.test.ts` covers the gateway branch directly (raw env key, runtime-settings key, custom-base-URL bypass attempt, keyless host, model pass-through, single-var-off) and is now hermetic against host gateway vars.

- Real-LLM trajectories: N/A — env-assembly/config logic only; no prompt, action, provider-context, or model-behavior change.
- Screenshots/video/frontend logs: N/A — no UI surface.
