### PR TITLE
fix(core): stay silent when the v5 runtime fails before a respond decision

### DIFF
--- a/packages/core/src/services/message.runtime-failure-suppression.test.ts
+++ b/packages/core/src/services/message.runtime-failure-suppression.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Failure-reply gating when the v5 message runtime dies BEFORE any
+ * RESPOND/IGNORE decision exists.
+ *
+ * Rate limits and provider outages throw from the Stage 1 model call itself,
+ * so no shouldRespond decision was ever made for the turn. The old behavior
+ * unconditionally sent the canned "something went wrong" reply — observed
+ * live as 91 canned-failure sends in 2 days into group relay rooms that never
+ * addressed the agent. The pipeline must:
+ *
+ *   1. stay SILENT (terminal IGNORE, no user-visible text) when the failing
+ *      turn was ambiguous group traffic the agent would have ignored, and
+ *   2. still surface the failure text when the turn deterministically
+ *      addressed the agent (platform mention/reply, DM/API channel).
+ *
+ * These tests drive the real `DefaultMessageService.handleMessage` pipeline —
+ * memory persistence, room fetch, Stage 1 dispatch, the failure catch, and
+ * terminal delivery — with only the runtime I/O surface mocked. The Stage 1
+ * `useModel` call rejects with a real provider rate-limit error, exactly like
+ * the live incident.
+ */
+
+import { v4 } from "uuid";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import { createMockRuntime } from "../testing/mock-runtime";
+import type { Room } from "../types/environment";
+import type { Memory } from "../types/memory";
+import {
+	asUUID,
+	ChannelType,
+	type Content,
+	type UUID,
+} from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+import { DefaultMessageService } from "./message";
+
+const AGENT = "00000000-0000-0000-0000-00000000000a" as UUID;
+const ENTITY = "00000000-0000-0000-0000-00000000000b" as UUID;
+const ROOM = "00000000-0000-0000-0000-00000000000c" as UUID;
+const RUN_ID = "00000000-0000-0000-0000-00000000000d" as UUID;
+
+const RATE_LIMIT_ERROR = new Error(
+	"[cli-inference:sdk] subscription rate limit reached: You've hit your session limit",
+);
+
+function makeMessage(overrides: Partial<Content> = {}): Memory {
+	return {
+		id: asUUID(v4()),
+		entityId: ENTITY,
+		agentId: AGENT,
+		roomId: ROOM,
+		content: {
+			text: "anyone up for a raid tonight?",
+			source: "discord",
+			channelType: ChannelType.GROUP,
+			...overrides,
+		},
+		createdAt: Date.now(),
+	};
+}
+
+function makeState(): State {
+	return { values: {}, data: {}, text: "" };
+}
+
+function makeFailingRuntime(room: Room): IAgentRuntime {
+	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+		responseHandlerFieldRegistry.register(evaluator);
+	}
+	return createMockRuntime({
+		agentId: AGENT,
+		character: {
+			name: "Remilio",
+			bio: "test agent",
+		},
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			trace: vi.fn(),
+		} as unknown as IAgentRuntime["logger"],
+		getSetting: vi.fn(() => undefined),
+		getService: vi.fn(() => null),
+		getModel: vi.fn(() => async () => {
+			throw RATE_LIMIT_ERROR;
+		}),
+		// Stage 1 RESPONSE_HANDLER dies with a provider rate limit — the same
+		// shape as the live incident. Every other model call (the failure-reply
+		// generator retries TEXT_* models) fails the same way, which routes
+		// buildStructuredFailureReply onto its rate-limited template path.
+		useModel: vi.fn(async () => {
+			throw RATE_LIMIT_ERROR;
+		}),
+		composeState: vi.fn(async () => makeState()),
+		runActionsByMode: vi.fn(async () => undefined),
+		applyPipelineHooks: vi.fn(async () => undefined),
+		emitEvent: vi.fn(async () => undefined),
+		startRun: vi.fn(() => RUN_ID),
+		getCurrentRunId: vi.fn(() => RUN_ID),
+		endRun: vi.fn(),
+		getMemoryById: vi.fn(async () => null),
+		createMemory: vi.fn(async () => asUUID(v4())),
+		updateMemory: vi.fn(async () => true),
+		queueEmbeddingGeneration: vi.fn(async () => undefined),
+		getParticipantUserState: vi.fn(async () => null),
+		getRoom: vi.fn(async () => room),
+		getRoomsByIds: vi.fn(async () => [room]),
+		getMemories: vi.fn(async () => []),
+		isCheckShouldRespondEnabled: vi.fn(() => true),
+		turnControllers: new TurnControllerRegistry(),
+		responseHandlerFieldRegistry,
+		responseHandlerFieldEvaluators: [
+			...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+		],
+	});
+}
+
+function makeRoom(type: ChannelType): Room {
+	return {
+		id: ROOM,
+		source: "discord",
+		type,
+	} as Room;
+}
+
+async function runTurn(message: Memory, room: Room) {
+	const runtime = makeFailingRuntime(room);
+	const service = new DefaultMessageService();
+	const deliveries: Content[] = [];
+	const result = await service.handleMessage(
+		runtime,
+		message,
+		async (content) => {
+			deliveries.push(content);
+			return [];
+		},
+	);
+	// Everything the callback delivered with visible text — what a connector
+	// would actually post to the channel.
+	const visibleTexts = deliveries
+		.map((content) => (typeof content.text === "string" ? content.text : ""))
+		.filter((text) => text.trim().length > 0);
+	return { runtime, result, deliveries, visibleTexts };
+}
+
+describe("v5 runtime failure before a respond decision", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("stays silent on ambiguous group traffic the agent would have ignored", async () => {
+		const { result, deliveries, visibleTexts } = await runTurn(
+			makeMessage(),
+			makeRoom(ChannelType.GROUP),
+		);
+
+		// No user-visible text may leave the pipeline — the canned failure
+		// reply into an unaddressed relay room was the bug.
+		expect(visibleTexts).toEqual([]);
+		expect(result.didRespond).toBe(false);
+		// The turn resolves as a terminal IGNORE, exactly like the decision the
+		// agent would have made had Stage 1 survived.
+		const terminal = deliveries.find((content) =>
+			Array.isArray(content.actions),
+		);
+		expect(terminal?.actions).toEqual(["IGNORE"]);
+	});
+
+	it("still surfaces the failure reply when the agent was platform-mentioned", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({
+				text: "@Remilio what's the plan?",
+				mentionContext: { isMention: true },
+			}),
+			makeRoom(ChannelType.GROUP),
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toHaveLength(1);
+		// buildStructuredFailureReply lands on the rate-limited template since
+		// every model call in this turn is rate-limited.
+		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+	});
+
+	it("still surfaces the failure reply on private DM channels", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({ channelType: ChannelType.DM }),
+			makeRoom(ChannelType.DM),
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toHaveLength(1);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9166,7 +9166,7 @@ export class DefaultMessageService implements IMessageService {
 						error: errMsg,
 						stack: errStack,
 					},
-					"v5 message runtime failed; returning structured failure reply",
+					"v5 message runtime failed",
 				);
 				// Mirror to process.stderr so bench / orchestrator runs can see
 				// the underlying cause when runtime.logger output is buffered or
@@ -9182,17 +9182,54 @@ export class DefaultMessageService implements IMessageService {
 				} catch {
 					// stderr write must never throw the runtime.
 				}
-				shouldRespondToMessage = true;
-				terminalDecision = null;
-				strategyResult = await this.buildStructuredFailureReply(
+				// Rate limits and provider outages throw from the Stage 1 model
+				// call itself — before any RESPOND/IGNORE decision exists. For
+				// ambiguous group traffic the pre-failure outcome would have been
+				// IGNORE, so an unconditional failure reply spams rooms that never
+				// addressed the agent (observed live: 91 canned-failure sends in
+				// 2 days into relay rooms during a rate-limit window). Surface
+				// failure text only when the turn deterministically addressed the
+				// agent (DM/API/SELF channel, platform mention/reply, whitelisted
+				// source, name+tag address), the turn is autonomous, or an early
+				// ack already went out (the user saw the bot engage). Everything
+				// else stays silent, matching the IGNORE it would have gotten.
+				const failureGate = this.shouldRespond(
 					runtime,
 					message,
-					state,
-					responseId,
-					"running the native tool message runtime",
+					room ?? undefined,
+					mentionContext,
 				);
-				_usedV5Runtime = true;
-				state = strategyResult.state;
+				const addressedForFailureReply =
+					failureGate.shouldRespond ||
+					mentionContext?.isMention === true ||
+					mentionContext?.isReply === true ||
+					isAutonomous ||
+					earlyReplyMessages.length > 0;
+				if (addressedForFailureReply) {
+					shouldRespondToMessage = true;
+					terminalDecision = null;
+					strategyResult = await this.buildStructuredFailureReply(
+						runtime,
+						message,
+						state,
+						responseId,
+						"running the native tool message runtime",
+					);
+					_usedV5Runtime = true;
+					state = strategyResult.state;
+				} else {
+					runtime.logger.info(
+						{
+							src: "service:message",
+							agentId: runtime.agentId,
+							roomId: message.roomId,
+							reason: failureGate.reason,
+						},
+						"v5 runtime failed before a respond decision on an unaddressed message; suppressing failure reply",
+					);
+					shouldRespondToMessage = false;
+					terminalDecision = "IGNORE";
+				}
 			}
 		} else if (!hasTextGenerationHandler(runtime)) {
 			await runtime.applyPipelineHooks(


### PR DESCRIPTION
## Problem

When the v5 message runtime fails — in practice, when the model provider is rate-limited and the Stage 1 `RESPONSE_HANDLER` call throws — the failure catch in `DefaultMessageService.processMessage` unconditionally set `shouldRespondToMessage = true` and delivered the canned structured failure reply.

The Stage 1 model call is what *produces* the RESPOND/IGNORE decision, so at that point no respond decision exists. For ambiguous group traffic the pre-failure outcome would have been IGNORE — instead the bot posted "Sorry, something went wrong on my end" into rooms that never addressed it.

Observed live (rate-limit window, 2 days):

- 177 `v5 message runtime failed` warns, all `subscription rate limit reached` thrown from the Stage 1 call
- 91 `Message sent (text=Sorry, something went wrong…)` channel sends
- 8/11 sampled sends went to a single relay room that never mentioned the bot; the corresponding trajectories errored with **0 stages** (no decision was ever made)

## Fix

Gate the structured failure reply on the same deterministic signals the pipeline already uses when no model judgment is available (mirrors the existing `!hasTextGenerationHandler` branch):

- send the failure reply only when the turn deterministically addressed the agent — DM/API/SELF channel, platform mention/reply, whitelisted source, name+tag address (`this.shouldRespond`), or the turn is autonomous, or an early ack already went out this turn (the user saw the bot engage);
- otherwise resolve the turn as a terminal `IGNORE` — exactly the decision the message would have gotten — and log the suppression with the gate reason.

Direct chat callers are unaffected: DM/API/`client_chat` turns still receive the failure text, so HTTP clients never see a blank turn.

## Test

`packages/core/src/services/message.runtime-failure-suppression.test.ts` drives the real `DefaultMessageService.handleMessage` pipeline (memory persistence, room fetch, Stage 1 dispatch, failure catch, terminal delivery) with `useModel` rejecting with the live incident's rate-limit error:

1. unaddressed group message → **no visible text delivered**, terminal `IGNORE` (fails on develop without this fix: the canned reply is delivered)
2. platform-mentioned group message → failure reply still delivered (rate-limited template)
3. DM channel → failure reply still delivered

## Verification

- `vitest run` on the message-area suites: 10 files, 124 tests green
- `bun run typecheck` (packages/core): clean
- verify-first: with the fix reverted, case 1 fails with the exact live symptom (visible canned text into the unaddressed room)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
