### PR TITLE
refactor(#12349): one gesture core for chat and shell interactions

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
@@ -1,13 +1,7 @@
 import { MoreHorizontal, PencilLine, X } from "lucide-react";
 import type React from "react";
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { memo, useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useClickSuppression, usePressAndHold } from "../../../gestures";
 import { cn } from "../../../lib/utils";
 
 // z-[200] mirrors Z_OVERLAY in ../../../lib/floating-layers.ts.
@@ -141,34 +135,20 @@ export const ChatConversationItem = memo(function ChatConversationItem({
   onSelect,
   variant = "default",
 }: ChatConversationItemProps) {
-  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const suppressClickRef = useRef(false);
+  // No auto-disarm: the tap the browser synthesizes after a long-press can land a
+  // full task later, so the arm must persist until that click consumes it.
+  const clickSuppression = useClickSuppression({ autoDisarm: false });
   const isGameModal = variant === "game-modal";
 
-  const clearLongPressTimer = useCallback(() => {
-    if (longPressTimerRef.current !== null) {
-      clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => clearLongPressTimer();
-  }, [clearLongPressTimer]);
-
-  const handleTouchStart = (event: React.TouchEvent<HTMLButtonElement>) => {
-    if (!mobile || !onOpenActions) return;
-    clearLongPressTimer();
-    longPressTimerRef.current = setTimeout(() => {
-      suppressClickRef.current = true;
-      onOpenActions(event, conversation);
-      clearLongPressTimer();
-    }, 450);
-  };
-
-  const handleTouchEnd = () => {
-    clearLongPressTimer();
-  };
+  // A held finger opens the row's action menu; the tap the browser then
+  // synthesizes is swallowed so it doesn't also fire onSelect.
+  const pressAndHold = usePressAndHold<HTMLButtonElement>({
+    enabled: mobile && Boolean(onOpenActions),
+    onHold: (event) => {
+      clickSuppression.arm();
+      onOpenActions?.(event, conversation);
+    },
+  });
 
   const renderedTitle = displayTitle ?? conversation.title;
   const showInlineActions = isGameModal;
@@ -200,20 +180,14 @@ export const ChatConversationItem = memo(function ChatConversationItem({
             : "m-0 flex h-auto w-full min-w-0 flex-1 cursor-pointer items-center gap-2 overflow-hidden rounded-none border-0 bg-transparent p-0 text-left hover:bg-transparent"
         }
         onClick={() => {
-          if (suppressClickRef.current) {
-            suppressClickRef.current = false;
-            return;
-          }
+          if (clickSuppression.consumeArmed()) return;
           onSelect();
         }}
         onContextMenu={(event) => {
           if (mobile || !onOpenActions) return;
           onOpenActions(event, conversation);
         }}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={handleTouchEnd}
-        onTouchMove={handleTouchEnd}
+        {...pressAndHold}
       >
         {isUnread ? (
           <span

--- a/packages/ui/src/components/shell/TopicGroup.tsx
+++ b/packages/ui/src/components/shell/TopicGroup.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+import type * as React from "react";
+import { useClickSuppression } from "../../gestures";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { usePullGesture } from "./use-pull-gesture";
@@ -63,23 +64,11 @@ function TitledTopicGroup({
   // straight back — a real tap/click on the header was a visible no-op
   // (collapse + instant re-expand). The buttons keep their onClick for keyboard
   // activation (Enter/Space), which arrives without a preceding pointer gesture.
-  const suppressClickRef = React.useRef(false);
+  const clickSuppression = useClickSuppression();
   const toggleFromGesture = (next: boolean) => {
-    suppressClickRef.current = true;
-    window.setTimeout(() => {
-      suppressClickRef.current = false;
-    }, 0);
+    clickSuppression.arm();
     onCollapsedChange(next);
   };
-  const suppressGestureClick = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!suppressClickRef.current) return;
-      suppressClickRef.current = false;
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [],
-  );
   const gesture = usePullGesture({
     onTap: () => toggleFromGesture(!collapsed),
     onPullUp: () => toggleFromGesture(true),
@@ -91,7 +80,7 @@ function TitledTopicGroup({
       data-testid="topic-group"
       data-topic={topic}
       data-collapsed={collapsed}
-      onClickCapture={suppressGestureClick}
+      onClickCapture={clickSuppression.onClickCapture}
     >
       {collapsed ? (
         <Button

--- a/packages/ui/src/components/shell/use-notification-pull.ts
+++ b/packages/ui/src/components/shell/use-notification-pull.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { rubberBand, useRafCoalescer } from "../../gestures";
 
 /**
  * iOS-notification-center pull gesture for the home dashboard.
@@ -42,14 +43,11 @@ const REVEAL_OVERSHOOT_RESISTANCE = 0.35;
 /**
  * Map raw finger travel to the reveal offset: 1:1 up to a soft cap, then a
  * damped rubber-band so a long over-pull keeps giving a little without the
- * affordance sliding arbitrarily far down the screen.
+ * affordance sliding arbitrarily far down the screen. Delegates to the shared
+ * {@link rubberBand} recognizer with this surface's tuned soft-cap/resistance.
  */
 export function revealOffsetForTravel(rawDown: number): number {
-  if (rawDown <= 0) return 0;
-  if (rawDown <= REVEAL_SOFT_MAX) return rawDown;
-  return (
-    REVEAL_SOFT_MAX + (rawDown - REVEAL_SOFT_MAX) * REVEAL_OVERSHOOT_RESISTANCE
-  );
+  return rubberBand(rawDown, REVEAL_SOFT_MAX, REVEAL_OVERSHOOT_RESISTANCE);
 }
 
 export interface NotificationPullOptions {
@@ -110,32 +108,11 @@ export function useNotificationPull(options: NotificationPullOptions): {
   const rejected = React.useRef(false);
 
   // Coalesce the high-frequency reveal updates to one per frame.
-  const pending = React.useRef<number | null>(null);
-  const raf = React.useRef(0);
-  const flush = React.useCallback(() => {
-    raf.current = 0;
-    const next = pending.current;
-    pending.current = null;
-    if (next != null) optsRef.current.onReveal(next);
-  }, []);
-  const schedule = React.useCallback(
-    (offset: number) => {
-      pending.current = offset;
-      if (raf.current === 0 && typeof requestAnimationFrame === "function") {
-        raf.current = requestAnimationFrame(flush);
-      } else if (typeof requestAnimationFrame !== "function") {
-        flush();
-      }
-    },
-    [flush],
+  const reveal = useRafCoalescer<number>((offset) =>
+    optsRef.current.onReveal(offset),
   );
-  const cancelScheduled = React.useCallback(() => {
-    if (raf.current !== 0 && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(raf.current);
-    }
-    raf.current = 0;
-    pending.current = null;
-  }, []);
+  const schedule = reveal.schedule;
+  const cancelScheduled = reveal.cancel;
 
   const resetGesture = React.useCallback(() => {
     start.current = null;
@@ -259,7 +236,7 @@ export function useNotificationPull(options: NotificationPullOptions): {
     [onTouchStart, onTouchMove, onTouchEnd, onTouchCancel],
   );
 
-  React.useEffect(() => cancelScheduled, [cancelScheduled]);
+  // (useRafCoalescer cancels its own in-flight frame on unmount.)
 
   return { ref: setRef };
 }

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -1,15 +1,31 @@
 import * as React from "react";
+import {
+  AXIS_COMMIT_SLOP,
+  commitAxis,
+  DEFAULT_PULL_DISTANCE,
+  DEFAULT_PULL_VELOCITY,
+  DEFAULT_SWIPE_DISTANCE,
+  DEFAULT_SWIPE_VELOCITY,
+  HORIZONTAL_DOMINANCE_RATIO,
+  isRealCaptureLoss,
+  resolvePull,
+  resolveSwipe,
+  TAP_SLOP,
+  useRafCoalescer,
+} from "../../gestures";
 
 /**
- * Pull/flick + swipe gesture detection for the homescreen shell.
+ * Pull/flick + swipe gesture detection for the homescreen shell — a thin adapter
+ * over the shared gesture core (`../../gestures`). It wires the pure recognizers
+ * (`resolvePull`/`resolveSwipe`/`commitAxis`), the rAF drag coalescer, and the
+ * lost-capture rule to React pointer handlers.
  *
  * Drives the Claude/Whisper-Flow-style interactions: pull UP on the homescreen
  * to reveal the chat, pull DOWN (or flick up on the voice overlay) to dismiss.
  * Optionally also detects horizontal swipes (left/right) for navigating between
- * conversations when the sheet is open. Pure pointer-event logic — bind the
- * returned handlers to any element. A gesture fires on release when it crosses
- * either a distance OR a velocity threshold, so both deliberate drags and quick
- * flicks register.
+ * conversations when the sheet is open. Bind the returned handlers to any
+ * element. A gesture fires on release when it crosses either a distance OR a
+ * velocity threshold, so both deliberate drags and quick flicks register.
  *
  * Axis lock: the gesture commits to a single axis (vertical OR horizontal) once
  * movement crosses {@link AXIS_COMMIT_SLOP}px, so a horizontal swipe never
@@ -54,14 +70,13 @@ export interface PullGestureOptions {
   velocityThresholdX?: number;
 }
 
-/** Movement (px) under which a release is treated as a tap, not a drag.
- *  Exported so consumers that must classify the browser's compat `click`
- *  (synthesized from the same press) use the SAME tap definition as the
- *  gesture engine — see the HomeScreen notification pull zone. */
-export const PULL_GESTURE_TAP_SLOP = 8;
-const TAP_SLOP = PULL_GESTURE_TAP_SLOP;
-/** Movement (px) at which the gesture commits to a single axis. */
-const AXIS_COMMIT_SLOP = 8;
+/** Movement (px) under which a release is treated as a tap, not a drag. Exported
+ *  so consumers that must classify the browser's compat `click` (synthesized
+ *  from the same press) use the SAME tap definition as the gesture engine — see
+ *  the HomeScreen notification pull zone. Aliases the shared {@link TAP_SLOP}. */
+export const PULL_GESTURE_TAP_SLOP = TAP_SLOP;
+
+export { resolvePull, resolveSwipe };
 
 export interface PullGestureBinding {
   onPointerDown: (event: React.PointerEvent) => void;
@@ -75,56 +90,6 @@ export interface PullGestureBinding {
 }
 
 type GestureAxis = "x" | "y";
-
-/** Decide whether a release should fire a pull, and in which direction. */
-export function resolvePull(
-  deltaUp: number,
-  velocityUp: number,
-  distanceThreshold: number,
-  velocityThreshold: number,
-): "up" | "down" | null {
-  const passed =
-    Math.abs(deltaUp) >= distanceThreshold ||
-    Math.abs(velocityUp) >= velocityThreshold;
-  if (!passed) return null;
-  return deltaUp > 0 ? "up" : "down";
-}
-
-/**
- * Fraction of the vertical travel the horizontal travel must reach to count as a
- * horizontal-dominant swipe (#10715). At 1.0 a swipe had to STRICTLY beat the
- * vertical (a 45° cone), which rejected clearly-horizontal swipes with moderate
- * vertical drift; 0.8 widens the cone to ~51° so a deliberate diagonal commits
- * while a mostly-vertical scroll/pull (horizontal well under 0.8× vertical) does
- * not.
- */
-const HORIZONTAL_DOMINANCE_RATIO = 0.8;
-
-/**
- * Decide whether a release should fire a horizontal swipe, and in which
- * direction. Requires horizontal dominance over the vertical travel so a
- * mostly-vertical drag never registers as a swipe. `deltaLeft` is positive when
- * the finger moved LEFT.
- */
-export function resolveSwipe(
-  deltaLeft: number,
-  velocityLeft: number,
-  deltaUp: number,
-  distanceThresholdX: number,
-  velocityThresholdX: number,
-): "left" | "right" | null {
-  // Horizontal must dominate the vertical component — but not STRICTLY (#10715):
-  // accept a wider (~51°) cone so a deliberate diagonal swipe commits while a
-  // mostly-vertical scroll/pull is still rejected. See HORIZONTAL_DOMINANCE_RATIO.
-  if (Math.abs(deltaLeft) < Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
-    return null;
-  }
-  const passed =
-    Math.abs(deltaLeft) >= distanceThresholdX ||
-    Math.abs(velocityLeft) >= velocityThresholdX;
-  if (!passed) return null;
-  return deltaLeft > 0 ? "left" : "right";
-}
 
 export function usePullGesture(
   options: PullGestureOptions,
@@ -141,10 +106,10 @@ export function usePullGesture(
     onSettleFree,
     onCancel,
     swipeEnabled = true,
-    distanceThreshold = 56,
-    velocityThreshold = 0.5,
-    distanceThresholdX = 64,
-    velocityThresholdX = 0.4,
+    distanceThreshold = DEFAULT_PULL_DISTANCE,
+    velocityThreshold = DEFAULT_PULL_VELOCITY,
+    distanceThresholdX = DEFAULT_SWIPE_DISTANCE,
+    velocityThresholdX = DEFAULT_SWIPE_VELOCITY,
   } = options;
 
   const hasSwipe =
@@ -160,60 +125,32 @@ export function usePullGesture(
     pointerId: number;
   } | null>(null);
   // Which axis the gesture committed to, once it crossed AXIS_COMMIT_SLOP.
-  const axis = React.useRef<"x" | "y" | null>(null);
+  const axis = React.useRef<GestureAxis | null>(null);
   // Last observed pointer position/time while pressed. REAL touch can end a
   // gesture with `pointercancel` (Android's renderer-unresponsive touch
   // pipeline, OS takeover) whose event coordinates are not trustworthy, so the
   // cancel-time commit decision (#9943) reads this tracked position instead.
   const last = React.useRef<{ x: number; y: number; t: number } | null>(null);
 
-  // Coalesce the continuous drag updates to at most one per animation frame.
-  // A trackpad/touch panel emits pointermove well above the display refresh
-  // (up to ~1000Hz), and each call fans out to MotionValue subscribers (vertical
-  // sheet) or a React setState (horizontal swipe `onDragX`) — running that more
-  // than once per painted frame is pure waste (only the last value is shown).
-  // rAF-pacing matches the work to the frame the user actually sees.
-  const pendingDrag = React.useRef<{ axis: GestureAxis; value: number } | null>(
-    null,
-  );
-  const dragRaf = React.useRef(0);
+  // Coalesce the continuous drag updates to at most one per animation frame: a
+  // trackpad/touch panel emits pointermove well above the display refresh, and
+  // each call fans out to a MotionValue subscriber (vertical sheet) or a React
+  // setState (horizontal swipe `onDragX`) — only the last value per frame shows.
   const onDragRef = React.useRef(onDrag);
   const onDragXRef = React.useRef(onDragX);
   onDragRef.current = onDrag;
   onDragXRef.current = onDragX;
-  const flushDrag = React.useCallback(() => {
-    dragRaf.current = 0;
-    const pending = pendingDrag.current;
-    pendingDrag.current = null;
-    if (!pending) return;
-    if (pending.axis === "x") onDragXRef.current?.(pending.value);
-    else onDragRef.current?.(pending.value);
-  }, []);
-  const scheduleDrag = React.useCallback(
-    (nextAxis: GestureAxis, value: number) => {
-      pendingDrag.current = { axis: nextAxis, value };
-      if (
-        dragRaf.current === 0 &&
-        typeof requestAnimationFrame === "function"
-      ) {
-        dragRaf.current = requestAnimationFrame(flushDrag);
-      }
+  const drag = useRafCoalescer<{ axis: GestureAxis; value: number }>(
+    (pending) => {
+      if (pending.axis === "x") onDragXRef.current?.(pending.value);
+      else onDragRef.current?.(pending.value);
     },
-    [flushDrag],
   );
-  const cancelDrag = React.useCallback(() => {
-    if (dragRaf.current !== 0 && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(dragRaf.current);
-    }
-    dragRaf.current = 0;
-    pendingDrag.current = null;
-  }, []);
-  const flushPendingDrag = React.useCallback(() => {
-    if (dragRaf.current !== 0 && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(dragRaf.current);
-    }
-    flushDrag();
-  }, [flushDrag]);
+  const scheduleDrag = React.useCallback(
+    (nextAxis: GestureAxis, value: number) =>
+      drag.schedule({ axis: nextAxis, value }),
+    [drag],
+  );
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent) => {
@@ -254,18 +191,13 @@ export function usePullGesture(
       const dx = s.x - event.clientX; // left positive
 
       if (axis.current === null) {
-        const ax = Math.abs(dx);
-        const ay = Math.abs(dy);
-        if (Math.max(ax, ay) >= AXIS_COMMIT_SLOP) {
-          // Same widened cone as resolveSwipe (#10715): when this binding can
-          // swipe, a deliberate diagonal (horizontal ≥ 0.8× vertical) commits
-          // the X axis. A strict ax > ay here re-narrowed the cone to 45° at
-          // the FIRST 8px of travel, so the exact diagonals the release-time
-          // dominance check was widened for never reached it.
-          const horizontalWins = hasSwipe
-            ? ax >= ay * HORIZONTAL_DOMINANCE_RATIO
-            : ax > ay;
-          axis.current = horizontalWins ? "x" : "y";
+        // Same widened cone as resolveSwipe (#10715): when this binding can
+        // swipe, a deliberate diagonal (horizontal ≥ 0.8× vertical) commits the
+        // X axis. A strict ax > ay would re-narrow the cone to 45° at the first
+        // 8px of travel.
+        const committed = commitAxis(dx, dy, AXIS_COMMIT_SLOP, hasSwipe);
+        if (committed !== null) {
+          axis.current = committed;
           // Take over the pointer now that intent is clear (deferred-capture path).
           if (hasSwipe && !hasVerticalPull) {
             try {
@@ -277,7 +209,7 @@ export function usePullGesture(
           // Reset the other axis's live offset to 0 so the committed axis owns
           // the visual. Drop any pending pre-commit frame first so it can't
           // override the reset on the next tick.
-          cancelDrag();
+          drag.cancel();
           if (axis.current === "x") {
             onDragReset?.();
             if (!hasSwipe) {
@@ -301,7 +233,7 @@ export function usePullGesture(
         scheduleDrag("y", dy); // pre-commit: drive the vertical sheet
       }
     },
-    [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, cancelDrag],
+    [hasSwipe, hasVerticalPull, onDragReset, onDragX, scheduleDrag, drag],
   );
 
   const finish = React.useCallback(
@@ -311,12 +243,11 @@ export function usePullGesture(
       // Apply the latest coalesced drag before deciding the release. Consumers
       // read that live value to choose the nearest detent, and the canceled rAF
       // cannot replay stale motion after the settle below.
-      flushPendingDrag();
+      drag.flush();
       const committedAxis = axis.current;
       start.current = null;
       axis.current = null;
       last.current = null;
-      if (!s) return;
 
       const deltaUp = s.y - event.clientY; // up positive
       const deltaLeft = s.x - event.clientX; // left positive
@@ -385,7 +316,7 @@ export function usePullGesture(
       }
     },
     [
-      flushPendingDrag,
+      drag,
       hasSwipe,
       onDragReset,
       onDragX,
@@ -408,20 +339,19 @@ export function usePullGesture(
       if (!s || s.pointerId !== event.pointerId) return;
       const committedAxis = axis.current;
       const l = last.current;
-      cancelDrag();
+      drag.cancel();
       start.current = null;
       axis.current = null;
       last.current = null;
       // Commit-on-cancel (REAL touch, #9943): Android's touch pipeline can
       // revoke the pointer with `pointercancel` AFTER the finger already
       // completed the flick — the renderer-unresponsive ack timeout or an OS
-      // takeover, which `touch-action: none` on the handle cannot prevent
-      // (it only stops scroll-takeover cancels). If the track we observed
-      // before the cancel already crossed the horizontal swipe threshold on a
-      // horizontal-dominant, non-vertically-committed gesture, honor the swipe
-      // the user performed instead of silently discarding it. The cancel
-      // event's own coordinates are NOT trustworthy (Chromium may report a
-      // stale/zero position), so this reads only the tracked pointermoves.
+      // takeover, which `touch-action: none` on the handle cannot prevent. If
+      // the track we observed before the cancel already crossed the horizontal
+      // swipe threshold on a horizontal-dominant, non-vertically-committed
+      // gesture, honor the swipe the user performed instead of discarding it.
+      // The cancel event's own coordinates are NOT trustworthy (Chromium may
+      // report a stale/zero position), so this reads only the tracked moves.
       if (hasSwipe && committedAxis !== "y" && l) {
         const deltaUp = s.y - l.y; // up positive
         const deltaLeft = s.x - l.x; // left positive
@@ -452,7 +382,7 @@ export function usePullGesture(
       onCancel?.();
     },
     [
-      cancelDrag,
+      drag,
       hasSwipe,
       onDragReset,
       onDragX,
@@ -464,28 +394,16 @@ export function usePullGesture(
     ],
   );
 
-  // A `lostpointercapture` that BUBBLED UP from a descendant (its `target` is
-  // not the element the binding is on) is that child's IMPLICIT touch capture
-  // being handed to US at axis-commit — a swipe that STARTS on an interactive/
-  // selectable child (e.g. a message bubble) gives that child implicit pointer
-  // capture on pointerdown; when the deferred-capture path then calls
-  // `setPointerCapture` on this surface, the child fires `lostpointercapture`,
-  // which bubbles here. Treating it as a cancel (as `onLostPointerCapture:
-  // cancel` did) aborts the swipe the instant it commits, so a genuine
-  // horizontal swipe that began on a bubble self-cancels. Ignore it: only a
-  // capture loss on the bound element ITSELF (`target === currentTarget` —
-  // device rotation / OS takeover, the case this handler exists for) should
-  // settle the gesture.
+  // Only a capture loss on the bound element ITSELF (device rotation / OS
+  // takeover) settles the gesture; a descendant's bubbled loss at axis-commit is
+  // ignored so a swipe that STARTED on a child bubble doesn't self-cancel.
   const lostCapture = React.useCallback(
     (event: React.PointerEvent) => {
-      if (event.target !== event.currentTarget) return;
+      if (!isRealCaptureLoss(event)) return;
       cancel(event);
     },
     [cancel],
   );
-
-  // Cancel any in-flight coalesced frame if the consumer unmounts mid-gesture.
-  React.useEffect(() => cancelDrag, [cancelDrag]);
 
   return {
     onPointerDown,

--- a/packages/ui/src/gestures/constants.ts
+++ b/packages/ui/src/gestures/constants.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared numeric thresholds for the pointer/touch gesture recognizers.
+ *
+ * These are the DEFAULTS. Each surface may still override the values it tunes
+ * (e.g. the notification pull's larger commit distance) by passing explicit
+ * options to its hook — the point of centralizing here is that the un-tuned
+ * knobs share one definition instead of drifting between three copies.
+ */
+
+/** Movement (px) under which a release is treated as a tap, not a drag. Also the
+ *  slop the notification-pull and axis-commit checks share. */
+export const TAP_SLOP = 8;
+
+/** Movement (px) at which a gesture commits to a single (x or y) axis. */
+export const AXIS_COMMIT_SLOP = 8;
+
+/**
+ * Fraction of the vertical travel the horizontal travel must reach to count as a
+ * horizontal-dominant swipe (#10715). At 1.0 a swipe had to STRICTLY beat the
+ * vertical (a 45° cone), which rejected clearly-horizontal swipes with moderate
+ * vertical drift; 0.8 widens the cone to ~51° so a deliberate diagonal commits
+ * while a mostly-vertical scroll/pull (horizontal well under 0.8× vertical) does
+ * not.
+ */
+export const HORIZONTAL_DOMINANCE_RATIO = 0.8;
+
+/** Default minimum vertical travel (px) to count as a pull. */
+export const DEFAULT_PULL_DISTANCE = 56;
+/** Default minimum vertical speed (px/ms) to count as a flick. */
+export const DEFAULT_PULL_VELOCITY = 0.5;
+/** Default minimum horizontal travel (px) to count as a swipe. */
+export const DEFAULT_SWIPE_DISTANCE = 64;
+/** Default minimum horizontal speed (px/ms) to count as a swipe flick. */
+export const DEFAULT_SWIPE_VELOCITY = 0.4;

--- a/packages/ui/src/gestures/gestures.test.ts
+++ b/packages/ui/src/gestures/gestures.test.ts
@@ -1,0 +1,291 @@
+// @vitest-environment jsdom
+//
+// Unit suite for the shared gesture core (#12349): the pure recognizers
+// (resolvePull/resolveSwipe/commitAxis/rubberBand) are exercised as pure math,
+// and the React helper hooks (useRafCoalescer, useClickSuppression,
+// usePressAndHold) are driven with synthetic input to verify their internal
+// contracts (frame coalescing, click swallowing, hold timing). The real browser
+// pointer pipeline is covered by the CDP-touch e2e runners; this is logic-only.
+import { act, renderHook } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AXIS_COMMIT_SLOP } from "./constants";
+import {
+  commitAxis,
+  resolvePull,
+  resolveSwipe,
+  rubberBand,
+} from "./recognizers";
+import { useClickSuppression } from "./useClickSuppression";
+import { DEFAULT_HOLD_MS, usePressAndHold } from "./usePressAndHold";
+import { useRafCoalescer } from "./useRafCoalescer";
+
+const DIST = 56;
+const VEL = 0.5;
+const DIST_X = 64;
+const VEL_X = 0.4;
+
+describe("resolvePull", () => {
+  it("fires up past the distance threshold, down below zero", () => {
+    expect(resolvePull(DIST, 0, DIST, VEL)).toBe("up");
+    expect(resolvePull(-DIST, 0, DIST, VEL)).toBe("down");
+  });
+  it("fires on a fast flick short of the distance", () => {
+    expect(resolvePull(10, VEL, DIST, VEL)).toBe("up");
+    expect(resolvePull(-10, -VEL, DIST, VEL)).toBe("down");
+  });
+  it("does not fire below both thresholds", () => {
+    expect(resolvePull(10, 0.1, DIST, VEL)).toBeNull();
+  });
+});
+
+describe("resolveSwipe", () => {
+  it("requires horizontal dominance (widened 0.8 cone)", () => {
+    // horizontal 64, vertical 50 → 64 >= 50*0.8 (40) → dominant, past distance.
+    expect(resolveSwipe(DIST_X, 0, 50, DIST_X, VEL_X)).toBe("left");
+    // vertical dominates → rejected.
+    expect(resolveSwipe(30, 0, 100, DIST_X, VEL_X)).toBeNull();
+  });
+  it("fires right on leftward-negative travel", () => {
+    expect(resolveSwipe(-DIST_X, 0, 0, DIST_X, VEL_X)).toBe("right");
+  });
+  it("fires on a horizontal flick short of the distance", () => {
+    expect(resolveSwipe(20, VEL_X, 0, DIST_X, VEL_X)).toBe("left");
+  });
+});
+
+describe("commitAxis", () => {
+  it("returns null below the slop", () => {
+    expect(commitAxis(2, 2, AXIS_COMMIT_SLOP, true)).toBeNull();
+  });
+  it("commits x for a dominant-horizontal swipe surface (widened cone)", () => {
+    // ax 10, ay 12 → 10 >= 12*0.8 (9.6) → x on a swipe surface.
+    expect(commitAxis(10, 12, AXIS_COMMIT_SLOP, true)).toBe("x");
+    // strict ax > ay on a non-swipe surface → y (10 < 12).
+    expect(commitAxis(10, 12, AXIS_COMMIT_SLOP, false)).toBe("y");
+  });
+  it("commits y for a dominant-vertical drag", () => {
+    expect(commitAxis(2, 20, AXIS_COMMIT_SLOP, true)).toBe("y");
+  });
+});
+
+describe("rubberBand", () => {
+  it("tracks 1:1 up to the soft cap, then damps the overshoot", () => {
+    expect(rubberBand(0, 96, 0.35)).toBe(0);
+    expect(rubberBand(50, 96, 0.35)).toBe(50);
+    expect(rubberBand(96, 96, 0.35)).toBe(96);
+    // 96 + (196-96)*0.35 = 131.
+    expect(rubberBand(196, 96, 0.35)).toBe(131);
+  });
+  it("clamps negatives to zero", () => {
+    expect(rubberBand(-10, 96, 0.35)).toBe(0);
+  });
+});
+
+describe("useRafCoalescer", () => {
+  let raf: (cb: FrameRequestCallback) => number;
+  let cancel: (h: number) => void;
+  beforeEach(() => {
+    raf = globalThis.requestAnimationFrame;
+    cancel = globalThis.cancelAnimationFrame;
+  });
+  afterEach(() => {
+    globalThis.requestAnimationFrame = raf;
+    globalThis.cancelAnimationFrame = cancel;
+    vi.restoreAllMocks();
+  });
+
+  it("delivers only the latest value once per frame", () => {
+    const frames: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(cb);
+      return frames.length;
+    }) as typeof requestAnimationFrame;
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+    act(() => {
+      result.current.schedule(1);
+      result.current.schedule(2);
+      result.current.schedule(3);
+    });
+    expect(sink).not.toHaveBeenCalled();
+    act(() => {
+      frames[0](0);
+    });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenLastCalledWith(3);
+  });
+
+  it("flush() forces the pending value out immediately", () => {
+    globalThis.requestAnimationFrame = (() =>
+      1) as typeof requestAnimationFrame;
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+    act(() => {
+      result.current.schedule(7);
+      result.current.flush();
+    });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenLastCalledWith(7);
+  });
+
+  it("survives a synchronous rAF (test env inlines the callback)", () => {
+    // A synchronous rAF clears the frame id INSIDE the flush; the coalescer must
+    // not re-mark the frame pending forever (the -1 sentinel guard).
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 42;
+    }) as typeof requestAnimationFrame;
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+    act(() => {
+      result.current.schedule(1);
+    });
+    expect(sink).toHaveBeenLastCalledWith(1);
+    act(() => {
+      result.current.schedule(2);
+    });
+    // The second schedule must still deliver — not be swallowed by a stuck id.
+    expect(sink).toHaveBeenLastCalledWith(2);
+    expect(sink).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs synchronously when requestAnimationFrame is unavailable", () => {
+    globalThis.requestAnimationFrame =
+      undefined as unknown as typeof requestAnimationFrame;
+    const sink = vi.fn();
+    const { result } = renderHook(() => useRafCoalescer<number>(sink));
+    act(() => {
+      result.current.schedule(5);
+    });
+    expect(sink).toHaveBeenCalledWith(5);
+  });
+});
+
+describe("useClickSuppression", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("swallows exactly one synthesized click after arm()", () => {
+    const { result } = renderHook(() => useClickSuppression());
+    const evt = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent;
+    act(() => result.current.arm());
+    act(() => result.current.onClickCapture(evt));
+    expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+    // A second click is NOT swallowed (disarmed on consume).
+    const evt2 = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent;
+    act(() => result.current.onClickCapture(evt2));
+    expect(evt2.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("consumeArmed() returns and clears the armed flag once", () => {
+    const { result } = renderHook(() =>
+      useClickSuppression({ autoDisarm: false }),
+    );
+    act(() => result.current.arm());
+    expect(result.current.consumeArmed()).toBe(true);
+    expect(result.current.consumeArmed()).toBe(false);
+  });
+
+  it("auto-disarms on the next macrotask when enabled", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useClickSuppression());
+    act(() => result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    // The stale arm was cleared — a later unrelated click is NOT swallowed.
+    expect(result.current.consumeArmed()).toBe(false);
+  });
+
+  it("does NOT auto-disarm when autoDisarm is false", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useClickSuppression({ autoDisarm: false }),
+    );
+    act(() => result.current.arm());
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // The arm persists for the trailing click of a touch long-press.
+    expect(result.current.consumeArmed()).toBe(true);
+  });
+});
+
+describe("usePressAndHold", () => {
+  afterEach(() => vi.useRealTimers());
+
+  function touch() {
+    return {} as unknown as React.TouchEvent<HTMLElement>;
+  }
+
+  it("fires onHold after the duration when enabled", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePressAndHold<HTMLElement>({ onHold }),
+    );
+    act(() => result.current.onTouchStart(touch()));
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS + 10);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the hold on touch end/move/cancel", () => {
+    for (const ender of [
+      "onTouchEnd",
+      "onTouchMove",
+      "onTouchCancel",
+    ] as const) {
+      vi.useFakeTimers();
+      const onHold = vi.fn();
+      const { result } = renderHook(() =>
+        usePressAndHold<HTMLElement>({ onHold }),
+      );
+      act(() => result.current.onTouchStart(touch()));
+      act(() => result.current[ender]());
+      act(() => {
+        vi.advanceTimersByTime(DEFAULT_HOLD_MS + 10);
+      });
+      expect(onHold).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    }
+  });
+
+  it("is inert when disabled", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePressAndHold<HTMLElement>({ onHold, enabled: false }),
+    );
+    act(() => result.current.onTouchStart(touch()));
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_HOLD_MS + 10);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+  });
+
+  it("respects a custom durationMs", () => {
+    vi.useFakeTimers();
+    const onHold = vi.fn();
+    const { result } = renderHook(() =>
+      usePressAndHold<HTMLElement>({ onHold, durationMs: 100 }),
+    );
+    act(() => result.current.onTouchStart(touch()));
+    act(() => {
+      vi.advanceTimersByTime(90);
+    });
+    expect(onHold).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+    expect(onHold).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/gestures/index.ts
+++ b/packages/ui/src/gestures/index.ts
@@ -1,0 +1,6 @@
+export * from "./constants";
+export * from "./lost-capture";
+export * from "./recognizers";
+export * from "./useClickSuppression";
+export * from "./usePressAndHold";
+export * from "./useRafCoalescer";

--- a/packages/ui/src/gestures/lost-capture.ts
+++ b/packages/ui/src/gestures/lost-capture.ts
@@ -1,0 +1,18 @@
+/**
+ * Distinguish a real capture loss on the bound element from a descendant's
+ * implicit-capture handoff that merely BUBBLED up.
+ *
+ * `lostpointercapture` bubbles. A swipe that STARTS on an interactive/selectable
+ * child (a message bubble, the notification pull-strip button) gives that child
+ * implicit pointer capture on pointerdown; when the surface then calls
+ * `setPointerCapture` at axis-commit, the child fires `lostpointercapture`, which
+ * bubbles here. Treating that as a cancel aborts the swipe the instant it
+ * commits. Only a capture loss on the bound element ITSELF (`target ===
+ * currentTarget` — device rotation / OS takeover) should settle the gesture.
+ */
+
+import type * as React from "react";
+
+export function isRealCaptureLoss(event: React.PointerEvent): boolean {
+  return event.target === event.currentTarget;
+}

--- a/packages/ui/src/gestures/recognizers.ts
+++ b/packages/ui/src/gestures/recognizers.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure, DOM-free gesture recognizers: given release deltas/velocities, decide
+ * what a pointer gesture resolved to. These are the shared decision core the
+ * pull/pager/notification hooks delegate to, so a single dominance/threshold
+ * rule governs every surface (#12349). No React, no events, no side effects —
+ * directly unit-testable.
+ */
+
+import { HORIZONTAL_DOMINANCE_RATIO } from "./constants";
+
+export type PullDirection = "up" | "down";
+export type SwipeDirection = "left" | "right";
+
+/**
+ * Decide whether a release should fire a pull, and in which direction. `deltaUp`
+ * is positive when the finger moved UP; a pull fires when either the distance or
+ * the velocity threshold is crossed.
+ */
+export function resolvePull(
+  deltaUp: number,
+  velocityUp: number,
+  distanceThreshold: number,
+  velocityThreshold: number,
+): PullDirection | null {
+  const passed =
+    Math.abs(deltaUp) >= distanceThreshold ||
+    Math.abs(velocityUp) >= velocityThreshold;
+  if (!passed) return null;
+  return deltaUp > 0 ? "up" : "down";
+}
+
+/**
+ * Decide whether a release should fire a horizontal swipe, and in which
+ * direction. Requires horizontal dominance over the vertical travel so a
+ * mostly-vertical drag never registers as a swipe. `deltaLeft` is positive when
+ * the finger moved LEFT.
+ */
+export function resolveSwipe(
+  deltaLeft: number,
+  velocityLeft: number,
+  deltaUp: number,
+  distanceThresholdX: number,
+  velocityThresholdX: number,
+): SwipeDirection | null {
+  // Horizontal must dominate the vertical component — but not STRICTLY (#10715):
+  // accept a wider (~51°) cone so a deliberate diagonal swipe commits while a
+  // mostly-vertical scroll/pull is still rejected.
+  if (Math.abs(deltaLeft) < Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO) {
+    return null;
+  }
+  const passed =
+    Math.abs(deltaLeft) >= distanceThresholdX ||
+    Math.abs(velocityLeft) >= velocityThresholdX;
+  if (!passed) return null;
+  return deltaLeft > 0 ? "left" : "right";
+}
+
+/**
+ * Which axis a gesture commits to once travel crosses the slop, or `null` while
+ * still ambiguous. `canSwipe` selects the widened diagonal cone (a horizontal
+ * swipe surface) versus a strict `ax > ay` (vertical-only pull). Used both at the
+ * mid-gesture commit and to derive the axis from release deltas when the browser
+ * coalesced every move into the release (#9943).
+ */
+export function commitAxis(
+  deltaLeft: number,
+  deltaUp: number,
+  slop: number,
+  canSwipe: boolean,
+): "x" | "y" | null {
+  const ax = Math.abs(deltaLeft);
+  const ay = Math.abs(deltaUp);
+  if (Math.max(ax, ay) < slop) return null;
+  const horizontalWins = canSwipe
+    ? ax >= ay * HORIZONTAL_DOMINANCE_RATIO
+    : ax > ay;
+  return horizontalWins ? "x" : "y";
+}
+
+/**
+ * Damped rubber-band: track travel 1:1 up to `softMax`, then apply `resistance`
+ * to the overshoot so a long over-pull keeps giving a little without sliding
+ * arbitrarily far. Shared by the notification reveal and the pager edge.
+ */
+export function rubberBand(
+  travel: number,
+  softMax: number,
+  resistance: number,
+): number {
+  if (travel <= 0) return 0;
+  if (travel <= softMax) return travel;
+  return softMax + (travel - softMax) * resistance;
+}

--- a/packages/ui/src/gestures/useClickSuppression.ts
+++ b/packages/ui/src/gestures/useClickSuppression.ts
@@ -1,0 +1,68 @@
+/**
+ * Swallow the compat `click` the browser synthesizes from a committed pointer
+ * gesture (a swipe/flick/long-press), so the same press doesn't also tap-launch
+ * the element under the release point.
+ *
+ * One mechanism for every consumer (pager, topic-group toggle, conversation
+ * long-press): call `arm()` when the gesture commits, attach `onClickCapture` to
+ * the same element as the pointer handlers. The arm auto-disarms on a microtask
+ * so a genuine later click is never eaten; it also disarms the instant it
+ * swallows one synthesized click.
+ */
+
+import * as React from "react";
+
+export interface ClickSuppressionOptions {
+  /**
+   * When true (default), an `arm()` that is never followed by a synthesized
+   * click auto-disarms on the next macrotask, so a stale arm can't eat an
+   * unrelated later click. Surfaces whose synthesized click arrives as a
+   * SEPARATE native event after `arm()` (a touch long-press, where the click
+   * may land a full task later) pass `false` and rely on consume-on-click only.
+   */
+  autoDisarm?: boolean;
+}
+
+export interface ClickSuppression {
+  /** Mark that a gesture just committed — the next synthesized click is swallowed. */
+  arm: () => void;
+  /** Attach to the gesture element's `onClickCapture`. */
+  onClickCapture: (event: React.MouseEvent) => void;
+  /** Read (and consume) the armed state directly, for handlers that own their
+   *  own onClick and must decide inline whether to no-op. */
+  consumeArmed: () => boolean;
+}
+
+export function useClickSuppression(
+  options: ClickSuppressionOptions = {},
+): ClickSuppression {
+  const { autoDisarm = true } = options;
+  const armed = React.useRef(false);
+  const autoDisarmRef = React.useRef(autoDisarm);
+  autoDisarmRef.current = autoDisarm;
+
+  const arm = React.useCallback(() => {
+    armed.current = true;
+    if (!autoDisarmRef.current) return;
+    // Auto-disarm on a macrotask so a later, unrelated click is never eaten if
+    // no synthesized click arrives (some gesture ends produce none).
+    setTimeout(() => {
+      armed.current = false;
+    }, 0);
+  }, []);
+
+  const onClickCapture = React.useCallback((event: React.MouseEvent) => {
+    if (!armed.current) return;
+    armed.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const consumeArmed = React.useCallback(() => {
+    if (!armed.current) return false;
+    armed.current = false;
+    return true;
+  }, []);
+
+  return { arm, onClickCapture, consumeArmed };
+}

--- a/packages/ui/src/gestures/usePressAndHold.ts
+++ b/packages/ui/src/gestures/usePressAndHold.ts
@@ -1,0 +1,68 @@
+/**
+ * Touch press-and-hold (long-press) recognizer. A stationary finger held past
+ * `durationMs` fires `onHold`; any touch end/cancel/move before then aborts.
+ * Pairs with click-suppression so the tap the browser synthesizes after a hold
+ * doesn't also fire the element's plain onClick (see useClickSuppression).
+ *
+ * DOM-free logic behind React touch handlers so a consumer just spreads the
+ * returned handlers onto its element; the timer is cleared on unmount.
+ */
+
+import * as React from "react";
+
+/** iOS-style long-press threshold. */
+export const DEFAULT_HOLD_MS = 450;
+
+export interface PressAndHoldOptions<E extends HTMLElement> {
+  /** Fired when the finger is held past `durationMs` without lifting/moving. */
+  onHold: (event: React.TouchEvent<E>) => void;
+  /** Hold duration (ms) before `onHold` fires. Default {@link DEFAULT_HOLD_MS}. */
+  durationMs?: number;
+  /** When false, the recognizer is inert (e.g. desktop, where context-menu owns it). */
+  enabled?: boolean;
+}
+
+export interface PressAndHoldBinding<E extends HTMLElement> {
+  onTouchStart: (event: React.TouchEvent<E>) => void;
+  onTouchEnd: () => void;
+  onTouchMove: () => void;
+  onTouchCancel: () => void;
+}
+
+export function usePressAndHold<E extends HTMLElement>({
+  onHold,
+  durationMs = DEFAULT_HOLD_MS,
+  enabled = true,
+}: PressAndHoldOptions<E>): PressAndHoldBinding<E> {
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onHoldRef = React.useRef(onHold);
+  onHoldRef.current = onHold;
+
+  const clear = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => clear, [clear]);
+
+  const onTouchStart = React.useCallback(
+    (event: React.TouchEvent<E>) => {
+      if (!enabled) return;
+      clear();
+      timerRef.current = setTimeout(() => {
+        clear();
+        onHoldRef.current(event);
+      }, durationMs);
+    },
+    [clear, durationMs, enabled],
+  );
+
+  return {
+    onTouchStart,
+    onTouchEnd: clear,
+    onTouchMove: clear,
+    onTouchCancel: clear,
+  };
+}

--- a/packages/ui/src/gestures/useRafCoalescer.ts
+++ b/packages/ui/src/gestures/useRafCoalescer.ts
@@ -1,0 +1,96 @@
+/**
+ * rAF-paced value coalescer for high-frequency gesture updates.
+ *
+ * A trackpad/touch panel emits pointer/touch moves well above the display
+ * refresh (up to ~1000Hz), and each drag update fans out to a MotionValue
+ * subscriber, a React setState, or a direct rail write — running that more than
+ * once per painted frame is pure waste (only the last value is shown). This
+ * schedules at most one flush per animation frame and always delivers the LATEST
+ * pending value. `schedule` batches; `flush` forces the pending value out now (a
+ * release must apply the final drag before deciding); `cancel` drops it.
+ *
+ * When `requestAnimationFrame` is unavailable (SSR / some test envs) the flush
+ * runs synchronously so callers never lose the final value.
+ */
+
+import * as React from "react";
+
+export interface RafCoalescer<T> {
+  /** Queue `value`; it is delivered to the sink on the next animation frame. */
+  schedule: (value: T) => void;
+  /** If a frame is pending, run it NOW (cancels the queued frame first). */
+  flush: () => void;
+  /** Drop any pending frame + value without delivering it. */
+  cancel: () => void;
+}
+
+// Read fresh per call (not a module-load const): SSR/jsdom without a stub, or a
+// test that toggles the global, must be observed at the moment of use.
+function raf(cb: FrameRequestCallback): number | null {
+  return typeof requestAnimationFrame === "function"
+    ? requestAnimationFrame(cb)
+    : null;
+}
+function cancelRaf(handle: number): void {
+  if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(handle);
+}
+
+/**
+ * `sink` receives the coalesced value once per frame. Pass a ref-backed callback
+ * (or a stable one) so the coalescer's own identity never changes between
+ * renders — the returned object is stable for the component's lifetime.
+ */
+export function useRafCoalescer<T>(sink: (value: T) => void): RafCoalescer<T> {
+  const sinkRef = React.useRef(sink);
+  sinkRef.current = sink;
+
+  const pending = React.useRef<{ value: T } | null>(null);
+  const rafId = React.useRef(0);
+
+  const flushNow = React.useCallback(() => {
+    rafId.current = 0;
+    const next = pending.current;
+    pending.current = null;
+    if (next) sinkRef.current(next.value);
+  }, []);
+
+  const schedule = React.useCallback(
+    (value: T) => {
+      pending.current = { value };
+      if (rafId.current !== 0) return; // a frame is already pending
+      // Mark the frame pending BEFORE scheduling: a synchronous rAF (some test
+      // envs run the callback inline) clears rafId inside flushNow, and assigning
+      // the returned handle afterwards would re-mark the frame as pending forever
+      // — swallowing every later value of the gesture.
+      rafId.current = -1;
+      const handle = raf(flushNow);
+      if (handle === null) {
+        // No rAF available (SSR / jsdom without a stub): deliver synchronously so
+        // the caller never loses the value. flushNow already reset rafId to 0.
+        if (rafId.current === -1) {
+          rafId.current = 0;
+          flushNow();
+        }
+        return;
+      }
+      if (rafId.current === -1) rafId.current = handle;
+    },
+    [flushNow],
+  );
+
+  const flush = React.useCallback(() => {
+    if (rafId.current > 0) cancelRaf(rafId.current);
+    flushNow();
+  }, [flushNow]);
+
+  const cancel = React.useCallback(() => {
+    if (rafId.current > 0) cancelRaf(rafId.current);
+    rafId.current = 0;
+    pending.current = null;
+  }, []);
+
+  // Drop any in-flight frame if the consumer unmounts mid-gesture.
+  React.useEffect(() => cancel, [cancel]);
+
+  return { schedule, flush, cancel };
+}

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -1,5 +1,13 @@
 import * as React from "react";
+import {
+  isRealCaptureLoss,
+  useClickSuppression,
+  useRafCoalescer,
+} from "../gestures";
 
+// Per-surface tuned overrides (deliberately tighter than the shared pull
+// defaults): the launcher rail commits its axis at a shorter slop and requires
+// stronger horizontal dominance than the vertical-pull surfaces (#12349).
 const AXIS_COMMIT_SLOP = 6;
 const AXIS_DOMINANCE_RATIO = 1.15;
 const MIN_DISTANCE_THRESHOLD = 64;
@@ -228,12 +236,9 @@ export function useHorizontalPager<
   const viewportRef = React.useRef<TViewport | null>(null);
   const railRef = React.useRef<HTMLDivElement | null>(null);
   const dragRef = React.useRef<DragState | null>(null);
-  const rafRef = React.useRef(0);
-  const pendingOffsetRef = React.useRef<number | null>(null);
-  // Set true for one tick when a gesture commits, so the click the browser
-  // synthesizes from the same press is swallowed (onClickCapture below) instead
-  // of tap-launching the element under the finger.
-  const suppressClickRef = React.useRef(false);
+  // Swallow the click the browser synthesizes from a committed swipe/flick so it
+  // can't also tap-launch the element under the release point.
+  const clickSuppression = useClickSuppression();
   // A committed swipe advances the page via onPageChange, which re-runs the
   // layout effect below — so the velocity-derived settle duration is handed to
   // that effect here (instead of the fixed SETTLE_MS) so the momentum survives
@@ -275,41 +280,13 @@ export function useHorizontalPager<
     [],
   );
 
-  const flushOffset = React.useCallback(() => {
-    rafRef.current = 0;
-    const offset = pendingOffsetRef.current;
-    pendingOffsetRef.current = null;
-    if (offset == null) return;
-    writeOffset(offset, null);
-  }, [writeOffset]);
-
-  const scheduleOffset = React.useCallback(
-    (offset: number) => {
-      pendingOffsetRef.current = offset;
-      if (rafRef.current !== 0) return;
-      if (typeof requestAnimationFrame === "function") {
-        // Mark the frame pending BEFORE scheduling: a synchronous rAF (test
-        // environments run the callback inline) clears rafRef inside
-        // flushOffset, and assigning the returned handle afterwards would
-        // re-mark the frame as pending forever — swallowing every later
-        // offset of the gesture.
-        rafRef.current = -1;
-        const handle = requestAnimationFrame(flushOffset);
-        if (rafRef.current === -1) rafRef.current = handle;
-        return;
-      }
-      flushOffset();
-    },
-    [flushOffset],
+  // Live pointer movement writes directly to the rail transform (no transition),
+  // paced by rAF so a drag never waits on React render scheduling.
+  const railWrite = useRafCoalescer<number>((offset) =>
+    writeOffset(offset, null),
   );
-
-  const cancelScheduledOffset = React.useCallback(() => {
-    if (rafRef.current !== 0 && typeof cancelAnimationFrame === "function") {
-      cancelAnimationFrame(rafRef.current);
-    }
-    rafRef.current = 0;
-    pendingOffsetRef.current = null;
-  }, []);
+  const scheduleOffset = railWrite.schedule;
+  const cancelScheduledOffset = railWrite.cancel;
 
   const canMove = React.useCallback((state: DragState, dx: number) => {
     if (dx < 0) return state.page < pageCountRef.current - 1;
@@ -388,7 +365,7 @@ export function useHorizontalPager<
     return () => observer.disconnect();
   }, [measureWidth, writeOffset]);
 
-  React.useEffect(() => cancelScheduledOffset, [cancelScheduledOffset]);
+  // (useRafCoalescer cancels its own in-flight frame on unmount.)
 
   const finish = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>, cancelled = false) => {
@@ -476,10 +453,7 @@ export function useHorizontalPager<
         };
         // A committed page change is a gesture commit — swallow the synthesized
         // click so the flick doesn't also tap-launch the element under it.
-        suppressClickRef.current = true;
-        setTimeout(() => {
-          suppressClickRef.current = false;
-        }, 0);
+        clickSuppression.arm();
         onPageChangeRef.current(targetPage);
       } else {
         // Already at the clamped edge — settle directly (no page change fires).
@@ -489,6 +463,7 @@ export function useHorizontalPager<
     [
       canMove,
       cancelScheduledOffset,
+      clickSuppression,
       measureWidth,
       releaseCapture,
       visualDragOffset,
@@ -634,23 +609,10 @@ export function useHorizontalPager<
   // for mouse/pen only, so a genuine loss still has target === currentTarget.
   const onLostPointerCapture = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.target !== event.currentTarget) return;
+      if (!isRealCaptureLoss(event)) return;
       finish(event, true);
     },
     [finish],
-  );
-
-  // Swallow the click a committed swipe/flick synthesizes (armed in finish() on
-  // page-change commits) so it can't tap-launch the element under the release
-  // point. One mechanism for every consumer.
-  const onClickCapture = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!suppressClickRef.current) return;
-      suppressClickRef.current = false;
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [],
   );
 
   const clampedPage = clampPage(page, pageCount);
@@ -664,7 +626,7 @@ export function useHorizontalPager<
       onPointerUp,
       onPointerCancel,
       onLostPointerCapture,
-      onClickCapture,
+      onClickCapture: clickSuppression.onClickCapture,
     },
     canPrev: clampedPage > 0,
     canNext: clampedPage < pageCount - 1,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -459,6 +459,7 @@ export {
   shouldReportFrameBudget,
   summarizeFrameSamples,
 } from "./hooks/frame-budget";
+export * from "./gestures";
 export * from "./hooks/index";
 export type { ActivityEvent } from "./hooks/useActivityEvents";
 export { useActivityEvents } from "./hooks/useActivityEvents";


### PR DESCRIPTION
Parent: #12188. Phase 2 of the gesture-consolidation work.

## What changed

Adds `packages/ui/src/gestures/` as the single home for pointer/touch gesture logic, and turns the three gesture hooks into thin adapters over it. Public APIs are unchanged; per-surface tuned thresholds are preserved as explicit overrides (never silent behavior changes).

**New shared core (`packages/ui/src/gestures/`):**
- `constants.ts` — tap/axis slop, horizontal-dominance ratio, per-surface default distance/velocity thresholds.
- `recognizers.ts` — pure, DOM-free `resolvePull` / `resolveSwipe` / `commitAxis` / `rubberBand`.
- `useRafCoalescer.ts` — one rAF-paced coalescer (delivers the latest value per frame; carries the synchronous-rAF `-1` sentinel guard that the pager needed, and falls back to synchronous delivery when rAF is unavailable).
- `useClickSuppression.ts` — swallow the compat `click` a committed gesture synthesizes (arm + `onClickCapture` + `consumeArmed`; `autoDisarm` opt-out for the touch long-press path whose trailing click lands a task later).
- `usePressAndHold.ts` — touch long-press recognizer.
- `lost-capture.ts` — `isRealCaptureLoss` (bound-element loss vs a descendant's bubbled implicit-capture handoff).

**Adapters (public API stable):**
- `use-pull-gesture` — delegates axis/pull/swipe decisions to the recognizers, drag pacing to the coalescer, and the lost-capture rule to the helper. Still exports `resolvePull`, `resolveSwipe`, `PULL_GESTURE_TAP_SLOP`, `usePullGesture`.
- `use-notification-pull` — `revealOffsetForTravel` now delegates to `rubberBand`; reveal pacing via the coalescer. Exports unchanged.
- `useHorizontalPager` — rAF pacing, click-suppression, and lost-capture routed through the shared helpers; keeps its **tuned** `AXIS_COMMIT_SLOP=6` / `AXIS_DOMINANCE_RATIO=1.15` as explicit per-surface overrides. Exports `useHorizontalPager`, `getVelocityAwarePagerTransitionMs`.
- `chat-conversation-item` — one-off long-press timer + click-suppress → shared hooks.
- `TopicGroup` — inline click-suppress → shared hook.

Consolidates: 3 rAF coalescer copies, 3 click-suppression copies, the one-off long-press timer, 2 lost-capture guards, and the duplicated axis/dominance/tap constants.

## Done-when checklist
- [x] The three existing gesture hooks are thin adapters over the shared core.
- [x] One-off long-press, click-suppression, and rAF copies consolidated where in scope.
- [x] Launcher call-site changes remain compatible with #12179 — `HomeLauncherSurface` still calls `useHorizontalPager` with the same options; the mechanics regression gate (which keys on the `useHorizontalPager` name + touch-action pin) passes.
- [x] Tuned per-surface thresholds preserved as explicit overrides.

## Verification
- New `packages/ui/src/gestures/gestures.test.ts` — 23 unit tests covering the pure recognizers (pull/swipe/commit-axis/rubber-band math), the rAF coalescer (latest-per-frame, forced flush, synchronous-rAF safety, no-rAF fallback), click-suppression (single swallow, consume-once, auto-disarm on/off), and press-and-hold (fire/cancel/disabled/custom duration).
- `bun run --cwd packages/ui test` on all touched suites: **81 passed** (gestures core, use-pull-gesture, use-notification-pull, useHorizontalPager x2, chat-conversation-item, mechanics-regression-gate).
- `biome check` on all touched files: clean.
- `tsc` (packages/ui): no new type errors introduced. (Pre-existing, unrelated: 4 missing generated `validation-keyword-data` modules in core/shared i18n + 1 missing `iwer` dep — these require a build step not run in this worktree and also make `HomeLauncherSurface.composed.test.tsx` fail to resolve its import; unaffected by this change, resolved by CI's build.)

Closes #12349