### PR TITLE
feat(import-conversations): Track A core — normalized types + ingestion pipeline (#11881)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2266,6 +2266,13 @@
         "vite": "^8.0.0",
       },
     },
+    "packages/import-conversations": {
+      "name": "@elizaos/import-conversations",
+      "version": "2.0.4",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+      },
+    },
     "packages/logger": {
       "name": "@elizaos/logger",
       "version": "2.0.3-beta.7",
@@ -6313,6 +6320,8 @@
     "@elizaos/gateway-webhook": ["@elizaos/gateway-webhook@workspace:packages/cloud/services/gateway-webhook"],
 
     "@elizaos/gcp-examples": ["@elizaos/gcp-examples@workspace:packages/examples/gcp"],
+
+    "@elizaos/import-conversations": ["@elizaos/import-conversations@workspace:packages/import-conversations"],
 
     "@elizaos/interrupt-bench": ["@elizaos/interrupt-bench@workspace:packages/benchmarks/interrupt-bench"],
 

--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@elizaos/import-conversations",
+  "version": "2.0.4",
+  "description": "Import prior AI conversation history (ChatGPT / Claude / Hermes exports) into elizaOS as searchable, scoped knowledge. Track A: shared core (normalized types + ingestion pipeline).",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "license": "MIT",
+  "homepage": "https://github.com/elizaOS/eliza",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elizaOS/eliza.git",
+    "directory": "packages/import-conversations"
+  },
+  "keywords": [
+    "elizaos",
+    "import",
+    "conversations",
+    "chatgpt",
+    "claude",
+    "hermes",
+    "migration"
+  ],
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "clean": "node ../scripts/rm-path-recursive.mjs dist",
+    "prepublishOnly": "bun run build",
+    "build": "bun run build:dist",
+    "build:dist": "node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/import-conversations",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+    "lint": "find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome check",
+    "lint:fix": "find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome check --write",
+    "format": "find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome format",
+    "format:fix": "find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome format --write",
+    "pack:dry-run": "cd dist && npm pack --dry-run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0"
+  }
+}

--- a/packages/import-conversations/src/__tests__/helpers.ts
+++ b/packages/import-conversations/src/__tests__/helpers.ts
@@ -1,0 +1,84 @@
+/** Shared test doubles: a fake DocumentSink and a fake streaming parser. */
+
+import type {
+  DocumentSink,
+  SinkAddResult,
+  SinkDocument,
+} from "../core/sink.ts";
+import type { NormalizedConversation } from "../core/types.ts";
+
+/** Records every stored document; simulates content-based dedup by filename+content. */
+export class FakeDocumentSink implements DocumentSink {
+  readonly stored = new Map<string, SinkDocument>();
+  readonly deleted: string[] = [];
+  /** All addDocument calls, in order (including deduped skips). */
+  readonly addCalls: SinkDocument[] = [];
+  private seq = 0;
+  /** When true, a repeat (same filename+content) returns status: "skipped". */
+  dedup: boolean;
+
+  constructor(opts: { dedup?: boolean } = {}) {
+    this.dedup = opts.dedup ?? true;
+  }
+
+  private key(doc: SinkDocument): string {
+    return `${doc.originalFilename}::${doc.content}`;
+  }
+
+  async addDocument(doc: SinkDocument): Promise<SinkAddResult> {
+    this.addCalls.push(doc);
+    const dedupKey = this.key(doc);
+    if (this.dedup) {
+      for (const [id, existing] of this.stored) {
+        if (this.key(existing) === dedupKey) {
+          return { id, status: "skipped" };
+        }
+      }
+    }
+    const id = `doc-${++this.seq}`;
+    this.stored.set(id, doc);
+    return { id, status: "stored" };
+  }
+
+  async deleteDocument(id: string): Promise<void> {
+    this.deleted.push(id);
+    this.stored.delete(id);
+  }
+}
+
+/** Turn an array of conversations into an AsyncIterable (a fake parser stream). */
+export async function* streamConversations(
+  conversations: NormalizedConversation[],
+  onYield?: (c: NormalizedConversation) => void,
+): AsyncIterable<NormalizedConversation> {
+  for (const c of conversations) {
+    onYield?.(c);
+    // Yield to the microtask queue so laziness is observable in tests.
+    await Promise.resolve();
+    yield c;
+  }
+}
+
+/** Build a minimal conversation fixture. */
+export function conv(
+  partial: Partial<NormalizedConversation> & { sourceConversationId: string },
+): NormalizedConversation {
+  return {
+    title: "Untitled",
+    createdAt: Date.parse("2024-05-01T12:00:00Z"),
+    updatedAt: Date.parse("2024-05-01T12:05:00Z"),
+    messages: [
+      {
+        role: "user",
+        text: "hello",
+        createdAt: Date.parse("2024-05-01T12:00:00Z"),
+      },
+      {
+        role: "assistant",
+        text: "hi there",
+        createdAt: Date.parse("2024-05-01T12:01:00Z"),
+      },
+    ],
+    ...partial,
+  };
+}

--- a/packages/import-conversations/src/core/index.ts
+++ b/packages/import-conversations/src/core/index.ts
@@ -1,0 +1,10 @@
+/** Public barrel for the conversation-importer core (Track A). */
+
+export * from "./manifest.ts";
+export * from "./pipeline.ts";
+export * from "./redact.ts";
+export * from "./registry.ts";
+export * from "./render.ts";
+export * from "./report.ts";
+export * from "./sink.ts";
+export * from "./types.ts";

--- a/packages/import-conversations/src/core/manifest.test.ts
+++ b/packages/import-conversations/src/core/manifest.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyConversation,
+  createManifest,
+  entryDocumentIds,
+  enumerateBatchDocumentIds,
+  manifestConversationCount,
+  manifestKey,
+  recordConversation,
+} from "./manifest.ts";
+
+describe("manifestKey", () => {
+  it("namespaces by source", () => {
+    expect(manifestKey("chatgpt", "abc")).toBe("chatgpt:abc");
+  });
+});
+
+describe("classifyConversation", () => {
+  it("classifies a brand-new conversation as added", () => {
+    const m = createManifest("batch-1", "chatgpt", 0);
+    expect(classifyConversation(m, "c1", 100)).toBe("added");
+  });
+
+  it("classifies an unchanged conversation (same updatedAt)", () => {
+    let m = createManifest("batch-1", "chatgpt", 0);
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 100,
+        documentIds: ["d1"],
+      },
+      0,
+    );
+    expect(classifyConversation(m, "c1", 100)).toBe("unchanged");
+    expect(classifyConversation(m, "c1", 50)).toBe("unchanged"); // older = still unchanged
+  });
+
+  it("classifies a newer conversation as updated", () => {
+    let m = createManifest("batch-1", "chatgpt", 0);
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 100,
+        documentIds: ["d1"],
+      },
+      0,
+    );
+    expect(classifyConversation(m, "c1", 200)).toBe("updated");
+  });
+
+  it("treats a missing incoming updatedAt as 0 (unchanged once recorded)", () => {
+    let m = createManifest("batch-1", "chatgpt", 0);
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: undefined,
+        documentIds: ["d1"],
+      },
+      0,
+    );
+    expect(classifyConversation(m, "c1", undefined)).toBe("unchanged");
+  });
+});
+
+describe("recordConversation", () => {
+  it("is immutable (returns a new manifest)", () => {
+    const m0 = createManifest("batch-1", "chatgpt", 0);
+    const m1 = recordConversation(
+      m0,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 100,
+        documentIds: ["d1"],
+      },
+      1,
+    );
+    expect(m0.entries).toEqual({});
+    expect(Object.keys(m1.entries)).toEqual(["c1"]);
+    expect(m1.updatedAt).toBe(1);
+  });
+
+  it("overwrites documentIds on re-record (updated path)", () => {
+    let m = createManifest("batch-1", "chatgpt", 0);
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 100,
+        documentIds: ["d1", "d2"],
+      },
+      0,
+    );
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 200,
+        documentIds: ["d3"],
+      },
+      1,
+    );
+    expect(entryDocumentIds(m, "c1")).toEqual(["d3"]);
+    expect(m.entries.c1.updatedAt).toBe(200);
+  });
+});
+
+describe("uninstall enumeration", () => {
+  it("enumerates every document id across the batch", () => {
+    let m = createManifest("batch-1", "chatgpt", 0);
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c1",
+        updatedAt: 1,
+        documentIds: ["a", "b"],
+      },
+      0,
+    );
+    m = recordConversation(
+      m,
+      {
+        source: "chatgpt",
+        sourceConversationId: "c2",
+        updatedAt: 1,
+        documentIds: ["c"],
+      },
+      0,
+    );
+    expect(enumerateBatchDocumentIds(m).sort()).toEqual(["a", "b", "c"]);
+    expect(manifestConversationCount(m)).toBe(2);
+  });
+
+  it("returns [] for a conversation with no entry", () => {
+    const m = createManifest("batch-1", "chatgpt", 0);
+    expect(entryDocumentIds(m, "missing")).toEqual([]);
+  });
+});

--- a/packages/import-conversations/src/core/manifest.ts
+++ b/packages/import-conversations/src/core/manifest.ts
@@ -1,0 +1,152 @@
+/**
+ * Import-batch manifest: idempotency + uninstall bookkeeping.
+ *
+ * The manifest records, per imported conversation, the source-provided identity
+ * `(source, sourceConversationId, updatedAt)` plus the DocumentSink ids that
+ * conversation produced. This drives:
+ *   - idempotent re-import: on re-upload, unchanged conversations are skipped,
+ *     newer ones (later `updatedAt`) are re-imported as `updated`.
+ *   - full-batch uninstall: enumerate every stored document id in a batch so
+ *     the app side can `deleteDocument` each (scope §4.4, hard requirement).
+ *
+ * The manifest itself is a plain serializable object; the eliza-app side is
+ * responsible for persisting it (e.g. as an import-state document). Core keeps
+ * it in-memory + pure so the pipeline is unit-testable.
+ */
+
+import type { ConversationSource } from "./types.ts";
+
+/** Classification of a conversation against the prior manifest state. */
+export type ConversationChange = "added" | "unchanged" | "updated";
+
+/** A single conversation's record within an import batch. */
+export interface ManifestEntry {
+  source: ConversationSource;
+  sourceConversationId: string;
+  /** Epoch ms `updatedAt` of the conversation at import time (0 when absent). */
+  updatedAt: number;
+  /** Document ids produced for this conversation (one per rendered part). */
+  documentIds: string[];
+  /** When this entry was last written, epoch ms. */
+  importedAt: number;
+}
+
+/** A full import batch (one export upload). */
+export interface ImportManifest {
+  batchId: string;
+  source: ConversationSource;
+  /** Keyed by `sourceConversationId`. */
+  entries: Record<string, ManifestEntry>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Build the dedup key for a conversation within a source namespace. */
+export function manifestKey(
+  source: ConversationSource,
+  sourceConversationId: string,
+): string {
+  return `${source}:${sourceConversationId}`;
+}
+
+/** Create an empty manifest for a new import batch. */
+export function createManifest(
+  batchId: string,
+  source: ConversationSource,
+  now: number = Date.now(),
+): ImportManifest {
+  return {
+    batchId,
+    source,
+    entries: {},
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Classify a conversation against a (possibly prior) manifest.
+ *
+ * - No prior entry → `added`.
+ * - Prior entry with an equal-or-newer stored `updatedAt` → `unchanged`.
+ * - Prior entry with an older stored `updatedAt` (incoming is newer) →
+ *   `updated`.
+ *
+ * A missing `updatedAt` on the incoming conversation is treated as `0`, so a
+ * conversation that never advertises an update time re-imports as `unchanged`
+ * once recorded (avoids churn) unless the export later supplies a real time.
+ */
+export function classifyConversation(
+  manifest: ImportManifest,
+  sourceConversationId: string,
+  incomingUpdatedAt: number | undefined,
+): ConversationChange {
+  const prior = manifest.entries[sourceConversationId];
+  if (!prior) {
+    return "added";
+  }
+  const incoming = incomingUpdatedAt ?? 0;
+  if (incoming > prior.updatedAt) {
+    return "updated";
+  }
+  return "unchanged";
+}
+
+/**
+ * Record (or replace) a conversation's entry after it has been stored. Returns
+ * a new manifest object (does not mutate the input) so callers can keep the
+ * prior state for reporting. Replacing an existing entry (the `updated` path)
+ * overwrites its `documentIds` — callers should have already scheduled the old
+ * documents for deletion via {@link entryDocumentIds}.
+ */
+export function recordConversation(
+  manifest: ImportManifest,
+  params: {
+    source: ConversationSource;
+    sourceConversationId: string;
+    updatedAt: number | undefined;
+    documentIds: string[];
+  },
+  now: number = Date.now(),
+): ImportManifest {
+  const entry: ManifestEntry = {
+    source: params.source,
+    sourceConversationId: params.sourceConversationId,
+    updatedAt: params.updatedAt ?? 0,
+    documentIds: [...params.documentIds],
+    importedAt: now,
+  };
+  return {
+    ...manifest,
+    updatedAt: now,
+    entries: {
+      ...manifest.entries,
+      [params.sourceConversationId]: entry,
+    },
+  };
+}
+
+/** Return the stored document ids for a conversation, or `[]` if not present. */
+export function entryDocumentIds(
+  manifest: ImportManifest,
+  sourceConversationId: string,
+): string[] {
+  return manifest.entries[sourceConversationId]?.documentIds ?? [];
+}
+
+/**
+ * Enumerate every document id in the batch — the uninstall surface. The
+ * app-side uninstall walks this list and calls `deleteDocument` per id.
+ */
+export function enumerateBatchDocumentIds(manifest: ImportManifest): string[] {
+  const ids: string[] = [];
+  for (const entry of Object.values(manifest.entries)) {
+    ids.push(...entry.documentIds);
+  }
+  return ids;
+}
+
+/** Total conversations recorded in the batch. */
+export function manifestConversationCount(manifest: ImportManifest): number {
+  return Object.keys(manifest.entries).length;
+}

--- a/packages/import-conversations/src/core/pipeline.test.ts
+++ b/packages/import-conversations/src/core/pipeline.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+  conv,
+  FakeDocumentSink,
+  streamConversations,
+} from "../__tests__/helpers.ts";
+import { enumerateBatchDocumentIds } from "./manifest.ts";
+import {
+  collectImport,
+  type ProgressEvent,
+  runImport,
+  uninstallBatch,
+} from "./pipeline.ts";
+import { REDACTED_PLACEHOLDER } from "./redact.ts";
+import type { NormalizedConversation } from "./types.ts";
+
+const NOW = () => 1_700_000_000_000;
+
+function opts(sink: FakeDocumentSink, extra: Record<string, unknown> = {}) {
+  return {
+    source: "chatgpt" as const,
+    batchId: "batch-1",
+    sink,
+    entityId: "entity-42",
+    now: NOW,
+    ...extra,
+  };
+}
+
+describe("pipeline end-to-end", () => {
+  it("parses → stores → reports with progress events", async () => {
+    const sink = new FakeDocumentSink();
+    const conversations = [
+      conv({ sourceConversationId: "c1", title: "First" }),
+      conv({ sourceConversationId: "c2", title: "Second" }),
+    ];
+    const progress: ProgressEvent[] = [];
+    const gen = runImport(
+      streamConversations(conversations),
+      opts(sink, { total: conversations.length }),
+    );
+    let res = await gen.next();
+    while (!res.done) {
+      progress.push(res.value);
+      res = await gen.next();
+    }
+    const { report, manifest } = res.value;
+
+    expect(report.summary.added).toBe(2);
+    expect(report.summary.documentsStored).toBe(2);
+    expect(sink.stored.size).toBe(2);
+
+    // progress events, one per conversation, with total
+    expect(progress).toHaveLength(2);
+    expect(progress[0]).toMatchObject({ processed: 1, total: 2 });
+    expect(progress[1]).toMatchObject({ processed: 2, total: 2 });
+
+    // provenance/scoping applied
+    const [doc] = sink.stored.values();
+    expect(doc.scope).toBe("user-private");
+    expect(doc.scopedToEntityId).toBe("entity-42");
+    expect(doc.addedFrom).toBe("import");
+    expect(doc.contentType).toBe("text/markdown");
+    const md = doc.metadata as {
+      import: Record<string, unknown>;
+      tags: string[];
+    };
+    expect(md.import.source).toBe("chatgpt");
+    expect(md.import.importBatchId).toBe("batch-1");
+    expect(md.tags).toContain("import");
+    expect(md.tags).toContain("import:chatgpt");
+
+    // manifest recorded both
+    expect(Object.keys(manifest.entries).sort()).toEqual(["c1", "c2"]);
+  });
+
+  it("redacts secrets before storing", async () => {
+    const sink = new FakeDocumentSink();
+    const c = conv({
+      sourceConversationId: "c1",
+      messages: [{ role: "user", text: "my key sk-abcdefgh12345678 leaked" }],
+    });
+    await collectImport(streamConversations([c]), opts(sink));
+    const [doc] = sink.stored.values();
+    expect(doc.content).toContain(REDACTED_PLACEHOLDER);
+    expect(doc.content).not.toContain("sk-abcdefgh12345678");
+  });
+
+  it("skips conversations with no renderable messages", async () => {
+    const sink = new FakeDocumentSink();
+    const empty = conv({ sourceConversationId: "empty", messages: [] });
+    const { report } = await collectImport(
+      streamConversations([empty]),
+      opts(sink),
+    );
+    expect(report.summary.skipped).toBe(1);
+    expect(report.summary.added).toBe(0);
+    expect(sink.stored.size).toBe(0);
+    expect(report.items[0].reason).toBeDefined();
+  });
+});
+
+describe("idempotent re-import", () => {
+  it("re-import of the same export is all unchanged (no new docs)", async () => {
+    const sink = new FakeDocumentSink();
+    const conversations = [conv({ sourceConversationId: "c1" })];
+
+    const first = await collectImport(
+      streamConversations(conversations),
+      opts(sink),
+    );
+    expect(first.report.summary.added).toBe(1);
+
+    const second = await collectImport(
+      streamConversations(conversations),
+      opts(sink, { manifest: first.manifest }),
+    );
+    expect(second.report.summary.unchanged).toBe(1);
+    expect(second.report.summary.added).toBe(0);
+    // no additional documents stored
+    expect(sink.stored.size).toBe(1);
+  });
+
+  it("re-import with a newer updatedAt re-imports as updated and replaces docs", async () => {
+    const sink = new FakeDocumentSink();
+    const v1 = conv({
+      sourceConversationId: "c1",
+      updatedAt: 1000,
+      messages: [{ role: "user", text: "v1 content" }],
+    });
+    const first = await collectImport(streamConversations([v1]), opts(sink));
+    const oldId = enumerateBatchDocumentIds(first.manifest)[0];
+
+    const v2 = conv({
+      sourceConversationId: "c1",
+      updatedAt: 2000,
+      messages: [{ role: "user", text: "v2 content changed" }],
+    });
+    const second = await collectImport(
+      streamConversations([v2]),
+      opts(sink, { manifest: first.manifest }),
+    );
+    expect(second.report.summary.updated).toBe(1);
+    // old document was deleted, new one stored
+    expect(sink.deleted).toContain(oldId);
+    const newIds = enumerateBatchDocumentIds(second.manifest);
+    expect(newIds).not.toContain(oldId);
+    expect(
+      [...sink.stored.values()].some((d) => d.content.includes("v2 content")),
+    ).toBe(true);
+  });
+});
+
+describe("content dedup via sink", () => {
+  it("reports a content-dedup skip when the sink dedups an added conversation", async () => {
+    const sink = new FakeDocumentSink({ dedup: true });
+    const c = conv({ sourceConversationId: "c1" });
+    // Store the doc directly first so the pipeline's add is deduped.
+    const parts = await collectImport(streamConversations([c]), opts(sink));
+    expect(parts.report.summary.added).toBe(1);
+
+    // A brand-new batch (fresh manifest) importing identical content → sink
+    // dedups → pipeline reports a content-dedup skip.
+    const sink2 = new FakeDocumentSink({ dedup: true });
+    // Pre-seed sink2 with the identical rendered doc.
+    const first = await collectImport(streamConversations([c]), opts(sink2));
+    const second = await collectImport(
+      streamConversations([c]),
+      opts(sink2, { batchId: "batch-2" }), // fresh manifest, same content
+    );
+    expect(first.report.summary.added).toBe(1);
+    expect(second.report.summary.skipped).toBe(1);
+    expect(second.report.items[0].reason).toContain("dedup");
+  });
+});
+
+describe("dry run", () => {
+  it("classifies + reports without storing", async () => {
+    const sink = new FakeDocumentSink();
+    const c = conv({ sourceConversationId: "c1" });
+    const { report } = await collectImport(
+      streamConversations([c]),
+      opts(sink, { dryRun: true }),
+    );
+    expect(report.dryRun).toBe(true);
+    expect(report.summary.added).toBe(1);
+    // nothing stored
+    expect(sink.stored.size).toBe(0);
+    expect(sink.addCalls).toHaveLength(0);
+  });
+
+  it("does not require a sink for a dry run", async () => {
+    const c = conv({ sourceConversationId: "c1" });
+    const { report } = await collectImport(streamConversations([c]), {
+      source: "chatgpt",
+      batchId: "b",
+      dryRun: true,
+      now: NOW,
+    });
+    expect(report.summary.added).toBe(1);
+  });
+
+  it("throws if a non-dry-run has no sink", async () => {
+    const c = conv({ sourceConversationId: "c1" });
+    await expect(
+      collectImport(streamConversations([c]), {
+        source: "chatgpt",
+        batchId: "b",
+        now: NOW,
+      }),
+    ).rejects.toThrow(/DocumentSink is required/);
+  });
+});
+
+describe("uninstall", () => {
+  it("deletes every document in the batch", async () => {
+    const sink = new FakeDocumentSink();
+    const conversations = [
+      conv({ sourceConversationId: "c1" }),
+      conv({ sourceConversationId: "c2" }),
+    ];
+    const { manifest } = await collectImport(
+      streamConversations(conversations),
+      opts(sink),
+    );
+    const deletedCount = await uninstallBatch(sink, manifest);
+    expect(deletedCount).toBe(2);
+    expect(sink.stored.size).toBe(0);
+  });
+});
+
+describe("streaming (laziness)", () => {
+  it("processes a lazy async iterable without materializing it upfront", async () => {
+    const sink = new FakeDocumentSink();
+    const yielded: string[] = [];
+    const conversations = [
+      conv({ sourceConversationId: "c1" }),
+      conv({ sourceConversationId: "c2" }),
+      conv({ sourceConversationId: "c3" }),
+    ];
+    const stream = streamConversations(conversations, (c) =>
+      yielded.push(c.sourceConversationId),
+    );
+
+    // Drive the generator one step at a time; after the first progress event,
+    // only the first conversation should have been pulled from the source.
+    const gen = runImport(stream, opts(sink));
+    const first = await gen.next();
+    expect(first.done).toBe(false);
+    expect(yielded).toEqual(["c1"]); // lazy: c2/c3 not yet pulled
+
+    // drain the rest
+    let res = await gen.next();
+    while (!res.done) res = await gen.next();
+    expect(yielded).toEqual(["c1", "c2", "c3"]);
+    expect(sink.stored.size).toBe(3);
+  });
+
+  it("never buffers: an infinite-until-limit generator is consumed incrementally", async () => {
+    const sink = new FakeDocumentSink();
+    let produced = 0;
+    async function* lazy(): AsyncIterable<NormalizedConversation> {
+      while (produced < 5) {
+        produced += 1;
+        yield conv({ sourceConversationId: `c${produced}` });
+      }
+    }
+    const events: number[] = [];
+    const gen = runImport(lazy(), opts(sink));
+    let res = await gen.next();
+    while (!res.done) {
+      events.push(produced); // producer count at the moment of each event
+      res = await gen.next();
+    }
+    // Each event observes at most one-ahead production (streaming, not buffered).
+    for (let i = 0; i < events.length; i++) {
+      expect(events[i]).toBe(i + 1);
+    }
+  });
+});

--- a/packages/import-conversations/src/core/pipeline.ts
+++ b/packages/import-conversations/src/core/pipeline.ts
@@ -1,0 +1,357 @@
+/**
+ * The ingestion pipeline: parse → redact → render → dedup(manifest) → store →
+ * report. Streaming by construction — it consumes the parser's
+ * `AsyncIterable<NormalizedConversation>` and never buffers all conversations.
+ *
+ * Storage goes through the injected {@link DocumentSink} port so core stays
+ * decoupled from eliza's real DocumentService (the app side supplies a thin
+ * adapter). Scope/provenance metadata is applied per scope §4.2/§4.4:
+ * `user-private` scope, `import` provenance, an import metadata block, and
+ * provenance tags.
+ *
+ * Progress events (`{ processed, total }`) are yielded for background-job UIs.
+ */
+
+import {
+  classifyConversation,
+  createManifest,
+  entryDocumentIds,
+  type ImportManifest,
+  recordConversation,
+} from "./manifest.ts";
+import { redactText } from "./redact.ts";
+import { type RenderOptions, renderConversation } from "./render.ts";
+import {
+  type ImportReport,
+  ReportBuilder,
+  SKIP_REASON_DUPLICATE_CONTENT,
+  SKIP_REASON_NO_MESSAGES,
+} from "./report.ts";
+import type { DocumentScope, DocumentSink, SinkDocument } from "./sink.ts";
+import type {
+  ConversationSource,
+  NormalizedConversation,
+  NormalizedMessage,
+} from "./types.ts";
+
+/** Progress event yielded as each conversation is processed. */
+export interface ProgressEvent {
+  processed: number;
+  /** Total, when known ahead of time; otherwise undefined for pure streams. */
+  total?: number;
+  /** The conversation id just handled. */
+  sourceConversationId: string;
+}
+
+export interface RunImportOptions {
+  source: ConversationSource;
+  batchId: string;
+  /**
+   * Storage port. Required for apply runs; may be omitted for a `dryRun`
+   * (a no-op sink is used and never invoked in that path).
+   */
+  sink?: DocumentSink;
+  /** The importing user's entity id — sets `scopedToEntityId`. */
+  entityId?: string;
+  /** Visibility scope for stored docs. Defaults to `user-private`. */
+  scope?: DocumentScope;
+  /** Prior manifest for idempotent re-import. A fresh one is created if absent. */
+  manifest?: ImportManifest;
+  /** Total conversation count, when known, for progress `total`. */
+  total?: number;
+  /** Dry run: classify + report but do not store. */
+  dryRun?: boolean;
+  /** Render/split options. */
+  render?: RenderOptions;
+  /** Clock injection for deterministic tests. */
+  now?: () => number;
+}
+
+/** The terminal result of an import run. */
+export interface RunImportResult {
+  report: ImportReport;
+  manifest: ImportManifest;
+}
+
+/** True when a conversation has at least one message with renderable content. */
+function hasRenderableMessages(conversation: NormalizedConversation): boolean {
+  const messages = conversation.messages ?? [];
+  return messages.some(
+    (m) =>
+      (m.text && m.text.trim().length > 0) || (m.attachments?.length ?? 0) > 0,
+  );
+}
+
+/** Apply secret redaction to every message's text + inlined attachment text. */
+function redactConversation(
+  conversation: NormalizedConversation,
+): NormalizedConversation {
+  const messages: NormalizedMessage[] = conversation.messages.map((m) => {
+    const redactedText = redactText(m.text ?? "");
+    const attachments = m.attachments?.map((att) =>
+      att.text ? { ...att, text: redactText(att.text) } : att,
+    );
+    return attachments
+      ? { ...m, text: redactedText, attachments }
+      : { ...m, text: redactedText };
+  });
+  // Also scrub the title (people paste keys into titles sometimes).
+  const title = conversation.title
+    ? redactText(conversation.title)
+    : conversation.title;
+  return { ...conversation, title, messages };
+}
+
+/** Build the provenance tag list for a conversation (scope §4.4). */
+function buildTags(
+  source: ConversationSource,
+  sourceConversationId: string,
+  dateMs: number | undefined,
+): string[] {
+  const tags = ["import", `import:${source}`, `conv:${sourceConversationId}`];
+  if (dateMs !== undefined && Number.isFinite(dateMs)) {
+    tags.push(`date:${new Date(dateMs).toISOString().slice(0, 7)}`);
+  }
+  return tags;
+}
+
+/** Filename for a rendered part (single-part omits the part suffix). */
+function partFilename(
+  source: ConversationSource,
+  sourceConversationId: string,
+  partIndex: number,
+  partCount: number,
+): string {
+  const base = `${source}/${sourceConversationId}`;
+  return partCount > 1 ? `${base}__part${partIndex + 1}.md` : `${base}.md`;
+}
+
+/**
+ * Run the import pipeline over a streamed source. Yields {@link ProgressEvent}s
+ * as it processes each conversation, and returns (via the async generator's
+ * return value) the final {@link RunImportResult}.
+ *
+ * Consume it as an async generator to observe progress, then read the return:
+ *
+ * ```ts
+ * const gen = runImport(source, opts);
+ * let res = await gen.next();
+ * while (!res.done) { onProgress(res.value); res = await gen.next(); }
+ * const { report, manifest } = res.value; // final result
+ * ```
+ *
+ * Or use {@link collectImport} to run to completion without progress handling.
+ */
+export async function* runImport(
+  conversations: AsyncIterable<NormalizedConversation>,
+  options: RunImportOptions,
+): AsyncGenerator<ProgressEvent, RunImportResult, void> {
+  const now = options.now ?? Date.now;
+  const scope: DocumentScope = options.scope ?? "user-private";
+  const dryRun = options.dryRun ?? false;
+  if (!dryRun && !options.sink) {
+    throw new Error(
+      "runImport: a DocumentSink is required for a non-dry-run import",
+    );
+  }
+  const report = new ReportBuilder(options.source, options.batchId, dryRun);
+  let manifest =
+    options.manifest ?? createManifest(options.batchId, options.source, now());
+
+  let processed = 0;
+
+  for await (const raw of conversations) {
+    processed += 1;
+
+    if (!hasRenderableMessages(raw)) {
+      report.skip({
+        sourceConversationId: raw.sourceConversationId,
+        title: raw.title,
+        reason: SKIP_REASON_NO_MESSAGES,
+      });
+      yield {
+        processed,
+        total: options.total,
+        sourceConversationId: raw.sourceConversationId,
+      };
+      continue;
+    }
+
+    // Idempotency classification BEFORE any storage work.
+    const change = classifyConversation(
+      manifest,
+      raw.sourceConversationId,
+      raw.updatedAt,
+    );
+
+    if (change === "unchanged") {
+      report.record({
+        sourceConversationId: raw.sourceConversationId,
+        title: raw.title,
+        change: "unchanged",
+        documentCount: entryDocumentIds(manifest, raw.sourceConversationId)
+          .length,
+      });
+      yield {
+        processed,
+        total: options.total,
+        sourceConversationId: raw.sourceConversationId,
+      };
+      continue;
+    }
+
+    // Redact, then render into (possibly multiple) part documents.
+    const conversation = redactConversation(raw);
+    const parts = renderConversation(
+      conversation,
+      options.source,
+      options.render,
+    );
+    const tags = buildTags(
+      options.source,
+      conversation.sourceConversationId,
+      conversation.updatedAt ?? conversation.createdAt,
+    );
+
+    if (dryRun) {
+      report.record({
+        sourceConversationId: conversation.sourceConversationId,
+        title: conversation.title,
+        change,
+        documentCount: parts.length,
+      });
+      yield {
+        processed,
+        total: options.total,
+        sourceConversationId: conversation.sourceConversationId,
+      };
+      continue;
+    }
+
+    // Non-null after the dry-run guard above.
+    const sink = options.sink as DocumentSink;
+
+    // On `updated`: delete the prior batch's documents for this conversation
+    // before re-storing (uninstall-then-reimport keeps the batch clean).
+    if (change === "updated") {
+      for (const oldId of entryDocumentIds(
+        manifest,
+        conversation.sourceConversationId,
+      )) {
+        await sink.deleteDocument(oldId);
+      }
+    }
+
+    const storedIds: string[] = [];
+    let anyStored = false;
+    for (const part of parts) {
+      const doc: SinkDocument = {
+        content: part.text,
+        contentType: "text/markdown",
+        originalFilename: partFilename(
+          options.source,
+          conversation.sourceConversationId,
+          part.index,
+          part.partCount,
+        ),
+        scope,
+        scopedToEntityId: options.entityId,
+        addedFrom: "import",
+        metadata: {
+          import: {
+            source: options.source,
+            sourceConversationId: conversation.sourceConversationId,
+            importBatchId: options.batchId,
+            exportedAt: conversation.updatedAt ?? conversation.createdAt,
+            importedAt: now(),
+            messageCount: part.messageCount,
+            part:
+              part.partCount > 1
+                ? { index: part.index, count: part.partCount }
+                : undefined,
+            dateRange: {
+              start: conversation.createdAt,
+              end: conversation.updatedAt,
+            },
+          },
+          tags,
+        },
+      };
+      const result = await sink.addDocument(doc);
+      storedIds.push(result.id);
+      if (result.status === "stored") {
+        anyStored = true;
+      }
+    }
+
+    // If the sink deduped every part (nothing new stored) on an `added`
+    // classification, report it as a content-dedup skip rather than added.
+    if (change === "added" && !anyStored) {
+      report.skip({
+        sourceConversationId: conversation.sourceConversationId,
+        title: conversation.title,
+        reason: SKIP_REASON_DUPLICATE_CONTENT,
+      });
+    } else {
+      report.record({
+        sourceConversationId: conversation.sourceConversationId,
+        title: conversation.title,
+        change,
+        documentCount: storedIds.length,
+      });
+      manifest = recordConversation(
+        manifest,
+        {
+          source: options.source,
+          sourceConversationId: conversation.sourceConversationId,
+          updatedAt: conversation.updatedAt,
+          documentIds: storedIds,
+        },
+        now(),
+      );
+    }
+
+    yield {
+      processed,
+      total: options.total,
+      sourceConversationId: conversation.sourceConversationId,
+    };
+  }
+
+  return { report: report.build(), manifest };
+}
+
+/**
+ * Convenience wrapper: run {@link runImport} to completion, ignoring progress
+ * events, and return the final result.
+ */
+export async function collectImport(
+  conversations: AsyncIterable<NormalizedConversation>,
+  options: RunImportOptions,
+): Promise<RunImportResult> {
+  const gen = runImport(conversations, options);
+  let res = await gen.next();
+  while (!res.done) {
+    res = await gen.next();
+  }
+  return res.value;
+}
+
+/**
+ * Uninstall an entire import batch: delete every stored document enumerated by
+ * the manifest. Returns the count deleted. (Convenience over
+ * `enumerateBatchDocumentIds` + sink.deleteDocument.)
+ */
+export async function uninstallBatch(
+  sink: Pick<DocumentSink, "deleteDocument">,
+  manifest: ImportManifest,
+): Promise<number> {
+  let count = 0;
+  for (const entry of Object.values(manifest.entries)) {
+    for (const id of entry.documentIds) {
+      await sink.deleteDocument(id);
+      count += 1;
+    }
+  }
+  return count;
+}

--- a/packages/import-conversations/src/core/redact.test.ts
+++ b/packages/import-conversations/src/core/redact.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { containsSecret, REDACTED_PLACEHOLDER, redactText } from "./redact.ts";
+
+describe("redactText", () => {
+  it("redacts OpenAI sk- keys", () => {
+    const out = redactText("my key is sk-abcd1234efgh5678 ok");
+    expect(out).toBe(`my key is ${REDACTED_PLACEHOLDER} ok`);
+  });
+
+  it("redacts sk-proj- style keys", () => {
+    const out = redactText("sk-proj-ABCdef_123-456XYZ done");
+    expect(out).toContain(REDACTED_PLACEHOLDER);
+    expect(out).not.toContain("sk-proj");
+  });
+
+  it("redacts GitHub tokens (ghp_ / gho_ / ghs_)", () => {
+    expect(redactText("ghp_0123456789abcdefghijABCDEF")).toBe(
+      REDACTED_PLACEHOLDER,
+    );
+    expect(redactText("gho_0123456789abcdefghijABCDEF")).toBe(
+      REDACTED_PLACEHOLDER,
+    );
+    expect(redactText("ghs_0123456789abcdefghijABCDEF")).toBe(
+      REDACTED_PLACEHOLDER,
+    );
+  });
+
+  it("redacts Bearer tokens", () => {
+    const out = redactText("Authorization: Bearer eyJhbGciOi.J9.abc-DEF_123");
+    expect(out).toContain(REDACTED_PLACEHOLDER);
+    expect(out).not.toContain("eyJhbGciOi");
+  });
+
+  it("redacts Slack xox tokens", () => {
+    expect(redactText("xoxb-123456789012-abcdEFGH")).toBe(REDACTED_PLACEHOLDER);
+    expect(redactText("xoxp-000-111-222abc")).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("redacts Google AIza keys", () => {
+    expect(redactText("AIzaSyD-abcdefghij_KLMNOP12345")).toBe(
+      REDACTED_PLACEHOLDER,
+    );
+  });
+
+  it("redacts AWS access key ids (AKIA / ASIA)", () => {
+    expect(redactText("AKIAIOSFODNN7EXAMPLE")).toBe(REDACTED_PLACEHOLDER);
+    expect(redactText("ASIAIOSFODNN7EXAMPLE")).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("redacts PEM private key blocks", () => {
+    const pem =
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEA\nabcdEFGH\n-----END RSA PRIVATE KEY-----";
+    const out = redactText(`before ${pem} after`);
+    expect(out).toBe(`before ${REDACTED_PLACEHOLDER} after`);
+  });
+
+  it("leaves clean text untouched", () => {
+    const clean = "the quick brown fox jumps over the lazy dog";
+    expect(redactText(clean)).toBe(clean);
+  });
+
+  it("redacts multiple secrets in one string", () => {
+    const out = redactText(
+      "sk-abcdefgh12345678 and ghp_0123456789abcdefghij0000",
+    );
+    expect(out).toBe(`${REDACTED_PLACEHOLDER} and ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("handles empty / falsy input", () => {
+    expect(redactText("")).toBe("");
+  });
+
+  it("is stable when reusing the global regexes (lastIndex reset)", () => {
+    const s = "sk-abcdefgh12345678";
+    expect(redactText(s)).toBe(REDACTED_PLACEHOLDER);
+    // second call must not miss due to a leftover lastIndex
+    expect(redactText(s)).toBe(REDACTED_PLACEHOLDER);
+  });
+});
+
+describe("containsSecret", () => {
+  it("detects a secret", () => {
+    expect(containsSecret("here is sk-abcdefgh12345678")).toBe(true);
+  });
+  it("returns false for clean text", () => {
+    expect(containsSecret("nothing to see here")).toBe(false);
+  });
+  it("returns false for empty", () => {
+    expect(containsSecret("")).toBe(false);
+  });
+});

--- a/packages/import-conversations/src/core/redact.ts
+++ b/packages/import-conversations/src/core/redact.ts
@@ -1,0 +1,71 @@
+/**
+ * Secret-pattern scrub for imported conversation text.
+ *
+ * Conversation history routinely contains pasted API keys, tokens, and
+ * credentials. `runtime.createMemory` only redacts *configured* secrets, not
+ * arbitrary pasted ones, so the importer must run pattern-based redaction
+ * itself before anything is stored.
+ *
+ * Patterns ported from ocplatform's migration SDK
+ * (`src/plugin-sdk/migration.ts` → `SECRET_VALUE_PATTERNS`), extended with a
+ * few high-signal cloud-credential shapes (AWS access key ids, PEM private-key
+ * blocks) that show up in pasted transcripts.
+ *
+ * See conversation-importer-scope.md §2.1 (secret hygiene) and §4.5.
+ */
+
+export const REDACTED_PLACEHOLDER = "[redacted]";
+
+/**
+ * Ordered secret value patterns. Each is applied globally to the input string.
+ * Order matters only for overlapping matches; these are disjoint enough that
+ * order is not significant, but PEM blocks are matched first so their inner
+ * base64 is not partially redacted by narrower rules.
+ */
+export const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+  // PEM private key blocks (multi-line). Matched first, dot-matches-newline.
+  /-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/gu,
+  // HTTP Bearer tokens.
+  /\bBearer\s+[A-Za-z0-9._~+/=-]+/gu,
+  // OpenAI-style keys (sk-, sk-proj-, etc.).
+  /\bsk-[A-Za-z0-9_-]{8,}\b/gu,
+  // GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_).
+  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/gu,
+  // Slack tokens (xoxb-/xoxa-/xoxp-/xoxr-/xoxs-).
+  /\bxox[abprs]-[A-Za-z0-9-]{8,}\b/gu,
+  // Google API keys.
+  /\bAIza[0-9A-Za-z_-]{12,}\b/gu,
+  // AWS access key ids (AKIA/ASIA + 16 uppercase-alnum).
+  /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/gu,
+];
+
+/**
+ * Replace every recognized secret pattern in `input` with
+ * {@link REDACTED_PLACEHOLDER}. Pure function; returns the input unchanged when
+ * it contains no matches. Empty / non-string-safe inputs return `""`-safe.
+ */
+export function redactText(input: string): string {
+  if (!input) {
+    return input;
+  }
+  let next = input;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    // Reset lastIndex defensively: these are module-level global regexes and a
+    // prior partial exec elsewhere could leave lastIndex non-zero. `replace`
+    // resets it, but being explicit avoids surprises if callers reuse patterns.
+    pattern.lastIndex = 0;
+    next = next.replace(pattern, REDACTED_PLACEHOLDER);
+  }
+  return next;
+}
+
+/** True when `input` contains at least one recognized secret pattern. */
+export function containsSecret(input: string): boolean {
+  if (!input) {
+    return false;
+  }
+  return SECRET_VALUE_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(input);
+  });
+}

--- a/packages/import-conversations/src/core/registry.test.ts
+++ b/packages/import-conversations/src/core/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ConversationImporter,
+  ConversationImporterRegistry,
+} from "./registry.ts";
+import type { NormalizedConversation } from "./types.ts";
+
+function fakeParser(
+  source: string,
+  detect: (input: unknown) => boolean,
+): ConversationImporter<unknown> {
+  return {
+    source,
+    detect,
+    async *parse(): AsyncIterable<NormalizedConversation> {
+      // empty stream for registry tests
+    },
+  };
+}
+
+describe("ConversationImporterRegistry", () => {
+  it("registers and looks up a parser by source", () => {
+    const reg = new ConversationImporterRegistry();
+    reg.register(fakeParser("chatgpt", () => true));
+    expect(reg.has("chatgpt")).toBe(true);
+    expect(reg.get("chatgpt")?.source).toBe("chatgpt");
+    expect(reg.sources()).toEqual(["chatgpt"]);
+    expect(reg.all()).toHaveLength(1);
+  });
+
+  it("rejects a parser with an empty source", () => {
+    const reg = new ConversationImporterRegistry();
+    expect(() => reg.register(fakeParser("", () => true))).toThrow();
+  });
+
+  it("unregister removes the parser", () => {
+    const reg = new ConversationImporterRegistry();
+    const off = reg.register(fakeParser("hermes", () => true));
+    expect(reg.has("hermes")).toBe(true);
+    off();
+    expect(reg.has("hermes")).toBe(false);
+  });
+
+  it("unregister only removes the same instance (no clobber after replace)", () => {
+    const reg = new ConversationImporterRegistry();
+    const off1 = reg.register(fakeParser("claude", () => true));
+    reg.register(fakeParser("claude", () => false)); // replaces
+    off1(); // must NOT remove the replacement
+    expect(reg.has("claude")).toBe(true);
+    expect(reg.get("claude")?.detect(null)).toBe(false);
+  });
+
+  it("detect returns the first matching parser in registration order", async () => {
+    const reg = new ConversationImporterRegistry();
+    reg.register(fakeParser("chatgpt", (i) => i === "cg"));
+    reg.register(fakeParser("claude", (i) => i === "cl"));
+    expect((await reg.detect("cl"))?.source).toBe("claude");
+    expect((await reg.detect("cg"))?.source).toBe("chatgpt");
+    expect(await reg.detect("nope")).toBeUndefined();
+  });
+
+  it("supports async detect predicates", async () => {
+    const reg = new ConversationImporterRegistry();
+    reg.register({
+      source: "async-src",
+      detect: async () => true,
+      async *parse() {},
+    });
+    expect((await reg.detect({}))?.source).toBe("async-src");
+  });
+
+  it("clear removes everything", () => {
+    const reg = new ConversationImporterRegistry();
+    reg.register(fakeParser("a", () => true));
+    reg.register(fakeParser("b", () => true));
+    reg.clear();
+    expect(reg.sources()).toEqual([]);
+  });
+});

--- a/packages/import-conversations/src/core/registry.ts
+++ b/packages/import-conversations/src/core/registry.ts
@@ -1,0 +1,102 @@
+/**
+ * Conversation-importer registry — eliza's missing
+ * `registerMigrationProvider`-equivalent, scoped to conversation import.
+ *
+ * A parser declares the `source` it handles, a `detect(input)` predicate, and a
+ * `parse(input)` streaming function that yields NormalizedConversations. Tracks
+ * B/C/D register their parsers here; the pipeline / app side resolves a parser
+ * for a given upload by `detect` or by explicit source.
+ */
+
+import type { ConversationSource, NormalizedConversation } from "./types.ts";
+
+/**
+ * A source parser. `parse` is streaming by construction — it returns an
+ * AsyncIterable so the pipeline never buffers an entire export in memory.
+ *
+ * @typeParam TInput - the parser's input shape (e.g. a zip handle, a directory
+ * path, a readable stream). Kept generic so core does not constrain source
+ * acquisition; the registry stores parsers as `ConversationImporter<unknown>`.
+ */
+export interface ConversationImporter<TInput = unknown> {
+  source: ConversationSource;
+  /** Cheap probe: does this parser recognize the given input? */
+  detect(input: TInput): boolean | Promise<boolean>;
+  /** Stream normalized conversations from the input. */
+  parse(input: TInput): AsyncIterable<NormalizedConversation>;
+}
+
+/**
+ * A registry of conversation importers. A default shared instance is exported;
+ * callers may also construct isolated registries (tests, multi-tenant).
+ */
+export class ConversationImporterRegistry {
+  private readonly bySource = new Map<string, ConversationImporter>();
+
+  /** Register (or replace) a parser for its `source`. Returns an unregister fn. */
+  register<TInput>(parser: ConversationImporter<TInput>): () => void {
+    if (!parser.source) {
+      throw new Error("ConversationImporter.source must be a non-empty string");
+    }
+    this.bySource.set(parser.source, parser as ConversationImporter);
+    return () => {
+      // Only remove if the same parser instance is still registered.
+      if (
+        this.bySource.get(parser.source) === (parser as ConversationImporter)
+      ) {
+        this.bySource.delete(parser.source);
+      }
+    };
+  }
+
+  /** Look up a parser by its source id. */
+  get(source: ConversationSource): ConversationImporter | undefined {
+    return this.bySource.get(source);
+  }
+
+  /** True when a parser is registered for `source`. */
+  has(source: ConversationSource): boolean {
+    return this.bySource.has(source);
+  }
+
+  /** All registered source ids. */
+  sources(): ConversationSource[] {
+    return [...this.bySource.keys()];
+  }
+
+  /** All registered parsers. */
+  all(): ConversationImporter[] {
+    return [...this.bySource.values()];
+  }
+
+  /**
+   * Resolve the first parser whose `detect(input)` returns true. Parsers are
+   * probed in registration order. Returns `undefined` when none match.
+   */
+  async detect(input: unknown): Promise<ConversationImporter | undefined> {
+    for (const parser of this.bySource.values()) {
+      if (await parser.detect(input)) {
+        return parser;
+      }
+    }
+    return undefined;
+  }
+
+  /** Remove all registered parsers (primarily for tests). */
+  clear(): void {
+    this.bySource.clear();
+  }
+}
+
+/** The default, process-wide importer registry. */
+export const conversationImporterRegistry = new ConversationImporterRegistry();
+
+/**
+ * Register a conversation importer on the default registry. Mirrors the
+ * ergonomics of openclaw's `api.registerMigrationProvider(...)`.
+ */
+export function registerConversationImporter<TInput>(
+  parser: ConversationImporter<TInput>,
+): () => void {
+  return conversationImporterRegistry.register(parser);
+}

--- a/packages/import-conversations/src/core/render.test.ts
+++ b/packages/import-conversations/src/core/render.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { renderConversation, renderHeader, renderMessage } from "./render.ts";
+import type { NormalizedConversation, NormalizedMessage } from "./types.ts";
+
+const T = (iso: string) => Date.parse(iso);
+
+function baseConv(messages: NormalizedMessage[]): NormalizedConversation {
+  return {
+    sourceConversationId: "c1",
+    title: "My chat",
+    createdAt: T("2024-05-01T12:00:00Z"),
+    updatedAt: T("2024-05-01T12:30:00Z"),
+    messages,
+  };
+}
+
+describe("renderHeader", () => {
+  it("renders title + source + date", () => {
+    const h = renderHeader(baseConv([]), "chatgpt");
+    expect(h).toBe("# My chat (imported from ChatGPT, 2024-05-01)");
+  });
+  it("falls back to Untitled and omits date when absent", () => {
+    const h = renderHeader(
+      { sourceConversationId: "x", messages: [] },
+      "hermes",
+    );
+    expect(h).toBe("# Untitled conversation (imported from Hermes)");
+  });
+});
+
+describe("renderMessage", () => {
+  it("formats role + timestamp + text", () => {
+    const out = renderMessage({
+      role: "user",
+      text: "hello world",
+      createdAt: T("2024-05-01T12:00:00Z"),
+    });
+    expect(out).toBe("**user** (2024-05-01 12:00): hello world");
+  });
+
+  it("omits timestamp when absent", () => {
+    expect(renderMessage({ role: "assistant", text: "hi" })).toBe(
+      "**assistant**: hi",
+    );
+  });
+
+  it("renders an attachment-only (empty text) message", () => {
+    const out = renderMessage({
+      role: "user",
+      text: "",
+      attachments: [
+        { name: "notes.txt", kind: "extracted-text", text: "line a\nline b" },
+      ],
+    });
+    expect(out).toContain("**user**");
+    expect(out).toContain("> [extracted-text: notes.txt]");
+    expect(out).toContain("> line a");
+    expect(out).toContain("> line b");
+  });
+
+  it("renders an image placeholder attachment without inline text", () => {
+    const out = renderMessage({
+      role: "user",
+      text: "look",
+      attachments: [{ name: "pic.png", kind: "image" }],
+    });
+    expect(out).toContain("> [image: pic.png]");
+  });
+});
+
+describe("renderConversation splitting", () => {
+  it("returns a single part for a short conversation", () => {
+    const parts = renderConversation(
+      baseConv([
+        { role: "user", text: "hi" },
+        { role: "assistant", text: "hello" },
+      ]),
+      "chatgpt",
+    );
+    expect(parts).toHaveLength(1);
+    expect(parts[0].partCount).toBe(1);
+    expect(parts[0].text).toContain("# My chat");
+    expect(parts[0].text).toContain("**user**: hi");
+    expect(parts[0].firstMessageIndex).toBe(0);
+    expect(parts[0].lastMessageIndex).toBe(1);
+  });
+
+  it("splits long conversations at message boundaries with overlap", () => {
+    // Each message ~ 400 chars ≈ 100 tokens; budget small to force splitting.
+    const big = "x".repeat(400);
+    const messages: NormalizedMessage[] = Array.from(
+      { length: 10 },
+      (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        text: `${i}-${big}`,
+      }),
+    );
+    const parts = renderConversation(baseConv(messages), "chatgpt", {
+      maxPartTokens: 250,
+      overlapMessages: 2,
+    });
+    expect(parts.length).toBeGreaterThan(1);
+    // Overlap: the first message of part n appears in the tail of part n-1.
+    for (let i = 1; i < parts.length; i++) {
+      expect(parts[i].firstMessageIndex).toBeLessThanOrEqual(
+        parts[i - 1].lastMessageIndex,
+      );
+    }
+    // Coverage: last part reaches the final message.
+    expect(parts.at(-1)?.lastMessageIndex).toBe(messages.length - 1);
+    // All parts carry the part suffix.
+    expect(parts[0].text).toContain("part 1/");
+  });
+
+  it("always makes forward progress even if one message exceeds the budget", () => {
+    const huge = "y".repeat(5000);
+    const messages: NormalizedMessage[] = [
+      { role: "user", text: huge },
+      { role: "assistant", text: huge },
+      { role: "user", text: huge },
+    ];
+    const parts = renderConversation(baseConv(messages), "claude", {
+      maxPartTokens: 100,
+      overlapMessages: 1,
+    });
+    // 3 oversized messages → at least 3 parts, terminates (no infinite loop).
+    expect(parts.length).toBeGreaterThanOrEqual(3);
+    expect(parts.at(-1)?.lastMessageIndex).toBe(2);
+  });
+
+  it("handles an empty conversation (header-only part)", () => {
+    const parts = renderConversation(baseConv([]), "hermes");
+    expect(parts).toHaveLength(1);
+    expect(parts[0].messageCount).toBe(0);
+    expect(parts[0].text).toContain("# My chat");
+  });
+});

--- a/packages/import-conversations/src/core/render.ts
+++ b/packages/import-conversations/src/core/render.ts
@@ -1,0 +1,209 @@
+/**
+ * Render a NormalizedConversation to a markdown transcript, and split long
+ * conversations into overlapping part-documents at message boundaries.
+ *
+ * Transcript format (scope §4.1):
+ *
+ *   # <title>  (imported from ChatGPT, 2024-05-01)
+ *   **user** (2024-05-01 12:00): ...
+ *   **assistant** (2024-05-01 12:01): ...
+ *
+ * Long conversations (> ~8k rendered tokens) split into part-documents at
+ * message boundaries with a 1-2 message overlap so retrieval context is never
+ * severed mid-exchange. Splitting returns an ordered array; a short
+ * conversation returns a single part.
+ */
+
+import type {
+  ConversationSource,
+  NormalizedConversation,
+  NormalizedMessage,
+} from "./types.ts";
+
+/** Approximate chars-per-token for the rough token budget used when splitting. */
+const CHARS_PER_TOKEN = 4;
+
+/** Default rendered-token budget per part before splitting kicks in. */
+export const DEFAULT_MAX_PART_TOKENS = 8_000;
+
+/** Default number of trailing messages repeated at the head of the next part. */
+export const DEFAULT_OVERLAP_MESSAGES = 2;
+
+/** Human-friendly source labels for the transcript header. */
+const SOURCE_LABELS: Record<string, string> = {
+  chatgpt: "ChatGPT",
+  claude: "Claude",
+  hermes: "Hermes",
+};
+
+export interface RenderedPart {
+  /** Full markdown transcript text for this part (includes the header). */
+  text: string;
+  /** 0-based part index. */
+  index: number;
+  /** Total number of parts the conversation was split into. */
+  partCount: number;
+  /** Number of messages rendered in this part (including overlap). */
+  messageCount: number;
+  /** Index (in the source `messages` array) of the first message in this part. */
+  firstMessageIndex: number;
+  /** Index (in the source `messages` array) of the last message in this part. */
+  lastMessageIndex: number;
+}
+
+export interface RenderOptions {
+  /** Rendered-token budget per part. Defaults to {@link DEFAULT_MAX_PART_TOKENS}. */
+  maxPartTokens?: number;
+  /** Overlap in messages between adjacent parts. Defaults to 2. */
+  overlapMessages?: number;
+}
+
+function labelForSource(source: ConversationSource): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+/** Format an epoch-ms timestamp as `YYYY-MM-DD` (UTC). */
+export function formatDate(epochMs?: number): string | undefined {
+  if (epochMs === undefined || !Number.isFinite(epochMs)) {
+    return undefined;
+  }
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+/** Format an epoch-ms timestamp as `YYYY-MM-DD HH:MM` (UTC). */
+export function formatDateTime(epochMs?: number): string | undefined {
+  if (epochMs === undefined || !Number.isFinite(epochMs)) {
+    return undefined;
+  }
+  const iso = new Date(epochMs).toISOString();
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)}`;
+}
+
+/** Build the `# title (imported from Source, date)` header line. */
+export function renderHeader(
+  conversation: NormalizedConversation,
+  source: ConversationSource,
+): string {
+  const title = conversation.title?.trim() || "Untitled conversation";
+  const label = labelForSource(source);
+  const date = formatDate(conversation.createdAt ?? conversation.updatedAt);
+  const suffix = date
+    ? ` (imported from ${label}, ${date})`
+    : ` (imported from ${label})`;
+  return `# ${title}${suffix}`;
+}
+
+/** Render a single message to its `**role** (ts): text` block (+ attachments). */
+export function renderMessage(message: NormalizedMessage): string {
+  const ts = formatDateTime(message.createdAt);
+  const head = ts ? `**${message.role}** (${ts}):` : `**${message.role}**:`;
+  const body = message.text?.trim() ?? "";
+  const lines: string[] = [];
+  lines.push(body ? `${head} ${body}` : head);
+
+  if (message.attachments?.length) {
+    for (const att of message.attachments) {
+      if (att.text?.trim()) {
+        lines.push(`> [${att.kind}: ${att.name}]`);
+        // Quote the extracted/inlined content so it reads as attached context.
+        for (const line of att.text.trim().split("\n")) {
+          lines.push(`> ${line}`);
+        }
+      } else {
+        lines.push(`> [${att.kind}: ${att.name}]`);
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+/** Rough token estimate for a rendered string. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Render a conversation into one or more part-documents. A conversation whose
+ * rendered body fits the token budget yields a single part; otherwise it is
+ * split at message boundaries with the configured message overlap.
+ *
+ * Overlap semantics: each subsequent part re-includes the last
+ * `overlapMessages` messages of the previous part at its head so a
+ * question/answer pair is never severed across parts.
+ */
+export function renderConversation(
+  conversation: NormalizedConversation,
+  source: ConversationSource,
+  options: RenderOptions = {},
+): RenderedPart[] {
+  const maxPartTokens = options.maxPartTokens ?? DEFAULT_MAX_PART_TOKENS;
+  const overlapMessages = Math.max(
+    0,
+    options.overlapMessages ?? DEFAULT_OVERLAP_MESSAGES,
+  );
+  const header = renderHeader(conversation, source);
+  const headerTokens = estimateTokens(header);
+
+  const messages = conversation.messages ?? [];
+  const rendered = messages.map((m) => renderMessage(m));
+  const renderedTokens = rendered.map((r) => estimateTokens(r));
+
+  // Group message indices into parts under the token budget.
+  const groups: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+  while (cursor < messages.length) {
+    let budget = maxPartTokens - headerTokens;
+    let end = cursor;
+    // Always include at least one message, even if it alone exceeds budget.
+    while (end < messages.length) {
+      const cost = renderedTokens[end] + 1; // +1 for the blank-line separator
+      if (end > cursor && cost > budget) {
+        break;
+      }
+      budget -= cost;
+      end += 1;
+    }
+    groups.push({ start: cursor, end }); // end is exclusive
+    if (end >= messages.length) {
+      break;
+    }
+    // Next part starts `overlapMessages` before the boundary (never before the
+    // current start, so we always make forward progress).
+    cursor = Math.max(cursor + 1, end - overlapMessages);
+  }
+
+  // Empty conversation → single header-only part.
+  if (groups.length === 0) {
+    return [
+      {
+        text: header,
+        index: 0,
+        partCount: 1,
+        messageCount: 0,
+        firstMessageIndex: 0,
+        lastMessageIndex: -1,
+      },
+    ];
+  }
+
+  const partCount = groups.length;
+  const partSuffix = partCount > 1;
+
+  return groups.map((group, index) => {
+    const slice = rendered.slice(group.start, group.end);
+    const headerLine = partSuffix
+      ? `${header}  · part ${index + 1}/${partCount}`
+      : header;
+    const text = [headerLine, "", ...slice]
+      .join("\n\n")
+      .replace(/\n{3,}/g, "\n\n");
+    return {
+      text,
+      index,
+      partCount,
+      messageCount: group.end - group.start,
+      firstMessageIndex: group.start,
+      lastMessageIndex: group.end - 1,
+    };
+  });
+}

--- a/packages/import-conversations/src/core/report.test.ts
+++ b/packages/import-conversations/src/core/report.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  notImported,
+  ReportBuilder,
+  SKIP_REASON_NO_MESSAGES,
+  summarizeReport,
+} from "./report.ts";
+
+describe("ReportBuilder", () => {
+  it("tallies counts across outcomes", () => {
+    const b = new ReportBuilder("chatgpt", "batch-1", false);
+    b.record({ sourceConversationId: "c1", change: "added", documentCount: 2 });
+    b.record({
+      sourceConversationId: "c2",
+      change: "unchanged",
+      documentCount: 1,
+    });
+    b.record({
+      sourceConversationId: "c3",
+      change: "updated",
+      documentCount: 3,
+    });
+    b.skip({ sourceConversationId: "c4", reason: SKIP_REASON_NO_MESSAGES });
+    b.error({ sourceConversationId: "c5", reason: "boom" });
+
+    const report = b.build();
+    expect(report.summary).toEqual({
+      total: 5,
+      added: 1,
+      unchanged: 1,
+      updated: 1,
+      skipped: 1,
+      errors: 1,
+      documentsStored: 2 + 1 + 3,
+    });
+  });
+
+  it("marks dryRun", () => {
+    const b = new ReportBuilder("hermes", "b", true);
+    expect(b.build().dryRun).toBe(true);
+  });
+
+  it("attaches an unchanged reason automatically", () => {
+    const b = new ReportBuilder("chatgpt", "b", false);
+    b.record({
+      sourceConversationId: "c1",
+      change: "unchanged",
+      documentCount: 0,
+    });
+    const item = b.build().items[0];
+    expect(item.outcome).toBe("unchanged");
+    expect(item.reason).toBeDefined();
+  });
+});
+
+describe("notImported", () => {
+  it("returns only skipped + errored items with reasons", () => {
+    const b = new ReportBuilder("chatgpt", "b", false);
+    b.record({ sourceConversationId: "ok", change: "added", documentCount: 1 });
+    b.skip({ sourceConversationId: "empty", reason: SKIP_REASON_NO_MESSAGES });
+    b.error({ sourceConversationId: "bad", reason: "parse failure" });
+    const report = b.build();
+    const missing = notImported(report);
+    expect(missing.map((i) => i.sourceConversationId).sort()).toEqual([
+      "bad",
+      "empty",
+    ]);
+    expect(missing.every((i) => Boolean(i.reason))).toBe(true);
+  });
+});
+
+describe("summarizeReport", () => {
+  it("produces a compact one-liner", () => {
+    const b = new ReportBuilder("chatgpt", "batch-9", false);
+    b.record({ sourceConversationId: "c1", change: "added", documentCount: 1 });
+    const line = summarizeReport(b.build());
+    expect(line).toContain("chatgpt apply batch-9");
+    expect(line).toContain("added=1");
+    expect(line).toContain("docs=1");
+  });
+});

--- a/packages/import-conversations/src/core/report.ts
+++ b/packages/import-conversations/src/core/report.ts
@@ -1,0 +1,171 @@
+/**
+ * Plan/apply report — mirrors ocplatform's migration report discipline
+ * (scope §2.1 / §4.3): every conversation ends in a classified outcome with a
+ * reason, and the report surfaces "what was NOT imported and why".
+ */
+
+import type { ConversationChange } from "./manifest.ts";
+import type { ConversationSource } from "./types.ts";
+
+/** Terminal outcome for a single conversation in a run. */
+export type ConversationOutcome =
+  | "added"
+  | "unchanged"
+  | "updated"
+  | "skipped"
+  | "error";
+
+/** Why a conversation was skipped or errored (free-form, human-readable). */
+export const SKIP_REASON_NO_MESSAGES =
+  "conversation has no renderable messages";
+export const SKIP_REASON_DUPLICATE_CONTENT =
+  "identical content already stored (dedup)";
+export const SKIP_REASON_UNCHANGED = "unchanged since last import";
+
+/** Per-conversation report line. */
+export interface ReportItem {
+  sourceConversationId: string;
+  title?: string;
+  outcome: ConversationOutcome;
+  /** Populated for skipped/error/unchanged outcomes. */
+  reason?: string;
+  /** Number of documents (parts) stored for this conversation. */
+  documentCount: number;
+}
+
+/** Aggregate counts across a run. */
+export interface ReportSummary {
+  total: number;
+  added: number;
+  unchanged: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  documentsStored: number;
+}
+
+/** A full plan-or-apply report. */
+export interface ImportReport {
+  source: ConversationSource;
+  batchId: string;
+  /** True for a dry-run plan, false for an applied run. */
+  dryRun: boolean;
+  summary: ReportSummary;
+  items: ReportItem[];
+}
+
+/** Mutable accumulator used by the pipeline to build a report incrementally. */
+export class ReportBuilder {
+  private readonly items: ReportItem[] = [];
+
+  constructor(
+    private readonly source: ConversationSource,
+    private readonly batchId: string,
+    private readonly dryRun: boolean,
+  ) {}
+
+  /** Record a stored/changed conversation. */
+  record(params: {
+    sourceConversationId: string;
+    title?: string;
+    change: ConversationChange;
+    documentCount: number;
+  }): void {
+    this.items.push({
+      sourceConversationId: params.sourceConversationId,
+      title: params.title,
+      outcome: params.change,
+      reason: params.change === "unchanged" ? SKIP_REASON_UNCHANGED : undefined,
+      documentCount: params.documentCount,
+    });
+  }
+
+  /** Record a conversation that was skipped, with a reason. */
+  skip(params: {
+    sourceConversationId: string;
+    title?: string;
+    reason: string;
+  }): void {
+    this.items.push({
+      sourceConversationId: params.sourceConversationId,
+      title: params.title,
+      outcome: "skipped",
+      reason: params.reason,
+      documentCount: 0,
+    });
+  }
+
+  /** Record a conversation that errored, with a reason. */
+  error(params: {
+    sourceConversationId: string;
+    title?: string;
+    reason: string;
+  }): void {
+    this.items.push({
+      sourceConversationId: params.sourceConversationId,
+      title: params.title,
+      outcome: "error",
+      reason: params.reason,
+      documentCount: 0,
+    });
+  }
+
+  /** Finalize into an immutable {@link ImportReport}. */
+  build(): ImportReport {
+    const summary: ReportSummary = {
+      total: this.items.length,
+      added: 0,
+      unchanged: 0,
+      updated: 0,
+      skipped: 0,
+      errors: 0,
+      documentsStored: 0,
+    };
+    for (const item of this.items) {
+      switch (item.outcome) {
+        case "added":
+          summary.added += 1;
+          break;
+        case "unchanged":
+          summary.unchanged += 1;
+          break;
+        case "updated":
+          summary.updated += 1;
+          break;
+        case "skipped":
+          summary.skipped += 1;
+          break;
+        case "error":
+          summary.errors += 1;
+          break;
+      }
+      summary.documentsStored += item.documentCount;
+    }
+    return {
+      source: this.source,
+      batchId: this.batchId,
+      dryRun: this.dryRun,
+      summary,
+      items: this.items.slice(),
+    };
+  }
+}
+
+/** Conversations that were not imported (skipped or errored), with reasons. */
+export function notImported(report: ImportReport): ReportItem[] {
+  return report.items.filter(
+    (item) => item.outcome === "skipped" || item.outcome === "error",
+  );
+}
+
+/** Render a compact human-readable one-line summary of a report. */
+export function summarizeReport(report: ImportReport): string {
+  const s = report.summary;
+  const mode = report.dryRun ? "plan" : "apply";
+  return (
+    `[${report.source} ${mode} ${report.batchId}] ` +
+    `total=${s.total} added=${s.added} unchanged=${s.unchanged} ` +
+    `updated=${s.updated} skipped=${s.skipped} errors=${s.errors} ` +
+    `docs=${s.documentsStored}`
+  );
+}

--- a/packages/import-conversations/src/core/sink.ts
+++ b/packages/import-conversations/src/core/sink.ts
@@ -1,0 +1,66 @@
+/**
+ * DocumentSink — the minimal storage port the pipeline writes through.
+ *
+ * Core deliberately does NOT depend on eliza's real `DocumentService`. Instead
+ * the pipeline stores through this narrow port so:
+ *   - core is unit-testable with a fake sink (no runtime/DB), and
+ *   - the eliza-app side provides a thin adapter mapping `addDocument` onto the
+ *     real `DocumentService.addDocument` (which brings content-based dedup,
+ *     fragmenting, batched embeddings, scoping, and hybrid search).
+ *
+ * The `status` on the add result lets the pipeline account for the real
+ * service's built-in dedup (`skipped` when an identical content+filename doc
+ * already exists) without knowing anything about how dedup is implemented.
+ *
+ * See conversation-importer-scope.md §4 (§4.1 render → §4.2 scope/provenance).
+ */
+
+/** Visibility scope for a stored document. Mirrors DocumentService scopes. */
+export type DocumentScope =
+  | "global"
+  | "owner-private"
+  | "user-private"
+  | "agent-private";
+
+/** Provenance of where a document came from. `import` is this package's value. */
+export type DocumentAddedFrom =
+  | "import"
+  | "chat"
+  | "upload"
+  | "url"
+  | "file"
+  | (string & {});
+
+/** A document to store. Field names align with DocumentService.addDocument. */
+export interface SinkDocument {
+  /** Full markdown transcript (a rendered part). */
+  content: string;
+  contentType: string;
+  /** e.g. `chatgpt/<conversation-id>.md` (or `...__partN.md`). */
+  originalFilename: string;
+  scope?: DocumentScope;
+  scopedToEntityId?: string;
+  addedFrom?: DocumentAddedFrom;
+  /** Provenance/import metadata block (see scope §4.2/§4.4). */
+  metadata?: Record<string, unknown>;
+}
+
+/** Result of storing a document. */
+export interface SinkAddResult {
+  /** The stored document id (adapter maps from the service's memory id). */
+  id: string;
+  /**
+   * `stored` when a new document was persisted; `skipped` when the sink's own
+   * dedup recognized identical content and did nothing.
+   */
+  status: "stored" | "skipped";
+}
+
+/**
+ * The storage port. The real adapter wraps `DocumentService`; tests use a fake.
+ * `deleteDocument` powers batch uninstall.
+ */
+export interface DocumentSink {
+  addDocument(doc: SinkDocument): Promise<SinkAddResult>;
+  deleteDocument(id: string): Promise<void>;
+}

--- a/packages/import-conversations/src/core/types.ts
+++ b/packages/import-conversations/src/core/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Normalized conversation model — the contract every source parser maps into.
+ *
+ * Track A owns these types. Parsers (Tracks B/C/D: ChatGPT / Claude / Hermes)
+ * are pure streaming functions that emit `NormalizedConversation`s; the
+ * ingestion pipeline in this package consumes them source-agnostically.
+ *
+ * See conversation-importer-scope.md §3.4.
+ */
+
+/**
+ * Known conversation sources. Open string union so future sources can register
+ * without a type change (see {@link registerConversationImporter}).
+ */
+export type ConversationSource =
+  | "chatgpt"
+  | "claude"
+  | "hermes"
+  | (string & {});
+
+/**
+ * Role of a single normalized message. `system` and `tool` are retained (some
+ * parsers keep them behind flags) but rendering/ingestion treats user+assistant
+ * as the primary signal.
+ */
+export type NormalizedRole = "user" | "assistant" | "system" | "tool";
+
+/** Kind of an attachment carried alongside a message. */
+export type AttachmentKind = "image" | "file" | "code" | "extracted-text";
+
+/**
+ * An attachment associated with a normalized message. `text` carries inlined
+ * content (e.g. Claude's `extracted_content`, a fenced code block, or an
+ * OCR/extracted-text blob) when available; binary media is represented by
+ * `name` + `kind` only.
+ */
+export interface NormalizedAttachment {
+  name: string;
+  kind: AttachmentKind;
+  /** Inlined textual content, when the export provides it. */
+  text?: string;
+}
+
+/**
+ * Per-message annotations that survive normalization but are not part of the
+ * primary transcript text (branch/hidden markers, originating tool name).
+ */
+export interface MessageAnnotations {
+  /** True when this message belongs to a non-active regeneration branch. */
+  branch?: boolean;
+  /** True when the source marked this message hidden from the conversation. */
+  hidden?: boolean;
+  /** Name of the tool that produced/consumed this message, if any. */
+  toolName?: string;
+}
+
+/**
+ * A single message after normalization. `text` is markdown-safe flattened text
+ * (code fenced, images placeholdered) ready for transcript rendering.
+ */
+export interface NormalizedMessage {
+  /** Stable id from the source export, when present. */
+  sourceMessageId?: string;
+  role: NormalizedRole;
+  /** Markdown-safe flattened message text. May be empty (attachment-only). */
+  text: string;
+  /** Epoch milliseconds. */
+  createdAt?: number;
+  attachments?: NormalizedAttachment[];
+  annotations?: MessageAnnotations;
+}
+
+/**
+ * A single conversation after normalization. Ordered `messages` represent the
+ * active thread (parsers are responsible for tree-flattening / branch pruning).
+ */
+export interface NormalizedConversation {
+  /** Stable conversation id from the source export. */
+  sourceConversationId: string;
+  title?: string;
+  /** Epoch milliseconds. */
+  createdAt?: number;
+  /** Epoch milliseconds. Drives idempotent re-import (see manifest). */
+  updatedAt?: number;
+  messages: NormalizedMessage[];
+  meta?: {
+    model?: string;
+    project?: string;
+    tags?: string[];
+  };
+}
+
+/**
+ * The top-level bundle a parser produces for a whole export. `conversations`
+ * is intentionally an array on this eager shape; the streaming pipeline path
+ * consumes an `AsyncIterable<NormalizedConversation>` directly and never
+ * materializes a full bundle.
+ */
+export interface ConversationBundle {
+  source: ConversationSource;
+  /** Export format fingerprint (e.g. schema/version marker), when derivable. */
+  sourceVersion?: string;
+  account?: {
+    id?: string;
+    email?: string;
+  };
+  conversations: NormalizedConversation[];
+}

--- a/packages/import-conversations/src/index.ts
+++ b/packages/import-conversations/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @elizaos/import-conversations — bring prior AI conversation history
+ * (ChatGPT / Claude / Hermes exports) into elizaOS as searchable, scoped
+ * knowledge.
+ *
+ * Track A ships the shared core: the normalized conversation contract, the
+ * secret-redacting / transcript-rendering ingestion pipeline (storing through
+ * an injectable DocumentSink port), idempotency + uninstall manifest, plan/apply
+ * report, and the importer registry that source parsers (Tracks B/C/D) register
+ * against.
+ */
+
+export * from "./core/index.ts";

--- a/packages/import-conversations/tsconfig.build.json
+++ b/packages/import-conversations/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowJs": false,
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/packages/import-conversations/tsconfig.json
+++ b/packages/import-conversations/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules/.bun/node_modules/@types"
+    ]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/import-conversations/vitest.config.ts
+++ b/packages/import-conversations/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**"],
+  },
+});


### PR DESCRIPTION
## What

Track A of the conversation-context importer (#11881): a **new package `packages/import-conversations/`** shipping the **shared core** — normalized types + the ingestion pipeline. This is the foundation Tracks B/C/D (ChatGPT / Claude / Hermes parsers) build against, so it lands as a clean, well-tested contract with **no parsers** in it yet.

## Why

eliza starts cold. A user with years of ChatGPT / Claude / Hermes history has thousands of messages of preferences, projects, and context that today never make it in. The openclaw `migrate-claude` / `migrate-hermes` providers move agent *state* but explicitly archive conversation history without parsing it — that's the gap. This core lets normalized conversations land as searchable, scoped, deduped, uninstallable knowledge through eliza's existing `DocumentService`, without core depending on the runtime (so it's fully unit-testable).

Design decisions match the scoping doc (`conversation-importer-scope.md`, §3.4 model / §4 ingestion / §5 architecture):
- **Documents-first** (not per-message Memory rows) — free dedup, chunking, embedding, hybrid search, clean uninstall.
- **DocumentSink port** — core stores through a minimal `addDocument`/`deleteDocument` interface; the eliza-app side provides the thin `DocumentService` adapter. Core never imports the runtime.
- **Streaming by construction** — the pipeline consumes the parser's `AsyncIterable<NormalizedConversation>` and never buffers a full export.

## Per-module summary

- **`core/types.ts`** — `ConversationBundle` / `NormalizedConversation` / `NormalizedMessage` (scope §3.4). The contract B/C/D map into. Open `ConversationSource` string union for future sources.
- **`core/redact.ts`** — `redactText(s)` secret-pattern scrub. Patterns ported from ocplatform's migration SDK (`SECRET_VALUE_PATTERNS`: Bearer, `sk-`, `gh[pousr]_`, `xox[abprs]-`, `AIza…`) + added AWS access-key ids (`AKIA/ASIA`) and PEM private-key blocks, since pasted transcripts carry those. `runtime.createMemory` only redacts *configured* secrets, so the importer must scrub pasted ones itself.
- **`core/render.ts`** — `NormalizedConversation → markdown transcript` (§4.1: `# title (imported from Source, date)` header; `**role** (ts): text` lines; quoted attachment blocks). Splits long conversations (>~8k rendered tokens) at message boundaries with a configurable 1-2 message overlap, returning ordered part-documents. Guarantees forward progress even for single oversized messages.
- **`core/manifest.ts`** — import-batch state keyed by `(source, sourceConversationId, updatedAt)`. `added` / `unchanged` / `updated` classification, immutable `recordConversation`, and `enumerateBatchDocumentIds` for **full-batch uninstall** (hard requirement, §4.4).
- **`core/report.ts`** — plan/apply summary (`added/unchanged/updated/skipped/errors` + docs stored) with per-item reasons and a `notImported()` "what was NOT imported and why" view, mirroring openclaw's plan/apply discipline.
- **`core/registry.ts`** — `registerConversationImporter(parser)` — eliza's missing `registerMigrationProvider`-equivalent, scoped to conversation import. A parser is `{ source; detect(input); parse(input): AsyncIterable<NormalizedConversation> }`. Register/lookup/detect(first-match)/unregister.
- **`core/sink.ts`** — the `DocumentSink` port (`addDocument`→`{id,status}` / `deleteDocument`) plus scope/provenance value types aligned to `DocumentsServiceLike`.
- **`core/pipeline.ts`** — orchestrates **parse → redact → render → dedup(manifest) → store → report**. Applies scope (`user-private`), provenance (`addedFrom: "import"`, import metadata block, `import` / `import:<source>` / `conv:<id>` / `date:YYYY-MM` tags per §4.2/§4.4). Yields `{ processed, total }` progress events (background-job friendly). `updated` deletes prior docs then re-stores; sink-level content dedup on an `added` conversation is reported as a dedup skip. `uninstallBatch` + dry-run supported.

## TEST

New package, so there's no prior regression baseline to protect. **58 new unit tests, all passing** (fixture-driven, with a fake `DocumentSink` + fake streaming parser — no runtime/DB needed):

- **redact (15):** each secret pattern individually (sk-, sk-proj-, ghp_/gho_/ghs_, Bearer, xox*, AIza, AKIA/ASIA, PEM block), multiple-in-one-string, clean-text untouched, empty input, global-regex `lastIndex` stability, `containsSecret`.
- **render (10):** header (with/without date, Untitled fallback), message format (role+ts, no-ts, attachment-only empty text, image placeholder), single-part short conversation, long-split with overlap (overlap invariant + full coverage + part suffix), forward-progress on oversized messages, empty conversation header-only part.
- **manifest (9):** key namespacing, classify added/unchanged/updated/missing-updatedAt, immutability of record, documentIds overwrite on update, uninstall enumeration across batch, empty-entry lookup.
- **report (5):** count tally across all outcomes, dryRun flag, auto unchanged-reason, `notImported` filter, compact one-liner.
- **registry (7):** register/lookup, empty-source rejection, unregister, no-clobber-after-replace, detect first-match in order, async detect, clear.
- **pipeline (12):** end-to-end parse→store→report **with progress events** + provenance/scoping assertions, secret redaction before store, no-message skip, idempotent re-import (unchanged), newer-updatedAt re-import (updated: old docs deleted + new stored), sink content-dedup skip, dry-run (no store / no sink required / throws without sink on apply), batch uninstall, **streaming laziness** (one-ahead pull, incremental consumption of a lazy generator without materializing).

**Baseline-delta:** N/A prior baseline (new package). +58 new tests, 58 passing / 0 failing.

Verification:
```
tsgo --noEmit -p tsconfig.json          # clean
biome check src (17 files)              # clean, no fixes
vitest run                              # 6 files, 58 passed
bun run build                           # dist emitted (tests excluded)
```

## Monorepo placement

Confirmed `packages/import-conversations/` compiles under the monorepo `packages/*` workspace glob (modeled on `packages/logger`'s package.json/tsconfig pattern: same `elizaos/import-conversations` naming, `tsgo` typecheck, `run-vitest` test runner, biome lint, `tsc --noCheck` build). `bun install` added exactly the 9-line workspace member entry to `bun.lock` (no dependency graph changes — the package has only a `@types/node` devDep already present in the workspace). No other placement adaptation was needed.

## DocumentSink decoupling

Confirmed: core imports nothing from `@elizaos/core` or the runtime. Storage flows exclusively through the `DocumentSink` port (`core/sink.ts`), whose value types mirror `DocumentsServiceLike` so the eliza-app adapter is a thin wrapper over `DocumentService.addDocument` / `deleteDocument`. The entire pipeline is exercised in tests against a fake sink.

Refs #11881. Does not merge until reviewed — memory/scope modeling sign-off welcome from @lalalune.

[sol-forge] — [sol-orch]
