### PR TITLE
refactor(core): consolidate globalThis ambient-context stashes (#12091 item 37)

### DIFF
--- a/packages/core/src/ambient-context.test.ts
+++ b/packages/core/src/ambient-context.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	getAmbientSingleton,
+	peekAmbientSingleton,
+	setAmbientSingleton,
+} from "./ambient-context";
+
+const KEY = Symbol.for("elizaos.test.ambient-context.singleton");
+
+afterEach(() => {
+	delete (globalThis as Record<PropertyKey, unknown>)[KEY];
+});
+
+describe("ambient-context singleton", () => {
+	it("creates the value once and reuses it across calls", () => {
+		const factory = vi.fn(() => ({ id: "first" }));
+
+		const a = getAmbientSingleton(KEY, factory);
+		const b = getAmbientSingleton(KEY, factory);
+
+		expect(a).toBe(b);
+		expect(factory).toHaveBeenCalledTimes(1);
+	});
+
+	it("stores the value on the shared global slot so duplicate copies agree", () => {
+		const value = { id: "shared" };
+		getAmbientSingleton(KEY, () => value);
+
+		expect((globalThis as Record<PropertyKey, unknown>)[KEY]).toBe(value);
+		expect(peekAmbientSingleton(KEY)).toBe(value);
+	});
+
+	it("setAmbientSingleton overrides the value everywhere immediately", () => {
+		getAmbientSingleton(KEY, () => ({ id: "original" }));
+		const override = { id: "override" };
+
+		setAmbientSingleton(KEY, override);
+
+		// A subsequent get returns the override, never re-running the factory.
+		const factory = vi.fn(() => ({ id: "unused" }));
+		expect(getAmbientSingleton(KEY, factory)).toBe(override);
+		expect(factory).not.toHaveBeenCalled();
+	});
+
+	it("peek returns undefined before anything is stored", () => {
+		expect(peekAmbientSingleton(KEY)).toBeUndefined();
+	});
+});

--- a/packages/core/src/ambient-context.ts
+++ b/packages/core/src/ambient-context.ts
@@ -1,0 +1,61 @@
+/**
+ * Core-owned ambient-context registry.
+ *
+ * Several core singletons (the trajectory + action-routing context managers,
+ * the trajectory-source registry, the curated-app and app-route-plugin
+ * registries) must be shared by every consumer regardless of which bundled copy
+ * of `@elizaos/core` they imported from. Historically each site hand-rolled its
+ * own `Symbol.for(...)` read/write against `globalThis`, plus a module-local
+ * cache. The module-local caches were the real hazard: under a duplicated core
+ * bundle each copy could cache a *different* instance while a
+ * `set…Manager(...)` override wrote only the shared global, so reads and writes
+ * disagreed and contexts interleaved.
+ *
+ * This module centralizes the pattern into one guarded accessor. The global
+ * slot is the single source of truth — there is no module-local cache — so all
+ * copies always observe the same instance, and an override is immediately
+ * visible everywhere.
+ *
+ * The correct end-state is to externalize `@elizaos/core` in downstream bundle
+ * configs so a second copy cannot load at all; until then this module makes the
+ * dual-copy path as safe as it can be.
+ */
+
+type AmbientSlot = Record<PropertyKey, unknown>;
+
+function ambientSlot(): AmbientSlot {
+	return globalThis as AmbientSlot;
+}
+
+/**
+ * Return the process-global singleton stored at `key`, creating it with
+ * `factory` (and storing it) on first access. All bundled core copies share the
+ * value because the read/write goes through `globalThis` under the same
+ * `Symbol.for` key.
+ */
+export function getAmbientSingleton<T>(key: symbol, factory: () => T): T {
+	const slot = ambientSlot();
+	const existing = slot[key];
+	if (existing !== undefined) {
+		return existing as T;
+	}
+	const created = factory();
+	slot[key] = created;
+	return created;
+}
+
+/**
+ * Overwrite the process-global singleton at `key`. Used by the test-only
+ * `set…Manager` overrides that need every copy to observe the replacement.
+ */
+export function setAmbientSingleton<T>(key: symbol, value: T): void {
+	ambientSlot()[key] = value;
+}
+
+/**
+ * Read the process-global singleton at `key` without creating one. Returns
+ * `undefined` when nothing has been stored yet.
+ */
+export function peekAmbientSingleton<T>(key: symbol): T | undefined {
+	return ambientSlot()[key] as T | undefined;
+}

--- a/packages/core/src/app-registry.ts
+++ b/packages/core/src/app-registry.ts
@@ -1,3 +1,5 @@
+import { getAmbientSingleton } from "./ambient-context";
+
 export interface ElizaCuratedAppDefinition {
 	slug: string;
 	canonicalName: string;
@@ -13,16 +15,9 @@ const ELIZA_CURATED_APP_REGISTRY_KEY = Symbol.for(
 );
 
 function getCuratedAppRegistryStore(): CuratedAppRegistryStore {
-	const globalObject = globalThis as Record<PropertyKey, unknown>;
-	const existing = globalObject[ELIZA_CURATED_APP_REGISTRY_KEY] as
-		| CuratedAppRegistryStore
-		| null
-		| undefined;
-	if (existing) return existing;
-
-	const created: CuratedAppRegistryStore = { entries: [] };
-	globalObject[ELIZA_CURATED_APP_REGISTRY_KEY] = created;
-	return created;
+	return getAmbientSingleton(ELIZA_CURATED_APP_REGISTRY_KEY, () => ({
+		entries: [],
+	}));
 }
 
 /**

--- a/packages/core/src/app-route-plugin-registry.ts
+++ b/packages/core/src/app-route-plugin-registry.ts
@@ -1,3 +1,4 @@
+import { getAmbientSingleton } from "./ambient-context";
 import { logger } from "./logger";
 import type { Plugin, Route } from "./types/plugin";
 
@@ -60,20 +61,9 @@ const APP_ROUTE_PLUGIN_REGISTRY_KEY = Symbol.for(
 );
 
 function getRegistryStore(): AppRoutePluginRegistryStore {
-	const globalObject = globalThis as Record<PropertyKey, unknown>;
-	const existing = globalObject[APP_ROUTE_PLUGIN_REGISTRY_KEY] as
-		| AppRoutePluginRegistryStore
-		| null
-		| undefined;
-	if (existing) {
-		return existing;
-	}
-
-	const created: AppRoutePluginRegistryStore = {
+	return getAmbientSingleton(APP_ROUTE_PLUGIN_REGISTRY_KEY, () => ({
 		entries: new Map<string, AppRoutePluginRegistryEntry>(),
-	};
-	globalObject[APP_ROUTE_PLUGIN_REGISTRY_KEY] = created;
-	return created;
+	}));
 }
 
 export function registerAppRoutePluginLoader(

--- a/packages/core/src/runtime/action-routing-context.ts
+++ b/packages/core/src/runtime/action-routing-context.ts
@@ -18,6 +18,7 @@
  *   - The trajectory recorder already uses the same pattern; this matches.
  */
 
+import { getAmbientSingleton, setAmbientSingleton } from "../ambient-context";
 import type { ActionModelClass } from "../types/components";
 import { StackContextManager } from "../utils/stack-context-manager";
 
@@ -37,9 +38,6 @@ interface IActionRoutingContextManager {
 }
 
 const MANAGER_KEY = Symbol.for("elizaos.actionRoutingContextManager");
-type GlobalWithManager = typeof globalThis & {
-	[MANAGER_KEY]?: IActionRoutingContextManager;
-};
 
 function isNodeEnvironment(): boolean {
 	return (
@@ -74,19 +72,10 @@ function initManagerSync(): IActionRoutingContextManager {
 	return new StackContextManager<ActionRoutingContext | undefined>();
 }
 
-let globalManager: IActionRoutingContextManager | null = null;
-
 function getOrCreate(): IActionRoutingContextManager {
-	if (!globalManager) {
-		const existing = (globalThis as GlobalWithManager)[MANAGER_KEY];
-		if (existing) {
-			globalManager = existing;
-		} else {
-			globalManager = initManagerSync();
-			(globalThis as GlobalWithManager)[MANAGER_KEY] = globalManager;
-		}
-	}
-	return globalManager;
+	// Shared global slot is the single source of truth (no module-local cache),
+	// matching the trajectory context manager — see ambient-context.ts.
+	return getAmbientSingleton(MANAGER_KEY, initManagerSync);
 }
 
 export function runWithActionRoutingContext<T>(
@@ -118,6 +107,5 @@ export function runWithoutActionRoutingContext<T>(
 export function setActionRoutingContextManager(
 	manager: IActionRoutingContextManager,
 ): void {
-	globalManager = manager;
-	(globalThis as GlobalWithManager)[MANAGER_KEY] = manager;
+	setAmbientSingleton(MANAGER_KEY, manager);
 }

--- a/packages/core/src/trajectory-context.ts
+++ b/packages/core/src/trajectory-context.ts
@@ -6,6 +6,7 @@
  * Browser: stack-based fallback.
  */
 
+import { getAmbientSingleton, setAmbientSingleton } from "./ambient-context";
 import type { PseudonymSession } from "./security/pii-pseudonymizer";
 import type { SecretSwapSession } from "./security/secret-swap";
 import type { RoleGateRole } from "./types/contexts";
@@ -63,14 +64,9 @@ export interface ITrajectoryContextManager {
 // The previous lazy async init (.then()) caused a race: the stack-based
 // fallback was used for early messages, which doesn't propagate context
 // through async/await — so logLlmCall never saw the trajectory step ID.
-let globalContextManager: ITrajectoryContextManager | null = null;
 const TRAJECTORY_CONTEXT_MANAGER_KEY = Symbol.for(
 	"elizaos.trajectoryContextManager",
 );
-
-type GlobalWithTrajectoryContextManager = typeof globalThis & {
-	[TRAJECTORY_CONTEXT_MANAGER_KEY]?: ITrajectoryContextManager;
-};
 
 function isNodeEnvironment(): boolean {
 	return (
@@ -106,29 +102,19 @@ function initContextManagerSync(): ITrajectoryContextManager {
 }
 
 function getOrCreateContextManager(): ITrajectoryContextManager {
-	if (!globalContextManager) {
-		const globalManager = (globalThis as GlobalWithTrajectoryContextManager)[
-			TRAJECTORY_CONTEXT_MANAGER_KEY
-		];
-		if (globalManager) {
-			globalContextManager = globalManager;
-		} else {
-			globalContextManager = initContextManagerSync();
-			(globalThis as GlobalWithTrajectoryContextManager)[
-				TRAJECTORY_CONTEXT_MANAGER_KEY
-			] = globalContextManager;
-		}
-	}
-	return globalContextManager;
+	// The shared global slot is the single source of truth (no module-local
+	// cache): under a duplicated core bundle every copy must observe the same
+	// manager, and `setTrajectoryContextManager` must be visible everywhere.
+	return getAmbientSingleton(
+		TRAJECTORY_CONTEXT_MANAGER_KEY,
+		initContextManagerSync,
+	);
 }
 
 export function setTrajectoryContextManager(
 	manager: ITrajectoryContextManager,
 ): void {
-	globalContextManager = manager;
-	(globalThis as GlobalWithTrajectoryContextManager)[
-		TRAJECTORY_CONTEXT_MANAGER_KEY
-	] = manager;
+	setAmbientSingleton(TRAJECTORY_CONTEXT_MANAGER_KEY, manager);
 }
 
 export function getTrajectoryContextManager(): ITrajectoryContextManager {

--- a/packages/core/src/trajectory-utils.ts
+++ b/packages/core/src/trajectory-utils.ts
@@ -1,3 +1,4 @@
+import { getAmbientSingleton } from "./ambient-context.js";
 import { isTruthyEnvValue } from "./env-utils.js";
 import {
 	CONTEXT_OBJECT_TRAJECTORY_VERSION,
@@ -1030,18 +1031,11 @@ const TRAJECTORY_SOURCE_REGISTRY_KEY = Symbol.for(
 	"elizaos.trajectorySourceRegistry",
 );
 
-type GlobalWithTrajectorySourceRegistry = typeof globalThis & {
-	[TRAJECTORY_SOURCE_REGISTRY_KEY]?: Map<string, TrajectorySourceMeta>;
-};
-
 function getRegistry(): Map<string, TrajectorySourceMeta> {
-	const g = globalThis as GlobalWithTrajectorySourceRegistry;
-	let registry = g[TRAJECTORY_SOURCE_REGISTRY_KEY];
-	if (!registry) {
-		registry = new Map<string, TrajectorySourceMeta>();
-		g[TRAJECTORY_SOURCE_REGISTRY_KEY] = registry;
-	}
-	return registry;
+	return getAmbientSingleton(
+		TRAJECTORY_SOURCE_REGISTRY_KEY,
+		() => new Map<string, TrajectorySourceMeta>(),
+	);
 }
 
 export function registerTrajectorySource(


### PR DESCRIPTION
## What

Part of the #12091 architecture audit — **item 37**: *Consolidate core's globalThis ambient-context stashes*.

Core stashed several process-global singletons on `globalThis` under ad-hoc `Symbol.for(...)` keys to survive the duplicate-core-bundle problem. Each site hand-rolled its own read/write **plus a module-local cache**. The module-local caches were the real interleaving hazard the item flags: under a duplicated core bundle each copy could cache a *different* manager instance while a `set…ContextManager(...)` override wrote only the shared global — so reads and writes disagreed and the trajectory / action-routing contexts interleaved. The non-Node `StackContextManager` fallback made it worse, since each copy kept its own stack.

## Change

Introduce one core-owned `packages/core/src/ambient-context.ts` with a guarded accessor — `getAmbientSingleton(key, factory)` / `setAmbientSingleton(key, value)` / `peekAmbientSingleton(key)`. The **global slot is now the single source of truth — there is no module-local cache** — so every core copy observes the same instance and an override is immediately visible everywhere. This directly addresses the two prioritized risks (the `StackContextManager` fallback and the `setTrajectoryContextManager` process-global override).

Migrated the globalThis ambient-context stash sites to it:

| Site | Key |
|---|---|
| `trajectory-context.ts` | `elizaos.trajectoryContextManager` (+ setter) |
| `runtime/action-routing-context.ts` | `elizaos.actionRoutingContextManager` (+ setter) |
| `trajectory-utils.ts` | `elizaos.trajectorySourceRegistry` |
| `app-registry.ts` | `elizaos.curated-app-registry` |
| `app-route-plugin-registry.ts` | `elizaos.app.route-plugin-registry` |

No behavior change on the normal single-copy path; the multi-copy path is strictly more consistent.

## Done-when evidence

- **"Symbol.for globalThis stashes for ambient context go through one module"** — satisfied for the migrated sites: all five now read/write `globalThis` only via `ambient-context.ts` (no direct `globalThis[...]` casts remain in those files).
- Seam test `packages/core/src/ambient-context.test.ts` (4 tests): create-once/reuse, shared-global storage, immediate override visibility, and empty-peek.
- Tests: `ambient-context.test.ts` + `trajectory-context.test.ts` + `app-route-plugin-registry.test.ts` + `action-model-routing.test.ts` + `message-runtime-stage1.test.ts` → **136 passed** (5 files). The last is a full AgentRuntime construct-and-process-message smoke, so the boot/trajectory path is intact.
- Typecheck (`packages/core`): only the **2 pre-existing** dangling-export errors in `src/features/trust/providers/index.ts` (`./roles.ts`, `./settings.ts`, removed in #12103 but still exported on `develop`) — **zero** new errors from this change. Biome clean on all touched files.

## Residual (reported per the item's [M]/broad fallback)

1. **Bundle externalization of `@elizaos/core`** — the item's second Done-when clause (*"bundle configs externalize core so a second copy cannot load"*) is **not** done here. Library/Node builds already externalize `@elizaos/*` (`packages/core/build.ts`); the duplicate-copy problem is specific to the **mobile** bundle (the same reason the `__bundle_safety_` anchors of item #34 exist). Externalizing core there and proving the APK/IPA still boots requires an on-device build + boot verification that is out of scope for a safe, self-contained refactor PR. This consolidation makes the dual-copy path as safe as it can be (single shared instance, no stale local caches) in the meantime.
2. **Sites intentionally left as-is** (not globalThis ambient-context stashes, so out of item scope): `runtime-route-context.ts` (`elizaos.runtime-route-host-context`) and `trajectory-utils.ts` `elizaos.recordLlmCallDepth` are keyed on the **runtime / context object** (already correctly per-scope, not global); `api/http-helpers.ts` `CACHED_REQUEST_BODY`/`CACHED_JSON_BODY` are keyed on the **Request** object; `actions/promote-subactions.ts` and `runtime/conversation-compaction-hook.ts` symbols are per-object markers / event-type constants, not stashes; `boot-env.ts`'s boot-config slot is handled by item #22 (PR #12153). `testing/browser-mocks.ts` install-marks are test-only.
3. **StackContextManager async algorithm** unchanged — its `finally`-pop before an async `fn` settles is a separate latent bug; fixing it is a behavior change beyond this refactor's "no behavior change" bar. The consolidation mitigates the *cross-copy* interleaving (one shared stack) but not concurrent-async within the non-Node fallback.

Refs #12091 (item 37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)