### PR TITLE
fix(ui): recover first-run finish errors without looping

### DIFF
--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -94,3 +94,19 @@ taps them out of order. The contract, enforced in `use-first-run-conductor.ts`
   the OAuth block, the interrupted flow resumes automatically when the store
   learns the connection landed. A fresh pick always supersedes the pending
   resume.
+- **No finish dead end (the loop fix).** When a finish/provision flow fails —
+  including a persistent `POST /api/first-run` failure such as a 404 — the
+  conductor seeds a DISTINCT recovery turn (`first-run:error:*`) carrying its own
+  `[CHOICE:first-run id=error]` with a human-readable message and three real ways
+  forward: **Try again** (`error:retry`, re-runs the last runtime's finish),
+  **Choose a different way to run** (`error:restart`, re-offers a fresh unlocked
+  runtime CHOICE), and **Configure in Settings** (`error:settings`). It never
+  re-appends the runtime question inline, so a repeating error can no longer loop
+  the greeting forever.
+- **"Other / configure in Settings" always escapes.** The `provider:other` pick
+  (BYOK) does NOT run a local finish flow that could fail and re-loop; it opens
+  the Settings tab (`setTab("settings")`) and exits first-run
+  (`completeFirstRun("settings")`), landing the user where they configure a
+  provider by hand. Both this and `error:settings` route through the same
+  `exitToSettings` helper, latched by `completedRef` so a double-tap can't flip
+  the gate twice.

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -194,6 +194,15 @@ beforeEach(() => {
   ensureLocalStorage().clear();
   vi.clearAllMocks();
   mocks.client.listLocalAgentBackups.mockResolvedValue([]);
+  // `clearAllMocks` resets call history but NOT implementations, so restore the
+  // default resolved implementations that individual tests override (a leaked
+  // `mockRejectedValue`/`mockResolvedValue` would otherwise poison later tests).
+  mocks.client.submitFirstRun.mockResolvedValue(undefined);
+  mocks.client.selectOrProvisionCloudAgent.mockResolvedValue({
+    apiBase: "https://agent.example.test",
+    agentId: "agent-1",
+    created: false,
+  });
   mocks.client.getCloudCompatAgents.mockResolvedValue({
     success: true,
     data: [],
@@ -266,9 +275,9 @@ describe("useFirstRunConductor", () => {
     unmount();
   });
 
-  it("keeps BYOK reachable after the runtime chooser was trimmed to Cloud + On this device: On this device → provider:other routes to the Settings handoff banner without a model download", async () => {
+  it("On this device → provider:other ('configure in Settings') opens the Settings tab and exits first-run without running a finish flow", async () => {
     const spies = seedAppStore();
-    const { turn, unmount } = renderConductor();
+    const { turn, transcript, unmount } = renderConductor();
     const greeting = await waitForTurn(turn, "first-run:greeting");
 
     // The chooser offers three locations — Cloud, On this device, Remote — but
@@ -284,19 +293,28 @@ describe("useFirstRunConductor", () => {
     // The provider sub-choice still offers "Other / configure in Settings" (BYOK).
     expect(provider.text).toContain("__first_run__:provider:other=");
 
+    // Selecting it must actually land the user in Settings and exit onboarding —
+    // NOT run a local finish that could fail and re-loop the questions.
     expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
-    await waitForTurn(turn, "first-run:tutorial");
+    await waitFor(() => {
+      expect(spies.setTab).toHaveBeenCalledWith("settings");
+    });
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("settings");
 
-    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
-    // configure-later wires NO provider: the Settings banner surfaces and no
-    // on-device model download starts.
-    expect(spies.showActionBanner).toHaveBeenCalledTimes(1);
-    expect(spies.showActionBanner.mock.calls[0][0].text).toContain(
-      "model provider in Settings",
-    );
+    // No finish flow ran: no POST, no model download, and no tutorial prompt
+    // (first-run is over — the user is in Settings).
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
     expect(
       mocks.autoDownloadRecommendedLocalModelInBackground,
     ).not.toHaveBeenCalled();
+    expect(transcript.current.some((m) => m.id === "first-run:tutorial")).toBe(
+      false,
+    );
+
+    // A confused double-tap must not flip the gate twice.
+    expect(tryHandleFirstRunAction("__first_run__:provider:other")).toBe(true);
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
     unmount();
   });
 
@@ -546,7 +564,7 @@ describe("useFirstRunConductor", () => {
     unmount();
   });
 
-  it("surfaces a cloud listing failure as an error turn with the runtime CHOICE again, then a LOCAL retry succeeds", async () => {
+  it("surfaces a cloud listing failure as a DISTINCT recovery turn (retry / restart / Settings), and 'restart' → LOCAL succeeds", async () => {
     mocks.client.getCloudCompatAgents.mockRejectedValue(
       new Error("cloud is down"),
     );
@@ -570,11 +588,25 @@ describe("useFirstRunConductor", () => {
     const errorTurn = transcript.current.find((message) =>
       message.id.startsWith("first-run:error:"),
     );
-    // The error turn re-offers the runtime CHOICE so the flow is recoverable.
-    expect(errorTurn?.text).toContain("__first_run__:runtime:local=");
+    // The error turn is a DISTINCT recovery surface — it does NOT silently
+    // re-offer the runtime question (the infinite-loop bug). It offers retry,
+    // restart, and an explicit Settings escape.
+    expect(errorTurn?.text).not.toContain("__first_run__:runtime:local=");
+    expect(errorTurn?.text).toContain("__first_run__:error:retry=");
+    expect(errorTurn?.text).toContain("__first_run__:error:restart=");
+    expect(errorTurn?.text).toContain("__first_run__:error:settings=");
     expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
 
-    // Retry via LOCAL still reaches the tutorial (and the single POST).
+    // "Choose a different way to run" re-offers a fresh runtime choice; picking
+    // LOCAL from it still reaches the tutorial (and the single POST).
+    expect(tryHandleFirstRunAction("__first_run__:error:restart")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
     expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
     await waitForTurn(turn, "first-run:provider");
     expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
@@ -582,6 +614,84 @@ describe("useFirstRunConductor", () => {
     );
     await waitForTurn(turn, "first-run:tutorial");
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("a persistent finish 404 does NOT re-loop the runtime question: the error turn stays distinct, offers retry, and 'Configure in Settings' escapes", async () => {
+    // Simulate the reported bug: POST /api/first-run always 404s ("Not found").
+    mocks.client.submitFirstRun.mockRejectedValue(new Error("Not found"));
+    const spies = seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // Local → on-device → finish 404s → a distinct error turn (NOT the greeting,
+    // NOT a bare runtime prompt).
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(turn, "first-run:provider");
+    expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
+      true,
+    );
+    const firstError = await waitFor(() => {
+      const t = transcript.current.find((m) =>
+        m.id.startsWith("first-run:error:"),
+      );
+      expect(t).toBeTruthy();
+      return t as ConversationMessage;
+    });
+    // Human message, not the raw "Not found"; distinct from the greeting; no
+    // re-looped runtime question.
+    expect(firstError.text).toContain("couldn't finish setting up your agent");
+    expect(firstError.text).not.toBe(turn("first-run:greeting")?.text);
+    expect(firstError.text).not.toContain("__first_run__:runtime:local=");
+
+    // Retry hits the SAME 404 — but each failure produces ONE bounded error
+    // turn, never an unbounded storm of runtime prompts.
+    const errorCountAfterFirst = transcript.current.filter((m) =>
+      m.id.startsWith("first-run:error:"),
+    ).length;
+    expect(errorCountAfterFirst).toBe(1);
+    expect(tryHandleFirstRunAction("__first_run__:error:retry")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.filter((m) => m.id.startsWith("first-run:error:"))
+          .length,
+      ).toBe(2);
+    });
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(2);
+
+    // The guaranteed escape: "Configure in Settings" opens Settings and exits
+    // first-run even though finish never succeeded.
+    expect(tryHandleFirstRunAction("__first_run__:error:settings")).toBe(true);
+    expect(spies.setTab).toHaveBeenCalledWith("settings");
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("settings");
+    unmount();
+  });
+
+  it("error:retry after a CLOUD listing failure re-seeds the OAuth turn and re-runs cloud provisioning (0 agents → auto-provision → tutorial)", async () => {
+    // First listing throws (transport failure), the retry succeeds with 0 agents.
+    mocks.client.getCloudCompatAgents
+      .mockRejectedValueOnce(new Error("cloud is down"))
+      .mockResolvedValue({ success: true, data: [] });
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) => m.id.startsWith("first-run:error:")),
+      ).toBe(true);
+    });
+
+    // "Try again" re-runs the SAME (cloud) flow: it re-seeds the connecting
+    // OAuth turn and calls listing a second time, then auto-provisions.
+    expect(tryHandleFirstRunAction("__first_run__:error:retry")).toBe(true);
+    await waitForTurn(turn, "first-run:tutorial");
+    expect(mocks.client.getCloudCompatAgents).toHaveBeenCalledTimes(2);
+    expect(mocks.client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    expect(turn("first-run:cloud-oauth")?.secretRequest?.status).toBe("saved");
     unmount();
   });
 
@@ -753,10 +863,18 @@ describe("useFirstRunConductor", () => {
       ).toBe(true);
     });
 
-    // The user re-picks LOCAL from the error turn. The original provider turn
-    // still exists (its widget locked itself on the first pick), so the
-    // conductor must seed a FRESH provider turn — otherwise the retry is a
-    // dead end in the real UI.
+    // The user takes "Choose a different way to run" from the error turn, then
+    // re-picks LOCAL. The original provider turn still exists (its widget locked
+    // itself on the first pick), so the conductor must seed a FRESH provider
+    // turn — otherwise the retry is a dead end in the real UI.
+    expect(tryHandleFirstRunAction("__first_run__:error:restart")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((message) =>
+          message.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
     expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
     await waitFor(() => {
       expect(

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -106,11 +106,11 @@ function newestLocalBackup(
 
 // The first-run location chooser: Cloud (managed), On this device, or Remote
 // (connect to an existing agent elsewhere). "Bring your own keys" is NOT a
-// location — it just ran the local backend and pre-highlighted the BYOK
-// inference provider, so it lived on the wrong axis; it stays reachable one step
-// later via the provider sub-choice (provider:other → localInference
-// "configure-later"). Remote picks an already-running agent by URL + token; it
-// owns its own provider, so it skips the provider sub-step.
+// location — it lives one step later on the provider sub-choice as
+// "Other / configure in Settings" (provider:other), which drops the user into
+// the full Settings UI to wire their own provider by hand. Remote picks an
+// already-running agent by URL + token; it owns its own provider, so it skips
+// the provider sub-step.
 const RUNTIME_CHOICE = [
   "[CHOICE:first-run id=runtime]",
   `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
@@ -143,6 +143,37 @@ const TUTORIAL_CHOICE = [
   `${FIRST_RUN_ACTION_PREFIX}tutorial:skip=Skip for now`,
   "[/CHOICE]",
 ].join("\n");
+
+// Recovery choice seeded when a finish/provision flow fails (e.g. a 404 from
+// POST /api/first-run). It replaces the old "re-append the runtime question"
+// behavior — which, on a persistent finish error, re-looped the runtime prompt
+// forever with no explanation and no escape. Every option here is a real way
+// forward: retry the same runtime, pick a different one, or bail out to Settings
+// and configure a provider by hand.
+const ERROR_CHOICE = [
+  "[CHOICE:first-run id=error]",
+  `${FIRST_RUN_ACTION_PREFIX}error:retry=Try again`,
+  `${FIRST_RUN_ACTION_PREFIX}error:restart=Choose a different way to run`,
+  `${FIRST_RUN_ACTION_PREFIX}error:settings=Configure in Settings`,
+  "[/CHOICE]",
+].join("\n");
+
+/**
+ * Turn a raw finish error into a human sentence. The underlying message can be
+ * a terse transport string ("Not found" for a 404, "Failed to fetch", …) that
+ * means nothing to a first-run user; lead with a clear framing and keep the raw
+ * detail for context.
+ */
+function finishErrorMessage(message: string): string {
+  const detail = message.trim();
+  const isTerse = /^(not found|failed to fetch|forbidden|unauthorized)$/i.test(
+    detail,
+  );
+  const lead = isTerse
+    ? `I couldn't finish setting up your agent (${detail}).`
+    : `I couldn't finish setting up your agent: ${detail}`;
+  return `${lead}\n\nYou can try again, pick a different way to run your agent, or configure a model provider yourself in Settings.`;
+}
 
 function cloudOAuthSecretRequest(
   status: ConversationSecretRequest["status"],
@@ -392,15 +423,32 @@ export function useFirstRunConductor(): void {
 
   const seedError = React.useCallback(
     (message: string) => {
+      // A DISTINCT, non-looping error surface. Previously this re-appended the
+      // runtime CHOICE, so a persistent finish error (e.g. the /api/first-run
+      // 404) re-offered the same runtime question forever with no way out. Now
+      // the error turn carries its own recovery choice (retry / restart /
+      // Settings escape) so onboarding is always recoverable.
       seedTurn(
         makeTurn(
           `first-run:error:${Date.now()}`,
-          `${message}\n\n${RUNTIME_CHOICE}`,
+          `${finishErrorMessage(message)}\n\n${ERROR_CHOICE}`,
         ),
       );
     },
     [seedTurn],
   );
+
+  // Explicit, non-finish escape hatch out of onboarding: flip the real gate and
+  // land the user in Settings so they can wire a model provider by hand. Used by
+  // the provider "Other / configure in Settings" pick AND the error-recovery
+  // "Configure in Settings" choice, so a broken finish never traps the user in
+  // the loop. Latched by completedRef so a double-tap can't flip the gate twice.
+  const exitToSettings = React.useCallback(() => {
+    if (completedRef.current) return;
+    completedRef.current = true;
+    setTab("settings");
+    completeFirstRun("settings");
+  }, [setTab, completeFirstRun]);
 
   const seedCloudAgentChoice = React.useCallback(
     (agents: { id?: string; name?: string }[]) => {
@@ -602,7 +650,7 @@ export function useFirstRunConductor(): void {
         }
         // On this device: run the local backend, then ask which model provider.
         // BYOK is the provider:other sub-choice ("Other / configure in
-        // Settings" → localInference "configure-later").
+        // Settings"), which opens Settings and exits first-run.
         draftRef.current = {
           ...draftRef.current,
           runtime: "local",
@@ -664,6 +712,16 @@ export function useFirstRunConductor(): void {
         if (id !== "on-device" && id !== "elizacloud" && id !== "other") {
           return true;
         }
+        if (id === "other") {
+          // "Other / configure in Settings" (bring your own keys): the user
+          // wants the full Settings UI to wire their own provider (Anthropic /
+          // Codex / z.ai / Kimi, …). Take them straight there and exit first-run
+          // instead of running a finish flow — the old path ran a local finish
+          // that, when it failed (e.g. the /api/first-run 404), re-looped the
+          // onboarding questions instead of ever reaching Settings.
+          exitToSettings();
+          return true;
+        }
         if (id === "elizacloud") {
           draftRef.current = {
             ...draftRef.current,
@@ -677,17 +735,6 @@ export function useFirstRunConductor(): void {
             localInference: "cloud-inference",
             agentName: draftRef.current.agentName,
           });
-        } else if (id === "other") {
-          // "Other / configure in Settings" (bring your own keys): run locally
-          // but wire NO provider, so the finish path's `needsProviderSetup`
-          // handoff surfaces the "Open Settings" banner where the user picks a
-          // subscription provider (Anthropic / Codex / z.ai / Kimi). NOT
-          // all-local — that would silently download an on-device model and
-          // suppress the banner.
-          draftRef.current = {
-            ...draftRef.current,
-            localInference: "configure-later",
-          };
         } else {
           // on-device: run every model locally (kicks off the download now).
           draftRef.current = {
@@ -723,6 +770,43 @@ export function useFirstRunConductor(): void {
         return true;
       }
 
+      if (group === "error") {
+        if (id !== "retry" && id !== "restart" && id !== "settings") {
+          return true;
+        }
+        if (id === "settings") {
+          exitToSettings();
+          return true;
+        }
+        if (id === "restart") {
+          // Re-offer a FRESH (unlocked) runtime choice so the user can switch
+          // how their agent runs after a failed finish. seedFreshChoiceTurn
+          // seeds a retry turn when the greeting already exists (the original
+          // runtime widget locked itself on its first pick).
+          seedFreshChoiceTurn(
+            "first-run:greeting",
+            `${GREETING}\n\n${RUNTIME_CHOICE}`,
+          );
+          return true;
+        }
+        // retry: re-run the SAME finish for the runtime the user last chose.
+        // The persist guard released itself on the failed POST, so a local
+        // retry re-POSTs; a cloud retry re-runs provisioning.
+        if (draftRef.current.runtime === "cloud") {
+          const connecting = makeTurn(
+            "first-run:cloud-oauth",
+            "Connecting your Eliza Cloud account…",
+            { secretRequest: cloudOAuthSecretRequest("pending") },
+          );
+          seedTurn(connecting);
+          replaceTurn("first-run:cloud-oauth", connecting);
+          startCloudProvisionFlow();
+          return true;
+        }
+        startProviderFinish();
+        return true;
+      }
+
       if (group === "tutorial") {
         if (id !== "start" && id !== "skip") return true;
         if (completedRef.current) return true;
@@ -745,6 +829,7 @@ export function useFirstRunConductor(): void {
       replaceTurn,
       handleOutcome,
       completeFirstRun,
+      exitToSettings,
       seedError,
       startCloudProvisionFlow,
       startProviderFinish,


### PR DESCRIPTION
Supersedes #11884 with the same first-run recovery fix rebased on current `develop`, preserving the already-merged cloud-login resume behavior from #11899.

## Summary

- Finish/provision failures seed a distinct recovery turn with retry, restart, and Settings actions instead of re-appending the runtime choice and looping.
- `provider:other` exits first-run into Settings instead of running a local finish flow that can fail and trap the user.
- Keeps current durable cloud-login resume markers/tests from `develop` while adding the #11884 recovery behavior.

## Validation

Run from `/home/shaw/eliza-worktrees/pr-11884-first-run`:

- `bun run --cwd packages/core prebuild` — pass
- `bun run --cwd packages/ui test src/first-run/` — pass, 16 files / 199 tests
- `bun run --cwd packages/ui typecheck` — pass
- `bunx @biomejs/biome check packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md packages/ui/src/first-run/use-first-run-conductor.test.ts packages/ui/src/first-run/use-first-run-conductor.ts` — pass
- `git diff --check origin/develop...HEAD` — pass

I could not push the rebase back to `roninjin10/eliza:fix/first-run-loop-configure-settings`; GitHub rejected the fork push with `Authentication required: You must have push access to verify locks` even though the original PR has maintainer edits enabled.