### PR TITLE
feat: add elizaos-plugin-true402 to registry

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-true402.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-true402.json
@@ -1,0 +1,19 @@
+{
+  "package": "elizaos-plugin-true402",
+  "repository": "github:true402/elizaos-plugin-true402",
+  "kind": "plugin",
+  "description": "Pre-trade rug/honeypot guard for Base tokens — real buy/sell simulation plus liquidity and ownership checks, pay-per-call over x402 (USDC on Base). No accounts, no API keys; free daily trial.",
+  "homepage": "https://true402.dev",
+  "version": "0.1.1",
+  "tags": [
+    "x402",
+    "base",
+    "usdc",
+    "token-safety",
+    "rug-check",
+    "honeypot",
+    "defi",
+    "micropayments",
+    "trading"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -748,6 +748,55 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-true402": {
+      "git": {
+        "repo": "true402/elizaos-plugin-true402",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-true402",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Pre-trade rug/honeypot guard for Base tokens — real buy/sell simulation plus liquidity and ownership checks, pay-per-call over x402 (USDC on Base). No accounts, no API keys; free daily trial.",
+      "homepage": "https://true402.dev",
+      "topics": [
+        "x402",
+        "base",
+        "usdc",
+        "token-safety",
+        "rug-check",
+        "honeypot",
+        "defi",
+        "micropayments",
+        "trading"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "plugin-agentscoin": {
       "git": {
         "repo": "axiosdevs/plugin-agentscoin",


### PR DESCRIPTION
## Summary
- adds the elizaos-plugin-true402 third-party registry source entry from #11849
- regenerates packages/registry/generated-registry.json so the runtime wire registry includes it

## Validation
- npm view elizaos-plugin-true402 version keywords description --json (confirmed 0.1.1 and elizaOS plugin keywords)
- bun run --cwd packages/registry validate
- bun run --cwd packages/registry generate
- bun run --cwd packages/registry test
- bun run --cwd packages/registry typecheck
- git diff --check

Supersedes #11849 because the contributor fork branch could not be updated by maintainer credentials, but the registry package requires the generated file to be committed.