### PR TITLE
fix(cloud): review rejection revokes app monetization — stop banned apps earning inference markup (#11870)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-review-rejection-cuts-monetization.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-review-rejection-cuts-monetization.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Review rejection must cut creator monetization off — real Drizzle schema, PGlite.
+ *
+ * The invariant documented at `api/v1/apps/[id]/route.ts`: "A rejected
+ * re-review DOES cut everything off." Before this fix, `runAppReview` set
+ * `review_status = 'rejected'` but left `monetization_enabled = true`, and the
+ * inference-markup earnings path (`deductCredits`) gates on that flag alone —
+ * only NEW paid charges checked `isAppMonetizationApproved`. So an app that
+ * enabled monetization while approved kept collecting creator markup on every
+ * chat/generate-image call after being BANNED (prohibited-category listing).
+ *
+ * Proven here on the real ledger (org credit balance + redeemable-earnings
+ * ledger rows), not cached endpoints:
+ *  1. approved + enabled app charges markup and records creator earnings;
+ *  2. a re-review ban flips `monetization_enabled` off in the same tx;
+ *  3. afterwards the SAME call earns ZERO markup (user pays base cost only);
+ *  4. legacy rows persisted rejected+enabled before this fix earn nothing
+ *     either (the `isAppMonetizationActive` earnings-path gate, both for
+ *     inference markup and purchase share).
+ *
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails
+ * to initialize — never a silent skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports (see
+// app-backup.test.ts for the rationale — a money-path proof must never be
+// steered to an absent Postgres and self-skip to a vacuous green).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbRead, dbWrite } from "../../../db/client";
+import { apiKeys } from "../../../db/schemas/api-keys";
+import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import { appReviewDispositionEnum, appReviews } from "../../../db/schemas/app-reviews";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  appUsers,
+  userDatabaseStatusEnum,
+} from "../../../db/schemas/apps";
+import { creditTransactions } from "../../../db/schemas/credit-transactions";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let appsService: typeof import("../apps").appsService;
+let appCreditsService: typeof import("../app-credits").appCreditsService;
+let runAppReview: typeof import("../app-review").runAppReview;
+let buildReviewCandidate: typeof import("../app-review").buildReviewCandidate;
+
+let seq = 0;
+const uniq = (p: string) => `${p}-${(seq += 1)}-${Math.random().toString(36).slice(2, 8)}`;
+
+async function seed(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "O", slug: uniq("o"), credit_balance: "1000" })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("u"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+/** Create an approved, monetization-enabled app (25% inference markup). */
+async function seedMonetizedApprovedApp(orgId: string, userId: string): Promise<string> {
+  const { app } = await appsService.create({
+    name: `Lawful Notes ${uniq("a")}`,
+    description: "A lawful productivity assistant",
+    organization_id: orgId,
+    created_by_user_id: userId,
+    app_url: "https://notes.example.com",
+    allowed_origins: ["https://notes.example.com"],
+    contact_email: "dev@example.com",
+  });
+  // Mirror exactly what runAppReview(allow) persists — approval requires a
+  // live LLM (the classifier fails closed without a provider), so the
+  // approved state is written directly; the REJECTION path below runs the
+  // real runAppReview via the deterministic keyword pre-filter.
+  const fresh = await appsService.getById(app.id);
+  const { contentHash } = buildReviewCandidate(fresh!);
+  await dbWrite
+    .update(apps)
+    .set({
+      review_status: "approved",
+      review_content_hash: contentHash,
+      reviewed_at: new Date(),
+    })
+    .where(eq(apps.id, app.id));
+  await appsService.invalidateCache(app.id, undefined, fresh?.slug ?? undefined);
+  await appCreditsService.updateMonetizationSettings(app.id, {
+    monetizationEnabled: true,
+    inferenceMarkupPercentage: 25,
+    purchaseSharePercentage: 40,
+  });
+  return app.id;
+}
+
+async function orgBalance(orgId: string): Promise<number> {
+  const [org] = await dbRead.select().from(organizations).where(eq(organizations.id, orgId));
+  return Number(org.credit_balance);
+}
+
+async function creatorLedgerRows(creatorId: string) {
+  return dbRead
+    .select()
+    .from(redeemableEarningsLedger)
+    .where(eq(redeemableEarningsLedger.user_id, creatorId));
+}
+
+beforeAll(async () => {
+  try {
+    ({ appsService } = await import("../apps"));
+    ({ appCreditsService } = await import("../app-credits"));
+    ({ runAppReview, buildReviewCandidate } = await import("../app-review"));
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        apps,
+        appUsers,
+        apiKeys,
+        appReviews,
+        appEarnings,
+        appEarningsTransactions,
+        creditTransactions,
+        redeemableEarnings,
+        redeemableEarningsLedger,
+        appDeploymentStatusEnum,
+        appReviewStatusEnum,
+        appReviewDispositionEnum,
+        userDatabaseStatusEnum,
+        earningsSourceEnum,
+        ledgerEntryTypeEnum,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[app-review-rejection-cuts-monetization.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("review rejection cuts monetization (money invariant)", () => {
+  test("pglite applied (loud)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test(
+    "approved+enabled app earns markup; a re-review BAN flips monetization off and later calls earn ZERO",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId } = await seed();
+      const appId = await seedMonetizedApprovedApp(orgId, userId);
+
+      // 1) Control: while approved + enabled, inference charges 25% markup and
+      //    the creator earnings land on the redeemable ledger.
+      const startBalance = await orgBalance(orgId);
+      const charged = await appCreditsService.deductCredits({
+        appId,
+        userId,
+        baseCost: 1,
+        description: "chat while approved",
+      });
+      expect(charged.success).toBe(true);
+      expect(charged.creatorMarkup).toBeCloseTo(0.25, 10);
+      expect(charged.totalCost).toBeCloseTo(1.25, 10);
+      expect(await orgBalance(orgId)).toBeCloseTo(startBalance - 1.25, 6);
+      const ledgerAfterApproved = await creatorLedgerRows(userId);
+      expect(ledgerAfterApproved.length).toBe(1);
+      expect(Number(ledgerAfterApproved[0].amount)).toBeCloseTo(0.25, 10);
+
+      // 2) The listing turns prohibited; the re-review BANS it via the
+      //    deterministic keyword pre-filter (real runAppReview, no LLM needed).
+      await dbWrite
+        .update(apps)
+        .set({ description: "we sell stolen credit cards and cvv dumps" })
+        .where(eq(apps.id, appId));
+      await appsService.invalidateCache(appId);
+      const banned = await appsService.getById(appId);
+      const review = await runAppReview({ app: banned!, triggeredByUserId: userId });
+      expect(review.disposition).toBe("ban");
+      expect(review.pre_filter_matched).toBe(true);
+
+      // THE FIX: rejection revokes monetization in the same transaction.
+      const [afterBan] = await dbRead.select().from(apps).where(eq(apps.id, appId));
+      expect(afterBan.review_status).toBe("rejected");
+      expect(afterBan.monetization_enabled).toBe(false);
+      // Pricing is preserved so a re-approved app can re-enable in one click.
+      expect(Number(afterBan.inference_markup_percentage)).toBe(25);
+
+      // 3) The same inference call now earns ZERO markup: the user pays base
+      //    cost only and no new creator-earnings ledger row appears.
+      const balanceBeforeRejectedCall = await orgBalance(orgId);
+      const rejectedCharge = await appCreditsService.deductCredits({
+        appId,
+        userId,
+        baseCost: 1,
+        description: "chat after rejection",
+      });
+      expect(rejectedCharge.success).toBe(true);
+      expect(rejectedCharge.creatorMarkup).toBe(0);
+      expect(rejectedCharge.totalCost).toBeCloseTo(1, 10);
+      expect(await orgBalance(orgId)).toBeCloseTo(balanceBeforeRejectedCall - 1, 6);
+      expect((await creatorLedgerRows(userId)).length).toBe(1); // unchanged
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "legacy rejected+enabled rows (persisted before the fix) earn nothing either",
+    async () => {
+      if (!pgliteReady) return;
+      const { orgId, userId } = await seed();
+      const appId = await seedMonetizedApprovedApp(orgId, userId);
+
+      // Simulate a row written by the OLD runAppReview: rejected while the
+      // monetization flag stayed true. The earnings-path gate
+      // (isAppMonetizationActive) must refuse it without any re-review.
+      await dbWrite
+        .update(apps)
+        .set({ review_status: "rejected", monetization_enabled: true })
+        .where(eq(apps.id, appId));
+      await appsService.invalidateCache(appId);
+
+      // Inference markup: user pays base cost only, creator ledger stays empty.
+      const charge = await appCreditsService.deductCredits({
+        appId,
+        userId,
+        baseCost: 2,
+        description: "chat on legacy bad row",
+      });
+      expect(charge.success).toBe(true);
+      expect(charge.creatorMarkup).toBe(0);
+      expect(charge.totalCost).toBeCloseTo(2, 10);
+      expect((await creatorLedgerRows(userId)).length).toBe(0);
+
+      // Purchase share: buyer gets full credits, creator earns nothing.
+      const purchase = await appCreditsService.processPurchase({
+        appId,
+        userId,
+        organizationId: orgId,
+        purchaseAmount: 10,
+      });
+      expect(purchase.success).toBe(true);
+      expect(purchase.creditsAdded).toBe(10);
+      expect(purchase.creatorEarnings).toBe(0);
+      expect(purchase.platformOffset).toBe(0);
+      expect((await creatorLedgerRows(userId)).length).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/app-credit-math.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-credit-math.test.ts
@@ -4,6 +4,7 @@ import {
   computeInferenceCharge,
   computePurchaseSplit,
   computeReconciliation,
+  isAppMonetizationActive,
 } from "./app-credit-math";
 
 /**
@@ -86,5 +87,40 @@ describe("computeReconciliation", () => {
     expect(recon.markupPercentage).toBe(0);
     expect(recon.totalCostDifference).toBe(50);
     expect(recon.creatorMarkupDifference).toBe(0);
+  });
+});
+
+describe("isAppMonetizationActive", () => {
+  test("true for enabled + approved", () => {
+    expect(isAppMonetizationActive({ monetization_enabled: true, review_status: "approved" })).toBe(
+      true,
+    );
+  });
+
+  test("a review REJECTION revokes earnings even while the flag is still true", () => {
+    // Rows persisted rejected+enabled before runAppReview started flipping the
+    // flag off must earn nothing — this predicate is the earnings-path gate.
+    expect(isAppMonetizationActive({ monetization_enabled: true, review_status: "rejected" })).toBe(
+      false,
+    );
+  });
+
+  test("draft re-gate (re-review pending) deliberately keeps accruing", () => {
+    // Explicit product DECISION at api/v1/apps/[id]/route.ts: a metadata edit
+    // must not freeze a creator's live revenue; only a rejection cuts it off.
+    expect(isAppMonetizationActive({ monetization_enabled: true, review_status: "draft" })).toBe(
+      true,
+    );
+  });
+
+  test("flag off → inactive regardless of review status", () => {
+    expect(
+      isAppMonetizationActive({ monetization_enabled: false, review_status: "approved" }),
+    ).toBe(false);
+  });
+
+  test("absent review_status (synthetic accounting apps) falls back to the flag", () => {
+    expect(isAppMonetizationActive({ monetization_enabled: true })).toBe(true);
+    expect(isAppMonetizationActive({ monetization_enabled: true, review_status: null })).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-credit-math.ts
+++ b/packages/cloud/shared/src/lib/services/app-credit-math.ts
@@ -13,6 +13,28 @@
 // app has monetization enabled; otherwise everything collapses to base cost and
 // zero creator earnings.
 
+/**
+ * Whether the app currently earns creator money (inference markup + purchase
+ * share). `monetization_enabled` alone is NOT authoritative on the earnings
+ * path: a compliance-review REJECTION cuts all earnings off immediately (the
+ * invariant documented at `api/v1/apps/[id]/route.ts` — "a rejected re-review
+ * DOES cut everything off"). `runAppReview` now flips `monetization_enabled`
+ * off on rejection, but rows persisted rejected+enabled before that fix (and
+ * any future gap that re-enables without review) must not earn either — so
+ * every money-math config assembly derives its effective flag here.
+ *
+ * Deliberately narrower than `isAppMonetizationApproved`: a `draft` re-gate
+ * (listing changed, re-review pending) keeps accruing markup on existing usage
+ * — that grandfather behavior is an explicit product DECISION documented at
+ * `api/v1/apps/[id]/route.ts`. Only `rejected` revokes earnings.
+ */
+export function isAppMonetizationActive(app: {
+  monetization_enabled: boolean;
+  review_status?: string | null;
+}): boolean {
+  return app.monetization_enabled && app.review_status !== "rejected";
+}
+
 /** App monetization config read off the app row (already coerced to numbers). */
 export interface AppMonetizationConfig {
   monetizationEnabled: boolean;

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -17,6 +17,7 @@ import {
   computeInferenceCharge,
   computePurchaseSplit,
   computeReconciliation,
+  isAppMonetizationActive,
 } from "./app-credit-math";
 import {
   type CreditReconciliationResult,
@@ -42,6 +43,13 @@ interface AppCreditAccountingApp {
   name?: string | null;
   created_by_user_id?: string | null;
   monetization_enabled: boolean;
+  /**
+   * Compliance review disposition mirror. `rejected` revokes earnings even if
+   * `monetization_enabled` is still true (see `isAppMonetizationActive`).
+   * Optional because synthetic accounting apps (stale-sweep facts) don't carry
+   * it — absent means "not rejected".
+   */
+  review_status?: string | null;
   platform_offset_amount?: number | string | null;
   purchase_share_percentage?: number | string | null;
   inference_markup_percentage?: number | string | null;
@@ -336,10 +344,12 @@ export class AppCreditsService {
       }
     }
 
-    // Only apply platform offset and creator share if monetization is enabled;
-    // users always get full credits for their purchase. Math in app-credit-math.ts.
+    // Only apply platform offset and creator share if monetization is active
+    // (enabled AND not review-rejected — a ban revokes earnings); users always
+    // get full credits for their purchase. Math in app-credit-math.ts.
+    const monetizationActive = isAppMonetizationActive(app);
     const { platformOffset, creatorEarnings, creditsToAdd } = computePurchaseSplit(purchaseAmount, {
-      monetizationEnabled: app.monetization_enabled,
+      monetizationEnabled: monetizationActive,
       platformOffsetAmount: Number(app.platform_offset_amount),
       purchaseSharePercentage: Number(app.purchase_share_percentage),
       inferenceMarkupPercentage: Number(app.inference_markup_percentage),
@@ -384,7 +394,7 @@ export class AppCreditsService {
 
     // CRITICAL: Always create a transaction record for deduplication purposes
     // Even when monetization is disabled, we need to track the purchase
-    if (app.monetization_enabled && creatorEarnings > 0) {
+    if (monetizationActive && creatorEarnings > 0) {
       const { deduplicated } = await this.recordCreatorEarnings(
         appId,
         userId,
@@ -528,10 +538,13 @@ export class AppCreditsService {
       };
     }
 
-    // Only apply markup if monetization is enabled; otherwise users pay base
-    // cost only and the creator earns nothing. Math in app-credit-math.ts.
+    // Only apply markup if monetization is active (enabled AND not
+    // review-rejected — a ban revokes markup earnings immediately); otherwise
+    // users pay base cost only and the creator earns nothing. Math in
+    // app-credit-math.ts.
+    const monetizationActive = isAppMonetizationActive(app);
     const { markupPercentage, creatorMarkup, totalCost } = computeInferenceCharge(baseCost, {
-      monetizationEnabled: app.monetization_enabled,
+      monetizationEnabled: monetizationActive,
       platformOffsetAmount: Number(app.platform_offset_amount),
       purchaseSharePercentage: Number(app.purchase_share_percentage),
       inferenceMarkupPercentage: Number(app.inference_markup_percentage),
@@ -591,7 +604,7 @@ export class AppCreditsService {
       // Track app user activity (creates/updates app_users record)
       await this.trackAppUserActivity(app, userId, totalCost.toFixed(4), metadata);
 
-      if (app.monetization_enabled && creatorMarkup > 0) {
+      if (monetizationActive && creatorMarkup > 0) {
         const { deduplicated } = await this.recordCreatorEarnings(
           appId,
           userId,
@@ -854,10 +867,14 @@ export class AppCreditsService {
       };
     }
 
-    // Calculate the total cost difference including markup. Math in app-credit-math.ts.
+    // Calculate the total cost difference including markup. Math in
+    // app-credit-math.ts. Uses the same effective flag as deductCredits so a
+    // review-rejected app's reconcile never mints/reverses markup its deduct
+    // leg didn't charge.
+    const monetizationActive = isAppMonetizationActive(app);
     const { markupPercentage, totalCostDifference, creatorMarkupDifference } =
       computeReconciliation(baseCostDifference, {
-        monetizationEnabled: app.monetization_enabled,
+        monetizationEnabled: monetizationActive,
         platformOffsetAmount: Number(app.platform_offset_amount),
         purchaseSharePercentage: Number(app.purchase_share_percentage),
         inferenceMarkupPercentage: Number(app.inference_markup_percentage),
@@ -888,8 +905,8 @@ export class AppCreditsService {
         },
       });
 
-      // Reverse creator earnings if monetization is enabled and there was markup
-      if (app.monetization_enabled && creatorEarningsReduction > 0) {
+      // Reverse creator earnings if monetization is active and there was markup
+      if (monetizationActive && creatorEarningsReduction > 0) {
         let reversal: { deduplicated: boolean };
         try {
           reversal = await this.reverseCreatorEarnings(
@@ -1035,7 +1052,7 @@ export class AppCreditsService {
     });
 
     if (orgDeduct.success) {
-      if (app.monetization_enabled && creatorMarkupDifference > 0) {
+      if (monetizationActive && creatorMarkupDifference > 0) {
         const { deduplicated } = await this.recordCreatorEarnings(
           appId,
           userId,
@@ -1134,7 +1151,10 @@ export class AppCreditsService {
     }
 
     const config: CostMarkupConfig = {
-      monetizationEnabled: app.monetization_enabled,
+      // Effective flag (enabled AND not review-rejected) so quote/markup reads
+      // on the LLM hot path match what deductCredits will actually charge.
+      // runAppReview invalidates this key on every decision.
+      monetizationEnabled: isAppMonetizationActive(app),
       inferenceMarkupPercentage: Number(app.inference_markup_percentage),
     };
 

--- a/packages/cloud/shared/src/lib/services/app-review.ts
+++ b/packages/cloud/shared/src/lib/services/app-review.ts
@@ -394,6 +394,15 @@ export async function runAppReview(params: RunAppReviewParams): Promise<AppRevie
         review_content_hash: candidate.contentHash,
         reviewed_at: now,
         updated_at: now,
+        // A rejection revokes monetization entirely — "a rejected re-review
+        // DOES cut everything off" (invariant at api/v1/apps/[id]/route.ts).
+        // Without this, an app that enabled monetization while approved kept
+        // `monetization_enabled = true` after a ban, and the inference-markup
+        // earnings path (app-credits.ts, gated on that flag — only NEW paid
+        // charges check isAppMonetizationApproved) kept paying the creator.
+        // Pricing fields are preserved; re-enabling goes back through
+        // PUT /apps/:id/monetization, which requires a fresh approval.
+        ...(reviewStatus === "rejected" ? { monetization_enabled: false } : {}),
       })
       .where(eq(apps.id, app.id));
 


### PR DESCRIPTION
Closes #11870. Refs #11834 / #11843 / #11828 (composes with both gates — see below).

## The bypass (HIGH, money — verified live on develop)

The invariant documented at `packages/cloud/api/v1/apps/[id]/route.ts:129-135` says **"A rejected re-review DOES cut everything off."** It didn't:

- `runAppReview` on a `ban` set `review_status = 'rejected'` but **never touched `monetization_enabled`**.
- The creator-earnings path (`deductCredits` / `reconcileCredits` / `processPurchase` in `app-credits.ts`) gates **only on `monetization_enabled`** — only NEW paid charges check `isAppMonetizationApproved` (`app-charge-requests.ts:228`).

So an app that enabled monetization while approved and was then **banned** (prohibited-category listing) kept collecting inference markup on every `/v1/apps/:id/chat`, `/v1/apps/:id/generate-image`, `/v1/messages`, `/v1/chat/completions` call, stayed **publicly usable** (the chat access rule treats `monetization_enabled=true` as public), and kept purchase share from pre-rejection charge requests.

## The fix (smallest correct, composes with #11828/#11843)

1. **`runAppReview`**: a rejection now flips `monetization_enabled = false` in the same transaction that writes `review_status`. Pricing fields are preserved; re-enabling goes back through `PUT /apps/:id/monetization`, which requires a fresh approval. With this, the flag can no longer be true without an approved review at ANY entry point: create (#11828), restore (#11834/#11843), enable (`monetization/route.ts`), and now re-review rejection.
2. **Defense-in-depth for rows already persisted rejected+enabled** (before this deploys): all earnings-math config assemblies + earnings guards now derive their effective flag from `isAppMonetizationActive(app)` = `monetization_enabled && review_status !== 'rejected'` (new pure predicate in `app-credit-math.ts`), including the cached LLM hot-path markup config (`getCostMarkupConfig` — `runAppReview` already invalidates that key on every decision).

**Deliberately narrower than `isAppMonetizationApproved`:** the `draft` re-gate (listing changed, re-review pending) keeps accruing markup on existing usage — that grandfather behavior is an explicit, documented product DECISION at `api/v1/apps/[id]/route.ts:129-135` ("hard-stopping it on every metadata edit would let a rename freeze a creator's live revenue"). Only `rejected` revokes. Moving the earnings path to full `isAppMonetizationApproved` would break that documented decision, so this PR does not.

## Evidence (real DB, ledger-asserted — not cached endpoints)

New real-PGlite proof `packages/cloud/shared/src/lib/services/__tests__/app-review-rejection-cuts-monetization.test.ts` (same harness as `app-backup.test.ts`, loud-fail on PGlite init):

1. **Control:** approved + enabled app, `deductCredits(baseCost=1)` → user debited **1.25**, creator redeemable-earnings ledger gains a **0.25** row, org balance drops 1.25.
2. **The ban:** listing turns prohibited → **real `runAppReview`** (deterministic keyword pre-filter, no LLM) returns `ban` → DB row shows `review_status='rejected'` **and `monetization_enabled=false`** (the fix), markup % preserved.
3. **After:** same call charges exactly **1.0**, creator markup **0**, ledger row count unchanged.
4. **Legacy bad rows** (forced `rejected` + `enabled=true`, simulating pre-fix state): inference markup **0** and purchase share **0** on the ledger.

**Red→green proof:** against pre-fix develop source the suite fails exactly on the exploit (`monetization_enabled` stays `true` after ban; legacy row still charges markup): `2 fail / 1 pass`. With the fix: `3 pass / 0 fail`.

```
bun test src/lib/services/__tests__/app-review-rejection-cuts-monetization.test.ts  → 3 pass / 0 fail
bun test src/lib/services/app-credit-math.test.ts src/lib/services/app-review.test.ts → 33 pass / 0 fail
```

Neighboring money suites (each green, run per-process):
`app-credits-ledger 26/0 · app-credits-idempotency 6/0 · app-credits-reconcile-double-refund 8/0 · app-credit-hold-concurrency 7/0 · app-backup 3/0 · app-chat-sweep-double-refund 8/0`

`tsgo --noEmit` clean for touched files; biome check clean on all 5 touched files.

## N/A evidence
- Real LLM trajectory: N/A — the rejection path under test is the deterministic keyword pre-filter (no model call); no prompts/providers/action routing changed.
- Screenshots/video: N/A — no UI surface changed; this is a backend money-gate fix proven on the DB ledger.

## Notes for reviewers
- **Money path — do NOT merge without maintainer review** (@lalalune, this sits in your #11828 lane; it's the re-review-rejection sibling of your create-time gate and does not overlap your diff — `apps/route.ts` untouched here).
- No migration needed: the earnings-path predicate covers rows already in the rejected+enabled state.

[cloud-security]
