### PR TITLE
refactor(core): fold advancedPlanning/advancedMemory into the native-feature registry (#12092 item 32)

### DIFF
--- a/packages/core/src/plugins/native-features.test.ts
+++ b/packages/core/src/plugins/native-features.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	nativeRuntimeFeatureDefaults,
+	nativeRuntimeFeaturePluginNames,
+	nativeRuntimeFeaturePlugins,
+	resolveNativeRuntimeFeatureFromPluginName,
+} from "./native-features.ts";
+
+// #12092 item 32: advancedPlanning/advancedMemory were bespoke if-blocks in
+// `_initializeCore`; they now live in the NativeRuntimeFeature registry so the
+// boot loop iterates ONE registry. These assert the registry is complete and
+// self-consistent (which is what makes the generic loop pick the features up),
+// and that the two folded-in features default OFF (flag is an explicit override).
+describe("native runtime feature registry (#12092 item 32)", () => {
+	const features = Object.keys(
+		nativeRuntimeFeatureDefaults,
+	) as Array<keyof typeof nativeRuntimeFeatureDefaults>;
+
+	it("includes advancedPlanning and advancedMemory, defaulting OFF", () => {
+		expect(nativeRuntimeFeatureDefaults.advancedPlanning).toBe(false);
+		expect(nativeRuntimeFeatureDefaults.advancedMemory).toBe(false);
+		// the always-on core features are unchanged
+		expect(nativeRuntimeFeatureDefaults.documents).toBe(true);
+		expect(nativeRuntimeFeatureDefaults.relationships).toBe(true);
+		expect(nativeRuntimeFeatureDefaults.trajectories).toBe(true);
+	});
+
+	it("has a plugin + name for every feature, and no undefined entries", () => {
+		for (const feature of features) {
+			const plugin = nativeRuntimeFeaturePlugins[feature];
+			expect(plugin, `plugin for ${feature}`).toBeDefined();
+			expect(typeof plugin.name).toBe("string");
+			expect(nativeRuntimeFeaturePluginNames[feature]).toBe(plugin.name);
+		}
+	});
+
+	it("maps each plugin name back to its feature (round-trip)", () => {
+		for (const feature of features) {
+			const name = nativeRuntimeFeaturePluginNames[feature];
+			expect(resolveNativeRuntimeFeatureFromPluginName(name)).toBe(feature);
+		}
+	});
+});

--- a/packages/core/src/plugins/native-features.ts
+++ b/packages/core/src/plugins/native-features.ts
@@ -20,15 +20,26 @@ import {
 	fetchDocumentFromUrl,
 	isYouTubeUrl,
 } from "../features/documents/index";
+import { createAdvancedMemoryPlugin } from "../features/advanced-memory/index";
+import { createAdvancedPlanningPlugin } from "../features/advanced-planning/index";
 import { trajectoriesPlugin } from "../features/trajectories/index";
 import { FollowUpService } from "../services/followUp";
 import { RelationshipsService } from "../services/relationships";
 import type { Plugin } from "../types/plugin";
 
+// advancedPlanning/advancedMemory are core-compiled feature plugins gated by a
+// character flag; they live in the native-feature registry (default off) rather
+// than as bespoke if-blocks in `_initializeCore`. Constructed once — the Plugin
+// object is stateless config, matching the other singleton entries below.
+const advancedPlanningPlugin = createAdvancedPlanningPlugin();
+const advancedMemoryPlugin = createAdvancedMemoryPlugin();
+
 export type NativeRuntimeFeature =
 	| "documents"
 	| "relationships"
-	| "trajectories";
+	| "trajectories"
+	| "advancedPlanning"
+	| "advancedMemory";
 
 export const relationshipsPlugin: Plugin = {
 	name: "relationships",
@@ -68,6 +79,8 @@ export const nativeRuntimeFeaturePlugins: Record<NativeRuntimeFeature, Plugin> =
 		documents: documentsPlugin,
 		relationships: relationshipsPlugin,
 		trajectories: trajectoriesPlugin,
+		advancedPlanning: advancedPlanningPlugin,
+		advancedMemory: advancedMemoryPlugin,
 	};
 
 export function getNativeRuntimeFeaturePlugin(
@@ -83,6 +96,8 @@ export const nativeRuntimeFeaturePluginNames: Record<
 	documents: documentsPlugin.name,
 	relationships: relationshipsPlugin.name,
 	trajectories: trajectoriesPlugin.name,
+	advancedPlanning: advancedPlanningPlugin.name,
+	advancedMemory: advancedMemoryPlugin.name,
 };
 
 export const nativeRuntimeFeatureDefaults: Record<
@@ -92,6 +107,8 @@ export const nativeRuntimeFeatureDefaults: Record<
 	documents: true,
 	relationships: true,
 	trajectories: true,
+	advancedPlanning: false,
+	advancedMemory: false,
 };
 
 export function resolveNativeRuntimeFeatureFromPluginName(

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -7,7 +7,6 @@ import {
 import { ensureConnection as ensureConnectionStandalone } from "./connection";
 import { deriveKnownSecrets } from "./constants/secrets";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
-import { createAdvancedMemoryPlugin } from "./features/advanced-memory/index";
 import {
 	type CapabilityConfig,
 	createBasicCapabilitiesPlugin,
@@ -1036,6 +1035,11 @@ export class AgentRuntime implements IAgentRuntime {
 			documents: opts.enableDocuments,
 			relationships: opts.enableRelationships,
 			trajectories: opts.enableTrajectories,
+			// Character flags are the explicit override for these two features
+			// (default false in the registry); build-character-config surfaces
+			// them as flags deliberately.
+			advancedPlanning: character.advancedPlanning,
+			advancedMemory: character.advancedMemory,
 		};
 		// Generate deterministic UUID from character name
 		// Falls back to random UUID only if no character name is provided
@@ -2363,21 +2367,6 @@ export class AgentRuntime implements IAgentRuntime {
 					this.registerPlugin(getNativeRuntimeFeaturePlugin(feature)),
 				);
 			}
-		}
-
-		if (this.character.advancedPlanning === true) {
-			const { createAdvancedPlanningPlugin } = await import(
-				"./features/advanced-planning/index.ts"
-			);
-			pluginRegistrationPromises.push(
-				this.registerPlugin(createAdvancedPlanningPlugin()),
-			);
-		}
-
-		if (this.character.advancedMemory === true) {
-			pluginRegistrationPromises.push(
-				this.registerPlugin(createAdvancedMemoryPlugin()),
-			);
 		}
 
 		for (const plugin of this.characterPlugins) {


### PR DESCRIPTION
## #12092 item 32 [P3][M] — advancedPlanning/advancedMemory bypass the native-feature registry

`_initializeCore` handled these two character flags as bespoke `if`-blocks (one `await import()`-ing its plugin), bypassing core's existing `nativeRuntimeFeature` registry that already does flag resolution, `ENABLE_*` settings overrides, defaults, dedupe, and the plugin-managed-as-native-feature guard. Only these two were ad hoc.

## Change
- `native-features.ts`: add `advancedPlanning`/`advancedMemory` to the `NativeRuntimeFeature` union, the plugins map (constructed once as stateless config singletons, like the other entries), the names map, and defaults (**false**).
- `runtime.ts`: feed `character.advancedPlanning`/`advancedMemory` into `nativeFeatureOptions` as the explicit override; **delete both `if`-blocks** and the now-unused `createAdvancedMemoryPlugin` import.
- Not moved to `character.plugins` — core receives constructed Plugin objects and `build-character-config` deliberately surfaces these as flags (per the audit note).

advanced-planning's index imports only types → the static import introduces **no cycle** (advancedMemory was already statically imported).

## Verification
- New `native-features.test.ts` — **3 pass**: both features present + default OFF, always-on core features unchanged, every feature has a consistent plugin+name, and each plugin name round-trips back to its feature.
- `grep "character.advancedPlanning === true|character.advancedMemory === true"` in runtime.ts → **0** (if-blocks gone).
- `turbo build @elizaos/core` ✅; `tsgo --noEmit` core → clean (no runtime/native-features errors).

| type | status |
|---|---|
| Registry-consistency unit test | ✅ 3 pass |
| Core typecheck | ✅ clean |
| Boot behavior | Unchanged — the generic loop already iterates the registry; these two now ride the same path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)