### PR TITLE
refactor(agent): move trajectory read wire-shaping to its core owner (#12092 item 7, partial)

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -38,6 +38,7 @@ import {
   sendJson,
   sendJsonError,
   stringToUuid,
+  tryHandleTrajectoryReadRoutes,
   type UUID,
 } from "@elizaos/core";
 import type {
@@ -493,7 +494,6 @@ import {
   tryHandleMusicPlayerStatusFallbackLazy,
   tryHandleRuntimePluginRoute,
 } from "./server-lazy-routes.ts";
-import { tryHandleTrajectoryFallback } from "./trajectory-fallback-routes.ts";
 import {
   EVM_PLUGIN_PACKAGE,
   resolveWalletAutomationMode as resolveAgentAutomationModeFromConfig,
@@ -3622,13 +3622,13 @@ async function handleRequest(
     return;
   }
 
-  // ── Trajectory read fallback ────────────────────────────────────────────
+  // ── Trajectory read routes (owned by core TrajectoriesService) ──────────
   // Serves GET /api/trajectories[/:id|/stats] from the core TrajectoriesService
   // when no plugin owns the route (mobile / training disabled), so the realtime
   // trajectory viewer works without @elizaos/plugin-training. Runs AFTER the
   // plugin routes above, so plugin-training's richer route wins when present.
   if (
-    await tryHandleTrajectoryFallback({
+    await tryHandleTrajectoryReadRoutes({
       pathname,
       method,
       url,

--- a/packages/core/src/features/trajectories/read-routes.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.test.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse } from "node:http";
-import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { tryHandleTrajectoryFallback } from "./trajectory-fallback-routes.ts";
+import type { IAgentRuntime } from "../../types";
+import { tryHandleTrajectoryReadRoutes } from "./read-routes";
 
 // Minimal ServerResponse capture — records statusCode + parsed JSON body.
 function mockRes(): {
@@ -24,20 +24,20 @@ function mockRes(): {
 function runtimeWith(
   service: unknown,
   rooms: Record<string, unknown> = {},
-): AgentRuntime {
+): IAgentRuntime {
   return {
     getService: (type: string) => (type === "trajectories" ? service : null),
     getRoom: async (id: string) => rooms[id] ?? null,
-  } as unknown as AgentRuntime;
+  } as unknown as IAgentRuntime;
 }
 
 const url = (p: string) => new URL(`http://localhost${p}`);
 
-describe("tryHandleTrajectoryFallback", () => {
+describe("tryHandleTrajectoryReadRoutes", () => {
   it("ignores non-trajectory paths and non-GET methods", async () => {
     const { res } = mockRes();
     expect(
-      await tryHandleTrajectoryFallback({
+      await tryHandleTrajectoryReadRoutes({
         pathname: "/api/health",
         method: "GET",
         url: url("/api/health"),
@@ -46,7 +46,7 @@ describe("tryHandleTrajectoryFallback", () => {
       }),
     ).toBe(false);
     expect(
-      await tryHandleTrajectoryFallback({
+      await tryHandleTrajectoryReadRoutes({
         pathname: "/api/trajectories",
         method: "DELETE",
         url: url("/api/trajectories"),
@@ -75,7 +75,7 @@ describe("tryHandleTrajectoryFallback", () => {
       }),
     };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories",
       method: "GET",
       url: url("/api/trajectories?limit=10"),
@@ -117,7 +117,7 @@ describe("tryHandleTrajectoryFallback", () => {
       },
     };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories",
       method: "GET",
       url: url("/api/trajectories?search=match&limit=10"),
@@ -171,7 +171,7 @@ describe("tryHandleTrajectoryFallback", () => {
       }),
     };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories/abc",
       method: "GET",
       url: url("/api/trajectories/abc"),
@@ -231,7 +231,7 @@ describe("tryHandleTrajectoryFallback", () => {
       }),
     };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories",
       method: "GET",
       url: url("/api/trajectories?resolve=1"),
@@ -262,7 +262,7 @@ describe("tryHandleTrajectoryFallback", () => {
   it("404s an unknown detail id", async () => {
     const service = { getTrajectoryDetail: async () => null };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories/missing",
       method: "GET",
       url: url("/api/trajectories/missing"),
@@ -275,7 +275,7 @@ describe("tryHandleTrajectoryFallback", () => {
 
   it("returns an empty list (200, not 404) when the service is absent", async () => {
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories",
       method: "GET",
       url: url("/api/trajectories"),
@@ -297,7 +297,7 @@ describe("tryHandleTrajectoryFallback", () => {
       },
     };
     const { res, get } = mockRes();
-    const handled = await tryHandleTrajectoryFallback({
+    const handled = await tryHandleTrajectoryReadRoutes({
       pathname: "/api/trajectories/stats",
       method: "GET",
       url: url("/api/trajectories/stats"),

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -1,22 +1,24 @@
 import type { ServerResponse } from "node:http";
-import type { AgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime, UUID } from "../../types";
 
 /**
- * Built-in compatibility fallback for the trajectory READ routes
+ * Owner-side read routes for the realtime trajectory viewer
  * (`GET /api/trajectories`, `/api/trajectories/:id`, `/api/trajectories/stats`).
  *
- * The realtime trajectory viewer (`@elizaos/plugin-trajectory-logger`) polls
- * these, but the routes are normally served by `@elizaos/plugin-training` — which
- * is NOT bundled on mobile (the device log: "Training service package
- * unavailable; training routes will be disabled"). Without a provider the viewer
- * gets a 404 and shows "Trajectory logging unavailable", even though the core
- * `TrajectoriesService` IS running and has data. This fallback reads that service
- * directly and returns the shapes the viewer expects.
+ * These live next to the data owner (`TrajectoriesService`, this package) so the
+ * viewer wire shapes stay co-located with the service that produces the data,
+ * instead of being hand-mirrored in the API host.
  *
- * Dispatch placement matters: this runs AFTER `tryHandleRuntimePluginRoute`, so
- * when plugin-training IS loaded (desktop) its richer route handles the request
- * first and this fallback is never reached — no shadowing, no regression. It only
- * fires when no plugin owns the path (mobile, or training disabled).
+ * The realtime trajectory viewer (`@elizaos/plugin-trajectory-logger`) polls
+ * these. On desktop the richer routes from `@elizaos/plugin-training` own the
+ * path (registered as runtime plugin routes) and handle the request first; this
+ * handler is only reached when no plugin owns the path (mobile, or training
+ * disabled). The core `TrajectoriesService` runs on every platform, so the
+ * viewer works without `@elizaos/plugin-training` bundled.
+ *
+ * The API host mounts this AFTER runtime plugin routes, so when plugin-training
+ * IS loaded its richer route wins and this handler is never reached — no
+ * shadowing, no regression.
  */
 
 interface ServiceTrajectoryListItem {
@@ -247,15 +249,13 @@ function detailToUi(
 }
 
 async function resolveRoomContext(
-  runtime: AgentRuntime | null | undefined,
+  runtime: IAgentRuntime | null | undefined,
   roomId: string | null | undefined,
   cache: Map<string, ResolvedRoomContext | null>,
 ): Promise<ResolvedRoomContext | null> {
   if (!roomId) return null;
   if (cache.has(roomId)) return cache.get(roomId) ?? null;
-  const room = await runtime?.getRoom?.(
-    roomId as `${string}-${string}-${string}-${string}-${string}`,
-  );
+  const room = await runtime?.getRoom?.(roomId as UUID);
   const context = room
     ? {
         id: String(room.id || roomId),
@@ -271,11 +271,16 @@ async function resolveRoomContext(
   return context;
 }
 
-export async function tryHandleTrajectoryFallback(options: {
+/**
+ * Handle the trajectory viewer READ routes from the core `TrajectoriesService`.
+ * Returns `true` when the request was handled (even on error), `false` when the
+ * path/method does not belong to these read routes.
+ */
+export async function tryHandleTrajectoryReadRoutes(options: {
   pathname: string;
   method: string;
   url: URL;
-  runtime: AgentRuntime | null | undefined;
+  runtime: IAgentRuntime | null | undefined;
   res: ServerResponse;
 }): Promise<boolean> {
   const { pathname, method, url, runtime, res } = options;
@@ -331,7 +336,7 @@ export async function tryHandleTrajectoryFallback(options: {
         scenarioId: url.searchParams.get("scenarioId") || undefined,
         batchId: url.searchParams.get("batchId") || undefined,
         // The SQL reader filters + counts by `search` (id/scenario_id/
-        // batch_id/metadata/steps_json LIKE). On mobile this fallback owns
+        // batch_id/metadata/steps_json LIKE). On mobile this owns
         // /api/trajectories, so without forwarding `search` the viewer's
         // search box returned the full unfiltered list.
         search: url.searchParams.get("search") || undefined,

--- a/packages/core/src/services/trajectories.ts
+++ b/packages/core/src/services/trajectories.ts
@@ -1,4 +1,5 @@
 export { TrajectoriesService } from "../features/trajectories/TrajectoriesService";
+export { tryHandleTrajectoryReadRoutes } from "../features/trajectories/read-routes";
 export * from "./trajectory-export";
 export * from "./trajectory-types";
 


### PR DESCRIPTION
## #12092 item 7 [P2][M] — host fallback shims hand-mirror plugin wire formats

The item groups three host shims, but they are structurally different — so this PR does the one that's cleanly ownable and documents the other two (which are genuinely load-bearing) with a follow-up plan.

| Shim | Decision |
|---|---|
| `trajectory-fallback-routes.ts` | **Moved to the core data owner; host shim deleted.** |
| `lifeops-inbox-fallback-routes.ts` | Left — owner (`plugin-personal-assistant`) is an OPTIONAL_CORE_PLUGIN absent on mobile; the shim is a real placeholder. |
| `music-player-route-fallback.ts` | Left — owner (`plugin-music`) absent on mobile; real placeholder (service-present branch is dead — plugin route wins when loaded). |

## Change (trajectory)
Trajectory reads are **not** a placeholder — the owner is the core `TrajectoriesService`, a native feature present on every platform incl. mobile. Moved the wire-shaping out of the host into the owner:
- New `packages/core/src/features/trajectories/read-routes.ts` — `tryHandleTrajectoryReadRoutes(...)` (moved verbatim, retyped to core `IAgentRuntime`), exported via `@elizaos/core`.
- `server.ts` now calls the core-owned handler **in the same dispatch position** (after `tryHandleRuntimePluginRoute`) so `plugin-training`'s richer trajectory routes still win on desktop — no regression.
- Deleted `packages/agent/src/api/trajectory-fallback-routes.ts`; moved its test to core.

**Done-criterion (trajectory):** `grep packages/agent/src/api` for the removed shim → NONE; no agent/api file constructs the trajectory wire shape.

## Follow-up plan (in the PR discussion / issue)
- **Inbox** (tractable next): `plugin-inbox` IS on mobile and owns `/api/lifeops/inbox/*` — move the placeholder base-list route there, normalize dispatch precedence vs PA on desktop.
- **Music** (needs a mechanism): a small `Plugin`-declared `fallbackPlaceholders` map the loader registers even when the plugin body is absent; then both remaining shims delete.

## Verification
- Relocated core test — **8/8 pass** (list, timeout→error, search, detail phase-classification, room-context resolve, 404, **200 empty when service absent = non-404**, stats-not-detail).
- `tsc` core: 0 errors in moved files; agent: 0 trajectory errors (rest pre-existing unbuilt-workspace `TS2307`). Dispatch order + mobile non-404 preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)