### PR TITLE
fix(mobile-resource): normalize lab artifact gaps for #12072

### DIFF
--- a/packages/benchmarks/mobile-resource/BASELINE.md
+++ b/packages/benchmarks/mobile-resource/BASELINE.md
@@ -15,8 +15,16 @@ fabricated number (AGENTS.md §3/§7).
    ```
 2. Repeat ≥3× on a quiet, thermally-cool device; take the conservative side
    (p50 floor for throughput, p90/peak for ceilings).
-3. Write the measured number + device + commit into the table below.
-4. Set the matching key in `budgets.json` with ~10–15% headroom, then ratchet it
+3. For physical-lab evidence (power meter, physical iOS), normalize the raw
+   files before promoting anything:
+   ```bash
+   node packages/benchmarks/mobile-resource/lab-artifacts.mjs \
+     --input=.github/issue-evidence/12072-lab \
+     --out=packages/benchmarks/mobile-resource/results/lab \
+     --fail-on-gaps
+   ```
+4. Write the measured number + device + commit into the table below.
+5. Set the matching key in `budgets.json` with ~10–15% headroom, then ratchet it
    down as optimisations land (monotonic-improvement discipline, same as
    `loadperf`).
 

--- a/packages/benchmarks/mobile-resource/README.md
+++ b/packages/benchmarks/mobile-resource/README.md
@@ -42,6 +42,12 @@ node packages/benchmarks/mobile-resource/run-workbench.mjs \
 
 # Consolidated report (markdown + HTML) from the latest results:
 node packages/benchmarks/mobile-resource/report.mjs
+
+# Normalize physical lab artifacts (power meter + physical iOS captures):
+node packages/benchmarks/mobile-resource/lab-artifacts.mjs \
+  --input=.github/issue-evidence/12072-lab \
+  --out=packages/benchmarks/mobile-resource/results/lab \
+  --fail-on-gaps
 ```
 
 Exit codes: `0` pass, `1` budget/gate failure, `2` skipped/unavailable (no
@@ -68,6 +74,7 @@ reachable the runner records `{ skipped }` and exits `2` rather than failing.
 | `android-probe.mjs` | Host-side adb probes (thermal/battery/memory) |
 | `ios-probe.mjs` | simctl device detect + MetricKit payload pull |
 | `report.mjs` | Consolidated markdown/HTML report from `results/` |
+| `lab-artifacts.mjs` | Physical-lab artifact normalizer for power-meter logs, physical iOS captures, and multi-run stability gaps |
 | `lib.mjs` | Shared utilities (result recording, git context, formatting, exec) |
 | `budgets.json` | Per device-class × tier budgets |
 | `BASELINE.md` | Measured baselines + how a baseline becomes a budget |
@@ -82,6 +89,26 @@ node --test packages/benchmarks/mobile-resource/metrics.test.mjs
 The pure aggregation + budget logic is unit-tested here; the device-driving
 runner and probes degrade to `skipped` off-device, so they are exercised in the
 `mobile-resource-workbench` CI lane on the self-hosted arm64 runner + iOS sim.
+
+## Physical lab artifacts
+
+Issue #12072 needs evidence the live runner cannot honestly create on a hosted
+machine: bench power-meter logs for idle/chat/voice/background scheduled work,
+physical iOS metrics for both tiers, and at least three cool-device runs before
+anything becomes a budget. `lab-artifacts.mjs` consumes those files and emits
+`lab-artifacts.json` plus `lab-artifacts.md`.
+
+Accepted inputs are CSV or JSON files. CSV columns are intentionally simple:
+`runId`, `platform`, `deviceClass`, `tier`, `workload`, `elapsedSeconds` or
+`atMs`, `powerW` or `voltageV` + `currentA`, optional `temperatureC`,
+`residentMemoryMb`, `batteryLevelPct`, and `isCharging`. JSON can be either a
+workbench `latest.json`, an array of the same sample rows, or an object with a
+`samples` array. One file may contain multiple `runId`s; the tool splits them
+into separate runs.
+
+`--fail-on-gaps` exits non-zero until the required workload/tier coverage is
+present. Missing measurements stay missing; they are reported as gaps instead
+of being replaced with zero.
 
 ## Notes
 

--- a/packages/benchmarks/mobile-resource/lab-artifacts.mjs
+++ b/packages/benchmarks/mobile-resource/lab-artifacts.mjs
@@ -1,0 +1,553 @@
+/**
+ * Physical lab artifact normalizer for the Mobile Resource Workbench (#12072).
+ *
+ * The live workbench records what the device can report directly. This tool
+ * consumes the harder human-lab evidence that arrives later: power-meter CSVs,
+ * physical iOS JSON captures, and exported workbench result JSON. It produces a
+ * reviewer-readable report and a machine-readable summary without fabricating
+ * missing measurements.
+ *
+ * Example:
+ *   node packages/benchmarks/mobile-resource/lab-artifacts.mjs \
+ *     --input=.github/issue-evidence/12072-lab \
+ *     --out=packages/benchmarks/mobile-resource/results/lab \
+ *     --fail-on-gaps
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  existsSync,
+  join,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "./lib.mjs";
+
+const DEFAULT_MIN_RUNS = 3;
+const EXPECTED_WORKLOADS = ["idle", "chat", "voice", "background"];
+const EXPECTED_IOS_TIERS = ["eliza-1-2b", "eliza-1-4b"];
+
+function isFiniteNum(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function numberOrNull(value) {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const cleaned = String(value).trim().replace(/,/g, "");
+  if (cleaned === "") return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+function field(row, names) {
+  for (const name of names) {
+    if (Object.hasOwn(row, name)) return row[name];
+    const hit = Object.keys(row).find(
+      (key) => key.toLowerCase() === name.toLowerCase(),
+    );
+    if (hit) return row[hit];
+  }
+  return null;
+}
+
+function inferFromPath(file) {
+  const lower = file.toLowerCase();
+  const workload = EXPECTED_WORKLOADS.find((w) => lower.includes(w)) ?? null;
+  const tier =
+    EXPECTED_IOS_TIERS.find((t) => lower.includes(t.toLowerCase())) ?? null;
+  const platform = lower.includes("ios")
+    ? "ios"
+    : lower.includes("android")
+      ? "android"
+      : null;
+  const deviceClass =
+    lower.includes("ios-phone") || lower.includes("iphone")
+      ? "ios-phone"
+      : lower.includes("android-phone") || lower.includes("pixel")
+        ? "android-phone"
+        : null;
+  return { workload, tier, platform, deviceClass };
+}
+
+function mean(values) {
+  const xs = values.filter(isFiniteNum);
+  if (!xs.length) return null;
+  return xs.reduce((sum, value) => sum + value, 0) / xs.length;
+}
+
+function stddev(values) {
+  const xs = values.filter(isFiniteNum);
+  if (xs.length < 2) return null;
+  const m = mean(xs);
+  return Math.sqrt(
+    xs.reduce((sum, value) => sum + (value - m) ** 2, 0) / (xs.length - 1),
+  );
+}
+
+function min(values) {
+  const xs = values.filter(isFiniteNum);
+  return xs.length ? Math.min(...xs) : null;
+}
+
+function max(values) {
+  const xs = values.filter(isFiniteNum);
+  return xs.length ? Math.max(...xs) : null;
+}
+
+function percentile(values, p) {
+  const xs = values.filter(isFiniteNum).sort((a, b) => a - b);
+  if (!xs.length) return null;
+  return xs[Math.min(xs.length - 1, Math.ceil((p / 100) * xs.length) - 1)];
+}
+
+function coefficientOfVariation(values) {
+  const m = mean(values);
+  const s = stddev(values);
+  if (!isFiniteNum(m) || m === 0 || !isFiniteNum(s)) return null;
+  return s / Math.abs(m);
+}
+
+function parseCsv(text) {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  if (lines.length < 2) return [];
+  const headers = splitCsvLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    return Object.fromEntries(headers.map((header, i) => [header, cells[i]]));
+  });
+}
+
+function splitCsvLine(line) {
+  const out = [];
+  let cell = "";
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"' && line[i + 1] === '"') {
+      cell += '"';
+      i += 1;
+    } else if (ch === '"') {
+      quoted = !quoted;
+    } else if (ch === "," && !quoted) {
+      out.push(cell.trim());
+      cell = "";
+    } else {
+      cell += ch;
+    }
+  }
+  out.push(cell.trim());
+  return out;
+}
+
+function normalizeSample(row) {
+  const atMs =
+    numberOrNull(field(row, ["atMs", "elapsedMs", "elapsed_ms"])) ??
+    secondsToMs(field(row, ["elapsedSeconds", "seconds", "time_s"]));
+  const voltageV = numberOrNull(field(row, ["voltageV", "voltage_v", "V"]));
+  const currentA = numberOrNull(field(row, ["currentA", "current_a", "A"]));
+  const powerW =
+    numberOrNull(field(row, ["powerW", "power_w", "watts", "W"])) ??
+    (isFiniteNum(voltageV) && isFiniteNum(currentA)
+      ? voltageV * currentA
+      : null);
+  return {
+    atMs,
+    workload: field(row, ["workload", "scenario"]) ?? null,
+    tier: field(row, ["tier", "modelTier"]) ?? null,
+    platform: field(row, ["platform", "os"]) ?? null,
+    deviceClass: field(row, ["deviceClass", "device_class"]) ?? null,
+    runId: field(row, ["runId", "run_id", "run"]) ?? null,
+    source: field(row, ["source", "meter", "kind"]) ?? null,
+    powerW,
+    voltageV,
+    currentA,
+    energyWh: numberOrNull(field(row, ["energyWh", "energy_wh", "Wh"])),
+    batteryLevelPct: numberOrNull(
+      field(row, ["batteryLevelPct", "battery_pct", "batteryPct"]),
+    ),
+    residentMemoryMb: numberOrNull(
+      field(row, ["residentMemoryMb", "rssMb", "rss_mb", "memoryMb"]),
+    ),
+    thermalState: field(row, ["thermalState", "thermal_state"]) ?? null,
+    temperatureC: numberOrNull(field(row, ["temperatureC", "tempC", "temp_c"])),
+    isCharging: parseBoolean(field(row, ["isCharging", "charging"])),
+  };
+}
+
+function secondsToMs(value) {
+  const n = numberOrNull(value);
+  return n == null ? null : n * 1000;
+}
+
+function parseBoolean(value) {
+  if (typeof value === "boolean") return value;
+  if (value == null || value === "") return null;
+  const normalized = String(value).trim().toLowerCase();
+  if (["1", "true", "yes", "charging"].includes(normalized)) return true;
+  if (["0", "false", "no", "discharging"].includes(normalized)) return false;
+  return null;
+}
+
+function walkFiles(paths) {
+  const files = [];
+  for (const p of paths) {
+    if (!existsSync(p)) continue;
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      for (const name of readdirSync(p))
+        files.push(...walkFiles([join(p, name)]));
+    } else if (/\.(csv|json)$/i.test(p)) {
+      files.push(p);
+    }
+  }
+  return files.sort();
+}
+
+function normalizeWorkbenchRecord(json, file) {
+  if (!json || typeof json !== "object" || !json.summary) return null;
+  const inferred = inferFromPath(file);
+  const summary = json.summary;
+  return {
+    file,
+    source: "workbench",
+    platform: json.platform ?? inferred.platform,
+    deviceClass: json.deviceClass ?? inferred.deviceClass,
+    tier: json.tier ?? inferred.tier,
+    workload: canonicalWorkload(json.workload ?? inferred.workload),
+    runId: json.recordedAt ?? json.git?.commit ?? file,
+    sampleCount: summary.resourceSamples ?? 0,
+    durationMs: summary.battery?.durationMs ?? null,
+    avgPowerW: null,
+    energyWh: null,
+    batteryDrainPct: summary.battery?.drainPct ?? null,
+    peakRssMb: summary.rss?.peakMb ?? null,
+    steadyRssMb: summary.rss?.steadyMb ?? null,
+    ttftP90Ms: summary.ttftMs?.p90 ?? null,
+    thermalMaxState: summary.thermal?.maxState ?? null,
+    maxTemperatureC: null,
+    chargingObserved: summary.battery?.chargingObserved ?? false,
+    notes: ["workbench-result"],
+  };
+}
+
+function canonicalWorkload(value) {
+  if (!value) return null;
+  const v = String(value).toLowerCase();
+  if (v.includes("single") || v.includes("chat") || v.includes("turn"))
+    return "chat";
+  if (v.includes("sustain")) return "chat";
+  if (v.includes("voice")) return "voice";
+  if (v.includes("idle") || v.includes("cold")) return "idle";
+  if (v.includes("background") || v.includes("scheduled")) return "background";
+  return v.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function summarizeSamples(samples, file) {
+  const inferred = inferFromPath(file);
+  const rows = samples.map(normalizeSample);
+  const workload = canonicalWorkload(
+    firstPresent(rows, "workload") ?? inferred.workload,
+  );
+  const tier = firstPresent(rows, "tier") ?? inferred.tier;
+  const platform = firstPresent(rows, "platform") ?? inferred.platform;
+  const deviceClass = firstPresent(rows, "deviceClass") ?? inferred.deviceClass;
+  const at = rows.map((row) => row.atMs).filter(isFiniteNum);
+  const power = rows.map((row) => row.powerW);
+  const battery = rows.map((row) => row.batteryLevelPct);
+  const rss = rows.map((row) => row.residentMemoryMb);
+  const temp = rows.map((row) => row.temperatureC);
+  const energyRows = rows.map((row) => row.energyWh).filter(isFiniteNum);
+  const durationMs = at.length >= 2 ? max(at) - min(at) : null;
+  const avgPowerW = mean(power);
+  const energyWh = energyRows.length
+    ? max(energyRows) - min(energyRows)
+    : isFiniteNum(avgPowerW) && isFiniteNum(durationMs)
+      ? avgPowerW * (durationMs / 3_600_000)
+      : null;
+  return {
+    file,
+    source: firstPresent(rows, "source") ?? "lab-samples",
+    platform,
+    deviceClass,
+    tier,
+    workload,
+    runId: firstPresent(rows, "runId") ?? file,
+    sampleCount: rows.length,
+    durationMs,
+    avgPowerW,
+    energyWh,
+    batteryDrainPct:
+      battery.filter(isFiniteNum).length >= 2
+        ? max(battery) - min(battery)
+        : null,
+    peakRssMb: max(rss),
+    steadyRssMb: percentile(rss, 50),
+    ttftP90Ms: null,
+    thermalMaxState: maxThermalState(rows),
+    maxTemperatureC: max(temp),
+    chargingObserved: rows.some((row) => row.isCharging === true),
+    notes: rows.some((row) => isFiniteNum(row.powerW))
+      ? ["power-meter"]
+      : ["sample-log"],
+  };
+}
+
+function splitSamplesByRun(samples, file) {
+  const normalized = samples.map((row) => ({
+    original: row,
+    sample: normalizeSample(row),
+  }));
+  const groups = new Map();
+  for (const row of normalized) {
+    const inferred = inferFromPath(file);
+    const key = [
+      row.sample.runId ?? file,
+      canonicalWorkload(row.sample.workload ?? inferred.workload) ??
+        "unknown-workload",
+      row.sample.tier ?? inferred.tier ?? "unknown-tier",
+      row.sample.platform ?? inferred.platform ?? "unknown-platform",
+      row.sample.deviceClass ?? inferred.deviceClass ?? "unknown-device",
+    ].join("|");
+    const arr = groups.get(key) ?? [];
+    arr.push(row.original);
+    groups.set(key, arr);
+  }
+  return [...groups.values()];
+}
+
+function firstPresent(rows, key) {
+  const found = rows.find((row) => row[key] != null && row[key] !== "");
+  return found?.[key] ?? null;
+}
+
+function maxThermalState(rows) {
+  const rank = { nominal: 0, fair: 1, serious: 2, critical: 3 };
+  let best = null;
+  let bestRank = -1;
+  for (const row of rows) {
+    const state = row.thermalState;
+    if (state == null) continue;
+    const r = rank[String(state).toLowerCase()];
+    if (r != null && r > bestRank) {
+      bestRank = r;
+      best = String(state).toLowerCase();
+    }
+  }
+  return best;
+}
+
+export function loadLabArtifacts(paths) {
+  const records = [];
+  const errors = [];
+  for (const file of walkFiles(paths)) {
+    try {
+      const text = readFileSync(file, "utf8");
+      if (/\.json$/i.test(file)) {
+        const json = JSON.parse(text);
+        const workbench = normalizeWorkbenchRecord(json, file);
+        if (workbench) records.push(workbench);
+        else if (Array.isArray(json))
+          for (const group of splitSamplesByRun(json, file))
+            records.push(summarizeSamples(group, file));
+        else if (Array.isArray(json.samples))
+          for (const group of splitSamplesByRun(json.samples, file))
+            records.push(summarizeSamples(group, file));
+      } else {
+        const rows = parseCsv(text);
+        if (rows.length)
+          for (const group of splitSamplesByRun(rows, file))
+            records.push(summarizeSamples(group, file));
+      }
+    } catch (err) {
+      errors.push({ file, error: err.message });
+    }
+  }
+  return { records, errors };
+}
+
+export function summarizeLabArtifacts(records, opts = {}) {
+  const minRuns = opts.minRuns ?? DEFAULT_MIN_RUNS;
+  const groups = new Map();
+  for (const rec of records) {
+    const key = [
+      rec.platform ?? "unknown-platform",
+      rec.deviceClass ?? "unknown-device",
+      rec.tier ?? "unknown-tier",
+      rec.workload ?? "unknown-workload",
+    ].join("|");
+    const arr = groups.get(key) ?? [];
+    arr.push(rec);
+    groups.set(key, arr);
+  }
+
+  const summaries = [...groups.entries()]
+    .map(([key, runs]) => summarizeGroup(key, runs, minRuns))
+    .sort((a, b) => a.key.localeCompare(b.key));
+  const gaps = coverageGaps(summaries, { minRuns });
+  return {
+    minRuns,
+    runCount: records.length,
+    groups: summaries,
+    gaps,
+    pass: gaps.length === 0 && summaries.every((group) => group.stable),
+  };
+}
+
+function summarizeGroup(key, runs, minRuns) {
+  const [platform, deviceClass, tier, workload] = key.split("|");
+  const energy = runs.map((run) => run.energyWh);
+  const power = runs.map((run) => run.avgPowerW);
+  const battery = runs.map((run) => run.batteryDrainPct);
+  const peakRss = runs.map((run) => run.peakRssMb);
+  const ttft = runs.map((run) => run.ttftP90Ms);
+  const chargingObserved = runs.some((run) => run.chargingObserved);
+  const energyCv = coefficientOfVariation(energy);
+  const coolRuns = runs.filter((run) => {
+    const tempOk = run.maxTemperatureC == null || run.maxTemperatureC < 43;
+    const thermalOk =
+      run.thermalMaxState == null ||
+      ["nominal", "fair"].includes(run.thermalMaxState);
+    return tempOk && thermalOk && !run.chargingObserved;
+  }).length;
+  const hasEnoughCoolRuns =
+    runs.length >= minRuns && coolRuns >= minRuns && !chargingObserved;
+  const stable =
+    hasEnoughCoolRuns && (energyCv === null ? true : energyCv <= 0.15);
+  return {
+    key,
+    platform,
+    deviceClass,
+    tier,
+    workload,
+    runs: runs.length,
+    coolRuns,
+    stable,
+    chargingObserved,
+    energyWh: stats(energy),
+    avgPowerW: stats(power),
+    batteryDrainPct: stats(battery),
+    peakRssMb: stats(peakRss),
+    ttftP90Ms: stats(ttft),
+    files: runs.map((run) => run.file),
+  };
+}
+
+function stats(values) {
+  return {
+    count: values.filter(isFiniteNum).length,
+    mean: mean(values),
+    min: min(values),
+    max: max(values),
+    stddev: stddev(values),
+    cv: coefficientOfVariation(values),
+  };
+}
+
+function coverageGaps(groups, { minRuns }) {
+  const gaps = [];
+  const byKey = new Map(groups.map((group) => [group.key, group]));
+  for (const workload of EXPECTED_WORKLOADS) {
+    const matching = groups.filter(
+      (group) => group.workload === workload && group.energyWh.count > 0,
+    );
+    if (matching.length === 0)
+      gaps.push(`missing power-meter energy evidence for ${workload}`);
+  }
+  for (const tier of EXPECTED_IOS_TIERS) {
+    const key = ["ios", "ios-phone", tier, "chat"].join("|");
+    const group = byKey.get(key);
+    if (!group) gaps.push(`missing physical iOS chat metrics for ${tier}`);
+    else if (group.runs < minRuns)
+      gaps.push(`physical iOS ${tier} has ${group.runs}/${minRuns} runs`);
+    else if (!group.stable)
+      gaps.push(`physical iOS ${tier} runs are not stable/cool enough`);
+  }
+  for (const group of groups) {
+    if (group.runs < minRuns)
+      gaps.push(`${group.key} has ${group.runs}/${minRuns} runs`);
+    if (group.chargingObserved)
+      gaps.push(`${group.key} observed charging during a lab run`);
+  }
+  return [...new Set(gaps)].sort();
+}
+
+export function renderLabMarkdown(summary) {
+  const lines = [];
+  lines.push("# Mobile Resource Lab Artifact Report");
+  lines.push("");
+  lines.push(`Runs: ${summary.runCount}`);
+  lines.push(`Minimum runs per stable group: ${summary.minRuns}`);
+  lines.push(`Status: ${summary.pass ? "PASS" : "GAPS"}`);
+  lines.push("");
+  lines.push(
+    "| Platform | Device | Tier | Workload | Runs | Cool | Energy Wh mean | Avg W mean | Peak RSS mean | Stable |",
+  );
+  lines.push(
+    "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+  );
+  for (const group of summary.groups) {
+    lines.push(
+      `| ${group.platform} | ${group.deviceClass} | ${group.tier} | ${group.workload} | ${group.runs} | ${group.coolRuns} | ${fmt(group.energyWh.mean)} | ${fmt(group.avgPowerW.mean)} | ${fmt(group.peakRssMb.mean)} | ${group.stable ? "yes" : "no"} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Gaps");
+  lines.push("");
+  if (!summary.gaps.length) lines.push("_None._");
+  else for (const gap of summary.gaps) lines.push(`- ${gap}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function fmt(value) {
+  return value == null ? "-" : Number(value).toFixed(3);
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const get = (name, fallback = null) => {
+    const hit = argv.find((arg) => arg.startsWith(`--${name}=`));
+    return hit ? hit.split("=").slice(1).join("=") : fallback;
+  };
+  return {
+    inputs: (get("input", "") || "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+    out: get(
+      "out",
+      join("packages", "benchmarks", "mobile-resource", "results", "lab"),
+    ),
+    minRuns: numberOrNull(get("min-runs", null)) ?? DEFAULT_MIN_RUNS,
+    failOnGaps: argv.includes("--fail-on-gaps"),
+  };
+}
+
+function main() {
+  const args = parseArgs();
+  if (!args.inputs.length) {
+    console.error(
+      "[mobile-resource-lab] --input=<dir-or-file>[,...] is required",
+    );
+    process.exit(2);
+  }
+  const { records, errors } = loadLabArtifacts(args.inputs);
+  const summary = summarizeLabArtifacts(records, { minRuns: args.minRuns });
+  const report = renderLabMarkdown(summary);
+  mkdirSync(args.out, { recursive: true });
+  writeFileSync(
+    join(args.out, "lab-artifacts.json"),
+    JSON.stringify({ ...summary, errors }, null, 2),
+  );
+  writeFileSync(join(args.out, "lab-artifacts.md"), report);
+  console.log(report);
+  if (errors.length)
+    console.error(`[mobile-resource-lab] parse errors: ${errors.length}`);
+  process.exit(args.failOnGaps && !summary.pass ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/packages/benchmarks/mobile-resource/metrics.test.mjs
+++ b/packages/benchmarks/mobile-resource/metrics.test.mjs
@@ -4,7 +4,15 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import {
+  loadLabArtifacts,
+  renderLabMarkdown,
+  summarizeLabArtifacts,
+} from "./lab-artifacts.mjs";
 import {
   checkBudgets,
   computeThroughput,
@@ -219,4 +227,106 @@ test("checkBudgets without workloadId keeps the full check set (non-idle workloa
   assert.ok(names.includes("peakRssMb"));
   // postIdleRss is idle-reclaim-only — chat workloads must not be gated on it.
   assert.ok(!names.includes("postIdleRssMb"));
+});
+
+test("lab-artifacts normalizes repeated power-meter and iOS physical runs", () => {
+  const dir = mkdtempSync(join(tmpdir(), "eliza-mobile-resource-lab-"));
+  try {
+    writeFileSync(
+      join(dir, "android-idle-eliza-1-2b-all-runs.csv"),
+      [
+        "runId,platform,deviceClass,tier,workload,elapsedSeconds,powerW,temperatureC,isCharging",
+        "idle-1,android,android-phone,eliza-1-2b,idle,0,1.00,31,false",
+        "idle-1,android,android-phone,eliza-1-2b,idle,60,1.10,32,false",
+        "idle-2,android,android-phone,eliza-1-2b,idle,0,1.04,31,false",
+        "idle-2,android,android-phone,eliza-1-2b,idle,60,1.05,32,false",
+        "idle-3,android,android-phone,eliza-1-2b,idle,0,1.07,31,false",
+        "idle-3,android,android-phone,eliza-1-2b,idle,60,1.03,32,false",
+      ].join("\n"),
+    );
+    for (const workload of ["chat", "voice", "background"]) {
+      for (let run = 1; run <= 3; run++) {
+        writeFileSync(
+          join(dir, `android-${workload}-eliza-1-2b-run${run}.csv`),
+          [
+            "platform,deviceClass,tier,workload,elapsedSeconds,powerW,temperatureC,isCharging",
+            `android,android-phone,eliza-1-2b,${workload},0,2.${run},32,false`,
+            `android,android-phone,eliza-1-2b,${workload},60,2.${run},33,false`,
+          ].join("\n"),
+        );
+      }
+    }
+    for (const tier of ["eliza-1-2b", "eliza-1-4b"]) {
+      for (let run = 1; run <= 3; run++) {
+        writeFileSync(
+          join(dir, `ios-chat-${tier}-run${run}.json`),
+          JSON.stringify({
+            platform: "ios",
+            deviceClass: "ios-phone",
+            tier,
+            workload: "single-turn",
+            recordedAt: `${tier}-${run}`,
+            summary: {
+              resourceSamples: 4,
+              battery: { drainPct: 2, chargingObserved: false },
+              rss: { peakMb: 2200 + run, steadyMb: 2100 + run },
+              ttftMs: { p90: 50_000 + run },
+              thermal: { maxState: "fair" },
+            },
+          }),
+        );
+      }
+    }
+
+    const { records, errors } = loadLabArtifacts([dir]);
+    assert.equal(errors.length, 0);
+    const summary = summarizeLabArtifacts(records, { minRuns: 3 });
+    assert.equal(summary.pass, true);
+    assert.deepEqual(summary.gaps, []);
+    const ios2b = summary.groups.find(
+      (group) => group.key === "ios|ios-phone|eliza-1-2b|chat",
+    );
+    assert.equal(ios2b.runs, 3);
+    assert.equal(ios2b.stable, true);
+    assert.match(renderLabMarkdown(summary), /Status: PASS/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lab-artifacts reports coverage gaps instead of fabricating missing evidence", () => {
+  const records = [
+    {
+      file: "ios-one.json",
+      source: "workbench",
+      platform: "ios",
+      deviceClass: "ios-phone",
+      tier: "eliza-1-2b",
+      workload: "chat",
+      runId: "one",
+      sampleCount: 4,
+      energyWh: null,
+      avgPowerW: null,
+      batteryDrainPct: 1,
+      peakRssMb: 2000,
+      ttftP90Ms: 1000,
+      thermalMaxState: "fair",
+      maxTemperatureC: null,
+      chargingObserved: true,
+      notes: ["workbench-result"],
+    },
+  ];
+  const summary = summarizeLabArtifacts(records, { minRuns: 3 });
+  assert.equal(summary.pass, false);
+  assert.ok(
+    summary.gaps.includes("missing power-meter energy evidence for idle"),
+  );
+  assert.ok(
+    summary.gaps.includes("missing physical iOS chat metrics for eliza-1-4b"),
+  );
+  assert.ok(
+    summary.gaps.includes(
+      "ios|ios-phone|eliza-1-2b|chat observed charging during a lab run",
+    ),
+  );
 });


### PR DESCRIPTION
## Summary

Adds a physical-lab artifact normalizer for #12072 in `packages/benchmarks/mobile-resource/lab-artifacts.mjs`.

The tool consumes CSV/JSON power-meter exports, physical iOS sample captures, and existing workbench `latest.json` files, then emits:

- `lab-artifacts.json`
- `lab-artifacts.md`
- explicit coverage gaps when required power/iOS/tier evidence is missing

It does not fabricate missing measurements. `--fail-on-gaps` exits non-zero until the required idle/chat/voice/background power evidence, physical iOS tier coverage, and repeated cool-device runs are present.

## Why

#12072 still needs human-lab captures before budgets can be promoted. The repo had a live workbench, but no deterministic way to normalize those later physical artifacts or prove which evidence gaps remain.

## Validation

- `node --test packages/benchmarks/mobile-resource/metrics.test.mjs`
- `bunx biome check packages/benchmarks/mobile-resource/lab-artifacts.mjs packages/benchmarks/mobile-resource/metrics.test.mjs packages/benchmarks/mobile-resource/README.md packages/benchmarks/mobile-resource/BASELINE.md`
- `git diff --check origin/develop..HEAD`

## Evidence

N/A - this PR adds the normalization/checking lane for future physical lab files. It does not include new power-meter or physical iOS captures; #12072 still requires those artifacts before budget promotion.

Refs #12072.
