### PR TITLE
fix(agent): migrate provider role gating to Provider.roleGate; delete fail-open PROVIDER_ROLE_OVERRIDES (#12094 item 3)

### DIFF
--- a/packages/agent/src/runtime/plugin-lifecycle.ts
+++ b/packages/agent/src/runtime/plugin-lifecycle.ts
@@ -690,7 +690,7 @@ function installPluginViewSync(runtime: RuntimeWithPluginLifecycle): void {
       // went through registerPlugin but never the boot gating pass, so their
       // owner-tier providers were exposed to any sender. This runs inside the try,
       // so a gating failure fails closed — the plugin is unloaded, not left with
-      // ungated providers. gateProvider is idempotent, so boot plugins already
+      // ungated providers. provider gating is idempotent, so boot plugins already
       // covered by the boot pass are unaffected.
       applyPluginRoleGating([plugin]);
       await migratePluginSchemasIfReady(runtime, plugin);

--- a/packages/agent/src/runtime/plugin-role-gating-chokepoint.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating-chokepoint.test.ts
@@ -70,9 +70,10 @@ function message(metadata: Record<string, unknown> = {}): Memory {
   } as Memory;
 }
 
-function provider(name: string): Provider {
+function provider(name: string, minRole?: string): Provider {
   return {
     name,
+    ...(minRole ? { roleGate: { minRole } } : {}),
     get: vi.fn(async () => ({ text: `${name}: visible` })),
   } as unknown as Provider;
 }
@@ -106,15 +107,16 @@ describe("registerPlugin chokepoint gates post-boot plugins", () => {
 
   it("gates a plugin registered AFTER boot identically to a boot-registered one", async () => {
     // "boot" plugin — registered during the initial gating pass.
-    const bootProvider = provider("SECRETS_STATUS"); // admin tier
+    const bootProvider = provider("SECRETS_STATUS", "ADMIN"); // admin-gated
     await registerViaChokepoint(
       pluginWithProviders("boot-plugin", [bootProvider]),
     );
 
     // "post-boot" plugin — the exact hot-install path: a later
-    // runtime.registerPlugin with a wallet/secrets provider. Before the fix this
-    // plugin bypassed gating entirely and leaked owner-tier context to everyone.
-    const hotProvider = provider("walletPortfolio"); // owner tier
+    // runtime.registerPlugin with an owner-gated provider. Before the chokepoint
+    // this plugin bypassed gating entirely and leaked owner-tier context to
+    // everyone.
+    const hotProvider = provider("wallet", "OWNER"); // owner-gated
     await registerViaChokepoint(
       pluginWithProviders("hot-wallet-plugin", [hotProvider]),
     );
@@ -136,9 +138,7 @@ describe("registerPlugin chokepoint gates post-boot plugins", () => {
     expect(await callGet(hotProvider, "GUEST")).toBe("");
     expect(await callGet(hotProvider, "USER")).toBe("");
     expect(await callGet(hotProvider, "ADMIN")).toBe("");
-    expect(await callGet(hotProvider, "OWNER")).toBe(
-      "walletPortfolio: visible",
-    );
+    expect(await callGet(hotProvider, "OWNER")).toBe("wallet: visible");
   });
 
   it("leaves non-sensitive providers untouched", async () => {
@@ -151,12 +151,15 @@ describe("registerPlugin chokepoint gates post-boot plugins", () => {
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
 
     // A sensitive provider whose `get` is a read-only data property, so
-    // gateProvider's reassignment throws. The fail-closed path must withhold it
+    // the wrap path.s reassignment throws. The fail-closed path must withhold it
     // rather than register it exposed.
     const original = vi.fn(
-      async (): Promise<ProviderResult> => ({ text: "walletPortfolio: leak" }),
+      async (): Promise<ProviderResult> => ({ text: "wallet: leak" }),
     );
-    const locked = { name: "walletPortfolio" } as unknown as Provider;
+    const locked = {
+      name: "wallet",
+      roleGate: { minRole: "OWNER" },
+    } as unknown as Provider;
     Object.defineProperty(locked, "get", {
       value: original,
       writable: false,

--- a/packages/agent/src/runtime/plugin-role-gating-registration.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating-registration.test.ts
@@ -8,9 +8,10 @@ import { installRuntimePluginLifecycle } from "./plugin-lifecycle.ts";
  * REGISTERS (via the plugin-lifecycle registerPlugin wrapper), not only in the
  * one-shot boot pass. Otherwise a plugin hot-installed after boot (plugin
  * manager / VFS) went through registerPlugin but never the boot gating pass, so
- * its owner/admin-tier providers (SECRETS_STATUS, walletPortfolio, shellHistory)
- * stayed exposed to any sender. The `__roleGate` marker proves gateProvider
- * wrapped the provider at registration.
+ * its owner/admin-tier providers (SECRETS_STATUS, wallet, SHELL_HISTORY)
+ * stayed exposed to any sender. Gating is driven by the provider's own declared
+ * `roleGate`; the `__roleGate` marker proves the provider was wrapped at
+ * registration.
  */
 function pluginWith(providers: Provider[], name = "hot-installed"): Plugin {
   return { name, description: "hot plugin", providers };
@@ -24,25 +25,27 @@ describe("provider role gating on post-boot plugin registration (#12087 Item 1)"
     const secrets = {
       name: "SECRETS_STATUS",
       description: "secrets",
+      roleGate: { minRole: "ADMIN" },
       get: async () => ({ text: "SENSITIVE" }),
     } as Provider;
     await runtime.registerPlugin(pluginWith([secrets], "hot-secrets"));
 
-    expect((secrets as { __roleGate?: string }).__roleGate).toBe("admin");
+    expect((secrets as { __roleGate?: string }).__roleGate).toBe("ADMIN");
   });
 
-  it("gates an owner-tier provider (walletPortfolio) on registration", async () => {
+  it("gates an owner-tier provider on registration", async () => {
     const runtime = createTestRuntime();
     installRuntimePluginLifecycle(runtime);
 
     const wallet = {
-      name: "walletPortfolio",
+      name: "wallet",
       description: "wallet",
+      roleGate: { minRole: "OWNER" },
       get: async () => ({ text: "0x…balance" }),
     } as Provider;
     await runtime.registerPlugin(pluginWith([wallet], "hot-wallet"));
 
-    expect((wallet as { __roleGate?: string }).__roleGate).toBe("owner");
+    expect((wallet as { __roleGate?: string }).__roleGate).toBe("OWNER");
   });
 
   it("leaves a non-sensitive provider un-wrapped", async () => {

--- a/packages/agent/src/runtime/plugin-role-gating.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.test.ts
@@ -3,9 +3,10 @@ import type {
   Memory,
   Plugin,
   Provider,
+  ProviderResult,
   State,
 } from "@elizaos/core";
-import { roleRank } from "@elizaos/core";
+import { logger } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const rolesMock = vi.hoisted(() => ({
@@ -14,11 +15,7 @@ const rolesMock = vi.hoisted(() => ({
 
 vi.mock("./roles.ts", () => rolesMock);
 
-import {
-  applyPluginRoleGating,
-  PROVIDER_ROLE_OVERRIDES,
-  TIER_TO_CANONICAL_ROLE,
-} from "./plugin-role-gating.ts";
+import { applyPluginRoleGating } from "./plugin-role-gating.ts";
 
 const runtime = {
   agentId: "11111111-1111-1111-1111-111111111111",
@@ -34,7 +31,17 @@ function message(metadata: Record<string, unknown> = {}): Memory {
   } as Memory;
 }
 
-function provider(name: string): Provider {
+/** A sensitive provider that declares its own gate — the only thing that gates. */
+function gatedProvider(name: string, minRole: string): Provider {
+  return {
+    name,
+    roleGate: { minRole },
+    get: vi.fn(async () => ({ text: `${name}: visible` })),
+  } as unknown as Provider;
+}
+
+/** A provider with NO declared gate — must stay public. */
+function plainProvider(name: string): Provider {
   return {
     name,
     get: vi.fn(async () => ({ text: `${name}: visible` })),
@@ -48,7 +55,7 @@ function pluginWithProviders(providers: Provider[]): Plugin {
   } as Plugin;
 }
 
-describe("applyPluginRoleGating", () => {
+describe("applyPluginRoleGating — in-flight role-check dedup", () => {
   beforeEach(() => {
     rolesMock.checkSenderRole.mockReset();
   });
@@ -62,7 +69,10 @@ describe("applyPluginRoleGating", () => {
           }, 10);
         }),
     );
-    const providers = [provider("SECRETS_STATUS"), provider("MISSING_SECRETS")];
+    const providers = [
+      gatedProvider("SECRETS_STATUS", "ADMIN"),
+      gatedProvider("MISSING_SECRETS", "ADMIN"),
+    ];
     applyPluginRoleGating([pluginWithProviders(providers)]);
 
     const results = await Promise.all(
@@ -82,18 +92,18 @@ describe("applyPluginRoleGating", () => {
     rolesMock.checkSenderRole
       .mockResolvedValueOnce({ role: "ADMIN", isOwner: false, isAdmin: true })
       .mockResolvedValueOnce({ role: "GUEST", isOwner: false, isAdmin: false });
-    const gatedProvider = provider("SECRETS_STATUS");
-    applyPluginRoleGating([pluginWithProviders([gatedProvider])]);
+    const provider = gatedProvider("SECRETS_STATUS", "ADMIN");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
 
     await expect(
-      gatedProvider.get?.(
+      provider.get?.(
         runtime,
         message({ fromId: "discord-user-1" }),
         {} as State,
       ),
     ).resolves.toMatchObject({ text: "SECRETS_STATUS: visible" });
     await expect(
-      gatedProvider.get?.(
+      provider.get?.(
         runtime,
         message({ fromId: "discord-user-1" }),
         {} as State,
@@ -109,16 +119,16 @@ describe("applyPluginRoleGating", () => {
       isOwner: false,
       isAdmin: true,
     });
-    const gatedProvider = provider("SECRETS_STATUS");
-    applyPluginRoleGating([pluginWithProviders([gatedProvider])]);
+    const provider = gatedProvider("SECRETS_STATUS", "ADMIN");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
 
     await Promise.all([
-      gatedProvider.get?.(
+      provider.get?.(
         runtime,
         message({ fromId: "discord-user-1" }),
         {} as State,
       ),
-      gatedProvider.get?.(
+      provider.get?.(
         runtime,
         message({ fromId: "discord-user-2" }),
         {} as State,
@@ -129,79 +139,13 @@ describe("applyPluginRoleGating", () => {
   });
 });
 
-describe("declared provider roleGate is enforced (#12087 Item 14)", () => {
-  beforeEach(() => {
-    rolesMock.checkSenderRole.mockReset();
-  });
-
-  function gatedProvider(name: string, minRole: string): Provider {
-    return {
-      name,
-      roleGate: { minRole },
-      get: vi.fn(async () => ({ text: `${name}: visible` })),
-    } as unknown as Provider;
-  }
-
-  async function textFor(
-    minRole: string,
-    callerRole: string,
-  ): Promise<string | undefined> {
-    rolesMock.checkSenderRole.mockResolvedValue({
-      role: callerRole,
-      isOwner: callerRole === "OWNER",
-      isAdmin: callerRole === "OWNER" || callerRole === "ADMIN",
-    });
-    // A name NOT in PROVIDER_ROLE_OVERRIDES — gating must come from the
-    // provider's own declared roleGate, not the override map.
-    const gated = gatedProvider("NOT_IN_OVERRIDES_PROVIDER", minRole);
-    applyPluginRoleGating([pluginWithProviders([gated])]);
-    const result = await gated.get?.(
-      runtime,
-      message({ fromId: "discord-user-1" }),
-      {} as State,
-    );
-    return result?.text;
-  }
-
-  it("redacts an ADMIN-declared provider for USER, passes for ADMIN", async () => {
-    expect(await textFor("ADMIN", "USER")).toBe("");
-    expect(await textFor("ADMIN", "ADMIN")).toBe(
-      "NOT_IN_OVERRIDES_PROVIDER: visible",
-    );
-  });
-
-  it("passes a USER-declared provider for USER, redacts for GUEST", async () => {
-    expect(await textFor("USER", "USER")).toBe(
-      "NOT_IN_OVERRIDES_PROVIDER: visible",
-    );
-    expect(await textFor("USER", "GUEST")).toBe("");
-  });
-});
-
-describe("override tiers map onto canonical role ranks", () => {
-  it("normalizes each lowercase tier to a canonical role rank", () => {
-    expect(roleRank(TIER_TO_CANONICAL_ROLE.user)).toBe(roleRank("USER"));
-    expect(roleRank(TIER_TO_CANONICAL_ROLE.admin)).toBe(roleRank("ADMIN"));
-    expect(roleRank(TIER_TO_CANONICAL_ROLE.owner)).toBe(roleRank("OWNER"));
-    // The tiers form a strict hierarchy: user < admin < owner.
-    expect(roleRank("USER")).toBeLessThan(roleRank("ADMIN"));
-    expect(roleRank("ADMIN")).toBeLessThan(roleRank("OWNER"));
-  });
-
-  it("only references known tiers in the provider override map", () => {
-    for (const tier of Object.values(PROVIDER_ROLE_OVERRIDES)) {
-      expect(TIER_TO_CANONICAL_ROLE[tier]).toBeDefined();
-    }
-  });
-});
-
-describe("provider gating outcomes follow the canonical gate", () => {
+describe("gating is driven ONLY by the provider's declared roleGate", () => {
   beforeEach(() => {
     rolesMock.checkSenderRole.mockReset();
   });
 
   async function visibleText(
-    providerName: string,
+    provider: Provider,
     callerRole: string,
   ): Promise<string | undefined> {
     rolesMock.checkSenderRole.mockResolvedValue({
@@ -209,9 +153,7 @@ describe("provider gating outcomes follow the canonical gate", () => {
       isOwner: callerRole === "OWNER",
       isAdmin: callerRole === "OWNER" || callerRole === "ADMIN",
     });
-    const gatedProvider = provider(providerName);
-    applyPluginRoleGating([pluginWithProviders([gatedProvider])]);
-    const result = await gatedProvider.get?.(
+    const result = await provider.get?.(
       runtime,
       message({ fromId: "discord-user-1" }),
       {} as State,
@@ -219,35 +161,101 @@ describe("provider gating outcomes follow the canonical gate", () => {
     return result?.text;
   }
 
-  it("redacts an owner-gated provider for GUEST and NONE callers but passes OWNER", async () => {
-    // app_browser_workspace is an "owner" override.
-    expect(PROVIDER_ROLE_OVERRIDES.app_browser_workspace).toBe("owner");
-    expect(await visibleText("app_browser_workspace", "GUEST")).toBe("");
-    expect(await visibleText("app_browser_workspace", "NONE")).toBe("");
-    expect(await visibleText("app_browser_workspace", "USER")).toBe("");
-    expect(await visibleText("app_browser_workspace", "ADMIN")).toBe("");
-    expect(await visibleText("app_browser_workspace", "OWNER")).toBe(
-      "app_browser_workspace: visible",
-    );
-  });
-
-  it("passes an admin-gated provider for ADMIN and OWNER, redacts below", async () => {
-    expect(PROVIDER_ROLE_OVERRIDES.SECRETS_STATUS).toBe("admin");
-    expect(await visibleText("SECRETS_STATUS", "GUEST")).toBe("");
-    expect(await visibleText("SECRETS_STATUS", "USER")).toBe("");
-    expect(await visibleText("SECRETS_STATUS", "ADMIN")).toBe(
+  it("denies an ADMIN-gated provider to a lower role, passes at/above ADMIN", async () => {
+    const provider = gatedProvider("SECRETS_STATUS", "ADMIN");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
+    expect(await visibleText(provider, "GUEST")).toBe("");
+    expect(await visibleText(provider, "USER")).toBe("");
+    expect(await visibleText(provider, "ADMIN")).toBe(
       "SECRETS_STATUS: visible",
     );
-    expect(await visibleText("SECRETS_STATUS", "OWNER")).toBe(
+    expect(await visibleText(provider, "OWNER")).toBe(
       "SECRETS_STATUS: visible",
     );
   });
 
-  it("passes a user-gated provider for everyone above GUEST", async () => {
-    expect(PROVIDER_ROLE_OVERRIDES.todos).toBe("user");
-    expect(await visibleText("todos", "GUEST")).toBe("");
-    expect(await visibleText("todos", "USER")).toBe("todos: visible");
-    expect(await visibleText("todos", "ADMIN")).toBe("todos: visible");
-    expect(await visibleText("todos", "OWNER")).toBe("todos: visible");
+  it("denies an OWNER-gated provider to everyone below OWNER, passes OWNER", async () => {
+    const provider = gatedProvider("browser_workspace", "OWNER");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
+    expect(await visibleText(provider, "GUEST")).toBe("");
+    expect(await visibleText(provider, "USER")).toBe("");
+    expect(await visibleText(provider, "ADMIN")).toBe("");
+    expect(await visibleText(provider, "OWNER")).toBe(
+      "browser_workspace: visible",
+    );
+  });
+
+  it("passes a USER-gated provider for everyone above GUEST, denies GUEST/NONE", async () => {
+    const provider = gatedProvider("CURRENT_TODOS", "USER");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
+    expect(await visibleText(provider, "NONE")).toBe("");
+    expect(await visibleText(provider, "GUEST")).toBe("");
+    expect(await visibleText(provider, "USER")).toBe("CURRENT_TODOS: visible");
+    expect(await visibleText(provider, "ADMIN")).toBe("CURRENT_TODOS: visible");
+    expect(await visibleText(provider, "OWNER")).toBe("CURRENT_TODOS: visible");
+  });
+
+  it("fails OPEN is impossible: removing the declaration leaves it PUBLIC (so the gate must live on the provider)", async () => {
+    // A provider with NO declared roleGate is NOT gated — visible to everyone,
+    // including NONE. This is the fail-open surface the old name-keyed override
+    // map created on every rename; the fix moves the gate onto the provider so a
+    // sensitive provider is only ungated if its OWN declaration is removed —
+    // a visible, reviewable edit in the owning plugin, never silent name drift.
+    const provider = plainProvider("SHELL_HISTORY");
+    applyPluginRoleGating([pluginWithProviders([provider])]);
+    expect((provider as { __roleGate?: string }).__roleGate).toBeUndefined();
+    expect(await visibleText(provider, "NONE")).toBe("SHELL_HISTORY: visible");
+  });
+
+  it("treats a GUEST/NONE minRole as non-restricting (public)", async () => {
+    const guestGated = gatedProvider("public-ish", "GUEST");
+    applyPluginRoleGating([pluginWithProviders([guestGated])]);
+    expect((guestGated as { __roleGate?: string }).__roleGate).toBeUndefined();
+    expect(await visibleText(guestGated, "NONE")).toBe("public-ish: visible");
+  });
+});
+
+describe("fail-CLOSED: a sensitive provider that cannot be wrapped is withheld", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+  });
+
+  it("withholds a declared-sensitive provider from EVERYONE when wrapping throws", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    rolesMock.checkSenderRole.mockResolvedValue({
+      role: "OWNER",
+      isOwner: true,
+      isAdmin: true,
+    });
+
+    // A sensitive provider whose `get` is a read-only data property: the wrap
+    // path's `provider.get = …` reassignment throws (strict-mode module), so the
+    // fail-closed branch must force-replace `get` with a redactor via
+    // defineProperty and withhold the content rather than register it exposed.
+    const original = vi.fn(
+      async (): Promise<ProviderResult> => ({ text: "SHELL_HISTORY: leak" }),
+    );
+    const locked = {
+      name: "SHELL_HISTORY",
+      roleGate: { minRole: "ADMIN" },
+    } as unknown as Provider;
+    Object.defineProperty(locked, "get", {
+      value: original,
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+
+    applyPluginRoleGating([pluginWithProviders([locked])]);
+
+    // Even OWNER must NOT see the leaked content — it was withheld, not gated.
+    const result = await locked.get?.(
+      runtime,
+      message({ fromId: "discord-user-1" }),
+      {} as State,
+    );
+    expect(result?.text).toBe("");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -1,10 +1,16 @@
 /**
- * Legacy provider role gating.
+ * Provider role gating.
+ *
+ * Sensitive providers declare their own `roleGate` (core `types/components.ts`)
+ * in the plugin that owns them; this module is the runtime chokepoint that
+ * enforces that declaration by withholding the provider's context from callers
+ * below the declared `minRole`. There is no top-down, name-keyed override table:
+ * the gate travels with the provider, so renaming or moving a provider can never
+ * silently drop its gate (the previous name-keyed override map was
+ * fail-OPEN on exactly that drift — #12094 item 3).
  *
  * Action access is declared on each action's `roleGate` and enforced by core
- * execution paths. This module only keeps provider redaction for legacy
- * providers that still use direct provider registration instead of the
- * context catalog.
+ * execution paths; only provider redaction lives here.
  *
  * @module plugin-role-gating
  */
@@ -19,66 +25,28 @@ import type {
 } from "@elizaos/core";
 import { logger, satisfiesRoleGate } from "@elizaos/core";
 
-// Lowercase tier alias kept for override-map ergonomics. Each tier normalizes to
-// a canonical `RoleGateRole` (`TIER_TO_CANONICAL_ROLE`) so the pass/fail decision
-// runs through the shared `satisfiesRoleGate` primitive instead of a local rank
-// reimplementation.
-type RoleGateTier = "user" | "admin" | "owner";
-
-const TIER_TO_CANONICAL_ROLE: Readonly<Record<RoleGateTier, RoleGateRole>> = {
-  user: "USER",
-  admin: "ADMIN",
-  owner: "OWNER",
-};
-
 // ---------------------------------------------------------------------------
-// Provider-level gating — providers that expose sensitive context.
-// Keys are exact provider `name` strings.
+// Sensitivity classification
 // ---------------------------------------------------------------------------
+// A provider is "sensitive" — and therefore gated — iff it declares a
+// `roleGate.minRole` that actually restricts anyone. NONE / GUEST are the
+// bottom of the rank hierarchy and gate nothing, so they are treated as
+// un-declared (a provider gated to GUEST is public).
 
-const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGateTier>> = {
-  // Shell
-  shellHistoryProvider: "admin",
-  terminalUsage: "admin",
-
-  // Orchestrator
-  ACTIVE_WORKSPACE_CONTEXT: "admin",
-  CODING_AGENT_EXAMPLES: "admin",
-
-  // Secrets
-  SECRETS_STATUS: "admin",
-  SECRETS_INFO: "admin",
-  MISSING_SECRETS: "admin",
-
-  // Cron
-  cronContext: "admin",
-
-  // Cloud
-  elizacloud_status: "admin",
-  elizacloud_credits: "admin",
-  elizacloud_health: "admin",
-  elizacloud_models: "admin",
-
-  // Todos
-  todos: "user",
-
-  // Browser / wallet operational state
-  app_browser_workspace: "owner",
-  computerState: "owner",
-  "get-balance": "owner",
-  "solana-wallet": "owner",
-  wallet: "owner",
-  walletBalance: "owner",
-  walletPortfolio: "owner",
-  tokenPrices: "owner",
-  chainInfo: "owner",
-
-  // Apps / plugins expose local installation/runtime state.
-  available_apps: "owner",
-  pluginConfigurationStatus: "owner",
-  pluginState: "owner",
-  registryPlugins: "owner",
-};
+/**
+ * The effective gating floor for a provider, or `undefined` when the provider
+ * declares no restricting gate. Single source of truth for "is this provider
+ * sensitive?" — used both by the normal wrap path and by the fail-closed
+ * withhold path so the two never disagree about which providers matter.
+ */
+function gatedMinRole(provider: Provider): RoleGateRole | undefined {
+  const minRole = (provider as { roleGate?: { minRole?: RoleGateRole } })
+    .roleGate?.minRole;
+  if (minRole && minRole !== "NONE" && minRole !== "GUEST") {
+    return minRole;
+  }
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Sender-role lookup dedup
@@ -87,11 +55,11 @@ const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGateTier>> = {
 // resolveEntityRole). When state composition runs, every gated provider's
 // wrapped `get()` calls it in parallel via `Promise.all`. With even a
 // modest set of gated providers (ACTIVE_WORKSPACE_CONTEXT,
-// CODING_AGENT_EXAMPLES, SECRETS_STATUS, walletPortfolio, etc. —
-// 10+ providers gated to admin or owner), that's 20+ DB queries per
-// turn before the planner is prompted. On a busy host the per-validator
-// stats compound and the provider provider-loop hits its overall
-// timeout cap, dropping providers from the prompt's context.
+// CODING_AGENT_EXAMPLES, SECRETS_STATUS, wallet, etc. — 10+ providers gated to
+// admin or owner), that's 20+ DB queries per turn before the planner is
+// prompted. On a busy host the per-validator stats compound and the provider
+// provider-loop hits its overall timeout cap, dropping providers from the
+// prompt's context.
 //
 // This intentionally dedups only live in-flight checks. Provider redaction is
 // security-sensitive, and `checkSenderRole` also depends on live connector
@@ -192,8 +160,8 @@ async function getCachedSenderRole(
 /**
  * Wrap a provider's get function so it returns empty content for callers below
  * `minRole`. Providers don't block; they just withhold context. `marker` records
- * the applied gate on the provider so re-application is idempotent (Item 1's
- * registration-time gating re-runs over already-gated boot plugins).
+ * the applied gate on the provider so re-application is idempotent (the
+ * registration-time chokepoint re-runs over already-gated boot plugins).
  */
 function wrapProviderWithMinRole(
   provider: Provider,
@@ -221,11 +189,6 @@ function wrapProviderWithMinRole(
   (provider as { __roleGate?: string }).__roleGate = marker;
 }
 
-/** Gate a provider by an override tier (marker = the lowercase tier). */
-function gateProvider(provider: Provider, tier: RoleGateTier): void {
-  wrapProviderWithMinRole(provider, TIER_TO_CANONICAL_ROLE[tier], tier);
-}
-
 /**
  * Hard-withhold a provider's output. Used as the fail-closed fallback when a
  * sensitive provider cannot be gated normally: rather than leaving its original
@@ -248,7 +211,7 @@ function withholdProvider(provider: Provider): void {
   }
   // Mark as gated at the strictest tier so a subsequent pass treats it as done.
   try {
-    (provider as { __roleGate?: RoleGateTier }).__roleGate = "owner";
+    (provider as { __roleGate?: string }).__roleGate = "OWNER";
   } catch {
     // Best-effort marker only; the withholding above already applied.
   }
@@ -257,8 +220,7 @@ function withholdProvider(provider: Provider): void {
 function withholdSensitiveProviders(plugin: Plugin): number {
   let withheld = 0;
   for (const provider of plugin.providers ?? []) {
-    const providerName = (provider as { name?: string }).name ?? "";
-    if (!PROVIDER_ROLE_OVERRIDES[providerName]) continue;
+    if (!gatedMinRole(provider)) continue;
     withholdProvider(provider);
     withheld++;
   }
@@ -267,11 +229,12 @@ function withholdSensitiveProviders(plugin: Plugin): number {
 
 /**
  * Apply role gating to the given plugins. Safe to call repeatedly and per
- * plugin: `gateProvider` is idempotent (already-gated providers are skipped),
- * so this doubles as the register-time chokepoint hook.
+ * plugin: `wrapProviderWithMinRole` is idempotent (already-gated providers are
+ * skipped), so this doubles as the register-time chokepoint hook.
  *
- * Providers in PROVIDER_ROLE_OVERRIDES get gated. Actions are intentionally
- * not wrapped here; use action.roleGate.
+ * Providers that declare a restricting `roleGate.minRole` get wrapped so their
+ * `get()` short-circuits to empty for callers below that role. Actions are
+ * intentionally not wrapped here; use action.roleGate.
  *
  * Fail-closed: if wrapping a sensitive provider throws, its content is withheld
  * entirely and the failure is logged at ERROR — redaction is never silently
@@ -282,45 +245,25 @@ export function applyPluginRoleGating(plugins: Plugin[]): void {
   let withheldProviders = 0;
 
   for (const plugin of plugins) {
-    // Gate providers
-    if (plugin.providers?.length) {
-      for (const provider of plugin.providers) {
+    if (!plugin.providers?.length) continue;
+    for (const provider of plugin.providers) {
+      const minRole = gatedMinRole(provider);
+      if (!minRole) continue;
+      try {
+        wrapProviderWithMinRole(provider, minRole, minRole);
+        gatedProviders++;
+      } catch (err) {
+        // Fail closed: a sensitive provider we could not wrap must not be
+        // exposed. Withhold its content and report loudly — never silently
+        // leave redaction disabled.
+        withholdProvider(provider);
+        withheldProviders++;
         const providerName = (provider as { name?: string }).name ?? "";
-        const providerTier = PROVIDER_ROLE_OVERRIDES[providerName];
-        if (providerTier) {
-          try {
-            gateProvider(provider, providerTier);
-            gatedProviders++;
-          } catch (err) {
-            // Fail closed: a sensitive provider we could not wrap must not be
-            // exposed. Withhold its content and report loudly — never silently
-            // leave redaction disabled.
-            withholdProvider(provider);
-            withheldProviders++;
-            logger.error(
-              `[role-gating] Failed to gate sensitive provider "${providerName}" (tier=${providerTier}); withholding its content to fail closed: ${
-                err instanceof Error ? err.message : String(err)
-              }`,
-            );
-          }
-          continue;
-        }
-        // #12087 Item 14: a provider that DECLARES a roleGate is now enforced at
-        // execution time here (its get() is short-circuited to empty for callers
-        // below minRole), so the declaration is no longer decorative and the
-        // provider needs no in-body hasAdminAccess/hasOwnerAccess preamble. NONE /
-        // GUEST minRoles gate nothing, so skip them.
-        const declaredMinRole = (
-          provider as { roleGate?: { minRole?: RoleGateRole } }
-        ).roleGate?.minRole;
-        if (
-          declaredMinRole &&
-          declaredMinRole !== "NONE" &&
-          declaredMinRole !== "GUEST"
-        ) {
-          wrapProviderWithMinRole(provider, declaredMinRole, declaredMinRole);
-          gatedProviders++;
-        }
+        logger.error(
+          `[role-gating] Failed to gate sensitive provider "${providerName}" (minRole=${minRole}); withholding its content to fail closed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     }
   }
@@ -377,6 +320,3 @@ export function installProviderRoleGatingChokepoint(
 
   runtime.__elizaProviderRoleGatingInstalled = true;
 }
-
-/** Exported for testing. */
-export { PROVIDER_ROLE_OVERRIDES, TIER_TO_CANONICAL_ROLE };

--- a/packages/core/src/features/plugin-manager/providers/pluginConfigurationStatus.ts
+++ b/packages/core/src/features/plugin-manager/providers/pluginConfigurationStatus.ts
@@ -56,7 +56,9 @@ export const pluginConfigurationStatusProvider: Provider & {
 	contextGate: { anyOf: ["connectors", "settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
+	// Local plugin install/config state is owner context — preserves the tier the
+	// former name-keyed override map enforced (#12094 item 3).
+	roleGate: { minRole: "OWNER" },
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/packages/core/src/features/plugin-manager/providers/pluginStateProvider.ts
+++ b/packages/core/src/features/plugin-manager/providers/pluginStateProvider.ts
@@ -47,7 +47,9 @@ export const pluginStateProvider: Provider & { relevanceKeywords: string[] } = {
 	contextGate: { anyOf: ["connectors", "settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "USER" },
+	// Local plugin runtime state is owner context — preserves the tier the former
+	// name-keyed override map enforced (#12094 item 3).
+	roleGate: { minRole: "OWNER" },
 
 	async get(
 		runtime: IAgentRuntime,

--- a/packages/core/src/features/plugin-manager/providers/registryPluginsProvider.ts
+++ b/packages/core/src/features/plugin-manager/providers/registryPluginsProvider.ts
@@ -50,7 +50,10 @@ export const registryPluginsProvider: Provider & {
 	contextGate: { anyOf: ["connectors", "settings"] },
 	cacheStable: true,
 	cacheScope: "agent",
-	roleGate: { minRole: "USER" },
+	// Registry-plugin availability against local install state is owner context —
+	// preserves the tier the former name-keyed override map enforced
+	// (#12094 item 3).
+	roleGate: { minRole: "OWNER" },
 
 	async get(
 		runtime: IAgentRuntime,

--- a/packages/core/src/features/secrets/providers/secrets-status.ts
+++ b/packages/core/src/features/secrets/providers/secrets-status.ts
@@ -38,7 +38,9 @@ export const secretsStatusProvider: Provider = {
 	contextGate: { anyOf: ["secrets", "settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "OWNER" },
+	// Secret presence/values are operator context — admin+ (preserves the tier
+	// the former name-keyed override map enforced; #12094 item 3).
+	roleGate: { minRole: "ADMIN" },
 
 	get: async (
 		runtime: IAgentRuntime,
@@ -176,7 +178,9 @@ export const secretsInfoProvider: Provider = {
 	contextGate: { anyOf: ["secrets", "settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "OWNER" },
+	// Secret presence/values are operator context — admin+ (preserves the tier
+	// the former name-keyed override map enforced; #12094 item 3).
+	roleGate: { minRole: "ADMIN" },
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/packages/core/src/features/secrets/setup/provider.ts
+++ b/packages/core/src/features/secrets/setup/provider.ts
@@ -231,7 +231,9 @@ export const missingSecretsProvider: Provider = {
 	contextGate: { anyOf: ["settings"] },
 	cacheStable: false,
 	cacheScope: "turn",
-	roleGate: { minRole: "OWNER" },
+	// Which secrets are still missing is operator context — admin+ (preserves the
+	// tier the former name-keyed override map enforced; #12094 item 3).
+	roleGate: { minRole: "ADMIN" },
 
 	get: async (
 		runtime: IAgentRuntime,

--- a/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/action-examples.ts
@@ -29,6 +29,9 @@ export const codingAgentExamplesProvider: Provider = {
   position: -1,
   contexts: ["code", "agent_internal"],
   contextGate: { anyOf: ["code", "agent_internal"] },
+  // Task-agent action guidance embeds live framework/auth state — admin+ only
+  // (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
   // Not agent-cacheable: the body embeds live framework state
   // (frameworkState.preferred / configuredSubscriptionProvider), which changes
   // as auth/availability changes during the agent's lifetime. Recompute per turn

--- a/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
@@ -41,6 +41,9 @@ export const activeWorkspaceContextProvider: Provider = {
   contextGate: { anyOf: ["code", "tasks", "agent_internal"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Live coding-workspace / task-agent state is operator context — admin+ only
+  // (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
 
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     const acpService = getAcpService(runtime);

--- a/plugins/plugin-app-control/src/providers/available-apps.ts
+++ b/plugins/plugin-app-control/src/providers/available-apps.ts
@@ -29,6 +29,9 @@ export const availableAppsProvider: Provider = {
 	contextGate: { anyOf: ["settings", "automation"] },
 	cacheStable: false,
 	cacheScope: "turn",
+	// Installed-app inventory + running counts are local install state — owner
+	// context (#12094 item 3).
+	roleGate: { minRole: "OWNER" },
 	dynamic: true,
 
 	get: async (

--- a/plugins/plugin-browser/src/providers/workspace.ts
+++ b/plugins/plugin-browser/src/providers/workspace.ts
@@ -25,6 +25,10 @@ export const browserWorkspaceProvider: Provider = {
   contextGate: { anyOf: ["browser", "web"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Live browser workspace (dispatch mode + open tabs/URLs) is owner-operator
+  // context (#12094 item 3: gate travels with the provider so a rename can't
+  // silently drop it).
+  roleGate: { minRole: "OWNER" },
   get: async () => {
     try {
       const mode = getBrowserWorkspaceMode();

--- a/plugins/plugin-computeruse/src/providers/computer-state.ts
+++ b/plugins/plugin-computeruse/src/providers/computer-state.ts
@@ -28,6 +28,9 @@ export const computerStateProvider: Provider = {
   },
   cacheStable: false,
   cacheScope: "turn",
+  // Live computer-use state (screen, tools, approval queue) is owner context
+  // (#12094 item 3).
+  roleGate: { minRole: "OWNER" },
   get: async (
     runtime: IAgentRuntime,
     _message: Memory,

--- a/plugins/plugin-elizacloud/src/cloud-providers/cloud-status.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/cloud-status.ts
@@ -20,6 +20,8 @@ export const cloudStatusProvider: Provider = {
   contextGate: { anyOf: ["settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Cloud account/connection state is operator context — admin+ only (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
   async get(runtime: IAgentRuntime, _message: Memory, _state: State): Promise<ProviderResult> {
     try {
       const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;

--- a/plugins/plugin-elizacloud/src/cloud-providers/container-health.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/container-health.ts
@@ -20,6 +20,8 @@ export const containerHealthProvider: Provider = {
   contextGate: { anyOf: ["settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Cloud container health is operator context — admin+ only (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
   async get(runtime: IAgentRuntime, _message: Memory, _state: State): Promise<ProviderResult> {
     try {
       const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;

--- a/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
@@ -19,6 +19,8 @@ export const creditBalanceProvider: Provider = {
   contextGate: { anyOf: ["settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Cloud credit balance is operator/billing context — admin+ only (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
   position: 91,
   async get(runtime: IAgentRuntime, _message: Memory, _state: State): Promise<ProviderResult> {
     const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;

--- a/plugins/plugin-elizacloud/src/cloud-providers/model-registry.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/model-registry.ts
@@ -23,6 +23,8 @@ export const modelRegistryProvider: Provider = {
   contextGate: { anyOf: ["settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Cloud model registry is operator/settings context — admin+ only (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
   position: 92,
   async get(runtime: IAgentRuntime, _message: Memory, _state: State): Promise<ProviderResult> {
     try {

--- a/plugins/plugin-shell/providers/shellHistoryProvider.ts
+++ b/plugins/plugin-shell/providers/shellHistoryProvider.ts
@@ -25,6 +25,9 @@ export const shellHistoryProvider: Provider = {
   contextGate: { anyOf: ["terminal", "code"] },
   cacheStable: false,
   cacheScope: "turn",
+  // Shell history / cwd / file ops are host-operator context — admin+ only.
+  // (#12094 item 3: the gate lives on the provider so it can't drift.)
+  roleGate: { minRole: "ADMIN" },
   dynamic: true,
   get: async (runtime: IAgentRuntime, message: Memory, _state: State) => {
     try {

--- a/plugins/plugin-todos/src/providers/current-todos.ts
+++ b/plugins/plugin-todos/src/providers/current-todos.ts
@@ -36,6 +36,9 @@ export const currentTodosProvider: Provider = {
   position: -5,
   contexts: [...TODOS_CONTEXTS],
   contextGate: { anyOf: [...TODOS_CONTEXTS] },
+  // The user's personal todos are member-scoped context — withheld from
+  // guest/anonymous callers (#12094 item 3).
+  roleGate: { minRole: "USER" },
   get: async (
     runtime: IAgentRuntime,
     message: Memory,


### PR DESCRIPTION
## What & why

`PROVIDER_ROLE_OVERRIDES` (`packages/agent/src/runtime/plugin-role-gating.ts`) gated sensitive providers' redaction via an **exact-name map two layers up from the owning plugins**. It was **fail-OPEN on drift**: a provider renamed or moved silently lost its gate. The map had already drifted in production:

| override key | real provider name | status before |
|---|---|---|
| `shellHistoryProvider` | `SHELL_HISTORY` | **ungated (fail-open)** |
| `app_browser_workspace` | `browser_workspace` | **ungated (fail-open)** |
| `todos` | `CURRENT_TODOS` | **ungated (fail-open)** |

The sanctioned bottom-up mechanism (`Provider.roleGate`, core `types/components.ts`) already existed and is already enforced by `applyPluginRoleGating`. This PR migrates every real provider to declare its own `roleGate` in the plugin that owns it, then **deletes the map + the tier shim** (`PROVIDER_ROLE_OVERRIDES`, `TIER_TO_CANONICAL_ROLE`, `RoleGateTier`, `gateProvider`). The gate now travels with the provider, so a rename can no longer drop it.

## Behavior

- **Matched providers** (name already matched the map): tier preserved exactly — the override always won over any declared value, so effective enforcement is unchanged. This required reconciling a few dormant declarations to their enforced tier: secrets providers `OWNER→ADMIN`; `pluginState`/`pluginConfigurationStatus`/`registryPlugins` `USER→OWNER`.
- **Drifted providers** (`SHELL_HISTORY` ADMIN, `browser_workspace` OWNER, `CURRENT_TODOS` USER): were fail-open, now gated — this is the **intended security fix** (closing the fail-open hole; fail-CLOSED).
- **Stale entries with no live provider** (`terminalUsage`, `cronContext`, `walletBalance`, `walletPortfolio`, `tokenPrices`, `chainInfo`) gated nothing and are dropped.
- Wallet providers (`wallet`, `get-balance`, `solana-wallet`) already declared `roleGate: OWNER` — untouched.

## Done-when evidence (issue #12094 item 3)

- `PROVIDER_ROLE_OVERRIDES` **deleted** — `grep -rn PROVIDER_ROLE_OVERRIDES --include=*.ts` returns **0** code references (comments carry no symbol).
- Every previously-listed **live** provider declares its own `roleGate`.
- Gate still enforces + fails CLOSED:
  - `packages/agent/src/runtime/plugin-role-gating.test.ts` — ADMIN/OWNER/USER tiers deny lower roles; a provider with **no** declaration is public (proving the gate must live on the provider, never a name map); a declared-sensitive provider whose `get()` cannot be wrapped is withheld from **everyone** and logged at ERROR (fail-CLOSED).
  - `plugin-role-gating-chokepoint.test.ts` / `-registration.test.ts` updated to drive gating via declared `roleGate`.

## Verification

- `bun run --cwd packages/agent test -- plugin-role-gating` → **15/15 pass**
- `bun run --cwd packages/agent test -- lifecycle` → **46/46 pass**
- `bun run --cwd packages/core test -- secrets plugin-manager` → **90/90 pass**
- `packages/core` typecheck clean; touched plugins typecheck clean (remaining errors are pre-existing unbuilt-sibling-module resolution, unrelated to this change).

Closes #12094 item 3 (Refs #12094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)