### PR TITLE
fix(core): trajectory finalize guard so records can't leak stuck in running status

### DIFF
--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -8,6 +8,7 @@ import {
 	captureToolStageIO,
 	createJsonFileTrajectoryRecorder,
 	encodeTrajectoryFieldValue,
+	finalizeTrajectoryRecording,
 	type RecordedStage,
 	type RecordedTrajectory,
 	resolveTrajectoryFieldCapBytes,
@@ -1160,5 +1161,127 @@ describe("integration: action stage records input/output/error (M12)", () => {
 		expect(markdown).toContain(
 			"- description: manage EXISTING scheduled items -> SCHEDULED_TASKS",
 		);
+	});
+});
+
+describe("finalizeTrajectoryRecording (running-status leak guard)", () => {
+	const rootMessage = { id: "msg-1", text: "hello", sender: "user-1" };
+
+	async function readPersisted(id: string): Promise<RecordedTrajectory> {
+		const raw = await fs.readFile(
+			path.join(tmpDir, "agent-test", `${id}.json`),
+			"utf8",
+		);
+		return JSON.parse(raw) as RecordedTrajectory;
+	}
+
+	it("writes a terminal status even when the pre-end work never settles", async () => {
+		const warn = vi.fn();
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+
+		await finalizeTrajectoryRecording({
+			recorder,
+			trajectoryId: id,
+			status: "finished",
+			// Simulates a hung background facts-stage model call.
+			beforeEnd: () => new Promise<void>(() => {}),
+			beforeEndTimeoutMs: 25,
+			logger: { warn },
+		});
+
+		const persisted = await readPersisted(id);
+		expect(persisted.status).toBe("finished");
+		expect(persisted.endedAt).toBeGreaterThan(0);
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({ trajectoryId: id, timeoutMs: 25 }),
+			expect.stringContaining("timed out"),
+		);
+	});
+
+	it("writes a terminal errored status even when the pre-end work throws", async () => {
+		const warn = vi.fn();
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+
+		await finalizeTrajectoryRecording({
+			recorder,
+			trajectoryId: id,
+			status: "errored",
+			beforeEnd: () => Promise.reject(new Error("facts stage exploded")),
+			logger: { warn },
+		});
+
+		const persisted = await readPersisted(id);
+		expect(persisted.status).toBe("errored");
+		expect(persisted.metrics.finalDecision).toBe("error");
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({ err: "facts stage exploded" }),
+			expect.stringContaining("pre-end work failed"),
+		);
+	});
+
+	it("records the pre-end stage before ending when it completes in time", async () => {
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+
+		await finalizeTrajectoryRecording({
+			recorder,
+			trajectoryId: id,
+			status: "finished",
+			beforeEnd: async () => {
+				await recorder.recordStage(id, {
+					stageId: "stage-facts-1",
+					kind: "factsAndRelationships",
+					startedAt: 1,
+					endedAt: 2,
+					latencyMs: 1,
+				});
+			},
+		});
+
+		const persisted = await readPersisted(id);
+		expect(persisted.status).toBe("finished");
+		expect(persisted.stages).toHaveLength(1);
+		expect(persisted.stages[0]?.stageId).toBe("stage-facts-1");
+	});
+
+	it("never throws, even when endTrajectory itself rejects", async () => {
+		const warn = vi.fn();
+		const failing = {
+			startTrajectory: () => "tj-x",
+			recordStage: async () => undefined,
+			endTrajectory: async () => {
+				throw new Error("disk gone");
+			},
+			load: async () => null,
+			list: async () => [],
+		};
+
+		await expect(
+			finalizeTrajectoryRecording({
+				recorder: failing,
+				trajectoryId: "tj-x",
+				status: "finished",
+				logger: { warn },
+			}),
+		).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({ err: "disk gone", trajectoryId: "tj-x" }),
+			expect.stringContaining("endTrajectory failed"),
+		);
+	});
+
+	it("ends immediately when there is no pre-end work", async () => {
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({ agentId: "agent-test", rootMessage });
+
+		await finalizeTrajectoryRecording({
+			recorder,
+			trajectoryId: id,
+			status: "finished",
+		});
+
+		expect((await readPersisted(id)).status).toBe("finished");
 	});
 });

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -1233,9 +1233,15 @@ class JsonFileTrajectoryRecorder implements TrajectoryRecorder {
 			trajectory.metrics.finalDecision = "error";
 		}
 
-		await this.queueFlushTrajectory(trajectory);
-		this.active.delete(trajectoryId);
-		this.flushQueues.delete(trajectoryId);
+		try {
+			await this.queueFlushTrajectory(trajectory);
+		} finally {
+			// Always retire the trajectory, even when the terminal flush fails —
+			// otherwise a failed write leaves the entry in `active` forever and
+			// late recordStage calls keep resurrecting a half-dead record.
+			this.active.delete(trajectoryId);
+			this.flushQueues.delete(trajectoryId);
+		}
 	}
 
 	async load(trajectoryId: string): Promise<RecordedTrajectory | null> {
@@ -1381,6 +1387,86 @@ export function createJsonFileTrajectoryRecorder(
 	opts: CreateJsonFileRecorderOptions = {},
 ): TrajectoryRecorder {
 	return new JsonFileTrajectoryRecorder(opts);
+}
+
+// ---------------------------------------------------------------------------
+// Trajectory finalization guard
+// ---------------------------------------------------------------------------
+
+/** Bound on optional pre-end work before the terminal status is written anyway. */
+export const DEFAULT_FINALIZE_TIMEOUT_MS = 60_000;
+
+export interface FinalizeTrajectoryRecordingOptions {
+	recorder: TrajectoryRecorder;
+	trajectoryId: string;
+	status: "finished" | "errored";
+	/**
+	 * Optional best-effort work to run before the terminal write (e.g. recording
+	 * a late background stage). Failures and timeouts are logged, never fatal.
+	 */
+	beforeEnd?: () => Promise<void>;
+	beforeEndTimeoutMs?: number;
+	logger?: RecorderLogger;
+}
+
+async function awaitBounded(
+	work: Promise<void>,
+	timeoutMs: number,
+): Promise<"done" | "timeout"> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			work.then(() => "done" as const),
+			new Promise<"timeout">((resolve) => {
+				timer = setTimeout(() => resolve("timeout"), timeoutMs);
+				(timer as { unref?: () => void }).unref?.();
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+		// A raced-out `work` may still reject later; keep that from surfacing as
+		// an unhandled rejection.
+		void work.catch(() => undefined);
+	}
+}
+
+/**
+ * Lifecycle guard: every started trajectory must reach a terminal status.
+ *
+ * Runs `beforeEnd` bounded by `beforeEndTimeoutMs`, then writes the terminal
+ * status no matter what — a hung or throwing `beforeEnd` (historically the
+ * background FACTS_AND_RELATIONSHIPS model call) must never leave the
+ * trajectory stuck in `running`.
+ */
+export async function finalizeTrajectoryRecording(
+	opts: FinalizeTrajectoryRecordingOptions,
+): Promise<void> {
+	const timeoutMs = opts.beforeEndTimeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS;
+	try {
+		if (opts.beforeEnd) {
+			const outcome = await awaitBounded(opts.beforeEnd(), timeoutMs);
+			if (outcome === "timeout") {
+				opts.logger?.warn?.(
+					{ trajectoryId: opts.trajectoryId, timeoutMs },
+					"[TrajectoryRecorder] finalize: pre-end work timed out; ending trajectory without it",
+				);
+			}
+		}
+	} catch (err) {
+		opts.logger?.warn?.(
+			{ err: (err as Error).message, trajectoryId: opts.trajectoryId },
+			"[TrajectoryRecorder] finalize: pre-end work failed",
+		);
+	} finally {
+		try {
+			await opts.recorder.endTrajectory(opts.trajectoryId, opts.status);
+		} catch (err) {
+			opts.logger?.warn?.(
+				{ err: (err as Error).message, trajectoryId: opts.trajectoryId },
+				"[TrajectoryRecorder] endTrajectory failed",
+			);
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -134,6 +134,7 @@ import { actionHasSubActions, runSubPlanner } from "../runtime/sub-planner";
 import { buildCanonicalSystemPrompt } from "../runtime/system-prompt";
 import {
 	createJsonFileTrajectoryRecorder,
+	finalizeTrajectoryRecording,
 	isTrajectoryRecordingEnabled,
 	type TrajectoryRecorder,
 } from "../runtime/trajectory-recorder";
@@ -6806,32 +6807,30 @@ export async function runV5MessageRuntimeStage1(args: {
 		// finalize in the background by default and let the turn return as soon as
 		// the reply is decided. Await it only when deterministic trajectory
 		// ordering is required (e.g. the scenario-runner) via ELIZA_AWAIT_FACTS_STAGE.
+		// finalizeTrajectoryRecording is the lifecycle guard: it bounds the wait
+		// on the facts stage and writes the terminal status no matter what, so a
+		// hung facts model call can never leave the trajectory stuck `running`.
 		const finalizeTrajectory = async () => {
-			try {
-				const factsOutcome = await factsTask;
-				if (recorder && trajectoryId && factsOutcome) {
-					await recordFactsAndRelationshipsStage({
-						recorder,
-						trajectoryId,
-						outcome: factsOutcome,
-						logger: args.runtime.logger,
-					});
-				}
-			} catch (factsErr) {
-				args.runtime.logger?.warn?.(
-					{ err: (factsErr as Error).message, trajectoryId },
-					"[facts] background facts-stage recording failed",
-				);
-			} finally {
-				if (recorder && trajectoryId) {
-					await recorder.endTrajectory(trajectoryId, endStatus).catch((err) => {
-						args.runtime.logger?.warn?.(
-							{ err: (err as Error).message, trajectoryId },
-							"[TrajectoryRecorder] endTrajectory failed",
-						);
-					});
-				}
-			}
+			if (!recorder || !trajectoryId) return;
+			await finalizeTrajectoryRecording({
+				recorder,
+				trajectoryId,
+				status: endStatus,
+				beforeEnd: async () => {
+					const factsOutcome = await factsTask;
+					if (factsOutcome) {
+						await recordFactsAndRelationshipsStage({
+							recorder,
+							trajectoryId,
+							outcome: factsOutcome,
+							logger: args.runtime.logger,
+						});
+					}
+				},
+				logger: args.runtime.logger as {
+					warn?: (context: unknown, message?: string) => void;
+				},
+			});
 		};
 		if (process.env.ELIZA_AWAIT_FACTS_STAGE === "true") {
 			await finalizeTrajectory();


### PR DESCRIPTION
## Problem

Trajectory records leak in non-terminal status `running`: on one live deployment, 115 on-disk trajectories are stuck `running` (90 of them with zero stages), skewing any "did the run finish" lookup and leaving dead entries behind. Terminal statuses are `finished`/`errored`; only `startTrajectory` writes `running`, and only `endTrajectory` flips it.

Root cause (`packages/core/src/services/message.ts`): the terminal write was gated behind an **unbounded** `await factsTask` inside the background `finalizeTrajectory()`. `factsTask` is the heavy background FACTS_AND_RELATIONSHIPS `TEXT_LARGE` call (30s+ per the code's own comment):

- if that model call hangs, `endTrajectory` never runs and the trajectory stays `running` forever — even though the user already got the reply;
- while it is pending, any process restart abandons the finalize and leaks the record (the initial `running` snapshot is already flushed to disk by design).

Secondary hardening (`packages/core/src/runtime/trajectory-recorder.ts`): `endTrajectory` skipped its `active`/`flushQueues` map cleanup when the terminal flush rejected, so a single failed write parked the entry in memory forever and late `recordStage` calls kept resurrecting a half-dead record.

## Fix (structural)

- New lifecycle guard `finalizeTrajectoryRecording()` in `trajectory-recorder.ts`: runs optional pre-end work (the facts-stage recording) **bounded by a timeout** (default 60s, unref'd timer), then writes the terminal status **no matter what** — timeout, rejection, or `endTrajectory` failure are logged, never fatal, and never block the terminal write. A raced-out pre-end promise gets a rejection handler so it can't surface as an unhandled rejection.
- `message.ts` finalize path now goes through the guard (same behavior for `ELIZA_AWAIT_FACTS_STAGE=true`, now also bounded instead of deadlockable).
- `endTrajectory` retires the trajectory from `active`/`flushQueues` in a `finally`.

## Tests

5 new tests in `trajectory-recorder.test.ts` (`finalizeTrajectoryRecording` block):
- hung pre-end work → terminal `finished` persisted to disk (the leak scenario);
- throwing pre-end work → terminal `errored` + `finalDecision: "error"`;
- completing pre-end work → stage recorded before end;
- `endTrajectory` rejection → guard resolves, warn logged;
- no pre-end work → immediate terminal write.

`packages/core`: trajectory-recorder (42), message-runtime-stage1 + dedupe + stable-prefix (90), trajectory-export + TrajectoriesService (11) all pass; `tsgo` typecheck clean.

## Ops follow-up (not in this PR)

Existing stuck-`running` rows/files are historical artifacts; this PR only stops new leaks. Backfilling the old records (marking stale `running` trajectories `errored` past a cutoff) is a one-off ops task. Note: writes are also silently droppable on a full disk (`atomicWriteJson` warn-and-swallow) — no in-process fix can survive ENOSPC; monitoring disk is part of the same ops follow-up.

## Evidence

- Live-deployment count: 115 `running` files under the agent trajectory dir (dates cluster on restart/disk-pressure days: 35 on 07-02, 41 on 07-03).
- N/A - screenshots/video: no UI surface; observability lifecycle fix.
- N/A - live-LLM trajectory: the change is the recorder lifecycle itself, exercised directly by the new tests against the real JSON-file recorder on disk.
