### PR TITLE
fix(ui): restore macOS two-finger swipe-back/forward trackpad navigation gesture

### DIFF
--- a/packages/ui/src/styles/overscroll-behavior.test.ts
+++ b/packages/ui/src/styles/overscroll-behavior.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for the macOS trackpad two-finger swipe-back / swipe-forward
+ * navigation gesture in the desktop (Electrobun) webview.
+ *
+ * The gesture is a browser-native back/forward navigation that drives the app's
+ * History API view navigation through the `popstate` listener in
+ * `state/startup-phase-hydrate.ts`. In webviews, a blanket
+ * `overscroll-behavior: none` on the scroll-root ALSO sets `-x: none`, which
+ * suppresses that swipe-to-navigate gesture. The root `html, body` rule must
+ * therefore relax the X axis (`overscroll-behavior-x: auto`) while keeping the
+ * Y axis locked (`overscroll-behavior-y: none`) to preserve the vertical
+ * rubber-band / pull-to-refresh suppression the rule was originally added for.
+ *
+ * Native mobile shells intentionally re-lock BOTH axes via the
+ * higher-specificity `body.native { overscroll-behavior: none }` rule in
+ * base.css — that lock must stay in place.
+ */
+function readStyle(name: string): string {
+  const raw = readFileSync(
+    fileURLToPath(new URL(`./${name}`, import.meta.url)),
+    "utf8",
+  );
+  // Strip CSS comments so their prose (which may contain `}` or the literal
+  // `overscroll-behavior: none` while explaining the rule) can't confuse the
+  // brace-matching or the assertions below.
+  return raw.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Extract the first CSS declaration block whose selector list matches `selector`. */
+function ruleBody(css: string, selector: string): string {
+  const idx = css.indexOf(selector);
+  expect(idx, `selector \`${selector}\` not found`).toBeGreaterThanOrEqual(0);
+  const open = css.indexOf("{", idx);
+  const close = css.indexOf("}", open);
+  expect(open).toBeGreaterThanOrEqual(0);
+  expect(close).toBeGreaterThan(open);
+  return css.slice(open + 1, close);
+}
+
+describe("styles.css root scroll-root overscroll-behavior", () => {
+  const css = readStyle("styles.css");
+  const rootBody = ruleBody(css, "html,\nbody");
+
+  it("relaxes the X axis so the desktop swipe-to-navigate gesture works", () => {
+    expect(rootBody).toMatch(/overscroll-behavior-x:\s*auto/);
+  });
+
+  it("keeps the Y axis locked to preserve vertical bounce/pull-to-refresh suppression", () => {
+    expect(rootBody).toMatch(/overscroll-behavior-y:\s*(none|contain)/);
+  });
+
+  it("does NOT use a blanket `overscroll-behavior: none` on the scroll-root (it would kill the swipe gesture)", () => {
+    expect(rootBody).not.toMatch(/overscroll-behavior:\s*none/);
+  });
+});
+
+describe("base.css native shell keeps both overscroll axes locked", () => {
+  const css = readStyle("base.css");
+
+  it("still locks overscroll-behavior on native (body.native) shells", () => {
+    const nativeBody = ruleBody(
+      css,
+      "body.native,\nbody.platform-ios,\nbody.platform-android",
+    );
+    expect(nativeBody).toMatch(/overscroll-behavior:\s*none/);
+  });
+});

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -46,7 +46,17 @@ body {
   margin: 0;
   background: var(--launch-bg, #ef5a1f);
   overflow: hidden;
-  overscroll-behavior: none;
+  /* Split the axes instead of a blanket `overscroll-behavior: none`.
+     `-y: none` keeps the vertical rubber-band / pull-to-refresh suppression
+     this rule was added for, while `-x: auto` re-enables the macOS trackpad
+     two-finger swipe-to-navigate (back/forward) gesture in the desktop
+     (Electrobun) webview. That native gesture drives the app's History API
+     navigation through the `popstate` listener in
+     state/startup-phase-hydrate.ts. Native mobile shells re-lock BOTH axes via
+     the higher-specificity `body.native { overscroll-behavior: none }` rule in
+     base.css, so this only relaxes the X axis on web + desktop. */
+  overscroll-behavior-x: auto;
+  overscroll-behavior-y: none;
   -webkit-text-size-adjust: 100%;
 }
 


### PR DESCRIPTION
Closes #11886

## Problem

On macOS, the standard trackpad **two-finger horizontal swipe to go back / forward** does not work in the desktop (Electrobun) app.

## Root cause

The scroll-root (`html, body`) in `packages/ui/src/styles/styles.css` set a blanket `overscroll-behavior: none`. In Chromium/WebKit webviews, `overscroll-behavior-x: none` **suppresses the native swipe-to-navigate (back/forward) gesture** at the horizontal scroll boundary.

The app already navigates via the History API — `window.history.pushState(...)` in `packages/ui/src/state/useNavigationState.ts`, with a `popstate` (non-hash) listener in `packages/ui/src/state/startup-phase-hydrate.ts` that maps the URL path back to a view tab. So a browser-native back/forward gesture drives the app's view navigation through `popstate`; the gesture was simply being blocked by the overscroll setting. The blanket rule was added to kill the *vertical* rubber-band / pull-to-refresh bounce, so only the X axis needs relaxing.

## Change

Split the axes on the root scroll-root:

```css
/* was: overscroll-behavior: none; */
overscroll-behavior-x: auto;   /* re-enables two-finger swipe back/forward */
overscroll-behavior-y: none;   /* preserves vertical bounce / pull-to-refresh suppression */
```

Scope notes:
- **Only the root `html, body` is touched.** Native mobile shells (`body.native`, `body.platform-ios`, `body.platform-android` in `base.css`) re-lock **both** axes at higher specificity — left as-is, so mobile stays fully locked.
- The first-run onboarding rule (`.first-run-screen` in `brand-gold.css`) and inner scroll containers that intentionally `contain`/`none` their overscroll (chat sheet, sidebars, `react-remove-scroll` lock) are **not** touched.
- Added `packages/ui/src/styles/overscroll-behavior.test.ts` — a regression guard asserting the root uses split-axis overscroll (`x: auto`, `y: none`) rather than a blanket `none`, and that the native shell rule stays fully locked.

## Webview engine

macOS Electrobun uses **WKWebView** (Linux uses CEF/Chromium — see `packages/app-core/platforms/electrobun/README.md` and `electrobun.config.ts`). On WKWebView the swipe gesture additionally requires `allowsBackForwardNavigationGestures = YES` on the webview. Whether Electrobun 1.18.1 already enables it **could not be inspected** — the native binary is downloaded at build time and is absent from a fresh worktree, and Eliza's own native layer (`native/macos/window-effects.mm`) does not create the WKWebView (Electrobun does). The CSS relaxation is necessary regardless of that property. **Native follow-up (if the gesture still doesn't fire after this CSS change):** locate the WKWebView subview in the native layer and set `allowsBackForwardNavigationGestures = YES` on `webview dom-ready`. This was intentionally NOT included here because it cannot be compiled or tested in this environment and would risk the desktop native build unverified.

## Verification

| Evidence | Status |
|---|---|
| Regression test (`packages/ui test overscroll-behavior`) | Pass — 4/4 |
| Biome check on changed files | Pass — no issues |
| `packages/ui typecheck` | Pre-existing unrelated failures only (missing build-generated `i18n/generated/validation-keyword-data.*` in core/shared — not present after `install:light`); no error references the changed files |
| **Real trackpad two-finger swipe back/forward on the macOS Electrobun build** | **N/A in sandbox — REQUIRES the user's confirmation.** A real trackpad gesture cannot be exercised headlessly. |
| Before/after screenshots + video walkthrough | N/A in sandbox — the change only becomes observable via the physical trackpad gesture on the real desktop build |

### Manual test steps for the user (macOS desktop / Electrobun build)

1. Rebuild + relaunch the desktop app so it picks up this CSS change (the bundle is baked at build time).
2. Navigate between at least two views (e.g. open the app, then switch to a different tab/page) so there is back/forward history.
3. On the trackpad, **swipe left-to-right with two fingers** → the app should navigate **back** to the previous view.
4. **Swipe right-to-left with two fingers** → the app should navigate **forward** again.
5. Confirm vertical scrolling inside content still does **not** rubber-band the whole window, and inner scroll areas (chat sheet, sidebars) still contain their scroll.

If step 3/4 still doesn't navigate after rebuilding, apply the native follow-up described above (`allowsBackForwardNavigationGestures = YES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)