### PR TITLE
refactor(app-core): TTS registry metadata-only, drop variable-specifier import (#12091 item 18)

### DIFF
--- a/packages/app-core/src/runtime/ensure-text-to-speech-handler.ts
+++ b/packages/app-core/src/runtime/ensure-text-to-speech-handler.ts
@@ -1,6 +1,7 @@
 import { loadElizaConfig } from "@elizaos/agent";
 import { type AgentRuntime, logger, ModelType } from "@elizaos/core";
 import { formatError } from "@elizaos/shared";
+import { loadDefaultTextToSpeechHandler } from "./tts-default-handler.js";
 import {
   DEFAULT_TEXT_TO_SPEECH_PROVIDER,
   isTextToSpeechProviderDisabled,
@@ -55,7 +56,7 @@ export async function ensureTextToSpeechHandler(
   }
 
   try {
-    const handler = await provider.loadHandler();
+    const handler = await loadDefaultTextToSpeechHandler();
 
     // Wrap the TTS handler with the first-sentence LRU cache so short
     // opener phrases like "Got it." / "Sure!" reuse synthesised bytes across

--- a/packages/app-core/src/runtime/tts-default-handler.ts
+++ b/packages/app-core/src/runtime/tts-default-handler.ts
@@ -1,0 +1,44 @@
+import { ModelType } from "@elizaos/core";
+import type { TtsModelHandler } from "./tts-provider-registry.js";
+
+/**
+ * Guarded, centralized loader for the default (edge-tts) TTS package.
+ *
+ * The primary path is that the edge-tts plugin self-registers its
+ * `ModelType.TEXT_TO_SPEECH` handler on the runtime when it loads (it is a
+ * normal plugin with an `autoEnable` gate and a `models` map). This loader is
+ * only used as the fallback for boot paths where that plugin was not collected,
+ * so streaming / swarm voice can still resolve a handler.
+ *
+ * Unlike the previous registry-driven `import(pluginName)`, the specifier here
+ * is a **string literal**, so bundlers can resolve it (or deliberately stub it)
+ * and it fails at build time rather than silently at runtime. It stays a
+ * *dynamic* import so the optional package is not eagerly pulled into bundles
+ * that never synthesize speech.
+ */
+type EdgeTtsPluginModule = {
+  default?: { models?: Record<string, TtsModelHandler> };
+  edgeTTSPlugin?: { models?: Record<string, TtsModelHandler> };
+};
+
+function readTextToSpeechHandler(
+  mod: EdgeTtsPluginModule,
+): TtsModelHandler | undefined {
+  const handler =
+    mod.default?.models?.[ModelType.TEXT_TO_SPEECH] ??
+    mod.edgeTTSPlugin?.models?.[ModelType.TEXT_TO_SPEECH];
+  return typeof handler === "function" ? handler : undefined;
+}
+
+export async function loadDefaultTextToSpeechHandler(): Promise<TtsModelHandler> {
+  const mod = (await import(
+    "@elizaos/plugin-edge-tts"
+  )) as EdgeTtsPluginModule;
+  const handler = readTextToSpeechHandler(mod);
+  if (!handler) {
+    throw new Error(
+      "@elizaos/plugin-edge-tts did not expose a TEXT_TO_SPEECH handler",
+    );
+  }
+  return handler;
+}

--- a/packages/app-core/src/runtime/tts-provider-registry.test.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.test.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_TEXT_TO_SPEECH_PROVIDER,
   isTextToSpeechProviderDisabled,
 } from "./tts-provider-registry.js";
+
+// ensure-text-to-speech-handler imports loadElizaConfig from the full agent
+// runtime graph; stub it so the seam test stays hermetic (edge-tts is enabled
+// by default → not disabled).
+vi.mock("@elizaos/agent", () => ({ loadElizaConfig: () => ({}) }));
 
 const appCoreRoot = resolve(import.meta.dirname, "../..");
 
@@ -19,14 +24,21 @@ describe("TTS provider registry", () => {
     }
   });
 
-  it("owns the default TTS plugin metadata", () => {
+  it("owns the default TTS plugin metadata only (no importable handler)", () => {
     expect(DEFAULT_TEXT_TO_SPEECH_PROVIDER).toMatchObject({
       pluginName: "@elizaos/plugin-edge-tts",
       pluginConfigKey: "edge-tts",
       providerName: "edge-tts",
       priority: 0,
     });
-    expect(typeof DEFAULT_TEXT_TO_SPEECH_PROVIDER.loadHandler).toBe("function");
+    // The registry entry is metadata-only: it carries no handler-loading
+    // function / importable module path (item 18, #12091). The concrete
+    // handler comes from the loaded plugin's runtime registration; the default
+    // fallback loader lives in tts-default-handler.ts.
+    expect(
+      (DEFAULT_TEXT_TO_SPEECH_PROVIDER as { loadHandler?: unknown }).loadHandler,
+    ).toBeUndefined();
+    expect(typeof DEFAULT_TEXT_TO_SPEECH_PROVIDER.wrapHandler).toBe("function");
   });
 
   it("honors config and env disable controls through the provider config key", () => {
@@ -64,5 +76,41 @@ describe("TTS provider registry", () => {
     expect(registrySource).toContain(
       "@elizaos/registry/first-party/generated.json",
     );
+  });
+
+  it("contains no variable-specifier import() (item 18 done-when)", () => {
+    const registrySource = readFileSync(
+      resolve(appCoreRoot, "src/runtime/tts-provider-registry.ts"),
+      "utf8",
+    );
+    // The old code did `import(this.pluginName)` — a variable specifier that
+    // bundlers cannot resolve. The registry must contain no dynamic import at
+    // all now; provider selection flows through loaded-plugin registration.
+    expect(registrySource).not.toMatch(/\bimport\s*\(/);
+  });
+});
+
+describe("ensureTextToSpeechHandler", () => {
+  it("uses the handler a loaded plugin already registered on the runtime", async () => {
+    const { ensureTextToSpeechHandler } = await import(
+      "./ensure-text-to-speech-handler.js"
+    );
+
+    const preRegistered = async () => new Uint8Array();
+    let registered: unknown;
+    const runtime = {
+      getModel: (_modelType: unknown) => preRegistered,
+      registerModel: (_modelType: unknown, handler: unknown) => {
+        registered = handler;
+      },
+    };
+
+    // A plugin already self-registered TEXT_TO_SPEECH, so ensure must NOT
+    // re-import the package or overwrite the registration.
+    await ensureTextToSpeechHandler(
+      runtime as unknown as Parameters<typeof ensureTextToSpeechHandler>[0],
+    );
+
+    expect(registered).toBeUndefined();
   });
 });

--- a/packages/app-core/src/runtime/tts-provider-registry.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.ts
@@ -1,6 +1,5 @@
 import process from "node:process";
 import type { AgentRuntime } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
 import firstPartyRegistry from "@elizaos/registry/first-party/generated.json" with {
   type: "json",
 };
@@ -20,32 +19,27 @@ export type TtsModelHandler = (
   input: unknown,
 ) => Promise<unknown>;
 
+/**
+ * Metadata-only description of a TTS provider. The concrete handler is NOT
+ * referenced here — voice plugins self-register their `TEXT_TO_SPEECH` handler
+ * on the runtime at plugin load (via their `models` map / `registerModel`), and
+ * the fallback loader for the default provider lives in `tts-default-handler.ts`
+ * behind a bundler-resolvable literal import. This entry carries no importable
+ * module path, so it stays browser-safe and bundler-analyzable.
+ */
 export interface TextToSpeechProviderRegistration {
   pluginName: string;
   pluginConfigKey: string;
   providerName: string;
   priority: number;
-  loadHandler: () => Promise<TtsModelHandler>;
   wrapHandler?: (handler: TtsModelHandler) => Promise<TtsModelHandler | null>;
 }
-
-type TtsPluginModule = {
-  default?: { models?: Record<string, TtsModelHandler> };
-  edgeTTSPlugin?: { models?: Record<string, TtsModelHandler> };
-};
 
 type FirstPartyRegistryEntry = {
   id?: string;
   npmName?: string;
   subtype?: string;
 };
-
-function readHandler(
-  plugin: TtsPluginModule["default"],
-): TtsModelHandler | undefined {
-  const handler = plugin?.models?.[ModelType.TEXT_TO_SPEECH];
-  return typeof handler === "function" ? handler : undefined;
-}
 
 function resolveDefaultTtsPluginName(): string {
   const entries = (
@@ -68,16 +62,6 @@ export const DEFAULT_TEXT_TO_SPEECH_PROVIDER: TextToSpeechProviderRegistration =
     pluginConfigKey: "edge-tts",
     providerName: "edge-tts",
     priority: 0,
-    async loadHandler(): Promise<TtsModelHandler> {
-      const nodeModule = (await import(this.pluginName)) as TtsPluginModule;
-      const handler = readHandler(nodeModule.default);
-      if (!handler) {
-        throw new Error(
-          `${DEFAULT_TEXT_TO_SPEECH_PROVIDER.pluginName} did not expose a TEXT_TO_SPEECH handler`,
-        );
-      }
-      return handler;
-    },
     wrapHandler: (handler) =>
       wrapEdgeTtsHandlerWithFirstLineCache(handler as EdgeTtsHandler),
   };


### PR DESCRIPTION
## What

Part of the #12091 arch-audit (dynamic imports & dependency direction), **item 18**.

`packages/app-core/src/runtime/tts-provider-registry.ts` fed an npm package name from registry JSON into `import(this.pluginName)` — a **variable-specifier** dynamic import that bundlers cannot resolve (fails at runtime with no compile-time signal) — and fished the handler out of `default.models[TEXT_TO_SPEECH]`.

## Change

- The registry entry (`TextToSpeechProviderRegistration` / `DEFAULT_TEXT_TO_SPEECH_PROVIDER`) is now **metadata-only**: `pluginName`, `pluginConfigKey`, `providerName`, `priority`, `wrapHandler`. No handler-loading function, no importable module path. Removed the dead `TtsPluginModule` / `readHandler` helpers and the `ModelType` import that only existed for them.
- Voice plugins already self-register their `TEXT_TO_SPEECH` handler on the runtime at load (`@elizaos/plugin-edge-tts` is a normal plugin with an `autoEnable` gate and a `models` map). `ensureTextToSpeechHandler` prefers that runtime registration (`getModel(TEXT_TO_SPEECH)` early-return) and only falls back to a new centralized loader `tts-default-handler.ts` whose specifier is a **bundler-resolvable string literal** (still a lazy dynamic import so the optional package is not eagerly bundled).

## Done-when evidence

- `tts-provider-registry.ts` contains **no** variable-specifier `import()` — grep-asserted in a new test (`grep -n "import(" … → none`).
- TTS selection works with handlers registered by loaded plugins — new seam test asserts `ensureTextToSpeechHandler` reuses the runtime-registered handler and does not re-register.
- `bun run --cwd packages/app-core vitest run src/runtime/tts-provider-registry.test.ts` → **6/6 pass**.
- `bun run --cwd packages/app-core build` → clean. Touched files typecheck clean (remaining app-core typecheck errors are pre-existing unbuilt-dependency resolution noise in unrelated files).

Refs #12091 (item 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)