### PR TITLE
fix: register Electrobun screen capture service

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -4371,10 +4371,11 @@ export async function startApiServer(opts?: {
             "[eliza-api] @elizaos/plugin-streaming did not export handleStreamRoute; skipping streaming route registration.",
           );
         }
-        // Desktop screen-capture bridge, resolved via the runtime service the
-        // desktop host registers (never a globalThis bridge). Absent on
-        // mobile/web/cloud → streaming falls back to another capture mode.
-        const screenCapture =
+        // Desktop screen-capture bridge, resolved lazily from the current
+        // runtime. Desktop app startup binds the API before the runtime exists,
+        // then supplies it through updateRuntime; restarts hot-swap the same
+        // state object.
+        const resolveScreenCapture = (): IScreenCaptureService | undefined =>
           state.runtime?.getService<IScreenCaptureService>(
             ServiceType.SCREEN_CAPTURE,
           ) ?? undefined;
@@ -4486,7 +4487,9 @@ export async function startApiServer(opts?: {
         const streamState = {
           streamManager,
           port,
-          screenCapture,
+          get screenCapture() {
+            return resolveScreenCapture();
+          },
           captureUrl: undefined as string | undefined,
           destinations,
           activeDestinationId,

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -122,6 +122,7 @@ import {
   resolveRendererAssetDir,
 } from "./runtime-layout";
 import { mergeRuntimePermissionStates } from "./runtime-permissions";
+import { startScreenCaptureBridgeServer } from "./screencapture-bridge-server";
 import { startScreenshotDevServer } from "./screenshot-dev-server";
 import { recordStartupPhase, resolveStartupBundlePath } from "./startup-trace";
 import {
@@ -2476,6 +2477,17 @@ async function main(): Promise<void> {
   const buildInfo = await BuildConfig.get();
   checkWebGpuBrowserSupport(buildInfo.defaultRenderer);
   cleanupFns.length = 0;
+  try {
+    const stopScreenCaptureBridge = await startScreenCaptureBridgeServer();
+    recordStartupPhase("screencapture_bridge_ready", {
+      pid: process.pid,
+    });
+    cleanupFns.push(stopScreenCaptureBridge);
+  } catch (err) {
+    logger.warn(
+      `[Main] Screen-capture bridge startup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   // Start the browser-workspace bridge without blocking first paint. The
   // renderer reaches it lazily (browser-workspace RPC), so it does not need to
   // be listening before the window opens. Register a cleanup that awaits the

--- a/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts
+++ b/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Functional loopback tests for the Electrobun screen-capture bridge.
+ *
+ * The harness binds a real localhost HTTP server but uses a fake capture
+ * manager, so it verifies auth, env handoff, and request normalization without
+ * invoking OS screen-capture tools.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type ScreenCaptureBridgeManager,
+  startScreenCaptureBridgeServer,
+} from "./screencapture-bridge-server";
+
+function testPort(): number {
+  return 39_000 + Math.floor(Math.random() * 1000);
+}
+
+describe("startScreenCaptureBridgeServer", () => {
+  it("publishes bridge env and forwards authenticated frame-capture controls", async () => {
+    const starts: unknown[] = [];
+    let active = false;
+    const manager: ScreenCaptureBridgeManager = {
+      async startFrameCapture(options) {
+        starts.push(options);
+        active = true;
+        return { available: true };
+      },
+      async stopFrameCapture() {
+        active = false;
+        return { available: true };
+      },
+      async isFrameCaptureActive() {
+        return { active };
+      },
+    };
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_DESKTOP_SCREENCAPTURE_PORT: String(testPort()),
+    };
+
+    const stop = await startScreenCaptureBridgeServer({
+      env,
+      manager,
+      token: "bridge-token",
+    });
+    try {
+      expect(env.ELIZA_DESKTOP_SCREENCAPTURE_URL).toMatch(
+        /^http:\/\/127\.0\.0\.1:\d+$/,
+      );
+      expect(env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN).toBe("bridge-token");
+
+      const unauthorized = await fetch(
+        `${env.ELIZA_DESKTOP_SCREENCAPTURE_URL}/health`,
+      );
+      expect(unauthorized.status).toBe(401);
+
+      const started = await fetch(
+        `${env.ELIZA_DESKTOP_SCREENCAPTURE_URL}/frame-capture/start`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer bridge-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            fps: 15,
+            quality: 70,
+            apiBase: "http://127.0.0.1:31337/ignored",
+            endpoint: "/api/stream/frame",
+            gameUrl: "http://127.0.0.1:5173/game",
+          }),
+        },
+      );
+      expect(started.status).toBe(200);
+      expect(await started.json()).toEqual({ available: true });
+      expect(starts).toEqual([
+        {
+          fps: 15,
+          quality: 70,
+          apiBase: "http://127.0.0.1:31337",
+          endpoint: "/api/stream/frame",
+          gameUrl: "http://127.0.0.1:5173/game",
+        },
+      ]);
+
+      const health = await fetch(
+        `${env.ELIZA_DESKTOP_SCREENCAPTURE_URL}/health`,
+        { headers: { Authorization: "Bearer bridge-token" } },
+      );
+      expect(await health.json()).toEqual({ ok: true, active: true });
+
+      const stopped = await fetch(
+        `${env.ELIZA_DESKTOP_SCREENCAPTURE_URL}/frame-capture/stop`,
+        { method: "POST", headers: { Authorization: "Bearer bridge-token" } },
+      );
+      expect(await stopped.json()).toEqual({ available: true });
+      expect(active).toBe(false);
+    } finally {
+      stop();
+    }
+  });
+
+  it("rejects malformed frame endpoint paths before calling the manager", async () => {
+    const starts: unknown[] = [];
+    const manager: ScreenCaptureBridgeManager = {
+      async startFrameCapture(options) {
+        starts.push(options);
+        return { available: true };
+      },
+      async stopFrameCapture() {
+        return { available: true };
+      },
+      async isFrameCaptureActive() {
+        return { active: false };
+      },
+    };
+    const env: NodeJS.ProcessEnv = {
+      ELIZA_DESKTOP_SCREENCAPTURE_PORT: String(testPort()),
+    };
+
+    const stop = await startScreenCaptureBridgeServer({
+      env,
+      manager,
+      token: "bridge-token",
+    });
+    try {
+      const response = await fetch(
+        `${env.ELIZA_DESKTOP_SCREENCAPTURE_URL}/frame-capture/start`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer bridge-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            apiBase: "https://example.com",
+            endpoint: "https://example.com/frame",
+          }),
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "apiBase must be an http loopback URL",
+      });
+      expect(starts).toEqual([]);
+    } finally {
+      stop();
+    }
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts
+++ b/packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts
@@ -1,0 +1,239 @@
+/**
+ * Loopback control bridge from the child Eliza runtime to Electrobun screen capture.
+ *
+ * The native `ScreenCaptureManager` owns OS-level capture in the desktop host
+ * process. The spawned child runtime cannot import that singleton directly, so
+ * this bridge exposes the narrow frame-capture control surface over localhost
+ * with a per-launch bearer token passed through environment variables.
+ */
+
+import crypto from "node:crypto";
+import http from "node:http";
+import { logger } from "./logger";
+import { findFirstAvailableLoopbackPort } from "./native/loopback-port";
+import { getScreenCaptureManager } from "./native/screencapture";
+
+const DEFAULT_BRIDGE_PORT = 31_342;
+const MAX_BODY_BYTES = 64 * 1024;
+
+type HostFrameCaptureOptions = {
+  fps?: number;
+  quality?: number;
+  apiBase?: string;
+  endpoint?: string;
+  gameUrl?: string;
+};
+
+export interface ScreenCaptureBridgeManager {
+  startFrameCapture(
+    options?: HostFrameCaptureOptions,
+  ): Promise<{ available: boolean; reason?: string }>;
+  stopFrameCapture(): Promise<{ available: boolean }>;
+  isFrameCaptureActive(): Promise<{ active: boolean }>;
+}
+
+export interface StartScreenCaptureBridgeServerOptions {
+  env?: NodeJS.ProcessEnv;
+  manager?: ScreenCaptureBridgeManager;
+  requestedPort?: number;
+  token?: string;
+}
+
+class InvalidBridgeRequestError extends Error {
+  readonly status = 400;
+}
+
+function isLoopback(addr: string | undefined): boolean {
+  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+}
+
+function json(
+  res: http.ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(body));
+}
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | null> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) {
+      throw new Error("request body too large");
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) return null;
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as T;
+}
+
+function isAuthorized(req: http.IncomingMessage, token: string): boolean {
+  if (!token) return false;
+  return req.headers.authorization === `Bearer ${token}`;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function qualityNumber(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 1 &&
+    value <= 100
+    ? value
+    : undefined;
+}
+
+function normalizeEndpoint(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    throw new InvalidBridgeRequestError("endpoint must be an absolute path");
+  }
+  return trimmed;
+}
+
+function normalizeLoopbackApiBase(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new InvalidBridgeRequestError("apiBase must be a valid URL");
+  }
+
+  const loopbackHosts = new Set(["127.0.0.1", "localhost", "[::1]"]);
+  if (parsed.protocol !== "http:" || !loopbackHosts.has(parsed.hostname)) {
+    throw new InvalidBridgeRequestError("apiBase must be an http loopback URL");
+  }
+  return `http://${parsed.host}`;
+}
+
+function normalizeGameUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeFrameCaptureOptions(
+  body: Record<string, unknown> | null,
+): HostFrameCaptureOptions {
+  if (!body) return {};
+  const options: HostFrameCaptureOptions = {};
+  const fps = positiveNumber(body.fps);
+  if (fps !== undefined) options.fps = fps;
+  const quality = qualityNumber(body.quality);
+  if (quality !== undefined) options.quality = quality;
+  const apiBase = normalizeLoopbackApiBase(body.apiBase);
+  if (apiBase !== undefined) options.apiBase = apiBase;
+  const endpoint = normalizeEndpoint(body.endpoint);
+  if (endpoint !== undefined) options.endpoint = endpoint;
+  const gameUrl = normalizeGameUrl(body.gameUrl);
+  if (gameUrl !== undefined) options.gameUrl = gameUrl;
+  return options;
+}
+
+function resolveRequestedPort(
+  env: NodeJS.ProcessEnv,
+  explicit: number | undefined,
+): number {
+  if (explicit !== undefined) return explicit;
+  return (
+    Number.parseInt((env.ELIZA_DESKTOP_SCREENCAPTURE_PORT ?? "").trim(), 10) ||
+    DEFAULT_BRIDGE_PORT
+  );
+}
+
+export async function startScreenCaptureBridgeServer(
+  options: StartScreenCaptureBridgeServerOptions = {},
+): Promise<() => void> {
+  const env = options.env ?? process.env;
+  const port = await findFirstAvailableLoopbackPort(
+    resolveRequestedPort(env, options.requestedPort),
+    {
+      host: "127.0.0.1",
+      maxHops: 32,
+    },
+  );
+  const token =
+    options.token?.trim() ||
+    env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN?.trim() ||
+    crypto.randomBytes(18).toString("hex");
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const manager = options.manager ?? getScreenCaptureManager();
+
+  env.ELIZA_DESKTOP_SCREENCAPTURE_URL = baseUrl;
+  env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN = token;
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (!isLoopback(req.socket.remoteAddress)) {
+        json(res, 403, { error: "forbidden" });
+        return;
+      }
+      if (!isAuthorized(req, token)) {
+        json(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const pathname = url.pathname;
+      const method = req.method ?? "GET";
+
+      if (pathname === "/health" && method === "GET") {
+        const active = await manager.isFrameCaptureActive();
+        json(res, 200, { ok: true, active: active.active });
+        return;
+      }
+
+      if (pathname === "/frame-capture/start" && method === "POST") {
+        const body = await readJsonBody<Record<string, unknown>>(req);
+        const result = await manager.startFrameCapture(
+          normalizeFrameCaptureOptions(body),
+        );
+        json(res, result.available ? 200 : 503, result);
+        return;
+      }
+
+      if (pathname === "/frame-capture/stop" && method === "POST") {
+        json(res, 200, await manager.stopFrameCapture());
+        return;
+      }
+
+      json(res, 404, { error: "not found" });
+    } catch (error) {
+      const status = error instanceof InvalidBridgeRequestError ? 400 : 500;
+      json(res, status, {
+        error: error instanceof Error ? error.message : "internal error",
+      });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  logger.info(
+    `[ScreenCaptureBridge] ${baseUrl} (loopback only; token required)`,
+  );
+
+  return () => {
+    server.close();
+  };
+}

--- a/packages/app-core/platforms/electrobun/src/startup-trace.ts
+++ b/packages/app-core/platforms/electrobun/src/startup-trace.ts
@@ -8,6 +8,7 @@ export const STARTUP_TRACE_PHASES = [
   "env_loaded",
   "crash_prompt_checked",
   "webgpu_initialized",
+  "screencapture_bridge_ready",
   "browser_workspace_bridge_ready",
   "desktop_test_bridge_ready",
   "creating_window",

--- a/packages/app-core/src/platform/desktop-screencapture-service.test.ts
+++ b/packages/app-core/src/platform/desktop-screencapture-service.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the child-runtime desktop screen-capture service.
+ *
+ * These tests stub only the loopback fetch boundary while exercising the real
+ * service class that the app-core runtime registers under `screen_capture`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DesktopScreenCaptureService,
+  resolveDesktopScreenCaptureApiBase,
+  resolveDesktopScreenCaptureBridgeConfig,
+} from "./desktop-screencapture-service";
+
+describe("desktop screen-capture service", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.ELIZA_API_PORT;
+  });
+
+  it("resolves bridge config only when URL and token are both present", () => {
+    expect(resolveDesktopScreenCaptureBridgeConfig({})).toBeNull();
+    expect(
+      resolveDesktopScreenCaptureBridgeConfig({
+        ELIZA_DESKTOP_SCREENCAPTURE_URL: " http://127.0.0.1:31342/ ",
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopScreenCaptureBridgeConfig({
+        ELIZA_DESKTOP_SCREENCAPTURE_URL: " http://127.0.0.1:31342/ ",
+        ELIZA_DESKTOP_SCREENCAPTURE_TOKEN: " token ",
+      }),
+    ).toEqual({
+      baseUrl: "http://127.0.0.1:31342",
+      token: "token",
+    });
+  });
+
+  it("posts authenticated start requests with the current child API base", async () => {
+    process.env.ELIZA_API_PORT = "32123";
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ available: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new DesktopScreenCaptureService(undefined, {
+      baseUrl: "http://127.0.0.1:31342",
+      token: "bridge-token",
+    });
+
+    await service.startFrameCapture({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+    });
+
+    expect(service.isFrameCaptureActive()).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call as unknown as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:31342/frame-capture/start");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer bridge-token");
+    expect(JSON.parse(String(init.body))).toEqual({
+      fps: 15,
+      quality: 70,
+      endpoint: "/api/stream/frame",
+      apiBase: "http://127.0.0.1:32123",
+    });
+  });
+
+  it("uses the desktop API base resolver default when the port env is absent", () => {
+    expect(resolveDesktopScreenCaptureApiBase()).toBe("http://127.0.0.1:31337");
+  });
+});

--- a/packages/app-core/src/platform/desktop-screencapture-service.ts
+++ b/packages/app-core/src/platform/desktop-screencapture-service.ts
@@ -1,0 +1,192 @@
+/**
+ * Child-runtime proxy for desktop frame capture owned by the Electrobun host.
+ *
+ * The desktop shell runs native screen capture in its main process while the
+ * Eliza runtime runs as a spawned child. This service registers the core
+ * `screen_capture` service in the child runtime and forwards control calls over
+ * the host loopback bridge published through environment variables.
+ */
+
+import {
+  type IAgentRuntime,
+  IScreenCaptureService,
+  logger,
+  type ScreenCaptureFrameOptions,
+  type Service,
+  ServiceType,
+} from "@elizaos/core";
+import { resolveDesktopApiPort } from "@elizaos/shared";
+
+const BRIDGE_REQUEST_TIMEOUT_MS = 10_000;
+
+export interface DesktopScreenCaptureBridgeConfig {
+  baseUrl: string;
+  token: string;
+}
+
+type BridgeStartResponse = {
+  available: boolean;
+  reason?: string;
+};
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveDesktopScreenCaptureBridgeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DesktopScreenCaptureBridgeConfig | null {
+  const baseUrl = normalizeEnvValue(env.ELIZA_DESKTOP_SCREENCAPTURE_URL);
+  const token = normalizeEnvValue(env.ELIZA_DESKTOP_SCREENCAPTURE_TOKEN);
+  if (!baseUrl || !token) return null;
+  return {
+    baseUrl: baseUrl.replace(/\/{1,1024}$/, ""),
+    token,
+  };
+}
+
+export function resolveDesktopScreenCaptureApiBase(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const port = resolveDesktopApiPort(env);
+  return `http://127.0.0.1:${port}`;
+}
+
+async function readBridgeError(response: Response): Promise<string> {
+  try {
+    return (await response.text()).trim().slice(0, 240);
+  } catch {
+    return "";
+  }
+}
+
+async function requestBridge<T>(
+  config: DesktopScreenCaptureBridgeConfig,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const headers = new Headers(init?.headers ?? {});
+  headers.set("Accept", "application/json");
+  if (!headers.has("Content-Type") && init?.body) {
+    headers.set("Content-Type", "application/json");
+  }
+  headers.set("Authorization", `Bearer ${config.token}`);
+
+  const response = await fetch(`${config.baseUrl}${path}`, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(BRIDGE_REQUEST_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readBridgeError(response);
+    throw new Error(
+      `desktop screen-capture bridge ${path} failed (${response.status})${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+export class DesktopScreenCaptureService extends IScreenCaptureService {
+  private readonly bridgeConfig: DesktopScreenCaptureBridgeConfig;
+  private active = false;
+
+  constructor(
+    runtime?: IAgentRuntime,
+    bridgeConfig?: DesktopScreenCaptureBridgeConfig,
+  ) {
+    super(runtime);
+    const resolvedConfig =
+      bridgeConfig ?? resolveDesktopScreenCaptureBridgeConfig();
+    if (!resolvedConfig) {
+      throw new Error(
+        "[DesktopScreenCaptureService] desktop screen-capture bridge is not configured",
+      );
+    }
+    this.bridgeConfig = resolvedConfig;
+  }
+
+  static override async start(runtime: IAgentRuntime): Promise<Service> {
+    const config = resolveDesktopScreenCaptureBridgeConfig();
+    if (!config) {
+      throw new Error(
+        "[DesktopScreenCaptureService] desktop screen-capture bridge is not configured",
+      );
+    }
+    logger.info(
+      `[DesktopScreenCaptureService] bridge configured at ${config.baseUrl}`,
+    );
+    return new DesktopScreenCaptureService(runtime, config);
+  }
+
+  isFrameCaptureActive(): boolean {
+    return this.active;
+  }
+
+  async startFrameCapture(options: ScreenCaptureFrameOptions): Promise<void> {
+    const payload = {
+      ...options,
+      apiBase: resolveDesktopScreenCaptureApiBase(),
+    };
+    const result = await requestBridge<BridgeStartResponse>(
+      this.bridgeConfig,
+      "/frame-capture/start",
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    if (!result.available) {
+      this.active = false;
+      throw new Error(
+        `[DesktopScreenCaptureService] host rejected frame capture${
+          result.reason ? `: ${result.reason}` : ""
+        }`,
+      );
+    }
+    this.active = true;
+  }
+
+  stopFrameCapture(): void {
+    this.active = false;
+    void requestBridge(this.bridgeConfig, "/frame-capture/stop", {
+      method: "POST",
+    }).catch((err: unknown) => {
+      logger.warn(
+        `[DesktopScreenCaptureService] stop request failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+
+  override async stop(): Promise<void> {
+    this.active = false;
+    await requestBridge(this.bridgeConfig, "/frame-capture/stop", {
+      method: "POST",
+    }).catch((err: unknown) => {
+      logger.warn(
+        `[DesktopScreenCaptureService] stop request failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+}
+
+export async function registerDesktopScreenCaptureService(
+  runtime: IAgentRuntime,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (!resolveDesktopScreenCaptureBridgeConfig(env)) return false;
+  if (runtime.getService(ServiceType.SCREEN_CAPTURE)) return true;
+  if (!runtime.hasService(ServiceType.SCREEN_CAPTURE)) {
+    await runtime.registerService(DesktopScreenCaptureService);
+  }
+  await runtime.getServiceLoadPromise(ServiceType.SCREEN_CAPTURE);
+  return runtime.getService(ServiceType.SCREEN_CAPTURE) !== null;
+}

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -55,6 +55,7 @@ import {
   syncElizaEnvAliases,
   syncResolvedApiPort,
 } from "@elizaos/shared";
+import { registerDesktopScreenCaptureService } from "../platform/desktop-screencapture-service.js";
 import { getApps, loadRegistry } from "../registry";
 import { registerSubAgentCredentialBridgeAdapter } from "../services/credential-tunnel-service";
 import { registerCoreSensitiveRequestAdapters } from "../services/sensitive-requests/index.js";
@@ -709,6 +710,17 @@ async function repairRuntimeAfterBoot(
       "[eliza] Mobile platform detected — skipping desktop-only boot helpers",
     );
     return runtime;
+  }
+
+  try {
+    const registered = await registerDesktopScreenCaptureService(runtime);
+    if (registered) {
+      logger.info("[eliza] Desktop ScreenCaptureService registered");
+    }
+  } catch (err) {
+    logger.warn(
+      `[eliza] Desktop ScreenCaptureService registration failed: ${formatError(err)}`,
+    );
   }
 
   await (await _localInference()).ensureLocalInferenceHandler(runtime);


### PR DESCRIPTION
Fixes #12249.

## Summary
- Start a token-protected localhost screen-capture bridge in the Electrobun host before the child runtime is spawned.
- Register a child-runtime `ScreenCaptureService` in app-core when the desktop bridge environment is present, forwarding frame-capture start/stop calls to the host bridge.
- Resolve the API stream route `screenCapture` service lazily so desktop startup can bind routes before the runtime exists and still pick up the later registered service.

## Root Cause
The Electrobun host owned the native `ScreenCaptureManager`, but the spawned Eliza child runtime never registered `ServiceType.SCREEN_CAPTURE`. The streaming plugin therefore could not start host-backed capture from the child process.

## Validation
Passed:
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/logger build`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bunx @biomejs/biome check packages/app-core/src/platform/desktop-screencapture-service.ts packages/app-core/src/platform/desktop-screencapture-service.test.ts packages/app-core/platforms/electrobun/src/screencapture-bridge-server.ts packages/app-core/platforms/electrobun/src/screencapture-bridge-server.test.ts packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/startup-trace.ts packages/app-core/src/runtime/eliza.ts packages/agent/src/api/server.ts`
- `bun run --cwd packages/app-core test -- src/platform/desktop-screencapture-service.test.ts` (3 tests)
- `bun run --cwd packages/app-core/platforms/electrobun test -- src/screencapture-bridge-server.test.ts` (2 tests)
- `git diff --check`

Attempted but blocked by existing repo/workspace issues:
- `bun run --cwd packages/app-core/platforms/electrobun typecheck`
- `bun run --cwd packages/app-core typecheck`
- `bun run --cwd packages/agent typecheck`
- `bun run verify`

The typecheck/verify blockers are pre-existing workspace-level failures, including missing optional workspace packages such as `@elizaos/auth`, `@elizaos/contracts`, `@elizaos/cloud-routing`, `@elizaos/plugin-commands`, `@elizaos/plugin-streaming`, native Capacitor packages, and existing UI/account/native typing errors. After fixes during development, no diagnostics pointed at the new screen-capture bridge files.

## Evidence
- Functional bridge test binds a real localhost HTTP server and verifies bearer auth, env handoff, request normalization, start/health/stop behavior, and rejection of malformed external API targets.
- Child service test verifies authenticated POST payloads include the child runtime API base.
- N/A: UI screenshots/video, live model trajectories, audio, and domain artifacts. This is a desktop host/runtime service bridge change with no UI, prompt, model, audio, or persisted artifact surface.
- Not captured in this CLI environment: a live packaged Electrobun desktop runtime screen-capture walkthrough. The PR remains draft until that device/runtime evidence can be captured if reviewers require it.