### PR TITLE
chore(#12229): dev SECRETS_MASTER_KEY for cloud:mock (M4 fail-closed follow-up)

### DIFF
--- a/scripts/cloud/mock-stack-up.mjs
+++ b/scripts/cloud/mock-stack-up.mjs
@@ -351,6 +351,13 @@ async function main() {
     CONTAINER_CONTROL_PLANE_URL: tCp,
     CONTAINER_CONTROL_PLANE_TOKEN: "local-mock-token",
     CRON_SECRET: "local-cron-secret",
+    // Fixed dev master key so the mock stack exercises the real secrets
+    // envelope end-to-end. Since #12229 (M4) the LocalKMSProvider fails closed
+    // when SECRETS_MASTER_KEY is unset, so any secrets op during a mock session
+    // (connector-OAuth token storage, provisioning/container-deploy secrets)
+    // would otherwise throw. This is a throwaway local-dev key, never a real one.
+    SECRETS_MASTER_KEY:
+      process.env.SECRETS_MASTER_KEY ?? "0123456789abcdef".repeat(4),
   };
 
   try {


### PR DESCRIPTION
Follow-up to #12229 (M4). The fail-closed KMS (`LocalKMSProvider.getMasterKey` throws when `SECRETS_MASTER_KEY` is unset) is correct for production, but `bun run cloud:mock` builds its child-process env without a master key — so any secrets operation during a mock session (connector-OAuth token storage, provisioning/container-deploy secrets) now throws on a dev machine.

This sets a **throwaway fixed dev master key** in the mock stack's `baseEnv` (overridable — respects an existing `SECRETS_MASTER_KEY` if the dev has one), so `cloud:mock` exercises the real secrets envelope end-to-end. Dev-only; production keeps failing closed (M4 unchanged).

- `node --check scripts/cloud/mock-stack-up.mjs` → OK
- Single-file, dev-tooling-only change.

Refs #12229

🤖 Generated with [Claude Code](https://claude.com/claude-code)