### PR TITLE
docs(#12234): prose headers + churn cleanup — ui/components/connectors (B04 slice)

### DIFF
--- a/packages/ui/src/components/connectors/BlueBubblesStatusPanel.tsx
+++ b/packages/ui/src/components/connectors/BlueBubblesStatusPanel.tsx
@@ -1,3 +1,11 @@
+/**
+ * Status panel for the BlueBubbles iMessage bridge, rendered in the connector
+ * setup surface. Fetches bridge status via `client.getBlueBubblesStatus` and
+ * surfaces the resolved webhook URL the user pastes into their BlueBubbles
+ * server, resolving a relative webhook path against the API base URL or the
+ * current window origin.
+ */
+
 import { useEffect } from "react";
 import { client } from "../../api";
 import { useFetchData } from "../../hooks";

--- a/packages/ui/src/components/connectors/ConnectorAccountAuditList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountAuditList.tsx
@@ -1,3 +1,10 @@
+/**
+ * Audit-log list for a single connector account: renders the recent
+ * `ConnectorAccountAuditEventRecord` events (fetched via the API client) inside
+ * an account's management view, with a manual refresh and localized event
+ * labels/timestamps.
+ */
+
 import { RefreshCw } from "lucide-react";
 import { useMemo } from "react";
 import { client } from "../../api";

--- a/packages/ui/src/components/connectors/ConnectorAccountCard.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountCard.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `ConnectorAccountCard` covering the account states
+ * (connected/owner default, other roles, error) under the translation provider.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountCard.tsx
@@ -1,3 +1,11 @@
+/**
+ * Card for one connector account in the account-management list: shows
+ * status/role/privacy, an editable label, and the per-account actions (set
+ * default, sync, privacy/purpose edit, delete-with-confirmation). Edits are
+ * sent as `ConnectorAccountUpdateInput` through the parent's callbacks; delete
+ * goes through a confirmation dialog.
+ */
+
 import { RefreshCw, Star, Trash2 } from "lucide-react";
 import { useCallback, useState } from "react";
 import type {

--- a/packages/ui/src/components/connectors/ConnectorAccountList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountList.tsx
@@ -1,3 +1,11 @@
+/**
+ * List of a connector's accounts, grouped by role section, backed by the
+ * `useConnectorAccounts` hook. Renders one `ConnectorAccountCard` per account
+ * and an add-account affordance; unknown-role accounts fall into the
+ * `CONNECTOR_UNKNOWN_ROLE_BUCKET` section so they are neither dropped nor
+ * mislabelled as the owner's own (#12087).
+ */
+
 import { Plus } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import type {

--- a/packages/ui/src/components/connectors/ConnectorAccountPrivacySelector.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountPrivacySelector.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `ConnectorAccountPrivacySelector` across the privacy
+ * levels, including the typed/public confirmation flows.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { ConnectorAccountPrivacy } from "../../api/client-agent";

--- a/packages/ui/src/components/connectors/ConnectorAccountPrivacySelector.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountPrivacySelector.tsx
@@ -1,3 +1,10 @@
+/**
+ * Privacy-level selector for a connector account (owner-only through public).
+ * Escalating to a broader level opens a confirmation dialog whose requirement
+ * (typed phrase vs. public acknowledgement) comes from
+ * `connector-account-options`, so the escalation guard lives in one place.
+ */
+
 import { useId, useMemo, useState } from "react";
 import type { ConnectorAccountPrivacy } from "../../api/client-agent";
 import { useTranslation } from "../../state/TranslationContext.hooks";

--- a/packages/ui/src/components/connectors/ConnectorAccountPurposeSelector.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountPurposeSelector.stories.tsx
@@ -1,3 +1,8 @@
+/**
+ * Storybook stories for `ConnectorAccountPurposeSelector` across the account
+ * roles, including the owner-role confirmation flow.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { ConnectorAccountRole } from "../../api/client-agent";

--- a/packages/ui/src/components/connectors/ConnectorAccountPurposeSelector.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountPurposeSelector.tsx
@@ -1,3 +1,9 @@
+/**
+ * Role/purpose selector for a connector account. Promoting an account to the
+ * OWNER role opens a confirmation dialog whose requirement comes from
+ * `connector-account-options`, keeping the owner-escalation guard centralized.
+ */
+
 import { useId, useMemo, useState } from "react";
 import type { ConnectorAccountRole } from "../../api/client-agent";
 import { useTranslation } from "../../state/TranslationContext.hooks";

--- a/packages/ui/src/components/connectors/ConnectorAccountSetupScope.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountSetupScope.tsx
@@ -1,3 +1,10 @@
+/**
+ * Account-scoping wrapper for connector setup flows: renders a selector of the
+ * connector's usable (connected, enabled) accounts and calls its render-prop
+ * child with the chosen account id, so a setup panel can scope its actions to a
+ * single account. Backed by the `useConnectorAccounts` hook.
+ */
+
 import type { ReactNode } from "react";
 import type { ConnectorAccountRecord } from "../../api/client-agent";
 import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Pure helpers backing `ConnectorModeSelector`: resolves a connector's ordered
+ * setup modes from the connector-mode registry, appends the plugin-managed mode
+ * from the connector-account catalog when applicable, filters cloud-only modes
+ * by Eliza Cloud connectivity, and maps a selected mode to its setup plugin id.
+ */
+
 import {
   CONNECTOR_PLUGIN_MANAGED_MODE_ID,
   type ConnectorManagementMode,

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.hooks.ts
@@ -1,3 +1,9 @@
+/**
+ * React state hook for `ConnectorModeSelector`: tracks the selected connector
+ * mode, seeds it from the connector's default, and re-defaults when the
+ * available mode list changes (e.g. Eliza Cloud connects/disconnects).
+ */
+
 import { useEffect, useState } from "react";
 import {
   getConnectorModes,

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.stories.tsx
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.stories.tsx
@@ -1,3 +1,9 @@
+/**
+ * Storybook stories for `ConnectorModeSelector` — a connector with multiple
+ * modes, and cloud-only modes gated on Eliza Cloud connectivity — under a mock
+ * app context.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import type { AppContextValue } from "../../state/types";

--- a/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
+++ b/packages/ui/src/components/connectors/ConnectorModeSelector.tsx
@@ -1,3 +1,10 @@
+/**
+ * Mode selector for a connector's setup surface: renders the connector's
+ * declared setup modes (from `ConnectorModeSelector.helpers`, ultimately the
+ * connector-mode registry) as a button group. Renders nothing when the
+ * connector has one mode or fewer.
+ */
+
 import { useAppSelector } from "../../state";
 import { Button } from "../ui/button";
 import { getConnectorModes } from "./ConnectorModeSelector.helpers";

--- a/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.tsx
+++ b/packages/ui/src/components/connectors/ConnectorQrPairingOverlay.tsx
@@ -1,3 +1,11 @@
+/**
+ * Generic QR-code pairing overlay shared by the phone-linking connectors
+ * (WhatsApp, Signal). Given a pairing status, QR data URL, and lifecycle
+ * callbacks, it renders the step instructions plus the QR/connected/error
+ * states; connector-specific overlays (`WhatsAppQrOverlay`, `SignalQrOverlay`)
+ * wrap it with their own pairing hook and copy.
+ */
+
 import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * Registry + resolution helpers for `ConnectorSetupPanel`. Holds the runtime
+ * registry that lets plugins register their own setup-panel component for a
+ * connector id (normalized to lowercase alphanumerics) instead of editing a
+ * hardcoded switch, and the lookups the dispatcher uses to pick a panel.
+ */
+
 import type React from "react";
 import { getBootConfig } from "../../config/boot-config";
 import { parseConnectorAccountManagementPanelPluginId } from "./connector-account-options";

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
@@ -1,3 +1,10 @@
+/**
+ * Dispatcher that renders the correct setup panel for a connector. Resolves the
+ * panel from the runtime registry (`connector-setup-panel-registry`) plus the
+ * built-in connector panels in this directory, and falls back to the generic
+ * account-management panel for plugin-managed connectors.
+ */
+
 import { getBootConfig } from "../../config/boot-config";
 import { BlueBubblesStatusPanel } from "./BlueBubblesStatusPanel";
 import { ConnectorAccountList } from "./ConnectorAccountList";

--- a/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
+++ b/packages/ui/src/components/connectors/DiscordLocalConnectorPanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Setup panel for the locally-hosted Discord connector: reads bridge status and
+ * the bot's guilds/channels via the API client and lets the owner pick the
+ * guild + channel the agent listens on.
+ */
+
 import { useCallback, useEffect, useState } from "react";
 import { client } from "../../api";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/connectors/IMessageStatusPanel.tsx
+++ b/packages/ui/src/components/connectors/IMessageStatusPanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Status panel for the native macOS iMessage connector. Surfaces the
+ * chat-database availability, send-only vs. read/write capability, and the
+ * full-disk-access permission prompt the connector needs to read messages.
+ */
+
 import { useCallback, useEffect, useState } from "react";
 import { client, type IMessageApiStatus } from "../../api";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/connectors/SignalQrOverlay.tsx
+++ b/packages/ui/src/components/connectors/SignalQrOverlay.tsx
@@ -1,3 +1,8 @@
+/**
+ * Signal-specific QR pairing overlay: wires the `useSignalPairing` hook and
+ * Signal linking copy into the shared `ConnectorQrPairingOverlay`.
+ */
+
 import { useMemo } from "react";
 import { useSignalPairing } from "../../hooks";
 import { DEFAULT_CONNECTOR_ACCOUNT_ID } from "../../hooks/useConnectorAccounts";

--- a/packages/ui/src/components/connectors/TelegramAccountConnectorPanel.tsx
+++ b/packages/ui/src/components/connectors/TelegramAccountConnectorPanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Setup panel for the Telegram user-account (MTProto) connector, as opposed to
+ * the bot connector. Drives the phone-number/login-code pairing flow against
+ * the API client and shows the linked account's handle/name once connected.
+ */
+
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../api";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/connectors/TelegramBotSetupPanel.stories.tsx
+++ b/packages/ui/src/components/connectors/TelegramBotSetupPanel.stories.tsx
@@ -1,3 +1,7 @@
+/**
+ * Storybook stories for `TelegramBotSetupPanel` under a mock app context.
+ */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { AppContextValue } from "../../state/types";
 import { AppContext } from "../../state/useApp";

--- a/packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/TelegramBotSetupPanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Setup panel for the Telegram bot connector: takes a bot token, validates it
+ * against the API client (which resolves the bot's identity), and reports the
+ * idle/validating/connected/error state.
+ */
+
 import { useCallback, useState } from "react";
 import { client } from "../../api";
 import { useAppSelector } from "../../state";

--- a/packages/ui/src/components/connectors/WhatsAppQrOverlay.tsx
+++ b/packages/ui/src/components/connectors/WhatsAppQrOverlay.tsx
@@ -1,3 +1,8 @@
+/**
+ * WhatsApp-specific QR pairing overlay: wires the `useWhatsAppPairing` hook and
+ * WhatsApp linking copy into the shared `ConnectorQrPairingOverlay`.
+ */
+
 import { useMemo } from "react";
 import { useWhatsAppPairing } from "../../hooks";
 import { DEFAULT_CONNECTOR_ACCOUNT_ID } from "../../hooks/useConnectorAccounts";

--- a/packages/ui/src/components/connectors/XRPairingPanel.tsx
+++ b/packages/ui/src/components/connectors/XRPairingPanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Setup panel for pairing XR / smart-glasses devices: polls pair state via the
+ * API client while the document is visible and renders the connected-device
+ * count plus the pairing action.
+ */
+
 import { useCallback, useEffect, useState } from "react";
 import { client, type XRPairState } from "../../api";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";

--- a/packages/ui/src/components/connectors/connector-account-options.test.ts
+++ b/packages/ui/src/components/connectors/connector-account-options.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the connector-account catalog helpers — privacy/role
+ * confirmation requirements and plugin-managed-account resolution. Pure
+ * functions, no runtime or network.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   CONNECTOR_OWNER_ROLE_CONFIRMATION,

--- a/packages/ui/src/components/connectors/connector-account-options.ts
+++ b/packages/ui/src/components/connectors/connector-account-options.ts
@@ -1,3 +1,10 @@
+/**
+ * Catalog and confirmation rules for connector-account attributes: the privacy
+ * levels, purposes/roles, and plugin-managed mode metadata rendered by the
+ * account selectors, plus the single source of truth for when a privacy
+ * escalation or owner-role promotion requires typed/explicit confirmation.
+ */
+
 import type {
   ConnectorAccountCreateInput,
   ConnectorAccountPrivacy,

--- a/packages/ui/src/components/connectors/connector-mode-registry.test.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Seam test for the connector-mode registry (#12094 item 1): a connector plugin
+ * whose id appears nowhere in this package can register its modes and get a
+ * fully working mode selector. In-memory registry, no runtime.
+ */
+
 import { describe, expect, it } from "vitest";
 import {
   getConnectorModes,

--- a/packages/ui/src/components/connectors/connector-mode-registry.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.ts
@@ -1,19 +1,24 @@
+/**
+ * Registry of connector setup-mode declarations, keyed by connector id (#12094).
+ *
+ * A connector's setup UI (`ConnectorModeSelector`) renders its mode selector
+ * generically from these declarations rather than a per-connector `switch`, so
+ * a connector plugin whose id appears nowhere in this package still gets a
+ * working mode selector by calling {@link registerConnectorModes} — the same
+ * pattern `registerConnectorSetupPanel` uses for panels. Built-in connectors
+ * are seeded at module load below; `ConnectorModeSelector.helpers.ts` reads
+ * back through {@link getDeclaredConnectorModes}.
+ */
+
 import {
   type ConnectorManagementMode,
   normalizeConnectorCatalogId,
 } from "./connector-account-options";
 
 /**
- * Declarative description of a single connector setup mode.
- *
- * This is the metadata a connector plugin declares (in its registry entry /
- * manifest) so the setup UI can render its mode selector generically. The
- * previous implementation hardcoded one giant `switch (connectorId)` in
- * `ConnectorModeSelector.helpers.ts`; a new or renamed connector plugin fell
- * through to an empty mode list with no setup UI. Declarations now live in this
- * registry — built-ins are seeded below, and any plugin can register its own
- * via {@link registerConnectorModes}, mirroring the sanctioned
- * `registerConnectorSetupPanel` pattern already used for panels.
+ * Declarative description of a single connector setup mode: the metadata a
+ * connector plugin declares (in its registry entry / manifest) so the setup UI
+ * can render its mode selector without hardcoding the connector.
  */
 export interface ConnectorModeDeclaration {
   /** Mode id, unique within a connector. */
@@ -68,8 +73,7 @@ export function getDeclaredConnectorModes(
 // ---------------------------------------------------------------------------
 // Built-in connector mode declarations.
 //
-// These seed the modes that used to be hardcoded in the `getConnectorModes`
-// switch. Ordering is significant — it is the exact order modes are presented
+// Declaration order is significant — it is the exact order modes are presented
 // (cloud-only modes are filtered out when Eliza Cloud is not connected, keeping
 // their declared position). The plugin-managed mode is injected separately by
 // `withPluginManagedMode` from the connector-account catalog, so it is not


### PR DESCRIPTION
Part of #12234 (comment-cleanup batch B04, parent #12181). Comment-only slice covering the `packages/ui/src/components/connectors/**` subtree (32 files; 29 changed).

## What changed
- Added a purpose-explaining prose file header to the 28 connector files that lacked one, per the root `CLAUDE.md` convention: first sentence states what the component/module does in system terms (never repeats the filename), then relationships (what it consumes/mounts into), design-system/architecture constraints, and issue anchors where they carry non-obvious rationale (`#12087`, `#12094`). React panels/overlays say what they render, where they mount (connector setup surface), and the shared-primitive constraint; story files get 1-line headers; test files get 1–3 line headers noting the surface under test and that the harness is pure/in-memory.
- `connector-mode-registry.ts`: rewrote change-narration ("The previous implementation hardcoded one giant switch… Declarations now live in this registry…" and "These seed the modes that used to be hardcoded…") into present-tense durable fact describing the registry's behavior and the significance of declaration order. This was the only churn hit flagged by the batch grep in this subtree.

Files already at the bar (`OwnerAgentConnectorSetupPanel.tsx`, `connector-setup-panel-registry.ts`, `__tests__/connectors-stories-smoke.test.tsx`) were left untouched.

## Done-when (this slice)
- [x] Every in-scope file in the slice opens with a prose header (self-audit prints nothing).
- [x] The one churn-flagged comment in these paths rewritten present-tense; no restatement comments added.
- [x] Zero functional diffs — `check:comment-only` green (29 files, every code token identical to origin/develop).
- [x] Lint green on the touched directory.

## Verification
```
$ bun run check:comment-only
[assert-comment-only-diff] OK — 29 source file(s) changed; every code token identical to origin/develop. Comments only.

$ bunx biome lint packages/ui/src/components/connectors
Checked 32 files in 76ms. No fixes applied.
```
`git diff --stat origin/develop...HEAD`: 29 files changed, 193 insertions(+), 12 deletions(-) — comment lines only.

Full-package `bun run --cwd packages/ui typecheck` reports only pre-existing, unrelated errors (missing `./generated/*` files and the `iwer` dev dep in this worktree; none in `connectors/`) — expected in a shared-node_modules worktree; comment-only changes cannot introduce type errors.

## PR evidence
Trajectory / screenshot / video / audio / domain-artifact rows: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Advances #12234 (one slice of ~22). Does not fully close the batch.