### PR TITLE
fix(security): close 5 P0 permission-boundary bypasses from arch audit (#12086)

### DIFF
--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -168,8 +168,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
         // Commands are contributed through the runtime service registered by
         // the commands plugin — no import edge into it, and the service
         // appends without resetting commands other plugins registered.
-        const commands =
-          runtime.getService<CommandRegistryService>("commands");
+        const commands = runtime.getService<CommandRegistryService>("commands");
         if (!commands) return false;
 
         let registered = 0;

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -245,6 +245,10 @@ import {
   PGLITE_ERROR_CODES,
 } from "./pglite-error-compat.ts";
 import { installRuntimePluginLifecycle } from "./plugin-lifecycle.ts";
+import {
+  applyPluginRoleGating,
+  installProviderRoleGatingChokepoint,
+} from "./plugin-role-gating.ts";
 import { validateIntentActionMap } from "./prompt-compaction.ts";
 import rolesPlugin from "./roles.ts";
 import { shouldRegisterSubAgentCredentialsPlugin } from "./sub-agent-credentials-runtime-policy.ts";
@@ -2859,6 +2863,7 @@ interface RuntimeWithMethodBindings extends AgentRuntime {
   __elizaMethodBindingsInstalled?: boolean;
   __elizaComponentWriteDiagnosticsInstalled?: boolean;
   __elizaEntityWriteDiagnosticsInstalled?: boolean;
+  __elizaProviderRoleGatingInstalled?: boolean;
   __elizaEntityCreateMutex?: Promise<void>;
 }
 
@@ -3239,6 +3244,18 @@ export function installRuntimeMethodBindings(runtime: AgentRuntime): void {
 
     runtimeWithBindings.__elizaEntityWriteDiagnosticsInstalled = true;
   }
+
+  // Provider role-gating chokepoint. EVERY plugin registration flows through
+  // runtime.registerPlugin — boot constructor plugins (core calls
+  // this.registerPlugin for each during initialize()), the deferred core-plugin
+  // waves, and post-boot hot-installs via the runtime API
+  // (packages/agent/src/api/plugin-runtime-apply.ts). Gating previously ran only
+  // as a one-shot boot pass, so hot-installed wallet/secrets plugins escaped
+  // redaction and leaked owner/admin-tier context to any sender. Wrapping
+  // registerPlugin gates sensitive providers at registration time, identically
+  // on every path, on both the boot and hot-reload runtimes. Installed here
+  // (before runtime.initialize()) so constructor plugins pass through it too.
+  installProviderRoleGatingChokepoint(runtimeWithBindings);
 
   runtimeWithBindings.__elizaMethodBindingsInstalled = true;
 }
@@ -4824,11 +4841,16 @@ export async function startEliza(
 
   const applyPluginRoleGatingIfAvailable = async (): Promise<void> => {
     try {
-      const { applyPluginRoleGating } = await import("./plugin-role-gating.ts");
+      // Belt-and-suspenders full-graph sweep. The durable enforcement point is
+      // the registerPlugin wrapper in installRuntimeMethodBindings, which gates
+      // each plugin at registration time; this re-gates the whole graph and is
+      // idempotent (already-gated providers are skipped). applyPluginRoleGating
+      // is fail-closed per provider.
       applyPluginRoleGating(runtime.plugins ?? []);
     } catch (err) {
-      logger.debug(
-        `[eliza] Plugin provider role gating skipped: ${formatError(err)}`,
+      // Never silently disable redaction — report loudly at ERROR.
+      logger.error(
+        `[eliza] Plugin provider role gating sweep failed: ${formatError(err)}`,
       );
     }
   };
@@ -5775,13 +5797,15 @@ export async function startEliza(
           );
 
           try {
-            const { applyPluginRoleGating } = await import(
-              "./plugin-role-gating.ts"
-            );
+            // Belt-and-suspenders full-graph sweep; the registerPlugin wrapper
+            // (installed on newRuntime via installRuntimeMethodBindings above)
+            // is the durable enforcement point and already gated each plugin at
+            // registration time. This re-gate is idempotent.
             applyPluginRoleGating(newRuntime.plugins ?? []);
           } catch (err) {
-            logger.debug(
-              `[eliza] Hot-reload plugin provider role gating skipped: ${formatError(err)}`,
+            // Never silently disable redaction — report loudly at ERROR.
+            logger.error(
+              `[eliza] Hot-reload plugin provider role gating sweep failed: ${formatError(err)}`,
             );
           }
 

--- a/packages/agent/src/runtime/plugin-role-gating-chokepoint.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating-chokepoint.test.ts
@@ -1,0 +1,177 @@
+/**
+ * P0 regression: provider role redaction must be enforced at a SINGLE runtime
+ * chokepoint (runtime.registerPlugin), not as a one-shot boot pass. A plugin
+ * registered AFTER boot via the runtime API (the hot-install / hot-reload path
+ * in packages/agent/src/api/plugin-runtime-apply.ts) must have its sensitive
+ * providers redacted identically to boot-registered plugins.
+ *
+ * The fix wraps runtime.registerPlugin via installProviderRoleGatingChokepoint
+ * so that EVERY registration calls `applyPluginRoleGating([plugin])` — boot
+ * constructor plugins, deferred waves, AND post-boot hot-installs. This suite
+ * installs that wrapper on a minimal runtime and drives runtime.registerPlugin
+ * directly, proving:
+ *   1. A plugin gated at boot and a plugin gated post-boot are redacted
+ *      identically.
+ *   2. Gating failure fails CLOSED: a sensitive provider that cannot be wrapped
+ *      is withheld from EVERY caller (even OWNER) and reported at ERROR — never
+ *      silently exposed.
+ */
+import type {
+  IAgentRuntime,
+  Memory,
+  Plugin,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rolesMock = vi.hoisted(() => ({
+  checkSenderRole: vi.fn(),
+}));
+
+vi.mock("./roles.ts", () => rolesMock);
+
+import { installProviderRoleGatingChokepoint } from "./plugin-role-gating.ts";
+
+let runtime: IAgentRuntime & {
+  plugins: Plugin[];
+  registerPlugin(plugin: Plugin): Promise<void>;
+};
+
+function makeRuntime() {
+  const plugins: Plugin[] = [];
+  const nextRuntime = {
+    agentId: "11111111-1111-1111-1111-111111111111",
+    plugins,
+    registerPlugin: vi.fn(async (plugin: Plugin) => {
+      plugins.push(plugin);
+    }),
+  } as unknown as IAgentRuntime & {
+    plugins: Plugin[];
+    registerPlugin(plugin: Plugin): Promise<void>;
+  };
+  installProviderRoleGatingChokepoint(nextRuntime);
+  return nextRuntime;
+}
+
+async function registerViaChokepoint(plugin: Plugin): Promise<void> {
+  await runtime.registerPlugin(plugin);
+}
+
+function message(metadata: Record<string, unknown> = {}): Memory {
+  return {
+    id: "22222222-2222-2222-2222-222222222222",
+    entityId: "33333333-3333-3333-3333-333333333333",
+    roomId: "44444444-4444-4444-4444-444444444444",
+    content: { text: "hi", source: "discord" },
+    metadata,
+  } as Memory;
+}
+
+function provider(name: string): Provider {
+  return {
+    name,
+    get: vi.fn(async () => ({ text: `${name}: visible` })),
+  } as unknown as Provider;
+}
+
+function pluginWithProviders(name: string, providers: Provider[]): Plugin {
+  return { name, providers } as Plugin;
+}
+
+async function callGet(
+  gated: Provider,
+  role: string,
+): Promise<string | undefined> {
+  rolesMock.checkSenderRole.mockResolvedValue({
+    role,
+    isOwner: role === "OWNER",
+    isAdmin: role === "OWNER" || role === "ADMIN",
+  });
+  const result = await gated.get?.(
+    runtime,
+    message({ fromId: "discord-user-1" }),
+    {} as State,
+  );
+  return result?.text;
+}
+
+describe("registerPlugin chokepoint gates post-boot plugins", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+    runtime = makeRuntime();
+  });
+
+  it("gates a plugin registered AFTER boot identically to a boot-registered one", async () => {
+    // "boot" plugin — registered during the initial gating pass.
+    const bootProvider = provider("SECRETS_STATUS"); // admin tier
+    await registerViaChokepoint(
+      pluginWithProviders("boot-plugin", [bootProvider]),
+    );
+
+    // "post-boot" plugin — the exact hot-install path: a later
+    // runtime.registerPlugin with a wallet/secrets provider. Before the fix this
+    // plugin bypassed gating entirely and leaked owner-tier context to everyone.
+    const hotProvider = provider("walletPortfolio"); // owner tier
+    await registerViaChokepoint(
+      pluginWithProviders("hot-wallet-plugin", [hotProvider]),
+    );
+
+    expect(runtime.plugins.map((plugin) => plugin.name)).toEqual([
+      "boot-plugin",
+      "hot-wallet-plugin",
+    ]);
+
+    // Boot-registered admin provider: redacted below ADMIN, visible at/above.
+    expect(await callGet(bootProvider, "GUEST")).toBe("");
+    expect(await callGet(bootProvider, "USER")).toBe("");
+    expect(await callGet(bootProvider, "ADMIN")).toBe(
+      "SECRETS_STATUS: visible",
+    );
+
+    // Post-boot owner provider: redacted for everyone below OWNER, visible for
+    // OWNER — identical enforcement to the boot-registered provider.
+    expect(await callGet(hotProvider, "GUEST")).toBe("");
+    expect(await callGet(hotProvider, "USER")).toBe("");
+    expect(await callGet(hotProvider, "ADMIN")).toBe("");
+    expect(await callGet(hotProvider, "OWNER")).toBe(
+      "walletPortfolio: visible",
+    );
+  });
+
+  it("leaves non-sensitive providers untouched", async () => {
+    const plain = provider("someHarmlessProvider");
+    await registerViaChokepoint(pluginWithProviders("plain-plugin", [plain]));
+    expect(await callGet(plain, "GUEST")).toBe("someHarmlessProvider: visible");
+  });
+
+  it("fails CLOSED: a sensitive provider that cannot be wrapped is withheld from everyone", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    // A sensitive provider whose `get` is a read-only data property, so
+    // gateProvider's reassignment throws. The fail-closed path must withhold it
+    // rather than register it exposed.
+    const original = vi.fn(
+      async (): Promise<ProviderResult> => ({ text: "walletPortfolio: leak" }),
+    );
+    const locked = { name: "walletPortfolio" } as unknown as Provider;
+    Object.defineProperty(locked, "get", {
+      value: original,
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+
+    await registerViaChokepoint(pluginWithProviders("locked-plugin", [locked]));
+
+    // Even an OWNER must NOT see the content — proves it was withheld, not merely
+    // gated (a normally-gated owner provider is visible to OWNER).
+    expect(await callGet(locked, "OWNER")).toBe("");
+    // ...and the failure was reported loudly (ERROR), not silently dropped.
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -228,13 +228,59 @@ function gateProvider(provider: Provider, tier: RoleGateTier): void {
 }
 
 /**
- * Apply role gating to all registered plugins. Call after runtime.initialize().
+ * Hard-withhold a provider's output. Used as the fail-closed fallback when a
+ * sensitive provider cannot be gated normally: rather than leaving its original
+ * `get` exposed (fail-open), replace it with one that returns no content for
+ * every caller so owner/admin-tier context can never leak.
+ */
+function withholdProvider(provider: Provider): void {
+  const redact = async (): Promise<ProviderResult> => ({ text: "" });
+  try {
+    provider.get = redact;
+  } catch {
+    // `get` may be a read-only data property; force-replace it when the
+    // property is configurable so withholding still wins over exposure.
+    Object.defineProperty(provider, "get", {
+      value: redact,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+  // Mark as gated at the strictest tier so a subsequent pass treats it as done.
+  try {
+    (provider as { __roleGate?: RoleGateTier }).__roleGate = "owner";
+  } catch {
+    // Best-effort marker only; the withholding above already applied.
+  }
+}
+
+function withholdSensitiveProviders(plugin: Plugin): number {
+  let withheld = 0;
+  for (const provider of plugin.providers ?? []) {
+    const providerName = (provider as { name?: string }).name ?? "";
+    if (!PROVIDER_ROLE_OVERRIDES[providerName]) continue;
+    withholdProvider(provider);
+    withheld++;
+  }
+  return withheld;
+}
+
+/**
+ * Apply role gating to the given plugins. Safe to call repeatedly and per
+ * plugin: `gateProvider` is idempotent (already-gated providers are skipped),
+ * so this doubles as the register-time chokepoint hook.
  *
  * Providers in PROVIDER_ROLE_OVERRIDES get gated. Actions are intentionally
  * not wrapped here; use action.roleGate.
+ *
+ * Fail-closed: if wrapping a sensitive provider throws, its content is withheld
+ * entirely and the failure is logged at ERROR — redaction is never silently
+ * disabled.
  */
 export function applyPluginRoleGating(plugins: Plugin[]): void {
-  let totalProviders = 0;
+  let gatedProviders = 0;
+  let withheldProviders = 0;
 
   for (const plugin of plugins) {
     // Gate providers
@@ -242,17 +288,77 @@ export function applyPluginRoleGating(plugins: Plugin[]): void {
       for (const provider of plugin.providers) {
         const providerName = (provider as { name?: string }).name ?? "";
         const providerTier = PROVIDER_ROLE_OVERRIDES[providerName];
-        if (providerTier) {
+        if (!providerTier) continue;
+        try {
           gateProvider(provider, providerTier);
-          totalProviders++;
+          gatedProviders++;
+        } catch (err) {
+          // Fail closed: a sensitive provider we could not wrap must not be
+          // exposed. Withhold its content and report loudly — never silently
+          // leave redaction disabled.
+          withholdProvider(provider);
+          withheldProviders++;
+          logger.error(
+            `[role-gating] Failed to gate sensitive provider "${providerName}" (tier=${providerTier}); withholding its content to fail closed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
         }
       }
     }
   }
 
-  if (totalProviders > 0) {
-    logger.info(`[role-gating] Total: ${totalProviders} provider(s) gated`);
+  if (gatedProviders > 0) {
+    logger.info(`[role-gating] Total: ${gatedProviders} provider(s) gated`);
   }
+  if (withheldProviders > 0) {
+    logger.error(
+      `[role-gating] ${withheldProviders} sensitive provider(s) withheld after a gating failure (fail-closed)`,
+    );
+  }
+}
+
+type ProviderRoleGatingRuntime = Pick<IAgentRuntime, "registerPlugin"> & {
+  __elizaProviderRoleGatingInstalled?: boolean;
+};
+
+/**
+ * Install the durable provider-gating chokepoint on runtime.registerPlugin so
+ * boot-time plugins and post-boot hot-installs are gated identically.
+ */
+export function installProviderRoleGatingChokepoint(
+  runtime: ProviderRoleGatingRuntime,
+): void {
+  if (runtime.__elizaProviderRoleGatingInstalled) return;
+
+  const originalRegisterPlugin = runtime.registerPlugin.bind(runtime);
+  runtime.registerPlugin = async (plugin: Plugin): Promise<void> => {
+    try {
+      applyPluginRoleGating([plugin]);
+    } catch (err) {
+      let withheld = 0;
+      try {
+        withheld = withholdSensitiveProviders(plugin);
+      } catch (withholdErr) {
+        logger.error(
+          `[role-gating] Provider role-gating failed for plugin "${plugin?.name}" and sensitive provider withholding also failed; blocking registration to fail closed: ${
+            withholdErr instanceof Error
+              ? withholdErr.message
+              : String(withholdErr)
+          }`,
+        );
+        throw err;
+      }
+      logger.error(
+        `[role-gating] Provider role-gating failed for plugin "${plugin?.name}"; withheld ${withheld} sensitive provider(s) to fail closed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    return originalRegisterPlugin(plugin);
+  };
+
+  runtime.__elizaProviderRoleGatingInstalled = true;
 }
 
 /** Exported for testing. */

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -455,33 +455,29 @@ async function resolveAuthorizedRouteRole(
 
   if (isTrustedLocalRequest(req)) return { ok: true, role: "OWNER" };
 
-  const db = options.state?.current?.adapter?.db;
-  const store = options.store
-    ? options.store
-    : db
-      ? new AuthStore(db as ConstructorParameters<typeof AuthStore>[0])
-      : null;
-  if (!db) {
+  const state = "state" in options ? options.state : undefined;
+  const db = state?.current?.adapter?.db;
+  const store =
+    "store" in options && options.store
+      ? options.store
+      : db
+        ? new AuthStore(db as ConstructorParameters<typeof AuthStore>[0])
+        : null;
+
+  if (!store) {
     const expectedToken = getCompatApiToken();
-    if (!store && !expectedToken) {
+    if (!expectedToken) {
       recordFailedAuth(ip);
       return { ok: false, status: 401, reason: "Unauthorized" };
     }
 
     const providedToken = getProvidedApiToken(req);
-    if (
-      !store &&
-      expectedToken &&
-      providedToken &&
-      tokenMatches(expectedToken, providedToken)
-    ) {
+    if (providedToken && tokenMatches(expectedToken, providedToken)) {
       return { ok: true, role: "OWNER" };
     }
 
-    if (!store) {
-      recordFailedAuth(ip);
-      return { ok: false, status: 401, reason: "Unauthorized" };
-    }
+    recordFailedAuth(ip);
+    return { ok: false, status: 401, reason: "Unauthorized" };
   }
 
   const method = (req.method ?? "GET").toUpperCase();
@@ -539,8 +535,8 @@ async function resolveAuthorizedRouteRole(
       resolveEmbedPrincipal(
         req,
         options.now,
-        "state" in options
-          ? (key) => readEmbedSessionSecretSetting(options.state.current, key)
+        state
+          ? (key) => readEmbedSessionSecretSetting(state.current, key)
           : options.readSetting,
       ),
     );

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -1,28 +1,118 @@
 import http from "node:http";
 import { Socket } from "node:net";
-import { describe, expect, it, vi } from "vitest";
-import type { CompatRuntimeState } from "./compat-route-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
 
-const sharedMocks = vi.hoisted(() => ({
+// This suite drives the REAL `ensureRouteMinRole` (via the real `./auth.ts`)
+// through the route handler, mocking only the session-resolution primitives.
+// The point is the P0 gate: raw table reads must require OWNER, so a USER-role
+// session must be rejected with 403 before any SQL runs. The explicit
+// `ensureOwner` dependency seam is also covered so local route tests can avoid
+// pulling the full auth graph when they do not need it.
+
+const mocks = vi.hoisted(() => ({
   executeRawSql: vi.fn(),
+  findActiveSession: vi.fn(),
+  findIdentity: vi.fn(),
+  verifyCsrfToken: vi.fn(),
 }));
 
-vi.mock("@elizaos/shared", async () => {
-  return {
-    executeRawSql: sharedMocks.executeRawSql,
-    quoteIdent: (value: string) => `"${value.replaceAll('"', '""')}"`,
-    sanitizeIdentifier: (value: string | null | undefined) =>
-      value?.replace(/[^a-zA-Z0-9_]/g, "") || null,
-    sqlLiteral: (value: string) => `'${value.replaceAll("'", "''")}'`,
-  };
-});
+vi.mock("@elizaos/core", () => ({
+  roleRank: (role: string | undefined) =>
+    (
+      ({
+        NONE: 0,
+        GUEST: 1,
+        USER: 2,
+        MEMBER: 2,
+        ADMIN: 3,
+        OWNER: 4,
+      }) as Record<string, number>
+    )[role ?? "NONE"] ?? 0,
+}));
 
-function makeReq(url: string): http.IncomingMessage {
+vi.mock("@elizaos/shared", () => ({
+  executeRawSql: mocks.executeRawSql,
+  quoteIdent: (value: string) => `"${String(value).replace(/"/g, '""')}"`,
+  resolveApiToken: (env: NodeJS.ProcessEnv) =>
+    env.ELIZA_API_TOKEN?.trim() || null,
+  sanitizeIdentifier: (value: string | null | undefined) => {
+    if (value == null) return null;
+    const trimmed = String(value).trim();
+    return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(trimmed) ? trimmed : null;
+  },
+  sqlLiteral: (value: unknown) => `'${String(value).replace(/'/g, "''")}'`,
+}));
+
+// Avoid loading the heavy @elizaos/agent config graph through the compat route.
+// For these tests, every request must resolve through the session/role path
+// rather than the ambient trusted-loopback OWNER short-circuit.
+vi.mock("./compat-route-shared", () => ({
+  DATABASE_UNAVAILABLE_MESSAGE: "Database unavailable",
+  isTrustedLocalRequest: () => false,
+}));
+
+vi.mock("./auth/sessions.js", () => ({
+  CSRF_HEADER_NAME: "x-eliza-csrf",
+  findActiveSession: mocks.findActiveSession,
+  verifyCsrfToken: mocks.verifyCsrfToken,
+}));
+
+vi.mock("../services/auth-store.js", () => ({
+  AuthStore: class MockAuthStore {
+    findIdentity = mocks.findIdentity;
+  },
+}));
+
+const STATE_WITHOUT_DB = {
+  current: null,
+} as unknown as Parameters<typeof handleDatabaseRowsCompatRoute>[2];
+
+const STATE_WITH_DB = {
+  current: { adapter: { db: {} } },
+} as unknown as Parameters<typeof handleDatabaseRowsCompatRoute>[2];
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    createdAt: 0,
+    csrfSecret: "csrf-secret",
+    expiresAt: Date.now() + 60_000,
+    id: "session-id",
+    identityId: "identity-id",
+    ip: null,
+    kind: "browser",
+    lastSeenAt: 0,
+    rememberDevice: false,
+    revokedAt: null,
+    scopes: [],
+    userAgent: null,
+    ...overrides,
+  };
+}
+
+function makeIdentity(kind: "owner" | "machine") {
+  return {
+    cloudUserId: null,
+    createdAt: 0,
+    displayName: kind,
+    id: `${kind}-identity`,
+    kind,
+    passwordHash: null,
+  };
+}
+
+function makeReq(
+  headers: http.IncomingHttpHeaders = {},
+  url = "/api/database/tables/secrets/rows?schema=public",
+): http.IncomingMessage {
   const req = new http.IncomingMessage(new Socket());
   req.method = "GET";
   req.url = url;
-  req.headers = { host: "localhost:3000" };
+  req.headers = { host: "example.test:2138", ...headers };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    configurable: true,
+    value: "203.0.113.9",
+  });
   return req;
 }
 
@@ -37,25 +127,53 @@ function fakeRes() {
     return res;
   }) as typeof res.end;
   return {
+    json: () => (body ? JSON.parse(body) : null),
     res,
     status: () => res.statusCode,
-    json: () => (body ? JSON.parse(body) : null),
   };
 }
 
-function makeState(
-  current: CompatRuntimeState["current"] = null,
-): CompatRuntimeState {
-  return {
-    current,
-    pendingAgentName: null,
-    pendingRestartReasons: [],
-  };
+function resetMocks(): void {
+  mocks.executeRawSql.mockReset();
+  mocks.findActiveSession.mockReset();
+  mocks.findIdentity.mockReset();
+  mocks.verifyCsrfToken.mockReset();
+  mocks.verifyCsrfToken.mockReturnValue(true);
 }
+
+// Canned introspection + read results so the OWNER path can complete without a
+// real database.
+function stubReadableTable() {
+  mocks.executeRawSql.mockImplementation(async (_runtime, sql: string) => {
+    if (sql.includes("information_schema.columns")) {
+      return { rows: [{ column_name: "id" }, { column_name: "value" }] };
+    }
+    if (sql.includes("count(*)")) {
+      return { rows: [{ total: 2 }] };
+    }
+    return {
+      rows: [
+        { id: 1, value: "a" },
+        { id: 2, value: "b" },
+      ],
+    };
+  });
+}
+
+beforeEach(() => {
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  resetMocks();
+});
+
+afterEach(() => {
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+});
 
 describe("handleDatabaseRowsCompatRoute", () => {
-  it("requires OWNER role before raw table rows can be read", async () => {
-    const req = makeReq("/api/database/tables/secrets/rows");
+  it("passes OWNER to the injected gate before raw table rows can be read", async () => {
+    const req = makeReq({}, "/api/database/tables/secrets/rows");
     const res = fakeRes();
     const ensureOwner = vi.fn(async (_req, routeRes) => {
       routeRes.statusCode = 403;
@@ -64,7 +182,9 @@ describe("handleDatabaseRowsCompatRoute", () => {
     });
 
     await expect(
-      handleDatabaseRowsCompatRoute(req, res.res, makeState(), { ensureOwner }),
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITHOUT_DB, {
+        ensureOwner,
+      }),
     ).resolves.toBe(true);
 
     expect(ensureOwner).toHaveBeenCalledWith(
@@ -75,16 +195,18 @@ describe("handleDatabaseRowsCompatRoute", () => {
     );
     expect(res.status()).toBe(403);
     expect(res.json()).toEqual({ error: "Insufficient role" });
-    expect(sharedMocks.executeRawSql).not.toHaveBeenCalled();
+    expect(mocks.executeRawSql).not.toHaveBeenCalled();
   });
 
-  it("continues route handling after OWNER authorization succeeds", async () => {
-    const req = makeReq("/api/database/tables/memories/rows");
+  it("continues route handling after the injected OWNER gate succeeds", async () => {
+    const req = makeReq({}, "/api/database/tables/memories/rows");
     const res = fakeRes();
     const ensureOwner = vi.fn(async () => true);
 
     await expect(
-      handleDatabaseRowsCompatRoute(req, res.res, makeState(), { ensureOwner }),
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITHOUT_DB, {
+        ensureOwner,
+      }),
     ).resolves.toBe(true);
 
     expect(ensureOwner).toHaveBeenCalledWith(
@@ -94,9 +216,61 @@ describe("handleDatabaseRowsCompatRoute", () => {
       "OWNER",
     );
     expect(res.status()).toBe(503);
-    expect(res.json()).toEqual({
-      error:
-        "Database not available. The agent may not be running or the database adapter is not initialized.",
+    expect(res.json()).toEqual({ error: "Database unavailable" });
+  });
+});
+
+describe("GET /api/database/tables/:name/rows OWNER gate", () => {
+  it("rejects a USER-role machine session with 403 and never reads the table", async () => {
+    // A machine identity resolves to the USER tier: an active session, but
+    // not OWNER. Before the fix this reached raw SELECT * FROM <table>; now
+    // it must be denied at the gate.
+    mocks.findActiveSession.mockResolvedValue(
+      makeSession({ id: "machine-session", kind: "machine" }),
+    );
+    mocks.findIdentity.mockResolvedValue(makeIdentity("machine"));
+
+    const req = makeReq({ authorization: "Bearer machine-session" });
+    const res = fakeRes();
+
+    const handled = await handleDatabaseRowsCompatRoute(
+      req,
+      res.res,
+      STATE_WITH_DB,
+    );
+
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(403);
+    expect(res.json()).toEqual({ error: "Insufficient role" });
+    expect(mocks.executeRawSql).not.toHaveBeenCalled();
+  });
+
+  it("allows an OWNER session to read rows", async () => {
+    mocks.findActiveSession.mockResolvedValue(makeSession());
+    mocks.findIdentity.mockResolvedValue(makeIdentity("owner"));
+    stubReadableTable();
+
+    const req = makeReq({ cookie: "eliza_session=owner-session" });
+    const res = fakeRes();
+
+    const handled = await handleDatabaseRowsCompatRoute(
+      req,
+      res.res,
+      STATE_WITH_DB,
+    );
+
+    expect(handled).toBe(true);
+    expect(res.status()).toBe(200);
+    expect(res.json()).toMatchObject({
+      columns: ["id", "value"],
+      rows: [
+        { id: 1, value: "a" },
+        { id: 2, value: "b" },
+      ],
+      schema: "public",
+      table: "secrets",
+      total: 2,
     });
+    expect(mocks.executeRawSql).toHaveBeenCalled();
   });
 });

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -66,6 +66,9 @@ export async function handleDatabaseRowsCompatRoute(
   }
 
   const ensureOwner = deps.ensureOwner ?? ensureRouteMinRole;
+  // Raw table reads expose arbitrary tables (secrets, sessions, identities),
+  // so this must require OWNER - matching the sibling `/api/secrets/*` routes -
+  // rather than accepting any active session.
   if (!(await ensureOwner(req, res, state, "OWNER"))) {
     return true;
   }

--- a/packages/app-core/src/api/dev-boot-history.test.ts
+++ b/packages/app-core/src/api/dev-boot-history.test.ts
@@ -7,10 +7,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // getLastFailedPluginDetails() accessor from @elizaos/agent — not by re-reading
 // a private globalThis symbol. Mock the accessor to prove the wiring
 // (Refs #12091 items 30/31).
+type FailedPluginDetail = { name: string; error: string };
+
 const { getLastFailedPluginDetails } = vi.hoisted(() => ({
-  getLastFailedPluginDetails: vi.fn<[], { name: string; error: string }[]>(
-    () => [],
-  ),
+  getLastFailedPluginDetails: vi.fn<() => FailedPluginDetail[]>(() => []),
 }));
 
 vi.mock("@elizaos/agent", () => ({

--- a/packages/app-core/src/runtime/tts-default-handler.ts
+++ b/packages/app-core/src/runtime/tts-default-handler.ts
@@ -31,9 +31,7 @@ function readTextToSpeechHandler(
 }
 
 export async function loadDefaultTextToSpeechHandler(): Promise<TtsModelHandler> {
-  const mod = (await import(
-    "@elizaos/plugin-edge-tts"
-  )) as EdgeTtsPluginModule;
+  const mod = (await import("@elizaos/plugin-edge-tts")) as EdgeTtsPluginModule;
   const handler = readTextToSpeechHandler(mod);
   if (!handler) {
     throw new Error(

--- a/packages/app-core/src/runtime/tts-provider-registry.test.ts
+++ b/packages/app-core/src/runtime/tts-provider-registry.test.ts
@@ -36,7 +36,8 @@ describe("TTS provider registry", () => {
     // handler comes from the loaded plugin's runtime registration; the default
     // fallback loader lives in tts-default-handler.ts.
     expect(
-      (DEFAULT_TEXT_TO_SPEECH_PROVIDER as { loadHandler?: unknown }).loadHandler,
+      (DEFAULT_TEXT_TO_SPEECH_PROVIDER as { loadHandler?: unknown })
+        .loadHandler,
     ).toBeUndefined();
     expect(typeof DEFAULT_TEXT_TO_SPEECH_PROVIDER.wrapHandler).toBe("function");
   });

--- a/packages/app-core/src/services/connector-target-catalog.test.ts
+++ b/packages/app-core/src/services/connector-target-catalog.test.ts
@@ -1,4 +1,4 @@
-import type { TargetEnumerationContext, TargetSource } from "@elizaos/core";
+import type { TargetSource } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   createElizaConnectorTargetCatalog,
@@ -68,7 +68,9 @@ describe("createElizaConnectorTargetCatalog", () => {
   });
 
   it("forwards groupId + getConfig + fetch/clock seams into enumerate", async () => {
-    const enumerate = vi.fn(async () => DISCORD_GROUPS);
+    const enumerate = vi.fn<TargetSource["enumerate"]>(
+      async () => DISCORD_GROUPS,
+    );
     const getConfig = () => ({ connectors: { discord: { token: "tok" } } });
     const fetchImpl = (async () => new Response()) as unknown as typeof fetch;
     const now = () => 123;
@@ -83,7 +85,8 @@ describe("createElizaConnectorTargetCatalog", () => {
     });
     await catalog.listGroups({ platform: "discord", groupId: "g1" });
 
-    const ctx = enumerate.mock.calls[0]?.[0] as TargetEnumerationContext;
+    const ctx = enumerate.mock.calls.at(0)?.[0];
+    if (!ctx) throw new Error("expected enumerate to receive a context");
     expect(ctx.groupId).toBe("g1");
     expect(ctx.getConfig).toBe(getConfig);
     expect(ctx.fetchImpl).toBe(fetchImpl);

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -527,7 +527,12 @@ describe("live routing regressions", () => {
 		const leanChatActions: Array<Pick<Action, "name" | "similes" | "tags">> = [
 			{
 				name: "TERMINAL_SHELL",
-				similes: ["RUN_IN_TERMINAL", "EXECUTE_COMMAND", "TERMINAL", "RUN_SHELL"],
+				similes: [
+					"RUN_IN_TERMINAL",
+					"EXECUTE_COMMAND",
+					"TERMINAL",
+					"RUN_SHELL",
+				],
 			},
 			{ name: "REPLY", similes: ["RESPOND"] },
 		];

--- a/packages/core/src/cloud-routing.ts
+++ b/packages/core/src/cloud-routing.ts
@@ -9,7 +9,7 @@ export type {
 export {
 	cloudServiceApisBaseUrl,
 	isCloudConnected,
-	resolveCloudRoute,
 	type RuntimeSettings as CloudRuntimeSettings,
+	resolveCloudRoute,
 	toRuntimeSettings,
 } from "@elizaos/cloud-routing";

--- a/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
+++ b/packages/core/src/features/basic-capabilities/dm-owner-grant.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { hasRoleAccess } from "../../roles.ts";
+import type { IAgentRuntime, Memory } from "../../types";
+import { EventType } from "../../types/events.ts";
+import { ChannelType } from "../../types/primitives.ts";
+import { createBasicCapabilitiesPlugin } from "./index.ts";
+
+/**
+ * P0 regression: the DM-world setup in `syncSingleUser` used to hardcode
+ * `ownership.ownerId = <sender>` + `roles[<sender>] = OWNER` for ANY DM world.
+ * With no canonical owner configured (ELIZA_ADMIN_ENTITY_ID unset — the
+ * DEFAULT), roles.ts then promoted EVERY DM sender to OWNER, clearing every
+ * `minRole: OWNER` gate (including SECRETS). Ownership must be granted ONLY to a
+ * configured owner, via roles.ts's `recordOwnerGrant`.
+ */
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+const OWNER_ID = "11111111-1111-1111-1111-111111111111";
+const STRANGER_ID = "22222222-2222-2222-2222-222222222222";
+const ROOM_ID = "33333333-3333-3333-3333-333333333333";
+const SERVER_ID = "44444444-4444-4444-4444-444444444444";
+
+type CapturedConnection = { metadata?: Record<string, unknown> };
+
+/**
+ * Drive the real ENTITY_JOINED handler for a DM from `entityId` and return the
+ * world metadata the handler passes to `ensureConnection`, plus a runtime that
+ * serves that metadata back through `getWorld`/`getRoom` so the downstream
+ * roles.ts resolution can be exercised on exactly what the handler produced.
+ */
+async function syncDmAndBuildResolutionRuntime(
+	entityId: string,
+	settings: Record<string, string | undefined>,
+): Promise<{
+	metadata: Record<string, unknown> | undefined;
+	runtime: IAgentRuntime;
+}> {
+	const captured: CapturedConnection[] = [];
+	const logger = {
+		debug() {},
+		info() {},
+		success() {},
+		warn() {},
+		error() {},
+	};
+
+	const syncRuntime = {
+		agentId: AGENT_ID,
+		character: { name: "TestAgent" },
+		logger,
+		getSetting: (key: string) => settings[key],
+		getEntitiesByIds: async () => [null],
+		getWorldsByIds: async () => [null],
+		ensureConnection: async (params: CapturedConnection) => {
+			captured.push(params);
+		},
+	} as unknown as IAgentRuntime;
+
+	const plugin = createBasicCapabilitiesPlugin();
+	const handler = plugin.events?.[EventType.ENTITY_JOINED]?.[0];
+	if (!handler) throw new Error("ENTITY_JOINED handler not registered");
+
+	await handler({
+		runtime: syncRuntime,
+		entityId,
+		worldId: SERVER_ID,
+		roomId: ROOM_ID,
+		metadata: { type: ChannelType.DM },
+		source: "client_chat",
+	} as never);
+
+	expect(captured).toHaveLength(1);
+	const metadata = captured[0]?.metadata;
+
+	// A runtime that resolves messages against exactly the captured world
+	// metadata, so hasRoleAccess/roles.ts sees what the handler wrote.
+	const resolutionRuntime = {
+		agentId: AGENT_ID,
+		logger,
+		getSetting: (key: string) => settings[key],
+		getRoom: async () => ({ id: ROOM_ID, worldId: SERVER_ID }),
+		getWorld: async () => ({ id: SERVER_ID, metadata }),
+		getEntityById: async () => null,
+		getRelationships: async () => [],
+	} as unknown as IAgentRuntime;
+
+	return { metadata, runtime: resolutionRuntime };
+}
+
+function dmMessage(entityId: string): Memory {
+	return {
+		entityId,
+		roomId: ROOM_ID,
+		content: { text: "hi", source: "client_chat" },
+	} as unknown as Memory;
+}
+
+describe("basic-capabilities DM world ownership (P0 permission bypass)", () => {
+	it("does NOT grant OWNER to a stranger DMing the agent when no owner is configured", async () => {
+		const { metadata, runtime } = await syncDmAndBuildResolutionRuntime(
+			STRANGER_ID,
+			{}, // DEFAULT config: ELIZA_ADMIN_ENTITY_ID unset
+		);
+
+		// No hardcoded owner grant on the world.
+		const roles = (metadata?.roles ?? {}) as Record<string, string>;
+		const ownership = metadata?.ownership as { ownerId?: string } | undefined;
+		expect(roles[STRANGER_ID]).toBeUndefined();
+		expect(ownership?.ownerId).toBeUndefined();
+
+		// And the stranger cannot clear a minRole: OWNER gate (e.g. SECRETS).
+		const msg = dmMessage(STRANGER_ID);
+		expect(await hasRoleAccess(runtime, msg, "OWNER")).toBe(false);
+		expect(await hasRoleAccess(runtime, msg, "ADMIN")).toBe(false);
+		// Basic USER-tier access is still allowed.
+		expect(await hasRoleAccess(runtime, msg, "GUEST")).toBe(true);
+	});
+
+	it("grants OWNER to a CONFIGURED owner DMing the agent", async () => {
+		const { metadata, runtime } = await syncDmAndBuildResolutionRuntime(
+			OWNER_ID,
+			{ ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		);
+
+		// Explicit, auditable owner grant recorded via recordOwnerGrant.
+		const roles = (metadata?.roles ?? {}) as Record<string, string>;
+		const roleSources = (metadata?.roleSources ?? {}) as Record<string, string>;
+		const ownership = metadata?.ownership as { ownerId?: string } | undefined;
+		expect(roles[OWNER_ID]).toBe("OWNER");
+		expect(roleSources[OWNER_ID]).toBe("owner");
+		expect(ownership?.ownerId).toBe(OWNER_ID);
+
+		// The configured owner clears the OWNER gate.
+		expect(await hasRoleAccess(runtime, dmMessage(OWNER_ID), "OWNER")).toBe(
+			true,
+		);
+	});
+
+	it("does NOT grant OWNER to a stranger even when a DIFFERENT owner is configured", async () => {
+		const { metadata, runtime } = await syncDmAndBuildResolutionRuntime(
+			STRANGER_ID,
+			{ ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		);
+
+		const roles = (metadata?.roles ?? {}) as Record<string, string>;
+		expect(roles[STRANGER_ID]).toBeUndefined();
+		expect(await hasRoleAccess(runtime, dmMessage(STRANGER_ID), "OWNER")).toBe(
+			false,
+		);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -19,6 +19,11 @@ import {
 	imageDescriptionTemplate,
 	postCreationTemplate,
 } from "../../prompts.ts";
+import {
+	getConfiguredOwnerEntityIds,
+	type RolesWorldMetadata,
+	recordOwnerGrant,
+} from "../../roles.ts";
 import { TURN_CONTROL_ROUTES } from "../../runtime/turn-routes";
 import { SensitiveRequestDispatchRegistryService } from "../../sensitive-requests/dispatch-registry.ts";
 import {
@@ -39,7 +44,6 @@ import { OptimizedPromptService } from "../../services/optimized-prompt.ts";
 import { resolveOptimizedPromptForRuntime } from "../../services/optimized-prompt-resolver.ts";
 import { TaskService } from "../../services/task.ts";
 import { TargetSourceRegistryService } from "../../target-sources/registry.ts";
-import type { Role } from "../../types/environment.ts";
 import { EventType } from "../../types/events.ts";
 import type {
 	ActionEventPayload,
@@ -69,7 +73,11 @@ import type {
 import { MemoryType } from "../../types/memory.ts";
 import { ModelType } from "../../types/model.ts";
 import type { ServiceClass } from "../../types/plugin.ts";
-import { ChannelType, ContentType } from "../../types/primitives.ts";
+import {
+	ChannelType,
+	ContentType,
+	type JsonValue,
+} from "../../types/primitives.ts";
 import {
 	composePromptFromState,
 	getLocalServerUrl,
@@ -89,8 +97,6 @@ import {
 } from "../autonomy/providers.ts";
 import { autonomyRoutes } from "../autonomy/routes.ts";
 import { AutonomyService } from "../autonomy/service.ts";
-
-const ROLE_OWNER: Role = "OWNER";
 
 // Re-export action and provider modules
 export * from "./actions/index.ts";
@@ -813,18 +819,24 @@ const syncSingleUser = async (
 	const roomId = createUniqueUuid(runtime, channelId);
 	const worldId = createUniqueUuid(runtime, messageServerId);
 
-	const worldMetadata =
-		type === ChannelType.DM
-			? {
-					ownership: {
-						ownerId: entityId,
-					},
-					roles: {
-						[entityId]: ROLE_OWNER,
-					},
-					settings: {}, // Initialize empty settings for setup
-				}
-			: undefined;
+	// DM worlds get an empty settings bucket for setup. Ownership is NOT granted
+	// to whoever happens to be DMing the agent: hardcoding
+	// `ownership.ownerId = entityId` + `roles[entityId] = OWNER` here promoted
+	// EVERY DM sender to OWNER (clearing every `minRole: OWNER` gate, including
+	// SECRETS) whenever no canonical owner was configured — the default. Owner
+	// resolution belongs to roles.ts. Only record an OWNER grant when this sender
+	// is a CONFIGURED owner (ELIZA_ADMIN_ENTITY_ID / owner contacts), via the
+	// sanctioned `recordOwnerGrant` API (explicit + auditable, #9948); otherwise
+	// leave the world ownerless so the sender resolves to a non-OWNER role.
+	let worldMetadata: Record<string, JsonValue> | undefined;
+	if (type === ChannelType.DM) {
+		const dmMetadata: Record<string, JsonValue> = { settings: {} };
+		if (getConfiguredOwnerEntityIds(runtime).includes(entityId)) {
+			dmMetadata.ownership = { ownerId: entityId };
+			recordOwnerGrant(dmMetadata as unknown as RolesWorldMetadata, entityId);
+		}
+		worldMetadata = dmMetadata;
+	}
 
 	runtime.logger.info(
 		{

--- a/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
+++ b/packages/core/src/plugin-lifecycle.context-role-gate.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
+import { ContextRegistry } from "./runtime/context-registry";
+import {
+	_resetActionRolePolicyCacheForTests,
+	executePlannedToolCall,
+} from "./runtime/execute-planned-tool-call";
+import type { Action, IAgentRuntime, Memory, UUID } from "./types";
+
+/**
+ * FIX 2 (#12089): an action's effective roleGate must be derived through the
+ * PER-RUNTIME context registry so a context registered at runtime by a plugin
+ * (via `runtime.contexts.register(...)`) with `roleGate.minRole = OWNER`
+ * participates in the gate. Previously the derivation read a module-level
+ * snapshot of only the first-party defaults, so a plugin context was invisible
+ * and the effective gate silently collapsed to USER — a permission bypass.
+ */
+
+const noop = () => undefined;
+
+function makeLifecycleRuntime(
+	contexts: ContextRegistry,
+): IAgentRuntime & { actions: Action[] } {
+	const runtime = {
+		agentId: "00000000-0000-0000-0000-0000000000a1" as UUID,
+		actions: [] as Action[],
+		contexts,
+		logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		registerAction(action: Action) {
+			runtime.actions.push(action);
+		},
+		registerPlugin: async () => undefined,
+		registerProvider: noop,
+		registerEvaluator: noop,
+		registerShortcut: noop,
+		registerModel: noop,
+		registerEvent: noop,
+		registerService: async () => undefined,
+		registerDatabaseAdapter: noop,
+	};
+	return runtime as unknown as IAgentRuntime & { actions: Action[] };
+}
+
+function msg(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000b1" as UUID,
+		entityId: "00000000-0000-0000-0000-0000000000c1" as UUID,
+		roomId: "00000000-0000-0000-0000-0000000000d1" as UUID,
+		content: { text: "run it" },
+	} as unknown as Memory;
+}
+
+describe("action roleGate resolves plugin-registered contexts (#12089)", () => {
+	afterEach(() => {
+		_resetActionRolePolicyCacheForTests();
+	});
+
+	it("derives an OWNER effective roleGate from a plugin-registered context", () => {
+		const contexts = new ContextRegistry();
+		contexts.register({ id: "plugin_billing", roleGate: { minRole: "OWNER" } });
+		const runtime = makeLifecycleRuntime(contexts);
+		installRuntimePluginLifecycle(runtime);
+
+		runtime.registerAction({
+			name: "REFUND",
+			description: "issue a refund",
+			contexts: ["plugin_billing"],
+			validate: async () => true,
+			handler: async () => ({ success: true }),
+		});
+
+		const stamped = runtime.actions.find((a) => a.name === "REFUND");
+		expect(stamped?.roleGate).toEqual({ minRole: "OWNER" });
+	});
+
+	it("blocks a USER but admits an OWNER at the planned-tool-call gate", async () => {
+		const contexts = new ContextRegistry();
+		contexts.register({ id: "plugin_billing", roleGate: { minRole: "OWNER" } });
+		const runtime = makeLifecycleRuntime(contexts);
+		installRuntimePluginLifecycle(runtime);
+
+		const handler = vi.fn(async () => ({ success: true }));
+		runtime.registerAction({
+			name: "REFUND",
+			description: "issue a refund",
+			contexts: ["plugin_billing"],
+			validate: async () => true,
+			handler,
+		});
+
+		const blocked = await executePlannedToolCall(
+			runtime,
+			{
+				message: msg(),
+				activeContexts: ["plugin_billing"],
+				userRoles: ["USER"],
+			},
+			{ name: "REFUND", params: {} },
+		);
+		expect(blocked.success).toBe(false);
+		expect(handler).not.toHaveBeenCalled();
+
+		const allowed = await executePlannedToolCall(
+			runtime,
+			{
+				message: msg(),
+				activeContexts: ["plugin_billing"],
+				userRoles: ["OWNER"],
+			},
+			{ name: "REFUND", params: {} },
+		);
+		expect(allowed.success).toBe(true);
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/plugin-lifecycle.ts
+++ b/packages/core/src/plugin-lifecycle.ts
@@ -1,5 +1,4 @@
 import { roleRank } from "./runtime/context-gates";
-import { DEFAULT_CONTEXT_DEFINITIONS } from "./runtime/default-contexts";
 import type { AgentContext, RoleGate, RoleGateRole } from "./types/contexts";
 import type { RegisteredEvaluator } from "./types/evaluator";
 import type {
@@ -284,19 +283,22 @@ function applyEffectiveActionContexts(
 	};
 }
 
-const DEFAULT_CONTEXT_ROLE_BY_ID = new Map(
-	DEFAULT_CONTEXT_DEFINITIONS.map((definition) => [
-		String(definition.id),
-		definition.roleGate?.minRole,
-	]),
-);
-
+/**
+ * Derive an action's effective role gate from the role gates declared by the
+ * contexts it is tagged with. Resolution goes through the PER-RUNTIME context
+ * registry (`runtime.contexts`) so contexts registered at runtime by plugins
+ * via `runtime.contexts.register(...)` participate — not just the first-party
+ * defaults. (Previously this read a module-level snapshot of the default
+ * contexts, so a plugin-registered context declaring `minRole: OWNER` was
+ * invisible and the gate silently collapsed to USER — a permission bypass.)
+ */
 function roleGateForActionContexts(
+	runtime: IAgentRuntime,
 	contexts: readonly AgentContext[] | undefined,
 ): RoleGate {
 	let minRole: RoleGateRole = "USER";
 	for (const context of contexts ?? []) {
-		const contextRole = DEFAULT_CONTEXT_ROLE_BY_ID.get(String(context));
+		const contextRole = runtime.contexts.get(context)?.roleGate?.minRole;
 		if (contextRole && roleRank(contextRole) > roleRank(minRole)) {
 			minRole = contextRole;
 		}
@@ -305,16 +307,22 @@ function roleGateForActionContexts(
 }
 
 function applyEffectiveActionAccess(
+	runtime: IAgentRuntime,
 	action: RuntimeAction,
 	pluginContexts: Plugin["contexts"] | undefined,
 ): RuntimeAction {
 	const withContexts = applyEffectiveActionContexts(action, pluginContexts);
 	const roleGate =
-		withContexts.roleGate ?? roleGateForActionContexts(withContexts.contexts);
+		withContexts.roleGate ??
+		roleGateForActionContexts(runtime, withContexts.contexts);
 	const subActions = withContexts.subActions?.map((subAction) =>
 		typeof subAction === "string"
 			? subAction
-			: applyEffectiveActionAccess(subAction as RuntimeAction, undefined),
+			: applyEffectiveActionAccess(
+					runtime,
+					subAction as RuntimeAction,
+					undefined,
+				),
 	);
 
 	if (withContexts === action) {
@@ -771,7 +779,11 @@ export function installRuntimePluginLifecycle(runtime: IAgentRuntime): void {
 		const capture = pluginRegistrationContext.getStore();
 		const actionsBefore = runtimeWithLifecycle.actions.length;
 		originalRegisterAction(
-			applyEffectiveActionAccess(action, capture?.ownership.plugin.contexts),
+			applyEffectiveActionAccess(
+				runtimeWithLifecycle,
+				action,
+				capture?.ownership.plugin.contexts,
+			),
 		);
 		if (!capture || runtimeWithLifecycle.actions.length <= actionsBefore)
 			return;

--- a/packages/core/src/plugins/native-features.test.ts
+++ b/packages/core/src/plugins/native-features.test.ts
@@ -13,9 +13,9 @@ import {
 // self-consistent (which is what makes the generic loop pick the features up),
 // and that the two folded-in features default OFF (flag is an explicit override).
 describe("native runtime feature registry (#12092 item 32)", () => {
-	const features = Object.keys(
-		nativeRuntimeFeatureDefaults,
-	) as Array<keyof typeof nativeRuntimeFeatureDefaults>;
+	const features = Object.keys(nativeRuntimeFeatureDefaults) as Array<
+		keyof typeof nativeRuntimeFeatureDefaults
+	>;
 
 	it("includes advancedPlanning and advancedMemory, defaulting OFF", () => {
 		expect(nativeRuntimeFeatureDefaults.advancedPlanning).toBe(false);

--- a/packages/core/src/plugins/native-features.ts
+++ b/packages/core/src/plugins/native-features.ts
@@ -10,6 +10,8 @@ import { advancedContactsProvider } from "../features/advanced-capabilities/prov
 import { factsProvider } from "../features/advanced-capabilities/providers/facts";
 import { followUpsProvider } from "../features/advanced-capabilities/providers/followUps";
 import { relationshipsProvider } from "../features/advanced-capabilities/providers/relationships";
+import { createAdvancedMemoryPlugin } from "../features/advanced-memory/index";
+import { createAdvancedPlanningPlugin } from "../features/advanced-planning/index";
 import {
 	__setDocumentUrlFetchImplForTests,
 	DocumentService,
@@ -20,8 +22,6 @@ import {
 	fetchDocumentFromUrl,
 	isYouTubeUrl,
 } from "../features/documents/index";
-import { createAdvancedMemoryPlugin } from "../features/advanced-memory/index";
-import { createAdvancedPlanningPlugin } from "../features/advanced-planning/index";
 import { trajectoriesPlugin } from "../features/trajectories/index";
 import { FollowUpService } from "../services/followUp";
 import { RelationshipsService } from "../services/relationships";

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -510,7 +510,17 @@ function actionResultToStreamingResult(
 
 export const _resetActionRolePolicyCacheForTests = _resetCacheForTests;
 
-function getGateFailure(
+/**
+ * The single authoritative access gate for running an action's handler.
+ * Enforces (in order): the private-action turn gate, ACTION_ROLE_POLICY, the
+ * action's contextGate, and the action's roleGate. Returns a human-readable
+ * reason string when the action must be blocked, or `undefined` when allowed.
+ *
+ * Exported so alternate execution entry points (e.g. the pre-LLM shortcut gate
+ * in services/message.ts) enforce the exact same policy instead of duplicating
+ * it — callers MUST supply already-resolved `ctx.userRoles`.
+ */
+export function getGateFailure(
 	action: Action,
 	ctx: ExecutePlannedToolCallContext,
 ): string | undefined {

--- a/packages/core/src/services/message.shortcut-gate.test.ts
+++ b/packages/core/src/services/message.shortcut-gate.test.ts
@@ -241,4 +241,82 @@ describe("runShortcutGate (#8791 pre-LLM gate)", () => {
 		);
 		expect(shortcutEvents).toHaveLength(1);
 	});
+
+	it("blocks a USER from an OWNER-gated action reached via a shortcut (#12088)", async () => {
+		// The shortcut deliberately omits requiresElevated, so registry.match()
+		// admits it for a USER — the target action's declared roleGate is now the
+		// only thing standing between a USER and the OWNER-gated handler.
+		const handler = vi.fn(async () => ({ success: true, text: "secret" }));
+		const gatedAction: Action = {
+			name: "OWNER_ONLY_ACTION",
+			description: "owner only",
+			roleGate: { minRole: "OWNER" },
+			validate: async () => true,
+			handler,
+		};
+		const { runtime, useModel } = makeRuntime({ actions: [gatedAction] });
+		(runtime.shortcutRegistry as ShortcutRegistry).register({
+			id: "cmd:owner",
+			kind: "explicit",
+			aliases: ["/owner"],
+			target: { kind: "action", name: "OWNER_ONLY_ACTION" },
+		});
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/owner secrets"),
+			state: {} as State,
+			responseId,
+			senderRole: "USER",
+		});
+
+		// getGateFailure rejects the USER before validate/handler run: the gate
+		// falls through to the normal pipeline (which enforces the gate again).
+		expect(result).toBeNull();
+		expect(handler).not.toHaveBeenCalled();
+		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	it("still runs the same OWNER-gated shortcut action for an OWNER sender (#12088)", async () => {
+		const handler = vi.fn(
+			async (
+				_rt: unknown,
+				_m: unknown,
+				_s: unknown,
+				_o: unknown,
+				callback?: (content: { text: string }) => Promise<unknown>,
+			) => {
+				if (callback) await callback({ text: "secret-value" });
+				return { success: true, text: "secret-value" };
+			},
+		);
+		const gatedAction: Action = {
+			name: "OWNER_ONLY_ACTION",
+			description: "owner only",
+			roleGate: { minRole: "OWNER" },
+			validate: async () => true,
+			// biome-ignore lint/suspicious/noExplicitAny: handler spy shape
+			handler: handler as any,
+		};
+		const { runtime } = makeRuntime({ actions: [gatedAction] });
+		(runtime.shortcutRegistry as ShortcutRegistry).register({
+			id: "cmd:owner",
+			kind: "explicit",
+			aliases: ["/owner"],
+			target: { kind: "action", name: "OWNER_ONLY_ACTION" },
+		});
+
+		const result = await runShortcutGate({
+			// biome-ignore lint/suspicious/noExplicitAny: minimal fake runtime
+			runtime: runtime as any,
+			message: msg("/owner secrets"),
+			state: {} as State,
+			responseId,
+			senderRole: "OWNER",
+		});
+
+		expect(result?.kind).toBe("direct_reply");
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -75,6 +75,7 @@ import {
 	type ExecutePlannedToolCallContext,
 	type ExecutePlannedToolCallOptions,
 	executePlannedToolCall,
+	getGateFailure,
 } from "../runtime/execute-planned-tool-call";
 import {
 	type FactsAndRelationshipsRunResult,
@@ -5649,6 +5650,35 @@ export async function runShortcutGate(args: {
 
 	const action = args.runtime.actions.find((a) => a.name === target.name);
 	if (!action) return null;
+
+	// #8791/#12088: enforce the SAME access gate the planned-tool-call path
+	// applies (getGateFailure) BEFORE validating or running the target action.
+	// The shortcut path previously reached action.handler based only on the
+	// shortcut's own requiresAuth/requiresElevated flags, so a USER could hit an
+	// OWNER-gated action (e.g. SECRETS) via a shortcut lacking requiresElevated.
+	// The action's own contexts are treated as active — mirroring
+	// executeV5PlannedToolCall — so enforcement reduces to the declared
+	// role/context gates with identical strength to the planner path.
+	const gateFailure = getGateFailure(action, {
+		message: args.message,
+		state: args.state,
+		activeContexts: mergeAgentContexts(undefined, action.contexts),
+		userRoles: [args.senderRole],
+		previousResults: [],
+	});
+	if (gateFailure) {
+		args.runtime.logger?.debug?.(
+			{
+				src: "shortcut-gate",
+				shortcut: match.shortcut.id,
+				action: action.name,
+				senderRole: args.senderRole,
+				gateFailure,
+			},
+			"shortcut target blocked by action gate; falling through to pipeline",
+		);
+		return null;
+	}
 
 	let valid = false;
 	try {


### PR DESCRIPTION
Closes the **5 P0 permission-boundary bypasses** from the architecture audit (#12086). Each finding is a case where a declared access gate was silently not enforced. All five are individually fixed, covered by focused tests, and rebased onto current `develop`.

## Fixes

| # | Bug | Issue | Files |
|---|-----|-------|-------|
| 1 | **Shortcut gate bypassed roleGate/contextGate** — `runShortcutGate` reached `action.handler` based only on the shortcut's own `requiresAuth`/`requiresElevated` flags, never calling `getGateFailure`; a USER could hit an OWNER-gated action via a shortcut. | #12087 | `core/src/services/message.ts`, `execute-planned-tool-call.ts` |
| 2 | **Action roleGate ignored plugin-registered contexts** — `roleGateForActionContexts` read a module-level snapshot of default contexts, so an action tagged with a plugin context declaring `minRole: OWNER` fell back to USER. | #12089 | `core/src/plugin-lifecycle.ts` |
| 3 | **basic-capabilities auto-granted OWNER to every DM sender** — DM worlds hardcoded `ownership.ownerId` + `roles[entityId]=OWNER`, promoting any DM sender to OWNER when no canonical owner was configured. | #12087 | `core/src/features/basic-capabilities/index.ts` |
| 4 | **Provider role redaction was a one-shot boot pass** — sensitive-provider redaction ran once at boot; plugins hot-installed via the runtime API escaped it, and a gating import error failed open silently. | #12087 | `agent/src/runtime/eliza.ts`, `plugin-role-gating.ts` |
| 5 | **Raw DB table reads gated by any-session auth, not OWNER** — `GET /api/database/tables/:name/rows` reads arbitrary tables but only required an active session. | #12088 | `app-core/src/api/database-rows-compat-routes.ts` |

## Approach

- Export the single authoritative `getGateFailure` and enforce it on the shortcut path before `validate`/`handler`, matching the planned-tool-call path.
- Resolve context role gates through the per-runtime context registry (`runtime.contexts`), not a static default-context map.
- Grant OWNER for DM worlds only when the sender is a configured owner, using `recordOwnerGrant`; otherwise leave the DM world ownerless.
- Wrap `runtime.registerPlugin` so provider role-gating covers boot and hot-install paths, and fail closed with ERROR-level logging when gating cannot be applied.
- Require OWNER via `ensureRouteMinRole` for raw DB row reads.

## Local Validation

Validated at head `50120e31388` rebased on `develop` `bbf9e6c05bf`.

- `git diff --check` — passed
- `bun run --cwd packages/core typecheck` — passed
- `bun run --cwd packages/agent typecheck` — passed
- `bun run --cwd packages/app-core typecheck` — passed
- `bun run --cwd packages/plugin-remote-manifest typecheck` — passed
- `bun run --cwd packages/core lint` — passed
- `bun run --cwd packages/agent lint` — passed
- `bun run --cwd packages/app-core lint` — passed
- `bun run --cwd packages/plugin-remote-manifest lint` — passed
- `bun run --cwd packages/core test -- message.shortcut-gate.test.ts plugin-lifecycle.context-role-gate.test.ts dm-owner-grant.test.ts` — 3 files / 15 tests passed
- `bun run --cwd packages/agent test -- plugin-role-gating-chokepoint.test.ts` — 1 file / 3 tests passed (known package export-order warning only)
- `bun run --cwd packages/app-core test -- database-rows-compat-routes.test.ts connector-target-catalog.test.ts` — 2 files / 10 tests passed
- `bun run --cwd packages/plugin-remote-manifest test` — 139 tests passed

## Notes

- During rebase, `develop` added route `publicReason` serialization and connector target catalog typing changes; this branch includes the required local type fixes so `agent` and `app-core` typecheck cleanly on the current base.
- Existing persisted DM worlds created before this fix may still contain stale owner metadata. This PR prevents new unsafe grants and covers the runtime path; a data migration would need to mutate existing user state deliberately.
