### PR TITLE
fix(orchestrator/security): variable-cost self-spend can't auto-authorize on an untrusted child-declared price (#11952)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
@@ -49,33 +49,37 @@ describe("estimateSelfSpendCostUsd", () => {
     );
   });
 
-  it("honors an explicit spend hint", () => {
+  it("honors an explicit spend hint above the base for server-known-cost commands", () => {
     expect(
       estimateSelfSpendCostUsd("containers.create", {
         [SPEND_HINT_PARAM]: 2.5,
       }),
     ).toBe(2.5);
-    expect(
-      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: 14.95 }),
-    ).toBe(14.95);
-    // string hints are coerced
-    expect(
-      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: "9.99" }),
-    ).toBe(9.99);
   });
 
-  it("returns null for hint-required commands without a hint", () => {
-    expect(estimateSelfSpendCostUsd("domains.buy")).toBeNull();
-    expect(estimateSelfSpendCostUsd("media.image.generate")).toBeNull();
-  });
-
-  it("rejects negative / non-finite hints", () => {
-    expect(
-      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: -5 }),
-    ).toBeNull();
-    expect(
-      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: "abc" }),
-    ).toBeNull();
+  // #11952: the child's self-declared hint is untrusted — for variable-cost
+  // commands it must NEVER produce an auto-authorizable estimate, no matter how
+  // it is declared. A positive under-declaration ($0.01 for a real $500 buy)
+  // was the residual hole left by #10980 (which only closed the $0 case).
+  it("always returns null for variable-cost commands regardless of the declared hint", () => {
+    for (const command of [
+      "domains.buy",
+      "media.image.generate",
+      "media.video.generate",
+      "promote.execute",
+      "advertising.campaigns.start",
+    ]) {
+      expect(estimateSelfSpendCostUsd(command)).toBeNull();
+      expect(
+        estimateSelfSpendCostUsd(command, { [SPEND_HINT_PARAM]: 0.01 }),
+      ).toBeNull();
+      expect(
+        estimateSelfSpendCostUsd(command, { [SPEND_HINT_PARAM]: 14.95 }),
+      ).toBeNull();
+      expect(
+        estimateSelfSpendCostUsd(command, { [SPEND_HINT_PARAM]: "9.99" }),
+      ).toBeNull();
+    }
   });
 
   // Regression: an attacker-declared cost of exactly 0 must not slip a paid
@@ -96,16 +100,6 @@ describe("estimateSelfSpendCostUsd", () => {
     ).toBe(3);
   });
 
-  it("treats a declared cost of 0 for a hint-required paid command as unknown (confirm)", () => {
-    expect(
-      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: 0 }),
-    ).toBeNull();
-    expect(
-      estimateSelfSpendCostUsd("media.image.generate", {
-        [SPEND_HINT_PARAM]: "0",
-      }),
-    ).toBeNull();
-  });
 });
 
 describe("decideSpendAuthorization — spend-cap bypass regression", () => {
@@ -119,6 +113,28 @@ describe("decideSpendAuthorization — spend-cap bypass regression", () => {
     });
     expect(decision.autoAuthorize).toBe(false);
     expect(decision.reason).toBe("unknown-cost");
+  });
+
+  // #11952: the positive-under-declaration hole. A rogue/injected sub-agent
+  // declaring a tiny price for a real, expensive variable-cost self-spend must
+  // NOT auto-authorize under the cap — the untrusted hint can't meter it.
+  it("does NOT auto-authorize a variable-cost self-spend under-declared to slip beneath the cap", () => {
+    for (const command of [
+      "domains.buy",
+      "media.video.generate",
+      "promote.execute",
+      "advertising.campaigns.start",
+    ]) {
+      const decision = decideSpendAuthorization({
+        command,
+        risk: "paid",
+        capUsd: 1000,
+        alreadySpentUsd: 0,
+        params: { [SPEND_HINT_PARAM]: 0.01 },
+      });
+      expect(decision.autoAuthorize).toBe(false);
+      expect(decision.reason).toBe("unknown-cost");
+    }
   });
 
   it("meters a 0-hint container at its base cost so a tiny cap is respected", () => {
@@ -176,9 +192,9 @@ describe("decideSpendAuthorization", () => {
     expect(decision.reason).toBe("destructive-requires-human");
   });
 
-  it("auto-authorizes a self-spend command within the cap and reports its cost", () => {
+  it("auto-authorizes a server-known-cost self-spend within the cap and reports its cost", () => {
     const decision = decideSpendAuthorization({
-      command: "domains.buy",
+      command: "containers.create",
       risk: "paid",
       capUsd: 50,
       alreadySpentUsd: 0,
@@ -189,9 +205,9 @@ describe("decideSpendAuthorization", () => {
     expect(decision.estimatedCostUsd).toBe(14.95);
   });
 
-  it("requires confirmation when a self-spend command exceeds the remaining budget", () => {
+  it("requires confirmation when a server-known-cost self-spend exceeds the remaining budget", () => {
     const decision = decideSpendAuthorization({
-      command: "domains.buy",
+      command: "containers.create",
       risk: "paid",
       capUsd: 20,
       alreadySpentUsd: 18,
@@ -203,12 +219,15 @@ describe("decideSpendAuthorization", () => {
     expect(decision.estimatedCostUsd).toBe(14.95);
   });
 
-  it("requires confirmation for a self-spend command of unknown cost", () => {
+  it("always requires confirmation for a variable-cost self-spend command", () => {
+    // Even a plausible, well-within-cap hint cannot auto-authorize — the price
+    // is server-quoted and the hint is untrusted (#11952).
     const decision = decideSpendAuthorization({
       command: "domains.buy",
       risk: "paid",
       capUsd: 50,
       alreadySpentUsd: 0,
+      params: { [SPEND_HINT_PARAM]: 14.95 },
     });
     expect(decision.autoAuthorize).toBe(false);
     expect(decision.reason).toBe("unknown-cost");
@@ -356,11 +375,10 @@ describe("durable spend ledger (#8924)", () => {
     });
     expect(within.autoAuthorize).toBe(true); // 9 + 0.67 <= 10
     const over = decideSpendAuthorization({
-      command: "domains.buy",
+      command: "containers.create",
       risk: "paid",
-      capUsd: 10,
-      alreadySpentUsd: getSessionSpendUsd("s1"),
-      params: { spendEstimateUsd: 2 },
+      capUsd: 9.5,
+      alreadySpentUsd: getSessionSpendUsd("s1"), // 9 + 0.67 > 9.5
     });
     expect(over.autoAuthorize).toBe(false);
     expect(over.reason).toBe("over-cap");
@@ -440,7 +458,7 @@ describe("spend ledger concurrency hardening", () => {
       withSessionSpendLock("sLock", async () => {
         await hydrateSessionSpendUsd("sLock");
         const decision = decideSpendAuthorization({
-          command: "domains.buy",
+          command: "containers.create",
           risk: "paid",
           capUsd: 10,
           alreadySpentUsd: getSessionSpendUsd("sLock"),

--- a/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
@@ -12,10 +12,14 @@
  *
  *   - `read` / `dry-run`            → never need authorization (unchanged);
  *   - `destructive`                 → ALWAYS require human confirmation;
- *   - self-spend commands           → auto-authorize only while the running
- *     (debit our own credits)         total + the command's estimated cost stays
- *                                     within the cap; otherwise fall back to
- *                                     confirmation;
+ *   - self-spend, server-known cost → auto-authorize only while the running
+ *     (containers.*)                  total + the base cost stays within the
+ *                                     cap; otherwise fall back to confirmation;
+ *   - self-spend, variable cost     → ALWAYS require human confirmation — the
+ *     (domains.buy, media.*,          real price is server-quoted and the only
+ *      promote.*, advertising.*)      in-band estimate is the child's untrusted
+ *                                     self-declared hint, which must never
+ *                                     auto-authorize a real external spend;
  *   - other `mutating` / `paid`     → auto-authorize while the allowance is
  *     (state changes + revenue        active. These do not debit our balance
  *      ops the *payer* funds, e.g.    (e.g. `apps.charges.create` creates a
@@ -76,6 +80,25 @@ export const SELF_SPEND_COMMANDS: ReadonlySet<string> = new Set([
   "advertising.creatives.create",
 ]);
 
+/**
+ * Self-spend commands whose real charge is a fixed, server-known base cost that
+ * the operator cannot under-declare below. Only these may auto-authorize from a
+ * cost estimate — the estimate is floored to the base, so a rogue/injected
+ * sub-agent cannot meter them under the cap.
+ *
+ * Every OTHER self-spend command (domains.buy, media.*, promote.*,
+ * advertising.*) has a variable, quote-time price the server determines. Its
+ * only in-band cost signal is the child sub-agent's own `spendEstimateUsd`
+ * hint, which is untrusted (parsed verbatim from the child directive JSON). A
+ * self-declared price can therefore never auto-authorize a real external
+ * spend — those commands always fall through to human confirmation (#11952,
+ * the positive-under-declaration residual of #10980).
+ */
+export const SERVER_KNOWN_COST_COMMANDS: ReadonlySet<string> = new Set([
+  "containers.create",
+  "containers.update",
+]);
+
 /** Coerce an unknown value to a finite, non-negative number, or `null`. */
 function toNonNegativeNumber(value: unknown): number | null {
   if (typeof value === "number") {
@@ -105,21 +128,21 @@ export function estimateSelfSpendCostUsd(
   command: string,
   params?: Record<string, unknown>,
 ): number | null {
-  const rawHint = toNonNegativeNumber(params?.[SPEND_HINT_PARAM]);
-  // A declared cost of exactly 0 for a *paid* command is not a credible price —
-  // treat it as "no hint". Otherwise an attacker-declared `spendEstimateUsd: 0`
-  // meters the command at $0 and slips under any cap forever (the old
-  // `hint ?? default` also returned 0, because `??` only catches null/undefined).
-  const positiveHint = rawHint !== null && rawHint > 0 ? rawHint : null;
-  if (command === "containers.create" || command === "containers.update") {
-    // Containers have a known base daily cost. Never meter below it — a caller
-    // that omits or under-declares the hint is still charged at least the base.
+  if (SERVER_KNOWN_COST_COMMANDS.has(command)) {
+    // Containers have a known base daily cost. Meter at least the base — a
+    // caller that omits or under-declares the hint is still charged the floor,
+    // and a hint above the base is honored. A declared cost of exactly 0 (which
+    // `??` would NOT catch) can never pull the estimate below the base.
+    const rawHint = toNonNegativeNumber(params?.[SPEND_HINT_PARAM]);
+    const positiveHint = rawHint !== null && rawHint > 0 ? rawHint : null;
     return Math.max(positiveHint ?? 0, CONTAINER_DAILY_COST_USD);
   }
-  // domains.buy, media.*, promote.*, advertising.* — require an explicit,
-  // positive hint (e.g. the quoted price from domains.check). Unknown or a
-  // non-positive declared cost → null → the caller asks a human to confirm.
-  return positiveHint;
+  // domains.buy, media.*, promote.*, advertising.* — variable, server-quoted
+  // price. The only in-band signal is the child's self-declared hint, which is
+  // untrusted, so it can never auto-authorize a real external spend. Always
+  // return null → the caller (decideSpendAuthorization) requires a human
+  // confirm regardless of the declared amount (#11952).
+  return null;
 }
 
 export interface SpendDecisionInput {


### PR DESCRIPTION
Closes #11952.

## Bug (MED — spend-cap bypass, prompt-injection blast-radius)

`plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts` — the #10980 fix floored **containers** to `CONTAINER_DAILY_COST_USD`, but for the variable-cost paid self-spend commands (`domains.buy`, `media.*`, `promote.*`, `advertising.*`) `estimateSelfSpendCostUsd` returned the **child-declared hint verbatim**. The hint comes from the child sub-agent's directive JSON (`extractParentAgentDirective` → `runCloudCommand` → `decideSpendAuthorization` → `estimateSelfSpendCostUsd`), so an injected/rogue sub-agent declaring `spendEstimateUsd: 0.01` for a real \$500 `domains.buy` was **metered at \$0.01**, auto-authorized under `ELIZA_AGENT_SPEND_CAP_USD`, and the real charge hit server-side — defeating the operator's throttle.

Same class as #10980, which closed only the exactly-\$0 case (→ null → confirm) and the container floor. The positive-under-declaration hole remained; `spend-allowance.test.ts` only covered `containers.*` + the \$0 case.

## Fix — option 1 (recommended, fail-safe)

For every variable-cost self-spend command, `estimateSelfSpendCostUsd` now returns `null` **regardless of the declared hint** — the real price is server-quoted and the only in-band signal is the untrusted child hint, which can never auto-authorize a real external spend. `decideSpendAuthorization` maps `null` → `unknown-cost` → human confirm. Only `SERVER_KNOWN_COST_COMMANDS` (`containers.create` / `containers.update`, floored to the base daily cost) can still auto-authorize from an estimate. Worst case: a legit sub-agent domain-buy asks for one confirm.

## Changes

- `spend-allowance.ts`: add `SERVER_KNOWN_COST_COMMANDS` allowlist; `estimateSelfSpendCostUsd` returns `null` for all variable-cost self-spend commands; updated module + function docstrings.
- `spend-allowance.test.ts`: regression coverage for the positive-under-declaration bypass across `domains.buy` / `media.*` / `promote.*` / `advertising.*` (\$0.01 and plausible-\$14.95 hints both → confirm); container tests unchanged.

## Verification

- `bun run --cwd plugins/plugin-agent-orchestrator test:unit` → **118 files / 1293 tests pass** on `develop` tip.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` → clean.

Note: the separate low-risk `withdraw-app-earnings` confirm-TTL asymmetry mentioned in #11952 was already closed on develop by #11957 — no change needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)