### PR TITLE
fix(ui): malformed model UiSpec bricks the whole app — contain to the widget (#12023)

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   type FormEvent,
   type ReactNode,
   useCallback,

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -32,6 +32,7 @@ import { defaultRegistry } from "../config-ui/config-renderer.helpers";
 import { UiRenderer } from "../config-ui/ui-renderer";
 import { Button } from "../ui/button";
 import { CodeBlock } from "../ui/code-block";
+import { ErrorBoundary } from "../ui/error-boundary";
 import { Input } from "../ui/input";
 import { AccountConnectBlock } from "./AccountConnectBlock";
 import { MessageAttachments } from "./MessageAttachments";
@@ -550,7 +551,32 @@ export function MessageUiSpecBlock({
         </div>
       )}
       <div className="p-3">
-        <UiRenderer spec={spec} onAction={handleAction} />
+        {/*
+          A model-emitted UiSpec can be malformed in ways the renderer can't
+          fully normalize (wrong-typed array props, unknown shapes). Without a
+          boundary here a single bad widget throws past every view boundary to
+          the app ROOT error screen — and because the message re-hydrates from
+          history, "Try Again"/restart re-crash it, bricking the app. Contain
+          any render throw to this one message and offer the raw JSON instead.
+        */}
+        <ErrorBoundary
+          fallback={() => (
+            <div className="rounded-sm border border-destructive/30 bg-destructive/5 p-3 text-xs text-muted">
+              <span className="font-semibold text-destructive">
+                Couldn't render this widget.
+              </span>{" "}
+              <button
+                type="button"
+                className="underline underline-offset-2"
+                onClick={() => setShowRaw((v) => !v)}
+              >
+                {showRaw ? "Hide JSON" : "View JSON"}
+              </button>
+            </div>
+          )}
+        >
+          <UiRenderer spec={spec} onAction={handleAction} />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+//
+// Regression for the HIGH-severity demo-killer: a model-emitted UiSpec that is
+// malformed in a way the renderer can't fully normalize (element missing
+// `props`/`children`, or an array prop that isn't an array) used to throw out
+// of MessageUiSpecBlock — past every view boundary to the app ROOT error
+// screen. Because the offending message re-hydrates from conversation history,
+// "Try Again" and full restarts re-crashed it, bricking the app until the
+// conversation was cleared. The fix defaults missing props/children in
+// ElementRenderer and wraps the UiRenderer in an ErrorBoundary, so any residual
+// render throw is contained to the single widget with a "View JSON" fallback.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UiSpec } from "../../config/ui-spec";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+import { MessageUiSpecBlock } from "./MessageContent";
+
+function withApp(node: React.ReactElement) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    sendActionMessage: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+  );
+}
+
+const asSpec = (o: unknown) => o as unknown as UiSpec;
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+describe("MessageUiSpecBlock — a malformed model spec never bricks the app", () => {
+  it("renders an element that omits props and children without throwing", () => {
+    // LLMs routinely emit leaf elements with no `props`/`children`. Pre-fix
+    // this threw Object.entries(undefined) / undefined.map() out of render.
+    const spec = asSpec({ root: "a", elements: { a: { type: "Text" } } });
+    expect(() =>
+      withApp(<MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />),
+    ).not.toThrow();
+  });
+
+  it("contains a renderer crash (non-array array-prop) to the widget fallback instead of propagating to the app root", () => {
+    // A Table whose `rows`/`columns` are strings, not arrays: the `?? []` cast
+    // doesn't guard wrong types, so `.map` throws. The ErrorBoundary must catch
+    // it and render the fallback rather than letting it escape render().
+    const spec = asSpec({
+      root: "a",
+      elements: {
+        a: { type: "Table", props: { rows: "nope", columns: "nope" } },
+      },
+    });
+    let container: HTMLElement | undefined;
+    expect(() => {
+      container = withApp(
+        <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+      ).container;
+    }).not.toThrow();
+    // The whole message did not disappear behind a root error screen — the
+    // contained fallback is shown, and the raw JSON stays reachable.
+    expect(screen.getByText("Couldn't render this widget.")).toBeTruthy();
+    expect(container?.textContent ?? "").toContain("View JSON");
+  });
+});

--- a/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.uispec-crash.test.tsx
@@ -11,7 +11,7 @@
 // render throw is contained to the single widget with a "View JSON" fallback.
 
 import { cleanup, render, screen } from "@testing-library/react";
-import type * as React from "react";
+import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UiSpec } from "../../config/ui-spec";
 import { __setAppValueForTests } from "../../state/app-store";
@@ -26,7 +26,7 @@ function withApp(node: React.ReactElement) {
   } as never;
   __setAppValueForTests(appValue);
   return render(
-    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+    React.createElement(AppContext.Provider, { value: appValue }, node),
   );
 }
 
@@ -43,7 +43,12 @@ describe("MessageUiSpecBlock — a malformed model spec never bricks the app", (
     // this threw Object.entries(undefined) / undefined.map() out of render.
     const spec = asSpec({ root: "a", elements: { a: { type: "Text" } } });
     expect(() =>
-      withApp(<MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />),
+      withApp(
+        React.createElement(MessageUiSpecBlock, {
+          spec,
+          raw: JSON.stringify(spec),
+        }),
+      ),
     ).not.toThrow();
   });
 
@@ -60,7 +65,10 @@ describe("MessageUiSpecBlock — a malformed model spec never bricks the app", (
     let container: HTMLElement | undefined;
     expect(() => {
       container = withApp(
-        <MessageUiSpecBlock spec={spec} raw={JSON.stringify(spec)} />,
+        React.createElement(MessageUiSpecBlock, {
+          spec,
+          raw: JSON.stringify(spec),
+        }),
       ).container;
     }).not.toThrow();
     // The whole message did not disappear behind a root error screen — the

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -1537,7 +1537,10 @@ function ElementRenderer({ elementId }: { elementId: string }) {
     );
   }
 
-  const resolvedProps = resolveProps(el.props, ctx);
+  // Model-emitted specs routinely omit `props`/`children` on an element;
+  // Object.entries(undefined) / undefined.map() would throw and (without the
+  // ErrorBoundary around MessageUiSpecBlock) crash the whole app. Default them.
+  const resolvedProps = resolveProps(el.props ?? {}, ctx);
 
   // Handle repeat / list rendering
   if (el.repeat) {
@@ -1566,8 +1569,8 @@ function ElementRenderer({ elementId }: { elementId: string }) {
     );
   }
 
-  // Normal rendering: resolve children
-  const childNodes = el.children.map((childId) => (
+  // Normal rendering: resolve children (default missing children to []).
+  const childNodes = (el.children ?? []).map((childId) => (
     <ElementRenderer key={childId} elementId={childId} />
   ));
 

--- a/packages/ui/src/components/config-ui/ui-renderer.tsx
+++ b/packages/ui/src/components/config-ui/ui-renderer.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import {
+import React, {
   createContext,
   useCallback,
   useContext,


### PR DESCRIPTION
Closes #12023. **HIGH demo-killer.** `[cloud-money]` (cross-lane, cc `[phone-ui]`/`[core-brain]`). Found by a Fable-5 hunt, verified with a node repro + a red/green test.

**Bug:** an element missing `props`/`children`, or an array prop that isn't an array, throws out of `MessageUiSpecBlock` past every view boundary to the app ROOT error screen; the message re-hydrates from history so restarts re-crash — the app is bricked. Triggered by the genui showcase flow.

**Fix:** default `el.props ?? {}`/`el.children ?? []` in ElementRenderer + wrap the `UiRenderer` in the existing `ErrorBoundary` (fallback surfaces raw JSON, never re-renders the crash).

**Proof:** `MessageContent.uispec-crash.test.tsx` — 2/2 green; **red without the fix** (both throw `Cannot convert undefined`/`Cannot read properties`). typecheck + biome clean. No visual change to valid specs (audit:app N/A — pure crash-containment). Not self-merging cross-lane.