### PR TITLE
fix(orchestrator): revoke model leases on native terminal paths

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts
@@ -378,6 +378,60 @@ describe("revoke on task end — all three terminal exit paths + teardown", () =
     await service.stop();
   });
 
+  it("cancelSession (real native cancel path) revokes the lease and kills model access", async () => {
+    enableGateway();
+    const gateway = new FakeGateway();
+    configureModelGatewayLease({ broker: gateway.broker() });
+    const { service, sessionId, env } = await spawnWith();
+    const token = env.OPENAI_API_KEY ?? "";
+    expect(gateway.callModel(token)).toBe(200);
+
+    await service.cancelSession(sessionId);
+    await settle();
+
+    expect(gateway.revoked).toEqual(["lease-1"]);
+    expect(gateway.callModel(token)).toBe(401);
+    await service.stop();
+  });
+
+  it("native prompt cancellation revokes the lease even without a session event", async () => {
+    enableGateway();
+    const gateway = new FakeGateway();
+    configureModelGatewayLease({ broker: gateway.broker() });
+    const { service, sessionId, env } = await spawnWith();
+    const token = env.OPENAI_API_KEY ?? "";
+    firstNativeClient().prompt.mockResolvedValueOnce({
+      stopReason: "cancelled",
+    });
+    expect(gateway.callModel(token)).toBe(200);
+
+    const result = await service.sendToSession(sessionId, "cancel me");
+    await settle();
+
+    expect(result.stopReason).toBe("cancelled");
+    expect(gateway.revoked).toEqual(["lease-1"]);
+    expect(gateway.callModel(token)).toBe(401);
+    await service.stop();
+  });
+
+  it("native prompt error with no output revokes the lease even without a session event", async () => {
+    enableGateway();
+    const gateway = new FakeGateway();
+    configureModelGatewayLease({ broker: gateway.broker() });
+    const { service, sessionId, env } = await spawnWith();
+    const token = env.OPENAI_API_KEY ?? "";
+    firstNativeClient().prompt.mockResolvedValueOnce({ stopReason: "error" });
+    expect(gateway.callModel(token)).toBe(200);
+
+    const result = await service.sendToSession(sessionId, "fail");
+    await settle();
+
+    expect(result.stopReason).toBe("error");
+    expect(gateway.revoked).toEqual(["lease-1"]);
+    expect(gateway.callModel(token)).toBe(401);
+    await service.stop();
+  });
+
   it("service.stop() revokes leases still live at teardown", async () => {
     enableGateway();
     const gateway = new FakeGateway();

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -979,6 +979,7 @@ export class AcpService extends Service {
         session.acpxSessionId ?? session.agentSessionId ?? session.id,
       );
       await this.store.updateStatus(sessionId, "cancelled");
+      void this.revokeModelLease(sessionId, "cancelSession:native");
       return;
     }
     const active = this.activeProcesses.get(sessionId);
@@ -999,6 +1000,7 @@ export class AcpService extends Service {
       });
     }
     await this.store.updateStatus(sessionId, "cancelled");
+    void this.revokeModelLease(sessionId, "cancelSession");
   }
 
   async closeSession(sessionId: string): Promise<void> {
@@ -1565,8 +1567,10 @@ export class AcpService extends Service {
       };
       if (stopped) {
         await this.store.updateStatus(session.id, "stopped");
+        void this.revokeModelLease(session.id, "native_prompt:stopped");
       } else if (cancelled) {
         await this.store.updateStatus(session.id, "cancelled");
+        void this.revokeModelLease(session.id, "native_prompt:cancelled");
       } else if (finalStopReason === "error" && !finalText?.trim()) {
         // Mirror the handleAcpEvent guard: a stopReason-error session that still
         // captured a real deliverable is relayed as a completion, so don't mark
@@ -1577,6 +1581,7 @@ export class AcpService extends Service {
           "errored",
           "ACP prompt ended with stopReason error",
         );
+        void this.revokeModelLease(session.id, "native_prompt:error");
       } else {
         await this.store.update(session.id, {
           status: "ready",
@@ -1588,6 +1593,7 @@ export class AcpService extends Service {
       const message = errorMessage(err);
       if (this.nativeStoppingSessionIds.has(session.id)) {
         await this.store.updateStatus(session.id, "stopped");
+        void this.revokeModelLease(session.id, "native_prompt:stopped");
         return {
           sessionId: session.id,
           response: finalText,
@@ -1600,6 +1606,7 @@ export class AcpService extends Service {
       }
       if (this.nativeCancelledPromptSessionIds.has(session.id)) {
         await this.store.updateStatus(session.id, "cancelled");
+        void this.revokeModelLease(session.id, "native_prompt:cancelled");
         return {
           sessionId: session.id,
           response: finalText,


### PR DESCRIPTION
## Summary
- revoke per-spawn model gateway leases when native cancellation marks a session terminal without going through `emitSessionEvent`
- revoke on native prompt stopped/cancelled/error-without-output paths so leaked child env tokens die immediately instead of waiting for TTL/service teardown
- add regressions for `cancelSession`, native prompt cancelled, and native prompt error result paths

Follow-up to #11979.

## Testing
- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/model-gateway-lease.test.ts`
  - 1 file passed, 19 tests passed
- `git diff --check`