### PR TITLE
fix(agent): exempt max token key variants from sensitivity

### DIFF
--- a/packages/agent/src/config/sensitive-keys.test.ts
+++ b/packages/agent/src/config/sensitive-keys.test.ts
@@ -20,7 +20,10 @@ describe("isSensitiveConfigKey", () => {
 
   it("does not classify non-secret token-count settings", () => {
     expect(isSensitiveConfigKey("maxTokens")).toBe(false);
+    expect(isSensitiveConfigKey("max_tokens")).toBe(false);
+    expect(isSensitiveConfigKey("max-tokens")).toBe(false);
     expect(isSensitiveConfigKey("models.large.maxTokens")).toBe(false);
+    expect(isSensitiveConfigKey("models.large.max_tokens")).toBe(false);
   });
 });
 
@@ -31,11 +34,13 @@ describe("sensitive config handling", () => {
         seed_phrase: "seed",
         connection_string: "postgres://secret",
         maxTokens: 2048,
+        max_tokens: 2048,
       }),
     ).toEqual({
       seed_phrase: "[REDACTED]",
       connection_string: "[REDACTED]",
       maxTokens: 2048,
+      max_tokens: 2048,
     });
   });
 
@@ -48,6 +53,7 @@ describe("sensitive config handling", () => {
             seed_phrase: { label: "Seed phrase" },
             connection_string: { label: "Connection string" },
             maxTokens: { label: "Max tokens" },
+            max_tokens: { label: "Max tokens" },
           },
         },
       ],
@@ -62,6 +68,9 @@ describe("sensitive config handling", () => {
     ).toBe(true);
     expect(
       schema.uiHints["plugins.entries.wallet.config.maxTokens"]?.sensitive,
+    ).toBeUndefined();
+    expect(
+      schema.uiHints["plugins.entries.wallet.config.max_tokens"]?.sensitive,
     ).toBeUndefined();
   });
 });

--- a/packages/agent/src/config/sensitive-keys.ts
+++ b/packages/agent/src/config/sensitive-keys.ts
@@ -5,9 +5,12 @@
  * injection/persistence policy, while this predicate controls redaction and UI
  * sensitivity hints for arbitrary config paths.
  */
-export const SENSITIVE_CONFIG_KEY_RE =
-  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|(?<!max)tokens?$/i;
+const SENSITIVE_CONFIG_KEY_RE =
+  /password|secret|api.?key|private.?key|seed.?phrase|authorization|connection.?string|credential|tokens?$/i;
 
 export function isSensitiveConfigKey(key: string): boolean {
+  const lastSegment = key.split(".").at(-1) ?? key;
+  const normalized = lastSegment.replace(/[-_\s]/g, "").toLowerCase();
+  if (/^maxtokens?$/.test(normalized)) return false;
   return SENSITIVE_CONFIG_KEY_RE.test(key);
 }


### PR DESCRIPTION
## Summary

Follow-up to #12148 / #12088 item 8.

The shared sensitive-config predicate exempted `maxTokens`, but snake/kebab-case variants like `max_tokens` and `max-tokens` still matched the raw `tokens?$` sensitive-key pattern. This keeps the raw regex private and routes callers through `isSensitiveConfigKey()`, which normalizes the last key segment before applying the max-token exemption.

## Validation

- `bun run --cwd packages/agent test -- src/config/sensitive-keys.test.ts`
- `bunx biome check packages/agent/src/config/sensitive-keys.ts packages/agent/src/config/sensitive-keys.test.ts packages/agent/src/api/server-helpers-config.ts packages/agent/src/config/schema.ts`
- `git diff --check`

## Evidence

N/A - config redaction/schema classification only; no UI or model trajectory change.

Refs #12088.
