### PR TITLE
refactor(ui): app-catalog curation reads declared manifest fields, not name sets (#12092 item 24)

### DIFF
--- a/packages/agent/src/services/registry-client-app-meta.ts
+++ b/packages/agent/src/services/registry-client-app-meta.ts
@@ -138,6 +138,10 @@ export function mergeAppMeta(
     developerOnly: patch.developerOnly ?? base.developerOnly,
     visibleInAppStore: patch.visibleInAppStore ?? base.visibleInAppStore,
     mainTab: patch.mainTab ?? base.mainTab,
+    catalogSection: patch.catalogSection ?? base.catalogSection,
+    featured: patch.featured ?? base.featured,
+    defaultHidden: patch.defaultHidden ?? base.defaultHidden,
+    scope: patch.scope ?? base.scope,
   };
 }
 

--- a/packages/agent/src/services/registry-client-local.ts
+++ b/packages/agent/src/services/registry-client-local.ts
@@ -48,6 +48,10 @@ interface LocalPackageAppMeta {
    * landing tab at boot.
    */
   mainTab?: boolean;
+  catalogSection?: string;
+  featured?: boolean;
+  defaultHidden?: boolean;
+  scope?: string;
 }
 
 interface LocalPackageElizaConfig {
@@ -259,6 +263,10 @@ function toLocalAppMeta(
     developerOnly: app?.developerOnly,
     visibleInAppStore: app?.visibleInAppStore,
     mainTab: app?.mainTab,
+    catalogSection: app?.catalogSection,
+    featured: app?.featured,
+    defaultHidden: app?.defaultHidden,
+    scope: app?.scope,
   };
 }
 

--- a/packages/agent/src/services/registry-client-network.ts
+++ b/packages/agent/src/services/registry-client-network.ts
@@ -139,6 +139,10 @@ async function fetchGeneratedRegistry(
               developerOnly?: boolean;
               visibleInAppStore?: boolean;
               mainTab?: boolean;
+              catalogSection?: string;
+              featured?: boolean;
+              defaultHidden?: boolean;
+              scope?: string;
             };
           }
         >;
@@ -207,6 +211,10 @@ async function fetchGeneratedRegistry(
             developerOnly: e.app.developerOnly,
             visibleInAppStore: e.app.visibleInAppStore,
             mainTab: e.app.mainTab,
+            catalogSection: e.app.catalogSection,
+            featured: e.app.featured,
+            defaultHidden: e.app.defaultHidden,
+            scope: e.app.scope,
           };
         }
 

--- a/packages/agent/src/services/registry-client-queries.ts
+++ b/packages/agent/src/services/registry-client-queries.ts
@@ -207,6 +207,10 @@ export function toAppInfo(
     developerOnly: meta?.developerOnly,
     visibleInAppStore: meta?.visibleInAppStore,
     mainTab: meta?.mainTab,
+    catalogSection: meta?.catalogSection,
+    featured: meta?.featured,
+    defaultHidden: meta?.defaultHidden,
+    scope: meta?.scope,
   };
 }
 

--- a/packages/agent/src/services/registry-client-types.ts
+++ b/packages/agent/src/services/registry-client-types.ts
@@ -57,6 +57,18 @@ export interface RegistryAppMeta {
    * `getMainTabApp()` in `@elizaos/app-core` at boot.
    */
   mainTab?: boolean;
+  /**
+   * Declared catalog home section (`games` | `developerUtilities` | `finance`
+   * | `other`), sourced from `package.json` → `elizaos.app.catalogSection`.
+   * When absent the section is derived from `category`/keywords.
+   */
+  catalogSection?: string;
+  /** Promote the app into the Featured catalog section. */
+  featured?: boolean;
+  /** Hide the app from the catalog by default (see `scope` for wallet reveal). */
+  defaultHidden?: boolean;
+  /** Capability scope gating default visibility (`"wallet"`). */
+  scope?: string;
 }
 
 export interface RegistryPluginInfo {

--- a/packages/shared/src/contracts/apps.ts
+++ b/packages/shared/src/contracts/apps.ts
@@ -201,6 +201,32 @@ export interface RegistryAppInfo {
    * to compute the shell's landing tab at boot.
    */
   mainTab?: boolean;
+  /**
+   * Declared home section for the app catalog, sourced from `package.json` →
+   * `elizaos.app.catalogSection`. One of the concrete catalog sections
+   * (`games` | `developerUtilities` | `finance` | `other`). When absent, the
+   * section is derived from `category` and keyword heuristics. The dynamic
+   * `featured` / `favorites` sections are never declared here (they are
+   * computed from `featured` and the user's starred apps).
+   */
+  catalogSection?: string;
+  /**
+   * If true, the app is promoted into the Featured catalog section. Sourced
+   * from `elizaos.app.featured`. Featured is presentational only — it does not
+   * make an otherwise-hidden app appear.
+   */
+  featured?: boolean;
+  /**
+   * If true, the app is hidden from the catalog by default and only surfaces
+   * when explicitly configured as a default app, or — for `scope: "wallet"`
+   * apps — when the wallet is enabled. Sourced from `elizaos.app.defaultHidden`.
+   */
+  defaultHidden?: boolean;
+  /**
+   * Capability scope that gates default visibility. `"wallet"` apps are
+   * revealed when the wallet is enabled. Sourced from `elizaos.app.scope`.
+   */
+  scope?: string;
 }
 
 export interface AppSessionState {

--- a/packages/ui/src/components/apps/helpers-catalog-curation.test.ts
+++ b/packages/ui/src/components/apps/helpers-catalog-curation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { RegistryAppInfo } from "../../api";
+import {
+  getAppCatalogSectionKey,
+  groupAppsForCatalog,
+  shouldShowAppInAppsView,
+} from "./helpers";
+
+// Curation is driven entirely by manifest-declared fields
+// (`package.json` → `elizaos.app.{catalogSection,featured,defaultHidden,scope}`),
+// not by hardcoded package-name sets. These cases assert the declared metadata
+// reproduces the classifications that were previously hardcoded in helpers.ts.
+
+function app(overrides: Partial<RegistryAppInfo>): RegistryAppInfo {
+  return {
+    category: "utility",
+    description: "",
+    displayName: "Demo",
+    name: "@elizaos/plugin-demo",
+    ...overrides,
+  } as RegistryAppInfo;
+}
+
+describe("getAppCatalogSectionKey — declared curation", () => {
+  it("promotes apps declaring featured into the Featured section", () => {
+    expect(
+      getAppCatalogSectionKey(app({ featured: true, category: "utility" })),
+    ).toBe("featured");
+  });
+
+  it("honors a declared catalogSection over the category heuristic", () => {
+    // Finance apps historically declared category "game" but were forced into
+    // finance by a name switch — now they declare catalogSection directly.
+    expect(
+      getAppCatalogSectionKey(
+        app({ catalogSection: "finance", category: "game" }),
+      ),
+    ).toBe("finance");
+    expect(
+      getAppCatalogSectionKey(app({ catalogSection: "games", category: "" })),
+    ).toBe("games");
+  });
+
+  it("falls back to the category heuristic when no section is declared", () => {
+    expect(getAppCatalogSectionKey(app({ category: "game" }))).toBe("games");
+    expect(getAppCatalogSectionKey(app({ category: "utility" }))).toBe(
+      "developerUtilities",
+    );
+  });
+
+  it("ignores a non-declarable section value (featured/favorites are dynamic)", () => {
+    // A non-declarable value must be ignored — the section is then identical
+    // to what the category/keyword heuristic yields with no declaration.
+    const base = { name: "@elizaos/app-widget", category: "misc" };
+    expect(
+      getAppCatalogSectionKey(app({ ...base, catalogSection: "favorites" })),
+    ).toBe(getAppCatalogSectionKey(app(base)));
+  });
+});
+
+describe("groupAppsForCatalog — declared curation", () => {
+  it("groups a featured app and a finance app into their sections", () => {
+    const sections = groupAppsForCatalog([
+      app({ name: "@elizaos/plugin-featured", featured: true }),
+      app({
+        name: "@elizaos/plugin-money",
+        catalogSection: "finance",
+        category: "game",
+      }),
+    ]);
+    const byKey = new Map(sections.map((s) => [s.key, s.apps.map((a) => a.name)]));
+    expect(byKey.get("featured")).toEqual(["@elizaos/plugin-featured"]);
+    expect(byKey.get("finance")).toEqual(["@elizaos/plugin-money"]);
+  });
+});
+
+describe("shouldShowAppInAppsView — declared default-hidden + wallet scope", () => {
+  // Curated app names pass the "curated / configured / internal" visibility
+  // gate, letting us exercise the defaultHidden + scope branch directly.
+  const walletApp = (overrides: Partial<RegistryAppInfo> = {}) =>
+    app({
+      name: "@elizaos/plugin-hyperliquid",
+      catalogSection: "finance",
+      defaultHidden: true,
+      scope: "wallet",
+      ...overrides,
+    });
+
+  it("hides a wallet-scoped default-hidden app when the wallet is off", () => {
+    expect(
+      shouldShowAppInAppsView(walletApp(), {
+        showAllApps: false,
+        walletEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("reveals a wallet-scoped default-hidden app when the wallet is on", () => {
+    expect(
+      shouldShowAppInAppsView(walletApp(), {
+        showAllApps: false,
+        walletEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a default-hidden app without wallet scope hidden even with wallet on", () => {
+    expect(
+      shouldShowAppInAppsView(
+        app({
+          name: "@elizaos/plugin-shopify",
+          catalogSection: "finance",
+          defaultHidden: true,
+        }),
+        { showAllApps: false, walletEnabled: true },
+      ),
+    ).toBe(false);
+  });
+
+  it("shows a plain (not default-hidden) catalog app", () => {
+    expect(
+      shouldShowAppInAppsView(
+        app({
+          name: "@elizaos/plugin-hyperliquid",
+          catalogSection: "finance",
+        }),
+        { showAllApps: false, walletEnabled: false },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/ui/src/components/apps/helpers.ts
+++ b/packages/ui/src/components/apps/helpers.ts
@@ -58,22 +58,27 @@ const APPS_VIEW_HIDDEN_APP_NAME_SET = new Set<string>(
   APPS_VIEW_HIDDEN_APP_NAMES,
 );
 
-const FEATURED_APP_NAMES = new Set<string>([
-  "@elizaos/plugin-personal-assistant",
+/**
+ * Catalog sections an app may declare in `package.json` →
+ * `elizaos.app.catalogSection`. The dynamic `featured` / `favorites` sections
+ * are computed (from the `featured` flag and the user's starred apps) and are
+ * never declarable.
+ */
+const DECLARABLE_APP_CATALOG_SECTIONS = new Set<AppCatalogSectionKey>([
+  "games",
+  "developerUtilities",
+  "finance",
+  "other",
 ]);
 
-const DEFAULT_VISIBLE_GAME_APP_NAMES = new Set<string>([]);
-
-const DEFAULT_HIDDEN_APP_NAMES = new Set<string>([
-  "@elizaos/plugin-hyperliquid",
-  "@elizaos/plugin-polymarket",
-  "@elizaos/plugin-shopify",
-]);
-
-const WALLET_SCOPED_APP_NAMES = new Set<string>([
-  "@elizaos/plugin-hyperliquid",
-  "@elizaos/plugin-polymarket",
-]);
+function isDeclarableCatalogSection(
+  value: string | undefined,
+): value is AppCatalogSectionKey {
+  return (
+    value !== undefined &&
+    (DECLARABLE_APP_CATALOG_SECTIONS as ReadonlySet<string>).has(value)
+  );
+}
 
 const APP_CATALOG_SECTION_ORDER: readonly AppCatalogSectionKey[] = [
   "featured",
@@ -92,10 +97,10 @@ function getConfiguredDefaultAppNames(): ReadonlySet<string> {
   );
 }
 
-function isFeaturedAppName(name: string): boolean {
-  return (
-    FEATURED_APP_NAMES.has(name) || getConfiguredDefaultAppNames().has(name)
-  );
+function isFeaturedApp(
+  app: Pick<RegistryAppInfo, "name" | "featured">,
+): boolean {
+  return app.featured === true || getConfiguredDefaultAppNames().has(app.name);
 }
 
 export interface AppCatalogSection {
@@ -163,7 +168,10 @@ export function isCuratedGameApp(
 }
 
 export function shouldShowAppInAppsView(
-  app: Pick<RegistryAppInfo, "category" | "name">,
+  app: Pick<
+    RegistryAppInfo,
+    "category" | "name" | "catalogSection" | "featured" | "defaultHidden" | "scope"
+  >,
   options: {
     isProd?: boolean;
     showAllApps?: boolean;
@@ -202,11 +210,13 @@ export function shouldShowAppInAppsView(
     category: app.category,
     displayName: "",
     description: "",
+    catalogSection: app.catalogSection,
+    featured: app.featured,
   });
 
   if (
-    DEFAULT_HIDDEN_APP_NAMES.has(canonicalName) &&
-    !(walletEnabled && WALLET_SCOPED_APP_NAMES.has(canonicalName)) &&
+    app.defaultHidden === true &&
+    !(walletEnabled && app.scope === "wallet") &&
     !configuredDefaultAppNames.has(app.name) &&
     !configuredDefaultAppNames.has(canonicalName)
   ) {
@@ -215,7 +225,7 @@ export function shouldShowAppInAppsView(
 
   if (sectionKey === "games") {
     return (
-      DEFAULT_VISIBLE_GAME_APP_NAMES.has(canonicalName) ||
+      app.defaultHidden === false ||
       configuredDefaultAppNames.has(app.name) ||
       configuredDefaultAppNames.has(canonicalName)
     );
@@ -320,10 +330,10 @@ export function getDefaultAppsCatalogSelection(
 export function getAppCatalogSectionKey(
   app: Pick<
     RegistryAppInfo,
-    "name" | "displayName" | "description" | "category"
+    "name" | "displayName" | "description" | "category" | "catalogSection" | "featured"
   >,
 ): AppCatalogSectionKey {
-  if (isFeaturedAppName(app.name)) {
+  if (isFeaturedApp(app)) {
     return "featured";
   }
 
@@ -331,14 +341,8 @@ export function getAppCatalogSectionKey(
     return "developerUtilities";
   }
 
-  const canonicalName = normalizeElizaCuratedAppName(app.name) ?? app.name;
-  switch (canonicalName) {
-    case "@elizaos/plugin-shopify":
-    case "@elizaos/plugin-hyperliquid":
-    case "@elizaos/plugin-polymarket":
-      return "finance";
-    case "@elizaos/plugin-feed":
-      return "games";
+  if (isDeclarableCatalogSection(app.catalogSection)) {
+    return app.catalogSection;
   }
 
   const normalizedCategory = app.category.trim().toLowerCase();
@@ -388,7 +392,7 @@ export function getAppCatalogSectionKey(
 export function getAppCatalogSectionLabel(
   app: Pick<
     RegistryAppInfo,
-    "name" | "displayName" | "description" | "category"
+    "name" | "displayName" | "description" | "category" | "catalogSection" | "featured"
   >,
 ): string {
   return APP_CATALOG_SECTION_LABELS[getAppCatalogSectionKey(app)];
@@ -419,7 +423,7 @@ export function groupAppsForCatalog(
   }
 
   const featuredApps = apps.filter(
-    (app) => isFeaturedAppName(app.name) && !favoriteAppNames.has(app.name),
+    (app) => isFeaturedApp(app) && !favoriteAppNames.has(app.name),
   );
   if (featuredApps.length > 0) {
     sections.push({

--- a/plugins/plugin-feed/package.json
+++ b/plugins/plugin-feed/package.json
@@ -49,6 +49,7 @@
     "app": {
       "displayName": "Feed",
       "category": "game",
+      "catalogSection": "games",
       "heroImage": "assets/hero.png",
       "launchType": "url",
       "launchUrl": "{FEED_CLIENT_URL}",

--- a/plugins/plugin-hyperliquid/package.json
+++ b/plugins/plugin-hyperliquid/package.json
@@ -41,7 +41,10 @@
   },
   "elizaos": {
     "app": {
-      "heroImage": "assets/hero.png"
+      "heroImage": "assets/hero.png",
+      "catalogSection": "finance",
+      "defaultHidden": true,
+      "scope": "wallet"
     },
     "appRegister": "register"
   },

--- a/plugins/plugin-personal-assistant/package.json
+++ b/plugins/plugin-personal-assistant/package.json
@@ -120,6 +120,7 @@
   "elizaos": {
     "app": {
       "heroImage": "assets/hero.png",
+      "featured": true,
       "permissions": [
         "reminders",
         "calendar",

--- a/plugins/plugin-polymarket/package.json
+++ b/plugins/plugin-polymarket/package.json
@@ -41,7 +41,10 @@
   },
   "elizaos": {
     "app": {
-      "heroImage": "assets/hero.png"
+      "heroImage": "assets/hero.png",
+      "catalogSection": "finance",
+      "defaultHidden": true,
+      "scope": "wallet"
     },
     "appRegister": "register"
   },

--- a/plugins/plugin-shopify/package.json
+++ b/plugins/plugin-shopify/package.json
@@ -76,7 +76,9 @@
   },
   "elizaos": {
     "app": {
-      "heroImage": "assets/hero.png"
+      "heroImage": "assets/hero.png",
+      "catalogSection": "finance",
+      "defaultHidden": true
     },
     "appRegister": "register"
   },


### PR DESCRIPTION
## #12092 item 24 [P2][M] — app catalog curation switches on hardcoded plugin package names

`helpers.ts` decided catalog section / featured / default-hidden / wallet-scope via hardcoded name SETS (`FEATURED_APP_NAMES`, `DEFAULT_HIDDEN_APP_NAMES`, `WALLET_SCOPED_APP_NAMES`) + a finance/games name switch. A plugin couldn't set its own placement; a rename silently broke curation.

## Change
- Extended the app manifest (`elizaos.app`) with `catalogSection`, `featured`, `defaultHidden`, `scope`; ingested through the SAME path as `visibleInAppStore`/`mainTab` (`RegistryAppInfo` + the agent registry-client chain: types / local / queries / network / app-meta merge).
- Declared the fields on the 5 currently-curated plugin package.json files (personal-assistant featured; hyperliquid/polymarket/shopify finance+hidden(+wallet); feed games).
- `helpers.ts` now reads `app.featured`/`app.catalogSection`/`app.defaultHidden`/`app.scope`; **deleted all 3 name sets + the switch**.

**Scoped-out with rationale:** `APPS_VIEW_HIDDEN_APP_NAMES`/`isHiddenFromAppsView` was left — it's a different concern (hide-entirely vs section-placement), and one entry (`plugin-task-coordinator`) is a synthesized internal-tool app carrying no manifest, so migrating it isn't behavior-preserving. Recommended as its own follow-up.

## Verification
- New `helpers-catalog-curation.test.ts` — **9 pass** (featured / declared-section / default-hidden / wallet-scoped on+off / plain). Full `apps/` suite **75/75**, no regression.
- `grep` for the removed sets across `packages/`+`plugins/` → **0** references.
- `tsgo` shared **0 errors**, ui **0 errors**; agent only pre-existing unbuilt-workspace `TS2307`.

| type | status |
|---|---|
| Unit tests (curation from manifest) | ✅ 9 pass; 75/75 suite |
| removed-name-set grep (→0) | ✅ |
| shared+ui typecheck | ✅ 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)