### PR TITLE
refactor(shared): single-source restart exit code

### DIFF
--- a/packages/agent/src/runtime/crash-injection.test.ts
+++ b/packages/agent/src/runtime/crash-injection.test.ts
@@ -1,3 +1,4 @@
+import { RESTART_EXIT_CODE as SHARED_RESTART_EXIT_CODE } from "@elizaos/shared/restart";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   armCrashInjection,
@@ -85,6 +86,10 @@ describe("resolveCrashInjectionConfig — production safety gate", () => {
 });
 
 describe("maybeInjectFault", () => {
+  it("re-exports the shared restart exit code", () => {
+    expect(RESTART_EXIT_CODE).toBe(SHARED_RESTART_EXIT_CODE);
+  });
+
   it("is a no-op when disarmed", () => {
     armCrashInjection({});
     expect(isCrashInjectionArmed()).toBe(false);

--- a/packages/agent/src/runtime/crash-injection.ts
+++ b/packages/agent/src/runtime/crash-injection.ts
@@ -12,7 +12,7 @@
  *   ELIZA_CRASH_INJECT="steady:throw"         → throw at steady state
  *   ELIZA_CRASH_INJECT="plugin-load:reject"   → unhandled rejection on plugin load
  *   ELIZA_CRASH_INJECT="model-load:hang:5000" → hang model load for 5s
- *   ELIZA_CRASH_INJECT="native-bridge:restart"→ request a clean restart (exit 75)
+ *   ELIZA_CRASH_INJECT="native-bridge:restart"→ request a clean restart
  *   ELIZA_CRASH_INJECT="steady:oom:200"       → grow heap by ~200MB chunks
  *
  * Logging deliberately uses `process.stderr` rather than the core logger: a
@@ -23,6 +23,9 @@
  * @module crash-injection
  */
 import process from "node:process";
+import { RESTART_EXIT_CODE } from "@elizaos/shared/restart";
+
+export { RESTART_EXIT_CODE };
 
 /** Lifecycle points an injected fault can target. Keep in sync with the matrix. */
 export const CRASH_INJECTION_POINTS = [
@@ -64,9 +67,6 @@ export type CrashInjectionConfig = Map<
   CrashInjectionPoint,
   CrashInjectionFault
 >;
-
-/** Exit code the supervisor (`run-node.mjs`) treats as "restart requested". */
-export const RESTART_EXIT_CODE = 75;
 
 const ENV_SPEC = "ELIZA_CRASH_INJECT";
 const ENV_ALLOW_PROD = "ELIZA_ALLOW_CRASH_INJECT";

--- a/packages/agent/test/crash-restart-supervisor.test.ts
+++ b/packages/agent/test/crash-restart-supervisor.test.ts
@@ -3,7 +3,7 @@
  *
  * Spawns the REAL `crash-injection` fixture child as a separate `bun` process
  * and drives it through a supervisor that mirrors `run-node.mjs`'s exit-code
- * contract: respawn on RESTART_EXIT_CODE (75), abort after MAX_RESTARTS_IN_WINDOW
+ * contract: respawn on RESTART_EXIT_CODE, abort after MAX_RESTARTS_IN_WINDOW
  * (5) restarts inside RESTART_WINDOW_MS (60s). This proves crash injection
  * actually produces the exit codes the supervisor keys on, and that the
  * supervisor restarts vs. propagates vs. storm-guards as designed — with real
@@ -14,6 +14,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { RESTART_EXIT_CODE } from "@elizaos/shared/restart";
 import { afterAll, describe, expect, it } from "vitest";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -28,8 +29,6 @@ const GUARDS_CHILD = path.join(HERE, "fixtures", "process-guards-child.ts");
 const describeE2E =
   process.env.RUN_CRASH_RESTART_E2E === "1" ? describe : describe.skip;
 
-// Mirrors run-node.mjs:154-159. Kept in sync via this comment + the e2e below.
-const RESTART_EXIT_CODE = 75;
 const MAX_RESTARTS_IN_WINDOW = 5;
 const RESTART_WINDOW_MS = 60_000;
 
@@ -72,7 +71,7 @@ const runMemoryChild = (env: Record<string, string>): Promise<number> =>
 const runGuardsChild = (env: Record<string, string>): Promise<number> =>
   runChildAt(GUARDS_CHILD, env, 10_000);
 
-/** Supervisor mirroring run-node.mjs: respawn on 75, storm-guard, else propagate. */
+/** Supervisor mirroring run-node.mjs: respawn on RESTART_EXIT_CODE, storm-guard, else propagate. */
 async function supervise(
   spawnChild: () => Promise<number>,
 ): Promise<{ spawns: number; finalCode: number; aborted: boolean }> {
@@ -98,7 +97,7 @@ async function supervise(
 describeE2E(
   "crash-injection produces the supervisor exit-code contract",
   () => {
-    it("restart mode exits 75 (supervisor would respawn)", async () => {
+    it("restart mode exits RESTART_EXIT_CODE (supervisor would respawn)", async () => {
       const code = await runChild({ ELIZA_CRASH_INJECT: "boot:restart" });
       expect(code).toBe(RESTART_EXIT_CODE);
     }, 20_000);
@@ -130,7 +129,7 @@ describeE2E(
 );
 
 describeE2E("supervisor restart contract (mirrors run-node.mjs)", () => {
-  it("respawns on exit 75 until the child stops requesting restart", async () => {
+  it("respawns on RESTART_EXIT_CODE until the child stops requesting restart", async () => {
     const counter = path.join(
       os.tmpdir(),
       `eliza-10203-counter-${process.pid}-a.txt`,
@@ -143,7 +142,7 @@ describeE2E("supervisor restart contract (mirrors run-node.mjs)", () => {
         CRASH_CHILD_RESTART_LIMIT: "3",
       }),
     );
-    // 3 restarts (exit 75) + 1 final clean run = 4 spawns; not aborted.
+    // 3 restarts + 1 final clean run = 4 spawns; not aborted.
     expect(result.spawns).toBe(4);
     expect(result.finalCode).toBe(0);
     expect(result.aborted).toBe(false);
@@ -174,7 +173,7 @@ describeE2E("supervisor restart contract (mirrors run-node.mjs)", () => {
 // End-to-end proof for the memory watchdog (#10197): the unit test covers
 // createMemoryWatchdog's threshold/debounce logic and the block above covers the
 // supervisor's exit-75 respawn — but nothing drives a REAL process whose real
-// RSS crosses the threshold through the real requestRestart seam. These close
+// RSS crosses the threshold through the real requestRestart path. These close
 // that gap with a spawned bun child under genuine memory pressure.
 describeE2E("memory watchdog -> supervised restart (real RSS pressure)", () => {
   it("trips on sustained RSS over threshold and exits RESTART_EXIT_CODE", async () => {
@@ -224,12 +223,18 @@ describeE2E("memory watchdog -> supervised restart (real RSS pressure)", () => {
 // rejection, proving the actual process.on(...) wiring behaves per policy.
 describeE2E("installProcessCrashGuards -> real process fault handling", () => {
   it("exits RESTART_EXIT_CODE on a real uncaught exception (restart policy)", async () => {
-    const code = await runGuardsChild({ PG_POLICY: "restart", PG_FAULT: "uncaught" });
+    const code = await runGuardsChild({
+      PG_POLICY: "restart",
+      PG_FAULT: "uncaught",
+    });
     expect(code).toBe(RESTART_EXIT_CODE);
   }, 15_000);
 
   it("exits 1 on a real uncaught exception (exit policy)", async () => {
-    const code = await runGuardsChild({ PG_POLICY: "exit", PG_FAULT: "uncaught" });
+    const code = await runGuardsChild({
+      PG_POLICY: "exit",
+      PG_FAULT: "uncaught",
+    });
     expect(code).toBe(1);
   }, 15_000);
 
@@ -242,7 +247,10 @@ describeE2E("installProcessCrashGuards -> real process fault handling", () => {
   }, 15_000);
 
   it("treats a real unhandled promise rejection as non-fatal -> stays alive, exit 0", async () => {
-    const code = await runGuardsChild({ PG_POLICY: "restart", PG_FAULT: "rejection" });
+    const code = await runGuardsChild({
+      PG_POLICY: "restart",
+      PG_FAULT: "rejection",
+    });
     expect(code).toBe(0);
   }, 15_000);
 });

--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -18,6 +18,10 @@ FROM node:24-bookworm-slim AS entrypoint-build
 WORKDIR /build
 COPY eliza/packages/app-core/deploy/cloud-agent-entrypoint.ts ./cloud-agent-entrypoint.ts
 COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.ts
+# cloud-agent-shared.ts imports this via ../../shared/... in the repo layout.
+# The builder copies TS files into /build, so mirror that relative path here for
+# esbuild's resolver without adding a runtime dependency on @elizaos/shared.
+COPY eliza/packages/shared/src/restart-exit-code.json /shared/src/restart-exit-code.json
 RUN npx --yes esbuild@0.28.1 cloud-agent-entrypoint.ts \
       --bundle --platform=node --format=esm --target=node24 \
       --external:@elizaos/* --external:node:* \

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -8,6 +8,11 @@
 
 import * as crypto from "node:crypto";
 import * as http from "node:http";
+import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
+  type: "json",
+};
+
+const CLOUD_AGENT_RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 
 // ─── Logger ─────────────────────────────────────────────────────────────
 //
@@ -817,7 +822,6 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
   // uncaught exception exits non-zero so the orchestrator (Docker
   // `--restart unless-stopped` / K8s `restartPolicy: Always`) relaunches a clean
   // container. Exit code matches @elizaos/shared RESTART_EXIT_CODE.
-  const CLOUD_AGENT_RESTART_EXIT_CODE = 75;
   process.on("unhandledRejection", (reason) => {
     logger.error("Unhandled promise rejection (non-fatal)", {
       err:

--- a/packages/app-core/scripts/run-node-supervisor.test.mjs
+++ b/packages/app-core/scripts/run-node-supervisor.test.mjs
@@ -4,31 +4,35 @@
  * Drives the *actual* runner — not a reimplementation — with `ELIZA_ENTRY_FILE`
  * pointed at a tiny fake child, in a temp cwd whose `dist/.buildstamp` makes the
  * staleness check skip the rebuild. The fake child exits with the real restart
- * exit code (75) a controlled number of times, so we assert the genuine
- * exit-75 → relaunch loop and the rapid-restart abort guard end to end, using
- * real OS processes and real exit codes.
+ * exit code a controlled number of times, so we assert the genuine restart
+ * relaunch loop and the rapid-restart abort guard end to end, using real OS
+ * processes and real exit codes.
  */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
+  type: "json",
+};
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUN_NODE = path.join(SCRIPT_DIR, "run-node.mjs");
+const RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 
-// A child that records each spawn and exits 75 (request restart) until it has
-// been started FAKE_CHILD_RESTART_UNTIL times, then exits 0 (clean).
+// A child that records each spawn and exits with the shared restart code until
+// it has been started FAKE_CHILD_RESTART_UNTIL times, then exits 0 (clean).
 const FAKE_CHILD = `import fs from "node:fs";
 const counterFile = process.env.FAKE_CHILD_COUNTER;
+const restartExitCode = Number(process.env.RESTART_EXIT_CODE);
 const restartUntil = Number(process.env.FAKE_CHILD_RESTART_UNTIL ?? "0");
 let count = 0;
 try { count = Number(fs.readFileSync(counterFile, "utf8").trim()) || 0; } catch {}
 count += 1;
 fs.writeFileSync(counterFile, String(count));
-process.exit(count <= restartUntil ? 75 : 0);
+process.exit(count <= restartUntil ? restartExitCode : 0);
 `;
 
 let workDir;
@@ -64,6 +68,7 @@ function runSupervisor(restartUntil) {
         ELIZA_RUNNER_LOG: "1",
         FAKE_CHILD_COUNTER: counterFile,
         FAKE_CHILD_RESTART_UNTIL: String(restartUntil),
+        RESTART_EXIT_CODE: String(RESTART_EXIT_CODE),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -86,8 +91,8 @@ function runSupervisor(restartUntil) {
 }
 
 describe("run-node.mjs supervisor (real processes)", () => {
-  it("relaunches a child that exits with code 75, then exits cleanly", async () => {
-    // Child requests a restart twice (exit 75), then exits 0 on the 3rd launch.
+  it("relaunches a child that exits with the restart code, then exits cleanly", async () => {
+    // Child requests a restart twice, then exits 0 on the 3rd launch.
     const { code, spawnCount, stderr } = await runSupervisor(2);
     expect(spawnCount).toBe(3); // initial + 2 relaunches
     expect(code).toBe(0); // clean exit after the child stops requesting restarts
@@ -95,7 +100,7 @@ describe("run-node.mjs supervisor (real processes)", () => {
   }, 30_000);
 
   it("aborts a crash loop after MAX_RESTARTS_IN_WINDOW restarts", async () => {
-    // Child always exits 75 → the guard must abort instead of spinning forever.
+    // Child always requests restart; the guard must abort instead of spinning forever.
     const { code, spawnCount, stderr } = await runSupervisor(
       Number.MAX_SAFE_INTEGER,
     );

--- a/packages/app-core/scripts/run-node.mjs
+++ b/packages/app-core/scripts/run-node.mjs
@@ -3,6 +3,9 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import restartExitCodeDefinition from "../../shared/src/restart-exit-code.json" with {
+  type: "json",
+};
 import { registerRestartAndShouldAbort } from "./lib/restart-guard.mjs";
 import { syncElizaEnvAliases } from "./lib/sync-eliza-env-aliases.mjs";
 import {
@@ -152,7 +155,7 @@ const logRunner = (message) => {
 };
 
 /** Exit code used by the restart action to signal "restart requested". */
-const RESTART_EXIT_CODE = 75;
+const RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 
 /** Guard against infinite restart loops. */
 const MAX_RESTARTS_IN_WINDOW = 5;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -103,6 +103,16 @@
       "import": "./dist/runtime-env.js",
       "default": "./dist/runtime-env.js"
     },
+    "./restart": {
+      "types": "./dist/restart.d.ts",
+      "eliza-source": {
+        "types": "./src/restart.ts",
+        "import": "./src/restart.ts",
+        "default": "./src/restart.ts"
+      },
+      "import": "./dist/restart.js",
+      "default": "./dist/restart.js"
+    },
     "./brand": {
       "types": "./dist/brand/index.d.ts",
       "import": "./dist/brand/index.js",

--- a/packages/shared/src/restart-exit-code.json
+++ b/packages/shared/src/restart-exit-code.json
@@ -1,0 +1,3 @@
+{
+  "restartExitCode": 75
+}

--- a/packages/shared/src/restart.ts
+++ b/packages/shared/src/restart.ts
@@ -8,12 +8,14 @@
  *
  * @module restart
  */
+import restartExitCodeDefinition from "./restart-exit-code.json" with {
+  type: "json",
+};
 
 /**
  * Special exit code that tells the CLI runner to restart the process.
- * Must stay in sync with `RESTART_EXIT_CODE` in `eliza/packages/app-core/scripts/run-node.mjs`.
  */
-export const RESTART_EXIT_CODE = 75;
+export const RESTART_EXIT_CODE = restartExitCodeDefinition.restartExitCode;
 
 /**
  * A function invoked when a restart is requested.


### PR DESCRIPTION
# Relates to

Addresses #12093 item 10.

Definition of Done: full standard in [`PR_EVIDENCE.md`](PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin develop && git rebase origin/develop`).
- [x] `bun install` was run after sync. `bun run verify` is not currently actionable because package-level typechecks fail on unrelated optional plugin/native declaration blockers documented below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] Focused checks pass post-sync; exact unrelated full-typecheck blockers are documented in **Known gaps / failures**.

# Risks

Low. This centralizes an existing numeric restart contract without changing the runtime value. Affected surfaces are restart supervision, crash injection, crash-restart tests, and the cloud-agent bundled entrypoint.

# Background

## What does this PR do?

Single-sources the supervised restart exit code in `packages/shared/src/restart-exit-code.json` and wires all restart-code consumers to that value:

- `@elizaos/shared` exports `RESTART_EXIT_CODE` from the JSON-backed restart module and adds a public `@elizaos/shared/restart` subpath.
- `packages/app-core/scripts/run-node.mjs` imports the buildless JSON directly instead of declaring its own value.
- `packages/agent/src/runtime/crash-injection.ts` re-exports the shared restart code instead of redeclaring it.
- Crash/restart supervisor tests use the shared value.
- Cloud-agent crash guards use the same JSON value, with `Dockerfile.cloud-agent` copying the JSON into the flattened esbuild builder path so the bundle inlines it without adding a runtime `@elizaos/shared` dependency.

## What kind of change is this?

Improvement / refactor of an existing runtime contract.

# Documentation changes needed?

My changes do not require project documentation changes. This is an internal contract refactor with test/build evidence.

# Testing

## Where should a reviewer start?

Start with `packages/shared/src/restart-exit-code.json`, then check `packages/shared/src/restart.ts`, `packages/app-core/scripts/run-node.mjs`, and `packages/agent/src/runtime/crash-injection.ts`.

## Detailed testing steps

Automated checks used:

- `bun install --frozen-lockfile --ignore-scripts`
- `node --check packages/app-core/scripts/run-node.mjs && node --check packages/app-core/scripts/run-node-supervisor.test.mjs`
- `bunx @biomejs/biome check packages/shared/src/restart.ts packages/shared/src/restart-exit-code.json packages/shared/package.json packages/agent/src/runtime/crash-injection.ts packages/agent/src/runtime/crash-injection.test.ts packages/agent/test/crash-restart-supervisor.test.ts packages/app-core/scripts/run-node.mjs packages/app-core/scripts/run-node-supervisor.test.mjs packages/app-core/deploy/cloud-agent-shared.ts packages/app-core/deploy/Dockerfile.cloud-agent`
- `bun run --cwd packages/shared test src/process-guards.test.ts`
- `bun run --cwd packages/agent test src/runtime/crash-injection.test.ts test/crash-restart-supervisor.test.ts`
- `bun run --cwd packages/app-core test scripts/run-node-supervisor.test.mjs`
- Docker-flattened cloud-agent esbuild simulation: copy the entrypoint/shared TS files into a temp `/root/build` layout, copy `restart-exit-code.json` into the corresponding two-level-up `shared/src` path, then run `npx --yes esbuild@0.28.1 cloud-agent-entrypoint.ts --bundle --platform=node --format=esm --target=node24 '--external:@elizaos/*' '--external:node:*' --outfile=entrypoint.js`
- `bun run --cwd packages/shared typecheck && bun run --cwd packages/shared build:dist`
- `bun run --cwd packages/agent build`
- `bun run --cwd packages/app-core build`
- `node --input-type=module -e 'const m = await import("@elizaos/shared/restart"); if (m.RESTART_EXIT_CODE !== 75) throw new Error(`unexpected ${m.RESTART_EXIT_CODE}`); console.log(m.RESTART_EXIT_CODE);'`
- `rg '(^|const\s+|export\s+const\s+)(RESTART_EXIT_CODE|CLOUD_AGENT_RESTART_EXIT_CODE)\s*=\s*75|restartExitCode"?:\s*75' -n packages plugins scripts --glob '!**/node_modules/**' --glob '!**/dist/**'` returns only `packages/shared/src/restart-exit-code.json`.

# Evidence Gate

- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface changed`.
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - no UI surface changed`.
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - no UI/user flow changed`.
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no server request path/logging behavior changed; real process supervisor and crash-injection tests exercise the runtime path`.
- [x] Frontend console and network logs show the request/response and state change, or marked `N/A - no frontend request/state path changed`.
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no LLM/action/provider/prompt/model behavior changed`.
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifact produced`.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no frontend or HTTP request path changed. Backend/runtime behavior is covered by real-process supervisor tests and the cloud-agent esbuild bundle simulation listed above.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI surface changed.

### After

N/A - no UI surface changed.

### Walkthrough video

N/A - no UI/user flow changed.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT/omnivoice behavior changed.

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` fails on unrelated existing workspace blockers: missing optional plugin declarations for `@elizaos/plugin-commands`, `@elizaos/plugin-streaming`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, `@elizaos/plugin-meetings`; downstream implicit-any errors in existing command/Discord tests; and existing `@elizaos/core` export mismatch for `warnOnUnmatchedActionRolePolicyKeys`.
- `bun run --cwd packages/app-core typecheck` fails on unrelated existing workspace blockers: the same agent/core mismatch, missing optional plugin declarations for `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, `@elizaos/plugin-anthropic`, missing native Capacitor declarations, existing `unknown` typing errors in `ios-runtime-bridge.ts`, and missing `@elizaos/tui` declarations.
- `bun run verify` was not run to completion because it includes the failing package typechecks above. Focused tests and builds for this restart-code change pass.
