### PR TITLE
refactor(core): model mobile device bridge as a runtime Service (#12091 item 35)

### DIFF
--- a/packages/agent/src/external-modules.d.ts
+++ b/packages/agent/src/external-modules.d.ts
@@ -1,30 +1,12 @@
 declare module "@elizaos/plugin-agent-orchestrator";
 declare module "@elizaos/plugin-capacitor-bridge" {
   import type { Server } from "node:http";
-  import type { AgentRuntime } from "@elizaos/core";
+  import type {
+    AgentRuntime,
+    MobileDeviceBridgeStatus,
+  } from "@elizaos/core";
 
-  export interface MobileDeviceBridgeStatus {
-    enabled: boolean;
-    connected: boolean;
-    devices: Array<{
-      deviceId: string;
-      capabilities: {
-        platform: "ios" | "android" | "web";
-        deviceModel: string;
-        totalRamGb: number;
-        cpuCores: number;
-        gpu: {
-          backend: "metal" | "vulkan" | "gpu-delegate";
-          available: boolean;
-        } | null;
-      };
-      loadedPath: string | null;
-      connectedSince: string;
-    }>;
-    primaryDeviceId: string | null;
-    pendingRequests: number;
-    modelPath: string | null;
-  }
+  export type { MobileDeviceBridgeStatus };
 
   export const mobileDeviceBridge: unknown;
   export function getMobileDeviceBridgeStatus(): MobileDeviceBridgeStatus;

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -156,6 +156,7 @@ export * from "./markdown";
 export * from "./media";
 export * from "./memory";
 export * from "./messaging/interactions";
+export * from "./mobile-device-bridge-service";
 export * from "./model-gateway";
 // Export network utilities (SSRF protection, secure fetch)
 export * from "./network";

--- a/packages/core/src/mobile-device-bridge-service.ts
+++ b/packages/core/src/mobile-device-bridge-service.ts
@@ -1,0 +1,55 @@
+import { Service, ServiceType } from "./types/service";
+
+/**
+ * Status snapshot of the mobile-device inference bridge (the host that relays
+ * on-device GPU inference to a paired phone).
+ *
+ * This is the single canonical definition of the bridge contract. The mobile
+ * host implements it as a runtime {@link MobileDeviceBridgeService}; consumers
+ * read it back via `runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE)`.
+ */
+export interface MobileDeviceBridgeStatus {
+	enabled: boolean;
+	connected: boolean;
+	devices: Array<{
+		deviceId: string;
+		capabilities: {
+			platform: "ios" | "android" | "web";
+			deviceModel: string;
+			totalRamGb: number;
+			cpuCores: number;
+			gpu: {
+				backend: "metal" | "vulkan" | "gpu-delegate";
+				available: boolean;
+			} | null;
+		};
+		loadedPath: string | null;
+		connectedSince: string;
+	}>;
+	primaryDeviceId: string | null;
+	pendingRequests: number;
+	modelPath: string | null;
+}
+
+/**
+ * Runtime service contract for the mobile device bridge.
+ *
+ * The mobile host (e.g. `@elizaos/plugin-capacitor-bridge`) registers a
+ * concrete subclass via a plugin `services` array; consumers resolve it with
+ * `runtime.getService<MobileDeviceBridgeService>(ServiceType.MOBILE_DEVICE_BRIDGE)`.
+ * There is no global/`Symbol.for` slot — registration flows through the normal
+ * service registry so it is typed, per-runtime, and never last-writer-wins.
+ */
+export abstract class MobileDeviceBridgeService extends Service {
+	static override serviceType: typeof ServiceType.MOBILE_DEVICE_BRIDGE =
+		ServiceType.MOBILE_DEVICE_BRIDGE;
+
+	abstract getMobileDeviceBridgeStatus(): MobileDeviceBridgeStatus;
+
+	abstract loadMobileDeviceBridgeModel(
+		modelPath: string,
+		modelId?: string,
+	): Promise<void>;
+
+	abstract unloadMobileDeviceBridgeModel(): Promise<void>;
+}

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -40,6 +40,7 @@ export interface ServiceTypeRegistry {
 	OPTIMIZED_PROMPT: "optimized_prompt";
 	CHANNEL_TOPICS: "channel_topics";
 	COMMANDS: "commands";
+	MOBILE_DEVICE_BRIDGE: "mobile_device_bridge";
 	UNKNOWN: "unknown";
 }
 
@@ -136,6 +137,7 @@ export const ServiceType = {
 	OPTIMIZED_PROMPT: "optimized_prompt",
 	CHANNEL_TOPICS: "channel_topics",
 	COMMANDS: "commands",
+	MOBILE_DEVICE_BRIDGE: "mobile_device_bridge",
 	UNKNOWN: "unknown",
 } as const;
 

--- a/plugins/plugin-capacitor-bridge/src/index.ts
+++ b/plugins/plugin-capacitor-bridge/src/index.ts
@@ -7,8 +7,12 @@ export async function runIosBridgeCli(argv?: string[]): Promise<void> {
 	const { runIosBridgeCli } = await import("./ios/bridge.js");
 	await runIosBridgeCli(argv);
 }
+import type { Plugin } from "@elizaos/core";
+import { CapacitorMobileDeviceBridgeService } from "./mobile-device-bridge-bootstrap.js";
+
 export {
 	attachMobileDeviceBridgeToServer,
+	CapacitorMobileDeviceBridgeService,
 	ensureMobileDeviceBridgeInferenceHandlers,
 	getMobileDeviceBridgeStatus,
 	loadMobileDeviceBridgeModel,
@@ -16,6 +20,19 @@ export {
 	mobileDeviceBridge,
 	unloadMobileDeviceBridgeModel,
 } from "./mobile-device-bridge-bootstrap.js";
+
+/**
+ * Mobile-host plugin: registers the device bridge as a runtime service so
+ * consumers resolve it via `runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE)`.
+ */
+export const mobileDeviceBridgePlugin: Plugin = {
+	name: "capacitor-bridge",
+	description:
+		"Registers the mobile device inference bridge as a runtime service.",
+	services: [CapacitorMobileDeviceBridgeService],
+};
+
+export default mobileDeviceBridgePlugin;
 export {
 	getMobileWorkspaceRoot,
 	installMobileFsShim,

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -37,6 +37,8 @@ import {
 	inferenceRamClassFromEnv,
 	type LocalInferencePriority,
 	logger,
+	MobileDeviceBridgeService,
+	type MobileDeviceBridgeStatus,
 	ModelType,
 	resolveBackgroundInferenceBudget,
 	resolveStateDir,
@@ -334,19 +336,7 @@ interface BundledModelManifest {
 	models?: BundledModelManifestEntry[];
 }
 
-export interface MobileDeviceBridgeStatus {
-	enabled: boolean;
-	connected: boolean;
-	devices: Array<{
-		deviceId: string;
-		capabilities: DeviceCapabilities;
-		loadedPath: string | null;
-		connectedSince: string;
-	}>;
-	primaryDeviceId: string | null;
-	pendingRequests: number;
-	modelPath: string | null;
-}
+export type { MobileDeviceBridgeStatus };
 
 class MobileDeviceBridge {
 	private wss: WssInstance | null = null;
@@ -1889,6 +1879,41 @@ export async function loadMobileDeviceBridgeModel(
 
 export async function unloadMobileDeviceBridgeModel(): Promise<void> {
 	await mobileDeviceBridge.unloadModel();
+}
+
+/**
+ * Runtime service wrapper over the module-level {@link mobileDeviceBridge}
+ * singleton. Registering this via a plugin `services` array lets consumers
+ * resolve the bridge with
+ * `runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE)` instead of reaching a
+ * global `Symbol.for` slot or dynamically importing this module by name.
+ */
+export class CapacitorMobileDeviceBridgeService extends MobileDeviceBridgeService {
+	capabilityDescription =
+		"Relays on-device GPU inference to a paired mobile device over the device bridge.";
+
+	static async start(
+		runtime: IAgentRuntime,
+	): Promise<CapacitorMobileDeviceBridgeService> {
+		return new CapacitorMobileDeviceBridgeService(runtime);
+	}
+
+	getMobileDeviceBridgeStatus(): MobileDeviceBridgeStatus {
+		return mobileDeviceBridge.status();
+	}
+
+	async loadMobileDeviceBridgeModel(
+		modelPath: string,
+		modelId?: string,
+	): Promise<void> {
+		await loadMobileDeviceBridgeModel(modelPath, modelId);
+	}
+
+	async unloadMobileDeviceBridgeModel(): Promise<void> {
+		await unloadMobileDeviceBridgeModel();
+	}
+
+	async stop(): Promise<void> {}
 }
 
 export async function attachMobileDeviceBridgeToServer(

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-service.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-service.test.ts
@@ -1,0 +1,44 @@
+// Item 35 (#12091): the mobile device bridge is modeled as a runtime Service
+// (ServiceType.MOBILE_DEVICE_BRIDGE) registered by the mobile-host plugin and
+// consumed via runtime.getService — NOT via the deleted core Symbol.for slot.
+import { AgentRuntime, ServiceType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	CapacitorMobileDeviceBridgeService,
+	mobileDeviceBridgePlugin,
+} from "./index";
+
+describe("mobile device bridge runtime service", () => {
+	it("exposes the canonical serviceType and plugin registration", () => {
+		expect(CapacitorMobileDeviceBridgeService.serviceType).toBe(
+			ServiceType.MOBILE_DEVICE_BRIDGE,
+		);
+		expect(mobileDeviceBridgePlugin.services).toContain(
+			CapacitorMobileDeviceBridgeService,
+		);
+	});
+
+	it("registers on a real runtime under the canonical service type", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.registerPlugin(mobileDeviceBridgePlugin);
+
+		// Proves the mobile host plugin registered a service that consumers can
+		// resolve via runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE).
+		expect(runtime.hasService(ServiceType.MOBILE_DEVICE_BRIDGE)).toBe(true);
+		expect(runtime.getRegisteredServiceTypes()).toContain(
+			ServiceType.MOBILE_DEVICE_BRIDGE,
+		);
+	});
+
+	it("implements the typed bridge contract", async () => {
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		const svc = await CapacitorMobileDeviceBridgeService.start(runtime);
+		expect(svc).toBeInstanceOf(CapacitorMobileDeviceBridgeService);
+
+		const status = svc.getMobileDeviceBridgeStatus();
+		expect(status).toBeDefined();
+		expect(Array.isArray(status.devices)).toBe(true);
+		expect(typeof status.connected).toBe("boolean");
+		expect(typeof status.enabled).toBe("boolean");
+	});
+});


### PR DESCRIPTION
## What

Part of the #12091 arch-audit (dynamic imports & dependency direction), **item 35**.

Core exported a `Symbol.for("elizaos.mobile-device-bridge.hooks")` global hook slot for a product-specific mobile bridge contract with **zero in-repo callers** of register/get; plugins reach the bridge via dynamic import of `plugin-capacitor-bridge`, and untyped copies of the `MobileDeviceBridgeStatus` contract were duplicated across plugins (last-writer-wins).

> Note: `develop` already deleted the dead `mobile-device-bridge-hooks.ts` slot file, but did **not** provide a typed replacement and still carries the duplicated `MobileDeviceBridgeStatus` copies. This PR supplies the canonical Service contract and de-duplicates.

## Change

- **core**: new `MobileDeviceBridgeService` abstract runtime Service (`ServiceType.MOBILE_DEVICE_BRIDGE`) + the single canonical `MobileDeviceBridgeStatus` type (`packages/core/src/mobile-device-bridge-service.ts`). Added `MOBILE_DEVICE_BRIDGE` to the `ServiceType` const + `ServiceTypeRegistry`.
- **plugin-capacitor-bridge** (mobile host): `CapacitorMobileDeviceBridgeService` wraps the existing `mobileDeviceBridge` singleton and is registered via a plugin `services` array (`mobileDeviceBridgePlugin`); consumers resolve it through `runtime.getService(ServiceType.MOBILE_DEVICE_BRIDGE)`. Its hand-copied `MobileDeviceBridgeStatus` now re-exports the core type.
- **agent** `external-modules.d.ts`: the duplicated `MobileDeviceBridgeStatus` shape now imports the core type.

## Done-when evidence

- The `Symbol.for` slot is gone from core — `grep -rn "elizaos.mobile-device-bridge.hooks\|registerMobileDeviceBridgeHooks\|getMobileDeviceBridgeHooks\|MobileDeviceBridgeHooks" packages/core/src` → **none**.
- The bridge contract has **one** typed definition consumed via `getService` — new test `plugins/plugin-capacitor-bridge/src/mobile-device-bridge-service.test.ts` registers the plugin on a real `AgentRuntime`, asserts `hasService(MOBILE_DEVICE_BRIDGE)` and that `CapacitorMobileDeviceBridgeService` implements the contract. **3/3 pass**; full capacitor-bridge suite green.
- `bun run --cwd packages/core build` + `typecheck` clean.

### Residual (out of scope, noted)

`plugin-local-inference/src/local-inference-routes.ts` keeps its own **loose read-model** `MobileDeviceBridgeStatus` (only reads `devices[].loadedPath`, plus an `enabled/connected/reason` unavailable stub) and consumes the bridge via a literal-specifier subpath dynamic import without a runtime handle at the call sites. Converging it onto the strict core type / `getService` would cascade into its route tests' mocks; left as a follow-up to keep this change self-contained and non-regressing.

Refs #12091 (item 35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)