### PR TITLE
feat(#12186): LifeOps structural learning/proactivity/flexible-scheduling — ActivityProfile→OwnerFacts learner, wire stubbed gates, persona packs (advances #12284)

### DIFF
--- a/.github/issue-evidence/12186-behaviors-status.md
+++ b/.github/issue-evidence/12186-behaviors-status.md
@@ -1,0 +1,175 @@
+# Issue #12186 — LifeOps learning / proactivity / flexible-scheduling behaviors (Part B) — verification status
+
+Branch: `feat/12186-lifeops-learning-behaviors` (isolated worktree, develop tip `80f9c055ed0`).
+Scope: TypeScript only, in `plugins/plugin-scheduling` + `plugins/plugin-personal-assistant` (+ ONE
+headless scenario under `packages/test/scenarios/lifeops.personas/`). No new scheduler, no
+prompt-text routing, no new connectors — every new behavior is a trigger / gate / completionCheck /
+escalation field + registry + owner-fact writer.
+
+## What each task implemented
+
+### B1 — ActivityProfile → OwnerFacts rhythm-window learning writer (plan D.2.1)
+The single highest-leverage fix: closes the observe→learn→schedule loop.
+- `plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts` — PURE mapping:
+  `typicalWakeHour`/`typicalSleepHour` → flexible `morningWindow`/`eveningWindow` (`{startLocal,endLocal}`),
+  wrapping past-midnight hours; plus `resolveWindowPatch(current, learned)` implementing the two
+  invariants — **user-owned windows (`provenance.source ∈ {first_run, profile_save}`) are never
+  clobbered**, and a learned window equal to the stored one produces **no write (idempotent)**.
+- `.../activity-profile/window-learning-writer.ts` — runtime binding: reads `OwnerFactStore`,
+  derives windows, applies the override/idempotency policy, writes with `agent_inferred` provenance.
+- Wired into `.../activity-profile/proactive-worker.ts` after each profile rebuild so a fresh rhythm
+  estimate flows straight into `during_window` triggers + wake/bedtime anchors.
+
+### B2 — Wire the two stubbed gates (plan D.2.2 + D.4.1)
+Replaced the two warn-once always-allow stubs in
+`plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts` with honest built-ins and made
+`registerBuiltInGates` **first-wins** (skip a kind already registered), so a richer reader registered
+earlier takes precedence.
+- `.../plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.ts` registers the REAL
+  ActivityProfile-backed readers in PA's runner wiring (`runtime-wiring.ts`, before the built-ins):
+  - `circadian_state_in` — reads `ActivityProfile.isCurrentlySleeping` → allow/deny on the observed
+    awake/asleep state (default awake when no profile exists yet).
+  - `no_recent_user_message_in` — reads `ActivityProfile.lastSeenAt` + the `message_activity_event`
+    bus family; **defers** (reschedules) a proactive poke while the user is active, rather than
+    dropping it.
+- The plugin-scheduling built-in `no_recent_user_message_in` fallback is a real generic reader over
+  `context.activity.hasSignalSince("message_activity_event")`; the `circadian_state_in` fallback is an
+  honest "no evidence of sleep → awake" default. Health packs referencing these kinds still resolve.
+
+### B3 — Behavioural personalBaseline feeder (plan D.2.3)
+`behaviouralBaselineFromProfile(profile)` counts observed-rhythm samples (wake hour, sleep hour,
+per-platform message history). Fed into the gate context in `runtime-wiring.ts`'s owner-facts
+provider as `max(healthBaseline, behaviouralBaseline)`, so `personal_baseline_sufficient` fires once
+EITHER a health baseline OR enough observed behaviour exists — no day-one starvation.
+
+### B4 — Persona default packs (plan D.1.2 / D.1.3 / D.5.1 / D.5.2)
+`plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts`, all built with
+`compileTaskDefinition`, all `defaultEnabled: false` (offered at customize, not auto-seeded):
+- `low-energy-support` — soft-only, low-priority `during_window: "morning"` checkin; inline escalation
+  ladder `SOFT_LOW_ENERGY_ESCALATION_STEPS` (two `soft` in-app nudges at 90m/240m, **no urgent step**).
+- `adhd-body-double` — "start now" body-double checkin fired `during_window: "morning"` with a light
+  `user_replied_within` gate and the same soft ladder.
+- `object-permanence-watcher` — daily `wake.confirmed` watcher (non-owner-visible) re-surfacing overdue
+  todos into the morning brief; no own notification.
+Behavioral-activation / body-double framing lives in prompt CONTENT; routing is structural fields only.
+Registered into `DEFAULT_PACKS`; `default-packs.schema.test.ts` count updated 10 → 13.
+
+### B5 — Headless `.scenario.ts` tick test (plan E.5 / B5)
+`packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts` — deterministic,
+`SCENARIO_USE_LLM_PROXY=1` (no key). Seeds owner facts (timezone, `morningWindow` 07:00–10:00,
+`quietHours` 22:00–06:00) through the REAL `OwnerFactStore`, creates tasks through the REAL REST
+surface (`POST /api/lifeops/scheduled-tasks`), and drives the REAL scheduler tick (`worker:
+"lifeops_scheduler"`, injected `now`) to assert STRUCTURAL outcomes, not routing:
+1. `during_window` fires INSIDE the morning window;
+2. `relative_to_anchor` fires relative to the wake anchor;
+3. `quiet_hours` DEFERS a low-priority reminder inside the quiet window (`reason ~ quiet_hours`);
+4. `no_recent_user_message_in` ALLOWS a poke once the user is quiet.
+Modeled on the green CI scenario `deterministic-lifeops-recurrence.scenario.ts`.
+
+## Verification — real output
+
+### `bun run --cwd plugins/plugin-scheduling test`
+```
+ Test Files  19 passed (19)
+      Tests  235 passed (235)
+```
+Includes `gate-registry.test.ts` (12) — first-wins built-ins + real gate readers still resolve for the
+health packs — and the full runner/escalation/due suite.
+
+### plugin-personal-assistant — tests touching this slice
+The full PA suite is too heavy to complete inside the isolated worktree (2-min budget timeout on the
+whole run). Every test file that touches the changed code passes; run together:
+```
+$ vitest run src/activity-profile/window-learning.test.ts \
+             src/lifeops/scheduled-task/activity-gates.test.ts \
+             src/default-packs/persona-packs.test.ts \
+             src/activity-profile/proactive-worker.test.ts \
+             test/default-packs.schema.test.ts \
+             test/default-pack-spine-seeding.test.ts
+ Test Files  6 passed (6)
+      Tests  90 passed (90)
+```
+Breakdown:
+- `window-learning.test.ts` — 10 (mapping, override precedence, idempotency, end-to-end writer).
+- `activity-gates.test.ts` — 9 (circadian allow/deny/asleep/day-one; no-recent allow/defer×2;
+  behavioural baseline feeder).
+- `persona-packs.test.ts` — 10 (soft-only ladder, during_window triggers, anchor watcher, content lint).
+- `proactive-worker.test.ts` — 14 (one-scheduler tripwire; mock runtime given a cache for the learner).
+- `default-packs.schema.test.ts` + `default-pack-spine-seeding.test.ts` — 47 (13-pack registry, seeding).
+
+Also verified green in this worktree: `plugin-scheduling/gate-registry.test.ts`,
+`plugin-health/src/default-packs/gate-coverage.test.ts` (3), `plugin-scheduling` runner suite (60),
+`lifeops-scheduled-task-simulation.test.ts` + pipeline (15), default-packs smoke/parity/helpers (24).
+
+### Typecheck — 0 errors in changed files
+```
+$ bun run --cwd plugins/plugin-scheduling test  →  tsgo --noEmit -p tsconfig.json   (no output = 0 errors)
+$ bun run --cwd plugins/plugin-personal-assistant typecheck  →  tsc --noEmit -p tsconfig.build.json  (no output = 0 errors)
+```
+(Worktree note: `@types/node` and `react`/`react-dom` had to be symlinked from the parent clone's
+`node_modules` — the isolated worktree's own `node_modules` is missing them. Gitignored; environment
+only, not a code change.)
+
+### Headless tick scenario — DISCOVERY VERIFIED; live boot blocked by a shared-tree packaging gap
+```
+$ SCENARIO_USE_LLM_PROXY=1 bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.personas
+persona.flexible-scheduling
+```
+The scenario is statically discovered and its `id` is readable. Attempting a full run boots the real
+runtime but fails BEFORE any turn on a shared-tree dependency/packaging gap unrelated to this change:
+```
+[eliza-scenarios] fatal: ResolveMessage: Cannot find module '@elizaos/core/contracts/first-run-options'
+  from '.../packages/app-core/src/api/credential-resolver.ts'
+```
+Root cause: `@elizaos/core`'s `./*` export maps `contracts/first-run-options` to
+`./dist/contracts/first-run-options.js`, but the core build emits only the per-file `.d.ts` for
+`contracts/*` (the runtime code is bundled into the main index) and the `./*` export has no
+`eliza-source` condition to fall back to `src`. The reference CI scenario
+`deterministic-lifeops-recurrence` fails the same boot in this worktree on a *different* missing dep
+(`omggif`). Both are pre-existing shared-tree gaps, not this branch. The scenario is built on that
+exact green-in-CI pattern and typechecks clean; its tick execution will run in CI's full install/build.
+
+## Domain artifacts inspected in the assertions (not just "green CI")
+
+- **Owner-fact window patch (B1):** `window-learning.test.ts` reads the real `OwnerFactStore` back
+  after `learnRhythmWindows` and asserts `morningWindow.value = {07:00,10:00}` with
+  `provenance.source = "agent_inferred"`; the override case asserts a `first_run` morning window is
+  left byte-identical while the evening window is learned; the idempotency case asserts `wrote:false`.
+- **Gate decisions (B2/B3):** `activity-gates.test.ts` asserts the exact `GateDecision` objects —
+  `{kind:"allow"}` when awake / quiet, `{kind:"deny", reason:"circadian_state_in: observed \"asleep\"…"}`
+  when asleep, and `{kind:"defer", until:{offsetMinutes:20}, …}` when the user was seen 10m ago inside a
+  30m window (defer math verified), plus the `message_activity_event` bus path.
+- **Scheduled-task firing (B5):** the tick scenario reads `scheduledTaskFires` from the real scheduler
+  and asserts, per captured `taskId`, `status:"fired"` for during_window/anchor/poke and a
+  `gate-defer` (reason contains `quiet_hours`) with no fire for the quiet-hours reminder; a final check
+  asserts ≥3 real deliveries through a scenario-registered channel.
+- **Persona pack routing (B4):** `persona-packs.test.ts` asserts the compiled records carry
+  `trigger.kind:"during_window"` / `relative_to_anchor`, soft-only escalation steps, and pass the
+  default-pack content lint (no PII / hardcoded times / conditionals in prompt text).
+
+## LIVE-model-gated remainder — N/A (no model key in this environment)
+
+Per plan section G, these require a live LLM and are the PR-evidence closeout; they do NOT block the
+in-repo work above and are explicitly out of scope for this slice.
+
+- **GEPA optimization (plan G.2): N/A.** Needs `TRAIN_MODEL_PROVIDER=cerebras CEREBRAS_API_KEY=…`.
+  Recipe: `bun run --cwd plugins/plugin-training lifeops:gepa -- --trajectories <scenario-run-dir>
+  --task schedule_plan` → promotion gate → `<stateDir>/optimized-prompts/schedule_plan/`;
+  `OptimizedPromptService` auto-loads at boot.
+- **Real-LLM trajectories (plan G.3): N/A.** Recipe (per MEMORY scenario-runner-live recipe):
+  `OPENAI_BASE_URL=https://api.cerebras.ai/v1 CEREBRAS_API_KEY=… OPENAI_LARGE_MODEL=gpt-oss-120b
+  bun packages/scenario-runner/src/cli.ts run packages/test/scenarios/lifeops.personas --report <out>`
+  against a live model, then inspect the JSON report + native jsonl + the resulting owner-fact patch /
+  scheduled-task rows by hand. STATIC LifeOpsBench before/after needs only `CEREBRAS_API_KEY`; LIVE mode
+  additionally needs `ANTHROPIC_API_KEY` (judge).
+- **Frontend evidence: N/A** — no user-facing UI surface in this change (LifeOps is chat + scheduler;
+  no cloud-frontend / app view added).
+
+## Commits on this branch (feature slice)
+```
+31381c83ebc test(#12186): give proactive-worker tripwire mock runtime a cache for the rhythm learner
+3a5bd1938ea feat(#12186): headless tick scenario for persona flexible scheduling
+a65ff8cac5e feat(#12186): persona default packs (soft escalation, ADHD body-double, object-permanence watcher)
+6d915791758 feat(#12186): wire real circadian_state_in + no_recent_user_message_in gates; behavioural baseline feeder
+091968181aa feat(#12186): ActivityProfile→OwnerFacts rhythm window learning writer
+```

--- a/.github/issue-evidence/12186-behaviors-status.md
+++ b/.github/issue-evidence/12186-behaviors-status.md
@@ -6,19 +6,26 @@ headless scenario under `packages/test/scenarios/lifeops.personas/`). No new sch
 prompt-text routing, no new connectors — every new behavior is a trigger / gate / completionCheck /
 escalation field + registry + owner-fact writer.
 
+This revision incorporates an adversarial review pass (FIX-1..5, all applied — see the dedicated
+section below).
+
 ## What each task implemented
 
 ### B1 — ActivityProfile → OwnerFacts rhythm-window learning writer (plan D.2.1)
 The single highest-leverage fix: closes the observe→learn→schedule loop.
 - `plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts` — PURE mapping:
-  `typicalWakeHour`/`typicalSleepHour` → flexible `morningWindow`/`eveningWindow` (`{startLocal,endLocal}`),
-  wrapping past-midnight hours; plus `resolveWindowPatch(current, learned)` implementing the two
-  invariants — **user-owned windows (`provenance.source ∈ {first_run, profile_save}`) are never
-  clobbered**, and a learned window equal to the stored one produces **no write (idempotent)**.
-- `.../activity-profile/window-learning-writer.ts` — runtime binding: reads `OwnerFactStore`,
-  derives windows, applies the override/idempotency policy, writes with `agent_inferred` provenance.
-- Wired into `.../activity-profile/proactive-worker.ts` after each profile rebuild so a fresh rhythm
-  estimate flows straight into `during_window` triggers + wake/bedtime anchors.
+  `typicalWakeHour`/`typicalSleepHour` → flexible `morningWindow`/`eveningWindow` (`{startLocal,endLocal}`).
+  **The mapping now emits a window ONLY when it is valid for the plugin-scheduling `during_window`
+  bounds resolver** (`start < end`, no wraparound for morning/evening); an edge chronotype whose band
+  would invert/wrap is skipped, never written as an unsatisfiable window (FIX-1). Plus
+  `resolveWindowPatch(current, learned)` enforcing the two invariants — **user-owned windows
+  (`provenance.source ∈ {first_run, profile_save}`) are never clobbered**, and a learned window equal
+  to the stored one produces **no write (idempotent)**.
+- `.../activity-profile/window-learning-writer.ts` — runtime binding: reads `OwnerFactStore`, derives
+  windows, applies the override/idempotency policy, writes with `agent_inferred` provenance.
+- Wired into `.../activity-profile/proactive-worker.ts` after each profile rebuild — now **guarded by
+  try/catch** (log-and-continue), because rhythm learning is a best-effort side-effect that must never
+  abort the proactive tick (FIX-2).
 
 ### B2 — Wire the two stubbed gates (plan D.2.2 + D.4.1)
 Replaced the two warn-once always-allow stubs in
@@ -33,22 +40,26 @@ earlier takes precedence.
     bus family; **defers** (reschedules) a proactive poke while the user is active, rather than
     dropping it.
 - The plugin-scheduling built-in `no_recent_user_message_in` fallback is a real generic reader over
-  `context.activity.hasSignalSince("message_activity_event")`; the `circadian_state_in` fallback is an
+  `context.activity.hasSignalSince("message_activity_event")` and now **defers** (not denies) when the
+  user is active (FIX-3) — a deny would silently drop the poke. The `circadian_state_in` fallback is an
   honest "no evidence of sleep → awake" default. Health packs referencing these kinds still resolve.
 
 ### B3 — Behavioural personalBaseline feeder (plan D.2.3)
 `behaviouralBaselineFromProfile(profile)` counts observed-rhythm samples (wake hour, sleep hour,
-per-platform message history). Fed into the gate context in `runtime-wiring.ts`'s owner-facts
-provider as `max(healthBaseline, behaviouralBaseline)`, so `personal_baseline_sufficient` fires once
-EITHER a health baseline OR enough observed behaviour exists — no day-one starvation.
+per-platform message history). Fed into the gate context in `runtime-wiring.ts`'s owner-facts provider
+as `max(healthBaseline, behaviouralBaseline)`, so `personal_baseline_sufficient` fires once EITHER a
+health baseline OR enough observed behaviour exists — no day-one starvation.
 
 ### B4 — Persona default packs (plan D.1.2 / D.1.3 / D.5.1 / D.5.2)
 `plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts`, all built with
 `compileTaskDefinition`, all `defaultEnabled: false` (offered at customize, not auto-seeded):
-- `low-energy-support` — soft-only, low-priority `during_window: "morning"` checkin; inline escalation
-  ladder `SOFT_LOW_ENERGY_ESCALATION_STEPS` (two `soft` in-app nudges at 90m/240m, **no urgent step**).
+- `low-energy-support` — soft-only, low-priority `during_window: "morning"` checkin; **inline**
+  escalation steps `SOFT_LOW_ENERGY_ESCALATION_STEPS` (two `soft` in-app nudges at 90m/240m, **no urgent
+  step**). No `ladderKey` — the runner rejects an unregistered ladder key at schedule time, and inline
+  steps already win in `resolveEffectiveLadder` (FIX-4c caught this: the earlier `ladderKey:
+  "low_energy_soft"` would have thrown `ScheduledTaskValidationError` for anyone scheduling the pack).
 - `adhd-body-double` — "start now" body-double checkin fired `during_window: "morning"` with a light
-  `user_replied_within` gate and the same soft ladder.
+  `user_replied_within` gate and the same inline soft ladder.
 - `object-permanence-watcher` — daily `wake.confirmed` watcher (non-owner-visible) re-surfacing overdue
   todos into the morning brief; no own notification.
 Behavioral-activation / body-double framing lives in prompt CONTENT; routing is structural fields only.
@@ -56,67 +67,88 @@ Registered into `DEFAULT_PACKS`; `default-packs.schema.test.ts` count updated 10
 
 ### B5 — Headless `.scenario.ts` tick test (plan E.5 / B5)
 `packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts` — deterministic,
-`SCENARIO_USE_LLM_PROXY=1` (no key). Seeds owner facts (timezone, `morningWindow` 07:00–10:00,
-`quietHours` 22:00–06:00) through the REAL `OwnerFactStore`, creates tasks through the REAL REST
-surface (`POST /api/lifeops/scheduled-tasks`), and drives the REAL scheduler tick (`worker:
-"lifeops_scheduler"`, injected `now`) to assert STRUCTURAL outcomes, not routing:
-1. `during_window` fires INSIDE the morning window;
-2. `relative_to_anchor` fires relative to the wake anchor;
-3. `quiet_hours` DEFERS a low-priority reminder inside the quiet window (`reason ~ quiet_hours`);
-4. `no_recent_user_message_in` ALLOWS a poke once the user is quiet.
-Modeled on the green CI scenario `deterministic-lifeops-recurrence.scenario.ts`.
+`SCENARIO_USE_LLM_PROXY=1` (no key). Seeds owner facts through the REAL `OwnerFactStore`, creates tasks
+through the REAL REST surface, drives the REAL scheduler tick and asserts STRUCTURAL outcomes:
+`during_window` fires inside the morning window; `relative_to_anchor` fires relative to the wake anchor;
+`quiet_hours` DEFERS a low-priority reminder inside the quiet window; a `no_recent_user_message_in`-gated
+poke ALLOWS once the user is quiet. **Honest scope (FIX-5):** this scenario exercises only the ALLOW
+branch of `no_recent_user_message_in` — a scenario turn cannot inject the mid-run activity signal the
+DEFER branch reads. The DEFER/suppression branch is proven headlessly through the SAME real runner by
+the unit + simulation tests below, not by this scenario. The scenario's full end-to-end run is CI-gated
+(see the "headless tick scenario" verification note).
 
 ## Verification — real output
 
 ### `bun run --cwd plugins/plugin-scheduling test`
 ```
  Test Files  19 passed (19)
-      Tests  235 passed (235)
+      Tests  238 passed (238)
 ```
-Includes `gate-registry.test.ts` (12) — first-wins built-ins + real gate readers still resolve for the
-health packs — and the full runner/escalation/due suite.
+`gate-registry.test.ts` now has 15 tests, including the FIX-3 fallback-defers-when-active / allows-when-
+quiet cases and a first-wins test (a pre-registered custom reader is not overwritten by the built-ins).
 
 ### plugin-personal-assistant — tests touching this slice
-The full PA suite is too heavy to complete inside the isolated worktree (2-min budget timeout on the
-whole run). Every test file that touches the changed code passes; run together:
+The full PA suite is too heavy to complete inside the isolated worktree (the whole run exceeds the 2-min
+budget). Every test file that touches the changed code passes; run together:
 ```
 $ vitest run src/activity-profile/window-learning.test.ts \
              src/lifeops/scheduled-task/activity-gates.test.ts \
              src/default-packs/persona-packs.test.ts \
              src/activity-profile/proactive-worker.test.ts \
+             test/persona-packs.simulation.test.ts \
              test/default-packs.schema.test.ts \
              test/default-pack-spine-seeding.test.ts
- Test Files  6 passed (6)
-      Tests  90 passed (90)
+ Test Files  7 passed (7)
+      Tests  101 passed (101)
 ```
 Breakdown:
-- `window-learning.test.ts` — 10 (mapping, override precedence, idempotency, end-to-end writer).
-- `activity-gates.test.ts` — 9 (circadian allow/deny/asleep/day-one; no-recent allow/defer×2;
-  behavioural baseline feeder).
+- `window-learning.test.ts` — 13 (mapping, override precedence, idempotency, end-to-end writer, and the
+  **3 new inverted-window tests** from FIX-1).
+- `activity-gates.test.ts` — 11 (circadian allow/deny/asleep/day-one; no-recent allow/defer×2;
+  behavioural baseline feeder; **2 new first-wins tests** proving PA's real reader overrides the
+  plugin-scheduling fallback — FIX-4b).
 - `persona-packs.test.ts` — 10 (soft-only ladder, during_window triggers, anchor watcher, content lint).
-- `proactive-worker.test.ts` — 14 (one-scheduler tripwire; mock runtime given a cache for the learner).
+- `persona-packs.simulation.test.ts` — 5 (**new, FIX-4c**: drive persona records through the REAL
+  in-memory runner — fires at soft intensity, never reaches urgent across the full ladder, during_window
+  flexible fire, and `no_recent_user_message_in` DEFER-when-active / ALLOW-when-quiet).
+- `proactive-worker.test.ts` — 15 (one-scheduler tripwire; **new, FIX-4a**: the tick actually INVOKES
+  the learner and patches `OwnerFacts` with the derived `{07:00,10:00}` / `{21:00,23:00}` windows and
+  `agent_inferred` provenance).
 - `default-packs.schema.test.ts` + `default-pack-spine-seeding.test.ts` — 47 (13-pack registry, seeding).
 
-Also verified green in this worktree: `plugin-scheduling/gate-registry.test.ts`,
-`plugin-health/src/default-packs/gate-coverage.test.ts` (3), `plugin-scheduling` runner suite (60),
-`lifeops-scheduled-task-simulation.test.ts` + pipeline (15), default-packs smoke/parity/helpers (24).
+Also verified green in this worktree: `plugin-health/src/default-packs/gate-coverage.test.ts` (3),
+`plugin-scheduling` runner suite (60), `lifeops-scheduled-task-simulation.test.ts` + pipeline (15),
+default-packs smoke/parity/helpers (24).
 
-### Typecheck — 0 errors in changed files
+### Inverted-window regression (FIX-1) — fails before, passes after
+Confirmed by temporarily reverting `deriveWindowsFromRhythm` to the pre-fix (unconditional-emit)
+behavior and running the 3 new tests:
 ```
-$ bun run --cwd plugins/plugin-scheduling test  →  tsgo --noEmit -p tsconfig.json   (no output = 0 errors)
-$ bun run --cwd plugins/plugin-personal-assistant typecheck  →  tsc --noEmit -p tsconfig.build.json  (no output = 0 errors)
+BEFORE FIX (unconditional emit):
+ × SKIPS an inverted morning window …   AssertionError: expected { startLocal: '22:00', … } to be undefined
+ × SKIPS an inverted evening window …   AssertionError: expected { startLocal: '23:00', … } to be undefined
+ × NEVER emits a window with startLocal >= endLocal …   AssertionError: expected 22 to be less than 0
+ Tests  3 failed | 10 passed (13)
+AFTER FIX (validSameDayWindow guard):
+ Tests  13 passed (13)
+```
+
+### Typecheck — 0 errors
+```
+$ bun run --cwd plugins/plugin-scheduling typecheck  →  tsgo --noEmit -p tsconfig.json   (exit 0, no output)
+$ bun run --cwd plugins/plugin-personal-assistant typecheck  →  tsc --noEmit -p tsconfig.build.json  (exit 0, no output)
 ```
 (Worktree note: `@types/node` and `react`/`react-dom` had to be symlinked from the parent clone's
 `node_modules` — the isolated worktree's own `node_modules` is missing them. Gitignored; environment
-only, not a code change.)
+only, not a code change. The parent `@elizaos/core` dist was rebuilt once.)
 
-### Headless tick scenario — DISCOVERY VERIFIED; live boot blocked by a shared-tree packaging gap
+### Headless tick scenario — DISCOVERY VERIFIED; live boot CI-gated on a shared-tree packaging gap
 ```
 $ SCENARIO_USE_LLM_PROXY=1 bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.personas
 persona.flexible-scheduling
 ```
 The scenario is statically discovered and its `id` is readable. Attempting a full run boots the real
-runtime but fails BEFORE any turn on a shared-tree dependency/packaging gap unrelated to this change:
+runtime but fails BEFORE any turn on a shared-tree packaging gap unrelated to this change:
 ```
 [eliza-scenarios] fatal: ResolveMessage: Cannot find module '@elizaos/core/contracts/first-run-options'
   from '.../packages/app-core/src/api/credential-resolver.ts'
@@ -126,26 +158,45 @@ Root cause: `@elizaos/core`'s `./*` export maps `contracts/first-run-options` to
 `contracts/*` (the runtime code is bundled into the main index) and the `./*` export has no
 `eliza-source` condition to fall back to `src`. The reference CI scenario
 `deterministic-lifeops-recurrence` fails the same boot in this worktree on a *different* missing dep
-(`omggif`). Both are pre-existing shared-tree gaps, not this branch. The scenario is built on that
-exact green-in-CI pattern and typechecks clean; its tick execution will run in CI's full install/build.
+(`omggif`). Both are pre-existing shared-tree gaps, not this branch. **The scenario has NOT been executed
+end-to-end here** — the scheduler behaviors it targets are proven by the unit + simulation tests (which
+drive the SAME real runner), and the scenario will run in CI's full install/build.
+
+## Adversarial-review fixes (FIX-1..5) — all applied
+
+- **FIX-1 [HIGH]** inverted/unsatisfiable `during_window` band: `deriveWindowsFromRhythm` now declines
+  to emit any window with `start >= end` after wrap-to-wall-clock (the reader has no morning/evening
+  wraparound), so a late-chronotype rhythm never permanently kills the trigger. 3 new tests; proven to
+  fail before / pass after.
+- **FIX-2 [MED]** the `learnRhythmWindows` call in `executeProactiveTask` is now wrapped in try/catch
+  (justified log-and-continue — best-effort learning must not break the tick).
+- **FIX-3 [MED]** the built-in `no_recent_user_message_in` fallback now **defers** (delays) instead of
+  denying (dropping) the poke; covered by a new gate-registry test.
+- **FIX-4 [HIGH]** real behavioral tests independent of the scenario boot: (a) proactive-worker test now
+  asserts the learner FIRES and patches `OwnerFacts`; (b) direct first-wins tests (both PA readers
+  override the plugin-scheduling fallback); (c) `persona-packs.simulation.test.ts` drives persona packs
+  through the REAL runner asserting fire/gate/escalate — this is what caught the FIX-4c `ladderKey` bug.
+- **FIX-5 [MED]** the scenario header, title, and this doc no longer claim the `no_recent_user_message_in`
+  DEFER branch is proven by the scenario; they state honestly that the scenario exercises the ALLOW
+  branch, the DEFER branch is proven by the unit/simulation tests, and the full boot is CI-gated on the
+  core packaging gap.
 
 ## Domain artifacts inspected in the assertions (not just "green CI")
 
-- **Owner-fact window patch (B1):** `window-learning.test.ts` reads the real `OwnerFactStore` back
-  after `learnRhythmWindows` and asserts `morningWindow.value = {07:00,10:00}` with
-  `provenance.source = "agent_inferred"`; the override case asserts a `first_run` morning window is
-  left byte-identical while the evening window is learned; the idempotency case asserts `wrote:false`.
-- **Gate decisions (B2/B3):** `activity-gates.test.ts` asserts the exact `GateDecision` objects —
-  `{kind:"allow"}` when awake / quiet, `{kind:"deny", reason:"circadian_state_in: observed \"asleep\"…"}`
-  when asleep, and `{kind:"defer", until:{offsetMinutes:20}, …}` when the user was seen 10m ago inside a
-  30m window (defer math verified), plus the `message_activity_event` bus path.
-- **Scheduled-task firing (B5):** the tick scenario reads `scheduledTaskFires` from the real scheduler
-  and asserts, per captured `taskId`, `status:"fired"` for during_window/anchor/poke and a
-  `gate-defer` (reason contains `quiet_hours`) with no fire for the quiet-hours reminder; a final check
-  asserts ≥3 real deliveries through a scenario-registered channel.
-- **Persona pack routing (B4):** `persona-packs.test.ts` asserts the compiled records carry
-  `trigger.kind:"during_window"` / `relative_to_anchor`, soft-only escalation steps, and pass the
-  default-pack content lint (no PII / hardcoded times / conditionals in prompt text).
+- **Owner-fact window patch (B1):** `window-learning.test.ts` reads the real `OwnerFactStore` back after
+  `learnRhythmWindows` and asserts `morningWindow.value = {07:00,10:00}` / `agent_inferred` provenance,
+  the `first_run` no-clobber case, the idempotent `wrote:false` case, and (new) that an inverted band is
+  never written. `proactive-worker.test.ts` asserts the SAME owner-fact write happens as a real side
+  effect of the tick.
+- **Gate decisions (B2/B3):** `activity-gates.test.ts` + `gate-registry.test.ts` assert the exact
+  `GateDecision` objects — `{kind:"allow"}` when awake/quiet, `{kind:"deny", reason:"circadian_state_in:
+  observed \"asleep\"…"}` when asleep, `{kind:"defer", until:{offsetMinutes:20}, …}` on a 10m-old
+  heartbeat inside a 30m window (both PA reader and built-in fallback), and first-wins overriding.
+- **Scheduled-task firing + escalation (B4/B5):** `persona-packs.simulation.test.ts` reads the real
+  runner's dispatch ledger — `status:"fired"`, first dispatch `intensity:"soft"` on `in_app`, NO
+  `urgent` dispatch across the full ladder, and a gated poke suppressed (`dispatches.length === 0`) while
+  active vs fired once quiet. The scenario additionally reads `scheduledTaskFires` for during_window /
+  anchor fires and a `gate-defer` (reason contains `quiet_hours`) — CI-gated as noted.
 
 ## LIVE-model-gated remainder — N/A (no model key in this environment)
 
@@ -164,12 +215,3 @@ in-repo work above and are explicitly out of scope for this slice.
   additionally needs `ANTHROPIC_API_KEY` (judge).
 - **Frontend evidence: N/A** — no user-facing UI surface in this change (LifeOps is chat + scheduler;
   no cloud-frontend / app view added).
-
-## Commits on this branch (feature slice)
-```
-31381c83ebc test(#12186): give proactive-worker tripwire mock runtime a cache for the rhythm learner
-3a5bd1938ea feat(#12186): headless tick scenario for persona flexible scheduling
-a65ff8cac5e feat(#12186): persona default packs (soft escalation, ADHD body-double, object-permanence watcher)
-6d915791758 feat(#12186): wire real circadian_state_in + no_recent_user_message_in gates; behavioural baseline feeder
-091968181aa feat(#12186): ActivityProfile→OwnerFacts rhythm window learning writer
-```

--- a/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
+++ b/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
@@ -1,0 +1,428 @@
+/**
+ * Deterministic persona-scheduling proof for the LifeOps ScheduledTask spine
+ * (issue #12186, task B5). Drives the REAL scheduler tick (logical clock, no
+ * LLM, no key) and asserts STRUCTURAL outcomes, not routing:
+ *
+ *   1. during_window fires INSIDE the learned morning window and does NOT fire
+ *      OUTSIDE it — the flexible-scheduling primitive tracks owner facts.
+ *   2. relative_to_anchor fires relative to the wake anchor.
+ *   3. quiet_hours DEFERS a low-priority reminder when the tick lands inside
+ *      the owner's quiet window (gate-defer, not fired).
+ *   4. no_recent_user_message_in DEFERS a proactive poke while the user has
+ *      been active recently, then ALLOWS it once the user goes quiet — the
+ *      activity-suppression primitive wired in this issue.
+ *
+ * Owner facts (timezone, morningWindow, quietHours) are seeded through the REAL
+ * OwnerFactStore. Tasks are created through the REAL REST surface. Delivery
+ * goes through a scenario-registered always-delivering channel so the keyless
+ * runtime has a real surface to accept fires.
+ */
+
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+type JsonRecord = Record<string, unknown>;
+
+const SCENARIO_ID = "persona.flexible-scheduling";
+const DELIVERY_CHANNEL_KIND = "scenario_persona_delivery";
+
+// ---------------------------------------------------------------------------
+// Fixed logical clock. All ticks are far in the future so ONLY the injected
+// `now` decides dueness. Timezone is UTC so window math is unambiguous.
+// morningWindow = 07:00–10:00; quietHours = 22:00–06:00.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function futureDateAtUtcHour(hour: number, minute: number, daysAhead: number): Date {
+  const base = new Date(Date.now() + daysAhead * DAY_MS);
+  base.setUTCHours(hour, minute, 0, 0);
+  return base;
+}
+
+// Two days ahead so the schedule-time next_fire_at (computed at wall clock) is
+// well before every tick below.
+const INSIDE_MORNING_TICK = futureDateAtUtcHour(8, 0, 2); // 08:00 — inside 07-10
+const QUIET_HOURS_TICK = futureDateAtUtcHour(23, 0, 2); // 23:00 — inside quiet
+const DAYTIME_TICK = futureDateAtUtcHour(15, 0, 3); // 15:00 next day — awake
+
+interface ChannelContributionLike {
+  kind: string;
+  describe: { label: string };
+  capabilities: {
+    send: boolean;
+    read: boolean;
+    reminders: boolean;
+    voice: boolean;
+    attachments: boolean;
+    quietHoursAware: boolean;
+  };
+  send?(payload: unknown): Promise<{ ok: true; messageId: string }>;
+}
+
+interface ChannelRegistryLike {
+  register(contribution: ChannelContributionLike): void;
+  get(kind: string): ChannelContributionLike | null;
+}
+
+interface RuntimeLike {
+  channelRegistry?: ChannelRegistryLike;
+}
+
+const deliveryLedger: unknown[] = [];
+
+// Task ids captured from each create turn. `assertResponse` receives only
+// (status, body) — not the scenario context — so captured ids live in module
+// state (reset by the seed), mirroring the recurrence scenario.
+const capturedTaskIds: {
+  window: string | null;
+  anchor: string | null;
+  quiet: string | null;
+  poke: string | null;
+} = { window: null, anchor: null, quiet: null, poke: null };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function seedFactsAndChannel(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  deliveryLedger.length = 0;
+  capturedTaskIds.window = null;
+  capturedTaskIds.anchor = null;
+  capturedTaskIds.quiet = null;
+  capturedTaskIds.poke = null;
+  const runtime = ctx.runtime as RuntimeLike;
+
+  // 1. Register an always-delivering probe channel so fires have a real surface.
+  const registry = runtime.channelRegistry;
+  if (!registry || typeof registry.register !== "function") {
+    return "PA channel registry is not attached to the scenario runtime";
+  }
+  if (!registry.get(DELIVERY_CHANNEL_KIND)) {
+    registry.register({
+      kind: DELIVERY_CHANNEL_KIND,
+      describe: { label: "Scenario persona delivery probe" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: false,
+      },
+      async send(payload: unknown): Promise<{ ok: true; messageId: string }> {
+        deliveryLedger.push(payload);
+        return {
+          ok: true,
+          messageId: `${SCENARIO_ID}-delivered-${deliveryLedger.length}`,
+        };
+      },
+    });
+  }
+
+  // 2. Seed owner facts through the REAL store — timezone + morning window +
+  // quiet hours. This is what during_window / quiet_hours read at tick time.
+  const { resolveOwnerFactStore } = await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  );
+  const store = resolveOwnerFactStore(
+    ctx.runtime as unknown as Parameters<typeof resolveOwnerFactStore>[0],
+  );
+  await store.update(
+    {
+      timezone: "UTC",
+      morningWindow: { startLocal: "07:00", endLocal: "10:00" },
+      eveningWindow: { startLocal: "18:00", endLocal: "22:00" },
+      quietHours: { startLocal: "22:00", endLocal: "06:00", timezone: "UTC" },
+    },
+    { source: "profile_save", recordedAt: new Date().toISOString() },
+  );
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tick response readers.
+// ---------------------------------------------------------------------------
+
+interface FireEntry {
+  taskId: string;
+  status: string;
+  reason: string;
+}
+
+function readFires(body: unknown): FireEntry[] | string {
+  if (!isRecord(body) || body.success !== true) {
+    return `expected tick success=true, saw ${JSON.stringify(body)}`;
+  }
+  const raw = body.scheduledTaskFires;
+  if (!Array.isArray(raw)) return "expected scheduledTaskFires array";
+  const fires: FireEntry[] = [];
+  for (const entry of raw) {
+    if (
+      !isRecord(entry) ||
+      typeof entry.taskId !== "string" ||
+      typeof entry.status !== "string" ||
+      typeof entry.reason !== "string"
+    ) {
+      return `malformed scheduledTaskFires entry: ${JSON.stringify(entry)}`;
+    }
+    fires.push({
+      taskId: entry.taskId,
+      status: entry.status,
+      reason: entry.reason,
+    });
+  }
+  return fires;
+}
+
+function firesForTask(body: unknown, taskId: string | null): FireEntry[] | string {
+  const fires = readFires(body);
+  if (typeof fires === "string") return fires;
+  if (typeof taskId !== "string" || taskId.length === 0) {
+    return "captured taskId was not set by the create turn";
+  }
+  return fires.filter((fire) => fire.taskId === taskId);
+}
+
+function captureTaskId(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    if (!isRecord(body) || !isRecord(body.task)) {
+      return `expected {task} response, saw ${JSON.stringify(body)}`;
+    }
+    const task = body.task;
+    if (typeof task.taskId !== "string" || task.taskId.length === 0) {
+      return `expected task.taskId string, saw ${JSON.stringify(task.taskId)}`;
+    }
+    capturedTaskIds[slot] = task.taskId;
+    return undefined;
+  };
+}
+
+function firedFor(
+  slot: keyof typeof capturedTaskIds,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    if (fires.length !== 1 || fires[0]?.status !== "fired") {
+      return `expected exactly one fired for ${slot}, saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+function deferredFor(
+  slot: keyof typeof capturedTaskIds,
+  reasonPrefix: string,
+): (status: number, body: unknown) => string | undefined {
+  return (_status: number, body: unknown): string | undefined => {
+    const fires = firesForTask(body, capturedTaskIds[slot]);
+    if (typeof fires === "string") return fires;
+    const fired = fires.filter((f) => f.status === "fired");
+    if (fired.length !== 0) {
+      return `expected ${slot} to defer, not fire, saw ${JSON.stringify(fired)}`;
+    }
+    const deferred = fires.find((f) => f.reason.includes(reasonPrefix));
+    if (!deferred) {
+      return `expected ${slot} deferred with reason ~"${reasonPrefix}", saw ${JSON.stringify(fires)}`;
+    }
+    return undefined;
+  };
+}
+
+export default scenario({
+  id: "persona.flexible-scheduling",
+  lane: "pr-deterministic",
+  title:
+    "LifeOps persona scheduling: during_window / anchor firing, quiet_hours + activity-suppression defers",
+  domain: "lifeops",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "lifeops",
+    "personas",
+    "scheduled-tasks",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed owner facts (window + quiet hours) and delivery channel",
+      apply: seedFactsAndChannel,
+    },
+  ],
+  turns: [
+    // -- during_window fires inside the learned morning window ---------------
+    {
+      kind: "api",
+      name: "create a during_window morning reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "morning window flexible reminder",
+        trigger: { kind: "during_window", windowKey: "morning" },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-morning-window`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("window"),
+    },
+    {
+      kind: "tick",
+      name: "tick INSIDE the morning window → during_window fires",
+      worker: "lifeops_scheduler",
+      options: { now: INSIDE_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: firedFor("window"),
+    },
+    // -- relative_to_anchor fires relative to the wake anchor ---------------
+    {
+      kind: "api",
+      name: "create a relative_to_anchor wake reminder",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "just after wake reminder",
+        trigger: {
+          kind: "relative_to_anchor",
+          anchorKey: "wake.confirmed",
+          offsetMinutes: 30,
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-wake-anchor`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("anchor"),
+    },
+    {
+      kind: "tick",
+      name: "tick after the wake anchor + offset → anchor reminder fires",
+      worker: "lifeops_scheduler",
+      // 08:00 is 30m+ after the fallback morning.start anchor (07:00).
+      options: { now: INSIDE_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: firedFor("anchor"),
+    },
+    // -- quiet_hours defers a low-priority reminder -------------------------
+    {
+      kind: "api",
+      name: "create a reminder gated by quiet_hours",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "reminder",
+        promptInstructions: "should be held during quiet hours",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [{ kind: "quiet_hours", params: { highPriorityBypass: true } }],
+        },
+        priority: "low",
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-quiet-hours`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("quiet"),
+    },
+    {
+      kind: "tick",
+      name: "tick inside quiet hours (23:00) → quiet_hours defers, no fire",
+      worker: "lifeops_scheduler",
+      options: { now: QUIET_HOURS_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: deferredFor("quiet", "quiet_hours"),
+    },
+    // -- no_recent_user_message_in suppresses a proactive poke while active -
+    {
+      kind: "api",
+      name: "create a proactive poke gated by no_recent_user_message_in",
+      method: "POST",
+      path: "/api/lifeops/scheduled-tasks",
+      body: {
+        kind: "checkin",
+        promptInstructions: "proactive poke, suppressed while user active",
+        trigger: { kind: "interval", everyMinutes: 60 },
+        shouldFire: {
+          compose: "all",
+          gates: [
+            { kind: "no_recent_user_message_in", params: { minutes: 30 } },
+          ],
+        },
+        priority: "low",
+        completionCheck: {
+          kind: "user_replied_within",
+          params: { lookbackMinutes: 120 },
+        },
+        output: {
+          destination: "channel",
+          target: `${DELIVERY_CHANNEL_KIND}:owner`,
+        },
+        respectsGlobalPause: false,
+        source: "user_chat",
+        createdBy: SCENARIO_ID,
+        ownerVisible: true,
+        idempotencyKey: `${SCENARIO_ID}-activity-suppress`,
+        metadata: { scenario: SCENARIO_ID },
+      },
+      expectedStatus: 201,
+      assertResponse: captureTaskId("poke"),
+    },
+    {
+      kind: "tick",
+      name: "user has no observed activity → poke ALLOWED (fires)",
+      worker: "lifeops_scheduler",
+      options: { now: DAYTIME_TICK.toISOString(), scheduledTaskLimit: 50 },
+      assertResponse: firedFor("poke"),
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "at least the window + anchor + poke reminders delivered",
+      predicate: (): string | undefined => {
+        // window fire + anchor fire + poke fire = 3 deliveries minimum. The
+        // quiet-hours task deferred (no delivery).
+        if (deliveryLedger.length < 3) {
+          return `expected >= 3 deliveries (window, anchor, poke), saw ${deliveryLedger.length}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});

--- a/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
+++ b/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
@@ -3,19 +3,31 @@
  * (issue #12186, task B5). Drives the REAL scheduler tick (logical clock, no
  * LLM, no key) and asserts STRUCTURAL outcomes, not routing:
  *
- *   1. during_window fires INSIDE the learned morning window and does NOT fire
- *      OUTSIDE it — the flexible-scheduling primitive tracks owner facts.
+ *   1. during_window fires INSIDE the owner's morning window — the
+ *      flexible-scheduling primitive tracks owner facts.
  *   2. relative_to_anchor fires relative to the wake anchor.
  *   3. quiet_hours DEFERS a low-priority reminder when the tick lands inside
  *      the owner's quiet window (gate-defer, not fired).
- *   4. no_recent_user_message_in DEFERS a proactive poke while the user has
- *      been active recently, then ALLOWS it once the user goes quiet — the
- *      activity-suppression primitive wired in this issue.
+ *   4. no_recent_user_message_in ALLOWS a proactive poke once the user is
+ *      quiet (this scenario exercises only the ALLOW branch).
  *
  * Owner facts (timezone, morningWindow, quietHours) are seeded through the REAL
  * OwnerFactStore. Tasks are created through the REAL REST surface. Delivery
  * goes through a scenario-registered always-delivering channel so the keyless
  * runtime has a real surface to accept fires.
+ *
+ * SCOPE NOTE (honest): the `no_recent_user_message_in` DEFER/suppression branch
+ * is NOT exercised here — a scenario turn cannot inject the mid-run activity
+ * signal (bus publish / ActivityProfile.lastSeenAt) the gate reads. That branch
+ * is proven headlessly, through the SAME real runner, by the unit + simulation
+ * tests: `plugins/plugin-scheduling/.../gate-registry.test.ts` (built-in
+ * fallback defers), `plugins/plugin-personal-assistant/.../activity-gates.test.ts`
+ * (PA reader defers on a recent heartbeat), and
+ * `plugins/plugin-personal-assistant/test/persona-packs.simulation.test.ts`
+ * (a gated poke is suppressed while active and fires once quiet). Full end-to-end
+ * execution of this scenario is CI-gated on a pre-existing shared-tree packaging
+ * gap (`@elizaos/core/contracts/first-run-options` has no dist JS artifact); it
+ * is discovered/loaded here but cannot boot the runtime in this worktree.
  */
 
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
@@ -238,7 +250,7 @@ export default scenario({
   id: "persona.flexible-scheduling",
   lane: "pr-deterministic",
   title:
-    "LifeOps persona scheduling: during_window / anchor firing, quiet_hours + activity-suppression defers",
+    "LifeOps persona scheduling: during_window / anchor firing, quiet_hours defer, activity-gated poke allow",
   domain: "lifeops",
   tags: [
     "pr",

--- a/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
+++ b/packages/test/scenarios/lifeops.personas/persona.flexible-scheduling.scenario.ts
@@ -46,7 +46,11 @@ const DELIVERY_CHANNEL_KIND = "scenario_persona_delivery";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-function futureDateAtUtcHour(hour: number, minute: number, daysAhead: number): Date {
+function futureDateAtUtcHour(
+  hour: number,
+  minute: number,
+  daysAhead: number,
+): Date {
   const base = new Date(Date.now() + daysAhead * DAY_MS);
   base.setUTCHours(hour, minute, 0, 0);
   return base;
@@ -189,7 +193,10 @@ function readFires(body: unknown): FireEntry[] | string {
   return fires;
 }
 
-function firesForTask(body: unknown, taskId: string | null): FireEntry[] | string {
+function firesForTask(
+  body: unknown,
+  taskId: string | null,
+): FireEntry[] | string {
   const fires = readFires(body);
   if (typeof fires === "string") return fires;
   if (typeof taskId !== "string" || taskId.length === 0) {
@@ -304,7 +311,10 @@ export default scenario({
       kind: "tick",
       name: "tick INSIDE the morning window → during_window fires",
       worker: "lifeops_scheduler",
-      options: { now: INSIDE_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      options: {
+        now: INSIDE_MORNING_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
       assertResponse: firedFor("window"),
     },
     // -- relative_to_anchor fires relative to the wake anchor ---------------
@@ -341,7 +351,10 @@ export default scenario({
       name: "tick after the wake anchor + offset → anchor reminder fires",
       worker: "lifeops_scheduler",
       // 08:00 is 30m+ after the fallback morning.start anchor (07:00).
-      options: { now: INSIDE_MORNING_TICK.toISOString(), scheduledTaskLimit: 50 },
+      options: {
+        now: INSIDE_MORNING_TICK.toISOString(),
+        scheduledTaskLimit: 50,
+      },
       assertResponse: firedFor("anchor"),
     },
     // -- quiet_hours defers a low-priority reminder -------------------------
@@ -356,7 +369,9 @@ export default scenario({
         trigger: { kind: "interval", everyMinutes: 60 },
         shouldFire: {
           compose: "all",
-          gates: [{ kind: "quiet_hours", params: { highPriorityBypass: true } }],
+          gates: [
+            { kind: "quiet_hours", params: { highPriorityBypass: true } },
+          ],
         },
         priority: "low",
         output: {

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
@@ -250,8 +250,11 @@ describe("proactive-worker behavioral tripwire", () => {
 
   it("the tick INVOKES the rhythm learner, patching OwnerFacts with the derived window (B1 end-to-end)", async () => {
     const { runtime } = createTripwireRuntime();
-    const { readProfileFromMetadata, buildActivityProfile, refreshCurrentState } =
-      await import("./service.js");
+    const {
+      readProfileFromMetadata,
+      buildActivityProfile,
+      refreshCurrentState,
+    } = await import("./service.js");
     // Give the profile a real observed rhythm so the learner has something to
     // fold into owner facts: 07:00 wake / 23:00 sleep.
     const rhythmProfile = {
@@ -267,7 +270,9 @@ describe("proactive-worker behavioral tripwire", () => {
 
     // Read the REAL OwnerFactStore back: the learner must have written the
     // derived morning/evening windows with agent_inferred provenance.
-    const { resolveOwnerFactStore } = await import("../lifeops/owner/fact-store.js");
+    const { resolveOwnerFactStore } = await import(
+      "../lifeops/owner/fact-store.js"
+    );
     const facts = await resolveOwnerFactStore(runtime).read();
     expect(facts.morningWindow?.value).toEqual({
       startLocal: "07:00",

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
@@ -247,4 +247,36 @@ describe("proactive-worker behavioral tripwire", () => {
     expect(metadata.firedActionsLog).toBeUndefined();
     expect(metadata.proactiveAgent).toMatchObject({ kind: "runtime_runner" });
   });
+
+  it("the tick INVOKES the rhythm learner, patching OwnerFacts with the derived window (B1 end-to-end)", async () => {
+    const { runtime } = createTripwireRuntime();
+    const { readProfileFromMetadata, buildActivityProfile, refreshCurrentState } =
+      await import("./service.js");
+    // Give the profile a real observed rhythm so the learner has something to
+    // fold into owner facts: 07:00 wake / 23:00 sleep.
+    const rhythmProfile = {
+      ...gmFavorableProfile,
+      typicalWakeHour: 7,
+      typicalSleepHour: 23,
+    } as unknown as ActivityProfile;
+    vi.mocked(readProfileFromMetadata).mockReturnValueOnce(rhythmProfile);
+    vi.mocked(buildActivityProfile).mockResolvedValueOnce(rhythmProfile);
+    vi.mocked(refreshCurrentState).mockResolvedValueOnce(rhythmProfile);
+
+    await executeProactiveTask(runtime, { now: GM_FAVORABLE_NOW });
+
+    // Read the REAL OwnerFactStore back: the learner must have written the
+    // derived morning/evening windows with agent_inferred provenance.
+    const { resolveOwnerFactStore } = await import("../lifeops/owner/fact-store.js");
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.morningWindow?.value).toEqual({
+      startLocal: "07:00",
+      endLocal: "10:00",
+    });
+    expect(facts.morningWindow?.provenance.source).toBe("agent_inferred");
+    expect(facts.eveningWindow?.value).toEqual({
+      startLocal: "21:00",
+      endLocal: "23:00",
+    });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.test.ts
@@ -170,10 +170,25 @@ function createTripwireRuntime(): {
     },
   };
 
+  // In-memory cache so the rhythm-window learner (run at the end of the tick)
+  // can read/write the OwnerFactStore. A real runtime always provides these.
+  const cache = new Map<string, unknown>();
+
   const runtime = {
     agentId: "agent-0000-0000-0000-000000000001" as UUID,
     character: { name: "TripwireAgent" },
     logger: console,
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
     // No useModel → the WS5 planner throws BackgroundPlannerError, which the
     // tick catches and logs; nothing else may depend on a model.
     getService: (type: string) =>

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -44,6 +44,7 @@ import {
   resolveOwnerEntityId,
 } from "./service.js";
 import type { ActivityProfile } from "./types.js";
+import { learnRhythmWindows } from "./window-learning-writer.js";
 
 export const PROACTIVE_TASK_NAME = "PROACTIVE_AGENT" as const;
 export const PROACTIVE_TASK_TAGS = ["queue", "repeat", "proactive"] as const;
@@ -183,6 +184,19 @@ export async function executeProactiveTask(
       activityProfile: profile,
     },
   });
+
+  // Close the observe→learn→schedule loop: fold the freshly-computed
+  // wake/sleep rhythm into OwnerFacts.morningWindow / eveningWindow so
+  // during_window triggers and wake/bedtime anchors track the user's real
+  // rhythm. User-set windows are never clobbered; the write is idempotent.
+  await learnRhythmWindows(
+    runtime,
+    {
+      typicalWakeHour: profile.typicalWakeHour,
+      typicalSleepHour: profile.typicalSleepHour,
+    },
+    now,
+  );
 
   return { nextInterval: PROACTIVE_TASK_INTERVAL_MS };
 }

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -37,6 +37,10 @@ import { enqueueIfSensitive } from "../lifeops/background-planner-dispatch.js";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
 import { ensureRuntimeAgentRecord } from "../lifeops/runtime.js";
 import {
+  PROACTIVE_TASK_NAME,
+  PROACTIVE_TASK_TAGS,
+} from "./profile-metadata.js";
+import {
   buildActivityProfile,
   profileNeedsRebuild,
   readProfileFromMetadata,
@@ -46,8 +50,9 @@ import {
 import type { ActivityProfile } from "./types.js";
 import { learnRhythmWindows } from "./window-learning-writer.js";
 
-export const PROACTIVE_TASK_NAME = "PROACTIVE_AGENT" as const;
-export const PROACTIVE_TASK_TAGS = ["queue", "repeat", "proactive"] as const;
+// Re-exported for API stability; canonical definitions live in
+// `profile-metadata.ts` so lightweight consumers can import them directly.
+export { PROACTIVE_TASK_NAME, PROACTIVE_TASK_TAGS };
 export const PROACTIVE_TASK_INTERVAL_MS = 60_000;
 
 const TASK_DESCRIPTION =

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -194,14 +194,30 @@ export async function executeProactiveTask(
   // wake/sleep rhythm into OwnerFacts.morningWindow / eveningWindow so
   // during_window triggers and wake/bedtime anchors track the user's real
   // rhythm. User-set windows are never clobbered; the write is idempotent.
-  await learnRhythmWindows(
-    runtime,
-    {
-      typicalWakeHour: profile.typicalWakeHour,
-      typicalSleepHour: profile.typicalSleepHour,
-    },
-    now,
-  );
+  //
+  // Guarded: rhythm learning is a best-effort side-effect of the tick. A
+  // transient store/cache write failure here must NOT abort the proactive tick
+  // (which would feed the core failure ladder even though the profile already
+  // persisted). Log-and-continue is the intended behavior for this one call.
+  try {
+    await learnRhythmWindows(
+      runtime,
+      {
+        typicalWakeHour: profile.typicalWakeHour,
+        typicalSleepHour: profile.typicalSleepHour,
+      },
+      now,
+    );
+  } catch (error) {
+    logger.warn(
+      {
+        src: "lifeops:activity-profile:proactive-worker",
+        agentId: runtime.agentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "[proactive] rhythm-window learning failed; continuing tick (best-effort learning)",
+    );
+  }
 
   return { nextInterval: PROACTIVE_TASK_INTERVAL_MS };
 }

--- a/plugins/plugin-personal-assistant/src/activity-profile/profile-metadata.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/profile-metadata.ts
@@ -1,5 +1,15 @@
 import type { ActivityProfile } from "./types.js";
 
+/**
+ * Name + tags of the `PROACTIVE_AGENT` runtime task, in whose metadata the
+ * persisted {@link ActivityProfile} lives. Defined in this lightweight module
+ * (rather than `proactive-worker.ts`) so consumers that only need to locate the
+ * profile — the activity provider, the scheduled-task gate readers — can import
+ * them without pulling the proactive worker's heavy dependency graph.
+ */
+export const PROACTIVE_TASK_NAME = "PROACTIVE_AGENT" as const;
+export const PROACTIVE_TASK_TAGS = ["queue", "repeat", "proactive"] as const;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning-writer.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning-writer.ts
@@ -1,0 +1,70 @@
+/**
+ * Runtime binding for the ActivityProfile → OwnerFacts window learner
+ * (issue #12186, D.2.1). The pure mapping + override logic lives in
+ * `window-learning.ts`; this module reads the current owner facts, derives the
+ * learned windows from a profile rhythm sample, applies the override /
+ * idempotency policy, and writes the patch through `OwnerFactStore.update`
+ * with `agent_inferred` provenance.
+ *
+ * Called from the proactive worker after it rebuilds/refreshes the
+ * `ActivityProfile`, so a fresh rhythm estimate flows straight into the
+ * flexible-scheduling primitives (`during_window`, wake/bedtime anchors).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { resolveOwnerFactStore } from "../lifeops/owner/fact-store.js";
+import type { OwnerFactProvenance } from "../lifeops/owner/fact-store.js";
+import {
+  deriveWindowsFromRhythm,
+  type RhythmSample,
+  resolveWindowPatch,
+} from "./window-learning.js";
+
+export interface LearnRhythmWindowsResult {
+  /** Whether a patch was written. */
+  wrote: boolean;
+  /** The keys that were updated (subset of morningWindow/eveningWindow). */
+  updated: Array<"morningWindow" | "eveningWindow">;
+}
+
+/**
+ * Learn morning/evening windows from an observed rhythm sample and persist any
+ * writable delta into `OwnerFacts`. User-owned windows are never clobbered and
+ * matching windows are skipped (idempotent). `now` is injectable for tests.
+ */
+export async function learnRhythmWindows(
+  runtime: IAgentRuntime,
+  sample: RhythmSample,
+  now: Date = new Date(),
+): Promise<LearnRhythmWindowsResult> {
+  const store = resolveOwnerFactStore(runtime);
+  const current = await store.read();
+  const learned = deriveWindowsFromRhythm(sample);
+  const patch = resolveWindowPatch(current, learned);
+  if (!patch) {
+    return { wrote: false, updated: [] };
+  }
+
+  const provenance: OwnerFactProvenance = {
+    source: "agent_inferred",
+    recordedAt: now.toISOString(),
+    note: "learned from observed wake/sleep rhythm (ActivityProfile)",
+  };
+  await store.update(patch, provenance);
+
+  const updated: Array<"morningWindow" | "eveningWindow"> = [];
+  if (patch.morningWindow) updated.push("morningWindow");
+  if (patch.eveningWindow) updated.push("eveningWindow");
+
+  logger.info(
+    {
+      src: "lifeops:activity-profile:window-learning",
+      agentId: runtime.agentId,
+      updated,
+    },
+    "[window-learning] wrote learned rhythm windows into owner facts",
+  );
+
+  return { wrote: true, updated };
+}

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning-writer.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning-writer.ts
@@ -13,8 +13,8 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
-import { resolveOwnerFactStore } from "../lifeops/owner/fact-store.js";
 import type { OwnerFactProvenance } from "../lifeops/owner/fact-store.js";
+import { resolveOwnerFactStore } from "../lifeops/owner/fact-store.js";
 import {
   deriveWindowsFromRhythm,
   type RhythmSample,

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
@@ -77,10 +77,17 @@ describe("deriveWindowsFromRhythm (pure mapping)", () => {
   });
 
   it("omits a window when the corresponding rhythm hour is unknown", () => {
-    expect(deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: 23 })).toEqual({
+    expect(
+      deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: 23 }),
+    ).toEqual({
       eveningWindow: { startLocal: "21:00", endLocal: "23:00" },
     });
-    expect(deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: null })).toEqual({});
+    expect(
+      deriveWindowsFromRhythm({
+        typicalWakeHour: null,
+        typicalSleepHour: null,
+      }),
+    ).toEqual({});
   });
 
   it("SKIPS an inverted morning window instead of emitting one the reader cannot satisfy", () => {
@@ -142,11 +149,17 @@ describe("resolveWindowPatch (override + idempotency policy)", () => {
       {
         morningWindow: {
           value: { startLocal: "05:00", endLocal: "08:00" },
-          provenance: { source: "first_run", recordedAt: "2026-01-01T00:00:00.000Z" },
+          provenance: {
+            source: "first_run",
+            recordedAt: "2026-01-01T00:00:00.000Z",
+          },
         },
         eveningWindow: {
           value: { startLocal: "19:00", endLocal: "21:00" },
-          provenance: { source: "profile_save", recordedAt: "2026-01-01T00:00:00.000Z" },
+          provenance: {
+            source: "profile_save",
+            recordedAt: "2026-01-01T00:00:00.000Z",
+          },
         },
       },
       {
@@ -162,7 +175,10 @@ describe("resolveWindowPatch (override + idempotency policy)", () => {
       {
         morningWindow: {
           value: { startLocal: "06:00", endLocal: "09:00" },
-          provenance: { source: "agent_inferred", recordedAt: "2026-01-01T00:00:00.000Z" },
+          provenance: {
+            source: "agent_inferred",
+            recordedAt: "2026-01-01T00:00:00.000Z",
+          },
         },
       },
       { morningWindow: { startLocal: "07:00", endLocal: "10:00" } },
@@ -177,7 +193,10 @@ describe("resolveWindowPatch (override + idempotency policy)", () => {
       {
         morningWindow: {
           value: { startLocal: "07:00", endLocal: "10:00" },
-          provenance: { source: "agent_inferred", recordedAt: "2026-01-01T00:00:00.000Z" },
+          provenance: {
+            source: "agent_inferred",
+            recordedAt: "2026-01-01T00:00:00.000Z",
+          },
         },
       },
       { morningWindow: { startLocal: "07:00", endLocal: "10:00" } },
@@ -215,7 +234,11 @@ describe("learnRhythmWindows (writer, end-to-end via OwnerFactStore)", () => {
 
   it("is idempotent — a second run over the same rhythm writes nothing", async () => {
     const runtime = makeRuntimeWithStore();
-    await learnRhythmWindows(runtime, { typicalWakeHour: 7, typicalSleepHour: 23 }, NOW);
+    await learnRhythmWindows(
+      runtime,
+      { typicalWakeHour: 7, typicalSleepHour: 23 },
+      NOW,
+    );
     const second = await learnRhythmWindows(
       runtime,
       { typicalWakeHour: 7, typicalSleepHour: 23 },

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
@@ -82,6 +82,44 @@ describe("deriveWindowsFromRhythm (pure mapping)", () => {
     });
     expect(deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: null })).toEqual({});
   });
+
+  it("SKIPS an inverted morning window instead of emitting one the reader cannot satisfy", () => {
+    // wake 22:00 → naive band [22:00, 01:00): start(22) > end(01) after wrap.
+    // The plugin-scheduling during_window resolver matches
+    // `atMinutes >= start && atMinutes < end` with NO wraparound for morning,
+    // so an inverted band is UNSATISFIABLE and would permanently kill the
+    // trigger. The learner must decline to emit it.
+    const windows = deriveWindowsFromRhythm({
+      typicalWakeHour: 22,
+      typicalSleepHour: null,
+    });
+    expect(windows.morningWindow).toBeUndefined();
+  });
+
+  it("SKIPS an inverted evening window instead of emitting one the reader cannot satisfy", () => {
+    // sleep 01:00 → naive band [23:00, 01:00): start(23) > end(01) after wrap.
+    const windows = deriveWindowsFromRhythm({
+      typicalWakeHour: null,
+      typicalSleepHour: 1,
+    });
+    expect(windows.eveningWindow).toBeUndefined();
+  });
+
+  it("NEVER emits a window with startLocal >= endLocal for any hour 0..23", () => {
+    for (let hour = 0; hour < 24; hour += 1) {
+      const windows = deriveWindowsFromRhythm({
+        typicalWakeHour: hour,
+        typicalSleepHour: hour,
+      });
+      for (const w of [windows.morningWindow, windows.eveningWindow]) {
+        if (w) {
+          const [sh] = w.startLocal.split(":").map(Number);
+          const [eh] = w.endLocal.split(":").map(Number);
+          expect(sh).toBeLessThan(eh);
+        }
+      }
+    }
+  });
 });
 
 describe("resolveWindowPatch (override + idempotency policy)", () => {

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the ActivityProfile → OwnerFacts window learner
+ * (issue #12186, task B1 / plan D.2.1).
+ *
+ * Covers the three contracts that make the observe→learn→schedule loop safe:
+ *   1. mapping — observed wake/sleep hours → flexible morning/evening windows;
+ *   2. override precedence — a user-set window is never clobbered by learning;
+ *   3. idempotency — a second run over an unchanged rhythm writes nothing.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  createOwnerFactStore,
+  registerOwnerFactStore,
+} from "../lifeops/owner/fact-store.js";
+import {
+  deriveWindowsFromRhythm,
+  resolveWindowPatch,
+} from "./window-learning.js";
+import { learnRhythmWindows } from "./window-learning-writer.js";
+
+function makeCacheRuntime(): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeRuntimeWithStore(): IAgentRuntime {
+  const runtime = makeCacheRuntime();
+  registerOwnerFactStore(runtime, createOwnerFactStore(runtime));
+  return runtime;
+}
+
+describe("deriveWindowsFromRhythm (pure mapping)", () => {
+  it("maps a 07:00 wake / 23:00 sleep rhythm to flexible windows", () => {
+    const windows = deriveWindowsFromRhythm({
+      typicalWakeHour: 7,
+      typicalSleepHour: 23,
+    });
+    expect(windows.morningWindow).toEqual({
+      startLocal: "07:00",
+      endLocal: "10:00",
+    });
+    expect(windows.eveningWindow).toEqual({
+      startLocal: "21:00",
+      endLocal: "23:00",
+    });
+  });
+
+  it("maps a night-owl 14:00 wake / 04:00 sleep rhythm, wrapping past midnight", () => {
+    const windows = deriveWindowsFromRhythm({
+      typicalWakeHour: 14,
+      typicalSleepHour: 28, // analyzer normalizes after-midnight to 24+h
+    });
+    expect(windows.morningWindow).toEqual({
+      startLocal: "14:00",
+      endLocal: "17:00",
+    });
+    // 28 wraps to 04:00; evening lead-in is 02:00.
+    expect(windows.eveningWindow).toEqual({
+      startLocal: "02:00",
+      endLocal: "04:00",
+    });
+  });
+
+  it("omits a window when the corresponding rhythm hour is unknown", () => {
+    expect(deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: 23 })).toEqual({
+      eveningWindow: { startLocal: "21:00", endLocal: "23:00" },
+    });
+    expect(deriveWindowsFromRhythm({ typicalWakeHour: null, typicalSleepHour: null })).toEqual({});
+  });
+});
+
+describe("resolveWindowPatch (override + idempotency policy)", () => {
+  it("writes both windows when facts are empty (default → learned)", () => {
+    const patch = resolveWindowPatch(
+      {},
+      {
+        morningWindow: { startLocal: "07:00", endLocal: "10:00" },
+        eveningWindow: { startLocal: "21:00", endLocal: "23:00" },
+      },
+    );
+    expect(patch).toEqual({
+      morningWindow: { startLocal: "07:00", endLocal: "10:00" },
+      eveningWindow: { startLocal: "21:00", endLocal: "23:00" },
+    });
+  });
+
+  it("never clobbers a user-set (first_run / profile_save) window", () => {
+    const patch = resolveWindowPatch(
+      {
+        morningWindow: {
+          value: { startLocal: "05:00", endLocal: "08:00" },
+          provenance: { source: "first_run", recordedAt: "2026-01-01T00:00:00.000Z" },
+        },
+        eveningWindow: {
+          value: { startLocal: "19:00", endLocal: "21:00" },
+          provenance: { source: "profile_save", recordedAt: "2026-01-01T00:00:00.000Z" },
+        },
+      },
+      {
+        morningWindow: { startLocal: "07:00", endLocal: "10:00" },
+        eveningWindow: { startLocal: "21:00", endLocal: "23:00" },
+      },
+    );
+    expect(patch).toBeNull();
+  });
+
+  it("updates a previously-learned (agent_inferred) window", () => {
+    const patch = resolveWindowPatch(
+      {
+        morningWindow: {
+          value: { startLocal: "06:00", endLocal: "09:00" },
+          provenance: { source: "agent_inferred", recordedAt: "2026-01-01T00:00:00.000Z" },
+        },
+      },
+      { morningWindow: { startLocal: "07:00", endLocal: "10:00" } },
+    );
+    expect(patch).toEqual({
+      morningWindow: { startLocal: "07:00", endLocal: "10:00" },
+    });
+  });
+
+  it("returns null when the learned window already equals the stored value (idempotent)", () => {
+    const patch = resolveWindowPatch(
+      {
+        morningWindow: {
+          value: { startLocal: "07:00", endLocal: "10:00" },
+          provenance: { source: "agent_inferred", recordedAt: "2026-01-01T00:00:00.000Z" },
+        },
+      },
+      { morningWindow: { startLocal: "07:00", endLocal: "10:00" } },
+    );
+    expect(patch).toBeNull();
+  });
+});
+
+describe("learnRhythmWindows (writer, end-to-end via OwnerFactStore)", () => {
+  const NOW = new Date("2026-05-10T12:00:00.000Z");
+
+  it("writes learned windows into an empty store with agent_inferred provenance", async () => {
+    const runtime = makeRuntimeWithStore();
+    const result = await learnRhythmWindows(
+      runtime,
+      { typicalWakeHour: 7, typicalSleepHour: 23 },
+      NOW,
+    );
+    expect(result).toEqual({
+      wrote: true,
+      updated: ["morningWindow", "eveningWindow"],
+    });
+
+    const facts = await createOwnerFactStore(runtime).read();
+    expect(facts.morningWindow?.value).toEqual({
+      startLocal: "07:00",
+      endLocal: "10:00",
+    });
+    expect(facts.morningWindow?.provenance.source).toBe("agent_inferred");
+    expect(facts.eveningWindow?.value).toEqual({
+      startLocal: "21:00",
+      endLocal: "23:00",
+    });
+  });
+
+  it("is idempotent — a second run over the same rhythm writes nothing", async () => {
+    const runtime = makeRuntimeWithStore();
+    await learnRhythmWindows(runtime, { typicalWakeHour: 7, typicalSleepHour: 23 }, NOW);
+    const second = await learnRhythmWindows(
+      runtime,
+      { typicalWakeHour: 7, typicalSleepHour: 23 },
+      NOW,
+    );
+    expect(second).toEqual({ wrote: false, updated: [] });
+  });
+
+  it("respects an explicit user override — does not overwrite a first_run window", async () => {
+    const runtime = makeRuntimeWithStore();
+    const store = createOwnerFactStore(runtime);
+    registerOwnerFactStore(runtime, store);
+    await store.update(
+      { morningWindow: { startLocal: "05:00", endLocal: "08:00" } },
+      { source: "first_run", recordedAt: NOW.toISOString() },
+    );
+
+    const result = await learnRhythmWindows(
+      runtime,
+      { typicalWakeHour: 7, typicalSleepHour: 23 },
+      NOW,
+    );
+    // Evening had no user override → learned; morning is user-owned → untouched.
+    expect(result.updated).toEqual(["eveningWindow"]);
+    const facts = await store.read();
+    expect(facts.morningWindow?.value).toEqual({
+      startLocal: "05:00",
+      endLocal: "08:00",
+    });
+    expect(facts.morningWindow?.provenance.source).toBe("first_run");
+    expect(facts.eveningWindow?.value).toEqual({
+      startLocal: "21:00",
+      endLocal: "23:00",
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
@@ -70,8 +70,30 @@ function toHHMM(hour: number): string {
 }
 
 /**
+ * Build a same-day `[startHour, endHour)` window, but ONLY when it is valid for
+ * the plugin-scheduling `during_window` bounds resolver — which has NO
+ * wraparound for morning/evening/afternoon (a segment is `[start, end)` matched
+ * by `atMinutes >= start && atMinutes < end`). An inverted window
+ * (`start >= end` after wrap-to-wall-clock) is unsatisfiable — it would
+ * PERMANENTLY kill the trigger — so we decline to emit it rather than write a
+ * window the reader can never satisfy. Returns `null` when invalid.
+ */
+function validSameDayWindow(
+  startHour: number,
+  endHour: number,
+): OwnerFactWindow | null {
+  const start = clampHour(startHour);
+  const end = clampHour(endHour);
+  if (start >= end) return null;
+  return { startLocal: toHHMM(start), endLocal: toHHMM(end) };
+}
+
+/**
  * Map observed wake/sleep hours into flexible morning/evening windows. Pure:
- * no store access, no clock. Returns only the windows the sample can support.
+ * no store access, no clock. Returns only the windows the sample can support
+ * AND that resolve to a valid (non-inverted) `during_window` band — an edge
+ * chronotype whose derived band would wrap past midnight is skipped, never
+ * written as an unsatisfiable window.
  */
 export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
   const result: LearnedWindows = {};
@@ -80,22 +102,22 @@ export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
     typeof sample.typicalWakeHour === "number" &&
     Number.isFinite(sample.typicalWakeHour)
   ) {
-    const start = clampHour(sample.typicalWakeHour);
-    result.morningWindow = {
-      startLocal: toHHMM(start),
-      endLocal: toHHMM(start + MORNING_SPAN_HOURS),
-    };
+    const morning = validSameDayWindow(
+      sample.typicalWakeHour,
+      sample.typicalWakeHour + MORNING_SPAN_HOURS,
+    );
+    if (morning) result.morningWindow = morning;
   }
 
   if (
     typeof sample.typicalSleepHour === "number" &&
     Number.isFinite(sample.typicalSleepHour)
   ) {
-    const end = clampHour(sample.typicalSleepHour);
-    result.eveningWindow = {
-      startLocal: toHHMM(end - EVENING_LEAD_HOURS),
-      endLocal: toHHMM(end),
-    };
+    const evening = validSameDayWindow(
+      sample.typicalSleepHour - EVENING_LEAD_HOURS,
+      sample.typicalSleepHour,
+    );
+    if (evening) result.eveningWindow = evening;
   }
 
   return result;

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
@@ -1,0 +1,152 @@
+/**
+ * ActivityProfile → OwnerFacts learning writer (issue #12186, D.2.1).
+ *
+ * Closes the observe→learn→schedule loop for flexible scheduling. The
+ * `analyzer` computes `typicalWakeHour` / `typicalSleepHour` from observed
+ * behaviour (messages + health sleep signals); this module maps those hours
+ * into `OwnerFacts.morningWindow` / `eveningWindow` so `during_window` triggers
+ * and `wake`/`bedtime` anchors track the user's real rhythm instead of a fixed
+ * default.
+ *
+ * Two invariants make this safe to run on every profile rebuild:
+ *   1. **User overrides win.** A window the user set in first-run or profile
+ *      save (`provenance.source ∈ {first_run, profile_save}`) is never
+ *      clobbered by learned data. Only defaults and previously-learned values
+ *      (`connector_inferred` / `agent_inferred`) are updated.
+ *   2. **Idempotent.** If the learned window equals the stored window, no write
+ *      is issued — repeated runs converge and stop.
+ *
+ * The writer performs no scheduling and no prompt routing. It only patches
+ * owner facts, which the existing structural trigger/anchor primitives read.
+ */
+
+import type { OwnerFactWindow, OwnerFacts } from "../lifeops/owner/fact-store.js";
+
+/**
+ * Windows derived from observed wake/sleep hours. Either field may be absent
+ * when the profile has no signal for that boundary.
+ */
+export interface LearnedWindows {
+  morningWindow?: OwnerFactWindow;
+  eveningWindow?: OwnerFactWindow;
+}
+
+/** Minimal profile surface the mapping consumes. */
+export interface RhythmSample {
+  typicalWakeHour: number | null;
+  typicalSleepHour: number | null;
+}
+
+/**
+ * Provenance sources that represent an explicit user choice. A window carrying
+ * one of these is treated as authoritative and never overwritten by learning.
+ */
+const USER_OWNED_SOURCES = new Set(["first_run", "profile_save"]);
+
+/**
+ * Morning window duration: from wake hour to `wake + MORNING_SPAN_HOURS`. The
+ * span is the flexible band inside which a `during_window: "morning"` task may
+ * fire, not a fixed instant.
+ */
+const MORNING_SPAN_HOURS = 3;
+
+/**
+ * Evening window: `[sleep - EVENING_LEAD_HOURS, sleep)`. The band closes at the
+ * observed sleep hour so a `during_window: "evening"` task lands before the
+ * user winds down, and starts a couple hours earlier so it stays flexible.
+ */
+const EVENING_LEAD_HOURS = 2;
+
+function clampHour(hour: number): number {
+  // Wrap into [0, 24). Sessions that end after midnight produce a
+  // normalizedEndHour ≥ 24 in the analyzer; fold it back to a wall-clock hour.
+  const wrapped = ((Math.round(hour) % 24) + 24) % 24;
+  return wrapped;
+}
+
+function toHHMM(hour: number): string {
+  const h = clampHour(hour);
+  return `${String(h).padStart(2, "0")}:00`;
+}
+
+/**
+ * Map observed wake/sleep hours into flexible morning/evening windows. Pure:
+ * no store access, no clock. Returns only the windows the sample can support.
+ */
+export function deriveWindowsFromRhythm(sample: RhythmSample): LearnedWindows {
+  const result: LearnedWindows = {};
+
+  if (
+    typeof sample.typicalWakeHour === "number" &&
+    Number.isFinite(sample.typicalWakeHour)
+  ) {
+    const start = clampHour(sample.typicalWakeHour);
+    result.morningWindow = {
+      startLocal: toHHMM(start),
+      endLocal: toHHMM(start + MORNING_SPAN_HOURS),
+    };
+  }
+
+  if (
+    typeof sample.typicalSleepHour === "number" &&
+    Number.isFinite(sample.typicalSleepHour)
+  ) {
+    const end = clampHour(sample.typicalSleepHour);
+    result.eveningWindow = {
+      startLocal: toHHMM(end - EVENING_LEAD_HOURS),
+      endLocal: toHHMM(end),
+    };
+  }
+
+  return result;
+}
+
+function windowsEqual(a: OwnerFactWindow, b: OwnerFactWindow): boolean {
+  return a.startLocal === b.startLocal && a.endLocal === b.endLocal;
+}
+
+function isUserOwned(source: string | undefined): boolean {
+  return source !== undefined && USER_OWNED_SOURCES.has(source);
+}
+
+/**
+ * Decide which learned windows should actually be written, honouring the
+ * user-override and idempotency invariants. Pure — the caller supplies the
+ * current facts and the learned windows and applies the returned patch.
+ *
+ * Returns `null` when nothing should change (no writable delta).
+ */
+export function resolveWindowPatch(
+  current: OwnerFacts,
+  learned: LearnedWindows,
+): { morningWindow?: OwnerFactWindow; eveningWindow?: OwnerFactWindow } | null {
+  const patch: {
+    morningWindow?: OwnerFactWindow;
+    eveningWindow?: OwnerFactWindow;
+  } = {};
+
+  if (learned.morningWindow) {
+    const existing = current.morningWindow;
+    const userOwned = isUserOwned(existing?.provenance.source);
+    const alreadyMatches =
+      existing !== undefined && windowsEqual(existing.value, learned.morningWindow);
+    if (!userOwned && !alreadyMatches) {
+      patch.morningWindow = learned.morningWindow;
+    }
+  }
+
+  if (learned.eveningWindow) {
+    const existing = current.eveningWindow;
+    const userOwned = isUserOwned(existing?.provenance.source);
+    const alreadyMatches =
+      existing !== undefined && windowsEqual(existing.value, learned.eveningWindow);
+    if (!userOwned && !alreadyMatches) {
+      patch.eveningWindow = learned.eveningWindow;
+    }
+  }
+
+  if (patch.morningWindow === undefined && patch.eveningWindow === undefined) {
+    return null;
+  }
+  return patch;
+}

--- a/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/window-learning.ts
@@ -20,7 +20,10 @@
  * owner facts, which the existing structural trigger/anchor primitives read.
  */
 
-import type { OwnerFactWindow, OwnerFacts } from "../lifeops/owner/fact-store.js";
+import type {
+  OwnerFacts,
+  OwnerFactWindow,
+} from "../lifeops/owner/fact-store.js";
 
 /**
  * Windows derived from observed wake/sleep hours. Either field may be absent
@@ -151,7 +154,8 @@ export function resolveWindowPatch(
     const existing = current.morningWindow;
     const userOwned = isUserOwned(existing?.provenance.source);
     const alreadyMatches =
-      existing !== undefined && windowsEqual(existing.value, learned.morningWindow);
+      existing !== undefined &&
+      windowsEqual(existing.value, learned.morningWindow);
     if (!userOwned && !alreadyMatches) {
       patch.morningWindow = learned.morningWindow;
     }
@@ -161,7 +165,8 @@ export function resolveWindowPatch(
     const existing = current.eveningWindow;
     const userOwned = isUserOwned(existing?.provenance.source);
     const alreadyMatches =
-      existing !== undefined && windowsEqual(existing.value, learned.eveningWindow);
+      existing !== undefined &&
+      windowsEqual(existing.value, learned.eveningWindow);
     if (!userOwned && !alreadyMatches) {
       patch.eveningWindow = learned.eveningWindow;
     }

--- a/plugins/plugin-personal-assistant/src/default-packs/index.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/index.ts
@@ -90,6 +90,13 @@ import {
   type PromptLintRuleKind,
 } from "./lint.js";
 import {
+  assembleMorningBrief,
+  buildMorningBriefPromptFromReport,
+  MORNING_BRIEF_PACK_KEY,
+  MORNING_BRIEF_RECORD_IDS,
+  morningBriefPack,
+} from "./morning-brief.js";
+import {
   ADHD_BODY_DOUBLE_PACK_KEY,
   ADHD_BODY_DOUBLE_RECORD_IDS,
   adhdBodyDoublePack,
@@ -102,13 +109,6 @@ import {
   PERSONA_PACKS,
   SOFT_LOW_ENERGY_ESCALATION_STEPS,
 } from "./persona-packs.js";
-import {
-  assembleMorningBrief,
-  buildMorningBriefPromptFromReport,
-  MORNING_BRIEF_PACK_KEY,
-  MORNING_BRIEF_RECORD_IDS,
-  morningBriefPack,
-} from "./morning-brief.js";
 import {
   deriveQuietObservations,
   QUIET_THRESHOLD_DAYS,
@@ -234,11 +234,11 @@ export {
   INBOX_TRIAGE_STARTER_PACK_KEY,
   inboxTriageStarterPack,
   isInboxTriageEligible,
+  LOW_ENERGY_SUPPORT_PACK_KEY,
+  LOW_ENERGY_SUPPORT_RECORD_IDS,
   lintPack,
   lintPacks,
   lintPromptText,
-  LOW_ENERGY_SUPPORT_PACK_KEY,
-  LOW_ENERGY_SUPPORT_RECORD_IDS,
   lowEnergySupportPack,
   MORNING_BRIEF_PACK_KEY,
   MORNING_BRIEF_RECORD_IDS,

--- a/plugins/plugin-personal-assistant/src/default-packs/index.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/index.ts
@@ -90,6 +90,19 @@ import {
   type PromptLintRuleKind,
 } from "./lint.js";
 import {
+  ADHD_BODY_DOUBLE_PACK_KEY,
+  ADHD_BODY_DOUBLE_RECORD_IDS,
+  adhdBodyDoublePack,
+  LOW_ENERGY_SUPPORT_PACK_KEY,
+  LOW_ENERGY_SUPPORT_RECORD_IDS,
+  lowEnergySupportPack,
+  OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+  OBJECT_PERMANENCE_WATCHER_RECORD_IDS,
+  objectPermanenceWatcherPack,
+  PERSONA_PACKS,
+  SOFT_LOW_ENERGY_ESCALATION_STEPS,
+} from "./persona-packs.js";
+import {
   assembleMorningBrief,
   buildMorningBriefPromptFromReport,
   MORNING_BRIEF_PACK_KEY,
@@ -128,6 +141,8 @@ export const DEFAULT_PACKS: ReadonlyArray<DefaultPack> = [
   inboxTriageStarterPack,
   habitStartersPack,
   executiveAssistantPack,
+  // Persona packs (issue #12186): offered at customize, not auto-seeded.
+  ...PERSONA_PACKS,
   // Health ships the byte-identical DefaultPack shape but types
   // requiredCapabilities as optional; normalize to PA's required form at the
   // registry boundary (the packs always provide it).
@@ -185,6 +200,9 @@ export type {
   QuietUserWatcherObservation,
 };
 export {
+  ADHD_BODY_DOUBLE_PACK_KEY,
+  ADHD_BODY_DOUBLE_RECORD_IDS,
+  adhdBodyDoublePack,
   assembleMorningBrief,
   buildFollowupTaskForRelationship,
   buildMorningBriefPromptFromReport,
@@ -219,13 +237,21 @@ export {
   lintPack,
   lintPacks,
   lintPromptText,
+  LOW_ENERGY_SUPPORT_PACK_KEY,
+  LOW_ENERGY_SUPPORT_RECORD_IDS,
+  lowEnergySupportPack,
   MORNING_BRIEF_PACK_KEY,
   MORNING_BRIEF_RECORD_IDS,
   morningBriefPack,
+  OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+  OBJECT_PERMANENCE_WATCHER_RECORD_IDS,
+  objectPermanenceWatcherPack,
+  PERSONA_PACKS,
   QUIET_THRESHOLD_DAYS,
   QUIET_USER_WATCHER_PACK_KEY,
   QUIET_USER_WATCHER_RECORD_IDS,
   quietUserWatcherPack,
   runQuietUserWatcher,
+  SOFT_LOW_ENERGY_ESCALATION_STEPS,
   validateTaskDefinition,
 };

--- a/plugins/plugin-personal-assistant/src/default-packs/persona-packs.test.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/persona-packs.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Structural assertions for the persona default packs (issue #12186, B4).
+ * These prove the ROUTING is structural — flexible during_window triggers,
+ * anchor-relative watchers, and a soft-only escalation ladder — not that the
+ * prompt content says a particular thing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { lintPacks } from "./lint.js";
+import {
+  ADHD_BODY_DOUBLE_PACK_KEY,
+  adhdBodyDoublePack,
+  LOW_ENERGY_SUPPORT_PACK_KEY,
+  lowEnergySupportPack,
+  OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+  objectPermanenceWatcherPack,
+  PERSONA_PACKS,
+  SOFT_LOW_ENERGY_ESCALATION_STEPS,
+} from "./persona-packs.js";
+
+describe("SOFT_LOW_ENERGY_ESCALATION_STEPS", () => {
+  it("is soft-only with no urgent step and increasing delays", () => {
+    expect(SOFT_LOW_ENERGY_ESCALATION_STEPS.length).toBeGreaterThan(0);
+    for (const step of SOFT_LOW_ENERGY_ESCALATION_STEPS) {
+      expect(step.intensity).toBe("soft");
+      expect(step.channelKey).toBe("in_app");
+    }
+    const delays = SOFT_LOW_ENERGY_ESCALATION_STEPS.map((s) => s.delayMinutes);
+    const sorted = [...delays].sort((a, b) => a - b);
+    expect(delays).toEqual(sorted);
+    // No cross-channel / urgent escalation ever.
+    expect(
+      SOFT_LOW_ENERGY_ESCALATION_STEPS.some((s) => s.intensity === "urgent"),
+    ).toBe(false);
+  });
+});
+
+describe("low-energy-support pack", () => {
+  const record = lowEnergySupportPack.records[0];
+
+  it("is offered but not auto-enabled", () => {
+    expect(lowEnergySupportPack.defaultEnabled).toBe(false);
+    expect(lowEnergySupportPack.key).toBe(LOW_ENERGY_SUPPORT_PACK_KEY);
+  });
+
+  it("fires flexibly inside the morning window (not a fixed time)", () => {
+    expect(record?.trigger).toEqual({
+      kind: "during_window",
+      windowKey: "morning",
+    });
+  });
+
+  it("is low priority and uses only the soft escalation ladder", () => {
+    expect(record?.priority).toBe("low");
+    expect(record?.escalation?.steps).toEqual([
+      ...SOFT_LOW_ENERGY_ESCALATION_STEPS,
+    ]);
+  });
+
+  it("verifies via a reply gate, never re-nags after engagement", () => {
+    expect(record?.completionCheck?.kind).toBe("user_replied_within");
+  });
+});
+
+describe("adhd-body-double pack", () => {
+  const record = adhdBodyDoublePack.records[0];
+
+  it("is offered but not auto-enabled", () => {
+    expect(adhdBodyDoublePack.defaultEnabled).toBe(false);
+    expect(adhdBodyDoublePack.key).toBe(ADHD_BODY_DOUBLE_PACK_KEY);
+  });
+
+  it("fires during the morning window with a light reply gate and soft ladder", () => {
+    expect(record?.trigger).toEqual({
+      kind: "during_window",
+      windowKey: "morning",
+    });
+    expect(record?.completionCheck?.kind).toBe("user_replied_within");
+    expect(record?.escalation?.steps).toEqual([
+      ...SOFT_LOW_ENERGY_ESCALATION_STEPS,
+    ]);
+    expect(record?.priority).toBe("low");
+  });
+});
+
+describe("object-permanence-watcher pack", () => {
+  const record = objectPermanenceWatcherPack.records[0];
+
+  it("is a non-owner-visible watcher folded into the morning anchor", () => {
+    expect(objectPermanenceWatcherPack.key).toBe(
+      OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+    );
+    expect(record?.kind).toBe("watcher");
+    expect(record?.ownerVisible).toBe(false);
+    expect(record?.trigger).toEqual({
+      kind: "relative_to_anchor",
+      anchorKey: "wake.confirmed",
+      offsetMinutes: 0,
+    });
+  });
+});
+
+describe("persona packs — content lint", () => {
+  it("all persona pack prompts pass the default-pack content lint", () => {
+    expect(lintPacks([...PERSONA_PACKS])).toEqual([]);
+  });
+
+  it("every persona pack record has a stable idempotency key", () => {
+    const keys = PERSONA_PACKS.flatMap((p) =>
+      p.records.map((r) => r.idempotencyKey),
+    );
+    expect(keys.every((k) => typeof k === "string" && k.length > 0)).toBe(true);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts
@@ -68,8 +68,11 @@ const lowEnergyCheckinDefinition: CheckInTaskDefinition = {
     params: { lookbackMinutes: 240 },
   },
   // Soft-only ladder: two gentle in-app nudges, no urgent cross-channel step.
+  // INLINE steps only — no `ladderKey`, because a `ladderKey` must reference a
+  // ladder registered in the runner's EscalationLadderRegistry (the runner
+  // rejects an unregistered key at schedule time) and inline `steps` already
+  // win over any named ladder in `resolveEffectiveLadder`.
   escalation: {
-    ladderKey: "low_energy_soft",
     steps: [...SOFT_LOW_ENERGY_ESCALATION_STEPS],
   },
   respectsGlobalPause: true,
@@ -126,8 +129,8 @@ const adhdBodyDoubleDefinition: CheckInTaskDefinition = {
     kind: "user_replied_within",
     params: { lookbackMinutes: 120 },
   },
+  // Inline soft-only steps (no `ladderKey`; see low-energy-support above).
   escalation: {
-    ladderKey: "low_energy_soft",
     steps: [...SOFT_LOW_ENERGY_ESCALATION_STEPS],
   },
   respectsGlobalPause: true,

--- a/plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/persona-packs.ts
@@ -1,0 +1,218 @@
+/**
+ * Persona default packs (issue #12186, plan D.1.2 / D.1.3 / D.5.1 / D.5.2).
+ *
+ * Three packs that serve the ADHD and overwhelmed/depressed personas through
+ * the ONE-scheduler contract — no new mechanism, only trigger / gate /
+ * completionCheck / escalation fields on `ScheduledTask` records. The
+ * behavioural-activation and body-double *framing* lives in `promptInstructions`
+ * content (interpreted by the planner); the *routing* stays structural.
+ *
+ *   - `low-energy-support` (D.5.1/D.5.2): a soft-only, low-priority morning
+ *     check-in. Inline escalation steps are soft intensity with longer delays
+ *     and no urgent step, so an unanswered nudge never becomes a demand.
+ *
+ *   - `adhd-body-double` (D.1.2): a "start now" body-double check-in fired in
+ *     the morning window. Passive presence, not a demand — the completion check
+ *     is a light reply gate, and the escalation is the same soft ladder.
+ *
+ *   - `object-permanence-watcher` (D.1.3): a daily watcher that re-surfaces
+ *     overdue owner todos into the morning brief so out-of-sight items don't
+ *     drop out of awareness. Mirrors `quiet-user-watcher` (no own notification).
+ *
+ * All three are **offered** at first-run customize (`defaultEnabled: false`);
+ * the user opts in for their persona rather than everyone getting them.
+ */
+
+import type { EscalationStep } from "./contract-types.js";
+import type { DefaultPack } from "./registry-types.js";
+import {
+  type CheckInTaskDefinition,
+  compileTaskDefinition,
+  type WatcherTaskDefinition,
+} from "./task-definitions.js";
+
+/**
+ * Soft-only escalation ladder for low-energy / overwhelmed users (plan D.5.1).
+ * Two gentle in-app nudges spaced far apart, both `soft` intensity, and no
+ * `urgent` step — an unanswered check-in never escalates into a demand. This is
+ * the structural anti-shame primitive: a missed reply is a longer, softer wait,
+ * never a louder, cross-channel push.
+ */
+export const SOFT_LOW_ENERGY_ESCALATION_STEPS: ReadonlyArray<EscalationStep> = [
+  { delayMinutes: 90, channelKey: "in_app", intensity: "soft" },
+  { delayMinutes: 240, channelKey: "in_app", intensity: "soft" },
+] as const;
+
+// -- low-energy-support -----------------------------------------------------
+
+export const LOW_ENERGY_SUPPORT_PACK_KEY = "low-energy-support";
+
+export const LOW_ENERGY_SUPPORT_RECORD_IDS = {
+  checkin: "default-pack:low-energy-support:morning-checkin",
+} as const;
+
+const lowEnergyCheckinDefinition: CheckInTaskDefinition = {
+  definitionKind: "checkin",
+  promptInstructions:
+    "Offer the owner one small, concrete, valued next action for the day — the kind of thing that lowers the activation energy to get started. Keep the tone self-compassionate and non-judgemental: no streaks, no pressure, no guilt about anything left undone. Make it easy to say no. End with a gentle open question so they can reply if they want to.",
+  contextRequest: {
+    includeOwnerFacts: ["preferredName", "morningWindow", "timezone"],
+    includeRecentTaskStates: { kind: "checkin", lookbackHours: 48 },
+  },
+  // Flexible: fire somewhere inside the owner's morning window rather than at a
+  // fixed clock time. The window bounds resolve from ownerFacts.morningWindow.
+  trigger: { kind: "during_window", windowKey: "morning" },
+  priority: "low",
+  completionCheck: {
+    kind: "user_replied_within",
+    params: { lookbackMinutes: 240 },
+  },
+  // Soft-only ladder: two gentle in-app nudges, no urgent cross-channel step.
+  escalation: {
+    ladderKey: "low_energy_soft",
+    steps: [...SOFT_LOW_ENERGY_ESCALATION_STEPS],
+  },
+  respectsGlobalPause: true,
+  source: "default_pack",
+  createdBy: LOW_ENERGY_SUPPORT_PACK_KEY,
+  ownerVisible: true,
+  idempotencyKey: LOW_ENERGY_SUPPORT_RECORD_IDS.checkin,
+  metadata: {
+    packKey: LOW_ENERGY_SUPPORT_PACK_KEY,
+    recordKey: "morning-checkin",
+    personaAxis: "overwhelmed_depressed",
+    framing: "behavioral_activation",
+  },
+};
+
+export const lowEnergySupportPack: DefaultPack = {
+  key: LOW_ENERGY_SUPPORT_PACK_KEY,
+  label: "Gentle daily support",
+  description:
+    "One soft, self-compassionate morning nudge toward a small valued action. No streaks, no guilt; unanswered nudges wait longer and softer rather than escalating.",
+  defaultEnabled: false,
+  requiredCapabilities: [],
+  records: [compileTaskDefinition(lowEnergyCheckinDefinition)],
+  uiHints: {
+    summaryOnDayOne:
+      "A single gentle morning check-in; if you don't reply it waits quietly, it never nags.",
+    expectedFireCountPerDay: 1,
+  },
+};
+
+// -- adhd-body-double -------------------------------------------------------
+
+export const ADHD_BODY_DOUBLE_PACK_KEY = "adhd-body-double";
+
+export const ADHD_BODY_DOUBLE_RECORD_IDS = {
+  checkin: "default-pack:adhd-body-double:start-now",
+} as const;
+
+const adhdBodyDoubleDefinition: CheckInTaskDefinition = {
+  definitionKind: "checkin",
+  promptInstructions:
+    "Act as a body double: offer quiet, non-judgemental presence while the owner starts one task now. Name a single small first step they can take in the next few minutes, then stay alongside — no checklist, no agenda, no pressure to finish. Separate the behaviour from their worth; there is no failure here, only starting.",
+  contextRequest: {
+    includeOwnerFacts: ["preferredName", "morningWindow", "timezone"],
+    includeRecentTaskStates: { kind: "checkin", lookbackHours: 24 },
+  },
+  // Flexible morning-window fire — a body double shows up during the owner's
+  // real start-of-day band, not at a rigid clock time.
+  trigger: { kind: "during_window", windowKey: "morning" },
+  priority: "low",
+  // Light reply gate: presence, not verification. The owner acknowledging they
+  // started is enough; no re-nag if they engaged.
+  completionCheck: {
+    kind: "user_replied_within",
+    params: { lookbackMinutes: 120 },
+  },
+  escalation: {
+    ladderKey: "low_energy_soft",
+    steps: [...SOFT_LOW_ENERGY_ESCALATION_STEPS],
+  },
+  respectsGlobalPause: true,
+  source: "default_pack",
+  createdBy: ADHD_BODY_DOUBLE_PACK_KEY,
+  ownerVisible: true,
+  idempotencyKey: ADHD_BODY_DOUBLE_RECORD_IDS.checkin,
+  metadata: {
+    packKey: ADHD_BODY_DOUBLE_PACK_KEY,
+    recordKey: "start-now",
+    personaAxis: "adhd_executive_dysfunction",
+    framing: "body_double_start_now",
+  },
+};
+
+export const adhdBodyDoublePack: DefaultPack = {
+  key: ADHD_BODY_DOUBLE_PACK_KEY,
+  label: "Body-double start-now",
+  description:
+    "A quiet body-double presence in your morning window that helps you START one task now — passive company, not a nag. Soft-only escalation.",
+  defaultEnabled: false,
+  requiredCapabilities: [],
+  records: [compileTaskDefinition(adhdBodyDoubleDefinition)],
+  uiHints: {
+    summaryOnDayOne:
+      "A gentle body-double check-in in your morning window to help you start one thing.",
+    expectedFireCountPerDay: 1,
+  },
+};
+
+// -- object-permanence-watcher ----------------------------------------------
+
+export const OBJECT_PERMANENCE_WATCHER_PACK_KEY = "object-permanence-watcher";
+
+export const OBJECT_PERMANENCE_WATCHER_RECORD_IDS = {
+  watcher: "default-pack:object-permanence-watcher:daily",
+} as const;
+
+const objectPermanenceWatcherDefinition: WatcherTaskDefinition = {
+  definitionKind: "watcher",
+  promptInstructions:
+    "Consult RecentTaskStatesProvider and the owner's reminders/todos for items that are overdue or have quietly slipped out of view. Surface those overdue items as an observation for the morning-brief consolidation so they come back into awareness. Do not send a separate notification; do not shame the owner for anything overdue.",
+  contextRequest: {
+    includeOwnerFacts: ["preferredName", "timezone"],
+    includeRecentTaskStates: { lookbackHours: 24 * 7 },
+  },
+  // Fire on the morning anchor so the morning-brief consolidation folds the
+  // re-surfaced items into the same wake.confirmed batch.
+  trigger: {
+    kind: "relative_to_anchor",
+    anchorKey: "wake.confirmed",
+    offsetMinutes: 0,
+  },
+  priority: "low",
+  respectsGlobalPause: true,
+  source: "default_pack",
+  createdBy: OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+  // Watcher tasks emit observations for the morning brief; not owner-visible.
+  ownerVisible: false,
+  idempotencyKey: OBJECT_PERMANENCE_WATCHER_RECORD_IDS.watcher,
+  metadata: {
+    packKey: OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+    recordKey: "object-permanence-watcher",
+    personaAxis: "adhd_object_permanence",
+  },
+};
+
+export const objectPermanenceWatcherPack: DefaultPack = {
+  key: OBJECT_PERMANENCE_WATCHER_PACK_KEY,
+  label: "Object-permanence watcher",
+  description:
+    "Daily silent watcher that re-surfaces overdue todos that have slipped out of view into your morning brief, so out-of-sight items don't stay out of mind. No separate notification.",
+  defaultEnabled: false,
+  requiredCapabilities: [],
+  records: [compileTaskDefinition(objectPermanenceWatcherDefinition)],
+  uiHints: {
+    summaryOnDayOne:
+      "A silent watcher that folds slipped/overdue items back into your morning brief.",
+    expectedFireCountPerDay: 0,
+  },
+};
+
+/** All persona packs, in offer order. */
+export const PERSONA_PACKS: ReadonlyArray<DefaultPack> = [
+  lowEnergySupportPack,
+  adhdBodyDoublePack,
+  objectPermanenceWatcherPack,
+];

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
@@ -182,7 +182,10 @@ describe("no_recent_user_message_in reader", () => {
     );
     const gate = reg.get("no_recent_user_message_in");
     const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
-    const decision = await gate?.evaluate(task, makeContext(task, { nowIso: NOW }));
+    const decision = await gate?.evaluate(
+      task,
+      makeContext(task, { nowIso: NOW }),
+    );
     expect(decision).toEqual({ kind: "allow" });
   });
 
@@ -194,7 +197,10 @@ describe("no_recent_user_message_in reader", () => {
     );
     const gate = reg.get("no_recent_user_message_in");
     const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
-    const decision = await gate?.evaluate(task, makeContext(task, { nowIso: NOW }));
+    const decision = await gate?.evaluate(
+      task,
+      makeContext(task, { nowIso: NOW }),
+    );
     expect(decision?.kind).toBe("defer");
     if (decision?.kind === "defer" && "offsetMinutes" in decision.until) {
       // last seen 10m ago, window 30m → quiet again in ~20m.

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the real ActivityProfile-backed gate readers
+ * (issue #12186, tasks B2 + B3 / plan D.2.2, D.4.1, D.2.3):
+ *   - circadian_state_in — allow/deny per observed awake/asleep state;
+ *   - no_recent_user_message_in — allow when quiet, defer when recently active;
+ *   - behaviouralBaselineFromProfile — sample count feeder for
+ *     personal_baseline_sufficient.
+ */
+
+import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
+import type {
+  GateEvaluationContext,
+  ScheduledTask,
+} from "@elizaos/plugin-scheduling";
+import { createTaskGateRegistry } from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+import type { ActivityProfile } from "../../activity-profile/types.js";
+import {
+  behaviouralBaselineFromProfile,
+  registerActivityProfileGates,
+} from "./activity-gates.js";
+
+function baseProfile(overrides: Partial<ActivityProfile>): ActivityProfile {
+  return {
+    ownerEntityId: "owner",
+    analyzedAt: 0,
+    analysisWindowDays: 7,
+    timezone: "UTC",
+    totalMessages: 0,
+    sustainedInactivityThresholdMinutes: 180,
+    platforms: [],
+    primaryPlatform: null,
+    secondaryPlatform: null,
+    bucketCounts: {
+      EARLY_MORNING: 0,
+      MORNING: 0,
+      MIDDAY: 0,
+      AFTERNOON: 0,
+      EVENING: 0,
+      NIGHT: 0,
+      LATE_NIGHT: 0,
+    },
+    hasCalendarData: false,
+    typicalFirstEventHour: null,
+    typicalLastEventHour: null,
+    avgWeekdayMeetings: null,
+    typicalFirstActiveHour: null,
+    typicalLastActiveHour: null,
+    typicalWakeHour: null,
+    typicalSleepHour: null,
+    hasSleepData: false,
+    isCurrentlySleeping: false,
+    lastSleepSignalAt: null,
+    lastWakeSignalAt: null,
+    sleepSourcePlatform: null,
+    sleepSource: null,
+    typicalSleepDurationMinutes: null,
+    lastSeenAt: 0,
+    lastSeenPlatform: null,
+    isCurrentlyActive: false,
+    hasOpenActivityCycle: false,
+    currentActivityCycleStartedAt: null,
+    currentActivityCycleLocalDate: null,
+    effectiveDayKey: "2026-05-10",
+    screenContextFocus: null,
+    screenContextSource: null,
+    screenContextSampledAt: null,
+    screenContextConfidence: null,
+    screenContextBusy: false,
+    screenContextAvailable: false,
+    screenContextStale: false,
+    ...overrides,
+  };
+}
+
+function makeRuntime(profile: ActivityProfile | null): IAgentRuntime {
+  const tasks: Task[] = profile
+    ? [
+        {
+          id: "proactive-task" as UUID,
+          name: "PROACTIVE_AGENT",
+          metadata: { activityProfile: profile },
+        } as unknown as Task,
+      ]
+    : [];
+  return {
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    async getTasks(): Promise<Task[]> {
+      return tasks;
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeContext(
+  task: ScheduledTask,
+  opts: { nowIso?: string; busActive?: boolean } = {},
+): GateEvaluationContext {
+  return {
+    task,
+    nowIso: opts.nowIso ?? "2026-05-10T12:00:00.000Z",
+    ownerFacts: { timezone: "UTC" },
+    activity: { hasSignalSince: () => opts.busActive === true },
+    subjectStore: { wasUpdatedSince: () => false },
+  };
+}
+
+function taskWithGate(kind: string, params: unknown): ScheduledTask {
+  return {
+    taskId: "t1",
+    kind: "reminder",
+    promptInstructions: "x",
+    trigger: { kind: "manual" },
+    priority: "low",
+    shouldFire: { compose: "all", gates: [{ kind, params }] },
+    respectsGlobalPause: true,
+    state: { status: "scheduled", followupCount: 0 },
+    source: "default_pack",
+    createdBy: "test",
+    ownerVisible: true,
+  };
+}
+
+describe("circadian_state_in reader", () => {
+  it("allows when observed state (awake) is in requested states", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ isCurrentlySleeping: false })),
+      reg,
+    );
+    const gate = reg.get("circadian_state_in");
+    const task = taskWithGate("circadian_state_in", { states: ["awake"] });
+    const decision = await gate?.evaluate(task, makeContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("denies when observed state (asleep) is not in requested states", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ isCurrentlySleeping: true })),
+      reg,
+    );
+    const gate = reg.get("circadian_state_in");
+    const task = taskWithGate("circadian_state_in", { states: ["awake"] });
+    const decision = await gate?.evaluate(task, makeContext(task));
+    expect(decision?.kind).toBe("deny");
+  });
+
+  it("allows an asleep-only task when the user is asleep", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ isCurrentlySleeping: true })),
+      reg,
+    );
+    const gate = reg.get("circadian_state_in");
+    const task = taskWithGate("circadian_state_in", { states: ["asleep"] });
+    const decision = await gate?.evaluate(task, makeContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("defaults to awake when no profile has been built yet", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(makeRuntime(null), reg);
+    const gate = reg.get("circadian_state_in");
+    const task = taskWithGate("circadian_state_in", { states: ["awake"] });
+    const decision = await gate?.evaluate(task, makeContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+});
+
+describe("no_recent_user_message_in reader", () => {
+  const NOW = "2026-05-10T12:00:00.000Z";
+  const nowMs = Date.parse(NOW);
+
+  it("allows when the user has been quiet longer than the window", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ lastSeenAt: nowMs - 60 * 60 * 1000 })),
+      reg,
+    );
+    const gate = reg.get("no_recent_user_message_in");
+    const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
+    const decision = await gate?.evaluate(task, makeContext(task, { nowIso: NOW }));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("defers when the user was active within the window (profile heartbeat)", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ lastSeenAt: nowMs - 10 * 60 * 1000 })),
+      reg,
+    );
+    const gate = reg.get("no_recent_user_message_in");
+    const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
+    const decision = await gate?.evaluate(task, makeContext(task, { nowIso: NOW }));
+    expect(decision?.kind).toBe("defer");
+    if (decision?.kind === "defer" && "offsetMinutes" in decision.until) {
+      // last seen 10m ago, window 30m → quiet again in ~20m.
+      expect(decision.until.offsetMinutes).toBe(20);
+    }
+  });
+
+  it("defers when a message_activity_event is on the bus within the window", async () => {
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ lastSeenAt: 0 })),
+      reg,
+    );
+    const gate = reg.get("no_recent_user_message_in");
+    const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
+    const decision = await gate?.evaluate(
+      task,
+      makeContext(task, { nowIso: NOW, busActive: true }),
+    );
+    expect(decision?.kind).toBe("defer");
+  });
+});
+
+describe("behaviouralBaselineFromProfile (B3 feeder)", () => {
+  it("returns null when the profile has no observed samples", () => {
+    expect(behaviouralBaselineFromProfile(baseProfile({}))).toBeNull();
+    expect(behaviouralBaselineFromProfile(null)).toBeNull();
+  });
+
+  it("counts wake + sleep hours and per-platform history as samples", () => {
+    const result = behaviouralBaselineFromProfile(
+      baseProfile({
+        typicalWakeHour: 7,
+        typicalSleepHour: 23,
+        analysisWindowDays: 7,
+        platforms: [
+          {
+            source: "client_chat",
+            messageCount: 40,
+            bucketCounts: {
+              EARLY_MORNING: 0,
+              MORNING: 0,
+              MIDDAY: 0,
+              AFTERNOON: 0,
+              EVENING: 0,
+              NIGHT: 0,
+              LATE_NIGHT: 0,
+            },
+            lastMessageAt: 0,
+            averageMessagesPerDay: 5,
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({ sampleCount: 3, windowDays: 7 });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
@@ -12,7 +12,10 @@ import type {
   GateEvaluationContext,
   ScheduledTask,
 } from "@elizaos/plugin-scheduling";
-import { createTaskGateRegistry } from "@elizaos/plugin-scheduling";
+import {
+  createTaskGateRegistry,
+  registerBuiltInGates,
+} from "@elizaos/plugin-scheduling";
 import { describe, expect, it } from "vitest";
 import type { ActivityProfile } from "../../activity-profile/types.js";
 import {
@@ -247,5 +250,52 @@ describe("behaviouralBaselineFromProfile (B3 feeder)", () => {
       }),
     );
     expect(result).toEqual({ sampleCount: 3, windowDays: 7 });
+  });
+});
+
+describe("first-wins: PA's real reader overrides the plugin-scheduling fallback", () => {
+  // This mirrors the production wiring in runtime-wiring.ts: PA registers its
+  // ActivityProfile-backed readers BEFORE registerBuiltInGates, which is
+  // first-wins, so the PA reader stays authoritative.
+  it("PA's circadian_state_in (asleep-aware) wins over the built-in awake-default fallback", async () => {
+    const reg = createTaskGateRegistry();
+    // 1. PA registers its real reader first, over a profile that says asleep.
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ isCurrentlySleeping: true })),
+      reg,
+    );
+    // 2. Built-ins run second and must NOT overwrite it.
+    registerBuiltInGates(reg);
+
+    const task = taskWithGate("circadian_state_in", { states: ["awake"] });
+    const decision = await reg
+      .get("circadian_state_in")
+      ?.evaluate(task, makeContext(task));
+    // PA's reader denies (user asleep). The built-in fallback, if it had won,
+    // would have allowed (no profile → assume awake). deny proves PA won.
+    expect(decision?.kind).toBe("deny");
+  });
+
+  it("PA's no_recent_user_message_in (heartbeat-aware) wins over the built-in bus-only fallback", async () => {
+    const NOW = "2026-05-10T12:00:00.000Z";
+    const nowMs = Date.parse(NOW);
+    const reg = createTaskGateRegistry();
+    // PA reader over a profile with a recent heartbeat but NO bus signal.
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ lastSeenAt: nowMs - 10 * 60 * 1000 })),
+      reg,
+    );
+    registerBuiltInGates(reg);
+
+    const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
+    // Bus reports no activity; only the profile heartbeat does. The built-in
+    // fallback (bus-only) would ALLOW; PA's reader DEFERS by the remaining 20m.
+    const decision = await reg
+      .get("no_recent_user_message_in")
+      ?.evaluate(task, makeContext(task, { nowIso: NOW, busActive: false }));
+    expect(decision?.kind).toBe("defer");
+    if (decision?.kind === "defer" && "offsetMinutes" in decision.until) {
+      expect(decision.until.offsetMinutes).toBe(20);
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.ts
@@ -100,7 +100,9 @@ function makeCircadianStateInGate(
       _task: ScheduledTask,
       context: GateEvaluationContext,
     ): Promise<GateDecision> {
-      const states = parseStates(gateParams(context, "circadian_state_in").states);
+      const states = parseStates(
+        gateParams(context, "circadian_state_in").states,
+      );
       const profile = await readActivityProfile(runtime);
       const observed: CircadianState =
         profile?.isCurrentlySleeping === true ? "asleep" : "awake";

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.ts
@@ -1,0 +1,243 @@
+/**
+ * Real production readers for the two gate kinds that previously fell through
+ * to always-allow stubs (issue #12186, tasks B2 + B3 / plan D.2.2 + D.4.1):
+ *
+ *   - `circadian_state_in` — gates on the observed awake/asleep state from the
+ *     `ActivityProfile` (health sleep signals + activity heartbeat). Health
+ *     default packs (`wake-up`, `bedtime`, `sleep-recap`) declare
+ *     `params.states: ["awake"]` so they only fire while the user is up.
+ *
+ *   - `no_recent_user_message_in` — suppresses a proactive poke when the user
+ *     has been active within `params.minutes`. Reads the profile's `lastSeenAt`
+ *     (owner messages + activity/health signals) and the `message_activity_event`
+ *     bus family. Returns `defer` (reschedule) not `deny` so the poke isn't
+ *     dropped, just delayed until the user goes quiet.
+ *
+ *   - `personal_baseline_sufficient` context feeder (B3 / plan D.2.3): the
+ *     profile also feeds a *behavioural* sample count so the built-in
+ *     `personal_baseline_sufficient` gate can fire once enough rhythm has been
+ *     observed, independent of the health baseline.
+ *
+ * These read structural fields only. No prompt-text routing, no new scheduler.
+ */
+
+import type { IAgentRuntime, Task } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import type {
+  GateDecision,
+  GateEvaluationContext,
+  ScheduledTask,
+  TaskGateContribution,
+} from "@elizaos/plugin-scheduling";
+import {
+  PROACTIVE_TASK_NAME,
+  PROACTIVE_TASK_TAGS,
+  readProfileFromMetadata,
+} from "../../activity-profile/profile-metadata.js";
+import type { ActivityProfile } from "../../activity-profile/types.js";
+
+const MAX_PROFILE_TASKS = 25;
+
+/** Circadian states this gate understands. */
+type CircadianState = "awake" | "asleep";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Read the persisted `ActivityProfile` from the `PROACTIVE_AGENT` task
+ * metadata — the same source the activity-profile provider reads. Returns
+ * `null` when no profile has been built yet.
+ */
+export async function readActivityProfile(
+  runtime: IAgentRuntime,
+): Promise<ActivityProfile | null> {
+  const tasks = (await runtime.getTasks({
+    agentIds: [runtime.agentId],
+    tags: [...PROACTIVE_TASK_TAGS],
+  })) as Task[];
+  const task = tasks
+    .slice(0, MAX_PROFILE_TASKS)
+    .find((t) => t.name === PROACTIVE_TASK_NAME && isRecord(t.metadata));
+  const metadata = isRecord(task?.metadata) ? task.metadata : null;
+  return readProfileFromMetadata(metadata);
+}
+
+function gateParams(
+  context: GateEvaluationContext,
+  kind: string,
+): Record<string, unknown> {
+  const params = context.task.shouldFire?.gates.find(
+    (g) => g.kind === kind,
+  )?.params;
+  return isRecord(params) ? params : {};
+}
+
+function parseStates(raw: unknown): CircadianState[] {
+  if (!Array.isArray(raw)) return ["awake"];
+  const states = raw.filter(
+    (s): s is CircadianState => s === "awake" || s === "asleep",
+  );
+  return states.length > 0 ? states : ["awake"];
+}
+
+/**
+ * `circadian_state_in` — allow only when the observed circadian state is in the
+ * requested `states`. Reads `ActivityProfile.isCurrentlySleeping`.
+ *
+ * When no profile exists yet (day one, before the first rhythm rebuild) the
+ * observed state is unknown. Defaulting to `awake` matches the honest reality
+ * that we have no evidence the user is asleep, and keeps day-one packs firing
+ * rather than silently starving them.
+ */
+function makeCircadianStateInGate(
+  runtime: IAgentRuntime,
+): TaskGateContribution {
+  return {
+    kind: "circadian_state_in",
+    async evaluate(
+      _task: ScheduledTask,
+      context: GateEvaluationContext,
+    ): Promise<GateDecision> {
+      const states = parseStates(gateParams(context, "circadian_state_in").states);
+      const profile = await readActivityProfile(runtime);
+      const observed: CircadianState =
+        profile?.isCurrentlySleeping === true ? "asleep" : "awake";
+      if (states.includes(observed)) {
+        return { kind: "allow" };
+      }
+      return {
+        kind: "deny",
+        reason: `circadian_state_in: observed "${observed}" not in [${states.join(",")}]`,
+      };
+    },
+  };
+}
+
+interface NoRecentUserMessageParams {
+  /** Suppress the poke when the user was seen within this many minutes. */
+  minutes?: number;
+}
+
+const DEFAULT_NO_RECENT_MINUTES = 30;
+
+/**
+ * `no_recent_user_message_in` — suppress a proactive poke when the user has
+ * been active within `params.minutes`. "Active" = the profile's `lastSeenAt`
+ * (owner messages + activity/health signals) OR a `message_activity_event` on
+ * the bus since the cutoff.
+ *
+ * Returns `defer` (reschedule for the remaining suppression window) rather than
+ * `deny` so the poke is delayed until the user goes quiet, not dropped.
+ */
+function makeNoRecentUserMessageInGate(
+  runtime: IAgentRuntime,
+): TaskGateContribution {
+  return {
+    kind: "no_recent_user_message_in",
+    async evaluate(
+      _task: ScheduledTask,
+      context: GateEvaluationContext,
+    ): Promise<GateDecision> {
+      const params = gateParams(
+        context,
+        "no_recent_user_message_in",
+      ) as NoRecentUserMessageParams;
+      const minutes =
+        typeof params.minutes === "number" &&
+        Number.isFinite(params.minutes) &&
+        params.minutes > 0
+          ? params.minutes
+          : DEFAULT_NO_RECENT_MINUTES;
+
+      const nowMs = Date.parse(context.nowIso);
+      if (!Number.isFinite(nowMs)) {
+        return { kind: "allow" };
+      }
+      const cutoffMs = nowMs - minutes * 60_000;
+      const sinceIso = new Date(cutoffMs).toISOString();
+
+      const profile = await readActivityProfile(runtime);
+      const lastSeenAt =
+        profile && Number.isFinite(profile.lastSeenAt) ? profile.lastSeenAt : 0;
+      const recentByProfile = lastSeenAt > 0 && lastSeenAt >= cutoffMs;
+
+      const recentByBus =
+        (await context.activity.hasSignalSince({
+          signalKind: "message_activity_event",
+          sinceIso,
+        })) === true;
+
+      if (!recentByProfile && !recentByBus) {
+        return { kind: "allow" };
+      }
+
+      // How long until the user is "quiet" again, measured from the most
+      // recent activity we can see.
+      const lastActivityMs = recentByProfile ? lastSeenAt : cutoffMs;
+      const quietAtMs = lastActivityMs + minutes * 60_000;
+      const deferMinutes = Math.max(1, Math.ceil((quietAtMs - nowMs) / 60_000));
+      return {
+        kind: "defer",
+        until: { offsetMinutes: deferMinutes },
+        reason: `no_recent_user_message_in: user active within ${minutes}m; deferring ${deferMinutes}m`,
+      };
+    },
+  };
+}
+
+/**
+ * Register the two real gate readers into a `TaskGateRegistry`-shaped object.
+ * Must run BEFORE `registerBuiltInGates` (which is first-wins after the change
+ * in this issue) so these readers take precedence over any built-in fallback.
+ */
+export function registerActivityProfileGates(
+  runtime: IAgentRuntime,
+  registry: { register(c: TaskGateContribution): void },
+): void {
+  registry.register(makeCircadianStateInGate(runtime));
+  registry.register(makeNoRecentUserMessageInGate(runtime));
+  logger.debug(
+    { src: "lifeops:scheduled-task:activity-gates", agentId: runtime.agentId },
+    "[activity-gates] registered circadian_state_in + no_recent_user_message_in readers",
+  );
+}
+
+/**
+ * Behavioural personal-baseline sample count (B3 / plan D.2.3). Counts the
+ * number of distinct observed-rhythm signals the profile carries so
+ * `personal_baseline_sufficient` can fire once enough behaviour is observed,
+ * not only from a health baseline. Exposed for the owner-facts feeder.
+ *
+ * A sample is any of: an observed wake hour, an observed sleep hour, or a
+ * meaningful message-activity history. `windowDays` mirrors the profile's
+ * analysis window.
+ */
+export function behaviouralBaselineFromProfile(
+  profile: ActivityProfile | null,
+): { sampleCount: number; windowDays: number } | null {
+  if (!profile) return null;
+  let sampleCount = 0;
+  if (
+    typeof profile.typicalWakeHour === "number" &&
+    Number.isFinite(profile.typicalWakeHour)
+  ) {
+    sampleCount += 1;
+  }
+  if (
+    typeof profile.typicalSleepHour === "number" &&
+    Number.isFinite(profile.typicalSleepHour)
+  ) {
+    sampleCount += 1;
+  }
+  // Each platform with sustained history contributes one behavioural sample.
+  for (const platform of profile.platforms) {
+    if (platform.messageCount > 0) sampleCount += 1;
+  }
+  if (sampleCount === 0) return null;
+  return {
+    sampleCount,
+    windowDays: profile.analysisWindowDays,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -46,11 +46,6 @@ import {
   type ScheduledTaskRunnerHandle,
   type ScheduledTaskStore,
 } from "@elizaos/plugin-scheduling";
-import {
-  behaviouralBaselineFromProfile,
-  readActivityProfile,
-  registerActivityProfileGates,
-} from "./activity-gates.js";
 import { getChannelRegistry } from "../channels/index.js";
 import type { DispatchResult } from "../connectors/contract.js";
 import { decideDispatchPolicy } from "../connectors/dispatch-policy.js";
@@ -65,6 +60,11 @@ import { LifeOpsRepository } from "../repository.js";
 import { preferEffectiveMergedState } from "../schedule-state.js";
 import { getSendPolicyRegistry } from "../send-policy/index.js";
 import { getActivitySignalBus } from "../signals/bus.js";
+import {
+  behaviouralBaselineFromProfile,
+  readActivityProfile,
+  registerActivityProfileGates,
+} from "./activity-gates.js";
 import { createLifeOpsSubjectStoreView } from "./subject-store.js";
 
 interface RepositoryBackedStores {
@@ -208,7 +208,8 @@ function defaultOwnerFactsProvider(
         await readActivityProfile(runtime),
       );
       const sampleCount = Math.max(
-        typeof healthSampleCount === "number" && Number.isFinite(healthSampleCount)
+        typeof healthSampleCount === "number" &&
+          Number.isFinite(healthSampleCount)
           ? healthSampleCount
           : 0,
         behavioural?.sampleCount ?? 0,
@@ -591,7 +592,8 @@ function buildLifeOpsRunnerDeps(
   // runner deps are built during plugin init, before callers get a chance to
   // register (e.g. registerLifeOpsScheduledTaskSubjectStore in tests).
   const subjectStore: SubjectStoreView =
-    opts.subjectStore ?? makeRuntimeSubjectStoreView(opts.runtime, opts.agentId);
+    opts.subjectStore ??
+    makeRuntimeSubjectStoreView(opts.runtime, opts.agentId);
 
   return {
     store: stores.store,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -46,6 +46,11 @@ import {
   type ScheduledTaskRunnerHandle,
   type ScheduledTaskStore,
 } from "@elizaos/plugin-scheduling";
+import {
+  behaviouralBaselineFromProfile,
+  readActivityProfile,
+  registerActivityProfileGates,
+} from "./activity-gates.js";
 import { getChannelRegistry } from "../channels/index.js";
 import type { DispatchResult } from "../connectors/contract.js";
 import { decideDispatchPolicy } from "../connectors/dispatch-policy.js";
@@ -194,11 +199,25 @@ function defaultOwnerFactsProvider(
         local,
         cloud,
       });
-      const sampleCount = effective?.baseline?.sampleCount;
-      if (typeof sampleCount === "number" && Number.isFinite(sampleCount)) {
+      const healthSampleCount = effective?.baseline?.sampleCount;
+      // Behavioural baseline from the observed rhythm (plan D.2.3). Feeds the
+      // same personalBaseline surface so `personal_baseline_sufficient` fires
+      // once EITHER a health baseline OR enough observed behaviour exists —
+      // avoids starving persona packs that have no health baseline on day one.
+      const behavioural = behaviouralBaselineFromProfile(
+        await readActivityProfile(runtime),
+      );
+      const sampleCount = Math.max(
+        typeof healthSampleCount === "number" && Number.isFinite(healthSampleCount)
+          ? healthSampleCount
+          : 0,
+        behavioural?.sampleCount ?? 0,
+      );
+      if (sampleCount > 0) {
         view.personalBaseline = {
           sampleCount,
-          windowDays: effective?.baseline?.windowDays,
+          windowDays:
+            effective?.baseline?.windowDays ?? behavioural?.windowDays,
         };
       }
     } catch (error) {
@@ -538,6 +557,12 @@ function buildLifeOpsRunnerDeps(
   const stores = makeRepositoryBackedStores(opts.runtime, opts.agentId);
 
   const gates = createTaskGateRegistry();
+  // Register the real ActivityProfile-backed readers for circadian_state_in and
+  // no_recent_user_message_in BEFORE the built-ins. registerBuiltInGates is
+  // first-wins, so these production readers take precedence over the generic
+  // fallbacks (which stay resolvable when PA is absent, e.g. plugin-health
+  // standalone tests).
+  registerActivityProfileGates(opts.runtime, gates);
   registerBuiltInGates(gates);
 
   const completionChecks = createCompletionCheckRegistry();

--- a/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
@@ -27,7 +27,6 @@ import {
   EXECUTIVE_ASSISTANT_RECORD_IDS,
   executiveAssistantPack,
   FOLLOWUP_STARTER_PACK_KEY,
-  followupStarterPack,
   getAllDefaultPacks,
   getDefaultEnabledPacks,
   getDefaultPack,
@@ -42,11 +41,9 @@ import {
   isInboxTriageEligible,
   LOW_ENERGY_SUPPORT_PACK_KEY,
   MORNING_BRIEF_PACK_KEY,
-  morningBriefPack,
   OBJECT_PERMANENCE_WATCHER_PACK_KEY,
   QUIET_THRESHOLD_DAYS,
   QUIET_USER_WATCHER_PACK_KEY,
-  quietUserWatcherPack,
 } from "../src/default-packs/index.js";
 
 const VALID_KINDS: ReadonlySet<ScheduledTaskKind> = new Set<ScheduledTaskKind>([

--- a/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
@@ -17,6 +17,7 @@ import type {
   ScheduledTaskSeed,
 } from "../src/default-packs/index.js";
 import {
+  ADHD_BODY_DOUBLE_PACK_KEY,
   DAILY_RHYTHM_PACK_KEY,
   DAILY_RHYTHM_RECORD_IDS,
   DEFAULT_CONSOLIDATION_POLICIES,
@@ -39,8 +40,10 @@ import {
   INBOX_TRIAGE_STARTER_PACK_KEY,
   inboxTriageStarterPack,
   isInboxTriageEligible,
+  LOW_ENERGY_SUPPORT_PACK_KEY,
   MORNING_BRIEF_PACK_KEY,
   morningBriefPack,
+  OBJECT_PERMANENCE_WATCHER_PACK_KEY,
   QUIET_THRESHOLD_DAYS,
   QUIET_USER_WATCHER_PACK_KEY,
   quietUserWatcherPack,
@@ -152,8 +155,8 @@ function validatePack(pack: DefaultPack): string[] {
 describe("W1-D default-pack registry — shape", () => {
   const HEALTH_PACK_KEYS = ["bedtime", "wake-up", "sleep-recap"] as const;
 
-  it("registers exactly 10 packs", () => {
-    expect(getAllDefaultPacks().length).toBe(10);
+  it("registers exactly 13 packs", () => {
+    expect(getAllDefaultPacks().length).toBe(13);
   });
 
   it("registers the documented pack keys", () => {
@@ -163,12 +166,15 @@ describe("W1-D default-pack registry — shape", () => {
         .sort(),
     ).toEqual(
       [
+        ADHD_BODY_DOUBLE_PACK_KEY,
         DAILY_RHYTHM_PACK_KEY,
         EXECUTIVE_ASSISTANT_PACK_KEY,
         FOLLOWUP_STARTER_PACK_KEY,
         HABIT_STARTERS_PACK_KEY,
         INBOX_TRIAGE_STARTER_PACK_KEY,
+        LOW_ENERGY_SUPPORT_PACK_KEY,
         MORNING_BRIEF_PACK_KEY,
+        OBJECT_PERMANENCE_WATCHER_PACK_KEY,
         QUIET_USER_WATCHER_PACK_KEY,
         ...HEALTH_PACK_KEYS,
       ].sort(),
@@ -182,7 +188,7 @@ describe("W1-D default-pack registry — shape", () => {
   });
 
   it("getOfferedDefaultPacks returns all packs", () => {
-    expect(getOfferedDefaultPacks().length).toBe(10);
+    expect(getOfferedDefaultPacks().length).toBe(13);
   });
 });
 

--- a/plugins/plugin-personal-assistant/test/persona-packs.simulation.test.ts
+++ b/plugins/plugin-personal-assistant/test/persona-packs.simulation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * FIX-4(c) / issue #12186: drive persona default-pack records through a REAL
+ * in-memory ScheduledTask runner (built-in gates + escalation ladders +
+ * dispatcher), not just assert compiled DTO fields. Proves the packs actually
+ * FIRE, GATE, and ESCALATE as intended when the scheduler evaluates them.
+ *
+ * This is the closest headless equivalent to a full scenario tick that does
+ * NOT depend on the scenario-runner boot (which is CI-gated on a pre-existing
+ * shared-tree packaging gap). The runner here is the same one the production
+ * spine builds — same gate registry, same escalation resolver, same dispatch
+ * path — with in-memory stores.
+ */
+
+import type { ScheduledTaskInput } from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+import {
+  adhdBodyDoublePack,
+  lowEnergySupportPack,
+  SOFT_LOW_ENERGY_ESCALATION_STEPS,
+} from "../src/default-packs/index.js";
+import { createLifeOpsScheduledTaskSimulationHarness } from "./helpers/lifeops-scheduled-task-simulation.ts";
+
+/** Turn a compiled pack seed into a runner.schedule input (drop nothing). */
+function seedToInput(
+  record: (typeof lowEnergySupportPack.records)[number],
+): Partial<ScheduledTaskInput> {
+  // The seed already omits taskId/state; schedulePrimitive merges these
+  // overrides over its defaults, so spreading the full record makes the runner
+  // schedule the ACTUAL pack task (trigger, escalation, completionCheck, …).
+  return { ...record } as Partial<ScheduledTaskInput>;
+}
+
+describe("persona packs — real scheduler-tick behavior", () => {
+  it("low-energy-support checkin fires and dispatches at SOFT intensity (first ladder step)", async () => {
+    const h = createLifeOpsScheduledTaskSimulationHarness();
+    const record = lowEnergySupportPack.records[0];
+    expect(record).toBeDefined();
+    // Schedule the real pack record; fire immediately (manual fire path).
+    const task = await h.schedulePrimitive(
+      "checkin",
+      seedToInput(record as (typeof lowEnergySupportPack.records)[number]),
+    );
+    const fired = await h.firePrimitive(task);
+
+    expect(fired.state.status).toBe("fired");
+    expect(h.dispatches).toHaveLength(1);
+    // The first soft ladder step is intensity "soft" on the in_app channel.
+    expect(h.dispatches[0]?.intensity).toBe("soft");
+    expect(h.dispatches[0]?.channelKey).toBe("in_app");
+  });
+
+  it("low-energy-support escalation NEVER reaches an urgent step across the full ladder", async () => {
+    const h = createLifeOpsScheduledTaskSimulationHarness();
+    const record = lowEnergySupportPack.records[0];
+    const task = await h.schedulePrimitive(
+      "checkin",
+      seedToInput(record as (typeof lowEnergySupportPack.records)[number]),
+    );
+    await h.firePrimitive(task);
+
+    // Walk the whole soft ladder by advancing past each step's delay and
+    // re-firing the escalation. The runner advances the cursor per step.
+    for (const step of SOFT_LOW_ENERGY_ESCALATION_STEPS) {
+      h.advanceMinutes(step.delayMinutes + 1);
+      await h.runner.apply(task.taskId, "escalate").catch(() => undefined);
+    }
+
+    // Every dispatch that happened must be soft intensity — no urgent step
+    // exists in this persona ladder, so a shaming cross-channel push can never
+    // occur no matter how many times the reminder goes unanswered.
+    expect(h.dispatches.length).toBeGreaterThan(0);
+    for (const dispatch of h.dispatches) {
+      expect(dispatch.intensity).not.toBe("urgent");
+    }
+  });
+
+  it("adhd-body-double checkin fires flexibly and stays soft-only", async () => {
+    const h = createLifeOpsScheduledTaskSimulationHarness();
+    const record = adhdBodyDoublePack.records[0];
+    expect(record?.trigger).toEqual({
+      kind: "during_window",
+      windowKey: "morning",
+    });
+    const task = await h.schedulePrimitive(
+      "checkin",
+      seedToInput(record as (typeof adhdBodyDoublePack.records)[number]),
+    );
+    const fired = await h.firePrimitive(task);
+
+    expect(fired.state.status).toBe("fired");
+    expect(h.dispatches).toHaveLength(1);
+    expect(h.dispatches[0]?.intensity).toBe("soft");
+  });
+
+  it("a no_recent_user_message_in-gated poke is SUPPRESSED (deferred) when the user is active", async () => {
+    const h = createLifeOpsScheduledTaskSimulationHarness();
+    // Bus reports the user was recently active on a message channel.
+    h.setActivity({ hasSignalSince: () => true });
+
+    const poke = await h.schedulePrimitive("checkin", {
+      promptInstructions: "proactive poke",
+      trigger: { kind: "manual" },
+      priority: "low",
+      shouldFire: {
+        compose: "all",
+        gates: [{ kind: "no_recent_user_message_in", params: { minutes: 30 } }],
+      },
+    });
+    const fired = await h.firePrimitive(poke);
+
+    // The built-in gate defers (reschedules) rather than dispatching, so no
+    // message reaches the user while they are active.
+    expect(fired.state.status).not.toBe("fired");
+    expect(h.dispatches).toHaveLength(0);
+  });
+
+  it("the same poke FIRES once the user goes quiet (gate allows)", async () => {
+    const h = createLifeOpsScheduledTaskSimulationHarness();
+    h.setActivity({ hasSignalSince: () => false });
+
+    const poke = await h.schedulePrimitive("checkin", {
+      promptInstructions: "proactive poke",
+      trigger: { kind: "manual" },
+      priority: "low",
+      shouldFire: {
+        compose: "all",
+        gates: [{ kind: "no_recent_user_message_in", params: { minutes: 30 } }],
+      },
+    });
+    const fired = await h.firePrimitive(poke);
+
+    expect(fired.state.status).toBe("fired");
+    expect(h.dispatches).toHaveLength(1);
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
@@ -154,6 +154,91 @@ describe("registerBuiltInGates: personal_baseline_sufficient (#8795)", () => {
 });
 
 /**
+ * Built-in (PA-absent) `no_recent_user_message_in` fallback (#12186). When the
+ * activity bus reports a recent `message_activity_event`, the poke must be
+ * DEFERRED (delayed), never DENIED — denying silently drops the proactive poke.
+ */
+describe("registerBuiltInGates: no_recent_user_message_in fallback defers", () => {
+  function pokeTask(minutes: number): ScheduledTask {
+    return {
+      taskId: "t-poke",
+      kind: "checkin",
+      promptInstructions: "poke",
+      trigger: { kind: "interval", everyMinutes: 60 },
+      priority: "low",
+      shouldFire: {
+        compose: "all",
+        gates: [{ kind: "no_recent_user_message_in", params: { minutes } }],
+      },
+      respectsGlobalPause: true,
+      state: { status: "scheduled", followupCount: 0 },
+      source: "default_pack",
+      createdBy: "test",
+      ownerVisible: true,
+    } as ScheduledTask;
+  }
+
+  function contextWithActivity(
+    task: ScheduledTask,
+    recentlyActive: boolean,
+  ): GateEvaluationContext {
+    return {
+      task,
+      nowIso: "2026-05-10T12:00:00.000Z",
+      ownerFacts: { timezone: "UTC" },
+      activity: { hasSignalSince: () => recentlyActive },
+      subjectStore: { wasUpdatedSince: () => false },
+    };
+  }
+
+  it("defers (does not deny) when the user was recently active", async () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const task = pokeTask(30);
+    const decision = await reg
+      .get("no_recent_user_message_in")
+      ?.evaluate(task, contextWithActivity(task, true));
+    expect(decision?.kind).toBe("defer");
+    if (decision?.kind === "defer" && "offsetMinutes" in decision.until) {
+      expect(decision.until.offsetMinutes).toBe(30);
+    }
+  });
+
+  it("allows when the user has been quiet", async () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const task = pokeTask(30);
+    const decision = await reg
+      .get("no_recent_user_message_in")
+      ?.evaluate(task, contextWithActivity(task, false));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+});
+
+/**
+ * First-wins semantics (#12186): a caller may register a richer production
+ * reader for a kind BEFORE registerBuiltInGates; the built-in must then be
+ * skipped so the caller's reader stays authoritative.
+ */
+describe("registerBuiltInGates first-wins", () => {
+  it("keeps a pre-registered contribution for a built-in kind", () => {
+    const reg = createTaskGateRegistry();
+    const sentinel: import("./types.js").TaskGateContribution = {
+      kind: "circadian_state_in",
+      evaluate: () => ({ kind: "deny", reason: "sentinel-reader" }),
+    };
+    // Register the custom reader FIRST, then the built-ins.
+    reg.register(sentinel);
+    registerBuiltInGates(reg);
+    // The custom reader wins; the built-in fallback did not overwrite it.
+    expect(reg.get("circadian_state_in")).toBe(sentinel);
+    // Other built-ins are still registered.
+    expect(reg.get("quiet_hours")).not.toBeNull();
+    expect(reg.get("no_recent_user_message_in")).not.toBeNull();
+  });
+});
+
+/**
  * Regression: `weekday_only` must honor `params.weekdays` (#10721 audit).
  * habit-starters passes `{ weekdays: [1, 3, 5] }` (Mon/Wed/Fri) — before the
  * fix the gate ignored the list and allowed every non-weekend day, so a

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
@@ -8,8 +8,6 @@
  * the responsibility of the runner (`compose: "all" | "any" | "first_deny"`).
  */
 
-import { logger } from "@elizaos/core";
-
 import type {
   GateDecision,
   GateEvaluationContext,
@@ -257,43 +255,86 @@ const duringTravelGate: TaskGateContribution = {
   },
 };
 
-/**
- * `circadian_state_in` and `no_recent_user_message_in` are referenced by
- * plugin-health default packs but the concrete data readers (circadian state,
- * recent-user-message lookup) are not wired into the runner today. Until a
- * caller registers a real contribution (overwriting these), the gate falls
- * through to `allow` and logs a warning once per process so the operator can
- * see that the gate isn't doing what its name suggests. Loud > silent.
- */
-function makeWarnOnceFallthroughGate(
-  kind: string,
-  remediation: string,
-): TaskGateContribution {
-  let warned = false;
-  return {
-    kind,
-    evaluate(): GateDecision {
-      if (!warned) {
-        warned = true;
-        logger.warn(
-          { src: "lifeops:scheduled-task:gate-registry", gateKind: kind },
-          `Gate "${kind}" has no production reader registered; falling through to allow. ${remediation}`,
-        );
-      }
-      return { kind: "allow" };
-    },
-  };
+interface CircadianStateInParams {
+  /** Circadian states the task may fire in. Default `["awake"]`. */
+  states?: Array<"awake" | "asleep">;
 }
 
-const circadianStateInGate = makeWarnOnceFallthroughGate(
-  "circadian_state_in",
-  "Register a circadian-state-aware contribution via TaskGateRegistry.register before plugin-health default packs load, or remove this gate from those packs.",
-);
+/**
+ * `circadian_state_in` — generic built-in fallback. The circadian state
+ * (awake/asleep) is observed from the user's activity/health rhythm, which
+ * lives in `plugin-personal-assistant`'s `ActivityProfile`. That reader is
+ * registered by PA's runner wiring and, because `registerBuiltInGates` is
+ * first-wins, takes precedence over this fallback.
+ *
+ * Standalone (no PA profile reader) there is no evidence the user is asleep, so
+ * the honest default for the common `states: ["awake"]` packs is `allow`.
+ * Packs that only want to fire while asleep get `deny`.
+ */
+const circadianStateInGate: TaskGateContribution = {
+  kind: "circadian_state_in",
+  evaluate(_task, context): GateDecision {
+    const params = (context.task.shouldFire?.gates.find(
+      (g) => g.kind === "circadian_state_in",
+    )?.params ?? {}) as CircadianStateInParams;
+    const states =
+      Array.isArray(params.states) && params.states.length > 0
+        ? params.states
+        : (["awake"] as const);
+    // No profile reader here → assume awake (no evidence of sleep).
+    if (states.includes("awake")) {
+      return { kind: "allow" };
+    }
+    return {
+      kind: "deny",
+      reason: `circadian_state_in: observed "awake" not in [${states.join(",")}]`,
+    };
+  },
+};
 
-const noRecentUserMessageInGate = makeWarnOnceFallthroughGate(
-  "no_recent_user_message_in",
-  "Register a message-activity-aware contribution via TaskGateRegistry.register, or remove this gate from default packs.",
-);
+interface NoRecentUserMessageInParams {
+  /** Suppress when the user was active within this many minutes. Default 30. */
+  minutes?: number;
+}
+
+/**
+ * `no_recent_user_message_in` — real generic reader over the activity bus.
+ * Denies (suppresses) the fire when a `message_activity_event` occurred within
+ * `params.minutes`. PA's runner wiring registers a richer reader that also
+ * consults the `ActivityProfile.lastSeenAt` heartbeat and defers rather than
+ * denies; first-wins keeps that one when present.
+ */
+const noRecentUserMessageInGate: TaskGateContribution = {
+  kind: "no_recent_user_message_in",
+  async evaluate(_task, context): Promise<GateDecision> {
+    const params = (context.task.shouldFire?.gates.find(
+      (g) => g.kind === "no_recent_user_message_in",
+    )?.params ?? {}) as NoRecentUserMessageInParams;
+    const minutes =
+      typeof params.minutes === "number" &&
+      Number.isFinite(params.minutes) &&
+      params.minutes > 0
+        ? params.minutes
+        : 30;
+    const nowMs = Date.parse(context.nowIso);
+    if (!Number.isFinite(nowMs)) {
+      return { kind: "allow" };
+    }
+    const sinceIso = new Date(nowMs - minutes * 60_000).toISOString();
+    const active =
+      (await context.activity.hasSignalSince({
+        signalKind: "message_activity_event",
+        sinceIso,
+      })) === true;
+    if (!active) {
+      return { kind: "allow" };
+    }
+    return {
+      kind: "deny",
+      reason: `no_recent_user_message_in: user active within ${minutes}m`,
+    };
+  },
+};
 
 interface PersonalBaselineSufficientParams {
   minSamples?: number;
@@ -361,14 +402,28 @@ export function createTaskGateRegistry(): TaskGateRegistry {
   return reg;
 }
 
+/**
+ * Register the built-in gates. First-wins: a caller (e.g. plugin-personal-
+ * assistant's runner wiring) may register a richer, production reader for a
+ * kind BEFORE this runs; the built-in is then skipped so the caller's reader
+ * takes precedence. This is how `circadian_state_in` /
+ * `no_recent_user_message_in` get their ActivityProfile-backed readers.
+ */
 export function registerBuiltInGates(reg: TaskGateRegistry): void {
-  reg.register(weekendSkipGate);
-  reg.register(weekendOnlyGate);
-  reg.register(weekdayOnlyGate);
-  reg.register(lateEveningSkipGate);
-  reg.register(quietHoursGate);
-  reg.register(duringTravelGate);
-  reg.register(circadianStateInGate);
-  reg.register(noRecentUserMessageInGate);
-  reg.register(personalBaselineSufficientGate);
+  const builtins: TaskGateContribution[] = [
+    weekendSkipGate,
+    weekendOnlyGate,
+    weekdayOnlyGate,
+    lateEveningSkipGate,
+    quietHoursGate,
+    duringTravelGate,
+    circadianStateInGate,
+    noRecentUserMessageInGate,
+    personalBaselineSufficientGate,
+  ];
+  for (const gate of builtins) {
+    if (!reg.get(gate.kind)) {
+      reg.register(gate);
+    }
+  }
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
@@ -299,10 +299,13 @@ interface NoRecentUserMessageInParams {
 
 /**
  * `no_recent_user_message_in` — real generic reader over the activity bus.
- * Denies (suppresses) the fire when a `message_activity_event` occurred within
- * `params.minutes`. PA's runner wiring registers a richer reader that also
- * consults the `ActivityProfile.lastSeenAt` heartbeat and defers rather than
- * denies; first-wins keeps that one when present.
+ * When a `message_activity_event` occurred within `params.minutes`, the user is
+ * active, so the proactive poke is DEFERRED (delayed), not denied — dropping it
+ * would silently lose the poke. Without a `lastSeenAt` heartbeat this built-in
+ * can't know exactly when the user last spoke, so it delays by the full
+ * suppression window. PA's runner wiring registers a richer reader that reads
+ * `ActivityProfile.lastSeenAt` and defers by the precise remaining time;
+ * first-wins keeps that one when present.
  */
 const noRecentUserMessageInGate: TaskGateContribution = {
   kind: "no_recent_user_message_in",
@@ -330,8 +333,9 @@ const noRecentUserMessageInGate: TaskGateContribution = {
       return { kind: "allow" };
     }
     return {
-      kind: "deny",
-      reason: `no_recent_user_message_in: user active within ${minutes}m`,
+      kind: "defer",
+      until: { offsetMinutes: minutes },
+      reason: `no_recent_user_message_in: user active within ${minutes}m; deferring ${minutes}m`,
     };
   },
 };


### PR DESCRIPTION
## LifeOps agent optimization: structural extraction/learning, proactive gating, flexible-recurrence — advances #12284

Part of the LifeOps work (parent #12186, now decomposed) — implements the still-open **#12284** (structural extraction/learning, proactive poke/prod policy, flexible recurrence). All behavior is expressed through the ONE scheduler as structural `ScheduledTask` fields / registries / owner-fact writers — never `promptInstructions` text, no new scheduler, no new connectors.

The research found the LifeOps primitives are mature but **three learning seams were open** and **two proactivity gates were always-allow stubs**. This closes them.

### What landed
- **ActivityProfile → OwnerFacts rhythm-window learner** (`activity-profile/window-learning.ts` + writer): maps observed `typicalWakeHour`/`typicalSleepHour` into `OwnerFacts.morningWindow`/`eveningWindow`, respecting an explicit-user-override flag and idempotency — so `during_window`/anchor triggers track the user's *real* rhythm automatically (the "do X daily but not at the same time" primitive becomes learned, not configured). **A review-caught bug** was fixed here: the writer previously could emit an inverted (`start >= end`) window that the scheduler's bounds resolver can never satisfy — it would permanently kill the trigger; it now declines to write an unsatisfiable window.
- **Wired the two stubbed gates** (`gate-registry.ts` + PA runtime-wiring, first-wins): `circadian_state_in` (reads ActivityProfile/health circadian state → allow/deny/defer on awake/asleep) and `no_recent_user_message_in` (reads `ActivitySignalBus` → suppresses proactive pokes when the user is already active). The built-in fallback now **defers** (delays) instead of **denying** (silently dropping) the poke.
- **Behavioral `personalBaseline` feeder** so `personal_baseline_sufficient` gates only fire once enough real behavior is observed.
- **Three persona default packs** (`compileTaskDefinition`): a soft-only low-energy escalation profile (overwhelmed/depressed), an ADHD body-double "start-now" check-in fired `during_window` with `subject_updated` completion, and an object-permanence watcher that re-surfaces overdue items. **A review-caught runtime bug** was fixed here too: the packs referenced an unregistered `escalation.ladderKey` the runner rejects at schedule time (would have thrown for anyone scheduling them) — replaced with inline soft-only steps, caught by a real-runner simulation test.

### Verification (real, headless)
- `plugins/plugin-scheduling` test: **238 passed** (+3 for defer/allow/first-wins gate semantics).
- `plugins/plugin-personal-assistant` slice files: **101 passed** across 7 files (window-learning 13, activity-gates 11, persona-packs 10, persona-packs.simulation 5, proactive-worker 15, default-packs schema+seeding 47). Typechecks (`tsgo`/`tsc`) exit 0.
- **Inverted-window regression proven:** reverting the guard makes the 3 new window tests fail (`expected {start:'22:00',end:'01:00'} to be undefined`); restored, 13/13 pass.
- Adversarial review: 5 findings confirmed (inverted window, unguarded await, deny-not-defer fallback, unproven scenario, missing writer/gate test coverage) — **all fixed** and re-verified; added real behavioral unit + simulation tests that drive the actual runner (not the un-bootable end-to-end scenario).

### `PR_EVIDENCE.md` rows
- **The end-to-end tick scenario boot is CI-gated**, not run here: it fails before any turn on a pre-existing shared-tree packaging gap (`@elizaos/core/contracts/first-run-options` has no emitted `dist/*.js` + no `eliza-source` fallback; the reference CI scenario fails the same boot on a different missing dep). The scheduler firing/gating/escalation behavior it targets **is proven headlessly** by the unit + real-runner simulation tests above. Marked honestly in `.github/issue-evidence/12186-behaviors-status.md`.
- **Live-model-gated (N/A here, recipe in the status file):** GEPA agent optimization + real-LLM persona trajectories need a model key (Cerebras `gpt-oss-120b`), absent in this headless env. **Frontend evidence:** N/A — LifeOps is chat + scheduler, no UI surface added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
