### PR TITLE
fix(openai): preserve free-form record-arg intent when closing open maps (#11249)

### DIFF
--- a/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
@@ -152,3 +152,104 @@ describe("sanitizeJsonSchema strict-constraint stripping", () => {
     expect(new Set(out.required as string[])).toEqual(new Set(["a", "b"]));
   });
 });
+
+/**
+ * A DECLARED free-form/open map (`additionalProperties: {type:"string"}` or
+ * `true`) must still be closed on the wire (strict providers 400 on open maps,
+ * and strictness is proxy-blind), but the intent must survive in `description`
+ * instead of being lost silently, so the map arg no longer always arrives empty
+ * (#11249).
+ */
+describe("sanitizeJsonSchema free-form record args (#11249)", () => {
+  it("closes a schema-valued additionalProperties but folds the intent into description", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        customFields: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      },
+      required: ["customFields"],
+      additionalProperties: false,
+    });
+    const prop = (out.properties as Record<string, Record<string, unknown>>).customFields;
+    // Still closed on the wire — no strict-grammar 400.
+    expect(prop.additionalProperties).toBe(false);
+    // Intent preserved (with the value type), not lost silently.
+    expect(typeof prop.description).toBe("string");
+    expect(prop.description as string).toContain("string");
+    expect(prop.description as string).toMatch(/key\/value pairs/);
+  });
+
+  it("closes additionalProperties:true and records the open-map intent", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        attributes: { type: "object", additionalProperties: true },
+      },
+      required: ["attributes"],
+      additionalProperties: false,
+    });
+    const prop = (out.properties as Record<string, Record<string, unknown>>).attributes;
+    expect(prop.additionalProperties).toBe(false);
+    expect(prop.description as string).toMatch(/key\/value pairs/);
+  });
+
+  it("does NOT add a hint to a plain object that never declared additionalProperties", () => {
+    const out = sanitize({
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    });
+    // Closed as before, but no spurious open-map hint on a normal object.
+    expect(out.additionalProperties).toBe(false);
+    expect(out.description).toBeUndefined();
+  });
+
+  it("preserves an existing description when folding the open-map hint", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        prefs: {
+          type: "object",
+          additionalProperties: { type: "string" },
+          description: "User preferences.",
+        },
+      },
+      required: ["prefs"],
+      additionalProperties: false,
+    });
+    const prop = (out.properties as Record<string, Record<string, unknown>>).prefs;
+    expect(prop.description as string).toContain("User preferences.");
+    expect(prop.description as string).toMatch(/key\/value pairs/);
+    expect(prop.additionalProperties).toBe(false);
+  });
+
+  it("closes nested free-form maps at any depth (no open map survives to the wire)", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        list: {
+          type: "array",
+          items: { type: "object", additionalProperties: { type: "number" } },
+        },
+        map: { type: "object", additionalProperties: true },
+      },
+      required: ["list", "map"],
+      additionalProperties: false,
+    });
+    // No truthy additionalProperties anywhere — every object is closed.
+    const keys = collectKeys(out);
+    expect(keys.has("additionalProperties")).toBe(true);
+    const openMapSurvived = JSON.stringify(out).includes('"additionalProperties":true');
+    expect(openMapSurvived).toBe(false);
+    const itemProp = (
+      (out.properties as Record<string, Record<string, unknown>>).list.items as Record<
+        string,
+        unknown
+      >
+    ).additionalProperties;
+    expect(itemProp).toBe(false);
+  });
+});

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -728,6 +728,28 @@ function stripStrictUnsupportedConstraints(node: Record<string, unknown>): void 
   node.description = existing ? `${existing} ${suffix}` : suffix;
 }
 
+/**
+ * Human phrase describing a DECLARED free-form/open map so the intent survives
+ * when we close the object on the wire. Returns `null` for an undeclared
+ * (`undefined`) additionalProperties — that is a plain object, not a data-loss
+ * case. `true` → open map of any value; a schema value → open map of that type.
+ */
+function additionalPropertiesHint(additionalProperties: unknown): string | null {
+  if (additionalProperties === true) {
+    return "also accepts arbitrary additional properties as key/value pairs";
+  }
+  if (
+    additionalProperties &&
+    typeof additionalProperties === "object" &&
+    !Array.isArray(additionalProperties)
+  ) {
+    const valueType = (additionalProperties as Record<string, unknown>).type;
+    const typeStr = typeof valueType === "string" ? `${valueType} ` : "";
+    return `also accepts arbitrary additional ${typeStr}values as key/value pairs`;
+  }
+  return null;
+}
+
 function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     // Permissive fallback: no `properties: {}`/`additionalProperties: false`
@@ -787,7 +809,25 @@ function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
   }
 
   if (sanitized.type === "object" && sanitized.additionalProperties !== false) {
+    // Strict-grammar providers reject open maps (schema-valued or `true`
+    // additionalProperties) with a hard 400, and provider strictness is
+    // proxy-blind (an agent on api.elizacloud.ai with OPENAI_API_KEY may still
+    // route to strict Cerebras — #11123/#11156), so we must always close the
+    // object on the wire. But a DECLARED free-form map (e.g. contact
+    // customFields = `additionalProperties: { type: "string" }`) was collapsed
+    // SILENTLY: the model saw a closed object, could emit no keys, and the arg
+    // always arrived empty (#11249). Fold the intent into `description`
+    // (mirroring stripStrictUnsupportedConstraints) so it is preserved —
+    // non-strict providers can still emit the pairs (app-side parseAndValidate
+    // re-checks the caller's ORIGINAL schema and accepts them), and strict
+    // providers surface the intent instead of losing it without a trace.
+    const hint = additionalPropertiesHint(sanitized.additionalProperties);
     sanitized.additionalProperties = false;
+    if (hint) {
+      const existing =
+        typeof sanitized.description === "string" ? sanitized.description.trim() : "";
+      sanitized.description = existing ? `${existing} (${hint})` : `(${hint})`;
+    }
   }
 
   if (sanitized.items) {


### PR DESCRIPTION
## Problem (#11249)

`sanitizeJsonSchema` (`plugins/plugin-openai/models/text.ts`) unconditionally forces `additionalProperties: false` on every object node — **correctly**, because strict-grammar providers (Cerebras via Eliza Cloud, OpenAI strict) reject open maps with a hard 400, and provider strictness is **proxy-blind** (an agent on `api.elizacloud.ai` with `OPENAI_API_KEY` may still route to strict Cerebras — this is exactly the #11123/#11156 sev-high). 

But a **declared** free-form map — `additionalProperties: { type: "string" }` or `true`, used by `packages/agent/src/actions/contact.ts` (preferences/customFields/attributes) and ~20 record args across plugin-personal-assistant/calendar/app-control — was collapsed **silently**: the model saw a closed object, could emit no keys, and the arg **always arrived empty** → silent data loss.

## What this ships (the safe half — issue's option 3, done well)

Keep `additionalProperties: false` on the wire (**zero** strict-provider regression), but fold the open-map intent into the node's `description`, in the exact fold-to-description style `stripStrictUnsupportedConstraints` already uses for stripped keywords:

> `(also accepts arbitrary additional string values as key/value pairs)`

- On **non-strict** providers (real OpenAI, the common deployment) this nudges the model to still emit the pairs, which app-side `parseAndValidate` accepts (it re-checks the caller's **original** schema) → the map is recovered.
- On **strict** providers the grammar still blocks extra keys (unavoidable), but the intent is **surfaced** instead of vanishing without a trace.
- A plain object that never declared `additionalProperties` gets **no** hint (not a data-loss case) — verified by test.

## What this deliberately does NOT do (owner's call)

It does **not** guarantee recovery of map keys under strict providers. That needs either:
- **provider-branching** — unsafe: strictness is proxy-blind, so it would reintroduce the #11123/#11156 400; or
- **re-modeling record args as JSON-string fields** (option 2) — a ~20-callsite redesign.

Per the issue, that's the model-layer owner's design decision (cc @lalalune). This PR is the safe improvement that can land **independently** of it, and closes the "silent" part of the silent-data-loss complaint now. Hence `Refs #11249`, not `Closes` — leaving the design call open.

## Evidence

`plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts` (drives the real `__INTERNAL_sanitizeJsonSchema`):

```
$ bun run --cwd plugins/plugin-openai test
 Test Files  7 passed | 1 skipped (8)
      Tests  87 passed | 3 skipped (90)
```

New cases: schema-valued map closes-with-hint (incl. value type); `true` closes-with-hint; plain object gets no hint; existing description preserved when folding; nested maps close at every depth with **no open map surviving to the wire**. `bunx @biomejs/biome check` clean; typecheck shows no errors in the changed file.

- **Live-LLM trajectory: N/A here** — no model key in this environment. The change is a pure schema transform proven by unit tests; the behavioral claim (non-strict providers honor the nudged keys) rests on app-side `parseAndValidate` accepting extra keys against the original schema, which is existing behavior. A live before/after on real OpenAI (empty map → populated map) is the natural follow-up capture when a key is available.

Refs #11249