### PR TITLE
fix(voice): TTS fails closed — no silent engine rotation in router/core/web/iOS (#12253)

### DIFF
--- a/.github/issue-evidence/12253-tts-loud-fail/01-failure-path-real-artifact-absence.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/01-failure-path-real-artifact-absence.log
@@ -12,4 +12,3 @@ stderr | src/services/router-tts-loud-fail-evidence.test.ts > #12253 failure-pat
       Tests  3 passed (3)
    Start at  21:23:10
    Duration  3.37s (transform 2.48s, setup 0ms, import 3.30s, tests 5ms, environment 0ms)
-

--- a/.github/issue-evidence/12253-tts-loud-fail/01-failure-path-real-artifact-absence.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/01-failure-path-real-artifact-absence.log
@@ -1,0 +1,15 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-aa241a524930b43ae/plugins/plugin-local-inference
+
+stderr | src/services/router-tts-loud-fail-evidence.test.ts > #12253 failure-path evidence — Kokoro artifacts absent > the real router re-throws the real Kokoro error and never calls edge-tts
+[1m[97m[41m Error     [49m[39m[22m [LocalInferenceRouter] eliza-local-inference failed for TEXT_TO_SPEECH; failing closed — refusing to swap to another voice engine (provider=eliza-local-inference, slot=TEXT_TO_SPEECH, policy=prefer-local, error=[voice] Kokoro model artifacts are not present on disk; Kokoro is the only on-device TTS backend (install an Eliza-1 bundle or stage the Kokoro GGUF + at least one voice .bin)., alternativesRefused=1)
+
+ ✓ src/services/router-tts-loud-fail-evidence.test.ts > #12253 failure-path evidence — Kokoro artifacts absent > the real on-disk probe returns null when no artifacts are staged 1ms
+ ✓ src/services/router-tts-loud-fail-evidence.test.ts > #12253 failure-path evidence — Kokoro artifacts absent > the real engine selector throws a loud, actionable error (no silent downgrade) 0ms
+ ✓ src/services/router-tts-loud-fail-evidence.test.ts > #12253 failure-path evidence — Kokoro artifacts absent > the real router re-throws the real Kokoro error and never calls edge-tts 3ms
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+   Start at  21:23:10
+   Duration  3.37s (transform 2.48s, setup 0ms, import 3.30s, tests 5ms, environment 0ms)
+

--- a/.github/issue-evidence/12253-tts-loud-fail/02-router-policy-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/02-router-policy-tests.log
@@ -48,4 +48,3 @@ stdout | src/services/router-tts-fail-closed.test.ts > non-TTS slots keep transi
       Tests  27 passed (27)
    Start at  21:23:21
    Duration  3.39s (transform 7.41s, setup 0ms, import 9.75s, tests 14ms, environment 0ms)
-

--- a/.github/issue-evidence/12253-tts-loud-fail/02-router-policy-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/02-router-policy-tests.log
@@ -1,0 +1,51 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-aa241a524930b43ae/plugins/plugin-local-inference
+
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy (static tier) > classifier sanity: strong favours local, weak does not, OKAY desktop splits 1ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy (static tier) > routes a strong device to the local provider 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy (static tier) > routes a weak device to the highest-priority cloud provider 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy (static tier) > falls back to cloud when no device assessment is available 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy (static tier) > uses the only available provider even if it is local on a weak device 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC3 live-signal demotion > demotes a strong device to cloud under SERIOUS thermal throttling 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC3 live-signal demotion > demotes a strong device to cloud under CRITICAL thermal throttling 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC3 live-signal demotion > demotes a strong device to cloud when decode TPS is below budget 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC3 live-signal demotion > does NOT demote on fair thermal + healthy TPS 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC3 live-signal demotion > does NOT demote when live signals are unmeasured (null) 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC4 per-modality independence > one OKAY-desktop assessment yields local TEXT_LARGE + cloud TEXT_TO_SPEECH 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — auto policy AC4 per-modality independence > TRANSCRIPTION (voice slot) also routes to cloud on OKAY desktop 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — local-only / cloud-only (AC2) > local-only always returns the local provider, never cloud 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — local-only / cloud-only (AC2) > local-only returns null when no local handler exists (no silent cloud fallback) 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — local-only / cloud-only (AC2) > cloud-only always returns a cloud provider, never local 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — local-only / cloud-only (AC2) > cloud-only returns null when only local handlers exist 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — prefer-local capability soft-hint > keeps local-first when no assessment is provided 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — prefer-local capability soft-hint > demotes to cloud on a POOR device that cannot run a local LM 0ms
+ ✓ src/services/routing-policy.test.ts > PolicyEngine — prefer-local capability soft-hint > still prefers local on a strong device 0ms
+ ✓ src/services/routing-policy.test.ts > assessVoiceModality (#12253 voice-modality visibility) > is viable on a MAX-tier device that can run the local voice stack 0ms
+ ✓ src/services/routing-policy.test.ts > assessVoiceModality (#12253 voice-modality visibility) > is not viable on a tier that cannot run local voice, with a reason 0ms
+ ✓ src/services/routing-policy.test.ts > assessVoiceModality (#12253 voice-modality visibility) > is not viable with an explicit reason when the tier is unknown 0ms
+stderr | src/services/router-voice-modality-warn.test.ts > prefer-local TTS on an unviable device tier > routes to the configured cloud voice and warns exactly once per boot
+[1m[30m[43m Warn      [49m[39m[22m [LocalInferenceRouter] Local voice stack unviable on this device tier; TEXT_TO_SPEECH routes to a cloud voice by configuration (not error recovery) (slot=TEXT_TO_SPEECH, policy=prefer-local, reason=device-tier-poor-cannot-run-local-voice, tier=POOR)
+
+stderr | src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > re-throws the local Kokoro error and never invokes edge-tts (prefer-local)
+[1m[97m[41m Error     [49m[39m[22m [LocalInferenceRouter] eliza-local-inference failed for TEXT_TO_SPEECH; failing closed — refusing to swap to another voice engine (provider=eliza-local-inference, slot=TEXT_TO_SPEECH, policy=prefer-local, error=Kokoro artifacts missing: no runtime available, alternativesRefused=1)
+
+ ✓ src/services/router-voice-modality-warn.test.ts > prefer-local TTS on an unviable device tier > routes to the configured cloud voice and warns exactly once per boot 4ms
+stderr | src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > re-throws even when the picked cloud voice fails (no secondary rotation)
+[1m[97m[41m Error     [49m[39m[22m [LocalInferenceRouter] edge-tts failed for TEXT_TO_SPEECH; failing closed — refusing to swap to another voice engine (provider=edge-tts, slot=TEXT_TO_SPEECH, policy=prefer-local, error=edge-tts 503, alternativesRefused=1)
+
+stdout | src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > allows an explicitly configured manual multi-provider TTS chain to rotate
+[36m Info      [39m [router] Provider elevenlabs failed for TEXT_TO_SPEECH; trying fallback provider (elevenlabs down)
+
+stdout | src/services/router-tts-fail-closed.test.ts > non-TTS slots keep transient failover > rotates TEXT_LARGE to the next provider on failure (prefer-local, cloud-only)
+[36m Info      [39m [router] Provider openai failed for TEXT_LARGE; trying fallback provider (openai 500)
+
+ ✓ src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > re-throws the local Kokoro error and never invokes edge-tts (prefer-local) 4ms
+ ✓ src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > re-throws even when the picked cloud voice fails (no secondary rotation) 0ms
+ ✓ src/services/router-tts-fail-closed.test.ts > router fails closed for TEXT_TO_SPEECH (#12253) > allows an explicitly configured manual multi-provider TTS chain to rotate 1ms
+ ✓ src/services/router-tts-fail-closed.test.ts > non-TTS slots keep transient failover > rotates TEXT_LARGE to the next provider on failure (prefer-local, cloud-only) 0ms
+
+ Test Files  3 passed (3)
+      Tests  27 passed (27)
+   Start at  21:23:21
+   Duration  3.39s (transform 7.41s, setup 0ms, import 9.75s, tests 14ms, environment 0ms)
+

--- a/.github/issue-evidence/12253-tts-loud-fail/03-core-failover-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/03-core-failover-tests.log
@@ -17,4 +17,3 @@
       Tests  11 passed (11)
    Start at  21:23:24
    Duration  2.62s (transform 1.79s, setup 0ms, import 2.48s, tests 10ms, environment 0ms)
-

--- a/.github/issue-evidence/12253-tts-loud-fail/03-core-failover-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/03-core-failover-tests.log
@@ -1,0 +1,20 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-aa241a524930b43ae/packages/core
+
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > falls through to the next provider when the preferred provider is rate-limited 4ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > falls through on transient 5xx provider failures 1ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > falls through on Anthropic 529 overloaded provider failures 0ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > does not fall through for non-retryable provider errors 1ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > does NOT fall over for TEXT_TO_SPEECH, even on a transient-looking error (voice fails closed #12253) 0ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > still falls over for a text slot on the same fetch-failed error (heuristic intact) 0ms
+ ✓ src/runtime/__tests__/use-model-provider-fallback.test.ts > AgentRuntime.useModel provider fallback > honors an explicitly pinned provider instead of trying another provider 0ms
+ ✓ src/services/message/provider-error-hygiene.test.ts > provider error hygiene > classifies Anthropic 529 overloaded errors as failover-eligible and retryable 1ms
+ ✓ src/services/message/provider-error-hygiene.test.ts > provider error hygiene > never marks TEXT_TO_SPEECH errors as failover-eligible (voice fails closed #12253) 0ms
+ ✓ src/services/message/provider-error-hygiene.test.ts > provider error hygiene > marks transient failure replies as non-persisted response memories 0ms
+ ✓ src/services/message/provider-error-hygiene.test.ts > provider error hygiene > does not skip ordinary assistant replies 0ms
+
+ Test Files  2 passed (2)
+      Tests  11 passed (11)
+   Start at  21:23:24
+   Duration  2.62s (transform 1.79s, setup 0ms, import 2.48s, tests 10ms, environment 0ms)
+

--- a/.github/issue-evidence/12253-tts-loud-fail/04-ui-hook-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/04-ui-hook-tests.log
@@ -16,4 +16,3 @@ stderr | src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails cl
       Tests  3 passed (3)
    Start at  21:23:27
    Duration  4.18s (transform 2.61s, setup 24ms, import 3.42s, tests 123ms, environment 550ms)
-

--- a/.github/issue-evidence/12253-tts-loud-fail/04-ui-hook-tests.log
+++ b/.github/issue-evidence/12253-tts-loud-fail/04-ui-hook-tests.log
@@ -1,0 +1,19 @@
+ DEPRECATED  `test.poolOptions` was removed in Vitest 4. All previous `poolOptions` are now top-level options. Please, refer to the migration guide: https://vitest.dev/guide/migration#pool-rework
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/agent-aa241a524930b43ae/packages/ui
+
+stderr | src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails closed (#12253) > surfaces a ttsError and never speaks via the browser when local-inference 502s
+[useVoiceChat] local-inference TTS failed; failing closed (no voice-engine swap): Local inference TTS 502: kokoro artifacts missing
+
+stderr | src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails closed (#12253) > clears the ttsError on the next utterance
+[useVoiceChat] local-inference TTS failed; failing closed (no voice-engine swap): Local inference TTS 502: boom
+
+ ✓ src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails closed (#12253) > surfaces a ttsError and never speaks via the browser when local-inference 502s 64ms
+ ✓ src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails closed (#12253) > clears the ttsError on the next utterance 56ms
+ ✓ src/hooks/useVoiceChat.fail-closed.test.tsx > useVoiceChat TTS fails closed (#12253) > still speaks via the browser when the browser is the CONFIGURED engine (edge/unset) 3ms
+
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+   Start at  21:23:27
+   Duration  4.18s (transform 2.61s, setup 24ms, import 3.42s, tests 123ms, environment 550ms)
+

--- a/.github/issue-evidence/12253-tts-loud-fail/README.md
+++ b/.github/issue-evidence/12253-tts-loud-fail/README.md
@@ -1,0 +1,83 @@
+# #12253 — Voice TTS fails closed (no silent engine swap)
+
+Sub-issue of #12187. Kokoro is the on-device voice; a Kokoro failure must be a
+**loud error**, never a silent swap to a different voice engine. This directory
+holds the failure-path evidence: with the Kokoro artifacts genuinely absent, the
+whole chain fails loud and **no other voice plays**.
+
+## Per-site before → after
+
+| Site | Before (silent swap) | After (fails closed) |
+|---|---|---|
+| `plugins/plugin-local-inference/src/services/router-handler.ts` | ANY throw from the picked TTS provider rotated engines (Kokoro → elizacloud → elevenlabs → openai → groq → edge-tts) at `logger.info` | For `TEXT_TO_SPEECH` with any non-`manual` policy the router **re-throws** the structured error and `logger.error`s `failing closed — refusing to swap to another voice engine`. Only an explicit `manual` multi-provider chain still rotates. Non-TTS slots keep transient failover. |
+| `plugins/plugin-local-inference/src/services/routing-policy.ts` | `prefer-local` + unviable device tier silently demoted the voice slot to cloud | `assessVoiceModality()` surfaces the demotion; the router warns **once per boot** and the `/api/local-inference/providers` route returns `voiceModality`, so a config-by-hardware cloud voice can never masquerade as a Kokoro failure. Demotion itself is kept — it is configuration, not error recovery. |
+| `packages/core/src/runtime.ts` + `packages/core/src/services/message/fallback-reply.ts` | `shouldFailOverModelProvider` / `isModelProviderFallbackError` matched a Kokoro model-download `fetch failed` and rotated to the next registered TTS provider (`logger.warn`) | Both take `modelType`; `TEXT_TO_SPEECH` returns `false` unconditionally. A voice swap is never transient-recoverable. Text slots keep the heuristic. |
+| `packages/ui/src/hooks/useVoiceChat.ts` | local-inference / ElevenLabs / native-talkmode failure fell through to browser `SpeechSynthesis` (`ttsDebug` only) | Each configured-engine failure calls `failClosed(engine, error)`: sets a visible `ttsError` state, stops the queue, `console.error`s, and does **not** call `speakBrowser`. Cleared on the next utterance. Cloud-proxy → direct-ElevenLabs-proxy stays (same voice, now `console.warn`). Browser TTS remains valid only as the **configured** engine. |
+| `packages/ui/src/voice/voice-chat-types.ts` + `ChatVoiceStatusBar.tsx` + `ChatView.tsx` + `useContinuousChat.ts` | no user-visible surface for a silenced voice | `VoiceTtsError` type; the status bar renders a danger banner (`data-testid="chat-voice-tts-error"`) and force-shows even when otherwise hidden — a silenced voice is never invisible. |
+| `plugins/plugin-native-talkmode/ios/.../TalkModePlugin.swift` | ElevenLabs streaming failure → `speakWithSystemTts` (AVSpeechSynthesizer) | Emits `elevenlabs_failed` and `call.resolve({ usedSystemTts: false, error })` + returns; AVSpeechSynthesizer is reachable only when the caller explicitly requests the system engine, never as error recovery. |
+| `packages/app-core/src/runtime/voice-warmup.ts` | warmup went through the router, which could silently warm edge-tts and report a healthy warmup | Warmup goes through the router with no pinned provider; the router now fails closed for TTS, so a broken Kokoro surfaces its structured error at `warn` instead of a green warmup on a different voice. |
+
+## Failure-path evidence (this is the issue DoD)
+
+`01-failure-path-real-artifact-absence.log` — the real chain with Kokoro
+artifacts **genuinely absent on disk** (`ELIZA_KOKORO_MODEL_DIR` → an empty temp
+dir). No synthetic throw is injected; every step is the production code:
+
+1. `resolveKokoroEngineConfig()` (real on-disk probe) → `null`.
+2. `selectVoiceBackend({ kokoroAvailable: false })` (real engine selector) →
+   throws `[voice] Kokoro model artifacts are not present on disk; …`.
+3. The **real** router + policy engine (`prefer-local`, MAX tier) picks
+   `eliza-local-inference`, its handler runs the real gate above and throws; the
+   router **re-throws that exact error** and **never calls the registered
+   `edge-tts` handler**. Captured loud log:
+
+   ```
+   [LocalInferenceRouter] eliza-local-inference failed for TEXT_TO_SPEECH; failing
+   closed — refusing to swap to another voice engine (provider=eliza-local-inference,
+   slot=TEXT_TO_SPEECH, policy=prefer-local, error=[voice] Kokoro model artifacts are
+   not present on disk; …, alternativesRefused=1)
+   ```
+
+At the route boundary this structured error becomes **HTTP 502** (see
+`plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts:209,223`),
+and in the web UI it becomes the visible `ttsError` banner
+(`04-ui-hook-tests.log`, asserting a `502` sets `ttsError` and
+`speechSynthesis.speak` is never called). iOS talkmode resolves
+`usedSystemTts: false` with the error (source diff; Swift not runnable here).
+
+## Test transcripts (real paths, no mocked subject-under-test)
+
+| Log | Suite | Result |
+|---|---|---|
+| `01-failure-path-real-artifact-absence.log` | `router-tts-loud-fail-evidence.test.ts` — real on-disk absence → engine → router | 3 passed |
+| `02-router-policy-tests.log` | `router-tts-fail-closed` + `router-voice-modality-warn` + `routing-policy` | 27 passed |
+| `03-core-failover-tests.log` | `use-model-provider-fallback` + `provider-error-hygiene` (core failover excludes TTS) | 11 passed |
+| `04-ui-hook-tests.log` | `useVoiceChat.fail-closed` (visible ttsError, no browser swap) | 3 passed |
+
+The router/policy tests mock only `./hardware` (device tier) and
+`./routing-preferences` (policy) so the pick is host-independent; the router,
+policy engine, Kokoro gate, and core classifiers under test are the real code.
+
+## Reproduce
+
+```bash
+# Failure path (real artifact absence → loud fail, no swap)
+NODE_OPTIONS=--experimental-sqlite bun run --cwd plugins/plugin-local-inference \
+  test -- router-tts-loud-fail-evidence --reporter verbose
+
+# Full fail-closed contract
+bun run --cwd plugins/plugin-local-inference test -- router-tts-fail-closed router-voice-modality-warn routing-policy
+bun run --cwd packages/core test -- use-model-provider-fallback provider-error-hygiene
+bun run --cwd packages/ui test -- useVoiceChat.fail-closed
+```
+
+## Not captured here (with reason)
+
+- **Real STT→TTS audio round-trip / narrated walkthrough** — N/A: this change is
+  a *negative* path (voice must **not** play on failure). The positive audio
+  round-trip is unchanged and belongs to the sibling latency/quality issues
+  (#12254/#12258). The audible assertion here is *silence + a surfaced error*,
+  proven at the route/unit level above.
+- **iOS on-device capture** — N/A in this worktree (no simulator/device build).
+  The Swift fail-closed change is a source diff; the web + router + core paths
+  are exercised for real above.

--- a/packages/app-core/src/runtime/voice-warmup.ts
+++ b/packages/app-core/src/runtime/voice-warmup.ts
@@ -1,15 +1,19 @@
 /**
- * voice-warmup — background "warm like embedding" for voice models.
+ * Background "warm like embedding" for voice models.
  *
- * Unlike embedding (which has a runtime-free `ensureModel` facade), the voice
- * models (local Whisper STT / Kokoro TTS, or cloud ElevenLabs) only load
- * through the live agent runtime's `useModel(TRANSCRIPTION | TEXT_TO_SPEECH, …)`
- * path — the Kokoro bridge auto-starts on the first TEXT_TO_SPEECH call, and
- * the cloud handler validates its connection. So we warm them AFTER the runtime
- * is ready by firing one tiny request at each, fire-and-forget. That actually
- * loads (not just downloads) the models, so the first real voice interaction is
- * instant — the embedding warmup's spirit, via the path voice already uses.
- * Nothing in the voice engine is touched.
+ * Voice models load only through the live agent runtime's
+ * `useModel(TRANSCRIPTION | TEXT_TO_SPEECH, …)` path, so we warm them AFTER the
+ * runtime is ready by firing one tiny request at each, fire-and-forget. That
+ * loads (not just downloads) the model the session will use, so the first real
+ * interaction is instant.
+ *
+ * The warmup call goes through the model router with NO pinned provider, so it
+ * exercises exactly the engine the session will use. It never picks the engine
+ * itself: the router fails closed for `TEXT_TO_SPEECH` (#12253), so a broken
+ * Kokoro surfaces its structured error here — logged at `warn` — instead of the
+ * router silently swapping in edge-tts and reporting a healthy warmup. Warmup is
+ * a first-use-latency optimization; a failure is non-fatal (the model loads on
+ * first real use) but is never masked by warming a different voice.
  *
  * Warmup is skipped for mobile, hot-reload respawns, explicit cloud-only
  * desktop runtimes, and ELIZA_SKIP_LOCAL_VOICE_WARMUP=1.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4836,8 +4836,11 @@ export class AgentRuntime implements IAgentRuntime {
 		);
 	}
 
-	private shouldFailOverModelProvider(error: unknown): boolean {
-		return isModelProviderFallbackError(error);
+	private shouldFailOverModelProvider(
+		error: unknown,
+		modelType: string,
+	): boolean {
+		return isModelProviderFallbackError(error, modelType);
 	}
 
 	private throwNoModelHandler(requestedModelKey: string): never {
@@ -5966,7 +5969,7 @@ export class AgentRuntime implements IAgentRuntime {
 					requestedProvider !== undefined ||
 					!nextModel ||
 					providerAttemptStartedOutput ||
-					!this.shouldFailOverModelProvider(error)
+					!this.shouldFailOverModelProvider(error, requestedModelKey)
 				) {
 					this.rethrowModelFailoverError(error);
 				}

--- a/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
@@ -93,6 +93,49 @@ describe("AgentRuntime.useModel provider fallback", () => {
 		expect(backup).not.toHaveBeenCalled();
 	});
 
+	it("does NOT fall over for TEXT_TO_SPEECH, even on a transient-looking error (voice fails closed #12253)", async () => {
+		const runtime = makeRuntime();
+		// A Kokoro model-download failure surfaces as "fetch failed", which the
+		// transient heuristic matches for text slots — but a voice swap is never
+		// transient-recoverable, so TTS must fail closed rather than rotate to a
+		// different voice engine.
+		const kokoroFails = vi.fn(async () => {
+			throw new Error("fetch failed: kokoro artifacts unreachable");
+		});
+		const edgeTts = vi.fn(async () => new Uint8Array([1, 2, 3]));
+
+		runtime.registerModel(
+			ModelType.TEXT_TO_SPEECH,
+			kokoroFails,
+			"eliza-local-inference",
+			100,
+		);
+		runtime.registerModel(ModelType.TEXT_TO_SPEECH, edgeTts, "edge-tts", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_TO_SPEECH, { text: "hello" }),
+		).rejects.toThrow("fetch failed");
+		expect(kokoroFails).toHaveBeenCalledTimes(1);
+		expect(edgeTts).not.toHaveBeenCalled();
+	});
+
+	it("still falls over for a text slot on the same fetch-failed error (heuristic intact)", async () => {
+		const runtime = makeRuntime();
+		const primary = vi.fn(async () => {
+			throw new Error("fetch failed");
+		});
+		const backup = vi.fn(async () => "backup-response");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, primary, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, backup, "eliza-cloud", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("backup-response");
+		expect(primary).toHaveBeenCalledTimes(1);
+		expect(backup).toHaveBeenCalledTimes(1);
+	});
+
 	it("honors an explicitly pinned provider instead of trying another provider", async () => {
 		const runtime = makeRuntime();
 		const cliSdkFails = vi.fn(async () => {

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -1,3 +1,5 @@
+import { ModelType } from "../../types/model";
+
 type ErrorWithStatus = {
 	status?: unknown;
 	statusCode?: unknown;
@@ -100,8 +102,20 @@ export function isAuthError(error: unknown): boolean {
  * This intentionally includes {@link isRateLimitError} so subscription-credit
  * exhaustion from CLI-SDK providers follows the same structural 429/session-limit
  * classifier as the graceful reply path.
+ *
+ * `modelType` gates the decision per slot. `TEXT_TO_SPEECH` never fails over:
+ * a voice swap is not a transient-recoverable condition, and a Kokoro
+ * model-download failure surfaces as `fetch failed`, which would otherwise match
+ * the transient heuristics below and silently rotate to a different voice engine
+ * (#12253). TTS fails closed — the configured voice errors loudly instead.
  */
-export function isModelProviderFallbackError(error: unknown): boolean {
+export function isModelProviderFallbackError(
+	error: unknown,
+	modelType?: string,
+): boolean {
+	if (modelType === ModelType.TEXT_TO_SPEECH) {
+		return false;
+	}
 	const unwrapped = unwrapRetryError(error);
 	if (isRateLimitError(error)) {
 		return true;

--- a/packages/core/src/services/message/provider-error-hygiene.test.ts
+++ b/packages/core/src/services/message/provider-error-hygiene.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Memory } from "../../types";
+import { type Memory, ModelType } from "../../types";
 import { shouldSkipResponseMemoryPersistence } from "../message";
 import {
 	isModelProviderFallbackError,
@@ -32,6 +32,23 @@ describe("provider error hygiene", () => {
 
 		expect(isModelProviderFallbackError(error)).toBe(true);
 		expect(isRateLimitError(error)).toBe(true);
+	});
+
+	it("never marks TEXT_TO_SPEECH errors as failover-eligible (voice fails closed #12253)", () => {
+		// "fetch failed" (Kokoro model-download failure) matches the transient
+		// heuristic for text slots, but a voice swap is not transient-recoverable.
+		const kokoroDownloadError = new Error("fetch failed");
+		expect(isModelProviderFallbackError(kokoroDownloadError)).toBe(true);
+		expect(
+			isModelProviderFallbackError(kokoroDownloadError, ModelType.TEXT_TO_SPEECH),
+		).toBe(false);
+		// A genuine 5xx from a TTS provider is likewise not a swap trigger.
+		const serviceError = Object.assign(new Error("service unavailable"), {
+			statusCode: 503,
+		});
+		expect(
+			isModelProviderFallbackError(serviceError, ModelType.TEXT_TO_SPEECH),
+		).toBe(false);
 	});
 
 	it("marks transient failure replies as non-persisted response memories", () => {

--- a/packages/core/src/services/message/provider-error-hygiene.test.ts
+++ b/packages/core/src/services/message/provider-error-hygiene.test.ts
@@ -40,7 +40,10 @@ describe("provider error hygiene", () => {
 		const kokoroDownloadError = new Error("fetch failed");
 		expect(isModelProviderFallbackError(kokoroDownloadError)).toBe(true);
 		expect(
-			isModelProviderFallbackError(kokoroDownloadError, ModelType.TEXT_TO_SPEECH),
+			isModelProviderFallbackError(
+				kokoroDownloadError,
+				ModelType.TEXT_TO_SPEECH,
+			),
 		).toBe(false);
 		// A genuine 5xx from a TTS provider is likewise not a swap trigger.
 		const serviceError = Object.assign(new Error("service unavailable"), {

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
@@ -10,15 +10,23 @@
  * - latency badge (speechEnd → voiceStart) with traffic-light colouring
  */
 
-import { Crown, RefreshCw, VolumeX } from "lucide-react";
+import { AlertTriangle, Crown, RefreshCw, VolumeX } from "lucide-react";
 import type * as React from "react";
 import type { ContinuousChatLatency } from "../../../hooks/useContinuousChat";
 import { cn } from "../../../lib/utils";
 import type {
   VoiceContinuousStatus,
   VoiceSpeakerMetadata,
+  VoiceTtsError,
 } from "../../../voice/voice-chat-types";
 import { Button } from "../../ui/button";
+
+/** User-facing label per failed engine for the fail-closed TTS banner (#12253). */
+const TTS_ERROR_ENGINE_LABEL: Record<VoiceTtsError["engine"], string> = {
+  "local-inference": "on-device voice",
+  elevenlabs: "ElevenLabs voice",
+  "native-talkmode": "voice",
+};
 
 export interface ChatVoiceStatusBarProps {
   status: VoiceContinuousStatus;
@@ -36,6 +44,12 @@ export interface ChatVoiceStatusBarProps {
   onUnlockAudio?: () => void;
   /** Transient pulse: browser speech recognition silently auto-reconnected. */
   micReconnected?: boolean;
+  /**
+   * Set when the configured TTS engine failed and playback was stopped WITHOUT
+   * substituting another voice (#12253). Rendered as a danger banner; forces the
+   * bar visible so a silent failure is never invisible.
+   */
+  ttsError?: VoiceTtsError | null;
   /** Visible only when continuous mode is on AND we have something to show. */
   visible?: boolean;
   className?: string;
@@ -91,11 +105,14 @@ export function ChatVoiceStatusBar({
   needsAudioUnlock = false,
   onUnlockAudio,
   micReconnected = false,
+  ttsError = null,
   visible = true,
   className,
   "data-testid": dataTestId,
 }: ChatVoiceStatusBarProps): React.ReactElement | null {
-  if (!visible) return null;
+  // A fail-closed TTS error must always show, even if the bar is otherwise
+  // hidden — a silenced voice with no explanation is exactly the bug (#12253).
+  if (!visible && !ttsError) return null;
 
   const speakerEntityId = speaker?.entityId ?? null;
   const isOwnerSpeaking =
@@ -132,6 +149,20 @@ export function ChatVoiceStatusBar({
       >
         {STATUS_LABEL[status]}
       </span>
+
+      {ttsError ? (
+        <span
+          className="inline-flex min-w-0 items-center gap-1 rounded-sm border border-danger/40 bg-danger/10 px-2 py-0.5 font-medium text-danger"
+          data-testid="chat-voice-tts-error"
+          data-engine={ttsError.engine}
+          title={ttsError.message}
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <span className="truncate">
+            {TTS_ERROR_ENGINE_LABEL[ttsError.engine]} unavailable
+          </span>
+        </span>
+      ) : null}
 
       {speakerName ? (
         <span

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -726,7 +726,7 @@ export function ChatView({
 
   const auxiliaryNode = (
     <>
-      {voiceStatusBarVisible ? (
+      {voiceStatusBarVisible || continuous.ttsError ? (
         <ChatVoiceStatusBar
           status={continuous.status}
           interimTranscript={continuous.interimTranscript}
@@ -735,7 +735,8 @@ export function ChatView({
           needsAudioUnlock={continuous.needsAudioUnlock}
           onUnlockAudio={continuous.unlockAudio}
           micReconnected={continuous.micReconnected}
-          visible
+          ttsError={continuous.ttsError}
+          visible={voiceStatusBarVisible}
           className={`mb-1 relative${isGameModal ? " pointer-events-auto" : ""}`}
           data-testid="chat-view-voice-status-bar"
         />

--- a/packages/ui/src/hooks/useContinuousChat.ts
+++ b/packages/ui/src/hooks/useContinuousChat.ts
@@ -26,6 +26,7 @@ import {
   type VoiceContinuousMode,
   type VoiceContinuousStatus,
   type VoiceSpeakerMetadata,
+  type VoiceTtsError,
 } from "../voice/voice-chat-types";
 
 export interface ContinuousChatLatency {
@@ -107,6 +108,11 @@ export interface ContinuousChatState {
    * user gesture, clearing `needsAudioUnlock`. Safe to call when already unlocked.
    */
   unlockAudio: () => void;
+  /**
+   * Mirror of `voice.ttsError`: set when the configured TTS engine failed and
+   * the queue was stopped WITHOUT swapping voices (#12253). `null` otherwise.
+   */
+  ttsError: VoiceTtsError | null;
   /** Start a new optimistic turn (R11 cancellation contract surface). */
   startTurn: () => ContinuousChatCancellationToken;
   /** Manually stop continuous capture without resetting `mode`. */
@@ -356,6 +362,7 @@ export function useContinuousChat(
     needsAudioUnlock: voice.needsAudioUnlock ?? false,
     micReconnected: voice.micReconnected ?? false,
     unlockAudio: voice.unlockAudio ?? NOOP_UNLOCK_AUDIO,
+    ttsError: voice.ttsError ?? null,
     startTurn,
     pause,
     resume,

--- a/packages/ui/src/hooks/useVoiceChat.fail-closed.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.fail-closed.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+/**
+ * useVoiceChat TTS fail-closed contract (#12253): when the configured voice
+ * engine fails, the hook surfaces a visible `ttsError`, stops the queue, and
+ * never silently swaps to browser SpeechSynthesis. Browser TTS stays valid only
+ * as the *configured* engine. Drives the real hook + real processQueue with a
+ * mocked HTTP layer and audio graph.
+ */
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithCsrf = vi.fn();
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: (...args: unknown[]) => fetchWithCsrf(...args),
+}));
+
+import { useVoiceChat } from "./useVoiceChat";
+
+class FakeUtterance extends EventTarget {
+  text: string;
+  lang = "";
+  rate = 1;
+  pitch = 1;
+  voice: SpeechSynthesisVoice | null = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: SpeechSynthesisErrorEvent) => void) | null = null;
+  constructor(text: string) {
+    super();
+    this.text = text;
+  }
+}
+
+const speechSynthesisMock = {
+  speaking: false,
+  pending: false,
+  spoken: [] as FakeUtterance[],
+  cancel: vi.fn(),
+  getVoices: vi.fn(() => []),
+  speak: vi.fn((u: FakeUtterance) => {
+    speechSynthesisMock.spoken.push(u);
+    u.onstart?.();
+    u.onend?.();
+  }),
+};
+
+class FakeAudioContext {
+  state = "running";
+  destination = {};
+  resume = vi.fn(async () => {});
+  createAnalyser = vi.fn(() => ({
+    fftSize: 2048,
+    smoothingTimeConstant: 0.8,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+  createBufferSource = vi.fn(() => ({
+    buffer: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    start: vi.fn(),
+    onended: null,
+  }));
+  decodeAudioData = vi.fn(async () => ({ duration: 0.1 }));
+  close = vi.fn(async () => {});
+}
+
+function installMocks() {
+  speechSynthesisMock.spoken = [];
+  speechSynthesisMock.speak.mockClear();
+  speechSynthesisMock.cancel.mockClear();
+  fetchWithCsrf.mockReset();
+  Object.defineProperty(window, "speechSynthesis", {
+    configurable: true,
+    value: speechSynthesisMock,
+  });
+  Object.defineProperty(window, "SpeechSynthesisUtterance", {
+    configurable: true,
+    value: FakeUtterance,
+  });
+  Object.defineProperty(globalThis, "SpeechSynthesisUtterance", {
+    configurable: true,
+    value: FakeUtterance,
+  });
+  Object.defineProperty(globalThis, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  Object.defineProperty(window, "AudioContext", {
+    configurable: true,
+    value: FakeAudioContext,
+  });
+  window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) =>
+    window.setTimeout(() => cb(performance.now()), 16),
+  ) as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = vi.fn((id: number) => clearTimeout(id));
+}
+
+describe("useVoiceChat TTS fails closed (#12253)", () => {
+  beforeEach(() => {
+    installMocks();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces a ttsError and never speaks via the browser when local-inference 502s", async () => {
+    fetchWithCsrf.mockResolvedValue(
+      new Response("kokoro artifacts missing", {
+        status: 502,
+        statusText: "Bad Gateway",
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "local-inference" },
+      }),
+    );
+
+    act(() => {
+      result.current.speak("hello there");
+    });
+
+    await waitFor(() => {
+      expect(result.current.ttsError).not.toBeNull();
+    });
+
+    expect(result.current.ttsError?.engine).toBe("local-inference");
+    expect(result.current.ttsError?.message).toContain("502");
+    // The whole point: NO silent swap to browser SpeechSynthesis.
+    expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    // The local-inference route was actually hit (real path, not short-circuit).
+    expect(fetchWithCsrf).toHaveBeenCalledWith(
+      expect.stringContaining("/api/tts/local-inference"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result.current.isSpeaking).toBe(false);
+  });
+
+  it("clears the ttsError on the next utterance", async () => {
+    fetchWithCsrf.mockResolvedValueOnce(
+      new Response("boom", { status: 502, statusText: "Bad Gateway" }),
+    );
+    // Second attempt: succeed with a WAV payload so no error is raised.
+    fetchWithCsrf.mockResolvedValueOnce(
+      new Response(new Uint8Array([1, 2, 3, 4]).buffer, {
+        status: 200,
+        headers: { "Content-Type": "audio/wav" },
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "local-inference" },
+      }),
+    );
+
+    act(() => {
+      result.current.speak("first");
+    });
+    await waitFor(() => {
+      expect(result.current.ttsError).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.speak("second");
+    });
+    await waitFor(() => {
+      expect(result.current.ttsError).toBeNull();
+    });
+    expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+  });
+
+  it("still speaks via the browser when the browser is the CONFIGURED engine (edge/unset)", async () => {
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: { provider: "edge" },
+      }),
+    );
+
+    act(() => {
+      result.current.speak("configured browser voice");
+    });
+
+    await waitFor(() => {
+      expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.ttsError ?? null).toBeNull();
+    // Never reached the local-inference route — the browser IS the config.
+    expect(fetchWithCsrf).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -1899,7 +1899,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           // Native mobile (Android/iOS Capacitor): route the reply through the
           // native TalkMode engine (Kotlin AudioTrack / on-device local-inference
           // TTS) per the Android TTS-owner decision, instead of the WebView
-          // AudioContext path. Falls through to the web TTS path on a native error.
+          // AudioContext path. Native errors fail closed below so the configured
+          // voice is not silently swapped for a different engine.
           if (Capacitor.isNativePlatform()) {
             const trimmed = task.text.trim();
             if (!trimmed) continue;

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -98,6 +98,7 @@ import {
   type VoiceSpeakerMetadata,
   type VoiceTranscriptEvent,
   type VoiceTranscriptPreviewEvent,
+  type VoiceTtsError,
   type VoiceTurn,
   webSpeechVoiceDebugFields,
 } from "../voice/voice-chat-types";
@@ -259,6 +260,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const micReconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  // Set when the configured TTS engine fails and the queue is stopped WITHOUT
+  // substituting a different voice (#12253). The voice UI renders this as a
+  // toast/banner; cleared on the next enqueue/stop.
+  const [ttsError, setTtsError] = useState<VoiceTtsError | null>(null);
 
   // Refs — stable across renders, read from animation loop & callbacks
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
@@ -1129,6 +1134,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     cancelPlayback();
     setIsSpeaking(false);
     setUsingAudioAnalysis(false);
+    setTtsError(null);
   }, [cancelPlayback]);
   interruptSpeechRef.current = stopSpeaking;
 
@@ -1258,11 +1264,23 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               return cloudRes;
             }
 
+            // Same-engine transport fallback (cloud proxy → direct ElevenLabs
+            // proxy): still ElevenLabs, same voice — NOT a voice swap (#12253).
+            // Log at warn (not debug-only) so the retry is visible in the
+            // console without the TTS debug flag.
+            console.warn(
+              `[useVoiceChat] Cloud TTS proxy returned ${cloudRes.status}; retrying via the direct ElevenLabs proxy (same voice)`,
+            );
             ttsDebug("useVoiceChat:cloud-proxy-fallback", {
               status: cloudRes.status,
               ttsTarget: describeTtsCloudFetchTargetForDebug(),
             });
           } catch (error) {
+            console.warn(
+              `[useVoiceChat] Cloud TTS proxy unreachable; retrying via the direct ElevenLabs proxy (same voice): ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
             ttsDebug("useVoiceChat:cloud-proxy-unavailable", {
               ttsTarget: describeTtsCloudFetchTargetForDebug(),
               error: error instanceof Error ? error.message : String(error),
@@ -1831,6 +1849,26 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
     void (async () => {
       let workerError: unknown = null;
+      // Set alongside `workerError` at a fail-closed site so the tail can raise
+      // a user-visible error state instead of silently swapping voices (#12253).
+      let ttsFailure: VoiceTtsError | null = null;
+      const failClosed = (
+        engine: VoiceTtsError["engine"],
+        error: unknown,
+      ): void => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[useVoiceChat] ${engine} TTS failed; failing closed (no voice-engine swap): ${message}`,
+        );
+        workerError = error;
+        ttsFailure = {
+          engine,
+          message,
+          atMs:
+            typeof performance !== "undefined" ? performance.now() : Date.now(),
+        };
+        queueRef.current = [];
+      };
       try {
         while (queueRef.current.length > 0) {
           if (workerGeneration !== generationRef.current) break;
@@ -1890,13 +1928,19 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ) {
                 break;
               }
-              ttsDebug("useVoiceChat:native-talkmode-failed-fallback", {
+              // FAIL CLOSED (#12253): the native talkmode engine is the
+              // configured voice. Do not fall through to the web TTS chain
+              // (a different voice) — stop the queue and surface the error.
+              usingAudioAnalysisRef.current = false;
+              setUsingAudioAnalysis(false);
+              ttsDebug("useVoiceChat:native-talkmode-failed", {
                 err:
                   error instanceof Error
                     ? `${error.name}: ${error.message.slice(0, 200)}`
                     : String(error).slice(0, 200),
               });
-              // Fall through to the web TTS path (elevenlabs/local/browser).
+              failClosed("native-talkmode", error);
+              break;
             }
           }
 
@@ -1921,23 +1965,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                     ? `${error.name}: ${error.message.slice(0, 200)}`
                     : String(error).slice(0, 200),
               });
-              // Local TTS failed — fall back to browser SpeechSynthesis so the
-              // reply stays audible rather than going silent. Only hard-error
-              // if the fallback ALSO fails.
-              try {
-                await speakBrowser(task.text, task, workerGeneration);
-                continue;
-              } catch (fallbackError) {
-                if (
-                  workerGeneration !== generationRef.current ||
-                  isAbortError(fallbackError)
-                ) {
-                  break;
-                }
-                workerError = fallbackError;
-                queueRef.current = [];
-                break;
-              }
+              // FAIL CLOSED (#12253): local-inference (Kokoro) is the configured
+              // voice. Do not silently swap to browser SpeechSynthesis — stop the
+              // queue and surface the error so the user hears silence + sees why,
+              // not a stranger's voice.
+              failClosed("local-inference", error);
+              break;
             }
           }
 
@@ -1969,24 +2002,14 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               });
               usingAudioAnalysisRef.current = false;
               setUsingAudioAnalysis(false);
-              // Cloud TTS failed (commonly: no ElevenLabs / cloud key on a
-              // default deploy). Fall back to the browser's built-in
-              // SpeechSynthesis so the reply is still AUDIBLE instead of going
-              // silent. Only hard-error if that fallback ALSO fails.
-              try {
-                await speakBrowser(task.text, task, workerGeneration);
-                continue;
-              } catch (fallbackError) {
-                if (
-                  workerGeneration !== generationRef.current ||
-                  isAbortError(fallbackError)
-                ) {
-                  break;
-                }
-                workerError = fallbackError;
-                queueRef.current = [];
-                break;
-              }
+              // FAIL CLOSED (#12253): ElevenLabs is the explicitly configured
+              // voice here (provider === "elevenlabs"). Do not silently swap to
+              // browser SpeechSynthesis — stop the queue and surface the error.
+              // (Same-engine transport retries live inside speakElevenLabs: the
+              // cloud proxy → /api/tts/elevenlabs retry is ElevenLabs→ElevenLabs,
+              // not a voice swap.)
+              failClosed("elevenlabs", error);
+              break;
             }
           } else {
             usingAudioAnalysisRef.current = false;
@@ -2025,6 +2048,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         usingAudioAnalysisRef.current = false;
         setUsingAudioAnalysis(false);
         setIsSpeaking(false);
+        // Raise a user-visible error only when a configured engine failed
+        // closed (#12253); the generic catch above leaves ttsFailure null.
+        if (ttsFailure) {
+          setTtsError(ttsFailure);
+        }
         return;
       }
       if (queueRef.current.length > 0) {
@@ -2041,6 +2069,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     (task: SpeakTask) => {
       const speakable = toSpeakableText(task.text);
       if (!speakable) return;
+
+      // A new utterance clears any prior fail-closed TTS error banner (#12253).
+      setTtsError(null);
 
       if (!task.append) {
         cancelPlayback();
@@ -2361,5 +2392,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     micReconnected,
     unlockAudio,
     assistantTtsQuality,
+    ttsError,
   };
 }

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -217,6 +217,21 @@ export interface QueueAssistantSpeechOptions {
   singing?: boolean;
 }
 
+/**
+ * A TTS engine failure that must be shown to the user rather than silently
+ * papered over with a different voice (#12253). The configured voice engine
+ * (Kokoro local-inference, ElevenLabs, or native talkmode) failed and the
+ * queue was stopped — no fallback voice was substituted.
+ */
+export interface VoiceTtsError {
+  /** Which engine failed: `local-inference`, `elevenlabs`, or `native-talkmode`. */
+  engine: "local-inference" | "elevenlabs" | "native-talkmode";
+  /** Human-readable failure message for a toast/banner. */
+  message: string;
+  /** UI monotonic timestamp (performance.now) when the failure surfaced. */
+  atMs: number;
+}
+
 export interface VoiceChatState {
   /** Whether voice input is currently active */
   isListening: boolean;
@@ -285,6 +300,15 @@ export interface VoiceChatState {
    * `standard` = browser / Edge voices or non-ElevenLabs provider.
    */
   assistantTtsQuality: "enhanced" | "standard";
+  /**
+   * Set when the configured TTS engine failed and the queue was stopped
+   * WITHOUT substituting a different voice (#12253). The voice UI surfaces this
+   * as a toast/banner. `null` when there is no outstanding failure; cleared on
+   * the next enqueue/stop. Optional on the interface so existing
+   * `VoiceChatState` mocks stay valid; `useVoiceChat` always returns a concrete
+   * value.
+   */
+  ttsError?: VoiceTtsError | null;
 }
 
 export interface SpeakTask {

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
@@ -27,6 +27,8 @@ import {
 } from "../services/handler-registry";
 import { tryGetMemoryArbiter } from "../services/memory-arbiter";
 import { snapshotProviders } from "../services/providers";
+import { resolveDeviceTier } from "../services/router-handler";
+import { assessVoiceModality } from "../services/routing-policy";
 import {
 	isRoutingPolicy,
 	ROUTING_POLICIES,
@@ -409,8 +411,18 @@ export async function handleLocalInferenceCompatRoutes(
 	if (method === "GET" && pathname === "/api/local-inference/providers") {
 		if (!(await ensureRouteAuthorized(req, res, state))) return true;
 		try {
-			const providers = await snapshotProviders();
-			sendJsonResponse(res, 200, { providers });
+			const [providers, deviceTier] = await Promise.all([
+				snapshotProviders(),
+				resolveDeviceTier(),
+			]);
+			// voiceModality tells the UI whether the local voice stack (Kokoro TTS /
+			// local ASR) can run on this device tier. When not viable, a cloud voice
+			// is the *configured* default — surfacing the reason here lets the UI
+			// explain that instead of the router silently swapping engines (#12253).
+			sendJsonResponse(res, 200, {
+				providers,
+				voiceModality: assessVoiceModality(deviceTier),
+			});
 		} catch (err) {
 			sendJsonErrorResponse(
 				res,

--- a/plugins/plugin-local-inference/src/services/router-handler.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.ts
@@ -406,17 +406,17 @@ function makeRouterHandler(slot: AgentModelSlot): AnyHandler {
 
 				if (manualPreferred || !hasAlternative || ttsFailsClosed) {
 					if (ttsFailsClosed && hasAlternative) {
+						const rawCode =
+							err instanceof Error
+								? (err as { code?: unknown }).code
+								: undefined;
 						logger.error(
 							{
 								provider: pick.provider,
 								slot,
 								policy,
 								error: err instanceof Error ? err.message : String(err),
-								errorCode:
-									err instanceof Error &&
-									typeof (err as { code?: unknown }).code === "string"
-										? (err as { code: string }).code
-										: undefined,
+								errorCode: typeof rawCode === "string" ? rawCode : undefined,
 								alternativesRefused: remaining.length - 1,
 							},
 							`[LocalInferenceRouter] ${pick.provider} failed for TEXT_TO_SPEECH; failing closed — refusing to swap to another voice engine`,

--- a/plugins/plugin-local-inference/src/services/router-handler.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.ts
@@ -73,7 +73,7 @@ import { localInferenceEngine } from "./engine";
 import { handlerRegistry } from "./handler-registry";
 import { probeHardware } from "./hardware";
 import { type LiveDeviceSignals, readLiveDeviceSignals } from "./live-signals";
-import { policyEngine } from "./routing-policy";
+import { assessVoiceModality, policyEngine } from "./routing-policy";
 import {
 	DEFAULT_ROUTING_POLICY,
 	type RoutingPolicy,
@@ -101,7 +101,15 @@ const DEVICE_TIER_TTL_MS = 30_000;
 let cachedDeviceTier: { at: number; assessment: DeviceTierAssessment } | null =
 	null;
 
-async function resolveDeviceTier(): Promise<DeviceTierAssessment | null> {
+/**
+ * Guards the once-per-boot warn emitted when a voice slot is routed to cloud
+ * because the device tier cannot run the local voice stack. The demotion is a
+ * legitimate configuration-by-hardware decision, but it must be announced so it
+ * can never masquerade as (or mask) a Kokoro artifact failure.
+ */
+let warnedVoiceModalityUnviable = false;
+
+export async function resolveDeviceTier(): Promise<DeviceTierAssessment | null> {
 	const now = Date.now();
 	if (cachedDeviceTier && now - cachedDeviceTier.at < DEVICE_TIER_TTL_MS) {
 		return cachedDeviceTier.assessment;
@@ -308,6 +316,30 @@ function makeRouterHandler(slot: AgentModelSlot): AnyHandler {
 			liveSignals = readLiveDeviceSignals();
 		}
 
+		// Voice-modality visibility (#12253): when a prefer-local/auto policy will
+		// route a voice slot to cloud because the device tier can't run the local
+		// voice stack, announce it once per boot. This is a configuration-by-
+		// hardware decision (kept), not error recovery — surfacing it keeps a
+		// genuine Kokoro artifact failure from hiding behind a "tier unviable" swap.
+		if (
+			(policy === "prefer-local" || policy === "auto") &&
+			(slot === "TEXT_TO_SPEECH" || slot === "TRANSCRIPTION")
+		) {
+			const voiceModality = assessVoiceModality(deviceTier);
+			if (!voiceModality.viable && !warnedVoiceModalityUnviable) {
+				warnedVoiceModalityUnviable = true;
+				logger.warn(
+					{
+						slot,
+						policy,
+						reason: voiceModality.reason,
+						tier: deviceTier?.tier ?? null,
+					},
+					`[LocalInferenceRouter] Local voice stack unviable on this device tier; ${slot} routes to a cloud voice by configuration (not error recovery)`,
+				);
+			}
+		}
+
 		const failedProviders = new Set<string>();
 		let lastError: unknown = null;
 
@@ -361,7 +393,35 @@ function makeRouterHandler(slot: AgentModelSlot): AnyHandler {
 				const hasAlternative = remaining.some(
 					(candidate) => candidate.provider !== pick.provider,
 				);
-				if (manualPreferred || !hasAlternative) {
+
+				// TTS fails closed (#12253): a configured voice may fail, but it must
+				// never be silently swapped for a different engine. Rotating providers
+				// on failure IS a silent voice swap (Kokoro → elizacloud → elevenlabs
+				// → … → edge-tts), so every automatic policy re-throws the structured
+				// error and lets the caller surface it (HTTP 502 / UI error state). The
+				// only legitimate multi-provider TTS chain is one the user explicitly
+				// configured via `manual` policy. Non-TTS slots keep transient failover.
+				const ttsFailsClosed =
+					slot === "TEXT_TO_SPEECH" && policy !== "manual";
+
+				if (manualPreferred || !hasAlternative || ttsFailsClosed) {
+					if (ttsFailsClosed && hasAlternative) {
+						logger.error(
+							{
+								provider: pick.provider,
+								slot,
+								policy,
+								error: err instanceof Error ? err.message : String(err),
+								errorCode:
+									err instanceof Error &&
+									typeof (err as { code?: unknown }).code === "string"
+										? (err as { code: string }).code
+										: undefined,
+								alternativesRefused: remaining.length - 1,
+							},
+							`[LocalInferenceRouter] ${pick.provider} failed for TEXT_TO_SPEECH; failing closed — refusing to swap to another voice engine`,
+						);
+					}
 					throw err;
 				}
 

--- a/plugins/plugin-local-inference/src/services/router-handler.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.ts
@@ -401,8 +401,7 @@ function makeRouterHandler(slot: AgentModelSlot): AnyHandler {
 				// error and lets the caller surface it (HTTP 502 / UI error state). The
 				// only legitimate multi-provider TTS chain is one the user explicitly
 				// configured via `manual` policy. Non-TTS slots keep transient failover.
-				const ttsFailsClosed =
-					slot === "TEXT_TO_SPEECH" && policy !== "manual";
+				const ttsFailsClosed = slot === "TEXT_TO_SPEECH" && policy !== "manual";
 
 				if (manualPreferred || !hasAlternative || ttsFailsClosed) {
 					if (ttsFailsClosed && hasAlternative) {

--- a/plugins/plugin-local-inference/src/services/router-tts-fail-closed.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-tts-fail-closed.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Router fail-closed contract for TEXT_TO_SPEECH (#12253): a configured voice
+ * may fail, but the router must never silently rotate to a different engine.
+ * Drives the real router + real policy engine against a fake runtime.models map
+ * (the introspection path), with a strong device tier so prefer-local
+ * deterministically prefers the local voice regardless of the host.
+ */
+
+import {
+	type AgentRuntime,
+	type IAgentRuntime,
+	ModelType,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prefsState = {
+	policy: {} as Record<string, string>,
+	preferredProvider: {} as Record<string, string>,
+};
+
+vi.mock("./routing-preferences", () => ({
+	DEFAULT_ROUTING_POLICY: "prefer-local",
+	readRoutingPreferences: vi.fn(async () => prefsState),
+}));
+
+// A CUDA workstation → MAX tier → canRunLocalVoice = true, so prefer-local picks
+// the local voice first. Mocking the probe keeps the test host-independent.
+const strongProbe = {
+	totalRamGb: 64,
+	freeRamGb: 48,
+	gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 22 },
+	cpuCores: 16,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "high",
+	source: "test",
+};
+
+vi.mock("./hardware", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./hardware")>()),
+	probeHardware: vi.fn(async () => strongProbe),
+}));
+
+import { installRouterHandler, ROUTER_PROVIDER } from "./router-handler";
+
+type Handler = (
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+) => Promise<unknown>;
+
+interface Candidate {
+	provider: string;
+	priority: number;
+	handler: Handler;
+}
+
+function installFor(slot: string): Map<string, Handler> {
+	const routerHandlers = new Map<string, Handler>();
+	const installTarget = {
+		registerModel: vi.fn(
+			(modelType: string, handler: Handler, provider: string) => {
+				if (provider === ROUTER_PROVIDER)
+					routerHandlers.set(modelType, handler);
+			},
+		),
+	} as unknown as AgentRuntime;
+	installRouterHandler(installTarget, {
+		skipSlots: (
+			["TEXT_SMALL", "TEXT_LARGE", "TEXT_EMBEDDING", "TEXT_TO_SPEECH", "TRANSCRIPTION"] as const
+		).filter((s) => s !== slot),
+	});
+	return routerHandlers;
+}
+
+function routerFor(modelType: string, candidates: Candidate[]) {
+	const slot =
+		modelType === ModelType.TEXT_TO_SPEECH ? "TEXT_TO_SPEECH" : "TEXT_LARGE";
+	const routerHandlers = installFor(slot);
+	const runtime = {
+		models: new Map<string, unknown[]>([[modelType, candidates]]),
+	} as unknown as IAgentRuntime;
+	const router = routerHandlers.get(modelType);
+	if (!router) throw new Error(`router handler for ${modelType} not installed`);
+	return { router, runtime };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	prefsState.policy = {};
+	prefsState.preferredProvider = {};
+});
+
+describe("router fails closed for TEXT_TO_SPEECH (#12253)", () => {
+	it("re-throws the local Kokoro error and never invokes edge-tts (prefer-local)", async () => {
+		const kokoroError = new Error(
+			"Kokoro artifacts missing: no runtime available",
+		);
+		const localHandler = vi.fn(async () => {
+			throw kokoroError;
+		});
+		const edgeHandler = vi.fn(async () => new Uint8Array([1, 2, 3]));
+
+		const { router, runtime } = routerFor(ModelType.TEXT_TO_SPEECH, [
+			{ provider: "eliza-local-inference", priority: 0, handler: localHandler },
+			{ provider: "edge-tts", priority: 0, handler: edgeHandler },
+		]);
+
+		await expect(router(runtime, { text: "hi" })).rejects.toBe(kokoroError);
+		expect(localHandler).toHaveBeenCalledTimes(1);
+		// The whole point: no silent voice swap.
+		expect(edgeHandler).not.toHaveBeenCalled();
+	});
+
+	it("re-throws even when the picked cloud voice fails (no secondary rotation)", async () => {
+		// Explicit cloud TTS config via prefer-local on a box with no local voice
+		// candidate: the configured cloud engine is edge; if it fails we must still
+		// fail closed rather than rotate to elevenlabs/openai/etc.
+		const edgeError = new Error("edge-tts 503");
+		const edgeHandler = vi.fn(async () => {
+			throw edgeError;
+		});
+		const elevenHandler = vi.fn(async () => new Uint8Array([9]));
+
+		const { router, runtime } = routerFor(ModelType.TEXT_TO_SPEECH, [
+			{ provider: "edge-tts", priority: 10, handler: edgeHandler },
+			{ provider: "elevenlabs", priority: 5, handler: elevenHandler },
+		]);
+
+		await expect(router(runtime, { text: "hi" })).rejects.toBe(edgeError);
+		expect(edgeHandler).toHaveBeenCalledTimes(1);
+		expect(elevenHandler).not.toHaveBeenCalled();
+	});
+
+	it("allows an explicitly configured manual multi-provider TTS chain to rotate", async () => {
+		prefsState.policy.TEXT_TO_SPEECH = "manual"; // user-configured chain
+
+		const primaryError = new Error("elevenlabs down");
+		const elevenHandler = vi.fn(async () => {
+			throw primaryError;
+		});
+		const edgeHandler = vi.fn(async () => new Uint8Array([7, 7]));
+
+		const { router, runtime } = routerFor(ModelType.TEXT_TO_SPEECH, [
+			{ provider: "elevenlabs", priority: 10, handler: elevenHandler },
+			{ provider: "edge-tts", priority: 0, handler: edgeHandler },
+		]);
+
+		const result = (await router(runtime, { text: "hi" })) as Uint8Array;
+		expect(Array.from(result)).toEqual([7, 7]);
+		expect(elevenHandler).toHaveBeenCalledTimes(1);
+		expect(edgeHandler).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("non-TTS slots keep transient failover", () => {
+	it("rotates TEXT_LARGE to the next provider on failure (prefer-local, cloud-only)", async () => {
+		const primaryError = new Error("openai 500");
+		const openaiHandler = vi.fn(async () => {
+			throw primaryError;
+		});
+		const anthropicHandler = vi.fn(async () => "anthropic-result");
+
+		const { router, runtime } = routerFor(ModelType.TEXT_LARGE, [
+			{ provider: "openai", priority: 10, handler: openaiHandler },
+			{ provider: "anthropic", priority: 5, handler: anthropicHandler },
+		]);
+
+		const result = await router(runtime, { prompt: "hi" });
+		expect(result).toBe("anthropic-result");
+		expect(openaiHandler).toHaveBeenCalledTimes(1);
+		expect(anthropicHandler).toHaveBeenCalledTimes(1);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/router-tts-fail-closed.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-tts-fail-closed.test.ts
@@ -67,7 +67,13 @@ function installFor(slot: string): Map<string, Handler> {
 	} as unknown as AgentRuntime;
 	installRouterHandler(installTarget, {
 		skipSlots: (
-			["TEXT_SMALL", "TEXT_LARGE", "TEXT_EMBEDDING", "TEXT_TO_SPEECH", "TRANSCRIPTION"] as const
+			[
+				"TEXT_SMALL",
+				"TEXT_LARGE",
+				"TEXT_EMBEDDING",
+				"TEXT_TO_SPEECH",
+				"TRANSCRIPTION",
+			] as const
 		).filter((s) => s !== slot),
 	});
 	return routerHandlers;

--- a/plugins/plugin-local-inference/src/services/router-tts-loud-fail-evidence.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-tts-loud-fail-evidence.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Failure-path evidence for #12253: with the Kokoro artifacts genuinely absent
+ * on disk, the whole TTS chain fails LOUD and never substitutes another voice.
+ * Unlike router-tts-fail-closed.test.ts (which injects a synthetic throw), this
+ * drives the REAL on-disk artifact check (`resolveKokoroEngineConfig` against an
+ * empty temp dir → null) through the REAL engine selector (`selectVoiceBackend`
+ * → throws) and into the REAL router + policy engine, asserting the router
+ * re-throws that real error and edge-tts is never invoked. Run with
+ * `--reporter verbose` to capture the transcript as issue evidence.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	type AgentRuntime,
+	type IAgentRuntime,
+	logger,
+	ModelType,
+} from "@elizaos/core";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { resolveKokoroEngineConfig } from "./voice/kokoro/kokoro-engine-discovery";
+import { selectVoiceBackend } from "./voice/kokoro/runtime-selection";
+
+const prefsState = {
+	policy: {} as Record<string, string>,
+	preferredProvider: {} as Record<string, string>,
+};
+
+vi.mock("./routing-preferences", () => ({
+	DEFAULT_ROUTING_POLICY: "prefer-local",
+	readRoutingPreferences: vi.fn(async () => prefsState),
+}));
+
+// MAX-tier probe so prefer-local deterministically picks the local voice first;
+// the point of the test is what happens when that local voice's artifacts are
+// missing, not host-tier demotion.
+const strongProbe = {
+	totalRamGb: 64,
+	freeRamGb: 48,
+	gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 22 },
+	cpuCores: 16,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "high",
+	source: "test",
+};
+
+vi.mock("./hardware", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./hardware")>()),
+	probeHardware: vi.fn(async () => strongProbe),
+}));
+
+import { installRouterHandler, ROUTER_PROVIDER } from "./router-handler";
+
+type Handler = (
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+) => Promise<unknown>;
+
+// A real empty models dir → the on-disk Kokoro probe finds nothing.
+const emptyModelsDir = mkdtempSync(path.join(tmpdir(), "kokoro-absent-"));
+const priorKokoroDir = process.env.ELIZA_KOKORO_MODEL_DIR;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	prefsState.policy = {};
+	prefsState.preferredProvider = {};
+	process.env.ELIZA_KOKORO_MODEL_DIR = emptyModelsDir;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterAll(() => {
+	if (priorKokoroDir === undefined) delete process.env.ELIZA_KOKORO_MODEL_DIR;
+	else process.env.ELIZA_KOKORO_MODEL_DIR = priorKokoroDir;
+	rmSync(emptyModelsDir, { recursive: true, force: true });
+});
+
+/** The real on-disk gate the local TTS handler consults before synthesizing. */
+function realLocalTtsHandler(): Uint8Array {
+	const layout = resolveKokoroEngineConfig();
+	const decision = selectVoiceBackend({ kokoroAvailable: layout !== null });
+	// Unreachable when artifacts are absent — selectVoiceBackend throws first.
+	return new Uint8Array([decision.backend.length]);
+}
+
+describe("#12253 failure-path evidence — Kokoro artifacts absent", () => {
+	it("the real on-disk probe returns null when no artifacts are staged", () => {
+		expect(resolveKokoroEngineConfig()).toBeNull();
+	});
+
+	it("the real engine selector throws a loud, actionable error (no silent downgrade)", () => {
+		expect(() => selectVoiceBackend({ kokoroAvailable: false })).toThrow(
+			/Kokoro model artifacts are not present on disk/,
+		);
+	});
+
+	it("the real router re-throws the real Kokoro error and never calls edge-tts", async () => {
+		const errorSpy = vi.spyOn(logger, "error");
+		const edgeHandler = vi.fn(async () => new Uint8Array([9, 9, 9]));
+
+		const routerHandlers = new Map<string, Handler>();
+		const installTarget = {
+			registerModel: vi.fn(
+				(modelType: string, handler: Handler, provider: string) => {
+					if (provider === ROUTER_PROVIDER)
+						routerHandlers.set(modelType, handler);
+				},
+			),
+		} as unknown as AgentRuntime;
+		installRouterHandler(installTarget, {
+			skipSlots: [
+				"TEXT_SMALL",
+				"TEXT_LARGE",
+				"TEXT_EMBEDDING",
+				"TRANSCRIPTION",
+			],
+		});
+
+		const runtime = {
+			models: new Map<string, unknown[]>([
+				[
+					ModelType.TEXT_TO_SPEECH,
+					[
+						{
+							provider: "eliza-local-inference",
+							priority: 0,
+							handler: async () => realLocalTtsHandler(),
+						},
+						{ provider: "edge-tts", priority: 0, handler: edgeHandler },
+					],
+				],
+			]),
+		} as unknown as IAgentRuntime;
+
+		const router = routerHandlers.get(ModelType.TEXT_TO_SPEECH);
+		if (!router) throw new Error("router handler for TTS not installed");
+
+		await expect(router(runtime, { text: "hello" })).rejects.toThrow(
+			/Kokoro model artifacts are not present on disk/,
+		);
+		// The whole point: no silent voice swap to another engine.
+		expect(edgeHandler).not.toHaveBeenCalled();
+		// And the fail-closed refusal was announced loudly.
+		const failClosedLogged = errorSpy.mock.calls.some((call) =>
+			JSON.stringify(call).includes("failing closed"),
+		);
+		expect(failClosedLogged).toBe(true);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/router-voice-modality-warn.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-voice-modality-warn.test.ts
@@ -69,7 +69,11 @@ function setup() {
 			[
 				ModelType.TEXT_TO_SPEECH,
 				[
-					{ provider: "eliza-local-inference", priority: 0, handler: localHandler },
+					{
+						provider: "eliza-local-inference",
+						priority: 0,
+						handler: localHandler,
+					},
 					{ provider: "edge-tts", priority: 0, handler: edgeHandler },
 				],
 			],

--- a/plugins/plugin-local-inference/src/services/router-voice-modality-warn.test.ts
+++ b/plugins/plugin-local-inference/src/services/router-voice-modality-warn.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Voice-modality visibility (#12253, WI2): when the device tier cannot run the
+ * local voice stack, prefer-local routes TEXT_TO_SPEECH to a cloud voice by
+ * configuration (not error recovery) — and the router announces it exactly once
+ * per boot at warn. Drives the real router + policy with a weak-device probe.
+ */
+
+import {
+	type AgentRuntime,
+	type IAgentRuntime,
+	logger,
+	ModelType,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prefsState = {
+	policy: {} as Record<string, string>,
+	preferredProvider: {} as Record<string, string>,
+};
+
+vi.mock("./routing-preferences", () => ({
+	DEFAULT_ROUTING_POLICY: "prefer-local",
+	readRoutingPreferences: vi.fn(async () => prefsState),
+}));
+
+// A 4 GB box → POOR tier → canRunLocalVoice = false, so prefer-local demotes
+// the local voice to cloud. Mocked so the test is host-independent.
+const weakProbe = {
+	totalRamGb: 4,
+	freeRamGb: 1.5,
+	gpu: null,
+	cpuCores: 2,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "low",
+	source: "test",
+};
+
+vi.mock("./hardware", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./hardware")>()),
+	probeHardware: vi.fn(async () => weakProbe),
+}));
+
+import { installRouterHandler, ROUTER_PROVIDER } from "./router-handler";
+
+type Handler = (
+	runtime: IAgentRuntime,
+	params: Record<string, unknown>,
+) => Promise<unknown>;
+
+function setup() {
+	const routerHandlers = new Map<string, Handler>();
+	const installTarget = {
+		registerModel: vi.fn(
+			(modelType: string, handler: Handler, provider: string) => {
+				if (provider === ROUTER_PROVIDER)
+					routerHandlers.set(modelType, handler);
+			},
+		),
+	} as unknown as AgentRuntime;
+	installRouterHandler(installTarget, {
+		skipSlots: ["TEXT_SMALL", "TEXT_LARGE", "TEXT_EMBEDDING", "TRANSCRIPTION"],
+	});
+	const localHandler = vi.fn(async () => new Uint8Array([1]));
+	const edgeHandler = vi.fn(async () => new Uint8Array([2]));
+	const runtime = {
+		models: new Map<string, unknown[]>([
+			[
+				ModelType.TEXT_TO_SPEECH,
+				[
+					{ provider: "eliza-local-inference", priority: 0, handler: localHandler },
+					{ provider: "edge-tts", priority: 0, handler: edgeHandler },
+				],
+			],
+		]),
+	} as unknown as IAgentRuntime;
+	const router = routerHandlers.get(ModelType.TEXT_TO_SPEECH);
+	if (!router) throw new Error("router handler for TTS not installed");
+	return { router, runtime, localHandler, edgeHandler };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	prefsState.policy = {};
+	prefsState.preferredProvider = {};
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("prefer-local TTS on an unviable device tier", () => {
+	it("routes to the configured cloud voice and warns exactly once per boot", async () => {
+		const warnSpy = vi.spyOn(logger, "warn");
+		const { router, runtime, localHandler, edgeHandler } = setup();
+
+		const first = (await router(runtime, { text: "hi" })) as Uint8Array;
+		const second = (await router(runtime, { text: "again" })) as Uint8Array;
+
+		// The device can't run local voice → cloud (edge) is the configured pick;
+		// the local voice is never attempted (a policy decision, not recovery).
+		expect(Array.from(first)).toEqual([2]);
+		expect(Array.from(second)).toEqual([2]);
+		expect(localHandler).not.toHaveBeenCalled();
+		expect(edgeHandler).toHaveBeenCalledTimes(2);
+
+		const voiceWarns = warnSpy.mock.calls.filter((call) =>
+			JSON.stringify(call).includes("Local voice stack unviable"),
+		);
+		expect(voiceWarns).toHaveLength(1);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/routing-policy.test.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { classifyDeviceTier, type DeviceTierAssessment } from "./device-tier";
 import type { HandlerRegistration } from "./handler-registry";
 import type { LiveDeviceSignals } from "./live-signals";
-import { policyEngine } from "./routing-policy";
+import { assessVoiceModality, policyEngine } from "./routing-policy";
 import type { AgentModelSlot, HardwareProbe } from "./types";
 
 function registration(
@@ -341,5 +341,27 @@ describe("PolicyEngine — prefer-local capability soft-hint", () => {
 			deviceTier: strongDevice,
 		});
 		expect(pick?.provider).toBe("eliza-local-inference");
+	});
+});
+
+describe("assessVoiceModality (#12253 voice-modality visibility)", () => {
+	it("is viable on a MAX-tier device that can run the local voice stack", () => {
+		const result = assessVoiceModality(strongDevice);
+		expect(result.viable).toBe(true);
+		expect(result.reason).toBe("device-can-run-local-voice");
+	});
+
+	it("is not viable on a tier that cannot run local voice, with a reason", () => {
+		expect(okayDesktop.canRunLocalVoice).toBe(false);
+		const result = assessVoiceModality(okayDesktop);
+		expect(result.viable).toBe(false);
+		expect(result.reason).toContain("cannot-run-local-voice");
+		expect(result.reason).toContain(okayDesktop.tier.toLowerCase());
+	});
+
+	it("is not viable with an explicit reason when the tier is unknown", () => {
+		const result = assessVoiceModality(null);
+		expect(result.viable).toBe(false);
+		expect(result.reason).toBe("device-tier-unknown");
 	});
 });

--- a/plugins/plugin-local-inference/src/services/routing-policy.ts
+++ b/plugins/plugin-local-inference/src/services/routing-policy.ts
@@ -107,6 +107,36 @@ function modalityViableForSlot(
 }
 
 /**
+ * Whether the device tier permits running the local voice stack (TTS/ASR).
+ *
+ * This is a *policy* answer (configuration-by-hardware), not error recovery: a
+ * device that cannot run local voice legitimately gets a cloud voice as its
+ * configured default. That default is fine — but it must be *visible* (the
+ * status route surfaces this and the router logs it once per boot) so the UI
+ * can explain why Kokoro is not the active voice, rather than the engine
+ * silently swapping under the user (#12253).
+ */
+export interface VoiceModalityViability {
+	viable: boolean;
+	reason: string;
+}
+
+export function assessVoiceModality(
+	assessment: DeviceTierAssessment | null,
+): VoiceModalityViability {
+	if (!assessment) {
+		return { viable: false, reason: "device-tier-unknown" };
+	}
+	if (assessment.canRunLocalVoice) {
+		return { viable: true, reason: "device-can-run-local-voice" };
+	}
+	return {
+		viable: false,
+		reason: `device-tier-${assessment.tier.toLowerCase()}-cannot-run-local-voice`,
+	};
+}
+
+/**
  * Whether `auto` should default this slot to local: the modality must be viable
  * AND the device must be a generally local-first machine (recommended "local",
  * or a MAX/GOOD tier). A device that merely *can* run the modality but is steered

--- a/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
+++ b/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
@@ -493,14 +493,25 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
                     )
                     interrupted = pcmStopRequested
                 } catch {
-                    // Fallback to system TTS on ElevenLabs failure
-                    print("[TalkMode] ElevenLabs failed, falling back to system TTS: \(error)")
+                    // Fail closed (#12253): ElevenLabs is the configured voice, so
+                    // do NOT silently swap to the system AVSpeechSynthesizer. Emit
+                    // the error and stop — no audio plays. AVSpeechSynthesizer is
+                    // reachable only when the caller explicitly requests the system
+                    // engine (the `else` branch below), never as error recovery.
+                    print("[TalkMode] ElevenLabs failed; failing closed, no system-TTS swap: \(error)")
                     emitError(
                         code: "elevenlabs_failed",
                         message: error.localizedDescription,
                         recoverable: true
                     )
-                    try await speakWithSystemTts(text: text, language: language)
+                    call.resolve([
+                        "completed": false,
+                        "interrupted": false,
+                        "usedSystemTts": false,
+                        "error": error.localizedDescription
+                    ])
+                    finishSpeaking()
+                    return
                 }
             } else {
                 try await speakWithSystemTts(text: text, language: language)


### PR DESCRIPTION
Kokoro is the on-device voice. A Kokoro failure must be a **loud error**, never a silent swap to a different voice engine. This makes TTS fail closed across all four silent-fallback sites identified in #12187: the model router, core provider-failover, the web `useVoiceChat` hook, and iOS talkmode — plus warmup honesty and a user-visible error surface.

Closes #12253. Part of #12187.

## Per-site before → after

| Site | Before (silent swap) | After (fails closed) |
|---|---|---|
| `plugins/plugin-local-inference/src/services/router-handler.ts` | ANY throw from the picked TTS provider rotated engines (Kokoro → elizacloud → elevenlabs → openai → groq → edge-tts) at `logger.info` | For `TEXT_TO_SPEECH` with any non-`manual` policy the router **re-throws** the structured error and `logger.error`s `failing closed — refusing to swap to another voice engine`. Only an explicit `manual` multi-provider chain still rotates. Non-TTS slots keep transient failover. |
| `plugins/plugin-local-inference/src/services/routing-policy.ts` + `local-inference-compat-routes.ts` | `prefer-local` + unviable device tier silently demoted the voice slot to cloud | `assessVoiceModality()` surfaces the demotion; the router warns **once per boot** and `/api/local-inference/providers` returns `voiceModality`. Demotion itself is kept — it is configuration-by-hardware, not error recovery — but it can no longer masquerade as a Kokoro failure. |
| `packages/core/src/runtime.ts` + `services/message/fallback-reply.ts` | `shouldFailOverModelProvider` / `isModelProviderFallbackError` matched a Kokoro model-download `fetch failed` and rotated to the next registered TTS provider (`logger.warn`) | Both take `modelType`; `TEXT_TO_SPEECH` returns `false` unconditionally (a voice swap is never transient-recoverable). Text slots keep the heuristic. |
| `packages/ui/src/hooks/useVoiceChat.ts` | local-inference / ElevenLabs / native-talkmode failure fell through to browser `SpeechSynthesis` (`ttsDebug` only) | Each configured-engine failure calls `failClosed(engine, error)`: sets a visible `ttsError` state, stops the queue, `console.error`s, and does **not** call `speakBrowser`. Cleared on the next utterance. Cloud-proxy → direct-ElevenLabs-proxy stays (same voice, now `console.warn`). Browser TTS remains valid only as the **configured** engine. |
| `voice-chat-types.ts` + `ChatVoiceStatusBar.tsx` + `ChatView.tsx` + `useContinuousChat.ts` | no user-visible surface for a silenced voice | New `VoiceTtsError` type; the status bar renders a danger banner (`data-testid="chat-voice-tts-error"`) and force-shows even when otherwise hidden — a silenced voice is never invisible. |
| `plugins/plugin-native-talkmode/ios/.../TalkModePlugin.swift` | ElevenLabs streaming failure → `speakWithSystemTts` (AVSpeechSynthesizer) | Emits `elevenlabs_failed` and resolves `usedSystemTts: false` + returns; AVSpeechSynthesizer is reachable only when the caller explicitly requests the system engine, never as error recovery. |
| `packages/app-core/src/runtime/voice-warmup.ts` | warmup could silently warm edge-tts and report a healthy warmup | Warmup goes through the router with no pinned provider; the router now fails closed for TTS, so a broken Kokoro surfaces its structured error at `warn` instead of a green warmup on a different voice. |

## Design decisions honored (from #12187, settled)

1. **TTS fails closed per-slot** — router re-throws for TTS, never rotates (except explicit `manual`).
2. **Core failover excludes TTS** — `shouldFailOverModelProvider` no longer matches a Kokoro `fetch failed`.
3. **The UI never swaps voices silently** — `useVoiceChat` surfaces a visible `ttsError` + stops the queue; iOS talkmode emits the error and does not speak with AVSpeechSynthesizer.

## Tests (real paths, no mocked subject-under-test)

| Suite | Result |
|---|---|
| `plugin-local-inference` — `router-tts-fail-closed` + `router-voice-modality-warn` + `routing-policy` + `router-tts-loud-fail-evidence` | 30 passed |
| `core` — `use-model-provider-fallback` + `provider-error-hygiene` (failover excludes TTS) | 11 passed |
| `ui` — `useVoiceChat.fail-closed` (visible ttsError, no browser swap) | 3 passed |

Typecheck clean on `plugin-local-inference`, `core`, `app-core`; touched `ui` files clean (one pre-existing unrelated `iwer` missing-dep error in an XR e2e fixture). Biome clean on all touched files.

## Failure-path evidence (issue DoD)

`.github/issue-evidence/12253-tts-loud-fail/` — with the Kokoro artifacts **genuinely absent on disk** (`ELIZA_KOKORO_MODEL_DIR` → empty temp dir), the real chain fails loud with **no other voice**:

1. `resolveKokoroEngineConfig()` (real on-disk probe) → `null`.
2. `selectVoiceBackend({ kokoroAvailable: false })` (real engine selector) → throws `[voice] Kokoro model artifacts are not present on disk; …`.
3. The **real** router + policy engine (`prefer-local`, MAX tier) picks `eliza-local-inference`, whose handler runs the real gate and throws; the router **re-throws that exact error** and **never invokes the registered `edge-tts` handler**. Captured loud log:

```
[LocalInferenceRouter] eliza-local-inference failed for TEXT_TO_SPEECH; failing
closed — refusing to swap to another voice engine (provider=eliza-local-inference,
slot=TEXT_TO_SPEECH, policy=prefer-local, error=[voice] Kokoro model artifacts are
not present on disk; …, alternativesRefused=1)
```

At the route boundary this structured error becomes **HTTP 502** (`local-inference-tts-route.ts`); in the web UI it becomes the visible `ttsError` banner (`04-ui-hook-tests.log` asserts a 502 sets `ttsError` and `speechSynthesis.speak` is never called). iOS talkmode resolves `usedSystemTts: false` (source diff; Swift not runnable in this worktree).

Full transcripts + per-site table: `.github/issue-evidence/12253-tts-loud-fail/README.md`.

## Evidence not captured (with reason)

- **Real STT→TTS audio round-trip / narrated walkthrough** — N/A: this is a *negative* path (voice must **not** play on failure). The audible assertion here is *silence + a surfaced error*, proven at the route/unit level. The positive audio round-trip is unchanged and belongs to siblings #12254/#12258.
- **iOS on-device capture** — N/A in this worktree (no simulator/device build). The Swift fail-closed change is a source diff; web + router + core paths are exercised for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
