### PR TITLE
fix(agent-orchestrator): register built apps at deploy completion so management surfaces can list them

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/built-apps-registry.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Built-apps registry: a successful app-deploy completion must produce a
+ * durable registry record with the verified live URL.
+ *
+ * Before this module existed, apps the agent built from chat were
+ * fire-and-forget — the router verified the live URL at `task_complete` and
+ * persisted only screenshot/trajectory artifacts, so nothing could ever list
+ * the app again (no `registerBuiltApp` anywhere in the repo).
+ *
+ * Covers:
+ *  1. pure derivation for both deploy targets (custom static host URL-shape
+ *     match; eliza-cloud app-build gate + code-host/loopback exclusion);
+ *  2. registry round-trip + redeploy dedupe on the runtime cache;
+ *  3. the REAL router path: handleEvent("task_complete") with a live URL
+ *     served by a local HTTP server → verification probes it → the registry
+ *     record lands in the runtime cache with that URL.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUILT_APPS_CACHE_KEY,
+  type BuiltAppRecord,
+  deriveBuiltApp,
+  listBuiltApps,
+  registerBuiltApp,
+  registerBuiltAppsForCompletion,
+} from "../services/built-apps-registry.ts";
+import { SubAgentRouter } from "../services/sub-agent-router.ts";
+
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const MSG = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "00000000-0000-4000-8000-000000000001";
+
+const CUSTOM_CONFIG = {
+  target: "custom" as const,
+  customAppsDir: "/srv/apps",
+  customBaseUrl: "https://example.org",
+};
+
+function record(overrides: Partial<BuiltAppRecord> = {}): BuiltAppRecord {
+  return {
+    slug: "snake-game",
+    name: "Snake Game",
+    url: "https://example.org/apps/snake-game/",
+    target: "custom",
+    sessionId: "sess-1",
+    registeredAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function cacheRuntime(): {
+  runtime: IAgentRuntime;
+  cache: Map<string, unknown>;
+} {
+  const cache = new Map<string, unknown>();
+  const runtime = {
+    getCache: async (key: string) => cache.get(key),
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, cache };
+}
+
+describe("deriveBuiltApp (custom static host)", () => {
+  it("derives slug + name from a verified URL under <base>/apps/<slug>/", () => {
+    const derived = deriveBuiltApp(
+      ["https://example.org/apps/snake-game/"],
+      CUSTOM_CONFIG,
+    );
+    expect(derived).toEqual({
+      slug: "snake-game",
+      name: "Snake Game",
+      url: "https://example.org/apps/snake-game/",
+      target: "custom",
+    });
+  });
+
+  it("matches a deep entry URL (index.html) to the same slug", () => {
+    const derived = deriveBuiltApp(
+      ["https://example.org/apps/todo/index.html"],
+      CUSTOM_CONFIG,
+    );
+    expect(derived?.slug).toBe("todo");
+  });
+
+  it("ignores verified URLs outside the configured apps base", () => {
+    expect(
+      deriveBuiltApp(
+        ["https://example.org/docs/guide/", "https://other.host/apps/x/"],
+        CUSTOM_CONFIG,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("deriveBuiltApp (eliza-cloud)", () => {
+  const CLOUD = { target: "eliza-cloud" as const };
+  const APP_TASK = "build a website for tracking my workouts and deploy it";
+
+  it("requires the app-build gate: a non-app task registers nothing", () => {
+    expect(
+      deriveBuiltApp(
+        ["https://myapp.elizacloud.example/"],
+        CLOUD,
+        "fix the failing unit test in packages/core",
+      ),
+    ).toBeNull();
+    expect(
+      deriveBuiltApp(["https://myapp.elizacloud.example/"], CLOUD),
+    ).toBeNull();
+  });
+
+  it("skips code-host and loopback URLs, registers the hosted app URL", () => {
+    const derived = deriveBuiltApp(
+      [
+        "https://github.com/acme/workouts/pull/12",
+        "http://127.0.0.1:3000/",
+        "https://workouts.apps.elizacloud.example/",
+      ],
+      CLOUD,
+      APP_TASK,
+    );
+    expect(derived).toEqual({
+      slug: "workouts",
+      name: "Workouts",
+      url: "https://workouts.apps.elizacloud.example/",
+      target: "eliza-cloud",
+    });
+  });
+});
+
+describe("registry round-trip", () => {
+  it("registers, lists, and dedupes a redeploy by target+slug", async () => {
+    const { runtime } = cacheRuntime();
+    expect(await listBuiltApps(runtime)).toEqual([]);
+
+    await registerBuiltApp(runtime, record());
+    await registerBuiltApp(runtime, record({ slug: "todo", name: "Todo" }));
+    expect(await listBuiltApps(runtime)).toHaveLength(2);
+
+    // Redeploy of the same app: refreshed record replaces, not duplicates.
+    const redeploy = record({
+      sessionId: "sess-2",
+      registeredAt: new Date(1000).toISOString(),
+    });
+    await registerBuiltApp(runtime, redeploy);
+    const apps = await listBuiltApps(runtime);
+    expect(apps).toHaveLength(2);
+    expect(apps[0]).toEqual(redeploy);
+  });
+
+  it("degrades gracefully when the runtime has no cache", async () => {
+    const bare = {} as IAgentRuntime;
+    expect(await registerBuiltApp(bare, record())).toBe(false);
+    expect(await listBuiltApps(bare)).toEqual([]);
+    expect(
+      await registerBuiltAppsForCompletion(bare, { id: "s" }, [
+        "https://example.org/apps/x/",
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("task_complete → registry record (real router path)", () => {
+  let server: Server;
+  let baseUrl: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = [
+    "ELIZA_CONFIG_PATH",
+    "ELIZA_APP_DEPLOY_TARGET",
+    "ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR",
+    "ELIZA_APP_DEPLOY_CUSTOM_BASE_URL",
+    "ELIZA_URL_VERIFY_SETTLE_MS",
+  ];
+
+  beforeEach(async () => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html><body>snake</body></html>");
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    // Hermetic config: no config file, custom static host via env.
+    process.env.ELIZA_CONFIG_PATH = "/nonexistent/built-apps-test.json";
+    process.env.ELIZA_APP_DEPLOY_TARGET = "custom";
+    process.env.ELIZA_APP_DEPLOY_CUSTOM_APPS_DIR = "/srv/apps";
+    process.env.ELIZA_APP_DEPLOY_CUSTOM_BASE_URL = baseUrl;
+    process.env.ELIZA_URL_VERIFY_SETTLE_MS = "0";
+  });
+
+  afterEach(async () => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it("a successful app-deploy completion writes the live URL to the registry", async () => {
+    const liveUrl = `${baseUrl}/apps/snake-game/`;
+    const cache = new Map<string, unknown>();
+    const session = {
+      id: "sess-app",
+      agentType: "codex",
+      name: "Ada",
+      workdir: "/tmp/built-apps-registry-test",
+      status: "ready",
+      createdAt: new Date(0),
+      lastActivityAt: new Date(0),
+      metadata: {
+        roomId: ROOM,
+        taskRoomId: ROOM,
+        messageId: MSG,
+        source: "discord",
+        label: "build snake game",
+        initialTask: "build a snake game web app and deploy it live",
+      },
+    };
+    const sessions = new Map<string, Record<string, unknown>>([
+      ["sess-app", session],
+    ]);
+    const acp = {
+      onSessionEvent: () => () => {},
+      getSession: async (id: string) => sessions.get(id),
+      getSessions: async () => [...sessions.values()],
+      getChangedPaths: () => [] as string[],
+      spawnSession: vi.fn(async () => ({ sessionId: "retry-1" })),
+      stopSession: vi.fn(async () => undefined),
+      updateSessionMetadata: vi.fn(async () => undefined),
+    };
+    const runtime = {
+      agentId: AGENT_ID,
+      character: { name: "Tester" },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: (key: string) => process.env[key],
+      getService: (type: string) =>
+        type === "ACP_SERVICE" || type === "ACP_SUBPROCESS_SERVICE"
+          ? acp
+          : undefined,
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: unknown) => {
+        cache.set(key, value);
+        return true;
+      },
+      createEntity: vi.fn(async () => true),
+      addParticipant: vi.fn(async () => true),
+      createMemory: vi.fn(async () => MSG),
+      emitEvent: vi.fn(async () => undefined),
+      useModel: vi.fn(async () => "{}"),
+    } as unknown as IAgentRuntime;
+
+    const router = new SubAgentRouter(runtime);
+    await router.start();
+    const internals = router as unknown as {
+      handleEvent(id: string, event: string, data: unknown): Promise<void>;
+    };
+    await internals.handleEvent("sess-app", "task_complete", {
+      response: `The snake game is built and live at ${liveUrl}`,
+      stopReason: "end_turn",
+    });
+    await router.stop();
+
+    const apps = cache.get(BUILT_APPS_CACHE_KEY) as BuiltAppRecord[];
+    expect(apps).toHaveLength(1);
+    expect(apps[0]).toMatchObject({
+      slug: "snake-game",
+      name: "Snake Game",
+      url: liveUrl,
+      target: "custom",
+      sessionId: "sess-app",
+      label: "build snake game",
+    });
+    expect(apps[0].registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -11,6 +11,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { listBuiltApps } from "../services/built-apps-registry.js";
 import {
   LLM_GOAL_VERIFIER_NAME,
   verifyGoalCompletion,
@@ -173,6 +174,15 @@ async function dispatchOrchestratorRoutes(
   const method = req.method?.toUpperCase();
   const url = new URL(req.url ?? "/", "http://localhost");
   const query = url.searchParams;
+
+  // GET /api/orchestrator/built-apps — apps the agent built + deployed from
+  // chat (verified live URL at task completion). Reads the durable registry
+  // written by the sub-agent router; independent of the task service, so it
+  // is dispatched before the service gate.
+  if (method === "GET" && pathname === `${PREFIX}/built-apps`) {
+    sendJson(res, { apps: await listBuiltApps(ctx.runtime) });
+    return true;
+  }
 
   const service = await resolveService(ctx);
   if (!service) {

--- a/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/built-apps-registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Durable registry of apps the agent built and deployed from chat.
+ *
+ * Without this, a built app is fire-and-forget: the router verifies the live
+ * URL at `task_complete` and then persists only narration/screenshot/trajectory
+ * artifacts, so the app never appears in any management surface — nothing can
+ * list, revisit, or delete what the agent shipped. This module records one
+ * {@link BuiltAppRecord} per successful app-deploy completion in the runtime
+ * cache (DB-backed, survives restarts) and exposes a read API for management
+ * consumers (`GET /api/orchestrator/built-apps`).
+ *
+ * Derivation is structural, matching the two deploy targets the spawn-time
+ * contract injects (see app-deploy-guidance):
+ *  - **custom** static host: a verified URL under the operator-configured
+ *    `<customBaseUrl>/apps/<slug>/` shape IS a built app — the URL shape is
+ *    definitive, no task-text inspection needed (loopback/LAN bases included:
+ *    the operator configured them, so they are the canonical app location).
+ *  - **eliza-cloud**: gated on the SAME app-build predicate that injected the
+ *    deploy contract (`isAppBuildTask` on the session's initial task), then
+ *    the first public verified URL that is not a code-host link. Monetized
+ *    cloud apps additionally self-register with the Cloud apps API per the
+ *    contract; this local record complements that with the orchestrator-side
+ *    view.
+ *
+ * @module services/built-apps-registry
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  type AppDeployConfig,
+  isAppBuildTask,
+  resolveAppDeployConfig,
+} from "./app-deploy-guidance.js";
+import type { SessionInfo } from "./types.js";
+
+export interface BuiltAppRecord {
+  /** Stable identity within a target: the app's path/host slug. */
+  slug: string;
+  /** Human-readable name derived from the slug. */
+  name: string;
+  /** The verified live URL reported to the user. */
+  url: string;
+  /** Which deploy target hosted the app. */
+  target: "eliza-cloud" | "custom";
+  /** The sub-agent session that produced this deploy. */
+  sessionId: string;
+  /** The task label the deploy ran under, when known. */
+  label?: string;
+  /** ISO timestamp of registration (redeploys refresh it). */
+  registeredAt: string;
+}
+
+export const BUILT_APPS_CACHE_KEY = "orchestrator:built-apps";
+/** Cap the registry so a long-lived agent can't grow the cache row unbounded. */
+export const MAX_BUILT_APPS = 200;
+
+/** Code-host / VCS links routinely appear alongside a deploy report ("PR
+ *  opened at …"); they are never the hosted app itself. */
+const CODE_HOST_RE =
+  /(^|\.)(github\.com|gist\.github\.com|raw\.githubusercontent\.com|gitlab\.com|bitbucket\.org)$/i;
+
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "::1" || host.startsWith("127.");
+}
+
+function slugToDisplayName(slug: string): string {
+  return slug
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
+ * Pure: derive the built-app identity from a completion's verified URLs and
+ * the configured deploy target. Returns null when the completion is not an
+ * app deploy (no matching URL shape / the task was not an app build).
+ */
+export function deriveBuiltApp(
+  verifiedUrls: readonly string[],
+  config: AppDeployConfig,
+  initialTask?: string,
+): Pick<BuiltAppRecord, "slug" | "name" | "url" | "target"> | null {
+  if (config.target === "custom" && config.customBaseUrl) {
+    const appsPrefix = `${config.customBaseUrl.replace(/\/+$/, "")}/apps/`;
+    for (const url of verifiedUrls) {
+      if (!url.startsWith(appsPrefix)) continue;
+      const slug = url.slice(appsPrefix.length).split(/[/?#]/, 1)[0]?.trim();
+      if (!slug) continue;
+      return {
+        slug,
+        name: slugToDisplayName(slug),
+        url,
+        target: "custom",
+      };
+    }
+    return null;
+  }
+  // eliza-cloud: the URL shape is not operator-known, so gate on the same
+  // predicate that injected the deploy contract at spawn. No initial task
+  // recorded (or not an app build) → not an app deploy.
+  if (!isAppBuildTask(initialTask)) return null;
+  for (const url of verifiedUrls) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
+    const host = parsed.hostname.toLowerCase();
+    // A loopback URL is a local build probe, not a hosted cloud app; a
+    // code-host URL is the change, not the deployment.
+    if (isLoopbackHost(host) || CODE_HOST_RE.test(host)) continue;
+    const slug = host.split(".", 1)[0] || host;
+    return {
+      slug,
+      name: slugToDisplayName(slug),
+      url,
+      target: "eliza-cloud",
+    };
+  }
+  return null;
+}
+
+type CacheRuntime = Pick<IAgentRuntime, "getCache" | "setCache">;
+
+function hasCache(runtime: unknown): runtime is CacheRuntime {
+  const r = runtime as Partial<CacheRuntime> | null | undefined;
+  return typeof r?.getCache === "function" && typeof r?.setCache === "function";
+}
+
+function asRecordList(value: unknown): BuiltAppRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (entry): entry is BuiltAppRecord =>
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as BuiltAppRecord).slug === "string" &&
+      typeof (entry as BuiltAppRecord).url === "string" &&
+      typeof (entry as BuiltAppRecord).target === "string",
+  );
+}
+
+/** Read the built-apps registry, newest first. Empty when never written. */
+export async function listBuiltApps(
+  runtime: unknown,
+): Promise<BuiltAppRecord[]> {
+  if (!hasCache(runtime)) return [];
+  return asRecordList(await runtime.getCache(BUILT_APPS_CACHE_KEY));
+}
+
+/**
+ * Insert (or refresh, keyed on target+slug) one record. Read-modify-write on
+ * the runtime cache — completions are handled serially per session in a
+ * single process, so no cross-process lock is needed here.
+ */
+export async function registerBuiltApp(
+  runtime: unknown,
+  record: BuiltAppRecord,
+): Promise<boolean> {
+  if (!hasCache(runtime)) return false;
+  const existing = await listBuiltApps(runtime);
+  const rest = existing.filter(
+    (entry) => !(entry.target === record.target && entry.slug === record.slug),
+  );
+  await runtime.setCache(
+    BUILT_APPS_CACHE_KEY,
+    [record, ...rest].slice(0, MAX_BUILT_APPS),
+  );
+  return true;
+}
+
+/**
+ * Task-completion hook: derive + persist the built app for a completion whose
+ * URLs verified live. Never throws — a registry failure must not break the
+ * completion delivery to the user. Returns the record when one was written.
+ */
+export async function registerBuiltAppsForCompletion(
+  runtime: unknown,
+  session: Pick<SessionInfo, "id" | "metadata">,
+  verifiedUrls: readonly string[],
+  log?: (level: "info" | "warn", message: string, ctx?: unknown) => void,
+): Promise<BuiltAppRecord | null> {
+  try {
+    const meta = session.metadata;
+    const initialTask =
+      typeof meta?.initialTask === "string" ? meta.initialTask : undefined;
+    const derived = deriveBuiltApp(
+      verifiedUrls,
+      resolveAppDeployConfig(),
+      initialTask,
+    );
+    if (!derived) return null;
+    const label = typeof meta?.label === "string" ? meta.label : undefined;
+    const record: BuiltAppRecord = {
+      ...derived,
+      sessionId: session.id,
+      ...(label ? { label } : {}),
+      registeredAt: new Date().toISOString(),
+    };
+    if (!(await registerBuiltApp(runtime, record))) {
+      log?.("warn", "built-app registry unavailable (no runtime cache)", {
+        sessionId: session.id,
+        slug: record.slug,
+      });
+      return null;
+    }
+    log?.("info", "registered built app", {
+      sessionId: session.id,
+      slug: record.slug,
+      target: record.target,
+      url: record.url,
+    });
+    return record;
+  } catch (err) {
+    log?.("warn", "built-app registration failed", {
+      sessionId: session.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -10,6 +10,7 @@ import type {
 } from "@elizaos/core";
 import { Service, ServiceType } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
+import { registerBuiltAppsForCompletion } from "./built-apps-registry.js";
 import {
   accountMetaFromSessionMetadata,
   type CodingAccountFailureKind,
@@ -1224,6 +1225,16 @@ export class SubAgentRouter extends Service {
     }
     if (event === "task_complete" && verifiedUrls.length > 0) {
       text = verifiedUrlCompletionFallback(text, verifiedUrls);
+      // A built app was fire-and-forget before this: the verified live URL
+      // survived only in narration/trajectory artifacts, so the app never
+      // appeared in any management list. Persist the durable registry record
+      // (never throws; a registry failure must not break delivery).
+      await registerBuiltAppsForCompletion(
+        this.runtime,
+        session,
+        verifiedUrls,
+        (level, message, ctx) => this.log(level, message, ctx),
+      );
     } else if (
       event === "task_complete" &&
       deliverable &&


### PR DESCRIPTION
## Relates to

Closes #12035 (orchestrator half; the UI consumer half is tracked there).

## Risks

Low. Additive only: new module + one awaited, never-throwing call inside the existing `task_complete` verified-URL branch, plus one new read-only GET route. A registry failure is logged and cannot break completion delivery.

## Background

Apps the agent builds from chat are fire-and-forget. The sub-agent router verifies the live URL at `task_complete` and reports it, but persists only narration/screenshot/trajectory artifacts — there is no `registerBuiltApp()` anywhere in the repo (verified on develop `37183468e5`), so a freshly built app never appears in any management list and nothing can revisit or delete it.

## What does this PR do?

- `services/built-apps-registry.ts`: durable registry of built apps in the runtime cache (`orchestrator:built-apps`, capped at 200, deduped on target+slug so redeploys refresh instead of duplicate). `deriveBuiltApp` is pure and structural, matching the two deploy targets the spawn-time contract injects (app-deploy-guidance): URL-shape match under `<customBaseUrl>/apps/<slug>/` for the custom static host; `isAppBuildTask` gate + first public non-code-host, non-loopback URL for eliza-cloud.
- `services/sub-agent-router.ts`: on `task_complete` with verified URLs, register the built app (slug, name, live URL, target, sessionId, label, timestamp). Never throws.
- `api/orchestrator-routes.ts`: `GET /api/orchestrator/built-apps` returns the registry (newest first) for management consumers; dispatched before the task-service availability gate since the registry does not depend on it.

## Documentation changes

Module-level docs in the new service; endpoint documented in the issue for the UI consumer.

## Testing

`src/__tests__/built-apps-registry.test.ts` (8 tests):
- pure derivation for both targets: slug/name from the apps-base URL shape, deep entry URLs, non-matching URLs; eliza-cloud app-build gate, code-host + loopback exclusion;
- registry round-trip: register, list, redeploy dedupe on target+slug, graceful no-cache degradation;
- the real router path: `SubAgentRouter.handleEvent("task_complete")` with a live URL served by a local HTTP server — verification probes it for real, and the registry record lands in the runtime cache with that URL, session id, and label.

Results on this branch (rebased on develop `b2f44a0f5e`):
- `bunx vitest run src/__tests__` → 34 passed, 2 skipped (pre-existing skips), 303 tests passed
- `bun run test:unit` → 120 files, 1321 tests passed
- `bun run typecheck` → clean
- `biome check` on touched files → clean

Evidence notes per PR_EVIDENCE.md: backend-only additive change — UI screenshots/video N/A (no UI in this PR; consumer half tracked in #12035). Live-LLM trajectory N/A - the change is post-model structural handling of an ACP `task_complete` event; the test drives the real router path with a real HTTP-verified URL rather than a mocked verification.
