### PR TITLE
fix(orchestrator): align spend-cap broker guidance

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -313,17 +313,14 @@ describe("runParentAgentBroker", () => {
       vi.stubEnv("ELIZA_CLOUD_BASE_URL", "https://cloud.test");
     }
 
-    it("self-authorizes a paid self-spend command within the cap and strips the spend hint", async () => {
+    it("self-authorizes a fixed-cost self-spend command within the cap and strips the spend hint", async () => {
       stubAllowance("50");
       const fetchMock = vi.fn(
         async () =>
-          new Response(
-            JSON.stringify({ success: true, status: "registered" }),
-            {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            },
-          ),
+          new Response(JSON.stringify({ success: true, id: "container-1" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
       );
       vi.stubGlobal("fetch", fetchMock);
 
@@ -333,8 +330,8 @@ describe("runParentAgentBroker", () => {
         message: brokerMessage(),
         args: {
           mode: "cloud-command",
-          command: "domains.buy",
-          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 14.95 },
+          command: "containers.create",
+          params: { image: "ghcr.io/acme/app:latest", spendEstimateUsd: 14.95 },
         },
       });
 
@@ -342,12 +339,14 @@ describe("runParentAgentBroker", () => {
       expect(result.text).not.toContain("Reply yes");
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/api/v1/apps/app-1/domains/buy");
+      expect(url.pathname).toBe("/api/v1/containers");
       // The reserved spend hint must NOT leak into the Cloud request body.
-      expect(init.body).toBe(JSON.stringify({ domain: "myapp.com" }));
+      expect(init.body).toBe(
+        JSON.stringify({ image: "ghcr.io/acme/app:latest" }),
+      );
     });
 
-    it("requires confirmation when a self-spend command exceeds the allowance", async () => {
+    it("requires confirmation when a fixed-cost self-spend command exceeds the allowance", async () => {
       stubAllowance("10");
       const fetchMock = vi.fn();
       vi.stubGlobal("fetch", fetchMock);
@@ -358,13 +357,34 @@ describe("runParentAgentBroker", () => {
         message: brokerMessage(),
         args: {
           mode: "cloud-command",
-          command: "domains.buy",
-          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 14.95 },
+          command: "containers.create",
+          params: { image: "ghcr.io/acme/app:latest", spendEstimateUsd: 14.95 },
         },
       });
 
       expect(result.text).toContain("Reply yes");
       expect(result.text).toContain("allowance");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("requires confirmation for variable-cost self-spend even with a positive hint", async () => {
+      stubAllowance("50");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "variable-spend",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "domains.buy",
+          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 0.01 },
+        },
+      });
+
+      expect(result.text).toContain("Reply yes");
+      expect(result.text).toContain("child-declared spend estimates");
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
@@ -392,8 +412,8 @@ describe("runParentAgentBroker", () => {
         message: brokerMessage(),
         args: {
           mode: "cloud-command",
-          command: "domains.buy",
-          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 2 },
+          command: "containers.create",
+          params: { image: "ghcr.io/acme/app:latest", spendEstimateUsd: 2 },
         },
       });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
@@ -99,7 +99,6 @@ describe("estimateSelfSpendCostUsd", () => {
       estimateSelfSpendCostUsd("containers.create", { [SPEND_HINT_PARAM]: 3 }),
     ).toBe(3);
   });
-
 });
 
 describe("decideSpendAuthorization — spend-cap bypass regression", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -32,7 +32,7 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
   description:
     "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
   guidance:
-    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
+    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). Fixed-cost self-spend commands such as `containers.create` may auto-authorize within the configured agent spend cap; variable-cost self-spend commands such as `domains.buy`, `media.*`, `promote.*`, and `advertising.*` always require human confirmation because the server-quoted price cannot be trusted from child-declared `params.spendEstimateUsd`. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task\'s thread; keep working, do not block waiting on it.',
 } as const;
 
 type ParentAgentMode =
@@ -1154,10 +1154,9 @@ async function runCloudCommand(args: {
     ) {
       preview = `${definition.command} would spend ~$${spendDecision.estimatedCostUsd.toFixed(2)}, exceeding your remaining $${remainingUsd.toFixed(2)} self-spend allowance. Proceed?`;
     } else if (spendDecision.reason === "unknown-cost") {
-      // Self-spend command with no cost hint. Give an autonomous agent an
-      // actionable path: fetch a quote and retry with the estimate so it can
-      // self-authorize within the cap instead of waiting on a human "yes".
-      preview = `${definition.command} is a paid Eliza Cloud command with an unknown cost. To self-authorize within your remaining $${remainingUsd.toFixed(2)} allowance, first fetch a quote (e.g. domains.check) and retry with params.spendEstimateUsd set to that price.`;
+      // Variable-cost self-spend is server-quoted and the child-declared
+      // estimate is untrusted, so the spend cap cannot self-authorize it.
+      preview = `${definition.command} is a paid Eliza Cloud command with a server-quoted variable cost. It requires explicit confirmation because child-declared spend estimates cannot self-authorize this kind of charge. Remaining self-spend allowance: $${remainingUsd.toFixed(2)}. Proceed?`;
     } else {
       preview = `${definition.command} is a ${definition.risk} Eliza Cloud command. Proceed?`;
     }


### PR DESCRIPTION
Follow-up to #11959. The security fix correctly made variable-cost self-spend commands require human confirmation, but the parent-agent broker guidance still told child agents to retry domains.buy with params.spendEstimateUsd to self-authorize.\n\nThis aligns the runtime guidance and broker tests with the merged policy:\n- fixed-cost containers can still auto-authorize within the spend cap\n- variable-cost domains/media/promote/advertising commands require confirmation even with a positive child-declared hint\n\nValidated locally:\n- bunx vitest run --config vitest.config.ts src/__tests__/spend-allowance.test.ts src/__tests__/parent-agent-broker.test.ts (48 passed)\n- bunx @biomejs/biome check changed files\n- git diff --check\n\nRefs #11952, follows #11959.