### PR TITLE
fix(core): plan the model-committed follow-up instead of shipping its promissory ack as the final reply

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -1029,3 +1029,137 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.reply).toBe(reply);
 	});
 });
+
+describe("model-committed plan — promissory ack never reinterpreted as a finished reply (2026-07-01)", () => {
+	// Live ack-then-nothing regressions (trajectories tj-df82b48e763b7b /
+	// tj-823d6382b54c66): the model routed a non-simple context of its OWN
+	// choosing AND named candidate actions of its OWN, i.e. by the Stage-1 field
+	// contract its replyText is an ACK for a plan it committed to — but the
+	// complete-direct-reply override fired on the sentence shape, pulled the turn
+	// to the simple path, and shipped the ack ("Let me take another pass…",
+	// "On it — attaching now") as the FINAL reply with no planner turn behind it.
+	// Both slipped past the earlier delegation-commitment guard because the
+	// CURRENT message text carries no coding keywords (the work context lives in
+	// the conversation history). The fix is structural, keyed on the
+	// model-authored plan shape against the action registry, never on the reply
+	// text: with a model-routed planning context, a registered delegation-class
+	// candidate commits unless the ask is delegation-excluded (creative writing /
+	// explanation / no-spawn), and candidates that resolve to NOTHING in the
+	// registry commit too (a capability gap — the planner turn is where that gets
+	// an honest "can't" instead of a shipped promise).
+
+	it("plans a rebuild follow-up when the model routes general + TASKS_SPAWN_AGENT, even though the critique text has no coding keywords", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText:
+					"Fair hit. Let me take another pass and give it real personality instead of the barebones version.",
+				intents: ["improve app", "rebuild landing page"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText:
+					"its a little barebones and generic. This isn't your best work",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
+	});
+
+	it("plans an attachment ask when the model routes general + names (unregistered) candidates instead of shipping the ack as the answer", () => {
+		// Candidates are retrieval hints — none resolve against the registry, but
+		// the model still committed to a plan; the planner turn must run so it can
+		// resolve a real action or answer honestly that it can't. What must NOT
+		// happen is the ack ("On it — attaching…now") going out as the whole turn.
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: [
+					"SEND_ATTACHMENT",
+					"UPLOAD_FILE",
+					"SEND_MESSAGE",
+				],
+				replyText: "On it — attaching the cat image here now.",
+				intents: ["attach image to discord"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "can you figure out how to attach that here so i can see it",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual([
+			"SEND_ATTACHMENT",
+			"UPLOAD_FILE",
+			"SEND_MESSAGE",
+		]);
+	});
+
+	it("still answers directly when the model routes general with NO candidates and a finished answer", () => {
+		// The override's protected case: planning pressure without model-named
+		// candidates (the shape the inference backstop injects) must still yield
+		// the complete direct answer.
+		const reply =
+			"The deploy pipeline builds the site, uploads it to the CDN, and flips the DNS alias once health checks pass.";
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: [],
+				replyText: reply,
+				intents: ["explain deploy pipeline"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "how does the deploy pipeline work?",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.reply).toBe(reply);
+	});
+
+	it("control-only candidates (REPLY) are not a plan commitment — finished answer stays direct", () => {
+		const reply =
+			"Nothing is scheduled for tonight — the last watcher run finished clean and no follow-ups are queued.";
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: ["REPLY"],
+				replyText: reply,
+				intents: ["status update"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "anything scheduled for tonight?",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.reply).toBe(reply);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3903,12 +3903,30 @@ export function messageHandlerFromFieldResult(
 	// live bug where "build the app" came back with contexts=[simple] +
 	// candidateActionNames=[TASKS_SPAWN_AGENT], so shouldPreferCompleteDirectReply
 	// treated the spawn as "weak", suppressed it, and the bot said "I'm building
-	// it" while never spawning. Still safe: looksLikeCodingWorkRequest excludes
+	// it" while never spawning. Still safe: the text gate below excludes
 	// creative-writing / explanation asks, and the candidate must be a REGISTERED
 	// delegation action — so this never fires on a poem or a how-do-I question.
+	const modelRoutedPlanningContext = rawContexts.some(
+		(context) => context.toLowerCase() !== SIMPLE_CONTEXT_ID,
+	);
+	// Text gate for the delegation commitment. When the model routed a planning
+	// context of its OWN (dual model-authored signal: context + candidate), the
+	// commitment stands unless the ask is a class delegation can never serve
+	// (creative writing, explanation, explicit no-spawn) — requiring positive
+	// coding keywords in the CURRENT message was the live ack-then-nothing hole
+	// (2026-07-01, trajectory tj-df82b48e763b7b): a follow-up critique of prior
+	// build work ("this isn't your best work") carries no coding keywords — the
+	// work context lives in conversation history — so the complete-direct-reply
+	// override dropped the model's TASKS_SPAWN_AGENT plan and shipped its ack
+	// ("Let me take another pass…") as the whole turn. In the contradictory
+	// contexts=[simple] shape the candidate is the only signal, so the message
+	// itself must still look like coding work.
+	const delegationTextGate = modelRoutedPlanningContext
+		? !looksLikeDelegationExcludedAsk(currentMessageText)
+		: looksLikeCodingWorkRequest(currentMessageText);
 	const modelCommittedToDelegation =
 		!preemptDirect &&
-		looksLikeCodingWorkRequest(currentMessageText) &&
+		delegationTextGate &&
 		modelProvidedRunnableDelegationCandidate(
 			rawCandidateActions,
 			runtimeContext?.actions ?? [],
@@ -3922,10 +3940,38 @@ export function messageHandlerFromFieldResult(
 			// direct answer into forced planning.
 			{ requireUnambiguous: initialPlanningContexts.length === 0 },
 		);
+	// The model can also route a planning context AND name candidates that
+	// resolve to NOTHING in the registry (e.g. SEND_ATTACHMENT / UPLOAD_FILE for
+	// "attach that here"). That is still a committed plan — the model believes
+	// tool work is needed and wrote its replyText as an ACK per the Stage-1
+	// field contract — but the candidates expose a capability gap, so the
+	// complete-direct-reply override must not reinterpret the full-sentence ack
+	// ("On it — attaching now.") as a finished answer and ship the promise as
+	// the WHOLE turn (live ack-then-nothing regression, 2026-07-01: trajectory
+	// tj-823d6382b54c66). The planner turn is where an unresolvable plan gets an
+	// honest "I can't do that here" instead of a silent broken promise. Keyed on
+	// the model-authored plan shape (contexts + candidates it emitted vs the
+	// action registry), never on the reply text. Registered candidates are not
+	// commitment by themselves: weak-class ones stay overridable (a complete
+	// answer beats a stray SHELL hint), non-weak ones already block the override
+	// via hasOnlyWeakDirectReplyPlanningSignals, and delegation-class ones are
+	// the guard above.
+	const modelCommittedToPlanning =
+		!preemptDirect &&
+		modelRoutedPlanningContext &&
+		runtimeContext !== undefined &&
+		rawCandidateActions.some((name) => {
+			const normalized = normalizeActionIdentifier(name);
+			return (
+				canonicalPlannerControlActionName(normalized) === null &&
+				!exposedActionMatches(runtimeContext.actions, normalized)
+			);
+		});
 	const preferCompleteDirectReply =
 		!preemptDirect &&
 		requestedPlanning &&
 		!modelCommittedToDelegation &&
+		!modelCommittedToPlanning &&
 		shouldPreferCompleteDirectReply({
 			replyText: replyTextRaw,
 			candidateActions: runnableCandidateActions,
@@ -7271,28 +7317,38 @@ function looksLikeActionExplanationRequest(text: string): boolean {
 	return !asksToExecuteAfterExplanation;
 }
 
+// Ask classes a coding delegation can never serve: an explicit "don't spawn",
+// an explanation/teaching ask, or creative writing that isn't a coding task.
+// Shared by looksLikeCodingWorkRequest (as its exclusion list) and the
+// delegation-commitment gate in messageHandlerFromFieldResult.
+function looksLikeDelegationExcludedAsk(text: string): boolean {
+	const normalized = text.toLowerCase();
+	if (!normalized.trim()) {
+		return false;
+	}
+	if (
+		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	if (looksLikeActionExplanationRequest(normalized)) {
+		return true;
+	}
+	return (
+		looksLikeCreativeWritingRequest(normalized) &&
+		!looksLikeCreativeCodingWorkRequest(normalized)
+	);
+}
+
 function looksLikeCodingWorkRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	if (!normalized.trim()) {
 		return false;
 	}
 
-	if (
-		/\b(?:do not|don't|dont|without)\s+(?:spawn|delegate|use|start)\s+(?:a\s+)?(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
-			normalized,
-		)
-	) {
-		return false;
-	}
-
-	if (looksLikeActionExplanationRequest(normalized)) {
-		return false;
-	}
-
-	if (
-		looksLikeCreativeWritingRequest(normalized) &&
-		!looksLikeCreativeCodingWorkRequest(normalized)
-	) {
+	if (looksLikeDelegationExcludedAsk(normalized)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Problem

The bot sends a promissory reply ("On it — attaching the cat image here now.", "Let me take another pass and give it real personality…") and then silently does nothing — the reply promises work the planner never ran. Observed live twice on Jul 1 (trajectories `tj-df82b48e763b7b`, `tj-823d6382b54c66`): each turn has exactly one stage — the Stage-1 field run — and the ack shipped as the final reply.

Both turns had the same shape: the model routed a **non-simple context of its own choosing** (`contexts:["general"]`) AND named **candidate actions of its own** (`TASKS_SPAWN_AGENT` in one, `SEND_ATTACHMENT`/`UPLOAD_FILE`/`SEND_MESSAGE` in the other). By the Stage-1 field contract that replyText is an ACK for a committed plan — but `shouldPreferCompleteDirectReply` fired on the sentence shape, pulled the turn to the simple path, and shipped the ack as the whole turn.

They slipped past the existing delegation-commitment guard because it requires `looksLikeCodingWorkRequest(currentMessageText)` — and the CURRENT message ("its a little barebones and generic. This isn't your best work" / "can you figure out how to attach that here") carries no coding keywords; the work context lives in conversation history.

## Fix (structural — keyed on the model-authored plan shape vs the action registry, never on reply text)

In `messageHandlerFromFieldResult`:

1. **Delegation commitment no longer requires coding keywords when the model routed a planning context itself.** With the dual model-authored signal (non-simple context + registered delegation-class candidate), the commitment stands unless the ask is a class delegation can never serve — explicit no-spawn, explanation/teaching, or non-coding creative writing (`looksLikeDelegationExcludedAsk`, factored out of `looksLikeCodingWorkRequest` so both stay in sync). The contradictory `contexts:[simple]` + spawn-candidate shape keeps the old positive-keyword requirement.
2. **Candidates that resolve to NOTHING in the registry are also a committed plan** (`modelCommittedToPlanning`): the model believes tool work is needed but named a capability gap. The planner turn must run so the turn gets a real action or an honest "can't" — not the promise shipped as the answer. Registered weak-class candidates stay overridable exactly as before; non-weak ones already blocked the override.

Protected cases keep their behavior (covered by tests): planning pressure with no model-named candidates (the backstop-injected shape) still yields the complete direct answer, and control-only candidates (REPLY) are not a commitment.

## Tests

4 new tests in `message-handler-bogus-candidates.test.ts` — the two live regressions (must plan, not ship the ack) and the two protected direct-answer cases. Both regression tests fail on develop before this change (`plan.simple` comes back `true` — the observed ack-then-nothing) and pass after.

- changed-file suite: 42/42 pass
- adjacent routing suites (`message-runtime-stage1`, `message-routing-live-regression`, `message-handler`, `message-handler-output`): 150/150 pass
- full `packages/core` src+runtime test dirs: identical failure set before/after (53 pre-existing dev-red failures in unrelated runtime/model-routing suites, byte-identical list) — no new failures
- `tsgo --noEmit`: clean
