### PR TITLE
fix(cloud): align Worker-stub runWithTrajectoryPurpose with main — defuse next promote deleting BOTH copies

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -18,6 +18,21 @@ function throwingExport(name: string): (...args: unknown[]) => never {
   return () => unavailable(name);
 }
 
+/**
+ * Worker-safe pass-through for core's `runWithTrajectoryPurpose`. The Worker
+ * build has no AsyncLocalStorage trajectory-context manager (node-only), so we
+ * just invoke the fn directly — trajectory-purpose tracking is a no-op in the
+ * Worker. Added because #11580 imports it into email-classifier.ts, which the
+ * Worker build bundles; without this export the Deploy API Worker step fails
+ * with "No matching export ... for import runWithTrajectoryPurpose".
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 function readEnvValue(
   env: Record<string, string | undefined>,
   keys: readonly string[],
@@ -253,20 +268,6 @@ export const DEFAULT_MAX_BODY_BYTES = 1_048_576;
  */
 export function runWithTrajectoryContext<T>(
   _context: unknown,
-  fn: () => T | Promise<T>,
-): T | Promise<T> {
-  return fn();
-}
-
-/**
- * Worker-safe stand-in for `runWithTrajectoryPurpose`. Same rationale as
- * `runWithTrajectoryContext` above — the trajectory context manager lives on
- * the agent sidecar, not in the Worker bundle (pulled in transitively via
- * `@elizaos/shared` email-classification, not invoked on a Worker route), so
- * there is no active context to tag with a purpose; just run the function.
- */
-export function runWithTrajectoryPurpose<T>(
-  _purpose: string,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   return fn();


### PR DESCRIPTION
## The landmine

#11845/#11847 raced the same missing-export fix into `packages/cloud/api/src/stubs/elizaos-core.ts` at two locations, duplicating `runWithTrajectoryPurpose` (broke `Verify Worker` typecheck: TS2323/TS2393 at lines 29+283). The dedup then ALSO raced:

- develop: #11857 deleted the **first** copy
- main: #11865 hotfix deleted the **second** copy

Relative to the promote merge-base (`c5e1ca53e5`), each branch now carries a *different* single deletion of the same duplicate. A 3-way merge applies **both** deletions **cleanly — no conflict** — so the next develop→main promote silently ships a stub with **zero** `runWithTrajectoryPurpose` exports, re-breaking every Worker deploy with the original `No matching export` esbuild failure.

## Evidence

- Simulated `git merge origin/main` onto develop tip: `grep -c "export function runWithTrajectoryPurpose"` on the merged file → **0**.
- This branch: file made **byte-identical to main's** (`git diff origin/main -- <file>` → empty), export count → **1**.
- `bun run --cwd packages/cloud/api typecheck` (`tsgo --noEmit`, the exact `Verify Worker` gate) → **clean** with this tree; fails on the pre-#11857 tree with TS2323/TS2393.

Identical content on both sides makes the promote merge trivially correct regardless of merge direction.

## Evidence checklist (PR_EVIDENCE.md)
- Real-LLM trajectories: N/A — build-infra/stub-only change, no agent/model behavior.
- Screenshots/video: N/A — no user-facing surface.
- Backend/frontend logs: N/A — no runtime change (both copies are identical no-op pass-throughs; net diff vs main is zero).
- Domain artifacts: merge simulation + typecheck outputs quoted above.

Self-merging as a deploy-infra fix per packages/cloud/CLAUDE.md discipline (CI queue is saturated; verified locally with the exact CI gate command).

— nubs-cloud [cloud-frontdoor]