### PR TITLE
fix(money): clamp embeddings affiliate payouts

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
@@ -270,9 +270,11 @@ describe("embeddings — success settles to actual usage exactly once", () => {
     // #10557: billUsage is now called WITHOUT the reservation, so it does NOT
     // reconcile internally (mirrors the real adapter's `if (reservation)`
     // guard). The route reconciles via the single first-call-wins settler.
-    billUsage.mockImplementation(async (_ctx, _usage, reservationArg) => {
+    billUsage.mockImplementation(async (_ctx, _usage, reservationArg, options) => {
       expect(reservationArg).toBeUndefined();
-      return makeBilling(ACTUAL);
+      const billing = makeBilling(ACTUAL);
+      await options?.reconcile?.(billing.totalCost);
+      return billing;
     });
 
     const { ctx, scheduled } = makeExecutionCtx();
@@ -331,7 +333,11 @@ describe("embeddings — billUsage internal throw releases the hold (#10557)", (
     const ACTUAL = 0.004;
     reserveCredits.mockResolvedValue(ledger.reservation);
     embed.mockResolvedValue({ embedding: [0.1], usage: { tokens: 5 } });
-    billUsage.mockResolvedValue(makeBilling(ACTUAL));
+    billUsage.mockImplementation(async (_ctx, _usage, _reservation, options) => {
+      const billing = makeBilling(ACTUAL);
+      await options?.reconcile?.(billing.totalCost);
+      return billing;
+    });
     usageCreate.mockRejectedValue(new Error("usage table write failed"));
 
     const { ctx, scheduled } = makeExecutionCtx();

--- a/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
@@ -172,18 +172,22 @@ beforeEach(() => {
     reservedAmount: 0.01,
     reconcile: mock(async () => undefined),
   });
-  billUsage.mockResolvedValue({
-    inputCost: 0.001,
-    outputCost: 0,
-    totalCost: 0.001,
-    baseInputCost: 0.001,
-    baseOutputCost: 0,
-    baseTotalCost: 0.001,
-    platformMarkup: 0,
-    inputTokens: 5,
-    outputTokens: 0,
-    totalTokens: 5,
-    markupApplied: true,
+  billUsage.mockImplementation(async (_context, _usage, _reservation, options) => {
+    const billing = {
+      inputCost: 0.001,
+      outputCost: 0,
+      totalCost: 0.001,
+      baseInputCost: 0.001,
+      baseOutputCost: 0,
+      baseTotalCost: 0.001,
+      platformMarkup: 0,
+      inputTokens: 5,
+      outputTokens: 0,
+      totalTokens: 5,
+      markupApplied: true,
+    };
+    await options?.reconcile?.(billing.totalCost);
+    return billing;
   });
   usageCreate.mockResolvedValue({ id: "usage-1" });
   embed.mockResolvedValue({ embedding: EMBEDDING, usage: { tokens: 5 } });
@@ -205,9 +209,9 @@ describe("POST /api/v1/embeddings — deferred billing", () => {
     const billingGate = new Promise<void>((resolve) => {
       releaseBilling = resolve;
     });
-    billUsage.mockImplementation(async () => {
+    billUsage.mockImplementation(async (_context, _usage, _reservation, options) => {
       await billingGate;
-      return {
+      const billing = {
         inputCost: 0.001,
         outputCost: 0,
         totalCost: 0.001,
@@ -220,6 +224,8 @@ describe("POST /api/v1/embeddings — deferred billing", () => {
         totalTokens: 5,
         markupApplied: true,
       };
+      await options?.reconcile?.(billing.totalCost);
+      return billing;
     });
 
     const { ctx, scheduled } = makeExecutionCtx();
@@ -318,6 +324,43 @@ describe("POST /api/v1/embeddings — single key validation", () => {
     expect(validateApiKey).not.toHaveBeenCalled();
     expect(billUsage.mock.calls[0][0].apiKeyId).toBe(API_KEY_ID);
     expect(usageCreate.mock.calls[0][0].api_key_id).toBe(API_KEY_ID);
+  });
+
+  test("affiliate code is included in both the upfront reserve and deferred bill context", async () => {
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await embeddingsRoute.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer eliza_test_key",
+          "Content-Type": "application/json",
+          "X-Affiliate-Code": "PARTNER1000",
+        },
+        body: JSON.stringify({
+          model: "text-embedding-3-small",
+          input: "hi",
+        }),
+      },
+      {},
+      ctx,
+    );
+    await Promise.all(scheduled);
+
+    expect(res.status).toBe(200);
+    expect(reserveCredits.mock.calls[0][0]).toMatchObject({
+      organizationId: ORG,
+      userId: USER,
+      affiliateCode: "PARTNER1000",
+    });
+    expect(billUsage.mock.calls[0][0]).toMatchObject({
+      organizationId: ORG,
+      userId: USER,
+      apiKeyId: API_KEY_ID,
+      affiliateCode: "PARTNER1000",
+    });
+    expect(typeof billUsage.mock.calls[0][0].requestId).toBe("string");
+    expect(typeof billUsage.mock.calls[0][3]?.reconcile).toBe("function");
   });
 });
 

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -213,6 +213,7 @@ app.post("/", async (c) => {
     // dedupe sourceId and must not be client-controllable (see the fuller note
     // in v1/chat/completions/route.ts).
     const requestId = crypto.randomUUID();
+    const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
     const orgId = user.organization_id;
     let reservation: Awaited<ReturnType<typeof reserveCredits>> | undefined;
     let optimisticReady = false;
@@ -364,6 +365,7 @@ app.post("/", async (c) => {
             model,
             provider,
             billingSource,
+            affiliateCode,
           },
           estimatedInputTokens,
           0,
@@ -429,12 +431,14 @@ app.post("/", async (c) => {
     // the only residual risk is an under-bill if the Worker dies before the
     // deferred task completes — an accepted trade-off for this route. The settler
     // prevents double-settlement inside the task.
-    const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
     const settleBilling = async () => {
       try {
-        // #10557: bill WITHOUT handing billUsage the reservation, then settle
-        // explicitly below — making `settleReservation` the SINGLE idempotent
-        // reconcile owner (mirrors /v1/messages and /v1/chat/completions).
+        // #10557: bill WITHOUT handing billUsage the raw reservation. Instead,
+        // pass the route's first-call-wins settler as the reconcile hook so
+        // settleReservation remains the SINGLE idempotent reconcile owner
+        // (mirrors /v1/messages and /v1/chat/completions). This also lets
+        // billUsage clamp affiliate payouts to the actually-collected revenue
+        // when a reserve/settle overage is uncollectable (#12017).
         // Previously billUsage was given the reservation and reconciled it at the
         // very END, AFTER two unguarded awaits (calculateCost + the affiliate-code
         // lookup). If either threw, that internal reconcile never ran and the
@@ -450,17 +454,15 @@ app.post("/", async (c) => {
             model,
             provider,
             billingSource,
+            requestId,
             // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
             // activate the existing billUsage affiliate branch (same as /v1/messages).
             affiliateCode,
           },
           { inputTokens: actualTokens, outputTokens: 0 },
+          undefined,
+          { reconcile: settleReservation },
         );
-
-        // Single reconcile site. The settler is first-call-wins idempotent, so
-        // this actual-cost charge can never be double-applied with the catch's
-        // settleReservation(0).
-        await settleReservation?.(billing.totalCost);
 
         logger.info("[Embeddings] Complete", {
           model,

--- a/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
@@ -147,6 +147,27 @@ describe("billUsage affiliate earnings guard (#10853)", () => {
     expect(addEarnings).not.toHaveBeenCalled();
   });
 
+  test("route-owned reconcile hook clamps affiliate earnings on uncollectable overage", async () => {
+    const reconcile = mock(async (actualCost: number) => ({
+      reservedAmount: 0.3,
+      actualCost,
+      reservationTransactionId: "reservation-route-owned-1",
+      settlementTransactionIds: [],
+      adjustmentType: "uncollected_overage" as const,
+    }));
+
+    const result = await billUsage(
+      { ...BASE, organizationId: "00000000-0000-4000-8000-0000000000org" },
+      USAGE,
+      undefined,
+      { reconcile },
+    );
+
+    expect(result.totalCost).toBeCloseTo(0.33, 6);
+    expect(reconcile).toHaveBeenCalledWith(result.totalCost);
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
   test("flat billing uncollectable overage does not mint affiliate earnings", async () => {
     const reconcile = mock(async (actualCost: number) => ({
       reservedAmount: 1,

--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -81,6 +81,17 @@ export interface BillingResult {
   markupApplied: boolean;
 }
 
+export interface BillUsageOptions {
+  /**
+   * Route-owned reconciliation hook for paths that keep a first-call-wins
+   * settler outside billUsage. This lets affiliate payouts be clamped to
+   * collected revenue without handing billUsage the raw reservation.
+   */
+  reconcile?: (
+    actualCost: number,
+  ) => Promise<CreditReconciliationResult | null | void>;
+}
+
 export interface FlatBillingCost {
   totalCost: number;
   baseTotalCost: number;
@@ -121,10 +132,9 @@ async function resolveBillableAffiliate(
 
 function collectedTotalCost(
   totalCost: number,
-  reservation: CreditReservation | undefined,
   reconciliation: CreditReconciliationResult | void | undefined,
 ): number {
-  if (!reservation || !reconciliation) return totalCost;
+  if (!reconciliation) return totalCost;
   if (reconciliation.adjustmentType === "uncollected_overage") {
     return Math.min(totalCost, reconciliation.reservedAmount);
   }
@@ -135,10 +145,9 @@ function collectedAffiliateEarnings(params: {
   nominalEarnings: number;
   preAffiliateTotalCost: number;
   totalCost: number;
-  reservation?: CreditReservation;
   reconciliation?: CreditReconciliationResult | void;
 }): number {
-  const collected = collectedTotalCost(params.totalCost, params.reservation, params.reconciliation);
+  const collected = collectedTotalCost(params.totalCost, params.reconciliation);
   const collectedMarkup = Math.max(0, collected - params.preAffiliateTotalCost);
   return Math.min(params.nominalEarnings, collectedMarkup);
 }
@@ -268,6 +277,7 @@ export async function billUsage(
   context: BillingContext,
   usage: AIUsage | undefined | null,
   reservation?: CreditReservation,
+  options: BillUsageOptions = {},
 ): Promise<BillingResult> {
   const { inputTokens, outputTokens, totalTokens, cacheReadInputTokens, cacheWriteInputTokens } =
     normalizeUsage(usage);
@@ -319,6 +329,17 @@ export async function billUsage(
       cacheWriteInputTokens,
       outputTokens,
     });
+  } else if (options.reconcile) {
+    reconciliation = (await options.reconcile(totalCost)) ?? undefined;
+    logger.info("[AI Billing] Credits reconciled", {
+      model: context.model,
+      actual: totalCost,
+      inputTokens,
+      billableInputTokens,
+      cacheReadInputTokens,
+      cacheWriteInputTokens,
+      outputTokens,
+    });
   }
 
   if (affiliate && affiliateEarnings > 0) {
@@ -326,7 +347,6 @@ export async function billUsage(
       nominalEarnings: affiliateEarnings,
       preAffiliateTotalCost,
       totalCost,
-      reservation,
       reconciliation,
     });
 
@@ -408,7 +428,6 @@ export async function billFlatUsage(
       nominalEarnings: affiliateEarnings,
       preAffiliateTotalCost,
       totalCost,
-      reservation,
       reconciliation,
     });
 


### PR DESCRIPTION
Fixes #12017

## Summary
- Thread X-Affiliate-Code into the embeddings credit reservation so affiliate markup is included before the provider call.
- Add a narrow billUsage reconcile hook for routes that own first-call-wins settlement, so affiliate payouts are clamped to collected revenue without handing billUsage the raw reservation.
- Update embeddings billing tests and shared billing affiliate guard coverage for the route-owned reconciliation path.

## Evidence
- `bun test packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts` - 9 pass, 0 fail.
- `bun test packages/cloud/api/__tests__/embeddings-route-billing.test.ts` - 8 pass, 0 fail.
- `bun test packages/cloud/api/__tests__/embeddings-credit-leak.test.ts` - 7 pass, 0 fail.
- `bun run --cwd packages/cloud/shared typecheck` - pass.
- `git diff --check` - pass.
- `bun run --cwd packages/cloud/api typecheck` - fails on pre-existing unrelated errors: `__tests__/stripe-connect-webhook-route.test.ts` Stripe API version literal and Hono duplicate-version types in `fal/proxy/route.ts`.
- Changed-file Biome check was not runnable from the nested `node_modules/.codex-worktrees` worktree; Biome reports the files do not exist in the workspace.

## Evidence N/A
- UI screenshots/video: N/A - API/shared billing path only.
- Real-LLM trajectories: N/A - no agent prompts, model selection, or runtime trajectory behavior changed.