### PR TITLE
chore(comment-cleanup): B17 batch — prose headers for plugin-web-search (#12247)

### DIFF
--- a/plugins/plugin-web-search/src/index.ts
+++ b/plugins/plugin-web-search/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Entry point for the web-search plugin.
+ *
+ * Exports the `webSearchPlugin` object and the `"web"` search-category
+ * definition (`WEB_SEARCH_CATEGORY`). Registering the plugin adds the
+ * Tavily-backed `WebSearchService` and registers the category with core's search
+ * dispatch (via `runtime.registerSearchCategory`) so web/news queries route
+ * here. Opt-in, and registers no actions/providers/evaluators/routes.
+ */
+
 import type { IAgentRuntime, Plugin, SearchCategoryRegistration } from "@elizaos/core";
 import { ServiceType } from "@elizaos/core";
 

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -1,3 +1,14 @@
+/**
+ * Tavily-backed `WebSearchService` — the `ServiceType.WEB_SEARCH` implementation.
+ *
+ * Wraps `@tavily/core` to fulfil the `IWebSearchService` contract (search /
+ * news / images / videos / suggestions / trending / page-info), normalizing
+ * Tavily's responses to core's shared shape. Degrades gracefully: without
+ * `TAVILY_API_KEY` it boots inert and throws a descriptive error on first use
+ * rather than crashing boot. `getPageInfo` is a raw fetch + regex scrape (not
+ * Tavily-backed); videos reuse web search since Tavily has no video endpoint.
+ */
+
 import { type IAgentRuntime, IWebSearchService, logger, ServiceType } from "@elizaos/core";
 import { tavily } from "@tavily/core";
 

--- a/plugins/plugin-web-search/src/types.ts
+++ b/plugins/plugin-web-search/src/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Local search option/result types for the web-search plugin, extending
+ * `@elizaos/core`'s shared search types (`SearchOptions`/`SearchResponse`) and
+ * re-exporting the image/news/video option types the service accepts. Keeps the
+ * plugin's Tavily-facing shapes aligned with core's search contract.
+ */
+
 import type {
     SearchOptions as CoreSearchOptions,
     SearchResponse as CoreSearchResponse,


### PR DESCRIPTION
Part of #12247 (B17: the `plugins/**` comment-cleanup fan-out), now unblocked by the merged Phase 0 (#12287).

## What changed

Adds a purpose-explaining prose header to the three previously-header-less source files in `plugin-web-search`, written in the plugin's own architecture terms (the Tavily-backed `WebSearchService` fulfilling `ServiceType.WEB_SEARCH`, the `"web"` search-category registration, graceful degradation when `TAVILY_API_KEY` is absent, and the raw-fetch `getPageInfo`).

3 files, headers only.

## Verification — machine-proven zero functional diff

```
$ bun run check:comment-only        # parser-based guard from #12287
[assert-comment-only-diff] OK — 3 source file(s) changed; every code token identical to origin/develop. Comments only.
```

- `biome check` — clean, no fixes.

N/A — comments only; no runtime/LLM/UI behavior is touched, so trajectories/screenshots/device captures don't apply (the comment-only guard is the binding evidence).

Scope note: this is **one batch** of B17's ~1,039-file fan-out (the parent explicitly scopes B17 as many small-plugin PRs). It demonstrates the merged guard end-to-end on a plugin and is safely mergeable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)