### PR TITLE
fix(cloud): narrow affiliate before applying markup

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -297,7 +297,7 @@ export async function billUsage(
   const affiliate = await resolveBillableAffiliate(context);
   const affiliateEarnings = affiliate ? preAffiliateTotalCost * affiliate.markupPercent : 0;
 
-  if (affiliateEarnings > 0) {
+  if (affiliate && affiliateEarnings > 0) {
     inputCost += inputCost * affiliate.markupPercent;
     outputCost += outputCost * affiliate.markupPercent;
     totalCost += affiliateEarnings;


### PR DESCRIPTION
## Summary
- fixes the cloud-shared typecheck regression left after #11976/#11984 by explicitly narrowing `affiliate` before reading `markupPercent`
- keeps the collected-affiliate earnings behavior unchanged

Refs #11972

## Testing
- On `origin/develop`: `bun run --cwd packages/cloud/shared typecheck` fails with TS18047 at `ai-billing.ts`
- On this fix: `bunx biome check packages/cloud/shared/src/lib/services/ai-billing.ts packages/cloud/shared/src/lib/services/credits.ts packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts`
- On this fix: `bun run --cwd packages/cloud/shared typecheck`
- On this fix: `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts`
