### PR TITLE
fix(app): replay late iOS launch URLs

### DIFF
--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -31,6 +31,13 @@ let activeVisibilityHandler: (() => void) | null = null;
 let activeOnlineHandler: (() => void) | null = null;
 let activeOfflineHandler: (() => void) | null = null;
 
+const COLD_LAUNCH_URL_REPLAY_MS = 15_000;
+const COLD_LAUNCH_URL_REPLAY_INTERVAL_MS = 1_000;
+
+function unrefTimer(timer: ReturnType<typeof setInterval>): void {
+  (timer as unknown as { unref?: () => void }).unref?.();
+}
+
 export function createMobileLifecycle(ctx: MobileLifecycleContext) {
   let keyboardListenersRegistered = false;
   let lifecycleListenersRegistered = false;
@@ -102,10 +109,18 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
     // Capacitor `appStateChange` listener and the `visibilitychange` fallback
     // below never double-dispatch — each only fires on an actual transition.
     let lastActive: boolean | null = null;
+    const handledDeepLinks = new Set<string>();
     const setAppActive = (active: boolean): void => {
       if (lastActive === active) return;
       lastActive = active;
       dispatchAppEvent(active ? APP_RESUME_EVENT : APP_PAUSE_EVENT);
+    };
+    const handleDeepLinkOnce = (url: string | null | undefined): boolean => {
+      const trimmed = url?.trim();
+      if (!trimmed || handledDeepLinks.has(trimmed)) return false;
+      handledDeepLinks.add(trimmed);
+      ctx.handleDeepLink(trimmed);
+      return true;
     };
 
     void Promise.resolve(
@@ -160,21 +175,38 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
 
     void Promise.resolve(
       CapacitorApp.addListener("appUrlOpen", ({ url }) => {
-        ctx.handleDeepLink(url);
+        handleDeepLinkOnce(url);
       }),
     ).catch((error) => {
       logNativePluginUnavailable("App", error);
     });
 
-    void CapacitorApp.getLaunchUrl()
-      .then((result) => {
-        if (result?.url) {
-          ctx.handleDeepLink(result.url);
-        }
-      })
-      .catch((error) => {
-        logNativePluginUnavailable("App", error);
-      });
+    let replayTimer: ReturnType<typeof setInterval> | null = null;
+    const replayStartedAt = Date.now();
+    const stopReplay = (): void => {
+      if (!replayTimer) return;
+      clearInterval(replayTimer);
+      replayTimer = null;
+    };
+    const readLaunchUrl = (): void => {
+      void CapacitorApp.getLaunchUrl()
+        .then((result) => {
+          if (handleDeepLinkOnce(result?.url)) stopReplay();
+        })
+        .catch((error) => {
+          stopReplay();
+          logNativePluginUnavailable("App", error);
+        });
+    };
+    readLaunchUrl();
+    replayTimer = setInterval(() => {
+      if (Date.now() - replayStartedAt >= COLD_LAUNCH_URL_REPLAY_MS) {
+        stopReplay();
+        return;
+      }
+      readLaunchUrl();
+    }, COLD_LAUNCH_URL_REPLAY_INTERVAL_MS);
+    unrefTimer(replayTimer);
   }
 
   async function initializeNetworkListener(): Promise<void> {

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -155,6 +155,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   historyBackSpy.mockRestore();
 });
 
@@ -326,6 +327,33 @@ describe("createMobileLifecycle — app lifecycle", () => {
     await vi.waitFor(() =>
       expect(ctx.handleDeepLink).toHaveBeenCalledWith("elizaos://voice"),
     );
+    expect(ctx.handleDeepLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a late cold-launch URL once during the bounded startup window (#12074)", async () => {
+    vi.useFakeTimers();
+    const ctx = makeContext();
+    const lifecycle = createMobileLifecycle(ctx);
+
+    lifecycle.initializeAppLifecycle();
+    await vi.waitFor(() =>
+      expect(capacitorAppMock.getLaunchUrl).toHaveBeenCalledTimes(1),
+    );
+    expect(ctx.handleDeepLink).not.toHaveBeenCalled();
+
+    capacitorAppMock.__setLaunchUrl({
+      url: "elizaos://aec-loop?tag=echo-only",
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(ctx.handleDeepLink).toHaveBeenCalledTimes(1);
+    expect(ctx.handleDeepLink).toHaveBeenCalledWith(
+      "elizaos://aec-loop?tag=echo-only",
+    );
+
+    fireAppEvent("appUrlOpen", { url: "elizaos://aec-loop?tag=echo-only" });
+    await vi.advanceTimersByTimeAsync(2_000);
+
     expect(ctx.handleDeepLink).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- replay Capacitor cold-launch URLs for a bounded startup window so late iOS launch URLs are still delivered
- dedupe cold and warm launch URL handling so the same deep link is handled once
- add regression coverage for delayed launch URL replay

## Validation
- bun run --cwd packages/app test test/mobile-lifecycle.test.ts
- bunx biome check packages/app/src/mobile-lifecycle.ts packages/app/test/mobile-lifecycle.test.ts
- git diff --check

## Evidence
- N/A - lifecycle unit fix only; no rendered UI surface changed in this cleanup commit.