### PR TITLE
fix(cloud): handle MiniMax music duration billing drift (#12067)

### DIFF
--- a/packages/cloud/api/__tests__/generate-music-duration-billing.test.ts
+++ b/packages/cloud/api/__tests__/generate-music-duration-billing.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Regression coverage for MiniMax music duration/billing drift (#12067).
+ *
+ * MiniMax Music 2.6 on Fal is billed per audio and does not expose a duration
+ * control in its current model schema. The route must not accept a client
+ * duration that the provider ignores, and it must not store/bill a fake default
+ * duration for that fixed-price model.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import * as audioRegistryActual from "@/lib/providers/audio/registry";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
+import * as contentSafetyActual from "@/lib/services/content-safety";
+import * as creditsActual from "@/lib/services/credits";
+import * as generationsActual from "@/lib/services/generations";
+
+const ORG = "00000000-0000-4000-8000-000000001267";
+const USER = "00000000-0000-4000-8000-000000001268";
+const MINIMAX = "fal-ai/minimax-music/v2.6";
+const ELEVENLABS = "elevenlabs/music_v1";
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitActual,
+  RateLimitPresets: { STRICT: { limit: 1, windowSeconds: 1 } },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  ...contentSafetyActual,
+  contentSafetyService: {
+    ...contentSafetyActual.contentSafetyService,
+    assertSafeForPublicUse: async () => undefined,
+  },
+}));
+
+const calculateMusicGenerationCostFromCatalog = mock();
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateMusicGenerationCostFromCatalog,
+}));
+
+const reserve = mock();
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: { ...creditsActual.creditsService, reserve },
+}));
+
+const generationsCreate = mock();
+mock.module("@/lib/services/generations", () => ({
+  ...generationsActual,
+  generationsService: {
+    ...generationsActual.generationsService,
+    create: generationsCreate,
+  },
+}));
+
+const getAudioProvider = mock();
+const generateAudio = mock();
+mock.module("@/lib/providers/audio/registry", () => ({
+  ...audioRegistryActual,
+  getAudioProvider,
+}));
+
+const musicRoute = (await import("../v1/generate-music/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module(
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    () => rateLimitActual,
+  );
+  mock.module("@/lib/services/content-safety", () => contentSafetyActual);
+  mock.module("@/lib/services/ai-pricing", () => aiPricingActual);
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module("@/lib/services/generations", () => generationsActual);
+  mock.module("@/lib/providers/audio/registry", () => audioRegistryActual);
+});
+
+type AppCtx = { set: (k: string, v: unknown) => void };
+
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold;
+  let reconcileCalls = 0;
+  let lastActual = Number.NaN;
+  return {
+    startBalance,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get lastActual() {
+      return lastActual;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        lastActual = actualCost;
+        balance += hold - actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+function costFor(model: string, unit: "request" | "minute", totalCost: number) {
+  return {
+    totalCost,
+    baseTotalCost: unit === "request" ? 0.15 : 0.25,
+    platformMarkup: totalCost - (unit === "request" ? 0.15 : 0.25),
+    matchedEntry: {
+      billingSource: model.startsWith("elevenlabs/") ? "elevenlabs" : "fal",
+      provider: model.startsWith("elevenlabs/") ? "elevenlabs" : "fal",
+      model,
+      productFamily: "music",
+      chargeType: "generation",
+      unit,
+      unitPrice: unit === "request" ? 0.15 : 0.25,
+      dimensions: {},
+      sourceKind: unit === "request" ? "fal_model_page" : "elevenlabs_snapshot",
+      sourceUrl: model.startsWith("elevenlabs/")
+        ? "https://elevenlabs.io/docs/api-reference/music/compose"
+        : "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
+    },
+  };
+}
+
+function post(
+  body: Record<string, unknown>,
+  env: Record<string, unknown> = { FAL_KEY: "fal-test-key" },
+) {
+  return musicRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  calculateMusicGenerationCostFromCatalog.mockReset();
+  reserve.mockReset();
+  generationsCreate.mockReset();
+  getAudioProvider.mockReset();
+  generateAudio.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", "key-1");
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+
+  generateAudio.mockResolvedValue({
+    source: "hosted",
+    url: "https://v3b.fal.media/files/music-output.mp3",
+    fileName: "music-output.mp3",
+    fileSize: 1234,
+    contentType: "audio/mpeg",
+    requestId: "req-music",
+    status: "completed",
+    raw: {
+      audio: {
+        url: "https://v3b.fal.media/files/music-output.mp3",
+        content_type: "audio/mpeg",
+      },
+    },
+  });
+  getAudioProvider.mockImplementation((billingSource: string) => ({
+    billingSource,
+    generate: generateAudio,
+  }));
+});
+
+describe("generate-music — MiniMax duration contract", () => {
+  test("rejects explicit durationSeconds for MiniMax before provider or credit work", async () => {
+    const res = await post({
+      model: MINIMAX,
+      prompt: "city pop verification",
+      durationSeconds: 10,
+    });
+
+    expect(res.status).toBe(400);
+    expect(calculateMusicGenerationCostFromCatalog).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(getAudioProvider).not.toHaveBeenCalled();
+
+    const body = (await res.json()) as { error?: string; code?: string };
+    expect(body.code).toBe("validation_error");
+    expect(body.error).toContain("does not support durationSeconds");
+  });
+
+  test("MiniMax success is fixed-price and does not forward or store a fake duration", async () => {
+    const cost = costFor(MINIMAX, "request", 0.18);
+    const ledger = makeLedgerReservation(100, cost.totalCost);
+    calculateMusicGenerationCostFromCatalog.mockResolvedValue(cost);
+    reserve.mockResolvedValue(ledger.reservation);
+    generationsCreate.mockResolvedValue({ id: "gen-music" });
+
+    const res = await post({
+      model: MINIMAX,
+      prompt: "city pop verification",
+      instrumental: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.lastActual).toBeCloseTo(0.18, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - 0.18, 10);
+
+    const pricingParams = calculateMusicGenerationCostFromCatalog.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(pricingParams.durationSeconds).toBeUndefined();
+    expect(pricingParams.dimensions).toEqual({ instrumental: true });
+
+    const providerRequest = generateAudio.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(providerRequest.durationSeconds).toBeUndefined();
+
+    const generationParams = generationsCreate.mock.calls[0]?.[0] as {
+      parameters: Record<string, unknown>;
+      dimensions: Record<string, unknown>;
+      cost: string;
+    };
+    expect(generationParams.parameters.durationControl).toBe("unsupported");
+    expect(generationParams.parameters.durationSeconds).toBeUndefined();
+    expect(
+      generationParams.parameters.requestedDurationSeconds,
+    ).toBeUndefined();
+    expect(generationParams.dimensions).toEqual({});
+    expect(generationParams.cost).toBe("0.18");
+  });
+
+  test("supported music models forward the resolved default duration for billing and provider input", async () => {
+    const cost = costFor(ELEVENLABS, "minute", 0.3);
+    const ledger = makeLedgerReservation(100, cost.totalCost);
+    const generate = mock(async (_req: Record<string, unknown>) => ({
+      source: "hosted",
+      url: "https://cdn.example.test/elevenlabs.mp3",
+      fileName: "elevenlabs.mp3",
+      fileSize: 2048,
+      contentType: "audio/mpeg",
+      requestId: "req-eleven",
+      status: "completed",
+      raw: {},
+    }));
+    calculateMusicGenerationCostFromCatalog.mockResolvedValue(cost);
+    reserve.mockResolvedValue(ledger.reservation);
+    generationsCreate.mockResolvedValue({ id: "gen-eleven" });
+    getAudioProvider.mockReturnValue({ billingSource: "elevenlabs", generate });
+
+    const res = await post(
+      {
+        model: ELEVENLABS,
+        prompt: "piano verification",
+      },
+      { ELEVENLABS_API_KEY: "eleven-test-key" },
+    );
+
+    expect(res.status).toBe(200);
+    const pricingParams = calculateMusicGenerationCostFromCatalog.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(pricingParams.durationSeconds).toBe(60);
+    expect(pricingParams.dimensions).toEqual({ durationSeconds: 60 });
+
+    const providerInput = generate.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(providerInput.durationSeconds).toBe(60);
+
+    const generationParams = generationsCreate.mock.calls[0]?.[0] as {
+      parameters: Record<string, unknown>;
+      dimensions: Record<string, unknown>;
+    };
+    expect(generationParams.parameters.durationControl).toBe("supported");
+    expect(generationParams.parameters.durationSeconds).toBe(60);
+    expect(generationParams.dimensions).toEqual({ duration: 60 });
+  });
+});

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -173,6 +173,17 @@ app.post("/", async (c) => {
         "validation_error",
       );
     }
+    if (
+      definition.durationControl === "unsupported" &&
+      request.durationSeconds !== undefined
+    ) {
+      return jsonError(
+        c,
+        400,
+        `Model ${request.model} does not support durationSeconds; omit durationSeconds and bill it as a fixed-price generation`,
+        "validation_error",
+      );
+    }
     if (!providerConfigured(c.env, provider)) {
       return jsonError(
         c,
@@ -197,14 +208,19 @@ app.post("/", async (c) => {
     });
 
     const durationSeconds =
-      request.durationSeconds ?? definition.defaultParameters.durationSeconds;
+      definition.durationControl === "supported"
+        ? (request.durationSeconds ??
+          definition.defaultParameters.durationSeconds)
+        : undefined;
     const cost = await calculateMusicGenerationCostFromCatalog({
       model: request.model,
       provider: definition.provider,
       billingSource: definition.billingSource,
       durationSeconds,
       dimensions: {
-        ...(durationSeconds ? { durationSeconds } : {}),
+        ...(definition.durationControl === "supported" && durationSeconds
+          ? { durationSeconds }
+          : {}),
         ...(request.instrumental !== undefined
           ? { instrumental: request.instrumental }
           : {}),
@@ -240,7 +256,7 @@ app.post("/", async (c) => {
         lyrics: request.lyrics,
         lyricsOptimizer: request.lyricsOptimizer,
         instrumental: request.instrumental,
-        durationSeconds: request.durationSeconds,
+        durationSeconds,
         referenceUrl: request.referenceUrl,
         seed: request.seed,
         outputFormat: request.outputFormat,
@@ -300,7 +316,11 @@ app.post("/", async (c) => {
       file_size: music.file_size ? BigInt(music.file_size) : undefined,
       mime_type: music.content_type ?? "audio/mpeg",
       parameters: {
-        durationSeconds,
+        ...(request.durationSeconds !== undefined
+          ? { requestedDurationSeconds: request.durationSeconds }
+          : {}),
+        ...(durationSeconds ? { durationSeconds } : {}),
+        durationControl: definition.durationControl,
         hasLyrics: Boolean(request.lyrics),
         lyricsOptimizer: request.lyricsOptimizer,
         instrumental: request.instrumental,
@@ -308,7 +328,7 @@ app.post("/", async (c) => {
         outputFormat: request.outputFormat,
       },
       dimensions: {
-        duration: durationSeconds,
+        ...(durationSeconds ? { duration: durationSeconds } : {}),
       },
       cost: String(cost.totalCost),
       credits: String(cost.totalCost),

--- a/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts
@@ -159,6 +159,7 @@ export interface SupportedMusicModelDefinition {
   billingSource: "fal" | "elevenlabs" | "suno";
   label: string;
   pageUrl: string;
+  durationControl: "supported" | "unsupported";
   defaultParameters: {
     durationSeconds: number;
   };
@@ -545,6 +546,7 @@ export const SUPPORTED_MUSIC_MODELS: SupportedMusicModelDefinition[] = [
     billingSource: "fal",
     label: "MiniMax Music 2.6",
     pageUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
+    durationControl: "unsupported",
     defaultParameters: {
       durationSeconds: 60,
     },
@@ -555,6 +557,7 @@ export const SUPPORTED_MUSIC_MODELS: SupportedMusicModelDefinition[] = [
     billingSource: "elevenlabs",
     label: "ElevenLabs Music v1",
     pageUrl: "https://elevenlabs.io/docs/api-reference/music/compose",
+    durationControl: "supported",
     defaultParameters: {
       durationSeconds: 60,
     },
@@ -565,6 +568,7 @@ export const SUPPORTED_MUSIC_MODELS: SupportedMusicModelDefinition[] = [
     billingSource: "suno",
     label: "Suno-compatible provider",
     pageUrl: "https://docs.sunoapi.org/suno-api/generate-music/",
+    durationControl: "supported",
     defaultParameters: {
       durationSeconds: 120,
     },
@@ -634,12 +638,12 @@ export const MUSIC_SNAPSHOT_PRICING: MusicSnapshotEntry[] = [
     billingSource: "fal",
     productFamily: "music",
     chargeType: "generation",
-    unit: "minute",
-    unitPrice: 0.1,
+    unit: "request",
+    unitPrice: 0.15,
     sourceUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
     metadata: {
       tier: "manual_override_recommended",
-      note: "Conservative fallback for MiniMax music generation until account-specific Fal pricing is refreshed.",
+      note: "Fal bills MiniMax Music 2.6 per audio generation and the model page exposes no duration control.",
     },
   },
   {

--- a/packages/cloud/shared/src/lib/services/ai-pricing/music-generation-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/music-generation-pricing.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+import { buildMusicSnapshotEntries } from "./providers/suno";
+import type { PreparedPricingEntry } from "./types";
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: async () => [],
+    listActiveEntries: async () => [],
+  },
+}));
+
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async (source: string): Promise<PreparedPricingEntry[]> =>
+    source === "fal" ? buildMusicSnapshotEntries("fal", "fal_model_page") : [],
+}));
+
+const { calculateMusicGenerationCostFromCatalog } = await import("./lookup");
+const { __clearPersistedPricingCache } = await import("./cache");
+
+beforeEach(() => {
+  __clearPersistedPricingCache();
+});
+
+test("MiniMax Music 2.6 resolves as Fal's fixed per-audio price, not requested-duration minutes", async () => {
+  const cost = await calculateMusicGenerationCostFromCatalog({
+    model: "fal-ai/minimax-music/v2.6",
+    provider: "fal",
+    billingSource: "fal",
+    durationSeconds: 10,
+    dimensions: { durationSeconds: 10 },
+  });
+
+  expect(cost.matchedEntry.unit).toBe("request");
+  expect(cost.matchedEntry.unitPrice).toBe(0.15);
+  expect(cost.baseTotalCost).toBe(0.15);
+  expect(cost.totalCost).toBe(0.18);
+});


### PR DESCRIPTION
Closes #12067.

## Summary

- marks `fal-ai/minimax-music/v2.6` as a music model without duration control
- rejects explicit `durationSeconds` for MiniMax instead of accepting a value the provider ignores
- changes MiniMax fallback pricing from `$0.10/minute` to Fal's current `$0.15/audio` fixed request price
- avoids storing a fake default duration for fixed-price MiniMax generations
- forwards resolved default duration for music models that do support duration control

Fal's current MiniMax Music 2.6 model page shows fixed per-audio pricing and a result schema with audio URL/file metadata, not a duration field or duration input control:
https://fal.ai/models/fal-ai/minimax-music/v2.6

## Verification

- `bun test packages/cloud/api/__tests__/generate-music-duration-billing.test.ts`
- `bun test packages/cloud/shared/src/lib/services/ai-pricing/music-generation-pricing.test.ts`
- `bunx @biomejs/biome check packages/cloud/api/v1/generate-music/route.ts packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts packages/cloud/api/__tests__/generate-music-duration-billing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/music-generation-pricing.test.ts`
- `git diff --check -- packages/cloud/api/v1/generate-music/route.ts packages/cloud/shared/src/lib/services/ai-pricing-definitions.ts packages/cloud/api/__tests__/generate-music-duration-billing.test.ts packages/cloud/shared/src/lib/services/ai-pricing/music-generation-pricing.test.ts`
- `bun run --cwd packages/cloud/api typecheck`
- `bun run --cwd packages/cloud/shared typecheck`

## Notes

No UI changes. The live production artifact that exposed this is in #12066 / #11745: a `durationSeconds: 10` MiniMax request returned a 110.631s MP3 while the old minute-based fallback billed as if 10s controlled the output.
