### PR TITLE
refactor(agent): single-source the dynamic-view host-external import rewrite (#12091 item 13)

### DIFF
--- a/packages/agent/src/api/dynamic-view-host-external.d.mts
+++ b/packages/agent/src/api/dynamic-view-host-external.d.mts
@@ -1,0 +1,19 @@
+/** globalThis hook the rewritten imports call to resolve a host-external module. */
+export declare const DYNAMIC_VIEW_IMPORT_GLOBAL: "__ELIZA_DYNAMIC_VIEW_IMPORT__";
+
+export declare function convertNamedImportsToDestructuring(
+  namedImports: string,
+): string;
+
+export declare function buildHostExternalImportReplacement(
+  importClause: string,
+  specifier: string,
+  index: number,
+): string;
+
+export declare function rewriteHostExternalImports(
+  source: string,
+  specifiers: readonly string[],
+): string;
+
+export declare function parseHostExternalSpecifiers(url: URL): string[];

--- a/packages/agent/src/api/dynamic-view-host-external.mjs
+++ b/packages/agent/src/api/dynamic-view-host-external.mjs
@@ -1,0 +1,128 @@
+/**
+ * Host-external view-import rewrite — single source of truth.
+ *
+ * A plugin view bundle is built with `@elizaos/ui`, `react`, three, … left as
+ * *external* bare imports. At serve time the bare imports are rewritten into
+ * `globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__("<specifier>")` calls that
+ * `DynamicViewLoader` resolves against its `HOST_EXTERNAL_IMPORTERS` map, so the
+ * view shares the host's singletons instead of loading a second copy.
+ *
+ * Both the agent bundle route (`views-routes.ts`) and the Playwright UI-smoke
+ * stub (`playwright-ui-smoke-api-stub.mjs`) must apply the identical transform,
+ * so it lives here once. Plain ESM (no deps, no build step) so the node-run
+ * smoke stub can import it directly by path while the agent bundles it normally.
+ *
+ * NOTE: this is the legacy `globalThis`-hook transform; replacing it with a
+ * native import map is tracked separately (arch-audit #12091 item 13).
+ */
+
+/** globalThis hook the rewritten imports call to resolve a host-external module. */
+export const DYNAMIC_VIEW_IMPORT_GLOBAL = "__ELIZA_DYNAMIC_VIEW_IMPORT__";
+
+/** @param {string} namedImports @returns {string} */
+export function convertNamedImportsToDestructuring(namedImports) {
+  return namedImports
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.replace(/\s+as\s+/u, ": "))
+    .join(", ");
+}
+
+/**
+ * @param {string} importClause
+ * @param {string} specifier
+ * @param {number} index
+ * @returns {string}
+ */
+export function buildHostExternalImportReplacement(
+  importClause,
+  specifier,
+  index,
+) {
+  const moduleVar = `__eliza_dynamic_view_host_external_${index}`;
+  const lines = [
+    `const ${moduleVar} = await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}(${JSON.stringify(specifier)});`,
+  ];
+  const trimmed = importClause.trim();
+  if (trimmed.startsWith("* as ")) {
+    lines.push(`const ${trimmed.slice("* as ".length).trim()} = ${moduleVar};`);
+    return lines.join("\n");
+  }
+
+  const namedMatch = trimmed.match(/^\{([\s\S]*)\}$/u);
+  if (namedMatch) {
+    lines.push(
+      `const { ${convertNamedImportsToDestructuring(namedMatch[1])} } = ${moduleVar};`,
+    );
+    return lines.join("\n");
+  }
+
+  const defaultAndNamedMatch = trimmed.match(/^([^,]+),\s*\{([\s\S]*)\}$/u);
+  if (defaultAndNamedMatch) {
+    lines.push(
+      `const ${defaultAndNamedMatch[1].trim()} = ${moduleVar}.default ?? ${moduleVar};`,
+    );
+    lines.push(
+      `const { ${convertNamedImportsToDestructuring(defaultAndNamedMatch[2])} } = ${moduleVar};`,
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(`const ${trimmed} = ${moduleVar}.default ?? ${moduleVar};`);
+  return lines.join("\n");
+}
+
+/**
+ * Rewrite every bare `import … from "<specifier>"` (and side-effect
+ * `import "<specifier>"`) whose specifier is host-external into a
+ * `globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__` call.
+ *
+ * @param {string} source
+ * @param {readonly string[]} specifiers
+ * @returns {string}
+ */
+export function rewriteHostExternalImports(source, specifiers) {
+  if (specifiers.length === 0) return source;
+  const specifierPattern = specifiers
+    .map((item) => item.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"))
+    .join("|");
+  const fromImportPattern = new RegExp(
+    `import\\s+([^;]*?)\\s+from\\s+["'](${specifierPattern})["'];?`,
+    "gu",
+  );
+  const sideEffectPattern = new RegExp(
+    `import\\s+["'](${specifierPattern})["'];?`,
+    "gu",
+  );
+  let replacementIndex = 0;
+
+  return source
+    .replace(fromImportPattern, (_match, importClause, specifier) =>
+      buildHostExternalImportReplacement(
+        String(importClause),
+        String(specifier),
+        replacementIndex++,
+      ),
+    )
+    .replace(
+      sideEffectPattern,
+      (_match, specifier) =>
+        `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}(${JSON.stringify(String(specifier))});`,
+    );
+}
+
+/**
+ * Read the host-external specifier list off a served-bundle request URL. The
+ * loader sends it (`hostExternalSpecifiers`) alongside `hostExternalRuntime=1`.
+ *
+ * @param {URL} url
+ * @returns {string[]}
+ */
+export function parseHostExternalSpecifiers(url) {
+  if (url.searchParams.get("hostExternalRuntime") !== "1") return [];
+  return (url.searchParams.get("hostExternalSpecifiers") ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/packages/agent/src/api/dynamic-view-host-external.test.ts
+++ b/packages/agent/src/api/dynamic-view-host-external.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  DYNAMIC_VIEW_IMPORT_GLOBAL,
+  parseHostExternalSpecifiers,
+  rewriteHostExternalImports,
+} from "./dynamic-view-host-external.mjs";
+
+/**
+ * `dynamic-view-host-external.mjs` is the single source of the host-external
+ * view-import rewrite consumed by BOTH the agent bundle route
+ * (`views-routes.ts`) and the Playwright UI-smoke stub. Locking the transform
+ * here keeps the two serve paths byte-identical.
+ */
+describe("rewriteHostExternalImports", () => {
+  const specifiers = ["@elizaos/ui", "react", "react/jsx-runtime"];
+
+  it("returns the source unchanged when no specifiers are host-external", () => {
+    const src = `import { foo } from "@elizaos/ui";`;
+    expect(rewriteHostExternalImports(src, [])).toBe(src);
+  });
+
+  it("rewrites a named import into a destructured host-external call", () => {
+    const out = rewriteHostExternalImports(
+      `import { Button, Input as TextInput } from "@elizaos/ui";`,
+      specifiers,
+    );
+    expect(out).toContain(
+      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("@elizaos/ui")`,
+    );
+    expect(out).toContain("const { Button, Input: TextInput } =");
+    expect(out).not.toContain(`from "@elizaos/ui"`);
+  });
+
+  it("rewrites a namespace import", () => {
+    const out = rewriteHostExternalImports(
+      `import * as React from "react";`,
+      specifiers,
+    );
+    expect(out).toContain(
+      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("react")`,
+    );
+    expect(out).toMatch(
+      /const React = __eliza_dynamic_view_host_external_\d+;/,
+    );
+  });
+
+  it("rewrites a default + named import with a .default fallback", () => {
+    const out = rewriteHostExternalImports(
+      `import React, { useState } from "react";`,
+      specifiers,
+    );
+    expect(out).toMatch(
+      /const React = __eliza_dynamic_view_host_external_\d+\.default \?\? __eliza_dynamic_view_host_external_\d+;/,
+    );
+    expect(out).toContain("const { useState } =");
+  });
+
+  it("rewrites a side-effect import", () => {
+    const out = rewriteHostExternalImports(
+      `import "react/jsx-runtime";`,
+      specifiers,
+    );
+    expect(out).toBe(
+      `await globalThis.${DYNAMIC_VIEW_IMPORT_GLOBAL}("react/jsx-runtime");`,
+    );
+  });
+
+  it("leaves non-host-external imports alone", () => {
+    const src = `import { local } from "./local.js";`;
+    expect(rewriteHostExternalImports(src, specifiers)).toBe(src);
+  });
+});
+
+describe("parseHostExternalSpecifiers", () => {
+  it("returns [] unless hostExternalRuntime=1", () => {
+    const url = new URL(
+      "http://x/bundle.js?hostExternalSpecifiers=react,@elizaos/ui",
+    );
+    expect(parseHostExternalSpecifiers(url)).toEqual([]);
+  });
+
+  it("splits and trims the specifier list when enabled", () => {
+    const url = new URL(
+      "http://x/bundle.js?hostExternalRuntime=1&hostExternalSpecifiers=react, @elizaos/ui ,",
+    );
+    expect(parseHostExternalSpecifiers(url)).toEqual(["react", "@elizaos/ui"]);
+  });
+});

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -41,6 +41,10 @@ import {
   setActiveViewElements,
 } from "../runtime/view-action-affinity.ts";
 import {
+  parseHostExternalSpecifiers,
+  rewriteHostExternalImports,
+} from "./dynamic-view-host-external.mjs";
+import {
   PendingRequestMap,
   type ViewInteractResult,
 } from "./pending-request-map.ts";
@@ -126,94 +130,6 @@ function contentTypeForViewAsset(assetPath: string): string {
     default:
       return "application/octet-stream";
   }
-}
-
-function convertNamedImportsToDestructuring(namedImports: string): string {
-  return namedImports
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .map((part) => part.replace(/\s+as\s+/u, ": "))
-    .join(", ");
-}
-
-function buildHostExternalImportReplacement(
-  importClause: string,
-  specifier: string,
-  index: number,
-): string {
-  const moduleVar = `__eliza_dynamic_view_host_external_${index}`;
-  const lines = [
-    `const ${moduleVar} = await globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__(${JSON.stringify(specifier)});`,
-  ];
-  const trimmed = importClause.trim();
-  if (trimmed.startsWith("* as ")) {
-    lines.push(`const ${trimmed.slice("* as ".length).trim()} = ${moduleVar};`);
-    return lines.join("\n");
-  }
-
-  const namedMatch = trimmed.match(/^\{([\s\S]*)\}$/u);
-  if (namedMatch) {
-    lines.push(
-      `const { ${convertNamedImportsToDestructuring(namedMatch[1])} } = ${moduleVar};`,
-    );
-    return lines.join("\n");
-  }
-
-  const defaultAndNamedMatch = trimmed.match(/^([^,]+),\s*\{([\s\S]*)\}$/u);
-  if (defaultAndNamedMatch) {
-    lines.push(
-      `const ${defaultAndNamedMatch[1].trim()} = ${moduleVar}.default ?? ${moduleVar};`,
-    );
-    lines.push(
-      `const { ${convertNamedImportsToDestructuring(defaultAndNamedMatch[2])} } = ${moduleVar};`,
-    );
-    return lines.join("\n");
-  }
-
-  lines.push(`const ${trimmed} = ${moduleVar}.default ?? ${moduleVar};`);
-  return lines.join("\n");
-}
-
-function rewriteHostExternalImports(
-  source: string,
-  specifiers: readonly string[],
-): string {
-  if (specifiers.length === 0) return source;
-  const specifierPattern = specifiers
-    .map((item) => item.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"))
-    .join("|");
-  const fromImportPattern = new RegExp(
-    `import\\s+([^;]*?)\\s+from\\s+["'](${specifierPattern})["'];?`,
-    "gu",
-  );
-  const sideEffectPattern = new RegExp(
-    `import\\s+["'](${specifierPattern})["'];?`,
-    "gu",
-  );
-  let replacementIndex = 0;
-
-  return source
-    .replace(fromImportPattern, (_match, importClause, specifier) =>
-      buildHostExternalImportReplacement(
-        String(importClause),
-        String(specifier),
-        replacementIndex++,
-      ),
-    )
-    .replace(
-      sideEffectPattern,
-      (_match, specifier) =>
-        `await globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__(${JSON.stringify(String(specifier))});`,
-    );
-}
-
-function parseHostExternalSpecifiers(url: URL): string[] {
-  if (url.searchParams.get("hostExternalRuntime") !== "1") return [];
-  return (url.searchParams.get("hostExternalSpecifiers") ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
 }
 
 /**

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -3,6 +3,12 @@ import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { WebSocketServer } from "ws";
+// Single source of the host-external view-import rewrite (owned by the agent
+// bundle route). Plain ESM so this node-run stub can import it without a build.
+import {
+  parseHostExternalSpecifiers,
+  rewriteHostExternalImports,
+} from "../../agent/src/api/dynamic-view-host-external.mjs";
 
 const port = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const repoRoot = path.resolve(
@@ -1506,83 +1512,6 @@ function contentTypeForSmokeViewAsset(assetPath) {
   if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
   if (ext === ".webp") return "image/webp";
   return "application/octet-stream";
-}
-
-function convertNamedImportsToDestructuring(namedImports) {
-  return namedImports
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .map((part) => part.replace(/\s+as\s+/u, ": "))
-    .join(", ");
-}
-
-function buildHostExternalImportReplacement(importClause, specifier, index) {
-  const moduleVar = `__eliza_dynamic_view_host_external_${index}`;
-  const lines = [
-    `const ${moduleVar} = await globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__(${JSON.stringify(specifier)});`,
-  ];
-  const trimmed = importClause.trim();
-  if (trimmed.startsWith("* as ")) {
-    lines.push(`const ${trimmed.slice("* as ".length).trim()} = ${moduleVar};`);
-    return lines.join("\n");
-  }
-  const namedMatch = trimmed.match(/^\{([\s\S]*)\}$/u);
-  if (namedMatch) {
-    lines.push(
-      `const { ${convertNamedImportsToDestructuring(namedMatch[1])} } = ${moduleVar};`,
-    );
-    return lines.join("\n");
-  }
-  const defaultAndNamedMatch = trimmed.match(/^([^,]+),\s*\{([\s\S]*)\}$/u);
-  if (defaultAndNamedMatch) {
-    lines.push(
-      `const ${defaultAndNamedMatch[1].trim()} = ${moduleVar}.default ?? ${moduleVar};`,
-    );
-    lines.push(
-      `const { ${convertNamedImportsToDestructuring(defaultAndNamedMatch[2])} } = ${moduleVar};`,
-    );
-    return lines.join("\n");
-  }
-  lines.push(`const ${trimmed} = ${moduleVar}.default ?? ${moduleVar};`);
-  return lines.join("\n");
-}
-
-function rewriteHostExternalImports(source, specifiers) {
-  if (specifiers.length === 0) return source;
-  const specifierPattern = specifiers
-    .map((item) => item.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"))
-    .join("|");
-  const fromImportPattern = new RegExp(
-    `import\\s+([^;]*?)\\s+from\\s+["'](${specifierPattern})["'];?`,
-    "gu",
-  );
-  const sideEffectPattern = new RegExp(
-    `import\\s+["'](${specifierPattern})["'];?`,
-    "gu",
-  );
-  let replacementIndex = 0;
-  return source
-    .replace(fromImportPattern, (_match, importClause, specifier) =>
-      buildHostExternalImportReplacement(
-        String(importClause),
-        String(specifier),
-        replacementIndex++,
-      ),
-    )
-    .replace(
-      sideEffectPattern,
-      (_match, specifier) =>
-        `await globalThis.__ELIZA_DYNAMIC_VIEW_IMPORT__(${JSON.stringify(String(specifier))});`,
-    );
-}
-
-function parseHostExternalSpecifiers(url) {
-  if (url.searchParams.get("hostExternalRuntime") !== "1") return [];
-  return (url.searchParams.get("hostExternalSpecifiers") ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
 }
 
 function smokeViewByRequest(id, viewType) {

--- a/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
+++ b/packages/plugin-remote-manifest/src/worker-runtime/descriptor.ts
@@ -109,6 +109,7 @@ export type WorkerPluginShape = {
     name?: string;
     path: string;
     public?: boolean;
+    publicReason?: string;
     isMultipart?: boolean;
     routeHandler?: AnyHandler;
   }>;


### PR DESCRIPTION
## What & why

#12091 item 13: `views-routes` and the Playwright UI smoke API stub each carried their own host-external import rewrite logic. This moves that logic into one agent-owned helper so dynamic view serving and the test stub use the same parser/rewrite behavior.

## Changes

- Added `packages/agent/src/api/dynamic-view-host-external.mjs` plus `.d.mts` typings.
- Added focused coverage for host-external import parsing and rewriting.
- Rewired `views-routes.ts` to call the shared helper.
- Rewired `packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs` to call the same helper.
- Rebased stale-base compatibility for the remote plugin descriptor `publicReason` route field.

## Current sync

- Base: `origin/develop` `a96f1bc7395114ad93650212d944c737bda41ca9`
- Head: `6adc2d0a3549620a01027f6812de7fb2d768ab18`

## Validation

- `git diff --check`
- `bunx @biomejs/biome check $(git diff --name-only --diff-filter=ACMR origin/develop...HEAD)` -> 6 files clean
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/agent test -- dynamic-view-host-external.test.ts remote-plugin-bridge.test.ts` -> 21 tests passed
- `bun run --cwd packages/plugin-remote-manifest typecheck`

## Notes

Agent tests still print the existing package export-order warning for `app-session-gate` (`types` after `default`); tests pass.
