### PR TITLE
fix(ui): native Apps tab 401 — fall back to the owner cloud API key when no Steward JWT exists

### DIFF
--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -248,4 +248,112 @@ describe("cloud api-client transport bridge", () => {
       expect(capacitorMocks.request).not.toHaveBeenCalled();
     });
   });
+
+  // --- AUTH FALLBACK (#11930): device-code sign-in stores the cloud API key,
+  // never the Steward JWT — native must fall back to it, web must not change.
+
+  describe("cloud API key auth fallback (#11930)", () => {
+    const CLOUD_API_KEY = "eliza-cloud-owner-api-key";
+
+    function nativeOk(): void {
+      capacitorMocks.request.mockResolvedValue({
+        status: 200,
+        data: { apps: [] },
+        headers: {},
+      });
+    }
+
+    afterEach(() => {
+      delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+    });
+
+    it("native: authorizes with the cloud API key when NO Steward token exists (the #11930 401 path)", async () => {
+      capacitorState.isNative = true;
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: CLOUD_API_KEY,
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      expect(capacitorMocks.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.elizacloud.ai/api/v1/apps",
+          headers: expect.objectContaining({
+            authorization: `Bearer ${CLOUD_API_KEY}`,
+          }),
+        }),
+      );
+    });
+
+    it("native: the Steward JWT still WINS over the cloud API key when both exist", async () => {
+      capacitorState.isNative = true;
+      // beforeEach already seeded STEWARD_TOKEN_KEY.
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: CLOUD_API_KEY,
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      expect(capacitorMocks.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            authorization: `Bearer ${STEWARD_TOKEN}`,
+          }),
+        }),
+      );
+    });
+
+    it("native: the __ELIZA_CLOUD_AUTH_TOKEN__ global outranks the REST token, matching getCloudAuthToken()", async () => {
+      capacitorState.isNative = true;
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+        "legacy-global-cloud-token";
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: CLOUD_API_KEY,
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      expect(capacitorMocks.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            authorization: "Bearer legacy-global-cloud-token",
+          }),
+        }),
+      );
+    });
+
+    it("web: stays byte-identical — NO Authorization header from the REST token without a Steward JWT", async () => {
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: CLOUD_API_KEY,
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ apps: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await api("/api/v1/apps");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [, calledInit] = fetchSpy.mock.calls[0];
+      expect(
+        new Headers((calledInit as RequestInit).headers).get("Authorization"),
+      ).toBeNull();
+    });
+  });
 });

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -25,6 +25,7 @@
  */
 
 import { Capacitor, CapacitorHttp } from "@capacitor/core";
+import { getElizaApiToken } from "@elizaos/shared";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { getBootConfig } from "../../config/boot-config";
@@ -152,6 +153,34 @@ function readStewardToken(): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the Cloud bearer for the auth header. The Steward session JWT stays
+ * first (canonical, unchanged). On native/Electrobun ONLY, fall back to the
+ * owner cloud API key: device-code sign-in never writes `STEWARD_TOKEN_KEY` —
+ * it stores the cloud API key on the agent client, which mirrors it into boot
+ * config + the `__ELIZA_API_TOKEN__` global (see `ElizaClient.setToken`). So
+ * without this fallback every native Apps API call left the WebView with NO
+ * Authorization header and 401'd (#11930). The chain mirrors the canonical
+ * `getCloudAuthToken()` in `../../api/client-cloud.ts` (steward JWT →
+ * `__ELIZA_CLOUD_AUTH_TOKEN__` global → client REST token), read here via the
+ * token's out-of-band mirrors because this module has no client handle. The
+ * Cloud API accepts both a Steward JWT and the owner API key. Web stays
+ * byte-identical (steward token or nothing, exactly as before).
+ */
+function readCloudBearerToken(): string | null {
+  const stewardToken = readStewardToken()?.trim();
+  if (stewardToken) return stewardToken;
+  if (!isNativeCloudRuntime()) return null;
+  const globalToken = (globalThis as Record<string, unknown>)
+    .__ELIZA_CLOUD_AUTH_TOKEN__;
+  if (typeof globalToken === "string" && globalToken.trim()) {
+    return globalToken.trim();
+  }
+  const restToken =
+    getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim();
+  return restToken || null;
 }
 
 // ---------------------------------------------------------------------------
@@ -334,7 +363,7 @@ export async function apiFetch(
     headers.set("Content-Type", "application/json");
   }
   if (!skipAuth) {
-    const token = readStewardToken();
+    const token = readCloudBearerToken();
     if (token && !headers.has("Authorization")) {
       headers.set("Authorization", `Bearer ${token}`);
     }


### PR DESCRIPTION
Fixes #11930

[phone-ui]

## Problem — auth behavior BEFORE

`packages/ui/src/cloud/lib/api-client.ts` built the `Authorization` header from `readStewardToken()` ONLY (localStorage `STEWARD_TOKEN_KEY`). Device-code sign-in on native/Electrobun never writes that key — it stores the **owner cloud API key** on the agent client (`ElizaClient.setToken()`, which mirrors it into boot config `apiToken` + the `__ELIZA_API_TOKEN__` global). Result: every Apps API call from a device-code-signed-in native/desktop app left the WebView with **no Authorization header** and 401'd — the Apps tab was dead on native.

## Fix — auth behavior AFTER

New `readCloudBearerToken()` mirrors the canonical resolver `getCloudAuthToken()` (`packages/ui/src/api/client-cloud.ts`), which the backend already honors for both credential types (Steward JWT **and** owner cloud API key):

1. **Steward JWT first** (localStorage) — unchanged, still wins whenever present.
2. Native/Electrobun ONLY, when no JWT: `__ELIZA_CLOUD_AUTH_TOKEN__` global, then the client REST token read via its mirrors `getBootConfig().apiToken || getElizaApiToken()` (this module has no client handle; the mirrors are exactly what `client.getRestAuthToken()` resolves — same pattern as `api/csrf-client.ts`).
3. **Web stays byte-identical**: the fallback is gated behind `isNativeCloudRuntime()`, per the module's documented same-origin/cookie contract.

## Tests (`api-client.test.ts`, vitest + jsdom — 14/14 green)

4 new cases in a `cloud API key auth fallback (#11930)` block:
- native + NO Steward token + cloud API key in boot config → CapacitorHttp request carries `authorization: Bearer <cloud-key>` (the 401 path is gone)
- native + BOTH present → the Steward JWT still wins
- native + `__ELIZA_CLOUD_AUTH_TOKEN__` global → outranks the REST token (matches `getCloudAuthToken()` ordering)
- web + NO Steward token + REST token present → **no** Authorization header (web path unchanged)

All 10 pre-existing transport-bridge tests (same-origin throw, allowlisted-host-only native bridge, error mapping) still pass.

## Mutation check

Neutered the fallback (`return null` before the native branch) → exactly the 2 fallback tests went red while steward-wins + web-unchanged stayed green → restored → 14/14 green. The tests demonstrably pin the fix.

`bunx biome check --write` clean on both files. Only `packages/ui/src/cloud/lib/api-client.{ts,test.ts}` touched — no backend/Worker/money surface.

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Root cause was pre-diagnosed by [phone-ui] while Fable-capped (posted on #11930), so this pass applied the exact fix. Independently re-verified: 2-file merge-base diff, 14/14 green (--no-cache), and the fallback mutation reproduced (neuter → 2 cloud-key tests red; restore → green). Native-gated so the web path is byte-identical. — [phone-ui]