### PR TITLE
fix(cloud/security): close remaining cross-org IDOR gaps from the auth-isolation sweep (#10852) [cloud-security]

### DIFF
--- a/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
+++ b/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Credits agent-bridge scope (#10852 sweep — service-key IDOR).
+ *
+ * The `agent_id` branch of GET /api/v1/credits/balance and POST
+ * /api/v1/credits/checkout resolves an ARBITRARY sandbox's org from a
+ * caller-supplied agent_id. It is a service-to-service capability (the Waifu
+ * bridge) and MUST require the shared service key. The bug: the routes called
+ * `validateServiceKey(c)` and DISCARDED the result — and validateServiceKey
+ * returns `null` (does NOT throw) on a missing/invalid X-Service-Key — so any
+ * authenticated caller could pass a sibling org's sandbox id and read that
+ * org's credit balance (balance) or mint a Stripe customer/session against, and
+ * write stripe_customer_id onto, that org's row (checkout).
+ *
+ * These tests exercise the REAL requireServiceKey (NOT a mock that always
+ * succeeds — that is exactly what masked the bug), proving:
+ *   - agent_id WITHOUT a valid X-Service-Key → 401, and NO db/credit/stripe
+ *     side effect fires (the denied-access path);
+ *   - agent_id WITH the correct service key + env → resolves the agent's org;
+ *   - the interactive (no agent_id) path is unaffected and needs no key.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const AGENT_ID = "123e4567-e89b-12d3-a456-426614174000";
+const SERVICE_ORG_ID = "00000000-0000-0000-0000-0000000000a1";
+const SERVICE_USER_ID = "00000000-0000-0000-0000-0000000000b2";
+const SERVICE_KEY = "super-secret-service-key";
+
+// ---- shared downstream spies (assert NO side effects on the denied path) ----
+const getCreditBalanceResponse = mock(async (organizationId: string) => ({
+  balance: organizationId === "agent-org" ? 4.5 : 1.25,
+  organizationId,
+}));
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  organization_id: "interactive-org",
+  id: "interactive-user",
+}));
+const checkoutSessionsCreate = mock(
+  async (_params: { metadata?: Record<string, string> }) => ({
+    id: "cs_should_not_happen",
+    url: "https://checkout.stripe.test/nope",
+  }),
+);
+const customersCreate = mock(async () => ({ id: "cus_should_not_happen" }));
+const updateOrganization = mock(async () => undefined);
+const getWithOrganization = mock(async () => ({
+  id: "agent-user",
+  email: "agent@example.test",
+  wallet_address: null,
+  organization_id: "agent-org",
+  organization: {
+    id: "agent-org",
+    name: "Agent Org",
+    stripe_customer_id: "cus_agent",
+    billing_email: "billing@example.test",
+    is_active: true,
+  },
+}));
+
+function dbChain(rows: unknown[]) {
+  return {
+    from: () => ({ where: () => ({ limit: async () => rows }) }),
+  };
+}
+const dbRead = {
+  select: mock(() =>
+    dbChain([{ organizationId: "agent-org", userId: "agent-user" }]),
+  ),
+};
+
+// service-key-hono-worker is deliberately NOT mocked — the REAL requireServiceKey
+// (WebCrypto constant-time compare against c.env.WAIFU_SERVICE_KEY) is under test.
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/db/helpers", () => ({ dbRead }));
+mock.module("@/lib/services/credit-balance-response", () => ({
+  getCreditBalanceResponse,
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getWithOrganization },
+}));
+mock.module("@/lib/services/organizations", () => ({
+  organizationsService: { update: updateOrganization },
+}));
+mock.module("@/lib/security/redirect-validation", () => ({
+  getDefaultPlatformRedirectOrigins: () => ["https://waifu.example.test"],
+  assertAllowedAbsoluteRedirectUrl: (url: string) => new URL(url),
+}));
+mock.module("@/lib/stripe", () => ({
+  requireStripe: () => ({
+    checkout: { sessions: { create: checkoutSessionsCreate } },
+    customers: { create: customersCreate },
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+const { default: balanceApp } = await import("../v1/credits/balance/route");
+const { default: checkoutApp } = await import("../v1/credits/checkout/route");
+
+const SERVICE_ENV = {
+  WAIFU_SERVICE_KEY: SERVICE_KEY,
+  WAIFU_SERVICE_ORG_ID: SERVICE_ORG_ID,
+  WAIFU_SERVICE_USER_ID: SERVICE_USER_ID,
+};
+
+function checkoutBody() {
+  return JSON.stringify({
+    credits: 5,
+    agent_id: AGENT_ID,
+    success_url: "https://waifu.example.test/success",
+    cancel_url: "https://waifu.example.test/cancel",
+  });
+}
+
+describe("credits agent-bridge — real service-key scope (#10852)", () => {
+  beforeEach(() => {
+    getCreditBalanceResponse.mockClear();
+    requireUserOrApiKeyWithOrg.mockClear();
+    checkoutSessionsCreate.mockClear();
+    customersCreate.mockClear();
+    updateOrganization.mockClear();
+    getWithOrganization.mockClear();
+    dbRead.select.mockClear();
+  });
+
+  test("balance: agent_id WITHOUT service key → 401, no db/credit read", async () => {
+    const res = await balanceApp.fetch(
+      new Request(`https://api.example.test/?agent_id=${AGENT_ID}`),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(dbRead.select).not.toHaveBeenCalled();
+    expect(getCreditBalanceResponse).not.toHaveBeenCalled();
+  });
+
+  test("balance: agent_id with WRONG service key → 401", async () => {
+    const res = await balanceApp.fetch(
+      new Request(`https://api.example.test/?agent_id=${AGENT_ID}`, {
+        headers: { "X-Service-Key": "wrong-key" },
+      }),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(dbRead.select).not.toHaveBeenCalled();
+    expect(getCreditBalanceResponse).not.toHaveBeenCalled();
+  });
+
+  test("balance: agent_id WITH correct service key → resolves agent org", async () => {
+    const res = await balanceApp.fetch(
+      new Request(`https://api.example.test/?agent_id=${AGENT_ID}`, {
+        headers: { "X-Service-Key": SERVICE_KEY },
+      }),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      balance: 4.5,
+      organizationId: "agent-org",
+    });
+    expect(getCreditBalanceResponse).toHaveBeenCalledWith("agent-org");
+  });
+
+  test("balance: interactive path (no agent_id) needs no service key", async () => {
+    const res = await balanceApp.fetch(
+      new Request("https://api.example.test/"),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      organizationId: "interactive-org",
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+    expect(dbRead.select).not.toHaveBeenCalled();
+  });
+
+  test("checkout: agent_id WITHOUT service key → 401, no stripe/org write", async () => {
+    const res = await checkoutApp.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: checkoutBody(),
+      }),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(dbRead.select).not.toHaveBeenCalled();
+    expect(getWithOrganization).not.toHaveBeenCalled();
+    expect(customersCreate).not.toHaveBeenCalled();
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(checkoutSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  test("checkout: agent_id WITH correct service key → creates session for agent org", async () => {
+    const res = await checkoutApp.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Service-Key": SERVICE_KEY,
+        },
+        body: checkoutBody(),
+      }),
+      SERVICE_ENV,
+    );
+    expect(res.status).toBe(200);
+    expect(checkoutSessionsCreate).toHaveBeenCalledTimes(1);
+    const params = checkoutSessionsCreate.mock.calls[0]?.[0] as {
+      metadata?: Record<string, string>;
+    };
+    expect(params.metadata).toMatchObject({
+      organization_id: "agent-org",
+      user_id: "agent-user",
+    });
+  });
+});

--- a/packages/cloud/api/training/vertex/jobs/route.ts
+++ b/packages/cloud/api/training/vertex/jobs/route.ts
@@ -18,8 +18,16 @@ async function __hono_GET(request: Request) {
     const jobId = searchParams.get("jobId");
     const persistedOnly = searchParams.get("persisted") === "true";
 
+    const viewer = {
+      organizationId: user.organization_id,
+      userId: user.id,
+    };
+
     if (jobId) {
-      const synced = await vertexModelRegistryService.syncJobStatus({ jobId });
+      const synced = await vertexModelRegistryService.syncJobStatus({
+        jobId,
+        viewer,
+      });
       if (!synced) {
         return Response.json(
           { error: "Tracked Vertex job not found" },
@@ -35,15 +43,24 @@ async function __hono_GET(request: Request) {
     }
 
     if (jobName) {
-      const [job, synced] = await Promise.all([
-        getTuningJobStatus(jobName),
-        vertexModelRegistryService.syncJobStatus({ vertexJobName: jobName }),
-      ]);
+      // Gate on the OWNED persisted record first — otherwise the direct Vertex
+      // fetch would leak a sibling org's (enumerable) tuning job config.
+      const synced = await vertexModelRegistryService.syncJobStatus({
+        vertexJobName: jobName,
+        viewer,
+      });
+      if (!synced) {
+        return Response.json(
+          { error: "Tracked Vertex job not found" },
+          { status: 404 },
+        );
+      }
 
+      const job = await getTuningJobStatus(jobName);
       return Response.json({
         job,
-        jobRecord: synced?.job,
-        tunedModelRecord: synced?.tunedModel,
+        jobRecord: synced.job,
+        tunedModelRecord: synced.tunedModel,
       });
     }
 

--- a/packages/cloud/api/v1/credits/balance/route.ts
+++ b/packages/cloud/api/v1/credits/balance/route.ts
@@ -13,7 +13,7 @@ import {
   failureResponse,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
-import { validateServiceKey } from "@/lib/auth/service-key-hono-worker";
+import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -51,7 +51,12 @@ async function resolveCreditOrganizationId(
     const user = await requireUserOrApiKeyWithOrg(c);
     return user.organization_id;
   }
-  await validateServiceKey(c);
+  // Resolving an ARBITRARY agent's org from a caller-supplied agent_id is a
+  // service-to-service capability (the Waifu bridge). Require the service key —
+  // `validateServiceKey` merely returned null on a missing/invalid key, which
+  // was discarded, letting any authenticated user read a sibling org's balance
+  // by passing that org's sandbox id. `requireServiceKey` throws instead.
+  await requireServiceKey(c);
 
   const [sandbox] = await dbRead
     .select({ organizationId: agentSandboxes.organization_id })

--- a/packages/cloud/api/v1/credits/checkout/route.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.ts
@@ -13,7 +13,7 @@ import {
   failureResponse,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
-import { validateServiceKey } from "@/lib/auth/service-key-hono-worker";
+import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -168,7 +168,13 @@ async function resolveCreditUser(
   agentId?: string,
 ): ReturnType<typeof requireUserOrApiKeyWithOrg> {
   if (!agentId) return requireUserOrApiKeyWithOrg(c);
-  await validateServiceKey(c);
+  // Attributing a checkout to an ARBITRARY agent's owner/org from a
+  // caller-supplied agent_id is a service-to-service capability. Require the
+  // service key — `validateServiceKey` returned null (not throw) on a
+  // missing/invalid key and the result was discarded, letting any authenticated
+  // caller mint a Stripe customer/session against, and write stripe_customer_id
+  // onto, a sibling org's row. `requireServiceKey` throws instead.
+  await requireServiceKey(c);
 
   const [sandbox] = await dbRead
     .select({

--- a/packages/cloud/shared/src/lib/services/__tests__/vertex-model-registry-scope.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/vertex-model-registry-scope.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Vertex model registry — cross-org isolation (#10852 sweep). Real Drizzle
+ * schema, in-process PGlite (never a silent skip: the `pgliteReady` guard fails
+ * loudly if pushSchema can't initialize).
+ *
+ * Two confirmed IDOR gaps, both proven here against the REAL SQL:
+ *
+ *   syncJobStatus (GET /api/training/vertex/jobs by id/name): resolved the
+ *   tuning job by id/name with NO visibility predicate, then RE-SYNCED it (a
+ *   write). One org could read AND mutate another org's tuning job. Fixed by
+ *   scoping the lookup with buildVisibilityCondition(viewer) — a cross-org id
+ *   now returns null (404 at the route) and never reaches the write.
+ *
+ *   activateAssignment (POST /api/training/vertex/assignments): resolved the
+ *   tuned model by id alone, letting one org bind another org's private
+ *   fine-tuned model into its own inference slot. Fixed by scoping the lookup
+ *   with buildModelVisibilityCondition({org,user}) — a non-visible model id is
+ *   now indistinguishable from a missing one ("Tuned model not found").
+ */
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { organizations } from "../../../db/schemas/organizations";
+import { users } from "../../../db/schemas/users";
+import { vertexModelAssignments } from "../../../db/schemas/vertex-model-assignments";
+import { vertexTunedModels } from "../../../db/schemas/vertex-tuned-models";
+import {
+  vertexTuningJobStateEnum,
+  vertexTuningJobs,
+  vertexTuningScopeEnum,
+  vertexTuningSlotEnum,
+} from "../../../db/schemas/vertex-tuning-jobs";
+
+const PGLITE_TIMEOUT = 120_000;
+let pgliteReady = true;
+let service: typeof import("../vertex-model-registry").vertexModelRegistryService;
+
+let orgA = "";
+let userA = "";
+let orgB = "";
+let userB = "";
+let jobB = "";
+let modelA = "";
+let modelB = "";
+let modelGlobal = "";
+
+async function seedOrgUser(name: string) {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name, slug: `${name}-${Date.now()}-${Math.random()}` })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({
+      steward_user_id: `${name}-u-${Date.now()}-${Math.random()}`,
+      organization_id: org.id,
+    })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+beforeAll(async () => {
+  try {
+    const schema = {
+      organizations,
+      users,
+      vertexTuningJobs,
+      vertexTunedModels,
+      vertexModelAssignments,
+      vertexTuningScopeEnum,
+      vertexTuningSlotEnum,
+      vertexTuningJobStateEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+
+    ({ orgId: orgA, userId: userA } = await seedOrgUser("orga"));
+    ({ orgId: orgB, userId: userB } = await seedOrgUser("orgb"));
+
+    // Org B's tuning job (the cross-org read/mutate target).
+    const [job] = await dbWrite
+      .insert(vertexTuningJobs)
+      .values({
+        vertex_job_name: "projects/p/locations/us-central1/tuningJobs/b1",
+        project_id: "p",
+        region: "us-central1",
+        display_name: "Org B Job",
+        base_model: "gemini-1.5",
+        slot: "response",
+        scope: "organization",
+        organization_id: orgB,
+        training_data_path: "gs://bucket/b/train.jsonl",
+        status: "JOB_STATE_RUNNING",
+      })
+      .returning();
+    jobB = job.id;
+
+    const [ma] = await dbWrite
+      .insert(vertexTunedModels)
+      .values({
+        vertex_model_id: "orga-model",
+        display_name: "Org A Model",
+        base_model: "gemini-1.5",
+        project_id: "p",
+        region: "us-central1",
+        slot: "response",
+        source_scope: "organization",
+        organization_id: orgA,
+      })
+      .returning();
+    modelA = ma.id;
+
+    const [mb] = await dbWrite
+      .insert(vertexTunedModels)
+      .values({
+        vertex_model_id: "orgb-model",
+        display_name: "Org B Model",
+        base_model: "gemini-1.5",
+        project_id: "p",
+        region: "us-central1",
+        slot: "response",
+        source_scope: "organization",
+        organization_id: orgB,
+      })
+      .returning();
+    modelB = mb.id;
+
+    const [mg] = await dbWrite
+      .insert(vertexTunedModels)
+      .values({
+        vertex_model_id: "global-model",
+        display_name: "Global Model",
+        base_model: "gemini-1.5",
+        project_id: "p",
+        region: "us-central1",
+        slot: "response",
+        source_scope: "global",
+      })
+      .returning();
+    modelGlobal = mg.id;
+
+    ({ vertexModelRegistryService: service } = await import("../vertex-model-registry"));
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[vertex-model-registry-scope.test] PGlite/pushSchema unavailable — failing loud.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("vertex model registry — cross-org isolation (#10852)", () => {
+  beforeEach(async () => {
+    if (pgliteReady) await dbWrite.delete(vertexModelAssignments);
+  });
+
+  test("pglite applied (loud)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  // --- finding 7: syncJobStatus cross-org read+mutate ---
+
+  test("syncJobStatus: org A viewer canNOT read org B's job by id (null, no write)", async () => {
+    const result = await service.syncJobStatus({
+      jobId: jobB,
+      viewer: { organizationId: orgA, userId: userA },
+    });
+    expect(result).toBeNull();
+
+    // The row must be UNTOUCHED — the old code re-synced (wrote) it cross-org.
+    const row = await dbWrite.query.vertexTuningJobs.findFirst({
+      where: eq(vertexTuningJobs.id, jobB),
+    });
+    expect(row?.status).toBe("JOB_STATE_RUNNING");
+  });
+
+  test("syncJobStatus: org A viewer canNOT read org B's job by name (null)", async () => {
+    const result = await service.syncJobStatus({
+      vertexJobName: "projects/p/locations/us-central1/tuningJobs/b1",
+      viewer: { organizationId: orgA, userId: userA },
+    });
+    expect(result).toBeNull();
+  });
+
+  test("job visibility predicate admits the owner (org B) and denies org A", async () => {
+    // syncJobStatus reuses buildVisibilityCondition; listVisibleJobs proves it
+    // both ways with no external Vertex call.
+    const bJobs = await service.listVisibleJobs({
+      organizationId: orgB,
+      userId: userB,
+    });
+    expect(bJobs.map((j) => j.id)).toContain(jobB);
+
+    const aJobs = await service.listVisibleJobs({
+      organizationId: orgA,
+      userId: userA,
+    });
+    expect(aJobs.map((j) => j.id)).not.toContain(jobB);
+  });
+
+  // --- finding 8: activateAssignment cross-org model bind ---
+
+  test("activateAssignment: org A canNOT activate org B's private model", async () => {
+    await expect(
+      service.activateAssignment({
+        scope: "organization",
+        slot: "response",
+        tunedModelId: modelB,
+        organizationId: orgA,
+        assignedByUserId: userA,
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    const rows = await dbWrite
+      .select()
+      .from(vertexModelAssignments)
+      .where(eq(vertexModelAssignments.tuned_model_id, modelB));
+    expect(rows).toHaveLength(0);
+  });
+
+  test("activateAssignment: org A CAN activate its own model", async () => {
+    const { assignment, tunedModel } = await service.activateAssignment({
+      scope: "organization",
+      slot: "response",
+      tunedModelId: modelA,
+      organizationId: orgA,
+      assignedByUserId: userA,
+    });
+    expect(tunedModel.id).toBe(modelA);
+    expect(assignment.organization_id).toBe(orgA);
+    expect(assignment.is_active).toBe(true);
+  });
+
+  test("activateAssignment: org A CAN activate a global model", async () => {
+    const { tunedModel } = await service.activateAssignment({
+      scope: "organization",
+      slot: "response",
+      tunedModelId: modelGlobal,
+      organizationId: orgA,
+      assignedByUserId: userA,
+    });
+    expect(tunedModel.id).toBe(modelGlobal);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/vertex-model-registry.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-model-registry.ts
@@ -380,14 +380,20 @@ export class VertexModelRegistryService {
   async syncJobStatus(params: {
     jobId?: string;
     vertexJobName?: string;
+    viewer: ViewerScope;
   }): Promise<VertexTuningJobRecordWithModel | null> {
+    // Scope the lookup to the caller (global + own-org + own-user rows) BEFORE
+    // reading OR mutating the row. Resolving by id/name alone let one org read
+    // and re-sync (a write) another org's tuning job — the by-id/name paths
+    // skipped the visibility predicate the list path already enforces.
+    const visibility = buildVisibilityCondition(params.viewer);
     const job = params.jobId
       ? await dbRead.query.vertexTuningJobs.findFirst({
-          where: eq(vertexTuningJobs.id, params.jobId),
+          where: and(eq(vertexTuningJobs.id, params.jobId), visibility),
         })
       : params.vertexJobName
         ? await dbRead.query.vertexTuningJobs.findFirst({
-            where: eq(vertexTuningJobs.vertex_job_name, params.vertexJobName),
+            where: and(eq(vertexTuningJobs.vertex_job_name, params.vertexJobName), visibility),
           })
         : null;
 
@@ -550,8 +556,19 @@ export class VertexModelRegistryService {
     const owner = normalizeScopeOwner(params);
 
     return dbWrite.transaction(async (tx) => {
+      // Only a tuned model the caller can actually SEE (global + own-org +
+      // own-user) may be bound to their assignment slot. Resolving by id alone
+      // let one org activate another org's private fine-tuned model into its
+      // own inference slot. Mirrors buildModelVisibilityCondition on the list
+      // path; a non-visible id is indistinguishable from a missing one.
       const tunedModel = await tx.query.vertexTunedModels.findFirst({
-        where: eq(vertexTunedModels.id, params.tunedModelId),
+        where: and(
+          eq(vertexTunedModels.id, params.tunedModelId),
+          buildModelVisibilityCondition({
+            organizationId: owner.organizationId,
+            userId: owner.userId,
+          }),
+        ),
       });
 
       if (!tunedModel) {


### PR DESCRIPTION
## Summary

Follow-up to the #10852 app-key-scope auth-isolation sweep (which confirmed **8** ownership-guard gaps). The `isAppKeyOutOfScope` gaps have already landed:

- `GET /api/v1/apps/:id` → **#11958** (merged)
- frontend / review / backup subtree → **#11943** (merged)

This PR closes the **4 remaining confirmed gaps**, which are a **different bug class** (org / service-key scope, not app-key). All were re-reproduced on current `develop`.

cc @lalalune — **security / multi-tenant isolation**. `[cloud-security]`

## What was wrong (and the fix)

### 1–2. `v1/credits/balance` + `v1/credits/checkout` — discarded service-key check (cross-org)
The `agent_id` branch resolves an **arbitrary** sandbox's org and called `validateServiceKey(c)` but **discarded the result**. `validateServiceKey` returns `null` (it does **not** throw) when the `X-Service-Key` header is missing/invalid, so the branch enforced nothing:
- **balance** → any authenticated caller passing a sibling org's sandbox `agent_id` read that org's credit balance.
- **checkout** → attributed a Stripe checkout to, minted a customer/session for, and wrote `stripe_customer_id` onto, a **sibling org's** row.

**Fix:** the `agent_id` (service-to-service) branch now calls `requireServiceKey(c)`, which **throws** on a missing/invalid key. The interactive (no `agent_id`) path is unchanged — it still resolves the caller's own org via `requireUserOrApiKeyWithOrg`.

### 3. `training/vertex/jobs` — cross-org read **and** mutation
`syncJobStatus({jobId|vertexJobName})` resolved the tuning job by id/name with **no** visibility predicate, then re-synced it (a DB **write**). One org could read **and mutate** another org's tuning job (org id, error messages, endpoint name, raw remote payload).

**Fix:** `syncJobStatus` takes a required `viewer` and scopes the lookup with `buildVisibilityCondition(viewer)` **before** the read/write (mirrors the list path). The by-name route now gates on the owned persisted record **before** the direct Vertex fetch (which would otherwise leak an enumerable sibling job's config). Non-visible id/name → `null` → `404`.

### 4. `training/vertex/assignments` — activate another org's private model
`activateAssignment` resolved the tuned model by id alone, letting one org bind another org's **private fine-tuned model** into its own inference slot (so its inference is served by the victim's model).

**Fix:** scope the tuned-model lookup with `buildModelVisibilityCondition({org,user})` (mirrors the list path); a non-visible id is now indistinguishable from a missing one.

## Tests — real path, no larp

- **`packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts`** drives the **REAL** `requireServiceKey` (WebCrypto constant-time compare — a mock that always succeeds is exactly what masked the bug): `agent_id` **without** a valid `X-Service-Key` → `401` with **no** db/credit/stripe side effect (denied-access path); **with** the correct key → resolves the agent org; the interactive (no `agent_id`) path still needs no key.
- **`packages/cloud/shared/src/lib/services/__tests__/vertex-model-registry-scope.test.ts`** is **real in-process PGlite** (`pushSchema`, loud `pgliteReady` guard): org A cannot `syncJobStatus` org B's job by id or name (returns `null`, and the row is **not** written), the visibility predicate admits the owner and denies the sibling, org A cannot `activateAssignment` org B's private model, while own-org and global models stay allowed.

## Verification

```
bun test packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts \
  packages/cloud/api/v1/credits/balance/route.test.ts \
  packages/cloud/api/v1/credits/checkout/route.test.ts
# 8 pass, 0 fail

bun --conditions=eliza-source test \
  packages/cloud/shared/src/lib/services/__tests__/vertex-model-registry-scope.test.ts
# 7 pass, 0 fail
```

- biome `check`: clean on all changed files.
- tsgo `typecheck` (cloud/api + cloud/shared): no errors on changed files.
- The two pre-existing `credits/*/route.test.ts` already alias `requireServiceKey` and stay green.

## Evidence checklist
- Multi-tenant isolation proven by test incl. the **denied-access** paths — see the two test files above. ✅
- DB state (no cross-org write) asserted in the PGlite vertex test. ✅
- Real-LLM trajectory / rendered UI — **N/A** (backend auth/scope only; no model or UI surface changed).