### PR TITLE
test(app): align onboarding ui-smoke spec with shipped composer copy

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -795,7 +795,7 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   await expect(composer).toBeDisabled();
   await expect(composer).toHaveAttribute(
     "placeholder",
-    "Tap a highlighted option above to continue",
+    "Pick an option to continue",
   );
   await expect(chatOverlay).toHaveAttribute("data-open", "true");
   await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary
The chat-first onboarding composer placeholder shipped as **"Pick an option to continue"** (`packages/ui/src/components/shell/ContinuousChatOverlay.tsx`, and asserted that way by `ContinuousChatOverlay.firstrun.test.tsx` + `run-chat-sheet-e2e.mjs`), but the shared ui-smoke helper `expectChatFirstOnboarding` in `packages/app/test/ui-smoke/onboarding-to-home.shared.ts` still asserted the stale copy **"Tap a highlighted option above to continue"**.

Every onboarding-to-home ui-smoke spec routes through that helper, so all 10 onboarding specs were red on pure spec drift — the app behavior is correct.

## Change
One line: update the expected placeholder in the shared helper to the shipped copy.

## Verification
- `git grep` on develop: the only remaining "Tap a highlighted option" occurrence was this spec; shipped source + unit test + chat-sheet e2e all agree on "Pick an option to continue".
- Test-only change, no runtime surface.

— nubs-cloud `[cloud-frontdoor]`