### PR TITLE
fix(scripts,test): resolve turbo from a git worktree + recognize design-system agent-rows in coverage

### DIFF
--- a/packages/app/test/core-view-action-surface-coverage.test.ts
+++ b/packages/app/test/core-view-action-surface-coverage.test.ts
@@ -231,7 +231,13 @@ function readRepoFiles(files: readonly string[]): string {
 function countAgentElements(source: string): number {
   return (
     (source.match(/useAgentElement(?:<[^>]*>)?\(/g)?.length ?? 0) +
-    (source.match(/\sagent=\{?["'`][^"'`]+["'`]\}?/g)?.length ?? 0)
+    (source.match(/\sagent=\{?["'`][^"'`]+["'`]\}?/g)?.length ?? 0) +
+    // Design-system agent-surface rows (`settings-agent-rows`,
+    // `useAgentElement`-backed controls) declare their agent-addressable control
+    // via an `agentId=` prop instead of a direct `useAgentElement(` call — a
+    // section built entirely from those rows (e.g. CapabilitiesSection after the
+    // design-system consolidation) is still fully agent-wired.
+    (source.match(/\sagentId=\{?["'`][^"'`]+["'`]\}?/g)?.length ?? 0)
   );
 }
 

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -9,17 +9,38 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
-const turboShimCandidates =
-  process.platform === "win32"
-    ? [
-        path.join(repoRoot, "node_modules/.bin/turbo.exe"),
-        path.join(repoRoot, "node_modules/.bin/turbo"),
-      ]
-    : [path.join(repoRoot, "node_modules/.bin/turbo")];
+
+// Every `node_modules` from repoRoot up to the filesystem root. A git worktree
+// (e.g. `.claude/worktrees/<name>`) has no `node_modules` of its own and shares
+// the parent checkout's via node's ancestor resolution — so turbo lives several
+// levels up. Walk the same chain node/bun would instead of only checking
+// repoRoot, so `run-turbo` works from a worktree, not just the primary checkout.
+function ancestorNodeModules(startDir) {
+  const dirs = [];
+  let dir = startDir;
+  while (true) {
+    dirs.push(path.join(dir, "node_modules"));
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return dirs;
+}
+
+const nodeModulesDirs = ancestorNodeModules(repoRoot);
+const shimNames =
+  process.platform === "win32" ? ["turbo.exe", "turbo"] : ["turbo"];
+const turboShimCandidates = nodeModulesDirs.flatMap((nm) =>
+  shimNames.map((name) => path.join(nm, ".bin", name)),
+);
 const turboShim = turboShimCandidates.find((candidate) =>
   fs.existsSync(candidate),
 );
-const turboPackageBin = path.join(repoRoot, "node_modules/turbo/bin/turbo");
+const turboPackageBin =
+  nodeModulesDirs
+    .map((nm) => path.join(nm, "turbo/bin/turbo"))
+    .find((candidate) => fs.existsSync(candidate)) ??
+  path.join(repoRoot, "node_modules/turbo/bin/turbo");
 const turboArgs = process.argv.slice(2);
 
 if (!turboArgs.some((arg) => arg === "--ui" || arg.startsWith("--ui="))) {


### PR DESCRIPTION
Two small infra/test fixes surfaced while shipping the launcher redesign (#11993/#11997).

## 1. `turbo` resolvable from a git worktree (`packages/scripts/run-turbo.mjs`)
A `.claude/worktrees/<name>` git worktree has no `node_modules` of its own — it shares the parent checkout's via node/bun ancestor resolution. `run-turbo.mjs` only checked `<repoRoot>/node_modules/.bin/turbo`, so from a worktree it errored `Unable to find turbo`, which broke `audit:app` and every turbo-driven script. Now it walks ancestor `node_modules` dirs (the same chain node resolves), finding the parent's turbo. Verified: `run-turbo.mjs --version` → `2.10.0` and `audit:app` runs past the turbo step from the worktree.

## 2. Coverage ratchet recognizes design-system agent-rows (`core-view-action-surface-coverage.test.ts`)
`CapabilitiesSection.tsx` failed "keeps every settings subsection owner wired to agent-surface controls" — but it is fully agent-wired, via the design-system `settings-agent-rows` (`SettingsSwitchRow`/`SettingsInputRow`/… which each call `useAgentElement({ id: agentId })`) rather than a direct `useAgentElement(` call. The consolidation in 78c444fa730 moved it entirely onto those rows; the test's `countAgentElements` heuristic didn't recognize the `agentId=` pattern. Added that pattern to the count (safe — it only increases counts, so it can't red a passing view). `CapabilitiesSection` is now correctly counted.

Verified: full `packages/app` unit suite **316/316 green** (was 315/316); `packages/ui` typecheck clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)