### PR TITLE
fix(examples/edad): Option-B deploy body — camelCase CreateContainerSchema keys + non-reserved cloud-key alias (#11929)

### DIFF
--- a/packages/cloud/api/__tests__/containers-create-contract.test.ts
+++ b/packages/cloud/api/__tests__/containers-create-contract.test.ts
@@ -15,7 +15,11 @@
  * to these keys by the compile-time test in
  * `packages/cloud/sdk/src/client.test.ts`.
  */
+
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { findReservedEnvKeys } from "@/lib/services/reserved-env-keys";
 import {
   CreateContainerSchema,
   PatchContainerSchema,
@@ -86,6 +90,77 @@ describe("POST /api/v1/containers — create contract (casing bug fix)", () => {
   test("rejects a body missing the required image (server is the source of truth)", () => {
     const parsed = CreateContainerSchema.safeParse({ name: "no-image" });
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe("edad README Option-B deploy body ↔ CreateContainerSchema (#11929)", () => {
+  // The orchestrator's app-deploy guidance tells coding sub-agents to follow
+  // the edad README's `POST /api/v1/containers` example VERBATIM, so this test
+  // pins the doc to the real schema: the exact JSON body in the README must
+  // round-trip with the sign-in + billing env keys intact. The pre-fix README
+  // posted snake_case keys that zod silently stripped — every deploy built
+  // from it shipped a container with NO env vars (dead sign-in + billing).
+  const readmePath = fileURLToPath(
+    new URL("../../../examples/cloud/edad/README.md", import.meta.url),
+  );
+  const readme = readFileSync(readmePath, "utf8");
+
+  function extractCurlBody(markdown: string): Record<string, unknown> {
+    // The single `curl … -d '{…}'` example in the Option-B deploy block.
+    const match = markdown.match(/-d '(\{[\s\S]*?\})'/);
+    if (!match) throw new Error("README curl -d body not found");
+    return JSON.parse(match[1]) as Record<string, unknown>;
+  }
+
+  test("the README body parses with every posted key recognized (nothing silently stripped)", () => {
+    const wire = extractCurlBody(readme);
+
+    const parsed = CreateContainerSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // zod strips unknown keys silently — equality of the key sets proves the
+    // doc posts ONLY keys the schema actually accepts.
+    expect(Object.keys(parsed.data).sort()).toEqual(Object.keys(wire).sort());
+  });
+
+  test("the sign-in + billing env keys survive to the container env", () => {
+    const wire = extractCurlBody(readme);
+    const parsed = CreateContainerSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    const env = parsed.data.environmentVars;
+    expect(env).toBeDefined();
+    if (!env) return;
+    // Sign-in: the OAuth session exchange needs the app id; billing: the
+    // owner cloud key funds `/api/v1/messages` forwards. server.ts reads
+    // `ELIZAOS_CLOUD_API_KEY ?? ELIZA_CLOUD_API_KEY` — the container path must
+    // use the second name (see the reserved-keys test below).
+    expect(env.ELIZA_APP_ID).toBeTruthy();
+    expect(env.ELIZA_CLOUD_API_KEY).toBeTruthy();
+    expect(env.ELIZA_AFFILIATE_CODE).toBeTruthy();
+    expect(env.ELIZA_CLOUD_URL).toBeTruthy();
+  });
+
+  test("the README env block carries no platform-reserved keys (route would 400)", () => {
+    // POST /api/v1/containers rejects reserved keys (#9853) — a README body
+    // using ELIZAOS_CLOUD_API_KEY would fail loudly with RESERVED_ENV_KEYS.
+    const wire = extractCurlBody(readme);
+    const env = (wire.environmentVars ?? {}) as Record<string, string>;
+    expect(findReservedEnvKeys(Object.keys(env))).toEqual([]);
+  });
+
+  test("REGRESSION: the README no longer posts the legacy snake_case keys", () => {
+    const wire = extractCurlBody(readme);
+    for (const legacyKey of [
+      "project_name",
+      "environment_vars",
+      "health_check_path",
+      "memory",
+    ]) {
+      expect(wire).not.toHaveProperty(legacyKey);
+    }
   });
 });
 

--- a/packages/examples/cloud/edad/README.md
+++ b/packages/examples/cloud/edad/README.md
@@ -118,7 +118,7 @@ branded domain and bills the app's monetized credit pool from the first message.
 
 ### Option B — standalone container on Eliza Cloud
 
-Self-hosting closes the loop: app earnings refill the org's credit balance via the earnings auto-fund service, container daily-billing keeps debiting that balance, and the app keeps itself alive as long as it earns enough.
+Self-hosting closes the loop: container daily-billing debits the owner's redeemable app earnings **before** org credits (the org's `payAsYouGoFromEarnings` toggle, on by default), so the app keeps itself alive as long as it earns enough.
 
 <!-- The plain ./Dockerfile cannot be built standalone: server.ts imports the
      `@elizaos/cloud-sdk` workspace dep, which only resolves inside the monorepo.
@@ -140,30 +140,36 @@ docker tag edad-chat:latest ghcr.io/<owner>/edad-chat:latest
 docker push ghcr.io/<owner>/edad-chat:latest
 
 # 2. POST /api/v1/containers (use any cloud API key with deploy scope)
+#    Body keys are camelCase — CreateContainerSchema
+#    (packages/cloud/api/v1/containers/schema.ts) strips unknown keys, so a
+#    snake_case body (project_name, environment_vars, …) deploys a container
+#    with NO env vars → dead sign-in + billing. Pass the cloud key as
+#    ELIZA_CLOUD_API_KEY: ELIZAOS_CLOUD_API_KEY is a platform-reserved env key
+#    this route rejects (#9853), and server.ts reads both names.
 curl -X POST https://www.elizacloud.ai/api/v1/containers \
   -H "Authorization: Bearer $ELIZA_API_KEY" \
   -H "content-type: application/json" \
   -d '{
     "name": "edad-chat",
-    "project_name": "edad",
+    "projectName": "edad",
     "port": 3000,
     "cpu": 256,
-    "memory": 512,
+    "memoryMb": 512,
     "image": "ghcr.io/<owner>/edad-chat:latest",
-    "health_check_path": "/health",
-    "environment_vars": {
+    "healthCheckPath": "/health",
+    "environmentVars": {
       "ELIZA_APP_ID": "<your-app-uuid>",
-      "ELIZAOS_CLOUD_API_KEY": "<your-cloud-key>",
+      "ELIZA_CLOUD_API_KEY": "<your-cloud-key>",
       "ELIZA_AFFILIATE_CODE": "<your-affiliate-code>",
       "ELIZA_CLOUD_URL": "https://www.elizacloud.ai"
     }
   }'
 
-# 3. (one-time, on the org dashboard) enable earnings auto-fund:
-#    PUT /api/v1/billing/earnings-auto-fund
-#    { "enabled": true, "amount": 5, "threshold": 2, "keepBalance": 10 }
-#    → when org credits dip below $2, auto-credit $5 from your redeemable
-#      earnings, keeping at least $10 cashable at all times.
+# 3. self-funding is ON by default: the container-billing cron pays each
+#    day's container charge from the owner's redeemable app earnings first,
+#    then org credits (org toggle `payAsYouGoFromEarnings`, default true).
+#    To keep earnings cashable instead and bill credits only:
+#    PUT /api/v1/billing/settings  { "payAsYouGoFromEarnings": false }
 ```
 
 The container listens on `:3000`, exposes `/health` for the ECS health check, and the same `/api/*` routes as the embedded variant. No code differs between Option A and B — just the host process.


### PR DESCRIPTION
`[cloud-frontdoor]` (money/auth-adjacent deploy path — flagging `[cloud-money]`/`[cloud-security]` for visibility)

Fixes #11929 (Priority:High launch-blocker).

## The defect

`packages/examples/cloud/edad/README.md` Option-B posts **snake_case** keys (`project_name`, `environment_vars`, `memory`, `health_check_path`) to `POST /api/v1/containers`, but `CreateContainerSchema` (`packages/cloud/api/v1/containers/schema.ts`) is camelCase and zod silently strips unknown keys. The deployed container therefore got **zero env vars** — no `ELIZA_APP_ID`, no cloud key → live-looking URL with **dead sign-in + billing**. The orchestrator's app-deploy guidance (`plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts`) tells coding sub-agents to follow this README verbatim, so every monetized-app deploy built from it shipped broken.

## What I found beyond the filed issue

1. **Casing alone doesn't fix it.** A correctly-cased body carrying `ELIZAOS_CLOUD_API_KEY` is **400-rejected** by the route's #9853 reserved-env-keys gate (`RESERVED_PLATFORM_ENV_KEYS` includes `ELIZAOS_CLOUD_API_KEY`), and the generic containers path injects nothing itself. `server.ts` already reads the fallback alias `ELIZA_CLOUD_API_KEY` — which is **not** reserved — so the README now passes the key under that name. Verified `validateEnvKey` + the hetzner client pass it through untouched.
2. **Step 3 called a nonexistent endpoint.** `PUT /api/v1/billing/earnings-auto-fund` doesn't exist (migration 0070's auto-fund columns are unwired). The real self-funding mechanism is the container-billing cron paying the daily charge from owner redeemable earnings first (`payAsYouGoFromEarnings`, default **true**, togglable via `PUT /api/v1/billing/settings`). The README now documents that.

## The fix (option (a) from the issue — README, plus contract tests)

- `packages/examples/cloud/edad/README.md`: Option-B curl body → `projectName` / `memoryMb` / `healthCheckPath` / `environmentVars`, cloud key as `ELIZA_CLOUD_API_KEY`, inline warning about the strip + reserved-key behavior; step 3 + intro rewritten to the real earnings-first billing mechanism.
- `packages/cloud/api/__tests__/containers-create-contract.test.ts`: 4 new tests that read the **actual README**, extract the exact curl `-d` JSON, and parse it against the **real** `CreateContainerSchema` (no mock):
  - every posted key is recognized (key-set equality — nothing silently stripped),
  - the sign-in + billing env keys (`ELIZA_APP_ID`, `ELIZA_CLOUD_API_KEY`, affiliate, cloud URL) survive to the container env,
  - `findReservedEnvKeys` finds none (the route's RESERVED_ENV_KEYS 400 can't fire),
  - the legacy snake_case keys are gone.

  Doc drift now fails CI instead of deploying dead containers.

The schema was deliberately left as-is (non-strict, camelCase): it is the documented wire contract, pinned by the SDK compile-time test in `packages/cloud/sdk/src/client.test.ts`, and making it strict or alias-accepting would change the public wire behavior — the issue's own analysis calls (a) the clean fix.

## Evidence

- **Red-proof:** ran the new tests against the pre-fix README (`git show HEAD~1:…`) → 3/4 fail exactly on the defect (stripped keys, reserved key posted, legacy keys present); post-fix → 9/9 pass.
- `bun test __tests__/containers-create-contract.test.ts` → **9 pass / 0 fail** (5 pre-existing + 4 new).
- `bun run --cwd packages/cloud/api typecheck` → clean.
- `biome check` on the changed test file → clean.
- `packages/examples/cloud/edad` smoke test (`bun run test`) → pass.
- Full `bun test __tests__` in the isolated worktree showed 2 unrelated failing files (`organizations-remove-member-detach`, `oxapay-webhook-route`); both pass 19/19 in a properly-installed checkout — environment artifact of the worktree's symlinked node_modules, untouched by this change.
- UI/video/trajectory evidence: N/A — doc + schema-contract test change; no UI surface, no model-facing behavior. The end-to-end re-verify of a live monetized deploy carrying the env into a real container is the #9300 staging showcase runbook (`packages/test/cloud-e2e/docs/showcase-apps-coverage.md`) and needs the staging control plane, tracked on the issue.
