### PR TITLE
fix(security): owner-gate raw DB rows and unify blocked env keys

### DIFF
--- a/packages/agent/src/api/plugin-discovery-helpers.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.ts
@@ -18,6 +18,8 @@ import {
 } from "./plugin-validation.ts";
 import { findOwnPackageRoot } from "./server-helpers.ts";
 
+export { BLOCKED_ENV_KEYS } from "../config/blocked-env-keys.ts";
+
 const require = createRequire(import.meta.url);
 
 // Pure-disk override helpers — inlined here to avoid module-scope dynamic
@@ -633,54 +635,6 @@ export function prefixLabel(key: string, suffix: string): string {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
     .join(" ");
 }
-
-// ---------------------------------------------------------------------------
-// Blocked env keys — dangerous system vars that must never be written via API
-// ---------------------------------------------------------------------------
-
-export const BLOCKED_ENV_KEYS = new Set([
-  // System-level injection vectors
-  "LD_PRELOAD",
-  "LD_LIBRARY_PATH",
-  "DYLD_INSERT_LIBRARIES",
-  "DYLD_LIBRARY_PATH",
-  "NODE_OPTIONS",
-  "NODE_EXTRA_CA_CERTS",
-  // TLS bypass — setting to "0" disables ALL certificate verification,
-  // enabling MITM interception of every outbound HTTPS request (API keys
-  // for OpenAI, Anthropic, ElevenLabs etc. sent in plaintext headers).
-  "NODE_TLS_REJECT_UNAUTHORIZED",
-  // Proxy hijack — routes all HTTP/HTTPS traffic through attacker proxy,
-  // exposing Authorization headers and API keys in transit.
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "ALL_PROXY",
-  "NO_PROXY",
-  // Module resolution override
-  "NODE_PATH",
-  // CA certificate override — trust rogue CAs for MITM
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "CURL_CA_BUNDLE",
-  "PATH",
-  "HOME",
-  "SHELL",
-  // Auth / step-up tokens — writable via API would grant privilege escalation
-  "ELIZA_API_TOKEN",
-  "ELIZA_WALLET_EXPORT_TOKEN",
-  "ELIZA_TERMINAL_RUN_TOKEN",
-  // Wallet private keys — writable via API would enable key theft / replacement
-  "EVM_PRIVATE_KEY",
-  "SOLANA_PRIVATE_KEY",
-  // Opinion Trade plugin secrets
-  "OPINION_PRIVATE_KEY",
-  "OPINION_API_KEY",
-  // Third-party auth tokens
-  "GITHUB_TOKEN",
-  // Database connection strings
-  "DATABASE_URL",
-  "POSTGRES_URL",
-]);
 
 /**
  * Top-level config keys accepted by `PUT /api/config`.

--- a/packages/agent/src/config/blocked-env-keys.test.ts
+++ b/packages/agent/src/config/blocked-env-keys.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { BLOCKED_ENV_KEYS } from "./blocked-env-keys";
+import { collectConfigEnvVars } from "./env-vars";
+
+describe("BLOCKED_ENV_KEYS", () => {
+  it("is the canonical union used by API writes and startup env sync", async () => {
+    const pluginDiscovery = await import("../api/plugin-discovery-helpers");
+
+    expect(pluginDiscovery.BLOCKED_ENV_KEYS).toBe(BLOCKED_ENV_KEYS);
+    expect(BLOCKED_ENV_KEYS.has("STEWARD_API_KEY")).toBe(true);
+    expect(BLOCKED_ENV_KEYS.has("STEWARD_AGENT_TOKEN")).toBe(true);
+    expect(BLOCKED_ENV_KEYS.has("ELIZA_CLOUD_CLIENT_ADDRESS_KEY")).toBe(true);
+    expect(BLOCKED_ENV_KEYS.has("OPINION_API_KEY")).toBe(true);
+    expect(BLOCKED_ENV_KEYS.has("OPINION_PRIVATE_KEY")).toBe(true);
+  });
+
+  it("blocks canonical secret keys during startup env collection", () => {
+    const envVars = collectConfigEnvVars({
+      env: {
+        vars: {
+          OPINION_API_KEY: "opinion-api",
+          STEWARD_API_KEY: "steward-api",
+          SAFE_PUBLIC_FLAG: "enabled",
+        },
+        OPINION_PRIVATE_KEY: "opinion-private",
+        STEWARD_AGENT_TOKEN: "steward-token",
+        SAFE_DIRECT_VALUE: "direct",
+      },
+    });
+
+    expect(envVars).toEqual({
+      SAFE_PUBLIC_FLAG: "enabled",
+      SAFE_DIRECT_VALUE: "direct",
+    });
+  });
+});

--- a/packages/agent/src/config/blocked-env-keys.ts
+++ b/packages/agent/src/config/blocked-env-keys.ts
@@ -1,0 +1,45 @@
+/**
+ * Environment variable keys that must never be written through user-editable
+ * config or synced from config into process.env.
+ *
+ * Categories:
+ * - Process-level code injection (NODE_OPTIONS, LD_PRELOAD, ...)
+ * - TLS/proxy hijack (NODE_TLS_REJECT_UNAUTHORIZED, HTTP_PROXY, ...)
+ * - Module/path resolution and process identity (NODE_PATH, PATH, HOME, ...)
+ * - Privilege escalation and step-up tokens
+ * - Wallet/steward/private trading secrets
+ * - Database connection strings
+ */
+export const BLOCKED_ENV_KEYS = new Set([
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "NODE_OPTIONS",
+  "NODE_EXTRA_CA_CERTS",
+  "NODE_TLS_REJECT_UNAUTHORIZED",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "NODE_PATH",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "CURL_CA_BUNDLE",
+  "PATH",
+  "HOME",
+  "SHELL",
+  "ELIZA_API_TOKEN",
+  "ELIZA_WALLET_EXPORT_TOKEN",
+  "ELIZA_TERMINAL_RUN_TOKEN",
+  "EVM_PRIVATE_KEY",
+  "SOLANA_PRIVATE_KEY",
+  "STEWARD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "ELIZA_CLOUD_CLIENT_ADDRESS_KEY",
+  "OPINION_PRIVATE_KEY",
+  "OPINION_API_KEY",
+  "GITHUB_TOKEN",
+  "DATABASE_URL",
+  "POSTGRES_URL",
+]);

--- a/packages/agent/src/config/env-vars.ts
+++ b/packages/agent/src/config/env-vars.ts
@@ -1,52 +1,5 @@
+import { BLOCKED_ENV_KEYS } from "./blocked-env-keys.ts";
 import type { ElizaConfig } from "./types.ts";
-
-/**
- * Environment variable keys that must NEVER be synced from config → process.env.
- *
- * Mirrors the BLOCKED_ENV_KEYS set in server.ts.  This is a defense-in-depth
- * gate: even if a blocked key is somehow persisted into eliza.config.json
- * (e.g. via an API bypass or manual file edit), it will not be loaded into the
- * process environment on startup.
- *
- * Categories:
- *   - Process-level code injection (NODE_OPTIONS, LD_PRELOAD, …)
- *   - TLS / proxy hijack (NODE_TLS_REJECT_UNAUTHORIZED, HTTP_PROXY, …)
- *   - Module resolution (NODE_PATH)
- *   - Privilege escalation tokens (ELIZA_API_TOKEN, …)
- *   - Wallet private keys
- *   - System paths
- */
-const BLOCKED_STARTUP_ENV_KEYS = new Set([
-  "LD_PRELOAD",
-  "LD_LIBRARY_PATH",
-  "DYLD_INSERT_LIBRARIES",
-  "DYLD_LIBRARY_PATH",
-  "NODE_OPTIONS",
-  "NODE_EXTRA_CA_CERTS",
-  "NODE_TLS_REJECT_UNAUTHORIZED",
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "ALL_PROXY",
-  "NO_PROXY",
-  "NODE_PATH",
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "CURL_CA_BUNDLE",
-  "PATH",
-  "HOME",
-  "SHELL",
-  "ELIZA_API_TOKEN",
-  "ELIZA_WALLET_EXPORT_TOKEN",
-  "ELIZA_TERMINAL_RUN_TOKEN",
-  "EVM_PRIVATE_KEY",
-  "SOLANA_PRIVATE_KEY",
-  "STEWARD_API_KEY",
-  "STEWARD_AGENT_TOKEN",
-  "ELIZA_CLOUD_CLIENT_ADDRESS_KEY",
-  "GITHUB_TOKEN",
-  "DATABASE_URL",
-  "POSTGRES_URL",
-]);
 
 /**
  * Maps connector config fields to the environment variables expected by
@@ -157,7 +110,7 @@ export function collectConfigEnvVars(
       if (!value) {
         continue;
       }
-      if (BLOCKED_STARTUP_ENV_KEYS.has(key.toUpperCase())) {
+      if (BLOCKED_ENV_KEYS.has(key.toUpperCase())) {
         continue;
       }
       entries[key] = value;
@@ -171,7 +124,7 @@ export function collectConfigEnvVars(
     if (typeof value !== "string" || !value.trim()) {
       continue;
     }
-    if (BLOCKED_STARTUP_ENV_KEYS.has(key.toUpperCase())) {
+    if (BLOCKED_ENV_KEYS.has(key.toUpperCase())) {
       continue;
     }
     entries[key] = value;
@@ -255,7 +208,7 @@ export function collectConnectorEnvVars(
       if (!normalized) {
         continue;
       }
-      if (BLOCKED_STARTUP_ENV_KEYS.has(envKey.toUpperCase())) {
+      if (BLOCKED_ENV_KEYS.has(envKey.toUpperCase())) {
         continue;
       }
       entries[envKey] = normalized;

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -1,0 +1,102 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
+
+const sharedMocks = vi.hoisted(() => ({
+  executeRawSql: vi.fn(),
+}));
+
+vi.mock("@elizaos/shared", async () => {
+  return {
+    executeRawSql: sharedMocks.executeRawSql,
+    quoteIdent: (value: string) => `"${value.replaceAll('"', '""')}"`,
+    sanitizeIdentifier: (value: string | null | undefined) =>
+      value?.replace(/[^a-zA-Z0-9_]/g, "") || null,
+    sqlLiteral: (value: string) => `'${value.replaceAll("'", "''")}'`,
+  };
+});
+
+function makeReq(url: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = url;
+  req.headers = { host: "localhost:3000" };
+  return req;
+}
+
+function fakeRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+function makeState(
+  current: CompatRuntimeState["current"] = null,
+): CompatRuntimeState {
+  return {
+    current,
+    pendingAgentName: null,
+    pendingRestartReasons: [],
+  };
+}
+
+describe("handleDatabaseRowsCompatRoute", () => {
+  it("requires OWNER role before raw table rows can be read", async () => {
+    const req = makeReq("/api/database/tables/secrets/rows");
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async (_req, routeRes) => {
+      routeRes.statusCode = 403;
+      routeRes.end(JSON.stringify({ error: "Insufficient role" }));
+      return false;
+    });
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, makeState(), { ensureOwner }),
+    ).resolves.toBe(true);
+
+    expect(ensureOwner).toHaveBeenCalledWith(
+      req,
+      res.res,
+      expect.anything(),
+      "OWNER",
+    );
+    expect(res.status()).toBe(403);
+    expect(res.json()).toEqual({ error: "Insufficient role" });
+    expect(sharedMocks.executeRawSql).not.toHaveBeenCalled();
+  });
+
+  it("continues route handling after OWNER authorization succeeds", async () => {
+    const req = makeReq("/api/database/tables/memories/rows");
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, makeState(), { ensureOwner }),
+    ).resolves.toBe(true);
+
+    expect(ensureOwner).toHaveBeenCalledWith(
+      req,
+      res.res,
+      expect.anything(),
+      "OWNER",
+    );
+    expect(res.status()).toBe(503);
+    expect(res.json()).toEqual({
+      error:
+        "Database not available. The agent may not be running or the database adapter is not initialized.",
+    });
+  });
+});

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -5,7 +5,7 @@ import {
   sanitizeIdentifier,
   sqlLiteral,
 } from "@elizaos/shared";
-import { ensureRouteAuthorized } from "./auth.ts";
+import { ensureRouteMinRole } from "./auth.ts";
 import {
   type CompatRuntimeState,
   DATABASE_UNAVAILABLE_MESSAGE,
@@ -20,6 +20,10 @@ interface TableIntrospection {
   resolvedSchema: string;
   columns: string[];
   expiresAt: number;
+}
+
+interface DatabaseRowsCompatRouteDeps {
+  ensureOwner?: typeof ensureRouteMinRole;
 }
 
 // Resolved schema + column list for a (schema, table) — stable unless a
@@ -53,6 +57,7 @@ export async function handleDatabaseRowsCompatRoute(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   state: CompatRuntimeState,
+  deps: DatabaseRowsCompatRouteDeps = {},
 ): Promise<boolean> {
   const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
   const match = /^\/api\/database\/tables\/([^/]+)\/rows$/.exec(pathname);
@@ -60,7 +65,8 @@ export async function handleDatabaseRowsCompatRoute(
     return false;
   }
 
-  if (!(await ensureRouteAuthorized(req, res, state))) {
+  const ensureOwner = deps.ensureOwner ?? ensureRouteMinRole;
+  if (!(await ensureOwner(req, res, state, "OWNER"))) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Addresses the first #12088 trust/security slice:

- Fixes item 1: `GET /api/database/tables/:name/rows` now requires OWNER via `ensureRouteMinRole(..., "OWNER")` before any raw SQL table read can run.
- Fixes item 2: replaces the drifted blocked-env key copies with one canonical `BLOCKED_ENV_KEYS` union used by startup env sync and API config/plugin env writes.
- Adds regression coverage for the OWNER gate and the canonical blocked key union.

## Validation

Passed locally on current `origin/develop` after `bun run --cwd packages/core prebuild`:

```bash
bun run --cwd packages/app-core test -- src/api/database-rows-compat-routes.test.ts
bun run --cwd packages/agent test -- src/config/blocked-env-keys.test.ts
bunx @biomejs/biome check \
  packages/app-core/src/api/database-rows-compat-routes.ts \
  packages/app-core/src/api/database-rows-compat-routes.test.ts \
  packages/agent/src/config/blocked-env-keys.ts \
  packages/agent/src/config/blocked-env-keys.test.ts \
  packages/agent/src/config/env-vars.ts \
  packages/agent/src/api/plugin-discovery-helpers.ts
git diff --check
rg "BLOCKED_STARTUP_ENV_KEYS|export const BLOCKED_ENV_KEYS|Mirrors the BLOCKED_ENV_KEYS" packages/agent/src/config packages/agent/src/api/plugin-discovery-helpers.ts -n
```

The final grep shows only the canonical definition in `packages/agent/src/config/blocked-env-keys.ts`.

## Evidence

N/A for screenshots/video/LLM trajectories: this is server-side auth/config filtering logic with no UI, model, prompt, or connector behavior change.

Refs #12088.
