### PR TITLE
refactor(#12411): declare command wire contract once in @elizaos/shared

### DIFF
--- a/packages/agent/src/tui/slash-commands.test.ts
+++ b/packages/agent/src/tui/slash-commands.test.ts
@@ -25,6 +25,8 @@ function makeCommand(
     surfaces: overrides.surfaces,
     target: overrides.target ?? { kind: "agent" },
     icon: overrides.icon,
+    source: overrides.source ?? "builtin",
+    views: overrides.views,
   };
 }
 
@@ -204,10 +206,39 @@ describe("resolveSlashDispatch", () => {
     });
   });
 
+  it("sends toggle-transcription to the agent (shared client action, no TUI behavior)", () => {
+    // toggle-transcription was missing from the old hand-synced TUI union; it is
+    // now part of the shared ClientCommandAction and must route like any other
+    // client action the terminal can't run locally (#12411).
+    const command = makeCommand({
+      key: "transcription",
+      target: { kind: "client", clientAction: "toggle-transcription" },
+    });
+    expect(
+      resolveSlashDispatch({ command, args: "" }, "/transcription"),
+    ).toEqual({ kind: "send", text: "/transcription" });
+  });
+
+  it("carries source and views through the shared wire contract", () => {
+    // source and views are shared-contract fields the old TUI copy dropped; the
+    // TUI must accept them without a type error (#12411).
+    const command = makeCommand({
+      key: "calendar",
+      source: "custom-action",
+      views: ["calendar"],
+    });
+    expect(command.source).toBe("custom-action");
+    expect(command.views).toEqual(["calendar"]);
+  });
+
   it("navigates to a pinned view id", () => {
     const command = makeCommand({
       key: "orchestrator",
-      target: { kind: "navigate", viewId: "orchestrator" },
+      target: {
+        kind: "navigate",
+        path: "/orchestrator",
+        viewId: "orchestrator",
+      },
     });
     expect(
       resolveSlashDispatch({ command, args: "" }, "/orchestrator"),
@@ -217,7 +248,7 @@ describe("resolveSlashDispatch", () => {
   it("navigates to a view id resolved from a /views <id> argument", () => {
     const command = makeCommand({
       key: "views",
-      target: { kind: "navigate" },
+      target: { kind: "navigate", path: "/views" },
       acceptsArgs: true,
       args: [{ name: "view", description: "View", dynamicChoices: "views" }],
     });
@@ -229,7 +260,12 @@ describe("resolveSlashDispatch", () => {
   it("sends tab/settings navigation to the agent (no terminal equivalent)", () => {
     const command = makeCommand({
       key: "settings",
-      target: { kind: "navigate", tab: "settings", section: "ai-model" },
+      target: {
+        kind: "navigate",
+        path: "/settings",
+        tab: "settings",
+        section: "ai-model",
+      },
     });
     expect(resolveSlashDispatch({ command, args: "" }, "/settings")).toEqual({
       kind: "send",

--- a/packages/agent/src/tui/slash-commands.ts
+++ b/packages/agent/src/tui/slash-commands.ts
@@ -2,75 +2,25 @@
  * Pure helpers that bridge the universal slash-command catalog (served by
  * `GET /api/commands?surface=tui`) into the terminal composer.
  *
- * The catalog item shape mirrors the server's `SerializedCommand`
- * (@elizaos/plugin-commands). We keep a local copy of the transport type so
- * the TUI does not take a runtime dependency on the commands plugin, matching
- * how the web client (`@elizaos/ui` `client-types-commands`) keeps its own.
+ * The wire contract (`SerializedCommand*`, `CommandsCatalogResponse`) is the
+ * one declared in `@elizaos/shared`; this module imports it rather than keeping
+ * a hand-synced copy, which is what fixes the prior TUI drift (a stale `target`
+ * union, a `string` `category`, and missing `toggle-transcription`/`source`/
+ * `views` — #12411). The agent already depends on `@elizaos/shared`.
  *
  * Everything here is pure (no terminal, no I/O) so it is unit-testable. The
  * side effects (HTTP, transcript mutation) live in `agent-terminal-tui.ts`.
  */
 
+import type { CommandArgSource, SerializedCommand } from "@elizaos/shared";
 import type { AutocompleteItem, SlashCommand } from "@elizaos/tui";
 
-export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
-
-export type CommandArgSource =
-  | "models"
-  | "views"
-  | "settings-sections"
-  | "skills"
-  | "providers";
-
-export type ClientCommandAction =
-  | "clear-chat"
-  | "new-conversation"
-  | "toggle-fullscreen"
-  | "open-command-palette"
-  | "show-commands";
-
-export interface SerializedCommandArg {
-  name: string;
-  description: string;
-  required?: boolean;
-  choices?: string[];
-  dynamicChoices?: CommandArgSource;
-  captureRemaining?: boolean;
-}
-
-export type SerializedCommandTarget =
-  | { kind: "agent"; action?: string }
-  | {
-      kind: "navigate";
-      tab?: string;
-      viewId?: string;
-      path?: string;
-      section?: string;
-    }
-  | { kind: "client"; clientAction: ClientCommandAction };
-
-export interface SerializedCommand {
-  key: string;
-  nativeName: string;
-  description: string;
-  textAliases: string[];
-  scope: "text" | "native" | "both";
-  category?: string;
-  acceptsArgs: boolean;
-  args: SerializedCommandArg[];
-  requiresAuth: boolean;
-  requiresElevated: boolean;
-  surfaces?: CommandSurface[];
-  target: SerializedCommandTarget;
-  icon?: string;
-}
-
-export interface CommandsCatalogResponse {
-  commands: SerializedCommand[];
-  surface: string | null;
-  agentId: string | null;
-  generatedAt: string;
-}
+export type {
+  CommandArgSource,
+  CommandsCatalogResponse,
+  SerializedCommand,
+  SerializedCommandArg,
+} from "@elizaos/shared";
 
 /**
  * The display name for a command (no leading slash). Prefers the first text

--- a/packages/shared/src/api/command-transport-types.ts
+++ b/packages/shared/src/api/command-transport-types.ts
@@ -1,0 +1,85 @@
+/**
+ * Canonical wire contract for the universal slash-command catalog served by
+ * `GET /api/commands`. This is the single declaration of the command transport
+ * shape — the projection `serializeCommand` produces, the TUI autocomplete
+ * consumes, the web composer renders, and the connector bridges forward.
+ *
+ * The domain vocabulary (`CommandScope`, `CommandCategory`, `CommandSurface`,
+ * `CommandArgSource`, `ClientCommandAction`, `CommandTarget`) lives in
+ * `@elizaos/core` alongside `CommandDefinition`; those types are re-exported
+ * here so every wire consumer references one enum/union and cannot drift (the
+ * TUI previously carried a hand-synced copy that lost `toggle-transcription`,
+ * the `source` field, `views`, and the strong `category` union — #12411).
+ *
+ * Kept in the shared api layer next to `agent-api-types` so agent, UI, TUI, and
+ * `@elizaos/plugin-commands` import one contract without a runtime dependency
+ * on the plugin.
+ */
+
+import type {
+  CommandArgSource,
+  CommandCategory,
+  CommandScope,
+  CommandSurface,
+  CommandTarget,
+} from "@elizaos/core";
+
+export type {
+  ClientCommandAction,
+  CommandArgSource,
+  CommandCategory,
+  CommandScope,
+  CommandSurface,
+  CommandTarget,
+} from "@elizaos/core";
+
+/**
+ * Wire-safe argument shape produced by `serializeCommand`. Static `choices` are
+ * inlined; `dynamicChoices` names a live source the client resolves at render
+ * time (function-valued definition choices drop to their tagged source).
+ */
+export interface SerializedCommandArg {
+  name: string;
+  description: string;
+  required?: boolean;
+  choices?: string[];
+  dynamicChoices?: CommandArgSource;
+  captureRemaining?: boolean;
+}
+
+/** Where a serialized catalog item came from — drives menu grouping/labels. */
+export type SerializedCommandSource = "builtin" | "custom-action" | "saved";
+
+/**
+ * The wire shape `GET /api/commands` serves and every client renders. Produced
+ * by `serializeCommand` (`@elizaos/plugin-commands`) with no field fabricated at
+ * the HTTP boundary. `target` is the `@elizaos/core` `CommandTarget` discriminant
+ * every surface routes on.
+ */
+export interface SerializedCommand {
+  key: string;
+  nativeName: string;
+  description: string;
+  textAliases: string[];
+  scope: CommandScope;
+  category?: CommandCategory;
+  acceptsArgs: boolean;
+  args: SerializedCommandArg[];
+  requiresAuth: boolean;
+  requiresElevated: boolean;
+  surfaces?: CommandSurface[];
+  target: CommandTarget;
+  icon?: string;
+  source: SerializedCommandSource;
+  /** View ids this command is scoped to (#8798); omitted when global. */
+  views?: string[];
+}
+
+/** Response body of `GET /api/commands`. */
+export interface CommandsCatalogResponse {
+  commands: SerializedCommand[];
+  surface: string | null;
+  activeViewId?: string | null;
+  agentId: string | null;
+  generatedAt: string;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./api/agent-api-types.js";
+export * from "./api/command-transport-types.js";
 export * from "./api/http-helpers.js";
 export * from "./api/route-helpers.js";
 // Leaf modules (no internal collisions)

--- a/packages/ui/src/api/client-types-commands.ts
+++ b/packages/ui/src/api/client-types-commands.ts
@@ -1,70 +1,33 @@
 /**
  * Transport types for the universal slash-command catalog served by
- * `GET /api/commands` (mirrors the connector-neutral catalog in
- * @elizaos/plugin-commands). Kept in the api layer so both the client method
- * and the chat menu share one contract without the api depending on UI code.
+ * `GET /api/commands`. The wire contract is declared once in `@elizaos/shared`
+ * (`SerializedCommand*`); the `SlashCommand*` names below are the UI-local
+ * aliases the chat menu and client method use. Aliasing (not re-declaring) is
+ * what keeps this surface from drifting off the shared contract (#12411).
  */
 
-export type CommandSurface = "gui" | "tui" | "discord" | "telegram";
+import type {
+  SerializedCommand,
+  SerializedCommandArg,
+  SerializedCommandSource,
+} from "@elizaos/shared";
 
-export type CommandArgSource =
-  | "models"
-  | "views"
-  | "settings-sections"
-  | "skills"
-  | "providers";
+export type {
+  ClientCommandAction,
+  CommandArgSource,
+  CommandSurface,
+  CommandsCatalogResponse,
+  CommandTarget as SlashCommandTarget,
+  SerializedCommand,
+  SerializedCommandArg,
+  SerializedCommandSource,
+} from "@elizaos/shared";
 
-export type ClientCommandAction =
-  | "clear-chat"
-  | "new-conversation"
-  | "toggle-fullscreen"
-  | "open-command-palette"
-  | "show-commands"
-  | "toggle-transcription";
+/** UI-local alias for the wire argument shape. */
+export type SlashCommandArg = SerializedCommandArg;
 
-export interface SlashCommandArg {
-  name: string;
-  description: string;
-  required?: boolean;
-  choices?: string[];
-  dynamicChoices?: CommandArgSource;
-  captureRemaining?: boolean;
-}
+/** UI-local alias for a catalog item's provenance. */
+export type SlashCommandSource = SerializedCommandSource;
 
-export type SlashCommandTarget =
-  | { kind: "agent"; action?: string }
-  | {
-      kind: "navigate";
-      tab?: string;
-      viewId?: string;
-      path?: string;
-      section?: string;
-    }
-  | { kind: "client"; clientAction: ClientCommandAction };
-
-/** Where a catalog item came from — drives grouping + labels in the menu. */
-export type SlashCommandSource = "builtin" | "custom-action" | "saved";
-
-export interface SlashCommandCatalogItem {
-  key: string;
-  nativeName: string;
-  description: string;
-  textAliases: string[];
-  scope: "text" | "native" | "both";
-  category?: string;
-  acceptsArgs: boolean;
-  args: SlashCommandArg[];
-  requiresAuth: boolean;
-  requiresElevated: boolean;
-  surfaces?: CommandSurface[];
-  target: SlashCommandTarget;
-  icon?: string;
-  source?: SlashCommandSource;
-}
-
-export interface CommandsCatalogResponse {
-  commands: SlashCommandCatalogItem[];
-  surface: string | null;
-  agentId: string | null;
-  generatedAt: string;
-}
+/** UI-local alias for a wire catalog item. */
+export type SlashCommandCatalogItem = SerializedCommand;

--- a/packages/ui/src/chat/slash-menu.fail-closed.test.ts
+++ b/packages/ui/src/chat/slash-menu.fail-closed.test.ts
@@ -26,6 +26,7 @@ function cmd(
     requiresElevated: partial.requiresElevated ?? false,
     target: partial.target ?? { kind: "agent" },
     ...partial,
+    source: partial.source ?? "builtin",
   };
 }
 

--- a/packages/ui/src/chat/slash-menu.surface-auth.test.ts
+++ b/packages/ui/src/chat/slash-menu.surface-auth.test.ts
@@ -16,6 +16,7 @@ function cmd(
     requiresElevated: partial.requiresElevated ?? false,
     target: partial.target ?? { kind: "agent" },
     ...partial,
+    source: partial.source ?? "builtin",
   };
 }
 

--- a/packages/ui/src/chat/slash-menu.test.ts
+++ b/packages/ui/src/chat/slash-menu.test.ts
@@ -30,6 +30,7 @@ function cmd(
     requiresElevated: partial.requiresElevated ?? false,
     target: partial.target ?? { kind: "agent" },
     ...partial,
+    source: partial.source ?? "builtin",
   };
 }
 

--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -68,6 +68,7 @@ function cmd(
     requiresElevated: false,
     target: { kind: "agent" },
     ...partial,
+    source: partial.source ?? "builtin",
   };
 }
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.slash.test.tsx
@@ -63,6 +63,7 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     target: { kind: "navigate", tab: "settings", path: "/settings" },
+    source: "builtin",
   },
   {
     key: "orchestrator",
@@ -75,6 +76,7 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     target: { kind: "navigate", viewId: "orchestrator", path: "/orchestrator" },
+    source: "builtin",
   },
   {
     key: "clear",
@@ -88,6 +90,7 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresElevated: false,
     surfaces: ["gui", "tui"],
     target: { kind: "client", clientAction: "clear-chat" },
+    source: "builtin",
   },
   {
     key: "help",
@@ -100,6 +103,7 @@ const COMMANDS: SlashCommandCatalogItem[] = [
     requiresAuth: false,
     requiresElevated: false,
     target: { kind: "agent" },
+    source: "builtin",
   },
 ];
 

--- a/plugins/plugin-commands/package.json
+++ b/plugins/plugin-commands/package.json
@@ -49,7 +49,8 @@
 		}
 	},
 	"dependencies": {
-		"@elizaos/core": "workspace:*"
+		"@elizaos/core": "workspace:*",
+		"@elizaos/shared": "workspace:*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.2",

--- a/plugins/plugin-commands/src/types.ts
+++ b/plugins/plugin-commands/src/types.ts
@@ -2,21 +2,12 @@
  * Command system types
  */
 
-import type {
-	CommandArgSource,
-	CommandCategory,
-	CommandDefinition,
-	CommandScope,
-	CommandSurface,
-	CommandTarget,
-	HandlerCallback,
-	Memory,
-} from "@elizaos/core";
+import type { CommandDefinition, HandlerCallback, Memory } from "@elizaos/core";
 
-// The canonical command contract lives in @elizaos/core so hosts and other
-// plugins can register/read commands through the runtime service without
-// importing this plugin. Re-exported here for existing intra-package and
-// downstream `@elizaos/plugin-commands` consumers.
+// The canonical command *definition* contract lives in @elizaos/core so hosts
+// and other plugins can register/read commands through the runtime service
+// without importing this plugin. Re-exported here for existing intra-package
+// and downstream `@elizaos/plugin-commands` consumers.
 export type {
 	ClientCommandAction,
 	CommandArgChoiceContext,
@@ -29,47 +20,15 @@ export type {
 	CommandTarget,
 } from "@elizaos/core";
 
-/**
- * Wire-safe argument shape produced by `serializeCommand`. Mirrors the client
- * (`@elizaos/ui` `SlashCommandArg`) and TUI (`SerializedCommandArg`) transport
- * types so all three consume one shape with no fabricated fields.
- */
-export interface SerializedCommandArg {
-	name: string;
-	description: string;
-	required?: boolean;
-	choices?: string[];
-	dynamicChoices?: CommandArgSource;
-	captureRemaining?: boolean;
-}
-
-/** Where a serialized catalog item came from — drives menu grouping/labels. */
-export type SerializedCommandSource = "builtin" | "custom-action" | "saved";
-
-/**
- * The canonical wire shape served by `GET /api/commands` and consumed by the
- * web composer (`SlashCommandCatalogItem`), the TUI autocomplete
- * (`SerializedCommand`), and the connector bridges. This is the single contract
- * the route projects — no field is fabricated at the HTTP boundary.
- */
-export interface SerializedCommand {
-	key: string;
-	nativeName: string;
-	description: string;
-	textAliases: string[];
-	scope: CommandScope;
-	category?: CommandCategory;
-	acceptsArgs: boolean;
-	args: SerializedCommandArg[];
-	requiresAuth: boolean;
-	requiresElevated: boolean;
-	surfaces?: CommandSurface[];
-	target: CommandTarget;
-	icon?: string;
-	source: SerializedCommandSource;
-	/** View ids this command is scoped to (#8798); omitted when global. */
-	views?: string[];
-}
+// The wire transport contract (`SerializedCommand*`) is declared once in
+// @elizaos/shared and consumed by every surface — the TUI, the UI client, and
+// the connector bridges — so no hand-synced copy can drift (#12411). Re-exported
+// here so `serializeCommand` and downstream plugin consumers keep one import.
+export type {
+	SerializedCommand,
+	SerializedCommandArg,
+	SerializedCommandSource,
+} from "@elizaos/shared";
 
 export interface CommandContext {
 	senderId?: string;


### PR DESCRIPTION
## What & why

The `SerializedCommand` transport type was declared **three times** — in `@elizaos/plugin-commands`, the UI client types (`@elizaos/ui`), and the agent TUI — and the copies had drifted. The TUI copy in particular:

- kept its own `SerializedCommandTarget` union instead of the core `CommandTarget`,
- typed `category` as a bare `string` (not the `CommandCategory` union),
- made `navigate.path` optional (the real contract requires it),
- was **missing** the `toggle-transcription` client action, the required `source` field, and `views`.

This publishes the wire contract **once** from `@elizaos/shared` and points every surface at it.

## Changes

- **New:** `packages/shared/src/api/command-transport-types.ts` — the single declaration of `SerializedCommand`, `SerializedCommandArg`, `SerializedCommandSource`, and `CommandsCatalogResponse`. It re-uses the domain vocabulary (`CommandTarget`, `ClientCommandAction`, `CommandScope`, `CommandCategory`, `CommandSurface`, `CommandArgSource`) from `@elizaos/core` (shared already depends on core — same pattern as `agent-api-types.ts`). Exported from the shared barrel.
- **plugin-commands** `src/types.ts` re-exports `SerializedCommand*` from `@elizaos/shared` (adds `@elizaos/shared` as a workspace dependency); still barrels them via `index.ts` for downstream `@elizaos/plugin-commands` consumers. `serialize.ts` / `connector-catalog.ts` are unchanged (they import from `./types`).
- **UI** `src/api/client-types-commands.ts` keeps its `SlashCommand*` names as thin **aliases** of the shared types instead of re-declaring them.
- **Agent TUI** `src/tui/slash-commands.ts` imports the shared types and drops its hand-synced copies (drift fixed). Helpers unchanged; `resolveSlashDispatch` already routes unknown client actions to the agent, so `toggle-transcription` is handled.
- **Tests** updated to the tightened contract (required `source`, required `navigate.path`) across the TUI + UI builders, plus two new TUI cases asserting `toggle-transcription` routing and `source`/`views` flow-through.

## Done when

- [x] The command transport type is declared once — only in `packages/shared/src/api/command-transport-types.ts` (verified: `grep -rn "interface SerializedCommand\b"` returns only the shared file).
- [x] TUI, UI, and plugin-commands compile against the same wire contract (scoped typechecks below).
- [x] No hand-synced command type copies remain (no `SlashCommandCatalogItem` / `SerializedCommandTarget` re-declarations; TUI no longer declares `toggle-fullscreen`/`navigate` unions).

## Verification (scoped — worktree shares parent node_modules)

- `bun run --cwd packages/shared typecheck` → **0 errors**
- `bun run --cwd plugins/plugin-commands typecheck` → **0 errors**
- `bun run --cwd packages/agent typecheck` → **0 errors**
- `bun run --cwd packages/ui typecheck` → clean for command files (one pre-existing unrelated `iwer` missing-dep error already on `develop`)
- `biome check` on all 11 touched files → clean
- Tests (vitest, live path):
  - plugin-commands `serialize.test.ts` → **13 passed**
  - agent `tui/slash-commands.test.ts` → **21 passed** (incl. new `toggle-transcription` + `source`/`views` cases)
  - UI `slash-menu.test.ts`, `slash-menu.surface-auth.test.ts`, `slash-menu.fail-closed.test.ts`, `useSlashCommandController.catalog.test.ts`, `ContinuousChatOverlay.slash.test.tsx` → **70 passed**

Closes #12411

🤖 Generated with [Claude Code](https://claude.com/claude-code)