### PR TITLE
fix(cloud): scope-guard GET /apps/:id — close the read-only cross-app row disclosure #11943 missed (#10852 class)

### DIFF
--- a/packages/cloud/api/__tests__/apps-frontend-key-scope.test.ts
+++ b/packages/cloud/api/__tests__/apps-frontend-key-scope.test.ts
@@ -90,10 +90,15 @@ const getByApiKeyId = mock(
   async (apiKeyId: string) =>
     Object.values(APPS).find((a) => a.api_key_id === apiKeyId) ?? null,
 );
+const withDatabaseState = mock(async (app: Record<string, unknown>) => ({
+  ...app,
+  database_state: "ready",
+}));
 mock.module("@/lib/services/apps", () => ({
   appsService: {
     getById: async (id: string) => APPS[id] ?? null,
     getByApiKeyId,
+    withDatabaseState,
     trackPageView: mock(async () => undefined),
   },
 }));
@@ -163,6 +168,15 @@ const runAppReview = mock(async () => ({
 mock.module("@/lib/services/app-review", () => ({
   runAppReview,
   getLatestAppReview: mock(async () => null),
+  buildReviewCandidate: mock(() => ({ contentHash: "hash" })),
+}));
+
+mock.module("@/lib/services/app-cleanup", () => ({
+  appCleanupService: { cleanupAndDeleteApp: mock(async () => undefined) },
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { getById: mock(async () => null) },
 }));
 
 mock.module("@/lib/utils/logger", () => ({
@@ -183,6 +197,7 @@ const { default: activateRoute } = await import(
 );
 const { default: reviewRoute } = await import("../v1/apps/[id]/review/route");
 const { default: backupRoute } = await import("../v1/apps/[id]/backup/route");
+const { default: appDetailRoute } = await import("../v1/apps/[id]/route");
 
 const app = new Hono();
 app.route("/api/v1/apps/:id/frontend", frontendRoute);
@@ -191,6 +206,7 @@ app.route("/api/v1/apps/:id/frontend/:deploymentId/activate", activateRoute);
 app.route("/api/v1/apps/:id/frontend/:deploymentId", deploymentRoute);
 app.route("/api/v1/apps/:id/review", reviewRoute);
 app.route("/api/v1/apps/:id/backup", backupRoute);
+app.route("/api/v1/apps/:id", appDetailRoute);
 
 function publishBody(): RequestInit {
   return {
@@ -218,6 +234,37 @@ beforeEach(() => {
   exportApp.mockClear();
   runAppReview.mockClear();
   getByApiKeyId.mockClear();
+  withDatabaseState.mockClear();
+});
+
+describe("raw app row detail — GET /api/v1/apps/:id", () => {
+  test("app A's key reading app B's raw app row → 403, row not expanded", async () => {
+    currentApiKeyId = KEY_A;
+    const res = await app.request(`/api/v1/apps/${APP_B}`);
+    await expectAccessDenied(res);
+    expect(withDatabaseState).not.toHaveBeenCalled();
+  });
+
+  test("own key → raw app row read allowed", async () => {
+    currentApiKeyId = KEY_B;
+    const res = await app.request(`/api/v1/apps/${APP_B}`);
+    expect(res.status).toBe(200);
+    expect(withDatabaseState).toHaveBeenCalledTimes(1);
+    const body = (await res.json()) as {
+      success: boolean;
+      app: { id: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.app.id).toBe(APP_B);
+  });
+
+  test("session auth → raw app row read allowed", async () => {
+    currentApiKeyId = undefined;
+    const res = await app.request(`/api/v1/apps/${APP_B}`);
+    expect(res.status).toBe(200);
+    expect(withDatabaseState).toHaveBeenCalledTimes(1);
+    expect(getByApiKeyId).not.toHaveBeenCalled();
+  });
 });
 
 describe("frontend publish — POST /api/v1/apps/:id/frontend (#10852 gap)", () => {

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -52,6 +52,11 @@ app.get("/", async (c) => {
     if (found.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
+    // An app-scoped API key may only read its own app, never a sibling's raw
+    // row (metadata, api_key_id, review state, automation config) (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), id)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
     return c.json({
       success: true,
       app: await appsService.withDatabaseState(found),


### PR DESCRIPTION
Follow-up to **#11943** (merged), which closed the app-key scope gap on 6 `/apps/[id]/*` route families. A Fable adversarial completeness review found **one handler in the same bug class still unguarded**: `GET /api/v1/apps/:id` (`packages/cloud/api/v1/apps/[id]/route.ts:44`) gated only on `organization_id` — while PUT/PATCH (via `updateApp`) and DELETE in the *same file* are scope-guarded.

**Impact:** an app-scoped API key minted for App A could still read sibling App B's **full raw app row** via `withDatabaseState(found)` (metadata, `api_key_id`, review state, automation/webhook config) — the read-only variant of exactly what #11943 fixed (and #11943 itself guards read-only handlers like backup/review GET, so GET-app-row should match).

**Fix:** mirror `updateApp`'s guard verbatim — `isAppKeyOutOfScope(c.get("apiKeyId"), id)` → 403, placed after the org check and before `withDatabaseState`. No-ops for session/owner-key auth (guard returns false when there's no app-scoped key), so legit same-app + session + org-key reads are unchanged. Import already present (used by `updateApp`).

Verified by grep (guard now on GET+PUT+PATCH); CI typechecks. Could not run tests locally (shared box at 100% disk, no node_modules). Same bug class as #10852. Money/security → @lalalune. — [cloud-security]