### PR TITLE
security(#12229): auth + secrets remediation — fail-closed KMS, AAD binding, SIWE/SIWS uri+chainId, SSRF footgun

### DIFF
--- a/packages/cloud/api/auth/siwe/nonce/route.ts
+++ b/packages/cloud/api/auth/siwe/nonce/route.ts
@@ -32,14 +32,16 @@ app.get("/", async (c) => {
     return c.json({ error: "Nonce storage unavailable" }, 503);
   }
 
-  const nonce = await issueNonce(redis);
+  const uri = getAppUrl(c.env);
+  const resolvedChainId = Number.isNaN(chainId) ? 1 : chainId;
+  const nonce = await issueNonce(redis, { uri, chainId: resolvedChainId });
 
   return c.json(
     {
       nonce,
       domain: getAppHost(c.env),
-      uri: getAppUrl(c.env),
-      chainId: Number.isNaN(chainId) ? 1 : chainId,
+      uri,
+      chainId: resolvedChainId,
       version: "1",
       statement: "Sign in to Eliza Cloud",
     },

--- a/packages/cloud/api/auth/siws/nonce/route.ts
+++ b/packages/cloud/api/auth/siws/nonce/route.ts
@@ -26,13 +26,14 @@ app.get("/", async (c) => {
     return c.json({ error: "Nonce storage unavailable" }, 503);
   }
 
-  const nonce = await issueSiwsNonce(redis);
+  const uri = getAppUrl(c.env);
+  const nonce = await issueSiwsNonce(redis, { uri, chainId });
 
   return c.json(
     {
       nonce,
       domain: getAppHost(c.env),
-      uri: getAppUrl(c.env),
+      uri,
       chainId,
       version: "1",
       statement: "Sign in to Eliza Cloud",

--- a/packages/cloud/shared/src/lib/services/field-encryption.aad.test.ts
+++ b/packages/cloud/shared/src/lib/services/field-encryption.aad.test.ts
@@ -1,0 +1,121 @@
+/**
+ * L6 (#12229): `FieldEncryptionService` binds an optional `table|rowId|column`
+ * AAD into AES-256-GCM so a ciphertext cannot be relocated to a different
+ * row/column and still decrypt.
+ *
+ * The crypto exercised is the REAL FieldEncryptionService (AES-256-GCM, org DEK
+ * wrapped by SECRETS_MASTER_KEY); only the org-key persistence (the db helpers)
+ * is swapped for an in-memory store — the same boundary the sibling
+ * `agent-env-crypto.test.ts` already mocks.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+
+import * as realHelpersNs from "../../db/helpers";
+
+interface OrgKeyRow {
+  id: string;
+  organization_id: string;
+  encrypted_dek: string;
+  key_version: number;
+  created_at: Date;
+  rotated_at: Date | null;
+}
+const orgKeyRows: OrgKeyRow[] = [];
+
+const orgKeyDb = {
+  query: {
+    organizationEncryptionKeys: {
+      findFirst: async () => orgKeyRows[0],
+    },
+  },
+  insert: () => ({
+    values: (v: Record<string, unknown>) => ({
+      onConflictDoNothing: () => ({
+        returning: async () => {
+          const row: OrgKeyRow = {
+            id: randomUUID(),
+            key_version: 1,
+            created_at: new Date(),
+            rotated_at: null,
+            organization_id: v.organization_id as string,
+            encrypted_dek: v.encrypted_dek as string,
+          };
+          orgKeyRows.push(row);
+          return [row];
+        },
+      }),
+    }),
+  }),
+};
+
+const realHelpers = { ...realHelpersNs };
+mock.module("../../db/helpers", () => ({
+  ...realHelpers,
+  dbRead: orgKeyDb,
+  dbWrite: orgKeyDb,
+}));
+
+const prevKey = process.env.SECRETS_MASTER_KEY;
+process.env.SECRETS_MASTER_KEY = "b".repeat(64);
+
+afterAll(() => {
+  if (prevKey === undefined) delete process.env.SECRETS_MASTER_KEY;
+  else process.env.SECRETS_MASTER_KEY = prevKey;
+});
+
+// Import AFTER the mock + env are in place.
+const { FieldEncryptionService } = await import("./field-encryption");
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+
+describe("L6 — FieldEncryptionService AAD coordinate binding", () => {
+  let svc: InstanceType<typeof FieldEncryptionService>;
+
+  beforeEach(() => {
+    svc = new FieldEncryptionService();
+  });
+
+  test("round-trips with matching coordinates", async () => {
+    const coords = { table: "user_databases", rowId: "row-1", column: "user_database_uri" };
+    const enc = await svc.encrypt(ORG, "postgres://secret", coords);
+    expect(await svc.decrypt(enc, coords)).toBe("postgres://secret");
+  });
+
+  test("a ciphertext moved to another row fails to decrypt", async () => {
+    const enc = await svc.encrypt(ORG, "postgres://secret", {
+      table: "user_databases",
+      rowId: "row-1",
+      column: "user_database_uri",
+    });
+    await expect(
+      svc.decrypt(enc, { table: "user_databases", rowId: "row-2", column: "user_database_uri" }),
+    ).rejects.toThrow();
+  });
+
+  test("a ciphertext moved to another column fails to decrypt", async () => {
+    const enc = await svc.encrypt(ORG, "postgres://secret", {
+      table: "user_databases",
+      rowId: "row-1",
+      column: "user_database_uri",
+    });
+    await expect(
+      svc.decrypt(enc, { table: "user_databases", rowId: "row-1", column: "backup_uri" }),
+    ).rejects.toThrow();
+  });
+
+  test("an AAD-bound ciphertext cannot be read without the coordinates", async () => {
+    const enc = await svc.encrypt(ORG, "postgres://secret", {
+      table: "user_databases",
+      rowId: "row-1",
+      column: "user_database_uri",
+    });
+    await expect(svc.decrypt(enc)).rejects.toThrow();
+  });
+
+  test("no-coords path is unchanged (backward compatible with pre-AAD rows)", async () => {
+    const enc = await svc.encrypt(ORG, "legacy-plaintext");
+    expect(await svc.decrypt(enc)).toBe("legacy-plaintext");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/field-encryption.ts
+++ b/packages/cloud/shared/src/lib/services/field-encryption.ts
@@ -42,6 +42,22 @@ interface ParsedEncryptedValue {
 }
 
 /**
+ * Table/row/column that a ciphertext belongs to. When supplied, the coordinates
+ * are bound into the AES-GCM AAD (`table|rowId|column`) so a ciphertext cannot
+ * be relocated to a different row/column and still decrypt. Mirrors the pattern
+ * in `db/crypto/field-crypto.ts` / `@elizaos/security/crypto/aead`.
+ */
+export interface FieldCoords {
+  table: string;
+  rowId: string;
+  column: string;
+}
+
+function aadForCoords(coords: FieldCoords): Buffer {
+  return Buffer.from(`${coords.table}|${coords.rowId}|${coords.column}`, "utf8");
+}
+
+/**
  * Field Encryption Service
  *
  * Provides encrypt/decrypt operations for sensitive database fields.
@@ -97,7 +113,7 @@ export class FieldEncryptionService {
    * @param plaintext - The value to encrypt
    * @returns Encrypted string in encoded format
    */
-  async encrypt(organizationId: string, plaintext: string): Promise<string> {
+  async encrypt(organizationId: string, plaintext: string, coords?: FieldCoords): Promise<string> {
     this.ensureInitialized();
 
     // Get or create the organization's DEK
@@ -107,8 +123,12 @@ export class FieldEncryptionService {
     // Generate random nonce
     const nonce = crypto.randomBytes(NONCE_LENGTH);
 
-    // Encrypt with AES-256-GCM
+    // Encrypt with AES-256-GCM. When `coords` are supplied, bind them into the
+    // GCM AAD so the ciphertext cannot be relocated to another row/column and
+    // still decrypt. Omitting `coords` preserves the pre-existing on-disk
+    // format (backward compatible with rows written before AAD binding).
     const cipher = crypto.createCipheriv(ALGORITHM, dek, nonce);
+    if (coords) cipher.setAAD(aadForCoords(coords));
     const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
     const authTag = cipher.getAuthTag();
 
@@ -131,7 +151,7 @@ export class FieldEncryptionService {
    * @param encryptedValue - The encrypted string to decrypt
    * @returns Decrypted plaintext
    */
-  async decrypt(encryptedValue: string): Promise<string> {
+  async decrypt(encryptedValue: string, coords?: FieldCoords): Promise<string> {
     this.ensureInitialized();
 
     const parsed = this.parseEncryptedValue(encryptedValue);
@@ -143,8 +163,11 @@ export class FieldEncryptionService {
     }
     const dek = this.unwrapDek(orgKey.encrypted_dek);
 
-    // Decrypt with AES-256-GCM
+    // Decrypt with AES-256-GCM. `coords` must match the AAD used at encrypt
+    // time; a mismatch (or a ciphertext moved to a different row/column) makes
+    // `decipher.final()` throw an auth-tag error.
     const decipher = crypto.createDecipheriv(ALGORITHM, dek, parsed.nonce);
+    if (coords) decipher.setAAD(aadForCoords(coords));
     decipher.setAuthTag(parsed.authTag);
 
     const plaintext = Buffer.concat([decipher.update(parsed.ciphertext), decipher.final()]);

--- a/packages/cloud/shared/src/lib/services/secrets/encryption.security.test.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/encryption.security.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Security remediation coverage for the cloud secrets envelope (#12229).
+ *
+ * - M4: `LocalKMSProvider.getMasterKey` must fail CLOSED when
+ *   `SECRETS_MASTER_KEY` is unset — never silently derive the publicly-known
+ *   all-zero key — unless `ALLOW_INSECURE_DEV_KMS=1` is explicitly set for local
+ *   development.
+ * - L6: `SecretsEncryptionService` binds an optional AAD into AES-256-GCM so a
+ *   ciphertext relocated to a different row/column fails to decrypt.
+ *
+ * The crypto exercised here is the REAL LocalKMSProvider / SecretsEncryptionService
+ * (AES-256-GCM via node:crypto) — nothing is mocked.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DecryptionError, LocalKMSProvider, SecretsEncryptionService } from "./encryption";
+
+const KEY = "a".repeat(64); // 32 bytes hex
+
+describe("M4 — LocalKMSProvider fails closed without SECRETS_MASTER_KEY", () => {
+  let prev: {
+    key: string | undefined;
+    node: string | undefined;
+    optIn: string | undefined;
+  };
+
+  beforeEach(() => {
+    prev = {
+      key: process.env.SECRETS_MASTER_KEY,
+      node: process.env.NODE_ENV,
+      optIn: process.env.ALLOW_INSECURE_DEV_KMS,
+    };
+    delete process.env.SECRETS_MASTER_KEY;
+    delete process.env.ALLOW_INSECURE_DEV_KMS;
+  });
+
+  afterEach(() => {
+    if (prev.key === undefined) delete process.env.SECRETS_MASTER_KEY;
+    else process.env.SECRETS_MASTER_KEY = prev.key;
+    if (prev.node === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = prev.node;
+    if (prev.optIn === undefined) delete process.env.ALLOW_INSECURE_DEV_KMS;
+    else process.env.ALLOW_INSECURE_DEV_KMS = prev.optIn;
+  });
+
+  test("non-prod boot with no key and no opt-in throws on first encrypt (no zero-key)", async () => {
+    process.env.NODE_ENV = "development";
+    const kms = new LocalKMSProvider();
+    await expect(kms.generateDataKey()).rejects.toThrow(/SECRETS_MASTER_KEY is required/);
+  });
+
+  test("production with no key throws (unchanged)", async () => {
+    process.env.NODE_ENV = "production";
+    const kms = new LocalKMSProvider();
+    await expect(kms.generateDataKey()).rejects.toThrow(/SECRETS_MASTER_KEY is required/);
+  });
+
+  test("production ignores the ALLOW_INSECURE_DEV_KMS opt-in and still throws", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOW_INSECURE_DEV_KMS = "1";
+    const kms = new LocalKMSProvider();
+    await expect(kms.generateDataKey()).rejects.toThrow(/SECRETS_MASTER_KEY is required/);
+  });
+
+  test("explicit ALLOW_INSECURE_DEV_KMS=1 in non-prod proceeds with an (insecure) key", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.ALLOW_INSECURE_DEV_KMS = "1";
+    const kms = new LocalKMSProvider();
+    const { plaintext, ciphertext } = await kms.generateDataKey();
+    expect(plaintext.length).toBe(32);
+    // round-trips under the same (dev) key
+    const dek = await kms.decrypt(ciphertext);
+    expect(Buffer.compare(dek, plaintext)).toBe(0);
+  });
+
+  test("a configured key works and does not require the opt-in", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.SECRETS_MASTER_KEY = KEY;
+    const kms = new LocalKMSProvider();
+    const { plaintext, ciphertext } = await kms.generateDataKey();
+    const dek = await kms.decrypt(ciphertext);
+    expect(Buffer.compare(dek, plaintext)).toBe(0);
+  });
+
+  test("constructor-provided key bypasses the env requirement", async () => {
+    process.env.NODE_ENV = "production";
+    const kms = new LocalKMSProvider(KEY);
+    const { plaintext } = await kms.generateDataKey();
+    expect(plaintext.length).toBe(32);
+  });
+});
+
+describe("L6 — SecretsEncryptionService AAD binds ciphertext to its coordinates", () => {
+  const svc = new SecretsEncryptionService(new LocalKMSProvider(KEY));
+
+  test("round-trips with a matching AAD", async () => {
+    const aad = "vendor_connections|row-1|access_token";
+    const enc = await svc.encrypt("super-secret-token", aad);
+    const dec = await svc.decrypt(enc, aad);
+    expect(dec).toBe("super-secret-token");
+  });
+
+  test("relocating a ciphertext to a different row/column fails to decrypt", async () => {
+    const enc = await svc.encrypt("super-secret-token", "vendor_connections|row-1|access_token");
+    // Attacker with DB-write copies the same envelope onto a different row.
+    await expect(svc.decrypt(enc, "vendor_connections|row-2|access_token")).rejects.toThrow(
+      DecryptionError,
+    );
+    // ...or a different column of the same row.
+    await expect(svc.decrypt(enc, "vendor_connections|row-1|refresh_token")).rejects.toThrow(
+      DecryptionError,
+    );
+  });
+
+  test("an AAD-bound ciphertext cannot be read without the AAD", async () => {
+    const enc = await svc.encrypt("super-secret-token", "table|row|col");
+    await expect(svc.decrypt(enc)).rejects.toThrow(DecryptionError);
+  });
+
+  test("no-AAD path is unchanged (backward compatible)", async () => {
+    const enc = await svc.encrypt("legacy-value");
+    expect(await svc.decrypt(enc)).toBe("legacy-value");
+  });
+
+  test("rotate preserves the AAD binding", async () => {
+    const aad = "table|row|col";
+    const enc = await svc.encrypt("v", aad);
+    const rotated = await svc.rotate(enc, aad);
+    expect(await svc.decrypt(rotated, aad)).toBe("v");
+    await expect(svc.decrypt(rotated, "table|other|col")).rejects.toThrow(DecryptionError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/secrets/encryption.ts
+++ b/packages/cloud/shared/src/lib/services/secrets/encryption.ts
@@ -49,12 +49,31 @@ export class LocalKMSProvider implements KMSProvider {
   private getMasterKey(): Buffer {
     const env = getCloudAwareEnv();
     const keySource = this.masterKeyHex || env.SECRETS_MASTER_KEY;
-    if (!keySource && env.NODE_ENV === "production") {
-      throw new Error("SECRETS_MASTER_KEY environment variable is required in production");
+    if (!keySource) {
+      // Fail CLOSED. Previously this silently derived an all-zero master key
+      // ("0".repeat(64)) outside production, so any staging/preview/self-host
+      // env that held real secrets but did not set NODE_ENV=production (or
+      // forgot SECRETS_MASTER_KEY) encrypted every DEK under a publicly-known
+      // key — a DB read then trivially recovered plaintext. Never derive the
+      // zero key. Production always throws; non-prod requires an explicit,
+      // loud ALLOW_INSECURE_DEV_KMS=1 opt-in for local development only.
+      if (env.NODE_ENV === "production" || env.ALLOW_INSECURE_DEV_KMS !== "1") {
+        throw new Error(
+          "SECRETS_MASTER_KEY is required to encrypt/decrypt secrets. " +
+            "Generate one with `openssl rand -hex 32`. " +
+            "For local development only, set ALLOW_INSECURE_DEV_KMS=1 to use an " +
+            "insecure all-zero key (never in production or with real secrets).",
+        );
+      }
+      logger.warn(
+        "[LocalKMSProvider] SECRETS_MASTER_KEY is unset and ALLOW_INSECURE_DEV_KMS=1 — " +
+          "using an INSECURE, publicly-known all-zero master key. Every secret encrypted " +
+          "in this process is effectively PLAINTEXT. Use this ONLY for local development.",
+      );
+      return Buffer.alloc(32, 0);
     }
-    const key = keySource || "0".repeat(64);
-    if (key.length !== 64) throw new Error("Master key must be 64 hex characters (32 bytes)");
-    return Buffer.from(key, "hex");
+    if (keySource.length !== 64) throw new Error("Master key must be 64 hex characters (32 bytes)");
+    return Buffer.from(keySource, "hex");
   }
 
   async generateDataKey() {
@@ -176,10 +195,17 @@ export class SecretsEncryptionService {
 
   isConfigured = () => this.kms.isConfigured();
 
-  async encrypt(plaintext: string): Promise<EncryptionResult> {
+  async encrypt(plaintext: string, aad?: string): Promise<EncryptionResult> {
     const { plaintext: dek, ciphertext: encryptedDek, keyId } = await this.kms.generateDataKey();
     const nonce = randomBytes(12);
     const cipher = createCipheriv("aes-256-gcm", dek, nonce);
+    // AAD binds the ciphertext to a caller-supplied context (e.g.
+    // `table|rowId|column`). GCM folds the AAD into the auth tag, so a
+    // ciphertext relocated to a different row/column decrypts only if the
+    // caller presents the same AAD — an attacker with DB-write cannot move a
+    // ciphertext between rows and still decrypt it. Omitting the AAD preserves
+    // the pre-existing on-disk format (backward compatible).
+    if (aad !== undefined) cipher.setAAD(Buffer.from(aad, "utf8"));
     const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
     dek.fill(0);
     return {
@@ -191,12 +217,10 @@ export class SecretsEncryptionService {
     };
   }
 
-  async decrypt({
-    encryptedValue,
-    encryptedDek,
-    nonce,
-    authTag,
-  }: DecryptionParams): Promise<string> {
+  async decrypt(
+    { encryptedValue, encryptedDek, nonce, authTag }: DecryptionParams,
+    aad?: string,
+  ): Promise<string> {
     let dek: Buffer;
     try {
       dek = await this.kms.decrypt(encryptedDek);
@@ -210,6 +234,7 @@ export class SecretsEncryptionService {
 
     try {
       const decipher = createDecipheriv("aes-256-gcm", dek, Buffer.from(nonce, "base64"));
+      if (aad !== undefined) decipher.setAAD(Buffer.from(aad, "utf8"));
       decipher.setAuthTag(Buffer.from(authTag, "base64"));
       const result = Buffer.concat([
         decipher.update(Buffer.from(encryptedValue, "base64")),
@@ -218,7 +243,7 @@ export class SecretsEncryptionService {
       return result;
     } catch (error) {
       throw new DecryptionError(
-        "Failed to decrypt secret value — stored encryption data may be corrupted",
+        "Failed to decrypt secret value — stored encryption data may be corrupted or AAD mismatch (row/column relocation)",
         "value_decryption",
         error,
       );
@@ -227,8 +252,8 @@ export class SecretsEncryptionService {
     }
   }
 
-  async rotate(params: DecryptionParams): Promise<EncryptionResult> {
-    return this.encrypt(await this.decrypt(params));
+  async rotate(params: DecryptionParams, aad?: string): Promise<EncryptionResult> {
+    return this.encrypt(await this.decrypt(params, aad), aad);
   }
 }
 

--- a/packages/cloud/shared/src/lib/utils/siwe-helpers.security.test.ts
+++ b/packages/cloud/shared/src/lib/utils/siwe-helpers.security.test.ts
@@ -1,0 +1,123 @@
+/**
+ * L7 (#12229): SIWE validation binds the signed `uri` + `chainId` to the values
+ * the server issued alongside the nonce (EIP-4361 completeness). A message on
+ * the correct domain with a valid signature but a substituted uri/chainId is
+ * rejected.
+ *
+ * The signature exercised is a REAL secp256k1 signature (viem) over the REAL
+ * EIP-4361 message; only the nonce store is an in-memory stand-in for Redis.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { createSiweMessage } from "viem/siwe";
+import { CacheKeys } from "../cache/keys";
+import type { CompatibleRedis } from "../cache/redis-factory";
+import { issueNonce, validateAndConsumeSIWE } from "./siwe-helpers";
+
+const HOST = "app.example.com";
+const URI = "https://app.example.com";
+
+function mockRedis(): CompatibleRedis {
+  const store = new Map<string, string>();
+  return {
+    async setex(key: string, _ttl: number, value: string) {
+      store.set(key, value);
+      return "OK";
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async getdel(key: string) {
+      const v = store.get(key) ?? null;
+      store.delete(key);
+      return v;
+    },
+  } as unknown as CompatibleRedis;
+}
+
+async function signMessage(params: {
+  nonce: string;
+  chainId: number;
+  uri: string;
+  domain: string;
+}) {
+  const account = privateKeyToAccount(generatePrivateKey());
+  const message = createSiweMessage({
+    address: account.address,
+    chainId: params.chainId,
+    domain: params.domain,
+    nonce: params.nonce,
+    uri: params.uri,
+    version: "1",
+    statement: "Sign in",
+    issuedAt: new Date(),
+  });
+  const signature = await account.signMessage({ message });
+  return { message, signature, address: account.address };
+}
+
+describe("L7 SIWE uri/chainId binding", () => {
+  test("accepts a message whose uri + chainId match the issued nonce", async () => {
+    const redis = mockRedis();
+    const nonce = await issueNonce(redis, { uri: URI, chainId: 1 });
+    const { message, signature } = await signMessage({ nonce, chainId: 1, uri: URI, domain: HOST });
+    const result = await validateAndConsumeSIWE(redis, message, signature, HOST);
+    expect(result.address).toBeTruthy();
+  });
+
+  test("rejects a valid signature that signed a different chainId", async () => {
+    const redis = mockRedis();
+    const nonce = await issueNonce(redis, { uri: URI, chainId: 1 });
+    // Same domain, valid signature, but the user signed chainId 137 (Polygon).
+    const { message, signature } = await signMessage({
+      nonce,
+      chainId: 137,
+      uri: URI,
+      domain: HOST,
+    });
+    await expect(validateAndConsumeSIWE(redis, message, signature, HOST)).rejects.toThrow(
+      /chainId does not match/i,
+    );
+  });
+
+  test("rejects a valid signature that signed a different uri", async () => {
+    const redis = mockRedis();
+    const nonce = await issueNonce(redis, { uri: URI, chainId: 1 });
+    const { message, signature } = await signMessage({
+      nonce,
+      chainId: 1,
+      uri: "https://evil.example.com",
+      domain: HOST,
+    });
+    await expect(validateAndConsumeSIWE(redis, message, signature, HOST)).rejects.toThrow(
+      /uri does not match/i,
+    );
+  });
+
+  test("does not burn the nonce on a uri/chainId mismatch (client can retry)", async () => {
+    const redis = mockRedis();
+    const nonce = await issueNonce(redis, { uri: URI, chainId: 1 });
+    const bad = await signMessage({ nonce, chainId: 137, uri: URI, domain: HOST });
+    await expect(validateAndConsumeSIWE(redis, bad.message, bad.signature, HOST)).rejects.toThrow();
+    // The nonce is still present; a corrected message succeeds.
+    const good = await signMessage({ nonce, chainId: 1, uri: URI, domain: HOST });
+    const ok = await validateAndConsumeSIWE(redis, good.message, good.signature, HOST);
+    expect(ok.address).toBeTruthy();
+  });
+
+  test("legacy binding-less nonce ('1') skips the uri/chainId assertions", async () => {
+    const redis = mockRedis();
+    // Simulate an in-flight nonce issued by the previous code path.
+    const nonce = "deadbeef";
+    await redis.setex(CacheKeys.siwe.nonce(nonce), 300, "1");
+    const { message, signature } = await signMessage({
+      nonce,
+      chainId: 999,
+      uri: "https://anything",
+      domain: HOST,
+    });
+    const result = await validateAndConsumeSIWE(redis, message, signature, HOST);
+    expect(result.address).toBeTruthy();
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/siwe-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/siwe-helpers.ts
@@ -19,12 +19,25 @@ import type { CompatibleRedis } from "../cache/redis-factory";
 export type { SiweMessage };
 
 const SIWE_DOMAIN_MISMATCH = "SIWE domain does not match app host";
+const SIWE_URI_MISMATCH = "SIWE uri does not match the server-issued uri";
+const SIWE_CHAIN_MISMATCH = "SIWE chainId does not match the server-issued chainId";
 const SIWE_NONCE_INVALID = "SIWE nonce invalid or already used";
 const SIWE_SIGNATURE_INVALID = "SIWE signature invalid";
 const SIWE_EXPIRED = "SIWE message has expired";
 const SIWE_NOT_YET_VALID = "SIWE message not yet valid";
 
 const NONCE_BYTES = 16;
+
+/**
+ * The `uri` + `chainId` the server issued alongside a nonce. These are bound to
+ * the nonce at issuance and re-checked at verify so the signed message cannot
+ * substitute a different `uri`/`chainId` on the same domain (EIP-4361
+ * completeness — the message must match every parameter the server offered).
+ */
+export interface SiweNonceBinding {
+  uri: string;
+  chainId: number;
+}
 
 function randomNonceHex(): string {
   const arr = new Uint8Array(NONCE_BYTES);
@@ -33,13 +46,51 @@ function randomNonceHex(): string {
 }
 
 /**
- * Allocate + persist a one-time SIWE nonce. Caller must have a per-request
- * Redis client.
+ * Allocate + persist a one-time SIWE nonce, binding the `uri`/`chainId` the
+ * server offered. Caller must have a per-request Redis client.
  */
-export async function issueNonce(redis: CompatibleRedis): Promise<string> {
+export async function issueNonce(
+  redis: CompatibleRedis,
+  binding: SiweNonceBinding,
+): Promise<string> {
   const nonce = randomNonceHex();
-  await redis.setex(CacheKeys.siwe.nonce(nonce), CacheTTL.siwe.nonce, "1");
+  await redis.setex(CacheKeys.siwe.nonce(nonce), CacheTTL.siwe.nonce, JSON.stringify(binding));
   return nonce;
+}
+
+/**
+ * Non-destructively read the `uri`/`chainId` bound to a nonce. Returns null if
+ * the nonce is absent or was stored in a legacy format without a binding (an
+ * in-flight nonce issued before this field existed) — legacy nonces simply skip
+ * the uri/chainId assertions, preserving the prior behavior for the short TTL
+ * window after a deploy.
+ */
+export async function readNonceBinding(
+  redis: CompatibleRedis,
+  nonce: string,
+): Promise<SiweNonceBinding | null> {
+  const value = await redis.get<string>(CacheKeys.siwe.nonce(nonce));
+  if (value === null || value === undefined) return null;
+  const parsed: unknown = typeof value === "string" ? safeJsonParse(value) : value;
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "uri" in parsed &&
+    "chainId" in parsed &&
+    typeof (parsed as SiweNonceBinding).uri === "string" &&
+    typeof (parsed as SiweNonceBinding).chainId === "number"
+  ) {
+    return { uri: (parsed as SiweNonceBinding).uri, chainId: (parsed as SiweNonceBinding).chainId };
+  }
+  return null;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -67,6 +118,7 @@ export async function validateSIWEMessage(
   message: string,
   signature: `0x${string}`,
   expectedHost: string,
+  expected?: SiweNonceBinding | null,
 ): Promise<{ address: string; parsed: SiweMessage }> {
   const parsed = parseSiweMessage(message);
   if (!parsed.address) {
@@ -77,6 +129,20 @@ export async function validateSIWEMessage(
   }
   if (parsed.domain !== expectedHost) {
     throw new Error(`${SIWE_DOMAIN_MISMATCH}: got ${parsed.domain}, expected ${expectedHost}`);
+  }
+  // EIP-4361 completeness: the signed `uri`/`chainId` must match what the server
+  // issued with the nonce. Domain + single-use nonce already block cross-site
+  // replay; this closes the gap where a message on the right domain signs a
+  // different uri/chainId than the one presented to the user.
+  if (expected) {
+    if (parsed.uri !== expected.uri) {
+      throw new Error(`${SIWE_URI_MISMATCH}: got ${parsed.uri}, expected ${expected.uri}`);
+    }
+    if (parsed.chainId !== expected.chainId) {
+      throw new Error(
+        `${SIWE_CHAIN_MISMATCH}: got ${parsed.chainId}, expected ${expected.chainId}`,
+      );
+    }
   }
 
   const address = getAddress(parsed.address);
@@ -114,7 +180,13 @@ export async function validateAndConsumeSIWE(
   signature: `0x${string}`,
   expectedHost: string,
 ): Promise<{ address: string; parsed: SiweMessage }> {
-  const result = await validateSIWEMessage(message, signature, expectedHost);
+  // Peek the nonce binding (uri/chainId) before validating so the signed
+  // message is checked against exactly what the server issued. The nonce is
+  // only consumed (getdel) after full validation so an invalid request does not
+  // burn it.
+  const nonceFromMessage = parseSiweMessage(message).nonce;
+  const binding = nonceFromMessage ? await readNonceBinding(redis, nonceFromMessage) : null;
+  const result = await validateSIWEMessage(message, signature, expectedHost, binding);
   const consumed = await consumeNonce(redis, result.parsed.nonce);
   if (!consumed) {
     throw new Error(SIWE_NONCE_INVALID);

--- a/packages/cloud/shared/src/lib/utils/siws-helpers.security.test.ts
+++ b/packages/cloud/shared/src/lib/utils/siws-helpers.security.test.ts
@@ -1,0 +1,110 @@
+/**
+ * L7 (#12229): SIWS validation binds the signed `uri` + `chainId` to the values
+ * the server issued with the nonce. A message on the correct domain with a valid
+ * ed25519 signature but a substituted uri/chainId is rejected.
+ *
+ * The signature exercised is a REAL ed25519 signature (tweetnacl) over the REAL
+ * SIWS message; only the nonce store is an in-memory stand-in for Redis.
+ */
+
+import { describe, expect, test } from "bun:test";
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+import { CacheKeys } from "../cache/keys";
+import type { CompatibleRedis } from "../cache/redis-factory";
+import { buildSiwsMessage, issueSiwsNonce, validateAndConsumeSIWS } from "./siws-helpers";
+
+const HOST = "app.example.com";
+const URI = "https://app.example.com";
+const CHAIN = "solana:mainnet";
+
+function mockRedis(): CompatibleRedis {
+  const store = new Map<string, string>();
+  return {
+    async setex(key: string, _ttl: number, value: string) {
+      store.set(key, value);
+      return "OK";
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async getdel(key: string) {
+      const v = store.get(key) ?? null;
+      store.delete(key);
+      return v;
+    },
+  } as unknown as CompatibleRedis;
+}
+
+function signSiws(params: { nonce: string; uri: string; chainId: string; domain: string }) {
+  const kp = nacl.sign.keyPair();
+  const address = bs58.encode(kp.publicKey);
+  const message = buildSiwsMessage({
+    domain: params.domain,
+    address,
+    statement: "Sign in",
+    uri: params.uri,
+    chainId: params.chainId,
+    nonce: params.nonce,
+    issuedAt: new Date(),
+  });
+  const sig = nacl.sign.detached(new TextEncoder().encode(message), kp.secretKey);
+  return { message, signature: bs58.encode(sig), address };
+}
+
+describe("L7 SIWS uri/chainId binding", () => {
+  test("accepts a message whose uri + chainId match the issued nonce", async () => {
+    const redis = mockRedis();
+    const nonce = await issueSiwsNonce(redis, { uri: URI, chainId: CHAIN });
+    const { message, signature, address } = signSiws({
+      nonce,
+      uri: URI,
+      chainId: CHAIN,
+      domain: HOST,
+    });
+    const result = await validateAndConsumeSIWS(redis, message, signature, HOST);
+    expect(result.address).toBe(address);
+  });
+
+  test("rejects a valid signature that signed a different chainId", async () => {
+    const redis = mockRedis();
+    const nonce = await issueSiwsNonce(redis, { uri: URI, chainId: CHAIN });
+    const { message, signature } = signSiws({
+      nonce,
+      uri: URI,
+      chainId: "solana:devnet",
+      domain: HOST,
+    });
+    await expect(validateAndConsumeSIWS(redis, message, signature, HOST)).rejects.toThrow(
+      /chainId does not match/i,
+    );
+  });
+
+  test("rejects a valid signature that signed a different uri", async () => {
+    const redis = mockRedis();
+    const nonce = await issueSiwsNonce(redis, { uri: URI, chainId: CHAIN });
+    const { message, signature } = signSiws({
+      nonce,
+      uri: "https://evil.example.com",
+      chainId: CHAIN,
+      domain: HOST,
+    });
+    await expect(validateAndConsumeSIWS(redis, message, signature, HOST)).rejects.toThrow(
+      /uri does not match/i,
+    );
+  });
+
+  test("legacy binding-less nonce ('1') skips the uri/chainId assertions", async () => {
+    const redis = mockRedis();
+    const nonce = "deadbeef";
+    await redis.setex(CacheKeys.siws.nonce(nonce), 300, "1");
+    const { message, signature } = signSiws({
+      nonce,
+      uri: "https://anything",
+      chainId: "solana:testnet",
+      domain: HOST,
+    });
+    const result = await validateAndConsumeSIWS(redis, message, signature, HOST);
+    expect(result.address).toBeTruthy();
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/siws-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/siws-helpers.ts
@@ -41,16 +41,62 @@ export interface SiwsMessage {
   notBefore?: Date;
 }
 
+/**
+ * The `uri` + `chainId` the server issued alongside a SIWS nonce, bound at
+ * issuance and re-checked at verify (EIP-4361 completeness — see siwe-helpers).
+ * SIWS `chainId` is a string (e.g. `solana:mainnet`), not a number.
+ */
+export interface SiwsNonceBinding {
+  uri: string;
+  chainId: string;
+}
+
 function randomNonceHex(): string {
   const arr = new Uint8Array(NONCE_BYTES);
   crypto.getRandomValues(arr);
   return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-export async function issueSiwsNonce(redis: CompatibleRedis): Promise<string> {
+export async function issueSiwsNonce(
+  redis: CompatibleRedis,
+  binding: SiwsNonceBinding,
+): Promise<string> {
   const nonce = randomNonceHex();
-  await redis.setex(CacheKeys.siws.nonce(nonce), CacheTTL.siws.nonce, "1");
+  await redis.setex(CacheKeys.siws.nonce(nonce), CacheTTL.siws.nonce, JSON.stringify(binding));
   return nonce;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Non-destructively read the `uri`/`chainId` bound to a SIWS nonce. Returns null
+ * for absent or legacy (binding-less) nonces, which then skip the uri/chainId
+ * assertions — preserving prior behavior for in-flight nonces after a deploy.
+ */
+export async function readSiwsNonceBinding(
+  redis: CompatibleRedis,
+  nonce: string,
+): Promise<SiwsNonceBinding | null> {
+  const value = await redis.get<string>(CacheKeys.siws.nonce(nonce));
+  if (value === null || value === undefined) return null;
+  const parsed: unknown = typeof value === "string" ? safeJsonParse(value) : value;
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "uri" in parsed &&
+    "chainId" in parsed &&
+    typeof (parsed as SiwsNonceBinding).uri === "string" &&
+    typeof (parsed as SiwsNonceBinding).chainId === "string"
+  ) {
+    return { uri: (parsed as SiwsNonceBinding).uri, chainId: (parsed as SiwsNonceBinding).chainId };
+  }
+  return null;
 }
 
 async function consumeSiwsNonce(redis: CompatibleRedis, nonce: string): Promise<boolean> {
@@ -170,12 +216,27 @@ export function validateSIWSMessage(
   message: string,
   signatureBase58: string,
   expectedHost: string,
+  expected?: SiwsNonceBinding | null,
 ): { address: string; parsed: SiwsMessage } {
   const parsed = parseSiwsMessage(message);
   if (parsed.domain !== expectedHost) {
     throw new Error(
       `SIWS domain does not match app host: got ${parsed.domain}, expected ${expectedHost}`,
     );
+  }
+  // EIP-4361 completeness: signed uri/chainId must match the server-issued
+  // values bound to the nonce (see siwe-helpers for rationale).
+  if (expected) {
+    if (parsed.uri !== expected.uri) {
+      throw new Error(
+        `SIWS uri does not match the server-issued uri: got ${parsed.uri}, expected ${expected.uri}`,
+      );
+    }
+    if (parsed.chainId !== expected.chainId) {
+      throw new Error(
+        `SIWS chainId does not match the server-issued chainId: got ${parsed.chainId}, expected ${expected.chainId}`,
+      );
+    }
   }
   const now = Date.now();
   if (parsed.expirationTime && parsed.expirationTime.getTime() <= now) {
@@ -207,7 +268,11 @@ export async function validateAndConsumeSIWS(
   signatureBase58: string,
   expectedHost: string,
 ): Promise<{ address: string; parsed: SiwsMessage }> {
-  const result = validateSIWSMessage(message, signatureBase58, expectedHost);
+  // Peek the nonce binding before validation; consume (getdel) only after full
+  // validation so an invalid request does not burn the nonce.
+  const nonceFromMessage = parseSiwsMessage(message).nonce;
+  const binding = nonceFromMessage ? await readSiwsNonceBinding(redis, nonceFromMessage) : null;
+  const result = validateSIWSMessage(message, signatureBase58, expectedHost, binding);
   const consumed = await consumeSiwsNonce(redis, result.parsed.nonce);
   if (!consumed) {
     throw new Error("SIWS nonce invalid or already used");

--- a/packages/core/src/network/fetch-guard.lookup-without-pin.test.ts
+++ b/packages/core/src/network/fetch-guard.lookup-without-pin.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+import type { LookupFn, PinnedLookupFetchLike } from "./ssrf.ts";
+
+// L8 (#12229): a `lookupFn` computes a DNS pin, but without a `pinnedFetchImpl`
+// to connect to that pinned IP the request would fall through to the unpinned
+// fetcher — the pin is computed and silently discarded, re-opening the
+// DNS-rebinding race (#11147). The guard must throw instead of downgrading.
+describe("fetchWithSsrfGuard: lookupFn without pinnedFetchImpl", () => {
+	const lookupFn: LookupFn = async () => [
+		{ address: "93.184.216.34", family: 4 },
+	];
+
+	it("throws when a lookupFn is provided without a pinnedFetchImpl", async () => {
+		const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+		await expect(
+			fetchWithSsrfGuard({
+				url: "https://example.com/resource",
+				fetchImpl,
+				lookupFn,
+			}),
+		).rejects.toThrow(/lookupFn was provided without a pinnedFetchImpl/i);
+		// It must NOT have connected through the unpinned fetcher.
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("succeeds when a lookupFn is paired with a pinnedFetchImpl", async () => {
+		const pinnedFetchImpl: PinnedLookupFetchLike = vi.fn(
+			async () => new Response("pinned", { status: 200 }),
+		);
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://example.com/resource",
+			// fetchImpl suppresses the node defaults so this test asserts the
+			// explicit pinned path only.
+			fetchImpl: vi.fn(async () => new Response("unpinned", { status: 200 })),
+			lookupFn,
+			pinnedFetchImpl,
+		});
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("pinned");
+		expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+		await release();
+	});
+
+	it("still allows the plain fetchImpl path with no lookupFn (unaffected)", async () => {
+		const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://example.com/page",
+			fetchImpl,
+		});
+		expect(response.status).toBe(200);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		await release();
+	});
+});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -250,6 +250,22 @@ export async function fetchWithSsrfGuard(
 	const pinnedFetchImpl =
 		params.pinnedFetchImpl ?? nodeDefaults?.pinnedFetchImpl;
 
+	// Fail CLOSED on the footgun that re-creates #11147: a `lookupFn` computes a
+	// DNS pin, but without a `pinnedFetchImpl` to connect to that pinned IP the
+	// request falls through to the unpinned `fetcher` — the pin is computed and
+	// then silently discarded, re-opening the DNS-rebinding race the lookup was
+	// meant to close. No current caller hits this (Node supplies both via
+	// nodeDefaults; edge supplies neither), but the combination must throw rather
+	// than downgrade to unpinned fetch.
+	if (lookupFn && !pinnedFetchImpl) {
+		throw new Error(
+			"SSRF guard: a DNS lookupFn was provided without a pinnedFetchImpl. " +
+				"Refusing to fall back to the unpinned fetcher — the computed DNS pin " +
+				"would be discarded, re-introducing a DNS-rebinding race. Provide a " +
+				"pinnedFetchImpl (e.g. node-pinned-fetch) alongside the lookupFn.",
+		);
+	}
+
 	const maxRedirects =
 		typeof params.maxRedirects === "number" &&
 		Number.isFinite(params.maxRedirects)


### PR DESCRIPTION
## Security remediation — auth + secrets primitives (sub-issue of #12183)

Surface: **auth + secrets primitives**. These are the residual hardening items from the read-only audit; the core of this surface is already strong (see the "do NOT re-flag" list in #12229). Files are disjoint from the other three sub-issues.

### Items shipped (each with a real test that drives the actual code path)

| id | file:line | what changed | test |
|----|-----------|--------------|------|
| **M4** | `packages/cloud/shared/src/lib/services/secrets/encryption.ts:49` | `LocalKMSProvider.getMasterKey` now fails **closed** when `SECRETS_MASTER_KEY` is unset — the previous `"0".repeat(64)` all-zero fallback is gone. Production always throws; non-prod throws unless `ALLOW_INSECURE_DEV_KMS=1` is explicitly set (then it logs a loud `[LocalKMSProvider]` warning and uses the zero key for local dev only). | `secrets/encryption.security.test.ts` — no-key+no-opt-in throws; prod throws even with opt-in; opt-in in non-prod warns+proceeds; configured key works. |
| **L6** | `secrets/encryption.ts:179` (`encrypt`/`decrypt`/`rotate`) and `field-encryption.ts:100,134` (`encrypt`/`decrypt`) | Optional AES-256-GCM **AAD** binding. Secrets service takes an `aad` string; field service takes a `FieldCoords {table,rowId,column}` → `table\|rowId\|column` AAD, mirroring `db/crypto/field-crypto.ts` / `@elizaos/security/crypto/aead`. A ciphertext relocated to a different row/column no longer decrypts. Omitting the AAD preserves the exact prior on-disk format (backward compatible). | `secrets/encryption.security.test.ts` + `field-encryption.aad.test.ts` — relocation → `DecryptionError`/GCM auth failure; matching AAD round-trips; no-AAD path unchanged. (field-encryption test uses the real `FieldEncryptionService` crypto with an in-memory org-key store, the same boundary `agent-env-crypto.test.ts` mocks.) |
| **L7** | `siwe-helpers.ts` + `siws-helpers.ts` + `auth/siwe/nonce/route.ts` + `auth/siws/nonce/route.ts` | `validateSIWEMessage`/`validateSIWSMessage` now assert the signed `uri` + `chainId` equal the values the server issued. The `{uri,chainId}` binding is threaded through nonce issuance (stored in Redis at `issueNonce`/`issueSiwsNonce`, read back non-destructively at verify). Legacy binding-less nonces (`"1"`) skip the assertions for the ≤300s post-deploy TTL window. Nonce is still consumed only after full validation (invalid requests don't burn it). | `siwe-helpers.security.test.ts` + `siws-helpers.security.test.ts` — real secp256k1 (viem) / ed25519 (nacl) signatures; a valid signature over a mismatched chainId/uri on the correct domain is rejected; matching values accepted; legacy nonce still works; mismatch doesn't burn the nonce. |
| **L8** | `packages/core/src/network/fetch-guard.ts:245` | `fetchWithSsrfGuard` now throws when a `lookupFn` is present without a `pinnedFetchImpl`, instead of silently falling through to the unpinned `fetcher` (which discards the computed DNS pin and re-opens the #11147 rebinding race). Node supplies both via `nodeDefaults`; edge supplies neither — existing callers unaffected. | `fetch-guard.lookup-without-pin.test.ts` — the footgun combo throws and the unpinned fetcher is never called; `lookupFn`+`pinnedFetchImpl` still works; plain `fetchImpl` (no lookup) unaffected. |

### Items deferred

- **M5** (edge/workerd DNS-rebinding TOCTOU) — not touched here. It is a code-marker + Cloudflare egress-policy/infra task, not a testable code change on this surface. Left to the infra half of #12229 (the network-policy portion is an operator action by design).
- **M6** (unified log redaction at the sink) — not done. Converging cloud (name-based) and core (value-regex) redaction onto one sink-level predicate is a cross-package refactor touching every `logger.error/warn` path; not tractable without churn in this focused PR.
- **L9** (Feed A2A agent-card fetch SSRF guard) — out of this surface's file set (`packages/feed/...`); belongs to a different sub-issue.
- **L6 production caller-wiring / at-rest backfill** — the AAD **capability + tests** ship here, but existing callers (discord/vendor connections, entity-settings, user-database) are **not** switched to pass AAD, because binding AAD on already-stored ciphertext would fail to decrypt without a versioned-format + backfill **live-data migration**. Wiring callers is a follow-up that must ship with that migration. The primitives are ready and proven.

### Verification

```
# cloud/shared (bun test)
bun test packages/cloud/shared/src/lib/services/secrets/encryption.security.test.ts \
         packages/cloud/shared/src/lib/utils/siwe-helpers.security.test.ts \
         packages/cloud/shared/src/lib/utils/siws-helpers.security.test.ts
#  → 20 pass / 0 fail
bun test packages/cloud/shared/src/lib/services/field-encryption.aad.test.ts
#  → 5 pass / 0 fail
bun test packages/cloud/shared/src/lib/auth/siwe-test-login.test.ts   # regression
#  → 3 pass / 0 fail (1 live-only skipped)

# core (vitest)
bun run --cwd packages/core test fetch-guard
#  → 26 pass / 0 fail (3 files, incl. new L8 test)

# typecheck (filtered to touched files) + biome — clean
bun run --cwd packages/cloud/shared typecheck   # no errors in touched files
bun run --cwd packages/core typecheck           # no errors in fetch-guard
bunx biome check <touched files>                # clean
```

### Notes for the merger
- L7 changes the SIWE/SIWS nonce Redis value from `"1"` to `{"uri","chainId"}` JSON. Backward-compatible: `readNonceBinding` returns `null` for the legacy `"1"` value and the uri/chainId assertions are skipped for those in-flight nonces (≤300s TTL). No breaking window for existing logins — the real headless-login regression test (`siwe-test-login.test.ts`) passes unchanged.
- M4 is the only change that can affect boot: a cloud process that today relies on the silent zero-key (no `SECRETS_MASTER_KEY`, `NODE_ENV≠production`) will now throw on first encrypt/decrypt. That is the intended fail-closed behavior. Local dev must set `SECRETS_MASTER_KEY` (recommended) or `ALLOW_INSECURE_DEV_KMS=1`. Flagged loudly here.

Refs #12229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
