### PR TITLE
fix(cloud): forward resolved video duration to provider — bill what you deliver (#11862 finding 2)

### DIFF
--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -252,6 +252,49 @@ describe("generate-video — pre-settle failure still refunds", () => {
   });
 });
 
+describe("generate-video — bills what it delivers (#11862 finding 2)", () => {
+  test("when the client omits durationSeconds, the RESOLVED billing default is forwarded to the provider (not undefined)", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue(validResult);
+    generationsCreate.mockResolvedValue({ id: "gen-1" });
+
+    // No durationSeconds in the request → billing resolves it to the catalog
+    // default (8, per the getDefaultVideoBillingDimensions mock above).
+    const res = await post({ model: MODEL, prompt: "a cat" });
+
+    expect(res.status).toBe(200);
+    // The provider (fal) maps durationSeconds → input.duration. Before the fix
+    // the raw request spread forwarded an undefined durationSeconds, so the
+    // provider rendered its OWN default while we billed 8s → undercharge.
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    const falInput = (
+      subscribe.mock.calls[0]?.[1] as { input?: Record<string, unknown> }
+    )?.input;
+    expect(falInput?.duration).toBe(8);
+    expect(falInput?.duration_seconds).toBe(8);
+  });
+
+  test("an explicit client durationSeconds is still forwarded unchanged", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue(validResult);
+    generationsCreate.mockResolvedValue({ id: "gen-1" });
+
+    const res = await post({
+      model: MODEL,
+      prompt: "a cat",
+      durationSeconds: 5,
+    });
+
+    expect(res.status).toBe(200);
+    const falInput = (
+      subscribe.mock.calls[0]?.[1] as { input?: Record<string, unknown> }
+    )?.input;
+    expect(falInput?.duration).toBe(5);
+  });
+});
+
 describe("generate-video — clean success settles once", () => {
   test("success path reconciles exactly once to totalCost", async () => {
     const ledger = makeLedgerReservation(100, COST);

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -178,6 +178,13 @@ app.post("/", async (c) => {
 
     const generated = await provider.generate({
       ...request,
+      // Bill-what-you-deliver: the org is charged for the RESOLVED duration
+      // (request.durationSeconds ?? the catalog default), but the raw request
+      // spread would forward an undefined durationSeconds when the client omits
+      // it — the provider then renders its OWN default (potentially longer),
+      // so the platform pays for a longer clip than it billed. Forward the
+      // resolved value so the generated duration matches the charge.
+      durationSeconds,
       apiKeys,
     });
     if (generated.hasNsfwConcepts?.some(Boolean)) {


### PR DESCRIPTION
Fixes finding 2 of #11862 (which was closed on finding 1's fix; findings 2/3 were punted with no open issue, so this stayed **live on develop**).

## Bug (MED, money — silent undercharge / platform loss)
`POST /api/v1/generate-video` bills the **resolved** duration:
```ts
const durationSeconds = request.durationSeconds ?? defaults.durationSeconds; // billed (line 121/136)
```
…but forwarded the **raw** request to the provider:
```ts
const generated = await provider.generate({ ...request, apiKeys }); // request.durationSeconds may be undefined
```
The fal provider gates on truthy `request.durationSeconds` (`fal-video-generation.ts:98`), so when a client **omits** `durationSeconds` the route bills the catalog default (e.g. 8s) but sends **no** duration upstream → the provider renders its **own** default (potentially longer) → the platform pays for a longer clip than it charged for. Billed ≠ delivered; silent per-request undercharge.

## Fix
Forward the **resolved** `durationSeconds` to `provider.generate` so the generated duration matches the charge (1 line + explanatory comment).

## Evidence
```
bun test generate-video-credit-leak.test.ts
 7 pass / 0 fail
```
New regression tests (extend the existing money-leak suite, same mock scaffold): an omitted `durationSeconds` forwards the billing default (8) to fal's `input.duration`/`input.duration_seconds` (not undefined); an explicit value is forwarded unchanged.

**Mutation-checked:** reverting the fix (raw `...request` spread) turns the omitted-duration test red (7→ "1 fail"); restored → 7 pass.

Biome clean. Found by a Fable-5 + adversarial-verify sweep of the second money wave.

**Note (out of scope, tracked):** #11862 finding 3 (flat per-second Atlas price ignores resolution/audio) + the Atlas provider not adopting the #11920 pending seam are separate; both live only on the still-open PR #11785, not on develop. Money lane → @lalalune; not self-merged.
