### PR TITLE
refactor(core,agent,streaming): ScreenCaptureService contract replaces dead __elizaScreenCapture global (#12091 item 12)

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 import {
   type AgentRuntime,
   type IAgentRuntime,
+  type IScreenCaptureService,
   isStreamingDestinationConfigured,
   logger,
   NotificationService,
@@ -4376,18 +4377,13 @@ export async function startApiServer(opts?: {
             "[eliza-api] @elizaos/plugin-streaming did not export handleStreamRoute; skipping streaming route registration.",
           );
         }
-        // Screen capture manager is injected by the desktop host via globalThis
-        const screenCapture = (globalThis as Record<string, unknown>)
-          .__elizaScreenCapture as
-          | {
-              isFrameCaptureActive(): boolean;
-              startFrameCapture(opts: {
-                fps?: number;
-                quality?: number;
-                endpoint?: string;
-              }): Promise<void>;
-            }
-          | undefined;
+        // Desktop screen-capture bridge, resolved via the runtime service the
+        // desktop host registers (never a globalThis bridge). Absent on
+        // mobile/web/cloud → streaming falls back to another capture mode.
+        const screenCapture =
+          state.runtime?.getService<IScreenCaptureService>(
+            ServiceType.SCREEN_CAPTURE,
+          ) ?? undefined;
 
         // Build destination registry — all configured destinations
         const _connectors = state.config.connectors ?? {};

--- a/packages/core/src/types/service-interfaces.ts
+++ b/packages/core/src/types/service-interfaces.ts
@@ -354,6 +354,36 @@ export abstract class IMediaGenerationService extends Service {
 // Browser Interfaces
 // ============================================================================
 
+/** Options for {@link IScreenCaptureService.startFrameCapture}. */
+export interface ScreenCaptureFrameOptions {
+	fps?: number;
+	quality?: number;
+	/** Agent HTTP endpoint the captured JPEG frames are POSTed to. */
+	endpoint?: string;
+	/** When set, capture a game/canvas URL instead of the app window. */
+	gameUrl?: string;
+}
+
+/**
+ * Desktop screen-capture bridge. The desktop host registers a working
+ * implementation via `runtime.registerService`; server + streaming route code
+ * resolves it with `runtime.getService(ServiceType.SCREEN_CAPTURE)` instead of a
+ * `globalThis` bridge. Absent (e.g. mobile/web) → capture falls back to another
+ * mode.
+ */
+export abstract class IScreenCaptureService extends Service {
+	static override readonly serviceType = ServiceType.SCREEN_CAPTURE;
+
+	public readonly capabilityDescription =
+		"Desktop screen/frame capture for live streaming";
+
+	abstract isFrameCaptureActive(): boolean;
+
+	abstract startFrameCapture(options: ScreenCaptureFrameOptions): Promise<void>;
+
+	abstract stopFrameCapture(): void;
+}
+
 export abstract class IBrowserService extends Service {
 	static override readonly serviceType = ServiceType.BROWSER;
 

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -41,6 +41,7 @@ export interface ServiceTypeRegistry {
 	CHANNEL_TOPICS: "channel_topics";
 	COMMANDS: "commands";
 	MOBILE_DEVICE_BRIDGE: "mobile_device_bridge";
+	SCREEN_CAPTURE: "screen_capture";
 	UNKNOWN: "unknown";
 }
 
@@ -138,6 +139,7 @@ export const ServiceType = {
 	CHANNEL_TOPICS: "channel_topics",
 	COMMANDS: "commands",
 	MOBILE_DEVICE_BRIDGE: "mobile_device_bridge",
+	SCREEN_CAPTURE: "screen_capture",
 	UNKNOWN: "unknown",
 } as const;
 

--- a/plugins/plugin-streaming/src/api/detect-capture-mode.test.ts
+++ b/plugins/plugin-streaming/src/api/detect-capture-mode.test.ts
@@ -1,0 +1,38 @@
+import { ServiceType } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectCaptureMode } from "./stream-routes.js";
+
+/**
+ * `detectCaptureMode` selects the FFmpeg input mode. The desktop screen-capture
+ * bridge is now discovered by the caller via
+ * `runtime.getService(ServiceType.SCREEN_CAPTURE)` (a typed
+ * {@link IScreenCaptureService}) and passed in explicitly — never read from a
+ * producerless globalThis screen-capture bridge (the old dead contract).
+ */
+describe("detectCaptureMode", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("exposes a canonical SCREEN_CAPTURE service type", () => {
+    expect(ServiceType.SCREEN_CAPTURE).toBe("screen_capture");
+  });
+
+  it("selects pipe when the desktop screen-capture service is present", () => {
+    delete process.env.STREAM_MODE;
+    expect(detectCaptureMode(true)).toBe("pipe");
+  });
+
+  it("does not select pipe from the bridge when the service is absent", () => {
+    delete process.env.STREAM_MODE;
+    delete process.env.DISPLAY;
+    // With no bridge and no DISPLAY, it falls through to a non-pipe mode.
+    expect(detectCaptureMode(false)).not.toBe("pipe");
+  });
+
+  it("honors an explicit STREAM_MODE override regardless of the bridge", () => {
+    process.env.STREAM_MODE = "x11grab";
+    expect(detectCaptureMode(true)).toBe("x11grab");
+  });
+});

--- a/plugins/plugin-streaming/src/api/stream-route-state.ts
+++ b/plugins/plugin-streaming/src/api/stream-route-state.ts
@@ -1,3 +1,4 @@
+import type { IScreenCaptureService } from "@elizaos/core";
 import type { StreamingDestination } from "./streaming-types.js";
 
 export interface StreamRouteState {
@@ -24,16 +25,7 @@ export interface StreamRouteState {
   };
   port?: number;
   captureUrl?: string;
-  screenCapture?: {
-    isFrameCaptureActive(): boolean;
-    startFrameCapture(opts: {
-      fps?: number;
-      quality?: number;
-      endpoint?: string;
-      gameUrl?: string;
-    }): Promise<void>;
-    stopFrameCapture?(): void;
-  };
+  screenCapture?: IScreenCaptureService;
   destinations: Map<string, StreamingDestination>;
   activeDestinationId?: string;
   activeStreamSource: {

--- a/plugins/plugin-streaming/src/api/stream-routes.ts
+++ b/plugins/plugin-streaming/src/api/stream-routes.ts
@@ -864,7 +864,7 @@ export async function handleStreamRoute(
 
       // Stop current frame capture if active
       if (state.screenCapture?.isFrameCaptureActive()) {
-        state.screenCapture.stopFrameCapture?.();
+        state.screenCapture.stopFrameCapture();
       }
 
       // Build capture options

--- a/plugins/plugin-streaming/src/api/stream-routes.ts
+++ b/plugins/plugin-streaming/src/api/stream-routes.ts
@@ -144,8 +144,15 @@ function error(res: ServerResponse, message: string, status: number): void {
  * 4. macOS -> "avfoundation" (native screen capture)
  * 5. Fallback -> "file" (Puppeteer CDP -> temp JPEG -> FFmpeg)
  */
-/** @internal Exported for testing. */
-export function detectCaptureMode(): StreamConfig["inputMode"] {
+/**
+ * @internal Exported for testing.
+ * @param hasScreenCaptureBridge whether the desktop host registered a
+ *   {@link IScreenCaptureService} (resolved by the caller via `getService`),
+ *   which selects "pipe" mode. Never read from a `globalThis` bridge.
+ */
+export function detectCaptureMode(
+  hasScreenCaptureBridge: boolean,
+): StreamConfig["inputMode"] {
   const explicit = process.env.STREAM_MODE;
   if (explicit === "ui" || explicit === "pipe") return "pipe";
   if (explicit === "x11grab") return "x11grab";
@@ -154,7 +161,7 @@ export function detectCaptureMode(): StreamConfig["inputMode"] {
   if (explicit === "file") return "file";
 
   // Desktop bridge -> pipe mode
-  if ("__elizaScreenCapture" in (globalThis as Record<string, unknown>)) {
+  if (hasScreenCaptureBridge) {
     return "pipe";
   }
 
@@ -263,7 +270,7 @@ async function startStreamPipeline(
   }
   const destId = activeDest?.id ?? null;
 
-  const mode = detectCaptureMode();
+  const mode = detectCaptureMode(Boolean(state.screenCapture));
 
   const audioSource = process.env.STREAM_AUDIO_SOURCE ?? "silent";
   const audioDevice = process.env.STREAM_AUDIO_DEVICE;


### PR DESCRIPTION
## What & why

#12091 item 12: replace the dead `globalThis.__elizaScreenCapture` bridge with a typed service contract. Server and streaming code now route screen-capture availability through `ServiceType.SCREEN_CAPTURE` / `IScreenCaptureService` instead of a producerless global.

## Changes

- Added `ServiceType.SCREEN_CAPTURE` and `IScreenCaptureService` to core service types.
- Updated agent stream route handling to resolve screen capture through runtime services.
- Updated plugin-streaming stream route state/capture mode selection to use the typed service contract.
- Added `detect-capture-mode.test.ts` coverage for service-present, service-absent, and explicit override paths.
- Rebased stale-base compatibility for the remote plugin descriptor `publicReason` route field.

## Current sync

- Base: `origin/develop` `f9c923e385d0e96e50d38f42af18a7bbb0567353`
- Head: `2afbef2c494805cfc07254a682655d4104d2d517`

## Validation

- `git diff --check`
- `bunx @biomejs/biome check $(git diff --name-only --diff-filter=ACMR origin/develop...HEAD)` -> 6 files clean
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/agent test -- remote-plugin-bridge.test.ts` -> 13 tests passed
- `bun run --cwd plugins/plugin-streaming typecheck`
- `bun run --cwd plugins/plugin-streaming test -- detect-capture-mode.test.ts` -> 4 tests passed
- `bun run --cwd packages/plugin-remote-manifest typecheck`
- Manual runtime check after core build: `ServiceType.SCREEN_CAPTURE` resolves to `screen_capture` from package import.

## Notes

Agent tests still print the existing package export-order warning for `app-session-gate` (`types` after `default`); tests pass.
