### PR TITLE
test(ui): lock in the chat no_provider failure gate in the continuous overlay

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1353,7 +1353,7 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getByLabelText(/send/)).toBeTruthy();
   });
 
-  it("renders the no_provider failure as a recovery gate with a Settings jump", () => {
+  it("renders the no_provider failure as a recovery gate with a Settings jump, while a normal turn still renders its content", () => {
     const openSettings = vi.fn();
     render(
       <ContinuousChatOverlay
@@ -1361,10 +1361,16 @@ describe("ContinuousChatOverlay", () => {
           openSettings,
           messages: [
             {
+              id: "ok",
+              role: "assistant",
+              content: "here is a normal answer",
+              createdAt: 1,
+            },
+            {
               id: "np",
               role: "assistant",
               content: "No model provider is configured.",
-              createdAt: 1,
+              createdAt: 2,
               failureKind: "no_provider",
             },
           ],
@@ -1372,10 +1378,28 @@ describe("ContinuousChatOverlay", () => {
       />,
     );
     fireEvent.focus(screen.getByLabelText("message"));
+
+    // The no_provider turn renders the STRUCTURED gate (heading + Settings CTA),
+    // not an empty/near-empty bubble — this is the actionable recovery the user
+    // needs on a first-message provider failure.
     expect(screen.getByText("Connect a provider to chat")).toBeTruthy();
-    const cta = screen.getByTestId("chat-no-provider-settings");
-    fireEvent.click(cta);
+    const gate = screen
+      .getByTestId("chat-no-provider-settings")
+      .closest('[data-failure="no_provider"]') as HTMLElement;
+    expect(gate).toBeTruthy();
+    // The server's fallback text rides inside the gate body (not dropped).
+    expect(gate.textContent).toContain("No model provider is configured.");
+
+    // The Settings CTA jumps to settings nav (setTab("settings") via the
+    // controller's openSettings).
+    fireEvent.click(screen.getByTestId("chat-no-provider-settings"));
     expect(openSettings).toHaveBeenCalledTimes(1);
+
+    // A normal assistant turn in the same thread is UNAFFECTED — it still
+    // renders its plain content as a thread bubble, not the gate.
+    const normal = screen.getByText("here is a normal answer");
+    expect(normal).toBeTruthy();
+    expect(normal.closest('[data-failure="no_provider"]')).toBeNull();
   });
 
   it("press-and-hold copies an assistant message and flashes confirmation", () => {


### PR DESCRIPTION
## What

Locks in the chat **no_provider failure gate** in the continuous chat overlay (`ContinuousChatOverlay.tsx` → `ThreadLine`).

The overlay is the *single* chat input on `/chat`. If a user's first message hits a `no_provider` failure (no LLM/model provider configured), the render path must show something actionable — not an empty/near-empty grey bubble. The structured gate ("Connect a provider to chat" + the server's fallback text + an **Open Settings** CTA wired to settings nav) already exists in `ThreadLine` and is wired end-to-end:

- `ShellMessage.failureKind` is carried through `useShellController` and the visible-message filter (`selectVisibleShellMessages` explicitly keeps `failureKind !== undefined` turns, so a content-less failure isn't dropped).
- `ThreadLine` branches on `failureKind === "no_provider"` and renders the gate with `data-testid="chat-no-provider-settings"`, wired to the controller's `openSettings` → `setTab("settings")`.
- Other `failureKind` values fall through to their existing message text (mirrors `MessageContent`; no invented copy).

## The gap this closes

The silent-failure risk is a future regression that drops `failureKind` on the overlay render path (rendering only `{message.content}`) and thereby swallows the *only* recovery affordance a first-run user has. This PR strengthens the existing overlay test so both invariants are asserted together and a regression can't land quietly:

- a `failureKind="no_provider"` assistant turn renders the structured gate (heading + the server fallback text in the body + the **Open Settings** CTA), and clicking the CTA jumps to settings nav (`openSettings` called once);
- a **normal** assistant turn in the same thread is unaffected — it still renders its plain content, and is *not* wrapped in the gate (`data-failure="no_provider"`).

## Scope

- Test-only change: `packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx`. The production gate is already on `develop`; this makes its contract regression-proof.

## Follow-up (out of scope, deliberately not in this PR)

The **cold-boot routing / dimming** first-run robustness fix is a documented follow-up and is intentionally not touched here.

## Testing

Best-effort local run was blocked: a fresh worktree with no build can't resolve unbuilt/codegen'd workspace deps (`@elizaos/cloud-routing` dist, `packages/core/src/i18n/generated/validation-keyword-data.ts`) that the ui vitest suite pulls in transitively — this needs a full monorepo build. **CI validates the suite.** The added assertions use only `screen` / `closest` / `textContent` / `vi.fn` patterns already proven green in this same test file, against the actual production markup (`data-testid="chat-no-provider-settings"`, `data-failure="no_provider"`, both call sites pass `onOpenSettings={openSettings}`).
