### PR TITLE
fix(core): stop auto-owner grants for ordinary DMs

### DIFF
--- a/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventType } from "../../types/events.ts";
+import type { IAgentRuntime, UUID } from "../../types/index.ts";
+import { ChannelType } from "../../types/primitives.ts";
+import { createBasicCapabilitiesPlugin } from "./index.ts";
+
+function makeRuntime(settings: Record<string, string> = {}) {
+	const ensureConnection = vi.fn(async () => undefined);
+	const runtime = {
+		agentId: "00000000-0000-0000-0000-0000000000a1" as UUID,
+		getSetting: vi.fn((key: string) => settings[key]),
+		getEntitiesByIds: vi.fn(async (ids: UUID[]) =>
+			ids.map((id) => ({
+				id,
+				metadata: {
+					username: `user-${id}`,
+				},
+			})),
+		),
+		getWorldsByIds: vi.fn(async () => []),
+		ensureConnection,
+		character: {
+			name: "Test Agent",
+		},
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			success: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	} as unknown as IAgentRuntime & {
+		ensureConnection: typeof ensureConnection;
+	};
+	return { runtime, ensureConnection };
+}
+
+async function runEntityJoined(runtime: IAgentRuntime, entityId: UUID) {
+	const handlers =
+		createBasicCapabilitiesPlugin().events?.[EventType.ENTITY_JOINED];
+	const handler = handlers?.[0];
+	expect(handler).toBeDefined();
+	await handler?.({
+		runtime,
+		entityId,
+		worldId: "00000000-0000-0000-0000-0000000000b1" as UUID,
+		roomId: "dm-channel-1" as UUID,
+		source: "test",
+		metadata: {
+			originalId: "dm-channel-1",
+			username: "sender",
+			type: ChannelType.DM,
+		},
+	});
+}
+
+describe("basic-capabilities DM owner grants", () => {
+	it("does not auto-grant OWNER to a new DM sender without an explicit owner setting", async () => {
+		const entityId = "00000000-0000-0000-0000-0000000000c1" as UUID;
+		const { runtime, ensureConnection } = makeRuntime();
+
+		await runEntityJoined(runtime, entityId);
+
+		expect(ensureConnection).toHaveBeenCalledTimes(1);
+		expect(ensureConnection.mock.calls[0]?.[0].metadata).toEqual({
+			settings: {},
+		});
+	});
+
+	it("records an auditable owner grant when the DM sender is the configured owner", async () => {
+		const entityId = "00000000-0000-0000-0000-0000000000c1" as UUID;
+		const { runtime, ensureConnection } = makeRuntime({
+			ELIZA_ADMIN_ENTITY_ID: entityId,
+		});
+
+		await runEntityJoined(runtime, entityId);
+
+		expect(ensureConnection).toHaveBeenCalledTimes(1);
+		expect(ensureConnection.mock.calls[0]?.[0].metadata).toEqual({
+			ownership: { ownerId: entityId },
+			roles: { [entityId]: "OWNER" },
+			roleSources: { [entityId]: "owner" },
+			settings: {},
+		});
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -19,6 +19,11 @@ import {
 	imageDescriptionTemplate,
 	postCreationTemplate,
 } from "../../prompts.ts";
+import {
+	getConfiguredOwnerEntityIds,
+	type RolesWorldMetadata,
+	recordOwnerGrant,
+} from "../../roles.ts";
 import { TURN_CONTROL_ROUTES } from "../../runtime/turn-routes";
 import { SensitiveRequestDispatchRegistryService } from "../../sensitive-requests/dispatch-registry.ts";
 import {
@@ -38,7 +43,6 @@ import { EvaluatorService } from "../../services/evaluator.ts";
 import { OptimizedPromptService } from "../../services/optimized-prompt.ts";
 import { resolveOptimizedPromptForRuntime } from "../../services/optimized-prompt-resolver.ts";
 import { TaskService } from "../../services/task.ts";
-import type { Role } from "../../types/environment.ts";
 import { EventType } from "../../types/events.ts";
 import type {
 	ActionEventPayload,
@@ -88,8 +92,6 @@ import {
 } from "../autonomy/providers.ts";
 import { autonomyRoutes } from "../autonomy/routes.ts";
 import { AutonomyService } from "../autonomy/service.ts";
-
-const ROLE_OWNER: Role = "OWNER";
 
 // Re-export action and provider modules
 export * from "./actions/index.ts";
@@ -774,6 +776,22 @@ const postGeneratedHandler = async (
 	}
 };
 
+type BasicCapabilitiesWorldMetadata = RolesWorldMetadata & {
+	settings: Record<string, never>;
+};
+
+function createDmWorldMetadata(
+	runtime: IAgentRuntime,
+	entityId: UUID,
+): BasicCapabilitiesWorldMetadata {
+	const metadata: BasicCapabilitiesWorldMetadata = { settings: {} };
+	if (getConfiguredOwnerEntityIds(runtime).includes(entityId)) {
+		metadata.ownership = { ownerId: entityId };
+		recordOwnerGrant(metadata, entityId);
+	}
+	return metadata;
+}
+
 /**
  * Syncs a single user into an entity
  */
@@ -814,15 +832,7 @@ const syncSingleUser = async (
 
 	const worldMetadata =
 		type === ChannelType.DM
-			? {
-					ownership: {
-						ownerId: entityId,
-					},
-					roles: {
-						[entityId]: ROLE_OWNER,
-					},
-					settings: {}, // Initialize empty settings for setup
-				}
+			? createDmWorldMetadata(runtime, entityId)
 			: undefined;
 
 	runtime.logger.info(


### PR DESCRIPTION
## Summary
- stops `basic-capabilities` from stamping every new DM world with `ownership.ownerId` and `roles[entityId]=OWNER`
- records an auditable owner grant only when the DM sender matches configured owner policy (`ELIZA_ADMIN_ENTITY_ID` / owner contacts via `getConfiguredOwnerEntityIds`)
- adds focused event-handler coverage for ordinary DM senders and configured-owner DM senders

## Issue
Refs #12087 item 2: `basic-capabilities` auto-grants OWNER to every DM sender. This does not close #12087 because it is a multi-item architecture audit.

## Validation
- bun run --cwd packages/core test src/features/basic-capabilities/dm-owner-grant.test.ts
- bunx biome check packages/core/src/features/basic-capabilities/index.ts packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
- git diff --check HEAD~1..HEAD
- bun run --cwd packages/core typecheck

## Evidence
- Focused regression: 1 test file passed, 2 tests passed.
- Screenshots/video: N/A - server-side role metadata creation, no UI surface.
- Live model trajectory: N/A - connection sync/role metadata logic; no model/provider/prompt behavior changed.