### PR TITLE
fix(ui): restore macOS swipe-back overscroll behavior

### DIFF
--- a/packages/ui/src/styles/overscroll-behavior.test.ts
+++ b/packages/ui/src/styles/overscroll-behavior.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for the macOS trackpad two-finger swipe-back / swipe-forward
+ * navigation gesture in the desktop (Electrobun) webview.
+ *
+ * The gesture is a browser-native back/forward navigation that drives the app's
+ * History API view navigation through the `popstate` listener in
+ * `state/startup-phase-hydrate.ts`. In webviews, a blanket
+ * `overscroll-behavior: none` on the scroll-root ALSO sets `-x: none`, which
+ * suppresses that swipe-to-navigate gesture. The root `html, body` rule must
+ * therefore relax the X axis (`overscroll-behavior-x: auto`) while keeping the
+ * Y axis locked (`overscroll-behavior-y: none`) to preserve the vertical
+ * rubber-band / pull-to-refresh suppression the rule was originally added for.
+ *
+ * Native mobile shells intentionally re-lock BOTH axes via the
+ * higher-specificity `body.native { overscroll-behavior: none }` rule in
+ * base.css — that lock must stay in place.
+ */
+function readStyle(name: string): string {
+  const raw = readFileSync(
+    fileURLToPath(new URL(`./${name}`, import.meta.url)),
+    "utf8",
+  );
+  // Strip CSS comments so their prose (which may contain `}` or the literal
+  // `overscroll-behavior: none` while explaining the rule) can't confuse the
+  // brace-matching or the assertions below.
+  return raw.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Extract the first CSS declaration block whose selector list matches `selector`. */
+function ruleBody(css: string, selector: string): string {
+  const idx = css.indexOf(selector);
+  expect(idx, `selector \`${selector}\` not found`).toBeGreaterThanOrEqual(0);
+  const open = css.indexOf("{", idx);
+  const close = css.indexOf("}", open);
+  expect(open).toBeGreaterThanOrEqual(0);
+  expect(close).toBeGreaterThan(open);
+  return css.slice(open + 1, close);
+}
+
+describe("styles.css root scroll-root overscroll-behavior", () => {
+  const css = readStyle("styles.css");
+  const rootBody = ruleBody(css, "html,\nbody");
+
+  it("relaxes the X axis so the desktop swipe-to-navigate gesture works", () => {
+    expect(rootBody).toMatch(/overscroll-behavior-x:\s*auto/);
+  });
+
+  it("keeps the Y axis locked to preserve vertical bounce/pull-to-refresh suppression", () => {
+    expect(rootBody).toMatch(/overscroll-behavior-y:\s*(none|contain)/);
+  });
+
+  it("does NOT use a blanket `overscroll-behavior: none` on the scroll-root (it would kill the swipe gesture)", () => {
+    expect(rootBody).not.toMatch(/overscroll-behavior:\s*none/);
+  });
+});
+
+describe("base.css native shell keeps both overscroll axes locked", () => {
+  const css = readStyle("base.css");
+
+  it("still locks overscroll-behavior on native (body.native) shells", () => {
+    const nativeBody = ruleBody(
+      css,
+      "body.native,\nbody.platform-ios,\nbody.platform-android",
+    );
+    expect(nativeBody).toMatch(/overscroll-behavior:\s*none/);
+  });
+});

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -46,7 +46,17 @@ body {
   margin: 0;
   background: var(--launch-bg, #ef5a1f);
   overflow: hidden;
-  overscroll-behavior: none;
+  /* Split the axes instead of a blanket `overscroll-behavior: none`.
+     `-y: none` keeps the vertical rubber-band / pull-to-refresh suppression
+     this rule was added for, while `-x: auto` re-enables the macOS trackpad
+     two-finger swipe-to-navigate (back/forward) gesture in the desktop
+     (Electrobun) webview. That native gesture drives the app's History API
+     navigation through the `popstate` listener in
+     state/startup-phase-hydrate.ts. Native mobile shells re-lock BOTH axes via
+     the higher-specificity `body.native { overscroll-behavior: none }` rule in
+     base.css, so this only relaxes the X axis on web + desktop. */
+  overscroll-behavior-x: auto;
+  overscroll-behavior-y: none;
   -webkit-text-size-adjust: 100%;
 }
 


### PR DESCRIPTION
Supersedes #11887. Closes #11886.

## Summary
- Split root overscroll behavior so desktop/web keep `overscroll-behavior-x: auto` while preserving vertical suppression with `overscroll-behavior-y: none`
- Keep native mobile shells fully locked via the existing higher-specificity native rule
- Add a regression test for the root and native overscroll contracts

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/ui test src/styles/overscroll-behavior.test.ts — 4 tests passed
- bun run --cwd packages/ui typecheck
- bunx @biomejs/biome check packages/ui/src/styles/styles.css packages/ui/src/styles/overscroll-behavior.test.ts
- git diff --check origin/develop...HEAD && git diff --check
- bun run --cwd packages/app audit:app — 357 passed; 356 findings good; minimalism-budget-failures=0

## Evidence / N/A
- packages/app/aesthetic-audit-output/report.json from the passing audit run
- N/A: physical macOS two-finger trackpad gesture could not be exercised in this Linux/headless environment; this CSS change is the necessary webview-side unblock, while actual hardware verification must happen on a rebuilt macOS Electrobun app
- N/A: real-LLM trajectories (CSS navigation gesture unblock only); audio (no voice change).