### PR TITLE
fix(bench): load benchmark plugins via the sanctioned resolver, not cwd escapes (#12091 item 32)

### DIFF
--- a/packages/app-core/src/benchmark/server.ts
+++ b/packages/app-core/src/benchmark/server.ts
@@ -1,7 +1,9 @@
 import crypto from "node:crypto";
 import http from "node:http";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { CORE_PLUGINS } from "@elizaos/agent/runtime/core-plugins";
+import { createElizaPlugin } from "@elizaos/agent/runtime/eliza-plugin";
+import { resolveElizaPluginImportSpecifier } from "@elizaos/agent/runtime/plugin-types";
 import {
   AgentRuntime,
   type ChatMessage,
@@ -19,8 +21,6 @@ import {
   type ToolDefinition,
 } from "@elizaos/core";
 import dotenv from "dotenv";
-import { CORE_PLUGINS } from "../../../agent/src/runtime/core-plugins.ts";
-import { createElizaPlugin } from "../../../agent/src/runtime/eliza-plugin.ts";
 import { autoWireCerebras } from "./cerebras-autowire.js";
 import {
   LifeOpsBenchHandler,
@@ -1615,24 +1615,9 @@ export async function startBenchmarkServer() {
       continue;
     }
     try {
-      let pluginModule: Record<string, unknown>;
-      try {
-        pluginModule = (await import(pluginName)) as Record<string, unknown>;
-      } catch (error) {
-        if (pluginName !== "@elizaos/plugin-sql") {
-          throw error;
-        }
-        const fallbackPath = path.resolve(
-          process.cwd(),
-          "../../plugins/plugin-sql/src/index.ts",
-        );
-        elizaLogger.warn(
-          `[bench] @elizaos/plugin-sql package entry is unavailable; falling back to workspace source at ${fallbackPath}`,
-        );
-        pluginModule = (await import(
-          pathToFileURL(fallbackPath).href
-        )) as Record<string, unknown>;
-      }
+      const pluginModule = (await import(
+        resolveElizaPluginImportSpecifier(pluginName)
+      )) as Record<string, unknown>;
       const plugin =
         pluginModule.default ?? pluginModule[Object.keys(pluginModule)[0]];
       if (plugin) {
@@ -1848,18 +1833,16 @@ export async function startBenchmarkServer() {
     try {
       process.env.COMPUTER_USE_ENABLED ??= "1";
       process.env.COMPUTERUSE_MODE ??= "local";
-      const localComputerusePath =
-        "../../../../plugins/plugin-computeruse/src/index.ts";
-      const computeruseModule = (await import(localComputerusePath)) as Record<
-        string,
-        unknown
-      >;
+      const computeruseName = "@elizaos/plugin-computeruse";
+      const computeruseModule = (await import(
+        resolveElizaPluginImportSpecifier(computeruseName)
+      )) as Record<string, unknown>;
       const computerusePlugin =
         computeruseModule.computerusePlugin ??
         computeruseModule.computerUsePlugin ??
         computeruseModule.default;
       if (computerusePlugin) {
-        plugins.push(toPlugin(computerusePlugin, localComputerusePath));
+        plugins.push(toPlugin(computerusePlugin, computeruseName));
         elizaLogger.info(
           "[bench] Loaded local plugin: @elizaos/plugin-computeruse",
         );
@@ -1902,12 +1885,8 @@ export async function startBenchmarkServer() {
     benchName === "social-alpha";
   if (enableSocialAlphaPlugin) {
     try {
-      const socialAlphaSrcPath = path.resolve(
-        process.cwd(),
-        "../../plugins/plugin-social-alpha/src/index.ts",
-      );
       const socialAlphaModule = (await import(
-        pathToFileURL(socialAlphaSrcPath).href
+        resolveElizaPluginImportSpecifier("@elizaos/plugin-social-alpha")
       )) as Record<string, unknown>;
       const socialAlphaPlugin =
         socialAlphaModule.socialAlphaPlugin ?? socialAlphaModule.default;


### PR DESCRIPTION
## What

Item 32 of #12091 (architecture refactor: dynamic imports & dependency direction).

`packages/app-core/src/benchmark/server.ts` did computed-specifier `import()` over a hardcoded plugin list with a `process.cwd()`-relative escape into `../../plugins/plugin-sql/src/index.ts` (only resolvable when the process starts from `packages/app-core`), plus two more `../../plugins/.../src/index.ts` escapes (computeruse, social-alpha), and imported `CORE_PLUGINS` / `createElizaPlugin` directly from `../../../agent/src/...`.

## Change

- Route every plugin load through **`resolveElizaPluginImportSpecifier`** (`@elizaos/agent/runtime/plugin-types`) — it returns a workspace-override `file://` URL when a local dist build exists, otherwise the **bare package specifier**; both are cwd-independent (bare specifiers resolve relative to the importing module, never `process.cwd()`).
- **Dropped** the cwd-relative plugin-sql `src` fallback and the two other `../../plugins/` `src` imports (computeruse, social-alpha now load by package name).
- Import `CORE_PLUGINS` / `createElizaPlugin` through the **`@elizaos/agent` package export map** (`@elizaos/agent/runtime/*`) instead of reaching into its `src/` — consistent with how the file already imports `@elizaos/core`.
- Removed the now-unused `pathToFileURL` import.

## Done-when evidence

```
$ grep -n "\.\./\.\./plugins/" packages/app-core/src/benchmark/server.ts   # no output
$ grep -n "agent/src/"        packages/app-core/src/benchmark/server.ts   # no output
```
- No bespoke name-list fallback loop remains; the loop delegates specifier resolution to the sanctioned resolver.
- **Runs from any cwd** — verified at runtime with cwd = repo root (not `packages/app-core`):
  ```
  resolved specifier: @elizaos/plugin-sql
  imported plugin name: @elizaos/plugin-sql
  cwd was: /home/shaw/eliza-worktrees/w1-item17-32
  ```
  The old `path.resolve(process.cwd(), "../../plugins/...")` fallback would have failed from this cwd.

## Tests / typecheck

- `bun run --cwd packages/app-core typecheck` → **0 errors in `benchmark/server.ts`** (remaining app-core errors are pre-existing unbuilt-`@elizaos/capacitor-*` / `plugin-anthropic` module-resolution noise, unrelated to this change).
- All benchmark tests that import `server.ts` pass: `server-utils` (16), `role-seeding` + `server-role-seeding` (24) — **40/40**.
- Biome clean on the touched file.

Refs #12091 (item 32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)