### PR TITLE
fix(core): let providers opt out of default registration

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4348,42 +4348,6 @@ export async function startEliza(
     }
   }
 
-  // ── Strip upstream skill providers ──────────────────────────────────────
-  // The upstream @elizaos/plugin-agent-skills registers providers that dump
-  // ALL loaded skills into every prompt (~2000-4000 tokens).  Eliza replaces
-  // them with a BM25-lite dynamic provider (see providers/skill-provider.ts)
-  // that injects only the most relevant skills per turn.
-  //
-  // We keep:
-  //   - agent_skills_overview  (lightweight stats, ~50 tokens)
-  //   - all actions (USE_SKILL, SEARCH_SKILLS, INSTALL_SKILL, …)
-  //   - the AGENT_SKILLS_SERVICE itself
-  {
-    const UPSTREAM_SKILL_PROVIDERS_TO_STRIP = new Set([
-      "agent_skills",
-      "agent_skill_instructions",
-      "agent_skills_catalog",
-    ]);
-    for (const plugin of pluginsForRuntime) {
-      if (
-        plugin.name === "@elizaos/plugin-agent-skills" &&
-        Array.isArray(plugin.providers)
-      ) {
-        const before = plugin.providers.length;
-        plugin.providers = plugin.providers.filter(
-          (p: { name?: string }) =>
-            !UPSTREAM_SKILL_PROVIDERS_TO_STRIP.has(p.name ?? ""),
-        );
-        const removed = before - plugin.providers.length;
-        if (removed > 0) {
-          logger.info(
-            `[eliza] Stripped ${removed} upstream skill provider(s) — using dynamic BM25-lite provider instead`,
-          );
-        }
-      }
-    }
-  }
-
   // Deduplicate actions across all plugins to avoid "Action already registered"
   // warnings from elizaOS core. basic-capabilities is registered first by the
   // runtime, so include it in deduplication so its actions take precedence.
@@ -5194,30 +5158,6 @@ export async function startEliza(
             `[eliza] Boosted deferred plugin "${plugin.name}" priority to ${plugin.priority} (preferred provider: ${preferredProviderId ?? "unknown"})`,
           );
           break;
-        }
-      }
-    }
-
-    for (const plugin of deferredPluginsForRuntime) {
-      if (
-        plugin.name === "@elizaos/plugin-agent-skills" &&
-        Array.isArray(plugin.providers)
-      ) {
-        const UPSTREAM_SKILL_PROVIDERS_TO_STRIP = new Set([
-          "agent_skills",
-          "agent_skill_instructions",
-          "agent_skills_catalog",
-        ]);
-        const before = plugin.providers.length;
-        plugin.providers = plugin.providers.filter(
-          (p: { name?: string }) =>
-            !UPSTREAM_SKILL_PROVIDERS_TO_STRIP.has(p.name ?? ""),
-        );
-        const removed = before - plugin.providers.length;
-        if (removed > 0) {
-          logger.info(
-            `[eliza] Stripped ${removed} deferred upstream skill provider(s) — using dynamic BM25-lite provider instead`,
-          );
         }
       }
     }

--- a/packages/core/src/__tests__/runtime-register-provider.test.ts
+++ b/packages/core/src/__tests__/runtime-register-provider.test.ts
@@ -38,4 +38,44 @@ describe("AgentRuntime.registerProvider deduplication", () => {
 		expect(runtime.providers.some((p) => p.name === "ALPHA")).toBe(true);
 		expect(runtime.providers.some((p) => p.name === "BETA")).toBe(true);
 	});
+
+	it("skips plugin providers that opt out of default registration", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "provider-default-registration-test" } as Character,
+		});
+
+		await runtime.registerPlugin({
+			name: "provider-default-registration-plugin",
+			description: "Provider registration behavior test",
+			providers: [
+				makeProvider("DEFAULT_PROVIDER", "default"),
+				{
+					...makeProvider("EXPLICIT_PROVIDER", "explicit"),
+					registerByDefault: false,
+				},
+			],
+		});
+
+		expect(runtime.providers.some((p) => p.name === "DEFAULT_PROVIDER")).toBe(
+			true,
+		);
+		expect(runtime.providers.some((p) => p.name === "EXPLICIT_PROVIDER")).toBe(
+			false,
+		);
+	});
+
+	it("allows direct registration of providers that opt out of plugin defaults", () => {
+		const runtime = new AgentRuntime({
+			character: { name: "provider-direct-registration-test" } as Character,
+		});
+
+		runtime.registerProvider({
+			...makeProvider("DIRECT_EXPLICIT_PROVIDER", "explicit"),
+			registerByDefault: false,
+		});
+
+		expect(
+			runtime.providers.some((p) => p.name === "DIRECT_EXPLICIT_PROVIDER"),
+		).toBe(true);
+	});
 });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1939,6 +1939,18 @@ export class AgentRuntime implements IAgentRuntime {
 				this.providers.map((provider) => provider.name),
 			);
 			for (const provider of pluginToRegister.providers) {
+				if (provider.registerByDefault === false) {
+					this.logger.debug(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							provider: provider.name,
+							plugin: pluginToRegister.name,
+						},
+						"Skipping plugin provider with registerByDefault=false",
+					);
+					continue;
+				}
 				if (existingProviderNames.has(provider.name)) {
 					this.logger.debug(
 						{

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -621,6 +621,15 @@ export interface Provider {
 	cacheScope?: CacheScope;
 
 	/**
+	 * Whether plugin registration should install this provider into the runtime.
+	 *
+	 * Defaults to true. Set to false for plugin-owned providers that are
+	 * available for direct composition or alternative host wiring, but should
+	 * not be part of the default provider surface every time the plugin loads.
+	 */
+	registerByDefault?: boolean;
+
+	/**
 	 * When true, this provider is always composed into the Stage-1 response
 	 * state regardless of the turn's selected contexts (like the built-in
 	 * FACTS / CURRENT_TIME signals). Lets a plugin opt a dynamic provider into

--- a/plugins/plugin-agent-skills/src/providers/skills.ts
+++ b/plugins/plugin-agent-skills/src/providers/skills.ts
@@ -42,6 +42,7 @@ export const skillsSummaryProvider: Provider = {
 	contextGate: { anyOf: ["agent_internal", "settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	registerByDefault: false,
 
 	dynamic: true,
 	get: async (
@@ -133,6 +134,7 @@ export const skillInstructionsProvider: Provider = {
 	description: "High-res instructions from the most relevant skill",
 	descriptionCompressed: "high-re instruction most relevant skill",
 	position: 5,
+	registerByDefault: false,
 
 	dynamic: true,
 	contexts: ["agent_internal", "settings"],
@@ -230,6 +232,7 @@ export const catalogAwarenessProvider: Provider = {
 	description: "Awareness of skills available on the registry",
 	descriptionCompressed: "Available skills on registry.",
 	position: 10,
+	registerByDefault: false,
 	dynamic: true,
 	contexts: ["agent_internal", "settings"],
 	contextGate: { anyOf: ["agent_internal", "settings"] },


### PR DESCRIPTION
## Summary
- add `Provider.registerByDefault` so plugins can expose providers without installing them into every runtime by default
- have `AgentRuntime.registerPlugin` skip providers with `registerByDefault: false` while preserving direct `registerProvider` behavior
- move agent-skills prompt-heavy provider suppression into the plugin declarations and remove host-side plugin-name mutation from agent boot

## Validation
- `bun run --cwd packages/core test -- src/__tests__/runtime-register-provider.test.ts`
- `bunx biome check packages/core/src/runtime.ts packages/core/src/types/components.ts packages/core/src/__tests__/runtime-register-provider.test.ts packages/agent/src/runtime/eliza.ts plugins/plugin-agent-skills/src/providers/skills.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `bun run --cwd plugins/plugin-agent-skills typecheck`

## Evidence
- N/A - framework/provider registration behavior; covered by focused runtime unit tests and source-level/package typechecks. No UI or live model path changed.