### PR TITLE
refactor(core): own the optional-app-route-plugin error contract (#12091 item 21)

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -34,6 +34,7 @@ import {
   isTruthyEnvValue,
   logger,
   ModelType,
+  OptionalAppRoutePluginUnavailableError,
   type Plugin,
   stringToUuid,
 } from "@elizaos/core";
@@ -327,16 +328,6 @@ async function ensureAutonomyBootstrapContext(
 // ---------------------------------------------------------------------------
 
 type AppRoutePluginModule = Record<string, unknown>;
-
-class OptionalAppRoutePluginUnavailableError extends Error {
-  constructor(
-    readonly specifier: string,
-    cause: unknown,
-  ) {
-    super(`Optional app route plugin ${specifier} is unavailable`, { cause });
-    this.name = "OptionalAppRoutePluginUnavailableError";
-  }
-}
 
 function splitPackageSpecifier(specifier: string): {
   packageName: string;

--- a/packages/core/src/app-route-plugin-registry.test.ts
+++ b/packages/core/src/app-route-plugin-registry.test.ts
@@ -11,7 +11,10 @@ import { describe, expect, it } from "vitest";
 import {
 	type AppRoutePluginRegistryEntry,
 	drainAppRoutePluginLoaders,
+	isOptionalAppRoutePluginUnavailableError,
 	listAppRoutePluginLoaders,
+	OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME,
+	OptionalAppRoutePluginUnavailableError,
 	registerAppRoutePluginLoader,
 } from "./app-route-plugin-registry";
 import type { Plugin, Route } from "./types/plugin";
@@ -80,13 +83,28 @@ describe("drainAppRoutePluginLoaders", () => {
 		expect(target.routes).toHaveLength(2);
 	});
 
-	it("isolates an optional-unavailable loader and still drains the rest", async () => {
+	it("isolates an optional-unavailable loader (core error class) and still drains the rest", async () => {
 		const target: { routes: Route[] } = { routes: [] };
-		const unavailable = new Error("nope");
-		unavailable.name = "OptionalAppRoutePluginUnavailableError";
 		await drainAppRoutePluginLoaders(target, [
 			loader("optional", () => {
-				throw unavailable;
+				throw new OptionalAppRoutePluginUnavailableError(
+					"@elizaos/plugin-absent",
+				);
+			}),
+			loader("ok", () => plugin("ok", [route("GET", "/api/ok")])),
+		]);
+		expect(target.routes).toEqual([{ type: "GET", path: "/api/ok" }]);
+	});
+
+	it("recognizes the optional-unavailable signal by name across bundles (no instanceof)", async () => {
+		// A duplicate @elizaos/core bundle produces a distinct class identity, so
+		// the host may throw an error that is only name-equal, not instanceof-equal.
+		const target: { routes: Route[] } = { routes: [] };
+		const foreign = new Error("nope");
+		foreign.name = OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME;
+		await drainAppRoutePluginLoaders(target, [
+			loader("optional", () => {
+				throw foreign;
 			}),
 			loader("ok", () => plugin("ok", [route("GET", "/api/ok")])),
 		]);
@@ -123,5 +141,26 @@ describe("drainAppRoutePluginLoaders", () => {
 		expect(
 			target.routes.some((r) => r.path === "/api/registered/from-global"),
 		).toBe(true);
+	});
+});
+
+describe("OptionalAppRoutePluginUnavailableError", () => {
+	it("carries the canonical name + specifier and is recognized by the guard", () => {
+		const err = new OptionalAppRoutePluginUnavailableError(
+			"@elizaos/plugin-absent",
+			new Error("cause"),
+		);
+		expect(err.name).toBe(OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME);
+		expect(err.specifier).toBe("@elizaos/plugin-absent");
+		expect(err.cause).toBeInstanceOf(Error);
+		expect(isOptionalAppRoutePluginUnavailableError(err)).toBe(true);
+	});
+
+	it("guard rejects unrelated errors and non-errors", () => {
+		expect(isOptionalAppRoutePluginUnavailableError(new Error("boom"))).toBe(
+			false,
+		);
+		expect(isOptionalAppRoutePluginUnavailableError("string")).toBe(false);
+		expect(isOptionalAppRoutePluginUnavailableError(null)).toBe(false);
 	});
 });

--- a/packages/core/src/app-route-plugin-registry.ts
+++ b/packages/core/src/app-route-plugin-registry.ts
@@ -8,6 +8,49 @@ export interface AppRoutePluginRegistryEntry {
 	load: AppRoutePluginLoader;
 }
 
+/**
+ * Canonical `Error.name` for the error an app-route plugin loader throws when
+ * its plugin is intentionally absent from this deployment (optional plugin).
+ *
+ * This single string literal is the whole cross-package contract: hosts
+ * (`@elizaos/app-core`) construct {@link OptionalAppRoutePluginUnavailableError}
+ * and {@link drainAppRoutePluginLoaders} recognizes it. Matching is by name (not
+ * `instanceof`) so it stays robust when a combined deployment bundles two copies
+ * of `@elizaos/core` — the class identity differs across bundles but the name
+ * does not.
+ */
+export const OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME =
+	"OptionalAppRoutePluginUnavailableError";
+
+/**
+ * Error an app-route plugin loader throws when its optional plugin is not
+ * installed in this deployment. Hosts throw it; {@link drainAppRoutePluginLoaders}
+ * treats it as a graceful skip. Owned by core so the contract has one definition.
+ */
+export class OptionalAppRoutePluginUnavailableError extends Error {
+	readonly specifier: string;
+
+	constructor(specifier: string, cause?: unknown) {
+		super(`Optional app route plugin ${specifier} is unavailable`, { cause });
+		this.name = OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME;
+		this.specifier = specifier;
+	}
+}
+
+/**
+ * Whether `err` is the optional-app-route-plugin-unavailable signal. Matches by
+ * `Error.name` (not `instanceof`) so it holds across duplicate `@elizaos/core`
+ * bundles in a combined deployment.
+ */
+export function isOptionalAppRoutePluginUnavailableError(
+	err: unknown,
+): boolean {
+	return (
+		err instanceof Error &&
+		err.name === OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME
+	);
+}
+
 interface AppRoutePluginRegistryStore {
 	entries: Map<string, AppRoutePluginRegistryEntry>;
 }
@@ -71,12 +114,8 @@ export async function drainAppRoutePluginLoaders(
 				return await load();
 			} catch (err) {
 				// The optional-unavailable error is thrown by loaders whose plugin is
-				// intentionally absent in this deployment; identify it by name to
-				// avoid a dependency on the app-core error class.
-				if (
-					err instanceof Error &&
-					err.name === "OptionalAppRoutePluginUnavailableError"
-				) {
+				// intentionally absent in this deployment.
+				if (isOptionalAppRoutePluginUnavailableError(err)) {
 					logger.debug(
 						`[app-routes] App route plugin ${id} unavailable, skipping route registration`,
 					);


### PR DESCRIPTION
## What & why
Refs #12091 (item 21). `packages/core/src/app-route-plugin-registry.ts` matched `err.name === "OptionalAppRoutePluginUnavailableError"` — a stringly duck-typed cross-package contract — against a class defined privately in `packages/app-core/src/runtime/eliza.ts:339`. The name literal lived in two packages with no shared definition.

## Change
Core now owns the contract in **one** place (`app-route-plugin-registry.ts`):
- `OPTIONAL_APP_ROUTE_PLUGIN_UNAVAILABLE_ERROR_NAME` — the single name literal
- `OptionalAppRoutePluginUnavailableError` — the error class hosts throw
- `isOptionalAppRoutePluginUnavailableError()` — a **name-based** guard (not `instanceof`), so it stays correct across duplicate `@elizaos/core` bundles in a combined deployment.

`app-core` imports the class from `@elizaos/core` and deletes its private copy. The sanctioned `Symbol.for` registry store is untouched. No behavior change — optional app-route plugins still degrade gracefully (debug-log + skip).

## Done-when evidence
- **Name literal in exactly one package:** `grep -rn '"OptionalAppRoutePluginUnavailableError"' --include=*.ts` (excluding dist/node_modules) → only `packages/core/src/app-route-plugin-registry.ts` (the constant) + the core test's `describe` string. `app-core` no longer contains the literal.
- **Optional plugins still degrade gracefully:** `packages/core/src/app-route-plugin-registry.test.ts` — 11/11 pass, incl. new cases: drain isolates a loader throwing the real `OptionalAppRoutePluginUnavailableError` class; drain isolates a name-only-equal error thrown by a foreign bundle; guard accepts the class + rejects unrelated errors/non-errors.
- **Typecheck:** `packages/core` and `packages/app-core` — zero errors in the touched files (`app-route-plugin-registry.ts`, `app-core/src/runtime/eliza.ts`). Pre-existing unrelated failures on `develop` remain (`core/src/features/trust/providers/index.ts` references non-existent `roles.ts`/`settings.ts`; missing optional plugin/capacitor type decls) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)