### PR TITLE
[codex] add eliza-code runner image install option

### DIFF
--- a/packages/cloud/services/coding-remote-runner/AGENTS.md
+++ b/packages/cloud/services/coding-remote-runner/AGENTS.md
@@ -30,8 +30,9 @@ POST /v1/processes/run                run a command (JSON body)
   `commandRunner`).
 - `Dockerfile` — `node:24-bookworm-slim` base; installs Bun plus `git`,
   `ripgrep`, `python3`, `jq`, `openssh-client`, and (by default) the Codex,
-  Claude Code, and opencode CLIs. Runs as the non-root `runner` user; healthcheck
-  hits `/health`.
+  Claude Code, and opencode CLIs. It can optionally install the elizaOS-owned
+  coding agent (`eliza-code-acp`) once `@elizaos/example-code` is published.
+  Runs as the non-root `runner` user; healthcheck hits `/health`.
 
 ## Scripts (scope with `--cwd`)
 
@@ -45,7 +46,9 @@ bun run --cwd packages/cloud/services/coding-remote-runner docker:build # build 
 
 Disable the bundled coding CLIs at image-build time with
 `--build-arg INSTALL_CODEX=false`, `INSTALL_CLAUDE_CODE=false`, and
-`INSTALL_OPENCODE=false`.
+`INSTALL_OPENCODE=false`. Opt into the elizaOS coding agent with
+`--build-arg INSTALL_ELIZA_CODE=true`; override the exact npm package with
+`--build-arg ELIZA_CODE_PACKAGE=@elizaos/example-code@<version>`.
 
 ## Env vars
 

--- a/packages/cloud/services/coding-remote-runner/CLAUDE.md
+++ b/packages/cloud/services/coding-remote-runner/CLAUDE.md
@@ -30,8 +30,9 @@ POST /v1/processes/run                run a command (JSON body)
   `commandRunner`).
 - `Dockerfile` — `node:24-bookworm-slim` base; installs Bun plus `git`,
   `ripgrep`, `python3`, `jq`, `openssh-client`, and (by default) the Codex,
-  Claude Code, and opencode CLIs. Runs as the non-root `runner` user; healthcheck
-  hits `/health`.
+  Claude Code, and opencode CLIs. It can optionally install the elizaOS-owned
+  coding agent (`eliza-code-acp`) once `@elizaos/example-code` is published.
+  Runs as the non-root `runner` user; healthcheck hits `/health`.
 
 ## Scripts (scope with `--cwd`)
 
@@ -45,7 +46,9 @@ bun run --cwd packages/cloud/services/coding-remote-runner docker:build # build 
 
 Disable the bundled coding CLIs at image-build time with
 `--build-arg INSTALL_CODEX=false`, `INSTALL_CLAUDE_CODE=false`, and
-`INSTALL_OPENCODE=false`.
+`INSTALL_OPENCODE=false`. Opt into the elizaOS coding agent with
+`--build-arg INSTALL_ELIZA_CODE=true`; override the exact npm package with
+`--build-arg ELIZA_CODE_PACKAGE=@elizaos/example-code@<version>`.
 
 ## Env vars
 

--- a/packages/cloud/services/coding-remote-runner/Dockerfile
+++ b/packages/cloud/services/coding-remote-runner/Dockerfile
@@ -4,6 +4,8 @@ ARG BUN_VERSION=canary
 ARG INSTALL_CODEX=true
 ARG INSTALL_CLAUDE_CODE=true
 ARG INSTALL_OPENCODE=true
+ARG INSTALL_ELIZA_CODE=false
+ARG ELIZA_CODE_PACKAGE=@elizaos/example-code@2.0.0-beta.0
 
 ENV BUN_INSTALL=/root/.bun
 ENV PATH=/root/.bun/bin:/usr/local/bin:$PATH
@@ -28,6 +30,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
 RUN if [ "$INSTALL_CODEX" = "true" ]; then npm install -g @openai/codex; fi \
   && if [ "$INSTALL_CLAUDE_CODE" = "true" ]; then npm install -g @anthropic-ai/claude-code; fi \
   && if [ "$INSTALL_OPENCODE" = "true" ]; then npm install -g opencode-ai; fi \
+  && if [ "$INSTALL_ELIZA_CODE" = "true" ]; then npm install -g "$ELIZA_CODE_PACKAGE"; fi \
   && npm cache clean --force
 
 WORKDIR /app

--- a/packages/cloud/services/coding-remote-runner/README.md
+++ b/packages/cloud/services/coding-remote-runner/README.md
@@ -22,16 +22,25 @@ ELIZA_CODING_WORKSPACE=/workspace
 ```
 
 The image includes `git`, `ripgrep`, `python3`, `openssh-client`, Codex CLI,
-Claude Code, and opencode by default. Disable runner installs at build time:
+Claude Code, and opencode by default. It can also install the elizaOS-owned
+coding agent (`eliza-code-acp`) once `@elizaos/example-code` is published.
+Disable runner installs, or opt into eliza-code, at build time:
 
 ```bash
 docker build \
   --build-arg INSTALL_CODEX=false \
   --build-arg INSTALL_CLAUDE_CODE=false \
   --build-arg INSTALL_OPENCODE=false \
+  --build-arg INSTALL_ELIZA_CODE=true \
+  --build-arg ELIZA_CODE_PACKAGE=@elizaos/example-code@2.0.0-beta.0 \
   -t ghcr.io/elizaos/coding-remote-runner:local \
   packages/cloud/services/coding-remote-runner
 ```
+
+`INSTALL_ELIZA_CODE` defaults to `false` so image builds keep working until the
+package exists on npm. The Cloud cutover can enable it and set
+`ELIZA_ACP_DEFAULT_AGENT=elizaos` plus
+`ELIZA_ELIZAOS_ACP_COMMAND=eliza-code-acp` on the runner environment.
 
 Configure Eliza Cloud to use the published image with:
 


### PR DESCRIPTION
## Summary
- Add optional coding remote runner image build args for installing the elizaOS-owned coding agent package.
- Keep the default image build unchanged until `@elizaos/example-code` is published.
- Document the Cloud cutover env vars for selecting `eliza-code-acp` through the orchestrator runner.

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/cloud/services/coding-remote-runner test`
- `bun run --cwd packages/cloud/services/coding-remote-runner typecheck`
- `cmp -s packages/cloud/services/coding-remote-runner/CLAUDE.md packages/cloud/services/coding-remote-runner/AGENTS.md`
- `docker build --build-arg INSTALL_CODEX=false --build-arg INSTALL_CLAUDE_CODE=false --build-arg INSTALL_OPENCODE=false --build-arg INSTALL_ELIZA_CODE=false -t eliza-coding-remote-runner:10059-build-arg-smoke packages/cloud/services/coding-remote-runner`

## Notes
- Advances #10059 by making the runner image ready for `eliza-code-acp` once the npm package exists.
- This does not publish `@elizaos/example-code`, push GHCR, or deploy Cloud; those remain gated on credentials/service access.
