### PR TITLE
fix(desktop): register cross-process ScreenCaptureService via electrobun loopback bridge (#12249)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -35,6 +35,7 @@ import { setApplicationMenuActionHandler } from "./application-menu-action-regis
 import { showBackgroundNoticeOnce } from "./background-notice";
 import { getBrandConfig } from "./brand-config";
 import { startBrowserWorkspaceBridgeServer } from "./browser-workspace-bridge-server";
+import { startScreenCaptureBridgeServer } from "./screencapture-bridge-server";
 import { readNavigationEventUrl } from "./cloud-auth-window";
 import {
   appendChatOverlayShellModeParam,
@@ -2503,6 +2504,23 @@ async function main(): Promise<void> {
   });
   if (stopDesktopTestBridgeServer) {
     cleanupFns.push(stopDesktopTestBridgeServer);
+  }
+
+  // Start the native screen-capture bridge and publish ELIZA_DESKTOP_SCREENCAPTURE_*
+  // BEFORE the agent child spawns (below, via _startAgent), so the child inherits
+  // the bridge URL/token and its DesktopScreenCaptureService can reach the host's
+  // capture. Awaited (not fire-and-forget) so the env is guaranteed set in time.
+  const stopScreenCaptureBridgeServer = await startScreenCaptureBridgeServer().catch(
+    (err) => {
+      logger.warn(
+        `[Main] Screen-capture bridge startup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    },
+  );
+  recordStartupPhase("screencapture_bridge_ready", { pid: process.pid });
+  if (stopScreenCaptureBridgeServer) {
+    cleanupFns.push(stopScreenCaptureBridgeServer);
   }
 
   // WHY push API base on every status tick with a port: embedded startup can

--- a/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration test for the host-side screen-capture bridge. Starts the real
+ * loopback HTTP server with the native `ScreenCaptureManager` mocked out (so no
+ * electrobun/OS capture is touched) and drives it over the wire, asserting the
+ * token auth gate and the route → manager-method mapping the child service
+ * depends on (#12249).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const manager = {
+  startFrameCapture: vi.fn(async () => ({ available: true as const })),
+  stopFrameCapture: vi.fn(async () => ({ available: true as const })),
+  isFrameCaptureActive: vi.fn(async () => ({ active: false })),
+};
+
+vi.mock("./native/screencapture", () => ({
+  getScreenCaptureManager: () => manager,
+}));
+
+const { startScreenCaptureBridgeServer } = await import(
+  "./screencapture-bridge-server.js"
+);
+
+let stop: (() => void) | undefined;
+let baseUrl = "";
+let token = "";
+
+// One server for the suite: restarting on the same loopback port per test makes
+// undici reuse a stale keep-alive socket and ECONNRESET the next request.
+beforeAll(async () => {
+  delete process.env.ELIZA_DESKTOP_SCREENCAPTURE_URL;
+  delete process.env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN;
+  stop = await startScreenCaptureBridgeServer();
+  baseUrl = process.env.ELIZA_DESKTOP_SCREENCAPTURE_URL ?? "";
+  token = process.env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN ?? "";
+});
+
+afterAll(() => {
+  stop?.();
+  stop = undefined;
+  delete process.env.ELIZA_DESKTOP_SCREENCAPTURE_URL;
+  delete process.env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN;
+});
+
+beforeEach(() => {
+  manager.startFrameCapture.mockClear();
+  manager.stopFrameCapture.mockClear();
+  manager.isFrameCaptureActive.mockClear();
+});
+
+function authed(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, ...(init?.headers ?? {}) },
+  });
+}
+
+describe("startScreenCaptureBridgeServer", () => {
+  it("publishes a loopback URL and a token to the child env", () => {
+    expect(baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(token).toHaveLength(36);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(401);
+  });
+
+  it("answers health when authorized", async () => {
+    const res = await authed("/health");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("maps POST /frame-capture/start to the native manager", async () => {
+    const res = await authed("/frame-capture/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fps: 15,
+        quality: 70,
+        endpoint: "/api/stream/frame",
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: true });
+    expect(manager.startFrameCapture).toHaveBeenCalledWith({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+      gameUrl: undefined,
+    });
+  });
+
+  it("maps POST /frame-capture/stop and GET /frame-capture/active", async () => {
+    expect(
+      (await authed("/frame-capture/stop", { method: "POST" })).status,
+    ).toBe(200);
+    expect(manager.stopFrameCapture).toHaveBeenCalledOnce();
+
+    const active = await authed("/frame-capture/active");
+    expect(await active.json()).toEqual({ active: false });
+    expect(manager.isFrameCaptureActive).toHaveBeenCalledOnce();
+  });
+
+  it("404s an unknown path", async () => {
+    expect((await authed("/nope")).status).toBe(404);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts
@@ -1,0 +1,156 @@
+/**
+ * Loopback HTTP bridge exposing the electrobun host's native screen capture to
+ * the spawned agent child.
+ *
+ * Native frame capture (`native/screencapture.ts`) can only run in the MAIN
+ * process; the agent runs as a `Bun.spawn` child, so it reaches the manager over
+ * this token-guarded 127.0.0.1 server instead of a cross-process object handle
+ * (#12249). The child's `DesktopScreenCaptureService` (registered as
+ * `ServiceType.SCREEN_CAPTURE`) is the only caller. This mirrors
+ * `browser-workspace-bridge-server.ts`; started alongside it in `index.ts`, it
+ * publishes its URL + token via `ELIZA_DESKTOP_SCREENCAPTURE_URL` / `_TOKEN`
+ * before the child spawns so the child inherits them.
+ */
+
+import crypto from "node:crypto";
+import http from "node:http";
+import { findFirstAvailableLoopbackPort } from "./native/loopback-port";
+import { getScreenCaptureManager } from "./native/screencapture";
+
+const DEFAULT_BRIDGE_PORT = 31_342;
+const MAX_BODY_BYTES = 64 * 1024;
+
+/** Frame-capture options forwarded verbatim from the child service. */
+interface FrameCaptureStartBody {
+  fps?: number;
+  quality?: number;
+  endpoint?: string;
+  gameUrl?: string;
+}
+
+function isLoopback(addr: string | undefined): boolean {
+  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+}
+
+function isAuthorized(req: http.IncomingMessage, token: string): boolean {
+  // A random token is always generated at startup; an empty token means
+  // misconfiguration, so reject rather than fail open.
+  if (!token) return false;
+  return req.headers.authorization === `Bearer ${token}`;
+}
+
+function json(
+  res: http.ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(body));
+}
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | null> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) throw new Error("request body too large");
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) return null;
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as T;
+}
+
+/**
+ * Start the bridge and publish its address to the child env. Returns a stop
+ * function. Callers should start this before spawning the agent child so the
+ * `ELIZA_DESKTOP_SCREENCAPTURE_*` vars are inherited.
+ */
+export async function startScreenCaptureBridgeServer(): Promise<() => void> {
+  const requestedPort =
+    Number.parseInt(
+      (process.env.ELIZA_DESKTOP_SCREENCAPTURE_PORT ?? "").trim(),
+      10,
+    ) || DEFAULT_BRIDGE_PORT;
+  const port = await findFirstAvailableLoopbackPort(requestedPort, {
+    host: "127.0.0.1",
+    maxHops: 32,
+  });
+  const token =
+    (process.env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN ?? "").trim() ||
+    crypto.randomBytes(18).toString("hex");
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const manager = getScreenCaptureManager();
+
+  process.env.ELIZA_DESKTOP_SCREENCAPTURE_URL = baseUrl;
+  process.env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN = token;
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (!isLoopback(req.socket.remoteAddress)) {
+        json(res, 403, { error: "forbidden" });
+        return;
+      }
+      if (!isAuthorized(req, token)) {
+        json(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const pathname = url.pathname;
+      const method = req.method ?? "GET";
+
+      if (pathname === "/health" && method === "GET") {
+        json(res, 200, { ok: true });
+        return;
+      }
+
+      if (pathname === "/frame-capture/active" && method === "GET") {
+        json(res, 200, await manager.isFrameCaptureActive());
+        return;
+      }
+
+      if (pathname === "/frame-capture/start" && method === "POST") {
+        const body = (await readJsonBody<FrameCaptureStartBody>(req)) ?? {};
+        json(
+          res,
+          200,
+          await manager.startFrameCapture({
+            fps: body.fps,
+            quality: body.quality,
+            endpoint: body.endpoint,
+            gameUrl: body.gameUrl,
+          }),
+        );
+        return;
+      }
+
+      if (pathname === "/frame-capture/stop" && method === "POST") {
+        json(res, 200, await manager.stopFrameCapture());
+        return;
+      }
+
+      json(res, 404, { error: "not found" });
+    } catch (error) {
+      json(res, 500, {
+        error: error instanceof Error ? error.message : "internal error",
+      });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  console.log(
+    `[ScreenCaptureBridge] ${baseUrl} (loopback only; token required)`,
+  );
+
+  return () => {
+    server.close();
+  };
+}

--- a/packages/app-core/platforms/electrobun/src/startup-trace.ts
+++ b/packages/app-core/platforms/electrobun/src/startup-trace.ts
@@ -10,6 +10,7 @@ export const STARTUP_TRACE_PHASES = [
   "webgpu_initialized",
   "browser_workspace_bridge_ready",
   "desktop_test_bridge_ready",
+  "screencapture_bridge_ready",
   "creating_window",
   "window_ready",
   "autostart_requested",

--- a/packages/app-core/src/platform/desktop-screencapture-service.test.ts
+++ b/packages/app-core/src/platform/desktop-screencapture-service.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the child-side screen-capture proxy service. Drives the real
+ * `DesktopScreenCaptureService` against a stubbed `fetch`, verifying the bridge
+ * request shape (URL, method, JSON body, bearer auth), the local active-state
+ * cache, and the env-gated registration — the parts that must be correct for
+ * `getService(SCREEN_CAPTURE)` to light up on desktop (#12249). The real host
+ * bridge + native capture are covered by the electrobun-side test and manual
+ * desktop verification.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DesktopScreenCaptureService,
+  registerDesktopScreenCaptureService,
+  resolveScreenCaptureBridgeConfig,
+} from "./desktop-screencapture-service.js";
+
+const URL_KEY = "ELIZA_DESKTOP_SCREENCAPTURE_URL";
+const TOKEN_KEY = "ELIZA_DESKTOP_SCREENCAPTURE_TOKEN";
+
+function cleanEnv(): void {
+  delete process.env[URL_KEY];
+  delete process.env[TOKEN_KEY];
+}
+
+beforeEach(cleanEnv);
+afterEach(() => {
+  cleanEnv();
+  vi.restoreAllMocks();
+});
+
+describe("resolveScreenCaptureBridgeConfig", () => {
+  it("returns null when the bridge URL is unset or blank", () => {
+    expect(resolveScreenCaptureBridgeConfig({})).toBeNull();
+    expect(resolveScreenCaptureBridgeConfig({ [URL_KEY]: "   " })).toBeNull();
+  });
+
+  it("strips a trailing slash and reads the optional token", () => {
+    expect(
+      resolveScreenCaptureBridgeConfig({
+        [URL_KEY]: "http://127.0.0.1:31342/",
+        [TOKEN_KEY]: "secret",
+      }),
+    ).toEqual({ baseUrl: "http://127.0.0.1:31342", token: "secret" });
+  });
+
+  it("leaves the token undefined when only the URL is set", () => {
+    expect(
+      resolveScreenCaptureBridgeConfig({ [URL_KEY]: "http://127.0.0.1:31342" }),
+    ).toEqual({ baseUrl: "http://127.0.0.1:31342", token: undefined });
+  });
+});
+
+function makeService(): DesktopScreenCaptureService {
+  return new DesktopScreenCaptureService(undefined, {
+    baseUrl: "http://127.0.0.1:31342",
+    token: "secret",
+  });
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("DesktopScreenCaptureService.startFrameCapture", () => {
+  it("POSTs options with bearer auth and marks capture active", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ available: true }));
+    const service = makeService();
+
+    expect(service.isFrameCaptureActive()).toBe(false);
+    await service.startFrameCapture({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+    });
+
+    expect(service.isFrameCaptureActive()).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:31342/frame-capture/start");
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Authorization")).toBe(
+      "Bearer secret",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+    });
+  });
+
+  it("throws and stays inactive when the host declines", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ available: false, reason: "permission denied" }),
+    );
+    const service = makeService();
+
+    await expect(service.startFrameCapture({})).rejects.toThrow(
+      /permission denied/,
+    );
+    expect(service.isFrameCaptureActive()).toBe(false);
+  });
+
+  it("throws on a non-2xx bridge response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "boom" }, false),
+    );
+    await expect(makeService().startFrameCapture({})).rejects.toThrow(
+      /failed \(500\)/,
+    );
+  });
+});
+
+describe("DesktopScreenCaptureService.stopFrameCapture", () => {
+  it("clears active immediately and fires a stop request", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ available: true }));
+    const service = makeService();
+    await service.startFrameCapture({});
+    expect(service.isFrameCaptureActive()).toBe(true);
+
+    service.stopFrameCapture();
+    expect(service.isFrameCaptureActive()).toBe(false);
+    // Flush the fire-and-forget stop request.
+    await Promise.resolve();
+    expect((fetchMock.mock.calls.at(-1) as [string, RequestInit])[0]).toBe(
+      "http://127.0.0.1:31342/frame-capture/stop",
+    );
+  });
+});
+
+describe("DesktopScreenCaptureService.start", () => {
+  it("throws when no bridge is configured", async () => {
+    await expect(
+      DesktopScreenCaptureService.start({} as IAgentRuntime),
+    ).rejects.toThrow(/no bridge configured/);
+  });
+
+  it("builds a service from env", async () => {
+    process.env[URL_KEY] = "http://127.0.0.1:31342";
+    const service = await DesktopScreenCaptureService.start(
+      {} as IAgentRuntime,
+    );
+    expect(service).toBeInstanceOf(DesktopScreenCaptureService);
+  });
+});
+
+describe("registerDesktopScreenCaptureService", () => {
+  function fakeRuntime(existing: unknown = null) {
+    return {
+      getService: vi.fn().mockReturnValue(existing),
+      registerService: vi.fn().mockResolvedValue(undefined),
+    } as unknown as IAgentRuntime & {
+      getService: ReturnType<typeof vi.fn>;
+      registerService: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  it("is a no-op when the bridge env is absent", async () => {
+    const runtime = fakeRuntime();
+    expect(await registerDesktopScreenCaptureService(runtime, {})).toBe(false);
+    expect(runtime.registerService).not.toHaveBeenCalled();
+  });
+
+  it("registers the service when the bridge env is present", async () => {
+    const runtime = fakeRuntime();
+    const registered = await registerDesktopScreenCaptureService(runtime, {
+      [URL_KEY]: "http://127.0.0.1:31342",
+    });
+    expect(registered).toBe(true);
+    expect(runtime.registerService).toHaveBeenCalledWith(
+      DesktopScreenCaptureService,
+    );
+  });
+
+  it("does not re-register when the service already exists", async () => {
+    const runtime = fakeRuntime({ isFrameCaptureActive: () => false });
+    expect(
+      await registerDesktopScreenCaptureService(runtime, {
+        [URL_KEY]: "http://127.0.0.1:31342",
+      }),
+    ).toBe(true);
+    expect(runtime.registerService).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/platform/desktop-screencapture-service.ts
+++ b/packages/app-core/src/platform/desktop-screencapture-service.ts
@@ -1,0 +1,169 @@
+/**
+ * Child-side `ScreenCaptureService` that proxies to the electrobun desktop host.
+ *
+ * The real screen/frame capture lives in the electrobun MAIN process
+ * (`platforms/electrobun/src/native/screencapture.ts`), but the agent runs as a
+ * spawned child, so `runtime.getService(SCREEN_CAPTURE)` would otherwise be null
+ * and the streaming routes stay inert (#12249). The host starts a loopback HTTP
+ * bridge (`screencapture-bridge-server.ts`) and hands the child its URL + token
+ * via `ELIZA_DESKTOP_SCREENCAPTURE_URL` / `_TOKEN`; this service reads that env,
+ * registers as `ServiceType.SCREEN_CAPTURE`, and forwards start/stop over HTTP —
+ * mirroring the proven browser-workspace bridge pattern in @elizaos/plugin-browser.
+ *
+ * `isFrameCaptureActive()` is synchronous per the interface, so it reports a
+ * local cache set on start/stop rather than round-tripping to the host.
+ */
+
+import {
+  type IAgentRuntime,
+  IScreenCaptureService,
+  logger,
+  type ScreenCaptureFrameOptions,
+  type Service,
+} from "@elizaos/core";
+
+/** Bridge address + shared secret the electrobun host published to the child. */
+export interface ScreenCaptureBridgeConfig {
+  baseUrl: string;
+  token?: string;
+}
+
+/** How long to wait on a bridge control request before giving up. */
+const BRIDGE_REQUEST_TIMEOUT_MS = 10_000;
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve the desktop screen-capture bridge from env, or `null` when it is not
+ * configured (mobile/web/cloud, or the host never started the bridge). A `null`
+ * result is the signal to skip registration and let capture fall back to another
+ * mode, exactly like the browser-workspace bridge.
+ */
+export function resolveScreenCaptureBridgeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ScreenCaptureBridgeConfig | null {
+  const baseUrl = normalizeEnvValue(env.ELIZA_DESKTOP_SCREENCAPTURE_URL);
+  if (!baseUrl) return null;
+  return {
+    baseUrl: baseUrl.replace(/\/{1,1024}$/, ""),
+    token: normalizeEnvValue(env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN),
+  };
+}
+
+async function requestBridge<T>(
+  config: ScreenCaptureBridgeConfig,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const headers = new Headers(init?.headers ?? {});
+  headers.set("Accept", "application/json");
+  if (!headers.has("Content-Type") && init?.body) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (config.token) headers.set("Authorization", `Bearer ${config.token}`);
+
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(BRIDGE_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await response
+      .text()
+      .then((text) => text.trim().slice(0, 240))
+      .catch(() => "");
+    throw new Error(
+      `screencapture bridge ${path} failed (${response.status})${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+/**
+ * Registered as `ServiceType.SCREEN_CAPTURE` in the desktop child runtime.
+ * `@elizaos/plugin-streaming` resolves it via `getService` and drives
+ * start/stop; each call is proxied to the host's native capture over the bridge.
+ */
+export class DesktopScreenCaptureService extends IScreenCaptureService {
+  private readonly bridge: ScreenCaptureBridgeConfig;
+  private active = false;
+
+  // The `bridge` arg stays optional so the class matches the runtime's
+  // `ServiceClass` shape (`new (runtime?) => Service`); when omitted it is
+  // resolved from env, and an absent config is a real misconfiguration since
+  // registration is env-gated.
+  constructor(runtime?: IAgentRuntime, bridge?: ScreenCaptureBridgeConfig) {
+    super(runtime);
+    const resolved = bridge ?? resolveScreenCaptureBridgeConfig();
+    if (!resolved) {
+      throw new Error(
+        "[DesktopScreenCaptureService] no bridge configured (ELIZA_DESKTOP_SCREENCAPTURE_URL unset)",
+      );
+    }
+    this.bridge = resolved;
+  }
+
+  static override async start(runtime: IAgentRuntime): Promise<Service> {
+    const service = new DesktopScreenCaptureService(runtime);
+    logger.info(
+      `[DesktopScreenCaptureService] desktop capture bridged to ${service.bridge.baseUrl}`,
+    );
+    return service;
+  }
+
+  isFrameCaptureActive(): boolean {
+    return this.active;
+  }
+
+  async startFrameCapture(options: ScreenCaptureFrameOptions): Promise<void> {
+    const result = await requestBridge<{ available: boolean; reason?: string }>(
+      this.bridge,
+      "/frame-capture/start",
+      { method: "POST", body: JSON.stringify(options ?? {}) },
+    );
+    if (!result.available) {
+      this.active = false;
+      throw new Error(
+        `[DesktopScreenCaptureService] host declined frame capture${result.reason ? `: ${result.reason}` : ""}`,
+      );
+    }
+    this.active = true;
+  }
+
+  stopFrameCapture(): void {
+    // Optimistically clear local state; the host stop is fire-and-forget so a
+    // slow/failed teardown never blocks the caller (interface returns void).
+    this.active = false;
+    void requestBridge(this.bridge, "/frame-capture/stop", {
+      method: "POST",
+    }).catch((err) => {
+      logger.warn(
+        `[DesktopScreenCaptureService] stop request failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.stopFrameCapture();
+  }
+}
+
+/**
+ * Register the proxy service on the desktop child runtime when the host bridge
+ * is configured. No-op (returns false) on mobile/web/cloud or before the host
+ * publishes the bridge env, so non-desktop boots are unaffected.
+ */
+export async function registerDesktopScreenCaptureService(
+  runtime: IAgentRuntime,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (!resolveScreenCaptureBridgeConfig(env)) return false;
+  if (runtime.getService(DesktopScreenCaptureService.serviceType)) return true;
+  await runtime.registerService(DesktopScreenCaptureService);
+  return true;
+}

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -23,6 +23,7 @@ import {
   startEliza as upstreamStartEliza,
 } from "@elizaos/agent";
 import { installAgentHostBridge } from "./install-agent-host-bridge.js";
+import { registerDesktopScreenCaptureService } from "../platform/desktop-screencapture-service.js";
 
 export { CHANNEL_PLUGIN_MAP } from "./channel-plugin-map.js";
 
@@ -724,6 +725,21 @@ async function repairRuntimeAfterBoot(
   }
 
   await (await _localInference()).ensureLocalInferenceHandler(runtime);
+
+  // Desktop only (the mobile early-return above skips this): register the
+  // screen-capture service backed by the electrobun host's loopback bridge so
+  // the streaming routes can drive capture. No-op when the host never published
+  // the bridge env (dev/web/cloud), leaving capture on its fallback path.
+  try {
+    if (await registerDesktopScreenCaptureService(runtime)) {
+      logger.info("[eliza] Desktop screen-capture service registered");
+    }
+  } catch (error) {
+    logger.warn(
+      `[eliza] Desktop screen-capture service registration failed: ${formatError(error)}`,
+    );
+  }
+
   const autonomyLoopEnabled = isRuntimeAutonomyEnabled(process.env);
   if (autonomyLoopEnabled) {
     await ensureAutonomyBootstrapContext(runtime);


### PR DESCRIPTION
Closes #12249.

## Problem

`ScreenCaptureService` (`ServiceType.SCREEN_CAPTURE`) is declared in `@elizaos/core` and `packages/agent/src/api/server.ts` resolves it via `runtime.getService(SCREEN_CAPTURE)` to hand `@elizaos/plugin-streaming` a capture driver. But **nothing registered a producer**: the only real implementation is the electrobun host's native `ScreenCaptureManager`, which lives in the **main process**, while the agent runs as a `Bun.spawn` child. So `getService` returned `null` and desktop screen-capture / streaming routes were inert.

## Fix — mirror the proven browser-workspace bridge

No new IPC concept is invented; this copies the exact pattern `@elizaos/plugin-browser` already uses for the electrobun browser workspace (parent loopback HTTP server + token, published to the child via env at spawn).

- **Host** — `packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts`: a token-guarded `127.0.0.1` server exposing `POST /frame-capture/start`, `POST /frame-capture/stop`, `GET /frame-capture/active`, `GET /health`, each mapping to `getScreenCaptureManager()`. Started alongside the browser-workspace bridge in `index.ts`, **awaited before** the agent child spawns, and publishes `ELIZA_DESKTOP_SCREENCAPTURE_URL` / `_TOKEN` (inherited by the child).
- **Child** — `packages/app-core/src/platform/desktop-screencapture-service.ts`: `DesktopScreenCaptureService` reads that env, registers as `ServiceType.SCREEN_CAPTURE`, and forwards `startFrameCapture`/`stopFrameCapture` over HTTP. `isFrameCaptureActive()` is sync per the interface, so it reports a local cache set on start/stop.
- **Registration** — `runtime/eliza.ts` `repairRuntimeAfterBoot` (desktop-only, past the mobile early-return) calls `registerDesktopScreenCaptureService`, a **no-op when the bridge env is absent** (dev/web/cloud), so non-desktop boots are unaffected.

Dependency direction is respected (core ← agent ← app-core): the proxy + registration live in app-core, which owns the electrobun platform; core/agent are untouched.

## Verification

**Automated (green in this worktree):**
- `packages/app-core/src/platform/desktop-screencapture-service.test.ts` — **12 tests**: config resolution (unset/blank/trailing-slash/token), request shape (URL, method, JSON body, `Authorization: Bearer`), active-state cache, decline + non-2xx error paths, and env-gated registration (no-op when absent / registers when present / no double-register).
- `packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts` — **6 tests**: real HTTP server with the native manager mocked; 401 without token, health, and the route→manager mapping for start/stop/active + 404.
- `bun run --cwd packages/app-core typecheck` and `bun run --cwd packages/app-core/platforms/electrobun typecheck` pass; biome clean.

**Human/desktop verification (requested before merge — cannot run in this worktree):**
- Launch the desktop app, start a stream, and confirm `[DesktopScreenCaptureService] desktop capture bridged to …` + `[ScreenCaptureBridge] http://127.0.0.1:…` in logs, `getService(SCREEN_CAPTURE)` non-null, and real frames reaching `/api/stream/screen`.
- Per-platform capture (macOS `screencapture`, Linux `scrot`, Windows PowerShell) via the existing native manager — unchanged by this PR, only now reachable.

N/A — no LLM/agent-trajectory or web-UI surface changes (desktop host wiring + a server-side service), so model trajectories and app screenshots do not apply; the desktop walkthrough above is the relevant evidence and is flagged for the human verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)