### PR TITLE
fix(core): clear stale task base interval on nextInterval

### DIFF
--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -177,6 +177,32 @@ describe("TaskService tick re-arm", () => {
 		expect(execute.mock.calls.length).toBeGreaterThanOrEqual(8);
 	});
 
+	it("clears stale baseInterval after a worker returns a fresh nextInterval", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => ({ nextInterval: 72 * 60 * 60_000 }));
+		workers.set("VARIABLE_CRON", { name: "VARIABLE_CRON", execute });
+		tasks.set("t-cron", {
+			id: "t-cron" as UUID,
+			name: "VARIABLE_CRON",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: {
+				updateInterval: 60_000,
+				baseInterval: 24 * 60 * 60_000,
+				updatedAt: T0 - 61_000,
+			},
+		});
+		(runtime as { serverless: boolean }).serverless = true;
+
+		service = (await TaskService.start(runtime)) as TaskService;
+		await service.runDueTasks();
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		const meta = tasks.get("t-cron")?.metadata;
+		expect(meta?.updateInterval).toBe(72 * 60 * 60_000);
+		expect(meta?.baseInterval).toBeUndefined();
+	});
+
 	it("never auto-pauses a repeat task with maxFailures <= 0", async () => {
 		const { runtime, tasks, workers } = makeTaskRuntime();
 		const execute = vi.fn(async () => {

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -465,6 +465,7 @@ export class TaskService extends Service {
 						: undefined;
 				if (nextInterval != null) {
 					newMeta.updateInterval = nextInterval;
+					delete newMeta.baseInterval;
 				} else if (baseInterval != null && typeof baseInterval === "number") {
 					newMeta.updateInterval = baseInterval;
 				}


### PR DESCRIPTION
Follow-up to #12050 / #12030 item 1. #12050 returned the trigger worker's per-fire cron interval as `nextInterval`, but the TaskService success path kept any stale `metadata.baseInterval` from an earlier failure. The next failure path prefers `baseInterval` over the current `updateInterval`, so varying-cadence triggers could still back off from an old seed.\n\n## Change\n- When a repeat worker returns `nextInterval`, persist it to `metadata.updateInterval` and clear stale `metadata.baseInterval`.\n- Add a regression that starts with stale `baseInterval`, has the worker return a fresh 72h `nextInterval`, runs the real TaskService path, and asserts `baseInterval` is removed.\n\n## Verification\n- `bun run --cwd packages/core test src/services/task.test.ts` — 13 passed.\n- `bunx biome check packages/core/src/services/task.ts packages/core/src/services/task.test.ts` — clean.\n- `git diff --check` — clean.\n\nN/A screenshots/video/live-LLM: core scheduler metadata fix with deterministic TaskService regression; no UI or model surface.