### PR TITLE
fix(cloud-apps): gated confirms that name a DIFFERENT target/amount refuse instead of executing the frozen snapshot

### DIFF
--- a/plugins/plugin-cloud-apps/AGENTS.md
+++ b/plugins/plugin-cloud-apps/AGENTS.md
@@ -35,6 +35,9 @@ src/
                          persist/find/deleteCloudAppConfirmation (task-backed, room-scoped),
                          CONFIRM_TTL_MS + pendingExpired (shared 15-min pending TTL; expired
                          pendings refuse the bare confirm and are re-stated/re-quoted),
+                         conflictingConfirmTarget/Amount/Domain (frozen-target guard: a confirm
+                         whose own params name a different target/amount refuses + clears the
+                         pending instead of executing the frozen snapshot),
                          confirmationPrompt, buildConnectorCta (label+https URL only — never a
                          secret/amount). CloudAppConfirmationAction is the gated-action union.
   deploy-gate.ts         runDeployGate: poll deploy status → READY, then reachability-probe the
@@ -112,6 +115,17 @@ bun run --cwd plugins/plugin-cloud-apps build       # bun build.ts
   planner's structured `confirm: true` for that pending task, using the params
   FROZEN at the first ask — never re-parsed from the follow-up text, never from
   English keyword matching (so non-English confirmations work).
+- **A confirm that names a DIFFERENT target/amount refuses (frozen-target
+  guard).** When the confirm turn's own structured params clearly name another
+  target than the frozen snapshot ("yes — delete Beta Dashboard" while the
+  pending delete is for Acme Bot; a different domain, influencer, or a
+  different structured amount), the gated action refuses, clears the pending,
+  and asks the user to re-state — it never executes the frozen target the user
+  is no longer talking about, and never silently switches to the new one.
+  Helpers: `conflictingConfirmTarget` / `conflictingConfirmAmount` /
+  `conflictingConfirmDomain` (safety.ts). Deliberately lenient: bare confirms,
+  partial names of the SAME target, and generic filler ("my app") never block,
+  and prose is never parsed.
 - **Secrets/money never transit the connector.** CTAs (`buildConnectorCta`) carry
   a label + an https URL only. Created/rotated API keys are surfaced once and
   never logged.

--- a/plugins/plugin-cloud-apps/CLAUDE.md
+++ b/plugins/plugin-cloud-apps/CLAUDE.md
@@ -35,6 +35,9 @@ src/
                          persist/find/deleteCloudAppConfirmation (task-backed, room-scoped),
                          CONFIRM_TTL_MS + pendingExpired (shared 15-min pending TTL; expired
                          pendings refuse the bare confirm and are re-stated/re-quoted),
+                         conflictingConfirmTarget/Amount/Domain (frozen-target guard: a confirm
+                         whose own params name a different target/amount refuses + clears the
+                         pending instead of executing the frozen snapshot),
                          confirmationPrompt, buildConnectorCta (label+https URL only — never a
                          secret/amount). CloudAppConfirmationAction is the gated-action union.
   deploy-gate.ts         runDeployGate: poll deploy status → READY, then reachability-probe the
@@ -112,6 +115,17 @@ bun run --cwd plugins/plugin-cloud-apps build       # bun build.ts
   planner's structured `confirm: true` for that pending task, using the params
   FROZEN at the first ask — never re-parsed from the follow-up text, never from
   English keyword matching (so non-English confirmations work).
+- **A confirm that names a DIFFERENT target/amount refuses (frozen-target
+  guard).** When the confirm turn's own structured params clearly name another
+  target than the frozen snapshot ("yes — delete Beta Dashboard" while the
+  pending delete is for Acme Bot; a different domain, influencer, or a
+  different structured amount), the gated action refuses, clears the pending,
+  and asks the user to re-state — it never executes the frozen target the user
+  is no longer talking about, and never silently switches to the new one.
+  Helpers: `conflictingConfirmTarget` / `conflictingConfirmAmount` /
+  `conflictingConfirmDomain` (safety.ts). Deliberately lenient: bare confirms,
+  partial names of the SAME target, and generic filler ("my app") never block,
+  and prose is never parsed.
 - **Secrets/money never transit the connector.** CTAs (`buildConnectorCta`) carry
   a label + an https URL only. Created/rotated API keys are surfaced once and
   never logged.

--- a/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
@@ -207,6 +207,92 @@ describe("BOOK_INFLUENCER (two-phase money confirm)", () => {
     expect(res.success).toBe(false);
     expect(res.data).toMatchObject({ reason: "no_pending_confirmation" });
   });
+
+  it("MONEY: confirm naming a DIFFERENT influencer refuses, funds nothing, clears the pending", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova to promote my app for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      captureCallback().fn,
+    );
+
+    const cb = captureCallback();
+    const result = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes — book Blaze instead"),
+      undefined,
+      { parameters: { confirm: true, influencer: "Blaze" } },
+      cb.fn,
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(result.success).toBe(false);
+    expect((result.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+    const reply = cb.calls.at(-1)?.text ?? "";
+    expect(reply).toContain("Blaze");
+    expect(reply).toContain("Nova");
+
+    // Pending cleared: a later bare confirm cannot fund the stale booking.
+    const followUp = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      captureCallback().fn,
+    );
+    expect(calls).toHaveLength(0);
+    expect((followUp.data as { reason: string }).reason).toBe(
+      "no_pending_confirmation",
+    );
+  });
+
+  it("MONEY: confirm carrying a DIFFERENT structured budget refuses (frozen $200 vs turn $999)", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBookings();
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      captureCallback().fn,
+    );
+    const result = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("confirm at $999"),
+      undefined,
+      { parameters: { confirm: true, amount: 999 } },
+      captureCallback().fn,
+    );
+    expect(calls).toHaveLength(0);
+    expect((result.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+
+    // Re-ask + a confirm that re-names the SAME influencer and budget books.
+    await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("hire Nova for $200"),
+      undefined,
+      { profileId: "inf_1", influencer: "Nova", amount: 200, brief: "post" },
+      captureCallback().fn,
+    );
+    const ok = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes book Nova for $200"),
+      undefined,
+      { parameters: { confirm: true, influencer: "Nova", amount: 200 } },
+      captureCallback().fn,
+    );
+    expect(ok.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.amount).toBe(200);
+    expect(calls[0]?.profileId).toBe("inf_1");
+  });
 });
 
 describe("BOOK_INFLUENCER pending-stacking + TTL guards", () => {
@@ -809,6 +895,52 @@ describe("BOOK_INFLUENCER escrow idempotency-key survival (#11844)", () => {
     const done = await confirm(runtime);
     expect(done.success).toBe(true);
     expect(escrow.calls.length).toBe(2);
+    expect(escrow.calls[1]?.idempotencyKey).toBe(
+      escrow.calls[0]?.idempotencyKey,
+    );
+    expect(escrow.holds.length).toBe(1);
+  });
+
+  it("a mismatched confirm against a recovery pending refuses but keeps the same-key repair pending alive", async () => {
+    const runtime = keyedRuntime();
+    const escrow = new FakeEscrow();
+    escrow.install();
+    await stagePending(runtime);
+
+    escrow.failNext = "response_lost";
+    await confirm(runtime);
+    const pending = await findPendingCloudAppConfirmation(
+      runtime,
+      roomOf(runtime),
+      "BOOK_INFLUENCER",
+    );
+    expect(pending?.metadata.recovery).toBe(true);
+
+    const mismatch = await bookInfluencerAction.handler(
+      runtime,
+      makeMessage("yes, book Mallory instead"),
+      undefined,
+      { parameters: { confirm: true, influencer: "Mallory" } },
+      undefined,
+    );
+    expect(mismatch.success).toBe(false);
+    expect(mismatch.data).toMatchObject({
+      reason: "confirm_target_mismatch",
+      recovery: true,
+    });
+    expect(escrow.calls.length).toBe(1);
+    expect(escrow.holds.length).toBe(1);
+
+    const stillPending = await findPendingCloudAppConfirmation(
+      runtime,
+      roomOf(runtime),
+      "BOOK_INFLUENCER",
+    );
+    expect(stillPending?.taskId).toBe(pending?.taskId);
+    expect(stillPending?.metadata.recovery).toBe(true);
+
+    const repaired = await confirm(runtime);
+    expect(repaired.success).toBe(true);
     expect(escrow.calls[1]?.idempotencyKey).toBe(
       escrow.calls[0]?.idempotencyKey,
     );

--- a/plugins/plugin-cloud-apps/__tests__/buy-app-domain.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/buy-app-domain.test.ts
@@ -336,6 +336,79 @@ describe("BUY_APP_DOMAIN confirm turn", () => {
     expect(replies[0]?.text).toContain("charged $13.99");
   });
 
+  it("MONEY: confirm naming a DIFFERENT domain refuses, buys nothing, clears the pending", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBuys();
+    await stagePurchase(runtime);
+
+    const { fn, calls: replies } = captureCallback();
+    const result = await buyAppDomainAction.handler?.(
+      runtime,
+      makeMessage("yes, buy othersite.net"),
+      undefined,
+      { parameters: { confirm: true, domain: "othersite.net" } },
+      fn,
+    );
+
+    expect(calls.length).toBe(0);
+    expect(result?.success).toBe(false);
+    expect(result?.data?.reason).toBe("confirm_target_mismatch");
+    const reply = replies.at(-1)?.text ?? "";
+    expect(reply).toContain("othersite.net");
+    expect(reply).toContain("example.com");
+
+    // Pending cleared: a later bare confirm cannot buy the stale domain.
+    const followUp = await buyAppDomainAction.handler?.(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      undefined,
+    );
+    expect(calls.length).toBe(0);
+    expect(followUp?.data?.reason).toBe("no_pending_confirmation");
+  });
+
+  it("MONEY: confirm naming a DIFFERENT app refuses, buys nothing", async () => {
+    setListApps(() => Promise.resolve({ success: true, apps: [APP, OTHER] }));
+    const runtime = keyedRuntime();
+    const { calls } = trackBuys();
+    await stagePurchase(runtime);
+
+    const result = await buyAppDomainAction.handler?.(
+      runtime,
+      makeMessage("yes — attach it to Other App"),
+      undefined,
+      { parameters: { confirm: true, appName: "Other App" } },
+      undefined,
+    );
+    expect(calls.length).toBe(0);
+    expect(result?.data?.reason).toBe("confirm_target_mismatch");
+  });
+
+  it("confirm re-naming the SAME domain + app still buys exactly once", async () => {
+    const runtime = keyedRuntime();
+    const { calls } = trackBuys();
+    await stagePurchase(runtime);
+
+    const result = await buyAppDomainAction.handler?.(
+      runtime,
+      makeMessage("confirm buying example.com for Acme Bot"),
+      undefined,
+      {
+        parameters: {
+          confirm: true,
+          domain: "example.com",
+          appName: "Acme Bot",
+        },
+      },
+      undefined,
+    );
+    expect(calls.length).toBe(1);
+    expect(calls[0].input.domain).toBe("example.com");
+    expect(result?.success).toBe(true);
+  });
+
   it("reads confirm from nested options.parameters (real planner path)", async () => {
     const runtime = keyedRuntime();
     const { calls } = trackBuys();

--- a/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
@@ -214,6 +214,89 @@ describe("DELETE_APP", () => {
     expect((result?.data as { reason: string }).reason).toBe("no_key");
   });
 
+  it("confirm naming a DIFFERENT app refuses, deletes nothing, and clears the pending", async () => {
+    const deletes = trackDeletes();
+    const runtime = keyedRuntime();
+    const cb = captureCallback();
+    await deleteAppAction.handler(
+      runtime,
+      makeMessage("delete Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    // Real planner path: params nested under options.parameters.
+    const result = await deleteAppAction.handler(
+      runtime,
+      makeMessage("actually — yes, delete Beta Dashboard"),
+      undefined,
+      { parameters: { confirm: true, appName: "Beta Dashboard" } },
+      cb.fn,
+    );
+
+    expect(deletes.count()).toBe(0);
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+    const reply = cb.calls.at(-1)?.text ?? "";
+    expect(reply).toContain("Beta Dashboard");
+    expect(reply).toContain("Acme Bot");
+
+    // The stale pending is cleared: a follow-up bare confirm cannot delete the
+    // frozen target either.
+    const followUp = await deleteAppAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      cb.fn,
+    );
+    expect(deletes.count()).toBe(0);
+    expect((followUp?.data as { reason: string }).reason).toBe(
+      "no_pending_confirmation",
+    );
+  });
+
+  it("confirm re-naming the SAME app (partial name / generic filler) still deletes", async () => {
+    const deletes = trackDeletes();
+    const runtime = keyedRuntime();
+    await deleteAppAction.handler(
+      runtime,
+      makeMessage("delete Acme Bot"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    const result = await deleteAppAction.handler(
+      runtime,
+      makeMessage("yes delete acme"),
+      undefined,
+      { parameters: { confirm: true, appName: "acme" } },
+      captureCallback().fn,
+    );
+    expect(deletes.count()).toBe(1);
+    expect((result?.data as { deleted: boolean }).deleted).toBe(true);
+
+    // Generic filler ("my app") is not a target switch either.
+    await deleteAppAction.handler(
+      runtime,
+      makeMessage("delete Acme Bot"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    const generic = await deleteAppAction.handler(
+      runtime,
+      makeMessage("yes delete my app"),
+      undefined,
+      { parameters: { confirm: true, appName: "my app" } },
+      captureCallback().fn,
+    );
+    expect(deletes.count()).toBe(2);
+    expect((generic?.data as { deleted: boolean }).deleted).toBe(true);
+  });
+
   it("surfaces a delete API error", async () => {
     setDeleteApp(() => Promise.reject(new Error("boom")));
     const runtime = keyedRuntime();

--- a/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
@@ -193,6 +193,48 @@ describe("REGENERATE_APP_API_KEY", () => {
     expect((result?.data as { reason: string }).reason).toBe("no_key");
   });
 
+  it("confirm naming a DIFFERENT app refuses, rotates nothing, and clears the pending", async () => {
+    const rotations = trackRotations();
+    const runtime = keyedRuntime();
+    const cb = captureCallback();
+    await regenerateAppApiKeyAction.handler(
+      runtime,
+      makeMessage("regenerate the API key for Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    const result = await regenerateAppApiKeyAction.handler(
+      runtime,
+      makeMessage("yes — rotate the key for Beta Dashboard"),
+      undefined,
+      { parameters: { confirm: true, appName: "Beta Dashboard" } },
+      cb.fn,
+    );
+
+    expect(rotations.count()).toBe(0);
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+    const reply = cb.calls.at(-1)?.text ?? "";
+    expect(reply).toContain("Beta Dashboard");
+    expect(reply).toContain("Acme Bot");
+    expect(reply).not.toContain(NEW_KEY);
+
+    const followUp = await regenerateAppApiKeyAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      cb.fn,
+    );
+    expect(rotations.count()).toBe(0);
+    expect((followUp?.data as { reason: string }).reason).toBe(
+      "no_pending_confirmation",
+    );
+  });
+
   it("surfaces a rotate API error", async () => {
     setRegenerateAppApiKey(() => Promise.reject(new Error("boom")));
     const runtime = keyedRuntime();

--- a/plugins/plugin-cloud-apps/__tests__/safety.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/safety.test.ts
@@ -3,6 +3,10 @@ import {
   buildConnectorCta,
   CONFIRM_TTL_MS,
   confirmationPrompt,
+  confirmReferenceMatchesTarget,
+  conflictingConfirmAmount,
+  conflictingConfirmDomain,
+  conflictingConfirmTarget,
   pendingExpired,
   readStructuredConfirmation,
 } from "../src/safety.ts";
@@ -56,6 +60,157 @@ describe("readStructuredConfirmation", () => {
     expect(readStructuredConfirmation({ confirm: "yes" })).toBe(null);
     expect(
       readStructuredConfirmation({ confirm: "delete Acme Bot — yes" }),
+    ).toBe(null);
+  });
+});
+
+describe("confirmReferenceMatchesTarget (frozen-target guard)", () => {
+  it("matches the frozen target by id, exact name, alias, and partial name", () => {
+    expect(confirmReferenceMatchesTarget(TARGET.id, TARGET)).toBe(true);
+    expect(confirmReferenceMatchesTarget("Acme Bot", TARGET)).toBe(true);
+    expect(confirmReferenceMatchesTarget("acme bot", TARGET)).toBe(true);
+    expect(confirmReferenceMatchesTarget("acme-bot", TARGET)).toBe(true);
+    // Partial names of the SAME target must never read as a switch.
+    expect(confirmReferenceMatchesTarget("Acme", TARGET)).toBe(true);
+    // A longer phrase containing the frozen name still matches.
+    expect(confirmReferenceMatchesTarget("the Acme Bot app", TARGET)).toBe(
+      true,
+    );
+  });
+
+  it("treats generic filler as a non-reference (never blocks)", () => {
+    expect(confirmReferenceMatchesTarget("my app", TARGET)).toBe(true);
+    expect(confirmReferenceMatchesTarget("the app", TARGET)).toBe(true);
+    expect(confirmReferenceMatchesTarget("it", TARGET)).toBe(true);
+  });
+
+  it("rejects a clearly different target", () => {
+    expect(confirmReferenceMatchesTarget("Beta Dashboard", TARGET)).toBe(false);
+    expect(
+      confirmReferenceMatchesTarget(
+        "99999999-8888-7777-6666-555555555555",
+        TARGET,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("conflictingConfirmTarget", () => {
+  it("returns null on a bare confirm (no reference sent)", () => {
+    expect(conflictingConfirmTarget({ confirm: true }, TARGET)).toBe(null);
+    expect(
+      conflictingConfirmTarget({ parameters: { confirm: true } }, TARGET),
+    ).toBe(null);
+    expect(conflictingConfirmTarget(undefined, TARGET)).toBe(null);
+  });
+
+  it("returns null when the confirm turn re-names the SAME target", () => {
+    expect(
+      conflictingConfirmTarget(
+        { parameters: { confirm: true, appName: "acme" } },
+        TARGET,
+      ),
+    ).toBe(null);
+  });
+
+  it("returns the conflicting reference when a DIFFERENT target is named (nested planner path)", () => {
+    expect(
+      conflictingConfirmTarget(
+        { parameters: { confirm: true, appName: "Beta Dashboard" } },
+        TARGET,
+      ),
+    ).toBe("Beta Dashboard");
+    expect(
+      conflictingConfirmTarget({ confirm: true, appName: "Beta" }, TARGET),
+    ).toBe("Beta");
+  });
+
+  it("honors custom reference keys (influencer bookings)", () => {
+    expect(
+      conflictingConfirmTarget(
+        { parameters: { confirm: true, influencer: "Bob Creator" } },
+        { name: "Alice Creator", id: "profile-1" },
+        ["profileId", "influencer"],
+      ),
+    ).toBe("Bob Creator");
+    expect(
+      conflictingConfirmTarget(
+        { parameters: { confirm: true, profileId: "profile-1" } },
+        { name: "Alice Creator", id: "profile-1" },
+        ["profileId", "influencer"],
+      ),
+    ).toBe(null);
+  });
+});
+
+describe("conflictingConfirmAmount", () => {
+  it("returns null on a bare confirm or a matching amount", () => {
+    expect(conflictingConfirmAmount({ confirm: true }, 100)).toBe(null);
+    expect(conflictingConfirmAmount({ parameters: { amount: 100 } }, 100)).toBe(
+      null,
+    );
+    expect(
+      conflictingConfirmAmount({ parameters: { amount: "100" } }, 100),
+    ).toBe(null);
+    expect(
+      conflictingConfirmAmount({ parameters: { amount: "$100" } }, 100),
+    ).toBe(null);
+  });
+
+  it("returns the conflicting amount when the confirm turn names a different one", () => {
+    expect(conflictingConfirmAmount({ parameters: { amount: 50 } }, 100)).toBe(
+      50,
+    );
+    expect(conflictingConfirmAmount({ amount: "50" }, 100)).toBe(50);
+  });
+
+  it("ignores prose amounts (never guesses)", () => {
+    expect(
+      conflictingConfirmAmount({ parameters: { amount: "fifty bucks" } }, 100),
+    ).toBe(null);
+  });
+});
+
+describe("conflictingConfirmDomain", () => {
+  it("returns null on a bare confirm or the same domain", () => {
+    expect(conflictingConfirmDomain({ confirm: true }, "yourbrand.com")).toBe(
+      null,
+    );
+    expect(
+      conflictingConfirmDomain(
+        { parameters: { domain: "yourbrand.com" } },
+        "yourbrand.com",
+      ),
+    ).toBe(null);
+    expect(
+      conflictingConfirmDomain(
+        { parameters: { domain: "WWW.YourBrand.com" } },
+        "yourbrand.com",
+      ),
+    ).toBe(null);
+  });
+
+  it("domains compare exactly: a substring domain is a DIFFERENT domain", () => {
+    expect(
+      conflictingConfirmDomain(
+        { parameters: { domain: "brand.com" } },
+        "yourbrand.com",
+      ),
+    ).toBe("brand.com");
+    expect(
+      conflictingConfirmDomain(
+        { parameters: { domain: "other.io" } },
+        "yourbrand.com",
+      ),
+    ).toBe("other.io");
+  });
+
+  it("ignores values that don't look like a domain", () => {
+    expect(
+      conflictingConfirmDomain(
+        { parameters: { domain: "the domain" } },
+        "yourbrand.com",
+      ),
     ).toBe(null);
   });
 });

--- a/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
@@ -186,6 +186,91 @@ describe("WITHDRAW_APP_EARNINGS", () => {
     expect(result?.success).toBe(true);
   });
 
+  it("MONEY: confirm naming a DIFFERENT app refuses, moves nothing, clears the pending", async () => {
+    const withdrawals = trackWithdrawals();
+    const runtime = keyedRuntime();
+    const cb = captureCallback();
+    await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("withdraw $50 from Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    const result = await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("yes — withdraw from Beta Dashboard"),
+      undefined,
+      { parameters: { confirm: true, appName: "Beta Dashboard" } },
+      cb.fn,
+    );
+
+    expect(withdrawals.calls).toHaveLength(0);
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+    const reply = cb.calls.at(-1)?.text ?? "";
+    expect(reply).toContain("Beta Dashboard");
+    expect(reply).toContain("Acme Bot");
+
+    // Pending cleared: a later bare confirm cannot fund the stale withdrawal.
+    const followUp = await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      cb.fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((followUp?.data as { reason: string }).reason).toBe(
+      "no_pending_confirmation",
+    );
+  });
+
+  it("MONEY: confirm carrying a DIFFERENT structured amount refuses (frozen $50 vs turn $500)", async () => {
+    const withdrawals = trackWithdrawals();
+    const runtime = keyedRuntime();
+    const cb = captureCallback();
+    await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("withdraw $50 from Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    const result = await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("confirm, make it $500"),
+      undefined,
+      { parameters: { confirm: true, amount: 500 } },
+      cb.fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe(
+      "confirm_target_mismatch",
+    );
+
+    // A matching structured amount on the confirm turn still withdraws.
+    await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("withdraw $50 from Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    const ok = await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("confirm the $50 withdrawal"),
+      undefined,
+      { parameters: { confirm: true, appName: "Acme Bot", amount: 50 } },
+      cb.fn,
+    );
+    expect(ok?.success).toBe(true);
+    expect(withdrawals.calls).toHaveLength(1);
+    expect(withdrawals.calls[0]?.request.amount).toBe(50);
+  });
+
   it("MONEY REGRESSION: planner-nested amount stages $50, NOT the full balance", async () => {
     // Real planner path (execute-planned-tool-call.ts): validated args arrive
     // under options.parameters and the text carries no digits. The old

--- a/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
+++ b/plugins/plugin-cloud-apps/src/actions/book-influencer.ts
@@ -46,6 +46,9 @@ import { cloudErrorInfo } from "../domain-intent.js";
 import {
   CONFIRM_TTL_MS,
   confirmationRoomId,
+  confirmTargetMismatchMessage,
+  conflictingConfirmAmount,
+  conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
   markCloudAppConfirmationRecovery,
@@ -243,6 +246,56 @@ export const bookInfluencerAction: Action = {
           userFacingText: CANCELED_MESSAGE,
           verifiedUserFacing: true,
           data: { booked: false, canceled: true },
+        };
+      }
+      // Frozen-snapshot guard: a confirm whose own params name a DIFFERENT
+      // influencer or budget must never fund the frozen booking the user is no
+      // longer talking about. (`appId`/`appName` carry the profile id + display
+      // name for this action.)
+      const profileConflict = conflictingConfirmTarget(
+        options,
+        { name: pending.metadata.appName, id: pending.metadata.appId },
+        ["profileId", "influencer"],
+      );
+      const budgetConflict = conflictingConfirmAmount(
+        options,
+        pending.metadata.amount,
+      );
+      if (profileConflict !== null || budgetConflict !== null) {
+        const requested =
+          profileConflict ??
+          `${usd(budgetConflict ?? 0)} (not ${usd(pending.metadata.amount)})`;
+        let msg: string;
+        if (isRecovery) {
+          msg =
+            `Your confirmation names "${requested}", but the pending recovery retry is for "${pending.metadata.appName}" at ${usd(pending.metadata.amount)}. ` +
+            `I did not retry or start a new booking, and I kept the recovery pending so its same escrow key survives. ` +
+            `Reply to confirm again to safely complete or replay the earlier attempt, or cancel to leave it.`;
+        } else {
+          await deleteCloudAppConfirmation(runtime, pending.taskId);
+          msg = confirmTargetMismatchMessage(
+            requested,
+            `booking of ${usd(pending.metadata.amount)}`,
+            pending.metadata.appName,
+          );
+        }
+        await callback?.({ text: msg, actions: ["BOOK_INFLUENCER"] });
+        return {
+          success: false,
+          text: `Confirm named "${requested}" but the pending booking was ${pending.metadata.appName} for ${usd(pending.metadata.amount)}; refused.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: {
+            reason: "confirm_target_mismatch",
+            booked: false,
+            requested,
+            pendingTarget: {
+              id: pending.metadata.appId,
+              name: pending.metadata.appName,
+            },
+            amount: pending.metadata.amount,
+            ...(isRecovery ? { recovery: true } : {}),
+          },
         };
       }
       // A recovery retry never expires (safety.ts): it resumes/replays money

--- a/plugins/plugin-cloud-apps/src/actions/buy-app-domain.ts
+++ b/plugins/plugin-cloud-apps/src/actions/buy-app-domain.ts
@@ -69,6 +69,9 @@ import {
   CONFIRM_TTL_MS,
   type ConnectorCta,
   confirmationRoomId,
+  confirmTargetMismatchMessage,
+  conflictingConfirmDomain,
+  conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
   pendingExpired,
@@ -363,6 +366,38 @@ export const buyAppDomainAction: Action = {
           userFacingText: CANCELED_MESSAGE,
           verifiedUserFacing: true,
           data: { purchased: false, canceled: true },
+        };
+      }
+
+      // Frozen-snapshot guard: a confirm whose own params name a DIFFERENT
+      // domain or app must never fund the frozen purchase the user is no
+      // longer talking about.
+      const domainConflict = conflictingConfirmDomain(options, domain);
+      const appConflict = conflictingConfirmTarget(options, {
+        name: target.name,
+        id: target.id,
+        aliases: target.slug ? [target.slug] : [],
+      });
+      if (domainConflict !== null || appConflict !== null) {
+        const requested = domainConflict ?? appConflict ?? "";
+        const msg = confirmTargetMismatchMessage(
+          requested,
+          `purchase of ${domain}`,
+          domainConflict !== null ? domain : target.name,
+        );
+        await callback?.({ text: msg, actions: ["BUY_APP_DOMAIN"] });
+        return {
+          success: false,
+          text: `Confirm named "${requested}" but the pending purchase was ${domain} for ${target.name}; refused.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: {
+            reason: "confirm_target_mismatch",
+            purchased: false,
+            requested,
+            domain,
+            pendingTarget: { id: target.id, name: target.name },
+          },
         };
       }
 

--- a/plugins/plugin-cloud-apps/src/actions/delete-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/delete-app.ts
@@ -33,6 +33,8 @@ import { invalidateAppsCache } from "../providers/cloud-apps.js";
 import {
   confirmationPrompt,
   confirmationRoomId,
+  confirmTargetMismatchMessage,
+  conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
   persistCloudAppConfirmation,
@@ -154,6 +156,35 @@ export const deleteAppAction: Action = {
         name: pending.metadata.appName,
         slug: pending.metadata.appSlug ?? pending.metadata.appName,
       };
+
+      // Frozen-target guard: a confirm whose own params name a DIFFERENT app
+      // must never delete the frozen one the user is no longer talking about.
+      const conflict = conflictingConfirmTarget(options, {
+        name: target.name,
+        id: target.id,
+        aliases: [target.slug],
+      });
+      if (conflict !== null) {
+        const msg = confirmTargetMismatchMessage(
+          conflict,
+          "delete",
+          target.name,
+        );
+        await callback?.({ text: msg, actions: ["DELETE_APP"] });
+        return {
+          success: false,
+          text: `Confirm named "${conflict}" but the pending delete was for ${target.name}; refused.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: {
+            reason: "confirm_target_mismatch",
+            deleted: false,
+            requested: conflict,
+            pendingTarget: { id: target.id, name: target.name },
+          },
+        };
+      }
+
       try {
         const result = await client.deleteApp(target.id);
         // Any delete attempt can change the app inventory — force the provider to

--- a/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
+++ b/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
@@ -31,6 +31,8 @@ import {
 } from "../client.js";
 import {
   confirmationRoomId,
+  confirmTargetMismatchMessage,
+  conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
   persistCloudAppConfirmation,
@@ -155,6 +157,35 @@ export const regenerateAppApiKeyAction: Action = {
         name: pending.metadata.appName,
         slug: pending.metadata.appSlug ?? pending.metadata.appName,
       };
+
+      // Frozen-target guard: a confirm whose own params name a DIFFERENT app
+      // must never rotate the frozen app's key.
+      const conflict = conflictingConfirmTarget(options, {
+        name: target.name,
+        id: target.id,
+        aliases: [target.slug],
+      });
+      if (conflict !== null) {
+        const msg = confirmTargetMismatchMessage(
+          conflict,
+          "API-key rotation",
+          target.name,
+        );
+        await callback?.({ text: msg, actions: ["REGENERATE_APP_API_KEY"] });
+        return {
+          success: false,
+          text: `Confirm named "${conflict}" but the pending rotation was for ${target.name}; refused.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: {
+            reason: "confirm_target_mismatch",
+            rotated: false,
+            requested: conflict,
+            pendingTarget: { id: target.id, name: target.name },
+          },
+        };
+      }
+
       try {
         const result = await client.regenerateAppApiKey(target.id);
         const newKey =

--- a/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
+++ b/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
@@ -49,6 +49,9 @@ import {
   buildConnectorCta,
   type ConnectorCta,
   confirmationRoomId,
+  confirmTargetMismatchMessage,
+  conflictingConfirmAmount,
+  conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
   persistCloudAppConfirmation,
@@ -235,6 +238,41 @@ export const withdrawAppEarningsAction: Action = {
         slug: pending.metadata.appSlug ?? pending.metadata.appName,
       };
       const amount = pending.metadata.amount;
+
+      // Frozen-snapshot guard: a confirm whose own params name a DIFFERENT app
+      // or amount must never fund the frozen withdrawal the user is no longer
+      // talking about.
+      const appConflict = conflictingConfirmTarget(options, {
+        name: target.name,
+        id: target.id,
+        aliases: [target.slug],
+      });
+      const amountConflict = conflictingConfirmAmount(options, amount);
+      if (appConflict !== null || amountConflict !== null) {
+        const requested =
+          appConflict ??
+          `${usd(amountConflict ?? amount)} (not ${usd(amount)})`;
+        const msg = confirmTargetMismatchMessage(
+          requested,
+          `withdrawal of ${usd(amount)}`,
+          target.name,
+        );
+        await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+        return {
+          success: false,
+          text: `Confirm named "${requested}" but the pending withdrawal was ${usd(amount)} from ${target.name}; refused.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: {
+            reason: "confirm_target_mismatch",
+            withdrawn: false,
+            requested,
+            pendingTarget: { id: target.id, name: target.name },
+            amount,
+          },
+        };
+      }
+
       const cta =
         pending.metadata.cta ??
         buildConnectorCta(

--- a/plugins/plugin-cloud-apps/src/safety.ts
+++ b/plugins/plugin-cloud-apps/src/safety.ts
@@ -144,6 +144,202 @@ export function readStructuredConfirmation(options?: unknown): boolean | null {
   return null;
 }
 
+// ─── Confirm-turn target consistency (the "frozen target" guard) ─────────────
+//
+// The gated actions execute the params FROZEN at the first ask — the confirm
+// turn is never re-parsed for new work. But when the confirm turn's own
+// structured params clearly name a DIFFERENT target ("yes — delete Beta
+// Dashboard" while the pending delete is for "Acme Bot"), executing the frozen
+// target acts on something the user is no longer talking about. These helpers
+// detect that conflict so the action refuses + clears the pending instead of
+// mutating. They are deliberately lenient: a bare confirm, generic filler
+// ("my app"), or a partial name of the SAME target never blocks.
+
+/**
+ * Planner-option keys that may carry the confirm turn's own app reference.
+ * Mirrors the reference keys the actions resolve with at the first ask, minus
+ * `query` (which can carry loose prose that must not read as a target switch).
+ */
+export const CONFIRM_APP_REFERENCE_KEYS = [
+  "app",
+  "appName",
+  "name",
+  "id",
+  "appId",
+] as const;
+
+/** Filler words that alone never name a specific target ("my app", "it"). */
+const GENERIC_REFERENCE_WORDS = new Set([
+  "my",
+  "the",
+  "this",
+  "that",
+  "our",
+  "your",
+  "it",
+  "its",
+  "app",
+  "apps",
+  "application",
+  "one",
+  "domain",
+  "influencer",
+  "creator",
+  "profile",
+  "booking",
+  "key",
+  "earnings",
+]);
+
+function normalizeReference(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/** True when the reference is generic filler that names no specific target. */
+function isGenericReference(reference: string): boolean {
+  return normalizeReference(reference)
+    .split(" ")
+    .every((word) => word.length === 0 || GENERIC_REFERENCE_WORDS.has(word));
+}
+
+/**
+ * The confirm turn's own structured target reference, when the planner sent
+ * one alongside `confirm` (nested `options.parameters` first — the real
+ * planner path — then top-level). Null = a bare confirm with no reference.
+ */
+export function readConfirmTurnReference(
+  options: unknown,
+  keys: readonly string[],
+): string | null {
+  if (!options || typeof options !== "object") return null;
+  const top = options as Record<string, unknown>;
+  const nested =
+    top.parameters && typeof top.parameters === "object"
+      ? (top.parameters as Record<string, unknown>)
+      : undefined;
+  for (const source of nested ? [nested, top] : [top]) {
+    for (const key of keys) {
+      const value = source[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * True when `reference` plausibly names the frozen target: its id verbatim, or
+ * a normalized exact/containment match on the name or an alias. Lenient on
+ * purpose — a partial name ("acme" for "Acme Bot") or generic filler ("my
+ * app") must NOT read as a target switch; only a clearly different name does.
+ */
+export function confirmReferenceMatchesTarget(
+  reference: string,
+  target: ConfirmTarget,
+): boolean {
+  const ref = normalizeReference(reference);
+  if (ref.length === 0 || isGenericReference(reference)) return true;
+  if (typeof target.id === "string" && normalizeReference(target.id) === ref) {
+    return true;
+  }
+  const names = [target.name, ...(target.aliases ?? [])]
+    .filter(
+      (name): name is string =>
+        typeof name === "string" && name.trim().length > 0,
+    )
+    .map(normalizeReference);
+  return names.some(
+    (name) => name === ref || name.includes(ref) || ref.includes(name),
+  );
+}
+
+/**
+ * The conflicting reference when the confirm turn's structured params name a
+ * DIFFERENT target than the frozen pending snapshot — the gated action must
+ * refuse (and clear the pending) instead of executing the frozen target. Null
+ * = consistent: a bare confirm, or a reference matching the frozen target.
+ */
+export function conflictingConfirmTarget(
+  options: unknown,
+  target: ConfirmTarget,
+  keys: readonly string[] = CONFIRM_APP_REFERENCE_KEYS,
+): string | null {
+  const reference = readConfirmTurnReference(options, keys);
+  if (reference === null) return null;
+  return confirmReferenceMatchesTarget(reference, target) ? null : reference;
+}
+
+/**
+ * The conflicting amount when the confirm turn's structured params carry a
+ * numeric amount that differs from the frozen one (e.g. "confirm — but only
+ * $50" against a pending $100 withdrawal). Only trusts an unambiguous number
+ * (a number, or a plain numeric string with an optional leading `$`); prose
+ * never blocks. Null = consistent or no amount sent.
+ */
+export function conflictingConfirmAmount(
+  options: unknown,
+  frozenAmount: number,
+): number | null {
+  if (!options || typeof options !== "object") return null;
+  const top = options as Record<string, unknown>;
+  const nested =
+    top.parameters && typeof top.parameters === "object"
+      ? (top.parameters as Record<string, unknown>)
+      : undefined;
+  const value = nested?.amount ?? top.amount;
+  let amount: number | null = null;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    amount = value;
+  } else if (typeof value === "string") {
+    const cleaned = value.trim().replace(/^\$/, "");
+    if (/^\d+(\.\d+)?$/.test(cleaned)) amount = Number(cleaned);
+  }
+  if (amount === null) return null;
+  return Math.abs(amount - frozenAmount) < 0.005 ? null : amount;
+}
+
+/**
+ * The conflicting domain when the confirm turn's structured `domain` param
+ * names a DIFFERENT domain than the frozen pending purchase. Domains are exact
+ * identifiers, so unlike app names this is an exact comparison
+ * (case-insensitive, ignoring a leading "www." and a trailing dot); values
+ * that don't look like a domain never block. Null = consistent or none sent.
+ */
+export function conflictingConfirmDomain(
+  options: unknown,
+  frozenDomain: string,
+): string | null {
+  const reference = readConfirmTurnReference(options, ["domain"]);
+  if (reference === null) return null;
+  const normalize = (value: string): string =>
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/\.$/, "")
+      .replace(/^www\./, "");
+  const turn = normalize(reference);
+  if (!turn.includes(".")) return null;
+  return turn === normalize(frozenDomain) ? null : reference;
+}
+
+/**
+ * The shared refusal copy for a confirm-turn target/amount conflict. Truthful:
+ * nothing was executed and the pending confirmation has been cleared by the
+ * caller before replying.
+ */
+export function confirmTargetMismatchMessage(
+  requested: string,
+  what: string,
+  pendingName: string,
+): string {
+  return (
+    `Your confirmation names "${requested}", but the pending ${what} was for "${pendingName}". ` +
+    `To be safe I did nothing, and that pending confirmation is now cleared. ` +
+    `Re-state what you want and I'll ask you to confirm again.`
+  );
+}
+
 export function confirmationRoomId(
   runtime: IAgentRuntime,
   message: Memory,


### PR DESCRIPTION
Last open item (Bug 6, MED-HIGH/money) from the 07-02 Fable adversarial apps-surface scan — the frozen-target confirm hole. (Bugs 5+7 of that scan are in #11835; the withdraw HIGH merged as #11810; BOOK_INFLUENCER guards merged as #11817.)

**The bug.** All five `safety.ts`-gated actions — `DELETE_APP`, `REGENERATE_APP_API_KEY`, `WITHDRAW_APP_EARNINGS`, `BUY_APP_DOMAIN`, `BOOK_INFLUENCER` — execute the params FROZEN at the first ask on any structured `confirm: true`, without ever comparing them to the confirm turn's OWN planner params. So with a pending delete for **Acme Bot**:

> user: "actually — yes, delete **Beta Dashboard**" → planner sends `{ confirm: true, appName: "Beta Dashboard" }` → the handler **deletes Acme Bot**.

Same shape for money: "confirm, make it $500" against a frozen $50 withdrawal withdrew the frozen $50 while the user believes something else happened; a confirm naming a different domain/influencer funded the frozen purchase/booking. The freeze itself is correct (prose must never re-target a money action) — the missing piece is *consistency checking* the structured params the planner does send.

**The fix** — a shared frozen-target guard in `safety.ts`, wired into all 5 gated actions at the confirm turn, before any mutation:

- `conflictingConfirmTarget(options, frozenTarget, keys)` — reads the confirm turn's own structured reference (nested `options.parameters` first, the real planner path) and flags a clear conflict with the frozen id/name/aliases.
- `conflictingConfirmAmount` (WITHDRAW + BOOK) — flags an unambiguous structured amount that differs from the frozen one.
- `conflictingConfirmDomain` (BUY_APP_DOMAIN) — domains are exact identifiers: exact compare (case-insensitive, `www.`/trailing-dot insensitive), so `brand.com` vs `yourbrand.com` is a conflict, not a fuzzy match.
- On conflict the action **refuses, clears the pending, and asks the user to re-state** — it never executes the frozen target the user is no longer talking about, and never silently switches to the newly-named one (that would mutate a target whose confirmation prompt the user never saw). `reason: "confirm_target_mismatch"`.
- **Deliberately lenient — no false blocks:** bare confirms, partial names of the SAME target ("acme" for "Acme Bot"), ids, slugs, and generic filler ("my app", "it") all pass; prose is never parsed; non-numeric amounts are ignored. Existing behavior on every happy path is unchanged.

**Evidence** (`plugins/plugin-cloud-apps`):
- `bun test __tests__`: **311 pass / 0 fail** (288 baseline + 23 new). New coverage: guard unit tests (match/generic/conflict semantics, nested planner shape, custom keys, amount + domain rules) and per-action e2e through the real confirm machine (only the SDK faked): mismatch → refusal + zero SDK mutation calls + pending cleared (follow-up bare confirm gets `no_pending_confirmation`); same-target re-name / matching amount+domain → executes exactly once (no false block).
- `tsgo --noEmit` clean; biome clean; branch rebased onto `origin/develop` tip and re-verified after rebase.
- Real-LLM trajectory: N/A — the planner boundary is exercised via the documented nested `options.parameters` handler contract in the tests above (same evidence basis as #11810/#11817/#11835 in this series); no prompt/model behavior changes, action `parameters` schemas unchanged.
- Docs: the frozen-target guard is now a stated invariant in the plugin `CLAUDE.md`/`AGENTS.md` conventions.

— nubs-cloud `[cloud-frontdoor]`