### PR TITLE
feat(import-conversations): add Claude export parser

### DIFF
--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/import-conversations",
   "version": "2.0.4",
-  "description": "Import prior AI conversation history (ChatGPT / Claude / Hermes exports) into elizaOS as searchable, scoped knowledge. Track A: shared core (normalized types + ingestion pipeline).",
+  "description": "Import prior AI conversation history (ChatGPT / Claude / Hermes exports) into elizaOS as searchable, scoped knowledge.",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -51,6 +51,16 @@
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./parsers/claude": {
+      "types": "./dist/parsers/claude.d.ts",
+      "eliza-source": {
+        "types": "./src/parsers/claude.ts",
+        "import": "./src/parsers/claude.ts",
+        "default": "./src/parsers/claude.ts"
+      },
+      "import": "./dist/parsers/claude.js",
+      "default": "./dist/parsers/claude.js"
     },
     "./parsers/hermes": {
       "types": "./dist/parsers/hermes.d.ts",

--- a/packages/import-conversations/src/index.ts
+++ b/packages/import-conversations/src/index.ts
@@ -11,5 +11,11 @@
  */
 
 export * from "./core/index.ts";
+export type { ParseOptions as ClaudeParseOptions } from "./parsers/claude.ts";
+export {
+  default as claudeParser,
+  detect as detectClaudeExport,
+  parse as parseClaudeExport,
+} from "./parsers/claude.ts";
 export type { ParseOptions } from "./parsers/hermes.ts";
 export { default as hermesParser, detect, parse } from "./parsers/hermes.ts";

--- a/packages/import-conversations/src/parsers/claude.test.ts
+++ b/packages/import-conversations/src/parsers/claude.test.ts
@@ -1,0 +1,192 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedConversation } from "../core/types.ts";
+import { claudeParser, detect, parse } from "./claude.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CLAUDE_EXPORT_DIR = path.join(here, "fixtures", "claude-export");
+const CLAUDE_JSON = path.join(CLAUDE_EXPORT_DIR, "conversations.json");
+
+async function collect(
+  iterable: AsyncIterable<NormalizedConversation>,
+): Promise<NormalizedConversation[]> {
+  const out: NormalizedConversation[] = [];
+  for await (const c of iterable) out.push(c);
+  return out;
+}
+
+function findConversation(
+  convos: NormalizedConversation[],
+  id: string,
+): NormalizedConversation {
+  const conversation = convos.find((c) => c.sourceConversationId === id);
+  expect(conversation).toBeDefined();
+  if (!conversation) throw new Error(`Expected Claude conversation ${id}`);
+  return conversation;
+}
+
+function makeZipWithConversationsJson(json: string): Buffer {
+  const fileName = "Claude Export/conversations.json";
+  const fileNameBytes = Buffer.from(fileName, "utf8");
+  const compressed = deflateRawSync(Buffer.from(json, "utf8"));
+
+  const localHeader = Buffer.alloc(30);
+  localHeader.writeUInt32LE(0x04034b50, 0);
+  localHeader.writeUInt16LE(20, 4);
+  localHeader.writeUInt16LE(0, 6);
+  localHeader.writeUInt16LE(8, 8);
+  localHeader.writeUInt32LE(0, 10);
+  localHeader.writeUInt32LE(0, 14);
+  localHeader.writeUInt32LE(compressed.length, 18);
+  localHeader.writeUInt32LE(Buffer.byteLength(json), 22);
+  localHeader.writeUInt16LE(fileNameBytes.length, 26);
+  localHeader.writeUInt16LE(0, 28);
+
+  const centralOffset =
+    localHeader.length + fileNameBytes.length + compressed.length;
+  const centralHeader = Buffer.alloc(46);
+  centralHeader.writeUInt32LE(0x02014b50, 0);
+  centralHeader.writeUInt16LE(20, 4);
+  centralHeader.writeUInt16LE(20, 6);
+  centralHeader.writeUInt16LE(0, 8);
+  centralHeader.writeUInt16LE(8, 10);
+  centralHeader.writeUInt32LE(0, 12);
+  centralHeader.writeUInt32LE(0, 16);
+  centralHeader.writeUInt32LE(compressed.length, 20);
+  centralHeader.writeUInt32LE(Buffer.byteLength(json), 24);
+  centralHeader.writeUInt16LE(fileNameBytes.length, 28);
+  centralHeader.writeUInt16LE(0, 30);
+  centralHeader.writeUInt16LE(0, 32);
+  centralHeader.writeUInt16LE(0, 34);
+  centralHeader.writeUInt16LE(0, 36);
+  centralHeader.writeUInt32LE(0, 38);
+  centralHeader.writeUInt32LE(0, 42);
+
+  const centralSize = centralHeader.length + fileNameBytes.length;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(centralSize, 12);
+  eocd.writeUInt32LE(centralOffset, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([
+    localHeader,
+    fileNameBytes,
+    compressed,
+    centralHeader,
+    fileNameBytes,
+    eocd,
+  ]);
+}
+
+describe("claude parser: detect()", () => {
+  it("returns true for a Claude export directory", async () => {
+    expect(await detect(CLAUDE_EXPORT_DIR)).toBe(true);
+  });
+
+  it("returns true for conversations.json directly", async () => {
+    expect(await detect(CLAUDE_JSON)).toBe(true);
+  });
+
+  it("returns false for a non-Claude directory", async () => {
+    expect(await detect(path.join(here, "fixtures", "hermes-home"))).toBe(
+      false,
+    );
+  });
+
+  it("returns true for a zipped Claude export containing conversations.json", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "claude-export-"));
+    const json = await readFile(CLAUDE_JSON, "utf8");
+    const zipPath = path.join(tmp, "claude-export.zip");
+    await writeFile(zipPath, makeZipWithConversationsJson(json));
+    expect(await detect(zipPath)).toBe(true);
+  });
+});
+
+describe("claude parser: parse() mapping", () => {
+  it("maps Claude conversations and chat_messages into normalized conversations", async () => {
+    const convos = await collect(parse(CLAUDE_EXPORT_DIR));
+    expect(convos).toHaveLength(2);
+
+    const first = findConversation(convos, "claude-conv-1");
+    expect(first.title).toBe("Project planning");
+    expect(first.createdAt).toBe(Date.parse("2026-01-01T10:00:00.000Z"));
+    expect(first.updatedAt).toBe(Date.parse("2026-01-01T10:05:00.000Z"));
+    expect(first.meta?.model).toBe("claude-sonnet-4");
+    expect(first.meta?.project).toBe("Agent continuity");
+    expect(first.meta?.tags).toContain("claude-export");
+
+    expect(first.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(first.messages[0]?.sourceMessageId).toBe("msg-1");
+    expect(first.messages[0]?.text).toContain("Summarize the importer plan");
+    expect(first.messages[1]?.text).toContain("Use DocumentService");
+  });
+
+  it("flattens typed content blocks and code blocks", async () => {
+    const convos = await collect(parse(CLAUDE_EXPORT_DIR));
+    const second = findConversation(convos, "claude-conv-2");
+
+    expect(second.messages[0]?.text).toContain("Here is a snippet");
+    expect(second.messages[0]?.text).toContain("```ts");
+    expect(second.messages[0]?.text).toContain("const ok = true;");
+  });
+
+  it("keeps extracted attachment text as normalized attachments", async () => {
+    const convos = await collect(parse(CLAUDE_EXPORT_DIR));
+    const first = findConversation(convos, "claude-conv-1");
+
+    const attachment = first.messages[0]?.attachments?.[0];
+    expect(attachment).toEqual({
+      name: "scope.md",
+      kind: "extracted-text",
+      text: "Track C should parse Claude chat_messages and inline attachments.",
+    });
+  });
+
+  it("can omit attachments when includeAttachments=false", async () => {
+    const convos = await collect(
+      parse(CLAUDE_EXPORT_DIR, { includeAttachments: false }),
+    );
+    const first = findConversation(convos, "claude-conv-1");
+    expect(first.messages[0]?.attachments).toBeUndefined();
+  });
+
+  it("streams incrementally from conversations.json", async () => {
+    const iterator = parse(CLAUDE_JSON)[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value.sourceConversationId).toBe("claude-conv-1");
+    await iterator.return?.();
+  });
+
+  it("parses a zipped Claude export", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "claude-export-"));
+    await mkdir(path.join(tmp, "nested"));
+    const json = await readFile(CLAUDE_JSON, "utf8");
+    const zipPath = path.join(tmp, "nested", "claude-export.zip");
+    await writeFile(zipPath, makeZipWithConversationsJson(json));
+
+    const convos = await collect(parse(zipPath));
+    expect(convos.map((c) => c.sourceConversationId)).toEqual([
+      "claude-conv-1",
+      "claude-conv-2",
+    ]);
+  });
+});
+
+describe("claude parser: exported parser object", () => {
+  it("exposes a ConversationParser with source 'claude'", () => {
+    expect(claudeParser.source).toBe("claude");
+    expect(typeof claudeParser.detect).toBe("function");
+    expect(typeof claudeParser.parse).toBe("function");
+  });
+});

--- a/packages/import-conversations/src/parsers/claude.ts
+++ b/packages/import-conversations/src/parsers/claude.ts
@@ -1,0 +1,364 @@
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import type { Readable } from "node:stream";
+
+import type { ConversationImporter } from "../core/registry.ts";
+import type {
+  AttachmentKind,
+  NormalizedAttachment,
+  NormalizedConversation,
+  NormalizedMessage,
+  NormalizedRole,
+} from "../core/types.ts";
+import {
+  readFirstJsonArrayObject,
+  streamJsonArrayObjects,
+} from "./json-array-stream.ts";
+import { findZipEntryMetadata, openZipEntryStream } from "./zip-entry.ts";
+
+export type ParseOptions = {
+  /**
+   * Keep file/image attachment metadata and inline `extracted_content` blocks.
+   * On by default because Claude exports include useful text extracted from
+   * uploaded documents.
+   */
+  includeAttachments?: boolean;
+};
+
+const SOURCE = "claude" as const;
+const CONVERSATIONS_JSON = "conversations.json";
+
+const DEFAULT_OPTIONS: Required<ParseOptions> = {
+  includeAttachments: true,
+};
+
+type RecordLike = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RecordLike {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  record: RecordLike,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function arrayField(record: RecordLike, keys: readonly string[]): unknown[] {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function toEpochMs(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+function normalizeRole(sender: string | undefined): NormalizedRole | undefined {
+  if (sender === "human" || sender === "user") return "user";
+  if (sender === "assistant") return "assistant";
+  if (sender === "system") return "system";
+  if (sender === "tool") return "tool";
+  return undefined;
+}
+
+function maybeFenceCode(text: string, language: string | undefined): string {
+  const lang = language ? language.replace(/[^a-z0-9_+-]/gi, "") : "";
+  return `\`\`\`${lang}\n${text}\n\`\`\``;
+}
+
+function textFromContentBlock(block: unknown): string | undefined {
+  if (typeof block === "string") return block;
+  if (!isRecord(block)) return undefined;
+
+  const type = stringField(block, ["type"]);
+  if (type === "image" || type === "file" || type === "attachment") {
+    return undefined;
+  }
+
+  const text = stringField(block, [
+    "text",
+    "content",
+    "value",
+    "input",
+    "name",
+  ]);
+  if (!text) return undefined;
+
+  if (type === "code") {
+    return maybeFenceCode(text, stringField(block, ["language", "lang"]));
+  }
+  return text;
+}
+
+function textFromMessage(record: RecordLike): string {
+  const directText = stringField(record, ["text"]);
+  if (directText !== undefined) return directText;
+
+  const content = record.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .map(textFromContentBlock)
+    .filter((part): part is string => Boolean(part && part.trim().length > 0))
+    .join("\n\n");
+}
+
+function attachmentKind(record: RecordLike): AttachmentKind {
+  const type = stringField(record, ["type", "kind"]);
+  const mime = stringField(record, ["mime_type", "mimeType", "content_type"]);
+  if (type === "image" || mime?.startsWith("image/")) return "image";
+  if (type === "code") return "code";
+  if (stringField(record, ["extracted_content", "extractedContent"])) {
+    return "extracted-text";
+  }
+  return "file";
+}
+
+function attachmentFromRecord(
+  record: RecordLike,
+): NormalizedAttachment | undefined {
+  const extracted = stringField(record, [
+    "extracted_content",
+    "extractedContent",
+    "extracted_text",
+    "extractedText",
+  ]);
+  const code = stringField(record, ["code"]);
+  const name =
+    stringField(record, [
+      "file_name",
+      "filename",
+      "name",
+      "title",
+      "id",
+      "type",
+    ]) ?? "attachment";
+
+  const kind = attachmentKind(record);
+  const text =
+    extracted ??
+    (kind === "code" && code ? maybeFenceCode(code, undefined) : undefined);
+
+  if (!text && name === "attachment" && kind === "file") return undefined;
+
+  return { name, kind, text };
+}
+
+function attachmentsFromMessage(record: RecordLike): NormalizedAttachment[] {
+  const out: NormalizedAttachment[] = [];
+  for (const candidate of [
+    ...arrayField(record, ["attachments", "files"]),
+    ...arrayField(record, ["content"]),
+  ]) {
+    if (!isRecord(candidate)) continue;
+    const attachment = attachmentFromRecord(candidate);
+    if (attachment) out.push(attachment);
+  }
+
+  const seen = new Set<string>();
+  return out.filter((attachment) => {
+    const key = `${attachment.kind}\0${attachment.name}\0${attachment.text ?? ""}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function normalizeMessage(
+  value: unknown,
+  opts: Required<ParseOptions>,
+): NormalizedMessage | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const role = normalizeRole(stringField(value, ["sender", "role"]));
+  if (!role) return undefined;
+
+  const attachments = opts.includeAttachments
+    ? attachmentsFromMessage(value)
+    : [];
+  const text = textFromMessage(value);
+  if (text.trim().length === 0 && attachments.length === 0) return undefined;
+
+  const message: NormalizedMessage = {
+    sourceMessageId: stringField(value, [
+      "uuid",
+      "id",
+      "message_id",
+      "messageId",
+    ]),
+    role,
+    text,
+    createdAt: toEpochMs(
+      stringField(value, ["created_at", "createdAt", "timestamp"]),
+    ),
+    attachments: attachments.length > 0 ? attachments : undefined,
+  };
+
+  return message;
+}
+
+function conversationTimestamps(messages: NormalizedMessage[]): {
+  createdAt?: number;
+  updatedAt?: number;
+} {
+  let createdAt: number | undefined;
+  let updatedAt: number | undefined;
+  for (const message of messages) {
+    if (typeof message.createdAt !== "number") continue;
+    if (createdAt === undefined || message.createdAt < createdAt) {
+      createdAt = message.createdAt;
+    }
+    if (updatedAt === undefined || message.createdAt > updatedAt) {
+      updatedAt = message.createdAt;
+    }
+  }
+  return { createdAt, updatedAt };
+}
+
+function normalizeConversation(
+  value: unknown,
+  index: number,
+  opts: Required<ParseOptions>,
+): NormalizedConversation | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const rawMessages = arrayField(value, ["chat_messages", "messages"]);
+  if (rawMessages.length === 0) return undefined;
+
+  const messages = rawMessages
+    .map((message) => normalizeMessage(message, opts))
+    .filter((message): message is NormalizedMessage => Boolean(message));
+  if (messages.length === 0) return undefined;
+
+  const { createdAt: firstMessageAt, updatedAt: lastMessageAt } =
+    conversationTimestamps(messages);
+  const sourceConversationId =
+    stringField(value, ["uuid", "id", "conversation_id", "conversationId"]) ??
+    `claude-conversation-${index + 1}`;
+  const title =
+    stringField(value, ["name", "title"]) ??
+    `Claude conversation ${sourceConversationId}`;
+
+  return {
+    sourceConversationId,
+    title,
+    createdAt:
+      toEpochMs(stringField(value, ["created_at", "createdAt"])) ??
+      firstMessageAt,
+    updatedAt:
+      toEpochMs(stringField(value, ["updated_at", "updatedAt"])) ??
+      lastMessageAt ??
+      firstMessageAt,
+    messages,
+    meta: {
+      model: stringField(value, ["model", "model_name", "modelName"]),
+      project: stringField(value, ["project", "project_name", "projectName"]),
+      tags: ["claude-export"],
+    },
+  };
+}
+
+function looksLikeClaudeConversation(value: unknown): boolean {
+  return isRecord(value) && Array.isArray(value.chat_messages);
+}
+
+async function resolveInput(
+  input: string,
+): Promise<
+  { kind: "json"; path: string } | { kind: "zip"; path: string } | undefined
+> {
+  let st: Awaited<ReturnType<typeof stat>>;
+  try {
+    st = await stat(input);
+  } catch {
+    return undefined;
+  }
+
+  if (st.isDirectory()) {
+    const jsonPath = path.join(input, CONVERSATIONS_JSON);
+    return existsSync(jsonPath) ? { kind: "json", path: jsonPath } : undefined;
+  }
+
+  if (!st.isFile()) return undefined;
+  if (input.toLowerCase().endsWith(".zip")) {
+    return { kind: "zip", path: input };
+  }
+  if (path.basename(input).toLowerCase() === CONVERSATIONS_JSON) {
+    return { kind: "json", path: input };
+  }
+  return undefined;
+}
+
+async function openConversationsStream(input: string): Promise<Readable> {
+  const resolved = await resolveInput(input);
+  if (!resolved) {
+    throw new Error(
+      `Claude export input must be a directory, ${CONVERSATIONS_JSON}, or .zip`,
+    );
+  }
+
+  if (resolved.kind === "json") {
+    return createReadStream(resolved.path);
+  }
+
+  return openZipEntryStream(resolved.path, CONVERSATIONS_JSON);
+}
+
+async function detect(input: string): Promise<boolean> {
+  try {
+    const resolved = await resolveInput(input);
+    if (!resolved) return false;
+    if (resolved.kind === "zip") {
+      const metadata = await findZipEntryMetadata(
+        resolved.path,
+        CONVERSATIONS_JSON,
+      );
+      if (!metadata) return false;
+    }
+
+    const first = await readFirstJsonArrayObject(
+      await openConversationsStream(input),
+    );
+    return looksLikeClaudeConversation(first);
+  } catch {
+    return false;
+  }
+}
+
+async function* parse(
+  input: string,
+  options?: ParseOptions,
+): AsyncIterable<NormalizedConversation> {
+  const opts: Required<ParseOptions> = { ...DEFAULT_OPTIONS, ...options };
+  const source = await openConversationsStream(input);
+  let index = 0;
+
+  for await (const value of streamJsonArrayObjects(source)) {
+    const conversation = normalizeConversation(value, index, opts);
+    index += 1;
+    if (conversation) yield conversation;
+  }
+}
+
+export const claudeParser: ConversationImporter<string> = {
+  source: SOURCE,
+  detect,
+  parse,
+};
+
+export { detect, parse };
+export default claudeParser;

--- a/packages/import-conversations/src/parsers/fixtures/claude-export/conversations.json
+++ b/packages/import-conversations/src/parsers/fixtures/claude-export/conversations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "uuid": "claude-conv-1",
+    "name": "Project planning",
+    "created_at": "2026-01-01T10:00:00.000Z",
+    "updated_at": "2026-01-01T10:05:00.000Z",
+    "model": "claude-sonnet-4",
+    "project_name": "Agent continuity",
+    "chat_messages": [
+      {
+        "uuid": "msg-1",
+        "sender": "human",
+        "created_at": "2026-01-01T10:00:10.000Z",
+        "text": "Summarize the importer plan",
+        "attachments": [
+          {
+            "file_name": "scope.md",
+            "extracted_content": "Track C should parse Claude chat_messages and inline attachments."
+          }
+        ]
+      },
+      {
+        "uuid": "msg-2",
+        "sender": "assistant",
+        "created_at": "2026-01-01T10:01:00.000Z",
+        "content": [
+          {
+            "type": "text",
+            "text": "Use DocumentService through the shared sink."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uuid": "claude-conv-2",
+    "name": "Code block export",
+    "created_at": "2026-01-02T09:00:00.000Z",
+    "updated_at": "2026-01-02T09:02:00.000Z",
+    "chat_messages": [
+      {
+        "uuid": "msg-3",
+        "sender": "human",
+        "created_at": "2026-01-02T09:00:01.000Z",
+        "content": [
+          {
+            "type": "text",
+            "text": "Here is a snippet"
+          },
+          {
+            "type": "code",
+            "language": "ts",
+            "text": "const ok = true;"
+          }
+        ]
+      },
+      {
+        "uuid": "msg-4",
+        "sender": "assistant",
+        "created_at": "2026-01-02T09:00:30.000Z",
+        "text": "Looks good."
+      }
+    ]
+  }
+]

--- a/packages/import-conversations/src/parsers/json-array-stream.ts
+++ b/packages/import-conversations/src/parsers/json-array-stream.ts
@@ -1,0 +1,113 @@
+import type { Readable } from "node:stream";
+
+/**
+ * Stream a top-level JSON array one object at a time.
+ *
+ * Conversation exports put all conversations in a single `conversations.json`
+ * array. This parser keeps memory bounded by accumulating only the current
+ * top-level object before handing it to `JSON.parse`.
+ */
+export async function* streamJsonArrayObjects(
+  source: Readable,
+): AsyncIterable<unknown> {
+  source.setEncoding("utf8");
+
+  let sawArrayStart = false;
+  let sawArrayEnd = false;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let current = "";
+
+  try {
+    for await (const chunk of source as AsyncIterable<string>) {
+      for (const ch of chunk) {
+        if (!sawArrayStart) {
+          if (/\s/.test(ch)) continue;
+          if (ch !== "[") {
+            throw new Error("Expected conversations.json to be a JSON array");
+          }
+          sawArrayStart = true;
+          continue;
+        }
+
+        if (sawArrayEnd) {
+          if (/\s/.test(ch)) continue;
+          throw new Error("Unexpected trailing data after JSON array");
+        }
+
+        if (depth === 0) {
+          if (/\s/.test(ch) || ch === ",") continue;
+          if (ch === "]") {
+            sawArrayEnd = true;
+            continue;
+          }
+          if (ch !== "{") {
+            throw new Error("Expected a conversation object in JSON array");
+          }
+          depth = 1;
+          current = "{";
+          inString = false;
+          escaped = false;
+          continue;
+        }
+
+        current += ch;
+
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (ch === "\\") {
+            escaped = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+          continue;
+        }
+
+        if (ch === '"') {
+          inString = true;
+          continue;
+        }
+
+        if (ch === "{" || ch === "[") {
+          depth += 1;
+          continue;
+        }
+
+        if (ch === "}" || ch === "]") {
+          depth -= 1;
+          if (depth === 0) {
+            yield JSON.parse(current) as unknown;
+            current = "";
+          }
+        }
+      }
+    }
+
+    if (!sawArrayStart) {
+      throw new Error("Expected conversations.json to be a JSON array");
+    }
+    if (depth !== 0 || inString) {
+      throw new Error("Unexpected end of JSON while reading conversation");
+    }
+    if (!sawArrayEnd) {
+      throw new Error("Unexpected end of JSON array");
+    }
+  } finally {
+    source.destroy();
+  }
+}
+
+/** Read the first object from a streamed JSON array, then close the stream. */
+export async function readFirstJsonArrayObject(
+  source: Readable,
+): Promise<unknown | undefined> {
+  const iterator = streamJsonArrayObjects(source)[Symbol.asyncIterator]();
+  try {
+    const first = await iterator.next();
+    return first.done ? undefined : first.value;
+  } finally {
+    await iterator.return?.();
+  }
+}

--- a/packages/import-conversations/src/parsers/zip-entry.ts
+++ b/packages/import-conversations/src/parsers/zip-entry.ts
@@ -1,0 +1,175 @@
+import { createReadStream } from "node:fs";
+import { open } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { createInflateRaw } from "node:zlib";
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const ZIP64_SENTINEL_16 = 0xffff;
+const ZIP64_SENTINEL_32 = 0xffffffff;
+const MAX_EOCD_SEARCH = 22 + 0xffff;
+
+type ZipEntryMetadata = {
+  name: string;
+  compressionMethod: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+  encrypted: boolean;
+};
+
+function normalizeEntryName(name: string): string {
+  return name.replace(/\\/g, "/");
+}
+
+function entryMatches(name: string, targetName: string): boolean {
+  const normalized = normalizeEntryName(name);
+  return normalized === targetName || normalized.endsWith(`/${targetName}`);
+}
+
+async function readRange(
+  path: string,
+  start: number,
+  length: number,
+): Promise<Buffer> {
+  const handle = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, start);
+    return bytesRead === length ? buffer : buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function findEndOfCentralDirectory(path: string): Promise<{
+  centralDirectoryOffset: number;
+  centralDirectorySize: number;
+}> {
+  const handle = await open(path, "r");
+  try {
+    const { size } = await handle.stat();
+    const tailLength = Math.min(size, MAX_EOCD_SEARCH);
+    const tailStart = size - tailLength;
+    const tail = Buffer.alloc(tailLength);
+    await handle.read(tail, 0, tailLength, tailStart);
+
+    for (let offset = tailLength - 22; offset >= 0; offset -= 1) {
+      if (tail.readUInt32LE(offset) !== EOCD_SIGNATURE) continue;
+
+      const totalEntries = tail.readUInt16LE(offset + 10);
+      const centralDirectorySize = tail.readUInt32LE(offset + 12);
+      const centralDirectoryOffset = tail.readUInt32LE(offset + 16);
+      if (
+        totalEntries === ZIP64_SENTINEL_16 ||
+        centralDirectorySize === ZIP64_SENTINEL_32 ||
+        centralDirectoryOffset === ZIP64_SENTINEL_32
+      ) {
+        throw new Error("ZIP64 conversation exports are not supported yet");
+      }
+
+      return { centralDirectoryOffset, centralDirectorySize };
+    }
+  } finally {
+    await handle.close();
+  }
+
+  throw new Error("Could not find ZIP central directory");
+}
+
+export async function findZipEntryMetadata(
+  path: string,
+  targetName = "conversations.json",
+): Promise<ZipEntryMetadata | undefined> {
+  const { centralDirectoryOffset, centralDirectorySize } =
+    await findEndOfCentralDirectory(path);
+  const centralDirectory = await readRange(
+    path,
+    centralDirectoryOffset,
+    centralDirectorySize,
+  );
+
+  let offset = 0;
+  while (offset + 46 <= centralDirectory.length) {
+    if (centralDirectory.readUInt32LE(offset) !== CENTRAL_DIRECTORY_SIGNATURE) {
+      throw new Error("Malformed ZIP central directory");
+    }
+
+    const generalPurposeFlags = centralDirectory.readUInt16LE(offset + 8);
+    const compressionMethod = centralDirectory.readUInt16LE(offset + 10);
+    const compressedSize = centralDirectory.readUInt32LE(offset + 20);
+    const uncompressedSize = centralDirectory.readUInt32LE(offset + 24);
+    const fileNameLength = centralDirectory.readUInt16LE(offset + 28);
+    const extraLength = centralDirectory.readUInt16LE(offset + 30);
+    const commentLength = centralDirectory.readUInt16LE(offset + 32);
+    const localHeaderOffset = centralDirectory.readUInt32LE(offset + 42);
+    const nameStart = offset + 46;
+    const nameEnd = nameStart + fileNameLength;
+    const name = centralDirectory.subarray(nameStart, nameEnd).toString("utf8");
+
+    if (
+      compressedSize === ZIP64_SENTINEL_32 ||
+      uncompressedSize === ZIP64_SENTINEL_32 ||
+      localHeaderOffset === ZIP64_SENTINEL_32
+    ) {
+      throw new Error(
+        "ZIP64 conversation export entries are not supported yet",
+      );
+    }
+
+    if (entryMatches(name, targetName)) {
+      return {
+        name: normalizeEntryName(name),
+        compressionMethod,
+        compressedSize,
+        uncompressedSize,
+        localHeaderOffset,
+        encrypted: (generalPurposeFlags & 0x1) !== 0,
+      };
+    }
+
+    offset = nameEnd + extraLength + commentLength;
+  }
+
+  return undefined;
+}
+
+export async function openZipEntryStream(
+  path: string,
+  targetName = "conversations.json",
+): Promise<Readable> {
+  const metadata = await findZipEntryMetadata(path, targetName);
+  if (!metadata) {
+    throw new Error(`ZIP export does not contain ${targetName}`);
+  }
+  if (metadata.encrypted) {
+    throw new Error("Encrypted ZIP conversation exports are not supported");
+  }
+  if (metadata.compressionMethod !== 0 && metadata.compressionMethod !== 8) {
+    throw new Error(
+      `Unsupported ZIP compression method ${metadata.compressionMethod}`,
+    );
+  }
+  if (metadata.compressedSize === 0) {
+    return Readable.from([]);
+  }
+
+  const localHeader = await readRange(path, metadata.localHeaderOffset, 30);
+  if (localHeader.readUInt32LE(0) !== LOCAL_FILE_HEADER_SIGNATURE) {
+    throw new Error("Malformed ZIP local file header");
+  }
+
+  const localFileNameLength = localHeader.readUInt16LE(26);
+  const localExtraLength = localHeader.readUInt16LE(28);
+  const dataStart =
+    metadata.localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+  const dataEnd = dataStart + metadata.compressedSize - 1;
+  const compressed = createReadStream(path, { start: dataStart, end: dataEnd });
+
+  if (metadata.compressionMethod === 0) {
+    return compressed;
+  }
+
+  return compressed.pipe(createInflateRaw());
+}


### PR DESCRIPTION
## What

Track C for #11881: adds a first-class Claude export parser to `@elizaos/import-conversations`.

- Parses Claude `conversations.json` from an export directory, direct JSON file, or `.zip` containing `conversations.json`.
- Streams the top-level JSON array one conversation object at a time instead of materializing the whole export.
- Maps Claude `chat_messages[]` into `NormalizedConversation` / `NormalizedMessage`, including `human` → `user`, typed text/code content blocks, timestamps, model/project metadata, and attachment `extracted_content`.
- Adds a tiny ZIP entry reader for stored/deflated `conversations.json` entries without adding a runtime dependency.
- Exports `./parsers/claude` and root aliases (`claudeParser`, `detectClaudeExport`, `parseClaudeExport`).

Refs #11881.

## Tests

- `bun run --cwd packages/import-conversations test`
- `bun run --cwd packages/import-conversations lint`
- `bun run --cwd packages/import-conversations typecheck`
- `bun run --cwd packages/import-conversations build`