### PR TITLE
fix(agent): persist explicit MEMORY creates where recall can read them

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -1,0 +1,158 @@
+import type { ActionResult, IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { memoryAction } from "./memories";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+
+type StoredRow = { memory: Memory; tableName: string; unique?: boolean };
+
+function makeRuntime(): { runtime: IAgentRuntime; rows: StoredRow[] } {
+  const rows: StoredRow[] = [];
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    createMemory: async (
+      memory: Memory,
+      tableName: string,
+      unique?: boolean,
+    ) => {
+      rows.push({ memory, tableName, unique });
+      return memory.id;
+    },
+    getMemories: async (params: {
+      tableName: string;
+      roomId?: UUID;
+      entityId?: UUID;
+    }) =>
+      rows
+        .filter((row) => row.tableName === params.tableName)
+        .filter((row) => !params.roomId || row.memory.roomId === params.roomId)
+        .filter(
+          (row) => !params.entityId || row.memory.entityId === params.entityId,
+        )
+        .map((row) => row.memory),
+  } as unknown as IAgentRuntime;
+  return { runtime, rows };
+}
+
+function makeMessage(): Memory {
+  return {
+    id: crypto.randomUUID() as UUID,
+    entityId: USER_ID,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    content: { text: "remember this: my favorite color is blue" },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+async function runAction(
+  runtime: IAgentRuntime,
+  message: Memory,
+  parameters: Record<string, string | string[]>,
+): Promise<ActionResult> {
+  const result = await memoryAction.handler(runtime, message, undefined, {
+    parameters,
+  });
+  if (!result) throw new Error("handler returned no result");
+  return result;
+}
+
+async function runCreate(
+  runtime: IAgentRuntime,
+  message: Memory,
+  parameters: Record<string, string | string[]>,
+): Promise<ActionResult> {
+  return runAction(runtime, message, { action: "create", ...parameters });
+}
+
+describe("MEMORY op:create", () => {
+  it("persists to the facts table scoped to the conversation room and speaker", async () => {
+    const { runtime, rows } = makeRuntime();
+    const message = makeMessage();
+
+    const result = await runCreate(runtime, message, {
+      text: "the user's favorite color is blue",
+      kind: "preference",
+      tags: ["color"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(rows).toHaveLength(1);
+    const { memory, tableName, unique } = rows[0];
+    expect(tableName).toBe("facts");
+    expect(unique).toBe(true);
+    expect(memory.entityId).toBe(USER_ID);
+    expect(memory.roomId).toBe(ROOM_ID);
+    expect(memory.content.text).toBe("the user's favorite color is blue");
+
+    const metadata = memory.metadata as Record<string, unknown>;
+    expect(metadata.kind).toBe("durable");
+    expect(metadata.category).toBe("preference");
+    expect(metadata.keywords).toEqual(["color"]);
+    expect(metadata.confidence).toBeGreaterThan(0.7);
+    expect(metadata.verificationStatus).toBe("self_reported");
+  });
+
+  it("is retrievable by the FACTS provider candidate queries", async () => {
+    // The FACTS provider builds two candidate pools over the `facts` table:
+    // one scoped to the conversation room, one to the speaker's entity ids.
+    // The old write (agent-scoped `memories` table in a synthetic room)
+    // matched neither, so the saved fact could never be recalled.
+    const { runtime } = makeRuntime();
+    await runCreate(runtime, makeMessage(), {
+      text: "the user's dog is named Jeff",
+    });
+
+    const roomPool = await runtime.getMemories({
+      tableName: "facts",
+      roomId: ROOM_ID,
+    });
+    expect(roomPool).toHaveLength(1);
+    expect(roomPool[0].content.text).toBe("the user's dog is named Jeff");
+
+    const entityPool = await runtime.getMemories({
+      tableName: "facts",
+      entityId: USER_ID,
+    });
+    expect(entityPool).toHaveLength(1);
+    expect(entityPool[0].content.text).toBe("the user's dog is named Jeff");
+  });
+
+  it("is found by MEMORY op:search after create", async () => {
+    const { runtime } = makeRuntime();
+    const message = makeMessage();
+    await runCreate(runtime, message, {
+      text: "the user's favorite color is blue",
+    });
+
+    const result = await runAction(runtime, message, {
+      action: "search",
+      query: "favorite color",
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as { memories: Array<{ text: string }> };
+    expect(data.memories).toHaveLength(1);
+    expect(data.memories[0].text).toBe("the user's favorite color is blue");
+  });
+
+  it("falls back to the agent entity when the message has none", async () => {
+    const { runtime, rows } = makeRuntime();
+    const message = {
+      ...makeMessage(),
+      entityId: undefined,
+    } as unknown as Memory;
+    const result = await runCreate(runtime, message, { text: "agent note" });
+    expect(result.success).toBe(true);
+    expect(rows[0].memory.entityId).toBe(AGENT_ID);
+  });
+
+  it("rejects an empty text", async () => {
+    const { runtime, rows } = makeRuntime();
+    const result = await runCreate(runtime, makeMessage(), { text: "   " });
+    expect(result.success).toBe(false);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -6,7 +6,7 @@ import type {
   Memory,
   UUID,
 } from "@elizaos/core";
-import { ChannelType, logger, ModelType, stringToUuid } from "@elizaos/core";
+import { MemoryType as CoreMemoryType, logger, ModelType } from "@elizaos/core";
 
 const MEMORY_OPS = ["create", "search", "update", "delete"] as const;
 type MemoryOp = (typeof MEMORY_OPS)[number];
@@ -82,8 +82,16 @@ function toListItem(memory: Memory, type: MemoryType): MemoryListItem {
   };
 }
 
+/**
+ * Confidence for facts the user explicitly asked to store. Higher than the
+ * reflection extractor's 0.7 — "remember this" is a direct instruction, not
+ * an inferred claim.
+ */
+const EXPLICIT_MEMORY_CONFIDENCE = 0.95;
+
 async function doCreate(
   runtime: IAgentRuntime,
+  message: Memory,
   params: MemoryParams,
 ): Promise<ActionResult> {
   const text = typeof params.text === "string" ? params.text.trim() : "";
@@ -100,37 +108,36 @@ async function doCreate(
     : [];
 
   const agentId = runtime.agentId as UUID;
-  const roomId = stringToUuid(
-    `${runtime.character.name ?? "eliza"}-manual-memories-room`,
-  ) as UUID;
   const memoryId = crypto.randomUUID() as UUID;
   const createdAt = Date.now();
 
-  const content: Record<string, unknown> = { text, source: "MEMORY" };
-  if (kind) content.kind = kind;
-  if (tags.length > 0) content.tags = tags;
-
-  await runtime
-    .ensureRoomExists({
-      id: roomId,
-      agentId,
-      name: "manual-memories",
-      source: "agent",
-      type: ChannelType.DM,
-      worldId: stringToUuid(`${agentId}-manual-memories-world`) as UUID,
-    })
-    .catch(() => undefined);
-
+  // Persist where the recall read path looks. The FACTS provider — the only
+  // default-on read path for user facts — scans the `facts` table scoped to
+  // the conversation room and the speaker's entity ids. The previous write
+  // (agent-scoped `memories` table in a synthetic manual-memories room) was
+  // invisible to it, so the agent acked "I'll remember" and then denied
+  // knowing the fact on the next turn.
   await runtime.createMemory(
     {
       id: memoryId,
-      entityId: agentId,
+      entityId: message.entityId ?? agentId,
       agentId,
-      roomId,
-      content,
+      roomId: message.roomId,
+      content: { text, source: "MEMORY" },
+      metadata: {
+        type: CoreMemoryType.CUSTOM,
+        source: "MEMORY",
+        kind: "durable",
+        category: kind ?? "user_note",
+        confidence: EXPLICIT_MEMORY_CONFIDENCE,
+        keywords: tags,
+        verificationStatus: "self_reported",
+        lastConfirmedAt: new Date(createdAt).toISOString(),
+      },
       createdAt,
     } as Memory,
-    "memories",
+    "facts",
+    true,
   );
 
   return {
@@ -332,7 +339,7 @@ export const memoryAction: Action = {
   validate: async () => true,
   handler: async (
     runtime: IAgentRuntime,
-    _message,
+    message,
     _state,
     options,
   ): Promise<ActionResult> => {
@@ -348,7 +355,7 @@ export const memoryAction: Action = {
     try {
       switch (op) {
         case "create":
-          return await doCreate(runtime, params);
+          return await doCreate(runtime, message, params);
         case "search":
           return await doSearch(runtime, params);
         case "update":


### PR DESCRIPTION
## Problem

"Remember this: X" produces an ack-then-contradict flow: the agent calls `MEMORY` `op:create`, replies "got it, I'll remember", and then on the next turn denies knowing the fact ("I don't have that saved").

Root cause: the action's write was a dead letter. `doCreate` stored the record in an agent-scoped `memories`-table row inside a synthetic `<name>-manual-memories-room`, with `entityId = agentId`. No recall path reads that location:

- The **FACTS provider** (`packages/core/src/features/advanced-capabilities/providers/facts.ts`) — the only default-on read path for user facts — scans the **`facts`** table scoped to the **conversation room** and the **speaker's related entity ids**. Wrong table, wrong room, wrong entity → the saved fact can never surface.
- On a natural recall turn ("what's my favorite color?") the message routes to the `general` context, where the `MEMORY` action isn't even visible, so `op:search` can't paper over it.
- The only thing that occasionally made recall work was the probabilistic reflection/stage-1 extraction, which is exactly why this failed intermittently in live trajectories.

## Fix

`doCreate` now persists into the existing facts store (no second store), scoped to the originating message:

- table `facts`, `roomId = message.roomId`, `entityId = message.entityId` (agent fallback)
- durable-kind fact metadata mirroring the reflection extractor's shape (`kind`, `category`, `keywords`, `verificationStatus`, `lastConfirmedAt`)
- `confidence 0.95` — above the extractor's 0.7, since the user explicitly asked to store it

`MEMORY op:search`, `op:update`, `op:delete` are unchanged and keep working on the new rows (search already scans `facts`; update/delete are id-based). The memories browse/feed API surfaces the `facts` table, so explicitly saved items remain visible in the app.

## Test

`packages/agent/src/actions/memories.test.ts` (new):
- create persists to `facts` scoped to the conversation room + speaker, with durable fact metadata — fails on the old code
- the two candidate queries the FACTS provider issues (room-scoped, entity-scoped over `facts`) both retrieve the saved fact — fails on the old code
- `op:search` round-trip after create
- agent-entity fallback when the message has no entity
- empty text rejected, nothing written

## Verification

- `bun test src/actions/memories.test.ts` → 5 pass / 0 fail
- agent actions suite → 28 pass; 1 pre-existing environment failure (`settings-backends.test.ts` can't resolve `@elizaos/vault` in the sparse harness, unrelated to this diff)
- package typecheck: identical error set before/after the change (zero new errors)
- rebased on `origin/develop` (`ee1396d54b`)
