### PR TITLE
fix(core): repair task backoff, cron days, plugin filters

### DIFF
--- a/packages/core/src/services/plugin-hooks.test.ts
+++ b/packages/core/src/services/plugin-hooks.test.ts
@@ -68,6 +68,33 @@ describe("applyPluginFilter — deny list", () => {
 			"@elizaos/plugin-sql",
 		]);
 	});
+
+	it("matches exactly, never by substring: deny 'x' must not remove plugin-xai", () => {
+		// plugin-x (the X/Twitter connector) and plugin-xai (the xAI model
+		// provider) are both real plugins in this repo. A substring match makes
+		// `deny: ["x"]` silently drop plugin-xai too — and `allow: ["x"]`
+		// silently admit it past the whitelist.
+		const plugins = [
+			plugin("@elizaos/plugin-x"),
+			plugin("@elizaos/plugin-xai"),
+		];
+		expect(names(applyPluginFilter(plugins, { deny: ["x"] }))).toEqual([
+			"@elizaos/plugin-xai",
+		]);
+		expect(names(applyPluginFilter(plugins, { allow: ["x"] }))).toEqual([
+			"@elizaos/plugin-x",
+		]);
+	});
+
+	it("still matches a scopeless 'plugin-<name>' entry against the scoped package", () => {
+		const plugins = [
+			plugin("@elizaos/plugin-discord"),
+			plugin("@elizaos/plugin-telegram"),
+		];
+		expect(
+			names(applyPluginFilter(plugins, { deny: ["plugin-discord"] })),
+		).toEqual(["@elizaos/plugin-telegram"]);
+	});
 });
 
 describe("createPluginFilterHook", () => {

--- a/packages/core/src/services/plugin-hooks.ts
+++ b/packages/core/src/services/plugin-hooks.ts
@@ -160,10 +160,18 @@ export function applyPluginFilter(
 		const safeLower = lower.length > 256 ? lower.slice(0, 256) : lower;
 		// Extract short name from full package name
 		const match = safeLower.match(/@[^/]+\/plugin-(.+)$/);
-		return match ? match[1] : safeLower;
+		if (match) return match[1];
+		// Scopeless "plugin-<name>" also normalizes to its short name.
+		return safeLower.startsWith("plugin-")
+			? safeLower.slice("plugin-".length)
+			: safeLower;
 	};
 
-	// Check if a plugin matches any name in a list
+	// Check if a plugin matches any name in a list. Matching is EXACT on the
+	// full name or the normalized short name — never substring. This filter is
+	// a policy boundary: a substring match makes an allow/deny entry silently
+	// hit unrelated plugins (e.g. deny "x" for the X connector must not also
+	// remove "@elizaos/plugin-xai").
 	const matchesAny = (plugin: Plugin, names: string[]): boolean => {
 		const pluginName = plugin.name.toLowerCase();
 		const pluginShortName = normalizePluginName(plugin.name);
@@ -171,9 +179,7 @@ export function applyPluginFilter(
 		return names.some((name) => {
 			const normalizedName = normalizePluginName(name);
 			return (
-				pluginName === name.toLowerCase() ||
-				pluginShortName === normalizedName ||
-				pluginName.includes(normalizedName)
+				pluginName === name.toLowerCase() || pluginShortName === normalizedName
 			);
 		});
 	};

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -284,6 +284,50 @@ describe("TaskService tick re-arm", () => {
 		await vi.advanceTimersByTimeAsync(120_000);
 		expect(execute).toHaveBeenCalledTimes(5);
 	});
+
+	it("does not compound backoff and restores the original cadence when baseInterval was never set", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		let failuresLeft = 2;
+		const execute = vi.fn(async () => {
+			if (failuresLeft > 0) {
+				failuresLeft -= 1;
+				throw new Error("boom");
+			}
+			return undefined;
+		});
+		workers.set("FLAKY_NO_BASE", { name: "FLAKY_NO_BASE", execute });
+		tasks.set("t-nobase", {
+			id: "t-nobase" as UUID,
+			name: "FLAKY_NO_BASE",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			// Deliberately NO baseInterval — the common createTask shape (e.g.
+			// createTestTasks). Backoff must still double off the ORIGINAL
+			// interval, not off the already-inflated updateInterval.
+			metadata: { updateInterval: 1_000, updatedAt: T0 },
+		});
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		// Failure 1 at +1s: backoff to 2^1 * 1s = 2s.
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(tasks.get("t-nobase")?.metadata?.updateInterval).toBe(2_000);
+
+		// Failure 2 at +3s: backoff must be 2^2 * ORIGINAL 1s = 4s, not
+		// 2^2 * the already-doubled 2s = 8s (exponential-of-exponential).
+		await vi.advanceTimersByTimeAsync(2_000);
+		expect(execute).toHaveBeenCalledTimes(2);
+		expect(tasks.get("t-nobase")?.metadata?.updateInterval).toBe(4_000);
+
+		// Success at +7s: cadence restored to the ORIGINAL 1s interval, not
+		// left permanently inflated at the last backoff value.
+		await vi.advanceTimersByTimeAsync(4_000);
+		expect(execute).toHaveBeenCalledTimes(3);
+		const meta = tasks.get("t-nobase")?.metadata;
+		expect(meta?.failureCount).toBe(0);
+		expect(meta?.updateInterval).toBe(1_000);
+	});
 });
 
 describe("AgentRuntime task mutations mark the local TaskService dirty", () => {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -515,6 +515,12 @@ export class TaskService extends Service {
 				} else {
 					const baseInterval =
 						meta?.baseInterval ?? meta?.updateInterval ?? 1000;
+					// Persist the resolved base the FIRST time we back off. Without it,
+					// the next failure's fallback reads the already-doubled
+					// updateInterval (the exponential-of-exponential this branch exists
+					// to prevent) and a later success "restores" updateInterval to the
+					// inflated backoff value permanently instead of the original cadence.
+					newMeta.baseInterval = baseInterval;
 					newMeta.updateInterval = Math.min(
 						baseInterval * 2 ** failureCount,
 						300_000,

--- a/packages/core/src/services/triggerScheduling.test.ts
+++ b/packages/core/src/services/triggerScheduling.test.ts
@@ -100,6 +100,51 @@ describe("computeNextCronRunAtMs - DST fall-back dedupe (#11046)", () => {
 	});
 });
 
+describe("computeNextCronRunAtMs - POSIX day-of-month/day-of-week OR semantics", () => {
+	// Standard (POSIX/Vixie) cron: when BOTH dom and dow are restricted, the
+	// job runs on days matching EITHER field. `0 0 13 * 5` = every 13th AND
+	// every Friday — not only Friday-the-13th.
+	const FRIDAY_JUL_3 = Date.UTC(2026, 6, 3, 12, 0, 0); // 2026-07-03 (a Friday)
+
+	it("sanity: the base date is a Friday", () => {
+		expect(new Date(FRIDAY_JUL_3).getUTCDay()).toBe(5);
+	});
+
+	it("fires on the next matching day-of-week even when the day-of-month has not arrived", () => {
+		// Next Friday (Jul 10) comes before the next 13th (Jul 13). AND
+		// semantics would instead wait months for a Friday-the-13th
+		// (2026-11-13).
+		expect(computeNextCronRunAtMs("0 0 13 * 5", FRIDAY_JUL_3)).toBe(
+			Date.UTC(2026, 6, 10, 0, 0, 0),
+		);
+	});
+
+	it("fires on the next matching day-of-month when it comes before the day-of-week", () => {
+		// `0 0 5 * 1`: the 5th (Sunday Jul 5) comes before the next Monday
+		// (Jul 6).
+		expect(computeNextCronRunAtMs("0 0 5 * 1", FRIDAY_JUL_3)).toBe(
+			Date.UTC(2026, 6, 5, 0, 0, 0),
+		);
+	});
+
+	it("keeps AND semantics when only one day field is restricted", () => {
+		// dom restricted, dow `*`: fire on the 13th regardless of weekday.
+		expect(computeNextCronRunAtMs("0 0 13 * *", FRIDAY_JUL_3)).toBe(
+			Date.UTC(2026, 6, 13, 0, 0, 0),
+		);
+		// dow restricted, dom `*`: fire on the next Monday.
+		expect(computeNextCronRunAtMs("0 0 * * 1", FRIDAY_JUL_3)).toBe(
+			Date.UTC(2026, 6, 6, 0, 0, 0),
+		);
+		// dom `*/2` starts with `*` => unrestricted for the OR rule (Vixie):
+		// dow must ALSO match, so the next fire is a Monday on an odd
+		// day-of-month (Jul 6 is Monday the 6th — even — so Jul 13 it is).
+		expect(computeNextCronRunAtMs("0 0 */2 * 1", FRIDAY_JUL_3)).toBe(
+			Date.UTC(2026, 6, 13, 0, 0, 0),
+		);
+	});
+});
+
 describe("computeNextCronRunAtMs - non-representable base guard (#11046)", () => {
 	it("returns null immediately for a base at/over the max representable Date", () => {
 		// Number.MAX_SAFE_INTEGER (~9.007e15) exceeds the max Date (±8.64e15), so

--- a/packages/core/src/services/triggerScheduling.ts
+++ b/packages/core/src/services/triggerScheduling.ts
@@ -28,6 +28,15 @@ interface CronSchedule {
 	dayOfMonth: Set<number>;
 	month: Set<number>;
 	dayOfWeek: Set<number>;
+	/**
+	 * Standard (POSIX/Vixie) cron day semantics: when BOTH day-of-month and
+	 * day-of-week are restricted (the field does not start with `*`), a
+	 * candidate matches when EITHER field matches; otherwise both must match.
+	 * `0 0 13 * 5` therefore fires on every 13th AND every Friday — not only
+	 * on Friday-the-13th.
+	 */
+	dayOfMonthRestricted: boolean;
+	dayOfWeekRestricted: boolean;
 }
 
 const CRON_RANGES: readonly CronRange[] = [
@@ -129,17 +138,30 @@ export function parseCronExpression(expression: string): CronSchedule | null {
 		dayOfMonth,
 		month,
 		dayOfWeek,
+		// Vixie-cron rule: a day field counts as "restricted" for the dom/dow
+		// OR-semantics only when it does not start with `*` (`*` and `*/n` are
+		// unrestricted).
+		dayOfMonthRestricted: !parts[2].trim().startsWith("*"),
+		dayOfWeekRestricted: !parts[4].trim().startsWith("*"),
 	};
 }
 
 function cronMatchesUTC(schedule: CronSchedule, candidateMs: number): boolean {
 	const candidate = new Date(candidateMs);
+	const dayOfMonthMatches = schedule.dayOfMonth.has(candidate.getUTCDate());
+	const dayOfWeekMatches = schedule.dayOfWeek.has(candidate.getUTCDay());
+	// POSIX/Vixie cron: when BOTH day fields are restricted, a day matching
+	// EITHER one fires; otherwise both must match (an unrestricted `*` field
+	// always matches anyway).
+	const dayMatches =
+		schedule.dayOfMonthRestricted && schedule.dayOfWeekRestricted
+			? dayOfMonthMatches || dayOfWeekMatches
+			: dayOfMonthMatches && dayOfWeekMatches;
 	return (
 		schedule.minute.has(candidate.getUTCMinutes()) &&
 		schedule.hour.has(candidate.getUTCHours()) &&
-		schedule.dayOfMonth.has(candidate.getUTCDate()) &&
-		schedule.month.has(candidate.getUTCMonth() + 1) &&
-		schedule.dayOfWeek.has(candidate.getUTCDay())
+		dayMatches &&
+		schedule.month.has(candidate.getUTCMonth() + 1)
 	);
 }
 


### PR DESCRIPTION
Supersedes #11926.

## Summary
- Persist task backoff base interval so repeated failures do not compound off already-inflated cadence
- Apply standard cron day-of-month/day-of-week OR semantics when both fields are restricted
- Make plugin allow/deny filtering exact on full or normalized short names, never substring matches

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/core test src/services/plugin-hooks.test.ts src/services/task.test.ts src/services/triggerScheduling.test.ts — 35 tests passed
- bun run --cwd packages/core typecheck
- bunx @biomejs/biome check changed files
- git diff --check origin/develop...HEAD && git diff --check

N/A: UI/audio/live-LLM trajectory; deterministic core scheduling/filter logic only.