### PR TITLE
perf(mobile): keep three.js off the boot graph via lazy programmable background

### DIFF
--- a/packages/ui/src/backgrounds/AppBackground.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.tsx
@@ -1,12 +1,25 @@
 import type * as React from "react";
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import type { ShaderConfig } from "../state/ui-preferences";
 import { DEFAULT_BACKGROUND_COLOR } from "../state/ui-preferences";
 import { useBackgroundConfig } from "../state/useBackgroundConfig";
 import { ImageBackground } from "./ImageBackground";
-import { ProgrammableShaderBackground } from "./ProgrammableShaderBackground";
 import { ShaderBackground } from "./ShaderBackground";
 import { useBackgroundApplyChannel } from "./useBackgroundApplyChannel";
+
+// three.js (~1.5 MB raw / ~320 KB brotli) is only needed for the opt-in GLSL
+// programmable-background mode — never for the default plain/preset shader that
+// every session paints at boot. A static import here pulled the whole
+// `vendor-three` chunk onto the first-paint (eager) graph because `AppBackground`
+// mounts at the shell root and is statically imported by `App.tsx`. Loading it
+// lazily keeps three off the boot path; it loads only when a user actually
+// selects a GLSL shader, and the plain `ShaderBackground` (same color) paints as
+// the Suspense fallback so the swap is seamless.
+const ProgrammableShaderBackground = lazy(() =>
+  import("./ProgrammableShaderBackground").then((m) => ({
+    default: m.ProgrammableShaderBackground,
+  })),
+);
 
 export interface AppBackgroundProps {
   /** Render the visual wallpaper layer. The background event channel stays mounted. */
@@ -29,12 +42,14 @@ function GlslBackground({
   const [failed, setFailed] = useState(false);
   if (failed) return <ShaderBackground color={color} />;
   return (
-    <ProgrammableShaderBackground
-      source={shader.source}
-      uniforms={shader.uniforms}
-      color={color}
-      onFallback={() => setFailed(true)}
-    />
+    <Suspense fallback={<ShaderBackground color={color} />}>
+      <ProgrammableShaderBackground
+        source={shader.source}
+        uniforms={shader.uniforms}
+        color={color}
+        onFallback={() => setFailed(true)}
+      />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## What

`AppBackground` mounts at the shell root and is statically imported by `App.tsx`, so its static import of `ProgrammableShaderBackground` dragged the entire `vendor-three` chunk (**~1.5 MB raw / ~320 KB brotli**) onto the **first-paint eager graph** — even though three.js is only needed for the opt-in GLSL programmable-background mode that most sessions never touch.

This lazy-loads `ProgrammableShaderBackground` so three is code-split **off the boot path**. The plain `ShaderBackground` (same color) paints as the `<Suspense>` fallback, so when a user does select a GLSL shader the swap is seamless.

## Why it's a real win (not speculative)

- `ProgrammableShaderBackground.tsx` is the **sole** consumer of `three` (`import * as THREE from "three"`).
- `AppBackground` was its **only eager production importer** — the other importers are `.stories.tsx` / `.test.tsx`, which aren't in the app bundle.
- So the dynamic import genuinely moves `vendor-three` off the first-paint graph (Vite auto-splits dynamic imports into their own chunk).

Directly shortens the mobile boot screen by shrinking the first-paint JS the shell must parse before it can render — complements the merged settings-lazyload (#11732).

## Verification

- Background suite **54/54** green (includes `AppBackground.test.tsx` — the lazy wrap + Suspense fallback render correctly).
- biome clean, typecheck clean, rebased clean onto develop.

Refs #10724 (memory/CPU/boot optimization umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)