### PR TITLE
fix(lifeops): implement no-reply timeout policy

### DIFF
--- a/.github/issue-evidence/11793-no-reply-policy.md
+++ b/.github/issue-evidence/11793-no-reply-policy.md
@@ -1,0 +1,44 @@
+# 11793 no-reply policy evidence
+
+Date: 2026-07-03
+
+## What changed
+
+- Completion timeouts now resolve a structural no-reply policy/state from
+  `ScheduledTask.metadata.noReplyPolicy` and `metadata.noReplyState`.
+- Defaults cover reminder, check-in, non-sensitive approval, and sensitive
+  approval silence semantics.
+- Sensitive approval silence expires with `terminalOutcome: "denied"` and does
+  not auto-execute an external output.
+- No-reply approval expiry is not a user skip, so `pipeline.onSkip` does not
+  fire for no-reply expiry.
+
+## Verification
+
+Passed:
+
+```bash
+bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
+bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/scheduler.fire-budget.test.ts src/lifeops/scheduled-task/scheduler.integration.test.ts
+bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+bunx biome check plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts plugins/plugin-personal-assistant/README.md
+git diff --check
+```
+
+Typecheck limitation:
+
+```bash
+bun run --cwd plugins/plugin-personal-assistant typecheck
+```
+
+This did not reach the no-reply change. It fails broadly in this worktree on
+workspace/package resolution and pre-existing package export/type errors, e.g.
+`Cannot find module '@elizaos/core'`, sibling plugin exports, and unrelated
+implicit-any/unknown errors across PA actions/routes.
+
+## N/A
+
+- UI screenshots/video: N/A - scheduler behavior only, no UI surface changed.
+- Real LLM trajectories: N/A - no prompt/model/action behavior changed; the
+  covered path is deterministic scheduler state transition logic.
+- Native/device capture: N/A - no native/mobile/desktop UI code changed.

--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -56,6 +56,48 @@ The frozen contract is defined in `src/lifeops/scheduled-task/types.ts`
 (the runner imports `ScheduledTask` from there). `src/lifeops/wave1-types.ts`
 is a slightly diverged copy consumed only by the `first-run` module.
 
+### No-reply semantics
+
+Completion timeouts are structural scheduler behavior, not prompt text. For
+scheduled items that wait on a user reply, personal-assistant resolves a
+persisted no-reply contract from `metadata.noReplyPolicy` plus
+`metadata.noReplyState` and applies it in the single scheduler timeout pass:
+
+```ts
+metadata: {
+  noReplyPolicy?: {
+    maxRetries: number;
+    retryCadenceMinutes: number[];
+    terminalStatus: "skipped" | "expired" | "failed";
+    terminalReason: string;
+    sensitive: boolean;
+    allowCrossChannel: boolean;
+    allowNonOwnerNotification: boolean;
+  };
+  noReplyState?: {
+    retryCount: number;
+    lastTimedOutAt?: string;
+    nextRetryAt?: string;
+    terminalReason?: string;
+    terminalOutcome?: "skipped" | "expired" | "failed" | "denied";
+  };
+}
+```
+
+Defaults are deliberately conservative:
+
+- reminders retry once after 60 minutes, then `skipped`;
+- check-ins retry once after 24 hours, then `expired`;
+- non-sensitive approvals retry after 30 minutes and 2 hours, then `expired`;
+- sensitive approvals retry once after 30 minutes, then expire with
+  `terminalOutcome: "denied"`;
+- cross-channel escalation and non-owner notification default to `false`.
+
+No no-reply path may auto-execute a sensitive output. Silence on money, data,
+or external-send approvals fails closed. No-reply expiry is not a user skip, so
+approval expiry does not fire `pipeline.onSkip`; authored skip pipelines remain
+reserved for explicit skip transitions.
+
 ## Runtime layout
 
 ```

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -717,7 +717,7 @@ describe("processDueScheduledTasks — production wiring", () => {
     expect(transitions).toContain("fired");
   });
 
-  it("times out an unanswered approval into skip and spawns the pipeline.onSkip followup", async () => {
+  it("times out an unanswered approval through no-reply expiry without spawning pipeline.onSkip", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;
 
@@ -729,8 +729,8 @@ describe("processDueScheduledTasks — production wiring", () => {
     // followup. (When `pipeline.onSkip` is set the approval-default rule does
     // NOT backfill `followupAfterMinutes`, so it must be provided.) On the
     // first tick the approval fires; once the timeout elapses a later tick
-    // runs the completion-timeout pass, which applies `skip` and propagates
-    // the onSkip child.
+    // runs the completion-timeout pass. No-reply expiry is not a user skip, so
+    // it must not propagate the onSkip child.
     const seed = await seedScheduledTask(runtime, {
       kind: "approval",
       promptInstructions: "Approve the wire transfer?",
@@ -758,6 +758,9 @@ describe("processDueScheduledTasks — production wiring", () => {
           },
         ],
       },
+      metadata: {
+        noReplyState: { retryCount: 2 },
+      },
     });
 
     const firstResult = await processDueScheduledTasks({
@@ -774,7 +777,7 @@ describe("processDueScheduledTasks — production wiring", () => {
     expect(afterFire?.state.status).toBe("fired");
 
     // Advance past `firedAt + followupAfterMinutes` (30m). The completion
-    // timeout pass now fires `skip`.
+    // timeout pass now expires the approval.
     const timeoutTick = new Date("2026-05-09T12:40:00.000Z");
     const timeoutResult = await processDueScheduledTasks({
       runtime,
@@ -786,11 +789,11 @@ describe("processDueScheduledTasks — production wiring", () => {
     const timedOut = timeoutResult.completionTimeouts.find(
       (t) => t.taskId === seed.taskId,
     );
-    expect(timedOut?.status).toBe("skipped");
-    expect(timedOut?.reason).toBe("completion_timeout_due");
+    expect(timedOut?.status).toBe("expired");
+    expect(timedOut?.reason).toBe("no_reply_approval_expired");
 
     const persisted = await repo.getScheduledTask(runtime.agentId, seed.taskId);
-    expect(persisted?.state.status).toBe("skipped");
+    expect(persisted?.state.status).toBe("expired");
 
     const transitions = (
       await repo.listScheduledTaskLog({
@@ -798,15 +801,14 @@ describe("processDueScheduledTasks — production wiring", () => {
         taskId: seed.taskId,
       })
     ).map((entry) => entry.transition);
-    expect(transitions).toContain("skipped");
+    expect(transitions).toContain("expired");
 
-    // The onSkip followup child is created and linked to the parent.
+    // Expiry is not skip, so the onSkip followup child is not created.
     const all = await repo.listScheduledTasks(runtime.agentId, {
       kind: "followup",
     });
     const child = all.find((t) => t.state.pipelineParentId === seed.taskId);
-    expect(child).toBeDefined();
-    expect(child?.kind).toBe("followup");
+    expect(child).toBeUndefined();
   });
 
   it("circadian_state_in gate falls through to allow and the task fires with a warn-once fallback", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Regression coverage for #11793: completion timeouts use structural
+ * no-reply policy/state instead of a single unconditional skip.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../test/helpers/runtime.ts";
+import { LifeOpsRepository } from "../repository.ts";
+import type { ScheduledTask } from "./index.ts";
+import { processDueScheduledTasks } from "./scheduler.ts";
+
+let runtimeResult: RealTestRuntimeResult | undefined;
+
+afterEach(async () => {
+  await runtimeResult?.cleanup?.();
+  runtimeResult = undefined;
+});
+
+interface Seed extends Omit<ScheduledTask, "taskId" | "state" | "createdBy"> {
+  taskId?: string;
+  createdBy?: string;
+  state?: ScheduledTask["state"];
+}
+
+async function seedScheduledTask(
+  runtime: RealTestRuntimeResult["runtime"],
+  seed: Seed,
+): Promise<ScheduledTask> {
+  const repo = new LifeOpsRepository(runtime);
+  const task: ScheduledTask = {
+    taskId: seed.taskId ?? `st_${Math.random().toString(36).slice(2, 10)}`,
+    kind: seed.kind,
+    promptInstructions: seed.promptInstructions,
+    trigger: seed.trigger,
+    priority: seed.priority,
+    respectsGlobalPause: seed.respectsGlobalPause,
+    source: seed.source,
+    createdBy: seed.createdBy ?? runtime.agentId,
+    ownerVisible: seed.ownerVisible,
+    state: seed.state ?? { status: "scheduled", followupCount: 0 },
+    ...(seed.completionCheck ? { completionCheck: seed.completionCheck } : {}),
+    ...(seed.escalation ? { escalation: seed.escalation } : {}),
+    ...(seed.output ? { output: seed.output } : {}),
+    ...(seed.pipeline ? { pipeline: seed.pipeline } : {}),
+    ...(seed.subject ? { subject: seed.subject } : {}),
+    ...(seed.idempotencyKey ? { idempotencyKey: seed.idempotencyKey } : {}),
+    ...(seed.metadata ? { metadata: seed.metadata } : {}),
+  };
+  await repo.upsertScheduledTask(runtime.agentId, task);
+  return task;
+}
+
+describe("processDueScheduledTasks — no-reply policy (#11793)", () => {
+  it("re-surfaces an unanswered reminder once before terminal skip", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    const reminder = await seedScheduledTask(runtime, {
+      taskId: "st_no_reply_reminder",
+      kind: "reminder",
+      promptInstructions: "Take medication.",
+      trigger: { kind: "once", atIso: "2026-05-09T11:00:00.000Z" },
+      priority: "high",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    });
+
+    const retryResult = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T11:31:00.000Z"),
+      limit: 5,
+    });
+
+    expect(retryResult.errors).toEqual([]);
+    expect(retryResult.completionTimeouts).toEqual([
+      {
+        taskId: reminder.taskId,
+        status: "scheduled",
+        reason: "no_reply_retry_1",
+        occurrenceAtIso: "2026-05-09T11:30:00.000Z",
+      },
+    ]);
+    const retried = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(retried?.trigger).toEqual({
+      kind: "once",
+      atIso: "2026-05-09T12:31:00.000Z",
+    });
+    expect(retried?.metadata?.noReplyPolicy).toMatchObject({
+      maxRetries: 1,
+      retryCadenceMinutes: [60],
+      terminalStatus: "skipped",
+      terminalReason: "no_reply_reminder_expired",
+      allowCrossChannel: false,
+      allowNonOwnerNotification: false,
+    });
+    expect(retried?.metadata?.noReplyState).toMatchObject({
+      retryCount: 1,
+      lastTimedOutAt: "2026-05-09T11:31:00.000Z",
+      nextRetryAt: "2026-05-09T12:31:00.000Z",
+    });
+
+    const refireResult = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T12:32:00.000Z"),
+      limit: 5,
+    });
+
+    expect(refireResult.errors).toEqual([]);
+    expect(refireResult.fires).toEqual([
+      {
+        taskId: reminder.taskId,
+        status: "fired",
+        reason: "once_due",
+        occurrenceAtIso: "2026-05-09T12:31:00.000Z",
+      },
+    ]);
+
+    const terminalResult = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T13:02:00.000Z"),
+      limit: 5,
+    });
+
+    expect(terminalResult.errors).toEqual([]);
+    expect(terminalResult.completionTimeouts).toEqual([
+      {
+        taskId: reminder.taskId,
+        status: "skipped",
+        reason: "no_reply_reminder_expired",
+        occurrenceAtIso: "2026-05-09T13:02:00.000Z",
+      },
+    ]);
+    const skipped = await repo.getScheduledTask(
+      runtime.agentId,
+      reminder.taskId,
+    );
+    expect(skipped?.state.status).toBe("skipped");
+    expect(skipped?.metadata?.noReplyState).toMatchObject({
+      retryCount: 1,
+      terminalReason: "no_reply_reminder_expired",
+      terminalOutcome: "skipped",
+    });
+  });
+
+  it("expires unanswered non-sensitive approvals instead of firing onSkip", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    const approval = await seedScheduledTask(runtime, {
+      taskId: "st_no_reply_approval",
+      kind: "approval",
+      promptInstructions: "Approve the low-risk plan?",
+      trigger: { kind: "once", atIso: "2026-05-09T11:00:00.000Z" },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      pipeline: {
+        onSkip: [
+          {
+            taskId: "st_on_skip_template",
+            kind: "followup",
+            promptInstructions:
+              "This should not be created by no-reply expiry.",
+            trigger: { kind: "manual" },
+            priority: "medium",
+            respectsGlobalPause: false,
+            source: "user_chat",
+            createdBy: runtime.agentId,
+            ownerVisible: true,
+            state: { status: "scheduled", followupCount: 0 },
+          },
+        ],
+      },
+      metadata: {
+        noReplyState: { retryCount: 2 },
+      },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    });
+
+    const result = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T11:31:00.000Z"),
+      limit: 5,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts).toEqual([
+      {
+        taskId: approval.taskId,
+        status: "expired",
+        reason: "no_reply_approval_expired",
+        occurrenceAtIso: "2026-05-09T11:30:00.000Z",
+      },
+    ]);
+    const expired = await repo.getScheduledTask(
+      runtime.agentId,
+      approval.taskId,
+    );
+    expect(expired?.state.status).toBe("expired");
+    expect(expired?.metadata?.noReplyState).toMatchObject({
+      retryCount: 2,
+      terminalReason: "no_reply_approval_expired",
+      terminalOutcome: "expired",
+    });
+    const followups = await repo.listScheduledTasks(runtime.agentId, {
+      kind: "followup",
+    });
+    expect(
+      followups.find((task) => task.state.pipelineParentId === approval.taskId),
+    ).toBeUndefined();
+  });
+
+  it("fails closed for sensitive approvals without cross-channel or non-owner defaults", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    const approval = await seedScheduledTask(runtime, {
+      taskId: "st_sensitive_no_reply_approval",
+      kind: "approval",
+      promptInstructions: "Approve sending the account export?",
+      trigger: { kind: "once", atIso: "2026-05-09T11:00:00.000Z" },
+      priority: "high",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      output: {
+        destination: "channel",
+        target: "external-email",
+        persistAs: "external_only",
+      },
+      metadata: {
+        privacyClass: "sensitive",
+        noReplyState: { retryCount: 1 },
+      },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    });
+
+    const result = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T11:31:00.000Z"),
+      limit: 5,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts).toEqual([
+      {
+        taskId: approval.taskId,
+        status: "expired",
+        reason: "no_reply_sensitive_denied",
+        occurrenceAtIso: "2026-05-09T11:30:00.000Z",
+      },
+    ]);
+    const denied = await repo.getScheduledTask(
+      runtime.agentId,
+      approval.taskId,
+    );
+    expect(denied?.state.status).toBe("expired");
+    expect(denied?.output).toEqual({
+      destination: "channel",
+      target: "external-email",
+      persistAs: "external_only",
+    });
+    expect(denied?.metadata?.noReplyPolicy).toMatchObject({
+      sensitive: true,
+      allowCrossChannel: false,
+      allowNonOwnerNotification: false,
+      terminalStatus: "expired",
+      terminalReason: "no_reply_sensitive_denied",
+    });
+    expect(denied?.metadata?.noReplyState).toMatchObject({
+      retryCount: 1,
+      terminalReason: "no_reply_sensitive_denied",
+      terminalOutcome: "denied",
+    });
+  });
+
+  it("keeps legacy timeout skip behavior for custom tasks without a no-reply policy", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const repo = new LifeOpsRepository(runtime);
+
+    const task = await seedScheduledTask(runtime, {
+      taskId: "st_custom_completion_timeout",
+      kind: "custom",
+      promptInstructions: "Custom task with legacy timeout semantics.",
+      trigger: { kind: "once", atIso: "2026-05-09T11:00:00.000Z" },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "plugin",
+      ownerVisible: true,
+      completionCheck: { kind: "user_acknowledged", followupAfterMinutes: 30 },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-09T11:00:00.000Z",
+      },
+    });
+
+    const result = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: new Date("2026-05-09T11:31:00.000Z"),
+      limit: 5,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.completionTimeouts).toEqual([
+      {
+        taskId: task.taskId,
+        status: "skipped",
+        reason: "completion_timeout_due",
+        occurrenceAtIso: "2026-05-09T11:30:00.000Z",
+      },
+    ]);
+    const skipped = await repo.getScheduledTask(runtime.agentId, task.taskId);
+    expect(skipped?.state.status).toBe("skipped");
+    expect(skipped?.metadata?.noReplyPolicy).toBeUndefined();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -26,6 +26,36 @@ import {
 import { LifeOpsRepository } from "../repository.js";
 import { getScheduledTaskRunner } from "./service.js";
 
+type NoReplyTerminalStatus = "skipped" | "expired" | "failed";
+
+interface NoReplyPolicy {
+  maxRetries: number;
+  retryCadenceMinutes: number[];
+  terminalStatus: NoReplyTerminalStatus;
+  terminalReason: string;
+  sensitive: boolean;
+  allowCrossChannel: boolean;
+  allowNonOwnerNotification: boolean;
+}
+
+interface StoredNoReplyPolicy {
+  maxRetries?: unknown;
+  retryCadenceMinutes?: unknown;
+  terminalStatus?: unknown;
+  terminalReason?: unknown;
+  sensitive?: unknown;
+  allowCrossChannel?: unknown;
+  allowNonOwnerNotification?: unknown;
+}
+
+interface NoReplyState {
+  retryCount: number;
+  lastTimedOutAt?: string;
+  nextRetryAt?: string;
+  terminalReason?: string;
+  terminalOutcome?: string;
+}
+
 export interface ProcessDueScheduledTasksRequest {
   runtime: IAgentRuntime;
   agentId: string;
@@ -108,6 +138,142 @@ function completionResult(task: ScheduledTask): ScheduledTaskCompletionResult {
     status: task.state.status,
     reason: task.state.lastDecisionLog ?? "completed",
     completionCheckKind: task.completionCheck?.kind ?? "unknown",
+  };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function readPositiveIntegerArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter(
+    (entry): entry is number =>
+      typeof entry === "number" && Number.isInteger(entry) && entry > 0,
+  );
+  return out.length > 0 ? out : undefined;
+}
+
+function readNoReplyState(task: ScheduledTask): NoReplyState {
+  const raw = readRecord(task.metadata?.noReplyState);
+  return {
+    retryCount: readPositiveInteger(raw?.retryCount) ?? 0,
+    lastTimedOutAt:
+      typeof raw?.lastTimedOutAt === "string" ? raw.lastTimedOutAt : undefined,
+    nextRetryAt:
+      typeof raw?.nextRetryAt === "string" ? raw.nextRetryAt : undefined,
+    terminalReason:
+      typeof raw?.terminalReason === "string" ? raw.terminalReason : undefined,
+    terminalOutcome:
+      typeof raw?.terminalOutcome === "string"
+        ? raw.terminalOutcome
+        : undefined,
+  };
+}
+
+function defaultNoReplyPolicyFor(task: ScheduledTask): NoReplyPolicy | null {
+  switch (task.kind) {
+    case "reminder":
+      return {
+        maxRetries: 1,
+        retryCadenceMinutes: [60],
+        terminalStatus: "skipped",
+        terminalReason: "no_reply_reminder_expired",
+        sensitive: false,
+        allowCrossChannel: false,
+        allowNonOwnerNotification: false,
+      };
+    case "checkin":
+      return {
+        maxRetries: 1,
+        retryCadenceMinutes: [24 * 60],
+        terminalStatus: "expired",
+        terminalReason: "no_reply_checkin_expired",
+        sensitive: false,
+        allowCrossChannel: false,
+        allowNonOwnerNotification: false,
+      };
+    case "approval": {
+      const metadata = task.metadata ?? {};
+      const sensitive =
+        metadata.sensitive === true ||
+        metadata.privacyClass === "sensitive" ||
+        metadata.privacyClass === "restricted" ||
+        metadata.requiresApproval === true;
+      return sensitive
+        ? {
+            maxRetries: 1,
+            retryCadenceMinutes: [30],
+            terminalStatus: "expired",
+            terminalReason: "no_reply_sensitive_denied",
+            sensitive: true,
+            allowCrossChannel: false,
+            allowNonOwnerNotification: false,
+          }
+        : {
+            maxRetries: 2,
+            retryCadenceMinutes: [30, 120],
+            terminalStatus: "expired",
+            terminalReason: "no_reply_approval_expired",
+            sensitive: false,
+            allowCrossChannel: false,
+            allowNonOwnerNotification: false,
+          };
+    }
+    default:
+      return null;
+  }
+}
+
+function resolveNoReplyPolicy(task: ScheduledTask): NoReplyPolicy | null {
+  const base = defaultNoReplyPolicyFor(task);
+  const raw = readRecord(
+    task.metadata?.noReplyPolicy,
+  ) as StoredNoReplyPolicy | null;
+  if (!base && !raw) return null;
+  const fallback = base ?? {
+    maxRetries: 0,
+    retryCadenceMinutes: [],
+    terminalStatus: "skipped" as const,
+    terminalReason: "no_reply_timeout",
+    sensitive: false,
+    allowCrossChannel: false,
+    allowNonOwnerNotification: false,
+  };
+  const terminalStatus =
+    raw?.terminalStatus === "skipped" ||
+    raw?.terminalStatus === "expired" ||
+    raw?.terminalStatus === "failed"
+      ? raw.terminalStatus
+      : fallback.terminalStatus;
+  return {
+    maxRetries: readPositiveInteger(raw?.maxRetries) ?? fallback.maxRetries,
+    retryCadenceMinutes:
+      readPositiveIntegerArray(raw?.retryCadenceMinutes) ??
+      fallback.retryCadenceMinutes,
+    terminalStatus,
+    terminalReason:
+      typeof raw?.terminalReason === "string" && raw.terminalReason.length > 0
+        ? raw.terminalReason
+        : fallback.terminalReason,
+    sensitive:
+      typeof raw?.sensitive === "boolean" ? raw.sensitive : fallback.sensitive,
+    allowCrossChannel:
+      typeof raw?.allowCrossChannel === "boolean"
+        ? raw.allowCrossChannel
+        : fallback.allowCrossChannel,
+    allowNonOwnerNotification:
+      typeof raw?.allowNonOwnerNotification === "boolean"
+        ? raw.allowNonOwnerNotification
+        : fallback.allowNonOwnerNotification,
   };
 }
 
@@ -251,16 +417,21 @@ export async function processDueScheduledTasks(
     const timeout = isCompletionTimeoutDue(task, request.now);
     if (timeout.due) {
       try {
-        const skipped = await runner.apply(task.taskId, "skip", {
+        const timedOut = await handleCompletionTimeout({
+          repo,
+          runner,
+          agentId: request.agentId,
+          task,
+          now: request.now,
           reason: timeout.reason,
         });
         result.completionTimeouts.push({
-          taskId: skipped.taskId,
-          status: skipped.state.status,
-          reason: timeout.reason,
+          taskId: timedOut.task.taskId,
+          status: timedOut.task.state.status,
+          reason: timedOut.reason,
           occurrenceAtIso: timeout.occurrenceAtIso,
         });
-        timeoutTaskIds.add(skipped.taskId);
+        timeoutTaskIds.add(timedOut.task.taskId);
       } catch (error) {
         const message = errorMessage(error);
         logger.warn(
@@ -306,6 +477,104 @@ export async function processDueScheduledTasks(
   }
 
   return result;
+}
+
+async function handleCompletionTimeout(args: {
+  repo: LifeOpsRepository;
+  runner: ReturnType<typeof getScheduledTaskRunner>;
+  agentId: string;
+  task: ScheduledTask;
+  now: Date;
+  reason: string;
+}): Promise<{ task: ScheduledTask; reason: string }> {
+  const policy = resolveNoReplyPolicy(args.task);
+  if (!policy) {
+    const skipped = await args.runner.apply(args.task.taskId, "skip", {
+      reason: args.reason,
+    });
+    return { task: skipped, reason: args.reason };
+  }
+
+  const state = readNoReplyState(args.task);
+  if (state.retryCount < policy.maxRetries) {
+    const cadenceIndex = Math.min(
+      state.retryCount,
+      Math.max(0, policy.retryCadenceMinutes.length - 1),
+    );
+    const retryMinutes = policy.retryCadenceMinutes[cadenceIndex] ?? 60;
+    const nextRetryAt = new Date(
+      args.now.getTime() + retryMinutes * 60_000,
+    ).toISOString();
+    args.task.metadata = {
+      ...(args.task.metadata ?? {}),
+      noReplyPolicy: {
+        ...(readRecord(args.task.metadata?.noReplyPolicy) ?? {}),
+        maxRetries: policy.maxRetries,
+        retryCadenceMinutes: policy.retryCadenceMinutes,
+        terminalStatus: policy.terminalStatus,
+        terminalReason: policy.terminalReason,
+        sensitive: policy.sensitive,
+        allowCrossChannel: policy.allowCrossChannel,
+        allowNonOwnerNotification: policy.allowNonOwnerNotification,
+      },
+      noReplyState: {
+        retryCount: state.retryCount + 1,
+        lastTimedOutAt: args.now.toISOString(),
+        nextRetryAt,
+      },
+    };
+    await args.repo.upsertScheduledTask(args.agentId, args.task);
+    const snoozed = await args.runner.apply(args.task.taskId, "snooze", {
+      untilIso: nextRetryAt,
+    });
+    snoozed.trigger = { kind: "once", atIso: nextRetryAt };
+    delete snoozed.state.firedAt;
+    snoozed.state.lastDecisionLog = `no_reply_retry_${state.retryCount + 1}: ${args.reason}`;
+    await args.repo.upsertScheduledTask(args.agentId, snoozed);
+    return {
+      task: snoozed,
+      reason: `no_reply_retry_${state.retryCount + 1}`,
+    };
+  }
+
+  args.task.metadata = {
+    ...(args.task.metadata ?? {}),
+    noReplyPolicy: {
+      ...(readRecord(args.task.metadata?.noReplyPolicy) ?? {}),
+      maxRetries: policy.maxRetries,
+      retryCadenceMinutes: policy.retryCadenceMinutes,
+      terminalStatus: policy.terminalStatus,
+      terminalReason: policy.terminalReason,
+      sensitive: policy.sensitive,
+      allowCrossChannel: policy.allowCrossChannel,
+      allowNonOwnerNotification: policy.allowNonOwnerNotification,
+    },
+    noReplyState: {
+      ...state,
+      lastTimedOutAt: args.now.toISOString(),
+      terminalReason: policy.terminalReason,
+      terminalOutcome: policy.sensitive ? "denied" : policy.terminalStatus,
+    },
+  };
+  await args.repo.upsertScheduledTask(args.agentId, args.task);
+
+  if (policy.terminalStatus === "skipped") {
+    const skipped = await args.runner.apply(args.task.taskId, "skip", {
+      reason: policy.terminalReason,
+    });
+    return { task: skipped, reason: policy.terminalReason };
+  }
+  const settled = await args.runner.pipeline(
+    args.task.taskId,
+    policy.terminalStatus,
+  );
+  const terminal =
+    (await args.repo.getScheduledTask(args.agentId, args.task.taskId)) ??
+    settled[0] ??
+    args.task;
+  terminal.state.lastDecisionLog = policy.terminalReason;
+  await args.repo.upsertScheduledTask(args.agentId, terminal);
+  return { task: terminal, reason: policy.terminalReason };
 }
 
 export async function processScheduledTaskInboundMessage(

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -347,6 +347,26 @@ export default defineConfig({
           "index.ts",
         ),
       },
+      {
+        find: /^@elizaos\/plugin-calendar\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-calendar",
+          "src",
+          "$1.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/plugin-calendar$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-calendar",
+          "src",
+          "index.ts",
+        ),
+      },
       // Lifeops decomposition: plugin-inbox / plugin-blocker are carved deps that
       // are NOT in build:core, so their unbuilt dist can't satisfy the subpath +
       // barrel imports plugin-personal-assistant pulls from them (vitest has no


### PR DESCRIPTION
## Summary

Implements the conservative no-reply timeout policy proposed in #11793 for LifeOps scheduled items.

- Resolves no-reply behavior from structural `ScheduledTask.metadata.noReplyPolicy` and `metadata.noReplyState` in the existing PA scheduler timeout pass.
- Adds default retry/terminal semantics for reminders, check-ins, non-sensitive approvals, and sensitive approvals.
- Keeps custom tasks without no-reply policy on the legacy completion-timeout skip behavior.
- Makes approval no-reply expiry distinct from user skip, so `pipeline.onSkip` does not fire on approval silence.
- Documents the persisted metadata contract and adds issue evidence at `.github/issue-evidence/11793-no-reply-policy.md`.

Closes #11793. Advances #10723.

## Validation

Passed:

```bash
bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts
bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/scheduler.fire-budget.test.ts src/lifeops/scheduled-task/scheduler.integration.test.ts
bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
bunx biome check plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.no-reply-policy.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts plugins/plugin-personal-assistant/README.md
git diff --check
```

Typecheck limitation:

```bash
bun run --cwd plugins/plugin-personal-assistant typecheck
```

This failed before reaching the no-reply change due to broad workspace/package resolution and pre-existing package export/type errors in this worktree, including `Cannot find module '@elizaos/core'`, sibling plugin export resolution, and unrelated implicit-any/unknown errors across PA actions/routes.

## Evidence

- `.github/issue-evidence/11793-no-reply-policy.md`

N/A: UI screenshots/video, native capture, and real-LLM trajectories are not applicable because this is deterministic scheduler state-transition logic with no UI, prompt, model, or connector behavior change.
