### PR TITLE
perf(mobile): unblock the API bind — cut Android cold boot ~21s → ~8s (#11903)

### DIFF
--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -8,6 +8,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { logger } from "@elizaos/core";
+import { isMobilePlatform } from "@elizaos/shared/runtime-env";
 import {
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
@@ -433,7 +434,14 @@ export async function fetchOllamaModels(
       urlStr = `http://${urlStr}`;
     }
     // @duplicate-component-audit-allow: Ollama tags is a model catalog lookup, not generation.
-    const res = await fetch(`${urlStr}/api/tags`);
+    // Cap the probe: Ollama defaults to localhost:11434, which does not exist on
+    // most devices (and on mobile the connect stalls on the OS TCP timeout for
+    // ~15s). This runs on the API-server startup path, so an unbounded fetch
+    // there blocked the whole boot/`server.listen` for ~15s (#11903). A short
+    // AbortSignal keeps a missing Ollama a fast, cheap "no models".
+    const res = await fetch(`${urlStr}/api/tags`, {
+      signal: AbortSignal.timeout(2_000),
+    });
     if (!res.ok) return [];
     const data = (await res.json()) as { models?: Array<{ name: string }> };
     return (data.models ?? []).map((m) => ({
@@ -703,6 +711,13 @@ export async function getOrFetchProvider(
     baseUrl =
       process.env.NEARAI_BASE_URL?.trim() || "https://cloud-api.near.ai/v1";
   }
+
+  // Ollama is a desktop localhost server (default :11434). No phone runs it, and
+  // on Android the connect to a dead localhost port blocks ~15s on the OS TCP
+  // timeout — AbortSignal.timeout does not interrupt bun's connect there — which,
+  // because provider caches warm on the API-server startup path, stalled the
+  // entire boot/`server.listen` for ~15s (#11903). Skip the probe on mobile.
+  if (providerId === "ollama" && isMobilePlatform()) return [];
 
   // Skip remote providers that need an API key when none is configured
   const keylessProviders = new Set([

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4196,18 +4196,28 @@ export async function startApiServer(opts?: {
     isMobilePlatform() ||
     process.env.ELIZA_DEVICE_BRIDGE_ENABLED?.trim() === "1"
   ) {
-    void getOptionalPluginApi<{
-      attachMobileDeviceBridgeToServer: (server: http.Server) => Promise<void>;
-    }>("capacitor")
-      .then(({ attachMobileDeviceBridgeToServer }) =>
-        attachMobileDeviceBridgeToServer(server),
-      )
-      .catch((err: unknown) => {
-        logger.warn(
-          "[eliza-api] Failed to attach mobile device bridge:",
-          err instanceof Error ? err.message : String(err),
-        );
-      });
+    // Defer to a macrotask: resolving @elizaos/plugin-capacitor-bridge (and its
+    // device-bridge attach) measured ~15s of blocking on the mobile bundle and
+    // — because it sat on the synchronous pre-`server.listen` path — held the
+    // whole API bind (and the boot screen) hostage for that entire time (#11903).
+    // The bridge only needs to attach a WS upgrade handler to the server object,
+    // which works fine once the server is already listening.
+    setImmediate(() => {
+      void getOptionalPluginApi<{
+        attachMobileDeviceBridgeToServer: (
+          server: http.Server,
+        ) => Promise<void>;
+      }>("capacitor")
+        .then(({ attachMobileDeviceBridgeToServer }) =>
+          attachMobileDeviceBridgeToServer(server),
+        )
+        .catch((err: unknown) => {
+          logger.warn(
+            "[eliza-api] Failed to attach mobile device bridge:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+    });
   }
   logger.debug(`[eliza-api] Server created (${Date.now() - apiStartTime}ms)`);
 


### PR DESCRIPTION
## What & why

On-device profiling of the Android cold boot (Pixel 6a) found the boot screen stayed up **~21s** because `startApiServer()` didn't call `server.listen` for ~15s. The client boot screen waits for agent `state:running`, which needs the API bound — so a pre-listen stall = a 15s boot screen. Two synchronous stalls on the pre-`listen` path were responsible; both are fixed here.

Closes the boot-duration half of #11903.

## Root cause (measured, not guessed)

I instrumented the boot with lap timers and bisected on-device across ~7 builds:

| lap | timing | note |
|---|---|---|
| bundle parse+eval → startEliza | ~540ms | **not** the bottleneck (a 24% minify experiment moved boot 0s, reverted) |
| runtime init → API `createServer` | ~1.2s | fine |
| `createServer` → `server.listen` | **~15,060ms** | ⬅ the stall |

Splitting that 15s window pinned it to **one statement**: the mobile device-bridge attach block. `createServer` itself was <15ms; the very next statement — `import("@elizaos/plugin-capacitor-bridge")` to attach the WS device bridge — held the synchronous pre-listen path for ~15s. A background ollama model-catalog `fetch()` to `localhost:11434` (no timeout) was a second ~15s stall surfacing in the same window.

## The fix (2 files)

1. **`server.ts`** — defer the capacitor device-bridge attach to a `setImmediate` macrotask. It only needs to add a WS `upgrade` handler to the already-created server, which works fine after `listen`. This dropped the measured API bind from **+15078ms → +15ms**.
2. **`model-provider-helpers.ts`** — skip the ollama provider probe on mobile (no phone runs localhost Ollama) and add a 2s `AbortSignal.timeout` to `fetchOllamaModels` for the desktop-misconfig case.

## Evidence (Pixel 6a, same build, bundle-swap)

`app launch → GET /api/status state:running`:
- **before:** ~21.5s
- **after:** **6.4s / 10.2s** across cold runs
- api lap `before server.listen`: **+15078ms → +15ms**

Full boot-timer + api-lap traces and the bisection are documented in #11903.

## Safety

The deferred block is the **WS device bridge** (`attachMobileDeviceBridgeToServer`), which is a no-op on bionic-host devices and a post-listen WS-handler add on stock builds. It is **separate** from the bionic-host inference registration (`ensureMobileDeviceBridgeInferenceHandlers`, gated on `ELIZA_BIONIC_HOST_DELEGATED` env), so on-device inference is unaffected.

## Evidence checklist
- Before/after boot timings: ✅ above (device-measured)
- Backend structured logs (boot-timer + api laps): ✅ in #11903
- Real-LLM trajectory: N/A — boot-path/latency change, no agent/model/prompt behavior change
- Screenshots/video: N/A — no rendered-UI change (this is agent-process boot latency); the user-visible effect is a shorter boot screen, quantified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)