### PR TITLE
refactor(core,shared): single-source name-token + recent-messages helpers (#12093 item 7)

### DIFF
--- a/packages/core/src/actions/recent-context.ts
+++ b/packages/core/src/actions/recent-context.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger";
+import { getRecentMessagesData } from "../recent-messages-state";
 import type { IAgentRuntime, Memory, State } from "../types";
 
 // Match any speaker prefix pattern: "word:" or "word word:" at the start of a line.
@@ -6,21 +7,6 @@ import type { IAgentRuntime, Memory, State } from "../types";
 // rather than hardcoding specific English role names.
 const STATE_SPEAKER_PREFIX_RE =
 	/^[a-zA-Z\u00C0-\u024F\u0400-\u04FF\u3000-\u9FFF]{1,20}\s*:\s*/;
-
-/**
- * Read the recent-messages memory array that `recentMessagesProvider` writes
- * into `state.data.providers.RECENT_MESSAGES.data.recentMessages`.
- *
- * This is the canonical path — the provider system does not populate any
- * other location. Inlined here (rather than imported from `@elizaos/shared`)
- * because `@elizaos/core` does not depend on `@elizaos/shared`, and `shared`
- * depends on `core`; importing it would create a package cycle.
- */
-function getRecentMessagesData(state: State | undefined): Memory[] {
-	const messages =
-		state?.data?.providers?.RECENT_MESSAGES?.data?.recentMessages;
-	return Array.isArray(messages) ? (messages as Memory[]) : [];
-}
 
 function normalizeConversationLine(value: string): string {
 	return value.replace(STATE_SPEAKER_PREFIX_RE, "").trim();

--- a/packages/core/src/features/plugin-manager/providers/relevance.ts
+++ b/packages/core/src/features/plugin-manager/providers/relevance.ts
@@ -1,22 +1,10 @@
+import { getRecentMessagesData } from "../../../recent-messages-state.ts";
 import type { Memory } from "../../../types/memory.ts";
 import type { State } from "../../../types/state.ts";
 import {
 	validateActionKeywords as coreValidateActionKeywords,
 	validateActionRegex as coreValidateActionRegex,
 } from "../../../validation/keywords.ts";
-
-/**
- * Read the recent-messages memory array that `recentMessagesProvider` writes
- * into `state.data.providers.RECENT_MESSAGES.data.recentMessages`.
- *
- * Inlined from @elizaos/shared to avoid a cross-package type import that
- * breaks tsc declaration emit (rootDir constraint).
- */
-function getRecentMessagesData(state: State | undefined): Memory[] {
-	const messages =
-		state?.data?.providers?.RECENT_MESSAGES?.data?.recentMessages;
-	return Array.isArray(messages) ? (messages as Memory[]) : [];
-}
 
 const IGNORED_PLUGIN_NAME_TOKENS = new Set([
 	"app",

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -90,7 +90,12 @@ export * from "./messaging/interactions";
 // Vendor-neutral model-gateway resolution (#11536 E1). Pure string logic, no
 // Node deps, so it is browser-safe and exported from both barrels.
 export * from "./model-gateway";
+// Pure isomorphic helpers (string token substitution + a state accessor).
+// Canonical owner is `@elizaos/core`; `@elizaos/shared` re-exports them from
+// this barrel so browser consumers resolve the same implementation.
+export * from "./name-tokens";
 export * from "./prompts";
+export * from "./recent-messages-state";
 export * from "./roles";
 export * from "./runtime";
 export { warnOnUnmatchedActionRolePolicyKeys } from "./runtime/action-role-policy";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -163,6 +163,7 @@ export * from "./memory";
 export * from "./messaging/interactions";
 export * from "./mobile-device-bridge-service";
 export * from "./model-gateway";
+export * from "./name-tokens";
 // Export network utilities (SSRF protection, secure fetch)
 export * from "./network";
 export { getOptimizationRootDir } from "./optimization-root-dir";
@@ -177,6 +178,7 @@ export * from "./providers/setup-progress";
 export * from "./providers/skill-eligibility";
 // Provisioning (migrations, agent/entity/room, embedding dimension) - node only
 export * from "./provisioning";
+export * from "./recent-messages-state";
 export * from "./roles";
 export * from "./runtime";
 export {

--- a/packages/core/src/name-tokens.test.ts
+++ b/packages/core/src/name-tokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { replaceNameTokens } from "./name-tokens";
+import { getRecentMessagesData } from "./recent-messages-state";
+import type { Memory, State } from "./types";
+
+/**
+ * Canonical `@elizaos/core` isomorphic helpers that `@elizaos/shared` (and, via
+ * shared, `@elizaos/ui`) re-export. These cases pin the behavior that the two
+ * former hand-inlined copies previously handled differently — whitespace inside
+ * the token braces and `$`-sequences in user-entered names.
+ */
+describe("replaceNameTokens (canonical core impl)", () => {
+	it("replaces both token spellings", () => {
+		expect(replaceNameTokens("Hi {{name}}, aka {{agentName}}.", "Momo")).toBe(
+			"Hi Momo, aka Momo.",
+		);
+	});
+
+	it("tolerates whitespace inside the braces", () => {
+		// The pre-consolidation core copy (system-prompt.ts) allowed whitespace;
+		// the shared copy did not. The reconciled impl accepts both.
+		expect(replaceNameTokens("Hi {{ name }}!", "Momo")).toBe("Hi Momo!");
+		expect(replaceNameTokens("yo {{  agentName  }}", "Momo")).toBe("yo Momo");
+	});
+
+	it("inserts names containing $-sequences literally", () => {
+		expect(replaceNameTokens("hello {{name}}", "Cash$$")).toBe("hello Cash$$");
+		expect(replaceNameTokens("hello {{name}}", "M$&M")).toBe("hello M$&M");
+		expect(replaceNameTokens("yo {{agentName}}", "A$AP")).toBe("yo A$AP");
+	});
+
+	it("returns falsey input unchanged", () => {
+		expect(replaceNameTokens("", "Momo")).toBe("");
+	});
+});
+
+describe("getRecentMessagesData (canonical core impl)", () => {
+	const memory = { id: "m1" } as unknown as Memory;
+
+	it("reads the canonical provider path", () => {
+		const state = {
+			data: {
+				providers: {
+					RECENT_MESSAGES: { data: { recentMessages: [memory] } },
+				},
+			},
+		} as unknown as State;
+		expect(getRecentMessagesData(state)).toEqual([memory]);
+	});
+
+	it("returns [] when the path is absent, undefined, or not an array", () => {
+		expect(getRecentMessagesData(undefined)).toEqual([]);
+		expect(getRecentMessagesData({} as State)).toEqual([]);
+		const bad = {
+			data: { providers: { RECENT_MESSAGES: { data: { recentMessages: 7 } } } },
+		} as unknown as State;
+		expect(getRecentMessagesData(bad)).toEqual([]);
+	});
+});

--- a/packages/core/src/name-tokens.ts
+++ b/packages/core/src/name-tokens.ts
@@ -1,0 +1,22 @@
+/**
+ * Replace un-substituted `{{name}}` / `{{agentName}}` tokens with the actual
+ * character name. Whitespace inside the braces (`{{ name }}`) is tolerated so
+ * hand-authored and setup-preset templates resolve identically.
+ *
+ * Canonical owner lives here in `@elizaos/core`: setup-preset characters ship
+ * `{{name}}` / `{{agentName}}` tokens in `system` / `bio` (PR #7101 preserves
+ * them on save so renames propagate), so the prompt builder must resolve them
+ * before forwarding text to the model. `@elizaos/shared` (and, through it,
+ * `@elizaos/ui`) re-exports this so preview tooling and the model see the same
+ * substitution.
+ *
+ * A replacer function is used (not the raw `name` string) so `$`-sequences in a
+ * name (e.g. "Cash$$", "M$&M") are inserted literally instead of being read as
+ * `String.replace` substitution patterns (`$&`, `$1`, `$$`).
+ */
+export function replaceNameTokens(text: string, name: string): string {
+	if (!text) return text;
+	return text
+		.replace(/\{\{\s*name\s*\}\}/g, () => name)
+		.replace(/\{\{\s*agentName\s*\}\}/g, () => name);
+}

--- a/packages/core/src/recent-messages-state.ts
+++ b/packages/core/src/recent-messages-state.ts
@@ -1,0 +1,16 @@
+import type { Memory, State } from "./types";
+
+/**
+ * Read the recent-messages memory array that `recentMessagesProvider` writes
+ * into `state.data.providers.RECENT_MESSAGES.data.recentMessages`.
+ *
+ * This is the canonical path — the provider system does not populate any other
+ * location. Canonical owner lives here in `@elizaos/core`; `@elizaos/shared`
+ * re-exports it so agent/plugin callers share one accessor. Don't reinvent this
+ * access in each caller.
+ */
+export function getRecentMessagesData(state: State | undefined): Memory[] {
+	const messages =
+		state?.data?.providers?.RECENT_MESSAGES?.data?.recentMessages;
+	return Array.isArray(messages) ? (messages as Memory[]) : [];
+}

--- a/packages/core/src/runtime/system-prompt.ts
+++ b/packages/core/src/runtime/system-prompt.ts
@@ -1,3 +1,4 @@
+import { replaceNameTokens } from "../name-tokens";
 import type { Character } from "../types/agent";
 import type { RoleGateRole } from "../types/contexts";
 import type { ChatMessage } from "../types/model";
@@ -27,22 +28,6 @@ export function normalizeSystemPromptRole(
 	return normalized || undefined;
 }
 
-// Mirrors `@elizaos/shared/src/utils/name-tokens.ts:replaceNameTokens`.
-// Inlined because `@elizaos/core` does not depend on `@elizaos/shared` at
-// runtime. Setup-preset characters ship with `{{name}}` / `{{agentName}}`
-// tokens in `system` and `bio` (PR #7101 deliberately preserves them on save
-// so renames propagate), so the canonical prompt builder must resolve them
-// before forwarding text to the model.
-function substituteNamePlaceholders(value: string, name: string): string {
-	if (!value) return value;
-	// Replacer functions, not the raw `name` string: `$`-sequences in a name
-	// (e.g. "Cash$$", "M$&M") are otherwise read as String.replace substitution
-	// patterns (`$&`, `$1`, `$$`) and corrupt the rendered name.
-	return value
-		.replace(/\{\{\s*name\s*\}\}/g, () => name)
-		.replace(/\{\{\s*agentName\s*\}\}/g, () => name);
-}
-
 export function buildCanonicalSystemPrompt(args: {
 	character?: Pick<Character, "name" | "system" | "bio"> | null;
 	userRole?: RoleGateRole | string | null;
@@ -52,14 +37,11 @@ export function buildCanonicalSystemPrompt(args: {
 		typeof character?.name === "string" && character.name.trim()
 			? character.name.trim()
 			: "the agent";
-	const system = substituteNamePlaceholders(
+	const system = replaceNameTokens(
 		typeof character?.system === "string" ? character.system.trim() : "",
 		name,
 	);
-	const bio = substituteNamePlaceholders(
-		renderSystemPromptBio(character?.bio),
-		name,
-	);
+	const bio = replaceNameTokens(renderSystemPromptBio(character?.bio), name);
 	const role = normalizeSystemPromptRole(args.userRole);
 	return [
 		system,

--- a/packages/shared/src/recent-messages-state.ts
+++ b/packages/shared/src/recent-messages-state.ts
@@ -1,14 +1,6 @@
-import type { Memory, State } from "@elizaos/core";
-
-/**
- * Read the recent-messages memory array that `recentMessagesProvider` writes
- * into `state.data.providers.RECENT_MESSAGES.data.recentMessages`.
- *
- * This is the canonical path — the provider system does not populate any
- * other location. Don't reinvent this access in each caller.
- */
-export function getRecentMessagesData(state: State | undefined): Memory[] {
-  const messages =
-    state?.data?.providers?.RECENT_MESSAGES?.data?.recentMessages;
-  return Array.isArray(messages) ? (messages as Memory[]) : [];
-}
+// `getRecentMessagesData` is owned by `@elizaos/core` (canonical accessor for
+// the `state.data.providers.RECENT_MESSAGES.data.recentMessages` array) and
+// re-exported here so agent/plugin consumers keep their `@elizaos/shared`
+// import path. The core symbol is exported from both the node and browser
+// barrels, so this re-export resolves in browser bundles too.
+export { getRecentMessagesData } from "@elizaos/core";

--- a/packages/shared/src/utils/name-tokens.test.ts
+++ b/packages/shared/src/utils/name-tokens.test.ts
@@ -23,6 +23,18 @@ describe("replaceNameTokens", () => {
     expect(replaceNameTokens("hello {{name}}", "M$&M")).toBe("hello M$&M");
     expect(replaceNameTokens("yo {{agentName}}", "A$AP")).toBe("yo A$AP");
   });
+
+  it("tolerates whitespace inside the braces (reconciled canonical behavior)", () => {
+    // The pre-consolidation shared copy required tight `{{name}}`; the core
+    // copy allowed `{{ name }}`. The single canonical impl is whitespace-
+    // tolerant so both spellings resolve the same everywhere.
+    expect(replaceNameTokens("Hi {{ name }}!", "Momo")).toBe("Hi Momo!");
+    expect(replaceNameTokens("Hi {{  agentName  }}!", "Momo")).toBe("Hi Momo!");
+  });
+
+  it("returns empty/falsey input unchanged", () => {
+    expect(replaceNameTokens("", "Momo")).toBe("");
+  });
 });
 
 describe("tokenizeNameOccurrences", () => {

--- a/packages/shared/src/utils/name-tokens.ts
+++ b/packages/shared/src/utils/name-tokens.ts
@@ -1,15 +1,9 @@
-/**
- * Replace un-substituted `{{name}}` / `{{agentName}}` tokens with the
- * actual character name. Handles legacy persisted templates from first-run setup.
- */
-export function replaceNameTokens(text: string, name: string): string {
-  // Use a replacer function so `$`-sequences in the name (e.g. "Cash$$",
-  // "$&") are inserted literally instead of being interpreted as
-  // String.replace substitution patterns.
-  return text
-    .replace(/\{\{name\}\}/g, () => name)
-    .replace(/\{\{agentName\}\}/g, () => name);
-}
+// `replaceNameTokens` is owned by `@elizaos/core` (canonical `{{name}}` /
+// `{{agentName}}` substitution — whitespace-tolerant, `$`-sequence safe) and
+// re-exported here so existing `@elizaos/shared` / `@elizaos/ui` consumers keep
+// their import path. The core symbol is exported from both the node and browser
+// barrels, so this re-export resolves in browser bundles too.
+export { replaceNameTokens } from "@elizaos/core";
 
 /**
  * Reverse of `replaceNameTokens` — rewrite whole-word occurrences of the


### PR DESCRIPTION
## What

Deletes core's three hand-inlined mirrors of `@elizaos/shared` helpers and makes `@elizaos/core` the canonical owner, following the existing `env-utils.ts` re-export pattern. Closes #12093 item 7 (Refs #12093).

Before, core carried private copies of two shared helpers (because core must not depend on shared), and they had **drifted**: core's `substituteNamePlaceholders` accepted `{{ name }}` (whitespace-tolerant) while shared's `replaceNameTokens` only matched tight `{{name}}` — so the model saw a different substitution than the UI preview.

## Changes

- **New canonical core modules**, exported from both `index.node.ts` and `index.browser.ts`:
  - `packages/core/src/name-tokens.ts` — `replaceNameTokens`
  - `packages/core/src/recent-messages-state.ts` — `getRecentMessagesData`
- **Deleted 3 inlined mirrors** in core:
  - `runtime/system-prompt.ts` — dropped local `substituteNamePlaceholders`, now imports `replaceNameTokens`
  - `actions/recent-context.ts` — dropped local `getRecentMessagesData`
  - `features/plugin-manager/providers/relevance.ts` — dropped local `getRecentMessagesData`
- **`@elizaos/shared` re-exports** both from `@elizaos/core` (`utils/name-tokens.ts` keeps `tokenizeNameOccurrences` local; `recent-messages-state.ts` becomes a re-export). `@elizaos/ui` keeps resolving `replaceNameTokens` through shared unchanged.
- **Drift reconciled to ONE implementation**: whitespace-tolerant (`{{ name }}` and `{{name}}` both resolve) and `$`-sequence-safe (replacer functions so names like `Cash$$`, `M$&M`, `A$AP` insert literally). This is the only intended behavior change — the whitespace-tolerant superset that core already used.

## Done-when (grep-verifiable)

- `grep 'function replaceNameTokens' packages plugins` → exactly 1 (core).
- `grep 'function getRecentMessagesData' packages plugins` → exactly 1 (core).
- shared re-exports both via `export { … } from "@elizaos/core"`.

## Verification

- `bun run --cwd packages/core typecheck` → clean (tsgo).
- `bun run --cwd packages/ui typecheck` → clean (browser consumer resolves the re-export through shared's barrel).
- `bun run --cwd packages/{core,shared} build` → pass.
- Tests: new `packages/core/src/name-tokens.test.ts` (6 tests: whitespace + `$`-sequence + accessor edges) and extended `packages/shared/src/utils/name-tokens.test.ts` (7 tests, now exercising the reconciled canonical impl through shared's re-export) — both green. `runtime/__tests__/system-prompt.test.ts` (8 tests) green.

Pre-existing failures unrelated to this change (confirmed identical to develop): `packages/shared/src/views/view-interact-protocol.test.ts` typecheck error (from the item-2 `STANDARD_CAPABILITIES`/`AGENT_SURFACE_CAPABILITY_IDS` migration) and agent's unbuilt-optional-plugin module-resolution errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)