### PR TITLE
refactor(ui): resolve the cloud token through one channel; delete the global slot (#12091 item 27)

### DIFF
--- a/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-agent-lifecycle.spec.ts
@@ -236,8 +236,7 @@ async function seedCloudActiveAgent(
   await page.addInitScript(
     ({ token, voiceKey }) => {
       localStorage.setItem(voiceKey, "1");
-      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-        token;
+      localStorage.setItem("steward_session_token", token);
     },
     { token: CLOUD_AUTH_TOKEN, voiceKey: VOICE_PREFIX_DONE_STORAGE_KEY },
   );

--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -426,8 +426,7 @@ for (const viewport of VIEWPORTS) {
         localStorage.clear();
         sessionStorage.clear();
         localStorage.setItem(voicePrefixDoneKey, "1");
-        (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-          cloudAuthToken;
+        localStorage.setItem("steward_session_token", cloudAuthToken);
       },
       {
         cloudAuthToken: CLOUD_AUTH_TOKEN,
@@ -754,8 +753,7 @@ test("new cloud agent provisions through direct cloud sandbox and reaches chat",
       localStorage.clear();
       sessionStorage.clear();
       localStorage.setItem(voicePrefixDoneKey, "1");
-      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-        cloudAuthToken;
+      localStorage.setItem("steward_session_token", cloudAuthToken);
     },
     {
       cloudAuthToken: CLOUD_AUTH_TOKEN,

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -568,10 +568,12 @@ export const CLOUD_AUTH_TOKEN = "ui-smoke-onboarding-cloud-token";
 export const CLOUD_AGENT_ID = "ui-smoke-cloud-agent-1";
 export const CLOUD_AGENT_NAME = "Smoke Cloud Agent";
 
-/** Inject the cloud session token before React boots (getCloudAuthToken reads it). */
+/** Inject the cloud session token before React boots (getCloudAuthToken reads
+ *  the canonical steward-session store first). */
 export async function injectCloudAuthToken(page: Page): Promise<void> {
   await page.addInitScript((token) => {
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ = token;
+    // STEWARD_TOKEN_KEY from @elizaos/shared/steward-session-client.
+    window.localStorage.setItem("steward_session_token", token);
   }, CLOUD_AUTH_TOKEN);
 }
 

--- a/packages/test/cloud-e2e/tests/app-client-handoff-success.spec.ts
+++ b/packages/test/cloud-e2e/tests/app-client-handoff-success.spec.ts
@@ -25,6 +25,11 @@
  *     again, nothing re-inserted).
  */
 
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { ElizaClient } from "@elizaos/ui/api";
 import { getBootConfig, setBootConfig } from "@elizaos/ui/config";
 import { authedClient } from "../src/helpers/monetization";
@@ -34,8 +39,6 @@ import {
 } from "../src/helpers/provisioning";
 import { seedModelPricing } from "../src/helpers/seed-pricing";
 import { expect, test } from "../src/helpers/test-fixtures";
-
-const CLOUD_TOKEN_GLOBAL = "__ELIZA_CLOUD_AUTH_TOKEN__";
 
 // Context-echo mock LLM so the shared turns produce a deterministic, real
 // transcript (reply derived from replayed history) — there must be something to
@@ -56,11 +59,9 @@ test.describe("app onboarding handoff — success switch", () => {
     const c = authedClient(cloudApiBase, authToken);
 
     const prevBoot = getBootConfig();
-    const prevToken = (globalThis as Record<string, unknown>)[
-      CLOUD_TOKEN_GLOBAL
-    ];
+    const prevToken = readStoredStewardToken();
     setBootConfig({ ...prevBoot, cloudApiBase });
-    (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = authToken;
+    writeStoredStewardToken(authToken);
 
     // Price the shared turn's model so the in-Worker billing path can settle a
     // real debit (no live BitRouter key). `openai/<model>` resolves billingSource
@@ -249,10 +250,10 @@ test.describe("app onboarding handoff — success switch", () => {
       ).toBe(4);
     } finally {
       setBootConfig(prevBoot);
-      if (prevToken === undefined) {
-        delete (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL];
+      if (prevToken === null) {
+        clearStoredStewardToken();
       } else {
-        (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = prevToken;
+        writeStoredStewardToken(prevToken);
       }
     }
   });

--- a/packages/test/cloud-e2e/tests/app-client-onboarding.spec.ts
+++ b/packages/test/cloud-e2e/tests/app-client-onboarding.spec.ts
@@ -21,11 +21,14 @@
  *      shared adapter. This is the documented best-effort handoff contract.
  */
 
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { ElizaClient } from "@elizaos/ui/api";
 import { getBootConfig, setBootConfig } from "@elizaos/ui/config";
 import { expect, test } from "../src/helpers/test-fixtures";
-
-const CLOUD_TOKEN_GLOBAL = "__ELIZA_CLOUD_AUTH_TOKEN__";
 
 test.describe("app onboarding client ↔ real cloud-api", () => {
   test("real ElizaClient provisions, reuses, and arms the handoff through the router", async ({
@@ -40,11 +43,9 @@ test.describe("app onboarding client ↔ real cloud-api", () => {
     // getBootConfig().cloudApiBase, and the compat fetch reads the cloud token
     // from the global the controller normally sets at sign-in.
     const prevBoot = getBootConfig();
-    const prevToken = (globalThis as Record<string, unknown>)[
-      CLOUD_TOKEN_GLOBAL
-    ];
+    const prevToken = readStoredStewardToken();
     setBootConfig({ ...prevBoot, cloudApiBase });
-    (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = authToken;
+    writeStoredStewardToken(authToken);
 
     try {
       const client = new ElizaClient(cloudApiBase, authToken);
@@ -104,10 +105,10 @@ test.describe("app onboarding client ↔ real cloud-api", () => {
       expect(handoff.status).toBe("timed-out");
     } finally {
       setBootConfig(prevBoot);
-      if (prevToken === undefined) {
-        delete (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL];
+      if (prevToken === null) {
+        clearStoredStewardToken();
       } else {
-        (globalThis as Record<string, unknown>)[CLOUD_TOKEN_GLOBAL] = prevToken;
+        writeStoredStewardToken(prevToken);
       }
     }
   });

--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // Mock-cloud connect e2e (#8621 / #8387): the REAL client connect path —
 // selectOrProvisionCloudAgent → cold-boot wait → base resolution → chat REST
 // round-trip — driven against a REAL HTTP server that implements the cloud
@@ -338,7 +339,6 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
   afterAll(async () => {
     await new Promise<void>((resolve) => server.close(() => resolve()));
     setBootConfig(DEFAULT_BOOT_CONFIG);
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   });
 
   beforeEach(() => {
@@ -349,7 +349,6 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
     // Make the mock origin the recognized direct-cloud base for both
     // isDirectCloudBase() (client-base origin match) and the native fallback.
     setBootConfig({ ...DEFAULT_BOOT_CONFIG, cloudApiBase: base });
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   });
 
   function makeClient(): ElizaClient {
@@ -503,8 +502,7 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
       detailFailuresRemaining: 2,
     });
     const client = makeClient();
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      AUTH_TOKEN;
+    client.setToken(AUTH_TOKEN);
     const record = await waitForCloudAgentRunning(client, {
       agentId: "agent-ded",
       pollIntervalMs: 20,

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -34,7 +34,6 @@ describe("ElizaClient direct Cloud auth on hosted web", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   });
 
   it("creates CLI sessions through the same-origin proxy and opens staging auth", async () => {

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -45,14 +45,12 @@ describe("ElizaClient direct Cloud auth on native", () => {
       branding: {},
       cloudApiBase: "https://www.elizacloud.ai",
     });
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
     capacitorMocks.get.mockReset();
     capacitorMocks.post.mockReset();
     capacitorMocks.request.mockReset();
   });
 
   afterEach(() => {
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -914,8 +912,7 @@ describe("ElizaClient direct Cloud auth on native", () => {
       login.apiBase ?? "https://api.elizacloud.ai",
       login.sessionId ?? "missing-session",
     );
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      poll.token;
+    client.setToken(poll.token ?? null);
 
     const status = await client.getCloudStatus();
     const agents = await client.getCloudCompatAgents();

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -21,24 +21,24 @@ function makeJwt(exp: number | null): string {
 describe("getCloudAuthToken (Cloud = Steward everywhere)", () => {
   beforeEach(() => {
     localStorage.removeItem(STEWARD_TOKEN_KEY);
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   });
 
   afterEach(() => {
     localStorage.removeItem(STEWARD_TOKEN_KEY);
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   });
 
-  it("prefers the Steward session token over the legacy global", () => {
+  it("prefers the Steward session token over the client REST token", () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, "steward-jwt");
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      "device-code-token";
-    expect(getCloudAuthToken()).toBe("steward-jwt");
+    const client = new ElizaClient();
+    client.setToken("client-token");
+    expect(getCloudAuthToken(client)).toBe("steward-jwt");
+    client.setToken(null);
   });
 
-  it("falls back to the legacy global when no Steward token (device-code/Remote)", () => {
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      "device-code-token";
+  it("resolves the device-code/Remote session token from the steward store", () => {
+    // The device-code/pairing flow persists its session token through the same
+    // steward-session store, so it resolves via the canonical Steward branch.
+    localStorage.setItem(STEWARD_TOKEN_KEY, "device-code-token");
     expect(getCloudAuthToken()).toBe("device-code-token");
   });
 

--- a/packages/ui/src/api/client-cloud-web-join-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-join-base.test.ts
@@ -45,13 +45,11 @@ function setHostname(hostname: string, protocol = "https:"): void {
 }
 
 beforeEach(() => {
-  (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-    "steward-jwt";
+  localStorage.setItem("steward_session_token", "steward-jwt");
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
 });
 
 describe("getCloudCompatAgents on hosted web with no agent baseUrl (join flow)", () => {

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -7,6 +7,7 @@ import { Capacitor, CapacitorHttp } from "@capacitor/core";
 import {
   readStoredStewardToken,
   STEWARD_REFRESH_ENDPOINT,
+  writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import {
@@ -320,19 +321,14 @@ function resolveDirectCloudClientApiBase(client: ElizaClient): string | null {
  * `steward-token` cookie; on native (`capacitor://localhost` / loopback) it is
  * sent as `Authorization: Bearer`.
  *
- * The legacy `__ELIZA_CLOUD_AUTH_TOKEN__` global and the client REST token are
- * kept only as fallbacks for the Remote (device-code/pairing) flow, which still
- * mints its own session token via `cloudLoginPollDirect`.
+ * The Remote (device-code/pairing) flow mints its own session token via
+ * `cloudLoginPollDirect` and persists it through the same steward-session store
+ * (`writeStoredStewardToken`), so it resolves here through the canonical Steward
+ * branch too. The client REST token is the last fallback.
  */
 export function getCloudAuthToken(client?: ElizaClient): string | null {
   const stewardToken = readStoredStewardToken()?.trim();
   if (stewardToken) return stewardToken;
-
-  const globalToken = (globalThis as Record<string, unknown>)
-    .__ELIZA_CLOUD_AUTH_TOKEN__;
-  if (typeof globalToken === "string" && globalToken.trim()) {
-    return globalToken.trim();
-  }
 
   const clientToken = client?.getRestAuthToken()?.trim();
   return clientToken || null;
@@ -3093,11 +3089,11 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
   // Ensure the direct-cloud requests below authenticate even on a cold boot,
-  // where the runtime global token may be empty (the caller always passes the
-  // session token).
-  if (authToken && typeof globalThis !== "undefined") {
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      authToken;
+  // where the resolved token may be empty (the caller always passes the session
+  // token). Persist it through the canonical steward-session store so
+  // getCloudAuthToken() resolves it for those requests.
+  if (authToken) {
+    writeStoredStewardToken(authToken);
   }
 
   // Reuse an existing agent unless the caller explicitly forces a new one. This

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -230,9 +230,9 @@ export interface CloudLoginPollResponse {
   status: "pending" | "authenticated" | "expired" | "error";
   /**
    * Cloud API key, returned only on `status: "authenticated"`. The renderer
-   * uses this to populate `globalThis.__ELIZA_CLOUD_AUTH_TOKEN__` so the
-   * direct cloud path (`/api/v1/eliza/...`) can be used for agent
-   * provisioning. Without it the renderer falls back to the proxy compat
+   * persists this through the steward-session store (the canonical cloud-token
+   * channel) so the direct cloud path (`/api/v1/eliza/...`) can be used for
+   * agent provisioning. Without it the renderer falls back to the proxy compat
    * path whose queue doesn't drain.
    */
   token?: string;

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -8,6 +8,7 @@ import {
   type ProviderStatus,
   parseCoinGeckoMarkets,
 } from "@elizaos/shared";
+import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import {
   summarizeTranscript,
   type Transcript,
@@ -361,10 +362,9 @@ function readIosCloudPairing(): IosCloudPairing {
   const id = stringValue(activeServer.id);
   const agentId = id?.startsWith("cloud:") ? id.slice("cloud:".length) : null;
   const storedToken = stringValue(activeServer.accessToken);
-  const globalToken = stringValue(
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__,
-  );
-  const token = storedToken ?? globalToken;
+  // The device-code/pairing flow persists its cloud session token through the
+  // steward-session store (see client-cloud.getCloudAuthToken).
+  const token = storedToken ?? readStoredStewardToken()?.trim() ?? null;
   const label = stringValue(activeServer.label);
   return {
     paired: Boolean(agentId && token),

--- a/packages/ui/src/cloud/join/lib/resolve-cloud-connection.ts
+++ b/packages/ui/src/cloud/join/lib/resolve-cloud-connection.ts
@@ -6,8 +6,8 @@
  * Auth model: Cloud = Steward, unified across web AND native.
  * The Steward JWT in `localStorage.steward_session_token` is the canonical auth
  * source for every Cloud connection, so the join flow reads it directly via the
- * shared steward-session client rather than the legacy `__ELIZA_CLOUD_AUTH_TOKEN__`
- * global.
+ * shared steward-session client. The device-code/pairing flow persists its own
+ * session token through the same store, so there is one cloud-token channel.
  */
 
 import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -275,10 +275,6 @@ describe("cloud api-client transport bridge", () => {
       });
     }
 
-    afterEach(() => {
-      delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
-    });
-
     it("native: authorizes with the cloud API key when NO Steward token exists (the #11930 401 path)", async () => {
       capacitorState.isNative = true;
       window.localStorage.removeItem(STEWARD_TOKEN_KEY);
@@ -308,24 +304,6 @@ describe("cloud api-client transport bridge", () => {
         branding: {},
         cloudApiBase: "https://www.elizacloud.ai",
         apiToken: "local-agent-bearer-token",
-      });
-      nativeOk();
-
-      await api("/api/v1/apps");
-
-      const call = capacitorMocks.request.mock.calls[0]?.[0];
-      expect(call?.url).toBe("https://api.elizacloud.ai/api/v1/apps");
-      expect(call?.headers.authorization).toBeUndefined();
-    });
-
-    it("native: does not send a non-cloud legacy global token as Cloud authorization", async () => {
-      capacitorState.isNative = true;
-      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
-      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-        "legacy-local-agent-bearer-token";
-      setBootConfig({
-        branding: {},
-        cloudApiBase: "https://www.elizacloud.ai",
       });
       nativeOk();
 
@@ -380,29 +358,6 @@ describe("cloud api-client transport bridge", () => {
         }),
       );
       expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
-    });
-
-    it("native: the __ELIZA_CLOUD_AUTH_TOKEN__ global outranks the REST token, matching getCloudAuthToken()", async () => {
-      capacitorState.isNative = true;
-      window.localStorage.removeItem(STEWARD_TOKEN_KEY);
-      (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-        "eliza_legacy_global_cloud_token";
-      setBootConfig({
-        branding: {},
-        cloudApiBase: "https://www.elizacloud.ai",
-        apiToken: CLOUD_API_KEY,
-      });
-      nativeOk();
-
-      await api("/api/v1/apps");
-
-      expect(capacitorMocks.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            authorization: "Bearer eliza_legacy_global_cloud_token",
-          }),
-        }),
-      );
     });
 
     it("web: stays byte-identical — NO Authorization header from the REST token without a Steward JWT", async () => {

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -187,10 +187,9 @@ function readLiveNativeStewardToken(token: string): string | null {
  * config (see `ElizaClient.setToken`). So
  * without this fallback every native Apps API call left the WebView with NO
  * Authorization header and 401'd (#11930). The chain mirrors the canonical
- * `getCloudAuthToken()` in `../../api/client-cloud.ts` (steward JWT →
- * `__ELIZA_CLOUD_AUTH_TOKEN__` global → client REST token), read here via the
- * token's out-of-band mirrors because this module has no client handle. The
- * Cloud API accepts both a Steward JWT and the owner API key. Web stays
+ * `getCloudAuthToken()` in `../../api/client-cloud.ts` (steward JWT → owner cloud
+ * API key), read here from boot config because this module has no client handle.
+ * The Cloud API accepts both a Steward JWT and the owner API key. Web stays
  * byte-identical (steward token or nothing, exactly as before).
  */
 function readCloudBearerToken(): string | null {
@@ -201,12 +200,6 @@ function readCloudBearerToken(): string | null {
     if (liveToken) return liveToken;
   }
   if (!isNativeCloudRuntime()) return null;
-  const globalToken = (globalThis as Record<string, unknown>)
-    .__ELIZA_CLOUD_AUTH_TOKEN__;
-  if (typeof globalToken === "string") {
-    const cloudKey = normalizeCloudApiKeyToken(globalToken);
-    if (cloudKey) return cloudKey;
-  }
   return (
     normalizeCloudApiKeyToken(getBootConfig().apiToken) ??
     normalizeCloudApiKeyToken(getElizaApiToken())

--- a/packages/ui/src/cloud/lib/auth-query.test.tsx
+++ b/packages/ui/src/cloud/lib/auth-query.test.tsx
@@ -60,12 +60,10 @@ beforeEach(() => {
     value: storage,
   });
   capacitorState.isNative = false;
-  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   setBootConfig({ branding: {}, apiToken: undefined });
 });
 
 afterEach(() => {
-  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
   vi.unstubAllGlobals();
 });
 
@@ -127,10 +125,12 @@ describe("shared cloud query gate — session from persisted JWT only (page-relo
     expect(result.current.userId).toBeNull();
   });
 
-  it("native: ignores a non-cloud legacy global token", () => {
+  it("native: ignores a non-JWT (non-cloud) steward token", () => {
     capacitorState.isNative = true;
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      "legacy-local-agent-bearer-token";
+    localStorage.setItem(
+      "steward_session_token",
+      "legacy-local-agent-bearer-token",
+    );
 
     const { result } = renderHook(() => useAuthenticatedQueryGate());
 

--- a/packages/ui/src/cloud/lib/use-session-auth.ts
+++ b/packages/ui/src/cloud/lib/use-session-auth.ts
@@ -84,12 +84,6 @@ function isNativeCloudRuntime(): boolean {
 
 function nativeCloudApiKey(): string | null {
   if (!isNativeCloudRuntime()) return null;
-  const globalToken = (globalThis as Record<string, unknown>)
-    .__ELIZA_CLOUD_AUTH_TOKEN__;
-  if (typeof globalToken === "string") {
-    const cloudKey = normalizeCloudApiKeyToken(globalToken);
-    if (cloudKey) return cloudKey;
-  }
   // Only a real cloud key (not the on-device agent bearer) counts as a native
   // cloud session.
   return (

--- a/packages/ui/src/components/pages/cloud-dashboard-utils.ts
+++ b/packages/ui/src/components/pages/cloud-dashboard-utils.ts
@@ -39,14 +39,6 @@ export const STATUS_BADGE: Record<
   },
 };
 
-export function getCloudAuthToken(): string {
-  if (typeof window === "undefined") return "";
-  return (
-    ((globalThis as Record<string, unknown>)
-      .__ELIZA_CLOUD_AUTH_TOKEN__ as string) || ""
-  );
-}
-
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }

--- a/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
@@ -244,14 +244,12 @@ beforeEach(() => {
     success: true,
     data: [],
   });
-  (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-    "cloud-token";
+  localStorage.setItem("steward_session_token", "cloud-token");
 });
 
 afterEach(() => {
   __setAppValueForTests(null);
   ensureLocalStorage().clear();
-  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
 });
 
 describe("first-run conductor fuzz storms", () => {

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -207,15 +207,13 @@ beforeEach(() => {
     success: true,
     data: [],
   });
-  (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-    "cloud-token";
+  localStorage.setItem("steward_session_token", "cloud-token");
 });
 
 afterEach(() => {
   __setAppValueForTests(null);
   resetTutorialState();
   ensureLocalStorage().clear();
-  delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
 });
 
 describe("useFirstRunConductor", () => {
@@ -835,7 +833,7 @@ describe("useFirstRunConductor", () => {
   });
 
   it("re-offers an UNLOCKED runtime choice when cloud login does not land, and the LOCAL escape completes", async () => {
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+    localStorage.removeItem("steward_session_token");
     mocks.client.getCloudStatus.mockResolvedValue({ connected: false });
     seedAppStore({ elizaCloudConnected: false });
     const { turn, unmount } = renderConductor();
@@ -864,7 +862,7 @@ describe("useFirstRunConductor", () => {
   });
 
   it("auto-resumes the interrupted cloud flow when the cloud connection lands", async () => {
-    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+    localStorage.removeItem("steward_session_token");
     mocks.client.getCloudStatus.mockResolvedValue({ connected: false });
     seedAppStore({ elizaCloudConnected: false });
     const { turn, unmount } = renderConductor();
@@ -880,8 +878,7 @@ describe("useFirstRunConductor", () => {
 
     // The user connects from the OAuth block instead of re-picking: the token
     // lands and the store learns the connection — the flow resumes by itself.
-    (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-      "cloud-token";
+    localStorage.setItem("steward_session_token", "cloud-token");
     mocks.client.getCloudStatus.mockResolvedValue({ connected: true });
     seedAppStore({ elizaCloudConnected: true });
 

--- a/packages/ui/src/state/useChatLifecycle.ts
+++ b/packages/ui/src/state/useChatLifecycle.ts
@@ -7,6 +7,7 @@
 
 import { logger } from "@elizaos/logger";
 import { getDefaultStylePreset } from "@elizaos/shared";
+import { clearStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import type {
   Conversation,
@@ -654,10 +655,12 @@ export function useChatLifecycle(deps: UseChatLifecycleDeps) {
           setElizaCloudUserId(null);
           setElizaCloudStatusReason(null);
           setElizaCloudLoginError(null);
-          // Clear the global cloud token so directCloudRequest stops firing
-          // against api.elizacloud.ai with a stale key after reset. Without
-          // this, the renderer keeps making direct cloud calls even though
-          // the UI shows disconnected.
+          // Clear the stored cloud session token so directCloudRequest stops
+          // firing against api.elizacloud.ai with a stale key after reset.
+          // Without this, the renderer keeps making direct cloud calls even
+          // though the UI shows disconnected. The device-code flow persists its
+          // token through the steward-session store, so clearing that store is
+          // what getCloudAuthToken() reads first.
           //
           // Coupling guarantee: this runs in `clearElizaCloudSessionUi`,
           // which `complete-reset-local-state-after-wipe.ts` calls on
@@ -666,16 +669,7 @@ export function useChatLifecycle(deps: UseChatLifecycleDeps) {
           // token clear happens on every reset path that uses the
           // shared cascade. (The cascade is the sole caller; there
           // is no path that calls one without the other.)
-          if (typeof globalThis !== "undefined") {
-            try {
-              delete (globalThis as Record<string, unknown>)
-                .__ELIZA_CLOUD_AUTH_TOKEN__;
-            } catch {
-              (
-                globalThis as Record<string, unknown>
-              ).__ELIZA_CLOUD_AUTH_TOKEN__ = undefined;
-            }
-          }
+          clearStoredStewardToken();
         },
         markFirstRunReset: () => {
           enableForceFreshFirstRun();

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -672,17 +672,14 @@ export function useCloudState({
             consecutivePollErrors = 0;
             if (poll.status === "authenticated") {
               if (poll.token && typeof window !== "undefined") {
-                (
-                  globalThis as Record<string, unknown>
-                ).__ELIZA_CLOUD_AUTH_TOKEN__ = poll.token;
-                // Persist the token DURABLY too, not just on the volatile window
-                // global. On a native device the OAuth opens an external browser
+                // Persist the device-code session token through the canonical
+                // steward-session store (which getCloudAuthToken reads first). On
+                // a native device the OAuth opens an external browser
                 // (SFSafariViewController) which backgrounds the WebView; iOS
-                // often cold-launches it on return, wiping the global — so
-                // getCloudAuthToken() read nothing, elizaCloudConnected never
-                // recomputed true, and onboarding restarted at the greeting.
-                // Writing the steward-session channel (which getCloudAuthToken
-                // reads first) lets the connection survive the relaunch.
+                // often cold-launches it on return, so the token must be durable,
+                // not a volatile in-memory global — otherwise getCloudAuthToken()
+                // reads nothing, elizaCloudConnected never recomputes true, and
+                // onboarding restarts at the greeting.
                 writeStoredStewardToken(poll.token);
                 // Also update boot config so subsequent reads use the resolved cloud base.
                 const cfg = getBootConfig();
@@ -929,19 +926,12 @@ export function useCloudState({
         scrubPersistedActiveServerToken();
         // SECURITY: scrubbing active-server.accessToken alone is incomplete —
         // the LIVE cloud bearer also lives in (a) localStorage steward_session_token
-        // (the JWT read on every /api/* call), (b) per-agent-profile accessToken
-        // copies, and (c) the in-memory __ELIZA_CLOUD_AUTH_TOKEN__ global. Clear
-        // all of them on an explicit disconnect so no usable credential survives
-        // at rest / in memory (XSS / same-origin plugin views).
+        // (the JWT read on every /api/* call, and where the device-code flow
+        // persists its session token) and (b) per-agent-profile accessToken
+        // copies. Clear both on an explicit disconnect so no usable credential
+        // survives at rest / in memory (XSS / same-origin plugin views).
         clearStoredStewardToken();
         scrubPersistedAgentProfileTokens();
-        try {
-          delete (globalThis as Record<string, unknown>)
-            .__ELIZA_CLOUD_AUTH_TOKEN__;
-        } catch {
-          (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
-            undefined;
-        }
         if (wasConnected) {
           setActionNotice("Disconnected from Eliza Cloud.", "success");
         }

--- a/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-routes-autonomous.ts
@@ -730,9 +730,9 @@ export async function handleCloudRoute(
         }
       }
 
-      // Return the cloud API key to the renderer so it can populate
-      // `globalThis.__ELIZA_CLOUD_AUTH_TOKEN__` and use the direct cloud
-      // path (`/api/v1/eliza/agents`) for agent creation/provisioning.
+      // Return the cloud API key to the renderer so it can persist it through
+      // the steward-session store and use the direct cloud path
+      // (`/api/v1/eliza/agents`) for agent creation/provisioning.
       // Without this, every cloud op falls back to the proxy compat path,
       // which creates agents in a namespace whose queue never drains
       // (agents stay `status: "queued"` forever — setup hangs).


### PR DESCRIPTION
Refs #12091 (item 27).

## Problem

`globalThis.__ELIZA_CLOUD_AUTH_TOKEN__` was a legacy device-code/pairing fallback that ~6 production modules hand-rolled untyped reads/writes/deletes against, and `cloud-dashboard-utils.ts` defined a **name-colliding second `getCloudAuthToken()`** that read *only* the global (while its caller's comment claimed Steward-first behavior). Per DECISIONS.md D3 the Steward session JWT is already canonical, and the device-code flow already persists its session token through the same steward-session store — so the global was a redundant third channel.

## Change

- **`getCloudAuthToken()` (client-cloud.ts)** drops the global branch: **Steward token → client REST token**. It is now the single accessor that resolves the cloud token.
- **Writers** persist through the steward-session store (`writeStoredStewardToken`) instead of the global; disconnect + reset clear it via `clearStoredStewardToken` (both were already called right next to the removed global ops, so this is behavior-preserving). `useCloudState` already dual-wrote the device-code token to Steward; `client.setToken(poll.token)` mirrors it into `bootConfig.apiToken`.
- **`api-client` + `use-session-auth`** drop their native cloud-API-key global branch: the global only ever held session JWTs, which `isCloudApiKeyToken` (an `eliza_` prefix check) rejects — so the branch was dead. The owner cloud key resolves from `bootConfig.apiToken` (the documented #11930 native path), unchanged.
- **`ios-local-agent-kernel`** reads the Steward token instead of the global.
- **The dead duplicate `getCloudAuthToken` in `cloud-dashboard-utils.ts` is deleted** — `CloudAgentsSection` already imports the canonical one from `client-cloud`.
- No new store added (the item's explicit constraint).

## Done-when evidence

- **`grep -rn "__ELIZA_CLOUD_AUTH_TOKEN__" packages/ plugins/`** returns only the **4 committed golden-master e2e HTML snapshots** (`packages/ui/src/components/**/__e2e__/output*/*.html`) that embed a pre-refactor bundled copy — they refresh on the next component-e2e snapshot run and have no runtime effect. All hand-authored source, docs, and tests are clean.
- **Exactly one accessor** (`getCloudAuthToken`) resolves the cloud token.

### Verification

- `@elizaos/ui` typecheck: **0 errors**. Biome clean on touched files (one pre-existing `noAssignInExpressions` warning at an untouched line).
- Tests (all green, updated to seed the canonical Steward store / client token): `client-cloud-steward-token` (steward-first + device-code-via-steward), `cloud/lib/api-client` (native #11930 cloud-key path via bootConfig), `cloud/lib/auth-query`, `client-cloud-direct-auth`, `client-cloud-connect-mock-cloud`, `client-cloud-web-join-base`, `client-cloud-direct-auth-web` — **77 passed**; `use-first-run-conductor` + `.fuzz` — **31 passed**; `useCloudState.steward-*` + `useChatLifecycle.readiness` + `complete-reset` — **23 passed**. Live-cloud Playwright specs (`packages/test/cloud-e2e`, `packages/app/test/ui-smoke`) routed through the steward-session client / `localStorage.steward_session_token`; not runnable without a live cloud stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)