### PR TITLE
test(ui): seed the #11084 auth gate in home-widget stories — fix 13 chat-stories-smoke hangs

### DIFF
--- a/packages/ui/src/components/chat/widgets/model-download.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from "../../../services/local-inference/types";
 import {
   assert,
+  WithAuthenticatedSession,
   waitForTestId,
 } from "../../../storybook/home-widget-decorator";
 import { MockAppProvider } from "../../../storybook/mock-providers";
@@ -108,9 +109,13 @@ function withHub(snapshot: ModelHubSnapshot): Decorator {
     }, 4_000);
     return (
       <MockAppProvider value={{ plugins: [], conversations: [] }}>
-        <div className="w-[360px] rounded-2xl bg-accent/20 p-3">
-          <Story />
-        </div>
+        {/* The hub fetch gates on `useIsAuthenticated()` (#11084); seed the
+            authenticated session or the widget stays dormant and self-hides. */}
+        <WithAuthenticatedSession>
+          <div className="w-[360px] rounded-2xl bg-accent/20 p-3">
+            <Story />
+          </div>
+        </WithAuthenticatedSession>
       </MockAppProvider>
     );
   };

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -133,6 +133,24 @@ export function useIsAuthenticated(): boolean {
   return state.phase === "authenticated";
 }
 
+/**
+ * Test/story seam for the #11084 auth gate: publish a synthetic status into the
+ * shared snapshot (and to subscribers) so `useIsAuthenticated`-gated loaders
+ * run without a live `/api/auth/me` probe. Harness-only — the jsdom story
+ * smoke + browser story gate have no auth backend, so without this the
+ * snapshot stays `loading` forever and every gated widget self-hides (the
+ * home-screen e2e solves the same gap by aliasing this module to
+ * `home-screen-fixture.auth-stub.ts`). Returns a restore that re-publishes
+ * the previous snapshot. Never call from product code.
+ */
+export function __setAuthStatusForTests(state: AuthStatusState): () => void {
+  const previous = authStatusSnapshot;
+  publishAuthStatus(state);
+  return () => {
+    publishAuthStatus(previous);
+  };
+}
+
 export function useAuthStatus(options: UseAuthStatusOptions = {}): {
   state: AuthStatusState;
   refetch: () => void;

--- a/packages/ui/src/storybook/home-widget-decorator.tsx
+++ b/packages/ui/src/storybook/home-widget-decorator.tsx
@@ -1,12 +1,51 @@
 import type { Decorator } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
 import {
+  __setAuthStatusForTests,
+  type AuthStatusState,
+} from "../hooks/useAuthStatus";
+import {
   HOME_WIDGET_MOCK_PLUGINS,
   installHomeWidgetFetchMock,
   seedHomeWidgetAppStore,
   seedHomeWidgetNotifications,
 } from "../widgets/__fixtures__/home-widget-mock-data";
 import { MockAppProvider } from "./mock-providers";
+
+/**
+ * Authenticated local session for stories. Since #11084 (#11107/#11122) every
+ * home/sidebar widget poller gates on `useIsAuthenticated()` before fetching;
+ * stories have no auth backend, so without seeding this the shared snapshot
+ * stays `loading` forever and every gated widget renders null (the play
+ * functions then poll to the test timeout). Mirrors the home-screen e2e's
+ * `home-screen-fixture.auth-stub.ts`.
+ */
+const STORY_AUTHENTICATED_SESSION: AuthStatusState = {
+  phase: "authenticated",
+  identity: { id: "story-owner", displayName: "Story Owner", kind: "owner" },
+  session: { id: "story-session", kind: "local", expiresAt: null },
+  access: { mode: "local", passwordConfigured: false, ownerConfigured: true },
+};
+
+/**
+ * Publish the authenticated session BEFORE `children` render (a `useState`
+ * initializer runs synchronously ahead of the child tree) and restore the
+ * previous snapshot on unmount — so gated widget loaders run during the story
+ * and later tests in the same jsdom module see the untouched snapshot.
+ */
+export function WithAuthenticatedSession({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const restoreAuth = useRef<(() => void) | null>(null);
+  useState(() => {
+    restoreAuth.current = __setAuthStatusForTests(STORY_AUTHENTICATED_SESSION);
+    return null;
+  });
+  useEffect(() => () => restoreAuth.current?.(), []);
+  return <>{children}</>;
+}
 
 /**
  * Seed the home-widget data BEFORE the widget subtree renders, so each widget's
@@ -39,11 +78,13 @@ export const withSeededHomeWidget: Decorator = (Story) => (
   <MockAppProvider
     value={{ plugins: HOME_WIDGET_MOCK_PLUGINS, conversations: [] }}
   >
-    <SeededHomeWidgetData>
-      <div className="w-[360px] bg-accent/20 p-3">
-        <Story />
-      </div>
-    </SeededHomeWidgetData>
+    <WithAuthenticatedSession>
+      <SeededHomeWidgetData>
+        <div className="w-[360px] bg-accent/20 p-3">
+          <Story />
+        </div>
+      </SeededHomeWidgetData>
+    </WithAuthenticatedSession>
   </MockAppProvider>
 );
 


### PR DESCRIPTION
## What

Fixes 13 deterministic 5s-timeout hangs in `packages/ui/src/components/chat/__tests__/chat-stories-smoke.test.tsx`: the `NeedsAttention` story across 7 home/chat widgets (calendar-upcoming, finances-alerts, goals-attention, health-sleep, inbox-unread, relationships-attention, needs-attention), the 4 model-download states (Downloading/Loading/Queued/DownloadFailed), and `ClickNavigatesToView`/`ClickPrefillsChat`.

## Root cause — test-harness gap, not a component bug

Since #11107/#11122 every home/chat widget data loader gates on `useIsAuthenticated()` before fetching (#11084). That hook is **observe-only**: it never probes `/api/auth/me` itself — it reads the shared module snapshot, which starts as `{ phase: "loading" }`. The story lanes have no auth backend and nothing ever resolves the snapshot, so every gated widget rendered `null` forever. The stories' `play` functions then polled `waitForTestId` (80 × 100ms = 8s) straight past vitest's 5s timeout — the "hang" was the poll, not a component loop.

**Not demo-visible:** in the real app the shell's `useAuthStatus()` probe resolves the snapshot, and an unauthenticated session sees the login gate rather than the home surface. The home-screen e2e already hit and documented this exact gap and fixed it by aliasing the hook module (`home-screen-fixture.auth-stub.ts`); this PR brings the equivalent seam to the jsdom story smoke + browser story gate.

## Fix

- `hooks/useAuthStatus.ts` — add `__setAuthStatusForTests(state): restore` seam (mirrors the notification-store `__…ForTests` precedent): publish a synthetic snapshot to the shared subscribers, return a restore of the previous one.
- `storybook/home-widget-decorator.tsx` — new `WithAuthenticatedSession` wrapper seeds an authenticated local session in a `useState` initializer (synchronously ahead of the widget subtree) and restores on unmount; wired into `withSeededHomeWidget` (covers the 9 widget-story failures).
- `components/chat/widgets/model-download.stories.tsx` — wrap the `withHub` decorator subtree in `WithAuthenticatedSession` (its hub fetch is gated the same way; covers the 4 model-download failures).

## Evidence

- **Before** (origin/develop tip `16b69a6edf`): `bun run --cwd packages/ui test chat-stories-smoke` → `Tests 13 failed | 130 passed (143)`, every failure `Error: Test timed out in 5000ms`, file wall time 126s.
- **After**: `Tests 143 passed (143)`, tests 4.1s (down from 69s of timeout burn).
- `bun run --cwd packages/ui typecheck` → exit 0; `biome check` clean on the touched files.
- Adjacent suites green: `useDataLoaders.auth-gate.test.tsx`, `needs-attention.test.tsx`, `model-download.test.tsx`, `useHomeModelStatus.test.tsx`, `shell-stories-smoke.test.tsx` (75 passed | 7 skipped).
- Screenshots / video / trajectories: N/A — test-harness-only change (story decorators + a test seam); no product render path altered, no runtime surface to capture.

Signed: nubs-cloud [cloud-frontdoor]