### PR TITLE
fix(desktop): scope transparency + vibrancy to the pill only — opaque dashboard, no glass sheet (#12184)

### DIFF
--- a/packages/app-core/platforms/electrobun/docs/desktop-window-lifecycle.md
+++ b/packages/app-core/platforms/electrobun/docs/desktop-window-lifecycle.md
@@ -28,7 +28,7 @@ summoned on demand.
 | Concern | Function | Default |
 | --- | --- | --- |
 | Bottom-bar (chat-overlay) shell is the resting surface | `shouldStartBottomBar()` (`desktop-bottom-bar-config.ts`) | **ON** (#10350); opt out with `ELIZA_DESKTOP_BOTTOM_BAR=0` |
-| Window presentation (frameless / transparent / titleBarStyle) | `resolveDesktopShellWindowPresentation()` | `bottom-bar` unless kiosk |
+| Window presentation (frameless / transparent / titleBarStyle) | `resolveDesktopShellWindowPresentation()` | `bottom-bar` unless kiosk; **transparency is scoped to the pill (macOS)** — the full dashboard and kiosk stay opaque, and no window gets a vibrancy frost, so nothing renders as a full-window glass sheet (#12184) |
 | Renderer told to render the overlay shell | `appendChatOverlayShellModeParam()` → `?shellMode=chat-overlay` | appended in `createMainWindow()` (`index.ts`) |
 | Bar geometry (anchored to work-area bottom edge) | `computeBottomBarFrame()` | 140px tall, full width |
 | Kiosk (fullscreen, exclusive) | `isKioskShellMode()` | opt-in; wins over bottom-bar |

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -136,7 +136,7 @@ describe("desktop bottom-bar config", () => {
       ).toEqual({
         mode: "default",
         titleBarStyle: "hiddenInset",
-        transparent: true,
+        transparent: false,
       });
     });
 

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -78,6 +78,15 @@ export interface DesktopShellWindowPresentation {
   transparent: boolean;
 }
 
+/**
+ * Resolve the window presentation for the current shell mode.
+ *
+ * Transparency is scoped to the chromeless bottom-bar pill on macOS only. The
+ * full dashboard ("default") window and kiosk stay opaque: a transparent window
+ * over dark web content reads as a full-window frosted sheet (the pill is the
+ * only surface that should show the desktop through it). Win/Linux transparency
+ * support varies, so the pill also stays opaque there for now (fork gap G4).
+ */
 export function resolveDesktopShellWindowPresentation(
   env: Record<string, string | undefined> = process.env,
   argv: readonly string[] = process.argv,
@@ -93,7 +102,7 @@ export function resolveDesktopShellWindowPresentation(
         : platform === "darwin"
           ? "hiddenInset"
           : "default",
-    transparent: !kiosk && platform === "darwin",
+    transparent: bottomBar && platform === "darwin",
   };
 }
 

--- a/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
@@ -52,6 +52,18 @@ describe("desktop experience contract — chat-first launch", () => {
     expect(presentation.transparent).toBe(true);
   });
 
+  it("keeps the full dashboard window opaque on macOS — transparency is the pill only (#12184)", () => {
+    // A transparent full window over dark web content renders as a full-window
+    // frosted-glass sheet; only the chromeless pill is transparent.
+    const presentation = resolveDesktopShellWindowPresentation(
+      { ELIZA_DESKTOP_BOTTOM_BAR: "0" },
+      [],
+      "darwin",
+    );
+    expect(presentation.mode).toBe("default");
+    expect(presentation.transparent).toBe(false);
+  });
+
   it("resolves kiosk presentation when requested", () => {
     const presentation = resolveDesktopShellWindowPresentation(
       { ELIZAOS_SHELL_MODE: "kiosk" },

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -92,7 +92,6 @@ import { getDesktopManager } from "./native/desktop";
 import { disposeNativeModules, initializeNativeModules } from "./native/index";
 import {
   enableBackForwardNavigationGestures,
-  enableVibrancy,
   ensureShadow,
   setNativeDragRegion,
   setTrafficLightsPosition,
@@ -406,9 +405,14 @@ const MAC_NATIVE_DRAG_REGION_X = 92;
 const MAC_NATIVE_DRAG_REGION_HEIGHT = 38;
 
 /**
- * Vibrancy, shadow, traffic lights, and native chrome layout. Re-calls native
- * layout whenever the window or webview subtree may have reordered so the drag
- * view stays above WKWebView.
+ * Shadow, traffic lights, drag region, and native chrome layout. Re-calls
+ * native layout whenever the window or webview subtree may have reordered so
+ * the drag view stays above WKWebView.
+ *
+ * Deliberately applies NO vibrancy (#12184): a vibrancy NSVisualEffectView
+ * behind a transparent window renders as a full-window frosted-glass sheet over
+ * the desktop. Only the chromeless pill and the tray popover are transparent,
+ * and each paints its own surface — the dashboard is a normal opaque window.
  */
 function applyMacOSWindowEffects(win: BrowserWindow): void {
   if (process.platform !== "darwin") return;
@@ -419,12 +423,9 @@ function applyMacOSWindowEffects(win: BrowserWindow): void {
     return;
   }
 
-  const vibrancyEnabled = enableVibrancy(
-    ptr as Parameters<typeof enableVibrancy>[0],
-  );
   const shadowEnabled = ensureShadow(ptr as Parameters<typeof ensureShadow>[0]);
   updateCurrentMainWindowEffectsState({
-    vibrancyEnabled,
+    vibrancyEnabled: false,
     shadowEnabled,
   });
 
@@ -1059,8 +1060,9 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
         y: state.y,
       };
   const titleBarStyle = presentation.titleBarStyle;
-  // Bottom bar wants a transparent surface so the desktop shows through the
-  // empty region above the bar; on darwin it pairs with vibrancy. Win/Linux
+  // Only the chromeless bottom bar is transparent (macOS), so the desktop shows
+  // through the empty region above the pill. The full dashboard stays opaque —
+  // transparency there reads as a frosted-glass sheet (#12184). Win/Linux
   // transparency support varies, so the bar stays opaque there for now.
   const transparent = presentation.transparent;
   // The pill spans the full work-area width but only the small bar is visible;
@@ -1156,7 +1158,8 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
     return win;
   }
 
-  // Bottom-bar shell: pin always-on-top and (on darwin) apply vibrancy. The bar
+  // Bottom-bar shell: pin always-on-top and apply the macOS chrome (shadow,
+  // drag region — no vibrancy, so the pill is the only painted surface). The bar
   // has fixed, display-derived geometry, so skip bounds persistence + the
   // first-launch maximize entirely.
   if (bottomBar) {


### PR DESCRIPTION
Fixes #12426. Part of #12184.

## Problem

On macOS the desktop app renders a **giant frosted-glass sheet** instead of an opaque dashboard (or, at rest, just the small pill). Regression from the #12184 Phase 1 work merged in #12300; present on `develop`.

## Root cause (native-side window flags only)

1. `resolveDesktopShellWindowPresentation()` returned `transparent: !kiosk && platform === "darwin"` — keyed on **platform alone**, so the full dashboard window was also created transparent. Transparent window + dark web content = glass.
2. `applyMacOSWindowEffects()` called `enableVibrancy()` for **both** the pill and the default window, adding a native `NSVisualEffectView` frost.

## Fix

- **Scope transparency to the pill:** `transparent: bottomBar && platform === "darwin"`. Full dashboard + kiosk stay opaque (macOS-only stays, since Win/Linux transparency support varies — fork gap G4).
- **Drop vibrancy entirely** from `applyMacOSWindowEffects()`. The pill is the only painted surface; the dashboard is a normal opaque window. Shadow / traffic-lights / drag chrome kept. `vibrancyEnabled` is a diagnostic-only snapshot field (nothing asserts it true) → set to `false`.
- Added a **durable contract-test guard** that the full dashboard is opaque on macOS; updated presentation test + `desktop-window-lifecycle.md`.
- **No renderer change:** chat-overlay shell already paints transparent (`html.eliza-chat-overlay-shell` in `styles.css`); the bug was purely the native transparent/vibrancy flags.

## Files

- `desktop-bottom-bar-config.ts` — transparency scoped to bottom-bar; invariant documented.
- `index.ts` — removed `enableVibrancy` import + call; header/inline comments updated; `vibrancyEnabled: false`.
- `desktop-bottom-bar-config.test.ts` — darwin `default` window now `transparent: false`.
- `desktop-experience-contract.test.ts` — new guard: full dashboard opaque on macOS.
- `docs/desktop-window-lifecycle.md` — presentation row notes transparency is pill-scoped, no vibrancy frost.

## Evidence

| Type | Status |
| --- | --- |
| Unit/contract tests | ✅ `bun run --cwd packages/app-core/platforms/electrobun test` → 62 files / 450 tests pass |
| Typecheck | ✅ package `tsgo --noEmit` clean |
| Real-LLM trajectory | N/A — no agent/action/provider/prompt/model change (native window flags only) |
| Before/after desktop screenshots + video | ⏳ Deferred — no running desktop instance or dev screenshot server present, and a fresh-worktree desktop build is blocked by heavy environment contention. The fix is native-window-flag-only and covered by the presentation + contract tests; a follow-up live capture (`ELIZA_DESKTOP_SCREENSHOT_SERVER=1` → `GET /api/dev/cursor-screenshot`, pill-at-rest + opaque dashboard) is tracked in #12426. |
| Backend logs | N/A — no new runtime code path; `[MacEffects]`/`[Main]` logs unchanged aside from the dropped vibrancy call |

🤖 Generated with [Claude Code](https://claude.com/claude-code)