### PR TITLE
fix(first-run): "On this device (recommended)" no longer misroutes to cloud (local download never triggered)

### DIFF
--- a/packages/ui/src/first-run/first-run.test.ts
+++ b/packages/ui/src/first-run/first-run.test.ts
@@ -434,6 +434,24 @@ describe("first-run flow", () => {
       draft: { localInference: "cloud-inference" },
       action: "finish",
     });
+
+    // Regression (#11841): the on-device option is labelled "On this device
+    // (recommended)". The word "recommended" must NOT be read as a cloud signal,
+    // or an explicit local pick becomes cloud-inference and the local model
+    // download never triggers.
+    const onDeviceRecommended = applyFirstRunVoiceTranscript({
+      step: "inference",
+      draft: localDraft,
+      transcript: "On this device (recommended)",
+    });
+    expect(onDeviceRecommended).toMatchObject({
+      step: "inference",
+      draft: { localInference: "all-local" },
+      action: "finish",
+    });
+    expect(
+      firstRunDownloadsLocalModel(onDeviceRecommended.draft.localInference),
+    ).toBe(true);
   });
 
   it("filters prompt echo before voice transcripts can mutate setup state", () => {

--- a/packages/ui/src/first-run/first-run.ts
+++ b/packages/ui/src/first-run/first-run.ts
@@ -341,8 +341,15 @@ export function applyFirstRunVoiceTranscript(args: {
       /\b(?:local|on device|on-device|this device|this computer|offline|device|phone)\b/.test(
         command,
       );
-    const wantsCloud =
-      /\b(?:cloud|elizacloud|eliza cloud|recommended|online)\b/.test(command);
+    // NB: "recommended" is NOT a cloud signal. The on-device option is labelled
+    // "On this device (recommended)", so matching "recommended" here misread an
+    // explicit local pick as cloud → `localInference` became "cloud-inference"
+    // and the local model download never triggered (#11841). Cloud options still
+    // carry "cloud"/"eliza cloud"/"online"; a bare "recommended" falls through to
+    // the same cloud-inference default below, so removing it changes nothing else.
+    const wantsCloud = /\b(?:cloud|elizacloud|eliza cloud|online)\b/.test(
+      command,
+    );
     if (wantsLocal && !wantsCloud) {
       draft.localInference = "all-local";
       return { step: "inference", draft, action: "finish" };


### PR DESCRIPTION
## Bug
Picking the local inference option — labelled **"On this device (recommended)"** — set `localInference = "cloud-inference"` instead of `all-local`, so `firstRunDownloadsLocalModel()` returned false and **the local model download was never requested**.

Root cause: the inference-step parser's cloud regex matched the word **"recommended"**:
```
/\b(?:cloud|elizacloud|eliza cloud|recommended|online)\b/
```
Since the on-device option carries "(recommended)", an explicit local pick was classified as cloud.

## Fix
Remove `recommended` from the cloud regex. It's a UI qualifier, not a cloud signal — cloud options still match on `cloud`/`eliza cloud`/`online`, and a bare "recommended" falls through to the same cloud-inference default, so nothing else changes.

## Test
Added a regression test asserting `applyFirstRunVoiceTranscript(..., "On this device (recommended)")` yields `localInference: "all-local"` + `firstRunDownloadsLocalModel(...) === true`. Full first-run suite: 22/22.

Split out of the swarm branch as a clean, single-purpose fix (the #11841 keep-awake work it rode alongside is already on develop via #11897).

🤖 Generated with [Claude Code](https://claude.com/claude-code)