### PR TITLE
refactor(ui): data-drive connector setup modes from declared metadata (#12094 item 1)

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -3,8 +3,8 @@ import {
   type ConnectorManagementMode,
   connectorAccountManagementPanelPluginId,
   getConnectorPluginManagedAccountOption,
-  normalizeConnectorCatalogId,
 } from "./connector-account-options";
+import { getDeclaredConnectorModes } from "./connector-mode-registry";
 
 export type ConnectorMode = {
   id: string;
@@ -33,221 +33,31 @@ function withPluginManagedMode(
 }
 
 /**
- * Returns available modes for each connector based on deployment context.
+ * Returns available modes for a connector, rendered generically from the modes
+ * the connector plugin declared in the connector-mode registry. Cloud-only
+ * modes are filtered out when Eliza Cloud is not connected.
  */
 export function getConnectorModes(
   connectorId: string,
   options?: { elizaCloudConnected?: boolean },
 ): ConnectorMode[] {
   const cloud = options?.elizaCloudConnected ?? false;
-  const normalizedConnectorId = normalizeConnectorCatalogId(connectorId);
-
-  switch (normalizedConnectorId) {
-    case "discord":
-      return withPluginManagedMode(connectorId, [
-        ...(cloud
-          ? [
-              {
-                id: "managed",
-                label: "OAuth Gateway",
-                labelKey: "connectormode.discord.managed.label",
-                description:
-                  "Invite the shared Eliza Cloud Discord gateway, nickname it to your agent, and route messages down to this app.",
-                descriptionKey: "connectormode.discord.managed.description",
-                managementMode: "cloud-managed" as const,
-              },
-            ]
-          : []),
-        {
-          id: "local",
-          label: "Desktop App",
-          labelKey: "connectormode.discord.local.label",
-          description: "Connect via local Discord desktop app (IPC)",
-          descriptionKey: "connectormode.discord.local.description",
-          managementMode: "local-setup",
-        },
-        {
-          id: "bot",
-          label: "Bot Token",
-          labelKey: "connectormode.discord.bot.label",
-          description:
-            "Use your own Discord bot with a token from the Developer Portal",
-          descriptionKey: "connectormode.discord.bot.description",
-          managementMode: "local-config",
-        },
-      ]);
-
-    case "telegram":
-      return withPluginManagedMode(connectorId, [
-        ...(cloud
-          ? [
-              {
-                id: "cloud-bot",
-                label: "Cloud Gateway",
-                labelKey: "connectormode.telegram.cloudBot.label",
-                description:
-                  "Telegram bot communication still starts with a BotFather token; Eliza Cloud can host the webhook and route it to this app.",
-                descriptionKey: "connectormode.telegram.cloudBot.description",
-                managementMode: "cloud-managed" as const,
-              },
-            ]
-          : []),
-        {
-          id: "bot",
-          label: "Bot Token",
-          labelKey: "connectormode.telegram.bot.label",
-          description: "Create a bot via @BotFather and paste the token",
-          descriptionKey: "connectormode.telegram.bot.description",
-          managementMode: "local-config",
-        },
-        {
-          id: "account",
-          label: "Personal Account",
-          labelKey: "connectormode.telegram.account.label",
-          description:
-            "Use your own Telegram account (requires app credentials from my.telegram.org)",
-          descriptionKey: "connectormode.telegram.account.description",
-          managementMode: "local-setup",
-        },
-      ]);
-
-    case "slack":
-      return withPluginManagedMode(connectorId, [
-        ...(cloud
-          ? [
-              {
-                id: "oauth",
-                label: "OAuth",
-                labelKey: "connectormode.slack.oauth.label",
-                description:
-                  "Connect Slack through Eliza Cloud OAuth for workspace-scoped bidirectional access.",
-                descriptionKey: "connectormode.slack.oauth.description",
-                managementMode: "cloud-managed" as const,
-              },
-            ]
-          : []),
-        {
-          id: "socket",
-          label: "Socket Mode Tokens",
-          labelKey: "connectormode.slack.socket.label",
-          description:
-            "Use your own Slack app token and bot token for the local connector runtime.",
-          descriptionKey: "connectormode.slack.socket.description",
-          managementMode: "local-config",
-        },
-      ]);
-
-    case "x":
-    case "twitter":
-      return withPluginManagedMode(connectorId, [
-        ...(cloud
-          ? [
-              {
-                id: "oauth",
-                label: "OAuth",
-                labelKey: "connectormode.x.oauth.label",
-                description:
-                  "Connect X/Twitter through Eliza Cloud OAuth so the agent can post, read mentions, and handle DMs through cloud-held tokens.",
-                descriptionKey: "connectormode.x.oauth.description",
-                managementMode: "cloud-managed" as const,
-              },
-            ]
-          : []),
-        {
-          id: "local-oauth",
-          label: "Local OAuth2",
-          labelKey: "connectormode.x.localOauth.label",
-          description:
-            "Use @elizaos/plugin-x with TWITTER_AUTH_MODE=oauth, a client ID, and a loopback redirect URI.",
-          descriptionKey: "connectormode.x.localOauth.description",
-          managementMode: "local-config",
-        },
-        {
-          id: "developer",
-          label: "Developer Tokens",
-          labelKey: "connectormode.x.developer.label",
-          description:
-            "Use OAuth 1.0a API keys and access tokens from the X Developer Portal.",
-          descriptionKey: "connectormode.x.developer.description",
-          managementMode: "local-config",
-        },
-      ]);
-
-    case "signal":
-      return withPluginManagedMode(connectorId, [
-        {
-          id: "qr",
-          label: "QR Pair",
-          labelKey: "connectormode.signal.qr.label",
-          description: "Link as a device to your Signal account via QR code",
-          descriptionKey: "connectormode.signal.qr.description",
-          managementMode: "local-setup",
-        },
-      ]);
-
-    case "whatsapp":
-      return withPluginManagedMode(connectorId, [
-        {
-          id: "qr",
-          label: "QR Pair",
-          labelKey: "connectormode.whatsapp.qr.label",
-          description: "Scan a QR code from your WhatsApp mobile app",
-          descriptionKey: "connectormode.whatsapp.qr.description",
-          managementMode: "local-setup",
-        },
-        {
-          id: "business",
-          label: "Business Cloud API",
-          labelKey: "connectormode.whatsapp.business.label",
-          description:
-            "Use WhatsApp Business API with access token and phone number ID",
-          descriptionKey: "connectormode.whatsapp.business.description",
-          managementMode: "local-config",
-        },
-      ]);
-
-    case "imessage":
-      return [
-        {
-          id: "direct",
-          label: "Direct (chat.db)",
-          labelKey: "connectormode.imessage.direct.label",
-          description:
-            "Read iMessage database directly on this Mac. Requires Full Disk Access.",
-          descriptionKey: "connectormode.imessage.direct.description",
-          managementMode: "local-setup",
-        },
-        {
-          id: "bluebubbles",
-          label: "BlueBubbles",
-          labelKey: "connectormode.imessage.bluebubbles.label",
-          description:
-            "Bridge via BlueBubbles server app. Works locally or over network.",
-          descriptionKey: "connectormode.imessage.bluebubbles.description",
-          managementMode: "local-config",
-        },
-        ...(cloud
-          ? [
-              {
-                id: "blooio",
-                label: "Blooio (Cloud)",
-                labelKey: "connectormode.imessage.blooio.label",
-                description:
-                  "Cloud-based iMessage/SMS gateway. No Mac needed on the server.",
-                descriptionKey: "connectormode.imessage.blooio.description",
-                managementMode: "cloud-managed" as const,
-              },
-            ]
-          : []),
-      ];
-
-    default:
-      return withPluginManagedMode(connectorId, []);
-  }
+  const modes: ConnectorMode[] = getDeclaredConnectorModes(connectorId)
+    .filter((mode) => cloud || !mode.cloudOnly)
+    .map((mode) => ({
+      id: mode.id,
+      label: mode.label,
+      description: mode.description,
+      labelKey: mode.labelKey,
+      descriptionKey: mode.descriptionKey,
+      managementMode: mode.managementMode,
+    }));
+  return withPluginManagedMode(connectorId, modes);
 }
 
 /**
- * Maps connector mode to the plugin ID that ConnectorSetupPanel renders.
+ * Maps a connector mode to the plugin ID that ConnectorSetupPanel renders,
+ * from the mode's declared `setupPluginId`.
  */
 export function modeToSetupPluginId(
   connectorId: string,
@@ -256,33 +66,10 @@ export function modeToSetupPluginId(
   if (modeId === CONNECTOR_PLUGIN_MANAGED_MODE_ID) {
     return connectorAccountManagementPanelPluginId(connectorId);
   }
-  const map: Record<string, Record<string, string>> = {
-    discord: { local: "discordlocal", bot: "discord", managed: "discord" },
-    telegram: {
-      "cloud-bot": "telegram",
-      bot: "telegram",
-      account: "telegramaccount",
-    },
-    slack: { oauth: "slack", socket: "slack" },
-    twitter: {
-      oauth: "twitter",
-      "local-oauth": "twitter",
-      developer: "twitter",
-    },
-    x: {
-      oauth: "x",
-      "local-oauth": "x",
-      developer: "x",
-    },
-    signal: { qr: "signal" },
-    whatsapp: { qr: "whatsapp", business: "whatsapp" },
-    imessage: {
-      direct: "imessage",
-      bluebubbles: "bluebubbles",
-      blooio: "blooio",
-    },
-  };
-  return map[normalizeConnectorCatalogId(connectorId)]?.[modeId] ?? null;
+  return (
+    getDeclaredConnectorModes(connectorId).find((mode) => mode.id === modeId)
+      ?.setupPluginId ?? null
+  );
 }
 
 export function getDefaultConnectorModeId(
@@ -292,19 +79,11 @@ export function getDefaultConnectorModeId(
   if (modes.some((mode) => mode.id === CONNECTOR_PLUGIN_MANAGED_MODE_ID)) {
     return CONNECTOR_PLUGIN_MANAGED_MODE_ID;
   }
-  const preferredDefaults: Record<string, string[]> = {
-    discord: ["bot"],
-    slack: ["oauth", "socket"],
-    telegram: ["bot"],
-    x: ["oauth", "local-oauth"],
-    twitter: ["oauth", "local-oauth"],
-  };
-  for (const preferred of preferredDefaults[
-    normalizeConnectorCatalogId(connectorId)
-  ] ?? []) {
-    if (modes.some((mode) => mode.id === preferred)) {
-      return preferred;
-    }
-  }
-  return modes[0]?.id ?? "";
+  const available = new Set(modes.map((mode) => mode.id));
+  const preferred = getDeclaredConnectorModes(connectorId)
+    .filter(
+      (mode) => mode.defaultPriority !== undefined && available.has(mode.id),
+    )
+    .sort((a, b) => (a.defaultPriority ?? 0) - (b.defaultPriority ?? 0))[0];
+  return preferred?.id ?? modes[0]?.id ?? "";
 }

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import { getBootConfig } from "../../config/boot-config";
 import { parseConnectorAccountManagementPanelPluginId } from "./connector-account-options";
+import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 
 export function normalizePluginId(pluginId: string): string {
   return pluginId
@@ -33,7 +34,7 @@ export function hasConnectorSetupPanel(pluginId: string): boolean {
   if (parseConnectorAccountManagementPanelPluginId(pluginId)) {
     return true;
   }
-  // Check registry first
+  // Plugin-registered panels take precedence over the built-in registry.
   if (connectorSetupRegistry.has(normalized)) {
     return true;
   }
@@ -43,21 +44,5 @@ export function hasConnectorSetupPanel(pluginId: string): boolean {
   ) {
     return Boolean(getBootConfig().lifeOpsBrowserSetupPanel);
   }
-  if (normalized.includes("telegramaccount")) {
-    return true;
-  }
-  if (normalized.includes("plugintelegram")) {
-    return true;
-  }
-  switch (normalized) {
-    case "whatsapp":
-    case "signal":
-    case "discordlocal":
-    case "bluebubbles":
-    case "imessage":
-    case "telegram":
-      return true;
-    default:
-      return false;
-  }
+  return resolveConnectorSetupPanelToken(normalized) !== null;
 }

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
@@ -11,6 +11,7 @@ import {
   getConnectorPluginManagedAccountOption,
   parseConnectorAccountManagementPanelPluginId,
 } from "./connector-account-options";
+import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 import { DiscordLocalConnectorPanel } from "./DiscordLocalConnectorPanel";
 import { IMessageStatusPanel } from "./IMessageStatusPanel";
 import { SignalQrOverlay } from "./SignalQrOverlay";
@@ -57,7 +58,7 @@ export function ConnectorSetupPanel({ pluginId }: { pluginId: string }) {
     return <RegisteredPanel />;
   }
 
-  // Fall back to hardcoded components
+  // Fall back to the built-in panels resolved from the setup-panel registry.
   if (
     normalized.includes("lifeopsbrowser") ||
     normalized.includes("browserbridg")
@@ -65,13 +66,11 @@ export function ConnectorSetupPanel({ pluginId }: { pluginId: string }) {
     const BrowserBridgeSetupPanel = getBootConfig().lifeOpsBrowserSetupPanel;
     return BrowserBridgeSetupPanel ? <BrowserBridgeSetupPanel /> : null;
   }
-  if (normalized.includes("telegramaccount")) {
-    return <TelegramAccountConnectorPanel />;
-  }
-  if (normalized.includes("plugintelegram")) {
-    return <TelegramBotSetupPanel />;
-  }
-  switch (normalized) {
+  switch (resolveConnectorSetupPanelToken(normalized)) {
+    case "telegram-account":
+      return <TelegramAccountConnectorPanel />;
+    case "telegram-bot":
+      return <TelegramBotSetupPanel />;
     case "whatsapp":
       return (
         <ConnectorAccountSetupScope provider="whatsapp" connectorId={pluginId}>
@@ -88,14 +87,12 @@ export function ConnectorSetupPanel({ pluginId }: { pluginId: string }) {
           )}
         </ConnectorAccountSetupScope>
       );
-    case "discordlocal":
+    case "discord-local":
       return <DiscordLocalConnectorPanel />;
     case "bluebubbles":
       return <BlueBubblesStatusPanel />;
     case "imessage":
       return <IMessageStatusPanel />;
-    case "telegram":
-      return <TelegramBotSetupPanel />;
     default:
       return null;
   }

--- a/packages/ui/src/components/connectors/connector-mode-registry.test.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  getConnectorModes,
+  getDefaultConnectorModeId,
+  modeToSetupPluginId,
+} from "./ConnectorModeSelector.helpers";
+import { hasConnectorSetupPanel } from "./ConnectorSetupPanel.helpers";
+import {
+  type ConnectorModeDeclaration,
+  registerConnectorModes,
+} from "./connector-mode-registry";
+
+/**
+ * Seam test for #12094 item 1: the connector setup mode list and copy must come
+ * from plugin-declared metadata, not a per-connector switch in the ui package.
+ * A connector plugin whose id appears nowhere in ui source can register its
+ * modes and get a fully functioning mode selector.
+ */
+describe("connector mode registry seam", () => {
+  it("renders a connector absent from ui source purely from its declared modes", () => {
+    // "acmechat" is a fictional connector plugin — it is not referenced in any
+    // switch or map in the ui package. It only exists via registration.
+    const declared: ConnectorModeDeclaration[] = [
+      {
+        id: "cloud",
+        label: "Acme Cloud",
+        description: "Route Acme Chat through the Acme Cloud gateway.",
+        managementMode: "cloud-managed",
+        setupPluginId: "acmechat",
+        cloudOnly: true,
+        defaultPriority: 1,
+      },
+      {
+        id: "token",
+        label: "API Token",
+        description: "Use an Acme Chat API token from the developer console.",
+        managementMode: "local-config",
+        setupPluginId: "acmechat",
+        defaultPriority: 2,
+      },
+    ];
+    registerConnectorModes("@elizaos/plugin-acmechat", declared);
+
+    // Cloud disconnected: the cloud-only mode is filtered out, leaving the
+    // declared token mode — no hardcoded branch required.
+    const offline = getConnectorModes("acmechat", {
+      elizaCloudConnected: false,
+    });
+    expect(offline.map((mode) => mode.id)).toEqual(["token"]);
+    expect(offline[0]?.label).toBe("API Token");
+    expect(offline[0]?.managementMode).toBe("local-config");
+
+    // Cloud connected: both declared modes render in declared order.
+    const online = getConnectorModes("acmechat", { elizaCloudConnected: true });
+    expect(online.map((mode) => mode.id)).toEqual(["cloud", "token"]);
+
+    // Setup routing and default selection derive from the declaration.
+    expect(modeToSetupPluginId("acmechat", "token")).toBe("acmechat");
+    expect(modeToSetupPluginId("acmechat", "cloud")).toBe("acmechat");
+    expect(getDefaultConnectorModeId("acmechat", online)).toBe("cloud");
+    expect(getDefaultConnectorModeId("acmechat", offline)).toBe("token");
+
+    // The connector id is accepted in its raw namespaced form too.
+    expect(
+      getConnectorModes("@elizaos/plugin-acmechat", {}).map((mode) => mode.id),
+    ).toEqual(["token"]);
+  });
+
+  it("preserves the built-in Discord modes (cloud gating + default)", () => {
+    const offline = getConnectorModes("discord", {
+      elizaCloudConnected: false,
+    });
+    expect(offline.map((mode) => mode.id)).toEqual(["local", "bot"]);
+    expect(getDefaultConnectorModeId("discord", offline)).toBe("bot");
+
+    const online = getConnectorModes("discord", { elizaCloudConnected: true });
+    expect(online.map((mode) => mode.id)).toEqual(["managed", "local", "bot"]);
+    expect(modeToSetupPluginId("discord", "local")).toBe("discordlocal");
+    expect(modeToSetupPluginId("discord", "bot")).toBe("discord");
+  });
+
+  it("treats twitter as an alias of x (dead case is gone, not the behavior)", () => {
+    expect(getConnectorModes("twitter", {}).map((m) => m.id)).toEqual(
+      getConnectorModes("x", {}).map((m) => m.id),
+    );
+    expect(modeToSetupPluginId("twitter", "developer")).toBe("x");
+  });
+
+  it("resolves the built-in setup panels for declared local-setup modes", () => {
+    expect(hasConnectorSetupPanel("discordlocal")).toBe(true);
+    expect(hasConnectorSetupPanel("telegramaccount")).toBe(true);
+    expect(hasConnectorSetupPanel("bluebubbles")).toBe(true);
+    // A namespaced telegram plugin id still resolves to the bot panel.
+    expect(hasConnectorSetupPanel("@elizaos/plugin-telegram")).toBe(true);
+    // A connector with no built-in panel and no declared modes stays false.
+    expect(hasConnectorSetupPanel("acmechat")).toBe(false);
+    expect(getConnectorModes("farcaster", {})).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -1,0 +1,275 @@
+import {
+  type ConnectorManagementMode,
+  normalizeConnectorCatalogId,
+} from "./connector-account-options";
+
+/**
+ * Declarative description of a single connector setup mode.
+ *
+ * This is the metadata a connector plugin declares (in its registry entry /
+ * manifest) so the setup UI can render its mode selector generically. The
+ * previous implementation hardcoded one giant `switch (connectorId)` in
+ * `ConnectorModeSelector.helpers.ts`; a new or renamed connector plugin fell
+ * through to an empty mode list with no setup UI. Declarations now live in this
+ * registry — built-ins are seeded below, and any plugin can register its own
+ * via {@link registerConnectorModes}, mirroring the sanctioned
+ * `registerConnectorSetupPanel` pattern already used for panels.
+ */
+export interface ConnectorModeDeclaration {
+  /** Mode id, unique within a connector. */
+  id: string;
+  label: string;
+  description: string;
+  labelKey?: string;
+  descriptionKey?: string;
+  managementMode?: ConnectorManagementMode;
+  /**
+   * Plugin id whose `ConnectorSetupPanel` renders this mode's setup surface.
+   * When it equals the connector id the generic env-var config form is used.
+   */
+  setupPluginId: string;
+  /** Mode is only offered when Eliza Cloud is connected. */
+  cloudOnly?: boolean;
+  /**
+   * Preference rank when picking the default selected mode (lower wins). Ties
+   * are broken by declaration order. Modes without a rank are never chosen as
+   * the default unless no ranked mode is available.
+   */
+  defaultPriority?: number;
+}
+
+const registry = new Map<string, readonly ConnectorModeDeclaration[]>();
+
+/**
+ * Register the setup modes a connector plugin declares. The connector id is
+ * normalized (`@elizaos/plugin-x` / `twitter` → `x`, etc.) before storage, so
+ * callers can pass raw plugin ids. Re-registering a connector replaces its
+ * declared modes.
+ */
+export function registerConnectorModes(
+  connectorId: string,
+  modes: readonly ConnectorModeDeclaration[],
+): void {
+  registry.set(normalizeConnectorCatalogId(connectorId), modes);
+}
+
+/**
+ * Returns the modes a connector has declared, or an empty list when the
+ * connector is unknown to the registry (it then falls back to its generic
+ * credential form, matching the pre-registry behavior for connectors with no
+ * declared mode list).
+ */
+export function getDeclaredConnectorModes(
+  connectorId: string,
+): readonly ConnectorModeDeclaration[] {
+  return registry.get(normalizeConnectorCatalogId(connectorId)) ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Built-in connector mode declarations.
+//
+// These seed the modes that used to be hardcoded in the `getConnectorModes`
+// switch. Ordering is significant — it is the exact order modes are presented
+// (cloud-only modes are filtered out when Eliza Cloud is not connected, keeping
+// their declared position). The plugin-managed mode is injected separately by
+// `withPluginManagedMode` from the connector-account catalog, so it is not
+// declared here.
+// ---------------------------------------------------------------------------
+
+registerConnectorModes("discord", [
+  {
+    id: "managed",
+    label: "OAuth Gateway",
+    labelKey: "connectormode.discord.managed.label",
+    description:
+      "Invite the shared Eliza Cloud Discord gateway, nickname it to your agent, and route messages down to this app.",
+    descriptionKey: "connectormode.discord.managed.description",
+    managementMode: "cloud-managed",
+    setupPluginId: "discord",
+    cloudOnly: true,
+  },
+  {
+    id: "local",
+    label: "Desktop App",
+    labelKey: "connectormode.discord.local.label",
+    description: "Connect via local Discord desktop app (IPC)",
+    descriptionKey: "connectormode.discord.local.description",
+    managementMode: "local-setup",
+    setupPluginId: "discordlocal",
+  },
+  {
+    id: "bot",
+    label: "Bot Token",
+    labelKey: "connectormode.discord.bot.label",
+    description:
+      "Use your own Discord bot with a token from the Developer Portal",
+    descriptionKey: "connectormode.discord.bot.description",
+    managementMode: "local-config",
+    setupPluginId: "discord",
+    defaultPriority: 1,
+  },
+]);
+
+registerConnectorModes("telegram", [
+  {
+    id: "cloud-bot",
+    label: "Cloud Gateway",
+    labelKey: "connectormode.telegram.cloudBot.label",
+    description:
+      "Telegram bot communication still starts with a BotFather token; Eliza Cloud can host the webhook and route it to this app.",
+    descriptionKey: "connectormode.telegram.cloudBot.description",
+    managementMode: "cloud-managed",
+    setupPluginId: "telegram",
+    cloudOnly: true,
+  },
+  {
+    id: "bot",
+    label: "Bot Token",
+    labelKey: "connectormode.telegram.bot.label",
+    description: "Create a bot via @BotFather and paste the token",
+    descriptionKey: "connectormode.telegram.bot.description",
+    managementMode: "local-config",
+    setupPluginId: "telegram",
+    defaultPriority: 1,
+  },
+  {
+    id: "account",
+    label: "Personal Account",
+    labelKey: "connectormode.telegram.account.label",
+    description:
+      "Use your own Telegram account (requires app credentials from my.telegram.org)",
+    descriptionKey: "connectormode.telegram.account.description",
+    managementMode: "local-setup",
+    setupPluginId: "telegramaccount",
+  },
+]);
+
+registerConnectorModes("slack", [
+  {
+    id: "oauth",
+    label: "OAuth",
+    labelKey: "connectormode.slack.oauth.label",
+    description:
+      "Connect Slack through Eliza Cloud OAuth for workspace-scoped bidirectional access.",
+    descriptionKey: "connectormode.slack.oauth.description",
+    managementMode: "cloud-managed",
+    setupPluginId: "slack",
+    cloudOnly: true,
+    defaultPriority: 1,
+  },
+  {
+    id: "socket",
+    label: "Socket Mode Tokens",
+    labelKey: "connectormode.slack.socket.label",
+    description:
+      "Use your own Slack app token and bot token for the local connector runtime.",
+    descriptionKey: "connectormode.slack.socket.description",
+    managementMode: "local-config",
+    setupPluginId: "slack",
+    defaultPriority: 2,
+  },
+]);
+
+registerConnectorModes("x", [
+  {
+    id: "oauth",
+    label: "OAuth",
+    labelKey: "connectormode.x.oauth.label",
+    description:
+      "Connect X/Twitter through Eliza Cloud OAuth so the agent can post, read mentions, and handle DMs through cloud-held tokens.",
+    descriptionKey: "connectormode.x.oauth.description",
+    managementMode: "cloud-managed",
+    setupPluginId: "x",
+    cloudOnly: true,
+    defaultPriority: 1,
+  },
+  {
+    id: "local-oauth",
+    label: "Local OAuth2",
+    labelKey: "connectormode.x.localOauth.label",
+    description:
+      "Use @elizaos/plugin-x with TWITTER_AUTH_MODE=oauth, a client ID, and a loopback redirect URI.",
+    descriptionKey: "connectormode.x.localOauth.description",
+    managementMode: "local-config",
+    setupPluginId: "x",
+    defaultPriority: 2,
+  },
+  {
+    id: "developer",
+    label: "Developer Tokens",
+    labelKey: "connectormode.x.developer.label",
+    description:
+      "Use OAuth 1.0a API keys and access tokens from the X Developer Portal.",
+    descriptionKey: "connectormode.x.developer.description",
+    managementMode: "local-config",
+    setupPluginId: "x",
+  },
+]);
+
+registerConnectorModes("signal", [
+  {
+    id: "qr",
+    label: "QR Pair",
+    labelKey: "connectormode.signal.qr.label",
+    description: "Link as a device to your Signal account via QR code",
+    descriptionKey: "connectormode.signal.qr.description",
+    managementMode: "local-setup",
+    setupPluginId: "signal",
+  },
+]);
+
+registerConnectorModes("whatsapp", [
+  {
+    id: "qr",
+    label: "QR Pair",
+    labelKey: "connectormode.whatsapp.qr.label",
+    description: "Scan a QR code from your WhatsApp mobile app",
+    descriptionKey: "connectormode.whatsapp.qr.description",
+    managementMode: "local-setup",
+    setupPluginId: "whatsapp",
+  },
+  {
+    id: "business",
+    label: "Business Cloud API",
+    labelKey: "connectormode.whatsapp.business.label",
+    description:
+      "Use WhatsApp Business API with access token and phone number ID",
+    descriptionKey: "connectormode.whatsapp.business.description",
+    managementMode: "local-config",
+    setupPluginId: "whatsapp",
+  },
+]);
+
+registerConnectorModes("imessage", [
+  {
+    id: "direct",
+    label: "Direct (chat.db)",
+    labelKey: "connectormode.imessage.direct.label",
+    description:
+      "Read iMessage database directly on this Mac. Requires Full Disk Access.",
+    descriptionKey: "connectormode.imessage.direct.description",
+    managementMode: "local-setup",
+    setupPluginId: "imessage",
+  },
+  {
+    id: "bluebubbles",
+    label: "BlueBubbles",
+    labelKey: "connectormode.imessage.bluebubbles.label",
+    description:
+      "Bridge via BlueBubbles server app. Works locally or over network.",
+    descriptionKey: "connectormode.imessage.bluebubbles.description",
+    managementMode: "local-config",
+    setupPluginId: "bluebubbles",
+  },
+  {
+    id: "blooio",
+    label: "Blooio (Cloud)",
+    labelKey: "connectormode.imessage.blooio.label",
+    description:
+      "Cloud-based iMessage/SMS gateway. No Mac needed on the server.",
+    descriptionKey: "connectormode.imessage.blooio.description",
+    managementMode: "cloud-managed",
+    setupPluginId: "blooio",
+    cloudOnly: true,
+  },
+]);

--- a/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
+++ b/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
@@ -1,0 +1,102 @@
+/**
+ * Registry that resolves a connector setup-plugin id to the token of the
+ * built-in setup panel that renders it. This replaces the per-connector-id
+ * `switch` that used to live in both `ConnectorSetupPanel.helpers.ts`
+ * (`hasConnectorSetupPanel`) and `ConnectorSetupPanel.tsx` (component render).
+ *
+ * Keeping the id → token rules in one pure module (no React) lets the boolean
+ * `hasConnectorSetupPanel` check and the component render share a single source
+ * of truth instead of two parallel switches that had to be kept in sync.
+ *
+ * Matching preserves the historical semantics exactly:
+ *  - `exact`: the normalized id equals the needle (the old `switch` cases).
+ *  - `substring`: the normalized id contains the needle (the old `.includes`
+ *    checks that catch namespaced plugin ids such as
+ *    `@elizaos/plugin-telegram` → `elizaosplugintelegram`).
+ * Rules are evaluated in registration order; the first match wins.
+ */
+export type ConnectorSetupPanelToken =
+  | "telegram-account"
+  | "telegram-bot"
+  | "whatsapp"
+  | "signal"
+  | "discord-local"
+  | "bluebubbles"
+  | "imessage";
+
+type MatchKind = "exact" | "substring";
+
+interface ConnectorSetupPanelRule {
+  token: ConnectorSetupPanelToken;
+  needle: string;
+  match: MatchKind;
+}
+
+const rules: ConnectorSetupPanelRule[] = [];
+
+export function registerConnectorSetupPanelRule(
+  rule: ConnectorSetupPanelRule,
+): void {
+  rules.push(rule);
+}
+
+/**
+ * Resolve a normalized plugin id to a built-in setup-panel token, or `null`
+ * when no built-in panel handles it.
+ */
+export function resolveConnectorSetupPanelToken(
+  normalizedId: string,
+): ConnectorSetupPanelToken | null {
+  for (const rule of rules) {
+    const matched =
+      rule.match === "exact"
+        ? normalizedId === rule.needle
+        : normalizedId.includes(rule.needle);
+    if (matched) return rule.token;
+  }
+  return null;
+}
+
+// Built-in rules. Order mirrors the previous `hasConnectorSetupPanel`
+// evaluation order (telegram-account and namespaced telegram bot ids before
+// the exact switch cases).
+registerConnectorSetupPanelRule({
+  token: "telegram-account",
+  needle: "telegramaccount",
+  match: "substring",
+});
+registerConnectorSetupPanelRule({
+  token: "telegram-bot",
+  needle: "plugintelegram",
+  match: "substring",
+});
+registerConnectorSetupPanelRule({
+  token: "telegram-bot",
+  needle: "telegram",
+  match: "exact",
+});
+registerConnectorSetupPanelRule({
+  token: "whatsapp",
+  needle: "whatsapp",
+  match: "exact",
+});
+registerConnectorSetupPanelRule({
+  token: "signal",
+  needle: "signal",
+  match: "exact",
+});
+registerConnectorSetupPanelRule({
+  token: "discord-local",
+  needle: "discordlocal",
+  match: "exact",
+});
+registerConnectorSetupPanelRule({
+  token: "bluebubbles",
+  needle: "bluebubbles",
+  match: "exact",
+});
+registerConnectorSetupPanelRule({
+  token: "imessage",
+  needle: "imessage",
+  match: "exact",
+});


### PR DESCRIPTION
## What

Item 1 of #12094 (arch-audit: top-down plugin knowledge in upper layers). Cut fresh against current `develop` — does not reuse the superseded PR #12289.

`ConnectorModeSelector.helpers.ts` had a giant `switch (connectorId)` hardcoding every connector plugin's setup modes, labels, descriptions, setup-plugin-id maps, and default-mode preferences; `ConnectorSetupPanel.helpers.ts` had a parallel `switch` for panel availability. A new/renamed connector plugin fell through to an empty mode list with no setup UI.

## Change

- New `connector-mode-registry.ts`: declarative `ConnectorModeDeclaration` metadata + `registerConnectorModes()` / `getDeclaredConnectorModes()`, seeded with the built-in connectors. Mirrors the sanctioned `registerConnectorSetupPanel` registry pattern.
- `ConnectorModeSelector.helpers.ts`: `getConnectorModes` / `modeToSetupPluginId` / `getDefaultConnectorModeId` now render the declared list generically (cloud-only filtering, `setupPluginId`, `defaultPriority`). No connector-id switch/case or per-connector map literals remain.
- New pure `connector-setup-panel-registry.ts`: id → panel-token resolver (exact + substring rules preserving the old `.includes` semantics for namespaced ids). `hasConnectorSetupPanel` and `ConnectorSetupPanel.tsx` share this single source instead of two parallel switches.
- Dead `case "twitter"` / `map.twitter` entries collapse into the `x` alias (already what `normalizeConnectorCatalogId` produced).

No behavior change. The previously-dead twitter branches are proven equivalent to the `x` alias by test.

## Done-when (item 1)

- [x] All connector-id switch/case and per-connector map literals removed from `ConnectorModeSelector.helpers.ts` and `ConnectorSetupPanel.helpers.ts` (`grep -nE 'switch \(|case "'` → none; no `"discord"/"telegram"/…` literals).
- [x] A connector plugin absent from ui source still gets a functioning mode selector from its declared modes — new seam test registers a fictional `acmechat` connector and asserts modes/setup-routing/default all resolve with no hardcoded branch.

## Verification

- `packages/ui` typecheck clean; `packages/ui` build clean; biome clean on touched files.
- `vitest` connectors + settings routing + plugin-view-connectors render: 45 passed (5 files), including the new `connector-mode-registry.test.ts` seam test and the existing `ConnectorsSection.routing.test.ts` regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)