### PR TITLE
fix(core): drop dangling roles.ts/settings.ts barrel exports — unbreak core build (#12103 fallout)

### DIFF
--- a/packages/core/src/features/trust/providers/index.ts
+++ b/packages/core/src/features/trust/providers/index.ts
@@ -1,5 +1,3 @@
 export * from "./adminTrust.ts";
-export * from "./roles.ts";
 export * from "./securityStatus.ts";
-export * from "./settings.ts";
 export * from "./trustProfile.ts";


### PR DESCRIPTION
## develop-red — core build broken

PR #12103 deleted `packages/core/src/features/trust/providers/roles.ts` and `settings.ts` but left `providers/index.ts` still doing `export * from "./roles.ts"` / `"./settings.ts"`. On a fresh `develop` checkout this fails **every full core build** and `tsgo`:

```
error: Could not resolve: "./roles.ts"
error: Could not resolve: "./settings.ts"
```

(Normally masked by turbo's build cache; any package.json change or clean checkout exposes it. Two independent #12092 sub-agents — items 19 and 28 — hit this wall.)

## Fix
Remove the two dangling export lines. The canonical `roleProvider`/`settingsProvider` live in `features/advanced-capabilities/providers`; **nothing imports the removed symbols from the trust barrel** (`grep` across `packages/`+`plugins/` → 0).

## Verification
`cd packages/core && bun run build` → **clean**: `✓ Built … @elizaos/core build complete!` for Node + Browser/Edge + Testing (was erroring before). Confirmed on a fresh worktree off develop.

| type | status |
|---|---|
| Core full build (was red → green) | ✅ |
| Importers of removed symbols | 0 (grep) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)