### PR TITLE
feat(release): attach downloadable binaries to GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -626,6 +626,40 @@ jobs:
         run: |
           node packages/scripts/verify-npm-pack-dist.mjs --all-public-dist-packages --build
 
+      # Stage downloadable release binaries so the GitHub Release carries more
+      # than just source archives (#11858): headline npm tarballs + standalone
+      # `elizaos` CLI executables for every platform + a combined checksum file.
+      # Runs while workspace:* refs are still replaced (packed dependency ranges
+      # match the registry) and before the "Restore workspace references" step.
+      # Gated to real release events — a workflow_dispatch beta (tag_created) or
+      # a stable GitHub `release`.
+      - name: Stage release binaries (npm tarballs + standalone CLI)
+        id: stage_artifacts
+        if: steps.tag.outputs.tag_created == 'true' || github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          ARTIFACT_DIR="${GITHUB_WORKSPACE}/release-artifacts"
+          rm -rf "${ARTIFACT_DIR}"
+          mkdir -p "${ARTIFACT_DIR}"
+
+          echo "📦 Packing headline npm tarballs..."
+          node packages/scripts/pack-release-artifacts.mjs --out "${ARTIFACT_DIR}/npm"
+
+          echo "🛠  Compiling standalone elizaos CLI binaries (all platforms)..."
+          bun packages/elizaos/build-standalone.ts --out "${ARTIFACT_DIR}/cli"
+
+          echo "🔐 Writing combined SHA256SUMS.txt..."
+          (
+            cd "${ARTIFACT_DIR}"
+            find . -type f \( -name '*.tgz' -o -name '*.tar.gz' -o -name '*.zip' \) \
+              | sed 's|^\./||' | sort \
+              | while read -r f; do shasum -a 256 "$f"; done > SHA256SUMS.txt
+          )
+
+          echo "artifact_dir=${ARTIFACT_DIR}" >> "$GITHUB_OUTPUT"
+          echo "=== staged release artifacts ==="
+          find "${ARTIFACT_DIR}" -type f | sort
+
       # Publish to NPM (only after git operations succeed)
       - name: Skip NPM publish on forks
         if: github.repository != 'elizaOS/eliza'
@@ -793,6 +827,17 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag_name }}
           name: ${{ steps.tag.outputs.tag_name }}
+          # Attach the staged downloadable binaries alongside the auto-generated
+          # source archives. fail_on_unmatched_files surfaces a broken staging
+          # step instead of silently publishing a source-only release again.
+          files: |
+            release-artifacts/npm/*.tgz
+            release-artifacts/npm/SHA256SUMS-npm.txt
+            release-artifacts/cli/*.tar.gz
+            release-artifacts/cli/*.zip
+            release-artifacts/cli/SHA256SUMS-cli.txt
+            release-artifacts/SHA256SUMS.txt
+          fail_on_unmatched_files: true
           body: |
             🔵 Beta Release
 
@@ -811,11 +856,37 @@ jobs:
             bun add @elizaos/core@${{ steps.release_type.outputs.dist_tag }}
             ```
 
+            ### Downloads
+
+            Prefer a self-contained binary? Grab a standalone `elizaos` CLI
+            (`elizaos-<platform>.tar.gz` / `.zip`) below — no npm or Bun required.
+            The `*.tgz` files are the exact npm tarballs; verify any download
+            against `SHA256SUMS.txt`.
+
             ---
 
             > **Note:** This is a ${{ steps.release_type.outputs.type }} release. Production releases use the `latest` tag and are triggered by GitHub releases on tags matching `v*.*.*`.
           draft: false
           prerelease: true
+
+      # Stable production releases already exist (a human created the GitHub
+      # release before this workflow fired on the `release` event), so we append
+      # the staged binaries to that existing release instead of creating one.
+      - name: Attach release binaries to production release
+        if: github.event_name == 'release' && steps.stage_artifacts.outputs.artifact_dir != ''
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            release-artifacts/npm/*.tgz
+            release-artifacts/npm/SHA256SUMS-npm.txt
+            release-artifacts/cli/*.tar.gz
+            release-artifacts/cli/*.zip
+            release-artifacts/cli/SHA256SUMS-cli.txt
+            release-artifacts/SHA256SUMS.txt
+          fail_on_unmatched_files: true
 
       - name: Summary
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1518,3 +1518,8 @@ railway.json
 .railwayignore
 .dockerignore
 packages/ui/src/components/shell/__e2e__/output-fused-wake-integration/
+
+# Standalone CLI build output (packages/elizaos/build-standalone.ts)
+packages/elizaos/dist-standalone/
+# Release artifacts staged by release.yaml (npm tarballs + CLI binaries)
+release-artifacts/

--- a/packages/elizaos/AGENTS.md
+++ b/packages/elizaos/AGENTS.md
@@ -53,10 +53,12 @@ Token replacement (`scaffold.ts`): plugin templates substitute `${PLUGINNAME}`, 
 
 ```bash
 bun run --cwd packages/elizaos build          # build.ts: prep templates + manifest, tsc, shebang
+bun run --cwd packages/elizaos build:standalone  # build-standalone.ts: cross-compile CLI binaries + archives
 bun run --cwd packages/elizaos dev            # build.ts --watch
 bun run --cwd packages/elizaos typecheck      # tsgo --noEmit
 bun run --cwd packages/elizaos test           # vitest run --passWithNoTests
 bun run --cwd packages/elizaos test:packaged  # scripts/packaged-smoke.mjs (packs + installs + create/upgrade)
+bun run --cwd packages/elizaos test:standalone  # scripts/standalone-smoke.mjs (compiles host binary, runs version/info/create)
 bun run --cwd packages/elizaos lint           # biome check --write (also lints templates/plugin + project/apps/app)
 bun run --cwd packages/elizaos lint:check     # biome check (no write)
 ```
@@ -78,6 +80,7 @@ Generated projects record state in `.elizaos/template.json` (`ProjectTemplateMet
 ## Conventions / gotchas
 
 - `manifest.ts` and `getTemplatesDir` read `templates-manifest.json` and `templates/` relative to `getPackageRoot()` (one dir up from `dist/`), so the CLI only works after `build` and against the shipped `dist` + `templates` (both in the `files` allowlist). `loadManifest` throws if the manifest is missing — run `build` first.
+- **Standalone binaries** (`build-standalone.ts`, released via `release.yaml`): a `bun build --compile` binary serves its embedded modules from the unreadable `/$bunfs` virtual root, so `getPackageRoot()` (`package-info.ts`) detects that case via `isStandaloneBinary()` and resolves assets from `path.dirname(process.execPath)` instead. The build script therefore stages `templates/`, `templates-manifest.json`, and `package.json` next to the executable inside each archive. `scripts/standalone-smoke.mjs` is the regression guard — if you change asset resolution, run `test:standalone`. The CLI still shells out to `git`/`gh`/`npm` at runtime, so the binary is self-contained for scaffolding but not for the git/registry steps.
 - `cli.ts` ends with top-level `await program.parseAsync()`; the bin shebang is `#!/usr/bin/env node` (re-applied by `ensureCliShebang` in `build.ts`).
 - Commands that interact with the user use `@clack/prompts` and call `process.exit(...)` directly on cancel/error; `deploy`/`capabilityRouterConnect` split a pure `run*` function (returns exit code) from the thin `process.exit` wrapper for testability.
 - `plugins submit --dry-run` prints the generated `entries/third-party/<pkg>.json` metadata. Opening a PR requires an explicit `--registry owner/repo`; no public default registry repository is configured. `@elizaos/*` names are rejected (reserved for first-party).

--- a/packages/elizaos/CLAUDE.md
+++ b/packages/elizaos/CLAUDE.md
@@ -53,10 +53,12 @@ Token replacement (`scaffold.ts`): plugin templates substitute `${PLUGINNAME}`, 
 
 ```bash
 bun run --cwd packages/elizaos build          # build.ts: prep templates + manifest, tsc, shebang
+bun run --cwd packages/elizaos build:standalone  # build-standalone.ts: cross-compile CLI binaries + archives
 bun run --cwd packages/elizaos dev            # build.ts --watch
 bun run --cwd packages/elizaos typecheck      # tsgo --noEmit
 bun run --cwd packages/elizaos test           # vitest run --passWithNoTests
 bun run --cwd packages/elizaos test:packaged  # scripts/packaged-smoke.mjs (packs + installs + create/upgrade)
+bun run --cwd packages/elizaos test:standalone  # scripts/standalone-smoke.mjs (compiles host binary, runs version/info/create)
 bun run --cwd packages/elizaos lint           # biome check --write (also lints templates/plugin + project/apps/app)
 bun run --cwd packages/elizaos lint:check     # biome check (no write)
 ```
@@ -78,6 +80,7 @@ Generated projects record state in `.elizaos/template.json` (`ProjectTemplateMet
 ## Conventions / gotchas
 
 - `manifest.ts` and `getTemplatesDir` read `templates-manifest.json` and `templates/` relative to `getPackageRoot()` (one dir up from `dist/`), so the CLI only works after `build` and against the shipped `dist` + `templates` (both in the `files` allowlist). `loadManifest` throws if the manifest is missing — run `build` first.
+- **Standalone binaries** (`build-standalone.ts`, released via `release.yaml`): a `bun build --compile` binary serves its embedded modules from the unreadable `/$bunfs` virtual root, so `getPackageRoot()` (`package-info.ts`) detects that case via `isStandaloneBinary()` and resolves assets from `path.dirname(process.execPath)` instead. The build script therefore stages `templates/`, `templates-manifest.json`, and `package.json` next to the executable inside each archive. `scripts/standalone-smoke.mjs` is the regression guard — if you change asset resolution, run `test:standalone`. The CLI still shells out to `git`/`gh`/`npm` at runtime, so the binary is self-contained for scaffolding but not for the git/registry steps.
 - `cli.ts` ends with top-level `await program.parseAsync()`; the bin shebang is `#!/usr/bin/env node` (re-applied by `ensureCliShebang` in `build.ts`).
 - Commands that interact with the user use `@clack/prompts` and call `process.exit(...)` directly on cancel/error; `deploy`/`capabilityRouterConnect` split a pure `run*` function (returns exit code) from the thin `process.exit` wrapper for testability.
 - `plugins submit --dry-run` prints the generated `entries/third-party/<pkg>.json` metadata. Opening a PR requires an explicit `--registry owner/repo`; no public default registry repository is configured. `@elizaos/*` names are rejected (reserved for first-party).

--- a/packages/elizaos/build-standalone.ts
+++ b/packages/elizaos/build-standalone.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env bun
+
+/**
+ * Build standalone `elizaos` CLI executables for every release platform.
+ *
+ * `bun build --compile` embeds the JS module graph into a single native binary,
+ * but the CLI still reads its templates/, templates-manifest.json, and
+ * package.json from disk at runtime (see src/manifest.ts + src/package-info.ts).
+ * Inside a compiled binary those live in the unreadable `/$bunfs` virtual root,
+ * so `getPackageRoot()` falls back to the executable's directory
+ * (`isStandaloneBinary()`), and we stage those assets next to the binary here.
+ *
+ * Each target produces `<out>/elizaos-<label>/` containing the binary + assets,
+ * archived to `.tar.gz` (unix) or `.zip` (windows). A single runner can cross
+ * compile every target, so the whole matrix builds on Linux in one step.
+ *
+ * Usage:
+ *   bun run build-standalone.ts [--out <dir>] [--target <label>[,<label>...]]
+ * Labels: linux-x64 linux-arm64 darwin-x64 darwin-arm64 windows-x64
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { copyDir } from "./safe-copy-dir.ts";
+
+const PACKAGE_DIR = import.meta.dir;
+const DIST_CLI = path.join(PACKAGE_DIR, "dist", "cli.js");
+
+interface Target {
+  /** Human-facing label used in archive names and --target selection. */
+  label: string;
+  /** `bun build --compile --target=` value. */
+  bunTarget: string;
+  os: "linux" | "darwin" | "windows";
+}
+
+const TARGETS: Target[] = [
+  { label: "linux-x64", bunTarget: "bun-linux-x64", os: "linux" },
+  { label: "linux-arm64", bunTarget: "bun-linux-arm64", os: "linux" },
+  { label: "darwin-x64", bunTarget: "bun-darwin-x64", os: "darwin" },
+  { label: "darwin-arm64", bunTarget: "bun-darwin-arm64", os: "darwin" },
+  { label: "windows-x64", bunTarget: "bun-windows-x64", os: "windows" },
+];
+
+function parseArgs(argv: string[]): { outDir: string; selected: Target[] } {
+  let outDir = path.join(PACKAGE_DIR, "dist-standalone");
+  let selected = TARGETS;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out") {
+      outDir = path.resolve(argv[++i] ?? outDir);
+    } else if (arg === "--target") {
+      const labels = new Set((argv[++i] ?? "").split(",").map((s) => s.trim()));
+      selected = TARGETS.filter((t) => labels.has(t.label));
+      if (selected.length === 0) {
+        throw new Error(
+          `No matching targets for --target; valid: ${TARGETS.map((t) => t.label).join(", ")}`,
+        );
+      }
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { outDir, selected };
+}
+
+function run(bin: string, args: string[], cwd = PACKAGE_DIR): void {
+  const result = spawnSync(bin, args, { cwd, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${bin} ${args.join(" ")} exited with code ${result.status}`,
+    );
+  }
+}
+
+function ensureBuilt(): void {
+  // The compiled binary embeds dist/cli.js; the archive ships templates/ and
+  // templates-manifest.json. `bun run build` produces all three.
+  if (
+    !fs.existsSync(DIST_CLI) ||
+    !fs.existsSync(path.join(PACKAGE_DIR, "templates-manifest.json"))
+  ) {
+    run("bun", ["run", "build"]);
+  }
+}
+
+function sha256(file: string): string {
+  return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function stageAssets(stageDir: string): void {
+  // Ship exactly what getPackageRoot() looks for next to the binary.
+  copyDir(
+    path.join(PACKAGE_DIR, "templates"),
+    path.join(stageDir, "templates"),
+  );
+  fs.copyFileSync(
+    path.join(PACKAGE_DIR, "templates-manifest.json"),
+    path.join(stageDir, "templates-manifest.json"),
+  );
+  fs.copyFileSync(
+    path.join(PACKAGE_DIR, "package.json"),
+    path.join(stageDir, "package.json"),
+  );
+}
+
+function archive(target: Target, stageDir: string, outDir: string): string {
+  const stageName = path.basename(stageDir);
+  if (target.os === "windows") {
+    const zipPath = path.join(outDir, `${stageName}.zip`);
+    fs.rmSync(zipPath, { force: true });
+    // -r recurse, -q quiet, -X strip extra file attributes for reproducibility.
+    run("zip", ["-r", "-q", "-X", zipPath, stageName], outDir);
+    return zipPath;
+  }
+  const tarPath = path.join(outDir, `${stageName}.tar.gz`);
+  fs.rmSync(tarPath, { force: true });
+  run("tar", ["-czf", tarPath, "-C", outDir, stageName]);
+  return tarPath;
+}
+
+function main(): void {
+  const { outDir, selected } = parseArgs(process.argv.slice(2));
+  ensureBuilt();
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const checksums: string[] = [];
+  for (const target of selected) {
+    const stageName = `elizaos-${target.label}`;
+    const stageDir = path.join(outDir, stageName);
+    fs.rmSync(stageDir, { recursive: true, force: true });
+    fs.mkdirSync(stageDir, { recursive: true });
+
+    const binName = target.os === "windows" ? "elizaos.exe" : "elizaos";
+    console.log(`\n▶ Compiling ${target.label} (${target.bunTarget})...`);
+    run("bun", [
+      "build",
+      DIST_CLI,
+      "--compile",
+      `--target=${target.bunTarget}`,
+      "--outfile",
+      path.join(stageDir, binName),
+    ]);
+
+    stageAssets(stageDir);
+    const archivePath = archive(target, stageDir, outDir);
+    fs.rmSync(stageDir, { recursive: true, force: true });
+
+    const digest = sha256(archivePath);
+    checksums.push(`${digest}  ${path.basename(archivePath)}`);
+    console.log(
+      `  ✅ ${path.basename(archivePath)} (${(fs.statSync(archivePath).size / 1e6).toFixed(1)} MB)`,
+    );
+  }
+
+  fs.writeFileSync(
+    path.join(outDir, "SHA256SUMS-cli.txt"),
+    `${checksums.join("\n")}\n`,
+  );
+  console.log(`\n✅ Standalone CLI archives written to ${outDir}`);
+}
+
+main();

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -24,12 +24,14 @@
   ],
   "scripts": {
     "build": "bun run build.ts",
+    "build:standalone": "bun run build-standalone.ts",
     "dev": "bun run build.ts --watch",
-    "lint": "bunx @biomejs/biome check --write README.md build.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false",
-    "lint:check": "bunx @biomejs/biome check README.md build.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check . --config-path ./biome.json --vcs-enabled=false",
+    "lint": "bunx @biomejs/biome check --write README.md build.ts build-standalone.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false",
+    "lint:check": "bunx @biomejs/biome check README.md build.ts build-standalone.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check . --config-path ./biome.json --vcs-enabled=false",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:packaged": "node ./scripts/packaged-smoke.mjs",
+    "test:standalone": "node ./scripts/standalone-smoke.mjs",
     "lint:bin-exports": "node ./scripts/lint-bin-exports.mjs",
     "prepublishOnly": "bun run build && bun run lint:bin-exports"
   },

--- a/packages/elizaos/scripts/standalone-smoke.mjs
+++ b/packages/elizaos/scripts/standalone-smoke.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * End-to-end smoke test for the standalone `elizaos` CLI binary.
+ *
+ * Builds the host-platform standalone archive (build-standalone.ts), extracts
+ * it to a temp dir, and drives the real binary through `version`, `info`, and
+ * `create` — the paths that read templates-manifest.json and the templates/
+ * tree from disk. This is the regression guard for the compiled-binary asset
+ * resolution in src/package-info.ts (getPackageRoot -> executable dir).
+ *
+ * Runs in the release workflow after `build:standalone`. Fails loudly on any
+ * non-zero exit or missing generated file.
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function hostLabel() {
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  switch (process.platform) {
+    case "darwin":
+      return `darwin-${arch}`;
+    case "linux":
+      return `linux-${arch}`;
+    case "win32":
+      return `windows-${arch}`;
+    default:
+      throw new Error(`Unsupported host platform: ${process.platform}`);
+  }
+}
+
+function run(bin, args, opts = {}) {
+  const result = spawnSync(bin, args, { stdio: "inherit", ...opts });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${bin} ${args.join(" ")} exited with code ${result.status}`,
+    );
+  }
+}
+
+function main() {
+  const label = hostLabel();
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "elizaos-standalone-"));
+  console.log(`[standalone-smoke] host target: ${label}`);
+  console.log(`[standalone-smoke] out dir: ${outDir}`);
+
+  // 1. Build the host-target archive only (fast; skips cross targets).
+  run(
+    "bun",
+    ["run", "build-standalone.ts", "--out", outDir, "--target", label],
+    {
+      cwd: PACKAGE_DIR,
+    },
+  );
+
+  // 2. Extract the archive.
+  const extractDir = path.join(outDir, "extracted");
+  fs.mkdirSync(extractDir, { recursive: true });
+  const stageName = `elizaos-${label}`;
+  if (process.platform === "win32") {
+    run("tar", [
+      "-xf",
+      path.join(outDir, `${stageName}.zip`),
+      "-C",
+      extractDir,
+    ]);
+  } else {
+    run("tar", [
+      "-xzf",
+      path.join(outDir, `${stageName}.tar.gz`),
+      "-C",
+      extractDir,
+    ]);
+  }
+
+  const binName = process.platform === "win32" ? "elizaos.exe" : "elizaos";
+  const binPath = path.join(extractDir, stageName, binName);
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`Compiled binary not found at ${binPath}`);
+  }
+  if (process.platform !== "win32") fs.chmodSync(binPath, 0o755);
+
+  // 3. Drive the real commands (all read on-disk assets next to the binary).
+  console.log("\n[standalone-smoke] elizaos version");
+  run(binPath, ["version"]);
+  console.log("\n[standalone-smoke] elizaos info");
+  run(binPath, ["info"]);
+
+  console.log("\n[standalone-smoke] elizaos create (plugin template)");
+  // `create` slugifies its name argument into a `plugin-<slug>/` directory
+  // created under the process CWD, so run it inside a dedicated clean dir.
+  const createCwd = path.join(outDir, "create-run");
+  fs.mkdirSync(createCwd, { recursive: true });
+  run(binPath, ["create", "smokeplugin", "--template", "plugin", "--yes"], {
+    cwd: createCwd,
+  });
+
+  // 4. Assert the template tree actually rendered.
+  const generated = fs
+    .readdirSync(createCwd, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name.startsWith("plugin-"))
+    .map((e) => path.join(createCwd, e.name));
+  const found = generated.find((dir) =>
+    fs.existsSync(path.join(dir, "package.json")),
+  );
+  if (!found) {
+    throw new Error(
+      `create did not produce a project with package.json (checked: ${generated.join(", ") || "none"})`,
+    );
+  }
+  const metadata = path.join(found, ".elizaos", "template.json");
+  if (!fs.existsSync(metadata)) {
+    throw new Error(`Generated project missing template metadata: ${metadata}`);
+  }
+  console.log(`\n[standalone-smoke] ✅ generated project at ${found}`);
+
+  fs.rmSync(outDir, { recursive: true, force: true });
+  console.log("[standalone-smoke] ✅ all checks passed");
+}
+
+main();

--- a/packages/elizaos/src/package-info.test.ts
+++ b/packages/elizaos/src/package-info.test.ts
@@ -1,0 +1,30 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getCliVersion,
+  getPackageRoot,
+  isStandaloneBinary,
+  readPackageJson,
+} from "./package-info.js";
+
+describe("package-info", () => {
+  it("does not report a standalone binary in the normal module runtime", () => {
+    // Under vitest we run from a real on-disk module, never from the bunfs
+    // virtual root, so the standalone-binary branch must stay off here.
+    expect(isStandaloneBinary()).toBe(false);
+  });
+
+  it("resolves the package root to the directory that holds package.json", () => {
+    const root = getPackageRoot();
+    expect(fs.existsSync(path.join(root, "package.json"))).toBe(true);
+    // package-info.ts lives in src/, so the root is one level up.
+    expect(path.basename(root)).toBe("elizaos");
+  });
+
+  it("reads name and version from the resolved package.json", () => {
+    const pkg = readPackageJson();
+    expect(pkg.name).toBe("elizaos");
+    expect(getCliVersion()).toBe(pkg.version);
+  });
+});

--- a/packages/elizaos/src/package-info.ts
+++ b/packages/elizaos/src/package-info.ts
@@ -10,7 +10,25 @@ interface PackageJson {
   version: string;
 }
 
+/**
+ * True when running from a `bun build --compile` standalone binary. Bun serves
+ * the bundled module graph from a virtual filesystem rooted at `/$bunfs` (older
+ * builds used `~BUN`), so `import.meta.url` — and therefore `__dirname` — points
+ * inside that virtual root rather than at a real directory on disk. Detecting
+ * this lets us resolve on-disk assets (templates, manifest, package.json) next
+ * to the real executable instead of at the unreadable bunfs path.
+ */
+export function isStandaloneBinary(): boolean {
+  return __dirname.includes("$bunfs") || __dirname.includes("~BUN");
+}
+
 export function getPackageRoot(): string {
+  // Standalone binaries ship their templates/, templates-manifest.json, and
+  // package.json alongside the executable (see build-standalone.ts), so the
+  // "package root" is the directory that contains the running binary.
+  if (isStandaloneBinary()) {
+    return path.dirname(process.execPath);
+  }
   return path.resolve(__dirname, "..");
 }
 

--- a/packages/scripts/pack-release-artifacts.mjs
+++ b/packages/scripts/pack-release-artifacts.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+/**
+ * Emit real npm tarballs (`.tgz`) for every public, dist-declaring workspace
+ * package into a release-artifacts directory, plus a SHA256SUMS-npm.txt.
+ *
+ * These are the exact tarballs `npm publish` would upload — attaching them to
+ * the GitHub release gives users offline / air-gapped installs and a
+ * checksum-verifiable copy of what shipped to the registry.
+ *
+ * Discovery mirrors verify-npm-pack-dist.mjs (lerna globs -> git-tracked ->
+ * non-private -> declares a dist entry point) so the emitted set matches the
+ * published set. Run AFTER workspace:* references have been replaced with real
+ * versions, so the packed dependency ranges match the registry.
+ *
+ * By default only the headline distributables are packed (the CLI + runtime
+ * packages users actually download directly) to keep the release asset list
+ * readable — every other package installs from the registry. Pass --all to
+ * emit a tarball for every public dist package, or --packages a,b,c to pick.
+ *
+ * Usage:
+ *   node packages/scripts/pack-release-artifacts.mjs --out <dir>
+ *   node packages/scripts/pack-release-artifacts.mjs --out <dir> --all
+ *   node packages/scripts/pack-release-artifacts.mjs --out <dir> --packages elizaos,@elizaos/core
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(scriptDir));
+
+// Headline packages a user is likely to download directly rather than install
+// from the registry. Everything else is available via `bun add`/`npm i`.
+const HEADLINE_PACKAGES = [
+  "elizaos",
+  "@elizaos/core",
+  "@elizaos/agent",
+  "@elizaos/app-core",
+];
+
+const args = process.argv.slice(2);
+let outDir = join(repoRoot, "release-artifacts", "npm");
+let packAll = false;
+let explicitPackages = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out") {
+    outDir = resolve(args[++i] ?? outDir);
+  } else if (args[i] === "--all") {
+    packAll = true;
+  } else if (args[i] === "--packages") {
+    explicitPackages = new Set(
+      (args[++i] ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+  } else {
+    console.error(`Unknown argument: ${args[i]}`);
+    process.exit(1);
+  }
+}
+
+function normalizePackagePath(value) {
+  return value.replace(/^\.\//, "").replace(/\\/g, "/");
+}
+
+function isDistArtifactPath(value) {
+  const normalized = normalizePackagePath(value);
+  return normalized.startsWith("dist/") || normalized.includes("/dist/");
+}
+
+function collectDistReferences(value, references = new Set()) {
+  if (typeof value === "string") {
+    const normalized = normalizePackagePath(value);
+    if (isDistArtifactPath(normalized) && !normalized.includes("*")) {
+      references.add(normalized);
+    }
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectDistReferences(item, references);
+  } else if (value && typeof value === "object") {
+    for (const item of Object.values(value)) {
+      collectDistReferences(item, references);
+    }
+  }
+  return references;
+}
+
+function expectsDist(pkg) {
+  return (
+    collectDistReferences({
+      main: pkg.main,
+      module: pkg.module,
+      types: pkg.types,
+      bin: pkg.bin,
+      exports: pkg.exports,
+    }).size > 0
+  );
+}
+
+function expandLernaPackagePattern(pattern) {
+  if (!pattern.includes("*")) return [pattern];
+  const [baseDir, suffix = ""] = pattern.split("*");
+  const normalizedBase = baseDir.replace(/\/$/, "");
+  const absoluteBase = join(repoRoot, normalizedBase);
+  if (!existsSync(absoluteBase)) return [];
+  return readdirSync(absoluteBase, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) =>
+      join(normalizedBase, entry.name, suffix.replace(/^\//, "")).replace(
+        /\\/g,
+        "/",
+      ),
+    );
+}
+
+function isTrackedPackageManifest(packageJsonPath) {
+  try {
+    execFileSync(
+      "git",
+      ["ls-files", "--error-unmatch", relative(repoRoot, packageJsonPath)],
+      { cwd: repoRoot, stdio: "ignore" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function discoverPublicDistPackageDirs() {
+  const lerna = JSON.parse(readFileSync(join(repoRoot, "lerna.json"), "utf8"));
+  const dirs = new Set();
+  for (const pattern of lerna.packages ?? []) {
+    for (const packageDir of expandLernaPackagePattern(pattern)) {
+      const packageJsonPath = join(repoRoot, packageDir, "package.json");
+      if (!existsSync(packageJsonPath)) continue;
+      if (!isTrackedPackageManifest(packageJsonPath)) continue;
+      const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      if (pkg.private === true) continue;
+      if (!expectsDist(pkg)) continue;
+      dirs.add(packageDir);
+    }
+  }
+  return [...dirs].sort();
+}
+
+function npmInvocation(extraArgs) {
+  if (process.platform === "win32") {
+    const npmCliPath = join(
+      dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    if (existsSync(npmCliPath)) {
+      return { command: process.execPath, args: [npmCliPath, ...extraArgs] };
+    }
+  }
+  return { command: "npm", args: extraArgs };
+}
+
+function parsePackJson(output) {
+  const trimmed = output.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const match = trimmed.match(/\[\s*\{[\s\S]*\]\s*$/);
+    if (!match) throw new Error(`Unable to parse npm pack JSON:\n${trimmed}`);
+    return JSON.parse(match[0]);
+  }
+}
+
+mkdirSync(outDir, { recursive: true });
+
+const allPackageDirs = discoverPublicDistPackageDirs();
+if (allPackageDirs.length === 0) {
+  console.error(
+    "No public dist packages discovered — refusing to emit an empty artifact set.",
+  );
+  process.exit(1);
+}
+
+function packageName(packageDir) {
+  return JSON.parse(
+    readFileSync(join(repoRoot, packageDir, "package.json"), "utf8"),
+  ).name;
+}
+
+let packageDirs;
+if (packAll) {
+  packageDirs = allPackageDirs;
+} else {
+  const wanted = explicitPackages ?? new Set(HEADLINE_PACKAGES);
+  const byName = new Map(allPackageDirs.map((d) => [packageName(d), d]));
+  packageDirs = [...wanted].map((name) => {
+    const dir = byName.get(name);
+    if (!dir) {
+      console.error(
+        `Requested package '${name}' is not a public dist package — aborting so the release does not silently drop it.`,
+      );
+      process.exit(1);
+    }
+    return dir;
+  });
+}
+
+console.log(
+  `Packing ${packageDirs.length}/${allPackageDirs.length} public package(s) into ${outDir}`,
+);
+
+const checksums = [];
+for (const packageDir of packageDirs) {
+  const absoluteDir = join(repoRoot, packageDir);
+  const pkg = JSON.parse(
+    readFileSync(join(absoluteDir, "package.json"), "utf8"),
+  );
+  const npm = npmInvocation(["pack", "--json", "--pack-destination", outDir]);
+  const output = execFileSync(npm.command, npm.args, {
+    cwd: absoluteDir,
+    encoding: "utf8",
+    env: { ...process.env, npm_config_loglevel: "error" },
+  });
+  const filename = parsePackJson(output)[0]?.filename;
+  if (!filename) {
+    throw new Error(`npm pack did not report a filename for ${pkg.name}`);
+  }
+  const tarballPath = join(outDir, filename);
+  if (!existsSync(tarballPath)) {
+    throw new Error(`Expected tarball not found: ${tarballPath}`);
+  }
+  const digest = createHash("sha256")
+    .update(readFileSync(tarballPath))
+    .digest("hex");
+  checksums.push(`${digest}  ${filename}`);
+  console.log(`  ✅ ${filename}`);
+}
+
+writeFileSync(join(outDir, "SHA256SUMS-npm.txt"), `${checksums.join("\n")}\n`);
+console.log(
+  `\n✅ ${checksums.length} tarball(s) + SHA256SUMS-npm.txt written to ${outDir}`,
+);


### PR DESCRIPTION
Supersedes #11859 and closes #11858.

This is the same release-binaries change from #11859, rebased onto current `origin/develop` after #11857 merged. It stages downloadable release assets for GitHub Releases:

- standalone `elizaos` CLI archives for linux/darwin/windows targets
- headline npm `.tgz` tarballs plus npm checksum file
- combined `SHA256SUMS.txt`

It also makes the compiled CLI resolve templates, `templates-manifest.json`, and `package.json` next to the executable when running from Bun's `/$bunfs` virtual root.

Local validation in `/tmp/eliza-11859-pr`:

- `actionlint .github/workflows/release.yaml`
- `git diff --check origin/develop...HEAD`
- `bun install --ignore-scripts` to provide the workspace toolchain in the temp worktree
- `bun run --cwd packages/elizaos typecheck`
- `bun run --cwd packages/elizaos lint:check`
- `bun test --cwd packages/elizaos src/package-info.test.ts`
- `bun run --cwd packages/elizaos build && bun run --cwd packages/elizaos test:standalone`
- `bun run --cwd packages/elizaos build && node packages/scripts/pack-release-artifacts.mjs --out /tmp/eliza-release-artifacts-npm --packages elizaos`

Observed artifacts:

- compiled `linux-x64` standalone archive exercised with `version`, `info`, and `create --template plugin --yes`
- generated plugin scaffold with `package.json` and `.elizaos/template.json`
- `/tmp/eliza-release-artifacts-npm/elizaos-2.0.3-beta.7.tgz`
- `/tmp/eliza-release-artifacts-npm/SHA256SUMS-npm.txt`

N/A: UI screenshots/video/frontend logs, real-LLM trajectories, native/device capture. This is release/CLI packaging automation only.