### PR TITLE
refactor(core): centralize __bundle_safety_ mobile-bundle anchors into one helper

### DIFF
--- a/packages/core/src/bundle-safety.test.ts
+++ b/packages/core/src/bundle-safety.test.ts
@@ -1,0 +1,70 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { anchorBundleSafety } from "./bundle-safety.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe("anchorBundleSafety", () => {
+	it("writes the exact __bundle_safety_<name>__ global key with the given values", () => {
+		const marker = { id: "seam-marker" };
+		anchorBundleSafety("TEST_SEAM_UNIT", [marker]);
+		const key = "__bundle_safety_TEST_SEAM_UNIT__";
+		const stashed = (globalThis as Record<string, unknown>)[key];
+		expect(Array.isArray(stashed)).toBe(true);
+		expect(stashed as unknown[]).toEqual([marker]);
+		expect((stashed as unknown[])[0]).toBe(marker);
+	});
+
+	it("gives each name a distinct global key so sibling barrels never collide", () => {
+		anchorBundleSafety("TEST_SEAM_A", ["a"]);
+		anchorBundleSafety("TEST_SEAM_B", ["b"]);
+		const g = globalThis as Record<string, unknown>;
+		expect(g.__bundle_safety_TEST_SEAM_A__).toEqual(["a"]);
+		expect(g.__bundle_safety_TEST_SEAM_B__).toEqual(["b"]);
+	});
+});
+
+describe("feature barrel anchors are centralized (item #12091.34 invariant)", () => {
+	// The inline `const __bundle_safety_X__ = [...]; (globalThis as ...).X = X`
+	// pattern is retired in favor of the single anchorBundleSafety helper. Guard
+	// against any barrel re-introducing the hand-rolled globalThis assignment.
+	const featuresDir = path.join(here, "features");
+
+	function walkIndexFiles(dir: string): string[] {
+		const out: string[] = [];
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) out.push(...walkIndexFiles(full));
+			else if (entry.name === "index.ts") out.push(full);
+		}
+		return out;
+	}
+
+	const indexFiles = walkIndexFiles(featuresDir);
+
+	it("finds the feature barrels", () => {
+		expect(indexFiles.length).toBeGreaterThan(10);
+	});
+
+	it("no feature barrel hand-rolls the __bundle_safety_ globalThis assignment", () => {
+		const offenders = indexFiles.filter((file) =>
+			readFileSync(file, "utf8").includes("__bundle_safety_"),
+		);
+		expect(offenders).toEqual([]);
+	});
+
+	it("every anchored barrel imports the shared helper", () => {
+		const anchored = indexFiles.filter((file) =>
+			readFileSync(file, "utf8").includes("anchorBundleSafety("),
+		);
+		expect(anchored.length).toBeGreaterThan(10);
+		for (const file of anchored) {
+			const src = readFileSync(file, "utf8");
+			expect(src).toMatch(
+				/import\s*\{\s*anchorBundleSafety\s*\}\s*from\s*"[^"]*bundle-safety\.ts"/,
+			);
+		}
+	});
+});

--- a/packages/core/src/bundle-safety.ts
+++ b/packages/core/src/bundle-safety.ts
@@ -1,0 +1,40 @@
+/**
+ * Bundle-safety anchor — mobile-bundle tree-shaking workaround.
+ *
+ * `Bun.build` lowers the cyclic `@elizaos/core` module graph to lazy
+ * CJS-interop inits for the on-device mobile agent bundle. Under that lowering
+ * it DROPS modules that are reachable only through re-export-only barrels,
+ * even with `"sideEffects": true` set — the feature silently vanishes from the
+ * shipped bundle (a public plugin export becomes an empty init stub plus a
+ * dangling namespace getter, so the agent dies at module init with a
+ * `ReferenceError` or the whole capability is missing on device).
+ *
+ * The established workaround is an EAGER anchor: a feature barrel value-imports
+ * every binding it must keep and stashes those references on `globalThis`. The
+ * `globalThis` write is an unremovable top-level side effect, so Bun.build
+ * retains the call, its argument array, and therefore the imported leaf module
+ * bodies. This helper centralizes that one-liner so the 15+ feature barrels
+ * that need it stop hand-rolling the `const … = [...]; (globalThis as …).… = …`
+ * boilerplate.
+ *
+ * The `name` MUST be unique per barrel — parents that `export *` two anchored
+ * barrels would otherwise collide on a shared global key and one barrel's
+ * anchor would overwrite the other's.
+ *
+ * Verified STILL PRESENT on `bun@1.4.0` (the version pinned in the repo's
+ * `packageManager`, 2026-07): a minimal `Bun.build --target=browser`
+ * reproduction drops an unused re-export-only barrel binding, and the anchor
+ * (inline or via this helper, minified or not) retains it. Delete this helper
+ * and restore plain barrel re-exports only once a Bun release ships that keeps
+ * re-export-only barrel bodies under CJS-interop lowering.
+ *
+ * Incident tracking (Bun.build barrel-drop): elizaOS/eliza #10727, #11030,
+ * #11248, #11276. Upstream: oven-sh/bun tree-shaking of re-export-only modules
+ * under lazy CJS-interop lowering.
+ */
+export function anchorBundleSafety(
+	name: string,
+	values: readonly unknown[],
+): void {
+	(globalThis as Record<string, unknown>)[`__bundle_safety_${name}__`] = values;
+}

--- a/packages/core/src/features/advanced-capabilities/actions/index.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/index.ts
@@ -14,6 +14,9 @@ export { postAction } from "./post.ts";
 export { roleAction, updateRoleAction } from "./role.ts";
 export { roomOpAction } from "./room.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -27,16 +30,10 @@ import {
 } from "./role.ts";
 import { roomOpAction as _bs_5_roomOpAction } from "./room.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_ACTIONS_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_ACTIONS_INDEX", [
 	_bs_1_messageAction,
 	_bs_2_postAction,
 	_bs_3_roleAction,
 	_bs_4_updateRoleAction,
 	_bs_5_roomOpAction,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_ACTIONS_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_ACTIONS_INDEX__;
+]);

--- a/packages/core/src/features/advanced-capabilities/evaluators/index.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/index.ts
@@ -12,6 +12,9 @@ export {
 	skillRefinementEvaluator,
 } from "./skill-items.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -31,9 +34,7 @@ import {
 	skillRefinementEvaluator as _bs_9_skillRefinementEvaluator,
 } from "./skill-items.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX", [
 	_bs_1_factMemoryEvaluator,
 	_bs_2_identityEvaluator,
 	_bs_3_reflectionItems,
@@ -43,8 +44,4 @@ const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__ = [
 	_bs_7_skillItems,
 	_bs_8_skillProposalEvaluator,
 	_bs_9_skillRefinementEvaluator,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX__;
+]);

--- a/packages/core/src/features/advanced-capabilities/experience/index.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/index.ts
@@ -10,6 +10,9 @@ export { experienceProvider } from "./providers/experienceProvider.ts";
 export type { ExperienceService } from "./service.ts";
 export * from "./types.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -19,14 +22,8 @@ import { searchExperiencesAction as _bs_1_searchExperiencesAction } from "./acti
 import { experiencePatternEvaluator as _bs_2_experiencePatternEvaluator } from "./evaluators/experience-items.ts";
 import { experienceProvider as _bs_3_experienceProvider } from "./providers/experienceProvider.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX", [
 	_bs_1_searchExperiencesAction,
 	_bs_2_experiencePatternEvaluator,
 	_bs_3_experienceProvider,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX__;
+]);

--- a/packages/core/src/features/advanced-capabilities/personality/index.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/index.ts
@@ -15,6 +15,9 @@ export { getPersonalityStore } from "./services/personality-store.ts";
 export * from "./types.ts";
 export * from "./verbosity-enforcer.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -24,14 +27,8 @@ import { characterAction as _bs_1_characterAction } from "./actions/character.ts
 import { personalityAction as _bs_3_personalityAction } from "./actions/personality.ts";
 import { userPersonalityProvider as _bs_2_userPersonalityProvider } from "./providers/user-personality.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PERSONALITY_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_PERSONALITY_INDEX", [
 	_bs_1_characterAction,
 	_bs_2_userPersonalityProvider,
 	_bs_3_personalityAction,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PERSONALITY_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PERSONALITY_INDEX__;
+]);

--- a/packages/core/src/features/advanced-capabilities/providers/index.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/index.ts
@@ -11,6 +11,9 @@ export { relationshipsProvider } from "./relationships.ts";
 export { roleProvider } from "./roles.ts";
 export { settingsProvider } from "./settings.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -23,17 +26,11 @@ import { relationshipsProvider as _bs_4_relationshipsProvider } from "./relation
 import { roleProvider as _bs_5_roleProvider } from "./roles.ts";
 import { settingsProvider as _bs_6_settingsProvider } from "./settings.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX", [
 	_bs_1_advancedContactsProvider,
 	_bs_2_factsProvider,
 	_bs_3_followUpsProvider,
 	_bs_4_relationshipsProvider,
 	_bs_5_roleProvider,
 	_bs_6_settingsProvider,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_CAPABILITIES_PROVIDERS_INDEX__;
+]);

--- a/packages/core/src/features/advanced-memory/schemas/index.ts
+++ b/packages/core/src/features/advanced-memory/schemas/index.ts
@@ -9,6 +9,9 @@ export { longTermMemories } from "./long-term-memories";
 export { memoryAccessLogs } from "./memory-access-logs";
 export { sessionSummaries } from "./session-summaries";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -18,14 +21,8 @@ import { longTermMemories as _bs_1_longTermMemories } from "./long-term-memories
 import { memoryAccessLogs as _bs_2_memoryAccessLogs } from "./memory-access-logs";
 import { sessionSummaries as _bs_3_sessionSummaries } from "./session-summaries";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_ADVANCED_MEMORY_SCHEMAS_INDEX__ = [
+anchorBundleSafety("FEATURES_ADVANCED_MEMORY_SCHEMAS_INDEX", [
 	_bs_1_longTermMemories,
 	_bs_2_memoryAccessLogs,
 	_bs_3_sessionSummaries,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_ADVANCED_MEMORY_SCHEMAS_INDEX__ =
-	__bundle_safety_FEATURES_ADVANCED_MEMORY_SCHEMAS_INDEX__;
+]);

--- a/packages/core/src/features/autonomy/index.ts
+++ b/packages/core/src/features/autonomy/index.ts
@@ -24,6 +24,9 @@ export {
 // Types
 export type { AutonomyConfig, AutonomyStatus } from "./types";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -46,9 +49,7 @@ import {
 	AutonomyService as _bs_8_AutonomyService,
 } from "./service";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_AUTONOMY_INDEX__ = [
+anchorBundleSafety("FEATURES_AUTONOMY_INDEX", [
 	_bs_1a_escalateAction,
 	_bs_1b_enableAutonomousModeAction,
 	_bs_1c_disableAutonomousModeAction,
@@ -59,8 +60,4 @@ const __bundle_safety_FEATURES_AUTONOMY_INDEX__ = [
 	_bs_6_AUTONOMY_TASK_NAME,
 	_bs_7_AUTONOMY_TASK_TAGS,
 	_bs_8_AutonomyService,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_AUTONOMY_INDEX__ =
-	__bundle_safety_FEATURES_AUTONOMY_INDEX__;
+]);

--- a/packages/core/src/features/basic-capabilities/actions/index.ts
+++ b/packages/core/src/features/basic-capabilities/actions/index.ts
@@ -9,6 +9,9 @@ export { ignoreAction } from "./ignore.ts";
 export { noneAction } from "./none.ts";
 export { replyAction } from "./reply.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -19,15 +22,9 @@ import { ignoreAction as _bs_2_ignoreAction } from "./ignore.ts";
 import { noneAction as _bs_3_noneAction } from "./none.ts";
 import { replyAction as _bs_4_replyAction } from "./reply.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX__ = [
+anchorBundleSafety("FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX", [
 	_bs_1_choiceAction,
 	_bs_2_ignoreAction,
 	_bs_3_noneAction,
 	_bs_4_replyAction,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX__ =
-	__bundle_safety_FEATURES_BASIC_CAPABILITIES_ACTIONS_INDEX__;
+]);

--- a/packages/core/src/features/basic-capabilities/providers/index.ts
+++ b/packages/core/src/features/basic-capabilities/providers/index.ts
@@ -26,6 +26,9 @@ export { uiContextProvider } from "./uiContext.ts";
 export { userEmotionSignalProvider } from "./userEmotionSignal.ts";
 export { worldProvider } from "./world.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -53,9 +56,7 @@ import { uiContextProvider as _bs_15_uiContextProvider } from "./uiContext.ts";
 import { userEmotionSignalProvider as _bs_17_userEmotionSignalProvider } from "./userEmotionSignal.ts";
 import { worldProvider as _bs_16_worldProvider } from "./world.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX__ = [
+anchorBundleSafety("FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX", [
 	_bs_1_actionStateProvider,
 	_bs_2_actionsProvider,
 	_bs_3_attachmentsProvider,
@@ -75,8 +76,4 @@ const __bundle_safety_FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX__ = [
 	_bs_17_userEmotionSignalProvider,
 	_bs_18_runtimeModelContextProvider,
 	_bs_19_channelTopicsProvider,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX__ =
-	__bundle_safety_FEATURES_BASIC_CAPABILITIES_PROVIDERS_INDEX__;
+]);

--- a/packages/core/src/features/oauth/index.ts
+++ b/packages/core/src/features/oauth/index.ts
@@ -41,14 +41,13 @@ export {
 	OAUTH_PROVIDERS,
 } from "./types.ts";
 
-import { oauthPlugin as _bs_1_oauthPlugin } from "./plugin.ts";
-
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name. Without this eager anchor
 // the whole feature is reachable only through re-export edges and Bun.build
 // tree-shakes the module bodies out of the mobile agent bundle (see
 // features/payments/index.ts — same incident class). The plugin eagerly
 // imports every action, so anchoring it keeps the full feature.
-const __bundle_safety_FEATURES_OAUTH_INDEX__ = [_bs_1_oauthPlugin];
-(globalThis as Record<string, unknown>).__bundle_safety_FEATURES_OAUTH_INDEX__ =
-	__bundle_safety_FEATURES_OAUTH_INDEX__;
+import { anchorBundleSafety } from "../../bundle-safety.ts";
+import { oauthPlugin as _bs_1_oauthPlugin } from "./plugin.ts";
+
+anchorBundleSafety("FEATURES_OAUTH_INDEX", [_bs_1_oauthPlugin]);

--- a/packages/core/src/features/payments/index.ts
+++ b/packages/core/src/features/payments/index.ts
@@ -33,20 +33,17 @@ export {
 	PAYMENT_SETTLER_SERVICE,
 } from "./types.ts";
 
-import { paymentAction as _bs_1_paymentAction } from "./actions/payment.ts";
-import { paymentsPlugin as _bs_2_paymentsPlugin } from "./plugin.ts";
-
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name. Without this eager anchor
 // the whole feature is reachable only through re-export edges and Bun.build
 // tree-shakes the module bodies out of the mobile agent bundle while keeping
 // the core namespace getter — `paymentsPlugin` then throws a ReferenceError
 // on first access on device.
-const __bundle_safety_FEATURES_PAYMENTS_INDEX__ = [
+import { anchorBundleSafety } from "../../bundle-safety.ts";
+import { paymentAction as _bs_1_paymentAction } from "./actions/payment.ts";
+import { paymentsPlugin as _bs_2_paymentsPlugin } from "./plugin.ts";
+
+anchorBundleSafety("FEATURES_PAYMENTS_INDEX", [
 	_bs_1_paymentAction,
 	_bs_2_paymentsPlugin,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_PAYMENTS_INDEX__ =
-	__bundle_safety_FEATURES_PAYMENTS_INDEX__;
+]);

--- a/packages/core/src/features/plugin-config/index.ts
+++ b/packages/core/src/features/plugin-config/index.ts
@@ -33,18 +33,13 @@ export {
 	PLUGIN_CONFIG_CLIENT_SERVICE,
 } from "./types.ts";
 
-import { pluginConfigPlugin as _bs_1_pluginConfigPlugin } from "./plugin.ts";
-
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name. Without this eager anchor
 // the whole feature is reachable only through re-export edges and Bun.build
 // tree-shakes the module bodies out of the mobile agent bundle (see
 // features/payments/index.ts — same incident class). The plugin eagerly
 // imports every action, so anchoring it keeps the full feature.
-const __bundle_safety_FEATURES_PLUGIN_CONFIG_INDEX__ = [
-	_bs_1_pluginConfigPlugin,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_PLUGIN_CONFIG_INDEX__ =
-	__bundle_safety_FEATURES_PLUGIN_CONFIG_INDEX__;
+import { anchorBundleSafety } from "../../bundle-safety.ts";
+import { pluginConfigPlugin as _bs_1_pluginConfigPlugin } from "./plugin.ts";
+
+anchorBundleSafety("FEATURES_PLUGIN_CONFIG_INDEX", [_bs_1_pluginConfigPlugin]);

--- a/packages/core/src/features/secrets/actions/index.ts
+++ b/packages/core/src/features/secrets/actions/index.ts
@@ -8,6 +8,9 @@
 
 export { maskSecretValue, secretsAction } from "./manage-secret.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force the binding identity into the module's init function
 // so Bun.build's tree-shake doesn't collapse this barrel into an empty
 // `init_X = () => {}`. Without this the on-device mobile agent explodes
@@ -15,10 +18,4 @@ export { maskSecretValue, secretsAction } from "./manage-secret.ts";
 // a re-exported binding at runtime.
 import { secretsAction as _bs_1_secretsAction } from "./manage-secret.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_SECRETS_ACTIONS_INDEX__ = [_bs_1_secretsAction];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_SECRETS_ACTIONS_INDEX__ =
-	__bundle_safety_FEATURES_SECRETS_ACTIONS_INDEX__;
+anchorBundleSafety("FEATURES_SECRETS_ACTIONS_INDEX", [_bs_1_secretsAction]);

--- a/packages/core/src/features/secrets/services/index.ts
+++ b/packages/core/src/features/secrets/services/index.ts
@@ -9,6 +9,9 @@ export {
 } from "./plugin-activator.ts";
 export { SECRETS_SERVICE_TYPE, SecretsService } from "./secrets.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -23,15 +26,9 @@ import {
 	SecretsService as _bs_4_SecretsService,
 } from "./secrets.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_SECRETS_SERVICES_INDEX__ = [
+anchorBundleSafety("FEATURES_SECRETS_SERVICES_INDEX", [
 	_bs_1_PLUGIN_ACTIVATOR_SERVICE_TYPE,
 	_bs_2_PluginActivatorService,
 	_bs_3_SECRETS_SERVICE_TYPE,
 	_bs_4_SecretsService,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_SECRETS_SERVICES_INDEX__ =
-	__bundle_safety_FEATURES_SECRETS_SERVICES_INDEX__;
+]);

--- a/packages/core/src/features/secrets/storage/index.ts
+++ b/packages/core/src/features/secrets/storage/index.ts
@@ -18,6 +18,9 @@ export { BaseSecretStorage, CompositeSecretStorage } from "./interface.ts";
 export { MemorySecretStorage } from "./memory-store.ts";
 export { WorldMetadataStorage } from "./world-store.ts";
 
+// Path-derived symbol so parents that `export *` two of these don't
+// collide on a shared `__BUNDLE_SAFETY__` name.
+import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
@@ -33,9 +36,7 @@ import {
 import { MemorySecretStorage as _bs_5_MemorySecretStorage } from "./memory-store.ts";
 import { WorldMetadataStorage as _bs_6_WorldMetadataStorage } from "./world-store.ts";
 
-// Path-derived symbol so parents that `export *` two of these don't
-// collide on a shared `__BUNDLE_SAFETY__` name.
-const __bundle_safety_FEATURES_SECRETS_STORAGE_INDEX__ = [
+anchorBundleSafety("FEATURES_SECRETS_STORAGE_INDEX", [
 	_bs_0_BrokerSecretStorage,
 	_bs_1_CharacterSettingsStorage,
 	_bs_2_ComponentSecretStorage,
@@ -43,8 +44,4 @@ const __bundle_safety_FEATURES_SECRETS_STORAGE_INDEX__ = [
 	_bs_4_CompositeSecretStorage,
 	_bs_5_MemorySecretStorage,
 	_bs_6_WorldMetadataStorage,
-];
-(
-	globalThis as Record<string, unknown>
-).__bundle_safety_FEATURES_SECRETS_STORAGE_INDEX__ =
-	__bundle_safety_FEATURES_SECRETS_STORAGE_INDEX__;
+]);


### PR DESCRIPTION
## What

Retires the 15x hand-rolled `__bundle_safety_*` globalThis anchor boilerplate in `packages/core/src/features/*` barrels, centralizing it into a single `anchorBundleSafety(name, values)` helper. Refs #12091 item 34.

## Why Not Delete

The anchors are a workaround for a real `Bun.build` issue: under lazy CJS-interop lowering of the cyclic `@elizaos/core` graph for the on-device mobile bundle, re-export-only barrel bodies can be tree-shaken out even with `sideEffects:true` (incidents #10727, #11030, #11248, #11276). Item 34 says to verify the bug against the current pinned Bun and delete only if fixed; otherwise centralize.

Verified still present on the repo's pinned Bun via a minimal faithful reproduction (`bun build --target=browser --format=esm`):

| variant | leaf retained? |
|---|---|
| plain re-export-only barrel (unused) | LEAF-DROPPED |
| inline anchor (old repo pattern) | LEAF-RETAINED |
| helper anchor (this PR) | LEAF-RETAINED |

Same result under `--minify-syntax --minify-whitespace` (iOS build settings). So deletion is unsafe; this PR centralizes the workaround.

## Behavior

The helper writes the same `__bundle_safety_<name>__` global key per barrel. Each barrel keeps its unique path-derived name, so sibling `export *` barrels do not collide. Executing the bundled oauth barrel confirms the runtime global key is present, is an array, and holds `oauthPlugin` as before.

## Local Validation

Validated at head `32d8d54f9fa` rebased on `develop` `d8daf609446c`.

- `git diff --check` — passed
- `bunx @biomejs/biome check $(git diff --name-only origin/develop...HEAD)` — 17 PR files passed, no fixes applied
- `bun run --cwd packages/core typecheck` — passed
- `bun run --cwd packages/core test -- bundle-safety.test.ts` — 1 file / 5 tests passed
- `bun run --cwd packages/core build` — passed, including declarations
- `rg -l "anchorBundleSafety" packages/core/src/features | wc -l` — 15 anchored feature barrels

## Files

- `packages/core/src/bundle-safety.ts` — new helper + tracking doc
- `packages/core/src/bundle-safety.test.ts` — seam tests
- 15 `packages/core/src/features/**/index.ts` barrels
