### PR TITLE
fix(agent): share sensitive config key classifier

### DIFF
--- a/packages/agent/src/api/server-helpers-config.ts
+++ b/packages/agent/src/api/server-helpers-config.ts
@@ -15,17 +15,12 @@ import {
   FIRST_RUN_PROVIDER_CATALOG,
 } from "@elizaos/shared/contracts/first-run-options";
 import type { ElizaConfig } from "../config/config.ts";
+import { isSensitiveConfigKey } from "../config/sensitive-keys.ts";
 import { generateWalletKeys, setSolanaWalletEnv } from "./wallet-keygen.ts";
 
 // ---------------------------------------------------------------------------
 // Config redaction
 // ---------------------------------------------------------------------------
-
-/**
- * Key patterns that indicate a value is sensitive and must be redacted.
- */
-export const SENSITIVE_KEY_RE =
-  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|(?<!max)tokens?$/i;
 
 export function isBlockedObjectKey(key: string): boolean {
   return (
@@ -57,7 +52,7 @@ export function redactDeep(val: unknown): unknown {
   if (typeof val === "object") {
     const out: Record<string, unknown> = {};
     for (const [key, child] of Object.entries(val as Record<string, unknown>)) {
-      if (SENSITIVE_KEY_RE.test(key)) {
+      if (isSensitiveConfigKey(key)) {
         out[key] = redactValue(child);
       } else {
         out[key] = redactDeep(child);

--- a/packages/agent/src/config/schema.ts
+++ b/packages/agent/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { VERSION } from "../runtime/version.ts";
+import { isSensitiveConfigKey } from "./sensitive-keys.ts";
 
 /** Known connector IDs for config schema generation. Keep in sync with runtime/plugin maps. */
 export const CONNECTOR_IDS = [
@@ -973,10 +974,8 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/eliza.png",
 };
 
-const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
-
 function isSensitivePath(path: string): boolean {
-  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+  return isSensitiveConfigKey(path);
 }
 
 type JsonSchemaObject = JsonSchemaNode & {

--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { redactConfigSecrets } from "../api/server-helpers-config.ts";
+import { buildConfigSchema } from "./schema.ts";
+import { isSensitiveConfigKey } from "./sensitive-keys.ts";
+
+describe("isSensitiveConfigKey", () => {
+  it("covers server redaction and UI-sensitive config names", () => {
+    for (const key of [
+      "authorization",
+      "credential",
+      "seed_phrase",
+      "seedPhrase",
+      "connection_string",
+      "connectionString",
+      "accessToken",
+    ]) {
+      expect(isSensitiveConfigKey(key), key).toBe(true);
+    }
+  });
+
+  it("does not classify non-secret token-count settings", () => {
+    expect(isSensitiveConfigKey("maxTokens")).toBe(false);
+    expect(isSensitiveConfigKey("models.large.maxTokens")).toBe(false);
+  });
+});
+
+describe("sensitive config handling", () => {
+  it("redacts keys covered by the shared predicate", () => {
+    expect(
+      redactConfigSecrets({
+        seed_phrase: "seed",
+        connection_string: "postgres://secret",
+        maxTokens: 2048,
+      }),
+    ).toEqual({
+      seed_phrase: "[REDACTED]",
+      connection_string: "[REDACTED]",
+      maxTokens: 2048,
+    });
+  });
+
+  it("marks plugin config UI hints sensitive with the same predicate", () => {
+    const schema = buildConfigSchema({
+      plugins: [
+        {
+          id: "wallet",
+          configUiHints: {
+            seed_phrase: { label: "Seed phrase" },
+            connection_string: { label: "Connection string" },
+            maxTokens: { label: "Max tokens" },
+          },
+        },
+      ],
+    });
+
+    expect(
+      schema.uiHints["plugins.entries.wallet.config.seed_phrase"]?.sensitive,
+    ).toBe(true);
+    expect(
+      schema.uiHints["plugins.entries.wallet.config.connection_string"]
+        ?.sensitive,
+    ).toBe(true);
+    expect(
+      schema.uiHints["plugins.entries.wallet.config.maxTokens"]?.sensitive,
+    ).toBeUndefined();
+  });
+});

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -1,0 +1,13 @@
+/**
+ * Single classifier for config keys whose values must be treated as secrets.
+ *
+ * This is intentionally separate from BLOCKED_ENV_KEYS: blocked keys are
+ * injection/persistence policy, while this predicate controls redaction and UI
+ * sensitivity hints for arbitrary config paths.
+ */
+export const SENSITIVE_CONFIG_KEY_RE =
+  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|(?<!max)tokens?$/i;
+
+export function isSensitiveConfigKey(key: string): boolean {
+  return SENSITIVE_CONFIG_KEY_RE.test(key);
+}


### PR DESCRIPTION
## Summary
- Extracts one shared `isSensitiveConfigKey` predicate for config secret classification.
- Uses the shared predicate for API config redaction and config schema UI sensitivity hints.
- Adds coverage for `seed_phrase` and `connection_string` in both redaction and UI hint paths, while keeping `maxTokens` non-sensitive.
- Addresses #12088 item 8.

## Validation
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/agent test -- src/config/sensitive-keys.test.ts`
- `bunx @biomejs/biome check packages/agent/src/config/sensitive-keys.ts packages/agent/src/config/sensitive-keys.test.ts packages/agent/src/api/server-helpers-config.ts packages/agent/src/config/schema.ts`
- `git diff --check`
- `rg "SENSITIVE_KEY_RE|SENSITIVE_PATTERNS|SENSITIVE_CONFIG_KEY_RE|isSensitiveConfigKey" packages/agent/src -n` shows one classifier definition and both consumers.

## Evidence
- N/A - config redaction/schema behavior with no visible UI or model behavior change.