### PR TITLE
refactor(commands): register commands through a runtime service, not module state (#12091 item 15)

### DIFF
--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -6,14 +6,18 @@
  * Memory search/get actions are superseded by the todos plugin.
  */
 
-import type { IAgentRuntime, Plugin, ServiceClass } from "@elizaos/core";
+import type {
+  CommandRegistryService,
+  IAgentRuntime,
+  Plugin,
+  ServiceClass,
+} from "@elizaos/core";
 import {
   AgentEventService,
   logger,
   NotificationService,
   promoteSubactionsToActions,
 } from "@elizaos/core";
-import type { CommandDefinition } from "@elizaos/plugin-commands";
 import { compactConversationAction } from "../actions/compact-conversation.ts";
 import { connectAccountAction } from "../actions/connect-account.ts";
 import { contactAction } from "../actions/contact.ts";
@@ -154,69 +158,52 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       // sweep orphaned files daily. The serving route is declared below.
       registerMediaPipelineHook(runtime);
       registerMediaGcTask(runtime);
-      const registerSkillsAsCommands = async () => {
-        try {
-          const skillsService = runtime.getService("AGENT_SKILLS_SERVICE");
-          if (!isAgentSkillsService(skillsService)) return false;
+      const registerSkillsAsCommands = () => {
+        const skillsService = runtime.getService("AGENT_SKILLS_SERVICE");
+        if (!isAgentSkillsService(skillsService)) return false;
 
-          const skills = skillsService.getLoadedSkills();
-          if (skills.length === 0) return false;
+        const skills = skillsService.getLoadedSkills();
+        if (skills.length === 0) return false;
 
-          let registerCommand: (command: CommandDefinition) => void;
-          let initForRuntime: (agentId: string) => void;
-          try {
-            const cmds = await import(
-              /* @vite-ignore */ "@elizaos/plugin-commands"
-            );
-            registerCommand = cmds.registerCommand;
-            initForRuntime = cmds.initForRuntime;
-          } catch {
-            return false;
-          }
+        // Commands are contributed through the runtime service registered by
+        // the commands plugin — no import edge into it, and the service
+        // appends without resetting commands other plugins registered.
+        const commands =
+          runtime.getService<CommandRegistryService>("commands");
+        if (!commands) return false;
 
-          initForRuntime(runtime.agentId);
-
-          let registered = 0;
-          for (const skill of skills) {
-            const slug = skill.slug.toLowerCase();
-            try {
-              registerCommand({
-                key: `skill-${slug}`,
-                description: skill.description.substring(0, 80),
-                textAliases: [`/${slug}`],
-                scope: "both",
-                category: "skills",
-                acceptsArgs: true,
-                args: [
-                  {
-                    name: "input",
-                    description: "Task or question for this skill",
-                    captureRemaining: true,
-                  },
-                ],
-              });
-              registered++;
-            } catch {
-              // Command may already be registered by another source.
-            }
-          }
-
-          if (registered > 0) {
-            logger.info(
-              `[eliza] Registered ${registered} skills as slash commands`,
-            );
-          }
-          return true;
-        } catch {
-          return false;
+        let registered = 0;
+        for (const skill of skills) {
+          const slug = skill.slug.toLowerCase();
+          commands.register({
+            key: `skill-${slug}`,
+            description: skill.description.substring(0, 80),
+            textAliases: [`/${slug}`],
+            scope: "both",
+            category: "skills",
+            acceptsArgs: true,
+            args: [
+              {
+                name: "input",
+                description: "Task or question for this skill",
+                captureRemaining: true,
+              },
+            ],
+          });
+          registered++;
         }
+
+        if (registered > 0) {
+          logger.info(
+            `[eliza] Registered ${registered} skills as slash commands`,
+          );
+        }
+        return true;
       };
 
-      void registerSkillsAsCommands().then((registered) => {
-        if (!registered) {
-          setTimeout(() => void registerSkillsAsCommands(), 5000);
-        }
-      });
+      if (!registerSkillsAsCommands()) {
+        setTimeout(() => registerSkillsAsCommands(), 5000);
+      }
     },
 
     providers: [

--- a/packages/core/src/types/commands.ts
+++ b/packages/core/src/types/commands.ts
@@ -1,0 +1,151 @@
+/**
+ * Command system contract.
+ *
+ * The canonical `CommandDefinition` shape and the `CommandRegistryService`
+ * runtime contract live here so hosts and plugins can register/read chat
+ * commands through the runtime service registry without importing the
+ * `@elizaos/plugin-commands` implementation (which owns the concrete registry,
+ * parser, actions, and route surface and re-exports these types).
+ */
+
+import { Service } from "./service";
+
+export type CommandScope = "text" | "native" | "both";
+
+export type CommandCategory =
+	| "session"
+	| "options"
+	| "status"
+	| "management"
+	| "media"
+	| "tools"
+	| "docks"
+	| "skills";
+
+/**
+ * The surfaces a command is offered on. Omitted/undefined on a definition means
+ * "all surfaces" (the default). `serializeCommand(cmd, surface)` filters on this.
+ */
+export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
+
+/**
+ * A live source a client resolves an argument's choices from at render time
+ * (the registry can't enumerate models/views/skills/providers statically). The
+ * definition tags the source; the client fetches the concrete values.
+ */
+export type CommandArgSource =
+	| "models"
+	| "views"
+	| "settings-sections"
+	| "skills"
+	| "providers";
+
+/**
+ * Client-only behaviors the in-app surfaces (GUI/TUI) run directly, with no
+ * agent round-trip and no remote surface. Connectors filter `client` targets
+ * out (a Discord/Telegram user has nothing to clear or full-screen).
+ */
+export type ClientCommandAction =
+	| "clear-chat"
+	| "new-conversation"
+	| "toggle-fullscreen"
+	| "open-command-palette"
+	| "show-commands"
+	| "toggle-transcription";
+
+/**
+ * Where a command executes — the single discriminant every surface routes on:
+ *   - `agent`    → the command runs through the agent (a deterministic command
+ *                  action handles it; `action` names that handler when known).
+ *   - `navigate` → opens a destination in the Eliza app; `path` is the in-app
+ *                  deep link, `tab`/`viewId`/`section` are routing hints.
+ *   - `client`   → a GUI/TUI-only behavior with no remote surface.
+ */
+export type CommandTarget =
+	| { kind: "agent"; action?: string }
+	| {
+			kind: "navigate";
+			path: string;
+			tab?: string;
+			viewId?: string;
+			section?: string;
+	  }
+	| { kind: "client"; clientAction: ClientCommandAction };
+
+export interface CommandArgChoiceContext {
+	provider?: string;
+	model?: string;
+	config?: Record<string, unknown>;
+}
+
+export interface CommandArgDefinition {
+	name: string;
+	description: string;
+	required?: boolean;
+	choices?: string[] | ((ctx: CommandArgChoiceContext) => string[]);
+	/**
+	 * A live choice source the client resolves at render time. Carried through
+	 * serialization so the client knows to fetch models/views/skills/etc. for
+	 * this arg instead of relying on static `choices`.
+	 */
+	dynamicChoices?: CommandArgSource;
+	captureRemaining?: boolean;
+}
+
+export interface CommandDefinition {
+	key: string;
+	nativeName?: string;
+	description: string;
+	textAliases: string[];
+	scope: CommandScope;
+	category?: CommandCategory;
+	acceptsArgs?: boolean;
+	args?: CommandArgDefinition[];
+	argsParsing?: "none" | "positional";
+	requiresAuth?: boolean;
+	requiresElevated?: boolean;
+	enabled?: boolean;
+	/**
+	 * Where this command executes. Omitted = `{ kind: "agent" }` (the default):
+	 * a deterministic command action handles it through the agent. Navigation /
+	 * client commands set this explicitly so every surface routes them the same.
+	 */
+	target?: CommandTarget;
+	/**
+	 * The surfaces this command is offered on. Omitted/undefined = all surfaces
+	 * (the default). `serializeCommand(cmd, surface)` filters on this so the
+	 * `?surface=` catalog query returns only what that surface should render.
+	 */
+	surfaces?: CommandSurface[];
+	/** Optional icon hint (lucide name) for menu rendering. */
+	icon?: string;
+	/**
+	 * View ids for which this command is *view-dependent*: it is only surfaced in
+	 * the command catalog while one of these views is the active (foreground)
+	 * surface. Omitted/undefined = globally available (the default). A non-empty
+	 * list scopes the command to those views — e.g. a `/calendar add` command that
+	 * only makes sense while the calendar view is open. (#8798)
+	 */
+	views?: string[];
+}
+
+/**
+ * Runtime contract for the chat-command registry. `@elizaos/plugin-commands`
+ * registers the concrete implementation under service type `"commands"`; hosts
+ * and other plugins contribute commands through
+ * `runtime.getService<CommandRegistryService>("commands")` so registrations
+ * always land on the loaded plugin instance's per-runtime store (no module-
+ * duplication drift) and never reset commands registered by earlier plugins.
+ */
+export abstract class CommandRegistryService extends Service {
+	static override readonly serviceType = "commands";
+
+	/**
+	 * Register (or replace, by `key`) a command on this runtime's store without
+	 * resetting existing registrations.
+	 */
+	abstract register(command: CommandDefinition): void;
+
+	/** All commands currently registered for this runtime. */
+	abstract list(): CommandDefinition[];
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -11,6 +11,9 @@ export * from "./access-context";
 export * from "./agent";
 // Channel configuration types for plugins
 export * from "./channel-config";
+// Chat-command contract (CommandDefinition + CommandRegistryService); the
+// concrete registry lives in @elizaos/plugin-commands and re-exports these.
+export * from "./commands";
 export * from "./components";
 // Connector setup HTTP-route contract (distinct from ./setup onboarding wizard)
 export * from "./connector-setup";

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -39,6 +39,7 @@ export interface ServiceTypeRegistry {
 	AGENT_EVENT: "agent_event";
 	OPTIMIZED_PROMPT: "optimized_prompt";
 	CHANNEL_TOPICS: "channel_topics";
+	COMMANDS: "commands";
 	UNKNOWN: "unknown";
 }
 
@@ -134,6 +135,7 @@ export const ServiceType = {
 	VOICE_CACHE: "voice_cache",
 	OPTIMIZED_PROMPT: "optimized_prompt",
 	CHANNEL_TOPICS: "channel_topics",
+	COMMANDS: "commands",
 	UNKNOWN: "unknown",
 } as const;
 

--- a/plugins/plugin-commands/__tests__/command-registry-service.test.ts
+++ b/plugins/plugin-commands/__tests__/command-registry-service.test.ts
@@ -1,0 +1,95 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { CommandRegistryService } from "../src/command-registry-service";
+import { initForRuntime } from "../src/registry";
+import type { CommandDefinition } from "../src/types";
+
+/**
+ * The CommandRegistryService is the runtime seam hosts and other plugins use to
+ * contribute commands (item #12091-15) — replacing a dynamic import of the
+ * plugin's module-level registry. Registrations must land on the queried
+ * runtime's store and must NOT reset commands registered by earlier plugins.
+ */
+
+function fakeRuntime(agentId: string): IAgentRuntime {
+	return { agentId } as unknown as IAgentRuntime;
+}
+
+const otherPluginCommand: CommandDefinition = {
+	key: "other-plugin-cmd",
+	description: "registered by a different plugin before the skills bridge",
+	textAliases: ["/other"],
+	scope: "both",
+	category: "tools",
+};
+
+function skillCommand(slug: string): CommandDefinition {
+	return {
+		key: `skill-${slug}`,
+		description: `${slug} skill`,
+		textAliases: [`/${slug}`],
+		scope: "both",
+		category: "skills",
+		acceptsArgs: true,
+		args: [
+			{
+				name: "input",
+				description: "Task or question for this skill",
+				captureRemaining: true,
+			},
+		],
+	};
+}
+
+describe("CommandRegistryService", () => {
+	it("exposes the canonical 'commands' service type", () => {
+		expect(CommandRegistryService.serviceType).toBe("commands");
+	});
+
+	it("registers a command on the queried runtime's store", async () => {
+		const agentId = "svc-agent-a";
+		initForRuntime(agentId);
+		const service = await CommandRegistryService.start(fakeRuntime(agentId));
+
+		service.register(otherPluginCommand);
+
+		const keys = service.list().map((c) => c.key);
+		expect(keys).toContain("other-plugin-cmd");
+		// Built-in defaults remain.
+		expect(keys).toContain("help");
+	});
+
+	it("keeps other plugins' commands alive across skills-bridge registration", async () => {
+		const agentId = "svc-agent-b";
+		initForRuntime(agentId);
+		const service = await CommandRegistryService.start(fakeRuntime(agentId));
+
+		// Another plugin registers first.
+		service.register(otherPluginCommand);
+
+		// The skills bridge then registers skill commands through the same seam
+		// (no initForRuntime, so nothing is reset).
+		for (const slug of ["research", "plan", "recap"]) {
+			service.register(skillCommand(slug));
+		}
+
+		const keys = service.list().map((c) => c.key);
+		expect(keys).toContain("other-plugin-cmd");
+		expect(keys).toContain("skill-research");
+		expect(keys).toContain("skill-plan");
+		expect(keys).toContain("skill-recap");
+	});
+
+	it("replaces by key rather than duplicating", async () => {
+		const agentId = "svc-agent-c";
+		initForRuntime(agentId);
+		const service = await CommandRegistryService.start(fakeRuntime(agentId));
+
+		service.register(skillCommand("dupe"));
+		service.register({ ...skillCommand("dupe"), description: "updated" });
+
+		const matches = service.list().filter((c) => c.key === "skill-dupe");
+		expect(matches).toHaveLength(1);
+		expect(matches[0].description).toBe("updated");
+	});
+});

--- a/plugins/plugin-commands/__tests__/registry.test.ts
+++ b/plugins/plugin-commands/__tests__/registry.test.ts
@@ -3,9 +3,11 @@ import {
 	findCommandByAlias,
 	findCommandByKey,
 	getCommandsByCategory,
+	getCommandsForRuntime,
 	getEnabledCommands,
 	initForRuntime,
 	registerCommand,
+	registerCommandForRuntime,
 	resetCommands,
 	startsWithCommand,
 	unregisterCommand,
@@ -86,5 +88,33 @@ describe("disabled commands + categories", () => {
 		const status = getCommandsByCategory("status");
 		expect(status.length).toBeGreaterThan(0);
 		expect(status.every((c) => c.category === "status")).toBe(true);
+	});
+});
+
+describe("per-runtime registration + clobber fix (item #12091-15)", () => {
+	const agentId = "clobber-agent";
+
+	it("registerCommandForRuntime targets the runtime store without a global useRuntime", () => {
+		initForRuntime(agentId);
+		registerCommandForRuntime(agentId, custom);
+		const keys = getCommandsForRuntime(agentId).map((c) => c.key);
+		expect(keys).toContain("frobnicate");
+		// Defaults are still present alongside the custom registration.
+		expect(keys).toContain("help");
+	});
+
+	it("initForRuntime re-seeds defaults but PRESERVES custom registrations", () => {
+		initForRuntime(agentId);
+		registerCommandForRuntime(agentId, custom);
+		expect(
+			getCommandsForRuntime(agentId).some((c) => c.key === "frobnicate"),
+		).toBe(true);
+
+		// A second init (previously reset the store to DEFAULT_COMMANDS, clobbering
+		// commands other plugins registered earlier) must keep the custom command.
+		initForRuntime(agentId);
+		const keys = getCommandsForRuntime(agentId).map((c) => c.key);
+		expect(keys).toContain("frobnicate");
+		expect(keys).toContain("help");
 	});
 });

--- a/plugins/plugin-commands/src/command-registry-service.ts
+++ b/plugins/plugin-commands/src/command-registry-service.ts
@@ -1,0 +1,42 @@
+/**
+ * CommandRegistryService — the runtime seam for the chat-command registry.
+ *
+ * Registered by this plugin under service type `"commands"`. Hosts and other
+ * plugins contribute commands through
+ * `runtime.getService<CommandRegistryService>("commands")` instead of importing
+ * this package, so registrations always land on the loaded plugin instance's
+ * per-runtime store (no module-duplication drift) and never reset commands
+ * registered by earlier plugins.
+ */
+
+import {
+	type CommandDefinition,
+	CommandRegistryService as CommandRegistryServiceContract,
+	type IAgentRuntime,
+} from "@elizaos/core";
+import {
+	getCommandsForRuntime,
+	registerCommandForRuntime,
+} from "./registry.js";
+
+export class CommandRegistryService extends CommandRegistryServiceContract {
+	static override readonly serviceType = "commands";
+	override capabilityDescription =
+		"Chat-command registry: register and read slash/native commands per runtime.";
+
+	static override async start(
+		runtime: IAgentRuntime,
+	): Promise<CommandRegistryService> {
+		return new CommandRegistryService(runtime);
+	}
+
+	async stop(): Promise<void> {}
+
+	override register(command: CommandDefinition): void {
+		registerCommandForRuntime(this.runtime.agentId, command);
+	}
+
+	override list(): CommandDefinition[] {
+		return getCommandsForRuntime(this.runtime.agentId);
+	}
+}

--- a/plugins/plugin-commands/src/index.ts
+++ b/plugins/plugin-commands/src/index.ts
@@ -27,11 +27,13 @@ import {
 	type Plugin,
 	type Provider,
 	type ProviderResult,
+	type ServiceClass,
 	type State,
 } from "@elizaos/core";
 // Deterministic command action layer (#8790): handlers, dispatch, settings,
 // and the registered *_COMMAND actions.
 import { commandActions, commandShortcuts } from "./actions";
+import { CommandRegistryService } from "./command-registry-service";
 import { detectCommand, hasCommand, normalizeCommandBody } from "./parser";
 import {
 	findCommandByAlias,
@@ -48,6 +50,8 @@ import type { CommandContext, CommandDefinition, CommandResult } from "./types";
 // Connector-neutral command catalog (getConnectorCommands / ConnectorCommand)
 // + settings-section resolution (resolveSettingsSection).
 export * from "./actions";
+// The runtime seam other packages register commands through.
+export { CommandRegistryService } from "./command-registry-service";
 // The documented ConnectorCommandBridge contract + shared auth-gating helpers
 // every communication connector implements (#8790).
 export * from "./connector-bridge";
@@ -169,6 +173,10 @@ export function isElevated(
 export const commandsPlugin: Plugin = {
 	name: "commands",
 	description: "Chat command system with /help, /status, /reset, etc.",
+
+	// Runtime seam: hosts/plugins register commands through this service instead
+	// of importing plugin-commands' module-level registry.
+	services: [CommandRegistryService as ServiceClass],
 
 	providers: [commandRegistryProvider],
 

--- a/plugins/plugin-commands/src/registry.ts
+++ b/plugins/plugin-commands/src/registry.ts
@@ -343,13 +343,34 @@ const fallbackStore: CommandStore = {
 /** Currently active store (set during init, reset on test teardown) */
 let activeStore: CommandStore = fallbackStore;
 
+const DEFAULT_COMMAND_KEYS: ReadonlySet<string> = new Set(
+	DEFAULT_COMMANDS.map((c) => c.key),
+);
+
 /**
- * Initialize an isolated command store for a specific runtime.
+ * Initialize (or re-seed) the isolated command store for a specific runtime.
  * Called from plugin init() to prevent cross-agent contamination.
+ *
+ * Re-seeds the built-in defaults but PRESERVES any custom (non-default)
+ * commands already registered for this runtime — e.g. commands contributed by
+ * other plugins that initialized before this one. Without this, a second
+ * `initForRuntime` call would reset the store to `DEFAULT_COMMANDS` and clobber
+ * those registrations.
  */
 export function initForRuntime(agentId: string): void {
+	const defaults = DEFAULT_COMMANDS.map((c) => ({ ...c }));
+	const existing = runtimeStores.get(agentId);
+	if (existing) {
+		const customs = existing.commands.filter(
+			(c) => !DEFAULT_COMMAND_KEYS.has(c.key),
+		);
+		existing.commands = [...defaults, ...customs];
+		existing.aliasMap = null;
+		activeStore = existing;
+		return;
+	}
 	const store: CommandStore = {
-		commands: DEFAULT_COMMANDS.map((c) => ({ ...c })),
+		commands: defaults,
 		aliasMap: null,
 	};
 	runtimeStores.set(agentId, store);
@@ -517,6 +538,30 @@ function getAliasMapForStore(
 		}
 	}
 	return store.aliasMap;
+}
+
+/**
+ * Register (or replace, by `key`) a command directly on a specific runtime's
+ * store — creating the store from defaults if it does not exist yet. Unlike
+ * the active-store `registerCommand`, this targets the runtime explicitly and
+ * never resets existing registrations, so callers (e.g. the runtime service)
+ * can contribute commands without racing the module-level `activeStore`.
+ */
+export function registerCommandForRuntime(
+	agentId: string,
+	command: CommandDefinition,
+): void {
+	let store = runtimeStores.get(agentId);
+	if (!store) {
+		store = {
+			commands: DEFAULT_COMMANDS.map((c) => ({ ...c })),
+			aliasMap: null,
+		};
+		runtimeStores.set(agentId, store);
+	}
+	store.commands = store.commands.filter((c) => c.key !== command.key);
+	store.commands.push(command);
+	store.aliasMap = null;
 }
 
 export function getCommandsForRuntime(

--- a/plugins/plugin-commands/src/types.ts
+++ b/plugins/plugin-commands/src/types.ts
@@ -2,125 +2,32 @@
  * Command system types
  */
 
-import type { HandlerCallback, Memory } from "@elizaos/core";
+import type {
+	CommandArgSource,
+	CommandCategory,
+	CommandDefinition,
+	CommandScope,
+	CommandSurface,
+	CommandTarget,
+	HandlerCallback,
+	Memory,
+} from "@elizaos/core";
 
-export type CommandScope = "text" | "native" | "both";
-export type CommandCategory =
-	| "session"
-	| "options"
-	| "status"
-	| "management"
-	| "media"
-	| "tools"
-	| "docks"
-	| "skills";
-
-/**
- * The surfaces a command is offered on. Omitted/undefined on a definition means
- * "all surfaces" (the default). `serializeCommand(cmd, surface)` filters on this.
- */
-export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
-
-/**
- * A live source a client resolves an argument's choices from at render time
- * (the registry can't enumerate models/views/skills/providers statically). The
- * definition tags the source; the client fetches the concrete values.
- */
-export type CommandArgSource =
-	| "models"
-	| "views"
-	| "settings-sections"
-	| "skills"
-	| "providers";
-
-/**
- * Client-only behaviors the in-app surfaces (GUI/TUI) run directly, with no
- * agent round-trip and no remote surface. Connectors filter `client` targets
- * out (a Discord/Telegram user has nothing to clear or full-screen).
- */
-export type ClientCommandAction =
-	| "clear-chat"
-	| "new-conversation"
-	| "toggle-fullscreen"
-	| "open-command-palette"
-	| "show-commands"
-	| "toggle-transcription";
-
-/**
- * Where a command executes — the single discriminant every surface routes on:
- *   - `agent`    → the command runs through the agent (a deterministic command
- *                  action handles it; `action` names that handler when known).
- *   - `navigate` → opens a destination in the Eliza app; `path` is the in-app
- *                  deep link, `tab`/`viewId`/`section` are routing hints.
- *   - `client`   → a GUI/TUI-only behavior with no remote surface.
- */
-export type CommandTarget =
-	| { kind: "agent"; action?: string }
-	| {
-			kind: "navigate";
-			path: string;
-			tab?: string;
-			viewId?: string;
-			section?: string;
-	  }
-	| { kind: "client"; clientAction: ClientCommandAction };
-
-export interface CommandArgDefinition {
-	name: string;
-	description: string;
-	required?: boolean;
-	choices?: string[] | ((ctx: CommandArgChoiceContext) => string[]);
-	/**
-	 * A live choice source the client resolves at render time. Carried through
-	 * serialization so the client knows to fetch models/views/skills/etc. for
-	 * this arg instead of relying on static `choices`.
-	 */
-	dynamicChoices?: CommandArgSource;
-	captureRemaining?: boolean;
-}
-
-export interface CommandArgChoiceContext {
-	provider?: string;
-	model?: string;
-	config?: Record<string, unknown>;
-}
-
-export interface CommandDefinition {
-	key: string;
-	nativeName?: string;
-	description: string;
-	textAliases: string[];
-	scope: CommandScope;
-	category?: CommandCategory;
-	acceptsArgs?: boolean;
-	args?: CommandArgDefinition[];
-	argsParsing?: "none" | "positional";
-	requiresAuth?: boolean;
-	requiresElevated?: boolean;
-	enabled?: boolean;
-	/**
-	 * Where this command executes. Omitted = `{ kind: "agent" }` (the default):
-	 * a deterministic command action handles it through the agent. Navigation /
-	 * client commands set this explicitly so every surface routes them the same.
-	 */
-	target?: CommandTarget;
-	/**
-	 * The surfaces this command is offered on. Omitted/undefined = all surfaces
-	 * (the default). `serializeCommand(cmd, surface)` filters on this so the
-	 * `?surface=` catalog query returns only what that surface should render.
-	 */
-	surfaces?: CommandSurface[];
-	/** Optional icon hint (lucide name) for menu rendering. */
-	icon?: string;
-	/**
-	 * View ids for which this command is *view-dependent*: it is only surfaced in
-	 * the command catalog while one of these views is the active (foreground)
-	 * surface. Omitted/undefined = globally available (the default). A non-empty
-	 * list scopes the command to those views — e.g. a `/calendar add` command that
-	 * only makes sense while the calendar view is open. (#8798)
-	 */
-	views?: string[];
-}
+// The canonical command contract lives in @elizaos/core so hosts and other
+// plugins can register/read commands through the runtime service without
+// importing this plugin. Re-exported here for existing intra-package and
+// downstream `@elizaos/plugin-commands` consumers.
+export type {
+	ClientCommandAction,
+	CommandArgChoiceContext,
+	CommandArgDefinition,
+	CommandArgSource,
+	CommandCategory,
+	CommandDefinition,
+	CommandScope,
+	CommandSurface,
+	CommandTarget,
+} from "@elizaos/core";
 
 /**
  * Wire-safe argument shape produced by `serializeCommand`. Mirrors the client


### PR DESCRIPTION
## What

Part of the #12091 architecture cleanup (dynamic imports & dependency direction). Item 15.

The skills→commands bridge in `packages/agent/src/runtime/eliza-plugin.ts` dynamic-imported `@elizaos/plugin-commands` and mutated its **module-level** registry. It called `initForRuntime(agentId)`, which **reset the store to `DEFAULT_COMMANDS`**, clobbering commands other plugins had already registered for that runtime. Under workspace-vs-`node_modules` module duplication the registrations could also land in the wrong module instance silently.

## Change

- **`@elizaos/core`** now owns the command contract: the `CommandDefinition` type family and an abstract `CommandRegistryService` (serviceType `"commands"`). `@elizaos/plugin-commands` **re-exports** the types, so no downstream consumer changes.
- `@elizaos/plugin-commands` registers a concrete `CommandRegistryService` backed by a new `registerCommandForRuntime(agentId, command)` that targets the runtime's store directly and **never resets** it.
- The agent bridge resolves `runtime.getService<CommandRegistryService>("commands")` and registers through it — **no import edge** into the plugin, and it no longer calls `initForRuntime`.
- **Clobber fix:** `initForRuntime` now re-seeds the built-in defaults while **preserving** any custom (non-default) commands already registered for the runtime.

## Done-when (item 15)

- ✅ `packages/agent/src/runtime/eliza-plugin.ts` has **no** `@elizaos/plugin-commands` import (dynamic or type). `grep '@elizaos/plugin-commands' eliza-plugin.ts` → only a prose comment, no import statement.
- ✅ Commands registered by other plugins survive skills-bridge init — covered by new tests.

## Evidence

- `bun run --cwd packages/core build` → clean (declarations regenerated).
- Typecheck clean (`tsgo --noEmit`) in `packages/core`, `plugins/plugin-commands`, `packages/agent`.
- `bun run --cwd plugins/plugin-commands test` → **7 files, 78 tests passed** (includes new `registry.test.ts` clobber-fix block + new `command-registry-service.test.ts` proving other plugins' commands survive skills-bridge registration and the service seam replaces/does-not-duplicate by key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)