### PR TITLE
fix(cli-inference): declare Claude Agent SDK optional dependency

### DIFF
--- a/.github/issue-evidence/11962-chat-first-turn-pool-first-review.md
+++ b/.github/issue-evidence/11962-chat-first-turn-pool-first-review.md
@@ -1,0 +1,66 @@
+# PR 11962 Chat First-Turn Pool-First Review
+
+Date: 2026-07-03
+Branch: `fix/chat-sub-pool-first-warm-auth`
+PR: https://github.com/elizaOS/eliza/pull/11962
+Issue context: https://github.com/elizaOS/eliza/issues/11180
+
+## Scope Reviewed
+
+- `plugins/plugin-cli-inference`: first warm-session auth, account-pool selection, subprocess-only env, rotation-on-limit, SDK dependency metadata.
+- `packages/ui`: in-chat onboarding conductor, single action/send funnel, continuous chat first-run lock, tutorial handoff, local model auto-download trigger, model-download home widget.
+- `plugins/plugin-local-inference`: resumable model download job, installed-model registration, chat-readable local inference status.
+
+## Current UX
+
+- Chat is one persistent `ContinuousChatOverlay` mounted by the app shell. During first-run, `firstRunOpen` pins it open, disables text/attachment/voice/send controls, and makes collapse paths no-op.
+- First-run choices are in-band chat turns using the reserved `__first_run__:` prefix. `AppContext` classifies every action value before send: first-run choices go to the headless conductor, non-first-run text is dropped while onboarding is active, and stale first-run sentinels never reach the server.
+- Onboarding flow is chat-native: runtime choice (`cloud`, `local`, `remote`), provider choice for local (`on-device`, `elizacloud`, `other`), then tutorial choice (`start`, `skip`). Setup completion is delayed until the tutorial choice so the tour remains reachable.
+- Local all-local setup starts the local agent, persists first-run once, then enqueues `autoDownloadRecommendedLocalModelInBackground`. The user lands in chat immediately while the model download continues.
+- Model download visibility is handled by the home widget and local-inference chat status: queued/downloading/loading/failed/retry/ready are surfaced from the local inference hub and download stream.
+- Tutorial is a post-setup guided overlay that drives the real chat controls into known states, pre-fills one navigation request, listens for actual user actions, and can be rerun from Help.
+- PR 11962's chat-brain path selects a pooled `claude-sdk`/`codex-sdk` account before the first SDK attempt, strips competing ambient auth vars from the subprocess env, reuses the selected env by session key, and rotates on subscription limits before provider failover.
+
+## Ideal UX
+
+- The user should never bounce between a separate wizard and chat. Setup, auth, model download state, first message, and tutorial should all be controlled through the same chat surface.
+- During setup, the user should only be able to make valid setup choices. Free text, stale widgets, double taps, and tutorial events should not leak into agent chat or move the sheet out of the setup state.
+- A connected Claude/Codex subscription should serve the first chat turn. Ambient CLI credentials should be fallback only, not the primary route when a healthy app-connected account exists.
+- Local-first setup should land in the app quickly, show clear model download progress, allow retry/cancel/manage actions, and avoid blocking the tutorial or basic navigation.
+- Failures should be recoverable through explicit choices: retry, choose a different runtime/provider, or configure in Settings.
+
+## Delta Closed In This Pass
+
+- Rebased PR 11962 onto `origin/develop`.
+- Kept the PR's pool-first behavior and tests intact.
+- Fixed the remaining `plugin-cli-inference` package-suite failure by adding the lazily imported `@anthropic-ai/claude-agent-sdk` to `optionalDependencies` and updating `bun.lock`.
+- Removed unrelated `bun install` artifact churn before final validation.
+
+## Remaining Delta / Risks
+
+- The account-pool session key is the warm SDK session key (`model`, mode, system prompt hash for Claude; `model`, mode for Codex), not an explicit conversation id. That is acceptable for PR 11962's first-turn auth fix, but the ideal affinity model would use a true conversation/thread key once this plugin receives one reliably.
+- Root `bun run verify` is blocked before package checks by the repo-wide type-safety ratchet on current `origin/develop`: `as unknown as` is `81` current vs `75` baseline, and `?? 0` in core/agent/app-core is `377` current vs `375` baseline. This branch does not touch those production source files.
+- UI screenshots/video were not recaptured for this backend/package-metadata branch. No UI pixels changed. The first-run/download/tutorial journey was validated with targeted UI tests listed below. If a UI PR changes these surfaces, capture with `bun run --cwd packages/app audit:app` and `bun run test:e2e:record`.
+- Live Claude/Codex model trajectory was not captured in this pass because no live app account-pool subscription credentials were available in the workspace. The unit suite validates the credential-selection contract and verifies pooled tokens never enter `process.env`.
+
+## Validation Run
+
+- `bun install` after rebase completed, including dev artifact sync.
+- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install` after manifest edit updated only dependency state.
+- `bun run --cwd packages/core build` passed.
+- `bun run --cwd plugins/plugin-cli-inference test -- __tests__/account-rotation.test.ts` passed: 1 file, 21 tests.
+- `bun run --cwd plugins/plugin-cli-inference test` passed: 7 files, 94 tests.
+- `bun run --cwd plugins/plugin-cli-inference typecheck` passed.
+- `bun run --cwd plugins/plugin-cli-inference lint:check` passed.
+- `bun run --cwd plugins/plugin-cli-inference build` passed.
+- Targeted UI journey slice passed: 8 files, 73 tests.
+  - `src/App.chat-overlay-first-run.test.tsx`
+  - `src/first-run/use-first-run-conductor.test.ts`
+  - `src/first-run/use-first-run-conductor.fuzz.test.ts`
+  - `src/first-run/first-run-action-channel.test.ts`
+  - `src/first-run/auto-download-recommended.test.ts`
+  - `src/components/chat/widgets/model-download.test.tsx`
+  - `src/components/shell/ContinuousChatOverlay.firstrun.test.tsx`
+  - `src/components/pages/tutorial/tutorial-steps.test.ts`
+- `git diff --check` passed.
+- `bun run verify` failed at `audit:type-safety-ratchet` before reaching this package: unrelated `as unknown as` and `?? 0` baselines exceeded in current `origin/develop`.

--- a/bun.lock
+++ b/bun.lock
@@ -3179,6 +3179,7 @@
         "vitest": "^4.0.0",
       },
       "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.200",
         "@openai/codex-sdk": "0.80.0",
       },
       "peerDependencies": {
@@ -5713,6 +5714,24 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.200", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.200", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.200", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.200", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.200", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.200", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.200", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.200", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.200" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-o13TM3boFIJE4oZdQDFw5TQfiev1sBoxwzKM2QGj/NPtxriGTP0PKNAQsGZvTsiEOIIH5rzPr/H81xVkkAw23g=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.200", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8UzzInVdRPDNIOvrAxYbHHJD/u13WSBx9fvEeuZnsZ6rZh0qnSI1QwU8Due0V2+m+ZnT3cEonmXDvo2ee/icWg=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.200", "", { "os": "darwin", "cpu": "x64" }, "sha512-DCwlQoO8HWGuFElE+Q5pYkiBTalXjjMATRAxXyc94fI6m1ZRqyba66dOea+zTmzHPpOb6zSoHYNLiXy7EjNpcg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.200", "", { "os": "linux", "cpu": "arm64" }, "sha512-NAEonp086ZOsf+3o/9Y5JRclO6C4n4ceiSuCpSDV6SSUOLBmCRi7r/PJOoMsIWwMshC6fnnkDKZamTpHjr75eg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.200", "", { "os": "linux", "cpu": "arm64" }, "sha512-ak0l+zpz3dKPjnBegUhOs1Y5xFveEQ1AVqmq6s8Q7qd3vO4SrDPiUOpxRkjkqWyGD8r8w+ezG+unf3U9IZ6DRg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.200", "", { "os": "linux", "cpu": "x64" }, "sha512-0R/In8G4fZLFFEIA1SqXRRf9mzDGx7roHpMawNdTT1QlG4XftGTlKMxfukt/YcxwzsNPWg4hJSkEDxsb+3J6FA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.200", "", { "os": "linux", "cpu": "x64" }, "sha512-Sf5TTCO3bc5ty7FX5F19WT3xbtU+f1biYD9+dDJ7YHyYFWuiPlWcnCJ8El8RSwCTuvz3OexJLwCqGHRWOC3eBg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.200", "", { "os": "win32", "cpu": "arm64" }, "sha512-iJx10bdrk3afa/Oq9QHRh2HaINT/xnsm5OrFNNLbix2CoOEY5lA7f0lk/s0OMiWnfXdv5vvtADpgZ5tvUoQykA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.200", "", { "os": "win32", "cpu": "x64" }, "sha512-Mka8YDpDIiSJcbrdoBhzX3S0n9DYcoYaEjS7lxwX3GyPi5PvXV4UBuXzj++7ieV/KS4w32Sm3mHQRpeVwnJZ0A=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 
@@ -13879,6 +13898,8 @@
     "@achingbrain/nat-port-mapper/race-signal": ["race-signal@2.0.0", "", {}, "sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA=="],
 
     "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.103.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-1uG7RNgoHTUxzOXqSCODKt0UTVlxWiHk/2Tt2/uQJiPW7XzBeKVuJyd3Aw6T3LPyvZV/jDTnPLX7SaM70WLLjA=="],
 
     "@apidevtools/json-schema-ref-parser/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -48,6 +48,7 @@
     }
   },
   "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.200",
     "@openai/codex-sdk": "0.80.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up to #11962, which merged while I was validating the chat first-turn pool-first path.

## What changed
- Adds the lazily imported `@anthropic-ai/claude-agent-sdk` to `@elizaos/plugin-cli-inference` optionalDependencies.
- Updates `bun.lock` with the resolved optional SDK packages.
- Adds `.github/issue-evidence/11962-chat-first-turn-pool-first-review.md` documenting the chat/onboarding/setup/model-download/tutorial review and validation.

## Validation
- `bun run --cwd plugins/plugin-cli-inference test` - passed, 7 files / 94 tests.
- `bun run --cwd plugins/plugin-cli-inference typecheck` - passed.
- `bun run --cwd plugins/plugin-cli-inference lint:check` - passed.
- `bun run --cwd plugins/plugin-cli-inference build` - passed.
- Targeted UI journey slice - passed, 8 files / 73 tests.
- `git diff --check` - passed.
- `bun run verify` - blocked at current `origin/develop` type-safety ratchet before package checks: `as unknown as` 81 > 75 and `?? 0` 377 > 375. This branch does not touch those production source files.

## Screenshots / video / live trajectories
- N/A - this follow-up has no UI pixel changes; the first-run/download/tutorial journey was validated by the focused UI test slice above.
- Live Claude/Codex trajectory not captured here because no live app account-pool subscription credentials were available in the workspace. The rotation contract remains covered by #11962 tests, including first-turn pooled auth and no parent `process.env` leakage.