### PR TITLE
fix(ui): require explicit public cloud route opt-in

### DIFF
--- a/packages/ui/src/cloud/public-pages/register.ts
+++ b/packages/ui/src/cloud/public-pages/register.ts
@@ -14,7 +14,10 @@
  */
 
 import { lazy } from "react";
-import { registerCloudRoute } from "../shell/cloud-route-registry";
+import {
+  CLOUD_PUBLIC_ROUTE_ACCESS,
+  registerCloudRoute,
+} from "../shell/cloud-route-registry";
 
 const PaymentRequestPage = lazy(
   () => import("./pages/payment/payment-request-page"),
@@ -53,6 +56,10 @@ const PrivacyPolicyPage = lazy(
 const BscPromoPage = lazy(() => import("./pages/bsc-page"));
 
 let registered = false;
+const PUBLIC_ROUTE_ACCESS = {
+  public: true,
+  publicAccess: CLOUD_PUBLIC_ROUTE_ACCESS,
+} as const;
 
 /**
  * Register all public-pages routes. Idempotent — safe to call more than once
@@ -66,19 +73,19 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "payment/:paymentRequestId",
     element: PaymentRequestPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "payment",
   });
   registerCloudRoute({
     path: "payment/success",
     element: PaymentSuccessPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "payment",
   });
   registerCloudRoute({
     path: "payment/app-charge/:appId/:chargeId",
     element: AppChargePaymentPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "payment",
   });
 
@@ -86,19 +93,19 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "approve/:approvalId",
     element: ApprovalPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "token",
   });
   registerCloudRoute({
     path: "ballot/:ballotId",
     element: BallotPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "token",
   });
   registerCloudRoute({
     path: "sensitive-requests/:requestId",
     element: SensitiveRequestPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "token",
   });
 
@@ -106,7 +113,7 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "chat/:characterRef",
     element: PublicChatPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "public",
   });
 
@@ -114,14 +121,14 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "invite/accept",
     element: InviteAcceptPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   // Legacy alias kept by the backend deep-link contract.
   registerCloudRoute({
     path: "accept-invitation",
     element: InviteAcceptPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
 
@@ -129,37 +136,37 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "login",
     element: LoginPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   registerCloudRoute({
     path: "auth/success",
     element: AuthSuccessPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   registerCloudRoute({
     path: "auth/error",
     element: AuthErrorPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   registerCloudRoute({
     path: "auth/cli-login",
     element: CliLoginPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   registerCloudRoute({
     path: "auth/callback/email",
     element: EmailCallbackPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
   registerCloudRoute({
     path: "app-auth/authorize",
     element: AppAuthAuthorizePage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "auth",
   });
 
@@ -167,19 +174,19 @@ export function registerPublicPages(): void {
   registerCloudRoute({
     path: "terms-of-service",
     element: TermsOfServicePage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "legal",
   });
   registerCloudRoute({
     path: "privacy-policy",
     element: PrivacyPolicyPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "legal",
   });
   registerCloudRoute({
     path: "bsc",
     element: BscPromoPage,
-    public: true,
+    ...PUBLIC_ROUTE_ACCESS,
     group: "public",
   });
 }

--- a/packages/ui/src/cloud/shell/cloud-route-registry.test.ts
+++ b/packages/ui/src/cloud/shell/cloud-route-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CLOUD_PUBLIC_ROUTE_ACCESS,
+  getCloudRoute,
+  registerCloudRoute,
+} from "./cloud-route-registry";
+
+function TestRoute() {
+  return null;
+}
+
+describe("cloud route public registration policy", () => {
+  it("rejects public routes without explicit reviewed-public opt-in", () => {
+    expect(() =>
+      registerCloudRoute({
+        path: "security/public-without-token",
+        element: TestRoute,
+        public: true,
+      }),
+    ).toThrow(/CLOUD_PUBLIC_ROUTE_ACCESS/);
+    expect(getCloudRoute("security/public-without-token")).toBeUndefined();
+  });
+
+  it("allows public routes with explicit reviewed-public opt-in", () => {
+    registerCloudRoute({
+      path: "security/public-with-token",
+      element: TestRoute,
+      public: true,
+      publicAccess: CLOUD_PUBLIC_ROUTE_ACCESS,
+    });
+
+    expect(getCloudRoute("security/public-with-token")).toMatchObject({
+      public: true,
+      publicAccess: CLOUD_PUBLIC_ROUTE_ACCESS,
+    });
+  });
+
+  it("warns in dev/test when re-registration flips a private route public", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registerCloudRoute({
+      path: "security/private-then-public",
+      element: TestRoute,
+    });
+    registerCloudRoute({
+      path: "security/private-then-public",
+      element: TestRoute,
+      public: true,
+      publicAccess: CLOUD_PUBLIC_ROUTE_ACCESS,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("re-registered from private to public"),
+    );
+  });
+});

--- a/packages/ui/src/cloud/shell/cloud-route-registry.ts
+++ b/packages/ui/src/cloud/shell/cloud-route-registry.ts
@@ -1,5 +1,7 @@
 import type { ComponentType, LazyExoticComponent } from "react";
 
+export const CLOUD_PUBLIC_ROUTE_ACCESS = "cloud-public-route-reviewed" as const;
+
 /**
  * Pluggable cloud-route registry.
  *
@@ -28,6 +30,12 @@ export interface CloudRouteDef {
    * (public marketing / auth / payment pages). Defaults to `false`.
    */
   public?: boolean;
+  /**
+   * Required whenever `public: true` is set. This makes public exposure a
+   * searchable, explicit opt-in instead of a boolean that can be flipped by
+   * accident during re-registration.
+   */
+  publicAccess?: typeof CLOUD_PUBLIC_ROUTE_ACCESS;
   /** Optional grouping key for nav/IA (e.g. `"dashboard"`, `"auth"`). */
   group?: string;
 }
@@ -65,19 +73,44 @@ interface CloudRouteEntry extends CloudRouteDef {
  */
 export function registerCloudRoute(def: CloudRouteDef): void {
   const store = getStore();
+  const existing = store.entries.get(def.path);
+  if (def.public === true && def.publicAccess !== CLOUD_PUBLIC_ROUTE_ACCESS) {
+    throw new Error(
+      `Cloud route "${def.path}" is public but did not opt in with CLOUD_PUBLIC_ROUTE_ACCESS`,
+    );
+  }
+  if (
+    isDevMode() &&
+    existing &&
+    existing.public !== true &&
+    def.public === true
+  ) {
+    console.warn(
+      `[cloud-route-registry] Route "${def.path}" was re-registered from private to public. Use CLOUD_PUBLIC_ROUTE_ACCESS only for intentionally public routes.`,
+    );
+  }
   const entry: CloudRouteEntry = { ...def, order: store.seq };
   store.seq += 1;
   store.entries.set(def.path, entry);
+}
+
+function isDevMode(): boolean {
+  return (
+    import.meta.env.DEV ||
+    import.meta.env.MODE === "test" ||
+    process.env.NODE_ENV !== "production"
+  );
 }
 
 /** All registered cloud routes, in registration order. */
 export function listCloudRoutes(): CloudRouteDef[] {
   return [...getStore().entries.values()]
     .sort((a, b) => (a as CloudRouteEntry).order - (b as CloudRouteEntry).order)
-    .map(({ path, element, public: isPublic, group }) => ({
+    .map(({ path, element, public: isPublic, publicAccess, group }) => ({
       path,
       element,
       public: isPublic,
+      publicAccess,
       group,
     }));
 }


### PR DESCRIPTION
## Summary
- Adds `CLOUD_PUBLIC_ROUTE_ACCESS` as the explicit reviewed-public opt-in required for `public: true` cloud routes.
- Rejects public route registration without the opt-in token.
- Emits a dev/test warning when a same-path override flips a private cloud route to public.
- Updates the existing public-pages route registrations to use the explicit opt-in.
- Addresses #12088 item 19.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/ui test -- src/cloud/shell/cloud-route-registry.test.ts src/cloud/register-all.test.ts`
- `bunx @biomejs/biome check packages/ui/src/cloud/shell/cloud-route-registry.ts packages/ui/src/cloud/shell/cloud-route-registry.test.ts packages/ui/src/cloud/public-pages/register.ts`
- `git diff --check`
- `rg "public:\s*true" packages/ui/src/cloud -n` shows public route registration now goes through `PUBLIC_ROUTE_ACCESS` plus tests/comments.

## Evidence
- N/A - security/route registry behavior with no visible UI or pixel change.
- N/A - no model/action/provider/prompt behavior changed.

## Notes
- Full app audit was attempted in the prior UI slice and fails before this route-registry change on the existing `builtin coverage matches navigation TAB_PATHS` check in `all-views-aesthetic-audit.spec.ts:881`.