### PR TITLE
refactor(core): register kernel security hooks through the plugin system (#12091 item 23)

### DIFF
--- a/packages/core/src/features/trust/providers/index.ts
+++ b/packages/core/src/features/trust/providers/index.ts
@@ -1,5 +1,3 @@
 export * from "./adminTrust.ts";
-export * from "./roles.ts";
 export * from "./securityStatus.ts";
-export * from "./settings.ts";
 export * from "./trustProfile.ts";

--- a/packages/core/src/plugins/core-security-hooks.test.ts
+++ b/packages/core/src/plugins/core-security-hooks.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentRuntime } from "../runtime.ts";
+import type { PipelineHookSpec } from "../types/pipeline-hooks.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+import {
+	CORE_SECURITY_HOOKS_PLUGIN_NAME,
+	createCoreSecurityHooksPlugin,
+} from "./core-security-hooks.ts";
+
+// #12091 item 23: the two always-on core security defenses used to be wired via
+// lazy `await import()` calls inside `AgentRuntime.initialize`, invisible to
+// plugin bookkeeping and with no dispose. They now register through a plugin's
+// `init`, so `registerPlugin` owns their lifecycle. These assert the plugin
+// registers BOTH pipeline hooks through the plugin `init` path — i.e. the same
+// `registerPipelineHook` calls now flow through `registerPlugin`.
+describe("core security hooks plugin (#12091 item 23)", () => {
+	it("registers both message-path security hooks through plugin init", async () => {
+		const registered: PipelineHookSpec[] = [];
+		const runtime = {
+			registerPipelineHook: (spec: PipelineHookSpec) => {
+				registered.push(spec);
+			},
+		} as unknown as IAgentRuntime;
+
+		const plugin = createCoreSecurityHooksPlugin();
+		expect(plugin.name).toBe(CORE_SECURITY_HOOKS_PLUGIN_NAME);
+		expect(plugin.init).toBeTypeOf("function");
+
+		await plugin.init?.({}, runtime);
+
+		const ids = registered.map((s) => s.id).sort();
+		expect(ids).toEqual([
+			"core:incoming-message-security",
+			"core:should-respond-injection-risk",
+		]);
+
+		const incoming = registered.find(
+			(s) => s.id === "core:incoming-message-security",
+		);
+		expect(incoming?.phase).toBe("incoming_before_compose");
+		const risk = registered.find(
+			(s) => s.id === "core:should-respond-injection-risk",
+		);
+		expect(risk?.phase).toBe("parallel_with_should_respond");
+	});
+
+	it("registers through the real boot path into plugin bookkeeping", async () => {
+		// Boot a real runtime the way `initialize` does — no dynamic feature
+		// imports left in that path (they moved onto this plugin). The security
+		// plugin must land in `runtime.plugins`, proving `registerPlugin` owns its
+		// lifecycle instead of the old lazy `await import()`.
+		const runtime = new AgentRuntime({ logLevel: "fatal" });
+		await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+		try {
+			const names = runtime.plugins.map((p) => p.name);
+			expect(names).toContain(CORE_SECURITY_HOOKS_PLUGIN_NAME);
+		} finally {
+			await runtime.stop();
+		}
+	});
+});

--- a/packages/core/src/plugins/core-security-hooks.ts
+++ b/packages/core/src/plugins/core-security-hooks.ts
@@ -1,0 +1,31 @@
+import { registerCoreShouldRespondRiskHook } from "../features/trust/should-respond-risk-gate";
+import { registerCoreIncomingMessageSecurityHook } from "../security/incoming-message-security";
+import type { Plugin } from "../types/plugin";
+
+export const CORE_SECURITY_HOOKS_PLUGIN_NAME = "core-security-hooks";
+
+/**
+ * Core message-path security defenses, registered through the plugin lifecycle
+ * so `registerPlugin` owns their bookkeeping and disposal instead of a bespoke
+ * lazy import inside `AgentRuntime.initialize`. The two hooks are always-on:
+ *
+ *  - `core:incoming-message-security` (GHSA-gh63-5vpj-39qp) — external-content
+ *    wrapping + sensitive-text scrubbing on the incoming user message.
+ *  - `core:should-respond-injection-risk` (#9949) — deterministic RiskFactors
+ *    stamping during the parallel-with-should-respond phase.
+ *
+ * Both `registerCore*Hook` functions are register-functions that call
+ * `runtime.registerPipelineHook`; wrapping them in a plugin `init` is a pure
+ * relocation of the same calls onto the plugin path with no behavior change.
+ */
+export function createCoreSecurityHooksPlugin(): Plugin {
+	return {
+		name: CORE_SECURITY_HOOKS_PLUGIN_NAME,
+		description:
+			"Always-on core message-path security defenses (external-content hardening + injection-risk stamping).",
+		init: (_config, runtime) => {
+			registerCoreIncomingMessageSecurityHook(runtime);
+			registerCoreShouldRespondRiskHook(runtime);
+		},
+	};
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -21,6 +21,7 @@ import { createLogger } from "./logger";
 import { simpleHash } from "./optimization/ab-analysis";
 import { getOptimizationRootDir } from "./optimization-root-dir";
 import { installRuntimePluginLifecycle } from "./plugin-lifecycle";
+import { createCoreSecurityHooksPlugin } from "./plugins/core-security-hooks";
 import {
 	getNativeRuntimeFeaturePlugin,
 	type NativeRuntimeFeature,
@@ -2359,6 +2360,15 @@ export class AgentRuntime implements IAgentRuntime {
 			this.registerPlugin(basicCapabilitiesPlugin),
 		);
 
+		// Always-on core message-path security defenses. Registered through the
+		// plugin lifecycle (GHSA-gh63-5vpj-39qp incoming-message hardening + #9949
+		// injection-risk stamping) so their pipeline hooks appear in plugin
+		// bookkeeping and dispose with the runtime, rather than a lazy dynamic
+		// import buried in initialize.
+		pluginRegistrationPromises.push(
+			this.registerPlugin(createCoreSecurityHooksPlugin()),
+		);
+
 		for (const feature of Object.keys(
 			nativeRuntimeFeatureDefaults,
 		) as NativeRuntimeFeature[]) {
@@ -2432,19 +2442,6 @@ export class AgentRuntime implements IAgentRuntime {
 
 		// Initialize message service
 		this.messageService = new DefaultMessageService();
-
-		const { registerCoreIncomingMessageSecurityHook } = await import(
-			"./security/incoming-message-security.js"
-		);
-		registerCoreIncomingMessageSecurityHook(this);
-
-		// #9949: stamp deterministic injection RiskFactors during the
-		// parallel-with-should-respond phase so the role-keyed verify gate in the
-		// message service can escalate borderline USER/GUEST messages.
-		const { registerCoreShouldRespondRiskHook } = await import(
-			"./features/trust/should-respond-risk-gate.js"
-		);
-		registerCoreShouldRespondRiskHook(this);
 
 		// Run migrations for all loaded plugins (unless explicitly skipped for serverless mode)
 		const skipMigrations = options?.skipMigrations ?? false;


### PR DESCRIPTION
## What

`AgentRuntime.initialize` hardwired its two always-on message-path security defenses via lazy dynamic imports, bypassing the plugin lifecycle used by every sibling feature — no dispose, hidden boot-order coupling, invisible to plugin bookkeeping. No cycle or bundler constraint justified the lazy imports (both modules already live in core).

Removed from `initialize`:
```ts
const { registerCoreIncomingMessageSecurityHook } = await import(
    "./security/incoming-message-security.js");
const { registerCoreShouldRespondRiskHook } = await import(
    "./features/trust/should-respond-risk-gate.js");
```

They are now wired as a single `core-security-hooks` plugin (`packages/core/src/plugins/core-security-hooks.ts`) whose `init` registers both pipeline hooks. It is registered through `registerPlugin` in the same batch as the basic-capabilities plugin, so `registerPlugin` owns their lifecycle and the plugin appears in `runtime.plugins`. Imports are static wiring in one composition file. This is a pure relocation — the same `registerPipelineHook` calls, no behavior change (`registerPipelineHook` is a plain map upsert with no dependency on adapter/messageService, so moving the calls earlier in `initialize` is safe).

Also completes already-merged #12103: it deleted `trust/providers/roles.ts` + `settings.ts` but left the barrel exporting them, leaving the core build red on develop. This drops those two orphaned exports (nothing imports them — consumers import the remaining providers directly).

## Done-when evidence

- `initialize` contains **no** dynamic imports of feature modules — `grep -c "await import(" packages/core/src/runtime.ts` → **0**.
- The hooks register through the plugin path and the plugin lands in plugin-lifecycle bookkeeping — new test `src/plugins/core-security-hooks.test.ts`:
  - unit: plugin `init` registers both hook ids (`core:incoming-message-security`, `core:should-respond-injection-risk`) with correct phases.
  - boot smoke: a real `AgentRuntime` booted via `initialize({ allowNoDatabase: true })` has `core-security-hooks` in `runtime.plugins`.
- `bun run --cwd packages/core build` — clean.
- `bun run --cwd packages/core typecheck` — clean.
- `bun run --cwd packages/core vitest run src/plugins src/security src/features/trust` — **184 passed**.

Refs #12091 (item 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)