### PR TITLE
refactor(agent,app-core): per-module plugin-load failure state, drop globalThis stash (#12091 items 30/31)

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -217,6 +217,7 @@ export * from "./runtime/owner-entity.ts";
 export * from "./runtime/plugin-collector.ts";
 export * from "./runtime/plugin-lifecycle.ts";
 export {
+  type FailedPluginDetail,
   getLastFailedPluginDetails,
   getLastFailedPluginNames,
   resolvePlugins,

--- a/packages/agent/src/runtime/index.ts
+++ b/packages/agent/src/runtime/index.ts
@@ -9,6 +9,7 @@ export * from "./owner-entity.ts";
 export * from "./plugin-collector.ts";
 export * from "./plugin-lifecycle.ts";
 export {
+  type FailedPluginDetail,
   getLastFailedPluginDetails,
   getLastFailedPluginNames,
   resolvePlugins,

--- a/packages/agent/src/runtime/plugin-resolver-failed-plugins.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver-failed-plugins.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getLastFailedPluginDetails,
+  getLastFailedPluginNames,
+  resolvePlugins,
+} from "./plugin-resolver";
+
+// Symbols the resolver USED to stash failures on (agent-wide globalThis).
+// The seam is now module-owned per-resolve state read via the typed accessors;
+// these globals must never be written again (Refs #12091 items 30/31).
+const LEGACY_NAMES_SYMBOL = Symbol.for(
+  "@elizaos/plugin-resolver/last-failed-plugin-names",
+);
+const LEGACY_DETAILS_SYMBOL = Symbol.for(
+  "@elizaos/plugin-resolver/last-failed-plugin-details",
+);
+
+describe("plugin-load failure reporting", () => {
+  it("exposes the last resolve pass's failures via the typed accessors without touching globalThis", async () => {
+    const previousCwd = process.cwd();
+    const previousEnv = process.env.BROKEN_PLUGIN_ENABLE;
+    const workspace = await mkdtemp(
+      path.join(tmpdir(), "eliza-plugin-failure-"),
+    );
+    const packageRoot = path.join(
+      workspace,
+      "node_modules",
+      "@thirdparty",
+      "plugin-broken",
+    );
+
+    try {
+      await mkdir(packageRoot, { recursive: true });
+      await writeFile(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@thirdparty/plugin-broken",
+          version: "0.0.0-test",
+          type: "module",
+          exports: { ".": "./index.js" },
+          elizaos: {
+            plugin: { autoEnableModule: "./auto-enable.js" },
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(packageRoot, "auto-enable.js"),
+        "export function shouldEnable(ctx) { return ctx.env.BROKEN_PLUGIN_ENABLE === '1'; }\n",
+        "utf8",
+      );
+      // Imports fine but exports no valid Plugin object -> recorded as a failure.
+      await writeFile(
+        path.join(packageRoot, "index.js"),
+        "export const notAPlugin = 1;\n",
+        "utf8",
+      );
+
+      process.env.BROKEN_PLUGIN_ENABLE = "1";
+      process.chdir(workspace);
+      const config = { plugins: { allow: [], entries: {} } };
+      await resolvePlugins(config, { quiet: true });
+
+      const details = getLastFailedPluginDetails();
+      const broken = details.find(
+        (d) => d.name === "@thirdparty/plugin-broken",
+      );
+      expect(broken).toBeDefined();
+      expect(broken?.error).toBe("no valid Plugin export");
+      expect(getLastFailedPluginNames()).toContain("@thirdparty/plugin-broken");
+
+      // The deleted global is gone: nothing is stashed on globalThis anymore.
+      expect(
+        (globalThis as Record<symbol, unknown>)[LEGACY_NAMES_SYMBOL],
+      ).toBeUndefined();
+      expect(
+        (globalThis as Record<symbol, unknown>)[LEGACY_DETAILS_SYMBOL],
+      ).toBeUndefined();
+
+      // Accessor returns a fresh copy each call — callers cannot mutate state.
+      const first = getLastFailedPluginDetails();
+      first.push({ name: "mutated", error: "mutated" });
+      expect(
+        getLastFailedPluginDetails().some((d) => d.name === "mutated"),
+      ).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+      if (previousEnv === undefined) delete process.env.BROKEN_PLUGIN_ENABLE;
+      else process.env.BROKEN_PLUGIN_ENABLE = previousEnv;
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -60,21 +60,19 @@ import {
   scanDropInPlugins,
 } from "./plugin-types.ts";
 
-const LAST_FAILED_PLUGIN_NAMES = Symbol.for(
-  "@elizaos/plugin-resolver/last-failed-plugin-names",
-);
+/** {name,error} for a plugin that failed to load on the last resolve pass. */
+export interface FailedPluginDetail {
+  name: string;
+  error: string;
+}
 
-type GlobalWithLastFailedPluginNames = typeof globalThis & {
-  [LAST_FAILED_PLUGIN_NAMES]?: string[];
-};
-
-const LAST_FAILED_PLUGIN_DETAILS = Symbol.for(
-  "@elizaos/plugin-resolver/last-failed-plugin-details",
-);
-
-type GlobalWithLastFailedPluginDetails = typeof globalThis & {
-  [LAST_FAILED_PLUGIN_DETAILS]?: Array<{ name: string; error: string }>;
-};
+/**
+ * The failure list from the most recent `resolvePlugins` pass in this module
+ * instance. Owned by the resolver rather than stashed on globalThis: readers
+ * (dev boot-history route, PGlite recovery skip-list) import the typed accessors
+ * below, which resolve to the same `@elizaos/agent` copy that ran the resolve.
+ */
+let lastFailedPluginDetails: readonly FailedPluginDetail[] = [];
 
 const RUNTIME_APP_PLUGIN_SUBPATHS = new Set([
   "@elizaos/plugin-calendar",
@@ -828,22 +826,15 @@ async function findNearestNodeModulesDir(
   }
 }
 
-function setLastFailedPlugins(
-  failed: ReadonlyArray<{ name: string; error: string }>,
-): void {
-  (globalThis as GlobalWithLastFailedPluginNames)[LAST_FAILED_PLUGIN_NAMES] =
-    failed.map((plugin) => plugin.name);
-  (globalThis as GlobalWithLastFailedPluginDetails)[
-    LAST_FAILED_PLUGIN_DETAILS
-  ] = failed.map((plugin) => ({ name: plugin.name, error: plugin.error }));
+function setLastFailedPlugins(failed: ReadonlyArray<FailedPluginDetail>): void {
+  lastFailedPluginDetails = failed.map((plugin) => ({
+    name: plugin.name,
+    error: plugin.error,
+  }));
 }
 
 export function getLastFailedPluginNames(): string[] {
-  return [
-    ...((globalThis as GlobalWithLastFailedPluginNames)[
-      LAST_FAILED_PLUGIN_NAMES
-    ] ?? []),
-  ];
+  return lastFailedPluginDetails.map((plugin) => plugin.name);
 }
 
 /**
@@ -852,15 +843,11 @@ export function getLastFailedPluginNames(): string[] {
  * the error message (e.g. a missing-export from a stale @elizaos/* copy) so the
  * dev boot-history endpoint can surface it without log scraping.
  */
-export function getLastFailedPluginDetails(): Array<{
-  name: string;
-  error: string;
-}> {
-  return [
-    ...((globalThis as GlobalWithLastFailedPluginDetails)[
-      LAST_FAILED_PLUGIN_DETAILS
-    ] ?? []),
-  ];
+export function getLastFailedPluginDetails(): FailedPluginDetail[] {
+  return lastFailedPluginDetails.map((plugin) => ({
+    name: plugin.name,
+    error: plugin.error,
+  }));
 }
 
 async function findAncestorNodeModulesDirs(

--- a/packages/app-core/src/api/dev-boot-history.test.ts
+++ b/packages/app-core/src/api/dev-boot-history.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// dev-boot-history reports plugin-load failures by calling the typed
+// getLastFailedPluginDetails() accessor from @elizaos/agent — not by re-reading
+// a private globalThis symbol. Mock the accessor to prove the wiring
+// (Refs #12091 items 30/31).
+const { getLastFailedPluginDetails } = vi.hoisted(() => ({
+  getLastFailedPluginDetails: vi.fn<[], { name: string; error: string }[]>(
+    () => [],
+  ),
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  getLastFailedPluginDetails,
+}));
+
+import { buildBootHistoryPayload } from "./dev-boot-history";
+
+describe("buildBootHistoryPayload — failed plugins", () => {
+  afterEach(() => {
+    getLastFailedPluginDetails.mockReset();
+    getLastFailedPluginDetails.mockReturnValue([]);
+  });
+
+  it("surfaces failures returned by the agent accessor", async () => {
+    const stateDir = await mkdtemp(path.join(tmpdir(), "eliza-boot-history-"));
+    try {
+      getLastFailedPluginDetails.mockReturnValue([
+        { name: "@elizaos/plugin-x", error: "no valid Plugin export" },
+      ]);
+
+      const payload = await buildBootHistoryPayload({
+        ELIZA_STATE_DIR: stateDir,
+      } as NodeJS.ProcessEnv);
+
+      expect(getLastFailedPluginDetails).toHaveBeenCalledTimes(1);
+      expect(payload.failedPlugins).toEqual([
+        { name: "@elizaos/plugin-x", error: "no valid Plugin export" },
+      ]);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no failures when the accessor returns an empty list", async () => {
+    const stateDir = await mkdtemp(path.join(tmpdir(), "eliza-boot-history-"));
+    try {
+      const payload = await buildBootHistoryPayload({
+        ELIZA_STATE_DIR: stateDir,
+      } as NodeJS.ProcessEnv);
+      expect(payload.failedPlugins).toEqual([]);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app-core/src/api/dev-boot-history.ts
+++ b/packages/app-core/src/api/dev-boot-history.ts
@@ -14,15 +14,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import {
+  type FailedPluginDetail,
+  getLastFailedPluginDetails,
+} from "@elizaos/agent";
 import { resolveStateDir } from "@elizaos/core";
 
 export const ELIZA_DEV_BOOT_HISTORY_SCHEMA = "elizaos.dev.boot-history/v1";
-
-/** {name,error} for plugins that failed to load on the last resolve pass. */
-interface FailedPluginDetail {
-  name: string;
-  error: string;
-}
 
 export interface BootHistoryPayload {
   schema: typeof ELIZA_DEV_BOOT_HISTORY_SCHEMA;
@@ -55,28 +53,6 @@ async function readJson(filePath: string): Promise<unknown> {
   }
 }
 
-/**
- * Read the plugin-load failures the resolver stashes on a global Symbol
- * (`@elizaos/agent` exposes the same data via `getLastFailedPluginDetails()`).
- * Reading the global directly keeps this dev route decoupled from the agent
- * barrel and robust to whichever `@elizaos/*` copy is loaded.
- */
-function readFailedPluginDetails(): FailedPluginDetail[] {
-  const raw = (globalThis as Record<symbol, unknown>)[
-    Symbol.for("@elizaos/plugin-resolver/last-failed-plugin-details")
-  ];
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw.filter(
-    (entry): entry is FailedPluginDetail =>
-      typeof entry === "object" &&
-      entry !== null &&
-      typeof (entry as { name?: unknown }).name === "string" &&
-      typeof (entry as { error?: unknown }).error === "string",
-  );
-}
-
 export async function buildBootHistoryPayload(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<BootHistoryPayload> {
@@ -99,7 +75,7 @@ export async function buildBootHistoryPayload(
     latestBoot,
     memory,
     restarts,
-    failedPlugins: readFailedPluginDetails(),
+    failedPlugins: getLastFailedPluginDetails(),
     hints: [
       "latestBoot===null means the runtime has not completed a boot since this process started (restart storm or hard crash) — check restarts and /api/dev/console-log.",
       "watch===true means the API runs under node --watch; a concurrent workspace build (tsc/vite) can rewrite watched files and trigger a restart loop.",


### PR DESCRIPTION
## What

Items 30 + 31 of the #12091 "Dynamic imports & dependency direction" refactor (parent #12086). Paired because 31 consumes 30's producer.

**Item 30** — plugin-resolver stashed last-resolve plugin-load failures on `globalThis` under two `Symbol.for` keys (`@elizaos/plugin-resolver/last-failed-plugin-names` / `-details`): agent-wide process-global state, justified only by duplicate-bundle survival. Now stored on module-owned state in the owning module (`plugin-resolver.ts`); the typed `getLastFailedPluginNames` / `getLastFailedPluginDetails` accessors are the single source of truth. `FailedPluginDetail` is exported through the agent barrels.

**Item 31** — `dev-boot-history.ts` re-declared the private symbol string and hand-validated the untyped `globalThis` payload. It now imports `getLastFailedPluginDetails` from `@elizaos/agent` (a barrel app-core already imports in ~10 files) and deletes the local symbol copy + shape validation. A symbol rename can no longer silently produce a zero-failure report.

## Done-when evidence

- Both symbol strings removed **entirely** — `grep -rn 'last-failed-plugin-names\|last-failed-plugin-details' packages/ plugins/ --include=*.ts` over source is empty (previously in plugin-resolver.ts x2 + dev-boot-history.ts x1).
- `plugin-resolver` writes nothing to `globalThis` (no `Symbol.for` / global stash remains); boot-history reports failures from the module-owned per-resolve state via the typed accessor.

## Tests (added, proving the seam)

- `packages/agent/src/runtime/plugin-resolver-failed-plugins.test.ts` — real `resolvePlugins` over a fixture whose package imports but exports no valid Plugin object; asserts `getLastFailedPluginDetails()` / `getLastFailedPluginNames()` return it, the legacy `globalThis` symbols stay `undefined`, and the accessor returns a fresh (non-mutable) copy.
- `packages/app-core/src/api/dev-boot-history.test.ts` — mocks `@elizaos/agent`'s accessor; asserts `buildBootHistoryPayload().failedPlugins` is sourced from it (called once) for both populated and empty cases.

Counts: agent `plugin-resolver*` files 4 tests / 2 files passed; app-core `dev-boot-history.test.ts` 2 tests / 1 file passed.

## Typecheck / build

- `bun run --cwd packages/core build`, `bun run --cwd packages/agent build` clean.
- `packages/agent` + `packages/app-core` typecheck: zero errors in touched files. Remaining `TS2307 Cannot find module '@elizaos/plugin-*'` are pre-existing environmental (unbuilt sibling plugins), unrelated to this change.

## Residual (honest)

True per-`AgentRuntime`-instance scoping would require threading a `PluginLoadReport` back through upstream `startEliza`'s 3 `resolvePlugins` call sites plus a runtime handle into the dev route — a cascade beyond a self-contained, behavior-neutral change. This PR removes the `globalThis` coupling (the concrete defect) and routes reads through the single resolved copy via the typed barrel accessor; module-owned state is behavior-identical to the old global for app-core's one-runtime-per-process deployment.

Refs #12091 (items 30, 31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)