### PR TITLE
ci(cloud): scope deploy-api to production env so it publishes STEWARD_PLATFORM_KEYS (#11937)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -179,6 +179,13 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
+    # Scope the job to the same GitHub environment as migrate-db so its
+    # production-environment secrets — notably STEWARD_PLATFORM_KEYS (#11461) —
+    # are visible to the publish-secrets step. Without this the un-scoped job
+    # only saw repo secrets, so `publish_secret` skipped the key and a redeploy
+    # would silently recreate the #11461 tenant-isolation gap (#11937). Mirrors
+    # the proven migrate-db declaration exactly (same protection semantics).
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
     # A production Worker deploy must never be cancelled mid-flight by a newer
     # main promote (#11640): the workflow-level group did not protect the
     # in-flight job, so rapid promotes cancelled every Worker deploy and prod


### PR DESCRIPTION
## Gap

#11461's durable re-publish path (#11757 — add `STEWARD_PLATFORM_KEYS` to the publish-secrets step) is **inert**: the `deploy-api` job in `cloud-cf-deploy.yml` has **no `environment:` declaration**, so `STEWARD_PLATFORM_KEYS` — a *production-environment* secret, not a repo secret — is **not visible** to the job. The `publish_secret` step skips it with a `::notice::`, so if the Worker secret is ever wiped/rotated out, a normal redeploy will NOT re-inject it, silently recreating the #11461 tenant-isolation gap.

## Fix

Add the **same** `environment:` expression that the `migrate-db` job already uses (line 126) — which deploys reliably today — to `deploy-api`:
```yaml
environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
```
Now the job runs in the production GitHub environment and its production-env secrets (incl. `STEWARD_PLATFORM_KEYS`) are visible, so the publish step actually re-injects the key on every redeploy. Same protection/concurrency semantics as migrate-db (proven pattern); YAML validated (`yaml.safe_load`).

Live deploy verification is operator-side (needs Cloudflare creds), but the change mirrors an existing, working job declaration exactly.

Closes #11937

🤖 Generated with [Claude Code](https://claude.com/claude-code)