### PR TITLE
fix(plugin-app-control): keep VIEWS off the planner surface on viewless-connector turns with no view intent

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -811,6 +811,117 @@ describe("view switching — VIEWS action resolver", () => {
 			);
 			expect(ok).toBe(true);
 		});
+
+		// The runtime composes the planner's action surface by calling validate
+		// WITHOUT planner options: the mode is inferable from the message text
+		// alone or not at all. On a text connector with no view surface, a turn
+		// whose text carries no view intent must NOT expose VIEWS — the planner
+		// otherwise sees a "view switching is a proactive default" tool it can
+		// only hallucinate with ("Opening your Relationships now" into a Discord
+		// channel that renders no views, observed live).
+		function runtimeWithTasks(tasks: ReadonlyArray<Record<string, unknown>>) {
+			return {
+				agentId: "agent-1",
+				getTasks: vi.fn(async ({ tags }: { tags?: string[] }) =>
+					tasks.filter((task) =>
+						(tags ?? []).some((tag) =>
+							(task.tags as string[] | undefined)?.includes(tag),
+						),
+					),
+				),
+			};
+		}
+
+		it.each(["discord", "telegram", "slack", "whatsapp"])(
+			"keeps VIEWS off the planner surface for a no-view-intent turn on %s (surface-composition validate: no options)",
+			async (source) => {
+				const action = createViewsAction({
+					client: clientFor(REGISTRY),
+					hasOwnerAccess: vi.fn(async () => true),
+				});
+				const ok = await action.validate(
+					runtimeWithTasks([]) as never,
+					sourcedMessage(
+						"lol did you catch what happened on the server last night",
+						source,
+					) as never,
+				);
+				expect(ok).toBe(false);
+			},
+		);
+
+		it("still exposes VIEWS for a no-view-intent turn on a local view-capable surface", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			for (const source of [undefined, "chat", "user_chat", "app"]) {
+				const ok = await action.validate(
+					runtimeWithTasks([]) as never,
+					{
+						entityId: "user-1",
+						roomId: "room-1",
+						agentId: "agent-1",
+						content: {
+							text: "lol did you catch what happened on the server last night",
+							...(source ? { source } : {}),
+						},
+					} as never,
+				);
+				expect(ok).toBe(true);
+			}
+		});
+
+		it("keeps a pending multi-turn create flow reachable on a text connector", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				runtimeWithTasks([
+					{
+						id: "task-1",
+						tags: ["views-create-intent"],
+						metadata: { roomId: "room-1", intent: "make a habit tracker" },
+					},
+				]) as never,
+				sourcedMessage("yes go ahead", "discord") as never,
+			);
+			expect(ok).toBe(true);
+		});
+
+		it("keeps a pending delete confirmation reachable on a text connector (owner only)", async () => {
+			const owner = vi.fn(async () => true);
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: owner,
+			});
+			const pendingDelete = [
+				{
+					id: "task-2",
+					tags: ["views-delete-confirm"],
+					metadata: {
+						roomId: "room-1",
+						viewId: "wallet",
+						viewLabel: "Wallet",
+						pluginName: "plugin-wallet-ui",
+					},
+				},
+			];
+			const ok = await action.validate(
+				runtimeWithTasks(pendingDelete) as never,
+				sourcedMessage("yes", "discord") as never,
+			);
+			expect(ok).toBe(true);
+			expect(owner).toHaveBeenCalled();
+
+			owner.mockResolvedValue(false);
+			const denied = await action.validate(
+				runtimeWithTasks(pendingDelete) as never,
+				sourcedMessage("yes", "discord") as never,
+			);
+			expect(denied).toBe(false);
+		});
 	});
 
 	describe("BUG PROBE: developerMode-gated views reachable by ACTIVE command", () => {

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -832,23 +832,25 @@ describe("view switching — VIEWS action resolver", () => {
 			};
 		}
 
-		it.each(["discord", "telegram", "slack", "whatsapp"])(
-			"keeps VIEWS off the planner surface for a no-view-intent turn on %s (surface-composition validate: no options)",
-			async (source) => {
-				const action = createViewsAction({
-					client: clientFor(REGISTRY),
-					hasOwnerAccess: vi.fn(async () => true),
-				});
-				const ok = await action.validate(
-					runtimeWithTasks([]) as never,
-					sourcedMessage(
-						"lol did you catch what happened on the server last night",
-						source,
-					) as never,
-				);
-				expect(ok).toBe(false);
-			},
-		);
+		it.each([
+			"discord",
+			"telegram",
+			"slack",
+			"whatsapp",
+		])("keeps VIEWS off the planner surface for a no-view-intent turn on %s (surface-composition validate: no options)", async (source) => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				runtimeWithTasks([]) as never,
+				sourcedMessage(
+					"lol did you catch what happened on the server last night",
+					source,
+				) as never,
+			);
+			expect(ok).toBe(false);
+		});
 
 		it("still exposes VIEWS for a no-view-intent turn on a local view-capable surface", async () => {
 			const action = createViewsAction({

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -2329,17 +2329,32 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				return ownerCheck(runtime, message);
 			}
 
-			// Desktop-only navigation/layout ops are invisible on a text connector
-			// that can't render views for the asker. Offering them there lets the
-			// planner pick VIEWS as a silent terminal action (no chat reply) — drop
-			// them so the turn falls back to a real REPLY. Text/content modes stay
-			// available everywhere. (#8613)
-			if (
-				mode &&
-				DESKTOP_ONLY_VIEW_MODES.has(mode) &&
-				messageHasNoViewSurface(message)
-			) {
-				return false;
+			if (messageHasNoViewSurface(message)) {
+				// Desktop-only navigation/layout ops are invisible on a text connector
+				// that can't render views for the asker. Offering them there lets the
+				// planner pick VIEWS as a silent terminal action (no chat reply) — drop
+				// them so the turn falls back to a real REPLY. Text/content modes stay
+				// available everywhere. (#8613)
+				if (mode && DESKTOP_ONLY_VIEW_MODES.has(mode)) {
+					return false;
+				}
+				// No inferable view intent at all. This is how the runtime composes the
+				// planner's action surface (validate is called without planner options),
+				// so returning true here exposes VIEWS — whose description tells the
+				// planner view switching is a proactive DEFAULT — on an ordinary chat
+				// turn over a connector that renders no views. The planner then claims
+				// a navigation it structurally cannot perform ("Opening your
+				// Relationships now" into a Discord channel, observed live). Keep VIEWS
+				// off the surface unless a multi-turn views flow is pending in this
+				// room; execution-time validate re-checks with the planner's options,
+				// so every mode-carrying call above still resolves normally.
+				if (!mode) {
+					if (await hasPendingViewsCreateIntent(runtime, roomId)) return true;
+					if (await hasPendingDeleteConfirm(runtime, roomId)) {
+						return ownerCheck(runtime, message);
+					}
+					return false;
+				}
 			}
 
 			// Read modes are visible to all users.


### PR DESCRIPTION
# keep VIEWS off the planner surface on viewless-connector turns with no view intent

## Bug (observed live)

The bot sent a hallucinated **"Opening your Relationships now"** into a Discord relay channel — it claimed a VIEWS navigation in a channel and context where no view surface exists for the asker, so nothing was (or could be) opened. Related to the known "VIEWS hijacks text-connector turns" class (#8613 fixed one dimension of it).

## Root cause

The runtime composes the planner's action surface by calling `action.validate(runtime, message, state)` **without planner options** (`collectV5PlannerCandidateActions`, `packages/core/src/services/message.ts`). The VIEWS validate only returned `false` on a viewless connector when a **desktop-only mode was inferable from the message text** (#8613). On an ordinary chat turn — text with no view intent at all, which is exactly the hallucination case — `inferMode()` returns `null` and validate fell through to `true`.

That exposed VIEWS to the planner with its description stating view switching is a "COMMON, DEFAULT, PROACTIVE response". The planner then claims a navigation it structurally cannot perform: the reply text ("Opening your X now") is delivered to the connector even though execution-time validate rejects the tool call (it re-runs with the planner's `action=show` options and hits the #8613 gate). The same over-claiming is documented in-repo: `packages/core/src/services/message.ts` notes Stage-1 "observed live: `candidateActions: ["VIEWS"]` on abstract-algebra MCQs".

## Fix — gate on connector/surface capability, not text

In the VIEWS `validate` (`plugins/plugin-app-control/src/actions/views.ts`): when `messageHasNoViewSurface(message)` (external text connector, or a sub-agent relay with viewless/unknown origin) and **no mode is inferable**, return `false` so VIEWS never enters the planner surface for that turn — unless a multi-turn views flow (pending create intent / pending delete confirm) is live in the room, which keeps owner authoring flows working over text connectors.

- Execution-time validate still re-checks with the planner's options, so every mode-carrying call resolves exactly as before.
- View-capable surfaces (dashboard / desktop / app chat, `source` absent or local) are untouched.
- Desktop-only-mode gating (#8613) unchanged; text-producing modes (`list`/`current`/`search`) still available everywhere.

## Test

`plugins/plugin-app-control/src/actions/views-switching.test.ts` — new cases in `validate() gating`:

- a no-view-intent turn on discord/telegram/slack/whatsapp does **not** expose VIEWS (surface-composition validate: no options) — fails without the fix (5 failing cases), passes with it
- the same turn on a local view-capable surface still exposes VIEWS
- a pending multi-turn create flow stays reachable on a text connector
- a pending delete confirmation stays reachable on a text connector, owner-gated

## Verification

- `plugins/plugin-app-control`: **1311/1311 tests pass** (36 files; `ViewManagerView.render.test.tsx` suite fails at import on clean develop too — pre-existing `@elizaos/ui` build artifact resolution, unrelated)
- `views-switching.test.ts`: 170/170 with fix; 5 fail without fix (red/green proven)
- `bun run --cwd plugins/plugin-app-control typecheck` (tsgo): clean
- Rebased on latest `origin/develop` (baabc196ff)

## Evidence notes

- Live trajectory (origin of this fix): Discord relay channel turn where the agent emitted "Opening your Relationships now" with a VIEWS claim and no surface to render it; captured in the deep-verify trajectory/flow audit of the live deployment.
- Video/screenshots: N/A — no UI change; behavior is planner-surface composition on text-connector turns, proven by the red/green validate tests above.
