### PR TITLE
feat(import-conversations): add DocumentService sink adapter

### DIFF
--- a/.github/issue-evidence/11881-document-service-sink.md
+++ b/.github/issue-evidence/11881-document-service-sink.md
@@ -1,0 +1,34 @@
+# Issue #11881: DocumentService sink adapter support slice
+
+## Scope
+
+Track F support work for the conversation importer:
+
+- Added a reusable `createDocumentServiceSink` adapter that maps the importer `DocumentSink` contract to a real `DocumentService`-shaped `addDocument` / `deleteDocument` API.
+- Exported it from the package root and from `@elizaos/import-conversations/adapters/document-service`.
+- Added focused tests for field mapping, deterministic client document ids, context defaults, delete delegation, custom skip-status mapping, and invalid service results.
+
+This does not implement Track E's upload/preview/manage UI.
+
+## Verification
+
+```sh
+bun run --cwd packages/import-conversations lint:fix
+bun run --cwd packages/import-conversations test src/adapters/document-service.test.ts
+bun run --cwd packages/import-conversations test
+bun run --cwd packages/import-conversations typecheck
+bun run --cwd packages/import-conversations build
+git diff --check
+```
+
+Results:
+
+- Adapter test: 1 file passed, 6 tests passed.
+- Full importer package test suite: 10 files passed, 106 tests passed.
+- Typecheck: passed.
+- Build: passed.
+- Whitespace check: passed.
+
+## Notes
+
+The current `DocumentService.addDocument` return value does not expose whether an existing content-based document was skipped. The adapter therefore defaults to `status: "stored"` and accepts `statusFromResult` for callers that can supply a reliable skip signal.

--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -52,6 +52,16 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./adapters/document-service": {
+      "types": "./dist/adapters/document-service.d.ts",
+      "eliza-source": {
+        "types": "./src/adapters/document-service.ts",
+        "import": "./src/adapters/document-service.ts",
+        "default": "./src/adapters/document-service.ts"
+      },
+      "import": "./dist/adapters/document-service.js",
+      "default": "./dist/adapters/document-service.js"
+    },
     "./parsers/claude": {
       "types": "./dist/parsers/claude.d.ts",
       "eliza-source": {

--- a/packages/import-conversations/src/adapters/document-service.test.ts
+++ b/packages/import-conversations/src/adapters/document-service.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import type { SinkDocument } from "../core/sink.ts";
+import {
+  createDocumentServiceSink,
+  type DocumentServiceAddOptions,
+  type DocumentServiceAddResult,
+  type DocumentServiceLike,
+  defaultImportClientDocumentId,
+} from "./document-service.ts";
+
+class FakeDocumentService implements DocumentServiceLike {
+  readonly added: DocumentServiceAddOptions[] = [];
+  readonly deleted: string[] = [];
+  nextResult: DocumentServiceAddResult = {
+    clientDocumentId: "client-doc",
+    storedDocumentMemoryId: "stored-doc",
+    fragmentCount: 2,
+  };
+
+  async addDocument(
+    options: DocumentServiceAddOptions,
+  ): Promise<DocumentServiceAddResult> {
+    this.added.push(options);
+    return this.nextResult;
+  }
+
+  async deleteDocument(documentId: string): Promise<void> {
+    this.deleted.push(documentId);
+  }
+}
+
+function doc(overrides: Partial<SinkDocument> = {}): SinkDocument {
+  return {
+    content: "# Imported transcript\n\nhello",
+    contentType: "text/markdown",
+    originalFilename: "chatgpt/c1.md",
+    scope: "user-private",
+    scopedToEntityId: "user-42",
+    addedFrom: "import",
+    metadata: {
+      import: { source: "chatgpt", sourceConversationId: "c1" },
+      tags: ["import", "import:chatgpt"],
+    },
+    ...overrides,
+  };
+}
+
+describe("createDocumentServiceSink", () => {
+  it("maps SinkDocument fields into DocumentService.addDocument", async () => {
+    const service = new FakeDocumentService();
+    const sink = createDocumentServiceSink(service, {
+      agentId: "agent-1",
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+      addedBy: "owner-1",
+      addedByRole: "OWNER",
+    });
+
+    const result = await sink.addDocument(doc());
+
+    expect(result).toEqual({ id: "stored-doc", status: "stored" });
+    expect(service.added).toHaveLength(1);
+    expect(service.added[0]).toMatchObject({
+      agentId: "agent-1",
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+      contentType: "text/markdown",
+      originalFilename: "chatgpt/c1.md",
+      content: "# Imported transcript\n\nhello",
+      scope: "user-private",
+      scopedToEntityId: "user-42",
+      addedBy: "owner-1",
+      addedByRole: "OWNER",
+      addedFrom: "import",
+      metadata: {
+        import: { source: "chatgpt", sourceConversationId: "c1" },
+        tags: ["import", "import:chatgpt"],
+      },
+    });
+    expect(service.added[0]?.clientDocumentId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("uses context defaults when the sink document omits optional provenance", async () => {
+    const service = new FakeDocumentService();
+    const sink = createDocumentServiceSink(service, {
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+      scopedToEntityId: "fallback-user",
+      addedFrom: "upload",
+    });
+
+    await sink.addDocument(
+      doc({ addedFrom: undefined, scopedToEntityId: undefined }),
+    );
+
+    expect(service.added[0]).toMatchObject({
+      scopedToEntityId: "fallback-user",
+      addedFrom: "upload",
+    });
+  });
+
+  it("allows callers to map a DocumentService result into skipped status", async () => {
+    const service = new FakeDocumentService();
+    service.nextResult = {
+      clientDocumentId: "existing-doc",
+      storedDocumentMemoryId: "existing-doc",
+      fragmentCount: 3,
+    };
+    const sink = createDocumentServiceSink(service, {
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+      statusFromResult: (result) =>
+        result.clientDocumentId === "existing-doc" ? "skipped" : "stored",
+    });
+
+    await expect(sink.addDocument(doc())).resolves.toEqual({
+      id: "existing-doc",
+      status: "skipped",
+    });
+  });
+
+  it("delegates deleteDocument for uninstallBatch", async () => {
+    const service = new FakeDocumentService();
+    const sink = createDocumentServiceSink(service, {
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+    });
+
+    await sink.deleteDocument("doc-123");
+
+    expect(service.deleted).toEqual(["doc-123"]);
+  });
+
+  it("throws when addDocument returns no usable document id", async () => {
+    const service = new FakeDocumentService();
+    service.nextResult = { fragmentCount: 0 };
+    const sink = createDocumentServiceSink(service, {
+      worldId: "world-1",
+      roomId: "room-1",
+      entityId: "entity-1",
+    });
+
+    await expect(sink.addDocument(doc())).rejects.toThrow(
+      /storedDocumentMemoryId or clientDocumentId/,
+    );
+  });
+});
+
+describe("defaultImportClientDocumentId", () => {
+  it("is stable for identical sink documents and changes with content", () => {
+    const first = defaultImportClientDocumentId(doc());
+    const again = defaultImportClientDocumentId(doc());
+    const changed = defaultImportClientDocumentId(doc({ content: "changed" }));
+
+    expect(first).toBe(again);
+    expect(first).not.toBe(changed);
+  });
+});

--- a/packages/import-conversations/src/adapters/document-service.ts
+++ b/packages/import-conversations/src/adapters/document-service.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import type {
+  DocumentScope,
+  DocumentSink,
+  SinkAddResult,
+  SinkDocument,
+} from "../core/sink.ts";
+
+type OpaqueId = string;
+
+export interface DocumentServiceAddOptions {
+  agentId?: OpaqueId;
+  worldId: OpaqueId;
+  roomId: OpaqueId;
+  entityId: OpaqueId;
+  clientDocumentId: OpaqueId;
+  contentType: string;
+  originalFilename: string;
+  content: string;
+  scope?: DocumentScope;
+  scopedToEntityId?: OpaqueId;
+  addedBy?: OpaqueId;
+  addedByRole?: string;
+  addedFrom?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DocumentServiceAddResult {
+  clientDocumentId?: OpaqueId;
+  storedDocumentMemoryId?: OpaqueId;
+  fragmentCount?: number;
+}
+
+export interface DocumentServiceLike {
+  addDocument(
+    options: DocumentServiceAddOptions,
+  ): Promise<DocumentServiceAddResult>;
+  deleteDocument(documentId: OpaqueId): Promise<void>;
+}
+
+export interface DocumentServiceSinkContext {
+  agentId?: OpaqueId;
+  worldId: OpaqueId;
+  roomId: OpaqueId;
+  entityId: OpaqueId;
+  scopedToEntityId?: OpaqueId;
+  addedBy?: OpaqueId;
+  addedByRole?: string;
+  addedFrom?: string;
+}
+
+export interface CreateDocumentServiceSinkOptions
+  extends DocumentServiceSinkContext {
+  clientDocumentId?: (doc: SinkDocument) => OpaqueId;
+  statusFromResult?: (
+    result: DocumentServiceAddResult,
+    doc: SinkDocument,
+  ) => SinkAddResult["status"];
+}
+
+function asUuidFromHash(input: string): string {
+  const hex = createHash("sha256").update(input).digest("hex");
+  const variant = ((parseInt(hex.slice(16, 18), 16) & 0x3f) | 0x80)
+    .toString(16)
+    .padStart(2, "0");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `4${hex.slice(13, 16)}`,
+    `${variant}${hex.slice(18, 20)}`,
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+export function defaultImportClientDocumentId(doc: SinkDocument): string {
+  return asUuidFromHash(
+    [
+      doc.contentType,
+      doc.originalFilename,
+      doc.scope ?? "",
+      doc.scopedToEntityId ?? "",
+      doc.content,
+    ].join("\0"),
+  );
+}
+
+function resultId(result: DocumentServiceAddResult): string {
+  const id = result.storedDocumentMemoryId ?? result.clientDocumentId;
+  if (!id) {
+    throw new Error(
+      "DocumentService sink: addDocument result must include storedDocumentMemoryId or clientDocumentId",
+    );
+  }
+  return id;
+}
+
+export function createDocumentServiceSink(
+  service: DocumentServiceLike,
+  options: CreateDocumentServiceSinkOptions,
+): DocumentSink {
+  const idFor = options.clientDocumentId ?? defaultImportClientDocumentId;
+  const statusFor = options.statusFromResult ?? (() => "stored" as const);
+
+  return {
+    async addDocument(doc: SinkDocument): Promise<SinkAddResult> {
+      const result = await service.addDocument({
+        agentId: options.agentId,
+        worldId: options.worldId,
+        roomId: options.roomId,
+        entityId: options.entityId,
+        clientDocumentId: idFor(doc),
+        contentType: doc.contentType,
+        originalFilename: doc.originalFilename,
+        content: doc.content,
+        scope: doc.scope,
+        scopedToEntityId: doc.scopedToEntityId ?? options.scopedToEntityId,
+        addedBy: options.addedBy,
+        addedByRole: options.addedByRole,
+        addedFrom: doc.addedFrom ?? options.addedFrom ?? "import",
+        metadata: doc.metadata,
+      });
+      return {
+        id: resultId(result),
+        status: statusFor(result, doc),
+      };
+    },
+    deleteDocument(documentId: string): Promise<void> {
+      return service.deleteDocument(documentId);
+    },
+  };
+}

--- a/packages/import-conversations/src/adapters/index.ts
+++ b/packages/import-conversations/src/adapters/index.ts
@@ -1,0 +1,1 @@
+export * from "./document-service.ts";

--- a/packages/import-conversations/src/index.ts
+++ b/packages/import-conversations/src/index.ts
@@ -10,6 +10,7 @@
  * against.
  */
 
+export * from "./adapters/index.ts";
 export * from "./core/index.ts";
 export type { ChatGptParseOptions } from "./parsers/chatgpt.ts";
 export {


### PR DESCRIPTION
## Summary
- add a reusable DocumentSink adapter for DocumentService-shaped add/delete APIs
- export it from the package root and @elizaos/import-conversations/adapters/document-service
- add focused adapter tests and evidence for the Track F support slice

Refs #11881

## Tests
- bun run --cwd packages/import-conversations lint:fix
- bun run --cwd packages/import-conversations test src/adapters/document-service.test.ts
- bun run --cwd packages/import-conversations test
- bun run --cwd packages/import-conversations typecheck
- bun run --cwd packages/import-conversations build
- git diff --check origin/develop..HEAD