### PR TITLE
refactor(plugin-local-inference): replace registerModel monkey-patch with getModelRegistrations() + MODEL_REGISTERED (#12091 item 7)

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -1463,10 +1463,10 @@ export async function ensureLocalInferenceHandler(
 		return;
 	}
 
-	// Install the side-registry interception as early as possible so it
-	// captures every subsequent `registerModel` call — including our own
-	// handlers below, plus anything else that registers during the rest of
-	// boot. Idempotent per-runtime.
+	// Mirror the runtime's model registry into the side-registry: it seeds
+	// from the current registrations and stays live via the `MODEL_REGISTERED`
+	// event — capturing our own handlers below plus anything else that
+	// registers during the rest of boot. Idempotent per-runtime.
 	handlerRegistry.installOn(runtime);
 
 	// Loader precedence:

--- a/plugins/plugin-local-inference/src/services/handler-registry.test.ts
+++ b/plugins/plugin-local-inference/src/services/handler-registry.test.ts
@@ -1,0 +1,144 @@
+import type {
+	IAgentRuntime,
+	ModelRegisteredEventPayload,
+	ModelRegistrationInfo,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handlerRegistry } from "./handler-registry";
+
+/**
+ * Minimal runtime double exposing only the public core surface the registry
+ * now depends on: `getModelRegistrations()` for the seed snapshot and
+ * `registerEvent` to receive `MODEL_REGISTERED`. Crucially it does NOT expose
+ * `registerModel` — proving the registry populates via the event/query API and
+ * never patches or wraps a `registerModel` method (the old prototype
+ * monkey-patch is gone).
+ */
+function makeFakeRuntime(seed: ModelRegistrationInfo[]) {
+	const eventHandlers = new Map<
+		string,
+		(payload: ModelRegisteredEventPayload) => Promise<void>
+	>();
+	const registerEvent = vi.fn(
+		(
+			event: string,
+			handler: (p: ModelRegisteredEventPayload) => Promise<void>,
+		) => {
+			eventHandlers.set(event, handler);
+		},
+	);
+	const runtime = {
+		getModelRegistrations: () => seed,
+		registerEvent,
+	} as unknown as IAgentRuntime;
+	return {
+		runtime,
+		registerEvent,
+		async fire(payload: ModelRegisteredEventPayload) {
+			const handler = eventHandlers.get("MODEL_REGISTERED");
+			if (!handler) throw new Error("MODEL_REGISTERED handler not registered");
+			await handler(payload);
+		},
+	};
+}
+
+function payload(
+	over: Partial<ModelRegisteredEventPayload>,
+): ModelRegisteredEventPayload {
+	return {
+		modelType: "TEXT_LARGE",
+		provider: "provider-x",
+		priority: 0,
+		runtime: {} as IAgentRuntime,
+		...over,
+	};
+}
+
+describe("local-inference handler-registry mirrors via the core API, not a patch", () => {
+	it("subscribes to MODEL_REGISTERED and never touches registerModel", () => {
+		const { runtime, registerEvent } = makeFakeRuntime([]);
+
+		handlerRegistry.installOn(runtime);
+
+		expect(registerEvent).toHaveBeenCalledTimes(1);
+		expect(registerEvent).toHaveBeenCalledWith(
+			"MODEL_REGISTERED",
+			expect.any(Function),
+		);
+		// The runtime double has no registerModel — installOn must not require
+		// or wrap one (the old monkey-patch path would have patched it).
+		expect(
+			(runtime as unknown as { registerModel?: unknown }).registerModel,
+		).toBeUndefined();
+	});
+
+	it("seeds from getModelRegistrations() on install", () => {
+		const { runtime } = makeFakeRuntime([
+			{
+				modelType: "SEED_ONLY_TYPE",
+				provider: "seed-provider",
+				priority: 42,
+				registrationOrder: 1,
+			},
+		]);
+
+		handlerRegistry.installOn(runtime);
+
+		const rows = handlerRegistry.getForType("SEED_ONLY_TYPE");
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			modelType: "SEED_ONLY_TYPE",
+			provider: "seed-provider",
+			priority: 42,
+		});
+	});
+
+	it("records subsequent registrations from the MODEL_REGISTERED event, metadata only", async () => {
+		const { runtime, fire } = makeFakeRuntime([]);
+		handlerRegistry.installOn(runtime);
+
+		await fire(
+			payload({
+				modelType: "EVENT_DRIVEN_TYPE",
+				provider: "high",
+				priority: 100,
+			}),
+		);
+		await fire(
+			payload({ modelType: "EVENT_DRIVEN_TYPE", provider: "low", priority: 1 }),
+		);
+
+		const rows = handlerRegistry.getForType("EVENT_DRIVEN_TYPE");
+		expect(rows.map((r) => r.provider)).toEqual(["high", "low"]);
+		// Metadata only — no captured handler function leaks into the registry.
+		expect(rows[0]).not.toHaveProperty("handler");
+	});
+
+	it("getForTypeExcluding drops the named provider", async () => {
+		const { runtime, fire } = makeFakeRuntime([]);
+		handlerRegistry.installOn(runtime);
+		await fire(
+			payload({
+				modelType: "EXCL_TYPE",
+				provider: "eliza-router",
+				priority: 9,
+			}),
+		);
+		await fire(
+			payload({ modelType: "EXCL_TYPE", provider: "openai", priority: 5 }),
+		);
+
+		expect(
+			handlerRegistry
+				.getForTypeExcluding("EXCL_TYPE", "eliza-router")
+				.map((r) => r.provider),
+		).toEqual(["openai"]);
+	});
+
+	it("is idempotent per runtime instance (no double subscription)", () => {
+		const { runtime, registerEvent } = makeFakeRuntime([]);
+		handlerRegistry.installOn(runtime);
+		handlerRegistry.installOn(runtime);
+		expect(registerEvent).toHaveBeenCalledTimes(1);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/handler-registry.ts
+++ b/plugins/plugin-local-inference/src/services/handler-registry.ts
@@ -1,34 +1,28 @@
 /**
- * Side-registry of model handlers registered on an AgentRuntime.
+ * Side-registry that mirrors the model handlers registered on an AgentRuntime.
  *
- * The elizaOS core exposes `runtime.registerModel(type, handler, provider,
- * priority)` but no way to list who registered what. This module intercepts
- * `registerModel` at runtime to record every registration in a Map keyed by
- * model type, plus fires status listeners so the UI can render a live
- * [ModelType × Provider] routing table.
+ * elizaOS core owns the model registry; this module keeps a handler-free mirror
+ * of it so the settings API/UI can render a live [ModelType × Provider] routing
+ * table and so `providers.ts` can report which slots a provider serves. It
+ * stays in sync through the public core API — {@link IAgentRuntime.getModelRegistrations}
+ * for the initial snapshot and the `MODEL_REGISTERED` runtime event for
+ * subsequent registrations — instead of monkey-patching the runtime's
+ * `registerModel` method on `AgentRuntime.prototype`.
  *
- * Because we monkey-patch `registerModel` we also keep the original
- * handler reference — the router-handler (see `router-handler.ts`) uses
- * this to dispatch inference calls by policy without going through
- * `runtime.useModel` (which would loop back to us and recurse).
+ * The mirror holds registration metadata only (never handler functions).
+ * Actual dispatch/failover is core's job; the router-handler picks a provider
+ * from this metadata and invokes it through live runtime introspection, so this
+ * module never captures or calls a handler.
  */
 
-import { AgentRuntime, type IAgentRuntime } from "@elizaos/core";
+import type { ModelRegisteredEventPayload } from "@elizaos/core";
+import { EventType, type IAgentRuntime } from "@elizaos/core";
 
 export interface HandlerRegistration {
 	modelType: string;
 	provider: string;
 	priority: number;
 	registeredAt: string;
-	/**
-	 * The original handler function. Captured so the router-handler can
-	 * dispatch to it directly, bypassing `runtime.useModel` which would
-	 * re-enter the router itself.
-	 */
-	handler: (
-		runtime: IAgentRuntime,
-		params: Record<string, unknown>,
-	) => Promise<unknown>;
 }
 
 type Listener = (registrations: HandlerRegistration[]) => void;
@@ -36,7 +30,7 @@ type Listener = (registrations: HandlerRegistration[]) => void;
 class HandlerRegistry {
 	private readonly registrations = new Map<string, HandlerRegistration[]>();
 	private readonly listeners = new Set<Listener>();
-	private installedOn: WeakSet<object> = new WeakSet();
+	private readonly installedOn = new WeakSet<object>();
 
 	/**
 	 * Snapshot of all registrations grouped by model type, sorted by
@@ -58,8 +52,8 @@ class HandlerRegistry {
 	}
 
 	/**
-	 * Registrations excluding a specific provider. Used by the router-handler
-	 * to find "all providers except me" when dispatching.
+	 * Registrations excluding a specific provider. Used by the router-handler's
+	 * diagnostics to describe "all providers except me".
 	 */
 	getForTypeExcluding(
 		modelType: string,
@@ -101,125 +95,43 @@ class HandlerRegistry {
 	}
 
 	/**
-	 * Install the interception on a runtime. Idempotent per runtime instance.
-	 * For most boot paths the prototype-level patch below already covers the
-	 * runtime before any plugin registers; this method is the belt-and-braces
-	 * fallback for runtimes constructed before the patch ran.
+	 * Mirror a runtime's model registry into this side-registry. Idempotent
+	 * per runtime instance. Seeds from the current registrations, then stays
+	 * live via the `MODEL_REGISTERED` event — no prototype patching, no
+	 * handler capture.
 	 */
-	installOn(runtime: AgentRuntime): void {
-		installPrototypePatch();
-		const rt = runtime as AgentRuntime & {
-			registerModel?: unknown;
-		};
-		if (typeof rt.registerModel !== "function") return;
-		if (this.installedOn.has(rt)) return;
-		this.installedOn.add(rt);
+	installOn(runtime: IAgentRuntime): void {
+		if (this.installedOn.has(runtime)) return;
+		this.installedOn.add(runtime);
 
-		// If the runtime already inherited the patched prototype method the
-		// prototype handles every call. Nothing to do per-instance.
-		const protoMethod = Object.getPrototypeOf(rt)?.registerModel as
-			| PatchMarkedRegisterModel
-			| undefined;
-		if (protoMethod?.[PATCH_MARK]) {
-			return;
-		}
-
-		// Per-instance wrap only for legacy runtimes whose prototype pre-dates
-		// our prototype patch (shouldn't happen in practice).
-		const original = rt.registerModel.bind(runtime) as (
-			modelType: string,
-			handler: HandlerRegistration["handler"],
-			provider: string,
-			priority?: number,
-		) => void;
-		rt.registerModel = ((
-			modelType: string,
-			handler: HandlerRegistration["handler"],
-			provider: string,
-			priority?: number,
-		) => {
+		const now = new Date().toISOString();
+		for (const reg of runtime.getModelRegistrations()) {
 			this.record({
-				modelType: String(modelType),
-				provider: String(provider),
-				priority: typeof priority === "number" ? priority : 0,
-				registeredAt: new Date().toISOString(),
-				handler,
+				modelType: reg.modelType,
+				provider: reg.provider,
+				priority: reg.priority,
+				registeredAt: now,
 			});
-			return original(modelType, handler, provider, priority);
-		}) as typeof rt.registerModel;
-	}
-
-	/** Exposed so the prototype patch can record through the singleton. */
-	recordFromPrototype(reg: HandlerRegistration): void {
-		this.record(reg);
-	}
-}
-
-const PATCH_MARK = Symbol.for("eliza.local-inference.registerModel.patched");
-let prototypePatched = false;
-
-type RegisterModelMethod = (
-	this: AgentRuntime,
-	modelType: string,
-	handler: HandlerRegistration["handler"],
-	provider: string,
-	priority?: number,
-) => void;
-
-type PatchMarkedRegisterModel = RegisterModelMethod & {
-	[PATCH_MARK]?: true;
-};
-
-/**
- * One-shot patch of `AgentRuntime.prototype.registerModel` so every runtime
- * instance — including ones constructed later in boot — records through
- * the singleton handler registry. Idempotent.
- */
-function installPrototypePatch(): void {
-	if (prototypePatched) return;
-	const proto = AgentRuntime.prototype as AgentRuntime & {
-		registerModel: RegisterModelMethod;
-	};
-	const original = proto.registerModel;
-	if (typeof original !== "function") return;
-	if ((original as PatchMarkedRegisterModel)[PATCH_MARK]) {
-		prototypePatched = true;
-		return;
-	}
-	const patched = function patchedRegisterModel(
-		this: AgentRuntime,
-		modelType: string,
-		handler: HandlerRegistration["handler"],
-		provider: string,
-		priority?: number,
-	): void {
-		try {
-			handlerRegistry.recordFromPrototype({
-				modelType: String(modelType),
-				provider: String(provider),
-				priority: typeof priority === "number" ? priority : 0,
-				registeredAt: new Date().toISOString(),
-				handler,
-			});
-		} catch {
-			// Never let registry bookkeeping break the registration path.
 		}
-		original.call(this, modelType, handler, provider, priority);
-	} as typeof original & { [PATCH_MARK]?: true };
-	patched[PATCH_MARK] = true;
-	proto.registerModel = patched;
-	prototypePatched = true;
-}
 
-// Install at module-import time. This is a process-wide side effect but a
-// benign one: the patch is idempotent and forwards to the original.
-installPrototypePatch();
+		runtime.registerEvent(
+			EventType.MODEL_REGISTERED,
+			async (payload: ModelRegisteredEventPayload) => {
+				this.record({
+					modelType: payload.modelType,
+					provider: payload.provider,
+					priority: payload.priority,
+					registeredAt: new Date().toISOString(),
+				});
+			},
+		);
+	}
+}
 
 export const handlerRegistry = new HandlerRegistry();
 
 /**
- * Public type used by the API/UI — omits the handler function for
- * serialisation and to prevent UI code from accidentally calling it.
+ * Public type used by the API/UI — the serialisable registration shape.
  */
 export interface PublicRegistration {
 	modelType: string;

--- a/plugins/plugin-local-inference/src/services/router-dispatch.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-dispatch.test.ts
@@ -1,0 +1,91 @@
+import {
+	type AgentRuntime,
+	type IAgentRuntime,
+	ModelType,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Force a deterministic manual policy pinned to our fake cloud provider so the
+// router picks it without consulting device tier / live signals / assignments.
+const prefsState = {
+	policy: { TEXT_LARGE: "manual" } as Record<string, string>,
+	preferredProvider: { TEXT_LARGE: "test-cloud" } as Record<string, string>,
+};
+
+vi.mock("./routing-preferences", () => ({
+	DEFAULT_ROUTING_POLICY: "prefer-local",
+	readRoutingPreferences: vi.fn(async () => prefsState),
+}));
+
+import { installRouterHandler, ROUTER_PROVIDER } from "./router-handler";
+
+type Handler = (
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+) => Promise<unknown>;
+
+/**
+ * Capture the router handler `installRouterHandler` registers for TEXT_LARGE,
+ * then build a runtime whose live `models` map carries a provider handler for
+ * the router to introspect and dispatch to — the path that used to depend on
+ * the `registerModel` prototype monkey-patch.
+ */
+function setup(providerHandler: Handler) {
+	const routerHandlers = new Map<string, Handler>();
+	const installTarget = {
+		registerModel: vi.fn(
+			(modelType: string, handler: Handler, provider: string) => {
+				if (provider === ROUTER_PROVIDER)
+					routerHandlers.set(modelType, handler);
+			},
+		),
+	} as unknown as AgentRuntime;
+	installRouterHandler(installTarget, {
+		skipSlots: [
+			"TEXT_SMALL",
+			"TEXT_EMBEDDING",
+			"TEXT_TO_SPEECH",
+			"TRANSCRIPTION",
+		],
+	});
+
+	const runtime = {
+		models: new Map<string, unknown[]>([
+			[
+				ModelType.TEXT_LARGE,
+				[{ provider: "test-cloud", priority: 0, handler: providerHandler }],
+			],
+		]),
+	} as unknown as IAgentRuntime;
+
+	const router = routerHandlers.get(ModelType.TEXT_LARGE);
+	if (!router) throw new Error("router handler for TEXT_LARGE not installed");
+	return { router, runtime };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("router dispatches via runtime introspection, not a prototype patch", () => {
+	it("invokes the registered provider handler resolved from runtime.models", async () => {
+		const providerHandler = vi.fn(async () => "cloud-result");
+		const { router, runtime } = setup(providerHandler);
+
+		const result = await router(runtime, { prompt: "hi" });
+
+		expect(result).toBe("cloud-result");
+		expect(providerHandler).toHaveBeenCalledTimes(1);
+		expect(providerHandler).toHaveBeenCalledWith(runtime, { prompt: "hi" });
+	});
+
+	it("surfaces the provider error in manual mode (no silent fallback)", async () => {
+		const boom = new Error("cloud down");
+		const providerHandler = vi.fn(async () => {
+			throw boom;
+		});
+		const { router, runtime } = setup(providerHandler);
+
+		await expect(router(runtime, { prompt: "hi" })).rejects.toBe(boom);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/router-handler.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.ts
@@ -7,9 +7,9 @@
  *
  *   1. Read the user's per-slot policy + preferred-provider choice from
  *      `routing-preferences.ts`.
- *   2. Ask the `policyEngine` to pick a provider from the handler
- *      registry's current set (excluding ourselves).
- *   3. Invoke that provider's original handler directly — bypassing
+ *   2. Ask the `policyEngine` to pick a provider from the runtime's live
+ *      model registry (excluding ourselves).
+ *   3. Invoke that provider's registered handler directly — bypassing
  *      `runtime.useModel` which would recurse into us.
  *   4. Record the observed latency so later "fastest" picks have data.
  *   5. On handler failure: retry the next eligible provider in priority
@@ -70,7 +70,6 @@ import {
 import { readEffectiveAssignments } from "./assignments";
 import { classifyDeviceTier, type DeviceTierAssessment } from "./device-tier";
 import { localInferenceEngine } from "./engine";
-import type { HandlerRegistration } from "./handler-registry";
 import { handlerRegistry } from "./handler-registry";
 import { probeHardware } from "./hardware";
 import { type LiveDeviceSignals, readLiveDeviceSignals } from "./live-signals";
@@ -132,6 +131,20 @@ type AnyHandler = (
 	params: Record<string, unknown>,
 ) => Promise<unknown>;
 
+/**
+ * A dispatchable candidate: registration metadata plus the live handler read
+ * from the runtime's model registry at dispatch time. The router selects a
+ * provider by policy and invokes its handler directly — bypassing
+ * `runtime.useModel`, which would re-enter the router and double-apply
+ * per-call processing (model-settings merge, streaming setup, PII swap).
+ */
+interface RoutableCandidate {
+	modelType: string;
+	provider: string;
+	priority: number;
+	handler: AnyHandler;
+}
+
 function slotToModelType(slot: AgentModelSlot): string | undefined {
 	switch (slot) {
 		case "TEXT_SMALL":
@@ -165,10 +178,17 @@ function shouldForceLocalInference(
 	return policy === "manual" && preferredProvider === "eliza-local-inference";
 }
 
+/**
+ * Read the live model registry off the runtime and return the dispatchable
+ * candidates (with handlers) for a model type, excluding the router itself.
+ * This is the router's dispatch source: `getModelRegistrations()` exposes the
+ * registry as handler-free metadata, but the router must invoke the picked
+ * provider's handler directly, so it reads the one live handler it needs here.
+ */
 function getRuntimeModelCandidates(
 	runtime: IAgentRuntime,
 	modelType: string,
-): HandlerRegistration[] {
+): RoutableCandidate[] {
 	const models = (runtime as { models?: unknown }).models;
 	if (!(models instanceof Map)) return [];
 	const registrations = models.get(modelType);
@@ -180,7 +200,7 @@ function getRuntimeModelCandidates(
 			): entry is {
 				provider: string;
 				priority?: number;
-				handler: HandlerRegistration["handler"];
+				handler: AnyHandler;
 			} =>
 				entry &&
 				typeof entry === "object" &&
@@ -192,17 +212,16 @@ function getRuntimeModelCandidates(
 			modelType,
 			provider: entry.provider,
 			priority: typeof entry.priority === "number" ? entry.priority : 0,
-			registeredAt: "runtime-introspection",
 			handler: entry.handler,
 		}))
 		.sort((a, b) => b.priority - a.priority);
 }
 
 export function filterUnavailableLocalInferenceCandidates(
-	candidates: HandlerRegistration[],
+	candidates: RoutableCandidate[],
 	localInferenceAvailable: boolean,
 	forceLocalInference: boolean,
-): HandlerRegistration[] {
+): RoutableCandidate[] {
 	if (forceLocalInference || localInferenceAvailable) {
 		return candidates;
 	}
@@ -216,8 +235,8 @@ export async function filterUnavailableLocalInference(
 	slot: AgentModelSlot,
 	policy: string,
 	preferredProvider: string | null,
-	candidates: HandlerRegistration[],
-): Promise<HandlerRegistration[]> {
+	candidates: RoutableCandidate[],
+): Promise<RoutableCandidate[]> {
 	// TTS is self-sufficient: its handler calls ensureActiveBundleVoiceReady()
 	// internally and can use the Kokoro-only bridge on demand.
 	if (slot === "TEXT_TO_SPEECH") {
@@ -269,17 +288,13 @@ function makeRouterHandler(slot: AgentModelSlot): AnyHandler {
 		// policies, honor the documented fallback behaviour: if the selected
 		// provider throws, try the next eligible provider instead of surfacing a
 		// local/model-specific failure while cloud providers are available.
-		const registeredCandidates = handlerRegistry.getForTypeExcluding(
-			modelType,
-			ROUTER_PROVIDER,
-		);
+		// Candidates (with live handlers) come straight from the runtime's model
+		// registry, excluding the router itself.
 		const candidates = await filterUnavailableLocalInference(
 			slot,
 			policy,
 			preferred,
-			registeredCandidates.length > 0
-				? registeredCandidates
-				: getRuntimeModelCandidates(runtime, modelType),
+			getRuntimeModelCandidates(runtime, modelType),
 		);
 
 		// Only the capability-aware policies need the hardware assessment + live

--- a/plugins/plugin-local-inference/src/services/routing-policy.test.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.test.ts
@@ -1,15 +1,9 @@
-import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { classifyDeviceTier, type DeviceTierAssessment } from "./device-tier";
 import type { HandlerRegistration } from "./handler-registry";
 import type { LiveDeviceSignals } from "./live-signals";
 import { policyEngine } from "./routing-policy";
 import type { AgentModelSlot, HardwareProbe } from "./types";
-
-const noopHandler: HandlerRegistration["handler"] = async (
-	_runtime: IAgentRuntime,
-	_params: Record<string, unknown>,
-) => null;
 
 function registration(
 	provider: string,
@@ -21,7 +15,6 @@ function registration(
 		provider,
 		priority,
 		registeredAt: "test",
-		handler: noopHandler,
 	};
 }
 

--- a/plugins/plugin-local-inference/src/services/routing-policy.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.ts
@@ -38,11 +38,21 @@
  */
 
 import type { DeviceTierAssessment } from "./device-tier";
-import type { HandlerRegistration } from "./handler-registry";
 import type { LiveDeviceSignals } from "./live-signals";
 import { liveSignalsDemoteLocal } from "./live-signals";
 import type { RoutingPolicy } from "./routing-preferences";
 import type { AgentModelSlot } from "./types";
+
+/**
+ * The minimal shape the policy engine needs to rank and select a provider. The
+ * router passes candidates that also carry a live handler; the engine only ever
+ * reads `provider` + `priority`, so it stays generic over the candidate type
+ * and returns the exact candidate (handler included) it picked.
+ */
+export interface ProviderCandidate {
+	provider: string;
+	priority: number;
+}
 
 const RING_SIZE = 32;
 
@@ -68,9 +78,9 @@ const VOICE_SLOTS: ReadonlySet<AgentModelSlot> = new Set([
  * in-process / Capacitor backends over the device bridge, matching the
  * `prefer-local` precedence.
  */
-function findLocalCandidate(
-	candidates: HandlerRegistration[],
-): HandlerRegistration | null {
+function findLocalCandidate<C extends ProviderCandidate>(
+	candidates: C[],
+): C | null {
 	const inProcess = candidates.find(
 		(c) =>
 			c.provider === "eliza-local-inference" ||
@@ -215,17 +225,17 @@ class PolicyEngine {
 	}
 
 	/**
-	 * Pick a provider for this (modelType, policy) given the registry.
-	 * Returns the HandlerRegistration whose handler the router-handler
-	 * should dispatch to, or null if no eligible handler exists.
+	 * Pick a provider for this (modelType, policy) given the candidate set.
+	 * Returns the candidate the router-handler should dispatch to (handler
+	 * included, since the type is preserved), or null if none are eligible.
 	 *
 	 * `preferredProvider` is only honoured for policy === "manual".
 	 */
-	pickProvider(args: {
+	pickProvider<C extends ProviderCandidate>(args: {
 		modelType: string;
 		policy: RoutingPolicy;
 		preferredProvider: string | null;
-		candidates: HandlerRegistration[];
+		candidates: C[];
 		/** Provider ID of the router itself — always excluded from candidates. */
 		selfProvider: string;
 		/**
@@ -248,7 +258,7 @@ class PolicyEngine {
 		 * demotion (the static decision stands).
 		 */
 		liveSignals?: LiveDeviceSignals | null;
-	}): HandlerRegistration | null {
+	}): C | null {
 		const eligible = args.candidates
 			.filter((c) => c.provider !== args.selfProvider)
 			.slice()


### PR DESCRIPTION
## What

Wave-2 #12161 removed the **dead** UI copy of the `registerModel` prototype monkey-patch. This finishes item 7 by migrating the **live** twin at `plugins/plugin-local-inference/src/services/handler-registry.ts` to the exact same core API that shipped in that wave.

The old code patched `AgentRuntime.prototype.registerModel` (a `PATCH_MARK` symbol + per-instance wrap) to capture handlers into a shadow registry, bypassing core failover and breaking on any core signature change.

## Change

- **`handler-registry.ts`** is now a **metadata-only mirror**: `installOn(runtime)` seeds from `runtime.getModelRegistrations()` and stays live via `EventType.MODEL_REGISTERED`. No prototype patch, no handler capture. (Mirrors the UI change #12161.)
- **`router-handler.ts`** already read the live `runtime.models` registry as a fallback; that is now its **sole dispatch source**. It keeps invoking the picked provider's registered handler **directly** — dispatching via `useModel` from inside a registered handler would re-enter the router and double-apply per-call processing (model-settings merge, streaming setup, PII swap), so raw dispatch is preserved.
- **`routing-policy.ts`** `pickProvider`/`findLocalCandidate` are generic over `ProviderCandidate` so the router's dispatch candidate (handler included) flows through unchanged.

**No behavior change**: same policy selection, same raw-handler dispatch, same cross-provider failover loop. Only the registry-population seam changed.

## Done-when evidence

- `grep -rn "prototype.registerModel\|PATCH_MARK\|recordFromPrototype" plugins/plugin-local-inference/src` → **no assignment remains** (only a docstring describing what we no longer do).
- Routing/registry populate through the core API:
  - `handler-registry.test.ts` — 5 cases: seeds from `getModelRegistrations()`, records via `MODEL_REGISTERED`, metadata-only (no leaked handler), `getForTypeExcluding`, idempotent; the runtime double has **no** `registerModel`, proving no patch.
  - `router-dispatch.test.ts` — the router picks + invokes a provider's handler resolved from `runtime.models` (manual policy; also asserts the error surfaces with no silent fallback).
- Plugin **typecheck clean**, **build clean**.
- Affected suites green: `handler-registry` + `router-dispatch` + `routing-policy` + `router-handler` (27) and `ensure-local-inference-handler` + `compat-routes` + `bionic-wire-encoding` (41).

Refs #12091 (item 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)