### PR TITLE
fix(core): add Cerebras to first-run provider catalog + drift-guard test (#12092 item 19)

### DIFF
--- a/packages/core/src/contracts/first-run-options.ts
+++ b/packages/core/src/contracts/first-run-options.ts
@@ -57,6 +57,7 @@ export interface StylePreset {
 
 export type FirstRunProviderFamily =
 	| "anthropic"
+	| "cerebras"
 	| "deepseek"
 	| "elizacloud"
 	| "gemini"
@@ -75,6 +76,7 @@ export type FirstRunProviderFamily =
 export type FirstRunProviderId =
 	| "anthropic"
 	| "anthropic-subscription"
+	| "cerebras"
 	| "deepseek"
 	| "deepseek-coding-subscription"
 	| "elizacloud"
@@ -425,6 +427,20 @@ export const FIRST_RUN_PROVIDER_CATALOG = [
 		order: 100,
 	},
 	{
+		id: "cerebras",
+		name: "Cerebras",
+		envKey: "CEREBRAS_API_KEY",
+		// Cerebras serves an OpenAI-compatible API, so it runs through the
+		// OpenAI plugin's Cerebras mode (CEREBRAS_API_KEY → api.cerebras.ai).
+		pluginName: "@elizaos/plugin-openai",
+		keyPrefix: "csk-",
+		description: "Fast inference for open models via Cerebras.",
+		family: "cerebras",
+		authMode: "api-key",
+		group: "local",
+		order: 105,
+	},
+	{
 		id: "deepseek",
 		name: "DeepSeek",
 		envKey: "DEEPSEEK_API_KEY",
@@ -518,6 +534,7 @@ export const DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER = {
 	deepseek: "deepseek-api",
 	zai: "zai-api",
 	moonshot: "moonshot-api",
+	cerebras: "cerebras-api",
 } as const satisfies Partial<
 	Record<FirstRunProviderId, LinkedAccountProviderId>
 >;
@@ -722,6 +739,9 @@ const FIRST_RUN_PROVIDER_ALIASES: Record<string, FirstRunProviderId> = {
 	moonshot: "moonshot",
 	moonshotai: "moonshot",
 	"moonshot-ai": "moonshot",
+	cerebras: "cerebras",
+	// Tolerate the linked-account form so env/integration callers normalize too.
+	"cerebras-api": "cerebras",
 };
 
 export function isSubscriptionProviderSelectionId(

--- a/packages/shared/src/contracts/first-run-cerebras.test.ts
+++ b/packages/shared/src/contracts/first-run-cerebras.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
+// Core is the innermost package (`packages/shared` depends on `@elizaos/core`,
+// never the reverse), so the first-run provider catalog is duplicated in both:
+// `packages/core/src/contracts/first-run-options.ts` is the canonical copy and
+// `packages/shared/src/contracts/first-run-options.ts` is the shared mirror.
+// These two MUST stay identical — when they drift, core's own
+// `normalizeFirstRunProviderId`/migration helpers silently miss the newer
+// providers (Cerebras was exactly this bug). Import both here and assert
+// equality so any future divergence fails CI in this package.
 import {
+  FIRST_RUN_PROVIDER_CATALOG as CORE_CATALOG,
+  DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER as CORE_DIRECT_ACCOUNT_MAP,
+  getDirectAccountProviderForFirstRunProvider as coreGetDirectAccountProvider,
+  normalizeFirstRunProviderId as coreNormalizeFirstRunProviderId,
+} from "../../../core/src/contracts/first-run-options";
+import {
+  DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER,
   FIRST_RUN_PROVIDER_CATALOG,
   getDirectAccountProviderForFirstRunProvider,
   getFirstRunProviderOption,
@@ -42,5 +57,38 @@ describe("Cerebras first-run provider", () => {
       "cerebras-api",
     );
     expect(isLinkedAccountProviderId("cerebras-api")).toBe(true);
+  });
+});
+
+// Drift guard: the shared mirror must match the canonical core copy exactly.
+// If a provider (or a helper's provider handling) is added to one file but not
+// the other, these assertions fail. Removing Cerebras from the core copy — the
+// original bug — trips both the catalog deep-equal and the normalize check.
+describe("first-run provider catalog core/shared alignment", () => {
+  it("core and shared expose an identical provider catalog", () => {
+    expect(CORE_CATALOG).toEqual(FIRST_RUN_PROVIDER_CATALOG);
+    expect(CORE_CATALOG.map((p) => p.id)).toEqual(
+      FIRST_RUN_PROVIDER_CATALOG.map((p) => p.id),
+    );
+  });
+
+  it("core and shared expose an identical direct-account map", () => {
+    expect(CORE_DIRECT_ACCOUNT_MAP).toEqual(
+      DIRECT_ACCOUNT_PROVIDER_BY_FIRST_RUN_PROVIDER,
+    );
+  });
+
+  it("the canonical core copy includes Cerebras", () => {
+    const coreCerebras = CORE_CATALOG.find((p) => p.id === "cerebras");
+    expect(coreCerebras).toBeDefined();
+    expect(coreCerebras?.envKey).toBe("CEREBRAS_API_KEY");
+    expect(coreCerebras?.family).toBe("cerebras");
+  });
+
+  it("core's normalize + direct-account helpers resolve Cerebras", () => {
+    expect(coreNormalizeFirstRunProviderId("cerebras")).toBe("cerebras");
+    expect(coreNormalizeFirstRunProviderId("CEREBRAS")).toBe("cerebras");
+    expect(coreNormalizeFirstRunProviderId("cerebras-api")).toBe("cerebras");
+    expect(coreGetDirectAccountProvider("cerebras")).toBe("cerebras-api");
   });
 });


### PR DESCRIPTION
## #12092 item 19 [P2][M] — first-run provider catalog duplicated & drifted between core and shared

The "~2888 differing lines" is almost entirely tabs-vs-spaces; `diff -w -b` shows the real drift is **one-directional and tiny**: shared is a strict semantic superset of core, differing ONLY by **Cerebras** (5 spots). Core's Cerebras-blind copy is imported by `plugin-elizacloud` (`migrateLegacyRuntimeConfig`/`isCloudInferenceSelectedInConfig`), so core was silently mis-normalizing Cerebras.

## Change (minimal safe fix — full physical single-source deferred, see below)
- Ported shared's Cerebras into **core** (canonical superset): `| "cerebras"` in the family + id unions, the `id:"cerebras"` catalog entry, the direct-account-provider map entry, and the normalize-alias entries. `diff -w -b` core vs shared is now **empty**.
- Added a **drift-guard alignment test** in shared importing BOTH catalogs and asserting deep-equality + core-includes-Cerebras + core-helper Cerebras normalization.

**Why not the full re-export single-source now:** three concrete blockers — (1) `export *`-ing first-run-options through core's index collides with core's existing `MessageExample` export; (2) the deep-subpath alternative bypasses the app's `@elizaos/core`-bare vite alias + shared's bare-only tsconfig path into an unverified browser-bundle path; (3) **core doesn't build on develop** right now (#12103 left `trust/providers/index.ts` exporting deleted `./roles.ts`/`./settings.ts`). Physical single-sourcing is a clean follow-up once those land.

## Verification
- Alignment test — **8 pass**; **red-proven**: stripping Cerebras from core → 2 failures; restored → green.
- `tsgo` core + shared: **0 errors in touched files** (2 pre-existing `trust/providers` errors from #12103, unrelated). With that develop breakage temp-patched (throwaway, reverted), core+shared **build 5/5**.

| type | status |
|---|---|
| Drift-guard alignment test (red/green) | ✅ 8 pass |
| Cerebras normalization in core helpers | ✅ |
| typecheck touched files | ✅ 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)