### PR TITLE
fix(agent): query app runs via AppSessionService instead of static plugin import (#12091 item 17)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,7 +106,6 @@
         "@elizaos/plugin-anthropic": "workspace:*",
         "@elizaos/plugin-aosp-local-inference": "workspace:*",
         "@elizaos/plugin-app-control": "workspace:*",
-        "@elizaos/plugin-app-manager": "workspace:*",
         "@elizaos/plugin-background-runner": "workspace:*",
         "@elizaos/plugin-birdclaw": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -300,7 +300,6 @@
     "@elizaos/plugin-anthropic": "workspace:*",
     "@elizaos/plugin-aosp-local-inference": "workspace:*",
     "@elizaos/plugin-app-control": "workspace:*",
-    "@elizaos/plugin-app-manager": "workspace:*",
     "@elizaos/plugin-background-runner": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",
     "@elizaos/plugin-capacitor-bridge": "workspace:*",

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4686,6 +4686,24 @@ export async function startEliza(
     }
   };
 
+  // Register the hosted-app run reader as a runtime service so the session gate
+  // can query it via getService instead of statically importing the plugin
+  // (which inverted the host→plugin dependency direction). Dynamic import keeps
+  // the plugin out of the agent's static module graph; absence is non-fatal and
+  // the gate treats it as "no active runs".
+  const registerAppSessionService = async (): Promise<void> => {
+    try {
+      const { AppSessionService } = await import(
+        /* @vite-ignore */ "@elizaos/plugin-app-manager"
+      );
+      await runtime.registerService(AppSessionService);
+    } catch (err) {
+      logger.debug(
+        `[eliza] AppSessionService registration skipped: ${formatError(err)}`,
+      );
+    }
+  };
+
   const registerRemoteCodingRunner = async (): Promise<void> => {
     if (isBundledMobileRuntime()) return;
     if (!shouldLoadRemoteCodingRunnerForBoot(runtime)) return;
@@ -5138,6 +5156,8 @@ export async function startEliza(
   const initializeRuntimeServices = async (): Promise<void> => {
     await registerConnectorSetupService();
     bootTimer.lap("svc:connector-setup");
+    await registerAppSessionService();
+    bootTimer.lap("svc:app-session");
     await registerRemoteCodingRunner();
     bootTimer.lap("svc:pre-init");
 

--- a/packages/agent/src/services/app-session-gate.test.ts
+++ b/packages/agent/src/services/app-session-gate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * app-session-gate unit test — the hosted-app session gate now reads AppManager
+ * runs from a runtime-registered service (`APP_SESSION_SERVICE_TYPE`) instead of
+ * statically importing `readAppRunStore` from `@elizaos/plugin-app-manager`.
+ *
+ * These tests prove the new seam: the gate queries `runtime.getService`, gates
+ * off (fails open to "no active runs") when the service is absent, and matches
+ * the previous behavior — active/non-stopped run for the canonical name → open;
+ * stopped or foreign runs → closed — when the service is present.
+ */
+
+import type { Action, IAgentRuntime, Provider } from "@elizaos/core";
+import {
+  APP_SESSION_SERVICE_TYPE,
+  type AppRunSummary,
+  type AppSessionServiceLike,
+} from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  gatePluginSessionForHostedApp,
+  hasActiveAppRunForCanonicalName,
+  isHostedAppActiveForAgentActions,
+} from "./app-session-gate.ts";
+
+const APP = "@elizaos/plugin-wifi";
+
+function run(appName: string, status: string): AppRunSummary {
+  return { appName, status } as AppRunSummary;
+}
+
+/** Runtime whose getService returns the supplied service (or undefined). */
+function makeRuntime(service?: AppSessionServiceLike): {
+  runtime: IAgentRuntime;
+  getService: ReturnType<typeof vi.fn>;
+} {
+  const getService = vi.fn((type: string) =>
+    type === APP_SESSION_SERVICE_TYPE ? service : undefined,
+  );
+  return { runtime: { getService } as unknown as IAgentRuntime, getService };
+}
+
+function serviceWith(runs: AppRunSummary[]): AppSessionServiceLike {
+  return { getRuns: () => runs };
+}
+
+describe("app-session-gate service seam", () => {
+  it("queries the runtime for APP_SESSION_SERVICE_TYPE", () => {
+    const { runtime, getService } = makeRuntime(serviceWith([]));
+    hasActiveAppRunForCanonicalName(runtime, APP);
+    expect(getService).toHaveBeenCalledWith(APP_SESSION_SERVICE_TYPE);
+  });
+
+  it("fails open to no-active-runs when the service is absent", () => {
+    const { runtime } = makeRuntime(undefined);
+    expect(hasActiveAppRunForCanonicalName(runtime, APP)).toBe(false);
+    expect(isHostedAppActiveForAgentActions(runtime, APP)).toBe(false);
+  });
+
+  it("reports active for a non-stopped run matching the canonical name", () => {
+    const { runtime } = makeRuntime(serviceWith([run(APP, "running")]));
+    expect(hasActiveAppRunForCanonicalName(runtime, APP)).toBe(true);
+  });
+
+  it("ignores stopped runs and runs for other apps", () => {
+    const stopped = makeRuntime(serviceWith([run(APP, "stopped")]));
+    expect(hasActiveAppRunForCanonicalName(stopped.runtime, APP)).toBe(false);
+
+    const foreign = makeRuntime(
+      serviceWith([run("@elizaos/plugin-phone", "running")]),
+    );
+    expect(hasActiveAppRunForCanonicalName(foreign.runtime, APP)).toBe(false);
+  });
+});
+
+describe("gatePluginSessionForHostedApp", () => {
+  const baseAction: Action = {
+    name: "APP_ACTION",
+    description: "",
+    examples: [],
+    similes: [],
+    validate: async () => true,
+    handler: async () => undefined,
+  };
+  const baseProvider: Provider = {
+    name: "APP_PROVIDER",
+    get: async () => ({ text: "ok", data: { available: true } }),
+  };
+
+  it("blocks action validate + provider get when no session is active", async () => {
+    const plugin = gatePluginSessionForHostedApp(
+      {
+        name: "p",
+        description: "",
+        actions: [baseAction],
+        providers: [baseProvider],
+      },
+      APP,
+    );
+    const { runtime } = makeRuntime(undefined);
+    const msg = {} as never;
+    const state = {} as never;
+
+    await expect(
+      plugin.actions?.[0]?.validate?.(runtime, msg, state),
+    ).resolves.toBe(false);
+    const result = await plugin.providers?.[0]?.get(runtime, msg, state);
+    expect(result?.data).toMatchObject({ appSessionInactive: true });
+  });
+
+  it("passes through to the wrapped action/provider when a run is active", async () => {
+    const plugin = gatePluginSessionForHostedApp(
+      {
+        name: "p",
+        description: "",
+        actions: [baseAction],
+        providers: [baseProvider],
+      },
+      APP,
+    );
+    const { runtime } = makeRuntime(serviceWith([run(APP, "running")]));
+    const msg = {} as never;
+    const state = {} as never;
+
+    await expect(
+      plugin.actions?.[0]?.validate?.(runtime, msg, state),
+    ).resolves.toBe(true);
+    const result = await plugin.providers?.[0]?.get(runtime, msg, state);
+    expect(result?.text).toBe("ok");
+  });
+});

--- a/packages/agent/src/services/app-session-gate.ts
+++ b/packages/agent/src/services/app-session-gate.ts
@@ -3,8 +3,17 @@
  * is active (AppManager run and/or overlay heartbeat for local overlay apps).
  */
 
-import type { Action, Plugin, Provider } from "@elizaos/core";
-import { readAppRunStore } from "@elizaos/plugin-app-manager";
+import type {
+  Action,
+  IAgentRuntime,
+  Plugin,
+  Provider,
+  Service,
+} from "@elizaos/core";
+import {
+  APP_SESSION_SERVICE_TYPE,
+  type AppSessionServiceLike,
+} from "@elizaos/shared";
 import { isOverlayAppPresenceActive } from "./overlay-app-presence.ts";
 
 const STOPPED_STATUSES = new Set(["stopped", "offline", "error", "failed"]);
@@ -13,14 +22,28 @@ function isRunStatusActive(status: string): boolean {
   return !STOPPED_STATUSES.has(status.trim().toLowerCase());
 }
 
-/** True when an AppManager run exists for this canonical app name and is not stopped. */
+/**
+ * True when an AppManager run exists for this canonical app name and is not
+ * stopped. Reads runs from the `@elizaos/plugin-app-manager` AppSessionService
+ * registered on the runtime; if the service is absent (plugin not loaded) it
+ * fails open to "no active runs" rather than importing the plugin statically.
+ */
 export function hasActiveAppRunForCanonicalName(
+  runtime: IAgentRuntime,
   appCanonicalName: string,
 ): boolean {
-  const runs = readAppRunStore();
-  return runs.some(
-    (run) => run.appName === appCanonicalName && isRunStatusActive(run.status),
+  const service = runtime.getService<Service & AppSessionServiceLike>(
+    APP_SESSION_SERVICE_TYPE,
   );
+  if (!service) {
+    return false;
+  }
+  return service
+    .getRuns()
+    .some(
+      (run) =>
+        run.appName === appCanonicalName && isRunStatusActive(run.status),
+    );
 }
 
 /**
@@ -28,9 +51,10 @@ export function hasActiveAppRunForCanonicalName(
  * or a recent dashboard heartbeat for an overlay app (e.g. companion).
  */
 export function isHostedAppActiveForAgentActions(
+  runtime: IAgentRuntime,
   appCanonicalName: string,
 ): boolean {
-  if (hasActiveAppRunForCanonicalName(appCanonicalName)) {
+  if (hasActiveAppRunForCanonicalName(runtime, appCanonicalName)) {
     return true;
   }
   return isOverlayAppPresenceActive(appCanonicalName);
@@ -46,7 +70,7 @@ function gateActions(
     return {
       ...action,
       validate: async (runtime, message, state) => {
-        if (!isHostedAppActiveForAgentActions(appCanonicalName)) {
+        if (!isHostedAppActiveForAgentActions(runtime, appCanonicalName)) {
           return false;
         }
         if (prevValidate) {
@@ -68,7 +92,7 @@ function gateProviders(
     return {
       ...provider,
       get: async (runtime, message, state) => {
-        if (!isHostedAppActiveForAgentActions(appCanonicalName)) {
+        if (!isHostedAppActiveForAgentActions(runtime, appCanonicalName)) {
           return {
             text: "",
             data: { available: false, appSessionInactive: true },

--- a/packages/shared/src/contracts/apps.ts
+++ b/packages/shared/src/contracts/apps.ts
@@ -299,6 +299,24 @@ export interface AppRunActionResult {
   run?: AppRunSummary | null;
 }
 
+/**
+ * Runtime service type under which `@elizaos/plugin-app-manager` registers its
+ * app-run reader. Consumers (e.g. the agent's hosted-app session gate) query
+ * `runtime.getService(APP_SESSION_SERVICE_TYPE)` instead of statically importing
+ * the plugin, keeping the host→plugin dependency direction correct.
+ */
+export const APP_SESSION_SERVICE_TYPE = "app-session";
+
+/**
+ * Contract for the app-session runtime service. Exposes the current AppManager
+ * run snapshot so gate logic can decide whether a hosted app is active without
+ * reaching into the plugin's on-disk store directly.
+ */
+export interface AppSessionServiceLike {
+  /** Current AppManager run snapshot (unfiltered; callers apply status logic). */
+  getRuns(): AppRunSummary[];
+}
+
 export type AppLaunchDiagnosticSeverity = "info" | "warning" | "error";
 
 export interface AppLaunchDiagnostic {

--- a/plugins/plugin-app-manager/src/index.ts
+++ b/plugins/plugin-app-manager/src/index.ts
@@ -27,3 +27,4 @@ export {
   resolveLegacyAppRunStoreFilePath,
   writeAppRunStore,
 } from "./services/app-run-store.ts";
+export { AppSessionService } from "./services/app-session-service.ts";

--- a/plugins/plugin-app-manager/src/services/app-session-service.test.ts
+++ b/plugins/plugin-app-manager/src/services/app-session-service.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { APP_SESSION_SERVICE_TYPE } from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeAppRunStore } from "./app-run-store.ts";
+import { AppSessionService } from "./app-session-service.ts";
+
+const tempDirs: string[] = [];
+
+async function makeStateDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "app-session-service-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function minimalRun(appName: string, status: string) {
+  return {
+    runId: `run-${appName}`,
+    appName,
+    displayName: appName,
+    pluginName: appName,
+    launchType: "hosted",
+    status,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    viewerAttachment: "unavailable",
+    health: { state: "healthy", message: null },
+  };
+}
+
+afterEach(async () => {
+  delete process.env.ELIZA_STATE_DIR;
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("AppSessionService", () => {
+  it("exposes the canonical service type", () => {
+    expect(AppSessionService.serviceType).toBe(APP_SESSION_SERVICE_TYPE);
+  });
+
+  it("getRuns reads the AppManager run store at the resolved state dir", async () => {
+    const dir = await makeStateDir();
+    process.env.ELIZA_STATE_DIR = dir;
+    writeAppRunStore(
+      // biome-ignore lint/suspicious/noExplicitAny: fixture is normalized on read.
+      [minimalRun("@elizaos/plugin-wifi", "running") as any],
+      dir,
+    );
+
+    const service = await AppSessionService.start({} as IAgentRuntime);
+    const runs = service.getRuns();
+
+    expect(runs.map((run) => run.appName)).toContain("@elizaos/plugin-wifi");
+    expect(
+      runs.find((run) => run.appName === "@elizaos/plugin-wifi")?.status,
+    ).toBe("running");
+    await service.stop();
+  });
+
+  it("getRuns returns an empty list when no store exists", async () => {
+    const dir = await makeStateDir();
+    process.env.ELIZA_STATE_DIR = dir;
+    const service = await AppSessionService.start({} as IAgentRuntime);
+    expect(service.getRuns()).toEqual([]);
+    await service.stop();
+  });
+});

--- a/plugins/plugin-app-manager/src/services/app-session-service.ts
+++ b/plugins/plugin-app-manager/src/services/app-session-service.ts
@@ -1,0 +1,37 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { Service } from "@elizaos/core";
+import {
+  APP_SESSION_SERVICE_TYPE,
+  type AppRunSummary,
+  type AppSessionServiceLike,
+} from "@elizaos/shared";
+import { readAppRunStore } from "./app-run-store.ts";
+
+/**
+ * Runtime service exposing the AppManager run store to in-runtime consumers
+ * (the agent's hosted-app session gate) via `runtime.getService`. This inverts
+ * the previous host→plugin static import: the agent no longer imports
+ * `readAppRunStore` from this plugin; it queries this service instead, and
+ * treats its absence as "no active runs".
+ */
+export class AppSessionService
+  extends Service
+  implements AppSessionServiceLike
+{
+  static override serviceType = APP_SESSION_SERVICE_TYPE;
+
+  override capabilityDescription =
+    "Exposes AppManager run state so hosted-app plugins can gate on active sessions.";
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<AppSessionService> {
+    return new AppSessionService(runtime);
+  }
+
+  getRuns(): AppRunSummary[] {
+    return readAppRunStore();
+  }
+
+  override async stop(): Promise<void> {}
+}


### PR DESCRIPTION
## What

Item 17 of #12091 (architecture refactor: dynamic imports & dependency direction).

`packages/agent/src/services/app-session-gate.ts` statically imported `readAppRunStore` from `@elizaos/plugin-app-manager`, inverting the host→plugin dependency direction and forming a **real cycle** (the plugin's `app-run-store.ts` imports `@elizaos/agent/config/paths`). `packages/agent/package.json` declared the workspace dependency.

## Change

- **New `AppSessionService`** (`serviceType: "app-session"`) in `plugin-app-manager`, wrapping `readAppRunStore()`.
- Registered at agent boot via a **dynamic import** in `eliza.ts` (`initializeRuntimeServices`), so there is no static module-graph edge from the host into the plugin.
- The gate now queries `runtime.getService(APP_SESSION_SERVICE_TYPE)` — the gate wrappers (`gateActions`/`gateProviders`) already receive `runtime` — and **treats absence as "no active runs"** (fails open, never throws).
- The service-type constant + `AppSessionServiceLike` contract live once in `@elizaos/shared` (`contracts/apps.ts`, beside `AppRunSummary`), so gate and plugin agree on one interface with no cycle.
- **Removed** the static import and the `@elizaos/plugin-app-manager` workspace dependency from `packages/agent/package.json` (+ `bun.lock`).

## Done-when evidence

- `packages/agent/package.json` no longer lists `@elizaos/plugin-app-manager`:
  ```
  $ grep plugin-app-manager packages/agent/package.json   # no output
  ```
- Gate unchanged with the plugin loaded (active/non-stopped run for the canonical name → open; stopped/foreign → closed); fails open to "no active runs" without it — proven by new tests.

## Tests / typecheck

- New `packages/agent/src/services/app-session-gate.test.ts` — 6 tests (queries the service type; absence → no runs; active run → open; stopped/foreign → closed; gated action/provider pass-through vs block). **6/6 pass.**
- New `plugins/plugin-app-manager/src/services/app-session-service.test.ts` — 3 tests (canonical serviceType; `getRuns` reads the store at the resolved state dir; empty store → `[]`). **3/3 pass.** Existing app-manager suite **15/15 pass.**
- `bun run --cwd packages/agent typecheck` → **0 errors** (after building sibling packages for resolution). `plugins/plugin-app-manager` typecheck clean. Biome clean on all touched files.
- `release-plugin-policy` test still green.

Refs #12091 (item 17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)