### PR TITLE
fix(cloud-apps): keep BOOK_INFLUENCER pending until fund resolves — no stranded escrow on transport failure (#11844)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
@@ -158,6 +158,69 @@ describe("BOOK_INFLUENCER (two-phase money confirm)", () => {
     expect(captured?.idempotencyKey).toMatch(/^influencer-confirm-.+/);
   });
 
+  it("a transport failure keeps the pending so a retry reuses the SAME escrow idempotency key (#11844)", async () => {
+    const runtime = keyedRuntime();
+    const keys: string[] = [];
+    let n = 0;
+    setCreateBooking((i) => {
+      keys.push(i.idempotencyKey ?? "");
+      n += 1;
+      // First fund attempt: a transport-level failure (thrown, no response).
+      if (n === 1) return Promise.reject(new Error("network down"));
+      return Promise.resolve({
+        success: true,
+        booking: {
+          id: "bk",
+          advertiser_org_id: "o",
+          influencer_profile_id: i.profileId,
+          amount: String(i.amount),
+          status: "offered",
+          brief: i.brief,
+        },
+      });
+    });
+
+    // Phase 1 — ask persists a pending (the sole holder of the idempotency key).
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova to promote my app for $200"),
+      undefined,
+      {
+        profileId: "inf_1",
+        influencer: "Nova",
+        amount: 200,
+        brief: "post about us",
+      },
+      captureCallback().callback,
+    );
+
+    // Phase 2 — confirm; the fund call THROWS. Must fail WITHOUT losing the pending.
+    const first = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes confirm"),
+      undefined,
+      { confirm: true },
+      captureCallback().callback,
+    );
+    expect(first.success).toBe(false);
+
+    // Retry the bare confirm — the pending survived, so the fund runs again with
+    // the SAME idempotency key (the escrow service dedups the crash-repair).
+    // Before the fix the pending was deleted BEFORE the throw, so this retry
+    // would find no pending (no_pending_confirmation) and never re-fund.
+    const second = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes confirm"),
+      undefined,
+      { confirm: true },
+      captureCallback().callback,
+    );
+    expect(second.success).toBe(true);
+    expect(keys.length).toBe(2);
+    expect(keys[0]).toMatch(/^influencer-confirm-.+/);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
   it("cancel: no booking", async () => {
     const runtime = keyedRuntime();
     let calls = 0;

--- a/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
+++ b/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
@@ -204,8 +204,9 @@ export const bookInfluencerAction: Action = {
           data: { reason: "no_pending_confirmation" },
         };
       }
-      await deleteCloudAppConfirmation(runtime, pending.taskId);
       if (confirmation === false) {
+        // No fund happens on cancel — safe to consume the pending now.
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
         await callback?.({
           text: CANCELED_MESSAGE,
           actions: ["BOOK_INFLUENCER"],
@@ -219,6 +220,8 @@ export const bookInfluencerAction: Action = {
         };
       }
       if (pendingExpired(pending)) {
+        // No fund happens on expiry — safe to consume the pending now.
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
         const msg =
           `That booking request for ${pending.metadata.appName} is more than ${Math.round(CONFIRM_TTL_MS / 60000)} minutes old, so I didn't fund anything. ` +
           `Ask me to book ${pending.metadata.appName} again and I'll re-confirm the details.`;
@@ -252,6 +255,14 @@ export const bookInfluencerAction: Action = {
             data: { reason: "error" },
           };
         }
+        // Fund SUCCEEDED — the escrow hold is placed, so consume the pending
+        // (the sole holder of the `influencer-confirm-<taskId>` idempotency key)
+        // now. On ANY failure — a returned {success:false} OR a thrown transport
+        // error (catch below) — we deliberately KEEP the pending so the user's
+        // retry reuses the SAME key and the escrow service dedups the crash-
+        // repair, instead of a lost response causing a double escrow-hold or a
+        // stranded, user-unrecoverable `funding` debit (#11844).
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
         const reply = `Booked ${pending.metadata.appName} for ${usd(pending.metadata.amount)} — the budget is held in escrow and released when you approve their deliverable.`;
         await callback?.({ text: reply, actions: ["BOOK_INFLUENCER"] });
         return {


### PR DESCRIPTION
Closes #11844. `[cloud-money]`

**Bug (money):** `book-influencer.ts` phase 2 deleted the pending (sole holder of the `influencer-confirm-<taskId>` escrow idempotency key) BEFORE `createBooking` resolved. A transport failure lost the key → the escrow crash-repair retry became unreachable → double escrow-hold on retry, or a stranded `funding` debit. Found in a [cloud-security] review of #11817 (pre-existing, not that PR's change).

**Fix:** delete the pending only on definitive outcomes (cancel / expiry / fund success). Keep it on ANY fund failure ({success:false} OR thrown) so the retry reuses the same key and the escrow dedups; stale pendings auto-expire via the 15-min TTL.

**Proof:** new regression — **15/0 green**; **red without the fix** (retry finds no pending, second confirm fails, key not reused). biome clean; the file typechecks clean (unrelated ad-* SDK-type errors are pre-existing). Money path — do not self-merge.