### PR TITLE
fix(core): bot-ness is context, not special handling — uniform addressing gate (#9874)

### DIFF
--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -87,6 +87,80 @@ describe("formatMessages", () => {
 		expect(rendered).not.toContain("reacted-to message in full");
 	});
 
+	it("tags a bot sender's name with (bot) so the model knows the participant is a bot", () => {
+		// Bot-ness surfaced as plain transcript context — what the agent KNOWS about
+		// a participant — not a behavioral branch. A message stamped fromBot at
+		// ingestion renders the speaker as "Name (bot)".
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000031" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000003" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: { text: "hey AgentC, can you deploy the site" },
+					metadata: { fromBot: true },
+				} as Memory,
+			],
+			entities: [
+				{
+					id: "00000000-0000-0000-0000-000000000003" as UUID,
+					names: ["OtherBot"],
+				} as never,
+			],
+		});
+
+		expect(rendered).toContain("OtherBot (bot):");
+	});
+
+	it("also reads fromBot from content.metadata (connector stamps either shape)", () => {
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000033" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000005" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: {
+						text: "status: queue drained",
+						metadata: { fromBot: true },
+					},
+				} as Memory,
+			],
+			entities: [
+				{
+					id: "00000000-0000-0000-0000-000000000005" as UUID,
+					names: ["RelayBot"],
+				} as never,
+			],
+		});
+
+		expect(rendered).toContain("RelayBot (bot):");
+	});
+
+	it("does NOT tag a human sender's name with (bot)", () => {
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000032" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000004" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: { text: "can you deploy the site" },
+				} as Memory,
+			],
+			entities: [
+				{
+					id: "00000000-0000-0000-0000-000000000004" as UUID,
+					names: ["Alice"],
+				} as never,
+			],
+		});
+
+		expect(rendered).toContain("Alice:");
+		expect(rendered).not.toContain("(bot)");
+	});
+
 	it("advertises a stored-content read when readable text is stored", () => {
 		const rendered = formatMessages({
 			messages: [

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
-import { addresseeIsNonOwnerBot } from "../addressed-to.ts";
+import { messageAddressedToOtherParticipant } from "../addressed-to.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
-const BOT_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const OTHER_BOT = "00000000-0000-0000-0000-0000000000bb" as UUID;
 const HUMAN_X = "00000000-0000-0000-0000-0000000000cc" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-000000000001" as UUID;
 const SENDER_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
@@ -12,7 +12,6 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
 	return {
 		agentId: AGENT_ID,
 		character: { name: "MyAgent" },
-		getAgent: vi.fn(async () => null),
 		getEntitiesForRoom: vi.fn(async () => [] as Entity[]),
 		...overrides,
 	} as unknown as IAgentRuntime;
@@ -34,10 +33,22 @@ function makeMessage(
 	} as Memory;
 }
 
-describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
-	it("returns false when there are no explicit addressees", async () => {
+// Room with this agent plus two other resolvable participants — one bot, one
+// human — so name→id resolution works and the human/bot cases are symmetric.
+function roomWithOthers(): Partial<IAgentRuntime> {
+	return {
+		getEntitiesForRoom: vi.fn(async () => [
+			{ id: AGENT_ID, names: ["MyAgent", "myagent_bot"] },
+			{ id: OTHER_BOT, names: ["SomeOtherBot"] },
+			{ id: HUMAN_X, names: ["Alice"] },
+		]),
+	} as unknown as Partial<IAgentRuntime>;
+}
+
+describe("messageAddressedToOtherParticipant (#9874 — uniform addressing gate)", () => {
+	it("returns false when there are no explicit addressees (DMs / undirected asks)", async () => {
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
 				message: makeMessage(),
 				addressedTo: [],
@@ -47,9 +58,9 @@ describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
 
 	it("returns false when addressed to this agent by name (case/@-insensitive)", async () => {
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
-				message: makeMessage({ fromBot: true }),
+				message: makeMessage(),
 				addressedTo: ["@myagent"],
 			}),
 		).toBe(false);
@@ -57,60 +68,80 @@ describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
 
 	it("returns false when addressed to this agent by id", async () => {
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
-				message: makeMessage({ fromBot: true }),
+				message: makeMessage(),
 				addressedTo: [AGENT_ID],
 			}),
 		).toBe(false);
 	});
 
-	it("returns true when a bot addresses someone other than us (sender fromBot)", async () => {
+	it("returns true when addressed to another bot participant (by id)", async () => {
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: [OTHER_BOT],
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when addressed to another bot participant (resolved by name)", async () => {
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(),
+				addressedTo: ["@SomeOtherBot"],
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when addressed to a HUMAN participant — same as a bot (uniform, not bot-specific)", async () => {
+		// The decisive change from the bot-specific version: a turn directed at a
+		// human who is not us is overheard crosstalk too, and is gated identically.
+		// Bot-ness is never consulted here.
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(),
+				addressedTo: ["Alice"],
+			}),
+		).toBe(true);
+	});
+
+	it("does NOT depend on the sender being a bot — fromBot is irrelevant to the gate", async () => {
+		// A non-bot sender addressing another participant still gates (no fromBot /
+		// getAgent requirement)...
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(),
+				addressedTo: ["Alice"],
+			}),
+		).toBe(true);
+		// ...and a bot sender addressing an UNRESOLVABLE name does NOT gate
+		// structurally: fromBot is no longer a trigger, so this residual overheard
+		// crosstalk is left to the model + the "(bot)" transcript tag (either
+		// content-level or legacy top-level fromBot).
+		expect(
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
 				message: makeMessage({ fromBot: true }),
-				addressedTo: ["SomeOtherBot"],
+				addressedTo: ["@ghost"],
 			}),
-		).toBe(true);
-	});
-
-	it("also accepts legacy top-level fromBot metadata", async () => {
+		).toBe(false);
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
 				message: makeMessage(undefined, { fromBot: true }),
-				addressedTo: ["SomeOtherBot"],
-			}),
-		).toBe(true);
-	});
-
-	it("returns true when an addressee resolves to a registered agent (no fromBot)", async () => {
-		const getAgent = vi.fn(async (id: UUID) =>
-			id === BOT_B ? ({ id: BOT_B } as unknown) : null,
-		);
-		expect(
-			await addresseeIsNonOwnerBot({
-				runtime: makeRuntime({ getAgent } as Partial<IAgentRuntime>),
-				message: makeMessage(),
-				addressedTo: [BOT_B],
-			}),
-		).toBe(true);
-	});
-
-	it("returns false when the addressee is a human (not a registered agent, not fromBot)", async () => {
-		expect(
-			await addresseeIsNonOwnerBot({
-				runtime: makeRuntime(),
-				message: makeMessage(),
-				addressedTo: [HUMAN_X],
+				addressedTo: ["@ghost"],
 			}),
 		).toBe(false);
 	});
 
-	it("returns false when an addressed name cannot be resolved and the sender is not a bot", async () => {
+	it("fails safe (false) when an addressed bare name cannot be resolved to a real participant", async () => {
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime: makeRuntime(),
 				message: makeMessage(),
 				addressedTo: ["@ghost"],
@@ -118,22 +149,30 @@ describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
 		).toBe(false);
 	});
 
-	it("returns false when a BOT addresses us by a platform-handle ALIAS (not character.name)", async () => {
-		// Regression: the agent's room entity carries platform-handle aliases
-		// (e.g. samantha_ai_bot) that are not character.name. A bot addressing us
-		// by such an alias must be recognized as addressed-to-us and NOT have its
-		// tool request suppressed — the self-by-resolution check runs before the
-		// fromBot short-circuit.
+	it("returns false when addressed to us by a platform-handle ALIAS (resolved to self, not character.name)", async () => {
+		// The agent's room entity carries platform aliases (e.g. samantha_ai_bot)
+		// that are not character.name. A turn addressed to us by such an alias must
+		// resolve to self and NOT be mistaken for an other-participant address.
 		const runtime = makeRuntime({
 			getEntitiesForRoom: vi.fn(async () => [
 				{ id: AGENT_ID, names: ["samantha_ai_bot", "Samantha"] },
 			]),
 		} as unknown as Partial<IAgentRuntime>);
 		expect(
-			await addresseeIsNonOwnerBot({
+			await messageAddressedToOtherParticipant({
 				runtime,
 				message: makeMessage({ fromBot: true }),
 				addressedTo: ["@samantha_ai_bot"],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when addressed to us AND another participant (we are among the addressees)", async () => {
+		expect(
+			await messageAddressedToOtherParticipant({
+				runtime: makeRuntime(roomWithOthers()),
+				message: makeMessage(),
+				addressedTo: ["@myagent", "@SomeOtherBot"],
 			}),
 		).toBe(false);
 	});

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -116,25 +116,31 @@ interface ResolveTargetsArgs {
 }
 
 /**
- * Detects bot-to-bot crosstalk: the inbound message is directed at another
- * participant that is NOT this agent, in a context where the agent is merely
- * overhearing. Used to suppress the simple→requiresTool promotion so the agent
- * does not fabricate a tool task from crosstalk it was not asked to act on
- * (#9874 item 1).
+ * Detects that the inbound message is explicitly directed at ANOTHER known
+ * participant — not this agent — so the agent is merely overhearing. Used to
+ * skip the simple→requiresTool promotion so the agent does not fabricate a tool
+ * task from a turn it was not asked to act on (#9874 item 1).
+ *
+ * Uniform, NOT bot-specific: it fires identically whether the other participant
+ * is a human or a bot. Bot-ness is surfaced to the model as CONTEXT instead (the
+ * conversation transcript tags `fromBot` senders as "Name (bot)"), so how to
+ * treat overheard bot crosstalk is the model's call with full context — there is
+ * no runtime type-branch on bot-ness here.
  *
  * Returns true only when ALL hold:
  *  - the message carries explicit `addressedTo` targets,
- *  - none of them is this agent (by name or id) — i.e. it is not addressed to us,
- *  - it is bot crosstalk: the SENDER is a bot (`fromBot` on either supported
- *    message metadata shape), OR a resolved addressee is itself a registered
- *    agent (`getAgent`).
+ *  - this agent is NOT among them (by literal name/id/username OR a resolved room
+ *    alias),
+ *  - at least one addressee RESOLVES to a real room participant other than us.
  *
- * A human owner addressed by name is never a registered agent and never carries
- * `fromBot`, so owner-directed talk does not trip this. Fails SAFE (returns
- * false) whenever it cannot positively confirm crosstalk — suppression is the
- * conservative action and is only taken on a clear signal.
+ * Fails SAFE (returns false) whenever it cannot positively confirm that a
+ * different real participant was addressed: empty `addressedTo`, a turn
+ * addressed to us, or an addressee that resolves to no real room entity (a bare
+ * unrecognized name) all return false — the agent keeps acting on requests meant
+ * for it, and DMs / undirected asks (which carry no other-participant addressee)
+ * are never gated.
  */
-export async function addresseeIsNonOwnerBot(
+export async function messageAddressedToOtherParticipant(
 	args: ApplyAddressedToArgs,
 ): Promise<boolean> {
 	const { runtime, message, addressedTo } = args;
@@ -149,6 +155,8 @@ export async function addresseeIsNonOwnerBot(
 	if (selfId) self.add(selfId.toLowerCase());
 	const selfName = runtime.character?.name;
 	if (selfName) self.add(normalize(selfName));
+	const selfUsername = runtime.character?.username;
+	if (selfUsername) self.add(normalize(selfUsername));
 
 	const cleaned = addressedTo
 		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
@@ -163,11 +171,9 @@ export async function addresseeIsNonOwnerBot(
 	}
 
 	// Resolve names→ids against the room. This also maps the agent's OWN entity
-	// aliases (platform handles like @samantha_ai_bot that connectors store on the
-	// agent's entity) to selfId, so a turn addressed to us by an alias is NOT
-	// mistaken for crosstalk — even when the sender is a bot. We must do this
-	// BEFORE the fromBot short-circuit, otherwise an owner-run relay bot
-	// addressing us by our handle would have its legitimate request suppressed.
+	// aliases (platform handles like @samantha_ai_bot that connectors store on
+	// the agent's entity) to selfId, so a turn addressed to us by an alias is NOT
+	// mistaken for an other-participant address.
 	const targets = await resolveAddressedTargets({
 		runtime,
 		message,
@@ -177,35 +183,11 @@ export async function addresseeIsNonOwnerBot(
 		return false;
 	}
 
-	// A bot talking to someone other than us is crosstalk we are overhearing.
-	const contentMetadata =
-		message.content?.metadata &&
-		typeof message.content.metadata === "object" &&
-		!Array.isArray(message.content.metadata)
-			? (message.content.metadata as Record<string, unknown>)
-			: undefined;
-	const topLevelMetadata =
-		message.metadata &&
-		typeof message.metadata === "object" &&
-		!Array.isArray(message.metadata)
-			? (message.metadata as Record<string, unknown>)
-			: undefined;
-	const senderIsBot =
-		contentMetadata?.fromBot === true || topLevelMetadata?.fromBot === true;
-	if (senderIsBot) {
-		return true;
-	}
-
-	// Otherwise confirm at least one addressee resolves to a registered agent.
-	for (const targetId of targets) {
-		if (targetId === selfId) {
-			continue;
-		}
-		if (await runtime.getAgent(targetId)) {
-			return true;
-		}
-	}
-	return false;
+	// Suppress only on a positively-resolved OTHER participant (every remaining
+	// target is non-self here). An addressee that resolves to no real entity (a
+	// bare unrecognized name) does not gate — the agent keeps acting, and the
+	// (bot) transcript tag lets the model handle any residual overheard crosstalk.
+	return targets.length > 0;
 }
 
 export async function resolveAddressedTargets(

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -279,11 +279,13 @@ export function routeMessageHandlerOutput(
 	// routing layer.
 	const candidateActionsRequestPlanning =
 		hasCandidateActions && output.plan.requiresTool !== false;
-	// #9874 item 1: when the caller has identified this turn as bot-to-bot
-	// crosstalk addressed to a non-owner bot, do NOT promote a simple-path turn
-	// into forced tool planning. The agent is overhearing talk it was not asked
-	// to act on; forcing a tool fabricates a phantom task (the false-ack seed).
-	// The Stage-1 simple reply still ships via the final_reply branch below.
+	// #9874 item 1: when the caller has identified this turn as explicitly
+	// addressed to another participant (not us), do NOT promote a simple-path turn
+	// into forced tool planning. The agent is overhearing talk it was not asked to
+	// act on; forcing a tool fabricates a phantom task (the false-ack seed). The
+	// flag is a uniform addressing signal — it does not depend on whether the other
+	// participant is a bot. The Stage-1 simple reply still ships via the
+	// final_reply branch below.
 	const promotionRequested =
 		(requiresTool || candidateActionsRequestPlanning) &&
 		nonSimpleContexts.length === 0;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -42,8 +42,8 @@ import { actionGateFailure, canActionRun } from "../runtime/action-gate";
 import { retrieveActions } from "../runtime/action-retrieval";
 import { tierActionResults } from "../runtime/action-tiering";
 import {
-	addresseeIsNonOwnerBot,
 	applyAddressedTo,
+	messageAddressedToOtherParticipant,
 } from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
 import { filterByContextGate } from "../runtime/context-gates";
@@ -6278,22 +6278,24 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler.plan.contexts,
 			availableContexts,
 		);
-		// #9874 item 1: suppress the simple→requiresTool promotion when this turn
-		// is bot-to-bot crosstalk addressed to a non-owner bot — the agent is
+		// #9874 item 1: skip the simple→requiresTool promotion when this turn is
+		// explicitly addressed to another participant (not us) — the agent is
 		// overhearing, not being asked to act, so forcing a tool fabricates a
-		// phantom task. Cheap-gated: only resolve addressees when a promotion could
-		// actually fire (requiresTool / candidateActions) and the message carries
-		// explicit addressees.
+		// phantom task. Uniform addressing gate, NOT bot-specific: it fires the
+		// same for human and bot addressees (bot-ness is surfaced to the model as
+		// transcript context, not handled here). Cheap-gated: only resolve
+		// addressees when a promotion could actually fire (requiresTool /
+		// candidateActions) and the message carries explicit addressees.
 		const mayPromoteToTool =
 			messageHandler.plan.requiresTool === true ||
 			(messageHandler.plan.candidateActions?.length ?? 0) > 0;
-		// Fail SAFE on any resolution error (DB hiccup in getEntitiesForRoom /
-		// getAgent): a transient failure must NOT convert a normal turn into the
-		// generic failure reply — it just means "don't suppress", matching the
+		// Fail SAFE on any resolution error (DB hiccup in getEntitiesForRoom): a
+		// transient failure must NOT convert a normal turn into the generic
+		// failure reply — it just means "don't suppress", matching the
 		// conservative contract and the fire-and-forget addressee handling above.
 		const suppressToolPromotion =
 			mayPromoteToTool && addressedTo.length > 0
-				? await addresseeIsNonOwnerBot({
+				? await messageAddressedToOtherParticipant({
 						runtime: args.runtime,
 						message: args.message,
 						addressedTo,

--- a/packages/core/src/services/message/bot-noise-triage.ts
+++ b/packages/core/src/services/message/bot-noise-triage.ts
@@ -100,6 +100,16 @@ export function isTriagableBotNoiseMessage(
 	const topLevelMetadata = metadataRecord(message.metadata);
 
 	// Positively bot/webhook-authored only (connector-stamped `fromBot`).
+	// NOTE: `fromBot` here is a COST proxy, not behavioral special-handling. This
+	// gate never suppresses a response — it only ROUTES high-volume automated
+	// relay traffic (the ~1000 IGNOREs/day webhook floods of #11944) to the cheap
+	// TEXT_SMALL tier, and fails OPEN on every uncertain path. The precondition
+	// SCOPES that cost route to where the volume problem actually is; dropping it
+	// to gate on addressing alone would widen triage to all unaddressed human
+	// group chatter — a strictly worse cost/quality trade #11944 does not justify.
+	// So a future "handle all messages uniformly" pass must NOT uniformize this
+	// away: behavior (respond vs not) still branches only on the model verdict +
+	// addressing, never on bot-ness.
 	const fromBot =
 		contentMetadata?.fromBot === true || topLevelMetadata?.fromBot === true;
 	if (!fromBot) return false;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -504,7 +504,21 @@ export const formatMessages = ({
 		const messageThought = (message.content as Content).thought;
 		const foundEntity = entityById.get(message.entityId);
 		const foundEntityNames = foundEntity?.names;
-		const formattedName = foundEntityNames?.[0] || "Unknown User";
+		const baseName = foundEntityNames?.[0] || "Unknown User";
+		// Surface bot/agent-ness as plain context the model reads: a sender whose
+		// message was stamped `fromBot` at ingestion renders as "Name (bot)". This
+		// is the agent simply KNOWING a participant is a bot — part of what it knows
+		// about that user — NOT a behavioral branch. Every message is still handled
+		// through the one uniform path; the tag just lets the model read multi-bot
+		// crosstalk for what it is instead of mistaking an overheard automated line
+		// for a directive to itself. Degrades gracefully: a connector that omits
+		// `fromBot` simply renders the bare name (untagged = treated as human).
+		const senderIsBot =
+			(message.metadata as { fromBot?: boolean } | undefined)?.fromBot ===
+				true ||
+			(message.content as { metadata?: { fromBot?: boolean } })?.metadata
+				?.fromBot === true;
+		const formattedName = senderIsBot ? `${baseName} (bot)` : baseName;
 
 		const attachments = (message.content as Content).attachments;
 		const visibleAttachments =

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -691,7 +691,7 @@ replyText: user-facing text. Always write. Simple path = whole answer. Planning 
 
 contexts (directly after replyText): ids from available_contexts. Never invent. ["simple"] or [] = direct reply, no planner.
 
-requiresTool=true for tools/actions/subagents/providers/filesystem/network/browser/API/live data/side effects/long work/verification. Else false.
+requiresTool=true for tools/actions/subagents/providers/filesystem/network/browser/API/live data/side effects/long work/verification. Else false. If the current message is directed at another participant rather than you — bot/webhook chatter, or one person addressing another by name (a "(bot)" tag marks automated senders) — you are only overhearing it: set requiresTool=false and do not invent a task from it.
 
 simple shortcut: choose contexts=["simple"] when the user is asking for a direct chat answer and ALL true:
 - direct conversational, creative, explanatory, summarization, rewriting, translation, brainstorming, or static-knowledge answer


### PR DESCRIPTION
## Why

The message pipeline branched behavior on **bot-ness** but never surfaced bot-ness as **context the model reads** — the exact inversion of good design (hidden behavior driven by an invisible fact). `addresseeIsNonOwnerBot` suppressed the `simple→requiresTool` promotion via a `fromBot` short-circuit + a `getAgent` registered-agent lookup, while `formatMessages` rendered a bare `name: text` transcript with no way for the model to tell a bot participant from a human.

Principle applied: **bot-ness belongs in the context the agent knows about a participant; behavior branches only on addressing — uniformly for humans and bots.**

## What changed

**Bot-ness → context (was missing entirely):**
- `formatMessages` tags a `fromBot` sender as `OtherBot (bot): …`, so the model reads multi-bot crosstalk for what it is. Degrades gracefully (no `fromBot` → bare name; reads both metadata shapes).

**Special handling → uniform addressing:**
- `addresseeIsNonOwnerBot` → **`messageAddressedToOtherParticipant`**. Both bot-ness checks removed. It now skips the forced-tool promotion **only** when the turn resolves to another real room participant that is not us — identically for human and bot crosstalk. DMs, undirected asks, and unresolvable bare names never gate (fail safe).
- Stage-1 prompt gains one clause on the `requiresTool` instruction: a message directed at another participant (a `(bot)` tag marks automated senders) is overheard → `requiresTool=false`, don't invent a task. This covers the residual unresolvable-addressee case the structural gate intentionally no longer catches.

**Left uniform-by-design (documented, unchanged):**
- `bot-noise-triage`: its `fromBot` precondition is now commented as a **cost proxy** — a fail-open cheap-model route for the #11944 webhook floods, not behavioral handling — so a future uniformize pass doesn't widen it to human chatter (a strictly worse cost/quality trade #11944's evidence rules out).
- `runtime-failure-suppression`: already keys purely on addressing; no change.

## Behavior delta (intended)

A human addressing another **human** by name in a group now gets the same no-forced-tool treatment as bot-to-bot crosstalk — full uniformity, no bot special-casing. The residual weak-model risk (a bot addressing an unresolvable name, e.g. `@GhostBot` not in the room) is no longer *structurally* suppressed; it leans on the new `(bot)` transcript tag + the Stage-1 prompt clause + the model. That trade was chosen deliberately (context over hardcoded branch).

## Tests / evidence

- `addressed-to` rewritten for the uniform semantics: human crosstalk now gated like bot crosstalk; `fromBot` no longer a trigger; unresolvable-addressee fails safe; self-by-alias still recognized.
- `formatMessages` bot-tag cases (both metadata shapes; human untagged).
- `message-handler` suppression-option cases retained.
- **Core typecheck clean; full core suite green.** Two failures on the suite are **pre-existing on clean `origin/develop`** and unrelated to this change (verified by running them on a clean tree): `tiered-action-surface` (fallout from the landed `SHELL→TERMINAL_SHELL` rename) and `link-extraction` (mock/fetch title). Flagged separately.

Recommended follow-up evidence: a real-LLM multi-bot arena trajectory on a small/local model to confirm the tag+prompt hold the residual case without the structural bot check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)