### PR TITLE
fix(cloud): restore orange brand background on login page

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -18,8 +18,11 @@ function StewardLoginSectionFallback() {
 function LoginBackground({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="theme-cloud min-h-screen bg-black text-white"
-      style={{ background: "var(--background)" }}
+      className="theme-cloud min-h-screen text-white"
+      style={{
+        background:
+          "linear-gradient(155deg, var(--brand-orange) 0%, #c2410c 52%, #7c2d12 100%)",
+      }}
     >
       <div className="flex min-h-screen w-full flex-col">
         <div className="relative z-10 flex flex-1 items-center justify-center p-4">


### PR DESCRIPTION
The login page went white — a dark sign-in card marooned on a blank white void (super moche).

## Root cause

`LoginBackground` set `bg-black` on the wrapper but then overrode it with an inline `style={{ background: "var(--background)" }}`. Inline styles win over Tailwind classes, and under `.theme-cloud` (a light theme — "black + white, neutral/orange accents") `--background` resolves to `#fff`. So the page painted pure white while the card stayed dark. Live prod confirmed: the wrapper computes `background: rgb(255, 255, 255)`.

This wasn't a #11271 regression — the same contradictory pair was in the original cloud-frontend page and got faithfully carried over in the port.

## Fix

Drop the inline `var(--background)` and paint the brand-orange gradient (`--brand-orange` → orange-700 → orange-900). The dark `bg-black/86` card now reads as intentional against the orange, and the orange Passkey button harmonizes with the background instead of floating on white. Back on-brand.

One file, style-only — no logic, types, or tests touched.