### PR TITLE
feat(core): secrets-feature federation — pluggable non-decrypting broker backend (#11536 E4)

### DIFF
--- a/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
+++ b/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime.ts";
+import type { IAgentRuntime } from "../../../types/index.ts";
+import {
+	SECRETS_BROKER_STRICT_KEY,
+	SECRETS_BROKER_TOKEN_KEY,
+	SECRETS_BROKER_URL_KEY,
+	SecretsBrokerUnavailableError,
+} from "../storage/index.ts";
+import type {
+	ISecretBrokerClient,
+	SecretContext,
+	SecretHandle,
+} from "../types.ts";
+import {
+	isSerializedSecretHandle,
+	parseSecretHandle,
+	SECRET_HANDLE_MARKER,
+} from "../types.ts";
+import { SecretsService } from "./secrets.ts";
+
+/**
+ * Build a mock runtime whose `getSetting` returns the supplied env map plus a
+ * fixed ENCRYPTION_SALT (required by the local backend), with a character that
+ * has a settings.secrets object the local store can use.
+ */
+function runtimeWithEnv(
+	env: Record<string, string | undefined>,
+): IAgentRuntime {
+	return createMockRuntime({
+		getSetting: ((key: string) =>
+			key === "ENCRYPTION_SALT"
+				? "test-salt"
+				: env[key]) as IAgentRuntime["getSetting"],
+		character: {
+			name: "T",
+			bio: [],
+			settings: { secrets: {} },
+		} as IAgentRuntime["character"],
+	});
+}
+
+const GLOBAL_CTX = (agentId: string): SecretContext => ({
+	level: "global",
+	agentId,
+});
+
+function makeHandleBroker(
+	over: Partial<SecretHandle> = {},
+): ISecretBrokerClient {
+	const handle: SecretHandle = {
+		marker: SECRET_HANDLE_MARKER,
+		ref: "lease-xyz",
+		key: "OPENAI_API_KEY",
+		resolveVia: "model-gateway",
+		...over,
+	};
+	return {
+		hasSecret: vi.fn(async (k: string) => k === handle.key),
+		issueHandle: vi.fn(async (k: string) => (k === handle.key ? handle : null)),
+	};
+}
+
+async function startService(
+	runtime: IAgentRuntime,
+	brokerClient?: ISecretBrokerClient,
+): Promise<SecretsService> {
+	return SecretsService.start(runtime, { brokerClient });
+}
+
+describe("SecretsService — broker UNSET: local default unchanged", () => {
+	it("uses the local composite store when no broker env is set", async () => {
+		const runtime = runtimeWithEnv({});
+		const client = makeHandleBroker();
+		const svc = await startService(runtime, client);
+
+		// A client was supplied but the env is unset -> broker never activates.
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		await svc.set("LOCAL_KEY", "local-value", ctx);
+		expect(await svc.get("LOCAL_KEY", ctx)).toBe("local-value");
+		// broker was never consulted
+		expect(client.issueHandle).not.toHaveBeenCalled();
+	});
+
+	it("does not activate the broker when env is set but no client is supplied", async () => {
+		const runtime = runtimeWithEnv({
+			[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+			[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+		});
+		const svc = await startService(runtime); // no brokerClient
+
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		await svc.set("LOCAL_KEY", "local-value", ctx);
+		expect(await svc.get("LOCAL_KEY", ctx)).toBe("local-value");
+	});
+});
+
+describe("SecretsService — broker CONFIGURED: precedence + handles", () => {
+	it("returns a serialized handle (never plaintext) for a broker-held key", async () => {
+		const runtime = runtimeWithEnv({
+			[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+			[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+		});
+		const client = makeHandleBroker();
+		const svc = await startService(runtime, client);
+
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		const value = await svc.get("OPENAI_API_KEY", ctx);
+		expect(isSerializedSecretHandle(value)).toBe(true);
+		expect(parseSecretHandle(value)?.ref).toBe("lease-xyz");
+		expect(await svc.exists("OPENAI_API_KEY", ctx)).toBe(true);
+	});
+
+	it("falls through to local for keys the broker does not hold", async () => {
+		const runtime = runtimeWithEnv({
+			[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+			[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+		});
+		const svc = await startService(runtime, makeHandleBroker());
+
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		await svc.set("LOCAL_ONLY", "local-value", ctx);
+		expect(await svc.get("LOCAL_ONLY", ctx)).toBe("local-value");
+	});
+});
+
+describe("SecretsService — fail-closed under strict", () => {
+	it("propagates SecretsBrokerUnavailableError instead of falling back to local", async () => {
+		const runtime = runtimeWithEnv({
+			[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+			[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+			[SECRETS_BROKER_STRICT_KEY]: "1",
+		});
+		// A configured-but-unreachable broker.
+		const unreachable: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+			issueHandle: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+		};
+		const svc = await startService(runtime, unreachable);
+
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		// Even though a local value would exist, strict mode must fail closed and
+		// never silently serve from the plaintext-capable local store.
+		await svc.set("OPENAI_API_KEY", "local-plaintext", ctx);
+		await expect(svc.get("OPENAI_API_KEY", ctx)).rejects.toBeInstanceOf(
+			SecretsBrokerUnavailableError,
+		);
+	});
+
+	it("non-strict: unreachable broker degrades to local (soft)", async () => {
+		const runtime = runtimeWithEnv({
+			[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+			[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+			// strict unset
+		});
+		const unreachable: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => false),
+			issueHandle: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+		};
+		const svc = await startService(runtime, unreachable);
+
+		const ctx = GLOBAL_CTX(runtime.agentId);
+		await svc.set("OPENAI_API_KEY", "local-plaintext", ctx);
+		expect(await svc.get("OPENAI_API_KEY", ctx)).toBe("local-plaintext");
+	});
+});

--- a/packages/core/src/features/secrets/services/secrets.ts
+++ b/packages/core/src/features/secrets/services/secrets.ts
@@ -14,12 +14,15 @@ import {
 } from "../../../types/index.ts";
 import { KeyManager } from "../crypto/encryption.ts";
 import {
+	BrokerSecretStorage,
 	CharacterSettingsStorage,
 	ComponentSecretStorage,
 	CompositeSecretStorage,
+	resolveSecretsBrokerConfig,
 	WorldMetadataStorage,
 } from "../storage/index.ts";
 import type {
+	ISecretBrokerClient,
 	PluginSecretRequirement,
 	SecretAccessLog,
 	SecretChangeCallback,
@@ -67,6 +70,13 @@ export class SecretsService extends Service {
 	private globalStorage!: CharacterSettingsStorage;
 	private worldStorage!: WorldMetadataStorage;
 	private userStorage!: ComponentSecretStorage;
+	/**
+	 * Non-decrypting broker backend (issue #11536, phase E4). `undefined` unless
+	 * BOTH the broker env is configured (`ELIZA_SECRETS_BROKER_URL`/`_TOKEN`) AND
+	 * a concrete {@link ISecretBrokerClient} was supplied via config. When unset,
+	 * behaviour is byte-for-byte the existing local composite default.
+	 */
+	private broker?: BrokerSecretStorage;
 
 	private accessLogs: SecretAccessLog[] = [];
 	private changeCallbacks: Map<string, SecretChangeCallback[]> = new Map();
@@ -98,12 +108,26 @@ export class SecretsService extends Service {
 			this.worldStorage = new WorldMetadataStorage(runtime, this.keyManager);
 			this.userStorage = new ComponentSecretStorage(runtime, this.keyManager);
 
-			// Create composite storage
+			// Create composite storage (the local default; unchanged)
 			this.storage = new CompositeSecretStorage({
 				globalStorage: this.globalStorage,
 				worldStorage: this.worldStorage,
 				userStorage: this.userStorage,
 			});
+
+			// E4: opt-in non-decrypting broker backend. Activated ONLY when both the
+			// broker env is configured AND a concrete client was supplied. A
+			// half-configured broker (env set, no client, or vice versa) leaves the
+			// service on the local default unchanged, so the common path is untouched.
+			const brokerClient = this.secretsConfig.brokerClient;
+			if (brokerClient) {
+				const brokerConfig = resolveSecretsBrokerConfig(
+					(key) => runtime.getSetting(key) as string | undefined,
+				);
+				if (brokerConfig) {
+					this.broker = new BrokerSecretStorage(brokerClient, brokerConfig);
+				}
+			}
 		}
 	}
 
@@ -126,6 +150,12 @@ export class SecretsService extends Service {
 		logger.info("[SecretsService] Initializing");
 
 		await this.storage.initialize();
+
+		// E4: initialize the broker backend when active. Logged distinctly so an
+		// operator can confirm the non-decrypting backend is in effect.
+		if (this.broker) {
+			await this.broker.initialize();
+		}
 
 		logger.info(
 			"[SecretsService] Secrets must be read explicitly from the service",
@@ -159,6 +189,18 @@ export class SecretsService extends Service {
 	 */
 	async get(key: string, context: SecretContext): Promise<string | null> {
 		this.logAccess(key, "read", context, true);
+
+		// E4 precedence: when the broker backend is active it is consulted FIRST.
+		// A hit returns a serialized non-decrypting handle (never plaintext); a
+		// miss falls through to the local composite default. Under strict mode a
+		// broker error throws (SecretsBrokerUnavailableError) rather than silently
+		// degrading to the plaintext-capable local store — the store enforces this.
+		if (this.broker) {
+			const handle = await this.broker.get(key, context);
+			if (handle !== null) {
+				return handle;
+			}
+		}
 
 		const value = await this.storage.get(key, context);
 
@@ -251,6 +293,14 @@ export class SecretsService extends Service {
 	 * Check if a secret exists.
 	 */
 	async exists(key: string, context: SecretContext): Promise<boolean> {
+		// E4 precedence: consult the broker first. A broker hit short-circuits;
+		// otherwise fall through to the local default. Strict-mode broker errors
+		// propagate from the store (fail-closed) instead of degrading to local.
+		if (this.broker) {
+			if (await this.broker.exists(key, context)) {
+				return true;
+			}
+		}
 		return this.storage.exists(key, context);
 	}
 

--- a/packages/core/src/features/secrets/storage/broker-config.test.ts
+++ b/packages/core/src/features/secrets/storage/broker-config.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolveSecretsBrokerConfig,
+	SECRETS_BROKER_STRICT_KEY,
+	SECRETS_BROKER_TOKEN_KEY,
+	SECRETS_BROKER_URL_KEY,
+	SecretsBrokerUnavailableError,
+} from "./broker-config.ts";
+
+/**
+ * Build a `getSetting`-shaped resolver from a plain record so the tests read
+ * like the env they model.
+ */
+function settings(map: Record<string, string | undefined>) {
+	return (key: string): string | undefined => map[key];
+}
+
+describe("resolveSecretsBrokerConfig — both-or-nothing gate", () => {
+	it("returns undefined when neither url nor token is set (local default)", () => {
+		expect(resolveSecretsBrokerConfig(settings({}))).toBeUndefined();
+	});
+
+	it("returns undefined when only the url is set (half-configured no-ops)", () => {
+		expect(
+			resolveSecretsBrokerConfig(
+				settings({ [SECRETS_BROKER_URL_KEY]: "https://broker.example" }),
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when only the token is set", () => {
+		expect(
+			resolveSecretsBrokerConfig(
+				settings({ [SECRETS_BROKER_TOKEN_KEY]: "handle-abc" }),
+			),
+		).toBeUndefined();
+	});
+
+	it("treats whitespace-only values as unset", () => {
+		expect(
+			resolveSecretsBrokerConfig(
+				settings({
+					[SECRETS_BROKER_URL_KEY]: "   ",
+					[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+				}),
+			),
+		).toBeUndefined();
+	});
+
+	it("activates and trims when both url and token are present", () => {
+		const cfg = resolveSecretsBrokerConfig(
+			settings({
+				[SECRETS_BROKER_URL_KEY]: "  https://broker.example  ",
+				[SECRETS_BROKER_TOKEN_KEY]: "  handle-abc  ",
+			}),
+		);
+		expect(cfg).toEqual({
+			url: "https://broker.example",
+			token: "handle-abc",
+			strict: false,
+		});
+	});
+
+	it("parses strict as a truthy env flag", () => {
+		const cfg = resolveSecretsBrokerConfig(
+			settings({
+				[SECRETS_BROKER_URL_KEY]: "https://broker.example",
+				[SECRETS_BROKER_TOKEN_KEY]: "handle-abc",
+				[SECRETS_BROKER_STRICT_KEY]: "1",
+			}),
+		);
+		expect(cfg?.strict).toBe(true);
+	});
+});
+
+describe("SecretsBrokerUnavailableError", () => {
+	it("names the broker url and carries the cause", () => {
+		const cause = new Error("ECONNREFUSED");
+		const err = new SecretsBrokerUnavailableError(
+			"https://broker.example",
+			cause,
+		);
+		expect(err.name).toBe("SecretsBrokerUnavailableError");
+		expect(err.brokerUrl).toBe("https://broker.example");
+		expect(err.message).toContain("https://broker.example");
+		expect((err as { cause?: unknown }).cause).toBe(cause);
+	});
+});

--- a/packages/core/src/features/secrets/storage/broker-config.ts
+++ b/packages/core/src/features/secrets/storage/broker-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Vendor-neutral secrets-broker configuration (issue #11536, phase E4).
+ *
+ * E4 gives the secrets feature a pluggable EXTERNAL-BROKER backend. The local
+ * AES-GCM stores (memory/character/world/component) remain the DEFAULT; the
+ * broker backend is an OPT-IN option for "eliza enterprise" deployments where
+ * the operator must prove the runtime CANNOT exfiltrate tenant credentials
+ * because it never holds the plaintext.
+ *
+ * Config names mirror the E1/E2 `ELIZA_MODEL_GATEWAY_*` and E3
+ * `ELIZA_CREDENTIAL_PROXY_*` conventions exactly, keeping the whole federation
+ * surface greppable and vendor-neutral. Steward is the REFERENCE broker, never
+ * a branded import or hard dependency:
+ *   - `ELIZA_SECRETS_BROKER_URL`     broker base URL (trusted operator config).
+ *   - `ELIZA_SECRETS_BROKER_TOKEN`   agent-scoped bearer handle. NOT a secret.
+ *   - `ELIZA_SECRETS_BROKER_STRICT`  fail-closed: when the broker is configured
+ *                                    but unreachable, refuse rather than fall
+ *                                    back to a local store that could hold
+ *                                    plaintext.
+ *
+ * Mode is ON only when BOTH url and token are present and non-empty \u2014 the same
+ * both-or-nothing rule the model gateway and credential proxy use, so a
+ * half-configured broker never silently no-ops into local plaintext storage.
+ *
+ * @module features/secrets/storage/broker-config
+ */
+
+import { isTruthyEnvValue } from "../../../env-utils.ts";
+
+export const SECRETS_BROKER_URL_KEY = "ELIZA_SECRETS_BROKER_URL";
+export const SECRETS_BROKER_TOKEN_KEY = "ELIZA_SECRETS_BROKER_TOKEN";
+export const SECRETS_BROKER_STRICT_KEY = "ELIZA_SECRETS_BROKER_STRICT";
+
+/**
+ * Resolved secrets-broker configuration. Presence of this object (returned by
+ * {@link resolveSecretsBrokerConfig}) is what flips the secrets service into
+ * broker-backend mode.
+ */
+export interface SecretsBrokerConfig {
+	url: string;
+	token: string;
+	/**
+	 * Fail-closed. When `true` and the broker is configured-but-unreachable, the
+	 * store refuses (throws) instead of degrading to a local store. When
+	 * `false`, an unreachable broker is a soft failure (read returns `null`),
+	 * but the default LOCAL stores are still what serves keys the broker doesn't
+	 * cover \u2014 the broker never silently leaks plaintext either way.
+	 */
+	strict: boolean;
+}
+
+/**
+ * Accessor shape. Callers pass their existing setting resolver so broker config
+ * honours the same precedence (config-env section over `process.env`) as every
+ * other setting. Kept local (not re-exported) so it can't collide with the
+ * identically-named resolver in the model-gateway / credential-proxy modules.
+ */
+type GetSettingFn = (key: string) => string | undefined;
+
+const trimToUndefined = (value: string | undefined): string | undefined => {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/**
+ * Thrown when strict broker mode is on and the configured broker cannot be
+ * reached / refuses. Named so the service can surface a fail-closed error
+ * instead of silently degrading to a local (plaintext-capable) store.
+ */
+export class SecretsBrokerUnavailableError extends Error {
+	readonly brokerUrl: string;
+	constructor(brokerUrl: string, cause?: unknown) {
+		super(
+			`Secrets broker is configured (${SECRETS_BROKER_URL_KEY}=${brokerUrl}) with ` +
+				`${SECRETS_BROKER_STRICT_KEY} on, but the broker is unreachable. ` +
+				`Refusing to fall back to local storage (fail-closed). ` +
+				`Fix the broker or unset ${SECRETS_BROKER_STRICT_KEY}.`,
+		);
+		this.name = "SecretsBrokerUnavailableError";
+		this.brokerUrl = brokerUrl;
+		if (cause !== undefined) {
+			(this as { cause?: unknown }).cause = cause;
+		}
+	}
+}
+
+/**
+ * Resolve the active secrets-broker config, or `undefined` when broker mode is
+ * off (either the URL or the token is unset). This is the single seam that
+ * decides local-default vs broker-backend; when it returns `undefined` the
+ * secrets service keeps today's behaviour byte-for-byte.
+ */
+export function resolveSecretsBrokerConfig(
+	getSetting: GetSettingFn,
+): SecretsBrokerConfig | undefined {
+	const url = trimToUndefined(getSetting(SECRETS_BROKER_URL_KEY));
+	const token = trimToUndefined(getSetting(SECRETS_BROKER_TOKEN_KEY));
+	if (!url || !token) return undefined;
+	return {
+		url,
+		token,
+		strict: isTruthyEnvValue(getSetting(SECRETS_BROKER_STRICT_KEY)),
+	};
+}

--- a/packages/core/src/features/secrets/storage/broker-store.test.ts
+++ b/packages/core/src/features/secrets/storage/broker-store.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import type {
+	ISecretBrokerClient,
+	SecretContext,
+	SecretHandle,
+} from "../types.ts";
+import {
+	isSerializedSecretHandle,
+	parseSecretHandle,
+	SECRET_HANDLE_MARKER,
+} from "../types.ts";
+import type { SecretsBrokerConfig } from "./broker-config.ts";
+import { SecretsBrokerUnavailableError } from "./broker-config.ts";
+import { BrokerSecretStorage } from "./broker-store.ts";
+
+const CONTEXT: SecretContext = {
+	level: "global",
+	agentId: "00000000-0000-0000-0000-000000000000",
+};
+
+function config(over: Partial<SecretsBrokerConfig> = {}): SecretsBrokerConfig {
+	return {
+		url: "https://broker.example",
+		token: "handle-abc",
+		strict: false,
+		...over,
+	};
+}
+
+function handle(over: Partial<SecretHandle> = {}): SecretHandle {
+	return {
+		marker: SECRET_HANDLE_MARKER,
+		ref: "lease-123",
+		key: "OPENAI_API_KEY",
+		resolveVia: "model-gateway",
+		...over,
+	};
+}
+
+describe("BrokerSecretStorage — non-decrypting invariant", () => {
+	it("SOURCE never imports or references the local decrypt path", () => {
+		// Structural guard: the whole point of the broker backend is that it has
+		// NO code path to plaintext. Assert the source imports neither the
+		// KeyManager nor the encryption module, and never calls `.decrypt`.
+		const raw = readFileSync(
+			fileURLToPath(new URL("./broker-store.ts", import.meta.url)),
+			"utf8",
+		);
+		// Strip comments so the assertion targets CODE, not the docstring that
+		// (deliberately) names KeyManager/decrypt while explaining their absence.
+		const code = raw
+			.replace(/\/\*[\s\S]*?\*\//g, "") // block comments
+			.replace(/(^|\s)\/\/[^\n]*/g, "$1"); // line comments
+		// No import of the encryption module (the only source of plaintext).
+		expect(code).not.toMatch(/from\s+["'].*crypto\/encryption/);
+		// No reference to the KeyManager (the decrypt-capable object).
+		expect(code).not.toMatch(/KeyManager/);
+		// No decrypt call anywhere in the code.
+		expect(code).not.toMatch(/\.decrypt\(/);
+	});
+
+	it("get() returns a serialized handle, never the plaintext", async () => {
+		// A hostile/buggy broker that tries to smuggle a raw value in must not be
+		// able to: the store re-serializes only the reference fields.
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => true),
+			issueHandle: vi.fn(async () =>
+				handle({
+					// deliberately inject a stray plaintext-looking field
+					...({ value: "sk-super-secret-plaintext" } as object),
+				}),
+			),
+		};
+		const store = new BrokerSecretStorage(broker, config());
+
+		const result = await store.get("OPENAI_API_KEY", CONTEXT);
+
+		expect(result).not.toBeNull();
+		expect(isSerializedSecretHandle(result)).toBe(true);
+		expect(result).not.toContain("sk-super-secret-plaintext");
+
+		const parsed = parseSecretHandle(result);
+		expect(parsed?.marker).toBe(SECRET_HANDLE_MARKER);
+		expect(parsed?.ref).toBe("lease-123");
+		expect(parsed?.key).toBe("OPENAI_API_KEY");
+		// the smuggled field did not survive re-serialization
+		expect((parsed as unknown as { value?: string })?.value).toBeUndefined();
+	});
+
+	it("get() returns null when the broker has no such secret", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => false),
+			issueHandle: vi.fn(async () => null),
+		};
+		const store = new BrokerSecretStorage(broker, config());
+		expect(await store.get("MISSING", CONTEXT)).toBeNull();
+	});
+
+	it("set() REFUSES on a read-only broker (no local fallback)", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => false),
+			issueHandle: vi.fn(async () => null),
+			// no storeSecret -> read-only
+		};
+		const store = new BrokerSecretStorage(broker, config());
+		expect(await store.set("K", "v", CONTEXT)).toBe(false);
+	});
+
+	it("set() delegates to a write-capable broker", async () => {
+		const storeSecret = vi.fn(async () => true);
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => false),
+			issueHandle: vi.fn(async () => null),
+			storeSecret,
+		};
+		const store = new BrokerSecretStorage(broker, config());
+		expect(await store.set("K", "v", CONTEXT)).toBe(true);
+		expect(storeSecret).toHaveBeenCalledWith("K", "v", CONTEXT);
+	});
+
+	it("getConfig()/updateConfig() never fabricate a plaintext-bearing config", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => true),
+			issueHandle: vi.fn(async () => handle()),
+		};
+		const store = new BrokerSecretStorage(broker, config());
+		expect(await store.getConfig("K", CONTEXT)).toBeNull();
+		expect(await store.updateConfig("K", CONTEXT, {})).toBe(false);
+	});
+});
+
+describe("BrokerSecretStorage — fail-closed vs fail-soft", () => {
+	it("strict: broker error on get() throws SecretsBrokerUnavailableError", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+			issueHandle: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+		};
+		const store = new BrokerSecretStorage(broker, config({ strict: true }));
+		await expect(store.get("K", CONTEXT)).rejects.toBeInstanceOf(
+			SecretsBrokerUnavailableError,
+		);
+	});
+
+	it("strict: broker error on exists() throws (no silent false)", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+			issueHandle: vi.fn(async () => null),
+		};
+		const store = new BrokerSecretStorage(broker, config({ strict: true }));
+		await expect(store.exists("K", CONTEXT)).rejects.toBeInstanceOf(
+			SecretsBrokerUnavailableError,
+		);
+	});
+
+	it("non-strict: broker error on get() returns null (soft)", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => false),
+			issueHandle: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+		};
+		const store = new BrokerSecretStorage(broker, config({ strict: false }));
+		expect(await store.get("K", CONTEXT)).toBeNull();
+	});
+
+	it("non-strict: broker error on exists() returns false (soft)", async () => {
+		const broker: ISecretBrokerClient = {
+			hasSecret: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}),
+			issueHandle: vi.fn(async () => null),
+		};
+		const store = new BrokerSecretStorage(broker, config({ strict: false }));
+		expect(await store.exists("K", CONTEXT)).toBe(false);
+	});
+});

--- a/packages/core/src/features/secrets/storage/broker-store.ts
+++ b/packages/core/src/features/secrets/storage/broker-store.ts
@@ -1,0 +1,194 @@
+/**
+ * Broker-backed non-decrypting secret storage (issue #11536, phase E4).
+ *
+ * ============================================================================
+ *  NON-DECRYPTING INVARIANT (the whole point of this file)
+ * ----------------------------------------------------------------------------
+ *  This store NEVER returns a plaintext secret value and NEVER calls the local
+ *  AES-GCM decrypt path (`crypto/encryption.ts`). Its `get`/read path returns a
+ *  {@link SecretHandle} \u2014 a reference to the secret \u2014 serialized as an opaque,
+ *  detectably-non-credential string. The real credential is resolved only at
+ *  USE-TIME, outside the runtime, through the already-shipped seams: the model
+ *  gateway (E1/E2) for provider keys and the credential proxy (E3) for
+ *  arbitrary API credentials. The broker injects the credential outbound
+ *  (header-only) and the runtime never holds it.
+ *
+ *  This is the "eliza enterprise" guarantee: on shared/cloud infra the operator
+ *  can prove the runtime CANNOT exfiltrate tenant credentials, because a broker
+ *  store literally has no code path that yields plaintext. There is
+ *  deliberately no `KeyManager`, no `decrypt`, no encryption import in this
+ *  module \u2014 if plaintext isn't reachable, it can't leak.
+ * ============================================================================
+ *
+ * Vendor-neutral: the store talks to an {@link ISecretBrokerClient}. Steward is
+ * the reference broker; this file has no branded import.
+ *
+ * @module features/secrets/storage/broker-store
+ */
+
+import { logger } from "../../../logger.ts";
+import type {
+	ISecretBrokerClient,
+	SecretConfig,
+	SecretContext,
+	SecretHandle,
+	SecretMetadata,
+	StorageBackend,
+} from "../types.ts";
+import { serializeSecretHandle } from "../types.ts";
+import type { SecretsBrokerConfig } from "./broker-config.ts";
+import { SecretsBrokerUnavailableError } from "./broker-config.ts";
+import { BaseSecretStorage } from "./interface.ts";
+
+/**
+ * Non-decrypting, broker-backed secret storage.
+ *
+ * `get` returns a SERIALIZED {@link SecretHandle}, never plaintext. `set`
+ * delegates to the broker's optional write path, or REFUSES when the broker is
+ * read-only (the runtime is not permitted to hand tenant credentials to the
+ * broker). `list`/`getConfig` expose metadata only \u2014 never values.
+ */
+export class BrokerSecretStorage extends BaseSecretStorage {
+	readonly storageType: StorageBackend = "broker";
+
+	private readonly broker: ISecretBrokerClient;
+	private readonly config: SecretsBrokerConfig;
+
+	constructor(broker: ISecretBrokerClient, config: SecretsBrokerConfig) {
+		super();
+		this.broker = broker;
+		this.config = config;
+	}
+
+	async initialize(): Promise<void> {
+		logger.info(
+			`[BrokerSecretStorage] Non-decrypting broker backend active (${this.config.url}). ` +
+				`Reads return handles, never plaintext.`,
+		);
+	}
+
+	/**
+	 * Whether the broker holds this secret. Fail-closed under strict mode: a
+	 * broker error becomes a thrown {@link SecretsBrokerUnavailableError} rather
+	 * than a silent `false` that could let a local store answer with plaintext.
+	 */
+	async exists(key: string, context: SecretContext): Promise<boolean> {
+		try {
+			return await this.broker.hasSecret(key, context);
+		} catch (error) {
+			return this.onBrokerError(error, false);
+		}
+	}
+
+	/**
+	 * NON-DECRYPTING READ. Returns a serialized {@link SecretHandle}, or `null`
+	 * when the broker has no such secret. NEVER returns plaintext and NEVER
+	 * touches the local decrypt path.
+	 */
+	async get(key: string, context: SecretContext): Promise<string | null> {
+		let handle: SecretHandle | null;
+		try {
+			handle = await this.broker.issueHandle(key, context);
+		} catch (error) {
+			return this.onBrokerError(error, null);
+		}
+		if (!handle) return null;
+		// Defense-in-depth: never let a misbehaving broker smuggle a raw value
+		// through the handle path. The handle carries only a reference.
+		return serializeSecretHandle({
+			marker: handle.marker,
+			ref: handle.ref,
+			key: handle.key,
+			resolveVia: handle.resolveVia,
+			brokerUrl: handle.brokerUrl ?? this.config.url,
+			expiresAt: handle.expiresAt,
+		});
+	}
+
+	/**
+	 * WRITE path. Delegates to the broker's optional `storeSecret`. When the
+	 * broker is read-only (no `storeSecret`), this REFUSES \u2014 returns `false` \u2014
+	 * because there is no local encrypted store to silently fall back to, and
+	 * writing a plaintext credential anywhere would defeat the invariant.
+	 */
+	async set(
+		key: string,
+		value: string,
+		context: SecretContext,
+		_config?: Partial<SecretConfig>,
+	): Promise<boolean> {
+		if (!this.broker.storeSecret) {
+			logger.warn(
+				`[BrokerSecretStorage] Broker is read-only; refusing to write secret '${key}'. ` +
+					`No local fallback (the broker backend never holds plaintext).`,
+			);
+			return false;
+		}
+		try {
+			return await this.broker.storeSecret(key, value, context);
+		} catch (error) {
+			return this.onBrokerError(error, false);
+		}
+	}
+
+	async delete(key: string, context: SecretContext): Promise<boolean> {
+		if (!this.broker.deleteSecret) {
+			return false;
+		}
+		try {
+			return await this.broker.deleteSecret(key, context);
+		} catch (error) {
+			return this.onBrokerError(error, false);
+		}
+	}
+
+	/** Metadata only \u2014 never values. */
+	async list(context: SecretContext): Promise<SecretMetadata> {
+		if (!this.broker.listSecrets) {
+			return {};
+		}
+		try {
+			return await this.broker.listSecrets(context);
+		} catch (error) {
+			return this.onBrokerError(error, {} as SecretMetadata);
+		}
+	}
+
+	/**
+	 * Broker stores expose no per-key config surface of their own (the broker
+	 * owns lifecycle/expiry). Returns `null` rather than fabricating a config.
+	 */
+	async getConfig(
+		_key: string,
+		_context: SecretContext,
+	): Promise<SecretConfig | null> {
+		return null;
+	}
+
+	/** Config is broker-owned; updates are a no-op refusal. */
+	async updateConfig(
+		_key: string,
+		_context: SecretContext,
+		_config: Partial<SecretConfig>,
+	): Promise<boolean> {
+		return false;
+	}
+
+	/**
+	 * Central fail-closed vs fail-soft decision. Under strict mode any broker
+	 * error is fatal (throw) so the caller cannot degrade to a plaintext-capable
+	 * local store; otherwise the error is logged and the soft default returned.
+	 */
+	private onBrokerError<T>(error: unknown, soft: T): T {
+		if (this.config.strict) {
+			if (error instanceof SecretsBrokerUnavailableError) throw error;
+			throw new SecretsBrokerUnavailableError(this.config.url, error);
+		}
+		logger.warn(
+			`[BrokerSecretStorage] Broker error (non-strict, returning soft default): ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return soft;
+	}
+}

--- a/packages/core/src/features/secrets/storage/index.ts
+++ b/packages/core/src/features/secrets/storage/index.ts
@@ -2,6 +2,15 @@
  * Storage module exports
  */
 
+export type { SecretsBrokerConfig } from "./broker-config.ts";
+export {
+	resolveSecretsBrokerConfig,
+	SECRETS_BROKER_STRICT_KEY,
+	SECRETS_BROKER_TOKEN_KEY,
+	SECRETS_BROKER_URL_KEY,
+	SecretsBrokerUnavailableError,
+} from "./broker-config.ts";
+export { BrokerSecretStorage } from "./broker-store.ts";
 export { CharacterSettingsStorage } from "./character-store.ts";
 export { ComponentSecretStorage } from "./component-store.ts";
 export type { ISecretStorage } from "./interface.ts";
@@ -14,6 +23,7 @@ export { WorldMetadataStorage } from "./world-store.ts";
 // into an empty `init_X = () => {}`. Without this the on-device
 // mobile agent explodes with `ReferenceError: <name> is not defined`
 // when a consumer dereferences a re-exported binding at runtime.
+import { BrokerSecretStorage as _bs_0_BrokerSecretStorage } from "./broker-store.ts";
 import { CharacterSettingsStorage as _bs_1_CharacterSettingsStorage } from "./character-store.ts";
 import { ComponentSecretStorage as _bs_2_ComponentSecretStorage } from "./component-store.ts";
 import {
@@ -26,6 +36,7 @@ import { WorldMetadataStorage as _bs_6_WorldMetadataStorage } from "./world-stor
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name.
 const __bundle_safety_FEATURES_SECRETS_STORAGE_INDEX__ = [
+	_bs_0_BrokerSecretStorage,
 	_bs_1_CharacterSettingsStorage,
 	_bs_2_ComponentSecretStorage,
 	_bs_3_BaseSecretStorage,

--- a/packages/core/src/features/secrets/types.ts
+++ b/packages/core/src/features/secrets/types.ts
@@ -54,7 +54,18 @@ export type ValidationStrategy =
 	| "url:reachable"
 	| "custom";
 
-export type StorageBackend = "memory" | "character" | "world" | "component";
+export type StorageBackend =
+	| "memory"
+	| "character"
+	| "world"
+	| "component"
+	/**
+	 * External non-decrypting broker backend (issue #11536, phase E4). Unlike
+	 * the local AES-GCM backends above, a `"broker"` store NEVER holds or returns
+	 * plaintext secret values: its read path yields a {@link SecretHandle} that is
+	 * resolved at use-time through the credential-proxy / model-gateway seam.
+	 */
+	| "broker";
 
 // ============================================================================
 // Core Secret Types
@@ -189,6 +200,121 @@ export interface EncryptedSecret {
 	algorithm: "aes-256-gcm";
 	/** Key identifier for key rotation */
 	keyId: string;
+}
+
+// ============================================================================
+// Broker Federation Types (issue #11536, phase E4)
+// ============================================================================
+
+/**
+ * Discriminator marking a value returned by a non-decrypting broker backend as
+ * a HANDLE (a reference to a secret), never the plaintext. Serialized into the
+ * handle's `value` field so a consumer that mistakes a handle for a raw secret
+ * gets an obviously-non-credential sentinel rather than something it might send
+ * on the wire.
+ */
+export const SECRET_HANDLE_MARKER = "eliza:secret-handle:v1" as const;
+
+/**
+ * A non-decrypting reference to a secret held by an third-party broker.
+ *
+ * This is the core E4 primitive: the broker backend issues a `SecretHandle`
+ * instead of a plaintext value. The handle is resolvable at USE-TIME through
+ * the already-shipped seams — the model gateway (E1/E2) for provider keys and
+ * the credential proxy (E3) for arbitrary API credentials — where the broker
+ * injects the real credential outbound (header-only) and the runtime never
+ * sees it. The runtime therefore CANNOT exfiltrate the credential because it
+ * never holds the plaintext.
+ */
+export interface SecretHandle {
+	/** Constant discriminator. Always {@link SECRET_HANDLE_MARKER}. */
+	readonly marker: typeof SECRET_HANDLE_MARKER;
+	/**
+	 * Opaque broker-scoped reference for this secret (e.g. a lease id or vault
+	 * path). NOT the credential; safe to log/persist. Resolved by the broker at
+	 * use-time via the proxy/gateway seam.
+	 */
+	readonly ref: string;
+	/** The secret key this handle stands in for. */
+	readonly key: string;
+	/**
+	 * Which use-time seam resolves this handle:
+	 *   - `"model-gateway"` — an OpenAI-compatible provider key (E1/E2).
+	 *   - `"credential-proxy"` — an arbitrary API credential injected by the
+	 *     credential proxy (E3).
+	 */
+	readonly resolveVia: "model-gateway" | "credential-proxy";
+	/** Optional broker base URL the handle resolves against (informational). */
+	readonly brokerUrl?: string;
+	/** Optional expiry (epoch ms) if the broker issued a time-bound handle. */
+	readonly expiresAt?: number;
+}
+
+/**
+ * Serialize a {@link SecretHandle} into the opaque string the `ISecretStorage`
+ * `get` contract returns. The result is deliberately NOT a credential: it is a
+ * prefixed JSON blob a consumer can detect via {@link isSerializedSecretHandle}
+ * and hand to the resolve seam instead of sending it as a bearer token.
+ */
+export function serializeSecretHandle(handle: SecretHandle): string {
+	return `${SECRET_HANDLE_MARKER}:${JSON.stringify(handle)}`;
+}
+
+/** Type guard: is a stored string a serialized {@link SecretHandle}? */
+export function isSerializedSecretHandle(value: string | null): boolean {
+	return (
+		typeof value === "string" && value.startsWith(`${SECRET_HANDLE_MARKER}:`)
+	);
+}
+
+/**
+ * Parse a serialized handle back into a {@link SecretHandle}, or `null` if the
+ * string is not a serialized handle / is malformed.
+ */
+export function parseSecretHandle(value: string | null): SecretHandle | null {
+	if (!isSerializedSecretHandle(value)) return null;
+	const json = (value as string).slice(`${SECRET_HANDLE_MARKER}:`.length);
+	try {
+		const parsed = JSON.parse(json) as SecretHandle;
+		if (parsed?.marker !== SECRET_HANDLE_MARKER) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The minimal contract a `"broker"` backend calls out to. Deliberately
+ * vendor-neutral: any broker that can (a) confirm a secret exists, (b) issue a
+ * non-decrypting handle for it, and optionally (c) store a secret write-only
+ * satisfies it. Steward is the REFERENCE implementation, not a hard dependency
+ * — this interface is defined in core with no branded import.
+ */
+export interface ISecretBrokerClient {
+	/** Does the broker hold a secret for this key? Never returns the value. */
+	hasSecret(key: string, context: SecretContext): Promise<boolean>;
+	/**
+	 * Issue a non-decrypting handle for a secret. MUST NOT return plaintext.
+	 * Returns `null` when the broker has no such secret.
+	 */
+	issueHandle(
+		key: string,
+		context: SecretContext,
+	): Promise<SecretHandle | null>;
+	/**
+	 * Optionally store a secret INTO the broker (write path). Brokers that are
+	 * read-only (the runtime is not permitted to write tenant credentials)
+	 * should omit this or return `false`; the store then refuses writes.
+	 */
+	storeSecret?(
+		key: string,
+		value: string,
+		context: SecretContext,
+	): Promise<boolean>;
+	/** Optionally remove a secret handle mapping from the broker. */
+	deleteSecret?(key: string, context: SecretContext): Promise<boolean>;
+	/** Optional metadata listing (never values). */
+	listSecrets?(context: SecretContext): Promise<SecretMetadata>;
 }
 
 /**
@@ -399,6 +525,16 @@ export interface SecretsServiceConfig {
 	enableAccessLogging: boolean;
 	/** Maximum access log entries to keep */
 	maxAccessLogEntries: number;
+	/**
+	 * Optional non-decrypting broker client (issue #11536, phase E4). Vendor-
+	 * neutral: core defines the {@link ISecretBrokerClient} contract but ships no
+	 * concrete broker. A deployment that wants the "eliza enterprise"
+	 * never-holds-plaintext guarantee supplies its client here AND sets the
+	 * `ELIZA_SECRETS_BROKER_URL`/`_TOKEN` env; both are required to activate the
+	 * broker backend. When unset, the service uses the local composite default
+	 * unchanged.
+	 */
+	brokerClient?: ISecretBrokerClient;
 }
 
 /**


### PR DESCRIPTION
## E4 — secrets-feature federation: pluggable non-decrypting broker backend

Closes the E4 lane of #11536 (federation), sitting after E1/E2 (keyless model gateway) and E3 (credential proxy). E4 gives the **secrets feature** an opt-in EXTERNAL-BROKER backend for "eliza enterprise" deployments where the operator must be able to **prove the runtime cannot exfiltrate tenant credentials** — because the broker backend has no code path to plaintext.

### The non-decrypting guarantee (the whole point)

`BrokerSecretStorage` NEVER returns a plaintext secret and NEVER calls the local AES-GCM decrypt path. There is deliberately **no `KeyManager`, no `decrypt`, no `crypto/encryption` import** in the broker module — if plaintext isn't reachable, it can't leak.

- `get()` returns a serialized **`SecretHandle`** (an opaque, detectably-non-credential reference), resolved at USE-TIME through the already-shipped seams: the **model gateway** (E1/E2) for provider keys and the **credential proxy** (E3) for arbitrary API credentials. The broker injects the real credential outbound (header-only); the runtime never holds it.
- Defense-in-depth: even a misbehaving broker that tries to smuggle a raw value through the handle path can't — the store re-serializes **only the reference fields**.
- `set()` delegates to the broker's optional write path, or **REFUSES** on a read-only broker (there is no plaintext-capable local store to silently fall back to).

### Vendor-neutral config

Mirrors the E1/E2 `ELIZA_MODEL_GATEWAY_*` and E3 `ELIZA_CREDENTIAL_PROXY_*` conventions exactly, keeping the federation surface greppable. **Steward is the reference broker; core ships no branded import.**

- `ELIZA_SECRETS_BROKER_URL` — broker base URL (trusted operator config)
- `ELIZA_SECRETS_BROKER_TOKEN` — agent-scoped bearer handle (NOT a secret)
- `ELIZA_SECRETS_BROKER_STRICT` — fail-closed toggle

Mode is ON only when BOTH url and token are present (the same both-or-nothing rule the gateway and proxy use), so a half-configured broker never silently no-ops into local plaintext storage.

### Default preserved + fail-closed

- **Broker UNSET → byte-for-byte the existing local default.** Zero change on the common path. The broker only activates when BOTH the env is configured AND a concrete `ISecretBrokerClient` is supplied via `SecretsServiceConfig.brokerClient`.
- **Broker CONFIGURED → precedence for reads/exists**, with the local composite store as fallback for keys the broker doesn't cover.
- **STRICT mode → fail-closed.** A configured-but-unreachable broker throws `SecretsBrokerUnavailableError` rather than silently degrading to the plaintext-capable local store. Non-strict degrades soft.

### Deferred wiring (honest scoping)

The broker **write path** is exposed on the store (`set()` → `storeSecret`) but is **not routed from `SecretsService.set()`** — writes stay on the local composite default. Wiring writes through the broker is a follow-up; it isn't needed for the read-side never-holds-plaintext guarantee and keeping it out keeps this diff minimal and low-risk.

### Tests

23 new tests, green alongside the 34 existing secrets tests (`npx vitest run packages/core/src/features/secrets` → 57 passed):

- **non-decrypting invariant** — source has no encryption import / KeyManager / `.decrypt(` call (structural guard); `get()` re-serializes only reference fields and drops a smuggled plaintext field.
- **default-local unchanged** when broker unset, and when env is set but no client is supplied.
- **fail-closed under strict** — `SecretsBrokerUnavailableError` propagates from an unreachable broker with a local value present (no fallback); non-strict degrades to local.
- **both-or-nothing config gate** + trim/whitespace handling.

Type-check: `tsc --noEmit -p packages/core/tsconfig.json` clean for all touched files (the only errors are pre-existing environmental: unbuilt generated i18n data + `drizzle-orm` not installed on this box).

Cross-ref: #11536

— [sol-orch]
