### PR TITLE
feat(#12353): local-agent IPC close-out — chat SSE proof, desktop proxy opt-in gate, straggler sweep

### DIFF
--- a/.github/issue-evidence/12353-straggler-sweep.txt
+++ b/.github/issue-evidence/12353-straggler-sweep.txt
@@ -1,0 +1,86 @@
+# Issue #12353 — local-agent IPC straggler sweep
+# Generated 2026-07-04T01:43:07Z on branch fix/12353-ipc-closeout-sweep
+# Base: origin/develop @ 8ef641aa849 (foundation slice #12293 merged)
+
+Scope: verify every local-agent network callsite in the renderer routes through
+the transport chain (AgentRequestTransport), the global fetch bridge, the
+localAgentRequest/localAgentStream* RPC/IPC methods, or the eliza-local-agent://
+scheme handler — with zero hardcoded loopback that assumes a reachable port in
+local IPC mode. Cloud (/api/v1/*) callsites are out of scope (remote HTTPS path).
+
+==================================================================
+1. WebSocket constructions in renderer source (expect: exactly one, the
+   sanctioned /ws in client-base.ts, skipped on IPC bases per Decision 5/8)
+==================================================================
+packages/ui/src/api/client-base.ts:1181:    // Browsers cannot set Authorization on `new WebSocket(url)`. Pass the same
+packages/ui/src/api/client-base.ts:1190:    this.ws = new WebSocket(url);
+
+==================================================================
+2. Raw 'new EventSource(' in renderer source outside openEventSource
+   (expect: none — all 8 consumers go through openEventSource, which returns
+   null on IPC bases and callers poll)
+==================================================================
+(none — clean)
+
+==================================================================
+3. Hardcoded loopback (127.0.0.1:31337 / localhost:31337) in renderer source
+   (expect: only comments, the dev-in-browser LoginView curl example, and the
+   documented dev/browser-mode fallback constants — never an assumed-reachable
+   local-agent call in IPC mode)
+==================================================================
+packages/ui/src/state/startup-coordinator.ts:354:    // cold-booting (e.g. `bun run dev` at localhost:2138 → localhost:31337,
+packages/ui/src/state/startup-phase-poll.ts:175:   * (127.0.0.1:31337) which the agent 401s as a cross-origin request, while
+packages/ui/src/state/startup-phase-poll.ts:623:        // the agent's raw loopback port (e.g. dev-in-browser at 127.0.0.1:31337)
+packages/ui/src/components/auth/LoginView.tsx:270:                    http://localhost:31337/
+packages/ui/src/components/auth/LoginView.tsx:281:                    {`curl -X POST http://127.0.0.1:31337/api/auth/setup -H "Content-Type: application/json" -d '{"displayName":"YOURNAME","password":"YOURPASS"}'`}
+packages/ui/src/voice/AMBIENT_GATE_PIXEL_VERIFICATION.md:34:The embedded agent listens on `127.0.0.1:31337` inside the app sandbox; it is
+packages/ui/src/first-run/runtime-target.ts:15:const DEFAULT_LOCAL_AGENT_API_BASE = "http://127.0.0.1:31337";
+packages/ui/src/first-run/probe-local-agent.ts:21:  "http://127.0.0.1:31337/api/health";
+
+==================================================================
+4. DOM media src/href sinks referencing local-agent media/music-player
+   (expect: all resolve via resolveApiUrl/resolveAppAssetUrl/normalizeMediaUrl,
+   which key off the boot-config api base -> eliza-local-agent://ipc scheme
+   handler in IPC mode; no hardcoded loopback)
+==================================================================
+packages/ui/src/cloud-ui/components/voice/voice-audio-player.tsx:118:      <audio ref={audioRef} src={audioUrl} preload="metadata">
+packages/ui/src/cloud-ui/components/voice/use-audio-player.ts:83:      audioRef.current.src = audioUrl;
+packages/ui/src/components/chat/widgets/music-player.tsx:107:      el.src = player.streamUrl;
+packages/ui/src/components/transcripts/TranscriptPlayer.tsx:45:        <audio ref={audio.audioRef} src={audioUrl} preload="metadata" />
+packages/ui/src/components/chat/TranscriptViewerOverlay.tsx:467:                src={audioUrl}
+packages/ui/src/components/pages/MediaGalleryView.tsx:602:                  src={normalizeMediaUrl(selectedItem.url)}
+packages/ui/src/components/pages/MediaGalleryView.tsx:608:                  src={normalizeMediaUrl(selectedItem.url)}
+packages/ui/src/components/pages/MediaGalleryView.tsx:622:                    src={normalizeMediaUrl(selectedItem.url)}
+packages/ui/src/cloud/api-explorer/api-tester.tsx:1059:                                src={audioData?._audioUrl}
+
+==================================================================
+CONCLUSION — zero unaccounted local-agent network calls
+==================================================================
+1. WebSocket: exactly one (client-base.ts:1190, the /ws realtime socket). It is
+   skipped on IPC bases by shouldTreatAsConnectedWithoutWebSocket; the desktop
+   RPC push replacement is sibling #12355. Accounted for.
+2. EventSource: no raw constructions outside openEventSource, which null-falls
+   back on IPC bases (all 8 consumers poll). Accounted for.
+3. Hardcoded loopback: every hit is a comment, the dev-in-browser LoginView curl
+   example (dev UX text, not a runtime call), a doc .md, or the documented
+   dev/browser-mode fallback constant in runtime-target.ts / probe-local-agent.ts.
+   - runtime-target.ts: iOS/Android return their IPC bases; other platforms use
+     getElizaApiBase() (-> eliza-local-agent://ipc once #12355 flips the desktop
+     base) and only fall back to loopback in dev/browser. Accounted for.
+   - probe-local-agent.ts: Android liveness probe routes through the Capacitor
+     Agent.request plugin (runNativeAndroidProbe); the raw-fetch loopback branch
+     only fires in dev/browser. Accounted for.
+   No callsite assumes a *reachable* local-agent HTTP port in IPC mode.
+4. DOM media sinks: every local-agent media/music-player src resolves through
+   resolveApiUrl / resolveAppAssetUrl / normalizeMediaUrl, which key off the
+   boot-config api base. In IPC mode that base is eliza-local-agent://ipc and the
+   bytes are served by the per-platform scheme handler (sibling #12351). No
+   hardcoded loopback. (cloud-ui/* and cloud/* audio players are remote-mode,
+   out of scope.)
+
+Every remaining local-agent network callsite routes through one of:
+  - the AgentRequestTransport chain (client.fetch / fetchWithCsrf / streamChatEndpoint),
+  - the per-platform global fetch bridge (raw fetch rescued in local mode),
+  - the localAgentRequest / localAgentStream* IPC methods (siblings), or
+  - the eliza-local-agent:// scheme handler for DOM media (sibling #12351).
+Cloud /api/v1/* is the remote HTTPS path and is explicitly out of scope.

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -106,6 +106,7 @@ import {
   createRendererApiProxyRequestInit,
   isRendererApiProxyPath,
   resolveRendererProxyIdleTimeoutSeconds,
+  shouldProxyToApiBase,
 } from "./renderer-api-proxy";
 import {
   getRendererAssetContentType,
@@ -843,7 +844,7 @@ async function startRendererServer(): Promise<string> {
       // or this static server (non-watch dev:desktop). Without this, every
       // /api/* call returned SPA HTML and Settings sat on "Loading…" forever.
       const apiBase = apiBaseOwner.getCurrent().base ?? initialApiBase;
-      if (apiBase && isRendererApiProxyPath(pathname)) {
+      if (shouldProxyToApiBase(apiBase) && isRendererApiProxyPath(pathname)) {
         const target = new URL(pathname + url.search, apiBase);
         try {
           const upstreamRequest = createRendererApiProxyRequestInit(

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
@@ -3,6 +3,7 @@ import {
   createRendererApiProxyRequestInit,
   isRendererApiProxyPath,
   resolveRendererProxyIdleTimeoutSeconds,
+  shouldProxyToApiBase,
 } from "./renderer-api-proxy";
 
 describe("renderer API proxy", () => {
@@ -50,6 +51,20 @@ describe("renderer API proxy", () => {
     expect(init.body).toBe(req.body);
     expect(init.duplex).toBe("half");
     expect((init.headers as Headers).get("host")).toBeNull();
+  });
+
+  it("proxies only to a reachable HTTP(S) api base, never the IPC scheme", () => {
+    // Local mode with the port exposed (ELIZA_API_EXPOSE_PORT=1) / external /
+    // cloud modes keep an HTTP listener the static server can forward to.
+    expect(shouldProxyToApiBase("http://127.0.0.1:31337")).toBe(true);
+    expect(shouldProxyToApiBase("https://agent.example.com")).toBe(true);
+
+    // Default local-agent IPC mode: no listener, no forwarding target. The
+    // proxy must stay dead so it never fetches a non-HTTP scheme.
+    expect(shouldProxyToApiBase("eliza-local-agent://ipc")).toBe(false);
+    expect(shouldProxyToApiBase(undefined)).toBe(false);
+    expect(shouldProxyToApiBase("")).toBe(false);
+    expect(shouldProxyToApiBase("not a url")).toBe(false);
   });
 
   it("keeps the renderer proxy idle timeout within Bun.serve limits", () => {

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
@@ -6,6 +6,29 @@ export function isRendererApiProxyPath(pathname: string): boolean {
   );
 }
 
+/**
+ * True when the resolved api base is a reachable HTTP(S) listener the static
+ * server can forward `/api`,`/ws`,`/music-player` to.
+ *
+ * Local-agent IPC mode resolves the api base to the `eliza-local-agent://ipc`
+ * scheme (#12180): there is no TCP listener, `/api` traffic rides the Electrobun
+ * RPC transport / custom scheme handler instead, and this proxy is dead. In that
+ * mode the proxy must not fire — forwarding to a non-HTTP scheme would throw and
+ * `fetch()` a base the agent never bound. The `ELIZA_API_EXPOSE_PORT=1` opt-in
+ * (dev tooling, LAN, e2e/Playwright HTTP harnesses) keeps the loopback listener
+ * and the HTTP api base, so the proxy stays active for those flows.
+ */
+export function shouldProxyToApiBase(apiBase: string | undefined): boolean {
+  if (!apiBase) return false;
+  let scheme: string;
+  try {
+    scheme = new URL(apiBase).protocol;
+  } catch {
+    return false;
+  }
+  return scheme === "http:" || scheme === "https:";
+}
+
 const BUN_SERVE_MAX_IDLE_TIMEOUT_SECONDS = 255;
 
 function parsePositiveInteger(value: string | undefined): number | null {

--- a/packages/ui/src/api/streamChatEndpoint-native-transport.test.ts
+++ b/packages/ui/src/api/streamChatEndpoint-native-transport.test.ts
@@ -105,7 +105,9 @@ describe("streamChatEndpoint over a native IPC streaming transport", () => {
     // second event fired.
     fake.emit("agentStreamChunk", {
       streamId: "chat-stream",
-      dataBase64: b64('data: {"type":"token","text":"Hel","fullText":"Hel"}\n\n'),
+      dataBase64: b64(
+        'data: {"type":"token","text":"Hel","fullText":"Hel"}\n\n',
+      ),
     });
     await flush();
     expect(tokens).toEqual([{ token: "Hel", accumulated: "Hel" }]);
@@ -156,7 +158,8 @@ describe("streamChatEndpoint over a native IPC streaming transport", () => {
     await flush();
     fake.emit("agentStreamResponse", { streamId: "chat-stream", status: 200 });
 
-    const doneFrame = 'data: {"type":"done","fullText":"Hi","agentName":"Eliza"}\n\n';
+    const doneFrame =
+      'data: {"type":"done","fullText":"Hi","agentName":"Eliza"}\n\n';
     const split = 20;
     fake.emit("agentStreamChunk", {
       streamId: "chat-stream",

--- a/packages/ui/src/api/streamChatEndpoint-native-transport.test.ts
+++ b/packages/ui/src/api/streamChatEndpoint-native-transport.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { ElizaClient } from "./client";
+import {
+  createNativeStreamingResponse,
+  type NativeStreamingAgentPlugin,
+} from "./native-agent-stream";
+import type { AgentRequestTransport } from "./transport";
+
+/**
+ * Close-out integration for the chat SSE path over the native IPC transports
+ * (#12353 / #12180 phase 4). Proves the invariant every per-platform streaming
+ * adapter (Android `agentStream*`, the iOS bridge events, the Electrobun RPC
+ * push events) relies on: a `Response` produced by `createNativeStreamingResponse`
+ * — the transport-agnostic native streaming bridge — drives `streamChatEndpoint`
+ * token-by-token, not as one buffered frame.
+ *
+ * The per-platform native/on-device leg (Swift/Kotlin/Electrobun RPC) is verified
+ * by the device-capture lanes in the sibling PRs; here the shared JS pipeline is
+ * driven end-to-end with a fake streaming plugin so the wiring is proven without a
+ * device.
+ */
+
+interface FakeStreamingAgent {
+  agent: NativeStreamingAgentPlugin;
+  emit: (eventName: string, payload: unknown) => void;
+}
+
+function makeFakeStreamingAgent(streamId = "chat-stream"): FakeStreamingAgent {
+  const listeners = new Map<string, Array<(e: unknown) => void>>();
+  const agent: NativeStreamingAgentPlugin = {
+    async requestStream() {
+      return { streamId };
+    },
+    async addListener(eventName, listener) {
+      const arr = listeners.get(eventName) ?? [];
+      arr.push(listener);
+      listeners.set(eventName, arr);
+      return {
+        remove() {
+          listeners.set(
+            eventName,
+            (listeners.get(eventName) ?? []).filter((l) => l !== listener),
+          );
+        },
+      };
+    },
+  };
+  const emit = (eventName: string, payload: unknown) => {
+    for (const l of listeners.get(eventName) ?? []) l(payload);
+  };
+  return { agent, emit };
+}
+
+const b64 = (s: string) => btoa(s);
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * A transport that fulfils streaming requests through the native streaming
+ * bridge (mirroring how each platform resolver returns a native-backed
+ * `Response`) and would fail loudly on a buffered request — so the test proves
+ * the streaming leg, not a buffered fallback.
+ */
+function nativeStreamingTransport(
+  fake: FakeStreamingAgent,
+): AgentRequestTransport {
+  return {
+    async request(url, init) {
+      const accept = new Headers(init.headers ?? {}).get("accept") ?? "";
+      if (!accept.toLowerCase().includes("text/event-stream")) {
+        throw new Error(
+          `expected a streaming chat request, got Accept: ${accept || "<none>"}`,
+        );
+      }
+      const path = new URL(url, "http://localhost").pathname;
+      return createNativeStreamingResponse(fake.agent, { path });
+    },
+  };
+}
+
+describe("streamChatEndpoint over a native IPC streaming transport", () => {
+  it("renders tokens INCREMENTALLY as native stream events arrive", async () => {
+    const fake = makeFakeStreamingAgent();
+    const client = new ElizaClient("eliza-local-agent://ipc", "token");
+    client.setRequestTransport(nativeStreamingTransport(fake));
+
+    const tokens: Array<{ token: string; accumulated?: string }> = [];
+    const resultPromise = client.streamChatEndpoint(
+      "/api/conversations/conv-1/messages/stream",
+      "hello",
+      (token, accumulated) => tokens.push({ token, accumulated }),
+    );
+
+    // Let requestStream + the three addListener awaits settle, then feed the
+    // response head so streamChatEndpoint starts reading the body.
+    await flush();
+    fake.emit("agentStreamResponse", {
+      streamId: "chat-stream",
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    // Two separate token frames on two separate native events: if the chat path
+    // buffered the whole body it could not surface the first token before the
+    // second event fired.
+    fake.emit("agentStreamChunk", {
+      streamId: "chat-stream",
+      dataBase64: b64('data: {"type":"token","text":"Hel","fullText":"Hel"}\n\n'),
+    });
+    await flush();
+    expect(tokens).toEqual([{ token: "Hel", accumulated: "Hel" }]);
+
+    fake.emit("agentStreamChunk", {
+      streamId: "chat-stream",
+      dataBase64: b64(
+        'data: {"type":"token","text":"lo","fullText":"Hello"}\n\n',
+      ),
+    });
+    await flush();
+    expect(tokens).toEqual([
+      { token: "Hel", accumulated: "Hel" },
+      { token: "lo", accumulated: "Hello" },
+    ]);
+
+    fake.emit("agentStreamChunk", {
+      streamId: "chat-stream",
+      dataBase64: b64(
+        'data: {"type":"done","fullText":"Hello","agentName":"Eliza"}\n\n',
+      ),
+    });
+    fake.emit("agentStreamComplete", { streamId: "chat-stream" });
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      text: "Hello",
+      agentName: "Eliza",
+      completed: true,
+    });
+  });
+
+  it("reassembles an SSE frame split across two native chunk events", async () => {
+    // The native bridge chunks the body at fixed byte boundaries (8 KiB on
+    // Android), so a single SSE `data:` frame can arrive across two events. The
+    // chat read loop must buffer across chunk boundaries and only act on a
+    // complete event — proving the transport boundary does not corrupt framing.
+    const fake = makeFakeStreamingAgent();
+    const client = new ElizaClient("eliza-local-agent://ipc", "token");
+    client.setRequestTransport(nativeStreamingTransport(fake));
+
+    const tokens: string[] = [];
+    const resultPromise = client.streamChatEndpoint(
+      "/api/conversations/conv-1/messages/stream",
+      "hello",
+      (token) => tokens.push(token),
+    );
+    await flush();
+    fake.emit("agentStreamResponse", { streamId: "chat-stream", status: 200 });
+
+    const doneFrame = 'data: {"type":"done","fullText":"Hi","agentName":"Eliza"}\n\n';
+    const split = 20;
+    fake.emit("agentStreamChunk", {
+      streamId: "chat-stream",
+      dataBase64: b64(doneFrame.slice(0, split)),
+    });
+    await flush();
+    // The frame is incomplete: no token yet, turn not resolved.
+    expect(tokens).toEqual([]);
+
+    fake.emit("agentStreamChunk", {
+      streamId: "chat-stream",
+      dataBase64: b64(doneFrame.slice(split)),
+    });
+    fake.emit("agentStreamComplete", { streamId: "chat-stream" });
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      text: "Hi",
+      agentName: "Eliza",
+      completed: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #12353

Parent: #12180 (local-agent IPC transport). This is the **phases 4–5 close-out**: chat-SSE-over-IPC verification, desktop proxy opt-in gating, and the final repo-wide straggler sweep. The per-platform phase-2/3 wiring (desktop RPC #12355, iOS streaming #12354, Android stdio #12352, media scheme handlers #12351) is being implemented **in parallel** by sibling agents; this PR delivers everything in scope that does **not** require their merged code, and flags the rest.

## What / why

### 1. Desktop renderer proxy gated on a reachable HTTP api base (scope: "Gate desktop /api, /ws, /music-player proxy behind exposed-port opt-in")
`packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts` gains `shouldProxyToApiBase(apiBase)`, and `index.ts` forwards `/api`,`/ws`,`/music-player` **only when the resolved api base is an HTTP(S) URL**. In default local-agent IPC mode the api base becomes `eliza-local-agent://ipc` (no TCP listener — traffic rides the Electrobun RPC transport + custom scheme handler), so the proxy must not fire; forwarding to a non-HTTP scheme would throw. Keying the gate on the api-base scheme rather than a premature default flip means:
- **Today (HTTP api base):** proxy stays active — desktop, external, cloud, and `ELIZA_API_EXPOSE_PORT=1` local mode are byte-for-byte unchanged.
- **When #12355 lands** and flips the desktop base to the IPC scheme: the proxy goes dead automatically, with no follow-up edit and no crash.

This is the non-breaking form of parent Decision 11. A hard "gate the proxy off by default" would break desktop local mode **now**, because on `develop` the desktop api base is still `http://127.0.0.1:<port>` and the agent still binds the port (the IPC api-base switch is sibling #12355).

### 2. Chat SSE verified over the native IPC streaming pipeline (scope: "Verify streamChatEndpoint over the native local-agent transports")
`packages/ui/src/api/streamChatEndpoint-native-transport.test.ts` drives `streamChatEndpoint` — the real chat entry point — through a transport that fulfils streaming requests with `createNativeStreamingResponse` (the transport-agnostic native streaming bridge that Android `agentStream*`, the iOS bridge events, and the Electrobun RPC push events all plug into). It proves:
- tokens render **incrementally** as native chunk events arrive (not one buffered frame), and
- an SSE frame **split across two native chunk events** is reassembled correctly across the transport boundary.

The shared JS wiring is thus proven without a device; the per-platform native leg (Swift/Kotlin/Electrobun RPC) is proven by the sibling device-capture lanes.

### 3. Final straggler sweep (scope: "Re-run repo-wide fetch/EventSource/WebSocket/DOM-media/loopback sweeps")
`.github/issue-evidence/12353-straggler-sweep.txt` captures the re-run of all sweeps against `develop` after the foundation slice (#12293). Result: **zero unaccounted local-agent network calls.** Every remaining callsite routes through the `AgentRequestTransport` chain, the per-platform global fetch bridge, the `localAgentRequest`/`localAgentStream*` IPC methods, or the `eliza-local-agent://` scheme handler. The only hardcoded-loopback hits are comments, the dev-in-browser `LoginView` curl example, and the documented dev/browser-mode fallback constants (`runtime-target.ts`, `probe-local-agent.ts`) — none assume a reachable local-agent port in IPC mode. Cloud `/api/v1/*` is the out-of-scope remote HTTPS path.

## Commands run & results

| Command | Result |
| --- | --- |
| `vitest run … renderer-api-proxy` (electrobun config) | **5 passed** (incl. new `shouldProxyToApiBase` cases) |
| `vitest run … streamChatEndpoint-native-transport` (ui) | **2 passed** |
| `vitest run … desktop-local-agent-transport native-agent-stream client-base-stream-abort transport` (ui) | **48 passed / 9 files** (regression check on the transport chain) |
| `vitest run … runtime-env.expose-port` (shared) | **17 passed** (opt-in resolver) |
| `vitest run … server-skip-listen` (agent) | **9 passed** (incl. the real Bun-subprocess **no-TCP-bind** behavioral proof) |
| `biome check` on all touched files | **clean** |

The foundation slice's `server-skip-listen` + `runtime-env.expose-port` suites are the evidence for the port-removal opt-in claim: with the gate primitive, an unset flag in local mode binds no port and `ELIZA_API_EXPOSE_PORT=1` re-opens it identically to `develop`.

## Evidence checklist (PR_EVIDENCE.md)

- **Real-LLM trajectories** — N/A: no agent/action/prompt/model behavior changes. This PR is transport/proxy plumbing + a client SSE integration test.
- **Backend logs** — N/A for this PR's slice: the per-platform stdio-bridge `dispatchRoute` log lines are produced by the sibling wiring PRs (#12352/#12354/#12355), not by the proxy gate or the client test here.
- **Frontend console/network logs (zero localhost agent calls in local mode)** — **partially blocked on siblings.** The straggler-sweep evidence (`12353-straggler-sweep.txt`) statically proves no renderer callsite assumes a reachable loopback port in IPC mode; the live "zero localhost calls" network trace requires the desktop IPC api-base (#12355) / mobile native transports, captured in those PRs.
- **Before/after screenshots + video walkthrough (desktop + mobile)** — **blocked on siblings.** `capture:linux-desktop` / `capture:ios-sim` / `capture:android-emu` for the IPC path require the merged per-platform wiring (#12355/#12354/#12352) and the flipped IPC api base; nothing in this PR changes rendered UI. See gaps.
- **Per-platform capture (native/mobile/desktop)** — **blocked on siblings** (same reason).
- **Audio + narrated walkthrough** — N/A: no voice/TTS/STT change.
- **Domain artifacts (memory/DB/wallet/on-chain)** — N/A: this change produces none (matches the parent's explicit N/A for this row).
- **Straggler-sweep artifact** — attached: `.github/issue-evidence/12353-straggler-sweep.txt`.

## Remaining gaps (blocked on parallel siblings — honestly out of my reach in this PR)

- **Live per-platform port-removal + streaming + media captures** (`capture:ios-sim`, `capture:android-emu`, `capture:linux-desktop`/`windows-desktop`; `adb shell cat /proc/net/tcp`; `lsof` no-listener proof; token-by-token screen recordings) require the merged desktop RPC handlers + IPC api-base (#12355), iOS streaming adapter (#12354), Android stdio switch (#12352), and media scheme handlers (#12351). Those flip the api base to `eliza-local-agent://ipc` and remove the native listeners — the pre-conditions for the captures. This PR's proxy gate + SSE pipeline test + sweep are the pieces that are correct and testable **now**; the device captures land with the sibling PRs.
- **Repo-wide `bun run verify`** was not run: this isolated worktree has no `node_modules` (worktrees share the parent tree, which was not linked here), so the full project-references typecheck can't resolve `@elizaos/*`. Mitigation: every touched file passes `biome check`, the changes are type-simple (`shouldProxyToApiBase(string|undefined): boolean`; test files using existing typed APIs), and all scoped vitest suites for the touched packages pass. Full `bun run verify` should run in CI where the workspace is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
