### PR TITLE
fix(actions): disambiguate overlapping action/provider names + remove the 160-char description cap

### DIFF
--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -327,6 +327,8 @@ export const memoryAction: Action = {
     "Manage agent memory records. op:create stores a new memory; op:search filters by type/entityId/roomId/query; op:update edits text and re-embeds (requires confirm:true); op:delete removes a memory (requires confirm:true).",
   descriptionCompressed:
     "manage agent memory create search update delete; update/delete require confirm:true",
+  routingHint:
+    "store/search/edit the agent's OWN memory records about the user or conversation -> MEMORY; do NOT use for open-web lookups -> WEB_SEARCH, for reading messages already in a channel -> MESSAGE (action=search), or for the skill catalog -> SKILL",
   validate: async () => true,
   handler: async (
     runtime: IAgentRuntime,

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -1,5 +1,5 @@
 /**
- * SHELL action — runs a shell command on the server.
+ * TERMINAL_SHELL action — runs one explicit shell command on the server.
  *
  * When triggered the action:
  *   1. Extracts the command from parameters or MCP-style JSON

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -31,7 +31,7 @@ import { resolveServerOnlyPort } from "@elizaos/shared";
 import { hasOwnerAccess } from "../security/access.ts";
 import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
-const TERMINAL_ACTION_NAME = "SHELL";
+const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
 const MAX_TERMINAL_DATA_CHARS = 16000;
 
 const FAIL = { success: false, text: "" } as const;
@@ -269,15 +269,7 @@ export const terminalAction: Action = {
   contexts: ["terminal", "code", "files", "admin"],
   roleGate: { minRole: "OWNER" },
 
-  similes: [
-    "RUN_IN_TERMINAL",
-    "RUN_COMMAND",
-    "EXECUTE_COMMAND",
-    "TERMINAL",
-    "RUN_SHELL",
-    "EXEC",
-    "CALL_MCP_TOOL",
-  ],
+  similes: ["RUN_IN_TERMINAL", "EXECUTE_COMMAND", "TERMINAL", "RUN_SHELL"],
 
   description:
     "Run a single explicit shell command that the user provided directly. " +
@@ -286,6 +278,8 @@ export const terminalAction: Action = {
     "The command output is captured as a document attachment for native planner follow-up. After the run, decide whether to reply, stay silent, continue with another action, or save the attachment via the clipboard plugin.",
   descriptionCompressed:
     "run one explicit shell command; not build/create/multi-step -> START_CODING_TASK",
+  routingHint:
+    "run ONE explicit user-provided command and capture its output as an attachment in the terminal view -> TERMINAL_SHELL; general shell/build/history or scripted commands -> SHELL (coding-tools); multi-step dev work -> START_CODING_TASK; MCP tools -> MCP",
 
   validate: async () => isLocalCodeExecutionAllowed(),
 

--- a/packages/agent/src/runtime/actions/web-search.ts
+++ b/packages/agent/src/runtime/actions/web-search.ts
@@ -167,6 +167,8 @@ export const webSearch: Action & Record<string, unknown> = {
   // whether Stage-1 labeled the turn "web" or "simple", with no keyword list.
   contexts: [],
   suppressInitialMessage: true,
+  routingHint:
+    "external/open-web or current real-world info (prices, news, weather, public facts about people/places/products, 'latest on...', recommendations) -> WEB_SEARCH; a specific URL you can already name -> WEB_FETCH; do NOT use for the user's own notes/memories/private data -> MEMORY (action=search); for messages already in a channel -> MESSAGE (action=search); for the skill catalog -> SKILL",
   description:
     "Search the open web and answer from the results. " +
     "Use this for any question that needs current, real-world, or external information — prices, exchange rates, weather, sports scores, stock/crypto values, news, current events, recommendations ('best X', 'top Y'), facts about people, places, products, or companies, 'what/who/where/when is …', 'latest on …', 'how to …'. " +

--- a/packages/agent/src/runtime/prompt-compaction.test.ts
+++ b/packages/agent/src/runtime/prompt-compaction.test.ts
@@ -84,7 +84,7 @@ describe("validateIntentActionMap", () => {
     expect(warned).toHaveLength(1);
     expect(warned[0]).toContain("INTENT_ACTION_MAP:");
     expect(warned[0]).toContain("not registered");
-    expect(warned[0]).toContain("terminal: SHELL, RUNTIME");
+    expect(warned[0]).toContain("terminal: SHELL, TERMINAL_SHELL, RUNTIME");
     expect(warned[0]).toContain("plugins not loaded in this config");
     // Per-action detail is preserved at debug level (opt-in TASKS still skipped).
     expect(

--- a/packages/agent/src/runtime/prompt-compaction.ts
+++ b/packages/agent/src/runtime/prompt-compaction.ts
@@ -136,7 +136,7 @@ export const UNIVERSAL_ACTIONS = new Set(["REPLY", "NONE", "IGNORE"]);
  */
 export const INTENT_ACTION_MAP: Record<string, Set<string>> = {
   coding: new Set(["TASKS"]),
-  terminal: new Set(["SHELL", "RUNTIME"]),
+  terminal: new Set(["SHELL", "TERMINAL_SHELL", "RUNTIME"]),
   issues: new Set(["TASKS"]),
   plugin_ui: new Set(["RUNTIME"]),
   wallet: new Set(),

--- a/packages/core/src/__tests__/description-compressed-lint.test.ts
+++ b/packages/core/src/__tests__/description-compressed-lint.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	lintDescriptionCompressed,
-	MAX_DESCRIPTION_LENGTH,
-} from "../utils/description-compressed-lint";
+import { lintDescriptionCompressed } from "../utils/description-compressed-lint";
 
 describe("lintDescriptionCompressed", () => {
 	it("reports a violation for an empty string", () => {
@@ -24,24 +21,10 @@ describe("lintDescriptionCompressed", () => {
 		expect(result.violations).toEqual([]);
 	});
 
-	it("accepts a description at exactly the max length", () => {
-		const text = `Send msg ${"x".repeat(MAX_DESCRIPTION_LENGTH - 9)}`;
-		expect(text.length).toBe(MAX_DESCRIPTION_LENGTH);
-
+	it("does not cap description length (full text reaches the model)", () => {
+		const text = `Send a Slack DM ${"x".repeat(500)}`;
 		const result = lintDescriptionCompressed(text);
-		const lengthViolations = result.violations.filter((v) =>
-			v.startsWith("length:"),
-		);
-		expect(lengthViolations).toEqual([]);
-	});
-
-	it("flags a description longer than the max length", () => {
-		const text = "Send a msg ".repeat(20);
-		expect(text.length).toBeGreaterThan(MAX_DESCRIPTION_LENGTH);
-
-		const result = lintDescriptionCompressed(text);
-		expect(result.ok).toBe(false);
-		expect(result.violations.some((v) => v.startsWith("length:"))).toBe(true);
+		expect(result.violations.some((v) => v.startsWith("length:"))).toBe(false);
 	});
 
 	it("flags banned filler phrases regardless of casing", () => {
@@ -142,11 +125,10 @@ describe("lintDescriptionCompressed", () => {
 	});
 
 	it("returns multiple violations for a description that breaks several rules at once", () => {
-		const text = `This action will ${"x".repeat(MAX_DESCRIPTION_LENGTH)} messages configuration basically simply please use this action in order to reach the user and the agent currently.`;
+		const text = `This action will handle messages configuration basically simply please use this action in order to reach the user and the agent currently.`;
 		const result = lintDescriptionCompressed(text);
 		expect(result.ok).toBe(false);
 
-		const lengthHits = result.violations.filter((v) => v.startsWith("length:"));
 		const phraseHits = result.violations.filter((v) =>
 			v.startsWith("banned-phrase:"),
 		);
@@ -157,7 +139,6 @@ describe("lintDescriptionCompressed", () => {
 			v.startsWith("non-imperative:"),
 		);
 
-		expect(lengthHits.length).toBeGreaterThanOrEqual(1);
 		expect(phraseHits.length).toBeGreaterThanOrEqual(5);
 		expect(wordHits.length).toBeGreaterThanOrEqual(2);
 		expect(leadHits.length).toBe(1);

--- a/packages/core/src/features/advanced-capabilities/actions/message.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/message.ts
@@ -3673,7 +3673,6 @@ export const messageAction: Action = {
 		"DIRECT_MESSAGE",
 		"CHAT",
 		"CHANNEL",
-		"ROOM",
 		// PRD action-catalog aliases. These resolve to MESSAGE subactions via
 		// handler argument routing; see packages/docs/action-prd-map.md.
 		"INBOX_LIST_UNREAD",
@@ -3700,6 +3699,8 @@ export const messageAction: Action = {
 	],
 	description: MESSAGE_DESCRIPTION,
 	descriptionCompressed: MESSAGE_COMPRESSED,
+	routingHint:
+		"send/read/search/triage messages on a connector or channel, or manage the inbox/drafts -> MESSAGE; do NOT use to reply in the CURRENT chat/thread -> REPLY, to join/mute/follow a channel -> ROOM, or to publish to a public feed/timeline -> POST",
 	contexts: MESSAGE_CONTEXTS,
 	roleGate: { minRole: "ADMIN" },
 	parameters: MESSAGE_PARAMETERS,

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -80,7 +80,7 @@ export const coreActionsSpec = {
 		{
 			name: "REPLY",
 			description:
-				"Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. This is not an email reply, inbox workflow, or external-channel send — use the dedicated connector actions for those surfaces.",
+				"Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. Do NOT use REPLY to send to a different channel/person or to run an email/inbox workflow — use MESSAGE (action=send) for a directed send to another channel or DM, MESSAGE inbox operations for triage/drafts, and POST to publish to a public feed.",
 			similes: ["GREET", "RESPOND", "RESPONSE"],
 			parameters: [],
 			examples: [
@@ -1701,7 +1701,7 @@ export const allActionsSpec = {
 		{
 			name: "REPLY",
 			description:
-				"Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. This is not an email reply, inbox workflow, or external-channel send — use the dedicated connector actions for those surfaces.",
+				"Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. Do NOT use REPLY to send to a different channel/person or to run an email/inbox workflow — use MESSAGE (action=send) for a directed send to another channel or DM, MESSAGE inbox operations for triage/drafts, and POST to publish to a public feed.",
 			similes: ["GREET", "RESPOND", "RESPONSE"],
 			parameters: [],
 			examples: [

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -3452,7 +3452,7 @@ export const allActionsSpec = {
 			parameters: [],
 			similes: ["WALK_FORWARD", "MOVE_FORWARD", "GO_FORWARD"],
 			descriptionCompressed:
-				"Start walking the AiNex robot forward. Sends walk.set+walk.command:start to the bridge. the robot keeps walking until AINEX_STOP is issued. Options: speed...",
+				"Start walking the AiNex robot forward. Sends walk.set+walk.command:start to the bridge. the robot keeps walking until AINEX_STOP is issued. Options: speed (1-4), x (0-0.05).",
 		},
 		{
 			name: "AINEX_WAVE",
@@ -4341,7 +4341,7 @@ export const allActionsSpec = {
 						],
 					},
 					descriptionCompressed:
-						"Calendar op. feed, next_event, search_events, create_event, update_event, delete_event, trip_window, bulk_reschedule, check_availability, propose_times...",
+						"Calendar op. feed, next_event, search_events, create_event, update_event, delete_event, trip_window, bulk_reschedule, check_availability, propose_times, update_preferences.",
 				},
 				{
 					name: "intent",
@@ -6394,7 +6394,7 @@ export const allActionsSpec = {
 				},
 			],
 			descriptionCompressed:
-				"Forensic git-history analysis for a path/glob surface. Returns peaks (peak quality moments), drift inflections (where rot started), and a post-mortem...",
+				"Forensic git-history analysis for a path/glob surface. Returns peaks (peak quality moments), drift inflections (where rot started), and a post-mortem narrative. Use when user asks 'when did this code get bad', 'where did rot start in X', or 'analyze git pathology for Y'. Actions: report (default), list (show cached reports).",
 		},
 		{
 			name: "GITHUB",
@@ -6602,7 +6602,7 @@ export const allActionsSpec = {
 				"TAG_VOICE",
 			],
 			descriptionCompressed:
-				"Attach a name to the most recently heard, still-unidentified voice so agent recognizes that person across sessions. Use when the owner says who a recent...",
+				'Attach a name to the most recently heard, still-unidentified voice so agent recognizes that person across sessions. Use when the owner says who a recent speaker is ("that was Jill", "this is my friend Sam").',
 		},
 		{
 			name: "INBOX",
@@ -6628,7 +6628,7 @@ export const allActionsSpec = {
 						],
 					},
 					descriptionCompressed:
-						"Inbox op: list | search | summarize | triage (classify new msgs with the AI triage classifier, then return the pending queue) | reply | snooze | archive |...",
+						"Inbox op: list | search | summarize | triage (classify new msgs with the AI triage classifier, then return the pending queue) | reply | snooze | archive | approve.",
 				},
 				{
 					name: "platforms",
@@ -6785,7 +6785,7 @@ export const allActionsSpec = {
 						],
 					},
 					descriptionCompressed:
-						"Operation: create_issue, get_issue, update_issue, delete_issue, create_comment, update_comment, delete_comment, list_comments, get_activity, clear_activity...",
+						"Operation: create_issue, get_issue, update_issue, delete_issue, create_comment, update_comment, delete_comment, list_comments, get_activity, clear_activity, search_issues. Infer if omitted.",
 				},
 			],
 			descriptionCompressed:
@@ -7068,21 +7068,14 @@ export const allActionsSpec = {
 				"USE_MCP",
 				"CALL_MCP_TOOL",
 				"CALL_TOOL",
-				"USE_TOOL",
 				"USE_MCP_TOOL",
-				"EXECUTE_TOOL",
 				"EXECUTE_MCP_TOOL",
-				"RUN_TOOL",
 				"RUN_MCP_TOOL",
-				"INVOKE_TOOL",
 				"INVOKE_MCP_TOOL",
 				"READ_MCP_RESOURCE",
 				"READ_RESOURCE",
-				"GET_RESOURCE",
 				"GET_MCP_RESOURCE",
-				"FETCH_RESOURCE",
 				"FETCH_MCP_RESOURCE",
-				"ACCESS_RESOURCE",
 				"ACCESS_MCP_RESOURCE",
 			],
 			exampleCalls: [
@@ -8734,7 +8727,7 @@ export const allActionsSpec = {
 						type: "string",
 					},
 					descriptionCompressed:
-						"For action=run: shell command, executed via /bin/bash -c. Keep routine inspection commands bounded. avoid broad scans like du -sh /* when a targeted path is...",
+						"For action=run: shell command, executed via /bin/bash -c. Keep routine inspection commands bounded. avoid broad scans like du -sh /* when a targeted path is enough. For JSON API data, prefer jq or node. use python3, not python, unless the environment explicitly shows python exists. For public unauthenticated API reads, quote URLs and prefer stable no-key endpoints. avoid deprecated, region-blocked, or exchange-gated endpoints when a neutral data API can answer the same question. For crypto spot prices, prefer CoinGecko simple price or Coinbase spot before exchange-gated APIs. avoid legacy Coindesk and Binance when a neutral source can answer. If stdout/stderr are marked empty, the command produced no output. try a different command/source when user still needs a value. Include every requested path in df, e.g. df -h//home. For cleanup candidates, follow the first bounded du result with a targeted du on the largest readable directory before answering. avoid && between du probes when permission-denied paths are expected.",
 				},
 				{
 					name: "description",
@@ -8765,7 +8758,7 @@ export const allActionsSpec = {
 						type: "string",
 					},
 					descriptionCompressed:
-						"Absolute cwd. must not resolve under blocked path. Omit unless user supplied this exact directory or the session was explicitly moved. default session cwd is...",
+						"Absolute cwd. must not resolve under blocked path. Omit unless user supplied this exact directory or the session was explicitly moved. default session cwd is safer than remembered paths.",
 				},
 				{
 					name: "limit",
@@ -9012,7 +9005,7 @@ export const allActionsSpec = {
 						],
 					},
 					descriptionCompressed:
-						"Task operation: create, spawn_agent, send, stop_agent, list_agents, cancel, history, control, share, provision_workspace, submit_workspace, manage_issues...",
+						"Task operation: create, spawn_agent, send, stop_agent, list_agents, cancel, history, control, share, provision_workspace, submit_workspace, manage_issues, archive, reopen.",
 				},
 				{
 					name: "op",
@@ -9109,7 +9102,7 @@ export const allActionsSpec = {
 						type: "string",
 					},
 					descriptionCompressed:
-						"Heuristic backend guess (elizaos, pi-agent, opencode, codex, or claude) for create/spawn_agent/control.resume. This is a weak hint - it loses to the operator...",
+						"Heuristic backend guess (elizaos, pi-agent, opencode, codex, or claude) for create/spawn_agent/control.resume. This is a weak hint - it loses to the operator default/pin and to character routing. To honor an EXPLICIT user request use requestedBackend instead.",
 				},
 				{
 					name: "appMonetized",
@@ -9120,7 +9113,7 @@ export const allActionsSpec = {
 						type: "boolean",
 					},
 					descriptionCompressed:
-						"Set true when user wants the app to EARN MONEY/charge for access - e.g. 'people pay $1 to chat with X', 'charge per msg', 'a paid app', 'monetized', a...",
+						"Set true when user wants the app to EARN MONEY/charge for access - e.g. 'people pay $1 to chat with X', 'charge per msg', 'a paid app', 'monetized', a paywall, or per-use pricing. Judge user's INTENT, not specific keywords. When true the sub-agent gets the monetized Eliza Cloud contract (register for an appId, inference markup, OAuth + affiliate billing) instead of a free static page. Leave unset for a normal free app or non-app task.",
 				},
 				{
 					name: "requestedBackend",
@@ -9132,7 +9125,7 @@ export const allActionsSpec = {
 						enum: ["elizaos", "pi-agent", "opencode", "codex", "claude"],
 					},
 					descriptionCompressed:
-						"Set ONLY when user EXPLICITLY named a coding backend for THIS task (e.g. 'use codex', 'have claude build it') - one of elizaos, pi-agent, opencode, codex...",
+						"Set ONLY when user EXPLICITLY named a coding backend for THIS task (e.g. 'use codex', 'have claude build it') - one of elizaos, pi-agent, opencode, codex, claude. Leave unset if user did not name one. never guess. Unlike agentType this overrides the configured default/pin.",
 				},
 				{
 					name: "taskComplexity",
@@ -9144,7 +9137,7 @@ export const allActionsSpec = {
 						enum: ["simple", "moderate", "hard"],
 					},
 					descriptionCompressed:
-						"Your honest assessment of this coding task's difficulty: 'simple' (small/routine), 'moderate', or 'hard' (large, subtle, multi-file, or architectural). Used...",
+						"Your honest assessment of this coding task's difficulty: 'simple' (small/routine), 'moderate', or 'hard' (large, subtle, multi-file, or architectural). Used only to route to whichever backend the character configured for that difficulty (character.routing.coding.byTag). Judge the task itself - do not echo words from user.",
 				},
 				{
 					name: "agents",
@@ -9233,7 +9226,7 @@ export const allActionsSpec = {
 						type: "boolean",
 					},
 					descriptionCompressed:
-						"For action=spawn_agent, suppress the immediate visible acknowledgement when user explicitly requested no interim reply, such as 'reply only after...",
+						"For action=spawn_agent, suppress the immediate visible acknowledgement when user explicitly requested no interim reply, such as 'reply only after verification'. The sub-agent completion router will post the final result.",
 				},
 				{
 					name: "input",
@@ -10088,7 +10081,7 @@ export const allActionsSpec = {
 				},
 			],
 			descriptionCompressed:
-				"Tunnel operations dispatched by `action`: start, stop, status. The `start` action accepts an optional `port` (defaults to 3000). `stop` and `status` take no...",
+				"Tunnel operations dispatched by `action`: start, stop, status. The `start` action accepts an optional `port` (defaults to 3000). `stop` and `status` take no params. Backed by whichever tunnel plugin is active (local Tailscale CLI, Eliza Cloud headscale, or ngrok).",
 		},
 		{
 			name: "UPDATE_APP",
@@ -10180,8 +10173,6 @@ export const allActionsSpec = {
 				"CALL_SKILL",
 				"USE_AGENT_SKILL",
 				"RUN_AGENT_SKILL",
-				"USE_CAPABILITY",
-				"RUN_CAPABILITY",
 			],
 			exampleCalls: [
 				{
@@ -10815,7 +10806,7 @@ export const allActionsSpec = {
 						},
 					},
 					descriptionCompressed:
-						"Thread lifecycle ops array. Item: type, optional workThreadId, sourceWorkThreadIds, instruction, reason, title, summary, sourceRef, trigger for...",
+						"Thread lifecycle ops array. Item: type, optional workThreadId, sourceWorkThreadIds, instruction, reason, title, summary, sourceRef, trigger for schedule_followup.",
 				},
 			],
 			descriptionCompressed:
@@ -11135,7 +11126,7 @@ export const allActionsSpec = {
 				"Describe what the user is currently looking at through their XR headset camera. Use this when the user asks 'what do you see', 'look at this', or any question about their surroundings.",
 			parameters: [],
 			descriptionCompressed:
-				"Describe what user is looking at through their XR headset camera. Use when user asks 'what do you see', 'look at this', or any question about their...",
+				"Describe what user is looking at through their XR headset camera. Use when user asks 'what do you see', 'look at this', or any question about their surroundings.",
 		},
 		{
 			name: "XR_RESIZE_VIEW",
@@ -11206,7 +11197,7 @@ export const allActionsSpec = {
 				},
 			],
 			descriptionCompressed:
-				"Resizes or repositions the active XR view panel. Set scale (0.5 = half, 1.0 = default, 2.0 = double), distance in meters (1.5 = default, smaller = closer)...",
+				"Resizes or repositions the active XR view panel. Set scale (0.5 = half, 1.0 = default, 2.0 = double), distance in meters (1.5 = default, smaller = closer), or fullscreen.",
 		},
 		{
 			name: "XR_SWITCH_VIEW",

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -5619,6 +5619,68 @@ export const allActionsSpec = {
 			],
 		},
 		{
+			name: "DRAFT_PRESS_RELEASE",
+			description:
+				"Create a draft press release in Eliza Cloud. Use when the user asks to draft or save a PR/press release for later distribution.",
+			parameters: [
+				{
+					name: "title",
+					description: "Press release headline/title.",
+					required: true,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "Press release headline/title.",
+				},
+				{
+					name: "body",
+					description: "Full press release body.",
+					required: true,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "Full press release body.",
+				},
+				{
+					name: "summary",
+					description: "Optional short summary.",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "Optional short summary.",
+				},
+				{
+					name: "targetRegions",
+					description: "Optional target regions such as US or EU.",
+					required: false,
+					schema: {
+						type: "array",
+						items: {
+							type: "string",
+						},
+					},
+					descriptionCompressed: "Optional target regions such as US or EU.",
+				},
+			],
+			descriptionCompressed: "Create a draft press release.",
+			similes: ["CREATE_PRESS_RELEASE", "DRAFT_PR", "WRITE_PRESS_RELEASE"],
+			exampleCalls: [
+				{
+					user: "Use DRAFT_PRESS_RELEASE with the provided parameters.",
+					actions: ["DRAFT_PRESS_RELEASE"],
+					params: {
+						DRAFT_PRESS_RELEASE: {
+							title: "example",
+							body: "example",
+							summary: "example",
+							targetRegions: "example",
+						},
+					},
+				},
+			],
+		},
+		{
 			name: "DUPLICATE_AD_CAMPAIGN",
 			description:
 				"Duplicate a Cloud advertising campaign config and creatives into a new draft. Requires structured campaignId; optional name sets the copy name.",
@@ -6308,6 +6370,15 @@ export const allActionsSpec = {
 			],
 		},
 		{
+			name: "GET_MEETING_TRANSCRIPT",
+			description:
+				"Retrieve the live or final transcript of a meeting the notetaker bot attended.",
+			parameters: [],
+			similes: ["MEETING_NOTES", "SHOW_MEETING_TRANSCRIPT"],
+			descriptionCompressed:
+				"Retrieve the live or final transcript of a meeting the notetaker bot attended.",
+		},
+		{
 			name: "GIT_PATHOLOGY",
 			description:
 				"Forensic git-history analysis for a path/glob surface. Returns peaks (peak quality moments), drift inflections (where rot started), and a post-mortem narrative. Use when the user asks 'when did this code get bad', 'where did rot start in X', or 'analyze git pathology for Y'. Actions: report (default), list (show cached reports).",
@@ -6759,6 +6830,32 @@ export const allActionsSpec = {
 			],
 		},
 		{
+			name: "JOIN_MEETING",
+			description:
+				"Send the agent's notetaker bot into a live Google Meet, Microsoft Teams, or Zoom meeting to attend and transcribe it in real time. Use this WHENEVER the message contains a Meet / Teams / Zoom meeting link (meet.google.com, teams.microsoft.com / teams.live.com, zoom.us / app.zoom.us) and the user wants the agent to join, attend, sit in on, cover, take notes on, record, or transcribe that meeting or call. Prefer this over calendar, reminder, scheduling, or plain reply actions when a joinable meeting URL is present — those only schedule or acknowledge, whereas this actually joins the call now. Requires a meeting URL in the message or a meetingUrl parameter.",
+			parameters: [],
+			similes: [
+				"INVITE_TO_MEETING",
+				"ATTEND_MEETING",
+				"TAKE_MEETING_NOTES",
+				"TRANSCRIBE_MEETING",
+				"RECORD_MEETING",
+				"SEND_NOTETAKER",
+				"JOIN_CALL",
+			],
+			descriptionCompressed:
+				"Send agent's notetaker bot into a live Google Meet, Microsoft Teams, or Zoom meeting to attend and transcribe it in real time. Use this WHENEVER the msg contains a Meet/Teams/Zoom meeting link (meet.google.com, teams.microsoft.com/teams.live.com, zoom.us/app.zoom.us) and user wants agent to join, attend, sit in on, cover, take notes on, record, or transcribe that meeting or call. Prefer this over calendar, reminder, scheduling, or plain reply actions when a joinable meeting URL is present - those only schedule or acknowledge, whereas this joins the call now. Requires a meeting URL in the msg or a meetingUrl param.",
+		},
+		{
+			name: "LEAVE_MEETING",
+			description:
+				"Leave a meeting the notetaker bot is currently attending and finalize its transcript.",
+			parameters: [],
+			similes: ["EXIT_MEETING", "STOP_MEETING_TRANSCRIPTION"],
+			descriptionCompressed:
+				"Leave a meeting the notetaker bot is attending and finalize its transcript.",
+		},
+		{
 			name: "LINEAR",
 			description:
 				"Manage Linear issues/comments/activity. Ops: create_issue, get_issue, update_issue, delete_issue, create_comment, update_comment, delete_comment, list_comments, get_activity, clear_activity, search_issues. Infer op if omitted.",
@@ -6894,6 +6991,14 @@ export const allActionsSpec = {
 			descriptionCompressed:
 				"Browse influencer profiles to book for promotion.",
 			similes: ["BROWSE_INFLUENCERS", "FIND_INFLUENCERS", "SEARCH_INFLUENCERS"],
+		},
+		{
+			name: "LIST_PRESS_RELEASES",
+			description:
+				"List the user's Eliza Cloud press releases and statuses. Use before choosing a draft to submit or edit.",
+			parameters: [],
+			descriptionCompressed: "List press release drafts/submissions.",
+			similes: ["LIST_PR_DRAFTS", "SHOW_PRESS_RELEASES", "MY_PRESS_RELEASES"],
 		},
 		{
 			name: "MANAGE_BROWSER_BRIDGE",
@@ -8974,6 +9079,58 @@ export const allActionsSpec = {
 			similes: ["END_TRANSCRIPTION", "STOP_RECORDING", "FINISH_TRANSCRIPT"],
 			descriptionCompressed:
 				"Stop the long-form voice transcription running on user's device.",
+		},
+		{
+			name: "SUBMIT_PRESS_RELEASE",
+			description:
+				"Submit a press release for paid/provider-backed distribution. Requires explicit confirmation before calling the Cloud submit route.",
+			parameters: [
+				{
+					name: "releaseId",
+					description: "Press release id to submit.",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "Press release id to submit.",
+				},
+				{
+					name: "title",
+					description: "Press release title to resolve.",
+					required: false,
+					schema: {
+						type: "string",
+					},
+					descriptionCompressed: "Press release title to resolve.",
+				},
+				{
+					name: "confirm",
+					description:
+						"Follow-up: true confirms the pending submit, false cancels.",
+					required: false,
+					schema: {
+						type: "boolean",
+					},
+					descriptionCompressed:
+						"Follow-up: true confirms the pending submit, false cancels.",
+				},
+			],
+			descriptionCompressed:
+				"Submit a press release for provider-backed distribution; requires confirm.",
+			similes: ["SUBMIT_PR", "DISTRIBUTE_PRESS_RELEASE", "SEND_PRESS_RELEASE"],
+			exampleCalls: [
+				{
+					user: "Use SUBMIT_PRESS_RELEASE with the provided parameters.",
+					actions: ["SUBMIT_PRESS_RELEASE"],
+					params: {
+						SUBMIT_PRESS_RELEASE: {
+							releaseId: "example",
+							title: "example",
+							confirm: false,
+						},
+					},
+				},
+			],
 		},
 		{
 			name: "TASKS",

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -3169,9 +3169,9 @@ export class AgentRuntime implements IAgentRuntime {
 	registerProvider(provider: Provider) {
 		const canonical = withCanonicalProviderDocs(provider);
 		if (this.providers.find((p) => p.name === canonical.name)) {
-			this.logger.debug(
+			this.logger.warn(
 				{ src: "agent", agentId: this.agentId, provider: canonical.name },
-				"Provider already registered, skipping",
+				"[AgentRuntime] Provider name collision: a provider with this name is already registered; keeping the first and skipping this one. The context the agent sees for this name is load-order-dependent — give the two providers distinct names.",
 			);
 			return;
 		}
@@ -3186,9 +3186,9 @@ export class AgentRuntime implements IAgentRuntime {
 		const canonical = withCanonicalActionDocs(action);
 		Object.assign(action, canonical);
 		if (this.actions.find((a) => a.name === action.name)) {
-			this.logger.debug(
+			this.logger.warn(
 				{ src: "agent", agentId: this.agentId, action: action.name },
-				"Action already registered, skipping",
+				"[AgentRuntime] Action name collision: an action with this name is already registered; keeping the first and skipping this one. Which handler/role-gate wins is load-order-dependent — rename one of the colliding actions to disambiguate.",
 			);
 		} else {
 			this.actions.push(action);

--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -1117,4 +1117,48 @@ describe("integration: action stage records input/output/error (M12)", () => {
 		expect(tool?.errorText).toContain("Connection refused");
 		expect(tool?.input).toBe('{"q":"missing-config"}');
 	});
+
+	it("captures the executed action's model-facing description (incl. routing hint) on the tool stage and renders it in the markdown review", async () => {
+		process.env.ELIZA_TRAJECTORY_REVIEW_MODE = "1";
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-docs",
+			rootMessage: { id: "m-docs", text: "remind me at 9pm" },
+		});
+
+		// The exposed ToolDefinition description = routingHint + "\n" + compressed
+		// description (what the planner actually saw for this action).
+		const modelFacingDescription =
+			"manage EXISTING scheduled items -> SCHEDULED_TASKS; coding work -> TASKS\nmanage owner scheduled items";
+		const toolStage: RecordedStage = {
+			stageId: "stage-tool-SCHEDULED_TASKS",
+			kind: "tool",
+			startedAt: 100,
+			endedAt: 210,
+			latencyMs: 110,
+			tool: {
+				name: "SCHEDULED_TASKS",
+				args: { action: "create" },
+				result: { ok: true },
+				success: true,
+				durationMs: 110,
+				description: modelFacingDescription,
+			},
+		};
+		await recorder.recordStage(id, toolStage);
+		await recorder.endTrajectory(id, "finished");
+
+		// JSON round-trip: the execution record is self-contained.
+		const loaded = await recorder.load(id);
+		const tool = loaded?.stages[0]?.tool;
+		expect(tool?.description).toBe(modelFacingDescription);
+
+		// Markdown review surfaces the when-to-use guidance on the executed action
+		// without cross-referencing the planner stage's model.tools.
+		const markdownPath = path.join(tmpDir, "agent-docs", `${id}.md`);
+		const markdown = await fs.readFile(markdownPath, "utf8");
+		expect(markdown).toContain(
+			"- description: manage EXISTING scheduled items -> SCHEDULED_TASKS",
+		);
+	});
 });

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2119,6 +2119,9 @@ async function executeQueuedToolCall(params: {
 		},
 	});
 
+	const exposedTool = params.params.tools?.find(
+		(tool) => tool.name === params.toolCall.name,
+	);
 	await recordToolStage({
 		recorder: params.params.recorder,
 		trajectoryId: params.params.trajectoryId,
@@ -2128,6 +2131,7 @@ async function executeQueuedToolCall(params: {
 		startedAt,
 		endedAt,
 		logger: params.params.runtime.logger,
+		description: exposedTool?.description,
 	});
 }
 
@@ -2140,6 +2144,7 @@ async function recordToolStage(args: {
 	startedAt: number;
 	endedAt: number;
 	logger?: PlannerRuntime["logger"];
+	description?: string;
 }): Promise<void> {
 	if (!args.recorder || !args.trajectoryId) return;
 	try {
@@ -2162,6 +2167,7 @@ async function recordToolStage(args: {
 				result: args.result,
 				success: args.result.success,
 				durationMs: args.endedAt - args.startedAt,
+				description: args.description,
 				input: io.input,
 				output: io.output,
 				errorText: io.errorText,

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -108,6 +108,16 @@ export interface RecordedToolStage {
 	result: unknown;
 	success: boolean;
 	durationMs: number;
+	/**
+	 * The model-facing tool description the planner was shown for this action —
+	 * i.e. the exposed `ToolDefinition.description`, which is the action's
+	 * `routingHint` (its "use when / do NOT use when" guidance) prepended to the
+	 * compressed description. Captured so a trajectory reviewer or training
+	 * pipeline can see WHAT the action was for — and judge whether the planner
+	 * had enough to disambiguate it — directly from the execution record, without
+	 * cross-referencing the preceding planner stage's `model.tools`.
+	 */
+	description?: string;
 	error?: string;
 	/**
 	 * Captured action-handler input (the resolved params passed into the
@@ -641,6 +651,9 @@ function renderTrajectoryMarkdown(trajectory: RecordedTrajectory): string {
 			lines.push(
 				`- tool: \`${stage.tool.name}\` ${stage.tool.success ? "ok" : "failed"}`,
 			);
+			if (stage.tool.description) {
+				lines.push(`- description: ${stage.tool.description}`);
+			}
 			lines.push(`- duration: ${formatDuration(stage.tool.durationMs)}`);
 			lines.push(
 				...markdownFence(

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -340,9 +340,9 @@ export interface Action {
 	 * CANONICAL "when to use / when NOT to use" carrier. Prefer this field over
 	 * burying disambiguation in `description`: `routingHint` is prepended
 	 * VERBATIM to the planner tool description (see `actions/to-tool.ts`) — it is
-	 * NOT run through `compressPromptDescription`, so it is never abbreviated or
-	 * truncated at the 160-char description cap, and it is captured in recorded
-	 * trajectories via the planner stage's `model.tools`. Any action that shares
+	 * NOT run through `compressPromptDescription`, so it is never abbreviated and
+	 * is captured in recorded trajectories via the planner stage's `model.tools`.
+	 * Any action that shares
 	 * a noun or simile with a sibling (e.g. TASKS vs SCHEDULED_TASKS, WEB_SEARCH
 	 * vs MEMORY search) should state its boundary here, and name the sibling to
 	 * route to, e.g.:

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -336,6 +336,21 @@ export interface Action {
 	 *   - VOICE_CALL:  "explicit call/phone/dial a person/business -> VOICE_CALL first; calendar/email secondary"
 	 * Surfaced into the planner prompt via {{actionRoutingHints}} so each
 	 * action carries its own routing rule alongside its description.
+	 *
+	 * CANONICAL "when to use / when NOT to use" carrier. Prefer this field over
+	 * burying disambiguation in `description`: `routingHint` is prepended
+	 * VERBATIM to the planner tool description (see `actions/to-tool.ts`) — it is
+	 * NOT run through `compressPromptDescription`, so it is never abbreviated or
+	 * truncated at the 160-char description cap, and it is captured in recorded
+	 * trajectories via the planner stage's `model.tools`. Any action that shares
+	 * a noun or simile with a sibling (e.g. TASKS vs SCHEDULED_TASKS, WEB_SEARCH
+	 * vs MEMORY search) should state its boundary here, and name the sibling to
+	 * route to, e.g.:
+	 *   "coding/software delegation -> TASKS; reminders/check-ins/recurring
+	 *    personal items -> SCHEDULED_TASKS/OWNER_REMINDERS (NOT this action)".
+	 * Reference an UPPER_SNAKE_CASE sibling action name explicitly — those tokens
+	 * also survive description compression, so the cross-reference stays intact
+	 * even in the compressed form.
 	 */
 	routingHint?: string;
 

--- a/packages/core/src/utils/description-compressed-lint.ts
+++ b/packages/core/src/utils/description-compressed-lint.ts
@@ -6,18 +6,19 @@
  * compressor would have applied:
  *
  * - Non-empty, trimmed.
- * - At most {@link MAX_DESCRIPTION_LENGTH} characters.
  * - No filler phrases that the compressor strips (`PHRASE_REPLACEMENTS`).
  * - No long-form word forms that the compressor abbreviates
  *   (`WORD_REPLACEMENTS` — `messages`, `configuration`, etc.).
  * - Starts with an imperative verb, not a stative one (`Helps`, `Allows`,
  *   `It`, `This`, `Should`).
  *
+ * There is intentionally NO maximum length: the full description text reaches
+ * the model (see `compressPromptDescription`, which no longer truncates), so a
+ * long-but-clear description with "use when / do NOT use when" guidance is fine.
+ *
  * Intended for ad-hoc tooling/tests. The helper is intentionally pure: caller
  * decides exit-code semantics.
  */
-
-export const MAX_DESCRIPTION_LENGTH = 160;
 
 /**
  * Banned phrases — must be a substring of one of the keys in
@@ -106,12 +107,6 @@ export function lintDescriptionCompressed(
 	}
 
 	const value = text;
-
-	if (value.length > MAX_DESCRIPTION_LENGTH) {
-		violations.push(
-			`length: descriptionCompressed is ${value.length} chars (max ${MAX_DESCRIPTION_LENGTH})`,
-		);
-	}
 
 	for (const { phrase, pattern } of BANNED_PHRASES) {
 		if (pattern.test(value)) {

--- a/packages/prompts/specs/actions/core.json
+++ b/packages/prompts/specs/actions/core.json
@@ -3,7 +3,7 @@
   "actions": [
     {
       "name": "REPLY",
-      "description": "Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. This is not an email reply, inbox workflow, or external-channel send — use the dedicated connector actions for those surfaces.",
+      "description": "Send a direct chat reply in the current conversation/thread. Default if the agent is responding with a message and no other action. Use REPLY at the beginning of a chain of actions as an acknowledgement, and at the end of a chain of actions as a final response. Do NOT use REPLY to send to a different channel/person or to run an email/inbox workflow — use MESSAGE (action=send) for a directed send to another channel or DM, MESSAGE inbox operations for triage/drafts, and POST to publish to a public feed.",
       "similes": ["GREET", "RESPOND", "RESPONSE"],
       "parameters": [],
       "examples": [

--- a/packages/prompts/specs/actions/plugins.generated.json
+++ b/packages/prompts/specs/actions/plugins.generated.json
@@ -3168,21 +3168,14 @@
         "USE_MCP",
         "CALL_MCP_TOOL",
         "CALL_TOOL",
-        "USE_TOOL",
         "USE_MCP_TOOL",
-        "EXECUTE_TOOL",
         "EXECUTE_MCP_TOOL",
-        "RUN_TOOL",
         "RUN_MCP_TOOL",
-        "INVOKE_TOOL",
         "INVOKE_MCP_TOOL",
         "READ_MCP_RESOURCE",
         "READ_RESOURCE",
-        "GET_RESOURCE",
         "GET_MCP_RESOURCE",
-        "FETCH_RESOURCE",
         "FETCH_MCP_RESOURCE",
-        "ACCESS_RESOURCE",
         "ACCESS_MCP_RESOURCE"
       ],
       "exampleCalls": [
@@ -5811,9 +5804,7 @@
         "EXECUTE_SKILL",
         "CALL_SKILL",
         "USE_AGENT_SKILL",
-        "RUN_AGENT_SKILL",
-        "USE_CAPABILITY",
-        "RUN_CAPABILITY"
+        "RUN_AGENT_SKILL"
       ],
       "exampleCalls": [
         {

--- a/packages/prompts/specs/actions/plugins.generated.json
+++ b/packages/prompts/specs/actions/plugins.generated.json
@@ -1932,6 +1932,63 @@
       ]
     },
     {
+      "name": "DRAFT_PRESS_RELEASE",
+      "description": "Create a draft press release in Eliza Cloud. Use when the user asks to draft or save a PR/press release for later distribution.",
+      "parameters": [
+        {
+          "name": "title",
+          "description": "Press release headline/title.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "body",
+          "description": "Full press release body.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "summary",
+          "description": "Optional short summary.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "targetRegions",
+          "description": "Optional target regions such as US or EU.",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "descriptionCompressed": "Create a draft press release.",
+      "similes": ["CREATE_PRESS_RELEASE", "DRAFT_PR", "WRITE_PRESS_RELEASE"],
+      "exampleCalls": [
+        {
+          "user": "Use DRAFT_PRESS_RELEASE with the provided parameters.",
+          "actions": ["DRAFT_PRESS_RELEASE"],
+          "params": {
+            "DRAFT_PRESS_RELEASE": {
+              "title": "example",
+              "body": "example",
+              "summary": "example",
+              "targetRegions": "example"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "DUPLICATE_AD_CAMPAIGN",
       "description": "Duplicate a Cloud advertising campaign config and creatives into a new draft. Requires structured campaignId; optional name sets the copy name.",
       "parameters": [],
@@ -2521,6 +2578,12 @@
       ]
     },
     {
+      "name": "GET_MEETING_TRANSCRIPT",
+      "description": "Retrieve the live or final transcript of a meeting the notetaker bot attended.",
+      "parameters": [],
+      "similes": ["MEETING_NOTES", "SHOW_MEETING_TRANSCRIPT"]
+    },
+    {
       "name": "GIT_PATHOLOGY",
       "description": "Forensic git-history analysis for a path/glob surface. Returns peaks (peak quality moments), drift inflections (where rot started), and a post-mortem narrative. Use when the user asks 'when did this code get bad', 'where did rot start in X', or 'analyze git pathology for Y'. Actions: report (default), list (show cached reports).",
       "parameters": [
@@ -2905,6 +2968,26 @@
       ]
     },
     {
+      "name": "JOIN_MEETING",
+      "description": "Send the agent's notetaker bot into a live Google Meet, Microsoft Teams, or Zoom meeting to attend and transcribe it in real time. Use this WHENEVER the message contains a Meet / Teams / Zoom meeting link (meet.google.com, teams.microsoft.com / teams.live.com, zoom.us / app.zoom.us) and the user wants the agent to join, attend, sit in on, cover, take notes on, record, or transcribe that meeting or call. Prefer this over calendar, reminder, scheduling, or plain reply actions when a joinable meeting URL is present — those only schedule or acknowledge, whereas this actually joins the call now. Requires a meeting URL in the message or a meetingUrl parameter.",
+      "parameters": [],
+      "similes": [
+        "INVITE_TO_MEETING",
+        "ATTEND_MEETING",
+        "TAKE_MEETING_NOTES",
+        "TRANSCRIBE_MEETING",
+        "RECORD_MEETING",
+        "SEND_NOTETAKER",
+        "JOIN_CALL"
+      ]
+    },
+    {
+      "name": "LEAVE_MEETING",
+      "description": "Leave a meeting the notetaker bot is currently attending and finalize its transcript.",
+      "parameters": [],
+      "similes": ["EXIT_MEETING", "STOP_MEETING_TRANSCRIPTION"]
+    },
+    {
       "name": "LINEAR",
       "description": "Manage Linear issues/comments/activity. Ops: create_issue, get_issue, update_issue, delete_issue, create_comment, update_comment, delete_comment, list_comments, get_activity, clear_activity, search_issues. Infer op if omitted.",
       "parameters": [
@@ -3027,6 +3110,13 @@
         "FIND_INFLUENCERS",
         "SEARCH_INFLUENCERS"
       ]
+    },
+    {
+      "name": "LIST_PRESS_RELEASES",
+      "description": "List the user's Eliza Cloud press releases and statuses. Use before choosing a draft to submit or edit.",
+      "parameters": [],
+      "descriptionCompressed": "List press release drafts/submissions.",
+      "similes": ["LIST_PR_DRAFTS", "SHOW_PRESS_RELEASES", "MY_PRESS_RELEASES"]
     },
     {
       "name": "MANAGE_BROWSER_BRIDGE",
@@ -4793,6 +4883,55 @@
       "description": "Stop the long-form voice transcription currently running on the user's device.",
       "parameters": [],
       "similes": ["END_TRANSCRIPTION", "STOP_RECORDING", "FINISH_TRANSCRIPT"]
+    },
+    {
+      "name": "SUBMIT_PRESS_RELEASE",
+      "description": "Submit a press release for paid/provider-backed distribution. Requires explicit confirmation before calling the Cloud submit route.",
+      "parameters": [
+        {
+          "name": "releaseId",
+          "description": "Press release id to submit.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "title",
+          "description": "Press release title to resolve.",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "confirm",
+          "description": "Follow-up: true confirms the pending submit, false cancels.",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "descriptionCompressed": "Submit a press release for provider-backed distribution; requires confirm.",
+      "similes": [
+        "SUBMIT_PR",
+        "DISTRIBUTE_PRESS_RELEASE",
+        "SEND_PRESS_RELEASE"
+      ],
+      "exampleCalls": [
+        {
+          "user": "Use SUBMIT_PRESS_RELEASE with the provided parameters.",
+          "actions": ["SUBMIT_PRESS_RELEASE"],
+          "params": {
+            "SUBMIT_PRESS_RELEASE": {
+              "releaseId": "example",
+              "title": "example",
+              "confirm": false
+            }
+          }
+        }
+      ]
     },
     {
       "name": "TASKS",

--- a/packages/prompts/src/prompt-compression.ts
+++ b/packages/prompts/src/prompt-compression.ts
@@ -1,5 +1,3 @@
-const MAX_DESCRIPTION_LENGTH = 160;
-
 const PROTECTED_PATTERNS = [
   /```[\s\S]*?```/g,
   /`[^`\n]+`/g,
@@ -111,34 +109,12 @@ function protectTechnicalSpans(value: string): {
   };
 }
 
-function truncateDescription(value: string): string {
-  if (value.length <= MAX_DESCRIPTION_LENGTH) {
-    return value;
-  }
-
-  const limit = MAX_DESCRIPTION_LENGTH - 3;
-  const tokens = value.match(/\S+\s*/g) ?? [value];
-  let out = "";
-
-  for (const token of tokens) {
-    const next = `${out}${token}`;
-    if (next.trimEnd().length > limit) {
-      break;
-    }
-    out = next;
-  }
-
-  const trimmed = (out || value.slice(0, limit))
-    .trimEnd()
-    .replace(/[\s,;:.!?-]+$/, "");
-
-  return `${trimmed}...`;
-}
-
 /**
  * Deterministic compact description text for model-facing action/provider docs.
  * Preserves code spans, URLs, paths, commands, env vars, and technical terms
- * while dropping common filler.
+ * while dropping common filler. The full text is preserved — there is no length
+ * cap or tail truncation, so disambiguation guidance written anywhere in a
+ * description always reaches the model intact.
  */
 export function compressPromptDescription(
   description: string | undefined,
@@ -175,7 +151,5 @@ export function compressPromptDescription(
     compact = compact.replace(pattern, replacement);
   }
 
-  compact = restore(normalizeWhitespace(compact));
-
-  return truncateDescription(compact);
+  return restore(normalizeWhitespace(compact));
 }

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -43,16 +43,12 @@ describe("prompt templates (src/index.ts)", () => {
     }
   });
 
-  it("compresses arbitrary descriptions into bounded single-line text", () => {
+  it("compresses arbitrary descriptions into single-line normalized text (no length cap)", () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 2_000 }), (description) => {
         const compressed = compressPromptDescription(description);
 
         assert.strictEqual(typeof compressed, "string");
-        assert.ok(
-          compressed.length <= 160,
-          `compressed description exceeded 160 chars: ${compressed.length}`,
-        );
         assert.ok(
           !/\s{2,}|\r|\n/.test(compressed),
           `compressed description should be single-line normalized text: ${JSON.stringify(
@@ -72,7 +68,6 @@ describe("prompt templates (src/index.ts)", () => {
     assert.match(compressed, /`npm run test`/);
     assert.match(compressed, /https:\/\/example\.com\/a\?b=c/);
     assert.match(compressed, /OPENAI_API_KEY/);
-    assert.ok(compressed.length <= 160);
   });
 
   it("exports at least one camelCaseTemplate constant", () => {
@@ -670,7 +665,7 @@ describe("specs directory", () => {
     }
   });
 
-  it("generated plugin action spec descriptions stay prompt-budget friendly", () => {
+  it("generated plugin action spec descriptions compress to non-empty single-line text", () => {
     const generated = readJsonFile(
       join(SPECS_DIR, "actions", "plugins.generated.json"),
     );
@@ -679,10 +674,6 @@ describe("specs directory", () => {
       assert.strictEqual(typeof action.description, "string");
       const compressed = compressPromptDescription(action.description);
       assert.ok(compressed.length > 0, `${action.name} should compress`);
-      assert.ok(
-        compressed.length <= 160,
-        `${action.name} compressed description should fit in prompt budget`,
-      );
       if (
         action.compressedDescription !== undefined &&
         action.descriptionCompressed !== undefined

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3223,6 +3223,8 @@ export const tasksAction: Action & {
     "Choose this when the user asks to delegate coding work, use a coding adapter by name, or run multi-step development work — it is the canonical path for coding sub-agents and is preferred over inline FILE / BASH for delegated work.",
   descriptionCompressed:
     "ACP coding sub-agent elizaos|pi-agent|opencode|claude|codex: spawn|send|control|list|history",
+  routingHint:
+    'delegate coding/software/dev work to a coding sub-agent, or drive a coding adapter by name (elizaos|pi-agent|opencode|claude|codex) -> TASKS; do NOT use for personal reminders, check-ins, follow-ups, alarms or recurring routines ("remind me...", "every day...") -> SCHEDULED_TASKS / OWNER_REMINDERS / OWNER_ROUTINES instead; not for one-off inline file edits or shell commands -> FILE / BASH',
   suppressPostActionContinuation: true,
   // When the planner picks any TASKS_* subaction (spawn_agent, send, etc.),
   // suppress the response-handler's draft reply: the action's own callback

--- a/plugins/plugin-agent-skills/src/actions/use-skill.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.ts
@@ -345,12 +345,12 @@ export const useSkillAction: Action = {
 		"CALL_SKILL",
 		"USE_AGENT_SKILL",
 		"RUN_AGENT_SKILL",
-		"USE_CAPABILITY",
-		"RUN_CAPABILITY",
 	],
 	description:
 		"Invoke an enabled skill by slug. The skill's instructions or script run and the result returns to the conversation.",
 	descriptionCompressed: "Invoke an enabled skill by slug.",
+	routingHint:
+		"invoke an already-enabled agent skill by slug -> USE_SKILL; do NOT use to call an external MCP tool -> MCP (action=call_tool), or to search/install/toggle the skill catalog -> SKILL",
 	parameters: USE_SKILL_PARAMETERS,
 
 	validate: async (runtime: IAgentRuntime): Promise<boolean> => {

--- a/plugins/plugin-mcp/src/actions/mcp.ts
+++ b/plugins/plugin-mcp/src/actions/mcp.ts
@@ -376,26 +376,21 @@ export const mcpAction: Action = {
     "USE_MCP",
     "CALL_MCP_TOOL",
     "CALL_TOOL",
-    "USE_TOOL",
     "USE_MCP_TOOL",
-    "EXECUTE_TOOL",
     "EXECUTE_MCP_TOOL",
-    "RUN_TOOL",
     "RUN_MCP_TOOL",
-    "INVOKE_TOOL",
     "INVOKE_MCP_TOOL",
     "READ_MCP_RESOURCE",
     "READ_RESOURCE",
-    "GET_RESOURCE",
     "GET_MCP_RESOURCE",
-    "FETCH_RESOURCE",
     "FETCH_MCP_RESOURCE",
-    "ACCESS_RESOURCE",
     "ACCESS_MCP_RESOURCE",
   ],
   description:
     "Single MCP entry point. Use action=call_tool to invoke an MCP tool, action=read_resource to read an MCP resource. Cloud runtimes also accept action=search_actions and action=list_connections.",
   descriptionCompressed: "MCP call_tool read_resource search_actions list_connections",
+  routingHint:
+    "call a tool or read a resource on a connected external MCP server -> MCP; do NOT use to invoke an agent skill -> USE_SKILL, or to run a local shell command / edit files -> BASH / FILE",
   parameters: [
     {
       name: "action",

--- a/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
+++ b/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
@@ -284,6 +284,12 @@ export const ownerAlarmsAction: Action = {
     "owner alarms: action=create|update|delete|complete|skip|snooze|review",
 };
 
+// Primary OWNER_GOALS surface. @elizaos/plugin-goals also declares an action
+// named OWNER_GOALS (its `goals.ts`); when personal-assistant is loaded THIS one
+// registers first and first-registration-wins silently skips plugin-goals'.
+// That is intentional, not a collision to "fix": both delegate to the same
+// GoalsService back-end, and plugin-goals' action is the deliberate fallback for
+// the PA-free topology. Do not remove either. See plugin-goals CLAUDE.md.
 export const ownerGoalsAction: Action = {
   ...makeOwnerLifeAction({
     name: "OWNER_GOALS",
@@ -299,6 +305,8 @@ export const ownerGoalsAction: Action = {
   description: "Owner goals: create/update/delete/review goals/progress.",
   descriptionCompressed:
     "owner goals: action=create|update|delete|review; backing kind=goal",
+  routingHint:
+    "long-horizon outcomes/aspirations the owner is working toward ('my goal is X', 'life goal') -> OWNER_GOALS; do NOT use for time-triggered reminders ('remind me at 9pm') -> OWNER_REMINDERS, one-off checklist items -> OWNER_TODOS, or recurring daily habits -> OWNER_ROUTINES",
 };
 
 // Owner-store todos surface. Backed by the app-lifeops owner definitions store

--- a/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
@@ -1,26 +1,14 @@
 import {
-  type Action,
-  type ActionResult,
   composePromptFromState,
-  type HandlerCallback,
   type IAgentRuntime,
   type Memory,
   ModelType,
   parseJSONObjectFromText,
   type State,
 } from "@elizaos/core";
-import { formatEther, type Hex, parseEther } from "viem";
-import {
-  assertEvmTransferRecipientAuthorized,
-  assertWalletFinancialActionAllowed,
-} from "../../../security/wallet-context-safety.js";
-import {
-  gateWalletFinancialExecution,
-  walletFinancialGateActionResult,
-} from "../../../security/wallet-financial-confirmation.js";
+import { type Hex, parseEther } from "viem";
 import { runIntentModel } from "../../../utils/intent-trajectory";
-import { requireActionSpec } from "../generated/specs/spec-helpers";
-import { initWalletProvider, type WalletProvider } from "../providers/wallet";
+import type { WalletProvider } from "../providers/wallet";
 import { transferTemplate } from "../templates";
 import {
   EVMError,
@@ -30,7 +18,7 @@ import {
   type Transaction,
   type TransferParams,
 } from "../types";
-import { buildSendTxParams, createEvmActionValidator } from "./helpers";
+import { buildSendTxParams } from "./helpers";
 
 export class TransferAction {
   constructor(private readonly walletProvider: WalletProvider) {}
@@ -127,135 +115,3 @@ export async function buildTransferDetails(
 
   return transferDetails;
 }
-
-const legacySpec = requireActionSpec("EVM_TRANSFER");
-const spec = { ...legacySpec, name: "WALLET" };
-
-export const transferAction: Action = {
-  name: spec.name,
-  description: spec.description,
-  descriptionCompressed: spec.descriptionCompressed,
-  contexts: ["finance", "crypto", "wallet", "payments"],
-  contextGate: { anyOf: ["finance", "crypto", "wallet", "payments"] },
-  roleGate: { minRole: "ADMIN" },
-  parameters: [
-    {
-      name: "amount",
-      description: "Human-readable amount to transfer.",
-      required: true,
-      schema: { type: "string" },
-    },
-    {
-      name: "toAddress",
-      description: "Recipient EVM address.",
-      required: true,
-      schema: { type: "string" },
-    },
-    {
-      name: "fromChain",
-      description: "Source EVM chain.",
-      required: false,
-      schema: { type: "string" },
-    },
-    {
-      name: "token",
-      description: "Native token or ERC-20 token symbol/address.",
-      required: false,
-      schema: { type: "string" },
-    },
-  ],
-
-  handler: async (
-    runtime: IAgentRuntime,
-    message: Memory,
-    state: State | undefined,
-    options: Record<string, unknown> | undefined,
-    callback?: HandlerCallback
-  ): Promise<ActionResult> => {
-    if (!state) {
-      state = (await runtime.composeState(message)) as State;
-    }
-
-    assertWalletFinancialActionAllowed(message, "transfer");
-
-    const walletProvider = await initWalletProvider(runtime);
-    const paramOptions = await buildTransferDetails(state, message, runtime, walletProvider);
-    assertEvmTransferRecipientAuthorized(message, options, paramOptions.toAddress);
-
-    const gate = await gateWalletFinancialExecution({
-      runtime,
-      message,
-      params: {
-        subaction: "transfer",
-        chain: paramOptions.fromChain,
-        amount: paramOptions.amount,
-        recipient: paramOptions.toAddress,
-        fromToken: paramOptions.token,
-        mode: "execute",
-        dryRun: false,
-      },
-      callback,
-    });
-    if (!gate.proceed) {
-      return walletFinancialGateActionResult(gate);
-    }
-
-    const action = new TransferAction(walletProvider);
-    const transferResp = await action.transfer(paramOptions);
-
-    const successText = `Successfully transferred ${paramOptions.amount} tokens to ${paramOptions.toAddress}\nTransaction Hash: ${transferResp.hash}`;
-
-    if (callback) {
-      callback({
-        text: successText,
-        content: {
-          success: true,
-          hash: transferResp.hash,
-          amount: formatEther(transferResp.value),
-          recipient: transferResp.to,
-          chain: paramOptions.fromChain,
-        },
-      });
-    }
-
-    return {
-      success: true,
-      text: successText,
-      values: {
-        transferSucceeded: true,
-      },
-      data: {
-        actionName: "EVM_TRANSFER_TOKENS",
-        transactionHash: transferResp.hash,
-        chain: paramOptions.fromChain,
-        amount: paramOptions.amount,
-        recipient: transferResp.to,
-      },
-    };
-  },
-  validate: createEvmActionValidator({
-    keywords: ["transfer"],
-    regex: /\b(?:transfer)\b/i,
-  }),
-
-  examples: [
-    [
-      {
-        name: "assistant",
-        content: {
-          text: "I'll help you transfer 1 ETH to 0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
-          action: "SEND_TOKENS",
-        },
-      },
-      {
-        name: "user",
-        content: {
-          text: "Transfer 1 ETH to 0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
-          action: "SEND_TOKENS",
-        },
-      },
-    ],
-  ],
-
-  similes: spec.similes ? [...spec.similes] : [],
-};


### PR DESCRIPTION
## Why

The Eliza agent picks actions by **name + description** (+ similes at Stage 1), but many actions share nouns/similes with no "when NOT to use" guidance, several duplicate names were dropped **silently** at load, and the model-facing description text was **hard-truncated to 160 chars** — so disambiguation guidance past 160 chars never reached the model. This makes the planner confuse siblings (the canonical example: the agent-orchestrator `TASKS` action vs the LifeOps `SCHEDULED_TASKS` action vs the runtime `Task` system — three different things sharing the word "task").

This PR makes siblings distinguishable to both the planner and to trajectory reviewers.

## What

**1. `routingHint` is now the canonical "use when X / do NOT use when Y → OTHER" carrier.** Unlike `description`, it is prepended verbatim to the planner tool (never compressed/truncated) and is captured in trajectories. Documented on the `Action` type and populated on the top cross-domain collisions: orchestrator `TASKS` (reciprocal to `SCHEDULED_TASKS`), `WEB_SEARCH`, `MEMORY`, `USE_SKILL`, `MCP`, `MESSAGE`, `OWNER_GOALS`.

**2. Removed the 160-char truncation/cap on model-facing descriptions.** `compressPromptDescription` no longer truncates (code spans/URLs still protected, filler still stripped, but nothing is cut); the parallel length rule in `lintDescriptionCompressed` is dropped. **22 baked descriptions in the generated docs were previously clipped with `...` and are now full.**

**3. Pruned generic cross-cutting similes** that made intents ambiguous: `USE_CAPABILITY`/`RUN_CAPABILITY` off `USE_SKILL`; `USE_TOOL`/`RUN_TOOL`/`EXECUTE_TOOL`/`INVOKE_TOOL`/generic resource verbs off `MCP`; `ROOM` off `MESSAGE` (collided with the `ROOM` action).

**4. Resolved the live `SHELL ×2` collision (security-relevant):** two registered actions were named `SHELL` (agent terminal, OWNER-gated, vs coding-tools) and one silently shadowed the other by load order. Renamed the terminal one → `TERMINAL_SHELL` (coding-tools `SHELL` is the fuller impl and already owns the generated spec); dropped its `EXEC`/`RUN_COMMAND`/`CALL_MCP_TOOL` similes; updated the compaction keep-set.

**5. Duplicate action/provider names now `warn` at boot** (was silent `debug`) — surfaces load-order-dependent collisions (`SHELL`, `SETTINGS`/`ROLES`/`CHARACTER`/`MCP` providers, `messageAction ×2`) instead of hiding them.

**6. Trajectory tool-execution records now carry the model-facing description** (the `ToolDefinition.description` the planner saw), so a reviewer/training pipeline can judge disambiguation from the execution record without cross-referencing `model.tools`.

**7. Fixes/cleanup:** `REPLY`'s description pointed at connector send-actions that no longer exist → now routes to `MESSAGE`/`POST`; documented `OWNER_GOALS ×2` as an intentional two-topology design (both hit one `GoalsService`) so it isn't "fixed" into a regression; removed the dead, never-registered `transferAction` const in wallet.

## Evidence

| Type | Status |
|---|---|
| Typecheck (core, agent, mcp, agent-skills, orchestrator, wallet, prompts) | ✅ clean (on source worktree; PR branch relies on CI) |
| Unit/integration tests | ✅ trajectory-recorder 37/37, planner-loop 92/92, action-retrieval/catalog/tiering, description-compressed-lint 10/10, prompts 34/34, plugin-mcp/agent-skills suites |
| De-truncation proof | ✅ generated `action-docs.ts` went from 22 `...`-clipped descriptions to 0 (remaining `...` are legit content: example texts, `[[x,y],...]`) |
| Real-LLM trajectory | ⚠️ **N/A in this environment — no model key set.** Reproduce with a live model: `packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out>` (e.g. Cerebras: `OPENAI_BASE_URL=https://api.cerebras.ai/v1` + `gpt-oss-120b`), asserting "cancel my reminder" → `SCHEDULED_TASKS` (not orchestrator `TASKS`) and that the full un-truncated routingHint appears in the recorded `model.tools`. |
| Frontend/screenshots | N/A — no UI surface changed |

## Notes
- No behavior change beyond routing/logging/prompt-text: pruned similes and the `SHELL`→`TERMINAL_SHELL` rename are the only routing-affecting changes; both are covered by the retrieval tests above.
- `plugins.generated.json` / `action-docs.ts` regenerated off the develop base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
