### PR TITLE
security(#12227): Cloud API (Workers BFF) remediation — timing-safe compares, service-key scope, webhook dedupe, rate-limit fail-closed

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -29,6 +29,15 @@ mock.module(
 // NOTE: mapConnectWebhookEvent is intentionally NOT mocked — the test exercises
 // the real pure mapping so a regression there is caught here too.
 
+// The route dedupes on event.id via webhookEventsRepository.tryCreate (#12227
+// L5). Stub it as a first-time delivery so these mapping/persist tests run;
+// replay dedupe itself is covered in the sibling dedupe.test.ts.
+mock.module("@elizaos/cloud-shared/db/repositories/webhook-events", () => ({
+  webhookEventsRepository: {
+    tryCreate: mock(async () => ({ created: true, event: { id: "evt" } })),
+  },
+}));
+
 mock.module("@/lib/stripe", () => ({
   isStripeConfigured: () => stripeConfigured,
   requireStripe: () => ({ webhooks: { constructEventAsync } }),

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -17,6 +17,11 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { describeSyncError, syncUserFromSteward } from "@/lib/steward-sync";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -139,6 +144,18 @@ function errorBody(
 }
 
 const app = new Hono<AppEnv>();
+
+// Pre-auth session-mint endpoint: previously guarded only by the Origin
+// allowlist + JWT verify, with no per-IP throttle. Add a strict, per-IP,
+// fail-closed rate limit so a credential-stuffing / token-spray flood on a
+// money/auth surface is bounded even if Redis blips at request time (M11).
+app.use(
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    keyGenerator: getIpKey,
+    failClosed: true,
+  }),
+);
 
 app.post("/", async (c) => {
   try {

--- a/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
@@ -1,0 +1,125 @@
+/**
+ * billing/checkout/verify — the S2S agent-billing branch must enforce a valid
+ * service key (#12227 L1). The route resolves credits for an agent when the
+ * Stripe session carries `metadata.agent_id`; it previously called
+ * `await validateServiceKey(c)` and DISCARDED the result. `validateServiceKey`
+ * returns null (does not throw) on a bad key, so the S2S gate was a no-op and
+ * the endpoint was triggerable unauthenticated. It now calls
+ * `requireServiceKey(c)`, which throws 401.
+ *
+ * This file intentionally does NOT mock the service-key module — the REAL
+ * `requireServiceKey` runs (constant-time compare against `WAIFU_SERVICE_KEY`)
+ * so we exercise the actual gate, and assert no invoice/credit/webhook side
+ * effect on the denied path.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const addCredits = mock(async () => ({ newBalance: 8.25 }));
+const createInvoice = mock(async () => undefined);
+const webhookFetch = mock(async () => Response.json({ ok: true }));
+const retrieveSession = mock(async () => ({
+  id: "cs_agent_paid",
+  payment_status: "paid",
+  amount_total: 500,
+  currency: "usd",
+  payment_intent: { id: "pi_agent_topup" },
+  metadata: {
+    organization_id: "agent-org",
+    user_id: "agent-user",
+    credits: "5.00",
+    type: "custom_amount",
+    agent_id: "123e4567-e89b-12d3-a456-426614174000",
+  },
+}));
+
+function dbChain(rows: unknown[]) {
+  return { from: () => ({ where: () => ({ limit: async () => rows }) }) };
+}
+
+mock.module("@/db/helpers", () => ({
+  dbRead: { select: mock(() => dbChain([])) },
+}));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getWithOrganization: mock(async () => null) },
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    addCredits,
+    getTransactionByStripePaymentIntent: mock(async () => null),
+  },
+}));
+mock.module("@/lib/services/invoices", () => ({
+  invoicesService: {
+    create: createInvoice,
+    getByStripeInvoiceId: mock(async () => null),
+  },
+}));
+mock.module("@/lib/services/organizations", () => ({
+  organizationsService: { getById: mock(async () => ({ credit_balance: "0" })) },
+}));
+mock.module("@/lib/security/safe-fetch", () => ({ safeFetch: webhookFetch }));
+mock.module("@/lib/stripe", () => ({
+  requireStripe: () => ({
+    checkout: { sessions: { retrieve: retrieveSession } },
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(env: Record<string, unknown>, headers: Record<string, string>) {
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ session_id: "cs_agent_paid" }),
+    }),
+    env,
+  );
+}
+
+describe("billing/checkout/verify — real service-key gate on agent branch (L1)", () => {
+  beforeEach(() => {
+    addCredits.mockClear();
+    createInvoice.mockClear();
+    webhookFetch.mockClear();
+    retrieveSession.mockClear();
+  });
+
+  test("a bogus X-Service-Key is 401 with NO credit/invoice/webhook side effect", async () => {
+    const res = await post(
+      { WAIFU_SERVICE_KEY: "the-real-key", NODE_ENV: "test" },
+      { "X-Service-Key": "not-the-real-key" },
+    );
+    expect(res.status).toBe(401);
+    expect(addCredits).not.toHaveBeenCalled();
+    expect(createInvoice).not.toHaveBeenCalled();
+    expect(webhookFetch).not.toHaveBeenCalled();
+  });
+
+  test("a MISSING service key is 401 (previously the discarded-result no-op passed through)", async () => {
+    const res = await post(
+      { WAIFU_SERVICE_KEY: "the-real-key", NODE_ENV: "test" },
+      {},
+    );
+    expect(res.status).toBe(401);
+    expect(addCredits).not.toHaveBeenCalled();
+    expect(createInvoice).not.toHaveBeenCalled();
+    expect(webhookFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.l1.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { Hono } from "hono";
 
 const addCredits = mock(async () => ({ newBalance: 8.25 }));
 const createInvoice = mock(async () => undefined);
@@ -57,7 +56,9 @@ mock.module("@/lib/services/invoices", () => ({
   },
 }));
 mock.module("@/lib/services/organizations", () => ({
-  organizationsService: { getById: mock(async () => ({ credit_balance: "0" })) },
+  organizationsService: {
+    getById: mock(async () => ({ credit_balance: "0" })),
+  },
 }));
 mock.module("@/lib/security/safe-fetch", () => ({ safeFetch: webhookFetch }));
 mock.module("@/lib/stripe", () => ({

--- a/packages/cloud/api/billing/checkout/verify/route.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.ts
@@ -20,7 +20,7 @@ import {
   failureResponse,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
-import { validateServiceKey } from "@/lib/auth/service-key-hono-worker";
+import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -213,7 +213,10 @@ async function resolveCreditUser(
   agentId?: string,
 ): ReturnType<typeof requireUserOrApiKeyWithOrg> {
   if (!agentId) return requireUserOrApiKeyWithOrg(c);
-  await validateServiceKey(c);
+  // S2S agent-billing branch: enforce a valid service key (validateServiceKey
+  // returns null on a bad key, so awaiting-and-discarding it left this path
+  // triggerable unauthenticated — see #11981 class).
+  await requireServiceKey(c);
 
   const [sandbox] = await dbRead
     .select({

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -6,9 +6,9 @@
  * `===` was replaced with `timingSafeEqualSecret`; these drive the real route.
  */
 
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
 const mintAgentToken = mock(async (agentId: string) => ({

--- a/packages/cloud/api/v1/agent-tokens/route.test.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Agent-token minting route — service-secret compare must be constant-time
+ * (#12227 M1). The route mints Steward agent JWTs for any `agentId`, so a
+ * timing oracle on the service-secret compare could recover
+ * ELIZA_CLOUD_SERVICE_TOKEN / AGENT_TOKEN_SERVICE_TOKEN and forge tokens. The
+ * `===` was replaced with `timingSafeEqualSecret`; these drive the real route.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const mintAgentToken = mock(async (agentId: string) => ({
+  token: `jwt-for-${agentId}`,
+  expiresAt: "2026-01-01T00:00:00Z",
+}));
+const getCurrentUser = mock(async () => null);
+
+mock.module("@/lib/auth/agent-token", () => ({ mintAgentToken }));
+mock.module("@/lib/auth/workers-hono-auth", () => ({ getCurrentUser }));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: agentTokensRoute } = await import("./route");
+
+const SECRET = "super-secret-service-token-value";
+const ENV = { ELIZA_CLOUD_SERVICE_TOKEN: SECRET };
+
+function post(headers: Record<string, string>) {
+  const app = new Hono();
+  app.route("/api/v1/agent-tokens", agentTokensRoute);
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/agent-tokens", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ agentId: "agent-xyz" }),
+    }),
+    ENV,
+  );
+}
+
+describe("agent-tokens route — constant-time service-secret gate (M1)", () => {
+  beforeEach(() => {
+    mintAgentToken.mockClear();
+    getCurrentUser.mockClear();
+  });
+
+  test("the source has no plain === / !== secret comparison", () => {
+    const src = readFileSync(
+      fileURLToPath(new URL("./route.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(src).toContain("timingSafeEqualSecret");
+    expect(src).not.toMatch(/supplied\s*===\s*expected/);
+    expect(src).not.toMatch(/supplied\s*!==\s*expected/);
+  });
+
+  test("the exact service token mints a JWT", async () => {
+    const res = await post({ authorization: `Bearer ${SECRET}` });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      token: "jwt-for-agent-xyz",
+    });
+    expect(mintAgentToken).toHaveBeenCalledTimes(1);
+  });
+
+  test("a 1-byte-off service token is rejected 401 and mints nothing", async () => {
+    const oneOff = `${SECRET.slice(0, -1)}X`;
+    const res = await post({ authorization: `Bearer ${oneOff}` });
+    expect(res.status).toBe(401);
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("a length-mismatched token is rejected 401 (no timingSafeEqual throw)", async () => {
+    const res = await post({ "x-eliza-service-token": `${SECRET}extra` });
+    expect(res.status).toBe(401);
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+
+  test("an absent token is rejected 401", async () => {
+    const res = await post({});
+    expect(res.status).toBe(401);
+    expect(mintAgentToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/agent-tokens/route.ts
+++ b/packages/cloud/api/v1/agent-tokens/route.ts
@@ -9,6 +9,7 @@
 
 import { Hono } from "hono";
 import { mintAgentToken } from "@/lib/auth/agent-token";
+import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -38,7 +39,8 @@ function hasServiceAccountAuth(c: AppContext): boolean {
     bearerToken(c) ??
     c.req.header("x-eliza-service-token") ??
     c.req.header("x-service-token");
-  return supplied === expected;
+  if (typeof supplied !== "string") return false;
+  return timingSafeEqualSecret(supplied, expected);
 }
 
 async function hasAdminAuth(c: AppContext): Promise<boolean> {

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
@@ -8,7 +8,15 @@
  * no-op — the account mutation runs exactly once.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { Hono } from "hono";
 
 process.env.DATABASE_URL ||= "pglite://memory";
@@ -38,9 +46,12 @@ mock.module("@/lib/stripe", () => ({
   requireStripe: () => ({ webhooks: { constructEventAsync } }),
   isStripeConfigured: () => true,
 }));
-mock.module("@elizaos/cloud-shared/db/repositories/stripe-connect-accounts", () => ({
-  stripeConnectAccountsRepository: { updateByAccountId },
-}));
+mock.module(
+  "@elizaos/cloud-shared/db/repositories/stripe-connect-accounts",
+  () => ({
+    stripeConnectAccountsRepository: { updateByAccountId },
+  }),
+);
 mock.module("@elizaos/cloud-shared/lib/services/stripe-connect-payout", () => ({
   mapConnectWebhookEvent,
 }));

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/dedupe.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Stripe-Connect webhook replay dedupe (#12227 L5). Stripe delivers
+ * at-least-once; without an event-id dedupe a re-delivered `account.updated`
+ * reapplies capability/status writes. The route now dedupes on `event.id` via
+ * the REAL `webhookEventsRepository.tryCreate` (in-process PGlite). Signature
+ * verification is the Stripe SDK's job (mocked, as in the main stripe webhook
+ * test); the dedupe path is exercised for real. Second delivery must be a
+ * no-op — the account mutation runs exactly once.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const CONNECT_EVENT = {
+  id: "evt_conn_1",
+  type: "account.updated",
+  account: "acct_1",
+  created: Math.floor(Date.now() / 1000),
+  data: { object: { charges_enabled: true, payouts_enabled: true } },
+};
+
+const constructEventAsync = mock(async () => CONNECT_EVENT);
+const updateByAccountId = mock(async () => undefined);
+const mapConnectWebhookEvent = mock(() => ({
+  ignored: false,
+  accountId: "acct_1",
+  status: "active",
+  chargesEnabled: true,
+  payoutsEnabled: true,
+  payoutStatus: "ready",
+}));
+
+mock.module("@/lib/stripe", () => ({
+  requireStripe: () => ({ webhooks: { constructEventAsync } }),
+  isStripeConfigured: () => true,
+}));
+mock.module("@elizaos/cloud-shared/db/repositories/stripe-connect-accounts", () => ({
+  stripeConnectAccountsRepository: { updateByAccountId },
+}));
+mock.module("@elizaos/cloud-shared/lib/services/stripe-connect-payout", () => ({
+  mapConnectWebhookEvent,
+}));
+mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
+  getAuditDispatcher: () => ({ emit: async () => undefined }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const PGLITE_TIMEOUT = 60_000;
+let closeDb: (() => Promise<void>) | undefined;
+let connectRoute: typeof import("./route").default;
+
+const ENV = {
+  STRIPE_CONNECT_WEBHOOK_SECRET: "whsec_connect_test",
+  NODE_ENV: "test",
+};
+
+function delivery() {
+  const app = new Hono();
+  app.route("/", connectRoute);
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "stripe-signature": "valid-signature",
+      },
+      body: JSON.stringify({ id: "evt_conn_1", type: "account.updated" }),
+    }),
+    ENV,
+  );
+}
+
+beforeAll(async () => {
+  const { dbWrite, closeDatabaseConnectionsForTests } = await import(
+    "@/db/client"
+  );
+  closeDb = closeDatabaseConnectionsForTests;
+  await dbWrite.execute(
+    `CREATE TABLE IF NOT EXISTS webhook_events (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      event_id text NOT NULL UNIQUE,
+      provider text NOT NULL,
+      event_type text,
+      payload_hash text NOT NULL,
+      source_ip text,
+      processed_at timestamp NOT NULL DEFAULT now(),
+      event_timestamp timestamp
+    );`,
+  );
+  ({ default: connectRoute } = await import("./route"));
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("Stripe-Connect webhook — replay dedupe (L5)", () => {
+  beforeEach(async () => {
+    updateByAccountId.mockClear();
+    mapConnectWebhookEvent.mockClear();
+    const { dbWrite } = await import("@/db/client");
+    await dbWrite.execute("DELETE FROM webhook_events;");
+  });
+
+  test("first delivery applies; a replay of the same event.id is a no-op", async () => {
+    const first = await delivery();
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({ success: true });
+    expect(updateByAccountId).toHaveBeenCalledTimes(1);
+
+    const replay = await delivery();
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({ duplicate: true });
+    // The capability/status write must run exactly once.
+    expect(updateByAccountId).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -1,4 +1,5 @@
 import { stripeConnectAccountsRepository } from "@elizaos/cloud-shared/db/repositories/stripe-connect-accounts";
+import { webhookEventsRepository } from "@elizaos/cloud-shared/db/repositories/webhook-events";
 import { mapConnectWebhookEvent } from "@elizaos/cloud-shared/lib/services/stripe-connect-payout";
 import { Hono } from "hono";
 import type Stripe from "stripe";
@@ -13,6 +14,18 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  * time — matches Stripe's SDK default and the main `stripe/webhook` route.
  */
 const STRIPE_WEBHOOK_TOLERANCE_SECONDS = 300;
+
+/** SHA-256 of the raw body for the webhook_events.payload_hash column.
+ *  WebCrypto-only so this works on Workers. */
+async function hashConnectPayload(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(body),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 function getClientIp(c: AppContext): string {
   return (
@@ -89,6 +102,26 @@ async function handlePOST(c: AppContext): Promise<Response> {
       { success: false, error: "Webhook signature verification failed" },
       400,
     );
+  }
+
+  // Replay dedupe on the Stripe event id (matches the main stripe/webhook and
+  // crypto webhooks). Stripe delivers at-least-once; without this a re-delivered
+  // `account.updated` reapplies capability/status writes. The mutation below is
+  // synchronous (no queue), so a committed marker with no rollback is safe.
+  const dedupe = await webhookEventsRepository.tryCreate({
+    event_id: `stripe-connect:${event.id}`,
+    provider: "stripe-connect",
+    event_type: event.type,
+    payload_hash: await hashConnectPayload(body),
+    source_ip: getClientIp(c),
+    event_timestamp: event.created ? new Date(event.created * 1000) : undefined,
+  });
+  if (!dedupe.created) {
+    logger.info("[StripeConnect] Duplicate event — skipping", {
+      eventId: event.id,
+      type: event.type,
+    });
+    return c.json({ success: true, duplicate: true });
   }
 
   const outcome = mapConnectWebhookEvent({

--- a/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
@@ -118,7 +118,7 @@ describe("jobs route", () => {
     });
   });
 
-  test("service-key polling can read owner-org jobs by id", async () => {
+  test("service-key polling is SCOPED to the service org (M3) — never unscoped", async () => {
     const response = await app.fetch(
       new Request("https://api.example.test/api/v1/jobs/job-1", {
         method: "GET",
@@ -130,16 +130,34 @@ describe("jobs route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       success: true,
-      data: {
-        id: "job-1",
-        status: "completed",
-        result: { logs: "ok" },
-      },
-      polling: { shouldContinue: false },
+      data: { id: "job-1" },
     });
-    expect(getJob).toHaveBeenCalledWith("job-1");
-    expect(getJobForOrg).not.toHaveBeenCalled();
+    // The route must scope the read to the org the service identity resolves to
+    // and must NEVER call the unscoped getJob for a shared service key.
+    expect(getJobForOrg).toHaveBeenCalledWith("job-1", "service-org");
+    expect(getJob).not.toHaveBeenCalled();
     expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  });
+
+  test("service-key request for another org's job returns 404 with no row leak (M3)", async () => {
+    // The job belongs to a different org, so the scoped read finds nothing.
+    getJobForOrg.mockResolvedValueOnce(undefined as never);
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/jobs/other-org-job", {
+        method: "GET",
+        headers: { "X-Service-Key": "svc" },
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Job not found",
+    });
+    expect(getJobForOrg).toHaveBeenCalledWith("other-org-job", "service-org");
+    expect(getJob).not.toHaveBeenCalled();
   });
 
   test("user/API-key polling stays scoped to the caller organization", async () => {

--- a/packages/cloud/api/v1/jobs/[jobId]/route.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.ts
@@ -22,10 +22,10 @@ app.get("/", async (c) => {
 
     const serviceIdentity = await validateServiceKey(c);
     if (serviceIdentity) {
-      // Service-key callers orchestrate jobs on behalf of wallet-owned agents,
-      // so their job rows may belong to the agent owner org rather than the
-      // service org configured on the key.
-      organizationId = null;
+      // Scope service-key reads to the org the service identity resolves to.
+      // A shared WAIFU service key must never grant an unscoped read of any
+      // org's provisioning job (status/result/error).
+      organizationId = serviceIdentity.organizationId;
     } else {
       const user = await requireUserOrApiKeyWithOrg(c);
       organizationId = user.organization_id;
@@ -36,9 +36,10 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Job ID is required" }, 400);
     }
 
-    const job = organizationId
-      ? await provisioningJobService.getJobForOrg(jobId, organizationId)
-      : await provisioningJobService.getJob(jobId);
+    const job = await provisioningJobService.getJobForOrg(
+      jobId,
+      organizationId,
+    );
 
     if (!job) {
       return c.json({ success: false, error: "Job not found" }, 404);

--- a/packages/cloud/api/v1/topup/10/route.ts
+++ b/packages/cloud/api/v1/topup/10/route.ts
@@ -7,6 +7,11 @@
 
 import { Hono } from "hono";
 
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -17,6 +22,16 @@ const topup = createTopupHandler({
   getSourceId: (walletAddress, paymentId) =>
     `${walletAddress.toLowerCase()}:10:${paymentId}`,
 });
+
+// Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
+// even during a Redis blip (M11).
+app.use(
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    keyGenerator: getIpKey,
+    failClosed: true,
+  }),
+);
 
 app.post("/", (c) => topup(c.req.raw, c.env));
 

--- a/packages/cloud/api/v1/topup/100/route.ts
+++ b/packages/cloud/api/v1/topup/100/route.ts
@@ -7,6 +7,11 @@
 
 import { Hono } from "hono";
 
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -17,6 +22,16 @@ const topup = createTopupHandler({
   getSourceId: (walletAddress, paymentId) =>
     `${walletAddress.toLowerCase()}:100:${paymentId}`,
 });
+
+// Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
+// even during a Redis blip (M11).
+app.use(
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    keyGenerator: getIpKey,
+    failClosed: true,
+  }),
+);
 
 app.post("/", (c) => topup(c.req.raw, c.env));
 

--- a/packages/cloud/api/v1/topup/50/route.ts
+++ b/packages/cloud/api/v1/topup/50/route.ts
@@ -7,6 +7,11 @@
 
 import { Hono } from "hono";
 
+import {
+  getIpKey,
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { createTopupHandler } from "@/lib/services/topup-handler";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -17,6 +22,16 @@ const topup = createTopupHandler({
   getSourceId: (walletAddress, paymentId) =>
     `${walletAddress.toLowerCase()}:50:${paymentId}`,
 });
+
+// Money route: per-IP, fail-closed rate limit so a top-up flood is bounded
+// even during a Redis blip (M11).
+app.use(
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    keyGenerator: getIpKey,
+    failClosed: true,
+  }),
+);
 
 app.post("/", (c) => topup(c.req.raw, c.env));
 

--- a/packages/cloud/api/v1/topup/topup-rate-limit.test.ts
+++ b/packages/cloud/api/v1/topup/topup-rate-limit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Top-up money routes are rate-limited and fail CLOSED on a Redis outage
+ * (#12227 M11). Proves the `rateLimit({ failClosed: true })` middleware is
+ * actually mounted on `/v1/topup/10` by driving a request through the real
+ * route with a throwing Redis dependency: the request must be rejected (503)
+ * BEFORE the top-up handler runs.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const handler = mock(async () => Response.json({ credited: true }));
+
+mock.module("@/lib/services/topup-handler", () => ({
+  createTopupHandler: () => handler,
+}));
+
+const throwingRedis = {
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pttl: async () => 1,
+  pexpire: async () => 1,
+};
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => throwingRedis,
+  hasRedisConfig: () => true,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: topupRoute } = await import("./10/route");
+
+const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };
+
+function post() {
+  const app = new Hono();
+  app.route("/api/v1/topup/10", topupRoute);
+  return app.fetch(
+    new Request("https://api.example.test/api/v1/topup/10", {
+      method: "POST",
+      headers: { "cf-connecting-ip": "203.0.113.9" },
+    }),
+    ENV,
+  );
+}
+
+describe("v1/topup/10 — money route fails closed on Redis outage (M11)", () => {
+  beforeEach(() => handler.mockClear());
+
+  test("a Redis outage returns 503 and never reaches the top-up handler", async () => {
+    const res = await post();
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "rate_limit_unavailable",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
+++ b/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
@@ -1,0 +1,129 @@
+/**
+ * BlueBubbles webhook replay dedupe (#12227 L5). The local relay retries
+ * deliveries; without an event-id dedupe a re-delivered message is routed to
+ * the agent twice (duplicate reply + double credit spend). The route now
+ * dedupes on `data.guid` via the REAL `webhookEventsRepository.tryCreate`
+ * (in-process PGlite). This drives the real route handler twice and pins the
+ * second delivery as a no-op.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const routePhoneMessage = mock(async () => ({
+  handled: true,
+  reason: "delivered",
+  replyText: "hi back",
+  agentId: "agent-1",
+  organizationId: "org-1",
+  userId: "user-1",
+}));
+const registerPhoneGatewayDevice = mock(async () => ({
+  id: "dev-1",
+  registered: true,
+}));
+
+mock.module("@/lib/services/agent-gateway-router", () => ({
+  agentGatewayRouterService: { routePhoneMessage },
+}));
+mock.module("@/lib/services/phone-gateway-devices", () => ({
+  registerPhoneGatewayDevice,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const PGLITE_TIMEOUT = 60_000;
+let closeDb: (() => Promise<void>) | undefined;
+let bbRoute: typeof import("./route").default;
+
+const SECRET = "bb-secret";
+const ENV = { BLUEBUBBLES_GATEWAY_SECRET: SECRET };
+
+function delivery(guid: string) {
+  const app = new Hono();
+  app.route("/", bbRoute);
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-eliza-gateway-secret": SECRET,
+      },
+      body: JSON.stringify({
+        type: "new-message",
+        data: {
+          guid,
+          text: "hello there",
+          handle: { address: "+15551234567" },
+        },
+      }),
+    }),
+    ENV,
+  );
+}
+
+beforeAll(async () => {
+  const { dbWrite, closeDatabaseConnectionsForTests } = await import(
+    "@/db/client"
+  );
+  closeDb = closeDatabaseConnectionsForTests;
+  await dbWrite.execute(
+    `CREATE TABLE IF NOT EXISTS webhook_events (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      event_id text NOT NULL UNIQUE,
+      provider text NOT NULL,
+      event_type text,
+      payload_hash text NOT NULL,
+      source_ip text,
+      processed_at timestamp NOT NULL DEFAULT now(),
+      event_timestamp timestamp
+    );`,
+  );
+  ({ default: bbRoute } = await import("./route"));
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("BlueBubbles webhook — replay dedupe (L5)", () => {
+  beforeEach(async () => {
+    routePhoneMessage.mockClear();
+    registerPhoneGatewayDevice.mockClear();
+    const { dbWrite } = await import("@/db/client");
+    await dbWrite.execute("DELETE FROM webhook_events;");
+  });
+
+  test("first delivery routes; a replay of the same guid is a no-op", async () => {
+    const first = await delivery("guid-abc-1");
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({ success: true });
+    expect(routePhoneMessage).toHaveBeenCalledTimes(1);
+
+    const replay = await delivery("guid-abc-1");
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      success: true,
+      skipped: "duplicate_delivery",
+    });
+    // The agent must NOT be re-invoked on the replay.
+    expect(routePhoneMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("a distinct guid is routed normally", async () => {
+    await delivery("guid-abc-1");
+    const other = await delivery("guid-xyz-2");
+    expect(other.status).toBe(200);
+    expect(routePhoneMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
+++ b/packages/cloud/api/webhooks/bluebubbles/dedupe.test.ts
@@ -7,7 +7,15 @@
  * second delivery as a no-op.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { Hono } from "hono";
 
 process.env.DATABASE_URL ||= "pglite://memory";

--- a/packages/cloud/api/webhooks/bluebubbles/route.test.ts
+++ b/packages/cloud/api/webhooks/bluebubbles/route.test.ts
@@ -33,6 +33,14 @@ mock.module("@/lib/services/phone-gateway-devices", () => ({
   registerPhoneGatewayDevice,
 }));
 
+// The route dedupes on the message guid via webhookEventsRepository.tryCreate
+// (#12227 L5). Stub it as a first-time delivery so these routing tests exercise
+// the routing path (dedupe itself is covered in dedupe.test.ts).
+const tryCreate = mock(async () => ({ created: true, event: { id: "evt-1" } }));
+mock.module("@/db/repositories/webhook-events", () => ({
+  webhookEventsRepository: { tryCreate },
+}));
+
 const { default: app } = await import("./route");
 
 const env = {

--- a/packages/cloud/api/webhooks/bluebubbles/route.ts
+++ b/packages/cloud/api/webhooks/bluebubbles/route.ts
@@ -8,6 +8,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { webhookEventsRepository } from "@/db/repositories/webhook-events";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { agentGatewayRouterService } from "@/lib/services/agent-gateway-router";
 import { registerPhoneGatewayDevice } from "@/lib/services/phone-gateway-devices";
@@ -159,6 +160,26 @@ export async function handleBlueBubblesWebhookPayload(
   const hasAttachments = Boolean(data.attachments?.length);
   if (!body && !hasAttachments) {
     return c.json({ success: true, skipped: "empty_message" });
+  }
+
+  // Replay dedupe on the message guid (matches the crypto/stripe webhooks).
+  // The local relay retries deliveries, so without this a re-delivered message
+  // is routed to the agent twice (duplicate reply + double credit spend).
+  const messageGuid = data.guid?.trim() ?? null;
+  if (messageGuid) {
+    const dedupe = await webhookEventsRepository.tryCreate({
+      event_id: `bluebubbles:${messageGuid}`,
+      provider: "bluebubbles",
+      event_type: type,
+      payload_hash: messageGuid,
+    });
+    if (!dedupe.created) {
+      logger.warn("[BlueBubblesWebhook] Duplicate delivery ignored", {
+        messageGuid,
+        type,
+      });
+      return c.json({ success: true, skipped: "duplicate_delivery" });
+    }
   }
 
   const organizationId =

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-scope.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-scope.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Real-DB cross-org isolation for provisioning-job reads (#12227 M3).
+ *
+ * `GET /api/v1/jobs/:jobId` previously set `organizationId = null` for any valid
+ * WAIFU service key and called the UNSCOPED `getJob(jobId)` — a single shared
+ * service key could read ANY org's provisioning job (status/result/error). The
+ * fix scopes every read to the resolved owner org via `getJobForOrg` →
+ * `jobsRepository.findByIdAndOrg`. This test proves the underlying SQL denies a
+ * cross-org read against the REAL Drizzle query (in-process PGlite), with no row
+ * leak.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORG_A = "00000000-0000-4000-8000-0000000000a1";
+const ORG_B = "00000000-0000-4000-8000-0000000000b2";
+const JOB_A = "00000000-0000-4000-8000-00000000a001";
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../jobs").jobsRepository;
+let pgliteReady = true;
+
+async function seedJob(id: string, orgId: string): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO jobs (
+      id, type, status, data, attempts, max_attempts, organization_id,
+      result, error, scheduled_for, created_at, updated_at
+    ) VALUES (
+      '${id}', 'agent_provision', 'completed', '{}'::jsonb, 1, 3, '${orgId}',
+      '{"secret":"org-a-only"}'::jsonb, NULL, NOW(), NOW(), NOW()
+    );`,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ jobsRepository: repo } = await import("../jobs"));
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS jobs (
+        id uuid PRIMARY KEY,
+        type text NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        data jsonb NOT NULL,
+        data_storage text NOT NULL DEFAULT 'inline',
+        data_key text,
+        agent_id text,
+        character_id text,
+        result jsonb,
+        result_storage text NOT NULL DEFAULT 'inline',
+        result_key text,
+        error text,
+        error_storage text NOT NULL DEFAULT 'inline',
+        error_key text,
+        attempts integer NOT NULL DEFAULT 0,
+        max_attempts integer NOT NULL DEFAULT 3,
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        api_key_id uuid,
+        generation_id uuid,
+        webhook_url text,
+        webhook_status text,
+        estimated_completion_at timestamp,
+        scheduled_for timestamp NOT NULL DEFAULT now(),
+        started_at timestamp,
+        completed_at timestamp,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      );`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    throw new Error(
+      `[jobs-scope] PGlite unavailable — this test must run for real: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("jobsRepository — cross-org job read isolation (M3)", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await dbWrite.execute("DELETE FROM jobs;");
+    await seedJob(JOB_A, ORG_A);
+  });
+
+  test("owner org reads its own job", async () => {
+    const job = await repo.findByIdAndOrg(JOB_A, ORG_A);
+    expect(job?.id).toBe(JOB_A);
+    expect(job?.result).toMatchObject({ secret: "org-a-only" });
+  });
+
+  test("a different org gets NOTHING for the same job id (no row leak)", async () => {
+    const job = await repo.findByIdAndOrg(JOB_A, ORG_B);
+    expect(job).toBeUndefined();
+  });
+
+  test("the unscoped path (what the route used to call) would have leaked it", async () => {
+    // Documents exactly why the route must never call the unscoped read for a
+    // shared service key: findById ignores the org and returns the row.
+    const leaked = await repo.findById(JOB_A);
+    expect(leaked?.id).toBe(JOB_A);
+    // ...but the scoped read the route now uses denies the cross-org caller.
+    expect(await repo.findByIdAndOrg(JOB_A, ORG_B)).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Rate limiter fail-closed behavior on a runtime Redis error (#12227 M11).
+ *
+ * The limiter falls OPEN on a Redis error at request time — correct for
+ * ordinary routes (a store outage shouldn't 500 the app). But money/auth
+ * routes (steward-session mint, crypto top-up) must fail CLOSED: losing the
+ * limiter there is worse than a brief 503. `RateLimitConfig.failClosed` opts a
+ * route into rejecting (503) instead of serving unlimited when Redis throws.
+ *
+ * The Redis DEPENDENCY is mocked to simulate the outage (that outage is the
+ * condition under test); the real `rateLimit` middleware logic runs.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+// Simulate a Redis backend that is present (getRedis returns a client) but
+// throws on every op — i.e. a runtime outage, not a "not configured" state.
+const throwingRedis = {
+  incr: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pttl: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+  pexpire: async () => {
+    throw new Error("ECONNREFUSED: redis down");
+  },
+};
+
+mock.module("../cache/redis-factory", () => ({
+  buildRedisClient: () => throwingRedis,
+  hasRedisConfig: () => true,
+  isCloudflareWorkerRuntime: () => false,
+}));
+
+const { rateLimit, RateLimitPresets, getIpKey } = await import(
+  "./rate-limit-hono-cloudflare"
+);
+
+// A configured, non-disabled env so getRedis returns the (throwing) client.
+const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };
+
+function appWith(config: Parameters<typeof rateLimit>[0]) {
+  const app = new Hono();
+  app.use(rateLimit(config));
+  app.get("/", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function req() {
+  return new Request("https://api.example.test/", {
+    method: "GET",
+    headers: { "cf-connecting-ip": "203.0.113.7" },
+  });
+}
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("rateLimit — fail-closed vs fall-open on runtime Redis error (M11)", () => {
+  test("fail-closed route rejects with 503 when Redis throws", async () => {
+    const app = appWith({
+      ...RateLimitPresets.STRICT,
+      keyGenerator: getIpKey,
+      failClosed: true,
+    });
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      code: "rate_limit_unavailable",
+    });
+  });
+
+  test("a normal (fall-open) route still serves 200 when Redis throws", async () => {
+    const app = appWith({ ...RateLimitPresets.STANDARD });
+    const res = await app.fetch(req(), ENV);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true });
+    // and it advertises the degraded policy rather than pretending it enforced.
+    expect(res.headers.get("X-RateLimit-Policy")).toBe("redis-unavailable");
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-fail-closed.test.ts
@@ -34,9 +34,7 @@ mock.module("../cache/redis-factory", () => ({
   isCloudflareWorkerRuntime: () => false,
 }));
 
-const { rateLimit, RateLimitPresets, getIpKey } = await import(
-  "./rate-limit-hono-cloudflare"
-);
+const { rateLimit, RateLimitPresets, getIpKey } = await import("./rate-limit-hono-cloudflare");
 
 // A configured, non-disabled env so getRedis returns the (throwing) client.
 const ENV = { REDIS_URL: "redis://mock:6379", NODE_ENV: "production" };

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -13,6 +13,14 @@ export interface RateLimitConfig {
   windowMs: number;
   maxRequests: number;
   keyGenerator?: (c: AppContext) => string;
+  /**
+   * Fail CLOSED on a runtime Redis error. Default (undefined/false) falls open
+   * — a Redis outage should not turn ordinary routes into 503s. Set on
+   * money/auth routes (session mint, top-up) where losing the limiter is worse
+   * than a brief availability hit: if the backing store throws at request time
+   * the request is rejected (503) instead of sailing through unlimited.
+   */
+  failClosed?: boolean;
 }
 
 function getRedis(env: Bindings): CompatibleRedis | null {
@@ -216,11 +224,29 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
         effectiveConfig.maxRequests,
       );
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (config.failClosed) {
+        // Money/auth route: losing the limiter is worse than a brief 503, so
+        // reject rather than serve unlimited requests while Redis is down.
+        logger.error("[RateLimit] Redis unavailable on fail-closed route; rejecting", {
+          error: message,
+        });
+        return c.json(
+          {
+            success: false,
+            error: "Service temporarily unavailable",
+            code: "rate_limit_unavailable" as const,
+            message: "Rate limiter backing store is unavailable; request rejected.",
+          },
+          503,
+          { "Retry-After": "30" },
+        );
+      }
       // Rate limiting is protective middleware. If its backing store is down
       // or unreachable in local Worker dev, requests should fall open instead
       // of turning application routes into 500s.
       logger.warn("[RateLimit] Redis unavailable; falling open", {
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
       result = fallOpenResult(effectiveConfig);
       policy = "redis-unavailable";


### PR DESCRIPTION
## Security remediation — Cloud API (Cloudflare Workers BFF), sub-issue #12227

Remediates the Medium-and-down hardening items on the Cloud API surface. The BFF
auth+proxy model was sound and no Critical/High was found; these close timing
oracles, service-key scope gaps, a discarded-auth no-op, rate-limit gaps, and
webhook replay windows. Every claimed item ships a real test driving the actual
code path (fails before / passes after).

### Items shipped

| id | file:line | what changed | test |
|----|-----------|--------------|------|
| **M1** | `v1/agent-tokens/route.ts:41` | Service-secret compare on the Steward agent-JWT mint route now uses `timingSafeEqualSecret` (from `@/lib/auth/cron`) instead of `===`. Removes a timing oracle that could recover `ELIZA_CLOUD_SERVICE_TOKEN`/`AGENT_TOKEN_SERVICE_TOKEN`. | `v1/agent-tokens/route.test.ts` — exact/1-byte-off/length-mismatch/absent secret; grep asserts no `===`/`!==` secret compare |
| **M3** | `v1/jobs/[jobId]/route.ts:24-41` | Service-key job reads are now scoped to the org the service identity resolves to (`getJobForOrg(jobId, serviceIdentity.organizationId)`); the unscoped `getJob` path is gone. A shared WAIFU key can no longer read any org's provisioning job. | `v1/jobs/[jobId]/route.test.ts` (route calls `getJobForOrg` w/ service org, cross-org id → 404) **+ real-PGlite** `db/repositories/__tests__/jobs-scope.test.ts` (cross-org `findByIdAndOrg` returns nothing, no row leak) |
| **L1** | `billing/checkout/verify/route.ts:216` | Agent-billing branch now calls `requireServiceKey(c)` (throws 401) instead of `await validateServiceKey(c)` and discarding the null-on-bad-key result. Endpoint is no longer triggerable unauthenticated. | `billing/checkout/verify/route.l1.test.ts` — **real** `requireServiceKey` (not mocked); bogus/missing key → 401, no credit/invoice/webhook side effect |
| **M11** | `middleware/rate-limit-hono-cloudflare.ts:198-227`; `auth/steward-session/route.ts`; `v1/topup/{10,50,100}/route.ts` | New `failClosed` option on `RateLimitConfig`: on a **runtime** Redis error, fail-closed routes return 503 instead of falling open. Added strict per-IP `rateLimit({ failClosed: true })` to the steward-session mint and the three top-up money routes (previously no per-IP limit at all). | `middleware/rate-limit-fail-closed.test.ts` (throwing Redis → 503 fail-closed / 200 fall-open) **+** `v1/topup/topup-rate-limit.test.ts` (money route 503s before the handler runs) |
| **L5** | `webhooks/bluebubbles/route.ts`; `v1/earnings/payout/stripe-connect/webhook/route.ts` | Replay dedupe via `webhookEventsRepository.tryCreate` — BlueBubbles on `data.guid`, Stripe-Connect on `event.id` — matching the crypto/stripe webhooks. A re-delivered payload is now a no-op. | **real-PGlite** `webhooks/bluebubbles/dedupe.test.ts` (replay → routing not re-invoked) **+** `.../stripe-connect/webhook/dedupe.test.ts` (replay → account write runs exactly once) |

Fixed the two existing tests my behavior change touched
(`__tests__/stripe-connect-webhook-route.test.ts`, `webhooks/bluebubbles/route.test.ts`)
to stub the new `tryCreate` dedupe call as a first-time delivery.

### Design notes for the merger

- **M11 fail-closed is scoped to the *runtime* Redis-error path only** (the
  `catch` at `rate-limit-hono-cloudflare.ts:218-227`), never the "Redis not
  configured / deliberately disabled" path (`getRedis` → null). So local dev and
  test envs that don't run Redis are unaffected; only a genuine at-request-time
  outage on a `failClosed` route 503s. This matches the spec's "fail closed on a
  runtime Redis error" and the boot-time fail-closed verdict already handles the
  prod-misconfig case.
- **M3**: the service identity resolves to `WAIFU_SERVICE_ORG_ID`; reads are now
  scoped to it. If a real deployment relied on cross-org service-key reads that
  behavior is intentionally removed (it was the vulnerability).
- **L5 Stripe-Connect** event ids are prefixed `stripe-connect:` in the
  `webhook_events` table so they can't false-collide with the main `stripe`
  provider's ids. The mutation is synchronous (no queue), so the dedupe marker
  needs no enqueue-rollback.

### Items deferred (implemented elsewhere / not in this PR's focus)

- **M2, L2, L3, L4, L12** — not attempted here (out of this PR's prioritized
  scope). No code touched.

### Not done / caveats

- No item required live containers; nothing is deferred for infra reasons.
- The Stripe-Connect and BlueBubbles dedupe tests are **real-PGlite** and need
  `@elizaos/core` + `@elizaos/cloud-routing` built (they are, in CI's cloud lane).

### Verification

```
# cloud/api (each file isolated, one bun process each — the package's real runner)
node packages/cloud/api/test/run-unit-isolated.mjs agent-tokens      # 5 pass
node packages/cloud/api/test/run-unit-isolated.mjs jobs              # 3 pass
node packages/cloud/api/test/run-unit-isolated.mjs checkout/verify   # 2 + 2 pass
node packages/cloud/api/test/run-unit-isolated.mjs topup             # 1 pass
node packages/cloud/api/test/run-unit-isolated.mjs bluebubbles       # 2 + 10 pass
node packages/cloud/api/test/run-unit-isolated.mjs stripe-connect    # 7 + 13 + 1 pass

# cloud/shared (bun test --isolate)
bun test --isolate packages/cloud/shared/src/lib/middleware/                       # 24 pass
bun test --isolate packages/cloud/shared/src/db/repositories/__tests__/jobs-scope.test.ts \
                   packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts  # 4 pass
```

All touched source + test files typecheck clean
(`bun run --cwd packages/cloud/api typecheck`, `--cwd packages/cloud/shared typecheck`
— remaining errors are pre-existing cross-package noise from unbuilt
`@elizaos/auth`/`@elizaos/shared`, not these files) and pass Biome.

Refs #12227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
