### PR TITLE
fix(cloud): keep Steward login on env tenant

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -734,6 +734,9 @@ jobs:
           VITE_ELIZA_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
           # Staging uses a separate Steward tenant (`elizacloud-staging`) so its
           # `magicLinkBaseUrl` redirects email callbacks back to staging.elizacloud.ai.
+          # The SPA reads the VITE_* key; keep NEXT_PUBLIC_* for legacy/shared
+          # callers that still run outside Vite's client env exposure.
+          VITE_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
           NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
           # Deployment-env signal baked into the SPA bundle. Read by isomorphic
           # cloud-shared code (e.g. agent flavor catalog) to branch on env.
@@ -1085,6 +1088,9 @@ jobs:
           NEXT_PUBLIC_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
           # Steward tenant pin (same tenant as the console; one identity across
           # the .elizacloud.ai cookie zone).
+          # The SPA reads the VITE_* key; keep NEXT_PUBLIC_* for legacy/shared
+          # callers that still run outside Vite's client env exposure.
+          VITE_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
           NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
           VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}

--- a/packages/app/wrangler.toml
+++ b/packages/app/wrangler.toml
@@ -22,6 +22,8 @@ compatibility_date = "2026-04-29"
 [vars]
 API_UPSTREAM = "https://api.elizacloud.ai"
 VITE_ELIZA_CLOUD_BASE = "https://www.elizacloud.ai"
+VITE_STEWARD_TENANT_ID = "elizacloud"
+NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud"
 # Per-env signal consumed by isomorphic code so the SPA can branch on
 # deployment env. Mirrors the cloud-frontend convention.
 VITE_ENVIRONMENT = "production"
@@ -33,5 +35,6 @@ VITE_ELIZA_CLOUD_BASE = "https://staging.elizacloud.ai"
 # with tenantId=elizacloud-staging and OAuth /authorize carries
 # tenant_id=elizacloud-staging (Steward resolves the OAuth tenant from the
 # query param, not the proxy X-Steward-Tenant header).
+VITE_STEWARD_TENANT_ID = "elizacloud-staging"
 NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud-staging"
 VITE_ENVIRONMENT = "staging"

--- a/packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts
@@ -18,12 +18,11 @@ import {
   type StewardPkcePair,
   storeStewardPkceVerifier,
 } from "@elizaos/shared/steward-session-client";
+import {
+  configuredStewardTenantId,
+  DEFAULT_STEWARD_TENANT_ID,
+} from "../../shell/steward-config";
 import { resolveBrowserStewardApiUrl } from "../../shell/steward-url";
-
-const DEFAULT_STEWARD_TENANT_ID =
-  (typeof process !== "undefined"
-    ? process.env.NEXT_PUBLIC_STEWARD_TENANT_ID
-    : undefined) || "elizacloud";
 
 export type { StewardOAuthProvider, StewardPkcePair };
 
@@ -45,7 +44,9 @@ export function buildStewardOAuthRedirectUri(origin: string): string {
 }
 
 export function resolveStewardOAuthTenantId(tenantId?: string | null): string {
-  return tenantId?.trim() || DEFAULT_STEWARD_TENANT_ID;
+  return (
+    tenantId?.trim() || configuredStewardTenantId(DEFAULT_STEWARD_TENANT_ID)
+  );
 }
 
 export function buildStewardOAuthAuthorizeUrl(

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -36,6 +36,10 @@ import { Alert, AlertDescription } from "../../../../components/primitives";
 import { Button } from "../../../../components/ui/button";
 import { Input } from "../../../../components/ui/input";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
+import {
+  configuredStewardTenantId,
+  DEFAULT_STEWARD_TENANT_ID,
+} from "../../../shell/steward-config";
 import { resolveBrowserStewardApiUrl } from "../../../shell/steward-url";
 import { getErrorMessage } from "../../lib/error-message";
 import {
@@ -71,10 +75,7 @@ const Github = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const STEWARD_TENANT_ID =
-  (typeof process !== "undefined"
-    ? process.env.NEXT_PUBLIC_STEWARD_TENANT_ID
-    : undefined) || "elizacloud";
+const STEWARD_TENANT_ID = configuredStewardTenantId(DEFAULT_STEWARD_TENANT_ID);
 const PLAYWRIGHT_TEST_AUTH_ENABLED =
   import.meta.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
   (typeof process !== "undefined" &&

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -14,6 +14,10 @@
 import { lazy, type ReactNode, Suspense, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { isPlaceholderValue, readStoredToken } from "./StewardProviderShared";
+import {
+  configuredStewardTenantId,
+  DEFAULT_STEWARD_TENANT_ID,
+} from "./steward-config";
 import { resolveBrowserStewardApiUrl } from "./steward-url";
 
 export {
@@ -153,10 +157,7 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   const playwrightTestAuthEnabled = isPlaywrightTestAuthEnabled();
 
   const apiUrl = resolveBrowserStewardApiUrl();
-  const tenantId =
-    typeof process !== "undefined"
-      ? process.env.NEXT_PUBLIC_STEWARD_TENANT_ID
-      : undefined;
+  const tenantId = configuredStewardTenantId(DEFAULT_STEWARD_TENANT_ID);
   const hasValidUrl = !isPlaceholderValue(apiUrl);
 
   useEffect(() => {

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -48,8 +48,34 @@ describe("Steward auth endpoint resolution", () => {
     );
   });
 
+  it("routes the staging app host to the api-staging worker directly", async () => {
+    setHostname("app-staging.elizacloud.ai");
+    const { configuredSessionEndpoint, configuredRefreshEndpoint } =
+      await loadEndpoints();
+
+    expect(configuredSessionEndpoint()).toBe(
+      "https://api-staging.elizacloud.ai/api/auth/steward-session",
+    );
+    expect(configuredRefreshEndpoint()).toBe(
+      "https://api-staging.elizacloud.ai/api/auth/steward-refresh",
+    );
+  });
+
   it("routes prod to the prod api worker directly", async () => {
     setHostname("elizacloud.ai");
+    const { configuredSessionEndpoint, configuredRefreshEndpoint } =
+      await loadEndpoints();
+
+    expect(configuredSessionEndpoint()).toBe(
+      "https://api.elizacloud.ai/api/auth/steward-session",
+    );
+    expect(configuredRefreshEndpoint()).toBe(
+      "https://api.elizacloud.ai/api/auth/steward-refresh",
+    );
+  });
+
+  it("routes the prod app host to the prod api worker directly", async () => {
+    setHostname("app.elizacloud.ai");
     const { configuredSessionEndpoint, configuredRefreshEndpoint } =
       await loadEndpoints();
 

--- a/packages/ui/src/cloud/shell/steward-config.test.ts
+++ b/packages/ui/src/cloud/shell/steward-config.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  configuredStewardApiUrlOverride,
+  configuredStewardTenantId,
+} from "./steward-config";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("configuredStewardTenantId", () => {
+  it("prefers the Vite-exposed Steward tenant for browser bundles", () => {
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", " elizacloud-staging ");
+    vi.stubEnv("NEXT_PUBLIC_STEWARD_TENANT_ID", "elizacloud");
+
+    expect(configuredStewardTenantId("elizacloud")).toBe("elizacloud-staging");
+  });
+
+  it("keeps the legacy NEXT_PUBLIC tenant as a fallback", () => {
+    vi.stubEnv("NEXT_PUBLIC_STEWARD_TENANT_ID", "elizacloud-staging");
+
+    expect(configuredStewardTenantId("elizacloud")).toBe("elizacloud-staging");
+  });
+
+  it("uses the fallback when the configured tenant is missing or placeholder", () => {
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "your_steward_tenant_id");
+
+    expect(configuredStewardTenantId("elizacloud")).toBe("elizacloud");
+  });
+});
+
+describe("configuredStewardApiUrlOverride", () => {
+  it("prefers the Vite-exposed Steward API override", () => {
+    vi.stubEnv(
+      "VITE_STEWARD_API_URL",
+      " https://api-staging.elizacloud.ai/steward ",
+    );
+    vi.stubEnv("NEXT_PUBLIC_STEWARD_API_URL", "https://api.elizacloud.ai");
+
+    expect(configuredStewardApiUrlOverride()).toBe(
+      "https://api-staging.elizacloud.ai/steward",
+    );
+  });
+
+  it("ignores placeholder Steward API overrides", () => {
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://your_steward_api_url");
+
+    expect(configuredStewardApiUrlOverride()).toBeUndefined();
+  });
+});

--- a/packages/ui/src/cloud/shell/steward-config.ts
+++ b/packages/ui/src/cloud/shell/steward-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Browser-safe Steward configuration.
+ *
+ * Vite only exposes client env vars through literal `import.meta.env.*` reads.
+ * Keep these as explicit property accesses so production bundles can inline the
+ * staging tenant instead of falling back to the prod default.
+ */
+
+export const DEFAULT_STEWARD_TENANT_ID = "elizacloud";
+
+function configuredValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const normalized = trimmed.toLowerCase();
+  if (
+    normalized.includes("your_steward_") ||
+    normalized.includes("your-steward-") ||
+    normalized.includes("replace_with") ||
+    normalized.includes("placeholder")
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+export function configuredStewardTenantId(fallback: string): string;
+export function configuredStewardTenantId(
+  fallback?: string,
+): string | undefined;
+export function configuredStewardTenantId(
+  fallback?: string,
+): string | undefined {
+  return (
+    configuredValue(import.meta.env?.VITE_STEWARD_TENANT_ID) ??
+    configuredValue(import.meta.env?.NEXT_PUBLIC_STEWARD_TENANT_ID) ??
+    configuredValue(
+      typeof process !== "undefined"
+        ? process.env.NEXT_PUBLIC_STEWARD_TENANT_ID
+        : undefined,
+    ) ??
+    configuredValue(fallback)
+  );
+}
+
+export function configuredStewardApiUrlOverride(): string | undefined {
+  return (
+    configuredValue(import.meta.env?.VITE_STEWARD_API_URL) ??
+    configuredValue(import.meta.env?.NEXT_PUBLIC_STEWARD_API_URL) ??
+    configuredValue(
+      typeof process !== "undefined"
+        ? process.env.NEXT_PUBLIC_STEWARD_API_URL
+        : undefined,
+    )
+  );
+}

--- a/packages/ui/src/cloud/shell/steward-url.ts
+++ b/packages/ui/src/cloud/shell/steward-url.ts
@@ -9,14 +9,12 @@
  * CORS + credentials).
  */
 
+import { configuredStewardApiUrlOverride } from "./steward-config";
+
 const STEWARD_PREFIX = "/steward";
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
-}
-
-function isUsableUrl(value: string | undefined): value is string {
-  return Boolean(value?.trim() && !value.includes("your_steward_"));
 }
 
 function getBrowserOrigin(): string | undefined {
@@ -44,6 +42,8 @@ function getBrowserHostname(): string | undefined {
  * the co-hosted proxy.
  */
 export const ELIZA_CLOUD_DIRECT_API_BY_HOST: Record<string, string> = {
+  "app.elizacloud.ai": "https://api.elizacloud.ai",
+  "app-staging.elizacloud.ai": "https://api-staging.elizacloud.ai",
   "elizacloud.ai": "https://api.elizacloud.ai",
   "www.elizacloud.ai": "https://api.elizacloud.ai",
   "dev.elizacloud.ai": "https://api.elizacloud.ai",
@@ -51,13 +51,8 @@ export const ELIZA_CLOUD_DIRECT_API_BY_HOST: Record<string, string> = {
 };
 
 export function resolveBrowserStewardApiUrl(origin?: string): string {
-  // Vite inlines this only via the literal property name.
-  const override =
-    import.meta.env?.NEXT_PUBLIC_STEWARD_API_URL ??
-    (typeof process !== "undefined"
-      ? process.env.NEXT_PUBLIC_STEWARD_API_URL
-      : undefined);
-  if (isUsableUrl(override)) {
+  const override = configuredStewardApiUrlOverride();
+  if (override) {
     return trimTrailingSlash(override);
   }
 


### PR DESCRIPTION
## Summary
- Fix Steward tenant resolution in the browser by reading the Vite-exposed `VITE_STEWARD_TENANT_ID` before legacy `NEXT_PUBLIC_*` fallbacks.
- Add `app.elizacloud.ai` and `app-staging.elizacloud.ai` to the direct browser host-to-API map so session and refresh calls bypass stale Pages proxy paths.
- Add deployment env parity for console/app builds and wrangler preview vars so staging bundles get `elizacloud-staging` baked in.

## Verification
- `bun run --cwd packages/ui test -- src/cloud/shell/steward-config.test.ts src/cloud/shell/StewardProviderShared.test.ts src/cloud/shell/StewardProvider.test.tsx` (19 tests passed)
- `bunx biome check packages/ui/src/cloud/shell/steward-config.ts packages/ui/src/cloud/shell/steward-config.test.ts packages/ui/src/cloud/shell/steward-url.ts packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts packages/ui/src/cloud/shell/StewardProvider.tsx packages/ui/src/cloud/shell/StewardProviderShared.test.ts`
- Staging env web build: `bun run --cwd packages/app build:web` with `VITE_STEWARD_TENANT_ID=elizacloud-staging`, `VITE_API_URL=https://api-staging.elizacloud.ai`, `VITE_ELIZA_APP_URL=https://app-staging.elizacloud.ai` (build + chunk safety passed)
- Bundle inspection: emitted `index-DGCBAZIZ.js` contains `VITE_STEWARD_TENANT_ID:\"elizacloud-staging\"`, `app-staging.elizacloud.ai`, and `https://api-staging.elizacloud.ai`; it does not contain `NEXT_PUBLIC_STEWARD_TENANT_ID`.

## Evidence / N/A
- Real-LLM trajectories: N/A - no agent/action/prompt/model behavior changed.
- Screenshots/video: N/A - no visual UI behavior changed; this is auth config/routing and deployment env plumbing.
- Backend/frontend logs: N/A locally - the live login-loop verification needs deployment of this branch to staging/prod.
