### PR TITLE
fix(core): remove runtime package installation from plugin loader (#12091 item 5)

### DIFF
--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -1,77 +1,120 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { tryInstallPlugin } from "./plugin";
+import { describe, expect, it, vi } from "vitest";
+import * as pluginModule from "./plugin";
+import { loadPlugin, type PluginResolver, resolvePlugins } from "./plugin";
+import type { Plugin } from "./types";
 
-const ENV_KEYS = [
-	"CI",
-	"ELIZA_NO_AUTO_INSTALL",
-	"ELIZA_NO_PLUGIN_AUTO_INSTALL",
-	"ELIZA_TEST_MODE",
-	"NODE_ENV",
-] as const;
+const makePlugin = (name: string): Plugin => ({
+	name,
+	description: `${name} test plugin`,
+});
 
-type BunStub = {
-	spawn: ReturnType<typeof vi.fn>;
-};
+describe("core plugin loader — no runtime install / no name imports", () => {
+	it("exposes no auto-install or module-import entry points", () => {
+		// The supply-chain surface (bun add / variable-specifier import) is gone:
+		// core no longer exports tryInstallPlugin or loadAndPreparePlugin.
+		expect(
+			(pluginModule as Record<string, unknown>).tryInstallPlugin,
+		).toBeUndefined();
+		expect(
+			(pluginModule as Record<string, unknown>).loadAndPreparePlugin,
+		).toBeUndefined();
+	});
+});
 
-const originalEnv = new Map(
-	ENV_KEYS.map((key) => [key, process.env[key]] as const),
-);
-const originalBun = (globalThis as { Bun?: unknown }).Bun;
-
-function restoreEnvironment(): void {
-	for (const key of ENV_KEYS) {
-		const value = originalEnv.get(key);
-		if (value === undefined) {
-			delete process.env[key];
-		} else {
-			process.env[key] = value;
-		}
-	}
-	if (originalBun === undefined) {
-		delete (globalThis as { Bun?: unknown }).Bun;
-	} else {
-		(globalThis as { Bun?: unknown }).Bun = originalBun;
-	}
-}
-
-function allowAutoInstallForTest(spawn: BunStub["spawn"]): void {
-	for (const key of ENV_KEYS) {
-		delete process.env[key];
-	}
-	process.env.NODE_ENV = "development";
-	(globalThis as { Bun?: BunStub }).Bun = { spawn };
-}
-
-describe("tryInstallPlugin", () => {
-	afterEach(() => {
-		restoreEnvironment();
-		vi.restoreAllMocks();
+describe("loadPlugin", () => {
+	it("passes through a valid Plugin object unchanged", async () => {
+		const plugin = makePlugin("@elizaos/plugin-object");
+		await expect(loadPlugin(plugin)).resolves.toBe(plugin);
 	});
 
-	it("honors the legacy plugin auto-install opt-out alias", async () => {
-		const spawn = vi.fn(() => ({ exited: Promise.resolve(1) }));
-		allowAutoInstallForTest(spawn);
-		process.env.ELIZA_NO_PLUGIN_AUTO_INSTALL = "true";
-
+	it("fails closed for a string reference when no resolver is injected", async () => {
 		await expect(
-			tryInstallPlugin("@elizaos/plugin-auto-install-disabled-test"),
-		).resolves.toBe(false);
-
-		expect(spawn).not.toHaveBeenCalled();
+			loadPlugin("@elizaos/plugin-missing-resolver"),
+		).resolves.toBeNull();
 	});
 
-	it("reaches Bun when no auto-install opt-out env is set", async () => {
-		const spawn = vi.fn(() => ({ exited: Promise.resolve(1) }));
-		allowAutoInstallForTest(spawn);
+	it("resolves a string reference through the injected resolver", async () => {
+		const resolved = makePlugin("@elizaos/plugin-resolved");
+		const resolver: PluginResolver = {
+			resolve: vi.fn(async () => resolved),
+		};
 
 		await expect(
-			tryInstallPlugin("@elizaos/plugin-auto-install-allowed-test"),
-		).resolves.toBe(false);
+			loadPlugin("@elizaos/plugin-resolved", resolver),
+		).resolves.toBe(resolved);
+		expect(resolver.resolve).toHaveBeenCalledWith("@elizaos/plugin-resolved");
+	});
 
-		expect(spawn).toHaveBeenCalledTimes(1);
-		expect(spawn).toHaveBeenCalledWith(["bun", "--version"], {
-			stdout: "pipe",
-			stderr: "pipe",
-		});
+	it("returns null when the resolver yields nothing", async () => {
+		const resolver: PluginResolver = { resolve: vi.fn(async () => null) };
+		await expect(
+			loadPlugin("@elizaos/plugin-none", resolver),
+		).resolves.toBeNull();
+	});
+
+	it("rejects a resolver result that is not a valid plugin", async () => {
+		const resolver: PluginResolver = {
+			resolve: vi.fn(async () => ({ notAPlugin: true }) as unknown as Plugin),
+		};
+		await expect(
+			loadPlugin("@elizaos/plugin-invalid", resolver),
+		).resolves.toBeNull();
+	});
+});
+
+describe("resolvePlugins", () => {
+	it("routes every string reference through the injected resolver", async () => {
+		const sql = makePlugin("@elizaos/plugin-sql");
+		const bootstrap = makePlugin("@elizaos/plugin-bootstrap");
+		const byName = new Map([
+			["@elizaos/plugin-sql", sql],
+			["@elizaos/plugin-bootstrap", bootstrap],
+		]);
+		const resolver: PluginResolver = {
+			resolve: vi.fn(async (name) => byName.get(name) ?? null),
+		};
+
+		const resolved = await resolvePlugins(
+			["@elizaos/plugin-sql", "@elizaos/plugin-bootstrap"],
+			false,
+			resolver,
+		);
+
+		const names = resolved.map((p) => p.name);
+		expect(names).toContain("@elizaos/plugin-sql");
+		expect(names).toContain("@elizaos/plugin-bootstrap");
+		expect(resolver.resolve).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips string references (does not install) when no resolver is injected", async () => {
+		const objectPlugin = makePlugin("@elizaos/plugin-inline");
+		const resolved = await resolvePlugins([
+			"@elizaos/plugin-string-only",
+			objectPlugin,
+		]);
+
+		const names = resolved.map((p) => p.name);
+		expect(names).toEqual(["@elizaos/plugin-inline"]);
+		expect(names).not.toContain("@elizaos/plugin-string-only");
+	});
+
+	it("mixes injected object plugins with resolver-resolved names", async () => {
+		const inline = makePlugin("@elizaos/plugin-inline2");
+		const resolvedByName = makePlugin("@elizaos/plugin-model");
+		const resolver: PluginResolver = {
+			resolve: vi.fn(async (name) =>
+				name === "@elizaos/plugin-model" ? resolvedByName : null,
+			),
+		};
+
+		const resolved = await resolvePlugins(
+			[inline, "@elizaos/plugin-model"],
+			false,
+			resolver,
+		);
+
+		const names = resolved.map((p) => p.name);
+		expect(names).toContain("@elizaos/plugin-inline2");
+		expect(names).toContain("@elizaos/plugin-model");
 	});
 });

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -3,121 +3,26 @@ import { logger } from "./logger";
 import type { Plugin } from "./types";
 import { detectEnvironment } from "./utils/environment";
 
-const attemptedInstalls = new Set<string>();
-
-type BunSpawnResult = {
-	exited: Promise<number>;
-};
-
-type BunLike = {
-	spawn(
-		command: string[],
-		options?: {
-			cwd?: string;
-			env?: Record<string, string>;
-			stdout?: unknown;
-			stderr?: unknown;
-		},
-	): BunSpawnResult;
-};
-
-function getBunRuntime(): BunLike | null {
-	const bunRuntime = (globalThis as { Bun?: BunLike }).Bun;
-	return bunRuntime && typeof bunRuntime.spawn === "function"
-		? bunRuntime
-		: null;
-}
-
-function isAutoInstallAllowed(): boolean {
-	if (process.env.ELIZA_NO_AUTO_INSTALL === "true") return false;
-	if (process.env.ELIZA_NO_PLUGIN_AUTO_INSTALL === "true") return false;
-	if (process.env.CI === "true") return false;
-	if (process.env.ELIZA_TEST_MODE === "true") return false;
-	if (process.env.NODE_ENV === "test") return false;
-	return true;
-}
-
-export async function tryInstallPlugin(pluginName: string): Promise<boolean> {
-	try {
-		if (!isAutoInstallAllowed()) {
-			logger.debug(
-				{ src: "core:plugin", pluginName },
-				"Auto-install disabled, skipping",
-			);
-			return false;
-		}
-
-		if (attemptedInstalls.has(pluginName)) {
-			logger.debug(
-				{ src: "core:plugin", pluginName },
-				"Auto-install already attempted, skipping",
-			);
-			return false;
-		}
-		attemptedInstalls.add(pluginName);
-
-		const bunRuntime = getBunRuntime();
-		if (!bunRuntime) {
-			logger.warn(
-				{ src: "core:plugin", pluginName },
-				"Bun runtime not available, cannot auto-install",
-			);
-			return false;
-		}
-
-		try {
-			const check = bunRuntime.spawn(["bun", "--version"], {
-				stdout: "pipe",
-				stderr: "pipe",
-			});
-			const code = await check.exited;
-			if (code !== 0) {
-				logger.warn(
-					{ src: "core:plugin", pluginName },
-					"Bun not available on PATH, cannot auto-install",
-				);
-				return false;
-			}
-		} catch {
-			logger.warn(
-				{ src: "core:plugin", pluginName },
-				"Bun not available on PATH, cannot auto-install",
-			);
-			return false;
-		}
-
-		logger.info(
-			{ src: "core:plugin", pluginName },
-			"Auto-installing missing plugin",
-		);
-		const install = bunRuntime.spawn(["bun", "add", pluginName], {
-			cwd: process.cwd(),
-			env: process.env as Record<string, string>,
-			stdout: "inherit",
-			stderr: "inherit",
-		});
-		const exit = await install.exited;
-
-		if (exit === 0) {
-			logger.info(
-				{ src: "core:plugin", pluginName },
-				"Plugin installed, retrying import",
-			);
-			return true;
-		}
-
-		logger.error(
-			{ src: "core:plugin", pluginName, exitCode: exit },
-			"Plugin installation failed",
-		);
-		return false;
-	} catch (error) {
-		logger.error(
-			{ src: "core:plugin", pluginName, error },
-			"Error during plugin installation",
-		);
-		return false;
-	}
+/**
+ * Resolves a plugin package name to a loaded {@link Plugin} object.
+ *
+ * Core never imports plugin modules by name and never installs packages — both
+ * are host concerns and a supply-chain surface that must not live in the
+ * kernel. Hosts (the `elizaos` CLI / `@elizaos/agent`, which already own plugin
+ * loaders) inject a `PluginResolver` so that string plugin references coming
+ * from character config can be turned into `Plugin` objects. Any package
+ * installation must happen behind explicit user approval in that host layer,
+ * never here.
+ *
+ * When no resolver is injected, string references are skipped (fail closed)
+ * rather than dynamically imported.
+ */
+export interface PluginResolver {
+	/**
+	 * Resolve a plugin package name (e.g. `@elizaos/plugin-sql`) to a Plugin
+	 * object, or `null` when the plugin cannot be resolved.
+	 */
+	resolve(pluginName: string): Promise<Plugin | null>;
 }
 
 export function isValidPluginShape(obj: unknown): obj is Plugin {
@@ -197,71 +102,6 @@ export function validatePlugin(plugin: unknown): {
 		isValid: errors.length === 0,
 		errors,
 	};
-}
-
-export async function loadAndPreparePlugin(
-	pluginName: string,
-): Promise<Plugin | null> {
-	let pluginModule: unknown;
-
-	try {
-		pluginModule = await import(/* @vite-ignore */ pluginName);
-	} catch (error: unknown) {
-		logger.warn(
-			{ src: "core:plugin", pluginName, error },
-			"Failed to load plugin",
-		);
-		const attempted = await tryInstallPlugin(pluginName);
-		if (!attempted) {
-			return null;
-		}
-		try {
-			pluginModule = await import(/* @vite-ignore */ pluginName);
-		} catch (secondError: unknown) {
-			logger.error(
-				{ src: "core:plugin", pluginName, error: secondError },
-				"Import failed after auto-install",
-			);
-			return null;
-		}
-	}
-
-	if (!pluginModule) {
-		logger.error(
-			{ src: "core:plugin", pluginName },
-			"Failed to load plugin module",
-		);
-		return null;
-	}
-	const expectedFunctionName = `${pluginName
-		.replace(/^@elizaos\/plugin-/, "")
-		.replace(/^@elizaos\//, "")
-		.replace(/-./g, (match) => match[1].toUpperCase())}Plugin`;
-
-	const moduleObj = pluginModule as Record<string, unknown>;
-	const exportsToCheck = [
-		moduleObj[expectedFunctionName],
-		moduleObj.default,
-		...Object.values(moduleObj),
-	];
-
-	for (const potentialPlugin of exportsToCheck) {
-		if (isValidPluginShape(potentialPlugin)) {
-			return potentialPlugin as Plugin;
-		}
-		if (typeof potentialPlugin === "function" && potentialPlugin.length === 0) {
-			const produced = potentialPlugin();
-			if (isValidPluginShape(produced)) {
-				return produced as Plugin;
-			}
-		}
-	}
-
-	logger.warn(
-		{ src: "core:plugin", pluginName },
-		"No valid plugin export found",
-	);
-	return null;
 }
 
 export function normalizePluginName(pluginName: string): string {
@@ -366,9 +206,37 @@ export function resolvePluginDependencies(
 
 export async function loadPlugin(
 	nameOrPlugin: string | Plugin,
+	resolver?: PluginResolver,
 ): Promise<Plugin | null> {
 	if (typeof nameOrPlugin === "string") {
-		return loadAndPreparePlugin(nameOrPlugin);
+		if (!resolver) {
+			logger.warn(
+				{ src: "core:plugin", pluginName: nameOrPlugin },
+				"No PluginResolver injected; core cannot resolve plugins by name (host must inject one)",
+			);
+			return null;
+		}
+		const resolved = await resolver.resolve(nameOrPlugin);
+		if (!resolved) {
+			logger.warn(
+				{ src: "core:plugin", pluginName: nameOrPlugin },
+				"PluginResolver returned no plugin for name",
+			);
+			return null;
+		}
+		const resolvedValidation = validatePlugin(resolved);
+		if (!resolvedValidation.isValid) {
+			logger.error(
+				{
+					src: "core:plugin",
+					pluginName: nameOrPlugin,
+					errors: resolvedValidation.errors,
+				},
+				"Resolved plugin failed validation",
+			);
+			return null;
+		}
+		return resolved;
 	}
 
 	const validation = validatePlugin(nameOrPlugin);
@@ -414,6 +282,7 @@ function queueDependency(
 async function resolvePluginsImpl(
 	plugins: (string | Plugin)[],
 	isTestMode: boolean = false,
+	resolver?: PluginResolver,
 ): Promise<Plugin[]> {
 	const pluginMap = new Map<string, Plugin>();
 	const seenDependencies = new Set<string>();
@@ -439,7 +308,7 @@ async function resolvePluginsImpl(
 		const next = queue[queueIndex];
 		queueIndex += 1;
 		if (!next) continue;
-		const loaded = await loadPlugin(next);
+		const loaded = await loadPlugin(next, resolver);
 		if (!loaded) continue;
 
 		const canonicalName = loaded.name;
@@ -465,11 +334,12 @@ async function resolvePluginsImpl(
 export async function resolvePlugins(
 	plugins: (string | Plugin)[],
 	isTestMode: boolean = false,
+	resolver?: PluginResolver,
 ): Promise<Plugin[]> {
 	const env = detectEnvironment();
 
 	if (env === "node") {
-		return resolvePluginsImpl(plugins, isTestMode);
+		return resolvePluginsImpl(plugins, isTestMode, resolver);
 	}
 
 	const pluginObjects = plugins.filter(

--- a/packages/core/src/runtime-composition.ts
+++ b/packages/core/src/runtime-composition.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 import type { CharacterInput } from "./character";
 import { parseCharacter } from "./character";
-import { resolvePlugins } from "./plugin";
+import { type PluginResolver, resolvePlugins } from "./plugin";
 import {
 	ensureAgentInfrastructure,
 	ensureEmbeddingDimension,
@@ -281,6 +281,12 @@ export interface CreateRuntimesOptions {
 	settings?: Record<string, string | boolean | number>;
 	/** When false, the runtime always responds (e.g. direct chat / harness). Passed to AgentRuntime. */
 	checkShouldRespond?: boolean;
+	/**
+	 * Resolves string plugin references (from character config) to Plugin
+	 * objects. Core never imports plugins by name or installs packages; hosts
+	 * inject this. When omitted, string plugin references are skipped.
+	 */
+	pluginResolver?: PluginResolver;
 }
 
 /**
@@ -322,7 +328,11 @@ export async function createRuntimes(
 	if (options?.sharedPlugins?.length) {
 		pluginInput.push(...options.sharedPlugins);
 	}
-	const resolvedPlugins = await resolvePlugins(pluginInput);
+	const resolvedPlugins = await resolvePlugins(
+		pluginInput,
+		false,
+		options?.pluginResolver,
+	);
 
 	const agentIds: UUID[] = [];
 	for (const c of characters) {


### PR DESCRIPTION
## What

Part of #12091 (item 5) — **[P1][SECURITY]**. Removes the supply-chain surface where `@elizaos/core`'s plugin loader auto-runs `bun add <name>` at runtime for plugin names sourced from character/plugin config.

`packages/core/src/plugin.ts` resolved plugin name strings via a variable-specifier dynamic import (`import(pluginName)`) and, on failure, spawned `bun add <name>` into `process.cwd()` (`tryInstallPlugin`), default-enabled outside CI/test. Names flow from character config and transitively from every loaded plugin's `dependencies` array, so any plugin could trigger installation of arbitrary npm packages — inside the kernel.

## Change

- Define a `PluginResolver` interface in core (`{ resolve(name): Promise<Plugin | null> }`). Hosts (the `elizaos` CLI / `@elizaos/agent`, which already own full plugin loaders) inject an implementation resolving names → Plugin objects.
- `loadPlugin(nameOrPlugin, resolver?)` and `resolvePlugins(plugins, isTestMode?, resolver?)` take the optional injected resolver. String references **fail closed** (skipped with a warning) when no resolver is provided — core never imports plugins by name and never spawns a package manager.
- Deleted `tryInstallPlugin`, `loadAndPreparePlugin`, and the Bun-spawn helpers (`getBunRuntime`, `isAutoInstallAllowed`, `attemptedInstalls`). None had any in-repo importer outside core.
- `runtime-composition.createRuntimes` threads a `pluginResolver` option through to `resolvePlugins`.

Deliberate, user-approved installation (`PluginManagerService.installFromNpm`, validated + `requiresRestart`) is unchanged — that is the sanctioned host-layer approval path the item endorses, not the boot loader.

## Done-when evidence

- `grep -n "bun add\|\.spawn(\|import(/\* @vite-ignore \*/" packages/core/src/plugin.ts` → **no matches** (no `bun add`/spawn-install and no variable-specifier plugin import remain in the loader).
- Plugin resolution in core goes only through the injected resolver — proven by new tests in `packages/core/src/plugin.test.ts` (injected resolver is called; missing resolver fails closed; invalid resolver result rejected; removed `tryInstallPlugin`/`loadAndPreparePlugin` are `undefined`).
- No external consumer imports `resolvePlugins`/`loadPlugin`/`tryInstallPlugin`/`loadAndPreparePlugin` from `@elizaos/core`; only internal `runtime-composition` uses it. Agent boot uses its own `resolvePlugins` (`packages/agent/src/runtime/plugin-resolver.ts`) and is unaffected by this additive change.

## Verification

- `bun run --cwd packages/core build` → clean (Node + browser + edge + d.ts).
- `bun run --cwd packages/core typecheck` → clean.
- `bun run --cwd packages/core test -- src/plugin.test.ts` → **9 passed**; plus adjacent composition/lifecycle tests **19 passed** total, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)