### PR TITLE
fix(mobile): stub fsevents in the iOS/Android agent bundle (native-addon leak)

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -254,6 +254,14 @@ const nativeStubs = {
   // portable mobile payload. Mobile does not run desktop password-auth routes,
   // so fail closed if anything reaches this surface.
   "@node-rs/argon2": path.join(stubsDir, "argon2.cjs"),
+  // `fsevents` is a macOS-only OPTIONAL native `.node` file-watcher pulled in
+  // transitively by `chokidar`. On the macOS build host Bun inlines its
+  // `fsevents-*.node` binary into the payload (it has no iOS/Android slice), so
+  // the native-addon leak guard fails the build. Every consumer already treats
+  // fsevents as optional and falls back to polling when it is absent (the normal
+  // non-macOS path), so map it to an empty module — the agent never watches
+  // files on-device.
+  fsevents: path.join(stubsDir, "empty.cjs"),
   "@types/react": path.join(stubsDir, "null-plugin.cjs"),
   "@types/react/jsx-runtime": path.join(stubsDir, "null-plugin.cjs"),
   "@types/react/jsx-dev-runtime": path.join(stubsDir, "null-plugin.cjs"),


### PR DESCRIPTION
The mobile agent-bundle build's native-addon leak guard fails the iOS build:

```
[build-mobile] FATAL: native Node addon(s) leaked into the ios mobile payload: fsevents-*.node
```

`fsevents` is a **macOS-only OPTIONAL** native file-watcher pulled in transitively by `chokidar`. On the macOS build host, Bun inlines its `fsevents-*.node` binary into the payload — but it has no iOS/Android slice, so the leak guard (correctly) aborts. Every fsevents consumer already treats it as optional and falls back to polling when it is absent (the normal Linux/Windows path), and the on-device agent never watches files — so I mapped `fsevents` to the empty stub in `nativeStubs` (alongside `@node-rs/argon2`, `node-llama-cpp`, etc.).

**Unblocks `ios:device:deploy` / `build:ios-bun`.** Verified: `bun run --cwd packages/agent build:ios-bun` now completes clean (agent-bundle.js 36 MB, no leak) where it previously FATAL'd; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)