### PR TITLE
feat(desktop): pill click-through + tray popover anchor/blur/launcher + dockless macOS default (#12184 Phase 1)

### DIFF
--- a/.github/issue-evidence/12184-desktop-pill-tray/README.md
+++ b/.github/issue-evidence/12184-desktop-pill-tray/README.md
@@ -1,0 +1,76 @@
+# #12184 Phase 1 — Desktop pill + tray launcher: evidence
+
+Branch `feat/12184-desktop-pill-tray-phase1`. App-layer only (electrobun@1.18.1
+npm APIs, zero fork changes), per the settled dossier plan (D1–D10).
+
+## What shipped (per work item)
+
+| Item | Change | Proof |
+| --- | --- | --- |
+| W1 | Pill window: `passthrough: true` (OS click-through on the transparent strip, direct + isolated-CEF paths), darwin `setVisibleOnAllWorkspaces(true)`, re-anchor on `showWindow()` + 5s poll via pure `shouldReanchorBottomBar()`; stale "No hide()" comment fixed | `desktop-bottom-bar-config.test.ts` (re-anchor cases), full EB lane green |
+| W2 | Global hotkey toggles the overlay (focused+visible → hide, else show+focus) via pure `decideChatOverlayToggle()`; Escape collapses the overlay first, hides the window when already collapsed | `packages/app/src/desktop-hotkey.test.ts` (3 cases) |
+| W3 | Tray popover anchored at real `Tray.getBounds()` via pure `computeTrayPopoverFrame()` (bottom-left→top-left y-flip, x-centering, work-area clamp, zero-rect top-right fallback); window reused across toggles; blur-dismiss with 200 ms tray-click re-entry guard | `tray-popover-position.test.ts` (6 cases incl. clamping + y-flip), `desktop-window.test.ts` popover suite |
+| W4 | `TrayLauncher` rows (icon + label per `DESKTOP_VIEW_WINDOWS` entry + "Open Eliza") above the WidgetHost stack in `TrayPopoverShell`; rows dispatch existing `tray-open-view-*` / `tray-show-window` ids through the shared `TRAY_ACTION_EVENT` handling — no new RPC, no catalog duplication (host registers localized rows into a ui store; ui cannot import app-core) | `TrayLauncher.test.tsx` (5 cases) + story |
+| W5 | Dockless macOS default: `shouldStartTrayFirst` ON for darwin (kill switch `ELIZA_DESKTOP_TRAY_FIRST=0`); pill still created at boot; Dock icon visible iff the set of full/managed windows (dashboard/surface/settings/app — `SurfaceWindowManager.onRegistryChanged` + main-window full/pill flag) is non-empty | updated `desktop-experience-contract.test.ts` + `desktop-tray-config.test.ts`; new `DesktopManager` dockless Dock-tracking suite; `desktop-window-lifecycle.md` updated in the same PR |
+
+## Verification (commands run, real output)
+
+- `bunx vitest run --config vitest.electrobun.config.ts` (packages/app-core/platforms/electrobun):
+  **61 files / 447 tests passed** — includes the new `tray-popover-position`,
+  re-anchor, and dockless Dock-tracking tests and the UPDATED
+  `desktop-experience-contract.test.ts`.
+- `bun run --cwd packages/ui test -- TrayLauncher`: **5/5 passed**.
+- `bunx vitest run --config packages/app/vitest.config.ts src/desktop-hotkey.test.ts`: **3/3 passed**.
+- `bun run --cwd packages/app-core typecheck`: clean.
+- `bun run --cwd packages/app-core/platforms/electrobun typecheck`: clean.
+- `bun run --cwd packages/ui typecheck`: only pre-existing failure
+  (`src/spatial/__e2e__/immersive-fixture.ts` → missing optional `iwer` module;
+  untouched by this PR).
+- `biome lint` over every touched file: clean.
+- `bun run --cwd packages/ui test -- App`: all App suites pass except the
+  pre-existing `App.screen-background-fuzz.test.tsx` worker-pool crash
+  (crashes identically on unmodified checkout; 0 assertions run — worktree
+  resource flake, not a regression).
+
+## Live capture — attempted, blocked by worktree topology (not faked)
+
+Two real launch attempts on this Mac (Apple Silicon, macOS):
+
+1. `ELIZA_DESKTOP_SCREENSHOT_SERVER=1 bun run dev:desktop` — renderer
+   `vite build` fails: `Could not load packages/ui/node_modules/lucide-react`.
+   This agent worktree (`.claude/worktrees/…`) shares the parent checkout's
+   `node_modules`; per-package `node_modules` dirs are empty here, so
+   package-relative resolution fails. Worked around with a symlink to the
+   parent's `lucide-react`.
+2. Re-run after the symlink — build progresses (12,406 modules transformed)
+   then fails inside the **parent tree's** stale `@elizaos/core` browser dist:
+   `"Buffer" is not exported by "__vite-browser-external", imported by
+   /Users/…/eliza/packages/core/dist/browser/index.browser.js` (parent path;
+   the parent checkout is on a different branch with concurrent agents).
+   Rebuilding the parent's dist would mutate shared artifacts under another
+   branch mid-flight, so it was not done. `dev:desktop:watch` and the packaged
+   `desktop-build.mjs build` path run the same renderer build first and hit the
+   same wall.
+
+Consequence: `GET /api/dev/cursor-screenshot` captures of the pill, popover
+launcher rows, hidden Dock icon, hotkey toggle, Escape, and blur-dismiss could
+not be produced from this worktree. They require a normal checkout with its own
+`bun install` + built `@elizaos/core` dist — flagged for pre-merge capture (the
+Phase 3 / W10 item in the dossier also re-captures per-OS evidence after the
+Phase 2 fork bump).
+
+## Evidence rows (PR_EVIDENCE.md)
+
+| Row | Status |
+| --- | --- |
+| Real-LLM trajectories | N/A — no agent/action/provider/prompt/model behavior change; window-management + shell UI only |
+| Backend structured logs | Partial — boot logs from the live-launch attempts captured (`[Main] …` lines print before the renderer build gate); full-path logs blocked as above |
+| Frontend console/network logs | N/A — blocked by the renderer-build blocker above |
+| Before/after screenshots (desktop) | N/A — blocked by the renderer-build blocker above; unit + contract tests pin every behavioral default |
+| Before/after screenshots (mobile) | N/A — desktop-only change; no mobile surface touched |
+| Video walkthrough | N/A — blocked by the renderer-build blocker above |
+| Per-platform capture: macOS | N/A — same blocker; macOS is the only Phase-1 target |
+| Per-platform capture: Windows | N/A — requires Phase 2 fork work (G3/G4) + non-mac hardware, per dossier D8 |
+| Per-platform capture: Linux | N/A — requires Phase 2 fork work + non-mac hardware, per dossier D8 (Linux tray is menu-only by platform constraint) |
+| Audio/narrated walkthrough | N/A — no voice/TTS/STT change |
+| Domain artifacts | Unit/contract test output above; no DB/memory/chain artifacts in scope |

--- a/packages/app-core/platforms/electrobun/docs/desktop-window-lifecycle.md
+++ b/packages/app-core/platforms/electrobun/docs/desktop-window-lifecycle.md
@@ -10,12 +10,18 @@ Issue #10720.
 
 On launch the desktop app opens **chat first** — a chromeless, transparent,
 always-on-top bottom bar rendering only the floating chat overlay, **not** the
-full dashboard window. Onboarding runs **conversationally inside that chat**
-(pick where the agent runs → optional Cloud login → provider → tutorial), never
-a separate setup window. The full app is always one gesture away (tray, menu
-bar "Views", deep link, or dock click), each of which opens the requested
-surface in its own window. This matches assistants like Claude Desktop: a
-resting chat surface, the rest of the app summoned on demand.
+full dashboard window. On macOS the app is **dockless by default** (#12184): the
+pill + menu-bar icon are the resting surface and there is **no Dock icon** until
+a full window opens. The pill passes clicks through its transparent regions
+(`passthrough`), joins every Space (`setVisibleOnAllWorkspaces`), and re-anchors
+to the primary display's work area when displays change. Onboarding runs
+**conversationally inside that chat** (pick where the agent runs → optional
+Cloud login → provider → tutorial), never a separate setup window. The full app
+is always one gesture away (tray popover launcher, tray/menu-bar "Views", deep
+link, or dock click), each of which opens the requested surface in its own
+window — and opening one reveals the Dock icon. This matches assistants like
+Claude Desktop / Wispr Flow: a resting chat surface, the rest of the app
+summoned on demand.
 
 ## Launch: chat-first is the default
 
@@ -31,6 +37,10 @@ The renderer's `ChatOverlayShell` (`packages/ui/src/App.tsx`) renders just the
 `HomePill` + `ContinuousChatOverlay` over a transparent background when
 `shellMode === "chat-overlay"`. No full-app tab system is mounted in this mode;
 "show a view" intents open a dedicated window instead (see **Summoning views**).
+Escape collapses the overlay first, then (when already collapsed) hides the
+window; the global summon hotkey **toggles** the pill (focused+visible →
+hide, else show+focus) via the pure `decideChatOverlayToggle()`
+(`packages/app/src/desktop-hotkey.ts`).
 
 ## Onboarding: in-chat, not a separate window
 
@@ -71,8 +81,9 @@ dedicated window:
 | Concern | Where | Behavior |
 | --- | --- | --- |
 | Tray created | `shouldCreateDesktopTray()` | ON by default; opt out `ELIZA_DESKTOP_DISABLE_TRAY=1` |
-| Tray-first (no boot window, window created lazily) | `shouldStartTrayFirst()` | macOS opt-in `ELIZA_DESKTOP_TRAY_FIRST=1` |
-| Tray popover (widget surface anchored at the tray) | `shouldEnableTrayPopover()` | macOS opt-in `ELIZA_DESKTOP_TRAY_POPOVER=1` |
+| Dockless (tray-first): pill at boot, Dock icon hidden at rest | `shouldStartTrayFirst()` | macOS **default ON** (#12184); kill switch `ELIZA_DESKTOP_TRAY_FIRST=0`. The pill window is still created at boot — it just isn't a "full window" for the Dock. |
+| Dock icon tracking | `DesktopManager.syncTrayFirstDock()` | Dock visible iff ≥1 full/managed window (dashboard/surface/settings/app) — driven by `setMainWindowFullWindow()` + `setManagedWindowsPresent()` (wired to `SurfaceWindowManager.onRegistryChanged`). The pill never counts. |
+| Tray popover (launcher + widget surface anchored at the tray icon) | `shouldEnableTrayPopover()` | macOS opt-in `ELIZA_DESKTOP_TRAY_POPOVER=1`; anchors under the real `Tray.getBounds()`, reuses one window across toggles, dismisses on blur (200ms tray-click guard). Hosts the `TrayLauncher` rows above the widget stack. |
 | Restore / create-if-missing / focus | `restoreWindow()` (`index.ts`) | unminimize + focus, or create the main window and attach RPC |
 | Show a surface + focus | `showMainSurface()` | `restoreWindow()` then `showWindow()` + tray-menu event to renderer |
 | Tray-icon click | `DesktopManager.trayClickHandler` | toggles the popover if configured, else `show + focus` (summon parity with the hotkey) |
@@ -82,14 +93,16 @@ dedicated window:
 ## Environment knobs
 
 `ELIZA_DESKTOP_BOTTOM_BAR` · `ELIZA_DESKTOP_DISABLE_TRAY` / `ELIZA_DESKTOP_TRAY`
-· `ELIZA_DESKTOP_TRAY_FIRST` · `ELIZA_DESKTOP_TRAY_POPOVER` · kiosk shell mode.
-All default to the chat-first, tray-enabled experience above.
+· `ELIZA_DESKTOP_TRAY_FIRST` (macOS dockless; **default ON**, set `=0` to keep
+the Dock icon at rest) · `ELIZA_DESKTOP_TRAY_POPOVER` · kiosk shell mode. All
+default to the chat-first, dockless-on-macOS, tray-enabled experience above.
 
 ## Contract tests
 
 `desktop-experience-contract.test.ts` pins the defaults this doc promises
 (chat-first bottom bar ON, `?shellMode=chat-overlay` appended, tray ON,
-tray-first/popover opt-in, kiosk overrides). `desktop-deep-link-events.test.ts`
+dockless/tray-first ON for macOS with a `=0` kill switch, popover opt-in, kiosk
+overrides). `desktop-deep-link-events.test.ts`
 covers the deep-link router. Full-shell e2e that drives the real Electrobun
 window via the `/api/dev/*` loopback (`dev/stack`, `dev/cursor-screenshot`,
 `dev/console-log`) requires a built desktop app and is captured by a human per

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -4,6 +4,7 @@ import {
   computeBottomBarFrame,
   DEFAULT_BOTTOM_BAR_HEIGHT,
   resolveDesktopShellWindowPresentation,
+  shouldReanchorBottomBar,
   shouldStartBottomBar,
 } from "./desktop-bottom-bar-config";
 
@@ -154,6 +155,24 @@ describe("desktop bottom-bar config", () => {
         titleBarStyle: "hidden",
         transparent: false,
       });
+    });
+  });
+
+  describe("shouldReanchorBottomBar", () => {
+    const base = { x: 0, y: 24, width: 1920, height: 1056 };
+
+    it("does not re-anchor when the work area is unchanged", () => {
+      expect(shouldReanchorBottomBar(base, { ...base })).toBe(false);
+    });
+
+    it("re-anchors on a width/height change (dock or resolution change)", () => {
+      expect(shouldReanchorBottomBar(base, { ...base, width: 1440 })).toBe(true);
+      expect(shouldReanchorBottomBar(base, { ...base, height: 900 })).toBe(true);
+    });
+
+    it("re-anchors on an origin change (display plug/unplug, monitor swap)", () => {
+      expect(shouldReanchorBottomBar(base, { ...base, x: 1920 })).toBe(true);
+      expect(shouldReanchorBottomBar(base, { ...base, y: 0 })).toBe(true);
     });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -121,3 +121,23 @@ export function computeBottomBarFrame(
     Math.round(workArea.y) + Math.round(workArea.height) - height - margin;
   return { x, y, width, height };
 }
+
+/**
+ * Whether the bottom bar must be re-anchored because the primary display's
+ * usable work area moved or resized (a display was plugged/unplugged, the dock
+ * or menu bar changed size, or the resolution changed). The bar frame is
+ * derived entirely from the work area, so any change to it strands the bar off
+ * the new bottom edge until we recompute + `setFrame`. Pure so the poll +
+ * `showWindow()` re-anchor decision is unit-testable.
+ */
+export function shouldReanchorBottomBar(
+  prevWorkArea: ScreenWorkArea,
+  nextWorkArea: ScreenWorkArea,
+): boolean {
+  return (
+    prevWorkArea.x !== nextWorkArea.x ||
+    prevWorkArea.y !== nextWorkArea.y ||
+    prevWorkArea.width !== nextWorkArea.width ||
+    prevWorkArea.height !== nextWorkArea.height
+  );
+}

--- a/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
@@ -74,11 +74,13 @@ describe("desktop experience contract — tray", () => {
     expect(shouldCreateDesktopTray({ ELIZA_DESKTOP_TRAY: "0" })).toBe(false);
   });
 
-  it("keeps tray-first and the popover opt-in (macOS)", () => {
-    expect(shouldStartTrayFirst({}, "darwin", [])).toBe(false);
+  it("defaults dockless (tray-first) ON for macOS with a =0 kill switch; popover stays opt-in", () => {
+    // #12184: dockless is now the resting macOS experience — pill + menu-bar
+    // icon, no Dock icon until a full window opens.
+    expect(shouldStartTrayFirst({}, "darwin", [])).toBe(true);
     expect(
-      shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "1" }, "darwin", []),
-    ).toBe(true);
+      shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "0" }, "darwin", []),
+    ).toBe(false);
     expect(shouldEnableTrayPopover({}, "darwin", [])).toBe(false);
     expect(
       shouldEnableTrayPopover(
@@ -89,7 +91,8 @@ describe("desktop experience contract — tray", () => {
     ).toBe(true);
   });
 
-  it("gates tray-first and popover off non-macOS platforms", () => {
+  it("gates dockless and popover off non-macOS platforms", () => {
+    expect(shouldStartTrayFirst({}, "win32", [])).toBe(false);
     expect(
       shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "1" }, "win32", []),
     ).toBe(false);

--- a/packages/app-core/platforms/electrobun/src/desktop-tray-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-tray-config.test.ts
@@ -44,45 +44,38 @@ describe("desktop tray config", () => {
 });
 
 describe("shouldStartTrayFirst", () => {
-  it("is opt-in: off by default even on macOS", () => {
-    expect(shouldStartTrayFirst({}, "darwin", [])).toBe(false);
-  });
-
-  it("is enabled on macOS when ELIZA_DESKTOP_TRAY_FIRST is truthy", () => {
+  it("defaults ON (dockless) for macOS (#12184)", () => {
+    expect(shouldStartTrayFirst({}, "darwin", [])).toBe(true);
     expect(
       shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "1" }, "darwin", []),
     ).toBe(true);
-    expect(
-      shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "true" }, "darwin", []),
-    ).toBe(true);
   });
 
-  it("stays off on non-macOS platforms even when requested", () => {
+  it("honors the ELIZA_DESKTOP_TRAY_FIRST=0 kill switch on macOS", () => {
+    for (const off of ["0", "false", "no"]) {
+      expect(
+        shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: off }, "darwin", []),
+      ).toBe(false);
+    }
+  });
+
+  it("stays off on non-macOS platforms even by default", () => {
+    expect(shouldStartTrayFirst({}, "win32", [])).toBe(false);
+    expect(shouldStartTrayFirst({}, "linux", [])).toBe(false);
     expect(
       shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "1" }, "win32", []),
-    ).toBe(false);
-    expect(
-      shouldStartTrayFirst({ ELIZA_DESKTOP_TRAY_FIRST: "1" }, "linux", []),
     ).toBe(false);
   });
 
   it("stays off when the tray itself is disabled", () => {
     expect(
-      shouldStartTrayFirst(
-        { ELIZA_DESKTOP_TRAY_FIRST: "1", ELIZA_DESKTOP_DISABLE_TRAY: "1" },
-        "darwin",
-        [],
-      ),
+      shouldStartTrayFirst({ ELIZA_DESKTOP_DISABLE_TRAY: "1" }, "darwin", []),
     ).toBe(false);
   });
 
   it("stays off in kiosk shell mode", () => {
     expect(
-      shouldStartTrayFirst(
-        { ELIZA_DESKTOP_TRAY_FIRST: "1", ELIZAOS_SHELL_MODE: "kiosk" },
-        "darwin",
-        [],
-      ),
+      shouldStartTrayFirst({ ELIZAOS_SHELL_MODE: "kiosk" }, "darwin", []),
     ).toBe(false);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/desktop-tray-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-tray-config.ts
@@ -25,14 +25,17 @@ export function shouldCreateDesktopTray(
 }
 
 /**
- * Whether the app should launch tray-first: no main window at startup, the
- * tray icon as the only surface, and the window created lazily on demand.
+ * Whether the app should launch dockless (tray-first): the pill + menu-bar
+ * icon are the resting surface and the macOS Dock icon stays hidden until a
+ * full window (dashboard / surface / settings / app) opens. The pill window is
+ * still created at boot — it just doesn't count for the Dock (#12184).
  *
- * Opt-in (default OFF). Tray-first is macOS-only — on Windows (CEF) the UI
- * message loop must be running before setApplicationMenu(), and Linux tray
- * support varies, so both keep a boot window. It also requires the tray to be
- * enabled and excludes kiosk shell mode (kiosk wants a fullscreen window).
- * Enable with ELIZA_DESKTOP_TRAY_FIRST=1.
+ * Default ON for macOS (#12184), the platform where the Dock/accessory model
+ * and menu-bar tray make this the native, unobtrusive experience. Kept
+ * macOS-only — on Windows (CEF) the UI message loop must be running before
+ * setApplicationMenu(), and Linux tray support varies. Requires the tray to be
+ * enabled and excludes kiosk shell mode (kiosk wants a fullscreen window). Kill
+ * switch: ELIZA_DESKTOP_TRAY_FIRST=0 restores the Dock icon at rest.
  */
 export function shouldStartTrayFirst(
   env: NodeJS.ProcessEnv = process.env,
@@ -42,7 +45,7 @@ export function shouldStartTrayFirst(
   if (platform !== "darwin") {
     return false;
   }
-  if (!parseTruthy(env.ELIZA_DESKTOP_TRAY_FIRST)) {
+  if (parseFalsy(env.ELIZA_DESKTOP_TRAY_FIRST)) {
     return false;
   }
   if (!shouldCreateDesktopTray(env)) {

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1062,6 +1062,10 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
   // empty region above the bar; on darwin it pairs with vibrancy. Win/Linux
   // transparency support varies, so the bar stays opaque there for now.
   const transparent = presentation.transparent;
+  // The pill spans the full work-area width but only the small bar is visible;
+  // OS-level click-through (passthrough) lets clicks on the transparent region
+  // land on the app underneath instead of being eaten by the invisible window.
+  const passthrough = bottomBar;
   const forceMainWindowCef = shouldForceMainWindowCef(
     process.env,
     process.platform,
@@ -1094,6 +1098,7 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
       renderer: resolveBootstrapShellRenderer(buildInfo),
       titleBarStyle,
       transparent,
+      passthrough,
     });
     win.webview.remove();
     const mainView = new BrowserView({
@@ -1111,6 +1116,9 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
       },
       windowId: win.id,
       rpc,
+      // Mirror the window's click-through onto the hosted view so the isolated
+      // (CEF) main-view path passes clicks through its transparent region too.
+      startPassthrough: passthrough,
     });
     win.webviewId = mainView.id;
     if (forceMainWindowCef) {
@@ -1127,6 +1135,7 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
       frame: windowFrame,
       titleBarStyle,
       transparent,
+      passthrough,
       rpc,
       ...(mainWindowPartition ? { partition: mainWindowPartition } : {}),
     });
@@ -1159,7 +1168,26 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
         `[main-window] bottom-bar setAlwaysOnTop() failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    // Join the pill to every Space/desktop (macOS) so it follows the user
+    // across Space switches instead of stranding on the Space it was created
+    // on. No-op on Windows/Linux (the pill is per-desktop there — fork gap G4).
+    if (process.platform === "darwin") {
+      try {
+        (
+          win as typeof win & {
+            setVisibleOnAllWorkspaces?: (flag: boolean) => void;
+          }
+        ).setVisibleOnAllWorkspaces?.(true);
+      } catch (err) {
+        logger.warn(
+          `[main-window] bottom-bar setVisibleOnAllWorkspaces() failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     applyMacOSWindowEffects(win);
+    // Keep the bar pinned to the primary display's bottom edge across display
+    // plug/unplug + resolution changes (recompute on showWindow() + 5s poll).
+    getDesktopManager().enableBottomBarReanchor();
     return win;
   }
 

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1230,10 +1230,11 @@ function attachMainWindow(
     transparent: presentation.transparent,
   });
   trackFocusedWindow(win);
-  // Reveal the Dock icon in tray-first mode whenever a main window is attached,
+  // Dockless mode: only a FULL main window (dashboard/kiosk) reveals the Dock
+  // icon — the chromeless bottom-bar pill never does. Declare which this is,
   // regardless of how it was opened (boot, tray "Show Window", Dock reopen, or
   // a direct restoreWindow() from a deep link that bypasses showWindow()).
-  getDesktopManager().markMainWindowShown();
+  getDesktopManager().setMainWindowFullWindow(presentation.mode !== "bottom-bar");
 
   win.webview.on("dom-ready", () => {
     injectApiBase(win);
@@ -2559,33 +2560,29 @@ async function main(): Promise<void> {
   // Create window first — on Windows (CEF) the UI message loop must be
   // running before any synchronous FFI calls like setApplicationMenu().
   // Calling setupApplicationMenu() before createMainWindow() deadlocks.
-  const trayFirst = shouldStartTrayFirst();
-  let mainWin: BrowserWindow | null = null;
-  if (trayFirst) {
-    // Tray-first (macOS, opt-in): no window at launch. The tray icon is the
-    // only surface; the main window is created lazily via restoreWindow() /
-    // DesktopManager.showWindow() on tray "Show Window", Dock reopen, or a
-    // deep link. setTrayFirstMode hides the Dock icon until a window is shown.
-    logger.info("[Main] Tray-first startup — deferring main window creation");
+  // Dockless (tray-first) mode is the macOS default (#12184): the resting
+  // experience is the pill + menu-bar icon with NO Dock icon. Unlike the old
+  // tray-first behavior we STILL create the pill window at boot — the pill is
+  // not a "full window" for Dock purposes, so setTrayFirstMode keeps the Dock
+  // icon hidden until a full window (dashboard/surface/settings/app) opens.
+  const dockless = shouldStartTrayFirst();
+  if (dockless) {
+    logger.info("[Main] Dockless startup — pill only, Dock icon hidden at rest");
     getDesktopManager().setTrayFirstMode(true);
-    recordStartupPhase("window_ready", {
-      pid: process.pid,
-    });
-  } else {
-    recordStartupPhase("creating_window", {
-      pid: process.pid,
-    });
-    const { rpc: mainRpc, sendToWebview: mainSendToWebview } =
-      createDesktopRpc("main");
-    mainWin = attachMainWindow(
-      await createMainWindow(mainRpc),
-      mainRpc,
-      mainSendToWebview,
-    );
-    recordStartupPhase("window_ready", {
-      pid: process.pid,
-    });
   }
+  recordStartupPhase("creating_window", {
+    pid: process.pid,
+  });
+  const { rpc: mainRpc, sendToWebview: mainSendToWebview } =
+    createDesktopRpc("main");
+  const mainWin: BrowserWindow | null = attachMainWindow(
+    await createMainWindow(mainRpc),
+    mainRpc,
+    mainSendToWebview,
+  );
+  recordStartupPhase("window_ready", {
+    pid: process.pid,
+  });
   seedFirstPartyRemotePluginsForStartup();
 
   // Per-window RPC tracking: surface windows each get their own typed
@@ -2623,6 +2620,11 @@ async function main(): Promise<void> {
     onRegistryChanged: () => {
       sendManagedWindowsChanged();
       setupApplicationMenu();
+      // Dockless mode: any open managed window (dashboard/surface/settings/app)
+      // reveals the Dock icon; closing the last one hides it again.
+      getDesktopManager().setManagedWindowsPresent(
+        (surfaceWindowManager?.listWindows().length ?? 0) > 0,
+      );
     },
     boundsStore: createAppWindowBoundsStore(),
   });

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -146,6 +146,8 @@ const electrobunMock = vi.hoisted(() => {
     quit: vi.fn(),
     showNotification: vi.fn(),
     showItemInFolder: vi.fn(),
+    setDockIconVisible: vi.fn(),
+    isDockIconVisible: vi.fn(() => true),
   };
   const GlobalShortcut = {
     isRegistered: vi.fn(() => false),
@@ -606,5 +608,65 @@ describe("DesktopManager main window controls", () => {
       expect.any(Function),
     );
     expect(tray.remove).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DesktopManager dockless (tray-first) Dock tracking (#12184)", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    resetDesktopManagerForTesting();
+    electrobunMock.reset();
+    // Dock control is macOS-only (setDockIconVisibility guards on darwin).
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  const dockCalls = (): boolean[] =>
+    electrobunMock.Utils.setDockIconVisible.mock.calls.map(
+      (call: unknown[]) => call[0] as boolean,
+    );
+
+  it("hides the Dock icon at rest — only the pill exists", () => {
+    const manager = new DesktopManager();
+    manager.setTrayFirstMode(true);
+    // Pill main window is attached: NOT a full window → Dock stays hidden.
+    manager.setMainWindowFullWindow(false);
+    expect(dockCalls().at(-1)).toBe(false);
+  });
+
+  it("reveals the Dock icon when a managed window opens, hides it when the last closes", () => {
+    const manager = new DesktopManager();
+    manager.setTrayFirstMode(true);
+    manager.setMainWindowFullWindow(false);
+
+    manager.setManagedWindowsPresent(true);
+    expect(dockCalls().at(-1)).toBe(true);
+
+    manager.setManagedWindowsPresent(false);
+    expect(dockCalls().at(-1)).toBe(false);
+  });
+
+  it("reveals the Dock icon when the main window itself is a full dashboard", () => {
+    const manager = new DesktopManager();
+    manager.setTrayFirstMode(true);
+    manager.setMainWindowFullWindow(true);
+    expect(dockCalls().at(-1)).toBe(true);
+  });
+
+  it("does not touch the Dock icon when dockless mode is off", () => {
+    const manager = new DesktopManager();
+    manager.setMainWindowFullWindow(true);
+    manager.setManagedWindowsPresent(true);
+    expect(electrobunMock.Utils.setDockIconVisible).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -17,7 +17,7 @@
  * - No powerMonitor — power state via `pmset` (macOS), sysfs (Linux), or WinForms power line (Windows)
  * - No nativeImage — tray icons use file paths directly
  * - No setOpacity on BrowserWindow — no-op
- * - No hide() on BrowserWindow — uses minimize() as fallback
+ * - hideWindow uses macOS orderOut (removes from Cmd+Tab); non-mac falls back to minimize()
  * - No app.setLoginItemSettings — stubbed
  */
 
@@ -44,6 +44,11 @@ import Electrobun, {
 } from "electrobun/bun";
 import { getBrandConfig } from "../brand-config";
 import type { DatabaseSnapshot } from "../database";
+import {
+  computeBottomBarFrame,
+  type ScreenWorkArea,
+  shouldReanchorBottomBar,
+} from "../desktop-bottom-bar-config";
 import {
   createElectrobunBrowserWindow,
   type ElectrobunBrowserWindowOptions,
@@ -73,6 +78,7 @@ import type {
   WindowBounds,
   WindowOptions,
 } from "../rpc-schema";
+import { computeTrayPopoverFrame, type Rect } from "../tray-popover-position";
 import type { SendToWebview } from "../types.js";
 import { resolveDesktopUpdateAvailability } from "../update-availability";
 import {
@@ -309,10 +315,17 @@ export class DesktopManager {
   private tray: Tray | null = null;
   private releaseNotesWindow: BrowserWindow | null = null;
   private releaseNotesView: BrowserView | null = null;
-  // Tray popover (#9953 Phase 4): a frameless, transparent, always-on-top
-  // app renderer window anchored at the tray that renders the widget surface.
+  // Tray popover (#9953 Phase 4 / #12184): a frameless, transparent,
+  // always-on-top app renderer window anchored at the tray icon. The window is
+  // created once and reused (hidden/shown) across toggles so re-opening is
+  // instant and preserves renderer state.
   private trayPopoverWindow: BrowserWindow | null = null;
   private trayPopoverConfig: TrayPopoverConfig | null = null;
+  private trayPopoverVisible = false;
+  // Deferred blur-to-dismiss: blur schedules a hide ~200ms out; a tray-icon
+  // re-click (which fires blur then tray-clicked) cancels the pending hide and
+  // toggles closed instead, so a click on the icon never double-fires.
+  private trayPopoverBlurHideTimer: ReturnType<typeof setTimeout> | null = null;
   private shortcuts: Map<string, ShortcutOptions> = new Map();
   private notificationCounter = 0;
   private sendToWebview: SendToWebview | null = null;
@@ -320,6 +333,13 @@ export class DesktopManager {
   private _windowHidden = false;
   private _focusPoller: ReturnType<typeof setInterval> | null = null;
   private _appActive = false;
+  // Bottom-bar (pill) re-anchoring: the bar frame is derived from the primary
+  // display's work area, computed once at window creation. A display
+  // plug/unplug or resolution change strands it, so when the main window is the
+  // pill we re-derive + setFrame on every showWindow() and on a cheap 5s poll.
+  private bottomBarReanchorEnabled = false;
+  private bottomBarWorkArea: ScreenWorkArea | null = null;
+  private bottomBarPoller: ReturnType<typeof setInterval> | null = null;
 
   // Callback to open the settings window (set by index.ts)
   private openSettingsCallback: ((tabHint?: string) => void) | null = null;
@@ -1187,6 +1207,9 @@ X-GNOME-Autostart-enabled=true
       if (!win) return;
       this.showMainWindow(win);
     }
+    // Re-anchor the pill to the current work area on every summon — the display
+    // may have changed (or the bar been stranded) while it was hidden.
+    this.reanchorBottomBarIfNeeded();
   }
 
   async hideWindow(): Promise<void> {
@@ -1321,6 +1344,57 @@ X-GNOME-Autostart-enabled=true
     this.removeEventHandler(window, "resize", this.windowEventHandlers.resize);
     this.removeEventHandler(window, "move", this.windowEventHandlers.move);
     this.windowEventHandlers = {};
+  }
+
+  /**
+   * Mark the main window as the chromeless bottom bar (pill) and start keeping
+   * it anchored to the primary display's bottom edge. Called once from
+   * `createMainWindow()` for the bottom-bar branch. Records the current work
+   * area as the baseline and polls every 5s while the bar is visible so a
+   * display plug/unplug or resolution change re-anchors within one interval.
+   */
+  enableBottomBarReanchor(): void {
+    this.bottomBarReanchorEnabled = true;
+    this.bottomBarWorkArea = this.readPrimaryWorkArea();
+    if (this.bottomBarPoller) return;
+    this.bottomBarPoller = setInterval(() => {
+      if (this._windowHidden) return;
+      this.reanchorBottomBarIfNeeded();
+    }, 5_000);
+  }
+
+  private readPrimaryWorkArea(): ScreenWorkArea | null {
+    try {
+      const display = Screen.getPrimaryDisplay();
+      return display?.workArea ?? null;
+    } catch (err) {
+      logger.warn(
+        `[Desktop] bottom-bar Screen.getPrimaryDisplay() failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Re-derive the bottom-bar frame from the current work area and `setFrame`
+   * the main window when the work area moved/resized since we last anchored.
+   * No-op unless the main window is the pill.
+   */
+  private reanchorBottomBarIfNeeded(): void {
+    if (!this.bottomBarReanchorEnabled) return;
+    const win = this.mainWindow;
+    if (!win) return;
+    const nextWorkArea = this.readPrimaryWorkArea();
+    if (!nextWorkArea) return;
+    if (
+      this.bottomBarWorkArea &&
+      !shouldReanchorBottomBar(this.bottomBarWorkArea, nextWorkArea)
+    ) {
+      return;
+    }
+    const frame = computeBottomBarFrame(nextWorkArea);
+    win.setFrame(frame.x, frame.y, frame.width, frame.height);
+    this.bottomBarWorkArea = nextWorkArea;
   }
 
   private _startFocusPoller(): void {
@@ -1924,39 +1998,88 @@ X-GNOME-Autostart-enabled=true
     }
   }
 
-  /** Whether the tray popover window is currently open. */
+  /** Whether the tray popover is currently visible. */
   isTrayPopoverOpen(): boolean {
-    return this.trayPopoverWindow !== null;
+    return this.trayPopoverVisible;
+  }
+
+  /** Read the tray icon's screen bounds; zero-rect on any failure or no tray. */
+  private readTrayBounds(): Rect {
+    const zero: Rect = { x: 0, y: 0, width: 0, height: 0 };
+    if (!this.tray) return zero;
+    try {
+      return this.tray.getBounds() ?? zero;
+    } catch (err) {
+      logger.warn(
+        `[Desktop] tray popover Tray.getBounds() failed; anchoring top-right: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return zero;
+    }
   }
 
   /**
-   * Toggle the tray popover: close it if open, otherwise open a frameless,
-   * transparent, always-on-top app renderer window anchored at the top-right of
-   * the primary display's work area (under the macOS menu-bar tray).
+   * Toggle the tray popover: hide it if visible, otherwise show it anchored at
+   * the real tray icon. The window is created once and reused across toggles.
    */
   async toggleTrayPopover(): Promise<void> {
-    const config = this.trayPopoverConfig;
-    if (!config) return;
-
-    if (this.trayPopoverWindow) {
-      this.closeTrayPopover();
+    if (!this.trayPopoverConfig) return;
+    if (this.trayPopoverVisible) {
+      this.hideTrayPopover();
       return;
     }
+    await this.showTrayPopover();
+  }
 
-    const POPOVER_WIDTH = 360;
-    const POPOVER_HEIGHT = 480;
-    const MARGIN = 8;
-    let anchor = { x: 1920, y: 0, width: 1920, height: 1080 };
+  private static readonly POPOVER_SIZE = { w: 360, h: 480, margin: 8 } as const;
+
+  /**
+   * Resolve the popover frame from the tray icon bounds + primary display work
+   * area. Falls back to top-right of the work area when the tray reports a
+   * zero-rect (Windows/Linux) or the Screen API is unavailable.
+   */
+  private resolveTrayPopoverFrame(): Rect {
+    const size = DesktopManager.POPOVER_SIZE;
+    let workArea: Rect = { x: 1920, y: 0, width: 1920, height: 1080 };
+    let primaryHeight = 1080;
     try {
       const display = Screen.getPrimaryDisplay();
-      if (display?.workArea) anchor = display.workArea;
+      if (display?.workArea) workArea = display.workArea;
+      primaryHeight =
+        display?.bounds?.height ?? workArea.y + workArea.height;
     } catch (err) {
       logger.warn(
         `[Desktop] tray popover Screen.getPrimaryDisplay() failed; using default anchor: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    const x = anchor.x + anchor.width - POPOVER_WIDTH - MARGIN;
-    const y = anchor.y + MARGIN;
+    return computeTrayPopoverFrame(
+      this.readTrayBounds(),
+      workArea,
+      size,
+      primaryHeight,
+    );
+  }
+
+  /**
+   * Show the tray popover, creating the frameless/transparent/always-on-top
+   * window on first use and reusing it afterwards. Re-anchors under the tray
+   * icon on every open.
+   */
+  private async showTrayPopover(): Promise<void> {
+    const config = this.trayPopoverConfig;
+    if (!config) return;
+
+    this.clearTrayPopoverBlurTimer();
+    const frame = this.resolveTrayPopoverFrame();
+
+    if (this.trayPopoverWindow) {
+      const win = this.trayPopoverWindow;
+      win.setFrame(frame.x, frame.y, frame.width, frame.height);
+      win.show();
+      this.trayPopoverVisible = true;
+      config.onWindowFocused?.(win);
+      win.focus();
+      return;
+    }
 
     const buildConfig = await BuildConfig.get();
     const renderer = this.resolvePreferredBrowserRenderer(buildConfig);
@@ -1964,7 +2087,7 @@ X-GNOME-Autostart-enabled=true
       title: `${getBrandConfig().appName}`,
       url: config.url,
       preload: config.preload,
-      frame: { x, y, width: POPOVER_WIDTH, height: POPOVER_HEIGHT },
+      frame,
       renderer,
       transparent: true,
       titleBarStyle: "hidden",
@@ -1985,17 +2108,54 @@ X-GNOME-Autostart-enabled=true
       // Non-fatal: popover still opens, just not pinned above other windows.
     }
 
+    // Dismiss on blur (click outside) — a resting tray flyout, unlike the pill.
+    // Deferred so a tray-icon re-click can cancel it and toggle closed instead.
+    win.on("blur", () => {
+      if (!this.trayPopoverVisible) return;
+      if (this.trayPopoverBlurHideTimer) return;
+      this.trayPopoverBlurHideTimer = setTimeout(() => {
+        this.trayPopoverBlurHideTimer = null;
+        this.hideTrayPopover();
+      }, 200);
+    });
+
     win.on("close", () => {
       this.trayPopoverWindow = null;
+      this.trayPopoverVisible = false;
+      this.clearTrayPopoverBlurTimer();
     });
 
     this.trayPopoverWindow = win;
+    this.trayPopoverVisible = true;
     config.onWindowFocused?.(win);
     win.focus();
   }
 
-  /** Close the tray popover window if open. */
+  /** Hide the tray popover (kept alive for instant reuse). */
+  hideTrayPopover(): void {
+    this.clearTrayPopoverBlurTimer();
+    if (!this.trayPopoverWindow || !this.trayPopoverVisible) return;
+    try {
+      this.trayPopoverWindow.hide();
+    } catch (err) {
+      logger.warn(
+        `[Desktop] Failed to hide tray popover: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.trayPopoverVisible = false;
+  }
+
+  private clearTrayPopoverBlurTimer(): void {
+    if (this.trayPopoverBlurHideTimer) {
+      clearTimeout(this.trayPopoverBlurHideTimer);
+      this.trayPopoverBlurHideTimer = null;
+    }
+  }
+
+  /** Close and discard the tray popover window (teardown path). */
   closeTrayPopover(): void {
+    this.clearTrayPopoverBlurTimer();
+    this.trayPopoverVisible = false;
     if (!this.trayPopoverWindow) return;
     try {
       this.trayPopoverWindow.close();
@@ -2480,6 +2640,11 @@ X-GNOME-Autostart-enabled=true
       clearInterval(this._focusPoller);
       this._focusPoller = null;
     }
+    if (this.bottomBarPoller) {
+      clearInterval(this.bottomBarPoller);
+      this.bottomBarPoller = null;
+    }
+    this.closeTrayPopover();
     this.teardownWindowEvents(this.mainWindow);
     this.mainWindow = null;
     this.releaseNotesView?.remove();

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -375,8 +375,17 @@ export class DesktopManager {
     | null = null;
   private requestQuitCallback: (() => void | Promise<void>) | null = null;
   private restoreMainWindowCallback: (() => void | Promise<void>) | null = null;
-  /** Tray-first mode: Dock icon follows main-window presence (macOS). */
+  /**
+   * Dockless (tray-first) mode: the Dock icon reflects the presence of FULL
+   * windows only (dashboard / surface / settings / app windows), never the
+   * chromeless pill. macOS-only; the Dock icon is hidden while just the pill
+   * exists and revealed the moment a full window opens.
+   */
   private trayFirstMode = false;
+  /** Keys of full/managed windows currently present (pill excluded). */
+  private readonly fullWindowKeys = new Set<string>();
+  /** Whether the attached main window counts as a full window (not the pill). */
+  private mainWindowIsFullWindow = false;
 
   // Track menu items for context-menu-clicked matching
   private trayMenuItems: Map<string, TrayMenuItem> = new Map();
@@ -497,7 +506,8 @@ export class DesktopManager {
     if (!window || this.mainWindow === window) {
       this.teardownWindowEvents(this.mainWindow);
       this.mainWindow = null;
-      this.syncTrayFirstDock(false);
+      this.mainWindowIsFullWindow = false;
+      this.refreshMainWindowPresence();
     }
   }
 
@@ -1224,7 +1234,7 @@ X-GNOME-Autostart-enabled=true
       win.minimize();
     }
     this._windowHidden = true;
-    this.syncTrayFirstDock(false);
+    this.refreshMainWindowPresence();
   }
 
   async focusWindow(): Promise<void> {
@@ -1274,7 +1284,7 @@ X-GNOME-Autostart-enabled=true
       win.focus();
     }
     this._windowHidden = false;
-    this.syncTrayFirstDock(true);
+    this.refreshMainWindowPresence();
   }
 
   private setupWindowEvents(): void {
@@ -1779,37 +1789,79 @@ X-GNOME-Autostart-enabled=true
   }
 
   /**
-   * Enable tray-first mode: the Dock icon is hidden until a main window is
-   * shown, then follows window presence (hidden when the window is hidden or
-   * closed). Call once at startup. No-op off macOS (setDockIconVisibility
-   * guards the native call).
+   * Enable dockless (tray-first) mode: the Dock icon is hidden until at least
+   * one FULL window (dashboard / surface / settings / app) exists, then tracks
+   * that set — the chromeless pill never counts. Call once at startup. No-op
+   * off macOS (setDockIconVisibility guards the native call).
    */
   setTrayFirstMode(enabled: boolean): void {
     this.trayFirstMode = enabled;
-    if (enabled) {
-      void this.setDockIconVisibility({ visible: false }).catch(() => {});
+    // Start from the current full-window set (empty at boot → Dock hidden).
+    this.syncTrayFirstDock();
+  }
+
+  /**
+   * Declare whether the attached main window counts as a full window (the
+   * dashboard/kiosk) or is the chromeless pill (which never reveals the Dock).
+   * Called from attachMainWindow() with the resolved shell presentation.
+   */
+  setMainWindowFullWindow(isFull: boolean): void {
+    this.mainWindowIsFullWindow = isFull;
+    this.refreshMainWindowPresence();
+  }
+
+  /**
+   * Report whether any managed surface/settings/app windows are currently open.
+   * Wired to SurfaceWindowManager.onRegistryChanged so opening the dashboard
+   * (or any view window) reveals the Dock icon and closing the last one hides
+   * it again.
+   */
+  setManagedWindowsPresent(present: boolean): void {
+    this.setFullWindowPresence("managed", present);
+  }
+
+  /**
+   * Signal that the main window has been attached/shown. Reveals the Dock icon
+   * in dockless mode only when the main window is a full window (not the pill),
+   * regardless of how it was opened (boot, tray "Show Window", Dock reopen, or
+   * a direct restoreWindow() from a deep link).
+   */
+  markMainWindowShown(): void {
+    this.refreshMainWindowPresence();
+  }
+
+  private refreshMainWindowPresence(): void {
+    this.setFullWindowPresence(
+      "main",
+      this.mainWindowIsFullWindow && !this._windowHidden,
+    );
+  }
+
+  /**
+   * Track whether a class of full/managed window is present. In dockless mode
+   * the Dock icon is visible iff the tracked set is non-empty. The pill is
+   * never reported here, so it never reveals the Dock.
+   */
+  private setFullWindowPresence(key: string, present: boolean): void {
+    const changed = present
+      ? !this.fullWindowKeys.has(key)
+      : this.fullWindowKeys.has(key);
+    if (present) {
+      this.fullWindowKeys.add(key);
+    } else {
+      this.fullWindowKeys.delete(key);
+    }
+    if (changed) {
+      this.syncTrayFirstDock();
     }
   }
 
-  /**
-   * Signal that a main window has been attached/shown. Reveals the Dock icon in
-   * tray-first mode regardless of how the window was opened — including
-   * createMainWindow()/attachMainWindow() paths (boot, restoreWindow() from a
-   * deep link) that bypass showWindow()/showMainWindow(). No-op outside
-   * tray-first.
-   */
-  markMainWindowShown(): void {
-    this.syncTrayFirstDock(true);
-  }
-
-  /**
-   * Toggle the Dock icon to match window presence, only in tray-first mode.
-   * Routed through every show/hide path so reopen-from-tray (which bypasses
-   * the window create path) keeps the Dock icon correct.
-   */
-  private syncTrayFirstDock(visible: boolean): void {
+  /** Match the Dock icon to full-window presence; only in dockless mode. */
+  private syncTrayFirstDock(): void {
     if (!this.trayFirstMode) return;
-    void this.setDockIconVisibility({ visible }).catch(() => {});
+    void this.setDockIconVisibility({
+      visible: this.fullWindowKeys.size > 0,
+    }).catch(() => {});
   }
 
   async showSelectionContextMenu(options: {

--- a/packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts
+++ b/packages/app-core/platforms/electrobun/src/tray-popover-position.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { computeTrayPopoverFrame } from "./tray-popover-position";
+
+const SIZE = { w: 360, h: 480, margin: 8 } as const;
+
+describe("computeTrayPopoverFrame", () => {
+  // Primary 1440x900 display, 24px menu bar excluded from the work area.
+  const primaryHeight = 900;
+  const workArea = { x: 0, y: 24, width: 1440, height: 876 };
+
+  it("centers the popover under a tray icon and hangs it below the menu bar", () => {
+    // A tray icon 900px from the left, 22px tall menu-bar item. In bottom-left
+    // screen coords its y is near the top of the display (900 - 22 = 878).
+    const trayBounds = { x: 900, y: 878, width: 30, height: 22 };
+    const frame = computeTrayPopoverFrame(
+      trayBounds,
+      workArea,
+      SIZE,
+      primaryHeight,
+    );
+
+    // x centered under the icon: 900 + 30/2 - 360/2 = 735.
+    expect(frame.x).toBe(735);
+    // y: iconBottomTopLeft = 900 - 878 = 22; + margin = 30; clamped to
+    // workArea.y + margin = 32 (the menu bar is excluded from the work area).
+    expect(frame.y).toBe(32);
+    expect(frame.width).toBe(360);
+    expect(frame.height).toBe(480);
+  });
+
+  it("clamps x so a right-edge icon never spills off-screen", () => {
+    // Icon hard against the right edge of the menu bar.
+    const trayBounds = { x: 1430, y: 878, width: 20, height: 22 };
+    const frame = computeTrayPopoverFrame(
+      trayBounds,
+      workArea,
+      SIZE,
+      primaryHeight,
+    );
+    // Right-clamped: workArea.x + width - w - margin = 0 + 1440 - 360 - 8 = 1072.
+    expect(frame.x).toBe(1072);
+    expect(frame.x + frame.width + SIZE.margin).toBeLessThanOrEqual(
+      workArea.x + workArea.width,
+    );
+  });
+
+  it("clamps x so a left-edge icon never spills off-screen", () => {
+    const trayBounds = { x: 2, y: 878, width: 20, height: 22 };
+    const frame = computeTrayPopoverFrame(
+      trayBounds,
+      workArea,
+      SIZE,
+      primaryHeight,
+    );
+    // Left-clamped to workArea.x + margin = 8.
+    expect(frame.x).toBe(8);
+  });
+
+  it("clamps y down to the work-area bottom when the converted anchor would spill below", () => {
+    // A pathological tray whose bottom-left y is near the screen bottom (10)
+    // converts to a top-left anchor near the bottom of the display; the frame
+    // must clamp UP to maxY so the popover stays fully inside the work area.
+    const trayBounds = { x: 700, y: 10, width: 30, height: 22 };
+    const frame = computeTrayPopoverFrame(
+      trayBounds,
+      workArea,
+      SIZE,
+      primaryHeight,
+    );
+    const maxY = workArea.y + workArea.height - SIZE.h - SIZE.margin;
+    expect(frame.y).toBe(maxY);
+    expect(frame.y).toBeLessThanOrEqual(maxY);
+    expect(frame.y).toBeGreaterThanOrEqual(workArea.y + SIZE.margin);
+  });
+
+  it("falls back to the top-right of the work area for a zero-rect (Windows/Linux stub)", () => {
+    const frame = computeTrayPopoverFrame(
+      { x: 0, y: 0, width: 0, height: 0 },
+      workArea,
+      SIZE,
+      primaryHeight,
+    );
+    // Top-right corner: x = 0 + 1440 - 360 - 8 = 1072; y = workArea.y + margin.
+    expect(frame.x).toBe(1072);
+    expect(frame.y).toBe(32);
+    expect(frame.width).toBe(360);
+    expect(frame.height).toBe(480);
+  });
+
+  it("honors the work-area origin on a secondary display (multi-monitor)", () => {
+    const secondary = { x: 1920, y: 24, width: 1920, height: 1056 };
+    const trayBounds = { x: 3200, y: 1058, width: 30, height: 22 };
+    const frame = computeTrayPopoverFrame(
+      trayBounds,
+      secondary,
+      SIZE,
+      1080,
+    );
+    // x centered: 3200 + 15 - 180 = 3035, inside [1928, 3552].
+    expect(frame.x).toBe(3035);
+    expect(frame.x).toBeGreaterThanOrEqual(secondary.x + SIZE.margin);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/tray-popover-position.ts
+++ b/packages/app-core/platforms/electrobun/src/tray-popover-position.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure geometry for anchoring the tray popover under the system-tray icon
+ * (#12184 / #9953 Phase 4).
+ *
+ * macOS `Tray.getBounds()` returns the `NSStatusItem` button frame in screen
+ * coordinates, which are **bottom-left origin** (Cocoa). Electrobun window
+ * frames are **top-left origin**. This module owns the origin flip + the
+ * x-centering + the work-area clamping so the anchoring is unit-testable
+ * without a live tray. Windows/Linux return a zero-rect stub from
+ * `getTrayBounds` (fork gaps G3), so a zero-rect falls back to the top-right of
+ * the work area (the pre-#12184 behavior).
+ */
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface TrayPopoverSize {
+  /** Popover width in points. */
+  w: number;
+  /** Popover height in points. */
+  h: number;
+  /** Gap between the tray icon / work-area edges and the popover. */
+  margin: number;
+}
+
+function isZeroRect(rect: Rect): boolean {
+  return (
+    rect.x === 0 && rect.y === 0 && rect.width === 0 && rect.height === 0
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Compute the top-left-origin frame for the tray popover.
+ *
+ * - When `trayBounds` is a real rect: x is centered under the tray icon; y is
+ *   the tray icon's bottom edge converted from bottom-left → top-left origin
+ *   via `primaryDisplayHeight` (so it hangs just below the menu-bar icon).
+ * - When `trayBounds` is a zero-rect (Windows/Linux stub): fall back to the
+ *   top-right corner of the work area.
+ *
+ * The result is always clamped inside `workArea` (inset by `margin`) so the
+ * popover can never spill off-screen — including when the icon sits near a
+ * screen edge.
+ */
+export function computeTrayPopoverFrame(
+  trayBounds: Rect,
+  workArea: Rect,
+  size: TrayPopoverSize,
+  primaryDisplayHeight: number,
+): Rect {
+  const { w, h, margin } = size;
+
+  const minX = workArea.x + margin;
+  const maxX = workArea.x + workArea.width - w - margin;
+  const minY = workArea.y + margin;
+  const maxY = workArea.y + workArea.height - h - margin;
+
+  if (isZeroRect(trayBounds)) {
+    // No icon geometry (Windows/Linux): pin to the top-right of the work area.
+    return {
+      x: clamp(workArea.x + workArea.width - w - margin, minX, maxX),
+      y: clamp(minY, minY, maxY),
+      width: w,
+      height: h,
+    };
+  }
+
+  // Center the popover horizontally under the tray icon.
+  const centeredX = trayBounds.x + trayBounds.width / 2 - w / 2;
+
+  // Bottom-left → top-left origin: the icon's bottom edge (visually just under
+  // the menu bar) sits at `primaryDisplayHeight - trayBounds.y` in top-left
+  // coordinates. Hang the popover from there, then let the clamp pin it below
+  // the menu bar (which `workArea.y` already excludes).
+  const iconBottomTopLeft = primaryDisplayHeight - trayBounds.y;
+  const anchoredY = iconBottomTopLeft + margin;
+
+  return {
+    x: Math.round(clamp(centeredX, minX, maxX)),
+    y: Math.round(clamp(anchoredY, minY, maxY)),
+    width: w,
+    height: h,
+  };
+}

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -9,10 +9,35 @@ import {
   dispatchOpenNotificationCenter,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
+import {
+  type DesktopLauncherEntry,
+  type DesktopLauncherIconId,
+  setDesktopLauncherEntries,
+} from "@elizaos/ui/state/desktop-tray-launcher";
 import { useApp } from "@elizaos/ui/state/useApp";
 import { openDesktopSettingsWindow } from "@elizaos/ui/utils/desktop-workspace";
 import { useEffect } from "react";
-import { DESKTOP_VIEW_WINDOWS, parseTrayOpenViewItemId } from "./tray-menu";
+import {
+  DESKTOP_VIEW_WINDOWS,
+  parseTrayOpenViewItemId,
+  trayOpenViewItemId,
+} from "./tray-menu";
+
+const LAUNCHER_ICON_IDS: ReadonlySet<string> = new Set<DesktopLauncherIconId>([
+  "tutorial",
+  "help",
+  "chat",
+  "character",
+  "documents",
+  "settings",
+  "background",
+]);
+
+function launcherIconForView(viewId: string): DesktopLauncherIconId {
+  return LAUNCHER_ICON_IDS.has(viewId)
+    ? (viewId as DesktopLauncherIconId)
+    : "view";
+}
 
 interface TrayActionDetail {
   itemId?: string;
@@ -39,6 +64,31 @@ export function DesktopTrayRuntime() {
     switchShellView,
     t,
   } = useApp();
+
+  // Publish the tray-popover launcher catalog to the renderer store the popover
+  // shell reads (#12184). Single source of truth stays `DESKTOP_VIEW_WINDOWS`;
+  // rows dispatch `tray-open-view-*` / `tray-show-window` through the same
+  // TRAY_ACTION_EVENT handler wired below, so no new RPC or duplicated catalog.
+  useEffect(() => {
+    if (!isElectrobunRuntime()) {
+      return;
+    }
+    const viewRows: DesktopLauncherEntry[] = DESKTOP_VIEW_WINDOWS.map(
+      (view) => ({
+        itemId: trayOpenViewItemId(view.id),
+        label: t(view.labelKey, { defaultValue: view.label }),
+        icon: launcherIconForView(view.id),
+      }),
+    );
+    setDesktopLauncherEntries([
+      {
+        itemId: "tray-show-window",
+        label: t("desktop.tray.openEliza", { defaultValue: "Open Eliza" }),
+        icon: "home",
+      },
+      ...viewRows,
+    ]);
+  }, [t]);
 
   // App menu "Reset App…" reuses the same push channel as tray `navigate-*`.
   // WHY: Electrobun already bridges `desktopTrayMenuClick`; no new IPC type needed.

--- a/packages/app/src/desktop-hotkey.test.ts
+++ b/packages/app/src/desktop-hotkey.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { decideChatOverlayToggle } from "./desktop-hotkey";
+
+describe("decideChatOverlayToggle", () => {
+  it("dismisses when the overlay is focused AND visible", () => {
+    expect(decideChatOverlayToggle({ focused: true, visible: true })).toBe(
+      "hide",
+    );
+  });
+
+  it("summons when hidden", () => {
+    expect(decideChatOverlayToggle({ focused: false, visible: false })).toBe(
+      "show",
+    );
+    expect(decideChatOverlayToggle({ focused: true, visible: false })).toBe(
+      "show",
+    );
+  });
+
+  it("summons when visible but not focused (backgrounded behind another app)", () => {
+    expect(decideChatOverlayToggle({ focused: false, visible: true })).toBe(
+      "show",
+    );
+  });
+});

--- a/packages/app/src/desktop-hotkey.ts
+++ b/packages/app/src/desktop-hotkey.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure decision for the global chat-overlay summon hotkey (#10716 / #12184).
+ *
+ * The hotkey toggles the floating chat surface (which, on desktop, is the main
+ * window / bottom-bar pill): pressing it while the window is already focused +
+ * visible dismisses it (returning focus to the previously active app via the
+ * macOS orderOut path); otherwise it summons + focuses it. Kept pure so the
+ * toggle logic is unit-testable without the Electrobun bridge.
+ */
+
+export interface DesktopWindowState {
+  focused: boolean;
+  visible: boolean;
+}
+
+export type ChatOverlayToggleAction = "show" | "hide";
+
+/**
+ * Decide whether a hotkey press should summon or dismiss the chat overlay.
+ * Only a window that is BOTH focused and visible is dismissed; anything else
+ * (hidden, or visible-but-backgrounded behind another app) is summoned +
+ * focused so the chord always brings the overlay forward first.
+ */
+export function decideChatOverlayToggle(
+  state: DesktopWindowState,
+): ChatOverlayToggleAction {
+  return state.focused && state.visible ? "hide" : "show";
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -135,6 +135,7 @@ import { renderBootFailure } from "./boot-failure";
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
+import { decideChatOverlayToggle } from "./desktop-hotkey";
 import {
   buildAssistantLaunchHashRoute,
   type DeepLinkNavigationIntent,
@@ -1857,7 +1858,19 @@ async function initializeDesktopShell(): Promise<void> {
     });
   }
 
+  // Toggle semantics (#12184): a focused + visible overlay is dismissed
+  // (focus returns to the previously active app via the macOS orderOut path);
+  // otherwise summon + focus it. Blur does NOT hide the pill — it is a resting
+  // surface (unlike the tray popover).
   const summonChatOverlay = async (): Promise<void> => {
+    const [{ focused }, { visible }] = await Promise.all([
+      Desktop.isWindowFocused(),
+      Desktop.isWindowVisible(),
+    ]);
+    if (decideChatOverlayToggle({ focused, visible }) === "hide") {
+      await Desktop.hideWindow();
+      return;
+    }
     await Desktop.showWindow();
     await Desktop.focusWindow();
   };

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -67,6 +67,7 @@ import { ShellOverlays } from "./components/shell/ShellOverlays";
 import { StartupFailureView } from "./components/shell/StartupFailureView";
 import { StartupScreen } from "./components/shell/StartupScreen";
 import { SystemWarningBanner } from "./components/shell/SystemWarningBanner";
+import { TrayLauncher } from "./components/shell/TrayLauncher";
 import { useBarSurfaceWindows } from "./components/shell/useBarSurfaceWindows";
 import { useKioskViewSurfaces } from "./components/shell/useKioskViewSurfaces";
 import { Button } from "./components/ui/button";
@@ -477,18 +478,20 @@ function ChatOverlayShell() {
 }
 
 /**
- * Native tray popover surface (#9953 Phase 4). Renders ONLY the widget surface
- * (reusing the shell widget registry's "home" slot) inside the frameless,
- * transparent, always-on-top window the native tray anchors near its icon — no
- * app chrome. Each widget self-hides when it has nothing to show, so the popover
- * is a compact at-a-glance panel.
+ * Native tray popover surface (#9953 Phase 4 / #12184). Renders the compact
+ * launcher (the `DESKTOP_VIEW_WINDOWS` catalog + "Open Eliza", registered by
+ * the desktop host) above the shell widget registry's "home" slot inside the
+ * frameless, transparent, always-on-top window the native tray anchors near its
+ * icon — no app chrome. Each widget self-hides when it has nothing to show, so
+ * the popover is a compact at-a-glance panel + one-click launcher.
  */
 function TrayPopoverShell() {
   return (
     <div
       data-testid="tray-popover-shell"
-      className="fixed inset-0 overflow-y-auto bg-transparent p-3"
+      className="fixed inset-0 flex flex-col gap-3 overflow-y-auto bg-transparent p-3"
     >
+      <TrayLauncher />
       <WidgetHost slot="home" layout="stack" />
     </div>
   );

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -32,6 +32,7 @@ import {
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
 } from "./bridge/electrobun-rpc";
+import { isElectrobunRuntime } from "./bridge/electrobun-runtime";
 import {
   NAVIGATE_SETTINGS_EVENT,
   type NavigateSettingsDetail,
@@ -445,6 +446,26 @@ function ChatOverlayShell() {
   // The bar has no inline tab system, so "show a view" / "show the launcher"
   // intents open dedicated on-demand desktop windows instead (#9953 Phase 3).
   useBarSurfaceWindows();
+  const controller = useShellControllerContext();
+  const overlayOpen = controller?.isOpen ?? false;
+  // Escape collapses the overlay first — while it is open, AssistantOverlay's
+  // own Escape handler closes it. Once already collapsed, Escape hides the
+  // desktop window entirely (#12184) so the pill dismisses to the background
+  // like a summoned panel. Desktop-only (web has no window to hide).
+  useEffect(() => {
+    if (typeof document === "undefined" || !isElectrobunRuntime()) {
+      return undefined;
+    }
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape" || overlayOpen) return;
+      void invokeDesktopBridgeRequest<void>({
+        rpcMethod: "desktopHideWindow",
+        ipcChannel: "desktop:hideWindow",
+      });
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [overlayOpen]);
   return (
     <div
       data-testid="chat-overlay-shell"

--- a/packages/ui/src/components/shell/TrayLauncher.stories.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { DesktopLauncherEntry } from "../../state/desktop-tray-launcher";
+import { TrayLauncher } from "./TrayLauncher";
+
+// TrayLauncher normally reads its rows from the desktop launcher store the host
+// populates from DESKTOP_VIEW_WINDOWS. Stories pass `entries` directly and a
+// no-op `onSelect` so they render deterministically without the desktop host.
+const CATALOG: DesktopLauncherEntry[] = [
+  { itemId: "tray-show-window", label: "Open Eliza", icon: "home" },
+  { itemId: "tray-open-view-tutorial", label: "Tutorial", icon: "tutorial" },
+  { itemId: "tray-open-view-help", label: "Help", icon: "help" },
+  { itemId: "tray-open-view-chat", label: "Messages", icon: "chat" },
+  { itemId: "tray-open-view-character", label: "Character", icon: "character" },
+  { itemId: "tray-open-view-documents", label: "Knowledge", icon: "documents" },
+  { itemId: "tray-open-view-settings", label: "Settings", icon: "settings" },
+  {
+    itemId: "tray-open-view-background",
+    label: "Background",
+    icon: "background",
+  },
+];
+
+const meta = {
+  title: "Shell/TrayLauncher",
+  component: TrayLauncher,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    entries: CATALOG,
+    onSelect: (itemId: string) => {
+      // eslint-disable-next-line no-console -- story action log
+      console.log("[TrayLauncher story] select", itemId);
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px] rounded-md bg-card p-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TrayLauncher>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullCatalog: Story = {};
+
+export const OpenElizaOnly: Story = {
+  args: {
+    entries: [{ itemId: "tray-show-window", label: "Open Eliza", icon: "home" }],
+  },
+};
+
+export const Empty: Story = {
+  args: { entries: [] },
+};

--- a/packages/ui/src/components/shell/TrayLauncher.test.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TRAY_ACTION_EVENT } from "../../events";
+import type { DesktopLauncherEntry } from "../../state/desktop-tray-launcher";
+import { setDesktopLauncherEntries } from "../../state/desktop-tray-launcher";
+import { TrayLauncher } from "./TrayLauncher";
+
+const ENTRIES: DesktopLauncherEntry[] = [
+  { itemId: "tray-show-window", label: "Open Eliza", icon: "home" },
+  { itemId: "tray-open-view-chat", label: "Messages", icon: "chat" },
+  { itemId: "tray-open-view-settings", label: "Settings", icon: "settings" },
+];
+
+afterEach(() => {
+  cleanup();
+  setDesktopLauncherEntries([]);
+});
+
+describe("TrayLauncher", () => {
+  it("renders a row per entry with its label", () => {
+    render(<TrayLauncher entries={ENTRIES} />);
+    expect(screen.getByText("Open Eliza")).toBeTruthy();
+    expect(screen.getByText("Messages")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+
+  it("dispatches TRAY_ACTION_EVENT with the row's item id on click (shared tray handling)", async () => {
+    const events: string[] = [];
+    const onEvent = (e: Event) => {
+      const detail = (e as CustomEvent<{ itemId?: string }>).detail;
+      if (detail?.itemId) events.push(detail.itemId);
+    };
+    document.addEventListener(TRAY_ACTION_EVENT, onEvent);
+    try {
+      render(<TrayLauncher entries={ENTRIES} />);
+      await userEvent.click(
+        screen.getByTestId("tray-launcher-row-tray-open-view-chat"),
+      );
+      await userEvent.click(
+        screen.getByTestId("tray-launcher-row-tray-show-window"),
+      );
+    } finally {
+      document.removeEventListener(TRAY_ACTION_EVENT, onEvent);
+    }
+    expect(events).toEqual(["tray-open-view-chat", "tray-show-window"]);
+  });
+
+  it("prefers an explicit onSelect handler over dispatching", async () => {
+    const onSelect = vi.fn();
+    render(<TrayLauncher entries={ENTRIES} onSelect={onSelect} />);
+    await userEvent.click(
+      screen.getByTestId("tray-launcher-row-tray-open-view-settings"),
+    );
+    expect(onSelect).toHaveBeenCalledWith("tray-open-view-settings");
+  });
+
+  it("reads the registered catalog when no entries prop is given", () => {
+    setDesktopLauncherEntries([
+      { itemId: "tray-open-view-help", label: "Help", icon: "help" },
+    ]);
+    render(<TrayLauncher />);
+    expect(screen.getByText("Help")).toBeTruthy();
+  });
+
+  it("renders nothing when there are no rows", () => {
+    const { container } = render(<TrayLauncher entries={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/TrayLauncher.tsx
+++ b/packages/ui/src/components/shell/TrayLauncher.tsx
@@ -1,0 +1,93 @@
+import {
+  BookOpen,
+  Bot,
+  GraduationCap,
+  HelpCircle,
+  Home,
+  Image,
+  LayoutGrid,
+  type LucideIcon,
+  MessageSquare,
+  Settings,
+} from "lucide-react";
+import type * as React from "react";
+import { dispatchAppEvent, TRAY_ACTION_EVENT } from "../../events";
+import { cn } from "../../lib/utils";
+import {
+  type DesktopLauncherEntry,
+  type DesktopLauncherIconId,
+  useDesktopLauncherEntries,
+} from "../../state/desktop-tray-launcher";
+import { Button } from "../ui/button";
+
+const ICONS: Record<DesktopLauncherIconId, LucideIcon> = {
+  tutorial: GraduationCap,
+  help: HelpCircle,
+  chat: MessageSquare,
+  character: Bot,
+  documents: BookOpen,
+  settings: Settings,
+  background: Image,
+  home: Home,
+  view: LayoutGrid,
+};
+
+export interface TrayLauncherProps {
+  /** Rows to render; defaults to the registered desktop launcher catalog. */
+  entries?: readonly DesktopLauncherEntry[];
+  /**
+   * Row click handler; defaults to dispatching the row's tray item id through
+   * `TRAY_ACTION_EVENT` — the same channel the native tray menu uses, so the
+   * popover opens the identical deduped window with no new RPC.
+   */
+  onSelect?: (itemId: string) => void;
+}
+
+/**
+ * Compact launcher for the desktop tray popover (#12184). Renders one row per
+ * registered `DesktopLauncherEntry` (the `DESKTOP_VIEW_WINDOWS` catalog plus
+ * "Open Eliza"), each opening the matching surface via the shared tray-action
+ * channel. Neutral rows, orange only as the interactive accent — no chrome.
+ * Renders nothing until the desktop host registers rows.
+ */
+export function TrayLauncher({
+  entries,
+  onSelect,
+}: TrayLauncherProps): React.JSX.Element | null {
+  const registered = useDesktopLauncherEntries();
+  const rows = entries ?? registered;
+  if (rows.length === 0) return null;
+
+  const handleSelect =
+    onSelect ??
+    ((itemId: string) => {
+      dispatchAppEvent(TRAY_ACTION_EVENT, { itemId });
+    });
+
+  return (
+    <nav
+      data-testid="tray-launcher"
+      aria-label="Launcher"
+      className="flex flex-col gap-0.5"
+    >
+      {rows.map((row) => {
+        const Icon = ICONS[row.icon] ?? LayoutGrid;
+        return (
+          <Button
+            key={row.itemId}
+            type="button"
+            variant="ghost"
+            data-testid={`tray-launcher-row-${row.itemId}`}
+            onClick={() => handleSelect(row.itemId)}
+            className={cn(
+              "h-9 w-full justify-start gap-3 px-2 text-sm font-normal",
+            )}
+          >
+            <Icon aria-hidden="true" className="text-muted-strong" />
+            <span className="truncate">{row.label}</span>
+          </Button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7486,6 +7486,7 @@
   "desktop.tray.sendTestNotification": "Send Test Notification",
   "desktop.tray.showWindow": "Show Window",
   "desktop.tray.hideWindow": "Hide Window",
+  "desktop.tray.openEliza": "Open Eliza",
   "desktop.tray.quit": "Quit",
   "desktop.tray.testNotification.title": "Desktop",
   "desktop.tray.testNotification.body": "Renderer tray actions are wired and responding.",

--- a/packages/ui/src/state/desktop-tray-launcher.ts
+++ b/packages/ui/src/state/desktop-tray-launcher.ts
@@ -1,0 +1,71 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Runtime registry for the desktop tray-popover launcher rows (#12184).
+ *
+ * The launcher catalog's single source of truth is `DESKTOP_VIEW_WINDOWS` in
+ * `@elizaos/app-core` (`runtime/desktop/tray-menu.ts`). `@elizaos/ui` cannot
+ * import `@elizaos/app-core` (that package depends on this one — importing it
+ * back would be a cycle), so the desktop host registers the resolved,
+ * localized rows here at runtime and the presentational `TrayLauncher`
+ * (rendered inside `TrayPopoverShell`) reads them. Same pattern as
+ * `registerAppShellPage`: the host contributes, the shell renders.
+ */
+
+/** Semantic icon key — the presentational layer maps it to a concrete glyph. */
+export type DesktopLauncherIconId =
+  | "tutorial"
+  | "help"
+  | "chat"
+  | "character"
+  | "documents"
+  | "settings"
+  | "background"
+  | "home"
+  | "view";
+
+export interface DesktopLauncherEntry {
+  /**
+   * Tray item id dispatched on click (e.g. `tray-open-view-chat`,
+   * `tray-show-window`) — routed through the same `TRAY_ACTION_EVENT` handling
+   * the native tray menu uses (`DesktopTrayRuntime`).
+   */
+  readonly itemId: string;
+  /** Localized row label. */
+  readonly label: string;
+  /** Semantic icon key resolved to a glyph by the presentational layer. */
+  readonly icon: DesktopLauncherIconId;
+}
+
+let entries: readonly DesktopLauncherEntry[] = [];
+const listeners = new Set<() => void>();
+
+/** Replace the desktop launcher rows and notify subscribers. */
+export function setDesktopLauncherEntries(
+  next: readonly DesktopLauncherEntry[],
+): void {
+  entries = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getDesktopLauncherEntries(): readonly DesktopLauncherEntry[] {
+  return entries;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Subscribe a React component to the desktop launcher rows. */
+export function useDesktopLauncherEntries(): readonly DesktopLauncherEntry[] {
+  return useSyncExternalStore(
+    subscribe,
+    getDesktopLauncherEntries,
+    getDesktopLauncherEntries,
+  );
+}

--- a/packages/ui/src/state/useChatOverlayHotkey.ts
+++ b/packages/ui/src/state/useChatOverlayHotkey.ts
@@ -1,18 +1,21 @@
 import { useSyncExternalStore } from "react";
 
 /**
- * User-configurable global hotkey that summons the floating chat surface
- * (#10716). On desktop the main window *is* the chat-overlay bottom bar, so
- * "summon chat" means show + focus the main window. The chosen accelerator is
- * registered with the OS via `Desktop.registerShortcut({ id: "chat-overlay" })`
- * in the desktop shell; pressing it fires `desktopShortcutPressed`, which the
- * shell handles by bringing the window to the foreground.
+ * User-configurable global hotkey that toggles the floating chat surface
+ * (#10716 / #12184). On desktop the main window *is* the chat-overlay bottom
+ * bar, so the hotkey toggles it: when the window is already focused + visible
+ * the press dismisses it (focus returns to the previously active app);
+ * otherwise it shows + focuses it. The chosen accelerator is registered with
+ * the OS via `Desktop.registerShortcut({ id: "chat-overlay" })`; pressing it
+ * fires `desktopShortcutPressed`, which the shell handles with the pure
+ * `decideChatOverlayToggle()` decision (packages/app/src/desktop-hotkey.ts).
  *
  * This is intentionally separate from the `command-palette` binding
  * (`CommandOrControl+K`): summoning chat and opening the palette are distinct
  * actions, so both shortcuts are registered and the default chat accelerator is
- * chosen to not collide with the palette. Persisted to localStorage so it
- * survives reloads and is readable synchronously at desktop boot.
+ * chosen to not collide with the palette (nor with Option+Space, which Claude
+ * and ChatGPT desktop both squat). Persisted to localStorage so it survives
+ * reloads and is readable synchronously at desktop boot.
  */
 
 const STORAGE_KEY = "eliza:chatOverlayHotkey";


### PR DESCRIPTION
Phase 1 of #12184 — app layer only, `electrobun@1.18.1` npm APIs, **zero fork changes**, executing the settled dossier design decisions D1–D10. One PR: W5's default flip is pinned by the updated contract test and shares the `DesktopManager` rework with W1/W3 — splitting it would leave the Dock-tracking plumbing dead in a first PR, and `ELIZA_DESKTOP_TRAY_FIRST=0` is the safety valve.

## Work items

### W1 — Pill window flags: click-through, all-Spaces, re-anchor
- The pill window spans the full work-area width but only the small bar is visible; it now passes `passthrough: true` (typed in `ElectrobunBrowserWindowOptions`) so clicks on the transparent strip land on the app underneath — both the direct window path and the isolated-CEF `BrowserView` path (`startPassthrough`).
- darwin `setVisibleOnAllWorkspaces(true)` after creation (guarded like `setAlwaysOnTop`) — the pill follows Space switches.
- Bar frame was computed once at boot; it now re-anchors on every `showWindow()` and a cheap 5s poll while visible, via pure `shouldReanchorBottomBar(prev, next)` in `desktop-bottom-bar-config.ts` (+ unit tests).
- Fixed the stale "No hide() on BrowserWindow" header comment in `native/desktop.ts`.

### W2 — Hotkey toggle + Escape-to-hide
- `summonChatOverlay` (packages/app/src/main.tsx) is now a toggle: focused + visible → `hideWindow()` (focus returns to the previous app via the macOS orderOut path), else show + focus. Decision extracted as pure `decideChatOverlayToggle()` (`packages/app/src/desktop-hotkey.ts`, + unit tests).
- Escape in the chat-overlay shell collapses the overlay first (AssistantOverlay already owns Escape while open); when already collapsed, Escape hides the window via `Desktop.hideWindow()` (desktop-only).

### W3 — Tray popover: real anchor, blur-dismiss, window reuse
- New pure `EB/src/tray-popover-position.ts` — `computeTrayPopoverFrame(trayBounds, workArea, {w:360,h:480,margin:8}, primaryDisplayHeight)`: x-centered under the real `Tray.getBounds()`, bottom-left→top-left y-axis flip via the primary display height, clamped to the work area, top-right fallback for the Windows/Linux zero-rect stub. Thorough unit tests incl. clamping + y-flip + multi-monitor origin.
- The popover window is created once and **reused** across toggles (hide/show + `setFrame` re-anchor on each open) — no cold-boot flash, renderer state preserved.
- `win.on("blur")` dismisses via a 200 ms deferred hide that a tray-icon re-click cancels (re-entry guard), so click-to-toggle never double-fires.

### W4 — Launcher content in the popover
- New `packages/ui/src/components/shell/TrayLauncher.tsx` (+ story + tests): compact rows (icon + label) per `DESKTOP_VIEW_WINDOWS` entry plus "Open Eliza", rendered above the existing `WidgetHost slot="home"` stack in `TrayPopoverShell`.
- Rows dispatch the existing `tray-open-view-*` / `tray-show-window` ids through the same `TRAY_ACTION_EVENT` → `DesktopTrayRuntime` handling the native tray menu uses — **no new RPC**, same deduped windows.
- Boundary-respecting reuse: `@elizaos/ui` cannot import `@elizaos/app-core` (dependency direction), so the desktop host (`DesktopTrayRuntime`) registers the resolved, localized catalog into a small ui runtime store (`setDesktopLauncherEntries`) the component reads — single source of truth stays `tray-menu.ts`, zero duplication. Neutral rows; orange stays accent-only (ghost variant, no blue).

### W5 — Dockless macOS default
- `shouldStartTrayFirst` now defaults ON for darwin; kill switch `ELIZA_DESKTOP_TRAY_FIRST=0`. Unlike the old opt-in tray-first, the pill window is **still created at boot** — the pill is not a "main window" for Dock purposes.
- `syncTrayFirstDock` reworked to track the **set** of full/managed windows: `setMainWindowFullWindow()` (pill vs dashboard, from the shell presentation in `attachMainWindow`) + `setManagedWindowsPresent()` (hooked to `SurfaceWindowManager.onRegistryChanged`). Dock icon visible iff that set is non-empty: fresh launch = pill + menu-bar icon + no Dock icon; opening any full window reveals it; closing the last hides it.
- `desktop-experience-contract.test.ts`, `desktop-tray-config.test.ts` updated and a new `DesktopManager` dockless Dock-tracking suite added; `EB/docs/desktop-window-lifecycle.md` updated in the same PR.

## Verification

- `bun run --cwd packages/app-core/platforms/electrobun test` → **61 files / 447 tests passed** (includes new `tray-popover-position`, re-anchor, toggle-decision, dockless Dock-tracking tests + the UPDATED contract test). Re-run green after rebasing onto latest `origin/develop`.
- `bun run --cwd packages/ui test -- TrayLauncher` → 5/5 passed.
- `packages/app` `src/desktop-hotkey.test.ts` → 3/3 passed.
- Typecheck: `packages/app-core` clean; `packages/app-core/platforms/electrobun` clean; `packages/ui` has only the pre-existing `iwer` optional-module failure in an untouched spatial e2e fixture.
- `biome lint` clean on every touched file.
- `bun run --cwd packages/ui test -- App` passes except the pre-existing `App.screen-background-fuzz.test.tsx` worker-pool crash (reproduces identically on unmodified checkout — worktree resource flake, 0 assertions run).
- `audit:app`: not runnable in this shared agent worktree (renderer vite build blocker below); TrayLauncher renders only in the tray-popover shell mode, which the audit walker does not reach.

## Evidence (PR_EVIDENCE.md rows)

Artifacts: [`.github/issue-evidence/12184-desktop-pill-tray/`](../tree/feat/12184-desktop-pill-tray-phase1/.github/issue-evidence/12184-desktop-pill-tray) (README with per-item proof table + raw launch logs).

| Row | Status |
| --- | --- |
| Real-LLM trajectories | N/A - no agent/action/provider/prompt/model behavior change (window management + shell UI only) |
| Backend structured logs | Partial - real launch-attempt logs committed (`live-launch-attempts.log`); full-path logs blocked (below) |
| Frontend console/network logs | N/A - blocked: live desktop launch not possible from this worktree (below) |
| Before/after screenshots (desktop) | N/A - blocked (below); every behavioral default is pinned by unit/contract tests instead |
| Before/after screenshots (mobile) | N/A - desktop-only change |
| Video walkthrough | N/A - blocked (below) |
| Per-platform capture: macOS | N/A - blocked (below); flagged for pre-merge capture on a normal checkout |
| Per-platform capture: Windows | N/A - requires Phase 2 fork work (G3/G4) + non-mac hardware, per dossier D8 |
| Per-platform capture: Linux | N/A - requires Phase 2 fork work + non-mac hardware, per dossier D8 (tray is menu-only on Linux by platform constraint) |
| Audio walkthrough | N/A - no voice change |
| Domain artifacts | Test outputs above; no DB/chain artifacts in scope |

**Live-capture blocker (honest):** two real launch attempts on this Mac (`ELIZA_DESKTOP_SCREENSHOT_SERVER=1 bun run dev:desktop`, then `dev:desktop:watch`, then retry after a `lucide-react` symlink workaround). This isolated agent worktree shares the parent checkout's `node_modules`; per-package `node_modules` are empty, and after working around that, the renderer `vite build` fails inside the **parent tree's** stale `@elizaos/core` browser dist (`"Buffer" is not exported by "__vite-browser-external"` — parent is a different branch with concurrent agents; rebuilding its dist mid-flight was not safe). Raw logs are committed as evidence. The pill/popover/Dock behaviors that could not be photographed are each pinned by unit or contract tests.

## Phase 2/3 leftovers (out of scope here, per dossier)

- W6 macOS `ElectrobunPanel : NSPanel` (non-activating panel), W7 Carbon hotkeys, W8 Windows tray/flyout enablement — fork work in `upstreams/electrobun` + one version-bump PR (W9).
- W10 per-OS capture per PR_EVIDENCE, including the macOS `cursor-screenshot` set this PR could not produce.

Part of #12184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
