### PR TITLE
fix(core): fail closed on secret requester checks

### DIFF
--- a/packages/core/src/features/secrets/actions/request-secret.ts
+++ b/packages/core/src/features/secrets/actions/request-secret.ts
@@ -96,6 +96,7 @@ export async function requestSecretHandler(
 			const exists = await service.exists(key, {
 				level: "global", // Check global/user level
 				agentId: runtime.agentId,
+				requesterId: message.entityId,
 				userId:
 					message.entityId !== runtime.agentId
 						? String(message.entityId)

--- a/packages/core/src/features/secrets/providers/secrets-status.ts
+++ b/packages/core/src/features/secrets/providers/secrets-status.ts
@@ -56,6 +56,7 @@ export const secretsStatusProvider: Provider = {
 			const globalSecrets = await secretsService.list({
 				level: "global",
 				agentId: runtime.agentId,
+				requesterId: runtime.agentId,
 			});
 
 			const secretKeys = Object.keys(globalSecrets);
@@ -192,6 +193,7 @@ export const secretsInfoProvider: Provider = {
 			const globalSecrets = await secretsService.list({
 				level: "global",
 				agentId: runtime.agentId,
+				requesterId: runtime.agentId,
 			});
 
 			const secretCount = Object.keys(globalSecrets).length;

--- a/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
+++ b/packages/core/src/features/secrets/services/secrets-broker-wiring.test.ts
@@ -43,6 +43,7 @@ function runtimeWithEnv(
 const GLOBAL_CTX = (agentId: string): SecretContext => ({
 	level: "global",
 	agentId,
+	requesterId: agentId,
 });
 
 function makeHandleBroker(

--- a/packages/core/src/features/secrets/services/secrets.ts
+++ b/packages/core/src/features/secrets/services/secrets.ts
@@ -340,7 +340,11 @@ export class SecretsService extends Service {
 	 * Get a global secret (agent-level)
 	 */
 	async getGlobal(key: string): Promise<string | null> {
-		return this.get(key, { level: "global", agentId: this.runtime.agentId });
+		return this.get(key, {
+			level: "global",
+			agentId: this.runtime.agentId,
+			requesterId: this.runtime.agentId,
+		});
 	}
 
 	/**
@@ -354,7 +358,11 @@ export class SecretsService extends Service {
 		return this.set(
 			key,
 			value,
-			{ level: "global", agentId: this.runtime.agentId },
+			{
+				level: "global",
+				agentId: this.runtime.agentId,
+				requesterId: this.runtime.agentId,
+			},
 			config,
 		);
 	}
@@ -367,6 +375,7 @@ export class SecretsService extends Service {
 			level: "world",
 			worldId,
 			agentId: this.runtime.agentId,
+			requesterId: this.runtime.agentId,
 		});
 	}
 
@@ -382,7 +391,12 @@ export class SecretsService extends Service {
 		return this.set(
 			key,
 			value,
-			{ level: "world", worldId, agentId: this.runtime.agentId },
+			{
+				level: "world",
+				worldId,
+				agentId: this.runtime.agentId,
+				requesterId: this.runtime.agentId,
+			},
 			config,
 		);
 	}
@@ -516,6 +530,7 @@ export class SecretsService extends Service {
 					exists = await this.exists(key, {
 						level: "global",
 						agentId: this.runtime.agentId,
+						requesterId: this.runtime.agentId,
 					});
 					break;
 				case "world":

--- a/packages/core/src/features/secrets/setup/action.ts
+++ b/packages/core/src/features/secrets/setup/action.ts
@@ -179,6 +179,7 @@ async function processSettingUpdates(
 	settings: Record<string, SetupSetting>,
 	updates: SettingUpdate[],
 	secretsService: SecretsService | null,
+	requesterId: string,
 ): Promise<{ updatedAny: boolean; messages: string[] }> {
 	if (!updates.length) {
 		return { updatedAny: false, messages: [] };
@@ -237,6 +238,7 @@ async function processSettingUpdates(
 				level: "world",
 				agentId: runtime.agentId,
 				worldId: world.id,
+				requesterId,
 			};
 
 			await secretsService.set(update.key, valueStr, context, {
@@ -422,6 +424,7 @@ export const updateSettingsAction: Action = {
 			settings,
 			extractedSettings,
 			secretsService,
+			message.entityId,
 		);
 
 		// Get updated settings

--- a/packages/core/src/features/secrets/setup/service.ts
+++ b/packages/core/src/features/secrets/setup/service.ts
@@ -506,6 +506,7 @@ export class SetupService extends Service {
 					agentId: this.runtime.agentId,
 					worldId: session.worldId,
 					userId: session.userId,
+					requesterId: session.userId,
 				};
 
 				await this.secretsService.set(currentSettingKey, value, context, {

--- a/packages/core/src/features/secrets/storage/access-control.test.ts
+++ b/packages/core/src/features/secrets/storage/access-control.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { createMockRuntime } from "../../../testing/mock-runtime.ts";
+import {
+	type Component,
+	type IAgentRuntime,
+	Role,
+	type UUID,
+} from "../../../types/index.ts";
+import { KeyManager } from "../crypto/encryption.ts";
+import { PermissionDeniedError, type SecretContext } from "../types.ts";
+import { CharacterSettingsStorage } from "./character-store.ts";
+import { ComponentSecretStorage } from "./component-store.ts";
+import { WorldMetadataStorage } from "./world-store.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const OWNER_ID = "00000000-0000-0000-0000-000000000002";
+const MEMBER_ID = "00000000-0000-0000-0000-000000000003";
+const STRANGER_ID = "00000000-0000-0000-0000-000000000004";
+const WORLD_ID = "00000000-0000-0000-0000-000000000005" as UUID;
+
+function keyManager(): KeyManager {
+	const manager = new KeyManager();
+	manager.initializeFromPassword(AGENT_ID, "test-salt");
+	return manager;
+}
+
+function makeRuntime(): IAgentRuntime {
+	const components = new Map<string, Component[]>();
+	const world = {
+		id: WORLD_ID,
+		agentId: AGENT_ID,
+		metadata: {
+			ownership: { ownerId: OWNER_ID },
+			roles: {
+				[OWNER_ID]: Role.OWNER,
+				[MEMBER_ID]: Role.MEMBER,
+			},
+			secrets: {},
+		},
+	};
+
+	return createMockRuntime({
+		agentId: AGENT_ID,
+		character: {
+			name: "T",
+			bio: [],
+			settings: { secrets: {} },
+		} as IAgentRuntime["character"],
+		getSetting: ((key: string) =>
+			key === "ELIZA_ADMIN_ENTITY_ID"
+				? OWNER_ID
+				: undefined) as IAgentRuntime["getSetting"],
+		getWorld: (async (id: UUID) =>
+			id === WORLD_ID ? world : null) as IAgentRuntime["getWorld"],
+		updateWorld: (async (nextWorld) => {
+			Object.assign(world, nextWorld);
+			return true;
+		}) as IAgentRuntime["updateWorld"],
+		getComponents: (async (entityId: UUID) =>
+			components.get(entityId) ?? []) as IAgentRuntime["getComponents"],
+		createComponent: (async (component: Component) => {
+			const list = components.get(component.entityId) ?? [];
+			list.push(component);
+			components.set(component.entityId, list);
+			return true;
+		}) as IAgentRuntime["createComponent"],
+		updateComponent: (async (component: Component) => {
+			const list = components.get(component.entityId) ?? [];
+			const index = list.findIndex((entry) => entry.id === component.id);
+			if (index >= 0) {
+				list[index] = component;
+			}
+			components.set(component.entityId, list);
+			return true;
+		}) as IAgentRuntime["updateComponent"],
+		deleteComponent: (async (componentId: UUID) => {
+			for (const [entityId, list] of components.entries()) {
+				components.set(
+					entityId,
+					list.filter((entry) => entry.id !== componentId),
+				);
+			}
+			return true;
+		}) as IAgentRuntime["deleteComponent"],
+	});
+}
+
+describe("secrets storage access control", () => {
+	it("fails closed for user secrets when requesterId is omitted", async () => {
+		const runtime = makeRuntime();
+		const storage = new ComponentSecretStorage(runtime, keyManager());
+		await storage.initialize();
+		const context: SecretContext = {
+			level: "user",
+			agentId: AGENT_ID,
+			userId: MEMBER_ID,
+		};
+
+		await expect(storage.get("USER_KEY", context)).rejects.toBeInstanceOf(
+			PermissionDeniedError,
+		);
+		await expect(
+			storage.set("USER_KEY", "value", context),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+
+	it("allows only the user to read and write user secrets", async () => {
+		const runtime = makeRuntime();
+		const storage = new ComponentSecretStorage(runtime, keyManager());
+		await storage.initialize();
+		const ownerContext: SecretContext = {
+			level: "user",
+			agentId: AGENT_ID,
+			userId: MEMBER_ID,
+			requesterId: MEMBER_ID,
+		};
+		const strangerContext: SecretContext = {
+			...ownerContext,
+			requesterId: STRANGER_ID,
+		};
+
+		await expect(storage.set("USER_KEY", "value", ownerContext)).resolves.toBe(
+			true,
+		);
+		await expect(storage.get("USER_KEY", ownerContext)).resolves.toBe("value");
+		await expect(
+			storage.get("USER_KEY", strangerContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+
+	it("requires world membership for world secret reads", async () => {
+		const runtime = makeRuntime();
+		const storage = new WorldMetadataStorage(runtime, keyManager());
+		await storage.initialize();
+		const ownerContext: SecretContext = {
+			level: "world",
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+			requesterId: OWNER_ID,
+		};
+		const memberContext: SecretContext = {
+			...ownerContext,
+			requesterId: MEMBER_ID,
+		};
+		const strangerContext: SecretContext = {
+			...ownerContext,
+			requesterId: STRANGER_ID,
+		};
+		const anonymousContext: SecretContext = {
+			level: "world",
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+		};
+
+		await storage.set("WORLD_KEY", "value", ownerContext);
+		await expect(storage.get("WORLD_KEY", memberContext)).resolves.toBe(
+			"value",
+		);
+		await expect(
+			storage.get("WORLD_KEY", strangerContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+		await expect(
+			storage.get("WORLD_KEY", anonymousContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+
+	it("requires OWNER or ADMIN for world secret writes", async () => {
+		const runtime = makeRuntime();
+		const storage = new WorldMetadataStorage(runtime, keyManager());
+		await storage.initialize();
+		const memberContext: SecretContext = {
+			level: "world",
+			agentId: AGENT_ID,
+			worldId: WORLD_ID,
+			requesterId: MEMBER_ID,
+		};
+
+		await expect(
+			storage.set("WORLD_KEY", "value", memberContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+
+	it("requires an entitled requester for global secrets", async () => {
+		const runtime = makeRuntime();
+		const storage = new CharacterSettingsStorage(runtime, keyManager());
+		await storage.initialize();
+		const ownerContext: SecretContext = {
+			level: "global",
+			agentId: AGENT_ID,
+			requesterId: OWNER_ID,
+		};
+		const anonymousContext: SecretContext = {
+			level: "global",
+			agentId: AGENT_ID,
+		};
+		const strangerContext: SecretContext = {
+			level: "global",
+			agentId: AGENT_ID,
+			requesterId: STRANGER_ID,
+		};
+
+		await expect(
+			storage.set("GLOBAL_KEY", "value", ownerContext),
+		).resolves.toBe(true);
+		await expect(storage.get("GLOBAL_KEY", ownerContext)).resolves.toBe(
+			"value",
+		);
+		await expect(
+			storage.get("GLOBAL_KEY", anonymousContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+		await expect(
+			storage.get("GLOBAL_KEY", strangerContext),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+});

--- a/packages/core/src/features/secrets/storage/character-store.ts
+++ b/packages/core/src/features/secrets/storage/character-store.ts
@@ -10,6 +10,7 @@
  */
 
 import { logger } from "../../../logger.ts";
+import { resolveCanonicalOwnerId } from "../../../roles.ts";
 import type { IAgentRuntime } from "../../../types/index.ts";
 import { isEncryptedSecret, type KeyManager } from "../crypto/encryption.ts";
 import type {
@@ -17,9 +18,11 @@ import type {
 	SecretConfig,
 	SecretContext,
 	SecretMetadata,
+	SecretPermissionType,
 	StorageBackend,
 	StoredSecret,
 } from "../types.ts";
+import { PermissionDeniedError } from "../types.ts";
 import { BaseSecretStorage } from "./interface.ts";
 
 const SECRETS_KEY = "secrets";
@@ -70,13 +73,15 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		}
 	}
 
-	async exists(key: string, _context: SecretContext): Promise<boolean> {
+	async exists(key: string, context: SecretContext): Promise<boolean> {
+		this.assertGlobalAccess(key, "read", context);
 		this.ensureSettingsStructure();
 		const secrets = this.getSecretsObject();
 		return key in secrets;
 	}
 
 	async get(key: string, context: SecretContext): Promise<string | null> {
+		this.assertGlobalAccess(key, "read", context);
 		this.ensureSettingsStructure();
 		const secrets = this.getSecretsObject();
 		const stored = secrets[key];
@@ -121,6 +126,7 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		context: SecretContext,
 		config?: Partial<SecretConfig>,
 	): Promise<boolean> {
+		this.assertGlobalAccess(key, "write", context);
 		this.ensureSettingsStructure();
 		const secrets = this.getSecretsObject();
 		const existingStored = secrets[key];
@@ -150,7 +156,8 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		return true;
 	}
 
-	async delete(key: string, _context: SecretContext): Promise<boolean> {
+	async delete(key: string, context: SecretContext): Promise<boolean> {
+		this.assertGlobalAccess(key, "delete", context);
 		this.ensureSettingsStructure();
 		const secrets = this.getSecretsObject();
 
@@ -164,7 +171,8 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		return true;
 	}
 
-	async list(_context: SecretContext): Promise<SecretMetadata> {
+	async list(context: SecretContext): Promise<SecretMetadata> {
+		this.assertGlobalAccess("*", "read", context);
 		const secrets = this.getSecretsObject();
 		const metadata: SecretMetadata = {};
 
@@ -203,6 +211,7 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		key: string,
 		context: SecretContext,
 	): Promise<SecretConfig | null> {
+		this.assertGlobalAccess(key, "read", context);
 		const secrets = this.getSecretsObject();
 		const stored = secrets[key];
 
@@ -219,9 +228,10 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 
 	async updateConfig(
 		key: string,
-		_context: SecretContext,
+		context: SecretContext,
 		config: Partial<SecretConfig>,
 	): Promise<boolean> {
+		this.assertGlobalAccess(key, "write", context);
 		this.ensureSettingsStructure();
 		const secrets = this.getSecretsObject();
 		const stored = secrets[key];
@@ -235,10 +245,7 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 				? (stored as StoredSecret)
 				: ({
 						value: stored as string,
-						config: this.createDefaultConfig(key, {
-							level: "global",
-							agentId: this.runtime.agentId,
-						}),
+						config: this.createDefaultConfig(key, context),
 					} satisfies StoredSecret);
 		storedSecret.config = {
 			...storedSecret.config,
@@ -265,5 +272,27 @@ export class CharacterSettingsStorage extends BaseSecretStorage {
 		}
 
 		return secrets as Record<string, StoredSecret>;
+	}
+
+	private assertGlobalAccess(
+		key: string,
+		action: SecretPermissionType,
+		context: SecretContext,
+	): void {
+		const requesterId = context.requesterId;
+		if (!requesterId) {
+			throw new PermissionDeniedError(key, action, context);
+		}
+
+		if (requesterId === this.runtime.agentId) {
+			return;
+		}
+
+		const ownerId = resolveCanonicalOwnerId(this.runtime);
+		if (ownerId && requesterId === ownerId) {
+			return;
+		}
+
+		throw new PermissionDeniedError(key, action, context);
 	}
 }

--- a/packages/core/src/features/secrets/storage/component-store.ts
+++ b/packages/core/src/features/secrets/storage/component-store.ts
@@ -14,6 +14,7 @@ import type {
 	SecretConfig,
 	SecretContext,
 	SecretMetadata,
+	SecretPermissionType,
 	StorageBackend,
 } from "../types.ts";
 import { PermissionDeniedError, StorageError } from "../types.ts";
@@ -59,6 +60,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 		if (!context.userId) {
 			return false;
 		}
+		this.assertUserAccess(key, "read", context);
 
 		const component = await this.findSecretComponent(context.userId, key);
 		return component !== null;
@@ -70,10 +72,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 			return null;
 		}
 
-		// Check permission - only the user can access their own secrets
-		if (context.requesterId && context.requesterId !== context.userId) {
-			throw new PermissionDeniedError(key, "read", context);
-		}
+		this.assertUserAccess(key, "read", context);
 
 		const component = await this.findSecretComponent(context.userId, key);
 		if (!component) {
@@ -113,10 +112,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 			throw new StorageError("Cannot set user secret without userId");
 		}
 
-		// Check permission - only the user can set their own secrets
-		if (context.requesterId && context.requesterId !== context.userId) {
-			throw new PermissionDeniedError(key, "write", context);
-		}
+		this.assertUserAccess(key, "write", context);
 
 		const existingComponent = await this.findSecretComponent(
 			context.userId,
@@ -183,10 +179,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 			return false;
 		}
 
-		// Check permission - only the user can delete their own secrets
-		if (context.requesterId && context.requesterId !== context.userId) {
-			throw new PermissionDeniedError(key, "delete", context);
-		}
+		this.assertUserAccess(key, "delete", context);
 
 		const component = await this.findSecretComponent(context.userId, key);
 		if (!component) {
@@ -205,10 +198,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 			return {};
 		}
 
-		// Check permission
-		if (context.requesterId && context.requesterId !== context.userId) {
-			throw new PermissionDeniedError("*", "read", context);
-		}
+		this.assertUserAccess("*", "read", context);
 
 		const components = await this.runtime.getComponents(context.userId as UUID);
 		const metadata: SecretMetadata = {};
@@ -241,6 +231,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 		if (!context.userId) {
 			return null;
 		}
+		this.assertUserAccess(key, "read", context);
 
 		const component = await this.findSecretComponent(context.userId, key);
 		if (!component) {
@@ -260,10 +251,7 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 			return false;
 		}
 
-		// Check permission
-		if (context.requesterId && context.requesterId !== context.userId) {
-			throw new PermissionDeniedError(key, "write", context);
-		}
+		this.assertUserAccess(key, "write", context);
 
 		const component = await this.findSecretComponent(context.userId, key);
 		if (!component) {
@@ -310,6 +298,16 @@ export class ComponentSecretStorage extends BaseSecretStorage {
 		}
 
 		return null;
+	}
+
+	private assertUserAccess(
+		key: string,
+		action: SecretPermissionType,
+		context: SecretContext,
+	): void {
+		if (!context.requesterId || context.requesterId !== context.userId) {
+			throw new PermissionDeniedError(key, action, context);
+		}
 	}
 
 	/**

--- a/packages/core/src/features/secrets/storage/world-store.ts
+++ b/packages/core/src/features/secrets/storage/world-store.ts
@@ -14,6 +14,7 @@ import type {
 	SecretConfig,
 	SecretContext,
 	SecretMetadata,
+	SecretPermissionType,
 	StorageBackend,
 	StoredSecret,
 } from "../types.ts";
@@ -55,6 +56,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 		if (!context.worldId) {
 			return false;
 		}
+		await this.assertReadPermission(key, context);
 
 		const secrets = await this.getWorldSecrets(context.worldId);
 		return key in secrets;
@@ -65,6 +67,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 			logger.warn("[WorldMetadataStorage] Cannot get secret without worldId");
 			return null;
 		}
+		await this.assertReadPermission(key, context);
 
 		const secrets = await this.getWorldSecrets(context.worldId);
 		const stored = secrets[key];
@@ -85,7 +88,15 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 				storedSecret.config.expiresAt &&
 				storedSecret.config.expiresAt < Date.now()
 			) {
-				await this.delete(key, context);
+				if (
+					context.requesterId &&
+					(await this.checkWritePermission(
+						context.worldId,
+						context.requesterId,
+					))
+				) {
+					await this.delete(key, context);
+				}
 				return null;
 			}
 
@@ -112,16 +123,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 			throw new StorageError("Cannot set world secret without worldId");
 		}
 
-		// Check write permission
-		if (context.requesterId) {
-			const hasPermission = await this.checkWritePermission(
-				context.worldId,
-				context.requesterId,
-			);
-			if (!hasPermission) {
-				throw new PermissionDeniedError(key, "write", context);
-			}
-		}
+		await this.assertWritePermission(key, "write", context);
 
 		const world = await this.getWorld(context.worldId);
 		if (!world) {
@@ -177,16 +179,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 			return false;
 		}
 
-		// Check write permission
-		if (context.requesterId) {
-			const hasPermission = await this.checkWritePermission(
-				context.worldId,
-				context.requesterId,
-			);
-			if (!hasPermission) {
-				throw new PermissionDeniedError(key, "delete", context);
-			}
-		}
+		await this.assertWritePermission(key, "delete", context);
 
 		const world = await this.getWorld(context.worldId);
 		if (!world) {
@@ -218,6 +211,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 		if (!context.worldId) {
 			return {};
 		}
+		await this.assertReadPermission("*", context);
 
 		const secrets = await this.getWorldSecrets(context.worldId);
 		const metadata: SecretMetadata = {};
@@ -256,6 +250,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 		if (!context.worldId) {
 			return null;
 		}
+		await this.assertReadPermission(key, context);
 
 		const secrets = await this.getWorldSecrets(context.worldId);
 		const stored = secrets[key];
@@ -284,16 +279,7 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 			return false;
 		}
 
-		// Check write permission
-		if (context.requesterId) {
-			const hasPermission = await this.checkWritePermission(
-				context.worldId,
-				context.requesterId,
-			);
-			if (!hasPermission) {
-				throw new PermissionDeniedError(key, "write", context);
-			}
-		}
+		await this.assertWritePermission(key, "write", context);
 
 		const world = await this.getWorld(context.worldId);
 		if (!world) {
@@ -387,6 +373,59 @@ export class WorldMetadataStorage extends BaseSecretStorage {
 
 		const userRole = roles[userId];
 		return userRole === Role.OWNER || userRole === Role.ADMIN;
+	}
+
+	private async assertReadPermission(
+		key: string,
+		context: SecretContext,
+	): Promise<void> {
+		if (!context.worldId || !context.requesterId) {
+			throw new PermissionDeniedError(key, "read", context);
+		}
+
+		if (await this.checkReadPermission(context.worldId, context.requesterId)) {
+			return;
+		}
+
+		throw new PermissionDeniedError(key, "read", context);
+	}
+
+	private async assertWritePermission(
+		key: string,
+		action: Extract<SecretPermissionType, "write" | "delete">,
+		context: SecretContext,
+	): Promise<void> {
+		if (!context.worldId || !context.requesterId) {
+			throw new PermissionDeniedError(key, action, context);
+		}
+
+		if (await this.checkWritePermission(context.worldId, context.requesterId)) {
+			return;
+		}
+
+		throw new PermissionDeniedError(key, action, context);
+	}
+
+	private async checkReadPermission(
+		worldId: string,
+		userId: string,
+	): Promise<boolean> {
+		const world = await this.getWorld(worldId);
+		if (!world) {
+			return false;
+		}
+
+		if (userId === this.runtime.agentId) {
+			return true;
+		}
+
+		if (world.metadata?.ownership?.ownerId === userId) {
+			return true;
+		}
+
+		const roles = world.metadata?.roles as Record<string, Role> | undefined;
+		const userRole = roles?.[userId];
+		return Boolean(userRole && userRole !== Role.NONE);
 	}
 
 	/**

--- a/plugins/plugin-calendly/src/connector-credential-refs.ts
+++ b/plugins/plugin-calendly/src/connector-credential-refs.ts
@@ -204,7 +204,11 @@ function resolveVaultWriters(
         await secrets.set?.(
           vaultRef,
           credential.value,
-          { level: "global", agentId: runtime.agentId },
+          {
+            level: "global",
+            agentId: runtime.agentId,
+            requesterId: runtime.agentId,
+          },
           { sensitive: true },
         );
         return vaultRef;

--- a/plugins/plugin-github/src/connector-credential-refs.ts
+++ b/plugins/plugin-github/src/connector-credential-refs.ts
@@ -391,7 +391,11 @@ function resolveVaultWriters(
         await secrets.set?.(
           vaultRef,
           credential.value,
-          { level: "global", agentId: runtime.agentId },
+          {
+            level: "global",
+            agentId: runtime.agentId,
+            requesterId: runtime.agentId,
+          },
           { sensitive: true },
         );
         return vaultRef;
@@ -439,6 +443,7 @@ async function readSecret(
     return candidate.get(vaultRef, {
       level: "global",
       agentId: runtime.agentId,
+      requesterId: runtime.agentId,
     });
   }
   return candidate.get(vaultRef, { reveal: true, caller });

--- a/plugins/plugin-google/src/connector-credential-refs.ts
+++ b/plugins/plugin-google/src/connector-credential-refs.ts
@@ -257,7 +257,7 @@ function resolveVaultWriters(
         await secrets.set?.(
           vaultRef,
           credential.value,
-          { level: "global", agentId: runtime.agentId },
+          { level: "global", agentId: runtime.agentId, requesterId: runtime.agentId },
           { sensitive: true }
         );
         return vaultRef;

--- a/plugins/plugin-google/src/credential-resolver.ts
+++ b/plugins/plugin-google/src/credential-resolver.ts
@@ -440,6 +440,7 @@ export class DefaultGoogleCredentialResolver implements GoogleCredentialResolver
             secretsService.get?.(key, {
               level: "global",
               agentId: this.runtime?.agentId,
+              requesterId: this.runtime?.agentId,
             }) ?? null,
         });
       }
@@ -580,6 +581,7 @@ async function readSecret(
     return candidate.get(vaultRef, {
       level: "global",
       agentId: runtime?.agentId,
+      requesterId: runtime?.agentId,
     });
   }
 

--- a/plugins/plugin-slack/src/connector-credential-refs.ts
+++ b/plugins/plugin-slack/src/connector-credential-refs.ts
@@ -204,7 +204,11 @@ function resolveVaultWriters(
         await secrets.set?.(
           vaultRef,
           credential.value,
-          { level: "global", agentId: runtime.agentId },
+          {
+            level: "global",
+            agentId: runtime.agentId,
+            requesterId: runtime.agentId,
+          },
           { sensitive: true },
         );
         return vaultRef;

--- a/plugins/plugin-x/src/connector-credential-refs.ts
+++ b/plugins/plugin-x/src/connector-credential-refs.ts
@@ -465,7 +465,11 @@ function resolveVaultWriters(
         await secrets.set?.(
           vaultRef,
           credential.value,
-          { level: "global", agentId: runtime.agentId },
+          {
+            level: "global",
+            agentId: runtime.agentId,
+            requesterId: runtime.agentId,
+          },
           { sensitive: true },
         );
         return vaultRef;
@@ -513,6 +517,7 @@ async function readSecret(
     return candidate.get(vaultRef, {
       level: "global",
       agentId: runtime.agentId,
+      requesterId: runtime.agentId,
     });
   }
   return candidate.get(vaultRef, { reveal: true, caller });


### PR DESCRIPTION
## Summary
- Makes component/user secret storage fail closed when requesterId is missing or does not match the user.
- Makes world secret reads require explicit world membership and writes require OWNER/ADMIN, with missing requesterId denied.
- Adds global secret entitlement checks for explicit agent/internal or canonical owner requester IDs.
- Updates internal setup/status/connector credential paths to pass explicit requester IDs.
- Addresses #12088 item 10.

## Validation
- bun run --cwd packages/core prebuild
- bun run --cwd packages/core test -- src/features/secrets/storage/access-control.test.ts src/features/secrets/services/secrets-broker-wiring.test.ts src/features/secrets/storage/broker-store.test.ts src/features/secrets/setup/service.test.ts
- bunx @biomejs/biome check <touched files>
- git diff --check

## Notes
- bun run --cwd packages/core typecheck is still blocked by existing @elizaos/cloud-routing declaration resolution from the shared dist/node_modules setup.