### PR TITLE
refactor(agent): codegen optional-plugin literal-import table + gate workspace-src fallback

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -33,6 +33,7 @@
     "dev": "bun --hot src/bin.ts",
     "prepublishOnly": "bun run build:dist",
     "build": "bun run build:dist",
+    "gen:optional-plugin-imports": "bun run scripts/gen-optional-plugin-imports.ts",
     "build:mobile": "bun run scripts/build-mobile-bundle.mjs",
     "build:ios-bun": "bun run scripts/build-mobile-bundle.mjs --target=ios",
     "build:ios-jsc": "bun run scripts/build-mobile-bundle.mjs --target=ios-jsc",

--- a/packages/agent/scripts/gen-optional-plugin-imports.ts
+++ b/packages/agent/scripts/gen-optional-plugin-imports.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+/**
+ * Regenerate `src/runtime/optional-plugin-imports.generated.ts` from the
+ * `OPTIONAL_STATIC_PLUGIN_PACKAGES` source of truth so the bundler sees literal
+ * `import()` specifiers without a hand-maintained if-chain.
+ *
+ * Run: bun run --cwd packages/agent gen:optional-plugin-imports
+ * A drift check (optional-plugins.test.ts) fails CI if this output is stale.
+ */
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  renderOptionalPluginImportsModule,
+} from "../src/runtime/optional-plugins.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const outPath = path.resolve(
+  here,
+  "..",
+  "src",
+  "runtime",
+  "optional-plugin-imports.generated.ts",
+);
+
+writeFileSync(
+  outPath,
+  renderOptionalPluginImportsModule(OPTIONAL_STATIC_PLUGIN_PACKAGES),
+);
+
+// Format so the committed file matches the repo's biome style; the drift test
+// asserts on the exported keys, not text, so formatting is free to differ.
+spawnSync("bunx", ["@biomejs/biome", "format", "--write", outPath], {
+  stdio: "inherit",
+});
+
+console.log(
+  `[gen-optional-plugin-imports] wrote ${OPTIONAL_STATIC_PLUGIN_PACKAGES.length} importers -> ${path.relative(path.resolve(here, ".."), outPath)}`,
+);

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -122,7 +122,6 @@ import {
   settingsDebugCloudSummary,
 } from "@elizaos/shared";
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
-import type { Vault } from "@elizaos/vault";
 import { type AgentHostBridge, getAgentHostBridge } from "./host-bridge.ts";
 
 // Host capabilities (wallet-key hydration, vault bootstrap/access, account

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -37,7 +37,9 @@ import { maybeInjectFault } from "./crash-injection.ts";
 import { runFirstTimeSetup } from "./first-time-setup.ts";
 import { startMemoryWatchdog } from "./memory-watchdog.ts";
 import { resolveConfigEnvForProcess } from "./operations/vault-bridge.ts";
+import { OPTIONAL_PLUGIN_IMPORTERS } from "./optional-plugin-imports.generated.ts";
 import {
+  isWorkspacePluginSourceFallbackAllowed,
   type PluginResolutionPhase,
   resolvePlugins,
 } from "./plugin-resolver.ts";
@@ -256,7 +258,11 @@ async function loadRequiredPluginSql(): Promise<
       path.dirname(fileURLToPath(import.meta.url)),
       "../../../../plugins/plugin-sql/src/index.node.ts",
     );
-    if (!isPluginSqlResolutionError(err) || !existsSync(sourceEntry)) {
+    if (
+      !isWorkspacePluginSourceFallbackAllowed() ||
+      !isPluginSqlResolutionError(err) ||
+      !existsSync(sourceEntry)
+    ) {
       throw err;
     }
     logger.debug(
@@ -282,73 +288,30 @@ function resolveWorkspacePluginSourceEntry(packageName: string): string | null {
   return null;
 }
 
-// Agent orchestrator ships as the standalone @elizaos/plugin-agent-orchestrator package.
+// Literal-specifier importers so Bun.build inlines each optional plugin into
+// the mobile bundle live in optional-plugin-imports.generated.ts, code-generated
+// from OPTIONAL_STATIC_PLUGIN_PACKAGES (optional-plugins.ts). Adding a plugin to
+// the descriptor table is enough; optional-plugins.test.ts fails if it lacks a
+// generated importer. Plugins not in the map (e.g. desktop-only gitpathologist)
+// load through a bare dynamic import from a node_modules/desktop install.
 const loadOptionalPlugin = async (packageName: string): Promise<unknown> => {
   try {
-    if (packageName === "@elizaos/plugin-agent-orchestrator") {
-      return await import(
-        /* @vite-ignore */ "@elizaos/plugin-agent-orchestrator"
-      );
-    }
-    if (packageName === "@elizaos/plugin-task-coordinator") {
-      return await import(
-        /* @vite-ignore */ "@elizaos/plugin-task-coordinator"
-      );
-    }
-    if (packageName === "@elizaos/plugin-app-control") {
-      const appControlPackageName = packageName;
-      return await import(/* @vite-ignore */ appControlPackageName);
-    }
-    if (packageName === "@elizaos/plugin-shell") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-shell");
-    }
-    if (packageName === "@elizaos/plugin-coding-tools") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-coding-tools");
-    }
-    if (packageName === "@elizaos/plugin-pty") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-pty");
-    }
-    if (packageName === "@elizaos/plugin-birdclaw") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-birdclaw");
-    }
-    if (packageName === "@elizaos/plugin-ollama") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-ollama");
-    }
-    if (packageName === "@elizaos/plugin-elizacloud") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-elizacloud");
-    }
-    if (packageName === "@elizaos/plugin-commands") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-commands");
-    }
-    if (packageName === "@elizaos/plugin-video") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-video");
-    }
-    if (packageName === "@elizaos/plugin-vision") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-vision");
-    }
-    if (packageName === "@elizaos/plugin-background-runner") {
-      return await import(
-        /* @vite-ignore */ "@elizaos/plugin-background-runner"
-      );
-    }
-    if (packageName === "@elizaos/plugin-anthropic") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-anthropic");
-    }
-    if (packageName === "@elizaos/plugin-openai") {
-      return await import(/* @vite-ignore */ "@elizaos/plugin-openai");
-    }
+    const importer = OPTIONAL_PLUGIN_IMPORTERS[packageName];
+    if (importer) return await importer();
     return await import(packageName);
   } catch {
-    const sourceEntry = resolveWorkspacePluginSourceEntry(packageName);
-    if (sourceEntry) {
-      try {
-        logger.debug(
-          `[eliza] Loading ${packageName} from workspace source at ${sourceEntry}`,
-        );
-        return await import(pathToFileURL(sourceEntry).href);
-      } catch {
-        // Fall through to the existing optional-plugin behavior: missing or
-        // unbuildable optional plugins are omitted from STATIC_ELIZA_PLUGINS.
+    if (isWorkspacePluginSourceFallbackAllowed()) {
+      const sourceEntry = resolveWorkspacePluginSourceEntry(packageName);
+      if (sourceEntry) {
+        try {
+          logger.debug(
+            `[eliza] Loading ${packageName} from workspace source at ${sourceEntry}`,
+          );
+          return await import(pathToFileURL(sourceEntry).href);
+        } catch {
+          // Missing or unbuildable optional plugins are omitted from
+          // STATIC_ELIZA_PLUGINS.
+        }
       }
     }
     return null;

--- a/packages/agent/src/runtime/optional-plugin-imports.generated.ts
+++ b/packages/agent/src/runtime/optional-plugin-imports.generated.ts
@@ -1,0 +1,28 @@
+// GENERATED FILE — DO NOT EDIT BY HAND.
+// Source of truth: ./optional-plugins.ts (OPTIONAL_STATIC_PLUGIN_PACKAGES).
+// Regenerate: bun run --cwd packages/agent gen:optional-plugin-imports
+//
+// Literal `import()` specifiers so Bun.build inlines each optional plugin into
+// the mobile bundle. The runtime looks each up by name in loadOptionalPlugin().
+
+export const OPTIONAL_PLUGIN_IMPORTERS: Record<string, () => Promise<unknown>> =
+  {
+    "@elizaos/plugin-agent-orchestrator": () =>
+      import("@elizaos/plugin-agent-orchestrator"),
+    "@elizaos/plugin-task-coordinator": () =>
+      import("@elizaos/plugin-task-coordinator"),
+    "@elizaos/plugin-shell": () => import("@elizaos/plugin-shell"),
+    "@elizaos/plugin-coding-tools": () =>
+      import("@elizaos/plugin-coding-tools"),
+    "@elizaos/plugin-pty": () => import("@elizaos/plugin-pty"),
+    "@elizaos/plugin-birdclaw": () => import("@elizaos/plugin-birdclaw"),
+    "@elizaos/plugin-ollama": () => import("@elizaos/plugin-ollama"),
+    "@elizaos/plugin-elizacloud": () => import("@elizaos/plugin-elizacloud"),
+    "@elizaos/plugin-commands": () => import("@elizaos/plugin-commands"),
+    "@elizaos/plugin-video": () => import("@elizaos/plugin-video"),
+    "@elizaos/plugin-vision": () => import("@elizaos/plugin-vision"),
+    "@elizaos/plugin-background-runner": () =>
+      import("@elizaos/plugin-background-runner"),
+    "@elizaos/plugin-anthropic": () => import("@elizaos/plugin-anthropic"),
+    "@elizaos/plugin-openai": () => import("@elizaos/plugin-openai"),
+  };

--- a/packages/agent/src/runtime/optional-plugins.test.ts
+++ b/packages/agent/src/runtime/optional-plugins.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  OPTIONAL_STATIC_PLUGIN_PACKAGES,
+  renderOptionalPluginImportsModule,
+  UNBUNDLED_OPTIONAL_PLUGINS,
+} from "./optional-plugins.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function readSource(file: string): string {
+  return readFileSync(path.join(here, file), "utf8");
+}
+
+/**
+ * Parse the generated importer map as TEXT. Importing the module would make
+ * Vite/vitest eagerly resolve every literal `import()` specifier (several
+ * optional plugins are intentionally unbuilt in this workspace), so the drift
+ * check reads the source and asserts on the literal `"pkg": () => import("pkg")`
+ * entries instead.
+ */
+function generatedImporterEntries(): { key: string; specifier: string }[] {
+  const source = readSource("optional-plugin-imports.generated.ts");
+  return [
+    ...source.matchAll(/"([^"]+)":\s*\(\)\s*=>\s*import\(\s*"([^"]+)"\s*\)/g),
+  ].map((m) => ({ key: m[1], specifier: m[2] }));
+}
+
+/**
+ * Optional plugin packages the descriptor table (CORE_STATIC_PLUGIN_REGISTRATIONS
+ * in eliza.ts) loads via getOptionalPlugin(...). Scanned from source so the
+ * check needs no heavy import of eliza.ts.
+ */
+function descriptorTableOptionalPackages(): string[] {
+  const source = readSource("eliza.ts");
+  const matches = source.matchAll(/getOptionalPlugin\(\s*"([^"]+)"\s*\)/g);
+  return [...new Set([...matches].map((m) => m[1]))];
+}
+
+describe("optional-plugin literal-import codegen", () => {
+  it("generated importer keys match the source of truth exactly", () => {
+    // Fails if optional-plugin-imports.generated.ts is stale — regenerate with
+    // `bun run --cwd packages/agent gen:optional-plugin-imports`.
+    const keys = generatedImporterEntries().map((e) => e.key);
+    expect(keys).toEqual([...OPTIONAL_STATIC_PLUGIN_PACKAGES]);
+  });
+
+  it("every generated entry is a literal-specifier import (key === specifier)", () => {
+    // The whole point: the bundler must see a string literal, never a variable.
+    for (const { key, specifier } of generatedImporterEntries()) {
+      expect(specifier, key).toBe(key);
+    }
+  });
+
+  it("renderer emits a literal import() for every source package", () => {
+    const rendered = renderOptionalPluginImportsModule(
+      OPTIONAL_STATIC_PLUGIN_PACKAGES,
+    );
+    for (const pkg of OPTIONAL_STATIC_PLUGIN_PACKAGES) {
+      expect(rendered, pkg).toContain(`"${pkg}": () => import("${pkg}")`);
+    }
+  });
+
+  it("bundled and unbundled optional lists are disjoint", () => {
+    const bundled = new Set(OPTIONAL_STATIC_PLUGIN_PACKAGES);
+    for (const pkg of UNBUNDLED_OPTIONAL_PLUGINS) {
+      expect(bundled.has(pkg), pkg).toBe(false);
+    }
+  });
+});
+
+describe("descriptor table ↔ generated imports consistency", () => {
+  const declared = descriptorTableOptionalPackages();
+  const resolvable = new Set<string>([
+    ...OPTIONAL_STATIC_PLUGIN_PACKAGES,
+    ...UNBUNDLED_OPTIONAL_PLUGINS,
+  ]);
+
+  it("finds the descriptor table's getOptionalPlugin entries", () => {
+    // Guard against the scan silently matching nothing (e.g. a refactor renamed
+    // getOptionalPlugin) which would make the check below vacuously pass.
+    expect(declared.length).toBeGreaterThan(0);
+  });
+
+  it("every descriptor-table optional plugin has a literal importer or is explicitly unbundled", () => {
+    // Adding getOptionalPlugin("@elizaos/plugin-new") to the descriptor table
+    // must be paired with an entry in OPTIONAL_STATIC_PLUGIN_PACKAGES (then
+    // regenerate) or UNBUNDLED_OPTIONAL_PLUGINS — no hand-written import branch,
+    // and no plugin silently non-bundleable.
+    for (const pkg of declared) {
+      expect(resolvable.has(pkg), `${pkg} has no importer nor exemption`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("every bundled literal importer is referenced by the descriptor table", () => {
+    // No orphan literal import bloating the mobile bundle for a plugin the
+    // runtime never loads.
+    const declaredSet = new Set(declared);
+    for (const pkg of OPTIONAL_STATIC_PLUGIN_PACKAGES) {
+      expect(declaredSet.has(pkg), `${pkg} is bundled but unused`).toBe(true);
+    }
+  });
+});

--- a/packages/agent/src/runtime/optional-plugins.ts
+++ b/packages/agent/src/runtime/optional-plugins.ts
@@ -1,0 +1,86 @@
+/**
+ * Source of truth for the optional plugins that must be baked into the mobile
+ * bundle via **literal** `import()` calls.
+ *
+ * `Bun.build` can only inline a dynamic import whose specifier is a string
+ * literal. The runtime resolves optional plugins by name (a variable), so a
+ * hand-written `if (name === X) import(X)` chain used to exist purely to hand
+ * the bundler those literals. That chain silently drifted from the descriptor
+ * table in `eliza.ts`: a plugin added to the table without a matching branch
+ * became non-bundleable with no error.
+ *
+ * Instead, this module owns the list, `optional-plugin-imports.generated.ts` is
+ * code-generated from it (literal imports the bundler sees), and
+ * `optional-plugins.test.ts` fails if the generated file drifts or if a
+ * descriptor-table entry has no importer. Regenerate with:
+ *
+ *   bun run --cwd packages/agent gen:optional-plugin-imports
+ *
+ * @module optional-plugins
+ */
+
+/**
+ * Optional plugin packages baked into the bundle via literal imports. Order is
+ * preserved into the generated file for a stable diff. Adding an entry here (and
+ * regenerating) is the ONLY step needed to make a new optional plugin
+ * bundleable — never hand-write an import branch.
+ */
+export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
+  "@elizaos/plugin-agent-orchestrator",
+  "@elizaos/plugin-task-coordinator",
+  "@elizaos/plugin-shell",
+  "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-pty",
+  "@elizaos/plugin-birdclaw",
+  "@elizaos/plugin-ollama",
+  "@elizaos/plugin-elizacloud",
+  "@elizaos/plugin-commands",
+  "@elizaos/plugin-video",
+  "@elizaos/plugin-vision",
+  "@elizaos/plugin-background-runner",
+  "@elizaos/plugin-anthropic",
+  "@elizaos/plugin-openai",
+];
+
+/**
+ * Optional plugins the runtime can load by name but that are intentionally NOT
+ * baked into the mobile bundle as literal imports — they load through a bare
+ * dynamic `import(packageName)` from a node_modules/desktop install instead.
+ *
+ * `@elizaos/plugin-gitpathologist` is a desktop-only git-forensics dev tool
+ * (skipped up front on android/ios in the descriptor table); baking it into the
+ * mobile bundle would pull its dependency tree in for a surface phones never use.
+ */
+export const UNBUNDLED_OPTIONAL_PLUGINS: readonly string[] = [
+  "@elizaos/plugin-gitpathologist",
+];
+
+const RELATIVE_GENERATED_PATH = "./optional-plugin-imports.generated.ts";
+
+/**
+ * Render the generated importer module from a package list. Pure so the codegen
+ * script and the drift test share one definition.
+ */
+export function renderOptionalPluginImportsModule(
+  packages: readonly string[],
+): string {
+  const entries = packages
+    .map((pkg) => `  "${pkg}": () => import("${pkg}"),`)
+    .join("\n");
+  return `// GENERATED FILE — DO NOT EDIT BY HAND.
+// Source of truth: ./optional-plugins.ts (OPTIONAL_STATIC_PLUGIN_PACKAGES).
+// Regenerate: bun run --cwd packages/agent gen:optional-plugin-imports
+//
+// Literal \`import()\` specifiers so Bun.build inlines each optional plugin into
+// the mobile bundle. The runtime looks each up by name in loadOptionalPlugin().
+
+export const OPTIONAL_PLUGIN_IMPORTERS: Record<
+  string,
+  () => Promise<unknown>
+> = {
+${entries}
+};
+`;
+}
+
+export { RELATIVE_GENERATED_PATH };

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -539,6 +539,27 @@ function resolveWorkspaceRoots(): string[] {
   return uniquePaths([process.cwd()]);
 }
 
+/**
+ * Whether the runtime may fall back to importing a plugin's unbuilt workspace
+ * `src/` tree (bypassing package `exports`/`dist`) when normal resolution fails.
+ *
+ * Dev-only escape hatch: a production build must resolve plugins through the
+ * bundle or node_modules, never a sibling `src/` tree. Honors the existing
+ * `ELIZA_DISABLE_WORKSPACE_PLUGIN_OVERRIDES` kill switch, refuses in a
+ * production runtime (mirrors crash-injection's production signal), and allows
+ * an explicit `ELIZA_ALLOW_WORKSPACE_PLUGIN_SRC=1` override for production
+ * debugging.
+ */
+export function isWorkspacePluginSourceFallbackAllowed(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.ELIZA_DISABLE_WORKSPACE_PLUGIN_OVERRIDES === "1") return false;
+  const isProduction =
+    env.NODE_ENV === "production" || env.ELIZA_BUILD_VARIANT === "production";
+  if (isProduction) return env.ELIZA_ALLOW_WORKSPACE_PLUGIN_SRC === "1";
+  return true;
+}
+
 function getWorkspacePluginOverridePath(pluginName: string): string | null {
   if (process.env.ELIZA_DISABLE_WORKSPACE_PLUGIN_OVERRIDES === "1") {
     return null;


### PR DESCRIPTION
## What & why

`packages/agent/src/runtime/eliza.ts` `loadOptionalPlugin` hand-maintained a 15-branch literal-import `if`-chain (required so `Bun.build` inlines each optional plugin into the mobile bundle) that duplicated the optional-plugin descriptor table (`CORE_STATIC_PLUGIN_REGISTRATIONS`) in the same file. A missing branch silently made a plugin non-bundleable — `@elizaos/plugin-gitpathologist` was exactly that: it fell through to a bare `import(packageName)` the bundler can't inline. On failure the fallback also deep-imported sibling packages' unbuilt `src/index.ts`, bypassing build/`exports`/conditions, in every runtime including production.

## Change

- **`optional-plugins.ts`** — single source of truth: `OPTIONAL_STATIC_PLUGIN_PACKAGES` (bundled) + `UNBUNDLED_OPTIONAL_PLUGINS` (intentionally desktop-only, bare dynamic import) + a pure renderer.
- **`optional-plugin-imports.generated.ts`** — code-generated literal `import()` specifiers the bundler sees, produced by **`scripts/gen-optional-plugin-imports.ts`** (`bun run --cwd packages/agent gen:optional-plugin-imports`).
- **`loadOptionalPlugin`** now looks up the generated importer map — no hand-written branch to add a plugin.
- Workspace-`src` fallback (both `loadOptionalPlugin` and `loadRequiredPluginSql`) gated behind **`plugin-resolver.isWorkspacePluginSourceFallbackAllowed()`**, which refuses in a production runtime (`NODE_ENV`/`ELIZA_BUILD_VARIANT === "production"`, honoring the existing `ELIZA_DISABLE_WORKSPACE_PLUGIN_OVERRIDES` kill switch and an `ELIZA_ALLOW_WORKSPACE_PLUGIN_SRC=1` escape hatch).

## Done-when evidence (item 16)

- **Adding a plugin to the descriptor table requires no hand-written import branch, verified by a check comparing table to generated imports** — `optional-plugins.test.ts` scans the descriptor table's `getOptionalPlugin("…")` entries and fails if any lacks a generated importer or an explicit unbundled exemption. Proven by injecting a probe entry:
  ```
  AssertionError: @elizaos/plugin-PROBE has no importer nor exemption: expected false to be true
   Test Files  1 failed (1) | Tests  1 failed | 6 passed
  ```
  Reverted → `Tests  7 passed (7)`. It also fails if the generated file drifts from the source list (regenerate to fix).
- **Production builds never import sibling `src/` trees** — the raw-`src` fallback is now unreachable when `NODE_ENV`/`ELIZA_BUILD_VARIANT === "production"` (short-circuits before `resolveWorkspacePluginSourceEntry`). Grep: the only raw `src/index*.ts` deep-imports (`loadOptionalPlugin`, `loadRequiredPluginSql`) are both guarded by `isWorkspacePluginSourceFallbackAllowed()`.

## No behavior change

The 14 previously-literal-bundled plugins keep byte-identical `import()` specifiers. `gitpathologist` keeps its bare dynamic import (`UNBUNDLED_OPTIONAL_PLUGINS`). The removed `app-control` branch used a **variable** specifier (never bundleable) and had **no caller** (`getOptionalPlugin` is never invoked for it) — dropping it changes nothing.

`plugin-resolver.ts:1869`'s workspace-override path already resolves through `package.json` `exports`/staging (not a raw `src` tree), so the shared dev-gate lives in that module and the raw-`src` defect is fixed at its source in `eliza.ts`.

## Verification

- `bunx vitest run src/runtime/optional-plugins.test.ts` → 7 passed; `core-plugins` + `plugin-resolver` + `plugin-resolver-failed-plugins` neighbors → green.
- Typecheck of touched files clean (`tsgo -p tsconfig.json`); remaining `TS2307`s are unbuilt-plugin resolution in this local checkout (e.g. `plugin-meetings` in an untouched discord file), identical to the pre-existing class and resolved in CI where all plugins are built.
- Biome clean on all touched files; codegen is idempotent (re-run → no diff).

> A full mobile `Bun.build` is heavy and not run here; inclusion is preserved because the generated file emits the same literal `import()` specifiers the old if-chain did (asserted by the key-===-specifier test), and no consumed side effect was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)