### PR TITLE
refactor(#12408): move view-interact protocol constants into @elizaos/shared

### DIFF
--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -36,8 +36,10 @@ import {
   readJsonBody,
   type ShellNavigateViewPayload,
 } from "@elizaos/shared";
-import { AGENT_SURFACE_CAPABILITY_IDS } from "@elizaos/ui/agent-surface/types";
-import { STANDARD_CAPABILITIES } from "@elizaos/ui/views/view-interact-protocol";
+import {
+  AGENT_SURFACE_CAPABILITY_IDS,
+  STANDARD_CAPABILITIES,
+} from "@elizaos/shared/views/view-interact-protocol";
 import {
   type ActiveViewElement,
   clearActiveViewContext,
@@ -142,8 +144,9 @@ function contentTypeForViewAsset(assetPath: string): string {
  * `entry.capabilities` — the protocol's standard caps (get-state / refresh /
  * focus-element / get-text / click-element / fill-input) plus the agent-surface
  * caps the shell registry handles generically (list-elements / agent-click /
- * agent-fill / …). Derived from the single canonical ui-side sources so the
- * route never drifts from what the frontend actually dispatches. (#8798)
+ * agent-fill / …). Derived from the single canonical `@elizaos/shared`
+ * view-interact protocol source so the route never drifts from what the frontend
+ * actually dispatches. (#8798, #12408)
  */
 const STANDARD_CAPABILITY_IDS: ReadonlySet<string> = new Set<string>([
   ...Object.values(STANDARD_CAPABILITIES),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -198,6 +198,16 @@
       "import": "./dist/contracts/apps.js",
       "default": "./dist/contracts/apps.js"
     },
+    "./views/view-interact-protocol": {
+      "types": "./dist/views/view-interact-protocol.d.ts",
+      "eliza-source": {
+        "types": "./src/views/view-interact-protocol.ts",
+        "import": "./src/views/view-interact-protocol.ts",
+        "default": "./src/views/view-interact-protocol.ts"
+      },
+      "import": "./dist/views/view-interact-protocol.js",
+      "default": "./dist/views/view-interact-protocol.js"
+    },
     "./voice-wer": {
       "types": "./dist/voice-wer.d.ts",
       "eliza-source": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -319,6 +319,7 @@ export * from "./utils/trajectory-format.js";
 export * from "./utils/tts-debug.js";
 export * from "./validation-keywords.js";
 export * from "./view-hero-art.js";
+export * from "./views/view-interact-protocol.js";
 export * from "./voice/first-sentence-snip.js";
 export * from "./voice/voice-cancellation-token.js";
 export * from "./voice.js";

--- a/packages/shared/src/views/view-interact-protocol.test.ts
+++ b/packages/shared/src/views/view-interact-protocol.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_SURFACE_CAPABILITY_IDS,
+  STANDARD_CAPABILITIES,
+} from "./view-interact-protocol";
+
+// Pins the view-interact protocol contract that both the agent server route
+// (packages/agent/src/api/views-routes.ts) and the UI DynamicViewLoader dispatch
+// against. These constants moved out of @elizaos/ui internals into shared so the
+// agent no longer depends on hoisted UI (#12408); this test is the single
+// guardrail that the ids/values stay frozen.
+describe("view-interact protocol contract", () => {
+  it("freezes the standard capability values dispatched by the frontend", () => {
+    expect(STANDARD_CAPABILITIES).toEqual({
+      GET_STATE: "get-state",
+      REFRESH: "refresh",
+      FOCUS_ELEMENT: "focus-element",
+      GET_TEXT: "get-text",
+      CLICK_ELEMENT: "click-element",
+      FILL_INPUT: "fill-input",
+    });
+  });
+
+  it("freezes the agent-surface capability ids handled by the shell registry", () => {
+    expect([...AGENT_SURFACE_CAPABILITY_IDS].sort()).toEqual(
+      [
+        "agent-click",
+        "agent-fill",
+        "agent-focus",
+        "agent-scroll-to",
+        "describe-element",
+        "get-agent-state",
+        "get-focus",
+        "list-elements",
+        "set-highlight",
+      ].sort(),
+    );
+  });
+
+  it("keeps the standard and agent-surface capability id sets disjoint", () => {
+    const standard = new Set(Object.values(STANDARD_CAPABILITIES));
+    for (const id of AGENT_SURFACE_CAPABILITY_IDS) {
+      expect(standard.has(id)).toBe(false);
+    }
+  });
+});

--- a/packages/shared/src/views/view-interact-protocol.ts
+++ b/packages/shared/src/views/view-interact-protocol.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical view-interact protocol contract shared by the agent server and the
+ * UI. The agent's views route (`packages/agent/src/api/views-routes.ts`) and the
+ * UI's DynamicViewLoader both dispatch against the same capability ids, so the
+ * ids live here — in the shared workspace contract — rather than inside UI
+ * internals, keeping the agent buildable without an `@elizaos/ui` dependency.
+ *
+ * The flow:
+ *   1. Agent POSTs to /api/views/:id/interact with a ViewInteractRequest body.
+ *   2. Server broadcasts a WS message {type:"view:interact", ...} to all clients.
+ *   3. DynamicViewLoader receives the WS message, calls the view module's
+ *      interact(capability, params) export (or a standard capability handler).
+ *   4. Frontend sends {type:"view:interact:result", ...} back over WS.
+ *   5. Server resolves the pending request and returns the result to the agent.
+ */
+
+export interface ViewInteractRequest {
+  viewId: string;
+  capability: string;
+  params?: Record<string, unknown>;
+  /** UUID generated server-side for correlating the async result. */
+  requestId: string;
+  /** Timeout in ms before the server gives up waiting. Default 5000. */
+  timeoutMs?: number;
+}
+
+export interface ViewInteractResult {
+  requestId: string;
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/** Standard capabilities that every view is expected to support. */
+export const STANDARD_CAPABILITIES = {
+  /** Returns the current view state as JSON. */
+  GET_STATE: "get-state",
+  /** Forces a data refresh / re-render. */
+  REFRESH: "refresh",
+  /** Focuses an input or button by CSS selector or name attribute. */
+  FOCUS_ELEMENT: "focus-element",
+  /** Returns the visible text content of the view container. */
+  GET_TEXT: "get-text",
+  /** Clicks an element by CSS selector or name attribute. Dispatched generically
+   *  by DynamicViewLoader / ShellViewAgentSurface for every loaded view. */
+  CLICK_ELEMENT: "click-element",
+  /** Sets the value of an input by selector/name. Dispatched generically by
+   *  DynamicViewLoader / ShellViewAgentSurface for every loaded view. */
+  FILL_INPUT: "fill-input",
+} as const;
+
+export type StandardCapability =
+  (typeof STANDARD_CAPABILITIES)[keyof typeof STANDARD_CAPABILITIES];
+
+/**
+ * Capability ids handled generically by the agent-surface registry (addressable
+ * elements, focus, programmatic fill/click). DynamicViewLoader routes any of
+ * these to the agent-surface capability handler before falling back to selector
+ * handling.
+ */
+export const AGENT_SURFACE_CAPABILITY_IDS: ReadonlySet<string> = new Set([
+  "list-elements",
+  "describe-element",
+  "get-focus",
+  "get-agent-state",
+  "agent-click",
+  "agent-fill",
+  "agent-focus",
+  "agent-scroll-to",
+  "set-highlight",
+]);

--- a/packages/ui/src/agent-surface/types.ts
+++ b/packages/ui/src/agent-surface/types.ts
@@ -135,15 +135,8 @@ export interface AgentActionResult {
   value?: unknown;
 }
 
-/** Capability ids handled generically by the agent-surface registry. */
-export const AGENT_SURFACE_CAPABILITY_IDS: ReadonlySet<string> = new Set([
-  "list-elements",
-  "describe-element",
-  "get-focus",
-  "get-agent-state",
-  "agent-click",
-  "agent-fill",
-  "agent-focus",
-  "agent-scroll-to",
-  "set-highlight",
-]);
+// Capability ids handled generically by the agent-surface registry. The
+// canonical definition lives in @elizaos/shared so the agent server can dispatch
+// against it without importing UI internals (#12408); re-exported here for the
+// UI's agent-surface consumers.
+export { AGENT_SURFACE_CAPABILITY_IDS } from "@elizaos/shared/views/view-interact-protocol";

--- a/packages/ui/src/views/view-interact-protocol.ts
+++ b/packages/ui/src/views/view-interact-protocol.ts
@@ -1,49 +1,14 @@
 /**
- * View interact protocol — shared types for agent ↔ view interactions.
- *
- * The flow:
- *   1. Agent POSTs to /api/views/:id/interact with a ViewInteractRequest body.
- *   2. Server broadcasts a WS message {type:"view:interact", ...} to all clients.
- *   3. DynamicViewLoader receives the WS message, calls the view module's
- *      interact(capability, params) export (or a standard capability handler).
- *   4. Frontend sends {type:"view:interact:result", ...} back over WS.
- *   5. Server resolves the pending request and returns the result to the agent.
+ * Re-exports the canonical view-interact protocol contract from
+ * `@elizaos/shared`. The constants and types live in shared so the agent server
+ * can dispatch against them without importing UI internals (#12408); this module
+ * keeps the historical `@elizaos/ui/views/view-interact-protocol` import path
+ * working for UI consumers.
  */
 
-export interface ViewInteractRequest {
-  viewId: string;
-  capability: string;
-  params?: Record<string, unknown>;
-  /** UUID generated server-side for correlating the async result. */
-  requestId: string;
-  /** Timeout in ms before the server gives up waiting. Default 5000. */
-  timeoutMs?: number;
-}
-
-export interface ViewInteractResult {
-  requestId: string;
-  success: boolean;
-  result?: unknown;
-  error?: string;
-}
-
-/** Standard capabilities that every view is expected to support. */
-export const STANDARD_CAPABILITIES = {
-  /** Returns the current view state as JSON. */
-  GET_STATE: "get-state",
-  /** Forces a data refresh / re-render. */
-  REFRESH: "refresh",
-  /** Focuses an input or button by CSS selector or name attribute. */
-  FOCUS_ELEMENT: "focus-element",
-  /** Returns the visible text content of the view container. */
-  GET_TEXT: "get-text",
-  /** Clicks an element by CSS selector or name attribute. Dispatched generically
-   *  by DynamicViewLoader / ShellViewAgentSurface for every loaded view. */
-  CLICK_ELEMENT: "click-element",
-  /** Sets the value of an input by selector/name. Dispatched generically by
-   *  DynamicViewLoader / ShellViewAgentSurface for every loaded view. */
-  FILL_INPUT: "fill-input",
-} as const;
-
-export type StandardCapability =
-  (typeof STANDARD_CAPABILITIES)[keyof typeof STANDARD_CAPABILITIES];
+export {
+  STANDARD_CAPABILITIES,
+  type StandardCapability,
+  type ViewInteractRequest,
+  type ViewInteractResult,
+} from "@elizaos/shared/views/view-interact-protocol";


### PR DESCRIPTION
Parent: #12093 (item 2). Removes cross-package coupling where the standalone-publishable agent server imported view-interact protocol constants from `@elizaos/ui` internals via **undeclared, hoisting-only** specifiers (`@elizaos/ui` is not a dependency of `packages/agent`).

## What changed
- **New canonical source** `packages/shared/src/views/view-interact-protocol.ts` — holds `STANDARD_CAPABILITIES`, `AGENT_SURFACE_CAPABILITY_IDS`, `ViewInteractRequest`, `ViewInteractResult`, `StandardCapability`. Exposed via the `@elizaos/shared/views/view-interact-protocol` subpath (added to `package.json` exports) and the shared barrel.
- **`@elizaos/ui` re-exports from shared** — `packages/ui/src/views/view-interact-protocol.ts` and `packages/ui/src/agent-surface/types.ts` now re-export the constants from `@elizaos/shared`, so every historical `@elizaos/ui` import path keeps working for UI consumers with zero drift. Single source of truth.
- **Agent imports from shared** — `packages/agent/src/api/views-routes.ts` imports both constants from `@elizaos/shared/views/view-interact-protocol` (`@elizaos/shared` is already a declared agent dependency).
- **Test** — `packages/shared/src/views/view-interact-protocol.test.ts` pins the frozen ids/values and their disjointness.

## Done-when checklist
- [x] `grep` for `@elizaos/ui` **import statements** in `packages/agent/src` returns none. (Remaining `@elizaos/ui` occurrences are ambient `declare module` shims in `external-modules.d.ts`, the `release-plugin-policy` external-specifier allowlist string, comments, and test-fixture source strings for the dynamic-view bundle rewriter — none are imports of these constants.)
- [x] The shared contract is the single source for the view-interact constants; UI re-exports from it.
- [x] Agent can publish standalone without relying on hoisted UI internals.

## Verification (scoped to touched packages — worktree shares parent node_modules; full monorepo verify runs in CI)
- `packages/shared` new contract test: **3 passed** (`view-interact-protocol.test.ts`).
- `packages/agent` views route tests: **11 passed** (`views-routes.interact-coverage`, `views-routes.interact-result`) — confirms the shared subpath import resolves and dispatch works end-to-end.
- `packages/agent` **75 passed** (`dynamic-view-host-external`, `view-agent-surface-coverage`) — the host-external test confirms `@elizaos/ui` still stays external in view bundles.
- `packages/ui` agent-surface tests: **18 passed** (`registry`, `integration`) — confirms the `capabilities.ts → types.ts → @elizaos/shared` re-export chain resolves.
- Biome `check` clean on all 6 touched files.
- Package typecheck via `tsgo` in this worktree fails only on pre-existing `TS2688` (missing hoisted `bun-types`/`node` type-lib resolution from the worktree path) — no errors reference the changed files; full typecheck runs in CI.

Closes #12408

🤖 Generated with [Claude Code](https://claude.com/claude-code)