### PR TITLE
fix(core): match connector admins only on stable ids

### DIFF
--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -155,6 +155,17 @@ describe("matchEntityToConnectorAdminWhitelist", () => {
 		).toBeNull();
 		expect(matchEntityToConnectorAdminWhitelist(null, whitelist)).toBeNull();
 	});
+
+	it("does not match mutable username fields against the whitelist", () => {
+		const whitelist = { discord: ["alice"] };
+
+		expect(
+			matchEntityToConnectorAdminWhitelist(
+				{ discord: { username: "alice", userName: "alice" } },
+				whitelist,
+			),
+		).toBeNull();
+	});
 });
 
 describe("canonical role rank (#9948)", () => {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -66,13 +66,12 @@ export interface ServerOwnershipState {
 const CONNECTOR_ADMINS_SETTING_KEY = "ELIZA_ROLES_CONNECTOR_ADMINS_JSON";
 const CANONICAL_OWNER_SETTING_KEY = "ELIZA_ADMIN_ENTITY_ID";
 const OWNER_CONTACTS_SETTING_KEY = "ELIZA_OWNER_CONTACTS_JSON";
-const CONNECTOR_ID_FIELDS = ["userId", "id", "username", "userName"] as const;
 const CONNECTOR_STABLE_ID_FIELDS = ["userId", "id"] as const;
-type ConnectorIdField = (typeof CONNECTOR_ID_FIELDS)[number];
+type ConnectorStableIdField = (typeof CONNECTOR_STABLE_ID_FIELDS)[number];
 type ConnectorAdminMatch = {
 	connector: string;
 	matchedValue: string;
-	matchedField: ConnectorIdField;
+	matchedField: ConnectorStableIdField;
 };
 
 type ResolveEntityRoleOptions = {
@@ -526,7 +525,7 @@ export function matchEntityToConnectorAdminWhitelist(
 			continue;
 		}
 
-		for (const field of CONNECTOR_ID_FIELDS) {
+		for (const field of CONNECTOR_STABLE_ID_FIELDS) {
 			const value = connectorMeta[field];
 			if (typeof value === "string" && platformIds.includes(value)) {
 				return { connector, matchedValue: value, matchedField: field };


### PR DESCRIPTION
## Summary

Addresses #12088 item 12.

- Connector-admin whitelist matching now checks only stable connector ID fields (`userId`, `id`).
- Mutable `username` / `userName` fields no longer grant ADMIN through the connector-admin whitelist.
- Adds a regression test for username-only whitelist matches.

## Validation

Passed locally on current `origin/develop` after `bun run --cwd packages/core prebuild`:

```bash
bun run --cwd packages/core test -- src/roles.test.ts
bunx @biomejs/biome check packages/core/src/roles.ts packages/core/src/roles.test.ts
git diff --check
```

The focused roles suite reported 1 file / 21 tests passing.

## Evidence

N/A for screenshots/video/LLM trajectories: core role resolution logic only; no UI, prompt, model, or connector runtime path changed beyond deterministic role matching.

Refs #12088.
