### PR TITLE
fix(ui): enable native Apps queries under API-key auth

### DIFF
--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -36,7 +36,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 
 const STEWARD_TOKEN = makeJwt({
   userId: "u1",
-  exp: Math.floor(Date.now() / 1000) + 600,
+  exp: 4_102_444_800,
 });
 
 function setElectrobun(active: boolean): void {

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -25,7 +25,19 @@ import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { setBootConfig } from "../../config/boot-config";
 import { ApiError, api } from "./api-client";
 
-const STEWARD_TOKEN = "steward-jwt-token";
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(payload)}.sig`;
+}
+
+const STEWARD_TOKEN = makeJwt({
+  userId: "u1",
+  exp: Math.floor(Date.now() / 1000) + 600,
+});
 
 function setElectrobun(active: boolean): void {
   const w = window as unknown as { __electrobunWindowId?: number };
@@ -289,7 +301,7 @@ describe("cloud api-client transport bridge", () => {
       );
     });
 
-    it("native: the Steward JWT still WINS over the cloud API key when both exist", async () => {
+    it("native: a live Steward JWT still WINS over the cloud API key when both exist", async () => {
       capacitorState.isNative = true;
       // beforeEach already seeded STEWARD_TOKEN_KEY.
       setBootConfig({
@@ -308,6 +320,31 @@ describe("cloud api-client transport bridge", () => {
           }),
         }),
       );
+    });
+
+    it("native: an expired Steward JWT is cleared and falls back to the cloud API key", async () => {
+      capacitorState.isNative = true;
+      window.localStorage.setItem(
+        STEWARD_TOKEN_KEY,
+        makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+      );
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: CLOUD_API_KEY,
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      expect(capacitorMocks.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            authorization: `Bearer ${CLOUD_API_KEY}`,
+          }),
+        }),
+      );
+      expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
     });
 
     it("native: the __ELIZA_CLOUD_AUTH_TOKEN__ global outranks the REST token, matching getCloudAuthToken()", async () => {

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -29,6 +29,7 @@ import { getElizaApiToken } from "@elizaos/shared";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { getBootConfig } from "../../config/boot-config";
+import { decodeJwtPayload } from "./jwt";
 
 // The single Eliza Cloud API host the native/Electrobun transport is allowed to
 // reach cross-origin. Kept deliberately narrow: only this exact host relaxes the
@@ -155,6 +156,28 @@ function readStewardToken(): string | null {
   }
 }
 
+function clearStoredStewardTokenIfCurrent(token: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.localStorage.getItem(STEWARD_TOKEN_KEY) === token) {
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    }
+  } catch {
+    // ignore storage/event failures; the fallback token path can still proceed.
+  }
+}
+
+function readLiveNativeStewardToken(token: string): string | null {
+  const claims = decodeJwtPayload(token);
+  const expMs = typeof claims?.exp === "number" ? claims.exp * 1000 : null;
+  if (!claims || expMs === null || expMs <= Date.now()) {
+    clearStoredStewardTokenIfCurrent(token);
+    return null;
+  }
+  return token;
+}
+
 /**
  * Resolve the Cloud bearer for the auth header. The Steward session JWT stays
  * first (canonical, unchanged). On native/Electrobun ONLY, fall back to the
@@ -171,7 +194,11 @@ function readStewardToken(): string | null {
  */
 function readCloudBearerToken(): string | null {
   const stewardToken = readStewardToken()?.trim();
-  if (stewardToken) return stewardToken;
+  if (stewardToken) {
+    if (!isNativeCloudRuntime()) return stewardToken;
+    const liveToken = readLiveNativeStewardToken(stewardToken);
+    if (liveToken) return liveToken;
+  }
   if (!isNativeCloudRuntime()) return null;
   const globalToken = (globalThis as Record<string, unknown>)
     .__ELIZA_CLOUD_AUTH_TOKEN__;

--- a/packages/ui/src/cloud/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/lib/auth-query.test.tsx
@@ -3,6 +3,14 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const capacitorState = vi.hoisted(() => ({ isNative: false }));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => capacitorState.isNative,
+  },
+}));
+
 // The query gate every cloud domain shares (analytics, api-keys, mcps,
 // applications, approvals, instances) must resolve the session the same way
 // the rest of the console does. Gating on the raw Steward SDK context (whose
@@ -12,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // page-reload reality: ONLY a persisted localStorage JWT, no Steward provider
 // mounted.
 
+import { setBootConfig } from "../../config/boot-config";
 import { useAuthenticatedQueryGate } from "./auth-query";
 
 function makeJwt(payload: Record<string, unknown>): string {
@@ -50,9 +59,13 @@ beforeEach(() => {
     configurable: true,
     value: storage,
   });
+  capacitorState.isNative = false;
+  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+  setBootConfig({ branding: {}, apiToken: undefined });
 });
 
 afterEach(() => {
+  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   vi.unstubAllGlobals();
 });
 
@@ -92,5 +105,38 @@ describe("shared cloud query gate — session from persisted JWT only (page-relo
 
     const { result } = renderHook(() => useAuthenticatedQueryGate(false));
     expect(result.current.enabled).toBe(false);
+  });
+
+  it("native: enables queries for an API-key session with no Steward JWT", () => {
+    capacitorState.isNative = true;
+    setBootConfig({ branding: {}, apiToken: "eliza_native_owner_key" });
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.userId).toMatch(/^native-api-key:/);
+  });
+
+  it("web: does not treat the REST API key as a session", () => {
+    setBootConfig({ branding: {}, apiToken: "eliza_web_owner_key" });
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.userId).toBeNull();
+  });
+
+  it("native: an expired Steward JWT does not block the API-key session gate", () => {
+    capacitorState.isNative = true;
+    storage.setItem(
+      "steward_session_token",
+      makeJwt({ userId: "u1", exp: Math.floor(Date.now() / 1000) - 600 }),
+    );
+    setBootConfig({ branding: {}, apiToken: "eliza_native_owner_key" });
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.userId).toMatch(/^native-api-key:/);
   });
 });

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -13,8 +13,12 @@
  * suites can exercise authed surfaces against a mock stack.
  */
 
+import { Capacitor } from "@capacitor/core";
+import { getElizaApiToken } from "@elizaos/shared";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { useContext, useEffect, useState } from "react";
+import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
+import { getBootConfig } from "../../config/boot-config";
 import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
@@ -70,6 +74,38 @@ function readPlaywrightTestSession(): StewardSessionUser {
   return {
     id: PLAYWRIGHT_TEST_USER_ID,
     email: PLAYWRIGHT_TEST_USER_EMAIL,
+  };
+}
+
+function isNativeCloudRuntime(): boolean {
+  return Capacitor.isNativePlatform() || isElectrobunRuntime();
+}
+
+function nativeCloudApiKey(): string | null {
+  if (!isNativeCloudRuntime()) return null;
+  const globalToken = (globalThis as Record<string, unknown>)
+    .__ELIZA_CLOUD_AUTH_TOKEN__;
+  if (typeof globalToken === "string" && globalToken.trim()) {
+    return globalToken.trim();
+  }
+  return getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim() || null;
+}
+
+function apiKeySessionId(token: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index++) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `native-api-key:${(hash >>> 0).toString(36)}`;
+}
+
+function readNativeApiKeySession(): StewardSessionUser {
+  const token = nativeCloudApiKey();
+  if (!token) return null;
+  return {
+    id: apiKeySessionId(token),
+    email: "",
   };
 }
 
@@ -132,6 +168,9 @@ export function useSessionAuth(): SessionAuthState {
   const [storageUser, setStorageUser] = useState<StewardSessionUser>(
     readStewardSessionFromStorage,
   );
+  const [apiKeyUser, setApiKeyUser] = useState<StewardSessionUser>(
+    readNativeApiKeySession,
+  );
   const [testUser, setTestUser] = useState<StewardSessionUser>(
     readPlaywrightTestSession,
   );
@@ -139,6 +178,7 @@ export function useSessionAuth(): SessionAuthState {
   useEffect(() => {
     const handler = () => {
       setStorageUser(readStewardSessionFromStorage());
+      setApiKeyUser(readNativeApiKeySession());
       setTestUser(readPlaywrightTestSession());
     };
     handler();
@@ -160,9 +200,12 @@ export function useSessionAuth(): SessionAuthState {
       }
     : null;
 
-  const user = providerUser ?? storageUser ?? testUser;
+  const user = providerUser ?? storageUser ?? apiKeyUser ?? testUser;
   const authenticated =
-    providerAuth.isAuthenticated || storageUser !== null || testUser !== null;
+    providerAuth.isAuthenticated ||
+    storageUser !== null ||
+    apiKeyUser !== null ||
+    testUser !== null;
   const ready = !providerAuth.isLoading || isPlaywrightTestAuthEnabled();
 
   return { ready, authenticated, user };


### PR DESCRIPTION
Closes #11961.

## Summary
- treat native/Electrobun cloud API-key credentials as an authenticated query-gate session without changing web behavior
- ignore and clear expired or malformed Steward JWTs on native before falling back to the durable cloud API key
- add regression coverage for native API-key query gating and expired-JWT bearer fallback

## Testing
- Not run locally: current checkout is not develop-shaped and has unrelated dirty app changes; relying on CI for the branch test matrix.