### PR TITLE
refactor(agent): extract E2B vendor sandbox backend to plugin-e2b-sandbox (#12092 item 11)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -155,7 +155,6 @@
         "crc-32": "^1.2.0",
         "diff3": "0.0.4",
         "drizzle-orm": "0.45.2",
-        "e2b": "^2.20.1",
         "esbuild": "^0.28.0",
         "ethers": "^6.16.0",
         "git-workspace-service": "0.4.5",
@@ -2745,9 +2744,19 @@
         "@elizaos/capacitor-camera": "workspace:*",
       },
       "peerDependencies": {
+        "@capacitor/app": "^8.0.0",
+        "@elizaos/capacitor-agent": "workspace:*",
+        "@elizaos/capacitor-llama": "workspace:*",
+        "llama-cpp-capacitor": "^0.1.5",
         "react": "19.2.5",
         "react-dom": "19.2.5",
       },
+      "optionalPeers": [
+        "@capacitor/app",
+        "@elizaos/capacitor-agent",
+        "@elizaos/capacitor-llama",
+        "llama-cpp-capacitor",
+      ],
     },
     "packages/vault": {
       "name": "@elizaos/vault",
@@ -3367,6 +3376,21 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+      },
+    },
+    "plugins/plugin-e2b-sandbox": {
+      "name": "@elizaos/plugin-e2b-sandbox",
+      "version": "1.0.0",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "e2b": "^2.20.1",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.5.2",
+        "@types/node": "^25.0.3",
+        "bun-types": "^1.2.25",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.0",
       },
     },
     "plugins/plugin-edge-tts": {
@@ -6451,6 +6475,8 @@
     "@elizaos/plugin-discord-local": ["@elizaos/plugin-discord-local@workspace:plugins/plugin-discord-local"],
 
     "@elizaos/plugin-documents": ["@elizaos/plugin-documents@workspace:plugins/plugin-documents"],
+
+    "@elizaos/plugin-e2b-sandbox": ["@elizaos/plugin-e2b-sandbox@workspace:plugins/plugin-e2b-sandbox"],
 
     "@elizaos/plugin-edge-tts": ["@elizaos/plugin-edge-tts@workspace:plugins/plugin-edge-tts"],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -347,7 +347,6 @@
     "crc-32": "^1.2.0",
     "diff3": "0.0.4",
     "drizzle-orm": "0.45.2",
-    "e2b": "^2.20.1",
     "esbuild": "^0.28.0",
     "ethers": "^6.16.0",
     "git-workspace-service": "0.4.5",

--- a/packages/agent/scripts/live-sandbox-smoke.ts
+++ b/packages/agent/scripts/live-sandbox-smoke.ts
@@ -3,8 +3,20 @@ import { createInterface } from "node:readline";
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import {
   E2BRemoteCapabilityRouterService,
+  type E2BSandboxFactory,
   type SandboxRunnerProvider,
 } from "../src/services/e2b-capability-router.ts";
+
+async function loadE2BSandboxFactory(
+  runtime: IAgentRuntime,
+): Promise<E2BSandboxFactory | undefined> {
+  try {
+    const mod = await import("@elizaos/plugin-e2b-sandbox");
+    return await mod.E2BSandboxFactoryService.start(runtime);
+  } catch {
+    return undefined;
+  }
+}
 
 type SmokeTarget = SandboxRunnerProvider | "codex-app-server";
 type JsonRecord = Record<string, unknown>;
@@ -62,7 +74,16 @@ async function runSandboxProviderSmoke(
     };
   }
   const runtime = makeRuntime({ ELIZA_CODING_REMOTE_RUNNER: provider });
-  const service = new E2BRemoteCapabilityRouterService(runtime);
+  // The e2b (`e2b.dev`) SDK backend lives in the optional
+  // `@elizaos/plugin-e2b-sandbox` plugin (not in `@elizaos/agent`); inject its
+  // sandbox factory so the router can reach the e2b provider in this smoke.
+  const factory =
+    provider === "e2b" ? await loadE2BSandboxFactory(runtime) : undefined;
+  const service = new E2BRemoteCapabilityRouterService(
+    runtime,
+    undefined,
+    factory,
+  );
   const availability = await service.availability();
   if (!availability.available) {
     return {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -96,12 +96,15 @@ import {
   createBasicCapabilitiesPlugin,
   createMessageMemory,
   drainAppRoutePluginLoaders,
+  E2B_SANDBOX_FACTORY_SERVICE_TYPE,
   EmbeddingDimensionProbeError,
   type Entity,
+  type IAgentRuntime,
   type LogEntry,
   logger,
   type Plugin,
   type Provider,
+  type ServiceClass,
   stringToUuid,
   subAgentCredentialsPlugin,
   type TargetInfo,
@@ -158,6 +161,26 @@ async function loadE2BCapabilityRouterModule(): Promise<E2BCapabilityRouterModul
   return (await import(
     /* @vite-ignore */ moduleId
   )) as E2BCapabilityRouterModule;
+}
+
+// The e2b (`e2b.dev`) SDK backend for the remote capability router lives in the
+// optional `@elizaos/plugin-e2b-sandbox` package — not in `@elizaos/agent`, so
+// the `e2b` dependency stays out of the trunk. When the router selects the
+// `e2b` provider we register the plugin's factory service so the router can
+// route filesystem / terminal / git into an e2b sandbox; if the plugin is not
+// installed we log and leave E2B unavailable rather than failing boot.
+async function registerE2BSandboxFactoryService(
+  runtime: IAgentRuntime,
+): Promise<boolean> {
+  if (runtime.getService(E2B_SANDBOX_FACTORY_SERVICE_TYPE)) return true;
+  const moduleId = "@elizaos/plugin-e2b-sandbox";
+  const mod = (await import(/* @vite-ignore */ moduleId)) as {
+    E2BSandboxFactoryService?: ServiceClass;
+  };
+  const ServiceClassRef = mod.E2BSandboxFactoryService;
+  if (!ServiceClassRef) return false;
+  await runtime.registerService(ServiceClassRef);
+  return true;
 }
 
 import {
@@ -4641,6 +4664,14 @@ export async function startEliza(
         await loadE2BCapabilityRouterModule();
       const result = await registerE2BRemoteCapabilityRouterIfEnabled(runtime);
       if (result.registered) {
+        if (result.provider === "e2b") {
+          const loaded = await registerE2BSandboxFactoryService(runtime);
+          if (!loaded) {
+            logger.warn(
+              "[eliza] E2B remote runner selected but @elizaos/plugin-e2b-sandbox is not installed; E2B filesystem/terminal/git will be unavailable until it is added.",
+            );
+          }
+        }
         logger.info("[eliza] Remote coding runner registered");
       }
     } catch (err) {
@@ -5726,7 +5757,11 @@ export async function startEliza(
             try {
               const { registerE2BRemoteCapabilityRouterIfEnabled } =
                 await loadE2BCapabilityRouterModule();
-              await registerE2BRemoteCapabilityRouterIfEnabled(newRuntime);
+              const result =
+                await registerE2BRemoteCapabilityRouterIfEnabled(newRuntime);
+              if (result.registered && result.provider === "e2b") {
+                await registerE2BSandboxFactoryService(newRuntime);
+              }
             } catch {
               // non-fatal
             }

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -1,5 +1,10 @@
 import nodePath from "node:path";
-import { CapabilityError, type IAgentRuntime, type UUID } from "@elizaos/core";
+import {
+  CapabilityError,
+  E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+  type IAgentRuntime,
+  type UUID,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   E2BRemoteCapabilityRouterService,
@@ -115,12 +120,15 @@ function replaceGlobalFetch(fetchImpl: typeof fetch): void {
   });
 }
 
-function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+function makeRuntime(
+  settings: Record<string, string> = {},
+  services: Record<string, unknown> = {},
+): IAgentRuntime {
   const runtime: Partial<IAgentRuntime> = {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
     character: { name: "E2B Test" },
     getSetting: (key: string) => settings[key],
-    getService: () => null,
+    getService: ((type: string) => services[type] ?? null) as never,
   };
   return runtime as IAgentRuntime;
 }
@@ -733,5 +741,37 @@ describe("E2BRemoteCapabilityRouterService", () => {
     await expect(
       service.fs.readText({ path: "/outside/file.ts" }),
     ).rejects.toBeInstanceOf(CapabilityError);
+  });
+
+  it("routes the e2b provider to the sandbox factory service registered by the plugin", async () => {
+    const factory = new FakeFactory();
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime({}, { [E2B_SANDBOX_FACTORY_SERVICE_TYPE]: factory }),
+      makeConfig({ provider: "e2b" }),
+    );
+
+    const result = await service.pty.runCommand({
+      command: "echo",
+      args: ["hi"],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(factory.configs).toHaveLength(1);
+    expect(factory.configs[0]?.provider).toBe("e2b");
+  });
+
+  it("reports e2b unavailable when the sandbox factory plugin is not registered", async () => {
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig({ provider: "e2b" }),
+    );
+
+    await expect(
+      service.pty.runCommand({ command: "echo", args: ["hi"] }),
+    ).rejects.toMatchObject({
+      code: "CAPABILITY_UNAVAILABLE",
+      capability: "fs",
+      method: "sandbox.create",
+    });
   });
 });

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -5,6 +5,9 @@ import {
   type CapabilityAvailability,
   CapabilityError,
   type CapabilityName,
+  E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+  type E2BSandboxClient,
+  type E2BSandboxFactoryService,
   type ElizaCapabilityRouter,
   type FileListParams,
   type FileListResult,
@@ -23,12 +26,22 @@ import {
   type JsonObject,
   type LocalModelStatusResult,
   logger,
+  normalizeSandboxEntryType,
   type RemotePluginCapability,
+  type SandboxCommandResult,
+  type SandboxCommandRunOptions,
+  type SandboxEntryInfo,
   Service,
   type TerminalRunParams,
   type TerminalRunResult,
 } from "@elizaos/core";
-import type { SandboxConnectOpts, SandboxOpts } from "e2b";
+
+export type {
+  E2BSandboxClient,
+  SandboxCommandResult,
+  SandboxCommandRunOptions,
+  SandboxEntryInfo,
+} from "@elizaos/core";
 
 const LOG_CONTEXT = { src: "service:e2b_remote_capability_router" } as const;
 const DEFAULT_E2B_WORKDIR = "/home/user";
@@ -84,179 +97,18 @@ export interface E2BSandboxFactory {
   create(config: E2BRemoteRunnerConfig): Promise<E2BSandboxClient>;
 }
 
-export interface SandboxEntryInfo {
-  path: string;
-  name: string;
-  type: "file" | "dir" | "symlink" | "other" | (string & {});
-  size: number;
-  mode?: number;
-  permissions?: string;
-  owner?: string;
-  group?: string;
-  modifiedTime?: Date;
-  symlinkTarget?: string;
-}
-
-export interface SandboxCommandRunOptions {
-  cwd?: string;
-  timeoutMs?: number;
-  requestTimeoutMs?: number;
-  envs?: Record<string, string>;
-  background?: false;
-}
-
-export interface SandboxCommandResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-  error?: string;
-}
-
-export interface E2BSandboxClient {
-  readonly sandboxId: string;
-  readonly workspacePrepared?: boolean;
-  readonly files: {
-    list(
-      path: string,
-      opts?: { depth?: number; requestTimeoutMs?: number },
-    ): Promise<SandboxEntryInfo[]>;
-    read(
-      path: string,
-      opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
-    ): Promise<string | Uint8Array>;
-    write(
-      path: string,
-      data: string,
-      opts?: { requestTimeoutMs?: number },
-    ): Promise<{ path: string; name: string }>;
-  };
-  readonly commands: {
-    run(
-      cmd: string,
-      opts?: SandboxCommandRunOptions,
-    ): Promise<SandboxCommandResult>;
-  };
-  kill(opts?: { requestTimeoutMs?: number }): Promise<void>;
-}
-
-class DefaultE2BSandboxFactory implements E2BSandboxFactory {
-  async create(config: E2BRemoteRunnerConfig): Promise<E2BSandboxClient> {
-    const { Sandbox } = await import("e2b");
-    if (config.sandboxId) {
-      return new E2BSandboxSdkClient(
-        await Sandbox.connect(config.sandboxId, connectOptions(config)),
-      );
-    }
-    if (config.template) {
-      return new E2BSandboxSdkClient(
-        await Sandbox.create(config.template, createOptions(config)),
-      );
-    }
-    return new E2BSandboxSdkClient(await Sandbox.create(createOptions(config)));
-  }
-}
-
-type E2BSdkEntryInfo = {
-  path: string;
-  name: string;
-  type?: string;
-  size?: number;
-  mode?: number;
-  permissions?: string;
-  owner?: string;
-  group?: string;
-  modifiedTime?: Date;
-  symlinkTarget?: string;
-};
-
-type E2BSdkSandbox = {
-  readonly sandboxId: string;
-  readonly files: {
-    list(
-      path: string,
-      opts?: { depth?: number; requestTimeoutMs?: number },
-    ): Promise<E2BSdkEntryInfo[]>;
-    read(
-      path: string,
-      opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
-    ): Promise<string | Uint8Array>;
-    write(
-      path: string,
-      data: string,
-      opts?: { requestTimeoutMs?: number },
-    ): Promise<{ path: string; name: string }>;
-  };
-  readonly commands: {
-    run(
-      cmd: string,
-      opts?: SandboxCommandRunOptions,
-    ): Promise<SandboxCommandResult>;
-  };
-  // The e2b SDK's Sandbox.kill() resolves to a boolean (was void in older SDK
-  // versions); match it so the SDK Sandbox stays structurally assignable here.
-  kill(opts?: { requestTimeoutMs?: number }): Promise<boolean>;
-};
-
-class E2BSandboxSdkClient implements E2BSandboxClient {
-  readonly files = {
-    list: (
-      path: string,
-      opts?: { depth?: number; requestTimeoutMs?: number },
-    ) => this.list(path, opts),
-    read: (
-      path: string,
-      opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
-    ) => this.sandbox.files.read(path, opts),
-    write: (path: string, data: string, opts?: { requestTimeoutMs?: number }) =>
-      this.sandbox.files.write(path, data, opts),
-  };
-  readonly commands = {
-    run: (cmd: string, opts?: SandboxCommandRunOptions) =>
-      this.sandbox.commands.run(cmd, opts),
-  };
-
-  constructor(private readonly sandbox: E2BSdkSandbox) {}
-
-  get sandboxId(): string {
-    return this.sandbox.sandboxId;
-  }
-
-  async kill(opts?: { requestTimeoutMs?: number }): Promise<void> {
-    await this.sandbox.kill(opts);
-  }
-
-  private async list(
-    path: string,
-    opts?: { depth?: number; requestTimeoutMs?: number },
-  ): Promise<SandboxEntryInfo[]> {
-    const entries = await this.sandbox.files.list(path, opts);
-    return entries.map((entry) => ({
-      path: entry.path,
-      name: entry.name,
-      type: normalizeEntryType(entry.type),
-      size: entry.size ?? 0,
-      ...(entry.mode === undefined ? {} : { mode: entry.mode }),
-      ...(entry.permissions === undefined
-        ? {}
-        : { permissions: entry.permissions }),
-      ...(entry.owner === undefined ? {} : { owner: entry.owner }),
-      ...(entry.group === undefined ? {} : { group: entry.group }),
-      ...(entry.modifiedTime === undefined
-        ? {}
-        : { modifiedTime: entry.modifiedTime }),
-      ...(entry.symlinkTarget === undefined
-        ? {}
-        : { symlinkTarget: entry.symlinkTarget }),
-    }));
-  }
-}
-
+// The e2b (`e2b.dev`) SDK backend lives in `@elizaos/plugin-e2b-sandbox`, which
+// registers an `E2BSandboxFactoryService` under `E2B_SANDBOX_FACTORY_SERVICE_TYPE`.
+// The router keeps the provider-neutral selection here and the eliza-cloud /
+// home HTTP runners below; the `e2b` provider is only reachable when the plugin
+// service is registered.
 class DefaultSandboxFactory implements E2BSandboxFactory {
-  private readonly e2bFactory = new DefaultE2BSandboxFactory();
   private readonly remoteHttpFactory = new RemoteRunnerHttpFactory();
   private readonly cloudFactory = new ElizaCloudCodingContainerFactory(
     this.remoteHttpFactory,
   );
+
+  constructor(private readonly runtime: IAgentRuntime) {}
 
   async create(config: E2BRemoteRunnerConfig): Promise<E2BSandboxClient> {
     if (config.provider === "eliza-cloud") {
@@ -268,7 +120,19 @@ class DefaultSandboxFactory implements E2BSandboxFactory {
     if (config.provider === "home") {
       return this.remoteHttpFactory.create(config);
     }
-    return this.e2bFactory.create(config);
+    const factory = this.runtime.getService<E2BSandboxFactoryService>(
+      E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+    );
+    if (!factory) {
+      throw new CapabilityError({
+        code: "CAPABILITY_UNAVAILABLE",
+        capability: "fs",
+        method: "sandbox.create",
+        message:
+          "E2B sandbox provider requires the @elizaos/plugin-e2b-sandbox plugin. Add it to the agent's plugins, or select the eliza-cloud or home remote runner instead.",
+      });
+    }
+    return factory.create(config);
   }
 }
 
@@ -610,17 +474,19 @@ export class E2BRemoteCapabilityRouterService
   private preparePromise: Promise<void> | null = null;
   private createdSandbox = false;
   private readonly routerConfig: E2BRemoteRunnerConfig;
+  private readonly factory: E2BSandboxFactory;
 
   constructor(
     runtime?: IAgentRuntime,
     routerConfig?: E2BRemoteRunnerConfig,
-    private readonly factory: E2BSandboxFactory = new DefaultSandboxFactory(),
+    factory?: E2BSandboxFactory,
   ) {
     if (!runtime) {
       throw new Error("E2BRemoteCapabilityRouterService requires a runtime.");
     }
     super(runtime);
     this.routerConfig = routerConfig ?? resolveE2BRemoteRunnerConfig(runtime);
+    this.factory = factory ?? new DefaultSandboxFactory(runtime);
   }
 
   static async start(runtime: IAgentRuntime): Promise<Service> {
@@ -1025,7 +891,7 @@ export class E2BRemoteCapabilityRouterService
 }
 
 export type E2BRegistrationResult =
-  | { registered: true }
+  | { registered: true; provider: SandboxRunnerProvider }
   | { registered: false; reason: "disabled" | "already-registered" };
 
 export async function registerE2BRemoteCapabilityRouterIfEnabled(
@@ -1037,7 +903,7 @@ export async function registerE2BRemoteCapabilityRouterIfEnabled(
     return { registered: false, reason: "already-registered" };
   }
   await runtime.registerService(E2BRemoteCapabilityRouterService);
-  return { registered: true };
+  return { registered: true, provider: config.provider };
 }
 
 export function resolveE2BRemoteRunnerConfig(
@@ -1125,30 +991,6 @@ export function resolveE2BRemoteRunnerConfig(
   };
 }
 
-function createOptions(config: E2BRemoteRunnerConfig): SandboxOpts {
-  return {
-    apiKey: config.apiKey,
-    accessToken: config.accessToken,
-    domain: config.domain,
-    envs: config.envs,
-    metadata: config.metadata,
-    timeoutMs: config.timeoutMs,
-    requestTimeoutMs: config.requestTimeoutMs,
-    allowInternetAccess: config.allowInternetAccess,
-    secure: true,
-  };
-}
-
-function connectOptions(config: E2BRemoteRunnerConfig): SandboxConnectOpts {
-  return {
-    apiKey: config.apiKey,
-    accessToken: config.accessToken,
-    domain: config.domain,
-    timeoutMs: config.timeoutMs,
-    requestTimeoutMs: config.requestTimeoutMs,
-  };
-}
-
 function hasRunnerCredentials(config: E2BRemoteRunnerConfig): boolean {
   if (config.provider === "eliza-cloud") {
     return Boolean(
@@ -1177,15 +1019,6 @@ function authHeaders(apiKey: string | undefined): Record<string, string> {
   return { authorization: `Bearer ${apiKey}` };
 }
 
-function normalizeEntryType(
-  type: string | undefined,
-): SandboxEntryInfo["type"] {
-  if (type === "dir" || type === "directory") return "dir";
-  if (type === "file") return "file";
-  if (type === "symlink") return "symlink";
-  return "other";
-}
-
 function remoteEntryType(entry: JsonObject): SandboxEntryInfo["type"] {
   const value =
     typeof entry.type === "string"
@@ -1195,7 +1028,7 @@ function remoteEntryType(entry: JsonObject): SandboxEntryInfo["type"] {
         : typeof entry.kind === "string"
           ? entry.kind
           : undefined;
-  return normalizeEntryType(value);
+  return normalizeSandboxEntryType(value);
 }
 
 function timeoutSignal(ms: number | undefined): {

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -1,5 +1,7 @@
 import type { JsonObject, JsonValue } from "../types/primitives";
 
+export * from "./sandbox-factory";
+
 export const CAPABILITY_ROUTER_SERVICE_TYPE = "capability-router" as const;
 
 export type CapabilityEnvironment =

--- a/packages/core/src/capabilities/sandbox-factory.ts
+++ b/packages/core/src/capabilities/sandbox-factory.ts
@@ -1,0 +1,115 @@
+import type { Service } from "../types/service";
+
+/**
+ * Service-type slot a remote-sandbox vendor plugin registers under to provide a
+ * concrete {@link E2BSandboxFactory} to the host capability router. The router
+ * (`packages/agent/src/services/e2b-capability-router.ts`) owns the
+ * provider-neutral routing + the eliza-cloud / home HTTP providers; the E2B
+ * (`e2b.dev`) SDK backend lives in `@elizaos/plugin-e2b-sandbox` and is only
+ * selectable when that plugin has registered this service.
+ */
+export const E2B_SANDBOX_FACTORY_SERVICE_TYPE = "e2b-sandbox-factory" as const;
+
+export interface SandboxEntryInfo {
+	path: string;
+	name: string;
+	type: "file" | "dir" | "symlink" | "other" | (string & {});
+	size: number;
+	mode?: number;
+	permissions?: string;
+	owner?: string;
+	group?: string;
+	modifiedTime?: Date;
+	symlinkTarget?: string;
+}
+
+export interface SandboxCommandRunOptions {
+	cwd?: string;
+	timeoutMs?: number;
+	requestTimeoutMs?: number;
+	envs?: Record<string, string>;
+	background?: false;
+}
+
+export interface SandboxCommandResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	error?: string;
+}
+
+export interface SandboxFileCapability {
+	list(
+		path: string,
+		opts?: { depth?: number; requestTimeoutMs?: number },
+	): Promise<SandboxEntryInfo[]>;
+	read(
+		path: string,
+		opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
+	): Promise<string | Uint8Array>;
+	write(
+		path: string,
+		data: string,
+		opts?: { requestTimeoutMs?: number },
+	): Promise<{ path: string; name: string }>;
+}
+
+export interface SandboxCommandCapability {
+	run(
+		cmd: string,
+		opts?: SandboxCommandRunOptions,
+	): Promise<SandboxCommandResult>;
+}
+
+/**
+ * Transport-neutral handle to a live remote sandbox. Implemented by every
+ * backend (e2b SDK, eliza-cloud / home HTTP runners). The router drives
+ * filesystem, terminal, and git capabilities exclusively through this surface.
+ */
+export interface E2BSandboxClient {
+	readonly sandboxId: string;
+	readonly workspacePrepared?: boolean;
+	readonly files: SandboxFileCapability;
+	readonly commands: SandboxCommandCapability;
+	kill(opts?: { requestTimeoutMs?: number }): Promise<void>;
+}
+
+/**
+ * The subset of the router's runner config a raw sandbox backend needs to
+ * create / connect a sandbox. The router's full `E2BRemoteRunnerConfig` is a
+ * superset of this, so it is directly assignable here.
+ */
+export interface E2BSandboxCreateOptions {
+	apiKey?: string;
+	accessToken?: string;
+	domain?: string;
+	sandboxId?: string;
+	template?: string;
+	envs: Record<string, string>;
+	metadata: Record<string, string>;
+	timeoutMs: number;
+	requestTimeoutMs: number;
+	allowInternetAccess: boolean;
+}
+
+/** A backend able to materialise an {@link E2BSandboxClient}. */
+export interface E2BSandboxFactory {
+	create(options: E2BSandboxCreateOptions): Promise<E2BSandboxClient>;
+}
+
+/**
+ * Shape of the service a sandbox-vendor plugin registers under
+ * {@link E2B_SANDBOX_FACTORY_SERVICE_TYPE}. Kept as an interface (not a runtime
+ * class) so this contract stays browser-safe; the concrete class lives in the
+ * plugin and `extends Service implements E2BSandboxFactory`.
+ */
+export interface E2BSandboxFactoryService extends Service, E2BSandboxFactory {}
+
+export function normalizeSandboxEntryType(
+	type: string | undefined,
+): SandboxEntryInfo["type"] {
+	if (type === "dir" || type === "directory") return "dir";
+	if (type === "file") return "file";
+	if (type === "symlink") return "symlink";
+	return "other";
+}

--- a/plugins/plugin-e2b-sandbox/build.ts
+++ b/plugins/plugin-e2b-sandbox/build.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-e2b-sandbox (Node). Orchestration lives in
+ * the shared driver (plugins/plugin-build.ts); this lists only what differs.
+ * `e2b` is externalized (heavy vendor SDK, imported lazily at runtime).
+ */
+import { buildPlugin } from "../plugin-build";
+
+await buildPlugin({
+  name: "@elizaos/plugin-e2b-sandbox",
+  clean: true,
+  externals: ["@elizaos/core", "e2b"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-e2b-sandbox/index.ts
+++ b/plugins/plugin-e2b-sandbox/index.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from "@elizaos/core";
+import { E2BSandboxFactoryService } from "./services/e2b-sandbox-factory-service";
+
+/**
+ * `@elizaos/plugin-e2b-sandbox` — the `e2b.dev` vendor backend for the host
+ * remote capability router.
+ *
+ * The router lives in the host (`@elizaos/agent`) and owns the provider-neutral
+ * selection logic plus the eliza-cloud / home HTTP runners. The E2B SDK path
+ * (and the `e2b` npm dependency) lives here: this plugin registers
+ * {@link E2BSandboxFactoryService} under `E2B_SANDBOX_FACTORY_SERVICE_TYPE`, and
+ * the router selects the `e2b` provider only when that service is present.
+ *
+ * Opt-in: enabled when the agent is configured for the `e2b` remote runner
+ * (`ELIZA_CODING_REMOTE_RUNNER=e2b` / `ELIZA_E2B_REMOTE_RUNNER`), or by listing
+ * the plugin in a character's plugin list.
+ */
+export const e2bSandboxPlugin: Plugin = {
+  name: "e2b-sandbox",
+  description:
+    "E2B (e2b.dev) cloud sandbox backend for the remote capability router — filesystem, terminal, and git in a vendor sandbox.",
+  services: [E2BSandboxFactoryService],
+};
+
+export default e2bSandboxPlugin;
+
+export {
+  E2BSandboxFactoryService,
+  E2BSandboxSdkClient,
+} from "./services/e2b-sandbox-factory-service";

--- a/plugins/plugin-e2b-sandbox/package.json
+++ b/plugins/plugin-e2b-sandbox/package.json
@@ -1,0 +1,107 @@
+{
+  "name": "@elizaos/plugin-e2b-sandbox",
+  "version": "1.0.0",
+  "description": "E2B (e2b.dev) cloud sandbox backend for the elizaOS remote capability router — registers the E2B sandbox factory service so the router can route filesystem/terminal/git into a vendor sandbox.",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaos/eliza.git"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./index.ts",
+      "development": "./index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "eliza",
+    "plugin",
+    "e2b",
+    "sandbox",
+    "capability-router",
+    "remote-runner"
+  ],
+  "author": "elizaOS",
+  "license": "MIT",
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "e2b": "^2.20.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.2",
+    "@types/node": "^25.0.3",
+    "bun-types": "^1.2.25",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.0"
+  },
+  "scripts": {
+    "build": "bun run build.ts",
+    "build:ts": "bun run build.ts",
+    "dev": "bun --hot build.ts",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check .",
+    "lint:check": "bun run lint",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "E2B_API_KEY": {
+        "type": "string",
+        "description": "E2B (e2b.dev) API key used to create sandboxes for the remote capability router.",
+        "required": false,
+        "sensitive": true
+      },
+      "E2B_ACCESS_TOKEN": {
+        "type": "string",
+        "description": "E2B access token (alternative to E2B_API_KEY).",
+        "required": false,
+        "sensitive": true
+      },
+      "E2B_DOMAIN": {
+        "type": "string",
+        "description": "Override the E2B API domain (self-hosted / enterprise deployments).",
+        "required": false,
+        "sensitive": false
+      },
+      "E2B_TEMPLATE": {
+        "type": "string",
+        "description": "E2B sandbox template id to create sandboxes from.",
+        "required": false,
+        "sensitive": false
+      }
+    }
+  },
+  "eliza": {
+    "platforms": [
+      "node"
+    ],
+    "runtime": "node",
+    "platformDetails": {
+      "node": "Default export (Node.js) — requires network access to the e2b.dev API"
+    }
+  }
+}

--- a/plugins/plugin-e2b-sandbox/services/e2b-sandbox-factory-service.ts
+++ b/plugins/plugin-e2b-sandbox/services/e2b-sandbox-factory-service.ts
@@ -1,0 +1,182 @@
+import {
+  E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+  type E2BSandboxClient,
+  type E2BSandboxCreateOptions,
+  type E2BSandboxFactoryService as E2BSandboxFactoryServiceContract,
+  type IAgentRuntime,
+  logger,
+  normalizeSandboxEntryType,
+  type SandboxCommandRunOptions,
+  type SandboxEntryInfo,
+  Service,
+} from "@elizaos/core";
+import type { SandboxConnectOpts, SandboxOpts } from "e2b";
+
+const LOG_CONTEXT = { src: "service:e2b_sandbox_factory" } as const;
+
+/**
+ * `@elizaos/plugin-e2b-sandbox` — the `e2b.dev` SDK backend for the host remote
+ * capability router. Registering this service under
+ * {@link E2B_SANDBOX_FACTORY_SERVICE_TYPE} is the single thing that lets the
+ * router select the `e2b` provider; without the plugin the router routes only
+ * eliza-cloud / home runners and reports E2B as unavailable.
+ */
+export class E2BSandboxFactoryService
+  extends Service
+  implements E2BSandboxFactoryServiceContract
+{
+  static override serviceType = E2B_SANDBOX_FACTORY_SERVICE_TYPE;
+
+  override capabilityDescription =
+    "Creates and connects e2b.dev cloud sandboxes for the remote capability router.";
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<E2BSandboxFactoryService> {
+    logger.info(LOG_CONTEXT, "[E2BSandboxFactory] Service started");
+    return new E2BSandboxFactoryService(runtime);
+  }
+
+  override async stop(): Promise<void> {}
+
+  async create(options: E2BSandboxCreateOptions): Promise<E2BSandboxClient> {
+    const { Sandbox } = await import("e2b");
+    if (options.sandboxId) {
+      return new E2BSandboxSdkClient(
+        await Sandbox.connect(options.sandboxId, connectOptions(options)),
+      );
+    }
+    if (options.template) {
+      return new E2BSandboxSdkClient(
+        await Sandbox.create(options.template, createOptions(options)),
+      );
+    }
+    return new E2BSandboxSdkClient(
+      await Sandbox.create(createOptions(options)),
+    );
+  }
+}
+
+type E2BSdkEntryInfo = {
+  path: string;
+  name: string;
+  type?: string;
+  size?: number;
+  mode?: number;
+  permissions?: string;
+  owner?: string;
+  group?: string;
+  modifiedTime?: Date;
+  symlinkTarget?: string;
+};
+
+type E2BSdkSandbox = {
+  readonly sandboxId: string;
+  readonly files: {
+    list(
+      path: string,
+      opts?: { depth?: number; requestTimeoutMs?: number },
+    ): Promise<E2BSdkEntryInfo[]>;
+    read(
+      path: string,
+      opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
+    ): Promise<string | Uint8Array>;
+    write(
+      path: string,
+      data: string,
+      opts?: { requestTimeoutMs?: number },
+    ): Promise<{ path: string; name: string }>;
+  };
+  readonly commands: {
+    run(
+      cmd: string,
+      opts?: SandboxCommandRunOptions,
+    ): Promise<{
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+      error?: string;
+    }>;
+  };
+  // The e2b SDK's Sandbox.kill() resolves to a boolean (was void in older SDK
+  // versions); match it so the SDK Sandbox stays structurally assignable here.
+  kill(opts?: { requestTimeoutMs?: number }): Promise<boolean>;
+};
+
+export class E2BSandboxSdkClient implements E2BSandboxClient {
+  readonly files = {
+    list: (
+      path: string,
+      opts?: { depth?: number; requestTimeoutMs?: number },
+    ) => this.list(path, opts),
+    read: (
+      path: string,
+      opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
+    ) => this.sandbox.files.read(path, opts),
+    write: (path: string, data: string, opts?: { requestTimeoutMs?: number }) =>
+      this.sandbox.files.write(path, data, opts),
+  };
+  readonly commands = {
+    run: (cmd: string, opts?: SandboxCommandRunOptions) =>
+      this.sandbox.commands.run(cmd, opts),
+  };
+
+  constructor(private readonly sandbox: E2BSdkSandbox) {}
+
+  get sandboxId(): string {
+    return this.sandbox.sandboxId;
+  }
+
+  async kill(opts?: { requestTimeoutMs?: number }): Promise<void> {
+    await this.sandbox.kill(opts);
+  }
+
+  private async list(
+    path: string,
+    opts?: { depth?: number; requestTimeoutMs?: number },
+  ): Promise<SandboxEntryInfo[]> {
+    const entries = await this.sandbox.files.list(path, opts);
+    return entries.map((entry) => ({
+      path: entry.path,
+      name: entry.name,
+      type: normalizeSandboxEntryType(entry.type),
+      size: entry.size ?? 0,
+      ...(entry.mode === undefined ? {} : { mode: entry.mode }),
+      ...(entry.permissions === undefined
+        ? {}
+        : { permissions: entry.permissions }),
+      ...(entry.owner === undefined ? {} : { owner: entry.owner }),
+      ...(entry.group === undefined ? {} : { group: entry.group }),
+      ...(entry.modifiedTime === undefined
+        ? {}
+        : { modifiedTime: entry.modifiedTime }),
+      ...(entry.symlinkTarget === undefined
+        ? {}
+        : { symlinkTarget: entry.symlinkTarget }),
+    }));
+  }
+}
+
+function createOptions(options: E2BSandboxCreateOptions): SandboxOpts {
+  return {
+    apiKey: options.apiKey,
+    accessToken: options.accessToken,
+    domain: options.domain,
+    envs: options.envs,
+    metadata: options.metadata,
+    timeoutMs: options.timeoutMs,
+    requestTimeoutMs: options.requestTimeoutMs,
+    allowInternetAccess: options.allowInternetAccess,
+    secure: true,
+  };
+}
+
+function connectOptions(options: E2BSandboxCreateOptions): SandboxConnectOpts {
+  return {
+    apiKey: options.apiKey,
+    accessToken: options.accessToken,
+    domain: options.domain,
+    timeoutMs: options.timeoutMs,
+    requestTimeoutMs: options.requestTimeoutMs,
+  };
+}

--- a/plugins/plugin-e2b-sandbox/test/e2b-sandbox-factory-service.test.ts
+++ b/plugins/plugin-e2b-sandbox/test/e2b-sandbox-factory-service.test.ts
@@ -1,0 +1,108 @@
+import {
+  E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+  type SandboxCommandRunOptions,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  E2BSandboxFactoryService,
+  E2BSandboxSdkClient,
+  e2bSandboxPlugin,
+} from "../index";
+
+type FakeSdkEntry = {
+  path: string;
+  name: string;
+  type?: string;
+  size?: number;
+  mode?: number;
+  modifiedTime?: Date;
+};
+
+function fakeSdkSandbox(entries: FakeSdkEntry[] = []) {
+  return {
+    sandboxId: "sbx_fake",
+    files: {
+      list: vi.fn(async () => entries),
+      read: vi.fn(async () => "file text"),
+      write: vi.fn(async (path: string) => ({
+        path,
+        name: path.split("/").pop() ?? path,
+      })),
+    },
+    commands: {
+      run: vi.fn(async (cmd: string, _opts?: SandboxCommandRunOptions) => ({
+        exitCode: 0,
+        stdout: `ran ${cmd}`,
+        stderr: "",
+      })),
+    },
+    kill: vi.fn(async () => true),
+  };
+}
+
+describe("plugin-e2b-sandbox", () => {
+  it("registers its service under the shared factory service type", () => {
+    expect(E2BSandboxFactoryService.serviceType).toBe(
+      E2B_SANDBOX_FACTORY_SERVICE_TYPE,
+    );
+    expect(e2bSandboxPlugin.name).toBe("e2b-sandbox");
+    expect(e2bSandboxPlugin.services).toContain(E2BSandboxFactoryService);
+  });
+
+  it("exposes a capability description and a no-op stop", async () => {
+    const runtime = { agentId: "a" } as never;
+    const service = await E2BSandboxFactoryService.start(runtime);
+    expect(typeof service.capabilityDescription).toBe("string");
+    await expect(service.stop()).resolves.toBeUndefined();
+  });
+
+  it("normalizes sandbox entry types and preserves optional fields on list", async () => {
+    const sandbox = fakeSdkSandbox([
+      {
+        path: "/workspace/src",
+        name: "src",
+        type: "directory",
+        size: 0,
+        mode: 0o755,
+        modifiedTime: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      { path: "/workspace/a.txt", name: "a.txt", type: "file", size: 3 },
+      { path: "/workspace/l", name: "l", type: "symlink" },
+      { path: "/workspace/x", name: "x", type: "socket" },
+    ]);
+    const client = new E2BSandboxSdkClient(sandbox as never);
+
+    expect(client.sandboxId).toBe("sbx_fake");
+    const entries = await client.files.list("/workspace");
+    expect(entries.map((entry) => entry.type)).toEqual([
+      "dir",
+      "file",
+      "symlink",
+      "other",
+    ]);
+    expect(entries[0]).toMatchObject({ name: "src", mode: 0o755, size: 0 });
+    expect(entries[0]?.modifiedTime).toEqual(
+      new Date("2026-01-01T00:00:00.000Z"),
+    );
+    // Missing size defaults to 0.
+    expect(entries[2]?.size).toBe(0);
+  });
+
+  it("delegates read/write/command to the underlying sandbox and awaits kill", async () => {
+    const sandbox = fakeSdkSandbox();
+    const client = new E2BSandboxSdkClient(sandbox as never);
+
+    await client.files.write("/workspace/out.txt", "hi");
+    expect(sandbox.files.write).toHaveBeenCalledWith(
+      "/workspace/out.txt",
+      "hi",
+      undefined,
+    );
+
+    const command = await client.commands.run("echo hi");
+    expect(command).toMatchObject({ exitCode: 0, stdout: "ran echo hi" });
+
+    await client.kill({ requestTimeoutMs: 1000 });
+    expect(sandbox.kill).toHaveBeenCalledWith({ requestTimeoutMs: 1000 });
+  });
+});

--- a/plugins/plugin-e2b-sandbox/tsconfig.build.json
+++ b/plugins/plugin-e2b-sandbox/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__", "build.ts"],
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "bun-types"]
+  }
+}

--- a/plugins/plugin-e2b-sandbox/tsconfig.json
+++ b/plugins/plugin-e2b-sandbox/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node", "bun-types"]
+  },
+  "include": ["./**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build.ts",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -128,6 +128,9 @@
         "./plugins/plugin-native-settings/src/index.ts"
       ],
       "@elizaos/plugin-discord": ["./plugins/plugin-discord/index.ts"],
+      "@elizaos/plugin-e2b-sandbox": [
+        "./plugins/plugin-e2b-sandbox/index.ts"
+      ],
       "@elizaos/plugin-edge-tts": ["./plugins/plugin-edge-tts/src/index.ts"],
       "@elizaos/plugin-elizacloud": [
         "./plugins/plugin-elizacloud/src/index.ts"


### PR DESCRIPTION
## #12092 item 11 [P2][M] — E2B vendor sandbox capability router in host services

A 1,687-line single-vendor remote-sandbox impl (Eliza Cloud URLs, `e2b` as a direct agent dep) lived in trunk despite `CAPABILITY_ROUTER_SERVICE_TYPE` being an existing extension point.

## Change — three-way split of the file
- **(a) provider-neutral router + selection + interface → stays in host** (`E2BRemoteCapabilityRouterService`, config resolution, path/git/fs/pty).
- **(b) eliza-cloud / home providers → stay in host** (untouched).
- **(c) E2B-specific + the `e2b` SDK → new `plugins/plugin-e2b-sandbox`** (`DefaultE2BSandboxFactory`, `E2BSandboxSdkClient`, `import "e2b"`), registering `E2BSandboxFactoryService` under a new `E2B_SANDBOX_FACTORY_SERVICE_TYPE`.
- New core contract `capabilities/sandbox-factory.ts` (service-type + browser-safe interfaces). Host's `DefaultSandboxFactory` uses the service if present, else throws `CAPABILITY_UNAVAILABLE ("requires @elizaos/plugin-e2b-sandbox")`. Boot registers the plugin service **only when the router selects e2b** via a `@vite-ignore` dynamic import — so the plugin is NOT an agent package dependency.

## Verification
- **`e2b` dep removed:** `grep '"e2b"' packages/agent/package.json` → **0**; `grep "from 'e2b'" packages/agent/src` → **0**; only importer repo-wide is the new plugin.
- **No cycle:** plugin's only build dep is `@elizaos/core` (turbo dry-run); `--filter=@elizaos/plugin-e2b-sandbox...` builds.
- Tests **82 pass** across affected suites: 18 router (incl. **2 new** proving E2B selected iff the factory service is registered), coding-remote-runner integration, **4 new** plugin, 59 core capability-consumer. `tsgo` plugin 0, agent 0 in touched files. Biome clean.

| type | status |
|---|---|
| Unit/integration tests | ✅ 82 pass |
| `e2b` dep + imports removed from agent | ✅ (grep 0/0) |
| cycle check | ✅ inward-only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)