### PR TITLE
refactor(core,ui): replace registerModel monkey-patch with getModelRegistrations() + MODEL_REGISTERED event (#12091 item 7)

### DIFF
--- a/packages/core/src/features/trust/providers/index.ts
+++ b/packages/core/src/features/trust/providers/index.ts
@@ -1,5 +1,3 @@
 export * from "./adminTrust.ts";
-export * from "./roles.ts";
 export * from "./securityStatus.ts";
-export * from "./settings.ts";
 export * from "./trustProfile.ts";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -145,6 +145,7 @@ import {
 	type Metadata,
 	type ModelHandler,
 	type ModelParamsMap,
+	type ModelRegistrationInfo,
 	type ModelResultMap,
 	ModelType,
 	type ModelTypeName,
@@ -4655,6 +4656,39 @@ export class AgentRuntime implements IAgentRuntime {
 				return (a.registrationOrder || 0) - (b.registrationOrder || 0);
 			});
 		}
+
+		// Announce the registration so observers (e.g. the local-inference
+		// routing table) can mirror the model registry without patching the
+		// runtime or capturing handlers. Fire-and-forget: a no-op when nothing
+		// is subscribed, and registry bookkeeping must never block boot.
+		void this.emitEvent(EventType.MODEL_REGISTERED, {
+			modelType: modelKey,
+			provider,
+			priority: priority || 0,
+		});
+	}
+
+	/**
+	 * Handler-free snapshot of every registered model handler, sorted by
+	 * priority (descending) then registration order within each model type —
+	 * the same order `getModel`/`useModel` select in. Exposes the private
+	 * `models` map as metadata so hosts and observers can render a routing
+	 * table or seed a mirror without touching handler functions. Pair with the
+	 * {@link EventType.MODEL_REGISTERED} event to stay live.
+	 */
+	getModelRegistrations(): ModelRegistrationInfo[] {
+		const out: ModelRegistrationInfo[] = [];
+		for (const [modelType, handlers] of this.models) {
+			for (const h of handlers) {
+				out.push({
+					modelType,
+					provider: h.provider,
+					priority: h.priority || 0,
+					registrationOrder: h.registrationOrder || 0,
+				});
+			}
+		}
+		return out;
 	}
 
 	/**

--- a/packages/core/src/runtime/__tests__/model-registrations.test.ts
+++ b/packages/core/src/runtime/__tests__/model-registrations.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import {
+	type Character,
+	EventType,
+	type ModelRegisteredEventPayload,
+	ModelType,
+} from "../../types";
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "ModelRegistrationsAgent",
+			bio: "test",
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+const noopHandler = async () => "ok";
+
+describe("AgentRuntime model-registration observability", () => {
+	it("emits MODEL_REGISTERED with registration metadata (no handler)", async () => {
+		const runtime = makeRuntime();
+		const seen: ModelRegisteredEventPayload[] = [];
+		runtime.registerEvent(EventType.MODEL_REGISTERED, async (payload) => {
+			seen.push(payload);
+		});
+
+		runtime.registerModel(ModelType.TEXT_LARGE, noopHandler, "provider-a", 50);
+
+		// registerModel emits fire-and-forget; give the microtask queue a turn.
+		await Promise.resolve();
+
+		expect(seen).toHaveLength(1);
+		const payload = seen[0];
+		expect(payload?.modelType).toBe(ModelType.TEXT_LARGE);
+		expect(payload?.provider).toBe("provider-a");
+		expect(payload?.priority).toBe(50);
+		// Metadata only — never leaks the handler function.
+		expect(payload).not.toHaveProperty("handler");
+	});
+
+	it("defaults the emitted priority to 0 when none is supplied", async () => {
+		const runtime = makeRuntime();
+		const seen: ModelRegisteredEventPayload[] = [];
+		runtime.registerEvent(EventType.MODEL_REGISTERED, async (payload) => {
+			seen.push(payload);
+		});
+
+		runtime.registerModel(ModelType.TEXT_SMALL, noopHandler, "provider-b");
+		await Promise.resolve();
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.priority).toBe(0);
+	});
+
+	it("getModelRegistrations() reflects every registration as handler-free metadata", () => {
+		const runtime = makeRuntime();
+		runtime.registerModel(ModelType.TEXT_LARGE, noopHandler, "provider-a", 50);
+		runtime.registerModel(ModelType.TEXT_LARGE, noopHandler, "provider-b", 10);
+		runtime.registerModel(ModelType.TEXT_EMBEDDING, noopHandler, "provider-a");
+
+		const regs = runtime.getModelRegistrations();
+
+		expect(regs).toHaveLength(3);
+		for (const reg of regs) {
+			expect(reg).not.toHaveProperty("handler");
+			expect(typeof reg.registrationOrder).toBe("number");
+		}
+
+		const large = regs.filter((r) => r.modelType === ModelType.TEXT_LARGE);
+		expect(large.map((r) => r.provider).sort()).toEqual([
+			"provider-a",
+			"provider-b",
+		]);
+		expect(
+			regs.find((r) => r.modelType === ModelType.TEXT_EMBEDDING)?.priority,
+		).toBe(0);
+	});
+
+	it("keeps useModel provider failover intact alongside the new registry API", async () => {
+		const runtime = makeRuntime();
+		const exhausted = vi.fn(async () => {
+			throw new Error("You've hit your session limit for now.");
+		});
+		const backup = vi.fn(async () => "backup response");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, exhausted, "primary", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, backup, "backup", 10);
+
+		// The registry lists both providers in priority order …
+		const providers = runtime
+			.getModelRegistrations()
+			.filter((r) => r.modelType === ModelType.TEXT_LARGE)
+			.sort((a, b) => b.priority - a.priority)
+			.map((r) => r.provider);
+		expect(providers).toEqual(["primary", "backup"]);
+
+		// … and core still fails over past the exhausted primary to the backup.
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hi" }),
+		).resolves.toBe("backup response");
+		expect(exhausted).toHaveBeenCalledTimes(1);
+		expect(backup).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -67,6 +67,7 @@ export enum EventType {
 
 	// Model events
 	MODEL_USED = "MODEL_USED",
+	MODEL_REGISTERED = "MODEL_REGISTERED",
 
 	// Embedding events
 	EMBEDDING_GENERATION_REQUESTED = "EMBEDDING_GENERATION_REQUESTED",
@@ -238,6 +239,22 @@ export interface ModelEventPayload extends EventPayload {
 		cacheCreationInputTokens?: number;
 		cachedInputTokens?: number;
 	};
+}
+
+/**
+ * Payload for {@link EventType.MODEL_REGISTERED}, emitted by
+ * `AgentRuntime.registerModel` whenever a plugin registers a model handler.
+ * Carries registration metadata only — never the handler function — so
+ * observers (e.g. the local-inference routing table) can mirror the runtime's
+ * model registry without capturing handlers or patching the prototype.
+ */
+export interface ModelRegisteredEventPayload extends EventPayload {
+	/** The model type key the handler was registered for (e.g. `TEXT_LARGE`). */
+	modelType: string;
+	/** The provider (plugin) name that registered the handler. */
+	provider: string;
+	/** Selection priority (higher wins); defaults to 0 when unspecified. */
+	priority: number;
 }
 
 /**
@@ -562,6 +579,7 @@ export interface EventPayloadMap {
 	[EventType.EVALUATOR_STARTED]: EvaluatorEventPayload;
 	[EventType.EVALUATOR_COMPLETED]: EvaluatorEventPayload;
 	[EventType.MODEL_USED]: ModelEventPayload;
+	[EventType.MODEL_REGISTERED]: ModelRegisteredEventPayload;
 	[EventType.EMBEDDING_GENERATION_REQUESTED]: EmbeddingGenerationPayload;
 	[EventType.EMBEDDING_GENERATION_COMPLETED]: EmbeddingGenerationPayload;
 	[EventType.EMBEDDING_GENERATION_FAILED]: EmbeddingGenerationPayload;

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1424,3 +1424,21 @@ export interface ModelHandler<
 
 	registrationOrder?: number;
 }
+
+/**
+ * Handler-free view of a single model registration, returned by
+ * `AgentRuntime.getModelRegistrations()`. Exposes the runtime's model registry
+ * as metadata only — no handler function — so hosts and observers can render a
+ * routing table or subscribe to registration changes without capturing
+ * handlers or reaching into the private `models` map.
+ */
+export interface ModelRegistrationInfo {
+	/** The model type key the handler is registered for (e.g. `TEXT_LARGE`). */
+	modelType: string;
+	/** The provider (plugin) name that registered the handler. */
+	provider: string;
+	/** Selection priority (higher wins); 0 when unspecified. */
+	priority: number;
+	/** Monotonic registration ordinal used as the priority tie-breaker. */
+	registrationOrder: number;
+}

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -40,6 +40,7 @@ import type {
 	GenerateTextParams,
 	GenerateTextResult,
 	ModelParamsMap,
+	ModelRegistrationInfo,
 	ModelResultMap,
 	ModelTypeName,
 	TextGenerationModelType,
@@ -901,6 +902,15 @@ export interface IAgentRuntime extends IDatabaseAdapter<object> {
 				params: Record<string, JsonValue | object>,
 		  ) => Promise<JsonValue | object>)
 		| undefined;
+
+	/**
+	 * List every registered model handler as handler-free metadata, sorted by
+	 * priority (descending) then registration order within each model type.
+	 * Hosts and observers use this to render a routing table or seed a mirror
+	 * of the model registry without capturing handlers or patching the runtime.
+	 * Pair with the {@link EventType.MODEL_REGISTERED} event to stay live.
+	 */
+	getModelRegistrations(): ModelRegistrationInfo[];
 
 	registerEvent<T extends keyof EventPayloadMap>(
 		event: T,

--- a/packages/ui/src/services/local-inference/handler-registry.test.ts
+++ b/packages/ui/src/services/local-inference/handler-registry.test.ts
@@ -1,0 +1,126 @@
+import type {
+  IAgentRuntime,
+  ModelRegisteredEventPayload,
+  ModelRegistrationInfo,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handlerRegistry } from "./handler-registry";
+
+/**
+ * Minimal runtime double exposing only the public core surface the registry
+ * now depends on: `getModelRegistrations()` for the seed snapshot and
+ * `registerEvent` to receive `MODEL_REGISTERED`. Crucially it does NOT expose
+ * `registerModel` — proving the registry populates via the event/query API and
+ * never patches or wraps a `registerModel` method.
+ */
+function makeFakeRuntime(seed: ModelRegistrationInfo[]) {
+  const eventHandlers = new Map<
+    string,
+    (payload: ModelRegisteredEventPayload) => Promise<void>
+  >();
+  const registerEvent = vi.fn(
+    (
+      event: string,
+      handler: (p: ModelRegisteredEventPayload) => Promise<void>,
+    ) => {
+      eventHandlers.set(event, handler);
+    },
+  );
+  const runtime = {
+    getModelRegistrations: () => seed,
+    registerEvent,
+  } as unknown as IAgentRuntime;
+  return {
+    runtime,
+    registerEvent,
+    async fire(payload: ModelRegisteredEventPayload) {
+      const handler = eventHandlers.get("MODEL_REGISTERED");
+      if (!handler) throw new Error("MODEL_REGISTERED handler not registered");
+      await handler(payload);
+    },
+  };
+}
+
+function payload(
+  over: Partial<ModelRegisteredEventPayload>,
+): ModelRegisteredEventPayload {
+  return {
+    modelType: "TEXT_LARGE",
+    provider: "provider-x",
+    priority: 0,
+    runtime: {} as IAgentRuntime,
+    ...over,
+  };
+}
+
+describe("UI handler-registry populates via the core event, not the patch", () => {
+  it("subscribes to MODEL_REGISTERED and never touches registerModel", () => {
+    const { runtime, registerEvent } = makeFakeRuntime([]);
+
+    handlerRegistry.installOn(runtime);
+
+    expect(registerEvent).toHaveBeenCalledTimes(1);
+    expect(registerEvent).toHaveBeenCalledWith(
+      "MODEL_REGISTERED",
+      expect.any(Function),
+    );
+    // The runtime double has no registerModel — installOn must not require
+    // or wrap one (the old monkey-patch path would have thrown/patched).
+    expect(
+      (runtime as unknown as { registerModel?: unknown }).registerModel,
+    ).toBeUndefined();
+  });
+
+  it("seeds from getModelRegistrations() on install", () => {
+    const { runtime } = makeFakeRuntime([
+      {
+        modelType: "SEED_ONLY_TYPE",
+        provider: "seed-provider",
+        priority: 42,
+        registrationOrder: 1,
+      },
+    ]);
+
+    handlerRegistry.installOn(runtime);
+
+    const rows = handlerRegistry.getForType("SEED_ONLY_TYPE");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      modelType: "SEED_ONLY_TYPE",
+      provider: "seed-provider",
+      priority: 42,
+    });
+  });
+
+  it("records subsequent registrations delivered by the MODEL_REGISTERED event", async () => {
+    const { runtime, fire } = makeFakeRuntime([]);
+    handlerRegistry.installOn(runtime);
+
+    await fire(
+      payload({
+        modelType: "EVENT_DRIVEN_TYPE",
+        provider: "high",
+        priority: 100,
+      }),
+    );
+    await fire(
+      payload({
+        modelType: "EVENT_DRIVEN_TYPE",
+        provider: "low",
+        priority: 1,
+      }),
+    );
+
+    const rows = handlerRegistry.getForType("EVENT_DRIVEN_TYPE");
+    expect(rows.map((r) => r.provider)).toEqual(["high", "low"]);
+    // Metadata only — no captured handler function leaks into the registry.
+    expect(rows[0]).not.toHaveProperty("handler");
+  });
+
+  it("is idempotent per runtime instance (no double subscription)", () => {
+    const { runtime, registerEvent } = makeFakeRuntime([]);
+    handlerRegistry.installOn(runtime);
+    handlerRegistry.installOn(runtime);
+    expect(registerEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/services/local-inference/handler-registry.ts
+++ b/packages/ui/src/services/local-inference/handler-registry.ts
@@ -1,38 +1,29 @@
 /**
  * Side-registry of model handlers registered on an AgentRuntime.
  *
- * The elizaOS core exposes `runtime.registerModel(type, handler, provider,
- * priority)` but no way to list who registered what. This module intercepts
- * `registerModel` at runtime to record every registration in a Map keyed by
- * model type, plus fires status listeners so the UI can render a live
- * [ModelType × Provider] routing table.
+ * elizaOS core owns the model registry; this module mirrors it for the UI so
+ * we can render a live [ModelType × Provider] routing table. It stays in sync
+ * through the public core API — {@link IAgentRuntime.getModelRegistrations} for
+ * the initial snapshot and the `MODEL_REGISTERED` runtime event for subsequent
+ * registrations — instead of patching `AgentRuntime.prototype.registerModel`.
  *
- * Because we monkey-patch `registerModel` we also keep the original
- * handler reference — the router-handler (see `router-handler.ts`) uses
- * this to dispatch inference calls by policy without going through
- * `runtime.useModel` (which would loop back to us and recurse).
+ * The registry holds registration metadata only (never handler functions):
+ * dispatch and provider failover are core's job via `runtime.useModel`, so the
+ * UI never captures or invokes handlers.
  */
 
-// Type-only import: pulling the `AgentRuntime` *value* here would drag core's
-// ~2MB browser bundle into the eager first-paint graph. Local inference is
-// opt-in, so the prototype patch is installed lazily from the runtime instance
-// passed to `installOn()` (see below) — we never need the static class.
-import type { AgentRuntime, IAgentRuntime } from "@elizaos/core";
+// Type-only imports keep `@elizaos/core`'s ~2MB browser bundle out of the
+// eager first-paint graph. Local inference is opt-in: the registry is seeded
+// from the live runtime instance handed to `installOn()` (see below), and the
+// `MODEL_REGISTERED` event key is referenced as a plain string literal so this
+// module never value-imports core.
+import type { IAgentRuntime, ModelRegisteredEventPayload } from "@elizaos/core";
 
 export interface HandlerRegistration {
   modelType: string;
   provider: string;
   priority: number;
   registeredAt: string;
-  /**
-   * The original handler function. Captured so the router-handler can
-   * dispatch to it directly, bypassing `runtime.useModel` which would
-   * re-enter the router itself.
-   */
-  handler: (
-    runtime: IAgentRuntime,
-    params: Record<string, unknown>,
-  ) => Promise<unknown>;
 }
 
 type Listener = (registrations: HandlerRegistration[]) => void;
@@ -40,7 +31,7 @@ type Listener = (registrations: HandlerRegistration[]) => void;
 class HandlerRegistry {
   private readonly registrations = new Map<string, HandlerRegistration[]>();
   private readonly listeners = new Set<Listener>();
-  private installedOn: WeakSet<object> = new WeakSet();
+  private readonly installedOn = new WeakSet<object>();
 
   /**
    * Snapshot of all registrations grouped by model type, sorted by
@@ -61,10 +52,7 @@ class HandlerRegistry {
     return list ? [...list] : [];
   }
 
-  /**
-   * Registrations excluding a specific provider. Used by the router-handler
-   * to find "all providers except me" when dispatching.
-   */
+  /** Registrations for a model type excluding a specific provider. */
   getForTypeExcluding(
     modelType: string,
     excludeProvider: string,
@@ -105,149 +93,43 @@ class HandlerRegistry {
   }
 
   /**
-   * Install the interception on a runtime. Idempotent per runtime instance.
-   * For most boot paths the prototype-level patch below already covers the
-   * runtime before any plugin registers; this method is the belt-and-braces
-   * fallback for runtimes constructed before the patch ran.
+   * Mirror a runtime's model registry into this side-registry. Idempotent
+   * per runtime instance. Seeds from the current registrations, then stays
+   * live via the `MODEL_REGISTERED` event — no prototype patching, no
+   * handler capture.
    */
-  installOn(runtime: AgentRuntime): void {
-    // Patch the prototype via the live instance (no static `AgentRuntime`
-    // import needed). Idempotent and benign — forwards to the original.
-    const proto = Object.getPrototypeOf(runtime) as {
-      registerModel?: RegisterModelMethod;
-    } | null;
-    if (proto) installPrototypePatch(proto);
-    const rt = runtime as AgentRuntime & {
-      registerModel?: unknown;
-    };
-    if (typeof rt.registerModel !== "function") return;
-    if (this.installedOn.has(rt)) return;
-    this.installedOn.add(rt);
+  installOn(runtime: IAgentRuntime): void {
+    if (this.installedOn.has(runtime)) return;
+    this.installedOn.add(runtime);
 
-    // If the runtime already inherited the patched prototype method the
-    // prototype handles every call. Nothing to do per-instance.
-    const protoMethod = Object.getPrototypeOf(rt)?.registerModel as
-      | RegisterModelMethod
-      | undefined;
-    if (protoMethod && isPatchedRegisterModel(protoMethod)) {
-      return;
-    }
-
-    // Per-instance wrap only for legacy runtimes whose prototype pre-dates
-    // our prototype patch (shouldn't happen in practice).
-    const original = rt.registerModel.bind(runtime) as (
-      modelType: string,
-      handler: HandlerRegistration["handler"],
-      provider: string,
-      priority?: number,
-    ) => void;
-    rt.registerModel = ((
-      modelType: string,
-      handler: HandlerRegistration["handler"],
-      provider: string,
-      priority?: number,
-    ) => {
+    const now = new Date().toISOString();
+    for (const reg of runtime.getModelRegistrations()) {
       this.record({
-        modelType: String(modelType),
-        provider: String(provider),
-        priority: typeof priority === "number" ? priority : 0,
-        registeredAt: new Date().toISOString(),
-        handler,
+        modelType: reg.modelType,
+        provider: reg.provider,
+        priority: reg.priority,
+        registeredAt: now,
       });
-      return original(modelType, handler, provider, priority);
-    }) as typeof rt.registerModel;
-  }
-
-  /** Exposed so the prototype patch can record through the singleton. */
-  recordFromPrototype(reg: HandlerRegistration): void {
-    this.record(reg);
-  }
-}
-
-const PATCH_MARK = Symbol.for("eliza.local-inference.registerModel.patched");
-let prototypePatched = false;
-
-type RegisterModelMethod = (
-  this: AgentRuntime,
-  modelType: string,
-  handler: HandlerRegistration["handler"],
-  provider: string,
-  priority?: number,
-) => void;
-
-type PatchedRegisterModelMethod = RegisterModelMethod & {
-  [PATCH_MARK]?: true;
-};
-
-function isPatchedRegisterModel(
-  method: unknown,
-): method is PatchedRegisterModelMethod {
-  return (
-    typeof method === "function" &&
-    (method as { [PATCH_MARK]?: true })[PATCH_MARK] === true
-  );
-}
-
-/**
- * One-shot patch of `AgentRuntime.prototype.registerModel` so every runtime
- * instance — including ones constructed later in boot — records through
- * the singleton handler registry. Idempotent.
- *
- * Takes the prototype object (obtained from a live runtime instance) rather
- * than referencing the static `AgentRuntime` class, so this module never
- * value-imports `@elizaos/core` and stays off the eager bundle graph.
- */
-function installPrototypePatch(proto: {
-  registerModel?: RegisterModelMethod;
-}): void {
-  if (prototypePatched) return;
-  const original = proto.registerModel;
-  if (typeof original !== "function") return;
-  if (isPatchedRegisterModel(original)) {
-    prototypePatched = true;
-    return;
-  }
-  const patched = function patchedRegisterModel(
-    this: unknown,
-    modelType: string,
-    handler: HandlerRegistration["handler"],
-    provider: string,
-    priority?: number,
-  ): void {
-    try {
-      handlerRegistry.recordFromPrototype({
-        modelType: String(modelType),
-        provider: String(provider),
-        priority: typeof priority === "number" ? priority : 0,
-        registeredAt: new Date().toISOString(),
-        handler,
-      });
-    } catch {
-      // Never let registry bookkeeping break the registration path.
     }
-    (original as RegisterModelMethod).call(
-      this as AgentRuntime,
-      modelType,
-      handler,
-      provider,
-      priority,
-    );
-  } as typeof original & { [PATCH_MARK]?: true };
-  patched[PATCH_MARK] = true;
-  proto.registerModel = patched;
-  prototypePatched = true;
-}
 
-// NOTE: no module-load patch. The prototype is patched lazily from the first
-// runtime instance handed to `handlerRegistry.installOn(runtime)` during
-// local-inference setup. This keeps `@elizaos/core` (and its ~2MB bundle) out
-// of the eager first-paint graph for every app that never opens local inference.
+    runtime.registerEvent(
+      "MODEL_REGISTERED",
+      async (payload: ModelRegisteredEventPayload) => {
+        this.record({
+          modelType: payload.modelType,
+          provider: payload.provider,
+          priority: payload.priority,
+          registeredAt: new Date().toISOString(),
+        });
+      },
+    );
+  }
+}
 
 export const handlerRegistry = new HandlerRegistry();
 
 /**
- * Public type used by the API/UI — omits the handler function for
- * serialisation and to prevent UI code from accidentally calling it.
+ * Public type used by the API/UI — the serialisable registration shape.
  */
 export interface PublicRegistration {
   modelType: string;


### PR DESCRIPTION
## What & why

Refs #12091 (item 7). The local-inference routing table used to rewrite `AgentRuntime.prototype.registerModel` (a `Symbol.for` prototype patch plus a per-instance wrap) to build a shadow registry of who registered what — an inverted, host→core reverse edge that bypassed core and broke on any `registerModel` signature change.

This replaces the monkey-patch with a real, public core API and has the UI mirror the runtime's model registry through it.

### Core (`packages/core`)
- New `IAgentRuntime.getModelRegistrations(): ModelRegistrationInfo[]` — handler-free snapshot of the model registry (modelType, provider, priority, registrationOrder).
- New `EventType.MODEL_REGISTERED` + `ModelRegisteredEventPayload` (metadata only, never the handler), emitted fire-and-forget from `registerModel` (mirrors the existing model-event pattern).
- Provider failover is unchanged: `useModel(type, params, provider)` already routes provider-scoped with the default-chain failover tail intact.

### UI (`packages/ui`)
- `services/local-inference/handler-registry.ts` no longer contains any prototype assignment. `installOn(runtime)` now **seeds** from `runtime.getModelRegistrations()` and **stays live** via the `MODEL_REGISTERED` event. The registry holds metadata only — no captured handlers.

### Incidental unblock
- Removed two dead re-exports (`./roles`, `./settings`) left dangling in the core trust-providers barrel by #12103; they otherwise fail `packages/core` build/typecheck on `develop`.

## Done-when evidence
- `handler-registry.ts` contains **no prototype assignment** — `grep -n "prototype|PATCH_MARK|\.registerModel =" packages/ui/src/services/local-inference/handler-registry.ts` returns only doc-comment mentions.
- Routing works through the new core API with failover intact — new core test asserts `useModel` fails past an exhausted primary to the backup while `getModelRegistrations()` lists both providers in priority order.
- New tests:
  - `packages/core/src/runtime/__tests__/model-registrations.test.ts` — registering a model emits `MODEL_REGISTERED` and `getModelRegistrations()` reflects it (4 tests, pass).
  - `packages/ui/src/services/local-inference/handler-registry.test.ts` — the UI registry populates via the event/query and never touches `registerModel` (4 tests, pass).

## Verification
- `packages/core` build ✓, typecheck ✓; `packages/ui` typecheck ✓
- core model tests: `model-provider-failover` + `use-model-provider-fallback` + `model-registrations` → 16 pass
- ui local-inference suite → 88 pass; biome clean on all touched files
- No behavior change: core registry/dispatch unchanged; UI registry is a passive mirror.

## Residual (out of scope, reported)
The **live** local-inference dispatch path — `plugins/plugin-local-inference/src/services/{handler-registry,router-handler}.ts` — keeps its own near-identical monkey-patch and dispatches captured raw handlers around `useModel` (bypassing failover). Converting it requires a priority-scoped `useModel` variant so the top-priority router can dispatch to a chosen provider without recursing into itself — a routing-subsystem redesign beyond this item's stated `packages/core` + `packages/ui` scope and carrying real behavior-change risk. The core API added here (`getModelRegistrations` + `MODEL_REGISTERED`) is the foundation a follow-up needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
