### PR TITLE
refactor(agent): delete dead global awareness-registry fallback (Refs #12091 item 8)

### DIFF
--- a/packages/agent/src/actions/runtime.self-status.test.ts
+++ b/packages/agent/src/actions/runtime.self-status.test.ts
@@ -1,0 +1,79 @@
+import type {
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { runtimeAction } from "./runtime.ts";
+
+/**
+ * Item #8 (Refs #12091): the dead global awareness-registry fallback is gone.
+ * `self_status` must resolve the registry solely from the AWARENESS_REGISTRY
+ * runtime service and fail closed when it is not registered.
+ */
+
+type AwarenessServiceLike = {
+  getDetail: (
+    runtime: IAgentRuntime,
+    module: string,
+    level: "brief" | "full",
+  ) => Promise<string>;
+};
+
+function makeRuntime(service: AwarenessServiceLike | null): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    actions: [],
+    getService: (t: string) => (t === "AWARENESS_REGISTRY" ? service : null),
+  } as unknown as IAgentRuntime;
+}
+
+const message = { content: { text: "" } } as unknown as Memory;
+
+async function runSelfStatus(runtime: IAgentRuntime): Promise<ActionResult> {
+  return (await runtimeAction.handler(
+    runtime,
+    message,
+    {} as State,
+    { parameters: { action: "self_status", module: "runtime" } },
+    (() => Promise.resolve([])) as unknown as HandlerCallback,
+  )) as ActionResult;
+}
+
+describe("RUNTIME self_status registry seam", () => {
+  it("uses the AWARENESS_REGISTRY service when registered", async () => {
+    let seen: { module: string; level: string } | null = null;
+    const service: AwarenessServiceLike = {
+      getDetail: async (_runtime, module, level) => {
+        seen = { module, level };
+        return "runtime module detail from service";
+      },
+    };
+    const result = await runSelfStatus(makeRuntime(service));
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("runtime module detail from service");
+    expect(seen).toEqual({ module: "runtime", level: "brief" });
+  });
+
+  it("fails closed when no AWARENESS_REGISTRY service is registered", async () => {
+    const result = await runSelfStatus(makeRuntime(null));
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("Self-awareness registry is not available");
+  });
+
+  it("fails closed when the service is not a valid registry (no getDetail)", async () => {
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-0000000000aa",
+      actions: [],
+      getService: (t: string) => (t === "AWARENESS_REGISTRY" ? {} : null),
+    } as unknown as IAgentRuntime;
+    const result = await runSelfStatus(runtime);
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("Self-awareness registry is not available");
+  });
+});

--- a/packages/agent/src/actions/runtime.ts
+++ b/packages/agent/src/actions/runtime.ts
@@ -27,7 +27,6 @@ import type {
 import { logger } from "@elizaos/core";
 import {
   type AwarenessRegistry,
-  getGlobalAwarenessRegistry,
   getValidationKeywordTerms,
   isSelfEditEnabled,
   requestRestart,
@@ -199,12 +198,8 @@ async function selfStatusOp(
   runtime: IAgentRuntime,
   params: RuntimeParams,
 ): Promise<ActionResult> {
-  const registry = (() => {
-    const service = runtime.getService("AWARENESS_REGISTRY");
-    return isAwarenessRegistry(service)
-      ? service
-      : getGlobalAwarenessRegistry();
-  })();
+  const service = runtime.getService("AWARENESS_REGISTRY");
+  const registry = isAwarenessRegistry(service) ? service : null;
   if (!registry) {
     return fail("self_status", "Self-awareness registry is not available.");
   }

--- a/packages/agent/src/api/agent-status-routes.ts
+++ b/packages/agent/src/api/agent-status-routes.ts
@@ -81,7 +81,7 @@ export interface AgentStatusRouteDeps {
     config: ElizaConfig,
   ) => string | undefined;
   resolveProviderFromModel: (model: string) => string | null;
-  getGlobalAwarenessRegistry: () => AwarenessRegistryLike | null;
+  getAwarenessRegistry: () => AwarenessRegistryLike | null;
   RegistryService: RegistryServiceStatic;
 }
 
@@ -150,7 +150,7 @@ export async function handleAgentStatusRoutes(
     const automationMode = capability.automationMode;
 
     let registrySummary: string | null = null;
-    const registry = deps.getGlobalAwarenessRegistry();
+    const registry = deps.getAwarenessRegistry();
     if (registry && state.runtime) {
       try {
         registrySummary = await registry.composeSummary(state.runtime);

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -341,7 +341,6 @@ function getPluginRegistryApi(): Promise<
   return pluginRegistryApiPromise;
 }
 
-import { getGlobalAwarenessRegistry } from "../awareness/registry.ts";
 import {
   type ElizaConfig,
   loadElizaConfig,
@@ -3053,9 +3052,9 @@ async function handleRequest(
               detectRuntimeModel,
             ),
           resolveProviderFromModel,
-          getGlobalAwarenessRegistry: coerce<
-            AgentStatusRouteArg["deps"]["getGlobalAwarenessRegistry"]
-          >(getGlobalAwarenessRegistry),
+          getAwarenessRegistry: coerce<
+            AgentStatusRouteArg["deps"]["getAwarenessRegistry"]
+          >(() => state.runtime?.getService("AWARENESS_REGISTRY") ?? null),
           RegistryService,
         },
       });

--- a/packages/agent/src/awareness/registry.ts
+++ b/packages/agent/src/awareness/registry.ts
@@ -1,5 +1,1 @@
-export {
-  AwarenessRegistry,
-  getGlobalAwarenessRegistry,
-  setGlobalAwarenessRegistry,
-} from "@elizaos/shared";
+export { AwarenessRegistry } from "@elizaos/shared";

--- a/packages/shared/src/awareness/registry.ts
+++ b/packages/shared/src/awareness/registry.ts
@@ -42,16 +42,6 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-let _globalRegistry: AwarenessRegistry | null = null;
-
-export function setGlobalAwarenessRegistry(registry: AwarenessRegistry): void {
-  _globalRegistry = registry;
-}
-
-export function getGlobalAwarenessRegistry(): AwarenessRegistry | null {
-  return _globalRegistry;
-}
-
 export class AwarenessRegistry {
   private readonly contributors: AwarenessContributor[] = [];
   private readonly contributorIds = new Set<string>();


### PR DESCRIPTION
## What

`getGlobalAwarenessRegistry` read a module-level singleton in `packages/shared/src/awareness/registry.ts` that was **never written** — `setGlobalAwarenessRegistry` had zero callers — so the fallback in the `self_status` action (`actions/runtime.ts:206`) and the `/api/agent/self-status` route deps wiring (`server.ts:3056`) always yielded `null`. Dead code masquerading as a fallback.

Refs #12091 (item 8).

## Change
- `packages/shared/src/awareness/registry.ts`: delete the `_globalRegistry` singleton and the `get/setGlobalAwarenessRegistry` pair (auto-removes them from the `@elizaos/shared` barrel via `awareness/index.ts`).
- `packages/agent/src/awareness/registry.ts`: drop the two re-exports; keep `AwarenessRegistry`.
- `packages/agent/src/actions/runtime.ts`: `self_status` op now resolves solely from `runtime.getService("AWARENESS_REGISTRY")` and **fails closed** when it is unregistered (no global fallback).
- `packages/agent/src/api/server.ts` + `agent-status-routes.ts`: the route's always-null `getGlobalAwarenessRegistry` dep is replaced by `getAwarenessRegistry`, wired to `state.runtime.getService("AWARENESS_REGISTRY")`. The `registrySummary` field (consumed by the Electrobun dashboard RPC) now actually populates when the service is registered, instead of being permanently omitted.

No behavior regression: both former paths were already dead (service unregistered ⇒ still fails closed, exactly as before), and the route summary strictly improves from always-null to service-backed.

## Done-when evidence
- **Grep:** `git grep -n GlobalAwarenessRegistry -- '*.ts' '*.tsx'` → no matches.
- **New test** `runtime.self-status.test.ts` (3/3 passing): `self_status` (a) uses the injected `AWARENESS_REGISTRY` service, (b) fails closed with no service registered, (c) fails closed on a non-registry service.
- `typecheck` clean in `packages/shared`, `packages/core`, and `packages/agent` (agent fully clean after building sibling workspace deps — the only prior errors were unbuilt `@elizaos/plugin-*` / `cloud-routing` resolution, unrelated to these files).
- `packages/shared` and `packages/core` build clean.
- `agent` `actions/runtime` suite green (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)