### PR TITLE
fix(agent): search_vectors drops semantic matches via BM25 rerank (#11938)

### DIFF
--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -599,7 +599,16 @@ async function opSearchVectors(
 
   const matches: Memory[] = await runtime.searchMemories({
     embedding,
-    query,
+    // Intentionally NO `query` here. Passing `query` makes runtime.searchMemories
+    // pipe the vector hits through rerankMemories → BM25, which DROPS every
+    // candidate with zero stemmed-keyword overlap (search.ts: `if (score <= 0)
+    // continue`). That turns "rerank" into a keyword FILTER: a semantic search
+    // like "automobile purchase" returns nothing for a stored "I bought a new
+    // car", and attachment-only memories (no content.text) are always dropped —
+    // defeating the whole point of a vector search. This IS a vector search, so
+    // the adapter's cosine-similarity order is authoritative. Mirrors the same
+    // deliberate omission in core/features/documents/service.ts, which documents
+    // this exact trap.
     tableName: table,
     limit,
     ...(typeof params.threshold === "number"


### PR DESCRIPTION
Closes #11938. Found by a Fable-5 hunt, hand-verified inline. `[cloud-money]` (cross-lane, core/agent).

**Bug (MED, demo-visible):** `search_vectors` (`database.ts:600`) passes `query` to `searchMemories` → BM25 rerank → `search.ts:1341` drops every zero-keyword-overlap candidate. A semantic search returns nothing on a synonym; attachment-only memories always dropped. The codebase documents this trap in `documents/service.ts` but this op still hits it.

**Fix:** drop `query` from the call (pure vector search; adapter cosine order is authoritative; mirrors documents/service.ts). `query` kept for the reply. typecheck + biome clean; unclaimed (collision-checked). Regression test = fast-follow. cc core/agent owner — not self-merging cross-lane.