### PR TITLE
test(cloud): add #8756 launch-hardening status collector

### DIFF
--- a/.github/issue-evidence/8756-launch-hardening-status/README.md
+++ b/.github/issue-evidence/8756-launch-hardening-status/README.md
@@ -1,0 +1,59 @@
+# #12081 / #8756 Launch-Hardening Status
+
+Generated: 2026-07-03T20:46:11.104Z
+
+This is a read-only collector. It does not deploy, approve environments, SSH to
+hosts, or print secret values.
+
+## Verdict
+
+| Check | Status |
+| Required production environment secrets exist | yes |
+| Latest build-agent-image run for develop is green | no |
+| Latest provisioning-worker deploy for develop is green | no |
+| Fresh-agent cloud provisioning probe passed | no / not run |
+| Issue closeable from this evidence alone | no |
+
+## Develop Head
+
+- Branch: `develop`
+- SHA: `d45052676121525e6777870b4cc5e64f5152a869`
+
+## Environment Secrets (production)
+
+| Secret | Present | Updated At |
+| SANDBOX_REGISTRY_REDIS_URL | yes | 2026-06-23T17:01:28Z |
+| ELIZA_PROVISIONING_HOST | yes | 2026-06-11T20:58:52Z |
+| ELIZA_PROVISIONING_SSH_KEY | yes | 2026-06-11T22:45:29Z |
+
+## Cloud Auth Secret
+
+| Secret | Present | Updated At | Source |
+| ELIZACLOUD_API_KEY | yes | 2026-04-05T07:46:17Z | github-repo-secret-list |
+
+## Workflows
+
+| Workflow | Run | Status | Conclusion | Head SHA | Updated |
+| Build Agent Image | https://github.com/elizaOS/eliza/actions/runs/28682554806 | pending |  | ec42f3ea2776b5ff0283cf03babda7e0bde3212b | 2026-07-03T20:42:24Z |
+| Deploy Eliza Provisioning Worker | https://github.com/elizaOS/eliza/actions/runs/28682121776 | pending |  | fec6b59c675f4e36312cd2321a969950ecd62903 | 2026-07-03T20:30:43Z |
+
+## Image
+
+- Image: `ghcr.io/elizaos/eliza:develop`
+- Digest: `sha256:54ce3645bcd3d5e23a2b06466691888a5bd656985e699984dbe3eb860b2c1a06`
+- Inspect succeeded: yes
+
+## Local Regression Check
+
+- `provisioning-worker-env-reconcile.test.ts`: passed
+
+## Fresh-Agent Probe
+
+- Attempted: no. Pass `--cloud-report <path>` with `ELIZA_CLOUD_AUTH_TOKEN` available to run the real fresh-agent probe.
+
+## Remaining
+
+This evidence can close the #12081 operator lane only when all verdict rows are
+green. If the workflow rows are still pending, cancelled, or missing, the live
+operator lane has not been proven complete. If the fresh-agent probe is not run,
+persistence, lean-plugin loading, and runtime reachability remain unverified.

--- a/.github/issue-evidence/8756-launch-hardening-status/status.json
+++ b/.github/issue-evidence/8756-launch-hardening-status/status.json
@@ -1,0 +1,95 @@
+{
+  "generatedAt": "2026-07-03T20:46:11.104Z",
+  "repo": "elizaOS/eliza",
+  "branch": "develop",
+  "environment": "production",
+  "developHead": {
+    "ok": true,
+    "sha": "d45052676121525e6777870b4cc5e64f5152a869",
+    "error": null
+  },
+  "environmentSecrets": {
+    "ok": true,
+    "expected": [
+      {
+        "name": "SANDBOX_REGISTRY_REDIS_URL",
+        "present": true,
+        "updatedAt": "2026-06-23T17:01:28Z",
+        "visibility": ""
+      },
+      {
+        "name": "ELIZA_PROVISIONING_HOST",
+        "present": true,
+        "updatedAt": "2026-06-11T20:58:52Z",
+        "visibility": ""
+      },
+      {
+        "name": "ELIZA_PROVISIONING_SSH_KEY",
+        "present": true,
+        "updatedAt": "2026-06-11T22:45:29Z",
+        "visibility": ""
+      }
+    ],
+    "count": 13
+  },
+  "cloudAuthSecret": {
+    "ok": true,
+    "name": "ELIZACLOUD_API_KEY",
+    "present": true,
+    "updatedAt": "2026-04-05T07:46:17Z",
+    "visibility": "",
+    "source": "github-repo-secret-list"
+  },
+  "workflows": {
+    "buildAgentImage": {
+      "ok": true,
+      "run": {
+        "conclusion": "",
+        "createdAt": "2026-07-03T20:42:23Z",
+        "databaseId": 28682554806,
+        "displayTitle": "feat(lifeops): live HITL test surface — connect model/accounts + run …",
+        "event": "push",
+        "headSha": "ec42f3ea2776b5ff0283cf03babda7e0bde3212b",
+        "status": "pending",
+        "updatedAt": "2026-07-03T20:42:24Z",
+        "url": "https://github.com/elizaOS/eliza/actions/runs/28682554806"
+      }
+    },
+    "deployProvisioningWorker": {
+      "ok": true,
+      "run": {
+        "conclusion": "",
+        "createdAt": "2026-07-03T20:30:42Z",
+        "databaseId": 28682121776,
+        "displayTitle": "fix(cloud): reject unsupported MiniMax music duration billing drift (…",
+        "event": "push",
+        "headSha": "fec6b59c675f4e36312cd2321a969950ecd62903",
+        "status": "pending",
+        "updatedAt": "2026-07-03T20:30:43Z",
+        "url": "https://github.com/elizaOS/eliza/actions/runs/28682121776"
+      }
+    }
+  },
+  "image": {
+    "ok": true,
+    "image": "ghcr.io/elizaos/eliza:develop",
+    "digest": "sha256:54ce3645bcd3d5e23a2b06466691888a5bd656985e699984dbe3eb860b2c1a06",
+    "outputExcerpt": "Name:      ghcr.io/elizaos/eliza:develop\nMediaType: application/vnd.docker.distribution.manifest.v2+json\nDigest:    sha256:54ce3645bcd3d5e23a2b06466691888a5bd656985e699984dbe3eb860b2c1a06"
+  },
+  "selfChecks": {
+    "provisioningWorkerEnvReconcile": {
+      "ok": true,
+      "status": 0,
+      "stdout": "bun test v1.4.0-canary.1 (64ae83c2f)",
+      "stderr": "packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts:\n(pass) deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring > sources the key from the GitHub secret into the deploy job env [0.12ms]\n(pass) deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring > forwards the key to the remote deploy script via the ssh-action envs allowlist [0.36ms]\n(pass) deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring > includes the key in the .env.local reconcile loop targeting /opt/eliza/cloud/.env.local [0.05ms]\n(pass) provisioning-worker .env.local reconcile loop (executed) > writes SANDBOX_REGISTRY_REDIS_URL into .env.local when the secret is set [41.39ms]\n(pass) provisioning-worker .env.local reconcile loop (executed) > replaces a stale hand-set value rather than appending a duplicate [402.61ms]\n(pass) provisioning-worker .env.local reconcile loop (executed) > skips the key (preserving any hand-set value) when the secret is unset [10.70ms]\n(pass) provisioning-worker .env.local reconcile loop (executed) > skips the key when the secret is the empty string [10.43ms]\n\n 7 pass\n 0 fail\n 30 expect() calls\nRan 7 tests across 1 file. [1247.00ms]"
+    }
+  },
+  "cloudProvisioning": null,
+  "verdict": {
+    "requiredSecretsPresent": true,
+    "imageReady": false,
+    "deployReady": false,
+    "cloudVerified": false,
+    "closeable": false
+  }
+}

--- a/.github/workflows/launch-hardening-8756.yml
+++ b/.github/workflows/launch-hardening-8756.yml
@@ -1,0 +1,63 @@
+name: "#8756 Launch Hardening Evidence"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment whose protected deploy secrets should be checked"
+        required: true
+        default: production
+        type: choice
+        options:
+          - production
+          - staging
+      branch:
+        description: "Branch to inspect for image/deploy workflow state"
+        required: true
+        default: develop
+      cloud_api_base:
+        description: "Eliza Cloud API base for the optional fresh-agent probe"
+        required: true
+        default: https://api.elizacloud.ai
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  collect:
+    name: Collect #8756 evidence
+    runs-on: ubuntu-24.04
+    environment: ${{ github.event.inputs.environment }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "canary"
+
+      - name: Collect read-only launch-hardening status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ELIZA_CLOUD_AUTH_TOKEN: ${{ secrets.ELIZACLOUD_API_KEY }}
+          ELIZA_CLOUD_API_BASE: ${{ github.event.inputs.cloud_api_base }}
+        run: |
+          set -euo pipefail
+          node scripts/cloud/verify-8756-launch-hardening.mjs \
+            --branch "${{ github.event.inputs.branch }}" \
+            --environment "${{ github.event.inputs.environment }}" \
+            --cloud-report .github/issue-evidence/8756-launch-hardening-status/cloud-provisioning.json
+
+      - name: Upload #8756 evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: 8756-launch-hardening-status
+          path: .github/issue-evidence/8756-launch-hardening-status/**
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/cloud/verify-8756-launch-hardening.mjs
+++ b/scripts/cloud/verify-8756-launch-hardening.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+// Read-only evidence collector for the launch-hardening operator lane
+// (#12081, superseding #8756). It gathers the public GitHub state that proves
+// whether closeout is ready without printing secret values or mutating live
+// infrastructure.
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const arg = (name, fallback = null) => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+};
+
+const repo = arg("--repo", "elizaOS/eliza");
+const branch = arg("--branch", "develop");
+const environment = arg("--environment", "production");
+const image = arg("--image", "ghcr.io/elizaos/eliza:develop");
+const cloudSecretName = arg("--cloud-secret-name", "ELIZACLOUD_API_KEY");
+const cloudTokenEnvName = "ELIZA_CLOUD_AUTH_TOKEN";
+const outDir = arg(
+  "--out-dir",
+  ".github/issue-evidence/8756-launch-hardening-status",
+);
+const cloudReport = arg("--cloud-report");
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+}
+
+function runJson(command, args) {
+  const result = run(command, args);
+  if (!result.ok) return { ok: false, error: result.stderr || result.stdout };
+  try {
+    return { ok: true, value: JSON.parse(result.stdout) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `failed to parse JSON from ${command}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      raw: result.stdout,
+    };
+  }
+}
+
+function latestRun(workflow) {
+  const result = runJson("gh", [
+    "run",
+    "list",
+    "-R",
+    repo,
+    "--workflow",
+    workflow,
+    "--branch",
+    branch,
+    "--limit",
+    "1",
+    "--json",
+    "databaseId,status,conclusion,createdAt,updatedAt,headSha,displayTitle,event,url",
+  ]);
+  if (!result.ok) return { ok: false, error: result.error };
+  return { ok: true, run: result.value?.[0] ?? null };
+}
+
+function listEnvironmentSecrets() {
+  const result = runJson("gh", [
+    "secret",
+    "list",
+    "-R",
+    repo,
+    "--env",
+    environment,
+    "--json",
+    "name,updatedAt,visibility",
+  ]);
+  if (!result.ok) return { ok: false, error: result.error };
+  const expected = [
+    "SANDBOX_REGISTRY_REDIS_URL",
+    "ELIZA_PROVISIONING_HOST",
+    "ELIZA_PROVISIONING_SSH_KEY",
+  ];
+  const byName = new Map(
+    result.value.map((secret) => [
+      secret.name,
+      {
+        name: secret.name,
+        present: true,
+        updatedAt: secret.updatedAt ?? null,
+        visibility: secret.visibility ?? null,
+      },
+    ]),
+  );
+  return {
+    ok: true,
+    expected: expected.map(
+      (name) =>
+        byName.get(name) ?? {
+          name,
+          present: false,
+          updatedAt: null,
+          visibility: null,
+        },
+    ),
+    count: result.value.length,
+  };
+}
+
+function listRepoSecret(name) {
+  const result = runJson("gh", [
+    "secret",
+    "list",
+    "-R",
+    repo,
+    "--json",
+    "name,updatedAt,visibility",
+  ]);
+  if (!result.ok) {
+    return {
+      ok: false,
+      name,
+      present: Boolean(process.env[cloudTokenEnvName]),
+      updatedAt: null,
+      visibility: null,
+      error: result.error,
+      source: "env-fallback",
+    };
+  }
+  const found = result.value.find((secret) => secret.name === name);
+  return {
+    ok: true,
+    name,
+    present: Boolean(found),
+    updatedAt: found?.updatedAt ?? null,
+    visibility: found?.visibility ?? null,
+    source: "github-repo-secret-list",
+  };
+}
+
+function developHead() {
+  const result = runJson("gh", [
+    "api",
+    `repos/${repo}/git/ref/heads/${branch}`,
+    "--jq",
+    ".object.sha",
+  ]);
+  if (!result.ok) {
+    const fallback = run("gh", [
+      "api",
+      `repos/${repo}/git/ref/heads/${branch}`,
+      "--jq",
+      ".object.sha",
+    ]);
+    return {
+      ok: fallback.ok,
+      sha: fallback.ok ? fallback.stdout : null,
+      error: fallback.ok ? null : fallback.stderr || fallback.stdout,
+    };
+  }
+  return { ok: true, sha: result.value };
+}
+
+function inspectImageDigest() {
+  const result = run("docker", ["buildx", "imagetools", "inspect", image]);
+  if (!result.ok)
+    return { ok: false, image, error: result.stderr || result.stdout };
+  const digest =
+    result.stdout.match(/Digest:\s+(sha256:[a-f0-9]{64})/)?.[1] ?? null;
+  return {
+    ok: true,
+    image,
+    digest,
+    outputExcerpt: result.stdout.split("\n").slice(0, 12).join("\n"),
+  };
+}
+
+function readOptionalCloudReport() {
+  if (!cloudReport) return null;
+  const result = run("node", [
+    "packages/app/scripts/cloud-provisioning-e2e.mjs",
+    "--fresh-agent",
+    "--report",
+    cloudReport,
+  ]);
+  return {
+    attempted: true,
+    ok: result.ok,
+    reportPath: cloudReport,
+    stdout: result.stdout.slice(0, 2000),
+    stderr: result.stderr.slice(0, 2000),
+  };
+}
+
+function runSelfChecks() {
+  return {
+    provisioningWorkerEnvReconcile: run("bun", [
+      "test",
+      "packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts",
+    ]),
+  };
+}
+
+function verdict(report) {
+  const requiredSecretsPresent = report.environmentSecrets.expected.every(
+    (secret) => secret.present,
+  );
+  const imageReady =
+    report.workflows.buildAgentImage.run?.status === "completed" &&
+    report.workflows.buildAgentImage.run?.conclusion === "success";
+  const deployReady =
+    report.workflows.deployProvisioningWorker.run?.status === "completed" &&
+    report.workflows.deployProvisioningWorker.run?.conclusion === "success";
+  const cloudVerified = report.cloudProvisioning?.ok === true;
+  return {
+    requiredSecretsPresent,
+    imageReady,
+    deployReady,
+    cloudVerified,
+    closeable:
+      requiredSecretsPresent && imageReady && deployReady && cloudVerified,
+  };
+}
+
+function table(rows) {
+  return rows
+    .map(
+      (row) =>
+        `| ${row.map((cell) => String(cell).replaceAll("\n", "<br>")).join(" | ")} |`,
+    )
+    .join("\n");
+}
+
+function renderMarkdown(report) {
+  const v = report.verdict;
+  return `# #12081 / #8756 Launch-Hardening Status
+
+Generated: ${report.generatedAt}
+
+This is a read-only collector. It does not deploy, approve environments, SSH to
+hosts, or print secret values.
+
+## Verdict
+
+${table([
+  ["Check", "Status"],
+  [
+    "Required production environment secrets exist",
+    v.requiredSecretsPresent ? "yes" : "no",
+  ],
+  [
+    "Latest build-agent-image run for develop is green",
+    v.imageReady ? "yes" : "no",
+  ],
+  [
+    "Latest provisioning-worker deploy for develop is green",
+    v.deployReady ? "yes" : "no",
+  ],
+  [
+    "Fresh-agent cloud provisioning probe passed",
+    v.cloudVerified ? "yes" : "no / not run",
+  ],
+  ["Issue closeable from this evidence alone", v.closeable ? "yes" : "no"],
+])}
+
+## Develop Head
+
+- Branch: \`${report.branch}\`
+- SHA: \`${report.developHead.sha ?? "unknown"}\`
+
+## Environment Secrets (${report.environment})
+
+${table([
+  ["Secret", "Present", "Updated At"],
+  ...report.environmentSecrets.expected.map((secret) => [
+    secret.name,
+    secret.present ? "yes" : "no",
+    secret.updatedAt ?? "n/a",
+  ]),
+])}
+
+## Cloud Auth Secret
+
+${table([
+  ["Secret", "Present", "Updated At", "Source"],
+  [
+    report.cloudAuthSecret.name,
+    report.cloudAuthSecret.present ? "yes" : "no",
+    report.cloudAuthSecret.updatedAt ?? "n/a",
+    report.cloudAuthSecret.source,
+  ],
+])}
+
+## Workflows
+
+${table([
+  ["Workflow", "Run", "Status", "Conclusion", "Head SHA", "Updated"],
+  [
+    "Build Agent Image",
+    report.workflows.buildAgentImage.run?.url ?? "missing",
+    report.workflows.buildAgentImage.run?.status ?? "missing",
+    report.workflows.buildAgentImage.run?.conclusion ?? "",
+    report.workflows.buildAgentImage.run?.headSha ?? "",
+    report.workflows.buildAgentImage.run?.updatedAt ?? "",
+  ],
+  [
+    "Deploy Eliza Provisioning Worker",
+    report.workflows.deployProvisioningWorker.run?.url ?? "missing",
+    report.workflows.deployProvisioningWorker.run?.status ?? "missing",
+    report.workflows.deployProvisioningWorker.run?.conclusion ?? "",
+    report.workflows.deployProvisioningWorker.run?.headSha ?? "",
+    report.workflows.deployProvisioningWorker.run?.updatedAt ?? "",
+  ],
+])}
+
+## Image
+
+- Image: \`${report.image.image}\`
+- Digest: \`${report.image.digest ?? "unavailable"}\`
+- Inspect succeeded: ${report.image.ok ? "yes" : "no"}
+
+## Local Regression Check
+
+- \`provisioning-worker-env-reconcile.test.ts\`: ${
+    report.selfChecks.provisioningWorkerEnvReconcile.ok ? "passed" : "failed"
+  }
+
+## Fresh-Agent Probe
+
+${
+  report.cloudProvisioning
+    ? `- Attempted: yes
+- Passed: ${report.cloudProvisioning.ok ? "yes" : "no"}
+- Report path: \`${report.cloudProvisioning.reportPath}\``
+    : "- Attempted: no. Pass `--cloud-report <path>` with `ELIZA_CLOUD_AUTH_TOKEN` available to run the real fresh-agent probe."
+}
+
+## Remaining
+
+This evidence can close the #12081 operator lane only when all verdict rows are
+green. If the workflow rows are still pending, cancelled, or missing, the live
+operator lane has not been proven complete. If the fresh-agent probe is not run,
+persistence, lean-plugin loading, and runtime reachability remain unverified.
+`;
+}
+
+mkdirSync(outDir, { recursive: true });
+const report = {
+  generatedAt: new Date().toISOString(),
+  repo,
+  branch,
+  environment,
+  developHead: developHead(),
+  environmentSecrets: listEnvironmentSecrets(),
+  cloudAuthSecret: listRepoSecret(cloudSecretName),
+  workflows: {
+    buildAgentImage: latestRun("build-agent-image.yml"),
+    deployProvisioningWorker: latestRun("deploy-eliza-provisioning-worker.yml"),
+  },
+  image: inspectImageDigest(),
+  selfChecks: runSelfChecks(),
+  cloudProvisioning: readOptionalCloudReport(),
+};
+report.verdict = verdict(report);
+
+writeFileSync(
+  path.join(outDir, "status.json"),
+  `${JSON.stringify(report, null, 2)}\n`,
+);
+writeFileSync(path.join(outDir, "README.md"), renderMarkdown(report));
+console.log(JSON.stringify(report.verdict, null, 2));


### PR DESCRIPTION
## Summary

Adds a read-only #8756 status collector that turns the launch-hardening operator lane into reproducible evidence instead of a hand-written status sweep.

The collector writes JSON and Markdown under `.github/issue-evidence/8756-launch-hardening-status/` and records, without printing secret values:

- required production environment secret presence and update timestamps
- repo-level cloud auth secret presence for the optional fresh-agent probe
- latest `build-agent-image.yml` state for `develop`
- latest `deploy-eliza-provisioning-worker.yml` state for `develop`
- current `ghcr.io/elizaos/eliza:develop` digest when Docker metadata is accessible
- the existing provisioning-worker env reconcile regression test result
- optional fresh-agent cloud provisioning probe status when `ELIZA_CLOUD_AUTH_TOKEN` is supplied

Also adds manual workflow `#8756 Launch Hardening Evidence` so an authorized maintainer can produce the secret-backed fresh-agent evidence artifact in GitHub Actions using the existing `ELIZACLOUD_API_KEY` secret. It is manual-only and does not deploy, approve environments, SSH to hosts, or print secret values.

The committed evidence currently shows the production deploy secrets and repo cloud auth secret exist, but the image/deploy workflows are still pending and the fresh-agent probe was not run locally, so #8756 is not closeable from this evidence alone yet.

## Validation

- `node --check scripts/cloud/verify-8756-launch-hardening.mjs`
- `bunx biome check scripts/cloud/verify-8756-launch-hardening.mjs .github/workflows/launch-hardening-8756.yml`
- `git diff --check -- scripts/cloud/verify-8756-launch-hardening.mjs .github/workflows/launch-hardening-8756.yml .github/issue-evidence/8756-launch-hardening-status`
- `node scripts/cloud/verify-8756-launch-hardening.mjs`

## Evidence

- `.github/issue-evidence/8756-launch-hardening-status/README.md`
- `.github/issue-evidence/8756-launch-hardening-status/status.json`
- GitHub Actions artifact after manual dispatch: `8756-launch-hardening-status`
