### PR TITLE
fix(desktop): bridge screen capture service (#12249)

### DIFF
--- a/packages/agent/src/api/server-skip-listen.test.ts
+++ b/packages/agent/src/api/server-skip-listen.test.ts
@@ -163,6 +163,23 @@ describe("startApiServer skipListen — source-level guard (#12180)", () => {
   });
 });
 
+describe("startApiServer streaming screen capture lookup — source-level guard (#12249)", () => {
+  it("resolves screenCapture lazily from the current runtime", () => {
+    expect(SERVER_SRC).toContain(
+      "const resolveScreenCapture = (): IScreenCaptureService | undefined =>",
+    );
+    expect(SERVER_SRC).toMatch(
+      /get\s+screenCapture\(\)\s*\{\s*return\s+resolveScreenCapture\(\);\s*\}/s,
+    );
+  });
+
+  it("does not snapshot the screen-capture service while streaming routes register", () => {
+    expect(SERVER_SRC).not.toMatch(
+      /const\s+screenCapture\s*=\s*state\.runtime\?\.getService/s,
+    );
+  });
+});
+
 describe("startApiServer skipListen — real boot in a Bun subprocess (#12180)", () => {
   it("has a boot harness fixture", () => {
     expect(existsSync(HARNESS_PATH)).toBe(true);

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4380,10 +4380,10 @@ export async function startApiServer(opts?: {
             "[eliza-api] @elizaos/plugin-streaming did not export handleStreamRoute; skipping streaming route registration.",
           );
         }
-        // Desktop screen-capture bridge, resolved via the runtime service the
-        // desktop host registers (never a globalThis bridge). Absent on
-        // mobile/web/cloud → streaming falls back to another capture mode.
-        const screenCapture =
+        // Desktop screen-capture bridge, resolved lazily from the current
+        // runtime. Desktop startup can bind streaming routes before the runtime
+        // service is registered, then updateRuntime hot-swaps state.runtime.
+        const resolveScreenCapture = (): IScreenCaptureService | undefined =>
           state.runtime?.getService<IScreenCaptureService>(
             ServiceType.SCREEN_CAPTURE,
           ) ?? undefined;
@@ -4495,7 +4495,9 @@ export async function startApiServer(opts?: {
         const streamState = {
           streamManager,
           port,
-          screenCapture,
+          get screenCapture() {
+            return resolveScreenCapture();
+          },
           captureUrl: undefined as string | undefined,
           destinations,
           activeDestinationId,

--- a/packages/agent/src/runtime/desktop-screen-capture-bridge-service.test.ts
+++ b/packages/agent/src/runtime/desktop-screen-capture-bridge-service.test.ts
@@ -1,0 +1,106 @@
+import { ServiceType } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetDesktopScreenCaptureBridgeServiceConfig,
+  DesktopScreenCaptureBridgeService,
+  registerDesktopScreenCaptureBridgeService,
+  resolveDesktopScreenCaptureBridgeConfig,
+} from "./desktop-screen-capture-bridge-service.ts";
+
+afterEach(() => {
+  _resetDesktopScreenCaptureBridgeServiceConfig();
+});
+
+describe("desktop screen capture bridge service", () => {
+  it("resolves only authenticated loopback bridge config", () => {
+    expect(resolveDesktopScreenCaptureBridgeConfig({})).toBeNull();
+    expect(
+      resolveDesktopScreenCaptureBridgeConfig({
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL: "https://example.com",
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN: "token",
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopScreenCaptureBridgeConfig({
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL: "http://127.0.0.1:31342/",
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN: "token",
+        ELIZA_API_PORT: "4567",
+      }),
+    ).toEqual({
+      baseUrl: "http://127.0.0.1:31342",
+      token: "token",
+      apiBase: "http://127.0.0.1:4567",
+    });
+  });
+
+  it("adds the child API base when starting host frame capture", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ available: true }), {
+        status: 200,
+      });
+    });
+    const service = new DesktopScreenCaptureBridgeService(
+      undefined,
+      {
+        baseUrl: "http://127.0.0.1:31342",
+        token: "token",
+        apiBase: "http://127.0.0.1:4567",
+      },
+      fetchImpl as unknown as typeof fetch,
+    );
+
+    await service.startFrameCapture({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+    });
+
+    expect(service.isFrameCaptureActive()).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:31342/frame-capture/start",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          fps: 15,
+          quality: 70,
+          endpoint: "/api/stream/frame",
+          apiBase: "http://127.0.0.1:4567",
+        }),
+      }),
+    );
+  });
+
+  it("registers and force-starts the runtime service when configured", async () => {
+    const calls: string[] = [];
+    const runtime = {
+      getService: vi.fn(() => null),
+      registerService: vi.fn(async (serviceClass) => {
+        calls.push(serviceClass.serviceType);
+      }),
+      getServiceLoadPromise: vi.fn(async (serviceType) => {
+        calls.push(`load:${serviceType}`);
+        return {} as never;
+      }),
+    };
+
+    await expect(
+      registerDesktopScreenCaptureBridgeService(runtime, {
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL: "http://127.0.0.1:31342",
+        ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN: "token",
+        ELIZA_API_PORT: "4567",
+      }),
+    ).resolves.toBe(true);
+
+    expect(runtime.registerService).toHaveBeenCalledWith(
+      DesktopScreenCaptureBridgeService,
+    );
+    expect(runtime.getServiceLoadPromise).toHaveBeenCalledWith(
+      ServiceType.SCREEN_CAPTURE,
+    );
+    expect(calls).toEqual(["screen_capture", "load:screen_capture"]);
+  });
+});

--- a/packages/agent/src/runtime/desktop-screen-capture-bridge-service.ts
+++ b/packages/agent/src/runtime/desktop-screen-capture-bridge-service.ts
@@ -1,0 +1,192 @@
+import {
+  type IAgentRuntime,
+  IScreenCaptureService,
+  logger,
+  type ScreenCaptureFrameOptions,
+  ServiceType,
+} from "@elizaos/core";
+import { resolveDesktopApiPort } from "@elizaos/shared";
+
+export const DESKTOP_SCREEN_CAPTURE_BRIDGE_URL_ENV =
+  "ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL";
+export const DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN_ENV =
+  "ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN";
+
+type RuntimeEnv = Record<string, string | undefined>;
+type FetchLike = typeof fetch;
+
+export interface DesktopScreenCaptureBridgeConfig {
+  baseUrl: string;
+  token: string;
+  apiBase: string;
+}
+
+function isLoopbackBridgeUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === "http:" &&
+      (parsed.hostname === "127.0.0.1" ||
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "::1")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function resolveDesktopScreenCaptureBridgeConfig(
+  env: RuntimeEnv = process.env,
+): DesktopScreenCaptureBridgeConfig | null {
+  const baseUrl = env[DESKTOP_SCREEN_CAPTURE_BRIDGE_URL_ENV]?.trim();
+  const token = env[DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN_ENV]?.trim();
+  if (!baseUrl || !token) return null;
+  if (!isLoopbackBridgeUrl(baseUrl)) return null;
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    token,
+    apiBase: `http://127.0.0.1:${resolveDesktopApiPort(env)}`,
+  };
+}
+
+export class DesktopScreenCaptureBridgeService extends IScreenCaptureService {
+  static override readonly serviceType = ServiceType.SCREEN_CAPTURE;
+  private static bridgeConfig: DesktopScreenCaptureBridgeConfig | null = null;
+
+  private active = false;
+  private readonly bridgeConfig: DesktopScreenCaptureBridgeConfig;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(
+    runtime?: IAgentRuntime,
+    bridgeConfig: DesktopScreenCaptureBridgeConfig | null = DesktopScreenCaptureBridgeService.bridgeConfig,
+    fetchImpl: FetchLike = fetch,
+  ) {
+    super(runtime);
+    if (!bridgeConfig) {
+      throw new Error("Desktop screen-capture bridge is not configured");
+    }
+    this.bridgeConfig = bridgeConfig;
+    this.fetchImpl = fetchImpl;
+  }
+
+  static configure(config: DesktopScreenCaptureBridgeConfig | null): void {
+    DesktopScreenCaptureBridgeService.bridgeConfig = config;
+  }
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<DesktopScreenCaptureBridgeService> {
+    if (!DesktopScreenCaptureBridgeService.bridgeConfig) {
+      throw new Error("Desktop screen-capture bridge is not configured");
+    }
+    return new DesktopScreenCaptureBridgeService(runtime);
+  }
+
+  override async stop(): Promise<void> {
+    if (!this.active) return;
+    try {
+      await this.stopFrameCapture();
+    } catch (error) {
+      logger.debug(
+        `[desktop-screen-capture] stop during service shutdown failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  override isFrameCaptureActive(): boolean {
+    return this.active;
+  }
+
+  override async startFrameCapture(
+    options: ScreenCaptureFrameOptions = {},
+  ): Promise<void> {
+    const result = await this.requestJson<{
+      available?: boolean;
+      reason?: string;
+    }>("/frame-capture/start", {
+      method: "POST",
+      body: JSON.stringify({
+        ...options,
+        apiBase: this.bridgeConfig.apiBase,
+        endpoint: options.endpoint ?? "/api/stream/frame",
+      }),
+    });
+    if (result.available === false) {
+      throw new Error(result.reason ?? "desktop screen capture unavailable");
+    }
+    this.active = true;
+  }
+
+  override stopFrameCapture(): void {
+    this.active = false;
+    void this.requestJson("/frame-capture/stop", { method: "POST" }).catch(
+      (error) => {
+        logger.debug(
+          `[desktop-screen-capture] stop bridge request failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      },
+    );
+  }
+
+  private async requestJson<T = Record<string, unknown>>(
+    pathname: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    const response = await this.fetchImpl(
+      `${this.bridgeConfig.baseUrl}${pathname}`,
+      {
+        ...init,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.bridgeConfig.token}`,
+          ...init.headers,
+        },
+      },
+    );
+    const text = await response.text();
+    const body = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+    if (!response.ok) {
+      const error =
+        typeof body.error === "string"
+          ? body.error
+          : `desktop screen-capture bridge returned ${response.status}`;
+      throw new Error(error);
+    }
+    return body as T;
+  }
+}
+
+type RuntimeWithServiceRegistration = Pick<
+  IAgentRuntime,
+  "getService" | "getServiceLoadPromise" | "registerService"
+>;
+
+export async function registerDesktopScreenCaptureBridgeService(
+  runtime: RuntimeWithServiceRegistration,
+  env: RuntimeEnv = process.env,
+): Promise<boolean> {
+  if (runtime.getService(ServiceType.SCREEN_CAPTURE)) {
+    return false;
+  }
+
+  const config = resolveDesktopScreenCaptureBridgeConfig(env);
+  DesktopScreenCaptureBridgeService.configure(config);
+  if (!config) {
+    return false;
+  }
+
+  await runtime.registerService(DesktopScreenCaptureBridgeService);
+  await runtime.getServiceLoadPromise(ServiceType.SCREEN_CAPTURE);
+  logger.info("[desktop-screen-capture] Registered Electrobun bridge service");
+  return true;
+}
+
+export function _resetDesktopScreenCaptureBridgeServiceConfig(): void {
+  DesktopScreenCaptureBridgeService.configure(null);
+}

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -128,6 +128,7 @@ import {
   settingsDebugCloudSummary,
 } from "@elizaos/shared";
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
+import { registerDesktopScreenCaptureBridgeService } from "./desktop-screen-capture-bridge-service.ts";
 import { type AgentHostBridge, getAgentHostBridge } from "./host-bridge.ts";
 
 // Host capabilities (wallet-key hydration, vault bootstrap/access, account
@@ -220,11 +221,11 @@ import {
   evaluateTeeBootGate,
   type TeeBootGate,
 } from "../services/tee-boot-gate.ts";
-import { resolveTeeEvidenceProvider } from "../services/tee-evidence-provider.ts";
 import {
   setTeeBootGateState,
   teeBootGateBlocksSecrets,
 } from "../services/tee-boot-gate-state.ts";
+import { resolveTeeEvidenceProvider } from "../services/tee-evidence-provider.ts";
 import {
   resolveDefaultAgentWorkspaceDir,
   shouldBootstrapWorkspaceInitFiles,
@@ -5090,6 +5091,8 @@ export async function startEliza(
 
     await initializeCoreRuntime();
     bootTimer.lap("svc:runtime.initialize");
+    await registerDesktopScreenCaptureBridgeService(runtime);
+    bootTimer.lap("svc:desktop-screen-capture");
   };
 
   const registerDeferredRuntimePlugins = async (

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -122,6 +122,7 @@ import {
   resolveRendererAssetDir,
 } from "./runtime-layout";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
+import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { recordStartupPhase, resolveStartupBundlePath } from "./startup-trace";
 import {
@@ -1234,7 +1235,9 @@ function attachMainWindow(
   // icon — the chromeless bottom-bar pill never does. Declare which this is,
   // regardless of how it was opened (boot, tray "Show Window", Dock reopen, or
   // a direct restoreWindow() from a deep link that bypasses showWindow()).
-  getDesktopManager().setMainWindowFullWindow(presentation.mode !== "bottom-bar");
+  getDesktopManager().setMainWindowFullWindow(
+    presentation.mode !== "bottom-bar",
+  );
 
   win.webview.on("dom-ready", () => {
     injectApiBase(win);
@@ -2526,6 +2529,18 @@ async function main(): Promise<void> {
     const stop = await browserWorkspaceBridgeStop;
     await stop?.();
   });
+  try {
+    const stopScreenCaptureBridgeServer =
+      await startScreenCaptureBridgeServer();
+    recordStartupPhase("screen_capture_bridge_ready", {
+      pid: process.pid,
+    });
+    cleanupFns.push(stopScreenCaptureBridgeServer);
+  } catch (err) {
+    logger.warn(
+      `[Main] Screen-capture bridge startup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   const stopDesktopTestBridgeServer = await startDesktopTestBridgeServer();
   recordStartupPhase("desktop_test_bridge_ready", {
     pid: process.pid,
@@ -2567,7 +2582,9 @@ async function main(): Promise<void> {
   // icon hidden until a full window (dashboard/surface/settings/app) opens.
   const dockless = shouldStartTrayFirst();
   if (dockless) {
-    logger.info("[Main] Dockless startup — pill only, Dock icon hidden at rest");
+    logger.info(
+      "[Main] Dockless startup — pill only, Dock icon hidden at rest",
+    );
     getDesktopManager().setTrayFirstMode(true);
   }
   recordStartupPhase("creating_window", {

--- a/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { startScreenCaptureBridgeServer } from "./screen-capture-bridge-server";
+
+const cleanupFns: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanupFns.length > 0) {
+    cleanupFns.pop()?.();
+  }
+});
+
+describe("screen capture bridge server", () => {
+  it("requires a bearer token and proxies frame-capture calls", async () => {
+    const calls: unknown[] = [];
+    let active = false;
+    const env: Record<string, string | undefined> = {
+      ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_PORT: "31342",
+      ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN: "test-token",
+    };
+    const stop = await startScreenCaptureBridgeServer({
+      env,
+      manager: {
+        isFrameCaptureActive: () => ({ active }),
+        startFrameCapture: (options) => {
+          calls.push(options);
+          active = true;
+          return { available: true };
+        },
+        stopFrameCapture: () => {
+          active = false;
+          return { available: true };
+        },
+      },
+    });
+    cleanupFns.push(stop);
+
+    const baseUrl = env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL;
+    expect(baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    const unauthorized = await fetch(`${baseUrl}/health`);
+    expect(unauthorized.status).toBe(401);
+
+    const headers = {
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+    };
+    const start = await fetch(`${baseUrl}/frame-capture/start`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        fps: 15,
+        quality: 70,
+        apiBase: "http://127.0.0.1:4567",
+        endpoint: "/api/stream/frame",
+      }),
+    });
+    expect(start.status).toBe(200);
+    expect(await start.json()).toEqual({ available: true });
+    expect(calls).toEqual([
+      {
+        fps: 15,
+        quality: 70,
+        apiBase: "http://127.0.0.1:4567",
+        endpoint: "/api/stream/frame",
+      },
+    ]);
+
+    const activeResponse = await fetch(`${baseUrl}/frame-capture`, {
+      headers,
+    });
+    expect(await activeResponse.json()).toEqual({ active: true });
+
+    const stopResponse = await fetch(`${baseUrl}/frame-capture/stop`, {
+      method: "POST",
+      headers,
+    });
+    expect(stopResponse.status).toBe(200);
+    expect(await stopResponse.json()).toEqual({ available: true });
+    expect(active).toBe(false);
+  });
+
+  it("rejects non-loopback API bases before reaching the manager", async () => {
+    let called = false;
+    const env: Record<string, string | undefined> = {
+      ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_PORT: "31442",
+      ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN: "test-token",
+    };
+    const stop = await startScreenCaptureBridgeServer({
+      env,
+      manager: {
+        isFrameCaptureActive: () => ({ active: false }),
+        startFrameCapture: () => {
+          called = true;
+          return { available: true };
+        },
+        stopFrameCapture: () => ({ available: true }),
+      },
+    });
+    cleanupFns.push(stop);
+
+    const response = await fetch(
+      `${env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL}/frame-capture/start`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          apiBase: "https://example.com",
+          endpoint: "/api/stream/frame",
+        }),
+      },
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "apiBase must be a loopback http URL",
+    });
+    expect(called).toBe(false);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.ts
@@ -1,0 +1,215 @@
+import crypto from "node:crypto";
+import http from "node:http";
+import { findFirstAvailableLoopbackPort } from "./native/loopback-port";
+import { getScreenCaptureManager } from "./native/screencapture";
+
+const DEFAULT_SCREEN_CAPTURE_BRIDGE_PORT = 31_342;
+const MAX_BODY_BYTES = 64 * 1024;
+
+type ScreenCaptureBridgeEnv = Record<string, string | undefined>;
+
+type ScreenCaptureManagerLike = {
+  isFrameCaptureActive(): Promise<{ active: boolean }> | { active: boolean };
+  startFrameCapture(options?: {
+    fps?: number;
+    quality?: number;
+    apiBase?: string;
+    endpoint?: string;
+    gameUrl?: string;
+  }):
+    | Promise<{ available: boolean; reason?: string }>
+    | {
+        available: boolean;
+        reason?: string;
+      };
+  stopFrameCapture(): Promise<{ available: boolean }> | { available: boolean };
+};
+
+export interface ScreenCaptureBridgeServerOptions {
+  env?: ScreenCaptureBridgeEnv;
+  manager?: ScreenCaptureManagerLike;
+}
+
+function isLoopback(addr: string | undefined): boolean {
+  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+}
+
+function json(
+  res: http.ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(body));
+}
+
+function isAuthorized(req: http.IncomingMessage, token: string): boolean {
+  if (!token) return false;
+  return req.headers.authorization === `Bearer ${token}`;
+}
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | null> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as T;
+}
+
+function pickFiniteNumber(
+  value: unknown,
+  options: { min?: number } = {},
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  if (typeof options.min === "number" && value < options.min) {
+    return undefined;
+  }
+  return value;
+}
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isLoopbackHttpBase(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.protocol === "http:" &&
+      (parsed.hostname === "127.0.0.1" ||
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "::1")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function normalizeStartBody(
+  body: Record<string, unknown> | null,
+): Parameters<ScreenCaptureManagerLike["startFrameCapture"]>[0] {
+  const apiBase = pickString(body?.apiBase);
+  if (apiBase && !isLoopbackHttpBase(apiBase)) {
+    throw new Error("apiBase must be a loopback http URL");
+  }
+
+  const endpoint = pickString(body?.endpoint);
+  if (endpoint && !endpoint.startsWith("/")) {
+    throw new Error("endpoint must be an absolute path");
+  }
+
+  const options: Parameters<ScreenCaptureManagerLike["startFrameCapture"]>[0] =
+    {};
+  const fps = pickFiniteNumber(body?.fps, { min: 1 });
+  const quality = pickFiniteNumber(body?.quality, { min: 1 });
+  const gameUrl = pickString(body?.gameUrl);
+  if (fps !== undefined) options.fps = fps;
+  if (quality !== undefined) options.quality = quality;
+  if (apiBase) options.apiBase = apiBase;
+  if (endpoint) options.endpoint = endpoint;
+  if (gameUrl) options.gameUrl = gameUrl;
+  return options;
+}
+
+export async function startScreenCaptureBridgeServer({
+  env = process.env,
+  manager = getScreenCaptureManager(),
+}: ScreenCaptureBridgeServerOptions = {}): Promise<() => void> {
+  const requestedPort =
+    Number.parseInt(
+      (env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_PORT ?? "").trim(),
+      10,
+    ) || DEFAULT_SCREEN_CAPTURE_BRIDGE_PORT;
+  const port = await findFirstAvailableLoopbackPort(requestedPort, {
+    host: "127.0.0.1",
+    maxHops: 32,
+  });
+  const token =
+    env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN?.trim() ||
+    crypto.randomBytes(18).toString("hex");
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_URL = baseUrl;
+  env.ELIZA_DESKTOP_SCREEN_CAPTURE_BRIDGE_TOKEN = token;
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (!isLoopback(req.socket.remoteAddress)) {
+        json(res, 403, { error: "forbidden" });
+        return;
+      }
+      if (!isAuthorized(req, token)) {
+        json(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const pathname = url.pathname;
+      const method = req.method ?? "GET";
+
+      if (pathname === "/health" && method === "GET") {
+        const active = await manager.isFrameCaptureActive();
+        json(res, 200, { ok: true, active: Boolean(active.active) });
+        return;
+      }
+
+      if (pathname === "/frame-capture" && method === "GET") {
+        const active = await manager.isFrameCaptureActive();
+        json(res, 200, { active: Boolean(active.active) });
+        return;
+      }
+
+      if (pathname === "/frame-capture/start" && method === "POST") {
+        const body = await readJsonBody<Record<string, unknown>>(req);
+        const result = await manager.startFrameCapture(
+          normalizeStartBody(body),
+        );
+        json(res, result.available ? 200 : 409, result);
+        return;
+      }
+
+      if (pathname === "/frame-capture/stop" && method === "POST") {
+        const result = await manager.stopFrameCapture();
+        json(res, 200, result);
+        return;
+      }
+
+      json(res, 404, { error: "not found" });
+    } catch (error) {
+      json(res, 500, {
+        error: error instanceof Error ? error.message : "internal error",
+      });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  console.log(
+    `[ScreenCaptureBridge] ${baseUrl} (loopback only; token required)`,
+  );
+
+  return () => {
+    server.close();
+  };
+}

--- a/packages/app-core/platforms/electrobun/src/startup-trace.ts
+++ b/packages/app-core/platforms/electrobun/src/startup-trace.ts
@@ -9,6 +9,7 @@ export const STARTUP_TRACE_PHASES = [
   "crash_prompt_checked",
   "webgpu_initialized",
   "browser_workspace_bridge_ready",
+  "screen_capture_bridge_ready",
   "desktop_test_bridge_ready",
   "creating_window",
   "window_ready",


### PR DESCRIPTION
## Summary
- add a private loopback Electrobun screen-capture bridge server with bearer auth
- register an agent runtime `ServiceType.SCREEN_CAPTURE` proxy when the desktop host exposes the bridge
- pass the spawned child API base into frame capture so dynamic desktop ports post frames to the right `/api/stream/frame` endpoint
- resolve `screenCapture` lazily in streaming route state so API startup before runtime/service registration still picks up the later desktop service

Fixes #12249.
Supersedes the duplicate #12249 attempts in #12310 and #12328: this PR includes the host bridge, child runtime service, dynamic child API-base forwarding, loopback validation, forced service load after runtime init, and the lazy streaming route lookup.

## Verification
- `bunx biome check packages/agent/src/api/server.ts packages/agent/src/api/server-skip-listen.test.ts packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.ts packages/app-core/platforms/electrobun/src/screen-capture-bridge-server.test.ts packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/startup-trace.ts packages/agent/src/runtime/desktop-screen-capture-bridge-service.ts packages/agent/src/runtime/desktop-screen-capture-bridge-service.test.ts packages/agent/src/runtime/eliza.ts`
- `bunx vitest run --config vitest.electrobun.config.ts src/screen-capture-bridge-server.test.ts` from `packages/app-core/platforms/electrobun` (2 tests)
- `bunx vitest run --config vitest.config.ts src/runtime/desktop-screen-capture-bridge-service.test.ts` from `packages/agent` (3 tests)
- `bunx vitest run --config vitest.config.ts src/api/server-skip-listen.test.ts` from `packages/agent` (9 tests)
- `git diff --check`

## Typecheck note
- `bun run --cwd packages/agent typecheck` and `bun run --cwd packages/app-core/platforms/electrobun typecheck` still exit 1 on existing unrelated unresolved optional workspace packages/pre-existing type errors; filtered output has no errors for the files touched here.
