### PR TITLE
refactor(core): statically import EventType in HookService (Refs #12091 item 36)

### DIFF
--- a/packages/core/src/services/hook.event-enumeration.test.ts
+++ b/packages/core/src/services/hook.event-enumeration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { EventType } from "../types/events";
+import type { IAgentRuntime } from "../types/runtime";
+import { HookService } from "./hook";
+
+/**
+ * Item #36 (Refs #12091): HookService enumerates HOOK_* event types via a
+ * static `import { EventType }` instead of an inline `require("../types/events")`.
+ * This proves the statically-imported enum is the source the interceptor setup
+ * registers, and that every HOOK_* member (and only those) gets wired.
+ */
+
+function makeRuntime(registered: string[]): IAgentRuntime {
+	return {
+		agentId: "00000000-0000-0000-0000-0000000000aa",
+		registerEvent: (eventType: string) => {
+			registered.push(eventType);
+		},
+	} as unknown as IAgentRuntime;
+}
+
+describe("HookService static HOOK_ event enumeration", () => {
+	it("registers exactly the statically-imported HOOK_* event types", async () => {
+		const registered: string[] = [];
+		await HookService.start(makeRuntime(registered));
+
+		const expected = Object.values(EventType).filter(
+			(e) => typeof e === "string" && e.startsWith("HOOK_"),
+		);
+
+		// Non-empty: the enum actually carries HOOK_ members.
+		expect(expected.length).toBeGreaterThan(0);
+		expect(new Set(registered)).toEqual(new Set(expected));
+		// Only HOOK_* events are intercepted.
+		expect(registered.every((e) => e.startsWith("HOOK_"))).toBe(true);
+	});
+});

--- a/packages/core/src/services/hook.ts
+++ b/packages/core/src/services/hook.ts
@@ -13,7 +13,8 @@
  * - Integration with runtime event system
  */
 
-import type { EventPayload, EventType } from "../types/events";
+import type { EventPayload } from "../types/events";
+import { EventType } from "../types/events";
 import type {
 	HookEligibilityResult,
 	HookFrontmatter,
@@ -163,10 +164,7 @@ export class HookService extends Service implements IHookService {
 	 */
 	private setupEventInterceptors(): void {
 		// Get all HOOK_* event types
-		const hookEventTypes = Object.values(
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			require("../types/events").EventType,
-		).filter(
+		const hookEventTypes = Object.values(EventType).filter(
 			(e) => typeof e === "string" && e.startsWith("HOOK_"),
 		) as EventType[];
 


### PR DESCRIPTION
## What

`HookService.setupEventInterceptors` enumerated `HOOK_*` event types via an inline `require("../types/events").EventType` — hiding the dependency and relying on Bun's `require` shim inside a `"type":"module"` package. `services/message.ts:164` already value-imports `EventType` statically (and `events.ts` has only type-only imports, so there is no cycle), so this switches `hook.ts` to the same static import and removes the `require()`.

Refs #12091 (item 36).

## Change
- `packages/core/src/services/hook.ts`: split the type-only import into `import type { EventPayload }` + `import { EventType }` (value import); replace the `require("../types/events").EventType` scan with `Object.values(EventType)`. No `eslint-disable` needed anymore.

## Done-when evidence
- **Grep:** `grep -n "require(" packages/core/src/services/hook.ts` → no matches (previously line 168).
- Hook event enumeration is now statically typed off the imported enum.
- **New test** `hook.event-enumeration.test.ts` asserts `HookService.start` registers **exactly** the statically-imported `HOOK_*` `EventType` members (and only those): 1 file / 1 test passing.
- `bun run --cwd packages/core typecheck` clean; `bun run --cwd packages/core build` (Node + browser + edge + d.ts) clean.
- Existing `streaming-runtime-hooks` core suite still green (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)