### PR TITLE
fix(core): keep brain-provider override failover tail

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4650,7 +4650,10 @@ export class AgentRuntime implements IAgentRuntime {
 	 * flips the chat brain on the next model call with no restart. Returns
 	 * undefined when the setting is empty OR names a provider that has no
 	 * registered text handler, so a stale or mistyped value never strands the
-	 * brain — it simply falls back to the default provider.
+	 * brain — it simply falls back to the default provider. The same contract
+	 * holds at call time: useModel keeps the default-chain registrations behind
+	 * the override as a failover tail, so a rate-limited/exhausted override
+	 * provider falls to the registered backups instead of stranding the brain.
 	 */
 	private resolveTextProviderOverride(): string | undefined {
 		const raw = this.getSetting("ELIZA_BRAIN_PROVIDER");
@@ -5131,9 +5134,30 @@ export class AgentRuntime implements IAgentRuntime {
 		const overrideResolved = providerOverride
 			? this.resolveModelRegistrations(requestedModelKey, providerOverride)
 			: [];
+		// The override provider goes FIRST, but the remaining default-chain
+		// registrations stay behind it as the failover tail. Without the tail a
+		// rate-limited override provider strands the brain (its throw has no next
+		// registration to fall to) even though healthy backup providers are
+		// registered — violating the "never strands the brain" contract of
+		// resolveTextProviderOverride. The failover loop below still only
+		// advances on fallback-class errors, so a healthy pinned provider keeps
+		// winning every call.
 		const resolvedModels =
 			overrideResolved.length > 0
-				? overrideResolved
+				? [
+						...overrideResolved,
+						...this.resolveModelRegistrations(
+							requestedModelKey,
+							requestedProvider,
+						).filter(
+							(candidate) =>
+								!overrideResolved.some(
+									(chosen) =>
+										chosen.handler === candidate.handler &&
+										chosen.modelKey === candidate.modelKey,
+								),
+						),
+					]
 				: this.resolveModelRegistrations(requestedModelKey, requestedProvider);
 		if (resolvedModels.length === 0) {
 			this.throwNoModelHandler(requestedModelKey);

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -3,17 +3,21 @@ import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
 import { type Character, ModelType } from "../../types";
 
-function makeRuntime(): AgentRuntime {
+function makeRuntime(settings: Record<string, string> = {}): AgentRuntime {
 	return new AgentRuntime({
 		character: {
 			name: "ProviderFailoverAgent",
 			bio: "test",
-			settings: {},
+			settings,
 		} as Character,
 		adapter: new InMemoryDatabaseAdapter(),
 		logLevel: "fatal",
 	});
 }
+
+/** The exact subscription-limit error the cli-inference SDK session throws live. */
+const CLI_INFERENCE_LIMIT_ERROR =
+	"[cli-inference:sdk] subscription rate limit reached: You've hit your session limit · resets 9:30pm (UTC)";
 
 describe("AgentRuntime.useModel provider failover", () => {
 	it("tries the next registered provider when the preferred provider is exhausted", async () => {
@@ -68,6 +72,117 @@ describe("AgentRuntime.useModel provider failover", () => {
 		).rejects.toThrow("invalid request payload");
 		expect(failingHandler).toHaveBeenCalledTimes(1);
 		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("fails over past an ELIZA_BRAIN_PROVIDER override when it is rate-limited", async () => {
+		// The owner pinned the chat brain to the subscription CLI route. When that
+		// provider throws its limit envelope the pin must NOT strand the brain —
+		// the remaining registered providers are the backup tier (#10893).
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error(CLI_INFERENCE_LIMIT_ERROR);
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			exhaustedHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("backup response");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("still prefers the ELIZA_BRAIN_PROVIDER override when it is healthy", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const pinnedHandler = vi.fn(async () => "pinned response");
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			pinnedHandler,
+			"cli-inference",
+			10,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			100,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("pinned response");
+		expect(pinnedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("does not fail over past a rate-limited override on ordinary errors", async () => {
+		const runtime = makeRuntime({ ELIZA_BRAIN_PROVIDER: "cli-inference" });
+		const failingHandler = vi.fn(async () => {
+			throw new Error("invalid request payload");
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			failingHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).rejects.toThrow("invalid request payload");
+		expect(failingHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("fails over RESPONSE_HANDLER to the backup provider on a subscription limit", async () => {
+		// RESPONSE_HANDLER is the user-facing reply tier the cli-inference route
+		// serves; the exact live limit throw must reach the backup registration.
+		const runtime = makeRuntime();
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error(CLI_INFERENCE_LIMIT_ERROR);
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			exhaustedHandler,
+			"cli-inference",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.RESPONSE_HANDLER, { prompt: "hello" }),
+		).resolves.toBe("backup response");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not switch providers when a provider is explicitly requested", async () => {


### PR DESCRIPTION
Supersedes #11935.

## Summary
- Keep default-chain model registrations behind `ELIZA_BRAIN_PROVIDER` override as a failover tail
- Preserve override-first behavior for healthy providers and no-failover behavior for ordinary errors
- Extend provider failover runtime tests

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/core test src/runtime/__tests__/model-provider-failover.test.ts — 7 tests passed
- bun run --cwd packages/core typecheck
- bunx @biomejs/biome check packages/core/src/runtime.ts packages/core/src/runtime/__tests__/model-provider-failover.test.ts
- git diff --check origin/develop...HEAD && git diff --check

N/A: UI/audio/live-LLM trajectory; deterministic runtime provider-ordering fix covered by runtime tests.