### PR TITLE
fix(core): triage unaddressed bot/webhook noise on TEXT_SMALL before Stage 1

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -107,6 +107,7 @@ Read by the runtime (see README for the full WHY of each):
 - `SECRET_SALT` — encryption salt, read by `getSalt()` in `src/settings.ts` (`ELIZA_ALLOW_DEFAULT_SECRET_SALT` overrides the production non-default check).
 - `ALLOW_NO_DATABASE` — fall back to `InMemoryDatabaseAdapter` on `initialize()` when no adapter is provided (`runtime.ts`).
 - `SHOULD_RESPOND_MODEL` (`small`/`large`, `services/message.ts`), `BASIC_CAPABILITIES_KEEP_RESP` (`services/message.ts`) — message/basic-capabilities behavior.
+- `ELIZA_BOT_NOISE_TRIAGE` (`services/message/bot-noise-triage.ts`) — set `0` to disable the TEXT_SMALL pre-gate that triages unaddressed bot/webhook group messages before the Stage 1 RESPONSE_HANDLER call (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -107,6 +107,7 @@ Read by the runtime (see README for the full WHY of each):
 - `SECRET_SALT` — encryption salt, read by `getSalt()` in `src/settings.ts` (`ELIZA_ALLOW_DEFAULT_SECRET_SALT` overrides the production non-default check).
 - `ALLOW_NO_DATABASE` — fall back to `InMemoryDatabaseAdapter` on `initialize()` when no adapter is provided (`runtime.ts`).
 - `SHOULD_RESPOND_MODEL` (`small`/`large`, `services/message.ts`), `BASIC_CAPABILITIES_KEEP_RESP` (`services/message.ts`) — message/basic-capabilities behavior.
+- `ELIZA_BOT_NOISE_TRIAGE` (`services/message/bot-noise-triage.ts`) — set `0` to disable the TEXT_SMALL pre-gate that triages unaddressed bot/webhook group messages before the Stage 1 RESPONSE_HANDLER call (default on).
 - Prompt-batcher knobs (all `PROMPT_BATCHER_*`, read in `runtime.ts`): `PROMPT_BATCHER_BATCH_SIZE`, `PROMPT_BATCHER_MAX_DRAIN_INTERVAL_MS`, `PROMPT_BATCHER_MAX_SECTIONS_PER_CALL`, `PROMPT_BATCHER_PACKING_DENSITY`, `PROMPT_BATCHER_MAX_TOKENS_PER_CALL`, `PROMPT_BATCHER_MAX_PARALLEL_CALLS`, `PROMPT_BATCHER_MODEL_SEPARATION`.
 - `ELIZA_STATE_DIR` — state-dir resolution (`utils/state-dir.ts`); `ELIZA_WORKSPACE_DIR` — workspace folder (`utils/workspace-folder-config.ts`).
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -237,6 +237,7 @@ import { isObjectRecord as isRecord } from "../utils/type-guards";
 import { maybeHandleAnalysisActivation } from "./analysis-mode-handler";
 import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
+import { runBotNoiseTriage } from "./message/bot-noise-triage";
 import {
 	findAvailableActionName,
 	findWebLookupActionName,
@@ -8862,6 +8863,46 @@ export class DefaultMessageService implements IMessageService {
 					mode: "none",
 				};
 			}
+		}
+
+		// Cheap-tier triage for unaddressed bot/webhook traffic. A relay channel
+		// flooding automated embeds otherwise burns a full composeState + Stage 1
+		// RESPONSE_HANDLER call (the most expensive model in the stack — on
+		// subscription-backed providers ~1000 IGNOREs/day drain the daily session
+		// budget and take the agent down) just to conclude IGNORE. Triage those
+		// turns on TEXT_SMALL BEFORE state composition; an IGNORE verdict ends the
+		// turn with zero large-tier calls. Addressed/human/private-channel turns
+		// never enter this gate, and any triage failure falls open to the full
+		// pipeline.
+		const botNoiseTriage = await runBotNoiseTriage({
+			runtime,
+			message,
+			explicitlyAddressesAgent,
+		});
+		if (botNoiseTriage.applied && !botNoiseTriage.respond) {
+			runtime.logger.info(
+				{
+					src: "service:message",
+					agentId: runtime.agentId,
+					roomId: message.roomId,
+					entityId: message.entityId,
+				},
+				"Unaddressed bot/webhook message ignored by small-model triage (skipped Stage 1)",
+			);
+			await this.emitRunEnded(
+				runtime,
+				runId,
+				message,
+				startTime,
+				"bot_noise_triage",
+			);
+			return {
+				didRespond: false,
+				responseContent: null,
+				responseMessages: [],
+				state: { values: {}, data: {}, text: "" } as State,
+				mode: "none",
+			};
 		}
 
 		// Room context for shouldRespond (fetch before compose so providers see

--- a/packages/core/src/services/message/bot-noise-triage.test.ts
+++ b/packages/core/src/services/message/bot-noise-triage.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Small-model triage for unaddressed bot/webhook traffic.
+ *
+ * Contract under test: a relay channel flooding automated webhook embeds must
+ * NOT reach the expensive Stage 1 RESPONSE_HANDLER call — the RESPOND/IGNORE
+ * verdict for positively bot-authored, unaddressed group messages is made by
+ * the cheap TEXT_SMALL tier. Everything ambiguous (humans, addressed turns,
+ * private channels, sub-agent relays, model failures, unparseable verdicts)
+ * fails OPEN into the normal pipeline.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { Memory } from "../../types/memory";
+import { ModelType } from "../../types/model";
+import { ChannelType, type UUID } from "../../types/primitives";
+import type { IAgentRuntime } from "../../types/runtime";
+import {
+  buildBotNoiseTriagePrompt,
+  isBotNoiseTriageEnabled,
+  isTriagableBotNoiseMessage,
+  runBotNoiseTriage,
+} from "./bot-noise-triage";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000000a" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000000b" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-00000000000c" as UUID;
+
+/** A ZenithProxy-style relay embed: webhook-authored, unaddressed, GROUP. */
+function relayEmbedMessage(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "00000000-0000-0000-0000-00000000000d" as UUID,
+    entityId: SENDER_ID,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    content: {
+      text: "3fingersBTW | ZenithProxy:\n\nEmbed #1:\n  Title:Started Queuing\n  Description:(none)",
+      source: "discord",
+      channelType: ChannelType.GROUP,
+    },
+    metadata: {
+      type: "message",
+      fromBot: true,
+      entityName: "ZenithProxy",
+      entityUserName: "ZenithProxy#0000",
+    } as Memory["metadata"],
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+function makeRuntime(args: {
+  modelResult?: unknown;
+  modelError?: Error;
+  settings?: Record<string, string>;
+  memories?: Memory[];
+  memoriesError?: Error;
+}): IAgentRuntime & { useModel: ReturnType<typeof vi.fn> } {
+  const useModel = vi.fn(async () => {
+    if (args.modelError) throw args.modelError;
+    return args.modelResult ?? "IGNORE";
+  });
+  const getMemories = vi.fn(async () => {
+    if (args.memoriesError) throw args.memoriesError;
+    return args.memories ?? [];
+  });
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Remilio" },
+    getSetting: (key: string) => args.settings?.[key],
+    useModel,
+    getMemories,
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  } as unknown as IAgentRuntime & { useModel: ReturnType<typeof vi.fn> };
+}
+
+describe("isTriagableBotNoiseMessage — deterministic preconditions", () => {
+  it("accepts an unaddressed webhook embed in a GROUP channel", () => {
+    expect(isTriagableBotNoiseMessage(relayEmbedMessage(), false)).toBe(true);
+  });
+
+  it("rejects addressed messages (mention/reply/name)", () => {
+    expect(isTriagableBotNoiseMessage(relayEmbedMessage(), true)).toBe(false);
+  });
+
+  it("rejects human-authored messages (no fromBot)", () => {
+    const message = relayEmbedMessage({
+      metadata: { type: "message" } as Memory["metadata"],
+    });
+    expect(isTriagableBotNoiseMessage(message, false)).toBe(false);
+  });
+
+  it("accepts fromBot stamped on content.metadata (alternate connector shape)", () => {
+    const base = relayEmbedMessage({
+      metadata: { type: "message" } as Memory["metadata"],
+    });
+    const message: Memory = {
+      ...base,
+      content: { ...base.content, metadata: { fromBot: true } },
+    };
+    expect(isTriagableBotNoiseMessage(message, false)).toBe(true);
+  });
+
+  it("rejects private channels (DM) and unknown/missing channel types", () => {
+    const dm = relayEmbedMessage();
+    dm.content = { ...dm.content, channelType: ChannelType.DM };
+    expect(isTriagableBotNoiseMessage(dm, false)).toBe(false);
+
+    const missing = relayEmbedMessage();
+    missing.content = { ...missing.content, channelType: undefined };
+    expect(isTriagableBotNoiseMessage(missing, false)).toBe(false);
+  });
+
+  it("rejects voice group rooms (own turn-taking pipeline)", () => {
+    const voice = relayEmbedMessage();
+    voice.content = { ...voice.content, channelType: ChannelType.VOICE_GROUP };
+    expect(isTriagableBotNoiseMessage(voice, false)).toBe(false);
+  });
+
+  it("rejects sub-agent completion relays (source and metadata shapes)", () => {
+    const bySource = relayEmbedMessage();
+    bySource.content = { ...bySource.content, source: "sub_agent" };
+    expect(isTriagableBotNoiseMessage(bySource, false)).toBe(false);
+
+    const byMetadata = relayEmbedMessage({
+      metadata: {
+        type: "message",
+        fromBot: true,
+        subAgent: true,
+      } as Memory["metadata"],
+    });
+    expect(isTriagableBotNoiseMessage(byMetadata, false)).toBe(false);
+  });
+
+  it("rejects autonomous turns and always-respond sources", () => {
+    const autonomous = relayEmbedMessage();
+    autonomous.content = {
+      ...autonomous.content,
+      metadata: { isAutonomous: true },
+    };
+    expect(isTriagableBotNoiseMessage(autonomous, false)).toBe(false);
+
+    const clientChat = relayEmbedMessage();
+    clientChat.content = { ...clientChat.content, source: "client_chat" };
+    expect(isTriagableBotNoiseMessage(clientChat, false)).toBe(false);
+  });
+});
+
+describe("isBotNoiseTriageEnabled", () => {
+  it("defaults ON and honors the opt-out", () => {
+    expect(isBotNoiseTriageEnabled(makeRuntime({}))).toBe(true);
+    for (const value of ["0", "false", "off", "no"]) {
+      expect(
+        isBotNoiseTriageEnabled(
+          makeRuntime({ settings: { ELIZA_BOT_NOISE_TRIAGE: value } }),
+        ),
+      ).toBe(false);
+    }
+    expect(
+      isBotNoiseTriageEnabled(
+        makeRuntime({ settings: { ELIZA_BOT_NOISE_TRIAGE: "1" } }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("runBotNoiseTriage — cheap-tier verdict", () => {
+  it("IGNORE verdict ends the turn via TEXT_SMALL, never RESPONSE_HANDLER", async () => {
+    const runtime = makeRuntime({ modelResult: "IGNORE" });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: true, respond: false });
+    expect(runtime.useModel).toHaveBeenCalledTimes(1);
+    const [modelType, params] = runtime.useModel.mock.calls[0] as [
+      string,
+      { prompt: string },
+    ];
+    expect(modelType).toBe(ModelType.TEXT_SMALL);
+    expect(modelType).not.toBe(ModelType.RESPONSE_HANDLER);
+    expect(params.prompt).toContain("ZenithProxy");
+    expect(params.prompt).toContain("Remilio");
+    expect(params.prompt).toContain("RESPOND or IGNORE");
+  });
+
+  it("RESPOND verdict falls through to the full pipeline", async () => {
+    const runtime = makeRuntime({ modelResult: "RESPOND" });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: true, respond: true });
+  });
+
+  it("accepts GenerateTextResult-shaped model output", async () => {
+    const runtime = makeRuntime({ modelResult: { text: "ignore" } });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: true, respond: false });
+  });
+
+  it("fails open on an unparseable verdict", async () => {
+    for (const garbage of ["", "maybe?", "RESPOND IGNORE"]) {
+      const runtime = makeRuntime({ modelResult: garbage });
+      const result = await runBotNoiseTriage({
+        runtime,
+        message: relayEmbedMessage(),
+        explicitlyAddressesAgent: false,
+      });
+      expect(result).toEqual({ applied: false });
+    }
+  });
+
+  it("fails open when the TEXT_SMALL call throws (missing handler / provider down)", async () => {
+    const runtime = makeRuntime({
+      modelError: new Error("No handler found for delegate type: TEXT_SMALL"),
+    });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: false });
+  });
+
+  it("still triages when the history fetch fails", async () => {
+    const runtime = makeRuntime({
+      modelResult: "IGNORE",
+      memoriesError: new Error("db down"),
+    });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: true, respond: false });
+  });
+
+  it("never calls the model for non-triagable messages", async () => {
+    const runtime = makeRuntime({});
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: true,
+    });
+    expect(result).toEqual({ applied: false });
+    expect(runtime.useModel).not.toHaveBeenCalled();
+  });
+
+  it("never calls the model when disabled", async () => {
+    const runtime = makeRuntime({
+      settings: { ELIZA_BOT_NOISE_TRIAGE: "0" },
+    });
+    const result = await runBotNoiseTriage({
+      runtime,
+      message: relayEmbedMessage(),
+      explicitlyAddressesAgent: false,
+    });
+    expect(result).toEqual({ applied: false });
+    expect(runtime.useModel).not.toHaveBeenCalled();
+  });
+
+  it("includes recent room history in the prompt, oldest first, excluding the current message", async () => {
+    const older = relayEmbedMessage({
+      id: "00000000-0000-0000-0000-000000000021" as UUID,
+      createdAt: 10,
+    });
+    older.content = { ...older.content, text: "earlier queue update" };
+    const agentMsg = relayEmbedMessage({
+      id: "00000000-0000-0000-0000-000000000022" as UUID,
+      entityId: AGENT_ID,
+      createdAt: 20,
+    });
+    agentMsg.content = { ...agentMsg.content, text: "on it" };
+    const current = relayEmbedMessage();
+    const runtime = makeRuntime({
+      modelResult: "IGNORE",
+      memories: [agentMsg, older, current],
+    });
+    await runBotNoiseTriage({
+      runtime,
+      message: current,
+      explicitlyAddressesAgent: false,
+    });
+    const [, params] = runtime.useModel.mock.calls[0] as [
+      string,
+      { prompt: string },
+    ];
+    const earlierIdx = params.prompt.indexOf("earlier queue update");
+    const agentIdx = params.prompt.indexOf("Remilio: on it");
+    expect(earlierIdx).toBeGreaterThan(-1);
+    expect(agentIdx).toBeGreaterThan(earlierIdx);
+  });
+});
+
+describe("buildBotNoiseTriagePrompt", () => {
+  it("clips oversized embed bodies so triage stays cheap", () => {
+    const prompt = buildBotNoiseTriagePrompt({
+      agentName: "Remilio",
+      senderName: "ZenithProxy",
+      messageText: "x".repeat(10_000),
+      historyLines: [],
+    });
+    expect(prompt.length).toBeLessThan(2_500);
+    expect(prompt).toContain("…");
+  });
+});

--- a/packages/core/src/services/message/bot-noise-triage.ts
+++ b/packages/core/src/services/message/bot-noise-triage.ts
@@ -1,0 +1,268 @@
+/**
+ * Small-model triage for unaddressed bot/webhook traffic.
+ *
+ * Every inbound message normally runs the full Stage 1 RESPONSE_HANDLER call —
+ * the most expensive model in the stack. That is correct for human/addressed
+ * turns (Stage 1 produces the reply), but a relay channel flooding automated
+ * webhook embeds (status feeds, queue updates, bot-to-bot chatter) burns a
+ * full composeState + RESPONSE_HANDLER call per message just to conclude
+ * IGNORE. On subscription-backed RESPONSE_HANDLER providers (plugin-cli-
+ * inference claude-sdk/codex-sdk) ~1000 such IGNOREs/day drain the daily
+ * session budget and take the whole agent down at the provider's reset window.
+ *
+ * This gate runs BEFORE state composition, only for messages that are
+ * positively bot/webhook-authored (`fromBot` connector metadata) AND not
+ * addressed to the agent (no platform mention/reply, agent not named in the
+ * text). It asks the cheap TEXT_SMALL tier for a one-word RESPOND/IGNORE
+ * verdict; IGNORE ends the turn with zero large-tier calls. Everything
+ * ambiguous fails OPEN into the normal pipeline: private channels, sub-agent
+ * completion relays, autonomous turns, missing channel metadata, a missing
+ * TEXT_SMALL handler, model errors, and unparseable verdicts all fall through
+ * to the full Stage 1 path, so behavior for addressed/owner/human traffic is
+ * unchanged.
+ */
+
+import type { Memory } from "../../types/memory";
+import { type GenerateTextParams, ModelType } from "../../types/model";
+import { ChannelType } from "../../types/primitives";
+import type { IAgentRuntime } from "../../types/runtime";
+
+/**
+ * Text group-ish channel types the gate applies to. Private channels
+ * (DM/VOICE_DM/SELF/API) always respond and never reach the gate; voice group
+ * rooms have their own turn-taking pipeline and are deliberately excluded.
+ */
+const TRIAGE_CHANNEL_TYPES: ReadonlySet<string> = new Set([
+  String(ChannelType.GROUP),
+  String(ChannelType.THREAD),
+  String(ChannelType.WORLD),
+  String(ChannelType.FORUM),
+  String(ChannelType.FEED),
+]);
+
+/** Sub-agent completion relays are routed by their own evaluator — never gate. */
+const SUB_AGENT_SOURCE = "sub_agent";
+
+/** Sources that bypass should-respond entirely (mirrors the deterministic gate). */
+const ALWAYS_RESPOND_SOURCES: readonly string[] = ["client_chat"];
+
+const MAX_HISTORY_MESSAGES = 8;
+const MAX_HISTORY_LINE_CHARS = 160;
+const MAX_CURRENT_TEXT_CHARS = 1200;
+
+export interface BotNoiseTriageArgs {
+  runtime: IAgentRuntime;
+  message: Memory;
+  /** Platform mention/reply or agent named in text (computed by the caller). */
+  explicitlyAddressesAgent: boolean;
+}
+
+export type BotNoiseTriageResult =
+  /** Gate did not apply (or failed open) — run the full pipeline. */
+  | { applied: false }
+  /** Small-model verdict. `respond: false` ends the turn before Stage 1. */
+  | { applied: true; respond: boolean };
+
+function metadataRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * The gate is ON by default; opt out with ELIZA_BOT_NOISE_TRIAGE=0|false|off.
+ */
+export function isBotNoiseTriageEnabled(runtime: IAgentRuntime): boolean {
+  const raw = runtime.getSetting("ELIZA_BOT_NOISE_TRIAGE");
+  if (raw === undefined || raw === null) return true;
+  const normalized = String(raw).trim().toLowerCase();
+  return !["0", "false", "no", "off"].includes(normalized);
+}
+
+/**
+ * Deterministic preconditions: only positively-identified, unaddressed
+ * bot/webhook group traffic is triagable. Anything the checks cannot confirm
+ * falls through to the full pipeline (fail-open).
+ */
+export function isTriagableBotNoiseMessage(
+  message: Memory,
+  explicitlyAddressesAgent: boolean,
+): boolean {
+  if (explicitlyAddressesAgent) return false;
+
+  const contentMetadata = metadataRecord(message.content?.metadata);
+  const topLevelMetadata = metadataRecord(message.metadata);
+
+  // Positively bot/webhook-authored only (connector-stamped `fromBot`).
+  const fromBot =
+    contentMetadata?.fromBot === true || topLevelMetadata?.fromBot === true;
+  if (!fromBot) return false;
+
+  // Autonomous self-turns are not inbound noise.
+  if (
+    contentMetadata?.isAutonomous === true ||
+    topLevelMetadata?.isAutonomous === true
+  ) {
+    return false;
+  }
+
+  // Sub-agent completion relays carry their own routing evaluator.
+  const source =
+    typeof message.content?.source === "string"
+      ? message.content.source.trim().toLowerCase()
+      : "";
+  if (source === SUB_AGENT_SOURCE) return false;
+  if (
+    contentMetadata?.subAgent === true ||
+    topLevelMetadata?.subAgent === true
+  ) {
+    return false;
+  }
+  if (ALWAYS_RESPOND_SOURCES.some((pattern) => source.includes(pattern))) {
+    return false;
+  }
+
+  // Only known text group-ish channels; unknown/missing channel type fails open.
+  const channelType =
+    typeof message.content?.channelType === "string"
+      ? message.content.channelType.trim().toUpperCase()
+      : "";
+  return TRIAGE_CHANNEL_TYPES.has(channelType);
+}
+
+function senderNameOf(message: Memory): string {
+  const metadata = metadataRecord(message.metadata);
+  const entityName = metadata?.entityName;
+  if (typeof entityName === "string" && entityName.trim() !== "") {
+    return entityName.trim();
+  }
+  const entityUserName = metadata?.entityUserName;
+  if (typeof entityUserName === "string" && entityUserName.trim() !== "") {
+    return entityUserName.trim();
+  }
+  return "bot";
+}
+
+function clip(text: string, maxChars: number): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  return collapsed.length > maxChars
+    ? `${collapsed.slice(0, maxChars)}…`
+    : collapsed;
+}
+
+function historyLine(runtime: IAgentRuntime, memory: Memory): string | null {
+  const text =
+    typeof memory.content?.text === "string" ? memory.content.text : "";
+  if (text.trim() === "") return null;
+  const name =
+    memory.entityId === runtime.agentId
+      ? (runtime.character?.name ?? "agent")
+      : senderNameOf(memory);
+  return `${name}: ${clip(text, MAX_HISTORY_LINE_CHARS)}`;
+}
+
+export function buildBotNoiseTriagePrompt(args: {
+  agentName: string;
+  senderName: string;
+  messageText: string;
+  historyLines: readonly string[];
+}): string {
+  const history =
+    args.historyLines.length > 0 ? args.historyLines.join("\n") : "(none)";
+  return [
+    `You decide whether ${args.agentName}, an AI agent in a group channel, should respond to a message.`,
+    `The newest message was posted by a bot or webhook and does not mention or address ${args.agentName}.`,
+    "",
+    "Recent channel messages:",
+    history,
+    "",
+    `Newest message, from ${args.senderName} (bot/webhook):`,
+    clip(args.messageText, MAX_CURRENT_TEXT_CHARS) || "(empty)",
+    "",
+    `Automated status feeds, embeds, queue/system updates, notifications, and bot-to-bot chatter not involving ${args.agentName} should be ignored.`,
+    `Answer RESPOND only if the message clearly asks ${args.agentName} something or requires ${args.agentName} to act.`,
+    "Reply with exactly one word: RESPOND or IGNORE.",
+  ].join("\n");
+}
+
+function parseTriageVerdict(raw: string): boolean | undefined {
+  const normalized = raw.trim().toUpperCase();
+  const saysIgnore = /\bIGNORE\b/.test(normalized);
+  const saysRespond = /\bRESPOND\b/.test(normalized);
+  if (saysIgnore && !saysRespond) return false;
+  if (saysRespond && !saysIgnore) return true;
+  return undefined;
+}
+
+/**
+ * Run the cheap-tier triage. Returns `{ applied: false }` whenever the gate
+ * does not confidently apply — the caller then runs the normal pipeline.
+ */
+export async function runBotNoiseTriage(
+  args: BotNoiseTriageArgs,
+): Promise<BotNoiseTriageResult> {
+  const { runtime, message, explicitlyAddressesAgent } = args;
+  if (!isBotNoiseTriageEnabled(runtime)) return { applied: false };
+  if (!isTriagableBotNoiseMessage(message, explicitlyAddressesAgent)) {
+    return { applied: false };
+  }
+
+  let historyLines: string[] = [];
+  try {
+    const recent = await runtime.getMemories({
+      tableName: "messages",
+      roomId: message.roomId,
+      count: MAX_HISTORY_MESSAGES,
+    });
+    historyLines = recent
+      .filter((memory) => memory.id !== message.id)
+      .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+      .map((memory) => historyLine(runtime, memory))
+      .filter((line): line is string => line !== null);
+  } catch {
+    // History is best-effort context; triage still works without it.
+  }
+
+  const prompt = buildBotNoiseTriagePrompt({
+    agentName: runtime.character?.name ?? "agent",
+    senderName: senderNameOf(message),
+    messageText:
+      typeof message.content?.text === "string" ? message.content.text : "",
+    historyLines,
+  });
+
+  try {
+    const params: GenerateTextParams = {
+      prompt,
+      // One word is the contract, but reasoning-style small models may spend
+      // budget before the visible answer — leave headroom so the verdict is
+      // never truncated into a fail-open.
+      maxTokens: 64,
+      temperature: 0,
+      voiceOutput: "internal",
+    };
+    const raw = await runtime.useModel(ModelType.TEXT_SMALL, params);
+    const text =
+      typeof raw === "string"
+        ? raw
+        : (((raw as { text?: unknown })?.text as string | undefined) ?? "");
+    const verdict = parseTriageVerdict(text);
+    if (verdict === undefined) {
+      // Unparseable verdict — fail open into the full pipeline.
+      return { applied: false };
+    }
+    return { applied: true, respond: verdict };
+  } catch (error) {
+    // No TEXT_SMALL handler / provider failure: the gate must never take
+    // the pipeline down. Fail open.
+    runtime.logger?.debug?.(
+      {
+        src: "service:message",
+        agentId: runtime.agentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[message] bot-noise triage model call failed — falling back to full pipeline",
+    );
+    return { applied: false };
+  }
+}


### PR DESCRIPTION
Closes #11944

### Problem

Every inbound message runs the full Stage 1 `RESPONSE_HANDLER` call — including relay/webhook noise the agent will only ever IGNORE. On a live agent, a Discord channel relaying ZenithProxy queue embeds produced ~1000 Stage 1 calls/day (70% of a 200-trajectory random sample end `shouldRespond:"IGNORE"`; example `tj-40c9a7018648c2`: 32,687-char prompt, 6.7 s, output `{"shouldRespond":"IGNORE"}`). With `RESPONSE_HANDLER` on a subscription-backed provider (plugin-cli-inference claude-sdk), that was 923 subscription calls on Jul 2 alone and 131 `subscription rate limit reached: You've hit your session limit · resets 4am (UTC)` failures — a nightly whole-agent outage. Full evidence in the linked issue.

The deterministic `shouldRespond()` gate only runs in the no-text-handler branch; with a text handler registered, `processMessage` → `runV5MessageRuntimeStage1` → `useModel(RESPONSE_HANDLER, …)` runs unconditionally. plugin-cli-inference deliberately leaves `TEXT_SMALL`/`NANO`/`MEDIUM` unregistered so "high-frequency should-respond/triage" stays on the cheap provider — but core never makes any such triage call, so the design intent has no effect.

### Fix

New pre-gate in `DefaultMessageService.processMessage` (`packages/core/src/services/message/bot-noise-triage.ts`), placed after the muted/personality gates and **before** room fetch / attachment processing / `composeResponseState`:

- Deterministic preconditions — the gate only considers messages that are **positively** bot/webhook-authored (connector-stamped `fromBot`) AND unaddressed (no platform mention/reply, agent not named in text) AND in a text group channel (`GROUP`/`THREAD`/`WORLD`/`FORUM`/`FEED`).
- Those messages get a one-word RESPOND/IGNORE verdict from `ModelType.TEXT_SMALL` on a compact prompt (recent room tail + clipped message text). IGNORE ends the turn with zero large-tier calls (`RUN_ENDED` status `bot_noise_triage`); RESPOND falls through to the normal pipeline.
- **Fail-open everywhere**: humans, addressed/owner turns, DMs/API/voice, sub-agent completion relays (`sub_agent` source / `subAgent` metadata), autonomous turns, `client_chat`, missing channel metadata, a missing TEXT_SMALL handler, provider errors, and unparseable verdicts all take the existing full Stage 1 path. Behavior for every non-noise turn is unchanged.
- Opt-out: `ELIZA_BOT_NOISE_TRIAGE=0` (documented in `packages/core/CLAUDE.md`/`AGENTS.md`).

Effect on the live failure mode: the ~1000/day IGNORE decisions move from an ~8k-token `RESPONSE_HANDLER` (opus via the Claude subscription) to a ~300-token `TEXT_SMALL` call (e.g. Cerebras gpt-oss), and additionally skip composeState entirely — reserving the subscription for addressed/owner turns.

### Testing

- `packages/core/src/services/message/bot-noise-triage.test.ts` — 19 tests: the real ZenithProxy embed shape triages via TEXT_SMALL and never touches RESPONSE_HANDLER; every fail-open path (addressed, human, DM, voice, sub-agent relay, autonomous, client_chat, missing channelType, model throw, garbage verdict, history-fetch failure); prompt content/ordering/clipping; enable-flag semantics; both `fromBot` metadata shapes.
- `bun run --cwd packages/core test` — 308/309 files, 2711/2712 tests pass; the single failure (`link-extraction.test.ts`) fails identically on clean `origin/develop` in the same environment (pre-existing, unrelated).
- `bun run --cwd packages/core typecheck` — clean.
- Targeted regression suites green: `message-runtime-stage1`, `message-routing-live-regression`, `message-stage1-context-catalog`, `services/message/*`.

### Evidence

- Live trajectory of the burn (read by hand): `tj-40c9a7018648c2` — ZenithProxy "Started Queuing" embed → single `RESPONSE_HANDLER` stage, 32,687-char prompt, `{"shouldRespond":"IGNORE",...}` output, $0 of value.
- Live server logs: 923 `[cli-inference] RESPONSE_HANDLER via claude-sdk` on Jul 2; 131 session-limit failures with the exact provider error string.
- N/A — screenshots/video: core message-pipeline cost fix, no UI surface.
- N/A — scenario-runner live trajectory for the new gate: the triage call is a one-word TEXT_SMALL completion fully covered by unit tests + the live-burn trajectories above; the gated deployment (self-hosted agent on the affected relay channel) will validate live before/after counts.
