### PR TITLE
fix(agent-api): streamed plugin routes lose status/headers + hono-mount 404s slash-variant paths the canonical dispatcher serves

### DIFF
--- a/packages/agent/src/api/hono-adapter.stream-headers.test.ts
+++ b/packages/agent/src/api/hono-adapter.stream-headers.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for the Hono adapter's streaming branch.
+ *
+ * A `routeHandler` returning `{ status, headers, stream }` (the documented
+ * SSE / long-response shape of `RouteHandlerResult`) must keep its status and
+ * headers on the wire. The stream branch used to build the streamed Response
+ * from a bare context — dropping `content-type: text/event-stream` (which
+ * breaks EventSource clients) and collapsing every non-200 status to 200 —
+ * while the non-stream branch preserved both.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { buildHonoAppForRuntime } from "./hono-adapter.ts";
+
+function makeRuntime(): IAgentRuntime {
+  async function* sse(): AsyncGenerator<Uint8Array | string> {
+    yield "data: hello\n\n";
+    yield new TextEncoder().encode("data: world\n\n");
+  }
+  return {
+    routes: [
+      {
+        type: "GET",
+        path: "/api/test-plugin/events",
+        public: true,
+        routeHandler: async () => ({
+          status: 201,
+          headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            "x-custom": "yes",
+          },
+          stream: sse(),
+        }),
+      },
+      {
+        type: "GET",
+        path: "/api/test-plugin/plain",
+        public: true,
+        routeHandler: async () => ({
+          status: 201,
+          headers: { "x-custom": "yes" },
+          body: { ok: true },
+        }),
+      },
+    ],
+  } as unknown as IAgentRuntime;
+}
+
+describe("hono-adapter streaming RouteHandlerResult", () => {
+  it("preserves the handler's status and headers on a streamed response", async () => {
+    const app = buildHonoAppForRuntime(makeRuntime(), {
+      isAuthorized: () => true,
+    });
+
+    const res = await app.request("/api/test-plugin/events");
+
+    expect(res.status).toBe(201);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    expect(res.headers.get("x-custom")).toBe("yes");
+    expect(await res.text()).toBe("data: hello\n\ndata: world\n\n");
+  });
+
+  it("keeps the non-stream branch behavior unchanged (control)", async () => {
+    const app = buildHonoAppForRuntime(makeRuntime(), {
+      isAuthorized: () => true,
+    });
+
+    const res = await app.request("/api/test-plugin/plain");
+
+    expect(res.status).toBe(201);
+    expect(res.headers.get("x-custom")).toBe("yes");
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/packages/agent/src/api/hono-adapter.ts
+++ b/packages/agent/src/api/hono-adapter.ts
@@ -14,6 +14,7 @@
 import type { IAgentRuntime, Route, RouteHandlerResult } from "@elizaos/core";
 import { type Context, Hono } from "hono";
 import { stream as honoStream } from "hono/streaming";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 import { dispatchRoute } from "./dispatch-route.ts";
 
@@ -156,6 +157,14 @@ export function mountRoutesOnHono(
       const headers = new Headers(result.headers ?? {});
       if (result.stream) {
         const resultStream = result.stream;
+        // Carry the handler's status and headers onto the streamed response —
+        // honoStream builds the Response from the context, so without this an
+        // SSE route loses its `content-type: text/event-stream` (breaking
+        // EventSource clients) and any non-200 status collapses to 200.
+        ctx.status(result.status as ContentfulStatusCode);
+        headers.forEach((value, key) => {
+          ctx.header(key, value);
+        });
         return honoStream(ctx, async (stream) => {
           for await (const chunk of resultStream) {
             await stream.write(chunk);

--- a/packages/agent/src/api/hono-mount.path-normalization.test.ts
+++ b/packages/agent/src/api/hono-mount.path-normalization.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for the hono-mount path-normalization seam.
+ *
+ * `hasHonoEligibleRoute` gates the Hono hand-off with the canonical
+ * `matchPluginRoutePath` matcher, which splits on `/` and drops empty
+ * segments — so `/api/x/` and `/api//x` match `/api/x`. Hono's router is
+ * strict about both. Before the fix, a trailing-slash request passed the
+ * tolerant gate, then 404'd inside Hono, and `tryHandleHonoRuntimeRoute`
+ * returned `true` — swallowing a request that `dispatchRoute` (the canonical
+ * dispatcher used by the in-process IPC surface) serves with 200.
+ */
+
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetHonoMountCache,
+  tryHandleHonoRuntimeRoute,
+} from "./hono-mount.ts";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    routes: [
+      {
+        type: "GET",
+        path: "/api/test-plugin/data",
+        public: true,
+        routeHandler: async () => ({ status: 200, body: { ok: true } }),
+      },
+    ],
+  } as unknown as IAgentRuntime;
+}
+
+interface FakeRes {
+  res: ServerResponse;
+  status: () => number;
+  body: () => string;
+  ended: () => Promise<void>;
+}
+
+function makeReqRes(
+  url: string,
+): { req: IncomingMessage; res: FakeRes["res"] } & FakeRes {
+  const req = Readable.from([]) as unknown as IncomingMessage;
+  req.method = "GET";
+  req.url = url;
+  req.headers = { host: "localhost" };
+
+  const chunks: Buffer[] = [];
+  let endedResolve: () => void;
+  const endedPromise = new Promise<void>((resolve) => {
+    endedResolve = resolve;
+  });
+  const emitter = new EventEmitter() as unknown as ServerResponse & {
+    statusCode: number;
+    writableEnded: boolean;
+  };
+  emitter.statusCode = 0;
+  emitter.writableEnded = false;
+  Object.assign(emitter, {
+    setHeader: () => emitter,
+    write: (c: Uint8Array | string) => {
+      chunks.push(Buffer.from(c));
+      return true;
+    },
+    end: (c?: Uint8Array | string) => {
+      if (c != null) chunks.push(Buffer.from(c));
+      emitter.writableEnded = true;
+      endedResolve();
+      return emitter;
+    },
+  });
+
+  return {
+    req,
+    res: emitter,
+    status: () => emitter.statusCode,
+    body: () => Buffer.concat(chunks).toString("utf8"),
+    ended: () => endedPromise,
+  };
+}
+
+describe("tryHandleHonoRuntimeRoute path normalization", () => {
+  beforeEach(() => {
+    resetHonoMountCache();
+  });
+
+  it("serves a trailing-slash path the canonical matcher accepts", async () => {
+    const h = makeReqRes("/api/test-plugin/data/");
+    const handled = await tryHandleHonoRuntimeRoute({
+      req: h.req,
+      res: h.res,
+      runtime: makeRuntime(),
+      isAuthorized: () => true,
+    });
+
+    expect(handled).toBe(true);
+    await h.ended();
+    expect(h.status()).toBe(200);
+    expect(JSON.parse(h.body())).toEqual({ ok: true });
+  });
+
+  it("serves a duplicate-slash path the canonical matcher accepts", async () => {
+    const h = makeReqRes("/api//test-plugin/data");
+    const handled = await tryHandleHonoRuntimeRoute({
+      req: h.req,
+      res: h.res,
+      runtime: makeRuntime(),
+      isAuthorized: () => true,
+    });
+
+    expect(handled).toBe(true);
+    await h.ended();
+    expect(h.status()).toBe(200);
+    expect(JSON.parse(h.body())).toEqual({ ok: true });
+  });
+
+  it("still serves the exact path (control)", async () => {
+    const h = makeReqRes("/api/test-plugin/data");
+    const handled = await tryHandleHonoRuntimeRoute({
+      req: h.req,
+      res: h.res,
+      runtime: makeRuntime(),
+      isAuthorized: () => true,
+    });
+
+    expect(handled).toBe(true);
+    await h.ended();
+    expect(h.status()).toBe(200);
+    expect(JSON.parse(h.body())).toEqual({ ok: true });
+  });
+
+  it("leaves unmatched paths unhandled so the server chain continues", async () => {
+    const h = makeReqRes("/api/test-plugin/other");
+    const handled = await tryHandleHonoRuntimeRoute({
+      req: h.req,
+      res: h.res,
+      runtime: makeRuntime(),
+      isAuthorized: () => true,
+    });
+
+    expect(handled).toBe(false);
+    expect(h.status()).toBe(0);
+    expect(h.body()).toBe("");
+  });
+});

--- a/packages/agent/src/api/hono-mount.ts
+++ b/packages/agent/src/api/hono-mount.ts
@@ -117,6 +117,22 @@ async function pipeWebBodyToNodeResponse(
  * `tryHandleRuntimePluginRoute`, so we let that path own it for the duration
  * of the migration.
  */
+/**
+ * Normalize a request pathname to the same shape the canonical
+ * `matchPluginRoutePath` matcher tolerates (it splits on `/` and drops empty
+ * segments, so duplicate and trailing slashes are ignored). Hono's router is
+ * strict about both, so without this a path like `/api/foo/` passes the
+ * tolerant `hasHonoEligibleRoute` gate below, then 404s inside Hono — the
+ * request is swallowed with a 404 even though `dispatchRoute` (the canonical
+ * dispatcher, used by the in-process IPC surface) serves the same path.
+ */
+function normalizeRoutePathname(pathname: string): string {
+  const collapsed = pathname.replace(/\/{2,}/g, "/");
+  return collapsed.length > 1 && collapsed.endsWith("/")
+    ? collapsed.slice(0, -1)
+    : collapsed;
+}
+
 function hasHonoEligibleRoute(
   runtime: IAgentRuntime,
   method: string,
@@ -145,14 +161,16 @@ export async function tryHandleHonoRuntimeRoute(options: {
 
   const method = req.method ?? "GET";
   const requestUrl = req.url ?? "/";
-  const pathname = (() => {
-    try {
-      return new URL(requestUrl, `http://${req.headers.host ?? "localhost"}`)
-        .pathname;
-    } catch {
-      return requestUrl.split("?")[0] ?? "/";
-    }
-  })();
+  const pathname = normalizeRoutePathname(
+    (() => {
+      try {
+        return new URL(requestUrl, `http://${req.headers.host ?? "localhost"}`)
+          .pathname;
+      } catch {
+        return requestUrl.split("?")[0] ?? "/";
+      }
+    })(),
+  );
 
   if (!hasHonoEligibleRoute(runtime, method, pathname)) {
     return false;
@@ -165,6 +183,10 @@ export async function tryHandleHonoRuntimeRoute(options: {
     req.url ?? "/",
     `http://${req.headers.host ?? "localhost"}`,
   );
+  // Hand Hono the normalized path so its strict router agrees with the
+  // tolerant eligibility gate above (and with dispatchRoute inside the
+  // handler, which re-matches against the same normalized path).
+  url.pathname = pathname;
   const headers = nodeHeadersToWeb(req.headers);
   headers.set(INTERNAL_AUTHORIZED_HEADER, options.isAuthorized() ? "1" : "0");
   headers.set(


### PR DESCRIPTION
## Summary

Two probe-confirmed bugs in the `runtime.routes` Hono seam (`packages/agent/src/api`), each fixed minimally with a mutation-checked unit test. This is the only HTTP server for new-shape `routeHandler` plugin routes (`server.ts` tries `tryHandleHonoRuntimeRoute` last, then hard-404s), so both defects are user-visible on every platform that serves plugin routes over HTTP.

## Bug 1 — `hono-adapter.ts`: streaming `RouteHandlerResult` drops its status and ALL headers

`RouteHandlerResult.stream` is the documented SSE / long-response shape (`packages/core/src/types/plugin.ts`). The stream branch built the streamed Response from a bare context, while the non-stream branch carefully preserved `result.status` + `result.headers`.

**Concrete failure input (probe-executed on develop before authoring):** a `routeHandler` returning `{ status: 201, headers: { "content-type": "text/event-stream", "x-custom": "yes" }, stream }` served through `buildHonoAppForRuntime` produced:

```
status = 200, content-type = null, x-custom = null   (body chunks intact)
```

The identical non-stream route returned `201` with headers preserved. `EventSource` clients hard-require `text/event-stream`, so any SSE plugin route breaks; any non-200 collapses to 200.

**Fix:** apply `result.status` and each `result.headers` entry onto the Hono context before `honoStream` (which builds its Response from the context). 3 lines + comment.

## Bug 2 — `hono-mount.ts`: eligibility gate and Hono router disagree → valid requests swallowed with 404

`hasHonoEligibleRoute` gates the hand-off with the canonical `matchPluginRoutePath` (splits on `/`, drops empty segments — tolerant of trailing/duplicate slashes). Hono's router is strict about both.

**Concrete failure input (probe-executed on develop):** runtime route `GET /api/my-plugin/data`; request `GET /api/my-plugin/data/`:

- canonical `dispatchRoute` (in-process IPC surface): `200 {"ok":true}`
- HTTP via `tryHandleHonoRuntimeRoute`: gate passes → Hono 404s → returns `handled=true` → client gets `404 Not Found`

Same for `/api//my-plugin/data`. The seam's own docstring promises "the Hono surface and the in-process IPC surface execute the exact same code path".

**Fix:** `normalizeRoutePathname()` (collapse duplicate slashes, strip trailing slash, root-safe) applied to the pathname used for both the eligibility check and the `Request` handed to Hono — so the gate, Hono, and `dispatchRoute` (which re-matches inside the handler) all agree.

## Evidence

- **Tests:** `hono-adapter.stream-headers.test.ts` (2 cases: streamed status/headers preserved + non-stream control) and `hono-mount.path-normalization.test.ts` (4 cases: trailing slash, duplicate slash, exact-path control, unmatched-falls-through control). `bunx vitest run --no-cache` → 6/6 green, re-verified after rebase onto latest develop.
- **Mutation checks (each fix independently):** reverting only `hono-adapter.ts` → stream test FAILS (content-type/status), control passes. Reverting only `hono-mount.ts` → exactly the 2 slash-tolerance tests FAIL (404 vs 200), controls pass. Both fixes restored after the check.
- **Regression check:** existing `runtime-plugin-routes.test.ts` + `public-route-audit.test.ts` → 8/8 green. `biome check` clean. Package typecheck shows only pre-existing unrelated `plugin-discord`/`plugin-meetings` errors (present on develop).
- Real-LLM trajectories: N/A — pure HTTP adapter/dispatch logic, no model/prompt/action behavior touched.
- Screenshots / video / mobile capture: N/A — no UI change; wire-level HTTP behavior proven by unit tests exercising the real Hono app and the real mount bridge.
- DB/domain artifacts: N/A — no persistence touched.

Also probed-and-dropped as not-real (rigor evidence): `evictOldestConversation` NaN-date non-eviction (bad input unreachable from all writers), `PendingRequestMap` duplicate-id premature delete (requestIds are `randomUUID()`), `setOwnerContact` partial-update field drop (replace semantics defensible; all callers write channelId only).

[phone-ui]

---
**Authored end-to-end by a Fable-5 agent** (verified 100% claude-fable-5), committed + pushed on its own branch. Each fix probe-executed against the real seam (concrete input → wrong output) BEFORE authoring. Independently re-verified: 4-file merge-base diff, 6/6 green (--no-cache), neighboring suites 8/8, and the SSE header-loss mutation reproduced (revert → stream test red; restore → green). Agent honestly DROPPED 6 candidates (NaN-date eviction unreachable, requestId-collision unreachable, owner-contact design choice, 3 cosmetic/dead-code) — probe-confirmed several as real-logic but unreachable-in-practice, so dropped rather than speculatively hardened. — [phone-ui]