### PR TITLE
fix(google-genai): surface native Gemini tool calls (#12077)

### DIFF
--- a/.github/issue-evidence/12077-google-genai-tool-calls.md
+++ b/.github/issue-evidence/12077-google-genai-tool-calls.md
@@ -1,0 +1,47 @@
+# #12077 Google GenAI native tool-call evidence
+
+Date: 2026-07-03
+
+## Summary
+
+Implemented the agent-actionable Google GenAI parser fix:
+
+- Native Gemini function calls are now surfaced from both `response.functionCalls` and `candidates[].content.parts[].functionCall`.
+- Tool calls are normalized into the runtime-compatible shape with `id`, `name`, `arguments`, `toolName`, `toolCallId`, `args`, and `input`.
+- Native result calls (`messages`, `tools`, `toolChoice`, or `responseSchema`) return `{ text, toolCalls, finishReason, usage, providerMetadata }`.
+- Legacy prompt-only calls still return a plain string.
+- Trajectory details now record `toolCalls`, `finishReason`, provider metadata, and provider token usage when available.
+
+## Mocked regression coverage
+
+`plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts` covers:
+
+- legacy prompt-only text response remains a string.
+- native text-only response returns a rich result with empty `toolCalls`.
+- one Gemini tool call from `response.functionCalls`.
+- multiple Gemini tool calls from `candidates[].content.parts[].functionCall`.
+- generated trajectory details include the normalized tool calls.
+
+## Live trajectory status
+
+Added a credential-gated live trajectory test in `plugins/plugin-google-genai/__tests__/trajectory.test.ts`:
+
+- `VITEST_LANE=post-merge bunx vitest run --config vitest.config.ts __tests__/trajectory.test.ts`
+- The test self-skips unless `GOOGLE_GENERATIVE_AI_API_KEY` is present.
+
+Credential audit, names only:
+
+- Current process env: no `GOOGLE_GENERATIVE_AI_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY`.
+- `/Users/shawwalters/eliza-workspace/milady/eliza/.env.local`: only Google OAuth client keys found, no Gemini/Google Generative AI key.
+- `gh secret list --repo elizaOS/eliza --json name,updatedAt`: no Gemini/Google Generative AI key secret present.
+
+Live Gemini model evidence remains blocked until a real `GOOGLE_GENERATIVE_AI_API_KEY` is provided.
+
+## Verification
+
+- `bunx vitest run --config vitest.config.ts __tests__/native-plumbing.shape.test.ts`: 7 passed.
+- `bunx vitest run --config vitest.config.ts`: 16 passed, 1 skipped.
+- `VITEST_LANE=post-merge bunx vitest run --config vitest.config.ts __tests__/trajectory.test.ts`: 1 skipped due missing key.
+- `bun run --cwd plugins/plugin-google-genai typecheck`: passed.
+- `bunx @biomejs/biome check plugins/plugin-google-genai/models/text.ts plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts plugins/plugin-google-genai/__tests__/trajectory.test.ts`: passed.
+- `git diff --check -- plugins/plugin-google-genai/models/text.ts plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts plugins/plugin-google-genai/__tests__/trajectory.test.ts`: passed.

--- a/plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts
@@ -97,56 +97,83 @@ describe("Google GenAI text native plumbing", () => {
     );
   });
 
+  it("keeps legacy prompt-only calls as plain text", async () => {
+    await expect(
+      handleTextSmall(runtime() as never, { prompt: "hello" } as never),
+    ).resolves.toBe('{"ok":true}');
+  });
+
   it("maps generic tools, toolChoice, response schema, and attachments into generateContent", async () => {
     const bytes = new Uint8Array([1, 2, 3]);
 
-    await expect(
-      handleTextSmall(
-        runtime() as never,
-        {
-          prompt: "Use the tools",
-          system: "You are concise.",
-          temperature: 0.2,
-          maxTokens: 123,
-          stopSequences: ["STOP"],
-          tools: {
-            lookup_weather: {
-              description: "Get weather",
-              inputSchema: {
-                type: "object",
-                properties: {
-                  city: { type: "string" },
-                },
-                required: ["city"],
-              },
-            },
-          },
-          toolChoice: { type: "tool", toolName: "lookup_weather" },
-          responseSchema: {
-            schema: {
+    const result = (await handleTextSmall(
+      runtime() as never,
+      {
+        prompt: "Use the tools",
+        system: "You are concise.",
+        temperature: 0.2,
+        maxTokens: 123,
+        stopSequences: ["STOP"],
+        tools: {
+          lookup_weather: {
+            description: "Get weather",
+            inputSchema: {
               type: "object",
               properties: {
-                ok: { type: "boolean" },
+                city: { type: "string" },
               },
+              required: ["city"],
             },
           },
-          attachments: [
-            {
-              data: "data:image/png;base64,AAA=",
-              mediaType: "image/png",
+        },
+        toolChoice: { type: "tool", toolName: "lookup_weather" },
+        responseSchema: {
+          schema: {
+            type: "object",
+            properties: {
+              ok: { type: "boolean" },
             },
-            {
-              data: "https://files.example/doc.pdf",
-              mediaType: "application/pdf",
-            },
-            {
-              data: bytes,
-              mediaType: "application/octet-stream",
-            },
-          ],
-        } as never,
-      ),
-    ).resolves.toBe('{"ok":true}');
+          },
+        },
+        attachments: [
+          {
+            data: "data:image/png;base64,AAA=",
+            mediaType: "image/png",
+          },
+          {
+            data: "https://files.example/doc.pdf",
+            mediaType: "application/pdf",
+          },
+          {
+            data: bytes,
+            mediaType: "application/octet-stream",
+          },
+        ],
+      } as never,
+    )) as unknown as {
+      text: string;
+      toolCalls: unknown[];
+      usage: {
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+      };
+      providerMetadata: { provider: string; modelName: string };
+    };
+
+    expect(result).toMatchObject({
+      text: '{"ok":true}',
+      toolCalls: [],
+      usage: {
+        promptTokens: "Use the tools".length,
+        completionTokens: '{"ok":true}'.length,
+        totalTokens: "Use the tools".length + '{"ok":true}'.length,
+      },
+      providerMetadata: {
+        provider: "google-genai",
+        modelName: "gemini-small",
+      },
+    });
 
     expect(mocks.generateContent).toHaveBeenCalledWith({
       model: "gemini-small",
@@ -223,8 +250,173 @@ describe("Google GenAI text native plumbing", () => {
     );
   });
 
+  it("surfaces a Gemini functionCalls response as native tool calls and records it", async () => {
+    mocks.generateContent.mockResolvedValueOnce({
+      text: "",
+      functionCalls: [
+        {
+          id: "weather-call-1",
+          name: "lookup_weather",
+          args: { city: "Paris", unit: "celsius" },
+        },
+      ],
+      candidates: [{ finishReason: "STOP" }],
+      modelVersion: "gemini-2.0-flash-001",
+      responseId: "response-1",
+      usageMetadata: {
+        promptTokenCount: 11,
+        candidatesTokenCount: 3,
+        totalTokenCount: 14,
+      },
+    });
+
+    const result = (await handleTextSmall(
+      runtime() as never,
+      {
+        prompt: "Check Paris weather",
+        tools: {
+          lookup_weather: {
+            description: "Get weather",
+            inputSchema: {
+              type: "object",
+              properties: {
+                city: { type: "string" },
+                unit: { type: "string" },
+              },
+            },
+          },
+        },
+        toolChoice: { type: "tool", toolName: "lookup_weather" },
+      } as never,
+    )) as unknown as {
+      text: string;
+      toolCalls: unknown[];
+      finishReason: string;
+      usage: unknown;
+      providerMetadata: unknown;
+    };
+
+    const expectedToolCalls = [
+      {
+        id: "weather-call-1",
+        name: "lookup_weather",
+        arguments: { city: "Paris", unit: "celsius" },
+        toolName: "lookup_weather",
+        toolCallId: "weather-call-1",
+        type: "function",
+        args: { city: "Paris", unit: "celsius" },
+        input: { city: "Paris", unit: "celsius" },
+      },
+    ];
+
+    expect(result).toMatchObject({
+      text: "",
+      toolCalls: expectedToolCalls,
+      finishReason: "tool-calls",
+      usage: {
+        promptTokens: 11,
+        completionTokens: 3,
+        totalTokens: 14,
+      },
+      providerMetadata: {
+        provider: "google-genai",
+        modelName: "gemini-small",
+        modelVersion: "gemini-2.0-flash-001",
+        responseId: "response-1",
+      },
+    });
+
+    const details = mocks.recordLlmCall.mock.calls.at(-1)?.[1];
+    expect(details).toMatchObject({
+      response: "",
+      toolCalls: expectedToolCalls,
+      finishReason: "tool-calls",
+      promptTokens: 11,
+      completionTokens: 3,
+      providerMetadata: {
+        provider: "google-genai",
+        modelName: "gemini-small",
+      },
+    });
+  });
+
+  it("extracts multiple Gemini function calls from candidate content parts", async () => {
+    mocks.generateContent.mockResolvedValueOnce({
+      candidates: [
+        {
+          finishReason: "STOP",
+          content: {
+            parts: [
+              { text: "I will check both." },
+              {
+                functionCall: {
+                  name: "lookup_weather",
+                  args: { city: "Paris" },
+                },
+              },
+              {
+                functionCall: {
+                  id: "timezone-call-1",
+                  name: "lookup_timezone",
+                  args: { city: "Paris" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 9,
+        candidatesTokenCount: 5,
+        totalTokenCount: 14,
+      },
+    });
+
+    const result = (await handleTextSmall(
+      runtime() as never,
+      {
+        prompt: "Check Paris weather and timezone",
+        tools: [
+          {
+            name: "lookup_weather",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+            },
+          },
+          {
+            name: "lookup_timezone",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+            },
+          },
+        ],
+      } as never,
+    )) as unknown as {
+      text: string;
+      toolCalls: Array<{ id: string; name: string; input: unknown }>;
+      finishReason: string;
+    };
+
+    expect(result.text).toBe("I will check both.");
+    expect(result.finishReason).toBe("tool-calls");
+    expect(result.toolCalls).toMatchObject([
+      {
+        id: "google-genai-tool-call-1",
+        name: "lookup_weather",
+        input: { city: "Paris" },
+      },
+      {
+        id: "timezone-call-1",
+        name: "lookup_timezone",
+        input: { city: "Paris" },
+      },
+    ]);
+  });
+
   it("omits duplicate system chat messages from the rendered prompt", async () => {
-    await handleTextSmall(
+    const result = (await handleTextSmall(
       runtime() as never,
       {
         system: "Shared system",
@@ -233,7 +425,12 @@ describe("Google GenAI text native plumbing", () => {
           { role: "user", content: "Hello" },
         ],
       } as never,
-    );
+    )) as unknown as { text: string; toolCalls: unknown[] };
+
+    expect(result).toMatchObject({
+      text: '{"ok":true}',
+      toolCalls: [],
+    });
 
     expect(mocks.generateContent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/plugins/plugin-google-genai/__tests__/trajectory.test.ts
+++ b/plugins/plugin-google-genai/__tests__/trajectory.test.ts
@@ -90,5 +90,61 @@ if (!SHOULD_RUN) {
       expect(structuredCall.completionTokens ?? 0).toBeGreaterThan(0);
       expect(structuredCall.response).toContain("4");
     }, 120_000);
+
+    it("records a native Gemini tool call trajectory", async () => {
+      const { handleTextSmall } = await import("../models/text");
+
+      const calls: CapturedLlmCall[] = [];
+      const runtime = createInlineRuntime(calls);
+
+      const result = (await runWithTrajectoryContext(
+        { trajectoryStepId: "step-google-tool-call" },
+        async () =>
+          handleTextSmall(runtime, {
+            prompt:
+              "Use the lookup_weather tool for Paris. Do not answer in plain text.",
+            maxTokens: 128,
+            tools: {
+              lookup_weather: {
+                description: "Lookup current weather for a city.",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    city: { type: "string" },
+                  },
+                  required: ["city"],
+                },
+              },
+            },
+            toolChoice: { type: "tool", toolName: "lookup_weather" },
+          } as Parameters<typeof handleTextSmall>[1]),
+      )) as unknown as {
+        text: string;
+        toolCalls?: Array<{
+          name?: string;
+          toolName?: string;
+          input?: unknown;
+          arguments?: unknown;
+        }>;
+        finishReason?: string;
+      };
+
+      expect(result.toolCalls?.length ?? 0).toBeGreaterThan(0);
+      expect(
+        result.toolCalls?.some(
+          (call) =>
+            call.name === "lookup_weather" ||
+            call.toolName === "lookup_weather",
+        ),
+      ).toBe(true);
+      expect(result.finishReason).toBe("tool-calls");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.stepId).toBe("step-google-tool-call");
+      expect(calls[0]?.actionType).toBe(
+        "google-genai.TEXT_SMALL.generateContent",
+      );
+      expect(calls[0]?.response ?? result.text).toBe(result.text);
+    }, 120_000);
   });
 }

--- a/plugins/plugin-google-genai/models/text.ts
+++ b/plugins/plugin-google-genai/models/text.ts
@@ -1,7 +1,10 @@
 import type {
   GenerateTextParams,
   IAgentRuntime,
+  JsonValue,
   RecordLlmCallDetails,
+  TokenUsage,
+  ToolCall,
 } from "@elizaos/core";
 import {
   buildCanonicalSystemPrompt,
@@ -53,6 +56,48 @@ type GoogleFunctionDeclaration = {
 type GoogleToolDeclaration = {
   functionDeclarations?: GoogleFunctionDeclaration[];
 };
+
+type GoogleFunctionCall = {
+  id?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+};
+
+type GoogleContentPart = {
+  text?: string;
+  thought?: boolean;
+  functionCall?: GoogleFunctionCall;
+};
+
+type GoogleGenerateContentResponse = {
+  text?: string;
+  functionCalls?: GoogleFunctionCall[];
+  candidates?: Array<{
+    content?: {
+      parts?: GoogleContentPart[];
+    };
+    finishReason?: string;
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+    cachedContentTokenCount?: number;
+  };
+  modelVersion?: string;
+  responseId?: string;
+  createTime?: string;
+};
+
+type GoogleNativeTextResult = {
+  text: string;
+  toolCalls: ToolCall[];
+  finishReason?: string;
+  usage: TokenUsage;
+  providerMetadata: Record<string, JsonValue | object | undefined>;
+};
+
+type GoogleTextModelResult = string & GoogleNativeTextResult;
 
 type GenericToolDescriptor = {
   name?: string;
@@ -289,6 +334,181 @@ function getModelNameForType(
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => toJsonValue(entry));
+  }
+  if (isRecord(value)) {
+    const record: Record<string, JsonValue> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry !== undefined) {
+        record[key] = toJsonValue(entry);
+      }
+    }
+    return record;
+  }
+  return String(value);
+}
+
+function toToolArguments(value: unknown): Record<string, JsonValue> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const jsonValue = toJsonValue(value);
+  return isRecord(jsonValue) ? (jsonValue as Record<string, JsonValue>) : {};
+}
+
+function readGoogleText(response: GoogleGenerateContentResponse): string {
+  if (typeof response.text === "string") {
+    return response.text;
+  }
+  return (
+    response.candidates?.[0]?.content?.parts
+      ?.filter((part) => !part.thought && typeof part.text === "string")
+      .map((part) => part.text)
+      .join("") ?? ""
+  );
+}
+
+function readGoogleFunctionCalls(
+  response: GoogleGenerateContentResponse,
+): GoogleFunctionCall[] {
+  if (
+    Array.isArray(response.functionCalls) &&
+    response.functionCalls.length > 0
+  ) {
+    return response.functionCalls;
+  }
+  const calls: GoogleFunctionCall[] = [];
+  for (const candidate of response.candidates ?? []) {
+    for (const part of candidate.content?.parts ?? []) {
+      if (part.functionCall) {
+        calls.push(part.functionCall);
+      }
+    }
+  }
+  return calls;
+}
+
+function normalizeGoogleToolCalls(
+  response: GoogleGenerateContentResponse,
+): ToolCall[] {
+  return readGoogleFunctionCalls(response)
+    .map((call, index): ToolCall | undefined => {
+      const name = typeof call.name === "string" ? call.name : "";
+      if (!name) {
+        return undefined;
+      }
+      const id =
+        typeof call.id === "string" && call.id.length > 0
+          ? call.id
+          : `google-genai-tool-call-${index + 1}`;
+      const args = toToolArguments(call.args);
+      return {
+        id,
+        name,
+        arguments: args,
+        toolName: name,
+        toolCallId: id,
+        type: "function",
+        args,
+        input: args,
+      };
+    })
+    .filter((call): call is ToolCall => Boolean(call));
+}
+
+function normalizeGoogleFinishReason(
+  response: GoogleGenerateContentResponse,
+  toolCalls: ToolCall[],
+): string | undefined {
+  if (toolCalls.length > 0) {
+    return "tool-calls";
+  }
+  return response.candidates?.find((candidate) => candidate.finishReason)
+    ?.finishReason;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+async function normalizeGoogleUsage(
+  response: GoogleGenerateContentResponse,
+  prompt: string,
+  text: string,
+): Promise<TokenUsage> {
+  const metadata = response.usageMetadata;
+  const promptTokens =
+    firstNumber(metadata?.promptTokenCount) ?? (await countTokens(prompt));
+  const completionTokens =
+    firstNumber(metadata?.candidatesTokenCount) ?? (await countTokens(text));
+  const totalTokens =
+    firstNumber(metadata?.totalTokenCount) ?? promptTokens + completionTokens;
+
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    cacheReadInputTokens: firstNumber(metadata?.cachedContentTokenCount),
+  };
+}
+
+async function buildGoogleNativeTextResult(
+  response: GoogleGenerateContentResponse,
+  prompt: string,
+  modelName: string,
+): Promise<GoogleNativeTextResult> {
+  const text = readGoogleText(response);
+  const toolCalls = normalizeGoogleToolCalls(response);
+  const usage = await normalizeGoogleUsage(response, prompt, text);
+
+  return {
+    text,
+    toolCalls,
+    finishReason: normalizeGoogleFinishReason(response, toolCalls),
+    usage,
+    providerMetadata: {
+      provider: "google-genai",
+      modelName,
+      modelVersion: response.modelVersion,
+      responseId: response.responseId,
+      createTime: response.createTime,
+      usageMetadata: response.usageMetadata,
+    },
+  };
+}
+
+function usesNativeTextResult(
+  params: GenerateTextParamsWithAttachments,
+): boolean {
+  return Boolean(
+    params.messages ||
+      params.tools ||
+      params.toolChoice ||
+      params.responseSchema,
+  );
+}
+
 function buildGoogleGenerationConfig(
   params: GenerateTextParamsWithAttachments,
   systemInstruction: string | undefined,
@@ -353,6 +573,7 @@ async function generateContentWithTrajectory(
   maxTokens: number | undefined,
   maxTokensOmitted: boolean | undefined,
   request: GenerateContentParams,
+  shouldReturnNativeResult: boolean,
 ): Promise<string> {
   const details = createLlmCallDetails(
     modelName,
@@ -364,26 +585,31 @@ async function generateContentWithTrajectory(
     maxTokensOmitted,
   );
   const response = await recordLlmCall(runtime, details, async () => {
-    const result = await genAI.models.generateContent(request);
-    const text = result.text || "";
-    details.response = text;
-    details.promptTokens = await countTokens(prompt);
-    details.completionTokens = await countTokens(text);
-    return result;
+    const result = (await genAI.models.generateContent(
+      request,
+    )) as GoogleGenerateContentResponse;
+    const normalized = await buildGoogleNativeTextResult(
+      result,
+      prompt,
+      modelName,
+    );
+    details.response = normalized.text;
+    details.toolCalls = normalized.toolCalls;
+    details.finishReason = normalized.finishReason;
+    details.providerMetadata = normalized.providerMetadata;
+    details.promptTokens = normalized.usage.promptTokens;
+    details.completionTokens = normalized.usage.completionTokens;
+    details.cacheReadInputTokens = normalized.usage.cacheReadInputTokens;
+    return normalized;
   });
 
-  const text = response.text || "";
-  const promptTokens = details.promptTokens ?? (await countTokens(prompt));
-  const completionTokens =
-    details.completionTokens ?? (await countTokens(text));
+  emitModelUsageEvent(runtime, modelType, prompt, response.usage);
 
-  emitModelUsageEvent(runtime, modelType, prompt, {
-    promptTokens,
-    completionTokens,
-    totalTokens: promptTokens + completionTokens,
-  });
+  if (shouldReturnNativeResult) {
+    return response as GoogleTextModelResult;
+  }
 
-  return text;
+  return response.text;
 }
 
 export async function handleTextSmall(
@@ -435,6 +661,7 @@ export async function handleTextSmall(
           stopSequences,
         ),
       },
+      usesNativeTextResult(params),
     );
   } catch (error) {
     logger.error(
@@ -493,6 +720,7 @@ export async function handleTextLarge(
           stopSequences,
         ),
       },
+      usesNativeTextResult(params),
     );
   } catch (error) {
     logger.error(
@@ -587,6 +815,7 @@ async function handleTextWithType(
           stopSequences,
         ),
       },
+      usesNativeTextResult(params),
     );
   } catch (error) {
     logger.error(


### PR DESCRIPTION
## Summary
- surface Gemini native tool calls from both response.functionCalls and candidate functionCall parts
- return the native text result shape for messages/tools/toolChoice/responseSchema calls while preserving prompt-only string responses
- record toolCalls, finishReason, provider metadata, and usage in trajectories
- add mocked regression coverage plus a credential-gated live Gemini tool-call trajectory test

## Verification
- bunx vitest run --config vitest.config.ts __tests__/native-plumbing.shape.test.ts
- bunx vitest run --config vitest.config.ts
- VITEST_LANE=post-merge bunx vitest run --config vitest.config.ts __tests__/trajectory.test.ts (skips without GOOGLE_GENERATIVE_AI_API_KEY)
- bun run --cwd plugins/plugin-google-genai typecheck
- bunx @biomejs/biome check plugins/plugin-google-genai/models/text.ts plugins/plugin-google-genai/__tests__/native-plumbing.shape.test.ts plugins/plugin-google-genai/__tests__/trajectory.test.ts
- git diff --check

## Live evidence status
No GOOGLE_GENERATIVE_AI_API_KEY/GEMINI_API_KEY/GOOGLE_API_KEY is present in process env or the checked local production env file, and the repo secret list has no Gemini/Google Generative AI key. The live trajectory lane is included and self-skips until that credential is provided.

Refs #12077