### PR TITLE
refactor(auth): SubscriptionAuthProvider extension point + migrate detection vendors out of host auth/ (#12092 item 10, partial)

### DIFF
--- a/packages/agent/src/auth/credentials.test.ts
+++ b/packages/agent/src/auth/credentials.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerSubscriptionAuthProvider,
+  resetSubscriptionAuthProviders,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAccounts, loadAccount, saveAccount } from "./account-storage";
 import {
   applySubscriptionCredentials,
@@ -297,6 +301,85 @@ describe("applySubscriptionCredentials", () => {
     expect(refreshMock).toHaveBeenCalledTimes(2);
     expect(refreshMock).toHaveBeenCalledWith("personal");
     expect(refreshMock).toHaveBeenCalledWith("work");
+  });
+});
+
+describe("getSubscriptionStatus drains the subscription-auth registry", () => {
+  beforeEach(() => {
+    resetSubscriptionAuthProviders();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetSubscriptionAuthProviders();
+    for (const dir of tempHomes.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces a Codex CLI login discovered via the built-in descriptor", () => {
+    const home = useTempElizaHome();
+    const codexDir = path.join(home, ".codex");
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexDir, "auth.json"),
+      JSON.stringify({ tokens: { access_token: "chatgpt-oauth-token" } }),
+      { mode: 0o600 },
+    );
+
+    const codexRows = getSubscriptionStatus().filter(
+      (row) => row.provider === "openai-codex",
+    );
+    expect(codexRows).toHaveLength(1);
+    expect(codexRows[0]).toMatchObject({
+      accountId: "codex-cli",
+      label: "Codex CLI",
+      source: "codex-cli",
+      configured: true,
+      valid: true,
+      expiresAt: null,
+    });
+    // The row still carries the vendor metadata the host attaches generically.
+    expect(codexRows[0]?.allowedClient).toBe(
+      "Codex CLI / Codex-backed provider",
+    );
+  });
+
+  it("omits the Codex row when no ~/.codex/auth.json login exists", () => {
+    useTempElizaHome();
+    const codexRows = getSubscriptionStatus().filter(
+      (row) => row.provider === "openai-codex",
+    );
+    expect(codexRows).toHaveLength(0);
+  });
+
+  it("surfaces a credential from a plugin-registered descriptor override", () => {
+    useTempElizaHome();
+    // Seed the built-ins (as a host entry point would), then let a plugin
+    // register its own descriptor for a vendor the host never hard-codes.
+    getSubscriptionStatus();
+    registerSubscriptionAuthProvider({
+      id: "zai-coding",
+      detectExternalCredentials: () => ({
+        accountId: "zai-plugin-cli",
+        label: "z.ai Coding (plugin)",
+        source: "coding-plan-key",
+        configured: true,
+        valid: true,
+        expiresAt: null,
+      }),
+    });
+
+    const zaiRows = getSubscriptionStatus().filter(
+      (row) => row.provider === "zai-coding",
+    );
+    expect(zaiRows).toHaveLength(1);
+    expect(zaiRows[0]).toMatchObject({
+      accountId: "zai-plugin-cli",
+      source: "coding-plan-key",
+      configured: true,
+    });
   });
 });
 

--- a/packages/agent/src/auth/credentials.ts
+++ b/packages/agent/src/auth/credentials.ts
@@ -15,11 +15,13 @@ import os from "node:os";
 import path from "node:path";
 import {
   getElizaNamespace,
+  getSubscriptionAuthProvider,
   logger,
   resolveStateDir,
   resolveUserPath,
 } from "@elizaos/core";
 import type { SubscriptionCredentialSource } from "@elizaos/shared/contracts/first-run-options";
+import { ensureBuiltinSubscriptionAuthProviders } from "../subscription-auth/builtin-providers.ts";
 import {
   type AccountCredentialRecord,
   deleteAccount,
@@ -244,26 +246,6 @@ export async function getAccessToken(
   });
 }
 
-/** Shape of `~/.codex/auth.json` (Codex CLI); fields vary by CLI version. */
-interface CodexCliAuthJson {
-  auth_mode?: string;
-  OPENAI_API_KEY?: string;
-  tokens?: {
-    access_token?: string;
-    refresh_token?: string;
-  };
-}
-
-function parseCodexCliAuthJson(raw: string): CodexCliAuthJson | null {
-  try {
-    const data = JSON.parse(raw) as CodexCliAuthJson;
-    if (!data || typeof data !== "object") return null;
-    return data;
-  } catch {
-    return null;
-  }
-}
-
 function readConfiguredAnthropicSetupToken(): string | null {
   const namespace = getElizaNamespace();
   const explicitConfig = process.env.ELIZA_CONFIG_PATH?.trim();
@@ -278,22 +260,6 @@ function readConfiguredAnthropicSetupToken(): string | null {
     return typeof token === "string" && token.trim() ? token.trim() : null;
   } catch {
     return null;
-  }
-}
-
-function hasCodexCliSubscriptionAuth(): boolean {
-  const authPath = path.join(os.homedir(), ".codex", "auth.json");
-  try {
-    const data = parseCodexCliAuthJson(fs.readFileSync(authPath, "utf-8"));
-    if (!data) return false;
-    if (data.tokens?.access_token?.trim()) return true;
-    return Boolean(
-      data.OPENAI_API_KEY?.trim() &&
-        data.auth_mode?.trim() &&
-        data.auth_mode.trim().toLowerCase() !== "api-key",
-    );
-  } catch {
-    return false;
   }
 }
 
@@ -340,21 +306,24 @@ function subscriptionStatusMetadata(
   };
 }
 
-function hasCommandOnPath(commandName: string): boolean {
-  const command = process.platform === "win32" ? "where" : "command -v";
-  try {
-    execSync(`${command} ${commandName}`, {
-      encoding: "utf8",
-      timeout: 1500,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return true;
-  } catch {
-    return false;
-  }
+/**
+ * Whether a vendor's registered subscription-auth descriptor discovers a
+ * *configured* external credential right now (a CLI login on disk, a tool on
+ * PATH). Used for the availability notices in
+ * {@link applySubscriptionCredentialsLocal}.
+ */
+function hasConfiguredExternalCredential(
+  provider: SubscriptionProvider,
+): boolean {
+  const discovered =
+    getSubscriptionAuthProvider(provider)?.detectExternalCredentials?.();
+  if (discovered == null) return false;
+  const rows = Array.isArray(discovered) ? discovered : [discovered];
+  return rows.some((row) => row.configured);
 }
 
 export function getSubscriptionStatus(): SubscriptionAccountStatus[] {
+  ensureBuiltinSubscriptionAuthProviders();
   const rows: SubscriptionAccountStatus[] = [];
 
   for (const provider of SUBSCRIPTION_PROVIDER_IDS) {
@@ -419,44 +388,28 @@ export function getSubscriptionStatus(): SubscriptionAccountStatus[] {
       }
     }
 
-    if (provider === "openai-codex" && hasCodexCliSubscriptionAuth()) {
-      rows.push({
-        ...metadata,
-        provider,
-        accountId: "codex-cli",
-        label: "Codex CLI",
-        configured: true,
-        valid: true,
-        expiresAt: null,
-        source: "codex-cli",
-      });
-    }
-
-    if (provider === "gemini-cli") {
-      const geminiCliDetected = hasCommandOnPath("gemini");
-      rows.push({
-        ...metadata,
-        provider,
-        accountId: "gemini-cli",
-        label: "Gemini CLI",
-        configured: geminiCliDetected,
-        valid: geminiCliDetected,
-        expiresAt: null,
-        source: geminiCliDetected ? "gemini-cli" : null,
-      });
-    }
-
-    if (provider === "deepseek-coding") {
-      rows.push({
-        ...metadata,
-        provider,
-        accountId: "deepseek-coding",
-        label: "DeepSeek Coding Plan",
-        configured: false,
-        valid: false,
-        expiresAt: null,
-        source: "unavailable",
-      });
+    // Credentials this vendor manages outside eliza's own account store (a
+    // Codex/Gemini CLI login, an unavailable-provider notice) are contributed
+    // by the vendor's registered subscription-auth descriptor, so host `auth/`
+    // no longer branches per vendor.
+    const discovered =
+      getSubscriptionAuthProvider(provider)?.detectExternalCredentials?.();
+    if (discovered != null) {
+      const discoveredRows = Array.isArray(discovered)
+        ? discovered
+        : [discovered];
+      for (const row of discoveredRows) {
+        rows.push({
+          ...metadata,
+          provider,
+          accountId: row.accountId,
+          label: row.label,
+          configured: row.configured,
+          valid: row.valid,
+          expiresAt: row.expiresAt,
+          source: row.source as SubscriptionCredentialSource,
+        });
+      }
     }
   }
 
@@ -644,6 +597,8 @@ export function applySubscriptionCredentialsLocal(
     return;
   }
 
+  ensureBuiltinSubscriptionAuthProviders();
+
   // ── Anthropic subscription ──────────────────────────────────────────
   //
   // Anthropic subscription tokens (sk-ant-oat*) are restricted to the
@@ -679,16 +634,19 @@ export function applySubscriptionCredentialsLocal(
         "Not applied to OPENAI_API_KEY; add a direct OpenAI API key for @elizaos/plugin-openai runtime inference.",
     );
   } else {
-    if (hasCodexCliSubscriptionAuth()) {
+    if (hasConfiguredExternalCredential("openai-codex")) {
       logger.info(
-        "[auth] OpenAI Codex CLI auth detected in ~/.codex/auth.json — available for Codex CLI-backed coding/model providers. " +
+        "[auth] OpenAI Codex CLI auth detected — available for Codex CLI-backed coding/model providers. " +
           "Not applied to OPENAI_API_KEY; add a direct OpenAI API key for @elizaos/plugin-openai runtime inference.",
       );
     }
   }
 
   const geminiAccounts = listProviderAccounts("gemini-cli");
-  if (geminiAccounts.length > 0 || hasCommandOnPath("gemini")) {
+  if (
+    geminiAccounts.length > 0 ||
+    hasConfiguredExternalCredential("gemini-cli")
+  ) {
     logger.info(
       "[auth] Gemini CLI subscription surface detected/configured — available only through Gemini CLI task agents. " +
         "Not applied to GOOGLE_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY.",

--- a/packages/agent/src/subscription-auth/builtin-providers.ts
+++ b/packages/agent/src/subscription-auth/builtin-providers.ts
@@ -1,0 +1,137 @@
+/**
+ * Built-in {@link SubscriptionAuthProvider} descriptors.
+ *
+ * Vendor-specific credential *discovery* (the surfaces where a login can be
+ * found: a first-party CLI login blob, a tool on `PATH`, an unavailable
+ * provider) lives here rather than inside host `auth/`, and is drained
+ * generically by `auth/credentials.ts` through the `@elizaos/core`
+ * subscription-auth registry.
+ *
+ * These are host built-ins today. The registry API is public, so the
+ * model-provider plugin that owns a vendor can register (and thereby own) its
+ * own descriptor via `registerSubscriptionAuthProvider` — replacing the
+ * built-in without any change to host `auth/`.
+ *
+ * @module subscription-auth/builtin-providers
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type DiscoveredSubscriptionCredential,
+  hasSubscriptionAuthProvider,
+  registerSubscriptionAuthProvider,
+} from "@elizaos/core";
+
+// ── openai-codex: ~/.codex/auth.json (Codex CLI ChatGPT login) ───────────────
+
+/** Shape of `~/.codex/auth.json` (Codex CLI); fields vary by CLI version. */
+interface CodexCliAuthJson {
+  auth_mode?: string;
+  OPENAI_API_KEY?: string;
+  tokens?: {
+    access_token?: string;
+    refresh_token?: string;
+  };
+}
+
+function parseCodexCliAuthJson(raw: string): CodexCliAuthJson | null {
+  try {
+    const data = JSON.parse(raw) as CodexCliAuthJson;
+    if (!data || typeof data !== "object") return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `~/.codex/auth.json` holds a usable Codex CLI subscription login
+ * (a ChatGPT OAuth token, or an API key paired with a non-`api-key` auth mode).
+ */
+function hasCodexCliSubscriptionAuth(): boolean {
+  const authPath = path.join(os.homedir(), ".codex", "auth.json");
+  try {
+    const data = parseCodexCliAuthJson(fs.readFileSync(authPath, "utf-8"));
+    if (!data) return false;
+    if (data.tokens?.access_token?.trim()) return true;
+    return Boolean(
+      data.OPENAI_API_KEY?.trim() &&
+        data.auth_mode?.trim() &&
+        data.auth_mode.trim().toLowerCase() !== "api-key",
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ── gemini-cli: `gemini` binary on PATH ──────────────────────────────────────
+
+function hasCommandOnPath(commandName: string): boolean {
+  const command = process.platform === "win32" ? "where" : "command -v";
+  try {
+    execSync(`${command} ${commandName}`, {
+      encoding: "utf8",
+      timeout: 1500,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register the built-in subscription-auth descriptors if they are not already
+ * present. Idempotent (keyed on the registry, so it re-seeds after a test
+ * reset), so it is safe to call from every host entry point that drains the
+ * registry.
+ */
+export function ensureBuiltinSubscriptionAuthProviders(): void {
+  // Any built-in present ⇒ already seeded. `openai-codex` is the sentinel.
+  if (hasSubscriptionAuthProvider("openai-codex")) return;
+
+  registerSubscriptionAuthProvider({
+    id: "openai-codex",
+    detectExternalCredentials: (): DiscoveredSubscriptionCredential | null =>
+      hasCodexCliSubscriptionAuth()
+        ? {
+            accountId: "codex-cli",
+            label: "Codex CLI",
+            source: "codex-cli",
+            configured: true,
+            valid: true,
+            expiresAt: null,
+          }
+        : null,
+  });
+
+  registerSubscriptionAuthProvider({
+    id: "gemini-cli",
+    detectExternalCredentials: (): DiscoveredSubscriptionCredential => {
+      const detected = hasCommandOnPath("gemini");
+      return {
+        accountId: "gemini-cli",
+        label: "Gemini CLI",
+        source: detected ? "gemini-cli" : null,
+        configured: detected,
+        valid: detected,
+        expiresAt: null,
+      };
+    },
+  });
+
+  registerSubscriptionAuthProvider({
+    id: "deepseek-coding",
+    detectExternalCredentials: (): DiscoveredSubscriptionCredential => ({
+      accountId: "deepseek-coding",
+      label: "DeepSeek Coding Plan",
+      source: "unavailable",
+      configured: false,
+      valid: false,
+      expiresAt: null,
+    }),
+  });
+}

--- a/packages/core/src/features/subscription-auth/index.ts
+++ b/packages/core/src/features/subscription-auth/index.ts
@@ -1,0 +1,11 @@
+export {
+	getSubscriptionAuthProvider,
+	hasSubscriptionAuthProvider,
+	listSubscriptionAuthProviders,
+	registerSubscriptionAuthProvider,
+	resetSubscriptionAuthProviders,
+} from "./registry.ts";
+export type {
+	DiscoveredSubscriptionCredential,
+	SubscriptionAuthProvider,
+} from "./types.ts";

--- a/packages/core/src/features/subscription-auth/registry.test.ts
+++ b/packages/core/src/features/subscription-auth/registry.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getSubscriptionAuthProvider,
+	hasSubscriptionAuthProvider,
+	listSubscriptionAuthProviders,
+	registerSubscriptionAuthProvider,
+	resetSubscriptionAuthProviders,
+} from "./registry.ts";
+import type { SubscriptionAuthProvider } from "./types.ts";
+
+const codexLike: SubscriptionAuthProvider = {
+	id: "openai-codex",
+	detectExternalCredentials: () => ({
+		accountId: "codex-cli",
+		label: "Codex CLI",
+		source: "codex-cli",
+		configured: true,
+		valid: true,
+		expiresAt: null,
+	}),
+};
+
+describe("subscription-auth registry", () => {
+	afterEach(() => {
+		resetSubscriptionAuthProviders();
+	});
+
+	it("registers and looks up a descriptor by id", () => {
+		expect(hasSubscriptionAuthProvider("openai-codex")).toBe(false);
+		registerSubscriptionAuthProvider(codexLike);
+		expect(hasSubscriptionAuthProvider("openai-codex")).toBe(true);
+		expect(getSubscriptionAuthProvider("openai-codex")).toBe(codexLike);
+		expect(getSubscriptionAuthProvider("nope")).toBeUndefined();
+	});
+
+	it("lists every registered descriptor", () => {
+		registerSubscriptionAuthProvider(codexLike);
+		registerSubscriptionAuthProvider({ id: "gemini-cli" });
+		expect(
+			listSubscriptionAuthProviders()
+				.map((p) => p.id)
+				.sort(),
+		).toEqual(["gemini-cli", "openai-codex"]);
+	});
+
+	it("overwrites a prior registration for the same id (plugin overrides built-in)", () => {
+		const builtin: SubscriptionAuthProvider = {
+			id: "openai-codex",
+			detectExternalCredentials: () => null,
+		};
+		registerSubscriptionAuthProvider(builtin);
+		registerSubscriptionAuthProvider(codexLike);
+		expect(getSubscriptionAuthProvider("openai-codex")).toBe(codexLike);
+		expect(listSubscriptionAuthProviders()).toHaveLength(1);
+	});
+
+	it("exposes discovered credentials verbatim to a draining host", () => {
+		registerSubscriptionAuthProvider(codexLike);
+		const discovered =
+			getSubscriptionAuthProvider(
+				"openai-codex",
+			)?.detectExternalCredentials?.();
+		expect(discovered).toMatchObject({
+			accountId: "codex-cli",
+			source: "codex-cli",
+			valid: true,
+		});
+	});
+});

--- a/packages/core/src/features/subscription-auth/registry.ts
+++ b/packages/core/src/features/subscription-auth/registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Registry for {@link SubscriptionAuthProvider} descriptors.
+ *
+ * Model-provider plugins (or host built-ins) register their vendor's
+ * subscription product here; the host `auth/` layer drains it generically.
+ * Registration is idempotent per id (last registration wins) so a plugin can
+ * override a host built-in without an ordering constraint.
+ *
+ * @module features/subscription-auth
+ */
+
+import type { SubscriptionAuthProvider } from "./types.ts";
+
+const registry = new Map<string, SubscriptionAuthProvider>();
+
+/**
+ * Register (or replace) the subscription-auth descriptor for a vendor id.
+ * Idempotent: re-registering the same id overwrites the prior descriptor.
+ */
+export function registerSubscriptionAuthProvider(
+	provider: SubscriptionAuthProvider,
+): void {
+	registry.set(provider.id, provider);
+}
+
+/** Look up the registered descriptor for a vendor id, or `undefined`. */
+export function getSubscriptionAuthProvider(
+	id: string,
+): SubscriptionAuthProvider | undefined {
+	return registry.get(id);
+}
+
+/** All registered descriptors, in registration order. */
+export function listSubscriptionAuthProviders(): SubscriptionAuthProvider[] {
+	return [...registry.values()];
+}
+
+/** True when a descriptor is registered for the vendor id. */
+export function hasSubscriptionAuthProvider(id: string): boolean {
+	return registry.has(id);
+}
+
+/**
+ * Remove all registered descriptors. Test-only — lets a suite start from a
+ * clean registry without reloading the module.
+ */
+export function resetSubscriptionAuthProviders(): void {
+	registry.clear();
+}

--- a/packages/core/src/features/subscription-auth/types.ts
+++ b/packages/core/src/features/subscription-auth/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Subscription-auth extension point.
+ *
+ * A model vendor's subscription product (its first-party CLI login, the
+ * credential-store key, the surfaces where a login can be discovered) is a
+ * property of the vendor, not of the host. This interface lets the plugin that
+ * owns a vendor describe that product so the host `auth/` layer can stay
+ * generic: the host drains the registry to discover and report subscription
+ * credentials and never branches on a vendor id. Host `auth/` keeps only the
+ * generic account store, credential storage, and refresh mutex.
+ *
+ * @module features/subscription-auth
+ */
+
+/**
+ * A subscription credential discovered outside eliza's own account store — a
+ * first-party CLI login blob (e.g. `~/.codex/auth.json`), a tool on `PATH`, or
+ * another unmanaged provider surface. It is surfaced as a read-only row in the
+ * subscription status list: it has no on-disk account file and cannot be
+ * deleted through the account store.
+ */
+export interface DiscoveredSubscriptionCredential {
+	/** Stable synthetic account id for the row, e.g. `"codex-cli"`. */
+	accountId: string;
+	/** User-facing label, e.g. `"Codex CLI"`. */
+	label: string;
+	/**
+	 * Provenance tag — a `SubscriptionCredentialSource` value (e.g. `"codex-cli"`,
+	 * `"gemini-cli"`, `"unavailable"`, or `null`). Typed as `string | null` here
+	 * so `@elizaos/core` need not depend on the host's credential-source union.
+	 */
+	source: string | null;
+	/** True when the surface is present/usable. */
+	configured: boolean;
+	/** True when the discovered credential is currently valid. */
+	valid: boolean;
+	/** Epoch-ms expiry, or `null` when the surface manages its own lifetime. */
+	expiresAt: number | null;
+}
+
+/**
+ * Describes a model vendor's subscription product to the host. Registered by
+ * the model-provider plugin that owns the vendor (or, transitionally, by a
+ * host built-in). The host reads these fields instead of hard-coding the
+ * vendor.
+ */
+export interface SubscriptionAuthProvider {
+	/** Credential-store provider id, e.g. `"openai-codex"`. */
+	readonly id: string;
+	/**
+	 * Discover subscription credentials this vendor manages outside eliza's
+	 * account store — CLI login blobs, tools on `PATH`, unavailable-provider
+	 * notices. Pure and read-only (it is called on every status poll). Returns
+	 * the row(s) to surface, or `null` / `[]` when the vendor manages nothing
+	 * discoverable right now.
+	 */
+	detectExternalCredentials?: () =>
+		| DiscoveredSubscriptionCredential
+		| DiscoveredSubscriptionCredential[]
+		| null;
+}

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -74,6 +74,7 @@ export * from "./features/advanced-memory";
 export * from "./features/basic-capabilities/index";
 export * from "./features/credential-proxy/index.ts";
 export * from "./features/documents/index";
+export * from "./features/subscription-auth/index.ts";
 export type {
 	DraftRecord,
 	DraftRequest,


### PR DESCRIPTION
## #12092 item 10 [P2][L] — vendor subscription auth flows hardcoded in host auth/

This is an `[L]`: full migration is blocked by two verified hazards, so this PR ships the durable seam + the deterministic vendors + a per-vendor plan.

### Why not all vendors in one PR
1. The `SubscriptionProvider` **id-vocabulary is shared** across ~15 files (core/shared/contracts/ui/cloud/plugin-local-inference + accounts/subscription routes) — removing an id from `auth/types.ts` ripples widely.
2. OAuth **start/refresh** (Codex/Anthropic loopback `:1455`, PKCE, `console.anthropic.com`) can't be live-tested here — high risk against "don't break subscription auth."

## Change
- New `packages/core/src/features/subscription-auth/` extension point: `SubscriptionAuthProvider { id; detectExternalCredentials?() }` + `DiscoveredSubscriptionCredential` + an idempotent (last-wins) registry (`register/get/list/has/reset`). Interface kept to only what's wired (no dead `refreshToken`/`startOAuthFlow` surface).
- Migrated the **detection-based** vendors out of host `auth/` into `packages/agent/src/subscription-auth/builtin-providers.ts` (drained via the public core registry — a model plugin can override any by `registerSubscriptionAuthProvider` at init):
  - **openai-codex** `~/.codex/auth.json` detection (the issue's named complaint #3), **gemini-cli** (whole vendor), **deepseek-coding** (whole vendor).
- `auth/credentials.ts`: `getSubscriptionStatus`/`applySubscriptionCredentialsLocal` now read the registry generically — deleted `hasCodexCliSubscriptionAuth`, `CodexCliAuthJson`, `parseCodexCliAuthJson`, `hasCommandOnPath`, and the codex/gemini/deepseek `if`-branches.

## Verification
- Core `registry.test.ts` — **4/4**; agent `credentials.test.ts` — **13/13** (10 orig + 3 new: Codex-CLI login surfaced via registry, row omitted when absent, plugin-registered descriptor drained). `oauth-flow`/`provider-switch` pass.
- Host-auth grep for the migrated vendors → **NONE** (only a doc-comment remains). tsgo touched files 0 errors.
- (`accounts-routes.test.ts` 5 failures are **pre-existing on clean develop** — `getDefaultAccountPool()` null harness, untouched path.)

## Follow-up plan (in the PR/issue): anthropic-subscription detection; codex/anthropic OAuth start+refresh (needs interface `startOAuthFlow`/`refreshToken` + a live-test lane); claude-code-stealth fetch-patch; zai/kimi `envVar` field; and the shared id-vocabulary collapse (its own cross-cutting PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)