### PR TITLE
fix(cloud): gate eliza app gateway demo

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-gateway-auth.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-gateway-auth.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { AuthenticationError } from "@/lib/api/cloud-worker-errors";
+import * as authActual from "@/lib/auth/workers-hono-auth";
+
+const requireUserOrApiKeyWithOrg = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...authActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const gatewayRoute = (await import("../eliza-app/gateway/[agentId]/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => authActual);
+});
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+});
+
+describe("POST /api/eliza-app/gateway/:agentId auth", () => {
+  test("rejects programmatic-looking bearer tokens unless route auth validates them", async () => {
+    requireUserOrApiKeyWithOrg.mockRejectedValue(
+      AuthenticationError("Invalid or expired API key"),
+    );
+
+    const res = await gatewayRoute.request("/", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_fake_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { success?: boolean; code?: string };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("authentication_required");
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the demo response for validated callers", async () => {
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+      organization: { id: "org-1", is_active: true, name: "Org" },
+      is_active: true,
+    });
+
+    const res = await gatewayRoute.request("/", {
+      method: "POST",
+      headers: {
+        "X-API-Key": "eliza_valid_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success?: boolean; reply?: string };
+    expect(body.success).toBe(true);
+    expect(body.reply).toContain("Hello there");
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/__tests__/middleware-auth-public-token-paths.test.ts
+++ b/packages/cloud/api/__tests__/middleware-auth-public-token-paths.test.ts
@@ -75,4 +75,8 @@ describe("isPublicPath — out-of-band token pages", () => {
       isPublicPath("/api/v1/advertising/campaigns/campaign-1/report/share"),
     ).toBe(false);
   });
+
+  test("eliza-app gateway demo route stays behind auth", () => {
+    expect(isPublicPath("/api/eliza-app/gateway/test-agent-001")).toBe(false);
+  });
 });

--- a/packages/cloud/api/eliza-app/gateway/[agentId]/route.ts
+++ b/packages/cloud/api/eliza-app/gateway/[agentId]/route.ts
@@ -9,6 +9,8 @@
 
 import { Hono } from "hono";
 
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const agentMemories = new Map<
@@ -19,6 +21,12 @@ const agentMemories = new Map<
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
+  try {
+    await requireUserOrApiKeyWithOrg(c);
+  } catch (error) {
+    return failureResponse(c, error);
+  }
+
   try {
     const agentId = c.req.param("agentId") ?? "";
     const body = (await c.req.json()) as { message?: string };

--- a/packages/cloud/api/src/middleware/auth.ts
+++ b/packages/cloud/api/src/middleware/auth.ts
@@ -138,7 +138,6 @@ const publicPathPrefixes = [
   "/api/eliza-app/user",
   "/api/eliza-app/cli-auth",
   "/api/eliza-app/onboarding",
-  "/api/eliza-app/gateway",
 ];
 
 // Out-of-band token pages (sensitive-request links, approval-signer links,

--- a/packages/cloud/api/test/e2e/group-f-connectors.test.ts
+++ b/packages/cloud/api/test/e2e/group-f-connectors.test.ts
@@ -22,7 +22,7 @@
  * Auth notes (from auth.ts publicPathPrefixes):
  *   - /api/eliza-app/webhook/* — public (no global auth gate)
  *   - /api/eliza-app/user/*   — public (handler does its own session check)
- *   - /api/eliza-app/gateway/* — public
+ *   - /api/eliza-app/gateway/* — auth-gated (handler validates API key/session)
  *   - /api/eliza/* — public
  *   - /api/webhooks/* — public
  *   - /api/eliza-app/connections requires an eliza-app session token
@@ -215,44 +215,23 @@ describeE2E("POST /api/eliza-app/connections/:platform/initiate", () => {
 // ---------------------------------------------------------------------------
 
 describeE2E("POST /api/eliza-app/gateway/:agentId", () => {
-  // Public path — no auth gate.
-
-  test("missing message body → 400", async () => {
+  test("no Authorization header → 401", async () => {
     const res = await api.post("/api/eliza-app/gateway/test-agent-001", {});
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { success?: boolean; code?: string };
     expect(body.success).toBe(false);
-    expect(body.error).toMatch(/empty message/i);
+    expect(body.code).toBe("authentication_required");
   });
 
-  test("valid message → 200 with reply", async () => {
-    const res = await api.post("/api/eliza-app/gateway/test-agent-001", {
-      message: "hello",
-    });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success?: boolean;
-      reply?: string;
-      historyLength?: number;
-    };
-    expect(body.success).toBe(true);
-    expect(typeof body.reply).toBe("string");
-    expect(body.reply?.length).toBeGreaterThan(0);
-    expect(typeof body.historyLength).toBe("number");
-  });
-
-  test("non-JSON body → 400 or 500", async () => {
-    const res = await fetch(
-      `${getBaseUrl()}/api/eliza-app/gateway/test-agent-001`,
+  test("invalid eliza API-key bearer → 401 before the canned reply handler", async () => {
+    const res = await api.post(
+      "/api/eliza-app/gateway/test-agent-001",
+      { message: "hello" },
       {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "not-json{{",
+        headers: { Authorization: "Bearer eliza_not_a_real_key" },
       },
     );
-    // The handler parses the body itself; malformed JSON surfaces as its own
-    // 500 envelope (not a middleware 400).
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(401);
   });
 });
 


### PR DESCRIPTION
Fixes #12043

## Summary
- Remove `/api/eliza-app/gateway` from the public global auth allowlist.
- Add route-level `requireUserOrApiKeyWithOrg` validation so `X-API-Key` / `Bearer eliza_*` headers cannot bypass auth into the canned echo handler.
- Update middleware, route, and connector e2e contract coverage for the gateway being auth-gated.

## Evidence
- `bun test packages/cloud/api/__tests__/middleware-auth-public-token-paths.test.ts packages/cloud/api/__tests__/eliza-app-gateway-auth.test.ts` - 11 pass, 0 fail.
- `REQUIRE_E2E_SERVER=0 bun test packages/cloud/api/test/e2e/group-f-connectors.test.ts` - 35 skipped, 0 fail; Worker unavailable locally at `http://localhost:8787`.
- `git diff --check` - pass.
- `bun run --cwd packages/cloud/api typecheck` - fails on pre-existing unrelated errors: `__tests__/stripe-connect-webhook-route.test.ts` Stripe API version literal and Hono duplicate-version types in `fal/proxy/route.ts`.
- Changed-file Biome check was not runnable from the nested `node_modules/.codex-worktrees` worktree; Biome reports the files do not exist in the workspace.

## Evidence N/A
- UI screenshots/video: N/A - API auth-gate change only.
- Real-LLM trajectories: N/A - no agent/action/provider/prompt/model behavior changed.