### PR TITLE
refactor(#12401): declare connector browser-bridge panel in the setup registry

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.helpers.ts
@@ -6,7 +6,6 @@
  */
 
 import type React from "react";
-import { getBootConfig } from "../../config/boot-config";
 import { parseConnectorAccountManagementPanelPluginId } from "./connector-account-options";
 import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 
@@ -17,11 +16,11 @@ export function normalizePluginId(pluginId: string): string {
     .replace(/[^a-z0-9]/g, "");
 }
 
-// ---------------------------------------------------------------------------
-// Connector setup panel registry — allows plugins to register their own
-// setup panels at runtime without modifying the hardcoded switch statement.
-// ---------------------------------------------------------------------------
-
+// Runtime registry of plugin-provided setup panel components, keyed by
+// normalized connector id. Plugins register their own panel here so the setup
+// UI resolves it without any connector-id knowledge in this helper; built-in
+// panels resolve through the separate token registry in
+// connector-setup-panel-registry.ts.
 export const connectorSetupRegistry = new Map<string, React.ComponentType>();
 
 /**
@@ -44,12 +43,6 @@ export function hasConnectorSetupPanel(pluginId: string): boolean {
   // Plugin-registered panels take precedence over the built-in registry.
   if (connectorSetupRegistry.has(normalized)) {
     return true;
-  }
-  if (
-    normalized.includes("lifeopsbrowser") ||
-    normalized.includes("browserbridg")
-  ) {
-    return Boolean(getBootConfig().lifeOpsBrowserSetupPanel);
   }
   return resolveConnectorSetupPanelToken(normalized) !== null;
 }

--- a/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/ConnectorSetupPanel.tsx
@@ -66,14 +66,13 @@ export function ConnectorSetupPanel({ pluginId }: { pluginId: string }) {
   }
 
   // Fall back to the built-in panels resolved from the setup-panel registry.
-  if (
-    normalized.includes("lifeopsbrowser") ||
-    normalized.includes("browserbridg")
-  ) {
-    const BrowserBridgeSetupPanel = getBootConfig().lifeOpsBrowserSetupPanel;
-    return BrowserBridgeSetupPanel ? <BrowserBridgeSetupPanel /> : null;
-  }
   switch (resolveConnectorSetupPanelToken(normalized)) {
+    case "lifeops-browser": {
+      // The registry only yields this token while the host has supplied the
+      // panel (its rule's `available` gate), so the component is present here.
+      const BrowserBridgeSetupPanel = getBootConfig().lifeOpsBrowserSetupPanel;
+      return BrowserBridgeSetupPanel ? <BrowserBridgeSetupPanel /> : null;
+    }
     case "telegram-account":
       return <TelegramAccountConnectorPanel />;
     case "telegram-bot":

--- a/packages/ui/src/components/connectors/connector-mode-registry.test.ts
+++ b/packages/ui/src/components/connectors/connector-mode-registry.test.ts
@@ -4,7 +4,9 @@
  * fully working mode selector. In-memory registry, no runtime.
  */
 
-import { describe, expect, it } from "vitest";
+import type { ComponentType } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { getBootConfig, setBootConfig } from "../../config/boot-config";
 import {
   getConnectorModes,
   getDefaultConnectorModeId,
@@ -15,6 +17,7 @@ import {
   type ConnectorModeDeclaration,
   registerConnectorModes,
 } from "./connector-mode-registry";
+import { resolveConnectorSetupPanelToken } from "./connector-setup-panel-registry";
 
 /**
  * Seam test for #12094 item 1: the connector setup mode list and copy must come
@@ -101,5 +104,46 @@ describe("connector mode registry seam", () => {
     // A connector with no built-in panel and no declared modes stays false.
     expect(hasConnectorSetupPanel("acmechat")).toBe(false);
     expect(getConnectorModes("farcaster", {})).toHaveLength(0);
+  });
+});
+
+/**
+ * The LifeOps browser-bridge panel is host-provided (a boot-config slot), not a
+ * statically bundled panel. Its presence gating must live in the setup-panel
+ * registry — not as a per-connector branch in ConnectorSetupPanel.helpers.ts.
+ * These tests drive the real getBootConfig/setBootConfig path.
+ */
+describe("browser-bridge panel availability gating", () => {
+  const StubBrowserPanel: ComponentType<Record<string, never>> = () => null;
+
+  afterEach(() => {
+    const { lifeOpsBrowserSetupPanel: _drop, ...rest } = getBootConfig();
+    void _drop;
+    setBootConfig(rest);
+  });
+
+  it("hides the browser-bridge panel until the host supplies it", () => {
+    // No host panel: the registry rule's `available` gate blocks the token, so
+    // both id forms report no setup panel.
+    expect(resolveConnectorSetupPanelToken("lifeopsbrowser")).toBeNull();
+    expect(hasConnectorSetupPanel("lifeopsbrowser")).toBe(false);
+    expect(hasConnectorSetupPanel("@elizaos/plugin-browser-bridge")).toBe(
+      false,
+    );
+  });
+
+  it("resolves the browser-bridge token once the host provides the panel", () => {
+    setBootConfig({
+      ...getBootConfig(),
+      lifeOpsBrowserSetupPanel: StubBrowserPanel,
+    });
+
+    // Both the namespaced and short connector ids now resolve to the token,
+    // and the boolean helper agrees — with zero connector-id code in the helper.
+    expect(resolveConnectorSetupPanelToken("lifeopsbrowser")).toBe(
+      "lifeops-browser",
+    );
+    expect(hasConnectorSetupPanel("lifeopsbrowser")).toBe(true);
+    expect(hasConnectorSetupPanel("@elizaos/plugin-browser-bridge")).toBe(true);
   });
 });

--- a/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
+++ b/packages/ui/src/components/connectors/connector-setup-panel-registry.ts
@@ -1,3 +1,5 @@
+import { getBootConfig } from "../../config/boot-config";
+
 /**
  * Registry that resolves a connector setup-plugin id to the token of the
  * built-in setup panel that renders it. This replaces the per-connector-id
@@ -14,6 +16,14 @@
  *    checks that catch namespaced plugin ids such as
  *    `@elizaos/plugin-telegram` → `elizaosplugintelegram`).
  * Rules are evaluated in registration order; the first match wins.
+ *
+ * A rule may carry an optional `available` predicate for panels whose backing
+ * component is supplied at runtime rather than statically bundled (e.g. the
+ * host-provided LifeOps browser-bridge panel). When present, the rule only
+ * matches while the predicate returns true — this is what keeps the boolean
+ * `hasConnectorSetupPanel` gate connector-id-free in the helper: the id → panel
+ * knowledge (including its availability condition) lives entirely in this
+ * registry, not in a per-connector branch in `ConnectorSetupPanel.helpers.ts`.
  */
 export type ConnectorSetupPanelToken =
   | "telegram-account"
@@ -22,7 +32,8 @@ export type ConnectorSetupPanelToken =
   | "signal"
   | "discord-local"
   | "bluebubbles"
-  | "imessage";
+  | "imessage"
+  | "lifeops-browser";
 
 type MatchKind = "exact" | "substring";
 
@@ -30,6 +41,11 @@ interface ConnectorSetupPanelRule {
   token: ConnectorSetupPanelToken;
   needle: string;
   match: MatchKind;
+  /**
+   * Optional gate for runtime-provided panels. When set, the rule only resolves
+   * while it returns true; omitted for statically bundled panels (always on).
+   */
+  available?: () => boolean;
 }
 
 const rules: ConnectorSetupPanelRule[] = [];
@@ -52,7 +68,7 @@ export function resolveConnectorSetupPanelToken(
       rule.match === "exact"
         ? normalizedId === rule.needle
         : normalizedId.includes(rule.needle);
-    if (matched) return rule.token;
+    if (matched && (rule.available?.() ?? true)) return rule.token;
   }
   return null;
 }
@@ -99,4 +115,21 @@ registerConnectorSetupPanelRule({
   token: "imessage",
   needle: "imessage",
   match: "exact",
+});
+
+// The LifeOps browser-bridge panel is a host-provided component (boot-config
+// slot), not a statically bundled one, so its rule only resolves while the host
+// has supplied it. Both namespaced (`lifeopsbrowser`) and short (`browserbridg`)
+// connector ids route to it — matching the ids the previous helper branch tested.
+registerConnectorSetupPanelRule({
+  token: "lifeops-browser",
+  needle: "lifeopsbrowser",
+  match: "substring",
+  available: () => Boolean(getBootConfig().lifeOpsBrowserSetupPanel),
+});
+registerConnectorSetupPanelRule({
+  token: "lifeops-browser",
+  needle: "browserbridg",
+  match: "substring",
+  available: () => Boolean(getBootConfig().lifeOpsBrowserSetupPanel),
 });


### PR DESCRIPTION
Parent: #12094 (item 1). Builds on #12420, which already data-drove the connector **mode** metadata (labels/descriptions/cloud-availability/defaults/setup-plugin-ids) out of the `ConnectorModeSelector.helpers.ts` switch into `connector-mode-registry.ts`, and moved most panel resolution into `connector-setup-panel-registry.ts`.

This PR removes the **last** per-connector branch left in a connectors helper file: the `lifeopsbrowser` / `browserbridg` `.includes()` special-case in `ConnectorSetupPanel.helpers.ts` (`hasConnectorSetupPanel`) and its twin in `ConnectorSetupPanel.tsx`, both hardcoding the host-provided `getBootConfig().lifeOpsBrowserSetupPanel` slot.

## What changed
- **`connector-setup-panel-registry.ts`**: added a `lifeops-browser` token and two substring rules (`lifeopsbrowser`, `browserbridg`) carrying an optional `available` predicate. Runtime-provided panels are now *declared like any other panel*, with their availability condition (`Boolean(getBootConfig().lifeOpsBrowserSetupPanel)`) living in the registry — not in a helper branch. `resolveConnectorSetupPanelToken` only yields a rule's token while its `available` gate passes.
- **`ConnectorSetupPanel.helpers.ts`**: `hasConnectorSetupPanel` now resolves purely through the registry. The per-connector `.includes()` branch and the now-unused `getBootConfig` import are gone. Both helper files (`ConnectorModeSelector.helpers.ts`, `ConnectorSetupPanel.helpers.ts`) contain **no connector-id switch or per-connector map**.
- **`ConnectorSetupPanel.tsx`**: renders the browser panel from the `lifeops-browser` token `case` instead of a leading `.includes()` branch — one source of truth shared with the boolean helper.

## Done when — checklist
- [x] `ConnectorModeSelector.helpers.ts` and `ConnectorSetupPanel.helpers.ts` contain no connector-id switch or per-connector mode maps. (`grep -nEi 'switch|case \"|\.includes\(|discord|telegram|whatsapp|imessage|signal|twitter|slack|browser|lifeops' <both files>` → no matches.)
- [x] A connector absent from UI source still gets a functioning mode selector and setup panel from declared metadata — covered by the existing `acmechat` registry seam test plus the new browser-bridge availability tests.

## Verification (scoped — shared-node_modules worktree, per repo env notes)
- `bunx vitest run packages/ui/src/components/connectors` → **38 passed**, including 2 new cases in `connector-mode-registry.test.ts` that drive the **real** `getBootConfig`/`setBootConfig` path: the browser-bridge token/`hasConnectorSetupPanel` returns false until the host supplies the panel, then resolves to `lifeops-browser` for both the namespaced (`@elizaos/plugin-browser-bridge`) and short id forms.
- `biome check` on all 4 touched files → clean.
- `tsc --noEmit -p packages/ui` → **zero errors on the touched files**. (The other errors tsc prints are the pre-existing `@types/react` duplication skew inherent to the shared-node_modules worktree topology — present on untouched files like `button.tsx`/`spinner.tsx` — and are unrelated to this change; full `bun run verify` is deferred to CI per the worktree env notes.)

`audit:app` for connector views: N/A — no visual/render change. This is a pure resolution-path refactor; the browser-bridge panel is dormant (no host currently sets `lifeOpsBrowserSetupPanel`), and all other panels resolve to the identical components as before (asserted by the unchanged registry tests).

Closes #12401

🤖 Generated with [Claude Code](https://claude.com/claude-code)