### PR TITLE
refactor(shared): type background apply event

### DIFF
--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -112,6 +112,35 @@ export function dispatchNavigateViewEvent(detail: NavigateViewDetail): void {
   window.dispatchEvent(createNavigateViewEvent(detail));
 }
 
+// ── View event bus ──────────────────────────────────────────────────────
+export const BACKGROUND_APPLY_EVENT = "background:apply" as const;
+
+/** Operation carried by a {@link BACKGROUND_APPLY_EVENT} payload. */
+export type BackgroundApplyOp = "set" | "undo" | "redo" | "reset";
+
+/** Tunable GLSL uniform patch the BACKGROUND action can send to the renderer. */
+export interface BackgroundShaderUniformPatch {
+  u_speed?: number;
+  u_scale?: number;
+  u_intensity?: number;
+  u_seed?: number;
+}
+
+/** Payload broadcast on {@link BACKGROUND_APPLY_EVENT}. */
+export interface BackgroundApplyPayload extends Record<string, unknown> {
+  op: BackgroundApplyOp;
+  /** "shader" (color field), "image" (cover image), or "glsl" (programmable shader). */
+  mode?: "shader" | "image" | "glsl";
+  /** 6-digit hex for shader/glsl mode. */
+  color?: string;
+  /** Same-origin image URL (`/api/media/...`) for image mode. */
+  imageUrl?: string;
+  /** Named GLSL preset id; the renderer resolves this to source. */
+  presetId?: string;
+  /** Uniform patch for glsl mode. */
+  uniforms?: BackgroundShaderUniformPatch;
+}
+
 // ── Avatar / VRM ─────────────────────────────────────────────────────────
 export const VRM_TELEPORT_COMPLETE_EVENT =
   "eliza:vrm-teleport-complete" as const;

--- a/packages/shared/src/views/view-interact-protocol.test.ts
+++ b/packages/shared/src/views/view-interact-protocol.test.ts
@@ -39,7 +39,9 @@ describe("view-interact protocol contract", () => {
   });
 
   it("keeps the standard and agent-surface capability id sets disjoint", () => {
-    const standard = new Set(Object.values(STANDARD_CAPABILITIES));
+    const standard: ReadonlySet<string> = new Set(
+      Object.values(STANDARD_CAPABILITIES),
+    );
     for (const id of AGENT_SURFACE_CAPABILITY_IDS) {
       expect(standard.has(id)).toBe(false);
     }

--- a/packages/ui/src/backgrounds/index.ts
+++ b/packages/ui/src/backgrounds/index.ts
@@ -31,5 +31,6 @@ export { SKY_BACKGROUND_COLOR, SOLID_BACKGROUND_CSS } from "./types";
 export {
   BACKGROUND_APPLY_EVENT,
   type BackgroundApplyOp,
+  type BackgroundApplyPayload,
   useBackgroundApplyChannel,
 } from "./useBackgroundApplyChannel";

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { BACKGROUND_APPLY_EVENT as SHARED_BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __setAppValueForTests } from "../state/app-store";
@@ -54,6 +55,10 @@ void main(){
 }`;
 
 describe("useBackgroundApplyChannel — raw GLSL source is not a sink (#11088)", () => {
+  it("uses the shared background apply event contract", () => {
+    expect(BACKGROUND_APPLY_EVENT).toBe(SHARED_BACKGROUND_APPLY_EVENT);
+  });
+
   it("sanity: the for-bomb slips past the static gate (why the channel must drop it)", () => {
     expect(isPlausibleFragmentSource(FOR_BOMB)).toBe(true);
   });

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
@@ -13,6 +13,10 @@
  * works from anywhere, not only on the Background view.
  */
 
+import {
+  BACKGROUND_APPLY_EVENT,
+  type BackgroundApplyPayload,
+} from "@elizaos/shared/events";
 import { useViewEvent } from "../hooks/useViewEvent";
 import {
   DEFAULT_BACKGROUND_COLOR,
@@ -27,12 +31,11 @@ import {
   type ShaderUniformValues,
 } from "./shader-schema";
 
-/** View-event type the BACKGROUND action broadcasts. Keep in sync with the
- * literal used in `plugins/plugin-app-control/src/actions/background.ts`. */
-export const BACKGROUND_APPLY_EVENT = "background:apply";
-
-/** Operation carried by a `background:apply` event payload. */
-export type BackgroundApplyOp = "set" | "undo" | "redo" | "reset";
+export type {
+  BackgroundApplyOp,
+  BackgroundApplyPayload,
+} from "@elizaos/shared/events";
+export { BACKGROUND_APPLY_EVENT };
 
 /** Pull a Partial<ShaderUniformValues> out of an untrusted payload field. */
 function readUniformPatch(
@@ -56,7 +59,7 @@ export function useBackgroundApplyChannel(): void {
   } = useBackgroundConfig();
 
   useViewEvent(BACKGROUND_APPLY_EVENT, (event) => {
-    const payload = event.payload;
+    const payload = event.payload as BackgroundApplyPayload;
     const op = typeof payload.op === "string" ? payload.op : "set";
 
     if (op === "undo") {

--- a/packages/ui/src/components/pages/__e2e__/background-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/background-fixture.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { AppBackground } from "../../../backgrounds/AppBackground";
 import {
   applyBackgroundRedo,
@@ -128,7 +129,7 @@ function Harness(): React.JSX.Element {
 
   useLayoutEffect(() => {
     (window as Win).__emitBgApply = (payload) =>
-      emitViewEvent("background:apply", payload, "agent");
+      emitViewEvent(BACKGROUND_APPLY_EVENT, payload, "agent");
   }, []);
 
   const onFile = useCallback(

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -1,6 +1,8 @@
 import type { IAgentRuntime, Media, Memory } from "@elizaos/core";
+import { BACKGROUND_APPLY_EVENT as SHARED_BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { describe, expect, it, vi } from "vitest";
 import {
+	BACKGROUND_APPLY_EVENT,
 	type BackgroundApplyPayload,
 	createBackgroundAction,
 	inferBackgroundPlan,
@@ -292,6 +294,10 @@ describe("programmable GLSL shader plan (#10694)", () => {
 });
 
 describe("BACKGROUND action handler", () => {
+	it("uses the shared background apply event contract", () => {
+		expect(BACKGROUND_APPLY_EVENT).toBe(SHARED_BACKGROUND_APPLY_EVENT);
+	});
+
 	function setup() {
 		const emitted: BackgroundApplyPayload[] = [];
 		const replies: string[] = [];

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -9,13 +9,14 @@
  * SAME `BackgroundConfig` the Background view and the always-mounted
  * `AppBackground` layer share — there is no second "homescreen scene" surface.
  * The action stays thin (rule 4): it resolves the intent, optionally generates
- * an image via the existing media route, and broadcasts ONE `background:apply`
+ * an image via the existing media route, and broadcasts ONE background apply
  * view event. The renderer's single subscriber (`useBackgroundApplyChannel` in
  * `@elizaos/ui`) applies it to the persisted store and maintains undo history.
  *
- * Delivery: `POST /api/views/events/broadcast { type: "background:apply" }` →
- * WS `view:event` → `emitViewEvent` → `useViewEvent("background:apply")`. Unlike
- * a per-view edit, the background applies globally, so this works from any view.
+ * Delivery: `POST /api/views/events/broadcast { type: BACKGROUND_APPLY_EVENT }` →
+ * WS `view:event` → `emitViewEvent` →
+ * `useViewEvent(BACKGROUND_APPLY_EVENT)`. Unlike a per-view edit, the background
+ * applies globally, so this works from any view.
  */
 
 import {
@@ -28,39 +29,23 @@ import {
 	type Memory,
 	type State,
 } from "@elizaos/core";
+import type {
+	BackgroundApplyPayload,
+	BackgroundShaderUniformPatch,
+} from "@elizaos/shared/events";
+import { BACKGROUND_APPLY_EVENT } from "@elizaos/shared/events";
 import { normalizeActionOptions, readStringOption } from "../params.js";
 
-/** Operation carried by the `background:apply` event. */
-export type BackgroundApplyOp = "set" | "undo" | "redo" | "reset";
+export type {
+	BackgroundApplyOp,
+	BackgroundApplyPayload,
+} from "@elizaos/shared/events";
+export { BACKGROUND_APPLY_EVENT };
 
 /** Tunable GLSL uniform patch the agent can drive (#10694). The GLSL source
  * itself lives in `@elizaos/ui` — the action only names a preset id + uniforms;
  * the renderer resolves id → source and validates it. */
-export interface ShaderUniformPatch {
-	u_speed?: number;
-	u_scale?: number;
-	u_intensity?: number;
-	u_seed?: number;
-}
-
-/**
- * Payload broadcast to the renderer. Mirrors the contract consumed by
- * `useBackgroundApplyChannel` in `@elizaos/ui` — keep the two in sync.
- */
-export interface BackgroundApplyPayload {
-	op: BackgroundApplyOp;
-	/** "shader" (color field), "image" (cover image), or "glsl" (programmable
-	 * shader). Omitted for undo/redo/reset. */
-	mode?: "shader" | "image" | "glsl";
-	/** 6-digit hex for shader/glsl mode. */
-	color?: string;
-	/** Same-origin image URL (`/api/media/…`) for image mode. */
-	imageUrl?: string;
-	/** Named GLSL preset id (renderer resolves → source) for glsl mode. */
-	presetId?: string;
-	/** Uniform patch for glsl mode (named preset set or a live-shader tweak). */
-	uniforms?: ShaderUniformPatch;
-}
+export type ShaderUniformPatch = BackgroundShaderUniformPatch;
 
 /** The resolved plan for one BACKGROUND invocation. */
 type BackgroundPlan =
@@ -440,7 +425,7 @@ async function defaultEmit(payload: BackgroundApplyPayload): Promise<void> {
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ type: "background:apply", payload }),
+			body: JSON.stringify({ type: BACKGROUND_APPLY_EVENT, payload }),
 			signal: AbortSignal.timeout(5_000),
 		},
 	);


### PR DESCRIPTION
## Summary

Addresses #12093 item 11.

Centralizes the `background:apply` view-event contract in `@elizaos/shared/events` and has both the UI background channel and `plugin-app-control` consume the shared constant/payload types. This removes the duplicated string/type declarations while preserving existing UI/plugin exports for callers.

## Changes

- Added `BACKGROUND_APPLY_EVENT`, `BackgroundApplyPayload`, `BackgroundApplyOp`, and shader uniform patch typing to `packages/shared/src/events/index.ts`.
- Updated `packages/ui` background channel, fixture, and exports to use the shared contract.
- Updated `plugin-app-control` background action/tests to use the shared event constant and payload types while keeping compatibility re-exports.
- Added assertions that UI/plugin event constants match the shared declaration.

## Validation

- Synced with `develop` via repeated `git fetch origin develop && git rebase origin/develop`; final pushed commit: `7c34d2854fb`.
- `bun install --frozen-lockfile --ignore-scripts` (no changes)
- `git diff --check origin/develop...HEAD`
- Literal scan: only `packages/shared/src/events/index.ts` declares `"background:apply"` in the touched shared/UI/plugin-app-control source paths.
- `bunx @biomejs/biome check packages/shared/src/events/index.ts packages/ui/src/backgrounds/index.ts packages/ui/src/backgrounds/useBackgroundApplyChannel.ts packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx packages/ui/src/components/pages/__e2e__/background-fixture.tsx plugins/plugin-app-control/src/actions/background.ts plugins/plugin-app-control/src/actions/background.test.ts`
- `bun run --cwd packages/ui test src/backgrounds/useBackgroundApplyChannel.test.tsx` (7 passed)
- `bun run --cwd plugins/plugin-app-control test src/actions/background.test.ts` (38 passed)
- `bun run --cwd packages/shared typecheck && bun run --cwd packages/shared build:dist`
- `bun run --cwd packages/ui typecheck && bun run --cwd packages/ui build`
- `bun run --cwd plugins/plugin-app-control typecheck && bun run --cwd plugins/plugin-app-control build`
- `bun run --cwd packages/app audit:app` on the rebased tree after the UI/app base updates: 373 passed; `broken=0`, `needs-work=0`, `needs-eyeball=23`, `good=349`, `hover-probe-failures=12`, `density-probe-failures=0`. The 12 hover probe failures are unchanged unrelated timeouts for `builtin-character`, `builtin-character-select`, and `builtin-transcripts` buttons. `builtin-background` passed mobile portrait, mobile landscape, desktop landscape, and iPad portrait.
- Manually reviewed `packages/app/aesthetic-audit-output/*/builtin-background.png`; background controls are centered and composer placement is clear on desktop, mobile portrait, mobile landscape, and iPad portrait.

## Known validation gap

- `NODE_OPTIONS="--max-old-space-size=8192" bun run --cwd packages/ui test src/App.screen-background-fuzz.test.tsx` still fails before executing tests with a Vitest worker JavaScript heap OOM. The focused background channel test and full app audit above cover the changed contract path.

## Evidence applicability

- Real LLM trajectories: N/A - no prompt/model/action decision behavior changed.
- Backend logs: N/A - no server request path changed.
- Frontend logs/network: covered by `audit:app` console/page error checks for `builtin-background` (0 errors).
- Screenshots/video: background screenshots were generated by `audit:app` and manually reviewed; no visual redesign or user-facing flow video required for this type-only event-contract consolidation.
