### PR TITLE
fix(cloud): forward billed video duration to provider

### DIFF
--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -252,6 +252,49 @@ describe("generate-video — pre-settle failure still refunds", () => {
   });
 });
 
+describe("generate-video — bills what it delivers (#11862 finding 2)", () => {
+  test("when the client omits durationSeconds, the RESOLVED billing default is forwarded to the provider (not undefined)", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue(validResult);
+    generationsCreate.mockResolvedValue({ id: "gen-1" });
+
+    // No durationSeconds in the request → billing resolves it to the catalog
+    // default (8, per the getDefaultVideoBillingDimensions mock above).
+    const res = await post({ model: MODEL, prompt: "a cat" });
+
+    expect(res.status).toBe(200);
+    // The provider (fal) maps durationSeconds → input.duration. Before the fix
+    // the raw request spread forwarded an undefined durationSeconds, so the
+    // provider rendered its OWN default while we billed 8s → undercharge.
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    const falInput = (
+      subscribe.mock.calls[0]?.[1] as { input?: Record<string, unknown> }
+    )?.input;
+    expect(falInput?.duration).toBe(8);
+    expect(falInput?.duration_seconds).toBe(8);
+  });
+
+  test("an explicit client durationSeconds is still forwarded unchanged", async () => {
+    const ledger = makeLedgerReservation(100, COST);
+    reserve.mockResolvedValue(ledger.reservation);
+    subscribe.mockResolvedValue(validResult);
+    generationsCreate.mockResolvedValue({ id: "gen-1" });
+
+    const res = await post({
+      model: MODEL,
+      prompt: "a cat",
+      durationSeconds: 5,
+    });
+
+    expect(res.status).toBe(200);
+    const falInput = (
+      subscribe.mock.calls[0]?.[1] as { input?: Record<string, unknown> }
+    )?.input;
+    expect(falInput?.duration).toBe(5);
+  });
+});
+
 describe("generate-video — clean success settles once", () => {
   test("success path reconciles exactly once to totalCost", async () => {
     const ledger = makeLedgerReservation(100, COST);

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -178,6 +178,13 @@ app.post("/", async (c) => {
 
     const generated = await provider.generate({
       ...request,
+      // Bill-what-you-deliver: the org is charged for the RESOLVED duration
+      // (request.durationSeconds ?? the catalog default), but the raw request
+      // spread would forward an undefined durationSeconds when the client omits
+      // it — the provider then renders its OWN default (potentially longer),
+      // so the platform pays for a longer clip than it billed. Forward the
+      // resolved value so the generated duration matches the charge.
+      durationSeconds,
       apiKeys,
     });
     if (generated.hasNsfwConcepts?.some(Boolean)) {


### PR DESCRIPTION
Supersedes #11940.

## Summary
- Forward resolved `durationSeconds` to video providers so generated duration matches the billed catalog/default duration
- Add regression coverage for omitted and explicit duration values

## Validation
- bun test packages/cloud/api/__tests__/generate-video-credit-leak.test.ts — 7 tests passed
- bun run --cwd packages/core prebuild
- bun run --cwd packages/cloud/api typecheck
- bunx @biomejs/biome check packages/cloud/api/__tests__/generate-video-credit-leak.test.ts packages/cloud/api/v1/generate-video/route.ts
- git diff --check origin/develop...HEAD && git diff --check

N/A: UI/audio/live-LLM trajectory; deterministic billing/provider request-shape fix covered by route-level tests.