### PR TITLE
fix(agent): guard the plugin-x402 dynamic import in dispatch-route (#12091 item 10)

### DIFF
--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -27,6 +27,7 @@ import {
   type AgentRuntime,
   type IAgentRuntime,
   type LegacyRouteHandler,
+  logger,
   type PaymentEnabledRoute,
   type Route,
   type RouteHandlerContext,
@@ -34,6 +35,79 @@ import {
   type RuntimeRouteHostContext,
   setRuntimeRouteHostContext,
 } from "@elizaos/core";
+
+// `@elizaos/plugin-x402` is optional: it is a desktop/cloud-only plugin and is
+// aliased to a null stub in the mobile agent bundle. Mirror the guarded loader
+// in api/server.ts (`getX402Plugin`) so a declared x402 route degrades to its
+// unwrapped handler instead of throwing:
+//   - not installed  → the dynamic import rejects → `.catch(() => null)`
+//   - mobile stub    → module loads but exports are no-op proxies whose
+//     `__mobileStub` flag is set and whose "functions" return `undefined`,
+//     so calling `createPaymentAwareHandler` would yield `undefined` and the
+//     subsequent invocation would be an unhandled TypeError.
+// A `null` result means "no usable payment wrapper" — callers fall through to
+// the unwrapped legacy handler.
+type X402PluginModule = typeof import("@elizaos/plugin-x402");
+
+/**
+ * Vet a resolved `@elizaos/plugin-x402` module: return it only when it exposes
+ * usable payment helpers, otherwise `null`. The mobile bundle aliases the
+ * plugin to a null stub whose exports are no-op proxies (flagged
+ * `__mobileStub`), so `createPaymentAwareHandler` would return `undefined` and
+ * calling it would throw. Exported for unit testing against the real stub.
+ */
+export function vetX402Module(mod: unknown): X402PluginModule | null {
+  if (mod == null) return null;
+  if ((mod as { __mobileStub?: boolean }).__mobileStub) return null;
+  const candidate = mod as Partial<X402PluginModule>;
+  if (
+    typeof candidate.createPaymentAwareHandler !== "function" ||
+    typeof candidate.isRoutePaymentWrapped !== "function"
+  ) {
+    return null;
+  }
+  return candidate as X402PluginModule;
+}
+
+/**
+ * Pick the handler an x402-declaring route should run. When no usable payment
+ * wrapper is available (`x402 === null`: plugin absent or mobile stub), fall
+ * through to the unwrapped legacy handler so the route serves a deliberate
+ * response instead of throwing. Exported for unit testing the fall-through.
+ */
+export function selectX402Handler(
+  x402: X402PluginModule | null,
+  route: Route,
+  legacyHandler: LegacyRouteHandler,
+): LegacyRouteHandler {
+  if (!x402) return legacyHandler;
+  if (x402.isRoutePaymentWrapped(route)) return legacyHandler;
+  return x402.createPaymentAwareHandler(
+    route as PaymentEnabledRoute,
+  ) as LegacyRouteHandler;
+}
+
+let x402PluginModule: X402PluginModule | null = null;
+let x402PluginModulePromise: Promise<X402PluginModule | null> | null = null;
+
+function importOptionalX402Plugin(): Promise<unknown> {
+  // Variable specifier keeps Vite's import-analysis from eagerly resolving the
+  // optional plugin's dist (which is absent in the unit lane / mobile bundle).
+  const specifier = "@elizaos/plugin-x402";
+  return import(/* @vite-ignore */ specifier);
+}
+
+async function getX402Plugin(): Promise<X402PluginModule | null> {
+  if (x402PluginModule) return x402PluginModule;
+  x402PluginModulePromise ??= importOptionalX402Plugin()
+    .then((mod) => {
+      const vetted = vetX402Module(mod);
+      if (vetted) x402PluginModule = vetted;
+      return vetted;
+    })
+    .catch(() => null);
+  return x402PluginModulePromise;
+}
 
 function matchPluginRoutePath(
   pattern: string,
@@ -403,14 +477,16 @@ export async function dispatchRoute(
       const legacyHandler = route.handler as LegacyRouteHandler;
       let effectiveHandler = legacyHandler;
       if (route.x402 != null) {
-        const x402Module = "@elizaos/plugin-x402";
-        const { createPaymentAwareHandler, isRoutePaymentWrapped } =
-          await import(/* @vite-ignore */ x402Module);
-        effectiveHandler = !isRoutePaymentWrapped(route)
-          ? (createPaymentAwareHandler(
-              route as PaymentEnabledRoute,
-            ) as LegacyRouteHandler)
-          : legacyHandler;
+        const x402 = await getX402Plugin();
+        if (!x402) {
+          // x402 plugin unavailable (mobile stub / not installed). Serve the
+          // route with its unwrapped handler rather than 500-ing; payment
+          // enforcement is inert where the plugin is not present.
+          logger.debug(
+            `[dispatchRoute] x402 plugin unavailable; serving ${method} ${args.path} without payment enforcement`,
+          );
+        }
+        effectiveHandler = selectX402Handler(x402, route, legacyHandler);
       }
 
       const { req, res, captured } = buildLegacyShim({

--- a/packages/agent/src/api/dispatch-route.x402.test.ts
+++ b/packages/agent/src/api/dispatch-route.x402.test.ts
@@ -1,0 +1,95 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import type { LegacyRouteHandler, Route } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { selectX402Handler, vetX402Module } from "./dispatch-route.ts";
+
+// The real null stub the mobile bundle aliases @elizaos/plugin-x402 to. Loading
+// the actual artifact (not a hand-rolled fake) keeps this test honest: if the
+// stub's shape changes, the guard's detection must still hold.
+const require = createRequire(import.meta.url);
+const mobileStub = require(
+  fileURLToPath(
+    new URL("../../scripts/mobile-stubs/null-plugin.cjs", import.meta.url),
+  ),
+);
+
+const legacyHandler: LegacyRouteHandler =
+  (async () => {}) as LegacyRouteHandler;
+
+function x402Route(): Route {
+  return {
+    path: "/paid",
+    type: "GET",
+    handler: legacyHandler,
+    x402: { price: "$0.01" },
+  } as unknown as Route;
+}
+
+describe("dispatch-route x402 guard (item 10)", () => {
+  describe("vetX402Module", () => {
+    it("rejects a missing plugin (null)", () => {
+      expect(vetX402Module(null)).toBeNull();
+      expect(vetX402Module(undefined)).toBeNull();
+    });
+
+    it("rejects the real mobile null stub via __mobileStub", () => {
+      // Sanity: the stub exposes the flag and its 'functions' return undefined.
+      expect((mobileStub as { __mobileStub?: boolean }).__mobileStub).toBe(
+        true,
+      );
+      expect(mobileStub.createPaymentAwareHandler()).toBeUndefined();
+      expect(vetX402Module(mobileStub)).toBeNull();
+    });
+
+    it("rejects a module missing the payment helpers", () => {
+      expect(vetX402Module({})).toBeNull();
+      expect(vetX402Module({ createPaymentAwareHandler: () => {} })).toBeNull();
+    });
+
+    it("accepts a module exposing both payment helpers", () => {
+      const mod = {
+        createPaymentAwareHandler: () => legacyHandler,
+        isRoutePaymentWrapped: () => false,
+      };
+      expect(vetX402Module(mod)).toBe(mod);
+    });
+  });
+
+  describe("selectX402Handler", () => {
+    it("falls through to the unwrapped handler when x402 is unavailable", () => {
+      // Plugin absent OR mobile stub: no unhandled TypeError, deliberate
+      // fall-through to the route's own handler.
+      expect(selectX402Handler(null, x402Route(), legacyHandler)).toBe(
+        legacyHandler,
+      );
+    });
+
+    it("wraps the handler when x402 is present and route is not yet wrapped", () => {
+      const wrapped = (async () => {}) as LegacyRouteHandler;
+      let wrapCalls = 0;
+      const mod = {
+        isRoutePaymentWrapped: () => false,
+        createPaymentAwareHandler: () => {
+          wrapCalls++;
+          return wrapped;
+        },
+      } as unknown as typeof import("@elizaos/plugin-x402");
+      const result = selectX402Handler(mod, x402Route(), legacyHandler);
+      expect(result).toBe(wrapped);
+      expect(wrapCalls).toBe(1);
+    });
+
+    it("does not double-wrap an already payment-wrapped route", () => {
+      const mod = {
+        isRoutePaymentWrapped: () => true,
+        createPaymentAwareHandler: () => {
+          throw new Error("should not wrap an already-wrapped route");
+        },
+      } as unknown as typeof import("@elizaos/plugin-x402");
+      expect(selectX402Handler(mod, x402Route(), legacyHandler)).toBe(
+        legacyHandler,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

`dispatchRoute` lazily `import()`s `@elizaos/plugin-x402` for any route declaring `x402` metadata, but — unlike its sibling loader in `api/server.ts` (`getX402Plugin`) — it did so **unguarded**:

- **Mobile bundle:** `@elizaos/plugin-x402` is aliased to a null stub (`scripts/mobile-stubs/null-plugin.cjs`) whose exports are no-op proxies. `createPaymentAwareHandler(route)` returned `undefined`; the subsequent `await effectiveHandler(...)` threw an unhandled **TypeError → 500**.
- **Plugin absent:** the dynamic import **rejected**; the rejection propagated to the hono adapter as a **500**.

So every x402-declaring route 500'd on those installs instead of degrading.

## Change

Mirror `server.ts` `getX402Plugin`:
- cache the import with `.catch(() => null)`,
- detect the `__mobileStub` flag and non-function exports,
- fall through to the **unwrapped legacy handler** when no usable payment wrapper exists (payment enforcement is inert where the plugin is not present).

Extracted two pure, exported functions used by the production path:
- `vetX402Module(mod)` — returns the module only when it exposes usable payment helpers, else `null`.
- `selectX402Handler(x402, route, legacyHandler)` — returns the unwrapped handler when `x402` is `null`, else wraps (respecting `isRoutePaymentWrapped`).

## Done-when evidence

> an x402-declaring route returns a deliberate response (unwrapped success or 402/501) on mobile-stub and plugin-absent installs; no unhandled TypeError path remains.

- New test `packages/agent/src/api/dispatch-route.x402.test.ts` loads the **real** mobile null-stub artifact and asserts `vetX402Module` returns `null` for it (and for a plugin-absent `null`), and that `selectX402Handler(null, x402Route, legacy) === legacy` — the deliberate unwrapped fall-through, no TypeError.
- Full-path wrap / no-double-wrap cases covered too. **7/7 pass.**
- No `@vite-ignore await import(...)` result is dereferenced without vetting anymore.

## Test / typecheck

- `bun run --cwd packages/agent vitest run src/api/dispatch-route.x402.test.ts` → **Test Files 1 passed, Tests 7 passed**.
- `packages/agent` typecheck: no errors reference the touched file. (Pre-existing environmental `Cannot find module '@elizaos/plugin-streaming'|'plugin-vision'|'cloud-routing'` errors are unbuilt optional-plugin dist, present on `develop`.)

Refs #12091 (item 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)