### PR TITLE
fix(cloud): align Worker core stub to main — prevent 0-export promote break

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -18,6 +18,21 @@ function throwingExport(name: string): (...args: unknown[]) => never {
   return () => unavailable(name);
 }
 
+/**
+ * Worker-safe pass-through for core's `runWithTrajectoryPurpose`. The Worker
+ * build has no AsyncLocalStorage trajectory-context manager (node-only), so we
+ * just invoke the fn directly — trajectory-purpose tracking is a no-op in the
+ * Worker. Added because #11580 imports it into email-classifier.ts, which the
+ * Worker build bundles; without this export the Deploy API Worker step fails
+ * with "No matching export ... for import runWithTrajectoryPurpose".
+ */
+export function runWithTrajectoryPurpose<T>(
+  _purpose: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return fn();
+}
+
 function readEnvValue(
   env: Record<string, string | undefined>,
   keys: readonly string[],


### PR DESCRIPTION
After #11861 promote, `runWithTrajectoryPurpose` in the Worker stub was deduped **differently** per branch — #11865 (main) kept the top copy, #11857 (develop) kept the other. A develop→main merge applies both removals → **0 exports → Worker build breaks** on the next promote (verified via `git merge-tree`). Aligns develop's stub byte-identical to main's (the version already on prod). Future promotes are a no-op on this file. — `[cloud-frontdoor]`