### PR TITLE
fix(cloud): health-breaker catches a present-but-invalid media key (#11953 residual of #11985)

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
 import { type IAgentRuntime, type Memory, ModelType, ServiceType } from "@elizaos/core";
 import { CloudMediaGenerationService } from "../services/cloud-media-generation-service";
 import { generateMediaAction } from "./media-generation";
 
+const GENERATED_IMAGE_URL = "https://cdn.example.com/generated.png";
+const HEALTH_RECHECK_COOLDOWN_MS = 5 * 60 * 1000;
+
 interface RuntimeOptions {
   cloudKey?: string | null;
   imageModelRegistered?: boolean;
+  /** Controls what the IMAGE model does when `generateMedia` runs. */
+  useModel?: () => Promise<unknown>;
 }
 
 /**
@@ -24,6 +29,7 @@ function createRuntime(options: RuntimeOptions): {
     getSetting: (key: string) => (key === "ELIZAOS_CLOUD_API_KEY" ? cloudKey : null),
     getModel: (modelType: string) =>
       modelType === ModelType.IMAGE && imageModelRegistered ? async () => [] : undefined,
+    useModel: options.useModel ?? (async () => [GENERATED_IMAGE_URL]),
   } as unknown as IAgentRuntime & {
     getService: (serviceType: string) => CloudMediaGenerationService | null;
   };
@@ -94,5 +100,82 @@ describe("GENERATE_MEDIA validate honesty gate (#11953)", () => {
   test("withholds the tool when no IMAGE model handler is registered", async () => {
     const { runtime } = createRuntime({ cloudKey: "sk-live-key", imageModelRegistered: false });
     expect(await runValidate(runtime, imageMessage())).toBe(false);
+  });
+});
+
+/**
+ * The key-presence gate above proves a key is CONFIGURED — not that it is VALID.
+ * A present-but-invalid/expired key (the literal #11953 title) passes the
+ * presence check yet 401s on every call. The health breaker catches that at call
+ * time so the action still drops from the catalog instead of promising-then-
+ * failing, and self-heals once the key is rotated.
+ */
+describe("CloudMediaGenerationService health breaker — present-but-invalid key (#11953)", () => {
+  afterEach(() => setSystemTime()); // reset any faked clock
+
+  test("opens after an invalid/expired-key failure so a keyed-but-dead provider drops from the catalog", async () => {
+    const { service } = createRuntime({
+      cloudKey: "sk-live-but-revoked",
+      useModel: async () => {
+        throw new Error("Media generation failed: Invalid or expired API key");
+      },
+    });
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(true); // key present → optimistic
+
+    await expect(service.generateMedia({ mediaType: "image", prompt: "a cat" })).rejects.toThrow(
+      /Invalid or expired API key/,
+    );
+
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false); // breaker open
+  });
+
+  test("does NOT open on a per-request (content-policy) failure — the tool stays available", async () => {
+    const { service } = createRuntime({
+      cloudKey: "sk-live-key",
+      useModel: async () => {
+        throw new Error("Your prompt was rejected by the content policy");
+      },
+    });
+    await expect(service.generateMedia({ mediaType: "image", prompt: "x" })).rejects.toThrow();
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(true);
+  });
+
+  test("half-opens after the cooldown to allow a re-probe", async () => {
+    const base = Date.parse("2026-07-03T00:00:00Z");
+    setSystemTime(new Date(base));
+    const { service } = createRuntime({
+      cloudKey: "sk-live-but-revoked",
+      useModel: async () => {
+        throw new Error("401 Unauthorized");
+      },
+    });
+
+    await expect(service.generateMedia({ mediaType: "image", prompt: "x" })).rejects.toThrow();
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+
+    setSystemTime(new Date(base + HEALTH_RECHECK_COOLDOWN_MS - 1000));
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false); // still cooling down
+
+    setSystemTime(new Date(base + HEALTH_RECHECK_COOLDOWN_MS));
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(true); // half-open re-probe
+  });
+
+  test("closes the breaker after a successful generation (self-heals once the key is rotated)", async () => {
+    let keyDead = true;
+    const { service } = createRuntime({
+      cloudKey: "sk-live-key",
+      useModel: async () => {
+        if (keyDead) throw new Error("Invalid or expired API key");
+        return [GENERATED_IMAGE_URL];
+      },
+    });
+
+    await expect(service.generateMedia({ mediaType: "image", prompt: "x" })).rejects.toThrow();
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+
+    keyDead = false; // operator rotated the key
+    const res = await service.generateMedia({ mediaType: "image", prompt: "x" });
+    expect(res.url).toBe(GENERATED_IMAGE_URL);
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-media-generation-service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-media-generation-service.ts
@@ -68,6 +68,44 @@ function hasImageModelHandler(runtime: IAgentRuntime): boolean {
   return typeof runtime.getModel(ModelType.IMAGE) === "function";
 }
 
+/**
+ * How long the service withholds itself after a hard backing failure before it
+ * allows one re-probe. `hasCloudMediaKey` only proves a key is PRESENT, not that
+ * it is valid — a present-but-expired/revoked key (the literal #11953 symptom,
+ * "Invalid or expired API key") passes the presence check yet 401s on every
+ * call. This breaker catches that case reactively: it opens on the first hard
+ * failure so the tool drops from the catalog instead of promising-then-failing,
+ * and half-opens after the cooldown to re-probe (closing on success — self-heal
+ * once the key is rotated). Short enough to recover fast, long enough that a run
+ * of requests during an outage doesn't each re-hit the dead provider.
+ */
+const HEALTH_RECHECK_COOLDOWN_MS = 5 * 60 * 1000;
+
+/**
+ * A `generateMedia` failure that means the BACKING provider is unusable for
+ * every request (dead/expired/revoked key, unauthorized, not configured, quota
+ * exhausted) — as opposed to a per-request failure (content rejected, transient
+ * network blip, empty result). Only the former should open the health breaker:
+ * disabling the whole action on a one-off content rejection would be wrong.
+ */
+function isBackingUnavailableError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return (
+    /\bapi[\s._-]?key\b/.test(message) ||
+    message.includes("unauthorized") ||
+    message.includes("forbidden") ||
+    message.includes("expired") ||
+    message.includes("invalid key") ||
+    message.includes("not configured") ||
+    message.includes("no image generation model") ||
+    message.includes("quota") ||
+    message.includes("insufficient") ||
+    message.includes("billing") ||
+    message.includes("payment required") ||
+    /\b40[123]\b/.test(message)
+  );
+}
+
 function normalizeImageResult(result: ImageResultLike | undefined): MediaGenerationResponse | null {
   if (!result) {
     return null;
@@ -121,6 +159,15 @@ function normalizeImageResult(result: ImageResultLike | undefined): MediaGenerat
 export class CloudMediaGenerationService extends IMediaGenerationService {
   static override readonly serviceType = ServiceType.MEDIA_GENERATION;
 
+  /**
+   * `null` = healthy. A timestamp = when the last hard backing failure opened
+   * the health breaker (see `isBackingUnavailableError`). While the breaker is
+   * open, `canGenerateMedia` reports the service unavailable so the
+   * GENERATE_MEDIA action drops out of the planner catalog even when a key is
+   * present but invalid/expired (#11953).
+   */
+  private unhealthySince: number | null = null;
+
   constructor(runtime?: IAgentRuntime) {
     super(runtime);
   }
@@ -137,7 +184,48 @@ export class CloudMediaGenerationService extends IMediaGenerationService {
     if (request.mediaType !== "image") {
       return false;
     }
-    return hasImageModelHandler(this.runtime) && hasCloudMediaKey(this.runtime);
+    // Presence checks (a key is configured + an IMAGE handler is registered)
+    // catch an ABSENT key up front; the breaker catches a PRESENT-but-invalid
+    // key that only fails at call time.
+    return (
+      hasImageModelHandler(this.runtime) &&
+      hasCloudMediaKey(this.runtime) &&
+      !this.isHealthBreakerOpen()
+    );
+  }
+
+  private isHealthBreakerOpen(): boolean {
+    if (this.unhealthySince === null) {
+      return false;
+    }
+    // Half-open once the cooldown elapses: allow one re-probe. The breaker only
+    // fully closes when a generation actually succeeds (`markHealthy`).
+    if (Date.now() - this.unhealthySince >= HEALTH_RECHECK_COOLDOWN_MS) {
+      return false;
+    }
+    return true;
+  }
+
+  private markUnhealthy(error: unknown): void {
+    this.unhealthySince = Date.now();
+    logger.warn(
+      {
+        src: "cloud:media_generation",
+        error: error instanceof Error ? error.message : String(error),
+        cooldownMs: HEALTH_RECHECK_COOLDOWN_MS,
+      },
+      "[GENERATE_MEDIA] backing image provider rejected the request (key invalid/expired?) — withholding the action from the catalog until re-probe",
+    );
+  }
+
+  private markHealthy(): void {
+    if (this.unhealthySince !== null) {
+      logger.info(
+        { src: "cloud:media_generation" },
+        "[GENERATE_MEDIA] backing image provider recovered — action re-enabled",
+      );
+    }
+    this.unhealthySince = null;
   }
 
   async generateMedia(request: MediaGenerationRequest): Promise<MediaGenerationResponse> {
@@ -150,10 +238,21 @@ export class CloudMediaGenerationService extends IMediaGenerationService {
       throw new Error("Media generation prompt is required.");
     }
 
-    const imageResponse = await this.runtime.useModel(ModelType.IMAGE, {
-      prompt,
-      ...(request.size ? { size: request.size } : {}),
-    });
+    let imageResponse: Awaited<ReturnType<IAgentRuntime["useModel"]>>;
+    try {
+      imageResponse = await this.runtime.useModel(ModelType.IMAGE, {
+        prompt,
+        ...(request.size ? { size: request.size } : {}),
+      });
+    } catch (error) {
+      // A dead/expired key (or other hard backing failure) fails every request
+      // the same way — open the breaker so subsequent turns withhold the action
+      // instead of re-promising and re-failing.
+      if (isBackingUnavailableError(error)) {
+        this.markUnhealthy(error);
+      }
+      throw error;
+    }
 
     const imageResults = Array.isArray(imageResponse)
       ? (imageResponse as ImageResultLike[])
@@ -173,6 +272,10 @@ export class CloudMediaGenerationService extends IMediaGenerationService {
       );
       throw new Error("Image model returned no media result.");
     }
+
+    // A real generation landed: the backing provider is live, so clear any
+    // previously-tripped breaker (self-heal once the key is rotated).
+    this.markHealthy();
 
     return {
       ...media,


### PR DESCRIPTION
## What & why

Follow-up to **#11985** (which fixed part of **#11953**). #11985 gates `GENERATE_MEDIA` on `hasCloudMediaKey` — a key-**presence** check. That closes the "no key configured" case, but **not the literal issue title, "Invalid or expired API key"**: a key that is *present but revoked/expired* passes the presence check and still 401s on every call. So the planner still picks the tool, the agent still acks **"generating now"**, and generation still fails — the reported **0/7** promise-then-fail.

This PR adds the missing **reactive** half so both cases are covered:

- **absent key** → caught up front by #11985's presence check (unchanged).
- **present-but-dead key** → caught at the first call by a health **circuit-breaker**, then the tool is honestly withheld from the catalog.

## How

`CloudMediaGenerationService` now carries a health breaker:

- A `generateMedia` failure classified as a **hard backing failure** (invalid/expired/revoked key, unauthorized, quota, `401/402/403`) **opens** the breaker → `canGenerateMedia` (the hook `validate()` already honors, from #11985) reports unavailable → `GENERATE_MEDIA` drops from the planner catalog. No more "generating now" ack before a guaranteed failure.
- A **successful** generation **closes** it (self-heals once the operator rotates the key).
- It **half-opens** after a 5-min cooldown to re-probe — no paid probe generation burned every turn.
- **Per-request** failures (content-policy rejection, transient blip, empty result) deliberately do **not** open it — only a whole-backend outage does.

There is no free way to prove a key is *live* without a paid generation, so no proactive key-validity probe is added; the breaker turns a run of promise-then-fail turns into one failure + honest "not available" until recovery. Documented in the service.

## Evidence

Real-model N/A — no live media backend or key rotation available in this environment (that's the operator/infra half, part 1 of #11953, out of scope here). The logic path is proven by unit tests driving the real service with a controllable `useModel`:

```
bun test src/lib/eliza/plugin-cloud-bootstrap/actions/media-generation.test.ts
12 pass, 0 fail
```

New breaker cases (on top of #11985's 8 presence-check cases):
- opens after an invalid/expired-key failure → `canGenerateMedia` flips false (keyed-but-dead provider drops from the catalog)
- a content-policy failure does **NOT** open it (tool stays available)
- half-opens after the cooldown (`setSystemTime`)
- closes on a successful generation (self-heal on key rotation)

Backend structured logs show the path firing: `[GENERATE_MEDIA] backing image provider rejected the request (key invalid/expired?) — withholding the action from the catalog until re-probe` and `… recovered — action re-enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)