### PR TITLE
fix(ui): scope direct-cloud page-host branch to the empty-baseUrl /join state

### DIFF
--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -120,3 +120,38 @@ describe("getCloudCompatAgents on hosted web with no agent baseUrl (join flow)",
     expect(urls.some((u) => u.includes("/api/v1/eliza/agents"))).toBe(false);
   });
 });
+
+// The regression NubsCarson flagged on PR #11448: the page-host branch is meant
+// ONLY for the empty-baseUrl /join state. When the client is connected to a
+// NON-cloud agent server (baseUrl = an agent URL that isn't a direct-cloud
+// base), the direct-cloud call must route to that connected agent, NOT the
+// cloud page host. Firing the page-host branch while connected sent the request
+// with the agent's Bearer to the cloud control plane → mis-route / 401.
+describe("getCloudCompatAgents connected to a non-cloud agent while served from a cloud host", () => {
+  it("routes to the connected agent, NOT the cloud page host", async () => {
+    // SPA is being served from a real cloud Pages host...
+    setHostname("app.elizacloud.ai");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ success: true, data: [] }));
+
+    // ...but the client is connected to an external, non-cloud agent server.
+    const client = new ElizaClient("https://my-agent.example.com");
+    await client.getCloudCompatAgents();
+
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+
+    // The request must hit the connected agent's absolute origin via the
+    // agent-proxy compat route.
+    expect(urls).toContain(
+      "https://my-agent.example.com/api/cloud/compat/agents",
+    );
+
+    // It must NOT resolve to the page host: no direct-cloud v1 route, and no
+    // same-site rewrite to a relative /api/v1 path against the cloud origin.
+    for (const url of urls) {
+      expect(url).not.toContain("/api/v1/eliza/agents");
+      expect(url).not.toContain("api.elizacloud.ai");
+    }
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -297,7 +297,13 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
   // agent-proxy fallback (/api/cloud/compat/*), a route only agent servers
   // mount — the cloud worker 404s it, so every web sign-in dead-ended on
   // "Couldn't connect to your agent".
-  if (typeof window !== "undefined") {
+  //
+  // Gate this on the empty-baseUrl state ONLY. Once the client is connected to
+  // a NON-cloud agent server (baseUrl = an agent URL that isn't a direct-cloud
+  // base — handled above), the direct-cloud call must go to that agent, not the
+  // page host. Firing this branch while connected would mis-route to the cloud
+  // host and 401. See PR #11448.
+  if (!baseUrl && typeof window !== "undefined") {
     const byHost = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
       window.location.hostname.toLowerCase(),
     );


### PR DESCRIPTION
## What

`resolveDirectCloudClientApiBase` (packages/ui/src/api/client-cloud.ts, ~line 294) has a page-host branch that resolves the direct-cloud API base from the browser page host. It's meant **only** for the empty-baseUrl `/join` state — when the SPA is served from a cloud host and no agent server is connected yet (`selectOrProvisionCloudAgent` runs before any agent connection exists).

Follow-up to #11448 — NubsCarson flagged the regression there.

## The bug

The branch fired on `typeof window !== "undefined"` **alone**. So it also kicked in when the client **is** connected to a NON-cloud agent server (`baseUrl` = an agent URL that isn't a direct-cloud base). On a cloud page host, the direct-cloud call then resolved to the **page host** instead of the connected agent:

- `directCloudRequest` issued the call against the cloud control plane (`/api/v1/eliza/agents`, same-site-rewritten) with the agent's Bearer attached
- the token doesn't belong to the cloud control plane -> **mis-route / 401**

Correct behavior for a connected non-cloud agent is to return `null` here, so the caller falls through to the agent-proxy compat path (`/api/cloud/compat/*`) against the connected agent.

## The fix

Gate the page-host branch on `!baseUrl`:

```ts
if (!baseUrl && typeof window !== "undefined") {
  const byHost = DIRECT_ELIZA_CLOUD_API_BY_HOST.get(
    window.location.hostname.toLowerCase(),
  );
  if (byHost) return byHost;
}
```

`baseUrl` is already read at the top of the function; the direct-cloud-base and native cases are handled above. `/join` (empty baseUrl on a cloud host) is completely unchanged.

## Tests

Extended `client-cloud-web-join-base.test.ts` with a sociable test through `getCloudCompatAgents` (real assertions on the resolved fetch URL, not existence/typeof):

- empty baseUrl on a cloud page host -> still resolves the page host (`/api/v1/eliza/agents`) — the existing /join guarantees still hold
- `baseUrl = https://my-agent.example.com` (non-cloud agent) served from `app.elizacloud.ai` -> routes to `https://my-agent.example.com/api/cloud/compat/agents`, and does **not** touch `/api/v1/eliza/agents` or `api.elizacloud.ai`

Verified the new test fails on the pre-fix guard (mis-routes to `/api/v1/eliza/agents`) and passes with the fix. Full `client-cloud` suite green locally (81 tests, 10 files); the two touched files are typecheck-clean. CI runs the full ui suite + typecheck for final validation.