### PR TITLE
fix(cloud/money): refund verified video failures even after the stale sweep (#11942)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
@@ -420,27 +420,99 @@ describe("deadline + unknown-state behavior", () => {
   );
 });
 
-describe("stranded-reservation sweep interplay — never mint", () => {
+async function settlementState(id: string): Promise<string | null> {
+  const res = await dbWrite.execute(
+    `SELECT metadata->>'settlement_state' AS settlement_state FROM generations WHERE id = '${id}';`,
+  );
+  return (res.rows[0] as { settlement_state: string | null }).settlement_state;
+}
+
+describe("stranded-reservation sweep interplay — compensating refund, never double (#11942)", () => {
   test(
-    "generic sweep settles first; the video sweep must not create a second movement",
+    "generic sweep charged first; a verified failure still refunds exactly once, honestly",
     async () => {
       const { generationId, reservationTransactionId } = await createTimedOutGeneration();
 
       // The #11493 backstop fires (e.g. this cron was down for >2h): the hold
-      // settles at the estimated cost.
+      // settles at the estimated (full) cost while the terminal state is still
+      // unknown — the org is charged the full video price.
       const sweepStats = await creditsService.sweepStaleReservations({ graceMs: 0 });
       expect(sweepStats.settled).toBeGreaterThanOrEqual(1);
       expect(await getReservationSettledAt(reservationTransactionId)).not.toBeNull();
       expect(await getBalance()).toBeCloseTo(START_BALANCE - COST, 6);
 
-      // Video sweep later verifies a terminal failure — the settled_at claim
-      // blocks its refund: no second movement, no minted credit.
+      // Video sweep later VERIFIES the render died upstream. reconcile() can no
+      // longer move the refund on the settled row, so the sweep issues the
+      // compensating refund under the shared `recon:<txid>:refund` key: the org
+      // is made whole and the ledger honestly reflects the refund.
       jobStatusImpl = async () => ({ state: "failed", error: "render exploded" });
+      const stats = await runSweep();
+      expect(stats).toMatchObject({ scanned: 1, refunded: 1, charged: 0 });
+
+      expect(await getBalance()).toBeCloseTo(START_BALANCE, 6);
+      expect(await refundRowsForReservation(reservationTransactionId)).toHaveLength(1);
+      const row = await getGenerationRow(generationId);
+      expect(row.status).toBe("failed");
+      expect(await settlementState(generationId)).toBe("refunded");
+
+      // Crash between compensating refund and row update, plus a concurrent
+      // double-poll: the shared key blocks any second movement.
+      await dbWrite.execute(
+        `UPDATE generations SET status = 'pending' WHERE id = '${generationId}';`,
+      );
+      await Promise.all([runSweep(), runSweep()]);
+      expect(await getBalance()).toBeCloseTo(START_BALANCE, 6);
+      expect(await refundRowsForReservation(reservationTransactionId)).toHaveLength(1);
+      expect((await getGenerationRow(generationId)).status).toBe("failed");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "generic sweep charged first; a deadline-expired job refunds once too",
+    async () => {
+      const { generationId, reservationTransactionId } = await createTimedOutGeneration({
+        ageMs: 2 * 60 * 60 * 1000,
+      });
+
+      const sweepStats = await creditsService.sweepStaleReservations({ graceMs: 0 });
+      expect(sweepStats.settled).toBeGreaterThanOrEqual(1);
+      expect(await getBalance()).toBeCloseTo(START_BALANCE - COST, 6);
+
+      // Still non-terminal upstream, but past the reconcile deadline: presumed
+      // dead. The refund-once promise must hold regardless of the stale sweep.
+      jobStatusImpl = async () => ({ state: "pending" });
+      const stats = await runSweep();
+      expect(stats).toMatchObject({ scanned: 1, expired: 1, refunded: 0, charged: 0 });
+
+      expect(await getBalance()).toBeCloseTo(START_BALANCE, 6);
+      expect(await refundRowsForReservation(reservationTransactionId)).toHaveLength(1);
+      expect(await settlementState(generationId)).toBe("refunded_expired");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "generic sweep charged first; a late upstream success is NOT refunded",
+    async () => {
+      const { generationId, reservationTransactionId } = await createTimedOutGeneration();
+
+      const sweepStats = await creditsService.sweepStaleReservations({ graceMs: 0 });
+      expect(sweepStats.settled).toBeGreaterThanOrEqual(1);
+      expect(await getBalance()).toBeCloseTo(START_BALANCE - COST, 6);
+
+      // The render actually completed upstream (fal billed us): the full charge
+      // the stale sweep took is correct — the compensating-refund path must NOT
+      // fire on success.
+      jobStatusImpl = async () => ({
+        state: "succeeded",
+        result: { requestId: JOB_ID, video: { url: "https://fal.media/late.mp4" } },
+      });
       await runSweep();
 
       expect(await getBalance()).toBeCloseTo(START_BALANCE - COST, 6);
       expect(await refundRowsForReservation(reservationTransactionId)).toHaveLength(0);
-      expect((await getGenerationRow(generationId)).status).toBe("failed");
+      expect((await getGenerationRow(generationId)).status).toBe("completed");
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/video-generation-reconcile.ts
+++ b/packages/cloud/shared/src/lib/services/video-generation-reconcile.ts
@@ -16,6 +16,13 @@
  *    is never refunded blind. The stranded-reservation sweep (#11493, ~2h
  *    grace) remains the platform-safe backstop that settles the hold at the
  *    estimated cost if this sweep can never reach the provider.
+ *
+ * The "refunded exactly once" guarantee holds even when that stale sweep
+ * settled the hold at full cost BEFORE this sweep verified the terminal state:
+ * `reconcile` can no longer move the refund on a settled row, so this sweep
+ * issues a compensating refund under the same `recon:<txid>:refund` key
+ * (`ensureHoldRefunded`) — otherwise a verified failure would be charged full
+ * price while the ledger falsely claimed a refund (#11942).
  */
 
 import { type Generation, generationsRepository } from "../../db/repositories/generations";
@@ -26,7 +33,7 @@ import {
   type VideoPendingSettlement,
 } from "../providers/video/types";
 import { logger } from "../utils/logger";
-import { creditsService } from "./credits";
+import { type CreditReconciliationResult, creditsService } from "./credits";
 
 /**
  * How long a pending video may stay non-terminal upstream before the sweep
@@ -89,8 +96,8 @@ async function settleHold(
   generation: Generation,
   settlement: VideoPendingSettlement,
   actualCost: number,
-): Promise<void> {
-  await creditsService.reconcile({
+): Promise<CreditReconciliationResult> {
+  return await creditsService.reconcile({
     organizationId: generation.organization_id,
     reservedAmount: settlement.reserved_amount,
     actualCost,
@@ -101,6 +108,47 @@ async function settleHold(
       model: generation.model,
       settlement_source: "video_pending_reconcile",
     },
+  });
+}
+
+/**
+ * Guarantees the hold for a dead render is refunded exactly once — even when the
+ * generic stranded-reservation sweep (#11493) beat this sweep to the
+ * reservation and settled it at full estimated cost.
+ *
+ * Once the reservation row carries `settled_at`, `creditsService.reconcile` is a
+ * no-op (`adjustmentType: 'none'`) and its keyed refund lane is unreachable, so
+ * `settleHold(…, 0)` alone leaves the org charged full price for a render we
+ * have now determined died upstream — while `markFailed` would still stamp a
+ * `settlement_state='refunded'` the ledger never backed (#11942). When
+ * `settleHold` could not move the refund itself, issue the compensating refund
+ * under the SAME idempotency key the reconcile refund lane uses
+ * (`recon:<reservationTxId>:refund`). `applyCreditIncrease` dedupes on that key
+ * (`ON CONFLICT DO NOTHING`), so the refund fires exactly once across the normal
+ * path, the stale-sweep path, crash-retries, and concurrent sweeps — the
+ * "refund exactly once" invariant now holds regardless of which sweep wins the
+ * race, instead of silently degrading to "refund zero times".
+ */
+async function ensureHoldRefunded(
+  generation: Generation,
+  settlement: VideoPendingSettlement,
+  reconciliation: CreditReconciliationResult,
+): Promise<void> {
+  if (reconciliation.adjustmentType === "refund") {
+    // settleHold refunded through the reservation lane under the same key.
+    return;
+  }
+  await creditsService.refundCredits({
+    organizationId: generation.organization_id,
+    amount: settlement.reserved_amount,
+    description: `Video generation: ${generation.model} (verified-failure refund)`,
+    metadata: {
+      ...(generation.user_id ? { user_id: generation.user_id } : {}),
+      reservation_transaction_id: settlement.reservation_transaction_id,
+      model: generation.model,
+      settlement_source: "video_pending_reconcile_stale_sweep_compensation",
+    },
+    stripePaymentIntentId: `recon:${settlement.reservation_transaction_id}:refund`,
   });
 }
 
@@ -203,7 +251,8 @@ export async function reconcilePendingVideoGenerations(params: {
     }
 
     if (job.state === "failed") {
-      await settleHold(generation, settlement, 0);
+      const reconciliation = await settleHold(generation, settlement, 0);
+      await ensureHoldRefunded(generation, settlement, reconciliation);
       await markFailed(generation, "refunded", job.error);
       stats.refunded++;
       logger.info("[VideoReconcile] Verified upstream failure — hold refunded", {
@@ -221,8 +270,11 @@ export async function reconcilePendingVideoGenerations(params: {
     }
 
     // Verified non-terminal past the deadline: the render is presumed dead
-    // upstream. Refund once (bounded loss if it somehow completes later).
-    await settleHold(generation, settlement, 0);
+    // upstream. Refund once (bounded loss if it somehow completes later). The
+    // outcome must not hinge on whether the stale sweep settled first, so the
+    // compensating refund keeps this branch's "refund once" promise honest too.
+    const reconciliation = await settleHold(generation, settlement, 0);
+    await ensureHoldRefunded(generation, settlement, reconciliation);
     await markFailed(
       generation,
       "refunded_expired",


### PR DESCRIPTION
## Problem (#11942)

In `video-generation-reconcile.ts`, when a verified upstream **failure** (or a deadline-expired job) is settled *after* the generic stranded-reservation sweep (#11493, ~2h grace) has already settled the hold at full estimated cost:

1. The generic `sweepStaleReservations` settles the reservation at `estimated_cost` (full video price, `settled_at` set).
2. Later, fal reports the job terminally failed → the reconcile failed branch calls `settleHold(generation, settlement, 0)` → `creditsService.reconcile` sees `settled_at != NULL` and returns `adjustmentType: 'none'` — **no refund is issued**; the keyed `recon:<txid>:refund` lane is unreachable.
3. But `markFailed` still stamps `settlement_state = 'refunded'`.

**Net:** the org is charged full price for a **verifiably failed** render, and the ledger falsely claims a refund that never moved. The commit's own "refund exactly once on verified failure" invariant silently degraded to "refund zero times".

## Fix

- `settleHold` now returns the `CreditReconciliationResult`.
- New `ensureHoldRefunded` helper: when `settleHold` could **not** move the refund itself (`adjustmentType !== 'refund'`, i.e. the stale sweep already settled the row), it issues a **compensating refund** under the **same** idempotency key the reconcile refund lane uses (`recon:<reservationTxId>:refund`).
- `applyCreditIncrease` dedupes on that key (`ON CONFLICT (stripe_payment_intent_id) DO NOTHING`), so the refund fires **exactly once** across the normal path, the stale-sweep path, crash-retries, and concurrent sweeps. The outcome no longer depends on which sweep wins the race, and the `refunded` / `refunded_expired` labels are now honest.
- Applied to both the verified-`failed` branch and the deadline-`expired` branch (the late-**success** branch is untouched — a delivered render's full charge is correct).

This is the hard-path option (actually refund) from the issue, not the "make the overcharge visible" fallback — a verified failure means fal produced nothing to bill for, so refunding is safe and correct.

## Why it's safe / idempotent

The compensating refund shares the exact `recon:<txid>:refund` key with the existing reservation refund lane:
- **Normal path** (`settled_at` NULL): `settleHold` refunds via the reservation lane → `adjustmentType='refund'` → helper no-ops. One refund row.
- **Stale-sweep path** (`settled_at` set): reconcile is a no-op → helper inserts the compensating refund once.
- **Crash-retry / concurrent double-poll:** the shared unique key makes every subsequent attempt an `ON CONFLICT DO NOTHING` no-op. Balance and refund-row count never move twice.

## Evidence — real PGlite money-path tests

`packages/cloud/shared/.../__tests__/video-generation-reconcile.test.ts` reserves **real** credits through the same atomic CTE the route uses, runs the **real** sweep, and asserts balances / `settled_at` / refund rows straight from the DB. The "stranded-reservation sweep interplay" block is rewritten to encode the corrected behavior, plus new expiry-after-stale-sweep and late-success-not-refunded cases.

```
$ bun test packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
 10 pass
 0 fail
 69 expect() calls
Ran 10 tests across 1 file. [22.23s]
```

New/updated assertions prove:
- stale sweep charges full (`balance = START-COST`) → verified failure → **`balance = START`, exactly 1 refund row, `settlement_state='refunded'`** (previously: still charged, 0 refund rows, false `'refunded'` label).
- idempotent across a forced crash-retry **and** a concurrent double-poll (balance stays `START`, still 1 refund row).
- expiry-after-stale-sweep refunds once (`settlement_state='refunded_expired'`).
- late upstream success after the stale sweep is **not** refunded (charge stands).

Verification run:
- `bunx @biomejs/biome check <changed files>` → clean.
- `bun run --cwd packages/cloud/shared typecheck` → no errors in the changed file (only pre-existing unrelated `i18n/generated/*` codegen-missing noise in this worktree).

## Scope / notes

- Money path — **not self-merging**; leaving for maintainer review per the package discipline rules (`packages/cloud/CLAUDE.md`).
- Trajectory evidence: **N/A** — this is a deterministic billing-reconcile sweep with no model call; the money path is proven end-to-end against real PGlite instead.

Closes #11942