### PR TITLE
fix(onboarding): resume into chat after cloud login + expose first-run choices to a11y

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -744,7 +744,7 @@ export const NOTIFICATIONS_TESTID = "widget-notifications";
 // First-run runtime/provider buttons live in the real chat transcript. The
 // headless conductor seeds the ChoiceWidgets and the chat action channel routes
 // their sentinel values before they hit the server.
-export const RUNTIME_CHOICE = (id: "cloud" | "local" | "other"): string =>
+export const RUNTIME_CHOICE = (id: "cloud" | "local" | "remote"): string =>
   `choice-__first_run__:runtime:${id}`;
 export const PROVIDER_CHOICE = (
   id: "on-device" | "elizacloud" | "other",
@@ -785,7 +785,7 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
     timeout: 15_000,
   });
   await expect(page.getByTestId(RUNTIME_CHOICE("local"))).toBeVisible();
-  await expect(page.getByTestId(RUNTIME_CHOICE("other"))).toBeVisible();
+  await expect(page.getByTestId(RUNTIME_CHOICE("remote"))).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
 
   // Onboarding gating: the chat is NON-INTERACTIVE except the choice widgets.
@@ -795,7 +795,7 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveAttribute(
     "placeholder",
-    "Choose an option to continue",
+    "Tap a highlighted option above to continue",
   );
   await expect(chatOverlay).toHaveAttribute("data-open", "true");
   await page.keyboard.press("Escape");
@@ -1016,9 +1016,12 @@ export async function completeOtherProviderSettingsHandoff(
 
   await expectChatFirstOnboarding(page);
 
-  const otherRuntime = page.getByTestId(RUNTIME_CHOICE("other"));
-  await expect(otherRuntime).toBeVisible({ timeout: 15_000 });
-  await click(otherRuntime);
+  // "Other / configure in Settings" is a PROVIDER sub-choice under the LOCAL
+  // runtime (the old top-level runtime:other was renamed/removed when the
+  // chooser became cloud/local/remote), so reach it via local → provider:other.
+  const localRuntime = page.getByTestId(RUNTIME_CHOICE("local"));
+  await expect(localRuntime).toBeVisible({ timeout: 15_000 });
+  await click(localRuntime);
 
   const otherProvider = page.getByTestId(PROVIDER_CHOICE("other"));
   await expect(otherProvider).toBeVisible({ timeout: 15_000 });

--- a/packages/ui/src/api/ios-local-agent-kernel.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.test.ts
@@ -108,6 +108,24 @@ describe("handleIosLocalAgentRequest", () => {
     });
   });
 
+  it("serves POST /api/first-run so local onboarding finish does not 404-loop", async () => {
+    // Regression: the kernel implemented GET /api/first-run/status but not
+    // POST /api/first-run, so finishLocal's submitFirstRun hit the catch-all
+    // 404 ("Not found"), which the conductor turned into a re-offer of the
+    // runtime chooser (the on-device "local path → not found → pick again"
+    // loop). It must accept + ack the finish payload.
+    await expect(getJson("/api/first-run/status")).resolves.toMatchObject({
+      complete: true,
+    });
+    const res = await post("/api/first-run", {
+      runtime: "local",
+      localInference: "all-local",
+      agentName: "Eliza",
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
   it("reports paired Cloud state and forwards chat through the Cloud bridge", async () => {
     const localStorage = stubLocalStorage();
     localStorage.setItem(

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -3001,6 +3001,19 @@ export async function handleIosLocalAgentRequest(
     });
   }
 
+  // First-run finish persist. The on-device JSContext kernel completes
+  // onboarding client-side (the conductor clears local first-run state and flips
+  // firstRunComplete), and `/api/first-run/status` already reports complete —
+  // but `submitFirstRun` POSTs the finish payload here. Without this route the
+  // POST fell through to the catch-all 404 ("Not found"), which the local finish
+  // rethrew and the conductor turned into a re-offer of the runtime chooser
+  // (the "not found → pick again" loop). Accept + ack; there is no server-side
+  // profile store on the local kernel, so this is a no-op success that matches
+  // the full-Bun bundle's behavior.
+  if (method === "POST" && pathname === "/api/first-run") {
+    return json({ ok: true });
+  }
+
   if (method === "GET" && pathname === "/api/config") {
     return json(localConfig());
   }

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -275,6 +275,59 @@ describe("ContinuousChatOverlay first-run gating", () => {
     );
   });
 
+  it("does NOT wrap a first-run CHOICE turn in a role=button bubble (keeps the choices in the AX tree for VoiceOver + on-device automation)", () => {
+    seedAppStoreWithActionSpy();
+    const controller = makeController({
+      messages: [
+        {
+          id: "first-run:greeting",
+          role: "assistant",
+          content: RUNTIME_CHOICE_MESSAGE,
+          createdAt: 1,
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
+
+    // The tap-to-reveal bubble wrapper (a role=button with a "message actions"
+    // label) collapses its subtree into a single atomic AX node in WKWebView,
+    // hiding the choices. A choice-bearing turn must therefore NOT render it.
+    expect(
+      screen.queryByRole("button", { name: /message actions/i }),
+    ).toBeNull();
+    // The choice buttons stay individually present + focusable (not tabIndex -1).
+    const cloud = screen.getByTestId("choice-__first_run__:runtime:cloud");
+    expect(cloud.closest('[role="button"]')).toBeNull();
+    expect(cloud.getAttribute("tabindex")).not.toBe("-1");
+  });
+
+  it("exposes the sr-only onboarding-state probe with the current step + choice ids while onboarding is open", () => {
+    seedAppStoreWithActionSpy();
+    const controller = makeController({
+      messages: [
+        {
+          id: "first-run:greeting",
+          role: "assistant",
+          content: RUNTIME_CHOICE_MESSAGE,
+          createdAt: 1,
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={controller} firstRunOpen />,
+    );
+    const probe = screen.getByTestId("onboarding-state-probe");
+    expect(probe.textContent).toContain("onboarding-step:runtime");
+    expect(probe.textContent).toContain("__first_run__:runtime:cloud");
+    expect(probe.textContent).toContain("__first_run__:runtime:remote");
+
+    // Once onboarding completes the probe is gone.
+    rerender(
+      <ContinuousChatOverlay controller={controller} firstRunOpen={false} />,
+    );
+    expect(screen.queryByTestId("onboarding-state-probe")).toBeNull();
+  });
+
   it("auto-collapses exactly once on the completion edge, unlocks the composer, and re-arms Escape", () => {
     const controller = makeController();
     const { rerender } = render(

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -75,6 +75,9 @@ import {
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
+import { findChoiceRegions } from "../chat/message-choice-parser";
+import { findFollowupsRegions } from "../chat/message-followups-parser";
+import { findFormRegions } from "../chat/message-form-parser";
 import { MessageAttachments } from "../chat/MessageAttachments";
 import { SensitiveRequestBlock } from "../chat/MessageContent";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
@@ -909,6 +912,24 @@ function isNestedInteractiveTarget(
 }
 
 /**
+ * True when an assistant turn's content carries an inline interactive widget
+ * (a `[CHOICE:…]` / `[FORM:…]` / `[FOLLOWUPS:…]` block — e.g. every first-run
+ * onboarding turn). Such a bubble must NOT be wrapped in the tap-to-reveal
+ * `role="button"` container: WebKit exposes an ARIA button as an ATOMIC AX leaf
+ * (its aria-label becomes the node's name and all descendants are dropped), so
+ * the wrapper silently removes the choice buttons + text from the native
+ * accessibility tree — invisible to VoiceOver AND to XCUITest. The parser
+ * helpers reset their own regex lastIndex, so repeated calls are safe.
+ */
+function messageHasInteractiveWidget(content: string): boolean {
+  return (
+    findChoiceRegions(content).length > 0 ||
+    findFormRegions(content).length > 0 ||
+    findFollowupsRegions(content).length > 0
+  );
+}
+
+/**
  * True while there's a live (non-collapsed) text selection. The
  * conversation-swipe binding lives on the transcript surface, which contains
  * the selectable message bubbles — so a MOUSE drag to highlight bubble text
@@ -1156,6 +1177,14 @@ const ThreadLine = React.memo(function ThreadLine({
   const canEdit =
     isUser && !!onEdit && trimmed.length > 0 && !message.id.startsWith("temp-");
   const hasActions = canRowCopy || canSpeak || canEdit;
+  // An assistant turn that carries an inline choice/form/followups widget (every
+  // first-run onboarding turn) must stay a plain container — never the
+  // tap-to-reveal `role="button"` bubble, which WebKit collapses into a single
+  // atomic AX node and thereby hides the choice buttons from VoiceOver + XCUITest.
+  const hasInteractiveWidget = React.useMemo(
+    () => isAssistant && messageHasInteractiveWidget(message.content),
+    [isAssistant, message.content],
+  );
 
   // A recoverable assistant failure (the agent was rate-limited or the provider
   // stalled / the stream was interrupted) gets a one-tap Retry that re-sends the
@@ -1176,7 +1205,7 @@ const ThreadLine = React.memo(function ThreadLine({
     if (sel && sel.toString().trim().length > 0) return;
     setRevealed((v) => !v);
   }, [hasActions, editing]);
-  const bubbleInteractive = hasActions && !editing;
+  const bubbleInteractive = hasActions && !editing && !hasInteractiveWidget;
   const handleBubbleClick = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!bubbleInteractive) return;
@@ -4023,6 +4052,26 @@ export function ContinuousChatOverlay({
             ? "full"
             : "half";
 
+  // Onboarding-state probe: the newest first-run CHOICE turn's step id + option
+  // values, surfaced as sr-only static AX text (mirrors chat-detent-probe /
+  // home-launcher-page-probe) so an on-device XCUITest can observe and drive
+  // first-run deterministically even where the WKWebView AX tree is imperfect.
+  const firstRunProbe = React.useMemo(() => {
+    if (!firstRunOpen) return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const region = findChoiceRegions(messages[i].content).find(
+        (r) => r.scope === "first-run" || r.scope.startsWith("first-run"),
+      );
+      if (region) {
+        return {
+          step: region.id,
+          choices: region.options.map((o) => o.value).join(","),
+        };
+      }
+    }
+    return null;
+  }, [firstRunOpen, messages]);
+
   return (
     <div
       ref={overlayRef}
@@ -4272,6 +4321,11 @@ export function ContinuousChatOverlay({
           <span className="sr-only" data-testid="chat-detent-probe">
             {`chat-detent:${detentLabel}`}
           </span>
+          {firstRunProbe ? (
+            <span className="sr-only" data-testid="onboarding-state-probe">
+              {`onboarding-step:${firstRunProbe.step} onboarding-choices:${firstRunProbe.choices}`}
+            </span>
+          ) : null}
           {/* CONTENT — sheen, glow, thread, composer. Crossfades with the glass
               and goes fully inert while pilled (opacity 0 + `inert` removes it
               from pointer, tab order, and the a11y tree) so it can't be reached

--- a/packages/ui/src/first-run/first-run-cloud-resume.test.ts
+++ b/packages/ui/src/first-run/first-run-cloud-resume.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __TEST_ONLY__,
+  clearCloudLoginPending,
+  markCloudLoginPending,
+  readCloudLoginPending,
+} from "./first-run-cloud-resume";
+
+function stubLocalStorage(): void {
+  const items = new Map<string, string>();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem: (k: string) => items.get(k) ?? null,
+        setItem: (k: string, v: string) => void items.set(k, v),
+        removeItem: (k: string) => void items.delete(k),
+      },
+    },
+  });
+}
+
+describe("first-run cloud-resume marker", () => {
+  beforeEach(() => stubLocalStorage());
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("round-trips a cloud marker and clears it", () => {
+    expect(readCloudLoginPending()).toBeNull();
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    expect(readCloudLoginPending()).toEqual({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    clearCloudLoginPending();
+    expect(readCloudLoginPending()).toBeNull();
+  });
+
+  it("round-trips a hybrid marker", () => {
+    markCloudLoginPending({
+      runtime: "hybrid",
+      localInference: "cloud-inference",
+      agentName: "Nova",
+    });
+    expect(readCloudLoginPending()?.runtime).toBe("hybrid");
+  });
+
+  it("rejects a corrupt / non-cloud marker instead of resuming into a bad state", () => {
+    window.localStorage.setItem(
+      __TEST_ONLY__.CLOUD_RESUME_STORAGE_KEY,
+      JSON.stringify({ runtime: "local", localInference: "all-local" }),
+    );
+    expect(readCloudLoginPending()).toBeNull();
+    window.localStorage.setItem(
+      __TEST_ONLY__.CLOUD_RESUME_STORAGE_KEY,
+      "{ not json",
+    );
+    expect(readCloudLoginPending()).toBeNull();
+  });
+});

--- a/packages/ui/src/first-run/first-run-cloud-resume.ts
+++ b/packages/ui/src/first-run/first-run-cloud-resume.ts
@@ -1,0 +1,83 @@
+// ============================================================================
+// Cloud-login resume marker (device WebView-eviction survival).
+//
+// On a native device the first-run cloud login opens an EXTERNAL browser
+// (SFSafariViewController), which backgrounds the WebView; iOS frequently
+// cold-launches the app on return, wiping the conductor's in-memory flow state
+// (draftRef / pendingCloudResumeRef / the transcript). Without a durable marker
+// the conductor re-mounts and re-seeds the greeting — the user experiences a
+// "restart" back to "where should your agent run?".
+//
+// This marker persists the minimum needed to RESUME the interrupted cloud flow
+// after the relaunch: the runtime intent + the draft fields the provision step
+// reads. Paired with the durable cloud token (steward-session), on return the
+// conductor re-arms the existing auto-resume path and completes onboarding into
+// chat instead of restarting. Cleared on completion or a fresh runtime pick.
+// ============================================================================
+
+import type { FirstRunLocalInference, FirstRunProfileDraft } from "./first-run";
+
+const CLOUD_RESUME_STORAGE_KEY = "eliza:first-run:cloud-resume";
+
+export interface CloudResumeMarker {
+  /** Which runtime initiated the cloud login (drives the resume branch). */
+  runtime: "cloud" | "hybrid";
+  localInference: FirstRunLocalInference;
+  agentName: string;
+}
+
+export function markCloudLoginPending(
+  draft: Pick<FirstRunProfileDraft, "localInference" | "agentName"> & {
+    runtime: "cloud" | "hybrid";
+  },
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CLOUD_RESUME_STORAGE_KEY,
+      JSON.stringify({
+        runtime: draft.runtime,
+        localInference: draft.localInference,
+        agentName: draft.agentName,
+      } satisfies CloudResumeMarker),
+    );
+  } catch {
+    // Storage unavailable → the flow still works in-session (in-memory refs);
+    // it just won't survive a WebView eviction. Non-fatal.
+  }
+}
+
+export function readCloudLoginPending(): CloudResumeMarker | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(CLOUD_RESUME_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CloudResumeMarker>;
+    if (parsed.runtime !== "cloud" && parsed.runtime !== "hybrid") return null;
+    if (
+      parsed.localInference !== "all-local" &&
+      parsed.localInference !== "cloud-inference" &&
+      parsed.localInference !== "configure-later"
+    ) {
+      return null;
+    }
+    return {
+      runtime: parsed.runtime,
+      localInference: parsed.localInference,
+      agentName: typeof parsed.agentName === "string" ? parsed.agentName : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearCloudLoginPending(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(CLOUD_RESUME_STORAGE_KEY);
+  } catch {
+    // Non-fatal.
+  }
+}
+
+export const __TEST_ONLY__ = { CLOUD_RESUME_STORAGE_KEY };

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -54,10 +54,7 @@ vi.mock("./auto-download-recommended", () => ({
     mocks.autoDownloadRecommendedLocalModelInBackground,
 }));
 
-import type {
-  ConversationMessage,
-  LocalAgentBackupMetadata,
-} from "../api";
+import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
 import { __setAppValueForTests } from "../state/app-store";
 import {
   ConversationMessagesCtx,
@@ -65,6 +62,11 @@ import {
 } from "../state/ConversationMessagesContext.hooks";
 import type { AppContextValue } from "../state/internal";
 import { tryHandleFirstRunAction } from "./first-run-action-channel";
+import {
+  clearCloudLoginPending,
+  markCloudLoginPending,
+  readCloudLoginPending,
+} from "./first-run-cloud-resume";
 import {
   type FirstRunFinishDraft,
   type FirstRunFinishPorts,
@@ -376,7 +378,9 @@ describe("useFirstRunConductor", () => {
     resolveBackups([backup]);
     await Promise.resolve();
     expect(
-      second.transcript.current.some((m) => m.id === "first-run:backup-restore"),
+      second.transcript.current.some(
+        (m) => m.id === "first-run:backup-restore",
+      ),
     ).toBe(false);
     second.unmount();
   });
@@ -465,6 +469,80 @@ describe("useFirstRunConductor", () => {
     expect(tryHandleFirstRunAction("__first_run__:tutorial:start")).toBe(true);
     expect(spies.completeFirstRun).toHaveBeenCalledWith("chat");
     expect(readTutorialState().active).toBe(true);
+    unmount();
+  });
+
+  it("arms a durable cloud-login resume marker synchronously when the cloud runtime is picked", async () => {
+    // The marker must be persisted at pick time — BEFORE the external browser
+    // login can background/evict the WebView — so an eviction mid-login can
+    // resume on relaunch instead of restarting at the greeting. Assert it
+    // synchronously, before the async provision completes and clears it.
+    seedAppStore();
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+    expect(readCloudLoginPending()).toBeNull();
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    expect(readCloudLoginPending()).toMatchObject({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+    });
+    unmount();
+  });
+
+  it("resumes an interrupted cloud login on relaunch (no greeting restart) when the durable marker + connection are present", async () => {
+    // Simulate the device flow AFTER the eviction+relaunch: the resume marker
+    // was persisted before the external browser login evicted the WebView, and
+    // the durable steward token makes elizaCloudConnected recompute true at
+    // mount. The conductor must CONTINUE into chat, not re-seed the "where
+    // should your agent run?" greeting.
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    const spies = seedAppStore(); // elizaCloudConnected: true (durable token)
+    const { transcript, turn, unmount } = renderConductor();
+
+    // It resumes straight into provisioning and completes onboarding into chat…
+    await waitForTurn(turn, "first-run:tutorial");
+    expect(mocks.client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    // …and NEVER bounced the user back to the runtime chooser.
+    expect(transcript.current.some((m) => m.id === "first-run:greeting")).toBe(
+      false,
+    );
+    // Completion clears the durable marker so a later launch starts clean.
+    expect(readCloudLoginPending()).toBeNull();
+
+    // "Take the tutorial" completes onboarding into chat.
+    expect(tryHandleFirstRunAction("__first_run__:tutorial:start")).toBe(true);
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("chat");
+    unmount();
+  });
+
+  it("clears the cloud resume marker on a fresh local runtime pick so a relaunch never resumes an abandoned cloud flow", async () => {
+    // The user had armed a cloud marker, then came back and chose local. Local
+    // is the latest intent — the stale cloud marker must be cleared.
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    // A local marker does not resume (readCloudLoginPending rejects non-cloud),
+    // so the greeting seeds normally and we can drive a fresh local pick.
+    clearCloudLoginPending();
+    seedAppStore();
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+    // Re-arm as if a prior cloud attempt left the marker behind.
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    expect(readCloudLoginPending()).toBeNull();
     unmount();
   });
 

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -13,7 +13,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   client: {
-    listLocalAgentBackups: vi.fn(async () => []),
+    listLocalAgentBackups: vi.fn(
+      async (): Promise<LocalAgentBackupMetadata[]> => [],
+    ),
     restoreLocalAgentBackup: vi.fn(async () => undefined),
     getAuthStatus: vi.fn(async () => ({ required: false })),
     getCloudStatus: vi.fn(async () => ({ connected: true })),
@@ -52,7 +54,10 @@ vi.mock("./auto-download-recommended", () => ({
     mocks.autoDownloadRecommendedLocalModelInBackground,
 }));
 
-import type { ConversationMessage } from "../api";
+import type {
+  ConversationMessage,
+  LocalAgentBackupMetadata,
+} from "../api";
 import { __setAppValueForTests } from "../state/app-store";
 import {
   ConversationMessagesCtx,
@@ -309,6 +314,71 @@ describe("useFirstRunConductor", () => {
       false,
     );
     unmount();
+  });
+
+  it("seeds the greeting IMMEDIATELY even when the local-backup probe never settles (cold-start unblock)", async () => {
+    // The regression: a fresh/booting device whose agent API hangs left the
+    // greeting unseeded (it used to be gated inside the backups probe's
+    // continuations), stranding the user at a locked composer. The greeting
+    // must now appear regardless of the probe.
+    mocks.client.listLocalAgentBackups.mockReturnValue(
+      new Promise<never>(() => {}), // never resolves and never rejects
+    );
+    seedAppStore();
+    const { turn, transcript, unmount } = renderConductor();
+
+    const greeting = await waitForTurn(turn, "first-run:greeting");
+    expect(greeting.text).toContain("where should your agent run?");
+    // And the runtime pick still works while the probe is stuck.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(turn, "first-run:provider");
+    // No backup-restore turn was seeded (the probe never returned any).
+    expect(
+      transcript.current.some((m) => m.id === "first-run:backup-restore"),
+    ).toBe(false);
+    unmount();
+  });
+
+  it("appends the backup-restore choice below the greeting when backups exist — but not once the user advanced past it", async () => {
+    // Backups resolve AFTER the greeting is already up: restore is offered as
+    // an additional turn, never replacing the greeting.
+    const backup = {
+      fileName: "backup-1.tar",
+      path: "/backups/backup-1.tar",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      agentId: "agent-1",
+      stateSha256: "sha-1",
+      sizeBytes: 10,
+    };
+    mocks.client.listLocalAgentBackups.mockResolvedValue([backup]);
+    seedAppStore();
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+    const restore = await waitForTurn(turn, "first-run:backup-restore");
+    expect(restore.text).toContain("__first_run__:backup-restore:");
+    unmount();
+
+    // Now the racing case: if the user picks a runtime BEFORE the (slow) backup
+    // probe resolves, the restore turn must NOT be appended after the fact.
+    vi.clearAllMocks();
+    let resolveBackups: (b: LocalAgentBackupMetadata[]) => void = () => {};
+    mocks.client.listLocalAgentBackups.mockReturnValue(
+      new Promise<LocalAgentBackupMetadata[]>((resolve) => {
+        resolveBackups = resolve;
+      }),
+    );
+    seedAppStore();
+    const second = renderConductor();
+    await waitForTurn(second.turn, "first-run:greeting");
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(second.turn, "first-run:provider");
+    // Backups arrive late — the user already advanced, so no restore turn.
+    resolveBackups([backup]);
+    await Promise.resolve();
+    expect(
+      second.transcript.current.some((m) => m.id === "first-run:backup-restore"),
+    ).toBe(false);
+    second.unmount();
   });
 
   it("REMOTE pick seeds the inline URL+token connect form (no provider step, no immediate finish)", async () => {

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -320,19 +320,32 @@ export function useFirstRunConductor(): void {
 
   const seedBackupRestoreChoice = React.useCallback(
     (backups: LocalAgentBackupMetadata[]) => {
-      latestLocalBackupRef.current = newestLocalBackup(backups);
-      if (!latestLocalBackupRef.current) {
-        seedRuntimeChoice();
-        return;
-      }
-      seedTurn(
-        makeTurn(
-          "first-run:backup-restore",
-          `${RESTORE_GREETING}\n\n${BACKUP_RESTORE_CHOICE}`,
-        ),
-      );
+      const latest = newestLocalBackup(backups);
+      // The greeting + runtime choice is already seeded on mount, so there is
+      // nothing to fall back to when there is no restorable backup.
+      if (!latest) return;
+      latestLocalBackupRef.current = latest;
+      // Offer restore as an ADDITIONAL turn below the greeting — but only while
+      // the user has NOT advanced past it (picking a runtime seeds a
+      // provider / cloud-oauth / remote-connect / tutorial / error turn, all
+      // source "first_run" with a non-greeting id). The atomic updater also
+      // prevents a double-seed if the backup probe ever fires twice (the
+      // restore turn itself is source "first_run" + non-greeting id).
+      setConversationMessages((prev) => {
+        const advancedPastGreeting = prev.some(
+          (m) => m.source === "first_run" && m.id !== "first-run:greeting",
+        );
+        if (advancedPastGreeting) return prev;
+        return [
+          ...prev,
+          makeTurn(
+            "first-run:backup-restore",
+            `${RESTORE_GREETING}\n\n${BACKUP_RESTORE_CHOICE}`,
+          ),
+        ];
+      });
     },
-    [seedRuntimeChoice, seedTurn],
+    [setConversationMessages],
   );
 
   // Ports for the headless finish use case. completeFirstRun is INTERCEPTED:
@@ -704,20 +717,20 @@ export function useFirstRunConductor(): void {
     }
     resetFirstRunPersistGuard();
     setFirstRunActionHandler((value) => handleActionRef.current(value));
+    // Seed the greeting + runtime choice IMMEDIATELY on mount — never gate it
+    // on the agent-readiness probe below. `listLocalAgentBackups()` hits the
+    // local agent API, which on a fresh/booting/wedged device can hang
+    // indefinitely; coupling the greeting to it stranded the user at a locked
+    // composer ("Tap a highlighted option above to continue") with no visible
+    // choices. The backup probe is now a purely additive upgrade.
+    seedRuntimeChoice();
     let cancelled = false;
     void client
       .listLocalAgentBackups()
       .then((backups) => {
-        if (cancelled) return;
-        if (backups.length > 0) {
-          seedBackupRestoreChoice(backups);
-          return;
-        }
-        seedRuntimeChoice();
+        if (!cancelled && backups.length > 0) seedBackupRestoreChoice(backups);
       })
-      .catch(() => {
-        if (!cancelled) seedRuntimeChoice();
-      });
+      .catch(() => {});
     return () => {
       cancelled = true;
       setFirstRunActionHandler(null);

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -47,6 +47,11 @@ import {
   setFirstRunActionHandler,
 } from "./first-run-action-channel";
 import {
+  clearCloudLoginPending,
+  markCloudLoginPending,
+  readCloudLoginPending,
+} from "./first-run-cloud-resume";
+import {
   bindCloudAgent,
   type FirstRunFinishDraft,
   type FirstRunFinishOutcome,
@@ -452,6 +457,9 @@ export function useFirstRunConductor(): void {
     void listOrAutoProvisionCloudAgent(draftRef.current, portsRef.current)
       .then((outcome) => {
         if (outcome.kind === "done" || outcome.kind === "pick-cloud-agent") {
+          // Login resolved + provisioning is proceeding — the resume marker has
+          // served its purpose; drop it so a later relaunch doesn't re-resume.
+          clearCloudLoginPending();
           replaceTurn(
             "first-run:cloud-oauth",
             makeTurn("first-run:cloud-oauth", "Eliza Cloud connected.", {
@@ -479,6 +487,33 @@ export function useFirstRunConductor(): void {
       });
   }, [handleOutcome]);
 
+  // Continue an interrupted cloud/hybrid flow once the connection is present.
+  // Shared by (a) the auto-resume effect below — used when the user connects
+  // from the retry turn's OAuth block and the store later learns the connection
+  // landed — and (b) the mount-time cloud-login rehydrate, which calls this
+  // directly when the durable token already made the connection live at launch
+  // (the effect fired once before the marker was armed, so it can't self-fire).
+  const runCloudResume = React.useCallback(
+    (resume: "cloud" | "hybrid") => {
+      if (busyRef.current || provisionedRef.current) return;
+      pendingCloudResumeRef.current = null;
+      if (resume === "cloud") {
+        replaceTurn(
+          "first-run:cloud-oauth",
+          makeTurn(
+            "first-run:cloud-oauth",
+            "Connecting your Eliza Cloud account…",
+            { secretRequest: cloudOAuthSecretRequest("pending") },
+          ),
+        );
+        startCloudProvisionFlow();
+        return;
+      }
+      startProviderFinish();
+    },
+    [replaceTurn, startCloudProvisionFlow, startProviderFinish],
+  );
+
   // Auto-resume: when the user connects Eliza Cloud from the retry turn's
   // OAuth block (instead of re-picking a runtime), continue the interrupted
   // flow the moment the store learns the connection landed. A fresh pick
@@ -486,28 +521,18 @@ export function useFirstRunConductor(): void {
   React.useEffect(() => {
     if (!active || !elizaCloudConnected) return;
     const resume = pendingCloudResumeRef.current;
-    if (!resume || busyRef.current || provisionedRef.current) return;
-    pendingCloudResumeRef.current = null;
-    if (resume === "cloud") {
-      replaceTurn(
-        "first-run:cloud-oauth",
-        makeTurn(
-          "first-run:cloud-oauth",
-          "Connecting your Eliza Cloud account…",
-          { secretRequest: cloudOAuthSecretRequest("pending") },
-        ),
-      );
-      startCloudProvisionFlow();
-      return;
-    }
-    startProviderFinish();
-  }, [
-    active,
-    elizaCloudConnected,
-    replaceTurn,
-    startCloudProvisionFlow,
-    startProviderFinish,
-  ]);
+    if (!resume) return;
+    runCloudResume(resume);
+  }, [active, elizaCloudConnected, runCloudResume]);
+
+  // Read-only mirrors so the mount effect can resume immediately when the
+  // durable token already made the connection live at launch — without adding
+  // elizaCloudConnected/runCloudResume to the mount effect's deps (which would
+  // re-register the action handler and re-seed on every connection change).
+  const elizaCloudConnectedRef = React.useRef(elizaCloudConnected);
+  elizaCloudConnectedRef.current = elizaCloudConnected;
+  const runCloudResumeRef = React.useRef(runCloudResume);
+  runCloudResumeRef.current = runCloudResume;
 
   const handleFirstRunAction = React.useCallback(
     (value: string): boolean => {
@@ -526,8 +551,11 @@ export function useFirstRunConductor(): void {
       // Once provisioning succeeded only the tutorial pick is live; taps on
       // leftover runtime/provider/cloud-agent widgets must not re-provision.
       if (provisionedRef.current && group !== "tutorial") return true;
-      // A fresh pick supersedes any armed connect-and-resume continuation.
+      // A fresh pick supersedes any armed connect-and-resume continuation —
+      // including the durable cloud-resume marker (the cloud/hybrid branches
+      // below re-arm it if the new pick is a cloud one).
       pendingCloudResumeRef.current = null;
+      clearCloudLoginPending();
 
       if (group === "runtime") {
         if (id !== "cloud" && id !== "local" && id !== "remote") return true;
@@ -537,6 +565,14 @@ export function useFirstRunConductor(): void {
             runtime: "cloud",
             localInference: "cloud-inference",
           };
+          // Persist a resume marker BEFORE the (device) external-browser OAuth
+          // backgrounds/evicts the WebView, so a cold-launch on return
+          // rehydrates this cloud flow instead of restarting at the greeting.
+          markCloudLoginPending({
+            runtime: "cloud",
+            localInference: "cloud-inference",
+            agentName: draftRef.current.agentName,
+          });
           const connecting = makeTurn(
             "first-run:cloud-oauth",
             "Connecting your Eliza Cloud account…",
@@ -633,6 +669,14 @@ export function useFirstRunConductor(): void {
             ...draftRef.current,
             localInference: "cloud-inference",
           };
+          // Hybrid (local runtime + Cloud inference) also opens the external
+          // OAuth browser — persist a resume marker so a WebView eviction on
+          // return rehydrates the hybrid finish rather than restarting.
+          markCloudLoginPending({
+            runtime: "hybrid",
+            localInference: "cloud-inference",
+            agentName: draftRef.current.agentName,
+          });
         } else if (id === "other") {
           // "Other / configure in Settings" (bring your own keys): run locally
           // but wire NO provider, so the finish path's `needsProviderSetup`
@@ -717,13 +761,46 @@ export function useFirstRunConductor(): void {
     }
     resetFirstRunPersistGuard();
     setFirstRunActionHandler((value) => handleActionRef.current(value));
-    // Seed the greeting + runtime choice IMMEDIATELY on mount — never gate it
-    // on the agent-readiness probe below. `listLocalAgentBackups()` hits the
-    // local agent API, which on a fresh/booting/wedged device can hang
-    // indefinitely; coupling the greeting to it stranded the user at a locked
-    // composer ("Tap a highlighted option above to continue") with no visible
-    // choices. The backup probe is now a purely additive upgrade.
-    seedRuntimeChoice();
+    // Cloud-login resume: if the app was cold-launched mid cloud OAuth (the
+    // external browser evicted the WebView on a device), rehydrate the
+    // interrupted cloud/hybrid flow instead of restarting at the greeting.
+    // The durable steward token (persisted at login) makes elizaCloudConnected
+    // recompute true after relaunch, so the auto-resume effect above completes
+    // onboarding into chat; the re-tappable OAuth turn below is the fallback if
+    // login never finished — either way the user is never bounced back to
+    // "where should your agent run?".
+    const cloudResume = readCloudLoginPending();
+    if (cloudResume) {
+      draftRef.current = {
+        ...draftRef.current,
+        agentName: cloudResume.agentName || draftRef.current.agentName,
+        runtime: cloudResume.runtime === "cloud" ? "cloud" : "local",
+        localInference: cloudResume.localInference,
+      };
+      pendingCloudResumeRef.current = cloudResume.runtime;
+      seedTurn(
+        makeTurn(
+          "first-run:cloud-oauth",
+          "Connecting your Eliza Cloud account…",
+          { secretRequest: cloudOAuthSecretRequest("pending") },
+        ),
+      );
+      // If the durable token already made the connection live at launch, the
+      // auto-resume effect above fired once before this marker was armed, so it
+      // won't self-fire — resume now. Otherwise leave the marker armed for the
+      // effect to catch when elizaCloudConnected flips true after the poll.
+      if (elizaCloudConnectedRef.current) {
+        runCloudResumeRef.current(cloudResume.runtime);
+      }
+    } else {
+      // Seed the greeting + runtime choice IMMEDIATELY on mount — never gate it
+      // on the agent-readiness probe below. `listLocalAgentBackups()` hits the
+      // local agent API, which on a fresh/booting/wedged device can hang
+      // indefinitely; coupling the greeting to it stranded the user at a locked
+      // composer ("Tap a highlighted option above to continue") with no visible
+      // choices. The backup probe is now a purely additive upgrade.
+      seedRuntimeChoice();
+    }
     let cancelled = false;
     void client
       .listLocalAgentBackups()
@@ -735,7 +812,7 @@ export function useFirstRunConductor(): void {
       cancelled = true;
       setFirstRunActionHandler(null);
     };
-  }, [active, seedBackupRestoreChoice, seedRuntimeChoice]);
+  }, [active, seedBackupRestoreChoice, seedRuntimeChoice, seedTurn]);
 }
 
 /** Mount point — call once inside the AppContext provider tree. Renders null. */

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -675,6 +675,15 @@ export function useCloudState({
                 (
                   globalThis as Record<string, unknown>
                 ).__ELIZA_CLOUD_AUTH_TOKEN__ = poll.token;
+                // Persist the token DURABLY too, not just on the volatile window
+                // global. On a native device the OAuth opens an external browser
+                // (SFSafariViewController) which backgrounds the WebView; iOS
+                // often cold-launches it on return, wiping the global — so
+                // getCloudAuthToken() read nothing, elizaCloudConnected never
+                // recomputed true, and onboarding restarted at the greeting.
+                // Writing the steward-session channel (which getCloudAuthToken
+                // reads first) lets the connection survive the relaunch.
+                writeStoredStewardToken(poll.token);
                 // Also update boot config so subsequent reads use the resolved cloud base.
                 const cfg = getBootConfig();
                 setBootConfig({


### PR DESCRIPTION
Relands a group of onboarding-resume and accessibility fixes onto develop (cherry-picked cleanly, zero conflicts).

## What / why
1. **Greeting shows immediately** — stop gating the onboarding greeting on the agent-wake probe, so the first-run screen renders without waiting on the runtime to wake.
2. **a11y: in-chat first-run choices** — expose the in-chat first-run choice buttons to the accessibility tree, and add an onboarding probe so e2e/a11y tooling can find them.
3. **Cloud login resume** — after a WebView eviction during cloud login, onboarding no longer restarts at the greeting; it resumes into chat (new `first-run-cloud-resume.ts` + persisted cloud state).
4. **iOS local kernel** — serve `POST /api/first-run` in the JSContext kernel, fixing the local onboarding "not found" loop.
5. **e2e realign** — restore the onboarding→home smoke by aligning the stale runtime choice id + locked-composer placeholder.

## Files
- `packages/ui/src/first-run/use-first-run-conductor.ts` (+test)
- `packages/ui/src/first-run/first-run-cloud-resume.ts` (new, +test)
- `packages/ui/src/state/useCloudState.ts`
- `packages/ui/src/components/shell/ContinuousChatOverlay.tsx` (+firstrun test)
- `packages/ui/src/api/ios-local-agent-kernel.ts` (+test)
- `packages/app/test/ui-smoke/onboarding-to-home.shared.ts`

## Testing
- `packages/ui` unit tests for all four touched suites — **51/51 pass** (`use-first-run-conductor`, `first-run-cloud-resume`, `ios-local-agent-kernel`, `ContinuousChatOverlay.firstrun`).
- `packages/ui` typecheck: touched files clean. The only `tsc` error is a pre-existing missing optional dep (`iwer`) in the untouched `spatial/__e2e__/immersive-fixture.ts`, identical on develop and unrelated to this change (env gap in the shared node_modules).
- **iOS on-device / rendered walkthrough: N/A here** — no simulator/device reachable in this environment. The original branch (`feat/multi-account-login-verification`) carries the device evidence for the onboarding-resume flow; re-capture on device before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)