### PR TITLE
style(cloud): format affiliate billing guard

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -107,7 +107,9 @@ interface BillableAffiliate {
   markupPercent: number;
 }
 
-async function resolveBillableAffiliate(context: BillingContext): Promise<BillableAffiliate | null> {
+async function resolveBillableAffiliate(
+  context: BillingContext,
+): Promise<BillableAffiliate | null> {
   if (!context.affiliateCode || context.organizationId === "anonymous") return null;
   const affiliate = await affiliatesRepository.getAffiliateCodeByCode(context.affiliateCode);
   if (!affiliate?.is_active) return null;

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -2056,7 +2056,9 @@ export class CreditsService {
         settlement_marker: RESERVATION_SETTLEMENT_MARKER,
         estimated_cost: estimatedCost,
         reserved_amount: reservedAmount,
-        ...(estimatedCostMultiplier !== 1 && { estimated_cost_multiplier: estimatedCostMultiplier }),
+        ...(estimatedCostMultiplier !== 1 && {
+          estimated_cost_multiplier: estimatedCostMultiplier,
+        }),
         ...(model && { model }),
       },
     });


### PR DESCRIPTION
Follow-up to #11976. The money fix merged before the Biome formatting correction landed, leaving two formatter violations on develop.

Validation:
- bunx @biomejs/biome check packages/cloud/shared/src/lib/services/ai-billing.ts packages/cloud/shared/src/lib/services/credits.ts packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
- git diff --check
- bun test packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts