### PR TITLE
fix(ui): don't treat the on-device agent bearer as a cloud session + refresh gate on same-view sign-in (#12046)

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -634,6 +634,14 @@ export class ElizaClient {
     } else {
       clearElizaApiToken();
     }
+    // A same-view sign-in/out (this is the only path that writes the token
+    // without a page load) must refresh any mounted session gate — e.g. the
+    // Apps tab — without a remount. `steward-token-sync` is the established
+    // "re-read your token" signal that use-session-auth already listens for.
+    // (#12046 Nit 2)
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    }
   }
 
   getBaseUrl(): string {

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -52,6 +52,25 @@ describe("getCloudAuthToken (Cloud = Steward everywhere)", () => {
   it("returns null when no token is available anywhere", () => {
     expect(getCloudAuthToken()).toBeNull();
   });
+
+  it("dispatches steward-token-sync on setToken so mounted gates refresh (#12046 Nit 2)", () => {
+    const client = new ElizaClient();
+    let syncs = 0;
+    const handler = () => {
+      syncs++;
+    };
+    window.addEventListener("steward-token-sync", handler);
+    try {
+      client.setToken("client-token");
+      client.setToken(null);
+      // Both the sign-in and the sign-out write must notify listeners — before
+      // the fix setToken dispatched nothing and the gate went stale until a
+      // remount.
+      expect(syncs).toBe(2);
+    } finally {
+      window.removeEventListener("steward-token-sync", handler);
+    }
+  });
 });
 
 describe("cloudTokenSecsRemaining", () => {

--- a/packages/ui/src/cloud/lib/cloud-api-key-token.test.ts
+++ b/packages/ui/src/cloud/lib/cloud-api-key-token.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { isCloudApiKeyToken } from "./cloud-api-key-token";
+
+describe("isCloudApiKeyToken (#12046)", () => {
+  it("accepts an `eliza_`-prefixed cloud API key", () => {
+    expect(isCloudApiKeyToken("eliza_live_abc123")).toBe(true);
+    expect(isCloudApiKeyToken("eliza_test_org_a_key")).toBe(true);
+    // leading/trailing whitespace is tolerated (tokens are trimmed at source)
+    expect(isCloudApiKeyToken("  eliza_live_abc123  ")).toBe(true);
+  });
+
+  it("rejects the on-device agent bearer (the #12046 wrong-auth cause)", () => {
+    // A JWT-shaped local agent bearer — mirrored into bootConfig.apiToken by
+    // first-run-finish — must NOT read as a cloud session.
+    expect(
+      isCloudApiKeyToken(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ2VudCJ9.sig",
+      ),
+    ).toBe(false);
+    // an opaque non-prefixed bearer
+    expect(isCloudApiKeyToken("agent-bearer-1234567890")).toBe(false);
+  });
+
+  it("rejects empty / nullish / non-string input", () => {
+    expect(isCloudApiKeyToken("")).toBe(false);
+    expect(isCloudApiKeyToken("   ")).toBe(false);
+    expect(isCloudApiKeyToken(null)).toBe(false);
+    expect(isCloudApiKeyToken(undefined)).toBe(false);
+  });
+
+  it("does not match a token that merely contains `eliza_` later on", () => {
+    expect(isCloudApiKeyToken("not_eliza_key")).toBe(false);
+    expect(isCloudApiKeyToken("Bearer eliza_live_abc")).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/lib/cloud-api-key-token.ts
+++ b/packages/ui/src/cloud/lib/cloud-api-key-token.ts
@@ -1,0 +1,13 @@
+/**
+ * Discriminates an Eliza Cloud API key from other bearer tokens.
+ *
+ * Cloud API keys are `eliza_`-prefixed. The on-device agent bearer that
+ * `first-run-finish` mirrors into `bootConfig.apiToken` on a local-agent
+ * install is NOT — so it must never be mistaken for a cloud session, or a user
+ * who never cloud-signed-in is reported `authenticated` and the Apps tab sends
+ * the local bearer to api.elizacloud.ai (401 → error state instead of a
+ * sign-in prompt). See #12046.
+ */
+export function isCloudApiKeyToken(token: string | null | undefined): boolean {
+  return typeof token === "string" && token.trim().startsWith("eliza_");
+}

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -23,6 +23,7 @@ import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
 } from "../shell/StewardProvider";
+import { isCloudApiKeyToken } from "./cloud-api-key-token";
 import { decodeJwtPayload } from "./jwt";
 
 export type StewardSessionUser = {
@@ -88,7 +89,11 @@ function nativeCloudApiKey(): string | null {
   if (typeof globalToken === "string" && globalToken.trim()) {
     return globalToken.trim();
   }
-  return getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim() || null;
+  // Only a real cloud key (not the on-device agent bearer) counts as a native
+  // cloud session.
+  const configToken =
+    getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim() || null;
+  return isCloudApiKeyToken(configToken) ? configToken : null;
 }
 
 function apiKeySessionId(token: string): string {


### PR DESCRIPTION
Fixes #12046 (both nits — follow-ups to #11973, the native Apps-tab API-key session gate).

## Nit 1 (MED) — local-agent-only first-run reported "authenticated"

`packages/ui/src/cloud/lib/use-session-auth.ts` — `nativeCloudApiKey()` treated **any** `bootConfig.apiToken` / `getElizaApiToken()` value as a cloud API-key session, with no cloud-key validation. On a mobile local-agent install, `first-run-finish` sets the **on-device agent bearer** via `client.setToken`, which mirrors into `bootConfig.apiToken` → a user who **never cloud-signed-in** was reported `authenticated`. Opening the Apps tab enabled the query gate, the api-client sent the **local agent bearer** to `api.elizacloud.ai`, `GET /api/v1/apps` 401'd, and the user saw an **error state instead of a sign-in prompt**.

**Fix:** add `isCloudApiKeyToken` (Eliza Cloud keys are `eliza_`-prefixed — verified against the key-mint contract, `expect(apiKey).toMatch(/^eliza_/)`; the on-device agent bearer is not) as a **zero-dep leaf module** and gate the config-token fallback through it. The explicit `__ELIZA_CLOUD_AUTH_TOKEN__` cloud-login global is unchanged.

## Nit 2 (LOW) — gate stale on same-view sign-in/out

`client.setToken()` — the only path that writes the token without a page load — dispatched **no event**, so a mounted session gate (Apps tab) stayed stale until remount (enabled=false after sign-in, or stale enabled=true after sign-out).

**Fix:** dispatch the established `steward-token-sync` signal (already the "re-read your token" event `use-session-auth` listens for, and already emitted elsewhere in this package) from `setToken()`, window-guarded.

## Verification

`bunx vitest run` on the three affected files → **all green**:
- `cloud-api-key-token.test.ts` (new): accepts `eliza_*`, rejects a JWT-shaped agent bearer / opaque bearer / empty / nullish / mid-string `eliza_`.
- `client-cloud-steward-token.test.ts` (new case): `setToken("…")` then `setToken(null)` dispatches `steward-token-sync` **twice** (sign-in + sign-out).
- Existing `client-cloud-steward-token` + `client-cloud-connect-mock-cloud` suites still pass with the added dispatch.

`tsgo --noEmit` on `packages/ui`: **zero errors in the touched files** (`use-session-auth.ts`, `cloud-api-key-token.ts`, `client-base.ts`).

| type | status |
|---|---|
| Unit tests (discriminator + event dispatch) | ✅ green, listed above |
| Backend logs | N/A — client-side auth gating only |
| Before/after screenshots + video | **N/A — no rendered change.** This is auth-state logic; the affected state (native local-agent-only boot) is not reproducible in the desktop `audit:cloud` harness, which logs in with a synthetic cloud JWT. The behavioral effect is "show the sign-in prompt instead of a 401 error state." |
| Real-LLM trajectory | N/A — no agent/model path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)