### PR TITLE
refactor(agent): move EVM wallet diagnostic card to a plugin-owned descriptor (#12092 item 8)

### DIFF
--- a/packages/agent/src/api/plugin-diagnostic.test.ts
+++ b/packages/agent/src/api/plugin-diagnostic.test.ts
@@ -1,0 +1,261 @@
+import type { PluginDiagnosticDescriptor } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/config";
+import type { WalletCapabilityStatus } from "./wallet-capability";
+
+const resolveWalletCapabilityStatusMock =
+  vi.fn<(state: unknown) => WalletCapabilityStatus>();
+
+vi.mock("./wallet-capability", () => ({
+  resolveWalletCapabilityStatus: (state: unknown) =>
+    resolveWalletCapabilityStatusMock(state),
+}));
+
+import {
+  buildPluginDiagnosticEntry,
+  resolveWalletDiagnosticStatus,
+} from "./plugin-diagnostic";
+
+const WALLET_DESCRIPTOR: PluginDiagnosticDescriptor = {
+  id: "evm",
+  name: "Plugin EVM",
+  description:
+    "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
+  tags: ["wallet", "evm", "bsc", "onchain"],
+  envKey: "EVM_PRIVATE_KEY",
+  category: "feature",
+  source: "bundled",
+  configKeys: [
+    "EVM_PRIVATE_KEY",
+    "BSC_RPC_URL",
+    "BSC_TESTNET_RPC_URL",
+    "ELIZA_WALLET_NETWORK",
+  ],
+  npmName: "@elizaos/plugin-wallet",
+  managementMode: "core-optional",
+  aliases: ["evm", "wallet"],
+  prerequisites: [
+    { key: "wallet", label: "wallet present" },
+    { key: "rpc", label: "rpc ready" },
+    { key: "plugin", label: "plugin loaded" },
+  ],
+};
+
+function makeCapability(
+  overrides: Partial<WalletCapabilityStatus>,
+): WalletCapabilityStatus {
+  return {
+    walletSource: "none",
+    walletNetwork: "mainnet",
+    evmAddress: null,
+    solanaAddress: null,
+    hasWallet: false,
+    hasEvm: false,
+    localSignerAvailable: false,
+    rpcReady: false,
+    automationMode: "full",
+    pluginEvmLoaded: false,
+    pluginEvmRequired: false,
+    executionReady: false,
+    executionBlockedReason: null,
+    evmSigningCapability: "none",
+    evmSigningReason: "",
+    ...overrides,
+  };
+}
+
+function makeState(allow: string[]): {
+  config: ElizaConfig;
+  runtime: null;
+} {
+  return {
+    config: { plugins: { allow } } as ElizaConfig,
+    runtime: null,
+  };
+}
+
+describe("buildPluginDiagnosticEntry", () => {
+  it("renders a descriptor + status into the plugin card generically", () => {
+    const entry = buildPluginDiagnosticEntry(WALLET_DESCRIPTOR, {
+      enabled: true,
+      configured: true,
+      isActive: false,
+      autoEnabled: true,
+      capabilityStatus: "auto-enabled",
+      capabilityReason: "because",
+      prerequisiteMet: { wallet: true, rpc: false, plugin: false },
+    });
+
+    expect(entry).toEqual({
+      id: "evm",
+      name: "Plugin EVM",
+      description:
+        "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
+      tags: ["wallet", "evm", "bsc", "onchain"],
+      enabled: true,
+      configured: true,
+      envKey: "EVM_PRIVATE_KEY",
+      category: "feature",
+      source: "bundled",
+      configKeys: [
+        "EVM_PRIVATE_KEY",
+        "BSC_RPC_URL",
+        "BSC_TESTNET_RPC_URL",
+        "ELIZA_WALLET_NETWORK",
+      ],
+      parameters: [],
+      validationErrors: [],
+      validationWarnings: [],
+      npmName: "@elizaos/plugin-wallet",
+      isActive: false,
+      autoEnabled: true,
+      managementMode: "core-optional",
+      capabilityStatus: "auto-enabled",
+      capabilityReason: "because",
+      prerequisites: [
+        { label: "wallet present", met: true },
+        { label: "rpc ready", met: false },
+        { label: "plugin loaded", met: false },
+      ],
+    });
+  });
+
+  it("copies descriptor arrays instead of aliasing them", () => {
+    const entry = buildPluginDiagnosticEntry(WALLET_DESCRIPTOR, {
+      enabled: false,
+      configured: false,
+      isActive: false,
+      autoEnabled: false,
+      capabilityStatus: "disabled",
+      capabilityReason: null,
+      prerequisiteMet: {},
+    });
+    expect(entry.tags).not.toBe(WALLET_DESCRIPTOR.tags);
+    expect(entry.configKeys).not.toBe(WALLET_DESCRIPTOR.configKeys);
+    expect(entry.prerequisites).toEqual([
+      { label: "wallet present", met: false },
+      { label: "rpc ready", met: false },
+      { label: "plugin loaded", met: false },
+    ]);
+  });
+});
+
+describe("resolveWalletDiagnosticStatus", () => {
+  it("preserves the exact loaded card output", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(
+      makeCapability({
+        evmAddress: "0xabc",
+        hasEvm: true,
+        hasWallet: true,
+        rpcReady: true,
+        pluginEvmLoaded: true,
+        pluginEvmRequired: true,
+        executionReady: true,
+      }),
+    );
+
+    const state = makeState([]);
+    const entry = buildPluginDiagnosticEntry(
+      WALLET_DESCRIPTOR,
+      resolveWalletDiagnosticStatus(WALLET_DESCRIPTOR, state),
+    );
+
+    expect(entry).toEqual({
+      id: "evm",
+      name: "Plugin EVM",
+      description:
+        "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
+      tags: ["wallet", "evm", "bsc", "onchain"],
+      enabled: true,
+      configured: true,
+      envKey: "EVM_PRIVATE_KEY",
+      category: "feature",
+      source: "bundled",
+      configKeys: [
+        "EVM_PRIVATE_KEY",
+        "BSC_RPC_URL",
+        "BSC_TESTNET_RPC_URL",
+        "ELIZA_WALLET_NETWORK",
+      ],
+      parameters: [],
+      validationErrors: [],
+      validationWarnings: [],
+      npmName: "@elizaos/plugin-wallet",
+      isActive: true,
+      autoEnabled: false,
+      managementMode: "core-optional",
+      capabilityStatus: "loaded",
+      capabilityReason: "Wallet execution is ready.",
+      prerequisites: [
+        { label: "wallet present", met: true },
+        { label: "rpc ready", met: true },
+        { label: "plugin loaded", met: true },
+      ],
+    });
+  });
+
+  it("maps auto-enabled when loaded but not required", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(
+      makeCapability({ pluginEvmLoaded: true, pluginEvmRequired: false }),
+    );
+    const status = resolveWalletDiagnosticStatus(
+      WALLET_DESCRIPTOR,
+      makeState([]),
+    );
+    expect(status.capabilityStatus).toBe("auto-enabled");
+    expect(status.enabled).toBe(true);
+    expect(status.autoEnabled).toBe(false);
+    expect(status.isActive).toBe(true);
+  });
+
+  it("blocks when a wallet is present but the plugin is not loaded", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(
+      makeCapability({
+        evmAddress: "0xabc",
+        hasEvm: true,
+        pluginEvmRequired: true,
+        executionBlockedReason: "BSC RPC is not configured.",
+      }),
+    );
+    const status = resolveWalletDiagnosticStatus(
+      WALLET_DESCRIPTOR,
+      makeState([]),
+    );
+    expect(status.capabilityStatus).toBe("blocked");
+    expect(status.capabilityReason).toBe("BSC RPC is not configured.");
+    expect(status.prerequisiteMet).toEqual({
+      wallet: true,
+      rpc: false,
+      plugin: false,
+    });
+  });
+
+  it("reports missing-prerequisites when enabled via allowlist alias only", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(makeCapability({}));
+    const status = resolveWalletDiagnosticStatus(
+      WALLET_DESCRIPTOR,
+      makeState(["wallet"]),
+    );
+    expect(status.enabled).toBe(true);
+    expect(status.capabilityStatus).toBe("missing-prerequisites");
+  });
+
+  it("enables via the npm package alias in the allowlist", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(makeCapability({}));
+    const status = resolveWalletDiagnosticStatus(
+      WALLET_DESCRIPTOR,
+      makeState(["@elizaos/plugin-wallet"]),
+    );
+    expect(status.enabled).toBe(true);
+  });
+
+  it("is disabled when neither loaded, required, nor allow-listed", () => {
+    resolveWalletCapabilityStatusMock.mockReturnValue(makeCapability({}));
+    const status = resolveWalletDiagnosticStatus(
+      WALLET_DESCRIPTOR,
+      makeState(["some-other-plugin"]),
+    );
+    expect(status.enabled).toBe(false);
+    expect(status.capabilityStatus).toBe("disabled");
+  });
+});

--- a/packages/agent/src/api/plugin-diagnostic.ts
+++ b/packages/agent/src/api/plugin-diagnostic.ts
@@ -1,0 +1,104 @@
+import type { AgentRuntime, PluginDiagnosticDescriptor } from "@elizaos/core";
+import type { ElizaConfig } from "../config/config.ts";
+import type { PluginEntry } from "./server-types.ts";
+import { resolveWalletCapabilityStatus } from "./wallet-capability.ts";
+
+/**
+ * Runtime-dynamic status the host resolves for a plugin diagnostic descriptor.
+ * Merged with the plugin-owned static descriptor to render the diagnostic card.
+ */
+export interface PluginDiagnosticRuntimeStatus {
+  enabled: boolean;
+  configured: boolean;
+  isActive: boolean;
+  autoEnabled: boolean;
+  capabilityStatus: NonNullable<PluginEntry["capabilityStatus"]>;
+  capabilityReason: string | null;
+  /** Satisfied state keyed by `PluginDiagnosticPrerequisite.key`. */
+  prerequisiteMet: Record<string, boolean>;
+}
+
+/**
+ * Generic renderer: merges a plugin-owned static descriptor with host-resolved
+ * runtime status into the `PluginEntry` the diagnostics card consumes. No
+ * plugin-specific literals live here — the descriptor supplies identity, config
+ * keys, tags, and prerequisite labels; the status supplies the live state.
+ */
+export function buildPluginDiagnosticEntry(
+  descriptor: PluginDiagnosticDescriptor,
+  status: PluginDiagnosticRuntimeStatus,
+): PluginEntry {
+  return {
+    id: descriptor.id,
+    name: descriptor.name,
+    description: descriptor.description,
+    tags: [...descriptor.tags],
+    enabled: status.enabled,
+    configured: status.configured,
+    envKey: descriptor.envKey,
+    category: descriptor.category,
+    source: descriptor.source,
+    configKeys: [...descriptor.configKeys],
+    parameters: [],
+    validationErrors: [],
+    validationWarnings: [],
+    npmName: descriptor.npmName,
+    isActive: status.isActive,
+    autoEnabled: status.autoEnabled,
+    managementMode: descriptor.managementMode,
+    capabilityStatus: status.capabilityStatus,
+    capabilityReason: status.capabilityReason,
+    prerequisites: descriptor.prerequisites.map((prerequisite) => ({
+      label: prerequisite.label,
+      met: status.prerequisiteMet[prerequisite.key] ?? false,
+    })),
+  };
+}
+
+/**
+ * Wallet-specific status resolver: maps the host's wallet capability snapshot
+ * onto the generic diagnostic status for the EVM wallet descriptor. This is the
+ * only wallet-aware glue; it lives beside the wallet capability engine, not in
+ * the generic host router.
+ */
+export function resolveWalletDiagnosticStatus(
+  descriptor: PluginDiagnosticDescriptor,
+  state: { config: ElizaConfig; runtime: AgentRuntime | null },
+): PluginDiagnosticRuntimeStatus {
+  const capability = resolveWalletCapabilityStatus(state);
+  const allow = state.config.plugins?.allow ?? [];
+  const enabled =
+    capability.pluginEvmLoaded ||
+    capability.pluginEvmRequired ||
+    allow.some(
+      (entry) =>
+        entry === descriptor.npmName || descriptor.aliases.includes(entry),
+    );
+
+  const capabilityStatus: PluginDiagnosticRuntimeStatus["capabilityStatus"] =
+    capability.pluginEvmLoaded
+      ? capability.pluginEvmRequired
+        ? "loaded"
+        : "auto-enabled"
+      : enabled
+        ? capability.evmAddress || capability.localSignerAvailable
+          ? "blocked"
+          : "missing-prerequisites"
+        : "disabled";
+
+  return {
+    enabled,
+    configured: capability.pluginEvmRequired,
+    isActive: capability.pluginEvmLoaded,
+    autoEnabled: capability.pluginEvmRequired && !capability.pluginEvmLoaded,
+    capabilityStatus,
+    capabilityReason: capability.executionReady
+      ? "Wallet execution is ready."
+      : capability.executionBlockedReason,
+    prerequisiteMet: {
+      wallet: Boolean(capability.evmAddress),
+      rpc: capability.rpcReady,
+      plugin: capability.pluginEvmLoaded,
+    },
+  };
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -341,6 +341,7 @@ function getPluginRegistryApi(): Promise<
   return pluginRegistryApiPromise;
 }
 
+import { walletDiagnosticDescriptor } from "@elizaos/plugin-wallet/diagnostic";
 import {
   type ElizaConfig,
   loadElizaConfig,
@@ -428,6 +429,10 @@ import { wireCoordinatorBridgesWhenReady } from "./coordinator-wiring.ts";
 import { createDeliveryDedupeState } from "./delivery-dedupe.ts";
 import { computeCanRespond } from "./health-routes.ts";
 import { pushWithBatchEvict } from "./memory-bounds.ts";
+import {
+  buildPluginDiagnosticEntry,
+  resolveWalletDiagnosticStatus,
+} from "./plugin-diagnostic.ts";
 import { createRuntimeReadyGate } from "./runtime-ready-gate.ts";
 import {
   cloneWithoutBlockedObjectKeys,
@@ -1550,63 +1555,18 @@ function persistAgentAutomationMode(
   };
 }
 
+/**
+ * Build the EVM wallet diagnostic card from the plugin-owned static descriptor
+ * (identity, config keys, tags, prerequisite labels) merged with the
+ * host-resolved runtime status. No plugin-specific literals live in the host.
+ */
 function buildPluginEvmDiagnosticEntry(
   state: Pick<ServerState, "config" | "runtime">,
 ): PluginEntry {
-  const capability = resolveWalletCapabilityStatus(state);
-  const enabled =
-    capability.pluginEvmLoaded ||
-    capability.pluginEvmRequired ||
-    (state.config.plugins?.allow ?? []).some((entry) => {
-      return (
-        entry === EVM_PLUGIN_PACKAGE || entry === "evm" || entry === "wallet"
-      );
-    });
-
-  const capabilityStatus = capability.pluginEvmLoaded
-    ? capability.pluginEvmRequired
-      ? "loaded"
-      : "auto-enabled"
-    : enabled
-      ? capability.evmAddress || capability.localSignerAvailable
-        ? "blocked"
-        : "missing-prerequisites"
-      : "disabled";
-
-  return {
-    id: "evm",
-    name: "Plugin EVM",
-    description:
-      "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
-    tags: ["wallet", "evm", "bsc", "onchain"],
-    enabled,
-    configured: capability.pluginEvmRequired,
-    envKey: "EVM_PRIVATE_KEY",
-    category: "feature",
-    source: "bundled",
-    configKeys: [
-      "EVM_PRIVATE_KEY",
-      "BSC_RPC_URL",
-      "BSC_TESTNET_RPC_URL",
-      "ELIZA_WALLET_NETWORK",
-    ],
-    parameters: [],
-    validationErrors: [],
-    validationWarnings: [],
-    npmName: EVM_PLUGIN_PACKAGE,
-    isActive: capability.pluginEvmLoaded,
-    autoEnabled: capability.pluginEvmRequired && !capability.pluginEvmLoaded,
-    managementMode: "core-optional",
-    capabilityStatus,
-    capabilityReason: capability.executionReady
-      ? "Wallet execution is ready."
-      : capability.executionBlockedReason,
-    prerequisites: [
-      { label: "wallet present", met: Boolean(capability.evmAddress) },
-      { label: "rpc ready", met: capability.rpcReady },
-      { label: "plugin loaded", met: capability.pluginEvmLoaded },
-    ],
-  };
+  return buildPluginDiagnosticEntry(
+    walletDiagnosticDescriptor,
+    resolveWalletDiagnosticStatus(walletDiagnosticDescriptor, state),
+  );
 }
 
 import { resolveWalletExportRejection as _resolveWalletExportRejection } from "./server-helpers-wallet.ts";

--- a/packages/agent/src/external-modules.d.ts
+++ b/packages/agent/src/external-modules.d.ts
@@ -742,6 +742,11 @@ declare module "@elizaos/plugin-wallet" {
   export function getWalletExportAuditLog(): unknown[];
 }
 
+declare module "@elizaos/plugin-wallet/diagnostic" {
+  import type { PluginDiagnosticDescriptor } from "@elizaos/core";
+  export const walletDiagnosticDescriptor: PluginDiagnosticDescriptor;
+}
+
 declare module "@elizaos/ui" {
   import type { ComponentType, RefObject } from "react";
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -305,6 +305,48 @@ export interface PluginAppLaunchDiagnostic {
 	message: string;
 }
 
+/**
+ * A single prerequisite a plugin declares for its diagnostic card. The host
+ * resolves runtime state and maps {@link key} to a satisfied boolean; the
+ * plugin owns the human-readable {@link label}.
+ */
+export interface PluginDiagnosticPrerequisite {
+	/** Stable key the host's status resolver maps to a satisfied boolean. */
+	key: string;
+	/** Human-readable label shown on the diagnostic card. */
+	label: string;
+}
+
+/**
+ * Static metadata a plugin contributes so the host can render its diagnostic
+ * card without hardcoding the plugin's identity, config keys, tags, or
+ * prerequisites. The host resolves the runtime-dynamic status (enabled,
+ * capability, prerequisite satisfaction) separately and merges it with this
+ * descriptor. Owning this here keeps a single source of truth: renaming a
+ * config key changes the descriptor, not the host.
+ */
+export interface PluginDiagnosticDescriptor {
+	id: string;
+	name: string;
+	description: string;
+	tags: string[];
+	envKey: string | null;
+	category:
+		| "ai-provider"
+		| "connector"
+		| "streaming"
+		| "database"
+		| "app"
+		| "feature";
+	source: "bundled" | "store";
+	configKeys: string[];
+	npmName: string;
+	managementMode: "standard" | "core-optional";
+	/** Config-allowlist entries that mean "this plugin is enabled". */
+	aliases: string[];
+	prerequisites: PluginDiagnosticPrerequisite[];
+}
+
 export interface PluginAppBridgeLaunchContext {
 	appName?: string;
 	launchUrl?: string | null;

--- a/plugins/plugin-wallet/build.ts
+++ b/plugins/plugin-wallet/build.ts
@@ -6,7 +6,7 @@
  * previous hand-rolled build.
  *
  * Notable specifics reproduced here:
- * - Four entrypoints are bundled together under `dist/` with Bun's default
+ * - Five entrypoints are bundled together under `dist/` with Bun's default
  *   `[dir]/[name].[ext]` naming, so `src/sdk/index.ts` etc. keep their tree.
  * - Only the primary `index.js`/`index.js.map` are renamed to `.mjs`/`.mjs.map`
  *   (the package `main`/`exports` point at `dist/index.mjs`); the secondary
@@ -30,6 +30,7 @@ await buildPlugin({
       label: "Node",
       entry: [
         "src/index.ts",
+        "src/diagnostic.ts",
         "src/sdk/index.ts",
         "src/wallet-action.ts",
         "src/lib/server-wallet-trade.ts",

--- a/plugins/plugin-wallet/src/diagnostic.ts
+++ b/plugins/plugin-wallet/src/diagnostic.ts
@@ -1,0 +1,36 @@
+import type { PluginDiagnosticDescriptor } from "@elizaos/core";
+
+/**
+ * Static diagnostic descriptor for the EVM wallet plugin. The agent host reads
+ * this to render the plugin's diagnostic card generically instead of
+ * hardcoding the plugin's identity, config keys, tags, and prerequisites.
+ * The runtime-dynamic status (loaded/enabled/prerequisite satisfaction) is
+ * resolved by the host and merged with this descriptor.
+ *
+ * This module is a dependency-free leaf so the host can import it eagerly
+ * without pulling in the plugin's runtime (viem, services, etc.).
+ */
+export const walletDiagnosticDescriptor: PluginDiagnosticDescriptor = {
+  id: "evm",
+  name: "Plugin EVM",
+  description:
+    "EVM wallet runtime for balance, transfer, and trade actions. Required for wallet execution in chat.",
+  tags: ["wallet", "evm", "bsc", "onchain"],
+  envKey: "EVM_PRIVATE_KEY",
+  category: "feature",
+  source: "bundled",
+  configKeys: [
+    "EVM_PRIVATE_KEY",
+    "BSC_RPC_URL",
+    "BSC_TESTNET_RPC_URL",
+    "ELIZA_WALLET_NETWORK",
+  ],
+  npmName: "@elizaos/plugin-wallet",
+  managementMode: "core-optional",
+  aliases: ["evm", "wallet"],
+  prerequisites: [
+    { key: "wallet", label: "wallet present" },
+    { key: "rpc", label: "rpc ready" },
+    { key: "plugin", label: "plugin loaded" },
+  ],
+};


### PR DESCRIPTION
## #12092 item 8 [P2][S] — EVM plugin diagnostic card hand-built inside server.ts

`buildPluginEvmDiagnosticEntry` in `packages/agent/src/api/server.ts` hardcoded another plugin's name, description, config keys (`EVM_PRIVATE_KEY`, `BSC_RPC_URL`…), tags, prerequisites, and alias matching (`entry === 'evm' || entry === 'wallet'`). A renamed config key silently broke the card.

## Change
- **New generic extension point** (none existed — the existing `PluginDiagnostic`/`PluginAppLaunchDiagnostic` don't fit): `PluginDiagnosticDescriptor` + `PluginDiagnosticPrerequisite` in `packages/core/src/types/plugin.ts` — static metadata a plugin contributes (id/name/description/tags/envKey/configKeys/aliases/prerequisites/…).
- **Descriptor moved to `@elizaos/plugin-wallet`** — new `plugins/plugin-wallet/src/diagnostic.ts` exports `walletDiagnosticDescriptor` (all former hardcoded literals), exposed at `@elizaos/plugin-wallet/diagnostic` + emitted via `build.ts`.
- **Host renders generically** — new `packages/agent/src/api/plugin-diagnostic.ts` splits a zero-literal `buildPluginDiagnosticEntry(descriptor, status)` from the wallet-specific status resolver (which reads the host's existing capability snapshot — stays host-side, shared by other routes). `server.ts`'s function is now a 5-line adapter (58→13 lines).

## Verification
- New `plugin-diagnostic.test.ts` — **8 pass**, incl. a **deep-equal locking the exact legacy "loaded" card output** plus auto-enabled / blocked / missing-prerequisite / disabled / alias-enable paths.
- `grep BSC_RPC_URL packages/agent/src/api/server.ts` → **0**; the `evm`/`wallet` alias literals are gone from the diagnostic function. (Two unrelated `EVM_PRIVATE_KEY` hits remain at server.ts:3784 env-hydration + :3832 plaintext-key security warning — out of scope, removing them would break wallet-address hydration + the security nudge; the "done when" scopes to the function.)
- `turbo build` core/plugin-sql/plugin-wallet ✅ (`dist/diagnostic.js` emitted); `tsgo` agent → zero errors in touched files (remaining are pre-existing unbuilt-workspace `TS2307`).

| type | status |
|---|---|
| Unit test incl. legacy-output deep-equal | ✅ 8 pass |
| server.ts literal grep (BSC_RPC_URL → 0) | ✅ |
| Card output | byte-for-byte preserved (locked by test) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)