### PR TITLE
fix(relationships): require trusted identity verification

### DIFF
--- a/plugins/plugin-relationships/src/actions/entity.ts
+++ b/plugins/plugin-relationships/src/actions/entity.ts
@@ -89,6 +89,13 @@ export interface EntityActionParameters {
   limit?: number;
 }
 
+interface TrustedIdentityVerification {
+  platform: string;
+  handle: string;
+  evidence: string;
+  verified: true;
+}
+
 function getParams(
   options: HandlerOptions | undefined,
 ): EntityActionParameters {
@@ -123,6 +130,37 @@ function entitySummary(entity: Entity): {
 }
 
 const ENTITY_KINDS_DEFAULT = "person";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function resolveTrustedIdentityVerification(
+  options: HandlerOptions | undefined,
+  platform: string,
+  handle: string,
+): TrustedIdentityVerification | null {
+  const candidate = options?.identityVerification;
+  if (!isRecord(candidate)) return null;
+  if (candidate.verified !== true) return null;
+  const verifiedPlatform = trimmed(
+    typeof candidate.platform === "string" ? candidate.platform : undefined,
+  );
+  const verifiedHandle = trimmed(
+    typeof candidate.handle === "string" ? candidate.handle : undefined,
+  );
+  const evidence = trimmed(
+    typeof candidate.evidence === "string" ? candidate.evidence : undefined,
+  );
+  if (!verifiedPlatform || !verifiedHandle || !evidence) return null;
+  if (verifiedPlatform !== platform || verifiedHandle !== handle) return null;
+  return {
+    platform: verifiedPlatform,
+    handle: verifiedHandle,
+    evidence,
+    verified: true,
+  };
+}
 
 export const entityAction: Action = {
   name: RELATIONSHIPS_ACTION_NAME,
@@ -334,11 +372,38 @@ export const entityAction: Action = {
           evidence: [evidence],
           confidence: 1,
         });
-        // User-asserted identities are verified — mark this (platform, handle).
+        const verification = resolveTrustedIdentityVerification(
+          options,
+          platform,
+          handle,
+        );
+        if (!verification) {
+          return reply({
+            success: false,
+            text: `Recorded identity ${platform}:${handle} as unverified. Verification requires trusted platform proof before it can be marked verified.`,
+            data: {
+              op,
+              error: "IDENTITY_VERIFICATION_REQUIRED",
+              entity: entitySummary(observation.entity),
+              mergedFrom: observation.mergedFrom ?? null,
+              conflict: observation.conflict ?? false,
+            },
+          });
+        }
         const verifiedIdentities: EntityIdentity[] =
           observation.entity.identities.map((identity) =>
             identity.platform === platform && identity.handle === handle
-              ? { ...identity, verified: true }
+              ? {
+                  ...identity,
+                  verified: true,
+                  evidence: Array.from(
+                    new Set([
+                      ...(identity.evidence ?? []),
+                      evidence,
+                      verification.evidence,
+                    ]),
+                  ),
+                }
               : identity,
           );
         const merged = await entityStore.upsert({

--- a/plugins/plugin-relationships/test/entity-action.test.ts
+++ b/plugins/plugin-relationships/test/entity-action.test.ts
@@ -120,12 +120,15 @@ function makeMessage(text = "graph op"): Memory {
   } as Memory;
 }
 
-async function call(parameters: Record<string, unknown>) {
+async function call(
+  parameters: Record<string, unknown>,
+  options: Partial<HandlerOptions> = {},
+) {
   return entityAction.handler(
     makeRuntime(),
     makeMessage(),
     undefined,
-    { parameters } as unknown as HandlerOptions,
+    { ...options, parameters } as unknown as HandlerOptions,
     async () => undefined,
   );
 }
@@ -227,7 +230,7 @@ describe("KNOWLEDGE_GRAPH action", () => {
     );
   });
 
-  it("set_identity observes then marks the asserted identity verified", async () => {
+  it("set_identity observes but does not verify without trusted proof", async () => {
     const observed = makeEntity({
       identities: [
         {
@@ -252,7 +255,11 @@ describe("KNOWLEDGE_GRAPH action", () => {
       handle: "@pat",
     });
 
-    expect(result?.success).toBe(true);
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      error: "IDENTITY_VERIFICATION_REQUIRED",
+      mergedFrom: ["ent_2"],
+    });
     expect(stores.entityStore.observeIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
         platform: "slack",
@@ -260,7 +267,45 @@ describe("KNOWLEDGE_GRAPH action", () => {
         confidence: 1,
       }),
     );
-    // The re-upsert must flip the matching identity to verified.
+    expect(stores.entityStore.upsert).not.toHaveBeenCalled();
+  });
+
+  it("set_identity marks verified only with trusted matching proof", async () => {
+    const observed = makeEntity({
+      identities: [
+        {
+          platform: "slack",
+          handle: "@pat",
+          verified: false,
+          confidence: 1,
+          addedAt: "2026-01-01T00:00:00.000Z",
+          addedVia: "platform_observation",
+          evidence: ["user_chat"],
+        } satisfies EntityIdentity,
+      ],
+    });
+    stores.entityStore.observeIdentity.mockResolvedValueOnce({
+      entity: observed,
+      mergedFrom: ["ent_2"],
+    });
+
+    const result = await call(
+      {
+        op: "set_identity",
+        platform: "slack",
+        handle: "@pat",
+      },
+      {
+        identityVerification: {
+          platform: "slack",
+          handle: "@pat",
+          verified: true,
+          evidence: "slack_oauth_subject_match",
+        },
+      } as Partial<HandlerOptions>,
+    );
+
+    expect(result?.success).toBe(true);
     const upsertArg = stores.entityStore.upsert.mock.calls.at(
       -1,
     )?.[0] as Entity;
@@ -268,6 +313,10 @@ describe("KNOWLEDGE_GRAPH action", () => {
       (identity) => identity.platform === "slack" && identity.handle === "@pat",
     );
     expect(reasserted?.verified).toBe(true);
+    expect(reasserted?.evidence).toEqual([
+      "user_chat",
+      "slack_oauth_subject_match",
+    ]);
     expect(result?.data).toMatchObject({ mergedFrom: ["ent_2"] });
   });
 


### PR DESCRIPTION
## Summary
- stop `KNOWLEDGE_GRAPH set_identity` from marking user/planner asserted identities as verified
- record the observed identity, but return `IDENTITY_VERIFICATION_REQUIRED` unless a trusted handler-option verifier matches platform+handle
- allow verified writes only through a non-parameter `identityVerification` context with matching evidence
- update tests for untrusted assertion blocking and trusted proof success

## #12088
- Completes item 11: identity verification hard gate.

## Tests
- `bun run --cwd packages/core prebuild`
- `bun run --cwd plugins/plugin-relationships test -- test/entity-action.test.ts`
- `bunx @biomejs/biome check plugins/plugin-relationships/src/actions/entity.ts plugins/plugin-relationships/test/entity-action.test.ts`
- `git diff --check`

## Typecheck note
- `bun run --cwd plugins/plugin-relationships typecheck` is still blocked by existing workspace issues: `packages/agent/src/runtime/eliza.ts` missing `AppSessionService` on the app-manager import shape and the existing `@elizaos/cloud-routing` declaration gap.

## Evidence
- N/A real LLM trajectories: no model/prompt behavior changed; this is action-side authorization/verification logic.
- N/A screenshots/video: no visible UI changed.
- Domain artifact evidence: focused tests assert untrusted identity assertions are observed but not verified, and trusted matching verifier context is required before `verified: true` is written.
