### PR TITLE
fix(cloud-apps): BOOK_INFLUENCER escrow double-hold — keep the idempotency key alive across a failed fund call (#11844)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
@@ -21,9 +21,11 @@ mock.module("@elizaos/cloud-sdk", () => ({
 const { bookInfluencerAction } = await import(
   "../src/actions/book-influencer.ts"
 );
-const { CONFIRM_TTL_MS, persistCloudAppConfirmation } = await import(
-  "../src/safety.ts"
-);
+const {
+  CONFIRM_TTL_MS,
+  findPendingCloudAppConfirmation,
+  persistCloudAppConfirmation,
+} = await import("../src/safety.ts");
 
 function profile(id: string, displayName: string): InfluencerProfileDto {
   return {
@@ -499,5 +501,317 @@ describe("BOOK_INFLUENCER influencer resolution (ambiguity-aware)", () => {
       profileId: "inf_1",
       amount: 40,
     });
+  });
+});
+
+/**
+ * Stateful fake escrow mirroring the SERVER's createBooking/fundBooking
+ * semantics (packages/cloud/shared/src/lib/services/influencer-marketplace.ts):
+ * a keyed debit ledger + a funding→offered finalize, where a same-key call
+ * resumes/replays the original booking without a second debit and a failed
+ * debit retires the funding row. Lets the tests count REAL credit holds across
+ * retries instead of just counting calls — a retry that mints a NEW key funds
+ * a second escrow here exactly like it would in production (#11844).
+ */
+class FakeEscrow {
+  /** Advertiser credit holds, one per funded booking — the money under guard. */
+  holds: Array<{ key: string; amount: number }> = [];
+  bookings = new Map<
+    string,
+    { id: string; status: "funding" | "offered"; amount: number }
+  >();
+  calls: CreateBookingInput[] = [];
+  /** Failure injected into the NEXT fresh (non-resume) fund call. */
+  failNext:
+    | "none"
+    | "response_lost"
+    | "crash_in_funding"
+    | "insufficient_credits" = "none";
+
+  install(): void {
+    setCreateBooking((input) => {
+      this.calls.push(input);
+      const key = input.idempotencyKey ?? `anon-${this.calls.length}`;
+      const existing = this.bookings.get(key);
+      if (existing) {
+        // Same-key resume/replay: drive a crashed `funding` row to `offered`
+        // (or return the already-offered booking) with NO new debit.
+        existing.status = "offered";
+        return Promise.resolve(this.ok(existing, input));
+      }
+      const mode = this.failNext;
+      this.failNext = "none";
+      if (mode === "insufficient_credits") {
+        // Clean business rejection: debit failed, funding row retired —
+        // no hold, no resumable state. Duck-typed CloudApiError (402).
+        return Promise.reject(
+          Object.assign(new Error("Insufficient credits"), {
+            statusCode: 402,
+            errorBody: { success: false, error: "Insufficient credits" },
+          }),
+        );
+      }
+      // The keyed debit — THE hold this whole suite is guarding.
+      this.holds.push({ key, amount: input.amount });
+      const booking = {
+        id: `bk_${this.bookings.size + 1}`,
+        status:
+          mode === "crash_in_funding"
+            ? ("funding" as const)
+            : ("offered" as const),
+        amount: input.amount,
+      };
+      this.bookings.set(key, booking);
+      if (mode === "response_lost" || mode === "crash_in_funding") {
+        // Transport-level failure AFTER the server committed money state:
+        // the client never sees a status code.
+        return Promise.reject(new TypeError("fetch failed: network dropped"));
+      }
+      return Promise.resolve(this.ok(booking, input));
+    });
+  }
+
+  private ok(
+    booking: { id: string; status: "funding" | "offered"; amount: number },
+    input: CreateBookingInput,
+  ) {
+    return {
+      success: true as const,
+      booking: {
+        id: booking.id,
+        advertiser_org_id: "org",
+        influencer_profile_id: input.profileId,
+        amount: String(booking.amount),
+        status: booking.status,
+        brief: input.brief,
+      },
+    };
+  }
+}
+
+describe("BOOK_INFLUENCER escrow idempotency-key survival (#11844)", () => {
+  beforeEach(() => resetSdk());
+
+  function roomOf(runtime: ReturnType<typeof keyedRuntime>): string {
+    return String(runtime.agentId);
+  }
+
+  async function stagePending(
+    runtime: ReturnType<typeof keyedRuntime>,
+  ): Promise<void> {
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      undefined,
+    );
+  }
+
+  async function confirm(runtime: ReturnType<typeof keyedRuntime>) {
+    return bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+  }
+
+  it("lane (a) fund committed + response lost: the pending/key survives and the re-confirm replays the SAME escrow — one hold, one key", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "response_lost";
+    const failed = await confirm(runtime);
+    expect(failed.success).toBe(false);
+    expect(failed.userFacingText).toContain("retry safely");
+    // The server DID commit before the response was lost.
+    expect(escrow.holds.length).toBe(1);
+
+    // The pending survived the transport failure: same task, marked recovery,
+    // still the sole holder of the key the first attempt used.
+    const pending = await findPendingCloudAppConfirmation(
+      runtime,
+      roomOf(runtime),
+      "BOOK_INFLUENCER",
+    );
+    expect(pending).not.toBeNull();
+    expect(pending?.metadata.recovery).toBe(true);
+    expect(escrow.calls[0]?.idempotencyKey).toBe(
+      `influencer-confirm-${pending?.taskId}`,
+    );
+
+    // Re-confirm: the SAME key replays the booking — NO second hold. (Before
+    // the fix the pending died with the first confirm, so this retry carried
+    // a NEW key and funded a SECOND escrow.)
+    const done = await confirm(runtime);
+    expect(done.success).toBe(true);
+    expect(done.data).toMatchObject({ booked: true, recovery: true });
+    expect(escrow.calls.length).toBe(2);
+    expect(escrow.calls[1]?.idempotencyKey).toBe(
+      escrow.calls[0]?.idempotencyKey,
+    );
+    expect(escrow.holds.length).toBe(1);
+    // Settled: the pending (and its key) is done with.
+    expect(
+      await findPendingCloudAppConfirmation(
+        runtime,
+        roomOf(runtime),
+        "BOOK_INFLUENCER",
+      ),
+    ).toBeNull();
+  });
+
+  it("lane (b) crash between keyed debit and finalize: the same-key re-confirm resumes 'funding' to terminal 'offered' with no second debit", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "crash_in_funding";
+    const failed = await confirm(runtime);
+    expect(failed.success).toBe(false);
+    const key = escrow.calls[0]?.idempotencyKey as string;
+    // Stranded server state: debited, stuck in `funding` — no API transition
+    // accepts it; only a same-key retry can repair it.
+    expect(escrow.bookings.get(key)?.status).toBe("funding");
+    expect(escrow.holds.length).toBe(1);
+
+    const done = await confirm(runtime);
+    expect(done.success).toBe(true);
+    expect(escrow.calls[1]?.idempotencyKey).toBe(key);
+    // Repaired to a terminal, user-actionable state — and still one debit.
+    expect(escrow.bookings.get(key)?.status).toBe("offered");
+    expect(escrow.holds.length).toBe(1);
+  });
+
+  it("the recovery retry is TTL-exempt: an aged recovery pending still repairs with the SAME key", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "crash_in_funding";
+    await confirm(runtime);
+    const pending = await findPendingCloudAppConfirmation(
+      runtime,
+      roomOf(runtime),
+      "BOOK_INFLUENCER",
+    );
+    expect(pending?.metadata.recovery).toBe(true);
+    // Age the recovery pending far past the confirm TTL.
+    await runtime.updateTask(pending?.taskId as never, {
+      metadata: {
+        ...pending?.metadata,
+        intentCreatedAt: new Date(
+          Date.now() - CONFIRM_TTL_MS - 60_000,
+        ).toISOString(),
+      },
+    });
+
+    // A plain pending would refuse the bare confirm here; the recovery one
+    // must still complete — expiring it would strand the `funding` debit.
+    const done = await confirm(runtime);
+    expect(done.success).toBe(true);
+    expect(escrow.calls[1]?.idempotencyKey).toBe(
+      escrow.calls[0]?.idempotencyKey,
+    );
+    expect(escrow.holds.length).toBe(1);
+  });
+
+  it("a definite 4xx rejection (insufficient credits) settles the confirm: nothing held, pending deleted, no recovery staged", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "insufficient_credits";
+    const res = await confirm(runtime);
+    expect(res.success).toBe(false);
+    expect(res.data).toMatchObject({
+      reason: "insufficient_credits",
+      booked: false,
+    });
+    expect(res.userFacingText).toContain("nothing was funded");
+    expect(escrow.holds.length).toBe(0);
+    expect(
+      await findPendingCloudAppConfirmation(
+        runtime,
+        roomOf(runtime),
+        "BOOK_INFLUENCER",
+      ),
+    ).toBeNull();
+
+    // No zombie retry: a later bare confirm has nothing to fund.
+    const again = await confirm(runtime);
+    expect(again.data).toMatchObject({ reason: "no_pending_confirmation" });
+    expect(escrow.calls.length).toBe(1);
+  });
+
+  it("canceling a recovery pending deletes it and is honest that the escrow may already be held", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "response_lost";
+    await confirm(runtime);
+
+    const res = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("no, cancel"),
+      undefined,
+      { confirm: false },
+      undefined,
+    );
+    expect(res.data).toMatchObject({ canceled: true, recovery: true });
+    expect(res.userFacingText).toContain("may already exist");
+    expect(
+      await findPendingCloudAppConfirmation(
+        runtime,
+        roomOf(runtime),
+        "BOOK_INFLUENCER",
+      ),
+    ).toBeNull();
+    // Canceling never silently funded anything new.
+    expect(escrow.calls.length).toBe(1);
+    expect(escrow.holds.length).toBe(1);
+  });
+
+  it("a new ask while a recovery pending waits re-prompts the safe retry instead of minting a new key", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "response_lost";
+    await confirm(runtime);
+
+    // A fresh phase-1 ask (different influencer) must not stack a second
+    // pending — the recovery (and its key) stays the one thing to settle.
+    const ask = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Mallory for $500"),
+      undefined,
+      { profileId: "inf_2", influencer: "Mallory", amount: 500, brief: "x" },
+      undefined,
+    );
+    expect(ask.data).toMatchObject({
+      confirmationRequired: true,
+      profileId: "inf_1",
+      amount: 200,
+    });
+    expect(ask.userFacingText).toContain("retry safely");
+
+    const done = await confirm(runtime);
+    expect(done.success).toBe(true);
+    expect(escrow.calls.length).toBe(2);
+    expect(escrow.calls[1]?.idempotencyKey).toBe(
+      escrow.calls[0]?.idempotencyKey,
+    );
+    expect(escrow.holds.length).toBe(1);
   });
 });

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -133,7 +133,12 @@ type ListAppDomainsFn = (id: string) => Promise<ListAppDomainsResponse>;
 
 type CloudAppsTestRuntime = Pick<
   IAgentRuntime,
-  "agentId" | "getSetting" | "getTasks" | "createTask" | "deleteTask"
+  | "agentId"
+  | "getSetting"
+  | "getTasks"
+  | "createTask"
+  | "updateTask"
+  | "deleteTask"
 >;
 
 interface SdkState {
@@ -709,6 +714,11 @@ export function makeRuntime(
       });
       return Promise.resolve(id);
     },
+    updateTask: (id: UUID, patch: Partial<Task>) => {
+      const idx = tasks.findIndex((task) => task.id === id);
+      if (idx >= 0) tasks[idx] = { ...tasks[idx], ...patch };
+      return Promise.resolve();
+    },
     deleteTask: (id: UUID) => {
       const idx = tasks.findIndex((task) => task.id === id);
       if (idx >= 0) tasks.splice(idx, 1);
@@ -767,6 +777,11 @@ export function memoryRuntime(
         `task-0000-0000-0000-${String(++taskCounter).padStart(12, "0")}` as UUID;
       tasks.push({ ...task, id, agentId: task.agentId ?? TEST_AGENT_ID });
       return Promise.resolve(id);
+    },
+    updateTask: (id: UUID, patch: Partial<Task>) => {
+      const idx = tasks.findIndex((task) => task.id === id);
+      if (idx >= 0) tasks[idx] = { ...tasks[idx], ...patch };
+      return Promise.resolve();
     },
     deleteTask: (id: UUID) => {
       const idx = tasks.findIndex((task) => task.id === id);

--- a/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
+++ b/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
@@ -16,7 +16,13 @@
  *   - a budget needs an explicit currency cue — a bare number in the message is
  *     never treated as dollars,
  *   - influencer names resolve through the ambiguity-aware matcher (client.ts);
- *     ties ask the user instead of booking a lookalike profile.
+ *     ties ask the user instead of booking a lookalike profile,
+ *   - the pending is deleted only AFTER the fund call resolves (#11844): its
+ *     taskId is the sole holder of the escrow idempotency key
+ *     (`influencer-confirm-<taskId>`), so on a transport-level failure the
+ *     pending is kept and marked `recovery: true` — a re-confirm re-sends the
+ *     SAME key and the server resumes/dedupes the exact booking (its funding
+ *     resume) instead of funding a second escrow.
  */
 
 import type { InfluencerProfileDto } from "@elizaos/cloud-sdk";
@@ -34,12 +40,15 @@ import {
   matchByReference,
   type ReferenceMatch,
   resolveCloudApiKey,
+  resolveCloudSiteBaseUrl,
 } from "../client.js";
+import { cloudErrorInfo } from "../domain-intent.js";
 import {
   CONFIRM_TTL_MS,
   confirmationRoomId,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
+  markCloudAppConfirmationRecovery,
   pendingExpired,
   persistCloudAppConfirmation,
   readStructuredConfirmation,
@@ -204,8 +213,26 @@ export const bookInfluencerAction: Action = {
           data: { reason: "no_pending_confirmation" },
         };
       }
-      await deleteCloudAppConfirmation(runtime, pending.taskId);
+      const isRecovery = pending.metadata.recovery === true;
       if (confirmation === false) {
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
+        if (isRecovery) {
+          // The earlier fund attempt failed at the transport level, so the
+          // escrow may already be held server-side. Never claim "nothing
+          // happened" — tell the user where to check and how to get a refund.
+          const bookingsUrl = `${resolveCloudSiteBaseUrl(runtime)}/dashboard/marketing/influencers`;
+          const msg =
+            `Okay — I won't retry that booking. Heads up: my earlier attempt to fund ${pending.metadata.appName} for ${usd(pending.metadata.amount)} didn't confirm either way, ` +
+            `so the booking may already exist with the budget held in escrow. Check your bookings at ${bookingsUrl} — if it's there you can cancel it for a full refund.`;
+          await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+          return {
+            success: true,
+            text: `Recovery retry for ${pending.metadata.appName} canceled; the earlier attempt may have funded the escrow.`,
+            userFacingText: msg,
+            verifiedUserFacing: true,
+            data: { booked: false, canceled: true, recovery: true },
+          };
+        }
         await callback?.({
           text: CANCELED_MESSAGE,
           actions: ["BOOK_INFLUENCER"],
@@ -218,7 +245,10 @@ export const bookInfluencerAction: Action = {
           data: { booked: false, canceled: true },
         };
       }
+      // A recovery retry never expires (safety.ts): it resumes/replays money
+      // already committed under the same key rather than staging a new charge.
       if (pendingExpired(pending)) {
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
         const msg =
           `That booking request for ${pending.metadata.appName} is more than ${Math.round(CONFIRM_TTL_MS / 60000)} minutes old, so I didn't fund anything. ` +
           `Ask me to book ${pending.metadata.appName} again and I'll re-confirm the details.`;
@@ -236,10 +266,16 @@ export const bookInfluencerAction: Action = {
           profileId: pending.metadata.appId,
           brief: pending.metadata.brief,
           amount: pending.metadata.amount,
-          // Stable per-confirmation key: a transport-level retry of this
-          // confirm cannot fund a second escrow (server dedupes on it).
+          // Stable per-confirmation key: the server dedupes/resumes on it, so
+          // a retry of this confirm can never fund a second escrow. The
+          // pending task is that key's ONLY holder — it must outlive any
+          // transport failure of this call (#11844).
           idempotencyKey: `influencer-confirm-${pending.taskId}`,
         });
+        // The server resolved the fund call at the business level (success or
+        // a clean rejection with no money held) — only now is the pending
+        // (and the idempotency key its taskId carries) done with.
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
         if (!result.success) {
           const msg = result.error
             ? `I couldn't fund that booking: ${result.error}`
@@ -252,7 +288,9 @@ export const bookInfluencerAction: Action = {
             data: { reason: "error" },
           };
         }
-        const reply = `Booked ${pending.metadata.appName} for ${usd(pending.metadata.amount)} — the budget is held in escrow and released when you approve their deliverable.`;
+        const reply = isRecovery
+          ? `Booked ${pending.metadata.appName} for ${usd(pending.metadata.amount)} — the retry completed the earlier attempt, so you were charged exactly once. The budget is held in escrow and released when you approve their deliverable.`
+          : `Booked ${pending.metadata.appName} for ${usd(pending.metadata.amount)} — the budget is held in escrow and released when you approve their deliverable.`;
         await callback?.({ text: reply, actions: ["BOOK_INFLUENCER"] });
         return {
           success: true,
@@ -263,19 +301,60 @@ export const bookInfluencerAction: Action = {
             booked: true,
             booking: { id: result.booking?.id },
             amount: pending.metadata.amount,
+            ...(isRecovery ? { recovery: true } : {}),
           },
         };
       } catch (err) {
+        const info = cloudErrorInfo(err);
         logger.warn(
-          `[BOOK_INFLUENCER] createBooking failed: ${err instanceof Error ? err.message : String(err)}`,
+          `[BOOK_INFLUENCER] createBooking failed (${info.status ?? "transport"}/${info.code ?? "-"}): ${info.message}`,
         );
-        await callback?.({ text: ERROR_MESSAGE, actions: ["BOOK_INFLUENCER"] });
+        if (info.status !== null && info.status < 500) {
+          // The server answered with a definite rejection — no escrow was
+          // held (a failed debit retires the funding row server-side), so the
+          // confirm is settled and the pending can go.
+          await deleteCloudAppConfirmation(runtime, pending.taskId);
+          if (info.status === 402) {
+            const billingUrl = `${resolveCloudSiteBaseUrl(runtime)}/dashboard/billing`;
+            const msg =
+              `Not enough credits to book ${pending.metadata.appName} for ${usd(pending.metadata.amount)} — nothing was funded. ` +
+              `Add credits and ask me again: ${billingUrl}`;
+            await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+            return {
+              success: false,
+              text: "Insufficient credits for the booking.",
+              userFacingText: msg,
+              verifiedUserFacing: true,
+              data: { reason: "insufficient_credits", booked: false },
+            };
+          }
+          const msg = `I couldn't fund that booking: ${info.message}. Nothing was funded.`;
+          await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+          return {
+            success: false,
+            text: `Booking rejected: ${info.message}`,
+            userFacingText: msg,
+            error: err instanceof Error ? err : new Error(String(err)),
+            data: { reason: "error", booked: false },
+          };
+        }
+        // Transport failure or 5xx: the outcome is UNKNOWN — the escrow may
+        // be fully funded (response lost) or stranded mid-funding. KEEP the
+        // pending and mark it recovery: its taskId is the sole holder of the
+        // idempotency key, so a re-confirm re-sends the SAME key and the
+        // server's funding resume finishes or replays the exact booking —
+        // never a second hold (#11844).
+        await markCloudAppConfirmationRecovery(runtime, pending);
+        const msg =
+          `I couldn't confirm whether the booking of ${pending.metadata.appName} for ${usd(pending.metadata.amount)} was funded — the Cloud API didn't answer. ` +
+          `Reply to confirm again and I'll retry safely: the retry completes or replays this same booking and can never charge you twice. Or cancel and I'll leave it.`;
+        await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
         return {
           success: false,
-          text: "Booking failed.",
-          userFacingText: ERROR_MESSAGE,
+          text: `Fund call for ${pending.metadata.appName} failed in transit; kept the pending for a same-key retry.`,
+          userFacingText: msg,
           error: err instanceof Error ? err : new Error(String(err)),
-          data: { reason: "error" },
+          data: { reason: "error", booked: false, recovery: true },
         };
       }
     }
@@ -284,13 +363,17 @@ export const bookInfluencerAction: Action = {
     // Never stack pendings: while a fresh one is waiting, re-prompt for it so a
     // later bare confirm can only ever fund the booking the user was shown.
     if (pending && !pendingExpired(pending)) {
+      const label = `${pending.metadata.appName}${
+        typeof pending.metadata.amount === "number"
+          ? ` for ${usd(pending.metadata.amount)}`
+          : ""
+      }`;
       const stillMsg =
-        `The booking of ${pending.metadata.appName}${
-          typeof pending.metadata.amount === "number"
-            ? ` for ${usd(pending.metadata.amount)}`
-            : ""
-        } is still waiting for confirmation. ` +
-        `Reply with a clear confirmation or cancellation.`;
+        pending.metadata.recovery === true
+          ? `My earlier attempt to fund the booking of ${label} didn't confirm either way. ` +
+            `Reply to confirm and I'll retry safely — it completes or replays that same booking and can never charge you twice. Or cancel to leave it.`
+          : `The booking of ${label} is still waiting for confirmation. ` +
+            `Reply with a clear confirmation or cancellation.`;
       await callback?.({ text: stillMsg, actions: ["BOOK_INFLUENCER"] });
       return {
         success: true,

--- a/plugins/plugin-cloud-apps/src/safety.ts
+++ b/plugins/plugin-cloud-apps/src/safety.ts
@@ -71,9 +71,13 @@ export interface CloudAppConfirmationMetadata {
   /** The exact domain a pending BUY_APP_DOMAIN confirmation is for. */
   domain?: string;
   /**
-   * True when the pending BUY_APP_DOMAIN is a recovery retry of a purchase
-   * that already charged + registered but failed to attach (the server
-   * finishes it without a new charge).
+   * True when the pending is a recovery retry of a money move whose earlier
+   * attempt already (or may already) have committed server-side:
+   * BUY_APP_DOMAIN — the purchase charged + registered but failed to attach
+   * (the server finishes it without a new charge); BOOK_INFLUENCER — the fund
+   * call failed at the transport level, so the escrow may already be held and
+   * the pending's taskId is the sole holder of the idempotency key the server
+   * dedupes/resumes on. Recovery retries complete without a second charge.
    */
   recovery?: boolean;
   cta?: ConnectorCta;
@@ -101,9 +105,10 @@ export const CONFIRM_TTL_MS = 15 * 60 * 1000;
 /**
  * True when a pending confirmation is older than {@link CONFIRM_TTL_MS}.
  *
- * A BUY_APP_DOMAIN recovery retry never expires: it completes with no new
- * charge — there is no stale price to protect, and expiring it would strand a
- * paid, unattached domain.
+ * A recovery retry never expires: it completes with no new charge — there is
+ * no stale price to protect, and expiring it would strand money already
+ * committed server-side (a paid, unattached domain; an influencer escrow whose
+ * idempotency key only the pending still holds).
  */
 export function pendingExpired(
   pending: PendingCloudAppConfirmation,
@@ -214,6 +219,33 @@ export async function persistCloudAppConfirmation(
       intentCreatedAt: metadata.intentCreatedAt ?? new Date().toISOString(),
     },
   });
+}
+
+/**
+ * Mark an existing pending confirmation as a recovery retry IN PLACE.
+ *
+ * The task is updated, never deleted + re-created: for BOOK_INFLUENCER the
+ * taskId is the escrow idempotency key (`influencer-confirm-<taskId>`), so a
+ * re-created task would mint a new key and let a user retry fund a SECOND
+ * escrow instead of resuming the first (#11844). Failures are logged and
+ * swallowed — the pending (and its key) survives either way; only the TTL
+ * exemption is best-effort.
+ */
+export async function markCloudAppConfirmationRecovery(
+  runtime: IAgentRuntime,
+  pending: PendingCloudAppConfirmation,
+): Promise<void> {
+  try {
+    await runtime.updateTask(pending.taskId as UUID, {
+      metadata: { ...pending.metadata, recovery: true },
+    });
+  } catch (err) {
+    logger.warn(
+      `[plugin-cloud-apps] failed to mark confirm task ${pending.taskId} as recovery: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
 }
 
 export async function deleteCloudAppConfirmation(


### PR DESCRIPTION
## Summary

Fixes #11844 — `BOOK_INFLUENCER` deleted its pending-confirmation task (the **sole holder** of the `influencer-confirm-<taskId>` escrow idempotency key) **before** `client.createBooking()` resolved, and never restored it on a thrown call. Since `@elizaos/cloud-sdk` `request()` does no retry, any transport-level failure lost the key forever:

- **lane (a)** fund committed, response lost → the user's retry minted a NEW key → the server correctly funded a **second escrow** (double hold of the advertiser's credits);
- **lane (b)** worker crash between the keyed debit and the finalize CAS → debit stranded in status `funding`, which **no** API transition accepts — the service's designed same-key repair (its own *"funding resume: crash between keyed debit and finalize is repaired by a same-key retry without a second debit"* test) was **unreachable** from the agent path.

## Fix (delete-after-resolve + recovery, per the `BUY_APP_DOMAIN` precedent)

`plugins/plugin-cloud-apps/src/actions/book-influencer.ts` phase 2:

- The pending is deleted only **after** `createBooking` resolves at the business level: success, a clean `success:false`, or a **definite 4xx** rejection (server-verified no-money outcomes — a failed debit retires the unfunded `funding` row server-side; there is no 4xx path after money moves).
- On a **transport failure or 5xx** (outcome UNKNOWN) the pending is **kept** and marked `recovery: true` **in place** — new `markCloudAppConfirmationRecovery()` in `safety.ts` uses `runtime.updateTask`, never delete+recreate, so the taskId (= the idempotency key) survives. A re-confirm re-sends the **SAME** key → the server resumes lane (b) via its funding resume or replays lane (a)'s success — never a second hold.
- Recovery pendings are TTL-exempt (`pendingExpired` already exempts `recovery === true`; expiring one would strand the `funding` debit) and get honest recovery-aware prompts: the re-prompt and failure reply say the retry "completes or replays this same booking and can never charge you twice"; **canceling** a recovery says the escrow *may already be held* and points at the dashboard bookings for a full-refund cancel — never "nothing happened".
- 402 maps to an honest insufficient-credits reply with the billing URL (mirrors `BUY_APP_DOMAIN`).
- CAS finalize + every existing guard (15-min TTL, no-stacking, currency cue, ambiguity-aware resolution) untouched; concurrent double-confirms still collapse on the server's `influencer_bookings_idempotency_key_uidx` as before.

## Evidence

**New regression suite** (`__tests__/book-influencer.test.ts`, "escrow idempotency-key survival (#11844)"): a stateful `FakeEscrow` mirrors the server's `createBooking`/`fundBooking` semantics — keyed debit ledger, `funding→offered` finalize, same-key resume without a new debit — so the tests count **real credit holds across retries**, not call counts. A retry that mints a new key funds a second escrow in the fake exactly like production would, which is what the old code did.

- lane (a) response lost after commit → pending survives w/ `recovery:true`, re-confirm carries the **same** key, booking replays: **1 hold, 1 key**, pending settled;
- lane (b) crash-in-funding → stranded `funding` + 1 hold; same-key re-confirm resumes to terminal `offered`, **still 1 hold**;
- aged recovery pending still repairs (TTL-exempt) with the same key;
- definite 402 → **0 holds**, pending deleted, no zombie retry (`no_pending_confirmation` after);
- recovery cancel deletes the pending + honest "may already exist … cancel it for a full refund" reply, funds nothing new;
- a fresh ask during recovery re-prompts the safe retry instead of minting a new key.

**Runs (local, symlinked-deps worktree):**

```
plugins/plugin-cloud-apps  bun test                          294 pass / 0 fail (28 files)
plugins/plugin-cloud-apps  bun test __tests__/book-influencer.test.ts   20 pass (14 existing + 6 new)
plugins/plugin-cloud-apps  bun run typecheck (tsgo --noEmit)  clean
biome check (4 touched files)                                clean
packages/cloud/shared      bun test influencer-marketplace.test.ts      17 pass / 0 fail (real PGlite)
```

The last run re-proves the server half of the loop at tip — including the funding-resume test this fix finally makes reachable from the agent path. No server code changed.

Real-LLM trajectory: N/A — no prompt/planner-visible surface changed (same action name/parameters/confirm protocol; only the post-confirm ordering, error taxonomy, and reply copy). The two-phase confirm protocol itself stays covered by `test/scenarios/cloud-apps-structured-confirm.scenario.ts`.
UI screenshots/video: N/A — connector-text-only agent action, no rendered UI surface.

## Out of scope (flagged, per the issue)

The issue's optional server-side belt-and-suspenders — a reconcile for **aged** `funding` rows (refund gated on the keyed debit tx actually existing) — is a server money change left to the maintainer lane; it would cover the residual sub-lane where a user cancels the recovery after a mid-fund crash instead of re-confirming (the cancel reply is now honest about it). Happy to follow up if wanted.

> **MONEY PATH — maintainer review requested.** Touches the escrow funding confirm flow (plugin side only). Please eyeball the delete-after-resolve ordering and the 4xx-settles / 5xx-recovers split before merge. Do not squash-merge from a stale base.

[cloud-security]
