### PR TITLE
fix(agent): trigger worker returns its re-arm interval so cron cadence doesn't drift (#12030 item 1)

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -267,6 +267,30 @@ describe("executeTriggerTask", () => {
     expect(typeof persisted?.nextRunAtMs).toBe("number");
   });
 
+  it("surfaces the re-armed updateInterval in the result so the worker hands it back as nextInterval (#12030)", async () => {
+    // A cron trigger re-arms with a per-fire interval (ms until the next fire),
+    // which varies. executeTriggerTask persists it — and must ALSO return it, so
+    // the task worker can pass it to the scheduler as `nextInterval`. Without
+    // this the worker returned undefined and the scheduler's success path
+    // clobbered the cadence with a frozen `baseInterval`, drifting to wrong days.
+    const task = makeTriggerTask({
+      triggerType: "cron",
+      cronExpression: "0 9 * * 1-5",
+    });
+
+    const result = await executeTriggerTask(handle.runtime, task, {
+      source: "scheduler",
+    });
+
+    expect(result.taskDeleted).toBe(false);
+    const persistedInterval = (
+      handle.updatedTasks[0]?.patch.metadata as { updateInterval?: number }
+    )?.updateInterval;
+    expect(typeof persistedInterval).toBe("number");
+    // The result carries the SAME interval that was persisted (not undefined).
+    expect(result.updateInterval).toBe(persistedInterval);
+  });
+
   it("dispatches an event trigger when the event-source eventKind matches", async () => {
     const task = makeTriggerTask({
       triggerType: "event",

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -45,6 +45,11 @@ export interface TriggerExecutionResult {
   // Present when a workflow-kind trigger dispatches to WORKFLOW_DISPATCH and
   // the service returns an execution id.
   executionId?: string;
+  // The re-arm interval this fire persisted (ms until the next scheduled fire).
+  // Trigger cadence VARIES per fire (e.g. a weekday cron's Fri→Mon gap), so the
+  // task worker must hand this back to the scheduler as `nextInterval` — else
+  // the success path falls back to a frozen `baseInterval` and drifts.
+  updateInterval?: number;
 }
 
 interface NotificationEmitter {
@@ -476,6 +481,10 @@ export async function executeTriggerTask(
     taskDeleted: false,
     trigger: triggerSummary,
     executionId: workflowExecutionId,
+    updateInterval:
+      typeof metadataToPersist.updateInterval === "number"
+        ? metadataToPersist.updateInterval
+        : undefined,
   };
 }
 
@@ -486,14 +495,18 @@ export function registerTriggerTaskWorker(runtime: IAgentRuntime): void {
     name: TRIGGER_TASK_NAME,
     shouldRun: async () => true,
     execute: async (rt, options, task) => {
-      // Return the full result so callers (tests, dashboards) can inspect
-      // trigger-specific fields like taskDeleted and runRecord.
-      // TaskWorker.execute is typed as returning only scheduling metadata; trigger
-      // workers return TriggerExecutionResult for tests and dashboards.
-      await executeTriggerTask(rt, task, {
+      const result = await executeTriggerTask(rt, task, {
         source: options.source === "manual" ? "manual" : "scheduler",
         force: options.force === true,
       });
+      // Hand the per-fire re-arm interval back to the task service as scheduling
+      // metadata. Without it, the service's success path falls through to a
+      // frozen `baseInterval` (seeded on the first transient failure), so a
+      // varying-cadence trigger (e.g. weekday cron) permanently drifts — firing
+      // on the wrong days. Deleted tasks don't reschedule, so return nothing.
+      if (!result.taskDeleted && typeof result.updateInterval === "number") {
+        return { nextInterval: result.updateInterval };
+      }
       return undefined;
     },
   });


### PR DESCRIPTION
Closes item 1 of #12030 (Fable-5 hunt, confirmed MED). `[cloud-money]` (cross-lane, cc `[core-brain]`).

**Bug:** trigger tasks re-arm with a per-fire interval that varies (weekday cron = 72h Fri→Mon). `executeTriggerTask` persists it but the worker's `execute()` returned `undefined`, so the task service fell through to a frozen `baseInterval` (seeded on the first transient failure) → a weekday cron fires Sat+Sun permanently after one throw.

**Fix:** surface `updateInterval` in the result + return `{ nextInterval }` from the worker (task.ts already prefers it over baseInterval). Returned value == already-persisted value, so consistent + low-risk.

**Proof:** new test — 18/18 green; **red without the fix** (`result.updateInterval` was undefined). typecheck + biome clean. Not self-merging cross-lane.