### PR TITLE
fix(ui): delay-gate the startup splash so it never flashes on fast cached boots

### DIFF
--- a/packages/ui/src/components/shell/StartupShell.test.tsx
+++ b/packages/ui/src/components/shell/StartupShell.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetStartupTraceForTests,
+  hasStartupMark,
+} from "../../state/startup-telemetry";
+import { STARTUP_SPLASH_DELAY_MS, StartupShell } from "./StartupShell";
+import type { StartupShellView } from "./startup-shell-types";
+
+// The child surfaces pull in heavy trees (branding, platform, bootstrap flow);
+// stub them so this suite only exercises StartupShell's own gating logic. The
+// real telemetry module is used unmocked so we can assert the first-paint mark.
+vi.mock("./StartupFailureView", () => ({
+  StartupFailureView: () => <div data-testid="startup-failure" />,
+}));
+vi.mock("./PairingView", () => ({
+  PairingView: () => <div data-testid="startup-pairing" />,
+}));
+vi.mock("../setup/BootstrapStep", () => ({
+  BootstrapStep: () => <div data-testid="startup-bootstrap" />,
+}));
+vi.mock("../../config/boot-config-store", () => ({
+  getBootConfig: () => ({}),
+}));
+vi.mock("../brand/eliza-mark", () => ({
+  ElizaMark: () => <svg data-testid="eliza-mark" />,
+}));
+
+const FIRST_PAINT_MARK = "startup-shell:first-paint";
+
+const loadingView: StartupShellView = {
+  kind: "loading",
+  phase: "starting-backend",
+  status: "Starting…",
+};
+
+function queryLoading() {
+  return screen.queryByTestId("startup-shell-loading");
+}
+
+// Timer callbacks call setState; flush them through act() so React commits the
+// re-render before the assertion reads the DOM.
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetStartupTraceForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe("StartupShell — delayed loading splash", () => {
+  it("does NOT render the splash before the delay threshold elapses", () => {
+    render(<StartupShell view={loadingView} onRetry={vi.fn()} />);
+
+    // Immediately after mount: nothing painted, no first-paint mark.
+    expect(queryLoading()).toBeNull();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
+
+    // Advance to just before the threshold — still hidden.
+    advance(STARTUP_SPLASH_DELAY_MS - 1);
+    expect(queryLoading()).toBeNull();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
+  });
+
+  it("renders the splash once the delay threshold is crossed", () => {
+    render(<StartupShell view={loadingView} onRetry={vi.fn()} />);
+
+    advance(STARTUP_SPLASH_DELAY_MS);
+
+    const splash = queryLoading();
+    expect(splash).not.toBeNull();
+    // Visual contract preserved: phase + role attributes still present.
+    expect(splash?.getAttribute("data-startup-phase")).toBe("starting-backend");
+    expect(splash?.getAttribute("role")).toBe("status");
+    // first-paint telemetry fires only when the splash actually paints.
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
+  });
+
+  it("NEVER renders the splash when the view becomes ready before the threshold (fast cached boot)", () => {
+    const { rerender } = render(
+      <StartupShell view={loadingView} onRetry={vi.fn()} />,
+    );
+
+    // App becomes ready well before the delay elapses.
+    advance(STARTUP_SPLASH_DELAY_MS - 50);
+    rerender(<StartupShell view={{ kind: "none" }} onRetry={vi.fn()} />);
+
+    // Even after the original timer would have fired, no flash.
+    advance(500);
+    expect(queryLoading()).toBeNull();
+    // The startup shell never painted, so no first-paint mark was recorded.
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
+  });
+
+  it("still shows the splash if a fast flicker returns to loading and then persists", () => {
+    const onRetry = vi.fn();
+    const { rerender } = render(
+      <StartupShell view={loadingView} onRetry={onRetry} />,
+    );
+
+    // Brief flip to ready then back to loading — the delay timer restarts.
+    advance(STARTUP_SPLASH_DELAY_MS - 20);
+    rerender(<StartupShell view={{ kind: "none" }} onRetry={onRetry} />);
+    expect(queryLoading()).toBeNull();
+
+    rerender(<StartupShell view={loadingView} onRetry={onRetry} />);
+    // Only 100ms of continuous loading — still hidden (timer restarted).
+    advance(100);
+    expect(queryLoading()).toBeNull();
+
+    // Cross the full threshold from the restart — now it paints.
+    advance(STARTUP_SPLASH_DELAY_MS);
+    expect(queryLoading()).not.toBeNull();
+  });
+});
+
+describe("StartupShell — non-loading views render immediately (no delay)", () => {
+  it("renders the error view immediately and marks first-paint", () => {
+    render(
+      <StartupShell
+        view={{
+          kind: "error",
+          error: {
+            reason: "backend-unreachable",
+            message: "boom",
+            phase: "starting-backend",
+          },
+        }}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("startup-failure")).toBeTruthy();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
+  });
+
+  it("renders the pairing view immediately and marks first-paint", () => {
+    render(<StartupShell view={{ kind: "pairing" }} onRetry={vi.fn()} />);
+
+    expect(screen.getByTestId("startup-pairing")).toBeTruthy();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
+  });
+
+  it("renders the bootstrap view immediately and marks first-paint", () => {
+    render(
+      <StartupShell
+        view={{ kind: "bootstrap", onAdvance: vi.fn() }}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("startup-bootstrap")).toBeTruthy();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(true);
+  });
+
+  it("renders nothing and marks nothing for the ready (none) view", () => {
+    const { container } = render(
+      <StartupShell view={{ kind: "none" }} onRetry={vi.fn()} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(hasStartupMark(FIRST_PAINT_MARK)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { getBootConfig } from "../../config/boot-config-store";
 import { markStartup } from "../../state/startup-telemetry";
 import { ElizaMark } from "../brand/eliza-mark";
@@ -20,6 +20,34 @@ const FONT = "'Poppins', Arial, system-ui, sans-serif";
 const LAUNCH_SURFACE =
   "bg-[var(--launch-bg,#ef5a1f)] text-[var(--accent-foreground,#fff)]";
 
+// A fast, already-cached boot flips the view through the loading state for only
+// a few milliseconds before the app is ready. Painting the full-screen orange
+// splash for those few ms and then ripping it away reads as a jarring flash. So
+// the splash is gated behind a short delay: it renders ONLY once the loading
+// state has persisted this long. A boot that becomes ready first never paints
+// it. Error / pairing / bootstrap views are NOT gated — they are terminal or
+// interactive states the user is meant to see immediately, not fast-flash cases.
+export const STARTUP_SPLASH_DELAY_MS = 220;
+
+/**
+ * True only after `active` has stayed `true` continuously for `delayMs`.
+ * Flips back to `false` the instant `active` goes `false`. The timer lives in
+ * an effect (never at render time) so the render path stays deterministic and
+ * the `audit:ui-determinism` gate stays green.
+ */
+function useDelayElapsed(active: boolean, delayMs: number): boolean {
+  const [elapsed, setElapsed] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setElapsed(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [active, delayMs]);
+  return elapsed;
+}
+
 function brandName(): string {
   return getBootConfig().branding?.appName ?? "elizaOS";
 }
@@ -31,11 +59,30 @@ function BrandMark(props: { className?: string }) {
 }
 
 export function StartupShell({ view, onRetry }: StartupShellProps) {
-  // Renderer cold-start checkpoint (#9565): the startup front door has painted.
-  // markStartup dedupes by name, so this records only the first paint.
+  // The loading splash is delay-gated (see STARTUP_SPLASH_DELAY_MS): it renders
+  // only once the loading state has persisted past the threshold, so a fast
+  // cached boot that becomes ready first never flashes it.
+  const splashElapsed = useDelayElapsed(
+    view.kind === "loading",
+    STARTUP_SPLASH_DELAY_MS,
+  );
+
+  // Renderer cold-start checkpoint (#9565): "first paint" of the startup front
+  // door = the moment visible startup UI actually renders. Error / pairing /
+  // bootstrap paint immediately; the loading splash paints only once the delay
+  // gate opens; the "none" (ready) branch renders null and must NOT count as a
+  // startup-shell paint (nothing painted). markStartup dedupes by name, so the
+  // first real paint wins.
+  const painting =
+    view.kind === "error" ||
+    view.kind === "pairing" ||
+    view.kind === "bootstrap" ||
+    (view.kind === "loading" && splashElapsed);
   useEffect(() => {
-    markStartup("startup-shell:first-paint", { view: view.kind });
-  }, [view.kind]);
+    if (painting) {
+      markStartup("startup-shell:first-paint", { view: view.kind });
+    }
+  }, [painting, view.kind]);
 
   if (view.kind === "error") {
     return <StartupFailureView error={view.error} onRetry={onRetry} />;
@@ -53,11 +100,14 @@ export function StartupShell({ view, onRetry }: StartupShellProps) {
     );
   }
 
-  if (view.kind === "none") {
-    return null;
+  if (view.kind === "loading") {
+    return splashElapsed ? (
+      <StartupLoading phase={view.phase} status={view.status} />
+    ) : null;
   }
 
-  return <StartupLoading phase={view.phase} status={view.status} />;
+  // kind === "none": app is ready, the startup shell renders nothing.
+  return null;
 }
 
 function StartupLoading(props: { phase: string; status: string }) {


### PR DESCRIPTION
## Problem

Closes #11883.

On a warm/cached load — where the app boots almost instantly — the full-screen `elizaOS` booting/splash screen flashes for a fraction of a second and is immediately ripped away. It's a jarring flash on every fast (2nd) load. The splash should only appear when the app does **not** load right away.

## Root cause

`packages/ui/src/components/shell/StartupShell.tsx` returned the full-screen orange `StartupLoading` splash **immediately** whenever `view.kind === "loading"` (the fall-through after the `error` / `pairing` / `bootstrap` / `none` branches). A fast cached boot transitions `loading → none` within a few milliseconds, so the splash painted for those few ms and then unmounted → flash.

## Fix

Gate **only** the loading splash behind a short delay, `STARTUP_SPLASH_DELAY_MS = 220`:

- `useDelayElapsed(active, delayMs)` returns `true` only after the loading state has persisted continuously for the threshold, and resets to `false` the instant loading ends. The timer lives in a `useEffect` (`setTimeout`, cleared on unmount / when the view kind changes) — **no render-time clock/timer**, so `audit:ui-determinism` stays green.
- If the view becomes ready (transitions away from `loading`) before the threshold, the splash **never renders** — the flash is eliminated.
- `error`, `pairing`, and `bootstrap` views still render **immediately** (they are terminal/interactive, not fast-flash cases).
- The `startup-shell:first-paint` telemetry mark now fires when visible startup UI actually paints — the immediate views, or the splash once its gate opens — and never on a null-rendering mount. Existing dedupe-by-name behavior is preserved.
- `StartupLoading`'s markup, `data-testid="startup-shell-loading"`, `data-startup-phase`, and roles are unchanged — only **when** it appears changed.

## Evidence

Primary proof is a new co-located unit test (`StartupShell.test.tsx`, vitest + jsdom, fake timers), 8 cases:

- splash is **absent** before the threshold (and no first-paint mark);
- splash **appears** exactly once the threshold is crossed (markup/role/phase preserved; first-paint mark fires);
- splash **never** renders when the view flips to `none` before the threshold (fast cached boot — no mark);
- a fast flicker `loading → none → loading` restarts the timer and only paints after a fresh full threshold;
- `error` / `pairing` / `bootstrap` render immediately and mark first-paint; `none` renders nothing and marks nothing.

Verification run in this branch:

- `bun run --cwd packages/ui typecheck` — pass
- `bunx @biomejs/biome check` on both changed files — pass (clean)
- `bunx vitest run src/components/shell/StartupShell.test.tsx` — 8/8 pass
- `bunx vitest run src/components/shell/` — 36 files, 624 pass / 7 skipped (no regressions in the shell suite, incl. the existing `StartupFailureView` test)
- `bun run audit:ui-determinism` — StartupShell is **not** flagged (0 occurrences); this change adds no render-time nondeterminism. (The audit's pre-existing failures are all in unrelated `cloud/` files with a stale baseline on `develop`.)

Timing behavior, before → after: on a fast cached boot the splash used to paint for a few ms then vanish (flash); now it never mounts. On a genuinely slow boot the splash still appears (220ms later) and stays until the app is ready, exactly as before.

N/A rows: real-LLM trajectories, backend logs, audio — N/A (pure client-side render-timing change; no agent/model/prompt/voice behavior touched). Screenshots/video — the flash is a sub-frame timing artifact best proven by the fake-timer unit test above; there is no steady-state visual change to the splash itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)