### PR TITLE
test(lifeops): add #11632 live validation status collector

### DIFF
--- a/.github/issue-evidence/8833-lifeops-live-validation/11632-status/README.md
+++ b/.github/issue-evidence/8833-lifeops-live-validation/11632-status/README.md
@@ -1,0 +1,40 @@
+# #11632 LifeOps Live-Validation Status
+
+Generated: 2026-07-03T20:43:37.390Z
+
+Verdict: **not closeable**. This is a read-only status artifact; live OAuth,
+account, sandbox, and physical-device rows still need operator evidence.
+
+| Surface | Status | Required | Present env names | Missing |
+|---|---|---|---|---|
+| Live model provider | blocked | one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, CEREBRAS_API_KEY, ELIZA_LIVE_TEST_LOCAL_LLAMA_CPP_BASE_URL | none | OPENAI_API_KEY, ANTHROPIC_API_KEY, CEREBRAS_API_KEY, ELIZA_LIVE_TEST_LOCAL_LLAMA_CPP_BASE_URL |
+| Google Calendar / Gmail | blocked | GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI | none | GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI |
+| Discord | blocked | one of: DISCORD_API_TOKEN, DISCORD_BOT_TOKEN | none | DISCORD_API_TOKEN, DISCORD_BOT_TOKEN |
+| Telegram | blocked | TELEGRAM_BOT_TOKEN | none | TELEGRAM_BOT_TOKEN |
+| Slack | blocked | SLACK_BOT_TOKEN, SLACK_APP_TOKEN | none | SLACK_BOT_TOKEN, SLACK_APP_TOKEN |
+| Signal | blocked | SIGNAL_ACCOUNT_NUMBER | none | SIGNAL_ACCOUNT_NUMBER, SIGNAL_HTTP_URL, SIGNAL_CLI_PATH |
+| WhatsApp | blocked | ELIZA_WHATSAPP_ACCESS_TOKEN, ELIZA_WHATSAPP_PHONE_NUMBER_ID | none | ELIZA_WHATSAPP_ACCESS_TOKEN, ELIZA_WHATSAPP_PHONE_NUMBER_ID |
+| X | blocked | one of: X_API_KEY, TWITTER_API_KEY, TWITTER_BEARER_TOKEN | none | X_API_KEY, TWITTER_API_KEY, TWITTER_BEARER_TOKEN |
+| Phone / SMS / Voice | blocked | TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN | none | TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN |
+| Health | blocked | one of: ELIZA_HEALTHKIT_CLI_PATH, ELIZA_GOOGLE_FIT_ACCESS_TOKEN, FITBIT_ACCESS_TOKEN, OURA_ACCESS_TOKEN, STRAVA_ACCESS_TOKEN, WITHINGS_ACCESS_TOKEN | none | ELIZA_HEALTHKIT_CLI_PATH, ELIZA_GOOGLE_FIT_ACCESS_TOKEN, FITBIT_ACCESS_TOKEN, OURA_ACCESS_TOKEN, STRAVA_ACCESS_TOKEN, WITHINGS_ACCESS_TOKEN |
+| Finances | blocked | one of: LIFEOPS_FINANCE_CSV_FIXTURE, PLAID_CLIENT_ID, PLAID_SECRET, PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET | none | LIFEOPS_FINANCE_CSV_FIXTURE, PLAID_CLIENT_ID, PLAID_SECRET, PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET |
+| iOS / macOS native permissions | blocked | one of: ELIZA_IMESSAGE_BACKEND, ELIZA_NATIVE_PERMISSIONS_DYLIB, ELIZA_HEALTHKIT_CLI_PATH | none | ELIZA_IMESSAGE_BACKEND, ELIZA_NATIVE_PERMISSIONS_DYLIB, ELIZA_HEALTHKIT_CLI_PATH |
+| Android native permissions | blocked | one of: ANDROID_SERIAL | ANDROID_HOME | ANDROID_SERIAL |
+
+## Device Tooling
+
+| Tool | Available | Summary |
+|---|---:|---|
+| adb | yes | List of devices attached<br>27051JEGR10034         device usb:5-2 product:bluejay model:Pixel_6a device:bluejay transport_id:2 |
+| xcrun | no | n/a |
+| devicectl | no | n/a |
+
+## Existing Evidence
+
+- present: `.github/issue-evidence/8833-lifeops-live-validation/README.md`
+- present: `.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/README.md`
+- present: `.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix.txt`
+- present: `.github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/connector-keyless-suites.txt`
+- missing: `.github/issue-evidence/8833-lifeops-live-validation/11632-status/owner-agent-permission-matrix.txt`
+- missing: `.github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-google-live.txt`
+- missing: `.github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-x-live.txt`

--- a/.github/issue-evidence/8833-lifeops-live-validation/11632-status/status.json
+++ b/.github/issue-evidence/8833-lifeops-live-validation/11632-status/status.json
@@ -1,0 +1,356 @@
+{
+  "issue": 11632,
+  "generatedAt": "2026-07-03T20:43:37.390Z",
+  "verdict": {
+    "closeable": false,
+    "reason": "This collector is read-only status evidence. #11632 still requires live OAuth/account/device artifacts unless a future run attaches those rows.",
+    "operatorReadyGroups": [],
+    "blockedGroups": [
+      "model",
+      "google",
+      "discord",
+      "telegram",
+      "slack",
+      "signal",
+      "whatsapp",
+      "x",
+      "twilio",
+      "health",
+      "finance",
+      "native_ios_macos",
+      "native_android"
+    ],
+    "liveRowsProven": false
+  },
+  "envGroups": [
+    {
+      "id": "model",
+      "label": "Live model provider",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CEREBRAS_API_KEY",
+        "ELIZA_LIVE_TEST_LOCAL_LLAMA_CPP_BASE_URL"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CEREBRAS_API_KEY",
+        "ELIZA_LIVE_TEST_LOCAL_LLAMA_CPP_BASE_URL"
+      ]
+    },
+    {
+      "id": "google",
+      "label": "Google Calendar / Gmail",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REDIRECT_URI"
+      ],
+      "requiredAny": [],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REDIRECT_URI"
+      ],
+      "missingRequiredAny": []
+    },
+    {
+      "id": "discord",
+      "label": "Discord",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "DISCORD_API_TOKEN",
+        "DISCORD_BOT_TOKEN"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "DISCORD_API_TOKEN",
+        "DISCORD_BOT_TOKEN"
+      ]
+    },
+    {
+      "id": "telegram",
+      "label": "Telegram",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "TELEGRAM_BOT_TOKEN"
+      ],
+      "requiredAny": [],
+      "optional": [
+        "TELEGRAM_TEST_CHAT_ID",
+        "TELEGRAM_ALLOWED_CHATS"
+      ],
+      "present": [],
+      "missingRequiredAll": [
+        "TELEGRAM_BOT_TOKEN"
+      ],
+      "missingRequiredAny": []
+    },
+    {
+      "id": "slack",
+      "label": "Slack",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN"
+      ],
+      "requiredAny": [],
+      "optional": [
+        "SLACK_USER_TOKEN",
+        "SLACK_CHANNEL_IDS",
+        "SLACK_SIGNING_SECRET"
+      ],
+      "present": [],
+      "missingRequiredAll": [
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN"
+      ],
+      "missingRequiredAny": []
+    },
+    {
+      "id": "signal",
+      "label": "Signal",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "SIGNAL_ACCOUNT_NUMBER"
+      ],
+      "requiredAny": [
+        "SIGNAL_HTTP_URL",
+        "SIGNAL_CLI_PATH"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [
+        "SIGNAL_ACCOUNT_NUMBER"
+      ],
+      "missingRequiredAny": [
+        "SIGNAL_HTTP_URL",
+        "SIGNAL_CLI_PATH"
+      ]
+    },
+    {
+      "id": "whatsapp",
+      "label": "WhatsApp",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "ELIZA_WHATSAPP_ACCESS_TOKEN",
+        "ELIZA_WHATSAPP_PHONE_NUMBER_ID"
+      ],
+      "requiredAny": [],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [
+        "ELIZA_WHATSAPP_ACCESS_TOKEN",
+        "ELIZA_WHATSAPP_PHONE_NUMBER_ID"
+      ],
+      "missingRequiredAny": []
+    },
+    {
+      "id": "x",
+      "label": "X",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "X_API_KEY",
+        "TWITTER_API_KEY",
+        "TWITTER_BEARER_TOKEN"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "X_API_KEY",
+        "TWITTER_API_KEY",
+        "TWITTER_BEARER_TOKEN"
+      ]
+    },
+    {
+      "id": "twilio",
+      "label": "Phone / SMS / Voice",
+      "readyForOperatorRun": false,
+      "requiredAll": [
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_AUTH_TOKEN"
+      ],
+      "requiredAny": [],
+      "optional": [
+        "TWILIO_PHONE_NUMBER",
+        "TWILIO_WEBHOOK_URL"
+      ],
+      "present": [],
+      "missingRequiredAll": [
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_AUTH_TOKEN"
+      ],
+      "missingRequiredAny": []
+    },
+    {
+      "id": "health",
+      "label": "Health",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "ELIZA_HEALTHKIT_CLI_PATH",
+        "ELIZA_GOOGLE_FIT_ACCESS_TOKEN",
+        "FITBIT_ACCESS_TOKEN",
+        "OURA_ACCESS_TOKEN",
+        "STRAVA_ACCESS_TOKEN",
+        "WITHINGS_ACCESS_TOKEN"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "ELIZA_HEALTHKIT_CLI_PATH",
+        "ELIZA_GOOGLE_FIT_ACCESS_TOKEN",
+        "FITBIT_ACCESS_TOKEN",
+        "OURA_ACCESS_TOKEN",
+        "STRAVA_ACCESS_TOKEN",
+        "WITHINGS_ACCESS_TOKEN"
+      ]
+    },
+    {
+      "id": "finance",
+      "label": "Finances",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "LIFEOPS_FINANCE_CSV_FIXTURE",
+        "PLAID_CLIENT_ID",
+        "PLAID_SECRET",
+        "PAYPAL_CLIENT_ID",
+        "PAYPAL_CLIENT_SECRET"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "LIFEOPS_FINANCE_CSV_FIXTURE",
+        "PLAID_CLIENT_ID",
+        "PLAID_SECRET",
+        "PAYPAL_CLIENT_ID",
+        "PAYPAL_CLIENT_SECRET"
+      ]
+    },
+    {
+      "id": "native_ios_macos",
+      "label": "iOS / macOS native permissions",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "ELIZA_IMESSAGE_BACKEND",
+        "ELIZA_NATIVE_PERMISSIONS_DYLIB",
+        "ELIZA_HEALTHKIT_CLI_PATH"
+      ],
+      "optional": [],
+      "present": [],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "ELIZA_IMESSAGE_BACKEND",
+        "ELIZA_NATIVE_PERMISSIONS_DYLIB",
+        "ELIZA_HEALTHKIT_CLI_PATH"
+      ]
+    },
+    {
+      "id": "native_android",
+      "label": "Android native permissions",
+      "readyForOperatorRun": false,
+      "requiredAll": [],
+      "requiredAny": [
+        "ANDROID_SERIAL"
+      ],
+      "optional": [
+        "ANDROID_HOME"
+      ],
+      "present": [
+        "ANDROID_HOME"
+      ],
+      "missingRequiredAll": [],
+      "missingRequiredAny": [
+        "ANDROID_SERIAL"
+      ]
+    }
+  ],
+  "devices": {
+    "adb": {
+      "command": "adb",
+      "available": true,
+      "status": 0,
+      "signal": null,
+      "summary": "List of devices attached\n27051JEGR10034         device usb:5-2 product:bluejay model:Pixel_6a device:bluejay transport_id:2"
+    },
+    "xcrun": {
+      "command": "xcrun",
+      "available": false,
+      "status": null,
+      "signal": null,
+      "summary": ""
+    },
+    "devicectl": {
+      "command": "devicectl",
+      "available": false,
+      "status": null,
+      "signal": null,
+      "summary": ""
+    }
+  },
+  "existingEvidence": [
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/README.md",
+      "exists": true
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/README.md",
+      "exists": true
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix.txt",
+      "exists": true,
+      "matched": [
+        "/20 passed/i"
+      ]
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/connector-keyless-suites.txt",
+      "exists": true,
+      "matched": [
+        "/pass/i"
+      ]
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/11632-status/owner-agent-permission-matrix.txt",
+      "exists": false,
+      "matched": []
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-google-live.txt",
+      "exists": false,
+      "matched": []
+    },
+    {
+      "path": ".github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-x-live.txt",
+      "exists": false,
+      "matched": []
+    }
+  ],
+  "nextCommands": [
+    "LIFEOPS_PERMISSION_MATRIX=1 bunx vitest run --config packages/test/vitest/integration.config.ts plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts",
+    "TEST_LANE=post-merge ELIZA_LIVE_TEST=1 bun run --cwd plugins/plugin-google test",
+    "TEST_LANE=post-merge ELIZA_LIVE_TEST=1 bun run --cwd plugins/plugin-x test",
+    "bun run dev && node .github/issue-evidence/8833-lifeops-live-validation/capture-views.mjs",
+    "bun run --cwd packages/app capture:android-emu",
+    "bun run --cwd packages/app capture:ios-sim"
+  ]
+}

--- a/.github/workflows/lifeops-live-validation-11632.yml
+++ b/.github/workflows/lifeops-live-validation-11632.yml
@@ -1,0 +1,109 @@
+name: "#11632 LifeOps Live Validation Status"
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_keyless_matrix:
+        description: "Run the deterministic OWNER/AGENT matrix harness"
+        type: boolean
+        default: true
+      run_live_connectors:
+        description: "Run live connector suites when credentials are configured"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    env:
+      ELIZA_SKIP_ARTIFACT_SYNC: "1"
+      ELIZA_LIVE_TEST: "1"
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
+      DISCORD_API_TOKEN: ${{ secrets.DISCORD_API_TOKEN }}
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+      SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
+      SIGNAL_ACCOUNT_NUMBER: ${{ secrets.SIGNAL_ACCOUNT_NUMBER }}
+      SIGNAL_HTTP_URL: ${{ secrets.SIGNAL_HTTP_URL }}
+      ELIZA_WHATSAPP_ACCESS_TOKEN: ${{ secrets.ELIZA_WHATSAPP_ACCESS_TOKEN }}
+      ELIZA_WHATSAPP_PHONE_NUMBER_ID: ${{ secrets.ELIZA_WHATSAPP_PHONE_NUMBER_ID }}
+      X_API_KEY: ${{ secrets.X_API_KEY }}
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+      TWILIO_PHONE_NUMBER: ${{ secrets.TWILIO_PHONE_NUMBER }}
+      FITBIT_ACCESS_TOKEN: ${{ secrets.FITBIT_ACCESS_TOKEN }}
+      OURA_ACCESS_TOKEN: ${{ secrets.OURA_ACCESS_TOKEN }}
+      STRAVA_ACCESS_TOKEN: ${{ secrets.STRAVA_ACCESS_TOKEN }}
+      WITHINGS_ACCESS_TOKEN: ${{ secrets.WITHINGS_ACCESS_TOKEN }}
+      PLAID_CLIENT_ID: ${{ secrets.PLAID_CLIENT_ID }}
+      PLAID_SECRET: ${{ secrets.PLAID_SECRET }}
+      PAYPAL_CLIENT_ID: ${{ secrets.PAYPAL_CLIENT_ID }}
+      PAYPAL_CLIENT_SECRET: ${{ secrets.PAYPAL_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install
+        run: bun run install:light
+
+      - name: Collect pre-run status
+        run: node scripts/lifeops/collect-11632-live-validation-status.mjs
+
+      - name: Run OWNER/AGENT matrix
+        if: ${{ inputs.run_keyless_matrix }}
+        env:
+          LIFEOPS_PERMISSION_MATRIX: "1"
+        run: |
+          set -o pipefail
+          mkdir -p .github/issue-evidence/8833-lifeops-live-validation/11632-status
+          bunx vitest run \
+            --config packages/test/vitest/integration.config.ts \
+            plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts \
+            2>&1 | tee .github/issue-evidence/8833-lifeops-live-validation/11632-status/owner-agent-permission-matrix.txt
+
+      - name: Run Google live connector suite
+        if: ${{ inputs.run_live_connectors }}
+        env:
+          TEST_LANE: post-merge
+        run: |
+          set -o pipefail
+          mkdir -p .github/issue-evidence/8833-lifeops-live-validation/11632-status
+          bun run --cwd plugins/plugin-google test \
+            2>&1 | tee .github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-google-live.txt
+
+      - name: Run X live connector suite
+        if: ${{ inputs.run_live_connectors }}
+        env:
+          TEST_LANE: post-merge
+        run: |
+          set -o pipefail
+          mkdir -p .github/issue-evidence/8833-lifeops-live-validation/11632-status
+          bun run --cwd plugins/plugin-x test \
+            2>&1 | tee .github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-x-live.txt
+
+      - name: Collect post-run status
+        if: always()
+        run: node scripts/lifeops/collect-11632-live-validation-status.mjs
+
+      - name: Upload status artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lifeops-11632-live-validation-status
+          path: .github/issue-evidence/8833-lifeops-live-validation/11632-status/

--- a/scripts/lifeops/collect-11632-live-validation-status.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const DEFAULT_OUT = join(
+  ROOT,
+  ".github/issue-evidence/8833-lifeops-live-validation/11632-status/status.json",
+);
+
+const CONNECTOR_GROUPS = [
+  {
+    id: "model",
+    label: "Live model provider",
+    requiredAny: [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "CEREBRAS_API_KEY",
+      "ELIZA_LIVE_TEST_LOCAL_LLAMA_CPP_BASE_URL",
+    ],
+  },
+  {
+    id: "google",
+    label: "Google Calendar / Gmail",
+    requiredAll: [
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+      "GOOGLE_REDIRECT_URI",
+    ],
+  },
+  {
+    id: "discord",
+    label: "Discord",
+    requiredAny: ["DISCORD_API_TOKEN", "DISCORD_BOT_TOKEN"],
+  },
+  {
+    id: "telegram",
+    label: "Telegram",
+    requiredAll: ["TELEGRAM_BOT_TOKEN"],
+    optional: ["TELEGRAM_TEST_CHAT_ID", "TELEGRAM_ALLOWED_CHATS"],
+  },
+  {
+    id: "slack",
+    label: "Slack",
+    requiredAll: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
+    optional: ["SLACK_USER_TOKEN", "SLACK_CHANNEL_IDS", "SLACK_SIGNING_SECRET"],
+  },
+  {
+    id: "signal",
+    label: "Signal",
+    requiredAll: ["SIGNAL_ACCOUNT_NUMBER"],
+    requiredAny: ["SIGNAL_HTTP_URL", "SIGNAL_CLI_PATH"],
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp",
+    requiredAll: [
+      "ELIZA_WHATSAPP_ACCESS_TOKEN",
+      "ELIZA_WHATSAPP_PHONE_NUMBER_ID",
+    ],
+  },
+  {
+    id: "x",
+    label: "X",
+    requiredAny: ["X_API_KEY", "TWITTER_API_KEY", "TWITTER_BEARER_TOKEN"],
+  },
+  {
+    id: "twilio",
+    label: "Phone / SMS / Voice",
+    requiredAll: ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"],
+    optional: ["TWILIO_PHONE_NUMBER", "TWILIO_WEBHOOK_URL"],
+  },
+  {
+    id: "health",
+    label: "Health",
+    requiredAny: [
+      "ELIZA_HEALTHKIT_CLI_PATH",
+      "ELIZA_GOOGLE_FIT_ACCESS_TOKEN",
+      "FITBIT_ACCESS_TOKEN",
+      "OURA_ACCESS_TOKEN",
+      "STRAVA_ACCESS_TOKEN",
+      "WITHINGS_ACCESS_TOKEN",
+    ],
+  },
+  {
+    id: "finance",
+    label: "Finances",
+    requiredAny: [
+      "LIFEOPS_FINANCE_CSV_FIXTURE",
+      "PLAID_CLIENT_ID",
+      "PLAID_SECRET",
+      "PAYPAL_CLIENT_ID",
+      "PAYPAL_CLIENT_SECRET",
+    ],
+  },
+  {
+    id: "native_ios_macos",
+    label: "iOS / macOS native permissions",
+    requiredAny: [
+      "ELIZA_IMESSAGE_BACKEND",
+      "ELIZA_NATIVE_PERMISSIONS_DYLIB",
+      "ELIZA_HEALTHKIT_CLI_PATH",
+    ],
+  },
+  {
+    id: "native_android",
+    label: "Android native permissions",
+    requiredAny: ["ANDROID_SERIAL"],
+    optional: ["ANDROID_HOME"],
+  },
+];
+
+function parseArgs(argv) {
+  const args = { out: DEFAULT_OUT };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--out") {
+      args.out = resolve(argv[++i]);
+    } else if (arg === "--help") {
+      console.log(
+        "Usage: node scripts/lifeops/collect-11632-live-validation-status.mjs [--out <status.json>]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function hasEnv(name) {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function commandAvailable(command, args = ["--version"]) {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  return {
+    command,
+    available: result.status === 0,
+    status: result.status,
+    signal: result.signal,
+    summary: summarizeOutput(`${result.stdout ?? ""}\n${result.stderr ?? ""}`),
+  };
+}
+
+function summarizeOutput(value) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 5)
+    .join("\n");
+}
+
+function groupStatus(group) {
+  const requiredAll = group.requiredAll ?? [];
+  const requiredAny = group.requiredAny ?? [];
+  const optional = group.optional ?? [];
+  const present = [...requiredAll, ...requiredAny, ...optional]
+    .filter(hasEnv)
+    .sort();
+  const missingRequiredAll = requiredAll.filter((name) => !hasEnv(name));
+  const anySatisfied = requiredAny.length === 0 || requiredAny.some(hasEnv);
+  const ready = missingRequiredAll.length === 0 && anySatisfied;
+  return {
+    id: group.id,
+    label: group.label,
+    readyForOperatorRun: ready,
+    requiredAll,
+    requiredAny,
+    optional,
+    present,
+    missingRequiredAll,
+    missingRequiredAny:
+      requiredAny.length > 0 && !anySatisfied ? requiredAny : [],
+  };
+}
+
+function fileStatus(path) {
+  const full = join(ROOT, path);
+  return { path, exists: existsSync(full) };
+}
+
+function parseEvidenceLog(path, patterns) {
+  const full = join(ROOT, path);
+  if (!existsSync(full)) return { path, exists: false, matched: [] };
+  const text = readFileSync(full, "utf8");
+  return {
+    path,
+    exists: true,
+    matched: patterns.filter((pattern) => pattern.test(text)).map(String),
+  };
+}
+
+function buildStatus() {
+  const envGroups = CONNECTOR_GROUPS.map(groupStatus);
+  const existingEvidence = [
+    fileStatus(".github/issue-evidence/8833-lifeops-live-validation/README.md"),
+    fileStatus(
+      ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/README.md",
+    ),
+    parseEvidenceLog(
+      ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/owner-agent-permission-matrix.txt",
+      [/20\/20 pass/i, /20 passed/i],
+    ),
+    parseEvidenceLog(
+      ".github/issue-evidence/8833-lifeops-live-validation/2026-07-02-keyless-run/connector-keyless-suites.txt",
+      [/all green/i, /pass/i],
+    ),
+    parseEvidenceLog(
+      ".github/issue-evidence/8833-lifeops-live-validation/11632-status/owner-agent-permission-matrix.txt",
+      [/20\/20 pass/i, /20 passed/i],
+    ),
+    parseEvidenceLog(
+      ".github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-google-live.txt",
+      [/pass/i, /skip/i],
+    ),
+    parseEvidenceLog(
+      ".github/issue-evidence/8833-lifeops-live-validation/11632-status/plugin-x-live.txt",
+      [/pass/i, /skip/i],
+    ),
+  ];
+  const devices = {
+    adb: commandAvailable("adb", ["devices", "-l"]),
+    xcrun: commandAvailable("xcrun", [
+      "simctl",
+      "list",
+      "devices",
+      "available",
+    ]),
+    devicectl: commandAvailable("devicectl", ["list", "devices"]),
+  };
+  const operatorReadyGroups = envGroups.filter(
+    (group) => group.readyForOperatorRun,
+  );
+  const blockedGroups = envGroups.filter((group) => !group.readyForOperatorRun);
+  const liveRowsProven = existingEvidence.some(
+    (entry) =>
+      entry.exists &&
+      (entry.path?.includes("plugin-google-live") ||
+        entry.path?.includes("plugin-x-live")),
+  );
+
+  return {
+    issue: 11632,
+    generatedAt: new Date().toISOString(),
+    verdict: {
+      closeable: false,
+      reason:
+        "This collector is read-only status evidence. #11632 still requires live OAuth/account/device artifacts unless a future run attaches those rows.",
+      operatorReadyGroups: operatorReadyGroups.map((group) => group.id),
+      blockedGroups: blockedGroups.map((group) => group.id),
+      liveRowsProven,
+    },
+    envGroups,
+    devices,
+    existingEvidence,
+    nextCommands: [
+      "LIFEOPS_PERMISSION_MATRIX=1 bunx vitest run --config packages/test/vitest/integration.config.ts plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts",
+      "TEST_LANE=post-merge ELIZA_LIVE_TEST=1 bun run --cwd plugins/plugin-google test",
+      "TEST_LANE=post-merge ELIZA_LIVE_TEST=1 bun run --cwd plugins/plugin-x test",
+      "bun run dev && node .github/issue-evidence/8833-lifeops-live-validation/capture-views.mjs",
+      "bun run --cwd packages/app capture:android-emu",
+      "bun run --cwd packages/app capture:ios-sim",
+    ],
+  };
+}
+
+function renderMarkdown(status) {
+  const cell = (value) =>
+    String(value || "n/a")
+      .replaceAll("|", "\\|")
+      .replace(/\r?\n/g, "<br>");
+  const rows = status.envGroups
+    .map((group) => {
+      const required =
+        group.requiredAll.length > 0
+          ? group.requiredAll.join(", ")
+          : `one of: ${group.requiredAny.join(", ")}`;
+      const present =
+        group.present.length > 0 ? group.present.join(", ") : "none";
+      const missing = [
+        ...group.missingRequiredAll,
+        ...group.missingRequiredAny,
+      ].join(", ");
+      return `| ${cell(group.label)} | ${group.readyForOperatorRun ? "ready" : "blocked"} | ${cell(required)} | ${cell(present)} | ${cell(missing || "none")} |`;
+    })
+    .join("\n");
+  return `# #11632 LifeOps Live-Validation Status
+
+Generated: ${status.generatedAt}
+
+Verdict: **not closeable**. This is a read-only status artifact; live OAuth,
+account, sandbox, and physical-device rows still need operator evidence.
+
+| Surface | Status | Required | Present env names | Missing |
+|---|---|---|---|---|
+${rows}
+
+## Device Tooling
+
+| Tool | Available | Summary |
+|---|---:|---|
+| adb | ${status.devices.adb.available ? "yes" : "no"} | ${cell(status.devices.adb.summary)} |
+| xcrun | ${status.devices.xcrun.available ? "yes" : "no"} | ${cell(status.devices.xcrun.summary)} |
+| devicectl | ${status.devices.devicectl.available ? "yes" : "no"} | ${cell(status.devices.devicectl.summary)} |
+
+## Existing Evidence
+
+${status.existingEvidence.map((entry) => `- ${entry.exists ? "present" : "missing"}: \`${entry.path}\``).join("\n")}
+`;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const status = buildStatus();
+mkdirSync(dirname(args.out), { recursive: true });
+writeFileSync(args.out, `${JSON.stringify(status, null, 2)}\n`, "utf8");
+writeFileSync(
+  join(dirname(args.out), "README.md"),
+  renderMarkdown(status),
+  "utf8",
+);
+console.log(`[11632-status] wrote ${args.out}`);
+console.log(
+  `[11632-status] closeable=${status.verdict.closeable} blocked=${status.verdict.blockedGroups.join(",")}`,
+);


### PR DESCRIPTION
## Summary

Adds a read-only status collector for #11632, the live/operator half of the LifeOps OWNER/AGENT validation lane.

- records credential/device readiness by connector family without printing secret values
- inspects the existing #8833 keyless evidence and the new #11632 status artifact locations
- reports native tooling availability (`adb`, `xcrun`, `devicectl`) without claiming device rows are complete
- adds a manual workflow that can run the deterministic OWNER/AGENT matrix and optionally run live connector suites when credentials are configured
- commits the current local status under `.github/issue-evidence/8833-lifeops-live-validation/11632-status/`

Current local verdict remains `closeable: false`: this host has no live model/OAuth connector env, no iOS/macOS tooling, and no committed live connector artifacts. The collector is meant to make that blocker explicit and repeatable, not to substitute for real operator evidence.

## Verification

- `node --check scripts/lifeops/collect-11632-live-validation-status.mjs`
- `node scripts/lifeops/collect-11632-live-validation-status.mjs`
- `bunx biome check scripts/lifeops/collect-11632-live-validation-status.mjs .github/workflows/lifeops-live-validation-11632.yml`
- `git diff --check HEAD~1..HEAD`

## Evidence

- `.github/issue-evidence/8833-lifeops-live-validation/11632-status/status.json`
- `.github/issue-evidence/8833-lifeops-live-validation/11632-status/README.md`

N/A: live OAuth/device screenshots/video are still required by #11632 and are explicitly reported blocked in the status artifact.