### PR TITLE
fix(ui): make first-run onboarding recoverable instead of looping on a finish error

### DIFF
--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -94,3 +94,19 @@ taps them out of order. The contract, enforced in `use-first-run-conductor.ts`
   the OAuth block, the interrupted flow resumes automatically when the store
   learns the connection landed. A fresh pick always supersedes the pending
   resume.
+- **No finish dead end (the loop fix).** When a finish/provision flow fails —
+  including a persistent `POST /api/first-run` failure such as a 404 — the
+  conductor seeds a DISTINCT recovery turn (`first-run:error:*`) carrying its own
+  `[CHOICE:first-run id=error]` with a human-readable message and three real ways
+  forward: **Try again** (`error:retry`, re-runs the last runtime's finish),
+  **Choose a different way to run** (`error:restart`, re-offers a fresh unlocked
+  runtime CHOICE), and **Configure in Settings** (`error:settings`). It never
+  re-appends the runtime question inline, so a repeating error can no longer loop
+  the greeting forever.
+- **"Other / configure in Settings" always escapes.** The `provider:other` pick
+  (BYOK) does NOT run a local finish flow that could fail and re-loop; it opens
+  the Settings tab (`setTab("settings")`) and exits first-run
+  (`completeFirstRun("settings")`), landing the user where they configure a
+  provider by hand. Both this and `error:settings` route through the same
+  `exitToSettings` helper, latched by `completedRef` so a double-tap can't flip
+  the gate twice.

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -187,6 +187,15 @@ beforeEach(() => {
   ensureLocalStorage().clear();
   vi.clearAllMocks();
   mocks.client.listLocalAgentBackups.mockResolvedValue([]);
+  // `clearAllMocks` resets call history but NOT implementations, so restore the
+  // default resolved implementations that individual tests override (a leaked
+  // `mockRejectedValue`/`mockResolvedValue` would otherwise poison later tests).
+  mocks.client.submitFirstRun.mockResolvedValue(undefined);
+  mocks.client.selectOrProvisionCloudAgent.mockResolvedValue({
+    apiBase: "https://agent.example.test",
+    agentId: "agent-1",
+    created: false,
+  });
   mocks.client.getCloudCompatAgents.mockResolvedValue({
     success: true,
     data: [],
@@ -259,9 +268,9 @@ describe("useFirstRunConductor", () => {
     unmount();
   });
 
-  it("keeps BYOK reachable after the runtime chooser was trimmed to Cloud + On this device: On this device → provider:other routes to the Settings handoff banner without a model download", async () => {
+  it("On this device → provider:other ('configure in Settings') opens the Settings tab and exits first-run without running a finish flow", async () => {
     const spies = seedAppStore();
-    const { turn, unmount } = renderConductor();
+    const { turn, transcript, unmount } = renderConductor();
     const greeting = await waitForTurn(turn, "first-run:greeting");
 
     // The chooser offers three locations — Cloud, On this device, Remote — but
@@ -277,19 +286,28 @@ describe("useFirstRunConductor", () => {
     // The provider sub-choice still offers "Other / configure in Settings" (BYOK).
     expect(provider.text).toContain("__first_run__:provider:other=");
 
+    // Selecting it must actually land the user in Settings and exit onboarding —
+    // NOT run a local finish that could fail and re-loop the questions.
     expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
-    await waitForTurn(turn, "first-run:tutorial");
+    await waitFor(() => {
+      expect(spies.setTab).toHaveBeenCalledWith("settings");
+    });
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("settings");
 
-    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
-    // configure-later wires NO provider: the Settings banner surfaces and no
-    // on-device model download starts.
-    expect(spies.showActionBanner).toHaveBeenCalledTimes(1);
-    expect(spies.showActionBanner.mock.calls[0][0].text).toContain(
-      "model provider in Settings",
-    );
+    // No finish flow ran: no POST, no model download, and no tutorial prompt
+    // (first-run is over — the user is in Settings).
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
     expect(
       mocks.autoDownloadRecommendedLocalModelInBackground,
     ).not.toHaveBeenCalled();
+    expect(transcript.current.some((m) => m.id === "first-run:tutorial")).toBe(
+      false,
+    );
+
+    // A confused double-tap must not flip the gate twice.
+    expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
     unmount();
   });
 
@@ -398,7 +416,7 @@ describe("useFirstRunConductor", () => {
     unmount();
   });
 
-  it("surfaces a cloud listing failure as an error turn with the runtime CHOICE again, then a LOCAL retry succeeds", async () => {
+  it("surfaces a cloud listing failure as a DISTINCT recovery turn (retry / restart / Settings), and 'restart' → LOCAL succeeds", async () => {
     mocks.client.getCloudCompatAgents.mockRejectedValue(
       new Error("cloud is down"),
     );
@@ -422,11 +440,25 @@ describe("useFirstRunConductor", () => {
     const errorTurn = transcript.current.find((message) =>
       message.id.startsWith("first-run:error:"),
     );
-    // The error turn re-offers the runtime CHOICE so the flow is recoverable.
-    expect(errorTurn?.text).toContain("__first_run__:runtime:local=");
+    // The error turn is a DISTINCT recovery surface — it does NOT silently
+    // re-offer the runtime question (the infinite-loop bug). It offers retry,
+    // restart, and an explicit Settings escape.
+    expect(errorTurn?.text).not.toContain("__first_run__:runtime:local=");
+    expect(errorTurn?.text).toContain("__first_run__:error:retry=");
+    expect(errorTurn?.text).toContain("__first_run__:error:restart=");
+    expect(errorTurn?.text).toContain("__first_run__:error:settings=");
     expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
 
-    // Retry via LOCAL still reaches the tutorial (and the single POST).
+    // "Choose a different way to run" re-offers a fresh runtime choice; picking
+    // LOCAL from it still reaches the tutorial (and the single POST).
+    expect(tryHandleFirstRunAction("__first_run__:error:restart")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
     expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
     await waitForTurn(turn, "first-run:provider");
     expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
@@ -434,6 +466,84 @@ describe("useFirstRunConductor", () => {
     );
     await waitForTurn(turn, "first-run:tutorial");
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("a persistent finish 404 does NOT re-loop the runtime question: the error turn stays distinct, offers retry, and 'Configure in Settings' escapes", async () => {
+    // Simulate the reported bug: POST /api/first-run always 404s ("Not found").
+    mocks.client.submitFirstRun.mockRejectedValue(new Error("Not found"));
+    const spies = seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // Local → on-device → finish 404s → a distinct error turn (NOT the greeting,
+    // NOT a bare runtime prompt).
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(turn, "first-run:provider");
+    expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
+      true,
+    );
+    const firstError = await waitFor(() => {
+      const t = transcript.current.find((m) =>
+        m.id.startsWith("first-run:error:"),
+      );
+      expect(t).toBeTruthy();
+      return t as ConversationMessage;
+    });
+    // Human message, not the raw "Not found"; distinct from the greeting; no
+    // re-looped runtime question.
+    expect(firstError.text).toContain("couldn't finish setting up your agent");
+    expect(firstError.text).not.toBe(turn("first-run:greeting")?.text);
+    expect(firstError.text).not.toContain("__first_run__:runtime:local=");
+
+    // Retry hits the SAME 404 — but each failure produces ONE bounded error
+    // turn, never an unbounded storm of runtime prompts.
+    const errorCountAfterFirst = transcript.current.filter((m) =>
+      m.id.startsWith("first-run:error:"),
+    ).length;
+    expect(errorCountAfterFirst).toBe(1);
+    expect(tryHandleFirstRunAction("__first_run__:error:retry")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.filter((m) => m.id.startsWith("first-run:error:"))
+          .length,
+      ).toBe(2);
+    });
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(2);
+
+    // The guaranteed escape: "Configure in Settings" opens Settings and exits
+    // first-run even though finish never succeeded.
+    expect(tryHandleFirstRunAction("__first_run__:error:settings")).toBe(true);
+    expect(spies.setTab).toHaveBeenCalledWith("settings");
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("settings");
+    unmount();
+  });
+
+  it("error:retry after a CLOUD listing failure re-seeds the OAuth turn and re-runs cloud provisioning (0 agents → auto-provision → tutorial)", async () => {
+    // First listing throws (transport failure), the retry succeeds with 0 agents.
+    mocks.client.getCloudCompatAgents
+      .mockRejectedValueOnce(new Error("cloud is down"))
+      .mockResolvedValue({ success: true, data: [] });
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) => m.id.startsWith("first-run:error:")),
+      ).toBe(true);
+    });
+
+    // "Try again" re-runs the SAME (cloud) flow: it re-seeds the connecting
+    // OAuth turn and calls listing a second time, then auto-provisions.
+    expect(tryHandleFirstRunAction("__first_run__:error:retry")).toBe(true);
+    await waitForTurn(turn, "first-run:tutorial");
+    expect(mocks.client.getCloudCompatAgents).toHaveBeenCalledTimes(2);
+    expect(mocks.client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    expect(turn("first-run:cloud-oauth")?.secretRequest?.status).toBe("saved");
     unmount();
   });
 
@@ -605,10 +715,18 @@ describe("useFirstRunConductor", () => {
       ).toBe(true);
     });
 
-    // The user re-picks LOCAL from the error turn. The original provider turn
-    // still exists (its widget locked itself on the first pick), so the
-    // conductor must seed a FRESH provider turn — otherwise the retry is a
-    // dead end in the real UI.
+    // The user takes "Choose a different way to run" from the error turn, then
+    // re-picks LOCAL. The original provider turn still exists (its widget locked
+    // itself on the first pick), so the conductor must seed a FRESH provider
+    // turn — otherwise the retry is a dead end in the real UI.
+    expect(tryHandleFirstRunAction("__first_run__:error:restart")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((message) =>
+          message.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
     expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
     await waitFor(() => {
       expect(

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -101,11 +101,11 @@ function newestLocalBackup(
 
 // The first-run location chooser: Cloud (managed), On this device, or Remote
 // (connect to an existing agent elsewhere). "Bring your own keys" is NOT a
-// location — it just ran the local backend and pre-highlighted the BYOK
-// inference provider, so it lived on the wrong axis; it stays reachable one step
-// later via the provider sub-choice (provider:other → localInference
-// "configure-later"). Remote picks an already-running agent by URL + token; it
-// owns its own provider, so it skips the provider sub-step.
+// location — it lives one step later on the provider sub-choice as
+// "Other / configure in Settings" (provider:other), which drops the user into
+// the full Settings UI to wire their own provider by hand. Remote picks an
+// already-running agent by URL + token; it owns its own provider, so it skips
+// the provider sub-step.
 const RUNTIME_CHOICE = [
   "[CHOICE:first-run id=runtime]",
   `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
@@ -138,6 +138,37 @@ const TUTORIAL_CHOICE = [
   `${FIRST_RUN_ACTION_PREFIX}tutorial:skip=Skip for now`,
   "[/CHOICE]",
 ].join("\n");
+
+// Recovery choice seeded when a finish/provision flow fails (e.g. a 404 from
+// POST /api/first-run). It replaces the old "re-append the runtime question"
+// behavior — which, on a persistent finish error, re-looped the runtime prompt
+// forever with no explanation and no escape. Every option here is a real way
+// forward: retry the same runtime, pick a different one, or bail out to Settings
+// and configure a provider by hand.
+const ERROR_CHOICE = [
+  "[CHOICE:first-run id=error]",
+  `${FIRST_RUN_ACTION_PREFIX}error:retry=Try again`,
+  `${FIRST_RUN_ACTION_PREFIX}error:restart=Choose a different way to run`,
+  `${FIRST_RUN_ACTION_PREFIX}error:settings=Configure in Settings`,
+  "[/CHOICE]",
+].join("\n");
+
+/**
+ * Turn a raw finish error into a human sentence. The underlying message can be
+ * a terse transport string ("Not found" for a 404, "Failed to fetch", …) that
+ * means nothing to a first-run user; lead with a clear framing and keep the raw
+ * detail for context.
+ */
+function finishErrorMessage(message: string): string {
+  const detail = message.trim();
+  const isTerse = /^(not found|failed to fetch|forbidden|unauthorized)$/i.test(
+    detail,
+  );
+  const lead = isTerse
+    ? `I couldn't finish setting up your agent (${detail}).`
+    : `I couldn't finish setting up your agent: ${detail}`;
+  return `${lead}\n\nYou can try again, pick a different way to run your agent, or configure a model provider yourself in Settings.`;
+}
 
 function cloudOAuthSecretRequest(
   status: ConversationSecretRequest["status"],
@@ -374,15 +405,32 @@ export function useFirstRunConductor(): void {
 
   const seedError = React.useCallback(
     (message: string) => {
+      // A DISTINCT, non-looping error surface. Previously this re-appended the
+      // runtime CHOICE, so a persistent finish error (e.g. the /api/first-run
+      // 404) re-offered the same runtime question forever with no way out. Now
+      // the error turn carries its own recovery choice (retry / restart /
+      // Settings escape) so onboarding is always recoverable.
       seedTurn(
         makeTurn(
           `first-run:error:${Date.now()}`,
-          `${message}\n\n${RUNTIME_CHOICE}`,
+          `${finishErrorMessage(message)}\n\n${ERROR_CHOICE}`,
         ),
       );
     },
     [seedTurn],
   );
+
+  // Explicit, non-finish escape hatch out of onboarding: flip the real gate and
+  // land the user in Settings so they can wire a model provider by hand. Used by
+  // the provider "Other / configure in Settings" pick AND the error-recovery
+  // "Configure in Settings" choice, so a broken finish never traps the user in
+  // the loop. Latched by completedRef so a double-tap can't flip the gate twice.
+  const exitToSettings = React.useCallback(() => {
+    if (completedRef.current) return;
+    completedRef.current = true;
+    setTab("settings");
+    completeFirstRun("settings");
+  }, [setTab, completeFirstRun]);
 
   const seedCloudAgentChoice = React.useCallback(
     (agents: { id?: string; name?: string }[]) => {
@@ -553,7 +601,7 @@ export function useFirstRunConductor(): void {
         }
         // On this device: run the local backend, then ask which model provider.
         // BYOK is the provider:other sub-choice ("Other / configure in
-        // Settings" → localInference "configure-later").
+        // Settings"), which opens Settings and exits first-run.
         draftRef.current = {
           ...draftRef.current,
           runtime: "local",
@@ -615,21 +663,20 @@ export function useFirstRunConductor(): void {
         if (id !== "on-device" && id !== "elizacloud" && id !== "other") {
           return true;
         }
+        if (id === "other") {
+          // "Other / configure in Settings" (bring your own keys): the user
+          // wants the full Settings UI to wire their own provider (Anthropic /
+          // Codex / z.ai / Kimi, …). Take them straight there and exit first-run
+          // instead of running a finish flow — the old path ran a local finish
+          // that, when it failed (e.g. the /api/first-run 404), re-looped the
+          // onboarding questions instead of ever reaching Settings.
+          exitToSettings();
+          return true;
+        }
         if (id === "elizacloud") {
           draftRef.current = {
             ...draftRef.current,
             localInference: "cloud-inference",
-          };
-        } else if (id === "other") {
-          // "Other / configure in Settings" (bring your own keys): run locally
-          // but wire NO provider, so the finish path's `needsProviderSetup`
-          // handoff surfaces the "Open Settings" banner where the user picks a
-          // subscription provider (Anthropic / Codex / z.ai / Kimi). NOT
-          // all-local — that would silently download an on-device model and
-          // suppress the banner.
-          draftRef.current = {
-            ...draftRef.current,
-            localInference: "configure-later",
           };
         } else {
           // on-device: run every model locally (kicks off the download now).
@@ -666,6 +713,43 @@ export function useFirstRunConductor(): void {
         return true;
       }
 
+      if (group === "error") {
+        if (id !== "retry" && id !== "restart" && id !== "settings") {
+          return true;
+        }
+        if (id === "settings") {
+          exitToSettings();
+          return true;
+        }
+        if (id === "restart") {
+          // Re-offer a FRESH (unlocked) runtime choice so the user can switch
+          // how their agent runs after a failed finish. seedFreshChoiceTurn
+          // seeds a retry turn when the greeting already exists (the original
+          // runtime widget locked itself on its first pick).
+          seedFreshChoiceTurn(
+            "first-run:greeting",
+            `${GREETING}\n\n${RUNTIME_CHOICE}`,
+          );
+          return true;
+        }
+        // retry: re-run the SAME finish for the runtime the user last chose.
+        // The persist guard released itself on the failed POST, so a local
+        // retry re-POSTs; a cloud retry re-runs provisioning.
+        if (draftRef.current.runtime === "cloud") {
+          const connecting = makeTurn(
+            "first-run:cloud-oauth",
+            "Connecting your Eliza Cloud account…",
+            { secretRequest: cloudOAuthSecretRequest("pending") },
+          );
+          seedTurn(connecting);
+          replaceTurn("first-run:cloud-oauth", connecting);
+          startCloudProvisionFlow();
+          return true;
+        }
+        startProviderFinish();
+        return true;
+      }
+
       if (group === "tutorial") {
         if (id !== "start" && id !== "skip") return true;
         if (completedRef.current) return true;
@@ -688,6 +772,7 @@ export function useFirstRunConductor(): void {
       replaceTurn,
       handleOutcome,
       completeFirstRun,
+      exitToSettings,
       seedError,
       startCloudProvisionFlow,
       startProviderFinish,


### PR DESCRIPTION
Closes #11882

## The bug

The in-chat first-run wizard could loop forever with **no escape**, so a fresh install can never finish configuring a model provider:

```
Hi — I'm Eliza. Let's get you set up. First, where should your agent run?
  [On this device]
Which model provider should Eliza use?
  [On this device (recommended)]
Starting local agent
Saving first-run profile
Not found            <-- HTTP 404 from POST /api/first-run
Hi — I'm Eliza. Let's get you set up. First, where should your agent run?   <-- loops back forever
```

Selecting **"Other / configure in Settings"** did not escape either — it re-ran the same finish flow, hit the same failure, and re-looped.

## Root cause (UX/navigation)

In `packages/ui/src/first-run/use-first-run-conductor.ts`:

1. On any finish/provision error, `seedError(message)` seeded a turn as `` `${message}\n\n${RUNTIME_CHOICE}` `` — it re-appended the **runtime question**. A persistent finish error (the 404 from `POST /api/first-run`) therefore re-offered the same runtime choice indefinitely, with no distinct error surface, no explanation, and no way out.
2. `provider:other` ("Other / configure in Settings") ran a local finish (`configure-later`) that, on the same 404, also fell into `seedError` and re-looped instead of ever opening Settings.

## Scope note — the 404 is NOT fixed here (it's a separate issue)

The underlying `POST /api/first-run` **"Not found" 404 is a backend/dev-environment problem** (the local app-core/agent server not serving `/api/first-run`) and requires a running environment to diagnose. **This PR does not touch it.** It fixes the UX/navigation defect so onboarding is **recoverable** — retry + an explicit escape into Settings — even when finish keeps failing.

## The fix

- **Distinct, non-looping error surface.** Finish errors now seed a dedicated recovery turn (`first-run:error:*`) with a human-readable message and its own `[CHOICE:first-run id=error]`:
  - **Try again** (`error:retry`) — re-runs the last runtime's finish (local re-POSTs; cloud re-provisions, re-seeding the OAuth turn).
  - **Choose a different way to run** (`error:restart`) — re-offers a fresh, unlocked runtime CHOICE so the user can switch cloud↔local.
  - **Configure in Settings** (`error:settings`) — the guaranteed escape.
  The runtime question is never re-appended inline again, so a repeating error can't loop the greeting forever.
- **"Other / configure in Settings" now escapes.** `provider:other` opens the Settings view via `setTab("settings")` and exits first-run via `completeFirstRun("settings")` (route id `"settings"`, the same id used everywhere in `App.tsx` and the existing needs-provider banner in `first-run-finish.ts`). It no longer runs a finish flow that could fail and trap the user.
- Both escapes route through one `exitToSettings` helper, latched by `completedRef` so a double-tap can't flip the gate twice.
- Terse transport strings ("Not found", "Failed to fetch", …) are wrapped in a clear human sentence by `finishErrorMessage`.

Local-success, cloud, and needs-cloud-login paths are unchanged.

## Before / after behavior

| | Before | After |
|---|---|---|
| Persistent finish 404 | Re-appends the runtime question → **infinite loop, no escape** | Distinct error turn with a clear message + **Try again / Choose a different way to run / Configure in Settings** |
| "Other / configure in Settings" | Runs a local finish → same 404 → re-loops | Opens Settings (`setTab("settings")`) and **exits first-run** |
| Cloud listing failure | Error turn re-offered the runtime CHOICE | Error turn offers retry/restart/Settings; `error:retry` re-runs cloud provisioning |

## Tests (primary evidence — the conductor is headless)

`bun run --cwd packages/ui test src/first-run/` — **191 passed (15 files)**, including:

- **New:** a persistent `POST /api/first-run` 404 does **not** re-loop the runtime question — the error turn is distinct (human message, no `runtime:local` button), `error:retry` re-attempts (2× POST, one bounded error turn per attempt), and `error:settings` calls `setTab("settings")` + `completeFirstRun("settings")` to escape.
- **New:** `error:retry` after a cloud listing failure re-seeds the OAuth turn and re-runs provisioning (0 agents → auto-provision → tutorial).
- **Updated:** `provider:other` opens the Settings tab and exits first-run without any finish flow / POST / model download / tutorial, and a double-tap flips the gate exactly once.
- **Updated:** the cloud-failure recovery and the "fresh provider turn on runtime re-pick" tests now drive the new `error:restart` → runtime re-pick path.
- **Hardened:** `beforeEach` restores default mock implementations (`clearAllMocks` keeps implementations, so a leaked `mockRejectedValue` would poison later tests).
- The confused-user **fuzz storms** (`use-first-run-conductor.fuzz.test.ts`) still hold all invariants (≤1 POST, ≤1 provision, ≤1 completeFirstRun, bounded transcript).

## Verification run

- `bun run --cwd packages/ui typecheck` — clean.
- `bunx @biomejs/biome check` on changed files — clean.
- `bun run --cwd packages/ui test src/first-run/` — 191 passed.

## Evidence checklist

- **Real-LLM trajectories** — N/A: no agent/action/provider/prompt/model behavior changed; this is chat-transcript navigation in a headless conductor.
- **Unit/behavior tests** — attached above (the flow is a headless conductor; these are the real evidence).
- **Rendered UI proof (screenshots/video)** — N/A here: reproducing the live loop needs the backend `/api/first-run` 404 (a separate, out-of-scope environment issue). The conductor logic is fully covered by the real finish use case under test.
- **Backend logs** — N/A: no server code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
