### PR TITLE
fix(cloud-apps): enforce confirm TTL on WITHDRAW_APP_EARNINGS (stale money-out confirm parity)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
@@ -21,6 +21,9 @@ mock.module("@elizaos/cloud-sdk", () => ({
 const { parseWithdrawAmount, withdrawAppEarningsAction } = await import(
   "../src/actions/withdraw-app-earnings.ts"
 );
+const { CONFIRM_TTL_MS, persistCloudAppConfirmation } = await import(
+  "../src/safety.ts"
+);
 
 const APP = makeApp({
   id: "id-acme",
@@ -163,6 +166,35 @@ describe("WITHDRAW_APP_EARNINGS", () => {
     const cta = (result?.data as { cta: ConnectorCta }).cta;
     expect(JSON.stringify(cta)).not.toContain(API_KEY);
     expect(cb.calls.at(-1)?.text).not.toContain(API_KEY);
+  });
+
+  it("refuses a STALE (expired) confirm instead of moving money — TTL parity with buy-domain/book-influencer", async () => {
+    const withdrawals = trackWithdrawals();
+    const runtime = keyedRuntime();
+    // A pending already older than the confirm TTL: a bare "yes" must NOT fire a
+    // money-out withdrawal on a stale confirmation.
+    await persistCloudAppConfirmation(runtime, {
+      roomId: String(runtime.agentId),
+      action: "WITHDRAW_APP_EARNINGS",
+      appId: APP.id,
+      appName: APP.name,
+      amount: 100,
+      intentCreatedAt: new Date(
+        Date.now() - CONFIRM_TTL_MS - 1000,
+      ).toISOString(),
+    });
+    const result = await withdrawAppEarningsAction.handler(
+      runtime,
+      makeMessage("confirmo"),
+      undefined,
+      { confirm: true },
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason?: string }).reason).toBe(
+      "confirmation_expired",
+    );
   });
 
   it("honors the first-turn amount and ignores follow-up amount prose", async () => {

--- a/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
+++ b/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
@@ -47,6 +47,7 @@ import {
 } from "../client.js";
 import {
   buildConnectorCta,
+  CONFIRM_TTL_MS,
   type ConnectorCta,
   confirmationRoomId,
   confirmTargetMismatchMessage,
@@ -54,6 +55,7 @@ import {
   conflictingConfirmTarget,
   deleteCloudAppConfirmation,
   findPendingCloudAppConfirmation,
+  pendingExpired,
   persistCloudAppConfirmation,
   readStructuredConfirmation,
 } from "../safety.js";
@@ -214,6 +216,24 @@ export const withdrawAppEarningsAction: Action = {
           text: "No pending withdrawal confirmation.",
           userFacingText: NO_PENDING_CONFIRMATION_MESSAGE,
           data: { reason: "no_pending_confirmation", withdrawn: false },
+        };
+      }
+
+      if (pendingExpired(pending)) {
+        // A stale confirm must not fire a money-out withdrawal on a bare "yes"
+        // long after the fact. Mirror BUY_APP_DOMAIN / BOOK_INFLUENCER: expire
+        // the pending and ask the user to re-request rather than moving money.
+        await deleteCloudAppConfirmation(runtime, pending.taskId);
+        const msg =
+          `That withdrawal request for ${pending.metadata.appName} is more than ${Math.round(CONFIRM_TTL_MS / 60000)} minutes old, so I didn't move any money. ` +
+          `Ask me to withdraw ${pending.metadata.appName}'s earnings again and I'll re-confirm the amount.`;
+        await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+        return {
+          success: false,
+          text: `Pending withdrawal of ${pending.metadata.appName} expired before confirmation.`,
+          userFacingText: msg,
+          verifiedUserFacing: true,
+          data: { reason: "confirmation_expired", withdrawn: false },
         };
       }
 


### PR DESCRIPTION
`[cloud-money]`. Addresses the withdraw-TTL note in #11952.

**Gap:** `WITHDRAW_APP_EARNINGS` honored a pending confirm regardless of age, while `BUY_APP_DOMAIN` + `BOOK_INFLUENCER` refuse one older than `CONFIRM_TTL_MS` (15 min). A bare "yes" long after the ask could fire a real money-out withdrawal on a stale confirmation. Low-risk (amount frozen + server-re-gated) but a surprising asymmetry.

**Fix:** same `pendingExpired()` guard — expired pending cleared, user asked to re-request (`reason: confirmation_expired`). Mirrors the other two gated actions.

**Proof:** new regression — **26/0 green; red without the fix** (a withdrawal fires on the stale confirm). typecheck + biome clean. Money path — no self-merge.