### PR TITLE
feat(meetings): drive the system Chrome/Edge, not a downloaded Chromium (#11856)

### DIFF
--- a/plugins/plugin-meetings/docs/DEPLOYMENT.md
+++ b/plugins/plugin-meetings/docs/DEPLOYMENT.md
@@ -43,11 +43,11 @@ on XTEST-grade input. Pick pure headless only for a Teams/Zoom-only deployment.
 
 macOS / Windows / a Linux desktop with a session. Turn on the `meetings` feature
 in your agent config (`features.meetings`) — no env flag needed. A display is
-always present, so the plugin auto-selects **headed**, and the system Chrome/Edge
-channel is used if no bundled browser is installed.
+always present, so the plugin auto-selects **headed**, and it **drives the Chrome
+or Edge you already have installed** — no separate Chromium download.
 
 ```bash
-# optional: pin a specific browser binary instead of the system channel
+# optional: pin a specific browser binary (otherwise your system Chrome/Edge is used)
 # export ELIZA_MEETINGS_CHROMIUM_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 ```
 

--- a/plugins/plugin-meetings/src/platform-support.test.ts
+++ b/plugins/plugin-meetings/src/platform-support.test.ts
@@ -61,28 +61,54 @@ describe("resolveHeadlessMode", () => {
 
 describe("chromiumExecutable", () => {
   it("prefers ELIZA_MEETINGS_CHROMIUM_PATH override when it exists", () => {
-    const r = chromiumExecutable("chrome", { ELIZA_MEETINGS_CHROMIUM_PATH: "/opt/chrome" });
+    const r = chromiumExecutable(
+      "chrome",
+      { ELIZA_MEETINGS_CHROMIUM_PATH: "/opt/chrome" },
+      "darwin",
+    );
     expect(r).toEqual({ source: "override", executablePath: "/opt/chrome" });
   });
 
   it("throws when the override path does not exist", () => {
     vi.mocked(existsSync).mockReturnValue(false);
-    expect(() => chromiumExecutable("chrome", { ELIZA_MEETINGS_CHROMIUM_PATH: "/nope" })).toThrow(
-      /does not exist/,
-    );
+    expect(() =>
+      chromiumExecutable("chrome", { ELIZA_MEETINGS_CHROMIUM_PATH: "/nope" }, "darwin"),
+    ).toThrow(/does not exist/);
   });
 
-  it("uses bundled Chromium when playwright has one installed", () => {
+  it("prefers the system Chrome the user already has over a download", () => {
+    // existsSync defaults to true → the first system path is 'installed'.
+    const r = chromiumExecutable("chrome", {}, "darwin");
+    expect(r).toEqual({
+      source: "system",
+      executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    });
+  });
+
+  it("prefers system Edge first when the caller wants the Edge channel", () => {
+    const r = chromiumExecutable("msedge", {}, "darwin");
+    expect(r).toEqual({
+      source: "system",
+      executablePath: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    });
+  });
+
+  it("uses bundled Chromium only when no system browser is installed", () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === "/pw/chromium");
     vi.spyOn(chromium, "executablePath").mockReturnValue("/pw/chromium");
-    const r = chromiumExecutable("chrome", {});
+    const r = chromiumExecutable("chrome", {}, "linux");
     expect(r).toEqual({ source: "bundled", executablePath: "/pw/chromium" });
   });
 
-  it("falls back to the system channel when no bundled browser exists", () => {
+  it("falls back to the system channel when nothing is resolvable", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
     vi.spyOn(chromium, "executablePath").mockImplementation(() => {
       throw new Error("not installed");
     });
-    expect(chromiumExecutable("msedge", {})).toEqual({ source: "channel", channel: "msedge" });
+    expect(chromiumExecutable("msedge", {}, "linux")).toEqual({
+      source: "channel",
+      channel: "msedge",
+    });
   });
 });
 
@@ -97,15 +123,23 @@ describe("resolveMeetingRuntimeSupport", () => {
     expect(r.reason).toMatch(/cannot run on a mobile/);
   });
 
-  it("is supported on desktop with a bundled browser and reports the path", () => {
+  it("is supported on desktop via the user's system browser and reports its path", () => {
+    const r = resolveMeetingRuntimeSupport(runtime, { DISPLAY: ":0" }, "linux");
+    expect(r.supported).toBe(true);
+    expect(r.chromiumPath).toBe("/usr/bin/google-chrome-stable");
+    expect(r.headless).toBe(false);
+  });
+
+  it("is supported via a bundled browser when no system browser exists", () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === "/pw/chromium");
     vi.spyOn(chromium, "executablePath").mockReturnValue("/pw/chromium");
     const r = resolveMeetingRuntimeSupport(runtime, { DISPLAY: ":0" }, "linux");
     expect(r.supported).toBe(true);
     expect(r.chromiumPath).toBe("/pw/chromium");
-    expect(r.headless).toBe(false);
   });
 
   it("is supported on desktop via the system channel fallback", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
     vi.spyOn(chromium, "executablePath").mockImplementation(() => {
       throw new Error("none");
     });

--- a/plugins/plugin-meetings/src/platform-support.ts
+++ b/plugins/plugin-meetings/src/platform-support.ts
@@ -23,7 +23,7 @@ import { existsSync } from "node:fs";
 export type BrowserChannel = "chrome" | "msedge";
 
 /** How Chromium was resolved — for logging and the capability report. */
-export type ChromiumSource = "override" | "bundled" | "channel";
+export type ChromiumSource = "override" | "system" | "bundled" | "channel";
 
 /** A resolved Chromium target: either an explicit binary or a system channel. */
 export interface ResolvedChromium {
@@ -47,16 +47,68 @@ export interface MeetingRuntimeSupport {
 }
 
 /**
+ * Known install locations for a system Chrome/Chromium, by platform. The bots
+ * drive the browser the user already has rather than downloading a separate one.
+ */
+const SYSTEM_CHROME_PATHS: Partial<Record<NodeJS.Platform, readonly string[]>> = {
+  darwin: [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+  ],
+  linux: [
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium-browser",
+    "/usr/bin/chromium",
+    "/snap/bin/chromium",
+    "/usr/bin/brave-browser",
+  ],
+  win32: [
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  ],
+};
+
+/** Known install locations for a system Microsoft Edge, by platform. */
+const SYSTEM_EDGE_PATHS: Partial<Record<NodeJS.Platform, readonly string[]>> = {
+  darwin: ["/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"],
+  linux: ["/usr/bin/microsoft-edge-stable", "/usr/bin/microsoft-edge"],
+  win32: [
+    "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+    "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+  ],
+};
+
+/**
+ * First existing system-browser binary on this host, honoring the caller's
+ * channel preference (Teams prefers Edge; Meet/Zoom prefer Chrome). Returns
+ * `null` when the user has no Chrome/Edge/Chromium installed.
+ */
+export function detectSystemBrowser(
+  prefer: BrowserChannel = "chrome",
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const chrome = SYSTEM_CHROME_PATHS[platform] ?? [];
+  const edge = SYSTEM_EDGE_PATHS[platform] ?? [];
+  const ordered =
+    prefer === "msedge" ? [...edge, ...chrome] : [...chrome, ...edge];
+  for (const candidate of ordered) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
  * Resolve which Chromium executable (or system channel) the bots would launch,
  * per the documented precedence:
  *   1. `ELIZA_MEETINGS_CHROMIUM_PATH` — explicit override (must exist).
- *   2. Playwright's bundled Chromium — when the browser download is installed.
- *   3. System channel fallback ("chrome" / "msedge").
- *
- * Returns `null` only when NO binary is resolvable AND no system channel is a
- * plausible fallback — i.e. the host genuinely has no Chromium. The channel
- * fallback is always plausible on desktop; callers that need certainty about a
- * concrete binary should inspect `source`/`executablePath`.
+ *   2. The system Chrome/Edge already installed on the machine — the bots drive
+ *      the user's own browser, never a separate download.
+ *   3. Playwright's bundled Chromium — only if a download happens to be present
+ *      (e.g. a headless server image that ran `playwright install`).
+ *   4. System channel fallback ("chrome" / "msedge") for playwright to resolve.
  *
  * @throws when the override path is set but does not exist — a misconfiguration
  *   the operator must fix, not something to silently downgrade.
@@ -64,6 +116,7 @@ export interface MeetingRuntimeSupport {
 export function chromiumExecutable(
   channel: BrowserChannel = "chrome",
   env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
 ): ResolvedChromium {
   const override = env.ELIZA_MEETINGS_CHROMIUM_PATH?.trim();
   if (override) {
@@ -75,7 +128,14 @@ export function chromiumExecutable(
     return { source: "override", executablePath: override };
   }
 
-  // Playwright's bundled Chromium — executablePath() throws if not installed.
+  // Prefer the Chrome/Edge already on the machine — no separate download.
+  const system = detectSystemBrowser(channel, platform);
+  if (system) {
+    return { source: "system", executablePath: system };
+  }
+
+  // Only when no system browser exists: playwright's bundled Chromium, if a
+  // download is present. executablePath() throws when it is not installed.
   try {
     const bundled = chromium.executablePath();
     if (bundled && existsSync(bundled)) {
@@ -170,7 +230,7 @@ export function resolveMeetingRuntimeSupport(
 
   let resolved: ResolvedChromium;
   try {
-    resolved = chromiumExecutable("chrome", env);
+    resolved = chromiumExecutable("chrome", env, platform);
   } catch (error) {
     return {
       supported: false,

--- a/plugins/plugin-meetings/src/platforms/shared/launch.test.ts
+++ b/plugins/plugin-meetings/src/platforms/shared/launch.test.ts
@@ -31,6 +31,8 @@ afterEach(() => {
 
 describe("launchMeetingBrowser headless + executable wiring", () => {
   it("passes an explicit headless option straight through to chromium.launch", async () => {
+    // No system browser installed → falls through to playwright's bundled one.
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === "/pw/chromium");
     const launch = vi.spyOn(chromium, "launch").mockResolvedValue(stubBrowser());
     vi.spyOn(chromium, "executablePath").mockReturnValue("/pw/chromium");
 
@@ -40,6 +42,22 @@ describe("launchMeetingBrowser headless + executable wiring", () => {
     const arg = launch.mock.calls[0][0];
     expect(arg?.headless).toBe(true);
     expect(arg?.executablePath).toBe("/pw/chromium");
+  });
+
+  it("drives the user's already-installed system browser by default (no download)", async () => {
+    // existsSync defaults to true → a system Chrome/Edge is 'installed', and is
+    // preferred over playwright's bundled Chromium.
+    const launch = vi.spyOn(chromium, "launch").mockResolvedValue(stubBrowser());
+    vi.spyOn(chromium, "executablePath").mockReturnValue("/pw/chromium");
+
+    await launchMeetingBrowser({ headless: true });
+
+    const arg = launch.mock.calls[0][0];
+    // A concrete system-browser binary path is passed — not the bundled download,
+    // and no channel is needed when we have a real path.
+    expect(typeof arg?.executablePath).toBe("string");
+    expect(arg?.executablePath).not.toBe("/pw/chromium");
+    expect(arg?.channel).toBeUndefined();
   });
 
   it("resolves headless from ELIZA_MEETINGS_HEADLESS when no option is given", async () => {

--- a/plugins/plugin-meetings/src/platforms/shared/launch.ts
+++ b/plugins/plugin-meetings/src/platforms/shared/launch.ts
@@ -5,8 +5,10 @@
  * (`resolveHeadlessMode`) both live in ../../platform-support.ts so the launcher
  * and the capability probe agree on the exact binary + mode. Resolution order:
  *   1. env ELIZA_MEETINGS_CHROMIUM_PATH — explicit override.
- *   2. Playwright's bundled Chromium (if the browser download is installed).
- *   3. System channel fallback ("chrome" / "msedge"). Teams prefers Edge via
+ *   2. The system Chrome/Edge already on the machine — the bots drive the
+ *      browser the user already has; no separate Chromium download.
+ *   3. Playwright's bundled Chromium (only if a download happens to be present).
+ *   4. System channel fallback ("chrome" / "msedge"). Teams prefers Edge via
  *      the `channel` param; Meet/Zoom use Chrome.
  *
  * Headless mode: explicit `ELIZA_MEETINGS_HEADLESS` wins, else headed only when


### PR DESCRIPTION
Part 1 of rewiring meeting transcription onto the browser you already have (follow-up to #11860).

## Why

The meeting bots don't need a **separate Chromium download** — they can drive the **Chrome / Edge already installed** on the machine. Previously `chromiumExecutable` preferred playwright's bundled download over the system browser.

## Change

New resolution precedence in `platform-support.ts`:

1. `ELIZA_MEETINGS_CHROMIUM_PATH` — explicit override (must exist).
2. **The system Chrome/Edge on the machine** — new `detectSystemBrowser()` with known per-OS install paths, honoring the channel preference (Teams → Edge, Meet/Zoom → Chrome). *No download.*
3. Playwright's bundled Chromium — only if a download happens to be present (e.g. a headless server image that ran `playwright install`).
4. System channel fallback for playwright to resolve.

- New `ChromiumSource: "system"`; `chromiumExecutable(channel, env, platform)` takes a platform arg for deterministic tests; `resolveMeetingRuntimeSupport` threads it through.
- Docs updated (launch header + DEPLOYMENT §a): the bots use your installed Chrome/Edge; `ELIZA_MEETINGS_CHROMIUM_PATH` is only an override.

**Server/headless unchanged:** with no system browser, it still falls back to the bundled/Xvfb Chromium, so the cloud topology (DEPLOYMENT §b) is untouched.

## Evidence

`platform-support.test.ts` covers the full precedence — override / system Chrome / system Edge / bundled-only / channel fallback — and `launch.test.ts` asserts a concrete system binary is passed to `chromium.launch` with no channel. Full plugin suite: **202 passed**.

_Next in this series: a standalone Meetings view (manager) + an integrated live browser pane that screencasts the bot in-call._

🤖 Generated with [Claude Code](https://claude.com/claude-code)