### PR TITLE
[codex] fix cloud api core stub duplicate export

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -18,21 +18,6 @@ function throwingExport(name: string): (...args: unknown[]) => never {
   return () => unavailable(name);
 }
 
-/**
- * Worker-safe pass-through for core's `runWithTrajectoryPurpose`. The Worker
- * build has no AsyncLocalStorage trajectory-context manager (node-only), so we
- * just invoke the fn directly — trajectory-purpose tracking is a no-op in the
- * Worker. Added because #11580 imports it into email-classifier.ts, which the
- * Worker build bundles; without this export the Deploy API Worker step fails
- * with "No matching export ... for import runWithTrajectoryPurpose".
- */
-export function runWithTrajectoryPurpose<T>(
-  _purpose: string,
-  fn: () => T | Promise<T>,
-): T | Promise<T> {
-  return fn();
-}
-
 function readEnvValue(
   env: Record<string, string | undefined>,
   keys: readonly string[],


### PR DESCRIPTION
## Summary

Removes the duplicate `runWithTrajectoryPurpose` export from the Cloudflare `@elizaos/core` compatibility stub. The latest develop Cloud CF Deploy failure is in the Verify Worker step: `src/stubs/elizaos-core.ts` redeclares `runWithTrajectoryPurpose` at lines 29 and 283.

The later grouped trajectory stub remains in place, so the worker bundle still has the export needed by `@elizaos/shared` email classification.

## Verification

- `bun --check packages/cloud/api/src/stubs/elizaos-core.ts`
- `bunx @biomejs/biome@2.5.2 check packages/cloud/api/src/stubs/elizaos-core.ts`
- `git diff --check`

## Notes

A full `bun install --frozen-lockfile --ignore-scripts` was attempted in a sparse checkout first, but Bun requires all workspace paths to be present and failed on omitted workspaces. Expanding to a full checkout was abandoned after the Git materialization stalled locally; disk was tight at roughly 34-35 GiB free.