### PR TITLE
fix(agent): send oauth beta header in inline anthropic subscription test probe

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -292,6 +292,10 @@ async function probeAnthropicUsage(accessToken: string): Promise<{
       headers: {
         "Content-Type": "application/json",
         "anthropic-version": "2023-06-01",
+        // OAuth subscription tokens are rejected with a 401 unless the
+        // oauth beta header is present — same header the canonical
+        // `pollAnthropicUsage` (app-core account-usage) sends.
+        "anthropic-beta": "oauth-2025-04-20",
         Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify({

--- a/packages/agent/test/api/accounts-routes.test.ts
+++ b/packages/agent/test/api/accounts-routes.test.ts
@@ -8,6 +8,7 @@ import {
   handleAccountsRoutes,
 } from "../../src/api/accounts-routes";
 import { listAccounts, saveAccount } from "../../src/auth/account-storage.js";
+import { getAccessToken } from "../../src/auth/credentials.ts";
 
 const poolMock = vi.hoisted(() => ({
   list: vi.fn(),
@@ -31,6 +32,12 @@ vi.mock("../../src/auth/account-storage.js", () => ({
   loadAccount: vi.fn(() => null),
   saveAccount: vi.fn(),
 }));
+
+vi.mock("../../src/auth/credentials.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/auth/credentials.ts")>();
+  return { ...actual, getAccessToken: vi.fn(async () => null) };
+});
 
 function linkedAccount(
   providerId: LinkedAccountConfig["providerId"],
@@ -88,6 +95,34 @@ describe("accounts routes provider-scoped account resolution", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the oauth beta header when testing an anthropic subscription", async () => {
+    vi.mocked(getAccessToken).mockResolvedValue("sk-ant-oat01-test");
+    poolMock.get.mockReturnValue(linkedAccount("anthropic-subscription"));
+    const fetchMock = vi.fn(
+      async () => new Response('{"id":"msg_1"}', { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext({
+      method: "POST",
+      pathname: "/api/accounts/anthropic-subscription/shared-id/test",
+    });
+
+    const handled = await handleAccountsRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["anthropic-beta"]).toBe("oauth-2025-04-20");
+    expect(headers.Authorization).toBe("Bearer sk-ant-oat01-test");
+    expect(ctx.body).toMatchObject({ ok: true, status: 200 });
   });
 
   it("patches the provider-matching account when ids collide", async () => {


### PR DESCRIPTION
## Problem

Clicking **Test** on a healthy, just-connected Claude subscription account reports a 401-shaped failure — the UI tells the user a good account is broken.

The inline test probe (`probeAnthropicUsage` in `packages/agent/src/api/accounts-routes.ts`) POSTs `https://api.anthropic.com/v1/messages` with the Bearer subscription (OAuth) token but omits the `anthropic-beta: oauth-2025-04-20` header. Anthropic rejects OAuth Bearer tokens on `/v1/messages` without that header, so the probe always fails for subscription accounts. The same wrong failure also hits the `refresh-usage` inline fallback path, which flips the account to `rate-limited`.

The canonical usage poller already sends the header (`pollAnthropicUsage`, `packages/app-core/src/services/account-usage.ts`), as does the OAuth `/v1/messages` path in `packages/agent/src/auth/claude-code-stealth.ts`.

## Fix

Add `anthropic-beta: oauth-2025-04-20` to the inline probe's headers — the one header the canonical OAuth paths send that the probe was missing (`Authorization: Bearer` and `Content-Type` were already there). Both call sites gate on `subscription === "anthropic-subscription"`, so the probe only ever sees OAuth subscription tokens and the header applies unconditionally.

## Test

`packages/agent/test/api/accounts-routes.test.ts` — drives the real route (`POST /api/accounts/anthropic-subscription/:id/test`) through `handleAccountsRoutes` with a stubbed global fetch and asserts the outbound request carries `anthropic-beta: oauth-2025-04-20` plus the Bearer token, and that the route reports `ok: true`.

- Without the fix (develop): `AssertionError: expected undefined to be 'oauth-2025-04-20'` — 1 failed | 5 passed
- With the fix: 6 passed (6)

## Verification

- `bun run vitest run test/api/accounts-routes.test.ts` (packages/agent): 6/6 pass
- `bun run typecheck` (packages/agent): 67 pre-existing errors on clean develop in a fresh worktree (unbuilt workspace deps, e.g. `@elizaos/plugin-streaming` TS2307), identical 67 with this diff — zero new
- `biome check` on both touched files: clean

## Evidence notes

- Real-LLM trajectories: N/A — no agent/action/prompt/model behavior change; this is an HTTP header on an account-health probe.
- UI screenshots/video: N/A — no rendered UI change; the existing Test button path now reports the true account state.
