### PR TITLE
feat(import-conversations): Track B — ChatGPT export parser (#11881)

### DIFF
--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -71,6 +71,16 @@
       },
       "import": "./dist/parsers/hermes.js",
       "default": "./dist/parsers/hermes.js"
+    },
+    "./parsers/chatgpt": {
+      "types": "./dist/parsers/chatgpt.d.ts",
+      "eliza-source": {
+        "types": "./src/parsers/chatgpt.ts",
+        "import": "./src/parsers/chatgpt.ts",
+        "default": "./src/parsers/chatgpt.ts"
+      },
+      "import": "./dist/parsers/chatgpt.js",
+      "default": "./dist/parsers/chatgpt.js"
     }
   },
   "devDependencies": {

--- a/packages/import-conversations/src/index.ts
+++ b/packages/import-conversations/src/index.ts
@@ -11,6 +11,12 @@
  */
 
 export * from "./core/index.ts";
+export type { ChatGptParseOptions } from "./parsers/chatgpt.ts";
+export {
+  chatgptParser,
+  flattenChatGptConversation,
+  streamJsonArrayElements,
+} from "./parsers/chatgpt.ts";
 export type { ParseOptions as ClaudeParseOptions } from "./parsers/claude.ts";
 export {
   default as claudeParser,

--- a/packages/import-conversations/src/parsers/chatgpt.test.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.test.ts
@@ -1,0 +1,196 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { ConversationImporterRegistry } from "../core/registry.ts";
+import type { NormalizedConversation } from "../core/types.ts";
+import {
+  chatgptParser,
+  detect,
+  flattenChatGptConversation,
+  parse,
+  streamJsonArrayElements,
+} from "./chatgpt.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const EXPORT_DIR = path.join(here, "fixtures", "chatgpt-export");
+const CONVERSATIONS_FILE = path.join(EXPORT_DIR, "conversations.json");
+
+async function collect(
+  iterable: AsyncIterable<NormalizedConversation>,
+): Promise<NormalizedConversation[]> {
+  const out: NormalizedConversation[] = [];
+  for await (const c of iterable) out.push(c);
+  return out;
+}
+
+/** Feed a string one code unit at a time to stress chunk-boundary handling. */
+async function* byChar(text: string): AsyncGenerator<string> {
+  for (const ch of text) yield ch;
+}
+
+describe("chatgpt parser: flattenChatGptConversation (tree flatten)", () => {
+  it("walks current_node -> root, dropping system/tool-directed/hidden nodes", async () => {
+    const [conv1] = await collect(parse(EXPORT_DIR));
+    expect(conv1.sourceConversationId).toBe("conv-1");
+    expect(conv1.title).toBe("Center a div");
+    expect(conv1.meta?.model).toBe("gpt-4o");
+    // create_time 1704067200 s -> ms; update_time keeps sub-second precision.
+    expect(conv1.createdAt).toBe(1704067200000);
+    expect(conv1.updatedAt).toBe(1704067260500);
+
+    const roles = conv1.messages.map((m) => m.role);
+    const texts = conv1.messages.map((m) => m.text);
+    // root(system,hidden), tool1(recipient!=all), and the a1-alt regen branch
+    // are all excluded; the active thread is exactly 5 messages.
+    expect(roles).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect(texts[0]).toBe("Hello, how do I center a div?");
+    expect(texts[1]).toBe("You can use flexbox.");
+    expect(texts[2]).toBe("Show me the CSS.");
+  });
+
+  it("prunes the inactive regeneration branch (a1-alt is never emitted)", async () => {
+    const [conv1] = await collect(parse(EXPORT_DIR));
+    const joined = conv1.messages.map((m) => m.text).join("\n");
+    expect(joined).not.toContain("CSS grid");
+    expect(joined).not.toContain("Regenerated");
+  });
+
+  it("fences code content and placeholders images with an attachment", async () => {
+    const [conv1] = await collect(parse(EXPORT_DIR));
+    const code = conv1.messages[3];
+    expect(code.text).toBe("```css\n.box { display: flex; }\n```");
+
+    const multimodal = conv1.messages[4];
+    expect(multimodal.text).toBe(
+      "Here is a diagram:\n\n[image: file-service://file-abc]",
+    );
+    expect(multimodal.attachments).toEqual([
+      { name: "file-service://file-abc", kind: "image" },
+    ]);
+  });
+
+  it("skips a conversation whose active thread has no surfaced messages", async () => {
+    // conv-2 is a hidden system root + a tool message -> flattens to nothing.
+    const all = await collect(parse(EXPORT_DIR));
+    expect(all.map((c) => c.sourceConversationId)).toEqual(["conv-1"]);
+  });
+
+  it("falls back to the newest leaf when current_node is missing", () => {
+    const conversation = {
+      conversation_id: "no-current",
+      mapping: {
+        root: { id: "root", parent: null, children: ["u1"], message: null },
+        u1: {
+          id: "u1",
+          parent: "root",
+          children: ["a1"],
+          message: {
+            author: { role: "user" },
+            create_time: 10,
+            content: { content_type: "text", parts: ["hi"] },
+          },
+        },
+        a1: {
+          id: "a1",
+          parent: "u1",
+          children: [],
+          message: {
+            author: { role: "assistant" },
+            create_time: 11,
+            content: { content_type: "text", parts: ["hello"] },
+          },
+        },
+      },
+    };
+    const out = flattenChatGptConversation(conversation);
+    expect(out?.messages.map((m) => m.text)).toEqual(["hi", "hello"]);
+  });
+
+  it("returns null for an empty conversation id", () => {
+    expect(
+      flattenChatGptConversation({
+        current_node: "x",
+        mapping: {
+          x: {
+            id: "x",
+            parent: null,
+            children: [],
+            message: {
+              author: { role: "user" },
+              content: { content_type: "text", parts: ["hi"] },
+            },
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("chatgpt parser: streamJsonArrayElements", () => {
+  it("yields the same top-level objects whether fed whole or char-by-char", async () => {
+    const json = JSON.stringify([
+      { a: 1, s: 'has ] and } and " inside' },
+      { b: [1, 2, { c: "nested" }], d: "e" },
+      { e: "unicode ★ and escape \\n" },
+    ]);
+
+    const whole: unknown[] = [];
+    for await (const el of streamJsonArrayElements(asChunks(json))) {
+      whole.push(el);
+    }
+    const streamed: unknown[] = [];
+    for await (const el of streamJsonArrayElements(byChar(json))) {
+      streamed.push(el);
+    }
+
+    expect(streamed).toHaveLength(3);
+    expect(streamed).toEqual(whole);
+    expect((streamed[0] as { s: string }).s).toBe('has ] and } and " inside');
+  });
+
+  it("handles an empty array", async () => {
+    const out: unknown[] = [];
+    for await (const el of streamJsonArrayElements(byChar("[]"))) out.push(el);
+    expect(out).toEqual([]);
+  });
+
+  it("throws when the top-level value is not an array", async () => {
+    await expect(
+      (async () => {
+        for await (const _ of streamJsonArrayElements(byChar('{"x":1}'))) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/expected a top-level JSON array/);
+  });
+});
+
+describe("chatgpt parser: detect() + registry", () => {
+  it("detects a ChatGPT export dir and a direct conversations.json path", async () => {
+    expect(await detect(EXPORT_DIR)).toBe(true);
+    expect(await detect(CONVERSATIONS_FILE)).toBe(true);
+  });
+
+  it("does not detect a non-existent path", async () => {
+    expect(await detect(path.join(here, "does-not-exist"))).toBe(false);
+  });
+
+  it("resolves via the registry by detect()", async () => {
+    const registry = new ConversationImporterRegistry();
+    registry.register(chatgptParser);
+    const resolved = await registry.detect(EXPORT_DIR);
+    expect(resolved?.source).toBe("chatgpt");
+  });
+});
+
+/** Split a string into fixed-size chunks (whole-feed comparison helper). */
+async function* asChunks(text: string, size = 7): AsyncGenerator<string> {
+  for (let i = 0; i < text.length; i += size) yield text.slice(i, i + size);
+}

--- a/packages/import-conversations/src/parsers/chatgpt.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.ts
@@ -1,0 +1,487 @@
+/**
+ * ChatGPT export parser (#11881 Track B).
+ *
+ * An official ChatGPT data export is a zip whose payload is a single
+ * `conversations.json` — a JSON **array** of conversation objects. Each
+ * conversation is a message **tree**: `mapping` holds `{ id, message, parent,
+ * children }` nodes and `current_node` points at the active leaf. The active
+ * thread is recovered by walking `current_node → parent` to the root and
+ * reversing; regeneration branches simply are not on that path, so branch
+ * pruning is implicit.
+ *
+ * Exports run 100 MB – 1 GB, so `parse` streams the top-level array element by
+ * element (one conversation in memory at a time) rather than buffering the file
+ * — see {@link streamJsonArrayElements}. The pure {@link flattenChatGptConversation}
+ * is the testable heart: tree walk + node filtering + content flattening.
+ *
+ * Track A owns the {@link NormalizedConversation} contract this maps into.
+ * See conversation-importer-scope.md §formats.
+ */
+
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { ConversationImporter } from "../core/registry.ts";
+import type {
+  NormalizedAttachment,
+  NormalizedConversation,
+  NormalizedMessage,
+  NormalizedRole,
+} from "../core/types.ts";
+
+const SOURCE = "chatgpt" as const;
+const CONVERSATIONS_FILE = "conversations.json";
+
+// --- Source shapes (partial — only the fields we read) ----------------------
+
+interface ChatGptAuthor {
+  role?: string;
+  name?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+interface ChatGptContent {
+  content_type?: string;
+  /** `text`: string[]; `multimodal_text`: (string | object)[]. */
+  parts?: unknown[];
+  /** `code` content type. */
+  text?: string;
+  language?: string;
+}
+
+interface ChatGptMessage {
+  id?: string;
+  author?: ChatGptAuthor | null;
+  /** Epoch SECONDS (float). */
+  create_time?: number | null;
+  content?: ChatGptContent | null;
+  /** Non-`all` recipient = tool-directed (function call / tool result). */
+  recipient?: string | null;
+  metadata?: {
+    is_visually_hidden_from_conversation?: boolean;
+    is_user_system_message?: boolean;
+    model_slug?: string;
+  } | null;
+}
+
+interface ChatGptNode {
+  id?: string;
+  message?: ChatGptMessage | null;
+  parent?: string | null;
+  children?: string[];
+}
+
+interface ChatGptConversation {
+  title?: string;
+  /** Epoch SECONDS (float). */
+  create_time?: number | null;
+  update_time?: number | null;
+  mapping?: Record<string, ChatGptNode>;
+  current_node?: string | null;
+  conversation_id?: string;
+  id?: string;
+}
+
+export type ChatGptParseOptions = {
+  /**
+   * Keep `system` messages that carry visible text (custom instructions can
+   * land here). Off by default — most system nodes are empty/hidden roots.
+   */
+  includeSystem?: boolean;
+};
+
+const DEFAULT_OPTIONS: Required<ChatGptParseOptions> = {
+  includeSystem: false,
+};
+
+// --- Content flattening -----------------------------------------------------
+
+function secondsToMs(value: number | null | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.round(value * 1000);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A recognizable attachment name for a non-text multimodal part. */
+function attachmentFromPart(
+  part: Record<string, unknown>,
+): NormalizedAttachment | undefined {
+  const contentType =
+    typeof part.content_type === "string" ? part.content_type : undefined;
+  const pointer =
+    typeof part.asset_pointer === "string" ? part.asset_pointer : undefined;
+  if (contentType === "image_asset_pointer" || pointer) {
+    return {
+      name: pointer ?? "image",
+      kind: "image",
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Flatten a single message's `content` into markdown-safe text plus any
+ * attachments. Returns `null` when the content type is one we never surface as
+ * transcript text (tool/browsing/execution output).
+ */
+function flattenContent(
+  content: ChatGptContent | null | undefined,
+): { text: string; attachments: NormalizedAttachment[] } | null {
+  if (!content) return { text: "", attachments: [] };
+  const type = content.content_type ?? "text";
+
+  if (type === "text") {
+    const parts = Array.isArray(content.parts) ? content.parts : [];
+    const text = parts
+      .filter((p): p is string => typeof p === "string")
+      .join("\n\n")
+      .trim();
+    return { text, attachments: [] };
+  }
+
+  if (type === "code") {
+    const code = typeof content.text === "string" ? content.text : "";
+    if (!code.trim()) return { text: "", attachments: [] };
+    const lang = typeof content.language === "string" ? content.language : "";
+    return {
+      text: `\`\`\`${lang}\n${code}\n\`\`\``,
+      attachments: [],
+    };
+  }
+
+  if (type === "multimodal_text") {
+    const parts = Array.isArray(content.parts) ? content.parts : [];
+    const textPieces: string[] = [];
+    const attachments: NormalizedAttachment[] = [];
+    for (const part of parts) {
+      if (typeof part === "string") {
+        if (part.trim()) textPieces.push(part);
+        continue;
+      }
+      if (isRecord(part)) {
+        const attachment = attachmentFromPart(part);
+        if (attachment) {
+          attachments.push(attachment);
+          textPieces.push(`[${attachment.kind}: ${attachment.name}]`);
+        }
+      }
+    }
+    return { text: textPieces.join("\n\n").trim(), attachments };
+  }
+
+  // execution_output / tether_* / system_error / unknown → not transcript text.
+  return null;
+}
+
+function normalizeRole(role: string | undefined): NormalizedRole | undefined {
+  if (
+    role === "user" ||
+    role === "assistant" ||
+    role === "system" ||
+    role === "tool"
+  ) {
+    return role;
+  }
+  return undefined;
+}
+
+/**
+ * Convert one tree node's message into a NormalizedMessage, or `undefined` when
+ * it should be dropped: no message, unknown/tool role, tool-directed
+ * (`recipient !== "all"`), hidden, or a system message when not requested. An
+ * empty-text message with no attachments is also dropped.
+ */
+function nodeToMessage(
+  node: ChatGptNode,
+  opts: Required<ChatGptParseOptions>,
+): NormalizedMessage | undefined {
+  const message = node.message;
+  if (!message) return undefined;
+
+  const role = normalizeRole(message.author?.role);
+  if (!role) return undefined;
+  if (role === "tool") return undefined;
+  if (role === "system" && !opts.includeSystem) return undefined;
+
+  // Tool-directed turns (function calls / results) carry a non-"all" recipient.
+  if (typeof message.recipient === "string" && message.recipient !== "all") {
+    return undefined;
+  }
+  if (message.metadata?.is_visually_hidden_from_conversation) return undefined;
+
+  const flattened = flattenContent(message.content);
+  if (!flattened) return undefined;
+  if (!flattened.text && flattened.attachments.length === 0) return undefined;
+
+  const normalized: NormalizedMessage = {
+    role,
+    text: flattened.text,
+  };
+  if (message.id) normalized.sourceMessageId = message.id;
+  const createdAt = secondsToMs(message.create_time);
+  if (createdAt !== undefined) normalized.createdAt = createdAt;
+  if (flattened.attachments.length > 0) {
+    normalized.attachments = flattened.attachments;
+  }
+  return normalized;
+}
+
+/**
+ * Walk the active thread from `current_node` up to the root and return the node
+ * ids in chronological (root → leaf) order. Falls back to the newest leaf when
+ * `current_node` is missing/dangling. A cycle guard bounds pathological input.
+ */
+function activeThreadNodeIds(conversation: ChatGptConversation): string[] {
+  const mapping = conversation.mapping ?? {};
+  let cursor = conversation.current_node ?? undefined;
+  if (!cursor || !mapping[cursor]) {
+    cursor = fallbackLeaf(mapping);
+  }
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  while (cursor && mapping[cursor] && !seen.has(cursor)) {
+    seen.add(cursor);
+    ids.push(cursor);
+    cursor = mapping[cursor].parent ?? undefined;
+  }
+  return ids.reverse();
+}
+
+/** Newest leaf (node with a message and no children), by message create_time. */
+function fallbackLeaf(
+  mapping: Record<string, ChatGptNode>,
+): string | undefined {
+  let best: string | undefined;
+  let bestTime = Number.NEGATIVE_INFINITY;
+  for (const [id, node] of Object.entries(mapping)) {
+    if (node.children && node.children.length > 0) continue;
+    if (!node.message) continue;
+    const time = node.message.create_time ?? 0;
+    if (time >= bestTime) {
+      bestTime = time;
+      best = id;
+    }
+  }
+  return best;
+}
+
+/**
+ * Flatten one ChatGPT conversation object into a NormalizedConversation, or
+ * `null` when it has no surfaced messages. Pure — the streaming/eager callers
+ * both funnel through here.
+ */
+export function flattenChatGptConversation(
+  conversation: ChatGptConversation,
+  options?: ChatGptParseOptions,
+): NormalizedConversation | null {
+  const opts: Required<ChatGptParseOptions> = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+  const mapping = conversation.mapping ?? {};
+
+  const messages: NormalizedMessage[] = [];
+  let model: string | undefined;
+  for (const id of activeThreadNodeIds(conversation)) {
+    const node = mapping[id];
+    if (!node) continue;
+    const message = nodeToMessage(node, opts);
+    if (!message) continue;
+    messages.push(message);
+    if (!model && message.role === "assistant") {
+      const slug = node.message?.metadata?.model_slug;
+      if (typeof slug === "string" && slug) model = slug;
+    }
+  }
+
+  if (messages.length === 0) return null;
+
+  const sourceConversationId =
+    conversation.conversation_id ?? conversation.id ?? "";
+  if (!sourceConversationId) return null;
+
+  const normalized: NormalizedConversation = {
+    sourceConversationId,
+    messages,
+  };
+  if (typeof conversation.title === "string" && conversation.title.trim()) {
+    normalized.title = conversation.title.trim();
+  }
+  const createdAt = secondsToMs(conversation.create_time);
+  if (createdAt !== undefined) normalized.createdAt = createdAt;
+  const updatedAt = secondsToMs(conversation.update_time);
+  if (updatedAt !== undefined) normalized.updatedAt = updatedAt;
+  if (model) normalized.meta = { model };
+  return normalized;
+}
+
+// --- Streaming top-level JSON array reader ----------------------------------
+
+function isWhitespace(ch: string): boolean {
+  return (
+    ch === " " || ch === "\n" || ch === "\r" || ch === "\t" || ch === "﻿" // leading byte-order mark
+  );
+}
+
+/**
+ * Yield each top-level element of a JSON **array** from a stream of string
+ * chunks, holding at most one element in memory at a time. A proper
+ * string/escape/nesting state machine so braces inside string values do not
+ * confuse depth tracking. Non-object elements are out of spec for a ChatGPT
+ * export; malformed elements throw from `JSON.parse` and are handled by the
+ * caller. This is what keeps a 1 GB `conversations.json` from being buffered.
+ */
+export async function* streamJsonArrayElements(
+  chunks: AsyncIterable<string>,
+): AsyncGenerator<unknown> {
+  let buf = "";
+  let pos = 0;
+  let started = false;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let elemStart = -1;
+
+  for await (const chunk of chunks) {
+    buf += chunk;
+    while (pos < buf.length) {
+      const ch = buf[pos];
+
+      if (!started) {
+        if (ch === "[") {
+          started = true;
+          pos++;
+          continue;
+        }
+        if (isWhitespace(ch)) {
+          pos++;
+          continue;
+        }
+        throw new Error(
+          "ChatGPT export: expected a top-level JSON array in conversations.json",
+        );
+      }
+
+      if (elemStart === -1) {
+        if (ch === "]") return;
+        if (ch === "," || isWhitespace(ch)) {
+          pos++;
+          continue;
+        }
+        elemStart = pos; // element begins at this char; fall through to scan it
+      }
+
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (ch === "\\") escaped = true;
+        else if (ch === '"') inString = false;
+        pos++;
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+        pos++;
+        continue;
+      }
+      if (ch === "{" || ch === "[") {
+        depth++;
+        pos++;
+        continue;
+      }
+      if (ch === "}" || ch === "]") {
+        depth--;
+        pos++;
+        if (depth === 0) {
+          yield JSON.parse(buf.slice(elemStart, pos));
+          buf = buf.slice(pos);
+          pos = 0;
+          elemStart = -1;
+        }
+        continue;
+      }
+      pos++;
+    }
+
+    // End of buffered input mid-scan: drop the already-consumed prefix when we
+    // are between elements so memory stays bounded to the current element.
+    if (elemStart === -1 && pos > 0) {
+      buf = buf.slice(pos);
+      pos = 0;
+    }
+  }
+}
+
+// --- ConversationImporter surface -------------------------------------------
+
+/** Resolve the `conversations.json` path for a dir or a direct file path. */
+function resolveConversationsFile(input: string): string {
+  if (input.toLowerCase().endsWith(".json")) return input;
+  return path.join(input, CONVERSATIONS_FILE);
+}
+
+async function* readFileChunks(filePath: string): AsyncGenerator<string> {
+  const stream = createReadStream(filePath, { encoding: "utf8" });
+  for await (const chunk of stream) {
+    yield chunk as string;
+  }
+}
+
+/**
+ * detect: `input` is a ChatGPT export when it resolves to a readable
+ * `conversations.json` whose first array element carries a `mapping` — the
+ * signature that separates a ChatGPT tree export from a Claude linear export
+ * (which has `chat_messages`).
+ */
+async function detect(input: string): Promise<boolean> {
+  const file = resolveConversationsFile(input);
+  if (!existsSync(file)) return false;
+  try {
+    const st = await stat(file);
+    if (!st.isFile()) return false;
+  } catch {
+    return false;
+  }
+  try {
+    for await (const element of streamJsonArrayElements(readFileChunks(file))) {
+      return (
+        isRecord(element) && isRecord((element as ChatGptConversation).mapping)
+      );
+    }
+  } catch {
+    return false;
+  }
+  return false; // empty array — nothing to import, not a positive match
+}
+
+/**
+ * parse: stream the export's `conversations.json` array, yielding one
+ * NormalizedConversation per source conversation that has surfaced messages.
+ * Conversations that flatten to nothing (all-tool/empty threads) are skipped.
+ */
+async function* parse(
+  input: string,
+  options?: ChatGptParseOptions,
+): AsyncIterable<NormalizedConversation> {
+  const file = resolveConversationsFile(input);
+  for await (const element of streamJsonArrayElements(readFileChunks(file))) {
+    if (!isRecord(element)) continue;
+    const conversation = flattenChatGptConversation(
+      element as ChatGptConversation,
+      options,
+    );
+    if (conversation) yield conversation;
+  }
+}
+
+export const chatgptParser: ConversationImporter<string> = {
+  source: SOURCE,
+  detect,
+  parse,
+};
+
+export { detect, parse };
+export default chatgptParser;

--- a/packages/import-conversations/src/parsers/fixtures/chatgpt-export/conversations.json
+++ b/packages/import-conversations/src/parsers/fixtures/chatgpt-export/conversations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "title": "Center a div",
+    "create_time": 1704067200.0,
+    "update_time": 1704067260.5,
+    "conversation_id": "conv-1",
+    "current_node": "a3",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["u1"],
+        "message": {
+          "id": "m-root",
+          "author": { "role": "system" },
+          "create_time": 1704067200.0,
+          "content": { "content_type": "text", "parts": [""] },
+          "metadata": { "is_visually_hidden_from_conversation": true }
+        }
+      },
+      "u1": {
+        "id": "u1",
+        "parent": "root",
+        "children": ["a1", "a1-alt"],
+        "message": {
+          "id": "m-u1",
+          "author": { "role": "user" },
+          "create_time": 1704067201.0,
+          "content": { "content_type": "text", "parts": ["Hello, how do I center a div?"] },
+          "metadata": {}
+        }
+      },
+      "a1": {
+        "id": "a1",
+        "parent": "u1",
+        "children": ["u2"],
+        "message": {
+          "id": "m-a1",
+          "author": { "role": "assistant" },
+          "create_time": 1704067202.0,
+          "content": { "content_type": "text", "parts": ["You can use flexbox."] },
+          "metadata": { "model_slug": "gpt-4o" }
+        }
+      },
+      "a1-alt": {
+        "id": "a1-alt",
+        "parent": "u1",
+        "children": [],
+        "message": {
+          "id": "m-a1-alt",
+          "author": { "role": "assistant" },
+          "create_time": 1704067203.0,
+          "content": { "content_type": "text", "parts": ["Regenerated: use CSS grid."] },
+          "metadata": { "model_slug": "gpt-4o" }
+        }
+      },
+      "u2": {
+        "id": "u2",
+        "parent": "a1",
+        "children": ["a2"],
+        "message": {
+          "id": "m-u2",
+          "author": { "role": "user" },
+          "create_time": 1704067204.0,
+          "content": { "content_type": "text", "parts": ["Show me the CSS."] },
+          "metadata": {}
+        }
+      },
+      "a2": {
+        "id": "a2",
+        "parent": "u2",
+        "children": ["tool1"],
+        "message": {
+          "id": "m-a2",
+          "author": { "role": "assistant" },
+          "create_time": 1704067205.0,
+          "content": { "content_type": "code", "language": "css", "text": ".box { display: flex; }" },
+          "metadata": { "model_slug": "gpt-4o" }
+        }
+      },
+      "tool1": {
+        "id": "tool1",
+        "parent": "a2",
+        "children": ["a3"],
+        "message": {
+          "id": "m-tool1",
+          "author": { "role": "assistant" },
+          "create_time": 1704067206.0,
+          "recipient": "browser",
+          "content": { "content_type": "text", "parts": ["search(\"center div\")"] },
+          "metadata": {}
+        }
+      },
+      "a3": {
+        "id": "a3",
+        "parent": "tool1",
+        "children": [],
+        "message": {
+          "id": "m-a3",
+          "author": { "role": "assistant" },
+          "create_time": 1704067207.0,
+          "content": {
+            "content_type": "multimodal_text",
+            "parts": [
+              "Here is a diagram:",
+              { "content_type": "image_asset_pointer", "asset_pointer": "file-service://file-abc" }
+            ]
+          },
+          "metadata": { "model_slug": "gpt-4o" }
+        }
+      }
+    }
+  },
+  {
+    "title": "Only tools",
+    "create_time": 1704070000.0,
+    "conversation_id": "conv-2",
+    "current_node": "t1",
+    "mapping": {
+      "sys": {
+        "id": "sys",
+        "parent": null,
+        "children": ["t1"],
+        "message": {
+          "id": "m-sys",
+          "author": { "role": "system" },
+          "content": { "content_type": "text", "parts": [""] },
+          "metadata": { "is_visually_hidden_from_conversation": true }
+        }
+      },
+      "t1": {
+        "id": "t1",
+        "parent": "sys",
+        "children": [],
+        "message": {
+          "id": "m-t1",
+          "author": { "role": "tool" },
+          "create_time": 1704070001.0,
+          "content": { "content_type": "execution_output", "text": "done" },
+          "metadata": {}
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
Parent: #11881. Depends on Track A (core) + registry — both already merged (`958c5a5802f`); Track D (Hermes) landed too. **ChatGPT was the remaining parser gap.**

## Scope

Adds `packages/import-conversations/src/parsers/chatgpt.ts` — a `ConversationImporter<string>` that maps an official ChatGPT export (`conversations.json`) into Track A's `NormalizedConversation` contract. Pure parser, no new deps.

- **`flattenChatGptConversation` (pure, the tested heart):** a ChatGPT conversation is a message **tree** (`mapping` + `current_node`). It recovers the **active thread** by walking `current_node → parent` to the root and reversing — so regeneration branches are **pruned implicitly** (they aren't on that path). Drops null / `system` / `tool`-role / tool-directed (`recipient !== "all"`) / `is_visually_hidden_from_conversation` nodes. Flattens `text` parts, **fences `code`** content (```lang```), and placeholders `multimodal_text` images as `[image: <ptr>]` + an `image` attachment. Derives `meta.model` from the first assistant `model_slug`; falls back to the newest leaf when `current_node` is missing/dangling; cycle-guarded.
- **`streamJsonArrayElements` (1 GB-safe):** a string/escape/nesting-aware state machine that yields the top-level array's objects **one at a time**, holding at most one conversation in memory — the scope's hard requirement for 100 MB–1 GB exports (no streaming-JSON dependency needed).
- **`detect` / `parse` + registry registration**; `.` barrel + `./parsers/chatgpt` subpath export (mirrors `./parsers/hermes`).

## Evidence

`packages/import-conversations/src/parsers/chatgpt.test.ts` drives the parser against a real fixture export:

```
$ bunx vitest run src/parsers/chatgpt.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ bunx vitest run   # whole package — the index export change is safe
 Test Files  8 passed (8)
      Tests  89 passed (89)
```

The 12 cases prove: active-thread flatten with correct role/text ordering; **branch pruning** (the `a1-alt` regeneration is never emitted); code fencing; image placeholder + attachment; **skip** of a tool-only conversation; missing-`current_node` newest-leaf fallback; empty-id → null; **streaming equivalence** fed char-by-char vs 7-char chunks (proves chunk-boundary correctness, incl. `]`/`}`/`"` inside string values); empty-array; non-array rejection; `detect` on a dir and a direct file; registry `detect()` resolution.

Verify: `bunx @biomejs/biome check` clean; `tsgo` typecheck shows no errors in the new files (only the worktree-wide missing-`@types/node` noise).

- **Live-LLM trajectory / UI:** N/A — this is a pure, deterministic format parser with no model call and no UI surface; the fixture-driven unit tests are the proof.

## Out of scope (other #11881 tracks)

Claude parser (Track C), the upload/consent/manage-imports UI (Track E), and the LLM-distillation fast-follow. Provisional note in the file: reconcile with Track A if the `NormalizedConversation` contract evolves.

Refs #11881