### PR TITLE
refactor(ui): single-source AOSP native-OS view-id gates (#12092 item 6, partial + blocker)

### DIFF
--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -28,7 +28,7 @@ import {
   resolveViewKind,
 } from "@elizaos/core";
 import type { ViewEntry } from "../../hooks/view-catalog";
-import { pathForTab } from "../../navigation";
+import { LAUNCHER_AOSP_ONLY_VIEW_IDS, pathForTab } from "../../navigation";
 
 /** Everyday apps, in display order. They lead the single launcher page; other
  *  loaded apps append after (alphabetically). */
@@ -78,15 +78,12 @@ export const LAUNCHER_PREVIEW_IDS: ReadonlySet<string> = new Set([
 /**
  * Native-OS surfaces that only belong on the AOSP ElizaOS fork. Appended to the
  * end of the launcher page when the AOSP shell is active; hidden on web,
- * desktop, iOS, and stock Play-Store Android.
+ * desktop, iOS, and stock Play-Store Android. Sourced from the canonical
+ * `LAUNCHER_AOSP_ONLY_VIEW_IDS` in `../../navigation` so this launcher gate and
+ * the router-level `NATIVE_OS_VIEW_IDS` filter never drift.
  */
-export const LAUNCHER_AOSP_ONLY_IDS: readonly string[] = [
-  "phone",
-  "messages",
-  "contacts",
-  "camera",
-  "files",
-];
+export const LAUNCHER_AOSP_ONLY_IDS: readonly string[] =
+  LAUNCHER_AOSP_ONLY_VIEW_IDS;
 
 /**
  * Views that never appear in the launcher grid:

--- a/packages/ui/src/hooks/useAvailableViews.ts
+++ b/packages/ui/src/hooks/useAvailableViews.ts
@@ -24,6 +24,7 @@ import {
 import {
   type BuiltinTab,
   isAospShellEnabled,
+  NATIVE_OS_VIEW_IDS,
   TAB_PATHS,
   titleForTab,
 } from "../navigation";
@@ -115,16 +116,12 @@ interface UseAvailableViewsOptions {
 const POLL_INTERVAL_MS = 30_000;
 
 /**
- * Native device-OS surfaces that only exist on the AOSP ElizaOS fork. They are
- * stripped from the routable view set on every other build (web, desktop, iOS,
- * stock Play-Store Android).
+ * Native device-OS surfaces that only exist on the AOSP ElizaOS fork, as a set
+ * for O(1) filtering. The id list is the canonical `NATIVE_OS_VIEW_IDS` in
+ * `../navigation`; they are stripped from the routable view set on every other
+ * build (web, desktop, iOS, stock Play-Store Android).
  */
-const NATIVE_OS_VIEW_IDS: ReadonlySet<string> = new Set([
-  "phone",
-  "messages",
-  "contacts",
-  "camera",
-]);
+const NATIVE_OS_VIEW_ID_SET: ReadonlySet<string> = new Set(NATIVE_OS_VIEW_IDS);
 
 async function fetchViewList(
   viewType?: "gui" | "tui" | "xr",
@@ -422,7 +419,7 @@ export function useAvailableViews(
     // else — web, desktop, iOS, and stock Play-Store Android — matching the
     // AOSP-gated home tiles (`nativeOs`) and the route gates in App.tsx.
     if (isAospShellEnabled()) return merged;
-    return merged.filter((view) => !NATIVE_OS_VIEW_IDS.has(view.id));
+    return merged.filter((view) => !NATIVE_OS_VIEW_ID_SET.has(view.id));
   }, [networkViews, appShellViews]);
 
   return {

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -163,6 +163,36 @@ export function isAospShellEnabled(
   );
 }
 
+/**
+ * The AOSP-ElizaOS-fork-only native device-OS surfaces (dialer, SMS, contacts,
+ * camera). They are gated to the fork via {@link isAospShellEnabled} everywhere
+ * they appear, so this is the single source of truth those gates read instead of
+ * each redeclaring the id set (which let the router filter and the launcher
+ * curation drift). Consumers:
+ *  - `useAvailableViews` strips these from the routable view set + view manager
+ *    on every non-fork build.
+ *  - `launcher-curation` appends {@link LAUNCHER_AOSP_ONLY_VIEW_IDS} to the
+ *    launcher only on the fork.
+ *  - `App.tsx` route gates (`renderPhoneSurface`) mount their pages only on the
+ *    fork.
+ */
+export const NATIVE_OS_VIEW_IDS = [
+  "phone",
+  "messages",
+  "contacts",
+  "camera",
+] as const;
+
+/**
+ * Native-OS launcher tiles: the routable native-OS surfaces plus Files — a
+ * cross-platform view (`/apps/files`) that stays routable everywhere but is only
+ * surfaced as a launcher tile on the fork.
+ */
+export const LAUNCHER_AOSP_ONLY_VIEW_IDS = [
+  ...NATIVE_OS_VIEW_IDS,
+  "files",
+] as const;
+
 interface WindowNavigationLocation {
   protocol: string;
   search: string;


### PR DESCRIPTION
## #12092 item 6 [P1][L] — AOSP apps baked into shared UI, stripped via id lists

**Partial: the safe dedup + a documented architectural blocker for the full extraction.**

### Delivered
Consolidated the duplicate AOSP view-id gate declarations into one canonical source (`packages/ui/src/navigation/index.ts`): `NATIVE_OS_VIEW_IDS` + `LAUNCHER_AOSP_ONLY_VIEW_IDS`. `useAvailableViews.ts` + `launcher-curation.ts` import it (export name preserved). Byte-identical sets; 46 tests pass.

### Why full extraction is blocked (finding for the AOSP owner)
1. **No build-time AOSP variant** — AOSP is runtime user-agent detection; the fork + stock Android build from the same Capacitor bundle. A plugin ships to all builds, so extraction wouldn't remove the code from any native bundle — runtime gating stays the only mechanism.
2. Live routes mount the trunk components directly; the `registerAppShellPage` path changes the native mount surface (needs on-device AOSP verification).
3. Strip lists also cover camera + files (out of scope); `plugin-phone/-messages/-contacts` already register *parallel* overlay components via a different registry — reconciling is a large on-device migration.

## Verification
ui tsc 0 errors; launcher-curation + useAvailableViews + HomeScreen 46 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)