### PR TITLE
fix(app-core): coding-account bridge honors config.accountStrategies

### DIFF
--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -803,7 +803,13 @@ function routeTargetsProvider(
   return providerId === "openai-codex" && route.backend === "openai";
 }
 
-function selectionForProvider(providerId: PoolProviderId): {
+/**
+ * Live read of the configured per-provider selection (the app's
+ * `config.accountStrategies` picker plus any llmText service-routing pin).
+ * Every account-selecting bridge resolves through this so the picker steers
+ * all of them — including the coding-agent bridge.
+ */
+export function selectionForProvider(providerId: PoolProviderId): {
   strategy?: Strategy;
   accountIds?: string[];
 } {
@@ -820,15 +826,6 @@ function selectionForProvider(providerId: PoolProviderId): {
       normalizeStrategy(defaultSelectionConfig.accountStrategies?.[providerId]),
     accountIds: routeSelection.accountIds,
   };
-}
-
-export function __getDefaultAccountPoolSelectionForTests(
-  providerId: PoolProviderId,
-): {
-  strategy?: Strategy;
-  accountIds?: string[];
-} {
-  return selectionForProvider(providerId);
 }
 
 export function configureDefaultAccountPoolSelection(

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -6,6 +6,7 @@ import type { AccountCredentialProvider } from "@elizaos/agent/auth/types";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __resetDefaultAccountPoolForTests,
+  configureDefaultAccountPoolSelection,
   getDefaultAccountPool,
 } from "./account-pool.js";
 import { readTodayCounters } from "./account-usage.js";
@@ -19,6 +20,7 @@ let home: string;
 let prevHome: string | undefined;
 let prevStateDir: string | undefined;
 let prevCodexModel: string | undefined;
+let prevCodingStrategy: string | undefined;
 
 function writeAccount(
   providerId: AccountCredentialProvider,
@@ -58,15 +60,29 @@ async function setUsage(
   });
 }
 
+async function setPriority(
+  providerId: AccountCredentialProvider,
+  id: string,
+  priority: number,
+): Promise<void> {
+  const pool = getDefaultAccountPool();
+  const account = pool.list(providerId as never).find((a) => a.id === id);
+  if (!account) throw new Error(`no account ${id}`);
+  await pool.upsert({ ...account, priority });
+}
+
 beforeEach(() => {
   prevHome = process.env.ELIZA_HOME;
   prevStateDir = process.env.ELIZA_STATE_DIR;
   prevCodexModel = process.env.ELIZA_CODEX_MODEL;
+  prevCodingStrategy = process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
+  delete process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
   home = mkdtempSync(path.join(tmpdir(), "coding-acct-"));
   process.env.ELIZA_HOME = home;
   // account-usage counters live under resolveStateDir() (ELIZA_STATE_DIR), not
   // ELIZA_HOME — isolate both so the usage-delta test doesn't touch real state.
   process.env.ELIZA_STATE_DIR = home;
+  configureDefaultAccountPoolSelection();
   __resetDefaultAccountPoolForTests();
 });
 
@@ -78,6 +94,12 @@ afterEach(() => {
   else process.env.ELIZA_STATE_DIR = prevStateDir;
   if (prevCodexModel === undefined) delete process.env.ELIZA_CODEX_MODEL;
   else process.env.ELIZA_CODEX_MODEL = prevCodexModel;
+  if (prevCodingStrategy === undefined) {
+    delete process.env.ELIZA_CODING_ACCOUNT_STRATEGY;
+  } else {
+    process.env.ELIZA_CODING_ACCOUNT_STRATEGY = prevCodingStrategy;
+  }
+  configureDefaultAccountPoolSelection();
   rmSync(home, { recursive: true, force: true });
 });
 
@@ -96,6 +118,51 @@ describe("coding-account-bridge", () => {
     expect(sel?.accountId).toBe("idle");
     expect(sel?.envPatch.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat-IDLE");
     expect(sel?.source).toBe("oauth");
+  });
+
+  it("honors config.accountStrategies so the app's strategy picker steers coding spawns", async () => {
+    writeAccount("anthropic-subscription", "primary", "sk-ant-oat-PRIMARY");
+    writeAccount("anthropic-subscription", "spare", "sk-ant-oat-SPARE");
+    getDefaultAccountPool();
+    // priority-strategy favors "primary"; least-used favors the idle "spare".
+    await setPriority("anthropic-subscription", "primary", 0);
+    await setPriority("anthropic-subscription", "spare", 1);
+    await setUsage("anthropic-subscription", "primary", 90);
+    await setUsage("anthropic-subscription", "spare", 5);
+    const bridge = getCodingAgentSelectorBridge();
+
+    // Unconfigured: least-used default.
+    const unconfigured = await bridge?.select("claude");
+    expect(unconfigured?.strategy).toBe("least-used");
+    expect(unconfigured?.accountId).toBe("spare");
+
+    // The picker writes config.accountStrategies — selection must follow it.
+    configureDefaultAccountPoolSelection({
+      accountStrategies: { "anthropic-subscription": "priority" },
+    });
+    const configured = await bridge?.select("claude");
+    expect(configured?.strategy).toBe("priority");
+    expect(configured?.accountId).toBe("primary");
+
+    // An explicit caller strategy still overrides the configured one.
+    const explicit = await bridge?.select("claude", {
+      strategy: "least-used",
+    });
+    expect(explicit?.strategy).toBe("least-used");
+    expect(explicit?.accountId).toBe("spare");
+
+    // The env var stays a fallback: used when no config, beaten by config.
+    configureDefaultAccountPoolSelection();
+    process.env.ELIZA_CODING_ACCOUNT_STRATEGY = "priority";
+    const envFallback = await bridge?.select("claude");
+    expect(envFallback?.strategy).toBe("priority");
+    expect(envFallback?.accountId).toBe("primary");
+    configureDefaultAccountPoolSelection({
+      accountStrategies: { "anthropic-subscription": "least-used" },
+    });
+    const configOverEnv = await bridge?.select("claude");
+    expect(configOverEnv?.strategy).toBe("least-used");
+    expect(configOverEnv?.accountId).toBe("spare");
   });
 
   it("materializes a per-account CODEX_HOME/auth.json for Codex (incl. id_token)", async () => {

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -45,7 +45,11 @@ import type {
   LinkedAccountProviderId,
   LinkedAccountUsage,
 } from "@elizaos/shared/contracts/service-routing";
-import type { AccountPool, Strategy } from "./account-pool.js";
+import {
+  type AccountPool,
+  type Strategy,
+  selectionForProvider,
+} from "./account-pool.js";
 
 const CODING_AGENT_SELECTOR_BRIDGE_SYMBOL: unique symbol = Symbol.for(
   "eliza.account-pool.coding-agent.v1",
@@ -58,7 +62,7 @@ const VALID_CODING_STRATEGIES = new Set<Strategy>([
   "quota-aware",
 ]);
 
-/** Default selection strategy — overridable via ELIZA_CODING_ACCOUNT_STRATEGY env var. */
+/** Last-resort strategy — the ELIZA_CODING_ACCOUNT_STRATEGY env var, else least-used. */
 function getDefaultCodingStrategy(): Strategy {
   const env =
     typeof process !== "undefined"
@@ -394,8 +398,17 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
     async select(agentType, opts) {
       const candidates = candidatesFor(agentType);
       if (candidates.length === 0) return null;
-      const strategy = opts?.strategy ?? getDefaultCodingStrategy();
       for (const providerId of candidates) {
+        // Explicit caller override > the app's per-provider
+        // config.accountStrategies (same live selectionForProvider read the
+        // anthropic/subscription bridges use, so the rotation-strategy picker
+        // steers coding spawns too) > ELIZA_CODING_ACCOUNT_STRATEGY env >
+        // least-used. Strategy only — the llmText route's accountIds pin the
+        // chat brain's account, not coding sub-agents.
+        const strategy =
+          opts?.strategy ??
+          selectionForProvider(providerId).strategy ??
+          getDefaultCodingStrategy();
         const account = await pool.select({
           providerId,
           strategy,


### PR DESCRIPTION
## Problem

The coding-agent account-selector bridge (`packages/app-core/src/services/coding-account-bridge.ts`) resolved its selection strategy from the `ELIZA_CODING_ACCOUNT_STRATEGY` env var only (default `least-used`). The app's per-provider rotation-strategy picker writes `config.accountStrategies[providerId]` (via `applyStrategyPatch` in `packages/agent/src/api/accounts-routes.ts`, applied at boot/hot-reload through `applyAccountPoolApiCredentials` → `configureDefaultAccountPoolSelection`) — but the coding bridge never read it.

Result: choosing a rotation strategy (or reordering account priority, which only matters under the `priority` strategy) in the app changed which account the chat brain used, but had **zero effect** on which account coding sub-agents (claude / codex / opencode) spawned on. The anthropic and subscription-selector bridges in `account-pool.ts` don't have this seam — they resolve through `selectionForProvider()`.

## Fix

Resolve the coding bridge's strategy per candidate provider through the same live `selectionForProvider()` read the other bridges use:

1. explicit caller `opts.strategy` (the orchestrator's `ELIZA_CODING_ACCOUNT_STRATEGY` setting pass-through) —
2. `config.accountStrategies[providerId]` —
3. `ELIZA_CODING_ACCOUNT_STRATEGY` env —
4. `least-used`.

Strategy only: the llmText service-route's `accountIds` pin the chat brain's account and are deliberately not applied to coding spawns. `selectionForProvider` is now exported; the unused `__getDefaultAccountPoolSelectionForTests` duplicate is removed (zero references tree-wide).

## Evidence

- New test `honors config.accountStrategies so the app's strategy picker steers coding spawns` sets up two `anthropic-subscription` accounts where `priority` and `least-used` pick different accounts, then proves: unconfigured → least-used; `config.accountStrategies` set → follows it; explicit caller strategy overrides config; env is a fallback used without config and beaten by config.
- Negative run: with the test in place and the two source files reverted to develop, the test fails exactly at the config phase (`AssertionError: expected 'least-used' to be 'priority'`) — it catches the bug.
- `vitest run` on every suite touching the changed files: `coding-account-bridge.test.ts` + `account-pool.test.ts` + `multi-account-{rotation,affinity-failover,refresh-failover}.test.ts` + `account-usage.test.ts` → **6 files, 67/67 passed**.
- `tsgo --noEmit -p tsconfig.json` (app-core): identical error inventory before/after the change (pre-existing, unrelated to these files) — zero errors in the changed files. `biome check` on the three changed files: clean.
- Trajectories / screenshots: N/A — pure account-selection plumbing beneath the spawn path; behavior is fully exercised by the deterministic pool tests above (no model/prompt/UI surface changed).
