### PR TITLE
fix(core): keep the provider-failover tail behind the brain-provider override

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4650,7 +4650,10 @@ export class AgentRuntime implements IAgentRuntime {
 	 * flips the chat brain on the next model call with no restart. Returns
 	 * undefined when the setting is empty OR names a provider that has no
 	 * registered text handler, so a stale or mistyped value never strands the
-	 * brain — it simply falls back to the default provider.
+	 * brain — it simply falls back to the default provider. The same contract
+	 * holds at call time: useModel keeps the default-chain registrations behind
+	 * the override as a failover tail, so a rate-limited/exhausted override
+	 * provider falls to the registered backups instead of stranding the brain.
 	 */
 	private resolveTextProviderOverride(): string | undefined {
 		const raw = this.getSetting("ELIZA_BRAIN_PROVIDER");
@@ -5131,9 +5134,30 @@ export class AgentRuntime implements IAgentRuntime {
 		const overrideResolved = providerOverride
 			? this.resolveModelRegistrations(requestedModelKey, providerOverride)
 			: [];
+		// The override provider goes FIRST, but the remaining default-chain
+		// registrations stay behind it as the failover tail. Without the tail a
+		// rate-limited override provider strands the brain (its throw has no next
+		// registration to fall to) even though healthy backup providers are
+		// registered — violating the "never strands the brain" contract of
+		// resolveTextProviderOverride. The failover loop below still only
+		// advances on fallback-class errors, so a healthy pinned provider keeps
+		// winning every call.
 		const resolvedModels =
 			overrideResolved.length > 0
-				? overrideResolved
+				? [
+						...overrideResolved,
+						...this.resolveModelRegistrations(
+							requestedModelKey,
+							requestedProvider,
+						).filter(
+							(candidate) =>
+								!overrideResolved.some(
+									(chosen) =>
+										chosen.handler === candidate.handler &&
+										chosen.modelKey === candidate.modelKey,
+								),
+						),
+					]
 				: this.resolveModelRegistrations(requestedModelKey, requestedProvider);
 		if (resolvedModels.length === 0) {
 			this.throwNoModelHandler(requestedModelKey);

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -3,17 +3,21 @@ import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
 import { type Character, ModelType } from "../../types";
 
-function makeRuntime(): AgentRuntime {
+function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
 	return new AgentRuntime({
 		character: {
 			name: "ProviderFailoverAgent",
 			bio: "test",
-			settings: {},
+			settings,
 		} as Character,
 		adapter: new InMemoryDatabaseAdapter(),
 		logLevel: "fatal",
 	});
 }
+
+/** The exact subscription-limit error the cli-inference SDK session throws live. */
+const CLI_INFERENCE_LIMIT_ERROR =
+	"[cli-inference:sdk] subscription rate limit reached: You've hit your session limit · resets 9:30pm (UTC)";
 
 describe("AgentRuntime.useModel provider failover", () => {
 	it("tries the next registered provider when the preferred provider is exhausted", async () => {
@@ -68,6 +72,117 @@ describe("AgentRuntime.useModel provider failover", () => {
 		).rejects.toThrow("invalid request payload");
 		expect(failingHandler).toHaveBeenCalledTimes(1);
 		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("fails over past an ELIZA_BRAIN_PROVIDER override when it is rate-limited", async () => {
+		// The owner pinned the chat brain to the subscription CLI route. When that
+		// provider throws its limit envelope the pin must NOT strand the brain —
+		// the remaining registered providers are the backup tier (#10893).
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error(CLI_INFERENCE_LIMIT_ERROR);
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			exhaustedHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("backup response");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("still prefers the ELIZA_BRAIN_PROVIDER override when it is healthy", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const pinnedHandler = vi.fn(async () => "pinned response");
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			pinnedHandler,
+			"cli-inference",
+			10,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			100,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("pinned response");
+		expect(pinnedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("does not fail over past a rate-limited override on ordinary errors", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const failingHandler = vi.fn(async () => {
+			throw new Error("invalid request payload");
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			failingHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).rejects.toThrow("invalid request payload");
+		expect(failingHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("fails over RESPONSE_HANDLER to the backup provider on a subscription limit", async () => {
+		// RESPONSE_HANDLER is the user-facing reply tier the cli-inference route
+		// serves; the exact live limit throw must reach the backup registration.
+		const runtime = makeRuntime();
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error(CLI_INFERENCE_LIMIT_ERROR);
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			exhaustedHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).resolves.toBe("backup response");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not switch providers when a provider is explicitly requested", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #10969 (issue #10893): the `useModel` provider-failover loop consumes the CLI-SDK brain's throw-to-failover contract on the DEFAULT resolution path, but the `ELIZA_BRAIN_PROVIDER` override path resolved **only the pinned provider's registrations**. When the pinned provider threw a rate-limit / subscription-limit error (the cli-inference `claude-sdk` brain's exact live failure: `[cli-inference:sdk] subscription rate limit reached: You've hit your session limit · resets 9:30pm (UTC)`), `resolvedModels` held a single entry, `!nextModel` short-circuited to rethrow, and the brain stayed down for the rest of the limit window — even though healthy backup providers (cloud / API key) were registered.

That violates `resolveTextProviderOverride`'s own documented contract ("a stale or mistyped value never strands the brain") and re-opens #10893 for any deployment that pins the chat brain to the subscription route — which is exactly the deployment shape the override exists for (owner flips the brain to the CLI/SDK route at runtime).

## Fix

Structural, in `useModel`'s resolution step: when the override resolves registrations, keep the remaining default-chain registrations **behind** it as the failover tail (deduped by handler + model key). The failover loop is unchanged — it still only advances on fallback-class errors (`isModelProviderFallbackError`: 429/529/5xx/session-limit/usage-limit), so:

- a **healthy** pinned provider keeps winning every call (override-first order preserved),
- **ordinary** errors (400s, parse failures) still rethrow without switching providers,
- an explicitly **pinned** `provider` argument still never fails over (unchanged),
- only a rate-limited/exhausted/unavailable override provider now falls to the registered backups.

## Verify-first evidence (red -> green on this branch's parent)

Red test on unmodified `origin/develop` (cff4189e7a): registered a `cli-inference` handler at priority 100 throwing the exact live limit envelope + an `elizacloud` backup at 10, with `ELIZA_BRAIN_PROVIDER=cli-inference`:

```
FAIL src/runtime/__tests__/model-provider-failover.test.ts
AssertionError: promise rejected "Error: [cli-inference:sdk] subscription r…" instead of resolving
Caused by: Error: [cli-inference:sdk] subscription rate limit reached: You've hit your session limit · resets 9:30pm (UTC)
```

The default-path cases (including RESPONSE_HANDLER with the same live error string) already passed on develop, confirming #10969's consumer works there — the override path was the residual strand.

## Tests

Extended `packages/core/src/runtime/__tests__/model-provider-failover.test.ts` (3 -> 7 cases):
- fails over past a rate-limited `ELIZA_BRAIN_PROVIDER` override to the registered backup (the red case above, now green)
- still prefers a healthy override even when the backup has higher priority
- does NOT fail over past the override on ordinary (non-fallback-class) errors
- RESPONSE_HANDLER default-path failover with the exact live cli-inference limit envelope (regression-binds the plugin's throw contract to core's classifier)

```
Test Files  1 passed (1)   Tests  7 passed (7)                    (model-provider-failover)
Test Files  63 passed (63) Tests  787 passed (787)                (full src/runtime/__tests__)
tsgo --noEmit: clean                                              (packages/core typecheck)
```

Biome: the two touched files report only the pre-existing whole-file tab-indent format diagnostics — byte-identical count on pristine develop (verified via stash); no new lint errors. `plugins/plugin-cli-inference` suite: 91/92, the 1 failure (`sdk-dependencies.test.ts`) is pre-existing on develop (1e5d7d0caf added the test without the matching `optionalDependencies` entry) and untouched by this change.

Trajectory/live-bot evidence: N/A - this is a deterministic provider-resolution ordering fix in `useModel`; the failing path is fully reproduced by the runtime-level red test above with the verbatim live error envelope from the incident log (bot.log "Structured failure reply generation failed ... error=subscription rate limit reached").

🤖 Generated with [Claude Code](https://claude.com/claude-code)