### PR TITLE
security(#12230): hosted-agents container hardening — image allowlist, fail-closed control-plane, run-spec caps

### DIFF
--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -26,6 +26,7 @@ import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quo
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { stripReservedElizaConfigKeys } from "@/lib/services/eliza-agent-config";
 import {
+  AgentImageNotAllowedError,
   AgentQuotaExceededError,
   elizaSandboxService,
 } from "@/lib/services/eliza-sandbox";
@@ -196,6 +197,14 @@ app.post("/", async (c) => {
           max: error.max,
         });
         return c.json(errorEnvelope(error.message), 429);
+      }
+      if (error instanceof AgentImageNotAllowedError) {
+        logger.warn("[compat] Agent creation blocked: image not allowed", {
+          orgId: user.organization_id,
+          image: error.image,
+          reason: error.reason,
+        });
+        return c.json(errorEnvelope(error.message), 403);
       }
       throw error;
     }

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -71,6 +71,19 @@ const enqueueAgentProvision = mock(async () => ({ id: "job-1" }));
 
 class AgentQuotaExceededError extends Error {}
 
+class AgentImageNotAllowedError extends Error {
+  readonly image: string;
+  readonly reason: "not_allowlisted" | "not_digest_pinned";
+  constructor(image: string, reason: "not_allowlisted" | "not_digest_pinned") {
+    super(
+      `Docker image '${image}' is not in the managed-agent image allowlist.`,
+    );
+    this.name = "AgentImageNotAllowedError";
+    this.image = image;
+    this.reason = reason;
+  }
+}
+
 mock.module("@/lib/auth/service-key-hono-worker", () => ({
   requireServiceKey,
   validateServiceKey: requireServiceKey,
@@ -111,6 +124,7 @@ mock.module("@/lib/services/characters/characters", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  AgentImageNotAllowedError,
   AgentQuotaExceededError,
   elizaSandboxService: {
     createAgent,
@@ -738,6 +752,51 @@ describe("service agent provisioning route", () => {
     expect(createCharacter).toHaveBeenCalledTimes(1);
     expect(deleteCharacter).toHaveBeenCalledWith("character-1");
     expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-allowlisted docker image with 403 (not 500) and cleans up the character", async () => {
+    createAgent.mockRejectedValueOnce(
+      new AgentImageNotAllowedError(
+        "registry.example.test/waifu-agent:latest",
+        "not_allowlisted",
+      ),
+    );
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Service-Key": "svc",
+        },
+        body: JSON.stringify({
+          tokenContractAddress: "0x0000000000000000000000000000000000000009",
+          chain: "bsc",
+          chainId: 56,
+          tokenName: "Waifu Smoke",
+          tokenTicker: "WSMOKE",
+          launchType: "native",
+          character: { name: "Smoke Agent" },
+          account: {
+            primaryWalletAddress: "0x0000000000000000000000000000000000000001",
+            chainType: "evm",
+          },
+          container: {
+            image: "registry.example.test/waifu-agent:latest",
+          },
+        }),
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      code: "agent_image_not_allowed",
+    });
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(deleteCharacter).toHaveBeenCalledWith("character-1");
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -17,6 +17,7 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import {
   failureResponse,
+  jsonError,
   ValidationError,
 } from "@/lib/api/cloud-worker-errors";
 import { toCompatStatus } from "@/lib/api/compat-envelope";
@@ -24,7 +25,10 @@ import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { insufficientCredits402 } from "@/lib/services/agent-billing-gate-402";
 import { charactersService } from "@/lib/services/characters/characters";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  AgentImageNotAllowedError,
+  elizaSandboxService,
+} from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
   checkProvisioningWorkerHealth,
@@ -581,6 +585,20 @@ app.post("/", async (c) => {
       202,
     );
   } catch (error) {
+    if (error instanceof AgentImageNotAllowedError) {
+      logger.warn("[service-api] Agent creation blocked: image not allowed", {
+        image: error.image,
+        reason: error.reason,
+      });
+      return jsonError(
+        c,
+        403,
+        error.message,
+        error.reason === "not_digest_pinned"
+          ? "agent_image_not_digest_pinned"
+          : "agent_image_not_allowed",
+      );
+    }
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/services/eliza-agent-config";
 import { prepareManagedElizaEnvironment } from "@/lib/services/eliza-managed-launch";
 import {
+  AgentImageNotAllowedError,
   AgentQuotaExceededError,
   elizaSandboxService,
 } from "@/lib/services/eliza-sandbox";
@@ -421,6 +422,20 @@ app.post("/", async (c) => {
         currentAgents: error.count,
         maxAgents: error.max,
       });
+    }
+    if (error instanceof AgentImageNotAllowedError) {
+      logger.warn("[agent-api] Agent creation blocked: image not allowed", {
+        orgId: user.organization_id,
+        image: error.image,
+        reason: error.reason,
+      });
+      throw new ApiError(
+        403,
+        error.reason === "not_digest_pinned"
+          ? "agent_image_not_digest_pinned"
+          : "agent_image_not_allowed",
+        error.message,
+      );
     }
     throw error;
   }

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { agentSandboxesRepository } from "@elizaos/cloud-shared/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@elizaos/cloud-shared/db/repositories/characters";
 import { dockerNodesRepository } from "@elizaos/cloud-shared/db/repositories/docker-nodes";
@@ -45,7 +46,7 @@ interface ForwardedAuth {
   organizationId: string;
 }
 
-const app = new Hono();
+export const app = new Hono();
 const client = getHetznerContainersClient();
 
 function errorStatus(error: unknown): number {
@@ -95,19 +96,49 @@ function requireForwardedAuth(c: Context): ForwardedAuth {
   return { userId, organizationId };
 }
 
+/**
+ * Constant-time string equality. Returns false on any length mismatch (that
+ * length leak is unavoidable and non-sensitive) without branching on content,
+ * so a token compare can't be timed byte-by-byte.
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * SECURITY (H4, #12230): fail CLOSED. The control-plane sidecar performs
+ * privileged, cross-tenant container mutations; when the shared internal token
+ * is unset the correct posture is "refuse everything" (503), NOT "allow
+ * everything" (the previous `if (expectedToken)` skipped auth entirely when the
+ * env was missing). The supplied-vs-expected compare is constant-time so the
+ * token can't be recovered by timing.
+ */
 function requireInternalToken(c: Context): void {
   const expectedToken = process.env.CONTAINER_CONTROL_PLANE_TOKEN?.trim();
-  if (expectedToken) {
-    const supplied = c.req.header("x-container-control-plane-token")?.trim();
-    if (supplied !== expectedToken) {
-      throw new Response(
-        JSON.stringify({ success: false, error: "Unauthorized" }),
-        {
-          status: 401,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    }
+  if (!expectedToken) {
+    logger.error(
+      "[container-control-plane] CONTAINER_CONTROL_PLANE_TOKEN unset — refusing request (fail-closed)",
+    );
+    throw new Response(
+      JSON.stringify({
+        success: false,
+        error: "Control-plane token not configured",
+      }),
+      {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+  const supplied = c.req.header("x-container-control-plane-token")?.trim();
+  if (!supplied || !timingSafeStringEqual(supplied, expectedToken)) {
+    throw new Response(JSON.stringify({ success: false, error: "Forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    });
   }
 }
 
@@ -1226,13 +1257,18 @@ const idleTimeout = Math.min(
     Number(process.env.CONTAINER_CONTROL_PLANE_IDLE_TIMEOUT_SECONDS ?? 255),
   ),
 );
-Bun.serve({
-  fetch: app.fetch,
-  hostname: process.env.HOST ?? "127.0.0.1",
-  idleTimeout,
-  port,
-});
+// Only bind a socket when this module is the process entrypoint. Importing it
+// (e.g. from an integration test that drives `app.fetch` directly) must NOT
+// start a listener.
+if (import.meta.main) {
+  Bun.serve({
+    fetch: app.fetch,
+    hostname: process.env.HOST ?? "127.0.0.1",
+    idleTimeout,
+    port,
+  });
 
-logger.info(
-  `[container-control-plane] listening on ${process.env.HOST ?? "127.0.0.1"}:${port}`,
-);
+  logger.info(
+    `[container-control-plane] listening on ${process.env.HOST ?? "127.0.0.1"}:${port}`,
+  );
+}

--- a/packages/cloud/services/container-control-plane/src/require-internal-token.test.ts
+++ b/packages/cloud/services/container-control-plane/src/require-internal-token.test.ts
@@ -1,0 +1,86 @@
+/**
+ * H4 (#12230): the container control-plane sidecar performs privileged,
+ * cross-tenant container mutations. Its internal-token gate must fail CLOSED:
+ *
+ *  - token UNSET  → refuse every request (503), never allow-all.
+ *  - token WRONG  → 403, via a CONSTANT-TIME compare (no byte-by-byte timing).
+ *
+ * Before this fix `requireInternalToken` only enforced the token
+ * `if (expectedToken)` and compared with `!==` — an unset env silently disabled
+ * auth entirely. These tests drive the REAL Hono app end to end through a
+ * `handleInternal`-wrapped route, so the gate is exercised exactly as in prod.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { app, timingSafeStringEqual } from "./index";
+
+const ROUTE = "/api/v1/cron/deployment-monitor";
+const HEADER = "x-container-control-plane-token";
+const savedToken = process.env.CONTAINER_CONTROL_PLANE_TOKEN;
+
+beforeEach(() => {
+  delete process.env.CONTAINER_CONTROL_PLANE_TOKEN;
+});
+afterEach(() => {
+  if (savedToken === undefined)
+    delete process.env.CONTAINER_CONTROL_PLANE_TOKEN;
+  else process.env.CONTAINER_CONTROL_PLANE_TOKEN = savedToken;
+});
+
+describe("requireInternalToken fails closed (H4)", () => {
+  test("unset token → 503 for every mutation (fail-closed)", async () => {
+    const res = await app.request(ROUTE, { method: "GET" });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("Control-plane token not configured");
+  });
+
+  test("unset token → 503 even when a token header is supplied", async () => {
+    const res = await app.request(ROUTE, {
+      method: "GET",
+      headers: { [HEADER]: "anything" },
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("wrong token → 403", async () => {
+    process.env.CONTAINER_CONTROL_PLANE_TOKEN = "the-real-secret";
+    const res = await app.request(ROUTE, {
+      method: "GET",
+      headers: { [HEADER]: "not-the-secret" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("missing token header when configured → 403", async () => {
+    process.env.CONTAINER_CONTROL_PLANE_TOKEN = "the-real-secret";
+    const res = await app.request(ROUTE, { method: "GET" });
+    expect(res.status).toBe(403);
+  });
+
+  test("a token that is a prefix of the real one → 403 (not a partial match)", async () => {
+    process.env.CONTAINER_CONTROL_PLANE_TOKEN = "the-real-secret";
+    const res = await app.request(ROUTE, {
+      method: "GET",
+      headers: { [HEADER]: "the-real" },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("timingSafeStringEqual", () => {
+  test("equal strings compare true", () => {
+    expect(timingSafeStringEqual("abc123", "abc123")).toBe(true);
+  });
+
+  test("different strings compare false", () => {
+    expect(timingSafeStringEqual("abc123", "abc124")).toBe(false);
+  });
+
+  test("length mismatch compares false without throwing", () => {
+    // node's timingSafeEqual throws on unequal-length buffers; the wrapper must
+    // guard that (returning false) instead of crashing.
+    expect(timingSafeStringEqual("abc", "abcdef")).toBe(false);
+    expect(timingSafeStringEqual("", "x")).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -20,6 +20,8 @@ export type ApiErrorCode =
   | "insufficient_credits"
   | "session_not_ready"
   | "agent_quota_exceeded"
+  | "agent_image_not_allowed"
+  | "agent_image_not_digest_pinned"
   | "internal_error";
 
 export interface ApiErrorOptions {

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -173,6 +173,41 @@ export const containersEnv = {
   },
 
   /**
+   * Allowlist of image refs/prefixes permitted for the MANAGED-AGENT lane
+   * (`POST /api/v1/eliza/agents` → `elizaSandboxService.createAgent`), enforced
+   * in the shared `createAgent` path so every route inherits it (H1, #12230).
+   *
+   * SECURITY: the managed-agent route accepts a caller-supplied `dockerImage`
+   * validated only by a permissive regex, then `docker pull`/`docker run`s it on
+   * the shared fleet. Without this gate any authenticated org could run an
+   * arbitrary image next to other tenants. This is that gate.
+   *
+   * DELIBERATELY SEPARATE from {@link codingContainerImageAllowlist}: managed
+   * agents ship ONLY the first-party runtime image, so the default is
+   * `ghcr.io/elizaos/*` and nothing else — NOT the coding lane's broader BYO set
+   * (`ghcr.io/dexploarer/*`, `ghcr.io/waifufun/*`). Operators widen via
+   * `AGENT_IMAGE_ALLOWLIST`.
+   *
+   * Format + matching rules are identical to the other allowlists
+   * (comma-separated glob prefixes; trailing `*` = prefix match; no `*` = exact;
+   * a bare `*` opts out). The call site ({@link isCodingContainerImageAllowed})
+   * is fail-closed, so an explicit empty env denies every managed-agent custom
+   * image rather than silently opening the gate.
+   */
+  agentImageAllowlist(): string[] {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.AGENT_IMAGE_ALLOWLIST, env.ELIZA_AGENT_IMAGE_ALLOWLIST);
+    if (raw === undefined) {
+      // First-party elizaOS runtime images only. Operators widen via env.
+      return ["ghcr.io/elizaos/*"];
+    }
+    return raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  },
+
+  /**
    * First-party TEMPLATE image stamped onto a template app (one created WITHOUT a
    * user repo) at create time, so create -> deploy resolves to a prebuilt,
    * allowlisted image instead of failing with "no image to deploy".

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -128,7 +128,7 @@ function baseRow(): AgentSandbox {
     bridge_port: null,
     web_ui_port: null,
     headscale_ip: null,
-    docker_image: "ghcr.io/example/agent:latest",
+    docker_image: "ghcr.io/elizaos/agent:latest",
     image_digest: null,
     previous_image_digest: null,
     previous_docker_image: null,
@@ -176,7 +176,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "alpha",
-      dockerImage: "ghcr.io/example/agent:latest",
+      dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
     expect(first.idempotent).toBe(false);
@@ -189,7 +189,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "alpha-retry",
-      dockerImage: "ghcr.io/example/agent:latest",
+      dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
     expect(second.idempotent).toBe(true);
@@ -209,7 +209,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_B,
       userId: USER,
       agentName: "beta",
-      dockerImage: "ghcr.io/example/agent:latest",
+      dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
     expect(res.idempotent).toBe(false);
@@ -228,7 +228,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "gamma",
-      dockerImage: "ghcr.io/example/agent:latest",
+      dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
     expect(res.idempotent).toBe(false);
@@ -258,7 +258,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
         organizationId: ORG_A,
         userId: USER,
         agentName: "no-reuse",
-        dockerImage: "ghcr.io/example/agent:latest",
+        dockerImage: "ghcr.io/elizaos/agent:latest",
       });
       expect(res.idempotent).toBe(false);
       expect(res.agent.id).toBe("repo-created");
@@ -283,7 +283,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
       organizationId: ORG_A,
       userId: USER,
       agentName: "forced-under-cap",
-      dockerImage: "ghcr.io/example/agent:latest",
+      dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: false,
       maxNonTerminalAgents: 5,
     });
@@ -319,7 +319,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
         organizationId: ORG_A,
         userId: USER,
         agentName: "forced-at-cap",
-        dockerImage: "ghcr.io/example/agent:latest",
+        dockerImage: "ghcr.io/elizaos/agent:latest",
         reuseExistingNonTerminal: false,
         maxNonTerminalAgents: 5,
       }),
@@ -345,7 +345,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
         organizationId: ORG_A,
         userId: USER,
         agentName: "waifu-launch",
-        dockerImage: "ghcr.io/example/agent:latest",
+        dockerImage: "ghcr.io/elizaos/agent:latest",
         reuseExistingNonTerminal: false,
         // maxNonTerminalAgents intentionally unset
       });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts
@@ -1,0 +1,123 @@
+/**
+ * H1 (#12230): the managed-agent lane must gate a caller-supplied `dockerImage`
+ * against the agent image allowlist BEFORE any DB write or `docker pull`.
+ *
+ * `POST /api/v1/eliza/agents` used to accept an arbitrary `dockerImage`
+ * (permissive regex only) and forward it straight to provisioning. The gate now
+ * lives in the SHARED `createAgent` path so every route inherits it. These tests
+ * drive the real gate (`assertAgentImageAllowed`) and the real `createAgent`
+ * reject path (which throws before touching the DB).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runWithCloudBindings } from "../runtime/cloud-bindings";
+import {
+  AgentImageNotAllowedError,
+  assertAgentImageAllowed,
+  elizaSandboxService,
+} from "./eliza-sandbox";
+
+describe("assertAgentImageAllowed (H1 gate)", () => {
+  test("no image → no-op (default first-party image used downstream)", () => {
+    runWithCloudBindings({}, () => {
+      expect(() => assertAgentImageAllowed(undefined)).not.toThrow();
+      expect(() => assertAgentImageAllowed("")).not.toThrow();
+    });
+  });
+
+  test("default allowlist permits the first-party elizaos namespace", () => {
+    runWithCloudBindings({}, () => {
+      expect(() => assertAgentImageAllowed("ghcr.io/elizaos/eliza:stable")).not.toThrow();
+    });
+  });
+
+  test("default allowlist rejects arbitrary third-party images", () => {
+    runWithCloudBindings({}, () => {
+      expect(() => assertAgentImageAllowed("docker.io/library/nginx:latest")).toThrow(
+        AgentImageNotAllowedError,
+      );
+      expect(() => assertAgentImageAllowed("ghcr.io/attacker/evil:latest")).toThrow(
+        AgentImageNotAllowedError,
+      );
+    });
+  });
+
+  test("default allowlist does NOT inherit the coding lane's BYO namespaces", () => {
+    // The coding-container allowlist includes dexploarer/waifufun; the managed
+    // agent lane must NOT — it ships only the first-party runtime image.
+    runWithCloudBindings({}, () => {
+      expect(() => assertAgentImageAllowed("ghcr.io/dexploarer/bnancy:latest")).toThrow(
+        AgentImageNotAllowedError,
+      );
+      expect(() => assertAgentImageAllowed("ghcr.io/waifufun/runner:v2")).toThrow(
+        AgentImageNotAllowedError,
+      );
+    });
+  });
+
+  test("operator env override widens the allowlist", () => {
+    runWithCloudBindings({ AGENT_IMAGE_ALLOWLIST: "ghcr.io/approved/*" }, () => {
+      expect(() => assertAgentImageAllowed("ghcr.io/approved/thing:1")).not.toThrow();
+      // The default elizaos entry is REPLACED, not merged, by an explicit env.
+      expect(() => assertAgentImageAllowed("ghcr.io/elizaos/eliza:stable")).toThrow(
+        AgentImageNotAllowedError,
+      );
+    });
+  });
+
+  test("an explicit all-empty-entries env denies every image (fail-closed)", () => {
+    // A configured-but-empty allowlist (only separators) parses to `[]`, and
+    // `isCodingContainerImageAllowed([])` is fail-closed — nothing is permitted,
+    // not even the first-party image.
+    runWithCloudBindings({ AGENT_IMAGE_ALLOWLIST: " , , " }, () => {
+      expect(() => assertAgentImageAllowed("ghcr.io/elizaos/eliza:stable")).toThrow(
+        AgentImageNotAllowedError,
+      );
+    });
+  });
+
+  test("digest-pin gate rejects a mutable tag when armed", () => {
+    runWithCloudBindings(
+      {
+        CONTAINER_IMAGE_REQUIRE_DIGEST: "true",
+      },
+      () => {
+        let thrown: unknown;
+        try {
+          assertAgentImageAllowed("ghcr.io/elizaos/eliza:latest");
+        } catch (e) {
+          thrown = e;
+        }
+        expect(thrown).toBeInstanceOf(AgentImageNotAllowedError);
+        expect((thrown as AgentImageNotAllowedError).reason).toBe("not_digest_pinned");
+      },
+    );
+  });
+
+  test("digest-pin gate accepts a fully pinned digest when armed", () => {
+    const pinned = `ghcr.io/elizaos/eliza@sha256:${"a".repeat(64)}`;
+    runWithCloudBindings({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, () => {
+      expect(() => assertAgentImageAllowed(pinned)).not.toThrow();
+    });
+  });
+});
+
+describe("createAgent rejects a non-allowlisted image before provisioning (H1)", () => {
+  test("throws AgentImageNotAllowedError and never reaches the DB", async () => {
+    // The gate is the FIRST statement in createAgent, so a non-allowlisted image
+    // rejects before any encryption / DB transaction. A rejection here therefore
+    // proves nothing was provisioned. If the gate were missing this call would
+    // instead fail deep in the DB layer (a different error), so the assertion on
+    // the error TYPE is load-bearing.
+    await runWithCloudBindings({}, async () => {
+      await expect(
+        elizaSandboxService.createAgent({
+          organizationId: "11111111-1111-1111-1111-111111111111",
+          userId: "22222222-2222-2222-2222-222222222222",
+          agentName: "evil",
+          dockerImage: "docker.io/library/nginx:latest",
+        }),
+      ).rejects.toBeInstanceOf(AgentImageNotAllowedError);
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -29,6 +29,7 @@ import {
   type NewAgentSandboxBackup,
 } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
+import { containersEnv } from "../config/containers-env";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
@@ -52,6 +53,7 @@ import {
 } from "./ai-billing";
 import { aiBillingRecordsService } from "./ai-billing-records";
 import { apiKeysService } from "./api-keys";
+import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import {
@@ -148,6 +150,52 @@ export class AgentQuotaExceededError extends Error {
     this.name = "AgentQuotaExceededError";
     this.count = count;
     this.max = max;
+  }
+}
+
+/**
+ * Thrown by createAgent when a caller-supplied `dockerImage` is not permitted by
+ * the managed-agent image allowlist, or (when the digest-pin gate is armed) is
+ * not pinned to a full sha256 digest (H1, #12230). Throwing here — before ANY
+ * DB write or `docker pull` — is what makes the gate fail-closed across every
+ * route that reaches createAgent, not just `POST /api/v1/eliza/agents`.
+ */
+export class AgentImageNotAllowedError extends Error {
+  readonly image: string;
+  readonly reason: "not_allowlisted" | "not_digest_pinned";
+  constructor(image: string, reason: "not_allowlisted" | "not_digest_pinned") {
+    super(
+      reason === "not_digest_pinned"
+        ? `Docker image '${image}' must be pinned to a full sha256 digest (e.g. ghcr.io/org/repo@sha256:<64 hex>).`
+        : `Docker image '${image}' is not in the managed-agent image allowlist.`,
+    );
+    this.name = "AgentImageNotAllowedError";
+    this.image = image;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Fail-closed gate for a caller-supplied managed-agent `dockerImage` (H1,
+ * #12230). No image → the default first-party runtime image is used downstream,
+ * nothing to gate. A supplied image must be on {@link
+ * containersEnv.agentImageAllowlist} and, when the digest-pin gate is armed,
+ * content-addressed. Throws {@link AgentImageNotAllowedError} otherwise.
+ */
+export function assertAgentImageAllowed(dockerImage: string | undefined): void {
+  if (!dockerImage) return;
+  const allowlist = containersEnv.agentImageAllowlist();
+  if (!isCodingContainerImageAllowed(dockerImage, allowlist)) {
+    logger.warn("[agent-sandbox] docker image rejected by allowlist", {
+      image: dockerImage,
+    });
+    throw new AgentImageNotAllowedError(dockerImage, "not_allowlisted");
+  }
+  if (imageRequiresDigestPin(dockerImage, containersEnv.requireDigestPinnedImages())) {
+    logger.warn("[agent-sandbox] docker image rejected: digest pin required", {
+      image: dockerImage,
+    });
+    throw new AgentImageNotAllowedError(dockerImage, "not_digest_pinned");
   }
 }
 
@@ -711,6 +759,13 @@ export class ElizaSandboxService {
     agent: AgentSandbox;
     idempotent: boolean;
   }> {
+    // SECURITY (H1, #12230): gate a caller-supplied image against the managed-
+    // agent allowlist BEFORE any DB write or provisioning. Throws
+    // AgentImageNotAllowedError (→ 4xx at the route) so a non-allowlisted image
+    // provisions nothing. Runs for EVERY createAgent caller — the gate lives in
+    // the shared service path, not per-route.
+    assertAgentImageAllowed(params.dockerImage);
+
     logger.info("[agent-sandbox] Creating agent", {
       orgId: params.organizationId,
       name: params.agentName,


### PR DESCRIPTION
Remediation for the **hosted/managed-agent container infrastructure** surface of the #12183 security review (sub-issue #12230 — the only cross-tenant / host-escape sub-issue). Focus was the clearly-correct, testable high-value items: **H1** and **H4** fully; **H2** implemented but flagged for live-container verification. H3 and the M-items are deferred (see below).

## What changed

| id | file:line | what changed | test |
|----|-----------|--------------|------|
| **H1** | `cloud/shared/src/lib/services/eliza-sandbox.ts` (top of `createAgent`), `containers-env.ts` (`agentImageAllowlist`), `cloud/api/v1/eliza/agents/route.ts` (403 mapping) | The managed-agent lane now gates a caller-supplied `dockerImage` against an image allowlist **in the shared `createAgent` path** (so every route — `/v1/eliza/agents`, the waifu `/v1/agents` launch, compat — inherits it), **before any DB write or `docker pull`**. Default allowlist is `ghcr.io/elizaos/*` only (deliberately NOT the coding lane's broader `dexploarer`/`waifufun` BYO set); operators widen via `AGENT_IMAGE_ALLOWLIST`. When the digest-pin gate (`CONTAINER_IMAGE_REQUIRE_DIGEST`) is armed, a custom image must also be `@sha256:`-pinned. Non-allowlisted → `403 agent_image_not_allowed`, provisions nothing. Coding-container path (`createCodingContainerAgent`) is untouched. | `eliza-sandbox-image-allowlist.test.ts` (9) — real gate + real `createAgent` reject-before-DB |
| **H4** | `cloud/services/container-control-plane/src/index.ts:119` | `requireInternalToken` now **fails closed**: when `CONTAINER_CONTROL_PLANE_TOKEN` is unset the sidecar `503`s every request (was: `if (expectedToken)` → auth skipped entirely = allow-all). The supplied-vs-expected compare is now **constant-time** (`crypto.timingSafeEqual` via a length-guarded wrapper) instead of `!==`; mismatch/missing header → `403`. | `require-internal-token.test.ts` (8) — drives the real Hono app end-to-end: unset→503, wrong→403, prefix→403, plus comparator unit tests |
| **H2** | `docker-sandbox-provider.ts:~1265`, `containers/hetzner-client/client.ts:~266` | Both agent-lane `docker create` specs now emit `--cap-drop=ALL`, `--security-opt no-new-privileges`, `--pids-limit` via the existing hardened `buildAppContainerSecurityFlags()`. `--cap-drop=ALL` is computed before the headscale `--cap-add=NET_ADMIN`, so the tunnel cap is still re-granted. | build/typecheck/lint only — **not** claimed as done; needs live `docker inspect` (see deferred) |

Supporting: `cloud-worker-errors.ts` adds the two new `ApiErrorCode`s; one existing test fixture (`eliza-sandbox-create-idempotency.test.ts`) that used a non-allowlisted placeholder image (`ghcr.io/example/agent`) was updated to an allowlisted namespace (`ghcr.io/elizaos/agent`) — those tests cover quota/idempotency, not image gating, and don't assert on the image string.

## Items deferred / not done

- **H2 (implemented, unverified)** — the run-spec flags are in the code but I have no live Docker node to confirm the managed agent image still boots under `--cap-drop=ALL` + `no-new-privileges`. **A reviewer with a scratch node must create a real agent container and confirm boot + `docker inspect` shows `CapDrop:[ALL]`, `SecurityOpt:[no-new-privileges]`, non-zero `PidsLimit` before merge-to-prod.** I did NOT add `--cpus`/`--read-only`/userns-remap (spec's "always") to avoid guessing values that could break boot.
- **H3 (network isolation) — NOT implemented.** Moving the agent lane to an `--internal` network + `127.0.0.1` publish is unsafe without the apps-lane egress proxy (M9): an `--internal` net with no egress proxy would cut the agent off from cloud-API/inference and break boot. This is a coupled H3+M9 change that needs the egress-proxy infra stood up and live verification. Deferred to avoid shipping a boot-breaking change.
- **M2, M8, M9, M10, L10** — out of scope for this pass (per-node SSH keys, per-node bootstrap tokens, agent-lane egress default-deny, remote-runner env minimization, agent-server timing-safe compare). Each needs its own change + infra verification.

## Verification (commands + results)

```
bun test packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts   → 9 pass / 0 fail
bun test packages/cloud/services/container-control-plane/src/require-internal-token.test.ts → 8 pass / 0 fail
bun test .../eliza-sandbox-create-idempotency.test.ts .../eliza-sandbox-coding-container-quota.test.ts .../coding-containers.test.ts → 0 fail
bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts → 52 pass / 0 fail
bun run --cwd packages/cloud/shared typecheck   → clean (touched files)
bun run --cwd packages/cloud/services/container-control-plane typecheck → clean
bun run --cwd packages/cloud/api typecheck → clean (touched route)
biome check (10 touched files) → clean
```

Live-container evidence (H2 `docker inspect`, H3 cross-tenant probe) is **N/A in this worktree** — no Docker fleet reachable. H1 rejection and H4 fail-closed are proven by the real-path tests above (H1 rejects before any DB/`docker pull`; H4 drives the real control-plane Hono app).

Refs #12230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
