### PR TITLE
fix(import-conversations): handle ChatGPT zip exports

### DIFF
--- a/packages/import-conversations/src/parsers/chatgpt.test.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.test.ts
@@ -1,5 +1,8 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 
 import { ConversationImporterRegistry } from "../core/registry.ts";
@@ -27,6 +30,64 @@ async function collect(
 /** Feed a string one code unit at a time to stress chunk-boundary handling. */
 async function* byChar(text: string): AsyncGenerator<string> {
   for (const ch of text) yield ch;
+}
+
+function makeZipWithConversationsJson(json: string): Buffer {
+  const fileName = "ChatGPT Export/conversations.json";
+  const fileNameBytes = Buffer.from(fileName, "utf8");
+  const compressed = deflateRawSync(Buffer.from(json, "utf8"));
+
+  const localHeader = Buffer.alloc(30);
+  localHeader.writeUInt32LE(0x04034b50, 0);
+  localHeader.writeUInt16LE(20, 4);
+  localHeader.writeUInt16LE(0, 6);
+  localHeader.writeUInt16LE(8, 8);
+  localHeader.writeUInt32LE(0, 10);
+  localHeader.writeUInt32LE(0, 14);
+  localHeader.writeUInt32LE(compressed.length, 18);
+  localHeader.writeUInt32LE(Buffer.byteLength(json), 22);
+  localHeader.writeUInt16LE(fileNameBytes.length, 26);
+  localHeader.writeUInt16LE(0, 28);
+
+  const centralOffset =
+    localHeader.length + fileNameBytes.length + compressed.length;
+  const centralHeader = Buffer.alloc(46);
+  centralHeader.writeUInt32LE(0x02014b50, 0);
+  centralHeader.writeUInt16LE(20, 4);
+  centralHeader.writeUInt16LE(20, 6);
+  centralHeader.writeUInt16LE(0, 8);
+  centralHeader.writeUInt16LE(8, 10);
+  centralHeader.writeUInt32LE(0, 12);
+  centralHeader.writeUInt32LE(0, 16);
+  centralHeader.writeUInt32LE(compressed.length, 20);
+  centralHeader.writeUInt32LE(Buffer.byteLength(json), 24);
+  centralHeader.writeUInt16LE(fileNameBytes.length, 28);
+  centralHeader.writeUInt16LE(0, 30);
+  centralHeader.writeUInt16LE(0, 32);
+  centralHeader.writeUInt16LE(0, 34);
+  centralHeader.writeUInt16LE(0, 36);
+  centralHeader.writeUInt32LE(0, 38);
+  centralHeader.writeUInt32LE(0, 42);
+
+  const centralSize = centralHeader.length + fileNameBytes.length;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(centralSize, 12);
+  eocd.writeUInt32LE(centralOffset, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([
+    localHeader,
+    fileNameBytes,
+    compressed,
+    centralHeader,
+    fileNameBytes,
+    eocd,
+  ]);
 }
 
 describe("chatgpt parser: flattenChatGptConversation (tree flatten)", () => {
@@ -176,6 +237,18 @@ describe("chatgpt parser: detect() + registry", () => {
   it("detects a ChatGPT export dir and a direct conversations.json path", async () => {
     expect(await detect(EXPORT_DIR)).toBe(true);
     expect(await detect(CONVERSATIONS_FILE)).toBe(true);
+  });
+
+  it("detects and parses a zipped official export", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "chatgpt-export-"));
+    await mkdir(path.join(tmp, "nested"));
+    const json = await readFile(CONVERSATIONS_FILE, "utf8");
+    const zipPath = path.join(tmp, "nested", "chatgpt-export.zip");
+    await writeFile(zipPath, makeZipWithConversationsJson(json));
+
+    expect(await detect(zipPath)).toBe(true);
+    const convos = await collect(parse(zipPath));
+    expect(convos.map((c) => c.sourceConversationId)).toEqual(["conv-1"]);
   });
 
   it("does not detect a non-existent path", async () => {

--- a/packages/import-conversations/src/parsers/chatgpt.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.ts
@@ -18,9 +18,10 @@
  * See conversation-importer-scope.md §formats.
  */
 
-import { createReadStream, existsSync } from "node:fs";
+import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import path from "node:path";
+import type { Readable } from "node:stream";
 
 import type { ConversationImporter } from "../core/registry.ts";
 import type {
@@ -29,6 +30,11 @@ import type {
   NormalizedMessage,
   NormalizedRole,
 } from "../core/types.ts";
+import {
+  readFirstJsonArrayObject,
+  streamJsonArrayObjects,
+} from "./json-array-stream.ts";
+import { findZipEntryMetadata, openZipEntryStream } from "./zip-entry.ts";
 
 const SOURCE = "chatgpt" as const;
 const CONVERSATIONS_FILE = "conversations.json";
@@ -417,17 +423,52 @@ export async function* streamJsonArrayElements(
 
 // --- ConversationImporter surface -------------------------------------------
 
-/** Resolve the `conversations.json` path for a dir or a direct file path. */
-function resolveConversationsFile(input: string): string {
-  if (input.toLowerCase().endsWith(".json")) return input;
-  return path.join(input, CONVERSATIONS_FILE);
+async function resolveInput(
+  input: string,
+): Promise<
+  { kind: "json"; path: string } | { kind: "zip"; path: string } | undefined
+> {
+  let st: Awaited<ReturnType<typeof stat>>;
+  try {
+    st = await stat(input);
+  } catch {
+    return undefined;
+  }
+
+  if (st.isDirectory()) {
+    const file = path.join(input, CONVERSATIONS_FILE);
+    try {
+      const fileStat = await stat(file);
+      return fileStat.isFile() ? { kind: "json", path: file } : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (!st.isFile()) return undefined;
+  if (input.toLowerCase().endsWith(".zip")) return { kind: "zip", path: input };
+  if (
+    path.basename(input).toLowerCase() === CONVERSATIONS_FILE ||
+    input.toLowerCase().endsWith(".json")
+  ) {
+    return { kind: "json", path: input };
+  }
+  return undefined;
 }
 
-async function* readFileChunks(filePath: string): AsyncGenerator<string> {
-  const stream = createReadStream(filePath, { encoding: "utf8" });
-  for await (const chunk of stream) {
-    yield chunk as string;
+async function openConversationsStream(input: string): Promise<Readable> {
+  const resolved = await resolveInput(input);
+  if (!resolved) {
+    throw new Error(
+      `ChatGPT export input must be a directory, ${CONVERSATIONS_FILE}, or .zip`,
+    );
   }
+
+  if (resolved.kind === "json") {
+    return createReadStream(resolved.path);
+  }
+
+  return openZipEntryStream(resolved.path, CONVERSATIONS_FILE);
 }
 
 /**
@@ -437,24 +478,24 @@ async function* readFileChunks(filePath: string): AsyncGenerator<string> {
  * (which has `chat_messages`).
  */
 async function detect(input: string): Promise<boolean> {
-  const file = resolveConversationsFile(input);
-  if (!existsSync(file)) return false;
   try {
-    const st = await stat(file);
-    if (!st.isFile()) return false;
-  } catch {
-    return false;
-  }
-  try {
-    for await (const element of streamJsonArrayElements(readFileChunks(file))) {
-      return (
-        isRecord(element) && isRecord((element as ChatGptConversation).mapping)
+    const resolved = await resolveInput(input);
+    if (!resolved) return false;
+    if (resolved.kind === "zip") {
+      const metadata = await findZipEntryMetadata(
+        resolved.path,
+        CONVERSATIONS_FILE,
       );
+      if (!metadata) return false;
     }
+
+    const first = await readFirstJsonArrayObject(
+      await openConversationsStream(input),
+    );
+    return isRecord(first) && isRecord((first as ChatGptConversation).mapping);
   } catch {
     return false;
   }
-  return false; // empty array — nothing to import, not a positive match
 }
 
 /**
@@ -466,8 +507,8 @@ async function* parse(
   input: string,
   options?: ChatGptParseOptions,
 ): AsyncIterable<NormalizedConversation> {
-  const file = resolveConversationsFile(input);
-  for await (const element of streamJsonArrayElements(readFileChunks(file))) {
+  const source = await openConversationsStream(input);
+  for await (const element of streamJsonArrayObjects(source)) {
     if (!isRecord(element)) continue;
     const conversation = flattenChatGptConversation(
       element as ChatGptConversation,

--- a/packages/import-conversations/src/parsers/claude.test.ts
+++ b/packages/import-conversations/src/parsers/claude.test.ts
@@ -129,6 +129,7 @@ describe("claude parser: parse() mapping", () => {
     expect(first.messages[0]?.sourceMessageId).toBe("msg-1");
     expect(first.messages[0]?.text).toContain("Summarize the importer plan");
     expect(first.messages[1]?.text).toContain("Use DocumentService");
+    expect(first.messages[1]?.attachments).toBeUndefined();
   });
 
   it("flattens typed content blocks and code blocks", async () => {
@@ -138,6 +139,7 @@ describe("claude parser: parse() mapping", () => {
     expect(second.messages[0]?.text).toContain("Here is a snippet");
     expect(second.messages[0]?.text).toContain("```ts");
     expect(second.messages[0]?.text).toContain("const ok = true;");
+    expect(second.messages[0]?.attachments).toBeUndefined();
   });
 
   it("keeps extracted attachment text as normalized attachments", async () => {

--- a/packages/import-conversations/src/parsers/claude.ts
+++ b/packages/import-conversations/src/parsers/claude.ts
@@ -93,6 +93,7 @@ function textFromContentBlock(block: unknown): string | undefined {
     "content",
     "value",
     "input",
+    "code",
     "name",
   ]);
   if (!text) return undefined;
@@ -131,6 +132,9 @@ function attachmentKind(record: RecordLike): AttachmentKind {
 function attachmentFromRecord(
   record: RecordLike,
 ): NormalizedAttachment | undefined {
+  const type = stringField(record, ["type", "kind"]);
+  if (type === "text" || type === "code") return undefined;
+
   const extracted = stringField(record, [
     "extracted_content",
     "extractedContent",


### PR DESCRIPTION
## What

Follow-up for #11881 after #12006/#12007 landed.

- Makes the ChatGPT parser accept official `.zip` exports containing `conversations.json`, not only directories/direct JSON files.
- Reuses the shared ZIP entry reader and top-level JSON array streamer added by the Claude parser.
- Prevents Claude typed text/code content blocks from being emitted as fake attachments in rendered transcripts.
- Adds regression coverage for zipped ChatGPT exports and Claude typed content blocks without bogus attachments.

Refs #11881.

## Tests

- `bun run --cwd packages/import-conversations test`
- `bun run --cwd packages/import-conversations lint`
- `bunx tsc --noCheck -p packages/import-conversations/tsconfig.build.json`
- `bunx @typescript/native-preview --noEmit -p packages/import-conversations/tsconfig.json`