### PR TITLE
chore(comment-cleanup): Phase 0 — convention + comments-only diff guard (#12181)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,48 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Slop and Comment Cleanup
+
+Comments must earn their keep: they explain intent a reader cannot get from the
+code, and they never narrate the edit that produced them. This is the binding
+convention for the repo-wide comment cleanup (#12181) and for every new file.
+
+1. **Every file opens with a prose header.** One `/** … */` block at the very
+   top — after a `#!` shebang or a third-party license block if present, before
+   the imports. Write sentences, not a form: no `@fileoverview`, `@author`,
+   `@date`, or `@version`. The position is the signal.
+2. **The first sentence says what the file does in system terms**, without
+   repeating the filename — "Local content-addressed media store for chat
+   attachments," not "This is media-store.ts." After that, add only what helps:
+   the relationships (what consumes it, what it consumes, which boundary it sits
+   on), the load-bearing invariants, and the gotchas to know before editing. An
+   issue ref like `(#8876)` is welcome when it anchors non-obvious rationale,
+   never as a substitute for stating it.
+3. **Length scales with weight.** A barrel `index.ts` or a tiny type file gets
+   one line; a typical module 2–6 lines; a load-bearing module 2–3 short
+   paragraphs. Hard ceiling ~25 lines — anything longer belongs in the package
+   `CLAUDE.md`/`README.md`; reference it instead. Test files get 1–3 lines: what
+   surface is under test and how real the harness is (live model vs.
+   deterministic proxy, real DB vs. in-memory).
+4. **In-body comments explain what the code cannot** — the "why," the invariant,
+   the non-obvious consequence — not a line-by-line English echo of the code.
+5. **Delete comment slop on sight:** change/churn narration ("now we do X,"
+   "refactored to…"), status updates, migration stories, and comments that just
+   restate the next line. Salvageable churn is rewritten to a present-tense fact
+   about how the code works today.
+6. **Accuracy over coverage — a wrong header is worse than none.** Read the
+   package's `CLAUDE.md` before writing headers in it and describe files in that
+   package's architecture terms. If you cannot determine what a file is for, flag
+   it rather than guess.
+
+Copy the tone from the exemplars already in the tree:
+`packages/agent/src/api/media-store.ts` (load-bearing module),
+`packages/ui/src/components/RoleGate.tsx` (component),
+`packages/scripts/run-all-tests.mjs` (script), and `.gitmodules` (config).
+Comment-cleanup batches carry **zero functional diffs** — machine-checked by
+`bun run check:comment-only` (`scripts/assert-comment-only-diff.mjs`), which
+tokenizes both revisions and fails on any non-comment token change.
+
 ## App visual review — REQUIRED for UI changes in `packages/app/`
 
 Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,48 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Slop and Comment Cleanup
+
+Comments must earn their keep: they explain intent a reader cannot get from the
+code, and they never narrate the edit that produced them. This is the binding
+convention for the repo-wide comment cleanup (#12181) and for every new file.
+
+1. **Every file opens with a prose header.** One `/** … */` block at the very
+   top — after a `#!` shebang or a third-party license block if present, before
+   the imports. Write sentences, not a form: no `@fileoverview`, `@author`,
+   `@date`, or `@version`. The position is the signal.
+2. **The first sentence says what the file does in system terms**, without
+   repeating the filename — "Local content-addressed media store for chat
+   attachments," not "This is media-store.ts." After that, add only what helps:
+   the relationships (what consumes it, what it consumes, which boundary it sits
+   on), the load-bearing invariants, and the gotchas to know before editing. An
+   issue ref like `(#8876)` is welcome when it anchors non-obvious rationale,
+   never as a substitute for stating it.
+3. **Length scales with weight.** A barrel `index.ts` or a tiny type file gets
+   one line; a typical module 2–6 lines; a load-bearing module 2–3 short
+   paragraphs. Hard ceiling ~25 lines — anything longer belongs in the package
+   `CLAUDE.md`/`README.md`; reference it instead. Test files get 1–3 lines: what
+   surface is under test and how real the harness is (live model vs.
+   deterministic proxy, real DB vs. in-memory).
+4. **In-body comments explain what the code cannot** — the "why," the invariant,
+   the non-obvious consequence — not a line-by-line English echo of the code.
+5. **Delete comment slop on sight:** change/churn narration ("now we do X,"
+   "refactored to…"), status updates, migration stories, and comments that just
+   restate the next line. Salvageable churn is rewritten to a present-tense fact
+   about how the code works today.
+6. **Accuracy over coverage — a wrong header is worse than none.** Read the
+   package's `CLAUDE.md` before writing headers in it and describe files in that
+   package's architecture terms. If you cannot determine what a file is for, flag
+   it rather than guess.
+
+Copy the tone from the exemplars already in the tree:
+`packages/agent/src/api/media-store.ts` (load-bearing module),
+`packages/ui/src/components/RoleGate.tsx` (component),
+`packages/scripts/run-all-tests.mjs` (script), and `.gitmodules` (config).
+Comment-cleanup batches carry **zero functional diffs** — machine-checked by
+`bun run check:comment-only` (`scripts/assert-comment-only-diff.mjs`), which
+tokenizes both revisions and fails on any non-comment token change.
+
 ## App visual review — REQUIRED for UI changes in `packages/app/`
 
 Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "audit:turbo-build-deps": "node packages/scripts/audit-turbo-build-deps.mjs",
     "audit:scripts": "node packages/scripts/audit-scripts.mjs",
     "audit:scripts:self-test": "node packages/scripts/audit-scripts.self-test.mjs",
+    "check:comment-only": "node scripts/assert-comment-only-diff.mjs",
+    "check:comment-only:self-test": "node scripts/assert-comment-only-diff.mjs --self-test",
     "audit:scripts:inventory": "node packages/scripts/audit-scripts-inventory.mjs",
     "audit:test-realness": "node packages/scripts/test-realness-audit.mjs --check",
     "audit:test-realness:evidence": "node packages/scripts/test-realness-audit.mjs --check --report .github/issue-evidence/10718-test-realness-inventory.md --json .github/issue-evidence/10718-test-realness-inventory.json",

--- a/scripts/assert-comment-only-diff.mjs
+++ b/scripts/assert-comment-only-diff.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Machine guard for the comment-cleanup effort (parent issue #12181): proves a
+ * branch changed *only* comments and whitespace, never a single token of code.
+ *
+ * The cleanup rewrites file headers and in-body comments across thousands of
+ * files. "Trust me, it's comments-only" is not evidence, so this script makes it
+ * checkable: for every file that differs from the merge base it tokenizes both
+ * revisions with the TypeScript scanner — which classifies comments and
+ * whitespace as *trivia* and skips them — and asserts the two non-trivia token
+ * streams are byte-identical. A one-token code change (rename, reordered
+ * argument, flipped operator) shifts the stream and fails; adding, rewriting, or
+ * deleting a comment does not. Any changed file with a non-source extension is
+ * also a failure, because a comment-only batch must never touch build/config.
+ *
+ * Consumed by the root `check:comment-only` script and by each batch PR's CI.
+ * Default base is `origin/develop`; pass an alternate base as the first argv.
+ * `--self-test` runs an internal proof that the guard catches a planted
+ * one-token change and passes a planted comments-only change (no git needed).
+ */
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import ts from "typescript";
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+/** JSX-capable scanning for .tsx/.jsx so `<Tag>` tokenizes the same on both sides. */
+function languageVariantFor(path) {
+  return path.endsWith(".tsx") || path.endsWith(".jsx")
+    ? ts.LanguageVariant.JSX
+    : ts.LanguageVariant.Standard;
+}
+
+function extensionOf(path) {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot);
+}
+
+/**
+ * The ordered non-trivia tokens of a source string. Each entry is `kind:text`
+ * so a rename (same kind, different text) diverges just like a structural edit.
+ * Comments and whitespace never appear — the scanner skips them as trivia — so
+ * two revisions that differ only in comments produce identical arrays.
+ *
+ * The bare scanner has no parser context, so it may mis-classify a regex vs.
+ * division or a template span. That is irrelevant here: the mis-scan is a pure
+ * function of the non-trivia characters, which are identical on both sides of a
+ * comments-only change, so it cancels out. Streams match iff the code matches.
+ */
+function tokenize(source, variant) {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ true,
+    variant,
+    source,
+  );
+  const tokens = [];
+  let token = scanner.scan();
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    tokens.push(`${token}:${scanner.getTokenText()}`);
+    token = scanner.scan();
+  }
+  return tokens;
+}
+
+/**
+ * Compare two token streams. Returns `null` when identical, otherwise the index
+ * and both sides of the first divergence so the caller can point at it.
+ */
+function firstDivergence(baseTokens, headTokens) {
+  const max = Math.max(baseTokens.length, headTokens.length);
+  for (let i = 0; i < max; i++) {
+    if (baseTokens[i] !== headTokens[i]) {
+      return {
+        index: i,
+        base: baseTokens[i] ?? "<end of file>",
+        head: headTokens[i] ?? "<end of file>",
+      };
+    }
+  }
+  return null;
+}
+
+/** `kind:text` → the readable token text, for the failure message. */
+function tokenLabel(entry) {
+  if (entry === "<end of file>") return entry;
+  const colon = entry.indexOf(":");
+  return entry.slice(colon + 1);
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 256,
+    // Capture stderr instead of inheriting so an expected failure (e.g.
+    // `git show base:<added-file>`) does not leak a `fatal:` line to output.
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** Merge base of `base` and HEAD, matching `git diff base...HEAD` semantics. */
+function resolveMergeBase(base) {
+  try {
+    return git(["merge-base", base, "HEAD"]).trim();
+  } catch {
+    // base may be an exact commit or unfetched ref; compare against it directly.
+    return base;
+  }
+}
+
+function changedFiles(mergeBase) {
+  return git(["diff", "--name-only", mergeBase, "--"])
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/** Base-revision contents of `path`, or `null` when the file is newly added. */
+function readBaseSource(mergeBase, path) {
+  try {
+    return git(["show", `${mergeBase}:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+/** Worktree contents of `path`, or `null` when the file was deleted. */
+function readHeadSource(path) {
+  try {
+    return execFileSync("cat", [path], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 256,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function runCheck(base) {
+  const mergeBase = resolveMergeBase(base);
+  const files = changedFiles(mergeBase);
+  const violations = [];
+
+  for (const path of files) {
+    if (!SOURCE_EXTENSIONS.has(extensionOf(path))) {
+      violations.push(
+        `${path}: non-source file changed (a comment-only batch must touch only ${[...SOURCE_EXTENSIONS].join(", ")})`,
+      );
+      continue;
+    }
+
+    const baseSource = readBaseSource(mergeBase, path);
+    const headSource = readHeadSource(path);
+    if (baseSource === null) {
+      violations.push(`${path}: file added (not a comments-only change)`);
+      continue;
+    }
+    if (headSource === null) {
+      violations.push(`${path}: file deleted (not a comments-only change)`);
+      continue;
+    }
+
+    const variant = languageVariantFor(path);
+    const divergence = firstDivergence(
+      tokenize(baseSource, variant),
+      tokenize(headSource, variant),
+    );
+    if (divergence) {
+      violations.push(
+        `${path}: code token changed at position ${divergence.index} — base \`${tokenLabel(divergence.base)}\` vs head \`${tokenLabel(divergence.head)}\``,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `[assert-comment-only-diff] ${violations.length} file(s) changed more than comments (base ${mergeBase}):`,
+    );
+    for (const violation of violations) console.error(`  - ${violation}`);
+    return 1;
+  }
+
+  console.log(
+    `[assert-comment-only-diff] OK — ${files.length} changed file(s), all comments-only (base ${mergeBase}).`,
+  );
+  return 0;
+}
+
+/**
+ * Prove the guard both ways without git: a planted one-token change must be
+ * caught, and a planted comments-only rewrite must pass. Exit non-zero if either
+ * assertion is wrong so the guard can never silently rot.
+ */
+function selfTest() {
+  const original = [
+    "/** Original header. */",
+    "export function add(a, b) {",
+    "  // sum them",
+    "  return a + b;",
+    "}",
+  ].join("\n");
+
+  const commentsOnly = [
+    "/** Rewritten header explaining what add does and who calls it. */",
+    "export function add(a, b) {",
+    "  return a + b; // still sums, comment moved to the line",
+    "}",
+  ].join("\n");
+
+  const oneTokenChange = [
+    "/** Original header. */",
+    "export function add(a, b) {",
+    "  // sum them",
+    "  return a - b;", // + flipped to -
+    "}",
+  ].join("\n");
+
+  const variant = ts.LanguageVariant.Standard;
+  const baseTokens = tokenize(original, variant);
+
+  const commentsDivergence = firstDivergence(
+    baseTokens,
+    tokenize(commentsOnly, variant),
+  );
+  const codeDivergence = firstDivergence(
+    baseTokens,
+    tokenize(oneTokenChange, variant),
+  );
+
+  let ok = true;
+  if (commentsDivergence !== null) {
+    ok = false;
+    console.error(
+      `[self-test] FAIL: comments-only rewrite was flagged at token ${commentsDivergence.index} (\`${tokenLabel(commentsDivergence.base)}\` vs \`${tokenLabel(commentsDivergence.head)}\`)`,
+    );
+  } else {
+    console.log("[self-test] PASS: comments-only rewrite accepted.");
+  }
+
+  if (codeDivergence === null) {
+    ok = false;
+    console.error(
+      "[self-test] FAIL: a one-token code change (`+` → `-`) slipped through.",
+    );
+  } else {
+    console.log(
+      `[self-test] PASS: one-token code change caught at token ${codeDivergence.index} (\`${tokenLabel(codeDivergence.base)}\` vs \`${tokenLabel(codeDivergence.head)}\`).`,
+    );
+  }
+
+  return ok ? 0 : 1;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--self-test")) {
+    process.exit(selfTest());
+  }
+  const base = args.find((arg) => !arg.startsWith("--")) ?? "origin/develop";
+  process.exit(runCheck(base));
+}
+
+main();


### PR DESCRIPTION
## Summary

Phase 0 foundations for the repo-wide comment cleanup (parent #12181). Lands **WI-1** and **WI-2** so the batch fan-out (#12231–#12247) can begin. No product code changes.

- **WI-1 — Codify the convention.** Adds a **"Slop and Comment Cleanup"** section to root `CLAUDE.md` and `AGENTS.md` (kept byte-identical) under "Repo-wide conventions". Encodes the six design decisions — prose file headers, the first-sentence rule, the length ladder, in-body intent comments, churn/slop removal, and accuracy-over-coverage — with pointers to the four in-tree exemplars (`media-store.ts`, `RoleGate.tsx`, `run-all-tests.mjs`, `.gitmodules`).
- **WI-2 — Comments-only diff guard.** Adds `scripts/assert-comment-only-diff.mjs` and the `check:comment-only` / `check:comment-only:self-test` root scripts. For every changed file it tokenizes both revisions with the TypeScript scanner (comments + whitespace are *trivia*, skipped) and asserts the non-trivia token streams are byte-identical; any non-comment token change, or any changed non-source file, fails the run. This makes a 1,000-file comment sweep **machine-provable** as zero-functional-diff.

## Verification / evidence

`typescript@^6.0.3` is already a root devDependency; the guard has no new deps.

**Self-test (`bun run check:comment-only:self-test`)** — proves both directions:
```
[self-test] PASS: comments-only rewrite accepted.
[self-test] PASS: one-token code change caught at token 11 (`+` vs `-`).
```

**End-to-end over real git** (planted probe file, base = probe commit):
- (A) header rewrite + comment move → `OK — 1 changed file(s), all comments-only` (exit 0).
- (B) one-token change `n * 2` → `n * 3` → `code token changed at position 14 — base \`2\` vs head \`3\`` (exit 1).

**Non-source / structural guards** (run against `origin/develop` on this branch):
- `AGENTS.md`, `CLAUDE.md`, `package.json` → flagged `non-source file changed`.
- `scripts/assert-comment-only-diff.mjs` → flagged `file added`.

Both WI-2 plants (a caught one-token change and a passing comments-only change) are demonstrated above, as the work item requires.

- `diff CLAUDE.md AGENTS.md` → empty (files identical).
- `biome check scripts/assert-comment-only-diff.mjs` → clean.

N/A — no runtime/LLM/UI/native surface is touched (docs + a dev script only), so trajectories, screenshots, and device captures do not apply.

Closes the Phase 0 half of #12181 (WI-1, WI-2). WI-3 (pilot) and the batch fan-out follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)