### PR TITLE
security(#12228): local-agent API port + compat dispatcher remediation

### DIFF
--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -10,6 +10,7 @@ import {
   isLoopbackBindHost,
   isNullOriginAllowed,
   isTrustedLocalRequest as isTrustedLocalRequestShared,
+  isWildcardBindHost,
   resolveAllowedHosts,
   resolveAllowedOrigins,
   resolveApiBindHost,
@@ -583,15 +584,33 @@ export function ensureApiTokenForBindHost(host: string): void {
   if (token) return;
 
   const cloudProvisioned = isCloudProvisionedContainer();
+  const wildcardBind = isWildcardBindHost(host);
+
+  // M7 (#12228): a wildcard bind (0.0.0.0 / ::) relaxes both the DNS-rebind
+  // Host check (`hostAllowed`) and the CORS origin check (`resolveCorsOrigin`
+  // reflects any origin with credentials). With ELIZA_DISABLE_AUTO_API_TOKEN=1
+  // and no explicit ELIZA_API_TOKEN that leaves the server listening on every
+  // interface with *no* authenticated boundary and both browser-origin
+  // protections off — silently wide open. Refuse to honor the disable flag in
+  // that exact combo: force a generated token so a real auth boundary exists.
+  // (A specific non-loopback IP bind keeps Host+CORS enforced, so the disable
+  // flag is still honored there.)
+  const forceTokenForWildcard = wildcardBind && disableAutoApiToken;
 
   // Cloud-provisioned containers must never run without an inbound API token
   // (isAuthorized rejects all requests when no token + cloud flag is set).
   // Override the disable flag for cloud containers so they always get a
   // fallback token rather than dead-locking into 401 on every request.
-  if (disableAutoApiToken && !cloudProvisioned) {
+  if (disableAutoApiToken && !cloudProvisioned && !forceTokenForWildcard) {
     return;
   }
-  if (!cloudProvisioned && isLoopbackBindHost(host)) return;
+  if (forceTokenForWildcard) {
+    logger.warn(
+      `[eliza-api] ELIZA_API_BIND=${host} is a wildcard bind and ELIZA_DISABLE_AUTO_API_TOKEN is set with no ELIZA_API_TOKEN. Refusing to start without an authenticated boundary: forcing a generated API token. DNS-rebind + CORS checks stay relaxed for wildcard binds, so this token is the only boundary. Set ELIZA_API_TOKEN explicitly, or bind to 127.0.0.1, to override.`,
+    );
+  }
+  if (!cloudProvisioned && !forceTokenForWildcard && isLoopbackBindHost(host))
+    return;
 
   const generated = crypto.randomBytes(32).toString("hex");
   setApiToken(process.env, generated);

--- a/packages/agent/src/api/server-helpers-auth.wildcard-token.test.ts
+++ b/packages/agent/src/api/server-helpers-auth.wildcard-token.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureApiTokenForBindHost,
+  getConfiguredApiToken,
+} from "./server-helpers-auth.ts";
+
+/**
+ * M7 (#12228): a wildcard bind (0.0.0.0 / ::) relaxes both the DNS-rebind Host
+ * check (`isAllowedHost`) and the CORS origin check (`resolveCorsOrigin`
+ * reflects any origin with credentials). With `ELIZA_DISABLE_AUTO_API_TOKEN=1`
+ * and no explicit `ELIZA_API_TOKEN`, the pre-fix code silently returned with no
+ * token — leaving the server listening on every interface with *no*
+ * authenticated boundary and both browser-origin protections off.
+ *
+ * `ensureApiTokenForBindHost` must now REFUSE that combo: force a generated
+ * token so a real auth boundary exists. The disable flag is still honored for
+ * loopback and specific (non-wildcard) non-loopback IP binds, which keep the
+ * Host + CORS guards enforced.
+ */
+const ENV_KEYS = [
+  "ELIZA_API_BIND",
+  "ELIZA_API_TOKEN",
+  "ELIZA_DISABLE_AUTO_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "STEWARD_AGENT_TOKEN",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("ensureApiTokenForBindHost — M7 wildcard-bind + disabled auto-token", () => {
+  it("forces a generated token for a wildcard bind even when auto-token is disabled", () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    expect(getConfiguredApiToken()).toBeUndefined();
+
+    ensureApiTokenForBindHost("0.0.0.0");
+
+    const token = getConfiguredApiToken();
+    expect(token).toBeTruthy();
+    // 32 random bytes → 64 hex chars.
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("forces a generated token for the IPv6 wildcard bind (::) too", () => {
+    process.env.ELIZA_API_BIND = "::";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    expect(getConfiguredApiToken()).toBeUndefined();
+
+    ensureApiTokenForBindHost("::");
+
+    expect(getConfiguredApiToken()).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("still honors the disable flag on a loopback bind (no token forced)", () => {
+    process.env.ELIZA_API_BIND = "127.0.0.1";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+
+    ensureApiTokenForBindHost("127.0.0.1");
+
+    expect(getConfiguredApiToken()).toBeUndefined();
+  });
+
+  it("still honors the disable flag on a specific non-loopback IP bind (Host+CORS stay enforced there)", () => {
+    process.env.ELIZA_API_BIND = "192.168.1.5";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+
+    ensureApiTokenForBindHost("192.168.1.5");
+
+    expect(getConfiguredApiToken()).toBeUndefined();
+  });
+
+  it("never overrides an explicitly configured token on a wildcard bind", () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+    process.env.ELIZA_DISABLE_AUTO_API_TOKEN = "1";
+    process.env.ELIZA_API_TOKEN = "operator-supplied-token";
+
+    ensureApiTokenForBindHost("0.0.0.0");
+
+    expect(getConfiguredApiToken()).toBe("operator-supplied-token");
+  });
+
+  it("generates a token for a wildcard bind when the disable flag is unset (pre-existing behavior preserved)", () => {
+    process.env.ELIZA_API_BIND = "0.0.0.0";
+
+    ensureApiTokenForBindHost("0.0.0.0");
+
+    expect(getConfiguredApiToken()).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
+++ b/packages/app-core/src/api/route-auth-policy.dispatch.test.ts
@@ -1,0 +1,146 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@elizaos/core"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    logger: {
+      ...actual.logger,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
+
+import type { CompatRuntimeState } from "./compat-route-shared";
+import { handleElizaCompatRoute } from "./server";
+
+/**
+ * H5 (#12228): the app-core compat dispatcher must be default-deny. The
+ * declarative policy table + `enforceCompatRouteAuthPolicy` landed in #12214;
+ * this test pins the behavior through the REAL dispatcher entrypoint
+ * (`handleElizaCompatRoute` → `handleCompatRoute` → `handleCompatRouteInner`),
+ * proving the gate short-circuits an un-gated (undeclared) compat route with a
+ * 401 BEFORE any `handle*` module runs — i.e. a future handler that forgets its
+ * own `ensureRoute*` call still cannot ship an unauthenticated compat route as
+ * long as its prefix is compat-managed.
+ */
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+const ENV_KEYS = [
+  "ELIZA_API_BIND",
+  "ELIZA_API_TOKEN",
+  "ELIZA_RUNTIME_MODE",
+] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  // Force a non-loopback peer + no token so the request is unauthenticated.
+  delete process.env.ELIZA_API_TOKEN;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  vi.restoreAllMocks();
+});
+
+function unauthReq(method: string, pathname: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = method;
+  req.url = pathname;
+  req.headers = { host: "example.test:2138" };
+  // A remote (non-loopback) peer is never trusted-local, so with no token the
+  // request is fully unauthenticated.
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "203.0.113.9",
+    configurable: true,
+  });
+  return req;
+}
+
+function captureRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.assignSocket(new Socket());
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+describe("compat dispatcher default-deny (H5)", () => {
+  it("401s an un-gated, undeclared compat-managed route before any handler runs", async () => {
+    // `/api/dev/*` is a compat-managed prefix but this specific path has NO
+    // policy entry — the stand-in for a freshly-added handler that forgot to
+    // declare its auth policy. The default-deny gate must reject it.
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      unauthReq("GET", "/api/dev/__throwaway_h5_ungated__"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(401);
+    expect(cap.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("401s an un-gated undeclared secrets (OWNER-prefix) mutation route", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      unauthReq("POST", "/api/secrets/__throwaway_h5_ungated__"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(401);
+    expect(cap.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("lets a genuinely non-compat route fall through to the upstream agent gate", async () => {
+    // `/api/messages` is owned by the agent server, not the compat layer. The
+    // dispatcher must NOT claim it (returns false) so the agent's own
+    // fail-closed gate handles it.
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      unauthReq("GET", "/api/messages"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(false);
+  });
+
+  it("serves a public compat route (i18n locale) without auth", async () => {
+    const cap = captureRes();
+    const handled = await handleElizaCompatRoute(
+      unauthReq("GET", "/api/i18n/locale"),
+      cap.res,
+      STATE,
+    );
+
+    expect(handled).toBe(true);
+    expect(cap.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Security remediation — local-agent API + port exposure (#12228)

Surface: the local agent HTTP server (`packages/agent/src/api/**`, `packages/app-core/src/api/**`). Builds on #12138 / #12088 / #12214. Does **not** touch any path in the issue's "VERIFIED-SECURE / do NOT re-flag" list.

### Per-item

| id | file:line | what changed | test |
|----|-----------|--------------|------|
| **M7** | `packages/agent/src/api/server-helpers-auth.ts:579-612` (`ensureApiTokenForBindHost`) | A wildcard bind (`0.0.0.0` / `::`) relaxes **both** the DNS-rebind Host check (`isAllowedHost`) and the CORS origin check (`resolveCorsOrigin` reflects any origin with credentials). Previously, `ELIZA_API_BIND=0.0.0.0 + ELIZA_DISABLE_AUTO_API_TOKEN=1 + no token` hit the early `return` at the old `:591` and the server listened on every interface with **no authenticated boundary** and both browser-origin protections off. Now the disable flag is **refused for that exact combo**: a token is force-generated + logged, so a real auth boundary exists. Loopback and specific non-loopback IP binds (Host+CORS still enforced there) keep honoring the flag; an explicit operator token is never overridden. | `packages/agent/src/api/server-helpers-auth.wildcard-token.test.ts` (6 cases: wildcard v4/v6 force-token, loopback honored, specific-IP honored, explicit-token preserved, disable-unset behavior preserved) |
| **H5** | `packages/app-core/src/api/route-auth-policy.ts` (gate) + `packages/app-core/src/api/server.ts:687` (dispatch) | The declarative default-deny policy table + `enforceCompatRouteAuthPolicy` **already landed on develop via #12214** (it is an ancestor of HEAD; verified every current compat handler path is covered by an explicit policy or a managed prefix). This PR **pins that gate at the real dispatcher entrypoint** (`handleElizaCompatRoute → handleCompatRoute → handleCompatRouteInner`), proving an un-gated, undeclared compat-managed route is `401`'d **before** any `handle*` module runs (the spec's "throwaway un-gated compat handler asserting 401"). Per-handler `ensureRoute*` calls remain as defense-in-depth. | `packages/app-core/src/api/route-auth-policy.dispatch.test.ts` (4 cases: undeclared `/api/dev/*` → 401, undeclared `/api/secrets/*` POST → 401, non-compat `/api/messages` falls through, public `/api/i18n/locale` serves) |

### Items deferred

- **L11** (public-route method restriction + shared-secret entropy doc) — **not implemented**. Low/Info hardening; out of the requested focus (M7 + H5). No change shipped.
- **M7 live-boot evidence** — the unit test drives the real `ensureApiTokenForBindHost` code path (not a mock). A full `eliza start` boot + cross-origin browser rejection capture needs a running local agent + browser and was not run in this CI-only worktree. The behavior is fully covered by the unit suite; the live capture is the only residual.

### Verification (commands + results)

```
bun run --cwd packages/agent test -- server-helpers-auth.wildcard-token   → 6 passed (M7)
bun run --cwd packages/agent test -- server-helpers-auth                   → 44 passed (no regressions)
bun run --cwd packages/app-core test -- route-auth-policy.dispatch          → 4 passed (H5)
bun run --cwd packages/app-core test -- route-auth-policy                   → 10 passed (existing #12214 + new)
bunx biome check <3 changed files>                                         → clean
bun run --cwd packages/agent typecheck                                     → clean
```

`packages/app-core typecheck` reports only **pre-existing** `@elizaos/capacitor-bun-runtime` optional-dep declaration errors in untouched files (`ios-runtime-bridge.ts`, `ios-local-agent-transport.ts`) — none reference the files this PR changes.

### Notes for the merger

- M7 is the genuinely new change and can break boot **only** in the wildcard + disable-flag + no-token combo, where it now generates a token (logged at `warn`) instead of running wide open — an intentional, safer posture. All other bind/token combinations are byte-identical.
- H5's gate itself is #12214's work; this PR adds the dispatcher-level end-to-end verification the issue asked for and confirms completeness. If you consider re-testing pre-landed behavior redundant, the test still has value as a regression pin at the real entrypoint.

Refs #12228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
