### PR TITLE
fix(core): propagate SHELL→TERMINAL_SHELL rename into direct-shell allowlists (follow-up to #12021)

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -518,6 +518,40 @@ describe("live routing regressions", () => {
 		).toEqual(["WEB_SEARCH"]);
 	});
 
+	it("fast-paths a direct shell ask to TERMINAL_SHELL in a lean-chat runtime (follow-up to #12021)", () => {
+		// PR #12021 renamed the terminal action SHELL -> TERMINAL_SHELL. In a
+		// lean-chat deployment (no plugin-coding-tools) TERMINAL_SHELL is the only
+		// shell action, so the SHELL_DIRECT_ACTIONS / WEAK_DIRECT_REPLY_OVERRIDE
+		// allowlists must recognise it — otherwise "run df -h on this VPS" silently
+		// falls through to the general planner instead of the direct shell path.
+		const leanChatActions: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{
+				name: "TERMINAL_SHELL",
+				similes: ["RUN_IN_TERMINAL", "EXECUTE_COMMAND", "TERMINAL", "RUN_SHELL"],
+			},
+			{ name: "REPLY", similes: ["RESPOND"] },
+		];
+		const shellText = "run df -h on this VPS";
+
+		// Inference resolves the renamed terminal action (by canonical name — no
+		// coding-tools SHELL present to win on priority).
+		const directCandidateActions = inferDirectCurrentRequestCandidateActions(
+			leanChatActions,
+			shellText,
+		);
+		expect(directCandidateActions).toEqual(["TERMINAL_SHELL"]);
+
+		// And the preference gate promotes it: without TERMINAL_SHELL in the
+		// allowlists this returned false and the turn fell through to planning.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["REPLY", "TERMINAL_SHELL"],
+				currentMessageText: shellText,
+				directCandidateActions,
+			}),
+		).toBe(true);
+	});
+
 	it("promotes explicit reply to direct shell/search action aliases", () => {
 		expect(
 			shouldPromoteExplicitReplyToOwnedAction(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4352,6 +4352,7 @@ const WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS = new Set(
 		"TASKS",
 		"TASKS_SPAWN_AGENT",
 		"TERMINAL",
+		"TERMINAL_SHELL",
 		"WEB_FETCH",
 		"WEB_SEARCH",
 	].map(normalizeActionIdentifier),
@@ -4360,6 +4361,7 @@ const WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS = new Set(
 const SHELL_DIRECT_ACTIONS = new Set(
 	[
 		"SHELL",
+		"TERMINAL_SHELL",
 		"RUN_IN_TERMINAL",
 		"RUN_COMMAND",
 		"EXECUTE_COMMAND",
@@ -4451,6 +4453,7 @@ function inferAckIntentCandidateActions(
 	if (looksLikeLocalShellRequest(actionText)) {
 		const shellAction = findAvailableActionName(actions, [
 			"SHELL",
+			"TERMINAL_SHELL",
 			"RUN_IN_TERMINAL",
 			"RUN_COMMAND",
 			"EXECUTE_COMMAND",

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -174,6 +174,7 @@ export function inferDirectCurrentRequestCandidateActions(
 	if (looksLikeLocalShellRequest(messageText)) {
 		const shellAction = findAvailableActionName(actions, [
 			"SHELL",
+			"TERMINAL_SHELL",
 			"RUN_IN_TERMINAL",
 			"RUN_COMMAND",
 			"EXECUTE_COMMAND",


### PR DESCRIPTION
## The regression

PR #12021 renamed the terminal action `SHELL` → `TERMINAL_SHELL` (`packages/agent/src/actions/terminal.ts`) but did not propagate the new name into two hardcoded shell-name allowlists in `packages/core/src/services/message.ts`:

- `WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS`
- `SHELL_DIRECT_ACTIONS`

Both sets are built by mapping their raw entries through `normalizeActionIdentifier` (`.toUpperCase().replace(/_/g, "")`), so `"TERMINAL_SHELL"` normalizes to `"TERMINALSHELL"`. Neither set listed it, so the renamed action was never a member.

## Lean-chat repro

In a lean-chat deployment (`ELIZA_PLUGIN_SET=lean-chat`, no `plugin-coding-tools`), `TERMINAL_SHELL` is the only shell action. For a message like `run `df -h` on this VPS`:

- `inferDirectCurrentRequestCandidateActions` still resolves `TERMINAL_SHELL` (via its `RUN_IN_TERMINAL` simile), so `directCandidateActions = ["TERMINAL_SHELL"]`.
- but `shouldPreferDirectCurrentCandidateActions` then does `SHELL_DIRECT_ACTIONS.has("TERMINALSHELL")` → `false` (and the `candidateActions.every(...)` weak-override check also fails), so the turn is **not** promoted to the direct shell path and silently falls through to the general planner.

## The fix

- Add `"TERMINAL_SHELL"` to `WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS` and `SHELL_DIRECT_ACTIONS`.
- Also add it to the two `findAvailableActionName` shell-name lookup lists (in `message.ts` `inferAckIntentCandidateActions` and `message/direct-action-heuristics.ts`). These already resolved via simile; adding the canonical name is defensive and placed after `"SHELL"` so mixed deployments (coding-tools `SHELL` present) keep their existing priority.
- Other candidates checked and left alone: `prompt-compaction.ts` already lists both `SHELL` and `TERMINAL_SHELL`; `planner-loop.ts` `name === "SHELL"` is the coding-tools trajectory summary (unrelated); the many `"SHELL"` env-var/$SHELL references are unrelated.

## Test

Added a regression test in `message-routing-live-regression.test.ts` that drives the real seam with a lean-chat fixture (only `TERMINAL_SHELL` + `REPLY`): it asserts inference resolves `["TERMINAL_SHELL"]` **and** `shouldPreferDirectCurrentCandidateActions` returns `true`. Verified it **fails** pre-fix (returned `false`) and passes after.

## Verification

- `bun run --cwd packages/core typecheck` → clean
- `message-routing-live-regression.test.ts` → 41 passed; `direct-action-heuristics.test.ts` → 5 passed