### PR TITLE
feat(ui): opaque full-screen onboarding + unlocked composer (#12178 Phase 2)

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -791,14 +791,19 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   await expect(page.getByTestId(RUNTIME_CHOICE("remote"))).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
 
-  // Onboarding gating: the chat is NON-INTERACTIVE except the choice widgets.
-  // The composer is locked (disabled textarea + "choose" placeholder) and the
-  // pinned-open sheet is non-dismissable — Escape must NOT collapse it.
+  // Onboarding surface (#12178): the composer is UNLOCKED (typed text is
+  // answered by the in-chat conductor, never the server) with an inviting
+  // placeholder, the backdrop is OPAQUE so the launcher/home is hidden, and the
+  // pinned-open sheet is still non-dismissable — Escape must NOT collapse it.
   const composer = page.getByTestId("chat-composer-textarea");
-  await expect(composer).toBeDisabled();
+  await expect(composer).toBeEnabled();
   await expect(composer).toHaveAttribute(
     "placeholder",
-    "Pick an option to continue",
+    "Ask me anything — or pick an option",
+  );
+  await expect(page.getByTestId("chat-first-run-backdrop")).toHaveAttribute(
+    "data-first-run-opaque",
+    "true",
   );
   await expect(chatOverlay).toHaveAttribute("data-open", "true");
   await page.keyboard.press("Escape");

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 
 // First-run onboarding gating for the floating chat overlay (`firstRunOpen`):
-// the sheet opens pinned at FULL, every collapse path (Escape, outside tap,
-// grabber pull-down/close) is a no-op, the composer (text/attach/voice/send) is
-// locked while the transcript's CHOICE widgets stay interactive, and the sheet
-// auto-collapses exactly once on the completion (falling) edge.
+// the sheet opens pinned at FULL with an OPAQUE backdrop, every collapse path
+// (Escape, outside tap, grabber pull-down/close) is a no-op, the composer TEXT
+// + SEND are UNLOCKED (#12178 — typed text is answered by the in-chat conductor
+// and never reaches the server) while attach + mic stay disabled, the CHOICE
+// widgets stay interactive, and the sheet auto-collapses (with the backdrop
+// fading to the normal scrim) exactly once on the completion (falling) edge.
 
 import {
   act,
@@ -125,14 +127,15 @@ describe("ContinuousChatOverlay first-run gating", () => {
     expect(screen.getByTestId("chat-thread")).toBeTruthy();
   });
 
-  it("locks the composer during onboarding: disabled textarea with a choice placeholder, attach + mic inert", () => {
+  it("unlocks the composer text during onboarding with an inviting placeholder; attach + mic stay inert", () => {
     const controller = makeController();
     render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
 
     const input = screen.getByLabelText("message") as HTMLTextAreaElement;
-    expect(input.disabled).toBe(true);
-    expect(input.placeholder).toBe("Pick an option to continue");
+    expect(input.disabled).toBe(false);
+    expect(input.placeholder).toBe("Ask me anything — or pick an option");
 
+    // Attach + mic have no agent to serve them yet — still inert (pre-runtime).
     const attach = screen.getByTestId("chat-composer-attach");
     expect(attach.getAttribute("aria-disabled")).toBe("true");
 
@@ -145,12 +148,13 @@ describe("ContinuousChatOverlay first-run gating", () => {
     expect(controller.toggleHandsFree).not.toHaveBeenCalled();
   });
 
-  it("keeps the send control disabled during onboarding even when a prefill lands a draft", () => {
+  it("routes composer free text to the in-chat conductor during onboarding — send stays live but the server is never reached", () => {
+    const sendActionMessage = seedAppStoreWithActionSpy();
     const controller = makeController();
     render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
 
-    // CHAT_PREFILL_EVENT is a real non-keyboard draft entry point; it must not
-    // become a send path around the disabled textarea.
+    // CHAT_PREFILL_EVENT is a real non-keyboard draft entry point; the composer
+    // is unlocked now, so it lands a draft and the send control goes live.
     act(() => {
       window.dispatchEvent(
         new CustomEvent(CHAT_PREFILL_EVENT, {
@@ -160,9 +164,57 @@ describe("ContinuousChatOverlay first-run gating", () => {
     });
 
     const send = screen.getByTestId("chat-composer-action");
-    expect(send.getAttribute("aria-disabled")).toBe("true");
+    expect(send.getAttribute("aria-disabled")).not.toBe("true");
     fireEvent.click(send);
+    // The typed text goes to the conductor via the shared action funnel — the
+    // HARD rule: nothing reaches the server pre-completion.
     expect(controller.send).not.toHaveBeenCalled();
+    expect(sendActionMessage).toHaveBeenCalledWith("free text mid-onboarding");
+  });
+
+  it("answers Enter-typed free text through the conductor funnel, never controller.send", () => {
+    const sendActionMessage = seedAppStoreWithActionSpy();
+    const controller = makeController();
+    render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
+
+    const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "will this work yet?" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(sendActionMessage).toHaveBeenCalledWith("will this work yet?");
+    expect(controller.send).not.toHaveBeenCalled();
+    // The composer clears after the conductor consumes the turn.
+    expect(input.value).toBe("");
+  });
+
+  it("paints an OPAQUE bg-bg backdrop while onboarding is open (no launcher/home shows through)", () => {
+    render(<ContinuousChatOverlay controller={makeController()} firstRunOpen />);
+    const backdrop = screen.getByTestId("chat-first-run-backdrop");
+    expect(backdrop.getAttribute("data-first-run-opaque")).toBe("true");
+    expect(backdrop.className).toContain("bg-bg");
+  });
+
+  it("drops the opaque backdrop off its opaque state on the completion edge (revealing the launcher)", () => {
+    const controller = makeController();
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={controller} firstRunOpen />,
+    );
+    expect(
+      screen
+        .getByTestId("chat-first-run-backdrop")
+        .getAttribute("data-first-run-opaque"),
+    ).toBe("true");
+
+    // Onboarding completes: the opaque layer fades to the normal scrim (or has
+    // already unmounted under reduced-motion) — either way it is no longer the
+    // full-opacity launcher-hiding layer.
+    rerender(
+      <ContinuousChatOverlay controller={controller} firstRunOpen={false} />,
+    );
+    const after = screen.queryByTestId("chat-first-run-backdrop");
+    expect(after?.getAttribute("data-first-run-opaque") ?? "false").not.toBe(
+      "true",
+    );
   });
 
   it("opens pinned at FULL and ignores Escape while onboarding is active", () => {
@@ -223,9 +275,8 @@ describe("ContinuousChatOverlay first-run gating", () => {
   });
 
   it("ignores tutorial chat-control events (rest/reset/prefill) while onboarding is active", () => {
-    render(
-      <ContinuousChatOverlay controller={makeController()} firstRunOpen />,
-    );
+    const controller = makeController();
+    render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
     const sheet = screen.getByTestId("chat-sheet");
     expect(sheet.getAttribute("data-detent")).toBe("full");
 
@@ -242,9 +293,9 @@ describe("ContinuousChatOverlay first-run gating", () => {
     }
     expect(sheet.getAttribute("data-variant")).toBe("open");
     expect(sheet.getAttribute("data-detent")).toBe("full");
-    // The composer stays locked (prefill did not open a send path).
-    const input = screen.getByLabelText("message") as HTMLTextAreaElement;
-    expect(input.disabled).toBe(true);
+    // The composer is unlocked now (#12178), but a stray prefill only lands a
+    // draft — it never auto-sends, so nothing reaches the server.
+    expect(controller.send).not.toHaveBeenCalled();
   });
 
   it("keeps the transcript CHOICE widgets interactive while the composer is locked", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -60,6 +60,7 @@ import {
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
+import { useAppSelectorShallow } from "../../state";
 import {
   clearChatDraft,
   readChatDraft,
@@ -1657,12 +1658,15 @@ export function ContinuousChatOverlay({
   slash?: SlashCommandController;
   /**
    * True while in-chat first-run onboarding is active (`firstRunComplete ===
-   * false` upstream). The overlay opens to FULL and LOCKS there: every
-   * collapse path (Escape, outside tap, grabber pull-down/close, header
-   * launcher) is a no-op and the composer (text, attach, voice, send) is
-   * disabled, so the seeded choice/OAuth widgets are the only input. On the
-   * falling edge — onboarding just completed — the sheet auto-collapses to the
-   * input bar, revealing the home screen.
+   * false` upstream). The overlay opens to FULL and pins there: every collapse
+   * path (Escape, outside tap, grabber pull-down/close, header launcher) is a
+   * no-op, and the backdrop is OPAQUE (`bg-bg`) so the launcher/home behind is
+   * hidden. The composer TEXT + SEND are unlocked (#12178) — typed text is
+   * answered locally by the in-chat conductor and never reaches the server —
+   * while attach + mic stay disabled (no agent to take media yet); the seeded
+   * choice/OAuth widgets remain the primary input. On the falling edge —
+   * onboarding just completed — the sheet auto-collapses to the input bar and
+   * the opaque backdrop fades to the normal scrim, revealing the home screen.
    */
   firstRunOpen?: boolean;
 }): React.JSX.Element {
@@ -1698,6 +1702,14 @@ export function ContinuousChatOverlay({
   // True once the server has reported no LLM/model provider is configured (a
   // `no_provider` assistant turn). Defaulted for minimal mock controllers.
   const noProviderConfigured = controller.noProviderConfigured ?? false;
+  // The shared action funnel — the SAME seam the transcript's CHOICE widgets
+  // use. During onboarding the unlocked composer routes free text through it so
+  // it reaches the in-chat conductor (and never the server); post-onboarding it
+  // is unused here (the composer sends via `controller.send`). In stories/tests
+  // with no AppContext the store returns an inert no-op.
+  const { sendActionMessage } = useAppSelectorShallow((s) => ({
+    sendActionMessage: s.sendActionMessage,
+  }));
   // Defensive default so a minimal mock controller (stories/tests) that predates
   // the swipe-nav surface still renders without crashing.
   const conversationNav = controller.conversationNav ?? EMPTY_CONVERSATION_NAV;
@@ -2411,11 +2423,24 @@ export function ContinuousChatOverlay({
     (text: string, images: ImageAttachment[] = []) => {
       const trimmed = text.trim();
       // An image-only turn is valid; only bail when there's nothing to send.
-      if ((!trimmed && images.length === 0) || !canSend) return;
-      // During onboarding the transcript is choice-driven: free text never
-      // reaches the server. The composer controls are disabled too — this
-      // guards the event-driven entry points (prefill, dictation, slash).
-      if (firstRunOpen) return;
+      if (!trimmed && images.length === 0) return;
+      // During onboarding the composer is unlocked (#12178) but free text is
+      // answered locally by the in-chat conductor and NEVER reaches the server.
+      // Route it through the shared action funnel (classify → "conductor" →
+      // conductor text handler) — `controller.send` is never called here, so
+      // "no server send pre-completion" holds. Attach is disabled during
+      // onboarding, so any images are dropped (text-only echo).
+      if (firstRunOpen) {
+        if (trimmed) void sendActionMessage(trimmed);
+        setDraft("");
+        setSlashDismissed(false);
+        setPendingImages([]);
+        setImageError(null);
+        inputRef.current?.focus();
+        return;
+      }
+      // Post-onboarding: a stopped agent can't take a turn.
+      if (!canSend) return;
       // Successful submit: drop the persisted draft for this conversation NOW
       // (not just via the debounced persist of the now-empty draft) so a reload
       // in the debounce window can't restore an already-sent draft.
@@ -2462,7 +2487,7 @@ export function ContinuousChatOverlay({
       detentHaptic();
       inputRef.current?.focus();
     },
-    [canSend, firstRunOpen, send, viewChatBinding],
+    [canSend, firstRunOpen, sendActionMessage, send, viewChatBinding],
   );
 
   // Tapping a suggestion sends it immediately (same path as submit), so the
@@ -3151,6 +3176,26 @@ export function ContinuousChatOverlay({
     if (was) goToDetent("collapsed");
   }, [firstRunOpen, goToDetent]);
 
+  // First-run opaque backdrop (#12178). While onboarding pins the sheet FULL,
+  // the backdrop is an OPAQUE `bg-bg` layer that hides the launcher/home behind
+  // the chat — the normal translucent gradient scrim would let them show
+  // through. On the falling edge (onboarding just completed) it fades opaque →
+  // transparent over ~400ms in step with the one-shot auto-collapse above,
+  // revealing home/launcher underneath (kept mounted, warm); reduced-motion
+  // cuts straight to hidden. `off` unmounts the layer for ordinary sessions.
+  const [firstRunBackdrop, setFirstRunBackdrop] = React.useState<
+    "opaque" | "revealing" | "off"
+  >(firstRunOpen ? "opaque" : "off");
+  React.useEffect(() => {
+    if (firstRunOpen) {
+      setFirstRunBackdrop("opaque");
+      return;
+    }
+    setFirstRunBackdrop((prev) =>
+      prev === "opaque" ? (reduce ? "off" : "revealing") : prev,
+    );
+  }, [firstRunOpen, reduce]);
+
   // Onboarding grows from the BOTTOM: size the sheet to its content (capped at
   // full) via the freeH rest-height seam, so the greeting + choice widget sit
   // just above the composer instead of floating under a tall empty panel. Drags
@@ -3611,6 +3656,13 @@ export function ContinuousChatOverlay({
   );
 
   const submit = React.useCallback(() => {
+    // Onboarding: skip slash/shortcut resolution entirely — every submit is
+    // answered by the in-chat conductor, so nothing runs a command or reaches
+    // the server (submitText routes free text to the conductor).
+    if (firstRunOpen) {
+      submitText(draft, pendingImages);
+      return;
+    }
     const shortcut =
       pendingImages.length === 0
         ? resolveClientShortcutExecution(
@@ -3632,7 +3684,7 @@ export function ContinuousChatOverlay({
       return;
     }
     submitText(draft, pendingImages);
-  }, [draft, pendingImages, runExecution, slash, submitText]);
+  }, [draft, pendingImages, firstRunOpen, runExecution, slash, submitText]);
 
   const pickSlashItem = React.useCallback(
     (index: number) => {
@@ -4265,6 +4317,35 @@ export function ContinuousChatOverlay({
           pointerEvents: "none",
         }}
       />
+
+      {/* First-run opaque backdrop (#12178): while onboarding is open this
+          OPAQUE `bg-bg` layer sits ABOVE the gradient scrim and BELOW the glass
+          panel, so no launcher/home pixel shows through — including behind the
+          translucent panel glass. On completion it fades to transparent (~400ms)
+          in step with the one-shot collapse, revealing the launcher warm
+          underneath; reduced-motion cuts. Pointer-transparent like the scrim. */}
+      {firstRunBackdrop !== "off" ? (
+        <motion.div
+          aria-hidden="true"
+          data-testid="chat-first-run-backdrop"
+          data-first-run-opaque={
+            firstRunBackdrop === "opaque" ? "true" : "false"
+          }
+          className="fixed inset-0 bg-bg"
+          initial={false}
+          animate={{ opacity: firstRunBackdrop === "opaque" ? 1 : 0 }}
+          transition={{
+            duration: firstRunBackdrop === "revealing" ? 0.4 : 0,
+            ease: "easeInOut",
+          }}
+          onAnimationComplete={() => {
+            setFirstRunBackdrop((prev) =>
+              prev === "revealing" ? "off" : prev,
+            );
+          }}
+          style={{ pointerEvents: "none" }}
+        />
+      ) : null}
 
       {/* No live interim transcript is shown above the composer while
           listening — the spoken words land as the sent message when the turn
@@ -4989,14 +5070,14 @@ export function ContinuousChatOverlay({
                     collapse();
                   }
                 }}
-                // During onboarding the transcript's choice widgets are the
-                // only input: typing is disabled until first-run completes.
+                // The composer is unlocked during onboarding (#12178): typing is
+                // always allowed. Free text is answered locally by the in-chat
+                // conductor and never reaches the server (submitText routes it).
                 // (This surface's strings are plain literals by design — see
                 // the imageError note above.)
-                disabled={firstRunOpen}
                 placeholder={
                   firstRunOpen
-                    ? "Pick an option to continue"
+                    ? "Ask me anything — or pick an option"
                     : noProviderConfigured
                       ? "Connect a model provider in Settings to chat"
                       : booting
@@ -5014,10 +5095,9 @@ export function ContinuousChatOverlay({
                 // and only when a slash catalog is wired in — a plain message
                 // box otherwise.
                 {...comboboxAria}
-                // During onboarding the composer is frozen (choice widgets are
-                // the only input), so brighten the placeholder from the resting
-                // 45% to 70% — a directive hint the user can actually read,
-                // rather than a greyed-out box that reads as dead.
+                // During onboarding the placeholder is a directive hint ("Ask me
+                // anything — or pick an option"), so brighten it from the resting
+                // 45% to 70% so it reads clearly beside the seeded choices.
                 className={`max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-white/[0.92] outline-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
                   firstRunOpen
                     ? "placeholder:text-white/70"
@@ -5071,7 +5151,11 @@ export function ContinuousChatOverlay({
                             ? "send another"
                             : "send"
                       }
-                      disabled={!canSend || firstRunOpen}
+                      // During onboarding the send button stays live regardless
+                      // of agent readiness — a typed message reaches the in-chat
+                      // conductor, not the (absent) agent. Post-onboarding a
+                      // stopped agent disables it as before.
+                      disabled={!firstRunOpen && !canSend}
                       // Keep focus in the textarea on tap: without this the
                       // button steals focus, the textarea blurs, the keyboard
                       // retracts and the composer relayouts between pointerdown

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -2005,8 +2005,14 @@ try {
     assert(
       (await p
         .getByTestId("chat-composer-textarea")
-        .getAttribute("placeholder")) === "Pick an option to continue",
-      "ONBOARDING: composer placeholder is 'Pick an option to continue'",
+        .getAttribute("placeholder")) === "Ask me anything — or pick an option",
+      "ONBOARDING: composer placeholder invites typing (#12178 unlock)",
+    );
+    assert(
+      (await p
+        .getByTestId("chat-composer-textarea")
+        .isEnabled()),
+      "ONBOARDING: composer textarea is unlocked (#12178)",
     );
     await snap(p, "state-onboarding-bottom-anchored");
     await p.close();

--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -22,25 +22,38 @@ choices and should keep negative assertions for deleted surfaces such as
 Current end-to-end evidence for issue #10709 lives in
 `.github/issue-evidence/10709-onboarding-chat/`.
 
-## The onboarding lock (#9952 follow-up)
+## The onboarding surface (#9952 → relaxed by #12178)
 
 While first-run is pending, the shell passes `firstRunOpen={firstRunComplete
 === false}` to `ContinuousChatOverlay` (`App.tsx`). `firstRunOpen` turns the
-overlay into a **modal onboarding surface** — the chat is the first painted
-surface, it is non-interactive except for the seeded choices, and it cannot be
-dismissed until onboarding completes. The contract, enforced in
+overlay into a **full-screen onboarding surface** — the chat is the first
+painted surface with an opaque backdrop, and it cannot be dismissed until
+onboarding completes. #9952 shipped this as a hard *lock* (composer disabled,
+free text dropped); **#12178 deliberately reverses the lock**: the composer is
+unlocked and typing is answered in-chat, while the "no server send
+pre-completion" property is preserved. The contract, enforced in
 `ContinuousChatOverlay.tsx` and covered by `ContinuousChatOverlay.firstrun.test.tsx`:
 
 - **Opens pinned at FULL.** Initial detent is `full` when `firstRunOpen`; a
   falling-edge-guarded effect re-pins to FULL on every change while
   `firstRunOpen` is true, so nothing can step it down.
-- **Composer is locked.** The textarea is `disabled` with the placeholder
-  "Choose an option to continue"; attach, mic/push-to-talk, and send are all
-  disabled. `submitText` hard-returns while `firstRunOpen`, closing the
-  non-keyboard side doors (chat-prefill event, dictation, slash commands). The
-  `AppContext` `sendActionMessage` backstop additionally drops any non
-  `__first_run__:` value while first-run is incomplete — nothing reaches the
-  server before a runtime exists.
+- **Opaque backdrop (#12178).** While `firstRunOpen` the backdrop is an opaque
+  `bg-bg` layer (`data-testid="chat-first-run-backdrop"`,
+  `data-first-run-opaque="true"`) stacked above the translucent gradient scrim
+  and below the glass panel, so no launcher/home pixel shows through — including
+  behind the panel glass. It matches the shell's `app-opaque-background` idiom
+  (token, not hardcoded black). The launcher stays mounted behind it, warm for
+  the reveal.
+- **Composer is UNLOCKED (#12178).** The textarea and send are live with the
+  placeholder "Ask me anything — or pick an option"; attach and mic/push-to-talk
+  stay disabled (no agent to serve media yet). Typed text is answered by the
+  conductor's local echo persona, never forwarded to the server: `submitText`
+  routes it through the shared `sendActionMessage` funnel, where
+  `classifyActionMessage` returns `"conductor"` and the value is delivered via
+  `tryHandleFirstRunText` (the `"conductor"` branch never calls the real send).
+  `submit` skips slash/shortcut resolution while `firstRunOpen`, so no command
+  runs and nothing reaches the server before a runtime exists. The `__first_run__:`
+  prefix is still reserved unconditionally.
 - **Undismissable.** Every collapse path is a no-op while `firstRunOpen`:
   `collapse()` (the single funnel for Escape on document/thread/composer,
   outside-tap, and the grabber close/tap), the live drag (`onDragOffset`),
@@ -51,15 +64,18 @@ dismissed until onboarding completes. The contract, enforced in
   a stray/adversarial event cannot collapse the pinned sheet).
 - **Auto-collapses once on completion.** A one-shot falling-edge (`firstRunOpen`
   true → false, tracked by `wasFirstRunOpenRef`) collapses the sheet to the
-  input bar, revealing the home screen. An ordinary session (onboarding never
-  active) never triggers this collapse, and the collapse gate is released so
+  input bar, and the opaque backdrop fades to the normal scrim over ~400ms in
+  step with the collapse (cut under `prefers-reduced-motion`), revealing the
+  home screen underneath. An ordinary session (onboarding never active) never
+  triggers this collapse, and the collapse gate is released so
   Escape/outside-tap/etc. work normally afterward.
 
 The desktop `?shellMode=chat-overlay` shell mounts the (headless,
 `firstRunComplete`-gated) conductor too, so a fresh chat-first desktop install
 seeds the same in-chat onboarding; once first-run completes the mount is a
-no-op (`App.chat-overlay-first-run.test.tsx`). Only the transcript's CHOICE
-widgets and any OAuth/secret blocks stay interactive during onboarding.
+no-op (`App.chat-overlay-first-run.test.tsx`). The transcript's CHOICE widgets,
+any OAuth/secret blocks, and the unlocked composer are the interactive surfaces
+during onboarding.
 
 ## Confused-user guards (conductor + send funnel)
 

--- a/packages/ui/src/first-run/README.md
+++ b/packages/ui/src/first-run/README.md
@@ -2,20 +2,30 @@
 
 | File | What it does |
 |------|--------------|
-| `use-first-run-conductor.ts` | Headless in-chat conductor that seeds first-run chat turns and routes `__first_run__:` choices. |
+| `use-first-run-conductor.ts` | Headless in-chat conductor that seeds first-run chat turns, routes `__first_run__:` choices, and answers typed free text with a local echo persona. |
+| `first-run-action-channel.ts` | The seam the chat send funnel consults: `__first_run__:` picks and (during onboarding) free text route to the conductor, never the server. |
 | `first-run-finish.ts` | Single headless finish use case: runtime startup, cloud/remote binding, and exactly-once `/api/first-run` persistence. |
 | `first-run.ts` | Deterministic first-run state helpers and submit payload builder. |
-| `setup-steps.ts` | Internal setup cursor for state-side completion callbacks. |
 | `reload-into-first-run-runtime.ts` | Runtime-switch URL and storage reset helper used by Settings. |
 | `deep-link-handler.ts` | Mobile deep-link adapter for selecting first-run runtime targets. |
 | `runtime-target.ts` | Persisted runtime identity (local / remote / elizacloud / elizacloud-hybrid) used across the shell and mobile runtime. |
 | `mobile-runtime-mode.ts` | Mobile-specific runtime mode persistence tied to the server target. |
 
-## The onboarding lock
+## The onboarding surface (#12178)
 
-While first-run is pending the floating chat is a modal onboarding surface:
-pinned FULL, composer locked ("Choose an option to continue"), every collapse
-path a no-op, and a one-shot auto-collapse on completion. The full contract (and
-which seam enforces each guarantee) is documented in
+While first-run is pending the floating chat is a full-screen onboarding
+surface: pinned FULL with an **opaque `bg-bg` backdrop** that hides the
+launcher/home behind it, every collapse path a no-op, and a one-shot
+auto-collapse — with the backdrop fading to the normal scrim — on completion.
+
+The composer is **unlocked** (#12178, a deliberate reversal of the #9952
+onboarding lock): the user can type freely with the placeholder "Ask me anything
+— or pick an option". Typed text is answered by the conductor's local echo
+persona (a friendly not-ready line that varies by flow position) and **never
+reaches the server pre-completion** — the AppContext send funnel enforces that
+via `classifyActionMessage` → `"conductor"` → `tryHandleFirstRunText`. Attach and
+mic stay disabled (no agent to serve media yet); the seeded CHOICE/OAuth widgets
+remain the primary input. The full contract (and which seam enforces each
+guarantee) is documented in
 [`IN_CHAT_ONBOARDING_DESIGN.md`](./IN_CHAT_ONBOARDING_DESIGN.md) and covered by
 `../components/shell/ContinuousChatOverlay.firstrun.test.tsx`.

--- a/packages/ui/src/first-run/first-run-action-channel.test.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.test.ts
@@ -3,22 +3,27 @@ import {
   classifyActionMessage,
   FIRST_RUN_ACTION_PREFIX,
   setFirstRunActionHandler,
+  setFirstRunTextHandler,
   tryHandleFirstRunAction,
+  tryHandleFirstRunText,
 } from "./first-run-action-channel";
 
 /**
  * The action channel is the seam that lets the chat's single send funnel
- * short-circuit first-run-scoped choice picks to the headless onboarding
- * conductor. Its load-bearing invariants: a first-run choice value is ONLY
- * dispatched to a conductor while one is active, a non-prefixed value is never
- * intercepted, and — via `classifyActionMessage` — a reserved-prefix value is
+ * short-circuit first-run-scoped choice picks AND (since #12178) free text to
+ * the headless onboarding conductor. Its load-bearing invariants: a first-run
+ * choice value is ONLY dispatched to a conductor while one is active, a
+ * non-prefixed value is never intercepted by the ACTION handler, free text is
+ * offered to the TEXT handler while onboarding is open (and never forwarded to
+ * the server), and — via `classifyActionMessage` — a reserved-prefix value is
  * NEVER forwarded to the server as a chat message, even after onboarding
  * finished and the handler is gone (leftover transcript widgets stay inert).
  */
 
 afterEach(() => {
-  // Module-scoped handler — reset so cases don't bleed into each other.
+  // Module-scoped handlers — reset so cases don't bleed into each other.
   setFirstRunActionHandler(null);
+  setFirstRunTextHandler(null);
 });
 
 describe("first-run action channel", () => {
@@ -78,8 +83,30 @@ describe("classifyActionMessage (the send funnel's routing contract)", () => {
     expect(classifyActionMessage(value, true)).toBe("first-run");
   });
 
-  it("drops free text while onboarding is active and sends it afterwards", () => {
-    expect(classifyActionMessage("hello", false)).toBe("dropped");
+  it("routes free text to the conductor while onboarding is active and sends it afterwards", () => {
+    expect(classifyActionMessage("hello", false)).toBe("conductor");
     expect(classifyActionMessage("hello", true)).toBe("send");
+  });
+});
+
+describe("free-text handler (the #12178 composer-unlock seam)", () => {
+  it("does not consume text when no conductor is registered", () => {
+    expect(tryHandleFirstRunText("will this work yet?")).toBe(false);
+  });
+
+  it("offers free text to the active conductor's text handler", () => {
+    const textHandler = vi.fn(() => true);
+    setFirstRunTextHandler(textHandler);
+    expect(tryHandleFirstRunText("will this work yet?")).toBe(true);
+    expect(textHandler).toHaveBeenCalledWith("will this work yet?");
+  });
+
+  it("stops consuming once the conductor clears its text handler (no leak after finish)", () => {
+    const textHandler = vi.fn(() => true);
+    setFirstRunTextHandler(textHandler);
+    expect(tryHandleFirstRunText("hi")).toBe(true);
+    setFirstRunTextHandler(null);
+    expect(tryHandleFirstRunText("hi")).toBe(false);
+    expect(textHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/first-run/first-run-action-channel.ts
+++ b/packages/ui/src/first-run/first-run-action-channel.ts
@@ -19,14 +19,27 @@
 export const FIRST_RUN_ACTION_PREFIX = "__first_run__:";
 
 type FirstRunActionHandler = (value: string) => boolean;
+type FirstRunTextHandler = (text: string) => boolean;
 
 let handler: FirstRunActionHandler | null = null;
+let textHandler: FirstRunTextHandler | null = null;
 
 /** The conductor registers (and on unmount/finish clears) its action handler. */
 export function setFirstRunActionHandler(
   next: FirstRunActionHandler | null,
 ): void {
   handler = next;
+}
+
+/**
+ * The conductor registers (and on unmount/finish clears) its free-text handler:
+ * the seam that lets the user type freely during onboarding and get a
+ * deterministic in-chat reply WITHOUT the text ever reaching the server.
+ */
+export function setFirstRunTextHandler(
+  next: FirstRunTextHandler | null,
+): void {
+  textHandler = next;
 }
 
 /**
@@ -41,20 +54,34 @@ export function tryHandleFirstRunAction(value: string): boolean {
 }
 
 /**
+ * Offer free text to the active onboarding conductor. Returns true when the
+ * conductor consumed it (rendered a local turn + reply); false when no
+ * conductor is active. The caller must NEVER forward the text to the server
+ * while onboarding is open — the hard "no server send pre-completion" property
+ * lives at the AppContext funnel, this is just the delivery seam.
+ */
+export function tryHandleFirstRunText(text: string): boolean {
+  if (!textHandler) return false;
+  return textHandler(text);
+}
+
+/**
  * How the chat's single send funnel must treat an action value:
  * - `"first-run"` — reserved-prefix value: offer it to the conductor and DROP
  *   it unconditionally. Even after onboarding completes (conductor
  *   unregistered), a tap on a leftover onboarding widget must never reach the
  *   server as a literal `__first_run__:` chat message.
- * - `"dropped"` — onboarding is still active: the transcript is choice-driven,
- *   so free text never reaches the server mid-setup (the composer is locked;
- *   this is the send-seam backstop).
+ * - `"conductor"` — onboarding is still active: free text is answered locally
+ *   by the in-chat conductor (`tryHandleFirstRunText`) and never reaches the
+ *   server mid-setup. The composer is unlocked (#12178, a deliberate reversal
+ *   of the #9952 onboarding lock), so this is the real delivery path, not a
+ *   backstop.
  * - `"send"` — a normal post-onboarding value: forward to the real send.
  */
 export function classifyActionMessage(
   value: string,
   firstRunComplete: boolean,
-): "first-run" | "dropped" | "send" {
+): "first-run" | "conductor" | "send" {
   if (value.startsWith(FIRST_RUN_ACTION_PREFIX)) return "first-run";
-  return firstRunComplete ? "send" : "dropped";
+  return firstRunComplete ? "send" : "conductor";
 }

--- a/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.fuzz.test.ts
@@ -7,13 +7,19 @@
 // network boundary. Deterministic: every storm derives from a fixed seed, so a
 // failure reproduces exactly.
 //
+// The storm also interleaves free-text sends (#12178 composer unlock): typed
+// text is answered by the conductor's local echo persona and must NEVER reach
+// the server, so the pick invariants below hold under mixed pick+text storms.
+//
 // Invariants (the "rock solid" contract):
 //   I1  POST /api/first-run fires at most once per onboarding session.
 //   I2  At most one cloud provisioning call per session.
 //   I3  completeFirstRun (the real gate flip) fires at most once.
 //   I4  Every reserved-prefix value is consumed (never falls through to chat).
-//   I5  The transcript stays bounded — no unbounded turn growth under spam.
+//   I5  Pick spam adds no turns beyond the bounded set; each free text adds
+//       exactly one user + one reply (both acknowledged, never deduped away).
 //   I6  No unhandled rejection escapes (vitest fails the file if one does).
+//   I7  Typed free text never triggers a server send (folded into I1/I2).
 
 import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
@@ -66,8 +72,21 @@ import {
   type ConversationMessagesValue,
 } from "../state/ConversationMessagesContext.hooks";
 import type { AppContextValue } from "../state/internal";
-import { tryHandleFirstRunAction } from "./first-run-action-channel";
+import {
+  tryHandleFirstRunAction,
+  tryHandleFirstRunText,
+} from "./first-run-action-channel";
 import { useFirstRunConductor } from "./use-first-run-conductor";
+
+// Free-text a confused user might type mid-flow, interleaved with the picks.
+const TEXT_POOL = [
+  "hello?",
+  "is it working yet",
+  "what do I do",
+  "   ", // blank — a no-op the conductor consumes without seeding a turn
+  "can you just start",
+  "__first_run__:not-really-a-pick", // looks prefixed but arrives as free text
+];
 
 function ensureLocalStorage(): Storage {
   if (typeof window.localStorage?.clear === "function") {
@@ -196,10 +215,23 @@ async function runStorm(opts: {
     ).toBe(true);
   });
 
+  // Count non-blank free-text sends so the transcript bound can account for the
+  // exactly-two turns (user + reply) each one legitimately adds.
+  let freeTextTurns = 0;
   for (let step = 0; step < STORM_STEPS; step += 1) {
-    const value = ACTION_POOL[Math.floor(rand() * ACTION_POOL.length)];
-    // I4: every reserved-prefix value is consumed by the active conductor.
-    expect(tryHandleFirstRunAction(value), `step ${step}: ${value}`).toBe(true);
+    // ~25% of steps type free text instead of tapping a choice — a confused
+    // user narrating at the flow. It must be consumed, never sent to the server.
+    if (rand() < 0.25) {
+      const text = TEXT_POOL[Math.floor(rand() * TEXT_POOL.length)];
+      expect(tryHandleFirstRunText(text), `step ${step}: text`).toBe(true);
+      if (text.trim()) freeTextTurns += 2;
+    } else {
+      const value = ACTION_POOL[Math.floor(rand() * ACTION_POOL.length)];
+      // I4: every reserved-prefix value is consumed by the active conductor.
+      expect(tryHandleFirstRunAction(value), `step ${step}: ${value}`).toBe(
+        true,
+      );
+    }
     if (rand() < 0.3) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
@@ -222,13 +254,21 @@ async function runStorm(opts: {
     spies.completeFirstRun.mock.calls.length,
     `seed ${opts.seed}: completeFirstRun count`,
   ).toBeLessThanOrEqual(1);
-  // I5 — transcript stays bounded under 250 spam actions. Every seeded turn
-  // has a stable id except error turns (one per settled failing flow, and a
-  // failing flow needs a fresh user pick to start — far fewer than steps).
+  // I5 — the choice-driven transcript stays bounded under 250 spam actions
+  // (every seeded choice/status turn has a stable id; error turns are one per
+  // settled failing flow), PLUS exactly two turns per non-blank free text. The
+  // free-text portion growing 1:1 with sends is the point — every typed message
+  // is acknowledged, never deduped away.
   expect(
     transcript.current.length,
     `seed ${opts.seed}: transcript size`,
-  ).toBeLessThanOrEqual(40);
+  ).toBeLessThanOrEqual(40 + freeTextTurns);
+  // Every free text was acknowledged: as many user echo turns as non-blank sends.
+  expect(
+    transcript.current.filter((turn) => turn.id.startsWith("first-run:user:"))
+      .length,
+    `seed ${opts.seed}: acknowledged free-text turns`,
+  ).toBe(freeTextTurns / 2);
   // Sanity: nothing rendered a raw "undefined" into the transcript.
   for (const turn of transcript.current) {
     expect(turn.text).not.toContain("undefined");

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -61,7 +61,10 @@ import {
   type ConversationMessagesValue,
 } from "../state/ConversationMessagesContext.hooks";
 import type { AppContextValue } from "../state/internal";
-import { tryHandleFirstRunAction } from "./first-run-action-channel";
+import {
+  tryHandleFirstRunAction,
+  tryHandleFirstRunText,
+} from "./first-run-action-channel";
 import {
   clearCloudLoginPending,
   markCloudLoginPending,
@@ -1112,5 +1115,68 @@ describe("persistFirstRun (driven through runFirstRunFinish)", () => {
     const retried = await runFirstRunFinish(draft, ports);
     expect(retried.kind).toBe("done");
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useFirstRunConductor — free-text replies (#12178 composer unlock)", () => {
+  it("echoes typed text as a local user turn + a friendly not-ready reply, never touching the server", async () => {
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // Before any runtime is picked, typing is answered with the "choosing"
+    // persona. The conductor renders the user's text as a real user turn.
+    expect(tryHandleFirstRunText("will this work yet?")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some(
+          (m) => m.role === "user" && m.text === "will this work yet?",
+        ),
+      ).toBe(true);
+    });
+    const reply = transcript.current.find(
+      (m) => m.role === "assistant" && m.id.startsWith("first-run:reply:"),
+    );
+    expect(reply?.text).toContain("pick one of the options above");
+    // The hard rule: no first-run POST happened just from typing.
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("varies the reply by flow position: wrap-up copy once provisioning is done", async () => {
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // Drive the LOCAL path to completion so the wrap-up (tutorial) step is live.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(turn, "first-run:provider");
+    expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
+      true,
+    );
+    await waitForTurn(turn, "first-run:tutorial");
+
+    expect(tryHandleFirstRunText("what now?")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some(
+          (m) =>
+            m.role === "assistant" &&
+            m.id.startsWith("first-run:reply:") &&
+            m.text.includes("Almost there"),
+        ),
+      ).toBe(true);
+    });
+    unmount();
+  });
+
+  it("consumes blank text as a no-op (no empty turn, no reply)", async () => {
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+    const before = transcript.current.length;
+    expect(tryHandleFirstRunText("   ")).toBe(true);
+    expect(transcript.current.length).toBe(before);
+    unmount();
   });
 });

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -12,6 +12,13 @@
 // channel so the chat's single send funnel short-circuits first-run picks
 // before they hit the server.
 //
+// The composer is UNLOCKED during onboarding (#12178, a deliberate reversal of
+// the #9952 onboarding lock): the user can type freely, and a second channel
+// handler (`setFirstRunTextHandler`) answers that free text with a local user
+// turn + a deterministic assistant reply that varies by flow position. Free
+// text NEVER reaches the server pre-completion — the AppContext funnel enforces
+// that; this hook only renders the local echo.
+//
 // Provisioning runs exactly once and POSTs /api/first-run exactly once (the
 // finish module funnels + idempotency-guards it). The real
 // `firstRunComplete` flip is DEFERRED to the tutorial-or-skip pick, so the
@@ -45,6 +52,7 @@ import { normalizeFirstRunName } from "./first-run";
 import {
   FIRST_RUN_ACTION_PREFIX,
   setFirstRunActionHandler,
+  setFirstRunTextHandler,
 } from "./first-run-action-channel";
 import {
   clearCloudLoginPending,
@@ -74,6 +82,26 @@ function cloudFailureMessage(err: unknown): string {
 
 const RESTORE_GREETING =
   "I found an existing local backup for this device. Restore it before setup, or start fresh?";
+
+// The onboarding composer is unlocked (#12178) — the user can type freely
+// before the model is running. Free text never reaches the server; the
+// conductor answers locally with a deterministic, friendly not-ready line that
+// varies by where we are in the flow and re-points at the pending choice. Copy
+// is a plain constant (deterministic — no clocks/RNG in the render path).
+const FIRST_RUN_TEXT_REPLY = {
+  // Before a runtime is picked / mid-choice: no agent exists yet.
+  choosing:
+    "I'm not fully set up yet — pick one of the options above and I'll get your agent running. You can ask me anything the moment I'm ready.",
+  // A finish/provision call is in flight.
+  provisioning:
+    "Hang tight — I'm getting your agent ready right now. I'll answer as soon as I'm set up.",
+  // Provisioning succeeded; only the accent + tutorial wrap-up remains.
+  wrapUp:
+    "Almost there — pick a tutorial option above (or skip) and I'm all yours.",
+  // A finish failed and the recovery choice is on screen.
+  error:
+    "Setup hit a snag. Use one of the options above to try again, choose another way to run, or open Settings — then I'll be right with you.",
+} as const;
 
 function makeTurn(
   id: string,
@@ -318,6 +346,13 @@ export function useFirstRunConductor(): void {
   // only on the next commit, so a double-tap could otherwise re-fire
   // completeFirstRun/startTutorial in the gap.
   const completedRef = React.useRef(false);
+  // True while a finish error's recovery choice is on screen; steers the
+  // free-text reply persona (below). Cleared when the next pick supersedes it.
+  const erroredRef = React.useRef(false);
+  // Monotonic id source for typed-text turns: guarantees a unique user/reply id
+  // per send even when two land in the same millisecond, so `seedTurn`'s id
+  // dedup never silently swallows an acknowledged message.
+  const textTurnSeqRef = React.useRef(0);
 
   // ── Transcript seam ──────────────────────────────────────────────────────
   const seedTurn = React.useCallback(
@@ -448,6 +483,7 @@ export function useFirstRunConductor(): void {
 
   const seedError = React.useCallback(
     (message: string) => {
+      erroredRef.current = true;
       // A DISTINCT, non-looping error surface. Previously this re-appended the
       // runtime CHOICE, so a persistent finish error (e.g. the /api/first-run
       // 404) re-offered the same runtime question forever with no way out. Now
@@ -636,9 +672,11 @@ export function useFirstRunConductor(): void {
       if (completedRef.current) return true;
       // A fresh pick supersedes any armed connect-and-resume continuation —
       // including the durable cloud-resume marker (the cloud/hybrid branches
-      // below re-arm it if the new pick is a cloud one).
+      // below re-arm it if the new pick is a cloud one) — and clears the error
+      // persona so the free-text reply tracks the live step, not a stale error.
       pendingCloudResumeRef.current = null;
       clearCloudLoginPending();
+      erroredRef.current = false;
 
       if (group === "runtime") {
         if (id !== "cloud" && id !== "local" && id !== "remote") return true;
@@ -885,14 +923,48 @@ export function useFirstRunConductor(): void {
   const handleActionRef = React.useRef(handleFirstRunAction);
   handleActionRef.current = handleFirstRunAction;
 
+  // Free-text handler: the user can type freely during onboarding (#12178).
+  // Render their text as a local user turn, then a deterministic assistant
+  // reply keyed on the live flow position. Nothing here touches the network —
+  // the "no server send pre-completion" property is enforced at the AppContext
+  // funnel; this only echoes into the transcript.
+  const handleFirstRunText = React.useCallback(
+    (text: string): boolean => {
+      const trimmed = text.trim();
+      if (!trimmed) return true;
+      const reply = busyRef.current
+        ? FIRST_RUN_TEXT_REPLY.provisioning
+        : provisionedRef.current
+          ? FIRST_RUN_TEXT_REPLY.wrapUp
+          : erroredRef.current
+            ? FIRST_RUN_TEXT_REPLY.error
+            : FIRST_RUN_TEXT_REPLY.choosing;
+      const seq = (textTurnSeqRef.current += 1);
+      seedTurn({
+        id: `first-run:user:${seq}`,
+        role: "user",
+        text: trimmed,
+        timestamp: Date.now(),
+        source: "first_run",
+      });
+      seedTurn(makeTurn(`first-run:reply:${seq}`, reply));
+      return true;
+    },
+    [seedTurn],
+  );
+  const handleTextRef = React.useRef(handleFirstRunText);
+  handleTextRef.current = handleFirstRunText;
+
   // Register the interceptor + seed the greeting while onboarding is active.
   React.useEffect(() => {
     if (!active) {
       setFirstRunActionHandler(null);
+      setFirstRunTextHandler(null);
       return;
     }
     resetFirstRunPersistGuard();
     setFirstRunActionHandler((value) => handleActionRef.current(value));
+    setFirstRunTextHandler((value) => handleTextRef.current(value));
     // Cloud-login resume: if the app was cold-launched mid cloud OAuth (the
     // external browser evicted the WebView on a device), rehydrate the
     // interrupted cloud/hybrid flow instead of restarting at the greeting.
@@ -943,6 +1015,7 @@ export function useFirstRunConductor(): void {
     return () => {
       cancelled = true;
       setFirstRunActionHandler(null);
+      setFirstRunTextHandler(null);
     };
   }, [active, seedBackupRestoreChoice, seedRuntimeChoice, seedTurn]);
 }

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -21,6 +21,7 @@ import { BrandingContext, DEFAULT_BRANDING } from "../config/branding";
 import {
   classifyActionMessage,
   tryHandleFirstRunAction,
+  tryHandleFirstRunText,
 } from "../first-run/first-run-action-channel";
 import {
   isMobileLocalAgentIpcBase,
@@ -1165,20 +1166,23 @@ function AppProviderInner({
   // after onboarding completes (conductor unregistered), a tap on a leftover
   // onboarding widget in the transcript is dropped here instead of sending the
   // literal sentinel to the agent as a chat message. While onboarding is
-  // ACTIVE (firstRunComplete false) every other value is dropped too: the
-  // transcript is choice-driven, so free text must never reach the server
-  // mid-setup (the overlay disables its composer; this is the send-seam
-  // backstop). Once onboarding completes, every non-first-run value falls
-  // through to the real send funnel unchanged. Widgets stay 100% display-only
-  // — both InlineWidgetText and MessageContent route picks through this single
-  // `sendActionMessage`.
+  // ACTIVE (firstRunComplete false) free text is routed to the conductor's
+  // in-chat reply persona (`tryHandleFirstRunText`) and never reaches the
+  // server — the #12178 composer unlock keeps chat interactive without
+  // breaking the "no server send pre-completion" property, which is enforced
+  // HERE (the `"conductor"` case never calls `rawSendActionMessage`). Once
+  // onboarding completes, every non-first-run value falls through to the real
+  // send funnel unchanged. Widgets stay 100% display-only — both
+  // InlineWidgetText and MessageContent route picks through this single
+  // `sendActionMessage`, and so does the unlocked composer during onboarding.
   const sendActionMessage = useCallback(
     (text: string): Promise<void> => {
       switch (classifyActionMessage(text, firstRunComplete === true)) {
         case "first-run":
           tryHandleFirstRunAction(text);
           return Promise.resolve();
-        case "dropped":
+        case "conductor":
+          tryHandleFirstRunText(text);
           return Promise.resolve();
         case "send":
           return rawSendActionMessage(text);


### PR DESCRIPTION
## What & why

**Part of #12178 (Phase 2)** — onboarding UX. #12178 is closed and WI-1 (delete the dead first-run wizard state layer) already landed on develop via **#12327**; this PR is rebased on develop and carries only the Phase-2 surface work (WI-2 + WI-3). A maintainer can reopen/track Phase 2 separately.

The goal (from #12178): make onboarding feel friendly and interactive **before the model is even running**, and make the full-screen start truly opaque.

### WI-2 — opaque full-screen + graceful exit

- While `firstRunOpen`, the chat renders an **opaque `bg-bg` backdrop** (`data-testid="chat-first-run-backdrop"`, `data-first-run-opaque="true"`) stacked above the translucent gradient scrim and below the glass panel, so **no launcher/home pixel shows through** — including behind the panel glass. Token, not hardcoded black; matches the shell's existing `app-opaque-background` idiom.
- On the completion falling edge the backdrop fades opaque → transparent over ~400ms **in step with the existing one-shot auto-collapse**, revealing the launcher/home (kept mounted, warm) underneath. `prefers-reduced-motion` cuts (no fade).

### WI-3 — unlock the composer (a deliberate reversal of #9952's onboarding lock)

- Removed `disabled={firstRunOpen}` from the textarea + send; **attach + mic stay disabled** pre-runtime. Placeholder → "Ask me anything — or pick an option".
- `classifyActionMessage`'s `"dropped"` branch becomes `"conductor"`: free text while `firstRunComplete === false` routes through the shared `sendActionMessage` funnel to the conductor's new `setFirstRunTextHandler`. **HARD RULE preserved: nothing reaches the server pre-completion** — the `"conductor"` case in `AppContext.sendActionMessage` never calls the real send, and `submit` skips slash/shortcut resolution while onboarding. `__first_run__:` stays reserved forever.
- The conductor renders typed text as a **local user turn + a deterministic assistant reply** that varies by flow position (choosing / provisioning / wrap-up / error) and re-points at the pending choice. Turn ids are monotonic so same-millisecond sends are never deduped away — every typed message is visibly acknowledged.

> **This is a deliberate reversal of #9952's onboarding lock**, not a regression. #9952 shipped the composer as hard-locked (disabled + free text dropped) to guarantee "no server send mid-setup". #12178's goal is the opposite UX — a friendly, typeable chat before the model exists — so we keep the *security* property (no pre-completion server send, enforced at the funnel) while dropping the *interactivity* restriction. Both design docs are updated to say so.

## Verification

| Check | Result |
|---|---|
| `packages/ui` unit tests (`first-run-action-channel`, `use-first-run-conductor`, `use-first-run-conductor.fuzz`, `ContinuousChatOverlay.firstrun`) | **59/59 pass** on the rebased tree |
| `packages/ui typecheck` | clean (only the pre-existing unrelated `iwer` missing-type-decl in an untouched spatial e2e fixture) |
| Fuzz storm | extended with interleaved free-text; asserts every typed message is acknowledged (1 user + 1 reply, never deduped) and no send reaches the server under 250-step pick+text storms |

### Evidence (`PR_EVIDENCE.md`)

- **Rendered UI (screenshots/video):** onboarding is not driven by `audit:app` (it never enters the first-run flow); before/after desktop+mobile captures + the `audit:app` verdicts land in the tracking follow-up (WI-7) under `.github/issue-evidence/12178-onboarding/`. The behavioral surface is fully covered by the unit + e2e specs above and the `onboarding-to-home` / chat-sheet e2e assertions updated here (opaque backdrop present, composer enabled, typed text → conductor, no server send).
- **Real-LLM trajectories:** `N/A - the pre-runtime conductor replies are deterministic local copy; no model is invoked (that's the point — the model isn't running yet).`
- **Backend logs:** `N/A - the hard rule under test is that NOTHING reaches the server pre-completion; asserted via mocked client (no server call).`

## Docs

Updated `packages/ui/src/first-run/README.md` and `IN_CHAT_ONBOARDING_DESIGN.md` (the "onboarding lock" sections now document the opaque backdrop + the #12178 unlock and the seam that keeps server-send off).

## Stacking

Follow-up PR (PR-3) will stack WI-4 (in-chat model download/switch status card) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
