### PR TITLE
fix(core): clarify conversation-history provider descriptions (#12404)

### DIFF
--- a/.github/issue-evidence/12404-conversation-history-provider-descriptions.md
+++ b/.github/issue-evidence/12404-conversation-history-provider-descriptions.md
@@ -1,0 +1,24 @@
+# Issue 12404 Evidence
+
+## Scope
+
+Reconciled conversation-history-adjacent provider descriptions without changing
+provider names, contexts, gates, data shape, or runtime behavior.
+
+## Verification
+
+- `bun run --cwd packages/core test -- src/features/basic-capabilities/providers/provider-descriptions.test.ts src/features/basic-capabilities/providers/platformContext.test.ts src/features/basic-capabilities/providers/recentMessages.test.ts`
+  - Result: 3 files passed, 19 tests passed.
+- `bun run --cwd packages/shared build:i18n`
+  - Result: generated core/shared validation keyword data needed by typecheck.
+- `bun run --cwd packages/cloud/routing build`
+  - Result: built linked workspace types needed by core typecheck.
+- `bun run --cwd packages/core typecheck`
+  - Result: passed.
+
+## Artifact Notes
+
+- Live-LLM trajectory: N/A. Metadata-only provider description cleanup; no model
+  routing behavior or prompt assembly logic changed.
+- Screenshots/video/native capture: N/A. No UI, device, or runtime view changed.
+- Backend logs: N/A. No service execution path changed.

--- a/packages/core/src/features/autonomy/providers.ts
+++ b/packages/core/src/features/autonomy/providers.ts
@@ -27,7 +27,7 @@ const MAX_AUTONOMY_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export const adminChatProvider: Provider = {
 	name: "ADMIN_CHAT_HISTORY",
 	description:
-		"Provides recent conversation history with the admin user for autonomous context",
+		"Autonomy-only admin control-room history: a short window of admin messages used when the autonomous loop is running.",
 	contexts: ["admin", "settings"],
 	contextGate: { anyOf: ["admin", "settings"] },
 	cacheStable: false,

--- a/packages/core/src/features/basic-capabilities/providers/platformContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/platformContext.ts
@@ -282,9 +282,9 @@ function normalizeUserContext(
 export const platformChatContextProvider: Provider = {
 	name: PLATFORM_CHAT_CONTEXT_PROVIDER_NAME,
 	description:
-		"Current platform chat context from registered message connectors.",
+		"Connector-specific room metadata for the current platform target, including source, channel/thread identifiers, summaries, and output guidance; not the canonical transcript.",
 	descriptionCompressed:
-		"Current chat/room context from relevant message connector hooks.",
+		"Connector room metadata and output guidance; not the canonical transcript.",
 	dynamic: true,
 	position: 125,
 	contexts: PLATFORM_CONTEXTS,
@@ -384,9 +384,9 @@ export const platformChatContextProvider: Provider = {
 export const platformUserContextProvider: Provider = {
 	name: PLATFORM_USER_CONTEXT_PROVIDER_NAME,
 	description:
-		"Current platform user/contact identity from registered message connectors.",
+		"Connector-specific sender identity metadata for the current platform user/contact, including handles, aliases, and account labels; not conversation history.",
 	descriptionCompressed:
-		"Current user/contact identity from relevant message connector hooks.",
+		"Connector sender identity and handles; not conversation history.",
 	dynamic: true,
 	position: 126,
 	contexts: PLATFORM_CONTEXTS,

--- a/packages/core/src/features/basic-capabilities/providers/provider-descriptions.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/provider-descriptions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { adminChatProvider } from "../../autonomy/providers.ts";
+import {
+	platformChatContextProvider,
+	platformUserContextProvider,
+} from "./platformContext.ts";
+import { recentMessagesProvider } from "./recentMessages.ts";
+
+vi.mock("../../autonomy/service.ts", () => ({
+	AUTONOMY_SERVICE_TYPE: "AUTONOMY_SERVICE",
+}));
+
+describe("conversation-history provider descriptions", () => {
+	it("keeps current-room transcript, connector context, user identity, and admin history distinct", () => {
+		const providers = [
+			recentMessagesProvider,
+			platformChatContextProvider,
+			platformUserContextProvider,
+			adminChatProvider,
+		];
+
+		expect(providers.map((provider) => provider.name)).toEqual([
+			"RECENT_MESSAGES",
+			"PLATFORM_CHAT_CONTEXT",
+			"PLATFORM_USER_CONTEXT",
+			"ADMIN_CHAT_HISTORY",
+		]);
+
+		const descriptions = providers.map((provider) =>
+			(provider.description ?? "").trim(),
+		);
+		expect(new Set(descriptions).size).toBe(descriptions.length);
+
+		expect(recentMessagesProvider.description).toContain(
+			"Canonical bounded transcript for the current room",
+		);
+		expect(platformChatContextProvider.description).toContain(
+			"Connector-specific room metadata",
+		);
+		expect(platformChatContextProvider.description).toContain(
+			"not the canonical transcript",
+		);
+		expect(platformUserContextProvider.description).toContain(
+			"Connector-specific sender identity metadata",
+		);
+		expect(platformUserContextProvider.description).toContain(
+			"not conversation history",
+		);
+		expect(adminChatProvider.description).toContain(
+			"Autonomy-only admin control-room history",
+		);
+	});
+});

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -3491,11 +3491,11 @@ export const coreProvidersSpec = {
 		{
 			name: "RECENT_MESSAGES",
 			description:
-				"Provides recent message history from the current conversation including formatted messages, posts, action results, and recent interactions",
+				"Canonical bounded transcript for the current room, including prior dialogue, post-style turns, action results, and cross-room recent interactions for memory continuity",
 			position: 100,
 			dynamic: true,
 			descriptionCompressed:
-				"Recent conversation messages, posts, action results.",
+				"Canonical current-room transcript: dialogue, posts, action results, recent interactions.",
 		},
 		{
 			name: "ACTION_STATE",
@@ -3663,11 +3663,11 @@ export const allProvidersSpec = {
 		{
 			name: "RECENT_MESSAGES",
 			description:
-				"Provides recent message history from the current conversation including formatted messages, posts, action results, and recent interactions",
+				"Canonical bounded transcript for the current room, including prior dialogue, post-style turns, action results, and cross-room recent interactions for memory continuity",
 			position: 100,
 			dynamic: true,
 			descriptionCompressed:
-				"Recent conversation messages, posts, action results.",
+				"Canonical current-room transcript: dialogue, posts, action results, recent interactions.",
 		},
 		{
 			name: "ACTION_STATE",

--- a/packages/prompts/specs/providers/core.json
+++ b/packages/prompts/specs/providers/core.json
@@ -16,10 +16,10 @@
     },
     {
       "name": "RECENT_MESSAGES",
-      "description": "Provides recent message history from the current conversation including formatted messages, posts, action results, and recent interactions",
+      "description": "Canonical bounded transcript for the current room, including prior dialogue, post-style turns, action results, and cross-room recent interactions for memory continuity",
       "position": 100,
       "dynamic": true,
-      "descriptionCompressed": "Recent conversation messages, posts, action results."
+      "descriptionCompressed": "Canonical current-room transcript: dialogue, posts, action results, recent interactions."
     },
     {
       "name": "ACTION_STATE",


### PR DESCRIPTION
## Summary

Closes #12404.

- clarifies `RECENT_MESSAGES` as the canonical bounded current-room transcript in the hand-maintained prompts provider spec and regenerated core docs
- distinguishes `PLATFORM_CHAT_CONTEXT` as connector room metadata/output guidance and `PLATFORM_USER_CONTEXT` as connector sender identity/handles
- narrows `ADMIN_CHAT_HISTORY` wording to autonomy-only admin control-room history
- adds a focused provider metadata assertion so the descriptions stay distinct without changing provider names or behavior
- adds issue evidence at `.github/issue-evidence/12404-conversation-history-provider-descriptions.md`

## Verification

- `bunx @biomejs/biome check packages/prompts/specs/providers/core.json packages/core/src/features/autonomy/providers.ts packages/core/src/features/basic-capabilities/providers/platformContext.ts packages/core/src/features/basic-capabilities/providers/provider-descriptions.test.ts packages/core/src/generated/action-docs.ts .github/issue-evidence/12404-conversation-history-provider-descriptions.md`
- `bun run --cwd packages/core test -- src/features/basic-capabilities/providers/provider-descriptions.test.ts src/features/basic-capabilities/providers/platformContext.test.ts src/features/basic-capabilities/providers/recentMessages.test.ts`
- `bun run --cwd packages/shared build:i18n`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/core typecheck`

## Evidence

- Live-LLM trajectory: N/A, metadata-only provider description cleanup; no model routing behavior or prompt assembly logic changed.
- Screenshots/video/native capture: N/A, no UI/device/runtime view changed.
- Backend logs: N/A, no service execution path changed.
