### PR TITLE
fix(ios): background URLSession for the ~5GB local-model download so it survives backgrounding/lock (#11841)

### DIFF
--- a/packages/app-core/platforms/ios/App/App/AppDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/AppDelegate.swift
@@ -3,6 +3,9 @@ import Capacitor
 import CapacitorBackgroundRunner
 import ObjectiveC
 import UserNotifications
+#if canImport(ElizaosCapacitorBunRuntime)
+import ElizaosCapacitorBunRuntime
+#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -38,6 +41,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
+    }
+
+    /// Background `URLSession` relaunch hook. iOS wakes the app in the
+    /// background when the on-device model download (#11841) finishes while the
+    /// app is suspended; it hands us a completion handler that must be invoked
+    /// once every queued session delegate event has been delivered. Forward it
+    /// to the runtime's background-download bridge, which owns that session and
+    /// calls the handler from `urlSessionDidFinishEvents`.
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        #if canImport(ElizaosCapacitorBunRuntime)
+        BackgroundDownloadBridge.shared.handleEventsForBackgroundURLSession(
+            identifier: identifier,
+            completionHandler: completionHandler
+        )
+        #else
+        completionHandler()
+        #endif
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -549,6 +549,7 @@ async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 	const runtime = await bootRuntimeWithRetry(bootElizaRuntime);
 	installIosNativeLlamaHandlers(runtime);
 	installKeepAwakeBridge();
+	installBackgroundDownloadBridge();
 
 	maybeAutoRunModelGrind();
 
@@ -2605,6 +2606,31 @@ function installKeepAwakeBridge(): void {
 		);
 		return true;
 	};
+}
+
+/**
+ * Expose the native background-download host functions on the full-Bun engine's
+ * Bun global so the in-process model downloader can route the ~5 GB weight pull
+ * through a native background `URLSession` that survives the app backgrounding
+ * or the device locking (#11841). The native handlers (`bg_download_*` in
+ * `FullBunEngineHost` → `BackgroundDownloadBridge`) start the task and report
+ * progress/terminal state; the downloader starts a job then polls status until
+ * it is terminal. Each function resolves the native host envelope's `result`
+ * object; a rejection means the host call itself failed. Only defines the
+ * functions when the engine has not already installed them.
+ */
+function installBackgroundDownloadBridge(): void {
+	const g = globalThis as typeof globalThis & {
+		__ELIZA_BRIDGE__?: Record<string, unknown>;
+	};
+	g.__ELIZA_BRIDGE__ = g.__ELIZA_BRIDGE__ ?? {};
+	if (typeof g.__ELIZA_BRIDGE__.bg_download_start === "function") return;
+	g.__ELIZA_BRIDGE__.bg_download_start = (args: unknown): Promise<unknown> =>
+		callIosHost("bg_download_start", args, 60_000);
+	g.__ELIZA_BRIDGE__.bg_download_status = (args: unknown): Promise<unknown> =>
+		callIosHost("bg_download_status", args, 60_000);
+	g.__ELIZA_BRIDGE__.bg_download_cancel = (args: unknown): Promise<unknown> =>
+		callIosHost("bg_download_cancel", args, 60_000);
 }
 
 function installIosNativeLlamaHandlers(runtime: IAgentRuntime): void {

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -1376,3 +1376,175 @@ describe("local inference downloader keep-awake (idle-timer) wiring (#11841)", (
 		}
 	});
 });
+
+describe("local inference downloader native background URLSession path (#11841)", () => {
+	type BgArgs = {
+		id: string;
+		url: string;
+		headers: Record<string, string>;
+		destPath: string;
+		expectedTotalBytes: number;
+	};
+	type BgSnapshot = {
+		id: string;
+		state: "running" | "completed" | "failed" | "cancelled";
+		received: number;
+		total: number;
+		destPath: string;
+		error?: string;
+	};
+	type BgBridgeGlobal = {
+		__ELIZA_BRIDGE__?: Record<string, unknown>;
+	};
+
+	/**
+	 * Stand in for the native iOS `BackgroundDownloadBridge` the runtime installs
+	 * on `globalThis.__ELIZA_BRIDGE__`. Resolves each requested URL against the
+	 * fetch fixture bodies, writes the bytes straight to the downloader's staging
+	 * `destPath` (as the real native session's `didFinishDownloadingTo` move
+	 * does), and reports terminal state synchronously so the downloader's poll
+	 * loop observes completion on its first `bg_download_status` call.
+	 */
+	function installBackgroundDownloadFixture(files: Map<string, string>): {
+		starts: BgArgs[];
+		restore: () => void;
+	} {
+		const starts: BgArgs[] = [];
+		const jobs = new Map<string, BgSnapshot>();
+		const g = globalThis as BgBridgeGlobal;
+		const hadBridge = "__ELIZA_BRIDGE__" in g;
+		const priorBridge = g.__ELIZA_BRIDGE__;
+
+		g.__ELIZA_BRIDGE__ = {
+			...(priorBridge ?? {}),
+			bg_download_start: async (raw: unknown): Promise<BgSnapshot> => {
+				const args = raw as BgArgs;
+				starts.push(args);
+				const remotePath = remotePathOf(args.url);
+				const body = files.get(remotePath);
+				if (body === undefined) {
+					const snap: BgSnapshot = {
+						id: args.id,
+						state: "failed",
+						received: 0,
+						total: 0,
+						destPath: args.destPath,
+						error: `missing ${remotePath}`,
+					};
+					jobs.set(args.id, snap);
+					return snap;
+				}
+				fs.mkdirSync(path.dirname(args.destPath), { recursive: true });
+				fs.writeFileSync(args.destPath, body);
+				const size = Buffer.byteLength(body);
+				const snap: BgSnapshot = {
+					id: args.id,
+					state: "completed",
+					received: size,
+					total: size,
+					destPath: args.destPath,
+				};
+				jobs.set(args.id, snap);
+				return snap;
+			},
+			bg_download_status: async (raw: unknown): Promise<BgSnapshot> => {
+				const { id } = raw as { id: string };
+				return (
+					jobs.get(id) ?? {
+						id,
+						state: "failed",
+						received: 0,
+						total: 0,
+						destPath: "",
+						error: `unknown id ${id}`,
+					}
+				);
+			},
+			bg_download_cancel: async (raw: unknown): Promise<BgSnapshot> => {
+				const { id } = raw as { id: string };
+				const snap = jobs.get(id);
+				if (snap) snap.state = "cancelled";
+				return (
+					snap ?? {
+						id,
+						state: "cancelled",
+						received: 0,
+						total: 0,
+						destPath: "",
+					}
+				);
+			},
+		};
+
+		return {
+			starts,
+			restore: () => {
+				if (hadBridge) g.__ELIZA_BRIDGE__ = priorBridge;
+				else delete g.__ELIZA_BRIDGE__;
+			},
+		};
+	}
+
+	it("installs the bundle through the native bridge without any in-process fetch", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+
+		// Any in-process fetch on the native path is a routing bug — fail loudly.
+		const fetchSpy = vi.fn(async () => {
+			throw new Error(
+				"fetch must not be used when the native bridge is present",
+			);
+		});
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+		const bg = installBackgroundDownloadFixture(freshBundleFixtureFiles());
+		try {
+			const downloader = new Downloader({
+				probeDeviceCaps: async () => cpuOnlyCaps,
+			});
+			const completed = waitForTerminal(downloader, model.id);
+			await downloader.start(model.id);
+			const job = await completed;
+
+			expect(job.state).toBe("completed");
+			expect(fetchSpy).not.toHaveBeenCalled();
+			// Every bundle file (manifest + weights) was pulled via the bridge.
+			expect(bg.starts.length).toBeGreaterThan(1);
+			const installed = (await listInstalledModels()).find(
+				(m) => m.id === model.id,
+			);
+			expect(installed).toBeDefined();
+		} finally {
+			bg.restore();
+		}
+	});
+
+	it("fails the job when the native bridge reports a failed transfer", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+
+		// Serve the manifest but drop the text weight so the native transfer for
+		// that file reports `failed` and the job surfaces the failure.
+		const files = freshBundleFixtureFiles();
+		files.delete(eliza1BundleRemotePath("text/eliza-1-2b-128k.gguf"));
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error(
+				"fetch must not be used when the native bridge is present",
+			);
+		}) as unknown as typeof fetch;
+		const bg = installBackgroundDownloadFixture(files);
+		try {
+			const downloader = new Downloader({
+				probeDeviceCaps: async () => cpuOnlyCaps,
+			});
+			const completed = waitForTerminal(downloader, model.id);
+			await downloader.start(model.id);
+			await expect(completed).rejects.toThrow();
+		} finally {
+			bg.restore();
+		}
+	});
+});

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -170,6 +170,60 @@ const DISK_HEADROOM_GB = 0.5;
  */
 const SHA_MISMATCH_MAX_ATTEMPTS = 2;
 
+/** Poll interval while a native background download is in flight (#11841). */
+const BACKGROUND_DOWNLOAD_POLL_MS = 500;
+
+/**
+ * Native iOS background-`URLSession` download bridge, exposed by the full-Bun /
+ * JSContext runtime on `globalThis.__ELIZA_BRIDGE__` (#11841). Present only on
+ * iOS; absent (so the in-process fetch path is used) on desktop, Android, and
+ * in tests unless a fake is installed. Each function resolves the native
+ * host-call `result` object.
+ */
+interface NativeBackgroundDownloadBridge {
+	bg_download_start(args: {
+		id: string;
+		url: string;
+		headers: Record<string, string>;
+		destPath: string;
+		expectedTotalBytes: number;
+	}): unknown | Promise<unknown>;
+	bg_download_status(args: { id: string }): unknown | Promise<unknown>;
+	bg_download_cancel(args: { id: string }): unknown | Promise<unknown>;
+}
+
+interface NativeBackgroundDownloadStatus {
+	state: "running" | "completed" | "failed" | "cancelled";
+	received?: number;
+	total?: number;
+	destPath?: string;
+	error?: string;
+}
+
+function parseBackgroundStatus(raw: unknown): NativeBackgroundDownloadStatus {
+	const value =
+		raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+	const state =
+		value.state === "completed" ||
+		value.state === "failed" ||
+		value.state === "cancelled"
+			? value.state
+			: "running";
+	return {
+		state,
+		received: typeof value.received === "number" ? value.received : undefined,
+		total: typeof value.total === "number" ? value.total : undefined,
+		destPath: typeof value.destPath === "string" ? value.destPath : undefined,
+		error: typeof value.error === "string" ? value.error : undefined,
+	};
+}
+
+function makeAbortError(): Error {
+	const error = new Error("Download aborted");
+	error.name = "AbortError";
+	return error;
+}
+
 interface TerminalDownloadsFile {
 	version: 1;
 	jobs: DownloadJob[];
@@ -639,6 +693,134 @@ export class Downloader {
 		}
 	}
 
+	/**
+	 * The native iOS background-`URLSession` download bridge, when the runtime
+	 * has installed it (#11841). Present only on iOS; `undefined` everywhere
+	 * else, which keeps every other platform on the in-process fetch path.
+	 */
+	private backgroundDownloadBridge():
+		| NativeBackgroundDownloadBridge
+		| undefined {
+		const bridge = (
+			globalThis as {
+				__ELIZA_BRIDGE__?: Record<string, unknown>;
+			}
+		).__ELIZA_BRIDGE__;
+		if (
+			bridge &&
+			typeof bridge.bg_download_start === "function" &&
+			typeof bridge.bg_download_status === "function" &&
+			typeof bridge.bg_download_cancel === "function"
+		) {
+			return bridge as unknown as NativeBackgroundDownloadBridge;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Download one whole remote file to `targetPath` through the native
+	 * background `URLSession` and resolve once the finished file is fully staged
+	 * there. The native session owns its own resume across app suspension / lock
+	 * (that is the point of #11841), so this path never sends a Range header —
+	 * it always targets the complete file and lets the OS resume as needed.
+	 * Progress is polled and mapped onto the job's cumulative byte counters; the
+	 * caller runs the existing sha256 gate on the staged file. `forceFresh`
+	 * discards any resumable/terminal native state for this id first, used when
+	 * the sha gate rejects a completed transfer and we must re-fetch from zero.
+	 */
+	private async transferViaBackgroundSession(args: {
+		bridge: NativeBackgroundDownloadBridge;
+		downloadId: string;
+		url: string;
+		headers: Record<string, string>;
+		targetPath: string;
+		record: ActiveJob;
+		baseBytes: number;
+		expectedTotalBytes: number;
+		forceFresh: boolean;
+	}): Promise<void> {
+		const {
+			bridge,
+			downloadId,
+			url,
+			headers,
+			targetPath,
+			record,
+			baseBytes,
+			expectedTotalBytes,
+			forceFresh,
+		} = args;
+
+		if (forceFresh) {
+			await Promise.resolve(
+				bridge.bg_download_cancel({ id: downloadId }),
+			).catch(() => undefined);
+		}
+
+		const started = parseBackgroundStatus(
+			await bridge.bg_download_start({
+				id: downloadId,
+				url,
+				headers,
+				destPath: targetPath,
+				expectedTotalBytes,
+			}),
+		);
+		if (started.state === "failed") {
+			throw new Error(
+				started.error ??
+					`native background download failed to start for ${downloadId}`,
+			);
+		}
+
+		let lastSampleBytes = record.job.received;
+		let lastSampleAt = Date.now();
+		for (;;) {
+			if (record.abortController.signal.aborted) {
+				await Promise.resolve(
+					bridge.bg_download_cancel({ id: downloadId }),
+				).catch(() => undefined);
+				throw makeAbortError();
+			}
+
+			const status = parseBackgroundStatus(
+				await bridge.bg_download_status({ id: downloadId }),
+			);
+			const received = status.received ?? 0;
+			if (status.total !== undefined && status.total > 0) {
+				record.job.total = Math.max(record.job.total, baseBytes + status.total);
+			}
+			record.job.received = baseBytes + received;
+
+			const now = Date.now();
+			const elapsed = now - lastSampleAt;
+			if (elapsed >= 1000) {
+				record.job.bytesPerSec =
+					((record.job.received - lastSampleBytes) * 1000) / elapsed;
+				record.job.etaMs =
+					record.job.bytesPerSec > 0
+						? ((record.job.total - record.job.received) * 1000) /
+							record.job.bytesPerSec
+						: null;
+				lastSampleAt = now;
+				lastSampleBytes = record.job.received;
+			}
+			this.throttleEmit(record);
+
+			if (status.state === "completed") return;
+			if (status.state === "cancelled") throw makeAbortError();
+			if (status.state === "failed") {
+				throw new Error(
+					status.error ?? `native background download failed for ${downloadId}`,
+				);
+			}
+
+			await new Promise((resolve) =>
+				setTimeout(resolve, BACKGROUND_DOWNLOAD_POLL_MS),
+			);
+		}
+	}
+
 	private async runJob(
 		catalogEntry: CatalogModel,
 		record: ActiveJob,
@@ -653,72 +835,91 @@ export class Downloader {
 			}
 
 			const url = buildHuggingFaceResolveUrl(catalogEntry);
-
-			const httpClient = await this.loadHttpClient();
-			const startByte = record.job.received;
-
 			const headers: Record<string, string> = {
 				"user-agent": "Eliza-LocalInference/1.0",
 				...resolveHfDownloadBase().authHeader,
 			};
-			if (startByte > 0) {
-				headers.range = `bytes=${startByte}-`;
-			}
 
-			const response = await httpClient.request(url, {
-				method: "GET",
-				headers,
-				signal: record.abortController.signal,
-			});
-
-			if (response.statusCode >= 400) {
-				throw new Error(
-					`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}`,
-				);
-			}
-			let effectiveStartByte = startByte;
-			if (effectiveStartByte > 0 && response.statusCode !== 206) {
-				effectiveStartByte = 0;
+			const backgroundBridge = this.backgroundDownloadBridge();
+			if (backgroundBridge) {
+				// iOS: route the whole file through the native background
+				// URLSession so it survives the app backgrounding / device lock
+				// (#11841). The native session owns resume, so no Range header.
 				record.job.received = 0;
-			}
+				await this.transferViaBackgroundSession({
+					bridge: backgroundBridge,
+					downloadId: stagingFilename(record.job.modelId),
+					url,
+					headers,
+					targetPath: record.stagingPath,
+					record,
+					baseBytes: 0,
+					expectedTotalBytes: record.job.total,
+					forceFresh: false,
+				});
+			} else {
+				const httpClient = await this.loadHttpClient();
+				const startByte = record.job.received;
 
-			const contentLengthHeader = response.headers["content-length"];
-			const contentLength = Array.isArray(contentLengthHeader)
-				? Number.parseInt(contentLengthHeader[0] ?? "0", 10)
-				: Number.parseInt(contentLengthHeader ?? "0", 10);
-			if (Number.isFinite(contentLength) && contentLength > 0) {
-				record.job.total = effectiveStartByte + contentLength;
-			}
-
-			const writeStream: Writable = fs.createWriteStream(record.stagingPath, {
-				flags: effectiveStartByte > 0 ? "a" : "w",
-			});
-
-			let lastSampleBytes = record.job.received;
-			let lastSampleAt = Date.now();
-
-			const bodyStream = Readable.from(response.body);
-			bodyStream.on("data", (chunk: Buffer) => {
-				record.job.received += chunk.length;
-
-				const now = Date.now();
-				const elapsed = now - lastSampleAt;
-				if (elapsed >= 1000) {
-					record.job.bytesPerSec =
-						((record.job.received - lastSampleBytes) * 1000) / elapsed;
-					record.job.etaMs =
-						record.job.bytesPerSec > 0
-							? ((record.job.total - record.job.received) * 1000) /
-								record.job.bytesPerSec
-							: null;
-					lastSampleAt = now;
-					lastSampleBytes = record.job.received;
+				if (startByte > 0) {
+					headers.range = `bytes=${startByte}-`;
 				}
 
-				this.throttleEmit(record);
-			});
+				const response = await httpClient.request(url, {
+					method: "GET",
+					headers,
+					signal: record.abortController.signal,
+				});
 
-			await pipeline(bodyStream, writeStream);
+				if (response.statusCode >= 400) {
+					throw new Error(
+						`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}`,
+					);
+				}
+				let effectiveStartByte = startByte;
+				if (effectiveStartByte > 0 && response.statusCode !== 206) {
+					effectiveStartByte = 0;
+					record.job.received = 0;
+				}
+
+				const contentLengthHeader = response.headers["content-length"];
+				const contentLength = Array.isArray(contentLengthHeader)
+					? Number.parseInt(contentLengthHeader[0] ?? "0", 10)
+					: Number.parseInt(contentLengthHeader ?? "0", 10);
+				if (Number.isFinite(contentLength) && contentLength > 0) {
+					record.job.total = effectiveStartByte + contentLength;
+				}
+
+				const writeStream: Writable = fs.createWriteStream(record.stagingPath, {
+					flags: effectiveStartByte > 0 ? "a" : "w",
+				});
+
+				let lastSampleBytes = record.job.received;
+				let lastSampleAt = Date.now();
+
+				const bodyStream = Readable.from(response.body);
+				bodyStream.on("data", (chunk: Buffer) => {
+					record.job.received += chunk.length;
+
+					const now = Date.now();
+					const elapsed = now - lastSampleAt;
+					if (elapsed >= 1000) {
+						record.job.bytesPerSec =
+							((record.job.received - lastSampleBytes) * 1000) / elapsed;
+						record.job.etaMs =
+							record.job.bytesPerSec > 0
+								? ((record.job.total - record.job.received) * 1000) /
+									record.job.bytesPerSec
+								: null;
+						lastSampleAt = now;
+						lastSampleBytes = record.job.received;
+					}
+
+					this.throttleEmit(record);
+				});
+
+				await pipeline(bodyStream, writeStream);
+			}
 
 			await fsp.rename(record.stagingPath, record.finalPath);
 
@@ -1013,88 +1214,111 @@ export class Downloader {
 		await fsp.mkdir(path.dirname(finalPath), { recursive: true });
 		await fsp.mkdir(path.dirname(stagingPath), { recursive: true });
 
+		const backgroundBridge = this.backgroundDownloadBridge();
 		const maxAttempts = expectedSha256 ? SHA_MISMATCH_MAX_ATTEMPTS : 1;
 		for (let attempt = 1; ; attempt++) {
-			let startByte = 0;
-			if (expectedSha256) {
-				startByte = await resumableStartByte(stagingPath, expectedSha256);
-				// Stamp the partial with the content hash it is being fetched
-				// against so a later resume can tell whether the .part still
-				// belongs to THIS content version.
-				await fsp.writeFile(
-					stagingMetaPath(stagingPath),
-					expectedSha256,
-					"utf8",
-				);
-			}
-			record.job.received = baseBytes + startByte;
-
 			const url = buildHuggingFaceResolveUrlForPath(catalogEntry, remotePath);
 			const headers: Record<string, string> = {
 				"user-agent": "Eliza-LocalInference/1.0",
 				...resolveHfDownloadBase().authHeader,
 			};
-			if (startByte > 0) {
-				headers.range = `bytes=${startByte}-`;
-			}
 
-			const httpClient = await this.loadHttpClient();
-			const response = await httpClient.request(url, {
-				method: "GET",
-				headers,
-				signal: record.abortController.signal,
-			});
-
-			if (response.statusCode >= 400) {
-				throw new Error(
-					`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
-				);
-			}
-			if (startByte > 0 && response.statusCode !== 206) {
-				startByte = 0;
+			if (backgroundBridge) {
+				// iOS: the whole file goes through the native background
+				// URLSession, which owns its own resume across suspension /
+				// lock (#11841). A sha-mismatch retry (attempt > 1) re-fetches
+				// from zero; the first attempt may reuse a completed transfer
+				// that outlived a runtime restart.
 				record.job.received = baseBytes;
-			}
+				await this.transferViaBackgroundSession({
+					bridge: backgroundBridge,
+					downloadId: path.basename(stagingPath),
+					url,
+					headers,
+					targetPath: stagingPath,
+					record,
+					baseBytes,
+					expectedTotalBytes: 0,
+					forceFresh: attempt > 1,
+				});
+				await fsp.rename(stagingPath, finalPath);
+			} else {
+				let startByte = 0;
+				if (expectedSha256) {
+					startByte = await resumableStartByte(stagingPath, expectedSha256);
+					// Stamp the partial with the content hash it is being fetched
+					// against so a later resume can tell whether the .part still
+					// belongs to THIS content version.
+					await fsp.writeFile(
+						stagingMetaPath(stagingPath),
+						expectedSha256,
+						"utf8",
+					);
+				}
+				record.job.received = baseBytes + startByte;
 
-			const contentLengthHeader = response.headers["content-length"];
-			const contentLength = Array.isArray(contentLengthHeader)
-				? Number.parseInt(contentLengthHeader[0] ?? "0", 10)
-				: Number.parseInt(contentLengthHeader ?? "0", 10);
-			if (Number.isFinite(contentLength) && contentLength > 0) {
-				record.job.total = Math.max(
-					record.job.total,
-					baseBytes + startByte + contentLength,
-				);
-			}
-
-			const writeStream: Writable = fs.createWriteStream(stagingPath, {
-				flags: startByte > 0 ? "a" : "w",
-			});
-
-			let lastSampleBytes = record.job.received;
-			let lastSampleAt = Date.now();
-			const bodyStream = Readable.from(response.body);
-			bodyStream.on("data", (chunk: Buffer) => {
-				record.job.received += chunk.length;
-
-				const now = Date.now();
-				const elapsed = now - lastSampleAt;
-				if (elapsed >= 1000) {
-					record.job.bytesPerSec =
-						((record.job.received - lastSampleBytes) * 1000) / elapsed;
-					record.job.etaMs =
-						record.job.bytesPerSec > 0
-							? ((record.job.total - record.job.received) * 1000) /
-								record.job.bytesPerSec
-							: null;
-					lastSampleAt = now;
-					lastSampleBytes = record.job.received;
+				if (startByte > 0) {
+					headers.range = `bytes=${startByte}-`;
 				}
 
-				this.throttleEmit(record);
-			});
+				const httpClient = await this.loadHttpClient();
+				const response = await httpClient.request(url, {
+					method: "GET",
+					headers,
+					signal: record.abortController.signal,
+				});
 
-			await pipeline(bodyStream, writeStream);
-			await fsp.rename(stagingPath, finalPath);
+				if (response.statusCode >= 400) {
+					throw new Error(
+						`HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
+					);
+				}
+				if (startByte > 0 && response.statusCode !== 206) {
+					startByte = 0;
+					record.job.received = baseBytes;
+				}
+
+				const contentLengthHeader = response.headers["content-length"];
+				const contentLength = Array.isArray(contentLengthHeader)
+					? Number.parseInt(contentLengthHeader[0] ?? "0", 10)
+					: Number.parseInt(contentLengthHeader ?? "0", 10);
+				if (Number.isFinite(contentLength) && contentLength > 0) {
+					record.job.total = Math.max(
+						record.job.total,
+						baseBytes + startByte + contentLength,
+					);
+				}
+
+				const writeStream: Writable = fs.createWriteStream(stagingPath, {
+					flags: startByte > 0 ? "a" : "w",
+				});
+
+				let lastSampleBytes = record.job.received;
+				let lastSampleAt = Date.now();
+				const bodyStream = Readable.from(response.body);
+				bodyStream.on("data", (chunk: Buffer) => {
+					record.job.received += chunk.length;
+
+					const now = Date.now();
+					const elapsed = now - lastSampleAt;
+					if (elapsed >= 1000) {
+						record.job.bytesPerSec =
+							((record.job.received - lastSampleBytes) * 1000) / elapsed;
+						record.job.etaMs =
+							record.job.bytesPerSec > 0
+								? ((record.job.total - record.job.received) * 1000) /
+									record.job.bytesPerSec
+								: null;
+						lastSampleAt = now;
+						lastSampleBytes = record.job.received;
+					}
+
+					this.throttleEmit(record);
+				});
+
+				await pipeline(bodyStream, writeStream);
+				await fsp.rename(stagingPath, finalPath);
+			}
 
 			const stat = await fsp.stat(finalPath);
 			const sha256 = await hashFile(finalPath);

--- a/plugins/plugin-native-bun-runtime/ElizaosCapacitorBunRuntime.podspec
+++ b/plugins/plugin-native-bun-runtime/ElizaosCapacitorBunRuntime.podspec
@@ -20,6 +20,7 @@ source_files = if include_full_bun_engine
     'ios/Sources/ElizaBunRuntimePlugin/FullBunEngineHost.swift',
     'ios/Sources/ElizaBunRuntimePlugin/SandboxPaths.swift',
     'ios/Sources/ElizaBunRuntimePlugin/bridge/KeepAwakeBridge.swift',
+    'ios/Sources/ElizaBunRuntimePlugin/bridge/BackgroundDownloadBridge.swift',
     'ios/Sources/ElizaBunRuntimePlugin/bridge/LlamaBridgeImpl.swift',
     'ios/Sources/ElizaBunRuntimePlugin/kokoro/**/*.swift'
   ]

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/BridgeInstaller.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/BridgeInstaller.swift
@@ -22,6 +22,7 @@ public struct BridgeKit {
     public let process: ProcessBridge
     public let ui: UIBridge
     public let keepAwake: KeepAwakeBridge
+    public let backgroundDownload: BackgroundDownloadBridge
 }
 
 public enum BridgeInstaller {
@@ -73,6 +74,12 @@ public enum BridgeInstaller {
         let keepAwake = KeepAwakeBridge()
         keepAwake.install(into: ctx)
 
+        // The shared singleton owns the one background URLSession allowed per
+        // identifier per process (and is the instance the AppDelegate relaunch
+        // hook forwards completion events to).
+        let backgroundDownload = BackgroundDownloadBridge.shared
+        backgroundDownload.install(into: ctx)
+
         return BridgeKit(
             fs: fs,
             paths: pathsBridge,
@@ -83,7 +90,8 @@ public enum BridgeInstaller {
             log: log,
             process: process,
             ui: ui,
-            keepAwake: keepAwake
+            keepAwake: keepAwake,
+            backgroundDownload: backgroundDownload
         )
     }
 }

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/FullBunEngineHost.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/FullBunEngineHost.swift
@@ -38,7 +38,8 @@ private let fullBunHostCallCallback: @convention(c) (
 ///   `ELIZA_MAX_PROTOCOL_LINE_BYTES` (16 MiB) cap prevents unbounded reads.
 /// - Host-call allowlist: only `llama_hardware_info`, `llama_load_model`,
 ///   `llama_generate`, `llama_free`, `llama_cancel`, `eliza_tts_synthesize`,
-///   and `eliza_asr_transcribe` are dispatched by
+///   `eliza_asr_transcribe`, `keep_awake_set`, `bg_download_start`,
+///   `bg_download_status`, and `bg_download_cancel` are dispatched by
 ///   `handleHostCall`. All other method names return `{"ok":false,"error":"..."}`.
 /// - `http_fetch` (JSContext compat path): loopback/local-agent URLs are
 ///   rejected at `HTTPBridge.isLocalLoopback` before a URLRequest is created.
@@ -407,6 +408,38 @@ final class FullBunEngineHost {
                 let enabled = boolValue(payload, "enabled") ?? false
                 KeepAwakeBridge.shared.setEnabled(enabled)
                 return encodeHostEnvelope(ok: true, result: ["enabled": NSNumber(value: enabled)])
+            case "bg_download_start":
+                // Route the large on-device model file through a native
+                // background URLSession so the ~5 GB transfer survives the app
+                // backgrounding / the device locking (#11841). The downloader
+                // polls `bg_download_status` for progress + completion.
+                guard let id = stringValue(payload, "id"), !id.isEmpty,
+                      let url = stringValue(payload, "url"), !url.isEmpty,
+                      let destPath = stringValue(payload, "destPath"), !destPath.isEmpty else {
+                    return encodeHostEnvelope(
+                        ok: false,
+                        error: "bg_download_start requires id, url, and destPath"
+                    )
+                }
+                let headers = stringMapValue(payload, "headers") ?? [:]
+                let total = int64Value(payload, "expectedTotalBytes") ?? 0
+                return encodeHostEnvelope(ok: true, result: BackgroundDownloadBridge.shared.start(
+                    id: id,
+                    urlString: url,
+                    headers: headers,
+                    destPath: destPath,
+                    expectedTotalBytes: total
+                ))
+            case "bg_download_status":
+                guard let id = stringValue(payload, "id"), !id.isEmpty else {
+                    return encodeHostEnvelope(ok: false, error: "bg_download_status requires id")
+                }
+                return encodeHostEnvelope(ok: true, result: BackgroundDownloadBridge.shared.status(id: id))
+            case "bg_download_cancel":
+                guard let id = stringValue(payload, "id"), !id.isEmpty else {
+                    return encodeHostEnvelope(ok: false, error: "bg_download_cancel requires id")
+                }
+                return encodeHostEnvelope(ok: true, result: BackgroundDownloadBridge.shared.cancel(id: id))
             default:
                 return encodeHostEnvelope(
                     ok: false,
@@ -662,6 +695,19 @@ final class FullBunEngineHost {
         if let value = payload[key] as? NSNumber { return value.floatValue }
         if let value = payload[key] as? String, let parsed = Float(value) { return parsed }
         return nil
+    }
+
+    private func stringMapValue(_ payload: [String: Any], _ key: String) -> [String: String]? {
+        guard let raw = payload[key] as? [String: Any] else { return nil }
+        var out: [String: String] = [:]
+        for (mapKey, value) in raw {
+            if let string = value as? String {
+                out[mapKey] = string
+            } else if let number = value as? NSNumber {
+                out[mapKey] = number.stringValue
+            }
+        }
+        return out
     }
 
     private func stringArrayValue(_ payload: [String: Any], _ key: String) -> [String]? {

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/BackgroundDownloadBridge+JSContext.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/BackgroundDownloadBridge+JSContext.swift
@@ -1,0 +1,44 @@
+import Foundation
+import JavaScriptCore
+
+/// JSContext (compatibility engine) installer for the background-download host
+/// functions.
+///
+/// Kept in its own file — separate from the JavaScriptCore-free
+/// `BackgroundDownloadBridge` core — so the core type can compile into the
+/// full-Bun engine build (which omits JavaScriptCore and never lists this file
+/// in its podspec source set). On the compat path the closures funnel into the
+/// same shared bridge used by the full-Bun `host_call` dispatch.
+///
+/// All three functions are synchronous native operations (kick off / read /
+/// cancel a `URLSessionDownloadTask`) so they return their result value
+/// directly to JS.
+extension BackgroundDownloadBridge {
+    public func install(into ctx: JSContext) {
+        ctx.installBridgeFunction(name: "bg_download_start") { args in
+            let payload = args.first?.toObject() as? [String: Any] ?? [:]
+            let id = payload["id"] as? String ?? ""
+            let url = payload["url"] as? String ?? ""
+            let headers = (args.first?.forProperty("headers")).map { $0.toStringMap() } ?? [:]
+            let destPath = payload["destPath"] as? String ?? ""
+            let total = (payload["expectedTotalBytes"] as? NSNumber)?.int64Value ?? 0
+            return self.start(
+                id: id,
+                urlString: url,
+                headers: headers,
+                destPath: destPath,
+                expectedTotalBytes: total
+            )
+        }
+        ctx.installBridgeFunction(name: "bg_download_status") { args in
+            let payload = args.first?.toObject() as? [String: Any] ?? [:]
+            let id = payload["id"] as? String ?? ""
+            return self.status(id: id)
+        }
+        ctx.installBridgeFunction(name: "bg_download_cancel") { args in
+            let payload = args.first?.toObject() as? [String: Any] ?? [:]
+            let id = payload["id"] as? String ?? ""
+            return self.cancel(id: id)
+        }
+    }
+}

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/BackgroundDownloadBridge.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/bridge/BackgroundDownloadBridge.swift
@@ -1,0 +1,409 @@
+import Foundation
+
+/// Native iOS **background `URLSession`** download for the large on-device
+/// model pull (#11841).
+///
+/// The full-Bun runtime otherwise streams the ~5 GB Eliza-1 weight file to disk
+/// with an in-process `fetch()`. iOS suspends that runtime the instant the app
+/// backgrounds or the device locks, so the multi-GB transfer stalls at
+/// "Loading eliza-1-2B…". A `URLSessionConfiguration.background` download task
+/// is owned by the system `nsurlsessiond` daemon, not the app process, so it
+/// keeps making progress while the app is suspended, survives a device lock,
+/// and can relaunch the app on completion.
+///
+/// Contract with the JS downloader (`plugin-local-inference`): the downloader
+/// drives this bridge synchronously through `host_call` —
+/// `bg_download_start`, then it polls `bg_download_status` until the state is
+/// terminal, and `bg_download_cancel` on user cancel. The bridge writes the
+/// finished file to the exact `destPath` the downloader passed (its `.part`
+/// staging path); the downloader then runs its existing sha256 verify + atomic
+/// rename into the models directory. Progress and terminal state are reported
+/// as plain values so the request/response `host_call` model needs no reverse
+/// push channel.
+///
+/// State survives a process restart (Bun runtime crash/relaunch mid-transfer):
+/// active-job metadata (`destPath`/`url`/`total`) and terminal outcomes are
+/// persisted to `UserDefaults`, and outstanding background tasks are
+/// re-associated by the OS when the session is recreated with the same
+/// identifier — the delegate callbacks then rebuild in-memory state from the
+/// persisted metadata keyed on `task.taskDescription`.
+public final class BackgroundDownloadBridge: NSObject {
+    /// Process-wide singleton — a background session identifier may only back a
+    /// single live `URLSession` instance per process.
+    public static let shared = BackgroundDownloadBridge()
+
+    public enum DownloadState: String {
+        case running
+        case completed
+        case failed
+        case cancelled
+    }
+
+    private static let sessionIdentifier = "ai.eliza.bun.background-download"
+    private static let persistenceKey = "ai.eliza.bun.background-download.state.v1"
+    /// Bounded automatic resume attempts for a task that fails with recoverable
+    /// resume data (transient network drop) before the job is surfaced as
+    /// failed to the downloader.
+    private static let maxAutoResumeAttempts = 5
+
+    private final class JobState {
+        let id: String
+        var destPath: String
+        var url: String
+        var headers: [String: String]
+        var received: Int64
+        var total: Int64
+        var state: DownloadState
+        var error: String?
+        var task: URLSessionDownloadTask?
+        var resumeData: Data?
+        var autoResumeAttempts: Int
+
+        init(
+            id: String,
+            destPath: String,
+            url: String,
+            headers: [String: String],
+            total: Int64
+        ) {
+            self.id = id
+            self.destPath = destPath
+            self.url = url
+            self.headers = headers
+            self.received = 0
+            self.total = total
+            self.state = .running
+            self.error = nil
+            self.task = nil
+            self.resumeData = nil
+            self.autoResumeAttempts = 0
+        }
+    }
+
+    private let lock = NSLock()
+    private var jobs: [String: JobState] = [:]
+    private var backgroundCompletionHandler: (() -> Void)?
+
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.background(
+            withIdentifier: Self.sessionIdentifier
+        )
+        // Relaunch the app in the background when tasks finish while it is
+        // suspended so the completion handoff runs without user interaction.
+        config.sessionSendsLaunchEvents = true
+        // A user-initiated model install must not be deferred by the OS.
+        config.isDiscretionary = false
+        config.allowsCellularAccess = true
+        config.waitsForConnectivity = true
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+
+    override public init() {
+        super.init()
+        loadPersistedState()
+        // Recreate the session eagerly so the OS re-associates any tasks that
+        // outlived a previous app launch and starts delivering their delegate
+        // callbacks (progress + completion) into this instance.
+        _ = session
+    }
+
+    // MARK: - host_call surface
+
+    /// Begin (or resume, or re-observe) a background download. Idempotent for a
+    /// given `id`: a second call while the task is live returns the current
+    /// snapshot instead of starting a duplicate transfer.
+    public func start(
+        id: String,
+        urlString: String,
+        headers: [String: String],
+        destPath: String,
+        expectedTotalBytes: Int64
+    ) -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = jobs[id] {
+            switch existing.state {
+            case .running, .completed:
+                return snapshot(existing)
+            case .failed, .cancelled:
+                // A prior terminal outcome for the same id is being retried —
+                // fall through to (re)start, resuming from resume data if we
+                // captured any.
+                existing.state = .running
+                existing.error = nil
+                existing.destPath = destPath
+                existing.url = urlString
+                existing.headers = headers
+                if expectedTotalBytes > 0 { existing.total = expectedTotalBytes }
+                existing.autoResumeAttempts = 0
+                startTask(for: existing)
+                persistLocked()
+                return snapshot(existing)
+            }
+        }
+
+        let job = JobState(
+            id: id,
+            destPath: destPath,
+            url: urlString,
+            headers: headers,
+            total: expectedTotalBytes
+        )
+        jobs[id] = job
+        startTask(for: job)
+        persistLocked()
+        return snapshot(job)
+    }
+
+    public func status(id: String) -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let job = jobs[id] else {
+            return ["state": DownloadState.failed.rawValue, "error": "unknown download id \(id)"]
+        }
+        return snapshot(job)
+    }
+
+    public func cancel(id: String) -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let job = jobs[id] else {
+            return ["state": DownloadState.cancelled.rawValue, "cancelled": false]
+        }
+        job.task?.cancel()
+        job.task = nil
+        job.resumeData = nil
+        job.state = .cancelled
+        persistLocked()
+        var result = snapshot(job)
+        result["cancelled"] = true
+        return result
+    }
+
+    /// AppDelegate relaunch hook: `application(_:handleEventsForBackgroundURLSession:completionHandler:)`
+    /// forwards here so the completion handler is called once every queued
+    /// delegate event has been delivered (`urlSessionDidFinishEvents`).
+    public func handleEventsForBackgroundURLSession(
+        identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == Self.sessionIdentifier else {
+            completionHandler()
+            return
+        }
+        lock.lock()
+        backgroundCompletionHandler = completionHandler
+        lock.unlock()
+        // Touch the session so it re-associates outstanding tasks and flushes
+        // their pending delegate callbacks.
+        _ = session
+    }
+
+    // MARK: - task lifecycle (caller holds `lock`)
+
+    private func startTask(for job: JobState) {
+        let task: URLSessionDownloadTask
+        if let resumeData = job.resumeData {
+            task = session.downloadTask(withResumeData: resumeData)
+            job.resumeData = nil
+        } else {
+            guard let url = URL(string: job.url) else {
+                job.state = .failed
+                job.error = "invalid download url"
+                return
+            }
+            var request = URLRequest(url: url)
+            for (key, value) in job.headers {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+            task = session.downloadTask(with: request)
+        }
+        task.taskDescription = job.id
+        job.task = task
+        job.state = .running
+        task.resume()
+    }
+
+    private func job(forTaskDescription description: String?) -> JobState? {
+        guard let description else { return nil }
+        return jobs[description]
+    }
+
+    private func snapshot(_ job: JobState) -> [String: Any] {
+        var result: [String: Any] = [
+            "id": job.id,
+            "state": job.state.rawValue,
+            "received": NSNumber(value: job.received),
+            "total": NSNumber(value: job.total),
+            "destPath": job.destPath,
+        ]
+        if let error = job.error {
+            result["error"] = error
+        }
+        return result
+    }
+
+    // MARK: - persistence
+
+    private func persistLocked() {
+        var payload: [String: [String: Any]] = [:]
+        for (id, job) in jobs {
+            var entry: [String: Any] = [
+                "destPath": job.destPath,
+                "url": job.url,
+                "headers": job.headers,
+                "received": NSNumber(value: job.received),
+                "total": NSNumber(value: job.total),
+                "state": job.state.rawValue,
+            ]
+            if let error = job.error { entry["error"] = error }
+            payload[id] = entry
+        }
+        UserDefaults.standard.set(payload, forKey: Self.persistenceKey)
+    }
+
+    private func loadPersistedState() {
+        guard
+            let payload = UserDefaults.standard.dictionary(forKey: Self.persistenceKey)
+                as? [String: [String: Any]]
+        else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        for (id, raw) in payload {
+            guard
+                let destPath = raw["destPath"] as? String,
+                let url = raw["url"] as? String
+            else { continue }
+            let headers = raw["headers"] as? [String: String] ?? [:]
+            let total = (raw["total"] as? NSNumber)?.int64Value ?? 0
+            let job = JobState(
+                id: id,
+                destPath: destPath,
+                url: url,
+                headers: headers,
+                total: total
+            )
+            job.received = (raw["received"] as? NSNumber)?.int64Value ?? 0
+            job.state = (raw["state"] as? String).flatMap(DownloadState.init) ?? .running
+            job.error = raw["error"] as? String
+            jobs[id] = job
+        }
+    }
+}
+
+extension BackgroundDownloadBridge: URLSessionDownloadDelegate {
+    public func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let job = job(forTaskDescription: downloadTask.taskDescription) else { return }
+        job.task = downloadTask
+        job.received = totalBytesWritten
+        if totalBytesExpectedToWrite > 0 {
+            job.total = totalBytesExpectedToWrite
+        }
+        job.state = .running
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        // The temp file at `location` is deleted the moment this callback
+        // returns, so the move to the destination must happen synchronously
+        // here — before we hand control back to URLSession.
+        lock.lock()
+        let job = job(forTaskDescription: downloadTask.taskDescription)
+        lock.unlock()
+        guard let job else { return }
+
+        let fileManager = FileManager.default
+        let destURL = URL(fileURLWithPath: job.destPath)
+        do {
+            try fileManager.createDirectory(
+                at: destURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: destURL.path) {
+                try fileManager.removeItem(at: destURL)
+            }
+            try fileManager.moveItem(at: location, to: destURL)
+        } catch {
+            lock.lock()
+            job.state = .failed
+            job.error = "failed to stage downloaded file: \(error.localizedDescription)"
+            persistLocked()
+            lock.unlock()
+            return
+        }
+
+        lock.lock()
+        if let attributes = try? fileManager.attributesOfItem(atPath: destURL.path),
+            let size = attributes[.size] as? NSNumber {
+            job.received = size.int64Value
+        }
+        job.state = .completed
+        job.task = nil
+        job.error = nil
+        persistLocked()
+        lock.unlock()
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let job = job(forTaskDescription: task.taskDescription) else { return }
+        // A successful transfer already flipped state to `.completed` in
+        // `didFinishDownloadingTo`; nothing to do here.
+        if job.state == .completed { return }
+        guard let error else { return }
+
+        let nsError = error as NSError
+        if nsError.code == NSURLErrorCancelled {
+            // An explicit cancel already set `.cancelled`; leave it.
+            if job.state != .cancelled { job.state = .cancelled }
+            job.task = nil
+            persistLocked()
+            return
+        }
+
+        // Recoverable failure: retry from resume data a bounded number of times
+        // so a transient drop mid-transfer does not surface as a hard failure.
+        if let resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data,
+            job.autoResumeAttempts < Self.maxAutoResumeAttempts {
+            job.resumeData = resumeData
+            job.autoResumeAttempts += 1
+            startTask(for: job)
+            persistLocked()
+            return
+        }
+
+        job.state = .failed
+        job.error = error.localizedDescription
+        job.task = nil
+        // Preserve any resume data for a later explicit retry via `start`.
+        job.resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+        persistLocked()
+    }
+
+    public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        lock.lock()
+        let handler = backgroundCompletionHandler
+        backgroundCompletionHandler = nil
+        lock.unlock()
+        DispatchQueue.main.async {
+            handler?()
+        }
+    }
+}


### PR DESCRIPTION
Closes #11841.

## Root cause
The on-device Eliza-1 download streams a plain in-process `fetch()` to disk inside the full-Bun runtime subprocess (`plugins/plugin-local-inference/src/services/downloader.ts`). iOS suspends that subprocess the instant the app backgrounds or the device locks, so the ~5 GB pull stalls at "Loading eliza-1-2B…". A lock/background is near-certain during a multi-GB transfer, so it reliably never finishes. The existing `keep_awake_set` idle-timer hold (also #11841) only prevents *auto-lock* for a foregrounded app — it does nothing for a manual lock or backgrounding.

## Fix
Route the large model file through a native **background `URLSession`** (`URLSessionConfiguration.background(withIdentifier:)`), which is owned by the system `nsurlsessiond` daemon rather than the app process. It keeps making progress while the app is suspended, survives a device lock, and relaunches the app on completion.

- **`bridge/BackgroundDownloadBridge.swift`** (new, JSC-free core): background `URLSession` + `URLSessionDownloadDelegate`. `sessionSendsLaunchEvents = true`, `isDiscretionary = false`. Bounded resume-data auto-retry on transient failure; preserves resume data for an explicit later retry. `UserDefaults` persistence of active-job metadata (`destPath`/`url`/`total`) + terminal state so a runtime restart mid-transfer reconnects. `didFinishDownloadingTo` synchronously moves the finished temp file to the downloader's staging `destPath`.
- **`bridge/BackgroundDownloadBridge+JSContext.swift`** (new): compat-engine installer, split out so the core compiles into the full-Bun engine (which omits JavaScriptCore).
- **`FullBunEngineHost.swift`**: `bg_download_start` / `bg_download_status` / `bg_download_cancel` `host_call` cases (+ allowlist doc + a `stringMapValue` helper).
- **`BridgeInstaller.swift`** + **podspec**: wire the bridge into the JSContext `BridgeKit` and add the core file to the full-Bun source set (`Network` already linked).
- **`AppDelegate.swift`**: `application(_:handleEventsForBackgroundURLSession:completionHandler:)` forwards the OS completion handler to the bridge (guarded by `#if canImport`). No Info.plist change is required — background `URLSession` downloads do not need a `UIBackgroundModes` entry.
- **`bridge.ts`**: expose `__ELIZA_BRIDGE__.bg_download_*` over `callIosHost` (mirrors `installKeepAwakeBridge`).
- **`downloader.ts`**: when the bridge is present (iOS only), route each file's transfer through the native session and poll `bg_download_status` for progress + completion; the existing sha256 gate + atomic rename are unchanged. The in-process fetch path is untouched on every other platform (desktop/Android/tests).

The synchronous request/response `host_call` model is respected: `start` returns immediately with a snapshot and the downloader polls `status` — no reverse push channel needed. When the app is suspended, polling pauses but the OS download continues; on resume the poll observes the completed/progressing state.

## Verification
- `plugin-local-inference` downloader suite: **22/22 pass**, including 2 new tests — the native bridge installs the full bundle with **no in-process fetch**, and a native `failed` transfer surfaces as a failed job.
- `tsc --noEmit` clean for `plugin-local-inference` and `plugin-capacitor-bridge`.
- Both new Swift files `swiftc -typecheck` clean against the iOS SDK (`arm64-apple-ios15.0`).
- Biome clean on the touched TS.

### On-device confirmation (human final step)
Device evidence not captured in this session (the full on-device build is heavy). To confirm on the attached iPhone "MoonCycles" (iPhone17,2 / iOS 18.7.8):
1. Build + deploy the full-Bun engine build to the device (fresh-worktree iOS device build recipe).
2. Onboard → "On this device" → download **eliza-1-2B** (~4.97 GB).
3. Once progress is moving, **lock the device / background the app** for several minutes.
4. Re-open: the download has continued (not stuck at "Loading eliza-1-2B…") and finishes; the model loads.
5. Capture screen recording + `ggml.log` / boot-trace into `.github/issue-evidence/11841-ios-background-download/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)