### PR TITLE
fix(agent): require public route auth intent

### DIFF
--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -25,6 +25,7 @@ import { Readable } from "node:stream";
 
 import {
   type AgentRuntime,
+  assertPublicRouteIntent,
   type IAgentRuntime,
   type LegacyRouteHandler,
   logger,
@@ -435,6 +436,7 @@ export async function dispatchRoute(
   const query = args.query ?? {};
 
   for (const route of runtime.routes as Route[]) {
+    assertPublicRouteIntent(route, "runtime.routes");
     if (route.type === "STATIC") continue;
     if (route.type !== method) continue;
     if (!route.handler && !route.routeHandler) continue;

--- a/packages/agent/src/api/hono-adapter.stream-headers.test.ts
+++ b/packages/agent/src/api/hono-adapter.stream-headers.test.ts
@@ -24,6 +24,8 @@ function makeRuntime(): IAgentRuntime {
         type: "GET",
         path: "/api/test-plugin/events",
         public: true,
+        name: "test-events",
+        publicReason: "Hono adapter stream header fixture route.",
         routeHandler: async () => ({
           status: 201,
           headers: {
@@ -38,6 +40,8 @@ function makeRuntime(): IAgentRuntime {
         type: "GET",
         path: "/api/test-plugin/plain",
         public: true,
+        name: "test-plain",
+        publicReason: "Hono adapter plain response fixture route.",
         routeHandler: async () => ({
           status: 201,
           headers: { "x-custom": "yes" },

--- a/packages/agent/src/api/hono-mount.path-normalization.test.ts
+++ b/packages/agent/src/api/hono-mount.path-normalization.test.ts
@@ -27,6 +27,8 @@ function makeRuntime(): IAgentRuntime {
         type: "GET",
         path: "/api/test-plugin/data",
         public: true,
+        name: "test-data",
+        publicReason: "Hono mount path normalization fixture route.",
         routeHandler: async () => ({ status: 200, body: { ok: true } }),
       },
     ],

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -79,6 +79,8 @@ export const mediaFileRoute: Route = {
   rawPath: true,
   public: true,
   name: "media-file",
+  publicReason:
+    "Media URLs are content-addressed capability links served pre-auth.",
   routeHandler: async (ctx) => {
     const filename = ctx.params?.filename ?? "";
     const result = handleMediaRouteRequest(

--- a/packages/agent/src/api/runtime-plugin-routes.test.ts
+++ b/packages/agent/src/api/runtime-plugin-routes.test.ts
@@ -35,8 +35,20 @@ function runtimeWithRoutes(routes: Route[]): AgentRuntime {
 describe("isPublicRuntimePluginRoute", () => {
   it("recognizes webhook endpoints through public route declarations", () => {
     const runtime = runtimeWithRoutes([
-      { type: "POST", path: "/api/whatsapp/webhook", public: true },
-      { type: "POST", path: "/webhooks/bluebubbles", public: true },
+      {
+        type: "POST",
+        path: "/api/whatsapp/webhook",
+        public: true,
+        name: "whatsapp-webhook",
+        publicReason: "WhatsApp webhook callback is externally delivered.",
+      },
+      {
+        type: "POST",
+        path: "/webhooks/bluebubbles",
+        public: true,
+        name: "bluebubbles-webhook",
+        publicReason: "BlueBubbles webhook callback is externally delivered.",
+      },
     ] as Route[]);
 
     expect(
@@ -103,6 +115,30 @@ async function startRouteServer(runtime: AgentRuntime): Promise<string> {
 }
 
 describe("tryHandleRuntimePluginRoute", () => {
+  it("rejects public routes without declared auth intent before dispatch", () => {
+    const runtime = {
+      routes: [
+        {
+          type: "GET",
+          path: "/plugin/public-without-intent",
+          public: true,
+          name: "public-without-intent",
+          handler: async (_req: RouteRequest, res: RouteResponse) => {
+            res.json({ reached: true });
+          },
+        },
+      ],
+    } as unknown as AgentRuntime;
+
+    expect(() =>
+      isPublicRuntimePluginRoute({
+        runtime,
+        method: "GET",
+        pathname: "/plugin/public-without-intent",
+      }),
+    ).toThrow(/must declare publicReason/);
+  });
+
   it("supports legacy handlers that call res.json directly", async () => {
     const runtime = {
       routes: [

--- a/packages/agent/src/api/runtime-plugin-routes.ts
+++ b/packages/agent/src/api/runtime-plugin-routes.ts
@@ -7,6 +7,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   type AgentRuntime,
+  assertPublicRouteIntent,
   isJsonObjectBody,
   type PaymentEnabledRoute,
   type Route,
@@ -87,6 +88,7 @@ export function isPublicRuntimePluginRoute(options: {
   if (!runtime?.routes?.length) return false;
 
   return (runtime.routes as Route[]).some((route) => {
+    assertPublicRouteIntent(route, "runtime.routes");
     if (
       route.type === "STATIC" ||
       route.type !== method ||
@@ -269,6 +271,7 @@ export async function tryHandleRuntimePluginRoute(options: {
   if (!runtime?.routes?.length) return false;
 
   for (const route of runtime.routes as Route[]) {
+    assertPublicRouteIntent(route, "runtime.routes");
     if (route.type === "STATIC") continue;
     if (route.type !== method) continue;
     const handler = route.handler;

--- a/packages/agent/src/services/remote-capability-cloud-sandbox.test.ts
+++ b/packages/agent/src/services/remote-capability-cloud-sandbox.test.ts
@@ -344,6 +344,8 @@ describe("cloud capability sandbox provisioner", () => {
                       path: "/cloud/capability",
                       public: true,
                       name: "cloud-capability-route",
+                      publicReason:
+                        "Remote cloud sandbox fixture public route.",
                     },
                   ],
                   views: [

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -206,6 +206,7 @@ const remoteModule: RemotePluginModuleManifest = {
       path: "/remote/demo",
       public: true,
       name: "remote-demo",
+      publicReason: "Remote adapter fixture public route.",
       description: "Remote route.",
     },
   ],
@@ -2363,6 +2364,7 @@ describe("remote plugin adapter", () => {
                 method: "STATIC",
                 path: "/remote/static",
                 public: true,
+                publicReason: "Remote adapter invalid static fixture.",
               },
             ],
           },
@@ -2469,6 +2471,7 @@ describe("remote plugin adapter", () => {
           method: "POST",
           path: "/volatile/route",
           public: true,
+          publicReason: "Remote adapter volatility fixture public route.",
         },
       ],
       views: [
@@ -2547,6 +2550,7 @@ describe("remote plugin adapter", () => {
           method: "POST",
           path: "/device-a/route",
           public: true,
+          publicReason: "Remote adapter device A fixture public route.",
         },
       ],
       views: [
@@ -2572,6 +2576,7 @@ describe("remote plugin adapter", () => {
           method: "POST",
           path: "/device-b/route",
           public: true,
+          publicReason: "Remote adapter device B fixture public route.",
         },
       ],
       views: [
@@ -3363,6 +3368,8 @@ describe("remote plugin adapter", () => {
                       path: "/device/ping",
                       public: true,
                       name: "device-ping",
+                      publicReason:
+                        "Remote adapter device ping fixture public route.",
                     },
                   ],
                   views: [
@@ -3608,6 +3615,8 @@ describe("remote plugin adapter", () => {
                   path: "/localhost/route",
                   public: true,
                   name: "localhost-route",
+                  publicReason:
+                    "Remote adapter localhost fixture public route.",
                 },
               ],
               views: [
@@ -3830,7 +3839,7 @@ export function createRouter() {
               methods: ["lookup"],
             }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/built-source/route", public: true, name: "built-source-route" }],
+            routes: [{ method: "POST", path: "/built-source/route", public: true, name: "built-source-route", publicReason: "Remote adapter built source fixture public route." }],
             views: [{ id: "built-source.view", label: "Built Source View", bundlePath: "/assets/remote-view.js" }],
           },
         ],
@@ -4249,7 +4258,7 @@ const server = createServer(async (req, res) => {
           description: "Remote plugin served from a child process.",
           actions: [{ name: "PROCESS_ACTION", description: "Run process action." }],
           providers: [{ name: "PROCESS_CONTEXT", description: "Process provider." }],
-          routes: [{ method: "POST", path: "/process/route", public: true, name: "process-route" }],
+          routes: [{ method: "POST", path: "/process/route", public: true, name: "process-route", publicReason: "Remote adapter process fixture public route." }],
           views: [{ id: "process.view", label: "Process View", bundlePath: "/assets/process-view.js" }],
         }] } });
       }
@@ -4494,7 +4503,7 @@ createServer(async (req, res) => {
             models: [{ modelType: "DOCKER_TEXT", priority: 10 }],
             services: [{ serviceType: "docker_service", capabilityDescription: "Docker service.", methods: ["lookup"] }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/docker/route", public: true, name: "docker-route" }],
+            routes: [{ method: "POST", path: "/docker/route", public: true, name: "docker-route", publicReason: "Remote adapter Docker fixture public route." }],
             views: [{ id: "docker.view", label: "Docker View", bundlePath: "/assets/docker-view.js" }],
           },
           {
@@ -4511,7 +4520,7 @@ createServer(async (req, res) => {
             models: [{ modelType: "DOCKER_TOOLS_TEXT", priority: 11 }],
             services: [{ serviceType: "docker_tools_service", capabilityDescription: "Docker tools service.", methods: ["lookup"] }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/docker-tools/route", public: true, name: "docker-tools-route" }],
+            routes: [{ method: "POST", path: "/docker-tools/route", public: true, name: "docker-tools-route", publicReason: "Remote adapter Docker tools fixture public route." }],
             views: [{ id: "docker.tools.view", label: "Docker Tools View", bundlePath: "/assets/docker-tools-view.js" }],
           },
         ] } });

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -245,10 +245,16 @@ export function createRemoteCapabilityPlugin(
       },
     };
     if (route.public) {
+      if (!route.publicReason?.trim()) {
+        throw new Error(
+          `[RemotePluginAdapter] public route ${route.path} must declare publicReason`,
+        );
+      }
       return {
         ...baseRoute,
         public: true,
         name: route.name ?? `${module.name}:${route.path}`,
+        publicReason: route.publicReason,
       };
     }
     return {

--- a/packages/agent/src/services/remote-plugin-bridge.test.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.test.ts
@@ -15,7 +15,7 @@ import {
   createHandlerRegistry,
   type RemoteServiceInstance,
   type WorkerPluginShape,
-} from "../../../plugin-worker-runtime/src/descriptor.ts";
+} from "../../../plugin-remote-manifest/src/worker-runtime/descriptor.ts";
 import { type BridgeChannel, RemotePluginBridge } from "./remote-plugin-bridge";
 
 class TestChannel implements BridgeChannel {
@@ -279,6 +279,7 @@ describe("RemotePluginBridge descriptor schema", () => {
           name: "route",
           path: "/route",
           public: true,
+          publicReason: "Remote bridge fixture public route.",
           isMultipart: false,
           routeHandler: () => new Response("ok"),
         },

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -250,6 +250,7 @@ const RouteDescriptorSchema = z
     type: RouteTypeSchema.optional(),
     name: z.string().optional(),
     public: z.boolean().optional(),
+    publicReason: z.string().optional(),
     isMultipart: z.boolean().optional(),
   })
   .passthrough();
@@ -861,10 +862,16 @@ export class RemotePluginBridge {
           `[RemotePluginBridge] public route ${descriptor.path} must declare a name`,
         );
       }
+      if (!descriptor.publicReason?.trim()) {
+        throw new Error(
+          `[RemotePluginBridge] public route ${descriptor.path} must declare publicReason`,
+        );
+      }
       return {
         ...routeBase,
         public: true,
         name: descriptor.name,
+        publicReason: descriptor.publicReason,
       };
     }
     return {

--- a/packages/core/src/app-route-plugin-registry.test.ts
+++ b/packages/core/src/app-route-plugin-registry.test.ts
@@ -83,6 +83,25 @@ describe("drainAppRoutePluginLoaders", () => {
 		expect(target.routes).toHaveLength(2);
 	});
 
+	it("rejects public routes without declared auth intent", async () => {
+		const target: { routes: Route[] } = { routes: [] };
+		await expect(
+			drainAppRoutePluginLoaders(target, [
+				loader("public-no-intent", () =>
+					plugin("public-no-intent", [
+						{
+							type: "GET",
+							path: "/api/public-no-intent",
+							public: true,
+							name: "public-no-intent",
+						} as Route,
+					]),
+				),
+			]),
+		).rejects.toThrow(/must declare publicReason/);
+		expect(target.routes).toEqual([]);
+	});
+
 	it("isolates an optional-unavailable loader (core error class) and still drains the rest", async () => {
 		const target: { routes: Route[] } = { routes: [] };
 		await drainAppRoutePluginLoaders(target, [

--- a/packages/core/src/app-route-plugin-registry.ts
+++ b/packages/core/src/app-route-plugin-registry.ts
@@ -1,6 +1,10 @@
 import { getAmbientSingleton } from "./ambient-context";
 import { logger } from "./logger";
-import type { Plugin, Route } from "./types/plugin";
+import {
+	assertPublicRouteIntent,
+	type Plugin,
+	type Route,
+} from "./types/plugin";
 
 export type AppRoutePluginLoader = () => Plugin | Promise<Plugin>;
 
@@ -125,6 +129,7 @@ export async function drainAppRoutePluginLoaders(
 		if (!plugin?.routes?.length) continue;
 		let added = 0;
 		for (const route of plugin.routes) {
+			assertPublicRouteIntent(route, plugin.name);
 			const routePath = route.path.startsWith("/")
 				? route.path
 				: `/${route.path}`;

--- a/packages/core/src/capabilities/index.test.ts
+++ b/packages/core/src/capabilities/index.test.ts
@@ -625,6 +625,8 @@ describe("capability router", () => {
 										method: "GET",
 										path: "/weather/:city",
 										public: true,
+										publicReason:
+											"Capability manifest weather fixture public route.",
 									},
 								],
 								views: [
@@ -757,7 +759,14 @@ describe("capability router", () => {
 					appBridge: {
 						hooks: ["prepareLaunch"],
 					},
-					routes: [{ method: "GET", path: "/weather/:city", public: true }],
+					routes: [
+						{
+							method: "GET",
+							path: "/weather/:city",
+							public: true,
+							publicReason: "Capability manifest weather fixture public route.",
+						},
+					],
 					views: [
 						{
 							id: "weather-panel",

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -214,6 +214,7 @@ export type RemotePluginRouteManifest = {
 	path: string;
 	name?: string;
 	public?: boolean;
+	publicReason?: string;
 	description?: string;
 };
 
@@ -839,6 +840,8 @@ export const CAPABILITY_ROUTER_PROTOCOL_FIXTURE = {
 				path: "/fixture/route",
 				public: true,
 				name: "fixture-route",
+				publicReason:
+					"Capability-router fixture route is unauthenticated test transport.",
 			},
 		],
 		views: [
@@ -3306,14 +3309,22 @@ function requireRemotePluginRoute(
 	validateRemotePluginRouteMethod(routeMethod, "method", method, true);
 	const name = optionalString(object, "name", method);
 	const isPublic = optionalBoolean(object, "public", method);
+	const publicReason = optionalString(object, "publicReason", method);
 	const description = optionalString(object, "description", method);
 	const path = requireNonEmptyString(object, "path", method);
 	validateRemotePluginPath(path, "path", method);
+	if (isPublic === true && !publicReason?.trim()) {
+		throw decodeError(
+			method,
+			"publicReason must be a non-empty string for public routes.",
+		);
+	}
 	return {
 		method: routeMethod,
 		path,
 		...(name === undefined ? {} : { name }),
 		...(isPublic === undefined ? {} : { public: isPublic }),
+		...(publicReason === undefined ? {} : { publicReason }),
 		...(description === undefined ? {} : { description }),
 	};
 }

--- a/packages/core/src/features/oauth/plugin.ts
+++ b/packages/core/src/features/oauth/plugin.ts
@@ -63,6 +63,8 @@ export const oauthLocalCallbackRoute: Route = {
 	path: "/api/oauth/callback",
 	name: "oauth-local-callback",
 	public: true,
+	publicReason:
+		"OAuth provider callback uses the unguessable intent id as capability.",
 	rawPath: true,
 	handler: async (req, res, runtime) => {
 		const body = (req.body ?? {}) as Record<string, unknown>;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -102,6 +102,7 @@ import {
 	type ActionResult,
 	type Agent,
 	type AppendConnectorAccountAuditEventParams,
+	assertPublicRouteIntent,
 	ChannelType,
 	type Character,
 	type Component,
@@ -2029,6 +2030,7 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 		if (pluginToRegister.routes) {
 			for (const route of pluginToRegister.routes) {
+				assertPublicRouteIntent(route, pluginToRegister.name);
 				const routePath = route.path.startsWith("/")
 					? route.path
 					: `/${route.path}`;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -166,6 +166,12 @@ interface BaseRoute {
 interface PublicRoute extends BaseRoute {
 	public: true;
 	name: string; // Name is required for public routes
+	/**
+	 * Reviewed reason this route may bypass the central auth gate.
+	 * Public routes without this intent are rejected by route registration and
+	 * dispatchers.
+	 */
+	publicReason: string;
 }
 
 interface PrivateRoute extends BaseRoute {
@@ -174,6 +180,15 @@ interface PrivateRoute extends BaseRoute {
 }
 
 export type Route = PublicRoute | PrivateRoute;
+
+export function assertPublicRouteIntent(route: Route, source = "plugin"): void {
+	if (route.public !== true) return;
+	const reason = (route as { publicReason?: unknown }).publicReason;
+	if (typeof reason === "string" && reason.trim().length > 0) return;
+	throw new Error(
+		`[RouteAuth] Public route ${source}:${route.type} ${route.path} must declare publicReason`,
+	);
+}
 
 /** Route that may include x402 payment fields (alias for authoring clarity) */
 export type PaymentEnabledRoute = Route;

--- a/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
@@ -305,6 +305,7 @@ export function buildAnnounceDescriptor(
       if (route.type) entry.type = route.type;
       if (route.name) entry.name = route.name;
       if (route.public !== undefined) entry.public = route.public;
+      if (route.publicReason) entry.publicReason = route.publicReason;
       if (route.isMultipart !== undefined)
         entry.isMultipart = route.isMultipart;
       if (route.routeHandler) {

--- a/plugins/plugin-bluebubbles/src/data-routes.ts
+++ b/plugins/plugin-bluebubbles/src/data-routes.ts
@@ -262,5 +262,7 @@ export const blueBubblesDataRoutes: Route[] = [
 		rawPath: true,
 		public: true,
 		name: "bluebubbles-webhook",
+		publicReason:
+			"BlueBubbles webhook delivery is authenticated by webhook payload validation.",
 	},
 ];

--- a/plugins/plugin-browser/src/plugin.ts
+++ b/plugins/plugin-browser/src/plugin.ts
@@ -109,47 +109,71 @@ function buildRouteContext(
   };
 }
 
-const STATIC_ROUTES: Array<{ type: string; path: string; public?: boolean }> = [
+const COMPANION_ROUTE_REASON =
+  "Browser companion callbacks use companion session identifiers as capability tokens.";
+
+const STATIC_ROUTES: Array<{
+  type: string;
+  path: string;
+  public?: boolean;
+  publicReason?: string;
+}> = [
   { type: "GET", path: "/api/browser-bridge/sessions" },
   { type: "GET", path: "/api/browser-bridge/settings" },
   { type: "POST", path: "/api/browser-bridge/settings" },
   { type: "POST", path: "/api/browser-bridge/companions/pair" },
   { type: "POST", path: "/api/browser-bridge/companions/auto-pair" },
   { type: "GET", path: "/api/browser-bridge/companions" },
-  { type: "POST", path: "/api/browser-bridge/companions/revoke", public: true },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/companions/revoke",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+  },
   { type: "GET", path: "/api/browser-bridge/packages" },
   { type: "POST", path: "/api/browser-bridge/packages/open-path" },
-  { type: "POST", path: "/api/browser-bridge/companions/sync", public: true },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/companions/sync",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+  },
   { type: "GET", path: "/api/browser-bridge/tabs" },
   { type: "GET", path: "/api/browser-bridge/current-page" },
   { type: "POST", path: "/api/browser-bridge/sync" },
   { type: "POST", path: "/api/browser-bridge/sessions" },
 ];
 
-const DYNAMIC_ROUTES: Array<{ type: string; path: string; public?: boolean }> =
-  [
-    { type: "GET", path: "/api/browser-bridge/sessions/:id" },
-    { type: "POST", path: "/api/browser-bridge/sessions/:id/confirm" },
-    { type: "POST", path: "/api/browser-bridge/sessions/:id/progress" },
-    { type: "POST", path: "/api/browser-bridge/sessions/:id/complete" },
-    { type: "POST", path: "/api/browser-bridge/companions/:id/revoke" },
-    {
-      type: "POST",
-      path: "/api/browser-bridge/companions/sessions/:id/progress",
-      public: true,
-    },
-    {
-      type: "POST",
-      path: "/api/browser-bridge/companions/sessions/:id/complete",
-      public: true,
-    },
-    { type: "POST", path: "/api/browser-bridge/packages/:browser/build" },
-    {
-      type: "POST",
-      path: "/api/browser-bridge/packages/:browser/open-manager",
-    },
-    { type: "GET", path: "/api/browser-bridge/packages/:browser/download" },
-  ];
+const DYNAMIC_ROUTES: Array<{
+  type: string;
+  path: string;
+  public?: boolean;
+  publicReason?: string;
+}> = [
+  { type: "GET", path: "/api/browser-bridge/sessions/:id" },
+  { type: "POST", path: "/api/browser-bridge/sessions/:id/confirm" },
+  { type: "POST", path: "/api/browser-bridge/sessions/:id/progress" },
+  { type: "POST", path: "/api/browser-bridge/sessions/:id/complete" },
+  { type: "POST", path: "/api/browser-bridge/companions/:id/revoke" },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/companions/sessions/:id/progress",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+  },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/companions/sessions/:id/complete",
+    public: true,
+    publicReason: COMPANION_ROUTE_REASON,
+  },
+  { type: "POST", path: "/api/browser-bridge/packages/:browser/build" },
+  {
+    type: "POST",
+    path: "/api/browser-bridge/packages/:browser/open-manager",
+  },
+  { type: "GET", path: "/api/browser-bridge/packages/:browser/download" },
+];
 
 function routeHandler(): LegacyRouteHandler {
   return async (
@@ -175,7 +199,9 @@ const browserBridgePluginRoutes: Route[] = [
         type: r.type as Route["type"],
         path: r.path,
         rawPath: true as const,
-        ...(r.public ? ({ public: true } as const) : {}),
+        ...(r.public
+          ? ({ public: true, publicReason: r.publicReason ?? "" } as const)
+          : {}),
         handler: routeHandler(),
       }) as Route,
   ),
@@ -185,7 +211,9 @@ const browserBridgePluginRoutes: Route[] = [
         type: r.type as Route["type"],
         path: r.path,
         rawPath: true as const,
-        ...(r.public ? ({ public: true } as const) : {}),
+        ...(r.public
+          ? ({ public: true, publicReason: r.publicReason ?? "" } as const)
+          : {}),
         handler: routeHandler(),
       }) as Route,
   ),

--- a/plugins/plugin-computeruse/src/index.ts
+++ b/plugins/plugin-computeruse/src/index.ts
@@ -47,6 +47,8 @@ const computerUseRoutes: Route[] = [
     rawPath: true,
     public: true,
     name: "computeruse-approvals-stream",
+    publicReason:
+      "Approval event stream is consumed by the local approval UI before API auth.",
     handler: computerUseRouteHandler(),
   },
   {

--- a/plugins/plugin-music/src/routes.ts
+++ b/plugins/plugin-music/src/routes.ts
@@ -549,12 +549,16 @@ async function controlSkipHandler(
  * **Agentic path:** the chat action PLAYBACK_OP (op=pause|resume|skip|stop|queue)
  * still routes control through the agent for natural language.
  */
+const PUBLIC_RADIO_ROUTE_REASON =
+  "Public radio endpoints must be reachable by audio clients that cannot send bearer tokens.";
+
 export const musicPlayerRoutes: Route[] = [
   {
     type: "GET",
     path: "/stream",
     public: true,
     name: "Stream Audio",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: streamAudioHandler,
   },
   {
@@ -562,6 +566,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/stream/:guildId",
     public: true,
     name: "Stream Audio (with guildId param)",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: streamAudioHandler,
   },
   {
@@ -569,6 +574,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/now-playing",
     public: true,
     name: "Now Playing",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: nowPlayingHandler,
   },
   {
@@ -576,6 +582,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/now-playing/:guildId",
     public: true,
     name: "Now Playing (with guildId param)",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: nowPlayingHandler,
   },
   {
@@ -583,6 +590,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/queue",
     public: true,
     name: "Queue",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: queueHandler,
   },
   {
@@ -590,6 +598,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/queue/:guildId",
     public: true,
     name: "Queue (with guildId param)",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: queueHandler,
   },
   {
@@ -597,6 +606,7 @@ export const musicPlayerRoutes: Route[] = [
     path: "/status",
     public: true,
     name: "Playback Status",
+    publicReason: PUBLIC_RADIO_ROUTE_REASON,
     handler: statusHandler,
   },
   {

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -254,6 +254,7 @@ interface PublicRouteSpec {
   path: string;
   public: true;
   name: string;
+  publicReason: string;
 }
 
 type RouteSpec = PrivateRouteSpec | PublicRouteSpec;
@@ -384,12 +385,16 @@ const LIFEOPS_DYNAMIC_ROUTES: RouteSpec[] = [
     path: "/api/lifeops/connectors/health/:provider/callback",
     public: true,
     name: "lifeops.health.callback",
+    publicReason:
+      "Health connector OAuth callbacks must accept provider redirects.",
   },
   {
     type: "GET",
     path: "/api/lifeops/connectors/health/:provider/success",
     public: true,
     name: "lifeops.health.success",
+    publicReason:
+      "Health connector OAuth success landing must render after provider redirects.",
   },
   // /api/lifeops/money/sources/:sourceId
   { type: "DELETE", path: "/api/lifeops/money/sources/:sourceId" },
@@ -485,12 +490,15 @@ const GOOGLE_CONNECTOR_ACCOUNT_ROUTES: RouteSpec[] = [
     path: "/api/connectors/google/oauth/callback",
     public: true,
     name: "connectors.google.oauth.callback",
+    publicReason: "Google OAuth callback must accept provider redirects.",
   },
   {
     type: "POST",
     path: "/api/connectors/google/oauth/callback",
     public: true,
     name: "connectors.google.oauth.callback.post",
+    publicReason:
+      "Google OAuth callback POST must accept provider redirect exchanges.",
   },
   { type: "GET", path: "/api/connectors/google/audit/events" },
 ];
@@ -540,6 +548,7 @@ function buildRawRoutes(
         rawPath: true,
         public: true,
         name: spec.name,
+        publicReason: spec.publicReason,
         handler,
       };
     }

--- a/plugins/plugin-wallet/src/routes/plugin.ts
+++ b/plugins/plugin-wallet/src/routes/plugin.ts
@@ -35,6 +35,8 @@ const walletHttpRoutes: Route[] = [
     rawPath: true,
     public: true,
     name: "wallet-market-overview",
+    publicReason:
+      "Market overview is cached public market data for unauthenticated wallet empty states.",
     handler: marketOverviewHandler,
   },
 ];

--- a/plugins/plugin-whatsapp/src/setup-routes.ts
+++ b/plugins/plugin-whatsapp/src/setup-routes.ts
@@ -429,6 +429,7 @@ export const whatsappSetupRoutes: Route[] = [
     handler: handleWebhookVerify,
     rawPath: true,
     public: true, // Meta webhook verification must bypass auth
+    publicReason: "Meta webhook verification must be reachable before local auth.",
   },
   {
     name: "whatsapp-webhook-event",
@@ -437,6 +438,7 @@ export const whatsappSetupRoutes: Route[] = [
     handler: handleWebhookEvent,
     rawPath: true,
     public: true, // Meta webhook delivery must bypass auth
+    publicReason: "Meta webhook delivery is authenticated by WhatsApp signature checks.",
   },
   {
     type: "POST",


### PR DESCRIPTION
## Summary
- Adds a required publicReason intent field for public runtime routes and rejects public routes without it at registration/dispatch boundaries.
- Carries publicReason through remote capability manifests, worker announce descriptors, remote adapter/bridge conversion, and current public route declarations.
- Adds tests for app-route registration rejection and runtime public-route dispatch rejection.
- Addresses #12088 item 6.

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/core test -- src/app-route-plugin-registry.test.ts src/capabilities/index.test.ts
- bun run --cwd packages/agent test -- src/api/runtime-plugin-routes.test.ts src/api/hono-adapter.stream-headers.test.ts src/api/hono-mount.path-normalization.test.ts src/services/remote-plugin-bridge.test.ts src/services/remote-plugin-adapter.test.ts
- bun run --cwd packages/plugin-remote-manifest test -- src/worker-runtime/descriptor.test.ts
- bunx @biomejs/biome check <touched files>
- git diff --check

## Notes
- bun run --cwd packages/agent typecheck still fails on existing workspace declaration/account model errors unrelated to this change (plugin-commands/plugin-streaming/@elizaos/contracts declarations and AccountWithCredentialFlag fields).