### PR TITLE
fix(app): make Android evidence capture resilient to sdcard pulls

### DIFF
--- a/packages/app/scripts/capture-android-emu.mjs
+++ b/packages/app/scripts/capture-android-emu.mjs
@@ -26,26 +26,60 @@ const PLATFORM = "android-emu";
 const log = logFor(PLATFORM);
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function captureScreenshot(adb, serial, outPath) {
-  const remote = "/sdcard/eliza-evidence-capture.png";
+const REMOTE_DIRS = ["/sdcard", "/data/local/tmp"];
+
+function isNonEmptyFile(path) {
+  return existsSync(path) && statSync(path).size > 0;
+}
+
+function removeRemote(adb, serial, remote) {
   spawnSync(adb, ["-s", serial, "shell", "rm", "-f", remote], {
     stdio: "ignore",
   });
+}
+
+function pullRemote(adb, serial, remote, outPath) {
+  spawnSync(adb, ["-s", serial, "pull", remote, outPath], { stdio: "ignore" });
+  return isNonEmptyFile(outPath);
+}
+
+function captureScreenshotViaRemote(adb, serial, outPath, remote) {
+  removeRemote(adb, serial, remote);
   spawnSync(adb, ["-s", serial, "shell", "screencap", "-p", remote], {
     stdio: "ignore",
   });
-  spawnSync(adb, ["-s", serial, "pull", remote, outPath], { stdio: "ignore" });
-  spawnSync(adb, ["-s", serial, "shell", "rm", "-f", remote], {
-    stdio: "ignore",
-  });
-  return existsSync(outPath) ? outPath : null;
+  const pulled = pullRemote(adb, serial, remote, outPath);
+  removeRemote(adb, serial, remote);
+  return pulled;
 }
 
-async function recordVideo(adb, serial, outPath, durationSec) {
-  const remote = "/sdcard/eliza-evidence-capture.mp4";
-  spawnSync(adb, ["-s", serial, "shell", "rm", "-f", remote], {
-    stdio: "ignore",
+function captureScreenshotViaExecOut(adb, serial, outPath) {
+  const res = spawnSync(adb, ["-s", serial, "exec-out", "screencap", "-p"], {
+    maxBuffer: 32 * 1024 * 1024,
   });
+  if (res.status !== 0 || !res.stdout?.length) return false;
+  writeFileSync(outPath, res.stdout);
+  return isNonEmptyFile(outPath);
+}
+
+function captureScreenshot(adb, serial, outPath) {
+  for (const dir of REMOTE_DIRS) {
+    if (
+      captureScreenshotViaRemote(
+        adb,
+        serial,
+        outPath,
+        `${dir}/eliza-evidence-capture.png`,
+      )
+    ) {
+      return outPath;
+    }
+  }
+  return captureScreenshotViaExecOut(adb, serial, outPath) ? outPath : null;
+}
+
+async function recordVideoToRemote(adb, serial, outPath, durationSec, remote) {
+  removeRemote(adb, serial, remote);
   const recorder = spawn(
     adb,
     [
@@ -72,11 +106,26 @@ async function recordVideo(adb, serial, outPath, durationSec) {
     new Promise((resolve) => recorder.once("close", resolve)),
     delay(5_000),
   ]);
-  spawnSync(adb, ["-s", serial, "pull", remote, outPath], { stdio: "ignore" });
-  spawnSync(adb, ["-s", serial, "shell", "rm", "-f", remote], {
-    stdio: "ignore",
-  });
-  return existsSync(outPath) ? outPath : null;
+  const pulled = pullRemote(adb, serial, remote, outPath);
+  removeRemote(adb, serial, remote);
+  return pulled;
+}
+
+async function recordVideo(adb, serial, outPath, durationSec) {
+  for (const dir of REMOTE_DIRS) {
+    if (
+      await recordVideoToRemote(
+        adb,
+        serial,
+        outPath,
+        durationSec,
+        `${dir}/eliza-evidence-capture.mp4`,
+      )
+    ) {
+      return outPath;
+    }
+  }
+  return null;
 }
 
 function captureLogcat(adb, serial, outPath) {


### PR DESCRIPTION
## Summary
- Harden `packages/app/scripts/capture-android-emu.mjs` so Android evidence capture does not depend on `/sdcard` pulls succeeding.
- Try `/sdcard`, then `/data/local/tmp`, and use `adb exec-out screencap -p` as the screenshot fallback.
- Treat zero-byte local artifacts as failed captures so scripts do not report empty proof.

Refs #10936.

## Validation
- `bun run --cwd packages/app capture:android-emu -- --issue 10936 --slug capture-helper-fallback --duration 1` against attached Android device `27051JEGR10034` produced PNG, MP4, and logcat artifacts. I manually opened the PNG; it showed only a black/locked screen, so I removed the generated files and did not commit them as #10936 attachment evidence.
- `bunx @biomejs/biome check packages/app/scripts/capture-android-emu.mjs`
- `node --check packages/app/scripts/capture-android-emu.mjs`
- `git diff --check`

## Evidence Notes
- UI audit N/A: script-only evidence-capture plumbing, no rendered app UI changes.
- This improves Android capture automation for #10936 but does not close the remaining iOS capture requirement.