### PR TITLE
refactor(agent,training): move toggle_training op behind a plugin service (#12091 item 9)

### DIFF
--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -5,7 +5,7 @@
  * Ops:
  *   - update_ai_provider → applyFirstRunConnectionConfig + saveElizaConfig
  *   - toggle_capability  → config.ui.capabilities.{wallet|browser|computerUse}
- *   - toggle_training    → app-training loadTrainingConfig/saveTrainingConfig
+ *   - toggle_training    → training plugin's TrainingConfigService (via registry)
  *   - set_owner_name     → config.ui.ownerName via owner-name service
  *   - set                → worldSettings registry write (key/value list)
  *
@@ -98,19 +98,40 @@ type CapabilityKey = (typeof CAPABILITY_KEYS)[number];
 
 const MODEL_SLOTS = ["nano", "small", "medium", "large", "mega"] as const;
 
-const TRAINING_CONFIG_MODULE = "@elizaos/plugin-training";
+// `toggle_training` is contributed by the training plugin, which registers a
+// TrainingConfigService under this name. The host dispatches to the service
+// instead of importing the plugin (which @elizaos/agent does not depend on):
+// the op is available only when the plugin is loaded, and reports unavailable
+// otherwise. The structural shape below mirrors the plugin's
+// TrainingConfigCapability so no import edge is created.
+const TRAINING_CONFIG_SERVICE = "training_config_service";
 
-interface TrainingConfig {
+interface AutoTrainToggleInput {
+  enabled: boolean;
+  threshold?: number;
+  cooldownHours?: number;
+}
+
+interface TrainingConfigSummary {
   autoTrain: boolean;
   triggerThreshold: number;
   triggerCooldownHours: number;
-  backends?: string[];
-  perTaskOverrides?: Record<string, unknown>;
 }
 
-interface TrainingConfigModule {
-  loadTrainingConfig: () => TrainingConfig;
-  saveTrainingConfig: (config: TrainingConfig) => void;
+interface TrainingConfigCapability {
+  applyAutoTrainToggle: (
+    input: AutoTrainToggleInput,
+  ) => TrainingConfigSummary | Promise<TrainingConfigSummary>;
+}
+
+function isTrainingConfigCapability(
+  service: unknown,
+): service is TrainingConfigCapability {
+  return (
+    service != null &&
+    typeof (service as { applyAutoTrainToggle?: unknown })
+      .applyAutoTrainToggle === "function"
+  );
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -301,6 +322,7 @@ function handleToggleCapability(params: Record<string, unknown>): ActionResult {
 // ── op: toggle_training ──────────────────────────────────────────────────
 
 async function handleToggleTraining(
+  runtime: IAgentRuntime,
   params: Record<string, unknown>,
 ): Promise<ActionResult> {
   if (typeof params.enabled !== "boolean") {
@@ -336,21 +358,21 @@ async function handleToggleTraining(
     );
   }
 
-  let next: TrainingConfig;
+  const service = runtime.getService(TRAINING_CONFIG_SERVICE);
+  if (!isTrainingConfigCapability(service)) {
+    return fail(
+      "TRAINING_UNAVAILABLE",
+      "Auto-training is unavailable — the training plugin is not loaded.",
+    );
+  }
+
+  let summary: TrainingConfigSummary;
   try {
-    const mod = (await import(TRAINING_CONFIG_MODULE)) as TrainingConfigModule;
-    const current = mod.loadTrainingConfig();
-    next = {
-      ...current,
-      autoTrain: params.enabled,
-      ...(typeof threshold === "number"
-        ? { triggerThreshold: Math.floor(threshold) }
-        : {}),
-      ...(typeof cooldownHours === "number"
-        ? { triggerCooldownHours: cooldownHours }
-        : {}),
-    };
-    mod.saveTrainingConfig(next);
+    summary = await service.applyAutoTrainToggle({
+      enabled: params.enabled,
+      ...(typeof threshold === "number" ? { threshold } : {}),
+      ...(typeof cooldownHours === "number" ? { cooldownHours } : {}),
+    });
   } catch (err) {
     logger.error(
       { error: err instanceof Error ? err.stack : String(err) },
@@ -363,12 +385,12 @@ async function handleToggleTraining(
   }
 
   return ok(
-    `Auto-training is now ${next.autoTrain ? "enabled" : "disabled"} (threshold ${next.triggerThreshold}, cooldown ${next.triggerCooldownHours}h).`,
+    `Auto-training is now ${summary.autoTrain ? "enabled" : "disabled"} (threshold ${summary.triggerThreshold}, cooldown ${summary.triggerCooldownHours}h).`,
     {
       op: "toggle_training",
-      autoTrain: next.autoTrain,
-      triggerThreshold: next.triggerThreshold,
-      triggerCooldownHours: next.triggerCooldownHours,
+      autoTrain: summary.autoTrain,
+      triggerThreshold: summary.triggerThreshold,
+      triggerCooldownHours: summary.triggerCooldownHours,
     },
   );
 }
@@ -936,7 +958,7 @@ export const settingsAction: Action = {
       case "toggle_capability":
         return handleToggleCapability(params);
       case "toggle_training":
-        return handleToggleTraining(params);
+        return handleToggleTraining(runtime, params);
       case "set_owner_name":
         return handleSetOwnerName(params);
       case "set":

--- a/packages/agent/src/actions/settings-training-op.test.ts
+++ b/packages/agent/src/actions/settings-training-op.test.ts
@@ -1,0 +1,139 @@
+import type {
+  ActionResult,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { settingsAction } from "./settings-actions.ts";
+
+// item 9: the host SETTINGS action must NOT import @elizaos/plugin-training.
+// It dispatches `toggle_training` to a TrainingConfigService the plugin
+// registers under the well-known name, and reports unavailable when the
+// service is absent (plugin not loaded).
+
+const TRAINING_CONFIG_SERVICE = "training_config_service";
+
+interface AutoTrainToggleInput {
+  enabled: boolean;
+  threshold?: number;
+  cooldownHours?: number;
+}
+
+function makeRuntime(service: unknown): IAgentRuntime {
+  return {
+    getService: (name: string) =>
+      name === TRAINING_CONFIG_SERVICE ? service : null,
+  } as unknown as IAgentRuntime;
+}
+
+const MESSAGE = { entityId: "owner" } as unknown as Memory;
+
+function invoke(
+  runtime: IAgentRuntime,
+  parameters: Record<string, unknown>,
+): Promise<ActionResult> {
+  return settingsAction.handler(runtime, MESSAGE, undefined, {
+    parameters,
+  } as HandlerOptions) as Promise<ActionResult>;
+}
+
+describe("SETTINGS toggle_training op (item 9)", () => {
+  it("does not statically import @elizaos/plugin-training", async () => {
+    const src = await import("node:fs").then((fs) =>
+      fs.readFileSync(
+        new URL("./settings-actions.ts", import.meta.url),
+        "utf8",
+      ),
+    );
+    expect(src).not.toMatch(/from ["']@elizaos\/plugin-training["']/);
+    expect(src).not.toMatch(/import\(\s*["']@elizaos\/plugin-training["']/);
+  });
+
+  it("reports unavailable when the training plugin is not loaded", async () => {
+    const result = await invoke(makeRuntime(null), {
+      action: "toggle_training",
+      enabled: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values?.error).toBe("TRAINING_UNAVAILABLE");
+  });
+
+  it("reports unavailable when a registered service lacks the capability", async () => {
+    // A service registered under the name but without applyAutoTrainToggle
+    // must not be treated as the training config capability.
+    const result = await invoke(makeRuntime({ somethingElse: () => {} }), {
+      action: "toggle_training",
+      enabled: false,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values?.error).toBe("TRAINING_UNAVAILABLE");
+  });
+
+  it("dispatches to the registered service and echoes its summary", async () => {
+    const calls: AutoTrainToggleInput[] = [];
+    const service = {
+      applyAutoTrainToggle(input: AutoTrainToggleInput) {
+        calls.push(input);
+        return {
+          autoTrain: input.enabled,
+          triggerThreshold: input.threshold ?? 100,
+          triggerCooldownHours: input.cooldownHours ?? 12,
+        };
+      },
+    };
+    const result = await invoke(makeRuntime(service), {
+      action: "toggle_training",
+      enabled: true,
+      threshold: 250,
+      cooldownHours: 6,
+    });
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([
+      { enabled: true, threshold: 250, cooldownHours: 6 },
+    ]);
+    expect(result.data).toMatchObject({
+      op: "toggle_training",
+      autoTrain: true,
+      triggerThreshold: 250,
+      triggerCooldownHours: 6,
+    });
+    expect(result.text).toContain("Auto-training is now enabled");
+  });
+
+  it("surfaces a validation error before touching the service", async () => {
+    let called = false;
+    const service = {
+      applyAutoTrainToggle() {
+        called = true;
+        return {
+          autoTrain: true,
+          triggerThreshold: 1,
+          triggerCooldownHours: 1,
+        };
+      },
+    };
+    const result = await invoke(makeRuntime(service), {
+      action: "toggle_training",
+      enabled: true,
+      threshold: -5,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values?.error).toBe("INVALID_THRESHOLD");
+    expect(called).toBe(false);
+  });
+
+  it("translates a service throw into SETTINGS_TOGGLE_TRAINING_FAILED", async () => {
+    const service = {
+      applyAutoTrainToggle() {
+        throw new Error("disk full");
+      },
+    };
+    const result = await invoke(makeRuntime(service), {
+      action: "toggle_training",
+      enabled: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values?.error).toBe("SETTINGS_TOGGLE_TRAINING_FAILED");
+  });
+});

--- a/plugins/plugin-training/src/register-runtime.ts
+++ b/plugins/plugin-training/src/register-runtime.ts
@@ -2,6 +2,7 @@ import type { AgentRuntime, Service } from "@elizaos/core";
 import { logger, OptimizedPromptService } from "@elizaos/core";
 import { registerSkillScoringCron } from "./core/skill-scoring-cron.js";
 import { registerTrajectoryExportCron } from "./core/trajectory-export-cron.js";
+import { registerTrainingConfigService } from "./services/training-config-service.js";
 import {
   bootstrapOptimizationFromAccumulatedTrajectories,
   registerTrainingTriggerService,
@@ -51,6 +52,11 @@ export async function registerTrainingRuntimeHooks(
     await registerTrajectoryExportCron(runtime);
     await registerSkillScoringCron(runtime);
   }
+  // Contribute the settings extension the host SETTINGS action dispatches
+  // `toggle_training` to (looked up by TRAINING_CONFIG_SERVICE name; the host
+  // does not import this plugin).
+  registerTrainingConfigService(runtime);
+
   const triggerService = registerTrainingTriggerService(runtime);
   logger.info(
     skipCronRegistration

--- a/plugins/plugin-training/src/services/index.ts
+++ b/plugins/plugin-training/src/services/index.ts
@@ -4,6 +4,15 @@ export {
   detectAvailableBackends,
 } from "./training-backend-check.js";
 export {
+  type AutoTrainToggleInput,
+  registerTrainingConfigService,
+  TRAINING_CONFIG_SERVICE,
+  type TrainingConfigCapability,
+  TrainingConfigService,
+  type TrainingConfigServiceOptions,
+  type TrainingConfigSummary,
+} from "./training-config-service.js";
+export {
   isNotImplementedError,
   NotImplementedError,
   TrainingService,

--- a/plugins/plugin-training/src/services/training-config-service.test.ts
+++ b/plugins/plugin-training/src/services/training-config-service.test.ts
@@ -1,0 +1,95 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TRAINING_CONFIG,
+  type TrainingConfig,
+} from "../core/training-config.js";
+import {
+  registerTrainingConfigService,
+  TRAINING_CONFIG_SERVICE,
+  TrainingConfigService,
+} from "./training-config-service.js";
+
+function baseConfig(): TrainingConfig {
+  return { ...DEFAULT_TRAINING_CONFIG, backends: ["native"] };
+}
+
+function makeService(initial: TrainingConfig = baseConfig()) {
+  let stored = initial;
+  const saved: TrainingConfig[] = [];
+  const service = new TrainingConfigService(undefined, {
+    loadConfig: () => stored,
+    saveConfig: (config) => {
+      stored = config;
+      saved.push(config);
+    },
+  });
+  return { service, saved, current: () => stored };
+}
+
+describe("TrainingConfigService.applyAutoTrainToggle", () => {
+  it("toggles autoTrain off and persists, preserving other fields", () => {
+    const { service, saved } = makeService(baseConfig());
+    const summary = service.applyAutoTrainToggle({ enabled: false });
+    expect(summary.autoTrain).toBe(false);
+    // Unspecified fields keep their prior values.
+    expect(summary.triggerThreshold).toBe(
+      DEFAULT_TRAINING_CONFIG.triggerThreshold,
+    );
+    expect(summary.triggerCooldownHours).toBe(
+      DEFAULT_TRAINING_CONFIG.triggerCooldownHours,
+    );
+    expect(saved).toHaveLength(1);
+    expect(saved[0].autoTrain).toBe(false);
+    expect(saved[0].backends).toEqual(["native"]);
+  });
+
+  it("floors the threshold and applies the cooldown", () => {
+    const { service, current } = makeService();
+    const summary = service.applyAutoTrainToggle({
+      enabled: true,
+      threshold: 250.9,
+      cooldownHours: 6,
+    });
+    expect(summary).toEqual({
+      autoTrain: true,
+      triggerThreshold: 250,
+      triggerCooldownHours: 6,
+    });
+    expect(current().triggerThreshold).toBe(250);
+    expect(current().triggerCooldownHours).toBe(6);
+  });
+
+  it("leaves threshold/cooldown untouched when omitted", () => {
+    const start: TrainingConfig = {
+      ...baseConfig(),
+      triggerThreshold: 42,
+      triggerCooldownHours: 3,
+    };
+    const { service } = makeService(start);
+    const summary = service.applyAutoTrainToggle({ enabled: true });
+    expect(summary.triggerThreshold).toBe(42);
+    expect(summary.triggerCooldownHours).toBe(3);
+  });
+});
+
+describe("registerTrainingConfigService", () => {
+  it("registers the service under TRAINING_CONFIG_SERVICE for host lookup", () => {
+    const services = new Map<string, unknown[]>();
+    const runtime = {
+      services,
+      getService: (name: string) => services.get(name)?.[0] ?? null,
+    } as unknown as IAgentRuntime;
+
+    const registered = registerTrainingConfigService(runtime, {
+      loadConfig: baseConfig,
+      saveConfig: () => {},
+    });
+    const looked = runtime.getService(TRAINING_CONFIG_SERVICE);
+    expect(looked).toBe(registered);
+    expect(
+      typeof (looked as { applyAutoTrainToggle?: unknown })
+        .applyAutoTrainToggle,
+    ).toBe("function");
+  });
+});

--- a/plugins/plugin-training/src/services/training-config-service.ts
+++ b/plugins/plugin-training/src/services/training-config-service.ts
@@ -1,0 +1,127 @@
+/**
+ * TrainingConfigService — the plugin-training-owned settings extension the host
+ * SETTINGS action dispatches `toggle_training` to.
+ *
+ * Previously the host action (`@elizaos/agent`) reached into this plugin via a
+ * computed-specifier `import("@elizaos/plugin-training")` to call
+ * `loadTrainingConfig`/`saveTrainingConfig` — a reverse dependency edge (host →
+ * plugin) that the agent package did not even declare. That business logic now
+ * lives here, behind a runtime service the host looks up by name: the plugin
+ * contributes the capability, the host stays a dispatcher.
+ *
+ * Service identifier: `TRAINING_CONFIG_SERVICE` (`"training_config_service"`).
+ */
+
+import {
+  type IAgentRuntime,
+  Service,
+  type ServiceTypeName,
+} from "@elizaos/core";
+import {
+  loadTrainingConfig as defaultLoadTrainingConfig,
+  saveTrainingConfig as defaultSaveTrainingConfig,
+  type TrainingConfig,
+} from "../core/training-config.js";
+
+declare module "@elizaos/core" {
+  interface ServiceTypeRegistry {
+    TRAINING_CONFIG_SERVICE: "training_config_service";
+  }
+}
+
+export const TRAINING_CONFIG_SERVICE =
+  "training_config_service" as ServiceTypeName;
+
+/** Input the host passes after validating the SETTINGS `toggle_training` op. */
+export interface AutoTrainToggleInput {
+  /** Enable or disable auto-training. */
+  enabled: boolean;
+  /** Optional new trigger threshold (trajectories per task). Floored on write. */
+  threshold?: number;
+  /** Optional new cooldown, in hours, between runs for the same task. */
+  cooldownHours?: number;
+}
+
+/**
+ * The three fields the host echoes back to the caller. Kept minimal on purpose
+ * — the host neither needs nor should know the full {@link TrainingConfig}
+ * shape.
+ */
+export interface TrainingConfigSummary {
+  autoTrain: boolean;
+  triggerThreshold: number;
+  triggerCooldownHours: number;
+}
+
+export interface TrainingConfigServiceOptions {
+  loadConfig?: () => TrainingConfig;
+  saveConfig?: (config: TrainingConfig) => void;
+}
+
+/**
+ * Structural contract the host depends on (it looks the service up by name and
+ * calls `applyAutoTrainToggle`). Declared here so the host can restate the same
+ * shape locally without importing this plugin.
+ */
+export interface TrainingConfigCapability {
+  applyAutoTrainToggle(input: AutoTrainToggleInput): TrainingConfigSummary;
+}
+
+export class TrainingConfigService
+  extends Service
+  implements TrainingConfigCapability
+{
+  static serviceType = TRAINING_CONFIG_SERVICE;
+
+  readonly capabilityDescription =
+    "Reads and mutates the auto-training config for the host SETTINGS toggle_training op.";
+
+  private readonly loadConfig: () => TrainingConfig;
+  private readonly saveConfig: (config: TrainingConfig) => void;
+
+  constructor(
+    runtime?: IAgentRuntime,
+    options: TrainingConfigServiceOptions = {},
+  ) {
+    super(runtime);
+    this.loadConfig = options.loadConfig ?? defaultLoadTrainingConfig;
+    this.saveConfig = options.saveConfig ?? defaultSaveTrainingConfig;
+  }
+
+  async stop(): Promise<void> {}
+
+  /**
+   * Merge the toggle over the persisted config, persist it, and return the
+   * summary the host echoes. Trusts pre-validated input (presence/type checks
+   * happen at the route/action layer).
+   */
+  applyAutoTrainToggle(input: AutoTrainToggleInput): TrainingConfigSummary {
+    const current = this.loadConfig();
+    const next: TrainingConfig = {
+      ...current,
+      autoTrain: input.enabled,
+      ...(typeof input.threshold === "number"
+        ? { triggerThreshold: Math.floor(input.threshold) }
+        : {}),
+      ...(typeof input.cooldownHours === "number"
+        ? { triggerCooldownHours: input.cooldownHours }
+        : {}),
+    };
+    this.saveConfig(next);
+    return {
+      autoTrain: next.autoTrain,
+      triggerThreshold: next.triggerThreshold,
+      triggerCooldownHours: next.triggerCooldownHours,
+    };
+  }
+}
+
+/** Register (or replace) the TrainingConfigService on the runtime service map. */
+export function registerTrainingConfigService(
+  runtime: IAgentRuntime,
+  options: TrainingConfigServiceOptions = {},
+): TrainingConfigService {
+  const service = new TrainingConfigService(runtime, options);
+  runtime.services.set(TRAINING_CONFIG_SERVICE, [service]);
+  return service;
+}


### PR DESCRIPTION
## What

The host `SETTINGS` action (`@elizaos/agent`) owned the `toggle_training` op and reached into `@elizaos/plugin-training` via a **computed-specifier** `import("@elizaos/plugin-training")` to call `loadTrainingConfig`/`saveTrainingConfig`. That is a reverse dependency edge (host → plugin) the agent package does not even declare, and it duplicated the `TrainingConfig` shape in the host.

## Change

plugin-training now contributes the capability as a runtime service the host dispatches to:

- **`plugins/plugin-training/src/services/training-config-service.ts`** — new `TrainingConfigService` (serviceType `training_config_service`) exposing `applyAutoTrainToggle(input)`. The merge/persist business logic (floor threshold, apply cooldown, preserve other fields) lives here. Loader/saver are injectable for tests.
- **`register-runtime.ts`** — `registerTrainingConfigService(runtime)` wired into `registerTrainingRuntimeHooks`, alongside the existing trigger service registration.
- **`settings-actions.ts`** — `handleToggleTraining` now takes `runtime`, looks the service up by name (`runtime.getService("training_config_service")`), validates input at the action layer, and dispatches. **No `@elizaos/plugin-training` reference remains** (structural `TrainingConfigCapability` interface restated locally — no import edge).

The op works when the plugin is loaded and returns `TRAINING_UNAVAILABLE` when it is not.

## Done-when evidence

> settings-actions.ts has no `@elizaos/plugin-training` import; toggle_training works when the plugin is loaded and reports unavailable when not.

```
$ grep -rn "plugin-training" packages/agent/src/actions/settings-actions.ts
CLEAN: zero plugin-training references in settings-actions.ts
```

- **`packages/agent/src/actions/settings-training-op.test.ts`** (new, **6/6 pass**): asserts no static/dynamic `@elizaos/plugin-training` import in the source; `TRAINING_UNAVAILABLE` when service absent or lacks the capability; dispatch echoes the service summary; validation error fires *before* touching the service; a service throw maps to `SETTINGS_TOGGLE_TRAINING_FAILED`.
- **`plugins/plugin-training/src/services/training-config-service.test.ts`** (new, **4/4 pass**): merge/floor/cooldown/preserve behavior + `registerTrainingConfigService` registers under the name for host lookup.
- Existing `settings-backends.test.ts` still green (**15/15**).

## Test / typecheck

- Host test 6/6, plugin test 4/4, existing SETTINGS test 15/15.
- `packages/agent` typecheck: no errors reference `settings-actions.ts`. `plugins/plugin-training` typecheck: no errors reference the new service files. (Pre-existing environmental errors only: unbuilt `@elizaos/ui` dist in FineTuningView, and `Cannot find name 'process'` on the unchanged `trainingCronRegistrationDisabled` — both present on `develop`.)

Refs #12091 (item 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)