### PR TITLE
fix(plugin-cloud-apps): DEPLOY_APP gate survives transient/stalled status polls; reachability probe mirrors server redirect rule

### DIFF
--- a/packages/cloud/sdk/src/apps.client.test.ts
+++ b/packages/cloud/sdk/src/apps.client.test.ts
@@ -220,6 +220,30 @@ describe("ElizaCloudClient typed app methods", () => {
     });
   });
 
+  it("getAppDeployStatus + getApp thread a per-request AbortSignal into fetch (deploy-gate poll timeout)", async () => {
+    const seenSignals: Array<AbortSignal | null | undefined> = [];
+    const fetchImpl = (async (_input, init = {}) => {
+      seenSignals.push(init.signal);
+      return new Response(JSON.stringify({ success: true, app: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const client = new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      apiKey: "eliza_test_key",
+      fetchImpl,
+    });
+
+    const controller = new AbortController();
+    await client.getAppDeployStatus("app_1", { signal: controller.signal });
+    await client.getApp("app_1", { signal: controller.signal });
+
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals[0]).toBe(controller.signal);
+    expect(seenSignals[1]).toBe(controller.signal);
+  });
+
   it("deleteApp DELETEs /api/v1/apps/:id", async () => {
     const { client, requests } = createClientRecorder({
       success: true,

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -784,10 +784,19 @@ export class ElizaCloudClient {
     return this.routes.getApiV1Apps<ListAppsResponse>();
   }
 
-  /** `GET /api/v1/apps/:id` — fetch a single app. */
-  getApp(appId: string): Promise<AppResponse> {
+  /**
+   * `GET /api/v1/apps/:id` — fetch a single app. Accepts a per-request
+   * `signal`/`timeoutMs` so long-running pollers (the DEPLOY_APP completion
+   * gate) can bound a stalled connection.
+   */
+  getApp(
+    appId: string,
+    options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
+  ): Promise<AppResponse> {
     return this.routes.getApiV1AppsById<AppResponse>({
       pathParams: { id: appId },
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
     });
   }
 
@@ -829,10 +838,19 @@ export class ElizaCloudClient {
     });
   }
 
-  /** `GET /api/v1/apps/:id/deploy/status` — latest deploy status (poll target). */
-  getAppDeployStatus(appId: string): Promise<AppDeployStatusResponse> {
+  /**
+   * `GET /api/v1/apps/:id/deploy/status` — latest deploy status (poll target).
+   * Accepts a per-request `signal`/`timeoutMs` so a stalled poll can be torn
+   * down instead of hanging the caller's poll loop.
+   */
+  getAppDeployStatus(
+    appId: string,
+    options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
+  ): Promise<AppDeployStatusResponse> {
     return this.routes.getApiV1AppsByIdDeployStatus<AppDeployStatusResponse>({
       pathParams: { id: appId },
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
     });
   }
 

--- a/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
@@ -14,6 +14,7 @@ const FAST_CONFIG: DeployGateConfig = {
   initialDelayMs: 1,
   maxDelayMs: 2,
   probeTimeoutMs: 10,
+  requestTimeoutMs: 50,
   healthPath: "/health",
 };
 
@@ -202,5 +203,146 @@ describe("runDeployGate", () => {
     const result = await runDeployGate(deps, FAST_CONFIG);
     expect(result.phase).toBe("unreachable");
     expect(result.error).toBe("no_production_url");
+  });
+});
+
+describe("runDeployGate — poll robustness (transient errors + per-request timeout)", () => {
+  it("REGRESSION: one throwing status poll does NOT abort the gate — it keeps polling and still resolves READY", async () => {
+    // Poll 1 throws (network blip), poll 2 is BUILDING, poll 3 is READY.
+    let calls = 0;
+    const pollErrors: Array<{ error: unknown; attempt: number }> = [];
+    const responses = [
+      statusRes({ status: "BUILDING" }),
+      statusRes({ status: "READY" }),
+    ];
+    const deps: DeployGateDeps = {
+      getStatus: () => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.reject(new Error("ECONNRESET: transient blip"));
+        }
+        return Promise.resolve(
+          responses[Math.min(calls - 2, responses.length - 1)],
+        );
+      },
+      getApp: () => Promise.resolve(appRes("https://acme.elizacloud.ai")),
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+      onPollError: (error, attempt) => pollErrors.push({ error, attempt }),
+    };
+
+    const result = await runDeployGate(deps, FAST_CONFIG);
+
+    expect(result.phase).toBe("ready");
+    expect(result.url).toBe("https://acme.elizacloud.ai");
+    expect(result.attempts).toBe(3);
+    expect(pollErrors).toHaveLength(1);
+    expect(pollErrors[0]?.attempt).toBe(1);
+    expect((pollErrors[0]?.error as Error).message).toContain("ECONNRESET");
+  });
+
+  it("a stalled status poll is cut off by the per-request timeout (signal aborts) and the gate continues", async () => {
+    // Poll 1 stalls forever unless the abort signal fires; poll 2 is READY.
+    let calls = 0;
+    let sawAbort = false;
+    const pollErrors: unknown[] = [];
+    const deps: DeployGateDeps = {
+      getStatus: (signal) => {
+        calls += 1;
+        if (calls === 1) {
+          // Simulate a signal-honoring fetch: resolve never, reject on abort.
+          return new Promise((_, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                sawAbort = true;
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        }
+        return Promise.resolve(statusRes({ status: "READY" }));
+      },
+      getApp: () => Promise.resolve(appRes("https://acme.elizacloud.ai")),
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+      onPollError: (error) => pollErrors.push(error),
+    };
+
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      requestTimeoutMs: 5,
+    });
+
+    expect(result.phase).toBe("ready");
+    expect(result.attempts).toBe(2);
+    expect(sawAbort).toBe(true);
+    expect(pollErrors).toHaveLength(1);
+    expect((pollErrors[0] as Error).message).toContain("timed out after 5ms");
+  });
+
+  it("even a signal-IGNORING stalled poll cannot hang the gate (raced against the deadline)", async () => {
+    let calls = 0;
+    const deps: DeployGateDeps = {
+      getStatus: () => {
+        calls += 1;
+        if (calls === 1) {
+          return new Promise(() => {}); // never settles, ignores the signal
+        }
+        return Promise.resolve(statusRes({ status: "READY" }));
+      },
+      getApp: () => Promise.resolve(appRes("https://acme.elizacloud.ai")),
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+    };
+
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      requestTimeoutMs: 5,
+    });
+
+    expect(result.phase).toBe("ready");
+    expect(result.attempts).toBe(2);
+  });
+
+  it("every poll failing still returns the HONEST timeout result (never claims done)", async () => {
+    const pollAttempts: number[] = [];
+    const deps: DeployGateDeps = {
+      getStatus: () => Promise.reject(new Error("boom")),
+      getApp: () => Promise.resolve(appRes("https://acme.elizacloud.ai")),
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+      onPollError: (_error, attempt) => pollAttempts.push(attempt),
+    };
+
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      maxAttempts: 3,
+    });
+
+    expect(result.phase).toBe("timeout");
+    expect(result.attempts).toBe(3);
+    expect(pollAttempts).toEqual([1, 2, 3]);
+  });
+
+  it("a stalled app re-read after READY falls back to the status vercelUrl instead of hanging", async () => {
+    const deps: DeployGateDeps = {
+      getStatus: () =>
+        Promise.resolve(
+          statusRes({ status: "READY", vercelUrl: "https://fallback.example" }),
+        ),
+      getApp: () => new Promise(() => {}), // stalls forever
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+    };
+
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      requestTimeoutMs: 5,
+    });
+
+    expect(result.phase).toBe("ready");
+    expect(result.url).toBe("https://fallback.example");
   });
 });

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -55,8 +55,14 @@ import type {
 } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory, Task, UUID } from "@elizaos/core";
 
+/** Per-request options the SDK's poll-friendly app getters accept. */
+type SdkRequestOptions = { signal?: AbortSignal; timeoutMs?: number };
+
 type ListAppsFn = () => Promise<ListAppsResponse>;
-type GetAppFn = (id: string) => Promise<AppResponse>;
+type GetAppFn = (
+  id: string,
+  options?: SdkRequestOptions,
+) => Promise<AppResponse>;
 type CreateAppFn = (input: CreateAppInput) => Promise<CreateAppResponse>;
 type CreateAdSlotFn = (
   input: CreateAdSlotInput,
@@ -103,7 +109,10 @@ type DeployAppFn = (
   id: string,
   input?: DeployAppInput,
 ) => Promise<DeployAppResponse>;
-type GetAppDeployStatusFn = (id: string) => Promise<AppDeployStatusResponse>;
+type GetAppDeployStatusFn = (
+  id: string,
+  options?: SdkRequestOptions,
+) => Promise<AppDeployStatusResponse>;
 type DeleteAppFn = (id: string) => Promise<DeleteAppResponse>;
 type UpdateAppFn = (id: string, patch: UpdateAppInput) => Promise<AppResponse>;
 type UpdateMonetizationFn = (
@@ -564,8 +573,8 @@ export class FakeElizaCloudClient {
   listApps(): Promise<ListAppsResponse> {
     return state.listApps();
   }
-  getApp(id: string): Promise<AppResponse> {
-    return state.getApp(id);
+  getApp(id: string, options?: SdkRequestOptions): Promise<AppResponse> {
+    return state.getApp(id, options);
   }
   createApp(input: CreateAppInput): Promise<CreateAppResponse> {
     return state.createApp(input);
@@ -638,8 +647,11 @@ export class FakeElizaCloudClient {
   exportAppBackup(appId: string): Promise<ExportAppBackupResponse> {
     return state.exportAppBackup(appId);
   }
-  getAppDeployStatus(id: string): Promise<AppDeployStatusResponse> {
-    return state.getAppDeployStatus(id);
+  getAppDeployStatus(
+    id: string,
+    options?: SdkRequestOptions,
+  ): Promise<AppDeployStatusResponse> {
+    return state.getAppDeployStatus(id, options);
   }
   deleteApp(id: string): Promise<DeleteAppResponse> {
     return state.deleteApp(id);

--- a/plugins/plugin-cloud-apps/__tests__/reachability.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reachability.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type FetchLike,
+  healthUrl,
+  probeReachable,
+  respondedLive,
+} from "../src/reachability.ts";
+
+describe("healthUrl", () => {
+  it("joins base + path, collapsing slashes", () => {
+    expect(healthUrl("https://acme.elizacloud.ai")).toBe(
+      "https://acme.elizacloud.ai/health",
+    );
+    expect(healthUrl("https://acme.elizacloud.ai///", "health")).toBe(
+      "https://acme.elizacloud.ai/health",
+    );
+    expect(healthUrl("https://acme.elizacloud.ai", "/status")).toBe(
+      "https://acme.elizacloud.ai/status",
+    );
+  });
+});
+
+describe("respondedLive", () => {
+  it("counts any completed non-gateway status as live (server's isReachableStatus rule)", () => {
+    for (const status of [200, 204, 301, 302, 307, 308, 401, 403, 404, 500]) {
+      expect(respondedLive({ ok: status < 300, status })).toBe(true);
+    }
+  });
+
+  it("counts Caddy gateway errors and no-response as NOT live", () => {
+    for (const status of [502, 503, 504]) {
+      expect(respondedLive({ ok: false, status })).toBe(false);
+    }
+    expect(respondedLive({ ok: false, error: "ECONNREFUSED" })).toBe(false);
+  });
+});
+
+describe("probeReachable", () => {
+  it("resolves ok:true with the status for a 2xx response", async () => {
+    const result = await probeReachable("https://app.example/health", {
+      fetchImpl: () => Promise.resolve({ ok: true, status: 200 }),
+    });
+    expect(result).toEqual({ ok: true, status: 200 });
+  });
+
+  it("REGRESSION: does NOT follow redirects — mirrors the server's probe (redirect: manual)", async () => {
+    // A redirecting /health used to be chased with redirect:"follow"; if the
+    // redirect target failed, the client probe contradicted the server's READY
+    // with a false "not live". The server's probeUrlReachable uses
+    // redirect:"manual" and treats the 3xx itself as "the app answered".
+    let seenInit: Parameters<FetchLike>[1];
+    const result = await probeReachable("https://app.example/health", {
+      fetchImpl: (_url, init) => {
+        seenInit = init;
+        return Promise.resolve({ ok: false, status: 302 });
+      },
+    });
+
+    expect(seenInit?.redirect).toBe("manual");
+    expect(seenInit?.method).toBe("GET");
+    expect(result.status).toBe(302);
+    // The gate's live rule must count the redirect as "the app answered".
+    expect(respondedLive(result)).toBe(true);
+  });
+
+  it("resolves ok:false with the status (not an error) for auth gates and 404s", async () => {
+    const result = await probeReachable("https://app.example/health", {
+      fetchImpl: () => Promise.resolve({ ok: false, status: 401 }),
+    });
+    expect(result).toEqual({ ok: false, status: 401 });
+    expect(respondedLive(result)).toBe(true);
+  });
+
+  it("never throws: a network error resolves to ok:false with no status", async () => {
+    const result = await probeReachable("https://app.example/health", {
+      fetchImpl: () => Promise.reject(new Error("ECONNREFUSED")),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(result.error).toBe("ECONNREFUSED");
+    expect(respondedLive(result)).toBe(false);
+  });
+
+  it("a stalled probe is aborted at timeoutMs and resolves ok:false (no hang)", async () => {
+    const result = await probeReachable("https://app.example/health", {
+      timeoutMs: 5,
+      // Signal-honoring stalled fetch: never resolves, rejects on abort.
+      fetchImpl: (_url, init) =>
+        new Promise((_, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new Error("aborted")),
+            { once: true },
+          );
+        }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeUndefined();
+    expect(respondedLive(result)).toBe(false);
+  });
+});

--- a/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
@@ -188,10 +188,21 @@ export const deployAppAction: Action = {
     const config: DeployGateConfig = DEFAULT_DEPLOY_GATE_CONFIG;
     const result = await runDeployGate(
       {
-        getStatus: () => client.getAppDeployStatus(target.id),
-        getApp: () => client.getApp(target.id),
+        // Thread the gate's per-poll abort signal into the HTTP request so a
+        // stalled connection is torn down at the requestTimeoutMs budget.
+        getStatus: (signal) => client.getAppDeployStatus(target.id, { signal }),
+        getApp: (signal) => client.getApp(target.id, { signal }),
         probe: (url) =>
           probeReachable(url, { timeoutMs: config.probeTimeoutMs }),
+        // A transient poll failure never aborts the gate — log and keep polling.
+        onPollError: (err, attempt) =>
+          logger.warn(
+            `[DEPLOY_APP] status poll ${attempt}/${config.maxAttempts} for ${
+              target.id
+            } failed (deploy continues server-side; will keep polling): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          ),
       },
       config,
     );

--- a/plugins/plugin-cloud-apps/src/deploy-gate.ts
+++ b/plugins/plugin-cloud-apps/src/deploy-gate.ts
@@ -13,6 +13,15 @@
  *      auth-gated 401/403 app, or one with no `/health` route, is still live).
  * Only when BOTH pass do we report the app live.
  *
+ * ROBUSTNESS: the deploy is already running server-side once the gate starts,
+ * so a transient status-poll failure (network blip, 5xx, HTTP timeout) must
+ * NOT abort the gate — it is logged via `onPollError` and the gate keeps
+ * polling until the overall attempt budget runs out, at which point it returns
+ * the honest "still building" timeout result (never a claim of done). Every
+ * poll is also bounded by a per-request timeout (`requestTimeoutMs`): the dep
+ * receives an AbortSignal to tear down the stalled connection, and the gate
+ * additionally races the call so even a signal-ignoring dep can never wedge it.
+ *
  * The gate is pure and fully injectable (status fetch, app fetch, probe, sleep)
  * so it can be unit-tested against a mocked status progression + reachability —
  * which is the proof for now: a real end-to-end deploy cannot be verified until
@@ -52,21 +61,41 @@ export interface DeployGateConfig {
   maxDelayMs: number;
   /** Per-probe HTTP timeout passed through to the reachability probe (ms). */
   probeTimeoutMs: number;
+  /**
+   * Per-request HTTP timeout for each Cloud API call the gate makes (the status
+   * poll + the app re-read), so one stalled connection can never hang a poll —
+   * let alone the gate — indefinitely.
+   */
+  requestTimeoutMs: number;
   /** Health path probed after READY. */
   healthPath: string;
 }
 
 export interface DeployGateDeps {
-  /** `client.getAppDeployStatus(id)`. */
-  getStatus: () => Promise<AppDeployStatusResponse>;
-  /** `client.getApp(id)` — re-read to get the authoritative production_url. */
-  getApp: () => Promise<AppResponse>;
+  /**
+   * `client.getAppDeployStatus(id)` — thread the per-poll `signal` into the
+   * HTTP request so a stalled connection is actually torn down at the
+   * `requestTimeoutMs` budget (the gate also races the call, so a dep that
+   * ignores the signal still can't hang it).
+   */
+  getStatus: (signal: AbortSignal) => Promise<AppDeployStatusResponse>;
+  /**
+   * `client.getApp(id)` — re-read to get the authoritative production_url.
+   * Receives the same per-request abort signal as `getStatus`.
+   */
+  getApp: (signal: AbortSignal) => Promise<AppResponse>;
   /** Probe a fully-qualified URL for reachability. */
   probe: (url: string) => Promise<ReachabilityResult>;
   /** Sleep between polls (injected so tests run instantly). */
   sleep?: (ms: number) => Promise<void>;
   /** Optional progress hook for streaming "still building…" updates. */
   onProgress?: (status: string, attempt: number) => void;
+  /**
+   * Optional hook fired when one status poll fails transiently (network error,
+   * HTTP timeout). The gate logs-and-continues — it never aborts on a poll
+   * error, because the deploy is still running server-side.
+   */
+  onPollError?: (error: unknown, attempt: number) => void;
 }
 
 /** Production defaults: ~ up to ~2 min of polling with capped backoff. */
@@ -75,6 +104,7 @@ export const DEFAULT_DEPLOY_GATE_CONFIG: DeployGateConfig = {
   initialDelayMs: 2_000,
   maxDelayMs: 10_000,
   probeTimeoutMs: 10_000,
+  requestTimeoutMs: 10_000,
   healthPath: "/health",
 };
 
@@ -107,6 +137,37 @@ function normalizeUrl(value: string | null | undefined): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/**
+ * Run one injected network call under a hard per-request budget. The dep gets
+ * an `AbortSignal` (threaded into `fetch` so the stalled connection is actually
+ * torn down), and the call is ALSO raced against the same deadline — so even an
+ * implementation that ignores the signal can never hang the gate.
+ */
+function callWithTimeout<T>(
+  call: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () =>
+      controller.abort(new Error(`${label} timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  const deadline = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => reject(controller.signal.reason),
+      { once: true },
+    );
+  });
+  const attempt = Promise.resolve(call(controller.signal));
+  // If the deadline wins, the in-flight call may still reject later (e.g. the
+  // aborted fetch) — swallow that so it never surfaces as an unhandled rejection.
+  attempt.catch(() => {});
+  return Promise.race([attempt, deadline]).finally(() => clearTimeout(timer));
+}
+
 export async function runDeployGate(
   deps: DeployGateDeps,
   config: DeployGateConfig = DEFAULT_DEPLOY_GATE_CONFIG,
@@ -116,62 +177,44 @@ export async function runDeployGate(
   let delay = config.initialDelayMs;
 
   for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
-    const statusRes = await deps.getStatus();
-    lastStatus = statusRes.status ?? "";
-    deps.onProgress?.(lastStatus, attempt);
-
-    const cls = classifyDeployStatus(lastStatus);
-
-    if (cls === "error") {
-      return {
-        phase: "error",
-        url: normalizeUrl(statusRes.vercelUrl),
-        status: lastStatus,
-        attempts: attempt,
-        error: statusRes.error ?? undefined,
-      };
+    let statusRes: AppDeployStatusResponse | undefined;
+    try {
+      statusRes = await callWithTimeout(
+        deps.getStatus,
+        config.requestTimeoutMs,
+        "deploy status poll",
+      );
+    } catch (err) {
+      // A transient poll failure must NOT abort the gate — the deploy is
+      // already running server-side. Log it and keep polling until the
+      // overall attempt budget runs out (which reports "still building",
+      // never a claim of done).
+      deps.onPollError?.(err, attempt);
     }
 
-    if (cls === "success") {
-      // Authoritative URL is the app row's production_url (deriveAppPublicUrl),
-      // NOT the create/deploy response. Fall back to the status' vercelUrl only
-      // if the re-read fails or hasn't populated production_url yet.
-      let url = normalizeUrl(statusRes.vercelUrl);
-      try {
-        const { app } = await deps.getApp();
-        url = normalizeUrl(app?.production_url) ?? url;
-      } catch {
-        // keep vercelUrl fallback
-      }
-      if (!url) {
+    if (statusRes) {
+      lastStatus = statusRes.status ?? "";
+      deps.onProgress?.(lastStatus, attempt);
+
+      const cls = classifyDeployStatus(lastStatus);
+
+      if (cls === "error") {
         return {
-          phase: "unreachable",
-          url: null,
+          phase: "error",
+          url: normalizeUrl(statusRes.vercelUrl),
           status: lastStatus,
           attempts: attempt,
-          error: "no_production_url",
+          error: statusRes.error ?? undefined,
         };
       }
-      const reachability = await deps.probe(healthUrl(url, config.healthPath));
-      return respondedLive(reachability)
-        ? {
-            phase: "ready",
-            url,
-            status: lastStatus,
-            attempts: attempt,
-            reachability,
-          }
-        : {
-            phase: "unreachable",
-            url,
-            status: lastStatus,
-            attempts: attempt,
-            reachability,
-            error: reachability.error,
-          };
+
+      if (cls === "success") {
+        return finishReady(deps, config, statusRes, lastStatus, attempt);
+      }
     }
 
-    // pending — wait then retry (skip the final wait so the loop exits to timeout)
+    // pending or failed poll — wait then retry (skip the final wait so the
+    // loop exits straight to the honest timeout result)
     if (attempt < config.maxAttempts) {
       await sleep(delay);
       delay = Math.min(delay * 2, config.maxDelayMs);
@@ -184,4 +227,54 @@ export async function runDeployGate(
     status: lastStatus,
     attempts: config.maxAttempts,
   };
+}
+
+/** READY observed — resolve the authoritative URL and run the reachability leg. */
+async function finishReady(
+  deps: DeployGateDeps,
+  config: DeployGateConfig,
+  statusRes: AppDeployStatusResponse,
+  lastStatus: string,
+  attempt: number,
+): Promise<DeployGateResult> {
+  // Authoritative URL is the app row's production_url (deriveAppPublicUrl),
+  // NOT the create/deploy response. Fall back to the status' vercelUrl only
+  // if the re-read fails or hasn't populated production_url yet.
+  let url = normalizeUrl(statusRes.vercelUrl);
+  try {
+    const { app } = await callWithTimeout(
+      deps.getApp,
+      config.requestTimeoutMs,
+      "app re-read",
+    );
+    url = normalizeUrl(app?.production_url) ?? url;
+  } catch {
+    // keep vercelUrl fallback
+  }
+  if (!url) {
+    return {
+      phase: "unreachable",
+      url: null,
+      status: lastStatus,
+      attempts: attempt,
+      error: "no_production_url",
+    };
+  }
+  const reachability = await deps.probe(healthUrl(url, config.healthPath));
+  return respondedLive(reachability)
+    ? {
+        phase: "ready",
+        url,
+        status: lastStatus,
+        attempts: attempt,
+        reachability,
+      }
+    : {
+        phase: "unreachable",
+        url,
+        status: lastStatus,
+        attempts: attempt,
+        reachability,
+        error: reachability.error,
+      };
 }

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -76,8 +76,10 @@ export function respondedLive(result: ReachabilityResult): boolean {
 /**
  * Probe a URL with a bounded HTTP GET. Never throws — a network error or abort
  * resolves to `{ ok: false }` with no `status`; any HTTP response resolves with
- * its `status` (and `ok` reflecting a strict 2xx). Callers that want the
- * server's "the app answered" rule should use {@link respondedLive}.
+ * its `status` (and `ok` reflecting a strict 2xx). Redirects are NOT followed
+ * (same as the server's probe): a 3xx surfaces as its own status, which
+ * {@link respondedLive} counts as live. Callers that want the server's "the app
+ * answered" rule should use {@link respondedLive}.
  */
 export async function probeReachable(
   url: string,
@@ -96,10 +98,17 @@ export async function probeReachable(
     // `app.production_url`, read back from the authenticated Cloud row via
     // `getApp` (Cloud-authoritative first-party origin), never from message text.
     // So a raw bounded GET is acceptable here without the core network SSRF guard.
+    //
+    // `redirect: "manual"` MIRRORS the server's authoritative probe
+    // (`probeUrlReachable` in cloud-shared app-reachability): don't chase
+    // redirects (avoid loops / external hops) — a 3xx already proves the app
+    // answered, and `respondedLive` treats it as live. Following redirects here
+    // let a redirecting `/health` land on a failing target and contradict the
+    // server's READY with a false "not live".
     const res = await fetchImpl(url, {
       method: "GET",
       signal: controller.signal,
-      redirect: "follow",
+      redirect: "manual",
     });
     const ok =
       res.ok === true ||


### PR DESCRIPTION
## Summary

Fixes 2 confirmed demo-path bugs (the "host/deploy an app" flow) in `plugins/plugin-cloud-apps`, from the apps-surface adversarial scan.

### Bug 1 (MED) — DEPLOY_APP gate status polls were uncaught + had no HTTP timeout

`runDeployGate`'s poll loop awaited `deps.getStatus()` bare. One transient poll error (network blip, 5xx) **threw out of the gate and the whole DEPLOY_APP handler**, and a stalled connection hung the poll forever — both AFTER the deploy had already been accepted (202), so the user was told the deploy failed/hung while it was actually still building server-side.

**Fix** (`src/deploy-gate.ts`, `src/actions/deploy-app.ts`):
- Each status poll now runs in a try/catch. A transient failure is reported via the new `onPollError` hook (DEPLOY_APP logs `[DEPLOY_APP] status poll N/24 … will keep polling`) and the gate **continues polling** within the existing overall attempt budget. If the budget runs out it still returns the honest `timeout` → "still building… ask me in a bit" result — it never claims done.
- Every Cloud API call the gate makes (status poll + the READY app re-read) is bounded by a **per-request HTTP timeout** (`requestTimeoutMs`, default 10s): the gate hands the dep an `AbortSignal` (threaded through the SDK into `fetch`, so the stalled connection is actually torn down) **and** races the call against the same deadline, so even a signal-ignoring dep can't wedge the gate.
- SDK enabler (`packages/cloud/sdk/src/client.ts`): `getApp` / `getAppDeployStatus` accept an optional per-request `{ signal, timeoutMs }`, forwarded to the existing `CloudRequestOptions` (additive — no callsite changes required).

### Bug 2 (LOW) — client reachability probe followed redirects; the server's authoritative probe does not

`probeReachable` used `redirect: "follow"`, while the server's probe that marks the app READY (`probeUrlReachable` in `packages/cloud/shared/src/lib/services/app-reachability.ts`) uses `redirect: "manual"` and counts a 3xx as reachable via `isReachableStatus`. A redirecting `/health` could be chased to a failing target and make the gate contradict the server's READY with a false "not live".

**Fix** (`src/reachability.ts`): the client probe now uses `redirect: "manual"`, mirroring the server — the 3xx surfaces as its own status, and `respondedLive` (which already excludes only the 502/503/504 gateway-down family) counts it as live.

## Tests

`__tests__/deploy-gate.test.ts` (new "poll robustness" suite):
- a poll that throws once → gate continues and still resolves READY (attempts=3, `onPollError` fired once)
- a **signal-honoring** stalled poll → aborted at `requestTimeoutMs` (signal really fires), gate continues to READY
- a **signal-ignoring** stalled poll → deadline race still prevents any hang
- every poll failing → honest `timeout` result after `maxAttempts` (never claims done)
- a stalled READY-time app re-read → falls back to the status `vercelUrl` instead of hanging

`__tests__/reachability.test.ts` (new file):
- REGRESSION: probe sends `redirect: "manual"`; a 302 resolves with its own status and `respondedLive` counts it live
- auth-gate 401 / 404 live; network error + per-request timeout not live; `respondedLive` full status matrix; `healthUrl` joins

`packages/cloud/sdk/src/apps.client.test.ts`: `getAppDeployStatus` + `getApp` thread the per-request `AbortSignal` into `fetch`.

## Evidence

- `bun test plugins/plugin-cloud-apps` → **334 pass / 0 fail** (29 files)
- `bun test packages/cloud/sdk/src/apps.client.test.ts src/client.test.ts` → 38 pass / 0 fail
- `tsgo --noEmit` clean for `plugins/plugin-cloud-apps` + `packages/cloud/sdk`
- `bunx @biomejs/biome@2.5.1 check` on all 8 changed files: clean
- Real-LLM trajectory: N/A — no prompt/action-description change; behavior change is inside the pure, injectable gate + probe, proven by the unit suites above. A real end-to-end deploy still can't be exercised until the staging deploy backend is armed (#9853 / Phase 4), same as the gate's existing proof standard.
- UI proof: N/A — no rendered surface changed; user-visible effect is the honest "still building" text on transient poll failure (already covered by the existing DEPLOY_APP reply tests).

— [cloud-security]
