### PR TITLE
fix(ui): gate dynamic view test import hook

### DIFF
--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { transform } from "esbuild";
 import { type ReactElement, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -29,6 +32,27 @@ describe("isSameOriginBundleUrl (view-bundle origin gate)", () => {
     expect(isSameOriginBundleUrl("http://evil.example/x.js")).toBe(false);
     // A protocol-relative URL resolves to a different origin → rejected.
     expect(isSameOriginBundleUrl("//evil.example/x.js")).toBe(false);
+  });
+
+  it("erases the test import hook from production builds before the origin gate", async () => {
+    const source = await readFile(
+      resolve(process.cwd(), "src/components/views/DynamicViewLoader.tsx"),
+      "utf8",
+    );
+    const output = await transform(source, {
+      loader: "tsx",
+      format: "esm",
+      minify: true,
+      treeShaking: true,
+      define: {
+        "import.meta.env.DEV": "false",
+        "import.meta.env.MODE": '"production"',
+        "process.env.NODE_ENV": '"production"',
+      },
+    });
+
+    expect(output.code).not.toContain("__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__");
+    expect(output.code).toContain("isSameOriginBundleUrl");
   });
 });
 

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -525,6 +525,9 @@ async function importViewBundle(
   bundleUrl: string,
 ): Promise<Record<string, unknown>> {
   if (
+    (import.meta.env.DEV ||
+      import.meta.env.MODE === "test" ||
+      process.env.NODE_ENV === "test") &&
     typeof window !== "undefined" &&
     window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__
   ) {


### PR DESCRIPTION
## Summary
- Gates `window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__` behind dev/test build flags so production builds hit the same-origin bundle gate before any mutable window import hook.
- Adds a production esbuild transform assertion that the test hook global is absent from optimized output.
- Addresses #12088 item 20.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/ui test -- src/components/views/DynamicViewLoader.test.tsx`
- `bunx @biomejs/biome check packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx`
- `git diff --check`

## Additional checks
- `bun run --cwd packages/ui typecheck` was attempted and fails on unrelated existing `@elizaos/contracts` declaration resolution and account model type errors outside this change.
- `bun run --cwd packages/app audit:app` was attempted because this is shared UI. It hit an existing builtin coverage failure at `all-views-aesthetic-audit.spec.ts:881` (`builtin coverage matches navigation TAB_PATHS`), then I stopped the remaining 365-case screenshot matrix after the first failure made the command non-passing.

## Evidence
- N/A - no visible UI/pixel behavior changed; this is a production-only security gate for a test hook.
- N/A - no model/action/provider/prompt behavior changed.