### PR TITLE
refactor(#12409): single-source ChatTurnStatus + ChatFailureKind SSE contract

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -33,6 +33,8 @@ import {
   type UUID,
 } from "@elizaos/core";
 import type {
+  ChatFailureKind,
+  ChatTurnStatus,
   LinkedAccountProviderId,
   LogEntry,
   ReadJsonBodyOptions,
@@ -1385,19 +1387,6 @@ export function getChatFailureReply(
   return getProviderIssueChatReply();
 }
 
-/**
- * Discriminator the conversation route includes in its 200 response so the
- * renderer can distinguish "provider configured but throwing" from "no
- * provider configured at all" — the latter is a UX gate ("Connect a
- * provider"), not a chat reply.
- */
-export type ChatFailureKind =
-  | "insufficient_credits"
-  | "no_provider"
-  | "provider_issue"
-  | "rate_limited"
-  | "local_inference";
-
 export function classifyChatFailure(
   err: unknown,
   logBuffer: LogEntry[],
@@ -1669,32 +1658,6 @@ export function writeChatTokenSse(
   fullText: string,
 ): void {
   writeSse(res, { type: "token", text, fullText });
-}
-
-/**
- * In-flight assistant-turn status, surfaced to the UI as an additive SSE
- * `{ type: "status", ... }` event so the chat can show what the agent is *doing*
- * rather than just breathing dots. The `token` / `done` / `error` contract is
- * unchanged — a client that ignores `status` events behaves exactly as before.
- *
- * The canonical (and only consumer-facing) definition lives in
- * `@elizaos/ui` `api/client-types-chat.ts` (`ChatTurnStatus`). It is re-declared
- * here — not imported — because the server must not depend on the React UI
- * package; this mirrors the existing `ChatFailureKind` arrangement. The two
- * declarations are kept structurally identical by the SSE-status unit test.
- */
-export interface ChatTurnStatus {
-  kind:
-    | "thinking"
-    | "streaming"
-    | "running_action"
-    | "running_tool"
-    | "evaluating"
-    | "waking"
-    | "speaking";
-  label?: string;
-  actionName?: string;
-  toolName?: string;
 }
 
 export function writeChatStatusSse(

--- a/packages/agent/src/api/chat-status-sse.test.ts
+++ b/packages/agent/src/api/chat-status-sse.test.ts
@@ -1,7 +1,8 @@
 import type http from "node:http";
+import type { ChatTurnStatus } from "@elizaos/shared";
 import { describe, expect, it, vi } from "vitest";
 
-import { type ChatTurnStatus, writeChatStatusSse } from "./chat-routes.ts";
+import { writeChatStatusSse } from "./chat-routes.ts";
 
 /** Minimal ServerResponse stand-in capturing the bytes written to the wire. */
 function makeRes(): {
@@ -52,10 +53,9 @@ describe("writeChatStatusSse (#8813)", () => {
     expect(writes).toHaveLength(0);
   });
 
-  it("accepts every ChatTurnStatus kind in the contract", () => {
-    // Compile-time + runtime guard that the server kind union stays in lockstep
-    // with the canonical @elizaos/ui ChatTurnStatus union (#8813). If a kind is
-    // added on one side and not the other, this array stops type-checking.
+  it("emits every kind in the shared ChatTurnStatus contract", () => {
+    // The union comes from the single @elizaos/shared contract (#12409); this
+    // asserts writeChatStatusSse renders each phase kind onto the wire.
     const kinds: ChatTurnStatus["kind"][] = [
       "thinking",
       "streaming",

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -34,6 +34,7 @@ import {
   type UUID,
   validateUuid,
 } from "@elizaos/core";
+import type { ChatFailureKind } from "@elizaos/shared";
 import {
   PatchConversationRequestSchema,
   PostConversationCleanupEmptyRequestSchema,
@@ -45,7 +46,6 @@ import type { ElizaConfig } from "../config/config.ts";
 import { resolveStateDir } from "../config/paths.ts";
 import type {
   AccountConnectRequest,
-  ChatFailureKind,
   ChatGenerationResult,
   LogEntry,
 } from "./chat-routes.ts";

--- a/packages/shared/src/contracts/chat.test.ts
+++ b/packages/shared/src/contracts/chat.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guards the single-source chat SSE contract (#12409): both `ChatTurnStatus`
+ * and `ChatFailureKind` are declared exactly once here and re-exported from the
+ * `@elizaos/shared` root, so the agent SSE emitter and the UI client parse the
+ * same union. The unions are type-only, so these tests pin the member sets via
+ * exhaustive const arrays that stop compiling if a member is added or removed
+ * on one side without updating this contract.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+  ChatFailureKind as RootChatFailureKind,
+  ChatTurnStatus as RootChatTurnStatus,
+} from "../index.js";
+import type { ChatFailureKind, ChatTurnStatus } from "./chat.js";
+
+// Compile-time proof the root barrel re-exports the same declaration: a
+// mismatch on either side is a type error, not a silent divergence.
+const _sameTurnStatus: RootChatTurnStatus = {} as ChatTurnStatus;
+const _sameFailureKind: RootChatFailureKind = "no_provider" as ChatFailureKind;
+void _sameTurnStatus;
+void _sameFailureKind;
+
+describe("ChatTurnStatus contract", () => {
+  it("covers exactly the seven in-flight turn phases", () => {
+    const kinds: ChatTurnStatus["kind"][] = [
+      "thinking",
+      "streaming",
+      "running_action",
+      "running_tool",
+      "evaluating",
+      "waking",
+      "speaking",
+    ];
+    expect(new Set(kinds).size).toBe(kinds.length);
+    expect(kinds).toHaveLength(7);
+  });
+
+  it("carries only optional label/actionName/toolName alongside kind", () => {
+    const running: ChatTurnStatus = {
+      kind: "running_action",
+      actionName: "SEND_MESSAGE",
+    };
+    const tool: ChatTurnStatus = { kind: "running_tool", toolName: "search" };
+    const bare: ChatTurnStatus = { kind: "thinking" };
+    expect(running.actionName).toBe("SEND_MESSAGE");
+    expect(tool.toolName).toBe("search");
+    expect(bare.label).toBeUndefined();
+  });
+});
+
+describe("ChatFailureKind contract", () => {
+  it("covers exactly the five turn-failure discriminators", () => {
+    const kinds: ChatFailureKind[] = [
+      "insufficient_credits",
+      "no_provider",
+      "provider_issue",
+      "rate_limited",
+      "local_inference",
+    ];
+    expect(new Set(kinds).size).toBe(kinds.length);
+    expect(kinds).toHaveLength(5);
+  });
+});

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -1,0 +1,53 @@
+/**
+ * Single-source SSE contract for the chat turn: the phases the agent reports
+ * mid-turn and the discriminator it returns when a turn fails. Both the agent
+ * server (chat/conversation SSE emission) and the UI client (SSE parsing +
+ * render) import these here so the wire format is declared exactly once and the
+ * two sides cannot drift (#12409, parent #12093).
+ */
+
+/**
+ * In-flight assistant-turn status, surfaced to the UI as an additive SSE
+ * `{ type: "status", ... }` event so the chat can show what the agent is *doing*
+ * rather than just breathing dots. The `token` / `done` / `error` SSE contract
+ * is unchanged — a client that ignores `status` events behaves exactly as before.
+ *
+ * - `thinking`   — the model is being called; no user-visible tokens yet.
+ * - `streaming`  — the model is emitting the user-visible reply token-by-token.
+ * - `running_action` — a concrete action handler is executing (carry
+ *                  `actionName`, e.g. "SEND_MESSAGE").
+ * - `running_tool`   — a tool/MCP call is running (carry `toolName`).
+ * - `evaluating` — post-response evaluators are running.
+ * - `waking`     — a non-running cloud agent is auto-resuming (HTTP 202 +
+ *                  Retry-After); the request is parked until it answers.
+ * - `speaking`   — the reply is being spoken aloud (voice output); client-derived.
+ */
+export interface ChatTurnStatus {
+  kind:
+    | "thinking"
+    | "streaming"
+    | "running_action"
+    | "running_tool"
+    | "evaluating"
+    | "waking"
+    | "speaking";
+  /** Optional short human-readable label override for the phase. */
+  label?: string;
+  /** Canonical action name when `kind === "running_action"`. */
+  actionName?: string;
+  /** Tool/MCP name when `kind === "running_tool"`. */
+  toolName?: string;
+}
+
+/**
+ * Discriminator the conversation route includes in its 200 response so the
+ * renderer can distinguish "provider configured but throwing" from "no
+ * provider configured at all" — the latter is a UX gate ("Connect a
+ * provider"), not a chat reply.
+ */
+export type ChatFailureKind =
+  | "insufficient_credits"
+  | "no_provider"
+  | "provider_issue"
+  | "rate_limited"
+  | "local_inference";

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -9,6 +9,7 @@ export * from "./apps-runs-routes.js";
 export * from "./auth-routes.js";
 export * from "./awareness.js";
 export * from "./character-routes.js";
+export * from "./chat.js";
 export * from "./cloud-coding-containers.js";
 export * from "./cloud-topology.js";
 export * from "./config.js";

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -9,6 +9,10 @@ import type {
   ConversationScope,
 } from "./client-types-core";
 
+// Single-source SSE chat contract lives in @elizaos/shared (#12409); re-exported
+// here so existing `@elizaos/ui` `api` consumers keep their import path.
+export type { ChatFailureKind, ChatTurnStatus } from "@elizaos/shared";
+
 // Conversations
 export interface Conversation {
   id: string;
@@ -128,13 +132,6 @@ export interface ConversationMessageReaction {
   count: number;
   users?: string[];
 }
-
-export type ChatFailureKind =
-  | "insufficient_credits"
-  | "no_provider"
-  | "provider_issue"
-  | "rate_limited"
-  | "local_inference";
 
 export interface ChatActionResultSummary {
   actionName?: string;
@@ -419,41 +416,6 @@ export interface ChatTokenUsage {
   totalTokens: number;
   llmCalls?: number;
   model?: string;
-}
-
-/**
- * The discrete phases an in-flight assistant turn moves through, surfaced to the
- * UI so the chat shows what the agent is *doing* (not just breathing dots).
- *
- * - `thinking`   — the turn started; the model is being prompted but no visible
- *                  text has streamed yet.
- * - `streaming`  — the model is emitting the user-visible reply token-by-token.
- * - `running_action` — a concrete action handler is executing (carry
- *                  `actionName`, e.g. "SEND_MESSAGE").
- * - `running_tool`   — a tool/MCP call is running (carry `toolName`).
- * - `evaluating` — post-response evaluators are running.
- * - `waking`     — a non-running cloud agent is auto-resuming (HTTP 202 +
- *                  Retry-After); the request is parked until it answers.
- * - `speaking`   — the reply is being spoken aloud (voice output); client-derived.
- *
- * Emitted by the server as additive SSE `{ type: "status", ... }` events and/or
- * derived client-side. The `token` / `done` / `error` SSE contract is unchanged.
- */
-export interface ChatTurnStatus {
-  kind:
-    | "thinking"
-    | "streaming"
-    | "running_action"
-    | "running_tool"
-    | "evaluating"
-    | "waking"
-    | "speaking";
-  /** Optional short human-readable label override for the phase. */
-  label?: string;
-  /** Canonical action name when `kind === "running_action"`. */
-  actionName?: string;
-  /** Tool/MCP name when `kind === "running_tool"`. */
-  toolName?: string;
 }
 
 // Document / Character Knowledge types


### PR DESCRIPTION
## What changed

`ChatTurnStatus` and `ChatFailureKind` were mirror-declared in two places — the agent SSE emitter (`packages/agent/src/api/chat-routes.ts`) and the UI client (`packages/ui/src/api/client-types-chat.ts`) — and kept in lockstep by a structural-identity unit guard. This moves both unions to a single `@elizaos/shared` contract so the wire format is declared exactly once and the two sides cannot drift (parent #12093 item 3).

- **shared:** new `packages/shared/src/contracts/chat.ts` declaring `ChatTurnStatus` + `ChatFailureKind`; barreled from `contracts/index.ts` (already re-exported at the `@elizaos/shared` root).
- **agent:** `chat-routes.ts` imports both from `@elizaos/shared` (mirror declarations deleted); `conversation-routes.ts` and `chat-status-sse.test.ts` now import from shared. SSE emission logic (`writeChatStatusSse`, `classifyChatFailure`) unchanged.
- **ui:** `client-types-chat.ts` re-exports both from shared, so existing `@elizaos/ui` `api` consumers (`AppContext`, `useShellController`, `ContinuousChatOverlay`, `client-base`, etc.) keep their import path. SSE parse/render behavior unchanged.
- **tests:** new `packages/shared/src/contracts/chat.test.ts` pins the union member sets (7 turn phases, 5 failure kinds) and proves the root-barrel re-export is the same declaration; the agent SSE-status test is reframed off the old mirror-lockstep guard onto the shared contract.

## Done when

- [x] Both types declared exactly once in shared (grep: only `packages/shared/src/contracts/chat.ts` declares them; `ChatTurnStatusValue` is a distinct UI context type).
- [x] SSE status emission and UI parsing behavior unchanged (behavioral tests green, no logic touched).
- [x] No mirror declarations remain in agent or UI (grep for `interface ChatTurnStatus` / `type ChatFailureKind` in both files returns none).

## Verification

Scoped to touched packages (worktree shares parent node_modules; full monorepo typecheck needs type-def libs not installed here — CI covers it):

- `bun x vitest run packages/shared/src/contracts/chat.test.ts` → **3 passed**
- `bun x vitest run packages/agent/src/api/chat-status-sse.test.ts` → **4 passed**
- `bun x vitest run packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts conversation-stream-sse-contract.test.ts` → **11 passed**
- `bun x vitest run packages/ui/src/api/client-types-chat.test.ts + components/shell/__tests__/useShellController.test.tsx` → **60 passed**
- `biome check` on all 7 touched files → **clean**

Closes #12409