### PR TITLE
fix(local-inference): graceful non-speculative fallback for a missing MTP drafter GGUF — #11517 back-compat, never brick an installed model

### DIFF
--- a/packages/ui/src/services/local-inference/active-model.test.ts
+++ b/packages/ui/src/services/local-inference/active-model.test.ts
@@ -1,14 +1,18 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   isForkOnlyKvCacheType,
   isStockKvCacheType,
   resolveLocalInferenceLoadArgs,
   validateLocalInferenceLoadArgs,
 } from "./active-model";
-import { ELIZA_1_MTP_TIER_IDS } from "./catalog";
+import {
+  ELIZA_1_HOSTED_MTP_TIER_IDS,
+  ELIZA_1_MTP_TIER_IDS,
+  findCatalogModel,
+} from "./catalog";
 import type { InstalledModel } from "./types";
 
 function makeInstalledModel(
@@ -35,8 +39,9 @@ function makeTempElizaBundle(
   const bundleRoot = mkdtempSync(pathJoin(tmpdir(), "eliza-ui-mtp-"));
   mkdirSync(pathJoin(bundleRoot, "text"), { recursive: true });
   const textPath = pathJoin(bundleRoot, "text", `eliza-1-${tier}-32k.gguf`);
-  // Shape a would-be separate-drafter MTP file. The resolver should ignore it
-  // until the shared catalog says that hosted Gemma drafter GGUFs are present.
+  // Shape a separate-drafter MTP file. The resolver wires it only for tiers
+  // whose drafter is hosted in the shared catalog (ELIZA_1_HOSTED_MTP_TIER_IDS)
+  // and ignores stray on-disk drafters for every other tier.
   const drafterPath = pathJoin(bundleRoot, "mtp", `drafter-${tier}.gguf`);
   writeFileSync(textPath, "fake-text-gguf");
   if (options.hasMtp !== false) {
@@ -121,8 +126,31 @@ describe("resolveLocalInferenceLoadArgs", () => {
     expect(args.kvOffload).toEqual({ gpuLayers: 10 });
   });
 
-  it("does not enable MTP args until hosted Gemma drafter GGUFs are cataloged", async () => {
-    for (const id of ELIZA_1_MTP_TIER_IDS) {
+  it("enables MTP args for hosted-drafter tiers whose drafter GGUF is bundled", async () => {
+    expect(ELIZA_1_HOSTED_MTP_TIER_IDS.length).toBeGreaterThan(0);
+    for (const id of ELIZA_1_HOSTED_MTP_TIER_IDS) {
+      const tier = id.replace("eliza-1-", "");
+      const bundle = makeTempElizaBundle(tier);
+      const target = makeInstalledModel(id, bundle.textPath, bundle.bundleRoot);
+      const mtp = findCatalogModel(id)?.runtime?.mtp;
+      expect(mtp?.specType).toBe("draft-mtp");
+      try {
+        const args = await resolveLocalInferenceLoadArgs(target);
+        expect(args.draftModelPath).toBe(bundle.drafterPath);
+        expect(args.draftMin).toBe(mtp?.draftMin);
+        expect(args.draftMax).toBe(mtp?.draftMax);
+        expect(args.mobileSpeculative).toBe(true);
+      } finally {
+        rmSync(bundle.bundleRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("ignores a stray on-disk drafter for tiers without a hosted Gemma drafter", async () => {
+    const hosted = new Set<string>(ELIZA_1_HOSTED_MTP_TIER_IDS);
+    const unhosted = ELIZA_1_MTP_TIER_IDS.filter((id) => !hosted.has(id));
+    expect(unhosted.length).toBeGreaterThan(0);
+    for (const id of unhosted) {
       const tier = id.replace("eliza-1-", "");
       const bundle = makeTempElizaBundle(tier);
       const target = makeInstalledModel(id, bundle.textPath, bundle.bundleRoot);
@@ -138,7 +166,12 @@ describe("resolveLocalInferenceLoadArgs", () => {
     }
   });
 
-  it("does not require a drafter GGUF while hosted Gemma MTP is unavailable", async () => {
+  it("falls back to a non-speculative load when a pre-cutover bundle is missing the drafter GGUF", async () => {
+    // Back-compat (#11517): a bundle installed BEFORE the Gemma-4 MTP cutover
+    // has no `mtp/drafter-*.gguf` on disk. The drafter is a perf-only
+    // speculative-decoding artifact, so the model must still load (warn +
+    // plain decode) — never hard-throw and brick the install.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const bundle = makeTempElizaBundle("2b", { hasMtp: false });
     try {
       const target = makeInstalledModel(
@@ -147,9 +180,18 @@ describe("resolveLocalInferenceLoadArgs", () => {
         bundle.bundleRoot,
       );
       const args = await resolveLocalInferenceLoadArgs(target);
+      expect(args.modelPath).toBe(bundle.textPath);
       expect(args.draftModelPath).toBeUndefined();
+      expect(args.draftMin).toBeUndefined();
+      expect(args.draftMax).toBeUndefined();
       expect(args.mobileSpeculative).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Re-download the model to enable the MTP drafter",
+        ),
+      );
     } finally {
+      warnSpy.mockRestore();
       rmSync(bundle.bundleRoot, { recursive: true, force: true });
     }
   });

--- a/packages/ui/src/services/local-inference/active-model.ts
+++ b/packages/ui/src/services/local-inference/active-model.ts
@@ -371,24 +371,33 @@ export async function resolveLocalInferenceLoadArgs(
   if (mtp) {
     // Same-file MTP (no `drafterFile`) embeds the NextN head in the text
     // GGUF and runs with no separate draft model; separate-drafter MTP
-    // declares a `drafterFile` and requires it present on disk.
+    // declares a `drafterFile` and needs the bundled drafter GGUF on disk.
     const sameFileMtp = !mtp.drafterFile;
     const drafterPath = sameFileMtp
       ? undefined
       : resolveMtpDrafterPath(installed, catalog);
-    if (!sameFileMtp && installed.bundleRoot && !drafterPath) {
-      throw new Error(
-        `[local-inference] ${installed.id} declares a separate-drafter MTP but no bundled drafter GGUF was found under ${installed.bundleRoot}`,
+    if (!sameFileMtp && !drafterPath) {
+      // Back-compat with pre-MTP-cutover installs (#11517): bundles
+      // downloaded before the tier's gemma4-assistant drafter was hosted
+      // (and single-file installs with no bundleRoot) have no
+      // `mtp/drafter-<tier>.gguf` on disk. The drafter is a perf-only
+      // speculative-decoding artifact — never brick an installed model over
+      // it. Load without MTP; re-downloading the bundle picks the drafter up.
+      console.warn(
+        `[local-inference] ${installed.id} declares a separate-drafter MTP but no drafter GGUF was found${
+          installed.bundleRoot ? ` under ${installed.bundleRoot}` : ""
+        }; loading without speculative decoding. Re-download the model to enable the MTP drafter.`,
       );
+    } else {
+      args.useGpu = true;
+      args.draftModelPath = drafterPath;
+      args.draftContextSize = args.contextSize;
+      args.draftMin = mtp.draftMin;
+      args.draftMax = mtp.draftMax;
+      args.speculativeSamples = mtp.draftMax;
+      args.mobileSpeculative = true;
+      args.disableThinking = true;
     }
-    args.useGpu = true;
-    args.draftModelPath = drafterPath;
-    args.draftContextSize = args.contextSize;
-    args.draftMin = mtp.draftMin;
-    args.draftMax = mtp.draftMax;
-    args.speculativeSamples = mtp.draftMax;
-    args.mobileSpeculative = true;
-    args.disableThinking = true;
   }
 
   mergeOverrides(args, overrides);

--- a/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
@@ -20,7 +20,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
 	resolveLocalInferenceLoadArgs,
 	resolveMmprojPath,
@@ -183,6 +183,40 @@ describe("WS2 mmproj routing", () => {
 		expect(resolved.draftMin).toBeUndefined();
 		expect(resolved.draftMax).toBeUndefined();
 		expect(resolved.mobileSpeculative).toBeUndefined();
+	});
+
+	it("falls back to a non-speculative load when a pre-cutover bundle is missing the drafter GGUF", async () => {
+		// Back-compat (#11517): a 2b/4b bundle installed BEFORE the Gemma-4 MTP
+		// cutover has no `mtp/drafter-<tier>.gguf` on disk even though the
+		// catalog now advertises runtime.mtp for the tier. The drafter is a
+		// perf-only speculative-decoding artifact — the text model must still
+		// load (warn + plain decode), never hard-throw and brick the install.
+		const tier = "2b";
+		expect(findCatalogModel(`eliza-1-${tier}`)?.runtime?.mtp?.specType).toBe(
+			"draft-mtp",
+		);
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const bundle = makeTempBundle({ hasMmproj: true, hasMtp: false, tier });
+			const installed = installedModel({
+				id: `eliza-1-${tier}`,
+				bundleRoot: bundle.bundleRoot,
+				path: bundle.textPath,
+			});
+			const resolved = await resolveLocalInferenceLoadArgs(installed);
+			expect(resolved.modelPath).toBe(bundle.textPath);
+			expect(resolved.draftModelPath).toBeUndefined();
+			expect(resolved.draftMin).toBeUndefined();
+			expect(resolved.draftMax).toBeUndefined();
+			expect(resolved.mobileSpeculative).toBeUndefined();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Re-download the model to enable the MTP drafter",
+				),
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
 	it("leaves mmprojPath undefined when bundleRoot is absent", async () => {

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -667,22 +667,32 @@ export async function resolveLocalInferenceLoadArgs(
 		// Two MTP shapes: embedded-draft-head MTP embeds the draft head in
 		// the text GGUF (no `drafterFile` in the catalog) and runs with no
 		// separate draft model; separate-drafter MTP declares a `drafterFile`
-		// and requires the bundled drafter GGUF to be present on disk.
+		// and needs the bundled drafter GGUF to be present on disk.
 		const sameFileMtp = !mtp.drafterFile;
 		const drafterPath = sameFileMtp
 			? undefined
 			: resolveMtpDrafterPath(installed, catalog, manifestLoader);
-		if (!sameFileMtp && installed.bundleRoot && !drafterPath) {
-			throw new Error(
-				`[local-inference] ${installed.id} declares a separate-drafter MTP but no bundled drafter GGUF was found under ${installed.bundleRoot}`,
+		if (!sameFileMtp && !drafterPath) {
+			// Back-compat with pre-MTP-cutover installs (#11517): bundles
+			// downloaded before the tier's gemma4-assistant drafter was hosted
+			// (and single-file installs with no bundleRoot) have no
+			// `mtp/drafter-<tier>.gguf` on disk. The drafter is a perf-only
+			// speculative-decoding artifact — never brick an installed model
+			// over it. Load without MTP; re-downloading the bundle picks the
+			// drafter up.
+			console.warn(
+				`[local-inference] ${installed.id} declares a separate-drafter MTP but no drafter GGUF was found${
+					installed.bundleRoot ? ` under ${installed.bundleRoot}` : ""
+				}; loading without speculative decoding. Re-download the model to enable the MTP drafter.`,
 			);
+		} else {
+			args.useGpu = true;
+			args.draftModelPath = drafterPath;
+			args.draftMin = mtp.draftMin;
+			args.draftMax = mtp.draftMax;
+			args.speculativeSamples = mtp.draftMax;
+			args.mobileSpeculative = true;
 		}
-		args.useGpu = true;
-		args.draftModelPath = drafterPath;
-		args.draftMin = mtp.draftMin;
-		args.draftMax = mtp.draftMax;
-		args.speculativeSamples = mtp.draftMax;
-		args.mobileSpeculative = true;
 	}
 
 	mergeOverrides(args, overrides);

--- a/plugins/plugin-local-inference/src/services/load-args-drafter.fuzz.test.ts
+++ b/plugins/plugin-local-inference/src/services/load-args-drafter.fuzz.test.ts
@@ -5,8 +5,10 @@
 //
 //   - `resolveLocalInferenceLoadArgs` — catalog + manifest + overrides merge,
 //     including the separate-drafter MTP rule: a hosted-MTP tier (eliza-1-2b
-//     declares `runtime.mtp.drafterFile`) with a bundleRoot but NO drafter
-//     GGUF on disk must throw, never silently load without speculation.
+//     declares `runtime.mtp.drafterFile`) with NO drafter GGUF on disk falls
+//     back to a plain non-speculative load (warn, no MTP args) — a
+//     pre-cutover install must never be bricked over the perf-only drafter
+//     (#11517 back-compat).
 //   - `validateLocalInferenceLoadArgs` — differential fuzz against an oracle
 //     mirroring the documented acceptance rules (stock vs fork KV cache
 //     types, contextSize/gpuLayers integrality, kvOffload shapes).
@@ -23,7 +25,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
 	isForkOnlyKvCacheType,
 	isStockKvCacheType,
@@ -149,29 +151,53 @@ describe("resolveLocalInferenceLoadArgs — separate-drafter MTP resolution", ()
 		expect(catalog2b?.runtime?.mtp?.drafterFile).toMatch(/drafter-2b\.gguf$/);
 	});
 
-	it("throws when the declared drafter GGUF is missing under bundleRoot", async () => {
-		const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
-		const installed = installedModel({
-			id: "eliza-1-2b",
-			path: bundle.textPath,
-			bundleRoot: bundle.bundleRoot,
-		});
-		await expect(resolveLocalInferenceLoadArgs(installed)).rejects.toThrow(
-			/separate-drafter MTP but no bundled drafter GGUF/,
-		);
+	it("falls back to a non-speculative load when the declared drafter GGUF is missing under bundleRoot", async () => {
+		// #11517 back-compat: a bundle installed before the Gemma-4 MTP cutover
+		// has no mtp/drafter-2b.gguf. The drafter is perf-only — the text model
+		// must still load (warn + plain decode), never throw.
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
+			const installed = installedModel({
+				id: "eliza-1-2b",
+				path: bundle.textPath,
+				bundleRoot: bundle.bundleRoot,
+			});
+			const resolved = await resolveLocalInferenceLoadArgs(installed);
+			expect(resolved.modelPath).toBe(bundle.textPath);
+			expect(resolved.draftModelPath).toBeUndefined();
+			expect(resolved.draftMin).toBeUndefined();
+			expect(resolved.draftMax).toBeUndefined();
+			expect(resolved.mobileSpeculative).toBeUndefined();
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Re-download the model to enable the MTP drafter",
+				),
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
-	it("does not throw for an external-scan install (no bundleRoot); drafter stays unset", async () => {
-		const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
-		const installed = installedModel({
-			id: "eliza-1-2b",
-			path: bundle.textPath,
-		});
-		const resolved = await resolveLocalInferenceLoadArgs(installed);
-		expect(resolved.draftModelPath).toBeUndefined();
-		// The MTP block still applies the catalog draft window defaults.
-		expect(resolved.draftMin).toBe(catalog2b?.runtime?.mtp?.draftMin);
-		expect(resolved.draftMax).toBe(catalog2b?.runtime?.mtp?.draftMax);
+	it("does not throw for an external-scan install (no bundleRoot); MTP stays fully unset", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const bundle = makeTempBundle({ tier: "2b", hasDrafter: false });
+			const installed = installedModel({
+				id: "eliza-1-2b",
+				path: bundle.textPath,
+			});
+			const resolved = await resolveLocalInferenceLoadArgs(installed);
+			expect(resolved.draftModelPath).toBeUndefined();
+			// No drafter on disk ⇒ the whole MTP block is skipped — a
+			// half-configured speculative state (draft window without a draft
+			// model) must never leak into the loader.
+			expect(resolved.draftMin).toBeUndefined();
+			expect(resolved.draftMax).toBeUndefined();
+			expect(resolved.mobileSpeculative).toBeUndefined();
+		} finally {
+			warnSpy.mockRestore();
+		}
 	});
 
 	it("prefers a manifest files.mtp entry that exists on disk over the catalog path", async () => {


### PR DESCRIPTION
## What

The Gemma-4 MTP cutover (#11517, extended to 4b by #11782) added `eliza-1-2b`/`eliza-1-4b` to `ELIZA_1_HOSTED_MTP_TIER_IDS`, so the shared catalog now declares separate-drafter `runtime.mtp` for those tiers. `resolveLocalInferenceLoadArgs` then **hard-threw** for any installed bundle missing `mtp/drafter-<tier>.gguf` — which is **every bundle downloaded before the cutover** — so a previously-working installed model could no longer load at all. Two `packages/ui` `active-model.test.ts` cases were red on develop catching exactly this regression.

## Why graceful fallback (not a throw)

The drafter is a **perf-only** speculative-decoding artifact (measured ~1.3-1.6x greedy speedup, #11517 evidence). A missing drafter degrades speed, not correctness — bricking the user's installed, previously-working model over it is the wrong UX. The resolver now:

- loads the text model **without MTP** (no draft args, no `mobileSpeculative`), and
- emits a `console.warn` telling the user to **re-download the model to enable the MTP drafter** (a fresh download bundles it, since the catalog advertises `components.mtp` for hosted tiers).

The fallback also closes a pre-existing hole: a no-`bundleRoot` install (external-scan / single-file GGUF) of a hosted-MTP tier previously leaked a **half-configured speculative state** (`draftMin`/`draftMax`/`mobileSpeculative` set with NO `draftModelPath`) into the loader. Now the whole MTP block is skipped whenever the drafter isn't on disk. (The capacitor-bridge bootstrap already behaved this way — `plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts` only passes MTP args when the drafter resolves — so this aligns the desktop/UI resolvers with the mobile path.)

Applied to **both copies** of the resolver: `packages/ui/src/services/local-inference/active-model.ts` (client mirror) and `plugins/plugin-local-inference/src/services/active-model.ts` (runtime).

## Tests

- `packages/ui` `active-model.test.ts` — the two stale pre-cutover tests are replaced with the post-cutover contract: hosted tiers with the drafter bundled **enable** MTP (path + catalog draft window), unhosted tiers ignore a stray on-disk drafter, and a pre-cutover bundle (no drafter) **falls back** with the warning asserted. `bun run --cwd packages/ui test active-model` → **17/17** (was 14 passed / 2 failed).
- `plugins/plugin-local-inference` `mmproj-routing.test.ts` — new pre-cutover fallback case → **10/10**.
- `plugins/plugin-local-inference` `load-args-drafter.fuzz.test.ts` — the throw assertion becomes the fallback assertion; the external-scan case now expects a fully-unset MTP block → **22/22**.
- Full related suites: ui `src/services/local-inference` **84/84**, plugin `active-model*` + `text-bundle` + `ensure-assigned-model-loaded` all green.
- `typecheck` green in both packages; biome clean on all touched files.

## Evidence

- Repro on develop tip (`c5e1ca53e5`): `bun run --cwd packages/ui test active-model` → 2 failed (`AssertionError: expected '/tmp/.../mtp/drafter-2b.gguf' to be undefined` and `Error: [local-inference] eliza-1-2b declares a separate-drafter MTP but no bundled drafter GGUF was found under /tmp/...`).
- After: 17/17. The back-compat scenario (bundle with text GGUF, no `mtp/` dir — byte-identical to a pre-cutover install layout) is exercised by real resolver calls against the real shared catalog in three suites, including the warn text.
- Screenshots/video: N/A — no rendered UI change; this is a loader-args resolution fix with deterministic file-system-level tests driving the real resolver + real catalog.
- Live-model trajectory: N/A — no prompt/model behavior change; the fix only decides whether speculative-decoding load args are passed. (On a pre-cutover install, develop currently cannot load the model at all, which is the bug.)

Fixes the 2 red `active-model.test.ts` cases on develop; back-compat regression from #11517.

Signed: nubs-cloud [cloud-frontdoor]

🤖 Generated with [Claude Code](https://claude.com/claude-code)