### PR TITLE
fix(ui): harden native Cloud API fallback tokens

### DIFF
--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ElizaClient } from "./client-base";
 import { cloudTokenSecsRemaining, getCloudAuthToken } from "./client-cloud";
 
@@ -47,6 +47,18 @@ describe("getCloudAuthToken (Cloud = Steward everywhere)", () => {
     client.setToken("client-token");
     expect(getCloudAuthToken(client)).toBe("client-token");
     client.setToken(null);
+  });
+
+  it("dispatches steward-token-sync when the client REST token changes", () => {
+    const listener = vi.fn();
+    window.addEventListener("steward-token-sync", listener);
+    const client = new ElizaClient();
+
+    client.setToken("client-token");
+    client.setToken(null);
+
+    window.removeEventListener("steward-token-sync", listener);
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 
   it("returns null when no token is available anywhere", () => {

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -265,7 +265,7 @@ describe("cloud api-client transport bridge", () => {
   // never the Steward JWT — native must fall back to it, web must not change.
 
   describe("cloud API key auth fallback (#11930)", () => {
-    const CLOUD_API_KEY = "eliza-cloud-owner-api-key";
+    const CLOUD_API_KEY = "eliza_cloud_owner_api_key";
 
     function nativeOk(): void {
       capacitorMocks.request.mockResolvedValue({
@@ -299,6 +299,41 @@ describe("cloud api-client transport bridge", () => {
           }),
         }),
       );
+    });
+
+    it("native: does not send a local-agent bearer token as Cloud authorization", async () => {
+      capacitorState.isNative = true;
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+        apiToken: "local-agent-bearer-token",
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      const call = capacitorMocks.request.mock.calls[0]?.[0];
+      expect(call?.url).toBe("https://api.elizacloud.ai/api/v1/apps");
+      expect(call?.headers.authorization).toBeUndefined();
+    });
+
+    it("native: does not send a non-cloud legacy global token as Cloud authorization", async () => {
+      capacitorState.isNative = true;
+      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
+      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+        "legacy-local-agent-bearer-token";
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://www.elizacloud.ai",
+      });
+      nativeOk();
+
+      await api("/api/v1/apps");
+
+      const call = capacitorMocks.request.mock.calls[0]?.[0];
+      expect(call?.url).toBe("https://api.elizacloud.ai/api/v1/apps");
+      expect(call?.headers.authorization).toBeUndefined();
     });
 
     it("native: a live Steward JWT still WINS over the cloud API key when both exist", async () => {
@@ -351,7 +386,7 @@ describe("cloud api-client transport bridge", () => {
       capacitorState.isNative = true;
       window.localStorage.removeItem(STEWARD_TOKEN_KEY);
       (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-        "legacy-global-cloud-token";
+        "eliza_legacy_global_cloud_token";
       setBootConfig({
         branding: {},
         cloudApiBase: "https://www.elizacloud.ai",
@@ -364,7 +399,7 @@ describe("cloud api-client transport bridge", () => {
       expect(capacitorMocks.request).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: expect.objectContaining({
-            authorization: "Bearer legacy-global-cloud-token",
+            authorization: "Bearer eliza_legacy_global_cloud_token",
           }),
         }),
       );

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -29,6 +29,7 @@ import { getElizaApiToken } from "@elizaos/shared";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { getBootConfig } from "../../config/boot-config";
+import { normalizeCloudApiKeyToken } from "./cloud-api-key-token";
 import { decodeJwtPayload } from "./jwt";
 
 // The single Eliza Cloud API host the native/Electrobun transport is allowed to
@@ -202,12 +203,14 @@ function readCloudBearerToken(): string | null {
   if (!isNativeCloudRuntime()) return null;
   const globalToken = (globalThis as Record<string, unknown>)
     .__ELIZA_CLOUD_AUTH_TOKEN__;
-  if (typeof globalToken === "string" && globalToken.trim()) {
-    return globalToken.trim();
+  if (typeof globalToken === "string") {
+    const cloudKey = normalizeCloudApiKeyToken(globalToken);
+    if (cloudKey) return cloudKey;
   }
-  const restToken =
-    getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim();
-  return restToken || null;
+  return (
+    normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
+    normalizeCloudApiKeyToken(getElizaApiToken())
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/cloud/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/lib/auth-query.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const capacitorState = vi.hoisted(() => ({ isNative: false }));
@@ -112,6 +112,42 @@ describe("shared cloud query gate — session from persisted JWT only (page-relo
     setBootConfig({ branding: {}, apiToken: "eliza_native_owner_key" });
 
     const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.userId).toMatch(/^native-api-key:/);
+  });
+
+  it("native: ignores a local-agent bearer token in boot config", () => {
+    capacitorState.isNative = true;
+    setBootConfig({ branding: {}, apiToken: "local-agent-bearer-token" });
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.userId).toBeNull();
+  });
+
+  it("native: ignores a non-cloud legacy global token", () => {
+    capacitorState.isNative = true;
+    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+      "legacy-local-agent-bearer-token";
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.userId).toBeNull();
+  });
+
+  it("native: refreshes the API-key session when the token sync event fires in the same view", () => {
+    capacitorState.isNative = true;
+
+    const { result } = renderHook(() => useAuthenticatedQueryGate());
+    expect(result.current.enabled).toBe(false);
+
+    setBootConfig({ branding: {}, apiToken: "eliza_native_owner_key" });
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
 
     expect(result.current.enabled).toBe(true);
     expect(result.current.userId).toMatch(/^native-api-key:/);

--- a/packages/ui/src/cloud/lib/cloud-api-key-token.ts
+++ b/packages/ui/src/cloud/lib/cloud-api-key-token.ts
@@ -11,3 +11,10 @@
 export function isCloudApiKeyToken(token: string | null | undefined): boolean {
   return typeof token === "string" && token.trim().startsWith("eliza_");
 }
+
+export function normalizeCloudApiKeyToken(
+  token: string | null | undefined,
+): string | null {
+  const trimmed = token?.trim() ?? null;
+  return isCloudApiKeyToken(trimmed) ? trimmed : null;
+}

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -23,7 +23,7 @@ import {
   LocalStewardAuthContext,
   type LocalStewardAuthValue,
 } from "../shell/StewardProvider";
-import { isCloudApiKeyToken } from "./cloud-api-key-token";
+import { normalizeCloudApiKeyToken } from "./cloud-api-key-token";
 import { decodeJwtPayload } from "./jwt";
 
 export type StewardSessionUser = {
@@ -86,14 +86,16 @@ function nativeCloudApiKey(): string | null {
   if (!isNativeCloudRuntime()) return null;
   const globalToken = (globalThis as Record<string, unknown>)
     .__ELIZA_CLOUD_AUTH_TOKEN__;
-  if (typeof globalToken === "string" && globalToken.trim()) {
-    return globalToken.trim();
+  if (typeof globalToken === "string") {
+    const cloudKey = normalizeCloudApiKeyToken(globalToken);
+    if (cloudKey) return cloudKey;
   }
   // Only a real cloud key (not the on-device agent bearer) counts as a native
   // cloud session.
-  const configToken =
-    getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim() || null;
-  return isCloudApiKeyToken(configToken) ? configToken : null;
+  return (
+    normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
+    normalizeCloudApiKeyToken(getElizaApiToken())
+  );
 }
 
 function apiKeySessionId(token: string): string {


### PR DESCRIPTION
## Summary
- Reuse the Cloud API-key discriminator to normalize native fallback tokens before treating them as Cloud auth.
- Stop the native/Electrobun Cloud dashboard transport from sending local-agent bearer tokens from boot config, `getElizaApiToken()`, or the legacy global to `api.elizacloud.ai`.
- Add regression coverage for bad boot/global fallback tokens, valid `eliza_` Cloud keys, and same-view token-sync refresh.

Closes #12095.
Follow-up to #12046 / #12084.

## Validation
- `bun run --cwd packages/ui test src/cloud/lib/auth-query.test.tsx src/cloud/lib/api-client.test.ts src/api/client-cloud-steward-token.test.ts` — 3 files, 36 tests passed.
- `bunx biome check packages/ui/src/cloud/lib/cloud-api-key-token.ts packages/ui/src/cloud/lib/use-session-auth.ts packages/ui/src/cloud/lib/api-client.ts packages/ui/src/cloud/lib/auth-query.test.tsx packages/ui/src/cloud/lib/api-client.test.ts packages/ui/src/api/client-cloud-steward-token.test.ts` — passed.
- `git diff --check HEAD~1..HEAD` — passed.
- `bun run --cwd packages/ui typecheck` — still fails on existing package-level issues unrelated to this diff: unresolved `@elizaos/contracts` artifacts and pre-existing `AccountWithCredentialFlag` shape errors in accounts/orchestrator UI files.