### PR TITLE
fix(ui): restore local ChatFailureKind binding broken by #12432 (develop-red TS2304)

### DIFF
--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -9,9 +9,12 @@ import type {
   ConversationScope,
 } from "./client-types-core";
 
-// Single-source SSE chat contract lives in @elizaos/shared (#12409); re-exported
-// here so existing `@elizaos/ui` `api` consumers keep their import path.
-export type { ChatFailureKind, ChatTurnStatus } from "@elizaos/shared";
+// Single-source SSE chat contract lives in @elizaos/shared (#12409); imported for
+// local use below AND re-exported so existing `@elizaos/ui` `api` consumers keep
+// their import path. (A bare `export type … from` creates no local binding, so
+// the `failureKind?: ChatFailureKind` field reference below would fail TS2304.)
+import type { ChatFailureKind, ChatTurnStatus } from "@elizaos/shared";
+export type { ChatFailureKind, ChatTurnStatus };
 
 // Conversations
 export interface Conversation {


### PR DESCRIPTION
**Develop-red fix.** #12432 re-exported `ChatFailureKind`/`ChatTurnStatus` from `client-types-chat.ts` via a bare `export type { … } from "@elizaos/shared"`, which creates no local binding — so the `failureKind?: ChatFailureKind` field reference in the same module fails `TS2304: Cannot find name 'ChatFailureKind'`, breaking `bun run typecheck` on develop. The PR's verification only ran vitest (esbuild strips types) so it slipped through. Fix: `import type` (local binding) + a separate re-export (preserves the `@elizaos/ui` api consumer path). Verified: `packages/ui` typecheck no longer reports the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)