### PR TITLE
fix(core): three basic-capabilities bugs — history-dropping crash, full-UUID choice rejection, dangling topics fragment

### DIFF
--- a/packages/core/src/features/basic-capabilities/actions/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+} from "../../../types/index.ts";
+import { choiceAction } from "./choice.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const ROOM_ID = "00000000-0000-0000-0000-000000000002";
+const TASK_ID = "aabbccdd-1111-2222-3333-444455556666";
+
+function createRuntime(executed: { options: unknown | null }): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		getTasks: vi.fn(async () => [
+			{
+				id: TASK_ID,
+				name: "confirm-post",
+				metadata: { options: [{ name: "post" }, { name: "cancel" }] },
+			},
+		]),
+		getTaskWorker: vi.fn(() => ({
+			name: "confirm-post",
+			execute: vi.fn(async (_runtime: unknown, options: unknown) => {
+				executed.options = options;
+			}),
+		})),
+		deleteTask: vi.fn(async () => {}),
+	} as IAgentRuntime;
+}
+
+function createMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000010",
+		agentId: AGENT_ID,
+		entityId: "00000000-0000-0000-0000-000000000003",
+		roomId: ROOM_ID,
+		content: { text: "post it", source: "discord" },
+	} as Memory;
+}
+
+describe("CHOOSE_OPTION action", () => {
+	it("accepts the full task UUID as taskId (parameter contract: short or full ID)", async () => {
+		const executed = { options: null as unknown | null };
+		const runtime = createRuntime(executed);
+
+		const result = await choiceAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			{
+				parameters: { taskId: TASK_ID, selectedOption: "post" },
+			} as HandlerOptions,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values?.selectedOption).toBe("post");
+		expect(result?.values?.taskId).toBe(TASK_ID);
+		expect(executed.options).toEqual({ option: "post" });
+	});
+
+	it("still accepts the 8-char short task id", async () => {
+		const executed = { options: null as unknown | null };
+		const runtime = createRuntime(executed);
+
+		const result = await choiceAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			{
+				parameters: {
+					taskId: TASK_ID.substring(0, 8),
+					selectedOption: "post",
+				},
+			} as HandlerOptions,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values?.taskId).toBe(TASK_ID);
+		expect(executed.options).toEqual({ option: "post" });
+	});
+
+	it("rejects an unknown task id", async () => {
+		const executed = { options: null as unknown | null };
+		const runtime = createRuntime(executed);
+
+		const result = await choiceAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			{
+				parameters: {
+					taskId: "99999999-9999-9999-9999-999999999999",
+					selectedOption: "post",
+				},
+			} as HandlerOptions,
+		);
+
+		expect(result?.success).toBe(false);
+		expect(result?.values?.error).toBe("TASK_NOT_FOUND");
+		expect(executed.options).toBeNull();
+	});
+});

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -162,12 +162,15 @@ export const choiceAction: Action = {
 		const { taskId, selectedOption } = _readChoiceParameters(message, _options);
 
 		if (taskId && selectedOption) {
-			const taskMap = new Map(
-				formattedTasks.map((task) => [task.taskId, task]),
-			);
-			const taskInfo = taskMap.get(taskId) as
-				| (typeof formattedTasks)[0]
-				| undefined;
+			// The taskId parameter accepts the "Short or full ID of the pending
+			// choice task" — key the lookup by both so a model passing the full
+			// UUID (as stored on the task) is not rejected with TASK_NOT_FOUND.
+			const taskMap = new Map<string, (typeof formattedTasks)[0]>();
+			for (const task of formattedTasks) {
+				taskMap.set(task.taskId, task);
+				taskMap.set(task.fullId, task);
+			}
+			const taskInfo = taskMap.get(taskId);
 
 			if (!taskInfo) {
 				if (callback) {

--- a/packages/core/src/features/basic-capabilities/providers/character.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/character.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../../../types/index.ts";
+import { ChannelType } from "../../../types/index.ts";
+import { characterProvider } from "./character.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const ROOM_ID = "00000000-0000-0000-0000-000000000002";
+
+function createRuntime(topics: string[]): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		character: {
+			name: "Eliza",
+			bio: ["A helpful agent."],
+			topics,
+		},
+		getRoom: vi.fn(async () => ({ id: ROOM_ID, type: ChannelType.GROUP })),
+	} as IAgentRuntime;
+}
+
+function createMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000010",
+		agentId: AGENT_ID,
+		entityId: "00000000-0000-0000-0000-000000000003",
+		roomId: ROOM_ID,
+		content: { text: "hi", source: "discord" },
+	} as Memory;
+}
+
+const EMPTY_STATE = { values: {}, data: {}, text: "" } as State;
+
+describe("CHARACTER provider topics formatting", () => {
+	it("omits the 'is also interested in' sentence when the picked topic is the only topic", async () => {
+		const result = await characterProvider.get(
+			createRuntime(["chess"]),
+			createMessage(),
+			EMPTY_STATE,
+		);
+
+		// The single topic is consumed as the current topic...
+		expect(result.values?.topic).toBe("chess");
+		// ...so there are no OTHER topics: no dangling
+		// "Eliza is also interested in " fragment may be rendered.
+		expect(result.values?.topics).toBe("");
+		expect(result.text).not.toMatch(/is also interested in\s*(\n|$)/);
+	});
+
+	it("still renders the other-topics sentence when more topics exist", async () => {
+		const result = await characterProvider.get(
+			createRuntime(["chess", "go", "poker"]),
+			createMessage(),
+			EMPTY_STATE,
+		);
+
+		const topics = result.values?.topics as string;
+		expect(topics).toContain("Eliza is also interested in ");
+		// The sentence actually names at least one topic after the lead-in.
+		expect(topics).toMatch(/is also interested in \S/);
+		// The currently-picked topic is excluded from the "also" list.
+		expect(topics).not.toContain(result.values?.topic as string);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/character.ts
+++ b/packages/core/src/features/basic-capabilities/providers/character.ts
@@ -120,16 +120,23 @@ export const characterProvider: Provider = {
 		// Write a post that is {{Spartan is dirty}} about {{Spartan is currently}}
 		const topic = topicString || "";
 
-		// Format topics list
-		const topics =
+		// Format topics list. Sample the OTHER topics first — when the picked
+		// topicString is the only topic, the filtered list is empty and the
+		// sentence must be omitted entirely instead of rendering the dangling
+		// fragment "X is also interested in ".
+		const otherTopics =
 			character.topics && character.topics.length > 0
-				? `${agentName} is also interested in ${deterministicSample(
+				? deterministicSample(
 						resolveCharacterList(character.topics, agentName).filter(
 							(topic: string) => topic !== topicString,
 						),
 						5,
 						buildDeterministicSeed(characterSeed, "topics"),
 					)
+				: [];
+		const topics =
+			otherTopics.length > 0
+				? `${agentName} is also interested in ${otherTopics
 						.map((topic, index, array) => {
 							if (index === array.length - 2) {
 								return `${topic} and `;

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -368,6 +368,39 @@ describe("recentMessagesProvider", () => {
 		expect(result.text).not.toContain("💬 [codex]");
 	});
 
+	it("keeps history when the incoming message has no metadata and its sender entity is unresolvable", async () => {
+		// Memory.metadata is optional. A message from an entity that is not a
+		// current room participant AND whose entity row is unavailable used to
+		// throw on `metaData.entityName`, and the catch collapsed the whole
+		// provider to "No recent messages available" — dropping ALL history.
+		const memories = [
+			makeMemory("msg-1", USER_ID, "hello agent", "discord", 1000),
+			makeMemory("msg-2", AGENT_ID, "hi there", "discord", 2000),
+		];
+
+		const strangerMessage = makeMemory(
+			"current",
+			"00000000-0000-0000-0000-000000000009",
+			"what did we discuss?",
+			"discord",
+			3000,
+		);
+		expect(strangerMessage.metadata).toBeUndefined();
+
+		const result = await recentMessagesProvider.get(
+			makeRuntime(memories),
+			strangerMessage,
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect((result.data as { error?: string })?.error).toBeUndefined();
+		expect(result.data?.recentMessages).toHaveLength(2);
+		expect(result.text).toContain("User: hello agent");
+		expect(result.text).toContain("Agent: hi there");
+		expect(result.text).toContain("Unknown User: what did we discuss?");
+		expect(result.text).not.toBe("No recent messages available");
+	});
+
 	it("sorts memories by timestamp before applying the conversation window", async () => {
 		const memories = Array.from({ length: 12 }, (_, index) => {
 			const n = 12 - index;

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -547,12 +547,16 @@ export const recentMessagesProvider: Provider = {
 				}
 			}
 
-			const metaData = message.metadata as CustomMetadata;
+			// `Memory.metadata` is optional — a message with no metadata from a
+			// sender whose entity row is unavailable must not throw here, or the
+			// catch below silently drops the ENTIRE conversation history for the
+			// turn ("No recent messages available").
+			const metaData = message.metadata as CustomMetadata | undefined;
 			const foundEntity = entitiesForFormatting.find(
 				(entity: Entity) => entity.id === message.entityId,
 			);
 			const senderName =
-				foundEntity?.names?.[0] || metaData.entityName || "Unknown User";
+				foundEntity?.names?.[0] || metaData?.entityName || "Unknown User";
 			const receivedMessageContent = message.content.text;
 
 			const hasReceivedMessage = !!receivedMessageContent?.trim();


### PR DESCRIPTION
## What

Three probe-confirmed bugs in `@elizaos/core`'s basic-capabilities bundle (the actions/providers every agent runs), each fixed minimally with a mutation-checked vitest regression test.

### 1. RECENT_MESSAGES provider silently drops ALL conversation history
`providers/recentMessages.ts` read `metaData.entityName` off `message.metadata as CustomMetadata` without guarding — but `Memory.metadata` is optional. A message from a sender who is not a current room participant AND whose entity row is unavailable (left the room / row temporarily missing) with no metadata threw `TypeError: undefined is not an object (evaluating 'metaData.entityName')`; the provider's catch-all then returned `"No recent messages available"` with `recentMessages: []` — the planner lost the entire room history for that turn.

**Concrete failure input:** current message `{ entityId: <not-in-room>, content: {text}, metadata: undefined }` with 2 valid dialogue memories in the room → before: `text === "No recent messages available"`, `data.error === "undefined is not an object (evaluating 'metaData.entityName')"`; after: full formatted history + `Unknown User` sender fallback.

### 2. CHOOSE_OPTION rejects the full task UUID
`actions/choice.ts` declares its `taskId` parameter as **"Short or full ID of the pending choice task."** but built the lookup map only from 8-char short ids. A model passing the task's real UUID (the id present on the task rows) got `TASK_NOT_FOUND` and the task worker never ran.

**Concrete failure input:** pending task `id = aabbccdd-1111-2222-3333-444455556666`, handler options `{ taskId: "aabbccdd-1111-2222-3333-444455556666", selectedOption: "post" }` → before: `success:false, "Could not find task with ID: aabbccdd-…"`, worker not executed; after: `success:true`, worker executes `{ option: "post" }`. Short-id and unknown-id behavior unchanged (covered by tests).

### 3. CHARACTER provider renders a dangling "X is also interested in " fragment
`providers/character.ts` filtered the deterministically-picked `topicString` out of the topics list, then unconditionally emitted the `"${agentName} is also interested in ${…}"` sentence. With a single-topic character (or all remaining topics equal to the picked one) the list is empty and the prompt got the fragment `"Eliza is also interested in "` — injected into every turn's composed text.

**Concrete failure input:** `character.topics = ["chess"]` → before: `values.topics === "Eliza is also interested in "`; after: `values.topics === ""` and the sentence is omitted. Multi-topic rendering unchanged (covered by test).

## Evidence

| Item | Result |
| --- | --- |
| Unit tests | `bunx vitest run --no-cache` on the 3 suites: **3 files / 17 tests passed** |
| Mutation check #1 | recentMessages.ts reverted to develop → its new test **fails** (1 failed / 11 passed); restored → green |
| Mutation check #2 | choice.ts reverted to develop → full-UUID test **fails** (1 failed / 2 passed); restored → green |
| Mutation check #3 | character.ts reverted to develop → single-topic test **fails** (1 failed / 1 passed); restored → green |
| Probe-execution | each bug reproduced by executing the real provider/handler with the concrete inputs above BEFORE authoring the fix |
| Lint / typecheck | biome clean on all 6 files; `bun run --cwd packages/core typecheck` (tsgo) clean |
| Live-LLM trajectory | N/A — pure deterministic option-parsing/formatting/guard logic; no prompt-content or model-behavior change (choice fix widens an id lookup to match its already-declared parameter contract) |
| Screenshots / video | N/A — no UI surface touched |
| DB / domain artifacts | N/A — no schema or persisted-data change; behavior proven via probe outputs + mutation-checked unit tests |

Scope: only `packages/core/src/features/basic-capabilities` sources + tests; 6 files, minimal surgical diffs.

Dropped as not-real after probing (honest ceiling evidence): choice-provider string-option description lookup (dead code, no observable output change), actionState run-order slice (adapter-order dependence unconfirmed), link-extraction trailing-`)` stripping (documented URL-extraction trade-off), formatMessages newest-first ordering (outside scope; load-bearing for attachment budgeting).

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix was probe-executed against the real function (concrete input → wrong output) BEFORE authoring. Independently re-verified: 6-file merge-base diff, 17/17 green (--no-cache), and the history-drop mutation reproduced (revert → recentMessages test red; restore → 12 pass). Agent honestly DROPPED 4 candidates (dead-code choice-provider compare, out-of-scope formatMessages ordering, speculative actionState order, URL-punctuation trade-off) — no forced fixes. — [phone-ui]