### PR TITLE
fix(ui): guard sensitive agent surface fields

### DIFF
--- a/packages/ui/src/agent-surface/element-reporter.hooks.ts
+++ b/packages/ui/src/agent-surface/element-reporter.hooks.ts
@@ -33,7 +33,7 @@ export function buildPayload(registry: ViewAgentRegistry): {
     id: e.id,
     role: e.role,
     label: e.label,
-    ...(typeof e.value === "string" ? { value: e.value } : {}),
+    ...(!e.sensitive && typeof e.value === "string" ? { value: e.value } : {}),
     ...(e.focused ? { focused: true } : {}),
   }));
   return { viewId: snap.viewId, elements };

--- a/packages/ui/src/agent-surface/element-reporter.test.ts
+++ b/packages/ui/src/agent-surface/element-reporter.test.ts
@@ -38,6 +38,28 @@ describe("element-reporter buildPayload", () => {
     expect("focused" in byId.send).toBe(false);
   });
 
+  it("does not report values for sensitive elements", () => {
+    const registry = new ViewAgentRegistry("auth", "gui");
+    registry.register(
+      {
+        id: "password",
+        label: "Password",
+        role: "text-input",
+        sensitive: true,
+        getValue: () => "secret-value",
+      },
+      () => null,
+    );
+
+    const payload = buildPayload(registry);
+    expect(payload.elements[0]).toMatchObject({
+      id: "password",
+      role: "text-input",
+      label: "Password",
+    });
+    expect("value" in payload.elements[0]).toBe(false);
+  });
+
   it("returns an empty element list for an empty view", () => {
     const registry = new ViewAgentRegistry("empty", "gui");
     expect(buildPayload(registry).elements).toEqual([]);

--- a/packages/ui/src/agent-surface/index.ts
+++ b/packages/ui/src/agent-surface/index.ts
@@ -35,6 +35,10 @@ export {
   ViewAgentRegistry,
 } from "./registry";
 export {
+  isSensitiveAgentElement,
+  SENSITIVE_AGENT_ELEMENT_REASON,
+} from "./sensitive";
+export {
   AGENT_SURFACE_CAPABILITY_IDS,
   type AgentActionResult,
   type AgentElementDescriptor,

--- a/packages/ui/src/agent-surface/integration.test.tsx
+++ b/packages/ui/src/agent-surface/integration.test.tsx
@@ -94,6 +94,46 @@ describe("agent-surface render integration", () => {
     expect(result).toMatchObject({ ok: true, id: "note", value: "hello" });
   });
 
+  it("stamps explicit sensitive state and blocks password fills", () => {
+    function SensitiveInner() {
+      const { ref, agentProps } = useAgentElement<HTMLInputElement>({
+        id: "owner-password",
+        role: "text-input",
+        label: "Owner password",
+        sensitive: true,
+      });
+      return (
+        <input
+          ref={ref}
+          type="password"
+          defaultValue="existing"
+          {...agentProps}
+        />
+      );
+    }
+    render(
+      <AgentSurfaceProvider viewId={VIEW} viewType="gui">
+        <SensitiveInner />
+      </AgentSurfaceProvider>,
+    );
+
+    const registry = getViewRegistry(VIEW, "gui");
+    if (!registry) throw new Error("registry missing");
+    const element = document.querySelector<HTMLInputElement>(
+      "[data-agent-id='owner-password']",
+    );
+    expect(element?.getAttribute("data-agent-sensitive")).toBe("true");
+    const result = handleAgentSurfaceCapability(registry, "agent-fill", {
+      id: "owner-password",
+      value: "changed",
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      id: "owner-password",
+    });
+    expect(element?.value).toBe("existing");
+  });
+
   it("tears down the registry when the view unmounts", () => {
     const { unmount } = render(
       <AgentSurfaceProvider viewId="ephemeral" viewType="gui">

--- a/packages/ui/src/agent-surface/registry.test.ts
+++ b/packages/ui/src/agent-surface/registry.test.ts
@@ -93,6 +93,57 @@ describe("ViewAgentRegistry", () => {
     expect(onInput).toHaveBeenCalledOnce();
   });
 
+  it("redacts and refuses to fill sensitive fields", () => {
+    const registry = makeRegistry();
+    const password = document.createElement("input");
+    password.type = "password";
+    password.value = "correct horse";
+    document.body.appendChild(password);
+    registry.register(
+      { id: "login.password", role: "text-input", label: "Password" },
+      () => password,
+    );
+
+    const snapshot = registry.snapshot().elements[0];
+    expect(snapshot).toMatchObject({
+      id: "login.password",
+      sensitive: true,
+      valueRedacted: true,
+    });
+    expect("value" in snapshot).toBe(false);
+
+    const result = registry.fill("login.password", "new password");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("sensitive element");
+    expect(password.value).toBe("correct horse");
+  });
+
+  it("honors explicit sensitive descriptors without a mounted DOM node", () => {
+    const registry = makeRegistry();
+    const onFill = vi.fn();
+    registry.register(
+      {
+        id: "api-key",
+        role: "text-input",
+        label: "Public provider key",
+        sensitive: true,
+        getValue: () => "sk-live",
+        onFill,
+      },
+      () => null,
+    );
+
+    const snapshot = registry.describe("api-key");
+    expect(snapshot).toMatchObject({
+      id: "api-key",
+      sensitive: true,
+      valueRedacted: true,
+    });
+    expect(snapshot && "value" in snapshot).toBe(false);
+    expect(registry.fill("api-key", "sk-next").ok).toBe(false);
+    expect(onFill).not.toHaveBeenCalled();
+  });
+
   it("rejects fills that violate the options whitelist", () => {
     const registry = makeRegistry();
     const select = document.createElement("select");

--- a/packages/ui/src/agent-surface/registry.ts
+++ b/packages/ui/src/agent-surface/registry.ts
@@ -8,6 +8,10 @@
  */
 
 import {
+  isSensitiveAgentElement,
+  SENSITIVE_AGENT_ELEMENT_REASON,
+} from "./sensitive";
+import {
   type AgentActionResult,
   type AgentElementDescriptor,
   type AgentElementSnapshot,
@@ -149,9 +153,12 @@ export class ViewAgentRegistry {
     const { descriptor } = record;
     const el = record.getElement();
     const role = descriptor.role ?? "region";
-    const value = descriptor.getValue
-      ? descriptor.getValue()
-      : readDomValue(el);
+    const sensitive = isSensitiveAgentElement(descriptor, el);
+    const value = sensitive
+      ? undefined
+      : descriptor.getValue
+        ? descriptor.getValue()
+        : readDomValue(el);
     const rect = el?.getBoundingClientRect();
     const visible = rect ? rect.width > 0 && rect.height > 0 : false;
     const focused =
@@ -165,7 +172,7 @@ export class ViewAgentRegistry {
       group: descriptor.group,
       description: descriptor.description,
       status: descriptor.status,
-      value,
+      ...(sensitive ? { sensitive: true, valueRedacted: true } : { value }),
       fillable: isFillable(descriptor),
       clickable: isClickable(descriptor),
       focused,
@@ -246,6 +253,9 @@ export class ViewAgentRegistry {
   fill(id: string, value: string): AgentActionResult {
     const record = this.elements.get(id);
     if (!record) return { ok: false, id, reason: "element not found" };
+    if (isSensitiveAgentElement(record.descriptor, record.getElement())) {
+      return { ok: false, id, reason: SENSITIVE_AGENT_ELEMENT_REASON };
+    }
     if (!isFillable(record.descriptor)) {
       return { ok: false, id, reason: "element is not fillable" };
     }

--- a/packages/ui/src/agent-surface/sensitive.ts
+++ b/packages/ui/src/agent-surface/sensitive.ts
@@ -1,0 +1,57 @@
+import type { AgentElementDescriptor } from "./types";
+
+export const SENSITIVE_AGENT_ELEMENT_REASON =
+  "sensitive element cannot be read or filled through the agent surface";
+
+const SENSITIVE_FIELD_PATTERN =
+  /\b(password|passcode|passphrase|secret|token|api[\s_-]*key|private[\s_-]*key|seed[\s_-]*phrase|mnemonic|bearer|credential|client[\s_-]*secret|access[\s_-]*token|refresh[\s_-]*token|jwt|otp|one[\s_-]*time[\s_-]*code)\b/i;
+
+function hasSensitiveText(value: unknown): boolean {
+  return typeof value === "string" && SENSITIVE_FIELD_PATTERN.test(value);
+}
+
+function elementLabels(el: HTMLElement): string[] {
+  if (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement
+  ) {
+    return Array.from(el.labels ?? [])
+      .map((label) => label.textContent ?? "")
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function isSensitiveAgentElement(
+  descriptor: Pick<
+    AgentElementDescriptor,
+    "id" | "label" | "group" | "description" | "sensitive"
+  >,
+  el: HTMLElement | null | undefined,
+): boolean {
+  if (descriptor.sensitive === true) return true;
+
+  if (el) {
+    const explicit = el.getAttribute("data-agent-sensitive");
+    if (explicit === "true" || explicit === "1") return true;
+    if (el instanceof HTMLInputElement) {
+      if (el.type === "password") return true;
+      if (el.autocomplete === "one-time-code") return true;
+    }
+  }
+
+  const searchableText = [
+    descriptor.id,
+    descriptor.label,
+    descriptor.group,
+    descriptor.description,
+    el?.getAttribute("name"),
+    el?.getAttribute("id"),
+    el?.getAttribute("aria-label"),
+    el?.getAttribute("placeholder"),
+    el?.getAttribute("autocomplete"),
+    ...(el ? elementLabels(el) : []),
+  ];
+  return searchableText.some(hasSensitiveText);
+}

--- a/packages/ui/src/agent-surface/types.ts
+++ b/packages/ui/src/agent-surface/types.ts
@@ -71,6 +71,12 @@ export interface AgentElementDescriptor {
   description?: string;
   /** Current status token rendered as `data-state` (e.g. "active", "error"). */
   status?: string;
+  /**
+   * Marks this element as credential/sensitive data. Sensitive elements remain
+   * addressable, but their values are redacted from snapshots and agent fills
+   * are rejected.
+   */
+  sensitive?: boolean;
   /** Sort priority for `list-elements` (lower first). Falls back to DOM order. */
   order?: number;
   /** Override fillability (else derived from role). */
@@ -98,6 +104,8 @@ export interface AgentElementSnapshot {
   description?: string;
   status?: string;
   value?: unknown;
+  sensitive?: boolean;
+  valueRedacted?: boolean;
   fillable: boolean;
   clickable: boolean;
   focused: boolean;

--- a/packages/ui/src/agent-surface/useAgentElement.ts
+++ b/packages/ui/src/agent-surface/useAgentElement.ts
@@ -28,6 +28,7 @@ export interface AgentElementHandle<T extends HTMLElement> {
     "data-agent-id": string;
     "data-agent-role": string;
     "data-agent-label": string;
+    "data-agent-sensitive"?: "true";
     "data-state"?: string;
   };
 }
@@ -63,6 +64,9 @@ export function useAgentElement<T extends HTMLElement = HTMLElement>(
       },
       get status() {
         return latest.current.status;
+      },
+      get sensitive() {
+        return latest.current.sensitive;
       },
       get order() {
         return latest.current.order;
@@ -102,7 +106,13 @@ export function useAgentElement<T extends HTMLElement = HTMLElement>(
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps drive the version bump
   useEffect(() => {
     registry?.touch();
-  }, [registry, descriptor.label, descriptor.status, descriptor.role]);
+  }, [
+    registry,
+    descriptor.label,
+    descriptor.status,
+    descriptor.role,
+    descriptor.sensitive,
+  ]);
 
   return {
     ref: elRef,
@@ -110,6 +120,9 @@ export function useAgentElement<T extends HTMLElement = HTMLElement>(
       "data-agent-id": descriptor.id,
       "data-agent-role": descriptor.role ?? "region",
       "data-agent-label": descriptor.label,
+      ...(descriptor.sensitive
+        ? { "data-agent-sensitive": "true" as const }
+        : {}),
       ...(descriptor.status ? { "data-state": descriptor.status } : {}),
     },
   };

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -436,6 +436,91 @@ describe("DynamicViewLoader", () => {
     });
   });
 
+  it("redacts and refuses raw DOM sensitive fields", async () => {
+    const bundleUrl = "https://capability.example.test/assets/sensitive.js";
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = vi.fn(async () => ({
+      default: function SensitivePanel() {
+        return (
+          <section>
+            <input
+              data-agent-id="owner-password"
+              data-agent-role="text-input"
+              data-agent-label="Owner password"
+              type="password"
+              defaultValue="existing-secret"
+            />
+          </section>
+        );
+      },
+    }));
+
+    render(<DynamicViewLoader bundleUrl={bundleUrl} viewId="sensitive.view" />);
+    await screen.findByDisplayValue("existing-secret");
+
+    const { dispatchViewInteract } = await import("./view-interact-registry");
+    await dispatchViewInteract(
+      "sensitive.view",
+      "gui",
+      "list-elements",
+      undefined,
+      "req-list-sensitive",
+    );
+    await dispatchViewInteract(
+      "sensitive.view",
+      "gui",
+      "agent-fill",
+      { id: "owner-password", value: "changed-secret" },
+      "req-fill-sensitive-agent",
+    );
+    await dispatchViewInteract(
+      "sensitive.view",
+      "gui",
+      "fill-input",
+      { selector: "[data-agent-id='owner-password']", value: "changed-secret" },
+      "req-fill-sensitive-selector",
+    );
+
+    expect(screen.getByDisplayValue("existing-secret")).toBeTruthy();
+    expect(sendWsMessage).toHaveBeenCalledWith({
+      type: "view:interact:result",
+      requestId: "req-list-sensitive",
+      success: true,
+      result: [
+        expect.objectContaining({
+          id: "owner-password",
+          sensitive: true,
+          valueRedacted: true,
+        }),
+      ],
+    });
+    const listCall = vi
+      .mocked(sendWsMessage)
+      .mock.calls.find(
+        ([message]) =>
+          message.type === "view:interact:result" &&
+          message.requestId === "req-list-sensitive",
+      );
+    expect(JSON.stringify(listCall?.[0])).not.toContain("existing-secret");
+    expect(sendWsMessage).toHaveBeenCalledWith({
+      type: "view:interact:result",
+      requestId: "req-fill-sensitive-agent",
+      success: true,
+      result: expect.objectContaining({
+        ok: false,
+        id: "owner-password",
+      }),
+    });
+    expect(sendWsMessage).toHaveBeenCalledWith({
+      type: "view:interact:result",
+      requestId: "req-fill-sensitive-selector",
+      success: true,
+      result: expect.objectContaining({
+        filled: false,
+        selector: "[data-agent-id='owner-password']",
+      }),
+    });
+  });
+
   it("reports missing focus targets without throwing", async () => {
     const bundleUrl = "https://capability.example.test/assets/missing-focus.js";
     window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = vi.fn(async () => ({

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -37,6 +37,8 @@ import {
   getViewRegistry,
   handleAgentSurfaceCapability,
   isAgentSurfaceCapability,
+  isSensitiveAgentElement,
+  SENSITIVE_AGENT_ELEMENT_REASON,
   type ViewAgentRegistry,
 } from "../../agent-surface";
 import { client } from "../../api/index.ts";
@@ -784,12 +786,20 @@ function readElementValue(el: HTMLElement): unknown {
 function snapshotDomAgentElement(el: HTMLElement) {
   const rect = el.getBoundingClientRect();
   const role = el.getAttribute("data-agent-role") || "region";
-  return {
+  const descriptor = {
     id: el.getAttribute("data-agent-id") || "",
-    role,
     label: el.getAttribute("data-agent-label") || "",
+    sensitive: el.getAttribute("data-agent-sensitive") === "true",
+  };
+  const sensitive = isSensitiveAgentElement(descriptor, el);
+  return {
+    id: descriptor.id,
+    role,
+    label: descriptor.label,
     status: el.getAttribute("data-state") || undefined,
-    value: readElementValue(el),
+    ...(sensitive
+      ? { sensitive: true, valueRedacted: true }
+      : { value: readElementValue(el) }),
     fillable: DOM_FILLABLE_AGENT_ROLES.has(role),
     clickable: DOM_CLICKABLE_AGENT_ROLES.has(role),
     focused:
@@ -880,6 +890,18 @@ function handleDomAgentSurfaceCapability(
       }
       const el = getAgentElementById(containerEl, id);
       if (!el) return { ok: false, id, reason: "element not found" };
+      if (
+        isSensitiveAgentElement(
+          {
+            id,
+            label: el.getAttribute("data-agent-label") || "",
+            sensitive: el.getAttribute("data-agent-sensitive") === "true",
+          },
+          el,
+        )
+      ) {
+        return { ok: false, id, reason: SENSITIVE_AGENT_ELEMENT_REASON };
+      }
       if (
         el instanceof HTMLInputElement ||
         el instanceof HTMLTextAreaElement ||
@@ -991,7 +1013,12 @@ async function handleStandardCapability(
       const id = agentIdParam(params);
       if (id && registry) {
         const result = registry.fill(id, value);
-        return { filled: result.ok, id, reason: result.reason, value };
+        return {
+          filled: result.ok,
+          id,
+          reason: result.reason,
+          ...(result.ok ? { value } : {}),
+        };
       }
       const { target, selector } = resolveInteractTarget(containerEl, params);
       if (!target) {
@@ -1002,6 +1029,27 @@ async function handleStandardCapability(
         target instanceof HTMLTextAreaElement ||
         target instanceof HTMLSelectElement
       ) {
+        if (
+          isSensitiveAgentElement(
+            {
+              id:
+                target.getAttribute("data-agent-id") ||
+                target.id ||
+                target.name ||
+                selector ||
+                "",
+              label: target.getAttribute("data-agent-label") || "",
+              sensitive: target.getAttribute("data-agent-sensitive") === "true",
+            },
+            target,
+          )
+        ) {
+          return {
+            filled: false,
+            selector,
+            reason: SENSITIVE_AGENT_ELEMENT_REASON,
+          };
+        }
         setNativeInputValue(target, value);
         return { filled: true, selector, value };
       }


### PR DESCRIPTION
## Summary
- redact sensitive agent-surface values from registry snapshots and reporter payloads
- block agent-fill/fill-input from mutating password, token, key, and explicitly sensitive fields
- apply the same guard to registered React elements and raw DOM fallback elements

## Verification
- bun run --cwd packages/ui test -- src/agent-surface/registry.test.ts src/agent-surface/element-reporter.test.ts src/agent-surface/integration.test.tsx src/components/views/DynamicViewLoader.test.tsx
- bunx @biomejs/biome check packages/ui/src/agent-surface/types.ts packages/ui/src/agent-surface/sensitive.ts packages/ui/src/agent-surface/registry.ts packages/ui/src/agent-surface/useAgentElement.ts packages/ui/src/agent-surface/element-reporter.hooks.ts packages/ui/src/agent-surface/index.ts packages/ui/src/agent-surface/registry.test.ts packages/ui/src/agent-surface/element-reporter.test.ts packages/ui/src/agent-surface/integration.test.tsx packages/ui/src/components/views/DynamicViewLoader.tsx packages/ui/src/components/views/DynamicViewLoader.test.tsx
- git diff --check