### PR TITLE
test(core): format promissory ack regression

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -1096,7 +1096,8 @@ describe("model-committed plan — promissory ack never reinterpreted as a finis
 			undefined,
 			{
 				actions: REAL_ACTIONS,
-				messageText: "can you figure out how to attach that here so i can see it",
+				messageText:
+					"can you figure out how to attach that here so i can see it",
 			},
 		);
 


### PR DESCRIPTION
## What

Follow-up to #12025. Applies Biome's wrapping to the new promissory-ack regression test that landed unformatted.

## Validation

- PASS: `bunx vitest run packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts packages/core/src/runtime/__tests__/message-handler.test.ts packages/core/src/runtime/__tests__/message-handler-output.test.ts`
- PASS: `bunx @biomejs/biome check packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts`
- PASS: `git diff --check`
