### PR TITLE
refactor(app-core): move crypto automation node specs into owning plugins (#12092 item 13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5314,6 +5314,7 @@
         "@coral-xyz/anchor": "^0.32.1",
         "@elizaos/cloud-routing": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "@elizaos/ui": "workspace:*",
         "@lifi/sdk": "^3.7.9",
         "@meteora-ag/dlmm": "^1.9.7",
         "@raydium-io/raydium-sdk": "^1.3.1-beta.58",
@@ -5336,9 +5337,13 @@
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
+        "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",
       },
+      "optionalPeers": [
+        "@elizaos/app-core",
+      ],
     },
     "plugins/plugin-wallet-ui": {
       "name": "@elizaos/plugin-wallet-ui",

--- a/packages/app-core/src/api/automation-node-contributors.ts
+++ b/packages/app-core/src/api/automation-node-contributors.ts
@@ -13,6 +13,97 @@ export type AutomationNodeContributor = (
   context: AutomationNodeContributorContext,
 ) => Promise<AutomationNodeDescriptor[]> | AutomationNodeDescriptor[];
 
+/**
+ * Declarative spec for an automation node whose availability is gated by a
+ * loaded runtime action or plugin. Owning plugins declare their specs and turn
+ * them into descriptors via {@link buildRuntimeCapabilityNodes} inside a
+ * registered contributor, so a plugin owns its own catalog entries.
+ */
+export interface RuntimeCapabilityNodeSpec {
+  id: string;
+  label: string;
+  description: string;
+  class: AutomationNodeDescriptor["class"];
+  backingCapability: string;
+  actionNames: string[];
+  pluginNames: string[];
+  ownerScoped: boolean;
+  enabledWithoutRuntimeCapability: boolean;
+  disabledReason: string;
+}
+
+function normalizeCapabilityName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function getRuntimeActionCapabilityNames(runtime: AgentRuntime): Set<string> {
+  const names = new Set<string>();
+  for (const action of runtime.actions ?? []) {
+    names.add(normalizeCapabilityName(action.name));
+    for (const simile of action.similes ?? []) {
+      names.add(normalizeCapabilityName(simile));
+    }
+  }
+  return names;
+}
+
+function getRuntimePluginNames(runtime: AgentRuntime): Set<string> {
+  return new Set(
+    (runtime.plugins ?? [])
+      .map((plugin) => normalizeCapabilityName(plugin.name))
+      .filter((name) => name.length > 0),
+  );
+}
+
+function hasMatchingRuntimeCapability(
+  spec: RuntimeCapabilityNodeSpec,
+  actionNames: Set<string>,
+  pluginNames: Set<string>,
+): boolean {
+  if (spec.enabledWithoutRuntimeCapability) {
+    return true;
+  }
+  return (
+    spec.actionNames.some((name) =>
+      actionNames.has(normalizeCapabilityName(name)),
+    ) ||
+    spec.pluginNames.some((name) =>
+      pluginNames.has(normalizeCapabilityName(name)),
+    )
+  );
+}
+
+/**
+ * Build catalog descriptors for a set of runtime-capability specs, gating each
+ * node's availability on the runtime's loaded actions/plugins.
+ */
+export function buildRuntimeCapabilityNodes(
+  specs: RuntimeCapabilityNodeSpec[],
+  runtime: AgentRuntime,
+): AutomationNodeDescriptor[] {
+  const actionNames = getRuntimeActionCapabilityNames(runtime);
+  const pluginNames = getRuntimePluginNames(runtime);
+  return specs.map((spec) => {
+    const enabled = hasMatchingRuntimeCapability(
+      spec,
+      actionNames,
+      pluginNames,
+    );
+    return {
+      id: spec.id,
+      label: spec.label,
+      description: spec.description,
+      class: spec.class,
+      source: "static_catalog",
+      backingCapability: spec.backingCapability,
+      ownerScoped: spec.ownerScoped,
+      requiresSetup: !enabled,
+      availability: enabled ? "enabled" : "disabled",
+      ...(enabled ? {} : { disabledReason: spec.disabledReason }),
+    };
+  });
+}
+
 const contributors = new Map<string, AutomationNodeContributor>();
 
 export function registerAutomationNodeContributor(

--- a/packages/app-core/src/api/automations-compat-routes.ts
+++ b/packages/app-core/src/api/automations-compat-routes.ts
@@ -21,7 +21,11 @@ import type {
   AutomationNodeDescriptor,
 } from "@elizaos/ui";
 import { ensureRouteAuthorized } from "./auth.ts";
-import { listAutomationNodeContributors } from "./automation-node-contributors";
+import {
+  buildRuntimeCapabilityNodes,
+  listAutomationNodeContributors,
+  type RuntimeCapabilityNodeSpec,
+} from "./automation-node-contributors";
 import type { CompatRuntimeState } from "./compat-route-shared";
 import {
   sendJsonError as sendJsonErrorResponse,
@@ -33,93 +37,14 @@ const BLOCKED_AUTOMATION_PROVIDER_NODES = new Set([
   "relevant-conversations",
 ]);
 
-interface StaticAutomationNodeSpec {
-  id: string;
-  label: string;
-  description: string;
-  class: AutomationNodeDescriptor["class"];
-  backingCapability: string;
-  actionNames: string[];
-  pluginNames: string[];
-  ownerScoped: boolean;
-  enabledWithoutRuntimeCapability: boolean;
-  disabledReason: string;
-}
-
-const STATIC_AUTOMATION_NODE_SPECS: StaticAutomationNodeSpec[] = [
-  {
-    id: "crypto:evm.swap",
-    label: "EVM swap",
-    description:
-      "EVM token swap automation backed by a loaded EVM runtime action.",
-    class: "action",
-    backingCapability: "SWAP",
-    actionNames: ["SWAP", "SWAP_TOKENS", "SWAP_TOKEN"],
-    pluginNames: ["evm", "wallet", "plugin-wallet", "@elizaos/plugin-wallet"],
-    ownerScoped: true,
-    enabledWithoutRuntimeCapability: false,
-    disabledReason: "Load the EVM plugin with swap support.",
-  },
-  {
-    id: "crypto:evm.bridge",
-    label: "EVM bridge",
-    description:
-      "EVM cross-chain bridge automation backed by a loaded EVM runtime action.",
-    class: "action",
-    backingCapability: "CROSS_CHAIN_TRANSFER",
-    actionNames: ["CROSS_CHAIN_TRANSFER", "BRIDGE", "BRIDGE_TOKENS"],
-    pluginNames: ["evm", "wallet", "plugin-wallet", "@elizaos/plugin-wallet"],
-    ownerScoped: true,
-    enabledWithoutRuntimeCapability: false,
-    disabledReason: "Load the EVM plugin with bridge support.",
-  },
-  {
-    id: "crypto:solana.swap",
-    label: "Solana swap",
-    description:
-      "Solana token swap automation backed by a loaded Solana runtime action.",
-    class: "action",
-    backingCapability: "SWAP_SOLANA",
-    actionNames: [
-      "SWAP_SOLANA",
-      "SWAP_SOL",
-      "SWAP_TOKENS_SOLANA",
-      "TOKEN_SWAP_SOLANA",
-      "TRADE_TOKENS_SOLANA",
-      "EXCHANGE_TOKENS_SOLANA",
-    ],
-    pluginNames: [
-      "chain_solana",
-      "solana",
-      "wallet",
-      "plugin-wallet",
-      "@elizaos/plugin-wallet",
-    ],
-    ownerScoped: true,
-    enabledWithoutRuntimeCapability: false,
-    disabledReason: "Load the Solana plugin with swap support.",
-  },
-  {
-    id: "crypto:hyperliquid.action",
-    label: "Hyperliquid action",
-    description:
-      "Hyperliquid automation entry point backed by a loaded Hyperliquid runtime plugin.",
-    class: "action",
-    backingCapability: "HYPERLIQUID_ACTION",
-    actionNames: [
-      "HYPERLIQUID_ACTION",
-      "HYPERLIQUID_ORDER",
-      "HYPERLIQUID_TRADE",
-    ],
-    pluginNames: [
-      "hyperliquid",
-      "plugin-hyperliquid",
-      "@elizaos/plugin-hyperliquid",
-    ],
-    ownerScoped: true,
-    enabledWithoutRuntimeCapability: false,
-    disabledReason: "Load the Hyperliquid runtime plugin.",
-  },
+/**
+ * Domain-agnostic automation trigger nodes that app-core owns directly. Nodes
+ * backed by a specific plugin's actions (wallet/EVM/Solana swaps + bridges,
+ * Hyperliquid trading, venue order events) are contributed by their owning
+ * plugin via {@link registerAutomationNodeContributor}, so a plugin action
+ * rename can never silently disable a node from here.
+ */
+const STATIC_AUTOMATION_NODE_SPECS: RuntimeCapabilityNodeSpec[] = [
   {
     id: "trigger:order.schedule",
     label: "Order schedule",
@@ -132,28 +57,6 @@ const STATIC_AUTOMATION_NODE_SPECS: StaticAutomationNodeSpec[] = [
     ownerScoped: false,
     enabledWithoutRuntimeCapability: true,
     disabledReason: "Automation schedules are unavailable.",
-  },
-  {
-    id: "trigger:order.event",
-    label: "Order event",
-    description:
-      "React to order lifecycle events emitted by a loaded trading venue plugin.",
-    class: "trigger",
-    backingCapability: "ORDER_EVENT",
-    actionNames: [
-      "ORDER_EVENT",
-      "ORDER_FILLED",
-      "ORDER_UPDATED",
-      "HYPERLIQUID_ACTION",
-    ],
-    pluginNames: [
-      "hyperliquid",
-      "plugin-hyperliquid",
-      "@elizaos/plugin-hyperliquid",
-    ],
-    ownerScoped: false,
-    enabledWithoutRuntimeCapability: false,
-    disabledReason: "Load an order-event-capable runtime plugin.",
   },
 ];
 
@@ -186,67 +89,6 @@ function resolveAdminEntityId(
     return configured as UUID;
   }
   return stringToUuid(`${agentName}-admin-entity`) as UUID;
-}
-
-function normalizeCapabilityName(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function getRuntimeActionCapabilityNames(runtime: AgentRuntime): Set<string> {
-  const names = new Set<string>();
-  for (const action of runtime.actions ?? []) {
-    names.add(normalizeCapabilityName(action.name));
-    for (const simile of action.similes ?? []) {
-      names.add(normalizeCapabilityName(simile));
-    }
-  }
-  return names;
-}
-
-function getRuntimePluginNames(runtime: AgentRuntime): Set<string> {
-  return new Set(
-    (runtime.plugins ?? [])
-      .map((plugin) => normalizeCapabilityName(plugin.name))
-      .filter((name) => name.length > 0),
-  );
-}
-
-function hasMatchingRuntimeCapability(
-  spec: StaticAutomationNodeSpec,
-  actionNames: Set<string>,
-  pluginNames: Set<string>,
-): boolean {
-  if (spec.enabledWithoutRuntimeCapability) {
-    return true;
-  }
-  return (
-    spec.actionNames.some((name) =>
-      actionNames.has(normalizeCapabilityName(name)),
-    ) ||
-    spec.pluginNames.some((name) =>
-      pluginNames.has(normalizeCapabilityName(name)),
-    )
-  );
-}
-
-function buildStaticAutomationNode(
-  spec: StaticAutomationNodeSpec,
-  actionNames: Set<string>,
-  pluginNames: Set<string>,
-): AutomationNodeDescriptor {
-  const enabled = hasMatchingRuntimeCapability(spec, actionNames, pluginNames);
-  return {
-    id: spec.id,
-    label: spec.label,
-    description: spec.description,
-    class: spec.class,
-    source: "static_catalog",
-    backingCapability: spec.backingCapability,
-    ownerScoped: spec.ownerScoped,
-    requiresSetup: !enabled,
-    availability: enabled ? "enabled" : "disabled",
-    ...(enabled ? {} : { disabledReason: spec.disabledReason }),
-  };
 }
 
 async function buildAutomationNodeCatalog(
@@ -299,14 +141,9 @@ async function buildAutomationNodeCatalog(
       availability: "enabled",
     }));
 
-  const runtimeActionCapabilityNames = getRuntimeActionCapabilityNames(runtime);
-  const runtimePluginNames = getRuntimePluginNames(runtime);
-  const staticAutomationNodes = STATIC_AUTOMATION_NODE_SPECS.map((spec) =>
-    buildStaticAutomationNode(
-      spec,
-      runtimeActionCapabilityNames,
-      runtimePluginNames,
-    ),
+  const staticAutomationNodes = buildRuntimeCapabilityNodes(
+    STATIC_AUTOMATION_NODE_SPECS,
+    runtime,
   );
   const contributorNodeGroups = await Promise.all(
     listAutomationNodeContributors().map((contributor) =>

--- a/packages/app-core/test/live-agent/automations-compat-routes.test.ts
+++ b/packages/app-core/test/live-agent/automations-compat-routes.test.ts
@@ -21,9 +21,83 @@ vi.doMock("../../src/api/auth.ts", () => ({
 }));
 
 import {
+  buildRuntimeCapabilityNodes,
   clearAutomationNodeContributorsForTests,
+  type RuntimeCapabilityNodeSpec,
   registerAutomationNodeContributor,
 } from "../../src/api/automation-node-contributors";
+
+// Representative crypto specs mirroring what plugin-wallet / plugin-hyperliquid
+// register through the contributor extension point. The plugins' own suites
+// assert their exact specs; here we prove app-core's catalog drains such
+// contributors and gates availability on runtime capabilities.
+const CRYPTO_CONTRIBUTOR_SPECS: RuntimeCapabilityNodeSpec[] = [
+  {
+    id: "crypto:evm.swap",
+    label: "EVM swap",
+    description:
+      "EVM token swap automation backed by a loaded EVM runtime action.",
+    class: "action",
+    backingCapability: "SWAP",
+    actionNames: ["SWAP", "SWAP_TOKENS", "SWAP_TOKEN"],
+    pluginNames: ["evm", "wallet"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the EVM plugin with swap support.",
+  },
+  {
+    id: "crypto:evm.bridge",
+    label: "EVM bridge",
+    description:
+      "EVM cross-chain bridge automation backed by a loaded EVM runtime action.",
+    class: "action",
+    backingCapability: "CROSS_CHAIN_TRANSFER",
+    actionNames: ["CROSS_CHAIN_TRANSFER", "BRIDGE", "BRIDGE_TOKENS"],
+    pluginNames: ["evm", "wallet"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the EVM plugin with bridge support.",
+  },
+  {
+    id: "crypto:solana.swap",
+    label: "Solana swap",
+    description:
+      "Solana token swap automation backed by a loaded Solana runtime action.",
+    class: "action",
+    backingCapability: "SWAP_SOLANA",
+    actionNames: ["SWAP_SOLANA", "SWAP_SOL"],
+    pluginNames: ["chain_solana", "solana", "wallet"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the Solana plugin with swap support.",
+  },
+  {
+    id: "crypto:hyperliquid.action",
+    label: "Hyperliquid action",
+    description:
+      "Hyperliquid automation entry point backed by a loaded Hyperliquid runtime plugin.",
+    class: "action",
+    backingCapability: "HYPERLIQUID_ACTION",
+    actionNames: ["HYPERLIQUID_ACTION", "HYPERLIQUID_ORDER"],
+    pluginNames: ["hyperliquid", "@elizaos/plugin-hyperliquid"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the Hyperliquid runtime plugin.",
+  },
+  {
+    id: "trigger:order.event",
+    label: "Order event",
+    description:
+      "React to order lifecycle events emitted by a loaded trading venue plugin.",
+    class: "trigger",
+    backingCapability: "ORDER_EVENT",
+    actionNames: ["ORDER_EVENT", "ORDER_FILLED", "HYPERLIQUID_ACTION"],
+    pluginNames: ["hyperliquid", "@elizaos/plugin-hyperliquid"],
+    ownerScoped: false,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load an order-event-capable runtime plugin.",
+  },
+];
 
 interface Harness {
   request: (
@@ -324,46 +398,6 @@ describe("automations compat routes", () => {
     );
     expect(body.nodes).toContainEqual(
       expect.objectContaining({
-        id: "crypto:evm.swap",
-        class: "action",
-        source: "static_catalog",
-        ownerScoped: true,
-        availability: "disabled",
-        disabledReason: "Load the EVM plugin with swap support.",
-      }),
-    );
-    expect(body.nodes).toContainEqual(
-      expect.objectContaining({
-        id: "crypto:evm.bridge",
-        class: "action",
-        source: "static_catalog",
-        ownerScoped: true,
-        availability: "disabled",
-        disabledReason: "Load the EVM plugin with bridge support.",
-      }),
-    );
-    expect(body.nodes).toContainEqual(
-      expect.objectContaining({
-        id: "crypto:solana.swap",
-        class: "action",
-        source: "static_catalog",
-        ownerScoped: true,
-        availability: "disabled",
-        disabledReason: "Load the Solana plugin with swap support.",
-      }),
-    );
-    expect(body.nodes).toContainEqual(
-      expect.objectContaining({
-        id: "crypto:hyperliquid.action",
-        class: "action",
-        source: "static_catalog",
-        ownerScoped: true,
-        availability: "disabled",
-        disabledReason: "Load the Hyperliquid runtime plugin.",
-      }),
-    );
-    expect(body.nodes).toContainEqual(
-      expect.objectContaining({
         id: "trigger:order.schedule",
         class: "trigger",
         source: "static_catalog",
@@ -371,19 +405,28 @@ describe("automations compat routes", () => {
         availability: "enabled",
       }),
     );
-    expect(body.nodes).toContainEqual(
-      expect.objectContaining({
-        id: "trigger:order.event",
-        class: "trigger",
-        source: "static_catalog",
-        ownerScoped: false,
-        availability: "disabled",
-        disabledReason: "Load an order-event-capable runtime plugin.",
-      }),
-    );
+
+    // Crypto nodes are owned by their plugins (plugin-wallet / plugin-hyperliquid)
+    // and only appear when those plugins register a contributor. With none
+    // registered here, they must be absent from the app-core static catalog.
+    for (const id of [
+      "crypto:evm.swap",
+      "crypto:evm.bridge",
+      "crypto:solana.swap",
+      "crypto:hyperliquid.action",
+      "trigger:order.event",
+    ]) {
+      expect(body.nodes.map((node) => node.id)).not.toContain(id);
+    }
   });
 
-  it("enables crypto automation descriptors only when matching capabilities are loaded", async () => {
+  it("drains crypto contributor nodes registered by owning plugins", async () => {
+    // Mirror how plugin-wallet / plugin-hyperliquid contribute their nodes: a
+    // registered contributor turns runtime-capability specs into descriptors.
+    registerAutomationNodeContributor("crypto-plugins", ({ runtime }) =>
+      buildRuntimeCapabilityNodes(CRYPTO_CONTRIBUTOR_SPECS, runtime),
+    );
+
     harness = await startApiHarness({
       current: buildRuntimeWithCryptoAutomationCapabilities() as never,
       pendingAgentName: null,
@@ -407,6 +450,36 @@ describe("automations compat routes", () => {
         expect.objectContaining({ id, availability: "enabled" }),
       );
     }
+  });
+
+  it("keeps crypto contributor nodes disabled when their capability is absent", async () => {
+    registerAutomationNodeContributor("crypto-plugins", ({ runtime }) =>
+      buildRuntimeCapabilityNodes(CRYPTO_CONTRIBUTOR_SPECS, runtime),
+    );
+
+    harness = await startApiHarness({
+      current: buildRuntimeStub() as never,
+      pendingAgentName: null,
+      pendingRestartReasons: [],
+    });
+
+    const response = await harness.request("/api/automations/nodes");
+    expect(response.status).toBe(200);
+    const body = response.json() as {
+      nodes: Array<{
+        id: string;
+        availability: string;
+        disabledReason?: string;
+      }>;
+    };
+
+    expect(body.nodes).toContainEqual(
+      expect.objectContaining({
+        id: "crypto:evm.swap",
+        availability: "disabled",
+        disabledReason: "Load the EVM plugin with swap support.",
+      }),
+    );
   });
 
   it("does not leak crypto secrets in the automation node catalog", async () => {

--- a/plugins/plugin-hyperliquid/src/automation-node-contributor.test.ts
+++ b/plugins/plugin-hyperliquid/src/automation-node-contributor.test.ts
@@ -1,0 +1,74 @@
+import {
+  type AutomationNodeContributorContext,
+  clearAutomationNodeContributorsForTests,
+  listAutomationNodeContributors,
+} from "@elizaos/app-core/api/automation-node-contributors";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerHyperliquidAutomationNodeContributor } from "./automation-node-contributor";
+
+function context(
+  runtime: Partial<{
+    actions: Array<{ name: string; similes?: string[] }>;
+    plugins: Array<{ name: string }>;
+  }>,
+): AutomationNodeContributorContext {
+  return {
+    runtime: { actions: [], plugins: [], ...runtime } as never,
+    config: {} as never,
+    agentName: "Eliza",
+    adminEntityId: "admin" as never,
+  };
+}
+
+const HYPERLIQUID_NODE_IDS = [
+  "crypto:hyperliquid.action",
+  "trigger:order.event",
+];
+
+describe("plugin-hyperliquid automation node contributor", () => {
+  afterEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  it("registers exactly one hyperliquid contributor", () => {
+    registerHyperliquidAutomationNodeContributor();
+    expect(listAutomationNodeContributors()).toHaveLength(1);
+  });
+
+  it("emits disabled hyperliquid nodes when no capability is loaded", async () => {
+    registerHyperliquidAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(context({}));
+
+    expect(nodes.map((node) => node.id)).toEqual(HYPERLIQUID_NODE_IDS);
+    expect(nodes.every((node) => node.availability === "disabled")).toBe(true);
+    expect(
+      nodes.find((node) => node.id === "crypto:hyperliquid.action")
+        ?.disabledReason,
+    ).toBe("Load the Hyperliquid runtime plugin.");
+    expect(
+      nodes.find((node) => node.id === "trigger:order.event")?.disabledReason,
+    ).toBe("Load an order-event-capable runtime plugin.");
+  });
+
+  it("enables both nodes when the hyperliquid plugin is loaded", async () => {
+    registerHyperliquidAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(
+      context({ plugins: [{ name: "@elizaos/plugin-hyperliquid" }] }),
+    );
+
+    expect(nodes.map((node) => node.id)).toEqual(HYPERLIQUID_NODE_IDS);
+    expect(nodes.every((node) => node.availability === "enabled")).toBe(true);
+  });
+
+  it("enables both nodes when a HYPERLIQUID_ACTION runtime action is present", async () => {
+    registerHyperliquidAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(
+      context({ actions: [{ name: "HYPERLIQUID_ACTION" }] }),
+    );
+
+    expect(nodes.every((node) => node.availability === "enabled")).toBe(true);
+  });
+});

--- a/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
+++ b/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
@@ -1,0 +1,75 @@
+import {
+  type AutomationNodeContributorContext,
+  buildRuntimeCapabilityNodes,
+  type RuntimeCapabilityNodeSpec,
+  registerAutomationNodeContributor,
+} from "@elizaos/app-core/api/automation-node-contributors";
+import type { AutomationNodeDescriptor } from "@elizaos/ui";
+
+/**
+ * Automation catalog nodes owned by the Hyperliquid plugin: the Hyperliquid
+ * trading action and the venue order-lifecycle event trigger. They live here
+ * (not hardcoded in app-core) so a Hyperliquid action rename or plugin name
+ * change updates the node alongside the code that gates it.
+ */
+const HYPERLIQUID_AUTOMATION_NODE_SPECS: RuntimeCapabilityNodeSpec[] = [
+  {
+    id: "crypto:hyperliquid.action",
+    label: "Hyperliquid action",
+    description:
+      "Hyperliquid automation entry point backed by a loaded Hyperliquid runtime plugin.",
+    class: "action",
+    backingCapability: "HYPERLIQUID_ACTION",
+    actionNames: [
+      "HYPERLIQUID_ACTION",
+      "HYPERLIQUID_ORDER",
+      "HYPERLIQUID_TRADE",
+    ],
+    pluginNames: [
+      "hyperliquid",
+      "plugin-hyperliquid",
+      "@elizaos/plugin-hyperliquid",
+    ],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the Hyperliquid runtime plugin.",
+  },
+  {
+    id: "trigger:order.event",
+    label: "Order event",
+    description:
+      "React to order lifecycle events emitted by a loaded trading venue plugin.",
+    class: "trigger",
+    backingCapability: "ORDER_EVENT",
+    actionNames: [
+      "ORDER_EVENT",
+      "ORDER_FILLED",
+      "ORDER_UPDATED",
+      "HYPERLIQUID_ACTION",
+    ],
+    pluginNames: [
+      "hyperliquid",
+      "plugin-hyperliquid",
+      "@elizaos/plugin-hyperliquid",
+    ],
+    ownerScoped: false,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load an order-event-capable runtime plugin.",
+  },
+];
+
+export function buildHyperliquidAutomationNodes({
+  runtime,
+}: AutomationNodeContributorContext): AutomationNodeDescriptor[] {
+  return buildRuntimeCapabilityNodes(
+    HYPERLIQUID_AUTOMATION_NODE_SPECS,
+    runtime,
+  );
+}
+
+export function registerHyperliquidAutomationNodeContributor(): void {
+  registerAutomationNodeContributor(
+    "hyperliquid",
+    buildHyperliquidAutomationNodes,
+  );
+}

--- a/plugins/plugin-hyperliquid/src/index.ts
+++ b/plugins/plugin-hyperliquid/src/index.ts
@@ -1,3 +1,7 @@
+import { registerHyperliquidAutomationNodeContributor } from "./automation-node-contributor";
+
+registerHyperliquidAutomationNodeContributor();
+
 export * from "./actions/perpetual-market";
 export * from "./client";
 export { HyperliquidView } from "./HyperliquidView";

--- a/plugins/plugin-wallet/package.json
+++ b/plugins/plugin-wallet/package.json
@@ -62,13 +62,20 @@
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist"
   },
   "peerDependencies": {
+    "@elizaos/app-core": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-elizacloud": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@elizaos/app-core": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@elizaos/cloud-routing": "workspace:*",
     "@elizaos/shared": "workspace:*",
+    "@elizaos/ui": "workspace:*",
     "@lifi/sdk": "^3.7.9",
     "@meteora-ag/dlmm": "^1.9.7",
     "@raydium-io/raydium-sdk": "^1.3.1-beta.58",

--- a/plugins/plugin-wallet/src/automation-node-contributor.test.ts
+++ b/plugins/plugin-wallet/src/automation-node-contributor.test.ts
@@ -1,0 +1,77 @@
+import {
+  type AutomationNodeContributorContext,
+  clearAutomationNodeContributorsForTests,
+  listAutomationNodeContributors,
+} from "@elizaos/app-core/api/automation-node-contributors";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerWalletAutomationNodeContributor } from "./automation-node-contributor";
+
+function context(
+  runtime: Partial<{
+    actions: Array<{ name: string; similes?: string[] }>;
+    plugins: Array<{ name: string }>;
+  }>,
+): AutomationNodeContributorContext {
+  return {
+    runtime: { actions: [], plugins: [], ...runtime } as never,
+    config: {} as never,
+    agentName: "Eliza",
+    adminEntityId: "admin" as never,
+  };
+}
+
+const WALLET_NODE_IDS = [
+  "crypto:evm.swap",
+  "crypto:evm.bridge",
+  "crypto:solana.swap",
+];
+
+describe("plugin-wallet automation node contributor", () => {
+  afterEach(() => {
+    clearAutomationNodeContributorsForTests();
+  });
+
+  it("registers exactly one wallet contributor", () => {
+    registerWalletAutomationNodeContributor();
+    expect(listAutomationNodeContributors()).toHaveLength(1);
+  });
+
+  it("emits disabled wallet nodes when no wallet capability is loaded", async () => {
+    registerWalletAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(context({}));
+
+    expect(nodes.map((node) => node.id)).toEqual(WALLET_NODE_IDS);
+    expect(nodes.every((node) => node.availability === "disabled")).toBe(true);
+    expect(nodes.every((node) => node.source === "static_catalog")).toBe(true);
+    expect(nodes.every((node) => node.ownerScoped)).toBe(true);
+    expect(
+      nodes.find((node) => node.id === "crypto:evm.swap")?.disabledReason,
+    ).toBe("Load the EVM plugin with swap support.");
+  });
+
+  it("enables all wallet nodes when the wallet plugin is loaded", async () => {
+    registerWalletAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(context({ plugins: [{ name: "wallet" }] }));
+
+    expect(nodes.map((node) => node.id)).toEqual(WALLET_NODE_IDS);
+    expect(nodes.every((node) => node.availability === "enabled")).toBe(true);
+    expect(nodes.every((node) => node.disabledReason === undefined)).toBe(true);
+  });
+
+  it("enables the solana node when a solana swap action is registered", async () => {
+    registerWalletAutomationNodeContributor();
+    const [contributor] = listAutomationNodeContributors();
+    const nodes = await contributor(
+      context({ actions: [{ name: "SWAP_SOLANA" }] }),
+    );
+
+    expect(
+      nodes.find((node) => node.id === "crypto:solana.swap")?.availability,
+    ).toBe("enabled");
+    expect(
+      nodes.find((node) => node.id === "crypto:evm.swap")?.availability,
+    ).toBe("disabled");
+  });
+});

--- a/plugins/plugin-wallet/src/automation-node-contributor.ts
+++ b/plugins/plugin-wallet/src/automation-node-contributor.ts
@@ -1,0 +1,78 @@
+import {
+  type AutomationNodeContributorContext,
+  buildRuntimeCapabilityNodes,
+  type RuntimeCapabilityNodeSpec,
+  registerAutomationNodeContributor,
+} from "@elizaos/app-core/api/automation-node-contributors";
+import type { AutomationNodeDescriptor } from "@elizaos/ui";
+
+/**
+ * Automation catalog nodes owned by the wallet plugin. These cover EVM + Solana
+ * swaps and cross-chain bridges backed by the wallet plugin's runtime actions.
+ * They live here (not hardcoded in app-core) so a wallet action rename or plugin
+ * name change updates the node in one place with the code it gates.
+ */
+const WALLET_AUTOMATION_NODE_SPECS: RuntimeCapabilityNodeSpec[] = [
+  {
+    id: "crypto:evm.swap",
+    label: "EVM swap",
+    description:
+      "EVM token swap automation backed by a loaded EVM runtime action.",
+    class: "action",
+    backingCapability: "SWAP",
+    actionNames: ["SWAP", "SWAP_TOKENS", "SWAP_TOKEN"],
+    pluginNames: ["evm", "wallet", "plugin-wallet", "@elizaos/plugin-wallet"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the EVM plugin with swap support.",
+  },
+  {
+    id: "crypto:evm.bridge",
+    label: "EVM bridge",
+    description:
+      "EVM cross-chain bridge automation backed by a loaded EVM runtime action.",
+    class: "action",
+    backingCapability: "CROSS_CHAIN_TRANSFER",
+    actionNames: ["CROSS_CHAIN_TRANSFER", "BRIDGE", "BRIDGE_TOKENS"],
+    pluginNames: ["evm", "wallet", "plugin-wallet", "@elizaos/plugin-wallet"],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the EVM plugin with bridge support.",
+  },
+  {
+    id: "crypto:solana.swap",
+    label: "Solana swap",
+    description:
+      "Solana token swap automation backed by a loaded Solana runtime action.",
+    class: "action",
+    backingCapability: "SWAP_SOLANA",
+    actionNames: [
+      "SWAP_SOLANA",
+      "SWAP_SOL",
+      "SWAP_TOKENS_SOLANA",
+      "TOKEN_SWAP_SOLANA",
+      "TRADE_TOKENS_SOLANA",
+      "EXCHANGE_TOKENS_SOLANA",
+    ],
+    pluginNames: [
+      "chain_solana",
+      "solana",
+      "wallet",
+      "plugin-wallet",
+      "@elizaos/plugin-wallet",
+    ],
+    ownerScoped: true,
+    enabledWithoutRuntimeCapability: false,
+    disabledReason: "Load the Solana plugin with swap support.",
+  },
+];
+
+export function buildWalletAutomationNodes({
+  runtime,
+}: AutomationNodeContributorContext): AutomationNodeDescriptor[] {
+  return buildRuntimeCapabilityNodes(WALLET_AUTOMATION_NODE_SPECS, runtime);
+}
+
+export function registerWalletAutomationNodeContributor(): void {
+  registerAutomationNodeContributor("wallet", buildWalletAutomationNodes);
+}

--- a/plugins/plugin-wallet/src/index.ts
+++ b/plugins/plugin-wallet/src/index.ts
@@ -1,7 +1,9 @@
 import "./core-augmentation.js";
+import { registerWalletAutomationNodeContributor } from "./automation-node-contributor.js";
 import { walletRouteRegistration } from "./register-routes.js";
 
 void walletRouteRegistration;
+registerWalletAutomationNodeContributor();
 
 export * from "./actions/index.js";
 export { BirdeyeService } from "./analytics/birdeye/service.js";

--- a/plugins/plugin-wallet/vitest.config.ts
+++ b/plugins/plugin-wallet/vitest.config.ts
@@ -7,6 +7,13 @@ const rootDir = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      // app-core only ships a built-dist export condition; point the automation
+      // node contributor registry at source so vitest resolves it without a
+      // pre-built app-core dist (the module is type-only at runtime).
+      "@elizaos/app-core/api/automation-node-contributors": path.resolve(
+        rootDir,
+        "../../packages/app-core/src/api/automation-node-contributors.ts",
+      ),
       "@elizaos/core": path.resolve(
         rootDir,
         "../../packages/core/src/index.node.ts",


### PR DESCRIPTION
## #12092 item 13 [P2][M] — crypto trading automation node specs hardcoded in app-core

`STATIC_AUTOMATION_NODE_SPECS` in `automations-compat-routes.ts` hardcoded wallet/Solana/Hyperliquid node descriptors incl. alias lists of their action names (`SWAP_SOLANA`, `HYPERLIQUID_ORDER`…) and plugin-name spellings — a plugin action rename silently disabled the node.

## Change (premise correction: `plugin-solana` doesn't exist — Solana lives in plugin-wallet)
Moved the 5 crypto specs into their owning plugins via `registerAutomationNodeContributor`; kept the 1 truly-generic node (`trigger:order.schedule`) static:

| Spec | New home |
|---|---|
| `crypto:evm.swap`, `crypto:evm.bridge`, `crypto:solana.swap` | **plugin-wallet** contributor |
| `crypto:hyperliquid.action`, `trigger:order.event` | **plugin-hyperliquid** contributor |
| `trigger:order.schedule` | kept static (generic) |

Extracted a shared `buildRuntimeCapabilityNodes(specs, runtime)` helper (still emits `source:"static_catalog"` + identical gating), so **catalog output is byte-identical when the plugins are loaded**.

### Build-cycle handled (the crux)
`agent→plugin-wallet` + `app-core→agent` already exist, so a plain `plugin-wallet→@elizaos/app-core` dep created a turbo cycle. Declared app-core an **optional `peerDependency`** in plugin-wallet — the exact idiom `@elizaos/agent` already uses — which turbo excludes from the build graph. Both plugin closures build cycle-free. (plugin-hyperliquid already depends on app-core; no cycle.)

## Verification
- **Done-criterion grep** (`SWAP_SOLANA|HYPERLIQUID|plugin-wallet|plugin-solana|plugin-hyperliquid` in `automations-compat-routes.ts`): 16 → **0**.
- Tests: app-core **5/5** (proves crypto nodes left the static catalog + flow through the registry), plugin-wallet **4/4**, plugin-hyperliquid **4/4**.
- `--filter=@elizaos/plugin-wallet...` / `plugin-hyperliquid...` closures cycle-free; core+plugin-sql build ✅. Biome clean.

| type | status |
|---|---|
| Unit tests (registry flow, all 3 packages) | ✅ 13 pass |
| done-criterion grep (→0) | ✅ |
| build-cycle | resolved via optional peerDep (agent↔app-core idiom) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)