### PR TITLE
refactor(agent): one loader owns plugin-local-inference server subpath layout (#12091 item 11)

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -52,6 +52,12 @@ import { startTrajectoryStepInDatabase } from "../runtime/trajectory-storage.ts"
 import { syncCharacterIntoConfig } from "../services/character-persistence.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import {
+  type LocalInferenceChatMetadata,
+  type LocalInferenceCommandIntent,
+  type LocalInferenceRouteApi,
+  loadLocalInferenceRouteApi,
+} from "./local-inference-server-api.ts";
+import {
   executeFallbackParsedActions,
   maybeHandleDirectBinanceSkillRequest,
   parseFallbackActionBlocks,
@@ -94,34 +100,10 @@ export type { ChatImageAttachment, LogEntry };
 
 const DEFAULT_CONVERSATION_TITLE_TIMEOUT_MS = 5_000;
 
-type LocalInferenceChatMetadata = Record<string, unknown>;
-type LocalInferenceCommandIntent =
-  | "cancel"
-  | "download"
-  | "redownload"
-  | "resume"
-  | "retry"
-  | "status"
-  | "switch_smaller"
-  | "use_cloud"
-  | "use_local";
-
-type LocalInferenceChatApi = {
-  getLocalInferenceChatStatus: (
-    intent: LocalInferenceCommandIntent,
-    error?: unknown,
-  ) => Promise<{
-    text: string;
-    localInference: LocalInferenceChatMetadata;
-  }>;
-  handleLocalInferenceChatCommand: (
-    intent: LocalInferenceCommandIntent,
-    prompt: string,
-  ) => Promise<{
-    text: string;
-    localInference: LocalInferenceChatMetadata;
-  }>;
-};
+type LocalInferenceChatApi = Pick<
+  LocalInferenceRouteApi,
+  "getLocalInferenceChatStatus" | "handleLocalInferenceChatCommand"
+>;
 
 let localInferenceChatApiPromise: Promise<LocalInferenceChatApi> | null = null;
 
@@ -129,12 +111,13 @@ let localInferenceChatApiPromise: Promise<LocalInferenceChatApi> | null = null;
  * Resolve the plugin-local-inference chat API used to turn a local-inference
  * failure into a user-facing status (download prompts, switch-model hints, …).
  *
- * An error-reporting path must NEVER throw. The mobile bundle can resolve the
- * dynamic `import("@elizaos/plugin-local-inference")` to a namespace whose named
- * export is `undefined` (tree-shake / circular-init artifact) — which previously
- * made the catch blocks throw `getLocalInferenceChatStatus is not a function`
- * and MASK the real error. So validate the import and fall back to a status
- * derived from the raw error, guaranteeing the actual failure surfaces.
+ * An error-reporting path must NEVER throw. On any platform the loaded module
+ * can carry an `undefined` named export (tree-shake / circular-init artifact) —
+ * which previously made the catch blocks throw
+ * `getLocalInferenceChatStatus is not a function` and MASK the real error. So
+ * validate the loaded functions and fall back to a status derived from the raw
+ * error, guaranteeing the actual failure surfaces. The always-real subpath is
+ * owned by `./local-inference-server-api.ts`.
  */
 function getLocalInferenceChatApi(): Promise<LocalInferenceChatApi> {
   localInferenceChatApiPromise ??=
@@ -155,9 +138,7 @@ function getLocalInferenceChatApi(): Promise<LocalInferenceChatApi> {
         }),
       };
       try {
-        const mod = (await import(
-          "@elizaos/plugin-local-inference"
-        )) as Partial<LocalInferenceChatApi>;
+        const mod = (await loadLocalInferenceRouteApi()) as Partial<LocalInferenceChatApi>;
         return {
           getLocalInferenceChatStatus:
             typeof mod.getLocalInferenceChatStatus === "function"

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -52,12 +52,6 @@ import { startTrajectoryStepInDatabase } from "../runtime/trajectory-storage.ts"
 import { syncCharacterIntoConfig } from "../services/character-persistence.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import {
-  type LocalInferenceChatMetadata,
-  type LocalInferenceCommandIntent,
-  type LocalInferenceRouteApi,
-  loadLocalInferenceRouteApi,
-} from "./local-inference-server-api.ts";
-import {
   executeFallbackParsedActions,
   maybeHandleDirectBinanceSkillRequest,
   parseFallbackActionBlocks,
@@ -81,6 +75,12 @@ import {
   isInsufficientCreditsError,
   isInsufficientCreditsMessage,
 } from "./credit-detection.ts";
+import {
+  type LocalInferenceChatMetadata,
+  type LocalInferenceCommandIntent,
+  type LocalInferenceRouteApi,
+  loadLocalInferenceRouteApi,
+} from "./local-inference-server-api.ts";
 import {
   buildWalletActionNotExecutedReply,
   cloneWithoutBlockedObjectKeys,
@@ -138,7 +138,8 @@ function getLocalInferenceChatApi(): Promise<LocalInferenceChatApi> {
         }),
       };
       try {
-        const mod = (await loadLocalInferenceRouteApi()) as Partial<LocalInferenceChatApi>;
+        const mod =
+          (await loadLocalInferenceRouteApi()) as Partial<LocalInferenceChatApi>;
         return {
           getLocalInferenceChatStatus:
             typeof mod.getLocalInferenceChatStatus === "function"

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -4,6 +4,7 @@ import { hasTextGenerationHandler } from "@elizaos/core";
 import type { ElizaConfig } from "../config/config.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
+import { loadLocalInferenceRouteApi } from "./local-inference-server-api.ts";
 
 type CloudHealthApi = {
   isCloudProvisionedContainer: () => boolean;
@@ -13,34 +14,13 @@ type CloudHealthApi = {
   ) => string | undefined;
 };
 
-type LocalInferenceHealthApi = {
-  getLocalInferenceActiveSnapshot: () => Promise<{
-    status?: string;
-    modelId?: string;
-  } | null>;
-};
-
 let cloudHealthApiPromise: Promise<CloudHealthApi> | null = null;
-let localInferenceHealthApiPromise: Promise<LocalInferenceHealthApi> | null =
-  null;
 
 function getCloudHealthApi(): Promise<CloudHealthApi> {
   cloudHealthApiPromise ??= import(
     "@elizaos/plugin-elizacloud"
   ) as Promise<CloudHealthApi>;
   return cloudHealthApiPromise;
-}
-
-function getLocalInferenceHealthApi(): Promise<LocalInferenceHealthApi> {
-  // Import the route module directly, NOT the package's bare entry. The mobile
-  // agent bundle stubs `@elizaos/plugin-local-inference` (the heavy Plugin entry)
-  // to a null module, so a bare import returns `{ getLocalInferenceActiveSnapshot:
-  // undefined }` and /api/status 500s. The deep subpath (the `./*` wildcard
-  // export) isn't stubbed and carries the real implementation on every platform.
-  localInferenceHealthApiPromise ??= import(
-    /* @vite-ignore */ "@elizaos/plugin-local-inference/local-inference-routes"
-  ) as Promise<LocalInferenceHealthApi>;
-  return localInferenceHealthApiPromise;
 }
 
 // ---------------------------------------------------------------------------
@@ -492,7 +472,7 @@ export async function handleHealthRoutes(
     let activeLocalModel: string | undefined;
     try {
       const { getLocalInferenceActiveSnapshot } =
-        await getLocalInferenceHealthApi();
+        await loadLocalInferenceRouteApi();
       const localInferenceActive =
         typeof getLocalInferenceActiveSnapshot === "function"
           ? await getLocalInferenceActiveSnapshot().catch(() => null)

--- a/packages/agent/src/api/local-inference-server-api.test.ts
+++ b/packages/agent/src/api/local-inference-server-api.test.ts
@@ -12,13 +12,11 @@ import * as loader from "./local-inference-server-api.ts";
  * subpath themselves — otherwise the stub knowledge is duplicated and drifts.
  */
 function readSibling(name: string): string {
-  return readFileSync(
-    fileURLToPath(new URL(name, import.meta.url)),
-    "utf8",
-  );
+  return readFileSync(fileURLToPath(new URL(name, import.meta.url)), "utf8");
 }
 
-const SUBPATH_IMPORT = /@elizaos\/plugin-local-inference\/(local-inference-routes|routes)\b/;
+const SUBPATH_IMPORT =
+  /@elizaos\/plugin-local-inference\/(local-inference-routes|routes)\b/;
 
 describe("local-inference-server-api loader (single subpath owner)", () => {
   it("exposes the two memoized subpath loaders", () => {
@@ -35,9 +33,9 @@ describe("local-inference-server-api loader (single subpath owner)", () => {
   });
 
   it("is the only api-route file that names the plugin subpaths", () => {
-    expect(SUBPATH_IMPORT.test(readSibling("./local-inference-server-api.ts"))).toBe(
-      true,
-    );
+    expect(
+      SUBPATH_IMPORT.test(readSibling("./local-inference-server-api.ts")),
+    ).toBe(true);
     for (const consumer of [
       "./server.ts",
       "./health-routes.ts",

--- a/packages/agent/src/api/local-inference-server-api.test.ts
+++ b/packages/agent/src/api/local-inference-server-api.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import * as loader from "./local-inference-server-api.ts";
+
+/**
+ * `local-inference-server-api.ts` is the ONE file in packages/agent that knows
+ * the plugin's stub/subpath layout: the mobile agent bundle null-stubs the bare
+ * `@elizaos/plugin-local-inference` entry but leaves the deep `./local-inference-routes`
+ * and `./routes` subpaths real on every platform. server.ts, health-routes.ts
+ * and chat-routes.ts must therefore consume THIS loader and never hand-pick a
+ * subpath themselves — otherwise the stub knowledge is duplicated and drifts.
+ */
+function readSibling(name: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(name, import.meta.url)),
+    "utf8",
+  );
+}
+
+const SUBPATH_IMPORT = /@elizaos\/plugin-local-inference\/(local-inference-routes|routes)\b/;
+
+describe("local-inference-server-api loader (single subpath owner)", () => {
+  it("exposes the two memoized subpath loaders", () => {
+    expect(typeof loader.loadLocalInferenceRouteApi).toBe("function");
+    expect(typeof loader.loadLocalInferenceVoiceRouteApi).toBe("function");
+    // Same call → same in-flight promise (memoized), so a warm route dispatch
+    // never re-imports the plugin subpath.
+    const a = loader.loadLocalInferenceRouteApi();
+    const b = loader.loadLocalInferenceRouteApi();
+    expect(a).toBe(b);
+    // Swallow the (possibly rejecting) import — resolvability is environmental;
+    // this test asserts identity + ownership, not the plugin body.
+    void a.catch(() => {});
+  });
+
+  it("is the only api-route file that names the plugin subpaths", () => {
+    expect(SUBPATH_IMPORT.test(readSibling("./local-inference-server-api.ts"))).toBe(
+      true,
+    );
+    for (const consumer of [
+      "./server.ts",
+      "./health-routes.ts",
+      "./chat-routes.ts",
+    ]) {
+      expect(SUBPATH_IMPORT.test(readSibling(consumer))).toBe(false);
+    }
+  });
+
+  it("keeps consumers off the null-stubbed bare entry", () => {
+    // health + server resolve everything through the loader; chat-routes loads
+    // the loader too (its real chat-status fns live on the same subpath).
+    for (const consumer of ["./server.ts", "./health-routes.ts"]) {
+      expect(readSibling(consumer)).not.toMatch(
+        /import\([^)]*"@elizaos\/plugin-local-inference"/,
+      );
+    }
+  });
+});

--- a/packages/agent/src/api/local-inference-server-api.ts
+++ b/packages/agent/src/api/local-inference-server-api.ts
@@ -1,0 +1,115 @@
+import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
+
+/**
+ * Single owner of the `@elizaos/plugin-local-inference` subpath layout for the
+ * agent's HTTP server.
+ *
+ * The mobile agent bundle null-stubs the plugin's *bare* entry
+ * (`@elizaos/plugin-local-inference`, the heavy `Plugin` object) via an exact
+ * alias in `scripts/build-mobile-bundle.mjs`, so a bare import yields `undefined`
+ * handlers and every `/api/local-inference/*`, `/api/status`, and local chat
+ * status path fails on-device. The deep route subpaths (`./local-inference-routes`
+ * and `./routes`) are matched by the same anchored stub regex and are therefore
+ * NOT stubbed — they carry the real implementations on every platform.
+ *
+ * This module is the ONLY file in `packages/agent` that encodes that
+ * stub/subpath knowledge. Every server-side consumer (server routing, health,
+ * chat) imports the typed loaders below instead of hand-picking a subpath.
+ */
+
+/** Route + chat surface exported by `.../local-inference-routes`. */
+export type LocalInferenceRouteApi = {
+  getLocalInferenceActiveModelId: () => string | undefined;
+  getLocalInferenceActiveSnapshot: () => Promise<{
+    status?: string;
+    modelId?: string;
+  } | null>;
+  handleLocalInferenceRoutes: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ) => Promise<boolean>;
+  getLocalInferenceChatStatus: (
+    intent: LocalInferenceCommandIntent,
+    error?: unknown,
+  ) => Promise<{
+    text: string;
+    localInference: LocalInferenceChatMetadata;
+  }>;
+  handleLocalInferenceChatCommand: (
+    intent: LocalInferenceCommandIntent,
+    prompt: string,
+  ) => Promise<{
+    text: string;
+    localInference: LocalInferenceChatMetadata;
+  }>;
+};
+
+/** Voice (TTS/ASR/diarization) surface exported by `.../routes`. */
+export type LocalInferenceVoiceRouteApi = {
+  handleLocalInferenceTtsRoute: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    state: { current: AgentRuntime | null },
+  ) => Promise<boolean>;
+  handleLocalInferenceAsrRoute: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    state: { current: AgentRuntime | null },
+  ) => Promise<boolean>;
+  handleLiveDiarizationRoute: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    state: { current: AgentRuntime | null },
+  ) => Promise<boolean>;
+};
+
+export type LocalInferenceChatMetadata = Record<string, unknown>;
+
+export type LocalInferenceCommandIntent =
+  | "cancel"
+  | "download"
+  | "redownload"
+  | "resume"
+  | "retry"
+  | "status"
+  | "switch_smaller"
+  | "use_cloud"
+  | "use_local";
+
+let routeApiPromise: Promise<LocalInferenceRouteApi> | null = null;
+let voiceRouteApiPromise: Promise<LocalInferenceVoiceRouteApi> | null = null;
+
+/**
+ * Load the local-inference route + chat API from the always-real
+ * `./local-inference-routes` subpath. A cold-boot import failure must not poison
+ * the memo: `??=` would otherwise cache the rejection and fail EVERY dependent
+ * route for the process lifetime, so the memo is cleared on reject and the next
+ * caller retries once the deferred plugin closure is resolvable.
+ */
+export function loadLocalInferenceRouteApi(): Promise<LocalInferenceRouteApi> {
+  routeApiPromise ??= (
+    import(
+      /* @vite-ignore */ "@elizaos/plugin-local-inference/local-inference-routes"
+    ) as Promise<LocalInferenceRouteApi>
+  ).catch((err: unknown) => {
+    routeApiPromise = null;
+    throw err;
+  });
+  return routeApiPromise;
+}
+
+/**
+ * Load the local-inference voice (TTS/ASR/diarization) API from the always-real
+ * `./routes` subpath. Same clear-on-reject memo semantics as
+ * {@link loadLocalInferenceRouteApi}.
+ */
+export function loadLocalInferenceVoiceRouteApi(): Promise<LocalInferenceVoiceRouteApi> {
+  voiceRouteApiPromise ??= (
+    import(/* @vite-ignore */ "@elizaos/plugin-local-inference/routes") as Promise<LocalInferenceVoiceRouteApi>
+  ).catch((err: unknown) => {
+    voiceRouteApiPromise = null;
+    throw err;
+  });
+  return voiceRouteApiPromise;
+}

--- a/packages/agent/src/api/local-inference-server-api.ts
+++ b/packages/agent/src/api/local-inference-server-api.ts
@@ -106,7 +106,9 @@ export function loadLocalInferenceRouteApi(): Promise<LocalInferenceRouteApi> {
  */
 export function loadLocalInferenceVoiceRouteApi(): Promise<LocalInferenceVoiceRouteApi> {
   voiceRouteApiPromise ??= (
-    import(/* @vite-ignore */ "@elizaos/plugin-local-inference/routes") as Promise<LocalInferenceVoiceRouteApi>
+    import(
+      /* @vite-ignore */ "@elizaos/plugin-local-inference/routes"
+    ) as Promise<LocalInferenceVoiceRouteApi>
   ).catch((err: unknown) => {
     voiceRouteApiPromise = null;
     throw err;

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -164,77 +164,21 @@ const optionalPluginImports = {
   workflow: () => importOptionalPlugin("@elizaos/plugin-workflow"),
 };
 
-type LocalInferenceServerApi = {
-  getLocalInferenceActiveModelId: () => string | undefined;
-  handleLocalInferenceRoutes: (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-  ) => Promise<boolean>;
-  handleLocalInferenceTtsRoute?: (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    state: { current: AgentRuntime | null },
-  ) => Promise<boolean>;
-  handleLocalInferenceAsrRoute?: (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    state: { current: AgentRuntime | null },
-  ) => Promise<boolean>;
-  handleLiveDiarizationRoute?: (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    state: { current: AgentRuntime | null },
-  ) => Promise<boolean>;
-};
+type LocalInferenceServerApi = LocalInferenceRouteApi & LocalInferenceVoiceRouteApi;
 
-let localInferenceServerApiPromise: Promise<LocalInferenceServerApi> | null =
-  null;
-
-function getLocalInferenceServerApi(): Promise<LocalInferenceServerApi> {
-  // Import the route modules directly, NOT the package's bare entry: the mobile
-  // agent bundle stubs `@elizaos/plugin-local-inference` (the heavy Plugin entry)
-  // to a null module, so a bare import yields undefined handlers and every
-  // /api/local-inference/* route 404s on-device. The deep subpaths (the `./*`
-  // wildcard + `./routes` exports) aren't stubbed and carry the real impls on
-  // every platform.
-  localInferenceServerApiPromise ??=
-    (async (): Promise<LocalInferenceServerApi> => {
-      const [routes, ttsRoutes] = await Promise.all([
-        import(
-          /* @vite-ignore */ "@elizaos/plugin-local-inference/local-inference-routes"
-        ) as Promise<
-          Pick<
-            LocalInferenceServerApi,
-            "getLocalInferenceActiveModelId" | "handleLocalInferenceRoutes"
-          >
-        >,
-        import(
-          /* @vite-ignore */ "@elizaos/plugin-local-inference/routes"
-        ) as Promise<
-          Pick<
-            LocalInferenceServerApi,
-            | "handleLocalInferenceTtsRoute"
-            | "handleLocalInferenceAsrRoute"
-            | "handleLiveDiarizationRoute"
-          >
-        >,
-      ]);
-      return {
-        getLocalInferenceActiveModelId: routes.getLocalInferenceActiveModelId,
-        handleLocalInferenceRoutes: routes.handleLocalInferenceRoutes,
-        handleLocalInferenceTtsRoute: ttsRoutes.handleLocalInferenceTtsRoute,
-        handleLocalInferenceAsrRoute: ttsRoutes.handleLocalInferenceAsrRoute,
-        handleLiveDiarizationRoute: ttsRoutes.handleLiveDiarizationRoute,
-      };
-    })().catch((err: unknown) => {
-      // A cold-boot import failure must not poison the memoized promise: `??=`
-      // would otherwise cache the rejection and 404 EVERY /api/local-inference/*
-      // route for the lifetime of the process. Clear the memo so the next request
-      // retries once the deferred plugin closure is resolvable.
-      localInferenceServerApiPromise = null;
-      throw err;
-    });
-  return localInferenceServerApiPromise;
+/**
+ * Combine the route + voice surfaces from the single subpath-owning loader
+ * (`./local-inference-server-api.ts`). The loaders there own the stub/subpath
+ * knowledge and each clear their memo on reject, so a cold-boot import failure
+ * surfaces here and retries on the next request — the same semantics as before,
+ * without this file knowing the plugin's stub layout.
+ */
+async function getLocalInferenceServerApi(): Promise<LocalInferenceServerApi> {
+  const [routeApi, voiceApi] = await Promise.all([
+    loadLocalInferenceRouteApi(),
+    loadLocalInferenceVoiceRouteApi(),
+  ]);
+  return { ...routeApi, ...voiceApi };
 }
 
 async function getOptionalPluginApi<T>(
@@ -430,6 +374,12 @@ import { persistConfigEnv } from "./config-env.ts";
 import { wireCoordinatorBridgesWhenReady } from "./coordinator-wiring.ts";
 import { createDeliveryDedupeState } from "./delivery-dedupe.ts";
 import { computeCanRespond } from "./health-routes.ts";
+import {
+  type LocalInferenceRouteApi,
+  type LocalInferenceVoiceRouteApi,
+  loadLocalInferenceRouteApi,
+  loadLocalInferenceVoiceRouteApi,
+} from "./local-inference-server-api.ts";
 import { pushWithBatchEvict } from "./memory-bounds.ts";
 import {
   buildPluginDiagnosticEntry,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -164,7 +164,8 @@ const optionalPluginImports = {
   workflow: () => importOptionalPlugin("@elizaos/plugin-workflow"),
 };
 
-type LocalInferenceServerApi = LocalInferenceRouteApi & LocalInferenceVoiceRouteApi;
+type LocalInferenceServerApi = LocalInferenceRouteApi &
+  LocalInferenceVoiceRouteApi;
 
 /**
  * Combine the route + voice surfaces from the single subpath-owning loader


### PR DESCRIPTION
## What

`server.ts`, `health-routes.ts` and `chat-routes.ts` each hand-encoded the same stub/subpath knowledge: the mobile agent bundle null-stubs the bare `@elizaos/plugin-local-inference` entry (`build-mobile-bundle.mjs` exact-alias), so each file separately imported a deep subpath (`./local-inference-routes`, `./routes`) and re-explained why. `chat-routes.ts` imported the *bare* (stubbed) entry, so on-device it fell back instead of using the real chat-status functions — which actually live on the always-real `./local-inference-routes` subpath.

This introduces **one** owner — `packages/agent/src/api/local-inference-server-api.ts` — exporting two typed, memoized, clear-on-reject loaders (`loadLocalInferenceRouteApi` / `loadLocalInferenceVoiceRouteApi`). server/health/chat all consume it.

## Why it's simpler

One file knows the plugin stub/subpath layout instead of three. The cold-boot clear-on-reject memo (a real fix: a poisoned memo 404s every local-inference route for the process lifetime) is defined once. chat-status on-device is upgraded from a degraded fallback to the real implementation.

No behavior change on desktop/server.

## Done-when evidence

- **Exactly one file** in `packages/agent` names the plugin subpaths: `grep -rln 'plugin-local-inference/local-inference-routes|plugin-local-inference/routes"' packages/agent/src/api/` → `local-inference-server-api.ts` only.
- `/api/local-inference/*` routing unchanged (server combines both surfaces); `chat-routes` uses the same loader.
- New `local-inference-server-api.test.ts` asserts the sole-owner invariant + loader memoization identity; touched suites (loader + health canRespond + chat-status SSE) = **11/11 pass**.
- Agent typecheck clean for all touched files (the only agent typecheck errors on develop are pre-existing `publicReason` drift in `plugin-remote-manifest/descriptor.ts` — unrelated to this change).

Refs #12091 (item 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)