### PR TITLE
fix(agent): default-deny connector account routes

### DIFF
--- a/packages/agent/src/api/connector-account-routes.test.ts
+++ b/packages/agent/src/api/connector-account-routes.test.ts
@@ -339,7 +339,7 @@ function createConnectorAccountHarness(options: {
   body?: Record<string, unknown>;
   storage?: TestStorage;
   adapter?: unknown;
-  authorize?: ConnectorAccountRouteContext["authorize"];
+  authorize?: ConnectorAccountRouteContext["authorize"] | null;
 }) {
   const captured: Captured = { status: 200, body: null };
   const storage = options.storage ?? new InMemoryConnectorAccountStorage();
@@ -377,7 +377,10 @@ function createConnectorAccountHarness(options: {
       captured.status = status;
       captured.body = { error: message };
     },
-    authorize: options.authorize,
+    authorize:
+      options.authorize === null
+        ? undefined
+        : (options.authorize ?? vi.fn(async () => true)),
   };
   return { ctx, captured, runtime, storage };
 }
@@ -456,6 +459,29 @@ describe("connector account routes", () => {
         method: "GET",
       }),
     );
+    expect(captured.status).toBe(403);
+    expect(captured.body).toEqual({ error: "Forbidden" });
+  });
+
+  it("defaults to forbidden for non-public connector account routes without an authorizer", async () => {
+    const { ctx, captured, storage } = createConnectorAccountHarness({
+      method: "GET",
+      pathname: "/api/connectors/slack/accounts",
+      authorize: null,
+    });
+    await storage.upsertAccount({
+      id: "acct_1",
+      provider: "slack",
+      role: "OWNER",
+      purpose: ["messaging"],
+      accessGate: "open",
+      status: "connected",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await expect(handleConnectorAccountRoutes(ctx)).resolves.toBe(true);
+
     expect(captured.status).toBe(403);
     expect(captured.body).toEqual({ error: "Forbidden" });
   });

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -657,7 +657,11 @@ export async function handleConnectorAccountRoutes(
     error(res, "Invalid connector provider", 400);
     return true;
   }
-  if (!isUnauthenticatedOAuthCallback(parsedPath, method) && ctx.authorize) {
+  if (!isUnauthenticatedOAuthCallback(parsedPath, method)) {
+    if (!ctx.authorize) {
+      error(res, "Forbidden", 403);
+      return true;
+    }
     const allowed = await ctx.authorize(
       authorizationRequestForPath(parsedPath, method, pathname),
     );

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -710,6 +710,7 @@ function googleConnectorAccountRouteHandler(): LegacyRouteHandler {
       json,
       error,
       readJsonBody: httpReadJsonBody,
+      authorize: async () => true,
     });
     if (!handled) {
       error(httpRes, "Connector account route not found", 404);


### PR DESCRIPTION
## Summary
- Makes non-public connector account routes return 403 when `handleConnectorAccountRoutes` is called without an authorizer.
- Keeps OAuth callback routes public.
- Passes an explicit allow-authorizer from the existing `withOwnerAdminGate` personal-assistant route wrapper, preserving the current production gate while removing the handler footgun.
- Addresses #12088 item 15.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/agent test -- src/api/connector-account-routes.test.ts`
- `bunx @biomejs/biome check packages/agent/src/api/connector-account-routes.ts packages/agent/src/api/connector-account-routes.test.ts plugins/plugin-personal-assistant/src/routes/plugin.ts`
- `git diff --check`

## Typecheck note
- `bun run --cwd plugins/plugin-personal-assistant typecheck` currently fails on unrelated pre-existing errors in `src/actions/scheduled-task.ts` and `src/plugin.ts` (`ScheduledTaskValidationError`, unknown error narrowing, and plugin-calendar exports).

## Evidence
- N/A - security boundary cleanup with no user-visible UI.
- N/A - no model/action/provider/prompt behavior changed.