### PR TITLE
fix(core): preserve semantic memory hits after BM25 rerank

### DIFF
--- a/packages/core/src/__tests__/runtime-rerank-memories.test.ts
+++ b/packages/core/src/__tests__/runtime-rerank-memories.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory } from "../types";
+
+function memory(id: string, text?: string): Memory {
+	return {
+		id: id as Memory["id"],
+		entityId: "entity-id" as Memory["entityId"],
+		roomId: "room-id" as Memory["roomId"],
+		content: text === undefined ? {} : { text },
+	} as Memory;
+}
+
+describe("AgentRuntime.rerankMemories", () => {
+	it("preserves zero-overlap vector hits after BM25-ranked matches", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "rerank-memory-test" } as Character,
+		});
+
+		const semanticOnly = memory("semantic-only", "I bought a new car");
+		const keywordMatch = memory("keyword-match", "automobile purchase receipt");
+		const attachmentOnly = memory("attachment-only");
+
+		const reranked = await runtime.rerankMemories("automobile purchase", [
+			semanticOnly,
+			keywordMatch,
+			attachmentOnly,
+		]);
+
+		expect(reranked).toEqual([keywordMatch, semanticOnly, attachmentOnly]);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -8713,7 +8713,18 @@ ${section_end}`;
 		}));
 		const bm25 = new BM25(docs);
 		const results = bm25.search(query, memories.length);
-		return results.map((result) => memories[result.index]);
+		const rankedIndexes = new Set(results.map((result) => result.index));
+		const rerankedMemories = results.map((result) => memories[result.index]);
+
+		// BM25 is a reranker, not a filter. Keep zero-overlap vector hits
+		// after scored matches so semantic recall cannot disappear.
+		for (let index = 0; index < memories.length; index++) {
+			if (!rankedIndexes.has(index)) {
+				rerankedMemories.push(memories[index]);
+			}
+		}
+
+		return rerankedMemories;
 	}
 	/**
 	 * Get the secrets to redact from character settings.


### PR DESCRIPTION
Closes #11960.

## Summary
- keep BM25-positive memory hits first, then append zero-overlap vector hits in their original adapter order
- add a core regression test for a synonym/attachment-only vector result pair that BM25 would otherwise drop

## Testing
- Not run locally: current local checkout is not develop-shaped and has unrelated dirty app changes; relying on CI for the develop branch test matrix.