### PR TITLE
chore(ui): declare optional native probe peers

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -314,8 +314,26 @@
     }
   },
   "peerDependencies": {
+    "@capacitor/app": "^8.0.0",
+    "@elizaos/capacitor-agent": "workspace:*",
+    "@elizaos/capacitor-llama": "workspace:*",
+    "llama-cpp-capacitor": "^0.1.5",
     "react": "19.2.5",
     "react-dom": "19.2.5"
+  },
+  "peerDependenciesMeta": {
+    "@capacitor/app": {
+      "optional": true
+    },
+    "@elizaos/capacitor-agent": {
+      "optional": true
+    },
+    "@elizaos/capacitor-llama": {
+      "optional": true
+    },
+    "llama-cpp-capacitor": {
+      "optional": true
+    }
   },
   "optionalDependencies": {
     "@elizaos/capacitor-bun-runtime": "workspace:*",

--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -14,8 +14,7 @@
  *      state.
  *   2. `installFirstRunDeepLinkListener` — the Capacitor wrapper that wires
  *      `App.addListener("appUrlOpen", ...)` and `App.getLaunchUrl()`. Tested
- *      with a mocked `@capacitor/app` (the package is not a declared
- *      dependency of `@elizaos/ui`; the host app supplies it). The "Capacitor
+ *      with a mocked optional-peer `@capacitor/app`. The "Capacitor
  *      bridge unavailable" scenario is exercised at the listener layer —
  *      Capacitor's web shim throws `Native Bridge unavailable` on
  *      `addListener` when no native runtime is attached, so that is the

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -175,10 +175,9 @@ export function routeFirstRunDeepLink(url: string, urlScheme: string): boolean {
  * when registration failed (no-op).
  */
 /**
- * Minimal contract this module needs from `@capacitor/app`. Keeps the package
- * import surface honest — `@elizaos/ui` does not declare `@capacitor/app` as a
- * direct dependency (the native bridge ships from the host app), and we don't
- * want a `typeof import("@capacitor/app")` to silently promote it.
+ * Minimal contract this module needs from `@capacitor/app`. Keeps the optional
+ * peer import surface honest; native hosts supply the bridge, and we don't want
+ * a `typeof import("@capacitor/app")` to silently promote it.
  */
 type AppUrlOpenEvent = { url: string };
 type ListenerHandle = { remove: () => Promise<void> };
@@ -206,9 +205,8 @@ export async function installFirstRunDeepLinkListener(options: {
   try {
     const capacitorAppPackage = "@capacitor/app";
     const mod = (await import(
-      // `@capacitor/app` is not a declared dependency of `@elizaos/ui` — the
-      // host app brings the native bridge. Dynamic import means web bundles
-      // skip this branch when the package is not installed.
+      // `@capacitor/app` is an optional peer supplied by native hosts. Dynamic
+      // import means web bundles skip this branch when the package is absent.
       /* @vite-ignore */ capacitorAppPackage
     )) as { App: CapacitorAppShape };
     capacitorApp = mod.App;


### PR DESCRIPTION
## Summary

Refs #12091.

This addresses #12091 item 28 by making the UI package manager-visible for runtime-probed native packages:

- declares `@capacitor/app`, `@elizaos/capacitor-agent`, `@elizaos/capacitor-llama`, and `llama-cpp-capacitor` as optional peer dependencies in `packages/ui/package.json`
- adds matching `peerDependenciesMeta.optional` entries
- updates first-run deep-link comments/tests so they describe the optional-peer contract instead of saying `@capacitor/app` is undeclared

Runtime behavior is unchanged: these branches still dynamically import only when the native host supplies the package.

## Evidence

- `bun install --frozen-lockfile --ignore-scripts` (no lockfile changes)
- `bunx biome check packages/ui/package.json packages/ui/src/first-run/deep-link-handler.ts packages/ui/src/first-run/__tests__/deep-link-entry.test.ts`
- `git diff --check HEAD~1..HEAD`
- `bun run --cwd packages/ui test src/first-run/__tests__/deep-link-entry.test.ts` (26 tests)
- `bun run --cwd packages/ui build`

## Known Upstream Blocker

- `bun run --cwd packages/ui typecheck` currently fails on current `origin/develop` before reaching this patch because `packages/core/src/features/trust/providers/index.ts` exports deleted `roles.ts` and `settings.ts`. That stale-export fix is already in draft PR #12142.

## Evidence N/A

- Screenshots/video: N/A - dependency metadata and comments only; no rendered UI or user flow changed.
- Live LLM trajectories: N/A - no agent/model/action/provider behavior changed.
