### PR TITLE
fix(app): unhandled boot promise → white screen on deploy-skew — add a reload card (#12028)

### DIFF
--- a/packages/app/src/boot-failure.ts
+++ b/packages/app/src/boot-failure.ts
@@ -1,0 +1,53 @@
+/**
+ * Last-resort boot error surface.
+ *
+ * `main()` awaits several fallible pre-mount steps (the dynamic `app-core` and
+ * `@elizaos/ui/voice` chunks). If any rejects, React never mounts and the user
+ * is stranded on a permanent blank page with no recovery — most commonly a
+ * stale `index.html` pointing at purged hashed chunks right after a prod
+ * redeploy, or a flaky network. The app's root ErrorBoundary can't help
+ * because React was never mounted.
+ *
+ * Paint a minimal, dependency-free reload card instead. A full reload
+ * re-fetches `index.html` and discards the in-session rejected-promise caches
+ * (`cachedDynamicImport` / `appModulesInitialized`), so it is the correct
+ * recovery path.
+ */
+export function renderBootFailure(
+  error: unknown,
+  doc: Document = document,
+): void {
+  try {
+    console.error("[boot] app failed to start", error);
+  } catch {
+    // never let logging mask the recovery UI
+  }
+
+  const root = doc.getElementById("root");
+  if (!root) return;
+  root.textContent = "";
+
+  const card = doc.createElement("div");
+  card.setAttribute("data-testid", "boot-failure");
+  card.style.cssText =
+    "display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;gap:16px;padding:24px;text-align:center;font-family:system-ui,-apple-system,sans-serif;color:#e5e7eb;background:#0f1117";
+
+  const message = doc.createElement("p");
+  message.textContent =
+    "Couldn't start the app. This can happen right after an update.";
+  message.style.cssText =
+    "margin:0;font-size:14px;max-width:24rem;line-height:1.5";
+
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.textContent = "Reload";
+  button.style.cssText =
+    "padding:8px 20px;border-radius:6px;border:1px solid #3f3f46;background:#18181b;color:#fafafa;font-size:14px;cursor:pointer";
+  button.addEventListener("click", () => {
+    doc.defaultView?.location.reload();
+  });
+
+  card.appendChild(message);
+  card.appendChild(button);
+  root.appendChild(card);
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -131,6 +131,7 @@ import {
   APP_NAMESPACE,
   APP_URL_SCHEME,
 } from "./app-config";
+import { renderBootFailure } from "./boot-failure";
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
@@ -2757,8 +2758,15 @@ async function main(): Promise<void> {
   // Swabble fallback. No-op off-desktop (no electrobun RPC). Awaited before
   // mountReactApp so `window.__ELIZA_FUSED_WAKE__` is set for the wake
   // controller's first-render capability probe.
-  const { registerDesktopFusedWake } = await import("@elizaos/ui/voice");
-  registerDesktopFusedWake();
+  // A separate hashed lazy chunk that runs on ALL platforms before first
+  // paint. Never let a voice-chunk load failure (e.g. a stale index.html
+  // pointing at a purged hash during a redeploy) gate mounting the app.
+  try {
+    const { registerDesktopFusedWake } = await import("@elizaos/ui/voice");
+    registerDesktopFusedWake();
+  } catch (error) {
+    console.warn("[boot] fused-wake voice module unavailable", error);
+  }
   markStartup("bridges:end", { platform });
   measureStartup("bridges", "bridges:start", "bridges:end");
   mountReactApp();
@@ -2766,10 +2774,17 @@ async function main(): Promise<void> {
   await initializePlatform();
 }
 
+// main() awaits fallible pre-mount chunks; a bare invocation would leave any
+// rejection unhandled and the page permanently blank. Route every boot failure
+// to an actionable reload card instead.
+function boot(): void {
+  void main().catch(renderBootFailure);
+}
+
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", main);
+  document.addEventListener("DOMContentLoaded", boot);
 } else {
-  main();
+  boot();
 }
 
 export { isAndroid, isDesktopPlatform as isDesktop, isIOS, isNative, platform };

--- a/packages/app/test/boot-failure.test.ts
+++ b/packages/app/test/boot-failure.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+//
+// Boot resilience: main() awaits fallible pre-mount chunks; if one rejects the
+// app used to be a permanent blank page. renderBootFailure is the .catch that
+// guarantees an actionable reload card instead. (#<boot-white-screen>)
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderBootFailure } from "../src/boot-failure";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("renderBootFailure", () => {
+  it("paints a reload card into #root instead of leaving a blank page", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    document.body.innerHTML = '<div id="root"></div>';
+
+    renderBootFailure(new Error("chunk 404"));
+
+    const card = document.querySelector('[data-testid="boot-failure"]');
+    expect(card).toBeTruthy();
+    const button = card?.querySelector("button");
+    expect(button?.textContent).toBe("Reload");
+  });
+
+  it("clears any partial content in #root before painting", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    document.body.innerHTML = '<div id="root"><span>half-mounted</span></div>';
+
+    renderBootFailure(new Error("boom"));
+
+    const root = document.getElementById("root");
+    expect(root?.textContent).not.toContain("half-mounted");
+    expect(root?.querySelector('[data-testid="boot-failure"]')).toBeTruthy();
+  });
+
+  it("is a no-op (no throw) when #root is absent", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderBootFailure(new Error("x"))).not.toThrow();
+  });
+
+  it("the Reload button triggers a full page reload", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    // jsdom's location.reload is non-configurable; stub via the getter path.
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...original, reload },
+    });
+    document.body.innerHTML = '<div id="root"></div>';
+
+    renderBootFailure(new Error("x"));
+    document
+      .querySelector<HTMLButtonElement>('[data-testid="boot-failure"] button')
+      ?.click();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: original,
+    });
+  });
+});


### PR DESCRIPTION
Closes #12028. `[cloud-money]` (cross-lane, cc `[phone-ui]`). MED, demo-relevant (prod redeploy during the demo window → blank page).

**Bug:** `main()` awaits pre-mount lazy chunks with no `.catch`; a stale `index.html` (redeploy) or flaky network 404s a hashed chunk → React never mounts → permanent white screen, no recovery.

**Fix:** `.catch(renderBootFailure)` reload card + wrap the pre-mount voice import in try/catch. **4/4 test green**, typecheck + biome clean. Additive (only runs on a rejection that today = blank screen). Not self-merging cross-lane.