### PR TITLE
refactor(core): make the boot-config store write-once (#12091 item 22)

### DIFF
--- a/packages/core/src/boot-env.test.ts
+++ b/packages/core/src/boot-env.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { syncBrandEnvToEliza, syncElizaEnvToBrand } from "./boot-env";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	syncAppEnvToEliza,
+	syncBrandEnvToEliza,
+	syncElizaEnvToBrand,
+} from "./boot-env";
 
 function withCleanEnv(keys: string[], run: () => void): void {
 	const previous = new Map(keys.map((key) => [key, process.env[key]] as const));
@@ -74,5 +78,72 @@ describe("boot env alias syncing", () => {
 
 			expect(process.env.ELIZA_BOOT_ENV_TEST_TARGET).toBeUndefined();
 		});
+	});
+});
+
+// The boot-config store is shared across core/shared/ui bundles via the same
+// global slot; getBootConfigStore must be write-once so a late window mirror
+// cannot silently replace an already-established store (item #22 Done-when).
+const STORE_KEY = Symbol.for("elizaos.app.boot-config");
+const WINDOW_KEY = "__ELIZAOS_APP_BOOT_CONFIG__";
+type Slot = Record<PropertyKey, unknown>;
+
+describe("boot config store is write-once", () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const tracked = [
+		"ELIZA_ESTABLISHED_SRC",
+		"ELIZA_WINDOW_SRC",
+		"ELIZA_SEED_SRC",
+		"ELIZA_ESTABLISHED_DST",
+		"ELIZA_WINDOW_DST",
+		"ELIZA_SEED_DST",
+	];
+
+	beforeEach(() => {
+		const slot = globalThis as Slot;
+		delete slot[STORE_KEY];
+		delete slot[WINDOW_KEY];
+		for (const key of tracked) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		const slot = globalThis as Slot;
+		delete slot[STORE_KEY];
+		delete slot[WINDOW_KEY];
+		for (const key of tracked) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+	});
+
+	it("the window-key mirror cannot replace an established store", () => {
+		const slot = globalThis as Slot;
+		slot[STORE_KEY] = {
+			current: { envAliases: [["ELIZA_ESTABLISHED_SRC", "ELIZA_ESTABLISHED_DST"]] },
+		};
+		slot[WINDOW_KEY] = {
+			envAliases: [["ELIZA_WINDOW_SRC", "ELIZA_WINDOW_DST"]],
+		};
+		process.env.ELIZA_ESTABLISHED_SRC = "established";
+		process.env.ELIZA_WINDOW_SRC = "window";
+
+		syncAppEnvToEliza();
+
+		expect(process.env.ELIZA_ESTABLISHED_DST).toBe("established");
+		expect(process.env.ELIZA_WINDOW_DST).toBeUndefined();
+	});
+
+	it("seeds the store from the window mirror when none exists yet", () => {
+		const slot = globalThis as Slot;
+		slot[WINDOW_KEY] = { envAliases: [["ELIZA_SEED_SRC", "ELIZA_SEED_DST"]] };
+		process.env.ELIZA_SEED_SRC = "seed";
+
+		syncAppEnvToEliza();
+
+		expect(process.env.ELIZA_SEED_DST).toBe("seed");
+		expect(slot[STORE_KEY]).toBeDefined();
 	});
 });

--- a/packages/core/src/boot-env.test.ts
+++ b/packages/core/src/boot-env.test.ts
@@ -122,7 +122,9 @@ describe("boot config store is write-once", () => {
 	it("the window-key mirror cannot replace an established store", () => {
 		const slot = globalThis as Slot;
 		slot[STORE_KEY] = {
-			current: { envAliases: [["ELIZA_ESTABLISHED_SRC", "ELIZA_ESTABLISHED_DST"]] },
+			current: {
+				envAliases: [["ELIZA_ESTABLISHED_SRC", "ELIZA_ESTABLISHED_DST"]],
+			},
 		};
 		slot[WINDOW_KEY] = {
 			envAliases: [["ELIZA_WINDOW_SRC", "ELIZA_WINDOW_DST"]],

--- a/packages/core/src/boot-env.ts
+++ b/packages/core/src/boot-env.ts
@@ -24,13 +24,13 @@ function getGlobalSlot(): GlobalConfigSlot {
 
 function getBootConfigStore(): BootConfigStore {
 	const globalObject = getGlobalSlot();
-	const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
-	if (mirroredWindowConfig) {
-		const mirroredStore: BootConfigStore = { current: mirroredWindowConfig };
-		globalObject[BOOT_CONFIG_STORE_KEY] = mirroredStore;
-		return mirroredStore;
-	}
 
+	// An established store always wins. The window-key mirror is only a
+	// pre-boot seed (set by the HTML bootstrap / Electrobun preload before any
+	// bundle loads) and must never replace a store that already exists —
+	// otherwise a stale or partial window value silently clobbers config that
+	// setBootConfig already committed, and the store's object identity churns
+	// on every read (dropping any store-only state).
 	const existing = globalObject[BOOT_CONFIG_STORE_KEY];
 	if (
 		existing &&
@@ -40,7 +40,13 @@ function getBootConfigStore(): BootConfigStore {
 		return existing as BootConfigStore;
 	}
 
-	const store: BootConfigStore = { current: DEFAULT_BOOT_CONFIG };
+	// No store yet: seed it once. Prefer a cross-bundle window mirror when a
+	// bootstrap set it, otherwise fall back to defaults. The slot is written
+	// once here and thereafter returned as-is by the branch above.
+	const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
+	const store: BootConfigStore = {
+		current: mirroredWindowConfig ?? DEFAULT_BOOT_CONFIG,
+	};
 	globalObject[BOOT_CONFIG_STORE_KEY] = store;
 	globalObject[BOOT_CONFIG_WINDOW_KEY] = store.current;
 	return store;

--- a/packages/shared/src/config/boot-config-store.ts
+++ b/packages/shared/src/config/boot-config-store.ts
@@ -92,13 +92,11 @@ function getGlobalSlot(): GlobalConfigSlot {
 
 function getBootConfigStore(): BootConfigStore {
   const globalObject = getGlobalSlot();
-  const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
-  if (mirroredWindowConfig) {
-    const mirroredStore: BootConfigStore = { current: mirroredWindowConfig };
-    globalObject[BOOT_CONFIG_STORE_KEY] = mirroredStore;
-    return mirroredStore;
-  }
 
+  // An established store always wins. The window-key mirror is only a pre-boot
+  // seed and must never replace a store that already exists — see the matching
+  // note in `@elizaos/core`'s boot-env.ts. All three copies (core, shared, ui)
+  // share the same global slot, so they must agree on write-once semantics.
   const existing = globalObject[BOOT_CONFIG_STORE_KEY];
   if (
     existing &&
@@ -108,7 +106,12 @@ function getBootConfigStore(): BootConfigStore {
     return existing as BootConfigStore;
   }
 
-  const store: BootConfigStore = { current: DEFAULT_BOOT_CONFIG };
+  // No store yet: seed it once from a cross-bundle window mirror if a bootstrap
+  // set it, otherwise from defaults.
+  const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
+  const store: BootConfigStore = {
+    current: mirroredWindowConfig ?? DEFAULT_BOOT_CONFIG,
+  };
   globalObject[BOOT_CONFIG_STORE_KEY] = store;
   globalObject[BOOT_CONFIG_WINDOW_KEY] = store.current;
   return store;

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -206,12 +206,11 @@ function getGlobalSlot(): GlobalConfigSlot {
 
 function getBootConfigStore(): BootConfigStore {
   const globalObject = getGlobalSlot();
-  const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
-  if (mirroredWindowConfig) {
-    const mirroredStore: BootConfigStore = { current: mirroredWindowConfig };
-    globalObject[BOOT_CONFIG_STORE_KEY] = mirroredStore;
-    return mirroredStore;
-  }
+
+  // An established store always wins. The window-key mirror is only a pre-boot
+  // seed and must never replace a store that already exists — see the matching
+  // note in `@elizaos/core`'s boot-env.ts. All three copies (core, shared, ui)
+  // share the same global slot, so they must agree on write-once semantics.
   const existing = globalObject[BOOT_CONFIG_STORE_KEY];
   if (
     existing &&
@@ -221,7 +220,12 @@ function getBootConfigStore(): BootConfigStore {
     return existing as BootConfigStore;
   }
 
-  const store: BootConfigStore = { current: DEFAULT_BOOT_CONFIG };
+  // No store yet: seed it once from a cross-bundle window mirror if a bootstrap
+  // set it, otherwise from defaults.
+  const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
+  const store: BootConfigStore = {
+    current: mirroredWindowConfig ?? DEFAULT_BOOT_CONFIG,
+  };
   globalObject[BOOT_CONFIG_STORE_KEY] = store;
   globalObject[BOOT_CONFIG_WINDOW_KEY] = store.current;
   return store;


### PR DESCRIPTION
## What

Part of the #12091 architecture audit — **item 22**: *Make boot config an injected immutable object*.

The boot-config store is shared across the `@elizaos/core`, `@elizaos/shared`, and `@elizaos/ui` bundles through a single `Symbol.for("elizaos.app.boot-config")` global slot, mirrored to the `__ELIZAOS_APP_BOOT_CONFIG__` window key that the HTML / Electrobun / Tails renderer bootstrap seeds **before any bundle loads**.

`getBootConfigStore()` read the window mirror *first* and, whenever it was present, wrapped it in a brand-new store object that overwrote the slot. This silently clobbered config already committed by `setBootConfig`, and churned the store's object identity on every read (dropping any store-only state). All three copies share the same slot, so the clobber was reachable through any of them.

## Change

Make the store read **write-once**: an established store always wins; the window mirror is consulted only to seed the *first* store when none exists yet. This preserves the cross-bundle pre-boot seed path (bootstrap sets the window key before the first read) while removing the read-order-dependent clobber. Applied identically to all three copies that touch the shared slot (`packages/core/src/boot-env.ts`, `packages/shared/src/config/boot-config-store.ts`, `packages/ui/src/config/boot-config-store.ts`).

## Done-when evidence

- **"the window-key mirror can no longer replace an established store"** — satisfied. New seam test `packages/core/src/boot-env.test.ts` (`boot config store is write-once`) establishes a store, then sets a *different* window mirror, and asserts (via the public `syncAppEnvToEliza`, which reads `getBootConfig().envAliases`) that the established store's aliases apply and the window mirror's do **not**. A second test proves the seed-from-window path still works when no store exists. Under the old code the first test fails (the window mirror wins).
- Tests: `packages/core` `boot-env.test.ts` **4 passed** (2 pre-existing + 2 new); `packages/ui` `boot-config-store.test.ts` **2 passed**.
- Typecheck (`packages/core`): only the **2 pre-existing** dangling-export errors in `src/features/trust/providers/index.ts` (`./roles.ts`, `./settings.ts`, removed in #12103 but still exported on `develop`) — **zero** new errors from this change.

## Residual (not in this PR)

The item's other Done-when clause — *"no code path mutates process.env for alias syncing"* — is **not** addressed here. The brand↔eliza alias mechanism works precisely by mutating `process.env` so that the many downstream `process.env.ELIZA_*` readers across `core`/`agent`/`app-core` observe aliased values (write sites: `server.ts`, `server-startup.ts`, `server-security.ts`, `server-wallet-trade.ts`, `runtime/eliza.ts`, `build-character-from-config.ts`). Removing the mutation requires migrating every downstream reader to an injected resolver — a runtime-wide, behavior-sensitive cascade that is not a safe self-contained change. Reported as residual per the refactor ground rules; the write-once half (the concrete clobber bug) ships here.

Refs #12091 (item 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)