### PR TITLE
fix(meetings): wire plugin auto-enable through the package manifest (#11856)

### DIFF
--- a/plugins/plugin-meetings/AGENTS.md
+++ b/plugins/plugin-meetings/AGENTS.md
@@ -85,10 +85,14 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 | `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in (`autoEnable.shouldEnable`) because the bots need a Chromium
-binary on the host — matching the env-gated connector plugin pattern. The
-predicate ORs the env keys but **vetoes auto-enable on mobile**
-(`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
+The plugin is opt-in because the bots need a Chromium binary on the host —
+matching the env-gated connector plugin pattern. Auto-enable is wired through the
+runtime's manifest mechanism: `package.json`'s `elizaos.plugin.autoEnableModule`
+points at the light root module [`auto-enable.ts`](./auto-enable.ts), whose
+`shouldEnable(ctx)` the resolver runs at boot (this manifest module — not the
+`Plugin.autoEnable` field — is what the loader reads). The predicate ORs the env
+keys but **vetoes auto-enable on mobile** (`ctx.isNativePlatform`, i.e.
+`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
 sandbox, so a set env key must not enable the plugin there.
 
 ## Platform support & deployment

--- a/plugins/plugin-meetings/CLAUDE.md
+++ b/plugins/plugin-meetings/CLAUDE.md
@@ -85,10 +85,14 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 | `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in (`autoEnable.shouldEnable`) because the bots need a Chromium
-binary on the host — matching the env-gated connector plugin pattern. The
-predicate ORs the env keys but **vetoes auto-enable on mobile**
-(`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
+The plugin is opt-in because the bots need a Chromium binary on the host —
+matching the env-gated connector plugin pattern. Auto-enable is wired through the
+runtime's manifest mechanism: `package.json`'s `elizaos.plugin.autoEnableModule`
+points at the light root module [`auto-enable.ts`](./auto-enable.ts), whose
+`shouldEnable(ctx)` the resolver runs at boot (this manifest module — not the
+`Plugin.autoEnable` field — is what the loader reads). The predicate ORs the env
+keys but **vetoes auto-enable on mobile** (`ctx.isNativePlatform`, i.e.
+`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
 sandbox, so a set env key must not enable the plugin there.
 
 ## Platform support & deployment

--- a/plugins/plugin-meetings/README.md
+++ b/plugins/plugin-meetings/README.md
@@ -85,11 +85,16 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 | `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in (`autoEnable.shouldEnable`) because the bots need a Chromium
-binary on the host — matching the env-gated connector plugin pattern. The
-predicate ORs the env keys but **vetoes auto-enable on mobile**
-(`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
-sandbox, so a set env key must not enable the plugin there.
+The plugin is opt-in because the bots need a Chromium binary on the host —
+matching the env-gated connector plugin pattern. Auto-enable is wired through
+the runtime's manifest mechanism: `package.json`'s
+`elizaos.plugin.autoEnableModule` points at the light root module
+[`auto-enable.ts`](./auto-enable.ts), whose `shouldEnable(ctx)` the resolver
+runs at boot (this manifest module — not the `Plugin.autoEnable` field — is what
+the loader reads). The predicate ORs the env keys but **vetoes auto-enable on
+mobile** (`ctx.isNativePlatform`, i.e. `ELIZA_PLATFORM=android|ios`): browser
+automation cannot run in an Android/iOS sandbox, so a set env key must not enable
+the plugin there — mobile users get meeting transcripts via a cloud-hosted agent.
 
 ## Platform support & deployment
 

--- a/plugins/plugin-meetings/auto-enable.ts
+++ b/plugins/plugin-meetings/auto-enable.ts
@@ -1,0 +1,30 @@
+// Auto-enable check for @elizaos/plugin-meetings.
+//
+// Plugin manifest entry-point — referenced by package.json's
+// `elizaos.plugin.autoEnableModule`. This is the ONLY mechanism the runtime
+// auto-enable engine reads: `packages/agent/src/runtime/plugin-resolver.ts`
+// walks each plugin's package.json and runs `autoEnableModule.shouldEnable(ctx)`
+// ("Auto-enable is sourced exclusively from per-plugin manifests … no central
+// map exists"). Keep this module light: env reads only, no service init, no
+// transitive imports of the plugin runtime (Playwright / the browser bots) — the
+// engine dynamic-imports dozens of these per boot.
+import type { PluginAutoEnableContext } from "@elizaos/core";
+
+/**
+ * The browser meeting bots need a Chromium binary on the host, so the plugin is
+ * opt-in: it auto-enables only when the operator flags it via
+ * `ELIZA_MEETINGS_ENABLED` or points at a Chromium binary via
+ * `ELIZA_MEETINGS_CHROMIUM_PATH`.
+ *
+ * The mobile veto keeps the flag honest: browser automation cannot run inside an
+ * Android / iOS app sandbox, so even a set env key must NOT auto-enable there
+ * (mobile users get meeting transcripts via a cloud-hosted agent — see
+ * docs/DEPLOYMENT.md). `ctx.isNativePlatform` is the engine's own
+ * `isMobilePlatform(process.env)` probe, so the veto needs no runtime import.
+ */
+export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
+  if (ctx.isNativePlatform) return false;
+  const enabled = ctx.env.ELIZA_MEETINGS_ENABLED?.trim();
+  const chromiumPath = ctx.env.ELIZA_MEETINGS_CHROMIUM_PATH?.trim();
+  return Boolean(enabled || chromiumPath);
+}

--- a/plugins/plugin-meetings/package.json
+++ b/plugins/plugin-meetings/package.json
@@ -30,8 +30,17 @@
   },
   "files": [
     "dist",
+    "auto-enable.ts",
     "NOTICE"
   ],
+  "elizaos": {
+    "plugin": {
+      "autoEnableModule": "./auto-enable.ts",
+      "capabilities": [
+        "meeting-transcription"
+      ]
+    }
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck",
     "test": "vitest run",

--- a/plugins/plugin-meetings/src/auto-enable.test.ts
+++ b/plugins/plugin-meetings/src/auto-enable.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import type { PluginAutoEnableContext } from "@elizaos/core";
+import { isMobilePlatform } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { shouldEnable } from "../auto-enable.ts";
+import { meetingsPlugin } from "./index.js";
+
+// The auto-enable engine loads a plugin ONLY when its package.json declares
+// `elizaos.plugin.autoEnableModule` and that module exports `shouldEnable(ctx)`
+// (packages/agent/src/runtime/plugin-resolver.ts — "sourced exclusively from
+// per-plugin manifests"). The runtime `Plugin.autoEnable` field is NOT read by
+// the loader. These tests guard the manifest wiring so the plugin can never
+// regress back to being undiscoverable.
+
+function ctx(
+  env: Record<string, string | undefined>,
+  isNativePlatform = false,
+): PluginAutoEnableContext {
+  return { env, config: {}, isNativePlatform };
+}
+
+describe("plugin-meetings auto-enable manifest wiring", () => {
+  it("declares autoEnableModule pointing at the shipped root module", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    );
+    expect(pkg.elizaos?.plugin?.autoEnableModule).toBe("./auto-enable.ts");
+    // The referenced module must ship (files) and export shouldEnable — the
+    // import at the top of this file already proves the export exists.
+    expect(pkg.files).toContain("auto-enable.ts");
+    expect(typeof shouldEnable).toBe("function");
+  });
+});
+
+describe("plugin-meetings shouldEnable", () => {
+  it("does NOT enable when no opt-in env is set", () => {
+    expect(shouldEnable(ctx({}))).toBe(false);
+    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "   " }))).toBe(false);
+  });
+
+  it("enables on the explicit opt-in flag", () => {
+    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "1" }))).toBe(true);
+    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "true" }))).toBe(true);
+  });
+
+  it("enables when a Chromium binary is provided", () => {
+    expect(
+      shouldEnable(ctx({ ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium" })),
+    ).toBe(true);
+  });
+
+  it("vetoes mobile even when the opt-in flag is set (no browser sandbox)", () => {
+    expect(
+      shouldEnable(
+        ctx(
+          {
+            ELIZA_MEETINGS_ENABLED: "1",
+            ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium",
+          },
+          true,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("stays in lockstep with the declarative Plugin.autoEnable predicate", () => {
+    const envs: Record<string, string | undefined>[] = [
+      {},
+      { ELIZA_MEETINGS_ENABLED: "1" },
+      { ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium" },
+      { ELIZA_PLATFORM: "ios", ELIZA_MEETINGS_ENABLED: "1" },
+      { ELIZA_PLATFORM: "android", ELIZA_MEETINGS_CHROMIUM_PATH: "/x" },
+    ];
+    for (const env of envs) {
+      const viaModule = shouldEnable(ctx(env, isMobilePlatform(env)));
+      const viaField = meetingsPlugin.autoEnable?.shouldEnable?.(env, {});
+      expect(viaModule).toBe(viaField);
+    }
+  });
+});

--- a/plugins/plugin-meetings/src/platforms/msteams/strategies.ts
+++ b/plugins/plugin-meetings/src/platforms/msteams/strategies.ts
@@ -9,6 +9,7 @@ import { logger } from "@elizaos/core";
 import type { Page } from "playwright-core";
 import type { MeetingEndReason } from "@elizaos/shared";
 import type { MeetingBotSession } from "../../types.js";
+import { anySelectorVisible } from "../shared/selectors.js";
 import type { AdmissionOutcome, PlatformStrategies } from "../shared/strategy.js";
 import { TeamsCaptionRouter } from "./caption-router.js";
 import {
@@ -34,18 +35,6 @@ import {
 
 const TAG = "[MsTeamsAdapter]";
 
-async function anyVisible(page: Page, selectors: string[]): Promise<boolean> {
-  for (const selector of selectors) {
-    const visible = await page
-      .locator(selector)
-      .first()
-      .isVisible()
-      .catch(() => false);
-    if (visible) return true;
-  }
-  return false;
-}
-
 async function isAdmitted(page: Page): Promise<boolean> {
   for (const selector of teamsInitialAdmissionIndicators) {
     const element = page.locator(selector).first();
@@ -58,14 +47,14 @@ async function isAdmitted(page: Page): Promise<boolean> {
 }
 
 async function isInWaitingRoom(page: Page): Promise<boolean> {
-  if (await anyVisible(page, teamsWaitingRoomIndicators)) return true;
+  if (await anySelectorVisible(page, teamsWaitingRoomIndicators)) return true;
   // "Join now" still visible means the prejoin never completed — treat as
   // pre-admission, not failure.
-  return anyVisible(page, ['button:has-text("Join now")']);
+  return anySelectorVisible(page, ['button:has-text("Join now")']);
 }
 
 async function isRejected(page: Page): Promise<boolean> {
-  return anyVisible(page, teamsRejectionIndicators);
+  return anySelectorVisible(page, teamsRejectionIndicators);
 }
 
 /**


### PR DESCRIPTION
Fast-follow fix for the meeting-transcription plugin merged in #11860 (closed #11856).

## The bug (shipped in #11860, live on `develop`)

`@elizaos/plugin-meetings` declared its opt-in condition on the runtime
`Plugin.autoEnable.shouldEnable` field. But the resolver sources auto-enable
**exclusively** from each plugin's `package.json` `elizaos.plugin.autoEnableModule`
— see `packages/agent/src/runtime/plugin-resolver.ts`:

> "Auto-enable is sourced exclusively from per-plugin manifests: walk plugin and
> app package.json files on disk and run each plugin's
> `autoEnableModule.shouldEnable(ctx)`. Each plugin owns its own enable conditions
> in `auto-enable.ts` — no central map exists."

The runtime `Plugin.autoEnable` field has **zero** loader consumers repo-wide, and
`plugin-meetings/package.json` had no `elizaos` block. Net effect on `develop`
today: the plugin is discovered as a candidate but **never enabled** —
`ELIZA_MEETINGS_ENABLED=1` does nothing, `MeetingService` never starts, and every
`/api/meetings*` route / `JOIN_MEETING`·`LEAVE_MEETING`·`GET_MEETING_TRANSCRIPT`
action / `ACTIVE_MEETINGS` provider is unreachable. Full surface, zero reachability.

## The fix (mirrors the established `plugin-suno` pattern)

- New root [`auto-enable.ts`](plugins/plugin-meetings/auto-enable.ts) exporting a
  light `shouldEnable(ctx)` — env reads only, no runtime imports; the mobile veto
  uses `ctx.isNativePlatform` (the engine builds it from `isMobilePlatform(process.env)`).
- `package.json`: `elizaos.plugin.autoEnableModule` + `files` entry so the module ships.
- Corrected README/CLAUDE/AGENTS, which described the dead field as the mechanism.
- Drive-by dedupe: MS Teams strategies now reuse the shared `anySelectorVisible`
  instead of a byte-identical local copy.

## Evidence

**Unit test** (`src/auto-enable.test.ts`, 6 cases — opt-in flag, Chromium path,
mobile veto, whitespace trim, manifest-wiring assertion, lockstep with the
declarative predicate): `6 passed`.

**Real-engine end-to-end** — drove the actual `evaluatePluginManifest(candidate, ctx)`
against the plugin's real packageRoot:

| env | isNativePlatform | `verdict.enabled` |
|---|---|---|
| _(none)_ | false | `false` |
| `ELIZA_MEETINGS_ENABLED=1` | false | **`true`** |
| `ELIZA_MEETINGS_CHROMIUM_PATH=…` | false | **`true`** |
| `ELIZA_MEETINGS_ENABLED=1` | true (mobile) | `false` (veto) |

All with `error: null` and `capabilities: ["meeting-transcription"]` surfaced —
i.e. the `.ts` manifest module loads and runs cleanly through the resolver's
dynamic-import path.

**Reachability chain confirmed:** `discoverPluginCandidates()` scans
`node_modules/@elizaos/*` + workspace `plugins/*`, so plugin-meetings is a
candidate wherever it's present; this manifest wiring is what then enables it.

Full plugin suite: `192 passed` (was 186 + 6 new). `typecheck`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)