### PR TITLE
fix(core): bot-noise triage — parse verdict via getV5ModelText + stripReasoningBlocks so it works for reasoning TEXT_SMALL providers (follow-up to #11946)

### DIFF
--- a/packages/core/src/services/message/bot-noise-triage.test.ts
+++ b/packages/core/src/services/message/bot-noise-triage.test.ts
@@ -204,6 +204,46 @@ describe("runBotNoiseTriage — cheap-tier verdict", () => {
 		expect(result).toEqual({ applied: true, respond: false });
 	});
 
+	it("parses IGNORE from a reasoning model that names both verdicts inside <think>", async () => {
+		// A REASONING-tier TEXT_SMALL provider (e.g. Cerebras gpt-oss) deliberates
+		// out loud before the one-word answer. The reasoning block mentions both
+		// RESPOND and IGNORE; only the post-think verdict counts. Without stripping
+		// the block the regex sees both words and fails open — the silent no-op.
+		const runtime = makeRuntime({
+			modelResult:
+				"<think>The bot embed is a status feed and does not address Remilio. " +
+				"I could RESPOND, but automated updates like this should IGNORE. " +
+				"Final answer below.</think>\nIGNORE",
+		});
+		const result = await runBotNoiseTriage({
+			runtime,
+			message: relayEmbedMessage(),
+			explicitlyAddressesAgent: false,
+		});
+		expect(result).toEqual({ applied: true, respond: false });
+	});
+
+	it("extracts the verdict from a content-array GenerateTextResult with no flat text", async () => {
+		// Reasoning-tier providers surface structured output: the flat `.text` is
+		// empty and the real assistant text lives in the `content` parts array.
+		// getV5ModelText must recover it; the ad-hoc `.text` read saw "" (fail open).
+		const runtime = makeRuntime({
+			modelResult: {
+				text: "",
+				content: [
+					{ type: "reasoning", text: "weighing RESPOND vs IGNORE" },
+					{ type: "text", text: "IGNORE" },
+				],
+			},
+		});
+		const result = await runBotNoiseTriage({
+			runtime,
+			message: relayEmbedMessage(),
+			explicitlyAddressesAgent: false,
+		});
+		expect(result).toEqual({ applied: true, respond: false });
+	});
+
 	it("fails open on an unparseable verdict", async () => {
 		for (const garbage of ["", "maybe?", "RESPOND IGNORE"]) {
 			const runtime = makeRuntime({ modelResult: garbage });

--- a/packages/core/src/services/message/bot-noise-triage.ts
+++ b/packages/core/src/services/message/bot-noise-triage.ts
@@ -23,9 +23,15 @@
  */
 
 import type { Memory } from "../../types/memory";
-import { type GenerateTextParams, ModelType } from "../../types/model";
+import {
+	type GenerateTextParams,
+	type GenerateTextResult,
+	ModelType,
+} from "../../types/model";
 import { ChannelType } from "../../types/primitives";
 import type { IAgentRuntime } from "../../types/runtime";
+import { stripReasoningBlocks } from "./fallback-reply";
+import { getV5ModelText } from "./generate-text-result";
 
 /**
  * Text group-ish channel types the gate applies to. Private channels
@@ -241,11 +247,16 @@ export async function runBotNoiseTriage(
 			temperature: 0,
 			voiceOutput: "internal",
 		};
-		const raw = await runtime.useModel(ModelType.TEXT_SMALL, params);
-		const text =
-			typeof raw === "string"
-				? raw
-				: (((raw as { text?: unknown })?.text as string | undefined) ?? "");
+		const raw = (await runtime.useModel(ModelType.TEXT_SMALL, params)) as
+			| string
+			| GenerateTextResult;
+		// Reuse the canonical helpers Stage 1 uses for the same TEXT_SMALL call:
+		// getV5ModelText handles the content-array / response-field result shapes
+		// (structured output from reasoning-tier providers has no flat `.text`),
+		// and stripReasoningBlocks drops <think>…</think> so a reasoning model
+		// that names both RESPOND and IGNORE while deliberating still yields a
+		// clean one-word verdict instead of an ambiguous fail-open.
+		const text = stripReasoningBlocks(getV5ModelText(raw));
 		const verdict = parseTriageVerdict(text);
 		if (verdict === undefined) {
 			// Unparseable verdict — fail open into the full pipeline.


### PR DESCRIPTION
## The bug

The pre-Stage-1 bot-noise triage gate (`packages/core/src/services/message/bot-noise-triage.ts`, landed in #11946) asks the cheap `TEXT_SMALL` tier for a one-word RESPOND/IGNORE verdict on unaddressed bot/webhook group traffic. It reimplemented weaker versions of two helpers the rest of the message service already uses for the identical `useModel(TEXT_SMALL, …)` call, so for a **REASONING-tier TEXT_SMALL provider** (e.g. Cerebras `gpt-oss` — the exact provider this feature targets) the gate **silently no-op'd**:

1. **Text extraction** read only a flat `.text` field: `(((raw as { text?: unknown })?.text) ?? "")`. Structured-output providers return the assistant text in the `content`-array or `response` field of `GenerateTextResult`, so `text` became `""`.
2. **`parseTriageVerdict`** ran the RESPOND/IGNORE regex over the raw text **without stripping `<think>…</think>` reasoning blocks**. A reasoning model that names *both* words while deliberating ("I could RESPOND, but this should IGNORE") matched both → returned `undefined`.

## Why the gate no-ops for reasoning providers

Both weak parses fail **open** (empty/ambiguous verdict → fall through to the full Stage 1 pipeline), so there is no false mute — but the net effect is the gate **never fires** for the recommended provider, and every bot-noise message still burns a full `composeState` + RESPONSE_HANDLER call, which is exactly the cost #11946 set out to avoid.

## The fix

Reuse the canonical helpers Stage 1 already uses for the same TEXT_SMALL call (see `message.ts` ~L7920, `stripReasoningBlocks(getV5ModelText(raw)).trim()`):

- **`getV5ModelText(raw)`** (`message/generate-text-result.ts`) — normalizes the `content`-array / `response`-field result shapes to text.
- **`stripReasoningBlocks(text)`** (`message/fallback-reply.ts`) — drops `<think>…</think>` before the RESPOND/IGNORE regex.

All existing **fail-open** behavior is preserved: empty/unparseable/ambiguous verdicts and model errors still fall through to the full pipeline (no silent mute).

## Tests

Added to `bot-noise-triage.test.ts` (21 pass, 2 new):

- `<think>…RESPOND…IGNORE…</think>\nIGNORE` now parses to **IGNORE** (was `undefined`).
- A `GenerateTextResult` with a `content` array and empty flat `.text` whose text says IGNORE is now extracted and parsed correctly.

Follow-up to #11946.