### PR TITLE
fix(plugin-wallet): restore agent-auto daily trade quota in canUseLocalTradeExecution

### DIFF
--- a/plugins/plugin-wallet/src/index.ts
+++ b/plugins/plugin-wallet/src/index.ts
@@ -33,7 +33,11 @@ export * from "./audit/audit-log.js";
 export { walletRouterAction } from "./chains/wallet-action.js";
 export * from "./contracts.js";
 export {
+  AGENT_AUTO_MAX_DAILY_TRADES,
+  agentAutoDailyTrades,
   canUseLocalTradeExecution,
+  getAgentAutoTradeDate,
+  recordAgentAutoTrade,
   resolveTradePermissionMode,
   resolveWalletExportRejection,
 } from "./lib/server-wallet-trade.js";

--- a/plugins/plugin-wallet/src/lib/server-wallet-trade.test.ts
+++ b/plugins/plugin-wallet/src/lib/server-wallet-trade.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  AGENT_AUTO_MAX_DAILY_TRADES,
+  agentAutoDailyTrades,
+  canUseLocalTradeExecution,
+  getAgentAutoTradeDate,
+  recordAgentAutoTrade,
+  resolveTradePermissionMode,
+} from "./server-wallet-trade";
+
+/**
+ * The plugin's `canUseLocalTradeExecution` must stay in exact parity with the
+ * host-canonical guard in `packages/agent/src/api/trade-safety.ts`. The
+ * regression this pins: the plugin copy had DROPPED the autonomous daily-trade
+ * quota, so `agent-auto` returned `true` unconditionally — letting an
+ * autonomous agent trade without any daily cap. These cases assert the cap is
+ * enforced (spend safety), the counting window is a UTC calendar day, and the
+ * consume/peek behavior matches the host.
+ */
+
+/** Reset the module-level daily-trade counter so cases don't bleed into each other. */
+function resetCounter(resetDate = ""): void {
+  agentAutoDailyTrades.count = 0;
+  agentAutoDailyTrades.resetDate = resetDate;
+}
+
+describe("recordAgentAutoTrade (daily cap)", () => {
+  beforeEach(() => resetCounter(getAgentAutoTradeDate()));
+  afterEach(() => resetCounter());
+
+  it("caps at 25 per day to match the host", () => {
+    expect(AGENT_AUTO_MAX_DAILY_TRADES).toBe(25);
+  });
+
+  it("allows up to the daily max, then rejects", () => {
+    for (let i = 1; i <= AGENT_AUTO_MAX_DAILY_TRADES; i += 1) {
+      expect(recordAgentAutoTrade()).toBe(true);
+      expect(agentAutoDailyTrades.count).toBe(i);
+    }
+    // the next one is over the cap
+    expect(recordAgentAutoTrade()).toBe(false);
+    expect(agentAutoDailyTrades.count).toBe(AGENT_AUTO_MAX_DAILY_TRADES);
+  });
+
+  it("resets the counter on a new calendar day", () => {
+    resetCounter("2000-01-01"); // a stale day
+    agentAutoDailyTrades.count = AGENT_AUTO_MAX_DAILY_TRADES; // pretend yesterday was maxed
+    expect(recordAgentAutoTrade()).toBe(true); // new day → reset → allowed
+    expect(agentAutoDailyTrades.count).toBe(1);
+    expect(agentAutoDailyTrades.resetDate).toBe(getAgentAutoTradeDate());
+  });
+
+  it("logs the rejection when the cap is hit", () => {
+    agentAutoDailyTrades.count = AGENT_AUTO_MAX_DAILY_TRADES;
+    const logs: string[] = [];
+    expect(recordAgentAutoTrade((m) => logs.push(m))).toBe(false);
+    expect(logs.join(" ")).toMatch(/daily trade limit reached/i);
+  });
+});
+
+describe("canUseLocalTradeExecution (local-key authorization)", () => {
+  beforeEach(() => resetCounter(getAgentAutoTradeDate()));
+  afterEach(() => resetCounter());
+
+  it("REGRESSION: agent-auto is BLOCKED once the daily quota is reached", () => {
+    // Under the cap: allowed. This exhausts exactly the daily budget.
+    for (let i = 1; i <= AGENT_AUTO_MAX_DAILY_TRADES; i += 1) {
+      expect(canUseLocalTradeExecution("agent-auto", true)).toBe(true);
+    }
+    expect(agentAutoDailyTrades.count).toBe(AGENT_AUTO_MAX_DAILY_TRADES);
+    // Over the cap: blocked. (Pre-fix, the drifted copy returned true here.)
+    expect(canUseLocalTradeExecution("agent-auto", true)).toBe(false);
+    expect(canUseLocalTradeExecution("agent-auto", true)).toBe(false);
+  });
+
+  it("manual-local-key: the user may, the agent may not", () => {
+    expect(canUseLocalTradeExecution("manual-local-key", false)).toBe(true);
+    expect(canUseLocalTradeExecution("manual-local-key", true)).toBe(false);
+  });
+
+  it("agent-auto: a non-agent user is always allowed (no quota)", () => {
+    expect(canUseLocalTradeExecution("agent-auto", false)).toBe(true);
+    expect(agentAutoDailyTrades.count).toBe(0);
+  });
+
+  it("agent-auto + agent consumes a quota slot by default", () => {
+    expect(canUseLocalTradeExecution("agent-auto", true)).toBe(true);
+    expect(agentAutoDailyTrades.count).toBe(1);
+  });
+
+  it("agent-auto + agent with consumeAgentQuota:false checks WITHOUT consuming", () => {
+    const before = agentAutoDailyTrades.count;
+    expect(
+      canUseLocalTradeExecution("agent-auto", true, undefined, {
+        consumeAgentQuota: false,
+      }),
+    ).toBe(true);
+    expect(agentAutoDailyTrades.count).toBe(before); // not consumed
+  });
+
+  it("agent-auto + agent at the cap is denied (peek and consume)", () => {
+    agentAutoDailyTrades.count = AGENT_AUTO_MAX_DAILY_TRADES;
+    expect(
+      canUseLocalTradeExecution("agent-auto", true, undefined, {
+        consumeAgentQuota: false,
+      }),
+    ).toBe(false);
+    expect(canUseLocalTradeExecution("agent-auto", true)).toBe(false);
+  });
+
+  it("denies any other permission mode (fail closed)", () => {
+    expect(canUseLocalTradeExecution("disabled", false)).toBe(false);
+    expect(canUseLocalTradeExecution("disabled", true)).toBe(false);
+    expect(canUseLocalTradeExecution("user-sign-only", false)).toBe(false);
+    expect(canUseLocalTradeExecution("user-sign-only", true)).toBe(false);
+  });
+});
+
+describe("resolveTradePermissionMode", () => {
+  it("returns configured valid modes and defaults to user-sign-only", () => {
+    expect(
+      resolveTradePermissionMode({ features: { tradePermissionMode: "agent-auto" } }),
+    ).toBe("agent-auto");
+    expect(
+      resolveTradePermissionMode({
+        features: { tradePermissionMode: "manual-local-key" },
+      }),
+    ).toBe("manual-local-key");
+    expect(resolveTradePermissionMode({ features: { tradePermissionMode: "bogus" } })).toBe(
+      "user-sign-only",
+    );
+    expect(resolveTradePermissionMode({ features: null })).toBe("user-sign-only");
+  });
+});
+
+describe("getAgentAutoTradeDate", () => {
+  it("returns a YYYY-MM-DD calendar day", () => {
+    expect(getAgentAutoTradeDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/plugins/plugin-wallet/src/lib/server-wallet-trade.ts
+++ b/plugins/plugin-wallet/src/lib/server-wallet-trade.ts
@@ -7,6 +7,7 @@
 import crypto from "node:crypto";
 import type http from "node:http";
 import { syncAppEnvToEliza, syncElizaEnvAliases } from "@elizaos/core";
+import type { TradePermissionMode } from "@elizaos/shared";
 
 import type { WalletExportRequestBody } from "../contracts.js";
 import {
@@ -144,10 +145,7 @@ const hardenedGuard = createHardenedExportGuard(
 // Exported types and functions
 // ---------------------------------------------------------------------------
 
-export type TradePermissionMode =
-  | "user-sign-only"
-  | "manual-local-key"
-  | "agent-auto";
+export type { TradePermissionMode };
 
 export function resolveTradePermissionMode(config: {
   features?: { tradePermissionMode?: unknown } | null;
@@ -163,16 +161,82 @@ export function resolveTradePermissionMode(config: {
   return "user-sign-only";
 }
 
+// ---------------------------------------------------------------------------
+// Autonomous (agent-auto) daily trade quota.
+//
+// Canonical semantics live in the host at
+// `packages/agent/src/api/trade-safety.ts`; this copy is kept in exact parity
+// (same 25/day cap, same UTC-calendar-day counting window, same consume/peek
+// behavior) so the `@elizaos/agent`-free plugin barrel enforces the identical
+// spend guard for its own consumers.
+// ---------------------------------------------------------------------------
+
+/** Maximum number of autonomous agent trades allowed per calendar day. */
+export const AGENT_AUTO_MAX_DAILY_TRADES = 25;
+
+/** Tracks autonomous trade count for rate-limiting in agent-auto mode. */
+export const agentAutoDailyTrades = { count: 0, resetDate: "" };
+
+export function getAgentAutoTradeDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Record an autonomous agent trade. Returns true if allowed, false if
+ * the daily limit has been reached. Resets the counter on a new calendar day.
+ */
+export function recordAgentAutoTrade(log?: (msg: string) => void): boolean {
+  const today = getAgentAutoTradeDate();
+  if (agentAutoDailyTrades.resetDate !== today) {
+    agentAutoDailyTrades.count = 0;
+    agentAutoDailyTrades.resetDate = today;
+  }
+  if (agentAutoDailyTrades.count >= AGENT_AUTO_MAX_DAILY_TRADES) {
+    log?.(
+      `[trade] Agent-auto daily trade limit reached (${AGENT_AUTO_MAX_DAILY_TRADES}). Rejecting autonomous trade.`,
+    );
+    return false;
+  }
+  agentAutoDailyTrades.count += 1;
+  log?.(
+    `[trade] Agent-auto autonomous trade ${agentAutoDailyTrades.count}/${AGENT_AUTO_MAX_DAILY_TRADES} for ${today}`,
+  );
+  return true;
+}
+
+type LocalTradeExecutionOptions = {
+  consumeAgentQuota?: boolean;
+};
+
+/**
+ * Returns true if local-key execution is permitted for the given actor.
+ *
+ * In `agent-auto` mode an autonomous agent is additionally capped at
+ * `AGENT_AUTO_MAX_DAILY_TRADES` trades per calendar day. By default a permitted
+ * agent-auto trade consumes one unit of daily quota; pass
+ * `{ consumeAgentQuota: false }` to peek at remaining headroom without spending
+ * it.
+ */
 export function canUseLocalTradeExecution(
   mode: TradePermissionMode,
   isAgent: boolean,
+  log?: (msg: string) => void,
+  options: LocalTradeExecutionOptions = {},
 ): boolean {
   if (mode === "agent-auto") {
+    if (isAgent) {
+      if (options.consumeAgentQuota === false) {
+        const today = getAgentAutoTradeDate();
+        if (agentAutoDailyTrades.resetDate !== today) {
+          return true;
+        }
+        return agentAutoDailyTrades.count < AGENT_AUTO_MAX_DAILY_TRADES;
+      }
+      return recordAgentAutoTrade(log);
+    }
     return true;
   }
-  if (mode === "manual-local-key") {
-    return !isAgent;
-  }
+  if (mode === "manual-local-key") return !isAgent;
   return false;
 }
 


### PR DESCRIPTION
## Latent trade-safety regression (found during #12092 item 2)

plugin-wallet's `canUseLocalTradeExecution` (`server-wallet-trade.ts:166`) had **drifted** from the host canonical `packages/agent/src/api/trade-safety.ts`: for `agent-auto` mode it did `return true` **unconditionally** — dropping the `AGENT_AUTO_MAX_DAILY_TRADES = 25`/UTC-day quota, the counter, `recordAgentAutoTrade`, and the peek/consume option. An autonomous agent could trade with **no daily cap**. It's a public barrel export, so any package consumer of `@elizaos/plugin-wallet` got the unguarded version (the host server uses its own canonical copy, so no in-repo caller regressed — but the exported contract was unsafe).

## Fix — exact host parity
Restored the constant, the `agentAutoDailyTrades` UTC-day counter, `getAgentAutoTradeDate`, `recordAgentAutoTrade`, `LocalTradeExecutionOptions`, and the full `canUseLocalTradeExecution(mode, isAgent, log?, options={})` — byte-for-byte the host logic (same limit, same day window, same consume-vs-peek). Also dropped the plugin's duplicate 3-value `TradePermissionMode` for the canonical 4-value type from `@elizaos/shared` (`import type`, zero runtime dep). Host `trade-safety.ts` left untouched (the trusted reference).

## Verification — red→green
- **RED (unfixed):** the 26th `agent-auto`+agent call was **allowed** (`expected true to be false`).
- **GREEN:** new `server-wallet-trade.test.ts` **13 pass** incl. `REGRESSION: agent-auto BLOCKED once the daily quota is reached` (25 allowed, 26th+ denied), new-day reset, peek-vs-consume, non-agent-always-allowed, manual-local-key, fail-closed for disabled/user-sign-only. `turbo build` 5/5; plugin-wallet tsc touched files 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)