### PR TITLE
fix(plugin-sql): JSON-sanitize backslash corruption + dropped worldId on memory reads + ignored limit param

### DIFF
--- a/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
@@ -77,6 +77,73 @@ describe("Log Integration Tests", () => {
       await expect(adapter.deleteLog(nonExistentId)).resolves.not.toThrow();
     });
 
+    it("honors the `limit` param from the IDatabaseAdapter contract (not just legacy `count`)", async () => {
+      // 15 logs; the pre-fix adapter only read `count` and silently capped any
+      // `limit` caller (runtime.getLogs, agent-export) at the default 10.
+      for (let i = 0; i < 15; i++) {
+        await adapter.log({
+          body: { seq: i },
+          entityId: testEntityId,
+          roomId: testRoomId,
+          type: "limit_test",
+        });
+      }
+
+      const all = await adapter.getLogs({ roomId: testRoomId, limit: 100 });
+      expect(all).toHaveLength(15);
+
+      const capped = await adapter.getLogs({ roomId: testRoomId, limit: 5 });
+      expect(capped).toHaveLength(5);
+
+      // Legacy `count` alias still works
+      const legacy = await adapter.getLogs({ roomId: testRoomId, count: 7 });
+      expect(legacy).toHaveLength(7);
+
+      // No limit provided keeps the historical default of 10
+      const defaulted = await adapter.getLogs({ roomId: testRoomId });
+      expect(defaulted).toHaveLength(10);
+    });
+
+    it("round-trips backslashes in log bodies without double-escaping", async () => {
+      const body = {
+        path: "C:\\Users\\dev\\project",
+        regex: "^\\d+\\q$",
+        unicodeish: "literal \\u12 sequence",
+      };
+      await adapter.log({
+        body,
+        entityId: testEntityId,
+        roomId: testRoomId,
+        type: "backslash_test",
+      });
+
+      const logs = await adapter.getLogs({
+        roomId: testRoomId,
+        type: "backslash_test",
+      });
+      expect(logs).toHaveLength(1);
+      // Pre-fix, sanitizeJsonObject doubled backslashes not followed by
+      // ["\/bfnrtu], so `path` came back as "C:\\\\Users\\dev\\project".
+      expect(logs[0].body).toEqual(body);
+    });
+
+    it("strips NUL characters so the jsonb insert does not fail", async () => {
+      const nul = String.fromCharCode(0);
+      await adapter.log({
+        body: { text: `a${nul}b` },
+        entityId: testEntityId,
+        roomId: testRoomId,
+        type: "nul_test",
+      });
+
+      const logs = await adapter.getLogs({
+        roomId: testRoomId,
+        type: "nul_test",
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].body).toEqual({ text: "ab" });
+    });
+
     it("should filter logs by type", async () => {
       await adapter.log({
         body: { message: "message 1" },

--- a/plugins/plugin-sql/src/__tests__/integration/memory-worldid.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-worldid.real.test.ts
@@ -1,0 +1,162 @@
+import {
+  ChannelType,
+  type Entity,
+  type Memory,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+/**
+ * Every memory READ path must return the stored `worldId`.
+ *
+ * Pre-fix, only searchMemoriesByEmbedding mapped `worldId` back onto the
+ * returned Memory; getMemories / getMemoriesByRoomIds / getMemoryById /
+ * getMemoriesByIds silently dropped it, so consumers that round-trip a
+ * fetched memory (e.g. agent-export -> restore, which remaps `mem.worldId`)
+ * permanently lost every memory→world association.
+ */
+describe("Memory worldId round-trip", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let testAgentId: UUID;
+  let testRoomId: UUID;
+  let testEntityId: UUID;
+  let testWorldId: UUID;
+  let memoryId: UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("memory_worldid_tests");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    testAgentId = setup.testAgentId;
+
+    testRoomId = v4() as UUID;
+    testEntityId = v4() as UUID;
+    testWorldId = v4() as UUID;
+
+    await adapter.createWorld({
+      id: testWorldId,
+      agentId: testAgentId,
+      name: "WorldId Test World",
+      serverId: "test-server",
+    } as World);
+    await adapter.createRooms([
+      {
+        id: testRoomId,
+        agentId: testAgentId,
+        worldId: testWorldId,
+        name: "WorldId Test Room",
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+    ]);
+    await adapter.createEntities([
+      {
+        id: testEntityId,
+        agentId: testAgentId,
+        names: ["WorldId Test Entity"],
+      } as Entity,
+    ]);
+    await adapter.addParticipant(testEntityId, testRoomId);
+
+    memoryId = await adapter.createMemory(
+      {
+        id: v4() as UUID,
+        entityId: testEntityId,
+        agentId: testAgentId,
+        roomId: testRoomId,
+        worldId: testWorldId,
+        content: { text: "memory with a world" },
+      } as Memory,
+      "messages"
+    );
+  });
+
+  afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  it("getMemories returns worldId (embedding branch)", async () => {
+    const memories = await adapter.getMemories({
+      tableName: "messages",
+      roomId: testRoomId,
+    });
+    expect(memories).toHaveLength(1);
+    expect(memories[0].worldId).toBe(testWorldId);
+  });
+
+  it("getMemories returns worldId (includeEmbedding: false branch)", async () => {
+    const memories = await adapter.getMemories({
+      tableName: "messages",
+      roomId: testRoomId,
+      includeEmbedding: false,
+    });
+    expect(memories).toHaveLength(1);
+    expect(memories[0].worldId).toBe(testWorldId);
+  });
+
+  it("getMemories filtered by worldId returns rows that carry that worldId", async () => {
+    const memories = await adapter.getMemories({
+      tableName: "messages",
+      worldId: testWorldId,
+    });
+    expect(memories).toHaveLength(1);
+    expect(memories[0].worldId).toBe(testWorldId);
+  });
+
+  it("getMemoryById returns worldId", async () => {
+    const memory = await adapter.getMemoryById(memoryId);
+    expect(memory).not.toBeNull();
+    expect(memory?.worldId).toBe(testWorldId);
+  });
+
+  it("getMemoriesByIds returns worldId", async () => {
+    const memories = await adapter.getMemoriesByIds([memoryId], "messages");
+    expect(memories).toHaveLength(1);
+    expect(memories[0].worldId).toBe(testWorldId);
+  });
+
+  it("getMemoriesByRoomIds returns worldId", async () => {
+    const memories = await adapter.getMemoriesByRoomIds({
+      roomIds: [testRoomId],
+      tableName: "messages",
+    });
+    expect(memories).toHaveLength(1);
+    expect(memories[0].worldId).toBe(testWorldId);
+  });
+
+  it("keeps worldId undefined for memories stored without one", async () => {
+    const noWorldRoomId = v4() as UUID;
+    await adapter.createRooms([
+      {
+        id: noWorldRoomId,
+        agentId: testAgentId,
+        name: "No-World Room",
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+    ]);
+    const noWorldMemoryId = await adapter.createMemory(
+      {
+        id: v4() as UUID,
+        entityId: testEntityId,
+        agentId: testAgentId,
+        roomId: noWorldRoomId,
+        content: { text: "memory without a world" },
+      } as Memory,
+      "messages"
+    );
+
+    const memory = await adapter.getMemoryById(noWorldMemoryId);
+    expect(memory).not.toBeNull();
+    expect(memory?.worldId).toBeUndefined();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeJsonObject } from "../../utils";
+
+/**
+ * Unit tests for sanitizeJsonObject.
+ *
+ * The sanitized value is always serialized with JSON.stringify before being
+ * bound as a `$1::jsonb` parameter, so JSON escaping is already handled by
+ * the serializer. sanitizeJsonObject must therefore:
+ *  - strip NUL characters (PostgreSQL/PGlite jsonb rejects the `\u0000`
+ *    escape JSON.stringify emits for them), and
+ *  - break circular references,
+ * and it must NOT rewrite anything else. The previous implementation also
+ * doubled every backslash not followed by ["\/bfnrtu] and mangled non-hex
+ * `\u` sequences, so a value like "C:\Users" was stored and read back as
+ * "C:\\Users" — silent corruption of any string containing a backslash.
+ */
+describe("sanitizeJsonObject", () => {
+  it("preserves backslashes exactly (no double-escaping)", () => {
+    // "C:\Users\dev" — backslash followed by chars outside ["\/bfnrtu]
+    const windowsPath = "C:\\Users\\dev";
+    expect(sanitizeJsonObject(windowsPath)).toBe(windowsPath);
+
+    // backslash followed by a char INSIDE the old allowlist must also survive
+    const escaped = "a\\b and a\\n tail";
+    expect(sanitizeJsonObject(escaped)).toBe(escaped);
+
+    // regex source strings are a common log payload
+    const regexSource = "^\\d+\\.\\d+$ plus \\q and a trailing backslash \\";
+    expect(sanitizeJsonObject(regexSource)).toBe(regexSource);
+  });
+
+  it("preserves literal \\u sequences that are not 4-hex escapes", () => {
+    const value = "literal \\u12 and \\uBEEF and \\u{1F600}";
+    expect(sanitizeJsonObject(value)).toBe(value);
+  });
+
+  it("round-trips through JSON.stringify/JSON.parse unchanged", () => {
+    const body = {
+      path: "C:\\Users\\dev\\project",
+      regex: "\\q\\z",
+      note: "plain text",
+      nested: { arr: ["\\x", 1, true, null] },
+    };
+    const sanitized = sanitizeJsonObject(body);
+    expect(JSON.parse(JSON.stringify(sanitized))).toEqual(body);
+  });
+
+  it("strips NUL characters from string values and object keys", () => {
+    const nul = String.fromCharCode(0);
+    expect(sanitizeJsonObject(`a${nul}b`)).toBe("ab");
+
+    const sanitized = sanitizeJsonObject({ [`k${nul}ey`]: `v${nul}al` }) as Record<string, string>;
+    expect(sanitized).toEqual({ key: "val" });
+  });
+
+  it("passes through null, undefined, numbers, and booleans", () => {
+    expect(sanitizeJsonObject(null)).toBeNull();
+    expect(sanitizeJsonObject(undefined)).toBeUndefined();
+    expect(sanitizeJsonObject(42)).toBe(42);
+    expect(sanitizeJsonObject(false)).toBe(false);
+  });
+
+  it("recurses into arrays and objects", () => {
+    const input = { list: ["C:\\tmp", { inner: "\\q" }] };
+    expect(sanitizeJsonObject(input)).toEqual(input);
+  });
+
+  it("breaks circular references by replacing the repeated object with null", () => {
+    const obj: Record<string, unknown> = { name: "loop" };
+    obj.self = obj;
+    const sanitized = sanitizeJsonObject(obj) as Record<string, unknown>;
+    expect(sanitized.name).toBe("loop");
+    expect(sanitized.self).toBeNull();
+    // Must be serializable after the cycle is broken
+    expect(() => JSON.stringify(sanitized)).not.toThrow();
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1510,6 +1510,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: memoryTable.entityId,
         agentId: memoryTable.agentId,
         roomId: memoryTable.roomId,
+        worldId: memoryTable.worldId,
         unique: memoryTable.unique,
         metadata: memoryTable.metadata,
       };
@@ -1521,6 +1522,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: string;
         agentId: string;
         roomId: string;
+        worldId: string | null;
         unique: boolean;
         metadata: unknown;
       };
@@ -1532,6 +1534,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: m.entityId as UUID,
         agentId: m.agentId as UUID,
         roomId: m.roomId as UUID,
+        // Include worldId (matching searchMemoriesByEmbedding): dropping it here
+        // stripped the world association from every read — e.g. agent-export
+        // round-trips silently lost memory→world links on restore.
+        worldId: (m.worldId ?? undefined) as UUID | undefined,
         unique: m.unique,
         metadata: m.metadata as MemoryMetadata,
         embedding: embedding ? Array.from(embedding) : undefined,
@@ -1636,6 +1642,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           entityId: memoryTable.entityId,
           agentId: memoryTable.agentId,
           roomId: memoryTable.roomId,
+          worldId: memoryTable.worldId,
           unique: memoryTable.unique,
           metadata: memoryTable.metadata,
         })
@@ -1662,6 +1669,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: row.entityId as UUID,
         agentId: row.agentId as UUID,
         roomId: row.roomId as UUID,
+        worldId: (row.worldId ?? undefined) as UUID | undefined,
         unique: row.unique,
         metadata: row.metadata,
       })) as Memory[];
@@ -1698,6 +1706,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: row.memory.entityId as UUID,
         agentId: row.memory.agentId as UUID,
         roomId: row.memory.roomId as UUID,
+        worldId: (row.memory.worldId ?? undefined) as UUID | undefined,
         unique: row.memory.unique,
         metadata: row.memory.metadata as MemoryMetadata,
         embedding: row.embedding ?? undefined,
@@ -1742,6 +1751,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         entityId: row.memory.entityId as UUID,
         agentId: row.memory.agentId as UUID,
         roomId: row.memory.roomId as UUID,
+        worldId: (row.memory.worldId ?? undefined) as UUID | undefined,
         unique: row.memory.unique,
         metadata: row.memory.metadata as MemoryMetadata,
         embedding: row.embedding ?? undefined,
@@ -1887,8 +1897,16 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   }
 
   /**
-   * Sanitizes a JSON object by replacing problematic Unicode escape sequences
-   * that could cause errors during JSON serialization/storage
+   * Sanitizes a JSON object for jsonb storage: strips NUL characters (which
+   * PostgreSQL/PGlite jsonb rejects as the `\u0000` escape) and breaks
+   * circular references.
+   *
+   * WHY nothing else is rewritten: the sanitized value is serialized with
+   * JSON.stringify, which already escapes backslashes and control characters
+   * correctly. This function used to ALSO double every backslash not followed
+   * by ["\/bfnrtu] and mangle non-hex `\u` sequences, so a body value like
+   * "C:\Users" was stored (and read back) as "C:\\Users" — silent data
+   * corruption of any string containing a backslash.
    *
    * @param value - The value to sanitize
    * @returns The sanitized value
@@ -1899,16 +1917,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     }
 
     if (typeof value === "string") {
-      // Handle multiple cases that can cause PostgreSQL/PgLite JSON parsing errors:
-      // 1. Remove null bytes (U+0000) which are not allowed in PostgreSQL text fields
-      // 2. Escape single backslashes that might be interpreted as escape sequences
-      // 3. Fix broken Unicode escape sequences (\u not followed by 4 hex digits)
-      const nullChar = String.fromCharCode(0);
-      const nullCharRegex = new RegExp(nullChar, "g");
-      return value
-        .replace(nullCharRegex, "") // Remove null bytes
-        .replace(/\\(?!["\\/bfnrtu])/g, "\\\\") // Escape single backslashes not part of valid escape sequences
-        .replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u"); // Fix malformed Unicode escape sequences
+      return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
     }
 
     if (typeof value === "object") {
@@ -1922,13 +1931,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         return value.map((item) => this.sanitizeJsonObject(item, seen));
       } else {
         const result: Record<string, unknown> = {};
-        const nullChar = String.fromCharCode(0);
-        const nullCharRegex = new RegExp(nullChar, "g");
         for (const [key, val] of Object.entries(value)) {
           // Also sanitize object keys
           const sanitizedKey =
             typeof key === "string"
-              ? key.replace(nullCharRegex, "").replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u")
+              ? key.replace(new RegExp(String.fromCharCode(0), "g"), "")
               : key;
           result[sanitizedKey] = this.sanitizeJsonObject(val, seen);
         }
@@ -1945,7 +1952,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
    * @param {UUID} params.entityId - The ID of the entity associated with the logs.
    * @param {UUID} [params.roomId] - The ID of the room associated with the logs.
    * @param {string} [params.type] - The type of the logs to retrieve.
-   * @param {number} [params.count] - The maximum number of logs to retrieve.
+   * @param {number} [params.limit] - The maximum number of logs to retrieve (`count` is a legacy alias).
    * @param {number} [params.offset] - The offset to retrieve logs from.
    * @returns {Promise<Log[]>} A Promise that resolves to an array of logs.
    */
@@ -1953,10 +1960,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     entityId?: UUID;
     roomId?: UUID;
     type?: string;
+    limit?: number;
     count?: number;
     offset?: number;
   }): Promise<Log[]> {
-    const { entityId, roomId, type, count, offset } = params;
+    const { entityId, roomId, type, offset } = params;
+    // Honor `limit` (the IDatabaseAdapter contract param — see
+    // types/database.ts getLogs) with `count` as a legacy alias, matching
+    // getMemories. Reading only `count` meant every caller passing `limit`
+    // (runtime.getLogs, agent-export's `getLogs({ limit: MAX_SAFE_INTEGER })`)
+    // silently fell back to the default 10 rows.
+    const effectiveLimit = params.limit ?? params.count ?? 10;
 
     // Use withEntityContext for RLS only when entityId is provided
     // Without entityId, bypass RLS to see all logs (for non-RLS mode)
@@ -1971,7 +1985,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           )
         )
         .orderBy(desc(logTable.createdAt))
-        .limit(count ?? 10)
+        .limit(effectiveLimit)
         .offset(offset ?? 0);
 
       const logs = result.map((log) => ({

--- a/plugins/plugin-sql/src/stores/log.store.ts
+++ b/plugins/plugin-sql/src/stores/log.store.ts
@@ -78,10 +78,14 @@ export class LogStore implements Store {
     entityId?: UUID;
     roomId?: UUID;
     type?: string;
+    limit?: number;
     count?: number;
     offset?: number;
   }): Promise<Log[]> {
-    const { entityId, roomId, type, count, offset } = params;
+    const { entityId, roomId, type, offset } = params;
+    // Honor `limit` (the IDatabaseAdapter contract param) with `count` as a
+    // legacy alias, matching BaseDrizzleAdapter.getLogs.
+    const effectiveLimit = params.limit ?? params.count ?? 10;
 
     return this.ctx.withIsolationContext(entityId ?? null, async (tx) => {
       const result = await tx
@@ -94,7 +98,7 @@ export class LogStore implements Store {
           )
         )
         .orderBy(desc(logTable.createdAt))
-        .limit(count ?? 10)
+        .limit(effectiveLimit)
         .offset(offset ?? 0);
 
       return result.map((log) => ({

--- a/plugins/plugin-sql/src/utils.browser.ts
+++ b/plugins/plugin-sql/src/utils.browser.ts
@@ -16,12 +16,14 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
-    return value
-      .replace(nullCharRegex, "")
-      .replace(/\\(?!["\\/bfnrtu])/g, "\\\\")
-      .replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u");
+    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting --
+    // the sanitized value is serialized with JSON.stringify, which already
+    // escapes backslashes and control characters correctly. (This function
+    // used to double every backslash not followed by ["\/bfnrtu] and mangle
+    // non-hex `\u` sequences, so a value like "C:\Users" came back as
+    // "C:\\Users" after a write/read round-trip -- silent data corruption.)
+    return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
   if (typeof value === "object") {
@@ -35,13 +37,9 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     }
 
     const result: Record<string, unknown> = {};
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
     for (const [key, val] of Object.entries(value)) {
       const sanitizedKey =
-        typeof key === "string"
-          ? key.replace(nullCharRegex, "").replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u")
-          : key;
+        typeof key === "string" ? key.replace(new RegExp(String.fromCharCode(0), "g"), "") : key;
       result[sanitizedKey] = sanitizeJsonObject(val, seen);
     }
     return result;

--- a/plugins/plugin-sql/src/utils.node.ts
+++ b/plugins/plugin-sql/src/utils.node.ts
@@ -60,12 +60,14 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
-    return value
-      .replace(nullCharRegex, "")
-      .replace(/\\(?!["\\/bfnrtu])/g, "\\\\")
-      .replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u");
+    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting --
+    // the sanitized value is serialized with JSON.stringify, which already
+    // escapes backslashes and control characters correctly. (This function
+    // used to double every backslash not followed by ["\/bfnrtu] and mangle
+    // non-hex `\u` sequences, so a value like "C:\Users" came back as
+    // "C:\\Users" after a write/read round-trip -- silent data corruption.)
+    return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
   if (typeof value === "object") {
@@ -79,13 +81,9 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     }
 
     const result: Record<string, unknown> = {};
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
     for (const [key, val] of Object.entries(value)) {
       const sanitizedKey =
-        typeof key === "string"
-          ? key.replace(nullCharRegex, "").replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u")
-          : key;
+        typeof key === "string" ? key.replace(new RegExp(String.fromCharCode(0), "g"), "") : key;
       result[sanitizedKey] = sanitizeJsonObject(val, seen);
     }
     return result;

--- a/plugins/plugin-sql/src/utils.ts
+++ b/plugins/plugin-sql/src/utils.ts
@@ -60,12 +60,14 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
-    return value
-      .replace(nullCharRegex, "")
-      .replace(/\\(?!["\\/bfnrtu])/g, "\\\\")
-      .replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u");
+    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting —
+    // the sanitized value is serialized with JSON.stringify, which already
+    // escapes backslashes and control characters correctly. (This function
+    // used to double every backslash not followed by ["\/bfnrtu] and mangle
+    // non-hex `\u` sequences, so a value like "C:\Users" came back as
+    // "C:\\Users" after a write/read round-trip — silent data corruption.)
+    return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 
   if (typeof value === "object") {
@@ -79,13 +81,9 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
     }
 
     const result: Record<string, unknown> = {};
-    const nullChar = String.fromCharCode(0);
-    const nullCharRegex = new RegExp(nullChar, "g");
     for (const [key, val] of Object.entries(value)) {
       const sanitizedKey =
-        typeof key === "string"
-          ? key.replace(nullCharRegex, "").replace(/\\u(?![0-9a-fA-F]{4})/g, "\\\\u")
-          : key;
+        typeof key === "string" ? key.replace(new RegExp(String.fromCharCode(0), "g"), "") : key;
       result[sanitizedKey] = sanitizeJsonObject(val, seen);
     }
     return result;


### PR DESCRIPTION
## Summary

Three real storage bugs in `@elizaos/plugin-sql`, found by auditing the adapter read/write paths against the `IDatabaseAdapter` contract, each fixed minimally and proven with a test that fails on the pre-fix code.

### 1. `getLogs` ignored the canonical `limit` param (only read legacy `count`)

- **Contract:** `IDatabaseAdapter.getLogs` (`packages/core/src/types/database.ts`) and `runtime.getLogs` declare `limit`. `BaseDrizzleAdapter.getLogs` read only `count`, so `.limit(count ?? 10)` capped every contract-conformant caller at 10 rows.
- **Concrete failure:** `packages/agent/src/services/agent-export.ts:815` does `db.getLogs({ limit: Number.MAX_SAFE_INTEGER })` to export *all* logs — with this adapter it exported **10**. Repro: insert 15 logs, `getLogs({ limit: 100 })` → 10 rows.
- **Fix:** `effectiveLimit = params.limit ?? params.count ?? 10` (the same limit/count pattern `getMemories` in the same file already uses), mirrored in `stores/log.store.ts`.

### 2. Memory read mappings dropped `worldId`

- `getMemories` (both embedding branches), `getMemoriesByRoomIds`, `getMemoryById`, and `getMemoriesByIds` never selected/mapped `memories.world_id` back onto the returned `Memory`. Only `searchMemoriesByEmbedding` did (it carries an `// Include worldId` comment from a prior fix that missed the other four paths).
- **Concrete failure:** `createMemory({ worldId: W, … })` then `getMemoryById(id).worldId === undefined`. Agent export → restore (`agent-export.ts:1014` remaps `mem.worldId`) permanently lost every memory→world association on round-trip.
- **Fix:** add `worldId` to the selects and row mappings on all four read paths (`worldId: (row.worldId ?? undefined)` — `undefined`, not `null`, for memories stored without a world).

### 3. `sanitizeJsonObject` corrupted stored strings (backslash double-escaping)

- The sanitizer runs **before** `JSON.stringify` (which already escapes backslashes/control chars correctly for the `$1::jsonb` bind), yet it also doubled every backslash not followed by `["\\/bfnrtu]` and rewrote non-hex `\u` sequences.
- **Concrete failure:** `adapter.log({ body: { path: "C:\Users\dev" } })` → `getLogs` returned `"C:\\Users\\dev"` — silent corruption of any log body containing a backslash (Windows paths, regex sources), and inconsistent (`\b` preserved, `\q` doubled). The memory content path in the same file uses plain `JSON.stringify` with no sanitizer and works, proving the escaping was never needed.
- **Fix:** keep the two things that ARE needed — NUL stripping (Postgres/PGlite jsonb rejects the `` escape) and circular-reference breaking — and delete the backslash/`\u` mangling. Applied identically to all four copies: `base.ts` (the live private copy used by `adapter.log`), `utils.ts`, `utils.node.ts`, `utils.browser.ts`.

## Evidence

| Test | Post-fix | Pre-fix (mutation check: sources reverted to `origin/develop`, tests kept) |
|---|---|---|
| `__tests__/integration/log.real.test.ts` (real PGlite, 6 tests) | 6/6 pass | `limit` test and backslash round-trip test **fail** (2/6) |
| `__tests__/integration/memory-worldid.real.test.ts` (real PGlite, 7 tests) | 7/7 pass | 6/7 **fail** (all worldId assertions) |
| `__tests__/unit/sanitize-json.test.ts` (pure, 7 tests) | 7/7 pass | 4/7 **fail** (backslash/`\u`/round-trip/recursion) |
| Regression: plugin-sql default suite | 57/57 pass | — |
| Regression: `memory.real.test.ts` (real PGlite) | 29/29 pass | — |
| `bun run --cwd plugins/plugin-sql typecheck` (tsgo) | clean | — |
| `bunx biome check` on all changed files | clean | — |

The `*.real.test.ts` suites run against a **real PGlite database** through the actual `PgliteDatabaseAdapter` (via `createIsolatedTestDatabase`, incl. full plugin migrations) — actual rows written and read back, not mocks. Run them with `cd plugins/plugin-sql/src && bunx vitest run --config vitest.real.config.ts __tests__/integration/log.real.test.ts __tests__/integration/memory-worldid.real.test.ts`.

- Screenshots / video walkthrough: **N/A** — backend storage-adapter change with no UI surface.
- Live-LLM trajectory: **N/A** — no agent/action/provider/prompt/model behavior change; pure DB read/write correctness, proven by real-DB round-trip tests above.
- Domain artifacts: the real PGlite rows are written and read back by the tests themselves (log bodies, memories with `world_id`), and asserted byte-exact.

## Not fixed (considered and dropped)

- `getLogs` not filtering by `entityId` (InMemoryDatabaseAdapter filters; SQL adapter uses it only as RLS context) — plausibly intentional, matching `getMemories`' explicit "RLS handles access control" design comment.
- plugin-sql local `stringToUuid` diverging from core's SHA-1 version — only used for self-consistent derived IDs; no cross-component consumer.

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5). The agent audited the adapter read/write paths against the IDatabaseAdapter contract, fixed 3 bugs + wrote their tests, and pushed its own complete version. Main loop independently verified on the final HEAD (710af2f9c4): working tree clean, sanitize unit test 7/7 (--no-cache), sanitize mutation reproduced (revert → 4/7 red), and directly evaluated the fixed function (C:\Users\dev round-trips EQUAL across all variants). The worldId + limit fixes carry their own new real-PGlite suites (memory-worldid.real.test.ts ×7, log.real.test.ts) that CI runs.

The agent also honestly DROPPED 4 candidates it verified were NOT bugs (entityId-filter-by-RLS-design, local string-to-uuid self-consistency, cron day-of-month/week simplification, expandTildePath cwd behavior) — no forced fixes. — [phone-ui]