### PR TITLE
test(#10722): add plugin-views keyboard focus-order audit to the WebKit ui-smoke lane

### DIFF
--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -48,15 +48,20 @@ const VOICE_MIC_SPEC = /(voice-realaudio|transcript-realaudio)\.spec\.ts/;
 // WebKit (Safari engine) pointer/focus/text-input lane. iOS/iPadOS ship Safari's
 // WebKit, but every default lane above is Chromium-only, so pointer, focus, and
 // text-input regressions specific to WebKit go uncaught. This lane re-runs the
-// chat pointer/focus/composer specs on WebKit. Scoped to keyless, stub-backed
-// specs that need no Chromium-only permissions (clipboard/microphone) or
-// fake-media launch flags, so they run green on WebKit (chat-message-actions and
-// wallet-inventory grant clipboard permissions WebKit does not support and are
-// intentionally excluded). Opt-in via PLAYWRIGHT_WEBKIT=1: WebKit is a separate
-// browser download (`playwright install webkit`) not present on every machine, so
-// gating keeps the default lane from reddening where WebKit is absent.
+// chat pointer/focus/composer specs plus the plugin-views keyboard focus-order
+// audit on WebKit. Scoped to keyless, stub-backed specs that need no
+// Chromium-only permissions (clipboard/microphone) or fake-media launch flags,
+// so they run green on WebKit (chat-message-actions and wallet-inventory grant
+// clipboard permissions WebKit does not support and are intentionally excluded).
+// CDP-touch specs (Input.dispatchTouchEvent is Chromium-only) stay on Chromium.
+// plugin-views-visual is included for its Tab-order keyboard-navigation audit:
+// the registered plugin views ship in the iOS/macOS WKWebView, so a WebKit focus
+// or sequential-focus-navigation divergence must be caught here, not only on
+// Chromium. Opt-in via PLAYWRIGHT_WEBKIT=1: WebKit is a separate browser download
+// (`playwright install webkit`) not present on every machine, so gating keeps the
+// default lane from reddening where WebKit is absent.
 const WEBKIT_POINTER_FOCUS_SPEC =
-  /(chat-overlay-controls-interactions|conversation-management|slash-commands)\.spec\.ts/;
+  /(chat-overlay-controls-interactions|conversation-management|slash-commands|plugin-views-visual)\.spec\.ts/;
 const webkitLaneEnabled = process.env.PLAYWRIGHT_WEBKIT === "1";
 // The all-views aesthetic audit (#8796) walks ~50 views × 2 viewports; it is a
 // dedicated tool run via `audit:app`, not part of the default e2e smoke.


### PR DESCRIPTION
## What

Expands the existing opt-in WebKit ui-smoke project (`PLAYWRIGHT_WEBKIT=1`) to include `plugin-views-visual.spec.ts` — the `Tab`-order / sequential-focus-navigation audit — alongside the chat pointer/focus/composer specs it already runs.

**Why WebKit specifically:** the registered plugin views ship in the iOS/macOS **WKWebView**, so a WebKit focus or sequential-focus-navigation divergence must be caught on the engine that actually ships to iOS — not only on Chromium. CDP-touch specs (`Input.dispatchTouchEvent` is Chromium-only) intentionally stay on Chromium; clipboard/mic specs remain excluded (WebKit doesn't grant those permissions).

Config-only change; keeps the `PLAYWRIGHT_WEBKIT=1` opt-in gating so the default lane never reddens where the WebKit browser isn't installed.

## ⚠️ Status: pushed for review, NOT yet merged

Biome clean, rebased clean onto develop, and the WebKit browser (`webkit-2311`) is present. But the ui-smoke `webServer` did not boot in this session (unrelated dev-server startup issue under load), so I could **not** confirm `plugin-views-visual` runs green on WebKit here. Before merge it needs one clean `PLAYWRIGHT_WEBKIT=1` run — either it passes (merge) or it surfaces a real WebKit focus divergence (a genuine #10722 finding to fix). **Do not merge until run green on WebKit.** Refs #10722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)