### PR TITLE
fix(ui): derive wallet section nav from registry

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -651,8 +651,8 @@ function useResolvedDynamicPage(tab: string): ResolvedDynamicPage | null {
  */
 /**
  * Props every app-shell page view receives, mirroring the OverlayAppContext that
- * `DynamicViewLoader` injects on web/desktop. Overlay-app views (polymarket,
- * …) read `t` / `exitToApps` from props and crash ("t is not a
+ * `DynamicViewLoader` injects on web/desktop. Overlay-app views can read
+ * `t` / `exitToApps` from props and crash ("t is not a
  * function") if mounted with none — which is exactly what happens on iOS/Android
  * where these views render through the in-process app-shell path instead of
  * DynamicViewLoader. Views that read translations from hooks ignore the extras.
@@ -1319,8 +1319,8 @@ function renderViewRouterContent({
       </TabContentView>
     );
   }
-  // Hyperliquid + Polymarket are sub-views of Wallet: the wallet family of
-  // routes shares one sub-nav rendered in the workspace chrome nav slot.
+  // Wallet-family routes share one sub-nav rendered in the workspace chrome
+  // nav slot. Plugins join it by registering app-shell pages with group=wallet.
   const walletNav = isWalletSectionPath(navigationPath) ? (
     <WalletSectionNav activePath={navigationPath} />
   ) : undefined;

--- a/packages/ui/src/components/pages/WalletSectionNav.test.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.test.tsx
@@ -1,21 +1,62 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerAppShellPage } from "../../app-shell-registry";
+import { resetUiRegistryHostForTests } from "../../registry-host";
 import { isWalletSectionPath, WalletSectionNav } from "./WalletSectionNav";
+
+function registerWalletSectionPages(): void {
+  registerAppShellPage({
+    id: "test.wallet",
+    pluginId: "test-wallet",
+    label: "Wallet",
+    path: "/inventory",
+    tabAffinity: "inventory",
+    group: "wallet",
+    order: 10,
+    loader: async () => ({ default: () => null }),
+  });
+  registerAppShellPage({
+    id: "test.perps",
+    pluginId: "test-perps",
+    label: "Perps",
+    path: "/perps",
+    tabAffinity: "inventory",
+    group: "wallet",
+    order: 20,
+    loader: async () => ({ default: () => null }),
+  });
+  registerAppShellPage({
+    id: "test.predictions",
+    pluginId: "test-predictions",
+    label: "Predictions",
+    path: "/predictions",
+    tabAffinity: "inventory",
+    group: "wallet",
+    order: 30,
+    loader: async () => ({ default: () => null }),
+  });
+}
+
+beforeEach(() => {
+  resetUiRegistryHostForTests();
+  registerWalletSectionPages();
+});
 
 afterEach(() => {
   cleanup();
   window.history.replaceState(null, "", "/");
+  resetUiRegistryHostForTests();
 });
 
 describe("isWalletSectionPath", () => {
-  it("matches wallet + its sub-view routes", () => {
+  it("matches wallet + registered sub-view routes", () => {
     for (const path of [
       "/wallet",
       "/inventory",
-      "/hyperliquid",
-      "/polymarket",
-      "/hyperliquid?tab=positions",
+      "/perps",
+      "/predictions",
+      "/perps?tab=positions",
     ]) {
       expect(isWalletSectionPath(path)).toBe(true);
     }
@@ -25,6 +66,23 @@ describe("isWalletSectionPath", () => {
     for (const path of ["/browser", "/automations", "/apps/logs", "/"]) {
       expect(isWalletSectionPath(path)).toBe(false);
     }
+  });
+
+  it("stops matching a sub-view when its app-shell registration is absent", () => {
+    resetUiRegistryHostForTests();
+    registerAppShellPage({
+      id: "test.wallet",
+      pluginId: "test-wallet",
+      label: "Wallet",
+      path: "/inventory",
+      tabAffinity: "inventory",
+      group: "wallet",
+      order: 10,
+      loader: async () => ({ default: () => null }),
+    });
+
+    expect(isWalletSectionPath("/perps")).toBe(false);
+    expect(isWalletSectionPath("/wallet")).toBe(true);
   });
 });
 
@@ -43,8 +101,8 @@ describe("WalletSectionNav", () => {
     ).toBeNull();
   });
 
-  it("marks Perps active on the hyperliquid route", () => {
-    render(<WalletSectionNav activePath="/hyperliquid" />);
+  it("marks Perps active on its registered route", () => {
+    render(<WalletSectionNav activePath="/perps" />);
     expect(
       screen
         .getByRole("button", { name: "Perps" })
@@ -55,7 +113,7 @@ describe("WalletSectionNav", () => {
   it("navigates to the sub-view route on click", () => {
     render(<WalletSectionNav activePath="/wallet" />);
     fireEvent.click(screen.getByRole("button", { name: "Predictions" }));
-    expect(window.location.pathname).toBe("/polymarket");
+    expect(window.location.pathname).toBe("/predictions");
   });
 
   it("does not renavigate when the active tab is clicked", () => {

--- a/packages/ui/src/components/pages/WalletSectionNav.tsx
+++ b/packages/ui/src/components/pages/WalletSectionNav.tsx
@@ -1,12 +1,10 @@
-/**
- * WalletSectionNav — the sub-navigation shared by the Wallet family of routes.
- *
- * Hyperliquid (perps) and Polymarket (predictions) are sub-views of Wallet
- * rather than standalone launcher apps, so the three routes render one another
- * under a common tab strip. Mounted in the workspace chrome `nav` slot for
- * `/wallet`, `/inventory`, `/hyperliquid`, and `/polymarket` (see App.tsx).
- */
-
+import { useSyncExternalStore } from "react";
+import {
+  type AppShellPageRegistration,
+  getAppShellPageRegistrySnapshot,
+  listAppShellPages,
+  subscribeAppShellPages,
+} from "../../app-shell-registry";
 import { cn } from "../../lib/utils";
 import { ViewBackButton } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
@@ -19,11 +17,8 @@ interface WalletSectionTab {
   aliases?: string[];
 }
 
-export const WALLET_SECTION_TABS: readonly WalletSectionTab[] = [
-  { id: "wallet", label: "Wallet", path: "/wallet", aliases: ["/inventory"] },
-  { id: "hyperliquid", label: "Perps", path: "/hyperliquid" },
-  { id: "polymarket", label: "Predictions", path: "/polymarket" },
-];
+const WALLET_SECTION_GROUP = "wallet";
+const WALLET_ROOT_PATH = "/wallet";
 
 function normalizePath(path: string): string {
   const trimmed = (path || "/").split(/[?#]/, 1)[0].toLowerCase();
@@ -33,22 +28,61 @@ function normalizePath(path: string): string {
     : withSlash;
 }
 
-const WALLET_SECTION_PATHS = new Set(
-  WALLET_SECTION_TABS.flatMap((tab) => [tab.path, ...(tab.aliases ?? [])]),
-);
+function compareWalletRegistrations(
+  a: AppShellPageRegistration,
+  b: AppShellPageRegistration,
+): number {
+  return (
+    (a.order ?? 100) - (b.order ?? 100) ||
+    a.label.localeCompare(b.label) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function walletRegistrationToTab(
+  registration: AppShellPageRegistration,
+): WalletSectionTab {
+  const registrationPath = normalizePath(registration.path);
+  if (registrationPath === "/inventory") {
+    return {
+      id: registration.id,
+      label: registration.label,
+      path: WALLET_ROOT_PATH,
+      aliases: [registrationPath],
+    };
+  }
+  return {
+    id: registration.id,
+    label: registration.label,
+    path: registrationPath,
+  };
+}
+
+export function walletSectionTabs(): WalletSectionTab[] {
+  return listAppShellPages()
+    .filter((registration) => registration.group === WALLET_SECTION_GROUP)
+    .sort(compareWalletRegistrations)
+    .map(walletRegistrationToTab);
+}
+
+function walletSectionPathSet(): Set<string> {
+  return new Set(
+    walletSectionTabs().flatMap((tab) => [tab.path, ...(tab.aliases ?? [])]),
+  );
+}
 
 /** True when a route belongs to the Wallet section (wallet + its sub-views). */
 export function isWalletSectionPath(path: string): boolean {
-  return WALLET_SECTION_PATHS.has(normalizePath(path));
+  return walletSectionPathSet().has(normalizePath(path));
 }
 
-function activeTabId(path: string): string {
+function activeTabId(path: string, tabs: readonly WalletSectionTab[]): string {
   const normalized = normalizePath(path);
-  const match = WALLET_SECTION_TABS.find(
+  const match = tabs.find(
     (tab) =>
       tab.path === normalized || (tab.aliases ?? []).includes(normalized),
   );
-  return match?.id ?? "wallet";
+  return match?.id ?? tabs[0]?.id ?? "";
 }
 
 function navigate(path: string): void {
@@ -70,7 +104,13 @@ export function WalletSectionNav({
 }: {
   activePath: string;
 }): React.JSX.Element {
-  const active = activeTabId(activePath);
+  useSyncExternalStore(
+    subscribeAppShellPages,
+    getAppShellPageRegistrySnapshot,
+    getAppShellPageRegistrySnapshot,
+  );
+  const tabs = walletSectionTabs();
+  const active = activeTabId(activePath, tabs);
   return (
     <nav
       aria-label="Wallet sections"
@@ -82,7 +122,7 @@ export function WalletSectionNav({
        *  it owns the launcher back button the other top-level views get from
        *  ViewHeader. Without it there is no way back to the launcher on mobile. */}
       <ViewBackButton className="mr-1" />
-      {WALLET_SECTION_TABS.map((tab) => {
+      {tabs.map((tab) => {
         const isActive = tab.id === active;
         return (
           <Button

--- a/packages/ui/src/navigation/index.test.ts
+++ b/packages/ui/src/navigation/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerAppShellPage } from "../app-shell-registry";
 import { resetUiRegistryHostForTests } from "../registry-host";
-import { tabFromPath } from "./index";
+import { ALL_TAB_GROUPS, tabFromPath } from "./index";
 
 beforeEach(() => {
   resetUiRegistryHostForTests();
@@ -48,5 +48,33 @@ describe("navigation tabFromPath", () => {
     });
 
     expect(tabFromPath("/test/phone-companion")).toBe("test.phone-companion");
+  });
+
+  it("builds wallet launcher grouping from app-shell page group metadata", () => {
+    registerAppShellPage({
+      id: "test.wallet",
+      pluginId: "test-wallet",
+      label: "Wallet",
+      path: "/inventory",
+      tabAffinity: "inventory",
+      group: "wallet",
+      order: 10,
+      loader: async () => ({ default: () => null }),
+    });
+    registerAppShellPage({
+      id: "test.perps",
+      pluginId: "test-perps",
+      label: "Perps",
+      path: "/perps",
+      tabAffinity: "inventory",
+      group: "wallet",
+      order: 20,
+      loader: async () => ({ default: () => null }),
+    });
+
+    const walletGroup = ALL_TAB_GROUPS.find(
+      (group) => group.label === "Wallet",
+    );
+    expect(walletGroup?.tabs).toEqual(["inventory", "test.perps"]);
   });
 });

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -105,6 +105,23 @@ export interface TabGroup {
   description?: string;
 }
 
+function walletLauncherTabs(): Tab[] {
+  const tabs = listAppShellPages()
+    .filter((entry) => entry.group === "wallet")
+    .sort(
+      (a, b) =>
+        (a.order ?? 100) - (b.order ?? 100) ||
+        a.label.localeCompare(b.label) ||
+        a.id.localeCompare(b.id),
+    )
+    .map((entry) =>
+      normalizePath(entry.path).toLowerCase() === "/inventory"
+        ? ((entry.tabAffinity ?? "inventory") as Tab)
+        : (entry.id as Tab),
+    );
+  return [...new Set(tabs.length ? tabs : ["inventory"])];
+}
+
 export interface AndroidPhoneSurfaceDetection {
   platform?: string;
   isNative?: boolean;
@@ -275,9 +292,10 @@ export const ALL_TAB_GROUPS: TabGroup[] = [
     description: "Avatar identity, style, examples, and knowledge",
   },
   {
-    // Hyperliquid + Polymarket are sub-views of Wallet, not standalone apps.
     label: "Wallet",
-    tabs: ["inventory", "hyperliquid", "polymarket"],
+    get tabs() {
+      return walletLauncherTabs();
+    },
     icon: Wallet,
     description:
       "Crypto wallets, token balances, perps, and prediction markets",
@@ -489,9 +507,9 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
   if (normalized === "/connectors") return "settings";
 
   // Check current paths first, then route unknown top-level paths through the
-  // view registry. Plugin views declare routes like `/hyperliquid` and
-  // `/contacts/tui` that are not built-in tabs; the Views tab can then match
-  // the exact registry path and mount the remote bundle.
+  // view registry. Plugin views can declare routes that are not built-in tabs;
+  // the Views tab can then match the exact registry path and mount the remote
+  // bundle.
   const knownTab = PATH_TO_TAB.get(normalized);
   if (knownTab) return knownTab;
   if (APPS_ENABLED && normalized.startsWith("/") && normalized !== "/") {

--- a/packages/ui/src/spatial/__tests__/divider-label.test.tsx
+++ b/packages/ui/src/spatial/__tests__/divider-label.test.tsx
@@ -8,7 +8,7 @@ import { Divider, SpatialSurface } from "../index.ts";
  * The DOM `Divider` primitive has three render branches: vertical rule,
  * labeled horizontal rule, and plain horizontal rule. The `label` prop is a
  * documented section-separator used by 20+ spatial views (health,
- * steward, phone, training, contacts, polymarket, wallet …). A "declutter"
+ * steward, phone, training, contacts, wallet, and market views). A "declutter"
  * pass that drops the labeled branch makes those section headers silently
  * vanish while still type-checking (the prop stays on `DividerProps`). These
  * tests assert the label actually reaches the DOM so such a regression fails

--- a/plugins/app-model-tester/src/ModelTesterView.test.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.test.tsx
@@ -7,7 +7,7 @@
 // navigation — functional parity with the legacy ModelTesterAppView surface,
 // expressed through the spatial action contract.
 
-import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import {
   cleanup,
   fireEvent,

--- a/plugins/app-model-tester/src/ModelTesterView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.tsx
@@ -16,8 +16,8 @@
  * presentational view stays modality-portable.
  */
 
-import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import type { OverlayAppContext } from "@elizaos/ui/components/apps/overlay-app-api";
+import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -10,7 +10,7 @@
 // retired HyperliquidTuiView surface. Also covers the unchanged `interact`
 // terminal capability handler the view bundle re-exports.
 
-import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import {
   cleanup,
   fireEvent,

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
@@ -11,9 +11,9 @@
  * `register-terminal-view.tsx`).
  */
 
-import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
+import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
 import { type CSSProperties, useCallback } from "react";
 import {
   type HyperliquidSnapshot,

--- a/plugins/plugin-hyperliquid/src/register.ts
+++ b/plugins/plugin-hyperliquid/src/register.ts
@@ -24,9 +24,12 @@ if (typeof window === "undefined") {
 registerAppShellPage({
   id: "hyperliquid",
   pluginId: "@elizaos/plugin-hyperliquid",
-  label: "Hyperliquid",
+  label: "Perps",
   icon: "TrendingUp",
   path: "/hyperliquid",
+  tabAffinity: "inventory",
+  group: "wallet",
+  order: 60,
   loader: () =>
     import("./hyperliquid-app-view-bundle.ts").then((m) => ({
       default: m.HyperliquidView,

--- a/plugins/plugin-phone/src/components/PhoneView.test.tsx
+++ b/plugins/plugin-phone/src/components/PhoneView.test.tsx
@@ -7,7 +7,7 @@
 // native bridge with the exact normalized arguments — functional parity with
 // the retired hand-written PhonePluginView/PhoneTuiView surfaces.
 
-import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import {
   cleanup,
   configure,

--- a/plugins/plugin-phone/src/components/PhoneView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneView.tsx
@@ -11,10 +11,10 @@
  */
 
 import { Phone } from "@elizaos/capacitor-phone";
-import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { consumeNavigateViewPayload } from "@elizaos/ui/app-navigate-view";
 import { Button } from "@elizaos/ui/components/ui/button";
+import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {

--- a/plugins/plugin-polymarket/src/register.ts
+++ b/plugins/plugin-polymarket/src/register.ts
@@ -23,9 +23,12 @@ if (typeof window === "undefined") {
 registerAppShellPage({
   id: "polymarket",
   pluginId: "@elizaos/plugin-polymarket",
-  label: "Polymarket",
+  label: "Predictions",
   icon: "BarChart2",
   path: "/polymarket",
+  tabAffinity: "inventory",
+  group: "wallet",
+  order: 70,
   loader: () =>
     import("./polymarket-view-bundle.ts").then((m) => ({
       default: m.PolymarketView,

--- a/plugins/plugin-scheduling/src/components/lifeops-live-test/LifeOpsLiveTestView.tsx
+++ b/plugins/plugin-scheduling/src/components/lifeops-live-test/LifeOpsLiveTestView.tsx
@@ -21,13 +21,15 @@
  * spatial-unsafe modules leak into the view bundle.
  */
 
-import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import {
   client,
   type PluginInfo,
   type ScheduledTaskView,
 } from "@elizaos/ui/api";
-import { dispatchFocusConnector } from "@elizaos/ui/events";
+import {
+  dispatchFocusConnector,
+  dispatchNavigateViewEvent,
+} from "@elizaos/ui/events";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.test.tsx
@@ -7,7 +7,7 @@
 // ids (`back`, `select:<slot>:<phase>`, `refresh`) — functional parity with the
 // retired hand-written GUI/TUI surfaces.
 
-import { NAVIGATE_VIEW_EVENT } from "@elizaos/shared/events";
+import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {
   cleanup,

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx
@@ -11,10 +11,10 @@
  * registry (see `register-terminal-view.tsx`).
  */
 
-import { dispatchNavigateViewEvent } from "@elizaos/shared/events";
 import type { OverlayAppContext } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { Button } from "@elizaos/ui/components/ui/button";
+import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
 
 import { useCallback, useState } from "react";
 import type { PhaseName } from "../phases";

--- a/plugins/plugin-wallet-ui/src/plugin.ts
+++ b/plugins/plugin-wallet-ui/src/plugin.ts
@@ -23,6 +23,7 @@ export const walletAppPlugin: Plugin = {
         icon: "Wallet",
         path: "/inventory",
         tabAffinity: "inventory",
+        group: "wallet",
         order: 50,
         componentExport: "@elizaos/plugin-wallet-ui#InventoryView",
       },

--- a/plugins/plugin-wallet-ui/src/register-routes.ts
+++ b/plugins/plugin-wallet-ui/src/register-routes.ts
@@ -29,6 +29,7 @@ registerAppShellPage({
   icon: "Wallet",
   path: "/inventory",
   tabAffinity: "inventory",
+  group: "wallet",
   order: 50,
   loader: () =>
     import("./InventoryView.tsx").then((module) => ({


### PR DESCRIPTION
Refs #12089

## What changed
- Derive wallet section tabs and wallet launcher grouping from `AppShellPageRegistration.group === "wallet"` instead of hardcoded wallet-family product tabs.
- Mark Wallet UI, Hyperliquid, and Polymarket app-shell registrations with wallet group metadata and stable ordering.
- Clear the app audit view-bundle blocker by routing plugin view navigation-event imports through the host-provided `@elizaos/ui/events` barrel instead of `@elizaos/shared/events`.

## Evidence
- `bun run --cwd packages/ui test -- src/components/pages/WalletSectionNav.test.tsx src/navigation/index.test.ts` — 2 files / 11 tests passed after final rebase.
- `bunx biome check ...` for all changed files — passed after final rebase.
- `bun run --cwd packages/ui typecheck` — passed after final rebase.
- Focused plugin tests passed after final rebase: HyperliquidView, ModelTesterView, PhoneView, TrajectoryLoggerView.
- `bun run --cwd packages/app audit:app` — passed on this branch before the final clean rebase: 373 passed, broken=0, needs-work=0. The final rebase was clean; fast checks were rerun afterward.

## Notes
This advances #12089 item 30 but does not close the issue. Broad product-name literals remain elsewhere in `packages/ui` widget/icon/API/test surfaces and should stay visible for the remaining audit work.