### PR TITLE
fix(plugin-cloud-apps): harden deploy gate polling

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
@@ -326,6 +326,36 @@ describe("runDeployGate — poll robustness (transient errors + per-request time
     expect(pollAttempts).toEqual([1, 2, 3]);
   });
 
+  it("fast-fails permanent Cloud API poll errors instead of timing out as still building", async () => {
+    const pollError = Object.assign(new Error("Forbidden"), {
+      name: "CloudApiError",
+      statusCode: 403,
+      errorBody: { success: false, error: "Forbidden" },
+    });
+    const pollAttempts: number[] = [];
+    const deps: DeployGateDeps = {
+      getStatus: () => Promise.reject(pollError),
+      getApp: () => Promise.resolve(appRes("https://acme.elizacloud.ai")),
+      probe: () => Promise.resolve({ ok: true, status: 200 }),
+      sleep: () => Promise.resolve(),
+      onPollError: (_error, attempt) => pollAttempts.push(attempt),
+    };
+
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      maxAttempts: 3,
+    });
+
+    expect(result).toEqual({
+      phase: "error",
+      url: null,
+      status: "",
+      attempts: 1,
+      error: "Forbidden",
+    });
+    expect(pollAttempts).toEqual([]);
+  });
+
   it("a stalled app re-read after READY falls back to the status vercelUrl instead of hanging", async () => {
     const deps: DeployGateDeps = {
       getStatus: () =>

--- a/plugins/plugin-cloud-apps/src/deploy-gate.ts
+++ b/plugins/plugin-cloud-apps/src/deploy-gate.ts
@@ -110,6 +110,7 @@ export const DEFAULT_DEPLOY_GATE_CONFIG: DeployGateConfig = {
 
 const TERMINAL_SUCCESS = new Set(["READY", "DEPLOYED"]);
 const TERMINAL_ERROR = new Set(["ERROR", "FAILED"]);
+const NON_RETRIABLE_POLL_ERROR_STATUSES = new Set([401, 403, 404]);
 
 type StatusClass = "success" | "error" | "pending";
 
@@ -135,6 +136,30 @@ function normalizeUrl(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function cloudApiStatusCode(err: unknown): number | null {
+  if (typeof err !== "object" || err === null) return null;
+  const value = (err as Record<string, unknown>).statusCode;
+  return typeof value === "number" ? value : null;
+}
+
+function isNonRetriablePollError(err: unknown): boolean {
+  const status = cloudApiStatusCode(err);
+  return status !== null && NON_RETRIABLE_POLL_ERROR_STATUSES.has(status);
+}
+
+function pollErrorMessage(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const body = (err as Record<string, unknown>).errorBody;
+    if (typeof body === "object" && body !== null) {
+      const bodyError = (body as Record<string, unknown>).error;
+      if (typeof bodyError === "string" && bodyError.trim().length > 0) {
+        return bodyError;
+      }
+    }
+  }
+  return err instanceof Error ? err.message : String(err ?? "unknown error");
 }
 
 /**
@@ -185,6 +210,15 @@ export async function runDeployGate(
         "deploy status poll",
       );
     } catch (err) {
+      if (isNonRetriablePollError(err)) {
+        return {
+          phase: "error",
+          url: null,
+          status: lastStatus,
+          attempts: attempt,
+          error: pollErrorMessage(err),
+        };
+      }
       // A transient poll failure must NOT abort the gate — the deploy is
       // already running server-side. Log it and keep polling until the
       // overall attempt budget runs out (which reports "still building",


### PR DESCRIPTION
Follow-up to #11928 (merged).

#11928 made transient status-poll failures log-and-continue under the deploy gate attempt budget. This PR keeps that behavior for transient network errors, timeouts, and retriable server failures, but fast-fails permanent Cloud API poll errors for 401/403/404 as `phase: "error"` instead of consuming the full poll budget and returning a misleading "still building" timeout.

Verification run in sparse temp checkout:
- `bun test plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts` -> 16 pass / 0 fail
- `git diff --check` -> passed