### PR TITLE
refactor(shared): centralize page scope contract

### DIFF
--- a/packages/agent/src/api/suggestions-routes.test.ts
+++ b/packages/agent/src/api/suggestions-routes.test.ts
@@ -87,6 +87,9 @@ describe("parseRequestBody", () => {
       parseRequestBody(JSON.stringify({ scope: "page-wallet" })).scope,
     ).toBe("page-wallet");
     expect(
+      parseRequestBody(JSON.stringify({ scope: "page-admin" })).scope,
+    ).toBeUndefined();
+    expect(
       parseRequestBody(JSON.stringify({ scope: "wallet" })).scope,
     ).toBeUndefined(); // missing page- prefix
     expect(

--- a/packages/agent/src/api/suggestions-routes.ts
+++ b/packages/agent/src/api/suggestions-routes.ts
@@ -24,6 +24,7 @@ import {
   ModelType,
   readRequestBodyBuffer,
 } from "@elizaos/core";
+import { isPageScope } from "@elizaos/shared/contracts";
 
 const MAX_BODY_BYTES = 16 * 1024;
 const SUGGESTION_COUNT = 3;
@@ -31,9 +32,6 @@ const MAX_SUGGESTION_CHARS = 48;
 const MIN_SUGGESTION_CHARS = 2;
 const MAX_CONTEXT_MESSAGES = 6;
 const MAX_CONTEXT_CHARS = 240;
-
-/** Page scopes mirror `PageScope` in @elizaos/ui (page-scoped-conversations). */
-const PAGE_SCOPE_PATTERN = /^page-[a-z][a-z0-9-]{1,30}$/;
 
 export interface SuggestionsRouteContext {
   req: http.IncomingMessage;
@@ -97,10 +95,7 @@ export function parseRequestBody(raw: string): SuggestionsRequest {
       ? Math.floor(hourValue)
       : undefined;
 
-  const scope =
-    typeof body.scope === "string" && PAGE_SCOPE_PATTERN.test(body.scope)
-      ? body.scope
-      : undefined;
+  const scope = isPageScope(body.scope) ? body.scope : undefined;
 
   return { messages: messages.slice(-MAX_CONTEXT_MESSAGES), hour, scope };
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -128,6 +128,16 @@
       "import": "./dist/events/index.js",
       "default": "./dist/events/index.js"
     },
+    "./contracts": {
+      "types": "./dist/contracts/index.d.ts",
+      "eliza-source": {
+        "types": "./src/contracts/index.ts",
+        "import": "./src/contracts/index.ts",
+        "default": "./src/contracts/index.ts"
+      },
+      "import": "./dist/contracts/index.js",
+      "default": "./dist/contracts/index.js"
+    },
     "./utils/permission-deep-links": {
       "types": "./dist/utils/permission-deep-links.d.ts",
       "eliza-source": {

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -25,6 +25,7 @@ export * from "./inbox.js";
 export * from "./inbox-routes.js";
 export * from "./memory-routes.js";
 export * from "./misc-routes.js";
+export * from "./page-scope.js";
 export * from "./permissions.js";
 export * from "./permissions-routes.js";
 export * from "./personal-assistant.js";

--- a/packages/shared/src/contracts/page-scope.test.ts
+++ b/packages/shared/src/contracts/page-scope.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { isPageScope, PAGE_SCOPES } from "./page-scope.js";
+
+describe("page-scope contract", () => {
+  it("accepts every declared page scope", () => {
+    for (const scope of PAGE_SCOPES) {
+      expect(isPageScope(scope)).toBe(true);
+    }
+  });
+
+  it("rejects well-formed but undeclared scopes", () => {
+    expect(isPageScope("page-admin")).toBe(false);
+    expect(isPageScope("page-browser-extra")).toBe(false);
+  });
+
+  it("rejects non-page-scope values", () => {
+    expect(isPageScope("wallet")).toBe(false);
+    expect(isPageScope("page-<script>")).toBe(false);
+    expect(isPageScope(42)).toBe(false);
+    expect(isPageScope(null)).toBe(false);
+  });
+});

--- a/packages/shared/src/contracts/page-scope.ts
+++ b/packages/shared/src/contracts/page-scope.ts
@@ -1,0 +1,28 @@
+export type PageScope =
+  | "page-browser"
+  | "page-character"
+  | "page-automations"
+  | "page-apps"
+  | "page-connectors"
+  | "page-phone"
+  | "page-plugins"
+  | "page-settings"
+  | "page-wallet";
+
+export const PAGE_SCOPES: readonly PageScope[] = [
+  "page-browser",
+  "page-character",
+  "page-automations",
+  "page-apps",
+  "page-connectors",
+  "page-phone",
+  "page-plugins",
+  "page-settings",
+  "page-wallet",
+] as const;
+
+const PAGE_SCOPE_SET = new Set<string>(PAGE_SCOPES);
+
+export function isPageScope(value: unknown): value is PageScope {
+  return typeof value === "string" && PAGE_SCOPE_SET.has(value);
+}

--- a/packages/ui/src/components/pages/page-scoped-conversations.ts
+++ b/packages/ui/src/components/pages/page-scoped-conversations.ts
@@ -1,31 +1,11 @@
+import type { PageScope } from "@elizaos/shared/contracts";
 import { client } from "../../api";
 import type {
   Conversation,
   ConversationMetadata,
 } from "../../api/client-types-chat";
 
-export type PageScope =
-  | "page-browser"
-  | "page-character"
-  | "page-automations"
-  | "page-apps"
-  | "page-connectors"
-  | "page-phone"
-  | "page-plugins"
-  | "page-settings"
-  | "page-wallet";
-
-export const PAGE_SCOPES: readonly PageScope[] = [
-  "page-browser",
-  "page-character",
-  "page-automations",
-  "page-apps",
-  "page-connectors",
-  "page-phone",
-  "page-plugins",
-  "page-settings",
-  "page-wallet",
-] as const;
+export { PAGE_SCOPES, type PageScope } from "@elizaos/shared/contracts";
 
 const PAGE_SCOPE_ROUTING_CONTEXTS: Record<
   PageScope,


### PR DESCRIPTION
## Summary

Addresses #12093 item 9.

- Moves the page-scope contract (`PageScope`, `PAGE_SCOPES`, `isPageScope`) into `@elizaos/shared/contracts`.
- Re-exports the shared contract from the existing UI `page-scoped-conversations` module so current UI imports keep working.
- Changes `packages/agent` suggestions parsing to validate scopes with `isPageScope` instead of a mirrored regex.
- Adds shared contract coverage and tightens the agent route test so well-formed but undeclared scopes such as `page-admin` are rejected.
- Adds the bare `@elizaos/shared/contracts` export map entry so the contract barrel works outside workspace aliases.

## Validation

Passed:

- `bunx @biomejs/biome check --write` on touched files
- `git diff --check origin/develop...HEAD`
- `bun run --cwd packages/shared test src/contracts/page-scope.test.ts`
- `bun run --cwd packages/agent test src/api/suggestions-routes.test.ts`
- `bun run --cwd packages/ui test src/components/shell/usePromptSuggestions.test.ts`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/shared build:dist`
- `bun run --cwd packages/ui build`
- `bun run --cwd packages/agent build`

Known unrelated failure observed:

- `bun run --cwd packages/agent typecheck` still fails on current `develop` due unresolved optional plugin packages (`@elizaos/plugin-commands`, `@elizaos/plugin-streaming`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, and `@elizaos/plugin-meetings`) plus downstream implicit-any errors in those unresolved optional paths. No PageScope-related errors appear.

No app visual audit was run because this is a shared contract/type validation change and does not change rendered UI pixels.
