### PR TITLE
fix(ui): restore local binding for ChatFailureKind/ChatTurnStatus (regression from #12432)

### DIFF
--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -3,15 +3,21 @@
 // Document*, Memory*, MCP*, Share*
 // ---------------------------------------------------------------------------
 
-import type { LinkedAccountProviderId } from "@elizaos/shared";
+import type {
+  ChatFailureKind,
+  ChatTurnStatus,
+  LinkedAccountProviderId,
+} from "@elizaos/shared";
 import type {
   ConversationMetadata,
   ConversationScope,
 } from "./client-types-core";
 
 // Single-source SSE chat contract lives in @elizaos/shared (#12409); re-exported
-// here so existing `@elizaos/ui` `api` consumers keep their import path.
-export type { ChatFailureKind, ChatTurnStatus } from "@elizaos/shared";
+// here so existing `@elizaos/ui` `api` consumers keep their import path. Imported
+// (not export-from) because `failureKind` fields below reference the type in this
+// module's scope.
+export type { ChatFailureKind, ChatTurnStatus };
 
 // Conversations
 export interface Conversation {


### PR DESCRIPTION
## What

#12432 single-sourced `ChatTurnStatus` + `ChatFailureKind` into `@elizaos/shared` and re-exported them from `packages/ui/src/api/client-types-chat.ts` with:

```ts
export type { ChatFailureKind, ChatTurnStatus } from "@elizaos/shared";
```

An `export … from` re-export creates **no local binding**, so the `failureKind?: ChatFailureKind` field reference further down the same module fails to resolve. `tsc`/`tsgo` reports:

```
packages/ui/src/api/client-types-chat.ts(336,17): error TS2304: Cannot find name 'ChatFailureKind'.
```

This breaks workspace `bun run typecheck` on `develop` (the UI file is cross-checked via the agent project references). Vitest/esbuild strips types so the PR's test + biome checks didn't catch it.

## Fix

Import the two types into module scope, then re-export them — consumers keep the same `@elizaos/ui` `api` import path, and the in-file field references resolve.

## Verification

- Before: agent typecheck → `TS2304: Cannot find name 'ChatFailureKind'`.
- After: that error is gone; only unrelated unbuilt-optional-plugin `TS2307` module-resolution noise remains (plugin-streaming/vision/background-runner/meetings — pre-existing, not built in the scoped worktree).
- `biome check` clean; `packages/ui/src/api/client-types-chat.test.ts` → 6 passed.

Follow-up to #12432 / #12409.