### PR TITLE
refactor(core): route boot-config store through the ambient-context accessor (#12091 item 37)

### DIFF
--- a/packages/core/src/boot-env.test.ts
+++ b/packages/core/src/boot-env.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { peekAmbientSingleton } from "./ambient-context";
 import {
 	syncAppEnvToEliza,
 	syncBrandEnvToEliza,
@@ -147,5 +148,20 @@ describe("boot config store is write-once", () => {
 
 		expect(process.env.ELIZA_SEED_DST).toBe("seed");
 		expect(slot[STORE_KEY]).toBeDefined();
+	});
+
+	it("stores the singleton through the ambient-context accessor", () => {
+		const slot = globalThis as Slot;
+		slot[WINDOW_KEY] = { envAliases: [["ELIZA_SEED_SRC", "ELIZA_SEED_DST"]] };
+
+		// First access seeds the store via setAmbientSingleton(STORE_KEY, …).
+		syncAppEnvToEliza();
+
+		// The accessor and the raw global slot observe the same instance, proving
+		// the store is read/written through ambient-context.ts, not a hand-rolled
+		// globalThis[Symbol.for(...)] access.
+		const viaAccessor = peekAmbientSingleton(STORE_KEY);
+		expect(viaAccessor).toBeDefined();
+		expect(viaAccessor).toBe(slot[STORE_KEY]);
 	});
 });

--- a/packages/core/src/boot-env.ts
+++ b/packages/core/src/boot-env.ts
@@ -1,3 +1,8 @@
+import {
+	peekAmbientSingleton,
+	setAmbientSingleton,
+} from "./ambient-context.js";
+
 interface AppBootConfig {
 	envAliases?: readonly (readonly [string, string])[];
 	[key: string]: unknown;
@@ -23,31 +28,32 @@ function getGlobalSlot(): GlobalConfigSlot {
 }
 
 function getBootConfigStore(): BootConfigStore {
-	const globalObject = getGlobalSlot();
-
+	// The store singleton lives on the shared global slot so every bundled copy
+	// of `@elizaos/core` observes the same instance. Read/write it through the
+	// core-owned ambient-context accessor rather than hand-rolling the
+	// `globalThis[Symbol.for(...)]` access (matches the trajectory/action/app
+	// registries consolidated in #12164).
+	//
 	// An established store always wins. The window-key mirror is only a
 	// pre-boot seed (set by the HTML bootstrap / Electrobun preload before any
 	// bundle loads) and must never replace a store that already exists —
 	// otherwise a stale or partial window value silently clobbers config that
 	// setBootConfig already committed, and the store's object identity churns
 	// on every read (dropping any store-only state).
-	const existing = globalObject[BOOT_CONFIG_STORE_KEY];
-	if (
-		existing &&
-		typeof existing === "object" &&
-		"current" in (existing as Record<string, unknown>)
-	) {
-		return existing as BootConfigStore;
+	const existing = peekAmbientSingleton<BootConfigStore>(BOOT_CONFIG_STORE_KEY);
+	if (existing && typeof existing === "object" && "current" in existing) {
+		return existing;
 	}
 
 	// No store yet: seed it once. Prefer a cross-bundle window mirror when a
 	// bootstrap set it, otherwise fall back to defaults. The slot is written
 	// once here and thereafter returned as-is by the branch above.
+	const globalObject = getGlobalSlot();
 	const mirroredWindowConfig = globalObject[BOOT_CONFIG_WINDOW_KEY];
 	const store: BootConfigStore = {
 		current: mirroredWindowConfig ?? DEFAULT_BOOT_CONFIG,
 	};
-	globalObject[BOOT_CONFIG_STORE_KEY] = store;
+	setAmbientSingleton(BOOT_CONFIG_STORE_KEY, store);
 	globalObject[BOOT_CONFIG_WINDOW_KEY] = store.current;
 	return store;
 }


### PR DESCRIPTION
## What

Wave-2 #12164 consolidated 5 globalThis `Symbol.for` singletons (trajectory / action-routing / trajectory-source / curated-app / app-route-plugin registries) into `packages/core/src/ambient-context.ts`. This finishes item 37 by routing the **last** genuine globalThis `Symbol.for` singleton in `packages/core` — the boot-config store — through the same accessor.

## Change

`getBootConfigStore()` now reads/writes `BOOT_CONFIG_STORE_KEY` via `peekAmbientSingleton` / `setAmbientSingleton` instead of a hand-rolled `globalThis[Symbol.for(...)]` access. **Byte-equivalent**: the established-store-wins guard and the (string-keyed) `__ELIZAOS_APP_BOOT_CONFIG__` window mirror seed are unchanged, so the write-once semantics from #12153 are preserved.

### Intentionally NOT migrated
The other `Symbol.for` sites the audit listed are **per-object** stashes, not globalThis singletons — moving them to a process-global accessor would be a correctness bug:
- `RECORD_LLM_CALL_DEPTH_KEY` → per-async-context trajectory object (nesting depth must stay per-request)
- `CACHED_REQUEST_BODY` / `CACHED_JSON_BODY` → per-`Request` object
- `RUNTIME_ROUTE_HOST_CONTEXT_KEY` → per-runtime object
- browser-mocks patch marks → test-only install guards

## Done-when evidence

- `grep` in `packages/core/src/boot-env.ts`: `BOOT_CONFIG_STORE_KEY` is read/written **only** via `peek`/`setAmbientSingleton`; no `globalThis[…KEY] =` singleton write remains anywhere in `packages/core/src`.
- Core **builds clean** (tsc declarations generated).
- `boot-env.test.ts` green — 5 cases incl. a new seam test asserting the accessor (`peekAmbientSingleton(STORE_KEY)`) and the raw global slot observe the **same** store instance; `ambient-context.test.ts` green.

Refs #12091 (item 37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)