### PR TITLE
test(ui/cloud): direct review-gate coverage for the apps Monetize toggle (#11801)

### DIFF
--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.test.tsx
@@ -197,4 +197,73 @@ describe("AppMonetizationSettings review gate", () => {
       }),
     );
   });
+
+  it("renders an already-approved app with an enabled toggle and no submit button", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      monetization: {
+        monetizationEnabled: false,
+        inferenceMarkupPercentage: 25,
+        purchaseSharePercentage: 10,
+        platformOffsetAmount: 1,
+        totalCreatorEarnings: 0,
+      },
+    });
+
+    renderMonetization(makeApp({ review_status: "approved" }));
+
+    expect(await screen.findByText("Review approved")).toBeTruthy();
+    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Submit for review" }),
+    ).toBeNull();
+  });
+
+  it("keeps the toggle gated on a rejected app and offers resubmission", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      monetization: {
+        monetizationEnabled: false,
+        inferenceMarkupPercentage: 25,
+        purchaseSharePercentage: 10,
+        platformOffsetAmount: 1,
+        totalCreatorEarnings: 0,
+      },
+    });
+
+    renderMonetization(makeApp({ review_status: "rejected" }));
+
+    expect(await screen.findByText("Review rejected")).toBeTruthy();
+    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      screen.getByRole("button", { name: "Submit for review" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the toggle gated while a review is pending", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      monetization: {
+        monetizationEnabled: false,
+        inferenceMarkupPercentage: 25,
+        purchaseSharePercentage: 10,
+        platformOffsetAmount: 1,
+        totalCreatorEarnings: 0,
+      },
+    });
+
+    renderMonetization(makeApp({ review_status: "under_review" }));
+
+    expect(await screen.findByText("Review in progress")).toBeTruthy();
+    expect((screen.getByRole("switch") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Submit for review" }),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Backend endpoints pre-existing (#11828); this is the frontend wire-up lane for #11801 — but on inspection of develop tip, **the #11801 UI wire-up itself already landed and merged in #11828** (`e9ac8125c2`): the Monetization tab has the review-status card, the "Submit for review" button (draft|rejected) POSTing `/api/v1/apps/:id/review`, and the Monetize Switch hard-gated on `review_status === "approved"` (server-gated too). Issue #11801 is closed. Rather than duplicate a shipped feature, this PR closes the remaining test gap.

## What this adds

Direct state coverage in `app-monetization-settings.test.tsx` (the existing test only exercised the draft→submit→approved flow):

- **approved** app from props → toggle ENABLED, no submit button
- **rejected** app → toggle stays gated + "Submit for review" re-offered (edit-and-resubmit loop)
- **under_review** app → toggle gated, no submit button

## Verification

- `bunx vitest run …/app-monetization-settings.test.tsx` → 4/4 green
- **Mutation check:** replacing `disabled={!reviewApproved}` with `disabled={false}` reds 3/4 tests; restored → green. The money-moment gate is now test-locked from multiple directions.
- Biome clean; test-file-only diff, zero backend/component changes.

Golden-path money moment (create app → submit for review → approve → monetize) verified working in code + tests on develop tip.

— [phone-ui]

---
**Verified + test-authored by a Fable-5 agent** (100% claude-fable-5). It found the #11801 UI wire-up already merged in #11828 and correctly did NOT duplicate it — instead hardened the genuinely-missing test coverage. Main loop independently re-verified: feature present on develop (8 anchor matches, not re-implemented), branch is test-ONLY (+69 lines, 1 file), 4/4 green, gate mutation reproduced (disabled={false} → 3/4 red; restore → green).

**4 UI/UX-session refinements** the agent flagged (functional gate is complete + test-locked; these are polish): (1) show review_status as a header/table badge (not only inside the Monetize tab); (2) fetch GET /review on mount so a returning rejected user sees the *why*; (3) create-app dialog hint that new apps start draft; (4) visual placement/copy of the review card. — [phone-ui]