### PR TITLE
feat(agent): MODEL_SWITCH + AGENT_SWITCH actions with one shared switch route (#12178 Phase 3)

### DIFF
--- a/packages/agent/src/api/runtime-switch-routes.test.ts
+++ b/packages/agent/src/api/runtime-switch-routes.test.ts
@@ -1,0 +1,395 @@
+// Server half of the #12178 runtime-switch contract. POST /api/runtime/
+// model-switch applies the switch through the existing local-inference routes
+// (injected loopbackFetch) and broadcasts shell:model-switch; POST
+// /api/runtime/agent-switch broadcasts shell:switch-agent and resolves against
+// a frontend result callback. The frontend halves are covered in packages/ui.
+//
+// Focused route unit test: real body parsing (Readable), a fake loopback fetch
+// standing in for the local-inference routes, no PGLite/runtime/LLM.
+
+import type http from "node:http";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleRuntimeSwitchRoutes,
+  type RuntimeSwitchRouteContext,
+  resolveAgentSwitchResult,
+} from "./runtime-switch-routes.ts";
+
+type Body = Record<string, unknown>;
+
+/** A fake local-inference loopback: records calls and replays scripted responses. */
+function fakeLoopback(routes: Record<string, { status: number; body: Body }>): {
+  fetch: typeof fetch;
+  calls: Array<{ method: string; path: string; body: Body | null }>;
+} {
+  const calls: Array<{ method: string; path: string; body: Body | null }> = [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const u = new URL(String(url));
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = init?.body ? (JSON.parse(String(init.body)) as Body) : null;
+    calls.push({ method, path: u.pathname, body });
+    const key = `${method} ${u.pathname}`;
+    const route = routes[key] ?? { status: 404, body: { error: "not mocked" } };
+    return new Response(JSON.stringify(route.body), {
+      status: route.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+function makeCtx(
+  method: string,
+  pathname: string,
+  body: Body | null,
+  loopbackFetch?: typeof fetch,
+): {
+  ctx: RuntimeSwitchRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  broadcastWs: ReturnType<typeof vi.fn>;
+} {
+  const req = Readable.from(
+    body === null ? [] : [Buffer.from(JSON.stringify(body))],
+  ) as unknown as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+  const broadcastWs = vi.fn();
+  const ctx: RuntimeSwitchRouteContext = {
+    req,
+    res,
+    method,
+    pathname,
+    json,
+    error,
+    broadcastWs,
+    ...(loopbackFetch ? { loopbackFetch } : {}),
+  };
+  return { ctx, json, error, broadcastWs };
+}
+
+/**
+ * Await real macrotask ticks until `predicate` holds. The route parses the
+ * request body from a stream before it broadcasts, so the broadcast lands a
+ * few ticks after the handler is invoked — not on the first microtask.
+ */
+async function flushUntil(predicate: () => boolean, tries = 50): Promise<void> {
+  for (let i = 0; i < tries && !predicate(); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("POST /api/runtime/model-switch", () => {
+  it("switches to cloud: flips both text slots and broadcasts shell:model-switch", async () => {
+    const loop = fakeLoopback({
+      "POST /api/local-inference/routing/preferred": {
+        status: 200,
+        body: { preferences: {} },
+      },
+      "POST /api/local-inference/routing/policy": {
+        status: 200,
+        body: { preferences: {} },
+      },
+    });
+    const { ctx, json, broadcastWs } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "cloud" },
+      loop.fetch,
+    );
+
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+
+    const preferredCalls = loop.calls.filter(
+      (c) => c.path === "/api/local-inference/routing/preferred",
+    );
+    expect(preferredCalls).toHaveLength(2); // TEXT_SMALL + TEXT_LARGE
+    expect(preferredCalls.every((c) => c.body?.provider === "elizacloud")).toBe(
+      true,
+    );
+
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "shell:model-switch",
+        target: "cloud",
+        status: "ready",
+      }),
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, target: "cloud" }),
+    );
+  });
+
+  it("switches to a locally-installed model: assigns, routes local, activates", async () => {
+    const loop = fakeLoopback({
+      "POST /api/local-inference/assignments": {
+        status: 200,
+        body: { assignments: { TEXT_LARGE: "eliza-1-2b" } },
+      },
+      "POST /api/local-inference/routing/preferred": {
+        status: 200,
+        body: { preferences: {} },
+      },
+      "POST /api/local-inference/routing/policy": {
+        status: 200,
+        body: { preferences: {} },
+      },
+      "GET /api/local-inference/installed": {
+        status: 200,
+        body: { models: [{ id: "eliza-1-2b" }] },
+      },
+      "POST /api/local-inference/active": {
+        status: 200,
+        body: { modelId: "eliza-1-2b", status: "ready" },
+      },
+    });
+    const { ctx, json, broadcastWs } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "local", model: "eliza-1-2b" },
+      loop.fetch,
+    );
+
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(
+      loop.calls.some((c) => c.path === "/api/local-inference/active"),
+    ).toBe(true);
+    expect(
+      loop.calls.some((c) => c.path === "/api/local-inference/downloads"),
+    ).toBe(false);
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "shell:model-switch",
+        target: "local",
+        model: "eliza-1-2b",
+        status: "ready",
+      }),
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, status: "ready" }),
+    );
+  });
+
+  it("switches to a not-yet-installed model: starts a download instead of activating", async () => {
+    const loop = fakeLoopback({
+      "POST /api/local-inference/assignments": {
+        status: 200,
+        body: { assignments: {} },
+      },
+      "POST /api/local-inference/routing/preferred": {
+        status: 200,
+        body: { preferences: {} },
+      },
+      "POST /api/local-inference/routing/policy": {
+        status: 200,
+        body: { preferences: {} },
+      },
+      "GET /api/local-inference/installed": {
+        status: 200,
+        body: { models: [] },
+      },
+      "POST /api/local-inference/downloads": {
+        status: 202,
+        body: { job: { modelId: "eliza-1-4b" } },
+      },
+    });
+    const { ctx, broadcastWs } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "local", model: "eliza-1-4b" },
+      loop.fetch,
+    );
+
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(
+      loop.calls.some((c) => c.path === "/api/local-inference/downloads"),
+    ).toBe(true);
+    expect(
+      loop.calls.some((c) => c.path === "/api/local-inference/active"),
+    ).toBe(false);
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "shell:model-switch",
+        status: "downloading",
+      }),
+    );
+  });
+
+  it("rejects a non-sanctioned local model at the boundary (no loopback calls)", async () => {
+    const loop = fakeLoopback({});
+    const { ctx, error } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "local", model: "llama-3-8b" },
+      loop.fetch,
+    );
+
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("not a sanctioned local model"),
+      400,
+    );
+    expect(loop.calls).toHaveLength(0);
+  });
+
+  it("rejects a non-default cloud model at the boundary", async () => {
+    const loop = fakeLoopback({});
+    const { ctx, error } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "cloud", model: "gpt-5" },
+      loop.fetch,
+    );
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("not a sanctioned cloud model"),
+      400,
+    );
+  });
+
+  it("rejects a missing/invalid target", async () => {
+    const { ctx, error } = makeCtx("POST", "/api/runtime/model-switch", {
+      target: "gpu",
+    });
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("local"),
+      400,
+    );
+  });
+
+  it("returns 502 when a local-inference route fails", async () => {
+    const loop = fakeLoopback({
+      "POST /api/local-inference/routing/preferred": {
+        status: 500,
+        body: { error: "disk full" },
+      },
+    });
+    const { ctx, error } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "cloud" },
+      loop.fetch,
+    );
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("Model switch failed"),
+      502,
+    );
+  });
+});
+
+describe("POST /api/runtime/agent-switch", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("broadcasts shell:switch-agent and resolves when the shell reports success", async () => {
+    const { ctx, json, broadcastWs } = makeCtx(
+      "POST",
+      "/api/runtime/agent-switch",
+      {
+        profile: "cloud",
+      },
+    );
+
+    const done = handleRuntimeSwitchRoutes(ctx);
+    await flushUntil(() => broadcastWs.mock.calls.length > 0);
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "shell:switch-agent", profile: "cloud" }),
+    );
+    const requestId = (broadcastWs.mock.calls[0][0] as { requestId: string })
+      .requestId;
+    expect(typeof requestId).toBe("string");
+
+    resolveAgentSwitchResult({
+      requestId,
+      ok: true,
+      profileId: "p1",
+      profileLabel: "My Cloud Agent",
+    });
+
+    expect(await done).toBe(true);
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        ok: true,
+        profileId: "p1",
+        profileLabel: "My Cloud Agent",
+      }),
+    );
+  });
+
+  it("relays an untrusted-remote refusal from the shell", async () => {
+    const { ctx, json, broadcastWs } = makeCtx(
+      "POST",
+      "/api/runtime/agent-switch",
+      {
+        profile: "my vps",
+      },
+    );
+    const done = handleRuntimeSwitchRoutes(ctx);
+    await flushUntil(() => broadcastWs.mock.calls.length > 0);
+    const requestId = (broadcastWs.mock.calls[0][0] as { requestId: string })
+      .requestId;
+    resolveAgentSwitchResult({
+      requestId,
+      ok: false,
+      reason: "untrusted-remote",
+    });
+    expect(await done).toBe(true);
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: false, reason: "untrusted-remote" }),
+    );
+  });
+
+  it("degrades to no-shell when no shell answers before the timeout", async () => {
+    vi.useFakeTimers();
+    const { ctx, json } = makeCtx("POST", "/api/runtime/agent-switch", {
+      profile: "cloud",
+    });
+    const done = handleRuntimeSwitchRoutes(ctx);
+    await vi.advanceTimersByTimeAsync(13_000);
+    expect(await done).toBe(true);
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: false, reason: "no-shell" }),
+    );
+  });
+
+  it("returns no-shell immediately when no broadcast transport is present", async () => {
+    const { ctx, json } = makeCtx("POST", "/api/runtime/agent-switch", {
+      profile: "cloud",
+    });
+    ctx.broadcastWs = undefined;
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: false, reason: "no-shell" }),
+    );
+  });
+
+  it("rejects a missing profile", async () => {
+    const { ctx, error } = makeCtx("POST", "/api/runtime/agent-switch", {});
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      "profile is required",
+      400,
+    );
+  });
+});
+
+describe("route matching", () => {
+  it("returns false for unrelated paths", async () => {
+    const { ctx } = makeCtx("POST", "/api/views/foo/navigate", {});
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(false);
+  });
+});

--- a/packages/agent/src/api/runtime-switch-routes.ts
+++ b/packages/agent/src/api/runtime-switch-routes.ts
@@ -1,0 +1,513 @@
+/**
+ * One shared HTTP surface for agent-driven runtime switching (#12178): the
+ * MODEL_SWITCH / AGENT_SWITCH actions and the deterministic `/model` command
+ * all POST here, so user- and agent-initiated switches run one implementation.
+ *
+ * Routes:
+ *   POST /api/runtime/model-switch         — flip text inference local↔cloud
+ *   POST /api/runtime/agent-switch         — repoint the app shell to a saved
+ *                                            runtime profile (resolved client-side)
+ *   POST /api/runtime/agent-switch/result  — frontend result callback
+ *
+ * Model switching is applied server-side through the EXISTING local-inference
+ * routes over loopback (assignments / routing / active / downloads — no second
+ * implementation of any of them), then broadcast as `shell:model-switch` so
+ * connected shells can surface a notice. Sanctioned-models-only is enforced
+ * here at the boundary: local ids must be curated Eliza-1 release tiers
+ * (`DEFAULT_ELIGIBLE_MODEL_IDS`), cloud is exactly
+ * `DEFAULT_ELIZA_CLOUD_TEXT_MODEL`.
+ *
+ * Distinct from `POST /api/provider/switch` (provider-switch-routes.ts): that
+ * is the BYOK provider-connection axis — persists an API key to the vault,
+ * rewrites the runtime connection config, and restarts the runtime. This
+ * route is the lightweight local↔cloud inference-routing axis (dossier §H
+ * "hybrid axis"): no restart, no key handling, routing preference only.
+ *
+ * Agent switching cannot complete server-side: runtime profiles are
+ * client-persisted (localStorage registry, see
+ * `packages/ui/src/state/agent-profiles.ts`), so the server deliberately owns
+ * no profile registry. The route broadcasts `shell:switch-agent` with a
+ * request id, the shell resolves the profile and applies it via the canonical
+ * `switchRuntimeNonDestructive` (inheriting its remote-trust gate), and
+ * reports the outcome back through the result callback — same
+ * pending-request pattern as the views interact round-trip.
+ */
+
+import { randomUUID } from "node:crypto";
+import type http from "node:http";
+
+import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import {
+  DEFAULT_ELIGIBLE_MODEL_IDS,
+  DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  FIRST_RUN_DEFAULT_MODEL_ID,
+  findCatalogModel,
+  type ProviderId,
+  readJsonBody,
+  TEXT_GENERATION_SLOTS,
+} from "@elizaos/shared";
+import { PendingRequestMap } from "./pending-request-map.ts";
+
+// Provider ids as registered with the routing layer. Typed against the shared
+// ProviderId union so a rename upstream fails compilation here. The string
+// values are owned by plugins/plugin-local-inference/src/provider.ts and
+// plugins/plugin-elizacloud — kept literal so this route never imports plugin
+// runtime modules.
+const LOCAL_TEXT_PROVIDER: ProviderId = "eliza-local-inference";
+const CLOUD_TEXT_PROVIDER: ProviderId = "elizacloud";
+
+const PREFIX = "/api/runtime";
+
+/** How long the model-load call may take before the switch reports an error. */
+const ACTIVE_LOAD_TIMEOUT_MS = 120_000;
+/** How long the shell gets to resolve + apply an agent switch. */
+const AGENT_SWITCH_TIMEOUT_MS = 12_000;
+const LOOPBACK_TIMEOUT_MS = 10_000;
+
+export type ModelSwitchTarget = "local" | "cloud";
+export type ModelSwitchStatus = "ready" | "loading" | "downloading";
+
+/** Wire response of POST /api/runtime/model-switch. */
+export interface ModelSwitchResponse {
+  ok: true;
+  target: ModelSwitchTarget;
+  model: string;
+  displayName: string;
+  status: ModelSwitchStatus;
+  /** Bundle size in GB when status === "downloading" (from the catalog). */
+  downloadSizeGb?: number;
+}
+
+/** Wire response of POST /api/runtime/agent-switch. */
+export interface AgentSwitchResponse {
+  ok: boolean;
+  profileId?: string;
+  profileLabel?: string;
+  /**
+   * Refusal/failure reason when ok=false:
+   * "not-found" | "untrusted-remote" (from the shell's trust gate) or
+   * "no-shell" (no connected shell answered in time).
+   */
+  reason?: string;
+}
+
+const pendingAgentSwitches = new PendingRequestMap();
+
+export interface RuntimeSwitchRouteContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  method: string;
+  pathname: string;
+  json: (res: http.ServerResponse, data: unknown, status?: number) => void;
+  error: (res: http.ServerResponse, message: string, status?: number) => void;
+  broadcastWs?: (payload: object) => void;
+  /** Test seam; defaults to global fetch against the server's own loopback. */
+  loopbackFetch?: typeof fetch;
+}
+
+function loopbackBase(): string {
+  return `http://127.0.0.1:${resolveServerOnlyPort(process.env)}`;
+}
+
+interface LoopbackResult {
+  ok: boolean;
+  status: number;
+  body: Record<string, unknown> | null;
+}
+
+async function loopbackJson(
+  fetchImpl: typeof fetch,
+  method: "GET" | "POST",
+  path: string,
+  body?: Record<string, unknown>,
+  timeoutMs: number = LOOPBACK_TIMEOUT_MS,
+): Promise<LoopbackResult> {
+  const response = await fetchImpl(`${loopbackBase()}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const parsed: unknown = await response.json().catch(() => null);
+  return {
+    ok: response.ok,
+    status: response.status,
+    body:
+      parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null,
+  };
+}
+
+function sanctionedLocalIds(): string {
+  return [...DEFAULT_ELIGIBLE_MODEL_IDS].join(", ");
+}
+
+/**
+ * Resolve the effective local model id for a switch request: an explicit
+ * sanctioned id wins; otherwise the current TEXT_LARGE assignment when it is
+ * sanctioned; otherwise the first-run default tier.
+ */
+async function resolveLocalModelId(
+  fetchImpl: typeof fetch,
+  requested: string | null,
+): Promise<string> {
+  if (requested) return requested;
+  const assignments = await loopbackJson(
+    fetchImpl,
+    "GET",
+    "/api/local-inference/assignments",
+  );
+  const current = (
+    assignments.body?.assignments as Record<string, unknown> | undefined
+  )?.TEXT_LARGE;
+  if (typeof current === "string" && DEFAULT_ELIGIBLE_MODEL_IDS.has(current)) {
+    return current;
+  }
+  return FIRST_RUN_DEFAULT_MODEL_ID;
+}
+
+async function applyTextRouting(
+  fetchImpl: typeof fetch,
+  provider: ProviderId,
+): Promise<void> {
+  // `preferredProvider` is only honoured under the "manual" policy
+  // (plugin-local-inference routing-policy.ts), so both are set per text slot.
+  for (const slot of TEXT_GENERATION_SLOTS) {
+    const preferred = await loopbackJson(
+      fetchImpl,
+      "POST",
+      "/api/local-inference/routing/preferred",
+      { slot, provider },
+    );
+    if (!preferred.ok) {
+      throw new Error(`routing/preferred ${slot} returned ${preferred.status}`);
+    }
+    const policy = await loopbackJson(
+      fetchImpl,
+      "POST",
+      "/api/local-inference/routing/policy",
+      { slot, policy: "manual" },
+    );
+    if (!policy.ok) {
+      throw new Error(`routing/policy ${slot} returned ${policy.status}`);
+    }
+  }
+}
+
+async function isModelInstalled(
+  fetchImpl: typeof fetch,
+  modelId: string,
+): Promise<boolean> {
+  const installed = await loopbackJson(
+    fetchImpl,
+    "GET",
+    "/api/local-inference/installed",
+  );
+  const models = installed.body?.models;
+  return (
+    Array.isArray(models) &&
+    models.some(
+      (model) =>
+        model !== null &&
+        typeof model === "object" &&
+        (model as Record<string, unknown>).id === modelId,
+    )
+  );
+}
+
+async function switchToLocal(
+  fetchImpl: typeof fetch,
+  modelId: string,
+): Promise<ModelSwitchResponse> {
+  const catalog = findCatalogModel(modelId);
+  const displayName = catalog?.displayName ?? modelId;
+
+  // Assign the chat slot first so readiness derivation reflects the chosen
+  // tier even while the bundle is still downloading.
+  const assignment = await loopbackJson(
+    fetchImpl,
+    "POST",
+    "/api/local-inference/assignments",
+    { slot: "TEXT_LARGE", modelId },
+  );
+  if (!assignment.ok) {
+    throw new Error(
+      typeof assignment.body?.error === "string"
+        ? assignment.body.error
+        : `assignments returned ${assignment.status}`,
+    );
+  }
+  await applyTextRouting(fetchImpl, LOCAL_TEXT_PROVIDER);
+
+  if (await isModelInstalled(fetchImpl, modelId)) {
+    const active = await loopbackJson(
+      fetchImpl,
+      "POST",
+      "/api/local-inference/active",
+      { modelId },
+      ACTIVE_LOAD_TIMEOUT_MS,
+    );
+    if (!active.ok) {
+      throw new Error(
+        typeof active.body?.error === "string"
+          ? active.body.error
+          : `active returned ${active.status}`,
+      );
+    }
+    const status: ModelSwitchStatus =
+      active.body?.status === "ready" ? "ready" : "loading";
+    return { ok: true, target: "local", model: modelId, displayName, status };
+  }
+
+  const download = await loopbackJson(
+    fetchImpl,
+    "POST",
+    "/api/local-inference/downloads",
+    { modelId },
+  );
+  if (!download.ok) {
+    throw new Error(
+      typeof download.body?.error === "string"
+        ? download.body.error
+        : `downloads returned ${download.status}`,
+    );
+  }
+  return {
+    ok: true,
+    target: "local",
+    model: modelId,
+    displayName,
+    status: "downloading",
+    ...(catalog ? { downloadSizeGb: catalog.sizeGb } : {}),
+  };
+}
+
+async function switchToCloud(
+  fetchImpl: typeof fetch,
+  modelId: string,
+): Promise<ModelSwitchResponse> {
+  await applyTextRouting(fetchImpl, CLOUD_TEXT_PROVIDER);
+  return {
+    ok: true,
+    target: "cloud",
+    model: modelId,
+    displayName: `Eliza Cloud (${modelId})`,
+    status: "ready",
+  };
+}
+
+/**
+ * Resolve a pending agent switch from the frontend's result callback. Exposed
+ * for the route's own result endpoint and for tests.
+ */
+export function resolveAgentSwitchResult(result: {
+  requestId: string;
+  ok: boolean;
+  profileId?: string;
+  profileLabel?: string;
+  reason?: string;
+}): void {
+  pendingAgentSwitches.resolve(result.requestId, {
+    requestId: result.requestId,
+    success: result.ok,
+    result: {
+      profileId: result.profileId,
+      profileLabel: result.profileLabel,
+      reason: result.reason,
+    },
+  });
+}
+
+export async function handleRuntimeSwitchRoutes(
+  ctx: RuntimeSwitchRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, json, error } = ctx;
+  if (!pathname.startsWith(PREFIX)) return false;
+  const fetchImpl = ctx.loopbackFetch ?? fetch;
+
+  // ── POST /api/runtime/model-switch ────────────────────────────────────────
+  if (method === "POST" && pathname === `${PREFIX}/model-switch`) {
+    const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
+      () => null,
+    );
+    if (!body) return true;
+
+    const target = body.target;
+    if (target !== "local" && target !== "cloud") {
+      error(res, 'target must be "local" or "cloud"', 400);
+      return true;
+    }
+    const requestedModel =
+      typeof body.model === "string" && body.model.trim().length > 0
+        ? body.model.trim()
+        : null;
+
+    // Sanctioned-models-only is a hard product rule: local = curated Eliza-1
+    // release tiers, cloud = the managed default text model. No other ids.
+    if (
+      target === "local" &&
+      requestedModel &&
+      !DEFAULT_ELIGIBLE_MODEL_IDS.has(requestedModel)
+    ) {
+      error(
+        res,
+        `"${requestedModel}" is not a sanctioned local model. Available: ${sanctionedLocalIds()}.`,
+        400,
+      );
+      return true;
+    }
+    if (
+      target === "cloud" &&
+      requestedModel &&
+      requestedModel !== DEFAULT_ELIZA_CLOUD_TEXT_MODEL
+    ) {
+      error(
+        res,
+        `"${requestedModel}" is not a sanctioned cloud model. Available: ${DEFAULT_ELIZA_CLOUD_TEXT_MODEL}.`,
+        400,
+      );
+      return true;
+    }
+
+    try {
+      const result =
+        target === "local"
+          ? await switchToLocal(
+              fetchImpl,
+              await resolveLocalModelId(fetchImpl, requestedModel),
+            )
+          : await switchToCloud(
+              fetchImpl,
+              requestedModel ?? DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+            );
+
+      logger.info(
+        {
+          src: "RuntimeSwitchRoutes",
+          target: result.target,
+          model: result.model,
+          status: result.status,
+        },
+        `[RuntimeSwitchRoutes] Model switch → ${result.target} (${result.model}, ${result.status})`,
+      );
+      ctx.broadcastWs?.({
+        type: "shell:model-switch",
+        target: result.target,
+        model: result.model,
+        displayName: result.displayName,
+        status: result.status,
+        ...(result.downloadSizeGb !== undefined
+          ? { downloadSizeGb: result.downloadSizeGb }
+          : {}),
+      });
+      json(res, result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        { src: "RuntimeSwitchRoutes", err: message, target },
+        `[RuntimeSwitchRoutes] Model switch to ${target} failed: ${message}`,
+      );
+      error(res, `Model switch failed: ${message}`, 502);
+    }
+    return true;
+  }
+
+  // ── POST /api/runtime/agent-switch ────────────────────────────────────────
+  if (method === "POST" && pathname === `${PREFIX}/agent-switch`) {
+    const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
+      () => null,
+    );
+    if (!body) return true;
+
+    const profile =
+      typeof body.profile === "string" && body.profile.trim().length > 0
+        ? body.profile.trim()
+        : null;
+    if (!profile) {
+      error(res, "profile is required", 400);
+      return true;
+    }
+    if (!ctx.broadcastWs) {
+      json(res, {
+        ok: false,
+        reason: "no-shell",
+      } satisfies AgentSwitchResponse);
+      return true;
+    }
+
+    const requestId = randomUUID();
+    logger.info(
+      { src: "RuntimeSwitchRoutes", requestId, profile },
+      `[RuntimeSwitchRoutes] Agent switch requested → "${profile}"`,
+    );
+    const pending = pendingAgentSwitches.waitFor(
+      requestId,
+      AGENT_SWITCH_TIMEOUT_MS,
+    );
+    ctx.broadcastWs({ type: "shell:switch-agent", requestId, profile });
+
+    try {
+      const outcome = await pending;
+      const detail =
+        outcome.result !== null &&
+        typeof outcome.result === "object" &&
+        !Array.isArray(outcome.result)
+          ? (outcome.result as Record<string, unknown>)
+          : {};
+      const response: AgentSwitchResponse = {
+        ok: outcome.success,
+        ...(typeof detail.profileId === "string"
+          ? { profileId: detail.profileId }
+          : {}),
+        ...(typeof detail.profileLabel === "string"
+          ? { profileLabel: detail.profileLabel }
+          : {}),
+        ...(typeof detail.reason === "string" ? { reason: detail.reason } : {}),
+      };
+      logger.info(
+        { src: "RuntimeSwitchRoutes", requestId, ...response },
+        `[RuntimeSwitchRoutes] Agent switch ${response.ok ? "applied" : `refused (${response.reason ?? "unknown"})`}`,
+      );
+      json(res, response);
+    } catch {
+      // waitFor timeout — no connected shell resolved the request.
+      logger.warn(
+        { src: "RuntimeSwitchRoutes", requestId, profile },
+        "[RuntimeSwitchRoutes] Agent switch timed out waiting for a shell",
+      );
+      json(res, {
+        ok: false,
+        reason: "no-shell",
+      } satisfies AgentSwitchResponse);
+    }
+    return true;
+  }
+
+  // ── POST /api/runtime/agent-switch/result ─────────────────────────────────
+  if (method === "POST" && pathname === `${PREFIX}/agent-switch/result`) {
+    const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
+      () => null,
+    );
+    if (!body) return true;
+    const requestId =
+      typeof body.requestId === "string" ? body.requestId : null;
+    if (!requestId) {
+      error(res, "requestId is required", 400);
+      return true;
+    }
+    resolveAgentSwitchResult({
+      requestId,
+      ok: body.ok === true,
+      profileId:
+        typeof body.profileId === "string" ? body.profileId : undefined,
+      profileLabel:
+        typeof body.profileLabel === "string" ? body.profileLabel : undefined,
+      reason: typeof body.reason === "string" ? body.reason : undefined,
+    });
+    json(res, { ok: true });
+    return true;
+  }
+
+  return false;
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -388,6 +388,7 @@ import {
   resolveWalletDiagnosticStatus,
 } from "./plugin-diagnostic.ts";
 import { createRuntimeReadyGate } from "./runtime-ready-gate.ts";
+import { handleRuntimeSwitchRoutes } from "./runtime-switch-routes.ts";
 import {
   cloneWithoutBlockedObjectKeys,
   decodePathComponent,
@@ -3408,6 +3409,21 @@ async function handleRequest(
       error,
       broadcastWs: state.broadcastWs ?? undefined,
       runtime: state.runtime,
+    })
+  ) {
+    return;
+  }
+
+  // ── Runtime switch routes (/api/runtime/model-switch, /agent-switch) ──────
+  if (
+    await handleRuntimeSwitchRoutes({
+      req,
+      res,
+      method,
+      pathname,
+      json,
+      error,
+      broadcastWs: state.broadcastWs ?? undefined,
     })
   ) {
     return;

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -1448,6 +1448,7 @@ function AppProviderInner({
     setConnected,
     setAgentStatus,
     setAgentStatusIfChanged,
+    setActionNotice,
     setStartupPhase,
     setStartupError,
     setAuthRequired,

--- a/packages/ui/src/state/agent-profiles.test.ts
+++ b/packages/ui/src/state/agent-profiles.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   addAgentProfile,
   loadAgentProfileRegistry,
+  resolveAgentProfileByQuery,
   scrubPersistedAgentProfileTokens,
   upsertAndActivateAgentProfile,
 } from "./agent-profiles";
@@ -143,5 +144,60 @@ describe("upsertAndActivateAgentProfile — cross-surface registry sync", () => 
       (x) => x.id === p.id,
     );
     expect(remote?.accessToken).toBe("keep-me");
+  });
+});
+
+describe("resolveAgentProfileByQuery", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("resolves by exact id, exact label, then unique substring", () => {
+    const cloud = addAgentProfile({
+      label: "My Cloud Agent",
+      kind: "cloud",
+      apiBase: "https://agent.example.test",
+    });
+    addAgentProfile({ label: "Laptop", kind: "local", apiBase: "" });
+
+    expect(resolveAgentProfileByQuery(cloud.id)?.id).toBe(cloud.id);
+    expect(resolveAgentProfileByQuery("my cloud agent")?.id).toBe(cloud.id);
+    // Unique substring of the label.
+    expect(resolveAgentProfileByQuery("laptop")?.label).toBe("Laptop");
+  });
+
+  it("resolves a unique kind keyword when exactly one profile has it", () => {
+    const remote = addAgentProfile({
+      label: "VPS",
+      kind: "remote",
+      apiBase: "https://vps.example.test",
+    });
+    addAgentProfile({ label: "Laptop", kind: "local", apiBase: "" });
+
+    expect(resolveAgentProfileByQuery("remote")?.id).toBe(remote.id);
+  });
+
+  it("returns null when a kind keyword is ambiguous", () => {
+    addAgentProfile({ label: "Laptop", kind: "local", apiBase: "" });
+    addAgentProfile({ label: "Desktop", kind: "local", apiBase: "" });
+
+    expect(resolveAgentProfileByQuery("local")).toBeNull();
+  });
+
+  it("returns null for an ambiguous substring, empty query, or no match", () => {
+    addAgentProfile({
+      label: "Cloud North",
+      kind: "cloud",
+      apiBase: "https://n.example.test",
+    });
+    addAgentProfile({
+      label: "Cloud South",
+      kind: "cloud",
+      apiBase: "https://s.example.test",
+    });
+
+    expect(resolveAgentProfileByQuery("cloud")).toBeNull(); // ambiguous substring
+    expect(resolveAgentProfileByQuery("   ")).toBeNull();
+    expect(resolveAgentProfileByQuery("nonexistent")).toBeNull();
   });
 });

--- a/packages/ui/src/state/agent-profiles.ts
+++ b/packages/ui/src/state/agent-profiles.ts
@@ -91,6 +91,41 @@ export function saveAgentProfileRegistry(registry: AgentProfileRegistry): void {
   }, undefined);
 }
 
+/**
+ * Resolve a free-text switch query (from the AGENT_SWITCH action / `shell:
+ * switch-agent` WS event) to a saved profile: exact id, then exact label
+ * (case-insensitive), then a unique label substring match, then a unique
+ * kind match ("cloud"/"local"/"remote"). Returns null when nothing matches or
+ * a substring/kind is ambiguous — the caller reports "not-found" rather than
+ * switching to the wrong agent.
+ */
+export function resolveAgentProfileByQuery(
+  query: string,
+  registry: AgentProfileRegistry = loadAgentProfileRegistry(),
+): AgentProfile | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return null;
+  const profiles = registry.profiles;
+
+  const byId = profiles.find((p) => p.id.toLowerCase() === q);
+  if (byId) return byId;
+
+  const byLabel = profiles.find((p) => p.label.trim().toLowerCase() === q);
+  if (byLabel) return byLabel;
+
+  const bySubstring = profiles.filter((p) =>
+    p.label.trim().toLowerCase().includes(q),
+  );
+  if (bySubstring.length === 1) return bySubstring[0];
+
+  if (q === "local" || q === "cloud" || q === "remote") {
+    const byKind = profiles.filter((p) => p.kind === q);
+    if (byKind.length === 1) return byKind[0];
+  }
+
+  return null;
+}
+
 export function getActiveProfile(): AgentProfile | null {
   const registry = loadAgentProfileRegistry();
   if (!registry.activeProfileId) return null;

--- a/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
@@ -68,6 +68,7 @@ vi.mock("../components/views/view-interact-registry", () => ({
 
 function makeDeps(): ReadyPhaseDeps {
   return {
+    setActionNotice: vi.fn(),
     setAgentStatusIfChanged: vi.fn(),
     setPendingRestart: vi.fn(),
     setPendingRestartReasons: vi.fn(),

--- a/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.switch.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+//
+// Frontend half of the #12178 runtime-switch contract: the bindReadyPhase
+// onWsEvent handlers for `shell:model-switch` and `shell:switch-agent`. Uses the
+// REAL switchRuntimeNonDestructive (and its real remote-trust gate) + real
+// agent-profile registry over jsdom localStorage; only the API client and global
+// fetch (the result callback transport) are doubled.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addAgentProfile } from "./agent-profiles";
+import { bindReadyPhase, type ReadyPhaseDeps } from "./startup-phase-hydrate";
+
+const clientMock = vi.hoisted(() => {
+  const handlers = new Map<string, (data: Record<string, unknown>) => void>();
+  return {
+    connectWs: vi.fn(),
+    disconnectWs: vi.fn(),
+    getCodingAgentStatus: vi.fn(async () => ({ tasks: [] })),
+    handlers,
+    onWsEvent: vi.fn(
+      (event: string, handler: (data: Record<string, unknown>) => void) => {
+        handlers.set(event, handler);
+        return () => {
+          handlers.delete(event);
+        };
+      },
+    ),
+    sendWsMessage: vi.fn(),
+    getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
+    repointBaseUrl: vi.fn(),
+    setToken: vi.fn(),
+  };
+});
+
+vi.mock("../api", () => ({ client: clientMock }));
+
+const setActionNotice = vi.fn();
+
+function makeDeps(): ReadyPhaseDeps {
+  return {
+    setAgentStatusIfChanged: vi.fn(),
+    setPendingRestart: vi.fn(),
+    setPendingRestartReasons: vi.fn(),
+    setSystemWarnings: vi.fn(),
+    showRestartBanner: vi.fn(),
+    setPtySessions: vi.fn(),
+    hasPtySessionsRef: { current: false },
+    agentRunningRef: { current: false },
+    setTabRaw: vi.fn(),
+    setConversationMessages: vi.fn(),
+    setUnreadConversations: vi.fn(),
+    setConversations: vi.fn(),
+    appendAutonomousEvent: vi.fn(),
+    notifyHeartbeatEvent: vi.fn(),
+    loadPlugins: vi.fn(async () => {}),
+    loadWalletConfig: vi.fn(async () => {}),
+    pollCloudCredits: vi.fn(),
+    activeConversationIdRef: { current: null },
+    elizaCloudPollInterval: { current: null },
+    elizaCloudLoginPollTimer: { current: null },
+    setActionNotice,
+  };
+}
+
+function lastResultBody(): Record<string, unknown> {
+  const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("result callback fetch was never called");
+  const [url, init] = call as [string, RequestInit];
+  expect(String(url)).toContain("/api/runtime/agent-switch/result");
+  return JSON.parse(String(init.body)) as Record<string, unknown>;
+}
+
+describe("bindReadyPhase shell:switch-agent handler", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clientMock.handlers.clear();
+    clientMock.repointBaseUrl.mockClear();
+    clientMock.setToken.mockClear();
+    setActionNotice.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+  });
+
+  it("refuses an untrusted remote profile and never repoints the client", () => {
+    addAgentProfile({
+      label: "My VPS",
+      kind: "remote",
+      apiBase: "https://evil.example.com",
+    });
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:switch-agent")?.({
+      requestId: "req-untrusted",
+      profile: "My VPS",
+    });
+
+    // The real trust gate blocked it: no in-place base/token repoint happened.
+    expect(clientMock.repointBaseUrl).not.toHaveBeenCalled();
+    expect(clientMock.setToken).not.toHaveBeenCalled();
+    // The refusal is relayed back to the originating agent and surfaced.
+    expect(lastResultBody()).toEqual({
+      requestId: "req-untrusted",
+      ok: false,
+      reason: "untrusted-remote",
+    });
+    expect(setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("untrusted remote"),
+      "error",
+    );
+
+    cleanup();
+  });
+
+  it("applies a trusted local profile and reports success", () => {
+    const laptop = addAgentProfile({
+      label: "Laptop",
+      kind: "local",
+      apiBase: "",
+    });
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:switch-agent")?.({
+      requestId: "req-local",
+      profile: "Laptop",
+    });
+
+    // A same-origin local runtime repoints back to the app's own host.
+    expect(clientMock.repointBaseUrl).toHaveBeenCalledWith(
+      window.location.origin,
+    );
+    expect(lastResultBody()).toEqual({
+      requestId: "req-local",
+      ok: true,
+      profileId: laptop.id,
+      profileLabel: "Laptop",
+    });
+    expect(setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("Laptop"),
+      "success",
+    );
+
+    cleanup();
+  });
+
+  it("reports not-found for an unknown profile query", () => {
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:switch-agent")?.({
+      requestId: "req-ghost",
+      profile: "does-not-exist",
+    });
+
+    expect(clientMock.repointBaseUrl).not.toHaveBeenCalled();
+    expect(lastResultBody()).toEqual({
+      requestId: "req-ghost",
+      ok: false,
+      reason: "not-found",
+    });
+
+    cleanup();
+  });
+
+  it("ignores a switch-agent event with no requestId", () => {
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:switch-agent")?.({ profile: "Laptop" });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(clientMock.repointBaseUrl).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+});
+
+describe("bindReadyPhase shell:model-switch handler", () => {
+  beforeEach(() => {
+    clientMock.handlers.clear();
+    setActionNotice.mockClear();
+  });
+
+  it("surfaces a cloud switch as a success notice", () => {
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:model-switch")?.({
+      target: "cloud",
+      model: "gemma-4-31b",
+      displayName: "Eliza Cloud (gemma-4-31b)",
+      status: "ready",
+    });
+
+    expect(setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("Eliza Cloud"),
+      "success",
+      undefined,
+      false,
+      false,
+    );
+
+    cleanup();
+  });
+
+  it("surfaces a local download as a busy notice", () => {
+    const cleanup = bindReadyPhase({ current: makeDeps() });
+
+    clientMock.handlers.get("shell:model-switch")?.({
+      target: "local",
+      model: "eliza-1-2b",
+      displayName: "Eliza-1 2B",
+      status: "downloading",
+    });
+
+    expect(setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("downloading"),
+      "success",
+      undefined,
+      false,
+      true,
+    );
+
+    cleanup();
+  });
+});

--- a/packages/ui/src/state/startup-phase-hydrate.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.ts
@@ -38,6 +38,12 @@ import {
 } from "../navigation";
 import { isTransientOptionalFetchFailure } from "../utils";
 import { emitViewEvent } from "../views/view-event-bus";
+import type { ActionTone } from "./action-notice";
+import {
+  loadAgentProfileRegistry,
+  resolveAgentProfileByQuery,
+} from "./agent-profiles";
+import { switchRuntimeNonDestructive } from "./switch-runtime";
 import {
   loadAvatarIndex,
   normalizeAvatarIndex,
@@ -110,6 +116,14 @@ export interface ReadyPhaseDeps {
   activeConversationIdRef: React.RefObject<string | null>;
   elizaCloudPollInterval: React.MutableRefObject<number | null>;
   elizaCloudLoginPollTimer: React.MutableRefObject<number | null>;
+  /** Transient shell toast — confirms agent-driven model/agent switches. */
+  setActionNotice: (
+    text: string,
+    tone?: ActionTone,
+    ttlMs?: number,
+    once?: boolean,
+    busy?: boolean,
+  ) => void;
 }
 
 function normalizeAppEmoteEvent(
@@ -461,6 +475,112 @@ export function bindReadyPhase(
     },
   );
 
+  // Agent-driven text-inference switch (#12178). The server has already applied
+  // the routing change over loopback before broadcasting; this handler surfaces
+  // the user-facing confirmation. Download progress (local target, missing
+  // bundle) continues to flow through the existing local-inference SSE stream +
+  // home model-status hook — no re-fetch needed here.
+  const unbindModelSwitch = client.onWsEvent(
+    "shell:model-switch",
+    (data: Record<string, unknown>) => {
+      const target = data.target === "cloud" ? "cloud" : "local";
+      const status =
+        data.status === "downloading" ||
+        data.status === "loading" ||
+        data.status === "ready"
+          ? data.status
+          : "ready";
+      const displayName =
+        typeof data.displayName === "string" && data.displayName.length > 0
+          ? data.displayName
+          : typeof data.model === "string"
+            ? data.model
+            : target === "cloud"
+              ? "Eliza Cloud"
+              : "the on-device model";
+      const notice =
+        target === "cloud"
+          ? `Switched to Eliza Cloud inference (${displayName}).`
+          : status === "downloading"
+            ? `Switching to on-device ${displayName} — downloading…`
+            : status === "loading"
+              ? `Switching to on-device ${displayName} — loading…`
+              : `Switched to on-device ${displayName}.`;
+      depsRef.current?.setActionNotice(
+        notice,
+        "success",
+        undefined,
+        false,
+        status === "downloading" || status === "loading",
+      );
+    },
+  );
+
+  // Agent-driven runtime-profile switch (#12178). The server owns no profile
+  // registry (profiles are client-persisted), so it broadcasts the request with
+  // a `requestId`; the shell resolves the profile, applies it via the canonical
+  // `switchRuntimeNonDestructive` (inheriting its remote-trust gate), and posts
+  // the outcome back to the ORIGINATING agent's result endpoint. The result must
+  // go to the origin base captured BEFORE the switch, since a successful switch
+  // repoints the live client to a different backend.
+  const unbindSwitchAgent = client.onWsEvent(
+    "shell:switch-agent",
+    (data: Record<string, unknown>) => {
+      const requestId =
+        typeof data.requestId === "string" ? data.requestId : null;
+      const query = typeof data.profile === "string" ? data.profile : "";
+      if (!requestId) return;
+
+      const originBase =
+        typeof client.getBaseUrl === "function" ? client.getBaseUrl() : "";
+      const reportResult = (body: {
+        ok: boolean;
+        profileId?: string;
+        profileLabel?: string;
+        reason?: string;
+      }): void => {
+        void fetch(`${originBase}/api/runtime/agent-switch/result`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ requestId, ...body }),
+        }).catch(() => {
+          // The switch already applied locally; a lost result callback only
+          // means the agent's HTTP call times out (it degrades to "no-shell").
+        });
+      };
+
+      const profile = resolveAgentProfileByQuery(
+        query,
+        loadAgentProfileRegistry(),
+      );
+      if (!profile) {
+        reportResult({ ok: false, reason: "not-found" });
+        return;
+      }
+
+      const result = switchRuntimeNonDestructive(profile.id);
+      if (!result.ok) {
+        reportResult({ ok: false, reason: result.reason });
+        if (result.reason === "untrusted-remote") {
+          depsRef.current?.setActionNotice(
+            `Refused to switch to "${profile.label}" — untrusted remote address.`,
+            "error",
+          );
+        }
+        return;
+      }
+      reportResult({
+        ok: true,
+        profileId: result.profile.id,
+        profileLabel: result.profile.label,
+      });
+      depsRef.current?.setActionNotice(
+        `Switched the app to "${result.profile.label}".`,
+        "success",
+      );
+    },
+  );
+
   const unbindViewEvent = client.onWsEvent(
     "view:event",
     (data: Record<string, unknown>) => {
@@ -780,6 +900,8 @@ export function bindReadyPhase(
     unbindSysWarn();
     unbindRestart();
     unbindShellNavigateView();
+    unbindModelSwitch();
+    unbindSwitchAgent();
     unbindViewEvent();
     unbindViewInteract();
     unbindConvUp();

--- a/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.view-interact.test.ts
@@ -38,6 +38,7 @@ vi.mock("../components/views/view-interact-registry", () => viewInteractMock);
 
 function makeDeps(): ReadyPhaseDeps {
   return {
+    setActionNotice: vi.fn(),
     setAgentStatusIfChanged: vi.fn(),
     setPendingRestart: vi.fn(),
     setPendingRestartReasons: vi.fn(),

--- a/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
@@ -37,6 +37,7 @@ vi.mock("../api", () => ({
 
 function makeDeps(): ReadyPhaseDeps {
   return {
+    setActionNotice: vi.fn(),
     setAgentStatusIfChanged: vi.fn(),
     setPendingRestart: vi.fn(),
     setPendingRestartReasons: vi.fn(),

--- a/plugins/plugin-app-control/src/actions/agent-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.test.ts
@@ -1,0 +1,142 @@
+// Unit coverage for the AGENT_SWITCH action: profile-query parsing, the OWNER
+// role gate, and the handler driving a mocked loopback switch client. The
+// client-side trust gate + real switch live in packages/ui; the route
+// round-trip lives in packages/agent.
+
+import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+	type AgentSwitchFn,
+	type AgentSwitchOutcome,
+	createAgentSwitchAction,
+	inferAgentSwitchProfile,
+} from "./agent-switch.ts";
+
+const runtime = {} as IAgentRuntime;
+
+function message(text: string): Memory {
+	return { content: { text } } as Memory;
+}
+
+function captureCallback(): { callback: HandlerCallback; texts: string[] } {
+	const texts: string[] = [];
+	const callback = vi.fn(async (payload: { text?: string }) => {
+		if (typeof payload.text === "string") texts.push(payload.text);
+		return [];
+	}) as unknown as HandlerCallback;
+	return { callback, texts };
+}
+
+describe("inferAgentSwitchProfile", () => {
+	it("uses an explicit profile option", () => {
+		expect(inferAgentSwitchProfile("", { profile: "cloud" })).toBe("cloud");
+		expect(inferAgentSwitchProfile("", { agent: "laptop" })).toBe("laptop");
+	});
+
+	it("extracts the label before the agent/runtime noun", () => {
+		expect(inferAgentSwitchProfile("switch to my cloud agent")).toBe("cloud");
+		expect(inferAgentSwitchProfile("use the laptop runtime")).toBe("laptop");
+		expect(inferAgentSwitchProfile("connect to my VPS agent")).toBe("VPS");
+	});
+
+	it("extracts a label after 'to' when a noun is present", () => {
+		expect(inferAgentSwitchProfile("switch to the production backend")).toBe(
+			"production",
+		);
+	});
+
+	it("returns null when no agent/runtime noun is present (defers to MODEL_SWITCH)", () => {
+		// A bare "switch to local" has no agent/runtime noun — the conservative
+		// gate defers it so it doesn't contend with MODEL_SWITCH's local/cloud.
+		expect(inferAgentSwitchProfile("switch back to local")).toBeNull();
+		expect(inferAgentSwitchProfile("what agent am I on?")).toBeNull();
+		expect(inferAgentSwitchProfile("hello")).toBeNull();
+		expect(inferAgentSwitchProfile("")).toBeNull();
+	});
+});
+
+describe("AGENT_SWITCH handler", () => {
+	function action(outcome: AgentSwitchOutcome | Error) {
+		const switchAgent: AgentSwitchFn = vi.fn(async () => {
+			if (outcome instanceof Error) throw outcome;
+			return outcome;
+		});
+		return { action: createAgentSwitchAction({ switchAgent }), switchAgent };
+	}
+
+	it("is OWNER role-gated (repoints the backend)", () => {
+		const { action: a } = action({ ok: true });
+		expect(a.roleGate).toEqual({ minRole: "OWNER" });
+		const profile = a.parameters?.find((p) => p.name === "profile");
+		expect(profile?.required).toBe(true);
+	});
+
+	it("validates only agent-switch phrasings", async () => {
+		const { action: a } = action({ ok: true });
+		expect(await a.validate(runtime, message("switch to my cloud agent"))).toBe(
+			true,
+		);
+		expect(await a.validate(runtime, message("good morning"))).toBe(false);
+	});
+
+	it("confirms a successful switch with the resolved label", async () => {
+		const { action: a, switchAgent } = action({
+			ok: true,
+			profileId: "p-cloud",
+			profileLabel: "My Cloud Agent",
+		});
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to my cloud agent"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(switchAgent).toHaveBeenCalledWith("cloud");
+		expect(result?.success).toBe(true);
+		expect(texts[0]).toMatch(/My Cloud Agent/);
+	});
+
+	it("reports an unknown profile refusal", async () => {
+		const { action: a } = action({ ok: false, reason: "not-found" });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to the ghost agent"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/couldn't find a saved runtime/);
+	});
+
+	it("reports an untrusted-remote refusal with the security reason", async () => {
+		const { action: a } = action({ ok: false, reason: "untrusted-remote" });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to my vps agent"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/isn't a trusted local\/VPN host/);
+	});
+
+	it("reports no connected shell", async () => {
+		const { action: a } = action({ ok: false, reason: "no-shell" });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to my cloud agent"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/No app window is connected/);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/agent-switch.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.ts
@@ -1,0 +1,248 @@
+/**
+ * AGENT_SWITCH action — repoints the app shell to a saved runtime profile
+ * (a local / cloud-dedicated / remote agent) from chat (#12178 WI-6).
+ *
+ * Runtime profiles are client-persisted (localStorage registry,
+ * packages/ui/src/state/agent-profiles.ts), so the server owns no profile
+ * list. The handler POSTs the shared loopback route
+ * `POST /api/runtime/agent-switch`, which broadcasts `shell:switch-agent`; the
+ * connected shell resolves the requested profile (by id or fuzzy label) and
+ * applies it via the canonical `switchRuntimeNonDestructive`, inheriting its
+ * remote-trust gate (an untrusted public URL is refused). The shell reports
+ * the outcome back and this handler narrates it — including the refusal reason
+ * for unknown/untrusted profiles.
+ *
+ * OWNER-gated: this repoints the backend the app talks to (and the bearer token
+ * it sends), so it is not a member-level capability.
+ */
+
+import type {
+	Action,
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "@elizaos/core";
+import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import { readStringOption } from "../params.js";
+
+/** Parsed wire response of POST /api/runtime/agent-switch. */
+export interface AgentSwitchOutcome {
+	ok: boolean;
+	profileId?: string;
+	profileLabel?: string;
+	reason?: string;
+}
+
+export type AgentSwitchFn = (profile: string) => Promise<AgentSwitchOutcome>;
+
+export interface AgentSwitchActionDeps {
+	switchAgent?: AgentSwitchFn;
+}
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+async function defaultSwitchAgent(
+	profile: string,
+): Promise<AgentSwitchOutcome> {
+	const port = resolveServerOnlyPort(process.env);
+	const response = await fetch(
+		`http://127.0.0.1:${port}/api/runtime/agent-switch`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ profile }),
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		},
+	);
+	const body = (await response.json().catch(() => null)) as Record<
+		string,
+		unknown
+	> | null;
+	if (!response.ok) {
+		return {
+			ok: false,
+			reason:
+				typeof body?.error === "string"
+					? body.error
+					: `agent switch returned ${response.status}`,
+		};
+	}
+	return {
+		ok: body?.ok === true,
+		profileId: typeof body?.profileId === "string" ? body.profileId : undefined,
+		profileLabel:
+			typeof body?.profileLabel === "string" ? body.profileLabel : undefined,
+		reason: typeof body?.reason === "string" ? body.reason : undefined,
+	};
+}
+
+const SWITCH_VERB_RE = /\b(switch|use|change|connect|move|go|activate)\b/i;
+const AGENT_NOUN_RE =
+	/\b(agent|runtime|backend|profile|instance|server|node)\b/i;
+
+/**
+ * Extract the target profile from an explicit option or the message. Returns
+ * null when no profile is named — AGENT_SWITCH never picks a profile blindly.
+ */
+export function inferAgentSwitchProfile(
+	text: string,
+	options?: Record<string, unknown>,
+): string | null {
+	const explicit =
+		readStringOption(options, "profile") ??
+		readStringOption(options, "agent") ??
+		readStringOption(options, "target");
+	if (explicit) return explicit;
+
+	const trimmed = text.trim();
+	if (!trimmed) return null;
+	if (!SWITCH_VERB_RE.test(trimmed) || !AGENT_NOUN_RE.test(trimmed))
+		return null;
+
+	// Pull the phrase after the agent/runtime noun: "switch to my cloud agent"
+	// → "cloud"; "use the laptop runtime" → "laptop". The shell resolves this
+	// fuzzy label against the profile registry (id or label).
+	const match =
+		/\b(?:switch|use|change|connect|move|go|activate)\b\s+(?:to\s+|over\s+to\s+)?(?:the\s+|my\s+)?(.+?)\s+(?:agent|runtime|backend|profile|instance|server|node)\b/i.exec(
+			trimmed,
+		);
+	const label = match?.[1]?.trim();
+	if (label && label.length > 0 && label.toLowerCase() !== "another") {
+		return label;
+	}
+	// "switch agent to X" / "switch to the X runtime" fallback: the phrase after
+	// "to".
+	const toMatch = /\bto\s+(?:the\s+|my\s+)?(.+?)\s*$/i.exec(trimmed);
+	const toLabel = toMatch?.[1]
+		?.replace(/\b(agent|runtime|backend|profile|instance|server|node)\b/gi, "")
+		.trim();
+	return toLabel && toLabel.length > 0 ? toLabel : null;
+}
+
+function narrateRefusal(reason: string | undefined, profile: string): string {
+	switch (reason) {
+		case "not-found":
+			return `I couldn't find a saved runtime called "${profile}". Add it in Settings → Runtimes first, or tell me one of your existing agents.`;
+		case "untrusted-remote":
+			return `I won't connect to "${profile}" — its address isn't a trusted local/VPN host, so switching to it could leak your session. Use a loopback, private-network, or tailscale runtime.`;
+		case "no-shell":
+			return "No app window is connected right now, so I can't switch the active agent from here.";
+		default:
+			return `I couldn't switch to "${profile}"${reason ? `: ${reason}` : ""}.`;
+	}
+}
+
+export function createAgentSwitchAction(
+	deps: AgentSwitchActionDeps = {},
+): Action {
+	const switchAgent = deps.switchAgent ?? defaultSwitchAgent;
+
+	return {
+		name: "AGENT_SWITCH",
+		contexts: ["general", "settings", "admin"],
+		contextGate: { anyOf: ["general", "settings", "admin"] },
+		roleGate: { minRole: "OWNER" },
+		similes: [
+			"SWITCH_AGENT",
+			"SWITCH_RUNTIME",
+			"CHANGE_AGENT",
+			"USE_AGENT",
+			"CONNECT_AGENT",
+			"SWITCH_TO_AGENT",
+			"SWITCH_BACKEND",
+			"USE_RUNTIME",
+		],
+		description:
+			"Switch the app to a different saved runtime/agent profile — a local agent, a dedicated Eliza Cloud agent, or a trusted remote (VPS/tailscale) backend. Repoints the live app to that profile without a page reload where allowed. Refuses unknown profiles and untrusted remote addresses.",
+		descriptionCompressed:
+			"agent switch <profile> — repoint the app to a saved runtime profile (local/cloud/remote) by id or label; refuses unknown or untrusted-remote profiles",
+		routingHint:
+			"Requests to change WHICH agent/backend the app talks to -> AGENT_SWITCH: 'switch to my cloud agent', 'use the laptop runtime', 'connect to my VPS agent', 'switch back to local'. This repoints the backend (owner-only); it is NOT model routing (that's MODEL_SWITCH) and NOT view navigation (VIEWS).",
+		suppressPostActionContinuation: true,
+
+		parameters: [
+			{
+				name: "profile",
+				description:
+					"The saved runtime profile to switch to — its id or a fuzzy label (e.g. 'cloud', 'laptop', 'my VPS agent'). Resolved against the app's runtime-profile registry.",
+				required: true,
+				schema: { type: "string" },
+			},
+		],
+
+		validate: async (
+			_runtime: IAgentRuntime,
+			message: Memory,
+		): Promise<boolean> => {
+			return (
+				inferAgentSwitchProfile(message.content.text ?? "", undefined) !== null
+			);
+		},
+
+		handler: async (
+			_runtime: IAgentRuntime,
+			message: Memory,
+			_state?: State,
+			options?: Record<string, unknown>,
+			callback?: HandlerCallback,
+		): Promise<ActionResult> => {
+			const profile = inferAgentSwitchProfile(
+				message.content.text ?? "",
+				options,
+			);
+			if (!profile) {
+				const reply =
+					'Tell me which agent to switch to — e.g. "switch to my cloud agent" or "use the laptop runtime".';
+				await callback?.({ text: reply });
+				return { success: false, text: reply };
+			}
+
+			logger.info(`[plugin-app-control] AGENT_SWITCH profile="${profile}"`);
+
+			try {
+				const outcome = await switchAgent(profile);
+				if (!outcome.ok) {
+					const reply = narrateRefusal(outcome.reason, profile);
+					await callback?.({ text: reply });
+					return {
+						success: false,
+						text: reply,
+						values: { profile, reason: outcome.reason },
+					};
+				}
+				const label = outcome.profileLabel ?? outcome.profileId ?? profile;
+				const reply = `Switched the app to "${label}".`;
+				await callback?.({ text: reply });
+				return {
+					success: true,
+					text: reply,
+					values: {
+						profile,
+						profileId: outcome.profileId,
+						profileLabel: outcome.profileLabel,
+					},
+					data: {
+						profileId: outcome.profileId,
+						profileLabel: outcome.profileLabel,
+					},
+				};
+			} catch (err) {
+				const messageText = err instanceof Error ? err.message : String(err);
+				logger.error(
+					`[plugin-app-control] AGENT_SWITCH failed: ${messageText}`,
+				);
+				const reply = `I couldn't switch to "${profile}": ${messageText}.`;
+				await callback?.({ text: reply });
+				return {
+					success: false,
+					text: reply,
+					values: { profile },
+				};
+			}
+		},
+	};
+}
+
+export const agentSwitchAction: Action = createAgentSwitchAction();

--- a/plugins/plugin-app-control/src/actions/model-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.test.ts
@@ -1,0 +1,214 @@
+// Unit coverage for the MODEL_SWITCH action: intent parsing, sanctioned-model
+// enforcement, and the handler driving a mocked loopback switch client (no
+// network). The route's real HTTP behavior is covered in packages/agent.
+
+import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import { DEFAULT_ELIZA_CLOUD_TEXT_MODEL } from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+	createModelSwitchAction,
+	inferModelSwitchRequest,
+	type ModelSwitchFn,
+	type ModelSwitchOutcome,
+	sanctionedModelError,
+} from "./model-switch.ts";
+
+const runtime = {} as IAgentRuntime;
+
+function message(text: string): Memory {
+	return { content: { text } } as Memory;
+}
+
+function captureCallback(): {
+	callback: HandlerCallback;
+	texts: string[];
+} {
+	const texts: string[] = [];
+	const callback = vi.fn(async (payload: { text?: string }) => {
+		if (typeof payload.text === "string") texts.push(payload.text);
+		return [];
+	}) as unknown as HandlerCallback;
+	return { callback, texts };
+}
+
+describe("inferModelSwitchRequest", () => {
+	it("parses explicit local/cloud options", () => {
+		expect(inferModelSwitchRequest("", { target: "local" })).toEqual({
+			target: "local",
+		});
+		expect(
+			inferModelSwitchRequest("", { target: "cloud", model: "gemma-4-31b" }),
+		).toEqual({ target: "cloud", model: "gemma-4-31b" });
+	});
+
+	it("detects a local switch from natural language", () => {
+		expect(inferModelSwitchRequest("switch to the local model")).toEqual({
+			target: "local",
+		});
+		expect(inferModelSwitchRequest("run inference on-device")).toEqual({
+			target: "local",
+		});
+	});
+
+	it("detects a cloud switch from natural language", () => {
+		expect(inferModelSwitchRequest("use eliza cloud")).toEqual({
+			target: "cloud",
+		});
+		expect(inferModelSwitchRequest("switch to cloud inference")).toEqual({
+			target: "cloud",
+		});
+	});
+
+	it("infers the local target from a named eliza-1 tier", () => {
+		expect(inferModelSwitchRequest("switch to eliza-1-4b")).toEqual({
+			target: "local",
+			model: "eliza-1-4b",
+		});
+	});
+
+	it("returns null when no target is named", () => {
+		expect(inferModelSwitchRequest("what model are you using?")).toBeNull();
+		expect(inferModelSwitchRequest("hello there")).toBeNull();
+		expect(inferModelSwitchRequest("")).toBeNull();
+	});
+
+	it("returns null on an ambiguous both-targets message", () => {
+		expect(
+			inferModelSwitchRequest("switch model between local and cloud"),
+		).toBeNull();
+	});
+});
+
+describe("sanctionedModelError", () => {
+	it("rejects a non-curated local id", () => {
+		expect(sanctionedModelError("local", "llama-3-8b")).toMatch(
+			/sanctioned on-device model/,
+		);
+	});
+	it("accepts a curated local tier", () => {
+		expect(sanctionedModelError("local", "eliza-1-2b")).toBeNull();
+	});
+	it("rejects a non-default cloud id", () => {
+		expect(sanctionedModelError("cloud", "gpt-5")).toMatch(
+			/sanctioned cloud model/,
+		);
+	});
+	it("accepts the default cloud model", () => {
+		expect(
+			sanctionedModelError("cloud", DEFAULT_ELIZA_CLOUD_TEXT_MODEL),
+		).toBeNull();
+	});
+	it("allows an absent model (route resolves the default)", () => {
+		expect(sanctionedModelError("local", undefined)).toBeNull();
+	});
+});
+
+describe("MODEL_SWITCH handler", () => {
+	function action(outcome: ModelSwitchOutcome | Error) {
+		const switchModel: ModelSwitchFn = vi.fn(async () => {
+			if (outcome instanceof Error) throw outcome;
+			return outcome;
+		});
+		return { action: createModelSwitchAction({ switchModel }), switchModel };
+	}
+
+	it("validates only messages that name a switch target", async () => {
+		const { action: a } = action({ ok: true });
+		expect(await a.validate(runtime, message("use the local model"))).toBe(
+			true,
+		);
+		expect(await a.validate(runtime, message("hi"))).toBe(false);
+	});
+
+	it("declares USER role gate and required target param", () => {
+		const { action: a } = action({ ok: true });
+		expect(a.roleGate).toEqual({ minRole: "USER" });
+		const target = a.parameters?.find((p) => p.name === "target");
+		expect(target?.required).toBe(true);
+		expect(target?.schema).toMatchObject({ enum: ["local", "cloud"] });
+	});
+
+	it("narrates a cloud switch", async () => {
+		const { action: a, switchModel } = action({
+			ok: true,
+			target: "cloud",
+			model: DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+			status: "ready",
+		});
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("use eliza cloud"),
+			undefined,
+			{ target: "cloud" },
+			callback,
+		);
+		expect(switchModel).toHaveBeenCalledWith({ target: "cloud" });
+		expect(result?.success).toBe(true);
+		expect(texts[0]).toMatch(/Eliza Cloud/);
+	});
+
+	it("narrates a local download in progress", async () => {
+		const { action: a } = action({
+			ok: true,
+			target: "local",
+			model: "eliza-1-2b",
+			displayName: "Eliza-1 2B",
+			status: "downloading",
+			downloadSizeGb: 1.4,
+		});
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to the local model"),
+			undefined,
+			{ target: "local" },
+			callback,
+		);
+		expect(result?.success).toBe(true);
+		expect(texts[0]).toMatch(/downloading \(1\.4 GB\)/);
+	});
+
+	it("refuses a non-sanctioned local model without calling the route", async () => {
+		const { action: a, switchModel } = action({ ok: true });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("use llama-3-8b locally"),
+			undefined,
+			{ target: "local", model: "llama-3-8b" },
+			callback,
+		);
+		expect(switchModel).not.toHaveBeenCalled();
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/sanctioned on-device model/);
+	});
+
+	it("surfaces a route failure as an unsuccessful result", async () => {
+		const { action: a } = action({ ok: false, error: "no provider" });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("use cloud"),
+			undefined,
+			{ target: "cloud" },
+			callback,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/no provider/);
+	});
+
+	it("surfaces a thrown transport error", async () => {
+		const { action: a } = action(new Error("ECONNREFUSED"));
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to local"),
+			undefined,
+			{ target: "local" },
+			callback,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts[0]).toMatch(/ECONNREFUSED/);
+	});
+});

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -1,0 +1,317 @@
+/**
+ * MODEL_SWITCH action — lets the agent flip its own text inference between
+ * on-device (Eliza-1) and Eliza Cloud from chat (#12178 WI-5).
+ *
+ * The handler POSTs the shared loopback route `POST /api/runtime/model-switch`
+ * (packages/agent/src/api/runtime-switch-routes.ts) — the same implementation
+ * the deterministic `/model local|cloud` command uses — which applies the
+ * switch through the existing local-inference routes and broadcasts
+ * `shell:model-switch` to connected shells. Sanctioned models only: local ids
+ * come from the curated Eliza-1 catalog (`DEFAULT_ELIGIBLE_MODEL_IDS`), cloud
+ * is exactly `DEFAULT_ELIZA_CLOUD_TEXT_MODEL`; both this handler and the route
+ * validate against the same shared constants.
+ */
+
+import type {
+	Action,
+	ActionResult,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "@elizaos/core";
+import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import {
+	DEFAULT_ELIGIBLE_MODEL_IDS,
+	DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+} from "@elizaos/shared";
+import { readStringOption } from "../params.js";
+
+export type ModelSwitchTarget = "local" | "cloud";
+
+/** Parsed wire response of POST /api/runtime/model-switch. */
+export interface ModelSwitchOutcome {
+	ok: boolean;
+	target?: ModelSwitchTarget;
+	model?: string;
+	displayName?: string;
+	status?: "ready" | "loading" | "downloading";
+	downloadSizeGb?: number;
+	error?: string;
+}
+
+export type ModelSwitchFn = (request: {
+	target: ModelSwitchTarget;
+	model?: string;
+}) => Promise<ModelSwitchOutcome>;
+
+export interface ModelSwitchActionDeps {
+	switchModel?: ModelSwitchFn;
+}
+
+const REQUEST_TIMEOUT_MS = 150_000;
+
+async function defaultSwitchModel(request: {
+	target: ModelSwitchTarget;
+	model?: string;
+}): Promise<ModelSwitchOutcome> {
+	const port = resolveServerOnlyPort(process.env);
+	const response = await fetch(
+		`http://127.0.0.1:${port}/api/runtime/model-switch`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(request),
+			// Local activation waits for the model load, which can take a while on
+			// first switch — give the route more headroom than a plain API call.
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		},
+	);
+	const body = (await response.json().catch(() => null)) as Record<
+		string,
+		unknown
+	> | null;
+	if (!response.ok || body?.ok !== true) {
+		return {
+			ok: false,
+			error:
+				typeof body?.error === "string"
+					? body.error
+					: `model switch returned ${response.status}`,
+		};
+	}
+	return {
+		ok: true,
+		target: body.target === "cloud" ? "cloud" : "local",
+		model: typeof body.model === "string" ? body.model : undefined,
+		displayName:
+			typeof body.displayName === "string" ? body.displayName : undefined,
+		status:
+			body.status === "ready" ||
+			body.status === "loading" ||
+			body.status === "downloading"
+				? body.status
+				: undefined,
+		downloadSizeGb:
+			typeof body.downloadSizeGb === "number" ? body.downloadSizeGb : undefined,
+	};
+}
+
+const LOCAL_TARGET_RE = /\b(local(?:ly)?|on[\s-]?device|offline)\b/i;
+const CLOUD_TARGET_RE = /\b(cloud|eliza\s?cloud|hosted)\b/i;
+const SWITCH_VERB_RE = /\b(switch|use|change|move|go|run|swap)\b/i;
+// "eliza cloud" / "on-device" are self-describing inference targets, so they
+// satisfy the noun requirement without the word "model".
+const MODEL_NOUN_RE =
+	/\b(model|inference|llm|eliza[\s-]?1|gemma|eliza\s?cloud|on[\s-]?device)\b/i;
+const MODEL_ID_RE = /\beliza-1-[a-z0-9-]+\b/i;
+
+/**
+ * Deterministic target/model extraction from an explicit option or the
+ * message text. Returns null when the message doesn't name a switch target —
+ * MODEL_SWITCH never guesses a direction.
+ */
+export function inferModelSwitchRequest(
+	text: string,
+	options?: Record<string, unknown>,
+): { target: ModelSwitchTarget; model?: string } | null {
+	const explicitTarget = readStringOption(options, "target")?.toLowerCase();
+	const explicitModel = readStringOption(options, "model") ?? undefined;
+	if (explicitTarget === "local" || explicitTarget === "cloud") {
+		return {
+			target: explicitTarget,
+			...(explicitModel && { model: explicitModel }),
+		};
+	}
+
+	const trimmed = text.trim();
+	if (!trimmed) return null;
+	const model = explicitModel ?? MODEL_ID_RE.exec(trimmed)?.[0]?.toLowerCase();
+
+	// A named Eliza-1 tier implies the local target even without the word
+	// "local" ("switch to eliza-1-4b").
+	const wantsLocal = LOCAL_TARGET_RE.test(trimmed) || Boolean(model);
+	const wantsCloud = CLOUD_TARGET_RE.test(trimmed);
+	if (wantsLocal === wantsCloud) return null; // ambiguous or absent
+	if (!SWITCH_VERB_RE.test(trimmed) || !MODEL_NOUN_RE.test(trimmed))
+		return null;
+
+	return {
+		target: wantsCloud ? "cloud" : "local",
+		...(model ? { model } : {}),
+	};
+}
+
+/**
+ * Pre-flight sanctioned-set check so the agent refuses with a helpful reply
+ * instead of a route 400. The route re-validates at the boundary; both read
+ * the same shared constants.
+ */
+export function sanctionedModelError(
+	target: ModelSwitchTarget,
+	model: string | undefined,
+): string | null {
+	if (!model) return null;
+	if (target === "local" && !DEFAULT_ELIGIBLE_MODEL_IDS.has(model)) {
+		return `"${model}" isn't a sanctioned on-device model. I can run: ${[...DEFAULT_ELIGIBLE_MODEL_IDS].join(", ")}.`;
+	}
+	if (target === "cloud" && model !== DEFAULT_ELIZA_CLOUD_TEXT_MODEL) {
+		return `"${model}" isn't a sanctioned cloud model. Eliza Cloud serves ${DEFAULT_ELIZA_CLOUD_TEXT_MODEL}.`;
+	}
+	return null;
+}
+
+function narrate(outcome: ModelSwitchOutcome): string {
+	if (outcome.target === "cloud") {
+		return `Switched to Eliza Cloud inference (${outcome.model ?? DEFAULT_ELIZA_CLOUD_TEXT_MODEL}).`;
+	}
+	const name = outcome.displayName ?? outcome.model ?? "the local model";
+	if (outcome.status === "downloading") {
+		const size =
+			outcome.downloadSizeGb !== undefined
+				? ` (${outcome.downloadSizeGb} GB)`
+				: "";
+		return `Switching to on-device ${name} — downloading${size}… I'll answer with it as soon as it's ready.`;
+	}
+	if (outcome.status === "loading") {
+		return `Switching to on-device ${name} — loading the model now.`;
+	}
+	return `Switched to on-device ${name}.`;
+}
+
+export function createModelSwitchAction(
+	deps: ModelSwitchActionDeps = {},
+): Action {
+	const switchModel = deps.switchModel ?? defaultSwitchModel;
+
+	return {
+		name: "MODEL_SWITCH",
+		contexts: ["general", "settings"],
+		contextGate: { anyOf: ["general", "settings"] },
+		roleGate: { minRole: "USER" },
+		similes: [
+			"SWITCH_MODEL",
+			"USE_LOCAL_MODEL",
+			"USE_CLOUD_MODEL",
+			"SWITCH_TO_LOCAL",
+			"SWITCH_TO_CLOUD",
+			"SWITCH_TO_ELIZA_CLOUD",
+			"USE_ON_DEVICE_MODEL",
+			"CHANGE_MODEL",
+			"SELECT_MODEL",
+		],
+		description:
+			"Switch the agent's text inference between the on-device Eliza-1 model (local) and Eliza Cloud (cloud). Optionally name a specific sanctioned Eliza-1 tier (e.g. eliza-1-2b, eliza-1-4b) for the local target. Applies immediately — assigns the model, flips inference routing, and starts a download when the local model isn't installed yet.",
+		descriptionCompressed:
+			"model switch local|cloud [eliza-1 tier] — flip text inference between on-device Eliza-1 and Eliza Cloud; downloads the local model when missing",
+		routingHint:
+			"Requests to change WHERE inference runs -> MODEL_SWITCH: 'switch to the local model', 'use cloud inference', 'run on-device', 'switch to eliza cloud', 'use eliza-1-4b'. This changes the live model routing; it is NOT settings navigation (opening the model settings page is VIEWS) and NOT a per-conversation preference.",
+		suppressPostActionContinuation: true,
+
+		parameters: [
+			{
+				name: "target",
+				description:
+					"Where text inference should run: local (on-device Eliza-1) or cloud (Eliza Cloud).",
+				required: true,
+				schema: { type: "string", enum: ["local", "cloud"] },
+			},
+			{
+				name: "model",
+				description:
+					"Optional sanctioned model id. Local: a curated Eliza-1 tier (eliza-1-2b, eliza-1-4b, …). Cloud: the managed default only.",
+				required: false,
+				schema: { type: "string" },
+			},
+		],
+
+		validate: async (
+			_runtime: IAgentRuntime,
+			message: Memory,
+		): Promise<boolean> => {
+			return (
+				inferModelSwitchRequest(message.content.text ?? "", undefined) !== null
+			);
+		},
+
+		handler: async (
+			_runtime: IAgentRuntime,
+			message: Memory,
+			_state?: State,
+			options?: Record<string, unknown>,
+			callback?: HandlerCallback,
+		): Promise<ActionResult> => {
+			const request = inferModelSwitchRequest(
+				message.content.text ?? "",
+				options,
+			);
+			if (!request) {
+				const reply =
+					'Tell me where to run inference — "switch to the local model" or "use Eliza Cloud". You can also name a tier, e.g. "use eliza-1-4b".';
+				await callback?.({ text: reply });
+				return { success: false, text: reply };
+			}
+
+			const refusal = sanctionedModelError(request.target, request.model);
+			if (refusal) {
+				await callback?.({ text: refusal });
+				return {
+					success: false,
+					text: refusal,
+					values: { target: request.target, model: request.model },
+				};
+			}
+
+			logger.info(
+				`[plugin-app-control] MODEL_SWITCH target=${request.target}${request.model ? ` model=${request.model}` : ""}`,
+			);
+
+			try {
+				const outcome = await switchModel(request);
+				if (!outcome.ok) {
+					const reply = `I couldn't switch the model: ${outcome.error ?? "unknown error"}.`;
+					await callback?.({ text: reply });
+					return {
+						success: false,
+						text: reply,
+						values: { target: request.target, model: request.model },
+					};
+				}
+				const reply = narrate(outcome);
+				await callback?.({ text: reply });
+				return {
+					success: true,
+					text: reply,
+					values: {
+						target: outcome.target ?? request.target,
+						model: outcome.model,
+						status: outcome.status,
+					},
+					data: {
+						target: outcome.target ?? request.target,
+						model: outcome.model,
+						displayName: outcome.displayName,
+						status: outcome.status,
+						...(outcome.downloadSizeGb !== undefined
+							? { downloadSizeGb: outcome.downloadSizeGb }
+							: {}),
+					},
+				};
+			} catch (err) {
+				const messageText = err instanceof Error ? err.message : String(err);
+				logger.error(
+					`[plugin-app-control] MODEL_SWITCH failed: ${messageText}`,
+				);
+				const reply = `I couldn't switch the model: ${messageText}.`;
+				await callback?.({ text: reply });
+				return {
+					success: false,
+					text: reply,
+					values: { target: request.target, model: request.model },
+				};
+			}
+		},
+	};
+}
+
+export const modelSwitchAction: Action = createModelSwitchAction();

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -13,8 +13,10 @@
  */
 
 import type { Plugin } from "@elizaos/core";
+import { agentSwitchAction } from "./actions/agent-switch.js";
 import { appAction, createAppAction } from "./actions/app.js";
 import { backgroundAction } from "./actions/background.js";
+import { modelSwitchAction } from "./actions/model-switch.js";
 import {
 	closeAllViewsAction,
 	closeViewAction,
@@ -36,6 +38,14 @@ import { AppWorkerHostService } from "./services/app-worker-host-service.js";
 import { VerificationRoomBridgeService } from "./services/verification-room-bridge.js";
 import { viewNavigationShortcuts } from "./shortcuts.js";
 
+export {
+	agentSwitchAction,
+	type AgentSwitchActionDeps,
+	type AgentSwitchFn,
+	type AgentSwitchOutcome,
+	createAgentSwitchAction,
+	inferAgentSwitchProfile,
+} from "./actions/agent-switch.js";
 export type { AppMode } from "./actions/app.js";
 export type {
 	BackgroundApplyOp,
@@ -51,6 +61,16 @@ export {
 	MATCHER_VIEW_IDS,
 	matchViewCommand,
 } from "./actions/view-command-matcher.js";
+export {
+	createModelSwitchAction,
+	inferModelSwitchRequest,
+	type ModelSwitchActionDeps,
+	type ModelSwitchFn,
+	type ModelSwitchOutcome,
+	modelSwitchAction,
+	type ModelSwitchTarget,
+	sanctionedModelError,
+} from "./actions/model-switch.js";
 export type { ViewsMode } from "./actions/views.js";
 export {
 	closeAllViewsAction,
@@ -130,6 +150,8 @@ export const appControlPlugin: Plugin = {
 		closeViewAction,
 		closeAllViewsAction,
 		backgroundAction,
+		modelSwitchAction,
+		agentSwitchAction,
 	],
 	shortcuts: viewNavigationShortcuts,
 	// Three-stage view-switch cascade:

--- a/plugins/plugin-commands/__tests__/model-switch-command.test.ts
+++ b/plugins/plugin-commands/__tests__/model-switch-command.test.ts
@@ -1,0 +1,162 @@
+// Coverage for `/model local|cloud [id]` routing through the shared
+// runtime-switch loopback route (#12178). The route HTTP is stubbed via a
+// mocked global fetch; a bare `/model <name>` must NOT hit the route (it stays
+// a per-room preference).
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCommand } from "../src/actions";
+import { parseModelSwitchArgs } from "../src/actions/handlers";
+import { initForRuntime } from "../src/registry";
+
+function makeRuntime(): IAgentRuntime {
+	const cache = new Map<string, unknown>();
+	return {
+		agentId: "agent-model",
+		character: { name: "Eliza", settings: {} },
+		actions: [],
+		getSetting: () => null,
+		getCache: async (key: string) => cache.get(key),
+		setCache: async (key: string, value: unknown) => {
+			cache.set(key, value);
+			return true;
+		},
+		deleteCache: async (key: string) => cache.delete(key),
+	} as unknown as IAgentRuntime;
+}
+
+function msg(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000010",
+		entityId: "00000000-0000-0000-0000-0000000000ab",
+		roomId: "room-model",
+		content: { text, source: "client_chat" },
+	} as unknown as Memory;
+}
+
+describe("parseModelSwitchArgs", () => {
+	it("parses local/cloud targets and an optional id", () => {
+		expect(
+			parseModelSwitchArgs({
+				key: "model",
+				canonical: "/model",
+				args: [],
+				rawArgs: "local",
+			}),
+		).toEqual({ target: "local" });
+		expect(
+			parseModelSwitchArgs({
+				key: "model",
+				canonical: "/model",
+				args: [],
+				rawArgs: "local eliza-1-4b",
+			}),
+		).toEqual({ target: "local", model: "eliza-1-4b" });
+		expect(
+			parseModelSwitchArgs({
+				key: "model",
+				canonical: "/model",
+				args: ["cloud"],
+				rawArgs: "",
+			}),
+		).toEqual({ target: "cloud" });
+	});
+
+	it("returns null for a bare model name (per-room preference path)", () => {
+		expect(
+			parseModelSwitchArgs({
+				key: "model",
+				canonical: "/model",
+				args: [],
+				rawArgs: "gpt-5",
+			}),
+		).toBeNull();
+	});
+});
+
+describe("/model local|cloud → shared runtime-switch route", () => {
+	let runtime: IAgentRuntime;
+	beforeEach(() => {
+		initForRuntime("agent-model");
+		runtime = makeRuntime();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("POSTs the runtime-switch route for /model cloud and narrates the reply", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						ok: true,
+						target: "cloud",
+						model: "gemma-4-31b",
+						status: "ready",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model cloud"));
+		expect(r.handled).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain("/api/runtime/model-switch");
+		expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+			target: "cloud",
+		});
+		expect(r.reply).toMatch(/Eliza Cloud/);
+	});
+
+	it("POSTs local with a specific tier and narrates a download", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						ok: true,
+						target: "local",
+						model: "eliza-1-4b",
+						displayName: "Eliza-1 4B",
+						status: "downloading",
+						downloadSizeGb: 2.6,
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model local eliza-1-4b"));
+		expect(r.handled).toBe(true);
+		expect(
+			JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
+		).toEqual({ target: "local", model: "eliza-1-4b" });
+		expect(r.reply).toMatch(/downloading \(2\.6 GB\)/);
+	});
+
+	it("surfaces a route error", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: "no provider" }), {
+					status: 502,
+					headers: { "Content-Type": "application/json" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model local"));
+		expect(r.handled).toBe(true);
+		expect(r.reply).toMatch(/no provider/);
+	});
+
+	it("does NOT hit the route for a bare /model <name> (per-room preference)", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const r = await resolveCommand(runtime, msg("/model claude-opus"));
+		expect(r.handled).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(r.reply).toMatch(/Model set to/);
+	});
+});

--- a/plugins/plugin-commands/src/actions/handlers.ts
+++ b/plugins/plugin-commands/src/actions/handlers.ts
@@ -15,6 +15,7 @@ import type {
 	Memory,
 	UUID,
 } from "@elizaos/core";
+import { resolveServerOnlyPort } from "@elizaos/core";
 import {
 	findCommandByKeyForRuntime,
 	getCommandsByCategoryForRuntime,
@@ -182,6 +183,84 @@ async function runCompactAction(
 	return reply("Conversation compaction completed.");
 }
 
+/**
+ * `/model local|cloud [id]` drives the SAME loopback runtime-switch route the
+ * MODEL_SWITCH action uses (packages/agent/src/api/runtime-switch-routes.ts),
+ * so a slash command and an agent action share one switch implementation. A
+ * bare model name (no local/cloud target) is not a runtime switch — it falls
+ * through to the per-room `/model` preference below.
+ */
+async function runModelSwitchViaRoute(
+	target: "local" | "cloud",
+	model: string | undefined,
+): Promise<CommandResult> {
+	const port = resolveServerOnlyPort(process.env);
+	let response: Response;
+	try {
+		response = await fetch(
+			`http://127.0.0.1:${port}/api/runtime/model-switch`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ target, ...(model ? { model } : {}) }),
+				signal: AbortSignal.timeout(150_000),
+			},
+		);
+	} catch (err) {
+		return reply(
+			`Couldn't switch the model: ${err instanceof Error ? err.message : String(err)}.`,
+		);
+	}
+	const body = (await response.json().catch(() => null)) as Record<
+		string,
+		unknown
+	> | null;
+	if (!response.ok || body?.ok !== true) {
+		return reply(
+			`Couldn't switch the model: ${
+				typeof body?.error === "string"
+					? body.error
+					: `route returned ${response.status}`
+			}.`,
+		);
+	}
+	if (body.target === "cloud") {
+		return reply(`Switched to Eliza Cloud inference (${body.model}).`);
+	}
+	const name =
+		typeof body.displayName === "string"
+			? body.displayName
+			: String(body.model);
+	if (body.status === "downloading") {
+		const size =
+			typeof body.downloadSizeGb === "number"
+				? ` (${body.downloadSizeGb} GB)`
+				: "";
+		return reply(`Switching to on-device ${name} — downloading${size}…`);
+	}
+	if (body.status === "loading") {
+		return reply(`Switching to on-device ${name} — loading now.`);
+	}
+	return reply(`Switched to on-device ${name}.`);
+}
+
+/**
+ * Parse a `/model` argument list into a runtime-switch target. Returns null
+ * when the first token is neither `local` nor `cloud` (a bare model name), so
+ * the caller keeps the per-room preference behavior.
+ */
+export function parseModelSwitchArgs(
+	parsed: ParsedCommand,
+): { target: "local" | "cloud"; model?: string } | null {
+	const tokens = (parsed.rawArgs?.trim() || parsed.args.join(" ").trim())
+		.split(/\s+/)
+		.filter(Boolean);
+	const first = tokens[0]?.toLowerCase();
+	if (first !== "local" && first !== "cloud") return null;
+	const model = tokens[1]?.trim();
+	return { target: first, ...(model ? { model } : {}) };
+}
+
 async function setOptionCommand(
 	runtime: IAgentRuntime,
 	roomId: string,
@@ -281,12 +360,21 @@ export async function runCommand(
 			);
 		}
 
+		case "model": {
+			// `/model local|cloud [id]` is a runtime inference switch shared with
+			// the MODEL_SWITCH action; a bare model name stays a per-room setting.
+			const switchArgs = parseModelSwitchArgs(parsed);
+			if (switchArgs) {
+				return runModelSwitchViaRoute(switchArgs.target, switchArgs.model);
+			}
+			return setOptionCommand(runtime, roomId, parsed, OPTION_COMMANDS.model);
+		}
+
 		case "think":
 		case "verbose":
 		case "reasoning":
 		case "queue":
 		case "elevated":
-		case "model":
 		case "tts":
 			return setOptionCommand(
 				runtime,


### PR DESCRIPTION
## Summary

Phase 3 of #12178 (dossier WI-5 + WI-6): make **model switching** (on-device ⇄ Eliza Cloud) and **agent switching** (repoint to a saved runtime profile) *first-class agent actions*, not just UI toggles — invokable by the agent from chat, by the user via `/model`, and (agent-switch) by natural language.

All three entrypoints share **one** loopback route — no fourth switch path, no third repoint implementation (dossier §H: `switchRuntimeNonDestructive` stays canonical).

```
MODEL_SWITCH action ─┐
/model local|cloud  ─┼─► POST /api/runtime/model-switch ─► existing local-inference routes ─► broadcastWs(shell:model-switch)
AGENT_SWITCH action ─┴─► POST /api/runtime/agent-switch ─► broadcastWs(shell:switch-agent, requestId) ─► shell resolves + switchRuntimeNonDestructive ─► result callback
```

### What changed
- **`plugins/plugin-app-control/src/actions/model-switch.ts`** — `MODEL_SWITCH` (`roleGate: USER`). `parameters: [{target: enum local|cloud}, {model?}]`. Sanctioned-only: local ids validated against `DEFAULT_ELIGIBLE_MODEL_IDS`, cloud against `DEFAULT_ELIZA_CLOUD_TEXT_MODEL`. Narrates the switch in its `ActionResult`.
- **`plugins/plugin-app-control/src/actions/agent-switch.ts`** — `AGENT_SWITCH` (`roleGate: OWNER`, since it repoints the backend + bearer token). `parameters: [{profile}]`. Refuses unknown/untrusted with a reason.
- **`packages/agent/src/api/runtime-switch-routes.ts`** — the one shared route. Model target applies through the **existing** local-inference routes over loopback (assign slot → flip routing preference/policy → activate or start download); cloud flips routing to `elizacloud`. Agent-switch broadcasts + awaits the shell via the same pending-request pattern as views `interact`.
- **`plugins/plugin-commands/src/actions/handlers.ts`** — `/model local|cloud [id]` hits the same route; a **bare** `/model <name>` still sets the per-room preference (unchanged).
- **`packages/ui/src/state/startup-phase-hydrate.ts`** — `onWsEvent("shell:model-switch")` surfaces a notice; `onWsEvent("shell:switch-agent")` resolves the profile and applies `switchRuntimeNonDestructive` (inheriting its remote-trust gate), posting the outcome to the origin's result endpoint.
- **`packages/ui/src/state/agent-profiles.ts`** — `resolveAgentProfileByQuery` (id → exact label → unique substring → unique kind; null on ambiguous/no-match).

Sanctioned-models-only is enforced at **both** boundaries (action pre-flight + route) reading the same shared constants — an untrusted id is refused, never silently routed.

## Testing — real-path suites (all green)

| Suite | Tests | What it drives |
|---|---|---|
| `packages/agent/src/api/runtime-switch-routes.test.ts` | 13 | Real route handler + real HTTP body parse (`Readable`); scripted local-inference loopback. cloud/local-installed/download, sanctioned refusals, 502, agent-switch success/untrusted/timeout/no-shell. |
| `plugins/plugin-app-control/src/actions/model-switch.test.ts` | 18 | Intent parsing, sanctioned enforcement, USER gate, handler narration + failure paths. |
| `plugins/plugin-app-control/src/actions/agent-switch.test.ts` | 10 | Profile parsing, OWNER gate, narration, not-found/untrusted/no-shell refusals. |
| `plugins/plugin-commands/__tests__/model-switch-command.test.ts` | 6 | `/model cloud|local [id]` → route; bare `/model <name>` stays a per-room preference. |
| `packages/ui/src/state/startup-phase-hydrate.switch.test.ts` (new) | 6 | `bindReadyPhase` WS handlers end-to-end w/ **real** `switchRuntimeNonDestructive` + **real** trust gate + real profile registry: untrusted-remote is blocked (no repoint), trusted local applies, not-found reported, model-switch notices. |
| `packages/ui/src/state/agent-profiles.test.ts` | +4 | `resolveAgentProfileByQuery` id/label/substring/kind + ambiguity. |
| `packages/ui/src/state/startup-phase-hydrate.{view-interact,navigate-frame,voice-control}.test.ts` | 23 | Regression: pass with `switch-runtime` newly in the graph + `setActionNotice` dep. |

`typecheck` clean on all four touched packages (`plugin-app-control`, `plugin-commands`, `packages/agent`, `packages/ui` — the lone `packages/ui` error is a pre-existing missing `iwer` devDep in an unrelated spatial e2e fixture). `biome check` clean on all touched files.

## Evidence

| Evidence type | Status |
|---|---|
| Real-path server route / plugin / UI unit + integration tests | ✅ Attached (table above; drives real body-parse, real route dispatch, real trust gate, real profile registry — no stub stands in for the thing under test) |
| Backend `[RuntimeSwitchRoutes]` structured logs | Route logs `[RuntimeSwitchRoutes] Model switch → <target> (<model>, <status>)` / `Agent switch applied|refused (<reason>)` on every call (see `runtime-switch-routes.ts`). |
| Live-LLM trajectory (agent selects MODEL_SWITCH) | See comment below if captured; otherwise `N/A` — requires a booted agent+plugin+route; the sub-agent worktree has no running dev app. Reviewer repro: `bun run dev` → chat "switch to the local model" / "use Eliza Cloud". |
| Frontend video walkthrough + before/after screenshots | `N/A` — no running dev app in this worktree; the first-run/overlay UI shell integration is owned by the sibling #12178 Phase 1-2 PRs. Reviewer repro: `/model cloud` and `/model local` in a dev build, watch the `shell:model-switch` WS frame + action notice. |

## Notes
- No fourth switch path / no third repoint impl (dossier execution-plan rule 2): agent-switch reuses `switchRuntimeNonDestructive`; model-switch reuses the local-inference routes.
- Sibling agents own #12178 Phase 1-2 (first-run/overlay). This PR touches only `startup-phase-hydrate.ts` (WS handlers) + `agent-profiles.ts` on the UI side — no first-run/overlay files.

Part of #12178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
