### PR TITLE
fix(core): match action role policy by exact name

### DIFF
--- a/packages/core/src/actions/promote-subactions.ts
+++ b/packages/core/src/actions/promote-subactions.ts
@@ -260,16 +260,8 @@ export function promoteSubactionsToActions(
 		const description = `${parent.description} — ${subBlurb}`;
 		const similes = Array.from(
 			new Set([
-				// Parent's name is FIRST simile so ACTION_ROLE_POLICY lookups
-				// (and any other simile-based lookup that does an exact name
-				// match across the simile list) resolve to the parent's
-				// declared role/policy. Without this, virtuals like
-				// `TASKS_SPAWN_AGENT` have no name in the policy table and
-				// fall through to the contextGate (which checks contexts
-				// like ["tasks", "code"]) — failing when the active context
-				// is just "general". The parent's similes are listed after,
-				// so the virtual still inherits everything the parent
-				// matched on.
+				// Parent's name is first so simile-based search/routing can still
+				// find promoted actions through the parent surface.
 				toUpperSnake(parent.name),
 				...(parent.similes ?? []),
 				...(override.similes ?? []),

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -35,6 +35,7 @@ import {
 	maybeReroute,
 	resolveChain,
 } from "./runtime/action-model-routing";
+import { getActionRolePolicyWarnings } from "./runtime/action-role-policy";
 import {
 	getActionRoutingContext,
 	runWithActionRoutingContext,
@@ -2386,6 +2387,30 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		await Promise.all(pluginRegistrationPromises);
+		for (const warning of getActionRolePolicyWarnings(this.actions)) {
+			if (warning.type === "unmatched") {
+				this.logger.warn(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						action: warning.actionName,
+						policyRole: warning.policyRole,
+					},
+					"[AgentRuntime] ACTION_ROLE_POLICY entry does not match a registered action name",
+				);
+				continue;
+			}
+			this.logger.warn(
+				{
+					src: "agent",
+					agentId: this.agentId,
+					action: warning.actionName,
+					policyRole: warning.policyRole,
+					declaredRole: warning.declaredRole,
+				},
+				"[AgentRuntime] ACTION_ROLE_POLICY entry lowers the action's declared role gate",
+			);
+		}
 
 		const allowNoDatabase =
 			options?.allowNoDatabase === true ||

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -884,7 +884,7 @@ describe("executePlannedToolCall", () => {
 			expect(handler).toHaveBeenCalledOnce();
 		});
 
-		it("matches a policy entry against the action's similes when canonical name is absent", async () => {
+		it("does not match a policy entry against the action's similes", async () => {
 			process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "NONE" });
 			_resetActionRolePolicyCacheForTests();
 			const handler = vi.fn(async () => ({ success: true }));
@@ -906,11 +906,12 @@ describe("executePlannedToolCall", () => {
 				{ name: "SHELL", params: {} },
 			);
 
-			expect(result.success).toBe(true);
-			expect(handler).toHaveBeenCalledOnce();
+			expect(result.success).toBe(false);
+			expect(String(result.error)).toContain("not allowed");
+			expect(handler).not.toHaveBeenCalled();
 		});
 
-		it("denies a simile policy entry when the caller lacks the required role", async () => {
+		it("does not let a simile policy entry tighten an unrelated action", async () => {
 			process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "OWNER" });
 			_resetActionRolePolicyCacheForTests();
 			const handler = vi.fn(async () => ({ success: true }));
@@ -932,9 +933,8 @@ describe("executePlannedToolCall", () => {
 				{ name: "SHELL", params: {} },
 			);
 
-			expect(result.success).toBe(false);
-			expect(String(result.error)).toContain("not allowed");
-			expect(handler).not.toHaveBeenCalled();
+			expect(result.success).toBe(true);
+			expect(handler).toHaveBeenCalledOnce();
 		});
 
 		it("ignores policy entries with unrecognized roles instead of granting access", async () => {

--- a/packages/core/src/runtime/__tests__/sub-planner.test.ts
+++ b/packages/core/src/runtime/__tests__/sub-planner.test.ts
@@ -300,15 +300,14 @@ describe("sub-planner helpers", () => {
 		).rejects.toThrow(/no sub-actions available/i);
 	});
 
-	it("exposes a child action when ACTION_ROLE_POLICY matches a child simile", async () => {
+	it("does not expose a child action when ACTION_ROLE_POLICY matches only a child simile", async () => {
 		process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "NONE" });
 		_resetActionRolePolicyCacheForTests();
 		const child = makeAction({
 			name: "SHELL",
 			similes: ["BASH", "EXEC", "RUN_COMMAND"],
 			contexts: ["terminal"],
-			contextGate: { anyOf: ["terminal"] },
-			roleGate: { minRole: "OWNER" },
+			contextGate: { anyOf: ["terminal"], roleGate: { minRole: "OWNER" } },
 		});
 		const parent = makeAction({
 			name: "PARENT",
@@ -326,29 +325,27 @@ describe("sub-planner helpers", () => {
 			data: { actionName: "SHELL" },
 		}));
 
-		await runSubPlanner({
-			runtime: makeRuntime([parent, child], useModel),
-			action: parent,
-			context: { id: "ctx", events: [] },
-			ctx: {
-				message: makeMessage(),
-				activeContexts: ["general"],
-				userRoles: ["GUEST"],
-			},
-			execute,
-			evaluate: async () => ({
-				success: true,
-				decision: "FINISH",
-				thought: "Done.",
-				messageToUser: "Done.",
+		await expect(
+			runSubPlanner({
+				runtime: makeRuntime([parent, child], useModel),
+				action: parent,
+				context: { id: "ctx", events: [] },
+				ctx: {
+					message: makeMessage(),
+					activeContexts: ["general"],
+					userRoles: ["GUEST"],
+				},
+				execute,
+				evaluate: async () => ({
+					success: true,
+					decision: "FINISH",
+					thought: "Done.",
+					messageToUser: "Done.",
+				}),
 			}),
-		});
+		).rejects.toThrow(/no sub-actions available/i);
 
-		expect(execute).toHaveBeenCalledWith(
-			expect.any(Object),
-			expect.any(Object),
-			expect.objectContaining({ name: "SHELL" }),
-			expect.objectContaining({ actions: [child] }),
-		);
+		expect(useModel).not.toHaveBeenCalled();
+		expect(execute).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/runtime/action-role-policy.test.ts
+++ b/packages/core/src/runtime/action-role-policy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	_resetActionRolePolicyCacheForTests,
+	getActionRolePolicyWarnings,
 	isActionAllowedByRolePolicy,
 	readActionRolePolicy,
 	resolveActionRolePolicyRole,
@@ -66,14 +67,12 @@ describe("resolveActionRolePolicyRole", () => {
 		expect(resolveActionRolePolicyRole("UNLISTED")).toBeUndefined();
 	});
 
-	it("resolves an object action by name, then falls back to a simile", () => {
+	it("resolves an object action by exact name only", () => {
 		setPolicy(JSON.stringify({ RUN_SHELL: "MEMBER" }));
 		expect(resolveActionRolePolicyRole({ name: "RUN_SHELL" })).toBe("MEMBER");
-		// name not in policy, but a simile is
 		expect(
 			resolveActionRolePolicyRole({ name: "EXEC", similes: ["RUN_SHELL"] }),
-		).toBe("MEMBER");
-		// nothing matches
+		).toBeUndefined();
 		expect(
 			resolveActionRolePolicyRole({ name: "EXEC", similes: ["NOPE"] }),
 		).toBeUndefined();
@@ -95,5 +94,42 @@ describe("isActionAllowedByRolePolicy (authorization)", () => {
 		setPolicy(JSON.stringify({ SHELL: "ADMIN" }));
 		expect(isActionAllowedByRolePolicy("SHELL", ["GUEST"])).toBe(false);
 		expect(isActionAllowedByRolePolicy("SHELL", undefined)).toBe(false);
+	});
+});
+
+describe("getActionRolePolicyWarnings", () => {
+	it("warns on unmatched exact action names", () => {
+		setPolicy(JSON.stringify({ BASH: "GUEST" }));
+		expect(getActionRolePolicyWarnings([{ name: "SHELL" }])).toEqual([
+			{ type: "unmatched", actionName: "BASH", policyRole: "GUEST" },
+		]);
+	});
+
+	it("warns when a policy entry loosens a declared gate", () => {
+		setPolicy(JSON.stringify({ SHELL: "GUEST" }));
+		expect(
+			getActionRolePolicyWarnings([
+				{ name: "SHELL", roleGate: { minRole: "OWNER" } },
+			]),
+		).toEqual([
+			{
+				type: "loosens",
+				actionName: "SHELL",
+				policyRole: "GUEST",
+				declaredRole: "OWNER",
+			},
+		]);
+	});
+
+	it("does not warn when a policy entry keeps or tightens the declared gate", () => {
+		setPolicy(JSON.stringify({ SHELL: "OWNER" }));
+		expect(
+			getActionRolePolicyWarnings([
+				{
+					name: "SHELL",
+					contextGate: { roleGate: { minRole: "ADMIN" } },
+				},
+			]),
+		).toEqual([]);
 	});
 });

--- a/packages/core/src/runtime/action-role-policy.ts
+++ b/packages/core/src/runtime/action-role-policy.ts
@@ -1,5 +1,9 @@
 import type { RoleGateRole } from "../types/contexts";
-import { normalizeGateRole, satisfiesRoleGate } from "./context-gates";
+import {
+	normalizeGateRole,
+	roleRank,
+	satisfiesRoleGate,
+} from "./context-gates";
 
 /**
  * Operator-supplied override map from the `ACTION_ROLE_POLICY` env var.
@@ -7,10 +11,10 @@ import { normalizeGateRole, satisfiesRoleGate } from "./context-gates";
  * Shape: `{"<ACTION_NAME>": "<RoleGateRole>", ...}` — e.g.
  * `{"SHELL":"GUEST","BROWSER":"MEMBER"}`.
  *
- * When an action name appears in this policy, its declared `contextGate` is
- * bypassed and access is decided solely by whether the caller satisfies the
- * policy's minimum role. Used to whitelist actions whose upstream
- * `contextGate` is narrower than a particular deployment needs.
+ * When an exact action name appears in this policy, its declared `contextGate`
+ * is bypassed and access is decided solely by whether the caller satisfies the
+ * policy's minimum role. Used to whitelist actions whose upstream `contextGate`
+ * is narrower than a particular deployment needs.
  *
  * Lookup is honored in two places:
  *   - `executePlannedToolCall` (top-level planner picks)
@@ -66,22 +70,35 @@ export function readActionRolePolicy(): Record<string, RoleGateRole> {
 
 type PolicyAddressableAction = {
 	name: string;
-	similes?: readonly string[];
+	contextGate?: {
+		roleGate?: {
+			minRole?: RoleGateRole;
+		};
+	};
+	roleGate?: {
+		minRole?: RoleGateRole;
+	};
 };
+
+export type ActionRolePolicyWarning =
+	| {
+			type: "unmatched";
+			actionName: string;
+			policyRole: RoleGateRole;
+	  }
+	| {
+			type: "loosens";
+			actionName: string;
+			policyRole: RoleGateRole;
+			declaredRole: RoleGateRole;
+	  };
 
 export function resolveActionRolePolicyRole(
 	action: string | PolicyAddressableAction,
 ): RoleGateRole | undefined {
 	const policy = readActionRolePolicy();
 	if (typeof action === "string") return policy[action];
-	const direct = policy[action.name];
-	if (direct) return direct;
-	for (const simile of action.similes ?? []) {
-		if (typeof simile !== "string") continue;
-		const role = policy[simile];
-		if (role) return role;
-	}
-	return undefined;
+	return policy[action.name];
 }
 
 /**
@@ -99,6 +116,46 @@ export function isActionAllowedByRolePolicy(
 		return false;
 	}
 	return satisfiesRoleGate(userRoles, { minRole: policyRole });
+}
+
+function declaredMinimumRole(
+	action: PolicyAddressableAction,
+): RoleGateRole | undefined {
+	const roles = [
+		action.contextGate?.roleGate?.minRole,
+		action.roleGate?.minRole,
+	].filter((role): role is RoleGateRole => Boolean(role));
+	if (roles.length === 0) return undefined;
+	return roles.reduce((strictest, role) =>
+		roleRank(role) > roleRank(strictest) ? role : strictest,
+	);
+}
+
+export function getActionRolePolicyWarnings(
+	actions: readonly PolicyAddressableAction[],
+): ActionRolePolicyWarning[] {
+	const policy = readActionRolePolicy();
+	const byName = new Map(actions.map((action) => [action.name, action]));
+	const warnings: ActionRolePolicyWarning[] = [];
+
+	for (const [actionName, policyRole] of Object.entries(policy)) {
+		const action = byName.get(actionName);
+		if (!action) {
+			warnings.push({ type: "unmatched", actionName, policyRole });
+			continue;
+		}
+		const declaredRole = declaredMinimumRole(action);
+		if (declaredRole && roleRank(policyRole) < roleRank(declaredRole)) {
+			warnings.push({
+				type: "loosens",
+				actionName,
+				policyRole,
+				declaredRole,
+			});
+		}
+	}
+
+	return warnings;
 }
 
 /** Test seam — clears the cached `ACTION_ROLE_POLICY` parse. */


### PR DESCRIPTION
## Summary
- Changes `ACTION_ROLE_POLICY` lookup to match exact action names only, no action simile fallback.
- Adds startup warnings for policy entries that match no registered action name or lower a declared role gate.
- Updates execute/sub-planner tests so simile policy keys no longer loosen or tighten unrelated actions.
- Addresses #12088 item 18.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/core test -- src/runtime/action-role-policy.test.ts src/runtime/__tests__/execute-planned-tool-call.test.ts src/runtime/__tests__/sub-planner.test.ts`
- `bunx @biomejs/biome check packages/core/src/runtime/action-role-policy.ts packages/core/src/runtime/action-role-policy.test.ts packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts packages/core/src/runtime/__tests__/sub-planner.test.ts packages/core/src/actions/promote-subactions.ts packages/core/src/runtime.ts`
- `git diff --check`

## Evidence
- N/A - security boundary/runtime policy cleanup with no user-visible UI.
- N/A - no model/action/provider/prompt behavior changed.