### PR TITLE
fix(cloud): remove duplicate runWithTrajectoryPurpose Worker-stub export — unblock prod deploy

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -273,20 +273,6 @@ export function runWithTrajectoryContext<T>(
   return fn();
 }
 
-/**
- * Worker-safe stand-in for `runWithTrajectoryPurpose`. Same rationale as
- * `runWithTrajectoryContext` above — the trajectory context manager lives on
- * the agent sidecar, not in the Worker bundle (pulled in transitively via
- * `@elizaos/shared` email-classification, not invoked on a Worker route), so
- * there is no active context to tag with a purpose; just run the function.
- */
-export function runWithTrajectoryPurpose<T>(
-  _purpose: string,
-  fn: () => T | Promise<T>,
-): T | Promise<T> {
-  return fn();
-}
-
 type InferenceTimingMeta = Record<string, string | number | boolean>;
 
 /**


### PR DESCRIPTION
**Prod-deploy hotfix.** The #11861 promote carried TWO `runWithTrajectoryPurpose` exports in `cloud/api/src/stubs/elizaos-core.ts` (my #11847 + codex's parallel #11857 both landed on develop). The duplicate fails the Worker esbuild ('redeclares runWithTrajectoryPurpose') at Deploy API Worker → the prod deploy (28653353358) fails, blocking the money fixes going live. Removed the second copy; `wrangler --dry-run` builds clean (15.8 MB, single export). Same fix #11857 applies to develop. — `[cloud-frontdoor]`