### PR TITLE
refactor(contracts): single-source TaskExecutionProfile in @elizaos/contracts (#12092 item 18)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -308,6 +308,7 @@
         "@clack/prompts": "^1.0.0",
         "@elizaos/agent": "workspace:*",
         "@elizaos/auth": "workspace:*",
+        "@elizaos/contracts": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-anthropic": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",
@@ -4672,6 +4673,7 @@
         "@elizaos/app-core": "workspace:*",
         "@elizaos/capacitor-calendar": "workspace:*",
         "@elizaos/capacitor-mobile-signals": "workspace:*",
+        "@elizaos/contracts": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/macosreminders": "workspace:*",
         "@elizaos/native-activity-tracker": "workspace:*",
@@ -4891,6 +4893,7 @@
       "name": "@elizaos/plugin-scheduling",
       "version": "2.0.3-beta.7",
       "dependencies": {
+        "@elizaos/contracts": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@elizaos/ui": "workspace:*",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -248,6 +248,7 @@
     "@capacitor/push-notifications": "^8.0.0",
     "@clack/prompts": "^1.0.0",
     "@elizaos/agent": "workspace:*",
+    "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-anthropic": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",

--- a/packages/app-core/src/services/task-host-capabilities.ts
+++ b/packages/app-core/src/services/task-host-capabilities.ts
@@ -31,20 +31,8 @@
  * to "all four available").
  */
 
+import type { TaskExecutionProfile } from "@elizaos/contracts";
 import type { IAgentRuntime } from "@elizaos/core";
-
-/**
- * Mirrors `TaskExecutionProfile` from `plugins/plugin-personal-assistant/src/lifeops/
- * scheduled-task/types.ts`. Re-declared here to avoid an import inversion
- * (app-core must not depend on app-lifeops). Kept in sync via the test at
- * `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runner.test.ts` which
- * imports both and asserts structural compatibility.
- */
-export type TaskExecutionProfileForHost =
-  | "foreground"
-  | "bg-light-30s"
-  | "bg-heavy-fgs"
-  | "notify-only";
 
 interface CapacitorPluginsLike {
   BackgroundRunner?: unknown;
@@ -63,8 +51,8 @@ interface CapacitorGlobalLike {
  */
 export function getHostExecutionCapabilities(
   runtime: IAgentRuntime,
-): ReadonlySet<TaskExecutionProfileForHost> {
-  const profiles = new Set<TaskExecutionProfileForHost>();
+): ReadonlySet<TaskExecutionProfile> {
+  const profiles = new Set<TaskExecutionProfile>();
   // Foreground + notify-only are always available.
   profiles.add("foreground");
   profiles.add("notify-only");
@@ -131,7 +119,7 @@ export function getHostExecutionCapabilities(
  * easier to serialize into `/api/health` extensions.
  */
 export function describeHostExecutionCapabilities(runtime: IAgentRuntime): {
-  profiles: TaskExecutionProfileForHost[];
+  profiles: TaskExecutionProfile[];
   isCapacitor: boolean;
   hasBackgroundRunner: boolean;
   hasElizaTasksPlugin: boolean;

--- a/packages/app-core/tsconfig.json
+++ b/packages/app-core/tsconfig.json
@@ -132,6 +132,8 @@
         "../../plugins/plugin-native-canvas/src/index.ts"
       ],
       "@elizaos/core": ["../core/src/index.node.ts"],
+      "@elizaos/contracts": ["../contracts/src/index.ts"],
+      "@elizaos/contracts/*": ["../contracts/src/*"],
       "@elizaos/capacitor-location": [
         "../../plugins/plugin-native-location/src/index.ts"
       ],

--- a/packages/contracts/src/contracts-drift.test.ts
+++ b/packages/contracts/src/contracts-drift.test.ts
@@ -6,6 +6,7 @@ import {
 	type BscTradeTxStatus,
 	CHARACTER_LANGUAGES,
 	type CharacterLanguage,
+	DEFAULT_TASK_EXECUTION_PROFILE,
 	DEPLOYMENT_TARGET_RUNTIMES,
 	type DeploymentTargetRuntime,
 	ELIZA_CLOUD_SERVICES,
@@ -31,6 +32,8 @@ import {
 	type ServiceRouteAccountStrategy,
 	type ServiceTransport,
 	type StewardWebhookEventType,
+	TASK_EXECUTION_PROFILES,
+	type TaskExecutionProfile,
 	type TradePermissionMode,
 	type WalletChainKind,
 	type WalletMarketOverviewProviderId,
@@ -145,6 +148,19 @@ describe('@elizaos/contracts public literals', () => {
 		expect(new Set(CHARACTER_LANGUAGES).size).toBe(CHARACTER_LANGUAGES.length);
 
 		expectTypeOf<CharacterLanguage>().toEqualTypeOf<(typeof CHARACTER_LANGUAGES)[number]>();
+	});
+
+	it('keeps scheduled-task execution profile literals exhaustive for runner + host probe', () => {
+		expect([...TASK_EXECUTION_PROFILES]).toEqual([
+			'foreground',
+			'bg-light-30s',
+			'bg-heavy-fgs',
+			'notify-only',
+		]);
+		expect(new Set(TASK_EXECUTION_PROFILES).size).toBe(TASK_EXECUTION_PROFILES.length);
+		expect(DEFAULT_TASK_EXECUTION_PROFILE).toBe('foreground');
+
+		expectTypeOf<TaskExecutionProfile>().toEqualTypeOf<(typeof TASK_EXECUTION_PROFILES)[number]>();
 	});
 
 	it('keeps role unions exhaustive for role-resolution consumers', () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,7 @@
 export * from './cloud-topology.js';
 export * from './deployment.js';
 export * from './roles.js';
+export * from './scheduled-task.js';
 export * from './service-routing.js';
 export * from './style.js';
 export * from './wallet.js';

--- a/packages/contracts/src/scheduled-task.ts
+++ b/packages/contracts/src/scheduled-task.ts
@@ -1,0 +1,37 @@
+/**
+ * Scheduled-task host execution profile contracts.
+ *
+ * What kind of host execution environment a scheduled task needs at fire
+ * time. Shared between the scheduling runner (@elizaos/plugin-scheduling),
+ * which consults it against the host's capabilities, and the host-capability
+ * probe (@elizaos/app-core), which reports which profiles the current host
+ * can satisfy. Both sides import this single definition so the runner and the
+ * probe agree on the exact profile set without a cast. Pure types only — the
+ * probe logic and runner behaviour live in their respective packages.
+ *
+ * - `foreground`:   requires the app foregrounded. Anything that would block
+ *                   the UI thread or needs the user present.
+ * - `bg-light-30s`: bookkeeping that fits in ~30s. Safe in iOS
+ *                   BGAppRefreshTask windows; no LLM action.
+ * - `bg-heavy-fgs`: needs an Android foreground service OR an iOS
+ *                   BGProcessingTask. Can run LLM inference. Long but bounded.
+ * - `notify-only`:  deliver a local notification; the user's tap opens the app
+ *                   in foreground where the real work runs.
+ */
+
+export const TASK_EXECUTION_PROFILES = [
+	'foreground',
+	'bg-light-30s',
+	'bg-heavy-fgs',
+	'notify-only',
+] as const;
+
+export type TaskExecutionProfile = (typeof TASK_EXECUTION_PROFILES)[number];
+
+/**
+ * Default profile assumed when a persisted task has no `executionProfile`
+ * column (back-compat for tasks written before this field landed). Foreground
+ * is the safest default — the runner downgrades to notify-only if even that
+ * isn't available.
+ */
+export const DEFAULT_TASK_EXECUTION_PROFILE: TaskExecutionProfile = 'foreground';

--- a/plugins/plugin-personal-assistant/package.json
+++ b/plugins/plugin-personal-assistant/package.json
@@ -67,6 +67,7 @@
     "@elizaos/app-core": "workspace:*",
     "@elizaos/capacitor-calendar": "workspace:*",
     "@elizaos/capacitor-mobile-signals": "workspace:*",
+    "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/macosreminders": "workspace:*",
     "@elizaos/native-activity-tracker": "workspace:*",

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -587,10 +587,7 @@ function buildLifeOpsRunnerDeps(
     },
     hostCapabilities:
       opts.hostCapabilities ??
-      (() =>
-        getHostExecutionCapabilities(
-          opts.runtime,
-        ) as ReadonlySet<TaskExecutionProfile>),
+      (() => getHostExecutionCapabilities(opts.runtime)),
     dispatcher: createProductionScheduledTaskDispatcher({
       runtime: opts.runtime,
     }),

--- a/plugins/plugin-personal-assistant/src/lifeops/wave1-types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/wave1-types.ts
@@ -6,6 +6,8 @@
  * Types only — no runtime behaviour.
  */
 
+import type { TaskExecutionProfile } from "@elizaos/contracts";
+
 export type TerminalState =
   | "completed"
   | "skipped"
@@ -30,12 +32,6 @@ export type ScheduledTaskKind =
   | "custom";
 
 export type ScheduledTaskPriority = "low" | "medium" | "high";
-
-export type TaskExecutionProfile =
-  | "foreground"
-  | "bg-light-30s"
-  | "bg-heavy-fgs"
-  | "notify-only";
 
 export type ScheduledTaskSource =
   | "default_pack"

--- a/plugins/plugin-scheduling/package.json
+++ b/plugins/plugin-scheduling/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/ui": "workspace:*",

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -17,6 +17,8 @@
  *    `failed` so observers see one consistent terminal state per branch.
  */
 
+import type { TaskExecutionProfile } from "@elizaos/contracts";
+
 // ---------------------------------------------------------------------------
 // ScheduledTask schema (frozen)
 // ---------------------------------------------------------------------------
@@ -45,42 +47,16 @@ export type ScheduledTaskKind =
   | "custom";
 
 /**
- * What kind of host execution environment a scheduled task needs at fire
- * time. The runner consults this against `getHostExecutionCapabilities`
- * (in `@elizaos/app-core/services/local-inference/host-capabilities`) and
- * substitutes `notify-only` semantics when the host can't satisfy the
- * requested profile (e.g. mobile background without an FGS / BGProcessingTask).
- *
- * - `"foreground"`: requires the app to be foregrounded. Anything that
- *   would block the UI thread or needs the user present.
- * - `"bg-light-30s"`: bookkeeping that fits in ~30 s. Safe in iOS
- *   BGAppRefreshTask windows; no LLM action.
- * - `"bg-heavy-fgs"`: needs an Android foreground service OR an iOS
- *   BGProcessingTask. Can run LLM inference. Long-running but bounded.
- * - `"notify-only"`: just deliver a local notification; the user's tap
- *   opens the app in foreground where the real work runs.
+ * Host execution profiles ({@link TaskExecutionProfile}) are the canonical
+ * contract shared with the host-capability probe in `@elizaos/app-core`, so
+ * they live in `@elizaos/contracts` (a leaf) and are re-exported here for the
+ * runner and existing `@elizaos/plugin-scheduling` consumers.
  */
-export type TaskExecutionProfile =
-  | "foreground"
-  | "bg-light-30s"
-  | "bg-heavy-fgs"
-  | "notify-only";
-
-export const TASK_EXECUTION_PROFILES = [
-  "foreground",
-  "bg-light-30s",
-  "bg-heavy-fgs",
-  "notify-only",
-] as const satisfies readonly TaskExecutionProfile[];
-
-/**
- * Default profile assumed when a persisted task has no `executionProfile`
- * column (back-compat for tasks written before this field landed).
- * Foreground is the safest default — the runner downgrades to notify-only
- * if even that isn't available.
- */
-export const DEFAULT_TASK_EXECUTION_PROFILE: TaskExecutionProfile =
-  "foreground";
+export type { TaskExecutionProfile } from "@elizaos/contracts";
+export {
+  DEFAULT_TASK_EXECUTION_PROFILE,
+  TASK_EXECUTION_PROFILES,
+} from "@elizaos/contracts";
 
 export type ScheduledTaskPriority = "low" | "medium" | "high";
 

--- a/plugins/plugin-scheduling/tsconfig.json
+++ b/plugins/plugin-scheduling/tsconfig.json
@@ -32,6 +32,8 @@
       "@elizaos/ui/*": ["../../packages/ui/src/*"],
       "@elizaos/core": ["../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../packages/core/src/*"],
+      "@elizaos/contracts": ["../../packages/contracts/src/index.ts"],
+      "@elizaos/contracts/*": ["../../packages/contracts/src/*"],
       "@elizaos/logger": ["../../packages/logger/src/index.ts"],
       "@elizaos/logger/*": ["../../packages/logger/src/*"],
       "@elizaos/shared": ["../../packages/shared/src/index.ts"],

--- a/plugins/tsconfig.build.shared.json
+++ b/plugins/tsconfig.build.shared.json
@@ -19,6 +19,8 @@
     "paths": {
       "@elizaos/core": ["../packages/core/dist/index.d.ts"],
       "@elizaos/core/*": ["../packages/core/dist/*"],
+      "@elizaos/contracts": ["../packages/contracts/dist/index.d.ts"],
+      "@elizaos/contracts/*": ["../packages/contracts/dist/*"],
       "@elizaos/shared": ["../packages/shared/dist/index.d.ts"],
       "@elizaos/shared/*": ["../packages/shared/dist/*"],
       "@elizaos/ui": ["../packages/ui/dist/index.d.ts"],


### PR DESCRIPTION
## #12092 item 18 [P2][S] — task-host-capabilities duplicates TaskExecutionProfile with no sync test

**Found THREE copies (not two — the audit's 'canonical lives in personal-assistant' claim was wrong), all byte-identical:**
- `plugin-scheduling/src/scheduled-task/types.ts` — the real canonical (owns `TASK_EXECUTION_PROFILES` + default).
- `plugin-personal-assistant/src/lifeops/wave1-types.ts` — a legacy dup (unmentioned by the audit).
- `app-core/.../task-host-capabilities.ts` — `TaskExecutionProfileForHost`.

All `"foreground"|"bg-light-30s"|"bg-heavy-fgs"|"notify-only"`. The comment claimed a sync test kept them aligned — that test doesn't exist; alignment rode entirely on an unchecked cast.

## Change
- New leaf `packages/contracts/src/scheduled-task.ts` defines `TASK_EXECUTION_PROFILES`/`TaskExecutionProfile`/`DEFAULT_TASK_EXECUTION_PROFILE` (const-tuple pattern like `deployment.ts`), exported + guarded by `contracts-drift.test.ts`.
- `plugin-scheduling/types.ts` **re-exports** from contracts (public API intact); app-core + wave1-types import from contracts (local dups deleted).
- **Removed** `TaskExecutionProfileForHost` + the unchecked `as ReadonlySet<TaskExecutionProfile>` cast at `runtime-wiring.ts:593` (both sides now share the declared type). `@elizaos/contracts` is a pure leaf → no cycle.

## Verification
- Single-definition grep → exactly one `type TaskExecutionProfile =` (contracts). `TaskExecutionProfileForHost` + the cast → **gone**.
- contracts-drift **10/10** (new profile assertion: array + exhaustiveness + default); plugin-scheduling **235/235** (runner exercises profile→notify-only substitution). contracts tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)