### PR TITLE
refactor(app-core): generic runtime-hook channel — drop hard-wired plugin-training boot step (#12092 item 16)

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -33,6 +33,7 @@ import {
   AutonomyService,
   ChannelType,
   CONNECTOR_TARGET_SOURCE_REGISTRY_SERVICE,
+  isOptionalAppRoutePluginUnavailableError,
   isTruthyEnvValue,
   logger,
   ModelType,
@@ -400,13 +401,19 @@ function resolvePluginExport(
   throw new Error("No plugin export found");
 }
 
-async function loadAppRoutePluginFromSpecifier(
+/**
+ * Import an app module by package specifier, with a workspace-source fallback
+ * for local/source mode. Throws {@link OptionalAppRoutePluginUnavailableError}
+ * when the package is genuinely absent (an optional plugin not installed in this
+ * deployment); rethrows any real load failure (syntax error, init throw, broken
+ * transitive dependency) so it is never misreported as "not installed". Shared
+ * by the route-plugin loader and the runtime-hook loader.
+ */
+async function importAppModuleFromSpecifier(
   specifier: string,
-  exportName: string | undefined,
-): Promise<Plugin> {
-  let module: AppRoutePluginModule;
+): Promise<AppRoutePluginModule> {
   try {
-    module = (await import(
+    return (await import(
       /* webpackIgnore: true */ specifier
     )) as AppRoutePluginModule;
   } catch (err) {
@@ -416,12 +423,19 @@ async function loadAppRoutePluginFromSpecifier(
       throw new OptionalAppRoutePluginUnavailableError(specifier, err);
     }
     logger.debug(
-      `[eliza] Loading app route plugin ${specifier} from workspace source at ${sourceEntry}`,
+      `[eliza] Loading app module ${specifier} from workspace source at ${sourceEntry}`,
     );
-    module = (await import(
+    return (await import(
       pathToFileURL(sourceEntry).href
     )) as AppRoutePluginModule;
   }
+}
+
+async function loadAppRoutePluginFromSpecifier(
+  specifier: string,
+  exportName: string | undefined,
+): Promise<Plugin> {
+  const module = await importAppModuleFromSpecifier(specifier);
   return resolvePluginExport(module, exportName);
 }
 
@@ -556,12 +570,6 @@ async function registerAppRoutePlugins(runtime: AgentRuntime): Promise<void> {
   await drainAppRoutePluginLoaders(runtime, getAppRoutePluginLoaders());
 }
 
-interface RuntimeHookModule {
-  registerTrainingRuntimeHooks?: (runtime: AgentRuntime) => Promise<void>;
-}
-
-const TRAINING_RUNTIME_HOOKS_SPECIFIER = "@elizaos/plugin-training";
-
 /**
  * Returns true only for genuine "module is not installed" import failures.
  * Bun raises `ResolveMessage` with `code === "ERR_MODULE_NOT_FOUND"` when a
@@ -578,36 +586,94 @@ function isModuleNotFoundError(err: unknown): boolean {
   return false;
 }
 
-async function registerTrainingRuntimeHooks(
+/**
+ * A runtime-hook contributor: an app's optional post-ready wiring step. `invoke`
+ * loads the app's declared hook module and calls it with the runtime. Resolved
+ * from the registry ({@link getRuntimeHookContributors}) — no feature plugin is
+ * hard-wired by name here; the host drains whatever apps declare a `runtimeHook`.
+ */
+interface RuntimeHookContributor {
+  id: string;
+  invoke: (runtime: AgentRuntime) => Promise<void>;
+}
+
+type RuntimeHookFn = (runtime: AgentRuntime) => void | Promise<void>;
+
+/**
+ * Load an app's runtime-hook export by specifier and invoke it. Uses the shared
+ * {@link importAppModuleFromSpecifier}, so an absent optional plugin surfaces as
+ * {@link OptionalAppRoutePluginUnavailableError} (a graceful skip in the drain)
+ * while a real load failure or a missing/wrong-typed export throws.
+ */
+async function loadAndInvokeRuntimeHook(
+  specifier: string,
+  exportName: string,
   runtime: AgentRuntime,
 ): Promise<void> {
-  let hookMod: RuntimeHookModule;
-  try {
-    hookMod = (await import(
-      TRAINING_RUNTIME_HOOKS_SPECIFIER
-    )) as RuntimeHookModule;
-  } catch (err) {
-    if (isModuleNotFoundError(err)) {
-      logger.warn(
-        `[eliza] @elizaos/plugin-training not installed, skipping runtime hooks`,
-      );
-      return;
-    }
-    // Real load failure (syntax error, broken transitive, init throw, etc.) —
-    // surface it loudly so it is not mistaken for "not installed".
-    logger.error(
-      `[eliza] @elizaos/plugin-training failed to load (not 'not installed'): ${formatErrorWithStack(err)}`,
-    );
-    throw err;
-  }
-
-  if (!hookMod.registerTrainingRuntimeHooks) {
+  const module = await importAppModuleFromSpecifier(specifier);
+  const hook = module[exportName];
+  if (typeof hook !== "function") {
     throw new Error(
-      `[eliza] ${TRAINING_RUNTIME_HOOKS_SPECIFIER} did not export registerTrainingRuntimeHooks`,
+      `[eliza] ${specifier} did not export a runtime-hook function "${exportName}"`,
     );
   }
+  await (hook as RuntimeHookFn)(runtime);
+}
 
-  await hookMod.registerTrainingRuntimeHooks(runtime);
+/**
+ * Resolve every app that declares a `runtimeHook` in the registry into a
+ * contributor. Data-driven and generic: the registry owns the package bindings
+ * (each plugin self-declares its hook in its own `registry-entry.json`), so the
+ * boot tail names no plugin.
+ */
+function getRuntimeHookContributors(): RuntimeHookContributor[] {
+  return getApps(loadRegistry()).flatMap((app) => {
+    const runtimeHook = app.launch.runtimeHook;
+    if (!runtimeHook) return [];
+    return [
+      {
+        id: app.npmName ?? app.id,
+        invoke: (runtime: AgentRuntime) =>
+          loadAndInvokeRuntimeHook(
+            runtimeHook.specifier,
+            runtimeHook.exportName,
+            runtime,
+          ),
+      },
+    ];
+  });
+}
+
+/**
+ * Drain runtime-hook contributors in order, invoking each against the runtime.
+ * An optional plugin that is not installed is skipped gracefully (debug-logged);
+ * any real failure is logged and rethrown so a broken hook is never mistaken for
+ * a benign absence. Exported for a focused unit test of the generic channel.
+ */
+export async function drainRuntimeHookContributors(
+  runtime: AgentRuntime,
+  contributors: RuntimeHookContributor[],
+): Promise<void> {
+  for (const { id, invoke } of contributors) {
+    try {
+      await invoke(runtime);
+    } catch (err) {
+      if (isOptionalAppRoutePluginUnavailableError(err)) {
+        logger.debug(
+          `[eliza] Runtime-hook contributor ${id} unavailable, skipping`,
+        );
+        continue;
+      }
+      logger.error(
+        `[eliza] Runtime-hook contributor ${id} failed: ${formatErrorWithStack(err)}`,
+      );
+      throw err;
+    }
+  }
+}
+
+async function registerRuntimeHooks(runtime: AgentRuntime): Promise<void> {
+  await drainRuntimeHookContributors(runtime, getRuntimeHookContributors());
 }
 
 // The most recent runtime handed to the post-ready boot tail. A backgrounded
@@ -725,7 +791,7 @@ async function repairRuntimeAfterBoot(
 export interface PostReadyBootSteps {
   ensureTextToSpeechHandler: (runtime: AgentRuntime) => Promise<void>;
   registerAppRoutePlugins: (runtime: AgentRuntime) => Promise<void>;
-  registerTrainingRuntimeHooks: (runtime: AgentRuntime) => Promise<void>;
+  registerRuntimeHooks: (runtime: AgentRuntime) => Promise<void>;
   registerCoreSensitiveRequestAdapters: (runtime: AgentRuntime) => void;
   registerSubAgentCredentialBridge: (runtime: AgentRuntime) => Promise<void>;
   registerSubAgentCredentialBridgeAdapter: (runtime: AgentRuntime) => boolean;
@@ -740,7 +806,7 @@ export interface PostReadyBootSteps {
 const DEFAULT_POST_READY_BOOT_STEPS: PostReadyBootSteps = {
   ensureTextToSpeechHandler,
   registerAppRoutePlugins,
-  registerTrainingRuntimeHooks,
+  registerRuntimeHooks,
   registerCoreSensitiveRequestAdapters,
   registerSubAgentCredentialBridge,
   registerSubAgentCredentialBridgeAdapter,
@@ -757,9 +823,8 @@ const DEFAULT_POST_READY_BOOT_STEPS: PostReadyBootSteps = {
  * keeps its original error behavior verbatim — there is no wrapping try/catch:
  * registerAppRoutePlugins isolates per-loader failures internally,
  * ensureTriggerEventBridge / ensureConnectorTargetCatalog swallow into
- * logger.warn internally, and ensureTextToSpeechHandler /
- * registerTrainingRuntimeHooks throw (preserved in the default inline-await
- * dispatch above).
+ * logger.warn internally, and ensureTextToSpeechHandler / registerRuntimeHooks
+ * throw (preserved in the default inline-await dispatch above).
  *
  * `steps` defaults to the real bound functions, so production behavior is
  * unchanged; the seam exists only so the phase split is unit-testable.
@@ -785,7 +850,11 @@ export async function runPostReadyBootTail(
   // runtime only consumes app route plugin loaders.
   await steps.registerAppRoutePlugins(runtime);
 
-  await steps.registerTrainingRuntimeHooks(runtime);
+  // Drain runtime-hook contributors: apps that declare a `runtimeHook` in the
+  // registry wire runtime-only concerns (services, crons, background bootstraps)
+  // that never reach the route table. Generic + data-driven — no feature plugin
+  // is named here. An uninstalled optional plugin is skipped gracefully.
+  await steps.registerRuntimeHooks(runtime);
 
   // Register first-party sensitive-request delivery adapters with the
   // dispatch registry (no-op when the registry service isn't present).

--- a/packages/app-core/src/runtime/repair-boot-phase.test.ts
+++ b/packages/app-core/src/runtime/repair-boot-phase.test.ts
@@ -28,7 +28,7 @@ function makeSteps(): { steps: PostReadyBootSteps; order: string[] } {
   const steps: PostReadyBootSteps = {
     ensureTextToSpeechHandler: vi.fn(record("tts", Promise.resolve())),
     registerAppRoutePlugins: vi.fn(record("appRoutes", Promise.resolve())),
-    registerTrainingRuntimeHooks: vi.fn(record("training", Promise.resolve())),
+    registerRuntimeHooks: vi.fn(record("runtimeHooks", Promise.resolve())),
     registerCoreSensitiveRequestAdapters: vi.fn(record("sensitive", undefined)),
     registerSubAgentCredentialBridge: vi.fn(
       record("credentialBridgeWiring", Promise.resolve()),
@@ -89,7 +89,7 @@ describe("runPostReadyBootTail — phase split", () => {
     expect(order).toEqual([
       "tts",
       "appRoutes",
-      "training",
+      "runtimeHooks",
       "sensitive",
       "credentialBridgeAdapter",
       "credentialBridgeWiring",
@@ -178,7 +178,7 @@ describe("runPostReadyBootTail — phase split", () => {
     expect(steps.ensureConnectorTargetCatalog).toHaveBeenCalledOnce();
   });
 
-  it("(error isolation) a throwing pre-ready-class step (TTS / training) rejects the tail", async () => {
+  it("(error isolation) a throwing pre-ready-class step (TTS / runtime hooks) rejects the tail", async () => {
     const runtime = makeFakeRuntime();
     __setLatestBootTailRuntimeForTest(runtime);
     const { steps } = makeSteps();

--- a/packages/app-core/src/runtime/runtime-hook-channel.test.ts
+++ b/packages/app-core/src/runtime/runtime-hook-channel.test.ts
@@ -1,0 +1,96 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { OptionalAppRoutePluginUnavailableError } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { drainRuntimeHookContributors } from "./eliza.ts";
+
+// The generic runtime-hook channel the boot tail drains. A "contributor" is
+// an app that declared a `runtimeHook` in the registry; the drain invokes each
+// against the runtime, skips an uninstalled optional plugin gracefully, and
+// rethrows a real failure. These tests exercise the drain directly (the boot
+// tail's post-ready timing is covered in repair-boot-phase.test.ts).
+function makeFakeRuntime(): AgentRuntime {
+  return {} as AgentRuntime;
+}
+
+describe("drainRuntimeHookContributors — generic runtime-hook channel", () => {
+  it("invokes a registered contributor with the runtime", async () => {
+    const runtime = makeFakeRuntime();
+    const invoke = vi.fn().mockResolvedValue(undefined);
+
+    await drainRuntimeHookContributors(runtime, [
+      { id: "@elizaos/plugin-example", invoke },
+    ]);
+
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledWith(runtime);
+  });
+
+  it("invokes every contributor in declared order", async () => {
+    const runtime = makeFakeRuntime();
+    const order: string[] = [];
+
+    await drainRuntimeHookContributors(runtime, [
+      {
+        id: "a",
+        invoke: async () => {
+          order.push("a");
+        },
+      },
+      {
+        id: "b",
+        invoke: async () => {
+          order.push("b");
+        },
+      },
+    ]);
+
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  it("no-ops when there are no contributors", async () => {
+    const runtime = makeFakeRuntime();
+    await expect(
+      drainRuntimeHookContributors(runtime, []),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips a contributor whose optional plugin is unavailable", async () => {
+    const runtime = makeFakeRuntime();
+    const after = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      drainRuntimeHookContributors(runtime, [
+        {
+          id: "@elizaos/plugin-missing",
+          invoke: () =>
+            Promise.reject(
+              new OptionalAppRoutePluginUnavailableError(
+                "@elizaos/plugin-missing",
+              ),
+            ),
+        },
+        { id: "@elizaos/plugin-present", invoke: after },
+      ]),
+    ).resolves.toBeUndefined();
+
+    // The graceful skip does not abort the rest of the drain.
+    expect(after).toHaveBeenCalledOnce();
+  });
+
+  it("rethrows a real contributor failure (not mistaken for a benign absence)", async () => {
+    const runtime = makeFakeRuntime();
+    const boom = new Error("hook init blew up");
+    const after = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      drainRuntimeHookContributors(runtime, [
+        { id: "@elizaos/plugin-broken", invoke: () => Promise.reject(boom) },
+        { id: "@elizaos/plugin-never", invoke: after },
+      ]),
+    ).rejects.toThrow(boom);
+
+    // A real failure short-circuits the remaining contributors.
+    expect(after).not.toHaveBeenCalled();
+  });
+});

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -1619,6 +1619,14 @@
           "help": "Discord channel ID used during test suite to locate the test channel for sending messages, voice interactions, and other test operations.",
           "advanced": false
         },
+        "DISCORD_VOICE_TRANSCRIPTS": {
+          "type": "string",
+          "required": false,
+          "sensitive": false,
+          "label": "Voice Transcripts",
+          "help": "Set to \"on\" to record live diarized meeting transcripts whenever the bot sits in a voice channel. Off by default; the /transcribe slash command can start/stop per channel.",
+          "advanced": false
+        },
         "DISCORD_VOICE_CHANNEL_ID": {
           "type": "string",
           "required": false,
@@ -7231,6 +7239,10 @@
         "routePlugin": {
           "specifier": "@elizaos/plugin-training/setup-routes",
           "exportName": "trainingPlugin"
+        },
+        "runtimeHook": {
+          "specifier": "@elizaos/plugin-training",
+          "exportName": "registerTrainingRuntimeHooks"
         }
       }
     },

--- a/packages/registry/src/first-party/schema.ts
+++ b/packages/registry/src/first-party/schema.ts
@@ -203,6 +203,18 @@ const appRoutePluginSchema = z.object({
   exportName: z.string().min(1).optional(),
 });
 
+// An app's optional runtime-hook contributor: a named export
+// `(runtime) => void | Promise<void>` the host invokes once, post-ready, to wire
+// runtime-only concerns (services, cron jobs, background bootstraps) that never
+// reach the route table. Parallel to `routePlugin` but for the generic
+// runtime-hook channel the boot tail drains — the host resolves it by data, so
+// no feature plugin is hard-wired by name. `exportName` is required: unlike a
+// route plugin (which can be the module default), a hook must name its function.
+const appRuntimeHookSchema = z.object({
+  specifier: packageRoutePluginSpecifierSchema,
+  exportName: z.string().min(1),
+});
+
 export const appLaunchSchema = z.object({
   type: z.enum(["internal-tab", "overlay", "server-launch"]),
   target: z.string().optional(),
@@ -215,6 +227,7 @@ export const appLaunchSchema = z.object({
   uiExtension: z.object({ detailPanelId: z.string() }).optional(),
   curatedSlug: z.string().optional(),
   routePlugin: appRoutePluginSchema.optional(),
+  runtimeHook: appRuntimeHookSchema.optional(),
   /**
    * If true, the app declares itself as the default landing tab.
    * Mirrors `package.json#elizaos.app.mainTab`. Consumed by

--- a/packages/registry/src/first-party/training-app-registry.test.ts
+++ b/packages/registry/src/first-party/training-app-registry.test.ts
@@ -48,6 +48,13 @@ describe("training app registry entry", () => {
           specifier: "@elizaos/plugin-training/setup-routes",
           exportName: "trainingPlugin",
         },
+        // Self-declared runtime-hook: the host drains this through the generic
+        // runtime-hook channel instead of hard-wiring the training specifier in
+        // the boot tail.
+        runtimeHook: {
+          specifier: "@elizaos/plugin-training",
+          exportName: "registerTrainingRuntimeHooks",
+        },
       },
     });
   });

--- a/plugins/plugin-training/registry-entry.json
+++ b/plugins/plugin-training/registry-entry.json
@@ -49,6 +49,10 @@
     "routePlugin": {
       "specifier": "@elizaos/plugin-training/setup-routes",
       "exportName": "trainingPlugin"
+    },
+    "runtimeHook": {
+      "specifier": "@elizaos/plugin-training",
+      "exportName": "registerTrainingRuntimeHooks"
     }
   }
 }


### PR DESCRIPTION
## #12092 item 16 [P2][M] — boot tail dynamic-imports plugin-training by name

`app-core/src/runtime/eliza.ts` hardcoded the `@elizaos/plugin-training` specifier + its `registerTrainingRuntimeHooks` export in a dedicated PostReadyBootStep — the only feature plugin hard-wired by name in the boot tail.

## Change (registry-driven generic channel)
Both literal options in the audit would **regress** behavior (coupling hook installation to the `ELIZA_SKIP_APP_ROUTE_PLUGINS` route-skip knob → silently dropping `OptimizedPromptService`). Instead a generic runtime-hook channel resolved through the registry like ROUTES:
- New optional `launch.runtimeHook { specifier, exportName }` in the registry schema (parallel to `routePlugin`).
- `eliza.ts`: shared `importAppModuleFromSpecifier`; `getRuntimeHookContributors()` (names no plugin); `drainRuntimeHookContributors` at the **same post-ready slot**. Deleted `TRAINING_RUNTIME_HOOKS_SPECIFIER` + `registerTrainingRuntimeHooks`.
- `plugin-training/registry-entry.json` declares `launch.runtimeHook` → byte-identical resolution; no plugin-training TS change.

## Verification
- **Done-criterion grep** in `eliza.ts` → **0** plugin-training identifiers.
- Tests **12 pass** (contributor invoked with runtime; ordered drain; no-op empty; skip unavailable-optional; rethrow real failure; boot ordering post-ready unchanged) + registry `runtimeHook` assertion + `app-route-plugin-skip` 13 pass. Rebased onto develop (kept item 4's `CONNECTOR_TARGET_SOURCE_REGISTRY_SERVICE` import); re-verified post-rebase.

| type | status |
|---|---|
| Unit tests (generic channel, timing) | ✅ |
| eliza.ts grep (→0) | ✅ |
| hook-install behavior | preserved (same slot) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)