### PR TITLE
fix(agent): gate providers on hot plugin registration

### DIFF
--- a/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
+++ b/packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
@@ -188,6 +188,28 @@ describe("skills-shaped plugin — 3 load/unload cycles", () => {
   });
 });
 
+describe("provider role gating during hot plugin registration", () => {
+  it("applies provider role gating to plugins registered after boot", async () => {
+    const runtime = createTestRuntime();
+    installRuntimePluginLifecycle(runtime);
+    const sensitiveProvider = {
+      name: "SECRETS_STATUS",
+      description: "sensitive secrets status",
+      get: vi.fn(async () => ({ text: "secret state" })),
+    };
+
+    await runtime.registerPlugin({
+      name: "synthetic-sensitive-plugin",
+      description: "Synthetic plugin with a sensitive provider",
+      providers: [sensitiveProvider],
+    });
+
+    expect((sensitiveProvider as { __roleGate?: string }).__roleGate).toBe(
+      "admin",
+    );
+  });
+});
+
 describe("app-shaped plugin — 3 load/unload cycles", () => {
   it("runs 3 cycles and restores baseline state each time", async () => {
     const runtime = createTestRuntime();

--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -15,6 +15,7 @@ import {
   registerPluginViews,
   unregisterPluginViews,
 } from "../api/views-registry.ts";
+import { applyPluginRoleGating } from "./plugin-role-gating.ts";
 import type { ToolCallCache } from "./tool-call-cache/index.ts";
 import {
   createToolCallCacheFromConfig,
@@ -683,6 +684,7 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
   runtime.registerPlugin = (async (plugin: Plugin) => {
     await baseRegisterPlugin(plugin);
     try {
+      applyPluginRoleGating([plugin]);
       await migratePluginSchemasIfReady(runtime, plugin);
       await registerPluginViews(plugin);
     } catch (error) {
@@ -707,6 +709,7 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
     runtime.reloadPlugin = async (plugin: Plugin) => {
       unregisterPluginViews(plugin.name);
       await baseReloadPlugin(plugin);
+      applyPluginRoleGating([plugin]);
       await registerPluginViews(plugin);
     };
   }
@@ -937,6 +940,7 @@ export function installRuntimePluginLifecycle(runtime: AgentRuntime): void {
         pluginsBefore,
         routesBefore,
       );
+      applyPluginRoleGating([plugin]);
       await migratePluginSchemasIfReady(runtime, plugin);
       if (
         capture.ownership.registeredPlugin ||


### PR DESCRIPTION
## Summary
- applies existing provider role gating inside the agent plugin lifecycle register/reload wrappers
- covers dynamically registered plugins after boot, including plugin-runtime-apply, VFS, directory loads, and reload paths
- adds a lifecycle smoke regression proving a hot-registered `SECRETS_STATUS` provider receives the admin provider gate

## Issue
Refs #12087 item 1: provider role redaction is a one-shot boot pass and hot-installed plugins escape it. This does not close #12087 because it is a multi-item architecture audit.

## Validation
- bun run --cwd packages/agent test -- src/__tests__/plugin-smoke-lifecycle.test.ts
- bunx biome check packages/agent/src/runtime/plugin-lifecycle.ts packages/agent/src/__tests__/plugin-smoke-lifecycle.test.ts
- git diff --check HEAD~1..HEAD
- bun run --cwd packages/agent typecheck

## Evidence
- Focused regression: 1 test file passed, 9 tests passed.
- Screenshots/video: N/A - runtime plugin lifecycle/provider redaction, no UI surface.
- Live model trajectory: N/A - provider registration/gating only; no model/prompt/action execution path changed.