### PR TITLE
fix(meetings): auto-enable via config feature toggle, drop ELIZA_MEETINGS_ENABLED (#11856)

### DIFF
--- a/plugins/plugin-meetings/AGENTS.md
+++ b/plugins/plugin-meetings/AGENTS.md
@@ -80,20 +80,20 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 
 | Variable | Required | Purpose |
 |---|---|---|
-| `ELIZA_MEETINGS_ENABLED` | No | Opt-in auto-enable flag for the plugin |
 | `ELIZA_MEETINGS_BOT_NAME` | No | Bot display name (default `"<character name> Notetaker"`) |
-| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
+| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable override the platform bots launch |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in because the bots need a Chromium binary on the host —
-matching the env-gated connector plugin pattern. Auto-enable is wired through the
-runtime's manifest mechanism: `package.json`'s `elizaos.plugin.autoEnableModule`
-points at the light root module [`auto-enable.ts`](./auto-enable.ts), whose
-`shouldEnable(ctx)` the resolver runs at boot (this manifest module — not the
-`Plugin.autoEnable` field — is what the loader reads). The predicate ORs the env
-keys but **vetoes auto-enable on mobile** (`ctx.isNativePlatform`, i.e.
-`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
-sandbox, so a set env key must not enable the plugin there.
+Enablement follows the standard feature-toggle convention (cf. plugin-shell /
+plugin-browser) — there is **no bespoke on/off env flag**. Auto-enable is wired
+through the runtime's manifest mechanism: `package.json`'s
+`elizaos.plugin.autoEnableModule` points at the light root module
+[`auto-enable.ts`](./auto-enable.ts), whose `shouldEnable(ctx)` the resolver runs
+at boot (this manifest module — not the `Plugin.autoEnable` field — is what the
+loader reads). It enables when the **`meetings` feature is on in config**
+(`config.features.meetings`) and the host is **not mobile** (`ctx.isNativePlatform`,
+i.e. `ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
+sandbox, so mobile users get meeting transcripts via a cloud-hosted agent instead.
 
 ## Platform support & deployment
 

--- a/plugins/plugin-meetings/CLAUDE.md
+++ b/plugins/plugin-meetings/CLAUDE.md
@@ -80,20 +80,20 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 
 | Variable | Required | Purpose |
 |---|---|---|
-| `ELIZA_MEETINGS_ENABLED` | No | Opt-in auto-enable flag for the plugin |
 | `ELIZA_MEETINGS_BOT_NAME` | No | Bot display name (default `"<character name> Notetaker"`) |
-| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
+| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable override the platform bots launch |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in because the bots need a Chromium binary on the host —
-matching the env-gated connector plugin pattern. Auto-enable is wired through the
-runtime's manifest mechanism: `package.json`'s `elizaos.plugin.autoEnableModule`
-points at the light root module [`auto-enable.ts`](./auto-enable.ts), whose
-`shouldEnable(ctx)` the resolver runs at boot (this manifest module — not the
-`Plugin.autoEnable` field — is what the loader reads). The predicate ORs the env
-keys but **vetoes auto-enable on mobile** (`ctx.isNativePlatform`, i.e.
-`ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
-sandbox, so a set env key must not enable the plugin there.
+Enablement follows the standard feature-toggle convention (cf. plugin-shell /
+plugin-browser) — there is **no bespoke on/off env flag**. Auto-enable is wired
+through the runtime's manifest mechanism: `package.json`'s
+`elizaos.plugin.autoEnableModule` points at the light root module
+[`auto-enable.ts`](./auto-enable.ts), whose `shouldEnable(ctx)` the resolver runs
+at boot (this manifest module — not the `Plugin.autoEnable` field — is what the
+loader reads). It enables when the **`meetings` feature is on in config**
+(`config.features.meetings`) and the host is **not mobile** (`ctx.isNativePlatform`,
+i.e. `ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
+sandbox, so mobile users get meeting transcripts via a cloud-hosted agent instead.
 
 ## Platform support & deployment
 

--- a/plugins/plugin-meetings/README.md
+++ b/plugins/plugin-meetings/README.md
@@ -80,21 +80,20 @@ Signal/WhatsApp pairing events use. No changes in `packages/agent` were needed.
 
 | Variable | Required | Purpose |
 |---|---|---|
-| `ELIZA_MEETINGS_ENABLED` | No | Opt-in auto-enable flag for the plugin |
 | `ELIZA_MEETINGS_BOT_NAME` | No | Bot display name (default `"<character name> Notetaker"`) |
-| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable the platform bots launch; also auto-enables the plugin |
+| `ELIZA_MEETINGS_CHROMIUM_PATH` | No | Chromium executable override the platform bots launch |
 | `ELIZA_MEETINGS_HEADLESS` | No | Force headless (`true`) / headed (`false`). When unset, auto-detected from the available display (macOS/Windows always headed; Linux headed only when `DISPLAY`/`WAYLAND_DISPLAY` is set) |
 
-The plugin is opt-in because the bots need a Chromium binary on the host —
-matching the env-gated connector plugin pattern. Auto-enable is wired through
-the runtime's manifest mechanism: `package.json`'s
+Enablement follows the standard feature-toggle convention (cf. plugin-shell /
+plugin-browser) — there is **no bespoke on/off env flag**. Auto-enable is wired
+through the runtime's manifest mechanism: `package.json`'s
 `elizaos.plugin.autoEnableModule` points at the light root module
-[`auto-enable.ts`](./auto-enable.ts), whose `shouldEnable(ctx)` the resolver
-runs at boot (this manifest module — not the `Plugin.autoEnable` field — is what
-the loader reads). The predicate ORs the env keys but **vetoes auto-enable on
-mobile** (`ctx.isNativePlatform`, i.e. `ELIZA_PLATFORM=android|ios`): browser
-automation cannot run in an Android/iOS sandbox, so a set env key must not enable
-the plugin there — mobile users get meeting transcripts via a cloud-hosted agent.
+[`auto-enable.ts`](./auto-enable.ts), whose `shouldEnable(ctx)` the resolver runs
+at boot (this manifest module — not the `Plugin.autoEnable` field — is what the
+loader reads). It enables when the **`meetings` feature is on in config**
+(`config.features.meetings`) and the host is **not mobile** (`ctx.isNativePlatform`,
+i.e. `ELIZA_PLATFORM=android|ios`): browser automation cannot run in an Android/iOS
+sandbox, so mobile users get meeting transcripts via a cloud-hosted agent instead.
 
 ## Platform support & deployment
 

--- a/plugins/plugin-meetings/auto-enable.ts
+++ b/plugins/plugin-meetings/auto-enable.ts
@@ -5,26 +5,39 @@
 // auto-enable engine reads: `packages/agent/src/runtime/plugin-resolver.ts`
 // walks each plugin's package.json and runs `autoEnableModule.shouldEnable(ctx)`
 // ("Auto-enable is sourced exclusively from per-plugin manifests … no central
-// map exists"). Keep this module light: env reads only, no service init, no
-// transitive imports of the plugin runtime (Playwright / the browser bots) — the
-// engine dynamic-imports dozens of these per boot.
+// map exists"). Keep this module light: config/env reads only, no service init,
+// no transitive imports of the plugin runtime (Playwright / the browser bots) —
+// the engine dynamic-imports dozens of these per boot.
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
+/** `config.features.<key>` truthy / not explicitly `{ enabled: false }`. */
+function isFeatureEnabled(
+  config: PluginAutoEnableContext["config"],
+  key: string,
+): boolean {
+  const feature = (config.features as Record<string, unknown> | undefined)?.[
+    key
+  ];
+  if (feature === true) return true;
+  if (feature && typeof feature === "object") {
+    return (feature as Record<string, unknown>).enabled !== false;
+  }
+  return false;
+}
+
 /**
- * The browser meeting bots need a Chromium binary on the host, so the plugin is
- * opt-in: it auto-enables only when the operator flags it via
- * `ELIZA_MEETINGS_ENABLED` or points at a Chromium binary via
- * `ELIZA_MEETINGS_CHROMIUM_PATH`.
+ * Enable when the user has turned the "meetings" feature on in their config AND
+ * the host can actually run the browser bots.
  *
- * The mobile veto keeps the flag honest: browser automation cannot run inside an
- * Android / iOS app sandbox, so even a set env key must NOT auto-enable there
- * (mobile users get meeting transcripts via a cloud-hosted agent — see
- * docs/DEPLOYMENT.md). `ctx.isNativePlatform` is the engine's own
- * `isMobilePlatform(process.env)` probe, so the veto needs no runtime import.
+ * No bespoke on/off env flag — the plugin follows the standard feature-toggle
+ * convention (cf. plugin-shell / plugin-browser): it comes on when meetings is
+ * enabled in config, not when an `ELIZA_MEETINGS_*` switch is set. The only
+ * capability gate is the mobile veto: browser automation cannot run inside an
+ * Android / iOS app sandbox (`ctx.isNativePlatform`, which the resolver derives
+ * from `isMobilePlatform(process.env)`), so mobile users route meeting
+ * transcripts through a cloud-hosted agent instead. `ELIZA_MEETINGS_CHROMIUM_PATH`
+ * stays a Chromium-resolution override, not an enable switch.
  */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
-  if (ctx.isNativePlatform) return false;
-  const enabled = ctx.env.ELIZA_MEETINGS_ENABLED?.trim();
-  const chromiumPath = ctx.env.ELIZA_MEETINGS_CHROMIUM_PATH?.trim();
-  return Boolean(enabled || chromiumPath);
+  return isFeatureEnabled(ctx.config, "meetings") && !ctx.isNativePlatform;
 }

--- a/plugins/plugin-meetings/docs/DEPLOYMENT.md
+++ b/plugins/plugin-meetings/docs/DEPLOYMENT.md
@@ -41,13 +41,13 @@ on XTEST-grade input. Pick pure headless only for a Teams/Zoom-only deployment.
 
 ## (a) Local desktop — headed, system Chrome
 
-macOS / Windows / a Linux desktop with a session. Nothing extra needed: a
-display is always present, so the plugin auto-selects **headed**, and the system
-Chrome/Edge channel is used if no bundled browser is installed.
+macOS / Windows / a Linux desktop with a session. Turn on the `meetings` feature
+in your agent config (`features.meetings`) — no env flag needed. A display is
+always present, so the plugin auto-selects **headed**, and the system Chrome/Edge
+channel is used if no bundled browser is installed.
 
 ```bash
-export ELIZA_MEETINGS_ENABLED=1
-# optional: pin a specific browser binary
+# optional: pin a specific browser binary instead of the system channel
 # export ELIZA_MEETINGS_CHROMIUM_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 ```
 
@@ -74,9 +74,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ### env
 
+Enable the `meetings` feature in the agent config baked into (or mounted onto)
+the image; the vars below are runtime tuning, not an enable switch.
+
 ```dockerfile
-ENV ELIZA_MEETINGS_ENABLED=1 \
-    ELIZA_MEETINGS_HEADLESS=false \
+ENV ELIZA_MEETINGS_HEADLESS=false \
     DISPLAY=:99
 # Point at a Chromium binary if you don't ship playwright's bundled download:
 # ENV ELIZA_MEETINGS_CHROMIUM_PATH=/usr/bin/chromium

--- a/plugins/plugin-meetings/src/auto-enable.test.ts
+++ b/plugins/plugin-meetings/src/auto-enable.test.ts
@@ -1,23 +1,22 @@
 import { readFileSync } from "node:fs";
 import type { PluginAutoEnableContext } from "@elizaos/core";
-import { isMobilePlatform } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { shouldEnable } from "../auto-enable.ts";
-import { meetingsPlugin } from "./index.js";
 
 // The auto-enable engine loads a plugin ONLY when its package.json declares
 // `elizaos.plugin.autoEnableModule` and that module exports `shouldEnable(ctx)`
 // (packages/agent/src/runtime/plugin-resolver.ts — "sourced exclusively from
-// per-plugin manifests"). The runtime `Plugin.autoEnable` field is NOT read by
-// the loader. These tests guard the manifest wiring so the plugin can never
-// regress back to being undiscoverable.
+// per-plugin manifests"). These tests guard the manifest wiring and the
+// config-driven enable predicate (no bespoke ELIZA_MEETINGS_* on/off flag).
 
 function ctx(
-  env: Record<string, string | undefined>,
+  config: Record<string, unknown>,
   isNativePlatform = false,
 ): PluginAutoEnableContext {
-  return { env, config: {}, isNativePlatform };
+  return { env: {}, config, isNativePlatform };
 }
+
+const withMeetings = (value: unknown) => ({ features: { meetings: value } });
 
 describe("plugin-meetings auto-enable manifest wiring", () => {
   it("declares autoEnableModule pointing at the shipped root module", () => {
@@ -33,48 +32,30 @@ describe("plugin-meetings auto-enable manifest wiring", () => {
 });
 
 describe("plugin-meetings shouldEnable", () => {
-  it("does NOT enable when no opt-in env is set", () => {
+  it("does NOT enable when the meetings feature is absent or turned off", () => {
     expect(shouldEnable(ctx({}))).toBe(false);
-    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "   " }))).toBe(false);
+    expect(shouldEnable(ctx({ features: {} }))).toBe(false);
+    expect(shouldEnable(ctx(withMeetings(false)))).toBe(false);
+    expect(shouldEnable(ctx(withMeetings({ enabled: false })))).toBe(false);
   });
 
-  it("enables on the explicit opt-in flag", () => {
-    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "1" }))).toBe(true);
-    expect(shouldEnable(ctx({ ELIZA_MEETINGS_ENABLED: "true" }))).toBe(true);
+  it("enables when the meetings feature is on in config", () => {
+    expect(shouldEnable(ctx(withMeetings(true)))).toBe(true);
+    expect(shouldEnable(ctx(withMeetings({ enabled: true })))).toBe(true);
+    // A feature object without an explicit `enabled: false` is treated as on.
+    expect(shouldEnable(ctx(withMeetings({ botName: "Notetaker" })))).toBe(true);
   });
 
-  it("enables when a Chromium binary is provided", () => {
-    expect(
-      shouldEnable(ctx({ ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium" })),
-    ).toBe(true);
+  it("does NOT key off any ELIZA_MEETINGS_* env flag (no bespoke switch)", () => {
+    const withEnvOnly: PluginAutoEnableContext = {
+      env: { ELIZA_MEETINGS_ENABLED: "1", ELIZA_MEETINGS_CHROMIUM_PATH: "/x" },
+      config: {},
+      isNativePlatform: false,
+    };
+    expect(shouldEnable(withEnvOnly)).toBe(false);
   });
 
-  it("vetoes mobile even when the opt-in flag is set (no browser sandbox)", () => {
-    expect(
-      shouldEnable(
-        ctx(
-          {
-            ELIZA_MEETINGS_ENABLED: "1",
-            ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium",
-          },
-          true,
-        ),
-      ),
-    ).toBe(false);
-  });
-
-  it("stays in lockstep with the declarative Plugin.autoEnable predicate", () => {
-    const envs: Record<string, string | undefined>[] = [
-      {},
-      { ELIZA_MEETINGS_ENABLED: "1" },
-      { ELIZA_MEETINGS_CHROMIUM_PATH: "/usr/bin/chromium" },
-      { ELIZA_PLATFORM: "ios", ELIZA_MEETINGS_ENABLED: "1" },
-      { ELIZA_PLATFORM: "android", ELIZA_MEETINGS_CHROMIUM_PATH: "/x" },
-    ];
-    for (const env of envs) {
-      const viaModule = shouldEnable(ctx(env, isMobilePlatform(env)));
-      const viaField = meetingsPlugin.autoEnable?.shouldEnable?.(env, {});
-      expect(viaModule).toBe(viaField);
-    }
+  it("vetoes mobile even when the feature is on (no browser sandbox)", () => {
+    expect(shouldEnable(ctx(withMeetings(true), true))).toBe(false);
   });
 });

--- a/plugins/plugin-meetings/src/index.ts
+++ b/plugins/plugin-meetings/src/index.ts
@@ -11,10 +11,12 @@
  *   - ACTIVE_MEETINGS provider
  *   - /api/meetings* rawPath routes
  *
- * Env:
- *   - ELIZA_MEETINGS_ENABLED       opt-in auto-enable flag
+ * Enable: turn the "meetings" feature on in config (see auto-enable.ts) — no
+ * bespoke on/off env flag; only auto-enables on a non-mobile host.
+ *
+ * Env (all optional):
  *   - ELIZA_MEETINGS_BOT_NAME      bot display name (default "<agent> Notetaker")
- *   - ELIZA_MEETINGS_CHROMIUM_PATH Chromium executable for the platform bots
+ *   - ELIZA_MEETINGS_CHROMIUM_PATH Chromium executable override for the bots
  *   - ELIZA_MEETINGS_HEADLESS      force headless (true) / headed (false); else
  *                                  auto-detected from the available display
  *
@@ -83,10 +85,10 @@ export const meetingsPlugin: Plugin = {
   actions: [joinMeetingAction, leaveMeetingAction, getMeetingTranscriptAction],
   providers: [activeMeetingsProvider],
   routes: meetingsRoutes,
-  // Opt-in auto-enable lives in the package manifest, not here: the runtime only
+  // Auto-enable lives in the package manifest, not here: the runtime only
   // consumes `elizaos.plugin.autoEnableModule` (./auto-enable.ts) — a bare
   // `Plugin.autoEnable` field has no runtime consumer. See ./auto-enable.ts for
-  // the predicate (env-gated with a native-platform veto).
+  // the predicate (config `features.meetings` toggle + a native-platform veto).
 };
 
 export default meetingsPlugin;


### PR DESCRIPTION
Follow-up to #11860 / #11988.

## Why

`@elizaos/plugin-meetings` gated auto-enable on a bespoke `ELIZA_MEETINGS_ENABLED` env flag. That isn't how elizaOS plugins enable — capability plugins come on when their **feature is turned on in config**, not via a custom on/off switch:

- `plugin-shell`: `isFeatureEnabled(ctx.config, "shell") && terminalSupportedByEnv(ctx)`
- `plugin-browser`: `isFeatureEnabled(ctx.config, "browser")`

Meetings needs no API key (bots join anonymously; ASR routes through the runtime model layer). Its only hard prerequisite is a **non-mobile host that can run a browser**.

## Change

`auto-enable.ts` now:

```ts
export function shouldEnable(ctx: PluginAutoEnableContext): boolean {
  return isFeatureEnabled(ctx.config, "meetings") && !ctx.isNativePlatform;
}
```

- Enable when the **`meetings` feature is on in config** (`config.features.meetings`) and the host is not mobile.
- **No `ELIZA_MEETINGS_*` on/off flag.** `ELIZA_MEETINGS_CHROMIUM_PATH` stays a Chromium-resolution *override*, not an enable gate.
- Removed `ELIZA_MEETINGS_ENABLED` from the index Env doc, the README/CLAUDE/AGENTS env table + enablement paragraph, and the DEPLOYMENT examples.

## Evidence

- Unit tests rewritten to the config-driven predicate — feature `on`/`off`/`{enabled:false}`/absent, mobile veto, and an explicit **negative test that `ELIZA_MEETINGS_*` env vars do NOT enable**. Full plugin suite: `198 passed`. Typecheck clean.
- Real-engine end-to-end via `evaluatePluginManifest(candidate, ctx)`:

| config | isNativePlatform | `enabled` |
|---|---|---|
| `{}` | false | `false` |
| `{ features: { meetings: false } }` | false | `false` |
| `{ features: { meetings: true } }` | false | **`true`** |
| `{ features: { meetings: true } }` | true (mobile) | `false` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)