### PR TITLE
refactor(agent): type /api/cloud/* dispatch against plugin-elizacloud host-route contract (#12094 item 2)

### DIFF
--- a/packages/agent/src/api/server-route-dispatch.ts
+++ b/packages/agent/src/api/server-route-dispatch.ts
@@ -8,12 +8,6 @@ import { handleInboxRoute } from "./inbox-routes.ts";
 import { handleNotificationRoute } from "./notification-routes.ts";
 import { handlePushTokenRoute } from "./push-token-routes.ts";
 import { tryHandleRuntimePluginRoute } from "./runtime-plugin-routes.ts";
-import type {
-  AgentCloudBillingRouteHandler,
-  AgentCloudCompatRouteHandler,
-  AgentCloudRelayRouteHandler,
-  AgentCloudRouteHandler,
-} from "./cloud-route-contracts.ts";
 import type { ServerState } from "./server-types.ts";
 
 // Lazy memoized loaders — previously these were module-scope `await import`,
@@ -22,12 +16,6 @@ import type { ServerState } from "./server-types.ts";
 // agent boot). Now each plugin only loads when its route group is first hit.
 type ComputeUsePluginModule = {
   handleSandboxRoute: (...args: unknown[]) => Promise<boolean>;
-};
-type CloudPluginRoutesModule = {
-  handleCloudBillingRoute: AgentCloudBillingRouteHandler;
-  handleCloudCompatRoute: AgentCloudCompatRouteHandler;
-  handleCloudRelayRoute: AgentCloudRelayRouteHandler;
-  handleCloudRoute: AgentCloudRouteHandler;
 };
 
 let computeUsePromise: Promise<ComputeUsePluginModule> | null = null;
@@ -38,11 +26,16 @@ function getComputeUsePlugin(): Promise<ComputeUsePluginModule> {
   return computeUsePromise;
 }
 
-let cloudRoutesPromise: Promise<CloudPluginRoutesModule> | null = null;
-function getCloudRoutesPlugin(): Promise<CloudPluginRoutesModule> {
-  cloudRoutesPromise ??= import(
-    "@elizaos/plugin-elizacloud"
-  ) as Promise<unknown> as Promise<CloudPluginRoutesModule>;
+// plugin-elizacloud owns these host-side cloud routes and exports them as a
+// typed contract (`@elizaos/plugin-elizacloud/host-routes`). Typing the lazy
+// import against the real exports means a handler signature change here is a
+// compile error, not a silent runtime break.
+type CloudHostRoutesModule =
+  typeof import("@elizaos/plugin-elizacloud/host-routes");
+
+let cloudRoutesPromise: Promise<CloudHostRoutesModule> | null = null;
+function getCloudRoutesPlugin(): Promise<CloudHostRoutesModule> {
+  cloudRoutesPromise ??= import("@elizaos/plugin-elizacloud/host-routes");
   return cloudRoutesPromise;
 }
 

--- a/packages/agent/src/api/server-types.ts
+++ b/packages/agent/src/api/server-types.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import type { AgentRuntime, Media, UUID } from "@elizaos/core";
+import type { CloudManager } from "@elizaos/plugin-elizacloud/host-routes";
 import type {
   AgentAutomationMode,
   AgentStartupDiagnostics,
@@ -13,7 +14,7 @@ import type { ElizaConfig } from "../config/config.ts";
 import type { SandboxManager } from "../services/sandbox-manager.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
 
-export type CloudManagerLike = unknown;
+export type CloudManagerLike = CloudManager | null;
 export type AppManagerLike = unknown;
 
 export interface StoppablePairingSession {

--- a/plugins/plugin-elizacloud/__tests__/host-routes.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/host-routes.test.ts
@@ -1,0 +1,113 @@
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleCloudBillingRoute,
+  handleCloudCompatRoute,
+  handleCloudRelayRoute,
+  handleCloudRoute,
+} from "../src/host-routes";
+
+/**
+ * Seam test for the typed host-route contract (issue #12094 item 2).
+ *
+ * `@elizaos/agent`'s server-route dispatcher lazily imports this module
+ * (`@elizaos/plugin-elizacloud/host-routes`) and dispatches through these
+ * exact exported signatures — no `unknown[]` shims, no `as never` casts. This
+ * test drives the real handlers (not mocks): with no cloud credentials and no
+ * runtime, each must reach its owner logic and answer, proving the contract the
+ * agent imports actually dispatches. No network is touched (all short-circuit
+ * before any upstream call).
+ */
+
+function makeResponse() {
+  let statusCode = 200;
+  let raw = "";
+  const res = {
+    headersSent: false,
+    setHeader: vi.fn(),
+    end: (chunk?: string) => {
+      if (typeof chunk === "string") raw = chunk;
+      (res as { headersSent: boolean }).headersSent = true;
+    },
+    get statusCode() {
+      return statusCode;
+    },
+    set statusCode(value: number) {
+      statusCode = value;
+    },
+  } as unknown as http.ServerResponse;
+  return {
+    res,
+    get statusCode() {
+      return statusCode;
+    },
+    get body(): unknown {
+      return raw ? JSON.parse(raw) : undefined;
+    },
+  };
+}
+
+const req = { url: "/", method: "GET" } as http.IncomingMessage;
+
+describe("plugin-elizacloud host-routes contract", () => {
+  it("handleCloudBillingRoute dispatches and 401s without credentials", async () => {
+    const cap = makeResponse();
+    const handled = await handleCloudBillingRoute(
+      req,
+      cap.res,
+      "/api/cloud/billing/summary",
+      "GET",
+      { config: {}, runtime: null }
+    );
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(401);
+    expect(cap.body).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("handleCloudBillingRoute ignores non-billing paths", async () => {
+    const cap = makeResponse();
+    const handled = await handleCloudBillingRoute(req, cap.res, "/api/cloud/other", "GET", {
+      config: {},
+      runtime: null,
+    });
+    expect(handled).toBe(false);
+    expect(cap.statusCode).toBe(200);
+  });
+
+  it("handleCloudCompatRoute dispatches and 401s without credentials", async () => {
+    const cap = makeResponse();
+    const handled = await handleCloudCompatRoute(req, cap.res, "/api/cloud/compat/models", "GET", {
+      config: {},
+      runtime: null,
+    });
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(401);
+  });
+
+  it("handleCloudRelayRoute reports no_runtime when runtime is absent", async () => {
+    const cap = makeResponse();
+    const json = vi.fn();
+    const handled = await handleCloudRelayRoute(
+      req,
+      cap.res,
+      "/api/cloud/relay-status",
+      "GET",
+      { runtime: undefined },
+      { json, error: vi.fn(), readJsonBody: vi.fn() }
+    );
+    expect(handled).toBe(true);
+    expect(json).toHaveBeenCalledWith(cap.res, expect.objectContaining({ available: false }));
+  });
+
+  it("handleCloudRoute serves relay-status with no runtime (available:false)", async () => {
+    const cap = makeResponse();
+    const handled = await handleCloudRoute(req, cap.res, "/api/cloud/relay-status", "GET", {
+      config: {},
+      cloudManager: null,
+      runtime: null,
+    });
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(200);
+    expect(cap.body).toMatchObject({ available: false });
+  });
+});

--- a/plugins/plugin-elizacloud/src/host-routes.ts
+++ b/plugins/plugin-elizacloud/src/host-routes.ts
@@ -1,0 +1,20 @@
+/**
+ * Typed host-route contract for the `@elizaos/agent` server-route dispatcher.
+ *
+ * The four handlers below run host-side and must work while `runtime === null`
+ * (cloud login provisions/restarts the runtime), so they cannot live in
+ * `Plugin.routes`. The agent lazily imports this module and dispatches through
+ * these real, exported signatures — no type-erased `unknown[]` shims. Because
+ * agent types against the exports here, changing a handler's signature (or its
+ * state type) is a compile error in `@elizaos/agent`.
+ */
+export { handleCloudBillingRoute } from "./routes/cloud-billing-routes";
+export { handleCloudCompatRoute } from "./routes/cloud-compat-routes";
+export { handleCloudRelayRoute } from "./routes/cloud-relay-routes";
+export { handleCloudRoute } from "./routes/cloud-routes";
+
+export type { CloudBillingRouteState } from "./routes/cloud-billing-routes";
+export type { CloudCompatRouteState } from "./routes/cloud-compat-routes";
+export type { CloudRelayRouteState } from "./routes/cloud-relay-routes";
+export type { CloudRouteState } from "./routes/cloud-routes";
+export type { CloudManager } from "./cloud/cloud-manager";


### PR DESCRIPTION
## What

Fixes the type-erased `/api/cloud/*` dispatch flagged in **#12094 item 2**.

`packages/agent/src/api/server-route-dispatch.ts` lazily imported `@elizaos/plugin-elizacloud` and chained its handlers through a local, type-erased `CloudPluginRoutesModule` plus an `as Promise<unknown> as Promise<...>` double cast. A plugin handler-signature change broke silently at runtime.

plugin-elizacloud now exports a **typed host-route contract** at the `@elizaos/plugin-elizacloud/host-routes` subpath — the four host-side handlers (`handleCloudBillingRoute`, `handleCloudCompatRoute`, `handleCloudRelayRoute`, `handleCloudRoute`) plus their real state types and `CloudManager`. The agent types its lazy import against those real exports.

The host-side dispatch itself is kept (these routes must work with `runtime === null`, so they can't live in `Plugin.routes`). The subpath is a distinct specifier, so it bypasses the agent's ambient module shim, which still decouples the rest of the plugin surface.

## Changes

- `plugins/plugin-elizacloud/src/host-routes.ts` (new) — exported typed contract (handlers + state types + `CloudManager`).
- `packages/agent/src/api/server-route-dispatch.ts` — delete `CloudPluginRoutesModule` and the `as unknown` cast; `getCloudRoutesPlugin()` is now `Promise<typeof import("@elizaos/plugin-elizacloud/host-routes")>`; drop the `cloud-route-contracts.ts` fiction import from the dispatch path.
- `packages/agent/src/api/server-types.ts` — retype `ServerState.cloudManager` to the real `CloudManager | null` so the cloud dispatch callsite needs no cast.
- `plugins/plugin-elizacloud/__tests__/host-routes.test.ts` (new) — seam test driving the real exported handlers.

## Done-when evidence

**Grep (server-route-dispatch.ts):**
- `CloudPluginRoutesModule` → 0 occurrences
- `as never` / `as unknown` → 0 in the cloud path (the one remaining `unknown[]` is `handleSandboxRoute` for plugin-computeruse, out of scope)
- no `cloud-route-contracts.ts` import remains

**Strong typing (compile error on signature change):** temporarily adding a required field to `CloudBillingRouteState` in the plugin produces, in `packages/agent`:
```
src/api/server-route-dispatch.ts(194,5): error TS2741: Property '__probe_required_field' is missing in type '{ config: ElizaConfig; runtime: AgentRuntime | null; }' but required in type 'CloudBillingRouteState'.
```

**Tests:** `plugins/plugin-elizacloud/__tests__/host-routes.test.ts` — 5/5 pass, driving the real handlers (401 without creds for billing/compat, relay `no_runtime`, `handleCloudRoute` relay-status `available:false`, non-billing guard fall-through). Existing `cloud-billing-routes` / `cloud-route-plugin` tests still pass.

**Typecheck:** clean in touched packages (remaining errors are pre-existing environmental unbuilt-plugin noise: `@elizaos/plugin-meetings`/`-streaming`/`-vision`, ui `AccountWithCredentialFlag` drift — all present on develop).

**No behavior change:** the same state objects are passed to the same handlers; the plugin reads the same fields it read before (top-level `saveConfig`/`createTelemetrySpan` were and remain excess/ignored — the plugin uses `services` defaults; `cloudManager` runtime value is unchanged).

> Note: the agent's local vitest env cannot resolve `@elizaos/plugin-discord/constants` (a source-condition subpath with no dist `.js`), which breaks any agent test that statically imports `server-route-dispatch.ts` — including the pre-existing `notification-lazy-route.test.ts`. The seam test therefore lives in plugin-elizacloud (the contract owner), where resolution is clean, and the agent wiring is proven by the compile-error check above.

Closes #12094 item 2 (Refs #12094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)