### PR TITLE
fix(cloud/auth): Bearer-based Steward JWT refresh for native/desktop (#11941)

### DIFF
--- a/packages/cloud/api/auth/steward-refresh/route.test.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// #11941 — native/desktop Steward JWT refresh. The route must accept a Steward
+// token in `Authorization: Bearer` as a cookieless rotation path for
+// Capacitor/Electrobun callers, WITHOUT weakening the browser cookie path's
+// cross-origin CSRF guard. These tests drive the real Hono handler with the
+// Steward upstream + token verification mocked (no live Steward reachable here).
+
+const nowSecs = Math.floor(Date.now() / 1000);
+
+const verifyStewardTokenCached = mock(async () => ({
+  userId: "user-1",
+  expiration: nowSecs + 3600,
+  issuedAt: nowSecs,
+}));
+
+mock.module("@/lib/auth/steward-client", () => ({
+  STEWARD_AUTH_UPSTREAM_TIMEOUT_MS: 25_000,
+  verifyStewardTokenCached,
+}));
+
+mock.module("@/lib/steward/sign", () => ({
+  signStewardMutatingRequest: mock(async () => {}),
+}));
+
+mock.module("@/lib/auth/cookie-domain", () => ({
+  cookieDomainForHost: () => undefined,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info() {}, warn() {}, error() {} },
+}));
+
+const { default: app } = await import("./route");
+
+const ENV = {
+  NODE_ENV: "production",
+  STEWARD_SESSION_SECRET: "test-secret",
+  STEWARD_API_URL: "https://steward.example.test",
+  STEWARD_TENANT_ID: "elizacloud",
+};
+
+/** Capture the last body the route forwarded to Steward `/auth/refresh`. */
+let lastStewardRefreshBody: { refreshToken?: string } | null = null;
+const realFetch = globalThis.fetch;
+
+function stewardOk(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      token: "rotated-access-jwt",
+      refreshToken: "rotated-refresh-token",
+      expiresIn: 3600,
+      expiresAt: nowSecs + 3600,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function stewardRejected(): Response {
+  return new Response(
+    JSON.stringify({ ok: false, error: "refresh token revoked" }),
+    { status: 401, headers: { "content-type": "application/json" } },
+  );
+}
+
+function mockStewardFetch(response: () => Response): void {
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    lastStewardRefreshBody =
+      typeof init?.body === "string" ? JSON.parse(init.body) : null;
+    return response();
+  }) as unknown as typeof fetch;
+}
+
+async function post(headers: Record<string, string>): Promise<Response> {
+  return app.fetch(
+    new Request("https://api.elizacloud.ai/", { method: "POST", headers }),
+    ENV,
+  );
+}
+
+describe("steward-refresh route — Bearer (native/desktop) rotation (#11941)", () => {
+  beforeEach(() => {
+    verifyStewardTokenCached.mockClear();
+    lastStewardRefreshBody = null;
+    globalThis.fetch = realFetch;
+  });
+
+  test("Bearer path: rotates with the Bearer token and ALWAYS returns the new JWT — no Origin header required", async () => {
+    mockStewardFetch(stewardOk);
+
+    // No Origin/Referer + no cookie: the cookie path would 403 on CSRF, but the
+    // Bearer path is CSRF-safe and must succeed.
+    const res = await post({ authorization: "Bearer native-refresh-token" });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; token?: string };
+    expect(body.ok).toBe(true);
+    // Native cannot read the HttpOnly cookie, so the token is always returned.
+    expect(body.token).toBe("rotated-access-jwt");
+    // The Bearer value (not a cookie) was forwarded to Steward as the refresh
+    // credential.
+    expect(lastStewardRefreshBody?.refreshToken).toBe("native-refresh-token");
+  });
+
+  test("Bearer path: an invalid/expired Bearer is rejected 401 invalid_token", async () => {
+    mockStewardFetch(stewardRejected);
+
+    const res = await post({ authorization: "Bearer dead-token" });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("invalid_token");
+  });
+
+  test("Bearer path: malformed Authorization header falls through to the cookie path (403 without a cookie/origin)", async () => {
+    mockStewardFetch(stewardOk);
+
+    // "Bearer" with no token is not a valid Bearer → treated as cookie path,
+    // which rejects a missing origin.
+    const res = await post({ authorization: "Bearer " });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("forbidden_origin");
+  });
+
+  test("cookie path UNCHANGED: a forbidden cross-origin POST is still rejected 403 (CSRF intact)", async () => {
+    mockStewardFetch(stewardOk);
+
+    const res = await post({
+      origin: "https://evil.example.com",
+      cookie: "steward-refresh-token=cookie-refresh",
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("forbidden_origin");
+    // The forbidden request never reached Steward.
+    expect(lastStewardRefreshBody).toBeNull();
+  });
+
+  test("cookie path UNCHANGED: an allowed first-party origin rotates via the cookie value", async () => {
+    mockStewardFetch(stewardOk);
+
+    const res = await post({
+      origin: "https://elizacloud.ai",
+      cookie: "steward-refresh-token=cookie-refresh",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; token?: string };
+    expect(body.ok).toBe(true);
+    // elizacloud.ai is a trusted origin → token mirrored back (unchanged).
+    expect(body.token).toBe("rotated-access-jwt");
+    // The COOKIE value (not a Bearer) was forwarded to Steward.
+    expect(lastStewardRefreshBody?.refreshToken).toBe("cookie-refresh");
+  });
+
+  test("no credential (no Bearer, no cookie) on an allowed origin → 401 missing_token", async () => {
+    mockStewardFetch(stewardOk);
+
+    const res = await post({ origin: "https://elizacloud.ai" });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("missing_token");
+  });
+});

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -19,6 +19,15 @@
  *
  * Origin/Referer CSRF check mirrors `/api/auth/steward-session`.
  *
+ * Native (Capacitor) and desktop (Electrobun) callers have no same-origin
+ * `steward-refresh-token` cookie, so they authenticate the rotation with their
+ * stored Steward token in an `Authorization: Bearer` header instead. That path
+ * forwards the Bearer token to Steward `/auth/refresh` exactly as the cookie
+ * value is forwarded, and always returns the rotated access token (native has no
+ * readable cookie to hydrate from). Bearer auth is not carried by ambient
+ * browser cookies, so it is CSRF-safe by construction; the origin CSRF check
+ * guards the cookie path only.
+ *
  * This route is the only way to refresh once the localStorage copy of the
  * refresh token is removed. Old browser tabs that still POST a refreshToken
  * to `/api/auth/steward-session` continue to work during the rollout window.
@@ -119,6 +128,22 @@ function shouldReturnClientToken(
   // CSRF check already accepts, otherwise valid HttpOnly-cookie sessions can
   // bounce back to /login on previews/custom same-origin hosts.
   return isPermittedOrigin(origin, host, isProduction);
+}
+
+/**
+ * Extract a Steward token from an `Authorization: Bearer <token>` header, or
+ * `null` when the header is absent/malformed. Native (Capacitor) and desktop
+ * (Electrobun) callers have no same-origin `steward-refresh-token` cookie, so
+ * they present their stored Steward token here to authenticate the rotation.
+ */
+function readBearerRefreshToken(c: {
+  req: { header: (name: string) => string | undefined };
+}): string | null {
+  const header = c.req.header("authorization");
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  return token && token.length > 0 ? token : null;
 }
 
 function stewardSecretConfigured(env: StewardVerifyEnv): boolean {
@@ -260,16 +285,31 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   const isProduction = c.env.NODE_ENV === "production";
-  const originCheck = checkOrigin(c, isProduction);
-  if (!originCheck.ok) {
-    logRefresh("forbidden-origin");
-    logger.warn("[steward-refresh] rejected cross-origin POST", {
-      detail: originCheck.reason,
-    });
-    return c.json(errorBody("Forbidden", "forbidden_origin"), 403);
+
+  // Native (Capacitor) / desktop (Electrobun) callers present the stored Steward
+  // token in `Authorization: Bearer` because they have no same-origin
+  // `steward-refresh-token` cookie. Bearer auth is not carried by ambient
+  // browser cookies, so — unlike a cookie — it cannot be forged by a cross-origin
+  // page; it is CSRF-safe by construction, and the token is validated
+  // equivalently to the cookie value (both are forwarded to Steward
+  // `/auth/refresh`, which rejects any invalid/expired/revoked token). The
+  // cross-origin CSRF allowlist is therefore the COOKIE path's guard only and is
+  // deliberately skipped for the Bearer path; it is never weakened for browsers.
+  const bearerToken = readBearerRefreshToken(c);
+
+  if (!bearerToken) {
+    const originCheck = checkOrigin(c, isProduction);
+    if (!originCheck.ok) {
+      logRefresh("forbidden-origin");
+      logger.warn("[steward-refresh] rejected cross-origin POST", {
+        detail: originCheck.reason,
+      });
+      return c.json(errorBody("Forbidden", "forbidden_origin"), 403);
+    }
   }
 
-  const refreshToken = getCookie(c, STEWARD_REFRESH_TOKEN_COOKIE);
+  const refreshToken =
+    bearerToken ?? getCookie(c, STEWARD_REFRESH_TOKEN_COOKIE);
   if (!refreshToken) {
     logRefresh("missing-refresh-cookie");
     return c.json(errorBody("Refresh token required", "missing_token"), 401);
@@ -318,15 +358,19 @@ app.post("/", async (c) => {
 
   if (refresh.kind === "error") {
     logRefresh(`upstream-${refresh.status}`);
-    // Steward returns 401 when the refresh token itself is invalid/revoked —
-    // the browser's HttpOnly cookie is stale, so clear it so the next page
-    // load goes straight to a login surface.
+    // Steward returns 401 when the refresh token itself is invalid/revoked. On
+    // the cookie path the browser's HttpOnly cookie is stale, so clear it so the
+    // next page load goes straight to a login surface. The Bearer path has no
+    // server-managed cookie to clear — native holds the token in localStorage and
+    // drops it itself when refresh returns null.
     if (refresh.status === 401) {
-      const domain = cookieDomainForHost(c.req.header("host"));
-      const opts = domain ? { path: "/", domain } : { path: "/" };
-      deleteCookie(c, STEWARD_TOKEN_COOKIE, opts);
-      deleteCookie(c, STEWARD_REFRESH_TOKEN_COOKIE, opts);
-      deleteCookie(c, STEWARD_AUTHED_COOKIE, opts);
+      if (!bearerToken) {
+        const domain = cookieDomainForHost(c.req.header("host"));
+        const opts = domain ? { path: "/", domain } : { path: "/" };
+        deleteCookie(c, STEWARD_TOKEN_COOKIE, opts);
+        deleteCookie(c, STEWARD_REFRESH_TOKEN_COOKIE, opts);
+        deleteCookie(c, STEWARD_AUTHED_COOKIE, opts);
+      }
       return c.json(errorBody("Refresh token rejected", "invalid_token"), 401);
     }
     return c.json(
@@ -383,7 +427,12 @@ app.post("/", async (c) => {
     ok: true,
     expiresAt: refresh.data.expiresAt,
     expiresIn: refresh.data.expiresIn,
-    ...(shouldReturnClientToken(c, isProduction) ? { token } : {}),
+    // Bearer (native/desktop) callers cannot read the HttpOnly cookie, so they
+    // always need the rotated JWT returned; the cookie path returns it only to
+    // trusted first-party origins (unchanged).
+    ...(bearerToken || shouldReturnClientToken(c, isProduction)
+      ? { token }
+      : {}),
   });
 });
 

--- a/packages/ui/src/api/client-cloud-steward-refresh.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-refresh.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+//
+// #11941 — native/desktop Steward JWT refresh. On web the session refresh rides
+// the same-origin HttpOnly `steward-refresh-token` cookie (`credentials:
+// "include"`, no Authorization header). Native (Capacitor) / desktop have no
+// such cookie, so the refresh must instead authenticate with the stored Steward
+// JWT via `Authorization: Bearer`. These tests lock both paths: the web cookie
+// POST stays byte-identical, and native sends the Bearer header over the native
+// HTTP bridge and persists/returns the rotated token (invalid tokens → null).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { capacitorState, capacitorHttpRequestMock } = vi.hoisted(() => ({
+  capacitorState: { isNative: false },
+  capacitorHttpRequestMock: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => capacitorState.isNative,
+  },
+  CapacitorHttp: {
+    request: capacitorHttpRequestMock,
+  },
+}));
+
+import { refreshCloudStewardSession } from "./client-cloud";
+
+const STEWARD_TOKEN_KEY = "steward_session_token";
+const NATIVE_ENDPOINT = "https://api.elizacloud.ai/api/auth/steward-refresh";
+const SAME_ORIGIN_ENDPOINT = "/api/auth/steward-refresh";
+
+describe("refreshCloudStewardSession — native/desktop Bearer refresh (#11941)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    capacitorState.isNative = false;
+    capacitorHttpRequestMock.mockReset();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("native: POSTs the stored Steward JWT as Authorization: Bearer over the native HTTP bridge and returns the rotated token", async () => {
+    capacitorState.isNative = true;
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stored-jwt");
+    capacitorHttpRequestMock.mockResolvedValue({
+      status: 200,
+      headers: {},
+      data: { token: "rotated-jwt", expiresIn: 3600 },
+    });
+
+    const result = await refreshCloudStewardSession({
+      endpoint: NATIVE_ENDPOINT,
+    });
+
+    // No same-origin cookie fetch on native.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(capacitorHttpRequestMock).toHaveBeenCalledTimes(1);
+    const req = capacitorHttpRequestMock.mock.calls[0][0];
+    expect(req).toMatchObject({ url: NATIVE_ENDPOINT, method: "POST" });
+    expect(req.headers.Authorization).toBe("Bearer stored-jwt");
+    expect(result).toEqual({ token: "rotated-jwt", expiresIn: 3600 });
+  });
+
+  it("native: parses a stringified JSON body from the native bridge", async () => {
+    capacitorState.isNative = true;
+    localStorage.setItem(STEWARD_TOKEN_KEY, "stored-jwt");
+    capacitorHttpRequestMock.mockResolvedValue({
+      status: 200,
+      headers: {},
+      data: JSON.stringify({ token: "rotated-jwt" }),
+    });
+
+    const result = await refreshCloudStewardSession({
+      endpoint: NATIVE_ENDPOINT,
+    });
+
+    expect(result).toEqual({ token: "rotated-jwt" });
+  });
+
+  it("native: returns null (no request) when no Steward token is stored", async () => {
+    capacitorState.isNative = true;
+
+    const result = await refreshCloudStewardSession({
+      endpoint: NATIVE_ENDPOINT,
+    });
+
+    expect(result).toBeNull();
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("native: returns null when the server rejects the Bearer token (401 invalid/expired)", async () => {
+    capacitorState.isNative = true;
+    localStorage.setItem(STEWARD_TOKEN_KEY, "expired-jwt");
+    capacitorHttpRequestMock.mockResolvedValue({
+      status: 401,
+      headers: {},
+      data: { error: "Refresh token rejected", code: "invalid_token" },
+    });
+
+    const result = await refreshCloudStewardSession({
+      endpoint: NATIVE_ENDPOINT,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("web: keeps the same-origin cookie POST byte-identical (credentials include, NO Authorization header)", async () => {
+    // A stored token exists on web too, but the web path must NOT send it as a
+    // Bearer header — it rides the HttpOnly cookie instead.
+    localStorage.setItem(STEWARD_TOKEN_KEY, "web-jwt");
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: "rotated-web-jwt" }),
+    });
+
+    const result = await refreshCloudStewardSession();
+
+    expect(capacitorHttpRequestMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(SAME_ORIGIN_ENDPOINT);
+    expect(init).toEqual({ method: "POST", credentials: "include" });
+    expect(init.headers).toBeUndefined();
+    expect(result).toEqual({ token: "rotated-web-jwt" });
+  });
+
+  it("web: returns null on a non-2xx cookie refresh", async () => {
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+
+    const result = await refreshCloudStewardSession();
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -8,6 +8,7 @@ import {
   readStoredStewardToken,
   STEWARD_REFRESH_ENDPOINT,
 } from "@elizaos/shared/steward-session-client";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import {
   type AgentReadinessProbe,
   type AuthedAgentFetch,
@@ -238,6 +239,17 @@ function shouldUseNativeCloudHttp(): boolean {
   return Capacitor.isNativePlatform();
 }
 
+/**
+ * Cookieless Steward targets. Capacitor native (`capacitor://localhost`) and
+ * Electrobun desktop both lack the same-origin `steward-refresh-token` cookie
+ * that the web refresh relies on, so their session refresh must authenticate
+ * with the stored Steward JWT as a Bearer token instead. Plain web keeps the
+ * cookie path.
+ */
+function shouldRefreshStewardWithBearer(): boolean {
+  return shouldUseNativeCloudHttp() || isElectrobunRuntime();
+}
+
 function resolveBrowserCloudApiRequestUrl(url: string): string {
   if (shouldUseNativeCloudHttp() || typeof window === "undefined") return url;
   try {
@@ -352,22 +364,63 @@ export function cloudTokenSecsRemaining(token: string): number | null {
 }
 
 /**
- * Cookie-backed Steward session refresh, mirroring cloud-frontend's
- * `AuthTokenSync` semantics. Sends an empty POST to the Steward refresh
- * endpoint with `credentials: "include"` so the HttpOnly
- * `steward-refresh-token` cookie travels automatically (web same-origin). The
- * server rotates the session and, for trusted Cloud origins / native callers,
- * returns the short-lived access token so the SPA can refresh its localStorage
- * Bearer mirror. Returns the fresh token when one was issued, else `null`.
+ * Steward session refresh. Rotates the short-lived Steward access token ahead of
+ * its JWT `exp` and returns the fresh token (persisted by the caller), else
+ * `null`.
  *
- * On native the same endpoint is reached via the configured cloud API base
- * (Bearer-refresh); the caller passes the absolute endpoint via `endpoint`.
+ * Web (same-origin) uses the cookie path: an empty POST with
+ * `credentials: "include"` carries the HttpOnly `steward-refresh-token` cookie
+ * automatically, and the server returns the rotated access token for trusted
+ * origins so the SPA can refresh its localStorage mirror.
+ *
+ * Native (Capacitor) and desktop (Electrobun) have no same-origin cookie, so a
+ * cookie-only POST can never rotate the session — the JWT would silently die at
+ * expiry. Those targets authenticate the rotation with the stored Steward JWT
+ * via `Authorization: Bearer <token>` instead: Capacitor over the native HTTP
+ * bridge (a cross-origin browser fetch from `capacitor://localhost` to the cloud
+ * API is not reachable), Electrobun over standard fetch. The caller passes the
+ * absolute cloud endpoint via `endpoint`.
  */
 export async function refreshCloudStewardSession(opts?: {
   endpoint?: string;
 }): Promise<{ token?: string; expiresAt?: number; expiresIn?: number } | null> {
   if (typeof fetch === "undefined") return null;
   const endpoint = opts?.endpoint ?? STEWARD_REFRESH_ENDPOINT;
+
+  if (shouldRefreshStewardWithBearer()) {
+    const token = readStoredStewardToken()?.trim();
+    if (!token) return null;
+    const headers = {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    };
+    if (shouldUseNativeCloudHttp()) {
+      const res = await CapacitorHttp.request({
+        url: endpoint,
+        method: "POST",
+        headers,
+        responseType: "json",
+        connectTimeout: 10_000,
+        readTimeout: 10_000,
+      });
+      if (res.status < 200 || res.status >= 300) return null;
+      return (
+        (parseDirectCloudJsonSafe(res.data) as {
+          token?: string;
+          expiresAt?: number;
+          expiresIn?: number;
+        } | null) ?? null
+      );
+    }
+    const response = await fetch(endpoint, { method: "POST", headers });
+    if (!response.ok) return null;
+    return (await response.json().catch(() => null)) as {
+      token?: string;
+      expiresAt?: number;
+      expiresIn?: number;
+    } | null;
+  }
+
   const response = await fetch(endpoint, {
     method: "POST",
     credentials: "include",


### PR DESCRIPTION
## Problem — native/desktop Steward JWT cannot be refreshed (#11941)

The Cloud connection unifies on a Steward session JWT (localStorage
`steward_session_token`). It expires in minutes and must be rotated ahead of
`exp`. On web the rotation rides the same-origin HttpOnly `steward-refresh-token`
cookie. On native (Capacitor) / desktop (Electrobun) there is no such cookie, so
the JWT silently died at expiry with no renewal.

Three gaps (from the issue):

1. **Client** — `refreshCloudStewardSession` (`packages/ui/src/api/client-cloud.ts`)
   sent a cookie-only POST (`credentials:"include"`) with **no Authorization
   header**, despite its comment claiming native "Bearer-refresh". Native has no
   Steward cookie → refresh always returned `null` → the JWT died with no renewal.
2. **Server** — `packages/cloud/api/auth/steward-refresh/route.ts` only accepted
   the HttpOnly cookie behind a CSRF origin allowlist that **rejects native
   origins in production** — no Bearer-based rotation path for native callers.
3. **Launcher** — `registerStewardLoginLauncher` has zero call sites. **Out of
   scope here** (that's #11930 territory); noted only.

## What changed

### Client — `refreshCloudStewardSession` (packages/ui/src/api/client-cloud.ts)
- On cookieless targets (`shouldUseNativeCloudHttp()` Capacitor **or**
  `isElectrobunRuntime()` desktop), read the stored Steward JWT and send it as
  `Authorization: Bearer <token>` on the refresh POST — Capacitor over the native
  HTTP bridge (`CapacitorHttp`, since a cross-origin browser fetch from
  `capacitor://localhost` to the cloud API is not reachable), Electrobun over
  standard `fetch`. No stored token → returns `null` (nothing to refresh with).
- The rotated JWT is returned in the existing `{ token, expiresAt, expiresIn }`
  shape; the callers already persist it via `writeStoredStewardToken(...)` — the
  same mechanism initial login uses.
- **Web is byte-identical**: when neither native nor Electrobun, the exact
  `fetch(endpoint, { method: "POST", credentials: "include" })` cookie POST runs,
  with **no** Authorization header.

### Server — `/api/auth/steward-refresh` (packages/cloud/api/auth/steward-refresh/route.ts)
- Accept a Steward token in `Authorization: Bearer` as a cookieless rotation
  path. The Bearer value is forwarded to Steward `/auth/refresh` **exactly as the
  cookie value is** (same `callStewardRefresh`, same access-token verification,
  same cookie-setting, same response shape) — mirrored validation keyed on the
  Bearer token.
- The Bearer path **always returns the rotated JWT** (native can't read the
  HttpOnly cookie), whereas the cookie path still returns it only to trusted
  first-party origins.
- On a Steward 401 the Bearer path returns `invalid_token` without clearing
  cookies (native has none); the cookie path's stale-cookie cleanup is unchanged.

## How web CSRF is NOT weakened

- The cross-origin CSRF allowlist (`checkOrigin`) now runs **only when there is
  no Bearer token** — i.e. for the cookie path, exactly as before. A browser on
  the web app never sends an Authorization header on this call (the client keeps
  the cookie-only path), so web always takes the unchanged cookie branch with the
  full origin check.
- The Bearer branch is CSRF-safe **by construction**: Bearer auth is not carried
  by ambient browser cookies, so a cross-origin page cannot forge it the way it
  can ride a cookie; and the token is validated equivalently upstream (Steward
  rejects any invalid/expired/revoked token). It also never reads the victim's
  cookie, so classic cookie-riding CSRF is impossible.
- Tests assert a forbidden cross-origin **cookie** POST is still `403` and never
  reaches Steward.

## Test evidence

**Client** — `packages/ui/src/api/client-cloud-steward-refresh.test.ts` (new, 6 tests, all green):
- native: POSTs the stored JWT as `Authorization: Bearer` over the native bridge and returns the rotated token
- native: parses a stringified JSON body from the bridge
- native: returns `null` (no request) when no Steward token is stored
- native: returns `null` when the server rejects the Bearer (401)
- web: same-origin cookie POST byte-identical — `credentials:"include"`, **no** Authorization header
- web: returns `null` on a non-2xx cookie refresh

```
Test Files  1 passed (1) ; Tests  6 passed (6)
```
Existing steward regression suites stay green (17 passed):
`useCloudState.steward-refresh.test.tsx`, `startup-phase-restore.steward-refresh.test.ts`, `client-cloud-steward-token.test.ts`.

**Server** — `packages/cloud/api/auth/steward-refresh/route.test.ts` (new, 6 tests, all green — drives the real Hono handler with Steward upstream + token verification mocked, since no live Steward is reachable in CI):
- Bearer path rotates with the Bearer token and always returns the new JWT — no Origin header required
- Bearer path: invalid/expired Bearer → 401 `invalid_token`
- malformed `Authorization` → falls through to cookie path (403 without cookie/origin)
- cookie path unchanged: forbidden cross-origin POST still 403 and never reaches Steward
- cookie path unchanged: allowed first-party origin rotates via the cookie value
- no credential on an allowed origin → 401 `missing_token`

```
6 pass / 0 fail  (node test/run-unit-isolated.mjs steward-refresh)
```

**Typecheck / lint**
- `bunx tsgo --noEmit` — packages/ui: 0 errors; packages/cloud/api: 0 errors (touched files clean).
- Biome clean on all touched files.

## Needs human verification before closing

This uses `Refs #11941` (not `Closes`). The unit tests mock the Steward upstream;
a human should verify the **full native refresh loop end-to-end against live
Steward** — sign in on a Capacitor build (and Electrobun), let a JWT approach
`exp`, and confirm the Bearer refresh returns a rotated token that is persisted
and keeps the cloud connection alive. Note also: the desktop lifecycle/restore
endpoint resolvers (`useCloudState` / `startup-phase-restore`) still resolve the
refresh endpoint same-origin on Electrobun (only `NativeAppsStudio` passes the
absolute cloud endpoint on desktop); Capacitor native is wired end-to-end.

Refs #11941

🤖 Generated with [Claude Code](https://claude.com/claude-code)
