### PR TITLE
fix(ui): hidden keep-alive views wake on tab refocus + desktop dock evicts the wrong pinned tab

### DIFF
--- a/packages/ui/src/hooks/useDesktopTabs.test.tsx
+++ b/packages/ui/src/hooks/useDesktopTabs.test.tsx
@@ -140,6 +140,7 @@ describe("useDesktopTabs", () => {
         label: "Remote Ledger",
         path: "/apps/remote-ledger",
         pinned: true,
+        pinnedAt: expect.any(Number),
       },
     ]);
 
@@ -152,6 +153,7 @@ describe("useDesktopTabs", () => {
         label: "Remote Ledger",
         path: "/apps/remote-ledger",
         pinned: true,
+        pinnedAt: expect.any(Number),
       },
     ]);
   });
@@ -187,6 +189,91 @@ describe("useDesktopTabs", () => {
         (t: { viewId: string }) => t.viewId,
       ),
     ).toEqual(["c", "d", "e", "f"]);
+  });
+
+  it("evicts by PIN age, not open order, when pin order differs from open order", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    // Open five tabs unpinned (open order a..e), then pin them in REVERSE
+    // order: e, d, c, b — the dock is now full and "e" holds the oldest pin.
+    act(() => {
+      for (const id of ["a", "b", "c", "d", "e"]) {
+        result.current.openTab(view(id));
+      }
+    });
+    act(() => {
+      for (const id of ["e", "d", "c", "b"]) {
+        result.current.pinTab(id);
+      }
+    });
+    expect(
+      result.current.tabs.filter((t) => t.pinned).map((t) => t.viewId),
+    ).toEqual(["b", "c", "d", "e"]);
+
+    // Pinning "a" overflows the dock. The OLDEST pin ("e") must pop off —
+    // the old array-order walk instead unpinned "b", the tab the user had
+    // pinned most recently before "a".
+    act(() => {
+      result.current.pinTab("a");
+    });
+
+    const pinned = result.current.tabs
+      .filter((t) => t.pinned)
+      .map((t) => t.viewId);
+    expect(pinned).toHaveLength(LAUNCHER_DOCK_LIMIT);
+    expect(pinned).toEqual(["a", "b", "c", "d"]);
+    // "e" stays open — it just leaves the dock.
+    expect(result.current.tabs.map((t) => t.viewId)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+
+  it("evicts by pin age through openTab({ pinned: true }) as well", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      for (const id of ["a", "b", "c", "d", "e"]) {
+        result.current.openTab(view(id));
+      }
+      for (const id of ["e", "d", "c", "b"]) {
+        result.current.pinTab(id);
+      }
+    });
+
+    // Re-opening "a" with pinned:true is the same overflow: oldest pin "e" pops.
+    act(() => {
+      result.current.openTab(view("a"), { pinned: true });
+    });
+
+    expect(
+      result.current.tabs.filter((t) => t.pinned).map((t) => t.viewId),
+    ).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("re-opening an already-pinned tab preserves its original pin age", () => {
+    const { result } = renderHook(() => useDesktopTabs());
+
+    act(() => {
+      for (const id of ["a", "b", "c", "d"]) {
+        result.current.openTab(view(id), { pinned: true });
+      }
+    });
+    // Re-open "a" (oldest pin). Its pin age must NOT refresh…
+    act(() => {
+      result.current.openTab(view("a"), { pinned: true });
+    });
+    // …so pinning a fifth tab still evicts "a", not "b".
+    act(() => {
+      result.current.openTab(view("e"), { pinned: true });
+    });
+
+    expect(
+      result.current.tabs.filter((t) => t.pinned).map((t) => t.viewId),
+    ).toEqual(["b", "c", "d", "e"]);
   });
 
   it("caps pinned tabs when promoting an open tab via pinTab", () => {

--- a/packages/ui/src/hooks/useDesktopTabs.ts
+++ b/packages/ui/src/hooks/useDesktopTabs.ts
@@ -18,6 +18,13 @@ export interface DesktopTab {
   icon?: string;
   /** Pinned tabs persist to localStorage and survive restarts. */
   pinned: boolean;
+  /**
+   * When the tab was pinned (epoch ms, strictly monotonic within a session).
+   * Drives the dock's oldest-pinned-first eviction and persists so pin age
+   * survives restarts. Absent on legacy persisted entries (treated as oldest,
+   * ties broken by tab order — the pre-`pinnedAt` behavior).
+   */
+  pinnedAt?: number;
 }
 
 const STORAGE_KEY = "elizaos.desktop.pinned-tabs";
@@ -29,17 +36,34 @@ function loadPersistedTabs(): DesktopTab[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (item): item is DesktopTab =>
-        item !== null &&
-        typeof item === "object" &&
-        typeof (item as DesktopTab).viewId === "string" &&
-        typeof (item as DesktopTab).label === "string" &&
-        typeof (item as DesktopTab).path === "string",
-    );
+    return parsed
+      .filter(
+        (item): item is DesktopTab =>
+          item !== null &&
+          typeof item === "object" &&
+          typeof (item as DesktopTab).viewId === "string" &&
+          typeof (item as DesktopTab).label === "string" &&
+          typeof (item as DesktopTab).path === "string",
+      )
+      .map((item) =>
+        typeof item.pinnedAt === "number" && Number.isFinite(item.pinnedAt)
+          ? item
+          : { ...item, pinnedAt: undefined },
+      );
   } catch {
     return [];
   }
+}
+
+/**
+ * Strictly-monotonic pin timestamp: wall-clock when it advances, +1 otherwise,
+ * so two pins in the same millisecond still order deterministically.
+ */
+let lastPinStamp = 0;
+function nextPinStamp(): number {
+  const now = Date.now();
+  lastPinStamp = now > lastPinStamp ? now : lastPinStamp + 1;
+  return lastPinStamp;
 }
 
 function persistPinnedTabs(tabs: DesktopTab[]): void {
@@ -52,13 +76,18 @@ function persistPinnedTabs(tabs: DesktopTab[]): void {
   }
 }
 
-function tabFromView(view: ViewRegistryEntry, pinned: boolean): DesktopTab {
+function tabFromView(
+  view: ViewRegistryEntry,
+  pinned: boolean,
+  pinnedAt?: number,
+): DesktopTab {
   return {
     viewId: view.id,
     label: view.label,
     path: view.path ?? `/apps/${view.id}`,
     icon: view.icon,
     pinned,
+    ...(pinned && pinnedAt !== undefined ? { pinnedAt } : {}),
   };
 }
 
@@ -66,18 +95,32 @@ function tabFromView(view: ViewRegistryEntry, pinned: boolean): DesktopTab {
  * iOS-style dock cap: at most LAUNCHER_DOCK_LIMIT pinned tabs. Pinning past
  * the limit evicts (unpins) the oldest pinned tabs first, never the one the user
  * just pinned (`keepId`). Unpinned tabs stay open; they just leave the dock.
+ *
+ * "Oldest pinned" is PIN age (`pinnedAt`), not tab order: the tab array is the
+ * visual open order, and walking it (the old implementation) unpinned whichever
+ * pinned tab happened to be OPENED first — when pin order differed from open
+ * order that was often the most recently pinned tab, so the dock popped the tab
+ * the user had just deliberately pinned moments earlier. Legacy entries without
+ * `pinnedAt` sort oldest; ties break by tab order (the old behavior).
  */
 function capPinnedTabs(tabs: DesktopTab[], keepId: string): DesktopTab[] {
-  const pinnedCount = tabs.filter((t) => t.pinned).length;
-  if (pinnedCount <= LAUNCHER_DOCK_LIMIT) return tabs;
-  let toEvict = pinnedCount - LAUNCHER_DOCK_LIMIT;
-  return tabs.map((tab) => {
-    if (toEvict > 0 && tab.pinned && tab.viewId !== keepId) {
-      toEvict -= 1;
-      return { ...tab, pinned: false };
-    }
-    return tab;
-  });
+  const pinned = tabs.filter((t) => t.pinned);
+  const overflow = pinned.length - LAUNCHER_DOCK_LIMIT;
+  if (overflow <= 0) return tabs;
+  const evict = new Set(
+    pinned
+      .map((tab, index) => ({ tab, index }))
+      .filter(({ tab }) => tab.viewId !== keepId)
+      .sort(
+        (a, b) =>
+          (a.tab.pinnedAt ?? 0) - (b.tab.pinnedAt ?? 0) || a.index - b.index,
+      )
+      .slice(0, overflow)
+      .map(({ tab }) => tab.viewId),
+  );
+  return tabs.map((tab) =>
+    evict.has(tab.viewId) ? { ...tab, pinned: false } : tab,
+  );
 }
 
 export interface UseDesktopTabsResult {
@@ -102,16 +145,24 @@ export function useDesktopTabs(): UseDesktopTabsResult {
   const openTab = useCallback(
     (view: ViewRegistryEntry, options?: { pinned?: boolean }) => {
       if (!isElectrobunRuntime()) return;
+      const nextPinned = options?.pinned === true;
+      // Stamped outside the updater so a re-run (StrictMode) reuses one stamp.
+      const stamp = nextPinned ? nextPinStamp() : undefined;
       setTabs((current) => {
         const exists = current.find((t) => t.viewId === view.id);
-        const nextPinned = options?.pinned === true;
         const next = exists
           ? current.map((tab) =>
               tab.viewId === view.id
-                ? { ...tabFromView(view, tab.pinned || nextPinned) }
+                ? // An already-pinned tab keeps its original pin age; only a
+                  // fresh pin gets stamped.
+                  tabFromView(
+                    view,
+                    tab.pinned || nextPinned,
+                    tab.pinned ? tab.pinnedAt : stamp,
+                  )
                 : tab,
             )
-          : [...current, tabFromView(view, nextPinned)];
+          : [...current, tabFromView(view, nextPinned, stamp)];
         return nextPinned ? capPinnedTabs(next, view.id) : next;
       });
     },
@@ -125,11 +176,16 @@ export function useDesktopTabs(): UseDesktopTabsResult {
 
   const pinTab = useCallback((viewId: string) => {
     if (!isElectrobunRuntime()) return;
+    const stamp = nextPinStamp();
     setTabs((current) => {
       const exists = current.find((t) => t.viewId === viewId);
       if (!exists) return current;
       const next = current.map((t) =>
-        t.viewId === viewId ? { ...t, pinned: true } : t,
+        t.viewId === viewId
+          ? t.pinned
+            ? t
+            : { ...t, pinned: true, pinnedAt: stamp }
+          : t,
       );
       return capPinnedTabs(next, viewId);
     });

--- a/packages/ui/src/state/view-lifecycle.hidden-resume.test.tsx
+++ b/packages/ui/src/state/view-lifecycle.hidden-resume.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// Hidden keep-alive views must STAY paused across app-resume / tab refocus.
+//
+// A pausable keep-alive view's resting phase while hidden IS "paused" —
+// `setActive` pauses it the moment another view becomes active (see the
+// "retains + pauses a keep-alive view when hidden" case in
+// view-lifecycle.test.tsx). The bug: `resumeAll` (fired on APP_RESUME and on
+// every `visibilitychange` back to visible) transitioned EVERY paused record,
+// flipping hidden retained views to "inactive" — un-pausing them. Concretely:
+// open Calendar (keepAlive+pausable), go Home (calendar retained+paused, its
+// polling stopped), switch browser tabs away and back — calendar's timers/
+// polling/media restarted (`usePausableInterval` gates on `isPaused`, and its
+// `onResume` handler fired) while the view was still hidden. Only the ACTIVE
+// view may wake on resume.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
+import {
+  __resetViewLifecycleForTests,
+  viewLifecycleController as ctrl,
+  registerViewPolicy,
+} from "./view-lifecycle";
+
+beforeEach(() => {
+  __resetViewLifecycleForTests();
+});
+
+afterEach(() => {
+  __resetViewLifecycleForTests();
+  // Drop any per-test visibilityState override so it can't leak.
+  Reflect.deleteProperty(document, "visibilityState");
+});
+
+function setDocumentVisibility(state: "hidden" | "visible"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("hidden keep-alive views stay paused across resume signals", () => {
+  it("APP_RESUME wakes only the active view; a hidden retained view stays paused", () => {
+    ctrl.installSignals();
+    registerViewPolicy("calendar", { keepAlive: true, pausable: true });
+    ctrl.setActive("calendar");
+    ctrl.setActive("settings");
+    // Hidden keep-alive resting phase: paused (polling/timers stopped).
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+
+    window.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    expect(ctrl.getPhase("settings")).toBe("paused");
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+
+    window.dispatchEvent(new Event(APP_RESUME_EVENT));
+    expect(ctrl.getPhase("settings")).toBe("active");
+    // The hidden retained view must NOT wake — it is still hidden.
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+  });
+
+  it("a tab hide/refocus cycle does not un-pause a hidden retained view", () => {
+    ctrl.installSignals();
+    registerViewPolicy("calendar", { keepAlive: true, pausable: true });
+    ctrl.setActive("calendar");
+    ctrl.setActive("settings");
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+
+    setDocumentVisibility("hidden");
+    setDocumentVisibility("visible");
+
+    expect(ctrl.getPhase("settings")).toBe("active");
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+  });
+
+  it("a bare visibility refocus (no prior hide) leaves hidden retained views paused", () => {
+    ctrl.installSignals();
+    registerViewPolicy("calendar", { keepAlive: true, pausable: true });
+    ctrl.setActive("calendar");
+    ctrl.setActive("settings");
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+
+    // Focus events fire on plain refocus without a hidden transition too.
+    setDocumentVisibility("visible");
+
+    expect(ctrl.getPhase("calendar")).toBe("paused");
+    // The active view was never paused, and stays active.
+    expect(ctrl.getPhase("settings")).toBe("active");
+  });
+});

--- a/packages/ui/src/state/view-lifecycle.ts
+++ b/packages/ui/src/state/view-lifecycle.ts
@@ -391,15 +391,20 @@ class ViewLifecycleController {
     }
   }
 
-  /** Resume every paused view (app-resume / tab visible). */
+  /**
+   * Resume the ACTIVE paused view (app-resume / tab visible). Hidden retained
+   * views deliberately stay "paused": that is their resting phase — `setActive`
+   * pauses a pausable keep-alive view the moment it is hidden — so waking them
+   * here (the old paused → "inactive" transition) restarted their timers/
+   * polling/media (`usePausableInterval` gates on `isPaused`, and views restart
+   * media/native subscriptions in `onResume`) while they were still hidden,
+   * on every tab refocus or app foreground.
+   */
   private resumeAll(): void {
     for (const record of this.records.values()) {
-      if (record.phase === "paused") {
-        this.transition(
-          record,
-          record.viewId === this.activeId ? "active" : "inactive",
-          "resume",
-        );
+      if (record.phase !== "paused") continue;
+      if (record.viewId === this.activeId) {
+        this.transition(record, "active", "resume");
       }
     }
   }


### PR DESCRIPTION
Two end-to-end fixed state/hooks bugs in `@elizaos/ui`, each with a mutation-checked regression test. Scope: `packages/ui/src/state` + `packages/ui/src/hooks` only.

## 1. `view-lifecycle.ts` — hidden keep-alive views un-pause on every tab refocus / app resume

**Before:** a pausable keep-alive view's resting phase while hidden is `paused` (`setActive` pauses it on hide — existing test asserts this). But `resumeAll`, wired to `APP_RESUME` **and every `visibilitychange` back to visible**, transitioned *every* paused record, flipping hidden retained views to `inactive` — un-pausing them. `useViewLifecycle` then reported `isPaused: false` and fired `onResume`, so `usePausableInterval` restarted its interval and views restarted media/native subscriptions **while still hidden**.

**User scenario:** open Calendar (keepAlive+pausable), go Home → calendar retained + paused (polling stopped). Switch browser tabs away and back (or lock/unlock the phone) → calendar's polling/timers/media silently restart in the background. Every refocus re-wakes every hidden retained view.

**After:** `resumeAll` wakes only the ACTIVE view; hidden retained views keep their resting `paused` phase.

**Tests:** `view-lifecycle.hidden-resume.test.tsx` — APP_PAUSE/APP_RESUME cycle, visibility hidden→visible cycle, bare visible refocus (3/3 green). Mutation check: all 3 FAIL with the fix reverted. Existing lifecycle + matrix suites: 91/91 green (the signal-bus "active view resumes to active" case is preserved).

## 2. `useDesktopTabs.ts` — dock pin cap unpins by open order, not pin age

**Before:** `capPinnedTabs` documents "evicts the oldest pinned tabs first, never the one just pinned", but walked the tab ARRAY (visual open order), unpinning the first pinned non-`keepId` tab it met.

**User scenario:** open tabs a, b, c, d, e; pin e, d, c, b (dock full — e is the oldest pin); pin a → the dock unpinned **b**, the tab pinned most recently before a, while stale-pinned e kept its slot. Existing tests only exercised pin-order == open-order, so it never tripped.

**After:** pins carry a persisted, session-monotonic `pinnedAt` stamp (stamped on fresh pin, preserved on re-open, sanitized on load); eviction sorts evictable pins oldest-`pinnedAt`-first with array-order tie-break. Legacy persisted entries (no `pinnedAt`) sort oldest with array-order ties — byte-identical to the old behavior for pre-migration data. Same input now evicts **e**.

**Tests:** 3 new cases in `useDesktopTabs.test.tsx` (pinTab overflow with reversed pin order, `openTab({pinned:true})` overflow, re-open preserves pin age) + persisted-shape assertions updated for `pinnedAt`; suite 8/8 green. Mutation check: pin-age tests FAIL with the fix reverted.

## Evidence
- Tests: see above; run via `bunx vitest run --no-cache` in `packages/ui`, all green at head.
- Mutation checks: each fix reverted in isolation → its regression tests fail; restored → green.
- `biome check --write` clean on all 4 touched files; `tsgo --noEmit` on packages/ui shows only a pre-existing, unrelated `iwer` module error also present on clean `origin/develop`.
- Screenshots / video / live-LLM trajectories: N/A — pure state-machine/hook logic with no rendered pixel change and no model path; behavior is fully captured by the deterministic unit/hook tests above.

Dropped as not-real after close reading (honest no-ship): `useWalletState` selections TypeError (type-required + always supplied by the only caller), `resource-cache.invalidate` stale-commit race (zero production callers — not exported from any barrel), `normalizeLastNativeTab` stale whitelist (no constructible user-visible wrong restore), composer draft handoff leak (already fixed on develop).

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Independently re-verified: 4-file merge-base diff, 11/11 green (--no-cache), and the view-lifecycle mutation reproduced (revert → 3/3 hidden-resume tests red; restore → green). Agent honestly DROPPED 7 candidates it verified were NOT bugs (parsers, wallet-save, resource-cache no-callers, persistence whitelist, already-fixed draft handoff, launcher NaN, various reducers) — no forced fixes; heavily-swept codebase. Both bugs are demo-relevant (a user hits them: background timers on tab-refocus; wrong tab evicted on pin). — [phone-ui]