### PR TITLE
fix(#12209): populate routingHint on remaining collision-prone actions

### DIFF
--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -726,6 +726,8 @@ export const databaseAction: Action = {
     "Inspect or query the agent's database. Ops: list_tables, get_table, query (read-only by default), search_vectors (semantic memory search).",
   descriptionCompressed:
     "database list_tables|get_table|query(read-only default)|search_vectors",
+  routingHint:
+    "inspect the agent's RAW database — list/read tables, run read-only SQL, or vector/similarity search over stored rows -> DATABASE; for the agent's own conversational memory records about the user -> MEMORY (action=search); for the user's stored files -> FILES; for open-web lookups -> WEB_SEARCH",
   validate: async (runtime) => {
     registerVectorSearchCategory(runtime);
     return true;

--- a/packages/agent/src/actions/files.ts
+++ b/packages/agent/src/actions/files.ts
@@ -169,6 +169,8 @@ export const filesAction: Action = {
     "Access stored files. op:list shows recent stored files (optional query/limit); op:get returns a file's details + served URL by fileName; op:delete removes a file (requires confirm:true).",
   descriptionCompressed:
     "list/get/delete stored files; delete requires confirm:true",
+  routingHint:
+    "list/get/delete the agent's stored files by filename (the content-addressed media store) -> FILES; to read an attachment or link already in THIS conversation -> ATTACHMENT (action=read), for owner document signature/approval/deadline/portal workflows -> OWNER_DOCUMENTS, or to query raw database tables/rows -> DATABASE",
   validate: async () => true,
   handler: async (
     runtime: IAgentRuntime,

--- a/packages/agent/src/runtime/actions/web-fetch.test.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.test.ts
@@ -251,3 +251,13 @@ describe("guarded WEB_FETCH User-Agent defaults", () => {
     ).resolves.toBe("CallerUA/1.0");
   });
 });
+
+describe("WEB_FETCH routing hint (#12209)", () => {
+  it("states its planner boundary versus WEB_SEARCH, ATTACHMENT, and MEMORY", () => {
+    const hint = webFetch.routingHint ?? "";
+    expect(hint).toContain("WEB_FETCH");
+    expect(hint).toContain("WEB_SEARCH");
+    expect(hint).toContain("ATTACHMENT");
+    expect(hint).toContain("MEMORY");
+  });
+});

--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -117,6 +117,8 @@ export const webFetch: Action & Record<string, unknown> = {
   // 0, so those turns fell through to a coding sub-agent spawn.
   contexts: ["web"],
   suppressInitialMessage: true,
+  routingHint:
+    "fetch/read the contents of ONE specific URL, JSON API, or data file whose address you already have or can construct exactly (a price/weather endpoint, a page you can name) -> WEB_FETCH; to discover pages or answer an open-ended real-world question with NO known URL (prices, news, recommendations, 'latest on...') -> WEB_SEARCH; to read a link/attachment already in THIS conversation -> ATTACHMENT (action=read); for the user's own notes/memories -> MEMORY (action=search)",
   description:
     "Fetch one specific URL and return its contents — a JSON API, data file, or page whose address you already have or can construct exactly. " +
     "Prefer a JSON API over an HTML page so the value parses cleanly, and fetch it inline THIS turn — " +

--- a/packages/core/src/features/advanced-capabilities/actions/post.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveOp } from "./post.ts";
+import { postAction, resolveOp } from "./post.ts";
 
 /**
  * #10471 — POST op routing must come from the planner-emitted `action` enum
@@ -33,5 +33,15 @@ describe("post resolveOp is i18n-safe (#10471)", () => {
 		// "search"/"read" here; that English-only behavior is gone.
 		expect(resolveOp({ parameters: {} })).toBe("send");
 		expect(resolveOp(undefined)).toBe("send");
+	});
+});
+
+describe("POST routing hint (#12209)", () => {
+	it("states its planner boundary versus MESSAGE, REPLY, and ROOM", () => {
+		const hint = postAction.routingHint ?? "";
+		expect(hint).toContain("POST");
+		expect(hint).toContain("MESSAGE");
+		expect(hint).toContain("REPLY");
+		expect(hint).toContain("ROOM");
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/actions/post.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/post.ts
@@ -648,6 +648,8 @@ export const postAction: Action = {
 	similes: ["TWEET", "CAST", "PUBLISH", "FEED_POST", "TIMELINE"],
 	description: POST_DESCRIPTION,
 	descriptionCompressed: POST_COMPRESSED,
+	routingHint:
+		"publish/broadcast to a PUBLIC feed or timeline (tweet/cast/publish), or read/search public posts -> POST; do NOT use for a direct/private message, DM, group, or channel -> MESSAGE, to reply in the CURRENT chat/thread -> REPLY, or to join/mute/follow a channel -> ROOM",
 	contexts: POST_CONTEXTS,
 	roleGate: { minRole: "ADMIN" },
 	validate: async (runtime, message, state) => {

--- a/packages/core/src/features/advanced-capabilities/actions/room.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/room.ts
@@ -496,6 +496,8 @@ export const roomOpAction: Action = {
 		"Room mute/unmute/follow/unfollow. Default current room. Use roomId or platform+chatName for connector chat. mute+durationMinutes returns auto-unmute hint.",
 	descriptionCompressed:
 		"room mute|unmute|follow|unfollow; roomId or platform+chatName; durationMinutes",
+	routingHint:
+		"mute/unmute/follow/unfollow or join/leave a chat, channel, group, or thread -> ROOM; do NOT use to send/read messages in it -> MESSAGE, to reply in the current chat -> REPLY, or to publish to a public feed/timeline -> POST",
 	parameters: [
 		{
 			name: "action",

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -336,6 +336,8 @@ export const readAttachmentAction: Action = {
 	],
 	description:
 		"Attachment operations. Use action=read to read current or recent attachments/link previews using extracted text, transcripts, page content, or media descriptions. Use action=save_as_document to store readable attachment content in the document store.",
+	routingHint:
+		"read or save the content of an attachment, link preview, or media ALREADY present in THIS conversation (extracted text/transcript/page/description) -> ATTACHMENT; to fetch a brand-new URL you name yourself -> WEB_FETCH, to manage the agent's stored files -> FILES, or to answer an open-web question -> WEB_SEARCH",
 	suppressPostActionContinuation: true,
 	validate: async (runtime, message) => {
 		const params = message.content as Record<string, unknown>;

--- a/plugins/plugin-browser/src/actions/browser.test.ts
+++ b/plugins/plugin-browser/src/actions/browser.test.ts
@@ -490,3 +490,13 @@ describe("BROWSER action", () => {
     expect(result?.text).toMatch(/^Browser action failed:/);
   });
 });
+
+describe("BROWSER routing hint (#12209)", () => {
+  it("states its planner boundary versus WEB_FETCH, WEB_SEARCH, and COMPUTER_USE", () => {
+    const hint = browserAction.routingHint ?? "";
+    expect(hint).toContain("BROWSER");
+    expect(hint).toContain("WEB_FETCH");
+    expect(hint).toContain("WEB_SEARCH");
+    expect(hint).toContain("COMPUTER_USE");
+  });
+});

--- a/plugins/plugin-browser/src/actions/browser.ts
+++ b/plugins/plugin-browser/src/actions/browser.ts
@@ -673,6 +673,8 @@ export const browserAction: Action = {
     "BROWSER action. Control registered browser target: app workspace, bridge Chrome/Safari companion, computeruse Chromium, or Stagehand fallback. BrowserService picks target if omitted. action=autofill_login + domain vault-gated autofills open workspace tab. action=wait_for_url + pattern opens an optional url then watches the tab and resumes when its URL matches (OAuth callback, deploy/CI done), streaming progress.",
   descriptionCompressed:
     "Browser open|navigate|click|type|screenshot|state|autofill_login|wait_for_url; bridge status elsewhere",
+  routingHint:
+    "drive an INTERACTIVE web browser session — navigate/click/type across pages, log into a site, or autofill saved credentials on a real browser target -> BROWSER; to fetch ONE URL's contents in a single shot -> WEB_FETCH, to answer an open-web question -> WEB_SEARCH, or to control native desktop apps/Finder/windows on the machine -> COMPUTER_USE",
   validate: async () => true,
   handler: async (
     runtime,


### PR DESCRIPTION
## What

Completes the open item from #12209: *"Systematically populate `routingHint` on the remaining collision-prone actions (only the top cross-domain ones were done in #12021)."*

`routingHint` is the compression-immune "use when / do NOT use when" carrier that `actions/to-tool.ts` prepends **verbatim** to each planner tool description (never abbreviated by `compressPromptDescription`). #12021 added it to the top cross-domain actions (MESSAGE, MEMORY, WEB_SEARCH, COMPUTER_USE, …). This PR annotates the **remaining first-party umbrella actions that share a verb/noun with a sibling that routes differently** and currently lacked a hint.

## How the candidate set was built

I enumerated all 234 action objects across `packages/` and `plugins/` and cross-indexed every `name` + `similes` token to find genuine collisions/cross-domain ambiguity, then filtered to actions that **co-load in a normal first-party agent** and **lack a hint**. The tell: several #12021 hints already *name* an un-hinted sibling ("a specific URL you can already name -> WEB_FETCH", "publish to a public feed/timeline -> POST", "join/mute/follow a channel -> ROOM"), so those named targets were the exact reciprocal gaps to fill.

I deliberately **excluded** the collisions #12209 marked "investigated and NOT done" or that are product/human calls: the XR ↔ facewear de-fork (`XR_*` duplicated across `plugin-xr`/`plugin-facewear`), the PA CALENDLY/`CALENDAR` collapse, `TERMINAL_SHELL`, `plugin-todos`, and the cloud CHARACTER override. Also excluded: `packages/feed/**` (separate product with distinct character configs that never co-load), `packages/examples`/`templates`, and the benchmark scaffolding — none are real runtime collisions.

## Actions annotated (7 source files, 2 lines each, additive only)

Each hint was written from the action's real `name`/`similes`/`description`/handler, and every sibling name referenced was verified to be a real registered action.

| Action | File | Collision / ambiguity | Hint boundary |
|---|---|---|---|
| `WEB_FETCH` | `packages/agent/src/runtime/actions/web-fetch.ts` | similes `LIVE_INFO`/`CURRENT_PRICE`/`CURRENT_WEATHER` overlap WEB_SEARCH's domain; WEB_SEARCH's hint already points "specific URL -> WEB_FETCH" | fetch ONE named URL/API -> WEB_FETCH; discover/open-web -> WEB_SEARCH; in-convo link -> ATTACHMENT; user notes -> MEMORY |
| `POST` | `packages/core/src/features/advanced-capabilities/actions/post.ts` | MESSAGE's hint already routes "public feed/timeline -> POST"; #12021 explicitly listed POST as remaining | public feed/timeline -> POST; DM/group/channel -> MESSAGE; current chat -> REPLY; channel membership -> ROOM |
| `ROOM` | `packages/core/src/features/advanced-capabilities/actions/room.ts` | MESSAGE's hint already routes "join/mute/follow a channel -> ROOM" | mute/follow/join a channel -> ROOM; send/read in it -> MESSAGE; reply -> REPLY; publish -> POST |
| `DATABASE` | `packages/agent/src/actions/database.ts` | `search_vectors`/`VECTOR_SEARCH`/`SIMILARITY_SEARCH` similes overlap MEMORY's semantic search | raw tables/SQL/vector rows -> DATABASE; agent memory records -> MEMORY; files -> FILES; web -> WEB_SEARCH |
| `FILES` | `packages/agent/src/actions/files.ts` | file/document/attachment noun overlap with ATTACHMENT and OWNER_DOCUMENTS | stored files by name -> FILES; in-convo attachment -> ATTACHMENT; doc workflows -> OWNER_DOCUMENTS; DB rows -> DATABASE |
| `ATTACHMENT` | `packages/core/src/features/working-memory/readAttachmentAction.ts` | similes `READ_URL`/`OPEN_URL`/`READ_WEBPAGE` overlap WEB_FETCH; `save_as_document` overlaps FILES | read/save in-convo attachment/link preview -> ATTACHMENT; brand-new URL -> WEB_FETCH; stored files -> FILES; web -> WEB_SEARCH |
| `BROWSER` | `plugins/plugin-browser/src/actions/browser.ts` | autofill/navigate overlap COMPUTER_USE + WEB_FETCH/WEB_SEARCH; #12021 listed AUTOFILL / MANAGE_BROWSER_BRIDGE as remaining | interactive browser session/login/autofill -> BROWSER; one-shot URL -> WEB_FETCH; open-web -> WEB_SEARCH; native desktop -> COMPUTER_USE |

The seven hints form a mutually-consistent cross-reference web (WEB_FETCH ↔ WEB_SEARCH ↔ ATTACHMENT ↔ MEMORY; POST ↔ MESSAGE ↔ REPLY ↔ ROOM; FILES ↔ ATTACHMENT ↔ DATABASE; BROWSER ↔ COMPUTER_USE).

## Tests

Added planner-routing-hint assertions (mirroring `views-management.test.ts` / `health.test.ts`) to:
- `packages/agent/src/runtime/actions/web-fetch.test.ts`
- `packages/core/src/features/advanced-capabilities/actions/post.test.ts`
- `plugins/plugin-browser/src/actions/browser.test.ts`

## Verification

- **Typecheck** (`tsgo --noEmit`): 0 errors in every touched file. Remaining errors are pre-existing cross-package `Cannot find module @elizaos/…` noise from an isolated-worktree build (identical on `develop`), not from these edits. The core declaration `tsc` type-checked all three touched core files with zero errors.
- **Tests** (all green after building the `@elizaos/cloud-routing` dist that the isolated worktree lacked):
  - `web-fetch.test.ts` — 15 passed (incl. new hint test)
  - `post.test.ts` — 5 passed (incl. new hint test)
  - `browser.test.ts` — 13 passed (incl. new hint test)
  - `files.test.ts` + `database.search-vectors.test.ts` — 9 passed (regression, actions still register/parse)
  - `readAttachmentAction.i18n.test.ts` — 2 passed (regression)
- The generated `packages/core/src/generated/action-docs.ts` does **not** carry `routingHint` (verified: 0 occurrences despite existing hinted actions), so no doc regeneration is required.

## Not done (deliberately, per #12209)

XR/facewear de-fork, `CALENDAR`/CALENDLY collapse, `TERMINAL_SHELL` deletion, `plugin-todos`, and the cloud CHARACTER override — all flagged in #12209 as unsafe or product/human decisions. `packages/feed/**` and examples/templates/benchmark duplicates are separate products or scaffolding, not real runtime collisions.

Refs #12209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
