### PR TITLE
refactor(agent): route browser live state through a runtime service (#12091 item 14)

### DIFF
--- a/packages/agent/src/providers/page-scoped-context.ts
+++ b/packages/agent/src/providers/page-scoped-context.ts
@@ -212,12 +212,38 @@ async function fetchBrowserBridgeCompanionLiveStatus(): Promise<
   }));
 }
 
-async function renderBrowserLiveState(): Promise<string | null> {
+/**
+ * Minimal structural view of the browser workspace service. Typed locally so
+ * the provider never takes an import edge into the browser plugin; the
+ * service is resolved by its runtime service type and the section is omitted
+ * for agents that do not have the plugin enabled.
+ */
+interface BrowserWorkspaceSnapshotView {
+  mode: string;
+  tabs: Array<{ title?: string | null; url: string; visible?: boolean }>;
+}
+interface BrowserWorkspaceServiceLike {
+  getWorkspaceSnapshot(): Promise<BrowserWorkspaceSnapshotView>;
+}
+
+const BROWSER_SERVICE_TYPE = "browser";
+
+function isBrowserWorkspaceService(
+  service: unknown,
+): service is BrowserWorkspaceServiceLike {
+  return (
+    typeof (service as { getWorkspaceSnapshot?: unknown } | null)
+      ?.getWorkspaceSnapshot === "function"
+  );
+}
+
+async function renderBrowserLiveState(
+  runtime: IAgentRuntime,
+): Promise<string | null> {
+  const service = runtime.getService(BROWSER_SERVICE_TYPE);
+  if (!isBrowserWorkspaceService(service)) return null;
   try {
-    const { getBrowserWorkspaceSnapshot } = await import(
-      "@elizaos/plugin-browser"
-    );
-    const snapshot = await getBrowserWorkspaceSnapshot();
+    const snapshot = await service.getWorkspaceSnapshot();
     const lines: string[] = [
       `Live browser state: bridge=${snapshot.mode}, ${snapshot.tabs.length} tab${snapshot.tabs.length === 1 ? "" : "s"}.`,
     ];
@@ -516,7 +542,7 @@ async function renderLiveStateForScope(
     case "page-character":
       return renderCharacterLiveState(runtime);
     case "page-browser":
-      return renderBrowserLiveState();
+      return renderBrowserLiveState(runtime);
     case "page-automations":
     case "automation-draft":
       return renderAutomationsLiveState(runtime);

--- a/plugins/plugin-browser/src/__tests__/browser-service.test.ts
+++ b/plugins/plugin-browser/src/__tests__/browser-service.test.ts
@@ -114,3 +114,16 @@ describe("BrowserService target routing", () => {
     expect(workspace.execute).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("BrowserService workspace snapshot seam (item #12091-14)", () => {
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("exposes the live workspace snapshot so hosts read it via the runtime service, not a plugin import", async () => {
+    const service = new BrowserService();
+    const snapshot = await service.getWorkspaceSnapshot();
+    expect(typeof snapshot.mode).toBe("string");
+    expect(Array.isArray(snapshot.tabs)).toBe(true);
+  });
+});

--- a/plugins/plugin-browser/src/browser-service.ts
+++ b/plugins/plugin-browser/src/browser-service.ts
@@ -33,9 +33,11 @@ import {
   type BrowserBridgeRouteService,
 } from "./service.js";
 import { maybeCreateStagehandTarget } from "./targets/stagehand-target.js";
+import { getBrowserWorkspaceSnapshot } from "./workspace/browser-workspace.js";
 import type {
   BrowserWorkspaceCommand,
   BrowserWorkspaceCommandResult,
+  BrowserWorkspaceSnapshot,
 } from "./workspace/browser-workspace-types.js";
 
 export const BROWSER_SERVICE_TYPE = "browser";
@@ -155,6 +157,15 @@ export class BrowserService extends Service {
     return this.targetOrder
       .map((id) => this.targets.get(id))
       .filter((target): target is BrowserTarget => target !== undefined);
+  }
+
+  /**
+   * Read-only live workspace snapshot (bridge mode + open tabs). Hosts query
+   * this through the runtime service registry so no caller needs a static
+   * import edge into this plugin.
+   */
+  getWorkspaceSnapshot(): Promise<BrowserWorkspaceSnapshot> {
+    return getBrowserWorkspaceSnapshot();
   }
 
   /**


### PR DESCRIPTION
## What

Part of the #12091 architecture cleanup (dynamic imports & dependency direction). Item 14.

`packages/agent/src/providers/page-scoped-context.ts` lazily `import()`ed `@elizaos/plugin-browser` to call the module-level `getBrowserWorkspaceSnapshot()`. That read browser workspace state **even for agents that don't have the browser plugin enabled**, and threw on mobile where the module stub is absent (the failure was silently nulled).

## Change

- `BrowserService` (already registered by the browser plugin, serviceType `"browser"`) now exposes `getWorkspaceSnapshot()`.
- The provider resolves the browser service via `runtime.getService("browser")` (typed structurally, no plugin import) and **omits the browser section when the service is absent**. No import edge from agent providers into the plugin.

## Done-when (item 14)

- ✅ `page-scoped-context.ts` has **no** `@elizaos/plugin-browser` import — `grep '@elizaos/plugin-browser' page-scoped-context.ts` → only a prose comment, no import statement.
- ✅ Live tab state appears **only** for agents with the plugin enabled: the section renders iff the `"browser"` service resolves; otherwise the provider returns `null`.

## Evidence

- Typecheck clean (`tsgo --noEmit`) in `plugins/plugin-browser` and `packages/agent`.
- `bun run --cwd plugins/plugin-browser build` → clean.
- `bun run --cwd plugins/plugin-browser test src/__tests__/browser-service.test.ts` → **6 tests passed**, including a new test proving `BrowserService.getWorkspaceSnapshot()` returns the live workspace snapshot (the seam the host reads through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)