### PR TITLE
refactor(core): extract LifeOps message-pipeline hooks into typed registries (#12092 item 5)

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import type { CandidateActionBackstopRule } from "../runtime/candidate-action-backstop";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
@@ -19,6 +20,38 @@ import { ModelType } from "../types/model";
 import { ChannelType, type UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
 import type { State } from "../types/state";
+
+// Mirrors the scheduled-task backstop rule that plugin-personal-assistant
+// registers via `registerCandidateActionBackstopRule`. Core no longer hardcodes
+// these action names / heuristic; the coding-delegation backstop consults
+// whatever rules a plugin registers, threaded in via `candidateBackstopRules`.
+const SCHEDULING_BACKSTOP_RULE: CandidateActionBackstopRule = {
+	actionNames: [
+		"SCHEDULED_TASKS",
+		"SCHEDULED_TASKS_ACKNOWLEDGE",
+		"SCHEDULED_TASKS_CANCEL",
+		"SCHEDULED_TASKS_COMPLETE",
+		"SCHEDULED_TASKS_CREATE",
+		"SCHEDULED_TASKS_DISMISS",
+		"SCHEDULED_TASKS_GET",
+		"SCHEDULED_TASKS_HISTORY",
+		"SCHEDULED_TASKS_LIST",
+		"SCHEDULED_TASKS_REOPEN",
+		"SCHEDULED_TASKS_SKIP",
+		"SCHEDULED_TASKS_SNOOZE",
+		"SCHEDULED_TASKS_UPDATE",
+	],
+	matches: (text: string): boolean =>
+		/\b(?:remind\s+me|reminder|scheduled\s+task|scheduled\s+item|todo|to[- ]?do|snooze|recap|check[- ]?in|follow[- ]?up|watcher|approval)\b/iu.test(
+			text,
+		) ||
+		/\b(?:schedule|create|make|add|set\s+up)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval)\b/iu.test(
+			text,
+		) ||
+		/\b(?:tomorrow|tonight|later|next\s+(?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|every\s+(?:day|week|month|morning|evening))\b/iu.test(
+			text,
+		),
+};
 
 function useModelCalls(runtime: IAgentRuntime): unknown[][] {
 	return (runtime.useModel as { mock: { calls: unknown[][] } }).mock.calls;
@@ -2204,7 +2237,7 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(routed.plan.candidateActions).toEqual(["TASKS"]);
 	});
 
-	it("repairs build requests misrouted to LifeOps scheduled tasks", () => {
+	it("repairs build requests misrouted to backstop-protected scheduled tasks", () => {
 		const routed = messageHandlerFromFieldResult(
 			{
 				shouldRespond: "RESPOND",
@@ -2230,6 +2263,7 @@ describe("runV5MessageRuntimeStage1", () => {
 					{ name: "SCHEDULED_TASKS" },
 				],
 				messageText: "update the website, add some fixes",
+				candidateBackstopRules: [SCHEDULING_BACKSTOP_RULE],
 			},
 		);
 
@@ -2239,7 +2273,7 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(routed.plan.candidateActions).toEqual(["TASKS"]);
 	});
 
-	it("keeps scheduled coding-related reminders on LifeOps scheduled tasks", () => {
+	it("keeps scheduled coding-related reminders on the backstop-protected scheduled tasks", () => {
 		const routed = messageHandlerFromFieldResult(
 			{
 				shouldRespond: "RESPOND",
@@ -2265,6 +2299,7 @@ describe("runV5MessageRuntimeStage1", () => {
 					{ name: "SCHEDULED_TASKS_CREATE" },
 				],
 				messageText: "create a scheduled task to fix the app tomorrow",
+				candidateBackstopRules: [SCHEDULING_BACKSTOP_RULE],
 			},
 		);
 

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -184,10 +184,25 @@ export {
 } from "./runtime/action-catalog";
 export { warnOnUnmatchedActionRolePolicyKeys } from "./runtime/action-role-policy";
 export * from "./runtime/builtin-field-evaluators";
+export {
+	__resetCandidateActionBackstopRulesForTests,
+	type CandidateActionBackstopRule,
+	getCandidateActionBackstopRules,
+	registerCandidateActionBackstopRule,
+} from "./runtime/candidate-action-backstop";
 export * from "./runtime/cleanup-scope";
 export * from "./runtime/context-gates";
 export * from "./runtime/context-registry";
 export * from "./runtime/conversation-compaction-hook";
+export {
+	__resetDirectMessageHooksForTests,
+	type DirectMessageHook,
+	type DirectMessageHookInput,
+	getDirectMessageHooks,
+	registerDirectMessageHook,
+	runDirectMessageHooks,
+	unregisterDirectMessageHook,
+} from "./runtime/direct-message-hook";
 export * from "./runtime/execute-planned-tool-call";
 export {
 	detectLocaleFromText,

--- a/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
+++ b/packages/core/src/runtime/__tests__/candidate-action-backstop.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { messageHandlerFromFieldResult } from "../../services/message";
+import type { IAgentRuntime } from "../../types/runtime";
+import {
+	__resetCandidateActionBackstopRulesForTests,
+	type CandidateActionBackstopRule,
+	getCandidateActionBackstopRules,
+	registerCandidateActionBackstopRule,
+} from "../candidate-action-backstop";
+
+const makeRuntime = (): IAgentRuntime => ({}) as unknown as IAgentRuntime;
+
+const schedulingRule: CandidateActionBackstopRule = {
+	actionNames: ["SCHEDULED_TASKS", "SCHEDULED_TASKS_CREATE"],
+	matches: (text) =>
+		/\b(?:remind\s+me|scheduled\s+task|tomorrow)\b/iu.test(text),
+};
+
+describe("candidate-action backstop registry", () => {
+	it("starts empty and returns registered rules in order", () => {
+		const runtime = makeRuntime();
+		expect(getCandidateActionBackstopRules(runtime)).toEqual([]);
+
+		const second: CandidateActionBackstopRule = {
+			actionNames: ["OTHER"],
+			matches: () => false,
+		};
+		registerCandidateActionBackstopRule(runtime, schedulingRule);
+		registerCandidateActionBackstopRule(runtime, second);
+
+		expect(getCandidateActionBackstopRules(runtime)).toEqual([
+			schedulingRule,
+			second,
+		]);
+
+		__resetCandidateActionBackstopRulesForTests(runtime);
+		expect(getCandidateActionBackstopRules(runtime)).toEqual([]);
+	});
+
+	it("keeps registrations isolated per runtime", () => {
+		const a = makeRuntime();
+		const b = makeRuntime();
+		registerCandidateActionBackstopRule(a, schedulingRule);
+		expect(getCandidateActionBackstopRules(a)).toHaveLength(1);
+		expect(getCandidateActionBackstopRules(b)).toEqual([]);
+	});
+
+	it("drives the coding-delegation backstop selection when threaded into the pipeline", () => {
+		const runtime = makeRuntime();
+		registerCandidateActionBackstopRule(runtime, schedulingRule);
+
+		const runtimeContext = {
+			actions: [
+				{
+					name: "TASKS",
+					tags: ["domain:coding", "resource:agent-task", "capability:delegate"],
+				},
+				{ name: "SCHEDULED_TASKS_CREATE" },
+			],
+			candidateBackstopRules: getCandidateActionBackstopRules(runtime),
+		};
+
+		// A genuine scheduled-task turn: the rule matches, so its candidate is
+		// protected and never rewritten to the coding-delegation action.
+		const scheduled = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["tasks"],
+				intents: ["create scheduled task"],
+				replyText: "I'll schedule that.",
+				candidateActionNames: ["SCHEDULED_TASKS_CREATE"],
+				facts: [],
+				relationships: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				...runtimeContext,
+				messageText: "create a scheduled task to fix the app tomorrow",
+			},
+		);
+		expect(scheduled.plan.contexts).not.toContain("code");
+		expect(scheduled.plan.candidateActions).toEqual(["SCHEDULED_TASKS_CREATE"]);
+
+		// A coding turn that only accidentally surfaced a scheduled-task
+		// candidate: the rule does not match, so the candidate is stripped and
+		// the coding-delegation action wins.
+		const coding = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["tasks"],
+				intents: ["update website"],
+				replyText: "On it.",
+				candidateActionNames: ["SCHEDULED_TASKS_CREATE"],
+				facts: [],
+				relationships: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				...runtimeContext,
+				messageText: "update the website code, add some fixes",
+			},
+		);
+		expect(coding.plan.contexts).toContain("code");
+		expect(coding.plan.candidateActions).toEqual(["TASKS"]);
+	});
+});

--- a/packages/core/src/runtime/__tests__/direct-message-hook.test.ts
+++ b/packages/core/src/runtime/__tests__/direct-message-hook.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { ActionResult } from "../../types/components";
+import type { Memory } from "../../types/memory";
+import type { IAgentRuntime } from "../../types/runtime";
+import type { State } from "../../types/state";
+import {
+	__resetDirectMessageHooksForTests,
+	type DirectMessageHook,
+	getDirectMessageHooks,
+	registerDirectMessageHook,
+	runDirectMessageHooks,
+	unregisterDirectMessageHook,
+} from "../direct-message-hook";
+
+const makeRuntime = (): IAgentRuntime => ({}) as unknown as IAgentRuntime;
+const input = (runtime: IAgentRuntime) => ({
+	runtime,
+	message: {} as Memory,
+	state: {} as State,
+});
+
+describe("pre-LLM direct-message hook registry", () => {
+	it("returns null when no hook is registered", async () => {
+		const runtime = makeRuntime();
+		expect(getDirectMessageHooks(runtime)).toEqual([]);
+		expect(await runDirectMessageHooks(runtime, input(runtime))).toBeNull();
+	});
+
+	it("returns the first hook that produces a result and skips later hooks", async () => {
+		const runtime = makeRuntime();
+		const calls: string[] = [];
+		const deferring: DirectMessageHook = async () => {
+			calls.push("deferring");
+			return null;
+		};
+		const handled: DirectMessageHook = async () => {
+			calls.push("handled");
+			return { success: true, text: "done" } satisfies ActionResult;
+		};
+		const never: DirectMessageHook = async () => {
+			calls.push("never");
+			return { success: true, text: "should not run" } satisfies ActionResult;
+		};
+		registerDirectMessageHook(runtime, deferring);
+		registerDirectMessageHook(runtime, handled);
+		registerDirectMessageHook(runtime, never);
+
+		const result = await runDirectMessageHooks(runtime, input(runtime));
+		expect(result?.text).toBe("done");
+		expect(calls).toEqual(["deferring", "handled"]);
+
+		__resetDirectMessageHooksForTests(runtime);
+		expect(getDirectMessageHooks(runtime)).toEqual([]);
+	});
+
+	it("unregisters a specific hook so it no longer fires", async () => {
+		const runtime = makeRuntime();
+		const hook: DirectMessageHook = async () => ({
+			success: true,
+			text: "handled",
+		});
+		registerDirectMessageHook(runtime, hook);
+		expect(await runDirectMessageHooks(runtime, input(runtime))).not.toBeNull();
+
+		unregisterDirectMessageHook(runtime, hook);
+		expect(getDirectMessageHooks(runtime)).toEqual([]);
+		expect(await runDirectMessageHooks(runtime, input(runtime))).toBeNull();
+	});
+
+	it("keeps hooks isolated per runtime", async () => {
+		const a = makeRuntime();
+		const b = makeRuntime();
+		registerDirectMessageHook(a, async () => ({ success: true, text: "a" }));
+		expect((await runDirectMessageHooks(a, input(a)))?.text).toBe("a");
+		expect(await runDirectMessageHooks(b, input(b))).toBeNull();
+	});
+});

--- a/packages/core/src/runtime/candidate-action-backstop.ts
+++ b/packages/core/src/runtime/candidate-action-backstop.ts
@@ -1,0 +1,63 @@
+/**
+ * Candidate-action backstop registry — lets a host plugin declare which
+ * candidate action names belong to it and how to recognize a message that is
+ * genuinely addressed to those actions.
+ *
+ * The message pipeline's coding-delegation backstop consults these rules before
+ * it strips candidate actions in favor of a coding-delegation action: when a
+ * message reads as coding work but a registered rule both owns one of the
+ * candidate actions AND matches the message text, the rule protects its
+ * candidates from being overridden. When the backstop does force coding
+ * delegation, every action owned by a registered rule is filtered out of the
+ * candidate set.
+ *
+ * Cycle-avoidance: core defines the slot, plugins fill it. Core never imports
+ * plugin-side symbols or hardcodes plugin-specific action names / heuristics.
+ *
+ * Registration uses a module-scoped WeakMap keyed by runtime instance so the
+ * rule lifetime tracks the runtime and we don't leak across tests — same shape
+ * as `SendPolicy` and `LocalizedExamplesProvider`.
+ */
+
+import type { IAgentRuntime } from "../types/runtime";
+
+export interface CandidateActionBackstopRule {
+	/**
+	 * Action names this rule protects. Compared against candidate actions using
+	 * the pipeline's canonical action-identifier normalization, so callers may
+	 * register either the canonical or a loosely-cased form.
+	 */
+	readonly actionNames: readonly string[];
+	/**
+	 * True when `messageText` is genuinely a request for this rule's actions.
+	 * Used to decide whether the candidates are protected from the coding
+	 * backstop on a given turn.
+	 */
+	matches(messageText: string): boolean;
+}
+
+const rules = new WeakMap<IAgentRuntime, CandidateActionBackstopRule[]>();
+
+export function registerCandidateActionBackstopRule(
+	runtime: IAgentRuntime,
+	rule: CandidateActionBackstopRule,
+): void {
+	const existing = rules.get(runtime);
+	if (existing) {
+		existing.push(rule);
+	} else {
+		rules.set(runtime, [rule]);
+	}
+}
+
+export function getCandidateActionBackstopRules(
+	runtime: IAgentRuntime,
+): readonly CandidateActionBackstopRule[] {
+	return rules.get(runtime) ?? [];
+}
+
+export function __resetCandidateActionBackstopRulesForTests(
+	runtime: IAgentRuntime,
+): void {
+	rules.delete(runtime);
+}

--- a/packages/core/src/runtime/direct-message-hook.ts
+++ b/packages/core/src/runtime/direct-message-hook.ts
@@ -1,0 +1,95 @@
+/**
+ * Pre-LLM direct-message hook registry — lets a host plugin fully handle
+ * certain requests deterministically before the planner/model runs.
+ *
+ * The message pipeline invokes registered hooks (in registration order) right
+ * after the pre-LLM shortcut gate and before any planner/model call. The first
+ * hook that returns an `ActionResult` short-circuits the turn with a direct
+ * reply; a hook returning `null`/`undefined` defers to the next hook and,
+ * ultimately, to the normal pipeline.
+ *
+ * Cycle-avoidance: core defines the typed slot, plugins fill it, and core never
+ * imports plugin-side symbols.
+ *
+ * Registration uses a module-scoped WeakMap keyed by runtime instance so the
+ * hook lifetime tracks the runtime and we don't leak across tests — same shape
+ * as `SendPolicy` and `LocalizedExamplesProvider`.
+ */
+
+import type { ActionResult } from "../types/components";
+import type { Memory } from "../types/memory";
+import type { IAgentRuntime } from "../types/runtime";
+import type { State } from "../types/state";
+
+export interface DirectMessageHookInput {
+	runtime: IAgentRuntime;
+	message: Memory;
+	state: State;
+}
+
+/**
+ * Async handler: returns an `ActionResult` when it fully handled the message,
+ * or `null`/`undefined` to defer to the next hook / the normal pipeline.
+ */
+export type DirectMessageHook = (
+	input: DirectMessageHookInput,
+) => Promise<ActionResult | null | undefined>;
+
+const hooks = new WeakMap<IAgentRuntime, DirectMessageHook[]>();
+
+export function registerDirectMessageHook(
+	runtime: IAgentRuntime,
+	hook: DirectMessageHook,
+): void {
+	const existing = hooks.get(runtime);
+	if (existing) {
+		existing.push(hook);
+	} else {
+		hooks.set(runtime, [hook]);
+	}
+}
+
+export function unregisterDirectMessageHook(
+	runtime: IAgentRuntime,
+	hook: DirectMessageHook,
+): void {
+	const existing = hooks.get(runtime);
+	if (!existing) {
+		return;
+	}
+	const next = existing.filter((entry) => entry !== hook);
+	if (next.length === 0) {
+		hooks.delete(runtime);
+	} else {
+		hooks.set(runtime, next);
+	}
+}
+
+export function getDirectMessageHooks(
+	runtime: IAgentRuntime,
+): readonly DirectMessageHook[] {
+	return hooks.get(runtime) ?? [];
+}
+
+/**
+ * Run registered hooks in order, returning the first `ActionResult` produced.
+ * Returns `null` when no hook handled the message.
+ */
+export async function runDirectMessageHooks(
+	runtime: IAgentRuntime,
+	input: DirectMessageHookInput,
+): Promise<ActionResult | null> {
+	for (const hook of getDirectMessageHooks(runtime)) {
+		const result = await hook(input);
+		if (result) {
+			return result;
+		}
+	}
+	return null;
+}
+
+export function __resetDirectMessageHooksForTests(
+	runtime: IAgentRuntime,
+): void {
+	hooks.delete(runtime);
+}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -46,6 +46,10 @@ import {
 	applyAddressedTo,
 } from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
+import {
+	type CandidateActionBackstopRule,
+	getCandidateActionBackstopRules,
+} from "../runtime/candidate-action-backstop";
 import { filterByContextGate } from "../runtime/context-gates";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
@@ -62,6 +66,7 @@ import {
 	getMessageHistoryCompactionHook,
 	type MessageHistoryCompactionTelemetry,
 } from "../runtime/conversation-compaction-hook";
+import { runDirectMessageHooks } from "../runtime/direct-message-hook";
 import {
 	type EvaluatorEffects,
 	type EvaluatorOutput,
@@ -898,7 +903,7 @@ function hasInboundBenchmarkContext(message: Memory): boolean {
  * Returns true when the current turn was issued by a benchmark harness AND the
  * `ELIZA_BENCH_FORCE_TOOL_CALL` env opt-in is set. Used to bias the planner
  * toward emitting structured tool calls instead of routing every turn through
- * `REPLY`, which is what LifeOpsBench and similar harnesses score against.
+ * `REPLY`, which is what tool-calling benchmark harnesses score against.
  *
  * Detection is intentionally narrow: we require BOTH
  *   1. an env-var opt-in (so default behavior is unchanged for normal chat), AND
@@ -2219,7 +2224,7 @@ async function collectV5PlannerCandidateActions(args: {
 	// messageHandler-picked `selectedContexts`. That filter excluded owner
 	// actions, CALENDAR, SCHEDULED_TASKS, etc. whenever the messageHandler routed to
 	// "general" — even when the user clearly asked for a habit/event/etc.
-	// (See `docs/audits/lifeops-2026-05-09/12-real-root-cause.md`.)
+	// (See the 2026-05-09 candidate-surface root-cause audit.)
 	//
 	// Now: the surface starts from every action, then applies only the same
 	// execution gates the planner executor will enforce. That keeps role-policy
@@ -3709,6 +3714,7 @@ export function messageHandlerFromFieldResult(
 	runtimeContext?: {
 		actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 		messageText?: string;
+		candidateBackstopRules?: readonly CandidateActionBackstopRule[];
 	},
 ): MessageHandlerResult {
 	const rawContexts = Array.isArray(result.contexts)
@@ -3724,6 +3730,7 @@ export function messageHandlerFromFieldResult(
 		candidateActions: rawCandidateActions,
 		actions: runtimeContext?.actions ?? [],
 		messageText: currentMessageText,
+		backstopRules: runtimeContext?.candidateBackstopRules ?? [],
 	});
 	const candidateActions = candidateBackstop.candidateActions;
 	const contexts =
@@ -4005,28 +4012,11 @@ export function messageHandlerFromFieldResult(
 	};
 }
 
-const LIFEOPS_SCHEDULED_TASK_ACTIONS = new Set(
-	[
-		"SCHEDULED_TASKS",
-		"SCHEDULED_TASKS_ACKNOWLEDGE",
-		"SCHEDULED_TASKS_CANCEL",
-		"SCHEDULED_TASKS_COMPLETE",
-		"SCHEDULED_TASKS_CREATE",
-		"SCHEDULED_TASKS_DISMISS",
-		"SCHEDULED_TASKS_GET",
-		"SCHEDULED_TASKS_HISTORY",
-		"SCHEDULED_TASKS_LIST",
-		"SCHEDULED_TASKS_REOPEN",
-		"SCHEDULED_TASKS_SKIP",
-		"SCHEDULED_TASKS_SNOOZE",
-		"SCHEDULED_TASKS_UPDATE",
-	].map(normalizeActionIdentifier),
-);
-
 function applyCodingCandidateBackstop(args: {
 	candidateActions: readonly string[];
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
 	messageText: string;
+	backstopRules: readonly CandidateActionBackstopRule[];
 }): { candidateActions: string[]; forceCodeContext: boolean } {
 	if (args.candidateActions.length === 0) {
 		return {
@@ -4040,13 +4030,19 @@ function applyCodingCandidateBackstop(args: {
 			forceCodeContext: false,
 		};
 	}
-	const hasLifeOpsScheduledCandidate = args.candidateActions.some((name) =>
-		LIFEOPS_SCHEDULED_TASK_ACTIONS.has(normalizeActionIdentifier(name)),
+	const normalizedCandidates = args.candidateActions.map(
+		normalizeActionIdentifier,
 	);
-	if (
-		hasLifeOpsScheduledCandidate &&
-		looksLikeLifeOpsScheduledTaskRequest(args.messageText)
-	) {
+	// A registered backstop rule protects its candidates when it both owns one
+	// of the candidate actions AND recognizes this message as addressed to it.
+	const protectedByRule = args.backstopRules.some((rule) => {
+		const owned = new Set(rule.actionNames.map(normalizeActionIdentifier));
+		return (
+			normalizedCandidates.some((name) => owned.has(name)) &&
+			rule.matches(args.messageText)
+		);
+	});
+	if (protectedByRule) {
 		return {
 			candidateActions: [...args.candidateActions],
 			forceCodeContext: false,
@@ -4060,9 +4056,13 @@ function applyCodingCandidateBackstop(args: {
 		};
 	}
 
+	const backstopActionNames = new Set(
+		args.backstopRules.flatMap((rule) =>
+			rule.actionNames.map(normalizeActionIdentifier),
+		),
+	);
 	const filtered = args.candidateActions.filter(
-		(name) =>
-			!LIFEOPS_SCHEDULED_TASK_ACTIONS.has(normalizeActionIdentifier(name)),
+		(name) => !backstopActionNames.has(normalizeActionIdentifier(name)),
 	);
 	if (filtered.length === args.candidateActions.length) {
 		return { candidateActions: filtered, forceCodeContext: false };
@@ -6038,6 +6038,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				{
 					actions: args.runtime.actions,
 					messageText: getUserMessageText(args.message),
+					candidateBackstopRules: getCandidateActionBackstopRules(args.runtime),
 				},
 			);
 		}
@@ -7362,24 +7363,6 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 			normalized,
 		);
 	return asksDelegation || asksCodingWork;
-}
-
-function looksLikeLifeOpsScheduledTaskRequest(text: string): boolean {
-	const normalized = text.toLowerCase();
-	if (!normalized.trim()) {
-		return false;
-	}
-	return (
-		/\b(?:remind\s+me|reminder|scheduled\s+task|scheduled\s+item|lifeops|todo|to[- ]?do|snooze|recap|check[- ]?in|follow[- ]?up|watcher|approval)\b/iu.test(
-			normalized,
-		) ||
-		/\b(?:schedule|create|make|add|set\s+up)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval)\b/iu.test(
-			normalized,
-		) ||
-		/\b(?:tomorrow|tonight|later|next\s+(?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|every\s+(?:day|week|month|morning|evening))\b/iu.test(
-			normalized,
-		)
-	);
 }
 
 function looksLikeExplicitDelegationRequest(text: string): boolean {
@@ -9141,9 +9124,9 @@ export class DefaultMessageService implements IMessageService {
 		// #8791: pre-LLM action shortcut gate runs FIRST — before any direct hook,
 		// planner, or model call. An explicit slash/`!` command (always-on) or a
 		// confident natural-language shortcut resolves to a deterministic action
-		// reply with zero inference. Placed here (ahead of the LifeOps/workflow
-		// direct hooks and the conditional v5 stage) so a slash command can never
-		// be pre-empted by another handler.
+		// reply with zero inference. Placed here (ahead of the pre-LLM
+		// direct-message hooks and the conditional v5 stage) so a slash command can
+		// never be pre-empted by another handler.
 		if (!strategyResult) {
 			const shortcutSenderRole = await resolveStage1SenderRole(
 				runtime,
@@ -9166,38 +9149,24 @@ export class DefaultMessageService implements IMessageService {
 			}
 		}
 
-		const directLifeOpsResult = strategyResult
+		const directHookResult = strategyResult
 			? null
-			: await (
-					runtime as IAgentRuntime & {
-						lifeOpsDirectMessageHook?: {
-							handleMessageRequest?: (args: {
-								runtime: IAgentRuntime;
-								message: Memory;
-								state: State;
-							}) => Promise<ActionResult | null | undefined>;
-						};
-					}
-				).lifeOpsDirectMessageHook?.handleMessageRequest?.({
-					runtime,
-					message,
-					state,
-				});
-		if (directLifeOpsResult) {
+			: await runDirectMessageHooks(runtime, { runtime, message, state });
+		if (directHookResult) {
 			const directText =
-				typeof directLifeOpsResult.text === "string" &&
-				directLifeOpsResult.text.trim().length > 0
-					? directLifeOpsResult.text.trim()
-					: directLifeOpsResult.success
+				typeof directHookResult.text === "string" &&
+				directHookResult.text.trim().length > 0
+					? directHookResult.text.trim()
+					: directHookResult.success
 						? "Done."
-						: "I couldn't complete that LifeOps request.";
+						: "I couldn't complete that request.";
 			strategyResult = createV5ReplyStrategyResult({
 				runtime,
 				message,
 				state,
 				responseId,
 				text: directText,
-				thought: "LifeOps direct workflow hook handled this request.",
+				thought: "A pre-LLM direct-message hook handled this request.",
 				mode: "simple",
 			});
 			_usedV5Runtime = true;

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
@@ -1,0 +1,69 @@
+/**
+ * Candidate-action backstop rule for LifeOps scheduled-task actions.
+ *
+ * The core message pipeline runs a coding-delegation backstop that, when a
+ * message reads as coding work, can strip candidate actions in favor of a
+ * coding-delegation action. LifeOps' scheduled-task admin actions
+ * (`SCHEDULED_TASKS*`) share verbs ("create", "make", "update") with coding
+ * requests, so without a rule a genuine "remind me tomorrow" turn whose
+ * candidate set included a scheduled-task action could be hijacked into a
+ * coding delegation.
+ *
+ * This rule declares LifeOps' scheduled-task action names plus a natural-
+ * language matcher so the pipeline protects those candidates on real
+ * scheduled-task turns and only strips them when the message is not one. It is
+ * registered into core via `registerCandidateActionBackstopRule` at plugin
+ * init — core no longer hardcodes these names or the heuristic.
+ */
+
+import type { CandidateActionBackstopRule } from "@elizaos/core";
+
+/**
+ * Canonical scheduled-task candidate action names the planner may emit for the
+ * `SCHEDULED_TASKS` umbrella action. Matched case/underscore-insensitively by
+ * the pipeline's action-identifier normalization.
+ */
+const SCHEDULED_TASK_ACTION_NAMES: readonly string[] = [
+  "SCHEDULED_TASKS",
+  "SCHEDULED_TASKS_ACKNOWLEDGE",
+  "SCHEDULED_TASKS_CANCEL",
+  "SCHEDULED_TASKS_COMPLETE",
+  "SCHEDULED_TASKS_CREATE",
+  "SCHEDULED_TASKS_DISMISS",
+  "SCHEDULED_TASKS_GET",
+  "SCHEDULED_TASKS_HISTORY",
+  "SCHEDULED_TASKS_LIST",
+  "SCHEDULED_TASKS_REOPEN",
+  "SCHEDULED_TASKS_SKIP",
+  "SCHEDULED_TASKS_SNOOZE",
+  "SCHEDULED_TASKS_UPDATE",
+];
+
+/**
+ * True when `text` is genuinely a scheduled-task / reminder request. Mirrors the
+ * heuristic previously hardcoded in core's message service.
+ */
+export function looksLikeScheduledTaskRequest(text: string): boolean {
+  const normalized = text.toLowerCase();
+  if (!normalized.trim()) {
+    return false;
+  }
+  return (
+    /\b(?:remind\s+me|reminder|scheduled\s+task|scheduled\s+item|lifeops|todo|to[- ]?do|snooze|recap|check[- ]?in|follow[- ]?up|watcher|approval)\b/iu.test(
+      normalized,
+    ) ||
+    /\b(?:schedule|create|make|add|set\s+up)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval)\b/iu.test(
+      normalized,
+    ) ||
+    /\b(?:tomorrow|tonight|later|next\s+(?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|every\s+(?:day|week|month|morning|evening))\b/iu.test(
+      normalized,
+    )
+  );
+}
+
+export function createScheduledTaskCandidateBackstopRule(): CandidateActionBackstopRule {
+  return {
+    actionNames: SCHEDULED_TASK_ACTION_NAMES,
+    matches: looksLikeScheduledTaskRequest,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -11,9 +11,12 @@ import {
   messagingTriageActions,
   type Plugin,
   promoteSubactionsToActions,
+  registerCandidateActionBackstopRule,
+  registerDirectMessageHook,
   registerLocalizedExamplesProvider,
   registerSendPolicy,
   type State,
+  unregisterDirectMessageHook,
 } from "@elizaos/core";
 import {
   getSelfControlPermissionState,
@@ -142,6 +145,7 @@ import {
   LIFEOPS_TASK_NAME,
   registerLifeOpsTaskWorker,
 } from "./lifeops/runtime.js";
+import { createScheduledTaskCandidateBackstopRule } from "./lifeops/scheduled-task/candidate-backstop.js";
 import { completeFiredTasksOnOwnerReply } from "./lifeops/scheduled-task/inbound-reply-completion.js";
 import {
   installLifeOpsScheduledTaskEventBridge,
@@ -1079,22 +1083,20 @@ const rawPersonalAssistantPlugin: Plugin = {
         lifeOpsMessageActionHook?: {
           handleMessageAction: typeof handleLifeOpsMessageAction;
         };
-        lifeOpsDirectMessageHook?: {
-          handleMessageRequest: typeof handleLifeOpsDirectMessageRequest;
-        };
       }
     ).lifeOpsMessageActionHook = {
       handleMessageAction: handleLifeOpsMessageAction,
     };
-    (
-      runtime as IAgentRuntime & {
-        lifeOpsDirectMessageHook?: {
-          handleMessageRequest: typeof handleLifeOpsDirectMessageRequest;
-        };
-      }
-    ).lifeOpsDirectMessageHook = {
-      handleMessageRequest: handleLifeOpsDirectMessageRequest,
-    };
+    // Pre-LLM direct-message hook: core invokes this before the planner/model
+    // runs, letting LifeOps handle certain requests (missed-call repair,
+    // document-signature, portal-upload) deterministically.
+    registerDirectMessageHook(runtime, handleLifeOpsDirectMessageRequest);
+    // Candidate-action backstop: protect LifeOps scheduled-task candidates from
+    // the core coding-delegation backstop on genuine scheduled-task turns.
+    registerCandidateActionBackstopRule(
+      runtime,
+      createScheduledTaskCandidateBackstopRule(),
+    );
 
     // First-party adapters backed by LifeOps services. Gmail and X replace the
     // core default adapters so MESSAGE triage operations operate on real
@@ -1223,8 +1225,7 @@ const rawPersonalAssistantPlugin: Plugin = {
   dispose: async (runtime: IAgentRuntime) => {
     delete (runtime as IAgentRuntime & { lifeOpsMessageActionHook?: unknown })
       .lifeOpsMessageActionHook;
-    delete (runtime as IAgentRuntime & { lifeOpsDirectMessageHook?: unknown })
-      .lifeOpsDirectMessageHook;
+    unregisterDirectMessageHook(runtime, handleLifeOpsDirectMessageRequest);
 
     const taskNames: readonly string[] = [
       PROACTIVE_TASK_NAME,


### PR DESCRIPTION
## #12092 item 5 [P1][M] — LifeOps planner logic hard-baked into core's message service

Core's `message.ts` hardcoded LifeOps' `SCHEDULED_TASKS_*` action names, an NL heuristic, and an untyped `lifeOpsDirectMessageHook` runtime property.

## Change — two generic extension points in core (no LifeOps names)
1. **`candidate-action-backstop.ts`** — per-runtime registry of `{ actionNames, matches(text) }` rules (follows the `SendPolicy`/`LocalizedExamplesProvider` pattern). The pipeline consults registered rules where it hardcoded `LIFEOPS_SCHEDULED_TASK_ACTIONS` + `looksLikeLifeOpsScheduledTaskRequest`.
2. **`direct-message-hook.ts`** — typed pre-LLM hook registry (`registerDirectMessageHook`/`runDirectMessageHooks`, first non-null wins) replacing the untyped runtime property.

**Deleted from message.ts:** `LIFEOPS_SCHEDULED_TASK_ACTIONS`, `looksLikeLifeOpsScheduledTaskRequest`, the `lifeOpsDirectMessageHook` cast/invocation (+ genericized incidental mentions). **plugin-personal-assistant** now registers its 13 action names + matcher (moved verbatim to `candidate-backstop.ts`) + its hook at `init`, and `unregisterDirectMessageHook` on dispose.

## Verification
- **Done-criterion:** `grep -ri lifeops packages/core/src/services/message.ts` → **0**.
- Candidate selection: generalized `applyCodingCandidateBackstop` reduces to the original for a single rule (same names + regex → identical output). Hook fires at the identical call site.
- Tests: 2 new seam suites **7 pass** + adapted Stage-1 backstop tests + bogus-candidates test (130 across the touched set per the run). core `tsc` 0 errors; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)