### PR TITLE
fix(app): guard initializeKeyboard so a bridge throw can't strand bootstrap (#12030 item 4)

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1519,25 +1519,32 @@ async function initializeStatusBar(): Promise<void> {
 async function initializeKeyboard(): Promise<void> {
   if (keyboardListenersRegistered) return;
 
-  if (isIOS) {
-    await Keyboard.setResizeMode({ mode: KeyboardResize.None });
-    await Keyboard.setScroll({ isDisabled: true });
-    await Keyboard.setAccessoryBarVisible({ isVisible: true });
+  // A Keyboard-bridge throw (pod/plugin skew) must not reject and strand the
+  // rest of bootstrap (deep links, hardware back, pause/resume, network) —
+  // guard it exactly like the sibling initializeStatusBar.
+  try {
+    if (isIOS) {
+      await Keyboard.setResizeMode({ mode: KeyboardResize.None });
+      await Keyboard.setScroll({ isDisabled: true });
+      await Keyboard.setAccessoryBarVisible({ isVisible: true });
+    }
+
+    keyboardListenersRegistered = true;
+    Keyboard.addListener("keyboardWillShow", (info) => {
+      document.body.style.setProperty(
+        "--keyboard-height",
+        `${info.keyboardHeight}px`,
+      );
+      document.body.classList.add("keyboard-open");
+    });
+
+    Keyboard.addListener("keyboardWillHide", () => {
+      document.body.style.setProperty("--keyboard-height", "0px");
+      document.body.classList.remove("keyboard-open");
+    });
+  } catch (error) {
+    logNativePluginUnavailable("Keyboard", error);
   }
-
-  keyboardListenersRegistered = true;
-  Keyboard.addListener("keyboardWillShow", (info) => {
-    document.body.style.setProperty(
-      "--keyboard-height",
-      `${info.keyboardHeight}px`,
-    );
-    document.body.classList.add("keyboard-open");
-  });
-
-  Keyboard.addListener("keyboardWillHide", () => {
-    document.body.style.setProperty("--keyboard-height", "0px");
-    document.body.classList.remove("keyboard-open");
-  });
 }
 
 /**

--- a/packages/app/src/mobile-lifecycle.keyboard-guard.test.ts
+++ b/packages/app/src/mobile-lifecycle.keyboard-guard.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMobileLifecycle } from "./mobile-lifecycle";
+
+// Regression for #12030 item 4. `initializeKeyboard` ran its iOS setup
+// (`await Keyboard.setResizeMode(...)` etc.) unguarded, unlike the sibling
+// `initializeStatusBar`. Under pod/plugin skew a Keyboard-bridge call throws,
+// so the returned promise rejected — and because bootstrap awaits it, every
+// later lifecycle step (deep links, hardware back, pause/resume, network) was
+// stranded. The guard must swallow + log the failure and resolve.
+vi.mock("@capacitor/keyboard", () => ({
+  KeyboardResize: { None: "none" },
+  Keyboard: {
+    setResizeMode: () => {
+      throw new Error("Keyboard plugin unavailable (simulated pod skew)");
+    },
+    setScroll: async () => {},
+    setAccessoryBarVisible: async () => {},
+    addListener: () => {},
+  },
+}));
+
+function makeIOSLifecycle() {
+  return createMobileLifecycle({
+    isNative: true,
+    isIOS: true,
+    isAndroid: false,
+    logPrefix: "[test]",
+    handleDeepLink: () => {},
+  });
+}
+
+describe("initializeKeyboard bridge-failure guard (#12030 item 4)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("resolves instead of rejecting when an iOS Keyboard call throws", async () => {
+    const lifecycle = makeIOSLifecycle();
+    // Before the guard this promise rejected with the bridge error, which the
+    // awaited bootstrap chain then propagated, stranding later wiring.
+    await expect(lifecycle.initializeKeyboard()).resolves.toBeUndefined();
+  });
+
+  it("logs the plugin as unavailable (same degradation as initializeStatusBar)", async () => {
+    const lifecycle = makeIOSLifecycle();
+    await lifecycle.initializeKeyboard();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Keyboard plugin not available"),
+      expect.anything(),
+    );
+  });
+
+  it("leaves the rest of the lifecycle API callable after a keyboard failure", async () => {
+    const lifecycle = makeIOSLifecycle();
+    await lifecycle.initializeKeyboard();
+    // The point of the fix: a keyboard failure no longer aborts bootstrap, so
+    // sibling wiring the caller invokes next still runs.
+    expect(() => lifecycle.initializeAppLifecycle()).not.toThrow();
+  });
+});

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -65,25 +65,31 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
   async function initializeKeyboard(): Promise<void> {
     if (keyboardListenersRegistered) return;
 
-    if (ctx.isIOS) {
-      await Keyboard.setResizeMode({ mode: KeyboardResize.None });
-      await Keyboard.setScroll({ isDisabled: true });
-      await Keyboard.setAccessoryBarVisible({ isVisible: true });
+    // A Keyboard-bridge throw (pod/plugin skew) must not reject and strand the
+    // rest of lifecycle wiring — guard it like the sibling initializeStatusBar.
+    try {
+      if (ctx.isIOS) {
+        await Keyboard.setResizeMode({ mode: KeyboardResize.None });
+        await Keyboard.setScroll({ isDisabled: true });
+        await Keyboard.setAccessoryBarVisible({ isVisible: true });
+      }
+
+      keyboardListenersRegistered = true;
+      Keyboard.addListener("keyboardWillShow", (info) => {
+        document.body.style.setProperty(
+          "--keyboard-height",
+          `${info.keyboardHeight}px`,
+        );
+        document.body.classList.add("keyboard-open");
+      });
+
+      Keyboard.addListener("keyboardWillHide", () => {
+        document.body.style.setProperty("--keyboard-height", "0px");
+        document.body.classList.remove("keyboard-open");
+      });
+    } catch (error) {
+      logNativePluginUnavailable("Keyboard", error);
     }
-
-    keyboardListenersRegistered = true;
-    Keyboard.addListener("keyboardWillShow", (info) => {
-      document.body.style.setProperty(
-        "--keyboard-height",
-        `${info.keyboardHeight}px`,
-      );
-      document.body.classList.add("keyboard-open");
-    });
-
-    Keyboard.addListener("keyboardWillHide", () => {
-      document.body.style.setProperty("--keyboard-height", "0px");
-      document.body.classList.remove("keyboard-open");
-    });
   }
 
   function initializeAppLifecycle(): void {


### PR DESCRIPTION
## The bug (#12030 item 4, `[phone-ui]`)

Both copies of `initializeKeyboard` — `packages/app/src/main.tsx:1519` and the live lifecycle helper `packages/app/src/mobile-lifecycle.ts:65` — run their iOS setup unguarded:

```ts
if (isIOS) {
  await Keyboard.setResizeMode({ mode: KeyboardResize.None });
  await Keyboard.setScroll({ isDisabled: true });
  await Keyboard.setAccessoryBarVisible({ isVisible: true });
}
```

The sibling `initializeStatusBar` right above it is wrapped in `try/catch` + `logNativePluginUnavailable(...)`. `initializeKeyboard` is not. Under pod/plugin skew a Keyboard-bridge call **throws**, so the returned promise rejects; bootstrap `await`s it, so the rejection propagates and **strands every later lifecycle step** — deep links, hardware back button, pause/resume, network listeners. (Only fires under bridge skew, not the shipped build — hence LOW, but it's a real single-point-of-failure in bootstrap.)

## The fix

Wrap each `initializeKeyboard` body in `try/catch`, degrading via `logNativePluginUnavailable("Keyboard", error)` — the exact pattern already proven on `initializeStatusBar` and `initializeNetworkListener`.

## Verification — real red→green test

New `packages/app/src/mobile-lifecycle.keyboard-guard.test.ts` mocks `@capacitor/keyboard` so `setResizeMode` throws (the on-device pod-skew failure), builds an iOS lifecycle, and asserts `initializeKeyboard()` **resolves + logs** instead of rejecting.

- **Without the guard:** `3 failed` — `AssertionError: promise rejected "Keyboard plugin unavailable…" instead of resolving` (proves the strand).
- **With the guard:** `3 passed`.

| type | status |
|---|---|
| Unit test (real mocked-bridge throw, red→green) | ✅ 3 pass (verified red without fix) |
| Backend logs | N/A — client bootstrap only |
| Before/after screenshots + video | **N/A — zero rendered change.** This is a defensive `try/catch` around native-bridge bootstrap calls; no component, style, or layout is touched, so `audit:app` would produce identical pixels. |
| Real-LLM trajectory | N/A — no agent/model path |
| Per-platform capture | N/A — failure only manifests under pod/bridge skew (not the shipped build); guarded behavior is proven by the mocked-throw unit test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)