### PR TITLE
docs(#12245): comment cleanup B15 — storage/wallet/payments plugin headers + churn removal

### DIFF
--- a/plugins/plugin-hyperliquid/__tests__/app-core-shim.ts
+++ b/plugins/plugin-hyperliquid/__tests__/app-core-shim.ts
@@ -1,3 +1,8 @@
+/**
+ * Minimal stand-in for `@elizaos/app-core`'s route-response helpers, used by
+ * the route-level tests in this package so they don't pull in the full
+ * app-core dependency tree.
+ */
 export const client = {};
 
 export function sendJson(

--- a/plugins/plugin-hyperliquid/__tests__/perpetual-market.test.ts
+++ b/plugins/plugin-hyperliquid/__tests__/perpetual-market.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the `PERPETUAL_MARKET` action and `PerpetualMarketService`:
+ * validation gating, the read/place_order discriminator, and response shapes.
+ * Runtime and fetch are mocked (no live model, no real Hyperliquid API calls).
+ */
 import type {
   HandlerCallback,
   IAgentRuntime,

--- a/plugins/plugin-hyperliquid/__tests__/smoke.test.ts
+++ b/plugins/plugin-hyperliquid/__tests__/smoke.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Smoke tests for `handleHyperliquidRoute` and `createHyperliquidInfoClient`:
+ * markets/funding/status/positions/orders route payloads, non-GET 501
+ * execution-disabled responses, and position/order normalization math
+ * (mark price, distance-to-liquidation, effective leverage). Fetch is mocked
+ * against fixed responses — no live Hyperliquid API calls.
+ */
 import type http from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
+++ b/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
@@ -1,3 +1,13 @@
+/**
+ * `PERPETUAL_MARKET` action and `PerpetualMarketService`: the conversational
+ * entry point for Hyperliquid perpetual-market reads. The service holds a
+ * registry of `PerpetualMarketProvider`s (Hyperliquid registered by default)
+ * keyed by target name; the action resolves the target provider, dispatches
+ * `read` (status/markets/market/positions/funding) or `place_order`, and maps
+ * the result to `ActionResult`. `place_order` always returns a disabled-
+ * execution notice — this app is read-only by design. Similes cover a large
+ * set of legacy `HYPERLIQUID_*` names for retrieval/fine-tune compatibility.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-hyperliquid/src/automation-node-contributor.test.ts
+++ b/plugins/plugin-hyperliquid/src/automation-node-contributor.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the Hyperliquid automation-node contributor: registration,
+ * and the enabled/disabled state of its nodes based on loaded plugins/actions.
+ * Runtime context is a plain in-memory stub — no live model or agent.
+ */
 import {
   type AutomationNodeContributorContext,
   clearAutomationNodeContributorsForTests,

--- a/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
+++ b/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
@@ -1,3 +1,8 @@
+/**
+ * Registers this plugin's automation-catalog node contributor with app-core,
+ * so the Hyperliquid action and order-event trigger show up as nodes in the
+ * automation builder whenever the Hyperliquid plugin is loaded.
+ */
 import {
   type AutomationNodeContributorContext,
   buildRuntimeCapabilityNodes,

--- a/plugins/plugin-hyperliquid/src/client.ts
+++ b/plugins/plugin-hyperliquid/src/client.ts
@@ -1,3 +1,9 @@
+/**
+ * Extends the shared `ElizaClient` prototype with typed helpers for the four
+ * Hyperliquid read routes. Import this module for its side effect (patching
+ * the prototype) before calling `hyperliquidStatus`/`hyperliquidMarkets`/
+ * `hyperliquidPositions`/`hyperliquidOrders` on an `ElizaClient` instance.
+ */
 import { ElizaClient } from "@elizaos/ui";
 import type {
   HyperliquidMarketsResponse,

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
@@ -1,3 +1,10 @@
+/**
+ * Tests for `HyperliquidSpatialView`, the single component source rendered
+ * across TUI, GUI, and XR modalities: width-contract terminal rendering,
+ * DOM output with agent hooks, terminal-view registration, the account-health
+ * summary strip, per-position detail, and closed-position filtering. Pure
+ * component rendering against static snapshots — no live model or network.
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {
@@ -120,10 +127,9 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
   });
 });
 
-// Ported from the retired rich-DOM HyperliquidAppView + HyperliquidPositionsPanel:
-// the account-health summary strip and the per-position detail (side, leverage,
-// notional, entry, distance-to-liquidation, pnl) now live in the one spatial
-// source, plus the #8796 missing-DTO-field crash guard.
+// The account-health summary strip and per-position detail (side, leverage,
+// notional, entry, distance-to-liquidation, pnl) live in this one spatial
+// source, including the #8796 missing-DTO-field crash guard.
 describe("HyperliquidSpatialView account-health + position detail", () => {
   const withSummary: HyperliquidSnapshot = {
     ...snapshot,

--- a/plugins/plugin-hyperliquid/src/hyperliquid-contracts.ts
+++ b/plugins/plugin-hyperliquid/src/hyperliquid-contracts.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared string constants and response/DTO types for the Hyperliquid plugin:
+ * guidance/error copy for credential and execution states, and the typed
+ * shapes of every `/api/hyperliquid/*` route response (status, markets,
+ * funding, positions, orders). Consumed by `routes.ts`, `client.ts`, the
+ * `PERPETUAL_MARKET` action, and the React/TUI views — this is the single
+ * source of truth for those shapes so route, client, and UI stay in sync.
+ */
 export const HYPERLIQUID_API_BASE = "https://api.hyperliquid.xyz";
 
 export const HYPERLIQUID_EXECUTION_BLOCKED_REASON =

--- a/plugins/plugin-hyperliquid/src/index.ts
+++ b/plugins/plugin-hyperliquid/src/index.ts
@@ -1,3 +1,4 @@
+/** Public package entry: registers the automation-node contributor as a side effect and re-exports the plugin, action, client, routes, and views. */
 import { registerHyperliquidAutomationNodeContributor } from "./automation-node-contributor";
 
 registerHyperliquidAutomationNodeContributor();

--- a/plugins/plugin-hyperliquid/src/plugin.ts
+++ b/plugins/plugin-hyperliquid/src/plugin.ts
@@ -1,3 +1,12 @@
+/**
+ * The `@elizaos/plugin-hyperliquid` `Plugin` object: registers the
+ * `PERPETUAL_MARKET` action, `PerpetualMarketService`, the read-only
+ * `/api/hyperliquid/*` routes (all POST routes 501 — execution is disabled),
+ * and the single Hyperliquid view rendered across GUI/XR/TUI modalities.
+ * Route handlers bridge the elizaOS `RouteRequest`/`RouteResponse` shape to
+ * Node's `http.IncomingMessage`/`http.ServerResponse`, which is what
+ * `handleHyperliquidRoute` in `routes.ts` expects.
+ */
 import type http from "node:http";
 import type {
   IAgentRuntime,

--- a/plugins/plugin-hyperliquid/src/register-routes.ts
+++ b/plugins/plugin-hyperliquid/src/register-routes.ts
@@ -1,3 +1,4 @@
+/** Side-effect module: registers a lazy loader so the app route layer can load `hyperliquidPlugin` opt-in without a static import. */
 import { registerAppRoutePluginLoader } from "@elizaos/core";
 
 registerAppRoutePluginLoader("@elizaos/plugin-hyperliquid", async () => {

--- a/plugins/plugin-hyperliquid/src/register.ts
+++ b/plugins/plugin-hyperliquid/src/register.ts
@@ -1,3 +1,9 @@
+/**
+ * Side-effect module: wires the Hyperliquid view into hosts that bypass the
+ * network-served `DynamicViewLoader` — the terminal engine (Node agent, no
+ * DOM) and native iOS/Android (which disable `DynamicViewLoader` and need the
+ * already-bundled component registered as an app-shell page).
+ */
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 
 // In a terminal host (the Node agent, no DOM), register the Hyperliquid view so

--- a/plugins/plugin-hyperliquid/src/routes.ts
+++ b/plugins/plugin-hyperliquid/src/routes.ts
@@ -1,3 +1,17 @@
+/**
+ * HTTP handling for every `/api/hyperliquid/*` route, and the client that
+ * talks to the public Hyperliquid Info API (`HYPERLIQUID_API_BASE`/info,
+ * POST, no API key). `handleHyperliquidRoute` resolves credential/vault
+ * config from env, serves `status` directly, proxies `markets`/`funding`/
+ * `positions`/`orders` through `createHyperliquidInfoClient`, and returns 501
+ * with an execution-disabled payload for every non-GET method — this app
+ * never signs or submits Hyperliquid exchange calls.
+ *
+ * The `parse*`/`compute*` helpers turn Hyperliquid's raw Info API responses
+ * into the typed DTOs in `hyperliquid-contracts.ts`, deriving mark price,
+ * distance-to-liquidation, and effective leverage server-side so consuming
+ * views only render numbers, never compute them.
+ */
 import type http from "node:http";
 import { sendJson, sendJsonError } from "@elizaos/app-core/api/response";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-hyperliquid/src/ui.ts
+++ b/plugins/plugin-hyperliquid/src/ui.ts
@@ -1,3 +1,4 @@
+/** Public re-export barrel for the view bundle build: the Hyperliquid view component, its interaction helpers, and the state hook. */
 export { HyperliquidView } from "./HyperliquidView.tsx";
 export { interact } from "./hyperliquid-interact.ts";
 export * from "./useHyperliquidState.ts";

--- a/plugins/plugin-hyperliquid/src/useHyperliquidState.ts
+++ b/plugins/plugin-hyperliquid/src/useHyperliquidState.ts
@@ -1,3 +1,8 @@
+/**
+ * React hook backing the Hyperliquid view: fetches status, markets,
+ * positions, and orders from the four read routes, polls every 15s, and
+ * exposes loading/error/unavailable state plus a manual `refresh()`.
+ */
 import { client } from "@elizaos/app-core";
 import { ApiError } from "@elizaos/ui";
 import { useCallback, useEffect, useState } from "react";

--- a/plugins/plugin-hyperliquid/vite.config.views.ts
+++ b/plugins/plugin-hyperliquid/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config for the standalone Hyperliquid view bundle (`dist/views/bundle.js`), built from the shared view-bundle preset. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-hyperliquid/vitest.config.ts
+++ b/plugins/plugin-hyperliquid/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for this plugin's unit tests. Aliases React and every
+ * `@elizaos/plugin-*` / `@elizaos/app-core` / `@elizaos/core` / `@elizaos/shared`
+ * import to source (or an in-package test shim) so tests run against a
+ * pre-built dist-less workspace.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-inmemorydb/access-context.test.ts
+++ b/plugins/plugin-inmemorydb/access-context.test.ts
@@ -1,14 +1,16 @@
+/**
+ * Pins the guarantee that the optional `accessContext` parameter on
+ * `getMemories`/`getMemoriesByRoomIds`/`searchMemories` is accepted by the
+ * types but does not (yet) filter results — permission-aware retrieval reads
+ * it in a later stage. Runs against a real in-memory `InMemoryDatabaseAdapter`
+ * + `MemoryStorage`, no mocks.
+ */
 import { randomUUID } from "node:crypto";
 import type { AccessContext, Memory, UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
 
-/**
- * PR 1 of permission-aware retrieval threads an optional `accessContext` through
- * the memory-read API but does not yet read it. These tests pin the guarantee
- * that passing one is accepted by the types and changes nothing at runtime.
- */
 describe("accessContext is a no-op on memory retrieval (PR 1)", () => {
   const agentId = randomUUID() as UUID;
   const ownerEntity = randomUUID() as UUID;

--- a/plugins/plugin-inmemorydb/hnsw.ts
+++ b/plugins/plugin-inmemorydb/hnsw.ts
@@ -1,3 +1,11 @@
+/**
+ * `EphemeralHNSW`: an in-memory, cosine-distance HNSW (Hierarchical Navigable
+ * Small World) vector index implementing `IVectorStorage`. Nodes are assigned
+ * a random level on insert; search descends from the entry point through
+ * upper layers before doing a beam search (`efSearch`) on layer 0. All state
+ * lives in the `nodes` map — nothing is persisted, and `clear()`/losing the
+ * process discards the index entirely.
+ */
 import type { IVectorStorage, VectorSearchResult } from "./types";
 
 interface HNSWNode {

--- a/plugins/plugin-inmemorydb/index.browser.ts
+++ b/plugins/plugin-inmemorydb/index.browser.ts
@@ -1,3 +1,4 @@
+/** Browser build entry point; re-exports the Node entry (`./index`) since the adapter is platform-agnostic. */
 import plugin from "./index";
 
 export * from "./index";

--- a/plugins/plugin-inmemorydb/index.ts
+++ b/plugins/plugin-inmemorydb/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Plugin entry point: the `init` hook registers `InMemoryDatabaseAdapter` as
+ * the runtime's `IDatabaseAdapter` only if none is already present, backed by
+ * a process-wide `MemoryStorage` singleton keyed off a global symbol so
+ * multiple adapter instances in one process share the same in-memory data.
+ */
 import {
   type IAgentRuntime,
   type IDatabaseAdapter,
@@ -28,10 +34,10 @@ export function createDatabaseAdapter(agentId: UUID): InMemoryDatabaseAdapter {
   return new InMemoryDatabaseAdapter(globalSingletons.storageManager, agentId);
 }
 
-// `IAgentRuntime` historically didn't expose `registerDatabaseAdapter` on the
-// public type — at runtime it does. We narrow the runtime to the registration
-// surface we need and call it defensively so the plugin still loads against
-// runtimes that don't accept adapter registration.
+// `registerDatabaseAdapter` is not part of the public `IAgentRuntime` type but
+// is present at runtime. Narrow to the registration surface actually needed
+// and call it defensively so the plugin still loads against runtimes that
+// don't accept adapter registration.
 type RuntimeWithRegister = IAgentRuntime & {
   registerDatabaseAdapter?: (adapter: IDatabaseAdapter) => void;
   adapter?: IDatabaseAdapter;

--- a/plugins/plugin-inmemorydb/storage-memory.test.ts
+++ b/plugins/plugin-inmemorydb/storage-memory.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for `MemoryStorage` — readiness gating, collection isolation, and CRUD — run against the real in-memory implementation, no mocks. */
 import { describe, expect, it } from "vitest";
 import { MemoryStorage } from "./storage-memory";
 

--- a/plugins/plugin-inmemorydb/storage-memory.ts
+++ b/plugins/plugin-inmemorydb/storage-memory.ts
@@ -1,3 +1,4 @@
+/** `IStorage` backed by a `Map` of collections to `Map<id, item>` — the raw key-value layer under `InMemoryDatabaseAdapter`; nothing here persists past `close()`/process exit. */
 import type { IStorage } from "./types";
 
 export class MemoryStorage implements IStorage {

--- a/plugins/plugin-inmemorydb/types.ts
+++ b/plugins/plugin-inmemorydb/types.ts
@@ -1,3 +1,4 @@
+/** Storage-backend contracts (`IStorage`, `IVectorStorage`) that `InMemoryDatabaseAdapter` is built against, plus the fixed set of collection names it operates on. */
 export interface IStorage {
   init(): Promise<void>;
   close(): Promise<void>;

--- a/plugins/plugin-inmemorydb/vitest.config.ts
+++ b/plugins/plugin-inmemorydb/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for this plugin's unit tests (node environment, no source aliasing needed). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-local-storage/src/index.ts
+++ b/plugins/plugin-local-storage/src/index.ts
@@ -1,3 +1,4 @@
+/** Plugin definition registering `LocalFileStorageService` as the agent's zero-config, filesystem-backed file storage — the default fallback when Eliza Cloud storage is not connected. */
 import type { Plugin } from "@elizaos/core";
 
 import { LocalFileStorageService } from "./services/local-storage";

--- a/plugins/plugin-local-storage/src/services/local-storage.test.ts
+++ b/plugins/plugin-local-storage/src/services/local-storage.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `LocalFileStorageService`: storage-root precedence,
+ * upload/download/exists/delete, key normalization, and signed-URL
+ * generation. Runs real filesystem I/O against temp directories; only the
+ * `IAgentRuntime` is stubbed.
+ */
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-local-storage/src/services/local-storage.ts
+++ b/plugins/plugin-local-storage/src/services/local-storage.ts
@@ -1,3 +1,10 @@
+/**
+ * `LocalFileStorageService`: filesystem-backed `ServiceType.REMOTE_FILES`
+ * implementation, wrapping `@brighter/storage-adapter-local`. Every storage
+ * key is normalized to a safe relative path (rejects absolute paths and
+ * `..` traversal) before touching disk, and parent directories are created
+ * on demand so nested keys don't fail with ENOENT.
+ */
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/plugins/plugin-local-storage/vitest.config.ts
+++ b/plugins/plugin-local-storage/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for this plugin's unit tests (node environment; extended timeouts for real filesystem I/O). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-localdb/index.browser.ts
+++ b/plugins/plugin-localdb/index.browser.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser plugin entry: `BrowserLocalStorage` implements `IStorage` on top of
+ * `window.localStorage` (JSON-serialized, flushed on every write), wrapped by
+ * `InMemoryDatabaseAdapter` for a persistent-across-reloads `IDatabaseAdapter`.
+ * The `init` hook is opt-in — it leaves any adapter already registered on the
+ * runtime in place.
+ */
 import type {
   IAgentRuntime,
   IDatabaseAdapter,

--- a/plugins/plugin-localdb/index.test.ts
+++ b/plugins/plugin-localdb/index.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests for the Node `plugin-localdb` entry: persistence of `FileStorage`
+ * data across adapter restarts, the plugin's adapter-registration gate, and
+ * the `LOCALDB_DATA_DIR` resolution. Runs real file I/O against temp
+ * directories — no mocked filesystem.
+ */
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/plugins/plugin-localdb/index.ts
+++ b/plugins/plugin-localdb/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Node plugin entry: `FileStorage` implements `IStorage` on top of a single
+ * JSON file (`<dataDir>/localdb.json`), wrapped by `InMemoryDatabaseAdapter`
+ * for a durable, restart-safe `IDatabaseAdapter`. Writes are serialized
+ * through a chained promise and committed via a temp-file-then-rename swap,
+ * so concurrent mutations can't interleave and a crash mid-write can't
+ * corrupt the live file. The `init` hook is opt-in — it leaves any adapter
+ * already registered on the runtime in place.
+ */
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type {

--- a/plugins/plugin-localdb/tsup.config.ts
+++ b/plugins/plugin-localdb/tsup.config.ts
@@ -1,3 +1,4 @@
+/** tsup build config: dual-entry build (Node `index.ts` + browser `index.browser.ts`), ESM only, with declaration output. */
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/plugins/plugin-localdb/vitest.config.ts
+++ b/plugins/plugin-localdb/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for this plugin's unit tests (node environment, extended timeouts for real file I/O, custom setup file). */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-localdb/vitest.setup.ts
+++ b/plugins/plugin-localdb/vitest.setup.ts
@@ -1,3 +1,4 @@
+/** Vitest setup: stubs `@elizaos/core`'s `logger` with no-op mocks so tests don't emit real log output, keeping the rest of the module's exports real. */
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", async (importOriginal) => {

--- a/plugins/plugin-polymarket/src/actions.test.ts
+++ b/plugins/plugin-polymarket/src/actions.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the PREDICTION_MARKET action: context-routing validation
+ * (structured `__contextRouting`/`selectedContexts`, no keyword-bank matching)
+ * and the disabled-trading-readiness shape of `place_order`. No network or
+ * runtime dependencies — `runtime`/`state` are plain fixtures.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { polymarketAction } from "./actions";
@@ -66,7 +72,6 @@ describe("PREDICTION_MARKET validate (#10471 — structured context, no keyword 
   });
 
   it("does NOT validate on market keyword text alone — the keyword bank is gone", async () => {
-    // Previously the multilingual READ/TRADE keyword banks matched these.
     expect(
       await polymarketAction.validate?.(
         runtime,

--- a/plugins/plugin-polymarket/src/actions.ts
+++ b/plugins/plugin-polymarket/src/actions.ts
@@ -1,3 +1,14 @@
+/**
+ * The `PREDICTION_MARKET` action and its backing `PredictionMarketService`:
+ * an extensible provider registry that today registers a single Polymarket
+ * provider. The action parses `action`/`kind`/legacy-simile params into a
+ * normalized `{ op, target }` pair, then routes through
+ * `PredictionMarketService.route()` to the matching provider (`execute()`),
+ * so a future non-Polymarket provider (e.g. Manifold) plugs in via
+ * `registerProvider()` without touching the action itself. Read operations
+ * call the local dashboard API (`/api/polymarket/*`); `place_order` only ever
+ * reports trading readiness, since signed CLOB order placement is disabled.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-polymarket/src/client.ts
+++ b/plugins/plugin-polymarket/src/client.ts
@@ -1,3 +1,9 @@
+/**
+ * Typed fetch helpers for the Polymarket REST routes, patched directly onto
+ * `ElizaClient.prototype` so `PolymarketClient` is a plain type intersection
+ * rather than a subclass. Consumers cast an `ElizaClient` instance to
+ * `PolymarketClient` to get these methods.
+ */
 import { ElizaClient } from "@elizaos/ui";
 import type {
   PolymarketDisabledResponse,

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
@@ -1,3 +1,8 @@
+/**
+ * Renders `PolymarketSpatialView` through all three modalities — TUI line
+ * layout (width-constrained), GUI/XR static DOM markup, and the terminal
+ * view registry — from fixture snapshots only (no live API or runtime).
+ */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-polymarket/src/index.ts
+++ b/plugins/plugin-polymarket/src/index.ts
@@ -1,3 +1,4 @@
+/** Public barrel: re-exports the plugin, action, client, provider, view, and route surfaces. */
 export * from "./actions";
 export * from "./client";
 export {

--- a/plugins/plugin-polymarket/src/orderbook.ts
+++ b/plugins/plugin-polymarket/src/orderbook.ts
@@ -1,3 +1,8 @@
+/**
+ * Derives best-bid/best-ask/midpoint/spread from raw CLOB price levels.
+ * Levels with a non-positive or unparsable price are ignored rather than
+ * treated as zero, so a malformed level can't win a `reduce` comparison.
+ */
 export interface PolymarketOrderbookLevel {
   price: string;
   size: string;

--- a/plugins/plugin-polymarket/src/plugin.ts
+++ b/plugins/plugin-polymarket/src/plugin.ts
@@ -1,3 +1,12 @@
+/**
+ * The exported `polymarketPlugin` Plugin object: wires the PREDICTION_MARKET
+ * action, PredictionMarketService, status provider, the seven
+ * `/api/polymarket/*` REST routes, and the single adaptive view declaration
+ * (GUI/XR/TUI from one spatial component) into the agent runtime. Route
+ * handlers here only adapt the framework's `RouteRequest`/`RouteResponse` to
+ * the real Node `http.IncomingMessage`/`ServerResponse` that `routes.ts`
+ * expects; all route logic itself lives in `handlePolymarketRoute`.
+ */
 import type http from "node:http";
 import type {
   IAgentRuntime,

--- a/plugins/plugin-polymarket/src/polymarket-contracts.ts
+++ b/plugins/plugin-polymarket/src/polymarket-contracts.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared request/response interfaces and upstream API base URLs for the
+ * Polymarket integration — the contract between `routes.ts` (producer),
+ * `client.ts` (typed fetch), and the view/action consumers.
+ */
 export const POLYMARKET_GAMMA_API_BASE = "https://gamma-api.polymarket.com";
 export const POLYMARKET_DATA_API_BASE = "https://data-api.polymarket.com";
 export const POLYMARKET_CLOB_API_BASE = "https://clob.polymarket.com";

--- a/plugins/plugin-polymarket/src/provider-text.ts
+++ b/plugins/plugin-polymarket/src/provider-text.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure env-to-text helper for `polymarketStatusProvider`: checks trading
+ * credential env vars (and their legacy aliases) and formats the per-turn
+ * status block without touching the network or the runtime.
+ */
 import {
   POLYMARKET_CLOB_API_BASE,
   POLYMARKET_DATA_API_BASE,

--- a/plugins/plugin-polymarket/src/provider.ts
+++ b/plugins/plugin-polymarket/src/provider.ts
@@ -1,3 +1,7 @@
+/**
+ * `POLYMARKET_STATUS` provider: injects per-turn Polymarket readiness text
+ * (from `derivePolymarketStatusText`) into `finance`/`crypto` contexts only.
+ */
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-polymarket/src/register-routes.ts
+++ b/plugins/plugin-polymarket/src/register-routes.ts
@@ -1,3 +1,4 @@
+/** Registers a lazy loader so app-route mounting can pull in `polymarketPlugin` on demand. */
 import { registerAppRoutePluginLoader } from "@elizaos/core";
 
 registerAppRoutePluginLoader("@elizaos/plugin-polymarket", async () => {

--- a/plugins/plugin-polymarket/src/register.ts
+++ b/plugins/plugin-polymarket/src/register.ts
@@ -1,3 +1,8 @@
+/**
+ * `appRegister` side-effect entry: registers the Polymarket view for the
+ * terminal host (DOM-guarded) and as an app-shell page for native platforms
+ * that disable `DynamicViewLoader`.
+ */
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 
 // In a terminal host (the Node agent, no DOM), register the Polymarket view so

--- a/plugins/plugin-polymarket/src/routes.test.ts
+++ b/plugins/plugin-polymarket/src/routes.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `handlePolymarketRoute` against hand-built Node request/
+ * response doubles — no real HTTP server. Focuses on the trading boundary:
+ * status stays readiness-only even with credentials present, and the
+ * orders route always returns 501.
+ */
 import { describe, expect, it } from "vitest";
 
 import { handlePolymarketRoute } from "./routes";

--- a/plugins/plugin-polymarket/src/routes.ts
+++ b/plugins/plugin-polymarket/src/routes.ts
@@ -1,3 +1,13 @@
+/**
+ * `handlePolymarketRoute()` — all HTTP logic for the `/api/polymarket/*`
+ * routes. Reads flow through the public Gamma (markets), CLOB (orderbook),
+ * and Data (positions) APIs and are normalized into the `Polymarket*`
+ * response contracts; upstream payloads are untyped JSON, so every field is
+ * read defensively (`readString`/`readBoolean`/`readNumericString`/…) rather
+ * than trusted. The orders route always returns 501 — signed trading is
+ * disabled in this app integration, mirrored by `buildStatusResponse`'s
+ * `trading.ready: false`.
+ */
 import type http from "node:http";
 import { sendJson, sendJsonError } from "@elizaos/app-core/api/response";
 import { logger } from "@elizaos/core";

--- a/plugins/plugin-polymarket/src/usePolymarketState.ts
+++ b/plugins/plugin-polymarket/src/usePolymarketState.ts
@@ -1,3 +1,8 @@
+/**
+ * `usePolymarketState()` — the live-state React hook backing `PolymarketView`.
+ * Fetches status + markets on mount/refresh, then conditionally fetches the
+ * agent's own positions when an account address is resolvable.
+ */
 import { client } from "@elizaos/app-core";
 import { useCallback, useEffect, useState } from "react";
 import "./client";

--- a/plugins/plugin-polymarket/vite.config.views.ts
+++ b/plugins/plugin-polymarket/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config for the `dist/views/bundle.js` view build (`build:views`), driven by the shared view-bundle preset. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-polymarket/vitest.config.ts
+++ b/plugins/plugin-polymarket/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Vitest config for this plugin's unit/component tests. Aliases React/ReactDOM
+ * to their real installed copies (avoiding duplicate-instance dedup issues)
+ * and anchors a couple of cross-plugin subpaths to source for the keyless
+ * test lane.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-sql/src/__tests__/connector-account-storage.types.test.ts
+++ b/plugins/plugin-sql/src/__tests__/connector-account-storage.types.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Compile-time check (no runtime assertions beyond expectTypeOf) that
+ * plugin-sql's re-exported connector-account storage types stay identical to
+ * the `@elizaos/core` contract types, including the adapter method signature.
+ */
 import type {
   ConnectorAccountRecord as CoreConnectorAccountRecord,
   UpsertConnectorAccountParams as CoreUpsertConnectorAccountParams,

--- a/plugins/plugin-sql/src/__tests__/integration/advanced-memory-storage.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/advanced-memory-storage.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Real-PGlite integration test for the built-in advanced-memory plugin running
+ * on top of plugin-sql storage: boots a full AgentRuntime with a migrated
+ * PGlite adapter, then verifies long-term memories are stored/retrieved
+ * (including across confirmed entity-identity links) and session summaries
+ * are persisted and read back for real conversation rooms.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import {
   AgentRuntime,

--- a/plugins/plugin-sql/src/__tests__/integration/agent.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/agent.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Real-database integration tests for agent CRUD on the shared
+ * PgDatabaseAdapter/PgliteDatabaseAdapter surface: create/get/update/delete/
+ * count/cleanup, settings-merge semantics (including nested null-removal of
+ * secrets), duplicate-name handling (UUID is the identity, not name), and
+ * cascade delete of an agent's worlds/rooms/entities/memories/components/
+ * participants/relationships/tasks/cache/logs.
+ */
 import {
   type Agent,
   ChannelType,

--- a/plugins/plugin-sql/src/__tests__/integration/base-adapter-methods.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/base-adapter-methods.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Real-database integration tests for `BaseDrizzleAdapter` CRUD/query methods
+ * (memories, entities, components, rooms) against an isolated test database,
+ * covering room/count filters, updates, cascade behavior on delete, and
+ * idempotent/no-op handling of duplicate or missing records.
+ */
 import type { ChannelType, Component, Content, Entity, Memory, Room, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/base-comprehensive.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/base-comprehensive.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Broader real-database coverage of `BaseDrizzleAdapter` beyond the basic CRUD
+ * suite: exact-match name search, cascade deletes, multi-room memory queries,
+ * component lifecycle, room/world relationships, embedding search, cached
+ * embeddings, and batch-create edge cases.
+ */
 import type {
   AgentRuntime,
   ChannelType,

--- a/plugins/plugin-sql/src/__tests__/integration/cache.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/cache.real.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Verifies BaseDrizzleAdapter's cache get/set/delete behavior (set, overwrite,
+ * delete, and miss-on-unknown-key) against a real isolated adapter instance.
+ */
 import type { AgentRuntime, UUID } from "@elizaos/core";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";

--- a/plugins/plugin-sql/src/__tests__/integration/cascade-delete.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/cascade-delete.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies that deleting an agent cascades through world, room, entity,
+ * memory, task, and cache rows created for that agent, and that deleting an
+ * agent with no related data (or a non-existent agent) is handled cleanly.
+ */
 import { ChannelType, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -141,7 +146,6 @@ describe("Cascade Delete Tests", () => {
     const nonExistentId = uuidv4() as UUID;
     const result = await adapter.deleteAgent(nonExistentId);
 
-    // With the new simplified deleteAgent, it should return false for non-existent agents
     expect(result).toBe(false);
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/component.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/component.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies component CRUD against a real isolated adapter: create/read,
+ * update, JSON-patch operations (set/increment/push/remove on nested paths),
+ * and delete, scoped to a seeded entity/room/world.
+ */
 import {
   type AgentRuntime,
   ChannelType,

--- a/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/connector-account-storage.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Verifies connector-account storage end to end against a real isolated
+ * database: plugin-sql migrations create the connector/OAuth tables
+ * idempotently, account upsert stores only credential refs (never plaintext
+ * secrets), audit metadata is redacted before insert, and OAuth flow state is
+ * single-use and expiry-aware.
+ */
 import type { UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/connectorAccount.store.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/connectorAccount.store.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Integration tests for connector-account persistence (accounts, credential
+ * refs, owner bindings, audit events, OAuth flow state) against a real
+ * isolated PGlite/Postgres adapter via `BaseDrizzleAdapter` delegation — no
+ * mocked adapter.
+ */
 import type { UUID } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { PgDatabaseAdapter } from "../../pg/adapter";

--- a/plugins/plugin-sql/src/__tests__/integration/electric-sync-deferred.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/electric-sync-deferred.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Integration tests for the deferred Electric Sync startup path against a
+ * real `PGliteClientManager` + `PgliteDatabaseAdapter` (temp-dir PGlite, no
+ * mocks) and a bogus sync URL — verifies phase ordering, `ensureSync()`
+ * idempotency, and `forceResync()` behavior. See the phase-order note below.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/electric-sync-end-to-end.test.ts
@@ -1,3 +1,11 @@
+/**
+ * End-to-end Electric Sync integration test against a real Postgres +
+ * Electric stack (`docker compose -f plugins/plugin-sql/docker-compose.electric-test.yml up -d`).
+ * Exercises the full data flow — Postgres (source) → Electric (shape server)
+ * → PGlite (`syncShapesToTables`) — including per-agent isolation and sync
+ * status transitions. All tests skip gracefully when the containers are not
+ * running.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,23 +16,6 @@ import { DatabaseMigrationService } from "../../migration-service";
 import { PGliteClientManager } from "../../pglite/manager";
 import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
-
-/**
- * End-to-end Electric Sync integration test.
- *
- * Requires a local Postgres + Electric stack. Start it with:
- *   docker compose -f plugins/plugin-sql/docker-compose.electric-test.yml up -d
- *
- * Tests the full data flow:
- *   Postgres (source) → Electric (shape server) → PGlite (syncShapesToTables)
- *
- * Verifies:
- *   1. Data inserted in Postgres flows to PGlite via Electric sync.
- *   2. Per-agent isolation: agentA's PGlite receives only agentA's rows.
- *   3. Sync status transitions from "syncing" → "synced".
- *
- * All tests skip gracefully when the Electric containers are not running.
- */
 
 const ELECTRIC_HEALTH_URL = "http://localhost:3000/api/health";
 const ELECTRIC_SYNC_URL = "http://localhost:3000";

--- a/plugins/plugin-sql/src/__tests__/integration/electric-sync-live-query.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/electric-sync-live-query.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for the PGlite live query extension (`pg.live`), each
+ * against a real `PGliteClientManager` in a temp directory with the
+ * plugin-sql Drizzle migrations applied. Verifies `liveNs.query()`'s
+ * reactive callback firing on INSERT/UPDATE/DELETE and its unsubscribe
+ * cleanup.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,19 +15,6 @@ import { DatabaseMigrationService } from "../../migration-service";
 import { PGliteClientManager } from "../../pglite/manager";
 import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
-
-/**
- * Integration tests for the PGlite live query extension (`pg.live`).
- *
- * Verifies three core behaviors of `liveNs.query()`:
- *  1. Reactive results — callbacks push updated rows after mutations.
- *  2. INSERT / UPDATE / DELETE — each mutation type triggers a callback.
- *  3. Unsubscribe cleanup — after unsubscribe(), no further callbacks fire.
- *
- * Each test creates its own PGlite instance in a temp directory, runs the
- * plugin-sql Drizzle migrations, and then exercises `live.query()` directly
- * on the `PGliteClientManager`.
- */
 
 function createTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));

--- a/plugins/plugin-sql/src/__tests__/integration/electric-write-back.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/electric-write-back.test.ts
@@ -1,3 +1,11 @@
+/**
+ * End-to-end Electric Write-Back test against Electric Cloud (the managed
+ * sync service, not a local Docker Compose stack) — verifies PGlite connects
+ * and syncs existing tables via `syncShapesToTables`. Skips gracefully when
+ * the Cloud env vars are unset or the proxy is unreachable. Write-back
+ * enabled/disabled/enqueue behavior itself is covered by the unit tests in
+ * `__tests__/unit/write-back.test.ts`.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,20 +15,6 @@ import { DatabaseMigrationService } from "../../migration-service";
 import { PGliteClientManager } from "../../pglite/manager";
 import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
-
-/**
- * End-to-end Electric Write-Back integration test.
- *
- * Uses Electric Cloud (managed sync service) instead of a local
- * Docker Compose stack. The Cloud manages Postgres + Electric.
- *
- * Tests the sync round-trip:
- *   1. PGlite connects to Electric Cloud and syncs existing tables
- *   2. Agent writes to local PGlite
- *   3. Electric Cloud syncs changes back to PGlite via syncShapesToTables
- *
- * All tests skip gracefully when the Cloud is not reachable.
- */
 
 // Caddy injects Electric Cloud auth from these env vars — the test just
 // checks they're set so Caddy can do its job.

--- a/plugins/plugin-sql/src/__tests__/integration/embedding.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/embedding.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifies memories can be created with embeddings and read back with the vector
+ * dimension preserved, including a database-wide dimension change (384 to 768).
+ * Runs against a real Postgres or PGlite backend via `createIsolatedTestDatabase`.
+ */
 import {
   ChannelType,
   type Entity,

--- a/plugins/plugin-sql/src/__tests__/integration/entity-array-fix.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity-array-fix.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies entity `names` is always persisted and read back as a string array,
+ * regardless of input shape (single string, empty array, Set, or non-standard
+ * values), across create, update, and batch-create. Runs against a real
+ * Postgres or PGlite backend via `createTestDatabase`.
+ */
 import type { Entity, UUID } from "@elizaos/core";
 import { stringToUuid } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/entity-create-assertions.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity-create-assertions.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared assertion helper for entity-creation tests: checks that
+ * `createEntities` reports exactly the expected set of entity IDs as created,
+ * order-independent. Used across the entity/base-adapter test suites so each
+ * one doesn't hand-roll the same length + set-membership check.
+ */
 import type { UUID } from "@elizaos/core";
 import { expect } from "vitest";
 

--- a/plugins/plugin-sql/src/__tests__/integration/entity-crud.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity-crud.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Verifies core entity CRUD (create, update, delete, name search, metadata
+ * round-trip) plus create-is-not-upsert idempotency and batch-with-duplicate
+ * handling. Runs against a real Postgres or PGlite backend via
+ * `createIsolatedTestDatabase`.
+ */
 import type { Entity, Metadata, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/entity-methods.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity-methods.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Verifies entity `names` normalization handles every input shape the field
+ * can arrive in (string, Set, Map, number, boolean, plain object, custom
+ * iterable, null/undefined, mixed-type arrays) without throwing or silently
+ * corrupting data, plus entity delete/search/name-lookup behavior. Runs
+ * against a real Postgres or PGlite backend via `createIsolatedTestDatabase`.
+ */
 import type { Entity, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/entity.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/entity.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Integration tests for entity create/get/update against a real isolated
+ * PGlite/Postgres adapter (`createIsolatedTestDatabase`), covering
+ * multi-entity batches, multi-name aliasing, and default metadata.
+ */
 import type { AgentRuntime, Entity, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/live-query-latency.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/live-query-latency.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Integration tests for PGlite live query latency: measures end-to-end time
+ * from INSERT to callback fire on the same `live.query()` pipeline the
+ * `/api/database/status/events` SSE/WebSocket endpoints use to push reactive
+ * table counts. Uses `live.query()` rather than `incrementalQuery` because
+ * these single-table tests use plain `COUNT(*)` aggregates with no stable
+ * row identifier, unlike the production UNION ALL query.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,21 +16,6 @@ import { DatabaseMigrationService } from "../../migration-service";
 import { PGliteClientManager } from "../../pglite/manager";
 import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
-
-/**
- * Integration tests for the PGlite live query latency.
- *
- * The SSE endpoint at /api/database/status/events and the WebSocket
- * endpoint at ws://host:PORT/api/database/status/events both use
- * live queries to push reactive table counts. These tests exercise
- * the same `live.query()` pipeline directly, measuring end-to-end
- * latency from INSERT to callback fire.
- *
- * Note: we use `live.query()` (not `incrementalQuery`) because the
- * production pipeline uses a UNION ALL query with a `table_name` key
- * column to identify rows, while these single-table tests use simple
- * COUNT(*) aggregates without a stable row identifier.
- */
 
 function createTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));

--- a/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/log.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Integration tests for log create/get/delete against a real isolated
+ * PGlite/Postgres adapter, covering the `limit`/legacy-`count` param
+ * contract, JSON-body escaping (backslashes, NUL stripping), and filtering
+ * by type.
+ */
 import { type AgentRuntime, ChannelType, type Entity, type Room, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -78,8 +84,6 @@ describe("Log Integration Tests", () => {
     });
 
     it("honors the `limit` param from the IDatabaseAdapter contract (not just legacy `count`)", async () => {
-      // 15 logs; the pre-fix adapter only read `count` and silently capped any
-      // `limit` caller (runtime.getLogs, agent-export) at the default 10.
       for (let i = 0; i < 15; i++) {
         await adapter.log({
           body: { seq: i },
@@ -122,8 +126,8 @@ describe("Log Integration Tests", () => {
         type: "backslash_test",
       });
       expect(logs).toHaveLength(1);
-      // Pre-fix, sanitizeJsonObject doubled backslashes not followed by
-      // ["\/bfnrtu], so `path` came back as "C:\\\\Users\\dev\\project".
+      // sanitizeJsonObject must not double a backslash that isn't followed
+      // by a valid JSON escape char (["\/bfnrtu]).
       expect(logs[0].body).toEqual(body);
     });
 

--- a/plugins/plugin-sql/src/__tests__/integration/memory-keyword-search.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-keyword-search.real.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Scale test for the keyword (`textContains`) search path on `getMemories`.
+ * Seeds a large fixture (>=2k rooms / >=200k message rows) and proves the
+ * keyword search is a single pushed-down SQL `ILIKE` predicate — not a
+ * "fetch every row, scan in JS" pattern — returns correct rows across
+ * conversations, reaches a hit far outside the recent window, and stays
+ * bounded in latency. Default mode is PGlite (WASM, in-process); set
+ * `POSTGRES_URL` to run against a real Postgres instead.
+ */
 import { ChannelType, type Entity, type Room, type UUID, type World } from "@elizaos/core";
 import { v4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -6,19 +15,6 @@ import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import { memoryTable } from "../../schema";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
-
-/**
- * Scale test for the keyword (`textContains`) search path on `getMemories`.
- *
- * Seeds a large fixture (≥2k rooms / ≥200k message rows) and proves that the
- * keyword search is backed by a single pushed-down SQL `ILIKE` predicate — not
- * a "fetch every row, scan in JS" pattern — that it returns correct rows across
- * conversations, that it reaches a hit far outside the recent window, and that
- * the query stays bounded in latency.
- *
- * Default mode: PGlite (WASM, in-process). Set `POSTGRES_URL` to run against a
- * real Postgres for a higher row count / tighter latency assertions.
- */
 
 const ROOMS = Number(process.env.KEYWORD_SEARCH_TEST_ROOMS ?? 2_000);
 const MESSAGES_PER_ROOM = Number(process.env.KEYWORD_SEARCH_TEST_MESSAGES_PER_ROOM ?? 100);

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-contains.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-contains.real.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Focused correctness test for the keyword (`textContains`) predicate on the
+ * SQL `getMemories` path — the small, fast complement to the 200k-row
+ * `memory-keyword-search.real.test.ts` scale test.
+ *
+ * It pins the load-bearing details the scale test cannot exercise cheaply:
+ * literal `_` and backslash escaping (not just `%`), AND-composition with the
+ * existing `roomId` / `tableName` filters, and that the predicate targets
+ * `content->>'text'` ONLY (a token hidden in another `content` field or in
+ * `metadata` must NOT match). Runs on PGlite by default; set `POSTGRES_URL`
+ * to run against a real Postgres.
+ */
 import {
   ChannelType,
   type Content,
@@ -17,18 +29,6 @@ import { embeddingTable, memoryTable } from "../../schema";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
-/**
- * Focused correctness test for the keyword (`textContains`) predicate on the
- * SQL `getMemories` path — the small, fast complement to the 200k-row
- * `memory-keyword-search.real.test.ts` scale test.
- *
- * It pins the load-bearing details the scale test cannot exercise cheaply:
- * literal `_` and backslash escaping (not just `%`), AND-composition with the
- * existing `roomId` / `tableName` filters, and that the predicate targets
- * `content->>'text'` ONLY (a token hidden in another `content` field or in
- * `metadata` must NOT match). Runs on PGlite by default; set `POSTGRES_URL`
- * to run against a real Postgres.
- */
 describe("getMemories textContains keyword filter (real SQL adapter)", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
   let cleanup: () => Promise<void>;

--- a/plugins/plugin-sql/src/__tests__/integration/memory-worldid.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-worldid.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Every memory READ path (`getMemories`, `getMemoriesByRoomIds`,
+ * `getMemoryById`, `getMemoriesByIds`) must map the stored `worldId` back
+ * onto the returned `Memory`, against a real isolated PGlite/Postgres
+ * adapter — consumers that round-trip a fetched memory (e.g. agent-export
+ * restore, which remaps `mem.worldId`) depend on every path agreeing.
+ */
 import {
   ChannelType,
   type Entity,
@@ -12,15 +19,6 @@ import type { PgDatabaseAdapter } from "../../pg/adapter";
 import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
 import { createIsolatedTestDatabase } from "../test-helpers";
 
-/**
- * Every memory READ path must return the stored `worldId`.
- *
- * Pre-fix, only searchMemoriesByEmbedding mapped `worldId` back onto the
- * returned Memory; getMemories / getMemoriesByRoomIds / getMemoryById /
- * getMemoriesByIds silently dropped it, so consumers that round-trip a
- * fetched memory (e.g. agent-export -> restore, which remaps `mem.worldId`)
- * permanently lost every memory→world association.
- */
 describe("Memory worldId round-trip", () => {
   let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
   let cleanup: () => Promise<void>;

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for the memory CRUD/retrieval/search surface against a
+ * real isolated PGlite/Postgres adapter: create/update/delete, partial and
+ * nested-partial metadata updates, room/id-list/pagination reads, embedding
+ * search, document+fragment cascade delete, and Memory<->MemoryModel field
+ * mapping.
+ */
 import {
   ChannelType,
   type Content,
@@ -45,7 +52,6 @@ describe("Memory Integration Tests", () => {
       cleanup = setup.cleanup;
       testAgentId = setup.testAgentId;
 
-      // Use random UUIDs to avoid conflicts
       testRoomId = v4() as UUID;
       testEntityId = v4() as UUID;
       testWorldId = v4() as UUID;
@@ -76,7 +82,7 @@ describe("Memory Integration Tests", () => {
       await adapter.addParticipant(testEntityId, testRoomId);
     } catch (error) {
       console.error("Failed to create test database for memory tests:", error);
-      throw error; // Fail the test instead of continuing
+      throw error;
     }
   });
 
@@ -211,10 +217,8 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should perform partial updates without affecting other fields", async () => {
-      // Create a complete memory first with content, metadata and embedding
       const memory = {
         ...memoryTestMemoriesWithEmbedding[0],
-        // Override with correct test IDs
         agentId: testAgentId,
         entityId: testEntityId,
         roomId: testRoomId,
@@ -228,7 +232,6 @@ describe("Memory Integration Tests", () => {
 
       const memoryId = await adapter.createMemory(memory, "memories");
 
-      // Update only content
       const contentUpdate = {
         id: memoryId,
         content: {
@@ -239,7 +242,6 @@ describe("Memory Integration Tests", () => {
 
       await adapter.updateMemory(contentUpdate);
 
-      // Verify only content changed, embedding and metadata preserved
       const afterContentUpdate = await adapter.getMemoryById(memoryId);
       expect(afterContentUpdate).not.toBeNull();
       if (!afterContentUpdate) throw new Error("Memory should exist");
@@ -250,7 +252,6 @@ describe("Memory Integration Tests", () => {
       );
       expect(afterContentUpdate.metadata).toEqual(memory.metadata);
 
-      // Update only one field in metadata
       const metadataUpdate = {
         id: memoryId,
         metadata: {
@@ -263,7 +264,6 @@ describe("Memory Integration Tests", () => {
 
       await adapter.updateMemory(metadataUpdate);
 
-      // Verify partial metadata update behaves as expected
       const afterMetadataUpdate = await adapter.getMemoryById(memoryId);
       expect(afterMetadataUpdate).not.toBeNull();
       if (!afterMetadataUpdate) throw new Error("Memory should exist");
@@ -278,10 +278,8 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should perform nested partial updates without overriding existing fields", async () => {
-      // Create a memory with rich content and metadata
       const originalMemory = {
         ...memoryTestMemoriesWithEmbedding[0],
-        // Override with correct test IDs
         agentId: testAgentId,
         entityId: testEntityId,
         roomId: testRoomId,
@@ -313,7 +311,6 @@ describe("Memory Integration Tests", () => {
 
       await adapter.updateMemory(contentTextUpdate);
 
-      // Verify content was updated but metadata preserved
       const afterContentTextUpdate = await adapter.getMemoryById(memoryId);
       expect(afterContentTextUpdate).not.toBeNull();
       if (!afterContentTextUpdate) throw new Error("Memory should exist");
@@ -337,7 +334,6 @@ describe("Memory Integration Tests", () => {
 
       await adapter.updateMemory(sourceUpdate);
 
-      // Verify metadata was updated and content preserved
       const afterSourceUpdate = await adapter.getMemoryById(memoryId);
       expect(afterSourceUpdate).not.toBeNull();
       if (!afterSourceUpdate || !afterContentTextUpdate) throw new Error("Memory should exist");
@@ -427,11 +423,9 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should retrieve memories by ID list", async () => {
-      // Create test memories and collect their IDs
       const memoryIds: UUID[] = [];
 
       for (const memory of memoryTestMemories.slice(0, 2)) {
-        // Override with correct test IDs
         const testMemory = {
           ...memory,
           agentId: testAgentId,
@@ -442,7 +436,6 @@ describe("Memory Integration Tests", () => {
         memoryIds.push(memoryId);
       }
 
-      // Retrieve memories by IDs
       const memories = await adapter.getMemoriesByIds(memoryIds, "memories");
 
       expect(memories).toHaveLength(2);
@@ -450,9 +443,7 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should retrieve memories with pagination", async () => {
-      // Create test memories
       for (const memory of memoryTestMemories) {
-        // Override with correct test IDs
         const testMemory = {
           ...memory,
           agentId: testAgentId,
@@ -462,7 +453,6 @@ describe("Memory Integration Tests", () => {
         await adapter.createMemory(testMemory, "memories");
       }
 
-      // Retrieve first page (limit to 2)
       const firstPage = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -471,20 +461,15 @@ describe("Memory Integration Tests", () => {
 
       expect(firstPage).toHaveLength(2);
 
-      // Test second page (remaining memories)
       const secondPage = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
       });
 
-      // There should be at least 3 memories total
       expect(secondPage.length).toBeGreaterThanOrEqual(memoryTestMemories.length);
     });
 
     it("should apply a LIMIT clause when only `limit` is passed (not `count`)", async () => {
-      // Regression: getMemories previously only honored `count`, so callers that
-      // passed the canonical `limit` param (recent-messages provider, attachments,
-      // autonomy history, etc.) received the full unbounded result set.
       for (const content of ["lim1", "lim2", "lim3", "lim4", "lim5"]) {
         await adapter.createMemory(createTestMemory({ text: content }), "memories");
       }
@@ -511,13 +496,11 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should retrieve memories with offset for pagination", async () => {
-      // Create 5 test memories with known content
       const memoryContents = ["mem1", "mem2", "mem3", "mem4", "mem5"];
       for (const content of memoryContents) {
         await adapter.createMemory(createTestMemory({ text: content }), "memories");
       }
 
-      // First page: get first 2 memories
       const firstPage = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -526,7 +509,6 @@ describe("Memory Integration Tests", () => {
       });
       expect(firstPage).toHaveLength(2);
 
-      // Second page: skip first 2, get next 2
       const secondPage = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -535,7 +517,6 @@ describe("Memory Integration Tests", () => {
       });
       expect(secondPage).toHaveLength(2);
 
-      // Third page: skip first 4, get remaining
       const thirdPage = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -544,26 +525,22 @@ describe("Memory Integration Tests", () => {
       });
       expect(thirdPage).toHaveLength(1);
 
-      // Verify no overlap between pages
       const allIds = [...firstPage, ...secondPage, ...thirdPage].map((m) => m.id);
       const uniqueIds = new Set(allIds);
       expect(allIds.length).toBe(uniqueIds.size);
     });
 
     it("should handle offset without count parameter", async () => {
-      // Create 5 test memories
       for (let i = 0; i < 5; i++) {
         await adapter.createMemory(createTestMemory({ text: `mem${i}` }), "memories");
       }
 
-      // Get all memories
       const allMemories = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
       });
       expect(allMemories.length).toBe(5);
 
-      // Get memories with only offset (skip first 2)
       const withOffset = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -571,19 +548,16 @@ describe("Memory Integration Tests", () => {
       });
       expect(withOffset.length).toBe(3);
 
-      // Verify the offset memories are the last 3 of all memories
       const lastThreeIds = allMemories.slice(2).map((m) => m.id);
       const offsetIds = withOffset.map((m) => m.id);
       expect(offsetIds).toEqual(lastThreeIds);
     });
 
     it("should handle edge cases for offset pagination", async () => {
-      // Create 3 test memories
       for (let i = 0; i < 3; i++) {
         await adapter.createMemory(createTestMemory({ text: `mem${i}` }), "memories");
       }
 
-      // Offset beyond available memories
       const beyondOffset = await adapter.getMemories({
         roomId: testRoomId,
         tableName: "memories",
@@ -612,10 +586,8 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should reject negative offset values", async () => {
-      // Create a test memory
       await adapter.createMemory(createTestMemory({ text: "test" }), "memories");
 
-      // Attempt to use negative offset
       await expect(
         adapter.getMemories({
           roomId: testRoomId,
@@ -624,7 +596,6 @@ describe("Memory Integration Tests", () => {
         })
       ).rejects.toThrow("offset must be a non-negative number");
 
-      // Attempt to use another negative offset
       await expect(
         adapter.getMemories({
           roomId: testRoomId,
@@ -636,17 +607,14 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should maintain consistent pagination results with countMemories", async () => {
-      // Create 10 test memories
       const totalMemories = 10;
       for (let i = 0; i < totalMemories; i++) {
         await adapter.createMemory(createTestMemory({ text: `mem${i}` }), "memories");
       }
 
-      // Get total count
       const totalCount = await adapter.countMemories(testRoomId, false, "memories");
       expect(totalCount).toBe(totalMemories);
 
-      // Paginate through all memories
       const pageSize = 3;
       const totalPages = Math.ceil(totalCount / pageSize);
       const allPaginatedMemories: Memory[] = [];
@@ -661,10 +629,8 @@ describe("Memory Integration Tests", () => {
         allPaginatedMemories.push(...pageMemories);
       }
 
-      // Verify we got all memories through pagination
       expect(allPaginatedMemories.length).toBe(totalMemories);
 
-      // Verify all IDs are unique (no duplicates from pagination)
       const ids = allPaginatedMemories.map((m) => m.id);
       const uniqueIds = new Set(ids);
       expect(ids.length).toBe(uniqueIds.size);
@@ -699,7 +665,6 @@ describe("Memory Integration Tests", () => {
 
   describe("Document and Fragment Operations", () => {
     it("should create a document with fragments", async () => {
-      // Create the document with correct test IDs
       const testDocument = {
         ...memoryTestDocument,
         agentId: testAgentId,
@@ -708,7 +673,6 @@ describe("Memory Integration Tests", () => {
       };
       await adapter.createMemory(testDocument, "documents");
 
-      // Create fragments that reference the document with correct test IDs
       for (const fragment of memoryTestFragments) {
         const testFragment = {
           ...fragment,
@@ -719,7 +683,6 @@ describe("Memory Integration Tests", () => {
         await adapter.createMemory(testFragment, "fragments");
       }
 
-      // Retrieve fragments for the document
       const fragments = await adapter.getMemories({
         tableName: "fragments",
         roomId: testRoomId,
@@ -729,7 +692,6 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should delete a document and its fragments", async () => {
-      // Create the document with correct test IDs
       const testDocument = {
         ...memoryTestDocument,
         agentId: testAgentId,
@@ -738,7 +700,6 @@ describe("Memory Integration Tests", () => {
       };
       await adapter.createMemory(testDocument, "documents");
 
-      // Create fragments that reference the document with correct test IDs
       for (const fragment of memoryTestFragments) {
         const testFragment = {
           ...fragment,
@@ -749,14 +710,12 @@ describe("Memory Integration Tests", () => {
         await adapter.createMemory(testFragment, "fragments");
       }
 
-      // Delete the document (should cascade to fragments)
+      // Deleting the document must cascade to its fragments.
       await adapter.deleteMemory(documentMemoryId);
 
-      // Verify document is deleted
       const document = await adapter.getMemoryById(documentMemoryId);
       expect(document).toBeNull();
 
-      // Verify fragments are also deleted
       const fragments = await adapter.getMemories({
         tableName: "fragments",
         roomId: testRoomId,
@@ -775,15 +734,12 @@ describe("Memory Integration Tests", () => {
         roomId: testRoomId,
       };
 
-      // Create the memory
       await adapter.createMemory(testMemory, "memories");
 
-      // Retrieve it from database
       const retrievedMemory = await adapter.getMemoryById(testMemory.id as UUID);
       expect(retrievedMemory).not.toBeNull();
       if (!retrievedMemory) throw new Error("Memory should exist");
 
-      // Verify all fields were properly mapped
       expect(retrievedMemory.id).toBe(testMemory.id as UUID);
       expect(retrievedMemory.entityId).toBe(testMemory.entityId);
       expect(retrievedMemory.roomId).toBe(testMemory.roomId);
@@ -797,10 +753,8 @@ describe("Memory Integration Tests", () => {
     });
 
     it("should handle partial Memory objects in mapToMemoryModel", async () => {
-      // Create a unique entity ID for this test to avoid conflicts
       const uniqueEntityId = v4() as UUID;
 
-      // Create the required entity first to avoid foreign key constraint violations
       await adapter.createEntities([
         {
           id: uniqueEntityId,
@@ -809,9 +763,8 @@ describe("Memory Integration Tests", () => {
         } as Entity,
       ]);
 
-      // Create a partial memory object
       const partialMemory: Partial<Memory> = {
-        id: memoryTestAgentId, // Using a known UUID
+        id: memoryTestAgentId,
         entityId: uniqueEntityId,
         roomId: testRoomId,
         agentId: testAgentId,
@@ -821,15 +774,12 @@ describe("Memory Integration Tests", () => {
         },
       };
 
-      // Create the memory
       await adapter.createMemory(partialMemory as Partial<Memory>, "memories");
 
-      // Retrieve it from database
       const retrievedMemory = await adapter.getMemoryById(partialMemory.id as UUID);
       expect(retrievedMemory).not.toBeNull();
       if (!retrievedMemory) throw new Error("Memory should exist");
 
-      // Verify fields were properly mapped with defaults where applicable
       expect(retrievedMemory.id).toBe(partialMemory.id);
       expect(retrievedMemory.entityId).toBe(partialMemory.entityId);
       expect(retrievedMemory.roomId).toBe(partialMemory.roomId);
@@ -843,10 +793,8 @@ describe("Memory Integration Tests", () => {
 
   describe("Memory Batch Operations", () => {
     it("should delete all memories in a room", async () => {
-      // Create a unique entity ID for this test to avoid conflicts
       const uniqueEntityId = v4() as UUID;
 
-      // Create the required entity first to avoid foreign key constraint violations
       await adapter.createEntities([
         {
           id: uniqueEntityId,
@@ -855,7 +803,6 @@ describe("Memory Integration Tests", () => {
         } as Entity,
       ]);
 
-      // Create test memories with correct entity IDs
       for (const memory of memoryTestMemories) {
         const testMemory = {
           ...memory,
@@ -866,14 +813,11 @@ describe("Memory Integration Tests", () => {
         await adapter.createMemory(testMemory, "memories");
       }
 
-      // Verify memories exist
       const countBefore = await adapter.countMemories(testRoomId, true, "memories");
       expect(countBefore).toBeGreaterThan(0);
 
-      // Delete all memories
       await adapter.deleteAllMemories(testRoomId, "memories");
 
-      // Verify memories were deleted
       const countAfter = await adapter.countMemories(testRoomId, true, "memories");
       expect(countAfter).toBe(0);
     });
@@ -891,17 +835,14 @@ describe("Memory Integration Tests", () => {
         },
       ]);
 
-      // Create memories in the first room
       await adapter.createMemory(createTestMemory({ text: "mem1-room1" }), "memories");
       await adapter.createMemory(createTestMemory({ text: "mem2-room1" }), "memories");
 
-      // Create memories in the second room
       await adapter.createMemory(
         { ...createTestMemory({ text: "mem3-room2" }), roomId: secondRoomId },
         "memories"
       );
 
-      // Retrieve memories from both rooms
       const memories = await adapter.getMemoriesByRoomIds({
         roomIds: [testRoomId, secondRoomId],
         tableName: "memories",
@@ -912,8 +853,6 @@ describe("Memory Integration Tests", () => {
   });
 
   it("should properly convert metadata objects to JSON when updating only metadata", async () => {
-    // This test specifically verifies the fix for the bug where metadata objects
-    // were being sent as [object Object] instead of proper JSON
     await adapter.ensureEmbeddingDimension(768);
     const memory = {
       entityId: testEntityId,
@@ -936,7 +875,6 @@ describe("Memory Integration Tests", () => {
     const memoryId = await adapter.createMemory(memory, "memory");
     expect(memoryId).toBeDefined();
 
-    // Update only metadata with a complex object
     const complexMetadata = {
       type: "updated",
       source: "test-update",
@@ -960,12 +898,11 @@ describe("Memory Integration Tests", () => {
 
     expect(updateResult).toBe(true);
 
-    // Verify the metadata was properly stored
     const updated = await adapter.getMemoryById(memoryId);
     expect(updated).not.toBeNull();
     if (!updated) throw new Error("Memory should exist");
     expect(updated.metadata).toEqual(complexMetadata);
     const content = updated.content as Record<string, unknown>;
-    expect(content.text).toBe("Initial content"); // Content should be unchanged
+    expect(content.text).toBe("Initial content");
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/messaging.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/messaging.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Integration tests for message server/channel/participant persistence and
+ * server-scoped memory retrieval, against a real isolated PGlite/Postgres
+ * adapter.
+ */
 import { ChannelType, type Content, type Memory, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/plugins/plugin-sql/src/__tests__/integration/participant.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/participant.real.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Integration tests for room participant add/remove/state against a real
+ * isolated PGlite/Postgres adapter.
+ */
 import { type AgentRuntime, ChannelType, type Entity, type Room, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -22,11 +26,9 @@ describe("Participant Integration Tests", () => {
     cleanup = setup.cleanup;
     testAgentId = setup.testAgentId;
 
-    // Generate random UUIDs for test data
     testRoomId = uuidv4() as UUID;
     testEntityId = uuidv4() as UUID;
 
-    // Create test room and entity
     await adapter.createRooms([
       {
         id: testRoomId,
@@ -86,16 +88,13 @@ describe("Participant Integration Tests", () => {
     });
 
     it("should check if entity is room participant", async () => {
-      // Initially not a participant
       let isParticipant = await adapter.isRoomParticipant(testRoomId, testEntityId);
       expect(isParticipant).toBe(false);
 
-      // Add as participant
       await adapter.addParticipant(testEntityId, testRoomId);
       isParticipant = await adapter.isRoomParticipant(testRoomId, testEntityId);
       expect(isParticipant).toBe(true);
 
-      // Remove participant
       await adapter.removeParticipant(testEntityId, testRoomId);
       isParticipant = await adapter.isRoomParticipant(testRoomId, testEntityId);
       expect(isParticipant).toBe(false);

--- a/plugins/plugin-sql/src/__tests__/integration/pglite-e2e.real.e2e.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/pglite-e2e.real.e2e.test.ts
@@ -1,3 +1,9 @@
+/**
+ * End-to-end tests for `PgliteDatabaseAdapter` across the full adapter
+ * surface (agents, entities, memories, components, concurrency, error
+ * handling) against a real in-process PGlite instance with migrations
+ * applied — no mocks, standing in for a real PostgreSQL backend.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import type { Agent, ChannelType, Component, Entity, Memory, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
@@ -9,7 +15,6 @@ import * as schema from "../../schema";
 import type { DrizzleDatabase } from "../../types";
 import { expectCreatedEntityIds } from "./entity-create-assertions";
 
-// Use PGLite for testing instead of real PostgreSQL
 describe("PostgreSQL E2E Tests", () => {
   const createTestAdapter = async () => {
     const client = new PGlite();
@@ -18,7 +23,6 @@ describe("PostgreSQL E2E Tests", () => {
     const adapter = new PgliteDatabaseAdapter(agentId, manager);
     await adapter.init();
 
-    // Run migrations for each adapter
     const migrationService = new DatabaseMigrationService();
     const db = adapter.getDatabase() as DrizzleDatabase;
     await migrationService.initializeWithDatabase(db);
@@ -123,7 +127,6 @@ describe("PostgreSQL E2E Tests", () => {
     it("should create and retrieve entities", async () => {
       const { adapter, agentId } = await createTestAdapter();
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",
@@ -163,7 +166,6 @@ describe("PostgreSQL E2E Tests", () => {
     it("should update an entity", async () => {
       const { adapter, agentId } = await createTestAdapter();
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",
@@ -204,7 +206,6 @@ describe("PostgreSQL E2E Tests", () => {
       adapter = result.adapter;
       agentId = result.agentId;
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",
@@ -213,7 +214,6 @@ describe("PostgreSQL E2E Tests", () => {
       roomId = uuidv4() as UUID;
       entityId = uuidv4() as UUID;
 
-      // Create room first
       await adapter.createRooms([
         {
           id: roomId,
@@ -224,7 +224,6 @@ describe("PostgreSQL E2E Tests", () => {
         },
       ]);
 
-      // Create required entity
       await adapter.createEntities([
         {
           id: entityId,
@@ -379,7 +378,6 @@ describe("PostgreSQL E2E Tests", () => {
       adapter = result.adapter;
       agentId = result.agentId;
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",
@@ -397,7 +395,6 @@ describe("PostgreSQL E2E Tests", () => {
         name: "Test World",
       });
 
-      // Create room
       await adapter.createRooms([
         {
           id: roomId,
@@ -512,7 +509,6 @@ describe("PostgreSQL E2E Tests", () => {
     it("should handle concurrent operations", async () => {
       const { adapter, agentId } = await createTestAdapter();
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",
@@ -540,7 +536,6 @@ describe("PostgreSQL E2E Tests", () => {
     it("should handle large batch operations", async () => {
       const { adapter, agentId } = await createTestAdapter();
 
-      // Create agent first
       await adapter.createAgent({
         id: agentId,
         name: "Test Agent",

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/pg-adapter-integration.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/pg-adapter-integration.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Direct integration tests for `PgliteDatabaseAdapter`/`PGliteClientManager`
+ * against a real in-process PGlite instance (Postgres-compatible surface):
+ * raw SQL, transactions, JSON/array/timestamp operations, error recovery,
+ * and adapter shutdown.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import type { UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
@@ -22,7 +28,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
       adapter = new PgliteDatabaseAdapter(testAgentId, manager);
       await adapter.init();
 
-      // Run migrations
       const migrationService = new DatabaseMigrationService();
       const db = adapter.getDatabase() as DrizzleDatabase;
       await migrationService.initializeWithDatabase(db);
@@ -33,7 +38,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
     });
 
     afterAll(async () => {
-      // Clean up test data
       const db = adapter.getDatabase() as DrizzleDatabase;
       await db.execute(sql`DELETE FROM agents WHERE id = ${testAgentId}`);
       await adapter.close();
@@ -77,7 +81,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
       it("should handle transactions through adapter", async () => {
         const db = adapter.getDatabase() as DrizzleDatabase;
 
-        // Create test table
         await db.execute(sql`
           CREATE TABLE IF NOT EXISTS pg_adapter_test (
             id SERIAL PRIMARY KEY,
@@ -86,7 +89,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
         `);
 
         try {
-          // Test transaction
           await db.transaction(async (tx) => {
             await tx.execute(sql`INSERT INTO pg_adapter_test (value) VALUES (100)`);
             await tx.execute(sql`INSERT INTO pg_adapter_test (value) VALUES (200)`);
@@ -98,7 +100,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
 
           expect(Number(result.rows[0].total)).toBe(300);
         } finally {
-          // Clean up
           await db.execute(sql`DROP TABLE IF EXISTS pg_adapter_test`);
         }
       });
@@ -154,7 +155,6 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
       it("should handle multiple operations", async () => {
         const db = adapter.getDatabase() as DrizzleDatabase;
 
-        // Execute multiple operations
         const results = await Promise.all([
           db.execute(sql`SELECT 1 as id`),
           db.execute(sql`SELECT 2 as id`),
@@ -186,14 +186,12 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
       it("should maintain connection after error", async () => {
         const db = adapter.getDatabase() as DrizzleDatabase;
 
-        // Cause an error
         try {
           await db.execute(sql`INVALID SQL`);
         } catch (_e) {
-          // Expected error
+          // Expected — the query itself is invalid.
         }
 
-        // Connection should still work
         const result = await db.execute(sql`SELECT 1 as value`);
         expect(result.rows[0].value).toBe(1);
       });
@@ -272,16 +270,13 @@ describe("PostgreSQL Adapter Direct Integration Tests", () => {
 
     describe("Adapter Shutdown", () => {
       it("should handle close gracefully", async () => {
-        // Create a temporary adapter
         const tempClient = new PGlite();
         const tempManager = new PGliteClientManager(tempClient);
         const tempAdapter = new PgliteDatabaseAdapter(uuidv4() as UUID, tempManager);
         await tempAdapter.init();
 
-        // Close it
         await tempAdapter.close();
 
-        // Should not be ready after close
         const isReady = await tempAdapter.isReady();
         expect(isReady).toBe(false);
       });

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-adapter.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-adapter.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises PgliteDatabaseAdapter and PGliteClientManager against a real
+ * in-memory PGlite instance (WASM Postgres) with migrations run through
+ * DatabaseMigrationService — connection lifecycle, withDatabase error
+ * propagation, and agent CRUD.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import type { Agent, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests for `PGliteClientManager`'s file-backed single-writer lock: rejects
+ * a second manager while the first is confirmed live, reclaims a lock left
+ * by a dead or reused PID, and reclaims unconditionally in mobile embedded
+ * mode where the liveness probe is unusable. Writes real lock files to a
+ * temp dir and exercises the real manager constructor — no mocked lock
+ * logic, only `readLinuxProcessStartedAtMs` is spied for the PID-reuse case.
+ */
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
@@ -1,3 +1,13 @@
+/**
+ * PostgreSQL RLS entity-isolation integration tests against a real Postgres
+ * with RLS enabled (`docker-compose up -d postgres`). Verifies entity-level
+ * isolation (user privacy), participant-based access control (room
+ * membership), Entity RLS composing with Server RLS (double isolation), and
+ * that `PostgresConnectionManager.withEntityContext()` sets the RLS entity
+ * context via the parameterized, transaction-scoped
+ * `set_config('app.entity_id', $1, true)` form — this exercises the real
+ * production code path, not a raw-interpolation stand-in.
+ */
 import { stringToUuid, type UUID } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { Client } from "pg";
@@ -5,24 +15,6 @@ import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { PostgresConnectionManager } from "../../../pg/manager";
 import { bootstrapPostgresRlsSchema, toPostgresSuperuserUrl } from "./rls-test-helpers";
-
-/**
- * PostgreSQL RLS Entity Integration Tests
- *
- * These tests require a real PostgreSQL database with RLS enabled.
- * Run with: docker-compose up -d postgres
- *
- * Tests verify:
- * - Entity-level isolation (user privacy)
- * - Participant-based access control (room membership)
- * - Entity RLS works with Server RLS (double isolation)
- * - withEntityContext() correctly sets entity context (regression test for the
- *   parameterized set_config() RLS context)
- *
- * IMPORTANT: Uses PostgresConnectionManager.withEntityContext() to test the actual
- * production code path. This exercises the parameterized set_config('app.entity_id', $1, true)
- * form (transaction-scoped), so the entity context applies without raw interpolation.
- */
 
 // Skip these tests if POSTGRES_URL is not set (e.g., in CI without PostgreSQL)
 describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", () => {
@@ -209,9 +201,8 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Entity Integration", 
   });
 
   it("should allow Alice to see room1 memories (tests withEntityContext + sql.raw fix)", async () => {
-    // This test verifies the production code path works:
-    // withEntityContext() -> sql.raw(`SET LOCAL app.entity_id = '${entityId}'`)
-    // Before the fix, this would fail with "syntax error at or near $1"
+    // Exercises the production path: withEntityContext() ->
+    // sql.raw(`SET LOCAL app.entity_id = '${entityId}'`).
     const result = await manager.withEntityContext(aliceId as UUID, async (tx) => {
       return await tx.execute(sql`SELECT id, room_id, content FROM memories`);
     });

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-logs.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-logs.real.test.ts
@@ -1,24 +1,15 @@
+/**
+ * PostgreSQL RLS integration tests for the `logs` table's STRICT entity
+ * isolation: logs hold sensitive activity data (model usage, embeddings)
+ * and must be visible only to entities participating in the log's room, with
+ * zero rows returned when no entity context is set. All connections use the
+ * `eliza_test` role (not superuser); `application_name` supplies the server
+ * context for RLS.
+ */
 import { Client } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { bootstrapPostgresRlsSchema } from "./rls-test-helpers";
-
-/**
- * PostgreSQL RLS Logs Integration Tests
- *
- * These tests verify that the `logs` table has STRICT Entity RLS isolation.
- * Logs contain sensitive user activity data (model usage, embeddings, etc.)
- * and must be isolated by entity participation in rooms.
- *
- * Tests verify:
- * - Logs are isolated by entity (user can only see their own logs)
- * - Logs from shared rooms are visible to all participants
- * - Logs from non-participant rooms are blocked
- * - withEntityContext() is required for log insertion
- *
- * Uses eliza_test user for ALL connections (not superuser) - the application_name
- * provides server context for RLS.
- */
 
 describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STRICT)", () => {
   let setupClient: Client; // Setup client with server context
@@ -160,9 +151,8 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STR
   });
 
   afterAll(async () => {
-    // Cleanup test data (need entity context for STRICT tables)
+    // Deletes need entity context because logs is a STRICT-RLS table.
     try {
-      // Delete logs with entity context
       await setupClient.query("BEGIN");
       await setupClient.query(`SET LOCAL app.entity_id = '${aliceId}'`);
       await setupClient.query(`DELETE FROM logs WHERE room_id IN ($1, $2)`, [
@@ -176,7 +166,6 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STR
       await setupClient.query(`DELETE FROM logs WHERE room_id = $1`, [bobPrivateRoomId]);
       await setupClient.query("COMMIT");
 
-      // Delete other data (non-STRICT tables)
       await setupClient.query(`DELETE FROM participants WHERE room_id IN ($1, $2, $3)`, [
         sharedRoomId,
         alicePrivateRoomId,
@@ -194,7 +183,6 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STR
       console.warn("[RLS Logs Test] Cleanup failed:", err);
     }
 
-    // Close connections
     if (setupClient) await setupClient.end();
     if (aliceClient) await aliceClient.end();
     if (bobClient) await bobClient.end();
@@ -226,7 +214,6 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STR
   });
 
   it("should isolate Alice logs from Bob (Alice sees 2, Bob sees 1)", async () => {
-    // Alice should see her 2 logs (shared room + private room)
     await aliceClient.query("BEGIN");
     await aliceClient.query(`SET LOCAL app.entity_id = '${aliceId}'`);
     const aliceResult = await aliceClient.query(
@@ -243,7 +230,6 @@ describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS - Logs Isolation (STR
     expect(aliceResult.rows).toHaveLength(2);
     expect(aliceResult.rows.every((row) => row.entity_id === aliceId)).toBe(true);
 
-    // Bob should see his 1 log (private room only)
     await bobClient.query("BEGIN");
     await bobClient.query(`SET LOCAL app.entity_id = '${bobId}'`);
     const bobResult = await bobClient.query(

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-message-server-agents.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-message-server-agents.real.test.ts
@@ -1,17 +1,15 @@
+/**
+ * PostgreSQL RLS integration tests for `message_server_agents`: verifies
+ * Server A cannot see, join across, modify, or delete Server B's associations
+ * — isolating Discord/Telegram server associations by `server_id`. All
+ * connections use the `eliza_test` role (not superuser); `application_name`
+ * supplies each server's RLS context, and each server's data is set up via
+ * its own connection.
+ */
 import { Client } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { bootstrapPostgresRlsSchema } from "./rls-test-helpers";
-
-/**
- * PostgreSQL RLS Integration Tests for message_server_agents
- *
- * Tests verify that Server A cannot see message_server_agents entries from Server B
- * This ensures proper isolation of Discord/Telegram server associations
- *
- * Uses eliza_test user for ALL connections (not superuser) - the application_name
- * provides server context for RLS. Each server's data is set up via its own connection.
- */
 
 describe.skipIf(!process.env.POSTGRES_URL)(
   "PostgreSQL RLS - message_server_agents Isolation",

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-server.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-server.real.test.ts
@@ -1,22 +1,14 @@
+/**
+ * PostgreSQL RLS integration tests for server-level isolation between
+ * different elizaOS instances sharing one database: enforced for
+ * non-superuser accounts, using the `eliza_test` role for all connections
+ * (`application_name` supplies each server's RLS context). Verifies data is
+ * completely isolated between servers.
+ */
 import { Client } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { bootstrapPostgresRlsSchema } from "./rls-test-helpers";
-
-/**
- * PostgreSQL RLS Server Integration Tests
- *
- * These tests require a real PostgreSQL database with RLS enabled.
- * Run with: docker-compose up -d postgres
- *
- * Tests verify:
- * - Server-level isolation between different elizaOS instances
- * - RLS policies are enforced for non-superuser accounts
- * - Data is completely isolated between servers
- *
- * Uses eliza_test user for ALL connections (not superuser) - the application_name
- * provides server context for RLS. Each server's data is set up via its own connection.
- */
 
 // Skip these tests if POSTGRES_URL is not set (e.g., in CI without PostgreSQL)
 describe.skipIf(!process.env.POSTGRES_URL)("PostgreSQL RLS Server Integration", () => {

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-test-helpers.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-test-helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared setup for the Postgres RLS integration tests in this directory:
+ * `bootstrapPostgresRlsSchema` wipes the target database (superuser),
+ * re-runs migrations, installs RLS functions/policies, and grants the
+ * non-superuser `eliza_test` role table/sequence access so the tests can
+ * exercise RLS as that role. `toPostgresSuperuserUrl` derives the
+ * superuser connection string used for the wipe/grant steps.
+ */
 import type { IDatabaseAdapter } from "@elizaos/core";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";

--- a/plugins/plugin-sql/src/__tests__/integration/relationship.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/relationship.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Integration tests for entity relationship create/update/retrieve against a
+ * real isolated PGlite/Postgres adapter, including duplicate-pair dedup and
+ * tag-scoped lookups.
+ */
 import type { AgentRuntime, Entity, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -22,11 +27,9 @@ describe("Relationship Integration Tests", () => {
     cleanup = setup.cleanup;
     testAgentId = setup.testAgentId;
 
-    // Generate random UUIDs for test data
     testEntityId = uuidv4() as UUID;
     testTargetEntityId = uuidv4() as UUID;
 
-    // Create test entities
     await adapter.createEntities([
       {
         id: testEntityId,

--- a/plugins/plugin-sql/src/__tests__/integration/room.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/room.real.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Room-store CRUD tests against a real PGlite (or Postgres, if `POSTGRES_URL`
+ * is set) adapter via `createIsolatedTestDatabase` — no mocks.
+ */
 import { type AgentRuntime, ChannelType, type Room, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -20,7 +24,6 @@ describe("Room Integration Tests", () => {
     cleanup = setup.cleanup;
     testAgentId = setup.testAgentId;
 
-    // Create a test world
     testWorldId = uuidv4() as UUID;
     await adapter.createWorld({
       id: testWorldId,

--- a/plugins/plugin-sql/src/__tests__/integration/seed/embedding-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/embedding-seed.ts
@@ -1,3 +1,9 @@
+/**
+ * Fixture agent/room/entity/memory/embedding records for the embedding
+ * integration tests — deterministic (fixed UUIDs, seeded IDs) so query
+ * results are stable across runs, covering the 384/512/768-dim embedding
+ * cases.
+ */
 import {
   type Agent,
   AgentStatus,
@@ -8,17 +14,15 @@ import {
   type UUID,
 } from "@elizaos/core";
 
-// Generate fixed UUIDs for testing to avoid type issues
+// Fixed UUID so fixtures are stable across runs instead of type-widened strings.
 const fixedUuid = (n: number): UUID =>
   `${"0".repeat(8)}-${"0".repeat(4)}-${"0".repeat(4)}-${"0".repeat(4)}-${n.toString().padStart(12, "0")}`;
 
-// Test IDs
 export const embeddingTestAgentId = fixedUuid(1);
 export const embeddingTestRoomId = fixedUuid(2);
 export const embeddingTestEntityId = fixedUuid(3);
 export const embeddingTestWorldId = fixedUuid(4);
 
-// Random vector generator for testing
 export const generateRandomVector = (size: number): number[] => {
   return Array.from({ length: size }, () => (Math.random() * 2 - 1) * 0.1);
 };
@@ -51,7 +55,6 @@ export const embeddingTestAgent = {
   },
 } as Agent;
 
-// Test Entity
 export const embeddingTestEntity: Entity = {
   id: embeddingTestEntityId,
   names: ["Test Entity"],
@@ -61,7 +64,6 @@ export const embeddingTestEntity: Entity = {
   },
 };
 
-// Test Room
 export const embeddingTestRoom: Room = {
   id: embeddingTestRoomId,
   name: "Embedding Test Room",
@@ -71,12 +73,11 @@ export const embeddingTestRoom: Room = {
   worldId: embeddingTestWorldId,
 };
 
-// Interface that extends Memory to include the type field for the database
+/** Memory shape used by these fixtures, with the DB-only `type` column made explicit. */
 export interface TestMemory extends Memory {
   type: string;
 }
 
-// Sample test memories
 export const embeddingTestMemories: TestMemory[] = [
   {
     id: fixedUuid(10),
@@ -122,7 +123,6 @@ export const embeddingTestMemories: TestMemory[] = [
   },
 ];
 
-// Embedding test data interface
 interface EmbeddingTestDataItem {
   id: UUID;
   memoryId: UUID;
@@ -132,7 +132,6 @@ interface EmbeddingTestDataItem {
   dim768?: number[];
 }
 
-// Sample embeddings of different dimensions
 export const embeddingTestData: EmbeddingTestDataItem[] = [
   {
     id: fixedUuid(30),
@@ -154,7 +153,6 @@ export const embeddingTestData: EmbeddingTestDataItem[] = [
   },
 ];
 
-// Memory with embedding
 export const embeddingTestMemoriesWithEmbedding: (TestMemory & {
   embedding: number[];
 })[] = [

--- a/plugins/plugin-sql/src/__tests__/integration/seed/memory-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/memory-seed.ts
@@ -1,3 +1,9 @@
+/**
+ * Fixture agent/entity/world/room/memory records for the memory integration
+ * tests, including embedding vectors and helpers (`generateEmbedding`,
+ * `createSimilarMemoryVector`) for exercising vector-similarity search and
+ * document/fragment relationships.
+ */
 import {
   type Agent,
   ChannelType,
@@ -9,13 +15,11 @@ import {
 } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs
 export const memoryTestAgentId = uuidv4() as UUID;
 export const memoryTestEntityId = uuidv4() as UUID;
 export const memoryTestRoomId = uuidv4() as UUID;
 export const memoryTestWorldId = uuidv4() as UUID;
 
-// Test data for memory integration tests
 export const memoryTestAgent: Agent = {
   id: memoryTestAgentId,
   name: "Memory Test Agent",
@@ -58,17 +62,14 @@ export const memoryTestRoom: Room = {
   metadata: {},
 };
 
-// Helper function to generate random embedding vectors
 export const generateEmbedding = (dimension: number = 384): number[] => {
   const vector = Array(dimension)
     .fill(0)
     .map(() => Math.random() * 2 - 1);
-  // Normalize
   const magnitude = Math.sqrt(vector.reduce((sum, val) => sum + val * val, 0));
   return vector.map((val) => Number((val / magnitude).toFixed(6)));
 };
 
-// Basic memory test objects
 export const memoryTestMemories: Memory[] = [
   {
     id: uuidv4() as UUID,
@@ -120,7 +121,6 @@ export const memoryTestMemories: Memory[] = [
   },
 ];
 
-// Memory test objects with embeddings
 export const memoryTestMemoriesWithEmbedding: Memory[] = [
   {
     ...memoryTestMemories[0],
@@ -151,7 +151,6 @@ export const memoryTestMemoriesWithEmbedding: Memory[] = [
   },
 ];
 
-// Document and fragments for testing document operations
 export const documentMemoryId = uuidv4() as UUID;
 export const memoryTestDocument: Memory = {
   id: documentMemoryId,
@@ -173,7 +172,6 @@ export const memoryTestDocument: Memory = {
   },
 };
 
-// Fragment memories that belong to the document
 export const memoryTestFragments: Memory[] = Array(3)
   .fill(0)
   .map((_, index) => ({
@@ -196,23 +194,19 @@ export const memoryTestFragments: Memory[] = Array(3)
     },
   }));
 
-// Helper function to create similar memory for vector similarity testing
+/** Blends `baseMemory`'s embedding with noise so the result has the given cosine similarity to it, for vector-similarity-search tests. */
 export const createSimilarMemoryVector = (baseMemory: Memory, similarity: number): Memory => {
-  // Only works if baseMemory has an embedding
   if (!baseMemory.embedding || !Array.isArray(baseMemory.embedding)) {
     throw new Error("Base memory must have an embedding");
   }
 
-  // Create a somewhat similar vector (higher similarity means more similar)
   const dimension = baseMemory.embedding.length;
   const noise = generateEmbedding(dimension);
 
-  // Blend the original vector with noise based on similarity
   const blendedVector = baseMemory.embedding.map((value, idx) => {
     return value * similarity + noise[idx] * (1 - similarity);
   });
 
-  // Normalize the resulting vector
   const magnitude = Math.sqrt(blendedVector.reduce((sum, val) => sum + val * val, 0));
   const normalizedVector = blendedVector.map((val) => Number((val / magnitude).toFixed(6)));
 

--- a/plugins/plugin-sql/src/__tests__/integration/seed/participant-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/participant-seed.ts
@@ -1,3 +1,4 @@
+/** Fixture agent/entity/world/room records for the room-participant integration tests. */
 import {
   type Agent,
   ChannelType,
@@ -8,13 +9,11 @@ import {
 } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs
 export const participantTestAgentId = uuidv4() as UUID;
 export const participantTestEntityId = uuidv4() as UUID;
 export const participantTestRoomId = uuidv4() as UUID;
 export const participantTestWorldId = uuidv4() as UUID;
 
-// Test data for participant integration tests
 export const participantTestAgent: Agent = {
   id: participantTestAgentId,
   name: "Participant Test Agent",

--- a/plugins/plugin-sql/src/__tests__/integration/seed/relationship-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/relationship-seed.ts
@@ -1,12 +1,11 @@
+/** Fixture agent/entity/relationship records for the relationship-store integration tests. */
 import type { Agent, Entity, Metadata, Relationship, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs for relationship tests
 export const relationshipTestAgentId = uuidv4() as UUID;
 export const relationshipTestSourceEntityId = uuidv4() as UUID;
 export const relationshipTestTargetEntityId = uuidv4() as UUID;
 
-// Test data for relationship integration tests
 export const relationshipTestAgent: Agent = {
   id: relationshipTestAgentId,
   name: "Relationship Test Agent",
@@ -40,7 +39,6 @@ export const relationshipTestTargetEntity: Entity = {
   },
 };
 
-// Test relationships
 export const relationshipTestRelationships: Relationship[] = [
   {
     id: uuidv4() as UUID,
@@ -68,7 +66,6 @@ export const relationshipTestRelationships: Relationship[] = [
   },
 ];
 
-// Helper function to create a relationship with custom tags and metadata
 export const createTestRelationship = (
   sourceId: UUID,
   target: UUID,

--- a/plugins/plugin-sql/src/__tests__/integration/seed/room-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/room-seed.ts
@@ -1,3 +1,4 @@
+/** Fixture agent/entity/world/room records for the room-store integration tests. */
 import {
   type Agent,
   ChannelType,
@@ -8,14 +9,12 @@ import {
 } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs
 export const roomTestAgentId = uuidv4() as UUID;
 export const roomTestEntityId = uuidv4() as UUID;
 export const roomTestWorldId = uuidv4() as UUID;
 export const roomTestRoomId = uuidv4() as UUID;
 export const roomTestRoom2Id = uuidv4() as UUID;
 
-// Test data for room integration tests
 export const roomTestAgent: Agent = {
   id: roomTestAgentId,
   name: "Room Test Agent",
@@ -48,7 +47,6 @@ export const roomTestWorld: World = {
   metadata: {},
 };
 
-// Basic room test objects
 export const roomTestRooms: Room[] = [
   {
     id: roomTestRoomId,
@@ -90,7 +88,6 @@ export const roomTestRooms: Room[] = [
   },
 ];
 
-// Helper function to create a modified room for update tests
 export const createModifiedRoom = (room: Room): Room => {
   return {
     ...room,

--- a/plugins/plugin-sql/src/__tests__/integration/seed/task-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/task-seed.ts
@@ -1,13 +1,12 @@
+/** Fixture task records for the task-store integration tests, covering room/tag filtering and name search. */
 import type { Task, UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs
 export const taskTestAgentId = uuidv4() as UUID;
 export const taskTestRoomId = uuidv4() as UUID;
 export const taskTestWorldId = uuidv4() as UUID;
 export const taskTestEntityId = uuidv4() as UUID;
 
-// Sample test tasks
 export const taskTestTasks: Task[] = [
   {
     id: uuidv4() as UUID,
@@ -67,12 +66,11 @@ export const taskTestTasks: Task[] = [
   },
 ];
 
-// Sample task with different room
 export const taskTestTaskDifferentRoom: Task = {
   id: uuidv4() as UUID,
   name: "Task Different Room",
   description: "This task belongs to a different room for filter testing",
-  roomId: uuidv4() as UUID, // Different room ID
+  roomId: uuidv4() as UUID,
   worldId: taskTestWorldId,
   tags: ["test", "different-room"],
   metadata: {
@@ -81,7 +79,6 @@ export const taskTestTaskDifferentRoom: Task = {
   },
 };
 
-// Test task with specific tags for filtering tests
 export const taskTestTaskWithSpecificTags: Task = {
   id: uuidv4() as UUID,
   name: "Task With Specific Tags",

--- a/plugins/plugin-sql/src/__tests__/integration/seed/world-seed.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/seed/world-seed.ts
@@ -1,11 +1,10 @@
+/** Fixture agent/entity/world records for the world-store integration tests, including owner/role metadata variants. */
 import { type Agent, type Entity, Role, type UUID, type World } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-// Test IDs
 export const worldTestAgentId = uuidv4() as UUID;
 export const worldTestEntityId = uuidv4() as UUID;
 
-// Test data for world integration tests
 export const worldTestAgent: Agent = {
   id: worldTestAgentId,
   name: "World Test Agent",
@@ -29,7 +28,6 @@ export const worldTestEntity: Entity = {
   },
 };
 
-// Basic test worlds
 export const worldTestWorlds: World[] = [
   {
     id: uuidv4() as UUID,

--- a/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/task.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Task-store CRUD and query (tags/room/name) tests against a real PGlite (or
+ * Postgres, if `POSTGRES_URL` is set) adapter via `createIsolatedTestDatabase`
+ * — no mocks.
+ */
 import { ChannelType, type Entity, type Room, type Task, type UUID } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -21,12 +26,10 @@ describe("Task Integration Tests", () => {
     cleanup = setup.cleanup;
     testAgentId = setup.testAgentId;
 
-    // Generate random UUIDs for test data
     testRoomId = uuidv4() as UUID;
     testWorldId = uuidv4() as UUID;
     testEntityId = uuidv4() as UUID;
 
-    // Create test world
     await adapter.createWorld({
       id: testWorldId,
       agentId: testAgentId,
@@ -34,7 +37,6 @@ describe("Task Integration Tests", () => {
       messageServerId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID,
     });
 
-    // Create test room
     await adapter.createRooms([
       {
         id: testRoomId,
@@ -46,7 +48,6 @@ describe("Task Integration Tests", () => {
       } as Room,
     ]);
 
-    // Create test entity
     await adapter.createEntities([
       {
         id: testEntityId,

--- a/plugins/plugin-sql/src/__tests__/integration/utils.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/utils.real.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the path-resolution helpers (`expandTildePath`, `resolveEnvFile`,
+ * `resolvePgliteDir`) against a real temp directory and real `.env` files on
+ * disk — no filesystem mocking.
+ */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -13,7 +18,6 @@ describe("Utils Integration Tests", () => {
     originalEnv = { ...process.env };
     originalCwd = process.cwd;
 
-    // Create a temporary directory for tests
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "utils-test-"));
     process.cwd = () => tempDir;
   });
@@ -22,7 +26,6 @@ describe("Utils Integration Tests", () => {
     process.env = originalEnv;
     process.cwd = originalCwd;
 
-    // Clean up temp directory
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -54,7 +57,6 @@ describe("Utils Integration Tests", () => {
 
   describe("resolveEnvFile", () => {
     it("should find .env in current directory", () => {
-      // Create .env file in temp dir
       fs.writeFileSync(path.join(tempDir, ".env"), "TEST=true");
 
       const result = resolveEnvFile(tempDir);
@@ -62,11 +64,9 @@ describe("Utils Integration Tests", () => {
     });
 
     it("should traverse up directories to find .env", () => {
-      // Create nested directories
       const subDir = path.join(tempDir, "sub", "nested");
       fs.mkdirSync(subDir, { recursive: true });
 
-      // Create .env in parent
       fs.writeFileSync(path.join(tempDir, ".env"), "TEST=true");
 
       const result = resolveEnvFile(subDir);
@@ -118,7 +118,6 @@ describe("Utils Integration Tests", () => {
     });
 
     it("should load .env file if it exists", () => {
-      // Create .env file with PGLITE_DATA_DIR
       fs.writeFileSync(path.join(tempDir, ".env"), "PGLITE_DATA_DIR=/from/env/file");
       delete process.env.PGLITE_DATA_DIR;
 
@@ -137,7 +136,6 @@ describe("Utils Integration Tests", () => {
 
       const result = resolvePgliteDir(customPath);
 
-      // Should return the provided path as-is
       expect(result).toBe(customPath);
     });
   });

--- a/plugins/plugin-sql/src/__tests__/integration/world.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/world.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * World-store CRUD tests against a real PGlite (or Postgres, if
+ * `POSTGRES_URL` is set) adapter via `createIsolatedTestDatabase` — no mocks.
+ * Covers UUID edge cases (nil UUID, non-RFC-version server ids) and
+ * duplicate-id rejection.
+ */
 import type { UUID, World } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -27,7 +33,6 @@ describe("World Integration Tests", () => {
 
   describe("World Tests", () => {
     beforeEach(async () => {
-      // Clean up worlds table before each test
       await (adapter.getDatabase() as DrizzleDatabase).delete(worldTable);
     });
 

--- a/plugins/plugin-sql/src/__tests__/migration/actual-runtime-scenario.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/actual-runtime-scenario.real.test.ts
@@ -1,6 +1,13 @@
+/**
+ * End-to-end simulation of how `RuntimeMigrator` behaves across the real
+ * multi-plugin boot sequence — separate migrator instances per plugin (as
+ * each plugin's `init` would create), a simulated app restart, and a single
+ * migrator shared across plugins — asserting migrations stay idempotent and
+ * both plugin schemas (`@elizaos/plugin-sql`, `polymarket`) coexist. Runs
+ * against a real Postgres/PGlite database via `createIsolatedTestDatabaseForMigration`.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper types for database query result rows
 interface MigrationRow {
   plugin_name: string;
   hash: string;
@@ -66,21 +73,17 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
     console.log("SCENARIO: Application Startup");
     console.log("=".repeat(80));
 
-    // Step 1: Application starts and initializes the database adapter (plugin-sql)
     console.log("\n📦 Step 1: Loading plugin-sql (database adapter)...");
 
-    // This is what happens in plugin-sql's initialization
     const sqlPluginMigrator = new RuntimeMigrator(db);
     await sqlPluginMigrator.initialize();
 
-    // Plugin-sql migrates its own schema
     await sqlPluginMigrator.migrate("@elizaos/plugin-sql", coreSchema, {
       verbose: false,
     });
 
     console.log("✅ plugin-sql loaded and migrated");
 
-    // Check migration state after plugin-sql
     const afterSqlPlugin = await db.execute(sql`
       SELECT plugin_name, hash, created_at 
       FROM migrations._migrations 
@@ -91,16 +94,11 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
       console.log(`  - ${m.plugin_name}`);
     }
 
-    // Step 2: Application loads other plugins (polymarket)
     console.log("\n📦 Step 2: Loading polymarket plugin...");
-
-    // This is what would happen in polymarket plugin's initialization
-    // IMPORTANT: In real runtime, would polymarket create its own migrator instance?
-    // Or would it use a shared one? Let's test both scenarios.
 
     console.log("\n--- Testing Scenario A: Polymarket creates its own migrator ---");
     const polymarketMigrator = new RuntimeMigrator(db);
-    // initialize() is idempotent - detects existing migration tables
+    // initialize() is idempotent: it detects the existing migration tables.
     await polymarketMigrator.initialize();
 
     await polymarketMigrator.migrate("polymarket", testPolymarketSchema, {
@@ -109,7 +107,6 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
 
     console.log("✅ polymarket loaded and migrated (own migrator)");
 
-    // Check migration state after polymarket
     const afterPolymarket = await db.execute(sql`
       SELECT plugin_name, hash, created_at 
       FROM migrations._migrations 
@@ -122,18 +119,16 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
 
     expect(afterPolymarket.rows.length).toBe(2);
 
-    // Step 3: Simulate app restart - what happens?
     console.log(`\n${"=".repeat(80)}`);
     console.log("SCENARIO: Application Restart");
     console.log("=".repeat(80));
 
     console.log("\n🔄 Simulating application restart...");
 
-    // Create new migrator instances (as would happen on restart)
+    // New migrator instances, as each plugin's init would create on restart.
     const sqlPluginMigrator2 = new RuntimeMigrator(db);
     await sqlPluginMigrator2.initialize();
 
-    // Plugin-sql tries to migrate again
     await sqlPluginMigrator2.migrate("@elizaos/plugin-sql", coreSchema, {
       verbose: false,
     });
@@ -141,12 +136,11 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
     const polymarketMigrator2 = new RuntimeMigrator(db);
     await polymarketMigrator2.initialize();
 
-    // Polymarket tries to migrate again
     await polymarketMigrator2.migrate("polymarket", testPolymarketSchema, {
       verbose: false,
     });
 
-    // Should still be only 2 migrations
+    // Re-migrating on restart must stay idempotent: still exactly 2 rows.
     const afterRestart = await db.execute(sql`
       SELECT plugin_name, hash, created_at 
       FROM migrations._migrations 
@@ -159,7 +153,6 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
     console.log("DIAGNOSTICS");
     console.log("=".repeat(80));
 
-    // Detailed diagnostic information
     console.log("\n🔍 Checking snapshots:");
     const snapshots = await db.execute(sql`
       SELECT plugin_name, COUNT(*) as count 
@@ -170,7 +163,6 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
       console.log(`  - ${s.plugin_name}: ${s.count} snapshots`);
     }
 
-    // Check if schemas are correctly created
     console.log("\n🔍 Checking schemas:");
     const schemas = await db.execute(sql`
       SELECT schema_name 
@@ -180,7 +172,6 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
     `);
     console.log("Schemas:", schemas.rows.map((r: SchemaRow) => r.schema_name).join(", "));
 
-    // Verify tables in each schema
     console.log("\n🔍 Tables per schema:");
     const tablesPerSchema = await db.execute(sql`
       SELECT schemaname, COUNT(*) as table_count 
@@ -199,13 +190,11 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
     console.log("SCENARIO: Shared Migrator Instance");
     console.log("=".repeat(80));
 
-    // Clear all existing data from previous test
     console.log("\n🧹 Cleaning up database from previous test...");
 
-    // Drop polymarket schema if it exists
     await db.execute(sql`DROP SCHEMA IF EXISTS polymarket CASCADE`);
 
-    // Drop all tables in public schema (except the migration tables which we'll handle separately)
+    // Migration tables (`migrations` schema) are dropped separately below.
     const tables = await db.execute(sql`
       SELECT tablename FROM pg_tables 
       WHERE schemaname = 'public' 
@@ -220,28 +209,24 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
       await db.execute(sql.raw(`DROP TABLE IF EXISTS public."${table.tablename}" CASCADE`));
     }
 
-    // Drop migrations schema entirely (it will be recreated)
+    // Dropped entirely; `initialize()` below recreates it.
     await db.execute(sql`DROP SCHEMA IF EXISTS migrations CASCADE`);
 
     console.log("\n🔄 Testing with shared migrator instance...");
 
-    // Single migrator instance shared across plugins
     const sharedMigrator = new RuntimeMigrator(db);
     await sharedMigrator.initialize();
 
-    // Plugin-sql uses shared migrator
     console.log("\n📦 plugin-sql using shared migrator...");
     await sharedMigrator.migrate("@elizaos/plugin-sql", coreSchema, {
       verbose: false,
     });
 
-    // Polymarket uses same shared migrator
     console.log("📦 polymarket using shared migrator...");
     await sharedMigrator.migrate("polymarket", testPolymarketSchema, {
       verbose: false,
     });
 
-    // Check final state
     const finalMigrations = await db.execute(sql`
       SELECT plugin_name, hash, created_at 
       FROM migrations._migrations 
@@ -255,7 +240,6 @@ describe("Actual Runtime Scenario - Plugin Loading Simulation", () => {
 
     expect(finalMigrations.rows.length).toBe(2);
 
-    // Test if both schemas exist
     const schemasExist = await db.execute(sql`
       SELECT 
         EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'public') as public_exists,

--- a/plugins/plugin-sql/src/__tests__/migration/comprehensive-migration.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/comprehensive-migration.real.test.ts
@@ -1,3 +1,12 @@
+/**
+ * End-to-end `RuntimeMigrator` coverage against a real Postgres/PGlite
+ * database (via `createIsolatedTestDatabaseForMigration`): a purpose-built
+ * schema exercising every constraint kind the migrator must diff and apply —
+ * dependency-ordered table creation, `vector` columns, foreign keys, unique
+ * and check constraints, actual constraint enforcement on insert, idempotent
+ * re-migration, empty schemas, and non-table schema exports that must be
+ * ignored rather than migrated.
+ */
 import { sql } from "drizzle-orm";
 import {
   boolean,
@@ -15,7 +24,6 @@ import {
 } from "drizzle-orm/pg-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper types for database query result rows
 interface VectorColumnRow {
   data_type: string;
   column_name: string;
@@ -49,7 +57,6 @@ import { RuntimeMigrator } from "../../runtime-migrator";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabaseForMigration } from "../test-helpers";
 
-// Test schema with all possible scenarios
 const testBaseTable = pgTable(
   "base_entities",
   {
@@ -144,7 +151,7 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     db = testSetup.db;
     cleanup = testSetup.cleanup;
 
-    // Vector extension is already installed by adapter.init()
+    // The vector extension is already installed by adapter.init().
   });
 
   afterAll(async () => {
@@ -154,7 +161,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
   });
 
   describe("Migration Execution", () => {
-    // Clean up any existing schemas before migration tests
     beforeAll(async () => {
       try {
         await db.execute(sql`DROP SCHEMA IF EXISTS migrations CASCADE`);
@@ -165,16 +171,13 @@ describe("Comprehensive Dynamic Migration Tests", () => {
         console.log("[TEST CLEANUP] Schema cleanup failed:", error);
       }
 
-      // Initialize RuntimeMigrator
       migrator = new RuntimeMigrator(db);
       await migrator.initialize();
     });
 
     it("should create all tables in correct dependency order", async () => {
-      // Run the migration
       await migrator.migrate("test-plugin", testSchema, { verbose: true });
 
-      // Verify all tables were created
       const result = await db.execute(
         sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_name`
       );
@@ -187,7 +190,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should create vector columns with correct types", async () => {
-      // Check vector column types
       const result = await db.execute(
         sql`SELECT column_name, data_type 
             FROM information_schema.columns 
@@ -200,14 +202,13 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       const vectorColumns = result.rows as VectorColumnRow[];
       expect(vectorColumns).toHaveLength(3);
 
-      // All vector columns should have USER-DEFINED type (vector extension)
+      // The pgvector extension reports its column type as USER-DEFINED.
       vectorColumns.forEach((col) => {
         expect(col.data_type).toBe("USER-DEFINED");
       });
     });
 
     it("should create foreign key constraints properly", async () => {
-      // Check that foreign key constraints exist
       const result = await db.execute(
         sql`SELECT tc.constraint_name, tc.table_name, kcu.column_name, ccu.table_name AS referenced_table
             FROM information_schema.table_constraints AS tc
@@ -223,7 +224,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       const foreignKeys = result.rows as ForeignKeyRow[];
       expect(foreignKeys.length).toBeGreaterThan(0);
 
-      // Check specific foreign keys
       const dependentFk = foreignKeys.find(
         (fk) =>
           fk.table_name === "dependent_entities" &&
@@ -234,7 +234,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should create unique constraints properly", async () => {
-      // Check that unique constraints exist
       const result = await db.execute(
         sql`SELECT tc.constraint_name, tc.table_name
             FROM information_schema.table_constraints AS tc
@@ -246,7 +245,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       const uniqueConstraints = result.rows as UniqueConstraintRow[];
       expect(uniqueConstraints.length).toBeGreaterThan(0);
 
-      // Check specific unique constraints
       const baseNameUnique = uniqueConstraints.find(
         (uc) =>
           uc.table_name === "base_entities" && uc.constraint_name === "base_entities_name_unique"
@@ -255,7 +253,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should create check constraints properly", async () => {
-      // Check that check constraints exist
       const result = await db.execute(
         sql`SELECT tc.constraint_name, tc.table_name
             FROM information_schema.table_constraints AS tc
@@ -267,7 +264,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       const checkConstraints = result.rows as CheckConstraintRow[];
       expect(checkConstraints.length).toBeGreaterThan(0);
 
-      // Check specific check constraints
       const valuePositive = checkConstraints.find(
         (cc) => cc.table_name === "dependent_entities" && cc.constraint_name === "value_positive"
       );
@@ -275,13 +271,11 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should support vector similarity operations", async () => {
-      // Insert test data with vector embeddings
       await db.execute(
         sql`INSERT INTO public.base_entities (id, name) VALUES 
             ('550e8400-e29b-41d4-a716-446655440000', 'test-entity')`
       );
 
-      // Insert vector embedding
       const testVector = Array(384)
         .fill(0)
         .map(() => Math.random())
@@ -291,7 +285,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
             ('550e8400-e29b-41d4-a716-446655440000', '[${sql.raw(testVector)}]')`
       );
 
-      // Test vector similarity query
       const result = await db.execute(
         sql`SELECT entity_id, dim_384 <=> '[${sql.raw(testVector)}]' as distance 
             FROM public.vector_embeddings 
@@ -309,7 +302,7 @@ describe("Comprehensive Dynamic Migration Tests", () => {
 
   describe("Data Integrity", () => {
     it("should enforce foreign key constraints", async () => {
-      // Try to insert dependent entity with non-existent base_id
+      // Inserting a dependent row against a non-existent base_id must fail.
       let errorThrown = false;
       try {
         await db.execute(
@@ -323,13 +316,12 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should enforce unique constraints", async () => {
-      // Insert a base entity
       await db.execute(
         sql`INSERT INTO public.base_entities (id, name) VALUES 
             ('550e8400-e29b-41d4-a716-446655440001', 'unique-test')`
       );
 
-      // Try to insert another with the same name
+      // A second row with the same name must violate the unique constraint.
       let errorThrown = false;
       try {
         await db.execute(
@@ -343,13 +335,12 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should enforce check constraints", async () => {
-      // Insert base entity first
       await db.execute(
         sql`INSERT INTO public.base_entities (id, name) VALUES 
             ('550e8400-e29b-41d4-a716-446655440003', 'check-test')`
       );
 
-      // Try to insert dependent with negative value (should fail)
+      // A negative value must violate the "value_positive" check constraint.
       let errorThrown = false;
       try {
         await db.execute(
@@ -365,7 +356,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
 
   describe("Edge Cases", () => {
     it("should handle idempotent migrations (running same migration twice)", async () => {
-      // Run migration again - should not fail
       let errorThrown = false;
       let _errorDetails: unknown = null;
       try {
@@ -377,7 +367,6 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       }
       expect(errorThrown).toBe(false);
 
-      // Tables should still exist
       const result = await db.execute(
         sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
       );
@@ -398,7 +387,7 @@ describe("Comprehensive Dynamic Migration Tests", () => {
     });
 
     it("should handle schema with non-table exports", async () => {
-      // Create a simple table just for this test to avoid conflicts
+      // A dedicated table avoids name conflicts with tables from other tests.
       const testMixedTable = pgTable("mixed_test_table", {
         id: uuid("id").primaryKey().defaultRandom(),
         name: text("name").notNull(),
@@ -423,11 +412,10 @@ describe("Comprehensive Dynamic Migration Tests", () => {
       }
       expect(errorThrown).toBe(false);
 
-      // Should only create the actual table
+      // Only the real table should be created; non-table exports are ignored.
       const result = await db.execute(
         sql`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
       );
-      // Should have mixed_test_table plus any tables from previous tests
       const mixedTableExists = result.rows.some(
         (row) => (row as { table_name: string }).table_name === "mixed_test_table"
       );

--- a/plugins/plugin-sql/src/__tests__/migration/data-persistence.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/data-persistence.real.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Real-PGlite tests proving `RuntimeMigrator` never loses existing rows when
+ * a schema changes underneath it — column additions, safe type widenings,
+ * foreign-key tables, JSON/array columns, large (1000-row) batches, and a
+ * destructive rename that must be rejected while leaving prior data intact.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
 import { sql } from "drizzle-orm";
@@ -18,10 +24,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../runtime-migrator/types";
 
-/**
- * Comprehensive data persistence tests to ensure data is never lost
- * during migrations, even in complex scenarios
- */
 describe("Data Persistence Through Migrations", () => {
   let pgClient: PGlite;
   let db: DrizzleDB;
@@ -40,7 +42,6 @@ describe("Data Persistence Through Migrations", () => {
 
   describe("Critical Data Persistence Scenarios", () => {
     it("should preserve ALL data through column additions", async () => {
-      // Step 1: Create a table with production data
       await db.execute(sql`
         CREATE TABLE customers (
           id SERIAL PRIMARY KEY,
@@ -50,7 +51,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert significant amount of data
       const customerData: Array<{ id: number; name: string; email: string }> = [];
       for (let i = 1; i <= 100; i++) {
         customerData.push({
@@ -67,17 +67,14 @@ describe("Data Persistence Through Migrations", () => {
         `);
       }
 
-      // Verify initial data
       const initialCount = await db.execute(sql`SELECT COUNT(*) as count FROM customers`);
       expect(Number(initialCount.rows[0].count)).toBe(100);
 
-      // Step 2: Define schema with new columns
       const customersTable = pgTable("customers", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         name: text("name").notNull(),
         email: text("email").notNull().unique(),
         created_at: timestamp("created_at").defaultNow(),
-        // New columns
         phone: varchar("phone", { length: 20 }),
         address: text("address"),
         is_active: boolean("is_active").default(true),
@@ -86,13 +83,11 @@ describe("Data Persistence Through Migrations", () => {
 
       const schema = { customers: customersTable };
 
-      // Step 3: Run migration with force to allow type changes
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Step 4: Verify ALL data is preserved
       const afterMigration = await db.execute(sql`
         SELECT * FROM customers 
         ORDER BY id
@@ -100,21 +95,18 @@ describe("Data Persistence Through Migrations", () => {
 
       expect(afterMigration.rows).toHaveLength(100);
 
-      // Verify each record
       for (let i = 0; i < 100; i++) {
         const row = afterMigration.rows[i];
         expect(row.id).toBe(i + 1);
         expect(row.name).toBe(`Customer ${i + 1}`);
         expect(row.email).toBe(`customer${i + 1}@example.com`);
         expect(row.created_at).toBeDefined();
-        // New columns should have defaults
         expect(row.is_active).toBe(true);
         expect(row.phone).toBeNull();
         expect(row.address).toBeNull();
         expect(row.metadata).toBeNull();
       }
 
-      // Step 5: Verify migration metadata is correct
       const status = await migrator.getStatus("@elizaos/plugin-sql");
       expect(status.hasRun).toBe(true);
       expect(status.snapshots).toBeGreaterThan(0);
@@ -123,7 +115,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should preserve data through column type changes that are safe", async () => {
-      // Create table with numeric data
       await db.execute(sql`
         CREATE TABLE products (
           id SERIAL PRIMARY KEY,
@@ -133,7 +124,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert product data
       const products = [
         { name: "Product A", price: 1999, stock: 100 },
         { name: "Product B", price: 2999, stock: 50 },
@@ -149,7 +139,6 @@ describe("Data Persistence Through Migrations", () => {
         `);
       }
 
-      // Define schema with type changes
       const productsTable = pgTable("products", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         name: text("name").notNull(),
@@ -160,13 +149,11 @@ describe("Data Persistence Through Migrations", () => {
 
       const schema = { products: productsTable };
 
-      // Run migration
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Verify data is preserved and correctly converted
       const result = await db.execute(sql`
         SELECT * FROM products ORDER BY id
       `);
@@ -180,7 +167,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should preserve data in related tables with foreign keys", async () => {
-      // Create related tables with data
       await db.execute(sql`
         CREATE TABLE departments (
           id SERIAL PRIMARY KEY,
@@ -200,7 +186,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert department data
       const deptIds: number[] = [];
       const departments = ["Engineering", "Sales", "Marketing", "HR"];
       for (const dept of departments) {
@@ -212,7 +197,6 @@ describe("Data Persistence Through Migrations", () => {
         deptIds.push(result.rows[0].id as number);
       }
 
-      // Insert employee data
       for (let i = 1; i <= 50; i++) {
         const deptId = deptIds[Math.floor(Math.random() * deptIds.length)];
         await db.execute(sql`
@@ -226,14 +210,12 @@ describe("Data Persistence Through Migrations", () => {
         `);
       }
 
-      // Verify initial state
       const empCount = await db.execute(sql`SELECT COUNT(*) as count FROM employees`);
       expect(Number(empCount.rows[0].count)).toBe(50);
 
       const deptCount = await db.execute(sql`SELECT COUNT(*) as count FROM departments`);
       expect(Number(deptCount.rows[0].count)).toBe(4);
 
-      // Define schemas with modifications
       const departmentsTable = pgTable("departments", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         name: text("name").notNull(),
@@ -258,13 +240,11 @@ describe("Data Persistence Through Migrations", () => {
         employees: employeesTable,
       };
 
-      // Run migration
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Verify all relationships are preserved
       const employeesAfter = await db.execute(sql`
         SELECT e.*, d.name as dept_name 
         FROM employees e
@@ -274,14 +254,12 @@ describe("Data Persistence Through Migrations", () => {
 
       expect(employeesAfter.rows).toHaveLength(50);
 
-      // Verify all employees still have valid department references
       for (const emp of employeesAfter.rows) {
         expect(emp.dept_name).toBeDefined();
         expect(departments).toContain(emp.dept_name as string);
         expect(emp.is_active).toBe(true); // New column should have default
       }
 
-      // Verify departments data
       const deptsAfter = await db.execute(sql`
         SELECT * FROM departments ORDER BY id
       `);
@@ -292,7 +270,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should handle migration rollback on failure without data loss", async () => {
-      // Create table with critical data
       await db.execute(sql`
         CREATE TABLE transactions (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -302,7 +279,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert transaction data
       const transactionIds: string[] = [];
       for (let i = 1; i <= 10; i++) {
         const result = await db.execute(sql`
@@ -313,43 +289,39 @@ describe("Data Persistence Through Migrations", () => {
         transactionIds.push(result.rows[0].id as string);
       }
 
-      // Verify initial state
       const initialData = await db.execute(sql`
         SELECT * FROM transactions ORDER BY amount
       `);
       expect(initialData.rows).toHaveLength(10);
 
-      // Try a migration that will fail (conflicting column type)
+      // `id: integer` conflicts with the existing UUID column, so this
+      // migration must be rejected as destructive rather than applied.
       const badSchema = pgTable("transactions", {
-        id: integer("id").primaryKey(), // Wrong type - will conflict
+        id: integer("id").primaryKey(),
         amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
         status: text("status").notNull(),
         created_at: timestamp("created_at").defaultNow(),
       });
 
-      // This should fail but not lose data
       try {
         await migrator.migrate(
           "@elizaos/plugin-sql",
           { transactions: badSchema },
           {
             verbose: false,
-            force: false, // Don't force destructive changes
+            force: false,
           }
         );
-        expect(true).toBe(false); // Should not reach here
+        expect(true).toBe(false); // Unreachable: migrate() above must throw.
       } catch (error) {
-        // Expected to fail
         expect((error as Error).message).toContain("Destructive migration blocked");
       }
 
-      // Verify data is still intact after failed migration
       const afterFailure = await db.execute(sql`
         SELECT * FROM transactions ORDER BY amount
       `);
       expect(afterFailure.rows).toHaveLength(10);
 
-      // Verify each transaction is unchanged
       for (let i = 0; i < 10; i++) {
         expect(afterFailure.rows[i].amount).toBe(`${String(100 * (i + 1))}.00`); // Numeric includes precision
         expect(afterFailure.rows[i].status).toBe("completed");
@@ -358,7 +330,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should correctly track migration history through multiple changes", async () => {
-      // Create initial table
       const ordersV1 = pgTable("orders", {
         id: serial("id").primaryKey(),
         total: integer("total").notNull(),
@@ -366,14 +337,13 @@ describe("Data Persistence Through Migrations", () => {
 
       await migrator.migrate("@elizaos/plugin-sql", { orders: ordersV1 }, { verbose: false });
 
-      // Insert data
       for (let i = 1; i <= 5; i++) {
         await db.execute(sql`
           INSERT INTO orders (total) VALUES (${i * 100})
         `);
       }
 
-      // Version 2: Add customer_name
+      // V2: adds customer_name.
       const ordersV2 = pgTable("orders", {
         id: serial("id").primaryKey(),
         total: integer("total").notNull(),
@@ -382,7 +352,7 @@ describe("Data Persistence Through Migrations", () => {
 
       await migrator.migrate("@elizaos/plugin-sql", { orders: ordersV2 }, { verbose: false });
 
-      // Version 3: Add status and created_at
+      // V3: adds status and created_at.
       const ordersV3 = pgTable("orders", {
         id: serial("id").primaryKey(),
         total: integer("total").notNull(),
@@ -393,7 +363,6 @@ describe("Data Persistence Through Migrations", () => {
 
       await migrator.migrate("@elizaos/plugin-sql", { orders: ordersV3 }, { verbose: false });
 
-      // Verify data persisted through all migrations
       const finalData = await db.execute(sql`
         SELECT * FROM orders ORDER BY id
       `);
@@ -405,13 +374,11 @@ describe("Data Persistence Through Migrations", () => {
         expect(finalData.rows[i].status).toBe("pending"); // Default value
       }
 
-      // Verify complete migration history
       const status = await migrator.getStatus("@elizaos/plugin-sql");
       expect(status.hasRun).toBe(true);
-      expect(status.journal?.entries).toHaveLength(3); // Three migrations
-      expect(status.snapshots).toBe(3); // Three snapshots
+      expect(status.journal?.entries).toHaveLength(3); // One per migrate() call above.
+      expect(status.snapshots).toBe(3);
 
-      // Verify each snapshot was saved correctly
       const journalEntries = status.journal?.entries || [];
       expect(journalEntries[0].idx).toBe(0);
       expect(journalEntries[1].idx).toBe(1);
@@ -419,7 +386,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should handle complex data with JSON and arrays correctly", async () => {
-      // Create table with complex data types
       await db.execute(sql`
         CREATE TABLE user_profiles (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -430,7 +396,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert complex data
       const profiles = [
         {
           username: "user1",
@@ -453,8 +418,7 @@ describe("Data Persistence Through Migrations", () => {
       ];
 
       for (const profile of profiles) {
-        // Handle arrays and JSONB properly for PostgreSQL
-        // Arrays need to be inserted as a PostgreSQL array literal
+        // Postgres array literals need the `{"a","b"}` text form, not JSON.
         const tagsLiteral = profile.tags
           ? `{${profile.tags.map((t) => `"${t}"`).join(",")}}`
           : "{}";
@@ -472,7 +436,6 @@ describe("Data Persistence Through Migrations", () => {
         );
       }
 
-      // Define schema with modifications
       const userProfilesTable = pgTable("user_profiles", {
         id: uuid("id").primaryKey().defaultRandom(),
         username: text("username").notNull(),
@@ -485,20 +448,17 @@ describe("Data Persistence Through Migrations", () => {
 
       const schema = { user_profiles: userProfilesTable };
 
-      // Run migration
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Verify complex data is preserved
       const result = await db.execute(sql`
         SELECT * FROM user_profiles ORDER BY username
       `);
 
       expect(result.rows).toHaveLength(3);
 
-      // Verify user1 data
       const user1 = result.rows[0];
       expect(user1.username).toBe("user1");
       expect(user1.settings).toEqual({
@@ -513,7 +473,6 @@ describe("Data Persistence Through Migrations", () => {
       });
       expect(user1.is_verified).toBe(false); // New column default
 
-      // Verify user2 data
       const user2 = result.rows[1];
       expect(user2.username).toBe("user2");
       expect(user2.settings).toEqual({
@@ -523,7 +482,6 @@ describe("Data Persistence Through Migrations", () => {
       });
       expect(user2.tags).toEqual(["user", "beta-tester"]);
 
-      // Verify user3 with null metadata
       const user3 = result.rows[2];
       expect(user3.username).toBe("user3");
       expect(user3.metadata).toBeNull();
@@ -531,7 +489,6 @@ describe("Data Persistence Through Migrations", () => {
     });
 
     it("should handle large-scale data migration efficiently", async () => {
-      // Create table with substantial amount of data
       await db.execute(sql`
         CREATE TABLE events (
           id SERIAL PRIMARY KEY,
@@ -541,7 +498,6 @@ describe("Data Persistence Through Migrations", () => {
         )
       `);
 
-      // Insert 1000 events
       const eventTypes = ["click", "view", "purchase", "signup", "logout"];
       const batchSize = 100;
 
@@ -563,11 +519,9 @@ describe("Data Persistence Through Migrations", () => {
         );
       }
 
-      // Verify initial count
       const initialCount = await db.execute(sql`SELECT COUNT(*) as count FROM events`);
       expect(Number(initialCount.rows[0].count)).toBe(1000);
 
-      // Define schema with new columns and indexes
       const eventsTable = pgTable("events", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         event_type: text("event_type").notNull(),
@@ -580,17 +534,14 @@ describe("Data Persistence Through Migrations", () => {
 
       const schema = { events: eventsTable };
 
-      // Run migration
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Verify all data is preserved
       const finalCount = await db.execute(sql`SELECT COUNT(*) as count FROM events`);
       expect(Number(finalCount.rows[0].count)).toBe(1000);
 
-      // Spot check some records
       const sample = await db.execute(sql`
         SELECT * FROM events 
         WHERE id IN (1, 100, 500, 999, 1000)
@@ -605,7 +556,6 @@ describe("Data Persistence Through Migrations", () => {
         expect(row.processed).toBe(false); // New column default
       }
 
-      // Verify migration completed successfully
       const status = await migrator.getStatus("@elizaos/plugin-sql");
       expect(status.hasRun).toBe(true);
       expect(status.lastMigration).toBeDefined();

--- a/plugins/plugin-sql/src/__tests__/migration/database-detection.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/database-detection.real.test.ts
@@ -1,33 +1,30 @@
+/**
+ * Tests for `RuntimeMigrator`'s private `isRealPostgresDatabase` connection-
+ * string sniffer, which decides whether a URL points at real Postgres (vs.
+ * PGlite/SQLite/in-memory/other engines) across the connection-string shapes
+ * used by major managed-Postgres providers. A thin subclass re-exposes the
+ * private method so it can be exercised directly; no real database connects.
+ */
 import { describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../runtime-migrator";
 import type { DrizzleDB } from "../../runtime-migrator/types";
 
-/**
- * Unit tests for the isRealPostgresDatabase method
- * Testing the improved database detection logic that handles various PostgreSQL connection formats
- */
 describe("RuntimeMigrator - Database Detection", () => {
-  // Create a test helper to access the private method
-  // Since isRealPostgresDatabase is private, we'll test it through a minimal wrapper
-  // Test interface for accessing private methods
   interface TestableRuntimeMigrator extends RuntimeMigrator {
     isRealPostgresDatabase(url: string): boolean;
   }
 
-  // Helper function to access private method
   function getTestableMigrator(migrator: RuntimeMigrator): TestableRuntimeMigrator {
     return migrator as TestableRuntimeMigrator;
   }
 
   class TestRuntimeMigrator extends RuntimeMigrator {
     constructor() {
-      // Pass a dummy db object since we're only testing the detection logic
-      // Create a minimal mock that satisfies DrizzleDB interface
+      // The detection logic under test never touches the db handle.
       const mockDb: Partial<DrizzleDB> = {};
       super(mockDb as DrizzleDB);
     }
 
-    // Expose the private method for testing
     public testIsRealPostgresDatabase(url: string): boolean {
       return getTestableMigrator(this).isRealPostgresDatabase(url);
     }
@@ -302,12 +299,11 @@ describe("RuntimeMigrator - Database Detection", () => {
     });
 
     it("should handle whitespace appropriately", () => {
-      // URLs with leading/trailing whitespace
       expect(migrator.testIsRealPostgresDatabase("  postgres://localhost:5432/mydb  ")).toBe(true);
       expect(migrator.testIsRealPostgresDatabase("\tpostgresql://localhost/db\n")).toBe(true);
       expect(migrator.testIsRealPostgresDatabase("  localhost:5432/mydb  ")).toBe(true);
 
-      // But reject truly empty strings
+      // Whitespace-only strings are still empty for detection purposes.
       expect(migrator.testIsRealPostgresDatabase("   ")).toBe(false);
     });
   });

--- a/plugins/plugin-sql/src/__tests__/migration/dynamic-migration.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/dynamic-migration.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * End-to-end tests that register plugin-defined Drizzle schemas (a simple
+ * hello-world table pair and a table set with FK relationships) through
+ * `createIsolatedTestDatabase`, confirm the runtime migrates and creates them
+ * alongside the core schema, and exercise a full memory write/read against
+ * one of the dynamically created tables. Runs against a real PGlite/Postgres
+ * adapter, not a mock.
+ */
 import {
   type AgentRuntime,
   ChannelType,
@@ -110,7 +118,6 @@ describe("Dynamic Migration Tests", () => {
         `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
       );
       const tableNames = tables.rows.map((r) => (r as { table_name: string }).table_name);
-      // Plugin tables are created in public schema
       expect(tableNames).toContain("hello_world");
       expect(tableNames).toContain("greetings");
     });
@@ -172,7 +179,6 @@ describe("Dynamic Migration Tests", () => {
 
       const db = complexAdapter.getDatabase();
 
-      // Check tables in public schema (where plugin tables are created)
       const tables = await db.execute(
         `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`
       );

--- a/plugins/plugin-sql/src/__tests__/migration/initialization-with-plugin.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/initialization-with-plugin.real.test.ts
@@ -1,6 +1,13 @@
+/**
+ * End-to-end `RuntimeMigrator` tests against a real isolated database proving
+ * core (`@elizaos/plugin-sql`) and plugin (polymarket test fixture) schemas
+ * migrate into separate Postgres schemas, stay isolated (no table
+ * cross-contamination, correct per-schema table/index/FK counts), are
+ * idempotent on re-migration, and support real read/write/upsert/transaction
+ * operations against the plugin's schema-qualified tables.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper type for database query result rows
 interface MigrationRow {
   plugin_name: string;
   hash: string;
@@ -29,10 +36,8 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     testAgentId = testSetup.testAgentId;
     db = testSetup.db;
 
-    // Create a new migrator for testing
     migrator = new RuntimeMigrator(db);
 
-    // Initialize migration infrastructure
     await migrator.initialize();
   });
 
@@ -50,7 +55,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
         verbose: true,
       });
 
-      // Verify core tables were created in public schema
       const tablesResult = await db.execute(
         sql.raw(`SELECT tablename FROM pg_tables 
                  WHERE schemaname = 'public' 
@@ -98,7 +102,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
         verbose: true,
       });
 
-      // Check if polymarket schema was created
       const schemaResult = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT 1 FROM information_schema.schemata 
@@ -112,7 +115,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     });
 
     it("should create plugin tables in polymarket schema", async () => {
-      // Verify plugin tables were created in polymarket schema
       const tablesResult = await db.execute(
         sql.raw(`SELECT tablename FROM pg_tables 
                  WHERE schemaname = 'polymarket' 
@@ -130,7 +132,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     });
 
     it("should verify no plugin tables in public schema", async () => {
-      // Ensure plugin tables are NOT in public schema
       const publicTablesResult = await db.execute(
         sql.raw(`SELECT tablename FROM pg_tables 
                  WHERE schemaname = 'public' 
@@ -156,7 +157,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     });
 
     it("should verify foreign key constraints work across tables in polymarket schema", async () => {
-      // Check that foreign key constraints were properly created
       const fkResult = await db.execute(
         sql.raw(`
           SELECT 
@@ -181,7 +181,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
       const foreignKeys = fkResult.rows;
       console.log(`Found ${foreignKeys.length} foreign keys in polymarket schema`);
 
-      // Verify at least some expected foreign keys exist
       interface ForeignKeyResult {
         table_name: string;
         foreign_table_name: string;
@@ -202,7 +201,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     });
 
     it("should create indexes in polymarket schema", async () => {
-      // Check that indexes were created
       const indexResult = await db.execute(
         sql.raw(`
           SELECT 
@@ -218,7 +216,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
       const indexes = indexResult.rows;
       console.log(`Found ${indexes.length} indexes in polymarket schema`);
 
-      // Verify some expected indexes exist
       interface IndexResult {
         tablename: string;
         indexname: string;
@@ -226,7 +223,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
       const marketIndexes = indexes.filter((idx) => (idx as IndexResult).tablename === "markets");
       expect(marketIndexes.length).toBeGreaterThan(0);
 
-      // Check for specific index
       const conditionIdIdx = indexes.find(
         (idx) => (idx as IndexResult).indexname === "markets_condition_id_idx"
       );
@@ -238,22 +234,18 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
     it("should skip re-migration when schema has not changed", async () => {
       console.log("\n🔄 Testing migration idempotency...\n");
 
-      // Try to migrate core schema again
       const _coreResult = await migrator.migrate("@elizaos/plugin-sql", coreSchema, {
         verbose: true,
       });
 
-      // Check logs to verify it was skipped
       const coreMigrations = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/plugin-sql'`)
       );
 
-      // Should only have 1 migration record
       const coreMigrationsRows0 = coreMigrations.rows[0];
       expect(Number(coreMigrationsRows0?.count ?? 0)).toBe(1);
 
-      // Try to migrate plugin schema again
       const _pluginResult = await migrator.migrate("polymarket", testPolymarketSchema, {
         verbose: true,
       });
@@ -263,7 +255,6 @@ describe("Runtime Migrator - Core + Plugin Schema Tests", () => {
                  WHERE plugin_name = 'polymarket'`)
       );
 
-      // Should only have 1 migration record
       const pluginMigrationsRows0 = pluginMigrations.rows[0];
       expect(Number(pluginMigrationsRows0?.count ?? 0)).toBe(1);
     });

--- a/plugins/plugin-sql/src/__tests__/migration/initialization.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/initialization.real.test.ts
@@ -1,6 +1,14 @@
+/**
+ * End-to-end `RuntimeMigrator` tests against a real isolated database:
+ * verifies `initialize()` creates the `migrations` schema and its
+ * `_migrations` / `_journal` / `_snapshots` tables with the expected
+ * columns, that a first `migrate()` of the core schema creates every core
+ * table and records a migration/journal/snapshot row, and that
+ * `getStatus()` reports correctly for both a migrated and a never-seen
+ * plugin name.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper types for database query result rows
 interface MigrationRow {
   plugin_name: string;
   hash: string;
@@ -54,7 +62,7 @@ describe("Runtime Migrator - Initialization Tests", () => {
     _testAgentId = testSetup.testAgentId;
     db = testSetup.db;
 
-    // Create a new migrator for testing (don't initialize yet as tests will do that)
+    // Left uninitialized here; the "Migration Infrastructure Setup" tests call initialize().
     migrator = new RuntimeMigrator(db);
   });
 
@@ -66,10 +74,8 @@ describe("Runtime Migrator - Initialization Tests", () => {
 
   describe("Migration Infrastructure Setup", () => {
     it("should initialize migration schema and tables", async () => {
-      // Initialize the migrator - this creates the migration infrastructure
       await migrator.initialize();
 
-      // Check migrations schema exists
       const schemaResult = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT 1 FROM information_schema.schemata 
@@ -99,7 +105,6 @@ describe("Runtime Migrator - Initialization Tests", () => {
     });
 
     it("should create migration tables with correct structure", async () => {
-      // Check _migrations table structure
       const migrationsColumns = await db.execute(
         sql.raw(`SELECT column_name, data_type, is_nullable
                  FROM information_schema.columns
@@ -114,7 +119,6 @@ describe("Runtime Migrator - Initialization Tests", () => {
       expect(columnNames).toContain("hash");
       expect(columnNames).toContain("created_at");
 
-      // Check _journal table structure
       const journalColumns = await db.execute(
         sql.raw(`SELECT column_name, data_type
                  FROM information_schema.columns
@@ -126,7 +130,6 @@ describe("Runtime Migrator - Initialization Tests", () => {
       expect(journalColumnNames).toContain("plugin_name");
       expect(journalColumnNames).toContain("entries");
 
-      // Check _snapshots table structure
       const snapshotColumns = await db.execute(
         sql.raw(`SELECT column_name, data_type
                  FROM information_schema.columns
@@ -147,7 +150,6 @@ describe("Runtime Migrator - Initialization Tests", () => {
         verbose: true,
       });
 
-      // Verify tables were created
       const tablesResult = await db.execute(
         sql.raw(`SELECT tablename FROM pg_tables 
                  WHERE schemaname = 'public' 

--- a/plugins/plugin-sql/src/__tests__/migration/introspection.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/introspection.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Real-PGlite tests for `DatabaseIntrospector`: reading table/column/FK/
+ * unique/check-constraint/index metadata back from tables created with raw
+ * SQL (not Drizzle), across the public schema, custom schemas, and plugin
+ * schemas; plus `RuntimeMigrator` behavior when tables pre-exist without a
+ * stored snapshot (introspect-then-diff) versus when a snapshot already
+ * exists (diff against the snapshot, skip re-introspection).
+ */
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
 import { sql } from "drizzle-orm";
@@ -15,24 +23,22 @@ describe("Database Introspection Tests", () => {
   let introspector: DatabaseIntrospector;
 
   beforeEach(async () => {
-    // Create in-memory database for testing
     pgClient = new PGlite({ extensions: { vector } });
     db = drizzle(pgClient);
     migrator = new RuntimeMigrator(db);
     introspector = new DatabaseIntrospector(db);
 
-    // Initialize migration tables
     await migrator.initialize();
   });
 
   afterEach(async () => {
-    // Clean up
     await pgClient.close();
   });
 
   describe("Basic Introspection", () => {
     it("should introspect existing tables without snapshots", async () => {
-      // First, create tables directly in the database (simulating pre-existing tables)
+      // Tables created via raw SQL simulate pre-existing production tables
+      // that were never registered with the migrator.
       await db.execute(sql`
         CREATE TABLE users (
           id SERIAL PRIMARY KEY,
@@ -62,15 +68,12 @@ describe("Database Introspection Tests", () => {
         CREATE INDEX idx_posts_published ON posts(published) WHERE published = true
       `);
 
-      // Now introspect the database
       const snapshot = await introspector.introspectSchema("public");
 
-      // Verify the snapshot contains the correct tables
       expect(Object.keys(snapshot.tables)).toHaveLength(2);
       expect(snapshot.tables["public.users"]).toBeDefined();
       expect(snapshot.tables["public.posts"]).toBeDefined();
 
-      // Verify users table structure
       const usersTable = snapshot.tables["public.users"];
       expect(usersTable.name).toBe("users");
       expect(usersTable.schema).toBe("public");
@@ -84,13 +87,11 @@ describe("Database Introspection Tests", () => {
       expect(usersTable.columns.email.notNull).toBe(true);
       expect(usersTable.uniqueConstraints).toBeDefined();
 
-      // Verify posts table structure
       const postsTable = snapshot.tables["public.posts"];
       expect(postsTable.name).toBe("posts");
       expect(Object.keys(postsTable.columns)).toHaveLength(6);
       expect(postsTable.columns.user_id.notNull).toBe(true);
 
-      // Verify foreign key
       const foreignKeys = Object.values(postsTable.foreignKeys);
       expect(foreignKeys).toHaveLength(1);
       expect(foreignKeys[0]).toMatchObject({
@@ -101,12 +102,10 @@ describe("Database Introspection Tests", () => {
         onDelete: "cascade",
       });
 
-      // Verify indexes
       expect(Object.keys(postsTable.indexes)).toHaveLength(2);
     });
 
     it("should handle introspection with custom schemas", async () => {
-      // Create a custom schema with tables
       await db.execute(sql`CREATE SCHEMA plugin_test`);
 
       await db.execute(sql`
@@ -127,15 +126,12 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Introspect the custom schema
       const snapshot = await introspector.introspectSchema("plugin_test");
 
-      // Verify the snapshot
       expect(Object.keys(snapshot.tables)).toHaveLength(2);
       expect(snapshot.tables["plugin_test.settings"]).toBeDefined();
       expect(snapshot.tables["plugin_test.logs"]).toBeDefined();
 
-      // Verify schema is set correctly
       const settingsTable = snapshot.tables["plugin_test.settings"];
       expect(settingsTable.schema).toBe("plugin_test");
       expect(settingsTable.name).toBe("settings");
@@ -156,18 +152,15 @@ describe("Database Introspection Tests", () => {
       const snapshot = await introspector.introspectSchema("public");
       const productsTable = snapshot.tables["public.products"];
 
-      // Verify check constraints were captured
       expect(Object.keys(productsTable.checkConstraints)).toHaveLength(2);
       expect(productsTable.checkConstraints.positive_price).toBeDefined();
       expect(productsTable.checkConstraints.positive_quantity).toBeDefined();
     });
 
     it("should detect existing tables correctly", async () => {
-      // Initially no tables
       let hasExisting = await introspector.hasExistingTables("@elizaos/plugin-sql");
       expect(hasExisting).toBe(false);
 
-      // Create a table
       await db.execute(sql`
         CREATE TABLE test_table (
           id SERIAL PRIMARY KEY,
@@ -175,7 +168,6 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Now should detect tables
       hasExisting = await introspector.hasExistingTables("@elizaos/plugin-sql");
       expect(hasExisting).toBe(true);
     });
@@ -183,7 +175,6 @@ describe("Database Introspection Tests", () => {
 
   describe("Migration with Pre-existing Tables", () => {
     it("should handle migration when tables already exist without snapshots", async () => {
-      // Step 1: Create tables directly (simulating production tables)
       await db.execute(sql`
         CREATE TABLE accounts (
           id SERIAL PRIMARY KEY,
@@ -193,26 +184,22 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Step 2: Define the schema in code (might have some differences)
       const accountsTable = pgTable("accounts", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         username: text("username").notNull().unique(),
         email: text("email").notNull().unique(),
         created_at: timestamp("created_at").defaultNow(),
-        // New field that doesn't exist in DB yet
-        updated_at: timestamp("updated_at").defaultNow(),
+        updated_at: timestamp("updated_at").defaultNow(), // Not present in the DB table above.
       });
 
       const schema = { accounts: accountsTable };
 
-      // Step 3: Run migration - should introspect existing tables first
-      // Use force to allow type changes in test environment
+      // migrate() must introspect the pre-existing table first, since there's no snapshot.
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Step 4: Verify the new column was added
       const result = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -226,7 +213,6 @@ describe("Database Introspection Tests", () => {
     });
 
     it("should preserve data when introspecting and migrating", async () => {
-      // Create table with data
       await db.execute(sql`
         CREATE TABLE products (
           id SERIAL PRIMARY KEY,
@@ -242,7 +228,6 @@ describe("Database Introspection Tests", () => {
         ('Product C', 300)
       `);
 
-      // Define schema with additional column
       const productsTable = pgTable("products", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         name: text("name").notNull(),
@@ -252,21 +237,17 @@ describe("Database Introspection Tests", () => {
 
       const schema = { products: productsTable };
 
-      // Run migration
-      // Use force to allow type changes in test environment
       await migrator.migrate("@elizaos/plugin-sql", schema, {
         verbose: false,
         force: true,
       });
 
-      // Verify data is preserved
       const result = await db.execute(sql`SELECT * FROM products ORDER BY id`);
       expect(result.rows).toHaveLength(3);
       expect(result.rows[0]).toMatchObject({ name: "Product A", price: 100 });
       expect(result.rows[1]).toMatchObject({ name: "Product B", price: 200 });
       expect(result.rows[2]).toMatchObject({ name: "Product C", price: 300 });
 
-      // Verify new column exists
       const columns = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -277,7 +258,6 @@ describe("Database Introspection Tests", () => {
     });
 
     it("should handle complex schema with foreign keys during introspection", async () => {
-      // Create related tables
       await db.execute(sql`
         CREATE TABLE organizations (
           id SERIAL PRIMARY KEY,
@@ -304,13 +284,10 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Introspect the schema
       const snapshot = await introspector.introspectSchema("public");
 
-      // Verify all tables are captured
       expect(Object.keys(snapshot.tables)).toHaveLength(3);
 
-      // Verify foreign keys are captured correctly
       const usersTable = snapshot.tables["public.users"];
       const usersFKs = Object.values(usersTable.foreignKeys);
       expect(usersFKs).toHaveLength(1);
@@ -325,7 +302,6 @@ describe("Database Introspection Tests", () => {
       const projectsFKs = Object.values(projectsTable.foreignKeys);
       expect(projectsFKs).toHaveLength(2);
 
-      // Verify composite unique constraint
       interface UniqueConstraint {
         columns: string[];
       }
@@ -337,7 +313,6 @@ describe("Database Introspection Tests", () => {
     });
 
     it("should handle plugin schemas correctly during introspection", async () => {
-      // Create schema for a plugin
       await db.execute(sql`CREATE SCHEMA test_plugin`);
 
       await db.execute(sql`
@@ -348,11 +323,9 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Test the hasExistingTables method for the plugin
       const hasExisting = await introspector.hasExistingTables("@elizaos/test-plugin");
       expect(hasExisting).toBe(true);
 
-      // Define schema in code
       const testSchema = pgSchema("test_plugin");
       const configTable = testSchema.table("config", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
@@ -363,12 +336,10 @@ describe("Database Introspection Tests", () => {
 
       const schema = { config: configTable };
 
-      // Run migration
       await migrator.migrate("@elizaos/test-plugin", schema, {
         verbose: false,
       });
 
-      // Verify the new column was added
       const result = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -398,7 +369,6 @@ describe("Database Introspection Tests", () => {
     });
 
     it("should not introspect when snapshot already exists", async () => {
-      // Create a table
       const testTable = pgTable("test", {
         id: integer("id").primaryKey(),
         name: text("name"),
@@ -406,10 +376,10 @@ describe("Database Introspection Tests", () => {
 
       const schema = { test: testTable };
 
-      // First migration - will create snapshot
+      // This first migrate() call creates the snapshot the second call diffs against.
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
 
-      // Manually create another table (simulating manual DB change)
+      // Table created outside the migrator, simulating an out-of-band manual DB change.
       await db.execute(sql`
         CREATE TABLE manual_table (
           id SERIAL PRIMARY KEY,
@@ -417,7 +387,6 @@ describe("Database Introspection Tests", () => {
         )
       `);
 
-      // Second migration with updated schema
       const updatedTestTable = pgTable("test", {
         id: integer("id").primaryKey(),
         name: text("name"),
@@ -426,12 +395,12 @@ describe("Database Introspection Tests", () => {
 
       const updatedSchema = { test: updatedTestTable };
 
-      // This should use the existing snapshot, not introspect
+      // Diffs against the stored snapshot rather than introspecting live tables.
       await migrator.migrate("@elizaos/plugin-sql", updatedSchema, {
         verbose: false,
       });
 
-      // The manual_table should still exist but not be in snapshots
+      // manual_table must survive untouched, since it was never part of any snapshot.
       const result = await db.execute(sql`
         SELECT table_name 
         FROM information_schema.tables 

--- a/plugins/plugin-sql/src/__tests__/migration/production-scenario.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/production-scenario.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Real-PGlite tests simulating production migration scenarios: a database
+ * that already has tables from earlier deployments (including the
+ * camelCase-vs-snake_case rename case the runtime migrator must block as
+ * destructive rather than silently drop/re-add), multiple plugins with
+ * pre-existing schemas, recovery from a partially-completed migration,
+ * idempotent repeated migration runs, and introspection at 20-table scale.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
 import { sql } from "drizzle-orm";
@@ -18,12 +26,6 @@ import { RuntimeMigrator } from "../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../runtime-migrator/types";
 import * as coreSchema from "../../schema";
 
-/**
- * These tests simulate real production scenarios where:
- * 1. The database already has tables from previous deployments
- * 2. The migration system is introduced later
- * 3. We need to handle existing data and schema gracefully
- */
 describe("Production Migration Scenarios", () => {
   let pgClient: PGlite;
   let db: DrizzleDB;
@@ -50,10 +52,10 @@ describe("Production Migration Scenarios", () => {
       // skipped branch (e.g. the migration unexpectedly renaming columns) fail loudly.
       expect.assertions(3);
 
-      // Simulate existing production database with OLD camelCase columns
-      // In production, migrations.ts handles RENAME operations BEFORE RuntimeMigrator runs.
-      // RuntimeMigrator alone cannot detect renames - it sees them as DROP + ADD (destructive).
-      // This test verifies that RuntimeMigrator correctly BLOCKS such destructive changes.
+      // Simulates a production DB with the old camelCase columns. In production,
+      // migrations.ts performs RENAME operations before RuntimeMigrator runs;
+      // RuntimeMigrator itself can't detect a rename — it sees old-name-gone +
+      // new-name-present as DROP + ADD, i.e. destructive — so it must block.
 
       await db.execute(sql`
         CREATE TABLE IF NOT EXISTS memories (
@@ -106,7 +108,6 @@ describe("Production Migration Scenarios", () => {
         )
       `);
 
-      // Insert some production data
       const agentId = "123e4567-e89b-12d3-a456-426614174000";
       const roomId = "223e4567-e89b-12d3-a456-426614174000";
 
@@ -126,17 +127,11 @@ describe("Production Migration Scenarios", () => {
         (${agentId}::uuid, ${roomId}::uuid, null, '{"text": "System initialized"}'::jsonb, 'message')
       `);
 
-      // RuntimeMigrator should BLOCK this migration because:
-      // - It sees camelCase columns (agentId, roomId, etc.)
-      // - Schema expects snake_case (agent_id, room_id, etc.)
-      // - This is detected as DROP + ADD = destructive change
       try {
         await migrator.migrate("@elizaos/plugin-sql", coreSchema, {
           verbose: false,
           force: false,
         });
-        // If we get here, the migration wasn't blocked - that's unexpected
-        // Check if there were actually destructive changes detected
         const memoryColumns = await db.execute(sql`
           SELECT column_name FROM information_schema.columns WHERE table_name = 'memories'
         `);
@@ -145,21 +140,17 @@ describe("Production Migration Scenarios", () => {
         // skipped, so the original camelCase "agentId" column must still be present.
         expect(columnNames).toContain("agentId");
       } catch (error) {
-        // Expected: Destructive migration should be blocked
         expect((error as Error).message).toContain("Destructive migration blocked");
       }
 
-      // Verify data is preserved (migration was blocked, not executed)
       const agents = await db.execute(sql`SELECT * FROM agents WHERE id = ${agentId}::uuid`);
       expect(agents.rows[0]).toBeDefined();
       expect(agents.rows[0].name).toBe("Production Agent");
     });
 
     it("should work with tables that already have snake_case columns (post-migration)", async () => {
-      // This test simulates a database that has ALREADY been migrated
-      // (migrations.ts already ran and renamed columns to snake_case)
-      // RuntimeMigrator should handle this gracefully
-
+      // Simulates a DB where migrations.ts already ran and renamed columns to
+      // snake_case, so RuntimeMigrator should see the schema already matching.
       await db.execute(sql`
         CREATE TABLE IF NOT EXISTS memories (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -211,7 +202,6 @@ describe("Production Migration Scenarios", () => {
         )
       `);
 
-      // Insert some production data
       const agentId = "123e4567-e89b-12d3-a456-426614174000";
       const roomId = "223e4567-e89b-12d3-a456-426614174000";
 
@@ -233,21 +223,17 @@ describe("Production Migration Scenarios", () => {
         (${agentId}::uuid, ${roomId}::uuid, null, '{"text": "Context established"}'::jsonb, 'message')
       `);
 
-      // RuntimeMigrator should work fine - schema already matches
       await migrator.migrate("@elizaos/plugin-sql", coreSchema, {
         verbose: false,
       });
 
-      // Verify data is preserved
       const agents = await db.execute(sql`SELECT * FROM agents WHERE id = ${agentId}::uuid`);
       expect(agents.rows[0]).toBeDefined();
       expect(agents.rows[0].name).toBe("Production Agent");
 
-      // Verify memories data is preserved
       const memories = await db.execute(sql`SELECT COUNT(*) as count FROM memories`);
       expect(Number(memories.rows[0].count)).toBe(3);
 
-      // Check that columns are snake_case
       const memoryColumns = await db.execute(sql`
         SELECT column_name
         FROM information_schema.columns
@@ -263,7 +249,6 @@ describe("Production Migration Scenarios", () => {
     });
 
     it("should handle version mismatch between DB and code schema", async () => {
-      // Create an older version of a table structure
       await db.execute(sql`
         CREATE TABLE participants (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -274,7 +259,6 @@ describe("Production Migration Scenarios", () => {
         )
       `);
 
-      // Add some data
       const agentId = "323e4567-e89b-12d3-a456-426614174000";
       const roomId = "423e4567-e89b-12d3-a456-426614174000";
 
@@ -285,7 +269,6 @@ describe("Production Migration Scenarios", () => {
         (${agentId}::uuid, ${roomId}::uuid, 'Bob')
       `);
 
-      // The new schema might have additional fields
       const participantTable = pgTable("participants", {
         id: uuid("id").primaryKey().defaultRandom(),
         agent_id: uuid("agent_id").notNull(),
@@ -300,16 +283,13 @@ describe("Production Migration Scenarios", () => {
 
       const schema = { participants: participantTable };
 
-      // Run migration
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
 
-      // Verify data is preserved
       const result = await db.execute(sql`SELECT * FROM participants ORDER BY user_name`);
       expect(result.rows).toHaveLength(2);
       expect(result.rows[0].user_name).toBe("Alice");
       expect(result.rows[1].user_name).toBe("Bob");
 
-      // Verify new columns exist
       const columns = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -326,9 +306,7 @@ describe("Production Migration Scenarios", () => {
 
   describe("Scenario 2: Multiple Plugin Tables in Production", () => {
     it("should handle multiple plugins with existing tables", async () => {
-      // Simulate a production environment with multiple plugins already deployed
-
-      // Plugin 1: Analytics plugin with its own schema
+      // Analytics plugin with its own schema, already deployed.
       await db.execute(sql`CREATE SCHEMA IF NOT EXISTS analytics`);
 
       await db.execute(sql`
@@ -351,7 +329,6 @@ describe("Production Migration Scenarios", () => {
         )
       `);
 
-      // Add some production data
       await db.execute(sql`
         INSERT INTO analytics.events (event_type, agent_id, payload) 
         VALUES 
@@ -366,17 +343,14 @@ describe("Production Migration Scenarios", () => {
         ('memory_usage_mb', 512.0, '{"process": "agent"}'::jsonb)
       `);
 
-      // Check if tables exist
       const hasExisting = await introspector.hasExistingTables("@elizaos/analytics");
       expect(hasExisting).toBe(true);
 
-      // Introspect to verify structure
       const snapshot = await introspector.introspectSchema("analytics");
       expect(Object.keys(snapshot.tables)).toHaveLength(2);
       expect(snapshot.tables["analytics.events"]).toBeDefined();
       expect(snapshot.tables["analytics.metrics"]).toBeDefined();
 
-      // Verify data is there
       const events = await db.execute(sql`
         SELECT COUNT(*) as count FROM analytics.events
       `);
@@ -389,7 +363,6 @@ describe("Production Migration Scenarios", () => {
     });
 
     it("should handle schema conflicts gracefully", async () => {
-      // Create a table that conflicts with what a plugin expects
       await db.execute(sql`
         CREATE TABLE tasks (
           id INTEGER PRIMARY KEY,
@@ -409,14 +382,12 @@ describe("Production Migration Scenarios", () => {
 
       const schema = { tasks: tasksTable };
 
-      // This should detect the type conflict
       try {
         await migrator.migrate("@elizaos/plugin-sql", schema, {
           verbose: false,
           force: false, // Don't allow destructive changes
         });
 
-        // If we get here without error, check what happened
         const columns = await db.execute(sql`
           SELECT column_name, data_type 
           FROM information_schema.columns 
@@ -424,10 +395,8 @@ describe("Production Migration Scenarios", () => {
           ORDER BY column_name
         `);
 
-        // The migration should have been blocked or handled gracefully
         expect(columns.rows).toBeDefined();
       } catch (error) {
-        // Expected: Destructive migration should be blocked
         expect((error as Error).message).toContain("Destructive migration blocked");
       }
     });
@@ -435,7 +404,8 @@ describe("Production Migration Scenarios", () => {
 
   describe("Scenario 3: Recovery from Failed Migrations", () => {
     it("should handle partial migration state gracefully", async () => {
-      // Simulate a partial migration where some tables were created but not all
+      // Only `users` exists here; `profiles` and `sessions` below simulate
+      // tables a prior, incomplete migration run never got to create.
       await db.execute(sql`
         CREATE TABLE users (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -444,8 +414,6 @@ describe("Production Migration Scenarios", () => {
         )
       `);
 
-      // But the related tables were not created (simulating a failed migration)
-      // Now define the complete schema
       const usersTable = pgTable("users", {
         id: uuid("id").primaryKey().defaultRandom(),
         name: text("name").notNull(),
@@ -477,10 +445,8 @@ describe("Production Migration Scenarios", () => {
         sessions: sessionsTable,
       };
 
-      // Run migration - should complete the partial migration
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
 
-      // Verify all tables exist
       const tables = await db.execute(sql`
         SELECT table_name 
         FROM information_schema.tables 
@@ -494,7 +460,6 @@ describe("Production Migration Scenarios", () => {
       expect(tableNames).toContain("profiles");
       expect(tableNames).toContain("sessions");
 
-      // Verify the users table was updated with new field
       const userColumns = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -507,7 +472,6 @@ describe("Production Migration Scenarios", () => {
     });
 
     it("should be idempotent when run multiple times", async () => {
-      // Create initial state
       await db.execute(sql`
         CREATE TABLE products (
           id SERIAL PRIMARY KEY,
@@ -522,7 +486,6 @@ describe("Production Migration Scenarios", () => {
         ('Product B', 149.99)
       `);
 
-      // Define schema
       const productsTable = pgTable("products", {
         id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
         name: text("name").notNull(),
@@ -532,12 +495,10 @@ describe("Production Migration Scenarios", () => {
 
       const schema = { products: productsTable };
 
-      // Run migration multiple times
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
       await migrator.migrate("@elizaos/plugin-sql", schema, { verbose: false });
 
-      // Verify data is still intact
       const products = await db.execute(sql`
         SELECT * FROM products ORDER BY id
       `);
@@ -545,7 +506,6 @@ describe("Production Migration Scenarios", () => {
       expect(products.rows[0].name).toBe("Product A");
       expect(products.rows[1].name).toBe("Product B");
 
-      // Verify structure is correct (not duplicated)
       const columns = await db.execute(sql`
         SELECT column_name 
         FROM information_schema.columns 
@@ -561,7 +521,6 @@ describe("Production Migration Scenarios", () => {
 
   describe("Scenario 4: Large Production Database", () => {
     it("should handle introspection of many tables efficiently", async () => {
-      // Create multiple tables to simulate a large production database
       const tableCount = 20;
 
       for (let i = 0; i < tableCount; i++) {
@@ -575,7 +534,6 @@ describe("Production Migration Scenarios", () => {
         `)
         );
 
-        // Add some data
         await db.execute(
           sql.raw(`
           INSERT INTO table_${i} (data) VALUES ('Data for table ${i}')
@@ -583,7 +541,6 @@ describe("Production Migration Scenarios", () => {
         );
       }
 
-      // Add some indexes
       for (let i = 0; i < 5; i++) {
         await db.execute(
           sql.raw(`
@@ -592,13 +549,10 @@ describe("Production Migration Scenarios", () => {
         );
       }
 
-      // Introspect the database
       const snapshot = await introspector.introspectSchema("public");
 
-      // Verify all tables were captured
       expect(Object.keys(snapshot.tables)).toHaveLength(tableCount);
 
-      // Verify data exists
       for (let i = 0; i < tableCount; i++) {
         const result = await db.execute(sql.raw(`SELECT COUNT(*) as count FROM table_${i}`));
         expect(Number(result.rows[0].count)).toBe(1);

--- a/plugins/plugin-sql/src/__tests__/migration/runtime-migrator.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/runtime-migrator.real.test.ts
@@ -1,6 +1,15 @@
+/**
+ * End-to-end `RuntimeMigrator` tests against a real isolated Postgres
+ * database, covering: migration-infrastructure init, running the core
+ * plugin-sql schema and tracking it in `_migrations`/`_journal`/`_snapshots`,
+ * column type/FK/unique/check-constraint/index creation, idempotent re-runs,
+ * dry-run and reset, error handling for an invalid schema, and — critically —
+ * that migrating plugin-sql never drops or alters tables/columns belonging
+ * to other plugins that happen to share the public schema. Accumulates a
+ * pass/fail summary logged in `afterAll` alongside the vitest assertions.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper types for database query result rows
 interface ExistsRow {
   exists: boolean;
 }
@@ -67,14 +76,12 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
     db = testSetup.db;
     cleanup = testSetup.cleanup;
 
-    // Initialize the runtime migrator
     migrator = new RuntimeMigrator(db);
 
-    // We're already in an isolated schema, so no cleanup needed
     console.log("🗑️  Test environment ready...");
 
     try {
-      // Drop migrations schema if exists (in case of previous test failure)
+      // Guards against a leftover `migrations` schema from a previous failed run.
       await db.execute(sql`DROP SCHEMA IF EXISTS migrations CASCADE`);
 
       console.log("✅ Test environment cleaned\n");
@@ -84,7 +91,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
   });
 
   afterAll(async () => {
-    // Print test summary
     console.log(`\n${"=".repeat(80)}`);
     console.log("📊 RUNTIME MIGRATOR TEST SUMMARY");
     console.log(`${"=".repeat(80)}\n`);
@@ -112,7 +118,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
     it("should initialize migration tables", async () => {
       await migrator.initialize();
 
-      // Check migrations schema exists
       const schemaResult = await db.execute(
         sql`SELECT EXISTS (
           SELECT 1 FROM information_schema.schemata 
@@ -129,7 +134,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         testResults.failed.push("Migration schema not created");
       }
 
-      // Check all migration tables exist
       const tables = ["_migrations", "_journal", "_snapshots"];
 
       for (const tableName of tables) {
@@ -155,10 +159,8 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
 
   describe("Schema Migration Execution", () => {
     it("should run initial migration for plugin-sql schema", async () => {
-      // Run the migration with the actual schema
       await migrator.migrate("plugin-sql", schema, { verbose: true });
 
-      // Check that tables were created in public schema
       const tablesResult = await db.execute(
         sql`SELECT tablename FROM pg_tables 
             WHERE schemaname = 'public' 
@@ -168,7 +170,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
       const createdTables = tablesResult.rows.map((r: TableInfoRow) => r.tablename);
       console.log(`\n📋 Tables created: ${createdTables.length}`);
 
-      // Expected tables from schema
       const expectedTables = [
         "agents",
         "cache",
@@ -347,10 +348,8 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
 
   describe("Idempotency", () => {
     it("should handle running the same migration twice", async () => {
-      // Run migration again - should not fail or create duplicates
       await migrator.migrate("plugin-sql", schema);
 
-      // Check that we still have only one migration record
       const result = await db.execute(
         sql`SELECT COUNT(*) as count
             FROM migrations._migrations
@@ -416,7 +415,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
 
   describe("Index Creation", () => {
     it("should create indexes on tables", async () => {
-      // First, let's see ALL indexes
       const allIndexes = await db.execute(
         sql`SELECT schemaname, tablename, indexname
             FROM pg_indexes
@@ -424,7 +422,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
       );
       console.log("All indexes in public schema:", allIndexes.rows);
 
-      // Then check for idx_ prefixed ones
       const result = await db.execute(
         sql`SELECT COUNT(*) as count
             FROM pg_indexes
@@ -435,14 +432,13 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
       const indexCount = parseInt(String((result.rows[0] as unknown as CountRow).count), 10);
       console.log("Count of idx_ indexes:", indexCount);
 
-      // Our schema does create indexes with idx_ prefix
       if (indexCount > 0) {
         testResults.passed.push(`Indexes created: ${indexCount}`);
       } else {
         testResults.failed.push("🔴 CRITICAL GAP: No indexes created");
       }
 
-      // We expect indexes to be created (memories table has idx_ indexes)
+      // The memories table's idx_-prefixed indexes are the ones asserted here.
       expect(indexCount).toBeGreaterThan(0);
     });
   });
@@ -458,14 +454,13 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
 
       const checkCount = parseInt(String((result.rows[0] as unknown as CountRow).count), 10);
 
-      // Our schema does create check constraints (e.g., in memories table)
       if (checkCount > 0) {
         testResults.passed.push(`Check constraints created: ${checkCount}`);
       } else {
         testResults.failed.push("🟡 GAP: No check constraints created");
       }
 
-      // We expect check constraints to be created
+      // The memories table's check constraints are the ones asserted here.
       expect(checkCount).toBeGreaterThan(0);
     });
   });
@@ -487,7 +482,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
     });
 
     it("should handle errors gracefully", async () => {
-      // Try to migrate with invalid schema
       let _errorCaught = false;
 
       try {
@@ -498,12 +492,10 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         _errorCaught = true;
       }
 
-      // The migrator now records empty schemas for plugins with no tables
-      // So we need to check if it was recorded as an empty migration
+      // A schema with no real tables is still recorded and considered "hasRun",
+      // but must not create any table matching the bogus entry.
       const _status = await migrator.getStatus("invalid-plugin");
 
-      // An empty schema is still considered "hasRun"
-      // but it should not have created any real tables
       const tablesResult = await db.execute(
         sql`SELECT COUNT(*) as count
             FROM information_schema.tables
@@ -525,7 +517,7 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
 
   describe("Table Filtering - Ignoring Other Plugin Tables", () => {
     it("should ignore tables in public schema that are not in plugin-sql schema", async () => {
-      // Create a table that is NOT in the plugin-sql schema (simulating another plugin)
+      // Simulates another plugin's table living alongside plugin-sql's own tables.
       await db.execute(
         sql`CREATE TABLE IF NOT EXISTS public.custom_analytics (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -536,23 +528,19 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         )`
       );
 
-      // Create an index on the custom table
       await db.execute(
         sql`CREATE INDEX IF NOT EXISTS idx_custom_analytics_event_type
             ON public.custom_analytics(event_type)`
       );
 
-      // Insert some test data
       await db.execute(
         sql`INSERT INTO public.custom_analytics (event_type, user_id, data)
             VALUES ('page_view', gen_random_uuid(), '{"page": "/home"}'::jsonb)`
       );
 
-      // Now run migration again with plugin-sql schema
-      // This should NOT try to drop the custom_analytics table
+      // Must not drop custom_analytics — it isn't part of the plugin-sql schema.
       await migrator.migrate("plugin-sql", schema, { verbose: true });
 
-      // Verify custom_analytics table still exists
       const tableExists = await db.execute(
         sql`SELECT EXISTS (
           SELECT 1 FROM pg_tables
@@ -570,7 +558,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         testResults.failed.push("Table filtering: custom_analytics table was deleted!");
       }
 
-      // Verify the data is still there
       const dataResult = await db.execute(
         sql`SELECT COUNT(*) as count FROM public.custom_analytics`
       );
@@ -587,12 +574,11 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         testResults.failed.push("Table filtering: custom_analytics data was deleted!");
       }
 
-      // Clean up
       await db.execute(sql`DROP TABLE IF EXISTS public.custom_analytics CASCADE`);
     });
 
     it("should not schedule DROP for tables from other plugins in public schema", async () => {
-      // Create a table simulating another plugin's data
+      // Simulates another plugin's data table living in the shared public schema.
       await db.execute(
         sql`CREATE TABLE IF NOT EXISTS public.other_plugin_data (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -603,10 +589,8 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         )`
       );
 
-      // Run migration
       await migrator.migrate("plugin-sql", schema, { verbose: true });
 
-      // Verify the table still exists and was not touched
       const tableExists = await db.execute(
         sql`SELECT EXISTS (
           SELECT 1 FROM pg_tables
@@ -618,8 +602,8 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
       const exists = (tableExists.rows[0] as ExistsRow).exists;
       expect(exists).toBe(true);
 
-      // Also verify the server_id column was not dropped by RuntimeMigrator
-      // (migrations.ts might drop it, but RuntimeMigrator should not)
+      // migrations.ts (which runs before RuntimeMigrator) may drop server_id,
+      // but RuntimeMigrator itself must never touch this foreign table.
       const columnExists = await db.execute(
         sql`SELECT EXISTS (
           SELECT 1 FROM information_schema.columns
@@ -629,8 +613,6 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         ) as exists`
       );
 
-      // The column might be dropped by migrations.ts (runs before RuntimeMigrator)
-      // but RuntimeMigrator itself should not touch this table
       const _serverIdExists = (columnExists.rows[0] as ExistsRow).exists;
 
       if (exists) {
@@ -643,19 +625,16 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
         );
       }
 
-      // Clean up
       await db.execute(sql`DROP TABLE IF EXISTS public.other_plugin_data CASCADE`);
     });
   });
 
   describe("Development Features", () => {
     it("should support dry-run mode", async () => {
-      // Test dry-run doesn't actually execute
       await migrator.migrate("dry-run-test", schema, {
         dryRun: true,
       });
 
-      // Check no tables were created
       const result = await db.execute(
         sql`SELECT COUNT(*) as count
             FROM migrations._migrations
@@ -673,13 +652,10 @@ describe("Runtime Migrator - PostgreSQL Integration Tests", () => {
     });
 
     it("should support reset for development", async () => {
-      // Create a test migration
       await migrator.migrate("reset-test", { testTable: {} });
 
-      // Reset it
       await migrator.reset("reset-test");
 
-      // Check it's gone
       const status = await migrator.getStatus("reset-test");
       expect(status.hasRun).toBe(false);
 

--- a/plugins/plugin-sql/src/__tests__/migration/runtime-simulation.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/runtime-simulation.real.test.ts
@@ -1,6 +1,15 @@
+/**
+ * End-to-end `RuntimeMigrator` test against a real isolated database that
+ * walks the full runtime flow a booting agent goes through: initialize
+ * migration infrastructure, migrate the core `@elizaos/plugin-sql` schema,
+ * migrate a plugin schema (polymarket) into its own Postgres schema, inspect
+ * the resulting migration/snapshot/journal rows, check `getStatus()` for
+ * both, then simulate an agent restart with a fresh `RuntimeMigrator`
+ * instance to confirm re-running both migrations is a no-op. A second test
+ * confirms migration records preserve registration order.
+ */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Helper types for database query result rows
 interface MigrationRow {
   plugin_name: string;
   hash: string;
@@ -64,11 +73,10 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 1: Initialize Migration System");
     console.log("=".repeat(80));
 
-    // Create a fresh migrator instance (simulating runtime startup)
+    // Fresh instance simulates a runtime process starting up cold.
     migrator = new RuntimeMigrator(db);
     await migrator.initialize();
 
-    // Verify migration infrastructure was created
     const schemasResult = await db.execute(sql`
       SELECT schema_name 
       FROM information_schema.schemata 
@@ -77,7 +85,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     expect(schemasResult.rows.length).toBe(1);
     console.log("✅ Migration schema created");
 
-    // Check migration tables
     const tablesResult = await db.execute(sql`
       SELECT tablename 
       FROM pg_tables 
@@ -94,12 +101,11 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 2: Migrate Core Schema (@elizaos/plugin-sql)");
     console.log("=".repeat(80));
 
-    // Migrate core schema (this is what plugin-sql does on initialization)
+    // Mirrors what plugin-sql's own init does.
     await migrator.migrate("@elizaos/plugin-sql", coreSchema, {
       verbose: true,
     });
 
-    // Verify core migration was recorded
     const coreMigrationCheck = await db.execute(sql`
       SELECT * FROM migrations._migrations 
       WHERE plugin_name = '@elizaos/plugin-sql'
@@ -115,7 +121,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("  - Hash:", coreMigration.hash);
     console.log("  - Created:", coreMigration.created_at);
 
-    // Check snapshots for core
     const coreSnapshots = await db.execute(sql`
       SELECT * FROM migrations._snapshots 
       WHERE plugin_name = '@elizaos/plugin-sql'
@@ -123,7 +128,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     `);
     console.log(`\n📸 Core snapshots: ${coreSnapshots.rows.length}`);
 
-    // Verify core tables in public schema
     const publicTables = await db.execute(sql`
       SELECT tablename FROM pg_tables 
       WHERE schemaname = 'public' 
@@ -137,12 +141,11 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 3: Migrate Plugin Schema (polymarket)");
     console.log("=".repeat(80));
 
-    // Now migrate the polymarket plugin schema (simulating plugin initialization)
+    // Mirrors a plugin's own init calling migrate() with its schema.
     await migrator.migrate("polymarket", testPolymarketSchema, {
       verbose: true,
     });
 
-    // Verify polymarket migration was recorded
     const polymarketMigrationCheck = await db.execute(sql`
       SELECT * FROM migrations._migrations 
       WHERE plugin_name = 'polymarket'
@@ -163,7 +166,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("  - Hash:", polymarketMigration.hash);
     console.log("  - Created:", polymarketMigration.created_at);
 
-    // Check snapshots for polymarket
     const polymarketSnapshots = await db.execute(sql`
       SELECT * FROM migrations._snapshots 
       WHERE plugin_name = 'polymarket'
@@ -171,7 +173,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     `);
     console.log(`\n📸 Polymarket snapshots: ${polymarketSnapshots.rows.length}`);
 
-    // Verify polymarket schema and tables
     const polymarketSchemaExists = await db.execute(sql`
       SELECT EXISTS (
         SELECT 1 FROM information_schema.schemata 
@@ -195,7 +196,7 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 4: Verify Complete Migration State");
     console.log("=".repeat(80));
 
-    // Check total migration records (should be 2: core + polymarket)
+    // Expects exactly 2: core + polymarket.
     const allMigrations = await db.execute(sql`
       SELECT 
         plugin_name,
@@ -213,7 +214,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
       console.log(`  - ${migration.plugin_name}: ${migration.hash} (${migration.created_at})`);
     }
 
-    // Check journal entries (if table exists)
     try {
       const journalEntries = await db.execute(sql`
         SELECT * FROM migrations._journal 
@@ -228,7 +228,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
       console.log("\n📓 Journal table not available or empty");
     }
 
-    // Verify snapshot content for polymarket
     const latestPolymarketSnapshot = await db.execute(sql`
       SELECT * FROM migrations._snapshots 
       WHERE plugin_name = 'polymarket'
@@ -249,7 +248,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
         console.log("  - Tables:", Object.keys(snapshotData.tables || {}).length);
         console.log("  - Table names:", Object.keys(snapshotData.tables || {}).join(", "));
 
-        // Check if tables are correctly namespaced
         for (const tableName of Object.keys(snapshotData.tables || {})) {
           expect(tableName).toMatch(/^polymarket\./);
           console.log(`    ✓ ${tableName} is correctly namespaced`);
@@ -263,7 +261,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 5: Test Migration Status Methods");
     console.log("=".repeat(80));
 
-    // Test getStatus for both plugins
     const coreStatus = await migrator.getStatus("@elizaos/plugin-sql");
     const polymarketStatus = await migrator.getStatus("polymarket");
 
@@ -285,11 +282,10 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("STEP 6: Simulate Re-initialization (Idempotency Check)");
     console.log("=".repeat(80));
 
-    // Create a new migrator instance (simulating restart)
+    // Fresh instance simulates an agent process restart.
     const migrator2 = new RuntimeMigrator(db);
     await migrator2.initialize();
 
-    // Try to migrate again - should skip both
     console.log("\n🔄 Re-running migrations (should skip)...");
 
     await migrator2.migrate("@elizaos/plugin-sql", coreSchema, {
@@ -300,7 +296,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
       verbose: false,
     });
 
-    // Verify still only 2 migration records
     const finalMigrationCount = await db.execute(sql`
       SELECT COUNT(*) as count FROM migrations._migrations
     `);
@@ -309,7 +304,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     const finalFirstRow = finalMigrationCount.rows?.[0];
     expect(Number(finalFirstRow?.count)).toBe(2);
 
-    // Final summary
     console.log(`\n${"=".repeat(80)}`);
     console.log("✅ MIGRATION SIMULATION COMPLETE");
     console.log("=".repeat(80));
@@ -327,7 +321,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
     console.log("Testing Plugin Registration Order");
     console.log("=".repeat(80));
 
-    // Check if order matters for migration recording
     const migrationOrder = await db.execute(sql`
       SELECT 
         plugin_name,
@@ -342,7 +335,6 @@ describe("Runtime Simulation - Full Migration Flow", () => {
       console.log(`  ${record.migration_order}. ${record.plugin_name} at ${record.created_at}`);
     }
 
-    // Core should be migrated first
     const firstMigration = migrationOrder.rows[0] as MigrationOrderRow;
     expect(firstMigration.plugin_name).toBe("@elizaos/plugin-sql");
 

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/01-drop-column-with-data.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/01-drop-column-with-data.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Schema-evolution test against the real elizaOS production schemas: proves
+ * `RuntimeMigrator` detects a column drop (removing `agents.username`) as
+ * data-losing, blocks it in both development and production without
+ * `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS`, allows it via that env var or the
+ * `force`/`allowDataLoss` migrate options, and that unrelated tables/rows
+ * survive the drop.
+ */
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../../runtime-migrator/runtime-migrator";
@@ -23,13 +31,6 @@ import { worldTable } from "../../../schema/world";
 import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-helpers";
 
 type CountRow = { count: number };
-
-/**
- * Schema Evolution Test 1: Dropping Columns from Production Schema
- *
- * This test uses the ACTUAL elizaOS production schemas to verify
- * that schema evolution properly handles column drops with real data.
- */
 
 describe("Schema Evolution Test: Drop Column with Production Schema", () => {
   let db: DrizzleDB;
@@ -75,16 +76,13 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
   });
 
   it("should handle dropping username column from agents table with production data", async () => {
-    // Apply the full production schema
     const schemaV1 = getFullSchemaV1();
 
     console.log("🚀 Migrating full production schema V1...");
     await migrator.migrate("@elizaos/production-schema-v1", schemaV1);
 
-    // Insert production-like data into multiple related tables
     console.log("\n📝 Inserting production data...");
 
-    // Insert agents with username field
     await db.insert(agentTable).values([
       {
         id: "550e8400-e29b-41d4-a716-446655440001",
@@ -120,7 +118,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       },
     ]);
 
-    // Insert related entities
     await db.insert(entityTable).values([
       {
         id: "660e8400-e29b-41d4-a716-446655440001",
@@ -136,7 +133,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       },
     ]);
 
-    // Insert memories linked to agents
     await db.insert(memoryTable).values([
       {
         id: "770e8400-e29b-41d4-a716-446655440001",
@@ -161,7 +157,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       },
     ]);
 
-    // Verify data was inserted
     const agentsBeforeCount = await db.execute(sql`SELECT COUNT(*) as count FROM agents`);
     const memoriesBeforeCount = await db.execute(sql`SELECT COUNT(*) as count FROM memories`);
 
@@ -169,7 +164,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     console.log(`  - Agents: ${(agentsBeforeCount.rows[0] as unknown as CountRow).count}`);
     console.log(`  - Memories: ${(memoriesBeforeCount.rows[0] as unknown as CountRow).count}`);
 
-    // Check usernames exist
     const usernameCheck = await db.execute(
       sql`SELECT name, username FROM agents WHERE username IS NOT NULL`
     );
@@ -179,8 +173,7 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       console.log(`    • ${typedRow.name}: @${typedRow.username}`);
     });
 
-    // Now create V2 schema WITHOUT username column (destructive change!)
-    // We need to recreate the agent table definition without username
+    // V2 redefines the agents table without `username` — a destructive change.
     const { pgTable, text, uuid, boolean, timestamp, jsonb, unique } = await import(
       "drizzle-orm/pg-core"
     );
@@ -193,7 +186,7 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
         createdAt: timestamp("created_at", { withTimezone: true }).default(sql`now()`).notNull(),
         updatedAt: timestamp("updated_at", { withTimezone: true }).default(sql`now()`).notNull(),
         name: text("name").notNull(),
-        // username: text('username'), // REMOVED - destructive change!
+        // No `username` field — its absence relative to V1 is the destructive change under test.
         system: text("system").default(""),
         bio: jsonb("bio").$type<string | string[]>().default(sql`'[]'::jsonb`),
         messageExamples: jsonb("message_examples").default(sql`'[]'::jsonb`).notNull(),
@@ -215,7 +208,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       agents: agentTableV2, // Replace with version without username
     };
 
-    // Test 1: Check migration for data loss warnings
     console.log("\n🔍 Checking migration for data loss...");
     const dataLossCheck = await migrator.checkMigration("@elizaos/production-schema-v1", schemaV2);
 
@@ -232,7 +224,7 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
       });
     }
 
-    // Test 2: Attempt migration without environment variable (should fail even in development)
+    // Must be blocked even in development, absent the override env var.
     process.env.NODE_ENV = "development";
     delete process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS;
 
@@ -249,7 +241,7 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     expect(blockedError?.message).toContain("ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS");
     console.log(`  ✅ Migration blocked: ${blockedError?.message}`);
 
-    // Test 3: Production mode should also block (even with more warnings)
+    // Production mode blocks too, with a stricter/longer error message.
     process.env.NODE_ENV = "production";
 
     console.log("\n🛡️  Testing production protection...");
@@ -265,7 +257,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     expect(productionError?.message).toContain("ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS");
     console.log(`  ✅ Production blocked: ${productionError?.message?.substring(0, 80) || ""}...`);
 
-    // Test 4: Allow migration with environment variable
     process.env.NODE_ENV = "development";
     process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = "true";
 
@@ -276,7 +267,7 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     // Reset for next test
     await migrator.migrate("@elizaos/production-schema-v1", schemaV1);
 
-    // Test 5: Force migration with options (alternative method)
+    // The force/allowDataLoss migrate() options are an alternative to the env var above.
     delete process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS;
 
     console.log("\n⚠️  Testing with force option...");
@@ -286,7 +277,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     });
     console.log("  ✅ Migration allowed with force option");
 
-    // Verify column was dropped
     const columnsAfter = await db.execute(
       sql`SELECT column_name FROM information_schema.columns 
           WHERE table_name = 'agents' AND table_schema = 'public'`
@@ -299,7 +289,6 @@ describe("Schema Evolution Test: Drop Column with Production Schema", () => {
     console.log(`  ✅ Agent table columns: ${columnNames.length}`);
     console.log("  ❌ Username column has been dropped");
 
-    // Verify related data is intact
     const agentsAfterCount = await db.execute(sql`SELECT COUNT(*) as count FROM agents`);
     const memoriesAfterCount = await db.execute(sql`SELECT COUNT(*) as count FROM memories`);
 

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/02-drop-table-with-relationships.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/02-drop-table-with-relationships.real.test.ts
@@ -1,15 +1,22 @@
+/**
+ * Schema-evolution test against the real elizaOS production schemas (with
+ * their actual foreign-key graph): proves `RuntimeMigrator` detects dropping
+ * the `memories` table — and dropping several interconnected tables at once
+ * (entities/memories/relationships/embeddings) — as data-losing, blocks it in
+ * development and production without `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS`,
+ * and surfaces what happens (including FK-constraint failures from
+ * `embeddings`) when the override is set.
+ */
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../../runtime-migrator/types";
 import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-helpers";
 
-// Helper types for database query result rows
 interface ExistsRow {
   exists: boolean;
 }
 
-// Helper function to safely cast query result rows
 function asExistsRow(row: unknown): ExistsRow {
   return row as ExistsRow;
 }
@@ -23,7 +30,6 @@ interface StatsRow {
   [key: string]: unknown;
 }
 
-// Import ALL production schemas
 import { agentTable } from "../../../schema/agent";
 import { cacheTable } from "../../../schema/cache";
 import { channelTable } from "../../../schema/channel";
@@ -42,19 +48,11 @@ import { roomTable } from "../../../schema/room";
 import { taskTable } from "../../../schema/tasks";
 import { worldTable } from "../../../schema/world";
 
-/**
- * Schema Evolution Test 2: Dropping Tables with Foreign Key Relationships
- *
- * This test uses the ACTUAL elizaOS production schemas with their
- * complex foreign key relationships to verify cascade behavior.
- */
-
 describe("Schema Evolution Test: Drop Table with Production Relationships", () => {
   let db: DrizzleDB;
   let migrator: RuntimeMigrator;
   let cleanup: () => Promise<void>;
 
-  // Full production schema
   const getFullSchemaV1 = () => ({
     agents: agentTable,
     memories: memoryTable,
@@ -93,16 +91,13 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
   });
 
   it("should handle dropping memories table with cascade effects on production schema", async () => {
-    // Apply full production schema
     const schemaV1 = getFullSchemaV1();
 
     console.log("🚀 Migrating full production schema...");
     await migrator.migrate("@elizaos/production-schema-v1", schemaV1);
 
-    // Insert interconnected production data
     console.log("\n📝 Creating interconnected production data...");
 
-    // 1. Create agents
     const agent1Id = "550e8400-e29b-41d4-a716-446655440001";
     const agent2Id = "550e8400-e29b-41d4-a716-446655440002";
 
@@ -139,7 +134,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       },
     ]);
 
-    // 2. Create entities
     const entity1Id = "660e8400-e29b-41d4-a716-446655440001";
     const entity2Id = "660e8400-e29b-41d4-a716-446655440002";
 
@@ -158,7 +152,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       },
     ]);
 
-    // 3. Create rooms
     const room1Id = "770e8400-e29b-41d4-a716-446655440001";
     const room2Id = "770e8400-e29b-41d4-a716-446655440002";
     const channelId1 = "990e8400-e29b-41d4-a716-446655440001";
@@ -186,7 +179,7 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       },
     ]);
 
-    // 4. Create memories (with foreign keys to agents, entities, rooms)
+    // Memories carry FKs to agents, entities, and rooms.
     await db.insert(memoryTable).values([
       {
         id: "880e8400-e29b-41d4-a716-446655440001",
@@ -220,7 +213,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       },
     ]);
 
-    // 5. Create relationships
     await db.insert(relationshipTable).values([
       {
         sourceEntityId: entity1Id,
@@ -231,10 +223,9 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       },
     ]);
 
-    // Skip embeddings creation as it's complex with vectors
-    // The key test is whether dropping memories table is detected
+    // Embeddings are skipped here (vector setup is complex); the case under
+    // test is whether dropping the memories table itself is detected.
 
-    // Verify all relationships are in place
     console.log("\n📊 Production data created:");
     const counts = await db.execute(sql`
       SELECT 
@@ -252,11 +243,10 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
     console.log(`  - Memories: ${stats.memories} (with FKs to agents, entities, rooms)`);
     console.log(`  - Relationships: ${stats.relationships}`);
 
-    // Create V2 schema WITHOUT memories table (destructive!)
-    // This will break foreign key relationships from embeddings
+    // V2 omits `memories` — a destructive drop — while `embeddings` still
+    // holds foreign keys pointing at it, which is the cascade case under test.
     const schemaV2 = {
       agents: agentTable,
-      // memories: memoryTable, // REMOVED - this will cause cascade issues!
       entities: entityTable,
       relationships: relationshipTable,
       rooms: roomTable,
@@ -267,14 +257,13 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       channels: channelTable,
       channelParticipants: channelParticipantsTable,
       components: componentTable,
-      embeddings: embeddingTable, // Still has references to memories!
+      embeddings: embeddingTable,
       logs: logTable,
       cache: cacheTable,
       tasks: taskTable,
       messageServerAgents: messageServerAgentsTable,
     };
 
-    // Test 1: Check for data loss warnings
     console.log("\n🔍 Checking migration for cascade effects...");
     const dataLossCheck = await migrator.checkMigration("@elizaos/production-schema-v1", schemaV2);
 
@@ -291,7 +280,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       });
     }
 
-    // Test 2: Should block without environment variable
     process.env.NODE_ENV = "development";
     delete process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS;
 
@@ -307,7 +295,7 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
     expect(blockedError?.message).toContain("Destructive migration blocked");
     console.log(`  ✅ Table drop blocked without env var`);
 
-    // Test 3: Production mode should also block
+    // Production mode blocks the same drop.
     process.env.NODE_ENV = "production";
 
     console.log("\n🛡️  Testing production protection...");
@@ -323,7 +311,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
     expect(productionError?.message).toContain("ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS");
     console.log(`  ✅ Table drop blocked in production`);
 
-    // Verify table still exists
     const tableExists = await db.execute(
       sql`SELECT EXISTS (
         SELECT FROM information_schema.tables 
@@ -332,17 +319,15 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
     );
     expect(asExistsRow(tableExists.rows[0]).exists).toBe(true);
 
-    // Test 4: Force drop with environment variable
     process.env.NODE_ENV = "development";
     process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = "true";
 
     console.log("\n⚠️  Attempting migration with ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS=true...");
 
-    // This might fail due to foreign key constraints from embeddings
+    // May fail here due to the embeddings table's FK constraint on memories.
     try {
       await migrator.migrate("@elizaos/production-schema-v1", schemaV2);
 
-      // If successful, verify consequences
       const tableExistsAfter = await db.execute(
         sql`SELECT EXISTS (
           SELECT FROM information_schema.tables 
@@ -368,7 +353,6 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
 
     await migrator.migrate("@elizaos/production-cascade-test", schemaV1);
 
-    // Insert minimal data to test cascade detection
     const agentId = "aa0e8400-e29b-41d4-a716-446655440001";
     await db.insert(agentTable).values({
       id: agentId,
@@ -386,11 +370,10 @@ describe("Schema Evolution Test: Drop Table with Production Relationships", () =
       style: {},
     });
 
-    // Schema V2: Drop multiple interconnected tables
+    // V2 omits entities, memories, relationships, and embeddings — all
+    // interconnected by foreign keys.
     const schemaV2 = {
       agents: agentTable,
-      // Dropped: entities, memories, relationships, embeddings
-      // These all have complex FK relationships
       rooms: roomTable,
       worlds: worldTable,
       participants: participantTable,

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Schema-evolution tests covering `RuntimeMigrator` column type-change
+ * handling with real data present: JSONB→text (lossy), text→integer
+ * (fails on non-numeric values), boolean→text, and two regression cases —
+ * varchar→uuid and boolean→integer — that require the generated `ALTER
+ * COLUMN ... USING ...` clause to use the correct cast, since Postgres
+ * rejects direct casts for these type pairs.
+ */
 import { boolean, integer, jsonb, pgTable, text, uuid, varchar } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../../runtime-migrator/runtime-migrator";
@@ -5,13 +13,6 @@ import type { DrizzleDB } from "../../../runtime-migrator/types";
 import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-helpers";
 
 type ContentObject = Record<string, unknown>;
-
-/**
- * Schema Evolution Test 3: Type Changes with Incompatible Data
- *
- * This test verifies handling of column type changes that could
- * cause data loss, conversion errors, or precision loss.
- */
 
 describe("Schema Evolution Test: Type Changes with Data", () => {
   let db: DrizzleDB;
@@ -28,7 +29,7 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
     migrator = new RuntimeMigrator(db);
     await migrator.initialize();
 
-    // Set environment variable for tests since they all test destructive operations
+    // Every test here exercises a destructive type change.
     process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = "true";
   });
 
@@ -51,7 +52,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
 
     await migrator.migrate("@elizaos/schema-evolution-test-types-v1", schemaV1);
 
-    // Insert complex JSON data
     await db.insert(memoryTableV1).values([
       {
         id: "110e8400-e29b-41d4-a716-446655440001",
@@ -116,7 +116,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
 
     const schemaV2 = { memories: memoryTableV2 };
 
-    // Check migration warnings
     const check = await migrator.checkMigration(
       "@elizaos/schema-evolution-test-types-v1",
       schemaV2
@@ -130,21 +129,17 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
       console.log(`  • ${warning}`);
     });
 
-    // Migration allowed because ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS is set in beforeEach
     await migrator.migrate("@elizaos/schema-evolution-test-types-v1", schemaV2);
 
-    // Check converted data
     const afterData = await db.select().from(memoryTableV2);
 
     console.log("\n📊 After type conversion:");
     console.log(`  - Content is now: ${typeof afterData[0].content}`);
     console.log(`  - First 100 chars: ${(afterData[0].content as string).substring(0, 100)}...`);
 
-    // Verify JSON was converted to string representation
     expect(typeof afterData[0].content).toBe("string");
     expect(afterData[0].content).toContain("{"); // Should be JSON string
 
-    // Try to parse it back to verify it's valid JSON string
     let _parsed: unknown;
     try {
       _parsed = JSON.parse(afterData[0].content as string);
@@ -167,7 +162,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
 
     await migrator.migrate("@elizaos/schema-evolution-test-text-to-int-v1", schemaV1);
 
-    // Insert mixed data - some valid, some invalid for integer conversion
     await db.insert(userTableV1).values([
       {
         name: "User 1",
@@ -207,7 +201,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
 
     const schemaV2 = { users: userTableV2 };
 
-    // This should warn about potential conversion issues
     const check = await migrator.checkMigration(
       "@elizaos/schema-evolution-test-text-to-int-v1",
       schemaV2
@@ -226,7 +219,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
       console.log(`  • ${warning}`);
     });
 
-    // Attempting migration should fail due to invalid data
     let migrationError: Error | null = null;
     try {
       await migrator.migrate("@elizaos/schema-evolution-test-text-to-int-v1", schemaV2);
@@ -234,15 +226,14 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
       migrationError = error as Error;
     }
 
-    // Should fail because 'unknown' and 'N/A' can't convert to integer
+    // Expected to fail: "unknown" and "N/A" can't cast to integer, and even
+    // "30.5" is rejected as not a valid integer literal.
     if (migrationError) {
       console.log("\n❌ Migration failed as expected:");
       console.log(`  Error: ${migrationError.message}`);
-      // The actual error is about decimal "30.5" not being valid integer
       expect(migrationError.message.toLowerCase()).toMatch(/failed query|invalid|error/);
     } else {
       console.log("\n⚠️  Migration succeeded with USING clause for conversion");
-      // If migration succeeded, check what happened to the data
       const afterData = await db.select().from(userTableV2);
       console.log("  Converted data:");
       afterData.forEach((row) => {
@@ -265,7 +256,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
 
     await migrator.migrate("@elizaos/schema-evolution-test-bool-v1", schemaV1);
 
-    // Insert boolean data
     await db.insert(settingsTableV1).values([
       { name: "Setting 1", enabled: true, verified: true, active: true },
       { name: "Setting 2", enabled: false, verified: false, active: false },
@@ -301,7 +291,6 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
       );
     });
 
-    // Verify conversion results
     expect(afterTextData[0].enabled).toBe("true");
     expect(afterTextData[1].enabled).toBe("false");
     expect(afterTextData[2].active).toBeNull();

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/04-safe-column-additions.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/04-safe-column-additions.real.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Schema-evolution tests proving `RuntimeMigrator` treats additive column
+ * changes as safe (no data-loss warnings, no destructive-migration block):
+ * nullable columns, `NOT NULL` columns backed by a default, columns whose
+ * default is a non-column-referencing SQL expression, and adding a dozen
+ * columns in a single migration. Runs against a real isolated database.
+ */
 import { sql } from "drizzle-orm";
 import { boolean, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,13 +15,6 @@ import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-he
 type AgentRow = Record<string, unknown>;
 type EntityRow = Record<string, unknown>;
 type ColumnRow = Record<string, unknown>;
-
-/**
- * Schema Evolution Test 4 & 5: Safe Column Additions
- *
- * This test verifies that adding nullable columns and columns with defaults
- * works correctly without data loss warnings.
- */
 
 describe("Schema Evolution Test: Safe Column Additions", () => {
   let db: DrizzleDB;
@@ -48,11 +48,9 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     const schemaV1 = { agents: agentTableV1 };
 
-    // Apply V1 and add data
     console.log("📦 Creating initial schema...");
     await migrator.migrate("@elizaos/safe-additions-v1", schemaV1);
 
-    // Insert test data
     await db.insert(agentTableV1).values([
       { name: "Agent Alpha", enabled: true },
       { name: "Agent Beta", enabled: false },
@@ -75,7 +73,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     const schemaV2 = { agents: agentTableV2 };
 
-    // Check migration - should have no warnings
     console.log("\n🔍 Checking for data loss warnings...");
     const check = await migrator.checkMigration("@elizaos/safe-additions-v1", schemaV2);
 
@@ -87,12 +84,11 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
       console.log("  ✅ No changes detected that would cause data loss");
     }
 
-    // Apply migration - should succeed without any environment variable
+    // No ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS needed — purely additive.
     console.log("\n📦 Applying safe migration...");
     await migrator.migrate("@elizaos/safe-additions-v1", schemaV2);
     console.log("  ✅ Migration completed successfully");
 
-    // Verify data is preserved and new columns are null
     const afterData = await db.execute(sql`SELECT * FROM agents ORDER BY name`);
 
     expect(afterData.rows.length).toBe(2);
@@ -120,7 +116,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
     console.log("📦 Creating initial schema...");
     await migrator.migrate("@elizaos/defaults-test-v1", schemaV1);
 
-    // Insert test data
     await db
       .insert(entityTableV1)
       .values([{ name: "Entity One" }, { name: "Entity Two" }, { name: "Entity Three" }]);
@@ -141,7 +136,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     const schemaV2 = { entities: entityTableV2 };
 
-    // Check migration - should have no warnings
     console.log("\n🔍 Checking for data loss warnings...");
     const check = await migrator.checkMigration("@elizaos/defaults-test-v1", schemaV2);
 
@@ -150,12 +144,10 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
       console.log("  ✅ No data loss (defaults protect existing rows)");
     }
 
-    // Apply migration
     console.log("\n📦 Applying migration with NOT NULL + defaults...");
     await migrator.migrate("@elizaos/defaults-test-v1", schemaV2);
     console.log("  ✅ Migration completed successfully");
 
-    // Verify defaults were applied to existing rows
     const afterData = await db.execute(sql`SELECT * FROM entities ORDER BY name`);
 
     expect(afterData.rows.length).toBe(3);
@@ -187,24 +179,21 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     await db.insert(testTableV1).values([{ name: "Test Record 1" }, { name: "Test Record 2" }]);
 
-    // V2: Add columns with DEFAULT expressions (that don't reference columns)
-    // and GENERATED columns (that can reference columns)
+    // Adds columns backed by DEFAULT expressions — these must not reference
+    // other columns; GENERATED ALWAYS AS expressions (e.g. to_tsvector, which
+    // can reference columns) aren't fully supported and are out of scope here.
     const testTableV2 = pgTable("test_complex", {
       id: uuid("id").primaryKey().defaultRandom(),
       name: text("name").notNull(),
-      // DEFAULT expressions (no column references allowed)
       createdAt: timestamp("created_at").default(sql`now()`).notNull(),
       status: text("status").default("active").notNull(),
       randomValue: integer("random_value").default(sql`floor(random() * 100)`),
       timestampWithOffset:
         timestamp("timestamp_with_offset").default(sql`now() + interval '1 hour'`),
-      // Using only valid DEFAULT expressions that don't reference columns
-      // (generatedAlwaysAs for expressions like to_tsvector isn't fully supported)
     });
 
     const schemaV2 = { test_complex: testTableV2 };
 
-    // Check and apply migration
     console.log("\n🔍 Testing complex column defaults...");
     const check = await migrator.checkMigration("@elizaos/complex-columns-v1", schemaV2);
 
@@ -215,7 +204,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     await migrator.migrate("@elizaos/complex-columns-v1", schemaV2);
 
-    // Verify defaults worked
     const afterData = await db.execute(sql`SELECT * FROM test_complex ORDER BY name`);
 
     for (const row of afterData.rows) {
@@ -244,10 +232,9 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
     console.log("📦 Creating minimal initial schema...");
     await migrator.migrate("@elizaos/multi-column-v1", schemaV1);
 
-    // V2: Add many columns at once
+    // Adds 12 columns in a single migration.
     const tableV2 = pgTable("multi_test", {
       id: uuid("id").primaryKey().defaultRandom(),
-      // Add 10+ columns in one migration
       name: text("name").default("unnamed").notNull(),
       description: text("description"),
       enabled: boolean("enabled").default(true).notNull(),
@@ -274,7 +261,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
 
     await migrator.migrate("@elizaos/multi-column-v1", schemaV2);
 
-    // Verify all columns exist
     const columns = await db.execute(
       sql`SELECT column_name, data_type, is_nullable, column_default 
           FROM information_schema.columns 
@@ -285,7 +271,6 @@ describe("Schema Evolution Test: Safe Column Additions", () => {
     expect(columns.rows.length).toBe(13); // id + 12 new columns
     console.log(`  ✅ All ${columns.rows.length} columns created successfully`);
 
-    // List all columns
     for (const col of columns.rows) {
       const column = col as ColumnRow;
       const nullable = column.is_nullable === "YES" ? "NULL" : "NOT NULL";

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/05-constraint-modifications.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/05-constraint-modifications.real.test.ts
@@ -1,16 +1,17 @@
+/**
+ * Schema-evolution tests covering `RuntimeMigrator` handling of adding
+ * `NOT NULL`, `UNIQUE`, and `CHECK` constraints to a table that already has
+ * violating rows: each case confirms the migration fails against dirty data,
+ * succeeds once the data is fixed, and that the constraint is actually
+ * enforced afterward by attempting a violating insert. A final test adds
+ * several constraint kinds in one migration.
+ */
 import { sql } from "drizzle-orm";
 import { boolean, check, integer, pgTable, text, unique, uuid } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../../runtime-migrator/types";
 import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-helpers";
-
-/**
- * Schema Evolution Test 6, 7, 8: Constraint Modifications
- *
- * Tests adding NOT NULL, UNIQUE, and CHECK constraints to existing data.
- * These operations can fail if existing data violates the new constraints.
- */
 
 describe("Schema Evolution Test: Constraint Modifications", () => {
   let db: DrizzleDB;
@@ -27,7 +28,7 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     migrator = new RuntimeMigrator(db);
     await migrator.initialize();
 
-    // Enable destructive migrations for constraint tests
+    // Every test here retries a constraint addition after fixing violating data.
     process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = "true";
   });
 
@@ -50,7 +51,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     console.log("📦 Creating schema with nullable email...");
     await migrator.migrate("@elizaos/not-null-test-v1", schemaV1);
 
-    // Insert data with some NULL emails
     await db.insert(userTableV1).values([
       { name: "User 1", email: "user1@example.com" },
       { name: "User 2", email: null }, // NULL email
@@ -72,14 +72,12 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     console.log("\n🔍 Checking NOT NULL constraint addition...");
     const check = await migrator.checkMigration("@elizaos/not-null-test-v1", schemaV2);
 
-    // This should warn about potential issues
     if (check) {
       expect(check.warnings.length).toBeGreaterThan(0);
       console.log("  ⚠️ Warnings detected:");
       check.warnings.forEach((w) => console.log(`    - ${w}`));
     }
 
-    // Try to apply migration - should fail due to NULL values
     console.log("\n❌ Attempting migration with NULL values...");
     let migrationError: Error | null = null;
     try {
@@ -93,17 +91,14 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       console.log(`  Error: ${migrationError.message.substring(0, 100)}...`);
     }
 
-    // Fix the data first
     console.log("\n🔧 Fixing NULL values...");
     await db.execute(sql`UPDATE users SET email = 'default@example.com' WHERE email IS NULL`);
     console.log("  ✅ Updated NULL emails with default values");
 
-    // Now migration should succeed
     console.log("\n📦 Retrying migration after fixing data...");
     await migrator.migrate("@elizaos/not-null-test-v1", schemaV2);
     console.log("  ✅ Migration succeeded after fixing NULL values");
 
-    // Verify constraint is in place
     let insertError: Error | null = null;
     try {
       await db.execute(sql`INSERT INTO users (name, email) VALUES ('Test User', NULL)`);
@@ -128,7 +123,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     console.log("📦 Creating schema without unique constraint...");
     await migrator.migrate("@elizaos/unique-test-v1", schemaV1);
 
-    // Insert data with duplicate usernames
     await db.insert(agentTableV1).values([
       { name: "Agent 1", username: "alpha" },
       { name: "Agent 2", username: "beta" },
@@ -161,7 +155,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       }
     }
 
-    // Try to apply migration - should fail due to duplicates
     console.log("\n❌ Attempting migration with duplicate values...");
     let migrationError: Error | null = null;
     try {
@@ -175,7 +168,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       console.log(`  Error: ${migrationError.message.substring(0, 100)}...`);
     }
 
-    // Fix duplicates
     console.log("\n🔧 Fixing duplicate values...");
     await db.execute(
       sql`UPDATE agents SET username = username || '-' || id WHERE username IN (
@@ -184,12 +176,10 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     );
     console.log("  ✅ Made usernames unique by appending IDs");
 
-    // Now migration should succeed
     console.log("\n📦 Retrying migration after fixing duplicates...");
     await migrator.migrate("@elizaos/unique-test-v1", schemaV2);
     console.log("  ✅ Migration succeeded after fixing duplicates");
 
-    // Verify unique constraint is enforced
     let insertError: Error | null = null;
     try {
       await db.execute(sql`INSERT INTO agents (name, username) VALUES ('Test', 'beta')`);
@@ -215,7 +205,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     console.log("📦 Creating schema without check constraints...");
     await migrator.migrate("@elizaos/check-test-v1", schemaV1);
 
-    // Insert data that would violate future constraints
     await db.insert(productTableV1).values([
       { name: "Product 1", price: 100, quantity: 10 },
       { name: "Product 2", price: -50, quantity: 5 }, // Negative price!
@@ -252,7 +241,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       }
     }
 
-    // Try to apply migration - should fail due to constraint violations
     console.log("\n❌ Attempting migration with constraint violations...");
     let migrationError: Error | null = null;
     try {
@@ -266,18 +254,15 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       console.log(`  Error: ${migrationError.message.substring(0, 100)}...`);
     }
 
-    // Fix violating data
     console.log("\n🔧 Fixing constraint violations...");
     await db.execute(sql`UPDATE products SET price = 1 WHERE price <= 0`);
     await db.execute(sql`UPDATE products SET quantity = 0 WHERE quantity < 0`);
     console.log("  ✅ Fixed negative and zero prices/quantities");
 
-    // Now migration should succeed
     console.log("\n📦 Retrying migration after fixing data...");
     await migrator.migrate("@elizaos/check-test-v1", schemaV2);
     console.log("  ✅ Migration succeeded after fixing violations");
 
-    // Verify check constraints are enforced
     let insertError: Error | null = null;
     try {
       await db.execute(
@@ -305,7 +290,6 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
     console.log("📦 Creating initial schema...");
     await migrator.migrate("@elizaos/multi-constraints-v1", schemaV1);
 
-    // Insert test data
     await db.insert(tableV1).values([
       { code: "ABC", value: 100, active: true },
       { code: "DEF", value: 200, active: false },
@@ -341,35 +325,29 @@ describe("Schema Evolution Test: Constraint Modifications", () => {
       console.log("    - CHECK constraint on value");
     }
 
-    // Fix data to meet all constraints
     console.log("\n🔧 Preparing data for constraints...");
     await db.execute(sql`DELETE FROM test_multi_constraints WHERE code IS NULL`);
     await db.execute(sql`UPDATE test_multi_constraints SET value = 50 WHERE value IS NULL`);
     await db.execute(sql`UPDATE test_multi_constraints SET active = true WHERE active IS NULL`);
 
-    // Apply migration
     console.log("\n📦 Applying multiple constraints...");
     await migrator.migrate("@elizaos/multi-constraints-v1", schemaV2);
     console.log("  ✅ All constraints added successfully");
 
-    // Verify all constraints work
     const violations: string[] = [];
 
-    // Test NOT NULL on code
     try {
       await db.execute(sql`INSERT INTO test_multi_constraints (code, value) VALUES (NULL, 100)`);
     } catch (_e) {
       violations.push("NOT NULL on code");
     }
 
-    // Test UNIQUE on code
     try {
       await db.execute(sql`INSERT INTO test_multi_constraints (code, value) VALUES ('ABC', 100)`);
     } catch (_e) {
       violations.push("UNIQUE on code");
     }
 
-    // Test CHECK on value
     try {
       await db.execute(sql`INSERT INTO test_multi_constraints (code, value) VALUES ('XYZ', -10)`);
     } catch (_e) {

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/06-index-evolution.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/06-index-evolution.real.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Schema-evolution tests proving `RuntimeMigrator` handles index changes
+ * (single-column, composite, expression/JSONB, partial, GIN, descending, text
+ * search) as safe, data-preserving operations: adding a first batch of
+ * indexes, dropping/renaming/recreating indexes on an existing table, a
+ * larger real-world-shaped indexing strategy verified via `EXPLAIN`, and
+ * redefining an index that keeps its name but targets a different column.
+ */
 import { sql } from "drizzle-orm";
 import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,13 +16,6 @@ import { createIsolatedTestDatabaseForSchemaEvolutionTests } from "../../test-he
 type IndexRow = Record<string, unknown>;
 type IndexDefRow = Record<string, unknown>;
 type CountRow = { count: number };
-
-/**
- * Schema Evolution Test 9 & 10: Index Evolution
- *
- * Tests adding, dropping, and recreating various types of indexes.
- * Index operations are generally safe as they don't affect data.
- */
 
 describe("Schema Evolution Test: Index Evolution", () => {
   let db: DrizzleDB;
@@ -56,7 +57,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     console.log("📦 Creating table without indexes...");
     await migrator.migrate("@elizaos/index-test-v1", schemaV1);
 
-    // Insert sample data
     await db.insert(memoryTableV1).values([
       {
         type: "conversation",
@@ -139,7 +139,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     await migrator.migrate("@elizaos/index-test-v1", schemaV2);
     console.log("  ✅ All indexes created successfully");
 
-    // Verify indexes were created
     const indexes = await db.execute(
       sql`SELECT indexname, indexdef 
           FROM pg_indexes 
@@ -182,7 +181,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     console.log("📦 Creating table with initial indexes...");
     await migrator.migrate("@elizaos/index-change-v1", schemaV1);
 
-    // Insert test data
     await db.insert(testTableV1).values([
       { col1: "a", col2: "b", col3: "c", metadata: { key: "value1" } },
       { col1: "d", col2: "e", col3: "f", metadata: { key: "value2" } },
@@ -231,7 +229,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     await migrator.migrate("@elizaos/index-change-v1", schemaV2);
     console.log("  ✅ Index modifications completed");
 
-    // Verify index changes
     const indexes = await db.execute(
       sql`SELECT indexname 
           FROM pg_indexes 
@@ -244,13 +241,11 @@ describe("Schema Evolution Test: Index Evolution", () => {
     console.log("\n📊 Final indexes:");
     indexNames.forEach((name) => console.log(`  - ${name}`));
 
-    // Check specific changes
     expect(indexNames).not.toContain("idx_col1"); // Should be dropped
     expect(indexNames).toContain("idx_col2"); // Should remain
     expect(indexNames).toContain("idx_col3"); // Should be added
     expect(indexNames).toContain("idx_metadata_key"); // Should be added
 
-    // Verify data is intact
     const dataCount = await db.execute(sql`SELECT COUNT(*) as count FROM test_index_changes`);
     expect(Number((dataCount.rows[0] as unknown as CountRow).count)).toBe(3);
     console.log("\n✅ All data preserved during index changes");
@@ -273,7 +268,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     console.log("📦 Creating initial table...");
     await migrator.migrate("@elizaos/complex-index-v1", schemaV1);
 
-    // Insert varied data
     const statuses = ["pending", "active", "completed", "archived"];
     const categories = ["A", "B", "C", null];
     const priorities = ["high", "medium", "low", "urgent"];
@@ -338,7 +332,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
 
     await migrator.migrate("@elizaos/complex-index-v1", schemaV2);
 
-    // Verify complex indexes
     const indexes = await db.execute(
       sql`SELECT 
             indexname, 
@@ -363,16 +356,13 @@ describe("Schema Evolution Test: Index Evolution", () => {
       console.log(`  - ${index.indexname} (${index.index_type})`);
     }
 
-    // Test index usage with EXPLAIN
     console.log("\n🔍 Testing index usage:");
 
-    // Test partial index usage
     const _explainPending = await db.execute(
       sql`EXPLAIN SELECT * FROM complex_indexes WHERE status = 'pending' ORDER BY created_at`
     );
     console.log("  ✅ Partial index for pending status can be used");
 
-    // Test covering index
     const _explainCovering = await db.execute(
       sql`EXPLAIN SELECT status, priority, created_at FROM complex_indexes WHERE status = 'active'`
     );
@@ -416,7 +406,6 @@ describe("Schema Evolution Test: Index Evolution", () => {
     console.log("\n📦 Changing index definition with same name...");
     await migrator.migrate("@elizaos/conflict-test-v1", schemaV2);
 
-    // Verify the index now points to field2
     const indexDef = await db.execute(
       sql`SELECT indexdef FROM pg_indexes 
           WHERE tablename = 'test_conflicts' 

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/07-foreign-key-evolution.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/07-foreign-key-evolution.real.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Schema-evolution tests covering `RuntimeMigrator` handling of foreign-key
+ * changes against real data: adding an FK where orphaned rows must first be
+ * cleaned up, changing `onDelete` behavior (CASCADE to SET NULL) on an
+ * existing relationship, adding a web of FKs with mixed CASCADE/SET NULL
+ * behaviors (including a composite FK) across four interconnected tables,
+ * and a one-directional manager-reference FK exercising constraint
+ * enforcement and SET NULL on delete.
+ */
 import { sql } from "drizzle-orm";
 import { foreignKey, pgTable, text, unique, uuid } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -9,13 +18,6 @@ type CountRow = { count: number };
 type ChildRow = Record<string, unknown>;
 type StatsRow = Record<string, unknown>;
 type DepartmentRow = Record<string, unknown>;
-
-/**
- * Schema Evolution Test 11 & 12: Foreign Key Evolution
- *
- * Tests adding foreign keys to existing data and modifying CASCADE behavior.
- * These operations can fail if there are orphaned records.
- */
 
 describe("Schema Evolution Test: Foreign Key Evolution", () => {
   let db: DrizzleDB;
@@ -32,7 +34,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     migrator = new RuntimeMigrator(db);
     await migrator.initialize();
 
-    // Enable for tests that need it
     process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = "true";
   });
 
@@ -63,7 +64,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     console.log("📦 Creating tables without foreign keys...");
     await migrator.migrate("@elizaos/fk-test-v1", schemaV1);
 
-    // Create valid agents
     const agent1Id = "550e8400-e29b-41d4-a716-446655440001";
     const agent2Id = "550e8400-e29b-41d4-a716-446655440002";
 
@@ -72,7 +72,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
       { id: agent2Id, name: "Agent 2" },
     ]);
 
-    // Create memories - some with valid agent IDs, some orphaned
     await db.insert(memoryTableV1).values([
       { agentId: agent1Id, content: "Memory 1 - Valid" },
       { agentId: agent2Id, content: "Memory 2 - Valid" },
@@ -118,7 +117,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
       }
     }
 
-    // Try to apply - should fail due to orphaned records
     console.log("\n❌ Attempting to add FK with orphaned records...");
     let migrationError: Error | null = null;
     try {
@@ -132,7 +130,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
       console.log(`  Error: ${migrationError.message.substring(0, 100)}...`);
     }
 
-    // Find and fix orphaned records
     console.log("\n🔧 Finding orphaned records...");
     const orphaned = await db.execute(
       sql`SELECT m.* FROM memories m 
@@ -141,7 +138,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     );
     console.log(`  Found ${orphaned.rows.length} orphaned memories`);
 
-    // Clean up orphaned records
     await db.execute(
       sql`DELETE FROM memories 
           WHERE agent_id NOT IN (SELECT id FROM agents) 
@@ -149,12 +145,10 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     );
     console.log("  ✅ Deleted orphaned records");
 
-    // Now migration should succeed
     console.log("\n📦 Retrying FK addition after cleanup...");
     await migrator.migrate("@elizaos/fk-test-v1", schemaV2);
     console.log("  ✅ Foreign key constraint added successfully");
 
-    // Verify FK is enforced
     let insertError: Error | null = null;
     try {
       await db.execute(
@@ -194,7 +188,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     console.log("📦 Creating tables with CASCADE delete...");
     await migrator.migrate("@elizaos/cascade-test-v1", schemaV1);
 
-    // Create test data
     const parent1Id = "110e8400-e29b-41d4-a716-446655440001";
     const parent2Id = "110e8400-e29b-41d4-a716-446655440002";
 
@@ -211,7 +204,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
 
     console.log("  ✅ Created 2 parents with 3 children");
 
-    // Test CASCADE delete behavior
     console.log("\n🔍 Testing current CASCADE behavior...");
     await db.execute(sql`DELETE FROM parents WHERE id = ${parent1Id}`);
     const remainingChildren = await db.execute(
@@ -259,7 +251,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     await migrator.migrate("@elizaos/cascade-test-v1", schemaV2);
     console.log("  ✅ CASCADE behavior changed to SET NULL");
 
-    // Test new SET NULL behavior
     console.log("\n🔍 Testing new SET NULL behavior...");
     await db.execute(sql`DELETE FROM parents WHERE id = ${parent2Id}`);
     const orphanedChildren = await db.execute(sql`SELECT * FROM children WHERE parent_id IS NULL`);
@@ -305,7 +296,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     console.log("📦 Creating complex structure without FKs...");
     await migrator.migrate("@elizaos/complex-fk-v1", schemaV1);
 
-    // Create interconnected data
     const worldId = "220e8400-e29b-41d4-a716-446655440001";
     const agentId = "330e8400-e29b-41d4-a716-446655440001";
     const roomId = "440e8400-e29b-41d4-a716-446655440001";
@@ -382,10 +372,9 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     await migrator.migrate("@elizaos/complex-fk-v1", schemaV2);
     console.log("  ✅ Complex foreign keys added");
 
-    // Test CASCADE behaviors
     console.log("\n🔍 Testing complex CASCADE behaviors...");
 
-    // Delete world should cascade to everything
+    // Deleting the world must cascade through agents, rooms, and memories.
     await db.execute(sql`DELETE FROM worlds WHERE id = ${worldId}`);
 
     const counts = await db.execute(sql`
@@ -425,7 +414,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     console.log("📦 Creating tables for manager reference test...");
     await migrator.migrate("@elizaos/circular-fk-v1", schemaV1);
 
-    // Create data
     const dept1Id = "550e8400-e29b-41d4-a716-446655440001";
     const emp1Id = "660e8400-e29b-41d4-a716-446655440001";
     const emp2Id = "660e8400-e29b-41d4-a716-446655440002";
@@ -468,10 +456,8 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     await migrator.migrate("@elizaos/circular-fk-v1", schemaV2);
     console.log("  ✅ Manager reference foreign key created successfully");
 
-    // Test that constraints work
     console.log("\n🔍 Testing manager reference constraints...");
 
-    // Try to insert invalid manager
     let insertError: Error | null = null;
     try {
       await db.execute(
@@ -485,7 +471,6 @@ describe("Schema Evolution Test: Foreign Key Evolution", () => {
     expect(insertError).not.toBeNull();
     console.log("  ✅ Invalid manager reference blocked");
 
-    // Delete employee who is a manager
     await db.execute(sql`DELETE FROM employees WHERE id = ${emp1Id}`);
     const deptAfter = await db.execute(
       sql`SELECT manager_id FROM departments WHERE id = ${dept1Id}`

--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/08-agent-name-constraint-removal.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/08-agent-name-constraint-removal.real.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Real-PGlite tests for the agent-table migration that drops the unique
+ * constraint on `agents.name` (allowing multiple agents to share a name,
+ * identified only by UUID): covers the raw ALTER TABLE DROP CONSTRAINT path
+ * against synthetic old-schema data, a production-data-shaped scenario,
+ * complex JSONB settings/message-examples plus a related `agent_sessions`
+ * table, confirms all lookups after migration are UUID-based (never by
+ * name), and checks the constraint drop inside a transaction.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import type { MessageExample } from "@elizaos/core";
 import { sql } from "drizzle-orm";
@@ -6,19 +15,11 @@ import { drizzle } from "drizzle-orm/pglite";
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach, describe, expect, it } from "vitest";
 
-/**
- * Test suite for agent table schema migration:
- * From: agent table WITH unique name constraint
- * To: agent table WITHOUT unique name constraint
- *
- * This verifies that existing databases can migrate correctly to support
- * multiple agents with the same name (UUID-based identification only).
- */
 describe("Schema Evolution: Agent Name Constraint Removal", () => {
   let client: PGlite;
   let db: ReturnType<typeof drizzle>;
 
-  // Define the OLD schema with unique name constraint
+  // Agents table as it existed with the unique name constraint.
   const _oldAgentTable = pgTable(
     "agents_old_schema",
     {
@@ -65,7 +66,7 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     }
   );
 
-  // Define the NEW schema without unique name constraint
+  // Agents table after the migration — no unique constraint on name.
   const _newAgentTable = pgTable("agents_new_schema", {
     id: uuid("id").primaryKey().defaultRandom(),
     enabled: boolean("enabled").default(true).notNull(),
@@ -105,13 +106,11 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   beforeEach(async () => {
-    // Create a fresh PGlite instance for each test
     client = new PGlite();
     db = drizzle(client);
   });
 
   it("should migrate from old schema with unique name constraint to new schema without it", async () => {
-    // Step 1: Create OLD schema with unique name constraint
     await db.execute(sql`
       CREATE TABLE agents_old_schema (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -134,7 +133,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Step 2: Insert test data with unique names (old constraint allows this)
     const agent1Id = uuidv4();
     const agent2Id = uuidv4();
     const agent3Id = uuidv4();
@@ -147,7 +145,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
         (${agent3Id}, 'Agent Three', 'user3', '["Third unique agent"]'::jsonb, '{"key": "value3"}'::jsonb)
     `);
 
-    // Verify old constraint prevents duplicates
     let duplicateError: unknown = null;
     try {
       await db.execute(sql`
@@ -167,14 +164,12 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       errorStr.includes("constraint");
     expect(hasUniqueError).toBe(true);
 
-    // Step 3: Perform migration - Drop the unique constraint
     await db.execute(sql`ALTER TABLE agents_old_schema DROP CONSTRAINT name_unique_old`);
 
-    // Step 4: Verify constraint was removed - should now allow duplicate names
     const duplicateId1 = uuidv4();
     const duplicateId2 = uuidv4();
 
-    // These should both succeed with the same name
+    // Both inserts below share the same name — the constraint drop must allow this.
     await db.execute(sql`
       INSERT INTO agents_old_schema (id, name, username, bio)
       VALUES (${duplicateId1}, 'Duplicate Name', 'dup_user1', '["First with duplicate name"]'::jsonb)
@@ -185,7 +180,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       VALUES (${duplicateId2}, 'Duplicate Name', 'dup_user2', '["Second with duplicate name"]'::jsonb)
     `);
 
-    // Step 5: Verify all agents exist including those with duplicate names
     const allAgents = await db.execute<{
       id: string;
       name: string;
@@ -206,7 +200,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     expect(duplicates[0].id).not.toBe(duplicates[1].id);
     expect(duplicates[0].username).not.toBe(duplicates[1].username);
 
-    // Step 6: Verify we can continue to create more duplicates
     const duplicateId3 = uuidv4();
     await db.execute(sql`
       INSERT INTO agents_old_schema (id, name, username, bio)
@@ -221,10 +214,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   it("should handle real-world migration scenario: existing database to new schema", async () => {
-    // Simulate a real-world scenario where a database has existing agents
-    // with unique names, and we need to migrate to support duplicate names
-
-    // Step 1: Create old schema and populate with production-like data
     await db.execute(sql`
       CREATE TABLE agents (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -247,7 +236,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Create "production" data - multiple agents with different names
     const productionAgents = [
       {
         id: uuidv4(),
@@ -282,13 +270,11 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       `);
     }
 
-    // Verify old constraint is active
     const countBefore = await db.execute<{ count: number }>(
       sql`SELECT COUNT(*) as count FROM agents`
     );
     expect(Number(countBefore.rows[0].count)).toBe(4);
 
-    // Verify constraint blocks duplicate names
     let constraintError: unknown = null;
     try {
       await db.execute(sql`
@@ -300,12 +286,10 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     }
     expect(constraintError).not.toBeNull();
 
-    // Step 2: MIGRATION - Drop the unique constraint
     console.log("🔄 [MIGRATION] Dropping unique name constraint...");
     await db.execute(sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS name_unique`);
     console.log("✅ [MIGRATION] Constraint dropped successfully");
 
-    // Step 3: Verify constraint is gone by checking pg_constraint
     const constraintCheck = await db.execute<{ constraint_name: string }>(sql`
       SELECT conname as constraint_name
       FROM pg_constraint
@@ -314,7 +298,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     `);
     expect(constraintCheck.rows.length).toBe(0);
 
-    // Step 4: Verify all existing data is preserved
     const allAgentsAfterMigration = await db.execute<{
       id: string;
       name: string;
@@ -330,7 +313,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       expect(found?.username).toBe(prodAgent.username);
     }
 
-    // Step 5: Verify we can now create agents with duplicate names
     const elizaClone1 = uuidv4();
     const elizaClone2 = uuidv4();
     const elizaClone3 = uuidv4();
@@ -350,7 +332,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       VALUES (${elizaClone3}, 'Eliza', 'eliza_clone3', '["Third Eliza clone"]'::jsonb)
     `);
 
-    // Step 6: Verify all Eliza instances exist
     const elizas = await db.execute<{
       id: string;
       name: string;
@@ -369,8 +350,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     expect(elizaUsernames).toContain("eliza_clone2");
     expect(elizaUsernames).toContain("eliza_clone3");
 
-    // Step 7: Verify CRUD operations work correctly on duplicate-name agents
-    // Update one Eliza
     await db.execute(sql`
       UPDATE agents 
       SET bio = '["Updated Eliza clone 1"]'::jsonb
@@ -383,7 +362,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
 
     expect(updatedEliza.rows[0].bio).toContain("Updated Eliza clone 1");
 
-    // Delete one Eliza
     await db.execute(sql`DELETE FROM agents WHERE id = ${elizaClone2}`);
 
     const remainingElizas = await db.execute<{ count: number }>(sql`
@@ -391,7 +369,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     `);
     expect(Number(remainingElizas.rows[0].count)).toBe(3);
 
-    // Final verification: Total agent count
     const finalAgentCount = await db.execute<{ count: number }>(sql`
       SELECT COUNT(*) as count FROM agents
     `);
@@ -401,7 +378,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   it("should handle migration with complex existing data and relationships", async () => {
-    // Create old schema
     await db.execute(sql`
       CREATE TABLE agents (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -424,7 +400,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Create related table that references agents
     await db.execute(sql`
       CREATE TABLE agent_sessions (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -434,7 +409,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Insert agents with complex data
     const complexAgent1 = {
       id: uuidv4(),
       name: "ComplexAgent",
@@ -470,18 +444,15 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Create session for this agent
     const sessionId = uuidv4();
     await db.execute(sql`
       INSERT INTO agent_sessions (id, agent_id, session_data)
       VALUES (${sessionId}, ${complexAgent1.id}, '{"active": true}'::jsonb)
     `);
 
-    // Perform migration
     console.log("🔄 [MIGRATION] Dropping unique constraint from complex setup...");
     await db.execute(sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS name_unique`);
 
-    // Verify complex data is preserved
     interface AgentSettings {
       nested?: { deep?: { value?: string } };
       secrets?: { apiKey?: string };
@@ -506,7 +477,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     expect(retrievedAgent.rows[0].settings.secrets.apiKey).toBe("secret123");
     expect(retrievedAgent.rows[0].message_examples[0][0].name).toBe("user");
 
-    // Verify session relationship is intact
     const session = await db.execute<{
       session_data: { active?: boolean };
     }>(sql`
@@ -514,7 +484,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     `);
     expect(session.rows[0].session_data.active).toBe(true);
 
-    // Now create duplicate complex agent
     const complexAgent2 = {
       id: uuidv4(),
       name: "ComplexAgent", // Same name
@@ -534,7 +503,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Verify both exist
     const complexAgents = await db.execute<{
       id: string;
       username: string;
@@ -550,8 +518,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   it("should verify NO name-based lookups remain in migrated system", async () => {
-    // This test ensures the system uses UUID-based lookups only
-
     await db.execute(sql`
       CREATE TABLE agents (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -578,7 +544,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     const agent2Id = uuidv4();
     const agent3Id = uuidv4();
 
-    // Create multiple agents with same name
     await db.execute(sql`
       INSERT INTO agents (id, name, username, bio)
       VALUES 
@@ -635,8 +600,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   it("should allow rollback if migration fails (transaction safety)", async () => {
-    // Test that migration failures don't corrupt data
-
     await db.execute(sql`
       CREATE TABLE agents (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -659,13 +622,11 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // Insert test data
     await db.execute(sql`
       INSERT INTO agents (id, name, username)
       VALUES (${uuidv4()}, 'TestAgent', 'test1')
     `);
 
-    // Verify constraint exists
     const constraintBefore = await db.execute<{ constraint_name: string }>(sql`
       SELECT conname as constraint_name
       FROM pg_constraint
@@ -674,25 +635,20 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     `);
     expect(constraintBefore.rows.length).toBe(1);
 
-    // Perform migration in transaction
+    // This transaction completes successfully here; a real migration could
+    // fail partway through (e.g. a later column addition), which is the
+    // scenario this test's transaction wrapping guards against.
     let migrationError: unknown = null;
     try {
       await db.transaction(async (tx) => {
-        // Drop constraint
         await tx.execute(sql`ALTER TABLE agents DROP CONSTRAINT name_unique`);
-
-        // Simulate a failure after constraint drop
-        // (In real scenario, this could be a failed column addition, etc.)
-        // For this test, we'll complete successfully
       });
     } catch (error) {
       migrationError = error;
     }
 
-    // Verify migration succeeded
     expect(migrationError).toBeNull();
 
-    // Verify constraint is gone
     const constraintAfter = await db.execute<{ constraint_name: string }>(sql`
       SELECT conname as constraint_name
       FROM pg_constraint
@@ -701,7 +657,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     `);
     expect(constraintAfter.rows.length).toBe(0);
 
-    // Verify data integrity
     const agents = await db.execute<{ count: number }>(sql`
       SELECT COUNT(*) as count FROM agents
     `);
@@ -711,8 +666,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
   });
 
   it("should document the migration path for users", async () => {
-    // This test serves as documentation for how users should migrate their databases
-
     console.log("\n📚 [MIGRATION GUIDE] Agent Name Constraint Removal");
     console.log("================================================================");
     console.log("If you have an existing elizaOS database with the old schema,");
@@ -735,7 +688,6 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
     console.log("✅ No manual intervention needed");
     console.log("================================================================\n");
 
-    // Simulate the scenario
     await db.execute(sql`
       CREATE TABLE agents (
         id UUID PRIMARY KEY,
@@ -758,16 +710,13 @@ describe("Schema Evolution: Agent Name Constraint Removal", () => {
       )
     `);
 
-    // User has existing agents
     await db.execute(sql`
       INSERT INTO agents (id, name, username)
       VALUES (${uuidv4()}, 'MyBot', 'bot1')
     `);
 
-    // Migration happens automatically
     await db.execute(sql`ALTER TABLE agents DROP CONSTRAINT IF EXISTS name_unique`);
 
-    // User can now create agents with duplicate names
     await db.execute(sql`
       INSERT INTO agents (id, name, username)
       VALUES 

--- a/plugins/plugin-sql/src/__tests__/migration/transaction-and-concurrency.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/transaction-and-concurrency.real.test.ts
@@ -1,3 +1,14 @@
+/**
+ * End-to-end `RuntimeMigrator` tests for transaction atomicity, PostgreSQL
+ * advisory-lock-based concurrency control, and advisory-lock ID security.
+ * Covers: full commit/rollback on migration success/failure, concurrent
+ * migrate() calls for the same vs. different plugins, high-concurrency
+ * (10-way) migration, lock-ID generation/validation/range-checking, and a
+ * race-condition regression where a double-check-after-acquiring-the-lock
+ * must catch a migration completed by another process while this one waited.
+ * Advisory-lock-specific tests are skipped unless running against real
+ * Postgres (`POSTGRES_URL` set), since PGlite doesn't support them.
+ */
 import { sql } from "drizzle-orm";
 import { integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -5,25 +16,22 @@ import { RuntimeMigrator } from "../../runtime-migrator";
 import type { DrizzleDatabase } from "../../types";
 import { createIsolatedTestDatabaseForMigration } from "../test-helpers";
 
-// Helper types for database query result rows
 interface CountRow {
   count: string | number;
 }
 
-// Helper interface for accessing private methods
 interface TestableRuntimeMigrator extends RuntimeMigrator {
   getAdvisoryLockId(pluginName: string): bigint;
   validateBigInt(value: bigint): boolean;
 }
 
-// Helper function to access private methods for testing
 function getTestableMigrator(migrator: RuntimeMigrator): TestableRuntimeMigrator {
   return migrator as TestableRuntimeMigrator;
 }
 
-// Helper function to create an invalid table reference for testing invalid schemas
+// Deliberately-invalid FK target, used to force a migration failure for the
+// rollback/error-isolation tests below.
 function createInvalidTableReference(): { id: ReturnType<typeof uuid> } {
-  // This intentionally returns null to create an invalid reference for testing
   return null as { id: ReturnType<typeof uuid> };
 }
 
@@ -44,7 +52,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
   });
 
   beforeEach(async () => {
-    // Clean up test tables before each test
     const testTables = [
       "test_transaction_success",
       "test_transaction_fail_1",
@@ -72,7 +79,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       }
     }
 
-    // Clean up test migration records
     try {
       await db.execute(
         sql.raw(`
@@ -118,7 +124,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       await migrator.migrate("@elizaos/transaction-test-success", validSchema);
 
-      // Verify table was created
       const tableExists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -129,7 +134,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       expect(tableExists.rows[0]?.exists).toBe(true);
 
-      // Verify migration was recorded
       const migrationRecorded = await db.execute(
         sql.raw(`SELECT COUNT(*) as count
                  FROM migrations._migrations
@@ -140,7 +144,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         1
       );
 
-      // Verify journal was recorded
       const journalRecorded = await db.execute(
         sql.raw(`SELECT COUNT(*) as count
                  FROM migrations._journal
@@ -151,16 +154,14 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     });
 
     it("should rollback all changes when migration fails", async () => {
-      // Mock a failure by providing an invalid schema that will cause SQL errors
       const failingSchema = {
         testTable1: pgTable("test_partial_migration", {
           id: uuid("id").primaryKey().defaultRandom(),
           data: text("data"),
         }),
-        // This table references a non-existent table, which should cause failure
+        // References a non-existent table, forcing the migration to fail.
         testTable2: pgTable("test_should_rollback", {
           id: uuid("id").primaryKey().defaultRandom(),
-          // Reference to non-existent table will fail
           fake_ref: uuid("fake_ref").references(() => createInvalidTableReference().id),
         }),
       };
@@ -174,11 +175,10 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         _errorMessage = (error as Error).message || "";
       }
 
-      // The migration should have failed
       expect(migrationFailed).toBe(true);
 
-      // Verify that the first table from the failed migration was NOT created
-      // This proves the transaction was rolled back
+      // The first table from the failed migration must not exist — proof the
+      // whole transaction rolled back rather than partially applying.
       const partialTableExists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -189,7 +189,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       expect(partialTableExists.rows[0]?.exists).toBe(false);
 
-      // Verify no migration record was created for the failed migration
       const failedMigrationRecorded = await db.execute(
         sql.raw(`SELECT COUNT(*) as count
                  FROM migrations._migrations
@@ -200,7 +199,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         parseInt(String((failedMigrationRecorded.rows[0] as unknown as CountRow).count), 10)
       ).toBe(0);
 
-      // Verify no journal entry was created for the failed migration
       const failedJournalRecorded = await db.execute(
         sql.raw(`SELECT COUNT(*) as count
                  FROM migrations._journal
@@ -213,7 +211,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     });
 
     it("should maintain consistent state across migration failures", async () => {
-      // Get initial state
       const initialMigrationCount = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations`)
       );
@@ -224,13 +221,11 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
                  WHERE table_schema = 'public'`)
       );
 
-      // Try an migration with invalid reference that will fail
       let errorOccurred = false;
       try {
         const invalidSchema = {
           testTable: pgTable("test_invalid_table", {
             id: uuid("id").primaryKey().defaultRandom(),
-            // This will create invalid foreign key reference
             invalid_ref: uuid("invalid_ref").references(() => createInvalidTableReference().id),
           }),
         };
@@ -242,7 +237,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       expect(errorOccurred).toBe(true);
 
-      // Verify state is unchanged
       const finalMigrationCount = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations`)
       );
@@ -264,7 +258,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
   });
 
   describe("PostgreSQL Advisory Locks for Concurrent Migrations", () => {
-    // Check if we're using real PostgreSQL (not PGLite)
     const postgresUrl = process.env.POSTGRES_URL || "";
     const isRealPostgres =
       postgresUrl &&
@@ -272,12 +265,13 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       !postgresUrl.includes("pglite") &&
       postgresUrl.includes("postgres");
 
-    // Skip advisory lock tests for PGLite since it doesn't support them
     const testOrSkip = isRealPostgres ? it : it.skip;
     testOrSkip(
       "should use advisory locks to prevent concurrent migrations for the same plugin",
       async () => {
-        // Use IDENTICAL schemas to test idempotency with concurrent calls
+        // Identical schemas exercise idempotency under concurrent calls:
+        // advisory locks should serialize the two calls, and the second
+        // should be a no-op skip rather than a duplicate migration.
         const schema = {
           testTable: pgTable("test_concurrent_3", {
             id: uuid("id").primaryKey().defaultRandom(),
@@ -286,8 +280,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
           }),
         };
 
-        // Try to run the same plugin migration concurrently with identical schemas
-        // Advisory locks should serialize them, and the second one should skip (idempotent)
         const [result1, result2] = await Promise.allSettled([
           migrator.migrate("@elizaos/concurrent-test-same-plugin", schema),
           migrator.migrate("@elizaos/concurrent-test-same-plugin", schema),
@@ -301,7 +293,7 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         expect(successCount + failureCount).toBe(2);
         expect(successCount).toBeGreaterThanOrEqual(1);
 
-        // Check final state - should have exactly one migration record
+        // Should have exactly one migration record.
         const migrationCount = await db.execute(
           sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/concurrent-test-same-plugin'`)
@@ -338,17 +330,14 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Run migrations concurrently for different plugins
       const [result1, result2] = await Promise.allSettled([
         migrator.migrate("@elizaos/concurrent-test-1", schema1),
         migrator.migrate("@elizaos/concurrent-test-2", schema2),
       ]);
 
-      // Both should complete successfully
       expect(result1.status).toBe("fulfilled");
       expect(result2.status).toBe("fulfilled");
 
-      // Verify both tables were created
       const table1Exists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -366,7 +355,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       expect(table1Exists.rows[0]?.exists).toBe(true);
       expect(table2Exists.rows[0]?.exists).toBe(true);
 
-      // Verify both migrations were recorded
       const migration1Count = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/concurrent-test-1'`)
@@ -382,7 +370,7 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     });
 
     testOrSkip("should use proper locking to prevent race conditions", async () => {
-      // Create multiple migrators to simulate different processes
+      // Three separate RuntimeMigrator instances simulate three concurrent processes.
       const migrator2 = new RuntimeMigrator(db);
       const migrator3 = new RuntimeMigrator(db);
 
@@ -394,14 +382,12 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Run migrations from multiple "processes" simultaneously
       const results = await Promise.allSettled([
         migrator.migrate("@elizaos/concurrent-test-locking", testSchema) as Promise<void>,
         migrator2.migrate("@elizaos/concurrent-test-locking", testSchema) as Promise<void>,
         migrator3.migrate("@elizaos/concurrent-test-locking", testSchema) as Promise<void>,
       ]);
 
-      // Check results
       const successfulMigrations = results.filter((r) => r.status === "fulfilled").length;
       const failedMigrations = results.filter((r) => r.status === "rejected").length;
 
@@ -409,10 +395,9 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         `Concurrent migration results: ${successfulMigrations} successful, ${failedMigrations} failed`
       );
 
-      // Should have exactly one successful migration due to advisory locking
+      // Advisory locking should let exactly one migration through.
       expect(successfulMigrations).toBeGreaterThanOrEqual(1);
 
-      // Verify only one migration record exists
       const migrationCount = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/concurrent-test-locking'`)
@@ -420,7 +405,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       expect(parseInt(String((migrationCount.rows[0] as unknown as CountRow).count), 10)).toBe(1);
 
-      // Verify table was created exactly once
       const tableExists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -432,7 +416,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     });
 
     testOrSkip("should release advisory locks after migration completion", async () => {
-      // Run a migration
       const testSchema = {
         testTable: pgTable("test_lock_cleanup", {
           id: uuid("id").primaryKey().defaultRandom(),
@@ -442,8 +425,7 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       await migrator.migrate("@elizaos/concurrent-test-cleanup", testSchema);
 
-      // Check if there are any advisory locks still held
-      // PostgreSQL advisory locks can be checked via pg_locks
+      // pg_locks exposes currently-held advisory locks.
       const activeLocks = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM pg_locks 
                  WHERE locktype = 'advisory' 
@@ -464,10 +446,8 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Should succeed without lock conflicts - migration completes without throwing
       await migrator.migrate("@elizaos/concurrent-test-cleanup-2", anotherSchema);
 
-      // Verify table was created
       const tableExists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -479,7 +459,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     });
 
     it("should handle high-concurrency scenarios with advisory locks", async () => {
-      // Create many concurrent migrations
       const migrationPromises: Promise<void>[] = [];
 
       for (let i = 0; i < 10; i++) {
@@ -494,10 +473,8 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         migrationPromises.push(migrator.migrate(`@elizaos/concurrent-test-high-${i}`, schema));
       }
 
-      // Wait for all migrations to complete
       const results = await Promise.allSettled(migrationPromises);
 
-      // Count successful migrations
       const successfulCount = results.filter((r) => r.status === "fulfilled").length;
       const failedCount = results.filter((r) => r.status === "rejected").length;
 
@@ -507,7 +484,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       expect(successfulCount).toBe(10);
       expect(failedCount).toBe(0);
 
-      // Verify all migration records exist
       const totalMigrations = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name LIKE '@elizaos/concurrent-test-high-%'`)
@@ -518,7 +494,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       }
       expect(parseInt((totalMigrations.rows[0] as unknown as QueryRow).count, 10)).toBe(10);
 
-      // Verify all tables were created
       const createdTables = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM information_schema.tables 
                  WHERE table_schema = 'public' 
@@ -541,28 +516,21 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Create an actually invalid schema that will cause an error
       const invalidSchema = {
         testTable: pgTable("test_invalid_concurrent", {
           id: uuid("id").primaryKey().defaultRandom(),
-          // This will cause an error during migration due to invalid reference
           bad_ref: uuid("bad_ref").references(() => createInvalidTableReference().id),
         }),
       };
 
-      // Run one valid and one invalid migration concurrently
       const [validResult, invalidResult] = await Promise.allSettled([
         migrator.migrate("@elizaos/concurrent-test-valid", validSchema),
         migrator.migrate("@elizaos/concurrent-test-invalid", invalidSchema),
       ]);
 
-      // Valid migration should succeed
       expect(validResult.status).toBe("fulfilled");
-
-      // Invalid migration should fail
       expect(invalidResult.status).toBe("rejected");
 
-      // Verify valid table was created
       const tableExists = await db.execute(
         sql.raw(`SELECT EXISTS (
           SELECT FROM information_schema.tables
@@ -572,7 +540,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
       expect(tableExists.rows[0]?.exists).toBe(true);
 
-      // Verify valid migration was recorded
       const validMigrationExists = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/concurrent-test-valid'`)
@@ -582,7 +549,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         parseInt(String((validMigrationExists.rows[0] as unknown as CountRow).count), 10)
       ).toBe(1);
 
-      // Verify invalid migration was NOT recorded
       const invalidMigrationExists = await db.execute(
         sql.raw(`SELECT COUNT(*) as count FROM migrations._migrations 
                  WHERE plugin_name = '@elizaos/concurrent-test-invalid'`)
@@ -596,7 +562,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
 
   describe("Advisory Lock Security", () => {
     it("should generate valid bigint lock IDs for plugins", async () => {
-      // Test that getAdvisoryLockId returns a valid bigint
       const testPlugins = [
         "@elizaos/plugin-sql",
         "@elizaos/plugin-openai",
@@ -605,19 +570,15 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       ];
 
       for (const pluginName of testPlugins) {
-        // Access private method for testing
         const lockId = getTestableMigrator(migrator).getAdvisoryLockId(pluginName);
 
-        // Verify it's a bigint
         expect(typeof lockId).toBe("bigint");
 
-        // Verify it's within PostgreSQL bigint range
         const _MIN_BIGINT = -9223372036854775808n;
         const MAX_BIGINT = 9223372036854775807n;
         expect(lockId).toBeGreaterThanOrEqual(0n); // We ensure positive values
         expect(lockId).toBeLessThanOrEqual(MAX_BIGINT);
 
-        // Verify it's non-zero
         expect(lockId).not.toBe(0n);
       }
     });
@@ -625,13 +586,11 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
     it("should generate consistent lock IDs for the same plugin", async () => {
       const pluginName = "@elizaos/advisory-lock-test";
 
-      // Generate lock ID multiple times
       const testMigrator = getTestableMigrator(migrator);
       const lockId1 = testMigrator.getAdvisoryLockId(pluginName);
       const lockId2 = testMigrator.getAdvisoryLockId(pluginName);
       const lockId3 = testMigrator.getAdvisoryLockId(pluginName);
 
-      // All should be identical
       expect(lockId1).toBe(lockId2);
       expect(lockId2).toBe(lockId3);
     });
@@ -644,7 +603,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       const lockId1 = testMigrator.getAdvisoryLockId(plugin1);
       const lockId2 = testMigrator.getAdvisoryLockId(plugin2);
 
-      // Should be different
       expect(lockId1).not.toBe(lockId2);
     });
 
@@ -652,7 +610,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       const testMigrator = getTestableMigrator(migrator);
       const validateBigInt = testMigrator.validateBigInt.bind(testMigrator);
 
-      // Valid values
       expect(validateBigInt(0n)).toBe(true);
       expect(validateBigInt(1n)).toBe(true);
       expect(validateBigInt(9223372036854775807n)).toBe(true); // MAX
@@ -676,30 +633,26 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Get the lock ID that would be used
       const testMigrator = getTestableMigrator(migrator);
       const lockId = testMigrator.getAdvisoryLockId("@elizaos/lock-security-test");
 
-      // Verify it's a valid bigint
       expect(typeof lockId).toBe("bigint");
 
-      // The actual SQL queries use CAST(${lockIdStr} AS bigint) for safety
-      // This ensures proper parameterization through Drizzle's sql tagged template
+      // The real lock queries use CAST(${lockIdStr} AS bigint), relying on
+      // Drizzle's sql tagged template for parameterization; the string form
+      // must therefore contain only digits.
       const lockIdStr = lockId.toString();
 
-      // Verify the string conversion doesn't introduce invalid characters
       expect(/^\d+$/.test(lockIdStr)).toBe(true);
     });
 
     it("should reject migration if invalid lock ID is generated", async () => {
-      // Save original method
       const testMigrator = getTestableMigrator(migrator);
       const originalGetLockId = testMigrator.getAdvisoryLockId.bind(testMigrator);
 
       try {
-        // Mock getAdvisoryLockId to return an invalid value
+        // Force an out-of-bigint-range lock ID to exercise the validation path.
         testMigrator.getAdvisoryLockId = () => {
-          // Return an out-of-range bigint
           return BigInt("99999999999999999999999999999");
         };
 
@@ -709,20 +662,15 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
           }),
         };
 
-        // This should throw an error due to invalid lock ID
         await expect(migrator.migrate("@elizaos/invalid-lock-test", testSchema)).rejects.toThrow(
           "Invalid advisory lock ID"
         );
       } finally {
-        // Restore original method
         testMigrator.getAdvisoryLockId = originalGetLockId;
       }
     });
 
     it("should handle concurrent migrations safely with advisory locks", async () => {
-      // This test verifies that our advisory lock mechanism would prevent
-      // race conditions in a real PostgreSQL environment
-
       const schema1 = {
         testTable: pgTable("test_advisory_concurrent_1", {
           id: uuid("id").primaryKey().defaultRandom(),
@@ -737,17 +685,14 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Run migrations concurrently
       const results = await Promise.allSettled([
         migrator.migrate("@elizaos/advisory-concurrent-test-1", schema1),
         migrator.migrate("@elizaos/advisory-concurrent-test-2", schema2),
       ]);
 
-      // Both should succeed
       expect(results[0].status).toBe("fulfilled");
       expect(results[1].status).toBe("fulfilled");
 
-      // Verify both tables were created
       const tablesExist = await db.execute(
         sql.raw(`
           SELECT COUNT(*) as count 
@@ -762,7 +707,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
   });
 
   describe("Race Condition Prevention", () => {
-    // Check if we're using real PostgreSQL (not PGLite)
     const postgresUrl = process.env.POSTGRES_URL || "";
     const isRealPostgres =
       postgresUrl &&
@@ -770,16 +714,14 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
       !postgresUrl.includes("pglite") &&
       postgresUrl.includes("postgres");
 
-    // Skip this test for PGLite since it doesn't support advisory locks
     const testOrSkip = isRealPostgres ? it : it.skip;
 
     testOrSkip("should handle race condition when lastMigration is initially null", async () => {
-      // This test verifies the fix for the race condition where:
-      // 1. Process A checks and finds lastMigration = null
-      // 2. Process B completes a migration while A waits for lock
-      // 3. Process A must detect the completion via double-check
-      // Requires real PostgreSQL (advisory locks not available in PGLite)
-
+      // Regression coverage for: (1) process A checks and finds
+      // lastMigration = null, (2) process B completes the migration while A
+      // waits for the advisory lock, (3) A must detect B's completion via a
+      // double-check after acquiring the lock rather than re-running the
+      // migration. Requires real Postgres — PGlite has no advisory locks.
       const pluginName = "@elizaos/test-race-condition-null-initial";
 
       const schema1 = {
@@ -798,7 +740,6 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         }),
       };
 
-      // Clean up any existing migration records for this test
       await db.execute(
         sql.raw(`DELETE FROM migrations._migrations WHERE plugin_name = '${pluginName}'`)
       );
@@ -806,15 +747,12 @@ describe("Runtime Migrator - Transaction Support & Concurrency Tests", () => {
         sql.raw(`DELETE FROM migrations._snapshots WHERE plugin_name = '${pluginName}'`)
       );
 
-      // Drop the table if it exists
       await db.execute(sql.raw(`DROP TABLE IF EXISTS test_race_null_initial`));
 
-      // Create two migrators to simulate two processes
       const migrator1 = new RuntimeMigrator(db);
       const migrator2 = new RuntimeMigrator(db);
 
-      // Run migrations concurrently - both should see no initial migration
-      // and both will try to acquire the lock
+      // Both instances see lastMigration = null and race to acquire the lock.
       const [result1, result2] = await Promise.allSettled([
         migrator1.migrate(pluginName, schema1),
         migrator2.migrate(pluginName, schema2),

--- a/plugins/plugin-sql/src/__tests__/migration/type-normalization.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/type-normalization.real.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Real-PGlite tests proving `RuntimeMigrator`'s type normalization treats
+ * database-introspected type spellings and their Drizzle schema equivalents
+ * as the same type — so no spurious diff/migration is generated — across
+ * SERIAL/BIGSERIAL/SMALLSERIAL vs. identity columns, timestamp with/without
+ * time zone, numeric/decimal, varchar/character varying, safe numeric and
+ * varchar-to-text promotions with data preserved, and a production-shaped
+ * table combining all of the above at once.
+ */
 import { PGlite } from "@electric-sql/pglite";
 import { vector } from "@electric-sql/pglite/vector";
 import { sql } from "drizzle-orm";
@@ -20,17 +29,6 @@ import { DatabaseIntrospector } from "../../runtime-migrator/drizzle-adapters/da
 import { RuntimeMigrator } from "../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../runtime-migrator/types";
 
-/**
- * Type Normalization Tests
- *
- * These tests verify that our type normalization correctly handles
- * equivalent type variations that occur between:
- * 1. Database introspection results
- * 2. Drizzle schema definitions
- *
- * This is critical for production scenarios where existing databases
- * may have been created with different type representations.
- */
 describe("Type Normalization", () => {
   let pgClient: PGlite;
   let db: DrizzleDB;
@@ -51,7 +49,6 @@ describe("Type Normalization", () => {
 
   describe("Serial Type Equivalence", () => {
     it("should recognize SERIAL as equivalent to INTEGER with auto-increment", async () => {
-      // Create table with SERIAL (as database would)
       await db.execute(sql`
         CREATE TABLE test_serial (
           id SERIAL PRIMARY KEY,
@@ -59,7 +56,7 @@ describe("Type Normalization", () => {
         )
       `);
 
-      // Define schema with integer().primaryKey().generatedByDefaultAsIdentity()
+      // Drizzle's equivalent of a raw SERIAL column.
       const schema = {
         test_serial: pgTable("test_serial", {
           id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
@@ -67,10 +64,8 @@ describe("Type Normalization", () => {
         }),
       };
 
-      // Migration should detect no changes
       await migrator.migrate("@test/serial", schema, { verbose: false });
 
-      // Verify no destructive changes were detected
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_serial`);
       expect(result).toBeDefined();
     });
@@ -92,7 +87,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/bigserial", schema, { verbose: false });
 
-      // Should complete without errors
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_bigserial`);
       expect(result).toBeDefined();
     });
@@ -114,7 +108,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/smallserial", schema, { verbose: false });
 
-      // Should complete without errors
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_smallserial`);
       expect(result).toBeDefined();
     });
@@ -122,7 +115,7 @@ describe("Type Normalization", () => {
 
   describe("Timestamp Type Variations", () => {
     it("should treat timestamp without time zone as equivalent to timestamp", async () => {
-      // Database introspection often returns 'timestamp without time zone'
+      // Introspecting a real DB typically reports 'timestamp without time zone'.
       await db.execute(sql`
         CREATE TABLE test_timestamp (
           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -142,7 +135,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/timestamp", schema, { verbose: false });
 
-      // Should not detect any changes
       const columns = await db.execute(sql`
         SELECT column_name, data_type 
         FROM information_schema.columns 
@@ -171,7 +163,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/timestamptz", schema, { verbose: false });
 
-      // Should complete without errors
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_timestamptz`);
       expect(result).toBeDefined();
     });
@@ -197,7 +188,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/numeric", schema, { verbose: false });
 
-      // Should complete without errors
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_numeric`);
       expect(result).toBeDefined();
     });
@@ -221,7 +211,6 @@ describe("Type Normalization", () => {
 
       await migrator.migrate("@test/varchar", schema, { verbose: false });
 
-      // Should complete without errors
       const result = await db.execute(sql`SELECT COUNT(*) FROM test_varchar`);
       expect(result).toBeDefined();
     });
@@ -237,13 +226,12 @@ describe("Type Normalization", () => {
         )
       `);
 
-      // Insert test data
       await db.execute(sql`
         INSERT INTO test_promotion (small_num, medium_num) 
         VALUES (100, 1000)
       `);
 
-      // Promote types to larger sizes (safe operation)
+      // Widening to a larger numeric type is a safe, non-destructive change.
       const schema = {
         test_promotion: pgTable("test_promotion", {
           id: integer("id").primaryKey().generatedByDefaultAsIdentity(),
@@ -252,10 +240,9 @@ describe("Type Normalization", () => {
         }),
       };
 
-      // This should be allowed without force flag
+      // No force flag needed — this is safe.
       await migrator.migrate("@test/promotion", schema, { verbose: false });
 
-      // Verify data is preserved
       const result = await db.execute(sql`
         SELECT * FROM test_promotion
       `);
@@ -289,7 +276,6 @@ describe("Type Normalization", () => {
         verbose: false,
       });
 
-      // Verify data is preserved
       const result = await db.execute(sql`
         SELECT * FROM test_text_promotion
       `);
@@ -300,7 +286,6 @@ describe("Type Normalization", () => {
 
   describe("Complex Real-World Scenario", () => {
     it("should handle mixed type variations in production-like table", async () => {
-      // Simulate a production table with various type representations
       await db.execute(sql`
         CREATE TABLE production_table (
           id BIGSERIAL PRIMARY KEY,
@@ -317,7 +302,6 @@ describe("Type Normalization", () => {
         )
       `);
 
-      // Insert test data
       await db.execute(sql`
         INSERT INTO production_table (user_id, username, email, age, balance, metadata) 
         VALUES (
@@ -330,7 +314,6 @@ describe("Type Normalization", () => {
         )
       `);
 
-      // Drizzle schema with normalized types
       const schema = {
         production_table: pgTable("production_table", {
           id: bigint("id", { mode: "number" }).primaryKey().generatedByDefaultAsIdentity(),
@@ -349,10 +332,8 @@ describe("Type Normalization", () => {
         }),
       };
 
-      // Should handle all type variations without errors
       await migrator.migrate("@test/production", schema, { verbose: false });
 
-      // Verify data integrity
       const result = await db.execute(sql`
         SELECT * FROM production_table
       `);

--- a/plugins/plugin-sql/src/__tests__/pg-sslmode.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pg-sslmode.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `normalizePgSslMode`: rewrites the `prefer`/`require`/
+ * `verify-ca` sslmode aliases to explicit `verify-full` (pinning today's
+ * pg-connection-string behavior ahead of its libpq-semantics change), while
+ * leaving `uselibpqcompat=true` connection strings and other sslmode values
+ * untouched. Pure string transform, no database involved.
+ */
 import { describe, expect, it } from "vitest";
 import { normalizePgSslMode } from "../pg/sslmode";
 

--- a/plugins/plugin-sql/src/__tests__/schema-data/index.ts
+++ b/plugins/plugin-sql/src/__tests__/schema-data/index.ts
@@ -1,3 +1,4 @@
+/** Shared deterministic `Character` fixture used across plugin-sql integration tests. */
 import type { Character } from "@elizaos/core";
 
 export const mockCharacter: Character = {

--- a/plugins/plugin-sql/src/__tests__/schema-data/test-plugin-schema.ts
+++ b/plugins/plugin-sql/src/__tests__/schema-data/test-plugin-schema.ts
@@ -1,3 +1,9 @@
+/**
+ * Fixture plugin schema used by migration tests to exercise a realistic
+ * multi-table, cross-schema-namespaced ("polymarket") Drizzle schema with
+ * foreign keys, a unique constraint, and an index — distinct from the core
+ * elizaOS schema.
+ */
 import { sql } from "drizzle-orm";
 import {
   boolean,

--- a/plugins/plugin-sql/src/__tests__/test-helpers.ts
+++ b/plugins/plugin-sql/src/__tests__/test-helpers.ts
@@ -1,3 +1,13 @@
+/**
+ * Shared setup helpers for `plugin-sql` integration/migration tests: each
+ * builds a real `AgentRuntime` wired to a real `PgliteDatabaseAdapter` (or, if
+ * `POSTGRES_URL` is set, a real `PgDatabaseAdapter`) — no mocked adapters —
+ * running the actual dynamic migration system against a scratch schema/temp
+ * dir, plus a `cleanup()` to tear it down. `createIsolatedTestDatabase`/
+ * `createTestDatabase` also seed a mock agent row and run all plugin
+ * migrations; `createIsolatedTestDatabaseForMigration` skips migrations so
+ * migration tests can drive that process themselves.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -34,8 +44,7 @@ export async function createTestDatabase(
   cleanup: () => Promise<void>;
 }> {
   if (process.env.POSTGRES_URL) {
-    // PostgreSQL testing - use superuser for full permissions
-    // Transform URL to use postgres:postgres credentials
+    // Superuser credentials give tests full DDL permissions (schema create/drop).
     const originalUrl = process.env.POSTGRES_URL;
     const superuserUrl = new URL(originalUrl);
     superuserUrl.username = "postgres";
@@ -56,7 +65,6 @@ export async function createTestDatabase(
     const schemaName = `test_${testAgentId.replace(/-/g, "_")}`;
     const db = connectionManager.getDatabase();
 
-    // Drop schema if it exists to ensure clean state
     await db.execute(sql.raw(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`));
     await db.execute(sql.raw(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`));
     await db.execute(sql.raw(`SET search_path TO ${schemaName}, public`));
@@ -83,7 +91,6 @@ export async function createTestDatabase(
 
     return { adapter, runtime, cleanup };
   } else {
-    // PGlite testing
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-test-"));
     const connectionManager = new PGliteClientManager({ dataDir: tempDir });
     await connectionManager.initialize();
@@ -138,14 +145,11 @@ export async function createIsolatedTestDatabase(
   cleanup: () => Promise<void>;
   testAgentId: UUID;
 }> {
-  // Generate a unique agent ID for this test
   const testAgentId = v4() as UUID;
   const testId = testName.replace(/[^a-zA-Z0-9]/g, "_").toLowerCase();
 
   if (process.env.POSTGRES_URL) {
-    // PostgreSQL - use superuser for full control over schema
-    // Transform URL to use postgres:postgres credentials (superuser)
-    // This ensures tests have full permissions to create/drop tables
+    // Superuser credentials give tests full permissions to create/drop tables.
     const originalUrl = process.env.POSTGRES_URL;
     const superuserUrl = new URL(originalUrl);
     superuserUrl.username = "postgres";
@@ -159,13 +163,12 @@ export async function createIsolatedTestDatabase(
 
     const db = connectionManager.getDatabase();
 
-    // Clean up custom schemas and migration tables for fresh start
     await db.execute(sql.raw(`DROP SCHEMA IF EXISTS migrations CASCADE`));
     await db.execute(sql.raw(`DROP TABLE IF EXISTS _snapshots CASCADE`));
     await db.execute(sql.raw(`DROP TABLE IF EXISTS _journal CASCADE`));
     await db.execute(sql.raw(`DROP TABLE IF EXISTS _migrations CASCADE`));
 
-    // Drop ALL tables in public schema for clean slate
+    // Drop every table in public for a clean slate before migrations run.
     await db.execute(
       sql.raw(`
       DO $$ DECLARE
@@ -185,13 +188,11 @@ export async function createIsolatedTestDatabase(
     });
     runtime.registerDatabaseAdapter(adapter);
 
-    // Run migrations on clean database
     const migrationService = new DatabaseMigrationService();
     await migrationService.initializeWithDatabase(db);
     migrationService.discoverAndRegisterPluginSchemas([sqlPlugin, ...testPlugins]);
     await migrationService.runAllPluginMigrations();
 
-    // Create test agent
     const created = await adapter.createAgent({
       ...mockCharacter,
       id: testAgentId,
@@ -202,16 +203,14 @@ export async function createIsolatedTestDatabase(
       throw new Error(`Failed to create test agent in createIsolatedTestDatabase (${testAgentId})`);
     }
 
+    // Tables are dropped at the start of the *next* test, not here, so tests
+    // can run in any order without depending on a prior test's teardown.
     const cleanup = async () => {
-      // Just close the connection - don't drop tables
-      // Tables are dropped at the START of each test, not at the end
-      // This ensures tests can run in any order
       await adapter.close();
     };
 
     return { adapter, runtime, cleanup, testAgentId };
   } else {
-    // PGLite - use unique directory per test
     const tempDir = path.join(os.tmpdir(), `eliza-test-${testId}-${Date.now()}`);
     console.log(`[TEST] Creating isolated PGLite database: ${tempDir}`);
 
@@ -227,13 +226,11 @@ export async function createIsolatedTestDatabase(
     });
     runtime.registerDatabaseAdapter(adapter);
 
-    // Run migrations
     const migrationService = new DatabaseMigrationService();
     await migrationService.initializeWithDatabase(adapter.getDatabase() as DrizzleDatabase);
     migrationService.discoverAndRegisterPluginSchemas([sqlPlugin, ...testPlugins]);
     await migrationService.runAllPluginMigrations();
 
-    // Create test agent
     const created = await adapter.createAgent({
       ...mockCharacter,
       id: testAgentId,
@@ -275,8 +272,7 @@ export async function createIsolatedTestDatabaseForMigration(testName: string): 
   const testId = testName.replace(/[^a-zA-Z0-9]/g, "_").toLowerCase();
 
   if (process.env.POSTGRES_URL) {
-    // PostgreSQL - use superuser for migration tests (needs DROP SCHEMA permissions)
-    // Transform the URL to use postgres:postgres credentials
+    // Migration tests need DROP SCHEMA permissions, so use superuser credentials.
     const originalUrl = process.env.POSTGRES_URL;
     const url = new URL(originalUrl);
     url.username = "postgres";
@@ -291,14 +287,11 @@ export async function createIsolatedTestDatabaseForMigration(testName: string): 
 
     const db = connectionManager.getDatabase();
 
-    // Drop custom schemas first (like polymarket, migrations)
-    // These are created by plugin tests and need to be cleaned
+    // Custom schemas created by plugin tests (e.g. polymarket) need cleanup too.
     await db.execute(sql.raw(`DROP SCHEMA IF EXISTS polymarket CASCADE`));
     await db.execute(sql.raw(`DROP SCHEMA IF EXISTS migrations CASCADE`));
 
-    // Drop ALL tables in public schema for clean slate
-    // This ensures each test starts fresh without leftover state from previous tests
-    // WARNING: This is destructive - only use for testing!
+    // Destructive: drops every table in public so each test starts from a clean slate.
     await db.execute(
       sql.raw(`
       DO $$ DECLARE
@@ -311,24 +304,21 @@ export async function createIsolatedTestDatabaseForMigration(testName: string): 
     `)
     );
 
-    // Ensure grants for eliza_test user (PostgreSQL 15+ requires explicit grants on public schema)
-    // These must be set at the start of each test to ensure eliza_test can create tables
+    // PostgreSQL 15+ requires explicit grants on the public schema; reissue them each test.
     await db.execute(sql.raw(`GRANT ALL ON SCHEMA public TO eliza_test`));
     await db.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO eliza_test`));
     await db.execute(sql.raw(`GRANT CREATE ON SCHEMA public TO eliza_test`));
 
     const cleanup = async () => {
       try {
-        // Clean up custom schemas
         await db.execute(sql.raw(`DROP SCHEMA IF EXISTS polymarket CASCADE`));
         await db.execute(sql.raw(`DROP SCHEMA IF EXISTS migrations CASCADE`));
-        // Clean up migration tables in public schema
         await db.execute(sql.raw(`DROP TABLE IF EXISTS _snapshots CASCADE`));
         await db.execute(sql.raw(`DROP TABLE IF EXISTS _journal CASCADE`));
         await db.execute(sql.raw(`DROP TABLE IF EXISTS _migrations CASCADE`));
 
-        // Restore grants for eliza_test user (PostgreSQL 15+ requires explicit grants on public schema)
-        // This is needed because migration tests run as superuser and may affect schema ownership
+        // Migration tests run as superuser and can change schema ownership,
+        // so restore eliza_test's grants before the next test runs.
         await db.execute(sql.raw(`GRANT ALL ON SCHEMA public TO eliza_test`));
         await db.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO eliza_test`));
         await db.execute(sql.raw(`GRANT CREATE ON SCHEMA public TO eliza_test`));
@@ -340,7 +330,6 @@ export async function createIsolatedTestDatabaseForMigration(testName: string): 
 
     return { db, adapter, cleanup, testAgentId };
   } else {
-    // PGLite - use unique directory per test
     const tempDir = path.join(os.tmpdir(), `eliza-migration-test-${testId}-${Date.now()}`);
     console.log(`[MIGRATION TEST] Creating isolated PGLite database: ${tempDir}`);
 
@@ -379,22 +368,17 @@ export async function createIsolatedTestDatabaseForSchemaEvolutionTests(testName
   testAgentId: UUID;
   originalDestructiveSetting?: string;
 }> {
-  // Save original environment variable
   const originalDestructiveSetting = process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS;
 
-  // Get the base setup
   const baseSetup = await createIsolatedTestDatabaseForMigration(testName);
 
-  // Enhance cleanup to restore environment variable
   const enhancedCleanup = async () => {
-    // Restore original environment variable
     if (originalDestructiveSetting !== undefined) {
       process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS = originalDestructiveSetting;
     } else {
       delete process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS;
     }
 
-    // Call original cleanup
     await baseSetup.cleanup();
   };
 

--- a/plugins/plugin-sql/src/__tests__/unit/close-pglite-singleton.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/close-pglite-singleton.test.ts
@@ -1,12 +1,15 @@
+/**
+ * Unit tests for `closePgliteSingleton()` / `getPgliteSingletonCache()`, the
+ * public accessors that let hosts recover or pre-seed the process-global
+ * PGlite manager without hand-copying the private
+ * `Symbol.for("elizaos.plugin-sql.global-singletons")`. Exercises the
+ * in-memory cache object directly with fake manager stubs — no real PGlite
+ * instance is created.
+ */
 import { afterEach, describe, expect, it } from "vitest";
 import { closePgliteSingleton, getPgliteSingletonCache } from "../../index.node";
 import { pgliteManagerCacheKey } from "../../pglite/manager-cache";
 
-/**
- * closePgliteSingleton() / getPgliteSingletonCache() are the public accessors
- * that let hosts recover or pre-seed the process-global PGlite manager without
- * hand-copying the private `Symbol.for("elizaos.plugin-sql.global-singletons")`.
- */
 describe("closePgliteSingleton", () => {
   afterEach(() => {
     const cache = getPgliteSingletonCache() as ReturnType<typeof getPgliteSingletonCache> & {

--- a/plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for `getOrCreatePgliteManagerForAgent` / `getActivePgliteManager`
+ * against an in-memory `PgliteManagerCache`, using a `FakeManager` stub (no
+ * real PGlite instance): confirms managers are reused per (dataDir, agentId)
+ * pair, are distinct across agent ids, and a manager reporting
+ * `isShuttingDown()` is replaced rather than reused.
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getActivePgliteManager,

--- a/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/sanitize-json.test.ts
@@ -1,20 +1,17 @@
+/**
+ * Unit tests for `sanitizeJsonObject`. The sanitized value is always
+ * serialized with `JSON.stringify` before being bound as a `$1::jsonb`
+ * parameter, so JSON escaping is already handled by the serializer;
+ * `sanitizeJsonObject` must therefore only strip NUL characters (PostgreSQL/
+ * PGlite jsonb rejects the escape JSON.stringify emits for them) and break
+ * circular references — nothing else. A prior implementation also doubled
+ * every backslash not followed by an allowlisted escape character and
+ * mangled non-hex unicode-escape sequences, so a Windows path like
+ * "C:\Users" round-tripped corrupted with doubled backslashes.
+ */
 import { describe, expect, it } from "vitest";
 import { sanitizeJsonObject } from "../../utils";
 
-/**
- * Unit tests for sanitizeJsonObject.
- *
- * The sanitized value is always serialized with JSON.stringify before being
- * bound as a `$1::jsonb` parameter, so JSON escaping is already handled by
- * the serializer. sanitizeJsonObject must therefore:
- *  - strip NUL characters (PostgreSQL/PGlite jsonb rejects the `\u0000`
- *    escape JSON.stringify emits for them), and
- *  - break circular references,
- * and it must NOT rewrite anything else. The previous implementation also
- * doubled every backslash not followed by ["\/bfnrtu] and mangled non-hex
- * `\u` sequences, so a value like "C:\Users" was stored and read back as
- * "C:\\Users" — silent corruption of any string containing a backslash.
- */
 describe("sanitizeJsonObject", () => {
   it("preserves backslashes exactly (no double-escaping)", () => {
     // "C:\Users\dev" — backslash followed by chars outside ["\/bfnrtu]

--- a/plugins/plugin-sql/src/__tests__/unit/write-back.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/write-back.test.ts
@@ -1,12 +1,10 @@
+/**
+ * Unit tests for `WriteBackService`'s queue, retry, batching, and flush
+ * logic — with `fetch` mocked via `vi.spyOn`, no real PGlite WASM or network
+ * calls involved.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WriteBackService } from "../../write-back";
-
-/**
- * Unit tests for WriteBackService.
- *
- * These tests validate the queue, debounce, retry, and flush logic
- * without requiring PGlite WASM or Docker containers.
- */
 
 describe("WriteBackService", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -51,7 +49,6 @@ describe("WriteBackService", () => {
       );
 
     wb.enqueue("memories", "insert", { id: "m-1", content: "hello" });
-    // Flush synchronously
     return wb.flush().then(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const url = fetchSpy.mock.calls[0]?.[0] as string;
@@ -124,7 +121,6 @@ describe("WriteBackService", () => {
 
     wb.enqueue("memories", "insert", { id: "m-1" });
 
-    // First flush: fails, re-queues. We flush again.
     await wb.flush(); // fails, re-queues
     await wb.flush(); // fails again
     await wb.flush(); // succeeds

--- a/plugins/plugin-sql/src/agent-mapping.ts
+++ b/plugins/plugin-sql/src/agent-mapping.ts
@@ -1,3 +1,9 @@
+/**
+ * Bidirectional mappers between the runtime's `Agent`-facing message-example
+ * and document/knowledge shapes and the legacy nested-array / string forms
+ * stored in the agents table's JSONB columns, so older rows keep loading
+ * under the current `MessageExampleGroup[]` / `DocumentSourceItem[]` types.
+ */
 import type { DocumentSourceItem, MessageExample, MessageExampleGroup } from "@elizaos/core";
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1,3 +1,12 @@
+/**
+ * `BaseDrizzleAdapter` is the shared `IDatabaseAdapter` implementation that
+ * `PgDatabaseAdapter` and `PgliteDatabaseAdapter` both extend: every runtime
+ * persistence operation (agents, entities, rooms, memories, relationships,
+ * tasks, logs, cache, connector accounts/OAuth flow state, pairing) is
+ * implemented once here against Drizzle, backend-agnostically, with
+ * `withDatabase`/`withEntityContext` retry and Row Level Security wiring
+ * left to the concrete Postgres/PGlite subclasses.
+ */
 import {
   type AccessContext,
   type Agent,

--- a/plugins/plugin-sql/src/build.ts
+++ b/plugins/plugin-sql/src/build.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env bun
-
+/**
+ * Build script for plugin-sql: bundles Node ESM, browser ESM, and CJS
+ * entrypoints via Bun, emits `tsc`-generated `.d.ts` declarations, rewrites
+ * relative declaration import specifiers to point at the bundled `.js`
+ * files, and hand-writes small re-export shims (root index, `/schema`,
+ * `/drizzle` subpaths) so consumers get a stable public surface over the
+ * dual-runtime bundle layout.
+ */
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { appendFile, readFile, writeFile } from "node:fs/promises";

--- a/plugins/plugin-sql/src/connector-credential-store.ts
+++ b/plugins/plugin-sql/src/connector-credential-store.ts
@@ -1,3 +1,10 @@
+/**
+ * `ConnectorCredentialStore` factory over a pluggable `ConnectorCredentialVault`
+ * (secret manager or password-manager reference), keyed by a deterministic
+ * `connector.<agentId>.<provider>.<accountId>.<credentialType>` vault-ref
+ * string built from `buildConnectorCredentialVaultRef`, so connector account
+ * credentials never need to be stored inline in the SQL tables themselves.
+ */
 import type { UUID } from "@elizaos/core";
 
 export interface ConnectorPasswordManagerReference {

--- a/plugins/plugin-sql/src/drizzle.config.ts
+++ b/plugins/plugin-sql/src/drizzle.config.ts
@@ -1,3 +1,4 @@
+/** drizzle-kit config for generating standalone SQL migrations from the plugin-sql schema (not used by the runtime's own auto-migration path). */
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
 

--- a/plugins/plugin-sql/src/drizzle/index.ts
+++ b/plugins/plugin-sql/src/drizzle/index.ts
@@ -1,3 +1,4 @@
+/** Re-exports common Drizzle query helpers so consumers avoid a direct drizzle-orm version dependency. */
 export {
   and,
   asc,

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser entry point for `@elizaos/plugin-sql`: registers a PGlite
+ * (WASM-only) `IDatabaseAdapter`, backed by a process-global, per-agent
+ * `PGliteClientManager` singleton cache so repeated imports never spin up
+ * duplicate PGlite instances. No PostgreSQL support — see `index.node.ts`
+ * for the Node/Bun entry that adds it.
+ */
 import {
   type IAgentRuntime,
   type IDatabaseAdapter,

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -1,3 +1,12 @@
+/**
+ * Node/Bun entry point for `@elizaos/plugin-sql`: registers either a
+ * `PgDatabaseAdapter` (when `postgresUrl` is set, with per-RLS-server-id
+ * connection-pool reuse) or a `PgliteDatabaseAdapter` (per-agent PGlite
+ * singleton), both drawn from the process-global singleton cache under
+ * `Symbol.for("elizaos.plugin-sql.global-singletons")`. Also re-exports the
+ * Drizzle query-helper subpath, RLS management functions, and the PGlite
+ * live-query / Electric Sync status/reset/close accessors used by hosts.
+ */
 import { mkdirSync } from "node:fs";
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
@@ -128,12 +137,10 @@ export function createDatabaseAdapter(
       );
     }
 
-    // Initialize connection managers map if needed
     if (!globalSingletons.postgresConnectionManagers) {
       globalSingletons.postgresConnectionManagers = new Map();
     }
 
-    // Get or create connection manager for this server_id
     let manager = globalSingletons.postgresConnectionManagers.get(managerKey);
     if (!shouldReusePostgresManager(manager)) {
       logger.debug(

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Default (`@elizaos/plugin-sql`) entry point — the same Postgres/PGlite
+ * dual-adapter registration as `index.node.ts`, but resolving its data
+ * directory via `./utils` instead of `./utils.node`. Registers either a
+ * `PgDatabaseAdapter` (when `postgresUrl` is set, with a shared
+ * process-global connection-pool singleton) or a per-agent
+ * `PgliteDatabaseAdapter`, and re-exports the RLS management functions plus
+ * PGlite live-query / Electric Sync status/reset/close accessors.
+ */
 import { mkdirSync } from "node:fs";
 import type { IDatabaseAdapter, UUID } from "@elizaos/core";
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -1,3 +1,11 @@
+/**
+ * `DatabaseMigrationService` orchestrates startup schema migration for every
+ * registered plugin: collects each plugin's `schema` export, runs the
+ * legacy entity-RLS backfill (`migrateToEntityRLS`), drives `RuntimeMigrator`
+ * per plugin (continuing past individual failures and aggregating them into
+ * one error), and — when `ENABLE_DATA_ISOLATION=true` — re-applies Row Level
+ * Security across all tables once every migration succeeds.
+ */
 import { type IDatabaseAdapter, logger, type Plugin } from "@elizaos/core";
 import { migrateToEntityRLS } from "./migrations";
 import { applyEntityRLSToAllTables, applyRLSToNewTables, installRLSFunctions } from "./rls";

--- a/plugins/plugin-sql/src/migrations.ts
+++ b/plugins/plugin-sql/src/migrations.ts
@@ -1,14 +1,22 @@
+/**
+ * One-off, idempotent Postgres schema migration (`migrateToEntityRLS`) that
+ * runs on every startup ahead of `RuntimeMigrator`: it moves a database from
+ * the old owner-based RLS scheme to Server RLS + Entity RLS (renaming
+ * `server_id` → `message_server_id`, converting TEXT ids to UUID, dropping
+ * obsolete RLS columns/indexes), then leaves RLS enabled or disables it
+ * depending on `ENABLE_DATA_ISOLATION`. Detects and no-ops on non-Postgres
+ * backends and on databases that already carry the migrated (snake_case)
+ * columns.
+ */
 import { type IDatabaseAdapter, logger } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { getDb } from "./types";
 
-// Column info row for schema introspection queries
 interface ColumnInfoRow {
   column_name: string;
   data_type: string;
 }
 
-// Table info row for schema introspection queries
 interface TableInfoRow {
   table_name: string;
 }
@@ -20,19 +28,7 @@ function getRows<T>(result: { rows: unknown[] }): T[] {
   return result.rows as T[];
 }
 
-/**
- * TEMPORARY MIGRATION: pre-1.6.5 → 1.6.5+ schema migration
- *
- * This migration runs automatically on startup and is idempotent.
- * It handles the migration from Owner RLS to Server RLS + Entity RLS, including:
- * - Disabling old RLS policies temporarily
- * - Renaming server_id → message_server_id in channels, worlds, rooms
- * - Converting TEXT → UUID where needed
- * - Dropping old server_id columns for RLS
- * - Cleaning up indexes
- *
- * @param adapter - Database adapter
- */
+/** Migrates a pre-1.6.5 database to the 1.6.5+ Server RLS + Entity RLS schema. */
 export async function migrateToEntityRLS(adapter: IDatabaseAdapter): Promise<void> {
   const db = getDb(adapter);
 

--- a/plugins/plugin-sql/src/neon/adapter.ts
+++ b/plugins/plugin-sql/src/neon/adapter.ts
@@ -1,3 +1,16 @@
+/**
+ * IDatabaseAdapter implementation for Neon's serverless Postgres driver, used when the
+ * runtime targets serverless/edge hosts (Vercel, Cloudflare Workers) instead of a
+ * long-lived pg Pool. Wraps a NeonConnectionManager (WebSocket-based connection) and
+ * delegates all shared query logic to BaseDrizzleAdapter, overriding only the
+ * connection lifecycle and RLS isolation-context methods that differ from the
+ * node-postgres adapter.
+ *
+ * Entity-level Row Level Security is applied via withIsolationContext, which sets
+ * both server and entity Postgres session context inside a transaction before
+ * running the callback; this mirrors the semantics of PgDatabaseAdapter/
+ * PostgresConnectionManager so callers can treat the two adapters interchangeably.
+ */
 import { type Agent, type Entity, logger, type Memory, type UUID } from "@elizaos/core";
 import type { NeonDatabase } from "drizzle-orm/neon-serverless";
 import { BaseDrizzleAdapter } from "../base";

--- a/plugins/plugin-sql/src/neon/manager.ts
+++ b/plugins/plugin-sql/src/neon/manager.ts
@@ -1,3 +1,13 @@
+/**
+ * Owns the WebSocket-based connection to a Neon serverless Postgres database:
+ * a @neondatabase/serverless Pool for raw access plus a Drizzle NeonDatabase handle
+ * consumed by NeonDatabaseAdapter. Connection pooling itself is delegated to Neon's
+ * edge proxy, so this manager is deliberately thinner than PostgresConnectionManager.
+ *
+ * withIsolationContext applies Row Level Security by running set_config() calls
+ * inside a transaction before invoking the caller's callback, using parameterized
+ * queries to avoid SQL injection through the server/entity id values.
+ */
 import { logger, type UUID, validateUuid } from "@elizaos/core";
 import { neonConfig, Pool } from "@neondatabase/serverless";
 import { sql } from "drizzle-orm";

--- a/plugins/plugin-sql/src/pg/adapter.ts
+++ b/plugins/plugin-sql/src/pg/adapter.ts
@@ -1,3 +1,14 @@
+/**
+ * IDatabaseAdapter implementation for standard PostgreSQL, used whenever POSTGRES_URL
+ * is configured (the non-serverless, non-PGlite path). Wraps a PostgresConnectionManager
+ * (a pg Pool singleton) and delegates all core persistence logic to BaseDrizzleAdapter,
+ * re-exposing a handful of base methods directly so the public class surface documents
+ * the adapter's full capability set even where the implementation is inherited unchanged.
+ *
+ * withEntityContext forwards to the manager's transaction-scoped Row Level Security
+ * context (see PostgresConnectionManager), which is a no-op unless ENABLE_DATA_ISOLATION
+ * is set.
+ */
 import {
   type Agent,
   type Component,

--- a/plugins/plugin-sql/src/pg/manager.ts
+++ b/plugins/plugin-sql/src/pg/manager.ts
@@ -1,3 +1,11 @@
+/**
+ * `PostgresConnectionManager` wraps a single `pg` `Pool` (env-tunable size,
+ * SSL mode normalized) behind the shared connection-manager surface used by
+ * `PgDatabaseAdapter`: exposes the pool and a Drizzle handle, tracks
+ * shutdown state so in-flight and new work is rejected during `close()`,
+ * and runs callbacks inside a transaction that sets the Row Level Security
+ * `app.entity_id` config when data isolation is enabled.
+ */
 import { logger, type UUID, validateUuid } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";

--- a/plugins/plugin-sql/src/pg/sslmode.ts
+++ b/plugins/plugin-sql/src/pg/sslmode.ts
@@ -1,3 +1,4 @@
+/** Resolves a Postgres connection string's sslmode alias to today's explicit TLS behavior, ahead of node-postgres parsing it. */
 const PG_SSLMODE_CURRENT_TLS_ALIASES = new Set(["prefer", "require", "verify-ca"]);
 
 /**

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -1,3 +1,11 @@
+/**
+ * `PgliteDatabaseAdapter` wraps `BaseDrizzleAdapter` for PGlite: routes
+ * database access through a `PGliteClientManager` (lazily initializing it
+ * and deferring Electric Sync startup to the first real operation, once
+ * migrated tables are guaranteed to exist), and overrides every mutating
+ * write method to additionally call `manager.notifyWrite()` so
+ * `WriteBackService` can forward local writes to the cloud API.
+ */
 import type { PGlite } from "@electric-sql/pglite";
 import {
   type Agent,

--- a/plugins/plugin-sql/src/pglite/errors.ts
+++ b/plugins/plugin-sql/src/pglite/errors.ts
@@ -1,3 +1,9 @@
+/**
+ * Typed error codes and helpers for fatal PGlite storage failures (data dir
+ * locked by another process, corrupted data, or a state requiring manual
+ * reset). `getPgliteErrorCode` walks an error's `cause` chain to find one of
+ * these codes even when it's wrapped by intermediate errors.
+ */
 export const PGLITE_ERROR_CODES = {
   ACTIVE_LOCK: "ELIZA_PGLITE_DATA_DIR_IN_USE",
   CORRUPT_DATA: "ELIZA_PGLITE_CORRUPT_DATA",

--- a/plugins/plugin-sql/src/pglite/manager-cache.ts
+++ b/plugins/plugin-sql/src/pglite/manager-cache.ts
@@ -1,3 +1,9 @@
+/**
+ * Keyed cache for per-agent/per-data-dir PGlite manager singletons, backing
+ * the process-global store at `Symbol.for("elizaos.plugin-sql.global-singletons")`.
+ * Lets multiple agents share one manager per (dataDir, agentId) pair while
+ * exposing only a narrow, private-implementation-safe surface to hosts.
+ */
 export interface ReusablePgliteManager {
   isShuttingDown(): boolean;
 }

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -1,3 +1,14 @@
+/**
+ * `PGliteClientManager` owns the lifecycle of a single embedded PGlite
+ * (WASM Postgres) instance: WASM extension loading, a cross-process data-dir
+ * lock (with PID/boot-id/proc-start-tick reuse detection so a recycled PID or
+ * an unclean container shutdown can't permanently brick boot), optional
+ * Electric Sync bootstrapping for the local-cloud read path, and forwarding
+ * local writes to `WriteBackService` for the cloud write path. Mobile
+ * embedded runtimes (iOS/Android local backend) are single-tenant and get a
+ * carve-out from the liveness heuristics since a leftover lock there is
+ * always stale.
+ */
 import {
   closeSync,
   existsSync,
@@ -628,16 +639,9 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
       return "missing";
     }
 
-    // iOS embedded mode is single-tenant: Bun runs as a thread inside the
-    // host app process, and ElizaBunRuntime serializes engine starts. Any
-    // leftover postmaster.pid is by definition stale — either from a prior
-    // app launch, or from a prior Bun thread in this same process that
-    // already exited. The standard `process.kill(pid, 0)` heuristic
-    // produces false positives here because the recorded PID matches the
-    // current iOS app PID.
     // Mobile embedded modes (iOS and Android) are single-tenant: each app
     // launch spawns a fresh Bun process, so any leftover postmaster.pid is
-    // always stale.  The process.kill(pid, 0) heuristic below can produce
+    // always stale. The process.kill(pid, 0) heuristic below can produce
     // false positives on both platforms (iOS: same-process PID; Android:
     // EPERM instead of ESRCH for cross-UID pids), so clear unconditionally.
     if (

--- a/plugins/plugin-sql/src/rls.ts
+++ b/plugins/plugin-sql/src/rls.ts
@@ -1,3 +1,12 @@
+/**
+ * PostgreSQL Row Level Security (RLS) setup and teardown for two independent
+ * isolation layers: per-server isolation (via a `server_id` column + the
+ * `current_server_id()` session function) and per-entity isolation (via
+ * `entity_id`/`author_id`/`room_id` + `current_entity_id()`). Installs SQL
+ * functions/policies that apply automatically to every existing and future
+ * table, so new schema tables need no manual RLS wiring. PGlite has no RLS
+ * support, so these helpers are only invoked on the Postgres adapter.
+ */
 import { type IDatabaseAdapter, logger, validateUuid } from "@elizaos/core";
 import { eq, sql } from "drizzle-orm";
 import { agentTable } from "./schema/agent";

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/database-introspector.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/database-introspector.ts
@@ -1,3 +1,11 @@
+/**
+ * Reads back the live PostgreSQL catalog (tables, columns, indexes, foreign
+ * keys, primary/unique/check constraints, enums) via raw `pg_catalog` /
+ * `information_schema` queries and assembles it into a `SchemaSnapshot` in
+ * the same shape the schema-transformer produces from Drizzle schema
+ * definitions. Used by the runtime migrator to establish a baseline snapshot
+ * when a plugin has existing tables but no recorded prior snapshot.
+ */
 import { logger } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { deriveSchemaName } from "../schema-transformer";

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/diff-calculator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/diff-calculator.ts
@@ -1,3 +1,11 @@
+/**
+ * Diffs two `SchemaSnapshot`s (previous vs. current) into a structured
+ * `SchemaDiff` describing every created/deleted/modified table, column,
+ * index, foreign key, and constraint. Feeds the SQL generator, which turns
+ * the diff into the actual migration statements. Type comparison is
+ * normalized (e.g. `serial` vs `integer`, `timestamp with/without time zone`)
+ * so equivalent Postgres type spellings don't register as spurious changes.
+ */
 import type {
   IndexColumn,
   SchemaCheckConstraint,
@@ -209,15 +217,13 @@ export async function calculateDiff(
     },
   };
 
-  // If no previous snapshot, all tables are new
+  // If no previous snapshot, all tables (and their indexes/foreign keys) are new.
   if (!previousSnapshot) {
     diff.tables.created = Object.keys(currentSnapshot.tables);
 
-    // Also track indexes and foreign keys from new tables
     for (const tableName in currentSnapshot.tables) {
       const table = currentSnapshot.tables[tableName];
 
-      // Add indexes
       if (table.indexes) {
         for (const indexName in table.indexes) {
           diff.indexes.created.push({
@@ -227,7 +233,6 @@ export async function calculateDiff(
         }
       }
 
-      // Add foreign keys
       if (table.foreignKeys) {
         for (const fkName in table.foreignKeys) {
           diff.foreignKeys.created.push(table.foreignKeys[fkName]);
@@ -241,14 +246,12 @@ export async function calculateDiff(
   const prevTables = previousSnapshot.tables || {};
   const currTables = currentSnapshot.tables || {};
 
-  // Find created tables
   for (const tableName in currTables) {
     if (!(tableName in prevTables)) {
       diff.tables.created.push(tableName);
 
       const table = currTables[tableName];
 
-      // Add indexes for new table
       if (table.indexes) {
         for (const indexName in table.indexes) {
           diff.indexes.created.push({
@@ -258,7 +261,6 @@ export async function calculateDiff(
         }
       }
 
-      // Add unique constraints for new table
       if (table.uniqueConstraints) {
         for (const uqName in table.uniqueConstraints) {
           diff.uniqueConstraints.created.push({
@@ -268,7 +270,6 @@ export async function calculateDiff(
         }
       }
 
-      // Add check constraints for new table
       if (table.checkConstraints) {
         for (const checkName in table.checkConstraints) {
           diff.checkConstraints.created.push({
@@ -278,7 +279,6 @@ export async function calculateDiff(
         }
       }
 
-      // Add foreign keys for new table
       if (table.foreignKeys) {
         for (const fkName in table.foreignKeys) {
           diff.foreignKeys.created.push(table.foreignKeys[fkName]);
@@ -287,21 +287,19 @@ export async function calculateDiff(
     }
   }
 
-  // Find deleted tables
   for (const tableName in prevTables) {
     if (!(tableName in currTables)) {
       diff.tables.deleted.push(tableName);
     }
   }
 
-  // Find modified tables (check columns, indexes, foreign keys)
   for (const tableName in currTables) {
     if (tableName in prevTables) {
       const prevTable = prevTables[tableName];
       const currTable = currTables[tableName];
 
-      // Early check: if the table schemas are identical, skip it entirely
-      // This prevents false positives when other tables are modified
+      // Skip the table entirely if its schema is unchanged, so an unrelated
+      // in-place edit elsewhere in the JSON doesn't register a false positive.
       const prevTableJson = JSON.stringify({
         columns: prevTable.columns || {},
         indexes: prevTable.indexes || {},
@@ -318,16 +316,13 @@ export async function calculateDiff(
         checkConstraints: currTable.checkConstraints || {},
       });
 
-      // If tables are identical, skip all processing for this table
       if (prevTableJson === currTableJson) {
         continue;
       }
 
-      // Compare columns
       const prevColumns = prevTable.columns || {};
       const currColumns = currTable.columns || {};
 
-      // Find added columns
       for (const colName in currColumns) {
         if (!(colName in prevColumns)) {
           diff.columns.added.push({
@@ -338,7 +333,6 @@ export async function calculateDiff(
         }
       }
 
-      // Find deleted columns
       for (const colName in prevColumns) {
         if (!(colName in currColumns)) {
           diff.columns.deleted.push({
@@ -348,14 +342,11 @@ export async function calculateDiff(
         }
       }
 
-      // Find modified columns
       for (const colName in currColumns) {
         if (colName in prevColumns) {
           const prevCol = prevColumns[colName];
           const currCol = currColumns[colName];
 
-          // Check for changes in column properties
-          // Use normalized type comparison
           const typeChanged = normalizeType(prevCol.type) !== normalizeType(currCol.type);
           const hasChanges =
             typeChanged ||
@@ -376,28 +367,23 @@ export async function calculateDiff(
         }
       }
 
-      // Compare indexes
       const prevIndexes = prevTable.indexes || {};
       const currIndexes = currTable.indexes || {};
 
-      // Find new, deleted, and altered indexes
       for (const indexName in currIndexes) {
         if (!(indexName in prevIndexes)) {
-          // New index
           diff.indexes.created.push({
             ...currIndexes[indexName],
             table: tableName,
           } as SchemaIndex & { table: string });
         } else {
-          // Check if index definition changed
           const prevIndex = prevIndexes[indexName];
           const currIndex = currIndexes[indexName];
 
-          // Deep comparison of index properties
           const indexChanged = isIndexChanged(prevIndex, currIndex);
 
           if (indexChanged) {
-            // Index definition changed - need to drop and recreate
+            // Same name, different definition: drop and recreate rather than ALTER.
             diff.indexes.altered.push({
               old: {
                 ...prevIndex,
@@ -414,7 +400,6 @@ export async function calculateDiff(
         }
       }
 
-      // Find deleted indexes (not altered)
       for (const indexName in prevIndexes) {
         if (!(indexName in currIndexes)) {
           diff.indexes.deleted.push({
@@ -424,11 +409,9 @@ export async function calculateDiff(
         }
       }
 
-      // Compare unique constraints
       const prevUniqueConstraints = prevTable.uniqueConstraints || {};
       const currUniqueConstraints = currTable.uniqueConstraints || {};
 
-      // Find new unique constraints
       for (const uqName in currUniqueConstraints) {
         if (!(uqName in prevUniqueConstraints)) {
           diff.uniqueConstraints.created.push({
@@ -438,7 +421,6 @@ export async function calculateDiff(
         }
       }
 
-      // Find deleted unique constraints
       for (const uqName in prevUniqueConstraints) {
         if (!(uqName in currUniqueConstraints)) {
           diff.uniqueConstraints.deleted.push({
@@ -448,11 +430,9 @@ export async function calculateDiff(
         }
       }
 
-      // Compare check constraints
       const prevCheckConstraints = prevTable.checkConstraints || {};
       const currCheckConstraints = currTable.checkConstraints || {};
 
-      // Find new check constraints
       for (const checkName in currCheckConstraints) {
         if (!(checkName in prevCheckConstraints)) {
           diff.checkConstraints.created.push({
@@ -462,7 +442,6 @@ export async function calculateDiff(
         }
       }
 
-      // Find deleted check constraints
       for (const checkName in prevCheckConstraints) {
         if (!(checkName in currCheckConstraints)) {
           diff.checkConstraints.deleted.push({
@@ -472,28 +451,23 @@ export async function calculateDiff(
         }
       }
 
-      // Compare foreign keys
       const prevFKs = prevTable.foreignKeys || {};
       const currFKs = currTable.foreignKeys || {};
 
-      // Find new, deleted, and altered foreign keys
       for (const fkName in currFKs) {
         if (!(fkName in prevFKs)) {
-          // New FK
           diff.foreignKeys.created.push(currFKs[fkName]);
         } else {
-          // Check if FK definition changed (CASCADE behavior, etc.)
           const prevFK = prevFKs[fkName];
           const currFK = currFKs[fkName];
 
-          // Compare FK properties
           const prevOnDelete = prevFK.onDelete || "no action";
           const currOnDelete = currFK.onDelete || "no action";
           const prevOnUpdate = prevFK.onUpdate || "no action";
           const currOnUpdate = currFK.onUpdate || "no action";
 
           if (prevOnDelete !== currOnDelete || prevOnUpdate !== currOnUpdate) {
-            // FK CASCADE behavior changed - need to drop and recreate
+            // CASCADE behavior changed: drop and recreate rather than ALTER.
             diff.foreignKeys.altered.push({
               old: prevFK,
               new: currFK,
@@ -502,7 +476,6 @@ export async function calculateDiff(
         }
       }
 
-      // Find deleted foreign keys (not altered)
       for (const fkName in prevFKs) {
         if (!(fkName in currFKs)) {
           const prevFK = prevFKs[fkName];

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/snapshot-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/snapshot-generator.ts
@@ -1,3 +1,13 @@
+/**
+ * Serializes a Drizzle schema module (tables, columns, indexes, foreign
+ * keys, primary/unique/check constraints) into the `SchemaSnapshot` shape
+ * used for diffing and migration generation. Much of the per-column and
+ * per-constraint handling deliberately mirrors Drizzle's own internal
+ * `pgSerializer`, since the fields it reads (`isUnique`, `config`, etc.) are
+ * internal Drizzle column properties not exposed in its public types. Also
+ * provides snapshot hashing (`hashSnapshot`, `hasChanges`) used to detect
+ * schema drift without a full field-by-field walk.
+ */
 import { is, SQL } from "drizzle-orm";
 import { getTableConfig, type PgColumn, PgDialect, PgTable } from "drizzle-orm/pg-core";
 import { extendedHash } from "../crypto-utils";
@@ -98,10 +108,8 @@ const sqlToStr = (sql: SQL, _casing: string | undefined) => {
 function extractTablesFromSchema(schema: DrizzleSchema): PgTable[] {
   const tables: PgTable[] = [];
 
-  // Iterate through all exports in the schema
   const exports = Object.values(schema);
   exports.forEach((t: unknown) => {
-    // Check if it's a PgTable using Drizzle's is() function
     if (is(t, PgTable)) {
       tables.push(t);
     }
@@ -120,10 +128,8 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
   const schemas: Record<string, string> = {};
   const enums: Record<string, SchemaEnum> = {};
 
-  // Extract tables from schema
   const pgTables = extractTablesFromSchema(schema);
 
-  // Process each table
   for (const table of pgTables) {
     const config = getTableConfig(table);
     const {
@@ -144,7 +150,8 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
     const uniqueConstraintObject: Record<string, SchemaUniqueConstraint> = {};
     const checksObject: Record<string, SchemaCheckConstraint> = {};
 
-    // Process columns - EXACT copy of Drizzle's logic
+    // Mirrors Drizzle's own column-processing logic exactly, since it reads
+    // internal column properties (see hasDrizzleColumnConfig above).
     columns.forEach((column: PgColumn) => {
       const name = column.name;
       const notNull = column.notNull;
@@ -159,7 +166,7 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
         notNull,
       };
 
-      // Handle defaults - EXACT copy from Drizzle's pgSerializer.ts lines 247-273
+      // Mirrors Drizzle's pgSerializer default-value handling.
       if (column.default !== undefined) {
         if (is(column.default, SQL)) {
           columnToSet.default = sqlToStr(column.default, undefined);
@@ -180,18 +187,14 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
             } else if (isPgArrayType(sqlTypeLowered) && Array.isArray(column.default)) {
               columnToSet.default = `'${buildArrayString(column.default as ArrayElement[], sqlTypeLowered)}'`;
             } else {
-              // Should do for all types
-              // columnToSet.default = `'${column.default}'::${sqlTypeLowered}`;
               columnToSet.default = column.default as string | number | boolean;
             }
           }
         }
       }
 
-      // Handle column-level unique constraints
-      // IMPORTANT: Check isUnique, not just uniqueName presence!
-      // Drizzle sets uniqueName for all columns but only unique ones should have constraints
-      // Type assertion: accessing internal Drizzle column properties not in public types
+      // Check isUnique, not just uniqueName presence: Drizzle sets uniqueName
+      // on every column but only actually-unique ones should get a constraint.
       const columnConfig = hasDrizzleColumnConfig(column) ? column.config : undefined;
       if (hasDrizzleColumnConfig(column) && column.isUnique && columnConfig?.uniqueName) {
         uniqueConstraintObject[columnConfig.uniqueName] = {
@@ -210,7 +213,6 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       getName: () => string;
     }
 
-    // Process primary keys
     primaryKeys.forEach((pk: DrizzlePrimaryKey) => {
       const columnNames = pk.columns.map((c) => c.name);
       const name = pk.getName();
@@ -228,7 +230,6 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       nullsNotDistinct?: boolean;
     }
 
-    // Process unique constraints
     uniqueConstraints.forEach((unq: DrizzleUniqueConstraint) => {
       const columnNames = unq.columns.map((c) => c.name);
       const name = unq.name || `${tableName}_${columnNames.join("_")}_unique`;
@@ -254,8 +255,8 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       onUpdate?: string;
     }
 
-    // Process foreign keys - includes both explicit foreignKeys and inline references
-    // Drizzle's getTableConfig automatically collects inline .references() into foreignKeys
+    // Covers both explicit foreignKeys and inline .references() — Drizzle's
+    // getTableConfig automatically collects inline references into foreignKeys.
     foreignKeys.forEach((fk: DrizzleForeignKey) => {
       const reference = fk.reference();
       const columnsFrom = reference.columns.map((it) => it.name);
@@ -268,7 +269,7 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       foreignKeysObject[name] = {
         name,
         tableFrom: tableName,
-        schemaFrom: tableSchema, // Add source table schema
+        schemaFrom: tableSchema,
         tableTo,
         schemaTo,
         columnsFrom,
@@ -298,8 +299,7 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       };
     }
 
-    // Process indexes
-    // Drizzle's getTableConfig returns indexes with internal types not exported from the package
+    // Drizzle's getTableConfig returns indexes with internal types not exported from the package.
     (indexes as DrizzleIndex[]).forEach((idx: DrizzleIndex) => {
       const indexCols = idx.config.columns;
       const indexColumns: IndexColumn[] = indexCols.map((col) => {
@@ -339,7 +339,6 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       value: SQL;
     }
 
-    // Process check constraints
     if (checks) {
       checks.forEach((check: DrizzleCheck) => {
         const checkName = check.name;
@@ -350,7 +349,6 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       });
     }
 
-    // Build the table object
     tables[`${tableSchema || "public"}.${tableName}`] = {
       name: tableName,
       schema: tableSchema || "public",
@@ -362,13 +360,11 @@ export async function generateSnapshot(schema: DrizzleSchema): Promise<SchemaSna
       checkConstraints: checksObject,
     };
 
-    // Track schemas
     if (tableSchema && tableSchema !== "public") {
       schemas[tableSchema] = tableSchema;
     }
   }
 
-  // Create snapshot in Drizzle's format
   const snapshot: SchemaSnapshot = {
     version: "7",
     dialect: "postgresql",

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -1,3 +1,13 @@
+/**
+ * Turns a `SchemaDiff` (from diff-calculator) into an ordered list of raw SQL
+ * migration statements — schemas and tables first, foreign keys after all
+ * tables exist, then column/index/constraint alterations, mirroring
+ * drizzle-kit's own statement ordering. Also runs a pre-flight data-loss
+ * check (`checkForDataLoss`) that flags destructive type changes, dropped
+ * tables/columns, and new NOT NULL columns without defaults. `ADD COLUMN` /
+ * `DROP COLUMN` statements are emitted with `IF NOT EXISTS` / `IF EXISTS` so
+ * a migration replays safely after a partial/crashed prior run.
+ */
 import { logger } from "@elizaos/core";
 import type {
   SchemaCheckConstraint,
@@ -45,7 +55,6 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
     requiresConfirmation: false,
   };
 
-  // Check for table deletions
   if (diff.tables.deleted.length > 0) {
     result.hasDataLoss = true;
     result.requiresConfirmation = true;
@@ -55,7 +64,6 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
     }
   }
 
-  // Check for column deletions
   if (diff.columns.deleted.length > 0) {
     result.hasDataLoss = true;
     result.requiresConfirmation = true;
@@ -65,14 +73,12 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
     }
   }
 
-  // Check for column type changes that might cause data loss
   for (const modified of diff.columns.modified) {
     const from = modified.changes.from;
     const to = modified.changes.to;
 
     if (!from || !to) continue;
 
-    // Check if type change is destructive
     if (from.type !== to.type) {
       const isDestructive = checkIfTypeChangeIsDestructive(from.type, to.type);
 
@@ -93,7 +99,6 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
       }
     }
 
-    // Check for adding NOT NULL without default to existing column
     if (!from.notNull && to.notNull && !to.default) {
       result.hasDataLoss = true;
       result.requiresConfirmation = true;
@@ -104,16 +109,14 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
     }
   }
 
-  // Check for adding NOT NULL columns without defaults
   for (const added of diff.columns.added) {
     if (added.definition.notNull && !added.definition.default) {
-      // This is only a problem if the table already has data
-      // We'll flag it as a potential issue
+      // Only a problem if the table already has rows, so this is a warning,
+      // not a hard data-loss finding — requiresConfirmation stays untouched.
       result.warnings.push(
         `Column "${added.column}" is being added to table "${added.table}" as NOT NULL without a default value. ` +
           `This will fail if the table contains data.`
       );
-      // Don't set requiresConfirmation here - it's only a warning
     }
   }
 
@@ -235,16 +238,13 @@ export async function generateMigrationSQL(
 ): Promise<string[]> {
   const statements: string[] = [];
 
-  // If no diff provided, calculate it
   if (!diff) {
     const { calculateDiff } = await import("./diff-calculator");
     diff = await calculateDiff(previousSnapshot, currentSnapshot);
   }
 
-  // Check for data loss
   const dataLossCheck = checkForDataLoss(diff);
 
-  // Log warnings if any
   if (dataLossCheck.warnings.length > 0) {
     logger.warn(
       { src: "plugin:sql", warnings: dataLossCheck.warnings },
@@ -252,7 +252,7 @@ export async function generateMigrationSQL(
     );
   }
 
-  // Phase 1: Collect unique schemas and create them first
+  // Phase 1: create every non-public schema referenced by a new table first.
   const schemasToCreate = new Set<string>();
   for (const tableName of diff.tables.created) {
     const table = currentSnapshot.tables[tableName];
@@ -264,12 +264,11 @@ export async function generateMigrationSQL(
     }
   }
 
-  // Create schemas first (following drizzle-kit pattern)
   for (const schema of schemasToCreate) {
     statements.push(`CREATE SCHEMA IF NOT EXISTS "${schema}";`);
   }
 
-  // Phase 2: Generate CREATE TABLE statements for new tables (WITHOUT foreign keys)
+  // Phase 2: CREATE TABLE for new tables, without foreign keys.
   const createTableStatements: string[] = [];
   const foreignKeyStatements: string[] = [];
 
@@ -282,16 +281,14 @@ export async function generateMigrationSQL(
     }
   }
 
-  // Add all CREATE TABLE statements
   statements.push(...createTableStatements);
 
-  // Phase 3: Add all foreign keys AFTER tables are created
-  // Deduplicate foreign key statements to avoid duplicate constraints
+  // Phase 3: add foreign keys after all tables exist, deduplicated by
+  // constraint name to avoid re-adding the same constraint twice.
   const uniqueFKs = new Set<string>();
   const dedupedFKStatements: string[] = [];
 
   for (const fkSQL of foreignKeyStatements) {
-    // Extract constraint name to check for duplicates
     const match = fkSQL.match(/ADD CONSTRAINT "([^"]+)"/);
     if (match) {
       const constraintName = match[1];
@@ -306,26 +303,20 @@ export async function generateMigrationSQL(
 
   statements.push(...dedupedFKStatements);
 
-  // Phase 4: Handle table modifications
-
-  // Generate DROP TABLE statements for deleted tables
+  // Phase 4: table modifications — drops, then column/index/constraint/FK changes.
   for (const tableName of diff.tables.deleted) {
     const [schema, name] = tableName.includes(".") ? tableName.split(".") : ["public", tableName];
     statements.push(`DROP TABLE IF EXISTS "${schema}"."${name}" CASCADE;`);
   }
 
-  // Generate ALTER TABLE statements for column changes
-  // Handle column additions
   for (const added of diff.columns.added) {
     statements.push(generateAddColumnSQL(added.table, added.column, added.definition));
   }
 
-  // Handle column deletions
   for (const deleted of diff.columns.deleted) {
     statements.push(generateDropColumnSQL(deleted.table, deleted.column));
   }
 
-  // Handle column modifications
   for (const modified of diff.columns.modified) {
     const alterStatements = generateAlterColumnSQL(
       modified.table,
@@ -335,29 +326,25 @@ export async function generateMigrationSQL(
     statements.push(...alterStatements);
   }
 
-  // Generate DROP INDEX statements (including altered ones - drop old version)
+  // Altered indexes are dropped (old definition) then recreated (new definition).
   for (const index of diff.indexes.deleted) {
     statements.push(generateDropIndexSQL(index));
   }
 
-  // Drop old version of altered indexes
   for (const alteredIndex of diff.indexes.altered) {
     statements.push(generateDropIndexSQL(alteredIndex.old));
   }
 
-  // Generate CREATE INDEX statements (including altered ones - create new version)
   for (const index of diff.indexes.created) {
     statements.push(generateCreateIndexSQL(index));
   }
 
-  // Create new version of altered indexes
   for (const alteredIndex of diff.indexes.altered) {
     statements.push(generateCreateIndexSQL(alteredIndex.new));
   }
 
-  // Generate CREATE UNIQUE CONSTRAINT statements
   for (const constraint of diff.uniqueConstraints.created) {
-    // Skip if it's part of a new table (already handled)
+    // Skip constraints on tables just created above — CREATE TABLE already includes them.
     const isNewTable = diff.tables.created.some((tableName) => {
       const [schema, table] = tableName.includes(".")
         ? tableName.split(".")
@@ -375,14 +362,12 @@ export async function generateMigrationSQL(
     }
   }
 
-  // Generate DROP UNIQUE CONSTRAINT statements
   for (const constraint of diff.uniqueConstraints.deleted) {
     statements.push(generateDropUniqueConstraintSQL(constraint));
   }
 
-  // Generate CREATE CHECK CONSTRAINT statements
   for (const constraint of diff.checkConstraints.created) {
-    // Skip if it's part of a new table (already handled)
+    // Skip constraints on tables just created above — CREATE TABLE already includes them.
     const isNewTable = diff.tables.created.some((tableName) => {
       const [schema, table] = tableName.includes(".")
         ? tableName.split(".")
@@ -400,35 +385,28 @@ export async function generateMigrationSQL(
     }
   }
 
-  // Generate DROP CHECK CONSTRAINT statements
   for (const constraint of diff.checkConstraints.deleted) {
     statements.push(generateDropCheckConstraintSQL(constraint));
   }
 
-  // Handle foreign key deletions first (including altered ones)
   for (const fk of diff.foreignKeys.deleted) {
     statements.push(generateDropForeignKeySQL(fk));
   }
 
-  // Drop old version of altered foreign keys
   for (const alteredFK of diff.foreignKeys.altered) {
     statements.push(generateDropForeignKeySQL(alteredFK.old));
   }
 
-  // Handle foreign key creations (for existing tables)
   for (const fk of diff.foreignKeys.created) {
-    // Only add if it's not part of a new table (those were handled above)
-    // Check both with and without schema prefix
+    // Skip FKs on tables just created above (Phase 3 already added them).
     const tableFrom = fk.tableFrom || "";
     const schemaFrom = fk.schemaFrom || "public";
 
     const isNewTable = diff.tables.created.some((tableName) => {
-      // Compare table names, handling schema prefixes
       const [createdSchema, createdTable] = tableName.includes(".")
         ? tableName.split(".")
         : ["public", tableName];
 
-      // Compare using the actual schema and table from the FK
       return createdTable === tableFrom && createdSchema === schemaFrom;
     });
 
@@ -437,7 +415,6 @@ export async function generateMigrationSQL(
     }
   }
 
-  // Create new version of altered foreign keys
   for (const alteredFK of diff.foreignKeys.altered) {
     statements.push(generateCreateForeignKeySQL(alteredFK.new));
   }

--- a/plugins/plugin-sql/src/runtime-migrator/extension-manager.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/extension-manager.ts
@@ -1,3 +1,11 @@
+/**
+ * Installs Postgres extensions (e.g. `vector`, `fuzzystrmatch`) required by
+ * plugin schemas. Extension names are allowlist-validated before being
+ * interpolated as an SQL identifier, since `CREATE EXTENSION` doesn't support
+ * parameterized identifiers. A failed or unavailable extension only logs a
+ * warning — it doesn't abort the migration, since not every deployment target
+ * has every optional extension available.
+ */
 import { logger } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import type { DrizzleDB } from "./types";
@@ -8,8 +16,6 @@ export class ExtensionManager {
   async installRequiredExtensions(extensions: string[]): Promise<void> {
     for (const extension of extensions) {
       try {
-        // Validate extension name to prevent SQL injection
-        // Extension names should only contain alphanumeric characters, underscores, and hyphens
         if (!/^[a-zA-Z0-9_-]+$/.test(extension)) {
           logger.warn(
             { src: "plugin:sql", extension },
@@ -18,7 +24,6 @@ export class ExtensionManager {
           continue;
         }
 
-        // Use sql.identifier for safe escaping of SQL identifiers
         await this.db.execute(sql`CREATE EXTENSION IF NOT EXISTS ${sql.identifier(extension)}`);
         logger.debug({ src: "plugin:sql", extension }, "Extension installed");
       } catch (error) {
@@ -27,8 +32,6 @@ export class ExtensionManager {
           { src: "plugin:sql", extension, error: errorMessage },
           "Could not install extension"
         );
-        // Some extensions might not be available or already installed
-        // This shouldn't stop the migration process
       }
     }
   }

--- a/plugins/plugin-sql/src/runtime-migrator/index.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/index.ts
@@ -1,9 +1,9 @@
+/** Public entry point for the diff-based schema runtime migrator: re-exports the diff/snapshot/SQL-generation adapters, the migrator itself, its storage layers, and its types. */
 export {
   calculateDiff,
   hasDiffChanges,
   type SchemaDiff,
 } from "./drizzle-adapters/diff-calculator";
-// Drizzle adapter exports (if needed for extensions)
 export {
   createEmptySnapshot,
   generateSnapshot,
@@ -17,7 +17,6 @@ export {
 } from "./drizzle-adapters/sql-generator";
 export { RuntimeMigrator } from "./runtime-migrator";
 export { JournalStorage } from "./storage/journal-storage";
-// Storage exports (if needed for advanced usage)
 export { MigrationTracker } from "./storage/migration-tracker";
 export { SnapshotStorage } from "./storage/snapshot-storage";
 export * from "./types";

--- a/plugins/plugin-sql/src/runtime-migrator/runtime-migrator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/runtime-migrator.ts
@@ -1,3 +1,15 @@
+/**
+ * `RuntimeMigrator` drives the diff-based schema migration that runs at agent
+ * boot: snapshot the plugin's current Drizzle schema, diff it against the
+ * last recorded snapshot (or an introspected baseline if none was recorded),
+ * generate SQL, and apply it inside a transaction — no `drizzle-kit
+ * generate` step required. Per-plugin PostgreSQL advisory locks (skipped on
+ * PGlite/dev databases) prevent concurrent migration races across processes.
+ * Destructive changes (dropped tables/columns, unsafe type changes) are
+ * blocked unless `ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS=true` or `options.force`
+ * is set. State is persisted via `MigrationTracker` (hash + timestamp),
+ * `JournalStorage` (Drizzle-compatible journal), and `SnapshotStorage`.
+ */
 import { logger } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { getRow } from "../types";
@@ -38,12 +50,10 @@ export class RuntimeMigrator {
    * All other plugins should use namespaced schemas
    */
   private getExpectedSchemaName(pluginName: string): string {
-    // Core plugin uses public schema
     if (pluginName === "@elizaos/plugin-sql") {
       return "public";
     }
 
-    // Use the schema transformer's logic for consistency
     return deriveSchemaName(pluginName);
   }
 
@@ -53,7 +63,6 @@ export class RuntimeMigrator {
   private async ensureSchemasExist(snapshot: SchemaSnapshot): Promise<void> {
     const schemasToCreate = new Set<string>();
 
-    // Collect all schemas from tables
     for (const table of Object.values(snapshot.tables)) {
       const schemaName = table.schema || "public";
       if (schemaName !== "public") {
@@ -61,14 +70,12 @@ export class RuntimeMigrator {
       }
     }
 
-    // Also add schemas from the snapshot's schemas object
     for (const schema of Object.keys(snapshot.schemas || {})) {
       if (schema !== "public") {
         schemasToCreate.add(schema);
       }
     }
 
-    // Create all non-public schemas
     for (const schemaName of schemasToCreate) {
       logger.debug({ src: "plugin:sql", schemaName }, "Ensuring schema exists");
       await this.db.execute(sql.raw(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`));
@@ -85,7 +92,6 @@ export class RuntimeMigrator {
     for (const table of Object.values(snapshot.tables)) {
       const actualSchema = table.schema || "public";
 
-      // Warn if non-core plugin is using public schema
       if (!isCorePLugin && actualSchema === "public") {
         logger.warn(
           {
@@ -98,7 +104,6 @@ export class RuntimeMigrator {
         );
       }
 
-      // Warn if core plugin is not using public schema
       if (isCorePLugin && actualSchema !== "public") {
         logger.warn(
           {
@@ -296,7 +301,6 @@ export class RuntimeMigrator {
   ): Promise<void> {
     const lockId = this.getAdvisoryLockId(pluginName);
 
-    // Validate lockId is within PostgreSQL bigint range
     if (!this.validateBigInt(lockId)) {
       throw new Error(`Invalid advisory lock ID generated for plugin ${pluginName}`);
     }
@@ -306,11 +310,10 @@ export class RuntimeMigrator {
     try {
       logger.info({ src: "plugin:sql", pluginName }, "Starting migration for plugin");
 
-      // Ensure migration tables exist
       await this.initialize();
 
-      // Only use advisory locks for real PostgreSQL databases
-      // Skip for PGLite or development databases
+      // Advisory locks only apply to real PostgreSQL — PGlite and other dev
+      // databases don't need cross-process coordination.
       const postgresUrl = process.env.POSTGRES_URL || process.env.DATABASE_URL || "";
       const isRealPostgres = this.isRealPostgresDatabase(postgresUrl);
 
@@ -318,8 +321,6 @@ export class RuntimeMigrator {
         try {
           logger.debug({ src: "plugin:sql", pluginName }, "Using PostgreSQL advisory locks");
 
-          // Convert bigint to string for SQL query
-          // The sql tagged template will properly parameterize this value
           const lockIdStr = lockId.toString();
 
           const lockResult = await this.db.execute(
@@ -337,7 +338,6 @@ export class RuntimeMigrator {
               "Migration already in progress, waiting for lock"
             );
 
-            // Wait for the lock (blocking call)
             await this.db.execute(sql`SELECT pg_advisory_lock(CAST(${lockIdStr} AS bigint))`);
             lockAcquired = true;
 
@@ -349,8 +349,8 @@ export class RuntimeMigrator {
             );
           }
         } catch (lockError) {
-          // If advisory locks fail, log but continue
-          // This might happen if the PostgreSQL version doesn't support advisory locks
+          // Some PostgreSQL versions/configurations don't support advisory
+          // locks — log and continue rather than blocking the migration.
           logger.warn(
             {
               src: "plugin:sql",
@@ -362,36 +362,29 @@ export class RuntimeMigrator {
           lockAcquired = false;
         }
       } else {
-        // For PGLite or other development databases, skip advisory locks
         logger.debug(
           { src: "plugin:sql" },
           "Development database detected, skipping advisory locks"
         );
       }
 
-      // Install required extensions
-      // pgcrypto is only needed for real PostgreSQL (PGLite uses native gen_random_uuid)
+      // pgcrypto is only needed for real PostgreSQL — PGlite has native gen_random_uuid.
       const extensions = isRealPostgres
         ? ["vector", "fuzzystrmatch", "pgcrypto"]
         : ["vector", "fuzzystrmatch"];
       await this.extensionManager.installRequiredExtensions(extensions);
 
-      // Generate current snapshot from schema
       const currentSnapshot = await generateSnapshot(schema);
 
-      // Ensure all schemas referenced in the snapshot exist
       await this.ensureSchemasExist(currentSnapshot);
 
-      // Validate schema usage and warn about potential issues
       this.validateSchemaUsage(pluginName, currentSnapshot);
 
       const currentHash = hashSnapshot(currentSnapshot);
 
-      // Check if we've already run this exact migration
-      // This check happens AFTER acquiring the lock to handle concurrent scenarios
-      // This is critical: if we had to wait for the lock (lockAcquired was initially false),
-      // another process may have completed the migration while we were waiting
-      // We MUST check regardless of whether lastMigration existed before
+      // Must re-check for an already-completed migration after acquiring the
+      // lock: if this call had to wait for the lock, another process may have
+      // already run this exact migration while we were waiting.
       const lastMigration = await this.migrationTracker.getLastMigration(pluginName);
       if (lastMigration && lastMigration.hash === currentHash) {
         logger.info(
@@ -401,10 +394,11 @@ export class RuntimeMigrator {
         return;
       }
 
-      // Load previous snapshot
       let previousSnapshot = await this.snapshotStorage.getLatestSnapshot(pluginName);
 
-      // If no snapshot exists but tables exist in database, introspect them
+      // No recorded snapshot but the plugin's tables already exist in the
+      // database (e.g. pre-migrator install): introspect them to establish
+      // a baseline instead of treating every existing table as newly created.
       if (!previousSnapshot && Object.keys(currentSnapshot.tables).length > 0) {
         const hasExistingTables = await this.introspector.hasExistingTables(pluginName);
 
@@ -414,16 +408,14 @@ export class RuntimeMigrator {
             "No snapshot found but tables exist in database, introspecting"
           );
 
-          // Determine the schema name for introspection
           const schemaName = this.getExpectedSchemaName(pluginName);
 
-          // Introspect the current database state
           const introspectedSnapshot = await this.introspector.introspectSchema(schemaName);
 
-          // IMPORTANT: Filter the introspected snapshot to only include tables that are
-          // defined in the current schema. This prevents tables from other plugins
-          // (e.g., gamification tables in 'public' schema) from being marked as "orphans"
-          // and scheduled for deletion.
+          // Filter to only tables defined in the current plugin's schema —
+          // otherwise tables belonging to other plugins sharing the same
+          // Postgres schema (e.g. other plugins in 'public') would be
+          // classified as orphans and scheduled for deletion.
           const expectedTableNames = new Set<string>();
           for (const tableKey of Object.keys(currentSnapshot.tables)) {
             const tableData = currentSnapshot.tables[tableKey];
@@ -431,7 +423,6 @@ export class RuntimeMigrator {
             expectedTableNames.add(tableName);
           }
 
-          // Filter introspected tables to only those in the current schema
           const filteredTables: Record<string, SchemaTable> = {};
           for (const tableKey of Object.keys(introspectedSnapshot.tables)) {
             const tableData = introspectedSnapshot.tables[tableKey];
@@ -446,18 +437,14 @@ export class RuntimeMigrator {
             }
           }
 
-          // Use filtered snapshot
           const filteredSnapshot = {
             ...introspectedSnapshot,
             tables: filteredTables,
           };
 
-          // Only use the introspected snapshot if it has tables
           if (Object.keys(filteredSnapshot.tables).length > 0) {
-            // Save this as the initial snapshot (idx: 0)
             await this.snapshotStorage.saveSnapshot(pluginName, 0, filteredSnapshot);
 
-            // Update journal to record this initial state
             await this.journalStorage.updateJournal(
               pluginName,
               0,
@@ -465,7 +452,6 @@ export class RuntimeMigrator {
               true
             );
 
-            // Record this as a migration
             const filteredHash = hashSnapshot(filteredSnapshot);
             await this.migrationTracker.recordMigration(pluginName, filteredHash, Date.now());
 
@@ -474,18 +460,15 @@ export class RuntimeMigrator {
               "Created initial snapshot from existing database"
             );
 
-            // Set this as the previous snapshot for comparison
             previousSnapshot = filteredSnapshot;
           }
         }
       }
 
-      // Check if there are actual changes
       if (!hasChanges(previousSnapshot, currentSnapshot)) {
         logger.info({ src: "plugin:sql", pluginName }, "No schema changes");
 
-        // For empty schemas, we still want to record the migration
-        // to ensure idempotency and consistency
+        // Record even an empty schema so re-runs stay idempotent.
         if (!previousSnapshot && Object.keys(currentSnapshot.tables).length === 0) {
           logger.info({ src: "plugin:sql", pluginName }, "Recording empty schema");
           await this.migrationTracker.recordMigration(pluginName, currentHash, Date.now());
@@ -498,30 +481,25 @@ export class RuntimeMigrator {
         return;
       }
 
-      // Calculate diff
       const diff = await calculateDiff(previousSnapshot, currentSnapshot);
 
-      // Check if diff has changes
       if (!hasDiffChanges(diff)) {
         logger.info({ src: "plugin:sql", pluginName }, "No actionable changes");
         return;
       }
 
-      // Check for potential data loss
       const dataLossCheck = checkForDataLoss(diff);
 
       if (dataLossCheck.hasDataLoss) {
         const isProduction = process.env.NODE_ENV === "production";
 
-        // Determine if destructive migrations are allowed
-        // Priority: explicit options > environment variable
+        // Explicit options take priority over the environment variable.
         const allowDestructive =
           options.force ||
           options.allowDataLoss ||
           process.env.ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS === "true";
 
         if (!allowDestructive) {
-          // Block the migration and provide clear instructions
           logger.error(
             {
               src: "plugin:sql",
@@ -539,7 +517,6 @@ export class RuntimeMigrator {
           throw new Error(errorMessage);
         }
 
-        // Log that we're proceeding with destructive operations
         if (dataLossCheck.requiresConfirmation) {
           logger.warn(
             { src: "plugin:sql", pluginName, warnings: dataLossCheck.warnings },
@@ -548,7 +525,6 @@ export class RuntimeMigrator {
         }
       }
 
-      // Generate SQL statements
       const sqlStatements = await generateMigrationSQL(previousSnapshot, currentSnapshot, diff);
 
       if (sqlStatements.length === 0) {
@@ -556,7 +532,6 @@ export class RuntimeMigrator {
         return;
       }
 
-      // Log what we're about to do
       logger.info(
         { src: "plugin:sql", pluginName, statementCount: sqlStatements.length },
         "Executing SQL statements"
@@ -570,7 +545,6 @@ export class RuntimeMigrator {
         });
       }
 
-      // Dry run mode - just log what would happen
       if (options.dryRun) {
         logger.info(
           { src: "plugin:sql", pluginName, statements: sqlStatements },
@@ -579,12 +553,10 @@ export class RuntimeMigrator {
         return;
       }
 
-      // Execute migration in transaction
       await this.executeMigration(pluginName, currentSnapshot, currentHash, sqlStatements);
 
       logger.info({ src: "plugin:sql", pluginName }, "Migration completed successfully");
 
-      // Return a success result
       return;
     } catch (error) {
       logger.error(
@@ -597,13 +569,12 @@ export class RuntimeMigrator {
       );
       throw error;
     } finally {
-      // Always release the advisory lock if we acquired it (only for real PostgreSQL)
+      // Release the advisory lock if this call acquired one (real PostgreSQL only).
       const postgresUrl = process.env.POSTGRES_URL || process.env.DATABASE_URL || "";
       const isRealPostgres = this.isRealPostgresDatabase(postgresUrl);
 
       if (lockAcquired && isRealPostgres) {
         try {
-          // Convert bigint to string for SQL query (same as when acquiring)
           const lockIdStr = lockId.toString();
           await this.db.execute(sql`SELECT pg_advisory_unlock(CAST(${lockIdStr} AS bigint))`);
           logger.debug({ src: "plugin:sql", pluginName }, "Advisory lock released");
@@ -633,40 +604,27 @@ export class RuntimeMigrator {
     let transactionStarted = false;
 
     try {
-      // Start manual transaction
       await this.db.execute(sql`BEGIN`);
       transactionStarted = true;
 
-      // Execute all SQL statements
       for (const stmt of sqlStatements) {
         logger.debug({ src: "plugin:sql", statement: stmt }, "Executing SQL statement");
         await this.db.execute(sql.raw(stmt));
       }
 
-      // Get next index for journal
       const idx = await this.journalStorage.getNextIdx(pluginName);
 
-      // Record migration
       await this.migrationTracker.recordMigration(pluginName, hash, Date.now());
 
-      // Update journal
       const tag = this.generateMigrationTag(idx, pluginName);
-      await this.journalStorage.updateJournal(
-        pluginName,
-        idx,
-        tag,
-        true // breakpoints
-      );
+      await this.journalStorage.updateJournal(pluginName, idx, tag, /* breakpoints */ true);
 
-      // Store snapshot
       await this.snapshotStorage.saveSnapshot(pluginName, idx, snapshot);
 
-      // Commit the transaction
       await this.db.execute(sql`COMMIT`);
 
       logger.info({ src: "plugin:sql", pluginName, tag }, "Recorded migration");
     } catch (error) {
-      // Rollback on error if transaction was started
       if (transactionStarted) {
         try {
           await this.db.execute(sql`ROLLBACK`);
@@ -695,7 +653,7 @@ export class RuntimeMigrator {
    * Generate migration tag (like 0000_jazzy_shard)
    */
   private generateMigrationTag(idx: number, pluginName: string): string {
-    // Generate a simple tag - in production, use Drizzle's word generation
+    // Simple index+timestamp tag; unlike drizzle-kit, this doesn't use word generation.
     const prefix = idx.toString().padStart(4, "0");
     const timestamp = Date.now().toString(36);
     return `${prefix}_${pluginName}_${timestamp}`;
@@ -754,22 +712,17 @@ export class RuntimeMigrator {
     try {
       logger.info({ src: "plugin:sql", pluginName }, "Checking migration");
 
-      // Generate current snapshot from schema
       const currentSnapshot = await generateSnapshot(schema);
 
-      // Load previous snapshot
       const previousSnapshot = await this.snapshotStorage.getLatestSnapshot(pluginName);
 
-      // Check if there are changes
       if (!hasChanges(previousSnapshot, currentSnapshot)) {
         logger.info({ src: "plugin:sql", pluginName }, "No changes detected");
         return null;
       }
 
-      // Calculate diff
       const diff = await calculateDiff(previousSnapshot, currentSnapshot);
 
-      // Check for data loss
       const dataLossCheck = checkForDataLoss(diff);
 
       if (dataLossCheck.hasDataLoss) {

--- a/plugins/plugin-sql/src/runtime-migrator/schema-transformer.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/schema-transformer.ts
@@ -1,3 +1,13 @@
+/**
+ * Derives the per-plugin PostgreSQL schema name a non-core plugin's tables
+ * should live in (so plugins don't collide in `public`), and provides
+ * `createPluginSchema` for plugins to declare their tables namespaced from
+ * the start. `transformPluginSchema` only warns about tables that aren't
+ * already namespaced — it can't safely rewrite an existing table's schema
+ * without reconstructing all its column/constraint definitions, so plugins
+ * are expected to use `createPluginSchema` / `pgSchema` directly instead of
+ * being auto-migrated into a namespace.
+ */
 import { logger } from "@elizaos/core";
 import { getTableConfig, type PgTable, pgSchema } from "drizzle-orm/pg-core";
 
@@ -17,15 +27,12 @@ interface PgSchemaObject {
  * Other plugins get their tables wrapped in a namespaced schema
  */
 export function transformPluginSchema(pluginName: string, schema: DrizzleSchema): DrizzleSchema {
-  // Core plugin uses public schema - no transformation needed
   if (pluginName === "@elizaos/plugin-sql") {
     return schema;
   }
 
-  // Derive schema name from plugin name
   const schemaName = deriveSchemaName(pluginName);
 
-  // If schema is already using pgSchema, return as-is
   if (isAlreadyNamespaced(schema, schemaName)) {
     logger.debug(
       { src: "plugin:sql", pluginName, schemaName },
@@ -36,18 +43,15 @@ export function transformPluginSchema(pluginName: string, schema: DrizzleSchema)
 
   logger.info({ src: "plugin:sql", pluginName, schemaName }, "Transforming plugin to use schema");
 
-  // Transform the schema object
   const transformed: DrizzleSchema = {};
 
   for (const [key, value] of Object.entries(schema)) {
     if (isPgTable(value)) {
-      // Get the table configuration
       const config = getTableConfig(value as PgTable);
 
-      // If the table doesn't have a schema or is in public, warn about it
+      // Can't rewrite an existing table's schema without reconstructing all
+      // its column/constraint definitions, so this only warns.
       if (!config.schema || config.schema === "public") {
-        // Can't easily transform existing tables to different schema
-        // (would require reconstructing all column definitions, constraints, etc.)
         logger.warn(
           {
             src: "plugin:sql",
@@ -59,21 +63,16 @@ export function transformPluginSchema(pluginName: string, schema: DrizzleSchema)
         );
         transformed[key] = value;
       } else {
-        // Table already has a schema, keep it as-is
         transformed[key] = value;
       }
     } else if (typeof value === "object" && value !== null) {
-      // Check if this is a schema object (created with pgSchema)
       const obj = value as PgSchemaObject;
       if (obj._schema && obj.table) {
-        // This is already a pgSchema object, keep it
         transformed[key] = value;
       } else {
-        // Regular object, keep as-is
         transformed[key] = value;
       }
     } else {
-      // Not a table, keep as-is
       transformed[key] = value;
     }
   }
@@ -85,28 +84,25 @@ export function transformPluginSchema(pluginName: string, schema: DrizzleSchema)
  * Derive a valid PostgreSQL schema name from a plugin name
  */
 export function deriveSchemaName(pluginName: string): string {
-  // Remove common prefixes and convert to lowercase with underscores
   let schemaName = pluginName
-    .replace(/^@[^/]+\//, "") // Remove npm scope like @elizaos/
-    .replace(/^plugin-/, "") // Remove plugin- prefix
+    .replace(/^@[^/]+\//, "") // strip npm scope, e.g. @elizaos/
+    .replace(/^plugin-/, "") // strip plugin- prefix
     .toLowerCase();
 
-  // Replace non-alphanumeric characters with underscores (avoid polynomial regex)
   schemaName = normalizeSchemaName(schemaName);
 
-  // Ensure schema name is valid (not empty, not a reserved word)
+  // Reject empty or reserved names, falling back to a safe derived name.
   const reserved = ["public", "pg_catalog", "information_schema", "migrations"];
   if (!schemaName || reserved.includes(schemaName)) {
-    // Fallback to using the full plugin name with safe characters
     schemaName = `plugin_${normalizeSchemaName(pluginName.toLowerCase())}`;
   }
 
-  // Ensure it starts with a letter (PostgreSQL requirement)
+  // PostgreSQL identifiers must start with a letter.
   if (!/^[a-z]/.test(schemaName)) {
     schemaName = `p_${schemaName}`;
   }
 
-  // Truncate if too long (PostgreSQL identifier limit is 63 chars)
+  // PostgreSQL identifier length limit is 63 characters.
   if (schemaName.length > 63) {
     schemaName = schemaName.substring(0, 63);
   }
@@ -115,8 +111,9 @@ export function deriveSchemaName(pluginName: string): string {
 }
 
 /**
- * Normalize a string to be a valid PostgreSQL identifier
- * Avoids polynomial regex by using string manipulation instead
+ * Normalize a string to be a valid PostgreSQL identifier.
+ * Uses plain string manipulation (not a single regex) to avoid a
+ * catastrophic-backtracking pattern on adversarial input.
  */
 function normalizeSchemaName(input: string): string {
   const chars: string[] = [];
@@ -129,17 +126,13 @@ function normalizeSchemaName(input: string): string {
       chars.push(char);
       prevWasUnderscore = false;
     } else if (!prevWasUnderscore) {
-      // Only add underscore if previous char wasn't already an underscore
       chars.push("_");
       prevWasUnderscore = true;
     }
-    // Skip consecutive non-alphanumeric characters
   }
 
-  // Remove leading and trailing underscores
   const result = chars.join("");
 
-  // Trim underscores from start and end efficiently
   let start = 0;
   let end = result.length;
 
@@ -162,8 +155,8 @@ function isPgTable(value: unknown): value is PgTable {
     return false;
   }
 
-  // Check for table-like properties
-  // This is a heuristic since we can't use instanceof across module boundaries
+  // instanceof doesn't work across module boundaries, so probe for the
+  // table config shape instead.
   try {
     const config = getTableConfig(value as PgTable);
     return config && typeof config.name === "string";

--- a/plugins/plugin-sql/src/runtime-migrator/storage/journal-storage.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/journal-storage.ts
@@ -1,3 +1,9 @@
+/**
+ * Persists the per-plugin Drizzle-compatible migration journal (a JSONB
+ * list of `JournalEntry` records) into the `migrations._journal` table, one
+ * row per plugin. `RuntimeMigrator` calls `updateJournal` after each applied
+ * migration to append an entry with the next index.
+ */
 import { sql } from "drizzle-orm";
 import { getRow } from "../../types";
 import type { DrizzleDB, Journal, JournalEntry } from "../types";
@@ -45,22 +51,18 @@ export class JournalStorage {
   }
 
   async addEntry(pluginName: string, entry: JournalEntry): Promise<void> {
-    // First, get the current journal
     let journal = await this.loadJournal(pluginName);
 
-    // If no journal exists, create a new one
     if (!journal) {
       journal = {
-        version: "7", // Latest Drizzle version
+        version: "7", // Latest Drizzle journal version
         dialect: "postgresql",
         entries: [],
       };
     }
 
-    // Add the new entry
     journal.entries.push(entry);
 
-    // Save the updated journal
     await this.saveJournal(pluginName, journal);
   }
 

--- a/plugins/plugin-sql/src/runtime-migrator/storage/migration-tracker.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/migration-tracker.ts
@@ -1,3 +1,10 @@
+/**
+ * Owns the `migrations` Postgres schema and its three bookkeeping tables —
+ * `_migrations` (per-plugin hash + timestamp of the last applied migration,
+ * mirroring Drizzle's `__drizzle_migrations`), `_journal`, and `_snapshots`
+ * — replacing the on-disk `_journal.json` / snapshot-file approach with
+ * database-backed state so migration history survives across environments.
+ */
 import { sql } from "drizzle-orm";
 import { getRow } from "../../types";
 import type { DrizzleDB } from "../types";
@@ -10,10 +17,8 @@ export class MigrationTracker {
   }
 
   async ensureTables(): Promise<void> {
-    // Ensure schema exists
     await this.ensureSchema();
 
-    // Create migrations table (like Drizzle's __drizzle_migrations)
     await this.db.execute(sql`
       CREATE TABLE IF NOT EXISTS migrations._migrations (
         id SERIAL PRIMARY KEY,
@@ -23,7 +28,6 @@ export class MigrationTracker {
       )
     `);
 
-    // Create journal table (replaces _journal.json)
     await this.db.execute(sql`
       CREATE TABLE IF NOT EXISTS migrations._journal (
         plugin_name TEXT PRIMARY KEY,
@@ -33,7 +37,6 @@ export class MigrationTracker {
       )
     `);
 
-    // Create snapshots table (replaces snapshot JSON files)
     await this.db.execute(sql`
       CREATE TABLE IF NOT EXISTS migrations._snapshots (
         id SERIAL PRIMARY KEY,

--- a/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/storage/snapshot-storage.ts
@@ -1,3 +1,4 @@
+/** CRUD over the `migrations._snapshots` table: one JSONB `SchemaSnapshot` row per (plugin, migration index), used by `RuntimeMigrator` to diff against the previously applied schema. */
 import { sql } from "drizzle-orm";
 import type { DrizzleDB, SchemaSnapshot } from "../types";
 

--- a/plugins/plugin-sql/src/runtime-migrator/types.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared types for the runtime migrator: the Drizzle-compatible journal and
+ * migration-metadata shapes, the `SchemaSnapshot` schema-representation
+ * tree (tables/columns/indexes/constraints/enums) used for diffing, the raw
+ * `pg_catalog`/`information_schema` row shapes returned by introspection
+ * queries, and the public `RuntimeMigrationOptions` for `RuntimeMigrator.migrate()`.
+ */
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -24,7 +31,6 @@ export interface MigrationMeta {
   bps: boolean;
 }
 
-// Schema column definition
 export interface SchemaColumn {
   name: string;
   type: string;
@@ -36,7 +42,6 @@ export interface SchemaColumn {
   uniqueType?: string;
 }
 
-// Index column definition
 export interface IndexColumn {
   expression: string;
   isExpression: boolean;
@@ -44,7 +49,6 @@ export interface IndexColumn {
   nulls?: string;
 }
 
-// Index definition
 export interface SchemaIndex {
   name: string;
   columns: IndexColumn[];
@@ -54,7 +58,6 @@ export interface SchemaIndex {
   concurrently?: boolean;
 }
 
-// Foreign key definition
 export interface SchemaForeignKey {
   name: string;
   tableFrom: string;
@@ -67,26 +70,22 @@ export interface SchemaForeignKey {
   onUpdate?: string;
 }
 
-// Primary key definition
 export interface SchemaPrimaryKey {
   name: string;
   columns: string[];
 }
 
-// Unique constraint definition
 export interface SchemaUniqueConstraint {
   name: string;
   columns: string[];
   nullsNotDistinct?: boolean;
 }
 
-// Check constraint definition
 export interface SchemaCheckConstraint {
   name: string;
   value: string;
 }
 
-// Table definition
 export interface SchemaTable {
   name: string;
   schema: string;
@@ -98,14 +97,12 @@ export interface SchemaTable {
   checkConstraints: Record<string, SchemaCheckConstraint>;
 }
 
-// Enum definition
 export interface SchemaEnum {
   name: string;
   schema: string;
   values: string[];
 }
 
-// Meta information
 export interface SchemaMeta {
   schemas: Record<string, string>;
   tables: Record<string, string>;
@@ -122,7 +119,7 @@ export interface SchemaSnapshot {
   internal?: Record<string, unknown>;
 }
 
-// Database introspection row types
+// Raw row shapes returned by DatabaseIntrospector's pg_catalog/information_schema queries.
 export interface TableInfoRow {
   table_schema: string;
   table_name: string;

--- a/plugins/plugin-sql/src/schema/agent.ts
+++ b/plugins/plugin-sql/src/schema/agent.ts
@@ -1,12 +1,12 @@
+/**
+ * The `agents` table: one row per agent, storing its Character definition
+ * (bio, examples, topics, adjectives, knowledge refs, plugins list, settings,
+ * style) alongside runtime flags (`enabled`, `server_id` for RLS isolation).
+ */
 import type { CharacterSettings, MessageExample } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { boolean, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
-/**
- * Represents a table for storing agent data.
- *
- * @type {Table}
- */
 export const agentTable = pgTable("agents", {
   id: uuid("id").primaryKey().defaultRandom(),
   enabled: boolean("enabled").default(true).notNull(),
@@ -15,7 +15,6 @@ export const agentTable = pgTable("agents", {
 
   updatedAt: timestamp("updated_at", { withTimezone: true }).default(sql`now()`).notNull(),
 
-  // Character
   name: text("name").notNull(),
   username: text("username"),
   system: text("system").default(""),

--- a/plugins/plugin-sql/src/schema/approvalRequests.ts
+++ b/plugins/plugin-sql/src/schema/approvalRequests.ts
@@ -1,7 +1,3 @@
-import { sql } from "drizzle-orm";
-import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
-import { agentTable } from "./agent";
-
 /**
  * Persistent backing store for the LifeOps human-in-the-loop approval queue.
  *
@@ -17,6 +13,10 @@ import { agentTable } from "./agent";
  * layer is the single source of truth for the state machine and the closed
  * action/channel enums (Commandment 7).
  */
+import { sql } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { agentTable } from "./agent";
+
 export const approvalRequestTable = pgTable(
   "approval_requests",
   {

--- a/plugins/plugin-sql/src/schema/authAuditEvent.ts
+++ b/plugins/plugin-sql/src/schema/authAuditEvent.ts
@@ -1,5 +1,3 @@
-import { bigint, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
-
 /**
  * Append-only audit row for every sensitive auth action.
  *
@@ -7,6 +5,8 @@ import { bigint, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
  * Token-shaped values in `metadata` MUST be redacted before insert by the
  * caller.
  */
+import { bigint, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+
 export const authAuditEventTable = pgTable(
   "auth_audit_events",
   {

--- a/plugins/plugin-sql/src/schema/authBootstrapJti.ts
+++ b/plugins/plugin-sql/src/schema/authBootstrapJti.ts
@@ -1,5 +1,3 @@
-import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
-
 /**
  * Replay-defence set for bootstrap-token `jti` claims. A row exists for every
  * bootstrap token successfully verified on this instance; subsequent
@@ -8,6 +6,8 @@ import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
  * Rows are kept until natural `exp` of the original token plus a buffer; the
  * cleanup job lives in the auth-store.
  */
+import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
+
 export const authBootstrapJtiSeenTable = pgTable(
   "auth_bootstrap_jti_seen",
   {

--- a/plugins/plugin-sql/src/schema/authIdentity.ts
+++ b/plugins/plugin-sql/src/schema/authIdentity.ts
@@ -1,6 +1,3 @@
-import { sql } from "drizzle-orm";
-import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
-
 /**
  * Auth identity row. One per real user / machine actor on this Eliza instance.
  *
@@ -10,6 +7,9 @@ import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
  * (with possible owner-bindings extending login methods); machines have
  * neither and are authenticated by the bearer token bound to their session.
  */
+import { sql } from "drizzle-orm";
+import { bigint, index, pgTable, text } from "drizzle-orm/pg-core";
+
 export const authIdentityTable = pgTable(
   "auth_identities",
   {

--- a/plugins/plugin-sql/src/schema/authOwnerBinding.ts
+++ b/plugins/plugin-sql/src/schema/authOwnerBinding.ts
@@ -1,6 +1,3 @@
-import { bigint, foreignKey, index, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core";
-import { authIdentityTable } from "./authIdentity";
-
 /**
  * Connector-owner binding. Lets an external connector account (Discord,
  * Telegram, WeChat, Matrix) prove ownership of a local Eliza identity.
@@ -9,6 +6,9 @@ import { authIdentityTable } from "./authIdentity";
  * Discord account can own multiple Eliza instances (one binding per
  * (connector, external) pair *per instance*) without cross-talk.
  */
+import { bigint, foreignKey, index, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core";
+import { authIdentityTable } from "./authIdentity";
+
 export const authOwnerBindingTable = pgTable(
   "auth_owner_bindings",
   {

--- a/plugins/plugin-sql/src/schema/authOwnerLoginToken.ts
+++ b/plugins/plugin-sql/src/schema/authOwnerLoginToken.ts
@@ -1,7 +1,3 @@
-import { bigint, foreignKey, index, pgTable, text } from "drizzle-orm/pg-core";
-import { authIdentityTable } from "./authIdentity";
-import { authOwnerBindingTable } from "./authOwnerBinding";
-
 /**
  * Single-use DM-link login tokens for the connector-owner convenience flow.
  *
@@ -15,6 +11,10 @@ import { authOwnerBindingTable } from "./authOwnerBinding";
  * `consumed_at` and the row is preserved for audit. Rows older than
  * `expires_at + 24h` are eligible for cleanup.
  */
+import { bigint, foreignKey, index, pgTable, text } from "drizzle-orm/pg-core";
+import { authIdentityTable } from "./authIdentity";
+import { authOwnerBindingTable } from "./authOwnerBinding";
+
 export const authOwnerLoginTokenTable = pgTable(
   "auth_owner_login_tokens",
   {

--- a/plugins/plugin-sql/src/schema/authSession.ts
+++ b/plugins/plugin-sql/src/schema/authSession.ts
@@ -1,6 +1,3 @@
-import { bigint, boolean, foreignKey, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
-import { authIdentityTable } from "./authIdentity";
-
 /**
  * Active authenticated session.
  *
@@ -12,6 +9,9 @@ import { authIdentityTable } from "./authIdentity";
  * Machine sessions list explicit scopes; browser sessions get an empty list
  * which the auth layer treats as "all scopes".
  */
+import { bigint, boolean, foreignKey, index, jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import { authIdentityTable } from "./authIdentity";
+
 export const authSessionTable = pgTable(
   "auth_sessions",
   {

--- a/plugins/plugin-sql/src/schema/cache.ts
+++ b/plugins/plugin-sql/src/schema/cache.ts
@@ -1,12 +1,16 @@
+/**
+ * Generic key/value cache table shared across plugins and runtime subsystems,
+ * scoped per agent. Values are arbitrary JSON; `expiresAt` is optional and
+ * left to callers to enforce (no background eviction job here).
+ *
+ * Primary key is the composite `(key, agentId)`, so the same key string can
+ * coexist across agents without collision. Rows cascade-delete when the
+ * owning agent is removed.
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, primaryKey, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 
-/**
- * Represents a PostgreSQL table for caching data.
- *
- * @type {pgTable}
- */
 export const cacheTable = pgTable(
   "cache",
   {

--- a/plugins/plugin-sql/src/schema/channel.ts
+++ b/plugins/plugin-sql/src/schema/channel.ts
@@ -1,3 +1,11 @@
+/**
+ * A conversation channel (DM, group, or connector-sourced room) belonging to
+ * a message server. `type` holds the `ChannelType` enum as text; `sourceType`
+ * / `sourceId` track the originating connector when the channel is mirrored
+ * from an external platform. Cascade-deletes when its message server is
+ * removed. When RLS is enabled, `applyRls` adds a `server_id` column at
+ * migration time for per-server row isolation (PostgreSQL only).
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { messageServerTable } from "./messageServer";
@@ -13,7 +21,6 @@ export const channelTable = pgTable("channels", {
   sourceId: text("source_id"),
   topic: text("topic"),
   metadata: jsonb("metadata"),
-  // server_id is added dynamically by RLS setup
   createdAt: timestamp("created_at", { mode: "date" }).default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: timestamp("updated_at", { mode: "date" }).default(sql`CURRENT_TIMESTAMP`).notNull(),
 });

--- a/plugins/plugin-sql/src/schema/channelParticipant.ts
+++ b/plugins/plugin-sql/src/schema/channelParticipant.ts
@@ -1,3 +1,8 @@
+/**
+ * Join table linking entities (agents or central users) to the channels they
+ * participate in. Composite primary key `(channelId, entityId)` prevents
+ * duplicate membership rows; cascade-deletes when the channel is removed.
+ */
 import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 import { channelTable } from "./channel";
 

--- a/plugins/plugin-sql/src/schema/component.ts
+++ b/plugins/plugin-sql/src/schema/component.ts
@@ -1,3 +1,10 @@
+/**
+ * Attaches structured, typed data (`type` + freeform `data` JSON) to an
+ * entity within a room/world context — e.g. profile fields, connector-
+ * specific metadata, or other per-entity extensions that don't belong on the
+ * core entity row. Cascade-deletes with its owning entity, agent, or room;
+ * `worldId` and `sourceEntityId` are optional and also cascade when set.
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
@@ -5,13 +12,9 @@ import { entityTable } from "./entity";
 import { roomTable } from "./room";
 import { worldTable } from "./world";
 
-/**
- * Represents a component table in the database.
- */
 export const componentTable = pgTable("components", {
   id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
 
-  // Foreign keys
   entityId: uuid("entity_id")
     .references(() => entityTable.id, { onDelete: "cascade" })
     .notNull(),
@@ -28,10 +31,8 @@ export const componentTable = pgTable("components", {
     onDelete: "cascade",
   }),
 
-  // Data
   type: text("type").notNull(),
   data: jsonb("data").default(sql`'{}'::jsonb`),
 
-  // Timestamps
   createdAt: timestamp("created_at").default(sql`now()`).notNull(),
 });

--- a/plugins/plugin-sql/src/schema/connectorAccounts.ts
+++ b/plugins/plugin-sql/src/schema/connectorAccounts.ts
@@ -1,3 +1,20 @@
+/**
+ * Four related tables for external connector (Discord, Telegram, X, etc.)
+ * account management, all scoped per agent and cascade-deleting with it:
+ *
+ * - `connectorAccountsTable` — one row per connected external account,
+ *   uniquely keyed on `(agentId, provider, accountKey)` and
+ *   `(agentId, provider, externalId)` while `deletedAt` is null (soft-delete
+ *   allows re-connecting the same account later).
+ * - `connectorAccountCredentialsTable` — credentials for an account, stored
+ *   only as a `vaultRef` pointer into `@elizaos/vault` or an external secret
+ *   manager; never the raw secret. Unique per `(accountId, credentialType)`.
+ * - `connectorAccountAuditEventsTable` — append-only audit trail of actions
+ *   taken against an account; survives account deletion (`onDelete: "set null"`).
+ * - `oauthFlowsTable` — short-lived, single-use OAuth state tracking keyed by
+ *   a composite `(agentId, provider, stateHash)` primary key; `stateHash` and
+ *   `codeVerifierRef` store hashes/vault pointers, never plaintext secrets.
+ */
 import { sql } from "drizzle-orm";
 import {
   index,

--- a/plugins/plugin-sql/src/schema/embedding.ts
+++ b/plugins/plugin-sql/src/schema/embedding.ts
@@ -1,3 +1,11 @@
+/**
+ * Vector storage for memory embeddings. Each row belongs to exactly one
+ * memory (enforced by the `embedding_source_check` CHECK constraint and a
+ * cascading FK) and carries one populated `dimNNN` column matching the
+ * embedding model's output width — the others stay null. Supporting multiple
+ * fixed-width columns instead of a single variable-length vector lets
+ * PostgreSQL index each dimension separately.
+ */
 import { relations, sql } from "drizzle-orm";
 import { check, foreignKey, index, pgTable, timestamp, uuid, vector } from "drizzle-orm/pg-core";
 import { memoryTable } from "./memory";
@@ -25,10 +33,6 @@ export const DIMENSION_MAP = {
   [VECTOR_DIMS.XXXL]: "dim3072",
 } as const;
 
-/**
- * Definition of the embeddings table in the database.
- * Contains columns for ID, Memory ID, Creation Timestamp, and multiple vector dimensions.
- */
 export const embeddingTable = pgTable(
   "embeddings",
   {
@@ -56,10 +60,7 @@ export const embeddingTable = pgTable(
   ]
 );
 
-/**
- * Defines the possible values for the Embedding Dimension Column.
- * It can be "dim384", "dim512", "dim768", "dim1024", "dim1536", or "dim3072".
- */
+/** Column names for each supported embedding width. */
 export type EmbeddingDimensionColumn =
   | "dim384"
   | "dim512"
@@ -69,12 +70,10 @@ export type EmbeddingDimensionColumn =
   | "dim2048"
   | "dim3072";
 
-/**
- * Retrieve the type of a specific column in the EmbeddingTable based on the EmbeddingDimensionColumn key.
- */
+/** Drizzle column type for a given `EmbeddingDimensionColumn` key. */
 export type EmbeddingTableColumn = (typeof embeddingTable._.columns)[EmbeddingDimensionColumn];
 
-// Relations - defined here to avoid circular dependency with memory.ts
+/** Defined here, not in memory.ts, to avoid a circular import between the two schema files. */
 export const memoryRelations = relations(memoryTable, ({ one }) => ({
   embedding: one(embeddingTable),
 }));

--- a/plugins/plugin-sql/src/schema/entity.ts
+++ b/plugins/plugin-sql/src/schema/entity.ts
@@ -1,12 +1,16 @@
+/**
+ * Drizzle table for entities — the participants (users, agents, personas) an
+ * agent can hold memories and relationships about. Scoped to an owning agent
+ * via a cascading `agent_id` foreign key, with a compound unique constraint on
+ * (id, agentId) so other tables can enforce agent-scoped foreign keys against
+ * this table. `metadata` carries free-form per-entity data; `names` tracks
+ * known aliases.
+ */
 import type { Metadata } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 
-/**
- * Represents an entity table in the database.
- * Includes columns for id, agentId, createdAt, names, and metadata.
- */
 export const entityTable = pgTable(
   "entities",
   {

--- a/plugins/plugin-sql/src/schema/entityIdentity.ts
+++ b/plugins/plugin-sql/src/schema/entityIdentity.ts
@@ -1,3 +1,15 @@
+/**
+ * Three related tables backing entity identity resolution and fact refinement.
+ * `entityIdentityTable` holds a strengthened (platform, handle) claim attached
+ * to an entity; re-observations of the same pair bump confidence and append to
+ * `evidenceMessageIds` rather than producing duplicate rows, enforced by a
+ * unique constraint on (entityId, platform, handle, agentId).
+ * `entityMergeCandidateTable` holds proposed merges between two entities
+ * pending accept/reject. `factCandidateTable` holds pending fact
+ * contradiction/merge proposals surfaced by the FactRefinementEvaluator; the
+ * Facts tab in the UI lets users accept or reject these. All three cascade
+ * delete with their referenced entity/agent rows.
+ */
 import { sql } from "drizzle-orm";
 import {
   boolean,
@@ -14,11 +26,6 @@ import {
 import { agentTable } from "./agent";
 import { entityTable } from "./entity";
 
-/**
- * Strengthened (platform, handle) claim attached to an entity. Re-observations
- * of the same pair bump confidence and append to evidence_message_ids rather
- * than producing duplicate rows.
- */
 export const entityIdentityTable = pgTable(
   "entity_identities",
   {

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel re-exporting every Drizzle table schema in this plugin, assembled
+ * into the plugin's `schema` export so `DatabaseMigrationService` can
+ * auto-migrate all of them at startup.
+ */
 export { agentTable } from "./agent";
 export { approvalRequestTable } from "./approvalRequests";
 export type { AuthAuditOutcome } from "./authAuditEvent";

--- a/plugins/plugin-sql/src/schema/log.ts
+++ b/plugins/plugin-sql/src/schema/log.ts
@@ -1,13 +1,13 @@
+/**
+ * Drizzle table for structured runtime logs (`body` as free-form JSON,
+ * `type` as a category tag) attributed to the entity and room that produced
+ * them. Both `entityId` and `roomId` cascade delete, so logs are pruned
+ * automatically when their owning entity or room is removed.
+ */
 import { sql } from "drizzle-orm";
 import { foreignKey, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { entityTable } from "./entity";
 import { roomTable } from "./room";
-
-/**
- * Represents a PostgreSQL table for storing logs.
- *
- * @type {Table}
- */
 
 export const logTable = pgTable(
   "logs",

--- a/plugins/plugin-sql/src/schema/longTermMemories.ts
+++ b/plugins/plugin-sql/src/schema/longTermMemories.ts
@@ -1,3 +1,11 @@
+/**
+ * Drizzle table for durable, categorized long-term memories distilled per
+ * (agent, entity) — each row carries its own `embedding` vector, a
+ * `confidence` score, and access tracking (`accessCount` /
+ * `lastAccessedAt`) used to decay or prioritize recall. Indexed by
+ * agent+entity, category, confidence, and creation time for retrieval
+ * queries.
+ */
 import { sql } from "drizzle-orm";
 import { index, integer, jsonb, pgTable, real, text, timestamp, uuid } from "drizzle-orm/pg-core";
 

--- a/plugins/plugin-sql/src/schema/memory.ts
+++ b/plugins/plugin-sql/src/schema/memory.ts
@@ -1,3 +1,11 @@
+/**
+ * Core memory table: every message, fact, document, or fragment an agent
+ * stores, keyed by `type` and free-form `content`/`metadata` JSON. Cascade
+ * deletes with its room, entity, or agent. Partial expression indexes and
+ * CHECK constraints on `metadata->>'type'` enforce shape invariants for the
+ * `fragment` and `document` metadata kinds without a dedicated column per
+ * kind. Relations are defined in `embedding.ts` to avoid a circular import.
+ */
 import { sql } from "drizzle-orm";
 import {
   boolean,
@@ -14,14 +22,6 @@ import { agentTable } from "./agent";
 import { entityTable } from "./entity";
 import { roomTable } from "./room";
 
-/**
- * Definition of the memory table in the database.
- *
- * @param {string} tableName - The name of the table.
- * @param {object} columns - An object containing the column definitions.
- * @param {function} indexes - A function that defines the indexes for the table.
- * @returns {object} - The memory table object.
- */
 export const memoryTable = pgTable(
   "memories",
   {
@@ -41,9 +41,6 @@ export const memoryTable = pgTable(
       onDelete: "cascade",
     }),
     worldId: uuid("world_id"),
-    // .references(() => worldTable.id, {
-    //   onDelete: 'set null',
-    // }),
     unique: boolean("unique").default(true).notNull(),
     metadata: jsonb("metadata").default({}).notNull(),
   },
@@ -65,11 +62,6 @@ export const memoryTable = pgTable(
       columns: [table.agentId],
       foreignColumns: [agentTable.id],
     }).onDelete("cascade"),
-    // foreignKey({
-    //   name: 'fk_world',
-    //   columns: [table.worldId],
-    //   foreignColumns: [worldTable.id],
-    // }).onDelete('set null'),
     index("idx_memories_metadata_type").on(sql`((metadata->>'type'))`),
     index("idx_memories_document_id").on(sql`((metadata->>'documentId'))`),
     index("idx_fragments_order").on(
@@ -99,5 +91,3 @@ export const memoryTable = pgTable(
     ),
   ]
 );
-
-// Relations are defined in embedding.ts to avoid circular dependency

--- a/plugins/plugin-sql/src/schema/memoryAccessLogs.ts
+++ b/plugins/plugin-sql/src/schema/memoryAccessLogs.ts
@@ -1,3 +1,9 @@
+/**
+ * Append-only log of reads/writes against `long_term_memories`, recording
+ * which agent accessed which memory, of what type, and how (`accessType`).
+ * Used for recall analytics and decay/prioritization heuristics, not for
+ * enforcing access control.
+ */
 import { sql } from "drizzle-orm";
 import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 

--- a/plugins/plugin-sql/src/schema/message.ts
+++ b/plugins/plugin-sql/src/schema/message.ts
@@ -1,3 +1,9 @@
+/**
+ * Central message store (`central_messages`) for a channel — one row per
+ * message across every connector, with a self-referencing
+ * `inReplyToRootMessageId` for threading and free-form `rawMessage`/`metadata`
+ * JSON for connector-specific payloads. Cascade-deletes with its channel.
+ */
 import { sql } from "drizzle-orm";
 import { type AnyPgColumn, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { channelTable } from "./channel";

--- a/plugins/plugin-sql/src/schema/messageServer.ts
+++ b/plugins/plugin-sql/src/schema/messageServer.ts
@@ -1,3 +1,8 @@
+/**
+ * A message server: the top-level grouping for channels, mirroring a
+ * connector-side server/guild/workspace (`sourceType`/`sourceId` identify the
+ * originating connector) or a purely local server. Owns `channelTable` rows.
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 

--- a/plugins/plugin-sql/src/schema/messageServerAgent.ts
+++ b/plugins/plugin-sql/src/schema/messageServerAgent.ts
@@ -1,3 +1,4 @@
+/** Join table linking agents to the message servers they participate in; composite PK prevents duplicate membership and cascade-deletes with either side. */
 import { pgTable, primaryKey, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 import { messageServerTable } from "./messageServer";

--- a/plugins/plugin-sql/src/schema/pairingAllowlist.ts
+++ b/plugins/plugin-sql/src/schema/pairingAllowlist.ts
@@ -1,11 +1,11 @@
-import { sql } from "drizzle-orm";
-import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
-import { agentTable } from "./agent";
-
 /**
  * Represents the allowlist of approved senders for each channel.
  * Senders in this list are permitted to send DMs to the bot.
  */
+import { sql } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { agentTable } from "./agent";
+
 export const pairingAllowlistTable = pgTable(
   "pairing_allowlist",
   {
@@ -24,9 +24,7 @@ export const pairingAllowlistTable = pgTable(
       .references(() => agentTable.id, { onDelete: "cascade" }),
   },
   (table) => [
-    // Index for looking up allowlist by channel and agent
     index("pairing_allowlist_channel_agent_idx").on(table.channel, table.agentId),
-    // Unique constraint to prevent duplicate entries
     uniqueIndex("pairing_allowlist_sender_channel_agent_idx").on(
       table.senderId,
       table.channel,

--- a/plugins/plugin-sql/src/schema/pairingRequest.ts
+++ b/plugins/plugin-sql/src/schema/pairingRequest.ts
@@ -1,3 +1,10 @@
+/**
+ * Drizzle schema for `pairing_requests` — short-lived DM pairing codes that let a
+ * user on a messaging channel (Telegram, Discord, WhatsApp, etc.) link their
+ * account to an agent before being approved. Rows are expected to be cleaned up
+ * once a request is approved or expires; the unique indexes enforce one active
+ * code and one active request per sender per channel/agent.
+ */
 import { sql } from "drizzle-orm";
 import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";

--- a/plugins/plugin-sql/src/schema/participant.ts
+++ b/plugins/plugin-sql/src/schema/participant.ts
@@ -1,14 +1,16 @@
+/**
+ * Drizzle schema for `participants` — join table linking an entity (and/or
+ * agent) to a room, with a per-room `roomState` (e.g. muted/followed). Both
+ * `entityId` and `roomId` cascade-delete via redundant FK declarations (index
+ * + explicit `foreignKey()`), so removing an entity or room prunes its
+ * participant rows automatically.
+ */
 import { sql } from "drizzle-orm";
 import { foreignKey, index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 import { entityTable } from "./entity";
 import { roomTable } from "./room";
 
-/**
- * Defines the schema for the "participants" table in the database.
- *
- * @type {import('knex').TableBuilder}
- */
 export const participantTable = pgTable(
   "participants",
   {
@@ -26,7 +28,6 @@ export const participantTable = pgTable(
     roomState: text("room_state"),
   },
   (table) => [
-    // unique("participants_user_room_agent_unique").on(table.entityId, table.roomId, table.agentId),
     index("idx_participants_user").on(table.entityId),
     index("idx_participants_room").on(table.roomId),
     foreignKey({

--- a/plugins/plugin-sql/src/schema/relationship.ts
+++ b/plugins/plugin-sql/src/schema/relationship.ts
@@ -1,3 +1,10 @@
+/**
+ * Drizzle schema for `relationships` — a directed edge between two entities,
+ * scoped to a single agent, carrying free-form `tags` and `metadata`. The
+ * `unique_relationship` constraint enforces at most one row per
+ * (source, target, agent) triple; direction matters, so A→B and B→A are
+ * distinct rows.
+ */
 import { sql } from "drizzle-orm";
 import {
   foreignKey,
@@ -12,10 +19,6 @@ import {
 import { agentTable } from "./agent";
 import { entityTable } from "./entity";
 
-/**
- * Defines the relationshipTable containing information about relationships between entities and agents.
- * @type {import('knex').TableBuilder}
- */
 export const relationshipTable = pgTable(
   "relationships",
   {

--- a/plugins/plugin-sql/src/schema/room.ts
+++ b/plugins/plugin-sql/src/schema/room.ts
@@ -1,23 +1,13 @@
+/**
+ * Drizzle schema for `rooms` — a conversation surface (DM, channel, thread)
+ * that entities and agents participate in. `worldId` has no FK constraint
+ * because a room can be created before its world row exists.
+ */
 import type { Metadata } from "@elizaos/core";
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 
-/**
- * Defines a table schema for 'rooms' in the database.
- *
- * @typedef {object} RoomTable
- * @property {string} id - The unique identifier for the room.
- * @property {string} agentId - The UUID of the agent associated with the room.
- * @property {string} source - The source of the room.
- * @property {string} type - The type of the room.
- * @property {string} messageServerId - The message server ID of the room.
- * @property {string} worldId - The UUID of the world associated with the room.
- * @property {string} name - The name of the room.
- * @property {object} metadata - Additional metadata for the room in JSON format.
- * @property {string} channelId - The channel ID of the room.
- * @property {number} createdAt - The timestamp of when the room was created.
- */
 export const roomTable = pgTable("rooms", {
   id: uuid("id").notNull().primaryKey().default(sql`gen_random_uuid()`),
   agentId: uuid("agent_id").references(() => agentTable.id, {
@@ -26,10 +16,7 @@ export const roomTable = pgTable("rooms", {
   source: text("source").notNull(),
   type: text("type").notNull(),
   messageServerId: uuid("message_server_id"),
-  worldId: uuid("world_id"), // optional: rooms may be created before a world row exists
-  // .references(() => worldTable.id, {
-  //   onDelete: 'cascade',
-  // }),
+  worldId: uuid("world_id"),
   name: text("name"),
   metadata: jsonb("metadata").$type<Metadata>(),
   channelId: text("channel_id"),

--- a/plugins/plugin-sql/src/schema/server.ts
+++ b/plugins/plugin-sql/src/schema/server.ts
@@ -1,12 +1,11 @@
+/**
+ * Drizzle schema for `servers` — one row per elizaOS instance in a
+ * multi-tenant deployment; its `id` is the RLS server UUID used to scope
+ * row-level-security policies across the rest of the schema.
+ */
 import { sql } from "drizzle-orm";
 import { pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
 
-/**
- * Represents a table for storing server data for RLS multi-tenant isolation.
- * Each server represents one elizaOS instance in a multi-tenant deployment.
- *
- * @type {Table}
- */
 export const serverTable = pgTable("servers", {
   id: uuid("id").primaryKey(),
   createdAt: timestamp("created_at", { withTimezone: true }).default(sql`now()`).notNull(),

--- a/plugins/plugin-sql/src/schema/sessionSummaries.ts
+++ b/plugins/plugin-sql/src/schema/sessionSummaries.ts
@@ -1,3 +1,10 @@
+/**
+ * Drizzle schema for `session_summaries` — rolling, embeddable summaries of a
+ * room's conversation, produced incrementally as messages accumulate.
+ * `lastMessageOffset` tracks how far the summarizer has read so later runs can
+ * resume rather than resummarize the whole room; `embedding` lets summaries be
+ * retrieved semantically alongside raw memories.
+ */
 import { sql } from "drizzle-orm";
 import { index, integer, jsonb, pgTable, real, text, timestamp, uuid } from "drizzle-orm/pg-core";
 

--- a/plugins/plugin-sql/src/schema/tasks.ts
+++ b/plugins/plugin-sql/src/schema/tasks.ts
@@ -1,12 +1,13 @@
+/**
+ * Drizzle schema for `tasks` — the persistence backing for the runtime's
+ * `Task` model (deferred/queued work items scoped to a room, world, entity,
+ * and/or agent), with free-form `tags` and `metadata` for scheduler-specific
+ * state.
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
 
-/**
- * Represents a table schema for tasks in the database.
- *
- * @type {PgTable}
- */
 export const taskTable = pgTable("tasks", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull(),

--- a/plugins/plugin-sql/src/schema/types.ts
+++ b/plugins/plugin-sql/src/schema/types.ts
@@ -1,14 +1,11 @@
+/**
+ * Drizzle `customType` definitions for columns whose driver representation
+ * doesn't match the app-level type: a JSON-encoded string stored as `jsonb`,
+ * and a JS epoch-millis number stored as `timestamptz`.
+ */
 import { customType } from "drizzle-orm/pg-core";
 
-/**
- * Represents a custom type for converting a string to a JSONB format and vice versa.
- * @param {Object} options - The options for the custom type.
- * @param {Function} options.dataType - A function that returns the data type as "jsonb".
- * @param {Function} options.toDriver - A function that converts a string to a JSON string.
- * @param {Function} options.fromDriver - A function that converts a JSON string back to a string.
- * @returns {Object} - The custom type for string to JSONB conversion.
- */
-
+/** Stores a JSON-encoded string value in a `jsonb` column. */
 export const stringJsonb = customType<{ data: string; driverData: string }>({
   dataType() {
     return "jsonb";
@@ -21,14 +18,7 @@ export const stringJsonb = customType<{ data: string; driverData: string }>({
   },
 });
 
-/**
- * Represents a custom type for converting a number to a timestamp string and vice versa.
- * @param {Object} options - The options for the custom type.
- * @param {Function} options.dataType - A function that returns the data type as "timestamptz".
- * @param {Function} options.toDriver - A function that converts a number to a timestamp string using the Date object's toISOString method.
- * @param {Function} options.fromDriver - A function that converts a timestamp string to a number using the Date object's getTime method.
- * @returns {Object} - The custom type for number to timestamp conversion.
- */
+/** Stores a JS epoch-millis number as a `timestamptz` column. */
 export const numberTimestamp = customType<{ data: number; driverData: string }>({
   dataType() {
     return "timestamptz";

--- a/plugins/plugin-sql/src/schema/world.ts
+++ b/plugins/plugin-sql/src/schema/world.ts
@@ -1,12 +1,10 @@
+/**
+ * Drizzle schema for `worlds` — the top-level container an agent's rooms
+ * belong to (e.g. one Discord/Telegram server), scoped to a single agent.
+ */
 import { sql } from "drizzle-orm";
 import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { agentTable } from "./agent";
-
-/**
- * Represents a table schema for worlds in the database.
- *
- * @type {PgTable}
- */
 
 export const worldTable = pgTable("worlds", {
   id: uuid("id").notNull().primaryKey().default(sql`gen_random_uuid()`),

--- a/plugins/plugin-sql/src/services/advanced-memory-storage.ts
+++ b/plugins/plugin-sql/src/services/advanced-memory-storage.ts
@@ -1,3 +1,16 @@
+/**
+ * `AdvancedMemoryStorageService` implements the runtime's `MemoryStorageProvider`
+ * on top of ordinary agent memories, storing long-term memories and session
+ * summaries as regular `Memory` rows (tagged via an `advancedMemory` envelope
+ * in `metadata`) in dedicated synthetic rooms rather than separate tables.
+ *
+ * Long-term memories are anchored to an "identity group" resolved through the
+ * optional `entity_resolution` service: entities confirmed-linked to the same
+ * person share one long-term-memory room (keyed by the lexicographically
+ * smallest entity ID in the group), so memories written under any alias in the
+ * group are visible from all of them. Session summaries are stored per-room
+ * without identity resolution.
+ */
 import {
   ChannelType,
   type IAgentRuntime,

--- a/plugins/plugin-sql/src/stores/agent.store.ts
+++ b/plugins/plugin-sql/src/stores/agent.store.ts
@@ -1,3 +1,9 @@
+/**
+ * CRUD store for the `agents` table: maps between the DB row shape (Drizzle
+ * insert/select types, epoch-millis timestamps, DB-encoded knowledge/message
+ * examples) and the runtime's `Agent` domain type. `update` deep-merges
+ * `settings` with the existing row rather than overwriting it wholesale.
+ */
 import { type Agent, logger, type UUID } from "@elizaos/core";
 import { count, eq } from "drizzle-orm";
 import {

--- a/plugins/plugin-sql/src/stores/cache.store.ts
+++ b/plugins/plugin-sql/src/stores/cache.store.ts
@@ -1,3 +1,4 @@
+/** Per-agent key/value cache store backed by the `cache` table (upsert on `set`, scoped by `agentId`). */
 import { logger } from "@elizaos/core";
 import { and, eq } from "drizzle-orm";
 import { cacheTable } from "../schema/index";

--- a/plugins/plugin-sql/src/stores/component.store.ts
+++ b/plugins/plugin-sql/src/stores/component.store.ts
@@ -1,3 +1,8 @@
+/**
+ * CRUD store for the `components` table (entity attachments scoped by type,
+ * and optionally by world/source-entity), mapping DB rows to the runtime's
+ * `Component` domain type.
+ */
 import type { Component, UUID } from "@elizaos/core";
 import { and, eq } from "drizzle-orm";
 import { componentTable } from "../schema/index";

--- a/plugins/plugin-sql/src/stores/connectorAccount.store.ts
+++ b/plugins/plugin-sql/src/stores/connectorAccount.store.ts
@@ -1,3 +1,15 @@
+/**
+ * Store for connector accounts (linked external identities like a Discord or
+ * Telegram account), their vault credential references, owner bindings,
+ * audit log, and OAuth flow state — backing the connector-account tables in
+ * `../schema`.
+ *
+ * OAuth flow state is looked up by a SHA-256 hash of the opaque `state`
+ * value rather than the value itself, so the raw state never round-trips
+ * through storage. Audit-event metadata is recursively redacted against
+ * `CONNECTOR_AUDIT_SECRET_KEY_PATTERN` before being persisted, since callers
+ * may pass through arbitrary provider payloads.
+ */
 import { createHash } from "node:crypto";
 import type {
   AppendConnectorAccountAuditEventParams,

--- a/plugins/plugin-sql/src/stores/entity.store.ts
+++ b/plugins/plugin-sql/src/stores/entity.store.ts
@@ -1,3 +1,10 @@
+/**
+ * CRUD + lookup store for the `entities` table, with helpers to fetch an
+ * entity's `components` via join and to resolve room membership through
+ * `participants`. Name matching (`getByNames`, `searchByName`) runs as raw
+ * SQL against the `names` text array rather than through the Drizzle query
+ * builder.
+ */
 import { randomUUID } from "node:crypto";
 import { type Component, type Entity, logger, type UUID } from "@elizaos/core";
 import { and, eq, inArray, or, sql } from "drizzle-orm";

--- a/plugins/plugin-sql/src/stores/index.ts
+++ b/plugins/plugin-sql/src/stores/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting every domain store and the shared `Store`/`StoreContext` types. */
 export * from "./agent.store";
 export * from "./cache.store";
 export * from "./component.store";

--- a/plugins/plugin-sql/src/stores/log.store.ts
+++ b/plugins/plugin-sql/src/stores/log.store.ts
@@ -1,3 +1,9 @@
+/**
+ * Store for the `logs` table: append-only event records (actions, evaluators,
+ * model calls, embedding events) plus `getAgentRunSummaries`, which
+ * reconstructs per-run status/timing/counts by aggregating `run_event` and
+ * related log rows rather than reading from a dedicated runs table.
+ */
 import type {
   AgentRunCounts,
   AgentRunSummary,

--- a/plugins/plugin-sql/src/stores/memory.store.ts
+++ b/plugins/plugin-sql/src/stores/memory.store.ts
@@ -1,3 +1,10 @@
+/**
+ * CRUD + vector-search store for the `memories` table. Reads join against
+ * `embeddingTable` on the runtime's configured embedding dimension
+ * (`ctx.getEmbeddingDimension()`); `searchByEmbedding` ranks by cosine
+ * distance. `tableName` partitions memories by logical type (facts,
+ * messages, long-term memories, etc.) within the same physical table.
+ */
 import { randomUUID } from "node:crypto";
 import { logger, type Memory, type MemoryMetadata, type UUID } from "@elizaos/core";
 import { and, cosineDistance, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";

--- a/plugins/plugin-sql/src/stores/messaging.store.ts
+++ b/plugins/plugin-sql/src/stores/messaging.store.ts
@@ -1,3 +1,11 @@
+/**
+ * Store for the messaging-server domain: `MessageServer` (an external
+ * platform connection), its `Channel`s, channel participants, and the
+ * `Message` rows within them. Distinct from `RoomStore`/`ParticipantStore`,
+ * which model the agent-facing conversation surface — this store models the
+ * underlying connector-side server/channel/message structure that rooms are
+ * synced from.
+ */
 import { randomUUID } from "node:crypto";
 import { ChannelType, type Metadata, type UUID } from "@elizaos/core";
 import { and, desc, eq, lt, sql } from "drizzle-orm";

--- a/plugins/plugin-sql/src/stores/participant.store.ts
+++ b/plugins/plugin-sql/src/stores/participant.store.ts
@@ -1,3 +1,8 @@
+/**
+ * Store for the `participants` join table: room membership per entity,
+ * scoped to the current agent, plus a per-(room, entity) follow/mute state
+ * (`roomState`).
+ */
 import { logger, type UUID } from "@elizaos/core";
 import { and, eq, inArray } from "drizzle-orm";
 import { participantTable, roomTable } from "../schema/index";

--- a/plugins/plugin-sql/src/stores/relationship.store.ts
+++ b/plugins/plugin-sql/src/stores/relationship.store.ts
@@ -1,3 +1,9 @@
+/**
+ * CRUD store for the `relationships` table (directed, tagged edges between
+ * entities). `getAll` runs raw SQL to filter by overlapping tags and to match
+ * either side of the relationship, since the Drizzle query builder doesn't
+ * cover the `&&` array-overlap operator used here.
+ */
 import { randomUUID } from "node:crypto";
 import { logger, type Metadata, type Relationship, type UUID } from "@elizaos/core";
 import { and, eq, type SQL, sql } from "drizzle-orm";

--- a/plugins/plugin-sql/src/stores/room.store.ts
+++ b/plugins/plugin-sql/src/stores/room.store.ts
@@ -1,3 +1,8 @@
+/**
+ * CRUD store for the `rooms` table, scoped to the current agent where
+ * applicable (`getByIds` filters by `agentId`; `getByWorld` does not, since a
+ * world already implies a single owning agent).
+ */
 import { randomUUID } from "node:crypto";
 import type { ChannelType, Room, RoomMetadata, UUID } from "@elizaos/core";
 import { and, eq, inArray } from "drizzle-orm";

--- a/plugins/plugin-sql/src/stores/task.store.ts
+++ b/plugins/plugin-sql/src/stores/task.store.ts
@@ -1,3 +1,4 @@
+/** CRUD store for the `tasks` table, scoped to the current agent; tag filtering uses a Postgres array-contains (`@>`) query. */
 import type { Task, TaskMetadata, UUID } from "@elizaos/core";
 import { and, eq, sql } from "drizzle-orm";
 import { taskTable } from "../schema/index";

--- a/plugins/plugin-sql/src/stores/types.ts
+++ b/plugins/plugin-sql/src/stores/types.ts
@@ -1,3 +1,4 @@
+/** Shared `Store`/`StoreContext` contract every domain store in this directory implements. */
 import type { UUID } from "@elizaos/core";
 import type { EmbeddingDimensionColumn } from "../schema/embedding";
 import type { DrizzleDatabase } from "../types";

--- a/plugins/plugin-sql/src/stores/world.store.ts
+++ b/plugins/plugin-sql/src/stores/world.store.ts
@@ -1,3 +1,4 @@
+/** CRUD store for the `worlds` table. */
 import { randomUUID } from "node:crypto";
 import type { UUID, World } from "@elizaos/core";
 import { eq } from "drizzle-orm";

--- a/plugins/plugin-sql/src/types.ts
+++ b/plugins/plugin-sql/src/types.ts
@@ -1,3 +1,4 @@
+/** Shared Drizzle DB type (Postgres or PGlite) and small adapter/result helpers used across the store layer. */
 import type { IDatabaseAdapter } from "@elizaos/core";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { PgliteDatabase } from "drizzle-orm/pglite";

--- a/plugins/plugin-sql/src/utils.browser.ts
+++ b/plugins/plugin-sql/src/utils.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build of `./utils`: filesystem-backed path resolution has no
+ * meaning in-browser, so these are fixed-value stubs; `sanitizeJsonObject` is
+ * the real, shared implementation (mirrored in `./utils.node.ts`).
+ */
 export function expandTildePath(filepath: string): string {
   return filepath;
 }
@@ -16,13 +21,12 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
-    // escape JSON.stringify emits for them. Nothing else needs rewriting --
-    // the sanitized value is serialized with JSON.stringify, which already
-    // escapes backslashes and control characters correctly. (This function
-    // used to double every backslash not followed by ["\/bfnrtu] and mangle
-    // non-hex `\u` sequences, so a value like "C:\Users" came back as
-    // "C:\\Users" after a write/read round-trip -- silent data corruption.)
+    // Strips NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting here --
+    // the value is serialized with JSON.stringify, which already escapes
+    // backslashes and control characters correctly; re-escaping them here
+    // would corrupt already-escaped strings (e.g. "C:\Users") on a
+    // write/read round-trip.
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 

--- a/plugins/plugin-sql/src/utils.node.ts
+++ b/plugins/plugin-sql/src/utils.node.ts
@@ -1,3 +1,9 @@
+/**
+ * Node/Bun build of `./utils`: resolves the PGlite data directory by walking
+ * up from cwd to find a `.env` file and to detect whether cwd is inside the
+ * elizaOS monorepo (so local dev defaults PGlite data under
+ * `<repo-root>/.eliza/.elizadb`), then falls back to `<cwd>/.eliza/.elizadb`.
+ */
 import { existsSync } from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
@@ -60,13 +66,12 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
-    // escape JSON.stringify emits for them. Nothing else needs rewriting --
-    // the sanitized value is serialized with JSON.stringify, which already
-    // escapes backslashes and control characters correctly. (This function
-    // used to double every backslash not followed by ["\/bfnrtu] and mangle
-    // non-hex `\u` sequences, so a value like "C:\Users" came back as
-    // "C:\\Users" after a write/read round-trip -- silent data corruption.)
+    // Strips NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting here --
+    // the value is serialized with JSON.stringify, which already escapes
+    // backslashes and control characters correctly; re-escaping them here
+    // would corrupt already-escaped strings (e.g. "C:\Users") on a
+    // write/read round-trip.
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 

--- a/plugins/plugin-sql/src/utils.ts
+++ b/plugins/plugin-sql/src/utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Default (Node/Bun) build of the plugin's platform-specific helpers, used by
+ * `./index.ts`; resolves the PGlite data directory by walking up from cwd to
+ * find a `.env` file and to detect whether cwd is inside the elizaOS
+ * monorepo, then falls back to `<cwd>/.eliza/.elizadb`. Kept in sync with
+ * `./utils.node.ts` (used by `./index.node.ts`); `./utils.browser.ts` stubs
+ * the filesystem-dependent parts for the browser build.
+ */
 import { existsSync } from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
@@ -38,7 +46,7 @@ export function resolvePgliteDir(dir?: string, fallbackDir?: string): string {
   if (existsSync(path.join(process.cwd(), "packages", "core"))) {
     monoPath = process.cwd();
   } else {
-    const twoUp = path.resolve(process.cwd(), "../.."); // assuming running from package
+    const twoUp = path.resolve(process.cwd(), "../..");
     if (existsSync(path.join(twoUp, "packages", "core"))) {
       monoPath = twoUp;
     }
@@ -60,13 +68,12 @@ export function sanitizeJsonObject(value: unknown, seen: WeakSet<object> = new W
   }
 
   if (typeof value === "string") {
-    // Strip NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
-    // escape JSON.stringify emits for them. Nothing else needs rewriting —
-    // the sanitized value is serialized with JSON.stringify, which already
-    // escapes backslashes and control characters correctly. (This function
-    // used to double every backslash not followed by ["\/bfnrtu] and mangle
-    // non-hex `\u` sequences, so a value like "C:\Users" came back as
-    // "C:\\Users" after a write/read round-trip — silent data corruption.)
+    // Strips NUL characters: PostgreSQL/PGlite jsonb rejects the `\u0000`
+    // escape JSON.stringify emits for them. Nothing else needs rewriting here —
+    // the value is serialized with JSON.stringify, which already escapes
+    // backslashes and control characters correctly; re-escaping them here
+    // would corrupt already-escaped strings (e.g. "C:\Users") on a
+    // write/read round-trip.
     return value.replace(new RegExp(String.fromCharCode(0), "g"), "");
   }
 

--- a/plugins/plugin-sql/src/utils/string-to-uuid.ts
+++ b/plugins/plugin-sql/src/utils/string-to-uuid.ts
@@ -1,3 +1,9 @@
+/**
+ * Deterministically derives a v4-shaped UUID from an arbitrary string (or
+ * passes an already-valid UUID through unchanged), so the same input always
+ * maps to the same synthetic ID — e.g. for deriving stable room/world IDs
+ * from a natural key.
+ */
 import type { UUID } from "@elizaos/core";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/plugins/plugin-sql/src/vitest.config.ts
+++ b/plugins/plugin-sql/src/vitest.config.ts
@@ -1,11 +1,12 @@
+/**
+ * Default vitest config for plugin-sql. The runner
+ * (`packages/scripts/run-all-tests.mjs`) drives lanes via env:
+ * `TEST_LANE=pr` sets `VITEST_EXCLUDE_REAL=1`; `TEST_LANE=post-merge` clears
+ * it so the real-PGlite suites (`runtime-migrator.real.test.ts`,
+ * `pglite-adapter.real.test.ts`, …) run instead of being excluded (#10104).
+ */
 import { defineConfig } from "vitest/config";
 
-// The runner (packages/scripts/run-all-tests.mjs) drives lanes via env:
-// TEST_LANE=pr sets VITEST_EXCLUDE_REAL=1, TEST_LANE=post-merge clears it so
-// "real keys flow through". This config used to hard-exclude *.real.test.ts
-// regardless, so the self-contained real-PGlite suites
-// (runtime-migrator.real.test.ts, pglite-adapter.real.test.ts, …) ran in NO
-// lane at all — the post-merge lane silently skipped them (#10104 audit).
 const excludeReal =
   process.env.VITEST_EXCLUDE_REAL === "1" || process.env.VITEST_LANE !== "post-merge";
 

--- a/plugins/plugin-sql/src/vitest.real.config.ts
+++ b/plugins/plugin-sql/src/vitest.real.config.ts
@@ -1,17 +1,15 @@
+/**
+ * Companion to `vitest.config.ts` that includes the real (`*.real.test.ts`)
+ * suites the default config excludes — the focused `memory-text-contains`
+ * adapter coverage plus the `memory-keyword-search` scale test. These
+ * exercise a real SQL store: PGlite by default, or a live Postgres via
+ * `POSTGRES_URL`. No `run-all-tests.mjs` lane runs this config; invoke it on
+ * demand via `bun run test:real:files`, after building `@elizaos/core` (this
+ * config uses normal workspace resolution rather than aliasing core to its
+ * TS source).
+ */
 import { defineConfig } from "vitest/config";
 
-// Companion to `vitest.config.ts` that INCLUDES the real (`*.real.test.ts`)
-// suites the default config statically excludes — the focused
-// `memory-text-contains` adapter coverage plus the `memory-keyword-search`
-// scale test. These exercise a real SQL store: PGlite by default, or a live
-// Postgres via `POSTGRES_URL`.
-//
-// Why a separate config: `vitest.config.ts` hard-excludes the real suites
-// (kept intentionally — see #9955) and no `run-all-tests.mjs` lane runs them,
-// so they were otherwise unrunnable. Invoke on demand via
-// `bun run test:real:files`. Build `@elizaos/core` first (e.g. `bun run build`),
-// since this config relies on normal workspace resolution rather than aliasing
-// core to its TS source.
 export default defineConfig({
   test: {
     include: ["**/*.real.test.ts"],

--- a/plugins/plugin-tee/index.browser.ts
+++ b/plugins/plugin-tee/index.browser.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser-unavailable stand-in for `teePlugin`: TEE attestation requires a
+ * server-side dstack SDK connection, so this entry only warns and does not
+ * wire up services/providers. Not referenced by package `exports` — the
+ * plugin is Node-only per `registry-entry.json`.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-tee/src/__tests__/tee-utils.test.ts
+++ b/plugins/plugin-tee/src/__tests__/tee-utils.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Real smoke test for the TEE plugin's pure utilities (issue #9943: the plugin
+ * shipped with zero tests). The plugin's index eagerly loads the Phala dstack
+ * SDK at module-eval, so this targets the dependency-free utils sub-module —
+ * the hex/SHA-256/endpoint helpers that every attestation path relies on — with
+ * real assertions (known vectors, round-trips, and the documented error cases).
+ */
 import { describe, expect, it } from "vitest";
 import {
   calculateSHA256,
@@ -7,13 +14,6 @@ import {
   uint8ArrayToHex,
 } from "../utils";
 
-/**
- * Real smoke test for the TEE plugin's pure utilities (issue #9943: the plugin
- * shipped with zero tests). The plugin's index eagerly loads the Phala dstack
- * SDK at module-eval, so this targets the dependency-free utils sub-module —
- * the hex/SHA-256/endpoint helpers that every attestation path relies on — with
- * real assertions (known vectors, round-trips, and the documented error cases).
- */
 describe("plugin-tee utils", () => {
   it("round-trips bytes through hex", () => {
     const bytes = new Uint8Array([0x00, 0x0f, 0xa0, 0xff, 0x42]);

--- a/plugins/plugin-tee/src/index.ts
+++ b/plugins/plugin-tee/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * `teePlugin` entry point: wires the default (Phala) vendor's actions and
+ * providers, registers `TEEService`, and validates `TEE_MODE` at init. Vendor
+ * selection (`TEE_VENDOR`) only affects which vendor's providers/actions are
+ * registered here — `TEEService` itself always uses the Phala key-derivation
+ * provider regardless of vendor.
+ */
+// biome-ignore-all assist/source/organizeImports: preserve current develop's export grouping in this comments-only pass.
 import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { TEEService } from "./services/tee";
 import { getVendor, TeeVendorNames } from "./vendors";

--- a/plugins/plugin-tee/src/providers/base.ts
+++ b/plugins/plugin-tee/src/providers/base.ts
@@ -1,3 +1,8 @@
+/**
+ * Abstract base classes every TEE vendor implements: `DeriveKeyProvider` for
+ * deterministic key derivation, `RemoteAttestationProvider` for TDX quote
+ * generation. Vendor-specific implementations live under `../vendors`.
+ */
 import type {
   DeriveKeyResult,
   RemoteAttestationQuote,

--- a/plugins/plugin-tee/src/providers/deriveKey.ts
+++ b/plugins/plugin-tee/src/providers/deriveKey.ts
@@ -1,3 +1,11 @@
+/**
+ * Phala TappdClient-backed key derivation: `PhalaDeriveKeyProvider` derives
+ * raw bytes, an Ed25519 (Solana) keypair, or an ECDSA (EVM) keypair from a
+ * `path`/`subject` pair, each accompanied by a TDX remote-attestation quote
+ * over the derived public key. `phalaDeriveKeyProvider` is the runtime
+ * `Provider` wrapper that reads `TEE_MODE`/`WALLET_SECRET_SALT` from
+ * settings and injects `solana_public_key`/`evm_address` into context.
+ */
 import crypto from "node:crypto";
 import {
   type IAgentRuntime,

--- a/plugins/plugin-tee/src/providers/index.ts
+++ b/plugins/plugin-tee/src/providers/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-exporting the provider base classes and the Phala derive-key / remote-attestation providers. */
 export { DeriveKeyProvider, RemoteAttestationProvider } from "./base";
 export { PhalaDeriveKeyProvider, phalaDeriveKeyProvider } from "./deriveKey";
 export {

--- a/plugins/plugin-tee/src/providers/remoteAttestation.ts
+++ b/plugins/plugin-tee/src/providers/remoteAttestation.ts
@@ -1,3 +1,9 @@
+/**
+ * Phala TappdClient-backed TDX remote attestation: `PhalaRemoteAttestationProvider`
+ * generates a quote over arbitrary report data; `phalaRemoteAttestationProvider`
+ * is the runtime `Provider` wrapper that quotes the current message payload
+ * and injects `quote`/`timestamp` into context.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-tee/src/services/index.ts
+++ b/plugins/plugin-tee/src/services/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-exporting `TEEService`. */
 export { TEEService } from "./tee";

--- a/plugins/plugin-tee/src/services/tee.ts
+++ b/plugins/plugin-tee/src/services/tee.ts
@@ -1,3 +1,10 @@
+/**
+ * TEEService — the elizaOS Service wrapper other plugins retrieve via
+ * `runtime.getService<TEEService>(TEEService.serviceType)` to get TEE-backed
+ * key derivation. Delegates all crypto to PhalaDeriveKeyProvider regardless of
+ * the configured TEE_VENDOR; only the vendor's providers/actions selection is
+ * vendor-aware.
+ */
 import {
   type IAgentRuntime,
   logger,
@@ -33,7 +40,6 @@ export class TEEService extends Service {
     const secretSalt =
       typeof secretSaltRaw === "string" ? secretSaltRaw : undefined;
 
-    // Set config as Metadata-compatible object
     this.config = {
       mode: teeMode,
       vendor,

--- a/plugins/plugin-tee/src/types/index.ts
+++ b/plugins/plugin-tee/src/types/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared TEE domain types: mode/vendor/attestation-type enums, key-derivation
+ * and attestation result shapes, and the `parseTeeMode` / `parseTeeVendor`
+ * validators used by `teePlugin.init` to reject unrecognized config values.
+ */
 export enum TeeMode {
   LOCAL = "LOCAL",
   DOCKER = "DOCKER",

--- a/plugins/plugin-tee/src/utils/index.ts
+++ b/plugins/plugin-tee/src/utils/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Standalone helpers for the TEE plugin: hex/byte conversion, SHA-256 hashing,
+ * `getTeeEndpoint` mode-to-URL resolution (LOCAL/DOCKER simulator vs no
+ * endpoint for PRODUCTION), and `uploadAttestationQuote`, which POSTs a raw
+ * attestation quote to Phala's public verification service
+ * (proof.t16z.com) and requires outbound network access.
+ */
 import { createHash } from "node:crypto";
 
 export function hexToUint8Array(hex: string): Uint8Array {

--- a/plugins/plugin-tee/src/vendors/index.ts
+++ b/plugins/plugin-tee/src/vendors/index.ts
@@ -1,3 +1,4 @@
+/** TEE vendor registry: `getVendor` looks up a `TeeVendorInterface` by `TeeVendorName`; Phala is the only registered vendor today. */
 import { PhalaVendor } from "./phala";
 import {
   type TeeVendorInterface,

--- a/plugins/plugin-tee/src/vendors/phala.ts
+++ b/plugins/plugin-tee/src/vendors/phala.ts
@@ -1,3 +1,8 @@
+/**
+ * Phala Network TEE vendor implementation. Registers no actions (remote
+ * attestation is exposed as a provider, not an action) and wires the
+ * derive-key and remote-attestation providers.
+ */
 import type { Action, Provider } from "@elizaos/core";
 import {
   phalaDeriveKeyProvider,

--- a/plugins/plugin-tee/src/vendors/types.ts
+++ b/plugins/plugin-tee/src/vendors/types.ts
@@ -1,3 +1,4 @@
+/** `TeeVendorInterface` contract each TEE vendor implements, plus the `TeeVendorNames` registry of known vendor keys. */
 import type { Action, Provider } from "@elizaos/core";
 
 export const TeeVendorNames = {

--- a/plugins/plugin-tee/vitest.config.ts
+++ b/plugins/plugin-tee/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for plugin-tee: points tests at agent source seams and runs src test files. */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-wallet-ui/src/InventoryVisualCopy.test.ts
+++ b/plugins/plugin-wallet-ui/src/InventoryVisualCopy.test.ts
@@ -1,12 +1,15 @@
+/**
+ * Static source-text assertions on `components/InventoryAppView.tsx` (the rich
+ * dashboard that `InventoryView` renders as its GUI/XR child) guarding two
+ * copy regressions: raw bullet separators in the RPC-provider status line,
+ * and reintroduced paragraph helper copy in the empty-wallet market pulse.
+ * No rendering — this is a text-fixture check, not a component test.
+ */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-// The RPC-provider status copy + the empty-wallet market-pulse hero live in the
-// rich dashboard (`InventoryAppView`), which the unified `InventoryView` renders
-// as its GUI/XR `Escape` child; the spatial `InventorySpatialView` is the TUI
-// fallback.
 const source = readFileSync(
   resolve(
     dirname(fileURLToPath(import.meta.url)),

--- a/plugins/plugin-wallet-ui/src/inventory/ChainIcon.tsx
+++ b/plugins/plugin-wallet-ui/src/inventory/ChainIcon.tsx
@@ -1,3 +1,8 @@
+/**
+ * `<ChainIcon>` renders an inline SVG logo for a resolved chain key. Only
+ * ethereum/base/bsc/avax/solana have art; unrecognized or unlisted chains
+ * render nothing (`null`) rather than falling back to a generic icon.
+ */
 import type * as React from "react";
 import { resolveChainKey } from "./chainConfig.ts";
 

--- a/plugins/plugin-wallet-ui/src/inventory/TokenLogo.tsx
+++ b/plugins/plugin-wallet-ui/src/inventory/TokenLogo.tsx
@@ -1,3 +1,9 @@
+/**
+ * `<TokenLogo>` renders a token's logo image, preferring `preferredLogoUrl`
+ * over the chain's native/contract CDN lookup, and falling back to a
+ * monogram badge (first letter of the symbol) on load failure or when no URL
+ * resolves.
+ */
 import { useState } from "react";
 import { getContractLogoUrl, getNativeLogoUrl } from "./chainConfig.ts";
 import { chainIcon } from "./constants.ts";

--- a/plugins/plugin-wallet-ui/src/inventory/chainConfig.test.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/chainConfig.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Chain config drives explorer links + address validation in the wallet UI.
+ * Lookups are case-insensitive and null for unknown chains; explorer URLs
+ * embed the hash/address; token URLs reject addresses failing the chain's
+ * address regex (so a bad address never produces a misleading link).
+ */
 import { describe, expect, it } from "vitest";
 import {
   getChainConfig,
@@ -6,13 +12,6 @@ import {
   getNativeLogoUrl,
   resolveChainKey,
 } from "./chainConfig.js";
-
-/**
- * Chain config drives explorer links + address validation in the wallet UI.
- * Lookups are case-insensitive and null for unknown chains; explorer URLs
- * embed the hash/address; token URLs reject addresses failing the chain's
- * address regex (so a bad address never produces a misleading link).
- */
 
 describe("getChainConfig / resolveChainKey", () => {
   it("resolves known chains case-insensitively, null for unknown", () => {

--- a/plugins/plugin-wallet-ui/src/inventory/constants.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/constants.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared inventory row/item types (`TokenRow`, `NftItem`) and the small
+ * formatting/matching helpers used across the wallet inventory UI: chain
+ * name normalization and badge codes, balance display formatting, address
+ * lowercasing, and lenient numeric parsing for untrusted balance strings.
+ */
 export const BSC_GAS_READY_THRESHOLD = 0.005;
 export const BSC_GAS_THRESHOLD = 0.005;
 export const HEX_ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;

--- a/plugins/plugin-wallet-ui/src/inventory/index.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/index.ts
@@ -1,3 +1,4 @@
+/** Barrel re-export for the `inventory/` module: chain config, row/item constants, `<TokenLogo>`, and `useInventoryData`. */
 export {
   CHAIN_CONFIGS,
   type ChainConfig,

--- a/plugins/plugin-wallet-ui/src/inventory/inventory-chain-filters.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/inventory-chain-filters.ts
@@ -1,3 +1,9 @@
+/**
+ * Per-user chain filter toggles for the inventory view, scoped to the primary
+ * chains (ethereum/base/bsc/avax/solana). Filters are always normalized
+ * against `DEFAULT_INVENTORY_CHAIN_FILTERS` before use, so a partial or
+ * missing filter object behaves as "all enabled."
+ */
 import type { InventoryChainFilters } from "@elizaos/ui/state";
 import type { ChainKey } from "./chainConfig.ts";
 import { resolveChainKey } from "./chainConfig.ts";

--- a/plugins/plugin-wallet-ui/src/inventory/media-url.test.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/media-url.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit coverage for `normalizeInventoryImageUrl`: gateway rewriting for
+ * ipfs/ipns/arweave URIs, rejection of `javascript:`/executable `data:` URIs,
+ * and pass-through of safe raster `data:image` URLs. Pure function, no
+ * network or DOM.
+ */
 import { describe, expect, it } from "vitest";
 import { normalizeInventoryImageUrl } from "./media-url.ts";
 

--- a/plugins/plugin-wallet-ui/src/inventory/useInventoryData.ts
+++ b/plugins/plugin-wallet-ui/src/inventory/useInventoryData.ts
@@ -1,3 +1,13 @@
+/**
+ * `useInventoryData` turns raw wallet API responses (balances, addresses,
+ * config, NFTs) into the sorted/filtered `TokenRow[]` and `NftItem[]` the
+ * inventory view renders, plus derived state (single-chain focus, per-chain
+ * errors, totals). EVM chains with a known address but no balance data yet
+ * are synthesized as zero-balance native rows so every configured chain has
+ * a row even before the balance fetch resolves; rows with zero balance and
+ * zero USD value are dropped. All sorting/filtering is memoized on the raw
+ * inputs and the user's sort/filter selections.
+ */
 import type {
   EvmChainBalance,
   WalletAddresses,

--- a/plugins/plugin-wallet-ui/src/plugin.ts
+++ b/plugins/plugin-wallet-ui/src/plugin.ts
@@ -1,3 +1,8 @@
+/**
+ * `walletAppPlugin` — the plugin descriptor registering the wallet inventory
+ * shell page, the shared GUI/XR/TUI wallet view, and the chat-sidebar wallet
+ * status widget.
+ */
 import type { Plugin } from "@elizaos/core";
 
 export const walletAppPlugin: Plugin = {

--- a/plugins/plugin-wallet-ui/src/register.ts
+++ b/plugins/plugin-wallet-ui/src/register.ts
@@ -1,10 +1,13 @@
+/**
+ * Side-effect entry point: registers the wallet shell page/widgets and, in a
+ * DOM-less terminal host, the terminal inventory view. Also re-exports the
+ * chain/address constants that consumers import from the package root, since
+ * the app build aliases `@elizaos/plugin-wallet-ui` to this module rather than
+ * the full barrel.
+ */
 import "./register-routes.ts";
 
 export { getExplorerTokenUrl } from "./inventory/chainConfig.ts";
-// Re-export the chain/address constants consumers import from the package root.
-// The app build aliases `@elizaos/plugin-wallet-ui` to THIS module (side-effect
-// entry, not the full barrel), so wallet-consuming plugins
-// (`import { isBscChainName } from "@elizaos/plugin-wallet-ui"`) resolve here.
 export {
   BSC_GAS_READY_THRESHOLD,
   HEX_ADDRESS_RE,

--- a/plugins/plugin-wallet-ui/src/ui.ts
+++ b/plugins/plugin-wallet-ui/src/ui.ts
@@ -1,3 +1,7 @@
+/**
+ * Triggers the `register-routes.ts` side effect and re-exports the wallet UI
+ * components, chain config, and hooks for component-level consumption.
+ */
 import "./register-routes.ts";
 
 export { useWalletState } from "@elizaos/ui/state";

--- a/plugins/plugin-wallet-ui/src/wallet-rpc.ts
+++ b/plugins/plugin-wallet-ui/src/wallet-rpc.ts
@@ -1,3 +1,4 @@
+/** Pure re-export of the wallet RPC helpers from `@elizaos/shared`; no local logic. */
 export {
   buildWalletRpcUpdateRequest,
   resolveInitialWalletRpcSelections,

--- a/plugins/plugin-wallet-ui/src/widgets/wallet-status.tsx
+++ b/plugins/plugin-wallet-ui/src/widgets/wallet-status.tsx
@@ -1,3 +1,9 @@
+/**
+ * `WalletStatusSidebarWidget` — the chat-sidebar widget showing abbreviated
+ * EVM/Solana addresses, per-chain badges, asset count, and total USD value.
+ * Renders `null` when `walletEnabled` is false; lazily loads wallet config
+ * and balances the first time it mounts with data missing.
+ */
 import {
   Button,
   type ChatSidebarWidgetProps,

--- a/plugins/plugin-wallet-ui/vite.config.views.ts
+++ b/plugins/plugin-wallet-ui/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite config for the standalone wallet view bundle (`dist/views/bundle.js`), built separately from the tsup plugin-entry build. */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-wallet-ui/vitest.config.ts
+++ b/plugins/plugin-wallet-ui/vitest.config.ts
@@ -1,3 +1,11 @@
+/**
+ * Vitest config for plugin-wallet-ui. Forces a single React/ReactDOM copy via
+ * explicit aliases (avoids duplicate-React errors across workspace packages),
+ * collapses `@elizaos/ui/<subpath>` imports to the single built `@elizaos/ui`
+ * package so subpath resolution doesn't depend on the ui package's dist
+ * layout, and redirects a plugin-health subpath import to source since that
+ * package publishes no matching subpath export.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-wallet/src/actions/index.ts
+++ b/plugins/plugin-wallet/src/actions/index.ts
@@ -1,1 +1,2 @@
+/** Barrel re-export for wallet action failure codes. */
 export * from "./failure-codes.js";

--- a/plugins/plugin-wallet/src/analytics/birdeye/actions/wallet-search-address.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/actions/wallet-search-address.ts
@@ -1,3 +1,4 @@
+/** Handler for the WALLET `search_address` subaction: Birdeye wallet/portfolio lookup by address, routed through `TokenInfoService`. */
 import type {
   ActionResult,
   HandlerCallback,

--- a/plugins/plugin-wallet/src/analytics/birdeye/birdeye-task.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/birdeye-task.ts
@@ -1,3 +1,10 @@
+/**
+ * `Birdeye` task runner: periodically syncs a configured wallet's Birdeye
+ * transaction history and portfolio into the agent's cache (`BIRDEYE_WALLET_ADDR`
+ * gates whether `syncWallet` does anything). Waits on `BirdeyeService`'s load
+ * promise before calling it, and merges cached transaction history with fresh
+ * data so cache failures never lose already-synced transactions.
+ */
 import {
   type Content,
   createUniqueUuid,

--- a/plugins/plugin-wallet/src/analytics/birdeye/birdeye.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/birdeye.ts
@@ -1,3 +1,10 @@
+/**
+ * `BirdeyeProvider` — low-level Birdeye REST client covering defi/token/
+ * wallet/trader/pair/search endpoints. Every call is cached via
+ * `runtime.getCache`/`setCache` and retried with a fixed delay on 5xx/429/408/
+ * 503 responses or network failures; non-retryable HTTP errors and exhausted
+ * retries are rethrown.
+ */
 import { elizaLogger, type IAgentRuntime } from "@elizaos/core";
 import {
   API_BASE_URL,
@@ -95,59 +102,8 @@ type FetchParams<T> = T & {
   headers?: Record<string, string>;
 };
 
-// emulate settings from 0.x
 const settings = process.env;
 
-/*
-class BaseCachedProvider {
-    private cache: NodeCache;
-
-    constructor(
-        private cacheManager: ICacheManager,
-        private cacheKey,
-        ttl?: number
-    ) {
-        this.runtime = runtime
-        this.cache = new NodeCache({ stdTTL: ttl || 300 });
-    }
-
-    private readFsCache<T>(key: string): Promise<T | null> {
-        return this.cacheManager.get<T>(path.join(this.cacheKey, key));
-    }
-
-    private writeFsCache<T>(key: string, data: T): Promise<void> {
-        return this.cacheManager.set(path.join(this.cacheKey, key), data, {
-            expires: Date.now() + 5 * 60 * 1000,
-        });
-    }
-
-    public async readFromCache<T>(key: string): Promise<T | null> {
-        // get memory cache first
-        const val = this.cache.get<T>(key);
-        if (val) {
-            return val;
-        }
-
-        const fsVal = await this.readFsCache<T>(key);
-        if (fsVal) {
-            // set to memory cache
-            this.cache.set(key, fsVal);
-        }
-
-        return fsVal;
-    }
-
-    public async writeToCache<T>(key: string, val: T): Promise<void> {
-        // Set in-memory cache
-        this.cache.set(key, val);
-
-        // Write to file-based cache
-        await this.writeFsCache(key, val);
-    }
-}
-*/
-
-// Custom error class for HTTP errors to distinguish from network errors
 class HttpError extends Error {
   constructor(
     public status: number,
@@ -158,26 +114,19 @@ class HttpError extends Error {
   }
 }
 
-// extends BaseCachedProvider
-// really more like a service
 export class BirdeyeProvider {
   private runtime: Pick<IAgentRuntime, "getCache" | "setCache">;
   private maxRetries: number;
 
   constructor(
     runtime: Pick<IAgentRuntime, "getCache" | "setCache">,
-    //cacheManager: ICacheManager,
     _symbolMap?: Record<string, string>,
     maxRetries?: number,
   ) {
-    // super(cacheManager, "birdeye/data")
     this.runtime = runtime;
     this.maxRetries = maxRetries || DEFAULT_MAX_RETRIES;
   }
 
-  /*
-   * COMMON FETCH FUNCTIONS
-   */
   private async fetchWithRetry<T extends BirdeyeApiResponse>(
     url: string,
     options: RequestInit = {},
@@ -236,17 +185,14 @@ export class BirdeyeProvider {
           success: true,
         } as T;
       } catch (error) {
-        // Check if this is an HTTP error (already handled status code logic above)
+        // HttpError retry eligibility is already decided above; a non-retryable
+        // HttpError reaching here must be rethrown as-is.
         if (error instanceof HttpError) {
-          // HTTP errors are only retried if isRetryable was true (handled above)
-          // If we're here, it means it wasn't retryable, so throw
           throw error;
         }
 
-        // Network errors (fetch failures before getting a response) are retryable
-        // This includes: connection failures, DNS errors, timeouts, etc.
+        // Network errors (connection failures, DNS errors, timeouts) are always retryable.
         if (attempts === this.maxRetries) {
-          // Out of retry attempts
           throw error;
         }
 

--- a/plugins/plugin-wallet/src/analytics/birdeye/constants.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/constants.ts
@@ -1,3 +1,8 @@
+/**
+ * Birdeye API constants: retry/backoff tuning, the public API base URL, and
+ * `BIRDEYE_ENDPOINTS` mapping each wrapped endpoint to its path and Birdeye
+ * API reference doc.
+ */
 export const DEFAULT_MAX_RETRIES = 3;
 
 export const BIRDEYE_SERVICE_NAME = "birdeye";

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/agent-portfolio-provider.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/agent-portfolio-provider.ts
@@ -1,13 +1,14 @@
+/**
+ * Agent portfolio data provider that queries the Birdeye API for the agent's
+ * configured wallet address (`BIRDEYE_WALLET_ADDR`). When set, fetches current
+ * token balances and makes compact JSON portfolio context available to the
+ * planner.
+ */
 import {
   createBirdeyePortfolioProvider,
   formatPortfolio,
 } from "./portfolio-factory";
 
-/**
- * Agent portfolio data provider that queries Birdeye API for the agent's wallet address.
- * When a wallet address is set, this provider fetches current token balances and makes
- * compact JSON portfolio context available to the planner.
- */
 export const agentPortfolioProvider = createBirdeyePortfolioProvider({
   name: "BIRDEYE_WALLET_PORTFOLIO",
   description: "Birdeye token balances for the agent wallet",

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/market.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/market.ts
@@ -1,6 +1,9 @@
+/**
+ * `marketProvider` — Birdeye market-overview provider for a fixed set of
+ * Solana tokens (SOL/wBTC/wETH), injecting a compact price/market-cap/
+ * liquidity table into planner context.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
-//import { addHeader, composeActionExamples, formatActionNames, formatActions } from '@elizaos/core';
-//import type { IToken } from '../types';
 import { BIRDEYE_SERVICE_NAME } from "../constants";
 import type { CacheWrapper, GetCacheTimedOptions } from "../types/shared";
 import { formatJsonScalar, formatJsonTable } from "../utils";
@@ -40,30 +43,13 @@ export async function getCacheTimed<T>(
   if (!wrapper) return;
   if (options.notOlderThan) {
     const diff = Date.now() - wrapper.setAt;
-    //console.log('checking notOlderThan', diff + 'ms', 'setAt', wrapper.setAt, 'asking', options.notOlderThan)
     if (diff > options.notOlderThan) {
-      // no data
       return;
     }
   }
-  // return data
   return wrapper.data;
 }
 
-/**
- * Provider for Birdeye market data
- *
- * @type {Provider}
- * @property {string} name - The name of the provider
- * @property {string} description - Description of the provider
- * @property {number} position - The position of the provider
- * @property {Function} get - Asynchronous function to get actions that validate for a given message
- *
- * @param {IAgentRuntime} runtime - The agent runtime
- * @param {Memory} message - The message memory
- * @param {State} state - The state of the agent
- * @returns {Object} Object containing data, values, and text related to actions
- */
 export const marketProvider: Provider = {
   name: "BIRDEYE_CRYPTOCURRENCY_MARKET_DATA",
   description: "Birdeye get latest cryptocurrencies overview",
@@ -74,11 +60,8 @@ export const marketProvider: Provider = {
   cacheStable: false,
   cacheScope: "turn",
   roleGate: { minRole: "USER" },
-  //position: -1,
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     try {
-      //console.log('BIRDEYE_CRYPTOCURRENCY_MARKET_DATA getting');
-
       // Static Solana market addresses used for the Birdeye overview.
       const TOKEN_ADDRESSES = {
         SOL: "So11111111111111111111111111111111111111112",
@@ -92,10 +75,8 @@ export const marketProvider: Provider = {
         "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs": "ETH", // wETH
       };
 
-      // get the market
       const CAs = Object.values(TOKEN_ADDRESSES);
 
-      // get services
       const birdeyeService = runtime.getService(BIRDEYE_SERVICE_NAME) as
         | {
             getTokensMarketData?: (
@@ -105,7 +86,7 @@ export const marketProvider: Provider = {
             ) => Promise<Record<string, MarketTokenSnapshot | undefined>>;
           }
         | undefined;
-      // want this for custom symbols
+      // Solana service, when present, resolves custom token symbols.
       const solanaService = runtime.getService("chain_solana") as
         | {
             getTokensSymbols?: (
@@ -114,7 +95,6 @@ export const marketProvider: Provider = {
           }
         | undefined;
 
-      // Guard Birdeye service before invoking methods
       if (
         !birdeyeService ||
         typeof birdeyeService.getTokensMarketData !== "function"
@@ -133,7 +113,6 @@ export const marketProvider: Provider = {
         };
       }
 
-      // get data
       const tokenSymbolsPromise =
         solanaService && typeof solanaService.getTokensSymbols === "function"
           ? solanaService.getTokensSymbols(CAs)
@@ -149,7 +128,6 @@ export const marketProvider: Provider = {
       const rows: MarketRow[] = [];
 
       for (const ca of CAs) {
-        // Check if result[ca] exists before accessing it
         if (!result[ca]) {
           rows.push({
             chain: "solana",
@@ -169,10 +147,9 @@ export const marketProvider: Provider = {
           t.symbol ??
           hardcodedSolanaCA2SymbolMap[ca] ??
           "(Not available)";
-        // unwrap symbols
+        // Normalize wrapped-asset symbols to their underlying asset.
         if (symbol === "WBTC") symbol = "BTC";
         if (symbol === "WETH") symbol = "ETH";
-        //console.log('t', t)
         rows.push({
           chain: "solana",
           address: ca,
@@ -184,8 +161,6 @@ export const marketProvider: Provider = {
         });
       }
 
-      //console.log('BIRDEYE_CRYPTOCURRENCY_MARKET_DATA - birdye market data text', latestTxt)
-
       const boundedRows = rows.slice(0, MARKET_ROW_LIMIT);
       const data = {
         tokens: Object.fromEntries(
@@ -195,7 +170,6 @@ export const marketProvider: Provider = {
 
       const values = {};
 
-      // Combine all text sections
       const text = [
         "birdeye_market_data:",
         "  status: ok",

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/portfolio-factory.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/portfolio-factory.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `createBirdeyePortfolioProvider` / `formatPortfolio` against
+ * a mocked runtime and mocked Birdeye service (no live API or LLM call):
+ * covers the plain-portfolio provider, the trade-including variant, and
+ * legacy portfolio-wrapper JSON formatting.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { WalletPortfolioResponse } from "../types/api/wallet";

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/portfolio-factory.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/portfolio-factory.ts
@@ -1,3 +1,11 @@
+/**
+ * `createBirdeyePortfolioProvider` builds a Birdeye wallet-portfolio provider
+ * (optionally including recent trades) for a configured `BIRDEYE_WALLET_ADDR`,
+ * used by `agentPortfolioProvider`. `formatPortfolio` renders a portfolio
+ * response as a compact JSON holdings table; both handle legacy
+ * (`{ data: { items } }`) and unwrapped portfolio response shapes. Display
+ * symbols are sanitized before injection into planner context.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { sanitizeWalletDisplayLabel } from "../../../security/wallet-context-safety.js";
 import { BIRDEYE_SERVICE_NAME } from "../constants";

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/trending.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/trending.ts
@@ -1,3 +1,9 @@
+/**
+ * `trendingProvider` — Birdeye trending-token provider, reading cached
+ * per-chain trending snapshots (Solana/Ethereum/Base, populated elsewhere)
+ * and injecting a bounded price/market-cap/volume/liquidity table into
+ * planner context. Skipped entirely when `BIRDEYE_NO_TRENDING=true`.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { formatJsonScalar, formatJsonTable } from "../utils";
 
@@ -43,30 +49,13 @@ export async function getCacheTimed<T>(
   if (!wrapper) return false;
   if (options.notOlderThan) {
     const diff = Date.now() - wrapper.setAt;
-    //console.log('checking notOlderThan', diff + 'ms', 'setAt', wrapper.setAt, 'asking', options.notOlderThan)
     if (diff > options.notOlderThan) {
-      // no data
       return false;
     }
   }
-  // return data
   return wrapper.data;
 }
 
-/**
- * Provider for Birdeye trending coins
- *
- * @type {Provider}
- * @property {string} name - The name of the provider
- * @property {string} description - Description of the provider
- * @property {number} position - The position of the provider
- * @property {Function} get - Asynchronous function to get actions that validate for a given message
- *
- * @param {IAgentRuntime} runtime - The agent runtime
- * @param {Memory} message - The message memory
- * @param {State} state - The state of the agent
- * @returns {Object} Object containing data, values, and text related to actions
- */
 export const trendingProvider: Provider = {
   name: "BIRDEYE_TRENDING_CRYPTOCURRENCY",
   description: "Birdeye's trending cryptocurrencies",
@@ -77,20 +66,9 @@ export const trendingProvider: Provider = {
   cacheStable: false,
   cacheScope: "turn",
   roleGate: { minRole: "USER" },
-  //position: -1,
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     try {
       runtime.logger.log("birdeye:provider:trending - get birdeye");
-      // Get all sentiments
-
-      /*
-      const chains = ['solana', 'eth', 'base'];
-      const tokenData = []
-      for(const chain of chains) {
-        tokenData = [...tokenData, ...(await runtime.getCache<IToken[]>('tokens_' + chain)) || []];
-      }
-      console.log('tokenData', tokenData)
-      */
       const solanaCache = await runtime.getCache<{
         data: TrendingToken[];
         setAt: number;
@@ -110,7 +88,6 @@ export const trendingProvider: Provider = {
         };
       }
       const solanaTokens = solanaCache.data;
-      //console.log('intel:provider - birdeye data', tokens)
       if (!solanaTokens.length) {
         runtime.logger.warn(
           "birdeye:provider:trending - no birdeye token data found",
@@ -125,24 +102,6 @@ export const trendingProvider: Provider = {
           data: {},
         };
       }
-
-      //console.log('birdeye:provider:trending - birdeye token data', tokens)
-      /*
-      name: "Bitcoin",
-      rank: 1,
-      chain: "L1",
-      price: 93768.60351119141,
-      symbol: "BTC",
-      address: "bitcoin",
-      logoURI: "https://s2.coinmarketcap.com/static/img/coins/128x128/1.png",
-      decimals: null,
-      provider: "coinmarketcap",
-      liquidity: null,
-      marketcap: 0,
-      last_updated: "2025-04-23T22:50:00.000Z",
-      volume24hUSD: 43588891208.92652,
-      price24hChangePercent: 1.17760374,
-      */
 
       const rows: TrendingRow[] = [];
 
@@ -160,7 +119,6 @@ export const trendingProvider: Provider = {
       const topSolanaTokens = solanaTokens.slice(0, 33);
       let tokens = [...topSolanaTokens];
 
-      // Try to get supply data if solanaService is available
       let supplies: SupplyMap = {};
       if (solanaService && typeof solanaService.getSupply === "function") {
         try {
@@ -194,8 +152,6 @@ export const trendingProvider: Provider = {
         if (supply) {
           const mcap = supply.multipliedBy(token.price);
           mcapValue = mcap.toFixed(0);
-          //console.log('Hum supply', supply.toFormat(), 'price', token.price, 'mcap', mcap.toFormat(2))
-          //console.log('Mac supply', supply, 'price', token.price, 'mcap', mcap.toFixed(0))
         }
 
         rows.push({
@@ -209,7 +165,6 @@ export const trendingProvider: Provider = {
           liquidityUsd: token.liquidity.toFixed(2),
         });
       }
-      // if in cache, then it's a lot of data, maybe too much
       const ethCache = await runtime.getCache<{
         data: TrendingToken[];
         setAt: number;
@@ -218,19 +173,6 @@ export const trendingProvider: Provider = {
         const ethTokens = ethCache.data.slice(0, 33);
         tokens = [...tokens, ...ethTokens];
         for (const token of ethTokens) {
-          // has a marketcap but seems to always be 0
-          //console.log('token', token)
-          /*
-          const rugKey = 'rugcheck_eth_' + token.address
-          const rugCache = await getCacheTimed(runtime, rugKey, { notOlderThan: 6 * 60 * 60 * 1000 })
-          //console.log('rugKey', rugKey, 'rugCache', rugCache)
-
-          // Damnatio memoriae
-          if (rugCache && rugCache === 'rug') {
-            console.log('omitting', token.address, 'because in rugCache')
-            continue
-          }
-          */
           rows.push({
             chain: "ethereum",
             address: token.address,
@@ -251,19 +193,6 @@ export const trendingProvider: Provider = {
         const baseTokens = baseCache.data.slice(0, 33);
         tokens = [...tokens, ...baseTokens];
         for (const token of baseTokens) {
-          // has a marketcap but seems to always be 0
-          //console.log('token', token)
-          /*
-          const rugKey = 'rugcheck_eth_' + token.address
-          const rugCache = await getCacheTimed(runtime, rugKey, { notOlderThan: 6 * 60 * 60 * 1000 })
-          //console.log('rugKey', rugKey, 'rugCache', rugCache)
-
-          // Damnatio memoriae
-          if (rugCache && rugCache === 'rug') {
-            console.log('omitting', token.address, 'because in rugCache')
-            continue
-          }
-          */
           rows.push({
             chain: "base",
             address: token.address,
@@ -277,45 +206,6 @@ export const trendingProvider: Provider = {
         }
       }
 
-      /*
-      let idx = 1;
-      // maybe filter by active chains
-      const reduceTokens = tokens.map((t) => {
-        const obj = {
-          name: t.name,
-          rank: t.rank,
-          chain: t.chain,
-          priceUsd: t.price,
-          symbol: t.symbol,
-          address: t.address,
-          // skip logo, decimals
-          // liquidity/marketcap are optimal
-          // last_updated
-          volume24hUSD: t.volume24hUSD,
-          price24hChangePercent: t.price24hChangePercent,
-        };
-        // optional fields
-        if (t.liquidity !== null) obj.liquidity = t.liquidity;
-        if (t.marketcap !== 0) obj.marketcap = t.marketcap;
-        return obj;
-      });
-      */
-
-      /*
-      for (const t of tokens) {
-        if (!sentiment?.occuringTokens?.length) continue;
-        sentiments += `ENTRY ${idx}\nTIME: ${sentiment.timeslot}\nTOKEN ANALYSIS:\n`;
-        for (const token of sentiment.occuringTokens) {
-          sentiments += `${token.token} - Sentiment: ${token.sentiment}\n${token.reason}\n`;
-        }
-        latestTxt += '\n-------------------\n';
-        idx++;
-      }
-      */
-      //latestTxt += '\n' + JSON.stringify(reduceTokens) + '\n';
-
-      //console.log('intel:provider - cmc token text', rows)
-
       const boundedRows = rows.slice(0, TRENDING_ROW_LIMIT);
       const data = {
         tokens: tokens.slice(0, TRENDING_ROW_LIMIT),
@@ -323,7 +213,6 @@ export const trendingProvider: Provider = {
 
       const values = {};
 
-      // Combine all text sections
       const text = [
         "birdeye_trending_tokens:",
         "  status: ok",

--- a/plugins/plugin-wallet/src/analytics/birdeye/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/providers/wallet.ts
@@ -1,9 +1,10 @@
+/**
+ * Optional wallet trade provider. Shares wallet, chain, service, error, and
+ * JSON formatting behavior with the agent portfolio provider through the
+ * portfolio factory, additionally including recent trade history.
+ */
 import { createBirdeyePortfolioProvider } from "./portfolio-factory";
 
-/**
- * Optional wallet trade provider. It shares wallet, chain, service, error, and JSON
- * formatting behavior with the agent portfolio provider through the portfolio factory.
- */
 export const tradePortfolioProvider = createBirdeyePortfolioProvider({
   name: "BIRDEYE_TRADE_PORTFOLIO",
   description: "Birdeye wallet portfolio and recent trade history",

--- a/plugins/plugin-wallet/src/analytics/birdeye/search-category.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/search-category.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the Birdeye search-category registration and
+ * `searchBirdeyeTokens` dispatch (symbol vs address mode), against a mocked
+ * runtime and mocked `BirdeyeProvider` fetch methods — no live API calls.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { BirdeyeProvider } from "./birdeye";

--- a/plugins/plugin-wallet/src/analytics/birdeye/search-category.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/search-category.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers the `birdeye_tokens` search category (`registerBirdeyeSearchCategories`)
+ * and implements its dispatch (`searchBirdeyeTokens`): auto-detects symbol vs
+ * contract-address queries, then fans out to Birdeye's search/overview/
+ * market-data/security/trade-data endpoints and renders a compact result table.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { BirdeyeProvider } from "./birdeye";
 import { BIRDEYE_SERVICE_NAME } from "./constants";

--- a/plugins/plugin-wallet/src/analytics/birdeye/service.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `BirdeyeService` market-data methods against a mocked
+ * `fetch` and an in-memory cache map: covers chain-scoped cache hits, cache
+ * writes with timed wrappers, and per-chain header propagation across the
+ * three requests that back single-token market data.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BirdeyeService } from "./service";
 

--- a/plugins/plugin-wallet/src/analytics/birdeye/service.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/service.ts
@@ -1,3 +1,15 @@
+/**
+ * `BirdeyeService` — the registered Birdeye client service (`serviceType:
+ * "birdeye"`). Wraps direct Birdeye REST calls (trending tokens, market data,
+ * security, token search, wallet portfolio/tx history) behind
+ * `resolveCloudRoute`, so requests use a local `BIRDEYE_API_KEY` or fall back
+ * to the Eliza Cloud `/apis/birdeye` proxy. Most lookups are cached via
+ * `runtime.getCache`/`setCache` with per-method TTLs (see `CACHE_DEFAULTS`),
+ * and `getTokensMarketData` batches uncached addresses into groups of 100 to
+ * respect Birdeye's multi-price endpoint limit. `start` also registers a
+ * recurring `BIRDEYE_SYNC_WALLET` task when `BIRDEYE_WALLET_ADDR` is set, and
+ * opportunistically registers Birdeye with `INTEL_DATAPROVIDER` if present.
+ */
 import {
   type RouteSpec,
   resolveCloudRoute,
@@ -45,17 +57,13 @@ export const BIRDEYE_ROUTE_SPEC: RouteSpec = {
   localKeyAuth: { kind: "header", headerName: "X-API-KEY" },
 };
 
-// Cache defaults for backwards compatibility
 const CACHE_DEFAULTS = {
-  // Token trade data cache (30 minutes)
   TOKEN_TRADE_DATA_TTL: 30 * 60 * 1000,
-  // Token security data cache (30 minutes)
   TOKEN_SECURITY_DATA_TTL: 30 * 60 * 1000,
-  // Token price/liquidity cache (30 seconds)
   TOKEN_MARKET_DATA_TTL: 30 * 1000,
 };
 
-// 'solana' | 'base' | 'ethereum'
+/** A Birdeye chain identifier, e.g. `"solana"` | `"base"` | `"ethereum"`. */
 type Chain = string;
 
 type CacheWrapper<T> = {
@@ -241,9 +249,8 @@ export class BirdeyeService extends Service {
     );
   }
 
-  // definitely should take a list of chains
+  /** Solana-only trending cache read; use `getTrendingTokens` for other chains. */
   async getTrending() {
-    //console.log('birdeye needs to get trending data');
     return this.runtime.getCache<IToken[]>(`tokens_solana`);
   }
 
@@ -251,7 +258,6 @@ export class BirdeyeService extends Service {
     chain: Chain,
     options?: { notOlderThan?: number; total?: number },
   ): Promise<CacheWrapper<IToken[]>> {
-    // Validate chain using extractChain
     let validatedChain: BirdeyeSupportedChain;
     try {
       validatedChain = extractChain(undefined, chain);
@@ -297,7 +303,6 @@ export class BirdeyeService extends Service {
     );
 
     const birdeyeFetchOptions: RequestInit = this.getBirdeyeFetchOptions(chain);
-    // Build all offset requests inline (no inner function)
     const settled = await Promise.allSettled(
       OFFSETS.map(async (offset) => {
         const res = await fetch(
@@ -369,8 +374,6 @@ export class BirdeyeService extends Service {
     return output;
   }
 
-  // options.depth 5
-  // options.notOlderThanMsecs
   async getTrendingTokens(
     chains: Chain[],
     options?: { notOlderThan?: number },
@@ -380,11 +383,10 @@ export class BirdeyeService extends Service {
         chains.map((chain) => this.getTrendingTokensForChain(chain, options)),
       );
 
-      // key output per chain - unwrap CacheWrapper to get IToken[] arrays
       const out: Record<string, IToken[]> = {};
       for (const i in chains) {
         const c = chains[i];
-        out[c] = results[i].data; // Extract data from CacheWrapper<IToken[]>
+        out[c] = results[i].data;
       }
 
       return out;
@@ -443,7 +445,6 @@ export class BirdeyeService extends Service {
         this.runtime.logger.warn(
           `getTokenMarketData - cant save result for ${tokenAddress}: ${JSON.stringify(data)}`,
         );
-        //logger.warn('getTokenMarketData - cant save result', data, 'for', tokenAddress);
         return false;
       }
 
@@ -460,39 +461,10 @@ export class BirdeyeService extends Service {
       this.runtime.logger.error(
         `Error fetching token market data: ${error instanceof Error ? error.message : String(error)}`,
       );
-      //this.runtime.logger.error({ error },'Error fetching token market data:');
       return false;
     }
   }
 
-  // we can do singles
-
-  // Token - Market Data (Multiple) max 20 (BUSINESS $700/mo)
-  // https://public-api.birdeye.so/defi/v3/token/market-data/multiple
-  // liq,price,supply, circulating,fdv,mcap
-
-  // Token - Trade Data (Multiple) max 20 (BUSINESS $700/mo)
-  // https://public-api.birdeye.so/defi/v3/token/trade-data/multiple
-  // has a lot of data
-
-  /*
-  async getTokensTradeData(chain: string, tokenAddresses: string[]): Promise<unknown> {
-    const tokenDb: Record<string, unknown> = {};
-    const chunkArray = (arr: string[], size: number) =>
-      arr.map((_, i) => (i % size === 0 ? arr.slice(i, i + size) : null)).filter(Boolean);
-    const twenties = chunkArray(tokenAddresses, 20);
-    const multipricePs = twenties.map((addresses) => {
-      const listStr = addresses.join(',');
-      return fetch(
-        `${this.birdeyeUrl('defi/v3/token/trade-data/multiple')}`,
-        this.getBirdeyeFetchOptions('solana')
-      );
-    });
-  }
-  */
-
-  // https://public-api.birdeye.so/defi/token_overview might be a better target
-  // what does this provide? 24h volume
   async getTokenTradeData(
     chain: string,
     tokenAddress: string,
@@ -504,7 +476,6 @@ export class BirdeyeService extends Service {
     const notOlderThan =
       options.notOlderThan ?? CACHE_DEFAULTS.TOKEN_TRADE_DATA_TTL;
 
-    // Check cache
     const cached = await this.getCacheTimed<TokenTradeDataSingleResponse>(key, {
       notOlderThan,
     });
@@ -512,7 +483,6 @@ export class BirdeyeService extends Service {
       return cached;
     }
 
-    // Fetch fresh data
     try {
       const resp = await fetch(
         `${this.birdeyeUrl("defi/v3/token/trade-data/single")}?address=${tokenAddress}&frames=${frames}`,
@@ -531,47 +501,12 @@ export class BirdeyeService extends Service {
     }
   }
 
-  // [Defi] Price Volume - Multi max 50 (premium $200/mo)
-  // https://public-api.birdeye.so/defi/price_volume/multi
-  // getting 500s
-  /*
-  async getTokensPriceVolume(tokenAddresses: string[], type = '24h'): Promise<unknown> {
-    const tokenDb: Record<string, unknown> = {};
-    const chunkArray = (arr: string[], size: number) =>
-      arr.map((_, i) => (i % size === 0 ? arr.slice(i, i + size) : null)).filter(Boolean);
-    const fities = chunkArray(tokenAddresses, 50);
-    this.runtime.logger?.debug(`getTokensPriceVolume - batches: ${fities.length}`);
-
-    // not sure we want to do this with rate limits...
-    const multipricePs = fities.map((addresses) => {
-      const listStr = addresses.join(',');
-      this.runtime.logger?.debug(`getTokensPriceVolume - batch addresses: ${listStr}`);
-      return fetch(
-        `${this.birdeyeUrl('defi/price_volume/multi')}?list_address=${listStr}&type=${type}`,
-        {...this.getBirdeyeFetchOptions('solana'), method: 'POST' }
-      );
-    });
-    const multipriceResps = await Promise.all(multipricePs); // wait for the requests to finish
-    const multipriceData = await Promise.all(
-      multipriceResps.map(async (resp) => {
-        if (!resp.ok) {
-          const text = await resp.text();
-          this.runtime.logger?.error(`API error: ${resp.status} - ${text}`);
-          return undefined;
-        }
-        return resp.json();
-      })
-    );
-
-    for (const mpd of multipriceData) {
-      this.runtime.logger?.debug('getTokensPriceVolume - response:', mpd);
-    }
-  }
-  */
-
-  // [Defi] Price - Multiple max 100 (all)
-  // https://public-api.birdeye.so/defi/multi_price
-  // Batch CU Cost = N^0.8 × 5 (base cost of a single call) (n_max: 100)
+  /**
+   * Fetches `[Defi] Price - Multiple` (`defi/multi_price`, max 100 addresses
+   * per call; Batch CU cost = N^0.8 × 5). Uncached addresses are chunked into
+   * batches of 100; a failed batch caches every address in it as `undefined`
+   * data rather than leaving them uncached.
+   */
   async getTokensMarketData(
     chain: string,
     tokenAddresses: string[],
@@ -626,9 +561,7 @@ export class BirdeyeService extends Service {
           .filter((chunk): chunk is string[] => chunk !== null);
 
       const hundos = chunkArray(uncachedAddresses, 100);
-      //console.log('getTokensMarketData hundos', hundos)
 
-      // Track batches with their addresses for cache management
       const batchesWithAddresses = hundos
         .map((addresses) => {
           if (addresses !== null) {
@@ -657,13 +590,10 @@ export class BirdeyeService extends Service {
         ),
       );
 
-      //const now = Date.now()
-
       for (let i = 0; i < multipriceData.length; i++) {
         const mpd = multipriceData[i];
         const batchAddresses = batchesWithAddresses[i].addresses;
 
-        // Guard against undefined/null mpd or missing data
         if (!mpd?.data || !mpd.success) {
           this.runtime.logger.warn(
             `birdeye:getTokensMarketData - batch failed (${batchAddresses.length} addresses), caching all as failed`,
@@ -680,26 +610,11 @@ export class BirdeyeService extends Service {
           continue;
         }
 
-        // Process data from successful batch
         for (const ca of batchAddresses) {
           const t = mpd.data[ca];
 
           if (t && typeof t.value === "number") {
-            /*
-            t {
-              isScaledUiToken: false,
-              value: 0.011726789622156722,
-              updateUnixTime: 1751591014,
-              updateHumanTime: "2025-07-04T01:03:34",
-              priceInNative: 0.00007683147650766234,
-              priceChange24h: -12.453478899440487,
-              liquidity: 1323844.6216610295,
-            }
-            */
             const marketSnapshot: BirdeyeTokenMarketSnapshot = {
-              //provider: 'birdeye',
-              //chain: 'solana',
-              //address: ca,
               priceUsd: t.value,
               priceSol: t.priceInNative,
               liquidity: t.liquidity ?? 0,
@@ -710,7 +625,6 @@ export class BirdeyeService extends Service {
                 t.mc,
                 t.realMc,
               ),
-              //volume24hUSD
             };
             tokenDb[ca] = marketSnapshot;
             this.runtime.logger.debug(
@@ -724,7 +638,6 @@ export class BirdeyeService extends Service {
               setAt: tsInMs,
             });
           } else {
-            // Token was in batch but has no valid data (or not in response)
             this.runtime.logger.warn(
               `${ca} no valid data in response: ${JSON.stringify(t)}`,
             );
@@ -743,13 +656,10 @@ export class BirdeyeService extends Service {
       this.runtime.logger.error(
         `Error fetching multiple tokens market data: ${error instanceof Error ? error.message : String(error)}`,
       );
-      //this.runtime.logger.error({ error }, 'Error fetching multiple tokens market data:', error);
       return tokenDb;
     }
   }
 
-  // Token - Security (single) all
-  // https://public-api.birdeye.so/defi/token_security
   async getTokenSecurityData(
     chain: string,
     tokenAddress: string,
@@ -760,7 +670,6 @@ export class BirdeyeService extends Service {
     const notOlderThan =
       options.notOlderThan ?? CACHE_DEFAULTS.TOKEN_SECURITY_DATA_TTL;
 
-    // Check cache
     const cached = await this.getCacheTimed<TokenSecurityResponse>(key, {
       notOlderThan,
     });
@@ -768,7 +677,6 @@ export class BirdeyeService extends Service {
       return cached;
     }
 
-    // Fetch fresh data
     try {
       const resp = await fetch(
         `${this.birdeyeUrl("defi/token_security")}?address=${tokenAddress}`,
@@ -787,14 +695,6 @@ export class BirdeyeService extends Service {
     }
   }
 
-  /*
-  async getToken(chain, ca) {
-    console.log('birdeye:srv getToken', chain, ca)
-    return getTokenMarketData(ca)
-  }
-  */
-
-  // lookup token
   async lookupToken(
     chain: string,
     ca: string,
@@ -803,9 +703,8 @@ export class BirdeyeService extends Service {
     try {
       const key = `birdeye_token_${chain}_${ca}`;
       const tsInMs = options.tsInMs ?? Date.now(); // only syscall if absolutely needed
-      const notOlderThan = options.notOlderThan ?? 30 * 1000; // a reasonable length (in ms)
+      const notOlderThan = options.notOlderThan ?? 30 * 1000;
 
-      // check cache
       const cache = await this.getCacheTimed<BirdeyeTokenMarketSnapshot>(key, {
         notOlderThan,
       });
@@ -835,14 +734,13 @@ export class BirdeyeService extends Service {
     options: GetCacheTimedOptions = {},
   ): Promise<Record<string, BirdeyeTokenMarketSnapshot | undefined>> {
     try {
-      // Lookup all tokens in parallel
       const results = await Promise.all(
         chainAndAddresses.map((cAA) =>
           this.lookupToken(cAA.chain, cAA.address, options),
         ),
       );
 
-      // Transform results into keyed object: key = `${chain}_${address}`
+      // Keyed by `${chain}_${address}`.
       const keyedResults: Record<
         string,
         BirdeyeTokenMarketSnapshot | undefined
@@ -880,12 +778,10 @@ export class BirdeyeService extends Service {
     symbol: string,
     options: GetCacheTimedOptions = {},
   ): Promise<TokenMarketSearchResponse["data"]["items"] | false> {
-    // set up cache
     const key = `birdeye_symbol_${symbol}`;
     const tsInMs = options.tsInMs ?? Date.now();
     const notOlderThan = options.notOlderThan ?? 30 * 1000;
 
-    // check cache
     const cache = await this.getCacheTimed<
       TokenMarketSearchResponse["data"]["items"]
     >(key, { notOlderThan });
@@ -907,18 +803,16 @@ export class BirdeyeService extends Service {
     return data;
   }
 
+  /** Fetches the wallet's entire token portfolio. */
   async fetchWalletTokenList(
     chain: BirdeyeSupportedChain,
     publicKey: string,
     options: GetCacheTimedOptions = {},
   ): Promise<WalletPortfolioResponse["data"] | false> {
-    // Get entire portfolio
-    // set up cache
     const key = `birdeye_walletTokenList_${chain}_${publicKey}`;
     const tsInMs = options.tsInMs ?? Date.now();
     const notOlderThan = options.notOlderThan ?? 30 * 1000;
 
-    // check cache
     const cache = await this.getCacheTimed<WalletPortfolioResponse["data"]>(
       key,
       { notOlderThan },
@@ -926,7 +820,6 @@ export class BirdeyeService extends Service {
     if (cache) {
       return cache;
     }
-    // get data
     const birdeyeFetchOptions: RequestInit = this.getBirdeyeFetchOptions(chain);
     const res = await fetch(
       `${this.birdeyeUrl("v1/wallet/token_list")}?wallet=${publicKey}`,
@@ -946,19 +839,16 @@ export class BirdeyeService extends Service {
     publicKey: string,
     options: GetCacheTimedOptions = {},
   ): Promise<WalletTransaction[] | false> {
-    // set up cache
     const key = `birdeye_walletTxList_${chain}_${publicKey}`;
     const tsInMs = options.tsInMs ?? Date.now();
     const notOlderThan = options.notOlderThan ?? 30 * 1000;
 
-    // check cache
     const cache = await this.getCacheTimed<WalletTransaction[]>(key, {
       notOlderThan,
     });
     if (cache) {
       return cache;
     }
-    // get data
     const birdeyeFetchOptions: RequestInit = this.getBirdeyeFetchOptions(chain);
     const res = await fetch(
       `${this.birdeyeUrl("v1/wallet/tx_list")}?wallet=${publicKey}&limit=100`,
@@ -1087,13 +977,10 @@ export class BirdeyeService extends Service {
     if (options.notOlderThan) {
       const now = options.tsInMs ?? Date.now();
       const diff = now - wrapper.setAt;
-      //console.log('checking notOlderThan', diff + 'ms', 'setAt', wrapper.setAt, 'asking', options.notOlderThan)
       if (diff > options.notOlderThan) {
-        // no data
         return false;
       }
     }
-    // return data
     return wrapper.data;
   }
 

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/api/common.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/api/common.ts
@@ -1,3 +1,10 @@
+/**
+ * Cross-cutting Birdeye API types: `BirdeyeApiParams`, the union of every
+ * endpoint's request params (used to type the shared fetch/cache helpers),
+ * the generic response wrapper, the shared `TimeInterval` enum, and the
+ * verbose `TokenTradeData` shape (per-window trade/volume/wallet stats at
+ * 30m/1h/2h/4h/8h/24h granularity, mirroring Birdeye's flat field naming).
+ */
 import type {
   BaseQuoteParams,
   DefiHistoryPriceParams,

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/api/defi.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/api/defi.ts
@@ -1,3 +1,4 @@
+/** Request/response types for Birdeye's `defi/*` endpoints (networks, price, multi-price, history, OHLCV, trades, base-quote). */
 import type { TimeInterval } from "./common";
 
 // Network Types

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/api/pair.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/api/pair.ts
@@ -1,6 +1,10 @@
+/**
+ * Request/response shapes for Birdeye's per-pair endpoints: recent trades,
+ * OHLCV candles, and single/multi pair overview (liquidity, volume, and trade
+ * counts bucketed across several trailing windows).
+ */
 import type { TimeInterval } from "./common";
 
-// Pair Trades Types
 export interface PairTradesParams {
   pair: string;
   limit?: number;
@@ -32,7 +36,6 @@ export interface PairTradesResponse {
   };
 }
 
-// OHLCV Pair Types
 export interface OHLCVPairParams {
   address: string;
   type?: TimeInterval;
@@ -56,7 +59,6 @@ export interface OHLCVPairResponse {
   };
 }
 
-// Pair Overview Types
 export interface PairOverviewMultiParams {
   list_address: string;
   before_time?: number;

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/api/search.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/api/search.ts
@@ -1,6 +1,6 @@
+/** Request/response shapes for Birdeye's combined token+market search endpoint. */
 import type { BirdeyeSupportedChain } from "../shared";
 
-// Search Types
 export interface TokenMarketSearchParams {
   chain?: BirdeyeSupportedChain | "all";
   keyword?: string;

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/api/token.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/api/token.ts
@@ -1,6 +1,6 @@
+/** Request/response shapes for Birdeye's per-token endpoints: trades, listings, security, overview, creation info, trending, metadata, market data/stats, holders, mint/burn events, new listings, top traders, markets, and volume-by-owner. */
 import type { TimeInterval, TokenTradeData } from "./common";
 
-// Token Trades Types
 export interface TokenTradesParams {
   address: string;
   limit?: number;
@@ -41,7 +41,6 @@ export interface TokenListParams {
   min_liquidity?: number;
 }
 
-// Token List Types
 export interface TokenListResponse {
   success: boolean;
   data: {
@@ -59,7 +58,6 @@ export interface TokenListResponse {
   };
 }
 
-// Token Security Types
 export interface TokenSecurityParams {
   address: string;
 }
@@ -98,7 +96,6 @@ export interface TokenSecurityResponse {
   };
 }
 
-// Token Overview Types
 export interface TokenOverviewParams {
   address: string;
 }
@@ -314,7 +311,6 @@ export interface TokenOverviewResponse {
   };
 }
 
-// Token Creation Info Types
 export interface TokenCreationInfoParams {
   address: string;
 }
@@ -339,7 +335,6 @@ export interface TokenTrendingParams {
   limit?: number;
 }
 
-// Token Trending Types
 export interface TokenTrendingResponse {
   success: boolean;
   data: {
@@ -360,7 +355,6 @@ export interface TokenTrendingResponse {
   };
 }
 
-// Token List V2 Types
 export interface TokenListV2Params {
   offset?: number;
   limit?: number;
@@ -409,7 +403,6 @@ export interface TokenTradeDataMultiResponse {
   };
 }
 
-// Token Metadata Single Types
 export interface TokenMetadataSingleParams {
   address: string;
 }
@@ -432,7 +425,6 @@ export interface TokenMetadataSingleResponse {
   };
 }
 
-// Token Market Data Types
 export interface TokenMarketDataParams {
   address: string;
 }
@@ -450,7 +442,6 @@ export interface TokenMarketDataResponse {
   };
 }
 
-// Token Trade Data Single Types
 export interface TokenTradeDataSingleParams {
   address: string;
 }
@@ -460,7 +451,6 @@ export interface TokenTradeDataSingleResponse {
   data: TokenTradeData;
 }
 
-// Token Market Stats Types
 export interface TokenMarketStatsResponse {
   success: boolean;
   data: {
@@ -474,7 +464,6 @@ export interface TokenMarketStatsResponse {
   };
 }
 
-// Token Holders Types
 export interface TokenHoldersParams {
   address: string;
   offset?: number;
@@ -495,7 +484,6 @@ export interface TokenHoldersResponse {
   };
 }
 
-// Token Mint Burn Types
 export interface MintBurnParams {
   address: string;
   sort_by: "block_time";
@@ -526,7 +514,6 @@ export interface MintBurnResponse {
   };
 }
 
-// New Listing Types
 export interface NewListingParams {
   time_to: number;
   meme_platform_enabled: boolean;
@@ -549,7 +536,6 @@ export interface NewListingResponse {
   };
 }
 
-// Top Traders Types
 export interface TopTradersParams {
   address: string;
   time_frame?: TimeInterval;
@@ -572,7 +558,6 @@ export interface TopTradersResponse {
   };
 }
 
-// All Markets Types
 export interface AllMarketsParams {
   address: string;
   time_frame: TimeInterval;
@@ -614,7 +599,6 @@ export interface AllMarketsResponse {
   };
 }
 
-// Token Volume By Owner Types
 export interface TokenVolumeByOwnerResponse {
   success: boolean;
   data: {

--- a/plugins/plugin-wallet/src/analytics/birdeye/types/shared.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/types/shared.ts
@@ -1,6 +1,6 @@
+/** Chain/address/cache/token shared types used across the Birdeye client and its providers. */
 import type { BIRDEYE_SUPPORTED_CHAINS } from "../utils";
 
-// Types
 export type BirdeyeSupportedChain = (typeof BIRDEYE_SUPPORTED_CHAINS)[number];
 
 export interface BaseAddress {
@@ -22,7 +22,7 @@ export interface ContractAddress extends BaseAddress {
   type: "contract";
 }
 
-// Shape of what's stored in the cache
+/** Shape of what's stored in the cache. */
 export interface CacheWrapper<T> {
   data: T;
   /** Unix ms timestamp when the entry was set */
@@ -36,24 +36,7 @@ export interface GetCacheTimedOptions {
   tsInMs?: number;
 }
 
-/**
- * Interface representing a token with various properties.
- * @typedef { object } IToken
- * @property { TDataProvider } provider - The data provider of the token.
- * @property { TChain } chain - The blockchain the token belongs to.
- * @property { string } address - The address of the token.
- * @property { number } decimals - The number of decimal places for the token.
- * @property { number } liquidity - The liquidity of the token.
- * @property { number } marketcap - The market cap of the token.
- * @property { string } logoURI - The URI for the token's logo.
- * @property { string } name - The name of the token.
- * @property { string } symbol - The symbol of the token.
- * @property { number } volume24hUSD - The 24-hour trading volume in USD.
- * @property { number } rank - The rank of the token.
- * @property { number } price - The current price of the token.
- * @property { number } price24hChangePercent - The percentage change in price over the last 24 hours.
- * @property { Date } last_updated - The date when the token data was last updated.
- */
+/** Normalized token descriptor merged from a Birdeye data provider response. */
 export interface IToken {
   provider: string;
   chain: BirdeyeSupportedChain;
@@ -71,24 +54,12 @@ export interface IToken {
   last_updated: Date;
 }
 
-/**
- * Interface representing a transaction history entry.
- * @property {string} txHash - The hash of the transaction.
- * @property {Date} blockTime - The time when the transaction occurred.
- * @property {any} data - Additional data related to the transaction.
- */
 export interface TransactionHistory {
   txHash: string;
   blockTime: Date;
   data: unknown;
 }
 
-/**
- * Interface representing a Portfolio object.
- * @typedef {Object} Portfolio
- * @property {string} key - The key associated with the portfolio.
- * @property {any} data - The data contained in the portfolio.
- */
 export interface Portfolio {
   key: string;
   data: unknown;

--- a/plugins/plugin-wallet/src/analytics/birdeye/utils.test.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/utils.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Birdeye analytics formatting + intent extraction. These render financial
+ * figures shown to the user and parse the result limit from free text, so the
+ * suffix thresholds, sign handling, and clamping are pinned.
+ */
 import { describe, expect, it } from "vitest";
 import {
   extractLimit,
@@ -6,12 +11,6 @@ import {
   formatValue,
   shortenAddress,
 } from "./utils.js";
-
-/**
- * Birdeye analytics formatting + intent extraction. These render financial
- * figures shown to the user and parse the result limit from free text, so the
- * suffix thresholds, sign handling, and clamping are pinned.
- */
 
 describe("formatValue", () => {
   it("scales to K/M/B with a $ prefix, N/A for falsy", () => {

--- a/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Birdeye client support: supported-chain/alias tables, address/timeframe/limit
+ * extraction from free-form user text, response formatting for chat display,
+ * and the shared `fetch` wrapper (`makeApiRequest`) used by the Birdeye service.
+ */
 import { logger } from "@elizaos/core";
 import { sanitizeWalletDisplayLabel } from "../../security/wallet-context-safety.js";
 import type { BirdeyeApiParams } from "./types/api/common";
@@ -8,7 +13,6 @@ import type {
 import type { TokenMetadataSingleResponse } from "./types/api/token";
 import type { BaseAddress, BirdeyeSupportedChain } from "./types/shared";
 
-// Constants
 export const BASE_URL = "https://public-api.birdeye.so";
 
 export const BIRDEYE_SUPPORTED_CHAINS = [
@@ -25,44 +29,23 @@ export const BIRDEYE_SUPPORTED_CHAINS = [
   "evm", // EVM-compatible chains but we don't know the chain
 ] as const;
 
-// Chain abbreviations and alternative names mapping
+/** Maps common chain abbreviations/alternative names to a canonical Birdeye chain id. */
 export const CHAIN_ALIASES: Record<string, BirdeyeSupportedChain> = {
-  // Solana
   sol: "solana",
-
-  // Ethereum
   eth: "ethereum",
   ether: "ethereum",
-
-  // Arbitrum
   arb: "arbitrum",
   arbitrumone: "arbitrum",
-
-  // Avalanche
   avax: "avalanche",
-
-  // BSC
   bnb: "bsc",
   binance: "bsc",
   "binance smart chain": "bsc",
-
-  // Optimism
   op: "optimism",
   opti: "optimism",
-
-  // Polygon
   matic: "polygon",
   poly: "polygon",
-
-  // Base
-  // no common abbreviations
-
-  // zkSync
   zks: "zksync",
   zk: "zksync",
-
-  // Sui
-  // no common abbreviations
 } as const;
 
 export class BirdeyeApiError extends Error {
@@ -81,7 +64,6 @@ export interface ApiResponse<T> {
   error?: string;
 }
 
-// Time-related types and constants
 export const TIME_UNITS = {
   second: 1,
   minute: 60,
@@ -109,22 +91,18 @@ export const TIMEFRAME_KEYWORDS = {
 export type TimeUnit = keyof typeof TIME_UNITS;
 export type Timeframe = keyof typeof TIMEFRAME_KEYWORDS;
 
-// Helper functions
 /**
- * Extract blockchain chain from address with optional explicit chain setting
- * @param text - The wallet address to analyze (optional if explicitChain is provided)
- * @param explicitChain - Optional explicit chain specification (from BIRDEYE_CHAIN setting)
- * @returns The detected or specified chain
- * @throws Error if address format is invalid or EVM address without explicit chain
+ * Detects the chain for an address, preferring an explicit chain/alias
+ * (from the `BIRDEYE_CHAIN` setting) when given. Throws for an unrecognized
+ * explicit chain, an empty address, or an EVM-shaped address with no explicit
+ * chain (since the 0x format alone can't disambiguate the EVM chain).
  */
 export const extractChain = (
   text?: string,
   explicitChain?: string,
 ): BirdeyeSupportedChain => {
-  // First, check for explicit chain setting
   if (explicitChain) {
     const normalizedChain = explicitChain.toLowerCase();
-    // Check if it's a valid chain or alias
     if (
       BIRDEYE_SUPPORTED_CHAINS.includes(
         normalizedChain as BirdeyeSupportedChain,
@@ -234,15 +212,12 @@ export const extractAddresses = (text: string): BaseAddress[] => {
   return addresses;
 };
 
-// Time extraction and analysis
 export const extractTimeframe = (text: string): Timeframe => {
-  // First, check for explicit timeframe mentions
   const timeframe = Object.keys(TIMEFRAME_KEYWORDS).find((tf) =>
     text.toLowerCase().includes(tf.toLowerCase()),
   );
   if (timeframe) return timeframe as Timeframe;
 
-  // Check for semantic timeframe hints
   const semanticMap = {
     "short term": "15m",
     "medium term": "1h",
@@ -261,18 +236,16 @@ export const extractTimeframe = (text: string): Timeframe => {
     }
   }
 
-  // Analyze for time-related words
   if (text.match(/minute|min|minutes/i)) return "15m";
   if (text.match(/hour|hourly|hours/i)) return "1h";
   if (text.match(/day|daily|24h/i)) return "1d";
   if (text.match(/week|weekly/i)) return "1w";
 
-  // Default based on context
   if (text.match(/trade|trades|trading|recent/i)) return "15m";
   if (text.match(/trend|analysis|analyze/i)) return "1h";
   if (text.match(/history|historical|long|performance/i)) return "1d";
 
-  return "1h"; // Default timeframe
+  return "1h";
 };
 
 export const extractTimeRange = (
@@ -280,7 +253,6 @@ export const extractTimeRange = (
 ): { start: number; end: number } => {
   const now = Math.floor(Date.now() / 1000);
 
-  // Check for specific date ranges
   const dateRangeMatch = text.match(
     /from\s+(\d{4}-\d{2}-\d{2})\s+to\s+(\d{4}-\d{2}-\d{2})/i,
   );
@@ -290,7 +262,6 @@ export const extractTimeRange = (
     return { start, end };
   }
 
-  // Check for relative time expressions
   const timeRegex = /(\d+)\s*(second|minute|hour|day|week|month)s?\s*ago/i;
   const match = text.match(timeRegex);
   if (match) {
@@ -300,7 +271,6 @@ export const extractTimeRange = (
     return { start, end: now };
   }
 
-  // Check for semantic time ranges
   const semanticRanges: Record<string, number> = {
     today: TIME_UNITS.day,
     "this week": TIME_UNITS.week,
@@ -319,43 +289,37 @@ export const extractTimeRange = (
     }
   }
 
-  // Analyze context for appropriate default range
   if (text.match(/trend|analysis|performance/i)) {
-    return { start: now - TIME_UNITS.week, end: now }; // 1 week for analysis
+    return { start: now - TIME_UNITS.week, end: now };
   }
   if (text.match(/trade|trades|trading|recent/i)) {
-    return { start: now - TIME_UNITS.day, end: now }; // 1 day for trading
+    return { start: now - TIME_UNITS.day, end: now };
   }
   if (text.match(/history|historical|long term/i)) {
-    return { start: now - TIME_UNITS.month, end: now }; // 1 month for history
+    return { start: now - TIME_UNITS.month, end: now };
   }
 
-  // Default to last 24 hours
   return { start: now - TIME_UNITS.day, end: now };
 };
 
 export const extractLimit = (text: string): number => {
-  // Check for explicit limit mentions
   const limitMatch = text.match(/\b(show|display|get|fetch|limit)\s+(\d+)\b/i);
   if (limitMatch) {
     const limit = Number.parseInt(limitMatch[2], 10);
-    return Math.min(Math.max(limit, 1), 100); // Clamp between 1 and 100
+    return Math.min(Math.max(limit, 1), 100);
   }
 
-  // Check for semantic limit hints
   if (text.match(/\b(all|everything|full|complete)\b/i)) return 100;
   if (text.match(/\b(brief|quick|summary|overview)\b/i)) return 5;
   if (text.match(/\b(detailed|comprehensive)\b/i)) return 50;
 
-  // Default based on context
   if (text.match(/\b(trade|trades|trading)\b/i)) return 10;
   if (text.match(/\b(analysis|analyze|trend)\b/i)) return 24;
   if (text.match(/\b(history|historical)\b/i)) return 50;
 
-  return 10; // Default limit
+  return 10;
 };
 
-// Formatting helpers
 export const formatValue = (value?: number): string => {
   if (!value) return "N/A";
   if (value && value >= 1_000_000_000) {
@@ -425,7 +389,6 @@ export const formatJsonTable = (
   return lines.join("\n");
 };
 
-// API helpers
 export async function makeApiRequest<T>(
   url: string,
   options: {
@@ -474,7 +437,6 @@ export async function makeApiRequest<T>(
   }
 }
 
-// Formatting helpers
 export const formatTokenInfo = (
   token: TokenResult,
   metadata?: TokenMetadataSingleResponse,
@@ -524,7 +486,6 @@ export const formatTokenInfo = (
     `🔄 Trades: ${trades}\n` +
     `🔗 Address: ${token.address}`;
 
-  // Add metadata if available
   if (metadata?.success) {
     const { extensions } = metadata.data;
     const links: string[] = [];
@@ -548,7 +509,6 @@ export const formatTokenInfo = (
   return output;
 };
 
-// Extract symbols from text
 export const extractSymbols = (
   text: string,
   // loose mode will try to extract more symbols but may include false positives
@@ -558,7 +518,6 @@ export const extractSymbols = (
   if (!text.matchAll) return [];
   const symbols = new Set<string>();
 
-  // Match patterns
   const patterns =
     mode === "strict"
       ? [
@@ -570,16 +529,15 @@ export const extractSymbols = (
           /\$([A-Z0-9]{2,10})\b/gi,
           // After articles (a/an)
           /\b(?:a|an)\s+([A-Z0-9]{2,10})\b/gi,
-          // // Standalone caps
+          // Standalone caps
           /\b[A-Z0-9]{2,10}\b/g,
-          // // Quoted symbols
+          // Quoted symbols
           /["']([A-Z0-9]{2,10})["']/gi,
-          // // Common price patterns
+          // Common price patterns
           /\b([A-Z0-9]{2,10})\/USD\b/gi,
           /\b([A-Z0-9]{2,10})-USD\b/gi,
         ];
 
-  // Extract all matches
   patterns.forEach((pattern) => {
     const matches = Array.from(text.matchAll(pattern));
     for (const match of matches) {
@@ -626,7 +584,6 @@ export const formatMetadataResponse = (
 
   let response = `Token Metadata for ${tokenData.name} (${tokenData.symbol}) on ${chainName}\n\n`;
 
-  // Basic Information
   response += "📝 Basic Information\n";
   response += `• Name: ${tokenData.name}\n`;
   response += `• Symbol: ${tokenData.symbol}\n`;
@@ -636,11 +593,9 @@ export const formatMetadataResponse = (
     response += `• Explorer: [View on ${chainName} Explorer](${chainExplorer})\n`;
   }
 
-  // Social Links
   response += "\n🔗 Social Links & Extensions\n";
   response += `${formatSocialLinks(tokenData)}\n`;
 
-  // Logo
   if (tokenData.logo_uri) {
     response += "\n🖼️ Logo\n";
     response += tokenData.logo_uri;

--- a/plugins/plugin-wallet/src/analytics/dexscreener/errors.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/errors.ts
@@ -1,3 +1,4 @@
+/** Error-message normalization for DexScreener HTTP/fetch failures. */
 interface DexScreenerFetchErr {
   readonly response?: { readonly data?: { readonly message?: string } };
   readonly message?: string;

--- a/plugins/plugin-wallet/src/analytics/dexscreener/index.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the DexScreener analytics submodule (search-category registration, service, types). */
 export { registerDexScreenerSearchCategory } from "./search-category";
 export { DexScreenerService } from "./service";
 export * from "./types";

--- a/plugins/plugin-wallet/src/analytics/dexscreener/search-category.test.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/search-category.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Covers `registerDexScreenerSearchCategory` idempotency and registered
+ * metadata against a mocked `IAgentRuntime` (no real search-category registry).
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-wallet/src/analytics/dexscreener/search-category.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/search-category.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers DexScreener as a search category so the runtime's generic search
+ * surface can dispatch token/pair queries to `DexScreenerService`.
+ * `registerDexScreenerSearchCategory` is idempotent — safe to call on every
+ * plugin init.
+ */
 import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const DEXSCREENER_SEARCH_CATEGORY: SearchCategoryRegistration = {

--- a/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
+++ b/plugins/plugin-wallet/src/analytics/dexscreener/service.ts
@@ -1,3 +1,12 @@
+/**
+ * DexScreener HTTP client (`Service` of type `"dexscreener"`): pair/token
+ * search, trending/new-pair discovery, boosted tokens, and price/order
+ * lookups. Several methods are proxies over endpoints DexScreener doesn't
+ * expose directly (trending, new pairs) — see inline notes per method.
+ * Resolves its base URL + auth headers from Eliza Cloud routing when no
+ * direct `DEXSCREENER_API_URL` is configured, and self rate-limits between
+ * requests via `DEXSCREENER_RATE_LIMIT_DELAY`.
+ */
 import {
   cloudServiceApisBaseUrl,
   toRuntimeSettings,
@@ -197,18 +206,16 @@ export class DexScreenerService extends Service {
     try {
       await this.rateLimit();
 
-      // DexScreener doesn't have a direct trending endpoint
-      // We'll use the boosted tokens endpoint as a proxy for trending
+      // DexScreener has no direct trending endpoint; use top boosted tokens
+      // as a proxy signal.
       const responseData = await this.get<
         DexScreenerBoostedToken[] | DexScreenerBoostedToken
       >(`/token-boosts/top/v1`);
 
-      // The boosted tokens response is an array of boosted tokens
       const boostedTokens = Array.isArray(responseData)
         ? responseData
         : [responseData];
 
-      // For each boosted token, we need to get the actual pair data
       const pairPromises = boostedTokens
         .slice(0, params.limit || 10)
         .map(async (token) => {
@@ -250,7 +257,8 @@ export class DexScreenerService extends Service {
     try {
       await this.rateLimit();
 
-      // Use search API with chain filter
+      // DexScreener has no chain-scoped listing endpoint, so search by chain
+      // name and filter the results down to that chain.
       const data = await this.get<{ pairs?: DexScreenerPair[] }>(
         `/latest/dex/search`,
         { q: params.chain },
@@ -258,12 +266,10 @@ export class DexScreenerService extends Service {
 
       let pairs: DexScreenerPair[] = data.pairs || [];
 
-      // Filter to only include pairs from the specified chain
       pairs = pairs.filter(
         (pair) => pair.chainId.toLowerCase() === params.chain.toLowerCase(),
       );
 
-      // Sort by specified criteria
       if (params.sortBy) {
         pairs.sort((a, b) => {
           switch (params.sortBy) {
@@ -284,7 +290,6 @@ export class DexScreenerService extends Service {
         });
       }
 
-      // Limit results
       const limitedPairs = params.limit
         ? pairs.slice(0, params.limit)
         : pairs.slice(0, 20);
@@ -309,25 +314,22 @@ export class DexScreenerService extends Service {
     try {
       await this.rateLimit();
 
-      // DexScreener doesn't have a direct new pairs endpoint
-      // We'll use the latest token profiles as a proxy for new tokens
+      // DexScreener has no direct new-pairs endpoint; use the latest token
+      // profiles as a proxy for newly listed tokens.
       const responseData = await this.get<
         DexScreenerProfile[] | DexScreenerProfile
       >(`/token-profiles/latest/v1`);
 
-      // The latest token profiles response is an array of profiles
       const profiles = Array.isArray(responseData)
         ? responseData
         : [responseData];
 
-      // Filter by chain if specified
       const filteredProfiles = params.chain
         ? profiles.filter(
             (p) => p.chainId.toLowerCase() === params.chain?.toLowerCase(),
           )
         : profiles;
 
-      // For each profile, we need to get the actual pair data
       const pairPromises = filteredProfiles
         .slice(0, params.limit || 10)
         .map(async (profile) => {
@@ -336,7 +338,6 @@ export class DexScreenerService extends Service {
               `/tokens/v1/${profile.chainId}/${profile.tokenAddress}`,
             );
             const pairs = Array.isArray(pairData) ? pairData : [];
-            // Return the first pair with 'new' label
             if (pairs.length > 0) {
               return {
                 ...pairs[0],
@@ -377,8 +378,8 @@ export class DexScreenerService extends Service {
   ): Promise<DexScreenerServiceResponse<DexScreenerProfile>> {
     try {
       await this.rateLimit();
-      // Token profiles are available through the latest profiles endpoint
-      // We need to fetch all and find the matching one
+      // No lookup-by-address endpoint exists; fetch the latest profiles and
+      // find the matching token address.
       const responseData = await this.get<
         DexScreenerProfile[] | DexScreenerProfile
       >(`/token-profiles/latest/v1`);

--- a/plugins/plugin-wallet/src/analytics/lpinfo/index.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/index.ts
@@ -1,28 +1,13 @@
+/**
+ * Composite liquidity-pool analytics plugin merging Steer Finance (vault/
+ * staking pools) and Kamino Protocol (lending/liquidity pools) providers,
+ * actions, and services into a single sub-plugin for pool tracking, yield
+ * analytics, and position management on Solana.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
-// Kamino Protocol Plugin
 import { kaminoPlugin } from "./kamino";
-// Steer Finance Plugin
 import { steerPlugin } from "./steer";
 
-/**
- * Liquidity Pool Information Plugin
- *
- * A comprehensive plugin that provides liquidity pool management and analytics
- * for multiple DeFi protocols on Solana.
- *
- * Supported Protocols:
- * - Steer Finance: Vault and staking pool management
- * - Kamino Protocol: Lending and liquidity pool management
- *
- * Features:
- * - Multi-protocol liquidity pool tracking
- * - Yield optimization analytics
- * - Position tracking and management
- * - Market data and statistics
- *
- * @author ElizaOS
- * @version 1.0.0
- */
 export const lpinfoPlugin: Plugin = {
   name: "lpinfo",
   description:
@@ -44,12 +29,10 @@ export default lpinfoPlugin;
 export { kaminoPlugin } from "./kamino";
 export * from "./kamino/providers/kaminoLiquidityProvider";
 export * from "./kamino/providers/kaminoPoolProvider";
-// Export Kamino components
 export * from "./kamino/providers/kaminoProvider";
 export * from "./kamino/services/kaminoLiquidityService";
 export * from "./kamino/services/kaminoService";
-// Re-export sub-plugins for granular control if needed
+// Sub-plugins are re-exported individually so callers can wire just one protocol.
 export { steerPlugin } from "./steer";
-// Export Steer components
 export * from "./steer/providers/steerLiquidityProvider";
 export * from "./steer/services/steerLiquidityService";

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/index.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/index.ts
@@ -1,16 +1,11 @@
+/** Kamino Protocol sub-plugin: lending/liquidity providers and services, composed into `lpinfoPlugin`. */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { kaminoLiquidityProvider } from "./providers/kaminoLiquidityProvider";
 import { kaminoPoolProvider } from "./providers/kaminoPoolProvider";
-// Providers
 import { kaminoProvider } from "./providers/kaminoProvider";
 import { KaminoLiquidityService } from "./services/kaminoLiquidityService";
-// Services
 import { KaminoService } from "./services/kaminoService";
 
-/**
- * Kamino Protocol Plugin
- * Provides comprehensive access to Kamino lending and liquidity protocols
- */
 export const kaminoPlugin: Plugin = {
   name: "kamino-protocol",
   description:

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoLiquidityProvider.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoLiquidityProvider.ts
@@ -1,3 +1,8 @@
+/**
+ * `KAMINO_LIQUIDITY` provider: renders Kamino liquidity pool/strategy data
+ * (optionally scoped to a token address found in the message) into planner
+ * context, using an LLM pass to turn raw pool stats into a readable report.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type {
@@ -86,10 +91,6 @@ function formatPromptValue(value: unknown): string {
   return String(value);
 }
 
-/**
- * Kamino Liquidity Protocol Provider
- * Provides information about Kamino liquidity pools and strategies
- */
 export const kaminoLiquidityProvider: Provider = {
   name: "KAMINO_LIQUIDITY",
   description:
@@ -106,7 +107,6 @@ export const kaminoLiquidityProvider: Provider = {
     let liquidityInfo = "";
 
     try {
-      // Extract token address from message content
       const content = message.content.text || "";
       const tokenMatch = content.match(/([A-Za-z0-9]{32,44})/);
 
@@ -115,7 +115,6 @@ export const kaminoLiquidityProvider: Provider = {
         tokenIdentifier = tokenMatch[1];
       }
 
-      // Get Kamino liquidity service
       const kaminoLiquidityService = runtime.getService(
         "KAMINO_LIQUIDITY_SERVICE",
       ) as KaminoLiquidityService;
@@ -126,7 +125,6 @@ export const kaminoLiquidityProvider: Provider = {
           liquidityInfo += `=== KAMINO LIQUIDITY POOL STATS ===\n\n`;
           liquidityInfo += `Token: ${tokenIdentifier}\n\n`;
 
-          // Resolve token information using Birdeye through the service
           const tokenInfo =
             await kaminoLiquidityService.resolveTokenWithBirdeye(
               tokenIdentifier,
@@ -142,13 +140,11 @@ export const kaminoLiquidityProvider: Provider = {
             liquidityInfo += `   📈 24h Change: ${tokenInfo.priceChange24h?.toFixed(2) || "N/A"}%\n\n`;
           }
 
-          // Get liquidity pool stats for the specific token using optimized method
           const poolStats = await getKaminoLiquidityStats(
             kaminoLiquidityService,
             tokenIdentifier,
           );
 
-          // Generate enhanced response using LLM
           const enhancedReport = await generateEnhancedKaminoLiquidityReport(
             runtime,
             {
@@ -161,11 +157,11 @@ export const kaminoLiquidityProvider: Provider = {
 
           liquidityInfo += enhancedReport;
         } else {
-          // No specific token provided, show protocol overview without wasting RPC calls
+          // No specific token given: show a protocol overview via
+          // testConnection() instead of the more expensive per-token RPC lookups.
           liquidityInfo += `=== KAMINO LIQUIDITY PROTOCOL OVERVIEW ===\n\n`;
           liquidityInfo += `🔍 Kamino Liquidity Protocol Information\n\n`;
 
-          // Use testConnection to get basic info without making expensive RPC calls
           const testResults = await kaminoLiquidityService.testConnection();
 
           liquidityInfo += `📊 Protocol Status:\n`;
@@ -174,10 +170,8 @@ export const kaminoLiquidityProvider: Provider = {
           liquidityInfo += `   🔗 RPC Endpoint: ${testResults.rpcEndpoint}\n`;
           liquidityInfo += `   📈 Available Strategies: ${testResults.strategyCount}\n\n`;
 
-          // Add general Kamino liquidity protocol info
           liquidityInfo += await getKaminoProtocolInfo(kaminoLiquidityService);
 
-          // Add usage instructions
           liquidityInfo += `💡 How to use:\n`;
           liquidityInfo += `   • Provide a token address to search for specific liquidity pools\n`;
           liquidityInfo += `   • Example: "Check Kamino liquidity for HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC"\n`;
@@ -203,9 +197,6 @@ export const kaminoLiquidityProvider: Provider = {
   },
 };
 
-/**
- * Get Kamino liquidity pool statistics for a specific token using optimized method
- */
 async function getKaminoLiquidityStats(
   kaminoLiquidityService: KaminoLiquidityService,
   tokenIdentifier: string,
@@ -215,7 +206,6 @@ async function getKaminoLiquidityStats(
   try {
     statsInfo += `🔍 SEARCHING FOR KAMINO LIQUIDITY POOLS...\n\n`;
 
-    // Use the optimized getTokenLiquidityStats method that uses filters and getStrategyByAddress
     const tokenStats =
       await kaminoLiquidityService.getTokenLiquidityStats(tokenIdentifier);
 
@@ -226,7 +216,6 @@ async function getKaminoLiquidityStats(
       statsInfo += `24h Volume: $${tokenStats.totalVolume.toLocaleString()}\n`;
       statsInfo += `APY Range: ${tokenStats.apyRange.min.toFixed(2)}% - ${tokenStats.apyRange.max.toFixed(2)}%\n\n`;
 
-      // Group strategies by type for better organization
       const strategyTypes = new Map<string, KaminoStrategy[]>();
       tokenStats.strategies.forEach((strategy) => {
         const type = strategy.strategyType;
@@ -248,13 +237,11 @@ async function getKaminoLiquidityStats(
         statsInfo += `   💰 Total TVL: $${totalTvl.toLocaleString()}\n`;
         statsInfo += `   🎯 Average APY: ${avgApy.toFixed(2)}%\n\n`;
 
-        // Show details for each strategy in this type
         for (const strategy of strategies) {
           statsInfo += await getStrategyDetails(strategy);
         }
       }
 
-      // Add direct link to Kamino app for found strategies
       statsInfo += `🔗 **View on Kamino:** https://app.kamino.finance/liquidity\n\n`;
     } else {
       statsInfo += `❌ No Kamino liquidity strategies found for ${tokenIdentifier}\n\n`;
@@ -270,7 +257,6 @@ async function getKaminoLiquidityStats(
       statsInfo += `🔗 Check available strategies at: https://app.kamino.finance/liquidity\n`;
     }
 
-    // Add general Kamino liquidity protocol info
     statsInfo += await getKaminoProtocolInfo(kaminoLiquidityService);
   } catch (error) {
     console.error("Error getting Kamino liquidity stats:", error);
@@ -280,9 +266,6 @@ async function getKaminoLiquidityStats(
   return statsInfo;
 }
 
-/**
- * Get detailed information about a specific strategy
- */
 async function getStrategyDetails(strategy: KaminoStrategy): Promise<string> {
   let details = `   🏊‍♂️ STRATEGY: ${strategy.address}\n`;
   details += `      📈 Type: ${strategy.strategyType}\n`;
@@ -305,9 +288,6 @@ async function getStrategyDetails(strategy: KaminoStrategy): Promise<string> {
   return details;
 }
 
-/**
- * Get general Kamino protocol information
- */
 async function getKaminoProtocolInfo(
   kaminoLiquidityService: KaminoLiquidityService,
 ): Promise<string> {
@@ -338,9 +318,7 @@ async function getKaminoProtocolInfo(
   return info;
 }
 
-/**
- * Generate enhanced Kamino liquidity report using LLM
- */
+/** Turns raw pool stats + market context into a narrative report via an LLM pass. */
 async function generateEnhancedKaminoLiquidityReport(
   runtime: IAgentRuntime,
   data: {
@@ -351,10 +329,8 @@ async function generateEnhancedKaminoLiquidityReport(
   },
 ): Promise<string> {
   try {
-    // Get additional market context
     const marketStats = await data.kaminoLiquidityService.getMarketStatistics();
 
-    // Create a focused prompt for the LLM
     const liquidityPrompt = `Generate a comprehensive liquidity analysis report for token ${data.tokenIdentifier} on Kamino Finance.
 
 TOKEN INFORMATION:
@@ -389,7 +365,6 @@ Make it comprehensive yet easy to read. Be specific about the data and provide c
 
 Generate a professional Kamino liquidity analysis report:`;
 
-    // Use LLM to generate the enhanced report
     const enhancedReport = await runtime.useModel(ModelType.TEXT_LARGE, {
       prompt: liquidityPrompt,
     });
@@ -397,6 +372,6 @@ Generate a professional Kamino liquidity analysis report:`;
     return enhancedReport || data.poolStats;
   } catch (error) {
     console.error("Error generating enhanced Kamino liquidity report:", error);
-    return data.poolStats; // Fallback to original stats
+    return data.poolStats;
   }
 }

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoPoolProvider.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoPoolProvider.ts
@@ -1,3 +1,8 @@
+/**
+ * `KAMINO_POOL` provider: looks up a single Kamino pool by the address found
+ * in the message and renders its strategy/token/metrics data into planner
+ * context, with an LLM pass producing a short pool-health analysis.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import type {
@@ -8,10 +13,6 @@ import type {
 const KAMINO_POOL_TEXT_LIMIT = 4000;
 type KaminoPoolReportData = NonNullable<KaminoPoolByAddressResult>;
 
-/**
- * Kamino Pool-Specific Provider
- * Provides detailed information about specific Kamino pools by their address
- */
 export const kaminoPoolProvider: Provider = {
   name: "KAMINO_POOL",
   description:
@@ -28,7 +29,6 @@ export const kaminoPoolProvider: Provider = {
     let poolInfo = "";
 
     try {
-      // Extract pool address from message content
       const content = message.content.text || "";
       const poolMatch = content.match(/([A-Za-z0-9]{32,44})/);
 
@@ -37,7 +37,6 @@ export const kaminoPoolProvider: Provider = {
         poolAddress = poolMatch[1];
       }
 
-      // Get Kamino liquidity service
       const kaminoLiquidityService = runtime.getService(
         "KAMINO_LIQUIDITY_SERVICE",
       ) as KaminoLiquidityService;
@@ -48,7 +47,6 @@ export const kaminoPoolProvider: Provider = {
           poolInfo += `=== KAMINO POOL ANALYSIS ===\n\n`;
           poolInfo += `🔍 Pool Address: ${poolAddress}\n\n`;
 
-          // Get detailed pool information
           const poolData =
             await kaminoLiquidityService.getPoolByAddress(poolAddress);
 
@@ -72,11 +70,9 @@ export const kaminoPoolProvider: Provider = {
             poolInfo += `🔗 Check available pools at: https://app.kamino.finance/liquidity\n`;
           }
         } else {
-          // No specific pool address provided, show usage instructions
           poolInfo += `=== KAMINO POOL PROVIDER ===\n\n`;
           poolInfo += `🔍 Kamino Pool-Specific Information\n\n`;
 
-          // Use testConnection to get basic info
           const testResults = await kaminoLiquidityService.testConnection();
 
           poolInfo += `📊 Service Status:\n`;
@@ -85,7 +81,6 @@ export const kaminoPoolProvider: Provider = {
           poolInfo += `   🔗 RPC Endpoint: ${testResults.rpcEndpoint}\n`;
           poolInfo += `   📈 Available Strategies: ${testResults.strategyCount}\n\n`;
 
-          // Add usage instructions
           poolInfo += `💡 How to use:\n`;
           poolInfo += `   • Provide a pool address to get detailed information\n`;
           poolInfo += `   • Example: "Kamino stats on pool cccsdfsdsdsxcxcxcsdsdsd"\n`;
@@ -215,9 +210,6 @@ function formatPromptValue(value: unknown): string {
   return String(value);
 }
 
-/**
- * Generate detailed pool report
- */
 async function generatePoolReport(
   runtime: IAgentRuntime,
   poolData: KaminoPoolReportData,
@@ -226,7 +218,6 @@ async function generatePoolReport(
   let report = "";
 
   try {
-    // Pool basic information
     report += `🏊‍♂️ POOL OVERVIEW:\n`;
     report += `   📍 Address: ${poolData.address}\n`;
     report += `   📅 Last Updated: ${new Date(poolData.timestamp).toLocaleString()}\n\n`;
@@ -243,12 +234,10 @@ async function generatePoolReport(
       report += `   🔄 Rebalancing: ${strategy.rebalancing}\n`;
       report += `   🕒 Last Rebalance: ${new Date(strategy.lastRebalance).toLocaleDateString()}\n\n`;
 
-      // Token information
       report += `🪙 TOKEN PAIR:\n`;
       report += `   Token A: ${strategy.tokenA}\n`;
       report += `   Token B: ${strategy.tokenB}\n\n`;
 
-      // Position details
       if (strategy.positions && strategy.positions.length > 0) {
         report += `📍 POSITIONS:\n`;
         for (const position of strategy.positions) {
@@ -260,7 +249,6 @@ async function generatePoolReport(
       }
     }
 
-    // Token information if available
     if (poolData.tokenInfo) {
       const tokenInfo = poolData.tokenInfo;
       report += `🔍 TOKEN INFORMATION:\n`;
@@ -282,7 +270,6 @@ async function generatePoolReport(
       report += `\n`;
     }
 
-    // Metrics summary
     if ("metrics" in poolData) {
       const metrics = poolData.metrics;
       report += `📈 PERFORMANCE METRICS:\n`;
@@ -295,7 +282,6 @@ async function generatePoolReport(
       report += `   🕒 Last Activity: ${new Date(metrics.lastRebalance).toLocaleString()}\n\n`;
     }
 
-    // Generate enhanced analysis using LLM
     const enhancedAnalysis = await generateEnhancedPoolAnalysis(
       runtime,
       poolData,
@@ -304,7 +290,6 @@ async function generatePoolReport(
       report += enhancedAnalysis;
     }
 
-    // Add action links
     report += `🔗 ACTIONS:\n`;
     report += `   • View on Kamino: https://app.kamino.finance/liquidity\n`;
     report += `   • Add Liquidity: https://app.kamino.finance/liquidity/deposit\n`;
@@ -317,15 +302,11 @@ async function generatePoolReport(
   return report;
 }
 
-/**
- * Generate enhanced pool analysis using LLM
- */
 async function generateEnhancedPoolAnalysis(
   runtime: IAgentRuntime,
   poolData: KaminoPoolReportData,
 ): Promise<string> {
   try {
-    // Create a focused prompt for the LLM
     const analysisPrompt = `Generate a concise pool analysis for Kamino Finance pool at address ${poolData.address}.
 
 POOL DATA:
@@ -347,7 +328,6 @@ Keep the analysis:
 
 Generate a concise Kamino pool analysis:`;
 
-    // Use LLM to generate the enhanced analysis
     const enhancedAnalysis = await runtime.useModel(ModelType.TEXT_LARGE, {
       prompt: analysisPrompt,
     });
@@ -359,6 +339,6 @@ Generate a concise Kamino pool analysis:`;
     return "";
   } catch (error) {
     console.error("Error generating enhanced pool analysis:", error);
-    return ""; // Return empty string if LLM analysis fails
+    return "";
   }
 }

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoProvider.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/providers/kaminoProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * `KAMINO_LENDING` provider: DM-only report of the user's Kamino lending/
+ * borrowing positions, resolved from their Solana metawallet(s), alongside
+ * available reserves and market data, narrated via an LLM pass. Gated to
+ * `OWNER` role and direct messages since it reads account wallet data.
+ */
 import type {
   Entity,
   IAgentRuntime,
@@ -8,7 +14,6 @@ import type {
 import { ModelType } from "@elizaos/core";
 import type { KaminoService } from "../services/kaminoService";
 
-// Kamino Lend Program constants
 const KAMINO_LEND_PROGRAM_ID = "GzFgdRJXmawPhGeBsyRCDLx4jAKPsvbUqoqitzppkzkW";
 const MAX_KAMINO_WALLETS = 5;
 const MAX_KAMINO_POSITIONS = 10;
@@ -139,10 +144,6 @@ function formatPromptValue(value: unknown): string {
   return String(value);
 }
 
-/**
- * Kamino Lending Protocol Provider
- * Provides information about Kamino lending positions and market data
- */
 export const kaminoProvider: Provider = {
   name: "KAMINO_LENDING",
   description:
@@ -159,7 +160,6 @@ export const kaminoProvider: Provider = {
     let kaminoInfo = "";
 
     try {
-      // Check if this is a DM (private message)
       const isDM = message.content.channelType?.toUpperCase() === "DM";
       if (isDM) {
         const account = await getAccountFromMessage(runtime, message);
@@ -171,7 +171,6 @@ export const kaminoProvider: Provider = {
           };
         }
 
-        // Get Kamino service with proper type casting
         const kaminoService = runtime.getService(
           "KAMINO_SERVICE",
         ) as KaminoService;
@@ -185,7 +184,6 @@ export const kaminoProvider: Provider = {
 
         kaminoInfo += `=== KAMINO LENDING PROTOCOL REPORT ===\n\n`;
 
-        // Get user's Kamino positions
         const userPositions = await getUserKaminoPositions(
           kaminoService,
           account,
@@ -196,7 +194,6 @@ export const kaminoProvider: Provider = {
         const discoveredMarkets =
           await getDiscoveredKaminoMarkets(kaminoService);
 
-        // Generate enhanced response using LLM
         const enhancedReport = await generateEnhancedKaminoLendingReport(
           runtime,
           {
@@ -233,9 +230,6 @@ export const kaminoProvider: Provider = {
   },
 };
 
-/**
- * Get user's Kamino positions
- */
 async function getUserKaminoPositions(
   kaminoService: KaminoService,
   account: unknown,
@@ -243,7 +237,6 @@ async function getUserKaminoPositions(
   let positionsInfo = "📊 YOUR KAMINO POSITIONS:\n\n";
 
   try {
-    // Extract wallet addresses from account
     const walletAddresses = getSolanaWalletAddresses(account);
 
     if (walletAddresses.length === 0) {
@@ -251,12 +244,10 @@ async function getUserKaminoPositions(
       return positionsInfo;
     }
 
-    // Get positions for each wallet
     for (const walletAddress of walletAddresses.slice(0, MAX_KAMINO_WALLETS)) {
       positionsInfo += `🔸 Wallet: ${walletAddress.slice(0, 8)}...${walletAddress.slice(-8)}\n`;
 
       try {
-        // Get real positions from Kamino service
         const positions = await kaminoService.getUserPositions(walletAddress);
 
         if ("error" in positions) {
@@ -267,13 +258,11 @@ async function getUserKaminoPositions(
         ) {
           positionsInfo += "   No Kamino positions found.\n\n";
 
-          // Show discovered markets info
           if (positions.markets && positions.markets.length > 0) {
             positionsInfo += `   🔍 Discovered ${positions.markets.length} Kamino markets\n`;
             positionsInfo += `   📊 User has ${positions.userAccounts || 0} token accounts\n\n`;
           }
         } else {
-          // Display lending positions
           if (positions.lending.length > 0) {
             positionsInfo += `   💰 LENDING POSITIONS (${positions.lending.length}):\n\n`;
 
@@ -289,7 +278,6 @@ async function getUserKaminoPositions(
             }
           }
 
-          // Display borrowing positions
           if (positions.borrowing.length > 0) {
             positionsInfo += `   💳 BORROWING POSITIONS (${positions.borrowing.length}):\n\n`;
 
@@ -305,7 +293,6 @@ async function getUserKaminoPositions(
             }
           }
 
-          // Display total portfolio value
           if (positions.totalValue !== undefined) {
             positionsInfo += `   💼 TOTAL PORTFOLIO VALUE: $${positions.totalValue.toFixed(2)}\n\n`;
           }
@@ -326,16 +313,12 @@ async function getUserKaminoPositions(
   return positionsInfo;
 }
 
-/**
- * Get available Kamino reserves for lending/borrowing
- */
 async function getAvailableKaminoReserves(
   kaminoService: KaminoService,
 ): Promise<string> {
   let reservesInfo = "🏦 AVAILABLE KAMINO RESERVES:\n\n";
 
   try {
-    // Get real reserves from Kamino service
     const reserves = await kaminoService.getAvailableReserves();
 
     if (reserves.length === 0) {
@@ -347,11 +330,10 @@ async function getAvailableKaminoReserves(
       return reservesInfo;
     }
 
-    // Show top reserves by supply APY
     const topLendingReserves = reserves
       .filter((r) => r.supplyApy > 0)
       .sort((a, b) => (b.supplyApy || 0) - (a.supplyApy || 0))
-      .slice(0, 5); // Show top 5 lending opportunities
+      .slice(0, 5);
 
     if (topLendingReserves.length > 0) {
       reservesInfo += "💰 TOP LENDING OPPORTUNITIES:\n\n";
@@ -376,16 +358,12 @@ async function getAvailableKaminoReserves(
   return reservesInfo;
 }
 
-/**
- * Get Kamino market overview
- */
 async function getKaminoMarketOverview(
   kaminoService: KaminoService,
 ): Promise<string> {
   let marketInfo = "📈 KAMINO MARKET OVERVIEW:\n\n";
 
   try {
-    // Get real market overview from Kamino service
     const overview = await kaminoService.getMarketOverview();
 
     if (!overview) {
@@ -401,7 +379,6 @@ async function getKaminoMarketOverview(
     marketInfo += `💰 Total TVL: $${overview.totalTvl.toLocaleString() || "N/A"}\n`;
     marketInfo += `💳 Total Borrowed: $${overview.totalBorrowed.toLocaleString() || "N/A"}\n\n`;
 
-    // Show top markets by TVL
     if (overview.markets && overview.markets.length > 0) {
       marketInfo += "🏆 TOP MARKETS BY TVL:\n\n";
 
@@ -425,16 +402,12 @@ async function getKaminoMarketOverview(
   return marketInfo;
 }
 
-/**
- * Get discovered Kamino markets
- */
 async function getDiscoveredKaminoMarkets(
   kaminoService: KaminoService,
 ): Promise<string> {
   let marketsInfo = "🔍 DISCOVERED KAMINO MARKETS:\n\n";
 
   try {
-    // Get discovered markets from Kamino service
     const markets = await kaminoService.discoverMarkets();
 
     if (markets.length === 0) {
@@ -444,7 +417,6 @@ async function getDiscoveredKaminoMarkets(
 
     marketsInfo += `📊 Total Markets Discovered: ${markets.length}\n\n`;
 
-    // Display discovered markets
     marketsInfo += "🏪 DISCOVERED MARKET ADDRESSES:\n\n";
 
     for (let i = 0; i < Math.min(markets.length, MAX_KAMINO_MARKETS); i++) {
@@ -454,7 +426,6 @@ async function getDiscoveredKaminoMarkets(
 
     marketsInfo += "\n";
 
-    // Show market discovery statistics
     marketsInfo += "📈 MARKET DISCOVERY STATS:\n";
     marketsInfo += `• Program ID: ${KAMINO_LEND_PROGRAM_ID}\n`;
     marketsInfo += `• Discovery Method: Program Account Query\n`;
@@ -468,9 +439,6 @@ async function getDiscoveredKaminoMarkets(
   return marketsInfo;
 }
 
-/**
- * Generate enhanced Kamino lending report using LLM
- */
 async function generateEnhancedKaminoLendingReport(
   runtime: IAgentRuntime,
   data: {
@@ -483,7 +451,6 @@ async function generateEnhancedKaminoLendingReport(
   },
 ): Promise<string> {
   try {
-    // Create a focused prompt for the LLM
     const lendingPrompt = `Generate a comprehensive lending analysis report for Kamino Finance lending.
 
 USER ACCOUNT DATA:
@@ -524,7 +491,6 @@ Make it comprehensive yet easy to read. Be specific about the user's data and pr
 
 Generate a professional Kamino lending analysis report:`;
 
-    // Use LLM to generate the enhanced report
     const enhancedReport = await runtime.useModel(ModelType.TEXT_LARGE, {
       prompt: lendingPrompt,
     });
@@ -535,6 +501,6 @@ Generate a professional Kamino lending analysis report:`;
     );
   } catch (error) {
     console.error("Error generating enhanced Kamino lending report:", error);
-    return `${data.userPositions}\n\n${data.availableReserves}\n\n${data.marketOverview}\n\n${data.discoveredMarkets}`; // Fallback to original data
+    return `${data.userPositions}\n\n${data.availableReserves}\n\n${data.marketOverview}\n\n${data.discoveredMarkets}`;
   }
 }

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoLiquidityService.ts
@@ -1,11 +1,19 @@
+/**
+ * `KAMINO_LIQUIDITY_SERVICE`: client for Kamino's liquidity-adjacent REST API.
+ * The API exposes no direct strategies/pools endpoint, so `getAllStrategies`
+ * and `getStrategyByAddress` synthesize `KaminoStrategy` records from staking
+ * yields and Limo (limit order) trade data; APY/fee/rebalancing/range
+ * heuristics on Limo-derived strategies (`calculateLimoApy` and friends) are
+ * estimates, not exact on-chain values. Token metadata comes from the
+ * `birdeye` service (`resolveTokenWithBirdeye`), looked up by service name
+ * rather than an import to avoid a hard dependency.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger, Service } from "@elizaos/core";
 
-// Kamino API constants
 const KAMINO_API_BASE_URL = "https://api.kamino.finance";
 const KAMINO_LIQUIDITY_PROGRAM_ID = "kamino-rest-api";
 
-// Known token addresses for reference
 const KNOWN_TOKENS: Record<string, string> = {
   HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC: "AI16Z Token",
   ai16z: "AI16Z Token (Symbol)",
@@ -218,9 +226,6 @@ export class KaminoLiquidityService extends Service {
     );
   }
 
-  /**
-   * Make a rate-limited API request to Kamino
-   */
   private async makeApiRequest<T>(
     endpoint: string,
     options: RequestInit = {},
@@ -251,9 +256,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Resolve token information using Birdeye API
-   */
   async resolveTokenWithBirdeye(
     tokenIdentifier: string,
   ): Promise<TokenInfo | null> {
@@ -331,9 +333,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get staking yields for tokens
-   */
   async getStakingYields(): Promise<StakingYield[]> {
     try {
       logger.log("Fetching staking yields from Kamino API...");
@@ -347,9 +346,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get median staking yields
-   */
   async getMedianStakingYields(): Promise<StakingYield[]> {
     try {
       logger.log("Fetching median staking yields from Kamino API...");
@@ -367,9 +363,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get Limo trades for a specific token pair
-   */
   async getLimoTrades(
     inTokenMint?: string,
     outTokenMint?: string,
@@ -395,9 +388,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get real-time market statistics from Kamino API
-   */
   async getMarketStatistics(): Promise<KaminoMarketStatistics | null> {
     try {
       logger.log("Fetching real-time market statistics from Kamino API...");
@@ -463,15 +453,10 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get all available Kamino strategies (not filtered by token)
-   */
   async getAllStrategies(): Promise<KaminoStrategy[]> {
     try {
       logger.log("Getting all available Kamino strategies...");
 
-      // Since the API doesn't have a direct strategies endpoint, we'll use staking yields
-      // and Limo trades to get a sense of available strategies
       const [stakingYields, limoTrades] = await Promise.all([
         this.getStakingYields(),
         this.getLimoTrades(),
@@ -479,7 +464,6 @@ export class KaminoLiquidityService extends Service {
 
       const strategies: KaminoStrategy[] = [];
 
-      // Convert staking yields to strategy-like objects
       for (const stakingYield of stakingYields) {
         strategies.push({
           address: stakingYield.tokenMint,
@@ -503,7 +487,6 @@ export class KaminoLiquidityService extends Service {
         });
       }
 
-      // Convert Limo trades to strategy-like objects
       const uniquePairs = new Set<string>();
       for (const trade of limoTrades) {
         const pairKey = `${trade.inMint}-${trade.outMint}`;
@@ -541,16 +524,12 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get a specific strategy by its address
-   */
   async getStrategyByAddress(
     strategyAddress: string,
   ): Promise<KaminoStrategy | null> {
     try {
       logger.log(`Getting strategy by address: ${strategyAddress}`);
 
-      // First, try to get all strategies and filter by address
       const allStrategies = await this.getAllStrategies();
       const strategy = allStrategies.find((s) => s.address === strategyAddress);
 
@@ -559,8 +538,8 @@ export class KaminoLiquidityService extends Service {
         return strategy;
       }
 
-      // If not found in general strategies, try to construct from specific data
-      // Check if it's a staking strategy
+      // Not in the synthesized strategy list; try constructing one directly
+      // from a matching staking yield, then from a matching Limo trade.
       const stakingYields = await this.getStakingYields();
       const stakingStrategy = stakingYields.find(
         (s) => s.tokenMint === strategyAddress,
@@ -591,7 +570,6 @@ export class KaminoLiquidityService extends Service {
         return strategy;
       }
 
-      // Check if it's a Limo trading strategy
       const limoTrades = await this.getLimoTrades();
       const limoTrade = limoTrades.find(
         (t) => t.inMint === strategyAddress || t.outMint === strategyAddress,
@@ -631,20 +609,15 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get detailed pool information by pool address
-   */
   async getPoolByAddress(
     poolAddress: string,
   ): Promise<KaminoPoolByAddressResult> {
     try {
       logger.log(`Getting pool information for address: ${poolAddress}`);
 
-      // Try to get strategy information first
       const strategy = await this.getStrategyByAddress(poolAddress);
 
       if (strategy) {
-        // Get additional token information if available
         let tokenInfo: TokenInfo | null = null;
         try {
           tokenInfo = await this.resolveTokenWithBirdeye(strategy.tokenA);
@@ -660,7 +633,6 @@ export class KaminoLiquidityService extends Service {
           strategy: strategy,
           tokenInfo: tokenInfo,
           timestamp: new Date().toISOString(),
-          // Add additional pool-specific metrics
           metrics: {
             totalValueLocked: strategy.estimatedTvl,
             volume24h: strategy.volume24h,
@@ -676,7 +648,6 @@ export class KaminoLiquidityService extends Service {
         return poolInfo;
       }
 
-      // If no strategy found, try to get basic token information
       try {
         const tokenInfo = await this.resolveTokenWithBirdeye(poolAddress);
         if (tokenInfo) {
@@ -704,19 +675,13 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get token liquidity information from Kamino
-   */
   async getTokenLiquidityStats(
     tokenIdentifier: string,
   ): Promise<TokenLiquidityStats> {
     try {
       logger.log(`Getting liquidity info for token: ${tokenIdentifier}`);
 
-      // First, try to resolve token information with Birdeye
       const tokenInfo = await this.resolveTokenWithBirdeye(tokenIdentifier);
-
-      // Normalize token identifier
       const normalizedToken = this.normalizeTokenIdentifier(tokenIdentifier);
 
       const stats: TokenLiquidityStats = {
@@ -737,18 +702,15 @@ export class KaminoLiquidityService extends Service {
           `Searching for strategies involving token: ${normalizedToken} via API`,
         );
 
-        // Get staking yields for this token
         const stakingYields = await this.getStakingYields();
         const tokenStakingYields = stakingYields.filter(
           (stakingYield) => stakingYield.tokenMint === normalizedToken,
         );
 
-        // Get Limo trades involving this token
         const limoTrades = await this.getLimoTrades(normalizedToken);
         const outTrades = await this.getLimoTrades(undefined, normalizedToken);
         const allTrades = [...limoTrades, ...outTrades];
 
-        // Convert to strategies
         if (tokenStakingYields.length > 0) {
           for (const stakingYield of tokenStakingYields) {
             stats.strategies.push({
@@ -774,7 +736,6 @@ export class KaminoLiquidityService extends Service {
           }
         }
 
-        // Convert Limo trades to strategies
         const uniquePairs = new Set<string>();
         for (const trade of allTrades) {
           const pairKey = `${trade.inMint}-${trade.outMint}`;
@@ -804,7 +765,6 @@ export class KaminoLiquidityService extends Service {
           }
         }
 
-        // Calculate aggregate stats
         if (stats.strategies.length > 0) {
           stats.poolCount = stats.strategies.length;
           stats.totalTvl = stats.strategies.reduce(
@@ -848,28 +808,19 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Calculate APY for Limo trading strategy using real API data
-   */
   private async calculateLimoApy(trade: LimoTrade): Promise<number> {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd) || 0;
       const tipAmount = parseFloat(trade.tipAmountUsd) || 0;
       const surplus = parseFloat(trade.surplusUsd) || 0;
 
-      // Get real staking yields from Kamino API
       const stakingYields = await this.getStakingYields();
-
-      // Find matching staking yield for the input token
       const matchingYield = stakingYields.find(
         (stakingYield) => stakingYield.tokenMint === trade.inMint,
       );
 
       if (matchingYield) {
-        // Use real APY data from the API
         const baseApy = parseFloat(matchingYield.apy) * 100; // Convert to percentage
-
-        // Adjust based on trade characteristics
         let adjustedApy = baseApy;
 
         // Higher trade volume might indicate better rates
@@ -885,7 +836,7 @@ export class KaminoLiquidityService extends Service {
         return Math.max(1, Math.min(50, adjustedApy));
       }
 
-      // Fallback calculation if no staking yield found
+      // No matching staking yield: use a heuristic baseline instead.
       let baseApy = 8;
       if (sizeUsd > 1000) baseApy += 2;
       if (sizeUsd > 10000) baseApy += 3;
@@ -899,28 +850,23 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Calculate fee tier for Limo trading strategy based on real market data
-   */
   private calculateLimoFeeTier(trade: LimoTrade): string {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd) || 0;
       const tipAmount = parseFloat(trade.tipAmountUsd) || 0;
 
-      // Get median staking yields to understand market conditions
-      // Higher APY markets typically have higher fees
+      // Higher-APY markets typically support higher fees; this fetch is
+      // currently unawaited so its result never affects the return below.
       const medianYields = this.getMedianStakingYields();
 
       medianYields.then((yields) => {
         if (yields.length > 0) {
-          // Calculate average median APY
           const avgMedianApy =
             yields.reduce(
               (sum, stakingYield) => sum + parseFloat(stakingYield.apy),
               0,
             ) / yields.length;
 
-          // Use median APY to adjust fee tiers
           if (avgMedianApy > 0.3) {
             // High yield market
             if (sizeUsd > 10000) return "0.08%";
@@ -937,7 +883,6 @@ export class KaminoLiquidityService extends Service {
         }
       });
 
-      // Default dynamic fee calculation based on trade characteristics
       if (sizeUsd > 10000) return "0.05%"; // Large trades get lower fees
       if (sizeUsd > 1000) return "0.1%"; // Medium trades
       if (tipAmount > 0.1) return "0.15%"; // High tip trades
@@ -947,9 +892,6 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Determine rebalancing strategy based on real market data and trade patterns
-   */
   private determineRebalancingStrategy(trade: LimoTrade): string {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd) || 0;
@@ -958,12 +900,12 @@ export class KaminoLiquidityService extends Service {
       const hoursSinceUpdate =
         (now.getTime() - updatedOn.getTime()) / (1000 * 60 * 60);
 
-      // Get recent Limo trades to understand market activity patterns
+      // Same unawaited-promise caveat as calculateLimoFeeTier: this recent-trade
+      // frequency analysis never actually influences the return value below.
       const recentTrades = this.getLimoTrades();
 
       recentTrades.then((trades) => {
         if (trades.length > 0) {
-          // Calculate average time between trades
           const recentTradeTimes = trades
             .slice(0, 10) // Look at last 10 trades
             .map((t) => new Date(t.updatedOn).getTime())
@@ -982,7 +924,6 @@ export class KaminoLiquidityService extends Service {
             const avgHoursBetweenTrades =
               avgTimeBetweenTrades / (1000 * 60 * 60);
 
-            // Use market activity to determine strategy
             if (avgHoursBetweenTrades < 0.5) return "Ultra High Frequency";
             if (avgHoursBetweenTrades < 2) return "High Frequency";
             if (avgHoursBetweenTrades < 12) return "Dynamic";
@@ -992,7 +933,6 @@ export class KaminoLiquidityService extends Service {
         }
       });
 
-      // Fallback strategy based on trade characteristics
       if (sizeUsd > 10000) return "Dynamic";
       if (sizeUsd > 5000) return "High Frequency";
       if (hoursSinceUpdate < 1) return "High Frequency";
@@ -1003,15 +943,11 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Determine trading range based on trade data
-   */
   private determineTradingRange(trade: LimoTrade): string {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd) || 0;
       const tipAmount = parseFloat(trade.tipAmountUsd) || 0;
 
-      // Determine range based on trade characteristics
       if (sizeUsd > 10000) return "Wide Range (0.5x - 2.0x)";
       if (sizeUsd > 1000) return "Medium Range (0.7x - 1.4x)";
       if (tipAmount > 0.05) return "Narrow Range (0.9x - 1.1x)";
@@ -1021,22 +957,16 @@ export class KaminoLiquidityService extends Service {
     }
   }
 
-  /**
-   * Normalize token identifier (handle symbols, addresses, etc.)
-   */
+  // Both branches currently return the identifier unchanged; this is a no-op
+  // pending real symbol/alias normalization.
   normalizeTokenIdentifier(identifier: string): string {
-    // If it looks like a valid Solana address, return as is
     if (identifier.length >= 32 && identifier.length <= 44) {
       return identifier;
     }
 
-    // For other cases, return the original identifier
     return identifier;
   }
 
-  /**
-   * Test connection and basic functionality
-   */
   async testConnection(): Promise<KaminoLiquidityConnectionTest> {
     try {
       logger.log("Testing Kamino liquidity service connection...");
@@ -1052,7 +982,6 @@ export class KaminoLiquidityService extends Service {
         timestamp: new Date().toISOString(),
       };
 
-      // Test basic API connection
       try {
         const stakingYields = await this.getStakingYields();
         results.connectionTest = true;
@@ -1064,7 +993,6 @@ export class KaminoLiquidityService extends Service {
         logger.error("API connection test failed:", formatLogError(error));
       }
 
-      // Test Limo trades endpoint
       try {
         const limoTrades = await this.getLimoTrades();
         results.limoTradesTest = true;
@@ -1075,7 +1003,6 @@ export class KaminoLiquidityService extends Service {
         logger.error("Limo trades test failed:", formatLogError(error));
       }
 
-      // Test strategy discovery
       try {
         const strategies = await this.getAllStrategies();
         results.strategyCount = strategies.length;
@@ -1124,7 +1051,6 @@ export class KaminoLiquidityService extends Service {
     try {
       logger.log("Starting KaminoLiquidityService...");
 
-      // Test connection on startup
       const testResults = await this.testConnection();
       logger.log({ testResults }, "Startup connection test results");
 

--- a/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/kamino/services/kaminoService.ts
@@ -1,10 +1,17 @@
+/**
+ * `KAMINO_SERVICE`: client for Kamino's lending-adjacent REST API. As with
+ * the sibling `KaminoLiquidityService`, the API has no direct
+ * markets/positions/reserves endpoints, so `discoverMarkets`,
+ * `getUserPositions`, `getMarketOverview`, and `getAvailableReserves`
+ * synthesize results from `/v2/staking-yields` and `/limo/trades`. Fields like
+ * TVL, borrow APY, and utilization that the API doesn't expose are
+ * heuristic estimates (see the `estimate*`/`calculate*` helpers below), not
+ * exact on-chain values.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger, Service } from "@elizaos/core";
 
-// Kamino API constants
 const KAMINO_API_BASE_URL = "https://api.kamino.finance";
-
-// Kamino Lend Program constants (for reference)
 const KAMINO_LEND_PROGRAM_ID = "GzFgdRJXmawPhGeBsyRCDLx4jAKPsvbUqoqitzppkzkW";
 const KAMINO_MULTISIG = "6hhBGCtmg7tPWUSgp3LG6X2rsmYWAc4tNsA6G4CnfQbM";
 
@@ -135,10 +142,6 @@ function formatLogError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/**
- * Kamino Lending Protocol Service
- * Handles interactions with Kamino lending protocol using the official API
- */
 export class KaminoService extends Service {
   private isRunning = false;
   private apiBaseUrl: string;
@@ -161,9 +164,6 @@ export class KaminoService extends Service {
     logger.log(`Program ID: ${KAMINO_LEND_PROGRAM_ID}`);
   }
 
-  /**
-   * Make a rate-limited API request to Kamino
-   */
   private async makeApiRequest<T>(
     endpoint: string,
     options: RequestInit = {},
@@ -194,15 +194,12 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Get all user positions (lending and borrowing) for a wallet address
-   */
   async getUserPositions(walletAddress: string): Promise<KaminoUserPositions> {
     try {
       logger.log(`Fetching user positions for wallet: ${walletAddress}`);
 
-      // Since the API doesn't have direct user position endpoints,
-      // we'll return a structure based on available market data
+      // No direct user-position endpoint exists; build a positions structure
+      // from discovered markets instead.
       const markets = await this.discoverMarkets();
       logger.log(`Discovered ${markets.length} Kamino markets`);
 
@@ -236,16 +233,12 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Discover all Kamino markets by querying available API endpoints
-   */
   async discoverMarkets(): Promise<string[]> {
     try {
       logger.log("Discovering Kamino markets...");
 
       const markets: string[] = [];
 
-      // Get staking yields to discover available tokens
       try {
         const stakingYields =
           await this.makeApiRequest<KaminoStakingYield[]>("/v2/staking-yields");
@@ -262,7 +255,6 @@ export class KaminoService extends Service {
         logger.warn("Error fetching staking yields:", formatLogError(error));
       }
 
-      // Get Limo trades to discover trading pairs
       try {
         const limoTrades =
           await this.makeApiRequest<KaminoLimoTrade[]>("/limo/trades");
@@ -290,9 +282,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Get market overview and statistics
-   */
   async getMarketOverview(): Promise<KaminoMarketOverview> {
     try {
       logger.log("Fetching market overview...");
@@ -308,22 +297,17 @@ export class KaminoService extends Service {
         multisig: KAMINO_MULTISIG,
       };
 
-      // Get staking yields for market data
       try {
         const stakingYields =
           await this.makeApiRequest<KaminoStakingYield[]>("/v2/staking-yields");
         overview.stakingYields = stakingYields.length;
 
-        // Calculate total TVL estimate from staking yields using real market data
         overview.totalTvl = stakingYields.reduce((sum, stakingYield) => {
           const apy = parseFloat(stakingYield.apy || "0");
-          // Use real APY data to estimate TVL
-          // Higher APY typically indicates lower supply (inverse relationship)
           const estimatedTvl = this.estimateTvlFromApy(apy);
           return sum + estimatedTvl;
         }, 0);
 
-        // Add market statistics from real data
         overview.avgApy =
           stakingYields.reduce(
             (sum, stakingYield) => sum + parseFloat(stakingYield.apy || "0"),
@@ -348,7 +332,6 @@ export class KaminoService extends Service {
         );
       }
 
-      // Get Limo trades for volume data
       try {
         const limoTrades =
           await this.makeApiRequest<KaminoLimoTrade[]>("/limo/trades");
@@ -363,7 +346,6 @@ export class KaminoService extends Service {
         );
       }
 
-      // Create market entries
       for (const market of markets) {
         overview.markets.push({
           address: market,
@@ -394,9 +376,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Get available reserves for lending/borrowing
-   */
   async getAvailableReserves(): Promise<KaminoReserve[]> {
     try {
       logger.log("Fetching available reserves...");
@@ -404,7 +383,6 @@ export class KaminoService extends Service {
       const _markets = await this.discoverMarkets();
       const reserves: KaminoReserve[] = [];
 
-      // Get staking yields to understand available lending opportunities
       try {
         const stakingYields =
           await this.makeApiRequest<KaminoStakingYield[]>("/v2/staking-yields");
@@ -434,7 +412,6 @@ export class KaminoService extends Service {
         );
       }
 
-      // Get Limo trades to understand trading opportunities
       try {
         const limoTrades =
           await this.makeApiRequest<KaminoLimoTrade[]>("/limo/trades");
@@ -475,9 +452,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Get program account info for debugging
-   */
   async getProgramInfo(): Promise<KaminoProgramInfo> {
     try {
       logger.log("Fetching program info...");
@@ -500,9 +474,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Calculate borrow APY based on supply APY
-   */
   private calculateBorrowApy(supplyApy: number): number {
     try {
       // Borrow APY is typically lower than supply APY
@@ -515,9 +486,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Estimate total supply based on staking yield data
-   */
   private estimateTotalSupply(stakingYield: KaminoStakingYield): number {
     try {
       const apy = parseFloat(stakingYield.apy || "0");
@@ -533,9 +501,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Estimate total borrow based on staking yield data
-   */
   private estimateTotalBorrow(stakingYield: KaminoStakingYield): number {
     try {
       const totalSupply = this.estimateTotalSupply(stakingYield);
@@ -547,9 +512,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Calculate utilization rate based on staking yield data
-   */
   private calculateUtilization(stakingYield: KaminoStakingYield): number {
     try {
       const totalSupply = this.estimateTotalSupply(stakingYield);
@@ -560,9 +522,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Calculate Limo supply APY based on real market data
-   */
   private async calculateLimoSupplyApy(
     trade: KaminoLimoTrade,
   ): Promise<number> {
@@ -570,19 +529,15 @@ export class KaminoService extends Service {
       const sizeUsd = parseFloat(trade.sizeUsd || "0");
       const tipAmount = parseFloat(trade.tipAmountUsd || "0");
 
-      // Get real staking yields to find base APY for the input token
       const stakingYields =
         await this.makeApiRequest<KaminoStakingYield[]>("/v2/staking-yields");
 
-      // Find matching staking yield for the input token
       const matchingYield = stakingYields.find(
         (stakingYield) => stakingYield.tokenMint === trade.inMint,
       );
 
       if (matchingYield) {
         const baseApy = parseFloat(matchingYield.apy ?? "0") * 100; // Convert to percentage
-
-        // Adjust based on trade characteristics
         let adjustedApy = baseApy;
 
         // Higher trade volume might indicate better rates
@@ -608,9 +563,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Calculate Limo borrow APY based on trade data
-   */
   private async calculateLimoBorrowApy(
     trade: KaminoLimoTrade,
   ): Promise<number> {
@@ -624,9 +576,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Estimate Limo borrow amount based on trade data
-   */
   private estimateLimoBorrow(trade: KaminoLimoTrade): number {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd || "0");
@@ -638,9 +587,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Calculate Limo utilization rate based on trade data
-   */
   private calculateLimoUtilization(trade: KaminoLimoTrade): number {
     try {
       const sizeUsd = parseFloat(trade.sizeUsd || "0");
@@ -657,15 +603,10 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Estimate TVL from APY using real market data patterns
-   */
   private estimateTvlFromApy(apy: number): number {
     try {
-      // Use real market data patterns to estimate TVL
-      // Higher APY typically indicates lower supply (inverse relationship)
-      // This is based on typical DeFi market dynamics
-
+      // Heuristic: higher APY typically indicates lower supply (inverse
+      // relationship), per typical DeFi market dynamics.
       if (apy > 0.5) return 50000; // Very high APY = very low supply
       if (apy > 0.3) return 100000; // High APY = low supply
       if (apy > 0.2) return 250000; // Medium-high APY
@@ -678,9 +619,6 @@ export class KaminoService extends Service {
     }
   }
 
-  /**
-   * Test connection and basic functionality
-   */
   async testConnection(): Promise<KaminoConnectionTestResult> {
     try {
       logger.log("Testing Kamino service connection...");
@@ -695,7 +633,6 @@ export class KaminoService extends Service {
         timestamp: new Date().toISOString(),
       };
 
-      // Test basic API connection
       try {
         const stakingYields =
           await this.makeApiRequest<KaminoStakingYield[]>("/v2/staking-yields");
@@ -708,7 +645,6 @@ export class KaminoService extends Service {
         logger.error("API connection test failed:", formatLogError(error));
       }
 
-      // Test Limo trades endpoint
       try {
         const limoTrades =
           await this.makeApiRequest<KaminoLimoTrade[]>("/limo/trades");
@@ -720,7 +656,6 @@ export class KaminoService extends Service {
         logger.error("Limo trades test failed:", formatLogError(error));
       }
 
-      // Test market discovery
       try {
         const markets = await this.discoverMarkets();
         results.marketCount = markets.length;
@@ -765,7 +700,6 @@ export class KaminoService extends Service {
     try {
       logger.log("Starting KaminoService...");
 
-      // Test connection on startup
       const testResults = await this.testConnection();
       logger.log({ testResults }, "Startup connection test results");
 

--- a/plugins/plugin-wallet/src/analytics/lpinfo/steer/index.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/steer/index.ts
@@ -1,15 +1,8 @@
+/** Steer Finance sub-plugin: vault/staking-pool provider and service, composed into `lpinfoPlugin`. */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
-
-// Providers
 import { steerLiquidityProvider } from "./providers/steerLiquidityProvider";
-
-// Services
 import { SteerLiquidityService } from "./services/steerLiquidityService";
 
-/**
- * Steer Finance Protocol Plugin
- * Provides comprehensive access to Steer Finance vaults and staking pools
- */
 export const steerPlugin: Plugin = {
   name: "steer-protocol",
   description:

--- a/plugins/plugin-wallet/src/analytics/lpinfo/steer/providers/steerLiquidityProvider.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/steer/providers/steerLiquidityProvider.ts
@@ -1,3 +1,8 @@
+/**
+ * `STEER_LIQUIDITY` provider: renders Steer Finance vault/staking-pool data
+ * into planner context, optionally scoped to a token address and chain found
+ * in the message text. `_getSteerGeneralOverview` is currently unreferenced.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import type { SteerLiquidityService } from "../services/steerLiquidityService";
 import type {
@@ -19,10 +24,6 @@ function getVaultTokenAddress(
     : vaultToken.address || "Unknown";
 }
 
-/**
- * Steer Finance Liquidity Protocol Provider
- * Provides information about Steer Finance vaults and staking pools
- */
 export const steerLiquidityProvider: Provider = {
   name: "STEER_LIQUIDITY",
   description:
@@ -39,7 +40,6 @@ export const steerLiquidityProvider: Provider = {
     let liquidityInfo = "";
 
     try {
-      // Get Steer liquidity service with proper type casting
       const steerLiquidityService = runtime.getService(
         "STEER_LIQUIDITY_SERVICE",
       ) as SteerLiquidityService;
@@ -53,21 +53,17 @@ export const steerLiquidityProvider: Provider = {
 
       liquidityInfo += `=== STEER FINANCE LIQUIDITY POOLS REPORT ===\n\n`;
 
-      // Extract token address and chain from message content
       const content = message.content.text || "";
 
-      // More flexible regex to catch various formats
       const tokenMatch = content.match(/(0x[a-fA-F0-9]{40})/);
-
-      // Also try to find any 0x pattern that might be a token address
+      // Broader match used to detect a near-miss address (wrong length) for
+      // a more helpful error message than a plain "not found".
       const anyHexMatch = content.match(/(0x[a-fA-F0-9]+)/);
 
-      // Extract chain name from content
       const chainMatch = content.match(
         /\b(base|ethereum|mainnet|polygon|arbitrum|optimism)\b/i,
       );
 
-      // Map chain names to chain IDs
       const chainNameToId: { [key: string]: number } = {
         ethereum: 1,
         mainnet: 1,
@@ -81,7 +77,6 @@ export const steerLiquidityProvider: Provider = {
         ? chainNameToId[chainMatch[1].toLowerCase()]
         : null;
 
-      // Validate chain if specified
       if (
         targetChainId &&
         chainMatch &&
@@ -99,7 +94,6 @@ export const steerLiquidityProvider: Provider = {
       if (tokenMatch) {
         const tokenIdentifier = tokenMatch[1];
 
-        // Validate token address format
         if (!isValidEthereumAddress(tokenIdentifier)) {
           liquidityInfo += `❌ Invalid Ethereum address format: ${tokenIdentifier}\n`;
           liquidityInfo += `Ethereum addresses must be exactly 40 hex characters (42 total with 0x prefix).\n\n`;
@@ -108,7 +102,6 @@ export const steerLiquidityProvider: Provider = {
           liquidityInfo += `• 0x6B175474E89094C44Da98b954EedeAC495271d0F (DAI)\n`;
           liquidityInfo += `• 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 (WETH)\n\n`;
         } else {
-          // Get token-specific liquidity stats with optional chain filtering
           const tokenStats = await getSteerLiquidityStats(
             steerLiquidityService,
             tokenIdentifier,
@@ -116,7 +109,6 @@ export const steerLiquidityProvider: Provider = {
           );
           liquidityInfo += tokenStats;
 
-          // Add single-asset deposit information if available
           const depositInfo = await getSingleAssetDepositInfo(
             steerLiquidityService,
             tokenIdentifier,
@@ -125,7 +117,6 @@ export const steerLiquidityProvider: Provider = {
           liquidityInfo += depositInfo;
         }
       } else if (anyHexMatch) {
-        // Found a hex pattern but it's not exactly 40 characters
         const foundHex = anyHexMatch[1];
         liquidityInfo += `⚠️ Found potential token address: ${foundHex}\n`;
         liquidityInfo += `❌ Invalid Ethereum address format: ${foundHex}\n`;
@@ -136,11 +127,11 @@ export const steerLiquidityProvider: Provider = {
         liquidityInfo += `• 0x9876543210987654321098765432109876543210\n\n`;
         liquidityInfo += `🔍 Your input "${foundHex}" has ${foundHex.length - 2} hex characters, but needs exactly 40.\n\n`;
       } else {
-        // No specific token provided, show protocol overview
+        // No specific token given: show a protocol overview via
+        // testConnection() instead of the more expensive per-token RPC lookups.
         liquidityInfo += `=== STEER FINANCE PROTOCOL OVERVIEW ===\n\n`;
         liquidityInfo += `🔍 Steer Finance Liquidity Protocol Information\n\n`;
 
-        // Use testConnection to get basic info without making expensive RPC calls
         const testResults = await steerLiquidityService.testConnection();
 
         liquidityInfo += `📊 Protocol Status:\n`;
@@ -149,10 +140,8 @@ export const steerLiquidityProvider: Provider = {
         liquidityInfo += `   📈 Available Vaults: ${testResults.vaultCount}\n`;
         liquidityInfo += `   🔒 Available Staking Pools: ${testResults.stakingPoolCount}\n\n`;
 
-        // Add general Steer Finance protocol info
         liquidityInfo += await getSteerProtocolInfo(steerLiquidityService);
 
-        // Add usage instructions
         liquidityInfo += `💡 How to use:\n`;
         liquidityInfo += `   • Provide a token address to search for specific liquidity pools\n`;
         liquidityInfo += `   • Optionally specify a chain to filter results (faster)\n`;
@@ -179,9 +168,6 @@ export const steerLiquidityProvider: Provider = {
   },
 };
 
-/**
- * Get Steer Finance liquidity pool statistics for a specific token
- */
 async function getSteerLiquidityStats(
   steerLiquidityService: SteerLiquidityService,
   tokenIdentifier: string,
@@ -190,7 +176,6 @@ async function getSteerLiquidityStats(
   let statsInfo = "";
 
   try {
-    // Add chain filtering info if specified
     if (targetChainId) {
       const chainName = getChainName(targetChainId);
       statsInfo += `🔍 SEARCHING FOR STEER FINANCE LIQUIDITY POOLS ON ${chainName.toUpperCase()}...\n\n`;
@@ -198,7 +183,6 @@ async function getSteerLiquidityStats(
       statsInfo += `🔍 SEARCHING FOR STEER FINANCE LIQUIDITY POOLS...\n\n`;
     }
 
-    // Get detailed liquidity stats for the token with optional chain filtering
     const tokenStats = await steerLiquidityService.getTokenLiquidityStats(
       tokenIdentifier,
       targetChainId,
@@ -211,7 +195,6 @@ async function getSteerLiquidityStats(
       statsInfo += `24h Volume: $${tokenStats.totalVolume.toLocaleString()}\n`;
       statsInfo += `APY Range: ${tokenStats.apyRange.min.toFixed(2)}% - ${tokenStats.apyRange.max.toFixed(2)}%\n\n`;
 
-      // Display vaults
       if (tokenStats.vaults.length > 0) {
         statsInfo += `🏦 VAULTS (${tokenStats.vaults.length}):\n\n`;
         for (const vault of tokenStats.vaults) {
@@ -219,7 +202,6 @@ async function getSteerLiquidityStats(
         }
       }
 
-      // Display staking pools
       if (tokenStats.stakingPools.length > 0) {
         statsInfo += `🔒 STAKING POOLS (${tokenStats.stakingPools.length}):\n\n`;
         for (const pool of tokenStats.stakingPools) {
@@ -227,7 +209,6 @@ async function getSteerLiquidityStats(
         }
       }
 
-      // Add direct link to Steer app for found strategies
       statsInfo += `🔗 **View on Steer Finance:** https://app.steer.finance\n\n`;
     } else {
       statsInfo += `❌ No Steer Finance liquidity pools found for ${tokenIdentifier}\n\n`;
@@ -235,7 +216,6 @@ async function getSteerLiquidityStats(
       statsInfo += `You can check available pools at: https://app.steer.finance\n`;
     }
 
-    // Add general Steer Finance protocol info
     statsInfo += await getSteerProtocolInfo(steerLiquidityService);
   } catch (error) {
     console.error("Error getting Steer liquidity stats:", error);
@@ -245,9 +225,6 @@ async function getSteerLiquidityStats(
   return statsInfo;
 }
 
-/**
- * Get detailed information about a specific vault
- */
 async function getVaultDetails(vault: SteerVaultDetailInput): Promise<string> {
   let details = `🏦 VAULT: ${vault.address}\n`;
   details += `   📈 Name: ${vault.name}\n`;
@@ -260,7 +237,6 @@ async function getVaultDetails(vault: SteerVaultDetailInput): Promise<string> {
   details += `   🕒 Created: ${new Date(vault.createdAt).toLocaleDateString()}\n`;
   details += `   ✅ Status: ${vault.isActive ? "Active" : "Inactive"}\n`;
 
-  // Show full token addresses if available
   if (vault.token0 && vault.token0 !== "Unknown") {
     const token0Address =
       typeof vault.token0 === "string"
@@ -283,7 +259,6 @@ async function getVaultDetails(vault: SteerVaultDetailInput): Promise<string> {
     details += `   🪙 Token1: Unknown\n`;
   }
 
-  // Display GraphQL enriched data if available
   if (vault.graphqlData) {
     details += `\n   📊 GRAPHQL ENRICHED DATA:\n`;
     details += `      🎯 Weekly Fee APR: ${vault.graphqlData.weeklyFeeAPR.toFixed(2)}%\n`;
@@ -325,9 +300,6 @@ async function getVaultDetails(vault: SteerVaultDetailInput): Promise<string> {
   return details;
 }
 
-/**
- * Get detailed information about a specific staking pool
- */
 async function getStakingPoolDetails(
   pool: SteerStakingPoolDetailInput,
 ): Promise<string> {
@@ -347,9 +319,6 @@ async function getStakingPoolDetails(
   return details;
 }
 
-/**
- * Get chain name from chain ID
- */
 function getChainName(chainId: number): string {
   const chainNames: { [key: number]: string } = {
     1: "Ethereum Mainnet",
@@ -360,9 +329,6 @@ function getChainName(chainId: number): string {
   return chainNames[chainId] || `Chain ${chainId}`;
 }
 
-/**
- * Get general Steer Finance protocol information
- */
 async function getSteerProtocolInfo(
   steerLiquidityService: SteerLiquidityService,
 ): Promise<string> {
@@ -376,7 +342,6 @@ async function getSteerProtocolInfo(
     info += `📊 Total Vaults: ${testResults.vaultCount}\n`;
     info += `🔒 Total Staking Pools: ${testResults.stakingPoolCount}\n\n`;
 
-    // Test GraphQL connection
     const graphqlStatus = await steerLiquidityService.testGraphQLConnection();
     info += `🔍 GraphQL Subgraph: ${graphqlStatus.success ? "Connected" : "Failed"}\n`;
     if (!graphqlStatus.success && graphqlStatus.error) {
@@ -406,9 +371,6 @@ async function getSteerProtocolInfo(
   return info;
 }
 
-/**
- * Get general Steer Finance overview
- */
 async function _getSteerGeneralOverview(
   steerLiquidityService: SteerLiquidityService,
 ): Promise<string> {
@@ -433,9 +395,6 @@ async function _getSteerGeneralOverview(
   return overview;
 }
 
-/**
- * Get single-asset deposit information for a token
- */
 async function getSingleAssetDepositInfo(
   steerLiquidityService: SteerLiquidityService,
   tokenIdentifier: string,
@@ -444,7 +403,6 @@ async function getSingleAssetDepositInfo(
   let depositInfo = "\n💎 SINGLE-ASSET DEPOSIT INFORMATION:\n\n";
 
   try {
-    // Get token stats to find vaults with optional chain filtering
     const tokenStats = await steerLiquidityService.getTokenLiquidityStats(
       tokenIdentifier,
       targetChainId,
@@ -472,7 +430,6 @@ async function getSingleAssetDepositInfo(
         depositInfo += `   🪙 Token0: ${token0Address} (${getTokenSymbol(token0Address)})\n`;
         depositInfo += `   🪙 Token1: ${token1Address} (${getTokenSymbol(token1Address)})\n`;
 
-        // Add additional APY breakdown if available
         if (vault.apr1d || vault.apr7d || vault.apr14d) {
           depositInfo += `   📊 APY Breakdown:\n`;
           if (vault.apr1d)
@@ -483,7 +440,6 @@ async function getSingleAssetDepositInfo(
             depositInfo += `      • 14D: ${vault.apr14d.toFixed(2)}%\n`;
         }
 
-        // Add fee breakdown if available
         if (vault.feeApr || vault.stakingApr || vault.merklApr) {
           depositInfo += `   💸 Fee Breakdown:\n`;
           if (vault.feeApr)
@@ -521,23 +477,16 @@ async function getSingleAssetDepositInfo(
   return depositInfo;
 }
 
-/**
- * Validate Ethereum address format
- */
 function isValidEthereumAddress(address: string): boolean {
-  // Check if it starts with 0x and has exactly 40 hex characters
   const ethereumAddressRegex = /^0x[a-fA-F0-9]{40}$/;
   return ethereumAddressRegex.test(address);
 }
 
-/**
- * Get token symbol from token address
- */
+// No symbol lookup is performed; this always returns a shortened address.
 function getTokenSymbol(address: string): string {
   if (!address || address === "Unknown") {
     return "Unknown";
   }
 
-  // Return shortened address for all tokens
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }

--- a/plugins/plugin-wallet/src/analytics/lpinfo/steer/services/steerLiquidityService.ts
+++ b/plugins/plugin-wallet/src/analytics/lpinfo/steer/services/steerLiquidityService.ts
@@ -1,3 +1,15 @@
+/**
+ * `STEER_LIQUIDITY_SERVICE`: client for Steer Finance vaults and staking
+ * pools across the chains in `SUPPORTED_CHAIN_IDS`, backed by
+ * `@steerprotocol/sdk` (per-chain `VaultClient`/`StakingClient`) with a
+ * GraphQL subgraph as the preferred, richer data source (`getVaultDetails`
+ * tries GraphQL first, falls back to the SDK). Vault records are enriched
+ * in multiple passes — SDK data, then GraphQL (`enrichVaultWithGraphQLData`),
+ * then optional pool/price lookups — and TVL is either read from the
+ * subgraph or estimated from raw token balances at an assumed $1/token
+ * (`calculateTvlFromBalances` — a rough approximation, not a priced TVL).
+ * `getTokenPrices` currently has no wired price feed and always returns null.
+ */
 import type { IAgentRuntime, JsonValue } from "@elizaos/core";
 import { logger, Service } from "@elizaos/core";
 import type { StakingPool } from "@steerprotocol/sdk";
@@ -8,7 +20,6 @@ import {
   VaultClient,
 } from "@steerprotocol/sdk";
 import { createPublicClient, createWalletClient, http } from "viem";
-// Import Viem for proper chain and transport configuration
 import { arbitrum, base, mainnet, optimism, polygon } from "viem/chains";
 
 import type {
@@ -75,14 +86,11 @@ interface RawSteerVault {
   merklApr?: number;
 }
 
-// Supported chain IDs
 const SUPPORTED_CHAIN_IDS = [1, 137, 42161, 10, 8453]; // mainnet, polygon, arbitrum, optimism, base
 
-// GraphQL endpoint for Steer Protocol
 const STEER_GRAPHQL_ENDPOINT =
   "https://api.subgraph.ormilabs.com/api/public/803c8c8c-be12-4188-8523-b9853e23051d/subgraphs/steer-protocol-base/prod/gn";
 
-// Interfaces for type safety
 interface TokenLiquidityStats {
   tokenIdentifier: string;
   normalizedToken: string;
@@ -105,7 +113,6 @@ interface ConnectionTestResult {
   error?: string;
 }
 
-// GraphQL Vault Data Interface
 interface GraphQLVaultData {
   id: string;
   name: string;
@@ -290,10 +297,6 @@ function hasGraphQLMeta(response: unknown): boolean {
   );
 }
 
-/**
- * Steer Finance Liquidity Protocol Service
- * Handles interactions with Steer Finance protocol using the official SDK
- */
 export class SteerLiquidityService extends Service {
   private isRunning = false;
   private supportedChains: number[];
@@ -311,12 +314,11 @@ export class SteerLiquidityService extends Service {
   constructor(runtime?: IAgentRuntime) {
     super(runtime);
 
-    // Initialize supported chains
     this.supportedChains = SUPPORTED_CHAIN_IDS;
 
-    // Initialize Steer SDK client
+    // A throwaway mainnet SteerClient just to fail fast if the SDK itself is
+    // misconfigured, before setting up the real per-chain clients below.
     try {
-      // Create a proper Viem client configuration for each chain
       const viemClient = createPublicClient({
         chain: mainnet,
         transport: http(),
@@ -335,7 +337,6 @@ export class SteerLiquidityService extends Service {
       throw new Error("Steer SDK initialization failed");
     }
 
-    // Initialize vault and staking clients for each supported chain
     this.initializeChainClients();
 
     logger.log("SteerLiquidityService initialized with multi-chain support");
@@ -344,7 +345,6 @@ export class SteerLiquidityService extends Service {
       "SteerLiquidityService ready to handle requests using official SDK",
     );
 
-    // Verify runtime has required methods
     if (!runtime?.getService) {
       logger.warn("Runtime missing getService method");
     }
@@ -352,13 +352,9 @@ export class SteerLiquidityService extends Service {
       logger.warn("Runtime missing getCache method");
     }
 
-    // Log successful initialization
     logger.log("SteerLiquidityService constructor completed successfully");
   }
 
-  /**
-   * Get the appropriate Viem chain object for a given chain ID
-   */
   private getViemChain(chainId: number) {
     switch (chainId) {
       case 1:
@@ -376,16 +372,11 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Initialize vault and staking clients for each supported chain
-   */
   private initializeChainClients(): void {
     try {
       for (const chainId of this.supportedChains) {
-        // Get the appropriate Viem chain object
         const viemChain = this.getViemChain(chainId);
 
-        // Create Viem clients for this chain
         const publicClient = createPublicClient({
           chain: viemChain,
           transport: http(),
@@ -396,7 +387,6 @@ export class SteerLiquidityService extends Service {
           transport: http(),
         });
 
-        // Initialize vault client for this chain
         const vaultClient = new VaultClient(
           publicClient as unknown as VaultClientCtor[0],
           walletClient as VaultClientCtor[1],
@@ -404,7 +394,6 @@ export class SteerLiquidityService extends Service {
         );
         this.vaultClients.set(chainId, vaultClient);
 
-        // Initialize staking client for this chain
         const stakingClient = new StakingClient(
           walletClient as unknown as StakingClientCtor[0],
         );
@@ -421,9 +410,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get token liquidity information from Steer Finance across all supported chains or a specific chain
-   */
   async getTokenLiquidityStats(
     tokenIdentifier: string,
     targetChainId?: number | null,
@@ -436,17 +422,14 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Normalize token identifier
       const normalizedToken = this.normalizeTokenIdentifier(tokenIdentifier);
       const tokenName = this.getTokenName(normalizedToken);
 
       const allVaults: SteerVaultDetailInput[] = [];
       const allStakingPools: SteerStakingPoolDetailInput[] = [];
 
-      // Determine which chains to search
       let chainsToSearch: number[];
       if (targetChainId) {
-        // Validate that the target chain is supported
         if (!this.supportedChains.includes(targetChainId)) {
           throw new Error(
             `Chain ${targetChainId} is not supported. Supported chains: ${this.supportedChains.join(", ")}`,
@@ -463,7 +446,6 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Check if this is a token address for targeted search
       const isTokenAddress =
         tokenIdentifier.startsWith("0x") && tokenIdentifier.length === 42;
 
@@ -472,7 +454,6 @@ export class SteerLiquidityService extends Service {
           `Token address detected, searching for specific vaults containing ${tokenIdentifier}`,
         );
 
-        // Search for vaults containing the specific token using SDK
         for (const chainId of chainsToSearch) {
           try {
             logger.log(
@@ -508,16 +489,15 @@ export class SteerLiquidityService extends Service {
         }
       }
 
-      // If no specific token vaults found or this is a general search, get all vaults
+      // Token-specific search found nothing (or wasn't attempted): fall back
+      // to fetching every vault on the searched chains.
       if (allVaults.length === 0) {
         logger.log(`Fetching all vault data from Steer Finance using SDK...`);
 
-        // Fetch data from specified chains using the SDK
         for (const chainId of chainsToSearch) {
           try {
             logger.log(`Fetching data for chain ${chainId}...`);
 
-            // Get vaults for this chain using SDK
             const chainVaults = await this.getAllVaultsForChain(chainId);
             allVaults.push(...chainVaults);
 
@@ -537,7 +517,6 @@ export class SteerLiquidityService extends Service {
         `Total vaults processed across ${chainsToSearch.length} chain(s): ${allVaults.length}`,
       );
 
-      // Calculate aggregate statistics
       const totalTvl = allVaults.reduce(
         (sum, vault) => sum + (vault.tvl || 0),
         0,
@@ -554,7 +533,6 @@ export class SteerLiquidityService extends Service {
         max: apyValues.length > 0 ? Math.max(...apyValues) : 0,
       };
 
-      // Log summary of what was found
       logger.log(`=== STEER LIQUIDITY STATS SUMMARY ===`);
       logger.log(`Total vaults found: ${allVaults.length}`);
       logger.log(`Total staking pools found: ${allStakingPools.length}`);
@@ -564,7 +542,6 @@ export class SteerLiquidityService extends Service {
         `APY Range: ${apyRange.min.toFixed(2)}% - ${apyRange.max.toFixed(2)}%`,
       );
 
-      // Log breakdown by chain
       const vaultsByChain = allVaults.reduce(
         (acc, vault) => {
           acc[vault.chainId] = (acc[vault.chainId] || 0) + 1;
@@ -608,9 +585,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get all vaults for a specific chain using the SDK
-   */
   private async getAllVaultsForChain(
     chainId: number,
   ): Promise<SteerVaultDetailInput[]> {
@@ -637,26 +611,24 @@ export class SteerLiquidityService extends Service {
         logger.warn(
           `Failed to get vaults for chain ${chainId}: ${sdkError || "Unknown error"}`,
         );
-        // If it's a server error, log it but continue with other chains
+        // A server-side error here is chain-specific; skip this chain rather
+        // than aborting the whole multi-chain search.
         if (sdkError?.includes("INTERNAL_SERVER_ERROR")) {
           logger.warn(`Chain ${chainId} has server issues, skipping for now`);
         }
         return [];
       }
 
-      // Debug: Log the response structure
       logger.log(
         getResponseDebug(vaultsResponse),
         `Vault response structure for chain ${chainId}`,
       );
 
-      // Extract vaults from the paginated response structure
       const vaults = getRawVaultNodes(vaultsResponse);
       logger.log(
         `Retrieved ${vaults.length} vaults from SDK for chain ${chainId}`,
       );
 
-      // Process and enrich vault data
       const processedVaults = await Promise.all(
         vaults.map(async (vault) => {
           try {
@@ -684,9 +656,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get vaults for a specific token on a specific chain using SDK
-   */
   private async getVaultsForToken(
     chainId: number,
     tokenAddress: string,
@@ -716,13 +685,11 @@ export class SteerLiquidityService extends Service {
         return [];
       }
 
-      // Extract vaults from the paginated response structure
       const allVaults = getRawVaultNodes(vaultsResponse);
       logger.log(
         `Searching ${allVaults.length} vaults for token ${tokenAddress} on chain ${chainId}`,
       );
 
-      // Debug: Log first vault structure to understand the data format
       if (allVaults.length > 0) {
         logger.log(
           {
@@ -740,16 +707,13 @@ export class SteerLiquidityService extends Service {
 
       const matchingVaults: SteerVaultDetailInput[] = [];
 
-      // Filter vaults that contain the target token
       for (const vault of allVaults) {
         try {
-          // Check if the vault contains the target token
           if (this.vaultContainsToken(vault, tokenAddress)) {
             logger.log(
               `Found matching vault ${vault.vaultAddress || vault.address} for token ${tokenAddress}`,
             );
 
-            // Process the vault data
             const processedVault = await this.processVaultData(vault, chainId);
             if (processedVault) {
               matchingVaults.push(processedVault);
@@ -776,16 +740,14 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Check if a vault contains a specific token
-   */
   private vaultContainsToken(
     vault: RawSteerVault,
     tokenAddress: string,
   ): boolean {
     const targetAddress = tokenAddress.toLowerCase();
 
-    // Check token0 and token1 - handle both string and object formats
+    // token0/token1 can come back as either a bare address string or an
+    // object with an `address` field, depending on the SDK response shape.
     const token0Address =
       typeof vault.token0 === "string" ? vault.token0 : vault.token0?.address;
     const token1Address =
@@ -798,7 +760,8 @@ export class SteerLiquidityService extends Service {
       return true;
     }
 
-    // Check pool address if available
+    // NOTE: any vault with a pool address matches here regardless of the
+    // target token — this does not actually check the pool for the token.
     if (vault.poolAddress) {
       return true;
     }
@@ -806,15 +769,11 @@ export class SteerLiquidityService extends Service {
     return false;
   }
 
-  /**
-   * Process vault data from SDK response
-   */
   private async processVaultData(
     vault: RawSteerVault,
     chainId: number,
   ): Promise<SteerVaultDetailInput | null> {
     try {
-      // Extract basic vault information
       const vaultAddress = vault.vaultAddress || vault.address || "";
       const poolAddress = vault.pool?.poolAddress || vault.poolAddress;
       const rawFeeTier = vault.pool?.feeTier ?? vault.fee ?? 0.3;
@@ -823,7 +782,6 @@ export class SteerLiquidityService extends Service {
           ? rawFeeTier
           : Number.parseFloat(rawFeeTier) || 0.3;
 
-      // Extract APY data from various sources
       const apyData = vault.aprData || {};
       const apy =
         vault.apy ||
@@ -874,7 +832,6 @@ export class SteerLiquidityService extends Service {
         merklApr: vault.merklApr,
       };
 
-      // Try to get additional data from SDK if available
       try {
         const gqlPeek = await this.getVaultDataFromGraphQL(vaultAddress);
         if (gqlPeek) {
@@ -891,11 +848,9 @@ export class SteerLiquidityService extends Service {
           }
         }
 
-        // Try to get pool-specific data if we have a pool address
         if (poolAddress) {
           const poolData = await this.getPoolData(poolAddress, chainId);
           if (poolData) {
-            // Update with pool data
             if (poolData.tvl) processedVault.tvl = poolData.tvl;
             if (poolData.volume24h)
               processedVault.volume24h = poolData.volume24h;
@@ -903,7 +858,8 @@ export class SteerLiquidityService extends Service {
           }
         }
 
-        // Try to get token price data for better TVL calculation
+        // getTokenPrices currently has no wired price feed (always null), so
+        // this branch is a no-op today pending a real price source.
         try {
           const token0Address =
             typeof vault.token0 === "string"
@@ -920,7 +876,6 @@ export class SteerLiquidityService extends Service {
               chainId,
             );
             if (priceData && processedVault.tvl === 0) {
-              // If we don't have TVL but have price data, we could calculate it
               logger.log(
                 `Price data available for vault ${vaultAddress}: Token0: $${priceData[token0Address]}, Token1: $${priceData[token1Address]}`,
               );
@@ -938,7 +893,6 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Enrich vault data with GraphQL information
       try {
         const enrichedVault = await this.enrichVaultWithGraphQLData(
           processedVault,
@@ -961,15 +915,11 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get vault details by address using GraphQL (preferred) or SDK fallback
-   */
   async getVaultDetails(
     vaultAddress: string,
     chainId: number,
   ): Promise<SteerVaultDetailInput | null> {
     try {
-      // First try to get data from GraphQL
       const graphqlData = await this.getVaultDataFromGraphQL(vaultAddress);
       if (graphqlData) {
         logger.log(`Found vault ${vaultAddress} via GraphQL`);
@@ -997,7 +947,6 @@ export class SteerLiquidityService extends Service {
           strategyType: "graphql",
           fee: feeTierBp / 10000,
           createdAt: Date.now(),
-          // Calculate basic metrics
           tvl: this.calculateTvlFromBalances(
             graphqlData.token0Balance,
             graphqlData.token1Balance,
@@ -1009,7 +958,6 @@ export class SteerLiquidityService extends Service {
         };
       }
 
-      // Fallback to SDK if GraphQL fails
       logger.log(
         `GraphQL data not available for ${vaultAddress}, falling back to SDK`,
       );
@@ -1024,9 +972,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get vault details by address using SDK (fallback method)
-   */
   private async getVaultDetailsFromSDK(
     vaultAddress: string,
     chainId: number,
@@ -1038,7 +983,8 @@ export class SteerLiquidityService extends Service {
         return null;
       }
 
-      // Get vault details using SDK - use getVaults and filter
+      // The SDK has no single-vault lookup; fetch the chain's vault list and
+      // find the matching address.
       const vaultResponse: unknown = await vaultClient.getVaults(
         { chainId },
         100,
@@ -1052,7 +998,6 @@ export class SteerLiquidityService extends Service {
         return null;
       }
 
-      // Extract vaults from the paginated response structure
       const vaults = getRawVaultNodes(vaultResponse);
       const normalizedVaultAddress = vaultAddress.toLowerCase();
       return (
@@ -1071,9 +1016,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get token prices for TVL calculation
-   */
   async getTokenPrices(
     _tokenAddresses: string[],
     chainId: number,
@@ -1091,9 +1033,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get pool data including TVL, volume, and fee information
-   */
   async getPoolData(
     poolAddress: string,
     chainId: number,
@@ -1110,7 +1049,6 @@ export class SteerLiquidityService extends Service {
         return null;
       }
 
-      // Try to get pool information using the SDK
       try {
         const poolsResponse = await vaultClient.getPools(
           { chainId, protocol: "uniswap-v3" },
@@ -1147,7 +1085,7 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Fallback: return basic pool data
+      // No matching pool found via the SDK: return zeroed placeholder data.
       return {
         tvl: 0,
         volume24h: 0,
@@ -1163,9 +1101,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get staking pool details by address using SDK
-   */
   async getStakingPoolDetails(
     poolAddress: string,
     chainId: number,
@@ -1177,7 +1112,6 @@ export class SteerLiquidityService extends Service {
         return null;
       }
 
-      // Get staking pool details using SDK
       const poolResponse = await stakingClient.getStakingPools({ chainId });
 
       if (!poolResponse.success || !poolResponse.data) {
@@ -1198,9 +1132,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Test GraphQL connection specifically
-   */
   async testGraphQLConnection(): Promise<{ success: boolean; error?: string }> {
     try {
       logger.log("Testing GraphQL connection to Steer Protocol subgraph...");
@@ -1247,9 +1178,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Test GraphQL vault query with a specific vault address
-   */
   async testGraphQLVaultQuery(
     vaultAddress: string,
   ): Promise<{ success: boolean; data?: GraphQLVaultData; error?: string }> {
@@ -1277,9 +1205,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Test connection to Steer Finance services using SDK
-   */
   async testConnection(): Promise<ConnectionTestResult> {
     try {
       logger.log("Testing Steer Finance connection using SDK...");
@@ -1288,12 +1213,10 @@ export class SteerLiquidityService extends Service {
       let totalStakingPoolCount = 0;
       const connectionErrors: string[] = [];
 
-      // Test SDK connection for each chain
       for (const chainId of this.supportedChains) {
         try {
           logger.log(`Testing connection for chain ${chainId}...`);
 
-          // Test vault client
           const vaultClient = this.vaultClients.get(chainId);
           if (vaultClient) {
             const vaultsResponse = await vaultClient.getVaults(
@@ -1313,7 +1236,6 @@ export class SteerLiquidityService extends Service {
             }
           }
 
-          // Test staking client
           const stakingClient = this.stakingClients.get(chainId);
           if (stakingClient) {
             const poolsResponse = await stakingClient.getStakingPools({
@@ -1362,49 +1284,35 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Normalize token identifier (handle different formats)
-   */
   private normalizeTokenIdentifier(tokenIdentifier: string): string {
-    // Remove common prefixes and normalize
     const normalized = tokenIdentifier.trim();
 
-    // Handle Solana-style addresses (base58)
+    // Base58, 44 chars: likely a Solana address, which Steer (EVM-only) can't use.
     if (
       normalized.length === 44 &&
       /^[1-9A-HJ-NP-Za-km-z]+$/.test(normalized)
     ) {
-      // This is likely a Solana address, but Steer is EVM-based
       logger.warn(
         `Token ${normalized} appears to be a Solana address, but Steer Finance is EVM-based`,
       );
     }
 
-    // Handle Ethereum-style addresses (0x...)
     if (normalized.startsWith("0x")) {
       return normalized.toLowerCase();
     }
 
-    // For symbol-based lookups, return as-is (no hardcoded mapping)
+    // Symbol-based lookups (no hardcoded symbol-to-address mapping) pass through as-is.
     return normalized;
   }
 
-  /**
-   * Get token name from identifier
-   */
   private getTokenName(tokenIdentifier: string): string {
-    // For token addresses, return a formatted version
     if (tokenIdentifier.startsWith("0x")) {
       return `Token ${tokenIdentifier.slice(0, 8)}...${tokenIdentifier.slice(-6)}`;
     }
 
-    // For symbols or other identifiers, return as-is
     return tokenIdentifier;
   }
 
-  /**
-   * Get chain name from chain ID
-   */
   private getChainName(chainId: number): string {
     const chainNames: { [key: number]: string } = {
       1: "Ethereum Mainnet",
@@ -1416,9 +1324,6 @@ export class SteerLiquidityService extends Service {
     return chainNames[chainId] || `Chain ${chainId}`;
   }
 
-  /**
-   * Clear expired cache entries
-   */
   private clearExpiredCache(): void {
     const now = Date.now();
     for (const [key, value] of this.cache.entries()) {
@@ -1456,7 +1361,6 @@ export class SteerLiquidityService extends Service {
     }
 
     try {
-      // Clear any expired cache entries
       this.clearExpiredCache();
 
       this.isRunning = true;
@@ -1492,9 +1396,6 @@ export class SteerLiquidityService extends Service {
     return this.isRunning;
   }
 
-  /**
-   * Preview single-asset deposit for a vault using SDK
-   */
   async previewSingleAssetDeposit(
     vaultAddress: string,
     chainId: number,
@@ -1509,7 +1410,6 @@ export class SteerLiquidityService extends Service {
         throw new Error(`No vault client available for chain ${chainId}`);
       }
 
-      // Get vault details to get the pool address and single asset deposit contract
       const vault = await this.getVaultDetails(vaultAddress, chainId);
       if (!vault) {
         throw new Error(`Vault ${vaultAddress} not found on chain ${chainId}`);
@@ -1526,7 +1426,6 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Preview the single-asset deposit using SDK
       const preview = await vaultClient.previewSingleAssetDeposit(
         {
           assets,
@@ -1552,9 +1451,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Execute single-asset deposit for a vault using SDK
-   */
   async executeSingleAssetDeposit(
     vaultAddress: string,
     chainId: number,
@@ -1570,7 +1466,6 @@ export class SteerLiquidityService extends Service {
         throw new Error(`No vault client available for chain ${chainId}`);
       }
 
-      // Get vault details to get the single asset deposit contract
       const vault = await this.getVaultDetails(vaultAddress, chainId);
       if (!vault) {
         throw new Error(`Vault ${vaultAddress} not found on chain ${chainId}`);
@@ -1587,7 +1482,6 @@ export class SteerLiquidityService extends Service {
         );
       }
 
-      // Execute the single-asset deposit using SDK
       const result = await vaultClient.singleAssetDeposit({
         assets,
         receiver,
@@ -1609,9 +1503,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get earned rewards for a staking pool using SDK
-   */
   async getEarnedRewards(
     poolAddress: string,
     accountAddress: string,
@@ -1637,9 +1528,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get total supply of a staking pool using SDK
-   */
   async getStakingPoolTotalSupply(
     poolAddress: string,
     chainId: number,
@@ -1663,9 +1551,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Get balance of a user in a staking pool using SDK
-   */
   async getStakingPoolBalance(
     poolAddress: string,
     accountAddress: string,
@@ -1691,9 +1576,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Fetch detailed vault data from Steer Protocol GraphQL subgraph
-   */
   async getVaultDataFromGraphQL(
     vaultAddress: string,
   ): Promise<GraphQLVaultData | null> {
@@ -1791,9 +1673,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Enrich vault data with GraphQL information
-   */
   async enrichVaultWithGraphQLData(
     vault: SteerVaultDetailInput,
     _chainId: number,
@@ -1806,14 +1685,11 @@ export class SteerLiquidityService extends Service {
       }
       logger.log(`Enriching vault ${vaultAddress} with GraphQL data...`);
 
-      // Fetch GraphQL data
       const graphqlData = await this.getVaultDataFromGraphQL(vaultAddress);
 
       if (graphqlData) {
-        // Merge GraphQL data with existing vault data
         const enrichedVault = {
           ...vault,
-          // GraphQL specific fields
           graphqlData: {
             weeklyFeeAPR: parseFloat(graphqlData.weeklyFeeAPR) || 0,
             token0Symbol: graphqlData.token0Symbol,
@@ -1831,12 +1707,10 @@ export class SteerLiquidityService extends Service {
             payloadIpfs: graphqlData.payloadIpfs,
             deployer: graphqlData.deployer,
           },
-          // Update existing fields with GraphQL data if available
           name: graphqlData.name || vault.name,
           token0: graphqlData.token0 || vault.token0,
           token1: graphqlData.token1 || vault.token1,
           poolAddress: graphqlData.pool || vault.poolAddress,
-          // Update TVL with GraphQL data if available
           tvl:
             vault.tvl ||
             this.calculateTvlFromBalances(
@@ -1845,7 +1719,6 @@ export class SteerLiquidityService extends Service {
               parseInt(graphqlData.token0Decimals, 10) || 18,
               parseInt(graphqlData.token1Decimals, 10) || 18,
             ),
-          // Calculate TVL from token balances if not available
           calculatedTvl: this.calculateTvlFromBalances(
             graphqlData.token0Balance,
             graphqlData.token1Balance,
@@ -1873,9 +1746,6 @@ export class SteerLiquidityService extends Service {
     }
   }
 
-  /**
-   * Calculate TVL from token balances using LP tokens as proxy
-   */
   private calculateTvlFromBalances(
     token0Balance: string,
     token1Balance: string,
@@ -1883,7 +1753,6 @@ export class SteerLiquidityService extends Service {
     token1Decimals: number,
   ): number {
     try {
-      // Convert string balances to numbers with proper decimals
       const token0Amount = parseFloat(token0Balance) / 10 ** token0Decimals;
       const token1Amount = parseFloat(token1Balance) / 10 ** token1Decimals;
 
@@ -1891,8 +1760,8 @@ export class SteerLiquidityService extends Service {
         `Token balances - Token0: ${token0Amount}, Token1: ${token1Amount}`,
       );
 
-      // Use a simple estimation: assume average token price of $1
-      // This is a rough approximation - in production you'd fetch real prices
+      // Rough approximation assuming $1/token; no real price feed is wired
+      // in (see getTokenPrices).
       const estimatedTvl = (token0Amount + token1Amount) * 1;
 
       logger.log(`Estimated TVL: $${estimatedTvl.toLocaleString()}`);

--- a/plugins/plugin-wallet/src/analytics/news/index.ts
+++ b/plugins/plugin-wallet/src/analytics/news/index.ts
@@ -1,34 +1,17 @@
+/**
+ * DeFi news sub-plugin: injects DeFi/crypto market context into
+ * conversations — global market stats, token data, and Brave New Coin RSS
+ * news — via `defiNewsProvider` and `NewsDataService`.
+ *
+ * News data works standalone. Market-cap/dominance/token stats additionally
+ * need a `COINGECKO_SERVICE` (from the analytics plugin or similar); Solana
+ * token lookups additionally use the optional `birdeye` and `chain_solana`
+ * services if present.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
-// Providers
 import { defiNewsProvider } from "./providers/defiNewsProvider";
-// Services
 import { NewsDataService } from "./services/newsDataService";
 
-/**
- * DeFi News Plugin
- *
- * A comprehensive plugin that automatically provides DeFi and crypto market context to conversations through providers.
- *
- * Features:
- * - Global DeFi market statistics (market cap, volume, dominance) - requires CoinGecko service
- * - Global crypto market data (active cryptocurrencies, total market cap, dominance) - requires CoinGecko service
- * - Latest crypto news from Brave New Coin RSS feed (always available)
- * - Token information (price, market cap, community stats, developer activity) - requires CoinGecko service
- *
- * Optional Dependencies:
- * - COINGECKO_SERVICE: Provided by analytics plugin or similar for market data
- * - birdeye: For Solana token lookups
- * - chain_solana: For Solana blockchain interactions
- *
- * Required Services:
- * - NEWS_DATA_SERVICE: Provided by this plugin for news data
- *
- * Note: This plugin works standalone with news data only. For full functionality,
- * ensure the analytics plugin (or similar) is loaded to provide the COINGECKO_SERVICE.
- *
- * @author ElizaOS
- * @version 2.0.0
- */
 export const defiNewsPlugin: Plugin = {
   name: "defi-news",
   description:
@@ -46,12 +29,7 @@ export const defiNewsPlugin: Plugin = {
 
 export default defiNewsPlugin;
 
-// Export types for external use
 export * from "./interfaces/types";
-// Export providers
 export { defiNewsProvider } from "./providers/defiNewsProvider";
-// Export services for direct access if needed
 export { NewsDataService } from "./services/newsDataService";
-
-// Export utilities
 export * from "./utils/formatters";

--- a/plugins/plugin-wallet/src/analytics/news/interfaces/types.ts
+++ b/plugins/plugin-wallet/src/analytics/news/interfaces/types.ts
@@ -1,12 +1,11 @@
+/**
+ * Wire types for the DeFi news sub-plugin: CoinGecko DeFi/crypto market
+ * data, DEX pair and OHLCV data, NewsData.io real-world articles, and the
+ * request/response/service contracts that tie them together.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 
-/**
- * DeFi News data types
- */
-
-// ============================================
-// CoinGecko DeFi Market Data Types
-// ============================================
+// CoinGecko DeFi market data
 
 export interface GlobalDefiData {
   defi_market_cap: string;
@@ -95,9 +94,7 @@ export interface OHLCVData {
   volume?: number;
 }
 
-// ============================================
-// NewsData.io Real World Events Types
-// ============================================
+// NewsData.io real-world events
 
 export interface RealWorldNewsArticle {
   article_id: string;
@@ -130,9 +127,7 @@ export interface RealWorldNewsResponse {
   nextPage?: string;
 }
 
-// ============================================
-// Request/Response Types
-// ============================================
+// Request/response types
 
 export interface DefiNewsRequest {
   tokenId?: string;
@@ -173,12 +168,9 @@ export interface DefiNewsResponse {
   error?: string;
 }
 
-// ============================================
-// Service Interfaces
-// ============================================
+// Service interfaces
 
 export interface DefiNewsService {
-  // CoinGecko DeFi Data
   getGlobalDefiData(): Promise<GlobalDefiData>;
   getGlobalCryptoData(): Promise<GlobalCryptoData>;
   getTokenData(
@@ -192,7 +184,6 @@ export interface DefiNewsService {
   getDexPairs(tokenId: string): Promise<DexPairData[]>;
   getOHLCVData(tokenId: string, days: number): Promise<OHLCVData[]>;
 
-  // Real World News
   getRealWorldNews(
     query: string,
     options?: {
@@ -203,9 +194,7 @@ export interface DefiNewsService {
   ): Promise<RealWorldNewsArticle[]>;
 }
 
-// ============================================
-// Action Types
-// ============================================
+// Action types
 
 export interface ActionRequest {
   runtime: IAgentRuntime;

--- a/plugins/plugin-wallet/src/analytics/news/providers/defiNewsProvider.ts
+++ b/plugins/plugin-wallet/src/analytics/news/providers/defiNewsProvider.ts
@@ -1,3 +1,11 @@
+/**
+ * `DEFI_NEWS` provider: renders a DeFi/crypto market report into planner
+ * context — global DeFi and crypto market stats (needs `COINGECKO_SERVICE`),
+ * latest Brave New Coin RSS headlines (always available), and, when a token
+ * symbol/name is detected in the message, per-token data resolved via
+ * Birdeye + on-chain lookup when available, falling back to a hardcoded
+ * symbol-to-CoinGecko-id table for a short list of major tokens.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import type { NewsDataService } from "../services/newsDataService";
 
@@ -72,28 +80,6 @@ interface SolanaTokenInfoService {
 }
 const DEFI_NEWS_TEXT_LIMIT = 4000;
 
-/**
- * DeFi News Provider
- *
- * Automatically provides comprehensive DeFi and crypto market context to conversations.
- * This provider is dynamic and fetches fresh data on each request.
- *
- * The provider aggregates data from:
- * - Global DeFi market statistics (market cap, volume, dominance) - requires CoinGecko service
- * - Global crypto market data (total market cap, active cryptocurrencies, dominance) - requires CoinGecko service
- * - Latest crypto news from Brave New Coin RSS feed (top 5 articles) - always available
- * - Token-specific data when mentioned - requires CoinGecko and optional Birdeye services
- *
- * The data is formatted as a comprehensive market report that can be used
- * by the agent to provide informed responses about DeFi and crypto markets.
- *
- * Note: The CoinGecko service should be provided by the analytics plugin or similar.
- * If not available, the provider will still work with news data only.
- *
- * @example
- * // The provider is automatically called by the framework
- * // No manual invocation needed - just add to plugin.providers array
- */
 export const defiNewsProvider: Provider = {
   name: "DEFI_NEWS",
   description:
@@ -110,7 +96,6 @@ export const defiNewsProvider: Provider = {
     let defiNewsInfo = "";
 
     try {
-      // Get services - CoinGecko from analytics or similar plugin, NewsData from this plugin
       const coinGeckoService = runtime.getService(
         "COINGECKO_SERVICE",
       ) as CoinGeckoService | null;
@@ -126,24 +111,19 @@ export const defiNewsProvider: Provider = {
         };
       }
 
-      // Check if a specific token is mentioned in the message
       const messageText = message.content.text || "";
 
       defiNewsInfo += `=== DEFI & CRYPTO MARKET REPORT ===\n\n`;
 
-      // Extract symbols dynamically from the message
       let extractedSymbols = extractSymbols(messageText, "loose");
       extractedSymbols = filterTokenSymbols(extractedSymbols);
 
-      // Also check for token names (bitcoin, ethereum, etc.)
       const namedSymbol = getSymbolFromTokenName(messageText);
       if (namedSymbol && !extractedSymbols.includes(namedSymbol)) {
         extractedSymbols.unshift(namedSymbol); // Add to front
       }
 
-      // If token symbols are detected and services are available, look them up
       if (extractedSymbols.length > 0 && coinGeckoService) {
-        // Try to get Birdeye service for symbol lookup
         const birdeyeService = runtime.getService(
           "birdeye",
         ) as BirdeyeLookupService | null;
@@ -152,10 +132,8 @@ export const defiNewsProvider: Provider = {
         ) as SolanaTokenInfoService | null;
 
         if (birdeyeService && solanaService) {
-          // Process up to 3 tokens
           for (const detectedSymbol of extractedSymbols.slice(0, 3)) {
             try {
-              // Look up token by symbol across all chains
               const options =
                 await birdeyeService.lookupSymbolAllChains(detectedSymbol);
               const exactOptions = options.filter(
@@ -167,7 +145,6 @@ export const defiNewsProvider: Provider = {
                 const tokenOption = exactOptions[0];
                 const tokenCA = tokenOption.address;
 
-                // Verify it's actually a token
                 const addressType = await solanaService.getAddressType(tokenCA);
 
                 if (addressType === "Token") {
@@ -189,7 +166,6 @@ export const defiNewsProvider: Provider = {
             }
           }
         } else {
-          // Fallback to CoinGecko ID lookup for major tokens
           for (const detectedSymbol of extractedSymbols.slice(0, 1)) {
             const coingeckoId = getCoinGeckoIdFromSymbol(detectedSymbol);
             if (coingeckoId) {
@@ -204,12 +180,10 @@ export const defiNewsProvider: Provider = {
         }
       }
 
-      // Get global DeFi data (if CoinGecko service is available)
       if (coinGeckoService) {
         const globalDefiData = await getGlobalDefiData(coinGeckoService);
         defiNewsInfo += globalDefiData;
 
-        // Get global crypto market data
         const globalCryptoData = await getGlobalCryptoData(coinGeckoService);
         defiNewsInfo += globalCryptoData;
       } else {
@@ -217,7 +191,6 @@ export const defiNewsProvider: Provider = {
           "⚠️ Market data unavailable (CoinGecko service not configured)\n\n";
       }
 
-      // Get latest crypto news (always available)
       const latestNews = await getLatestCryptoNews(newsDataService);
       defiNewsInfo += latestNews;
     } catch (error) {
@@ -241,14 +214,7 @@ export const defiNewsProvider: Provider = {
   },
 };
 
-/**
- * Extract symbols from text
- * Dynamically extracts token symbols from natural language
- *
- * @param text - The text to extract symbols from
- * @param mode - "strict" only matches $SYMBOL format, "loose" matches various patterns
- * @returns Array of detected symbols
- */
+/** Extracts candidate token symbols from free-form text; `mode` controls strictness (see below). */
 export const extractSymbols = (
   text: string,
   // loose mode will try to extract more symbols but may include false positives
@@ -258,7 +224,6 @@ export const extractSymbols = (
   if (!text.matchAll) return [];
   const symbols = new Set<string>();
 
-  // Match patterns
   const patterns =
     mode === "strict"
       ? [
@@ -281,7 +246,6 @@ export const extractSymbols = (
           /\b([A-Z0-9]{2,10})-USD\b/gi,
         ];
 
-  // Extract all matches
   patterns.forEach((pattern) => {
     const matches = text.matchAll(pattern);
     for (const match of matches) {
@@ -293,11 +257,9 @@ export const extractSymbols = (
   return Array.from(symbols);
 };
 
-/**
- * Filter extracted symbols to remove common words and validate potential tokens
- */
 function filterTokenSymbols(symbols: string[]): string[] {
-  // Common words to exclude (not tokens)
+  // Common English words and fiat currency codes that match the symbol
+  // regexes but aren't tokens.
   const excludeWords = new Set([
     "THE",
     "AND",
@@ -350,9 +312,6 @@ function filterTokenSymbols(symbols: string[]): string[] {
   });
 }
 
-/**
- * Map common token names to their symbols
- */
 function getSymbolFromTokenName(text: string): string | null {
   const lowerText = text.toLowerCase();
 
@@ -379,10 +338,7 @@ function getSymbolFromTokenName(text: string): string | null {
   return null;
 }
 
-/**
- * Get CoinGecko ID from token symbol
- * Fallback mapping for major tokens when Birdeye is not available
- */
+/** Fallback symbol-to-CoinGecko-id mapping for major tokens, used when Birdeye is unavailable. */
 function getCoinGeckoIdFromSymbol(symbol: string): string | null {
   const symbolToCoinGeckoId: Record<string, string> = {
     BTC: "bitcoin",
@@ -403,9 +359,6 @@ function getCoinGeckoIdFromSymbol(symbol: string): string | null {
   return symbolToCoinGeckoId[symbol.toUpperCase()] || null;
 }
 
-/**
- * Get global DeFi market data
- */
 async function getGlobalDefiData(
   coinGeckoService: CoinGeckoService,
 ): Promise<string> {
@@ -428,9 +381,6 @@ async function getGlobalDefiData(
   return defiInfo;
 }
 
-/**
- * Get global crypto market data
- */
 async function getGlobalCryptoData(
   coinGeckoService: CoinGeckoService,
 ): Promise<string> {
@@ -465,9 +415,6 @@ async function getGlobalCryptoData(
   return cryptoInfo;
 }
 
-/**
- * Get latest crypto news
- */
 async function getLatestCryptoNews(
   newsDataService: NewsDataService,
 ): Promise<string> {
@@ -510,10 +457,6 @@ async function getLatestCryptoNews(
   return newsInfo;
 }
 
-/**
- * Get token information by contract address
- * Uses Birdeye + CoinGecko to fetch comprehensive token data
- */
 async function getTokenInfoByAddress(
   coinGeckoService: CoinGeckoService,
   solanaService: SolanaTokenInfoService,
@@ -523,10 +466,8 @@ async function getTokenInfoByAddress(
   let tokenInfo = `📊 TOKEN INFORMATION:\n\n`;
 
   try {
-    // Import PublicKey if needed
     const { PublicKey } = await import("@solana/web3.js");
 
-    // Get token symbol from Solana (for verification)
     let tokenSymbol = symbol;
     try {
       const onChainSymbol = await solanaService.getTokenSymbol(
@@ -539,12 +480,10 @@ async function getTokenInfoByAddress(
       // fall back to provided symbol when on-chain lookup fails
     }
 
-    // Try to search CoinGecko by symbol
     let coinData: CoinGeckoCoinData | null = null;
     const searchResults = await coinGeckoService.searchCoin(tokenSymbol);
 
     if (searchResults && searchResults.length > 0) {
-      // Try to find exact match by Solana platform address
       const solanaMatch = searchResults.find(
         (coin) =>
           coin.platforms?.solana?.toLowerCase() === tokenAddress.toLowerCase(),
@@ -553,7 +492,6 @@ async function getTokenInfoByAddress(
       if (solanaMatch) {
         coinData = await coinGeckoService.getCoinData(solanaMatch.id);
       } else {
-        // Use first result as fallback
         coinData = await coinGeckoService.getCoinData(searchResults[0].id);
       }
     }
@@ -565,7 +503,6 @@ async function getTokenInfoByAddress(
       return tokenInfo;
     }
 
-    // Format comprehensive token data
     tokenInfo += `🪙 ${coinData.name} (${coinData.symbol.toUpperCase()})\n`;
     tokenInfo += `📍 Contract Address: ${tokenAddress}\n\n`;
 
@@ -643,10 +580,6 @@ async function getTokenInfoByAddress(
   return tokenInfo;
 }
 
-/**
- * Get token information
- * This is a helper function that can be used for specific token queries
- */
 export async function getTokenInfo(
   coinGeckoService: CoinGeckoService,
   tokenId: string,

--- a/plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts
+++ b/plugins/plugin-wallet/src/analytics/news/services/newsDataService.ts
@@ -1,10 +1,14 @@
+/**
+ * `NEWS_DATA_SERVICE`: fetches and hand-parses the Brave New Coin RSS feed
+ * (`bravenewcoin.com/rss/insights`) with a small regex-based XML reader
+ * (`parseRSS`/`extractTag`) rather than a full XML parser, into
+ * `RealWorldNewsArticle` records. `getTokenNews`/`getDefiNews` are thin
+ * query-filter wrappers over `getLatestNews`.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import type { RealWorldNewsArticle } from "../interfaces/types";
 
-/**
- * RSS Feed Item Interface
- */
 interface RSSItem {
   title?: string;
   link?: string;
@@ -16,12 +20,6 @@ interface RSSItem {
   creator?: string;
 }
 
-/**
- * Brave New Coin RSS Service for Real-World Crypto Events
- *
- * This service fetches real-world news and events related to cryptocurrency
- * from Brave New Coin RSS feed.
- */
 export class NewsDataService extends Service {
   static serviceType = "NEWS_DATA_SERVICE";
   private rssUrl: string = "https://bravenewcoin.com/rss/insights";
@@ -30,17 +28,11 @@ export class NewsDataService extends Service {
     return "Provides real-world cryptocurrency news and events from Brave New Coin RSS feed";
   }
 
-  /**
-   * Start the NewsData service (static method for framework)
-   */
   static async start(runtime: IAgentRuntime) {
     const service = new NewsDataService(runtime);
     return service;
   }
 
-  /**
-   * Stop the NewsData service (static method for framework)
-   */
   static async stop(runtime: IAgentRuntime) {
     const service = runtime.getService(NewsDataService.serviceType);
     if (!service) {
@@ -48,26 +40,18 @@ export class NewsDataService extends Service {
     }
   }
 
-  /**
-   * Stop the service instance
-   */
   async stop(): Promise<void> {}
 
-  /**
-   * Parse RSS XML to extract news items
-   */
   private parseRSS(xmlText: string): RSSItem[] {
     const items: RSSItem[] = [];
 
     try {
-      // Extract all <item> blocks from the RSS feed
       const itemRegex = /<item>([\s\S]*?)<\/item>/g;
       const itemMatches = xmlText.matchAll(itemRegex);
 
       for (const match of itemMatches) {
         const itemXml = match[1];
 
-        // Extract individual fields
         const title = this.decodeHtmlEntities(
           this.extractTag(itemXml, "title") || "",
         );
@@ -111,9 +95,6 @@ export class NewsDataService extends Service {
     return items;
   }
 
-  /**
-   * Extract content from XML tag
-   */
   private extractTag(xml: string, tagName: string): string | undefined {
     const regex = new RegExp(
       `<${tagName}[^>]*><!\\[CDATA\\[(.*?)\\]\\]><\\/${tagName}>`,
@@ -136,16 +117,10 @@ export class NewsDataService extends Service {
     return undefined;
   }
 
-  /**
-   * Strip HTML tags from text
-   */
   private stripHtml(html: string): string {
     return html.replace(/<[^>]*>/g, "").trim();
   }
 
-  /**
-   * Decode HTML entities (e.g., &#8217; to ')
-   */
   private decodeHtmlEntities(text: string): string {
     const entities: Record<string, string> = {
       "&#8217;": "'",
@@ -175,9 +150,6 @@ export class NewsDataService extends Service {
     return decoded;
   }
 
-  /**
-   * Fetch latest crypto news from Brave New Coin RSS feed
-   */
   async getLatestNews(options?: {
     query?: string;
     language?: string;
@@ -262,9 +234,6 @@ export class NewsDataService extends Service {
     }
   }
 
-  /**
-   * Fetch news about a specific token
-   */
   async getTokenNews(
     tokenSymbol: string,
     options?: {
@@ -280,9 +249,6 @@ export class NewsDataService extends Service {
     });
   }
 
-  /**
-   * Fetch DeFi-specific news
-   */
   async getDefiNews(options?: {
     language?: string;
     limit?: number;
@@ -295,9 +261,6 @@ export class NewsDataService extends Service {
     });
   }
 
-  /**
-   * Fetch blockchain and crypto market news
-   */
   async getCryptoMarketNews(options?: {
     language?: string;
     limit?: number;

--- a/plugins/plugin-wallet/src/analytics/news/utils/formatters.test.ts
+++ b/plugins/plugin-wallet/src/analytics/news/utils/formatters.test.ts
@@ -1,3 +1,8 @@
+/**
+ * DeFi news formatters render financial figures and validate token addresses.
+ * Magnitude suffixes, percent sign/emoji, and address-shape validation must be
+ * exact — isValidTokenAddress in particular gates EVM/Solana address inputs.
+ */
 import { describe, expect, it } from "vitest";
 import {
   extractTokenSymbol,
@@ -9,12 +14,6 @@ import {
   stripHtml,
   truncateText,
 } from "./formatters.js";
-
-/**
- * DeFi news formatters render financial figures and validate token addresses.
- * Magnitude suffixes, percent sign/emoji, and address-shape validation must be
- * exact — isValidTokenAddress in particular gates EVM/Solana address inputs.
- */
 
 describe("formatCurrency", () => {
   it("scales with T/B/M/K suffixes", () => {

--- a/plugins/plugin-wallet/src/analytics/token-info/action.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/action.ts
@@ -1,3 +1,7 @@
+/**
+ * Folded into WALLET as `action=token_info`. Routes token-info queries through
+ * the registered TokenInfoService providers (DexScreener, Birdeye, CoinGecko).
+ */
 import type {
   ActionResult,
   HandlerCallback,
@@ -24,10 +28,6 @@ function unavailable(
   };
 }
 
-/**
- * Folded into WALLET as `action=token_info`. Routes token-info queries through
- * the registered TokenInfoService providers (DexScreener, Birdeye, CoinGecko).
- */
 export async function tokenInfoHandler(
   runtime: IAgentRuntime,
   message: Memory,

--- a/plugins/plugin-wallet/src/analytics/token-info/index.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the token-info analytics submodule (handler, dispatcher service, types). */
 export { tokenInfoHandler } from "./action";
 export { TOKEN_INFO_SERVICE_TYPE, TokenInfoService } from "./service";
 export * from "./types";

--- a/plugins/plugin-wallet/src/analytics/token-info/params.test.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/params.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Token-info param parsing turns loose agent options + free text into a typed
+ * query. Param readers coerce/trim and reject junk; subaction normalization
+ * canonicalizes labels; and intent inference routes a message to the right
+ * read-only lookup.
+ */
 import type { Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
@@ -8,13 +14,6 @@ import {
   readParams,
   readStringParam,
 } from "./params.js";
-
-/**
- * Token-info param parsing turns loose agent options + free text into a typed
- * query. Param readers coerce/trim and reject junk; subaction normalization
- * canonicalizes labels; and intent inference routes a message to the right
- * read-only lookup.
- */
 
 const msg = (text: string): Memory =>
   ({ content: { text } }) as unknown as Memory;

--- a/plugins/plugin-wallet/src/analytics/token-info/params.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/params.ts
@@ -1,3 +1,11 @@
+/**
+ * Turns loose `WALLET` action options (and, failing that, free-form message
+ * text) into a typed `TokenInfoParams` query: subaction aliasing/normalization
+ * (`normalizeTokenInfoSubaction`, `SUBACTION_ALIASES`), keyword-based intent
+ * inference when no explicit subaction is given (`inferTokenInfoSubaction`),
+ * and tolerant param readers that coerce strings/numbers/booleans from a
+ * merged top-level + nested `parameters` bag.
+ */
 import type { HandlerOptions, Memory, State } from "@elizaos/core";
 import {
   TOKEN_INFO_SUBACTIONS,

--- a/plugins/plugin-wallet/src/analytics/token-info/providers.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/providers.ts
@@ -1,3 +1,11 @@
+/**
+ * The three `TokenInfoProvider` implementations `TokenInfoService` dispatches
+ * to: DexScreener (pairs/trending/boosted/profiles), Birdeye (token search +
+ * wallet portfolio), and CoinGecko (search/token/trending via direct REST
+ * calls, no SDK). Each `execute*` function switches on `params.subaction`,
+ * emits through the action callback via `emit`, and reports failures with a
+ * provider-scoped `target` field rather than throwing.
+ */
 import type { ActionResult, ContentValue, IAgentRuntime } from "@elizaos/core";
 import { BirdeyeProvider } from "../birdeye/birdeye";
 import { searchBirdeyeTokens } from "../birdeye/search-category";

--- a/plugins/plugin-wallet/src/analytics/token-info/service.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/service.ts
@@ -1,3 +1,12 @@
+/**
+ * `TokenInfoService` (`serviceType: "token-info"`): a provider registry that
+ * routes a `TokenInfoParams` query to the named/aliased provider, or, when
+ * none is named, to the subaction's default provider
+ * (`DEFAULT_PROVIDER_BY_SUBACTION`) and falls back to the single provider
+ * that supports it if there's exactly one candidate. Bundled providers are
+ * DexScreener, Birdeye, and CoinGecko (`./providers`); more can be added via
+ * `registerProvider`.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import {
   createBirdeyeTokenInfoProvider,

--- a/plugins/plugin-wallet/src/analytics/token-info/types.ts
+++ b/plugins/plugin-wallet/src/analytics/token-info/types.ts
@@ -1,3 +1,4 @@
+/** Shared contracts between `TokenInfoService`, its providers, and the `token_info` action handler. */
 import type {
   ActionResult,
   HandlerCallback,

--- a/plugins/plugin-wallet/src/api/wallet-routes.test.ts
+++ b/plugins/plugin-wallet/src/api/wallet-routes.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Confirms the plaintext private-key export route stays hard-disabled
+ * (HTTP 410, no key material in the response) against a hand-built
+ * `WalletRouteContext` mock — no real HTTP server or wallet backend involved.
+ */
 import { describe, expect, it, vi } from "vitest";
 import { handleWalletRoutes, type WalletRouteContext } from "./wallet-routes";
 

--- a/plugins/plugin-wallet/src/audit/audit-log.test.ts
+++ b/plugins/plugin-wallet/src/audit/audit-log.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Wallet audit log integrity (#8801 — shipped untested). Each row is a SHA-256
+ * over its canonical fields, chained via `prevHash`, so the log is tamper-
+ * evident: `verifyAuditLogRow` must accept an untouched row and REJECT any row
+ * whose content, prevHash, or stored hash was altered after the fact. That
+ * tamper-detection is the whole point of the log, so it is pinned here.
+ */
 import { describe, expect, it } from "vitest";
 import {
   type AuditLogRow,
@@ -6,13 +13,6 @@ import {
   verifyAuditLogRow,
 } from "./audit-log.ts";
 
-/**
- * Wallet audit log integrity (#8801 — shipped untested). Each row is a SHA-256
- * over its canonical fields, chained via `prevHash`, so the log is tamper-
- * evident: `verifyAuditLogRow` must accept an untouched row and REJECT any row
- * whose content, prevHash, or stored hash was altered after the fact. That
- * tamper-detection is the whole point of the log, so it is pinned here.
- */
 const input = (over: Partial<AuditLogRowInput> = {}): AuditLogRowInput =>
   ({
     actor: "agent",

--- a/plugins/plugin-wallet/src/audit/audit-log.ts
+++ b/plugins/plugin-wallet/src/audit/audit-log.ts
@@ -1,3 +1,10 @@
+/**
+ * Hash-chained, append-only audit log row for wallet actions and signing
+ * events. Each row's `rowHash` is a SHA-256 over its canonical fields
+ * (including `prevHash`, which links to the previous row), so
+ * `verifyAuditLogRow` can detect any row whose content, chain link, or
+ * stored hash was altered after the fact.
+ */
 import { createHash } from "node:crypto";
 import type {
   ActionFailureCode,
@@ -28,9 +35,6 @@ export type AuditOutcome =
   | "approved"
   | "rejected";
 
-/**
- * Row shape for the append-only audit log.
- */
 export interface AuditLogRow {
   readonly id: bigint;
   readonly ts: number;

--- a/plugins/plugin-wallet/src/automation-node-contributor.test.ts
+++ b/plugins/plugin-wallet/src/automation-node-contributor.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Covers `registerWalletAutomationNodeContributor`'s node availability logic
+ * (disabled by default, enabled once the wallet plugin or a matching action
+ * is present) against a hand-built runtime context — no real agent runtime.
+ */
 import {
   type AutomationNodeContributorContext,
   clearAutomationNodeContributorsForTests,

--- a/plugins/plugin-wallet/src/automation-node-contributor.ts
+++ b/plugins/plugin-wallet/src/automation-node-contributor.ts
@@ -1,3 +1,9 @@
+/**
+ * Automation catalog nodes owned by the wallet plugin. These cover EVM + Solana
+ * swaps and cross-chain bridges backed by the wallet plugin's runtime actions.
+ * They live here (not hardcoded in app-core) so a wallet action rename or plugin
+ * name change updates the node in one place with the code it gates.
+ */
 import {
   type AutomationNodeContributorContext,
   buildRuntimeCapabilityNodes,
@@ -6,12 +12,6 @@ import {
 } from "@elizaos/app-core/api/automation-node-contributors";
 import type { AutomationNodeDescriptor } from "@elizaos/ui";
 
-/**
- * Automation catalog nodes owned by the wallet plugin. These cover EVM + Solana
- * swaps and cross-chain bridges backed by the wallet plugin's runtime actions.
- * They live here (not hardcoded in app-core) so a wallet action rename or plugin
- * name change updates the node in one place with the code it gates.
- */
 const WALLET_AUTOMATION_NODE_SPECS: RuntimeCapabilityNodeSpec[] = [
   {
     id: "crypto:evm.swap",

--- a/plugins/plugin-wallet/src/browser-shim/index.ts
+++ b/plugins/plugin-wallet/src/browser-shim/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the browser-environment wallet shim builder. */
 export {
   buildWalletShim,
   buildWalletShimFromTemplate,

--- a/plugins/plugin-wallet/src/chains/__tests__/wallet-router.test.ts
+++ b/plugins/plugin-wallet/src/chains/__tests__/wallet-router.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Exercises `walletRouterAction`'s real chain-selection, confirmation-gate,
+ * and dry-run logic end to end against fake `IAgentRuntime`/chain-handler
+ * doubles — no live model, network, or chain, but the routing/gating code
+ * under test is the real production path, not a stub.
+ */
 import type { HandlerOptions, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { WalletBackendService } from "../../services/wallet-backend-service";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/custom-chain.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/custom-chain.ts
@@ -1,7 +1,11 @@
+/**
+ * EVM test-chain fixtures: viem chain definitions and well-known local/testnet
+ * accounts shared across the EVM wallet test suites. The private keys here are
+ * the public, well-known Anvil default-mnemonic keys — never real funds.
+ */
 import { defineChain } from "viem";
 import { arbitrumSepolia, baseSepolia, hardhat, optimismSepolia, sepolia } from "viem/chains";
 
-// Export the actual testnets we'll use
 export { arbitrumSepolia, baseSepolia, hardhat, optimismSepolia, sepolia };
 
 // Local Anvil chain configuration

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/live-rpc.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/live-rpc.ts
@@ -1,3 +1,14 @@
+/**
+ * Shared helpers for the live-RPC integration tests: loads `.env.local` candidates
+ * (repo root, eliza/cloud, eliza/steward-fi) for credentials, then resolves which
+ * RPC transport to exercise — Eliza Cloud's proxy route when `ELIZAOS_CLOUD_API_KEY`
+ * is set and its `eth_blockNumber` probe succeeds, otherwise the first responsive
+ * public RPC from a per-chain candidate list (env-configured URLs first, then
+ * hardcoded public endpoints). Results are cached per-process via
+ * `HEALTHY_RPC_CACHE` and `cloudRpcReadyPromise` so repeated probes in the same
+ * test run don't re-hit the network. `LIVE_EVM_RPC_TEST` gates whether the real
+ * on-chain integration tests run at all.
+ */
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/transfer.live.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/transfer.live.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Live-network EVM transfer tests: exercises `TransferAction`/`WalletProvider`
+ * against real mainnet/base/bsc RPC endpoints (Eliza Cloud RPC when
+ * `ELIZAOS_CLOUD_API_KEY` is set, else public fallback RPCs) with a
+ * generated or env-supplied unfunded key — no mocked chain state.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { Account } from "viem";
 import { formatEther, parseEther } from "viem";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/test-utils.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/test-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Test-only runtime factory for EVM chain tests: wraps the core PGlite-backed
+ * test runtime helper and tracks each runtime's cleanup function in a WeakMap so
+ * callers can tear it down without holding onto the closure themselves.
+ */
 import type { AgentRuntime } from "@elizaos/core";
 
 import { createTestRuntime as createPgliteRuntime } from "../../../../../../packages/core/test/helpers/pglite-runtime";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/chain-handler.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/chain-handler.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `createEvmWalletChainHandler`'s prepare/execute transfer and
+ * swap paths, and for the router's dedup of transfer/swap planner actions.
+ * The wallet client and its `sendTransaction` are faked — no real signing or
+ * network calls.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { parseEther } from "viem";
 import { base, mainnet } from "viem/chains";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `buildSwapDetails`'s relative-amount resolution
+ * (absolute/half/max/percent → concrete token amount from wallet balance).
+ * The intent-extraction LLM call is mocked to return fixed JSON so each case
+ * isolates the arithmetic and validation, not model behavior.
+ */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { base } from "viem/chains";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
@@ -1,18 +1,18 @@
+/**
+ * Regression guard for a per-reply hang: `evmWalletProvider.get()` runs inside
+ * `composeState` on every message and is awaited before the agent replies, so
+ * a balance RPC against a slow/unreachable endpoint must bound itself rather
+ * than block the turn until `composeState`'s provider timeout fires.
+ * `getWalletBalanceForChain` is expected to resolve to `null` (same as any RPC
+ * error) instead of hanging. Uses fake timers and a mocked public client — no
+ * real RPC calls.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { generatePrivateKey } from "viem/accounts";
 import { mainnet } from "viem/chains";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WalletProvider } from "../../providers/wallet";
 
-/**
- * Regression guard for the dedicated-agent "~28s per reply" hang.
- *
- * evmWalletProvider.get() runs inside composeState on every message and is
- * awaited before the agent replies. A balance RPC against a slow/unreachable
- * endpoint used to hang until composeState's 30s provider cap fired, blocking the
- * whole turn. getWalletBalanceForChain now bounds the RPC and must resolve to
- * null (handled like any RPC error) instead of hanging.
- */
 function makeRuntime(): IAgentRuntime {
   return {
     getCache: vi.fn(async () => null),

--- a/plugins/plugin-wallet/src/chains/evm/actions/helpers.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared helpers for the EVM wallet actions: the EVM-private-key validator
+ * gate, the `confirmationRequired` response shape that stages an on-chain
+ * action pending a user confirmation turn, and `buildSendTxParams` for
+ * assembling viem `SendTransactionParameters` from optional fields. See
+ * `isConfirmed` for why LLM-supplied confirmation flags are never trusted.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -1,3 +1,13 @@
+/**
+ * EVM token swap: `SwapAction` shops a quote across Li.Fi, Bebop, and
+ * KyberSwap (best-price-first, with slippage escalation and per-quote error
+ * recovery across `slippageLevels`), handles ERC-20 approval when needed, and
+ * submits the winning route's transaction. `buildSwapDetails` turns the LLM's
+ * structured intent into concrete `SwapParams`, resolving relative amounts
+ * (half/max/percent) against the wallet's live chain balance. `swapAction` is
+ * the `WALLET`/`swap` subaction entry point and always runs through
+ * `gateWalletFinancialExecution` before submission.
+ */
 import type { ActionResult, HandlerCallback, IAgentRuntime, Memory, State } from "@elizaos/core";
 import {
   gateWalletFinancialExecution,

--- a/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
@@ -1,3 +1,10 @@
+/**
+ * EVM native/token transfer: `TransferAction.transfer` sends a native-value
+ * transaction (with optional calldata) through the resolved wallet client.
+ * `buildTransferDetails` turns the LLM's structured reply into validated
+ * `TransferParams`, checking the target chain against the wallet's
+ * configured chains before returning.
+ */
 import {
   composePromptFromState,
   type IAgentRuntime,

--- a/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
+++ b/plugins/plugin-wallet/src/chains/evm/bridge-router.ts
@@ -1,3 +1,13 @@
+/**
+ * Cross-chain EVM bridging via Li.Fi: `BridgeAction` quotes routes, executes
+ * the selected route through the LiFi SDK's `EVM` provider (wired to the
+ * wallet's own signer/chain-switch through the adapter functions above),
+ * tracks in-flight route status in `activeRoutes`, and polls the bridge
+ * status endpoint until the route completes or times out. `routeEvmBridge`
+ * is the `WALLET`/`bridge` subaction entry point: it returns a `prepare`
+ * quote (no signing) or drives a full `execute` bridge and returns the
+ * submitted transaction.
+ */
 import { logger } from "@elizaos/core";
 import {
   createConfig,

--- a/plugins/plugin-wallet/src/chains/evm/build.ts
+++ b/plugins/plugin-wallet/src/chains/evm/build.ts
@@ -1,4 +1,10 @@
 #!/usr/bin/env bun
+/**
+ * Build script for the EVM chain subpackage: bundles `index.ts` with
+ * `Bun.build` (externalizing `@elizaos/core` and the on-chain SDK deps),
+ * then runs `tsc --noCheck` to emit type declarations, writing a fallback
+ * `index.d.ts` barrel if `tsc` doesn't produce one.
+ */
 
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";

--- a/plugins/plugin-wallet/src/chains/evm/chain-handler.ts
+++ b/plugins/plugin-wallet/src/chains/evm/chain-handler.ts
@@ -1,3 +1,11 @@
+/**
+ * `EvmWalletChainHandler` implements `WalletChainHandler` for a single EVM
+ * chain, dispatching `transfer`/`swap`/`gov` subactions from the wallet
+ * router: `prepare*` methods stage a transaction without signing, `execute*`
+ * methods resolve token addresses (native, address, or via the token-data
+ * service), build calldata, and submit through the wallet's signer. One
+ * instance is registered per configured chain by `chains/registry.ts`.
+ */
 import type { ITokenDataService } from "@elizaos/core";
 import {
   type Address,

--- a/plugins/plugin-wallet/src/chains/evm/constants.ts
+++ b/plugins/plugin-wallet/src/chains/evm/constants.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared constants for EVM wallet operations: service/cache keys, gas and
+ * slippage tuning, the sentinel native-token address (plus KyberSwap's
+ * distinct native sentinel), per-aggregator chain-name maps, and the
+ * default chain set.
+ */
 export const EVM_SERVICE_NAME = "evmService" as const;
 export const EVM_WALLET_DATA_CACHE_KEY = "evm_wallet_data" as const;
 export const CACHE_REFRESH_INTERVAL_MS = 60000;

--- a/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Aerodrome (Base) DEX liquidity-pool management sub-plugin: registers
+ * `AerodromeLpService` and its LP protocol provider with the shared
+ * `LpManagementService` registry.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createEvmLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/services/AerodromeLpService.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/services/AerodromeLpService.ts
@@ -1,3 +1,10 @@
+/**
+ * `AerodromeLpService` implements `IEvmLpService` for Aerodrome, the ve(3,3)
+ * DEX on Base (chain 8453 only): pool lookup/reads via the factory and pool
+ * contracts, and add/remove-liquidity writes through the Aerodrome router
+ * with ERC-20 approval handled inline. `getAllPositions` is not implemented
+ * (would need pool tracking or an indexer) and always returns an empty list.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   type Address,
@@ -518,9 +525,8 @@ export class AerodromeLpService extends Service implements IEvmLpService {
   async getAllPositions(chainId: number, _owner: Address): Promise<EvmPositionDetails[]> {
     if (!this.supportsChain(chainId)) return [];
 
-    // For Aerodrome, we would need to iterate through known pools
-    // This is a simplified implementation - in production, you'd want to
-    // track pools the user has interacted with or use an indexer
+    // Not implemented: would require tracking pools the user has interacted
+    // with, or an indexer, since Aerodrome has no on-chain "positions by owner" query.
     logger.info(`[AerodromeLpService] getAllPositions not fully implemented - need pool tracking`);
     return [];
   }

--- a/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/types.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/aerodrome/types.ts
@@ -1,9 +1,8 @@
-import type { Address } from "viem";
-
 /**
  * Aerodrome DEX specific types
  * Aerodrome is a ve(3,3) DEX on Base, fork of Velodrome
  */
+import type { Address } from "viem";
 
 export type AerodromePoolType = "volatile" | "stable";
 

--- a/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/index.ts
@@ -1,3 +1,8 @@
+/**
+ * PancakeSwap V3 liquidity-pool management sub-plugin: registers
+ * `PancakeSwapV3LpService` and its LP protocol provider with the shared
+ * `LpManagementService` registry.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createEvmLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/services/PancakeSwapV3LpService.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/services/PancakeSwapV3LpService.ts
@@ -1,3 +1,10 @@
+/**
+ * `PancakeSwapV3LpService` implements `IEvmLpService` for PancakeSwap V3
+ * across BSC, Ethereum, Arbitrum, and Base: concentrated-liquidity pool
+ * reads via the factory/pool contracts, and NFT-position mint/decrease/
+ * collect/burn writes through the nonfungible position manager, with
+ * per-chain RPC clients and ERC-20 approval handled inline.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   type Address,

--- a/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/types.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/pancakeswp/types.ts
@@ -1,9 +1,8 @@
-import type { Address } from "viem";
-
 /**
  * PancakeSwap V3 specific types
  * PancakeSwap V3 is based on Uniswap V3 with some modifications
  */
+import type { Address } from "viem";
 
 export const PANCAKESWAP_V3_FEE_TIERS = {
   LOWEST: 100, // 0.01%

--- a/plugins/plugin-wallet/src/chains/evm/dex/uniswap/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/uniswap/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Uniswap V3 liquidity-pool management sub-plugin: registers
+ * `UniswapV3LpService` and its LP protocol provider with the shared
+ * `LpManagementService` registry.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createEvmLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/evm/dex/uniswap/services/UniswapV3LpService.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/uniswap/services/UniswapV3LpService.ts
@@ -1,3 +1,10 @@
+/**
+ * `UniswapV3LpService` implements `IEvmLpService` for Uniswap V3 across
+ * Ethereum, Base, Arbitrum, Polygon, and Optimism: concentrated-liquidity
+ * pool reads via the factory/pool contracts, and NFT-position mint/decrease/
+ * collect/burn writes through the nonfungible position manager, with
+ * per-chain RPC clients and ERC-20 approval handled inline.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   type Address,
@@ -66,7 +73,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
   }
 
   private initializeRpcUrls(): void {
-    // Try to get RPC URLs from settings
     const rpcSettings: Record<number, string[]> = {
       1: ["ETHEREUM_RPC_URL", "ETH_RPC_URL", "EVM_PROVIDER_MAINNET"],
       8453: ["BASE_RPC_URL", "EVM_PROVIDER_BASE"],
@@ -233,7 +239,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
         }),
       ]);
 
-      // Get token info
       const [symbol0, decimals0, symbol1, decimals1] = await Promise.all([
         client
           .readContract({
@@ -315,18 +320,15 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       const publicClient = this.getPublicClient(params.chainId);
       const walletClient = this.getWalletClient(params.chainId, params.wallet.privateKey);
 
-      // Get pool info
       const poolInfo = await this.getPoolInfo(params.chainId, params.poolAddress);
       if (!poolInfo) {
         return { success: false, error: "Pool not found" };
       }
 
-      // Calculate min amounts with slippage
       const slippageMultiplier = BigInt(10000 - params.slippageBps);
       const amount0Min = (params.tokenAAmount * slippageMultiplier) / 10000n;
       const amount1Min = ((params.tokenBAmount ?? 0n) * slippageMultiplier) / 10000n;
 
-      // Approve tokens if needed
       await this.approveToken(
         params.chainId,
         params.wallet.privateKey,
@@ -347,11 +349,10 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
 
       const deadline = params.deadline ?? BigInt(Math.floor(Date.now() / 1000) + 1800); // 30 min default
 
-      // Determine tick range
       const tickLower = params.tickLower ?? poolInfo.currentTick! - 1000;
       const tickUpper = params.tickUpper ?? poolInfo.currentTick! + 1000;
 
-      // Align ticks to tick spacing
+      // Align ticks to the pool's spacing so the position is valid on-chain.
       const tickSpacing = poolInfo.tickSpacing ?? 60;
       const alignedTickLower = Math.floor(tickLower / tickSpacing) * tickSpacing;
       const alignedTickUpper = Math.ceil(tickUpper / tickSpacing) * tickSpacing;
@@ -426,13 +427,11 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       const publicClient = this.getPublicClient(params.chainId);
       const walletClient = this.getWalletClient(params.chainId, params.wallet.privateKey);
 
-      // Get position info
       const position = await this.getPositionFromContract(params.chainId, params.tokenId);
       if (!position) {
         return { success: false, error: "Position not found" };
       }
 
-      // Calculate liquidity to remove
       let liquidityToRemove = position.liquidity;
       if (params.percentageToRemove && params.percentageToRemove < 100) {
         liquidityToRemove = (position.liquidity * BigInt(params.percentageToRemove)) / 100n;
@@ -441,7 +440,8 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       const deadline = params.deadline ?? BigInt(Math.floor(Date.now() / 1000) + 1800);
       const _slippageMultiplier = BigInt(10000 - params.slippageBps);
 
-      // First, decrease liquidity
+      // Removing liquidity is a two-step position-manager protocol: decrease
+      // liquidity first, then collect the freed tokens as a separate call.
       const decreaseParams = {
         tokenId: params.tokenId,
         liquidity: liquidityToRemove,
@@ -461,7 +461,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       const decreaseHash = await walletClient.writeContract(decreaseRequest);
       await publicClient.waitForTransactionReceipt({ hash: decreaseHash });
 
-      // Then collect the tokens
       const collectParams = {
         tokenId: params.tokenId,
         recipient: params.wallet.address,
@@ -568,7 +567,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
   ): Promise<EvmPositionDetails | null> {
     if (!this.supportsChain(chainId)) return null;
 
-    // If we have a token ID, get that specific position
     if (tokenId) {
       const position = await this.getPositionFromContract(chainId, tokenId);
       if (!position) return null;
@@ -576,7 +574,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       const client = this.getPublicClient(chainId);
       const _chain = getViemChain(chainId);
 
-      // Get token info
       const [symbol0, decimals0, symbol1, decimals1] = await Promise.all([
         client
           .readContract({
@@ -642,7 +639,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       };
     }
 
-    // Otherwise, find positions for this owner in this pool
     const positions = await this.getAllPositions(chainId, owner);
     return positions.find((p) => p.poolId.toLowerCase() === poolAddress.toLowerCase()) ?? null;
   }
@@ -674,7 +670,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
 
         const position = await this.getPositionFromContract(chainId, tokenId as bigint);
         if (position && position.liquidity > 0n) {
-          // Find the pool address
           const poolAddress = await client.readContract({
             address: addresses.factory,
             abi: UNISWAP_V3_FACTORY_ABI,
@@ -709,7 +704,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
     const result: Record<string, Partial<EvmPoolInfo>> = {};
 
     for (const address of poolAddresses) {
-      // Try each supported chain
       for (const chainId of this.getSupportedChainIds()) {
         try {
           const poolInfo = await this.getPoolInfo(chainId, address);
@@ -740,7 +734,6 @@ export class UniswapV3LpService extends Service implements IEvmLpService {
       throw new Error("Wallet account is required to approve token spending.");
     }
 
-    // Check current allowance
     const allowance = await publicClient.readContract({
       address: tokenAddress,
       abi: ERC20_ABI,

--- a/plugins/plugin-wallet/src/chains/evm/dex/uniswap/types.ts
+++ b/plugins/plugin-wallet/src/chains/evm/dex/uniswap/types.ts
@@ -1,8 +1,7 @@
-import type { Address } from "viem";
-
 /**
  * Uniswap V3 specific types
  */
+import type { Address } from "viem";
 
 export const UNISWAP_V3_FEE_TIERS = {
   LOWEST: 100, // 0.01%

--- a/plugins/plugin-wallet/src/chains/evm/gov-router.ts
+++ b/plugins/plugin-wallet/src/chains/evm/gov-router.ts
@@ -1,3 +1,10 @@
+/**
+ * On-chain governance (OpenZeppelin `Governor`) support for the `WALLET`/`gov`
+ * subaction: validates op-specific required params, ABI-encodes the
+ * propose/vote/queue/execute calldata against the `OZGovernor` artifact, and
+ * `routeEvmGovernance` either returns a `prepare` quote or submits the
+ * transaction through the wallet's signer.
+ */
 import type { Chain, Hex } from "viem";
 import {
   type Address,

--- a/plugins/plugin-wallet/src/chains/evm/index.browser.ts
+++ b/plugins/plugin-wallet/src/chains/evm/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build facade for the EVM plugin: real EVM signing needs Node-only
+ * dependencies, so the browser bundle swaps in this no-op stub that only
+ * warns and directs callers to a server proxy.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-wallet/src/chains/evm/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/index.ts
@@ -1,3 +1,9 @@
+/**
+ * EVM sub-plugin composed into `@elizaos/plugin-wallet`'s top-level
+ * `walletPlugin` — not intended to be loaded standalone. Registers
+ * `EVMService`, the EVM wallet/balance providers, the sign HTTP routes, and
+ * the `WALLET` subactions promoted from `walletRouterAction`.
+ */
 import type { Action, IAgentRuntime, Plugin, ServiceClass } from "@elizaos/core";
 import { promoteSubactionsToActions } from "@elizaos/core";
 import { walletRouterAction } from "../wallet-action";

--- a/plugins/plugin-wallet/src/chains/evm/providers/get-balance.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/get-balance.ts
@@ -1,3 +1,11 @@
+/**
+ * `tokenBalanceProvider` injects an ERC-20 balance into planner context when
+ * the incoming message looks balance/token-related (keyword + regex gate).
+ * It runs a small-model intent extraction to pull the token symbol and chain
+ * from free text, resolves the token address via Li.Fi, and reads the
+ * on-chain balance directly. Returns an empty result on no-match, and a
+ * text-only error result (never throws) when resolution fails.
+ */
 import {
   type IAgentRuntime,
   type Memory,

--- a/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
@@ -1,3 +1,16 @@
+/**
+ * EVM wallet: `WalletProvider` wraps a viem account across the agent's
+ * configured chains, resolving RPC transport per chain (managed/Eliza-Cloud
+ * RPC with auto-fallback to the chain's default RPC on auth failure, or a
+ * direct custom/default URL) and bounding balance reads so a slow endpoint
+ * can never stall a reply turn. `LazyTeeWalletProvider` defers key
+ * derivation to the TEE service and proxies signing calls once ready.
+ * `initWalletProvider` is the entry point: it resolves TEE vs local-key mode
+ * and generates+persists a new `EVM_PRIVATE_KEY` if none is configured.
+ * `evmWalletProvider` is the planner-context provider that surfaces the
+ * address and per-chain balances, preferring `EVMService`'s cache and
+ * falling back to a direct fetch.
+ */
 import * as path from "node:path";
 import {
   type IAgentRuntime,
@@ -432,7 +445,6 @@ function genChainsFromRuntime(runtime: IAgentRuntime): {
 
   const chainsToUse = configuredChains.length > 0 ? configuredChains : [...DEFAULT_CHAINS];
 
-  // Validate RPC provider configuration
   const validation = validateRPCProviderConfig(runtime);
   for (const warning of validation.warnings) {
     logger.warn(warning);
@@ -441,7 +453,6 @@ function genChainsFromRuntime(runtime: IAgentRuntime): {
     logger.info(`EVM RPC providers available: ${validation.providers.join(", ")}`);
   }
 
-  // Initialize the multi-provider RPC manager
   const rpcManager = initRPCProviderManager(runtime);
 
   const chains: Record<string, Chain> = {};

--- a/plugins/plugin-wallet/src/chains/evm/routes/sign.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/routes/sign.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for the browser EVM signing HTTP routes (`evmSignRoutes`):
+ * token-gating (503 when unconfigured, 401 on a wrong token), CORS behavior
+ * (no credentialed cross-origin reflection, loopback origins allowed), and
+ * request validation (chain id, bigint fields) short-circuiting before the
+ * wallet backend is ever touched. `resolveWalletBackend` is mocked — no
+ * real signing occurs.
+ */
 import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { evmSignRoutes } from "./sign";

--- a/plugins/plugin-wallet/src/chains/evm/service.ts
+++ b/plugins/plugin-wallet/src/chains/evm/service.ts
@@ -1,3 +1,11 @@
+/**
+ * `EVMService` owns the periodic refresh of the agent's EVM wallet
+ * address/balances into runtime cache (`EVM_WALLET_DATA_CACHE_KEY`), on a
+ * `CACHE_REFRESH_INTERVAL_MS` timer plus on-demand `forceUpdate`.
+ * `getCachedData` serves the cache and transparently refreshes when stale;
+ * `evmWalletProvider` (`providers/wallet.ts`) reads through this service
+ * before falling back to a direct fetch.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import {
   CACHE_REFRESH_INTERVAL_MS,

--- a/plugins/plugin-wallet/src/chains/evm/templates/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/templates/index.ts
@@ -1,3 +1,4 @@
+/** Re-exports the EVM action prompt templates from `../prompts`. */
 export {
   bridgeTemplate,
   executeProposalTemplate,

--- a/plugins/plugin-wallet/src/chains/evm/tests/json-integration.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/tests/json-integration.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Live-LLM integration test for `parseJSONObjectFromText`: sends a real
+ * transfer-extraction prompt to a live Anthropic/OpenAI/Groq model (whichever
+ * API key is configured) and asserts the parsed JSON contains the expected
+ * chain/amount/address. Skipped unless `ELIZA_LIVE_JSON_TEST=1` (or
+ * `ELIZA_LIVE_TEST=1`) and a provider key is present.
+ */
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";

--- a/plugins/plugin-wallet/src/chains/evm/types/index.ts
+++ b/plugins/plugin-wallet/src/chains/evm/types/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Central EVM types module: zod schemas (and their inferred types) for
+ * addresses/hashes/hex/amounts and each action's params (transfer, swap,
+ * bridge, governance vote/queue/execute), the `EVMError`/`EVMErrorCode`
+ * error type used across the EVM chain, and small runtime assertion helpers
+ * (`assertDefined`, `assertChainConfigured`) used at wallet-provider
+ * boundaries.
+ */
 import type { Route, Token } from "@lifi/sdk";
 import type {
   Account,

--- a/plugins/plugin-wallet/src/chains/evm/vitest.config.ts
+++ b/plugins/plugin-wallet/src/chains/evm/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for the EVM chain subpackage; excludes live/real/e2e suites from the default run. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-wallet/src/chains/registry.ts
+++ b/plugins/plugin-wallet/src/chains/registry.ts
@@ -1,3 +1,15 @@
+/**
+ * `registerDefaultWalletChainHandlers` builds and registers the default
+ * `WalletChainHandler`s on the `WalletBackendService`: one EVM handler per
+ * configured chain (transfer/swap/bridge, delegating swap to `SwapAction`
+ * and bridge to `routeEvmBridge`), a Solana handler (native SOL transfer
+ * plus SPL transfer/swap via Jupiter, built by hand rather than through a
+ * shared SDK), and a pump.fun handler that requests a serialized buy
+ * transaction from PumpPortal's trade-local API, signs it through the
+ * resolved wallet backend or local keypair, and submits it directly to
+ * Solana RPC. All execute paths assume the caller has already passed the
+ * financial-confirmation gate upstream.
+ */
 import type { IAgentRuntime, ITokenDataService } from "@elizaos/core";
 import {
   createAssociatedTokenAccountInstruction,

--- a/plugins/plugin-wallet/src/chains/solana/actions/confirmation.ts
+++ b/plugins/plugin-wallet/src/chains/solana/actions/confirmation.ts
@@ -1,3 +1,9 @@
+/**
+ * Solana counterpart of the EVM confirmation helper: `confirmationRequired`
+ * builds the staged-but-unsigned response shape that asks the user to
+ * confirm before an on-chain Solana action executes. See `isConfirmed` for
+ * why LLM-supplied confirmation flags are never trusted.
+ */
 import type { ActionResult, HandlerCallback } from "@elizaos/core";
 
 type ConfirmationValue =

--- a/plugins/plugin-wallet/src/chains/solana/bn.ts
+++ b/plugins/plugin-wallet/src/chains/solana/bn.ts
@@ -1,3 +1,4 @@
+/** Re-exports `bignumber.js` as the shared arbitrary-precision type for Solana token/lamport math. */
 import type { default as BigNumberType } from "bignumber.js";
 import BigNumberLib from "bignumber.js";
 

--- a/plugins/plugin-wallet/src/chains/solana/build.ts
+++ b/plugins/plugin-wallet/src/chains/solana/build.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env bun
+/**
+ * Build script for the Solana chain subpackage: bundles `index.ts` with
+ * `Bun.build`, externalizing every declared dependency from `package.json`,
+ * then runs `tsc --noCheck` to emit type declarations.
+ */
 
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";

--- a/plugins/plugin-wallet/src/chains/solana/constants.ts
+++ b/plugins/plugin-wallet/src/chains/solana/constants.ts
@@ -1,2 +1,3 @@
+/** Service registration key and wallet-data cache key for the Solana chain. */
 export const SOLANA_SERVICE_NAME = "chain_solana";
 export const SOLANA_WALLET_DATA_CACHE_KEY = "solana/walletData";

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/e2e/scenarios.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/e2e/scenarios.ts
@@ -1,9 +1,3 @@
-import { strict as assert } from "node:assert";
-import type { IAgentRuntime, Memory, State, TestSuite } from "@elizaos/core";
-import { Keypair } from "@solana/web3.js";
-import { meteoraPositionProvider } from "../providers/positionProvider.ts";
-import type { MeteoraLpService } from "../services/MeteoraLpService.ts";
-
 /**
  * Defines a suite of E2E tests for Meteora LP management scenarios.
  *
@@ -11,6 +5,12 @@ import type { MeteoraLpService } from "../services/MeteoraLpService.ts";
  * interactions including pool discovery, liquidity provision, position management,
  * and market data retrieval.
  */
+import { strict as assert } from "node:assert";
+import type { IAgentRuntime, Memory, State, TestSuite } from "@elizaos/core";
+import { Keypair } from "@solana/web3.js";
+import { meteoraPositionProvider } from "../providers/positionProvider.ts";
+import type { MeteoraLpService } from "../services/MeteoraLpService.ts";
+
 export const meteoraScenarios: TestSuite = {
   name: "Meteora Plugin E2E Scenarios",
   tests: [
@@ -22,7 +22,6 @@ export const meteoraScenarios: TestSuite = {
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
         assert(meteoraService, "MeteoraLpService should be available");
 
-        // Test getting all pools
         const allPools = await meteoraService.getPools();
         console.log(`Found ${allPools.length} Meteora pools`);
 
@@ -48,7 +47,6 @@ export const meteoraScenarios: TestSuite = {
 
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
 
-        // Test with specific token pair filter
         const solUsdcMint = "So11111111111111111111111111111111111111112"; // SOL
         const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"; // USDC
 
@@ -77,11 +75,10 @@ export const meteoraScenarios: TestSuite = {
 
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
 
-        // First get some pools to test with
         const pools = await meteoraService.getPools();
         assert(pools.length > 0, "Need at least one pool for market data test");
 
-        const poolIds = pools.slice(0, 3).map((p) => p.id); // Test with first 3 pools
+        const poolIds = pools.slice(0, 3).map((p) => p.id);
         const marketData = await meteoraService.getMarketDataForPools(poolIds);
 
         assert(typeof marketData === "object", "Market data should be an object");
@@ -130,8 +127,6 @@ export const meteoraScenarios: TestSuite = {
       fn: async (runtime: IAgentRuntime) => {
         console.log("Testing position provider integration...");
 
-        // Test that the position provider is properly registered and can be called
-        // Create a minimal Memory object for testing
         const testMemory: Memory = {
           id: "test-memory-id",
           entityId: "test-user",
@@ -167,10 +162,8 @@ export const meteoraScenarios: TestSuite = {
 
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
 
-        // Test start/stop methods exist and can be called
         assert(typeof meteoraService.stop === "function", "Service should have stop method");
 
-        // These should not throw errors
         await meteoraService.stop();
 
         console.log("✅ Service lifecycle test passed");
@@ -184,7 +177,6 @@ export const meteoraScenarios: TestSuite = {
 
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
 
-        // Test with invalid pool ID
         const invalidPoolId = "invalid-pool-id-12345";
         const userKeypair = Keypair.generate();
 
@@ -214,7 +206,6 @@ export const meteoraScenarios: TestSuite = {
         // Use a random public key that likely has no positions
         const randomUser = Keypair.generate().publicKey.toBase58();
 
-        // Get a real pool ID to test with
         const pools = await meteoraService.getPools();
         if (pools.length === 0) {
           console.log("Skipping test - no pools available");
@@ -224,7 +215,6 @@ export const meteoraScenarios: TestSuite = {
         const poolId = pools[0].id;
         const positionDetails = await meteoraService.getLpPositionDetails(randomUser, poolId);
 
-        // Should return null for user with no positions
         assert(positionDetails === null, "Should return null for user with no positions");
 
         console.log("✅ Position details test passed");
@@ -238,7 +228,6 @@ export const meteoraScenarios: TestSuite = {
 
         const meteoraService = runtime.getService("meteora-lp") as MeteoraLpService;
 
-        // Get a real pool ID
         const pools = await meteoraService.getPools();
         if (pools.length === 0) {
           console.log("Skipping test - no pools available");

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/e2e/test-utils.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/e2e/test-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Scenario-test helpers for the Meteora E2E suite: `setupScenario` creates a
+ * fresh world/user/room against a live `IAgentRuntime`, and
+ * `sendMessageAndWaitForResponse` emits a `MESSAGE_RECEIVED` event and
+ * resolves once the agent's response callback fires.
+ */
 import { strict as assert } from "node:assert";
 import {
   asUUID,

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Meteora (Solana DLMM) liquidity-pool management sub-plugin. `init`
+ * dynamically imports `MeteoraLpService` because its DLMM dependency is
+ * optional; if that import fails, Meteora LP support is silently disabled
+ * rather than blocking agent boot. Registers the service's LP protocol
+ * provider with the shared `LpManagementService` registry.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createSolanaLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/providers/positionProvider.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/providers/positionProvider.ts
@@ -1,3 +1,9 @@
+/**
+ * Meteora DLMM position provider: injects the agent wallet's current Meteora
+ * LP positions (pool, in-range status, bin distance/range) into planner
+ * context. Scans a fixed seed pool list rather than a live pool discovery
+ * API; extend `POOL_ADDRESSES` in `fetchPositions` to track more pools.
+ */
 import {
   elizaLogger,
   type IAgentRuntime,
@@ -104,7 +110,6 @@ export const meteoraPositionProvider: Provider = {
       } else {
         positionText = `Found ${positionCount} Meteora LP position${positionCount > 1 ? "s" : ""}. ${inRangeCount} ${inRangeCount === 1 ? "is" : "are"} currently in range.`;
 
-        // Add details for each position
         positions.forEach((pos, index) => {
           positionText += `\n\nPosition ${index + 1}:`;
           positionText += `\n- Pool: ${pos.poolAddress.slice(0, 8)}...`;

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/services/MeteoraLpService.ts
@@ -1,3 +1,13 @@
+/**
+ * Meteora DLMM adapter implementing the wallet plugin's DEX/LP surface
+ * (`getPools`, `addLiquidity`, `removeLiquidity`, `getLpPositionDetails`,
+ * `getMarketDataForPools`) against Meteora's public API and on-chain DLMM
+ * program. Pool metadata comes from the Meteora DLMM API; liquidity math and
+ * transaction building go through the `DLMM` SDK wrapper. Simplifications to
+ * be aware of: `addLiquidity` always uses a fixed +/-10 bin spot strategy,
+ * `removeLiquidity` always removes 100% of the first position found for the
+ * pool, and USD valuation is not computed (no price oracle wired).
+ */
 import * as anchor from "@coral-xyz/anchor";
 import {
   type IAgentRuntime,

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/loadWallet.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/loadWallet.ts
@@ -1,3 +1,9 @@
+/**
+ * Loads a Solana connection plus signer or public key from runtime settings
+ * for the Meteora DEX adapters. Private keys are accepted as base58 or
+ * base64; TEE-derived keys are not wired up here (no DeriveKeyProvider) —
+ * the wallet always comes from the configured private/public key settings.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";

--- a/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/sendTransaction.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/meteora/utils/sendTransaction.ts
@@ -1,3 +1,12 @@
+/**
+ * Builds, simulates, prioritizes, and submits a versioned Solana transaction
+ * for the Meteora DEX adapters, retrying send + status polling until
+ * confirmed or a 90s timeout. Compute unit limit is derived from simulation
+ * (with a 30% safety margin) and the priority fee from the 95th-percentile
+ * recent prioritization fee, both added as compute-budget instructions ahead
+ * of the caller's instructions. Adapted from the pattern documented at
+ * https://orca-so.github.io/whirlpools/Whirlpools%20SDKs/Whirlpools/Send%20Transaction.
+ */
 import { elizaLogger } from "@elizaos/core";
 import {
   ComputeBudgetProgram,
@@ -8,7 +17,6 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 
-// For more information: https://orca-so.github.io/whirlpools/Whirlpools%20SDKs/Whirlpools/Send%20Transaction
 export async function sendTransaction(
   connection: Connection,
   instructions: TransactionInstruction[],
@@ -16,28 +24,24 @@ export async function sendTransaction(
 ): Promise<string> {
   const latestBlockhash = await connection.getLatestBlockhash();
 
-  // Create a new TransactionMessage with the instructions
   const messageV0 = new TransactionMessage({
     payerKey: wallet.publicKey,
     recentBlockhash: latestBlockhash.blockhash,
     instructions,
   }).compileToV0Message();
 
-  // Estimate compute units
   const simulatedTx = new VersionedTransaction(messageV0);
   simulatedTx.sign([wallet]);
   const simulation = await connection.simulateTransaction(simulatedTx);
   const computeUnits = simulation.value.unitsConsumed || 200_000;
   const safeComputeUnits = Math.ceil(Math.max(computeUnits * 1.3, computeUnits + 100_000));
 
-  // Get prioritization fee
   const recentPrioritizationFees = await connection.getRecentPrioritizationFees();
   const prioritizationFee =
     recentPrioritizationFees.map((fee) => fee.prioritizationFee).sort((a, b) => a - b)[
       Math.ceil(0.95 * recentPrioritizationFees.length) - 1
     ] ?? 0;
 
-  // Add compute budget instructions
   const computeBudgetInstructions = [
     ComputeBudgetProgram.setComputeUnitLimit({ units: safeComputeUnits }),
     ComputeBudgetProgram.setComputeUnitPrice({
@@ -45,7 +49,6 @@ export async function sendTransaction(
     }),
   ];
 
-  // Create final transaction
   const finalMessage = new TransactionMessage({
     payerKey: wallet.publicKey,
     recentBlockhash: latestBlockhash.blockhash,
@@ -55,7 +58,6 @@ export async function sendTransaction(
   const transaction = new VersionedTransaction(finalMessage);
   transaction.sign([wallet]);
 
-  // Send and confirm transaction
   const timeoutMs = 90000;
   const startTime = Date.now();
 

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Orca Whirlpool LP sub-plugin: registers the Orca position provider and
+ * `OrcaService`, and plugs Orca into the shared `LpManagementService`
+ * protocol registry so it appears alongside the other DEX adapters.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createSolanaLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/providers/positionProvider.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/providers/positionProvider.ts
@@ -1,3 +1,10 @@
+/**
+ * Orca LP position provider: injects the agent wallet's current Orca
+ * Whirlpool positions into planner context. `fetchPositions` currently
+ * always returns an empty list — the installed `@orca-so/whirlpools-sdk`
+ * version does not expose a position-lookup helper, so this is a stub
+ * pending an SDK upgrade rather than a live query.
+ */
 import {
   type IAgentRuntime,
   logger,

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/services/srv_orca.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/services/srv_orca.ts
@@ -1,3 +1,8 @@
+/**
+ * `OrcaService` — placeholder lifecycle service registered for the Orca DEX
+ * adapter (`ORCA_SERVICE`). Currently does no RPC or pool work itself; it
+ * exists so the Orca sub-plugin has a service to register and dispose.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 
 export class OrcaService extends Service {

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/types.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/types.ts
@@ -1,3 +1,4 @@
+/** Shared types for the Orca LP position/rebalance/trading-config surface. */
 export interface LPPosition {
   positionId: string;
   poolAddress: string;

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/utils/sendTransaction.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/utils/sendTransaction.ts
@@ -1,3 +1,12 @@
+/**
+ * Builds, simulates, prioritizes, and submits a versioned Solana transaction
+ * for the Orca DEX adapter, retrying send + status polling until confirmed
+ * or a 90s timeout. Compute unit limit is derived from simulation (with a
+ * 30% safety margin) and the priority fee from the 95th-percentile recent
+ * prioritization fee, both added as compute-budget instructions ahead of the
+ * caller's instructions. Adapted from the pattern documented at
+ * https://orca-so.github.io/whirlpools/Whirlpools%20SDKs/Whirlpools/Send%20Transaction.
+ */
 import { elizaLogger } from "@elizaos/core";
 import {
   ComputeBudgetProgram,
@@ -8,7 +17,6 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 
-// For more information: https://orca-so.github.io/whirlpools/Whirlpools%20SDKs/Whirlpools/Send%20Transaction
 export async function sendTransaction(
   connection: Connection,
   instructions: TransactionInstruction[],
@@ -16,28 +24,24 @@ export async function sendTransaction(
 ): Promise<string> {
   const latestBlockhash = await connection.getLatestBlockhash();
 
-  // Create a new TransactionMessage with the instructions
   const messageV0 = new TransactionMessage({
     payerKey: wallet.publicKey,
     recentBlockhash: latestBlockhash.blockhash,
     instructions,
   }).compileToV0Message();
 
-  // Estimate compute units
   const simulatedTx = new VersionedTransaction(messageV0);
   simulatedTx.sign([wallet]);
   const simulation = await connection.simulateTransaction(simulatedTx);
   const computeUnits = simulation.value.unitsConsumed || 200_000;
   const safeComputeUnits = Math.ceil(Math.max(computeUnits * 1.3, computeUnits + 100_000));
 
-  // Get prioritization fee
   const recentPrioritizationFees = await connection.getRecentPrioritizationFees();
   const prioritizationFee =
     recentPrioritizationFees.map((fee) => fee.prioritizationFee).sort((a, b) => a - b)[
       Math.ceil(0.95 * recentPrioritizationFees.length) - 1
     ] ?? 0;
 
-  // Add compute budget instructions
   const computeBudgetInstructions = [
     ComputeBudgetProgram.setComputeUnitLimit({ units: safeComputeUnits }),
     ComputeBudgetProgram.setComputeUnitPrice({
@@ -45,7 +49,6 @@ export async function sendTransaction(
     }),
   ];
 
-  // Create final transaction
   const finalMessage = new TransactionMessage({
     payerKey: wallet.publicKey,
     recentBlockhash: latestBlockhash.blockhash,
@@ -55,7 +58,6 @@ export async function sendTransaction(
   const transaction = new VersionedTransaction(finalMessage);
   transaction.sign([wallet]);
 
-  // Send and confirm transaction
   const timeoutMs = 90000;
   const startTime = Date.now();
 

--- a/plugins/plugin-wallet/src/chains/solana/dex/raydium/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/raydium/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Raydium CLMM LP sub-plugin: registers the Raydium position provider and
+ * `RaydiumService`, plugs Raydium into the shared `LpManagementService`
+ * protocol registry, and (if a Solana service with an exchange registry is
+ * present) registers itself there too.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import {
   createSolanaLpProtocolProvider,

--- a/plugins/plugin-wallet/src/chains/solana/dex/raydium/providers/positionProvider.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/raydium/providers/positionProvider.ts
@@ -1,3 +1,10 @@
+/**
+ * Raydium CLMM position provider: injects the agent wallet's current Raydium
+ * positions (pool, in-range status, distance/width in bps) into planner
+ * context. Loads the Raydium SDK's `Clmm`/`Position` namespaces dynamically
+ * and degrades to an empty position list (with a warning) if the installed
+ * SDK version doesn't expose the expected position-lookup functions.
+ */
 import {
   type IAgentRuntime,
   logger,
@@ -141,7 +148,6 @@ export const raydiumPositionProvider: Provider = {
         };
       }
 
-      // Decode the private key to get public address
       const bs58 = await import("bs58");
       const { Keypair } = await import("@solana/web3.js");
       const secretKey = bs58.default.decode(privateKey);
@@ -191,15 +197,12 @@ const fetchPositions = async (
     if (!api) return [];
     const { clmm, position: positionApi } = api;
 
-    // Get all positions for the owner
     const positions = (await positionApi.getPositionsByOwner(connection, ownerAddress))
       .map(toRaydiumPositionRecord)
       .filter((position): position is RaydiumPositionRecord => position !== null);
 
-    // Fetch all unique pools
     const poolsMap = new Map<string, RaydiumClmmPoolInfo>();
 
-    // First pass: collect all pool addresses
     for (const position of positions) {
       if (!poolsMap.has(position.poolId.toString())) {
         const poolInfo = await clmm.getPool(connection, position.poolId);
@@ -214,17 +217,14 @@ const fetchPositions = async (
           throw new Error(`Missing pool metadata for pool ID ${position.poolId.toString()}`);
         }
 
-        // Calculate price and range information
         const currentPrice = pool.currentPrice;
         const positionLowerPrice = pool.tickArrayLower;
         const positionUpperPrice = pool.tickArrayUpper;
 
-        // Check if position is in range
         const inRange =
           position.tickLower <= pool.currentTickIndex &&
           pool.currentTickIndex <= position.tickUpper;
 
-        // Calculate position metrics
         const positionCenterPrice = (positionLowerPrice + positionUpperPrice) / 2;
         const distanceCenterPositionFromPoolPriceBps =
           (Math.abs(currentPrice - positionCenterPrice) / currentPrice) * 10000;

--- a/plugins/plugin-wallet/src/chains/solana/dex/raydium/services/srv_raydium.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/raydium/services/srv_raydium.ts
@@ -1,3 +1,12 @@
+/**
+ * `RaydiumService` — quote, swap, and analytics client for Raydium, plus a
+ * CLMM position surface (`getPositions`/`createPosition`/`closePosition`/
+ * `updatePosition`). Quote/swap/analytics methods call the public
+ * `api.raydium.io` REST API directly. The CLMM position methods route
+ * through a local `Position` stub (not the Raydium SDK's `Position` module)
+ * that always throws, since the installed Raydium SDK version does not
+ * expose position helpers — calling any of them fails until that's wired up.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import type { Connection, PublicKey } from "@solana/web3.js";
 import type { JupiterQuoteResponse } from "../types.ts";
@@ -35,7 +44,6 @@ export class RaydiumService extends Service {
   static serviceType = "RAYDIUM_SERVICE";
   capabilityDescription = "Provides standardized access to DEX liquidity pools." as const;
 
-  // Configuration constants
   private readonly CONFIRMATION_CONFIG = {
     MAX_ATTEMPTS: 12,
     INITIAL_TIMEOUT: 2000,
@@ -49,9 +57,7 @@ export class RaydiumService extends Service {
     console.log("RAYDIUM_SERVICE cstr");
   }
 
-  // return Raydium Provider handle
   async registerProvider(provider: RaydiumRegisteredProvider) {
-    // add to registry
     const id = Object.values(this.registry).length + 1;
     console.log("registered", provider.name, `as Raydium provider #${id}`);
     this.registry[id] = provider;
@@ -152,7 +158,6 @@ export class RaydiumService extends Service {
     return false;
   }
 
-  // Get token price in USDC
   async getTokenPrice(
     tokenMint: string,
     quoteMint: string = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
@@ -163,17 +168,16 @@ export class RaydiumService extends Service {
       const quote = await this.getQuote({
         inputMint: tokenMint,
         outputMint: quoteMint,
-        amount: baseAmount, // Dynamic amount based on token decimals
+        amount: baseAmount,
         slippageBps: 50,
       });
-      return Number(quote.outAmount) / 10 ** inputDecimals; // Convert using same decimals
+      return Number(quote.outAmount) / 10 ** inputDecimals;
     } catch (error) {
       logger.error(`Failed to get token price: ${formatUnknownError(error)}`);
       return 0;
     }
   }
 
-  // Get best swap route
   async getBestRoute({
     inputMint,
     outputMint,
@@ -238,7 +242,6 @@ export class RaydiumService extends Service {
         amount,
         slippageBps,
       });
-      // Calculate minimum received based on slippage
       const minReceived = Number(quote.outAmount) * (1 - slippageBps / 10000);
       return minReceived;
     } catch (error) {
@@ -291,7 +294,6 @@ export class RaydiumService extends Service {
         slippageBps: 50,
       });
 
-      // Calculate optimal slippage based on liquidity and price impact
       const priceImpact = Number(quote.priceImpactPct);
       let recommendedSlippage: number;
 
@@ -323,7 +325,6 @@ export class RaydiumService extends Service {
     volume24h: number;
   }> {
     try {
-      // Fetch token pair information from Jupiter API
       const response = await fetch(
         `https://api.raydium.io/v2/main/pairs/${inputMint}/${outputMint}`
       );
@@ -349,7 +350,6 @@ export class RaydiumService extends Service {
     timeframe?: string;
   }): Promise<Array<{ timestamp: number; price: number }>> {
     try {
-      // Fetch historical price data from Jupiter API
       const response = await fetch(
         `https://api.raydium.io/v2/main/prices/${inputMint}/${outputMint}?timeframe=${timeframe}`
       );
@@ -394,7 +394,6 @@ export class RaydiumService extends Service {
         priceImpact: number;
       }> = [];
 
-      // Find potential arbitrage paths
       for (const token1 of commonTokens) {
         if (token1 === startingMint) continue;
 

--- a/plugins/plugin-wallet/src/chains/solana/dex/raydium/types.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/raydium/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Quote/swap request-response shapes consumed by `RaydiumService`. Named
+ * `Jupiter*` because they mirror the Jupiter aggregator quote API shape, not
+ * because Raydium calls Jupiter — `RaydiumService` hits `api.raydium.io`
+ * directly and parses responses into these types.
+ */
 export interface JupiterQuoteParams {
   inputMint: string;
   outputMint: string;

--- a/plugins/plugin-wallet/src/chains/solana/environment.ts
+++ b/plugins/plugin-wallet/src/chains/solana/environment.ts
@@ -1,3 +1,9 @@
+/**
+ * Zod schema and validator for required Solana runtime settings (RPC URL,
+ * slippage, and either a private key + public key pair or a secret salt for
+ * TEE-derived keys). `validateSolanaConfig` throws a combined, human-readable
+ * error listing every missing/invalid field.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { z } from "zod";
 

--- a/plugins/plugin-wallet/src/chains/solana/index.browser.ts
+++ b/plugins/plugin-wallet/src/chains/solana/index.browser.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser build entry for the Solana sub-plugin: a no-op facade that warns
+ * and does nothing, since Solana signing/RPC is server-only. Resolved in
+ * place of `index.ts` when bundling for a browser target.
+ */
 import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 

--- a/plugins/plugin-wallet/src/chains/solana/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Solana sub-plugin composed into `walletPlugin`: registers `SolanaService` +
+ * `SolanaWalletService`, the Solana wallet provider, and the Solana REST/sign
+ * routes. Init is a no-op when `SOLANA_RPC_URL` is unset. If an `INTEL_CHAIN`
+ * service is present it registers Solana with it opportunistically (failure
+ * to register is logged, not fatal).
+ */
 import type { IAgentRuntime, Plugin, ServiceTypeName } from "@elizaos/core";
 import { SOLANA_SERVICE_NAME } from "./constants";
 import { walletProvider } from "./providers/wallet";

--- a/plugins/plugin-wallet/src/chains/solana/keypairUtils.ts
+++ b/plugins/plugin-wallet/src/chains/solana/keypairUtils.ts
@@ -1,3 +1,11 @@
+/**
+ * Resolves the agent's Solana keypair or public key from runtime settings
+ * (base58 or base64 encoded `SOLANA_PRIVATE_KEY`/`WALLET_PRIVATE_KEY`, or
+ * `SOLANA_PUBLIC_KEY`/`WALLET_PUBLIC_KEY` for the public-key-only path). If
+ * no key is configured, `getWalletKey` generates a new keypair, persists it
+ * to runtime settings, and logs the new address so the operator can fund it
+ * — callers should not assume a missing key means failure.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";

--- a/plugins/plugin-wallet/src/chains/solana/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/solana/providers/wallet.ts
@@ -1,3 +1,9 @@
+/**
+ * Solana-specific wallet provider: formats the cached `WalletPortfolio` (from
+ * `SOLANA_WALLET_DATA_CACHE_KEY`) into planner context text and values —
+ * total balance, top non-zero token holdings, and SOL/BTC/ETH prices. Reads
+ * only from cache; it does not itself fetch RPC or Birdeye data.
+ */
 import type { IAgentRuntime, Memory, Provider, ProviderResult, State } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import BigNumber from "../bn";

--- a/plugins/plugin-wallet/src/chains/solana/routes/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/routes/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Solana REST routes (address, balance, and related wallet queries) mounted
+ * directly on the plugin's `routes` array. Each handler looks up `SolanaService`
+ * from the runtime and returns a uniform `ApiResponse<T>` success/error envelope.
+ */
 import type { LegacyRouteHandler, Route } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { SOLANA_WALLET_DATA_CACHE_KEY } from "../constants";

--- a/plugins/plugin-wallet/src/chains/solana/routes/sign.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/routes/sign.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the Solana browser-signing HTTP routes: auth-token
+ * validation (bearer/header token, origin checks) and request/response
+ * shaping. `resolveWalletBackend` is mocked, so no real Solana signer or RPC
+ * is exercised.
+ */
 import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { solanaSignRoutes } from "./sign";

--- a/plugins/plugin-wallet/src/chains/solana/service.ts
+++ b/plugins/plugin-wallet/src/chains/solana/service.ts
@@ -1,3 +1,22 @@
+/**
+ * `SolanaService` is the Solana chain runtime: it owns the RPC `Connection`,
+ * lazily loads the signing keypair (`getWalletKey`), and implements the
+ * `WalletChainHandler` contract (`getWalletChainHandler`/
+ * `executeWalletRouterAction`) so `WalletBackendService` can route `transfer`
+ * and `swap` subactions here. Beyond routing, it covers the full surface a
+ * Solana wallet needs: SOL/SPL transfer and Jupiter-quoted swap execution
+ * (with Token-2022 support), portfolio aggregation with Birdeye price
+ * enrichment and disk-backed caching (`updateWalletData`/`getCachedData`),
+ * token metadata/decimals/symbol resolution (including Token-2022 metadata
+ * pointer parsing), address validation and private-key detection in
+ * free-form strings, and account subscription management over the RPC
+ * websocket.
+ *
+ * `SolanaWalletService` is a deprecated thin compatibility adapter that
+ * forwards `getPortfolio`/`getBalance`/`transferSol` to a live `SolanaService`
+ * instance looked up by `chain_solana`; new code should depend on
+ * `SolanaService` directly.
+ */
 import { type IAgentRuntime, logger, Service, type ServiceTypeName } from "@elizaos/core";
 
 export interface WalletAsset {

--- a/plugins/plugin-wallet/src/chains/solana/types.ts
+++ b/plugins/plugin-wallet/src/chains/solana/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared type surface for the Solana chain sub-package: wallet portfolio and
+ * token-account shapes, HTTP response DTOs for the Solana REST routes,
+ * Jupiter quote/swap types, and RPC notification/cache-entry shapes used
+ * across the service, provider, and routes.
+ */
 import type { Keypair, PublicKey } from "@solana/web3.js";
 
 export interface Item {

--- a/plugins/plugin-wallet/src/chains/solana/vitest.config.ts
+++ b/plugins/plugin-wallet/src/chains/solana/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config scoping the Solana chain sub-suite to its own test/spec globs, run under Node. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-wallet/src/chains/wallet-action.ts
+++ b/plugins/plugin-wallet/src/chains/wallet-action.ts
@@ -1,3 +1,16 @@
+/**
+ * Defines `walletRouterAction`, the single `WALLET` action that dispatches
+ * every wallet subaction (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`,
+ * `token_info`, `search_address`) and absorbs the legacy per-verb similes
+ * (`SWAP`, `TRANSFER`, `CROSS_CHAIN_TRANSFER`, `WALLET_GOV`, `PUMP_FUN_BUY`,
+ * `TOKEN_INFO`, `BIRDEYE_SEARCH`, …) so older prompts keep working. It parses
+ * and validates raw params via `parseWalletRouterParams`, routes financial
+ * subactions through the `wallet-context-safety` recipient/injection guards
+ * and the `wallet-financial-confirmation` gate before touching
+ * `WalletBackendService`, and dispatches the two read-only analytics
+ * subactions (`token_info`, `search_address`) directly to their handlers
+ * without the financial confirmation gate.
+ */
 import type {
   Action,
   ActionResult,

--- a/plugins/plugin-wallet/src/contracts.ts
+++ b/plugins/plugin-wallet/src/contracts.ts
@@ -1,3 +1,9 @@
+/**
+ * Transport-level DTO types shared between the wallet HTTP routes and their
+ * consumers: export request/rejection shapes, and the market-overview
+ * response (price snapshots, movers, Polymarket predictions) served by
+ * `wallet-market-overview-route.ts`.
+ */
 export interface WalletExportRequestBody {
   confirm?: boolean;
   exportToken?: string;

--- a/plugins/plugin-wallet/src/diagnostic.ts
+++ b/plugins/plugin-wallet/src/diagnostic.ts
@@ -1,5 +1,3 @@
-import type { PluginDiagnosticDescriptor } from "@elizaos/core";
-
 /**
  * Static diagnostic descriptor for the EVM wallet plugin. The agent host reads
  * this to render the plugin's diagnostic card generically instead of
@@ -10,6 +8,8 @@ import type { PluginDiagnosticDescriptor } from "@elizaos/core";
  * This module is a dependency-free leaf so the host can import it eagerly
  * without pulling in the plugin's runtime (viem, services, etc.).
  */
+import type { PluginDiagnosticDescriptor } from "@elizaos/core";
+
 export const walletDiagnosticDescriptor: PluginDiagnosticDescriptor = {
   id: "evm",
   name: "Plugin EVM",

--- a/plugins/plugin-wallet/src/index.ts
+++ b/plugins/plugin-wallet/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Package barrel for `@elizaos/plugin-wallet`: re-exports the wallet plugin
+ * object, all chain/analytics/LP services, providers, routes, the SDK
+ * (ERC-6551/x402/CCTP/escrow), and supporting types. Consumers should import
+ * from here rather than reaching into subpaths.
+ */
 import "./core-augmentation.js";
 import { registerWalletAutomationNodeContributor } from "./automation-node-contributor.js";
 import { walletRouteRegistration } from "./register-routes.js";

--- a/plugins/plugin-wallet/src/lib/wallet-export-guard.test.ts
+++ b/plugins/plugin-wallet/src/lib/wallet-export-guard.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the hardened wallet-export guard: nonce-based replay
+ * protection, audit-log recording, and rate-limiting behavior, driven with
+ * fake timers and a synthetic `IncomingMessage`. No real HTTP server or
+ * wallet key material is involved.
+ */
 import type http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/plugins/plugin-wallet/src/lp/actions/liquidity.ts
+++ b/plugins/plugin-wallet/src/lp/actions/liquidity.ts
@@ -1,3 +1,11 @@
+/**
+ * Defines `liquidityAction`, the LP management action promoted into
+ * subactions (list pools, open/close/reposition a position, list positions)
+ * dispatched against `LpManagementService`'s registered DEX providers. Formats
+ * pool and position results into human-readable summaries and resolves
+ * finance/crypto/wallet-context gating the same way the top-level wallet
+ * action does.
+ */
 import type {
   Action,
   ActionExample,

--- a/plugins/plugin-wallet/src/lp/e2e/real-token-tests.ts
+++ b/plugins/plugin-wallet/src/lp/e2e/real-token-tests.ts
@@ -1,3 +1,9 @@
+/**
+ * `TestSuite` that exercises the LP manager against real token addresses on
+ * Solana mainnet (ai16z, degenai, SOL) through the live `DexInteractionService`
+ * and `YieldOptimizationService` — pool discovery and yield comparison hit
+ * actual DEX protocols, not mocks.
+ */
 import { strict as assert } from "node:assert";
 import type { IAgentRuntime, TestSuite } from "@elizaos/core";
 import type { DexInteractionService } from "../services/DexInteractionService.ts";

--- a/plugins/plugin-wallet/src/lp/e2e/scenarios.ts
+++ b/plugins/plugin-wallet/src/lp/e2e/scenarios.ts
@@ -1,8 +1,14 @@
+/**
+ * `TestSuite` of conversational E2E scenarios for the LP manager plugin
+ * (onboarding, yield optimization, rebalancing, …), run against a live
+ * `IAgentRuntime` through `setupScenario`/`sendMessageAndWaitForResponse` —
+ * exercises the real agent message pipeline, asserting on the agent's actual
+ * response text.
+ */
 import { strict as assert } from "node:assert";
 import type { IAgentRuntime, TestSuite } from "@elizaos/core";
 import { sendMessageAndWaitForResponse, setupScenario } from "./test-utils.ts";
 
-// Mock services are registered in setupScenario; this hook is called for backward compatibility.
 async function setupMockLpData(_runtime: IAgentRuntime) {}
 
 /**

--- a/plugins/plugin-wallet/src/lp/e2e/test-utils.ts
+++ b/plugins/plugin-wallet/src/lp/e2e/test-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared setup/assertion helpers for the LP manager's `TestSuite` scenarios
+ * (`scenarios.ts`, `real-token-tests.ts`): builds a world/user/room against a
+ * live `IAgentRuntime` and sends a message through the real agent pipeline,
+ * waiting for its response.
+ */
 import { strict as assert } from "node:assert";
 import {
   asUUID,

--- a/plugins/plugin-wallet/src/lp/lp-manager-entry.ts
+++ b/plugins/plugin-wallet/src/lp/lp-manager-entry.ts
@@ -1,3 +1,13 @@
+/**
+ * Composes `lpManagerPlugin`, the LP (liquidity provisioning) sub-plugin:
+ * registers the LP services (management, vault, user profile, yield
+ * optimization, concentrated liquidity, DEX interaction) and the
+ * `liquidityAction`, then on `init` detects which chains/DEXes are
+ * configured (Solana private key/RPC → Raydium/Orca/Meteora; EVM RPCs →
+ * Uniswap/PancakeSwap/Aerodrome) and dynamically imports + initializes only
+ * those DEX plugins. Also re-exports the DEX plugins/services and LP types
+ * for direct consumption.
+ */
 import {
   type IAgentRuntime,
   logger,
@@ -13,10 +23,8 @@ import { LpManagementService } from "./services/LpManagementService.ts";
 import { UserLpProfileService } from "./services/UserLpProfileService.ts";
 import { VaultService } from "./services/VaultService.ts";
 import { YieldOptimizationService } from "./services/YieldOptimizationService.ts";
-// LpAutoRebalanceTask import removed - file doesn't exist
 import type { EvmDex, SolanaDex } from "./types.ts";
 
-// It's good practice to define a unique name for the plugin
 export const LP_MANAGER_PLUGIN_NAME = "@elizaos/plugin-lp-manager";
 
 /**

--- a/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.ts
+++ b/plugins/plugin-wallet/src/lp/services/ConcentratedLiquidityService.ts
@@ -1,3 +1,7 @@
+/**
+ * ConcentratedLiquidityService exposes the concentrated-liquidity surface while
+ * DEX-specific providers add position creation and rebalancing support.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import type {
   IConcentratedLiquidityService,
@@ -5,10 +9,6 @@ import type {
   IRangeParams,
 } from "../types";
 
-/**
- * ConcentratedLiquidityService exposes the concentrated-liquidity surface while
- * DEX-specific providers add position creation and rebalancing support.
- */
 export class ConcentratedLiquidityService
   extends Service
   implements IConcentratedLiquidityService

--- a/plugins/plugin-wallet/src/lp/services/DexInteractionService.ts
+++ b/plugins/plugin-wallet/src/lp/services/DexInteractionService.ts
@@ -1,3 +1,10 @@
+/**
+ * Backward-compatible facade over `LpManagementService` for callers still
+ * written against the older DEX-interaction API surface (pool listing,
+ * add/remove liquidity, position lookups). New routing and protocol
+ * ownership live in `LpManagementService`; this class forwards to it plus
+ * `UserLpProfileService`/`VaultService`.
+ */
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
 import type {
   AddLiquidityConfig,

--- a/plugins/plugin-wallet/src/lp/services/LpManagementService.test.ts
+++ b/plugins/plugin-wallet/src/lp/services/LpManagementService.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `LpManagementService`'s provider-routing logic (matching a
+ * request to the right registered DEX provider, error on no match). Providers
+ * are hand-built `vi.fn()` stubs — no real Solana/EVM RPC or DEX program is
+ * exercised.
+ */
 import { describe, expect, it, vi } from "vitest";
 import {
   LpManagementService,

--- a/plugins/plugin-wallet/src/lp/services/LpManagementService.ts
+++ b/plugins/plugin-wallet/src/lp/services/LpManagementService.ts
@@ -1,3 +1,11 @@
+/**
+ * Top-level LP orchestrator: owns the registry of `LpProtocolProvider`
+ * adapters (Solana DEXes via `ILpService`, EVM DEXes via `IEvmLpService`) and
+ * dispatches `listPools`/`openPosition`/`closePosition`/`repositionPosition`/
+ * position-lookup calls to the provider matching a request's chain/DEX. Other
+ * LP services (`DexInteractionService` and callers needing a shared instance)
+ * resolve it through `getLpManagementService`.
+ */
 import {
   type IAgentRuntime,
   type ILpService,

--- a/plugins/plugin-wallet/src/lp/services/UserLpProfileService.ts
+++ b/plugins/plugin-wallet/src/lp/services/UserLpProfileService.ts
@@ -1,3 +1,9 @@
+/**
+ * In-memory registry of per-user LP profiles: vault linkage, auto-rebalance
+ * preferences, and tracked LP positions. State is not persisted across
+ * restarts — this is the source of truth for "which vault/config does this
+ * user have" while the process is running.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import type {
   IUserLpProfileService,

--- a/plugins/plugin-wallet/src/lp/services/VaultService.ts
+++ b/plugins/plugin-wallet/src/lp/services/VaultService.ts
@@ -1,3 +1,9 @@
+/**
+ * Generates and caches per-user Solana vault keypairs for LP operations,
+ * encrypting the secret key as a hex string for storage by the caller. The
+ * public-key cache here is in-memory only; callers are responsible for
+ * durable storage of `secretKeyEncrypted`.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import {

--- a/plugins/plugin-wallet/src/lp/services/YieldOptimizationService.ts
+++ b/plugins/plugin-wallet/src/lp/services/YieldOptimizationService.ts
@@ -1,3 +1,9 @@
+/**
+ * Finds better LP yield opportunities across all supported DEXes and
+ * estimates the cost (transaction fees, swap fees, slippage) of rebalancing
+ * a user's position into one. Estimates use fixed average fee constants and
+ * a default SOL/USD price rather than live fee/price data.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import type {

--- a/plugins/plugin-wallet/src/lp/services/__tests__/MockLpService.ts
+++ b/plugins/plugin-wallet/src/lp/services/__tests__/MockLpService.ts
@@ -1,3 +1,9 @@
+/**
+ * In-memory `ILpService` test double: serves a fixed SOL/USDC pool and
+ * tracks positions in a local `Map` instead of calling any real DEX. Used by
+ * `LpManagementService.test.ts` and other LP tests to exercise routing logic
+ * without a live Solana RPC or DEX program.
+ */
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import type {
   AddLiquidityConfig,

--- a/plugins/plugin-wallet/src/lp/types.ts
+++ b/plugins/plugin-wallet/src/lp/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared type surface for the LP (liquidity provisioning) subsystem: chain
+ * and DEX identifiers, per-chain RPC/wallet configuration, and the
+ * position/pool/vault/yield-optimization domain types consumed by the LP
+ * services and `liquidityAction`. Re-exports the core LP types
+ * (`ILpService`, `PoolInfo`, `LpPositionDetails`, `TransactionResult`,
+ * `TokenBalance`) alongside package-specific extensions.
+ */
 import type {
   IAgentRuntime,
   ILpService,
@@ -10,7 +18,6 @@ import type {
 import type { Keypair as SolanaKeypair } from "@solana/web3.js";
 import type { Address, Hash } from "viem";
 
-// Re-export types from core with modern syntax
 export type {
   ILpService,
   LpPositionDetails,

--- a/plugins/plugin-wallet/src/lp/utils/solanaClient.ts
+++ b/plugins/plugin-wallet/src/lp/utils/solanaClient.ts
@@ -1,3 +1,9 @@
+/**
+ * Solana RPC/wallet helpers for the LP subsystem: builds a `Connection` from
+ * runtime settings, loads a signer or address-only wallet from
+ * `SOLANA_PRIVATE_KEY`/`SOLANA_PUBLIC_KEY` (base58 or base64), and sends a
+ * signed transaction with blockhash-based confirmation.
+ */
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { Connection, clusterApiUrl, Keypair, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";

--- a/plugins/plugin-wallet/src/plugin.routes.test.ts
+++ b/plugins/plugin-wallet/src/plugin.routes.test.ts
@@ -1,3 +1,4 @@
+/** Unit test asserting `walletPlugin.routes` exposes the full expected set of EVM and Solana browser-signing route names (no live server, just the static route table). */
 import { describe, expect, it } from "vitest";
 import { walletPlugin } from "./plugin";
 

--- a/plugins/plugin-wallet/src/plugin.ts
+++ b/plugins/plugin-wallet/src/plugin.ts
@@ -1,3 +1,10 @@
+/**
+ * Composes `walletPlugin`, the top-level plugin object the agent loads:
+ * merges the core wallet-backend plugin (signing service + `wallet` provider)
+ * with the EVM and Solana sub-plugins' services/providers/actions/routes, and
+ * registers the Birdeye/DexScreener/TokenInfo analytics services. `init` and
+ * `dispose` fan out to each composed piece in turn.
+ */
 import { resolveCloudRoute, toRuntimeSettings } from "@elizaos/cloud-routing";
 import {
   type IAgentRuntime,

--- a/plugins/plugin-wallet/src/policy/policy.ts
+++ b/plugins/plugin-wallet/src/policy/policy.ts
@@ -1,3 +1,8 @@
+/**
+ * `PolicyModule` interface for on-chain spend-policy enforcement (size
+ * limits, allowlists, cooldowns). Actions delegate here after zod parsing and
+ * plugin-level checks rather than inlining policy logic themselves.
+ */
 import type { ApprovalSummary, SignScope } from "../wallet/pending.js";
 
 export interface PolicyEvaluation {

--- a/plugins/plugin-wallet/src/providers/canonical-provider.ts
+++ b/plugins/plugin-wallet/src/providers/canonical-provider.ts
@@ -1,3 +1,9 @@
+/**
+ * Typed venue / data-source adapter. Canonical actions dispatch into concrete
+ * provider classes registered on the runtime provider registry.
+ *
+ * See docs/architecture/wallet-and-trading.md §B.3.
+ */
 import type {
   IAgentRuntime,
   Memory,
@@ -7,12 +13,6 @@ import type {
 
 export type HealthStatus = { ok: true } | { ok: false; reason: string };
 
-/**
- * Typed venue / data-source adapter. Canonical actions dispatch into concrete
- * provider classes registered on the runtime provider registry.
- *
- * See docs/architecture/wallet-and-trading.md §B.3.
- */
 export interface CanonicalProvider {
   readonly name: string;
   readonly contextBudgetTokens: number;

--- a/plugins/plugin-wallet/src/providers/wallet-provider.ts
+++ b/plugins/plugin-wallet/src/providers/wallet-provider.ts
@@ -1,3 +1,10 @@
+/**
+ * Top-level `wallet` provider: injects the agent's live EVM + Solana
+ * addresses into planner context whenever a finance/crypto/wallet context is
+ * active. Reads addresses through `WalletBackendService` (never raw key env
+ * vars) and degrades to a plain status message if the service is unavailable
+ * or the backend isn't configured yet.
+ */
 import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
 import type { WalletBackendService } from "../services/wallet-backend-service.js";
 import {

--- a/plugins/plugin-wallet/src/register-routes.test.ts
+++ b/plugins/plugin-wallet/src/register-routes.test.ts
@@ -1,3 +1,4 @@
+/** Unit test with `@elizaos/core` mocked: asserts `register-routes.ts` registers its app-route plugin loader under the `@elizaos/plugin-wallet:routes` key on import. */
 import { describe, expect, it, vi } from "vitest";
 
 const { registerAppRoutePluginLoader } = vi.hoisted(() => ({

--- a/plugins/plugin-wallet/src/routes/wallet-market-overview-route.ts
+++ b/plugins/plugin-wallet/src/routes/wallet-market-overview-route.ts
@@ -1,3 +1,14 @@
+/**
+ * `handleWalletMarketOverviewRoute` serves `/api/wallet/market-overview`:
+ * price snapshots and top movers from CoinGecko plus highlighted Polymarket
+ * predictions, normalized into `WalletMarketOverviewResponse` and merged into
+ * per-source `WalletMarketOverviewSource` status (available/stale/error) so
+ * the client can render partial data gracefully. Falls back to a cloud
+ * preview endpoint (`resolveCloudApiBaseUrl`) when direct upstream calls are
+ * unavailable, caches successful responses for `MARKET_OVERVIEW_CACHE_TTL_MS`
+ * and serves stale-but-cached data on upstream failure, and rate-limits
+ * refreshes per client address via `consumeRefreshSlot`.
+ */
 import type http from "node:http";
 import { logger } from "@elizaos/core";
 import { resolveCloudApiBaseUrl } from "@elizaos/shared";

--- a/plugins/plugin-wallet/src/sdk/abi.ts
+++ b/plugins/plugin-wallet/src/sdk/abi.ts
@@ -1,3 +1,10 @@
+/**
+ * Contract ABIs for the ERC-6551 agent-wallet SDK: `AgentAccountV2Abi` (the
+ * per-agent smart-account implementation — spend policy, operator
+ * authorization, execute/queue/approve, health/activity read functions) and
+ * `AgentAccountFactoryV2Abi` (deploys/looks up an account's address for a
+ * given NFT).
+ */
 export const AgentAccountV2Abi = [
   // ─── Owner Functions ───
   {
@@ -132,7 +139,7 @@ export const AgentAccountV2Abi = [
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
   },
-  // [MAX-ADDED] ABI entries for wallet health check & activity history
+  // ABI entries for wallet health check & activity history
   {
     name: "tokenContract",
     type: "function",

--- a/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.ts
+++ b/plugins/plugin-wallet/src/sdk/escrow/MutualStakeEscrow.ts
@@ -1,3 +1,10 @@
+/**
+ * Client wrapper for the mutual-stake escrow contracts: deploys a new
+ * `StakeVault` via the factory (`createEscrow`), and provides typed
+ * read/write helpers over a vault's lifecycle (fund, fulfill, challenge,
+ * resolve) keyed by `TaskStatus`. Verifier addresses and encoding are
+ * delegated to `verifiers.ts`.
+ */
 import type { Address, Hex, PublicClient, WalletClient } from "viem";
 import type {
   CreateEscrowParams,

--- a/plugins/plugin-wallet/src/sdk/escrow/types.ts
+++ b/plugins/plugin-wallet/src/sdk/escrow/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Type surface for the mutual-stake escrow SDK: on-chain task lifecycle
+ * (`TaskStatus`), verifier selection, and the parameter/result/detail shapes
+ * used by `MutualStakeEscrow.ts` and `verifiers.ts`.
+ */
 import type { Address, Hash, Hex } from "viem";
 
 /** Mirrors the on-chain TaskStatus enum */

--- a/plugins/plugin-wallet/src/sdk/escrow/verifiers.ts
+++ b/plugins/plugin-wallet/src/sdk/escrow/verifiers.ts
@@ -1,3 +1,8 @@
+/**
+ * Verifier registry and encoding helpers for the mutual-stake escrow: known
+ * verifier contract addresses per chain/type, and ABI-encoding of verifier
+ * data (optimistic vs hash-based) passed into `createEscrow`.
+ */
 import {
   type Address,
   encodeAbiParameters,

--- a/plugins/plugin-wallet/src/sdk/index.ts
+++ b/plugins/plugin-wallet/src/sdk/index.ts
@@ -1,3 +1,11 @@
+/**
+ * SDK barrel: re-exports the ERC-6551 wallet-core primitives (ABIs,
+ * `createWallet`, spend-policy/transfer/budget helpers), x402 micropayment
+ * types and client, and adds higher-level agent-wallet conveniences on top —
+ * `agentExecute`/`getPendingApprovals`/`approveTransaction` for the
+ * queue-or-execute spend-policy flow, plus budget forecasting, wallet health
+ * checks, batch transfers, and on-chain activity history queries.
+ */
 import type { JsonValue } from "@elizaos/core";
 import {
   type Address,
@@ -57,7 +65,7 @@ export type {
   X402SettlementResponse,
   X402TransactionLog,
 } from "./x402/index.js";
-// [MAX-ADDED] x402 protocol support
+// x402 protocol support
 export {
   createX402Client,
   createX402Fetch,
@@ -266,11 +274,11 @@ export async function getWalletAddress(config: {
   ]) as Promise<Address>;
 }
 
-// ─── [MAX-ADDED] Value-Add Features for Agent Customers ───
+// ─── Value-Add Features for Agent Customers ───
 
 /**
- * [MAX-ADDED] Budget forecast with period-aware remaining capacity.
- * Why: Agents need to know not just "how much is left" but "when does budget reset"
+ * Budget forecast with period-aware remaining capacity.
+ * Agents need to know not just "how much is left" but "when does budget reset"
  * so they can plan spending across time windows and avoid unnecessary queuing.
  */
 export async function getBudgetForecast(
@@ -303,8 +311,8 @@ export async function getBudgetForecast(
 }
 
 /**
- * [MAX-ADDED] Wallet health check — diagnostic snapshot for agent self-monitoring.
- * Why: Agents need a single-call way to verify their wallet is properly configured,
+ * Wallet health check — diagnostic snapshot for agent self-monitoring.
+ * Agents need a single-call way to verify their wallet is properly configured,
  * check operator status, and monitor queue depth before executing transactions.
  */
 export async function getWalletHealth(
@@ -354,8 +362,8 @@ export async function getWalletHealth(
 }
 
 /**
- * [MAX-ADDED] Batch agent token transfers — multiple transfers in sequential calls.
- * Why: Agents often need to pay multiple recipients (tips, fees, splits). This helper
+ * Batch agent token transfers — multiple transfers in sequential calls.
+ * Agents often need to pay multiple recipients (tips, fees, splits). This helper
  * reduces boilerplate and returns all tx hashes. Each is a separate on-chain tx
  * (true batching would need a multicall contract, but this is the safe SDK-level helper).
  */
@@ -378,8 +386,8 @@ export async function batchAgentTransfer(
 }
 
 /**
- * [MAX-ADDED] Activity history — query past wallet events for self-auditing.
- * Why: Agents need to verify what happened on-chain (transfers, operator changes,
+ * Activity history — query past wallet events for self-auditing.
+ * Agents need to verify what happened on-chain (transfers, operator changes,
  * policy updates) without relying on external indexers. This queries event logs directly.
  */
 export async function getActivityHistory(

--- a/plugins/plugin-wallet/src/sdk/router/index.ts
+++ b/plugins/plugin-wallet/src/sdk/router/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the SDK's payment-rail router: chooses which payment rail (e.g. x402, on-chain) handles a given payment context. */
 export type {
   PaymentContext,
   PaymentRail,

--- a/plugins/plugin-wallet/src/sdk/tokens/decimals.test.ts
+++ b/plugins/plugin-wallet/src/sdk/tokens/decimals.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, it } from "vitest";
-import { parseAmount, toHuman, toRaw } from "./decimals.ts";
-
 /**
  * Token-amount decimal conversion (#8801 — money-critical, shipped untested).
  * `toRaw` turns a human amount into raw on-chain base units and `toHuman`
@@ -8,6 +5,9 @@ import { parseAmount, toHuman, toRaw } from "./decimals.ts";
  * the floor-on-excess-precision behavior, the round-trip, and the
  * reject-malformed-input path.
  */
+import { describe, expect, it } from "vitest";
+import { parseAmount, toHuman, toRaw } from "./decimals.ts";
+
 describe("toRaw", () => {
   it("scales integer and fractional amounts by decimals", () => {
     expect(toRaw("100", 6)).toBe(100_000_000n);

--- a/plugins/plugin-wallet/src/sdk/wallet-core.ts
+++ b/plugins/plugin-wallet/src/sdk/wallet-core.ts
@@ -1,3 +1,10 @@
+/**
+ * Core client for an existing ERC-6551 `AgentAccountV2` wallet: connects a
+ * viem `WalletClient`/`PublicClient` pair to the account contract and
+ * exposes `setSpendPolicy`/`agentTransferToken`/`checkBudget` and related
+ * read/write helpers. Supports Base, Base Sepolia, Ethereum, Arbitrum, and
+ * Polygon.
+ */
 import {
   type Address,
   type Chain,

--- a/plugins/plugin-wallet/src/security/__tests__/wallet-context-safety.test.ts
+++ b/plugins/plugin-wallet/src/security/__tests__/wallet-context-safety.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the wallet-context-safety guards: display-label
+ * sanitization and EVM transfer recipient authorization against
+ * injected/inferred addresses. Pure functions exercised with hand-built
+ * `Memory` fixtures — no real runtime, model, or chain involved.
+ */
 import type { Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {

--- a/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
+++ b/plugins/plugin-wallet/src/security/__tests__/wallet-financial-confirmation.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the wallet financial confirmation gate: verifies that a
+ * caller-supplied `confirmed` option is never treated as authorization, that
+ * a first on-chain attempt is held pending until the user replies to
+ * confirm, and that pending keys normalize equivalent transfer params. Uses
+ * an in-memory fake `IAgentRuntime` cache (no real runtime or chain).
+ */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { isConfirmed } from "../../chains/evm/actions/helpers.js";

--- a/plugins/plugin-wallet/src/security/wallet-context-safety.ts
+++ b/plugins/plugin-wallet/src/security/wallet-context-safety.ts
@@ -1,3 +1,17 @@
+/**
+ * Security guards that stand between untrusted message/channel content and
+ * on-chain financial writes. `assertWalletFinancialActionAllowed` blocks
+ * transfer/swap/bridge/pump_fun_buy subactions when core has flagged the
+ * inbound message as suspected prompt injection (GHSA-gh63-5vpj-39qp).
+ * `assertEvmTransferRecipientAuthorized` and `messageAuthorizesEvmRecipient`
+ * enforce that an EVM transfer recipient was explicitly stated by the user
+ * (in message text or structured action parameters) rather than inferred from
+ * token metadata, prior session context, or other embedded addresses
+ * (GHSA-7qxr-x6cg-r9cc). `sanitizeWalletDisplayLabel` strips embedded
+ * addresses and routing-hint phrases before untrusted labels are ever shown
+ * back to the user. These are load-bearing security checks — do not weaken or
+ * bypass them from calling code.
+ */
 import type { Memory } from "@elizaos/core";
 
 /** GHSA-7qxr-x6cg-r9cc — embedded addresses in token metadata must not become transfer recipients. */

--- a/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
@@ -1,3 +1,17 @@
+/**
+ * Confirmation gate that every on-chain wallet write (`transfer`, `swap`,
+ * `bridge`, `gov`, `pump_fun_buy`) must pass through before submission
+ * (GHSA-rqm7-f4jc-84x3). `gateWalletFinancialExecution` calls core's
+ * `requireConfirmation` with a stable pending key derived from the request
+ * params (`walletFinancialPendingKey`) and a human-readable preview of the
+ * pending action (`walletFinancialPreview`); it only proceeds once the user
+ * has replied to confirm in a later turn. `mode=execute` and `dryRun=false`
+ * alone are not sufficient — the LLM cannot bypass this gate by setting
+ * request params, since confirmation state lives in runtime cache and is
+ * keyed off the actual transfer/swap/bridge parameters, not caller-supplied
+ * flags. `dryRun=true` requests skip the gate entirely (no signing occurs).
+ * Do not remove or short-circuit this gate from calling code.
+ */
 import type {
   ActionResult,
   ConfirmationDecision,

--- a/plugins/plugin-wallet/src/services/wallet-backend-service.ts
+++ b/plugins/plugin-wallet/src/services/wallet-backend-service.ts
@@ -1,3 +1,17 @@
+/**
+ * Top-level signing and chain-routing service for the wallet plugin. On
+ * start it resolves the active {@link WalletBackend} (local EOA or Steward,
+ * via `resolveWalletBackend`) and registers all default chain handlers
+ * (`registerDefaultWalletChainHandlers`). `routeWalletAction` is the single
+ * entry point every wallet subaction (`transfer`, `swap`, `bridge`, `gov`,
+ * `pump_fun_buy`, …) dispatches through: it resolves the chain handler by
+ * alias, validates required params, and for `dryRun`/`mode=prepare` requests
+ * returns metadata without invoking the handler's `execute()` (bridge is an
+ * exception — it always calls `execute()` so Li.Fi/CCTP routing can surface
+ * a real quote). If backend resolution fails at boot, the service still
+ * starts so metadata/dry-run stays available; `getWalletBackend()` throws the
+ * captured error only when a caller actually needs signing.
+ */
 import {
   type IAgentRuntime,
   type ITokenDataService,

--- a/plugins/plugin-wallet/src/types/wallet-router.ts
+++ b/plugins/plugin-wallet/src/types/wallet-router.ts
@@ -1,3 +1,13 @@
+/**
+ * Contract types for the wallet router: `WalletRouterParams` /
+ * `WalletRouterResult` are the request/response shapes `WalletBackendService`
+ * dispatches, and `WalletChainHandler` is the interface every chain
+ * implementation (EVM, Solana, pump.fun, …) must satisfy to plug into
+ * `registerDefaultWalletChainHandlers`. Also defines the Zod schema
+ * (`WalletRouterParamsSchema`) that parses and normalizes raw action input
+ * (string/number coercion, comma-separated array parsing, truthy-string
+ * booleans) into a validated `WalletRouterParams`.
+ */
 import type {
   IAgentRuntime,
   ITokenDataService,

--- a/plugins/plugin-wallet/src/wallet-action.ts
+++ b/plugins/plugin-wallet/src/wallet-action.ts
@@ -1,1 +1,2 @@
+/** Top-level re-export of the WALLET action so consumers can import it from the package root. */
 export { default, walletRouterAction } from "./chains/wallet-action.js";

--- a/plugins/plugin-wallet/src/wallet/backend.ts
+++ b/plugins/plugin-wallet/src/wallet/backend.ts
@@ -1,3 +1,10 @@
+/**
+ * Defines `WalletBackend`, the single signing abstraction the rest of the
+ * plugin depends on — chain handlers, providers, and canonical actions reach
+ * signing only through this interface, never by reading raw private key env
+ * vars directly. `LocalEoaBackend` and `StewardBackend` are its two
+ * implementations, selected by `select-backend.ts`.
+ */
 import type {
   PublicKey,
   Transaction,

--- a/plugins/plugin-wallet/src/wallet/errors.ts
+++ b/plugins/plugin-wallet/src/wallet/errors.ts
@@ -1,3 +1,8 @@
+/**
+ * Error types for the `WalletBackend` signing path: missing key configuration,
+ * an unreachable Steward backend, a pending human approval that must be
+ * resolved before signing continues, and malformed Solana key material.
+ */
 import type { PendingApproval } from "./pending.js";
 
 export type WalletBackendNotConfiguredCode =

--- a/plugins/plugin-wallet/src/wallet/index.ts
+++ b/plugins/plugin-wallet/src/wallet/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the `WalletBackend` abstraction: the signer interface, its local/Steward implementations, error types, and pending-approval/sign-result types. */
 export type {
   SolanaSigner,
   WalletAddresses,

--- a/plugins/plugin-wallet/src/wallet/local-eoa-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/local-eoa-backend.ts
@@ -1,3 +1,12 @@
+/**
+ * `WalletBackend` implementation that signs with raw private keys read
+ * directly from settings/env (`EVM_PRIVATE_KEY`, `SOLANA_PRIVATE_KEY` /
+ * `WALLET_PRIVATE_KEY`) — the desktop/local-agent default when no Steward
+ * credentials are configured. Does not autogenerate keys; construction
+ * throws `WalletBackendNotConfiguredError` if neither chain has a usable key.
+ * `LocalSolanaSigner` wraps a `Keypair` to satisfy the `SolanaSigner`
+ * interface for transaction and message signing.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   Keypair,

--- a/plugins/plugin-wallet/src/wallet/pending.ts
+++ b/plugins/plugin-wallet/src/wallet/pending.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared types for signing scopes, pending human-approval flows, and
+ * canonical handler results used across `WalletBackend` and the audit/policy
+ * modules. `SignScope` names each signing operation as `<domain>.<operation>`
+ * for audit-log and policy attribution; `SignResult` is either a completed
+ * `SignaturePayload` or a `PendingApproval` awaiting user confirmation.
+ */
 import type {
   ActionFailureCode,
   ValidateFailureCode,

--- a/plugins/plugin-wallet/src/wallet/select-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/select-backend.ts
@@ -1,3 +1,8 @@
+/**
+ * Selects the active `WalletBackend` implementation from the
+ * `ELIZA_WALLET_BACKEND` setting (`local` / `steward` / `auto`), with `auto`
+ * preferring Steward when the agent is cloud-provisioned.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import type { WalletBackend } from "./backend.js";
 import { LocalEoaBackend } from "./local-eoa-backend.js";

--- a/plugins/plugin-wallet/src/wallet/steward-backend.ts
+++ b/plugins/plugin-wallet/src/wallet/steward-backend.ts
@@ -1,3 +1,15 @@
+/**
+ * `WalletBackend` implementation backed by Steward, the cloud/mobile
+ * multi-tenant signing service — used when `ELIZA_WALLET_BACKEND=steward` or
+ * (in `auto` mode) when the agent is cloud-provisioned. Dynamically imports
+ * `@elizaos/app-steward` at construction time (avoiding a devDependency
+ * cycle) to init the EVM account and fetch vault chain addresses; throws
+ * `StewardUnavailableError` if the module can't be loaded or Steward env
+ * config (`STEWARD_API_URL`/`STEWARD_AGENT_TOKEN`/`STEWARD_AGENT_ID`) is
+ * missing. Solana addresses may be exposed when Steward's vault endpoint
+ * returns them, but Solana transaction signing is not yet wired here —
+ * `getSolanaSigner()` always throws.
+ */
 import type { IAgentRuntime } from "@elizaos/core";
 import { PublicKey } from "@solana/web3.js";
 import type { Account, Hex, TypedDataDefinition } from "viem";

--- a/plugins/plugin-wallet/vitest.config.ts
+++ b/plugins/plugin-wallet/vitest.config.ts
@@ -1,3 +1,9 @@
+/**
+ * Package-level vitest config: aliases `@elizaos/app-core`, `@elizaos/core`,
+ * and `@elizaos/logger` to source so tests resolve without a pre-built dist,
+ * and excludes live/opt-in suites (funded-wallet transfer tests, guarded
+ * post-merge-only suites) from the default run.
+ */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-x402/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-x402/src/__tests__/core-test-mock.ts
@@ -1,3 +1,4 @@
+/** Shared `@elizaos/core` mock (logger only) imported by this package's vitest suites. */
 import { vi } from "vitest";
 
 vi.mock("@elizaos/core", () => ({

--- a/plugins/plugin-x402/src/payment-wrapper.test.ts
+++ b/plugins/plugin-x402/src/payment-wrapper.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for `applyPaymentProtection`'s route-wrapping and 402-response
+ * behavior. Runtime, request, and response objects are hand-built fakes and
+ * `fetch` is stubbed where exercised — no real HTTP dispatch, facilitator,
+ * or on-chain verification is involved.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyPaymentProtection,

--- a/plugins/plugin-x402/src/payment-wrapper.ts
+++ b/plugins/plugin-x402/src/payment-wrapper.ts
@@ -1,3 +1,21 @@
+/**
+ * x402 **seller** middleware for plugin HTTP routes.
+ *
+ * **Why one middleware layer:** plugins should not each reimplement 402 bodies,
+ * header encodings, facilitator POSTs, replay semantics, or chain RPC checks.
+ * This module is the single integration point for “paid route” behavior.
+ *
+ * **Why multiple verification strategies coexist:** deployments differ—some
+ * have on-chain receipts only, some use facilitator payment IDs, some use modern
+ * `PAYMENT-SIGNATURE` payloads. Keeping strategies behind one `verifyPayment`
+ * function preserves one gate while letting operators choose what their clients send.
+ *
+ * **Why standard path calls settle:** see `x402-standard-payment.ts`—settlement is
+ * the economically meaningful step after verify for facilitator-backed flows.
+ *
+ * **Why we still emit legacy JSON 402:** backward compatibility for wallets and
+ * tools that parse the body; V2 clients additionally read `PAYMENT-REQUIRED`.
+ */
 import type {
   Character,
   IAgentRuntime,
@@ -75,25 +93,6 @@ import {
   type PaymentExtraMetadata,
   type X402Response,
 } from "./x402-types.js";
-
-/**
- * x402 **seller** middleware for plugin HTTP routes.
- *
- * **Why one middleware layer:** plugins should not each reimplement 402 bodies,
- * header encodings, facilitator POSTs, replay semantics, or chain RPC checks.
- * This module is the single integration point for “paid route” behavior.
- *
- * **Why multiple verification strategies coexist:** deployments differ—some
- * have on-chain receipts only, some use facilitator payment IDs, some use modern
- * `PAYMENT-SIGNATURE` payloads. Keeping strategies behind one `verifyPayment`
- * function preserves one gate while letting operators choose what their clients send.
- *
- * **Why standard path calls settle:** see `x402-standard-payment.ts`—settlement is
- * the economically meaningful step after verify for facilitator-backed flows.
- *
- * **Why we still emit legacy JSON 402:** backward compatibility for wallets and
- * tools that parse the body; V2 clients additionally read `PAYMENT-REQUIRED`.
- */
 
 /**
  * Set on routes returned by {@link applyPaymentProtection} so HTTP dispatch
@@ -612,15 +611,12 @@ async function verifyPayment(
  * Sanitize and validate payment ID format
  */
 function sanitizePaymentId(paymentId: string): string {
-  // Remove any whitespace
   const cleaned = paymentId.trim();
 
-  // Validate format (alphanumeric, hyphens, underscores only)
   if (!/^[a-zA-Z0-9_-]+$/.test(cleaned)) {
     throw new Error("Invalid payment ID format");
   }
 
-  // Limit length to prevent abuse
   if (cleaned.length > 128) {
     throw new Error("Payment ID too long");
   }
@@ -638,7 +634,6 @@ async function verifyPaymentIdViaFacilitator(
 ): Promise<boolean> {
   logSection("FACILITATOR VERIFICATION");
 
-  // Sanitize payment ID
   let cleanPaymentId: string;
   try {
     cleanPaymentId = sanitizePaymentId(paymentId);
@@ -1084,7 +1079,6 @@ async function verifyEip712Authorization(
 ): Promise<boolean> {
   log("Verifying EIP-712 authorization signature");
 
-  // Type guard for payment data
   if (typeof paymentData !== "object" || paymentData === null) {
     logError("Invalid payment data: must be an object");
     return false;
@@ -1113,7 +1107,6 @@ async function verifyEip712Authorization(
       return false;
     }
 
-    // Validate authorization fields
     if (
       !authorization.from ||
       !authorization.to ||
@@ -1130,7 +1123,6 @@ async function verifyEip712Authorization(
       value: authorization.value,
     });
 
-    // Null check before toLowerCase()
     if (!authorization.to) {
       logError('Authorization missing "to" field');
       return false;
@@ -1943,7 +1935,6 @@ function generateDescription(route: PaymentEnabledRoute): string {
   return `${action} ${resource}`;
 }
 
-// Re-export types from core
 export type { X402RequestValidator, X402ValidationResult } from "@elizaos/core";
 
 /**

--- a/plugins/plugin-x402/src/startup-validator.test.ts
+++ b/plugins/plugin-x402/src/startup-validator.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `validateX402Startup` covering config resolution and
+ * rejection cases. Pure in-process assertions against fabricated route
+ * objects — no real HTTP dispatch, DB, or network involved.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { validateX402Startup } from "./startup-validator.js";
 

--- a/plugins/plugin-x402/src/x402-facilitator-binding.ts
+++ b/plugins/plugin-x402/src/x402-facilitator-binding.ts
@@ -1,3 +1,10 @@
+/**
+ * Binds a facilitator's payment-verification response to the specific route
+ * it was requested for, so a valid-but-unrelated 200 cannot unlock a
+ * different resource. Strict mode requires the response to echo `resource`,
+ * route, price, and payment config; relaxed mode only rejects fields that
+ * are present and mismatched.
+ */
 import type {
   FacilitatorVerificationResponse,
   FacilitatorVerifyContext,

--- a/plugins/plugin-x402/src/x402-replay-durable.ts
+++ b/plugins/plugin-x402/src/x402-replay-durable.ts
@@ -1,3 +1,15 @@
+/**
+ * Durable, cross-restart replay guard for x402 payment credentials, backed
+ * by the runtime's `cache` table (or `runtime.getCache`/`setCache` when the
+ * SQL connection isn't reachable). Reservation is two-phase: `TryReserve`
+ * atomically claims a replay key as "inflight" with a TTL (via `INSERT ...
+ * ON CONFLICT DO NOTHING` when SQL is available, so concurrent requests for
+ * the same credential can't both proceed), then callers either
+ * `CommitReservation` on successful verification (marking the key
+ * permanently "consumed") or `AbortReservation` on failure (freeing it for
+ * retry). Expired inflight reservations can be stolen so a crashed request
+ * doesn't permanently block retries.
+ */
 import { createHash, randomUUID } from "node:crypto";
 import { type AgentRuntime, logger } from "@elizaos/core";
 import { sql } from "drizzle-orm";

--- a/plugins/plugin-x402/src/x402-replay-keys.ts
+++ b/plugins/plugin-x402/src/x402-replay-keys.ts
@@ -1,3 +1,9 @@
+/**
+ * Derives canonical, encoding-independent replay keys from x402 payment
+ * proofs and facilitator payment IDs, so the same underlying EVM tx, Solana
+ * signature, or EIP-712 intent is recognized as a replay whether the proof
+ * arrives raw, base64-wrapped, or nested in a JSON payload.
+ */
 import { createHash } from "node:crypto";
 
 function sha256Utf8(s: string): string {

--- a/plugins/plugin-x402/src/x402-resolve.ts
+++ b/plugins/plugin-x402/src/x402-resolve.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves a route's `x402` declaration (boolean shorthand or partial
+ * config) against `character.settings.x402` defaults, plus the event names
+ * emitted around payment negotiation.
+ */
 import type {
   AgentRuntime,
   Character,

--- a/plugins/plugin-x402/vitest.config.ts
+++ b/plugins/plugin-x402/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for plugin-x402: node environment, 60s timeouts, shared core mock setup. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
Batch **B15** of the repo-wide comment cleanup (parent #12181), issue #12245. **Comments only — zero functional diff**, machine-checked.

## Scope covered

Prose file headers added to every previously header-less source file, plus churn-comment cleanup, across the batch's plugins: `plugin-sql`, `plugin-localdb`, `plugin-local-storage`, `plugin-inmemorydb`, `plugin-wallet`, `plugin-wallet-ui`, `plugin-hyperliquid`, `plugin-polymarket`, `plugin-x402`, `plugin-tee`.

- **433 source files** changed, all comment-only.
- Every in-scope file now opens with a purpose-explaining header written from reading the file (system-terms first sentence, relationships/invariants as warranted, length scaled to weight; test files state the surface under test + how real the harness is).
- Churn handled per the convention: change-narration deleted, durable-but-churn-phrased notes rewritten to present tense, code-restatement stripped, and a handful of mislabeled/dead comments removed (e.g. a Drizzle table mislabeled as Knex JSDoc, dead commented-out FK/`.references()` blocks, a Jupiter-vs-Raydium API mislabel).

**Build artifacts excluded:** the four `plugin-hyperliquid/src/*.js` compiled siblings (they carry `//# sourceMappingURL` and mirror their `.ts` sources) are treated as build output and left untouched — same spirit as the generated-file exclusion.

## Verification

```
node scripts/assert-comment-only-diff.mjs origin/develop
  → OK — 433 source file(s) changed; every code token identical to origin/develop. Comments only.

self-audit (every in-scope file opens with a header, excl. compiled .js):
  → prints nothing (0 remaining)

bunx biome check <changed files>
  → Checked 417 files. No fixes applied.
```

Header self-audit clean, guard green, Biome clean, no double-headers.

## Evidence rows

Trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Reviewer protocol: spot-read ≥10% of the new headers against the code they describe; skim the churn deletions for the keep/rewrite classes. A follow-up was filed for 4 real dead-code bugs a reviewer spotted in the wallet Steer/Kamino services (left untouched here per the comments-only mandate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)