### PR TITLE
fix(app-core): enforce declarative route auth policy

### DIFF
--- a/packages/app-core/src/api/route-auth-policy.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.test.ts
@@ -1,0 +1,127 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import {
+  COMPAT_ROUTE_AUTH_POLICIES,
+  enforceCompatRouteAuthPolicy,
+  isCompatManagedRoute,
+  resolveCompatRouteAuthPolicy,
+} from "./route-auth-policy";
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+function fakeReq(options: {
+  method: string;
+  pathname: string;
+  headers?: http.IncomingHttpHeaders;
+  remoteAddress?: string;
+}): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = options.method;
+  req.url = options.pathname;
+  req.headers = {
+    host: "example.test:2138",
+    ...(options.headers ?? {}),
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: options.remoteAddress ?? "203.0.113.9",
+    configurable: true,
+  });
+  return req;
+}
+
+function fakeRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+describe("compat route auth policy table", () => {
+  it("has stable unique policy ids", () => {
+    const ids = COMPAT_ROUTE_AUTH_POLICIES.map((policy) => policy.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("declares auth tiers for representative compat routes", () => {
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/auth/status"),
+    ).toMatchObject({ id: "auth.status", tier: "public" });
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/first-run/status"),
+    ).toMatchObject({ id: "first-run.status", tier: "session" });
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/secrets/inventory"),
+    ).toMatchObject({ id: "secrets", tier: "OWNER" });
+    expect(
+      resolveCompatRouteAuthPolicy("GET", "/api/database/tables/foo/rows"),
+    ).toMatchObject({ id: "database.rows", tier: "OWNER" });
+  });
+
+  it("fails closed for undeclared app-core-managed routes", async () => {
+    const req = fakeReq({ method: "GET", pathname: "/api/dev/not-declared" });
+    const res = fakeRes();
+
+    await expect(
+      enforceCompatRouteAuthPolicy(
+        req,
+        res.res,
+        STATE,
+        "GET",
+        "/api/dev/not-declared",
+      ),
+    ).resolves.toBe("denied");
+    expect(res.status()).toBe(401);
+    expect(res.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("does not let prefix policies bleed into sibling path names", () => {
+    expect(resolveCompatRouteAuthPolicy("GET", "/api/pluginsx")).toBeNull();
+    expect(isCompatManagedRoute("/api/pluginsx")).toBe(false);
+    expect(resolveCompatRouteAuthPolicy("GET", "/pairing")).toBeNull();
+    expect(isCompatManagedRoute("/pairing")).toBe(false);
+  });
+
+  it("lets non-compat routes fall through to the upstream server", async () => {
+    const req = fakeReq({ method: "GET", pathname: "/api/messages" });
+    const res = fakeRes();
+
+    expect(isCompatManagedRoute("/api/messages")).toBe(false);
+    await expect(
+      enforceCompatRouteAuthPolicy(req, res.res, STATE, "GET", "/api/messages"),
+    ).resolves.toBe("unmanaged");
+    expect(res.status()).toBe(200);
+    expect(res.json()).toBeNull();
+  });
+
+  it("allows public declarations without a session", async () => {
+    const req = fakeReq({ method: "GET", pathname: "/api/i18n/locale" });
+    const res = fakeRes();
+
+    await expect(
+      enforceCompatRouteAuthPolicy(
+        req,
+        res.res,
+        STATE,
+        "GET",
+        "/api/i18n/locale",
+      ),
+    ).resolves.toBe("allowed");
+    expect(res.status()).toBe(200);
+  });
+});

--- a/packages/app-core/src/api/route-auth-policy.ts
+++ b/packages/app-core/src/api/route-auth-policy.ts
@@ -1,0 +1,255 @@
+import type http from "node:http";
+import { ensureRouteAuthorized, ensureRouteMinRole } from "./auth.ts";
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { sendJsonError } from "./response";
+
+export type CompatRouteAuthTier = "public" | "session" | "OWNER";
+
+export type CompatRoutePolicyMatcher =
+  | { kind: "exact"; path: string }
+  | { kind: "prefix"; prefix: string }
+  | { kind: "regex"; pattern: RegExp };
+
+export interface CompatRouteAuthPolicy {
+  id: string;
+  tier: CompatRouteAuthTier;
+  methods?: readonly string[];
+  matcher: CompatRoutePolicyMatcher;
+}
+
+const METHODS = {
+  GET: ["GET"],
+  POST: ["POST"],
+} as const;
+
+const publicExact = (
+  id: string,
+  method: keyof typeof METHODS,
+  path: string,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "public",
+  methods: METHODS[method],
+  matcher: { kind: "exact", path },
+});
+
+const sessionExact = (
+  id: string,
+  method: keyof typeof METHODS,
+  path: string,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "session",
+  methods: METHODS[method],
+  matcher: { kind: "exact", path },
+});
+
+const ownerExact = (
+  id: string,
+  method: keyof typeof METHODS,
+  path: string,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "OWNER",
+  methods: METHODS[method],
+  matcher: { kind: "exact", path },
+});
+
+const sessionPrefix = (id: string, prefix: string): CompatRouteAuthPolicy => ({
+  id,
+  tier: "session",
+  matcher: { kind: "prefix", prefix },
+});
+
+const ownerPrefix = (id: string, prefix: string): CompatRouteAuthPolicy => ({
+  id,
+  tier: "OWNER",
+  matcher: { kind: "prefix", prefix },
+});
+
+const publicPrefix = (id: string, prefix: string): CompatRouteAuthPolicy => ({
+  id,
+  tier: "public",
+  matcher: { kind: "prefix", prefix },
+});
+
+const sessionRegex = (
+  id: string,
+  method: keyof typeof METHODS,
+  pattern: RegExp,
+): CompatRouteAuthPolicy => ({
+  id,
+  tier: "session",
+  methods: METHODS[method],
+  matcher: { kind: "regex", pattern },
+});
+
+export const COMPAT_ROUTE_AUTH_POLICIES: readonly CompatRouteAuthPolicy[] = [
+  publicExact("i18n.locale", "GET", "/api/i18n/locale"),
+  publicExact("cloud.pair-popup", "GET", "/pair"),
+  publicExact(
+    "auth.bootstrap.exchange",
+    "POST",
+    "/api/auth/bootstrap/exchange",
+  ),
+  publicExact("auth.setup", "POST", "/api/auth/setup"),
+  publicExact("auth.login.password", "POST", "/api/auth/login/password"),
+  publicExact("auth.status", "GET", "/api/auth/status"),
+  publicExact("auth.pair", "POST", "/api/auth/pair"),
+  publicExact("embed.auth", "POST", "/api/embed/auth"),
+  publicExact("tts.elevenlabs-passthrough", "POST", "/api/tts/elevenlabs"),
+
+  sessionExact("runtime.mode", "GET", "/api/runtime/mode"),
+  sessionPrefix("cloud.compat", "/api/cloud/compat/"),
+  sessionPrefix("cloud.v1", "/api/cloud/v1/"),
+  sessionPrefix("cloud.billing", "/api/cloud/billing/"),
+
+  sessionExact("dev.stack", "GET", "/api/dev/stack"),
+  sessionExact("dev.route-catalog", "GET", "/api/dev/route-catalog"),
+  sessionExact("dev.cursor-screenshot", "GET", "/api/dev/cursor-screenshot"),
+  sessionExact("dev.console-log", "GET", "/api/dev/console-log"),
+  sessionExact("dev.voice-latency", "GET", "/api/dev/voice-latency"),
+  sessionExact(
+    "dev.device-resource-metrics",
+    "GET",
+    "/api/dev/device-resource-metrics",
+  ),
+  sessionExact("dev.inference-timing", "GET", "/api/dev/inference-timing"),
+  sessionExact("dev.boot-history", "GET", "/api/dev/boot-history"),
+  sessionExact("dev.health", "GET", "/api/dev/health"),
+  sessionExact("dev.route-timings", "GET", "/api/dev/route-timings"),
+
+  sessionExact("auth.password.change", "POST", "/api/auth/password/change"),
+  sessionExact("auth.logout", "POST", "/api/auth/logout"),
+  sessionExact("auth.me", "GET", "/api/auth/me"),
+  sessionExact("auth.sessions", "GET", "/api/auth/sessions"),
+  sessionRegex(
+    "auth.sessions.revoke",
+    "POST",
+    /^\/api\/auth\/sessions\/[^/]+\/revoke$/,
+  ),
+  sessionExact("first-run.status", "GET", "/api/first-run/status"),
+  sessionExact(
+    "background.run-due-tasks",
+    "POST",
+    "/api/background/run-due-tasks",
+  ),
+  sessionPrefix("sensitive-requests", "/api/sensitive-requests"),
+  sessionPrefix("local-inference", "/api/local-inference/"),
+  sessionPrefix("voice.local-inference", "/api/voice/"),
+  sessionPrefix("voice.v1-local-inference", "/v1/voice/"),
+  sessionPrefix("automations", "/api/automations"),
+  sessionExact("tts.cloud", "POST", "/api/tts/cloud"),
+  sessionPrefix("workbench", "/api/workbench"),
+  sessionPrefix("plugins.management", "/api/plugins"),
+  sessionPrefix("catalog", "/api/catalog"),
+  sessionExact("first-run.submit", "POST", "/api/first-run"),
+  sessionRegex("plugins.ui-spec", "GET", /^\/api\/plugins\/[^/]+\/ui-spec$/),
+  sessionExact("agents.list", "GET", "/api/agents"),
+  sessionExact("config.read", "GET", "/api/config"),
+
+  ownerPrefix("secrets", "/api/secrets/"),
+  ownerExact("drop.status", "GET", "/api/drop/status"),
+  ownerExact("agent.reset", "POST", "/api/agent/reset"),
+  ownerPrefix("credential-tunnel", "/api/credential-tunnel"),
+  ownerPrefix("database.rows", "/api/database/"),
+
+  // Device-secret bearer auth is enforced by internal-routes.ts. The
+  // dispatcher declares it public so the handler's host-secret auth can run.
+  publicPrefix("internal.device-secret", "/api/internal/"),
+] as const;
+
+const COMPAT_MANAGED_PREFIXES = [
+  "/api/auth/",
+  "/api/background/",
+  "/api/catalog",
+  "/api/cloud/",
+  "/api/config",
+  "/api/credential-tunnel/",
+  "/api/database/",
+  "/api/dev/",
+  "/api/drop/",
+  "/api/embed/",
+  "/api/first-run",
+  "/api/i18n/",
+  "/api/internal/",
+  "/api/local-inference/",
+  "/api/voice/",
+  "/api/plugins",
+  "/api/runtime/",
+  "/api/secrets/",
+  "/api/sensitive-requests",
+  "/api/tts/",
+  "/api/workbench",
+  "/api/agents",
+  "/v1/voice/",
+  "/pair",
+] as const;
+
+function methodMatches(policy: CompatRouteAuthPolicy, method: string): boolean {
+  return !policy.methods || policy.methods.includes(method);
+}
+
+function pathMatches(
+  matcher: CompatRoutePolicyMatcher,
+  pathname: string,
+): boolean {
+  switch (matcher.kind) {
+    case "exact":
+      return pathname === matcher.path;
+    case "prefix":
+      return prefixMatches(pathname, matcher.prefix);
+    case "regex":
+      return matcher.pattern.test(pathname);
+  }
+}
+
+function prefixMatches(pathname: string, prefix: string): boolean {
+  if (prefix.endsWith("/")) return pathname.startsWith(prefix);
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+export function resolveCompatRouteAuthPolicy(
+  method: string,
+  pathname: string,
+): CompatRouteAuthPolicy | null {
+  const normalizedMethod = method.toUpperCase();
+  return (
+    COMPAT_ROUTE_AUTH_POLICIES.find(
+      (policy) =>
+        methodMatches(policy, normalizedMethod) &&
+        pathMatches(policy.matcher, pathname),
+    ) ?? null
+  );
+}
+
+export function isCompatManagedRoute(pathname: string): boolean {
+  return COMPAT_MANAGED_PREFIXES.some((prefix) =>
+    prefixMatches(pathname, prefix),
+  );
+}
+
+type CompatRoutePolicyDecision = "allowed" | "denied" | "unmanaged";
+
+export async function enforceCompatRouteAuthPolicy(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  state: CompatRuntimeState,
+  method: string,
+  pathname: string,
+): Promise<CompatRoutePolicyDecision> {
+  const policy = resolveCompatRouteAuthPolicy(method, pathname);
+  if (!policy) {
+    if (!isCompatManagedRoute(pathname)) return "unmanaged";
+    sendJsonError(res, 401, "Unauthorized");
+    return "denied";
+  }
+
+  if (policy.tier === "public") return "allowed";
+
+  const authorized =
+    policy.tier === "OWNER"
+      ? await ensureRouteMinRole(req, res, state, "OWNER")
+      : await ensureRouteAuthorized(req, res, state);
+  return authorized ? "allowed" : "denied";
+}

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -48,6 +48,7 @@ import {
   getConfiguredCompatAgentName,
 } from "./compat-route-shared";
 import { sendJson as sendJsonResponse } from "./response";
+import { enforceCompatRouteAuthPolicy } from "./route-auth-policy";
 import { handleRuntimeModeRoute } from "./runtime-mode-routes";
 
 export {
@@ -683,6 +684,16 @@ async function handleCompatRouteInner(
   if (gate.mode === "remote") {
     if (await forwardRemoteCloudMutation(req, res)) return true;
   }
+
+  const authPolicyDecision = await enforceCompatRouteAuthPolicy(
+    req,
+    res,
+    state,
+    method,
+    url.pathname,
+  );
+  if (authPolicyDecision === "denied") return true;
+  if (authPolicyDecision === "unmanaged") return false;
 
   // Runtime mode introspection — UI shells hit this on boot for the
   // useRuntimeMode() hook.


### PR DESCRIPTION
## Summary
- add a declarative app-core compat route auth policy table with public/session/OWNER tiers
- enforce the policy once in the compat dispatcher before handler dispatch
- fail closed for undeclared app-core-managed routes while allowing non-compat upstream routes to fall through

## Verification
- bun run --cwd packages/core prebuild
- bun run --cwd packages/app-core test -- src/api/route-auth-policy.test.ts src/api/__tests__/ensure-route-min-role.test.ts src/api/__tests__/ensure-min-role.test.ts src/api/auth-session-routes.real.test.ts src/api/auth-pairing-routes.test.ts src/api/internal-routes.test.ts src/api/drop-status-compat-route.test.ts src/api/database-rows-compat-routes.test.ts
- bunx @biomejs/biome check packages/app-core/src/api/route-auth-policy.ts packages/app-core/src/api/route-auth-policy.test.ts packages/app-core/src/api/server.ts
- git diff --check

## Typecheck
- bun run --cwd packages/app-core typecheck: fails on existing baseline errors in src/api/auth.ts, src/api/dev-boot-history.test.ts, src/runtime/eliza.ts, src/services/connector-target-catalog.test.ts, and ../core/src/cloud-routing.ts declaration resolution; no new route-policy file errors were reported.