### PR TITLE
fix(ui): refresh native Steward sessions with Bearer auth

### DIFF
--- a/packages/cloud/api/auth/steward-refresh/route.test.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type VerifiedStewardClaims = {
+  userId: string;
+  email: string;
+  tenantId: string;
+  expiration: number;
+  issuedAt: number;
+};
+
+const verifyStewardTokenCached = mock<
+  (_env: unknown, _token: string) => Promise<VerifiedStewardClaims | null>
+>(async () => ({
+  userId: "steward-user-1",
+  email: "user@example.com",
+  tenantId: "elizacloud",
+  expiration: Math.floor(Date.now() / 1000) + 60,
+  issuedAt: Math.floor(Date.now() / 1000) - 60,
+}));
+
+const mintStewardTokenFromClaims = mock<
+  (
+    _env: unknown,
+    _claims: VerifiedStewardClaims,
+    _ttlSeconds: number,
+  ) => Promise<{ token: string; expiresAt: number; expiresIn: number } | null>
+>(async () => ({
+  token: "fresh-steward-jwt",
+  expiresAt: 1_800_000_000,
+  expiresIn: 3600,
+}));
+
+mock.module("@/lib/auth/steward-client", () => ({
+  STEWARD_AUTH_UPSTREAM_TIMEOUT_MS: 25_000,
+  verifyStewardTokenCached,
+  mintStewardTokenFromClaims,
+}));
+
+mock.module("@/lib/steward/sign", () => ({
+  signStewardMutatingRequest: mock(async () => undefined),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const ENV = {
+  NODE_ENV: "production",
+  STEWARD_JWT_SECRET: "secret",
+  STEWARD_TENANT_ID: "elizacloud",
+};
+
+function post(headers: HeadersInit = {}) {
+  return app.fetch(
+    new Request("https://api.elizacloud.ai/", {
+      method: "POST",
+      headers,
+    }),
+    ENV,
+  );
+}
+
+describe("steward-refresh bearer rotation", () => {
+  beforeEach(() => {
+    verifyStewardTokenCached.mockClear();
+    mintStewardTokenFromClaims.mockClear();
+    verifyStewardTokenCached.mockResolvedValue({
+      userId: "steward-user-1",
+      email: "user@example.com",
+      tenantId: "elizacloud",
+      expiration: Math.floor(Date.now() / 1000) + 60,
+      issuedAt: Math.floor(Date.now() / 1000) - 60,
+    });
+    mintStewardTokenFromClaims.mockResolvedValue({
+      token: "fresh-steward-jwt",
+      expiresAt: 1_800_000_000,
+      expiresIn: 3600,
+    });
+  });
+
+  test("accepts native Bearer refresh without browser Origin or refresh cookie", async () => {
+    const response = await post({
+      Authorization: "Bearer near-expiry-steward-jwt",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      token: "fresh-steward-jwt",
+      expiresAt: 1_800_000_000,
+      expiresIn: 3600,
+    });
+    expect(verifyStewardTokenCached).toHaveBeenCalledWith(
+      expect.objectContaining({ STEWARD_JWT_SECRET: "secret" }),
+      "near-expiry-steward-jwt",
+    );
+    expect(mintStewardTokenFromClaims).toHaveBeenCalledWith(
+      expect.objectContaining({ STEWARD_JWT_SECRET: "secret" }),
+      expect.objectContaining({ userId: "steward-user-1" }),
+      3600,
+    );
+  });
+
+  test("rejects invalid Bearer refresh before falling back to cookie refresh", async () => {
+    verifyStewardTokenCached.mockResolvedValue(null);
+
+    const response = await post({
+      Authorization: "Bearer expired-steward-jwt",
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid token",
+      code: "invalid_token",
+    });
+    expect(mintStewardTokenFromClaims).not.toHaveBeenCalled();
+  });
+
+  test("keeps the browser cookie path origin-gated when no Bearer token is supplied", async () => {
+    const response = await post();
+
+    expect(response.status).toBe(403);
+    expect(verifyStewardTokenCached).not.toHaveBeenCalled();
+    expect(mintStewardTokenFromClaims).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -32,6 +32,7 @@ import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
+  mintStewardTokenFromClaims,
   STEWARD_AUTH_UPSTREAM_TIMEOUT_MS,
   type StewardVerifyEnv,
   verifyStewardTokenCached,
@@ -43,6 +44,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const STEWARD_REFRESH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60;
 const STEWARD_TOKEN_COOKIE = "steward-token";
 const STEWARD_REFRESH_TOKEN_COOKIE = "steward-refresh-token";
+const BEARER_REFRESH_TTL_SECONDS = 60 * 60;
 
 // ─── CSRF origin allowlist (must stay in lockstep with steward-session) ───
 const PERMITTED_ORIGIN_HOSTS = new Set<string>([
@@ -119,6 +121,15 @@ function shouldReturnClientToken(
   // CSRF check already accepts, otherwise valid HttpOnly-cookie sessions can
   // bounce back to /login on previews/custom same-origin hosts.
   return isPermittedOrigin(origin, host, isProduction);
+}
+
+function readBearerToken(c: {
+  req: { header: (name: string) => string | undefined };
+}): string | null {
+  const auth = c.req.header("authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  const token = auth.slice("Bearer ".length).trim();
+  return token || null;
 }
 
 function stewardSecretConfigured(env: StewardVerifyEnv): boolean {
@@ -260,6 +271,50 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   const isProduction = c.env.NODE_ENV === "production";
+  const bearerToken = readBearerToken(c);
+  if (bearerToken) {
+    if (!stewardSecretConfigured(c.env)) {
+      logRefresh("bearer-server-secret-missing");
+      return c.json(
+        errorBody(
+          "Steward verification not configured on server",
+          "server_secret_missing",
+        ),
+        503,
+      );
+    }
+
+    const claims = await verifyStewardTokenCached(c.env, bearerToken);
+    if (!claims) {
+      logRefresh("bearer-invalid-token");
+      return c.json(errorBody("Invalid token", "invalid_token"), 401);
+    }
+
+    const refreshed = await mintStewardTokenFromClaims(
+      c.env,
+      claims,
+      BEARER_REFRESH_TTL_SECONDS,
+    );
+    if (!refreshed) {
+      logRefresh("bearer-mint-failed");
+      return c.json(
+        errorBody(
+          "Steward verification not configured on server",
+          "server_secret_missing",
+        ),
+        503,
+      );
+    }
+
+    logRefresh("ok-bearer");
+    return c.json({
+      ok: true,
+      token: refreshed.token,
+      expiresAt: refreshed.expiresAt,
+      expiresIn: refreshed.expiresIn,
+    });
+  }
+
   const originCheck = checkOrigin(c, isProduction);
   if (!originCheck.ok) {
     logRefresh("forbidden-origin");

--- a/packages/cloud/shared/src/lib/auth/steward-client.ts
+++ b/packages/cloud/shared/src/lib/auth/steward-client.ts
@@ -17,7 +17,7 @@
  */
 
 import { createHash } from "crypto";
-import { type JWTPayload, jwtVerify } from "jose";
+import { type JWTPayload, jwtVerify, SignJWT } from "jose";
 import { cache } from "../cache/client";
 import { InMemoryLRUCache } from "../cache/in-memory-lru-cache";
 import { CacheKeys, CacheTTL } from "../cache/keys";
@@ -89,6 +89,8 @@ export interface StewardVerifyEnv {
   STEWARD_TENANT_ID?: string;
 }
 
+export const STEWARD_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+
 // Cache the encoded secret keyed by raw value, so repeated requests with the
 // same secret skip the TextEncoder allocation. Bounded at one entry — secrets
 // don't rotate on every request, and a stale entry just costs one re-encode.
@@ -114,6 +116,42 @@ function resolveJwtSecret(env: StewardVerifyEnv): Uint8Array | null {
   const key = new TextEncoder().encode(raw);
   _jwtSecretCache = { raw, key };
   return key;
+}
+
+export async function mintStewardTokenFromClaims(
+  env: StewardVerifyEnv,
+  claims: StewardTokenClaims,
+  ttlSeconds = STEWARD_ACCESS_TOKEN_TTL_SECONDS,
+): Promise<{ token: string; expiresAt: number; expiresIn: number } | null> {
+  const secret = resolveJwtSecret(env);
+  if (!secret) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = Math.max(1, Math.floor(ttlSeconds));
+  const expiresAt = now + expiresIn;
+  const payload: Record<string, unknown> = {
+    userId: claims.userId,
+  };
+  if (claims.email) payload.email = claims.email;
+  const walletAddress = claims.walletAddress ?? claims.address;
+  if (walletAddress) {
+    payload.address = walletAddress;
+    payload.walletAddress = walletAddress;
+  }
+  if (claims.walletChain) payload.walletChain = claims.walletChain;
+  if (claims.tenantId) {
+    payload.tenantId = claims.tenantId;
+    payload.tenant_id = claims.tenantId;
+  }
+
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setSubject(claims.userId)
+    .setIssuedAt(now)
+    .setExpirationTime(expiresAt)
+    .sign(secret);
+
+  return { token, expiresAt, expiresIn };
 }
 
 /**

--- a/packages/ui/src/api/client-cloud-steward-refresh-native.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-refresh-native.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const capacitorMocks = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+  },
+  CapacitorHttp: {
+    request: capacitorMocks.request,
+  },
+}));
+
+vi.mock("../bridge/electrobun-runtime", () => ({
+  isElectrobunRuntime: () => false,
+}));
+
+import { refreshCloudStewardSession } from "./client-cloud";
+
+describe("refreshCloudStewardSession native bearer refresh", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    capacitorMocks.request.mockReset();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("posts native refresh through CapacitorHttp with the stored Steward JWT as Bearer", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stored-steward-jwt");
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+    capacitorMocks.request.mockResolvedValue({
+      status: 200,
+      data: { ok: true, token: "fresh-steward-jwt", expiresIn: 3600 },
+    });
+
+    const result = await refreshCloudStewardSession({
+      endpoint: "https://api.elizacloud.ai/api/auth/steward-refresh",
+    });
+
+    expect(capacitorMocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.elizacloud.ai/api/auth/steward-refresh",
+        method: "POST",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          Authorization: "Bearer stored-steward-jwt",
+        }),
+      }),
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: true,
+      token: "fresh-steward-jwt",
+      expiresIn: 3600,
+    });
+  });
+
+  it("does not require fetch for native bearer refresh", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stored-steward-jwt");
+    globalThis.fetch = undefined as unknown as typeof fetch;
+    capacitorMocks.request.mockResolvedValue({
+      status: 200,
+      data: { token: "fresh-steward-jwt", expiresIn: 3600 },
+    });
+
+    await expect(
+      refreshCloudStewardSession({
+        endpoint: "https://api.elizacloud.ai/api/auth/steward-refresh",
+      }),
+    ).resolves.toEqual({
+      token: "fresh-steward-jwt",
+      expiresIn: 3600,
+    });
+
+    expect(capacitorMocks.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attempt a native refresh without a bearer token", async () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await expect(
+      refreshCloudStewardSession({
+        endpoint: "https://api.elizacloud.ai/api/auth/steward-refresh",
+      }),
+    ).resolves.toBeNull();
+
+    expect(capacitorMocks.request).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -8,6 +8,7 @@ import {
   readStoredStewardToken,
   STEWARD_REFRESH_ENDPOINT,
 } from "@elizaos/shared/steward-session-client";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import {
   type AgentReadinessProbe,
   type AuthedAgentFetch,
@@ -238,6 +239,11 @@ function shouldUseNativeCloudHttp(): boolean {
   return Capacitor.isNativePlatform();
 }
 
+function shouldUseNativeStewardRefreshHttp(endpoint: string): boolean {
+  if (!/^https?:\/\//i.test(endpoint)) return false;
+  return Capacitor.isNativePlatform() || isElectrobunRuntime();
+}
+
 function resolveBrowserCloudApiRequestUrl(url: string): string {
   if (shouldUseNativeCloudHttp() || typeof window === "undefined") return url;
   try {
@@ -366,8 +372,33 @@ export function cloudTokenSecsRemaining(token: string): number | null {
 export async function refreshCloudStewardSession(opts?: {
   endpoint?: string;
 }): Promise<{ token?: string; expiresAt?: number; expiresIn?: number } | null> {
-  if (typeof fetch === "undefined") return null;
   const endpoint = opts?.endpoint ?? STEWARD_REFRESH_ENDPOINT;
+  if (shouldUseNativeStewardRefreshHttp(endpoint)) {
+    const token = readStoredStewardToken()?.trim();
+    if (!token) return null;
+    const response = await withDirectCloudHttpTimeout(
+      CapacitorHttp.request({
+        url: endpoint,
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        responseType: "json",
+        connectTimeout: 10_000,
+        readTimeout: 10_000,
+      }),
+      { method: "POST", url: endpoint },
+    );
+    if (response.status < 200 || response.status >= 300) return null;
+    return parseDirectCloudJsonSafe(response.data) as {
+      token?: string;
+      expiresAt?: number;
+      expiresIn?: number;
+    } | null;
+  }
+
+  if (typeof fetch === "undefined") return null;
   const response = await fetch(endpoint, {
     method: "POST",
     credentials: "include",

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -375,12 +375,12 @@ async function requestDesktopAgentStartForStartup(): Promise<void> {
  * the same-origin cookie path (the HttpOnly `steward-refresh-token` cookie
  * travels automatically), so we return `undefined` to let
  * {@link refreshCloudStewardSession} fall back to its same-origin default.
- * Native (`capacitor://localhost`) has no same-origin cookie, so refresh against
- * the configured Cloud API base (Bearer-refresh). Mirrors
+ * Native/Electrobun has no same-origin cookie, so refresh against the configured
+ * Cloud API base (Bearer-refresh). Mirrors
  * `resolveStewardRefreshEndpoint` in `state/useCloudState.ts`.
  */
 function resolveRestoreStewardRefreshEndpoint(): string | undefined {
-  if (!isNative) return undefined;
+  if (!isNative && !isElectrobunRuntime()) return undefined;
   const cloudBase =
     getBootConfig().cloudApiBase?.trim() ||
     RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL;

--- a/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+
+const clientCloudMocks = vi.hoisted(() => ({
+  refreshCloudStewardSession: vi.fn(),
+}));
+
+vi.mock("../api/client-cloud", () => ({
+  cloudTokenSecsRemaining: () => 0,
+  refreshCloudStewardSession: clientCloudMocks.refreshCloudStewardSession,
+}));
+
+vi.mock("../bridge", () => ({
+  invokeDesktopBridgeRequestWithTimeout: vi.fn(),
+  isElectrobunRuntime: () => true,
+}));
+
+import { useCloudState } from "./useCloudState";
+
+function makeParams() {
+  return {
+    setActionNotice: vi.fn(),
+    loadWalletConfig: vi.fn(async () => {}),
+    t: (key: string) => key,
+  };
+}
+
+describe("useCloudState — Electrobun Steward refresh endpoint", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://www.elizacloud.ai",
+    });
+    clientCloudMocks.refreshCloudStewardSession.mockReset();
+    clientCloudMocks.refreshCloudStewardSession.mockResolvedValue({
+      token: "fresh",
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the Cloud API refresh endpoint on Electrobun instead of the local origin", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "near-expiry-steward-jwt");
+
+    renderHook(() => useCloudState(makeParams()));
+
+    await waitFor(() =>
+      expect(clientCloudMocks.refreshCloudStewardSession).toHaveBeenCalledWith({
+        endpoint: "https://api.elizacloud.ai/api/auth/steward-refresh",
+      }),
+    );
+  });
+});

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -182,12 +182,12 @@ function canPollCloudStatus(): boolean {
 /**
  * Resolve the Steward refresh endpoint for the current target. On hosted web
  * the same-origin cookie path works (the HttpOnly `steward-refresh-token`
- * cookie travels automatically). On native (`capacitor://localhost`) there is
- * no same-origin cookie, so refresh against the configured cloud API base
- * (Bearer-refresh). Returns `undefined` to use the shared default.
+ * cookie travels automatically). On native/Electrobun there is no same-origin
+ * cookie, so refresh against the configured cloud API base (Bearer-refresh).
+ * Returns `undefined` to use the shared default.
  */
 function resolveStewardRefreshEndpoint(): string | undefined {
-  if (!isCapacitorNativeRuntime()) return undefined;
+  if (!isCapacitorNativeRuntime() && !isElectrobunRuntime()) return undefined;
   const cloudBase =
     getBootConfig().cloudApiBase?.trim() || DEFAULT_DIRECT_CLOUD_BASE_URL;
   try {


### PR DESCRIPTION
## Summary
- add a Bearer-based Steward refresh path that verifies the native JWT and mints a fresh short-lived Steward JWT
- have native/Electrobun refresh call the Cloud API endpoint with Authorization via CapacitorHttp instead of cookie-only fetch
- route Electrobun refresh to the Cloud API base and cover the native/desktop paths with focused tests

Fixes #11941

## Testing
- bunx biome check packages/cloud/shared/src/lib/auth/steward-client.ts packages/cloud/api/auth/steward-refresh/route.ts packages/cloud/api/auth/steward-refresh/route.test.ts packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-steward-refresh-native.test.ts packages/ui/src/state/useCloudState.ts packages/ui/src/state/startup-phase-restore.ts packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
- bun run --cwd packages/ui test src/api/client-cloud-steward-refresh-native.test.ts src/state/useCloudState.steward-refresh-electrobun.test.tsx src/state/useCloudState.steward-refresh.test.tsx src/state/startup-phase-restore.steward-refresh.test.ts
- bun test packages/cloud/api/auth/steward-refresh/route.test.ts
- bun run --cwd packages/cloud/api typecheck
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/cloud/shared typecheck