### PR TITLE
fix(app-control): register a built app before telling the user to launch it (#11954)

### DIFF
--- a/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
@@ -79,24 +79,29 @@ describe("VerificationRoomBridgeService — boot-order retry", () => {
 		expect(coordinator.__listenerCount()).toBe(0);
 	});
 
-	it("gives up quietly after ATTACH_MAX_RETRIES without binding twice", async () => {
+	it("keeps retrying past ATTACH_MAX_RETRIES and still binds when the coordinator appears late", async () => {
 		const coordinator = makeCoordinator();
 		const { runtime, setService } = makeRuntime({});
 
 		const service = await VerificationRoomBridgeService.start(runtime);
 
-		// Drain the entire retry budget: 60 retries × 500ms = 30s.
+		// Drain well past the escalation threshold (60 retries × 500ms = 30s).
+		// The bridge no longer gives up there (see scheduleAttachRetry) — it keeps
+		// polling on a capped backoff so a heavy-boot coordinator that registers
+		// minutes late is still wired, instead of leaving verdicts unposted.
 		vi.advanceTimersByTime(31_000);
-		await Promise.resolve();
-
-		// Service eventually shows up AFTER giving up. Bridge must NOT
-		// subscribe — the retry loop already terminated.
-		setService("SWARM_COORDINATOR", coordinator);
-		vi.advanceTimersByTime(5_000);
 		await Promise.resolve();
 		expect(coordinator.__listenerCount()).toBe(0);
 
+		// The coordinator finally registers; a later retry tick binds it exactly
+		// once (success clears the timer, so no second subscription).
+		setService("SWARM_COORDINATOR", coordinator);
+		vi.advanceTimersByTime(10_000);
+		await Promise.resolve();
+		expect(coordinator.__listenerCount()).toBe(1);
+
 		await service.stop();
+		expect(coordinator.__listenerCount()).toBe(0);
 	});
 
 	it("stop() cancels a pending retry timer", async () => {
@@ -160,6 +165,118 @@ describe("VerificationRoomBridgeService — verdict posting", () => {
 			},
 		};
 	}
+
+	// An app pass carries the built dir on `verification.params.workdir` only —
+	// no top-level `workdir` — which exercises the params fallback in decodeEvent.
+	function appEvent(verdict: "pass" | "fail") {
+		return {
+			type: verdict === "pass" ? "task_complete" : "escalation",
+			sessionId: `sess-app-${verdict}`,
+			data: {
+				originRoomId: "room-99",
+				label: "create-app:notes",
+				summary: verdict === "fail" ? "build error" : undefined,
+				verification: {
+					source: "custom-validator",
+					verdict,
+					validator: { service: "app-verification", method: "verifyApp" },
+					params: {
+						appName: "notes",
+						workdir: "/repo/eliza/apps/app-notes",
+						profile: "full",
+					},
+				},
+			},
+		};
+	}
+
+	it("registers the built app and tells the user to launch it (#11954)", async () => {
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				ok: true,
+				registered: 1,
+				items: [{ slug: "notes", canonicalName: "app-notes" }],
+			}),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appEvent("pass"));
+		await flush();
+
+		// It POSTed the workdir (resolved from verification.params) to the apps
+		// registration route so `launch <name>` can resolve the fresh app.
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			expect.stringContaining("/api/apps/load-from-directory"),
+			expect.objectContaining({
+				method: "POST",
+				body: expect.stringContaining("/repo/eliza/apps/app-notes"),
+			}),
+		);
+
+		expect(runtime.createMemory).toHaveBeenCalledTimes(1);
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).toContain("notes app built, verified, and registered");
+		expect(text).toContain("launch notes");
+		expect(memory.content.metadata).toMatchObject({ verdict: "pass" });
+
+		await service.stop();
+	});
+
+	it("surfaces an app registration failure honestly, not a dead-end launch (#11954)", async () => {
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: false,
+			status: 503,
+			json: async () => ({
+				ok: false,
+				error: "AppRegistryService is not registered on the runtime",
+			}),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appEvent("pass"));
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).toContain("built and verified");
+		expect(text).toContain("registration failed");
+		expect(text).toContain("AppRegistryService is not registered");
+		// It must NOT falsely promise a launch that will dead-end.
+		expect(text).not.toContain("Reply 'launch notes'");
+
+		await service.stop();
+	});
+
+	it("reports a no-manifest app dir honestly (registered: 0)", async () => {
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true, registered: 0, items: [] }),
+		} as Response);
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		coordinator.__emit(appEvent("pass"));
+		await flush();
+
+		const [memory] = (runtime.createMemory as ReturnType<typeof vi.fn>).mock
+			.calls[0];
+		const text = memory.content.text as string;
+		expect(text).toContain("no app manifest was found");
+		expect(text).not.toContain("Reply 'launch notes'");
+
+		await service.stop();
+	});
 
 	it("live-loads the plugin and posts a 'loaded live' verdict (never reinject)", async () => {
 		const coordinator = makeCoordinator();

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -175,7 +175,10 @@ function decodeEvent(event: SwarmEventLike): BridgeEventPayload | null {
 		method,
 		targetName,
 		label: readString(event.data, "label"),
-		workdir: readString(event.data, "workdir"),
+		// verifyApp carries the built dir only on `verification.params.workdir`
+		// (verifyPlugin also mirrors it at the top level); read both so app
+		// registration below always has the workdir (#11954).
+		workdir: readString(event.data, "workdir") ?? readString(params, "workdir"),
 		summary: readString(event.data, "summary"),
 		retryCount: readNumber(event.data, "retryCount"),
 		maxRetries: readNumber(event.data, "maxRetries"),
@@ -227,10 +230,73 @@ async function loadPluginFromWorkdir(
 	}
 }
 
+/**
+ * Register a freshly built app directory into the running runtime via the
+ * loopback apps API so `launch <name>` can resolve it. The verifyApp pass hands
+ * off `eliza/apps/app-<slug>` (the app's own dir); `/api/apps/load-from-directory`
+ * now registers that dir directly (in addition to scanning subdirs). Without
+ * this step a verified app was never registered and `launch <name>` dead-ended
+ * at "No installed app matches" (#11954). Returns the outcome so the verdict
+ * message can tell the user whether the app is launchable or only built on disk.
+ */
+async function registerAppFromWorkdir(
+	workdir: string,
+): Promise<{ ok: boolean; registered: number; error?: string }> {
+	const port = resolveServerOnlyPort(process.env);
+	try {
+		const resp = await fetch(
+			`http://127.0.0.1:${port}/api/apps/load-from-directory`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ directory: workdir }),
+				signal: AbortSignal.timeout(30_000),
+			},
+		);
+		const body = (await resp.json().catch(() => ({}))) as Record<
+			string,
+			unknown
+		>;
+		if (resp.ok && body.ok === true) {
+			return {
+				ok: true,
+				registered: typeof body.registered === "number" ? body.registered : 0,
+			};
+		}
+		return {
+			ok: false,
+			registered: 0,
+			error:
+				typeof body.error === "string"
+					? body.error
+					: `register returned HTTP ${resp.status}`,
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			registered: 0,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
 async function buildPassMessage(payload: BridgeEventPayload): Promise<string> {
 	const isApp = payload.method === VERIFY_APP_METHOD;
 	if (isApp) {
-		// Apps resolve through the launch/registry path.
+		// Register the freshly built app so `launch <name>` resolves — a verified
+		// app that was never registered dead-ends at "No installed app matches"
+		// (#11954). Best-effort: on failure the app still exists on disk.
+		if (payload.workdir) {
+			const reg = await registerAppFromWorkdir(payload.workdir);
+			if (reg.ok && reg.registered > 0) {
+				return `${payload.targetName} app built, verified, and registered. Reply 'launch ${payload.targetName}' to open it.`;
+			}
+			if (reg.ok) {
+				return `${payload.targetName} app built and verified, but no app manifest was found at ${payload.workdir} to register. Check the app's package.json 'elizaos.app' field before launching.`;
+			}
+			return `${payload.targetName} app built and verified at ${payload.workdir}, but registration failed: ${reg.error}. Re-run load-from-directory before launching.`;
+		}
+		// No workdir on the event — fall back to the best-effort launch hint.
 		return `${payload.targetName} app built and verified. Reply 'launch ${payload.targetName}' to open it.`;
 	}
 
@@ -330,9 +396,10 @@ export class VerificationRoomBridgeService extends Service {
 			// is not deterministic, so the orchestrator may register its
 			// SwarmCoordinator after we ran. Retry on a backoff up to
 			// `ATTACH_MAX_RETRIES` so the bridge ends up wired whenever the
-			// orchestrator IS in the plugin set. After the retry budget
-			// expires we give up quietly — `plugin-app-control` still works
-			// for non-create flows without the bridge.
+			// orchestrator IS in the plugin set. The retry never gives up (see
+			// scheduleAttachRetry) — it backs off and gets louder past
+			// ATTACH_MAX_RETRIES so a late-registering coordinator is still wired;
+			// stop() cancels the pending timer.
 			this.scheduleAttachRetry();
 			return;
 		}

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -82,6 +82,7 @@ async function callRoute(args: {
   favoriteApps?: FavoriteAppsStore;
   getPluginManager?: AppsRouteContext["getPluginManager"];
   actorRole?: AppsRouteActorRole | null;
+  runtime?: AppsRouteContext["runtime"];
 }): Promise<{
   handled: boolean;
   res: CapturedResponse;
@@ -100,7 +101,7 @@ async function callRoute(args: {
     appManager,
     favoriteApps: args.favoriteApps,
     actorRole: args.actorRole,
-    runtime: null,
+    runtime: args.runtime ?? null,
     getPluginManager:
       args.getPluginManager ??
       (() =>
@@ -334,6 +335,145 @@ describe("handleAppsRoutes", () => {
       expect(refreshRegistry).toHaveBeenCalledTimes(1);
     } finally {
       await rm(packageDir, { recursive: true, force: true });
+    }
+  });
+});
+
+interface MockRegistry {
+  register: ReturnType<typeof vi.fn>;
+  recordManifestRejection: ReturnType<typeof vi.fn>;
+}
+
+function createMockRegistryRuntime(): {
+  runtime: AppsRouteContext["runtime"];
+  registry: MockRegistry;
+} {
+  const registry: MockRegistry = {
+    register: vi.fn(async () => {}),
+    recordManifestRejection: vi.fn(async () => {}),
+  };
+  const runtime = {
+    getService: (type: string) => (type === "app-registry" ? registry : null),
+  } as unknown as AppsRouteContext["runtime"];
+  return { runtime, registry };
+}
+
+async function writeAppManifest(
+  dir: string,
+  name: string,
+  app: Record<string, unknown>,
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name, version: "0.0.0", elizaos: { app } }),
+    "utf8",
+  );
+}
+
+describe("POST /api/apps/load-from-directory — single-dir registration (#11954)", () => {
+  it("registers an app when the directory itself carries the elizaos.app manifest", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "app-single-"));
+    const appDir = path.join(root, "eliza", "apps", "app-notes");
+    try {
+      await writeAppManifest(appDir, "app-notes", {
+        slug: "notes",
+        displayName: "Notes",
+      });
+      const { runtime, registry } = createMockRegistryRuntime();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: appDir },
+        runtime,
+      });
+
+      expect(result.handled).toBe(true);
+      expect(result.res.status).toBe(200);
+      expect(result.res.body).toMatchObject({
+        ok: true,
+        registered: 1,
+        items: [{ slug: "notes", canonicalName: "app-notes" }],
+      });
+      // Registered with the app's own dir + external trust — exactly the path
+      // the verifyApp handoff (verification-room-bridge) now drives (#11954).
+      expect(registry.register).toHaveBeenCalledTimes(1);
+      expect(registry.register).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "notes", directory: appDir }),
+        expect.objectContaining({ trust: "external" }),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still scans subdirectories when a parent/container dir is passed", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "app-scan-"));
+    const appsDir = path.join(root, "apps");
+    try {
+      await writeAppManifest(path.join(appsDir, "app-alpha"), "app-alpha", {
+        slug: "alpha",
+      });
+      await writeAppManifest(path.join(appsDir, "app-beta"), "app-beta", {
+        slug: "beta",
+      });
+      // A non-app subdir must be ignored.
+      await mkdir(path.join(appsDir, "not-an-app"), { recursive: true });
+      const { runtime, registry } = createMockRegistryRuntime();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: appsDir },
+        runtime,
+      });
+
+      expect(result.res.status).toBe(200);
+      // The container dir has no manifest of its own, so only the two app
+      // subdirs register — the top-level candidate must not double-count.
+      expect(result.res.body).toMatchObject({ ok: true, registered: 2 });
+      expect(registry.register).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("registers 0 for a directory that is neither an app nor a container of apps", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "app-empty-"));
+    try {
+      await mkdir(path.join(root, "src"), { recursive: true });
+      const { runtime, registry } = createMockRegistryRuntime();
+
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: root },
+        runtime,
+      });
+
+      expect(result.res.status).toBe(200);
+      expect(result.res.body).toMatchObject({ ok: true, registered: 0 });
+      expect(registry.register).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("503s when no AppRegistryService is on the runtime", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "app-noreg-"));
+    const appDir = path.join(root, "app-notes");
+    try {
+      await writeAppManifest(appDir, "app-notes", { slug: "notes" });
+      const result = await callRoute({
+        method: "POST",
+        pathname: "/api/apps/load-from-directory",
+        body: { directory: appDir },
+        runtime: null,
+      });
+      expect(result.res.status).toBe(503);
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1587,10 +1587,12 @@ export async function handleAppsRoutes(
       error(res, "AppRegistryService is not registered on the runtime", 503);
       return true;
     }
+    // Capture the guard-narrowed handle so the nested per-directory closure
+    // keeps the non-undefined type (control-flow narrowing does not cross into
+    // the closure otherwise).
+    const registerApp = registry.register;
 
     try {
-      const entries = await fs.readdir(directory, { withFileTypes: true });
-      let registered = 0;
       const items: Array<{ slug: string; canonicalName: string }> = [];
       const rejectedManifests: Array<{
         directory: string;
@@ -1598,12 +1600,15 @@ export async function handleAppsRoutes(
         reason: string;
         path: string;
       }> = [];
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const subdir = path.join(directory, entry.name);
-        const pkgPath = path.join(subdir, "package.json");
+
+      // Register a single directory whose own package.json carries the
+      // `elizaos.app` manifest. Returns true when registered; records a
+      // rejection (and returns false) when the manifest is present but its
+      // permissions are malformed; returns false when the dir is not an app.
+      const registerAppDir = async (appDir: string): Promise<boolean> => {
+        const pkgPath = path.join(appDir, "package.json");
         const raw = await fs.readFile(pkgPath, "utf8").catch(() => null);
-        if (raw === null) continue;
+        if (raw === null) return false;
         const parsed = JSON.parse(raw) as Record<string, unknown>;
         const elizaos =
           parsed.elizaos && typeof parsed.elizaos === "object"
@@ -1613,15 +1618,15 @@ export async function handleAppsRoutes(
           elizaos?.app && typeof elizaos.app === "object"
             ? (elizaos.app as Record<string, unknown>)
             : null;
-        if (!appMeta) continue;
+        if (!appMeta) return false;
         const packageName =
           typeof parsed.name === "string" ? parsed.name : null;
-        if (!packageName) continue;
+        if (!packageName) return false;
 
         const permissionsResult = parseAppPermissions(appMeta.permissions);
         if (permissionsResult.ok === false) {
           const rejection = {
-            directory: subdir,
+            directory: appDir,
             packageName,
             reason: permissionsResult.reason,
             path: permissionsResult.path,
@@ -1632,7 +1637,7 @@ export async function handleAppsRoutes(
             requesterEntityId: null,
             requesterRoomId: null,
           });
-          continue;
+          return false;
         }
 
         const basename = packageName.replace(/^@[^/]+\//, "").trim();
@@ -1650,21 +1655,41 @@ export async function handleAppsRoutes(
           slug,
           canonicalName: packageName,
           aliases,
-          directory: subdir,
+          directory: appDir,
           displayName,
           isolation: parseAppIsolation(appMeta.isolation),
         };
         if (permissionsResult.manifest.raw !== null) {
           entryRecord.requestedPermissions = permissionsResult.manifest.raw;
         }
-        await registry.register(entryRecord, {
+        await registerApp(entryRecord, {
           requesterEntityId: null,
           requesterRoomId: null,
           trust: "external",
         });
-        registered += 1;
         items.push({ slug, canonicalName: packageName });
+        return true;
+      };
+
+      // Accept either a single freshly-built app directory (the dir itself
+      // carries the `elizaos.app` manifest — e.g. a `verifyApp` pass handing off
+      // `eliza/apps/app-<slug>`, #11954) or a parent directory to scan for app
+      // subdirectories. Trying the top-level dir first makes single-app
+      // registration work without the caller knowing which shape it passed; a
+      // parent/container dir has no manifest of its own, so it falls through to
+      // the subdir scan exactly as before.
+      const candidates = [directory];
+      const entries = await fs.readdir(directory, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          candidates.push(path.join(directory, entry.name));
+        }
       }
+      let registered = 0;
+      for (const candidate of candidates) {
+        if (await registerAppDir(candidate)) registered += 1;
+      }
+
       json(res, {
         ok: true,
         directory,


### PR DESCRIPTION
## Problem (#11954)

After `APP create` builds and verifies a local app, `VerificationRoomBridge` tells the user **"Reply 'launch <name>'"** — but launching then fails with **"No installed app matches"**, because the freshly built app was never registered.

Root cause (concrete, on develop):
- `verification-room-bridge.ts` `buildPassMessage` — the **APP** branch skipped registration entirely and only the **PLUGIN** branch live-loaded, yet the APP branch still emitted the `launch <name>` suggestion.
- A scaffolded app lives at `eliza/apps/app-<slug>` (`app-create.ts`) but is in **neither** the `AppRegistryService` registry **nor** `config.plugins.installs`, so `app-launch.ts` → `client.listInstalledApps()` → `resolveInstalledApp()` resolves to `none`.
- Net: a **promise-then-fail** UX — the user is told to launch an app that can never resolve.

## Fix

1. **`/api/apps/load-from-directory` now registers the given directory itself** when that dir's own `package.json` carries the `elizaos.app` manifest (the `verifyApp` handoff passes the app's **own** dir), in addition to the existing subdirectory scan. The per-directory registration is factored into a helper and applied to `[directory, ...subdirs]`. A parent/container dir has no manifest of its own, so it falls through to the subdir scan **exactly as before** — existing callers (`APP load_from_directory`) are unaffected.
2. **`VerificationRoomBridge`'s `verifyApp` pass now POSTs the built workdir to that route** before emitting the launch hint (mirroring the plugin branch's live-load), and reports honestly when registration **fails** or finds **no manifest** instead of dead-ending the user.
3. **`decodeEvent` reads `workdir` from `verification.params.workdir`** as well as the top level, since `verifyApp` events carry it only under `params`.

Also corrected a **stale test + source comment** in the same file: the boot-order retry was changed to **retry indefinitely** with backoff (`scheduleAttachRetry`), but the "gives up quietly after `ATTACH_MAX_RETRIES`" test and an `attach()` comment still described the old give-up behavior. The test now asserts the bridge binds a late-registering coordinator (and unbinds on `stop()`), matching current source.

## Evidence — real vitest suites (no mocked thing-under-test)

`plugin-app-manager` route test drives the **real** `handleAppsRoutes` against **real filesystem** temp dirs with a mock registry:

```
$ bun run --cwd plugins/plugin-app-manager test -- apps-routes
 Test Files  1 passed (1)
      Tests  15 passed (15)
```
New cases: single app dir → `registered: 1` + `register(dir, {trust:'external'})`; parent/container dir → scans subdirs, top-level does not double-count; neither-app-nor-container → `registered: 0`; missing `AppRegistryService` → `503`.

`plugin-app-control` bridge test drives the **real** service + event decode, stubbing only the loopback `fetch`:

```
$ bun run --cwd plugins/plugin-app-control test -- verification-room-bridge
 Test Files  1 passed (1)
      Tests  13 passed (13)
```
New cases: app pass → POSTs workdir (resolved from `params`) to `/api/apps/load-from-directory` + "built, verified, and registered. Reply 'launch notes'"; registration failure → honest message, no false launch promise; no-manifest (`registered: 0`) → honest message; plus the corrected retry test.

Verification: `bunx @biomejs/biome check` clean on all 4 files; package typechecks show only pre-existing unrelated worktree noise (missing `@types/node`/`@types/webxr`/`i18n/generated`), none in the changed files.

## Evidence I could NOT capture here (marked, not skipped)

- **Live create→verify→launch walkthrough / trajectory:** N/A in this environment — needs a running agent + coding-agent build + live model. The fix is proven at the two seams it changes (the registration route and the bridge's post-verify branch) with real fs + real service tests; the end-to-end path is `create → verifyApp pass → bridge POST → registry.register → listInstalledApps → launch resolves`.

## Scope / notes

- Not self-merging — leaving for review per the package discipline. The route change is additive (existing scan behavior preserved).

Closes #11954