### PR TITLE
fix(agent): rely on public routes for webhook auth exemptions

### DIFF
--- a/packages/agent/src/api/runtime-plugin-routes.test.ts
+++ b/packages/agent/src/api/runtime-plugin-routes.test.ts
@@ -1,8 +1,16 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import type { AgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
+import type {
+  AgentRuntime,
+  Route,
+  RouteRequest,
+  RouteResponse,
+} from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
-import { tryHandleRuntimePluginRoute } from "./runtime-plugin-routes";
+import {
+  isPublicRuntimePluginRoute,
+  tryHandleRuntimePluginRoute,
+} from "./runtime-plugin-routes";
 
 let servers: http.Server[] = [];
 
@@ -18,6 +26,56 @@ afterEach(async () => {
     ),
   );
   servers = [];
+});
+
+function runtimeWithRoutes(routes: Route[]): AgentRuntime {
+  return { routes } as AgentRuntime;
+}
+
+describe("isPublicRuntimePluginRoute", () => {
+  it("recognizes webhook endpoints through public route declarations", () => {
+    const runtime = runtimeWithRoutes([
+      { type: "POST", path: "/api/whatsapp/webhook", public: true },
+      { type: "POST", path: "/webhooks/bluebubbles", public: true },
+    ] as Route[]);
+
+    expect(
+      isPublicRuntimePluginRoute({
+        runtime,
+        method: "POST",
+        pathname: "/api/whatsapp/webhook",
+      }),
+    ).toBe(true);
+    expect(
+      isPublicRuntimePluginRoute({
+        runtime,
+        method: "POST",
+        pathname: "/webhooks/bluebubbles",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not exempt matching webhook paths unless the route is public", () => {
+    const runtime = runtimeWithRoutes([
+      { type: "POST", path: "/api/whatsapp/webhook" },
+      { type: "POST", path: "/webhooks/bluebubbles", public: false },
+    ] as Route[]);
+
+    expect(
+      isPublicRuntimePluginRoute({
+        runtime,
+        method: "POST",
+        pathname: "/api/whatsapp/webhook",
+      }),
+    ).toBe(false);
+    expect(
+      isPublicRuntimePluginRoute({
+        runtime,
+        method: "POST",
+        pathname: "/webhooks/bluebubbles",
+      }),
+    ).toBe(false);
+  });
 });
 
 async function startRouteServer(runtime: AgentRuntime): Promise<string> {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1937,32 +1937,6 @@ async function handleRequest(
     method === "GET" &&
     pathname === "/api/first-run/status" &&
     isCloudProvisioned;
-  // Webhook exemptions: handlers MUST authenticate callers (see plugin handlers).
-  // WhatsApp: X-Hub-Signature-256 HMAC (WHATSAPP_APP_SECRET).
-  // BlueBubbles: X-BlueBubbles-Webhook-Secret (BLUEBUBBLES_WEBHOOK_SECRET).
-  const isWhatsAppWebhookEndpoint = pathname === "/api/whatsapp/webhook";
-  let blueBubblesWebhookPath =
-    pathname === "/webhooks/bluebubbles" ? "/webhooks/bluebubbles" : null;
-  if (pathname.startsWith("/webhooks/")) {
-    const { resolveBlueBubblesWebhookPath } = await getOptionalPluginApi<{
-      resolveBlueBubblesWebhookPath: (args: unknown) => string;
-    }>("imessage");
-    blueBubblesWebhookPath =
-      typeof resolveBlueBubblesWebhookPath === "function"
-        ? resolveBlueBubblesWebhookPath({
-            runtime: state.runtime
-              ? {
-                  getService: (type: string) =>
-                    (
-                      state.runtime as { getService: (t: string) => unknown }
-                    ).getService(type),
-                }
-              : undefined,
-          })
-        : blueBubblesWebhookPath;
-  }
-  const isBlueBubblesWebhookEndpoint =
-    blueBubblesWebhookPath != null && pathname === blueBubblesWebhookPath;
   const isAuthProtectedPath = isAuthProtectedRoute(pathname);
 
   const canonicalizeRestartReason = (reason: string): string => {
@@ -2108,8 +2082,6 @@ async function handleRequest(
     !isAuthEndpoint &&
     !isHealthEndpoint &&
     !isCloudFirstRunStatusEndpoint &&
-    !isWhatsAppWebhookEndpoint &&
-    !isBlueBubblesWebhookEndpoint &&
     !isPublicRuntimePluginRoute({
       runtime: state.runtime,
       method,
@@ -3107,7 +3079,7 @@ async function handleRequest(
   // ── WhatsApp routes (/api/whatsapp/*) ────────────────────────────────────
   // Moved to @elizaos/plugin-whatsapp setup-routes.ts (registered via Plugin.routes).
 
-  // ── BlueBubbles routes (/api/bluebubbles/*, /webhooks/bluebubbles) ──
+  // ── BlueBubbles routes ──────────────────────────────────────────────────
   // Extracted to @elizaos/plugin-bluebubbles setup-routes.ts (Plugin.routes).
 
   // ── Notification + inbox routes (/api/notifications/*, /api/inbox/*) ──


### PR DESCRIPTION
## Summary
- Removes hardcoded WhatsApp and BlueBubbles webhook auth exemptions from the central agent auth gate.
- Leaves unauthenticated webhook access governed by `route.public` through `isPublicRuntimePluginRoute`.
- Adds focused tests proving webhook paths are only exempt when their runtime route is declared public.
- Addresses #12088 item 17.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/agent test -- src/api/runtime-plugin-routes.test.ts`
- `bunx @biomejs/biome check packages/agent/src/api/server.ts packages/agent/src/api/runtime-plugin-routes.test.ts`
- `git diff --check`
- `rg "isWhatsAppWebhookEndpoint|isBlueBubblesWebhookEndpoint|/api/whatsapp/webhook|/webhooks/bluebubbles" packages/agent/src/api/server.ts -n` returns no matches.

## Evidence
- N/A - security boundary cleanup with no user-visible UI.
- N/A - no model/action/provider/prompt behavior changed.