### PR TITLE
fix(ui): dynamic view/overlay load failures show the recoverable card, never a blank screen

### DIFF
--- a/packages/ui/src/components/apps/AppWindowRenderer.helpers.test.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.helpers.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetRetainedLazyModulesForTests } from "../../retained-lazy";
 import { getOverlayAppLazyComponent } from "./AppWindowRenderer.helpers";
-import type { OverlayApp } from "./overlay-app-api";
+import type { OverlayApp, OverlayAppContext } from "./overlay-app-api";
 
 describe("getOverlayAppLazyComponent", () => {
   beforeEach(() => {
@@ -58,5 +59,77 @@ describe("getOverlayAppLazyComponent", () => {
     expect(cleanupModule).not.toHaveBeenCalled();
     window.dispatchEvent(new Event("memorypressure"));
     await waitFor(() => expect(cleanupModule).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders the recoverable 'Failed to load view' card when the overlay bundle fails, and Retry re-imports", async () => {
+    // Regression: an overlay app whose lazy bundle rejected used to render a
+    // blank white screen (fallback:null, no onError). It must now show the SAME
+    // recoverable card as a remote view.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    let attempt = 0;
+    const app: OverlayApp = {
+      name: "test.overlay.broken",
+      displayName: "Broken Overlay",
+      description: "Broken overlay",
+      category: "test",
+      icon: null,
+      loader: async () => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error("Failed to fetch dynamically imported module");
+        }
+        return {
+          default: function RecoveredOverlay() {
+            return <div>Overlay recovered</div>;
+          },
+        };
+      },
+    };
+
+    const Overlay = getOverlayAppLazyComponent(app);
+    expect(Overlay).toBeTruthy();
+    if (!Overlay) return;
+
+    const { container } = render(
+      <Overlay exitToApps={() => {}} uiTheme="light" t={(key) => key} />,
+    );
+
+    // The card is actually mounted — a blank screen would render none of this.
+    const retry = await screen.findByRole("button", { name: /retry/i });
+    expect(screen.getByText("Failed to load view")).toBeTruthy();
+    expect(screen.getByText("View ID: test.overlay.broken")).toBeTruthy();
+    expect(container.textContent).not.toBe("");
+
+    await act(async () => {
+      retry.click();
+    });
+
+    await screen.findByText("Overlay recovered");
+    expect(screen.queryByText("Failed to load view")).toBeNull();
+    consoleError.mockRestore();
+  });
+
+  it("renders the error card when the overlay module lacks a renderable default export", async () => {
+    const app: OverlayApp = {
+      name: "test.overlay.noexport",
+      displayName: "No Export Overlay",
+      description: "No export overlay",
+      category: "test",
+      icon: null,
+      loader: async () => ({
+        default: undefined as unknown as ComponentType<OverlayAppContext>,
+      }),
+    };
+
+    const Overlay = getOverlayAppLazyComponent(app);
+    expect(Overlay).toBeTruthy();
+    if (!Overlay) return;
+
+    render(<Overlay exitToApps={() => {}} uiTheme="light" t={(key) => key} />);
+
+    await screen.findByText("Failed to load view");
+    expect(screen.getByText("View ID: test.overlay.noexport")).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/apps/AppWindowRenderer.helpers.ts
+++ b/packages/ui/src/components/apps/AppWindowRenderer.helpers.ts
@@ -1,5 +1,10 @@
 import { type ComponentType, createElement } from "react";
 import { RetainedLazyComponent } from "../../retained-lazy";
+import {
+  navigateToViews,
+  ViewErrorState,
+  ViewLoadingSkeleton,
+} from "../views/ViewStatusStates";
 import type { OverlayApp, OverlayAppContext } from "./overlay-app-api";
 
 const lazyComponentCache = new WeakMap<
@@ -19,7 +24,19 @@ export function getOverlayAppLazyComponent(
       loader,
       cacheKey: app.name,
       componentProps: props,
-      fallback: null,
+      // A failed overlay-app import (bundle 404 / network error / a module with
+      // no renderable default export) must surface the SAME recoverable
+      // "Failed to load view" card as a remote view — never a blank/white
+      // screen. `fallback` covers the loading gap; `onError` renders the card
+      // with a Retry that re-imports and a Back that exits the overlay.
+      fallback: createElement(ViewLoadingSkeleton),
+      onError: (error, retry) =>
+        createElement(ViewErrorState, {
+          viewId: app.name,
+          error,
+          onRetry: retry,
+          onBack: props.exitToApps ?? navigateToViews,
+        }),
     });
   };
   lazyComponentCache.set(app.loader, created);

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -664,6 +664,53 @@ describe("DynamicViewLoader", () => {
     expect(screen.getByText("View ID: broken.view")).toBeTruthy();
   });
 
+  it("shows the recoverable card (never a blank screen) when the bundle import rejects, and Retry re-imports", async () => {
+    // Mode 1: a rejected dynamic import (bundle 404 / network / fetch error)
+    // must land on the SAME "Failed to load view" card with a working Retry —
+    // not a blank/white render.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const bundleUrl = "https://capability.example.test/assets/network-fail.js";
+    let attempt = 0;
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("Failed to fetch dynamically imported module");
+      }
+      return {
+        default: function RecoveredPanel() {
+          return <div>Network recovered v{attempt}</div>;
+        },
+      };
+    });
+
+    const { container } = render(
+      <DynamicViewLoader bundleUrl={bundleUrl} viewId="network.view" />,
+    );
+
+    const retry = await screen.findByRole("button", { name: /retry/i });
+    // The actual card is in the DOM (not an empty container).
+    expect(screen.getByText("Failed to load view")).toBeTruthy();
+    expect(screen.getByText("View ID: network.view")).toBeTruthy();
+    expect(
+      screen.getByText("Failed to fetch dynamically imported module"),
+    ).toBeTruthy();
+    expect(container.textContent).not.toBe("");
+
+    await act(async () => {
+      retry.click();
+    });
+
+    // Retry actually re-attempts the import — the fixed bundle mounts.
+    await screen.findByText("Network recovered v2");
+    expect(screen.queryByText("Failed to load view")).toBeNull();
+    expect(window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__).toHaveBeenCalledTimes(
+      2,
+    );
+    consoleError.mockRestore();
+  });
+
   it("recovers a view that crashes at render when Retry re-imports a fixed bundle", async () => {
     // A render crash must not latch the ErrorBoundary forever: clicking Retry
     // evicts the cached module, bumps reloadKey (which re-keys the boundary so

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -21,16 +21,8 @@
 
 import { resolveAppBranding } from "@elizaos/shared";
 import {
-  AlertTriangle,
-  ArrowLeft,
-  Ban,
-  LoaderCircle,
-  RotateCw,
-} from "lucide-react";
-import {
   type ComponentType,
   memo,
-  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -66,7 +58,6 @@ import {
   planModuleCacheEvictions,
 } from "../../state/bounded-view-lru";
 import { installHeapPressureMonitor } from "../../state/heap-pressure-monitor";
-import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useApp } from "../../state/useApp.ts";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
 import {
@@ -89,6 +80,12 @@ import { Button } from "../ui/button.tsx";
 import { ErrorBoundary } from "../ui/error-boundary";
 import { Input } from "../ui/input.tsx";
 import { Spinner } from "../ui/spinner.tsx";
+import {
+  navigateToViews,
+  ViewErrorState,
+  ViewLoadingSkeleton,
+  ViewRestrictedState,
+} from "./ViewStatusStates";
 import { registerViewInteractHandler } from "./view-interact-registry";
 
 interface ViewBundleModule {
@@ -1011,175 +1008,6 @@ async function handleStandardCapability(
     default:
       throw new Error(`Unknown standard capability "${capability}"`);
   }
-}
-
-/**
- * Navigate back to the view launcher (`/views`). Hoisted so the error/crash
- * recovery surfaces can offer a "Back to views" escape hatch without depending
- * on the view itself having wired the `exitToApps` prop.
- */
-function navigateToViews() {
-  if (typeof window !== "undefined") {
-    window.history.pushState(null, "", "/views");
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }
-}
-
-function ViewStatusFrame({
-  tone,
-  icon,
-  title,
-  children,
-  actions,
-}: {
-  tone: "loading" | "error" | "restricted";
-  icon: ReactNode;
-  title: ReactNode;
-  children?: ReactNode;
-  actions?: ReactNode;
-}) {
-  const toneClass =
-    tone === "error"
-      ? "border-destructive/25 bg-destructive/5 text-destructive"
-      : tone === "restricted"
-        ? "border-muted-foreground/20 bg-muted/20 text-muted-foreground"
-        : "border-primary/20 bg-primary/5 text-primary";
-
-  return (
-    <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center p-6">
-      <div
-        className={`flex w-full max-w-sm flex-col gap-3 rounded-lg border p-4 ${toneClass}`}
-      >
-        <div className="flex items-center gap-3">
-          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-background/70">
-            {icon}
-          </div>
-          <div className="min-w-0 text-left">
-            <div className="text-sm font-semibold">{title}</div>
-            {children ? (
-              <div className="mt-1 text-xs opacity-75">{children}</div>
-            ) : null}
-          </div>
-        </div>
-        {actions ? (
-          <div className="flex flex-wrap gap-2 pl-[3.25rem]">{actions}</div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function ViewLoadingSkeleton() {
-  const { t } = useTranslation();
-  return (
-    <ViewStatusFrame
-      tone="loading"
-      icon={
-        <LoaderCircle className="h-5 w-5 animate-spin" aria-hidden="true" />
-      }
-      title={t("dynamicviewloader.loading", { defaultValue: "Loading view…" })}
-    />
-  );
-}
-
-function ViewRecoveryActions({
-  onRetry,
-  onBack,
-}: {
-  onRetry: () => void;
-  onBack: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 gap-1 rounded-sm text-xs"
-        onClick={onRetry}
-      >
-        <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
-        {t("dynamicviewloader.retry", { defaultValue: "Retry" })}
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 gap-1 rounded-sm text-xs"
-        onClick={onBack}
-      >
-        <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-        {t("dynamicviewloader.back", { defaultValue: "Back to views" })}
-      </Button>
-    </>
-  );
-}
-
-function ViewErrorState({
-  viewId,
-  error,
-  onRetry,
-  onBack,
-}: {
-  viewId: string;
-  error?: Error | null;
-  onRetry?: () => void;
-  onBack?: () => void;
-}) {
-  const { t } = useTranslation();
-  return (
-    <ViewStatusFrame
-      tone="error"
-      icon={<AlertTriangle className="h-5 w-5" aria-hidden="true" />}
-      title={t("dynamicviewloader.error.title", {
-        defaultValue: "Failed to load view",
-      })}
-      actions={
-        onRetry && onBack ? (
-          <ViewRecoveryActions onRetry={onRetry} onBack={onBack} />
-        ) : undefined
-      }
-    >
-      <span>
-        {t("dynamicviewloader.viewId", {
-          viewId,
-          defaultValue: "View ID: {{viewId}}",
-        })}
-      </span>
-      {error?.message ? (
-        <span className="mt-1 block break-words font-mono text-[10px] opacity-60">
-          {error.message}
-        </span>
-      ) : null}
-    </ViewStatusFrame>
-  );
-}
-
-function ViewRestrictedState({ viewId }: { viewId: string }) {
-  const { t } = useTranslation();
-  return (
-    <ViewStatusFrame
-      tone="restricted"
-      icon={<Ban className="h-5 w-5" aria-hidden="true" />}
-      title={t("dynamicviewloader.restricted.title", {
-        defaultValue: "View not available on this platform",
-      })}
-    >
-      <span>
-        {t("dynamicviewloader.restricted.body", {
-          defaultValue:
-            "Dynamic views cannot be loaded on iOS or Android store builds.",
-        })}
-      </span>
-      <span className="mt-1 block">
-        {t("dynamicviewloader.viewId", {
-          viewId,
-          defaultValue: "View ID: {{viewId}}",
-        })}
-      </span>
-    </ViewStatusFrame>
-  );
 }
 
 interface DynamicViewLoaderProps {

--- a/packages/ui/src/components/views/ViewErrorBoundary.test.tsx
+++ b/packages/ui/src/components/views/ViewErrorBoundary.test.tsx
@@ -95,6 +95,20 @@ describe("ViewErrorBoundary", () => {
     expect(viewLifecycleController.getPhase("crasher")).not.toBe("crashed");
   });
 
+  it("renders a non-blank fallback card (message + retry), never an empty container", () => {
+    const { container } = render(
+      <ViewErrorBoundary viewId="crasher">
+        <Boom />
+      </ViewErrorBoundary>,
+    );
+    const card = screen.getByTestId("view-error-boundary-fallback");
+    // The card is a real, non-empty DOM node — not a blank white screen.
+    expect(card).toBeTruthy();
+    expect(container.textContent).not.toBe("");
+    expect(card.textContent).toContain("kaboom");
+    expect(screen.getByTestId("view-error-retry")).toBeTruthy();
+  });
+
   it("uses a caller-supplied richer fallback when provided", () => {
     render(
       <ViewErrorBoundary

--- a/packages/ui/src/components/views/ViewStatusStates.tsx
+++ b/packages/ui/src/components/views/ViewStatusStates.tsx
@@ -1,0 +1,191 @@
+/**
+ * Shared view status surfaces — the loading skeleton, the recoverable
+ * "Failed to load view" error card, and the platform-restricted card.
+ *
+ * These were originally private to `DynamicViewLoader`, but EVERY way of
+ * dynamically loading a view (the remote-bundle `DynamicViewLoader` AND the
+ * `RetainedLazyComponent`-based overlay/app loaders) must surface the SAME
+ * recoverable card on failure instead of a blank/white screen. Extracting them
+ * here lets each loader reuse the identical UI (issue: harden view load errors)
+ * rather than inventing a second error surface.
+ */
+
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Ban,
+  LoaderCircle,
+  RotateCw,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "../../state/TranslationContext.hooks";
+import { Button } from "../ui/button.tsx";
+
+/**
+ * Navigate back to the view launcher (`/views`). Hoisted so the error/crash
+ * recovery surfaces can offer a "Back to views" escape hatch without depending
+ * on the view itself having wired the `exitToApps` prop.
+ */
+export function navigateToViews() {
+  if (typeof window !== "undefined") {
+    window.history.pushState(null, "", "/views");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+}
+
+export function ViewStatusFrame({
+  tone,
+  icon,
+  title,
+  children,
+  actions,
+}: {
+  tone: "loading" | "error" | "restricted";
+  icon: ReactNode;
+  title: ReactNode;
+  children?: ReactNode;
+  actions?: ReactNode;
+}) {
+  const toneClass =
+    tone === "error"
+      ? "border-destructive/25 bg-destructive/5 text-destructive"
+      : tone === "restricted"
+        ? "border-muted-foreground/20 bg-muted/20 text-muted-foreground"
+        : "border-primary/20 bg-primary/5 text-primary";
+
+  return (
+    <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center p-6">
+      <div
+        className={`flex w-full max-w-sm flex-col gap-3 rounded-lg border p-4 ${toneClass}`}
+      >
+        <div className="flex items-center gap-3">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-background/70">
+            {icon}
+          </div>
+          <div className="min-w-0 text-left">
+            <div className="text-sm font-semibold">{title}</div>
+            {children ? (
+              <div className="mt-1 text-xs opacity-75">{children}</div>
+            ) : null}
+          </div>
+        </div>
+        {actions ? (
+          <div className="flex flex-wrap gap-2 pl-[3.25rem]">{actions}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function ViewLoadingSkeleton() {
+  const { t } = useTranslation();
+  return (
+    <ViewStatusFrame
+      tone="loading"
+      icon={
+        <LoaderCircle className="h-5 w-5 animate-spin" aria-hidden="true" />
+      }
+      title={t("dynamicviewloader.loading", { defaultValue: "Loading view…" })}
+    />
+  );
+}
+
+export function ViewRecoveryActions({
+  onRetry,
+  onBack,
+}: {
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 gap-1 rounded-sm text-xs"
+        onClick={onRetry}
+      >
+        <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
+        {t("dynamicviewloader.retry", { defaultValue: "Retry" })}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-7 gap-1 rounded-sm text-xs"
+        onClick={onBack}
+      >
+        <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+        {t("dynamicviewloader.back", { defaultValue: "Back to views" })}
+      </Button>
+    </>
+  );
+}
+
+export function ViewErrorState({
+  viewId,
+  error,
+  onRetry,
+  onBack,
+}: {
+  viewId: string;
+  error?: Error | null;
+  onRetry?: () => void;
+  onBack?: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <ViewStatusFrame
+      tone="error"
+      icon={<AlertTriangle className="h-5 w-5" aria-hidden="true" />}
+      title={t("dynamicviewloader.error.title", {
+        defaultValue: "Failed to load view",
+      })}
+      actions={
+        onRetry && onBack ? (
+          <ViewRecoveryActions onRetry={onRetry} onBack={onBack} />
+        ) : undefined
+      }
+    >
+      <span>
+        {t("dynamicviewloader.viewId", {
+          viewId,
+          defaultValue: "View ID: {{viewId}}",
+        })}
+      </span>
+      {error?.message ? (
+        <span className="mt-1 block break-words font-mono text-[10px] opacity-60">
+          {error.message}
+        </span>
+      ) : null}
+    </ViewStatusFrame>
+  );
+}
+
+export function ViewRestrictedState({ viewId }: { viewId: string }) {
+  const { t } = useTranslation();
+  return (
+    <ViewStatusFrame
+      tone="restricted"
+      icon={<Ban className="h-5 w-5" aria-hidden="true" />}
+      title={t("dynamicviewloader.restricted.title", {
+        defaultValue: "View not available on this platform",
+      })}
+    >
+      <span>
+        {t("dynamicviewloader.restricted.body", {
+          defaultValue:
+            "Dynamic views cannot be loaded on iOS or Android store builds.",
+        })}
+      </span>
+      <span className="mt-1 block">
+        {t("dynamicviewloader.viewId", {
+          viewId,
+          defaultValue: "View ID: {{viewId}}",
+        })}
+      </span>
+    </ViewStatusFrame>
+  );
+}

--- a/packages/ui/src/retained-lazy.test.tsx
+++ b/packages/ui/src/retained-lazy.test.tsx
@@ -182,6 +182,65 @@ describe("RetainedLazyComponent", () => {
     );
   });
 
+  it("surfaces onError with a working retry when the loader rejects (never blank)", async () => {
+    let attempt = 0;
+    const loader = vi.fn(async (): Promise<RetainedLazyModule<TestProps>> => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("bundle 404");
+      return {
+        default: function OkPanel({ label }: TestProps) {
+          return <div>{label}</div>;
+        },
+      };
+    });
+
+    render(
+      <RetainedLazyComponent
+        loader={loader}
+        componentProps={{ label: "recovered lazy" }}
+        onError={(error, retry) => (
+          <div>
+            <span data-testid="lazy-error">{error.message}</span>
+            <button type="button" onClick={retry}>
+              retry-lazy
+            </button>
+          </div>
+        )}
+      />,
+    );
+
+    const retryButton = await screen.findByText("retry-lazy");
+    expect(screen.getByTestId("lazy-error").textContent).toBe("bundle 404");
+
+    await act(async () => {
+      retryButton.click();
+    });
+
+    await screen.findByText("recovered lazy");
+    expect(screen.queryByTestId("lazy-error")).toBeNull();
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces onError when the module has no renderable default export (mode 3, not blank)", async () => {
+    const loader = vi.fn(
+      async () =>
+        ({ default: undefined }) as unknown as RetainedLazyModule<TestProps>,
+    );
+
+    render(
+      <RetainedLazyComponent
+        loader={loader}
+        componentProps={{ label: "x" }}
+        onError={(error) => <div data-testid="lazy-error">{error.message}</div>}
+      />,
+    );
+
+    const node = await screen.findByTestId("lazy-error");
+    expect(node.textContent).toContain(
+      "did not export a default React component",
+    );
+  });
+
   it("evicts inactive modules on live heap pressure and emits the heap value (#10196)", async () => {
     Object.defineProperty(performance, "memory", {
       configurable: true,

--- a/packages/ui/src/retained-lazy.tsx
+++ b/packages/ui/src/retained-lazy.tsx
@@ -1,6 +1,7 @@
 import {
   type ComponentType,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -20,6 +21,21 @@ import {
 import { installHeapPressureMonitor } from "./state/heap-pressure-monitor";
 
 type RetainedCleanup = () => void | Promise<void>;
+
+/**
+ * A resolved module is only mountable if its `default` export is a React
+ * component — a function component/class, or an exotic component object
+ * (`memo`/`forwardRef`/`lazy`, which carry a `$$typeof`). Anything else
+ * (a missing/undefined export, a plain object, a string) would make React throw
+ * "Element type is invalid" and paint a blank screen when rendered as
+ * `<Component … />`, so we detect it up front and surface the error card.
+ */
+function isRenderableComponent(value: unknown): boolean {
+  return (
+    typeof value === "function" ||
+    (typeof value === "object" && value !== null && "$$typeof" in value)
+  );
+}
 
 export interface RetainedLazyModule<TProps extends object> {
   default: ComponentType<TProps>;
@@ -352,11 +368,24 @@ export function RetainedLazyComponent<TProps extends object>({
   cacheKey?: string;
   componentProps: TProps;
   fallback?: ReactNode;
-  onError?: (error: Error) => ReactNode;
+  /**
+   * Recoverable failure surface. Receives the error and a `retry` that
+   * re-imports the module (invalidating the failed cache entry). Callers should
+   * render a card with a Retry affordance so a load/parse/missing-export failure
+   * never leaves a blank screen. When omitted, `fallback` is shown instead of a
+   * blank render.
+   */
+  onError?: (error: Error, retry: () => void) => ReactNode;
 }) {
   const [module, setModule] = useState<RetainedLazyModule<TProps> | null>(null);
   const [error, setError] = useState<Error | null>(null);
+  // Bumping this re-runs the load effect after a Retry: the failed cache entry
+  // is invalidated and the module re-imported, so a transient failure recovers
+  // instead of latching a permanent error card.
+  const [reloadKey, setReloadKey] = useState(0);
 
+  // reloadKey is a manual re-import trigger (see `retry`), so it must be a dep.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey re-arms the import
   useEffect(() => {
     let cancelled = false;
     const lease = acquireRetainedLazyModule(loader, { cacheKey });
@@ -364,7 +393,17 @@ export function RetainedLazyComponent<TProps extends object>({
     setError(null);
     void lease.promise
       .then((nextModule) => {
-        if (!cancelled) setModule(nextModule);
+        if (cancelled) return;
+        // Import resolved but the module has no renderable default component:
+        // mounting `<undefined … />` throws "Element type is invalid" and paints
+        // blank. Surface the recoverable error instead of rendering nothing.
+        if (!isRenderableComponent(nextModule?.default)) {
+          setError(
+            new Error("Loaded module did not export a default React component"),
+          );
+          return;
+        }
+        setModule(nextModule);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -374,12 +413,21 @@ export function RetainedLazyComponent<TProps extends object>({
       cancelled = true;
       lease.release();
     };
-  }, [loader, cacheKey]);
+  }, [loader, cacheKey, reloadKey]);
 
-  const renderedError = useMemo(
-    () => (error && onError ? onError(error) : null),
-    [error, onError],
-  );
+  const retry = useCallback(() => {
+    invalidateRetainedLazyModule(loader);
+    setError(null);
+    setModule(null);
+    setReloadKey((k) => k + 1);
+  }, [loader]);
+
+  const renderedError = useMemo(() => {
+    if (!error) return null;
+    // A caller with `onError` gets the recoverable card; otherwise fall back to
+    // the loading placeholder rather than a blank render.
+    return onError ? onError(error, retry) : fallback;
+  }, [error, onError, retry, fallback]);
   if (error) return renderedError;
   if (!module) return <>{fallback}</>;
   const Component = module.default;


### PR DESCRIPTION
Closes #11895

## Problem

Opening some views showed a **plain white screen** with no error and no way to recover (reported: "click autonomy → white screen"), while other view failures correctly showed the **"Failed to load view"** card (View ID + error message + Retry / Back). The handling was inconsistent — several dynamic-loading failure modes rendered blank instead of the recoverable card.

## Audit — every catchable way a dynamic view can fail

`DynamicViewLoader` (remote `/api/views` bundles) **already** funnels all three modes into the recoverable card; I added the missing coverage and confirmed it:

| Mode | Path | Result |
| --- | --- | --- |
| 1. Dynamic import rejects (404 / network) | `DynamicViewLoader` load effect → `setLoadError` | ✅ card + Retry (re-imports) |
| 2. Render-time throw in the loaded view | inner `ErrorBoundary` keyed by `bundleUrl:reloadKey` | ✅ card + Retry (remounts + re-imports) |
| 3. Module resolves without a valid component export | load-time `isReactComponentExport` guard → `setLoadError` | ✅ card |

The blank screen came from the **other** dynamic loader — **`RetainedLazyComponent`**, used by **overlay apps** via `getOverlayAppLazyComponent`, which was mounted with `fallback: null` and **no `onError`**, and never checked the resolved `module.default`:

- overlay bundle **rejects** (404 / network) → `RetainedLazyComponent` renders `null` → **blank white screen**;
- overlay module has a **missing/undefined default export** → `<undefined … />` → React "Element type is invalid" → **blank / crash**.

## Fix

- **Extract** the shared status surfaces (loading skeleton, "Failed to load view" card, restricted card) out of `DynamicViewLoader` into `ViewStatusStates.tsx` so every dynamic-view loader **reuses the identical card** — no second/invented error surface.
- **Harden `RetainedLazyComponent`**: guard a missing/undefined default export before mounting, and give `onError` a `retry` callback that re-imports (invalidates the failed cache entry + re-runs the load). `onError`-less callers now fall back to the loading placeholder instead of a blank render. (Signature change is backward-compatible — existing callers ignore the new 2nd arg.)
- **Wire `getOverlayAppLazyComponent`** to render the shared card + Retry (Back exits the overlay) on any failure, instead of `fallback: null`.

Retry genuinely re-attempts the import in every mode (it resets the boundary / bumps the reload key and invalidates the module cache) — not just clears the message.

## Explicitly out of scope

A view that **loads and renders fine but whose CSS/stylesheet failed to inject** (the "loaded-but-unstyled / invisible light-mode text" case) is **not** catchable here — there is no error to catch, the JS renders correctly. This PR fixes white/blank/crash screens, **not** the separate CSS-delivery flakiness.

## Tests & verification

Unit tests are the primary evidence — every one asserts the card is **actually in the DOM (not an empty container)** for its failure mode and that Retry re-imports:

- `DynamicViewLoader.test.tsx` — import-reject → card + Retry re-imports (new); existing missing-export + render-crash-retry retained.
- `retained-lazy.test.tsx` — loader-reject → `onError` + Retry re-imports; missing/undefined default export → `onError` card (not blank).
- `AppWindowRenderer.helpers.test.tsx` — overlay bundle failure → real **"Failed to load view"** card + Retry re-imports; missing default export → card.
- `ViewErrorBoundary.test.tsx` — render-throw fallback is a non-empty card with the message + Retry, never an empty container.

Commands run in `packages/ui` (fresh worktree, `install:light`):

- `bun run vitest run` on the 4 suites → **37 passed**.
- `bun run typecheck` (`tsgo --noEmit`) → **clean**.
- `bunx @biomejs/biome check` on all 8 changed files → **clean**.

Codegen note: `packages/core/src/i18n/generated/validation-keyword-data.ts` (gitignored) was generated locally so the jsdom suites resolve; it is **not** in the commit.

### Evidence matrix

- Unit/jsdom tests (real DOM assertions per failure mode): ✅ attached above (37 passing).
- Live Playwright render of a deliberately-broken view: N/A — the behavior is fully exercised at the loader level in jsdom (card asserted in the DOM for import-reject, render-throw, and missing-export across both loaders); a full app build/deploy adds no signal for this loader-only change.
- Backend/model trajectories: N/A — pure client-side view-loading UI, no agent/model/prompt behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)