### PR TITLE
fix(agent): preserve semantic search vector results

### DIFF
--- a/packages/agent/src/actions/database.search-vectors.test.ts
+++ b/packages/agent/src/actions/database.search-vectors.test.ts
@@ -1,0 +1,69 @@
+import type { ActionResult, IAgentRuntime, Memory } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { databaseAction } from "./database";
+
+function createRuntime() {
+  const searchMemories = vi.fn().mockResolvedValue([
+    {
+      id: "memory-1",
+      content: { text: "I bought a new car" },
+      roomId: "room-1",
+      entityId: "entity-1",
+      createdAt: 123,
+      similarity: 0.91,
+    },
+  ]);
+  const useModel = vi.fn().mockImplementation((model: unknown) => {
+    if (model === ModelType.TEXT_EMBEDDING) return [0.1, 0.2, 0.3];
+    throw new Error(`unexpected model ${model}`);
+  });
+
+  const runtime = {
+    useModel,
+    searchMemories,
+    registerSearchCategory: vi.fn(),
+    adapter: {},
+  } as unknown as IAgentRuntime;
+
+  return { runtime, searchMemories, useModel };
+}
+
+describe("DATABASE search_vectors", () => {
+  it("does not pass the text query into vector memory search", async () => {
+    const { runtime, searchMemories, useModel } = createRuntime();
+
+    const result = (await databaseAction.handler(
+      runtime,
+      {} as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "search_vectors",
+          query: "automobile purchase",
+          table: "memories",
+          limit: 7,
+          threshold: 0.4,
+        },
+      },
+    )) as ActionResult;
+
+    expect(useModel).toHaveBeenCalledWith(ModelType.TEXT_EMBEDDING, {
+      text: "automobile purchase",
+    });
+    expect(searchMemories).toHaveBeenCalledWith({
+      embedding: [0.1, 0.2, 0.3],
+      tableName: "memories",
+      limit: 7,
+      match_threshold: 0.4,
+    });
+    expect(searchMemories.mock.calls[0]?.[0]).not.toHaveProperty("query");
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      op: "search_vectors",
+      query: "automobile purchase",
+      table: "memories",
+    });
+  });
+});

--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -599,7 +599,16 @@ async function opSearchVectors(
 
   const matches: Memory[] = await runtime.searchMemories({
     embedding,
-    query,
+    // Intentionally NO `query` here. Passing `query` makes runtime.searchMemories
+    // pipe the vector hits through rerankMemories → BM25, which DROPS every
+    // candidate with zero stemmed-keyword overlap (search.ts: `if (score <= 0)
+    // continue`). That turns "rerank" into a keyword FILTER: a semantic search
+    // like "automobile purchase" returns nothing for a stored "I bought a new
+    // car", and attachment-only memories (no content.text) are always dropped —
+    // defeating the whole point of a vector search. This IS a vector search, so
+    // the adapter's cosine-similarity order is authoritative. Mirrors the same
+    // deliberate omission in core/features/documents/service.ts, which documents
+    // this exact trap.
     tableName: table,
     limit,
     ...(typeof params.threshold === "number"


### PR DESCRIPTION
Supersedes #11939. Closes #11938.

## Summary
- Stop passing the text query into `runtime.searchMemories` for `DATABASE` `search_vectors`, so BM25 rerank cannot filter out zero-keyword-overlap semantic matches
- Keep the original query in the returned action data for caller context
- Add a focused regression test around the real `databaseAction.handler` path

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/agent test src/actions/database.search-vectors.test.ts — 1 test passed
- bun run --cwd packages/agent typecheck
- bunx @biomejs/biome check packages/agent/src/actions/database.ts packages/agent/src/actions/database.search-vectors.test.ts
- git diff --check origin/develop...HEAD && git diff --check

N/A: screenshots/audio/live-LLM trajectory; this is a deterministic database action parameter fix with no UI or model-prompt behavior change.