### PR TITLE
fix(#12216): local-LLM pipeline hardening — training/quant/publish (finite-weights guard, NaN-guard, tier-agreement, kernel-parity CI, reproducibility)

### DIFF
--- a/.github/issue-evidence/12216-training-status.md
+++ b/.github/issue-evidence/12216-training-status.md
@@ -7,7 +7,35 @@ Scope: Python training/quant/publish + data-capture only
 plugin-local-inference and cloud fixes (C5/C6/C8/C9/C11/C12/C13/C15/C16/C18) are
 a separate agent's scope and are NOT touched here.
 
-## Fixes landed (9 commits, per-fix)
+## Adversarial-review follow-ups (3 confirmed issues — all fixed)
+
+A coordinator adversarial review found three real issues. All fixed in this
+worktree, committed (not pushed):
+
+1. **[HIGH] New regression tests never ran in CI.** The `cpu-smoke` pytest list
+   is hardcoded and only `test_recipes_smoke.py` had been added — the C2 finite-
+   guard, C3 registry, C4 manifest-agreement, and C10/C14/C17 tests were never
+   executed by CI. **Fix (`855b734ac9b`):** added all seven of my test files to
+   the `cpu-smoke` invocation. Verified each is listed in the YAML.
+2. **[HIGH] False green from silently-skipping parity tests.** `test_recipes_
+   smoke.py`'s C-reference byte-exact parity tests resolved to a NONEXISTENT
+   `packages/training/inference/{verify,reference}/` path, so all six silently
+   `pytest.skip`'d — coverage theater. The real C refs DO exist, at
+   `plugins/plugin-local-inference/native/{verify,reference}/` (directly tracked,
+   not a submodule). **Fix (`a30d8383487`):** corrected the path resolution
+   (`_HERE.parents[3]`) with an `ELIZA_KERNEL_REF_DIR` override, and the CI step
+   now mounts that dir + sets the env so the parity tests **compile-and-run in
+   CI** instead of skipping. Verified: the six parity tests now RUN (35 passed,
+   0 skipped locally, was 29 passed + 6 skipped). When refs are genuinely absent
+   the skip is loud and names the exact missing file — no silent skip.
+3. **[MEDIUM] C10 tokenizer hash never captured.** `train_local.py` called
+   `log_environment()` without `tokenizer_path`, so the tokenizer artifact hash
+   (required by AGENTS.md §9) was missing. **Fix (`4449deaa6d9`):** train_local.py
+   now materializes the exact tokenizer (incl. chat-template override) to
+   `out_dir/tokenizer` and passes it; a regression test asserts the tokenizer
+   sha256 lands in `environment.json`.
+
+## Fixes landed (per-fix commits)
 
 | Fix | Commit | Summary |
 | --- | --- | --- |
@@ -15,8 +43,8 @@ a separate agent's scope and are NOT touched here.
 | **C1** (P0) | `521f6ae101a` | Ported the gemma4_unified Liger-off NaN-guard from stranded commit `b7e412f41cb` into `train_local.py`: `model_type` / `architectures` containing `gemma4_unified` / `Gemma4Unified*` → force `use_liger=False` + warn. No-op when the arch is absent (develop has no gemma4_unified today) — defensive insurance. |
 | **C3** (P1) | `65f2381257f` | Set `use_liger=False` explicitly on `gemma4-12b` and `gemma4-31b` registry entries — registry is now the single source of truth, no code/registry split-brain. |
 | **C4** (P1) | `b71392b28dd` | Catalog↔manifest↔publish tier-set agreement test. Python: new `test_catalog_manifest_publish_tiers_agree` mechanically parses `TIERS=(...)` out of `publish_all_eliza1.sh` and asserts == `ELIZA_1_TIERS`. TS: new `catalog.test.ts` case pins `ELIZA_1_TIER_IDS` + bare-tier projection. |
-| **C7** (P1) | `8696ff7816d` | Wired `quantization/test_recipes_smoke.py` into `training-stack.yml` `cpu-smoke` pytest list (CI docker image already `uv sync --extra train`, tests skip cleanly without C refs/compiler). Drive-by: fixed stale `eliza/packages/inference/...` + `.../native-plugins/...` path comments in `_kernel_manifest.py` + `test_recipes_smoke.py` → real `packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/`. |
-| **C10** (P2) | `b250717ae55` | Extended `log_environment()` with the AGENTS.md §9 reproducibility manifest: sha256 of dataset files, tokenizer-artifact hash (dir digests combined), base-checkpoint hash, `git rev-parse HEAD` (+ dirty flag). Non-local HF ids skipped, not faked. |
+| **C7** (P1) | `8696ff7816d`, `a30d8383487`, `855b734ac9b` | Wired `quantization/test_recipes_smoke.py` into `training-stack.yml` `cpu-smoke`. **After review**: fixed the C-ref path bug so the six byte-exact parity tests actually COMPILE-AND-RUN (not silently skip), and the CI step mounts `plugins/plugin-local-inference/native` + sets `ELIZA_KERNEL_REF_DIR` so they run for real in CI. Drive-by: fixed stale `eliza/packages/inference/...` path comments → real `packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/`. |
+| **C10** (P2) | `b250717ae55`, `4449deaa6d9` | Extended `log_environment()` with the AGENTS.md §9 reproducibility manifest: sha256 of dataset files, tokenizer-artifact hash (dir digests combined), base-checkpoint hash, `git rev-parse HEAD` (+ dirty flag). Non-local HF ids skipped, not faked. **After review**: `train_local.py` now passes `tokenizer_path` (materialized to `out_dir/tokenizer`) so the tokenizer hash is actually captured. |
 | **C14** (P2) | `dc7d552ff23` | New `eliza-1.manifest.schema.json` (draft 2020-12) backing the `$schema` URL; promoted a real versioned fixture `fixtures/eliza-1-4b.manifest.json` (built via `build_manifest`, not the cache stub); test runs the fixture through BOTH `validate_manifest()` and the JSON Schema, asserts both agree. |
 | **C17** (P2) | `6bdc46b51b3` | Content-hash dedup for `eliza_native_v1` rows in `prepare_eliza1_trajectory_dataset.py`, keyed on canonical native `(request, response)` (provenance excluded). On by default; `--no-dedup` escape hatch; count surfaced as `manifest.droppedDuplicateNativeRows`. |
 | **doc drift** | `7f500fb7957` | Fixed stale trajectory state-dir path in `AGENTS.md` + mirrored `CLAUDE.md`: was `~/.eliza/state`, code resolves `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` (`packages/core/src/utils/state-dir.ts`). Docs kept in lockstep. |
@@ -26,16 +54,16 @@ a separate agent's scope and are NOT touched here.
 Python (via `uv run --no-project --with pytest --with torch --with numpy --with transformers --with scipy --with jsonschema`):
 
 ```
-scripts/training/test_finite_guard.py           -> 11 passed
-scripts/training/test_model_registry.py         -> 20 passed
-scripts/training/test_instrumentation.py        ->  6 passed
-scripts/training/test_optimizer_cpu.py          -> (in aggregate) passed / 5 apollo_torch-gated skips
-scripts/manifest/test_eliza1_manifest.py        -> passed (incl. C4 agreement + existing canonical test)
-scripts/manifest/test_eliza1_manifest_schema.py ->  7 passed
-scripts/quantization/test_recipes_smoke.py      -> 29 passed, 6 skipped (C-ref/compiler + GPU-gated)
-scripts/test_prepare_eliza1_trajectory_dataset.py -> 8 passed (3 new dedup cases)
+scripts/training/test_finite_guard.py             -> 11 passed
+scripts/training/test_model_registry.py           -> 20 passed
+scripts/training/test_instrumentation.py          ->  7 passed  (+1 tokenizer-hash regression)
+scripts/training/test_optimizer_cpu.py            ->  1 passed,  5 skipped (apollo_torch-gated)
+scripts/manifest/test_eliza1_manifest.py          -> 69 passed  (incl. C4 agreement)
+scripts/manifest/test_eliza1_manifest_schema.py   ->  7 passed
+scripts/quantization/test_recipes_smoke.py        -> 35 passed,  0 skipped  (was 29+6; C-ref parity now RUNS)
+scripts/test_prepare_eliza1_trajectory_dataset.py ->  8 passed  (3 dedup cases)
 
-Aggregate run of all eight files: 151 passed, 11 skipped in ~28s.
+Aggregate run of all eight files: 158 passed, 5 skipped in ~7s.
 ruff check on every changed .py: All checks passed!
 ```
 
@@ -45,12 +73,23 @@ TS (via `bunx vitest run` in `packages/shared`):
 packages/shared/src/local-inference/catalog.test.ts -> 11 passed
 ```
 
-CI config: `.github/workflows/training-stack.yml` validated as well-formed YAML.
+CI config: `.github/workflows/training-stack.yml` validated as well-formed YAML;
+all seven new/modified test files are listed in the `cpu-smoke` pytest
+invocation, and the job mounts the kernel-ref dir so the parity tests run there.
 
-The 11 skips are all clean, load-bearing skips: `apollo_torch`-gated optimizer
-tests (package not installed locally) and the C-reference byte-exact
-kernel-parity + GPU tests (skip when the C ref files / a C compiler are absent —
-verified the skip messages, not silent passes).
+**C7 parity-test disclosure (honest):** the six C-reference byte-exact parity
+tests in `test_recipes_smoke.py` (`test_qjl_block_layout_packing_matches_c_ref`,
+`test_polarquant_block_dequant_parity_against_c_ref`,
+`test_qjl_projection_layout_matches_c_ref`,
+`test_polarquant_full_block_parity_against_c_ref`,
+`test_polarquant_python_sign_vector_pinned`,
+`test_kernel_reference_files_exist_and_compile_clean`) **now COMPILE the real C
+references and RUN** (they used to silently skip against a nonexistent path). The
+remaining 5 skips in the aggregate are only the `apollo_torch`-gated optimizer
+tests — that package isn't installed in the minimal local env; it IS present in
+the CI `--extra train` image, where those run too. There are no longer any
+silent parity skips masquerading as coverage. If the kernel-ref dir is ever
+genuinely absent, the skip is loud and names the exact missing file.
 
 ## ⚑ C19 — MAINTAINER DECISION REQUIRED (not implemented — do not guess)
 
@@ -115,13 +154,19 @@ Per plan section D. These cannot be exercised in this worktree (no GPU, no
   `test_eliza1_tier_ids_are_canonical`. I added the *three-file* agreement check
   (mechanical parse of `publish_all_eliza1.sh::TIERS`) which was the missing
   piece, plus the TS half.
-- **C7 stale-path caveat:** the plan said the functional path resolution in
-  `test_recipes_smoke.py` "resolves correctly" and only the comments were wrong.
-  In fact the functional `_REF_C`/`_TURBO_C` paths point at
-  `packages/training/inference/{verify,reference}/` which does not exist, and the
-  named C ref files (`qjl_polar_ref.c` / `turbo_kernels.c`) don't exist anywhere
-  in the tree — so those C-parity tests **skip** (they don't fail). I fixed the
-  stale *comments* (in C7 scope) to point at the real
-  `packages/native/plugins/...` locations; wiring up the actual C references is
-  GPU/kernel-repo work outside Part A.
+- **C7 stale-path — corrected after review:** the plan said the functional path
+  resolution "resolves correctly" and only the comments were wrong. In fact the
+  functional `_REF_C`/`_TURBO_C` paths pointed at a nonexistent
+  `packages/training/inference/{verify,reference}/`, so the six C-parity tests
+  silently skipped — a false green. The real C refs (`qjl_polar_ref.c` /
+  `turbo_kernels.c`) DO exist, at
+  `plugins/plugin-local-inference/native/{verify,reference}/` (directly tracked,
+  not a submodule). My first pass only fixed the stale prose comments. After the
+  adversarial review I fixed the actual path resolution (`_HERE.parents[3]` +
+  `ELIZA_KERNEL_REF_DIR` override) so the parity tests **compile-and-run** (35
+  passed, 0 skipped), and the CI step mounts that dir so they run in CI too. The
+  `packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/` header/
+  centroid comments remain accurate for the *codebook* pins; the compiled
+  C-reference sources are the `plugin-local-inference/native/{verify,reference}`
+  ones.
 ```

--- a/.github/issue-evidence/12216-training-status.md
+++ b/.github/issue-evidence/12216-training-status.md
@@ -1,0 +1,127 @@
+# Issue #12216 — Part A: training / quant / publish / data-capture hardening
+
+Branch: `fix/12216-training-pipeline-hardening` (off develop tip `03dbd8c501e`).
+Scope: Python training/quant/publish + data-capture only
+(`packages/training/`, plus one shared test in
+`packages/shared/src/local-inference/catalog.test.ts`). The
+plugin-local-inference and cloud fixes (C5/C6/C8/C9/C11/C12/C13/C15/C16/C18) are
+a separate agent's scope and are NOT touched here.
+
+## Fixes landed (9 commits, per-fix)
+
+| Fix | Commit | Summary |
+| --- | --- | --- |
+| **C2** (P0) | `7bf49703e19` | Generic post-step finite-weights guard (`assert_finite_step` / `FiniteWeightsCallback`) in `training/instrumentation.py`, wired unconditionally into `train_local.py`. Checks `torch.isfinite()` across trainable params every `logging_steps` and raises `RuntimeError` naming offenders so a divergent run dies within one save interval instead of writing an all-NaN checkpoint. **Also fixed a latent MRO bug**: the existing `make_hf_callback` listed `TrainerCallback` first, so the base's no-op `on_step_end`/`on_train_begin`/`on_train_end` shadowed the instrumentation hooks — the memory-budget breach guard and tokens/sec trace never fired. Reversed base order (mixin first) on both factories. |
+| **C1** (P0) | `521f6ae101a` | Ported the gemma4_unified Liger-off NaN-guard from stranded commit `b7e412f41cb` into `train_local.py`: `model_type` / `architectures` containing `gemma4_unified` / `Gemma4Unified*` → force `use_liger=False` + warn. No-op when the arch is absent (develop has no gemma4_unified today) — defensive insurance. |
+| **C3** (P1) | `65f2381257f` | Set `use_liger=False` explicitly on `gemma4-12b` and `gemma4-31b` registry entries — registry is now the single source of truth, no code/registry split-brain. |
+| **C4** (P1) | `b71392b28dd` | Catalog↔manifest↔publish tier-set agreement test. Python: new `test_catalog_manifest_publish_tiers_agree` mechanically parses `TIERS=(...)` out of `publish_all_eliza1.sh` and asserts == `ELIZA_1_TIERS`. TS: new `catalog.test.ts` case pins `ELIZA_1_TIER_IDS` + bare-tier projection. |
+| **C7** (P1) | `8696ff7816d` | Wired `quantization/test_recipes_smoke.py` into `training-stack.yml` `cpu-smoke` pytest list (CI docker image already `uv sync --extra train`, tests skip cleanly without C refs/compiler). Drive-by: fixed stale `eliza/packages/inference/...` + `.../native-plugins/...` path comments in `_kernel_manifest.py` + `test_recipes_smoke.py` → real `packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/`. |
+| **C10** (P2) | `b250717ae55` | Extended `log_environment()` with the AGENTS.md §9 reproducibility manifest: sha256 of dataset files, tokenizer-artifact hash (dir digests combined), base-checkpoint hash, `git rev-parse HEAD` (+ dirty flag). Non-local HF ids skipped, not faked. |
+| **C14** (P2) | `dc7d552ff23` | New `eliza-1.manifest.schema.json` (draft 2020-12) backing the `$schema` URL; promoted a real versioned fixture `fixtures/eliza-1-4b.manifest.json` (built via `build_manifest`, not the cache stub); test runs the fixture through BOTH `validate_manifest()` and the JSON Schema, asserts both agree. |
+| **C17** (P2) | `6bdc46b51b3` | Content-hash dedup for `eliza_native_v1` rows in `prepare_eliza1_trajectory_dataset.py`, keyed on canonical native `(request, response)` (provenance excluded). On by default; `--no-dedup` escape hatch; count surfaced as `manifest.droppedDuplicateNativeRows`. |
+| **doc drift** | `7f500fb7957` | Fixed stale trajectory state-dir path in `AGENTS.md` + mirrored `CLAUDE.md`: was `~/.eliza/state`, code resolves `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` (`packages/core/src/utils/state-dir.ts`). Docs kept in lockstep. |
+
+## Real test output (headless, CPU-only, this worktree)
+
+Python (via `uv run --no-project --with pytest --with torch --with numpy --with transformers --with scipy --with jsonschema`):
+
+```
+scripts/training/test_finite_guard.py           -> 11 passed
+scripts/training/test_model_registry.py         -> 20 passed
+scripts/training/test_instrumentation.py        ->  6 passed
+scripts/training/test_optimizer_cpu.py          -> (in aggregate) passed / 5 apollo_torch-gated skips
+scripts/manifest/test_eliza1_manifest.py        -> passed (incl. C4 agreement + existing canonical test)
+scripts/manifest/test_eliza1_manifest_schema.py ->  7 passed
+scripts/quantization/test_recipes_smoke.py      -> 29 passed, 6 skipped (C-ref/compiler + GPU-gated)
+scripts/test_prepare_eliza1_trajectory_dataset.py -> 8 passed (3 new dedup cases)
+
+Aggregate run of all eight files: 151 passed, 11 skipped in ~28s.
+ruff check on every changed .py: All checks passed!
+```
+
+TS (via `bunx vitest run` in `packages/shared`):
+
+```
+packages/shared/src/local-inference/catalog.test.ts -> 11 passed
+```
+
+CI config: `.github/workflows/training-stack.yml` validated as well-formed YAML.
+
+The 11 skips are all clean, load-bearing skips: `apollo_torch`-gated optimizer
+tests (package not installed locally) and the C-reference byte-exact
+kernel-parity + GPU tests (skip when the C ref files / a C compiler are absent —
+verified the skip messages, not silent passes).
+
+## ⚑ C19 — MAINTAINER DECISION REQUIRED (not implemented — do not guess)
+
+`packages/training/scripts/manifest/eliza1_manifest.py::REQUIRED_KERNELS_BY_TIER`
+requires `turbo3_tcq` on **all five tiers** (`2b/4b/9b/27b/27b-256k`), but
+`packages/training/AGENTS.md` §3 frames Trellis-coded TCQ as
+"(long-context-only) ... the largest variant". These disagree. Two possible
+reconciliations — a human must pick:
+
+1. **Code is right (TCQ is universal post-Gemma-cutover):** update AGENTS.md §3
+   to drop the "long-context-only" framing and document that `turbo3_tcq` is a
+   universal required kernel. The TS-side validator comment implies this is the
+   deliberate post-cutover behavior, which slightly favors this option — but it
+   is not conclusive.
+2. **Doc is right (TCQ is long-context-only):** scope
+   `REQUIRED_KERNELS_BY_TIER`'s `turbo3_tcq` requirement back to just
+   `27b-256k`.
+
+I did **not** change `REQUIRED_KERNELS_BY_TIER` or AGENTS.md §3 — flipping either
+side changes the publish gate's required-kernel contract, which is a product
+decision, not a mechanical fix. Existing test
+`test_eliza1_manifest.py::test_eliza1_tier_ids_are_canonical` currently pins the
+all-tiers behavior, so option (2) would also require updating that assertion.
+
+## GPU / HF-gated remainder (out of headless scope — deferred to CI / operator)
+
+Per plan section D. These cannot be exercised in this worktree (no GPU, no
+`HF_TOKEN`, no device matrix):
+
+- **GPU-gated (the load-bearing C1/C3 confirmation):** actually re-running the
+  12B/31B SFT after C1/C3 land to confirm no NaN divergence. The code fix is in
+  place and unit-tested at the guard level (C2), but *live* NaN-prevention needs
+  a real 12B/31B run. Recipe: on an FSDP box (e.g. 2×H200),
+  `uv run --extra train python scripts/train_local.py --registry-key gemma4-12b
+  --train-file data/final/train.jsonl` (or `scripts/train_vast.sh`) and confirm
+  the first ~50 steps' loss stays finite + the saved checkpoint's weights pass
+  `assert_finite_step`. With C2 wired, a divergent run now dies loudly within one
+  `logging_steps` interval instead of saving dead weights.
+- **GPU-gated (quant):** the four real-artifact quant runs
+  (`test_turboquant.py` / `test_qjl.py` / `test_polarquant.py` /
+  `test_fused_turboquant.py`) against real Gemma checkpoints, and measured
+  `4b`/`9b`/`27b`/`27b-256k` tier evidence (only `2b` has published numbers
+  today). The `--trellis`/TCQ path has zero measured evidence for any tier. C7
+  wires the *synthetic CPU* smoke + C-ref parity into CI; the real-artifact runs
+  remain GPU-gated by design.
+- **HF-gated (corpus durability):** actually invoking
+  `scripts/publish_dataset_to_hf.py` to push a real corpus snapshot (code is
+  ready; needs `HF_TOKEN` + network). C17 makes the corpus dedup-clean before
+  push. Recipe: `HF_TOKEN=hf_xxx uv run python -m scripts.publish.publish_dataset
+  --dry-run` first, then without `--dry-run` to push. Nothing invokes this
+  automatically today — corpus durability remains operator-run-only (the "lost a
+  corpus to a pruned worktree" concern is mitigated by dedup + reproducibility
+  hashing here, but automatic durable backup is out of Part-A scope).
+
+## Notes on plan deltas found while implementing
+
+- **C2 uncovered a real adjacent bug** (shadowed `make_hf_callback` MRO — the
+  memory-budget guard never fired). Fixed in the same commit since it is the
+  same one-line ordering fix in the same module and directly in the spirit of
+  "make guards actually fire"; added an MRO regression test.
+- **C4 Python half was already partly covered** by the pre-existing
+  `test_eliza1_tier_ids_are_canonical`. I added the *three-file* agreement check
+  (mechanical parse of `publish_all_eliza1.sh::TIERS`) which was the missing
+  piece, plus the TS half.
+- **C7 stale-path caveat:** the plan said the functional path resolution in
+  `test_recipes_smoke.py` "resolves correctly" and only the comments were wrong.
+  In fact the functional `_REF_C`/`_TURBO_C` paths point at
+  `packages/training/inference/{verify,reference}/` which does not exist, and the
+  named C ref files (`qjl_polar_ref.c` / `turbo_kernels.c`) don't exist anywhere
+  in the tree — so those C-parity tests **skip** (they don't fail). I fixed the
+  stale *comments* (in C7 scope) to point at the real
+  `packages/native/plugins/...` locations; wiring up the actual C references is
+  GPU/kernel-repo work outside Part A.
+```

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -96,10 +96,19 @@ jobs:
       - name: Run pure-python test suite
         # All pytest files in scripts/ that don't need GPU. test_reward_fn
         # may be a no-op in some branches; we still surface its result.
+        #
+        # We ALSO mount the local-inference plugin's kernel-reference tree at
+        # /workspace/kernel-refs and point ELIZA_KERNEL_REF_DIR at it, so
+        # test_recipes_smoke.py's C-reference byte-exact parity tests actually
+        # COMPILE-AND-RUN in CI instead of silently skipping (they used to skip
+        # against a nonexistent path — a false green). The CPU image ships a C
+        # compiler (cc) for exactly this.
         run: |
           docker run --rm \
             -v "${{ github.workspace }}/packages/training:/workspace/live" \
+            -v "${{ github.workspace }}/plugins/plugin-local-inference/native:/workspace/kernel-refs:ro" \
             -e PYTHONPATH=/workspace/live/scripts \
+            -e ELIZA_KERNEL_REF_DIR=/workspace/kernel-refs \
             eliza-training-cpu:ci \
             -c "set -e; \
                 cd /workspace/live; \
@@ -109,7 +118,13 @@ jobs:
                   scripts/test_cap_distribution.py \
                   scripts/test_reward_fn.py \
                   scripts/test_tier_caps.py \
-                  scripts/quantization/test_recipes_smoke.py"
+                  scripts/quantization/test_recipes_smoke.py \
+                  scripts/training/test_finite_guard.py \
+                  scripts/training/test_instrumentation.py \
+                  scripts/training/test_model_registry.py \
+                  scripts/manifest/test_eliza1_manifest.py \
+                  scripts/manifest/test_eliza1_manifest_schema.py \
+                  scripts/test_prepare_eliza1_trajectory_dataset.py"
 
       - name: Corpus-quality chain end-to-end smoke
         # Synthesizer dry-runs → classifier → audit --strict-phases →

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -108,7 +108,8 @@ jobs:
                   scripts/test_eliza_record.py \
                   scripts/test_cap_distribution.py \
                   scripts/test_reward_fn.py \
-                  scripts/test_tier_caps.py"
+                  scripts/test_tier_caps.py \
+                  scripts/quantization/test_recipes_smoke.py"
 
       - name: Corpus-quality chain end-to-end smoke
         # Synthesizer dry-runs → classifier → audit --strict-phases →

--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -25,6 +25,26 @@ const EXPECTED_CHAT_PARAMS: Record<string, string> = {
 };
 
 describe("Eliza-1 runtime quant metadata", () => {
+  it("pins the canonical tier set (three-file agreement)", () => {
+    // The Eliza-1 tier set is declared in THREE places that must stay in sync:
+    // catalog.ts::ELIZA_1_TIER_IDS (here), eliza1_manifest.py::ELIZA_1_TIERS,
+    // and publish_all_eliza1.sh::TIERS. Renaming a tier means updating all
+    // three together (the Python + shell surfaces are enforced in
+    // packages/training/scripts/manifest/test_eliza1_manifest.py::
+    // test_catalog_manifest_publish_tiers_agree). The runtime catalog uses the
+    // full `eliza-1-<tier>` slugs; the bare tier ids are what the manifest and
+    // publish matrix key on.
+    expect(ELIZA_1_TIER_IDS).toEqual([
+      "eliza-1-2b",
+      "eliza-1-4b",
+      "eliza-1-9b",
+      "eliza-1-27b",
+      "eliza-1-27b-256k",
+    ]);
+    const bareTiers = ELIZA_1_TIER_IDS.map((id) => id.slice("eliza-1-".length));
+    expect(bareTiers).toEqual(["2b", "4b", "9b", "27b", "27b-256k"]);
+  });
+
   it("keeps stable ids but exposes requested size-cased display names", () => {
     for (const id of ELIZA_1_TIER_IDS) {
       const entry = MODEL_CATALOG.find((model) => model.id === id);

--- a/packages/training/AGENTS.md
+++ b/packages/training/AGENTS.md
@@ -14,8 +14,10 @@ applies to everything under `packages/training/`.
 - **TESTING HARNESS:** Nebius (OpenAI-compatible inference endpoint
   used for rollouts during RL — `NEBIUS_BASE_URL`, `NEBIUS_API_KEY`).
 - **Continuous RL data:** on-disk JSONL exports under
-  `${ELIZA_STATE_DIR:-~/.eliza/state}/trajectories/`, written by the
-  eliza native trajectory recorder. No database dependency.
+  `${ELIZA_STATE_DIR}/trajectories/`, written by the eliza native trajectory
+  recorder. The state dir resolves (see `packages/core/src/utils/state-dir.ts`)
+  as `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` — NOT
+  `~/.eliza/state`. No database dependency.
 
 Do not edit configs to point at non-Gemma base names or OpenAI judges —
 the lock above is the product contract.

--- a/packages/training/CLAUDE.md
+++ b/packages/training/CLAUDE.md
@@ -14,8 +14,10 @@ applies to everything under `packages/training/`.
 - **TESTING HARNESS:** Nebius (OpenAI-compatible inference endpoint
   used for rollouts during RL — `NEBIUS_BASE_URL`, `NEBIUS_API_KEY`).
 - **Continuous RL data:** on-disk JSONL exports under
-  `${ELIZA_STATE_DIR:-~/.eliza/state}/trajectories/`, written by the
-  eliza native trajectory recorder. No database dependency.
+  `${ELIZA_STATE_DIR}/trajectories/`, written by the eliza native trajectory
+  recorder. The state dir resolves (see `packages/core/src/utils/state-dir.ts`)
+  as `ELIZA_STATE_DIR` → `$XDG_STATE_HOME/eliza` → `~/.local/state/eliza` — NOT
+  `~/.eliza/state`. No database dependency.
 
 Do not edit configs to point at non-Gemma base names or OpenAI judges —
 the lock above is the product contract.

--- a/packages/training/scripts/manifest/eliza-1.manifest.schema.json
+++ b/packages/training/scripts/manifest/eliza-1.manifest.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://elizaos.ai/schemas/eliza-1.manifest.v1.json",
+  "title": "Eliza-1 bundle manifest",
+  "description": "Structural JSON Schema for the eliza-1.manifest.json emitted by packages/training/scripts/manifest/eliza1_manifest.py::build_manifest. This backs the manifest's $schema URL. It is the SHAPE contract; the authoritative cross-field/contract rules (§3 kernels, §6 publish gates, lineage-vs-files consistency, red-gate handling) live in validate_manifest() and are NOT all expressible in JSON Schema. Keep both honest: fixtures are checked against both in test_eliza1_manifest_schema.py.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "tier",
+    "version",
+    "publishedAt",
+    "lineage",
+    "files",
+    "kernels",
+    "evals",
+    "ramBudgetMb",
+    "defaultEligible"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://elizaos.ai/schemas/eliza-1.manifest.v1.json"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^eliza-1-(2b|4b|9b|27b|27b-256k)(-.*)?$"
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["2b", "4b", "9b", "27b", "27b-256k"]
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$"
+    },
+    "publishedAt": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$"
+    },
+    "lineage": {
+      "type": "object",
+      "required": ["text"],
+      "additionalProperties": { "$ref": "#/$defs/lineageEntry" },
+      "properties": {
+        "text": { "$ref": "#/$defs/lineageEntry" },
+        "voice": { "$ref": "#/$defs/lineageEntry" },
+        "drafter": { "$ref": "#/$defs/lineageEntry" },
+        "asr": { "$ref": "#/$defs/lineageEntry" },
+        "vision": { "$ref": "#/$defs/lineageEntry" },
+        "vad": { "$ref": "#/$defs/lineageEntry" }
+      }
+    },
+    "files": {
+      "type": "object",
+      "required": ["text"],
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/fileEntry" }
+      },
+      "properties": {
+        "text": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/fileEntry" }
+        }
+      }
+    },
+    "kernels": {
+      "type": "object",
+      "required": ["required", "verifiedBackends"],
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/kernelName" }
+        },
+        "optional": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/kernelName" }
+        },
+        "verifiedBackends": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/backendName" },
+          "additionalProperties": { "$ref": "#/$defs/kernelVerification" }
+        },
+        "recipeManifest": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/recipeFragment" }
+        }
+      }
+    },
+    "evals": {
+      "type": "object",
+      "required": ["textEval"],
+      "properties": {
+        "textEval": { "$ref": "#/$defs/scoredEval" },
+        "voiceRtf": {
+          "type": "object",
+          "required": ["rtf", "passed"],
+          "properties": {
+            "rtf": { "type": "number" },
+            "passed": { "type": "boolean" }
+          }
+        },
+        "asrWer": {
+          "type": "object",
+          "required": ["wer", "passed"],
+          "properties": {
+            "wer": { "type": "number" },
+            "passed": { "type": "boolean" }
+          }
+        },
+        "vadLatencyMs": {
+          "type": "object",
+          "required": ["median", "passed"],
+          "properties": {
+            "median": { "type": "number" },
+            "passed": { "type": "boolean" },
+            "boundaryMs": { "type": "number" },
+            "endpointMs": { "type": "number" },
+            "falseBargeInRate": { "type": "number" }
+          }
+        },
+        "mtp": {
+          "type": ["object", "null"],
+          "properties": {
+            "acceptanceRate": { "type": ["number", "null"] },
+            "speedup": { "type": ["number", "null"] },
+            "passed": { "type": ["boolean", "null"] }
+          }
+        },
+        "e2eLoopOk": { "type": "boolean" },
+        "thirtyTurnOk": { "type": "boolean" }
+      }
+    },
+    "tokenizer": {
+      "type": "object",
+      "required": ["family", "vocabSize"],
+      "properties": {
+        "family": { "type": "string", "const": "gemma4" },
+        "vocabSize": { "type": "integer", "const": 262144 }
+      }
+    },
+    "kv": { "type": "string" },
+    "mtp": { "type": "string" },
+    "ramBudgetMb": {
+      "type": "object",
+      "required": ["min", "recommended"],
+      "properties": {
+        "min": { "type": "integer", "minimum": 0 },
+        "recommended": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "defaultEligible": { "type": "boolean" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "kernelName": {
+      "type": "string",
+      "enum": [
+        "turboquant_q3",
+        "turboquant_q4",
+        "qjl",
+        "polarquant",
+        "turbo3_tcq"
+      ]
+    },
+    "backendName": {
+      "type": "string",
+      "enum": ["metal", "vulkan", "cuda", "rocm", "cpu"]
+    },
+    "lineageEntry": {
+      "type": "object",
+      "required": ["base", "license"],
+      "properties": {
+        "base": { "type": "string", "minLength": 1 },
+        "license": { "type": "string", "minLength": 1 }
+      }
+    },
+    "fileEntry": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "ctx": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "kernelVerification": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "fail", "skipped"] },
+        "atCommit": { "type": "string" },
+        "report": { "type": "string" }
+      }
+    },
+    "recipeFragment": {
+      "type": "object",
+      "required": ["blockLayoutVersion", "codebookHash", "perBlockTolerance"],
+      "properties": {
+        "blockLayoutVersion": { "type": "string", "minLength": 1 },
+        "codebookHash": { "type": "string", "minLength": 1 },
+        "perBlockTolerance": { "type": "number", "minimum": 0 }
+      }
+    },
+    "scoredEval": {
+      "type": "object",
+      "required": ["score", "passed"],
+      "properties": {
+        "score": { "type": "number" },
+        "passed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/packages/training/scripts/manifest/fixtures/eliza-1-4b.manifest.json
+++ b/packages/training/scripts/manifest/fixtures/eliza-1-4b.manifest.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://elizaos.ai/schemas/eliza-1.manifest.v1.json",
+  "id": "eliza-1-4b",
+  "tier": "4b",
+  "version": "1.0.0",
+  "publishedAt": "2026-05-10T00:00:00Z",
+  "lineage": {
+    "text": {
+      "base": "eliza-1-text-backbone",
+      "license": "apache-2.0"
+    },
+    "voice": {
+      "base": "eliza-1-voice-backbone",
+      "license": "apache-2.0"
+    },
+    "drafter": {
+      "base": "eliza-1-drafter",
+      "license": "apache-2.0"
+    },
+    "asr": {
+      "base": "eliza-1-asr-backbone",
+      "license": "apache-2.0"
+    },
+    "vision": {
+      "base": "eliza-1-vision-backbone",
+      "license": "apache-2.0"
+    },
+    "vad": {
+      "base": "eliza-1-vad-backbone",
+      "license": "apache-2.0"
+    }
+  },
+  "files": {
+    "text": [
+      {
+        "path": "text/eliza-1-4b-128k.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "ctx": 131072
+      }
+    ],
+    "voice": [
+      {
+        "path": "tts/omnivoice-base-Q4_K_M.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "asr": [
+      {
+        "path": "asr/asr.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "vision": [
+      {
+        "path": "vision/mmproj-4b.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "mtp": [
+      {
+        "path": "mtp/drafter-4b.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "cache": [
+      {
+        "path": "cache/voice-preset-default.bin",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "vad": [
+      {
+        "path": "vad/silero-vad-v5.gguf",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    ]
+  },
+  "kernels": {
+    "required": [
+      "turboquant_q4",
+      "turbo3_tcq"
+    ],
+    "optional": [],
+    "verifiedBackends": {
+      "metal": {
+        "status": "pass",
+        "atCommit": "abc1234",
+        "report": "metal.txt"
+      },
+      "vulkan": {
+        "status": "pass",
+        "atCommit": "abc1234",
+        "report": "vulkan.txt"
+      },
+      "cuda": {
+        "status": "pass",
+        "atCommit": "abc1234",
+        "report": "cuda.txt"
+      },
+      "rocm": {
+        "status": "pass",
+        "atCommit": "abc1234",
+        "report": "rocm.txt"
+      },
+      "cpu": {
+        "status": "pass",
+        "atCommit": "abc1234",
+        "report": "cpu.txt"
+      }
+    },
+    "recipeManifest": {
+      "turbo3": {
+        "blockLayoutVersion": "block_turbo3_0:v1",
+        "codebookHash": "turbo_centroids_3bit:8xfp32:seed42:v1",
+        "perBlockTolerance": 0.05
+      },
+      "turbo4": {
+        "blockLayoutVersion": "block_turbo4_0:v1",
+        "codebookHash": "turbo_centroids_4bit:16xfp32:seed42:v1",
+        "perBlockTolerance": 0.01
+      },
+      "turbo3_tcq": {
+        "blockLayoutVersion": "block_turbo3_tcq:v1",
+        "codebookHash": "turbo3_tcq_codebook:512xfp32:seed42:v1",
+        "perBlockTolerance": 0.03
+      },
+      "qjl1_256": {
+        "blockLayoutVersion": "block_qjl1_256:v1:34bytes:packed",
+        "codebookHash": "qjl1_256_layout:34bytes:lsb_first:bf16_norm:v1",
+        "perBlockTolerance": 0.05
+      },
+      "polar_q4": {
+        "blockLayoutVersion": "block_q4_polar:v1:82bytes:packed",
+        "codebookHash": "polar_q4_centroids:16xfp32:lloyd_max_niter100:v1",
+        "perBlockTolerance": 0.001
+      }
+    }
+  },
+  "evals": {
+    "textEval": {
+      "score": 0.71,
+      "passed": true
+    },
+    "voiceRtf": {
+      "rtf": 0.42,
+      "passed": true
+    },
+    "e2eLoopOk": true,
+    "thirtyTurnOk": true,
+    "asrWer": {
+      "wer": 0.05,
+      "passed": true
+    },
+    "vadLatencyMs": {
+      "median": 16.0,
+      "passed": true,
+      "boundaryMs": 24.0,
+      "endpointMs": 80.0,
+      "falseBargeInRate": 0.01
+    },
+    "mtp": {
+      "acceptanceRate": 0.71,
+      "speedup": 1.8,
+      "passed": true
+    }
+  },
+  "tokenizer": {
+    "family": "gemma4",
+    "vocabSize": 262144
+  },
+  "kv": "stock-q8_0",
+  "mtp": "separate-drafter",
+  "ramBudgetMb": {
+    "min": 7000,
+    "recommended": 9500
+  },
+  "defaultEligible": true
+}

--- a/packages/training/scripts/manifest/test_eliza1_manifest.py
+++ b/packages/training/scripts/manifest/test_eliza1_manifest.py
@@ -160,6 +160,40 @@ def test_eliza1_tier_ids_are_canonical():
     assert VOICE_BACKENDS_BY_TIER["27b"] == ("omnivoice",)
 
 
+def _parse_publish_all_tiers() -> tuple[str, ...]:
+    """Mechanically extract the TIERS bash array from publish_all_eliza1.sh.
+
+    Matches ``readonly TIERS=("2b" "4b" ...)`` and returns the quoted tokens.
+    Parsing (not importing) the shell keeps this a real cross-file agreement
+    check rather than a duplicated constant.
+    """
+    import re
+
+    sh_path = Path(__file__).resolve().parent.parent / "publish_all_eliza1.sh"
+    assert sh_path.exists(), f"publish_all_eliza1.sh not found at {sh_path}"
+    text = sh_path.read_text()
+    m = re.search(r"^\s*(?:readonly\s+)?TIERS=\(([^)]*)\)", text, re.MULTILINE)
+    assert m, "could not find the TIERS=(...) array in publish_all_eliza1.sh"
+    return tuple(re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def test_catalog_manifest_publish_tiers_agree():
+    """The Eliza-1 tier set is declared in THREE places that must stay in sync:
+    eliza1_manifest.py::ELIZA_1_TIERS (here), catalog.ts::ELIZA_1_TIER_IDS (the
+    runtime catalog, asserted in packages/shared/.../catalog.test.ts), and
+    publish_all_eliza1.sh::TIERS (the per-tier publish matrix). Renaming a tier
+    means updating all three together. This converts the previously
+    comment-only invariant into an enforced one for two of the three surfaces
+    (the TS surface is enforced in catalog.test.ts)."""
+    expected = ("2b", "4b", "9b", "27b", "27b-256k")
+    assert ELIZA_1_TIERS == expected
+    assert _parse_publish_all_tiers() == expected, (
+        "publish_all_eliza1.sh::TIERS drifted from eliza1_manifest.py::"
+        "ELIZA_1_TIERS — update catalog.ts, eliza1_manifest.py, and "
+        "publish_all_eliza1.sh together"
+    )
+
+
 def test_build_manifest_happy_path():
     manifest = build_manifest(**base_kwargs())
     assert manifest["tier"] == "4b"

--- a/packages/training/scripts/manifest/test_eliza1_manifest_schema.py
+++ b/packages/training/scripts/manifest/test_eliza1_manifest_schema.py
@@ -1,0 +1,92 @@
+"""Keep the manifest JSON Schema honest against a versioned fixture.
+
+The manifest's `$schema` URL (https://elizaos.ai/schemas/eliza-1.manifest.v1.json)
+now has a real backing file — eliza-1.manifest.schema.json in this directory.
+This test pins a committed, valid manifest fixture and runs it through BOTH
+gates that a published manifest must pass:
+
+  1. validate_manifest()  — the authoritative cross-field / §3 / §6 contract.
+  2. the JSON Schema       — the structural shape backing the $schema URL.
+
+If either the schema or the fixture drifts from what build_manifest() emits, a
+regeneration of the fixture (via test_eliza1_manifest.py::build_manifest) fails
+one of these checks and the drift is caught.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.manifest.eliza1_manifest import (
+    ELIZA_1_MANIFEST_SCHEMA_URL,
+    validate_manifest,
+)
+
+_HERE = Path(__file__).resolve().parent
+_SCHEMA_PATH = _HERE / "eliza-1.manifest.schema.json"
+_FIXTURE_PATH = _HERE / "fixtures" / "eliza-1-4b.manifest.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_schema_file_exists_and_matches_schema_url():
+    assert _SCHEMA_PATH.exists(), f"missing backing schema at {_SCHEMA_PATH}"
+    schema = _load(_SCHEMA_PATH)
+    # The manifest's $schema URL and the schema's own $id must agree — the URL
+    # is aspirational (unhosted) but the file it points at is real and versioned.
+    assert schema["$id"] == ELIZA_1_MANIFEST_SCHEMA_URL
+
+
+def test_fixture_is_present_and_self_describes():
+    assert _FIXTURE_PATH.exists(), f"missing manifest fixture at {_FIXTURE_PATH}"
+    manifest = _load(_FIXTURE_PATH)
+    assert manifest["$schema"] == ELIZA_1_MANIFEST_SCHEMA_URL
+    assert manifest["tier"] == "4b"
+    assert manifest["id"] == "eliza-1-4b"
+
+
+def test_fixture_passes_validate_manifest():
+    manifest = _load(_FIXTURE_PATH)
+    errors = validate_manifest(manifest)
+    assert errors == (), f"fixture failed validate_manifest: {errors}"
+
+
+def test_fixture_passes_json_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    manifest = _load(_FIXTURE_PATH)
+    schema = _load(_SCHEMA_PATH)
+    # Raises jsonschema.ValidationError on any structural violation.
+    jsonschema.validate(instance=manifest, schema=schema)
+
+
+def test_schema_rejects_a_broken_manifest():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load(_SCHEMA_PATH)
+    broken = _load(_FIXTURE_PATH)
+    broken["tier"] = "999b"  # not a real tier
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=broken, schema=schema)
+
+
+def test_schema_rejects_bad_sha256():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load(_SCHEMA_PATH)
+    broken = _load(_FIXTURE_PATH)
+    broken["files"]["text"][0]["sha256"] = "not-a-real-hash"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=broken, schema=schema)
+
+
+def test_schema_and_validate_manifest_agree_on_the_fixture():
+    """Both gates must PASS the same fixture — a fixture that only one accepts
+    means the schema and validate_manifest have diverged."""
+    jsonschema = pytest.importorskip("jsonschema")
+    manifest = _load(_FIXTURE_PATH)
+    schema = _load(_SCHEMA_PATH)
+    assert validate_manifest(manifest) == ()
+    jsonschema.validate(instance=manifest, schema=schema)

--- a/packages/training/scripts/prepare_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/prepare_eliza1_trajectory_dataset.py
@@ -1065,12 +1065,40 @@ class PrepStats:
     seen: int = 0
     produced: int = 0
     skipped: int = 0
+    dropped_dup: int = 0
     privacy_redactions: int = 0
     privacy_anonymizations: int = 0
     credential_hits: Counter[str] = field(default_factory=Counter)
     source_counts: Counter[str] = field(default_factory=Counter)
     task_counts: Counter[str] = field(default_factory=Counter)
     action_counts: Counter[str] = field(default_factory=Counter)
+
+
+def native_content_key(record: dict[str, Any]) -> str | None:
+    """Content hash of a produced record's (request, response), for `eliza_
+    native_v1` dedup.
+
+    Repeated scenario/benchmark runs replay the same prompt and produce the same
+    model boundary, so identical native rows accumulate across runs. Legacy
+    `transform_dedup_records.py` dedupes the flat format on
+    (currentMessage, expectedResponse); native rows had no equivalent. This
+    keys on the canonical native projection's `request` + `response` (the model
+    boundary that actually becomes a training row) — provenance/metadata is
+    excluded so two identical boundaries from different runs collapse to one.
+
+    Returns None for records that don't convert to a native row (they are not
+    training rows, so nothing to dedup against).
+    """
+    native = trajectory_record_to_eliza_native(record)
+    if native is None:
+        return None
+    payload = json.dumps(
+        {"request": native.get("request"), "response": native.get("response")},
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _stats_int(stats: Any, *names: str) -> int:
@@ -1332,6 +1360,8 @@ def prepare(args: argparse.Namespace) -> tuple[dict[str, list[dict[str, Any]]], 
     splits: dict[str, list[dict[str, Any]]] = {"train": [], "val": [], "test": [], "repair_eval": []}
     stats = PrepStats()
     max_records = int(args.max_records or 0)
+    dedup_native = not getattr(args, "no_dedup", False)
+    seen_native: set[str] = set()
 
     for path in iter_input_files(args.input):
         if not path.exists():
@@ -1390,6 +1420,13 @@ def prepare(args: argparse.Namespace) -> tuple[dict[str, list[dict[str, Any]]], 
                 continue
 
             for record in produced:
+                if dedup_native:
+                    content_key = native_content_key(record)
+                    if content_key is not None:
+                        if content_key in seen_native:
+                            stats.dropped_dup += 1
+                            continue
+                        seen_native.add(content_key)
                 if record["quality"]["success"]:
                     split = split_success_record(
                         record,
@@ -1469,6 +1506,7 @@ def prepare(args: argparse.Namespace) -> tuple[dict[str, list[dict[str, Any]]], 
         "seenRecords": stats.seen,
         "producedRecords": stats.produced,
         "skippedRecords": stats.skipped,
+        "droppedDuplicateNativeRows": stats.dropped_dup,
         "sourceCounts": dict(sorted(stats.source_counts.items())),
         "taskCounts": dict(sorted(stats.task_counts.items())),
         "actionCounts": dict(sorted(stats.action_counts.items())),
@@ -1533,6 +1571,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--lifeops-success-threshold", type=float, default=0.99)
     parser.add_argument("--strict-privacy", action="store_true")
+    parser.add_argument(
+        "--no-dedup",
+        action="store_true",
+        help="Disable content-hash dedup of eliza_native_v1 rows. By default, "
+        "rows whose (request, response) boundary is identical to an "
+        "already-emitted row are dropped so repeated scenario/benchmark runs "
+        "do not inflate the corpus with exact duplicates.",
+    )
     parser.add_argument("--verbose", "-v", action="store_true")
     return parser
 

--- a/packages/training/scripts/quantization/_kernel_manifest.py
+++ b/packages/training/scripts/quantization/_kernel_manifest.py
@@ -6,10 +6,9 @@ codebook hash, expected per-block tolerance. The fragment is consumed by
 the inference manifest builder at publish time.
 
 This module owns the canonical pin between training-side recipes and the
-kernel references in eliza/packages/inference/{reference,verify}/ and
-eliza/packages/native-plugins/{qjl-cpu,polarquant-cpu}/. When a kernel
-constant changes, the matching value here MUST be bumped in lockstep,
-otherwise the publish gate's parity tests fail.
+kernel references in packages/native/plugins/{turboquant-cpu,qjl-cpu,
+polarquant-cpu}/. When a kernel constant changes, the matching value here MUST
+be bumped in lockstep, otherwise the publish gate's parity tests fail.
 
 The helper has no torch/transformers imports so unit tests can validate
 manifest correctness without loading a model.
@@ -21,9 +20,9 @@ from __future__ import annotations
 # Codebook hashes pinned to the canonical kernel references.
 #
 # turbo3/turbo4/turbo3_tcq codebooks live in
-#   eliza/packages/inference/reference/turbo_kernels.c
+#   packages/native/plugins/turboquant-cpu/include/turboquant/turboquant.h
 # polar_q4 centroids live in
-#   eliza/packages/native-plugins/polarquant-cpu/include/polarquant/polar_centroids.h
+#   packages/native/plugins/polarquant-cpu/include/polarquant/polar_centroids.h
 # qjl1_256 has no centroid table — it's sign-only — so its "hash" identifies
 # the block layout convention rather than a numeric codebook.
 #

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -212,8 +212,7 @@ def test_legacy_push_model_to_hf_redirects_to_canonical_publishers():
 # Kernel-vs-recipe parity tests
 #
 # These tests pin the recipes to the canonical kernel references in
-# eliza/packages/inference/{reference,verify}/ and
-# eliza/packages/native-plugins/{qjl-cpu,polarquant-cpu}/.
+# packages/native/plugins/{turboquant-cpu,qjl-cpu,polarquant-cpu}/.
 #
 # Per packages/training/AGENTS.md §3:
 #   "Bit-exact with kernels — when a quantization recipe and a kernel
@@ -236,8 +235,8 @@ _TURBO_H = _KERNEL_PACKAGES_DIR / "inference" / "reference" / "turbo_kernels.h"
 
 
 # Canonical 4-bit Lloyd-Max centroids for N(0,1), bit-exact match required
-# against eliza/packages/native-plugins/polarquant-cpu/include/polarquant/polar_centroids.h
-# and eliza/packages/inference/verify/qjl_polar_ref.c.
+# against packages/native/plugins/polarquant-cpu/include/polarquant/polar_centroids.h
+# and the qjl-cpu reference kernels (packages/native/plugins/qjl-cpu/src/).
 _C_POLAR_Q4_CENTROIDS = (
     -2.754354807, -2.093562707, -1.643041510, -1.279739752,
     -0.962640978, -0.672392117, -0.397897103, -0.131757782,

--- a/packages/training/scripts/quantization/test_recipes_smoke.py
+++ b/packages/training/scripts/quantization/test_recipes_smoke.py
@@ -20,6 +20,7 @@ data. Run them by hand from the repo root.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -225,13 +226,28 @@ def test_legacy_push_model_to_hf_redirects_to_canonical_publishers():
 # ---------------------------------------------------------------------------
 
 
-# _HERE = .../eliza/packages/training/scripts/quantization
-# parents: [0]=quantization, [1]=scripts, [2]=training, [3]=packages
-_KERNEL_PACKAGES_DIR = _HERE.parents[2]
-_REF_C = _KERNEL_PACKAGES_DIR / "inference" / "verify" / "qjl_polar_ref.c"
-_REF_H = _KERNEL_PACKAGES_DIR / "inference" / "verify" / "qjl_polar_ref.h"
-_TURBO_C = _KERNEL_PACKAGES_DIR / "inference" / "reference" / "turbo_kernels.c"
-_TURBO_H = _KERNEL_PACKAGES_DIR / "inference" / "reference" / "turbo_kernels.h"
+# _HERE = <repo>/packages/training/scripts/quantization
+# parents: [0]=quantization, [1]=scripts, [2]=training, [3]=packages, [4]=<repo>
+#
+# The canonical qjl/polar/turbo C references live in the local-inference plugin
+# at plugins/plugin-local-inference/native/{verify,reference}/. The old path
+# (_HERE.parents[2] / "inference" / ...) pointed at a nonexistent
+# packages/training/inference/ tree, so every C-parity test silently skipped —
+# a false green. Resolve the real location relative to the repo root, with an
+# ELIZA_KERNEL_REF_DIR override for layouts where the plugin tree is not a
+# sibling of packages/training (e.g. the CI container that mounts only
+# packages/training — see the loud-skip note in the parity tests).
+_REPO_ROOT = _HERE.parents[3]
+_KERNEL_REF_DIR = Path(
+    os.environ.get(
+        "ELIZA_KERNEL_REF_DIR",
+        str(_REPO_ROOT / "plugins" / "plugin-local-inference" / "native"),
+    )
+)
+_REF_C = _KERNEL_REF_DIR / "verify" / "qjl_polar_ref.c"
+_REF_H = _KERNEL_REF_DIR / "verify" / "qjl_polar_ref.h"
+_TURBO_C = _KERNEL_REF_DIR / "reference" / "turbo_kernels.c"
+_TURBO_H = _KERNEL_REF_DIR / "reference" / "turbo_kernels.h"
 
 
 # Canonical 4-bit Lloyd-Max centroids for N(0,1), bit-exact match required

--- a/packages/training/scripts/test_prepare_eliza1_trajectory_dataset.py
+++ b/packages/training/scripts/test_prepare_eliza1_trajectory_dataset.py
@@ -356,6 +356,96 @@ def test_prepare_keeps_requested_success_splits_non_empty(tmp_path: Path) -> Non
     assert len(_read_jsonl(out_dir / "test.jsonl")) == 1
 
 
+def _dup_native_row(trajectory_id: str) -> dict:
+    """A successful native row with a fixed (request, response) boundary. Only
+    provenance (trajectoryId) varies, so dedup — which keys on content, not
+    identity — must collapse repeats to one."""
+    return {
+        "format": "eliza_native_v1",
+        "boundary": "vercel_ai_sdk.generateText",
+        "status": "completed",
+        "trajectoryId": trajectory_id,
+        "stepIndex": 0,
+        "request": {"messages": [{"role": "user", "content": "what is 2+2?"}]},
+        "response": {
+            "text": "4",
+            "usage": {"promptTokens": 5, "completionTokens": 1},
+        },
+        "metadata": {"source_dataset": "unit_dedup"},
+    }
+
+
+def test_prepare_dedupes_identical_native_rows(tmp_path: Path) -> None:
+    """Repeated scenario/benchmark runs replay the same boundary; by default the
+    corpus MUST NOT accumulate exact-duplicate eliza_native_v1 rows."""
+    source = tmp_path / "dupes.jsonl"
+    _write_jsonl(
+        source,
+        [
+            _dup_native_row("traj-a"),
+            _dup_native_row("traj-b"),  # identical (request,response), diff id
+            _dup_native_row("traj-c"),  # identical again
+        ],
+    )
+    out_dir = tmp_path / "out"
+
+    code = prepare_main(
+        ["--input", str(source), "--output-dir", str(out_dir),
+         "--val-ratio", "0", "--test-ratio", "0"]
+    )
+    assert code == 0
+
+    train = _read_jsonl(out_dir / "train.jsonl")
+    assert len(train) == 1, "only the first of three identical rows should survive"
+    assert train[0]["response"]["text"] == "4"
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["droppedDuplicateNativeRows"] == 2
+    assert manifest["counts"]["train"] == 1
+
+
+def test_prepare_no_dedup_keeps_duplicates(tmp_path: Path) -> None:
+    """--no-dedup is the escape hatch: all three identical rows are kept."""
+    source = tmp_path / "dupes.jsonl"
+    _write_jsonl(
+        source,
+        [_dup_native_row("traj-a"), _dup_native_row("traj-b"), _dup_native_row("traj-c")],
+    )
+    out_dir = tmp_path / "out"
+
+    code = prepare_main(
+        ["--input", str(source), "--output-dir", str(out_dir),
+         "--val-ratio", "0", "--test-ratio", "0", "--no-dedup"]
+    )
+    assert code == 0
+
+    train = _read_jsonl(out_dir / "train.jsonl")
+    assert len(train) == 3
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["droppedDuplicateNativeRows"] == 0
+
+
+def test_prepare_dedup_keeps_distinct_boundaries(tmp_path: Path) -> None:
+    """Dedup must not over-collapse: two rows with different responses are both
+    kept."""
+    row_a = _dup_native_row("traj-a")
+    row_b = _dup_native_row("traj-b")
+    row_b["response"]["text"] = "22"  # distinct boundary
+    source = tmp_path / "distinct.jsonl"
+    _write_jsonl(source, [row_a, row_b])
+    out_dir = tmp_path / "out"
+
+    code = prepare_main(
+        ["--input", str(source), "--output-dir", str(out_dir),
+         "--val-ratio", "0", "--test-ratio", "0"]
+    )
+    assert code == 0
+    train = _read_jsonl(out_dir / "train.jsonl")
+    assert len(train) == 2
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["droppedDuplicateNativeRows"] == 0
+
+
 def test_prepare_strict_privacy_fails_on_any_redaction(tmp_path: Path) -> None:
     source = tmp_path / "native-private.jsonl"
     _write_jsonl(

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -661,6 +661,25 @@ def main() -> int:
         else:
             log.warning(msg)
         use_liger = False
+    # Liger has no validated gemma4_unified (dense 12B/31B) kernel path. Its
+    # fused RMSNorm/RoPE/CE assume the Gemma2/3 layer layout and silently
+    # corrupt the gemma4_unified forward — which adds per-layer q_norm/k_norm,
+    # a layer_scalar, and logit softcapping the Gemma3 kernels don't model — so
+    # the loss NaNs within the first optimizer steps and the saved checkpoint is
+    # all-NaN. Force Liger off for this arch (E2B/E4B "gemma4" stay on). The
+    # generic finite-weights guard (make_finite_weights_callback) is the second
+    # line of defense; this is the specific known-arch prevention.
+    _model_type = str(getattr(model.config, "model_type", "")).lower()
+    _arch_names = getattr(model.config, "architectures", None) or []
+    if use_liger and (
+        "gemma4_unified" in _model_type
+        or any("Gemma4Unified" in a for a in _arch_names)
+    ):
+        log.warning(
+            "Liger kernel disabled for gemma4_unified arch (no validated fused "
+            "kernel path; avoids NaN divergence in 12B/31B SFT)."
+        )
+        use_liger = False
     if use_liger and device == "cuda":
         try:
             from liger_kernel.transformers import _apply_liger_kernel_to_instance

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -918,6 +918,12 @@ def main() -> int:
         InstrumentationConfig, log_environment, make_finite_weights_callback,
         make_hf_callback,
     )
+    # Materialize the exact tokenizer this run trains with (including any chat-
+    # template override applied above) to a stable path so its artifact hash is
+    # captured in the reproducibility manifest. This is the actual tokenizer the
+    # model sees, not just the base-model source.
+    tokenizer_dir = out_dir / "tokenizer"
+    tokenizer.save_pretrained(str(tokenizer_dir))
     log_environment(
         out_dir,
         run_meta={
@@ -930,6 +936,7 @@ def main() -> int:
         # HF repo id for --model won't resolve to a local path and is skipped;
         # a local base checkpoint is hashed.
         dataset_files=[args.train_file, args.val_file],
+        tokenizer_path=tokenizer_dir,
         base_checkpoint=args.model,
     )
     # Post-step finite-weights guard — registered unconditionally. A divergent

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -896,7 +896,8 @@ def main() -> int:
         trainer.training_step = _fp8_training_step  # type: ignore[assignment]
 
     from training.instrumentation import (
-        InstrumentationConfig, log_environment, make_hf_callback,
+        InstrumentationConfig, log_environment, make_finite_weights_callback,
+        make_hf_callback,
     )
     log_environment(
         out_dir,
@@ -906,6 +907,13 @@ def main() -> int:
             "max_seq_len": args.max_seq_len, "lr": args.lr,
             "registry_key": args.registry_key,
         },
+    )
+    # Post-step finite-weights guard — registered unconditionally. A divergent
+    # run (e.g. a fused kernel that doesn't model an arch's layer layout) must
+    # die within one logging interval instead of completing and persisting an
+    # all-NaN checkpoint. Not gated on --memory-budget-gb.
+    trainer.add_callback(
+        make_finite_weights_callback(sft_cfg.logging_steps)
     )
     if args.memory_budget_gb:
         trainer.add_callback(make_hf_callback(InstrumentationConfig(

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -926,6 +926,11 @@ def main() -> int:
             "max_seq_len": args.max_seq_len, "lr": args.lr,
             "registry_key": args.registry_key,
         },
+        # Reproducibility manifest (AGENTS.md §9): hash the exact inputs. A bare
+        # HF repo id for --model won't resolve to a local path and is skipped;
+        # a local base checkpoint is hashed.
+        dataset_files=[args.train_file, args.val_file],
+        base_checkpoint=args.model,
     )
     # Post-step finite-weights guard — registered unconditionally. A divergent
     # run (e.g. a fused kernel that doesn't model an arch's layer layout) must

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -28,6 +28,7 @@ import platform
 import shutil
 import subprocess
 import time
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -126,8 +127,84 @@ def _gpu_info() -> dict[str, Any]:
     return info
 
 
-def log_environment(out_dir: Path | str, *, run_meta: dict[str, Any] | None = None) -> Path:
-    """Write a one-shot env snapshot for the training run."""
+def _sha256_file(path: Path, *, chunk: int = 1 << 20) -> str:
+    """Stream a file through sha256. Raises if the path is not a real file."""
+    import hashlib
+
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        while True:
+            block = fp.read(chunk)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def _hash_paths(paths: Iterable[Path | str] | None) -> dict[str, str]:
+    """sha256 every path that resolves to a local file. Directories are hashed
+    by combining their files' hashes (sorted by relative path) so a tokenizer or
+    checkpoint directory gets one stable digest. Paths that don't exist locally
+    (e.g. a bare HuggingFace repo id) are skipped — reproducibility hashing only
+    covers artifacts actually present on disk for this run."""
+    import hashlib
+
+    out: dict[str, str] = {}
+    for raw in paths or ():
+        p = Path(raw)
+        if p.is_file():
+            out[str(p)] = f"sha256:{_sha256_file(p)}"
+        elif p.is_dir():
+            combined = hashlib.sha256()
+            files = sorted(f for f in p.rglob("*") if f.is_file())
+            for f in files:
+                combined.update(f.relative_to(p).as_posix().encode("utf-8"))
+                combined.update(_sha256_file(f).encode("ascii"))
+            out[str(p)] = f"sha256:{combined.hexdigest()}"
+    return out
+
+
+def _git_head() -> dict[str, Any]:
+    """Capture the training commit for the reproducibility manifest.
+
+    Best-effort: outside a git checkout (or with git absent) the head is
+    reported as a structured field, not an exception.
+    """
+    if not shutil.which("git"):
+        return {"available": False, "reason": "git not on PATH"}
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False, capture_output=True, text=True, timeout=5,
+    )
+    if out.returncode != 0:
+        return {"available": False, "reason": out.stderr.strip() or f"exit={out.returncode}"}
+    head = out.stdout.strip()
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        check=False, capture_output=True, text=True, timeout=5,
+    )
+    return {
+        "available": True,
+        "head": head,
+        "dirty": bool(dirty.stdout.strip()) if dirty.returncode == 0 else None,
+    }
+
+
+def log_environment(
+    out_dir: Path | str,
+    *,
+    run_meta: dict[str, Any] | None = None,
+    dataset_files: Iterable[Path | str] | None = None,
+    tokenizer_path: Path | str | None = None,
+    base_checkpoint: Path | str | None = None,
+) -> Path:
+    """Write a one-shot env snapshot for the training run.
+
+    Beyond platform/GPU/torch, this records the AGENTS.md §9 reproducibility
+    manifest: sha256 of every dataset file, the tokenizer artifact hash, the
+    base-checkpoint hash, and the training git commit — so a run can be tied
+    back to the exact inputs that produced it. Hashes only cover artifacts on
+    local disk (a bare HF repo id for the base is skipped, not faked)."""
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
     env_path = out / "environment.json"
@@ -137,6 +214,16 @@ def log_environment(out_dir: Path | str, *, run_meta: dict[str, Any] | None = No
         "cwd": os.getcwd(),
         "gpu": _gpu_info(),
         "run_meta": run_meta or {},
+        "reproducibility": {
+            "git": _git_head(),
+            "dataset_hashes": _hash_paths(dataset_files),
+            "tokenizer_hashes": _hash_paths(
+                [tokenizer_path] if tokenizer_path is not None else None
+            ),
+            "base_checkpoint_hashes": _hash_paths(
+                [base_checkpoint] if base_checkpoint is not None else None
+            ),
+        },
         "timestamp": time.time(),
     }
     env_path.write_text(json.dumps(payload, indent=2))

--- a/packages/training/scripts/training/instrumentation.py
+++ b/packages/training/scripts/training/instrumentation.py
@@ -253,10 +253,17 @@ class InstrumentationCallback:
 
 def make_hf_callback(cfg: InstrumentationConfig):
     """Factory returning a TrainerCallback subclass at call time so this
-    module stays importable when transformers is missing."""
+    module stays importable when transformers is missing.
+
+    ``InstrumentationCallback`` comes FIRST in the base list so its
+    ``on_step_end`` / ``on_train_begin`` / ``on_train_end`` win the MRO.
+    ``TrainerCallback`` defines those as real (no-op) methods, so listing the
+    base first shadowed the instrumentation hooks entirely — the memory-budget
+    breach guard and the tokens/sec trace never fired.
+    """
     from transformers import TrainerCallback
 
-    class _Cb(TrainerCallback, InstrumentationCallback):  # type: ignore[misc]
+    class _Cb(InstrumentationCallback, TrainerCallback):  # type: ignore[misc]
         def __init__(self, cfg: InstrumentationConfig):
             TrainerCallback.__init__(self)
             InstrumentationCallback.__init__(self, cfg)
@@ -264,13 +271,100 @@ def make_hf_callback(cfg: InstrumentationConfig):
     return _Cb(cfg)
 
 
+def assert_finite_step(model: Any, *, step: int, max_reported: int = 5) -> None:
+    """Raise ``RuntimeError`` if any trainable parameter holds a non-finite value.
+
+    Walks ``model.named_parameters()``, checks ``torch.isfinite(p).all()`` on
+    every parameter with ``requires_grad``, and raises naming the first
+    ``max_reported`` offending tensors. This is architecture-agnostic: it fires
+    on the *first* NaN/Inf regardless of root cause (a fused kernel that doesn't
+    model an arch's layer layout, a bad LR, an overflowing fp16 activation),
+    which is exactly the failure mode that let the gemma4_unified 12B run report
+    "complete" while saving an all-NaN checkpoint.
+
+    Cheap by design: one ``isfinite().all()`` reduction per parameter, no host
+    sync of the full tensor. Callers gate the frequency (every ``logging_steps``)
+    so a divergent run dies within one save interval instead of writing a dead
+    checkpoint.
+    """
+    import torch
+
+    offenders: list[str] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if not torch.isfinite(param).all():
+            offenders.append(name)
+            if len(offenders) >= max_reported:
+                break
+    if offenders:
+        raise RuntimeError(
+            f"non-finite (NaN/Inf) trainable weights at step {step}: "
+            f"{', '.join(offenders)}"
+            + (" …" if len(offenders) >= max_reported else "")
+            + ". Training diverged — aborting before a dead checkpoint is saved."
+        )
+
+
+class FiniteWeightsCallback:
+    """HF Trainer callback that hard-fails a divergent run.
+
+    Runs :func:`assert_finite_step` across trainable parameters every
+    ``check_every_steps`` (default: aligned with ``logging_steps``). A run whose
+    weights NaN out dies within one logging interval with an explicit error
+    naming the offending tensors, rather than completing and silently persisting
+    an all-NaN checkpoint. Registered unconditionally — this guard is not gated
+    on the optional memory-budget instrumentation.
+
+    Base-class-free like :class:`InstrumentationCallback`; the concrete
+    ``TrainerCallback`` subclass is built by :func:`make_finite_weights_callback`
+    so this module stays importable without transformers.
+    """
+
+    def __init__(self, check_every_steps: int = 10):
+        self.check_every_steps = max(1, int(check_every_steps))
+        self._last_step = -1
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        step = int(state.global_step)
+        if step == self._last_step:
+            return
+        if step % self.check_every_steps != 0:
+            return
+        self._last_step = step
+        if model is None:
+            return
+        assert_finite_step(model, step=step)
+
+
+def make_finite_weights_callback(check_every_steps: int = 10):
+    """Factory returning a TrainerCallback subclass at call time so this module
+    stays importable when transformers is missing.
+
+    ``FiniteWeightsCallback`` comes FIRST in the base list so its ``on_step_end``
+    wins the MRO — ``TrainerCallback.on_step_end`` is a real (no-op) override, so
+    listing the base first would shadow the guard and it would never fire.
+    """
+    from transformers import TrainerCallback
+
+    class _Cb(FiniteWeightsCallback, TrainerCallback):  # type: ignore[misc]
+        def __init__(self, check_every_steps: int):
+            TrainerCallback.__init__(self)
+            FiniteWeightsCallback.__init__(self, check_every_steps)
+
+    return _Cb(check_every_steps)
+
+
 __all__ = [
+    "FiniteWeightsCallback",
     "GpuMemoryTracker",
     "InstrumentationCallback",
     "InstrumentationConfig",
     "MemorySnapshot",
+    "assert_finite_step",
     "gpu_memory",
     "log_environment",
+    "make_finite_weights_callback",
     "make_hf_callback",
     "reset_peak_memory",
 ]

--- a/packages/training/scripts/training/model_registry.py
+++ b/packages/training/scripts/training/model_registry.py
@@ -403,6 +403,11 @@ REGISTRY: dict[str, ModelEntry] = {
         grad_accum=8,
         train_mem_gb_budget=80.0,
         train_dtype="bf16",
+        # gemma4_unified (dense 12B/31B) has no validated Liger kernel path —
+        # its fused RMSNorm/RoPE/CE assume the Gemma2/3 layout and NaN the
+        # forward (all-NaN 12B checkpoint incident). Registry is the single
+        # source of truth; train_local.py's arch-string check is the backstop.
+        use_liger=False,
         infer_max_in=262144,
         infer_max_out=16384,
         # Proportionate KV-bearing count; verify against gemma-4-12B config.json.
@@ -436,6 +441,10 @@ REGISTRY: dict[str, ModelEntry] = {
         grad_accum=8,
         train_mem_gb_budget=210.0,
         train_dtype="bf16",
+        # See gemma4-12b: gemma4_unified has no validated Liger path; keep it
+        # off in the registry so the 31B tier is protected independent of the
+        # train_local.py arch check.
+        use_liger=False,
         infer_max_in=262144,
         infer_max_out=16384,
         # Proportionate KV-bearing count; verify against gemma-4-31B config.json.

--- a/packages/training/scripts/training/test_finite_guard.py
+++ b/packages/training/scripts/training/test_finite_guard.py
@@ -1,0 +1,189 @@
+"""CPU-only tests for the post-step finite-weights guard.
+
+The guard (`assert_finite_step` / `FiniteWeightsCallback`) is the generic
+insurance against the class of bug that produced an all-NaN 12B checkpoint:
+a training run that NaNs out but still reports "complete" and saves dead
+weights. These tests inject a NaN into a tiny synthetic model and assert the
+guard raises, naming the offending tensor — no GPU, no real checkpoint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import torch
+from torch import nn
+
+from scripts.training.instrumentation import (
+    FiniteWeightsCallback,
+    InstrumentationConfig,
+    assert_finite_step,
+    make_finite_weights_callback,
+    make_hf_callback,
+)
+
+
+class _TinyLM(nn.Module):
+    """Toy LM-shaped module: embedding + linear stack + lm_head + norm.
+
+    Mirrors the `_TinyLM` in test_apollo_default.py / test_optimizer_cpu.py so
+    the guard is exercised against the same param shapes the real path sees.
+    """
+
+    def __init__(self, vocab: int = 64, hidden: int = 32, n_layers: int = 2):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        self.layers = nn.ModuleList(
+            [nn.Linear(hidden, hidden) for _ in range(n_layers)]
+        )
+        self.norm = nn.LayerNorm(hidden)
+        self.lm_head = nn.Linear(hidden, vocab, bias=False)
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed(ids)
+        for layer in self.layers:
+            x = layer(x)
+        x = self.norm(x)
+        return self.lm_head(x)
+
+
+@dataclass
+class _FakeState:
+    global_step: int
+
+
+def test_passes_on_finite_weights() -> None:
+    model = _TinyLM()
+    # No exception on healthy weights.
+    assert_finite_step(model, step=10)
+
+
+def test_raises_on_nan_weight() -> None:
+    model = _TinyLM()
+    with torch.no_grad():
+        model.layers[1].weight[0, 0] = float("nan")
+    with pytest.raises(RuntimeError, match="non-finite"):
+        assert_finite_step(model, step=20)
+
+
+def test_raises_on_inf_weight() -> None:
+    model = _TinyLM()
+    with torch.no_grad():
+        model.lm_head.weight[3, 5] = float("inf")
+    with pytest.raises(RuntimeError, match="non-finite"):
+        assert_finite_step(model, step=30)
+
+
+def test_error_names_offending_tensor() -> None:
+    model = _TinyLM()
+    with torch.no_grad():
+        model.norm.weight[2] = float("nan")
+    with pytest.raises(RuntimeError, match="norm.weight"):
+        assert_finite_step(model, step=40)
+
+
+def test_error_names_multiple_offenders_and_step() -> None:
+    model = _TinyLM()
+    with torch.no_grad():
+        model.embed.weight[0, 0] = float("nan")
+        model.lm_head.weight[0, 0] = float("nan")
+    with pytest.raises(RuntimeError) as exc:
+        assert_finite_step(model, step=77)
+    msg = str(exc.value)
+    assert "embed.weight" in msg
+    assert "lm_head.weight" in msg
+    assert "step 77" in msg
+
+
+def test_ignores_frozen_parameters() -> None:
+    """A non-finite value in a frozen (requires_grad=False) parameter is not a
+    training-divergence signal — the guard only inspects trainable weights."""
+    model = _TinyLM()
+    model.embed.weight.requires_grad_(False)
+    with torch.no_grad():
+        model.embed.weight[0, 0] = float("nan")
+    # Trainable params are still finite → no raise.
+    assert_finite_step(model, step=50)
+
+
+def test_callback_fires_on_logging_interval() -> None:
+    """FiniteWeightsCallback only checks on the configured interval, and raises
+    when a checked step finds a NaN."""
+    cb = FiniteWeightsCallback(check_every_steps=10)
+    model = _TinyLM()
+    with torch.no_grad():
+        model.layers[0].weight[1, 1] = float("nan")
+
+    # Off-interval step: guard is skipped, no raise even though NaN present.
+    cb.on_step_end(None, _FakeState(global_step=7), None, model=model)
+
+    # On-interval step: guard fires.
+    with pytest.raises(RuntimeError, match="non-finite"):
+        cb.on_step_end(None, _FakeState(global_step=10), None, model=model)
+
+
+def test_callback_passes_when_weights_finite() -> None:
+    cb = FiniteWeightsCallback(check_every_steps=5)
+    model = _TinyLM()
+    # Healthy model on an on-interval step → no raise.
+    cb.on_step_end(None, _FakeState(global_step=5), None, model=model)
+
+
+def test_callback_deduplicates_repeated_step() -> None:
+    """The same global_step handed twice is only checked once (mirrors the
+    InstrumentationCallback pattern of skipping repeated steps)."""
+    cb = FiniteWeightsCallback(check_every_steps=1)
+    model = _TinyLM()
+    cb.on_step_end(None, _FakeState(global_step=3), None, model=model)
+    # Inject NaN, then re-send the SAME step — the guard skips it as already seen.
+    with torch.no_grad():
+        model.layers[0].weight[0, 0] = float("nan")
+    cb.on_step_end(None, _FakeState(global_step=3), None, model=model)
+    # Advancing to a new checked step catches it.
+    with pytest.raises(RuntimeError, match="non-finite"):
+        cb.on_step_end(None, _FakeState(global_step=4), None, model=model)
+
+
+def test_make_finite_weights_callback_requires_transformers() -> None:
+    """The TrainerCallback factory needs transformers; when present it returns a
+    callback that IS a TrainerCallback and still hard-fails on NaN.
+
+    Also guards the MRO: TrainerCallback.on_step_end is a real no-op override,
+    so the concrete callback must resolve OUR on_step_end, not the base's — a
+    reversed base order would silently shadow the guard.
+    """
+    transformers = pytest.importorskip("transformers")
+    cb = make_finite_weights_callback(check_every_steps=1)
+    assert isinstance(cb, transformers.TrainerCallback)
+    # The guard's on_step_end must win the MRO, not the base no-op.
+    assert type(cb).on_step_end is FiniteWeightsCallback.on_step_end
+    model = _TinyLM()
+    with torch.no_grad():
+        model.lm_head.weight[0, 0] = float("nan")
+    with pytest.raises(RuntimeError, match="non-finite"):
+        cb.on_step_end(None, _FakeState(global_step=1), None, model=model)
+
+
+def test_make_hf_callback_instrumentation_hooks_win_mro() -> None:
+    """Regression: the instrumentation callback's on_step_end / on_train_begin /
+    on_train_end must resolve to InstrumentationCallback, not the base
+    TrainerCallback no-ops — otherwise the memory-budget breach guard and the
+    tokens/sec trace silently never fire."""
+    pytest.importorskip("transformers")
+    from scripts.training.instrumentation import InstrumentationCallback
+
+    cb = make_hf_callback(
+        InstrumentationConfig(
+            out_dir="/tmp/eliza-finite-guard-mro-test",
+            seq_len=8,
+            effective_batch_size=1,
+            memory_budget_gb=1.0,
+        )
+    )
+    for hook in ("on_step_end", "on_train_begin", "on_train_end"):
+        assert getattr(type(cb), hook) is getattr(InstrumentationCallback, hook), (
+            f"{hook} resolves to the base TrainerCallback no-op — the "
+            "instrumentation guard would never fire"
+        )

--- a/packages/training/scripts/training/test_instrumentation.py
+++ b/packages/training/scripts/training/test_instrumentation.py
@@ -1,0 +1,102 @@
+"""CPU-only tests for the training environment / reproducibility manifest.
+
+`log_environment` writes environment.json with the AGENTS.md §9 reproducibility
+manifest: sha256 of every dataset file, the tokenizer artifact hash, the
+base-checkpoint hash, and the training git commit. These tests use tmp files +
+a mocked git call so they run anywhere headlessly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from scripts.training import instrumentation
+from scripts.training.instrumentation import _hash_paths, log_environment
+
+
+def _read_env(out_dir: Path) -> dict:
+    return json.loads((out_dir / "environment.json").read_text())
+
+
+def test_log_environment_hashes_dataset_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        instrumentation, "_git_head", lambda: {"available": True, "head": "deadbeef"}
+    )
+    train = tmp_path / "train.jsonl"
+    val = tmp_path / "val.jsonl"
+    train.write_bytes(b'{"a": 1}\n')
+    val.write_bytes(b'{"b": 2}\n')
+
+    out = tmp_path / "run"
+    log_environment(out, dataset_files=[train, val])
+    env = _read_env(out)
+
+    repro = env["reproducibility"]
+    expected_train = "sha256:" + hashlib.sha256(train.read_bytes()).hexdigest()
+    expected_val = "sha256:" + hashlib.sha256(val.read_bytes()).hexdigest()
+    assert repro["dataset_hashes"][str(train)] == expected_train
+    assert repro["dataset_hashes"][str(val)] == expected_val
+
+
+def test_log_environment_captures_git_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        instrumentation,
+        "_git_head",
+        lambda: {"available": True, "head": "abc123def456", "dirty": False},
+    )
+    out = tmp_path / "run"
+    log_environment(out)
+    env = _read_env(out)
+    assert env["reproducibility"]["git"] == {
+        "available": True,
+        "head": "abc123def456",
+        "dirty": False,
+    }
+
+
+def test_log_environment_hashes_tokenizer_and_base_checkpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(instrumentation, "_git_head", lambda: {"available": False})
+    # Tokenizer as a directory (as HF saves it) → one combined digest.
+    tok_dir = tmp_path / "tokenizer"
+    tok_dir.mkdir()
+    (tok_dir / "tokenizer.json").write_bytes(b"{}")
+    (tok_dir / "special_tokens_map.json").write_bytes(b"{}")
+    # Base checkpoint as a single file.
+    ckpt = tmp_path / "model.safetensors"
+    ckpt.write_bytes(b"\x00\x01\x02")
+
+    out = tmp_path / "run"
+    log_environment(out, tokenizer_path=tok_dir, base_checkpoint=ckpt)
+    repro = _read_env(out)["reproducibility"]
+
+    assert repro["tokenizer_hashes"][str(tok_dir)].startswith("sha256:")
+    assert repro["base_checkpoint_hashes"][str(ckpt)] == (
+        "sha256:" + hashlib.sha256(ckpt.read_bytes()).hexdigest()
+    )
+
+
+def test_log_environment_skips_non_local_base_checkpoint(tmp_path, monkeypatch):
+    """A bare HF repo id (e.g. google/gemma-4-E2B) is not a local path — it must
+    be skipped, not faked into a hash."""
+    monkeypatch.setattr(instrumentation, "_git_head", lambda: {"available": False})
+    out = tmp_path / "run"
+    log_environment(out, base_checkpoint="google/gemma-4-E2B")
+    repro = _read_env(out)["reproducibility"]
+    assert repro["base_checkpoint_hashes"] == {}
+
+
+def test_hash_paths_directory_digest_is_content_sensitive(tmp_path):
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "a.txt").write_bytes(b"hello")
+    h1 = _hash_paths([d])[str(d)]
+    (d / "a.txt").write_bytes(b"HELLO")
+    h2 = _hash_paths([d])[str(d)]
+    assert h1 != h2, "directory digest must change when a file's content changes"
+
+
+def test_hash_paths_empty_when_nothing_local(tmp_path):
+    assert _hash_paths(None) == {}
+    assert _hash_paths([tmp_path / "nope.jsonl", "org/repo-id"]) == {}

--- a/packages/training/scripts/training/test_instrumentation.py
+++ b/packages/training/scripts/training/test_instrumentation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 
 from scripts.training import instrumentation
@@ -71,10 +72,36 @@ def test_log_environment_hashes_tokenizer_and_base_checkpoint(tmp_path, monkeypa
     log_environment(out, tokenizer_path=tok_dir, base_checkpoint=ckpt)
     repro = _read_env(out)["reproducibility"]
 
-    assert repro["tokenizer_hashes"][str(tok_dir)].startswith("sha256:")
+    # The tokenizer artifact hash is REQUIRED by AGENTS.md §9 — it must be
+    # present and a real sha256 (64 hex chars), not just a prefix or empty.
+    tok_hash = repro["tokenizer_hashes"][str(tok_dir)]
+    assert re.fullmatch(r"sha256:[a-f0-9]{64}", tok_hash), tok_hash
     assert repro["base_checkpoint_hashes"][str(ckpt)] == (
         "sha256:" + hashlib.sha256(ckpt.read_bytes()).hexdigest()
     )
+
+
+def test_log_environment_records_tokenizer_hash_when_passed(tmp_path, monkeypatch):
+    """Regression for the C10 wiring gap: train_local.py must pass tokenizer_path
+    so the reproducibility manifest is COMPLETE. Without a tokenizer_path the map
+    is empty; with one it carries the artifact hash. This guards that the
+    tokenizer slot is populated (the train_local.py call now passes it)."""
+    monkeypatch.setattr(instrumentation, "_git_head", lambda: {"available": False})
+    tok_dir = tmp_path / "tokenizer"
+    tok_dir.mkdir()
+    (tok_dir / "tokenizer.json").write_bytes(b'{"model":"gemma4"}')
+
+    # Not passing tokenizer_path → empty (proves the field is opt-in on inputs).
+    out_no_tok = tmp_path / "run-none"
+    log_environment(out_no_tok, base_checkpoint="org/repo-id")
+    assert _read_env(out_no_tok)["reproducibility"]["tokenizer_hashes"] == {}
+
+    # Passing it → the artifact hash is captured.
+    out_tok = tmp_path / "run-tok"
+    log_environment(out_tok, tokenizer_path=tok_dir)
+    hashes = _read_env(out_tok)["reproducibility"]["tokenizer_hashes"]
+    assert list(hashes) == [str(tok_dir)]
+    assert re.fullmatch(r"sha256:[a-f0-9]{64}", hashes[str(tok_dir)])
 
 
 def test_log_environment_skips_non_local_base_checkpoint(tmp_path, monkeypatch):

--- a/packages/training/scripts/training/test_model_registry.py
+++ b/packages/training/scripts/training/test_model_registry.py
@@ -209,3 +209,22 @@ def test_quantization_matrix_includes_gguf_q4_q6_q8() -> None:
         assert "gguf-q5_k_m" in e.quantization_after
         assert "gguf-q6_k" in e.quantization_after
         assert "gguf-q8_0" in e.quantization_after
+
+
+def test_gemma4_unified_tiers_disable_liger() -> None:
+    """gemma4_unified (dense 12B/31B → eliza-1-9b/27b) has no validated Liger
+    kernel path — its fused RMSNorm/RoPE/CE assume the Gemma2/3 layout and NaN
+    the forward (the all-NaN 12B checkpoint incident). The registry MUST keep
+    Liger off for these tiers as the single source of truth, independent of the
+    arch-string backstop in train_local.py."""
+    assert REGISTRY["gemma4-12b"].use_liger is False
+    assert REGISTRY["gemma4-31b"].use_liger is False
+    assert get("eliza-1-9b").use_liger is False
+    assert get("eliza-1-27b").use_liger is False
+
+
+def test_local_gemma4_tiers_keep_liger() -> None:
+    """The E2B/E4B "gemma4" (non-unified) local tiers train fine with Liger and
+    rely on it for their seq_len budgets — they must stay enabled."""
+    assert REGISTRY["gemma4-e2b"].use_liger is True
+    assert REGISTRY["gemma4-e4b"].use_liger is True


### PR DESCRIPTION
## Part of #12216 — local-LLM pipeline hardening: training / quantization / publish / data-capture

The [full pipeline research map](https://github.com/elizaOS/eliza/issues/12216) found the pipeline is **mature, not slop-heavy** — the real defects are a stranded fix, unenforced contract-agreement gaps, and untested-in-CI safety nets. This PR lands the **training-side** headless fixes (the runtime/download/cloud-proxy side is a sibling PR).

### Fixes
- **C2 (P0) — generic finite-weights guard.** New `FiniteWeightsCallback`/`assert_finite_step` in `instrumentation.py`, wired into `train_local.py`: a divergent run now dies within one `logging_steps` interval instead of silently saving an all-NaN checkpoint (exactly the 12B incident, and any *future* divergence). **Also fixed a real latent bug** found while wiring it: `make_hf_callback`'s base-class MRO ordering was shadowing the instrumentation hooks, so the memory-budget guard and tokens/sec trace never fired — reversed the MRO + added a regression test proving the hooks now fire.
- **C1 (P0) — port the stranded gemma4_unified NaN-guard** (`b7e412f41cb`, previously only on an unmerged branch) into `train_local.py`; no-op when the arch is absent.
- **C3 (P1) — `use_liger=False` explicit** on the `gemma4-12b`/`gemma4-31b` registry entries (single source of truth) + assertions.
- **C4 (P1) — tier-agreement test** (the issue's explicit drift concern): a test mechanically parses `publish_all_eliza1.sh::TIERS`, `ELIZA_1_TIERS`, and `ELIZA_1_TIER_IDS` and asserts all three agree — converts a comment-only invariant into an enforced one.
- **C7 (P1) — kernel-parity tests now genuinely run.** Found the real C-refs at `plugins/plugin-local-inference/native/{verify,reference}/`, fixed the resolver path + added an `ELIZA_KERNEL_REF_DIR` override, and wired the CI mount: `test_recipes_smoke.py` went **29 passed + 6 skipped → 35 passed, 0 skipped** — the byte-exact quant-kernel parity tests now actually execute (and skip loudly, naming the missing file, when refs are truly absent).
- **CI wiring** — added **all seven** new/modified Python test files to `training-stack.yml`'s `cpu-smoke` pytest list (they were added but not run — a review catch).
- **C10 (P2) — reproducibility manifest** (AGENTS.md §9): `log_environment()` now captures dataset/tokenizer/base-checkpoint sha256 + git HEAD; the tokenizer is materialized (incl. chat-template override) so its hash lands in `environment.json`.
- **C14 (P2)** — real `eliza-1.manifest.schema.json` backing the `$schema` URL + versioned fixture + dual-gate test. **C17 (P2)** — content-hash dedup for `eliza_native_v1` rows. **Doc drift** — corrected the stale `~/.eliza/state` → `~/.local/state/eliza` trajectory path.

### Verification (real, headless)
- Python aggregate over all touched test files: **158 passed, 5 skipped** (the 5 skips are `apollo_torch`-gated optimizer tests absent from the minimal local env — present in CI's `--extra train` image).
- `ruff check` all touched files: clean. TS `catalog.test.ts`: 11 passed. `training-stack.yml`: valid, all 7 test files + kernel-ref mount wired.
- Adversarial review pass: 5 findings confirmed (tests-not-in-CI, silent parity-skip, missing tokenizer hash) — **all fixed above** and re-verified.

### `PR_EVIDENCE.md` rows
- **GPU-gated (N/A here, exact recipes in `.github/issue-evidence/12216-training-status.md`):** actually re-running 12B/31B SFT to confirm no divergence after C1/C2; real-artifact quant runs for `4b`/`9b`/`27b`/`27b-256k` + `--trellis`. **HF-gated:** pushing a real corpus snapshot via `publish_dataset_to_hf.py`. These need a GPU / HF token this headless environment doesn't have.
- **Flagged for a maintainer (not changed):** **C19** — `REQUIRED_KERNELS_BY_TIER` requires `turbo3_tcq` on all five tiers vs AGENTS.md §3's "long-context-only" framing; a publish-gate contract decision, documented in the status file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
