### PR TITLE
chore(comment-cleanup): WI-3 pilot — prose headers for logger/prompts/skills/registry (#12181)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,48 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Slop and Comment Cleanup
+
+Comments must earn their keep: they explain intent a reader cannot get from the
+code, and they never narrate the edit that produced them. This is the binding
+convention for the repo-wide comment cleanup (#12181) and for every new file.
+
+1. **Every file opens with a prose header.** One `/** … */` block at the very
+   top — after a `#!` shebang or a third-party license block if present, before
+   the imports. Write sentences, not a form: no `@fileoverview`, `@author`,
+   `@date`, or `@version`. The position is the signal.
+2. **The first sentence says what the file does in system terms**, without
+   repeating the filename — "Local content-addressed media store for chat
+   attachments," not "This is media-store.ts." After that, add only what helps:
+   the relationships (what consumes it, what it consumes, which boundary it sits
+   on), the load-bearing invariants, and the gotchas to know before editing. An
+   issue ref like `(#8876)` is welcome when it anchors non-obvious rationale,
+   never as a substitute for stating it.
+3. **Length scales with weight.** A barrel `index.ts` or a tiny type file gets
+   one line; a typical module 2–6 lines; a load-bearing module 2–3 short
+   paragraphs. Hard ceiling ~25 lines — anything longer belongs in the package
+   `CLAUDE.md`/`README.md`; reference it instead. Test files get 1–3 lines: what
+   surface is under test and how real the harness is (live model vs.
+   deterministic proxy, real DB vs. in-memory).
+4. **In-body comments explain what the code cannot** — the "why," the invariant,
+   the non-obvious consequence — not a line-by-line English echo of the code.
+5. **Delete comment slop on sight:** change/churn narration ("now we do X,"
+   "refactored to…"), status updates, migration stories, and comments that just
+   restate the next line. Salvageable churn is rewritten to a present-tense fact
+   about how the code works today.
+6. **Accuracy over coverage — a wrong header is worse than none.** Read the
+   package's `CLAUDE.md` before writing headers in it and describe files in that
+   package's architecture terms. If you cannot determine what a file is for, flag
+   it rather than guess.
+
+Copy the tone from the exemplars already in the tree:
+`packages/agent/src/api/media-store.ts` (load-bearing module),
+`packages/ui/src/components/RoleGate.tsx` (component),
+`packages/scripts/run-all-tests.mjs` (script), and `.gitmodules` (config).
+Comment-cleanup batches carry **zero functional diffs** — machine-checked by
+`bun run check:comment-only` (`scripts/assert-comment-only-diff.mjs`), which
+tokenizes both revisions and fails on any non-comment token change.
+
 ## App visual review — REQUIRED for UI changes in `packages/app/`
 
 Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,48 @@ To build on the runtime from your own TypeScript with no CLI/UI, import
 - Keep weak types (`any` / `unknown` / unsafe casts) out; validate at runtime
   boundaries and type the validated result.
 
+## Slop and Comment Cleanup
+
+Comments must earn their keep: they explain intent a reader cannot get from the
+code, and they never narrate the edit that produced them. This is the binding
+convention for the repo-wide comment cleanup (#12181) and for every new file.
+
+1. **Every file opens with a prose header.** One `/** … */` block at the very
+   top — after a `#!` shebang or a third-party license block if present, before
+   the imports. Write sentences, not a form: no `@fileoverview`, `@author`,
+   `@date`, or `@version`. The position is the signal.
+2. **The first sentence says what the file does in system terms**, without
+   repeating the filename — "Local content-addressed media store for chat
+   attachments," not "This is media-store.ts." After that, add only what helps:
+   the relationships (what consumes it, what it consumes, which boundary it sits
+   on), the load-bearing invariants, and the gotchas to know before editing. An
+   issue ref like `(#8876)` is welcome when it anchors non-obvious rationale,
+   never as a substitute for stating it.
+3. **Length scales with weight.** A barrel `index.ts` or a tiny type file gets
+   one line; a typical module 2–6 lines; a load-bearing module 2–3 short
+   paragraphs. Hard ceiling ~25 lines — anything longer belongs in the package
+   `CLAUDE.md`/`README.md`; reference it instead. Test files get 1–3 lines: what
+   surface is under test and how real the harness is (live model vs.
+   deterministic proxy, real DB vs. in-memory).
+4. **In-body comments explain what the code cannot** — the "why," the invariant,
+   the non-obvious consequence — not a line-by-line English echo of the code.
+5. **Delete comment slop on sight:** change/churn narration ("now we do X,"
+   "refactored to…"), status updates, migration stories, and comments that just
+   restate the next line. Salvageable churn is rewritten to a present-tense fact
+   about how the code works today.
+6. **Accuracy over coverage — a wrong header is worse than none.** Read the
+   package's `CLAUDE.md` before writing headers in it and describe files in that
+   package's architecture terms. If you cannot determine what a file is for, flag
+   it rather than guess.
+
+Copy the tone from the exemplars already in the tree:
+`packages/agent/src/api/media-store.ts` (load-bearing module),
+`packages/ui/src/components/RoleGate.tsx` (component),
+`packages/scripts/run-all-tests.mjs` (script), and `.gitmodules` (config).
+Comment-cleanup batches carry **zero functional diffs** — machine-checked by
+`bun run check:comment-only` (`scripts/assert-comment-only-diff.mjs`), which
+tokenizes both revisions and fails on any non-comment token change.
+
 ## App visual review — REQUIRED for UI changes in `packages/app/`
 
 Any change in `packages/app/` (or a shared package whose UI bleeds into it) MUST

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "audit:turbo-build-deps": "node packages/scripts/audit-turbo-build-deps.mjs",
     "audit:scripts": "node packages/scripts/audit-scripts.mjs",
     "audit:scripts:self-test": "node packages/scripts/audit-scripts.self-test.mjs",
+    "check:comment-only": "node scripts/assert-comment-only-diff.mjs",
+    "check:comment-only:self-test": "node scripts/assert-comment-only-diff.mjs --self-test",
     "audit:scripts:inventory": "node packages/scripts/audit-scripts-inventory.mjs",
     "audit:test-realness": "node packages/scripts/test-realness-audit.mjs --check",
     "audit:test-realness:evidence": "node packages/scripts/test-realness-audit.mjs --check --report .github/issue-evidence/10718-test-realness-inventory.md --json .github/issue-evidence/10718-test-realness-inventory.json",

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the logger implementation — env-driven level/format resolution and redaction; vitest with a stubbed env. */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,3 +1,13 @@
+/**
+ * The `@elizaos/logger` structured-logger implementation (adze + fast-redact).
+ *
+ * Resolves level/format/redaction from env (`LOG_LEVEL`, `LOG_JSON_FORMAT`, …)
+ * via `./env` and exports `logger`, which `@elizaos/core` re-exports — so this is
+ * the single logger every package and plugin uses (`console` is disallowed in
+ * server code). Leaf module: no `@elizaos/*` dependency, keeping logging off the
+ * core runtime's module graph.
+ */
+
 // Test hook to clear env cache in logger tests (kept internal)
 export const __loggerTestHooks = {
   clearEnvCacheForTests: () => {},

--- a/packages/logger/vitest.config.ts
+++ b/packages/logger/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for the `@elizaos/logger` unit tests. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/prompts/scripts/file-utils.js
+++ b/packages/prompts/scripts/file-utils.js
@@ -1,3 +1,9 @@
+/**
+ * Filesystem helpers (readText / readJson / ensureDirectory) shared by the
+ * prompts package codegen scripts (the plugin-action-spec and action-docs
+ * generators).
+ */
+
 import fs from "node:fs";
 
 export function readText(filePath) {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Single source of truth for the elizaOS LLM prompt templates.
+ *
+ * Each template is a plain string exported under two names — a camelCase form
+ * and an UPPER_SNAKE_CASE alias (e.g. `replyTemplate` / `REPLY_TEMPLATE`) — with
+ * `{{...}}` placeholders the runtime fills via core's `composePrompt`.
+ * `@elizaos/core` re-exports these (`packages/core/src/prompts.ts`); keeping them
+ * here lets the action-docs codegen consume them without depending back on core.
+ */
+
 export { compressPromptDescription } from "./prompt-compression.js";
 
 export const addContactTemplate = `task: Extract contact information to add to relationships.

--- a/packages/prompts/src/prompt-compression.ts
+++ b/packages/prompts/src/prompt-compression.ts
@@ -1,3 +1,13 @@
+/**
+ * Deterministic compressor for action/provider descriptions.
+ *
+ * Shrinks verbose descriptions (drops filler phrases, normalizes wording) while
+ * protecting spans that must survive verbatim — code fences, inline code, URLs,
+ * paths, and SCREAMING_CASE identifiers (`PROTECTED_PATTERNS`). Used by the
+ * action-docs generator and re-exported by `@elizaos/core`, so the same
+ * compression runs at build time and at runtime.
+ */
+
 const PROTECTED_PATTERNS = [
   /```[\s\S]*?```/g,
   /`[^`\n]+`/g,

--- a/packages/prompts/test/check-secrets.test.js
+++ b/packages/prompts/test/check-secrets.test.js
@@ -1,3 +1,5 @@
+/** Tests the prompt-file secret/PII scanner (`scripts/check-secrets.js`) against planted fixtures; bun:test, deterministic. */
+
 import assert from "node:assert";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/packages/prompts/test/prompt-compression.test.js
+++ b/packages/prompts/test/prompt-compression.test.js
@@ -1,3 +1,5 @@
+/** Tests `compressPromptDescription` — filler removal plus protected-span (code/URL/path/SCREAMING_CASE) preservation; vitest, deterministic. */
+
 import { describe, expect, it } from "vitest";
 import { compressPromptDescription } from "../src/prompt-compression.js";
 

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -1,3 +1,5 @@
+/** Regression assertions on the exported prompt template wording; bun:test, deterministic. */
+
 import assert from "node:assert";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/packages/registry/src/first-party/app-registry.ts
+++ b/packages/registry/src/first-party/app-registry.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime store of curated-app name aliases for the first-party registry.
+ *
+ * `registerCuratedApp` records a curated app's canonical name plus aliases so
+ * name matching can resolve a user/agent-supplied name to a slug. Backed by a
+ * global-symbol-keyed store so a single registry persists across bundled copies
+ * of the package.
+ */
+
 export interface ElizaCuratedAppDefinition {
   slug: string;
   canonicalName: string;

--- a/packages/registry/src/first-party/facewear-registry.test.ts
+++ b/packages/registry/src/first-party/facewear-registry.test.ts
@@ -1,3 +1,5 @@
+/** Validates the curated facewear registry entries against the first-party schema; vitest reading the committed JSON. */
+
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/registry/src/first-party/provider-plugin-map.test.ts
+++ b/packages/registry/src/first-party/provider-plugin-map.test.ts
@@ -1,3 +1,5 @@
+/** Tests the provider→plugin map derived from the first-party registry; vitest, deterministic. */
+
 import { describe, expect, it } from "vitest";
 import { collectProviderPluginMap } from "./generate";
 import providerPluginMap from "./provider-plugin-map.json" with {

--- a/packages/registry/src/first-party/training-app-registry.test.ts
+++ b/packages/registry/src/first-party/training-app-registry.test.ts
@@ -1,3 +1,5 @@
+/** Validates that the curated training-app registry entries load and match the first-party schema; vitest, deterministic. */
+
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearRegistryCacheForTests,

--- a/packages/registry/src/registry.test.ts
+++ b/packages/registry/src/registry.test.ts
@@ -1,3 +1,5 @@
+/** Tests the third-party registry: entry validation and wire-format generation over the committed entries; vitest. */
+
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/registry/vitest.config.ts
+++ b/packages/registry/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for the `@elizaos/registry` unit tests. */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/skills/src/formatter.ts
+++ b/packages/skills/src/formatter.ts
@@ -1,3 +1,12 @@
+/**
+ * Renders loaded skills into the text surfaces that consume them.
+ *
+ * `formatSkillsForPrompt`/`formatSkillEntriesForPrompt` build the compact
+ * skills block injected into the agent's system prompt (skills with
+ * `disable-model-invocation` are omitted); `buildSkillCommandSpecs` derives the
+ * sanitized `/skill:name` command specs for the chat UI's command dispatch.
+ */
+
 import type { Skill, SkillCommandSpec, SkillEntry } from "./types.js";
 
 function compactPromptField(str: string): string {

--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -1,3 +1,13 @@
+/**
+ * YAML frontmatter parsing and serialization for `SKILL.md` files.
+ *
+ * `parseFrontmatter`/`stripFrontmatter` split a skill markdown string into its
+ * frontmatter object and body; `resolveSkillMetadata`/`resolveSkillInvocationPolicy`/
+ * `resolveSkillProvenance` normalize the raw frontmatter into the typed shapes the
+ * loader uses. `serializeSkillFile` is the inverse, used by the curated learning
+ * loop to rewrite a skill after refining its provenance or content.
+ */
+
 import { parse, stringify } from "yaml";
 import type {
   SkillFrontmatter,

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -1,3 +1,14 @@
+/**
+ * Discovers and loads skills from disk into `Skill` / `SkillEntry` objects.
+ *
+ * `loadSkills` merges skills across the precedence chain (bundled → managed →
+ * curated/active → project → explicit paths; later names win), validating that a
+ * skill's `name` matches its directory and dropping ones with no description.
+ * Symlinks are resolved and duplicate real paths deduped. `loadSkillEntries`
+ * additionally parses full frontmatter/metadata. The curated `proposed/` dir is
+ * never loaded here — it requires human promotion first.
+ */
+
 import {
   existsSync,
   readdirSync,

--- a/packages/skills/src/resolver.ts
+++ b/packages/skills/src/resolver.ts
@@ -1,3 +1,14 @@
+/**
+ * Resolves the on-disk locations skills load from.
+ *
+ * `getSkillsDir` finds this package's bundled `skills/` directory (overridable
+ * via `ELIZAOS_BUNDLED_SKILLS_DIR`, cached after first resolution);
+ * `getCuratedActiveDir`/`getProposedSkillsDir` sit under the state dir and back
+ * the curated learning loop, and `promoteSkill` atomically moves a proposed
+ * skill into `active/` so it starts loading. Consumed by `loader.ts` and the
+ * agent runtime's startup skill discovery.
+ */
+
 import {
   existsSync,
   mkdirSync,

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -1,3 +1,12 @@
+/**
+ * Shared type system for the bundled skills library (`@elizaos/skills`).
+ *
+ * Describes a loaded skill and its `SKILL.md` frontmatter — invocation policy,
+ * OS/binary/env requirements, and provenance (human vs. agent-generated, plus
+ * optimization lineage from the learning loop). `loader`, `frontmatter`,
+ * `formatter`, and `resolver` all build on these types.
+ */
+
 export interface SkillProvenance {
   source: "human" | "agent-generated" | "agent-refined";
   derivedFromTrajectory?: string;

--- a/packages/skills/test/formatter.test.ts
+++ b/packages/skills/test/formatter.test.ts
@@ -1,3 +1,5 @@
+/** Tests `formatSkillsForPrompt` / `buildSkillCommandSpecs` output (invocation-policy filtering, name sanitization); bun:test, deterministic. */
+
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import {

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -1,3 +1,5 @@
+/** Tests SKILL.md frontmatter parse/serialize plus metadata/invocation-policy resolution; bun:test, deterministic. */
+
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import {

--- a/packages/skills/test/provenance.test.ts
+++ b/packages/skills/test/provenance.test.ts
@@ -1,3 +1,5 @@
+/** Tests skill provenance resolution (human vs. agent-generated, optimization lineage); bun:test, deterministic. */
+
 import assert from "node:assert";
 import {
   mkdirSync,

--- a/packages/skills/test/resolver.test.ts
+++ b/packages/skills/test/resolver.test.ts
@@ -1,3 +1,5 @@
+/** Tests skills-directory resolution and the curated active/proposed/promote flow; bun:test over temp fixtures. */
+
 import assert from "node:assert";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/scripts/assert-comment-only-diff.mjs
+++ b/scripts/assert-comment-only-diff.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Machine guard for the comment-cleanup effort (parent issue #12181): proves a
+ * branch changed *only* comments and whitespace, never a single token of code.
+ *
+ * The cleanup rewrites file headers and in-body comments across thousands of
+ * files. "Trust me, it's comments-only" is not evidence, so this script makes it
+ * checkable: for every file that differs from the merge base it tokenizes both
+ * revisions with the TypeScript scanner — which classifies comments and
+ * whitespace as *trivia* and skips them — and asserts the two non-trivia token
+ * streams are byte-identical. A one-token code change (rename, reordered
+ * argument, flipped operator) shifts the stream and fails; adding, rewriting, or
+ * deleting a comment does not. Any changed file with a non-source extension is
+ * also a failure, because a comment-only batch must never touch build/config.
+ *
+ * Consumed by the root `check:comment-only` script and by each batch PR's CI.
+ * Default base is `origin/develop`; pass an alternate base as the first argv.
+ * `--self-test` runs an internal proof that the guard catches a planted
+ * one-token change and passes a planted comments-only change (no git needed).
+ */
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import ts from "typescript";
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+/** JSX-capable scanning for .tsx/.jsx so `<Tag>` tokenizes the same on both sides. */
+function languageVariantFor(path) {
+  return path.endsWith(".tsx") || path.endsWith(".jsx")
+    ? ts.LanguageVariant.JSX
+    : ts.LanguageVariant.Standard;
+}
+
+function extensionOf(path) {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot);
+}
+
+/**
+ * The ordered non-trivia tokens of a source string. Each entry is `kind:text`
+ * so a rename (same kind, different text) diverges just like a structural edit.
+ * Comments and whitespace never appear — the scanner skips them as trivia — so
+ * two revisions that differ only in comments produce identical arrays.
+ *
+ * The bare scanner has no parser context, so it may mis-classify a regex vs.
+ * division or a template span. That is irrelevant here: the mis-scan is a pure
+ * function of the non-trivia characters, which are identical on both sides of a
+ * comments-only change, so it cancels out. Streams match iff the code matches.
+ */
+function tokenize(source, variant) {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ true,
+    variant,
+    source,
+  );
+  const tokens = [];
+  let token = scanner.scan();
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    tokens.push(`${token}:${scanner.getTokenText()}`);
+    token = scanner.scan();
+  }
+  return tokens;
+}
+
+/**
+ * Compare two token streams. Returns `null` when identical, otherwise the index
+ * and both sides of the first divergence so the caller can point at it.
+ */
+function firstDivergence(baseTokens, headTokens) {
+  const max = Math.max(baseTokens.length, headTokens.length);
+  for (let i = 0; i < max; i++) {
+    if (baseTokens[i] !== headTokens[i]) {
+      return {
+        index: i,
+        base: baseTokens[i] ?? "<end of file>",
+        head: headTokens[i] ?? "<end of file>",
+      };
+    }
+  }
+  return null;
+}
+
+/** `kind:text` → the readable token text, for the failure message. */
+function tokenLabel(entry) {
+  if (entry === "<end of file>") return entry;
+  const colon = entry.indexOf(":");
+  return entry.slice(colon + 1);
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 256,
+    // Capture stderr instead of inheriting so an expected failure (e.g.
+    // `git show base:<added-file>`) does not leak a `fatal:` line to output.
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** Merge base of `base` and HEAD, matching `git diff base...HEAD` semantics. */
+function resolveMergeBase(base) {
+  try {
+    return git(["merge-base", base, "HEAD"]).trim();
+  } catch {
+    // base may be an exact commit or unfetched ref; compare against it directly.
+    return base;
+  }
+}
+
+function changedFiles(mergeBase) {
+  return git(["diff", "--name-only", mergeBase, "--"])
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/** Base-revision contents of `path`, or `null` when the file is newly added. */
+function readBaseSource(mergeBase, path) {
+  try {
+    return git(["show", `${mergeBase}:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+/** Worktree contents of `path`, or `null` when the file was deleted. */
+function readHeadSource(path) {
+  try {
+    return execFileSync("cat", [path], {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024 * 256,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function runCheck(base) {
+  const mergeBase = resolveMergeBase(base);
+  const files = changedFiles(mergeBase);
+  const violations = [];
+
+  for (const path of files) {
+    if (!SOURCE_EXTENSIONS.has(extensionOf(path))) {
+      violations.push(
+        `${path}: non-source file changed (a comment-only batch must touch only ${[...SOURCE_EXTENSIONS].join(", ")})`,
+      );
+      continue;
+    }
+
+    const baseSource = readBaseSource(mergeBase, path);
+    const headSource = readHeadSource(path);
+    if (baseSource === null) {
+      violations.push(`${path}: file added (not a comments-only change)`);
+      continue;
+    }
+    if (headSource === null) {
+      violations.push(`${path}: file deleted (not a comments-only change)`);
+      continue;
+    }
+
+    const variant = languageVariantFor(path);
+    const divergence = firstDivergence(
+      tokenize(baseSource, variant),
+      tokenize(headSource, variant),
+    );
+    if (divergence) {
+      violations.push(
+        `${path}: code token changed at position ${divergence.index} — base \`${tokenLabel(divergence.base)}\` vs head \`${tokenLabel(divergence.head)}\``,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `[assert-comment-only-diff] ${violations.length} file(s) changed more than comments (base ${mergeBase}):`,
+    );
+    for (const violation of violations) console.error(`  - ${violation}`);
+    return 1;
+  }
+
+  console.log(
+    `[assert-comment-only-diff] OK — ${files.length} changed file(s), all comments-only (base ${mergeBase}).`,
+  );
+  return 0;
+}
+
+/**
+ * Prove the guard both ways without git: a planted one-token change must be
+ * caught, and a planted comments-only rewrite must pass. Exit non-zero if either
+ * assertion is wrong so the guard can never silently rot.
+ */
+function selfTest() {
+  const original = [
+    "/** Original header. */",
+    "export function add(a, b) {",
+    "  // sum them",
+    "  return a + b;",
+    "}",
+  ].join("\n");
+
+  const commentsOnly = [
+    "/** Rewritten header explaining what add does and who calls it. */",
+    "export function add(a, b) {",
+    "  return a + b; // still sums, comment moved to the line",
+    "}",
+  ].join("\n");
+
+  const oneTokenChange = [
+    "/** Original header. */",
+    "export function add(a, b) {",
+    "  // sum them",
+    "  return a - b;", // + flipped to -
+    "}",
+  ].join("\n");
+
+  const variant = ts.LanguageVariant.Standard;
+  const baseTokens = tokenize(original, variant);
+
+  const commentsDivergence = firstDivergence(
+    baseTokens,
+    tokenize(commentsOnly, variant),
+  );
+  const codeDivergence = firstDivergence(
+    baseTokens,
+    tokenize(oneTokenChange, variant),
+  );
+
+  let ok = true;
+  if (commentsDivergence !== null) {
+    ok = false;
+    console.error(
+      `[self-test] FAIL: comments-only rewrite was flagged at token ${commentsDivergence.index} (\`${tokenLabel(commentsDivergence.base)}\` vs \`${tokenLabel(commentsDivergence.head)}\`)`,
+    );
+  } else {
+    console.log("[self-test] PASS: comments-only rewrite accepted.");
+  }
+
+  if (codeDivergence === null) {
+    ok = false;
+    console.error(
+      "[self-test] FAIL: a one-token code change (`+` → `-`) slipped through.",
+    );
+  } else {
+    console.log(
+      `[self-test] PASS: one-token code change caught at token ${codeDivergence.index} (\`${tokenLabel(codeDivergence.base)}\` vs \`${tokenLabel(codeDivergence.head)}\`).`,
+    );
+  }
+
+  return ok ? 0 : 1;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--self-test")) {
+    process.exit(selfTest());
+  }
+  const base = args.find((arg) => !arg.startsWith("--")) ?? "origin/develop";
+  process.exit(runCheck(base));
+}
+
+main();


### PR DESCRIPTION
Part of #12181 (comment cleanup). The **WI-3 pilot / calibration PR** — applies the settled convention end-to-end to the small-libs corner (`packages/logger`, `prompts`, `skills`, `registry`).

> Stacked on #12286 (Phase 0: the "Slop and Comment Cleanup" convention + the `check:comment-only` guard). Once #12286 merges, this PR's diff reduces to just the header additions below.

## What changed

Every source and test file in the four packages that **lacked a top-of-file prose header** now has one — described in that package's own architecture terms (e.g. skills' curated learning loop, prompts' template/codegen split, the logger leaf-package rationale, the registry's two-format split). Test files get a 1-line header naming the surface under test and the harness (all deterministic unit tests — bun:test / vitest, no live model). Files already at the bar were left untouched (accuracy over coverage).

24 files: 12 source + 12 test across the four packages.

## Verification — machine-proven zero functional diff

This is exactly what Phase 0's guard was built for:

```
$ bun run check:comment-only            # base = Phase 0 branch
[assert-comment-only-diff] OK — 24 changed file(s), all comments-only
```

- `biome check` on all 24 files — clean, no fixes.
- `bun run --cwd packages/skills test` — **60/60 pass** (spot-check; the guard already proves the code tokens are byte-identical, so behavior cannot have changed).

N/A — comments only; no runtime/LLM/UI/native behavior is touched, so trajectories, screenshots, and device captures do not apply (the comment-only guard is the binding evidence).

Per the parent's plan, a maintainer should eyeball the header tone/accuracy here before the B17 batch fan-out begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)