### PR TITLE
refactor(ui): derive bundled content packs from shared preset registry (#12092 item 33)

### DIFF
--- a/packages/ui/src/content-packs/bundled-packs.test.ts
+++ b/packages/ui/src/content-packs/bundled-packs.test.ts
@@ -1,0 +1,75 @@
+import {
+  getDefaultStylePreset,
+  getStylePresets,
+} from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { getBundledContentPacks } from "./bundled-packs";
+
+/**
+ * Bundled content packs must be derived from the shared character-preset
+ * registry, not hardcoded. This guards against the historical drift where
+ * bundled-packs.ts carried its own (stale) catchphrases — e.g. Chen read
+ * "Hey there!" while the registry says "Let's get to work!".
+ */
+describe("getBundledContentPacks", () => {
+  const defaultPresetId = getDefaultStylePreset().id;
+  const registryPresets = getStylePresets().filter(
+    (preset) => preset.id !== defaultPresetId,
+  );
+
+  it("produces one pack per named (non-default) preset", () => {
+    const packs = getBundledContentPacks();
+    expect(packs).toHaveLength(8);
+    expect(packs.map((pack) => pack.manifest.id)).toEqual(
+      registryPresets.map((preset) => preset.id),
+    );
+  });
+
+  it("derives name + catchphrase from the shared registry for all 8 characters", () => {
+    const packs = getBundledContentPacks();
+    for (const preset of registryPresets) {
+      const pack = packs.find((candidate) => candidate.manifest.id === preset.id);
+      expect(pack, `missing bundled pack for ${preset.id}`).toBeDefined();
+      // Name matches the registry.
+      expect(pack?.manifest.name).toBe(preset.name);
+      expect(pack?.personality?.name).toBe(preset.name);
+      // Catchphrase matches the registry (proves the drift is gone).
+      expect(pack?.personality?.catchphrase).toBe(preset.catchphrase);
+      expect(pack?.manifest.assets.personality?.catchphrase).toBe(
+        preset.catchphrase,
+      );
+    }
+  });
+
+  it("has no stale catchphrases from the old hardcoded table", () => {
+    const packs = getBundledContentPacks();
+    const stale: Record<string, string> = {
+      chen: "Hey there!",
+      jin: "What's up?",
+      kei: "Hi!",
+      momo: "Hello!",
+      rin: "Greetings!",
+      ryu: "Yo!",
+      satoshi: "Welcome!",
+      yuki: "Nice to meet you!",
+    };
+    for (const pack of packs) {
+      expect(pack.personality?.catchphrase).not.toBe(stale[pack.manifest.id]);
+    }
+  });
+
+  it("references /vrms assets by avatarIndex-derived slug", () => {
+    const packs = getBundledContentPacks();
+    for (const preset of registryPresets) {
+      const pack = packs.find((candidate) => candidate.manifest.id === preset.id);
+      const slug = `bundled-${preset.avatarIndex}`;
+      expect(pack?.avatarIndex).toBe(preset.avatarIndex);
+      expect(pack?.vrmUrl).toBeUndefined();
+      expect(pack?.vrmPreviewUrl).toBe(`/vrms/previews/${slug}.png`);
+      expect(pack?.backgroundUrl).toBe(`/vrms/backgrounds/${slug}.png`);
+      expect(pack?.manifest.assets.vrm?.slug).toBe(slug);
+      expect(pack?.manifest.assets.vrm?.file).toBe(`${slug}.vrm.gz`);
+      expect(pack?.source).toEqual({ kind: "bundled", id: preset.id });
+    }
+  });
+});

--- a/packages/ui/src/content-packs/bundled-packs.ts
+++ b/packages/ui/src/content-packs/bundled-packs.ts
@@ -1,120 +1,64 @@
 /**
- * Bundled content packs derived from the existing character presets.
+ * Bundled content packs derived from the shared character-preset registry.
  *
- * Each of the 8 built-in characters (Chen, Jin, Kei, etc.) becomes a
- * content pack with their VRM, background, and personality.
+ * Every named built-in character (Chen, Jin, Kei, …) — i.e. every style preset
+ * except the app's default agent — becomes a content pack. All character data
+ * (id, name, avatarIndex, catchphrase) comes from the shared registry so it
+ * cannot drift; this module only shapes those presets into ResolvedContentPacks
+ * that reference the existing /vrms assets by avatarIndex.
  */
 
-import type { ContentPackManifest, ResolvedContentPack } from "@elizaos/shared";
+import {
+  type ContentPackManifest,
+  getDefaultStylePreset,
+  getStylePresets,
+  type ResolvedContentPack,
+  type StylePreset,
+} from "@elizaos/shared";
 
-interface BundledPackDef {
-  id: string;
-  name: string;
-  avatarIndex: number;
-  slug: string;
-  catchphrase: string;
-}
+const PACK_VERSION = "1.0.0";
 
-const BUNDLED_PACK_DEFS: BundledPackDef[] = [
-  {
-    id: "chen",
-    name: "Chen",
-    avatarIndex: 1,
-    slug: "bundled-1",
-    catchphrase: "Hey there!",
-  },
-  {
-    id: "jin",
-    name: "Jin",
-    avatarIndex: 2,
-    slug: "bundled-2",
-    catchphrase: "What's up?",
-  },
-  {
-    id: "kei",
-    name: "Kei",
-    avatarIndex: 3,
-    slug: "bundled-3",
-    catchphrase: "Hi!",
-  },
-  {
-    id: "momo",
-    name: "Momo",
-    avatarIndex: 4,
-    slug: "bundled-4",
-    catchphrase: "Hello!",
-  },
-  {
-    id: "rin",
-    name: "Rin",
-    avatarIndex: 5,
-    slug: "bundled-5",
-    catchphrase: "Greetings!",
-  },
-  {
-    id: "ryu",
-    name: "Ryu",
-    avatarIndex: 6,
-    slug: "bundled-6",
-    catchphrase: "Yo!",
-  },
-  {
-    id: "satoshi",
-    name: "Satoshi",
-    avatarIndex: 7,
-    slug: "bundled-7",
-    catchphrase: "Welcome!",
-  },
-  {
-    id: "yuki",
-    name: "Yuki",
-    avatarIndex: 8,
-    slug: "bundled-8",
-    catchphrase: "Nice to meet you!",
-  },
-];
-
-function defToManifest(def: BundledPackDef): ContentPackManifest {
-  return {
-    id: def.id,
-    name: def.name,
-    version: "1.0.0",
+function presetToResolvedPack(preset: StylePreset): ResolvedContentPack {
+  const slug = `bundled-${preset.avatarIndex}`;
+  const manifest: ContentPackManifest = {
+    id: preset.id,
+    name: preset.name,
+    version: PACK_VERSION,
     assets: {
       vrm: {
-        file: `${def.slug}.vrm.gz`,
-        preview: `previews/${def.slug}.png`,
-        slug: def.slug,
+        file: `${slug}.vrm.gz`,
+        preview: `previews/${slug}.png`,
+        slug,
       },
-      background: `backgrounds/${def.slug}.png`,
+      background: `backgrounds/${slug}.png`,
       personality: {
-        name: def.name,
-        catchphrase: def.catchphrase,
+        name: preset.name,
+        catchphrase: preset.catchphrase,
       },
     },
+  };
+  return {
+    manifest,
+    avatarIndex: preset.avatarIndex,
+    vrmPreviewUrl: `/vrms/previews/${slug}.png`,
+    backgroundUrl: `/vrms/backgrounds/${slug}.png`,
+    personality: manifest.assets.personality,
+    source: { kind: "bundled", id: preset.id },
   };
 }
 
 let _cached: ResolvedContentPack[] | null = null;
 
-function defToResolvedPack(def: BundledPackDef): ResolvedContentPack {
-  const manifest = defToManifest(def);
-  return {
-    manifest,
-    avatarIndex: def.avatarIndex,
-    vrmPreviewUrl: `/vrms/previews/${def.slug}.png`,
-    backgroundUrl: `/vrms/backgrounds/${def.slug}.png`,
-    personality: manifest.assets.personality,
-    source: { kind: "bundled", id: def.id },
-  };
-}
-
 /**
- * Get all bundled content packs (derived from the 8 built-in characters).
- * Bundled packs use avatarIndex (1-8) to reference existing VRM assets
- * rather than generating custom VRM URLs.
+ * Get all bundled content packs (the named built-in characters — one per style
+ * preset, excluding the default agent). Bundled packs use avatarIndex (1-8) to
+ * reference existing VRM assets rather than generating custom VRM URLs.
  */
 export function getBundledContentPacks(): ResolvedContentPack[] {
   if (_cached) return _cached;
-  _cached = BUNDLED_PACK_DEFS.map(defToResolvedPack);
+  const defaultPresetId = getDefaultStylePreset().id;
+  _cached = getStylePresets()
+    .filter((preset) => preset.id !== defaultPresetId)
+    .map(presetToResolvedPack);
   return _cached;
 }


### PR DESCRIPTION
## #12092 item 33 [P3][S] — bundled character content packs duplicate the shared preset registry

`packages/ui/src/content-packs/bundled-packs.ts` hardcoded `BUNDLED_PACK_DEFS` (8 characters: id, name, avatarIndex, catchphrase) duplicating the canonical `CHARACTER_DEFINITIONS` / `getStylePresets()` in `packages/shared` — and it had **drifted**: all 8 catchphrases were stale placeholders.

### Change
`getBundledContentPacks()` now derives from `getStylePresets()` (filtering the default-agent preset via `getDefaultStylePreset().id`), mapping each preset into `ResolvedContentPack`. Only pack-shaping logic remains (`slug = bundled-${avatarIndex}`, `.vrm.gz`/preview/background asset paths, `/vrms/...` URLs). Output shape is byte-for-byte identical; no hardcoded character data left.

### The drift fixed (before → after, `en`)
| character | was | now (registry) |
|---|---|---|
| chen | "Hey there!" | "Let's get to work!" |
| jin | "What's up?" | "Anything you need, boss!" |
| kei | "Hi!" | "Hey sure. Why not?" |
| momo | "Hello!" | "I can't wait!" |
| rin | "Greetings!" | "I won't let you down." |
| ryu | "Yo!" | "How bad could it be?" |
| satoshi | "Welcome!" | "I'll handle it." |
| yuki | "Nice to meet you!" | "Are you thinking what I'm thinking?" |

### Verification
- New `bundled-packs.test.ts` — **4 pass**: asserts 8 packs; name + catchphrase equal the registry for all 8; no stale catchphrases; avatarIndex-derived slug/asset URLs preserved.
- `turbo build` core+shared ✅; `tsgo --noEmit` ui → **0 errors**.

| type | status |
|---|---|
| Unit test (registry alignment, all 8) | ✅ 4 pass |
| ui typecheck | ✅ 0 errors |
| Visual | N/A — data-derivation only; pack shape byte-identical |

🤖 Generated with [Claude Code](https://claude.com/claude-code)