### PR TITLE
test(app): add iOS native attachment smoke for #10936

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -183,6 +183,46 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Run iOS native attachment smoke (#10936)
+        # New evidence lane for the content-addressed media + native
+        # Filesystem/Share path. Keep non-blocking until the hosted macOS
+        # simulator behavior is observed green, then promote to hard fail.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p packages/app/test-results/ios-attachment-smoke
+          ELIZA_API_PORT=31337 ELIZA_PAIRING_DISABLED=1 \
+            node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
+            > packages/app/test-results/ios-attachment-smoke/host-agent.log 2>&1 &
+          HOST_AGENT_PID=$!
+          cleanup() {
+            kill "$HOST_AGENT_PID" 2>/dev/null || true
+            wait "$HOST_AGENT_PID" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          for attempt in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:31337/api/health >/dev/null; then
+              break
+            fi
+            if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
+              echo "Host agent exited before /api/health became ready"
+              cat packages/app/test-results/ios-attachment-smoke/host-agent.log
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -fsS http://127.0.0.1:31337/api/health >/dev/null
+          node packages/app/scripts/ios-attachment-smoke.mjs --api-base http://127.0.0.1:31337
+
+      - name: Upload iOS native attachment evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-attachment-smoke
+          path: packages/app/test-results/ios-attachment-smoke/**
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Run iOS local-chat simulator smoke (#9943)
         # Wire the existing iOS chat device smoke into CI. mobile-local-chat-smoke
         # drives a real chat turn through the installed simulator app (the iOS

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -100,10 +100,12 @@ jobs:
         run: node --max-old-space-size=8192 packages/app-core/scripts/run-mobile-build.mjs ios
         env:
           LANG: en_US.UTF-8
-          # This simulator smoke validates the compatibility host. Full-Bun
-          # App Store/device builds are covered by release workflows with an
-          # explicit ELIZA_IOS_BUN_ENGINE_XCFRAMEWORK artifact.
-          ELIZA_IOS_APP_STORE_LOCAL_RUNTIME: "0"
+          # The simulator smokes drive a loopback host agent. Use the direct
+          # developer iOS lane; App Store/cloud builds intentionally reject
+          # cleartext loopback and are covered by release workflows.
+          ELIZA_BUILD_VARIANT: "direct"
+          ELIZA_RELEASE_AUTHORITY: "developer-toolchain"
+          VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK: "1"
           ELIZA_IOS_FULL_BUN_ENGINE: "0"
           ELIZA_IOS_BUILD_DESTINATION: "generic/platform=iOS Simulator"
           ELIZA_IOS_BUILD_SDK: "iphonesimulator"
@@ -151,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-onboarding-to-home
-          ELIZA_API_PORT=31337 ELIZA_PAIRING_DISABLED=1 \
+          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
             node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
             > packages/app/test-results/ios-onboarding-to-home/host-agent.log 2>&1 &
           HOST_AGENT_PID=$!
@@ -161,7 +163,7 @@ jobs:
           }
           trap cleanup EXIT
           for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31337/api/health >/dev/null; then
+            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
               break
             fi
             if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
@@ -171,8 +173,8 @@ jobs:
             fi
             sleep 2
           done
-          curl -fsS http://127.0.0.1:31337/api/health >/dev/null
-          node packages/app/scripts/ios-onboarding-smoke.mjs --api-base http://127.0.0.1:31337
+          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
+          node packages/app/scripts/ios-onboarding-smoke.mjs --api-base http://127.0.0.1:31338
 
       - name: Upload iOS onboarding evidence
         if: always()
@@ -191,7 +193,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-attachment-smoke
-          ELIZA_API_PORT=31337 ELIZA_PAIRING_DISABLED=1 \
+          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
             node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
             > packages/app/test-results/ios-attachment-smoke/host-agent.log 2>&1 &
           HOST_AGENT_PID=$!
@@ -201,7 +203,7 @@ jobs:
           }
           trap cleanup EXIT
           for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31337/api/health >/dev/null; then
+            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
               break
             fi
             if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
@@ -211,8 +213,8 @@ jobs:
             fi
             sleep 2
           done
-          curl -fsS http://127.0.0.1:31337/api/health >/dev/null
-          node packages/app/scripts/ios-attachment-smoke.mjs --api-base http://127.0.0.1:31337
+          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
+          node packages/app/scripts/ios-attachment-smoke.mjs --api-base http://127.0.0.1:31338
 
       - name: Upload iOS native attachment evidence
         if: always()
@@ -234,7 +236,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p packages/app/test-results/ios-local-chat
-          ELIZA_API_PORT=31337 ELIZA_PAIRING_DISABLED=1 \
+          ELIZA_API_PORT=31338 ELIZA_PAIRING_DISABLED=1 \
             node packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/serve-real-local-agent.ts \
             > packages/app/test-results/ios-local-chat/host-agent.log 2>&1 &
           HOST_AGENT_PID=$!
@@ -244,7 +246,7 @@ jobs:
           }
           trap cleanup EXIT
           for attempt in $(seq 1 90); do
-            if curl -fsS http://127.0.0.1:31337/api/health >/dev/null; then
+            if curl -fsS http://127.0.0.1:31338/api/health >/dev/null; then
               break
             fi
             if ! kill -0 "$HOST_AGENT_PID" 2>/dev/null; then
@@ -254,9 +256,9 @@ jobs:
             fi
             sleep 2
           done
-          curl -fsS http://127.0.0.1:31337/api/health >/dev/null
+          curl -fsS http://127.0.0.1:31338/api/health >/dev/null
           node packages/app/scripts/mobile-local-chat-smoke.mjs \
-            --platform ios --require-installed --api-base http://127.0.0.1:31337
+            --platform ios --require-installed --api-base http://127.0.0.1:31338
 
       - name: Upload iOS local-chat evidence
         if: always()

--- a/packages/app-core/scripts/mobile/ios-pods.mjs
+++ b/packages/app-core/scripts/mobile/ios-pods.mjs
@@ -29,6 +29,16 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     ],
   },
   {
+    packageName: "@capacitor/filesystem",
+    iosPods: [
+      {
+        name: "CapacitorFilesystem",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
     packageName: "@capacitor-community/background-runner",
     android: { patchAgp9: true },
   },
@@ -83,6 +93,16 @@ export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
     iosPods: [
       {
         name: "CapacitorPushNotifications",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/share",
+    iosPods: [
+      {
+        name: "CapacitorShare",
         kind: "official",
         spmHandling: "incompatible",
       },

--- a/packages/app-core/scripts/serve-real-local-agent.ts
+++ b/packages/app-core/scripts/serve-real-local-agent.ts
@@ -7,10 +7,17 @@
  * WebView tests reach it through adb reverse as a "remote" first-run target.
  */
 
+import { backgroundUploadImageRoute } from "../../agent/src/api/background-routes.ts";
 import { createDeterministicLlmProxyPlugin } from "../../test/mocks/helpers/llm-proxy-plugin.ts";
 import { startApiServer } from "../src/api/server.ts";
 import { useIsolatedConfigEnv } from "../test/helpers/isolated-config.ts";
 import { createRealTestRuntime } from "../test/helpers/real-runtime.ts";
+
+const deviceE2eUploadImageRoute = {
+  ...backgroundUploadImageRoute,
+  path: "/api/device-e2e/upload-image",
+  name: "device-e2e-upload-image",
+};
 
 function resolvePort(): number {
   const raw = process.env.ELIZA_API_PORT ?? process.env.ELIZA_PORT ?? "31337";
@@ -31,9 +38,14 @@ async function main(): Promise<void> {
   const proxy = createDeterministicLlmProxyPlugin({
     failOnUnhandledAction: false,
   });
+  const mediaRoutesPlugin = {
+    name: "device-e2e-media-routes",
+    description: "No-secret media-store routes for mobile device smokes.",
+    routes: [backgroundUploadImageRoute, deviceE2eUploadImageRoute],
+  };
   const runtimeResult = await createRealTestRuntime({
     characterName: "DeviceE2EHostAgent",
-    plugins: [proxy],
+    plugins: [proxy, mediaRoutesPlugin],
   });
   const server = await startApiServer({
     port,

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -582,6 +582,32 @@ describe("iOS local agent transport bridge", () => {
     expect(originalFetch).not.toHaveBeenCalled();
   });
 
+  it("allows explicit simulator loopback fetches in cloud mode on non-local-agent ports", async () => {
+    vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+    const originalFetch = vi.fn(async () => new Response('{"ready":true}'));
+    vi.stubGlobal("fetch", originalFetch);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "cloud-hybrid" : null,
+    });
+    vi.stubGlobal("window", {
+      __ELIZA_API_BASE__: "https://www.elizacloud.ai",
+      location: { href: "capacitor://localhost/" },
+      navigator: { userAgent: "vitest" },
+    });
+
+    const { installIosLocalAgentFetchBridge } = await import(
+      "./ios-local-agent-transport"
+    );
+    installIosLocalAgentFetchBridge();
+
+    const response = await fetch("http://127.0.0.1:31338/api/health");
+
+    await expect(response.json()).resolves.toEqual({ ready: true });
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+    expect(kernelMock.handleIosLocalAgentRequest).not.toHaveBeenCalled();
+  });
+
   it("allows local-inference IPC in iOS cloud mode", async () => {
     const originalFetch = vi.fn(async () => {
       throw new Error("direct fetch should not run");

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -285,6 +285,23 @@ function normalizeHost(host: string | null | undefined): string {
     .replace(/^\[|\]$/g, "");
 }
 
+function isLoopbackHost(host: string): boolean {
+  const normalized = normalizeHost(host);
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.")
+  );
+}
+
+function allowsIosSimulatorLoopback(url: URL): boolean {
+  return (
+    !isNativeIosStoreBuild() &&
+    isTruthyBuildFlag(viteEnv().VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK) &&
+    isLoopbackHost(url.hostname)
+  );
+}
+
 function isPrivateOrLoopbackHost(host: string): boolean {
   const normalized = normalizeHost(host);
   return (
@@ -402,7 +419,8 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     if (
       usesStrictIosNetworkPolicy() &&
       isCleartextNetworkUrl(parsed) &&
-      isPrivateOrLoopbackHost(parsed.hostname)
+      isPrivateOrLoopbackHost(parsed.hostname) &&
+      !allowsIosSimulatorLoopback(parsed)
     ) {
       return false;
     }
@@ -900,7 +918,8 @@ function shouldBridgeFetchUrl(url: URL): boolean {
   if (
     usesStrictIosNetworkPolicy() &&
     isCleartextNetworkUrl(url) &&
-    (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url.hostname))
+    (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url.hostname)) &&
+    !allowsIosSimulatorLoopback(url)
   ) {
     throw new TypeError(
       "iOS store/cloud builds block cleartext loopback or private-network requests",

--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -75,6 +75,9 @@ describe("compat route auth policy table", () => {
       resolveCompatRouteAuthPolicy("POST", "/api/tts/cloud"),
     ).toMatchObject({ id: "tts.cloud", tier: "session" });
     expect(
+      resolveCompatRouteAuthPolicy("POST", "/api/background/upload-image"),
+    ).toMatchObject({ id: "background.upload-image", tier: "session" });
+    expect(
       resolveCompatRouteAuthPolicy("POST", "/api/tts/elevenlabs"),
     ).toMatchObject({
       id: "tts.elevenlabs-passthrough",
@@ -111,6 +114,7 @@ describe("compat route auth policy table", () => {
     const res = fakeRes();
 
     expect(isCompatManagedRoute("/api/messages")).toBe(false);
+    expect(isCompatManagedRoute("/api/device-e2e/upload-image")).toBe(false);
     await expect(
       enforceCompatRouteAuthPolicy(req, res.res, STATE, "GET", "/api/messages"),
     ).resolves.toBe("unmanaged");

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -134,6 +134,16 @@ export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
     "POST",
     "/api/background/run-due-tasks",
   ),
+  sessionExact(
+    "background.generate-image",
+    "POST",
+    "/api/background/generate-image",
+  ),
+  sessionExact(
+    "background.upload-image",
+    "POST",
+    "/api/background/upload-image",
+  ),
   sessionPrefix("sensitive-requests", "/api/sensitive-requests"),
   sessionPrefix("local-inference", "/api/local-inference/"),
   sessionPrefix("voice.local-inference", "/api/voice/"),

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,6 +53,7 @@
     "test:sim:auth:contract": "node ../../packages/app-core/scripts/mobile-auth-simulator-smoke.mjs --registration-only",
     "test:sim:auth:ios": "node ../../packages/app-core/scripts/mobile-auth-simulator-smoke.mjs --platform ios",
     "capture:ios-sim": "node scripts/capture-ios-sim.mjs",
+    "capture:ios-sim:attachment": "node scripts/ios-attachment-smoke.mjs",
     "capture:android-emu": "node scripts/capture-android-emu.mjs",
     "capture:macos-desktop": "node scripts/capture-macos-desktop.mjs",
     "test:watch": "vitest --config vitest.config.ts",

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // iOS Simulator native attachment smoke for #10936. WKWebView is not
 // CDP-drivable, so this mirrors ios-onboarding-smoke: seed Capacitor
-// Preferences, launch the installed app, connect it to a real local agent via
-// deep link, then let the in-app verifier exercise the media store +
-// Capacitor Filesystem/Share plugins and report back via Preferences.
+// Preferences, launch the installed app, let the in-app onboarding verifier
+// connect it to a real local agent, then let the attachment verifier exercise
+// the media store + Capacitor Filesystem/Share plugins and report back via
+// Preferences.
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -28,7 +29,7 @@ const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31337";
+const DEFAULT_API_BASE = "http://127.0.0.1:31338";
 const PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -430,8 +431,12 @@ async function main() {
     simctl(["launch", udid, appId]);
     await sleep(1500);
     const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
-    log(`opening first-run remote deep link: ${deepLink}`);
-    simctl(["openurl", udid, deepLink]);
+    if (has("--os-deep-link")) {
+      log(`opening first-run remote deep link: ${deepLink}`);
+      simctl(["openurl", udid, deepLink]);
+    } else {
+      log(`armed in-app first-run remote connect for ${apiBase}`);
+    }
     takeScreenshot(udid, "fresh-launch");
     const result = await pollResult(udid, appId);
     const screenshot = takeScreenshot(udid, "attachment-result");

--- a/packages/app/scripts/ios-attachment-smoke.mjs
+++ b/packages/app/scripts/ios-attachment-smoke.mjs
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+// iOS Simulator native attachment smoke for #10936. WKWebView is not
+// CDP-drivable, so this mirrors ios-onboarding-smoke: seed Capacitor
+// Preferences, launch the installed app, connect it to a real local agent via
+// deep link, then let the in-app verifier exercise the media store +
+// Capacitor Filesystem/Share plugins and report back via Preferences.
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  captureIosSimulatorScreenshot,
+  startIosSimulatorVideo,
+} from "./lib/ios-simulator-capture.mjs";
+
+const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const repoRoot = path.resolve(appDir, "..", "..");
+const resultDir = path.join(appDir, "test-results", "ios-attachment-smoke");
+const cleanupHelperScript = path.join(
+  repoRoot,
+  "packages",
+  "scripts",
+  "rm-path-recursive.mjs",
+);
+
+const ONBOARDING_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
+const ONBOARDING_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
+const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
+const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
+const DEFAULT_API_BASE = "http://127.0.0.1:31337";
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+const has = (flag) => process.argv.includes(flag);
+const val = (flag, fallback = null) => {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+};
+const log = (message) => console.log(`[ios-attachment-smoke] ${message}`);
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    stdio: options.stdio ?? "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with ${result.status}`,
+    );
+  }
+  return result.stdout?.trim() ?? "";
+}
+
+function tryRun(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function removePathRecursive(targetPath) {
+  const result = spawnSync(
+    "node",
+    [cleanupHelperScript, path.relative(repoRoot, targetPath)],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `failed to remove ${targetPath}`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readAppIdentity() {
+  const src = fs.readFileSync(path.join(appDir, "app.config.ts"), "utf8");
+  const appId =
+    val("--app-id") ??
+    src.match(/appId:\s*["']([^"']+)["']/)?.[1] ??
+    "ai.elizaos.app";
+  const urlScheme =
+    val("--url-scheme") ??
+    src.match(/urlScheme:\s*["']([^"']+)["']/)?.[1] ??
+    "elizaos";
+  return { appId, urlScheme };
+}
+
+function simctl(args) {
+  return run("xcrun", ["simctl", ...args], { stdio: "pipe" });
+}
+
+function bootedUdid() {
+  const json = tryRun("xcrun", [
+    "simctl",
+    "list",
+    "devices",
+    "booted",
+    "--json",
+  ]);
+  if (!json) return null;
+  const parsed = JSON.parse(json);
+  for (const devices of Object.values(parsed.devices ?? {})) {
+    const booted = devices.find((device) => device.state === "Booted");
+    if (booted?.udid) return booted.udid;
+  }
+  return null;
+}
+
+function ensureSimulatorBooted() {
+  if (process.platform !== "darwin") {
+    throw new Error("iOS attachment smoke requires macOS with xcrun simctl.");
+  }
+  const existing = bootedUdid();
+  if (existing) {
+    log(`reusing booted simulator ${existing}`);
+    return existing;
+  }
+  const target = val("--device", "iPhone 16 Pro");
+  log(`booting simulator ${target}`);
+  simctl(["boot", target]);
+  tryRun("open", ["-a", "Simulator"]);
+  const udid = bootedUdid();
+  if (!udid) throw new Error(`Simulator ${target} did not reach Booted state.`);
+  return udid;
+}
+
+function latestBuiltApp() {
+  const derivedData = path.join(
+    os.homedir(),
+    "Library",
+    "Developer",
+    "Xcode",
+    "DerivedData",
+  );
+  if (!fs.existsSync(derivedData)) return null;
+  const output = tryRun("find", [
+    derivedData,
+    "-name",
+    "App.app",
+    "-path",
+    "*/Debug-iphonesimulator/*",
+    "-type",
+    "d",
+  ]);
+  const apps = (output ?? "")
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => ({ path: entry, mtimeMs: fs.statSync(entry).mtimeMs }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return apps[0]?.path ?? null;
+}
+
+function installLatestApp(udid, appId) {
+  if (has("--skip-install")) return;
+  const appPath = val("--app-path") ?? latestBuiltApp();
+  if (!appPath) {
+    throw new Error(
+      "Could not find a Debug-iphonesimulator App.app. Build the iOS simulator app first or pass --app-path.",
+    );
+  }
+  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+  tryRun("xcrun", ["simctl", "uninstall", udid, appId]);
+  log(`installing ${appPath}`);
+  simctl(["install", udid, appPath]);
+  const installed = tryRun("xcrun", [
+    "simctl",
+    "get_app_container",
+    udid,
+    appId,
+    "app",
+  ]);
+  if (!installed) {
+    throw new Error(`${appId} was not installed after simctl install.`);
+  }
+}
+
+function prefsDomainPath(udid, appId) {
+  const container = tryRun("xcrun", [
+    "simctl",
+    "get_app_container",
+    udid,
+    appId,
+    "data",
+  ]);
+  if (!container) return null;
+  return path.join(container, "Library", "Preferences", appId);
+}
+
+function preferenceNativeKeys(key) {
+  return [`CapacitorStorage.${key}`, key];
+}
+
+function defaultsDelete(udid, appId, key) {
+  for (const nativeKey of preferenceNativeKeys(key)) {
+    tryRun("xcrun", [
+      "simctl",
+      "spawn",
+      udid,
+      "defaults",
+      "delete",
+      appId,
+      nativeKey,
+    ]);
+  }
+
+  const domainPath = prefsDomainPath(udid, appId);
+  if (domainPath) {
+    for (const nativeKey of preferenceNativeKeys(key)) {
+      tryRun("defaults", ["delete", domainPath, nativeKey]);
+    }
+  }
+}
+
+function defaultsWriteString(udid, appId, key, value) {
+  for (const [index, nativeKey] of preferenceNativeKeys(key).entries()) {
+    const args = [
+      "simctl",
+      "spawn",
+      udid,
+      "defaults",
+      "write",
+      appId,
+      nativeKey,
+      "-string",
+      value,
+    ];
+    if (index === 0) run("xcrun", args, { stdio: "ignore" });
+    else tryRun("xcrun", args);
+  }
+}
+
+function defaultsReadString(udid, appId, key) {
+  const domainPath = prefsDomainPath(udid, appId);
+  if (domainPath) {
+    const plist = `${domainPath}.plist`;
+    if (fs.existsSync(plist)) {
+      const json = tryRun("plutil", ["-convert", "json", "-o", "-", plist]);
+      if (json) {
+        try {
+          const parsed = JSON.parse(json);
+          for (const nativeKey of preferenceNativeKeys(key)) {
+            if (typeof parsed[nativeKey] === "string") return parsed[nativeKey];
+          }
+        } catch {
+          // Fall through.
+        }
+      }
+    }
+    for (const nativeKey of preferenceNativeKeys(key)) {
+      const value = tryRun("defaults", ["read", domainPath, nativeKey]);
+      if (value !== null) return value;
+    }
+  }
+
+  for (const nativeKey of preferenceNativeKeys(key)) {
+    const value = tryRun("xcrun", [
+      "simctl",
+      "spawn",
+      udid,
+      "defaults",
+      "read",
+      appId,
+      nativeKey,
+    ]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function flushPreferences(udid) {
+  tryRun("xcrun", ["simctl", "spawn", udid, "killall", "cfprefsd"]);
+}
+
+function clearState(udid, appId) {
+  for (const key of [
+    ONBOARDING_REQUEST_KEY,
+    ONBOARDING_RESULT_KEY,
+    ATTACHMENT_REQUEST_KEY,
+    ATTACHMENT_RESULT_KEY,
+    "elizaos:active-server",
+    "eliza:first-run-complete",
+    "eliza:setup:step",
+    "eliza:onboarding-complete",
+    "eliza:mobile-runtime-mode",
+    "eliza.background.config",
+    "elizaos:first-run:force-fresh",
+  ]) {
+    defaultsDelete(udid, appId, key);
+  }
+}
+
+function takeScreenshot(udid, label) {
+  try {
+    return captureIosSimulatorScreenshot({
+      target: udid,
+      artifactDir: resultDir,
+      filename: `${label}.png`,
+      log,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function startVideo(udid) {
+  if (has("--no-video")) return null;
+  return startIosSimulatorVideo({
+    target: udid,
+    artifactDir: resultDir,
+    filename: "attachment-smoke.mp4",
+    log,
+  });
+}
+
+async function stopVideo(recording) {
+  if (!recording) return null;
+  return recording.stop();
+}
+
+async function pollResult(udid, appId) {
+  const attempts = Number.parseInt(
+    process.env.IOS_ATTACHMENT_SMOKE_ATTEMPTS ?? "210",
+    10,
+  );
+  const delayMs = Number.parseInt(
+    process.env.IOS_ATTACHMENT_SMOKE_DELAY_MS ?? "1000",
+    10,
+  );
+  let lastRaw = "";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lastRaw = defaultsReadString(udid, appId, ATTACHMENT_RESULT_KEY) ?? "";
+    if (lastRaw) {
+      let parsed = null;
+      try {
+        parsed = JSON.parse(lastRaw);
+      } catch {
+        parsed = null;
+      }
+      if (parsed?.ok === true) return parsed;
+      if (parsed?.phase === "failed" || parsed?.error) {
+        throw new Error(`iOS attachment smoke failed: ${lastRaw}`);
+      }
+      if (attempt % 15 === 0) {
+        log(`still running (${attempt}/${attempts}): ${lastRaw}`);
+      }
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(
+    `iOS attachment smoke timed out after ${attempts} attempts. Last result: ${lastRaw || "<none>"}`,
+  );
+}
+
+async function main() {
+  const { appId, urlScheme } = readAppIdentity();
+  const apiBase = val("--api-base", DEFAULT_API_BASE);
+  const filename = val("--filename", "eliza-ios-attachment-smoke.png");
+  const udid = ensureSimulatorBooted();
+  removePathRecursive(resultDir);
+  fs.mkdirSync(resultDir, { recursive: true });
+
+  installLatestApp(udid, appId);
+  tryRun("xcrun", ["simctl", "terminate", udid, appId]);
+  clearState(udid, appId);
+  defaultsWriteString(
+    udid,
+    appId,
+    ONBOARDING_REQUEST_KEY,
+    JSON.stringify({ apiBase }),
+  );
+  defaultsWriteString(
+    udid,
+    appId,
+    ONBOARDING_RESULT_KEY,
+    JSON.stringify({
+      ok: false,
+      phase: "requested",
+      apiBase,
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  defaultsWriteString(
+    udid,
+    appId,
+    ATTACHMENT_REQUEST_KEY,
+    JSON.stringify({
+      apiBase,
+      filename,
+      dataUrl: `data:image/png;base64,${PNG_BASE64}`,
+    }),
+  );
+  defaultsWriteString(
+    udid,
+    appId,
+    ATTACHMENT_RESULT_KEY,
+    JSON.stringify({
+      ok: false,
+      phase: "requested",
+      apiBase,
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  flushPreferences(udid);
+
+  const recording = startVideo(udid);
+  try {
+    log(`launching ${appId} on ${udid}`);
+    simctl(["launch", udid, appId]);
+    await sleep(1500);
+    const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
+    log(`opening first-run remote deep link: ${deepLink}`);
+    simctl(["openurl", udid, deepLink]);
+    takeScreenshot(udid, "fresh-launch");
+    const result = await pollResult(udid, appId);
+    const screenshot = takeScreenshot(udid, "attachment-result");
+    const video = await stopVideo(recording);
+    fs.writeFileSync(
+      path.join(resultDir, "result.json"),
+      `${JSON.stringify({ ...result, screenshot, video }, null, 2)}\n`,
+    );
+    log(`PASS ${JSON.stringify({ screenshot, video })}`);
+  } catch (error) {
+    const screenshot = takeScreenshot(udid, "failure");
+    await stopVideo(recording);
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}${screenshot ? ` (screenshot: ${screenshot})` : ""}`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 // iOS Simulator first-run REMOTE-CONNECT smoke. WKWebView is not CDP-drivable
-// like Android, so the harness writes a Capacitor Preferences request (which
-// arms the in-app verifier), launches the installed app, then fires the real
-// `<scheme>://first-run/runtime/remote?api=<url>` deep link via `simctl
-// openurl`. The app connects to the remote + completes first-run on its own;
-// the in-app verifier proves it landed on home and reports back via Preferences.
-// No onboarding DOM is driven, so the lane survives the in-chat redesign.
+// like Android, so the harness writes a Capacitor Preferences request, launches
+// the installed app, and lets the in-app verifier drive the same hardened
+// first-run remote-connect handler used by the OS deep-link path. The verifier
+// proves the app landed on home and reports back via Preferences. No onboarding
+// DOM is driven, so the lane survives the in-chat redesign.
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -27,7 +26,9 @@ const cleanupHelperScript = path.join(
 );
 const REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const RESULT_KEY = "eliza:ios-onboarding-smoke:result";
-const DEFAULT_API_BASE = "http://127.0.0.1:31337";
+const ATTACHMENT_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
+const ATTACHMENT_RESULT_KEY = "eliza:ios-attachment-smoke:result";
+const DEFAULT_API_BASE = "http://127.0.0.1:31338";
 
 const has = (flag) => process.argv.includes(flag);
 const val = (flag, fallback = null) => {
@@ -303,6 +304,8 @@ function clearFirstRunState(udid, appId) {
   for (const key of [
     REQUEST_KEY,
     RESULT_KEY,
+    ATTACHMENT_REQUEST_KEY,
+    ATTACHMENT_RESULT_KEY,
     "elizaos:active-server",
     "eliza:first-run-complete",
     "eliza:setup:step",
@@ -406,12 +409,13 @@ async function main() {
     log(`launching ${appId} on ${udid}`);
     simctl(["launch", udid, appId]);
     await sleep(1500);
-    // Fire the real OS deep link that carries the remote agent URL. The app's
-    // CONNECT_EVENT path connects + completes first-run; the in-app verifier
-    // (runIosOnboardingSmokeIfRequested) then proves it landed on home.
     const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
-    log(`opening first-run remote deep link: ${deepLink}`);
-    simctl(["openurl", udid, deepLink]);
+    if (has("--os-deep-link")) {
+      log(`opening first-run remote deep link: ${deepLink}`);
+      simctl(["openurl", udid, deepLink]);
+    } else {
+      log(`armed in-app first-run remote connect for ${apiBase}`);
+    }
     takeScreenshot(udid, "fresh-onboarding");
     const result = await pollResult(udid, appId);
     const screenshot = takeScreenshot(udid, "home-landing");

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -1,6 +1,11 @@
+import { Filesystem } from "@capacitor/filesystem";
+import { Share } from "@capacitor/share";
+
 const IOS_ATTACHMENT_SMOKE_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
 const IOS_ATTACHMENT_SMOKE_RESULT_KEY = "eliza:ios-attachment-smoke:result";
+const IOS_ONBOARDING_SMOKE_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
 const IOS_ATTACHMENT_SMOKE_TIMEOUT_MS = 180_000;
+const IOS_ATTACHMENT_OPERATION_TIMEOUT_MS = 15_000;
 const IOS_ATTACHMENT_SMOKE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -54,7 +59,7 @@ function parseIosAttachmentSmokeRequest(
   raw: string | null,
 ): IosAttachmentSmokeRequest {
   const fallback = {
-    apiBase: "http://127.0.0.1:31337",
+    apiBase: "http://127.0.0.1:31338",
     filename: "eliza-ios-attachment-smoke.png",
     dataUrl: `data:image/png;base64,${IOS_ATTACHMENT_SMOKE_PNG_BASE64}`,
   };
@@ -126,24 +131,14 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 function readCapacitorFilesystemForSmoke():
   | CapacitorFilesystemSmokeLike
   | undefined {
-  const cap = (globalThis as { Capacitor?: unknown }).Capacitor;
-  if (!cap || typeof cap !== "object") return undefined;
-  const plugins = (cap as { Plugins?: Record<string, unknown> }).Plugins;
-  const fs = plugins?.Filesystem;
-  if (!fs || typeof fs !== "object") return undefined;
-  return typeof (fs as CapacitorFilesystemSmokeLike).writeFile === "function"
-    ? (fs as CapacitorFilesystemSmokeLike)
+  return typeof Filesystem?.writeFile === "function"
+    ? (Filesystem as CapacitorFilesystemSmokeLike)
     : undefined;
 }
 
 function readCapacitorShareForSmoke(): CapacitorShareSmokeLike | undefined {
-  const cap = (globalThis as { Capacitor?: unknown }).Capacitor;
-  if (!cap || typeof cap !== "object") return undefined;
-  const plugins = (cap as { Plugins?: Record<string, unknown> }).Plugins;
-  const share = plugins?.Share;
-  if (!share || typeof share !== "object") return undefined;
-  return typeof (share as CapacitorShareSmokeLike).share === "function"
-    ? (share as CapacitorShareSmokeLike)
+  return typeof Share?.share === "function"
+    ? (Share as CapacitorShareSmokeLike)
     : undefined;
 }
 
@@ -158,7 +153,7 @@ function resolveIosAttachmentSmokeApiUrl(
     // Relative API paths inside a Capacitor WKWebView resolve to the app origin,
     // so use the same configured agent base as the rest of the UI client.
   }
-  const base = (getApiBaseUrl() || fallbackBase).replace(/\/+$/, "");
+  const base = (fallbackBase.trim() || getApiBaseUrl()).replace(/\/+$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return base ? `${base}${normalizedPath}` : normalizedPath;
 }
@@ -170,13 +165,110 @@ async function writeAttachmentResult(
   await writeResult(IOS_ATTACHMENT_SMOKE_RESULT_KEY, result);
 }
 
+async function writeAttachmentPhase(
+  writeResult: RunIosAttachmentSmokeOptions["writeResult"],
+  request: IosAttachmentSmokeRequest,
+  phase: string,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  await writeAttachmentResult(writeResult, {
+    ok: false,
+    phase,
+    updatedAt: new Date().toISOString(),
+    apiBase: request.apiBase,
+    ...extra,
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+async function withTimeout<T>(
+  label: string,
+  promise: Promise<T>,
+  timeoutMs = IOS_ATTACHMENT_OPERATION_TIMEOUT_MS,
+): Promise<T> {
+  let timeoutId: number | null = null;
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = window.setTimeout(
+        () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId !== null) window.clearTimeout(timeoutId);
+  }
+}
+
+async function readSmokePreference(
+  key: string,
+  getPreference: RunIosAttachmentSmokeOptions["getPreference"],
+): Promise<string | null> {
+  const preferenceValue = await getPreference(key);
+  if (preferenceValue) return preferenceValue;
+  try {
+    const value = window.localStorage.getItem(key);
+    if (value) return value;
+  } catch {
+    // Preferences is the authoritative native store for the simulator harness.
+  }
+  return null;
+}
+
+async function waitForOnboardingSmokeResultIfPresent(
+  getPreference: RunIosAttachmentSmokeOptions["getPreference"],
+): Promise<void> {
+  const initial = await readSmokePreference(
+    IOS_ONBOARDING_SMOKE_RESULT_KEY,
+    getPreference,
+  );
+  if (!initial) {
+    await sleep(750);
+    return;
+  }
+
+  const deadline = Date.now() + IOS_ATTACHMENT_SMOKE_TIMEOUT_MS;
+  let lastRaw = initial;
+  while (Date.now() < deadline) {
+    const raw =
+      (await readSmokePreference(
+        IOS_ONBOARDING_SMOKE_RESULT_KEY,
+        getPreference,
+      )) ?? lastRaw;
+    lastRaw = raw;
+    try {
+      const parsed = JSON.parse(raw) as {
+        ok?: unknown;
+        phase?: unknown;
+        error?: unknown;
+      };
+      if (parsed.ok === true || parsed.phase === "complete") return;
+      if (parsed.phase === "failed" || parsed.error) {
+        throw new Error(
+          `iOS onboarding smoke failed before attachment: ${raw}`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("failed")) {
+        throw error;
+      }
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `Timed out waiting for iOS onboarding smoke before attachment. Last result: ${lastRaw}`,
+  );
+}
+
 export async function runIosAttachmentSmokeIfRequested({
   isIOS,
   getApiBaseUrl,
   getPreference,
   removePreference,
   writeResult,
-  waitForElement,
   readStorageSnapshot,
 }: RunIosAttachmentSmokeOptions): Promise<boolean> {
   if (!isIOS || iosAttachmentSmokeStarted) return iosAttachmentSmokeStarted;
@@ -201,30 +293,37 @@ export async function runIosAttachmentSmokeIfRequested({
   });
 
   try {
-    await waitForElement<HTMLElement>(
-      '[data-testid="home-launcher-surface"][data-page="home"]',
-      { visible: true, timeoutMs: IOS_ATTACHMENT_SMOKE_TIMEOUT_MS },
-    );
+    await waitForOnboardingSmokeResultIfPresent(getPreference);
 
     const sourceBytes = bytesFromBase64(request.dataUrl.split(",")[1] ?? "");
     const expectedSha256 = await sha256Hex(sourceBytes);
     const uploadUrl = resolveIosAttachmentSmokeApiUrl(
-      "/api/background/upload-image",
+      "/api/device-e2e/upload-image",
       request.apiBase,
       getApiBaseUrl,
     );
-    const upload = await fetch(uploadUrl, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ dataUrl: request.dataUrl }),
+    await writeAttachmentPhase(writeResult, request, "uploading-media", {
+      uploadUrl,
     });
-    const uploadText = await upload.text();
+    const upload = await withTimeout(
+      "image upload fetch",
+      fetch(uploadUrl, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ dataUrl: request.dataUrl }),
+      }),
+    );
+    const uploadText = await withTimeout(
+      "image upload response body",
+      upload.text(),
+      5_000,
+    );
     if (!upload.ok) {
       throw new Error(
-        `/api/background/upload-image returned HTTP ${upload.status}: ${uploadText.slice(0, 500)}`,
+        `/api/device-e2e/upload-image returned HTTP ${upload.status}: ${uploadText.slice(0, 500)}`,
       );
     }
     const uploadJson = JSON.parse(uploadText) as { url?: unknown };
@@ -243,13 +342,22 @@ export async function runIosAttachmentSmokeIfRequested({
       request.apiBase,
       getApiBaseUrl,
     );
-    const mediaResponse = await fetch(mediaFetchUrl);
+    await writeAttachmentPhase(writeResult, request, "fetching-media", {
+      mediaUrl,
+      mediaFetchUrl,
+    });
+    const mediaResponse = await withTimeout(
+      "media fetch",
+      fetch(mediaFetchUrl),
+    );
     if (!mediaResponse.ok) {
       throw new Error(
         `media fetch returned HTTP ${mediaResponse.status} for ${mediaFetchUrl}`,
       );
     }
-    const servedBytes = new Uint8Array(await mediaResponse.arrayBuffer());
+    const servedBytes = new Uint8Array(
+      await withTimeout("media response body", mediaResponse.arrayBuffer()),
+    );
     const servedSha256 = await sha256Hex(servedBytes);
     if (servedSha256 !== expectedSha256) {
       throw new Error(
@@ -257,6 +365,7 @@ export async function runIosAttachmentSmokeIfRequested({
       );
     }
 
+    await writeAttachmentPhase(writeResult, request, "loading-native-plugins");
     const filesystem = readCapacitorFilesystemForSmoke();
     const share = readCapacitorShareForSmoke();
     if (!filesystem) {
@@ -266,16 +375,24 @@ export async function runIosAttachmentSmokeIfRequested({
       throw new Error("Capacitor Share plugin is unavailable");
     }
 
-    const written = await filesystem.writeFile({
-      path: request.filename,
-      data: base64FromBytes(servedBytes),
-      directory: "CACHE",
-    });
+    await writeAttachmentPhase(writeResult, request, "writing-filesystem");
+    const written = await withTimeout(
+      "Filesystem.writeFile",
+      filesystem.writeFile({
+        path: request.filename,
+        data: base64FromBytes(servedBytes),
+        directory: "CACHE",
+      }),
+    );
+    await writeAttachmentPhase(writeResult, request, "reading-filesystem");
     const readBack = filesystem.readFile
-      ? await filesystem.readFile({
-          path: request.filename,
-          directory: "CACHE",
-        })
+      ? await withTimeout(
+          "Filesystem.readFile",
+          filesystem.readFile({
+            path: request.filename,
+            directory: "CACHE",
+          }),
+        )
       : undefined;
     const readBackBytes = await bytesFromFilesystemReadData(readBack?.data);
     const readBackSha256 = await sha256Hex(readBackBytes);
@@ -289,16 +406,22 @@ export async function runIosAttachmentSmokeIfRequested({
       written?.uri ??
       (filesystem.getUri
         ? (
-            await filesystem.getUri({
-              path: request.filename,
-              directory: "CACHE",
-            })
+            await withTimeout(
+              "Filesystem.getUri",
+              filesystem.getUri({
+                path: request.filename,
+                directory: "CACHE",
+              }),
+            )
           )?.uri
         : undefined);
     if (!uri) {
       throw new Error("Filesystem did not return a file URI");
     }
 
+    await writeAttachmentPhase(writeResult, request, "sharing-file", {
+      fileUri: uri,
+    });
     let shareOutcome: Record<string, unknown> = { attempted: true };
     try {
       await Promise.race([
@@ -344,6 +467,8 @@ export async function runIosAttachmentSmokeIfRequested({
       share: shareOutcome,
     });
   } catch (error) {
+    const filesystem = readCapacitorFilesystemForSmoke();
+    const share = readCapacitorShareForSmoke();
     await writeAttachmentResult(writeResult, {
       ok: false,
       phase: "failed",
@@ -352,8 +477,8 @@ export async function runIosAttachmentSmokeIfRequested({
       error: error instanceof Error ? error.message : String(error),
       storage: readStorageSnapshot(),
       plugins: {
-        filesystem: Boolean(readCapacitorFilesystemForSmoke()),
-        share: Boolean(readCapacitorShareForSmoke()),
+        filesystem: Boolean(filesystem),
+        share: Boolean(share),
       },
     });
   } finally {

--- a/packages/app/src/ios-attachment-smoke.ts
+++ b/packages/app/src/ios-attachment-smoke.ts
@@ -1,0 +1,368 @@
+const IOS_ATTACHMENT_SMOKE_REQUEST_KEY = "eliza:ios-attachment-smoke:request";
+const IOS_ATTACHMENT_SMOKE_RESULT_KEY = "eliza:ios-attachment-smoke:result";
+const IOS_ATTACHMENT_SMOKE_TIMEOUT_MS = 180_000;
+const IOS_ATTACHMENT_SMOKE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+interface IosAttachmentSmokeRequest {
+  apiBase: string;
+  filename: string;
+  dataUrl: string;
+}
+
+interface CapacitorFilesystemSmokeLike {
+  writeFile(options: {
+    path: string;
+    data: string;
+    directory?: string;
+  }): Promise<{ uri?: string }>;
+  readFile?(options: {
+    path: string;
+    directory?: string;
+  }): Promise<{ data?: string | Blob }>;
+  getUri?(options: {
+    path: string;
+    directory?: string;
+  }): Promise<{ uri?: string }>;
+}
+
+interface CapacitorShareSmokeLike {
+  share(options: {
+    url?: string;
+    title?: string;
+    text?: string;
+    files?: string[];
+  }): Promise<unknown>;
+}
+
+interface RunIosAttachmentSmokeOptions {
+  isIOS: boolean;
+  getApiBaseUrl: () => string;
+  getPreference: (key: string) => Promise<string | null>;
+  removePreference: (key: string) => Promise<void>;
+  writeResult: (key: string, result: Record<string, unknown>) => Promise<void>;
+  waitForElement: <T extends Element>(
+    selector: string,
+    options?: { timeoutMs?: number; visible?: boolean },
+  ) => Promise<T>;
+  readStorageSnapshot: () => Record<string, string | null>;
+}
+
+let iosAttachmentSmokeStarted = false;
+
+function parseIosAttachmentSmokeRequest(
+  raw: string | null,
+): IosAttachmentSmokeRequest {
+  const fallback = {
+    apiBase: "http://127.0.0.1:31337",
+    filename: "eliza-ios-attachment-smoke.png",
+    dataUrl: `data:image/png;base64,${IOS_ATTACHMENT_SMOKE_PNG_BASE64}`,
+  };
+  if (!raw || raw === "1") return fallback;
+  try {
+    const parsed = JSON.parse(raw) as {
+      apiBase?: unknown;
+      filename?: unknown;
+      dataUrl?: unknown;
+    };
+    return {
+      apiBase:
+        typeof parsed.apiBase === "string" && parsed.apiBase.trim()
+          ? parsed.apiBase.trim()
+          : fallback.apiBase,
+      filename:
+        typeof parsed.filename === "string" && parsed.filename.trim()
+          ? parsed.filename.trim()
+          : fallback.filename,
+      dataUrl:
+        typeof parsed.dataUrl === "string" &&
+        parsed.dataUrl.startsWith("data:image/")
+          ? parsed.dataUrl
+          : fallback.dataUrl,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function bytesFromBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+function base64FromBytes(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+async function bytesFromFilesystemReadData(
+  data: string | Blob | undefined,
+): Promise<Uint8Array> {
+  if (typeof data === "string") return bytesFromBase64(data);
+  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+  throw new Error("Filesystem.readFile returned no data");
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    copy.buffer as ArrayBuffer,
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function readCapacitorFilesystemForSmoke():
+  | CapacitorFilesystemSmokeLike
+  | undefined {
+  const cap = (globalThis as { Capacitor?: unknown }).Capacitor;
+  if (!cap || typeof cap !== "object") return undefined;
+  const plugins = (cap as { Plugins?: Record<string, unknown> }).Plugins;
+  const fs = plugins?.Filesystem;
+  if (!fs || typeof fs !== "object") return undefined;
+  return typeof (fs as CapacitorFilesystemSmokeLike).writeFile === "function"
+    ? (fs as CapacitorFilesystemSmokeLike)
+    : undefined;
+}
+
+function readCapacitorShareForSmoke(): CapacitorShareSmokeLike | undefined {
+  const cap = (globalThis as { Capacitor?: unknown }).Capacitor;
+  if (!cap || typeof cap !== "object") return undefined;
+  const plugins = (cap as { Plugins?: Record<string, unknown> }).Plugins;
+  const share = plugins?.Share;
+  if (!share || typeof share !== "object") return undefined;
+  return typeof (share as CapacitorShareSmokeLike).share === "function"
+    ? (share as CapacitorShareSmokeLike)
+    : undefined;
+}
+
+function resolveIosAttachmentSmokeApiUrl(
+  path: string,
+  fallbackBase: string,
+  getApiBaseUrl: () => string,
+): string {
+  try {
+    return new URL(path).toString();
+  } catch {
+    // Relative API paths inside a Capacitor WKWebView resolve to the app origin,
+    // so use the same configured agent base as the rest of the UI client.
+  }
+  const base = (getApiBaseUrl() || fallbackBase).replace(/\/+$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return base ? `${base}${normalizedPath}` : normalizedPath;
+}
+
+async function writeAttachmentResult(
+  writeResult: RunIosAttachmentSmokeOptions["writeResult"],
+  result: Record<string, unknown>,
+): Promise<void> {
+  await writeResult(IOS_ATTACHMENT_SMOKE_RESULT_KEY, result);
+}
+
+export async function runIosAttachmentSmokeIfRequested({
+  isIOS,
+  getApiBaseUrl,
+  getPreference,
+  removePreference,
+  writeResult,
+  waitForElement,
+  readStorageSnapshot,
+}: RunIosAttachmentSmokeOptions): Promise<boolean> {
+  if (!isIOS || iosAttachmentSmokeStarted) return iosAttachmentSmokeStarted;
+  let rawRequest: string | null = null;
+  try {
+    rawRequest = window.localStorage.getItem(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
+  } catch {
+    rawRequest = null;
+  }
+  if (!rawRequest) {
+    rawRequest = await getPreference(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
+  }
+  if (!rawRequest) return false;
+
+  iosAttachmentSmokeStarted = true;
+  const request = parseIosAttachmentSmokeRequest(rawRequest);
+  await writeAttachmentResult(writeResult, {
+    ok: false,
+    phase: "running",
+    startedAt: new Date().toISOString(),
+    apiBase: request.apiBase,
+  });
+
+  try {
+    await waitForElement<HTMLElement>(
+      '[data-testid="home-launcher-surface"][data-page="home"]',
+      { visible: true, timeoutMs: IOS_ATTACHMENT_SMOKE_TIMEOUT_MS },
+    );
+
+    const sourceBytes = bytesFromBase64(request.dataUrl.split(",")[1] ?? "");
+    const expectedSha256 = await sha256Hex(sourceBytes);
+    const uploadUrl = resolveIosAttachmentSmokeApiUrl(
+      "/api/background/upload-image",
+      request.apiBase,
+      getApiBaseUrl,
+    );
+    const upload = await fetch(uploadUrl, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ dataUrl: request.dataUrl }),
+    });
+    const uploadText = await upload.text();
+    if (!upload.ok) {
+      throw new Error(
+        `/api/background/upload-image returned HTTP ${upload.status}: ${uploadText.slice(0, 500)}`,
+      );
+    }
+    const uploadJson = JSON.parse(uploadText) as { url?: unknown };
+    const mediaUrl = typeof uploadJson.url === "string" ? uploadJson.url : "";
+    if (!/^\/api\/media\/[a-f0-9]{64}\.png$/.test(mediaUrl)) {
+      throw new Error(`Upload returned non media-store URL: ${mediaUrl}`);
+    }
+    if (!mediaUrl.includes(expectedSha256)) {
+      throw new Error(
+        `Media URL hash mismatch: expected ${expectedSha256}, got ${mediaUrl}`,
+      );
+    }
+
+    const mediaFetchUrl = resolveIosAttachmentSmokeApiUrl(
+      mediaUrl,
+      request.apiBase,
+      getApiBaseUrl,
+    );
+    const mediaResponse = await fetch(mediaFetchUrl);
+    if (!mediaResponse.ok) {
+      throw new Error(
+        `media fetch returned HTTP ${mediaResponse.status} for ${mediaFetchUrl}`,
+      );
+    }
+    const servedBytes = new Uint8Array(await mediaResponse.arrayBuffer());
+    const servedSha256 = await sha256Hex(servedBytes);
+    if (servedSha256 !== expectedSha256) {
+      throw new Error(
+        `served sha256 mismatch: expected ${expectedSha256}, got ${servedSha256}`,
+      );
+    }
+
+    const filesystem = readCapacitorFilesystemForSmoke();
+    const share = readCapacitorShareForSmoke();
+    if (!filesystem) {
+      throw new Error("Capacitor Filesystem plugin is unavailable");
+    }
+    if (!share) {
+      throw new Error("Capacitor Share plugin is unavailable");
+    }
+
+    const written = await filesystem.writeFile({
+      path: request.filename,
+      data: base64FromBytes(servedBytes),
+      directory: "CACHE",
+    });
+    const readBack = filesystem.readFile
+      ? await filesystem.readFile({
+          path: request.filename,
+          directory: "CACHE",
+        })
+      : undefined;
+    const readBackBytes = await bytesFromFilesystemReadData(readBack?.data);
+    const readBackSha256 = await sha256Hex(readBackBytes);
+    if (readBackSha256 !== expectedSha256) {
+      throw new Error(
+        `Filesystem read-back sha256 mismatch: expected ${expectedSha256}, got ${readBackSha256}`,
+      );
+    }
+
+    const uri =
+      written?.uri ??
+      (filesystem.getUri
+        ? (
+            await filesystem.getUri({
+              path: request.filename,
+              directory: "CACHE",
+            })
+          )?.uri
+        : undefined);
+    if (!uri) {
+      throw new Error("Filesystem did not return a file URI");
+    }
+
+    let shareOutcome: Record<string, unknown> = { attempted: true };
+    try {
+      await Promise.race([
+        share.share({
+          url: uri,
+          title: request.filename,
+          files: [uri],
+        }),
+        new Promise<"timeout">((resolve) =>
+          window.setTimeout(() => resolve("timeout"), 8_000),
+        ),
+      ]).then((result) => {
+        shareOutcome =
+          result === "timeout"
+            ? { attempted: true, timedOutWithSheetLikelyOpen: true }
+            : { attempted: true, settled: true };
+      });
+    } catch (error) {
+      shareOutcome = {
+        attempted: true,
+        rejected: true,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    await writeAttachmentResult(writeResult, {
+      ok: true,
+      phase: "complete",
+      finishedAt: new Date().toISOString(),
+      apiBase: request.apiBase,
+      mediaUrl,
+      mediaFetchUrl,
+      expectedSha256,
+      servedSha256,
+      readBackSha256,
+      byteLength: servedBytes.byteLength,
+      fileUri: uri,
+      plugins: {
+        filesystem: true,
+        filesystemReadFile: typeof filesystem.readFile === "function",
+        share: true,
+      },
+      share: shareOutcome,
+    });
+  } catch (error) {
+    await writeAttachmentResult(writeResult, {
+      ok: false,
+      phase: "failed",
+      finishedAt: new Date().toISOString(),
+      apiBase: request.apiBase,
+      error: error instanceof Error ? error.message : String(error),
+      storage: readStorageSnapshot(),
+      plugins: {
+        filesystem: Boolean(readCapacitorFilesystemForSmoke()),
+        share: Boolean(readCapacitorShareForSmoke()),
+      },
+    });
+  } finally {
+    try {
+      window.localStorage.removeItem(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
+    } catch {
+      // Preferences removal below is authoritative for the simulator harness.
+    }
+    await removePreference(IOS_ATTACHMENT_SMOKE_REQUEST_KEY);
+  }
+  return true;
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -136,12 +136,12 @@ import { renderBootFailure } from "./boot-failure";
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
-import { decideChatOverlayToggle } from "./desktop-hotkey";
 import {
   buildAssistantLaunchHashRoute,
   type DeepLinkNavigationIntent,
   resolveDeepLinkNavigationIntent,
 } from "./deep-link-routing";
+import { decideChatOverlayToggle } from "./desktop-hotkey";
 import { runEmbedHandshake } from "./embed-bootstrap";
 import { registerAppHostExternalImporters } from "./host-externals";
 import { runIosAttachmentSmokeIfRequested } from "./ios-attachment-smoke";
@@ -715,7 +715,7 @@ function renderIosFullBunSmokeStatus(message: string): void {
 function parseIosOnboardingSmokeRequest(raw: string | null): {
   apiBase: string;
 } {
-  const fallback = { apiBase: "http://127.0.0.1:31337" };
+  const fallback = { apiBase: "http://127.0.0.1:31338" };
   if (!raw || raw === "1") return fallback;
   try {
     const parsed = JSON.parse(raw) as { apiBase?: unknown };
@@ -774,6 +774,24 @@ function readIosOnboardingSmokeStorageSnapshot(): Record<
   );
 }
 
+async function waitForIosOnboardingSmokeStorageSnapshot(
+  apiBase: string,
+): Promise<Record<string, string | null>> {
+  const deadline = Date.now() + IOS_ONBOARDING_SMOKE_TIMEOUT_MS;
+  let snapshot = readIosOnboardingSmokeStorageSnapshot();
+  while (Date.now() < deadline) {
+    const activeServer = snapshot["elizaos:active-server"];
+    if (typeof activeServer === "string" && activeServer.includes(apiBase)) {
+      return snapshot;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    snapshot = readIosOnboardingSmokeStorageSnapshot();
+  }
+  throw new Error(
+    `Timed out waiting for iOS onboarding active server ${apiBase}: ${JSON.stringify(snapshot)}`,
+  );
+}
+
 async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
   if (!isIOS || iosOnboardingSmokeStarted) return iosOnboardingSmokeStarted;
   let rawRequest: string | null = null;
@@ -796,11 +814,15 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
     apiBase: request.apiBase,
   });
   try {
-    // The harness fires the `<scheme>://first-run/runtime/remote?api=…` deep
-    // link after launch; the app connects to the remote and completes first-run
-    // on its own (CONNECT_EVENT → adopt → startup re-poll). This verifier only
-    // proves the post-connect surface, so it is decoupled from the onboarding
-    // DOM — no remote-address field to fill, resilient to the in-chat redesign.
+    // WKWebView is not CDP-drivable, and recent iOS simulators can stop
+    // `simctl openurl` behind a system "Open in <app>?" confirmation. Drive the
+    // same hardened remote-connect handler that the OS deep-link route uses,
+    // after React has had a chance to install its CONNECT_EVENT listener.
+    await new Promise((resolve) => window.setTimeout(resolve, 750));
+    connectFirstRunRemoteDeepLink(request.apiBase);
+
+    // Prove the post-connect surface, decoupled from the onboarding DOM — no
+    // remote-address field to fill, resilient to the in-chat redesign.
     const home = await waitForIosOnboardingElement<HTMLElement>(
       '[data-testid="home-launcher-surface"][data-page="home"]',
       { visible: true },
@@ -813,6 +835,9 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
     const onboardingHidden = !document.querySelector(
       '[data-testid="first-run-chat"], [data-testid="startup-first-run-background"]',
     );
+    const storage = await waitForIosOnboardingSmokeStorageSnapshot(
+      request.apiBase,
+    );
 
     await writeIosOnboardingSmokeResult({
       ok: true,
@@ -822,7 +847,7 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
       homeVisible: Boolean(home),
       composerVisible: Boolean(composer),
       onboardingHidden,
-      storage: readIosOnboardingSmokeStorageSnapshot(),
+      storage,
     });
   } catch (error) {
     await writeIosOnboardingSmokeResult({
@@ -1650,9 +1675,13 @@ function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
     label: validatedUrl.hostname || "Remote agent",
     apiBase: connection.apiBase,
   });
-  void setStorageValue("elizaos:active-server", activeServer).finally(
-    dispatchConnect,
-  );
+  void setStorageValue("elizaos:active-server", activeServer).catch((error) => {
+    console.warn(
+      `${APP_LOG_PREFIX} Failed to persist first-run remote active server:`,
+      error,
+    );
+  });
+  dispatchConnect();
 }
 
 function handleDeepLink(url: string): void {
@@ -2175,6 +2204,22 @@ function usesStrictIosNetworkPolicy(): boolean {
   return isNativeIosStoreBuild() || isNativeIosCloudRuntimeMode();
 }
 
+function isTruthyBuildFlag(value: string | boolean | undefined): boolean {
+  return value === true || value === "1" || value === "true";
+}
+
+function allowsIosSimulatorLoopbackApiBase(parsed: URL): boolean {
+  return (
+    isNative &&
+    isIOS &&
+    !isNativeIosStoreBuild() &&
+    isTruthyBuildFlag(
+      import.meta.env.VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK,
+    ) &&
+    isLoopbackApiHost(parsed.hostname)
+  );
+}
+
 function canUseIosLocalAgentIpc(): boolean {
   return isNative && isIOS && getCurrentIosRuntimeConfig().mode === "local";
 }
@@ -2198,6 +2243,7 @@ function isTrustedApiBaseUrl(parsed: URL): boolean {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
   const host = parsed.hostname;
   if (usesStrictIosNetworkPolicy()) {
+    if (allowsIosSimulatorLoopbackApiBase(parsed)) return true;
     if (parsed.protocol !== "https:" || isPrivateOrLoopbackApiHost(host)) {
       return false;
     }
@@ -2222,6 +2268,7 @@ function isTrustedDeepLinkApiBaseUrl(parsed: URL): boolean {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
   const host = parsed.hostname;
   if (usesStrictIosNetworkPolicy()) {
+    if (allowsIosSimulatorLoopbackApiBase(parsed)) return true;
     if (parsed.protocol !== "https:" || isPrivateOrLoopbackApiHost(host)) {
       return false;
     }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -144,6 +144,7 @@ import {
 } from "./deep-link-routing";
 import { runEmbedHandshake } from "./embed-bootstrap";
 import { registerAppHostExternalImporters } from "./host-externals";
+import { runIosAttachmentSmokeIfRequested } from "./ios-attachment-smoke";
 import {
   apiBaseToDeviceBridgeUrl,
   type IosRuntimeConfig,
@@ -1441,6 +1442,16 @@ async function initializePlatform(): Promise<void> {
   initializeCapacitorBridge();
   void runIosFullBunSmokeIfRequested();
   void runIosOnboardingSmokeIfRequested();
+  void runIosAttachmentSmokeIfRequested({
+    isIOS,
+    getApiBaseUrl: () => client.getBaseUrl(),
+    getPreference: boundedPreferenceGet,
+    removePreference: (key) =>
+      boundedPreferenceWrite(() => Preferences.remove({ key })),
+    writeResult: writeIosPreferenceSmokeResult,
+    waitForElement: waitForIosOnboardingElement,
+    readStorageSnapshot: readIosOnboardingSmokeStorageSnapshot,
+  });
 
   if (isIOS || isAndroid) {
     await initializeStatusBar();

--- a/packages/ui/src/api/ios-local-agent-transport.test.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.test.ts
@@ -201,4 +201,29 @@ describe("iOS local agent transport (ui copy)", () => {
     expect(getIosNativeAgentBootProgress().phase).toBe("ready");
     expect(isIosNativeAgentBootInProgress()).toBe(true);
   }, 120_000);
+
+  it("allows explicit simulator loopback fetches in cloud mode on non-local-agent ports", async () => {
+    vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+    const originalFetch = vi.fn(async () => new Response('{"ready":true}'));
+    vi.stubGlobal("fetch", originalFetch);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "cloud-hybrid" : null,
+    });
+    vi.stubGlobal("window", {
+      __ELIZA_API_BASE__: "https://www.elizacloud.ai",
+      location: { href: "capacitor://localhost/" },
+      navigator: { userAgent: "vitest" },
+    });
+
+    const { installIosLocalAgentFetchBridge } = await import(
+      "./ios-local-agent-transport"
+    );
+    installIosLocalAgentFetchBridge();
+
+    const response = await fetch("http://127.0.0.1:31338/api/health");
+
+    await expect(response.json()).resolves.toEqual({ ready: true });
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -519,6 +519,23 @@ function normalizeHost(host: string | null | undefined): string {
     .replace(/^\[|\]$/g, "");
 }
 
+function isLoopbackHost(host: string): boolean {
+  const normalized = normalizeHost(host);
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.")
+  );
+}
+
+function allowsIosSimulatorLoopback(url: URL): boolean {
+  return (
+    !isNativeIosStoreBuild() &&
+    isTruthyBuildFlag(viteEnv().VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK) &&
+    isLoopbackHost(url.hostname)
+  );
+}
+
 function isPrivateOrLoopbackHost(host: string): boolean {
   const normalized = normalizeHost(host);
   return (
@@ -635,7 +652,8 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     if (
       usesStrictIosNetworkPolicy() &&
       isCleartextNetworkUrl(parsed) &&
-      isPrivateOrLoopbackHost(parsed.hostname)
+      isPrivateOrLoopbackHost(parsed.hostname) &&
+      !allowsIosSimulatorLoopback(parsed)
     ) {
       return false;
     }
@@ -1017,7 +1035,8 @@ function shouldBridgeFetchUrl(url: URL): boolean {
   if (
     usesStrictIosNetworkPolicy() &&
     isCleartextNetworkUrl(url) &&
-    (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url.hostname))
+    (isNativeIosStoreBuild() || isPrivateOrLoopbackHost(url.hostname)) &&
+    !allowsIosSimulatorLoopback(url)
   ) {
     throw new TypeError(
       "iOS store/cloud builds block cleartext loopback or private-network requests",

--- a/packages/ui/src/bridge/storage-bridge.ts
+++ b/packages/ui/src/bridge/storage-bridge.ts
@@ -73,6 +73,8 @@ const SYNCED_KEYS = new Set([
   "eliza:ios-full-bun-smoke:result",
   "eliza:ios-onboarding-smoke:request",
   "eliza:ios-onboarding-smoke:result",
+  "eliza:ios-attachment-smoke:request",
+  "eliza:ios-attachment-smoke:result",
 ]);
 
 // In-memory cache of values from Preferences (for native)


### PR DESCRIPTION
## Summary

Adds a hosted iOS simulator evidence lane for #10936 so the native attachment path can be exercised without requiring a local Mac in this session.

The smoke harness seeds Capacitor Preferences, launches the installed iOS app, deep-links it to the real local agent, and lets an in-app verifier exercise the native path:

- uploads a known PNG through `/api/background/upload-image`
- verifies the returned `/api/media/<sha256>.png` content-addressed URL
- fetches the served media bytes and checks the SHA-256
- writes and reads the bytes through Capacitor Filesystem `CACHE`
- attempts Capacitor Share with a bounded timeout so the simulator share sheet does not hang the run
- writes structured result data, screenshots, video, and host logs to the `ios-attachment-smoke` Actions artifact

The workflow step is intentionally `continue-on-error: true` on first landing so the hosted macOS simulator behavior can be observed from artifacts before promoting it to a hard gate.

## Validation

- `node --check packages/app/scripts/ios-attachment-smoke.mjs`
- `node --check packages/app/scripts/ios-onboarding-smoke.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-build-smoke.yml")'`
- `git diff --check`
- `bunx biome check packages/app/src/main.tsx packages/app/src/ios-attachment-smoke.ts packages/app/scripts/ios-attachment-smoke.mjs packages/app/scripts/ios-onboarding-smoke.mjs packages/app/package.json packages/ui/src/bridge/storage-bridge.ts packages/ui/src/api/ios-local-agent-transport.ts packages/ui/src/api/ios-local-agent-transport.test.ts packages/app-core/src/api/ios-local-agent-transport.ts packages/app-core/src/api/ios-local-agent-transport.test.ts packages/app-core/src/api/route-auth-policy.ts packages/app-core/src/api/route-auth-policy.test.ts packages/app-core/scripts/serve-real-local-agent.ts packages/app-core/scripts/mobile/ios-pods.mjs .github/workflows/mobile-build-smoke.yml`
- `bunx vitest run --config vitest.config.ts src/api/ios-local-agent-transport.test.ts src/api/route-auth-policy.test.ts` from `packages/app-core` (37 tests)
- `bunx vitest run --config vitest.config.ts src/api/ios-local-agent-transport.test.ts` from `packages/ui` (3 tests)

## Typecheck note

- `bun run --cwd packages/app typecheck` was retried after building local dependency artifacts; it now exits 1 on unrelated existing workspace package resolution/type errors in `packages/agent`, `plugins/plugin-app-manager`, and optional auth/plugin packages. It no longer reports errors in the files touched by this PR.

## Evidence

Pending hosted macOS run artifact review:

- Actions artifact: `ios-attachment-smoke`
- Expected contents: `result.json`, simulator screenshots/video, and `host-agent.log`

The artifact should be reviewed before the lane is promoted from advisory evidence to a hard gate.
