### PR TITLE
fix(agent): rely on runtime gate for terminal action role

### DIFF
--- a/packages/agent/src/actions/terminal-role-gate.test.ts
+++ b/packages/agent/src/actions/terminal-role-gate.test.ts
@@ -1,0 +1,52 @@
+import {
+  executePlannedToolCall,
+  type IAgentRuntime,
+  type Memory,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { terminalAction } from "./terminal.ts";
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    actions: [terminalAction],
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeMessage(): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000012087",
+    entityId: "00000000-0000-0000-0000-000000000001",
+    roomId: "00000000-0000-0000-0000-000000000002",
+    content: { text: "run echo hello" },
+  } as Memory;
+}
+
+describe("terminalAction runtime role gate", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks non-owner callers before terminal execution reaches the handler transport", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await executePlannedToolCall(
+      makeRuntime(),
+      {
+        message: makeMessage(),
+        activeContexts: ["terminal"],
+        userRoles: ["MEMBER"],
+      },
+      { name: "TERMINAL_SHELL", params: { command: "echo hello" } },
+    );
+
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain("not allowed");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -28,7 +28,6 @@ import {
   stringToUuid,
 } from "@elizaos/core";
 import { resolveServerOnlyPort } from "@elizaos/shared";
-import { hasOwnerAccess } from "../security/access.ts";
 import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
 
 const TERMINAL_ACTION_NAME = "TERMINAL_SHELL";
@@ -292,18 +291,6 @@ export const terminalAction: Action = {
           actionName: TERMINAL_ACTION_NAME,
           suppressPostActionContinuation: true,
           terminal: { storeBuildBlocked: true },
-        },
-      };
-    }
-
-    if (!(await hasOwnerAccess(runtime, message))) {
-      return {
-        success: false,
-        text: "Permission denied: only the owner may run terminal commands.",
-        data: {
-          actionName: TERMINAL_ACTION_NAME,
-          suppressPostActionContinuation: true,
-          terminal: { permissionDenied: true },
         },
       };
     }


### PR DESCRIPTION
## Summary
- Removes the duplicate `hasOwnerAccess` check from the `TERMINAL_SHELL` action handler.
- Leaves `roleGate: { minRole: "OWNER" }` as the single enforcement declaration for the terminal action.
- Adds a focused regression proving a MEMBER caller is rejected by `executePlannedToolCall` before the terminal transport/fetch path is reached.

Refs #12087 item 27.

## Validation
- `bun install --frozen-lockfile`
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (local generated prerequisite for agent tests)
- `bun run --cwd packages/agent test src/actions/terminal-role-gate.test.ts` — 1 test passed
- `bun run --cwd packages/core test src/runtime/__tests__/execute-planned-tool-call.test.ts` — 31 tests passed
- `bunx @biomejs/biome check packages/agent/src/actions/terminal.ts packages/agent/src/actions/terminal-role-gate.test.ts` — passed
- `git diff --check HEAD~1..HEAD` — passed

## Typecheck
- `bun run --cwd packages/agent typecheck` still fails on existing workspace resolution issues outside this diff: `@elizaos/plugin-meetings` from `plugins/plugin-discord/voice-meetings.ts` and `@elizaos/cloud-routing` from `plugins/plugin-wallet/*`.

## Evidence
- Runtime/framework change; no UI, media, connector, or model behavior changed. Real LLM trajectory, screenshots, audio, and platform capture are N/A. The focused runtime-boundary tests above are the executable evidence.