### PR TITLE
refactor(agent): share connector id schema source

### DIFF
--- a/packages/agent/src/config/connector-ids.test.ts
+++ b/packages/agent/src/config/connector-ids.test.ts
@@ -1,0 +1,23 @@
+import { CONNECTOR_IDS as SHARED_CONNECTOR_IDS } from "@elizaos/shared/config/schema";
+import { describe, expect, test } from "vitest";
+
+import { CONNECTOR_IDS as AGENT_CONNECTOR_IDS } from "./schema.ts";
+
+describe("CONNECTOR_IDS", () => {
+  test("agent re-exports the shared connector id list", () => {
+    expect(AGENT_CONNECTOR_IDS).toBe(SHARED_CONNECTOR_IDS);
+  });
+
+  test("includes connector ids that drifted out of the shared copy", () => {
+    expect(AGENT_CONNECTOR_IDS).toEqual(
+      expect.arrayContaining([
+        "matrix",
+        "nostr",
+        "blooio",
+        "twitch",
+        "mattermost",
+        "googlechat",
+      ]),
+    );
+  });
+});

--- a/packages/agent/src/config/schema.ts
+++ b/packages/agent/src/config/schema.ts
@@ -1,29 +1,8 @@
+import { CONNECTOR_IDS } from "@elizaos/shared/config/schema";
 import { VERSION } from "../runtime/version.ts";
 import { isSensitiveConfigKey } from "./sensitive-keys.ts";
 
-/** Known connector IDs for config schema generation. Keep in sync with runtime/plugin maps. */
-export const CONNECTOR_IDS = [
-  "bluebubbles",
-  "telegram",
-  "telegramAccount",
-  "discord",
-  "discordLocal",
-  "slack",
-  "twitter",
-  "whatsapp",
-  "signal",
-  "imessage",
-  "farcaster",
-  "lens",
-  "msteams",
-  "feishu",
-  "matrix",
-  "nostr",
-  "blooio",
-  "twitch",
-  "mattermost",
-  "googlechat",
-] as const;
+export { CONNECTOR_IDS };
 
 import { ElizaSchema } from "./zod-schema.ts";
 

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -1,9 +1,4 @@
-// CYCLE BREAK: previously imported CONNECTOR_IDS from `@elizaos/agent`,
-// creating an agent ↔ shared ESM cycle that broke node module resolution
-// at bench-server boot. Inline the upstream id list so shared has its
-// own canonical copy. Keep in sync with `packages/agent/src/config/schema.ts`
-// when new connectors are added there.
-const _upstreamConnectorIds = [
+const ELIZA_CORE_CONNECTOR_IDS = [
   "bluebubbles",
   "telegram",
   "telegramAccount",
@@ -18,20 +13,20 @@ const _upstreamConnectorIds = [
   "lens",
   "msteams",
   "feishu",
+  "matrix",
+  "nostr",
+  "blooio",
+  "twitch",
+  "mattermost",
+  "googlechat",
 ] as const;
 
-const ELIZA_COMPAT_CONNECTOR_IDS = ["telegramAccount"] as const;
-/** App-local connectors not present in upstream @elizaos/agent. */
+/** App-local connectors that still participate in config schema generation. */
 export const ELIZA_LOCAL_CONNECTOR_IDS = ["wechat"] as const;
 
-export const CONNECTOR_IDS = Array.from(
-  new Set([
-    ..._upstreamConnectorIds,
-    ...ELIZA_COMPAT_CONNECTOR_IDS,
-    ...ELIZA_LOCAL_CONNECTOR_IDS,
-  ]),
-) as ReadonlyArray<
-  | (typeof _upstreamConnectorIds)[number]
-  | (typeof ELIZA_COMPAT_CONNECTOR_IDS)[number]
-  | (typeof ELIZA_LOCAL_CONNECTOR_IDS)[number]
->;
+export const CONNECTOR_IDS = [
+  ...ELIZA_CORE_CONNECTOR_IDS,
+  ...ELIZA_LOCAL_CONNECTOR_IDS,
+] as const;
+
+export type ConnectorId = (typeof CONNECTOR_IDS)[number];


### PR DESCRIPTION
## Summary
- make `@elizaos/shared` the single source for `CONNECTOR_IDS`
- add the six connector ids that had drifted out of the shared copy (`matrix`, `nostr`, `blooio`, `twitch`, `mattermost`, `googlechat`)
- have `packages/agent` import/re-export the shared connector list and add a regression test for the alignment

Covers #12093 item 8.

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts` (worktree setup for generated i18n)
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/agent test src/config/connector-ids.test.ts` (2 passed)
- `bunx @biomejs/biome check packages/shared/src/config/schema.ts packages/agent/src/config/schema.ts packages/agent/src/config/connector-ids.test.ts`
- `git diff --check HEAD~1..HEAD`
- `bun run --cwd packages/shared build:dist`
- `bun run --cwd packages/agent build`

## Known upstream validation blockers
- `bun run --cwd packages/shared typecheck` still fails on current `origin/develop` because `packages/core/src/features/trust/providers/index.ts` exports deleted `roles.ts` and `settings.ts`.
- `bun run --cwd packages/agent typecheck` also hits that same upstream trust-provider export break plus pre-existing unresolved optional plugin package declarations (`@elizaos/plugin-commands`, `@elizaos/plugin-streaming`, `@elizaos/plugin-meetings`, `@elizaos/cloud-routing`, etc.).

## Evidence
N/A - refactor-only config constant ownership; no UI, model trajectory, external connector, or live service path changed.
