### PR TITLE
feat(ui): post-login permission-priming modal (soft-ask) for voice/location/notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ packages/ui/src/components/shell/__e2e__/output-voice-recording/
 packages/ui/src/components/pages/tutorial/__e2e__/output-tutorial/
 # FTU welcome e2e output (screenshots + webm — regenerate via test:ftu-home-e2e)
 packages/ui/src/components/chat/widgets/__e2e__/output-ftu/
+# Permission-priming e2e output (screenshots + webm + stubs — regenerate via test:permission-priming-e2e)
+packages/ui/src/components/permissions/__e2e__/output-permission-priming/
 # View-lifecycle e2e output (screenshots + webm + telemetry — regenerate via test:view-lifecycle-e2e)
 packages/ui/src/components/views/__e2e__/output-view-lifecycle/
 # Desktop bottom-bar e2e output (screenshots + webm — regenerate via test:bottombar-e2e; committed evidence lives in .github/issue-evidence/9953-windows-bottom-bar/)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "test:home-screen-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs",
     "test:warmup-eviction-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-warmup-eviction-e2e.mjs",
     "test:tutorial-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs",
+    "test:permission-priming-e2e": "bun run --cwd ../.. packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs",
     "test:immersive-e2e": "bun run --cwd ../.. packages/ui/src/spatial/__e2e__/run-immersive-e2e.mjs",
     "test:chat-ambient-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-ambient-e2e.mjs",
     "test:view-parity": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --no-experimental-webstorage --disable-warning=ExperimentalWarning\" vitest run --config ./vitest.config.ts registered-view-parity",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -48,6 +48,7 @@ import { CustomActionEditor } from "./components/custom-actions/CustomActionEdit
 import { CustomActionsPanel } from "./components/custom-actions/CustomActionsPanel";
 import { AppsPageView } from "./components/pages/AppsPageView";
 import { TutorialOverlay } from "./components/pages/tutorial/TutorialOverlay";
+import { PermissionPrimingOverlay } from "./components/permissions/PermissionPrimingOverlay";
 import { ActionBanner } from "./components/shell/ActionBanner";
 import { AssistantOverlay } from "./components/shell/AssistantOverlay";
 import { BugReportModal } from "./components/shell/BugReportModal";
@@ -2499,6 +2500,13 @@ export function App() {
             only when the tutorial is active (launched from the home Tutorial
             tile or the Help view). */}
         <TutorialOverlay />
+        {/* Post-login permission priming: a one-time soft-ask modal that walks
+            the user through the platform's onboarding permission set (voice,
+            location, notifications) BEFORE any OS prompt. Self-gates on
+            authenticated + firstRunComplete !== false + no active tutorial, so
+            it never collides with the in-chat first-run conductor. Renders null
+            when not eligible; re-triggerable from Settings → Permissions. */}
+        <PermissionPrimingOverlay />
         {/* Notification center, headless for now: the visible bell is hidden,
             but this still self-boots the notification store (hydrate + live
             stream) and routes interrupt toasts through ActionNotice. Restore

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -246,7 +246,11 @@ export * from "./pages/TrajectoryDetailView";
 export * from "./pages/WorkflowEditor";
 export * from "./pages/workflow-graph-events";
 // DesktopWorkspaceSection omitted — App.tsx lazy-loads it.
+export * from "./permissions/PermissionPrimingModal";
+export * from "./permissions/PermissionPrimingOverlay";
 export * from "./permissions/PermissionRecoveryCallout";
+export * from "./permissions/permission-priming";
+export * from "./permissions/use-permission-priming";
 export * from "./RoleGate.tsx";
 export * from "./ShellModalityProvider.tsx";
 export * from "./ShellRoleProvider.tsx";

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.stories.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.stories.tsx
@@ -1,0 +1,135 @@
+import type { PermissionId } from "@elizaos/shared/contracts/permissions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { MockAppProvider } from "../../storybook/mock-providers";
+import { PermissionPrimingModal } from "./PermissionPrimingModal";
+import type {
+  PermissionPrimingController,
+  PrimingItem,
+  PrimingItemStatus,
+} from "./use-permission-priming";
+
+const meta = {
+  title: "Permissions/PermissionPrimingModal",
+  component: PermissionPrimingModal,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <MockAppProvider>
+        <Story />
+      </MockAppProvider>
+    ),
+  ],
+} satisfies Meta<typeof PermissionPrimingModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function item(
+  id: PermissionId,
+  status: PrimingItemStatus,
+  canRequest = false,
+): PrimingItem {
+  return { id, status, canRequest, requesting: false, resolved: false };
+}
+
+function controller(
+  active: PrimingItem | null,
+  overrides: Partial<PermissionPrimingController> = {},
+): PermissionPrimingController {
+  const items = active ? [active] : [];
+  return {
+    items,
+    activeIndex: 0,
+    active,
+    currentStep: 1,
+    totalSteps: items.length || 1,
+    ready: true,
+    done: active === null,
+    request: async () => {},
+    skip: () => {},
+    openSettings: async () => {},
+    recheck: async () => {},
+    skipAll: () => {},
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+export const Microphone: Story = {
+  args: {
+    ids: ["microphone"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(item("microphone", "not-determined", true), {
+      currentStep: 1,
+      totalSteps: 3,
+    }),
+  },
+};
+
+export const Location: Story = {
+  args: {
+    ids: ["location"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(item("location", "not-determined", true), {
+      currentStep: 3,
+      totalSteps: 3,
+    }),
+  },
+};
+
+export const Notifications: Story = {
+  args: {
+    ids: ["notifications"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(
+      item("notifications", "not-determined", true),
+      { currentStep: 2, totalSteps: 3 },
+    ),
+  },
+};
+
+export const Requesting: Story = {
+  args: {
+    ids: ["microphone"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller({
+      id: "microphone",
+      status: "not-determined",
+      canRequest: true,
+      requesting: true,
+      resolved: false,
+    }),
+  },
+};
+
+export const DeniedRetryable: Story = {
+  args: {
+    ids: ["location"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(item("location", "denied", true)),
+  },
+};
+
+export const DeniedSettingsOnly: Story = {
+  args: {
+    ids: ["microphone"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(item("microphone", "denied", false)),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    ids: ["microphone"],
+    open: true,
+    onComplete: noop,
+    controllerOverride: controller(null, { ready: false, done: false }),
+  },
+};

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.test.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import type { PermissionId } from "@elizaos/shared/contracts/permissions";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { installJsdomUiPolyfills } from "../../../test/portable-stories";
+import { MockAppProvider } from "../../storybook/mock-providers";
+import { PermissionPrimingModal } from "./PermissionPrimingModal";
+import type {
+  PermissionPrimingController,
+  PrimingItem,
+  PrimingItemStatus,
+} from "./use-permission-priming";
+
+beforeAll(() => {
+  installJsdomUiPolyfills();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderModal(node: ReactElement) {
+  return render(<MockAppProvider>{node}</MockAppProvider>);
+}
+
+function item(
+  id: PermissionId,
+  status: PrimingItemStatus,
+  canRequest = false,
+): PrimingItem {
+  return { id, status, canRequest, requesting: false, resolved: false };
+}
+
+function makeController(
+  overrides: Partial<PermissionPrimingController> = {},
+): PermissionPrimingController {
+  return {
+    items: [],
+    activeIndex: 0,
+    active: null,
+    currentStep: 1,
+    totalSteps: 1,
+    ready: true,
+    done: false,
+    request: vi.fn(async () => {}),
+    skip: vi.fn(),
+    openSettings: vi.fn(async () => {}),
+    recheck: vi.fn(async () => {}),
+    skipAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("PermissionPrimingModal", () => {
+  it("renders the active card with rationale and Enable / Not now", () => {
+    const controller = makeController({
+      items: [item("microphone", "not-determined", true)],
+      active: item("microphone", "not-determined", true),
+      currentStep: 1,
+      totalSteps: 1,
+    });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+
+    expect(screen.getByTestId("priming-card-microphone")).toBeTruthy();
+    // MockAppProvider's t returns the defaultValue, so real copy renders.
+    expect(screen.getByText("Talk to me")).toBeTruthy();
+    expect(screen.getByTestId("priming-enable-microphone")).toBeTruthy();
+    expect(screen.getByTestId("priming-skip-microphone")).toBeTruthy();
+  });
+
+  it("Enable fires the OS request, Not now skips without it", () => {
+    const controller = makeController({
+      items: [item("microphone", "not-determined", true)],
+      active: item("microphone", "not-determined", true),
+    });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("priming-enable-microphone"));
+    expect(controller.request).toHaveBeenCalledWith("microphone");
+    expect(controller.skip).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("priming-skip-microphone"));
+    expect(controller.skip).toHaveBeenCalledWith("microphone");
+  });
+
+  it("shows the recovery callout for a denied card; retry re-checks when it can't re-prompt", () => {
+    const controller = makeController({
+      items: [item("microphone", "denied", false)],
+      active: item("microphone", "denied", false),
+    });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+
+    expect(screen.getByTestId("priming-recovery-microphone")).toBeTruthy();
+    // canRequest === false → the retry action re-checks status (post-Settings).
+    fireEvent.click(screen.getByTestId("priming-recovery-microphone-retry"));
+    expect(controller.recheck).toHaveBeenCalledWith("microphone");
+    expect(controller.request).not.toHaveBeenCalled();
+  });
+
+  it("a denied card that can still re-prompt retries via request()", () => {
+    const controller = makeController({
+      items: [item("location", "denied", true)],
+      active: item("location", "denied", true),
+    });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["location"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("priming-recovery-location-retry"));
+    expect(controller.request).toHaveBeenCalledWith("location");
+  });
+
+  it("renders a loading state until the initial check completes", () => {
+    const controller = makeController({ ready: false, active: null });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+    expect(screen.getByTestId("permission-priming-loading")).toBeTruthy();
+  });
+
+  it("calls onComplete exactly once when the sequence is done", () => {
+    const onComplete = vi.fn();
+    const controller = makeController({
+      ready: true,
+      done: true,
+      active: null,
+    });
+    const { rerender } = renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={onComplete}
+        controllerOverride={controller}
+      />,
+    );
+    rerender(
+      <MockAppProvider>
+        <PermissionPrimingModal
+          ids={["microphone"]}
+          open
+          onComplete={onComplete}
+          controllerOverride={controller}
+        />
+      </MockAppProvider>,
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("Skip for now skips the whole flow", () => {
+    const controller = makeController({
+      items: [item("microphone", "not-determined", true)],
+      active: item("microphone", "not-determined", true),
+    });
+    renderModal(
+      <PermissionPrimingModal
+        ids={["microphone"]}
+        open
+        onComplete={vi.fn()}
+        controllerOverride={controller}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("priming-skip-all"));
+    expect(controller.skipAll).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
@@ -1,0 +1,328 @@
+import type { PermissionId } from "@elizaos/shared/contracts/permissions";
+import {
+  AudioLines,
+  Bell,
+  Camera,
+  type LucideIcon,
+  MapPin,
+  Mic,
+  ShieldCheck,
+} from "lucide-react";
+import * as React from "react";
+import { appNameInterpolationVars, useBranding } from "../../config/branding";
+import { useAppSelector } from "../../state/app-store";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { PermissionRecoveryCallout } from "./PermissionRecoveryCallout";
+import { PRIMING_COPY } from "./permission-priming";
+import {
+  type PermissionPrimingController,
+  usePermissionPriming,
+} from "./use-permission-priming";
+
+/**
+ * Onboarding permission-priming modal — the "soft-ask" surface shown once,
+ * post-login. For each relevant permission it presents *our* rationale and an
+ * Enable / Not now choice; the real OS dialog only fires on Enable. Denied
+ * permissions get an in-place recovery affordance (retry or open OS settings).
+ *
+ * This is a controlled dialog: the parent owns `open` and is told when the
+ * sequence is finished via `onComplete` (granted, skipped, or dismissed).
+ */
+
+const ICONS: Record<string, LucideIcon> = {
+  mic: Mic,
+  "audio-lines": AudioLines,
+  "map-pin": MapPin,
+  bell: Bell,
+  camera: Camera,
+};
+
+export interface PermissionPrimingModalProps {
+  /** Ordered permissions to prime; resolved per-platform by the caller. */
+  ids: PermissionId[];
+  open: boolean;
+  /** Fired once when the sequence completes (all resolved or dismissed). */
+  onComplete: () => void;
+  /** Test/story seam to inject a controller instead of the live hook. */
+  controllerOverride?: PermissionPrimingController;
+}
+
+/**
+ * Container: routes to the live hook, or an injected controller for
+ * tests/stories. Splitting keeps the live `usePermissionPriming` (and its
+ * on-mount OS status check) from running at all when a controller is supplied.
+ */
+export function PermissionPrimingModal(
+  props: PermissionPrimingModalProps,
+): React.JSX.Element {
+  return props.controllerOverride ? (
+    <PermissionPrimingModalView
+      controller={props.controllerOverride}
+      open={props.open}
+      onComplete={props.onComplete}
+    />
+  ) : (
+    <PermissionPrimingModalLive {...props} />
+  );
+}
+
+function PermissionPrimingModalLive({
+  ids,
+  open,
+  onComplete,
+}: PermissionPrimingModalProps): React.JSX.Element {
+  const controller = usePermissionPriming(ids);
+  return (
+    <PermissionPrimingModalView
+      controller={controller}
+      open={open}
+      onComplete={onComplete}
+    />
+  );
+}
+
+function PermissionPrimingModalView({
+  controller,
+  open,
+  onComplete,
+}: {
+  controller: PermissionPrimingController;
+  open: boolean;
+  onComplete: () => void;
+}): React.JSX.Element {
+  const {
+    active,
+    currentStep,
+    totalSteps,
+    ready,
+    done,
+    request,
+    skip,
+    recheck,
+    skipAll,
+  } = controller;
+
+  const t = useAppSelector((s) => s.t);
+  const branding = useBranding();
+
+  // Fire onComplete exactly once when the sequence finishes.
+  const completedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (done && !completedRef.current) {
+      completedRef.current = true;
+      onComplete();
+    }
+  }, [done, onComplete]);
+
+  const headerTitle = t("permissionpriming.title", {
+    defaultValue: "Set up {{appName}}",
+    ...appNameInterpolationVars(branding),
+  });
+  const headerSubtitle = t("permissionpriming.subtitle", {
+    defaultValue: "A couple of quick permissions so I'm ready to help.",
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Dismissing (X / Escape / outside tap) soft-skips the rest; the parent
+        // is then told via the done-effect.
+        if (!next) skipAll();
+      }}
+    >
+      <DialogContent
+        showCloseButton
+        data-testid="permission-priming-modal"
+        aria-describedby="permission-priming-subtitle"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-accent" aria-hidden />
+            {headerTitle}
+          </DialogTitle>
+          <DialogDescription id="permission-priming-subtitle">
+            {headerSubtitle}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!ready ? (
+          <div
+            className="py-8 text-center text-sm text-muted"
+            data-testid="permission-priming-loading"
+          >
+            {t("permissionpriming.checking", {
+              defaultValue: "Checking permissions…",
+            })}
+          </div>
+        ) : active ? (
+          <PrimingCard
+            key={active.id}
+            id={active.id}
+            status={active.status}
+            canRequest={active.canRequest}
+            requesting={active.requesting}
+            currentStep={currentStep}
+            totalSteps={totalSteps}
+            onEnable={() => void request(active.id)}
+            onSkip={() => skip(active.id)}
+            onRecheck={() => void recheck(active.id)}
+            onSkipAll={skipAll}
+          />
+        ) : (
+          <div
+            className="py-8 text-center text-sm text-muted"
+            data-testid="permission-priming-done"
+          >
+            {t("permissionpriming.allSet", { defaultValue: "You're all set." })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PrimingCardProps {
+  id: PermissionId;
+  status: PermissionPrimingController["items"][number]["status"];
+  canRequest: boolean;
+  requesting: boolean;
+  currentStep: number;
+  totalSteps: number;
+  onEnable: () => void;
+  onSkip: () => void;
+  onRecheck: () => void;
+  onSkipAll: () => void;
+}
+
+function PrimingCard({
+  id,
+  status,
+  canRequest,
+  requesting,
+  currentStep,
+  totalSteps,
+  onEnable,
+  onSkip,
+  onRecheck,
+  onSkipAll,
+}: PrimingCardProps): React.JSX.Element {
+  const t = useAppSelector((s) => s.t);
+  const copy = PRIMING_COPY[id];
+  const Icon = copy ? (ICONS[copy.icon] ?? ShieldCheck) : ShieldCheck;
+  const title = copy ? t(copy.titleKey, { defaultValue: copy.title }) : id;
+  const rationale = copy
+    ? t(copy.rationaleKey, { defaultValue: copy.rationale })
+    : "";
+
+  const denied = status === "denied";
+
+  return (
+    <div className="flex flex-col gap-4" data-testid={`priming-card-${id}`}>
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border border-border bg-bg-accent text-accent">
+          <Icon className="h-5 w-5" aria-hidden />
+        </span>
+        <div className="min-w-0">
+          <div className="text-base font-semibold text-txt-strong">{title}</div>
+          <p className="mt-1 text-sm leading-snug text-txt">{rationale}</p>
+        </div>
+      </div>
+
+      {denied ? (
+        <PermissionRecoveryCallout
+          permission={id}
+          title={t("permissionpriming.deniedTitle", {
+            defaultValue: "Permission was declined",
+          })}
+          description={
+            canRequest
+              ? t("permissionpriming.deniedRetry", {
+                  defaultValue:
+                    "You can try again, or turn it on later in Settings.",
+                })
+              : t("permissionpriming.deniedSettings", {
+                  defaultValue:
+                    "To enable it, open Settings and allow access, then re-check.",
+                })
+          }
+          retryLabel={
+            canRequest
+              ? t("permissionpriming.tryAgain", { defaultValue: "Try again" })
+              : t("permissionpriming.iveEnabledIt", {
+                  defaultValue: "I've enabled it",
+                })
+          }
+          onRetry={canRequest ? onEnable : onRecheck}
+          testId={`priming-recovery-${id}`}
+        />
+      ) : null}
+
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted" data-testid="priming-progress">
+          {t("permissionpriming.stepOf", {
+            defaultValue: "Step {{current}} of {{total}}",
+            current: currentStep,
+            total: totalSteps,
+          })}
+        </span>
+        <div className="flex items-center gap-2">
+          {denied ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={onSkip}
+              data-testid={`priming-skip-${id}`}
+            >
+              {t("permissionpriming.continue", { defaultValue: "Continue" })}
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={onSkip}
+                disabled={requesting}
+                data-testid={`priming-skip-${id}`}
+              >
+                {t("permissionpriming.notNow", { defaultValue: "Not now" })}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="default"
+                onClick={onEnable}
+                disabled={requesting}
+                data-testid={`priming-enable-${id}`}
+              >
+                {requesting
+                  ? t("permissionpriming.requesting", {
+                      defaultValue: "Requesting…",
+                    })
+                  : t("permissionpriming.enable", { defaultValue: "Enable" })}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="self-center text-xs text-muted underline-offset-2 hover:text-txt hover:underline"
+        onClick={onSkipAll}
+        data-testid="priming-skip-all"
+      >
+        {t("permissionpriming.skipAll", { defaultValue: "Skip for now" })}
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/permissions/PermissionPrimingOverlay.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingOverlay.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { useIsAuthenticated } from "../../hooks/useAuthStatus";
+import { useAppSelector } from "../../state";
+import { useTutorial } from "../pages/tutorial/tutorial-controller";
+import { PermissionPrimingModal } from "./PermissionPrimingModal";
+import {
+  hasPrimedPermissions,
+  markPermissionsPrimed,
+  resolvePrimingSet,
+} from "./permission-priming";
+
+/**
+ * Mounts the permission-priming modal exactly once, right after onboarding.
+ *
+ * Mounted as a shell-root sibling (next to FirstRunConductorMount /
+ * TutorialOverlay) and self-gates — it renders `null` unless:
+ *  - the user is authenticated (post-login; local resolves silently, cloud
+ *    clears LoginView),
+ *  - first-run has completed (`firstRunComplete !== false`), so the in-chat
+ *    onboarding lock is already released and there is nothing to collide with,
+ *  - the tutorial is not active (never stack two full-screen surfaces — a chosen
+ *    tour runs first, then priming),
+ *  - the platform has a non-empty priming set (web is intentionally empty), and
+ *  - it hasn't already been shown (persisted flag; re-trigger lives in Settings).
+ */
+export function PermissionPrimingOverlay(): React.JSX.Element | null {
+  const authed = useIsAuthenticated();
+  const firstRunComplete = useAppSelector((s) => s.firstRunComplete);
+  const tutorial = useTutorial();
+
+  const ids = React.useMemo(() => resolvePrimingSet(), []);
+  const [primed, setPrimed] = React.useState<boolean>(hasPrimedPermissions);
+  const [open, setOpen] = React.useState(false);
+
+  const eligible =
+    authed &&
+    firstRunComplete !== false &&
+    !tutorial.active &&
+    ids.length > 0 &&
+    !primed;
+
+  // Open the first time eligibility is satisfied; once open it stays open until
+  // the sequence completes (we never yank the modal out from under the user).
+  React.useEffect(() => {
+    if (eligible) setOpen(true);
+  }, [eligible]);
+
+  const handleComplete = React.useCallback(() => {
+    markPermissionsPrimed();
+    setPrimed(true);
+    setOpen(false);
+  }, []);
+
+  if (!open || primed || ids.length === 0) return null;
+
+  return (
+    <PermissionPrimingModal ids={ids} open={open} onComplete={handleComplete} />
+  );
+}

--- a/packages/ui/src/components/permissions/__e2e__/permission-priming-fixture.tsx
+++ b/packages/ui/src/components/permissions/__e2e__/permission-priming-fixture.tsx
@@ -1,0 +1,43 @@
+/**
+ * Fixture for the permission-priming e2e (run-permission-priming-e2e.mjs).
+ * Mounts the REAL {@link PermissionPrimingModal} on its LIVE path (the real
+ * `usePermissionPriming` hook + client-permissions registry). The runner
+ * esbuild-stubs the `api/client` singleton so `getPermission` / `requestPermission`
+ * are deterministic and need no backend — `window.__deny` scripts a denial for a
+ * given permission id.
+ *
+ * The app store is seeded directly (a minimal `t`) rather than via MockAppProvider,
+ * keeping the bundle graph to the modal's own dependencies. `onComplete` stamps
+ * `document.body[data-primed]` so the runner can prove the sequence completed.
+ */
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import type { AppContextValue } from "../../../state/internal";
+import { seedAppValue } from "../../../state/app-store";
+import { PermissionPrimingModal } from "../PermissionPrimingModal";
+
+// Minimal store: the modal only reads `s.t`. Returns the provided defaultValue
+// (with {{name}} interpolation) so real copy renders in the screenshots.
+seedAppValue({
+  t: (key: string, values?: Record<string, unknown>) => {
+    const raw = (values?.defaultValue as string | undefined) ?? key;
+    return raw.replace(/\{\{(\w+)\}\}/g, (_m, name) =>
+      String(values?.[name] ?? "Eliza"),
+    );
+  },
+} as unknown as AppContextValue);
+
+function Fixture(): React.JSX.Element {
+  return (
+    <PermissionPrimingModal
+      ids={["microphone", "location", "notifications"]}
+      open
+      onComplete={() => {
+        document.body.setAttribute("data-primed", "1");
+      }}
+    />
+  );
+}
+
+const root = document.getElementById("root");
+if (root) createRoot(root).render(<Fixture />);

--- a/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
+++ b/packages/ui/src/components/permissions/__e2e__/run-permission-priming-e2e.mjs
@@ -1,0 +1,241 @@
+/**
+ * Real-browser e2e for the onboarding permission-priming modal — no app server.
+ * Bundles permission-priming-fixture.tsx (the REAL modal on its live hook) with
+ * esbuild, stubs the `api/client` singleton so OS requests are deterministic,
+ * and drives the soft-ask gesture flow end to end in headless chromium:
+ *   - the first card (microphone) shows Enable / Not now;
+ *   - tapping Enable fires the (stubbed) OS request and advances to the next card;
+ *   - a scripted denial keeps the card active and surfaces the recovery callout;
+ *   - Continue advances past the denied card;
+ *   - granting the last card completes the sequence (body[data-primed]).
+ * Captures desktop + mobile screenshots (each state) and a mobile video.
+ *
+ * Run: bun run --cwd packages/ui test:permission-priming-e2e
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stylesDir = join(here, "../../../styles");
+const outDir = join(here, "output-permission-priming");
+await mkdir(outDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+const baseCss = await readFile(join(stylesDir, "base.css"), "utf8");
+const TOKEN_SHIM = `
+.bg-accent{background-color:var(--accent)}
+.bg-accent-subtle{background-color:var(--accent-subtle)}
+.text-accent{color:var(--accent)}
+.text-accent-fg{color:var(--accent-foreground)}
+.bg-bg-accent{background-color:var(--bg-accent)}
+.border-warn\\/30{border-color:rgba(234,179,8,0.3)}
+.bg-warn\\/10{background-color:rgba(234,179,8,0.1)}
+`;
+
+// Deterministic client stub: an in-memory permission store; requestPermission
+// grants unless window.__deny[id] is set. Written to the gitignored output dir.
+const clientStub = join(outDir, "client-stub.mjs");
+await writeFile(
+  clientStub,
+  `const store = (globalThis.__perm ||= {});
+function snap(id) {
+  const status = store[id] ?? "not-determined";
+  return { id, status, canRequest: status === "not-determined", platform: "web", lastChecked: 0 };
+}
+export const client = {
+  async getPermission(id) { return snap(id); },
+  async requestPermission(id) {
+    const denied = globalThis.__deny && globalThis.__deny[id];
+    store[id] = denied ? "denied" : "granted";
+    return snap(id);
+  },
+  async openPermissionSettings() {},
+};
+`,
+);
+const stubClient = {
+  name: "stub-client",
+  setup(b) {
+    b.onResolve({ filter: /api\/client(\.[tj]s)?$/ }, () => ({
+      path: clientStub,
+    }));
+  },
+};
+
+// The modal's graph incidentally reaches `@elizaos/core` (a UI util imports the
+// `@elizaos/shared` barrel, whose HTTP helpers import core). The modal never
+// executes any of it, so stub core to a proxy of undefineds and shim node
+// builtins — same "stub heavy deps with esbuild onResolve" pattern the other
+// __e2e__ runners use for their network deps.
+// CJS stub (`.cjs` so esbuild wraps it and `module` is defined): arbitrary
+// named imports of core resolve to `undefined` via CJS interop, since the modal
+// never executes any core code path.
+const coreStub = join(outDir, "core-stub.cjs");
+await writeFile(coreStub, "module.exports = {};\n");
+const stubCore = {
+  name: "stub-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core($|\/)/ }, () => ({ path: coreStub }));
+  },
+};
+const NODE_BUILTINS =
+  /^(node:|fs$|fs\/promises$|path$|crypto$|os$|util$|events$|stream$|child_process$|http$|https$|net$|tls$|url$|zlib$|buffer$|assert$|readline$|worker_threads$|perf_hooks$|module$|constants$|string_decoder$|tty$|dns$|querystring$|vm$|v8$|async_hooks$)/;
+const shimNodeBuiltins = {
+  name: "shim-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: NODE_BUILTINS }, (a) => ({
+      path: a.path,
+      namespace: "node-empty",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "node-empty" }, () => ({
+      // CJS so arbitrary named builtin imports resolve to undefined via interop.
+      contents: "module.exports = {};",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "permission-priming-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubClient, stubCore, shimNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><title>permission priming e2e</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<style>${baseCss}</style>
+<style>${TOKEN_SHIM}</style>
+<style>html,body{margin:0;height:100%;background:var(--bg)}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "permission-priming.html");
+await writeFile(htmlPath, html);
+const url = `file://${htmlPath}`;
+
+const sink = { errors: [] };
+const browser = await chromium.launch();
+let shot = 0;
+async function snap(p, name) {
+  shot += 1;
+  const file = `${String(shot).padStart(2, "0")}-${name}.png`;
+  await p.screenshot({ path: join(outDir, file) });
+  console.log(`  📸 ${file}`);
+}
+
+async function runFlow(page, label) {
+  await page.goto(url);
+  await page.waitForSelector('[data-testid="priming-card-microphone"]');
+  assert(
+    await page.getByTestId("priming-enable-microphone").isVisible(),
+    `[${label}] first card (microphone) shows Enable`,
+  );
+  await snap(page, `${label}-01-microphone`);
+
+  // Enable microphone → granted → advance to location.
+  await page.getByTestId("priming-enable-microphone").click();
+  await page.waitForSelector('[data-testid="priming-card-location"]');
+  assert(
+    (await page.getByTestId("priming-card-microphone").count()) === 0,
+    `[${label}] granting microphone advances to the next card`,
+  );
+  await snap(page, `${label}-02-location`);
+
+  // Script a denial for location, then Enable → denied → recovery callout.
+  await page.evaluate(() => {
+    window.__deny = { location: true };
+  });
+  await page.getByTestId("priming-enable-location").click();
+  await page.waitForSelector('[data-testid="priming-recovery-location"]');
+  assert(
+    await page.getByTestId("priming-recovery-location").isVisible(),
+    `[${label}] a denied permission surfaces the recovery callout`,
+  );
+  await snap(page, `${label}-03-location-denied`);
+
+  // Continue past the denied card → notifications.
+  await page.getByTestId("priming-skip-location").click();
+  await page.waitForSelector('[data-testid="priming-card-notifications"]');
+  assert(true, `[${label}] Continue advances past the denied card`);
+
+  // Grant notifications (denial cleared) → sequence complete.
+  await page.evaluate(() => {
+    window.__deny = {};
+  });
+  await page.getByTestId("priming-enable-notifications").click();
+  await page.waitForFunction(() => document.body.dataset.primed === "1");
+  assert(true, `[${label}] granting the last card completes the sequence`);
+  await snap(page, `${label}-04-complete`);
+}
+
+try {
+  for (const view of [
+    { name: "desktop", viewport: { width: 1180, height: 820 } },
+    { name: "mobile", viewport: { width: 402, height: 874 } },
+  ]) {
+    const ctx = await browser.newContext({ viewport: view.viewport });
+    const page = await ctx.newPage();
+    page.on("pageerror", (e) => sink.errors.push(`[${view.name}] ${e}`));
+    await runFlow(page, view.name);
+    await ctx.close();
+  }
+
+  // Video walkthrough of the full soft-ask flow (mobile).
+  const vctx = await browser.newContext({
+    viewport: { width: 402, height: 874 },
+    deviceScaleFactor: 2,
+    recordVideo: { dir: outDir, size: { width: 402, height: 874 } },
+  });
+  const movie = await vctx.newPage();
+  movie.on("pageerror", (e) => sink.errors.push(`[video] ${e}`));
+  await movie.goto(url);
+  await movie.waitForSelector('[data-testid="priming-card-microphone"]');
+  await movie.waitForTimeout(700);
+  await movie.getByTestId("priming-enable-microphone").click();
+  await movie.waitForSelector('[data-testid="priming-card-location"]');
+  await movie.waitForTimeout(700);
+  await movie.evaluate(() => {
+    window.__deny = { location: true };
+  });
+  await movie.getByTestId("priming-enable-location").click();
+  await movie.waitForSelector('[data-testid="priming-recovery-location"]');
+  await movie.waitForTimeout(700);
+  await movie.getByTestId("priming-skip-location").click();
+  await movie.waitForSelector('[data-testid="priming-card-notifications"]');
+  await movie.evaluate(() => {
+    window.__deny = {};
+  });
+  await movie.getByTestId("priming-enable-notifications").click();
+  await movie.waitForFunction(() => document.body.dataset.primed === "1");
+  await movie.waitForTimeout(500);
+  const video = await movie.video();
+  await movie.close();
+  await vctx.close();
+  if (video) console.log(`  🎥 ${await video.path()}`);
+} finally {
+  await browser.close();
+}
+
+assert(sink.errors.length === 0, `no page errors (${sink.errors.length})`);
+for (const e of sink.errors) console.error(`  ⚠ ${e}`);
+
+console.log(`\nScreenshots (${shot}) → ${outDir}`);
+if (failures > 0) {
+  console.error(`\nPERMISSION PRIMING E2E FAILED (${failures})`);
+  process.exit(1);
+}
+console.log("\nPERMISSION PRIMING E2E PASSED");

--- a/packages/ui/src/components/permissions/permission-priming.test.ts
+++ b/packages/ui/src/components/permissions/permission-priming.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  hasPrimedPermissions,
+  markPermissionsPrimed,
+  PERMISSION_PRIMING_STORAGE_KEY,
+  PRIMING_COPY,
+  resetPermissionPriming,
+  resolvePrimingSet,
+} from "./permission-priming";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("resolvePrimingSet", () => {
+  it("returns the voice-first set on iOS, including speech-recognition", () => {
+    expect(resolvePrimingSet({ platform: "ios" })).toEqual([
+      "microphone",
+      "speech-recognition",
+      "notifications",
+      "location",
+    ]);
+  });
+
+  it("returns mic/notifications/location on android and desktop", () => {
+    expect(resolvePrimingSet({ platform: "android" })).toEqual([
+      "microphone",
+      "notifications",
+      "location",
+    ]);
+    expect(resolvePrimingSet({ platform: "desktop" })).toEqual([
+      "microphone",
+      "notifications",
+      "location",
+    ]);
+  });
+
+  it("primes nothing on web (JIT only — eager browser prompts are a dark pattern)", () => {
+    expect(resolvePrimingSet({ platform: "web" })).toEqual([]);
+  });
+
+  it("never includes an id without a declared iOS usage string (crash guard)", () => {
+    // contacts / reminders / bluetooth have no NS*UsageDescription — requesting
+    // them on iOS aborts the process, so they must never appear in any set.
+    for (const platform of ["ios", "android", "desktop", "web"] as const) {
+      const set = resolvePrimingSet({ platform });
+      expect(set).not.toContain("contacts");
+      expect(set).not.toContain("reminders");
+      expect(set).not.toContain("bluetooth");
+    }
+  });
+
+  it("only returns ids that have priming copy", () => {
+    for (const platform of ["ios", "android", "desktop"] as const) {
+      for (const id of resolvePrimingSet({ platform })) {
+        expect(PRIMING_COPY[id]).toBeDefined();
+      }
+    }
+  });
+
+  it("honors an explicit `only` override, still filtered to ids with copy", () => {
+    expect(
+      resolvePrimingSet({ only: ["microphone", "contacts", "location"] }),
+    ).toEqual(["microphone", "location"]);
+  });
+});
+
+describe("priming persistence", () => {
+  it("defaults to not-primed and flips on mark", () => {
+    expect(hasPrimedPermissions()).toBe(false);
+    markPermissionsPrimed();
+    expect(localStorage.getItem(PERMISSION_PRIMING_STORAGE_KEY)).toBe("1");
+    expect(hasPrimedPermissions()).toBe(true);
+  });
+
+  it("reset clears the flag so the modal can be re-triggered", () => {
+    markPermissionsPrimed();
+    resetPermissionPriming();
+    expect(hasPrimedPermissions()).toBe(false);
+    expect(localStorage.getItem(PERMISSION_PRIMING_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/packages/ui/src/components/permissions/permission-priming.ts
+++ b/packages/ui/src/components/permissions/permission-priming.ts
@@ -1,0 +1,163 @@
+import type { PermissionId } from "@elizaos/shared/contracts/permissions";
+import { getFrontendPlatform } from "../../platform/platform-guards";
+
+/**
+ * Permission-priming logic for the post-login onboarding modal.
+ *
+ * This module owns three concerns and nothing else:
+ *  1. Which permissions to prime, per platform, as an explicit crash-guarded
+ *     allowlist (never a loop over PERMISSION_IDS — that would hard-crash iOS on
+ *     an unentitled request; see the platform table below).
+ *  2. The plain-language rationale copy shown in each soft-ask card, before any
+ *     OS dialog is triggered.
+ *  3. The persisted "already primed" flag so the modal shows once and can be
+ *     re-triggered from Settings.
+ *
+ * The soft-ask contract: the OS permission dialog is only ever fired when the
+ * user taps "Enable" on a card. Priming a permission here does NOT request it —
+ * it only decides that a rationale card is worth showing.
+ */
+
+export type PrimingPlatform = "ios" | "android" | "desktop" | "web";
+
+export interface PrimingPermissionCopy {
+  /** Icon key (matches SYSTEM_PERMISSIONS `icon` keys in permission-types). */
+  icon: string;
+  /** i18n key for the card title; `title` is the English fallback. */
+  titleKey: string;
+  title: string;
+  /** i18n key for the value-proposition line; `rationale` is the fallback. */
+  rationaleKey: string;
+  rationale: string;
+}
+
+/**
+ * Value-proposition copy for every permission we ever prime. Keyed by
+ * PermissionId. First-person, benefit-led — this is what earns the "Enable"
+ * tap, so it must read as *why the user wins*, not what the OS is about to ask.
+ */
+export const PRIMING_COPY: Partial<
+  Record<PermissionId, PrimingPermissionCopy>
+> = {
+  microphone: {
+    icon: "mic",
+    titleKey: "permissionpriming.microphone.title",
+    title: "Talk to me",
+    rationaleKey: "permissionpriming.microphone.rationale",
+    rationale:
+      "Turn on your microphone so you can speak instead of type. Voice stays on your device unless you send it.",
+  },
+  "speech-recognition": {
+    icon: "audio-lines",
+    titleKey: "permissionpriming.speechRecognition.title",
+    title: "Understand your voice",
+    rationaleKey: "permissionpriming.speechRecognition.rationale",
+    rationale:
+      "Allow speech recognition so I can turn what you say into text for hands-free chats.",
+  },
+  location: {
+    icon: "map-pin",
+    titleKey: "permissionpriming.location.title",
+    title: "Plan around where you are",
+    rationaleKey: "permissionpriming.location.rationale",
+    rationale:
+      "Share your location so I can factor in travel time, your time zone, and place-aware reminders.",
+  },
+  notifications: {
+    icon: "bell",
+    titleKey: "permissionpriming.notifications.title",
+    title: "Reach you when it matters",
+    rationaleKey: "permissionpriming.notifications.rationale",
+    rationale:
+      "Let me send notifications for reminders, follow-ups, and results from work I do in the background.",
+  },
+  camera: {
+    icon: "camera",
+    titleKey: "permissionpriming.camera.title",
+    title: "Show me things",
+    rationaleKey: "permissionpriming.camera.rationale",
+    rationale:
+      "Enable the camera so you can capture photos and video for me to look at.",
+  },
+};
+
+/**
+ * Explicit per-platform, ordered priming sets. Highest-value first (voice).
+ *
+ * iOS crash guard: every id here MUST have a declared `NS*UsageDescription` in
+ * packages/app-core/platforms/ios/App/App/Info.plist — requesting an unentitled
+ * permission on iOS aborts the process. Verified present for this set:
+ * microphone, speech-recognition, notifications, location (When-In-Use). Never
+ * add contacts / reminders / bluetooth here (their usage strings are absent).
+ *
+ * Web is intentionally empty: eager browser permission prompts on load are a
+ * dark pattern browsers de-rank, so on web everything stays just-in-time via the
+ * agent's in-chat permission-card.
+ */
+const PRIMING_SETS: Record<PrimingPlatform, readonly PermissionId[]> = {
+  ios: ["microphone", "speech-recognition", "notifications", "location"],
+  android: ["microphone", "notifications", "location"],
+  desktop: ["microphone", "notifications", "location"],
+  web: [],
+};
+
+export interface ResolvePrimingOptions {
+  /** Override the detected platform (tests / Settings). */
+  platform?: PrimingPlatform;
+  /**
+   * Explicit id list, e.g. a Settings "re-request just these" flow. Still
+   * filtered so only ids with priming copy survive.
+   */
+  only?: readonly PermissionId[];
+}
+
+/**
+ * The ordered list of permissions to prime for the current platform. Only ids
+ * that have both a platform-set entry (or explicit `only`) AND rationale copy
+ * are returned, so the modal can never render a card it has no words for.
+ */
+export function resolvePrimingSet(
+  opts: ResolvePrimingOptions = {},
+): PermissionId[] {
+  const platform = opts.platform ?? getFrontendPlatform();
+  const base = opts.only ?? PRIMING_SETS[platform] ?? [];
+  return base.filter(
+    (id): id is PermissionId => PRIMING_COPY[id] !== undefined,
+  );
+}
+
+/** localStorage key for the shown-once flag. */
+export const PERMISSION_PRIMING_STORAGE_KEY = "eliza:permissions-primed";
+
+/**
+ * True once the priming modal has run to completion (granted, skipped, or
+ * dismissed). Storage access can throw in locked-down webviews — a throw means
+ * "we don't know", which we treat as not-yet-primed so the modal errs toward
+ * showing rather than silently never appearing.
+ */
+export function hasPrimedPermissions(): boolean {
+  try {
+    return localStorage.getItem(PERMISSION_PRIMING_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Record that priming has been shown so it does not reappear on next launch. */
+export function markPermissionsPrimed(): void {
+  try {
+    localStorage.setItem(PERMISSION_PRIMING_STORAGE_KEY, "1");
+  } catch {
+    // Storage unavailable — the modal will show again next launch, which is a
+    // benign degradation, not a failure worth surfacing.
+  }
+}
+
+/** Clear the flag so the priming modal can be re-triggered (Settings entry). */
+export function resetPermissionPriming(): void {
+  try {
+    localStorage.removeItem(PERMISSION_PRIMING_STORAGE_KEY);
+  } catch {
+    // Same benign degradation as markPermissionsPrimed.
+  }
+}

--- a/packages/ui/src/components/permissions/use-permission-priming.test.ts
+++ b/packages/ui/src/components/permissions/use-permission-priming.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import type {
+  PermissionId,
+  PermissionState,
+  PermissionStatus,
+} from "@elizaos/shared/contracts/permissions";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPermission: vi.fn(),
+  requestPermission: vi.fn(),
+  openPermissionSettings: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    client: {
+      getPermission: mocks.getPermission,
+      requestPermission: mocks.requestPermission,
+      openPermissionSettings: mocks.openPermissionSettings,
+    },
+  };
+});
+
+import { usePermissionPriming } from "./use-permission-priming";
+
+function state(
+  id: PermissionId,
+  status: PermissionStatus,
+  canRequest = status === "not-determined",
+): PermissionState {
+  return { id, status, canRequest, platform: "web", lastChecked: 0 };
+}
+
+/** Route getPermission by id from a status map. */
+function seedStatuses(map: Partial<Record<PermissionId, PermissionStatus>>) {
+  mocks.getPermission.mockImplementation(async (id: PermissionId) =>
+    state(id, map[id] ?? "not-determined"),
+  );
+}
+
+const IDS: PermissionId[] = ["microphone", "location", "notifications"];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePermissionPriming", () => {
+  it("checks on mount without prompting and drops already-granted ids", async () => {
+    seedStatuses({
+      microphone: "granted",
+      location: "not-determined",
+      notifications: "granted",
+    });
+
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // Mount only checks; it must never request.
+    expect(mocks.requestPermission).not.toHaveBeenCalled();
+    // Granted ids are excluded; only location remains.
+    expect(result.current.items.map((i) => i.id)).toEqual(["location"]);
+    expect(result.current.active?.id).toBe("location");
+    expect(result.current.totalSteps).toBe(1);
+    expect(result.current.done).toBe(false);
+  });
+
+  it("is done immediately when everything is already granted", async () => {
+    seedStatuses({
+      microphone: "granted",
+      location: "granted",
+      notifications: "granted",
+    });
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.active).toBeNull();
+    expect(result.current.done).toBe(true);
+  });
+
+  it("fires the OS request only on request(), resolves + advances on grant", async () => {
+    seedStatuses({
+      microphone: "not-determined",
+      location: "not-determined",
+      notifications: "not-determined",
+    });
+    mocks.requestPermission.mockImplementation(async (id: PermissionId) =>
+      state(id, "granted", false),
+    );
+
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.active?.id).toBe("microphone");
+
+    await act(async () => {
+      await result.current.request("microphone");
+    });
+
+    expect(mocks.requestPermission).toHaveBeenCalledWith("microphone");
+    // Granted → resolved → advance to the next card.
+    expect(result.current.active?.id).toBe("location");
+    expect(result.current.currentStep).toBe(2);
+  });
+
+  it("keeps a denied card active with a recovery path, then skip advances", async () => {
+    seedStatuses({ microphone: "not-determined" });
+    mocks.getPermission.mockImplementation(async (id: PermissionId) =>
+      state(id, id === "microphone" ? "not-determined" : "granted"),
+    );
+    mocks.requestPermission.mockResolvedValueOnce(
+      state("microphone", "denied", false),
+    );
+
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.items.map((i) => i.id)).toEqual(["microphone"]);
+
+    await act(async () => {
+      await result.current.request("microphone");
+    });
+
+    // Denied does NOT resolve — the card stays active so recovery can show.
+    expect(result.current.active?.id).toBe("microphone");
+    expect(result.current.active?.status).toBe("denied");
+    expect(result.current.active?.canRequest).toBe(false);
+    expect(result.current.done).toBe(false);
+
+    act(() => result.current.skip("microphone"));
+    expect(result.current.done).toBe(true);
+  });
+
+  it("surfaces a thrown request as denied instead of a dead card", async () => {
+    seedStatuses({ microphone: "not-determined" });
+    mocks.getPermission.mockImplementation(async (id: PermissionId) =>
+      state(id, id === "microphone" ? "not-determined" : "granted"),
+    );
+    mocks.requestPermission.mockRejectedValueOnce(new Error("bridge down"));
+
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    await act(async () => {
+      await result.current.request("microphone");
+    });
+
+    expect(result.current.active?.status).toBe("denied");
+    expect(result.current.active?.requesting).toBe(false);
+  });
+
+  it("skipAll resolves everything at once", async () => {
+    seedStatuses({
+      microphone: "not-determined",
+      location: "not-determined",
+      notifications: "not-determined",
+    });
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.totalSteps).toBe(3);
+
+    act(() => result.current.skipAll());
+    expect(result.current.done).toBe(true);
+    expect(result.current.active).toBeNull();
+    expect(mocks.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("recheck reflects a permission granted out-of-band (e.g. via Settings)", async () => {
+    seedStatuses({ microphone: "denied" });
+    mocks.getPermission.mockImplementation(async (id: PermissionId) =>
+      state(id, id === "microphone" ? "denied" : "granted"),
+    );
+
+    const { result } = renderHook(() => usePermissionPriming(IDS));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    // A denied id is still promptable-as-a-card (not satisfied), so it shows.
+    expect(result.current.active?.id).toBe("microphone");
+
+    mocks.getPermission.mockImplementation(async (id: PermissionId) =>
+      state(id, "granted", false),
+    );
+    await act(async () => {
+      await result.current.recheck("microphone");
+    });
+    expect(result.current.done).toBe(true);
+  });
+});

--- a/packages/ui/src/components/permissions/use-permission-priming.ts
+++ b/packages/ui/src/components/permissions/use-permission-priming.ts
@@ -1,0 +1,249 @@
+import type {
+  IPermissionsRegistry,
+  PermissionId,
+  PermissionStatus,
+} from "@elizaos/shared/contracts/permissions";
+import * as React from "react";
+import { client } from "../../api/client";
+import { isDesktopPlatform, isNative } from "../../platform";
+import {
+  createMobileSignalsPermissionsRegistry,
+  openMobilePermissionSettings,
+} from "../../platform/mobile-permissions-client";
+import { createClientPermissionsRegistry } from "../composites/chat/permission-card.helpers";
+
+/**
+ * Sequencing controller for the onboarding permission-priming modal.
+ *
+ * Generalizes the single-permission `useMicrophonePermission` to an ordered set
+ * of PermissionIds and walks them one card at a time. It reuses the exact same
+ * platform routing every other permission surface uses — the native
+ * MobileSignals registry on iOS/Android, the (desktop-patched or web) client
+ * registry elsewhere — so there is no second permission client.
+ *
+ * Soft-ask: the OS dialog is only fired from `request()` (the card's "Enable"
+ * tap). Nothing here prompts on mount — mount only *checks* current status so
+ * already-granted permissions are skipped and never re-prompted.
+ *
+ * Like `useMicrophonePermission`, no method throws — every path resolves to a
+ * concrete, renderable state.
+ */
+
+export type PrimingItemStatus = PermissionStatus | "unknown";
+
+export interface PrimingItem {
+  id: PermissionId;
+  status: PrimingItemStatus;
+  /** Whether the OS request can still be (re)fired; false once hard-denied. */
+  canRequest: boolean;
+  /** True while this item's OS request is in flight. */
+  requesting: boolean;
+  /**
+   * True once the user is done with this card — granted, or explicitly skipped.
+   * A denied item is NOT resolved: it stays active so the recovery affordance
+   * shows and the user can retry, open settings, or skip.
+   */
+  resolved: boolean;
+}
+
+export interface PermissionPrimingController {
+  /** Promptable items in order (already-granted/N-A ids are excluded). */
+  items: PrimingItem[];
+  /** Index into `items` of the first unresolved card, or `items.length`. */
+  activeIndex: number;
+  /** The card currently shown, or null when the sequence is complete. */
+  active: PrimingItem | null;
+  /** 1-based position of the active card for a "x of N" indicator. */
+  currentStep: number;
+  /** Total number of cards in the sequence. */
+  totalSteps: number;
+  /** True once the initial status check has completed. */
+  ready: boolean;
+  /** True when every item is resolved (or there were none). */
+  done: boolean;
+  /** Fire the OS request for `id` (the "Enable" tap). */
+  request: (id: PermissionId) => Promise<void>;
+  /** Skip `id` without touching the OS (soft-deny; capability preserved). */
+  skip: (id: PermissionId) => void;
+  /** Open OS settings so a hard-denied permission can be granted manually. */
+  openSettings: (id: PermissionId) => Promise<void>;
+  /** Re-check `id`'s status (e.g. after returning from OS settings). */
+  recheck: (id: PermissionId) => Promise<void>;
+  /** Skip every remaining card at once ("Not now" for the whole flow). */
+  skipAll: () => void;
+}
+
+const PRIMING_FEATURE = { app: "onboarding", action: "permission-priming" };
+const PRIMING_REASON =
+  "Requested during onboarding so the assistant is ready to use this feature.";
+
+/** Statuses that need no action, so their card is never shown. */
+function isSatisfied(status: PrimingItemStatus): boolean {
+  return (
+    status === "granted" ||
+    status === "not-applicable" ||
+    status === "restricted"
+  );
+}
+
+function selectRegistry(): IPermissionsRegistry {
+  return isNative && !isDesktopPlatform()
+    ? createMobileSignalsPermissionsRegistry(undefined, client)
+    : createClientPermissionsRegistry(client);
+}
+
+async function openSettingsFor(id: PermissionId): Promise<void> {
+  if (isNative && !isDesktopPlatform()) {
+    await openMobilePermissionSettings(id);
+    return;
+  }
+  await client.openPermissionSettings(id);
+}
+
+export function usePermissionPriming(
+  ids: readonly PermissionId[],
+): PermissionPrimingController {
+  const registry = React.useMemo(selectRegistry, []);
+  const idsKey = ids.join(",");
+
+  const [items, setItems] = React.useState<PrimingItem[]>([]);
+  const [ready, setReady] = React.useState(false);
+  const requestingRef = React.useRef<Set<PermissionId>>(new Set());
+
+  // Mount check: probe each id WITHOUT prompting, then keep only the ones that
+  // still need action. Already-granted / not-applicable / restricted ids are
+  // dropped so no card is shown for them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `idsKey` is the stable string identity of `ids`; depending on the `ids` array itself would re-run the OS status check on every render for callers that pass a fresh array literal.
+  React.useEffect(() => {
+    let cancelled = false;
+    requestingRef.current = new Set();
+    setReady(false);
+    setItems([]);
+    void (async () => {
+      const checked = await Promise.all(
+        ids.map(async (id) => {
+          try {
+            const state = await registry.check(id);
+            return { id, status: state.status, canRequest: state.canRequest };
+          } catch {
+            // Treat an unknowable status as promptable — better to offer the
+            // card than to silently skip a real permission.
+            return {
+              id,
+              status: "unknown" as PrimingItemStatus,
+              canRequest: true,
+            };
+          }
+        }),
+      );
+      if (cancelled) return;
+      setItems(
+        checked
+          .filter((entry) => !isSatisfied(entry.status))
+          .map((entry) => ({
+            id: entry.id,
+            status: entry.status,
+            canRequest: entry.canRequest,
+            requesting: false,
+            resolved: false,
+          })),
+      );
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // idsKey captures the id list identity; registry is stable (useMemo []).
+  }, [idsKey, registry]);
+
+  const patch = React.useCallback(
+    (id: PermissionId, next: Partial<PrimingItem>) => {
+      setItems((current) =>
+        current.map((item) => (item.id === id ? { ...item, ...next } : item)),
+      );
+    },
+    [],
+  );
+
+  const request = React.useCallback(
+    async (id: PermissionId) => {
+      if (requestingRef.current.has(id)) return;
+      requestingRef.current.add(id);
+      patch(id, { requesting: true });
+      try {
+        const state = await registry.request(id, {
+          reason: PRIMING_REASON,
+          feature: PRIMING_FEATURE,
+        });
+        patch(id, {
+          status: state.status,
+          canRequest: state.canRequest,
+          requesting: false,
+          // Granting resolves the card; a denial keeps it active for recovery.
+          resolved: state.status === "granted",
+        });
+      } catch {
+        // A thrown request is itself a soft failure — surface it as denied so
+        // the recovery affordance shows rather than a dead card.
+        patch(id, { status: "denied", canRequest: false, requesting: false });
+      } finally {
+        requestingRef.current.delete(id);
+      }
+    },
+    [patch, registry],
+  );
+
+  const skip = React.useCallback(
+    (id: PermissionId) => {
+      patch(id, { resolved: true });
+    },
+    [patch],
+  );
+
+  const openSettings = React.useCallback(async (id: PermissionId) => {
+    try {
+      await openSettingsFor(id);
+    } catch {
+      // Opening OS settings is best-effort; a failure must not wedge the flow.
+    }
+  }, []);
+
+  const recheck = React.useCallback(
+    async (id: PermissionId) => {
+      try {
+        const state = await registry.check(id);
+        patch(id, {
+          status: state.status,
+          canRequest: state.canRequest,
+          resolved: state.status === "granted",
+        });
+      } catch {
+        // Leave the current state untouched if the re-check can't resolve.
+      }
+    },
+    [patch, registry],
+  );
+
+  const skipAll = React.useCallback(() => {
+    setItems((current) => current.map((item) => ({ ...item, resolved: true })));
+  }, []);
+
+  const activeIndex = items.findIndex((item) => !item.resolved);
+  const active = activeIndex === -1 ? null : items[activeIndex];
+  const done = ready && active === null;
+
+  return {
+    items,
+    activeIndex: activeIndex === -1 ? items.length : activeIndex,
+    active,
+    currentStep: activeIndex === -1 ? items.length : activeIndex + 1,
+    totalSteps: items.length,
+    ready,
+    done,
+    request,
+    skip,
+    openSettings,
+    recheck,
+    skipAll,
+  };
+}

--- a/packages/ui/src/components/settings/PermissionsSection.tsx
+++ b/packages/ui/src/components/settings/PermissionsSection.tsx
@@ -18,6 +18,8 @@ import {
   openMobilePermissionSettings,
 } from "../../platform/mobile-permissions-client";
 import { useAppSelector } from "../../state";
+import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
+import { resolvePrimingSet } from "../permissions/permission-priming";
 import { StreamingPermissionsSettingsView } from "../permissions/StreamingPermissions";
 import { CapabilityToggle, PermissionRow } from "./permission-controls";
 import { useDesktopPermissionsState } from "./permission-controls.hooks";
@@ -642,8 +644,75 @@ function DesktopPermissionsView() {
   );
 }
 
-export function PermissionsSection() {
+/**
+ * Re-trigger for the onboarding permission-priming modal. Lets a user who
+ * declined or mis-tapped a permission during onboarding re-run the guided
+ * soft-ask flow at any time. Renders nothing on platforms with no priming set
+ * (web), where every permission is requested just-in-time instead.
+ */
+function PermissionPrimingSettingsCard() {
+  const t = useAppSelector((s) => s.t);
+  const branding = useBranding();
+  const ids = useMemo(() => resolvePrimingSet(), []);
+  const [open, setOpen] = useState(false);
+
+  if (ids.length === 0) return null;
+
+  return (
+    <SettingsGroup
+      title={t("permissionssection.QuickSetup", {
+        defaultValue: "Quick setup",
+      })}
+      footer={t("permissionssection.QuickSetupNote", {
+        defaultValue:
+          "Walk through the key permissions ({{appName}} voice, location, notifications) with an explanation for each.",
+        ...appNameInterpolationVars(branding),
+      })}
+    >
+      <SettingsRow
+        label={t("permissionssection.SetUpPermissions", {
+          defaultValue: "Set up permissions",
+        })}
+        description={t("permissionssection.SetUpPermissionsDesc", {
+          defaultValue:
+            "Re-run the guided permission prompts, including any you previously declined.",
+        })}
+        control={
+          <SettingsActionButton
+            agentId="perm-priming-open"
+            agentLabel="Set up permissions"
+            agentGroup="permissions"
+            variant="default"
+            size="sm"
+            className="min-h-11 rounded-sm px-3 text-xs font-semibold"
+            onClick={() => setOpen(true)}
+          >
+            {t("permissionssection.Review", { defaultValue: "Review" })}
+          </SettingsActionButton>
+        }
+      />
+      {open ? (
+        <PermissionPrimingModal
+          ids={ids}
+          open={open}
+          onComplete={() => setOpen(false)}
+        />
+      ) : null}
+    </SettingsGroup>
+  );
+}
+
+function PermissionsSectionBody() {
   if (isWebPlatform()) return <WebPermissionsView />;
   if (isNative && !isDesktopPlatform()) return <MobilePermissionsView />;
   return <DesktopPermissionsView />;
+}
+
+export function PermissionsSection() {
+  return (
+    <SettingsStack>
+      <PermissionPrimingSettingsCard />
+      <PermissionsSectionBody />
+    </SettingsStack>
+  );
 }


### PR DESCRIPTION
Closes #12288.

## What & why

Onboarding primed **zero** OS permissions — every capability (voice, travel-time/location, reminders/notifications) reached for its OS permission lazily, at first use. That means a fresh user often grants nothing, and the first prompt appears with no context (max denial). On iOS a denied native prompt can **never** be re-shown (only a deep-link to Settings), so a context-free first ask permanently burns the capability.

This adds the missing step: a **one-time, post-login soft-ask modal**. For each platform-relevant permission it shows *our own* rationale card **before** any OS dialog and fires the real request **only on "Enable."** "Not now" advances without touching the OS, so nothing is burned — the App-Store-safe way to "request permissions at start." Denied permissions get in-modal recovery (retry / open Settings / re-check), and the whole flow is re-triggerable from Settings → Permissions.

## Design (grounded in an 8-agent recon of the repo)

- **Mount:** a shell-root sibling `<PermissionPrimingOverlay/>` in `App.tsx`, self-gated on `useIsAuthenticated()` + `firstRunComplete !== false` + `!useTutorial().active` + non-empty platform set + not-yet-primed. Gating on `firstRunComplete !== false` (after onboarding completes) means the `ContinuousChatOverlay` first-run composer-lock is already gone — it never collides with the in-chat conductor.
- **Per-platform, crash-guarded set:** iOS `microphone / speech-recognition / notifications / location(WhenInUse)`; Android + desktop `microphone / notifications / location`; **web empty** (eager browser prompts are a dark pattern). iOS ids are an explicit allowlist of declared `NS*UsageDescription` keys — **never** contacts/reminders/bluetooth (absent → hard crash).
- **Reuses the existing stack** — `client.requestPermission/getPermission/openPermissionSettings`, `createMobileSignalsPermissionsRegistry` (iOS/Android) vs `createClientPermissionsRegistry` (desktop/web), `PermissionRecoveryCallout`, the `SYSTEM_PERMISSIONS` catalog — and generalizes the previously-dormant `useMicrophonePermission`. No second permission client.

Complements #12178 (onboarding UX) and #12086/#12087 (permissions decoupling); does not touch role/trust enforcement.

## Files

New under `packages/ui/src/components/permissions/`: `permission-priming.ts`, `use-permission-priming.ts`, `PermissionPrimingModal.tsx`, `PermissionPrimingOverlay.tsx` (+ tests, stories, `__e2e__/`). Edited: `App.tsx` (mount), `PermissionsSection.tsx` (re-trigger), `components/index.ts`, `package.json`, `.gitignore`.

## Evidence

- **Unit** — 22 tests: set resolver + iOS crash-guard + persistence; hook sequencing (grant→advance, denied-stays-active, thrown→denied, skip, skipAll, recheck); modal wiring (Enable/Not-now/recovery/skip-all/onComplete-once). ✅
- **Stories** — 7 states (mic/location/notifications/requesting/denied-retryable/denied-settings-only/loading), auto-covered by the jsdom smoke + browser story gate. ✅
- **Isolated browser e2e** (`test:permission-priming-e2e`) — drives the **real** modal + hook (stubbed client) through the full soft-ask flow incl. the **denied-recovery** path, desktop **and** mobile, 0 page errors; screenshots + video captured and hand-reviewed. ✅
- `bun run --cwd packages/ui typecheck` + `lint` clean; branch rebased onto `develop`.
- **N/A — live-LLM trajectory:** no agent/action/prompt/model behavior changed (pure onboarding UI + client permission calls).
- **Pending (CI/device, can't run in this shared-node_modules worktree):** `audit:app` desktop+mobile to `good`, and real native OS-prompt capture (`capture:ios-sim` / `capture:android-emu` / `capture:macos-desktop`) including the denied state — the real OS dialog can't be proven in mocked-bundle Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)