### PR TITLE
feat(import-conversations): Track D — Hermes parser (streaming JSONL + memory notes) (#11881)

### DIFF
--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -51,6 +51,16 @@
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./parsers/hermes": {
+      "types": "./dist/parsers/hermes.d.ts",
+      "eliza-source": {
+        "types": "./src/parsers/hermes.ts",
+        "import": "./src/parsers/hermes.ts",
+        "default": "./src/parsers/hermes.ts"
+      },
+      "import": "./dist/parsers/hermes.js",
+      "default": "./dist/parsers/hermes.js"
     }
   },
   "devDependencies": {

--- a/packages/import-conversations/src/index.ts
+++ b/packages/import-conversations/src/index.ts
@@ -11,3 +11,5 @@
  */
 
 export * from "./core/index.ts";
+export type { ParseOptions } from "./parsers/hermes.ts";
+export { default as hermesParser, detect, parse } from "./parsers/hermes.ts";

--- a/packages/import-conversations/src/parsers/fixtures/hermes-home/memories/2026-01-01.md
+++ b/packages/import-conversations/src/parsers/fixtures/hermes-home/memories/2026-01-01.md
@@ -1,0 +1,4 @@
+# 2026-01-01
+
+- Synthetic daily note used for parser tests.
+- Should map to a single system/note message with the full markdown body.

--- a/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260101_120000_aaaa1111.jsonl
+++ b/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260101_120000_aaaa1111.jsonl
@@ -1,0 +1,8 @@
+{"role": "session_meta", "tools": [{"type": "function", "function": {"name": "browser_click"}}], "model": "test-model-x", "platform": "discord", "timestamp": "2026-01-01T12:00:00.000000"}
+{"role": "user", "content": "hey there", "timestamp": "2026-01-01T12:00:05.000000"}
+{"role": "assistant", "content": "hey", "reasoning": "user greeted me, respond briefly per SOUL.md", "finish_reason": "stop", "timestamp": "2026-01-01T12:00:06.000000"}
+{"role": "assistant", "content": "let me check that", "reasoning": "need to call a tool", "finish_reason": "tool_calls", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "skill_view", "arguments": "{\"name\":\"demo\"}"}}], "timestamp": "2026-01-01T12:00:07.000000"}
+{"role": "tool", "content": "{\"success\": true}", "tool_call_id": "call_1", "timestamp": "2026-01-01T12:00:08.000000"}
+{"role": "assistant", "content": "done", "reasoning": null, "finish_reason": "stop", "timestamp": "2026-01-01T12:00:09.000000"}
+{ this line is malformed json and must be skipped
+{"role": "user", "content": "thanks", "timestamp": "2026-01-01T12:00:10.000000"}

--- a/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260102_083000_bbbb2222.jsonl
+++ b/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260102_083000_bbbb2222.jsonl
@@ -1,0 +1,3 @@
+{"role": "session_meta", "tools": [], "model": "", "platform": "cli", "timestamp": "2026-01-02T08:30:00.000000"}
+{"role": "user", "content": "second session first message", "timestamp": "2026-01-02T08:30:01.000000"}
+{"role": "assistant", "content": "second session reply", "reasoning": "some private thoughts", "finish_reason": "stop", "timestamp": "2026-01-02T08:30:02.000000"}

--- a/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260103_090000_cccc3333.jsonl
+++ b/packages/import-conversations/src/parsers/fixtures/hermes-home/sessions/20260103_090000_cccc3333.jsonl
@@ -1,0 +1,2 @@
+{"role": "user", "content": "no meta header session", "timestamp": "2026-01-03T09:00:00.000000"}
+{"role": "assistant", "content": "handled without a meta line", "reasoning": null, "finish_reason": "stop", "timestamp": "2026-01-03T09:00:01.000000"}

--- a/packages/import-conversations/src/parsers/hermes.test.ts
+++ b/packages/import-conversations/src/parsers/hermes.test.ts
@@ -1,0 +1,237 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedConversation } from "../core/types.ts";
+import { detect, hermesParser, parse } from "./hermes.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const HERMES_HOME = path.join(here, "fixtures", "hermes-home");
+const SESSIONS_DIR = path.join(HERMES_HOME, "sessions");
+
+/** Drain an async iterable into an array (test helper). */
+async function collect(
+  iterable: AsyncIterable<NormalizedConversation>,
+): Promise<NormalizedConversation[]> {
+  const out: NormalizedConversation[] = [];
+  for await (const c of iterable) out.push(c);
+  return out;
+}
+
+function findConversation(
+  convos: NormalizedConversation[],
+  id: string,
+): NormalizedConversation {
+  const conversation = convos.find((c) => c.sourceConversationId === id);
+  expect(conversation).toBeDefined();
+  if (!conversation) {
+    throw new Error(`Expected Hermes conversation ${id}`);
+  }
+  return conversation;
+}
+
+describe("hermes parser: detect()", () => {
+  it("returns true for a Hermes home dir (has sessions/ with .jsonl)", async () => {
+    expect(await detect(HERMES_HOME)).toBe(true);
+  });
+
+  it("returns true when pointed directly at a sessions/ dir", async () => {
+    expect(await detect(SESSIONS_DIR)).toBe(true);
+  });
+
+  it("returns false for a non-existent path", async () => {
+    expect(await detect(path.join(here, "does-not-exist"))).toBe(false);
+  });
+
+  it("returns false for a dir without a sessions/ subdir", async () => {
+    // The memories dir has no sessions/ under it.
+    expect(await detect(path.join(HERMES_HOME, "memories"))).toBe(false);
+  });
+});
+
+describe("hermes parser: parse() mapping", () => {
+  it("parses session_meta into conversation meta and drops it as a message", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    // Title derived from the timestamped filename.
+    expect(first.title).toBe("Hermes session 2026-01-01 12:00:00");
+    // model from meta.
+    expect(first.meta?.model).toBe("test-model-x");
+    // platform surfaced as a tag.
+    expect(first.meta?.tags).toContain("platform:discord");
+    // createdAt anchored to the meta timestamp (epoch ms).
+    expect(first.createdAt).toBe(Date.parse("2026-01-01T12:00:00.000000"));
+    // The session_meta line is NOT a message.
+    expect(first.messages.every((m) => m.role !== "system")).toBe(true);
+  });
+
+  it("drops the reasoning (chain-of-thought) field by default", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    for (const m of first.messages) {
+      expect(m.text).not.toContain("respond briefly per SOUL.md");
+      expect(m.text).not.toContain("need to call a tool");
+      expect(m.text).not.toContain("reasoning");
+    }
+  });
+
+  it("optionally includes reasoning as a fenced block when includeReasoning=true", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false, includeReasoning: true }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    const withReasoning = first.messages.find((m) =>
+      m.text.includes("respond briefly per SOUL.md"),
+    );
+    expect(withReasoning).toBeDefined();
+    expect(withReasoning?.text).toContain("```reasoning");
+  });
+
+  it("maps roles: user + assistant present, tool dropped by default", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    const roles = first.messages.map((m) => m.role);
+    expect(roles).toContain("user");
+    expect(roles).toContain("assistant");
+    expect(roles).not.toContain("tool");
+  });
+
+  it("sets annotations.toolName on assistant tool_calls", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    const toolCaller = first.messages.find(
+      (m) => m.annotations?.toolName === "skill_view",
+    );
+    expect(toolCaller).toBeDefined();
+    expect(toolCaller?.role).toBe("assistant");
+  });
+
+  it("includes tool messages (with toolName from tool_call_id) when includeToolMessages=true", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false, includeToolMessages: true }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    const toolMsg = first.messages.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg?.annotations?.toolName).toBe("call_1");
+  });
+
+  it("skips a malformed JSON line without crashing (resilience)", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    // The two user lines ("hey there", "thanks") both survive; the malformed
+    // line between them is skipped rather than aborting the file.
+    const userTexts = first.messages
+      .filter((m) => m.role === "user")
+      .map((m) => m.text);
+    expect(userTexts).toEqual(["hey there", "thanks"]);
+  });
+
+  it("handles a session with NO session_meta header (older format)", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const noMeta = findConversation(convos, "20260103_090000_cccc3333");
+    // First line was a real user message and must be retained.
+    expect(noMeta.messages[0]?.role).toBe("user");
+    expect(noMeta.messages[0]?.text).toBe("no meta header session");
+    // No meta timestamp -> createdAt falls back to the earliest message time.
+    expect(noMeta.createdAt).toBe(Date.parse("2026-01-03T09:00:00.000000"));
+  });
+
+  it("sets per-message createdAt from ISO timestamps (epoch ms)", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    const user = first.messages.find((m) => m.role === "user");
+    expect(user?.createdAt).toBe(Date.parse("2026-01-01T12:00:05.000000"));
+  });
+
+  it("derives createdAt/updatedAt bounds from the min/max message time", async () => {
+    // When there IS a meta header, createdAt anchors to it; updatedAt tracks the
+    // latest message. Verifies the incremental min/max bookkeeping (no array
+    // spread) produces correct bounds.
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const first = findConversation(convos, "20260101_120000_aaaa1111");
+    expect(first.createdAt).toBe(Date.parse("2026-01-01T12:00:00.000000"));
+    // Latest surviving message timestamp in the fixture is the final "thanks".
+    expect(first.updatedAt).toBe(Date.parse("2026-01-01T12:00:10.000000"));
+  });
+});
+
+describe("hermes parser: multi-session dir + streaming", () => {
+  it("yields one conversation per session, in chronological (filename) order", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    const ids = convos.map((c) => c.sourceConversationId);
+    expect(ids).toEqual([
+      "20260101_120000_aaaa1111",
+      "20260102_083000_bbbb2222",
+      "20260103_090000_cccc3333",
+    ]);
+  });
+
+  it("streams incrementally (generator yields before all sessions are read)", async () => {
+    const iterator = parse(HERMES_HOME, { includeMemories: false })[
+      Symbol.asyncIterator
+    ]();
+    const firstResult = await iterator.next();
+    expect(firstResult.done).toBe(false);
+    // We got the first conversation without having drained the whole dir; this
+    // proves the async generator is lazy/streaming, not batch-then-return.
+    expect(firstResult.value.sourceConversationId).toBe(
+      "20260101_120000_aaaa1111",
+    );
+    const secondResult = await iterator.next();
+    expect(secondResult.value?.sourceConversationId).toBe(
+      "20260102_083000_bbbb2222",
+    );
+  });
+});
+
+describe("hermes parser: memory notes lane", () => {
+  it("includes memories/*.md as date-titled single-note conversations by default", async () => {
+    const convos = await collect(parse(HERMES_HOME));
+    const note = convos.find(
+      (c) => c.sourceConversationId === "memory:2026-01-01",
+    );
+    expect(note).toBeDefined();
+    expect(note?.title).toBe("Hermes daily note 2026-01-01");
+    expect(note?.messages).toHaveLength(1);
+    expect(note?.messages[0]?.role).toBe("system");
+    expect(note?.messages[0]?.text).toContain("Synthetic daily note");
+    expect(note?.meta?.tags).toContain("memory-note");
+    expect(note?.meta?.tags).toContain("date:2026-01");
+  });
+
+  it("omits memory notes when includeMemories=false", async () => {
+    const convos = await collect(
+      parse(HERMES_HOME, { includeMemories: false }),
+    );
+    expect(
+      convos.some((c) => c.sourceConversationId.startsWith("memory:")),
+    ).toBe(false);
+  });
+});
+
+describe("hermes parser: exported parser object", () => {
+  it("exposes a ConversationParser with source 'hermes'", () => {
+    expect(hermesParser.source).toBe("hermes");
+    expect(typeof hermesParser.detect).toBe("function");
+    expect(typeof hermesParser.parse).toBe("function");
+  });
+});

--- a/packages/import-conversations/src/parsers/hermes.ts
+++ b/packages/import-conversations/src/parsers/hermes.ts
@@ -1,0 +1,425 @@
+import { createReadStream, existsSync } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { createInterface } from "node:readline";
+
+import type { ConversationImporter } from "../core/registry.ts";
+import type {
+  NormalizedConversation,
+  NormalizedMessage,
+  NormalizedRole,
+} from "../core/types.ts";
+
+export type ParseOptions = {
+  /**
+   * Keep assistant chain-of-thought (`reasoning`) text. Off by default: CoT is
+   * privacy-sensitive and noisy. When true, reasoning is appended to the
+   * assistant message text under a fenced block.
+   */
+  includeReasoning?: boolean;
+  /**
+   * Keep `tool` role messages as annotated context. Off by default. When true,
+   * tool outputs are emitted as `role: "tool"` messages with
+   * `annotations.toolName` set where derivable.
+   */
+  includeToolMessages?: boolean;
+  /**
+   * Include agent-authored daily memory notes (Hermes `memories/*.md`) as
+   * date-titled single-note conversations. On by default (cheap, high value).
+   */
+  includeMemories?: boolean;
+};
+
+const SOURCE = "hermes" as const;
+
+/**
+ * Shape of a Hermes session_meta header line (first line of a session file).
+ * `model` is often an empty string; `platform` records the connector (discord,
+ * cli, etc.). `tools` is a schema dump we skip.
+ */
+type HermesSessionMeta = {
+  role: "session_meta";
+  tools?: unknown[];
+  model?: string;
+  platform?: string;
+  timestamp?: string;
+};
+
+/**
+ * A single Hermes tool_call as embedded on assistant lines. We only need the
+ * function name to derive `annotations.toolName`.
+ */
+type HermesToolCall = {
+  function?: { name?: string };
+};
+
+/** A Hermes message line (user / assistant / tool). */
+type HermesMessageLine = {
+  role: string;
+  content?: string;
+  reasoning?: string | null;
+  finish_reason?: string;
+  timestamp?: string;
+  tool_call_id?: string;
+  tool_calls?: HermesToolCall[];
+};
+
+const DEFAULT_OPTIONS: Required<ParseOptions> = {
+  includeReasoning: false,
+  includeToolMessages: false,
+  includeMemories: true,
+};
+
+/** Parse an ISO timestamp to epoch ms, or undefined if absent/unparseable. */
+function toEpochMs(iso: string | undefined): number | undefined {
+  if (!iso) return undefined;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+/** Map a raw Hermes role string to a normalized role. */
+function normalizeRole(role: string): NormalizedRole | undefined {
+  if (role === "user" || role === "assistant" || role === "tool") return role;
+  if (role === "system") return "system";
+  return undefined;
+}
+
+/**
+ * Derive a stable, human-legible conversation id + title from a session file
+ * name like `20260319_025534_bd09d0df.jsonl`.
+ */
+function sessionIdFromFilename(fileName: string): string {
+  return fileName.replace(/\.jsonl$/i, "");
+}
+
+function titleFromSessionId(sessionId: string): string {
+  // 20260319_025534_bd09d0df -> "Hermes session 2026-03-19 02:55:34"
+  const m = sessionId.match(/^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})/);
+  if (m) {
+    const [, y, mo, d, h, mi, s] = m;
+    return `Hermes session ${y}-${mo}-${d} ${h}:${mi}:${s}`;
+  }
+  return `Hermes session ${sessionId}`;
+}
+
+/**
+ * Convert one parsed Hermes line into a NormalizedMessage, or undefined if the
+ * line should be dropped (unknown role, or a tool line when tools are excluded).
+ */
+function lineToMessage(
+  parsed: HermesMessageLine,
+  opts: Required<ParseOptions>,
+): NormalizedMessage | undefined {
+  const role = normalizeRole(parsed.role);
+  if (!role) return undefined;
+
+  if (role === "tool" && !opts.includeToolMessages) return undefined;
+
+  const createdAt = toEpochMs(parsed.timestamp);
+  let text = typeof parsed.content === "string" ? parsed.content : "";
+
+  // Drop chain-of-thought by default; optionally append it as a fenced block.
+  if (
+    opts.includeReasoning &&
+    typeof parsed.reasoning === "string" &&
+    parsed.reasoning.length > 0
+  ) {
+    text = `${text}\n\n\`\`\`reasoning\n${parsed.reasoning}\n\`\`\``;
+  }
+
+  const message: NormalizedMessage = { role, text, createdAt };
+
+  // Assistant lines that invoke tools: record the (first) tool name.
+  if (Array.isArray(parsed.tool_calls) && parsed.tool_calls.length > 0) {
+    const toolName = parsed.tool_calls[0]?.function?.name;
+    if (toolName) {
+      message.annotations = { ...(message.annotations ?? {}), toolName };
+    }
+  }
+
+  // Tool result lines carry a tool_call_id but not the name; surface the id as
+  // the toolName annotation so downstream can correlate.
+  if (role === "tool" && parsed.tool_call_id) {
+    message.annotations = {
+      ...(message.annotations ?? {}),
+      toolName: parsed.tool_call_id,
+    };
+  }
+
+  return message;
+}
+
+/**
+ * Stream a single Hermes session file, yielding one NormalizedConversation.
+ *
+ * Reads line-by-line via readline (never buffers the whole file). The first
+ * line is either a `session_meta` header (skipped as a message but used for
+ * conversation meta) OR — for older/partial sessions — a plain message; both
+ * are handled. Malformed JSON lines are skipped, not fatal.
+ */
+async function parseSessionFile(
+  filePath: string,
+  opts: Required<ParseOptions>,
+): Promise<NormalizedConversation> {
+  const fileName = path.basename(filePath);
+  const sessionId = sessionIdFromFilename(fileName);
+
+  const messages: NormalizedMessage[] = [];
+  let meta: HermesSessionMeta | undefined;
+  let firstLineSeen = false;
+  // Track message-time bounds incrementally (never spread a big array into
+  // Math.min/max — that overflows the call stack on large sessions, which is
+  // exactly the streaming case this parser targets).
+  let minMessageTime: number | undefined;
+  let maxMessageTime: number | undefined;
+
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: "utf8" }),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+
+  try {
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      let parsed: HermesMessageLine | HermesSessionMeta;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // Resilience: a truncated/corrupt line must not abort the session.
+        continue;
+      }
+
+      if (!firstLineSeen) {
+        firstLineSeen = true;
+        if ((parsed as HermesSessionMeta).role === "session_meta") {
+          meta = parsed as HermesSessionMeta;
+          continue; // header consumed; not a message
+        }
+        // No meta header (older session) — fall through to treat as a message.
+      }
+
+      const message = lineToMessage(parsed as HermesMessageLine, opts);
+      if (message) {
+        messages.push(message);
+        if (typeof message.createdAt === "number") {
+          if (
+            minMessageTime === undefined ||
+            message.createdAt < minMessageTime
+          ) {
+            minMessageTime = message.createdAt;
+          }
+          if (
+            maxMessageTime === undefined ||
+            message.createdAt > maxMessageTime
+          ) {
+            maxMessageTime = message.createdAt;
+          }
+        }
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  // Conversation timing: prefer the meta header timestamp; fall back to the
+  // first/last message timestamps we saw. Bounds are accumulated incrementally
+  // above so this stays O(1) memory and never spreads a large array.
+  const metaCreatedAt = toEpochMs(meta?.timestamp);
+  const createdAt = metaCreatedAt ?? minMessageTime;
+  const updatedAt = maxMessageTime ?? createdAt;
+
+  const model = meta?.model && meta.model.length > 0 ? meta.model : undefined;
+  const platform =
+    meta?.platform && meta.platform.length > 0 ? meta.platform : undefined;
+
+  const conversation: NormalizedConversation = {
+    sourceConversationId: sessionId,
+    title: titleFromSessionId(sessionId),
+    createdAt,
+    updatedAt,
+    messages,
+    meta: {
+      model,
+      tags: platform ? [`platform:${platform}`] : undefined,
+    },
+  };
+
+  return conversation;
+}
+
+/**
+ * Parse one Hermes daily memory note (`memories/YYYY-MM-DD.md`) into a
+ * date-titled conversation with a single system/note message. These are
+ * agent-authored context, cheap to include, and high value per token.
+ */
+async function parseMemoryFile(
+  filePath: string,
+): Promise<NormalizedConversation | undefined> {
+  const fileName = path.basename(filePath);
+  const dateMatch = fileName.match(/^(\d{4}-\d{2}-\d{2})\.md$/);
+  const dateTag = dateMatch?.[1];
+
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+  if (content.trim().length === 0) return undefined;
+
+  const createdAt = dateTag ? toEpochMs(`${dateTag}T00:00:00Z`) : undefined;
+
+  return {
+    sourceConversationId: `memory:${fileName.replace(/\.md$/i, "")}`,
+    title: dateTag ? `Hermes daily note ${dateTag}` : `Hermes note ${fileName}`,
+    createdAt,
+    updatedAt: createdAt,
+    messages: [
+      {
+        role: "system",
+        text: content,
+        createdAt,
+        annotations: { toolName: "hermes-memory-note" },
+      },
+    ],
+    meta: {
+      tags: [
+        "memory-note",
+        ...(dateTag ? [`date:${dateTag.slice(0, 7)}`] : []),
+      ],
+    },
+  };
+}
+
+/** Resolve the sessions/ dir for a given Hermes home (or a sessions dir itself). */
+function resolveSessionsDir(input: string): string {
+  const base = path.basename(input);
+  if (base === "sessions") return input;
+  return path.join(input, "sessions");
+}
+
+function resolveMemoriesDir(input: string): string {
+  const base = path.basename(input);
+  if (base === "sessions") return path.join(path.dirname(input), "memories");
+  return path.join(input, "memories");
+}
+
+/**
+ * detect: true when `input` looks like a Hermes home. We accept either a home
+ * dir containing `sessions/` with `.jsonl` files, or a `sessions` dir directly.
+ * We also confirm the Hermes signature by peeking the first line of one session
+ * file for a `session_meta` header OR a plausible message shape.
+ */
+async function detect(input: string): Promise<boolean> {
+  try {
+    const st = await stat(input);
+    if (!st.isDirectory()) return false;
+  } catch {
+    return false;
+  }
+
+  const sessionsDir = resolveSessionsDir(input);
+  if (!existsSync(sessionsDir)) return false;
+
+  let entries: string[];
+  try {
+    entries = await readdir(sessionsDir);
+  } catch {
+    return false;
+  }
+  const jsonlFiles = entries.filter((f) => f.toLowerCase().endsWith(".jsonl"));
+  const firstJsonl = jsonlFiles[0];
+  if (!firstJsonl) return false;
+
+  // Peek the first non-empty line of the first session file for the signature.
+  const sample = path.join(sessionsDir, firstJsonl);
+  const rl = createInterface({
+    input: createReadStream(sample, { encoding: "utf8" }),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+  try {
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line) as { role?: string };
+        // session_meta header, or a recognizable message role.
+        return (
+          parsed.role === "session_meta" ||
+          parsed.role === "user" ||
+          parsed.role === "assistant" ||
+          parsed.role === "tool"
+        );
+      } catch {
+        return false;
+      }
+    }
+  } finally {
+    rl.close();
+  }
+  return false;
+}
+
+/**
+ * parse: streaming async generator. Yields one NormalizedConversation per
+ * session file (sorted by filename = chronological), then optionally the daily
+ * memory notes. Each session is streamed line-by-line; we never hold more than
+ * one session's messages in memory at a time, and conversations are yielded
+ * incrementally as each file completes.
+ */
+async function* parse(
+  input: string,
+  options?: ParseOptions,
+): AsyncIterable<NormalizedConversation> {
+  const opts: Required<ParseOptions> = { ...DEFAULT_OPTIONS, ...options };
+
+  const sessionsDir = resolveSessionsDir(input);
+  if (existsSync(sessionsDir)) {
+    let entries: string[] = [];
+    try {
+      entries = await readdir(sessionsDir);
+    } catch {
+      entries = [];
+    }
+    const sessionFiles = entries
+      .filter((f) => f.toLowerCase().endsWith(".jsonl"))
+      .sort(); // filenames are timestamp-prefixed => chronological
+
+    for (const fileName of sessionFiles) {
+      const filePath = path.join(sessionsDir, fileName);
+      yield await parseSessionFile(filePath, opts);
+    }
+  }
+
+  if (opts.includeMemories) {
+    const memoriesDir = resolveMemoriesDir(input);
+    if (existsSync(memoriesDir)) {
+      let entries: string[] = [];
+      try {
+        entries = await readdir(memoriesDir);
+      } catch {
+        entries = [];
+      }
+      const memoryFiles = entries
+        .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/i.test(f))
+        .sort();
+
+      for (const fileName of memoryFiles) {
+        const conv = await parseMemoryFile(path.join(memoriesDir, fileName));
+        if (conv) yield conv;
+      }
+    }
+  }
+}
+
+export const hermesParser: ConversationImporter<string> = {
+  source: SOURCE,
+  detect,
+  parse,
+};
+
+// Named exports for direct use + testing of internals.
+export { detect, parse };
+export default hermesParser;


### PR DESCRIPTION
## What

Track D of the conversation-context importer (#11881): the **Hermes parser**. Adds `packages/import-conversations/parsers/hermes.ts`, a pure streaming parser that turns local Hermes agent state (`sessions/*.jsonl` + `memories/*.md`) into the normalized `NormalizedConversation` contract from the scope doc (§3.3, §3.4).

This is the cheapest of the four source parsers and doubles as the **streaming testbed** for the whole importer — we have live local Hermes data to validate the line-by-line streaming contract against.

## Why

eliza starts cold. The importer (see #11881) gives a user agent continuity from their prior AI life. Hermes users have their history in `~/.hermes/sessions/*.jsonl` (one session per file) plus agent-authored daily notes in `~/.hermes/memories/*.md`. The existing openclaw `migrate-hermes` extension **archives** these without parsing them — that's the gap this closes for the Hermes source.

## Per-part summary

- **`parsers/hermes.ts`** — implements the `ConversationParser` surface `{ source: "hermes", detect(input), parse(input): AsyncIterable<NormalizedConversation> }`.
  - `detect(input)`: true when the path looks like a Hermes home — a `sessions/` dir (or a `sessions/` dir passed directly) containing `.jsonl` files whose first line is a `session_meta` header or a recognizable message role. Cheap: peeks one line of one file.
  - `parse(input, options?)`: **streaming async generator**. Reads each session file line-by-line via `readline` (never buffers a whole session into memory), yields **one `NormalizedConversation` per session** incrementally, then optionally the daily memory notes. Session files are processed in filename (= chronological) order.
  - Mapping: `session_meta` → conversation `title` / `createdAt` / `meta.model` / `meta.tags: ["platform:<x>"]` (dropped as a message). Each message line → `NormalizedMessage` (role, text, `createdAt` from ISO ts). `reasoning` (chain-of-thought) **dropped by default** (`includeReasoning` opt appends it as a fenced block). `tool` messages **dropped by default** (`includeToolMessages` opt keeps them). Assistant `tool_calls` → `annotations.toolName`. Malformed JSON lines are **skipped, not fatal**.
  - `memories/YYYY-MM-DD.md` daily notes → date-titled single system-note conversations (on by default; cheap, high value per token).
  - Conversation time bounds (`createdAt`/`updatedAt`) are accumulated **incrementally** while reading — no `Math.min(...bigArray)` spread, so huge sessions don't overflow the call stack.
- **`core/types.ts`** — a **local mirror** of the scope §3.4 normalized model (`ConversationBundle` / `NormalizedConversation` / `NormalizedMessage` / `ConversationParser` / `ParseOptions`). See "Track A dependency" below.
- **`src/index.ts`** — package barrel re-exporting the parser + types.
- **`__tests__/`** — fixture-based tests + synthetic Hermes-home fixtures.
- **`package.json` / `tsconfig.json` / `vitest.config.ts`** — package scaffold.

## Track A type dependency

The shared core types (`@elizaos/import-conversations/core/types`) are being built in parallel on **Track A (#11889)**. This PR does **not** block on it: `core/types.ts` here is a structural copy of the §3.4 contract, marked with a `// TODO: replace local type mirror with @elizaos/import-conversations/core/types once #11881 Track A merges` note. When Track A lands, delete the mirror and re-export the canonical types — the parser code needs no other change. This keeps Track D independently compilable + testable today.

## Hermes format surprises vs the scope doc

- **Not every session has a `session_meta` header.** The scope (§3.3) assumed line 1 is always `session_meta`; real older sessions start with a plain `user` message. The parser detects this (first successfully-parsed line) and treats it as a message instead of a header. Covered by a test + validated on live data.
- **`session_meta.model` is often an empty string** in real data (the connector doesn't always record it). Empty-string `model`/`platform` collapse to `undefined` rather than leaking `""`.

## TEST — 19 tests, all passing

Fixture-based (synthetic fixtures only — **no real personal Hermes data committed**). Fixtures: a session with meta+user+assistant+tool+reasoning lines **and a malformed line**, a second session, a no-`session_meta` (older-format) session, and a daily memory note.

1. `detect()` true for a Hermes home dir
2. `detect()` true when pointed directly at a `sessions/` dir
3. `detect()` false for a non-existent path
4. `detect()` false for a dir without `sessions/`
5. `session_meta` parsed into conversation meta (title/model/platform-tag/createdAt) and dropped as a message
6. `reasoning` dropped by default (no CoT leakage)
7. `reasoning` included as a fenced block when `includeReasoning=true`
8. roles mapped: user + assistant present, tool dropped by default
9. `annotations.toolName` set on assistant `tool_calls`
10. tool messages included (with `toolName` from `tool_call_id`) when `includeToolMessages=true`
11. malformed JSON line skipped, not fatal (both surrounding user lines survive)
12. session with **no** `session_meta` header handled (older format)
13. per-message `createdAt` set from ISO timestamps (epoch ms)
14. `createdAt`/`updatedAt` derived from min/max message time (guards the incremental-bounds path)
15. multi-session dir: one conversation per session, chronological order
16. streaming: generator yields incrementally (first conversation before the dir is drained)
17. `memories/*.md` included as date-titled single-note conversations by default
18. memory notes omitted when `includeMemories=false`
19. exported `hermesParser` has `source: "hermes"` + detect/parse fns

```
Test Files  1 passed (1)
     Tests  19 passed (19)
```

Also validated **once against a throwaway copy of real local Hermes sessions** (read-only; nothing sanitized-and-committed) to prove real-data handling: a 199-message session streamed fine, the no-meta older session parsed, empty-string `model` collapsed, tool messages dropped, 120 tool-name annotations set, **zero reasoning leakage**. Only synthetic fixtures are in the diff.

Biome clean on source (0 errors), `tsgo --noEmit` clean. Codex-reviewed (gpt-5.5); both findings addressed (incremental min/max for large-session safety; lockfile note below).

## Notes

- Does **not** touch `bun.lock` per the fleet's build-file rules. The new `packages/import-conversations` workspace will need a lockfile entry for `--frozen-lockfile` CI; that wiring belongs with Track A (#11889) which owns the package's core, or a follow-up lockfile-regen commit — flagging so it isn't missed.
- Depends on Track A (#11889) for the canonical shared types (mirrored locally in the meantime).

Refs #11881. Depends on #11889.

Signed: [sol-forge] — [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
