### PR TITLE
fix(core): enforce runtime gate for shortcut actions

### DIFF
--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -510,7 +510,7 @@ function actionResultToStreamingResult(
 
 export const _resetActionRolePolicyCacheForTests = _resetCacheForTests;
 
-function getGateFailure(
+export function getGateFailure(
 	action: Action,
 	ctx: ExecutePlannedToolCallContext,
 ): string | undefined {

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -14,11 +14,13 @@ function echoAction(
 	opts: {
 		validate?: () => Promise<boolean>;
 		onOptions?: (options: Record<string, unknown> | undefined) => void;
+		roleGate?: Action["roleGate"];
 	} = {},
 ): Action {
 	return {
 		name: "ECHO_COMMAND",
 		description: "echo",
+		roleGate: opts.roleGate,
 		validate: opts.validate ?? (async () => true),
 		handler: async (_rt, message, _state, options, callback) => {
 			opts.onOptions?.(options);
@@ -169,6 +171,45 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		expect(result).toBeNull();
 		expect(validate).toHaveBeenCalledTimes(1);
 		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	it("falls through before validate when the target action role gate rejects the sender", async () => {
+		const validate = vi.fn(async () => true);
+		const onOptions = vi.fn();
+		const warn = vi.fn();
+		const { runtime, useModel, emitEvent } = makeRuntime({
+			actions: [
+				echoAction({
+					validate,
+					onOptions,
+					roleGate: { minRole: "OWNER" },
+				}),
+			],
+		});
+		runtime.logger.warn = warn;
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/echo hi"),
+			state: {} as State,
+			responseId,
+			senderRole: "USER",
+		});
+
+		expect(result).toBeNull();
+		expect(validate).not.toHaveBeenCalled();
+		expect(onOptions).not.toHaveBeenCalled();
+		expect(useModel).not.toHaveBeenCalled();
+		expect(emitEvent).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				src: "shortcut-gate",
+				shortcut: "cmd:echo",
+				action: "ECHO_COMMAND",
+			}),
+			expect.stringContaining("runtime gate"),
+		);
 	});
 
 	it("falls through and logs when an explicit shortcut action validate() throws (#9153)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -75,6 +75,7 @@ import {
 	type ExecutePlannedToolCallContext,
 	type ExecutePlannedToolCallOptions,
 	executePlannedToolCall,
+	getGateFailure,
 } from "../runtime/execute-planned-tool-call";
 import {
 	type FactsAndRelationshipsRunResult,
@@ -5649,6 +5650,24 @@ export async function runShortcutGate(args: {
 
 	const action = args.runtime.actions.find((a) => a.name === target.name);
 	if (!action) return null;
+
+	const gateFailure = getGateFailure(action, {
+		message: args.message,
+		state: args.state,
+		userRoles: [args.senderRole],
+	});
+	if (gateFailure) {
+		args.runtime.logger?.warn?.(
+			{
+				src: "shortcut-gate",
+				shortcut: match.shortcut.id,
+				action: action.name,
+				gateFailure,
+			},
+			"shortcut action blocked by runtime gate; falling through to pipeline",
+		);
+		return null;
+	}
 
 	let valid = false;
 	try {


### PR DESCRIPTION
## Summary
- routes pre-LLM shortcut action dispatch through the same runtime gate used by planned tool execution
- blocks private/action-role-policy/context/role-gated actions before shortcut validate() or handler() can run
- adds a regression test proving a USER slash shortcut cannot execute an OWNER-gated action

## Issue
Refs #12087 item 3: shortcut gate executes actions without enforcing declared roleGate/contextGate. This does not close #12087 because it is a multi-item architecture audit.

## Validation
- bun run --cwd packages/core test src/services/message.shortcut-gate.test.ts
- bunx biome check packages/core/src/runtime/execute-planned-tool-call.ts packages/core/src/services/message.ts packages/core/src/services/message.shortcut-gate.test.ts
- git diff --check HEAD~1..HEAD
- bun run --cwd packages/core typecheck

## Evidence
- Focused regression: 1 test file passed, 9 tests passed.
- Screenshots/video: N/A - server-side runtime gate, no UI surface.
- Live model trajectory: N/A - deterministic pre-LLM shortcut gate; no model/provider/prompt behavior is invoked by this path.