### PR TITLE
fix(app-control): register a freshly built app on verification-pass so 'launch it' works (#11954)

### DIFF
--- a/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
@@ -79,24 +79,28 @@ describe("VerificationRoomBridgeService — boot-order retry", () => {
 		expect(coordinator.__listenerCount()).toBe(0);
 	});
 
-	it("gives up quietly after ATTACH_MAX_RETRIES without binding twice", async () => {
+	it("keeps retrying past ATTACH_MAX_RETRIES and binds once when the coordinator appears late", async () => {
 		const coordinator = makeCoordinator();
 		const { runtime, setService } = makeRuntime({});
 
 		const service = await VerificationRoomBridgeService.start(runtime);
 
-		// Drain the entire retry budget: 60 retries × 500ms = 30s.
+		// Drain past the entire fast-retry budget (60 retries × 500ms = 30s). The
+		// bridge does NOT give up here — a heavy boot can register the coordinator
+		// well past that window, so it keeps retrying with a coarser backoff.
 		vi.advanceTimersByTime(31_000);
-		await Promise.resolve();
-
-		// Service eventually shows up AFTER giving up. Bridge must NOT
-		// subscribe — the retry loop already terminated.
-		setService("SWARM_COORDINATOR", coordinator);
-		vi.advanceTimersByTime(5_000);
 		await Promise.resolve();
 		expect(coordinator.__listenerCount()).toBe(0);
 
+		// The coordinator finally shows up long after the fast window. The
+		// still-running retry loop must bind it — exactly once.
+		setService("SWARM_COORDINATOR", coordinator);
+		vi.advanceTimersByTime(5_000);
+		await Promise.resolve();
+		expect(coordinator.__listenerCount()).toBe(1);
+
 		await service.stop();
+		expect(coordinator.__listenerCount()).toBe(0);
 	});
 
 	it("stop() cancels a pending retry timer", async () => {
@@ -210,6 +214,131 @@ describe("VerificationRoomBridgeService — verdict posting", () => {
 		expect(text).toContain("import threw: bad export");
 		expect(text).toContain("Reload the agent");
 		expect(text).not.toContain("reinject");
+
+		await service.stop();
+	});
+
+	// A scaffolded app lives at <repoRoot>/eliza/apps/app-<name>; the
+	// load-from-directory route scans a PARENT for app subdirs, so the bridge
+	// must register the workdir's parent, not the workdir itself.
+	function appPassEvent() {
+		return {
+			type: "task_complete",
+			sessionId: "app-pass",
+			data: {
+				originRoomId: "room-99",
+				label: "create-app:notes",
+				workdir: "/repo/eliza/apps/app-notes",
+				verification: {
+					source: "custom-validator",
+					verdict: "pass",
+					validator: { service: "app-verification", method: "verifyApp" },
+					params: {
+						appName: "notes",
+						workdir: "/repo/eliza/apps/app-notes",
+						profile: "full",
+					},
+				},
+			},
+		};
+	}
+
+	it("registers the built app on pass so 'launch <name>' resolves (#11954)", async () => {
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				ok: true,
+				directory: "/repo/eliza/apps",
+				registered: 1,
+				items: [{ slug: "notes", canonicalName: "notes" }],
+				rejectedManifests: [],
+			}),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appPassEvent());
+		await flush();
+
+		// It POSTed the app's PARENT dir to the app-register route so a subsequent
+		// listInstalledApps() + launch resolves the freshly built app.
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			expect.stringContaining("/api/apps/load-from-directory"),
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ directory: "/repo/eliza/apps" }),
+			}),
+		);
+
+		expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+		const [memory, table] = (runtime.createMemory as ReturnType<typeof vi.fn>)
+			.mock.calls[0];
+		expect(table).toBe("messages");
+		expect(memory.roomId).toBe("room-99");
+		const text = memory.content.text as string;
+		expect(text).toContain("notes app built, verified, and installed");
+		expect(text).toContain("launch notes");
+		expect(memory.content.metadata).toMatchObject({ verdict: "pass" });
+
+		await service.stop();
+	});
+
+	it("does not promise a launch when app registration fails", async () => {
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: false,
+			status: 503,
+			json: async () => ({
+				ok: false,
+				error: "AppRegistryService is not registered on the runtime",
+			}),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appPassEvent());
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).toContain("built and verified");
+		expect(text).toContain("installing it failed");
+		expect(text).toContain("AppRegistryService is not registered");
+		// The false "reply 'launch notes' to open it" promise must be gone.
+		expect(text).not.toContain("launch notes");
+
+		await service.stop();
+	});
+
+	it("stays honest when the scan registers nothing matching the app name", async () => {
+		// Registry scan succeeded but the built app's manifest was rejected or
+		// registered under a different name — no launchable match for `notes`.
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				ok: true,
+				directory: "/repo/eliza/apps",
+				registered: 1,
+				items: [{ slug: "some-other-app", canonicalName: "some-other-app" }],
+				rejectedManifests: [],
+			}),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appPassEvent());
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).toContain("did not register under a launchable name");
+		expect(text).not.toContain("launch notes");
 
 		await service.stop();
 	});

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -33,6 +33,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { logger, resolveServerOnlyPort, Service } from "@elizaos/core";
 
@@ -227,11 +228,97 @@ async function loadPluginFromWorkdir(
 	}
 }
 
+interface RegisteredAppItem {
+	slug: string;
+	canonicalName: string;
+}
+
+/**
+ * Register a freshly built app into the running runtime via the loopback agent
+ * API so a subsequent `launch <name>` resolves. The
+ * `/api/apps/load-from-directory` route scans a *parent* directory for app
+ * subdirs and registers each valid one through the AppRegistryService
+ * (`trust: "external"`), so we pass the workdir's parent, not the workdir
+ * itself. That register is idempotent by slug and the worker host returns the
+ * existing worker for an already-registered sibling, so re-scanning the shared
+ * apps dir does not churn unrelated apps. Returns the registered items so the
+ * verdict message can confirm the app is actually launchable instead of
+ * promising a `launch` that would fail with "No installed app matches".
+ */
+async function loadAppFromWorkdir(
+	workdir: string,
+): Promise<
+	{ ok: true; items: RegisteredAppItem[] } | { ok: false; error: string }
+> {
+	const port = resolveServerOnlyPort(process.env);
+	const directory = path.dirname(workdir);
+	try {
+		const resp = await fetch(
+			`http://127.0.0.1:${port}/api/apps/load-from-directory`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ directory }),
+				signal: AbortSignal.timeout(30_000),
+			},
+		);
+		const body = (await resp.json().catch(() => ({}))) as Record<
+			string,
+			unknown
+		>;
+		if (resp.ok && body.ok === true) {
+			const items = Array.isArray(body.items)
+				? body.items.filter(
+						(item): item is RegisteredAppItem =>
+							isRecord(item) &&
+							typeof item.slug === "string" &&
+							typeof item.canonicalName === "string",
+					)
+				: [];
+			return { ok: true, items };
+		}
+		return {
+			ok: false,
+			error:
+				typeof body.error === "string"
+					? body.error
+					: `register returned HTTP ${resp.status}`,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
 async function buildPassMessage(payload: BridgeEventPayload): Promise<string> {
 	const isApp = payload.method === VERIFY_APP_METHOD;
 	if (isApp) {
-		// Apps resolve through the launch/registry path.
-		return `${payload.targetName} app built and verified. Reply 'launch ${payload.targetName}' to open it.`;
+		// Register the freshly built app so `launch <name>` resolves. Without this
+		// the app is on disk but absent from the registry + installs, and launch
+		// fails with "No installed app matches" (#11954). Only promise the launch
+		// once a registered app actually resolves to the name we'd tell the user.
+		if (!payload.workdir) {
+			return `${payload.targetName} app built and verified, but its build directory is unknown, so it could not be installed. It won't launch until it's registered.`;
+		}
+		const load = await loadAppFromWorkdir(payload.workdir);
+		if (!load.ok) {
+			return `${payload.targetName} app built and verified at ${payload.workdir}, but installing it failed: ${load.error}. It won't launch until it's registered — reload the agent or check its package.json manifest.`;
+		}
+		const target = payload.targetName.toLowerCase();
+		const launchable = load.items.some(
+			(item) =>
+				item.slug.toLowerCase() === target ||
+				item.canonicalName.toLowerCase() === target,
+		);
+		if (launchable) {
+			return `${payload.targetName} app built, verified, and installed — reply 'launch ${payload.targetName}' to open it.`;
+		}
+		// The registry scan succeeded but nothing resolved to the requested name:
+		// the built manifest is missing its `elizaos.app` block or registered
+		// under a different name. Don't promise a launch that would fail.
+		return `${payload.targetName} app built and verified at ${payload.workdir}, but it did not register under a launchable name — reply 'list apps' to see what installed.`;
 	}
 
 	// Plugins: attempt to live-load the built source so its views/actions appear


### PR DESCRIPTION
## The broken handoff

After the coding agent builds an app and verification passes, the verification room bridge posts **"Reply 'launch \<name\>' to open it."** into the originating chat. But launching then fails with **"No installed app matches"**, because the freshly built app was never registered.

Root cause (`plugins/plugin-app-control/src/services/verification-room-bridge.ts`, `buildPassMessage`): the **APP** branch returned the "launch it" suggestion without registering anything. Only the **PLUGIN** branch live-loaded its workdir (`/api/plugins/load-from-directory`). So the app was in neither the registry nor `config.plugins.installs`, and launch resolution (`app-launch.ts` → `resolveInstalledApp` over `client.listInstalledApps()`) returned `none`.

## The fix

Added a `loadAppFromWorkdir` helper mirroring `loadPluginFromWorkdir` (same fetch shape, `resolveServerOnlyPort`, 30s timeout, structured error return). The APP pass branch now registers the built app **before** promising the launch.

### Endpoint + directory used, and why

- **Endpoint:** `POST /api/apps/load-from-directory` (`plugin-app-manager/src/api/apps-routes.ts`). This is the same registry path the issue prescribes — it registers each app subdir via the `app-registry` service's `register(..., trust: "external")`. (`POST /api/apps/install` was rejected: it installs by **package name** from a plugin registry via `pluginManager.installPlugin`, not a freshly built local directory.)
- **Directory:** `path.dirname(workdir)`. A scaffolded app lives at `<repoRoot>/eliza/apps/app-<name>` (`app-create.ts` `findFreeWorkdir`, `APPS_RELATIVE_PATH = "eliza/apps"`), and the route scans a **parent** dir for app subdirs — it does not register the passed dir itself. So the workdir's parent (the shared `eliza/apps` dir) is the correct argument.
- **Sibling safety:** `AppRegistryService.register` upserts by slug, and `AppWorkerHostService.spawn` returns the existing worker for an already-registered slug (see its own comment: *"If a worker already exists for the slug, returns its existing snapshot"*). So re-scanning the shared apps dir re-registers siblings idempotently and does not restart their workers.

### Honest messaging

The bridge only emits the "reply 'launch \<name\>'" promise once a returned registry item actually resolves to the requested name (scaffold sets `slug === canonicalName === name`, and launch resolves on `name`/`displayName`/`pluginName`). Otherwise it returns an honest message:
- registration HTTP/registry failure → *"…installing it failed: \<error\>. It won't launch until it's registered…"*
- scan succeeded but nothing matched the name → *"…did not register under a launchable name — reply 'list apps' to see what installed."*
- missing workdir → *"…its build directory is unknown, so it could not be installed…"*

## Test evidence

Added 3 tests to `verification-room-bridge.test.ts` (mock the loopback fetch):
- **registers the built app on pass so 'launch \<name\>' resolves (#11954)** — asserts the bridge POSTs the workdir's **parent** (`{"directory":"/repo/eliza/apps"}`) to `/api/apps/load-from-directory`, and the verdict message says *"notes app built, verified, and installed … launch notes"*.
- **does not promise a launch when app registration fails** — asserts the false "launch notes" promise is gone and the real error surfaces.
- **stays honest when the scan registers nothing matching the app name** — asserts the "did not register under a launchable name" message.

Also aligned one **pre-existing stale test** in the same file: the retry loop was changed to retry indefinitely (per its own source comments), but `"gives up quietly after ATTACH_MAX_RETRIES"` still asserted the old give-up behavior. Verified **red on `origin/develop`** before rewriting it to assert the current late-bind behavior.

```
vitest  (verification-room-bridge.test.ts) : 13 passed
vitest  (full plugin-app-control suite)    : 1298 passed
  (1 unrelated file fails to import @elizaos/ui/components/ui/button — unbuilt @elizaos/ui dist in this worktree, not this change)
tsgo --noEmit : exit 0 (clean)
biome check   : clean, no fixes applied
```

Closes #11954

🤖 Generated with [Claude Code](https://claude.com/claude-code)