### PR TITLE
fix(app-core): store steward credentials securely

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/steward.ts
+++ b/packages/app-core/platforms/electrobun/src/native/steward.ts
@@ -143,7 +143,7 @@ async function configureStewardEnvFromCredentials(): Promise<void> {
 
     try {
       const { saveStewardCredentials } = await loadStewardCredentialsModule();
-      saveStewardCredentials({
+      await saveStewardCredentials({
         apiUrl: apiBase,
         tenantId: credentials.tenantId,
         agentId: credentials.agentId,

--- a/packages/app-core/src/security/agent-vault-id.ts
+++ b/packages/app-core/src/security/agent-vault-id.ts
@@ -1,12 +1,27 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
-import { resolveStateDir } from "@elizaos/core";
 
 import type { SecureStoreSecretKind } from "./platform-secure-store";
 
 /** Fixed Keychain / Secret Service “service” identifier (see docs/guides/platform-secure-store.md). */
 export const ELIZA_AGENT_VAULT_SERVICE = "ai.elizaos.agent.vault";
+
+// Keep this dependency-light: platform secure-store modules are imported by
+// Electrobun bootstrap code where pulling the @elizaos/core barrel is costly.
+function resolveStateDir(): string {
+  const explicit = process.env.ELIZA_STATE_DIR?.trim();
+  if (explicit) return explicit;
+  const namespace = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdgStateHome = process.env.XDG_STATE_HOME?.trim();
+  const stateHome = xdgStateHome
+    ? path.isAbsolute(xdgStateHome)
+      ? xdgStateHome
+      : path.join(homedir(), xdgStateHome)
+    : path.join(homedir(), ".local", "state");
+  return path.join(stateHome, namespace);
+}
 
 /**
  * Canonical state directory for this process. Mirrors the canonical

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
@@ -30,7 +30,9 @@ function stewardOsPairs(): ReadonlyArray<
 > {
   return [
     ["STEWARD_API_URL", "steward.api_url"],
+    ["STEWARD_TENANT_ID", "steward.tenant_id"],
     ["STEWARD_AGENT_ID", "steward.agent_id"],
+    ["STEWARD_API_KEY", "steward.api_key"],
     ["STEWARD_AGENT_TOKEN", "steward.agent_token"],
   ];
 }

--- a/packages/app-core/src/security/platform-secure-store.ts
+++ b/packages/app-core/src/security/platform-secure-store.ts
@@ -13,7 +13,9 @@ export type SecureStoreSecretKind =
   | "wallet.evm_private_key"
   | "wallet.solana_private_key"
   | "steward.api_url"
+  | "steward.tenant_id"
   | "steward.agent_id"
+  | "steward.api_key"
   | "steward.agent_token";
 
 export type SecureStoreUnavailableReason =

--- a/packages/app-core/src/services/steward-credentials.test.ts
+++ b/packages/app-core/src/services/steward-credentials.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  PlatformSecureStore,
+  SecureStoreGetResult,
+  SecureStoreSecretKind,
+  SecureStoreSetResult,
+} from "../security/platform-secure-store";
+import {
+  loadStewardCredentials,
+  saveStewardCredentials,
+} from "./steward-credentials";
+
+class MemorySecureStore implements PlatformSecureStore {
+  readonly backend = "none";
+  readonly values = new Map<string, string>();
+
+  constructor(private readonly available = true) {}
+
+  async get(
+    vaultId: string,
+    kind: SecureStoreSecretKind,
+  ): Promise<SecureStoreGetResult> {
+    const value = this.values.get(`${vaultId}:${kind}`);
+    return value ? { ok: true, value } : { ok: false, reason: "not_found" };
+  }
+
+  async set(
+    vaultId: string,
+    kind: SecureStoreSecretKind,
+    value: string,
+  ): Promise<SecureStoreSetResult> {
+    this.values.set(`${vaultId}:${kind}`, value);
+    return { ok: true };
+  }
+
+  async delete(vaultId: string, kind: SecureStoreSecretKind): Promise<void> {
+    this.values.delete(`${vaultId}:${kind}`);
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.available;
+  }
+}
+
+function credentialsPath(stateDir: string): string {
+  return path.join(stateDir, "steward-credentials.json");
+}
+
+describe("steward credentials", () => {
+  let previousStateDir: string | undefined;
+  let stateDir: string;
+
+  beforeEach(() => {
+    previousStateDir = process.env.ELIZA_STATE_DIR;
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "steward-creds-"));
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    if (previousStateDir === undefined) {
+      delete process.env.ELIZA_STATE_DIR;
+    } else {
+      process.env.ELIZA_STATE_DIR = previousStateDir;
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("stores steward secrets in the secure store, not the metadata file", async () => {
+    const secureStore = new MemorySecureStore();
+
+    await saveStewardCredentials(
+      {
+        apiUrl: "https://steward.local",
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        apiKey: "tenant-api-key",
+        agentToken: "agent-token",
+        walletAddresses: { evm: "0xabc" },
+        agentName: "Agent",
+      },
+      { secureStore },
+    );
+
+    const raw = fs.readFileSync(credentialsPath(stateDir), "utf8");
+    expect(raw).toContain("0xabc");
+    expect(raw).not.toContain("tenant-api-key");
+    expect(raw).not.toContain("agent-token");
+
+    const loaded = await loadStewardCredentials({ secureStore });
+    expect(loaded).toMatchObject({
+      apiUrl: "https://steward.local",
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      apiKey: "tenant-api-key",
+      agentToken: "agent-token",
+    });
+  });
+
+  it("migrates legacy plaintext secrets and scrubs the file", async () => {
+    const secureStore = new MemorySecureStore();
+    fs.writeFileSync(
+      credentialsPath(stateDir),
+      JSON.stringify(
+        {
+          apiUrl: "https://legacy.local",
+          tenantId: "tenant-legacy",
+          agentId: "agent-legacy",
+          apiKey: "legacy-api-key",
+          agentToken: "legacy-agent-token",
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+
+    const loaded = await loadStewardCredentials({ secureStore });
+
+    expect(loaded).toMatchObject({
+      apiUrl: "https://legacy.local",
+      tenantId: "tenant-legacy",
+      agentId: "agent-legacy",
+      apiKey: "legacy-api-key",
+      agentToken: "legacy-agent-token",
+    });
+    const raw = fs.readFileSync(credentialsPath(stateDir), "utf8");
+    expect(raw).not.toContain("legacy-api-key");
+    expect(raw).not.toContain("legacy-agent-token");
+  });
+
+  it("scrubs legacy plaintext secrets even when secure store is unavailable", async () => {
+    const secureStore = new MemorySecureStore(false);
+    fs.writeFileSync(
+      credentialsPath(stateDir),
+      JSON.stringify(
+        {
+          apiUrl: "https://legacy.local",
+          tenantId: "tenant-legacy",
+          agentId: "agent-legacy",
+          apiKey: "legacy-api-key",
+          agentToken: "legacy-agent-token",
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+
+    const loaded = await loadStewardCredentials({ secureStore });
+
+    expect(loaded).toMatchObject({
+      apiUrl: "https://legacy.local",
+      tenantId: "tenant-legacy",
+      agentId: "agent-legacy",
+      apiKey: "",
+      agentToken: "",
+    });
+    const raw = fs.readFileSync(credentialsPath(stateDir), "utf8");
+    expect(raw).not.toContain("legacy-api-key");
+    expect(raw).not.toContain("legacy-agent-token");
+  });
+});

--- a/packages/app-core/src/services/steward-credentials.ts
+++ b/packages/app-core/src/services/steward-credentials.ts
@@ -1,14 +1,21 @@
 /**
  * Steward credential persistence for non-sidecar (web/dev) mode.
  *
- * On first setup, saves steward credentials to `<state-dir>/steward-credentials.json`.
- * State dir honors ELIZA_STATE_DIR > XDG state home.
- * Environment variables always override file values.
+ * On first setup, saves non-secret steward metadata to
+ * `<state-dir>/steward-credentials.json` and saves secret values to the
+ * platform secure store. State dir honors ELIZA_STATE_DIR > XDG state home.
+ * Environment variables always override persisted values.
  */
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import type {
+  PlatformSecureStore,
+  SecureStoreSecretKind,
+} from "../security/platform-secure-store";
+import { createNodePlatformSecureStore } from "../security/platform-secure-store-node";
 
 // Inlined to avoid pulling the @elizaos/core source barrel into consumers
 // that only need state-dir resolution (e.g. the Electrobun bun bundle, which
@@ -42,49 +49,220 @@ export interface PersistedStewardCredentials {
 }
 
 const CREDENTIALS_FILENAME = "steward-credentials.json";
+const STEWARD_SECRET_KINDS = {
+  apiUrl: "steward.api_url",
+  tenantId: "steward.tenant_id",
+  agentId: "steward.agent_id",
+  apiKey: "steward.api_key",
+  agentToken: "steward.agent_token",
+} as const satisfies Record<string, SecureStoreSecretKind>;
+
+type StewardCredentialSecretField = keyof typeof STEWARD_SECRET_KINDS;
+type StewardCredentialsMetadata = Omit<
+  PersistedStewardCredentials,
+  StewardCredentialSecretField
+> &
+  Partial<Pick<PersistedStewardCredentials, "apiUrl" | "tenantId" | "agentId">>;
+
+interface StewardCredentialPersistenceOptions {
+  secureStore?: PlatformSecureStore;
+}
 
 function resolveCredentialsPath(): string {
   return path.join(resolveStateDir(), CREDENTIALS_FILENAME);
 }
 
-/**
- * Load persisted steward credentials from disk.
- * Returns null if file doesn't exist or is unreadable.
- */
-export function loadStewardCredentials(): PersistedStewardCredentials | null {
+function deriveStewardVaultId(): string {
+  const resolved = path.resolve(resolveStateDir());
+  let canonicalStateDir = resolved;
+  try {
+    canonicalStateDir = fs.realpathSync(resolved);
+  } catch {
+    // Directory may not exist before first save.
+  }
+  const hash = createHash("sha256").update(canonicalStateDir, "utf8").digest();
+  const token = Buffer.from(hash).toString("base64url").slice(0, 16);
+  return `mldy1-${token}`;
+}
+
+function createStewardSecureStore(
+  options: StewardCredentialPersistenceOptions = {},
+): PlatformSecureStore {
+  return options.secureStore ?? createNodePlatformSecureStore();
+}
+
+function readCredentialsFile():
+  | (Partial<PersistedStewardCredentials> & StewardCredentialsMetadata)
+  | null {
   const credPath = resolveCredentialsPath();
   try {
     if (!fs.existsSync(credPath)) {
       return null;
     }
-    const raw = fs.readFileSync(credPath, "utf-8");
-    const parsed = JSON.parse(raw) as PersistedStewardCredentials;
-    if (!parsed.apiUrl || !parsed.tenantId || !parsed.agentId) {
-      return null;
-    }
-    return parsed;
+    return JSON.parse(
+      fs.readFileSync(credPath, "utf-8"),
+    ) as Partial<PersistedStewardCredentials> & StewardCredentialsMetadata;
   } catch {
     return null;
   }
 }
 
-/**
- * Save steward credentials to disk with restrictive permissions (0o600).
- */
-export function saveStewardCredentials(
-  credentials: PersistedStewardCredentials,
+function writeCredentialsMetadata(
+  credentials: PersistedStewardCredentials | StewardCredentialsMetadata,
 ): void {
   const credPath = resolveCredentialsPath();
   const dir = path.dirname(credPath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  const data = {
-    ...credentials,
+  const data: StewardCredentialsMetadata = {
+    walletAddresses: credentials.walletAddresses,
+    agentName: credentials.agentName,
     createdAt: credentials.createdAt ?? new Date().toISOString(),
   };
+  if (credentials.apiUrl) data.apiUrl = credentials.apiUrl;
+  if (credentials.tenantId) data.tenantId = credentials.tenantId;
+  if (credentials.agentId) data.agentId = credentials.agentId;
 
   fs.writeFileSync(credPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+}
+
+async function readStewardSecret(
+  store: PlatformSecureStore,
+  vaultId: string,
+  field: StewardCredentialSecretField,
+): Promise<string | null> {
+  const got = await store.get(vaultId, STEWARD_SECRET_KINDS[field]);
+  return got.ok && got.value.trim() ? got.value.trim() : null;
+}
+
+async function writeStewardSecret(
+  store: PlatformSecureStore,
+  vaultId: string,
+  field: StewardCredentialSecretField,
+  value: string,
+): Promise<void> {
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  const result = await store.set(vaultId, STEWARD_SECRET_KINDS[field], trimmed);
+  if (!result.ok) {
+    throw new Error(
+      `secure store rejected ${field}: ${result.message ?? result.reason}`,
+    );
+  }
+}
+
+async function migrateLegacyFileSecrets(
+  store: PlatformSecureStore,
+  vaultId: string,
+  parsed: Partial<PersistedStewardCredentials> & StewardCredentialsMetadata,
+): Promise<void> {
+  const migrated: Partial<PersistedStewardCredentials> = {};
+  for (const field of Object.keys(
+    STEWARD_SECRET_KINDS,
+  ) as StewardCredentialSecretField[]) {
+    const value = parsed[field];
+    if (typeof value === "string" && value.trim()) {
+      await writeStewardSecret(store, vaultId, field, value);
+      migrated[field] = value.trim();
+    }
+  }
+  if (Object.keys(migrated).length > 0) {
+    writeCredentialsMetadata({ ...parsed, ...migrated });
+  }
+}
+
+/**
+ * Load persisted steward credentials from metadata + platform secure store.
+ * Returns null if credentials are missing or unreadable.
+ */
+export async function loadStewardCredentials(
+  options: StewardCredentialPersistenceOptions = {},
+): Promise<PersistedStewardCredentials | null> {
+  const parsed = readCredentialsFile();
+  if (!parsed) return null;
+
+  const store = createStewardSecureStore(options);
+  const hasLegacySecrets = (
+    Object.keys(STEWARD_SECRET_KINDS) as StewardCredentialSecretField[]
+  ).some((field) => {
+    const value = parsed[field];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+  if (await store.isAvailable()) {
+    const vaultId = deriveStewardVaultId();
+    await migrateLegacyFileSecrets(store, vaultId, parsed);
+
+    const secureValues: Partial<
+      Pick<PersistedStewardCredentials, StewardCredentialSecretField>
+    > = {};
+    for (const field of Object.keys(
+      STEWARD_SECRET_KINDS,
+    ) as StewardCredentialSecretField[]) {
+      const value = await readStewardSecret(store, vaultId, field);
+      if (value) {
+        secureValues[field] = value;
+      }
+    }
+
+    const apiUrl = secureValues.apiUrl || parsed.apiUrl || null;
+    const tenantId = secureValues.tenantId || parsed.tenantId || null;
+    const agentId = secureValues.agentId || parsed.agentId || null;
+    if (!apiUrl || !tenantId || !agentId) {
+      return null;
+    }
+
+    return {
+      apiUrl,
+      tenantId,
+      agentId,
+      apiKey: secureValues.apiKey || "",
+      agentToken: secureValues.agentToken || "",
+      walletAddresses: parsed.walletAddresses,
+      agentName: parsed.agentName,
+      createdAt: parsed.createdAt,
+    };
+  }
+
+  if (hasLegacySecrets) {
+    writeCredentialsMetadata(parsed);
+  }
+
+  const apiUrl = parsed.apiUrl || null;
+  const tenantId = parsed.tenantId || null;
+  const agentId = parsed.agentId || null;
+  if (!apiUrl || !tenantId || !agentId) return null;
+  return {
+    apiUrl,
+    tenantId,
+    agentId,
+    apiKey: "",
+    agentToken: "",
+    walletAddresses: parsed.walletAddresses,
+    agentName: parsed.agentName,
+    createdAt: parsed.createdAt,
+  };
+}
+
+/**
+ * Save steward credentials to the platform secure store and metadata to disk.
+ */
+export async function saveStewardCredentials(
+  credentials: PersistedStewardCredentials,
+  options: StewardCredentialPersistenceOptions = {},
+): Promise<void> {
+  const store = createStewardSecureStore(options);
+  if (await store.isAvailable()) {
+    const vaultId = deriveStewardVaultId();
+    await Promise.all(
+      (Object.keys(STEWARD_SECRET_KINDS) as StewardCredentialSecretField[]).map(
+        (field) =>
+          writeStewardSecret(store, vaultId, field, credentials[field]),
+      ),
+    );
+  }
+
+  writeCredentialsMetadata(credentials);
 }
 
 /**
@@ -93,10 +271,11 @@ export function saveStewardCredentials(
  *
  * Returns null if steward is not configured at all.
  */
-export function resolveEffectiveStewardConfig(
+export async function resolveEffectiveStewardConfig(
   env: NodeJS.ProcessEnv = process.env,
-): PersistedStewardCredentials | null {
-  const persisted = loadStewardCredentials();
+  options: StewardCredentialPersistenceOptions = {},
+): Promise<PersistedStewardCredentials | null> {
+  const persisted = await loadStewardCredentials(options);
 
   const apiUrl = env.STEWARD_API_URL?.trim() || persisted?.apiUrl || null;
   if (!apiUrl) {


### PR DESCRIPTION
## Summary
- persist steward secret fields in the platform secure store instead of `steward-credentials.json`
- keep the JSON file metadata-only and scrub legacy plaintext secrets during load/migration
- extend steward OS-store hydration for tenant/API key fields
- keep secure-store vault-id derivation dependency-light for Electrobun bootstrap

## #12088
- Completes item 9: steward credentials secure store.

## Tests
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/app-core test -- src/services/steward-credentials.test.ts src/security/agent-vault-id.test.ts`
- `bunx @biomejs/biome check packages/app-core/src/services/steward-credentials.ts packages/app-core/src/services/steward-credentials.test.ts packages/app-core/src/security/platform-secure-store.ts packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts packages/app-core/src/security/agent-vault-id.ts packages/app-core/platforms/electrobun/src/native/steward.ts`
- `git diff --check`

## Typecheck note
- `bun run --cwd packages/app-core typecheck` still fails on existing baseline issues in `src/api/auth.ts`, `src/api/dev-boot-history.test.ts`, `src/services/connector-target-catalog.test.ts`, and the existing `@elizaos/cloud-routing` declaration gap. After `packages/core prebuild`, no generated-keyword errors remain.

## Evidence
- N/A real LLM trajectories: no agent/model/action/prompt behavior changed.
- N/A screenshots/video: no visible UI changed; credential persistence plumbing only.
- Domain artifact evidence: focused tests assert saved steward metadata JSON excludes `apiKey` / `agentToken`, secure-store backed load restores them, and legacy plaintext files are scrubbed after migration or unavailable-store load.
