### PR TITLE
fix: gate GENERATE_MEDIA on a usable media key so the agent never promises-then-fails (#11953)

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { type IAgentRuntime, type Memory, ModelType, ServiceType } from "@elizaos/core";
+import { CloudMediaGenerationService } from "../services/cloud-media-generation-service";
+import { generateMediaAction } from "./media-generation";
+
+interface RuntimeOptions {
+  cloudKey?: string | null;
+  imageModelRegistered?: boolean;
+}
+
+/**
+ * Builds a runtime whose media surface mirrors the cloud agent: plugin-elizacloud
+ * registers the ModelType.IMAGE handler statically (present even without a key),
+ * and ELIZAOS_CLOUD_API_KEY is the credential the image path authenticates with.
+ */
+function createRuntime(options: RuntimeOptions): {
+  runtime: IAgentRuntime;
+  service: CloudMediaGenerationService;
+} {
+  const { cloudKey = null, imageModelRegistered = true } = options;
+
+  const runtime = {
+    agentId: "agent-cloud-1",
+    getSetting: (key: string) => (key === "ELIZAOS_CLOUD_API_KEY" ? cloudKey : null),
+    getModel: (modelType: string) =>
+      modelType === ModelType.IMAGE && imageModelRegistered ? async () => [] : undefined,
+  } as unknown as IAgentRuntime & {
+    getService: (serviceType: string) => CloudMediaGenerationService | null;
+  };
+
+  const service = new CloudMediaGenerationService(runtime);
+  runtime.getService = (serviceType: string) =>
+    serviceType === ServiceType.MEDIA_GENERATION ? service : null;
+
+  return { runtime, service };
+}
+
+function imageMessage(text = "generate an image of a cat wearing a space helmet"): Memory {
+  return {
+    agentId: "agent-cloud-1",
+    entityId: "user-1",
+    roomId: "room-1",
+    content: { text },
+  } as Memory;
+}
+
+function runValidate(runtime: IAgentRuntime, message: Memory): Promise<boolean> {
+  const validate = generateMediaAction.validate;
+  if (!validate) {
+    throw new Error("generateMediaAction.validate is not defined");
+  }
+  return validate(runtime, message) as Promise<boolean>;
+}
+
+describe("CloudMediaGenerationService.canGenerateMedia (#11953 health gate)", () => {
+  test("true when the cloud media key is present and an IMAGE model is registered", () => {
+    const { service } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: true });
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(true);
+  });
+
+  test("false when the cloud media key is absent (registered handler is not enough)", () => {
+    const { service } = createRuntime({ cloudKey: null, imageModelRegistered: true });
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+  });
+
+  test("false when the cloud media key is empty/whitespace", () => {
+    const { service } = createRuntime({ cloudKey: "   ", imageModelRegistered: true });
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+  });
+
+  test("false when no IMAGE model handler is registered", () => {
+    const { service } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: false });
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+  });
+
+  test("false for non-image media types (cloud supports image only)", () => {
+    const { service } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: true });
+    expect(service.canGenerateMedia({ mediaType: "video" })).toBe(false);
+    expect(service.canGenerateMedia({ mediaType: "audio" })).toBe(false);
+  });
+});
+
+describe("GENERATE_MEDIA validate honesty gate (#11953)", () => {
+  test("withholds the tool when the cloud media key is missing — no false 'generating now'", async () => {
+    const { runtime } = createRuntime({ cloudKey: null, imageModelRegistered: true });
+    expect(await runValidate(runtime, imageMessage())).toBe(false);
+  });
+
+  test("exposes the tool when the cloud media key is present (unchanged behavior)", async () => {
+    const { runtime } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: true });
+    expect(await runValidate(runtime, imageMessage())).toBe(true);
+  });
+
+  test("withholds the tool when no IMAGE model handler is registered", async () => {
+    const { runtime } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: false });
+    expect(await runValidate(runtime, imageMessage())).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.ts
@@ -171,8 +171,25 @@ export const generateMediaAction: ActionWithParams = {
       return false;
     }
 
-    if (!getMediaService(runtime)) {
+    const service = getMediaService(runtime);
+    if (!service) {
       logger.warn("[GENERATE_MEDIA] Runtime missing media generation service");
+      return false;
+    }
+
+    // Honesty gate (#11953): only expose GENERATE_MEDIA when the backing media
+    // key + image model are actually usable. Otherwise the planner picks it, the
+    // agent acks "generating now", and generation fails with an expired/absent
+    // key — a promise-then-fail. Withholding the tool keeps the ack honest.
+    if (!(await service.canGenerateMedia({ mediaType }))) {
+      logger.debug(
+        {
+          src: "cloud:generate_media:validate",
+          agentId: runtime.agentId,
+          mediaType,
+        },
+        "[GENERATE_MEDIA] media backend not usable (missing cloud media key or image model) — tool withheld",
+      );
       return false;
     }
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-media-generation-service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-media-generation-service.ts
@@ -41,6 +41,33 @@ function imageMimeTypeFromUrl(url: string): string | undefined {
   }
 }
 
+// The cloud image path authenticates to Eliza Cloud with ELIZAOS_CLOUD_API_KEY
+// (plugin-elizacloud `getApiKey`). plugin-elizacloud registers the
+// ModelType.IMAGE handler statically — it is present even when the key is
+// absent — so a registered handler alone is NOT proof the backend can generate.
+// Without a usable key every image call 401s ("Invalid or expired API key"),
+// which is what turned image generation 0/7 live (#11953) with every failure
+// arriving AFTER a user-facing "generating now" ack. Gate availability on the
+// key so the planner never offers a tool that is guaranteed to fail.
+const CLOUD_MEDIA_API_KEY_SETTING = "ELIZAOS_CLOUD_API_KEY";
+
+function hasCloudMediaKey(runtime: IAgentRuntime): boolean {
+  const fromSetting = runtime.getSetting(CLOUD_MEDIA_API_KEY_SETTING);
+  if (typeof fromSetting === "string" && fromSetting.trim().length > 0) {
+    return true;
+  }
+  const env =
+    typeof globalThis === "object" && "process" in globalThis
+      ? (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+      : undefined;
+  const fromEnv = env?.[CLOUD_MEDIA_API_KEY_SETTING];
+  return typeof fromEnv === "string" && fromEnv.trim().length > 0;
+}
+
+function hasImageModelHandler(runtime: IAgentRuntime): boolean {
+  return typeof runtime.getModel(ModelType.IMAGE) === "function";
+}
+
 function normalizeImageResult(result: ImageResultLike | undefined): MediaGenerationResponse | null {
   if (!result) {
     return null;
@@ -103,6 +130,15 @@ export class CloudMediaGenerationService extends IMediaGenerationService {
   }
 
   async stop(): Promise<void> {}
+
+  override canGenerateMedia(
+    request: Pick<MediaGenerationRequest, "mediaType" | "audioKind">,
+  ): boolean {
+    if (request.mediaType !== "image") {
+      return false;
+    }
+    return hasImageModelHandler(this.runtime) && hasCloudMediaKey(this.runtime);
+  }
 
   async generateMedia(request: MediaGenerationRequest): Promise<MediaGenerationResponse> {
     if (request.mediaType !== "image") {


### PR DESCRIPTION
## The bug (promise-then-fail)

Cloud agent image generation went **0/7** live: `GENERATE_MEDIA` returned `Media generation failed: Invalid or expired API key`, but **every** failure arrived **after** a user-facing "generating now" ack. The UX was promise-then-fail. In one window the image tool wasn't even exposed to the planner yet the agent still acked "On it — generating…".

Root cause: the cloud media service (`CloudMediaGenerationService`) inherited `IMediaGenerationService.canGenerateMedia()`'s default `return true`, so `GENERATE_MEDIA.validate()` always exposed the tool. The planner picked it, the agent acked, then `runtime.useModel(ModelType.IMAGE)` → plugin-elizacloud → Eliza Cloud 401'd on a dead key. `plugin-elizacloud` registers the `ModelType.IMAGE` handler **statically** (present even with no key), so "handler is registered" was never proof the backend could actually generate.

## The fix (honesty gate)

Follows the convention the **core** `generateMediaAction` already uses (it gates `validate()` on `service.canGenerateMedia()`); the cloud action simply never did.

- `CloudMediaGenerationService` now **overrides `canGenerateMedia()`** to require **both** a registered `ModelType.IMAGE` handler **and** a present `ELIZAOS_CLOUD_API_KEY` (image-only; non-image → false).
- `generateMediaAction.validate()` **withholds the tool** when `canGenerateMedia()` is false (structured debug log), so the planner never offers — and the agent never acks — a tool backed by an absent/dead key. When usable, behavior is unchanged.

This also makes availability **deterministic**, which is what removes the "acked while the tool wasn't in the action set" inconsistency: the tool is present in the catalog iff the backend is usable, so the planner isn't primed to promise a tool that isn't really there.

### What I gate on (and why)

**Key presence** (`ELIZAOS_CLOUD_API_KEY`, the cloud media credential — distinct from the server-side fal/bitrouter provider secrets) **+ IMAGE handler registration.** This is free, synchronous, and deterministic — no live key, no paid generation, no flaky network probe in the 250ms `validate()` budget. A remote auth-probe was **not** cleanly feasible for free: the cloud `/models` list is `skipAuth` (public, can't validate a key), `POST /models/status` only reflects server provider-config presence (not key validity), and no client/key helper is exported cross-package.

### What remains operator (part 1 of #11953)

The **invalid-but-present-key** case (the actual live 0/7 was an *expired* key, and the failing secret is a server-side media-provider key the agent cannot inspect) still needs the **operator key rotation** — part 1 of the issue. This code fix fully closes the **missing/absent-key** promise-then-fail and the "no image tool exposed but agent acked" cases; part 1 closes the expired-key case.

## Test evidence

New `packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts` (`bun:test`), **8/8 pass**, full cloud-bootstrap dir **16/16 pass**:

- `canGenerateMedia`: true (key + handler); false (no key, even with handler); false (empty/whitespace key); false (no IMAGE handler); false (non-image video/audio).
- `validate`: **withheld when key missing** (no false "generating now"); exposed when key present (unchanged); withheld when no IMAGE handler.

`tsgo --noEmit` → 0 errors; `biome check` → clean, on all three touched files.

Refs #11953 (part 1 operator media-key rotation still needed to fully close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)