### PR TITLE
fix(cloud): return video provider diagnostics before settle

### DIFF
--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -152,8 +152,15 @@ const validResult = {
 
 interface ErrorResponseBody {
   error?: string;
+  code?: string;
   details?: {
     supportedModels?: string[];
+    provider?: string;
+    model?: string;
+    billingSource?: string;
+    upstreamStatus?: number;
+    upstreamCode?: string;
+    upstreamMessage?: string;
   };
 }
 
@@ -236,14 +243,32 @@ describe("generate-video — post-settle failure must not refund (#10278)", () =
 });
 
 describe("generate-video — pre-settle failure still refunds", () => {
-  test("fal.subscribe throws BEFORE settle: reconciled once to 0, balance restored", async () => {
+  test("provider throws BEFORE settle: refunds and returns provider diagnostics", async () => {
     const ledger = makeLedgerReservation(100, COST);
     reserve.mockResolvedValue(ledger.reservation);
-    subscribe.mockRejectedValue(new Error("fal upstream 503"));
+    const providerError = Object.assign(new Error("fal upstream 503"), {
+      status: 503,
+      code: "FAL_UPSTREAM_UNAVAILABLE",
+    });
+    subscribe.mockRejectedValue(providerError);
 
     const res = await post();
 
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as ErrorResponseBody;
+    expect(body).toMatchObject({
+      success: false,
+      error: "Video provider request failed",
+      code: "internal_error",
+      details: {
+        provider: "fal",
+        model: MODEL,
+        billingSource: "fal",
+        upstreamStatus: 503,
+        upstreamCode: "FAL_UPSTREAM_UNAVAILABLE",
+        upstreamMessage: "fal upstream 503",
+      },
+    });
     expect(generationsCreate).not.toHaveBeenCalled();
     // Failure before settle → full refund (reconcile(0)).
     expect(ledger.reconcileCalls).toBe(1);

--- a/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
@@ -246,10 +246,13 @@ describe("generate-video — pre-settle failure still refunds", () => {
   test("provider throws BEFORE settle: refunds and returns provider diagnostics", async () => {
     const ledger = makeLedgerReservation(100, COST);
     reserve.mockResolvedValue(ledger.reservation);
-    const providerError = Object.assign(new Error("fal upstream 503"), {
-      status: 503,
-      code: "FAL_UPSTREAM_UNAVAILABLE",
-    });
+    const providerError = Object.assign(
+      new Error("fal upstream 503 api_key=secret-token"),
+      {
+        status: 503,
+        code: "FAL_UPSTREAM_UNAVAILABLE",
+      },
+    );
     subscribe.mockRejectedValue(providerError);
 
     const res = await post();
@@ -266,7 +269,7 @@ describe("generate-video — pre-settle failure still refunds", () => {
         billingSource: "fal",
         upstreamStatus: 503,
         upstreamCode: "FAL_UPSTREAM_UNAVAILABLE",
-        upstreamMessage: "fal upstream 503",
+        upstreamMessage: "fal upstream 503 api_key=[REDACTED]",
       },
     });
     expect(generationsCreate).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -65,6 +65,40 @@ interface PendingSettlementContext {
   parameters: Record<string, unknown>;
 }
 
+function providerFailureDetails(options: {
+  provider: string;
+  model: string;
+  billingSource: string;
+  error: unknown;
+}): Record<string, unknown> {
+  const errorRecord =
+    typeof options.error === "object" && options.error !== null
+      ? (options.error as Record<string, unknown>)
+      : {};
+  const details: Record<string, unknown> = {
+    provider: options.provider,
+    model: options.model,
+    billingSource: options.billingSource,
+  };
+  const status = errorRecord.status ?? errorRecord.statusCode;
+  if (typeof status === "number" && Number.isFinite(status)) {
+    details.upstreamStatus = status;
+  }
+  if (typeof errorRecord.code === "string" && errorRecord.code.trim()) {
+    details.upstreamCode = errorRecord.code.trim().slice(0, 128);
+  }
+  const message =
+    options.error instanceof Error
+      ? options.error.message
+      : typeof options.error === "string"
+        ? options.error
+        : "";
+  if (message.trim()) {
+    details.upstreamMessage = message.trim().slice(0, 500);
+  }
+  return details;
+}
+
 app.post("/", async (c) => {
   let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
     null;
@@ -176,17 +210,33 @@ app.post("/", async (c) => {
       },
     };
 
-    const generated = await provider.generate({
-      ...request,
-      // Bill-what-you-deliver: the org is charged for the RESOLVED duration
-      // (request.durationSeconds ?? the catalog default), but the raw request
-      // spread would forward an undefined durationSeconds when the client omits
-      // it — the provider then renders its OWN default (potentially longer),
-      // so the platform pays for a longer clip than it billed. Forward the
-      // resolved value so the generated duration matches the charge.
-      durationSeconds,
-      apiKeys,
-    });
+    let generated: Awaited<ReturnType<typeof provider.generate>>;
+    try {
+      generated = await provider.generate({
+        ...request,
+        // Bill-what-you-deliver: the org is charged for the RESOLVED duration
+        // (request.durationSeconds ?? the catalog default), but the raw request
+        // spread would forward an undefined durationSeconds when the client omits
+        // it — the provider then renders its OWN default (potentially longer),
+        // so the platform pays for a longer clip than it billed. Forward the
+        // resolved value so the generated duration matches the charge.
+        durationSeconds,
+        apiKeys,
+      });
+    } catch (error) {
+      if (error instanceof VideoGenerationPendingError) throw error;
+      throw new ApiError(
+        503,
+        "internal_error",
+        "Video provider request failed",
+        providerFailureDetails({
+          provider: definition.provider,
+          model: request.model,
+          billingSource: definition.billingSource,
+          error,
+        }),
+      );
+    }
     if (generated.hasNsfwConcepts?.some(Boolean)) {
       throw new ApiError(
         400,

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -65,6 +65,16 @@ interface PendingSettlementContext {
   parameters: Record<string, unknown>;
 }
 
+function redactProviderErrorMessage(message: string): string {
+  return message
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "sk-[REDACTED]")
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [REDACTED]")
+    .replace(
+      /\b(api[_-]?key|access[_-]?token|token|secret|authorization)=([^&\s]+)/gi,
+      "$1=[REDACTED]",
+    );
+}
+
 function providerFailureDetails(options: {
   provider: string;
   model: string;
@@ -94,7 +104,10 @@ function providerFailureDetails(options: {
         ? options.error
         : "";
   if (message.trim()) {
-    details.upstreamMessage = message.trim().slice(0, 500);
+    details.upstreamMessage = redactProviderErrorMessage(message.trim()).slice(
+      0,
+      500,
+    );
   }
   return details;
 }


### PR DESCRIPTION
## Summary
- return a 503 Cloud API error with safe provider/model/billing/upstream diagnostics when video generation fails before settlement
- preserve the existing pending-generation hold path by rethrowing VideoGenerationPendingError unchanged
- extend the generate-video credit leak regression test to assert refund behavior and diagnostic response shape

## Issue
Refs #12078. This does not close #12078 because live video provider generation and artifact review still require credentialed production/staging evidence.

## Validation
- bunx biome check packages/cloud/api/v1/generate-video/route.ts packages/cloud/api/__tests__/generate-video-credit-leak.test.ts
- git diff --check HEAD~1..HEAD
- bun run --cwd packages/cloud/api typecheck
- bun test --coverage --coverage-reporter=lcov --reporter=dots packages/cloud/api/__tests__/generate-video-credit-leak.test.ts

## Evidence
- Targeted regression: 7 pass, 0 fail, 29 expect() calls.
- Live video generation evidence: N/A for this PR; #12078 remains open for credentialed FAL/provider run, generated video artifact, logs, and catalog verification.