### PR TITLE
fix(scheduling): collapse midnight-spanning during_window fires to one occurrence (#12030 item 7)

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isCompletionTimeoutDue,
   isScheduledTaskDue,
+  markWindowFireIfNeeded,
   pendingPromptRoomIdForTask,
 } from "./due.js";
 import type { ScheduledTask } from "./types.js";
@@ -213,6 +214,153 @@ describe("owner_local cron tz resolution", () => {
       due: true,
       reason: "cron_due",
       occurrenceAtIso: "2026-05-10T09:00:00.000Z",
+    });
+  });
+});
+
+describe("during_window night wrap-around — no double-fire across midnight (#12030)", () => {
+  // Night runs 22:00–06:00, split into two segments both named "night":
+  // [22:00, 24:00) and [00:00, 06:00). It is ONE occurrence per night.
+  const NIGHT_FACTS = {
+    timezone: "UTC",
+    morningWindow: { start: "06:00", end: "11:00" },
+    eveningWindow: { start: "18:00", end: "22:00" },
+  };
+  const nightTask = (overrides: Partial<ScheduledTask> = {}): ScheduledTask =>
+    task({
+      trigger: { kind: "during_window", windowKey: "night" },
+      ...overrides,
+    });
+
+  it("blocks the after-midnight tick with the key the pre-midnight fire stamped", async () => {
+    const preMidnight = nightTask();
+    const first = await isScheduledTaskDue(preMidnight, {
+      now: new Date("2026-05-10T23:00:00.000Z"),
+      ownerFacts: NIGHT_FACTS,
+    });
+    expect(first).toMatchObject({ due: true, reason: "window_due" });
+
+    // The tick persists this occurrence key with the fire.
+    const stamped = markWindowFireIfNeeded(preMidnight, {
+      now: new Date("2026-05-10T23:00:00.000Z"),
+      ownerFacts: NIGHT_FACTS,
+    });
+    expect(stamped?.lastWindowFireKey).toBe("2026-05-10:night:night");
+
+    // 00:30 the next calendar day is still the SAME night — before the fix its
+    // key rolled to `2026-05-11:night:night` and it fired a second time.
+    const afterMidnight = await isScheduledTaskDue(
+      nightTask({
+        metadata: { lastWindowFireKey: stamped?.lastWindowFireKey as string },
+      }),
+      {
+        now: new Date("2026-05-11T00:30:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(afterMidnight).toMatchObject({
+      due: false,
+      reason: "window_already_fired",
+    });
+  });
+
+  it("blocks the after-midnight tick via the firedAt backstop (no lastWindowFireKey yet)", async () => {
+    const decision = await isScheduledTaskDue(
+      nightTask({
+        state: {
+          status: "fired",
+          followupCount: 0,
+          firedAt: "2026-05-10T23:00:00.000Z",
+        },
+      }),
+      {
+        now: new Date("2026-05-11T00:30:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(decision).toMatchObject({
+      due: false,
+      reason: "window_already_fired",
+    });
+  });
+
+  it("still fires once when the task is created after midnight (pre-midnight segment never fired)", async () => {
+    const created = nightTask();
+    const decision = await isScheduledTaskDue(created, {
+      now: new Date("2026-05-11T02:00:00.000Z"),
+      ownerFacts: NIGHT_FACTS,
+    });
+    expect(decision).toMatchObject({ due: true, reason: "window_due" });
+
+    // ...and after it stamps, a later same-night tick is blocked.
+    const stamped = markWindowFireIfNeeded(created, {
+      now: new Date("2026-05-11T02:00:00.000Z"),
+      ownerFacts: NIGHT_FACTS,
+    });
+    expect(stamped?.lastWindowFireKey).toBe("2026-05-10:night:night");
+    const later = await isScheduledTaskDue(
+      nightTask({
+        metadata: { lastWindowFireKey: stamped?.lastWindowFireKey as string },
+      }),
+      {
+        now: new Date("2026-05-11T02:30:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(later).toMatchObject({
+      due: false,
+      reason: "window_already_fired",
+    });
+  });
+
+  it("fires again on a genuinely new night", async () => {
+    const decision = await isScheduledTaskDue(
+      nightTask({
+        metadata: { lastWindowFireKey: "2026-05-10:night:night" },
+      }),
+      {
+        now: new Date("2026-05-11T22:30:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(decision).toMatchObject({ due: true, reason: "window_due" });
+  });
+
+  it("keeps morning and night independent for morning_or_night", async () => {
+    // Fired this morning — the night half of the same window still fires.
+    const nightAfterMorning = await isScheduledTaskDue(
+      task({
+        trigger: { kind: "during_window", windowKey: "morning_or_night" },
+        metadata: {
+          lastWindowFireKey: "2026-05-10:morning_or_night:morning",
+        },
+      }),
+      {
+        now: new Date("2026-05-10T23:00:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(nightAfterMorning).toMatchObject({
+      due: true,
+      reason: "window_due",
+    });
+
+    // But the night's after-midnight tail does NOT re-fire.
+    const nightTail = await isScheduledTaskDue(
+      task({
+        trigger: { kind: "during_window", windowKey: "morning_or_night" },
+        metadata: {
+          lastWindowFireKey: "2026-05-10:morning_or_night:night",
+        },
+      }),
+      {
+        now: new Date("2026-05-11T00:30:00.000Z"),
+        ownerFacts: NIGHT_FACTS,
+      },
+    );
+    expect(nightTail).toMatchObject({
+      due: false,
+      reason: "window_already_fired",
     });
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -10,7 +10,7 @@ import type {
 } from "./types.js";
 
 const MINUTE_MS = 60_000;
-const _DAY_MS = 24 * 60 * MINUTE_MS;
+const DAY_MS = 24 * 60 * MINUTE_MS;
 const CRON_CATCHUP_WINDOW_MS = 36 * 60 * MINUTE_MS;
 
 export interface ScheduledTaskDueContext {
@@ -383,6 +383,36 @@ function windowBoundsMinutes(
   return windows[windowKey] ?? [];
 }
 
+/**
+ * Stable per-occurrence key for a `during_window` fire. A window that wraps past
+ * midnight — `night` is `[eveningEnd, 24:00)` ∪ `[0, morningStart)` — is ONE
+ * occurrence per night, but its two segments share the name `"night"` and land
+ * on different calendar days. Attribute the after-midnight segment to the
+ * PREVIOUS local day so both halves collapse onto a single key; otherwise a
+ * night reminder fires once before midnight and a second time after it, because
+ * the date component of the key rolls over while the segment is still active
+ * (#12030). Returns `null` when no segment of the window is active at `at`.
+ */
+function windowOccurrenceKey(
+  at: Date,
+  timeZone: string,
+  windowKey: string,
+  ownerFacts: OwnerFactsView,
+): string | null {
+  const parts = localParts(at, timeZone);
+  const atMinutes = parts.hour * 60 + parts.minute;
+  const windows = windowBoundsMinutes(windowKey, ownerFacts);
+  const active = windows.find(
+    (window) => atMinutes >= window.start && atMinutes < window.end,
+  );
+  if (!active) return null;
+  const isAfterMidnightTail =
+    active.start === 0 &&
+    windows.some((w) => w.name === active.name && w.end === 24 * 60);
+  const anchor = isAfterMidnightTail ? new Date(at.getTime() - DAY_MS) : at;
+  return `${localDateKey(anchor, timeZone)}:${windowKey}:${active.name}`;
+}
+
 function duringWindowDue(
   task: ScheduledTask,
   trigger: Extract<ScheduledTaskTrigger, { kind: "during_window" }>,
@@ -390,34 +420,34 @@ function duringWindowDue(
 ): ScheduledTaskDueDecision {
   const ownerFacts = context.ownerFacts ?? {};
   const timeZone = ownerFacts.timezone ?? "UTC";
-  const parts = localParts(context.now, timeZone);
-  const nowMinutes = parts.hour * 60 + parts.minute;
-  const windows = windowBoundsMinutes(trigger.windowKey, ownerFacts);
-  const active = windows.find(
-    (window) => nowMinutes >= window.start && nowMinutes < window.end,
+  const fireKey = windowOccurrenceKey(
+    context.now,
+    timeZone,
+    trigger.windowKey,
+    ownerFacts,
   );
-  if (!active) return { due: false, reason: "window_inactive" };
-  const fireKey = `${localDateKey(context.now, timeZone)}:${trigger.windowKey}:${active.name}`;
+  if (fireKey === null) return { due: false, reason: "window_inactive" };
   if (task.metadata?.lastWindowFireKey === fireKey) {
     return { due: false, reason: "window_already_fired" };
   }
-  // A `firedAt` stamped inside the currently active window means this
-  // window's occurrence already happened. `lastWindowFireKey` is written by
-  // the tick AFTER the fire persists, so a recurrence-refire re-read in that
-  // gap (or a lost metadata edit) must still see the same window as spent —
-  // otherwise a parallel tick could double-fire one window occurrence.
+  // A `firedAt` stamped inside the same window occurrence means it already
+  // happened. `lastWindowFireKey` is written by the tick AFTER the fire
+  // persists, so a recurrence-refire re-read in that gap (or a lost metadata
+  // edit) must still see the occurrence as spent — otherwise a parallel tick
+  // could double-fire it. Comparing occurrence keys (not raw calendar dates)
+  // also collapses the two halves of a midnight-spanning window into one.
   const firedAtMs = parseIsoMs(task.state.firedAt);
   if (
     task.state.status !== "scheduled" &&
     firedAtMs !== null &&
-    localDateKey(new Date(firedAtMs), timeZone) ===
-      localDateKey(context.now, timeZone)
+    windowOccurrenceKey(
+      new Date(firedAtMs),
+      timeZone,
+      trigger.windowKey,
+      ownerFacts,
+    ) === fireKey
   ) {
-    const firedParts = localParts(new Date(firedAtMs), timeZone);
-    const firedMinutes = firedParts.hour * 60 + firedParts.minute;
-    if (firedMinutes >= active.start && firedMinutes < active.end) {
-      return { due: false, reason: "window_already_fired" };
-    }
+    return { due: false, reason: "window_already_fired" };
   }
   return {
     due: true,
@@ -474,15 +504,16 @@ export function markWindowFireIfNeeded(
   if (task.trigger.kind !== "during_window") return null;
   const ownerFacts = context.ownerFacts ?? {};
   const timeZone = ownerFacts.timezone ?? "UTC";
-  const parts = localParts(context.now, timeZone);
-  const nowMinutes = parts.hour * 60 + parts.minute;
-  const active = windowBoundsMinutes(task.trigger.windowKey, ownerFacts).find(
-    (window) => nowMinutes >= window.start && nowMinutes < window.end,
+  const fireKey = windowOccurrenceKey(
+    context.now,
+    timeZone,
+    task.trigger.windowKey,
+    ownerFacts,
   );
-  if (!active) return null;
+  if (fireKey === null) return null;
   return {
     ...(task.metadata ?? {}),
-    lastWindowFireKey: `${localDateKey(context.now, timeZone)}:${task.trigger.windowKey}:${active.name}`,
+    lastWindowFireKey: fireKey,
   };
 }
 


### PR DESCRIPTION
## The bug (#12030 item 7, `[core-brain]`/LifeOps)

`windowBoundsMinutes` (`plugins/plugin-scheduling/src/scheduled-task/due.ts`) returns the `night` window as **two segments, both named `"night"`**:

```ts
night: [
  { name: "night", start: eveningEnd, end: 24 * 60 }, // e.g. 22:00–24:00
  { name: "night", start: 0,          end: morningStart }, // 00:00–06:00
],
```

But the fire key was `${localDateKey(now)}:${windowKey}:${active.name}` and the firedAt backstop required `localDateKey(firedAt) === localDateKey(now)`. So:

- 23:00 (day 1) → fires, stamps `2026-05-10:night:night`.
- 00:30 (day 2) → the active segment is *still* `"night"`, but `localDateKey(now)` is now day 2 → key `2026-05-11:night:night`. **Both guards miss → it fires a second time.**

Every `during_window: "night"` (and `morning_or_night`) reminder/check-in double-fires each night that crosses midnight.

## The fix

Add `windowOccurrenceKey`, which attributes the **after-midnight tail** — a segment with `start === 0` whose same-named sibling ends at `24:00` — to the **previous local day**, so both halves of one night collapse onto a single key. The fire-key guard, the firedAt backstop (now comparing occurrence keys instead of raw calendar dates), and `markWindowFireIfNeeded` all route through it.

Edge cases preserved:
- **Created after midnight** (pre-midnight segment never fired) → still fires **once**.
- **Genuinely new night** → fires again.
- **`morning_or_night`** → morning and night stay **independent** occurrences.

## Verification — real red→green

`bun run --cwd plugins/plugin-scheduling test`:

- **Without the attribution:** `4 failed` — the two cross-midnight ticks return `due: true` and the key is `2026-05-11:night:night` instead of `2026-05-10:night:night` (reproduces the double-fire).
- **With the fix:** full suite green — **19 files, 231 tests** (5 new night-wrap tests + no regression to `dst-boundaries` / `recurrence-refire`). Typecheck clean.

| type | status |
|---|---|
| Unit tests (real due-evaluation path, red→green) | ✅ 231 pass; verified red without fix |
| Backend logs | N/A — pure due-evaluation logic; the runner's fire path is unchanged |
| Real-LLM trajectory | N/A — deterministic scheduler decision, no model call |
| Screenshots / video | N/A — no UI surface |
| Domain artifact | The `lastWindowFireKey` occurrence key is asserted directly in the tests (`2026-05-10:night:night` for both night halves) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)