### PR TITLE
refactor(#12410): decouple app-core Node barrel from React UI internals

### DIFF
--- a/packages/app-core/src/api/automation-action-classifier.ts
+++ b/packages/app-core/src/api/automation-action-classifier.ts
@@ -1,5 +1,5 @@
 import { type Action, hasActionTags } from "@elizaos/core";
-import type { AutomationNodeDescriptor } from "@elizaos/ui";
+import type { AutomationNodeDescriptor } from "@elizaos/shared";
 
 const AGENT_AUTOMATION_ACTION_TAGS = [
   "domain:agent-orchestration",

--- a/packages/app-core/src/api/automation-node-contributors.ts
+++ b/packages/app-core/src/api/automation-node-contributors.ts
@@ -1,6 +1,6 @@
 import type { loadElizaConfig } from "@elizaos/agent";
 import type { AgentRuntime, UUID } from "@elizaos/core";
-import type { AutomationNodeDescriptor } from "@elizaos/ui";
+import type { AutomationNodeDescriptor } from "@elizaos/shared";
 
 export interface AutomationNodeContributorContext {
   runtime: AgentRuntime;

--- a/packages/app-core/src/api/automations-compat-routes.ts
+++ b/packages/app-core/src/api/automations-compat-routes.ts
@@ -19,9 +19,9 @@ import { type AgentRuntime, stringToUuid, type UUID } from "@elizaos/core";
 import type {
   AutomationNodeCatalogResponse,
   AutomationNodeDescriptor,
-} from "@elizaos/ui";
-import { classifyRuntimeActionNode } from "./automation-action-classifier.ts";
+} from "@elizaos/shared";
 import { ensureRouteAuthorized } from "./auth.ts";
+import { classifyRuntimeActionNode } from "./automation-action-classifier.ts";
 import {
   buildRuntimeCapabilityNodes,
   listAutomationNodeContributors,

--- a/packages/app-core/src/api/i18n-locale-routes.ts
+++ b/packages/app-core/src/api/i18n-locale-routes.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 import { loadElizaConfig } from "@elizaos/agent";
-import { normalizeLanguage } from "@elizaos/ui/i18n";
+import { normalizeLanguage } from "@elizaos/shared";
 import { sendJson as sendJsonResponse } from "./response";
 
 type LanguageCandidate = {

--- a/packages/app-core/src/api/node-ui-decoupling.test.ts
+++ b/packages/app-core/src/api/node-ui-decoupling.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Guards the app-core Node ↔ @elizaos/ui decoupling (#12410). Statically scans
+ * the Node-reachable API/service modules to prove none import React UI
+ * internals, checks the moved registration surfaces resolve from
+ * @elizaos/shared with behavior identical to the old `@elizaos/ui` surface, and
+ * asserts the `@elizaos/ui` package no longer publishes a broad `./*` wildcard
+ * export. Runs against the real source tree and the real @elizaos/shared
+ * implementation — no mocks.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type AutomationNodeCatalogResponse,
+  type AutomationNodeDescriptor,
+  DEFAULT_UI_LANGUAGE,
+  isElizaOS,
+  normalizeLanguage,
+  UI_LANGUAGES,
+  userAgentHasElizaOSMarker,
+} from "@elizaos/shared";
+import { normalizeLanguage as uiNormalizeLanguage } from "@elizaos/ui/i18n";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+
+// Modules that are reachable from the Node `@elizaos/app-core` barrel / the API
+// server graph. None of these may import the React UI barrel or its
+// renderer-only sub-surfaces (`i18n`, `platform`).
+const NODE_REACHABLE_SOURCES = [
+  "packages/app-core/src/api/i18n-locale-routes.ts",
+  "packages/app-core/src/api/automation-node-contributors.ts",
+  "packages/app-core/src/api/automation-action-classifier.ts",
+  "packages/app-core/src/api/automations-compat-routes.ts",
+  "packages/app-core/src/services/app-updates/update-policy.ts",
+];
+
+// Import specifiers a Node-reachable module must never carry, because they pull
+// (or transitively evaluate) the renderer graph (Capacitor bridges, lucide
+// icons, message dictionaries).
+const FORBIDDEN_UI_SPECIFIERS = [
+  '"@elizaos/ui"',
+  '"@elizaos/ui/i18n"',
+  '"@elizaos/ui/platform"',
+];
+
+function readSource(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), "utf8");
+}
+
+describe("app-core Node modules stay decoupled from React UI internals", () => {
+  for (const rel of NODE_REACHABLE_SOURCES) {
+    it(`${rel} imports no React UI internals`, () => {
+      const source = readSource(rel);
+      for (const specifier of FORBIDDEN_UI_SPECIFIERS) {
+        // Only flag real import/export-from statements, not prose in comments.
+        const importPattern = new RegExp(
+          `(?:import|export)[^;]*from\\s+${specifier.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}`,
+        );
+        expect(
+          importPattern.test(source),
+          `${rel} must not import from ${specifier}`,
+        ).toBe(false);
+      }
+    });
+  }
+});
+
+describe("moved registration surfaces resolve from @elizaos/shared", () => {
+  it("re-exports language normalization identically to @elizaos/ui/i18n", () => {
+    const samples = [
+      "en",
+      "en-US",
+      "zh",
+      "zh-CN",
+      "zh-Hans-CN",
+      "ko-KR",
+      "pt-BR",
+      "fil-PH",
+      "  ja  ",
+      "xx-unknown",
+      "",
+      42,
+      null,
+      undefined,
+    ];
+    for (const sample of samples) {
+      expect(normalizeLanguage(sample)).toBe(uiNormalizeLanguage(sample));
+    }
+    expect(normalizeLanguage("de")).toBe(DEFAULT_UI_LANGUAGE);
+    expect(UI_LANGUAGES).toContain("en");
+  });
+
+  it("detects the AOSP ElizaOS user-agent marker", () => {
+    expect(userAgentHasElizaOSMarker("Mozilla/5.0 ElizaOS/2.0 (Linux)")).toBe(
+      true,
+    );
+    expect(userAgentHasElizaOSMarker("Mozilla/5.0 (Linux; Android 14)")).toBe(
+      false,
+    );
+    expect(userAgentHasElizaOSMarker(null)).toBe(false);
+  });
+
+  it("isElizaOS() is false in a Node process (userAgent lacks the marker)", () => {
+    // Node 24 exposes a global `navigator`, but its userAgent (e.g. "Node.js/24")
+    // never carries the AOSP `ElizaOS/<tag>` marker, so a Node API process is
+    // correctly not detected as an ElizaOS system image.
+    expect(isElizaOS()).toBe(false);
+  });
+
+  it("exposes the automation-node catalog contract as a typed shape", () => {
+    const descriptor: AutomationNodeDescriptor = {
+      id: "n1",
+      label: "Send message",
+      description: "",
+      class: "action",
+      source: "core",
+      backingCapability: "SEND_MESSAGE",
+      ownerScoped: false,
+      requiresSetup: false,
+      availability: "enabled",
+    };
+    const catalog: AutomationNodeCatalogResponse = {
+      nodes: [descriptor],
+      summary: { total: 1, enabled: 1, disabled: 0 },
+    };
+    expect(catalog.nodes[0].class).toBe("action");
+  });
+});
+
+describe("@elizaos/ui export map has no broad wildcard", () => {
+  it("does not publish a catch-all ./* export for internal files", () => {
+    const pkg = JSON.parse(readSource("packages/ui/package.json")) as {
+      exports: Record<string, unknown>;
+    };
+    expect(pkg.exports["./*"]).toBeUndefined();
+  });
+
+  it("keeps curated entrypoints the desktop shell + app-core rely on", () => {
+    const pkg = JSON.parse(readSource("packages/ui/package.json")) as {
+      exports: Record<string, unknown>;
+    };
+    for (const entry of [
+      "./App",
+      "./browser",
+      "./build-variant",
+      "./navigation",
+      "./i18n",
+      "./platform",
+      "./app-shell-registry",
+      "./utils/*",
+      "./services/*",
+    ]) {
+      expect(
+        pkg.exports[entry],
+        `@elizaos/ui must export ${entry}`,
+      ).toBeDefined();
+    }
+  });
+});

--- a/packages/app-core/src/services/app-updates/update-policy.ts
+++ b/packages/app-core/src/services/app-updates/update-policy.ts
@@ -1,7 +1,10 @@
 import { Capacitor } from "@capacitor/core";
-import type { AgentUpdateAuthority, AgentUpdateStatus } from "@elizaos/shared";
+import {
+  type AgentUpdateAuthority,
+  type AgentUpdateStatus,
+  isElizaOS,
+} from "@elizaos/shared";
 import { type BuildVariant, getBuildVariant } from "@elizaos/ui/build-variant";
-import { isElizaOS } from "@elizaos/ui/platform";
 
 export type AppUpdatePlatform = "desktop" | "ios" | "android" | "web";
 export type AppDistributionChannel =

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -85,7 +85,7 @@ import { createTranslator } from "@elizaos/ui/i18n";
 import {
   getWindowNavigationPath,
   isAppWindowRoute,
-} from "@elizaos/ui/navigation/index";
+} from "@elizaos/ui/navigation";
 import type { ShareTargetPayload } from "@elizaos/ui/platform";
 import {
   applyLaunchConnection,

--- a/packages/shared/src/contracts/automation-nodes.ts
+++ b/packages/shared/src/contracts/automation-nodes.ts
@@ -1,0 +1,37 @@
+/**
+ * Automation-node catalog contract shared between the Node API that builds the
+ * catalog (`@elizaos/app-core` automation routes) and the React client that
+ * renders it (`@elizaos/ui`). Kept here so the Node side can type its route
+ * handlers without importing React UI internals; `@elizaos/ui` re-exports these
+ * from `api/client-types-config` for the renderer.
+ */
+
+export type AutomationNodeClass =
+  | "trigger"
+  | "action"
+  | "context"
+  | "integration"
+  | "agent"
+  | "flow-control";
+
+export interface AutomationNodeDescriptor {
+  id: string;
+  label: string;
+  description: string;
+  class: AutomationNodeClass;
+  source: string;
+  backingCapability: string;
+  ownerScoped: boolean;
+  requiresSetup: boolean;
+  availability: "enabled" | "disabled";
+  disabledReason?: string;
+}
+
+export interface AutomationNodeCatalogResponse {
+  nodes: AutomationNodeDescriptor[];
+  summary: {
+    total: number;
+    enabled: number;
+    disabled: number;
+  };
+}

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -7,6 +7,7 @@ export * from "./apps-lifecycle-routes.js";
 export * from "./apps-loading-routes.js";
 export * from "./apps-runs-routes.js";
 export * from "./auth-routes.js";
+export * from "./automation-nodes.js";
 export * from "./awareness.js";
 export * from "./character-routes.js";
 export * from "./chat.js";

--- a/packages/shared/src/i18n/language.test.ts
+++ b/packages/shared/src/i18n/language.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the React-free language-normalization surface that Node route
+ * handlers depend on (moved here from `@elizaos/ui/i18n` in #12410).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_UI_LANGUAGE,
+  normalizeLanguage,
+  UI_LANGUAGES,
+} from "./language.js";
+
+describe("normalizeLanguage", () => {
+  it("passes through exact supported codes", () => {
+    for (const lang of UI_LANGUAGES) {
+      expect(normalizeLanguage(lang)).toBe(lang);
+    }
+  });
+
+  it("maps regional BCP-47 tags onto the base supported language", () => {
+    expect(normalizeLanguage("en-US")).toBe("en");
+    expect(normalizeLanguage("zh")).toBe("zh-CN");
+    expect(normalizeLanguage("zh-Hans-CN")).toBe("zh-CN");
+    expect(normalizeLanguage("ko-KR")).toBe("ko");
+    expect(normalizeLanguage("pt-BR")).toBe("pt");
+    expect(normalizeLanguage("fil-PH")).toBe("tl");
+    expect(normalizeLanguage("  ja  ")).toBe("ja");
+  });
+
+  it("falls back to the default for unsupported or non-string input", () => {
+    expect(normalizeLanguage("de")).toBe(DEFAULT_UI_LANGUAGE);
+    expect(normalizeLanguage("")).toBe(DEFAULT_UI_LANGUAGE);
+    expect(normalizeLanguage(42)).toBe(DEFAULT_UI_LANGUAGE);
+    expect(normalizeLanguage(null)).toBe(DEFAULT_UI_LANGUAGE);
+    expect(normalizeLanguage(undefined)).toBe(DEFAULT_UI_LANGUAGE);
+  });
+});

--- a/packages/shared/src/i18n/language.ts
+++ b/packages/shared/src/i18n/language.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical UI language codes and BCP-47 → supported-language normalization.
+ * Pure, React-free, and dependency-free so Node route handlers (content
+ * negotiation in `@elizaos/app-core`) can normalize `Accept-Language` without
+ * pulling the renderer's message dictionaries. `@elizaos/ui/i18n` re-exports
+ * these and layers the message-dictionary lookup on top.
+ */
+
+export const UI_LANGUAGES = [
+  "en",
+  "zh-CN",
+  "ko",
+  "es",
+  "pt",
+  "vi",
+  "tl",
+  "ja",
+] as const;
+
+export type UiLanguage = (typeof UI_LANGUAGES)[number];
+
+export const DEFAULT_UI_LANGUAGE: UiLanguage = "en";
+
+const UI_LANGUAGE_SET = new Set<string>(UI_LANGUAGES);
+
+/**
+ * Map an arbitrary language tag (or non-string input) onto one of the
+ * supported {@link UI_LANGUAGES}, falling back to {@link DEFAULT_UI_LANGUAGE}.
+ */
+export function normalizeLanguage(input: unknown): UiLanguage {
+  if (typeof input !== "string") return DEFAULT_UI_LANGUAGE;
+  const trimmed = input.trim();
+  if (!trimmed) return DEFAULT_UI_LANGUAGE;
+  if (UI_LANGUAGE_SET.has(trimmed)) return trimmed as UiLanguage;
+
+  const lower = trimmed.toLowerCase();
+  if (lower === "zh" || lower === "zh-cn" || lower.startsWith("zh-hans")) {
+    return "zh-CN";
+  }
+  if (lower === "en" || lower.startsWith("en-")) {
+    return "en";
+  }
+  if (lower.startsWith("ko")) return "ko";
+  if (lower.startsWith("es")) return "es";
+  if (lower.startsWith("pt")) return "pt";
+  if (lower.startsWith("vi")) return "vi";
+  if (lower.startsWith("tl") || lower.startsWith("fil")) return "tl";
+  if (lower.startsWith("ja")) return "ja";
+  return DEFAULT_UI_LANGUAGE;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -252,6 +252,9 @@ export * from "./env-utils.js";
 export * from "./error-classification.js";
 export * from "./events/index.js";
 export * from "./format-error.js";
+// Canonical UI language codes + BCP-47 normalization (React-free) so Node
+// route handlers can normalize `Accept-Language` without the renderer.
+export * from "./i18n/language.js";
 // Knowledge-graph primitives — canonical Entity/Relationship types + the
 // identity-merge engine. Dependency-free; the DB-backed stores stay in
 // @elizaos/plugin-personal-assistant.
@@ -272,6 +275,7 @@ export * from "./local-inference/index.js";
 export * from "./loopback-trust.js";
 export * from "./meetings.js";
 export * from "./platform/aosp-user-agent.js";
+export * from "./platform/eliza-os.js";
 export * from "./platform/is-native-server.js";
 export * from "./process-guards.js";
 export * from "./recent-messages-state.js";

--- a/packages/shared/src/platform/eliza-os.test.ts
+++ b/packages/shared/src/platform/eliza-os.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for the React-free AOSP ElizaOS detection surface that Node
+ * update-policy code depends on (moved here from `@elizaos/ui/platform` in
+ * #12410).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { isElizaOS, userAgentHasElizaOSMarker } from "./eliza-os.js";
+
+describe("userAgentHasElizaOSMarker", () => {
+  it("matches the framework marker on AOSP ElizaOS system images", () => {
+    expect(userAgentHasElizaOSMarker("Mozilla/5.0 ElizaOS/2.0.4 (Linux)")).toBe(
+      true,
+    );
+  });
+
+  it("rejects stock Android, empty, and non-string user agents", () => {
+    expect(userAgentHasElizaOSMarker("Mozilla/5.0 (Linux; Android 14)")).toBe(
+      false,
+    );
+    expect(userAgentHasElizaOSMarker("")).toBe(false);
+    expect(userAgentHasElizaOSMarker(null)).toBe(false);
+    expect(userAgentHasElizaOSMarker(undefined)).toBe(false);
+  });
+});
+
+describe("isElizaOS", () => {
+  const originalNavigator = Reflect.getOwnPropertyDescriptor(
+    globalThis,
+    "navigator",
+  );
+
+  afterEach(() => {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", originalNavigator);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  });
+
+  it("is true when navigator.userAgent carries the marker", () => {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { userAgent: "Mozilla/5.0 ElizaOS/2.0 (Linux; Android 14)" },
+    });
+    expect(isElizaOS()).toBe(true);
+  });
+
+  it("is false for a stock user agent", () => {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { userAgent: "Mozilla/5.0 (Linux; Android 14)" },
+    });
+    expect(isElizaOS()).toBe(false);
+  });
+});

--- a/packages/shared/src/platform/eliza-os.ts
+++ b/packages/shared/src/platform/eliza-os.ts
@@ -1,0 +1,30 @@
+/**
+ * AOSP ElizaOS renderer detection. Pure user-agent matching plus a `navigator`
+ * probe, React-free so Node/Bun-reachable update-policy code can ask "is this
+ * device an ElizaOS system image?" without importing the renderer's platform
+ * barrel (Capacitor + bridge modules). `@elizaos/ui/platform` re-exports these.
+ *
+ * The Android framework appends `ElizaOS/<tag>` to the WebView user-agent only
+ * on Eliza-derived AOSP system images (see MainActivity user-agent suffix);
+ * stock Android and non-Android platforms never carry it.
+ */
+
+export function userAgentHasElizaOSMarker(
+  userAgent: string | null | undefined,
+): boolean {
+  if (typeof userAgent !== "string" || userAgent.length === 0) return false;
+  return /\bElizaOS\/\S/.test(userAgent);
+}
+
+export const isAospElizaUserAgent = userAgentHasElizaOSMarker;
+
+/**
+ * True when the current runtime is an ElizaOS AOSP system image, detected via
+ * the renderer's `navigator.userAgent`. In non-browser runtimes (Node/Bun API
+ * process) there is no `navigator`, so this is `false`.
+ */
+export function isElizaOS(): boolean {
+  const nav = (globalThis as { navigator?: { userAgent?: string } }).navigator;
+  if (!nav) return false;
+  return userAgentHasElizaOSMarker(nav.userAgent ?? "");
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -301,6 +301,36 @@
       "import": "./dist/utils/index.js",
       "default": "./dist/utils/index.js"
     },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "import": "./dist/utils/*.js",
+      "default": "./dist/utils/*.js"
+    },
+    "./services/*": {
+      "types": "./dist/services/*.d.ts",
+      "import": "./dist/services/*.js",
+      "default": "./dist/services/*.js"
+    },
+    "./themes": {
+      "types": "./dist/themes/index.d.ts",
+      "import": "./dist/themes/index.js",
+      "default": "./dist/themes/index.js"
+    },
+    "./App": {
+      "types": "./dist/App.d.ts",
+      "import": "./dist/App.js",
+      "default": "./dist/App.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js",
+      "default": "./dist/browser.js"
+    },
+    "./build-variant": {
+      "types": "./dist/build-variant.d.ts",
+      "import": "./dist/build-variant.js",
+      "default": "./dist/build-variant.js"
+    },
     "./voice": {
       "types": "./dist/voice/index.d.ts",
       "import": "./dist/voice/index.js",
@@ -312,12 +342,7 @@
       "default": "./dist/widgets/index.js"
     },
     "./dist/styles/*.css": "./dist/styles/*.css",
-    "./*.css": "./dist/*.css",
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "default": "./dist/*.js"
-    }
+    "./*.css": "./dist/*.css"
   },
   "peerDependencies": {
     "@capacitor/app": "^8.0.0",

--- a/packages/ui/src/api/client-types-config.ts
+++ b/packages/ui/src/api/client-types-config.ts
@@ -1634,13 +1634,13 @@ export type AutomationStatus =
   | "completed"
   | "draft"
   | "system";
-export type AutomationNodeClass =
-  | "trigger"
-  | "action"
-  | "context"
-  | "integration"
-  | "agent"
-  | "flow-control";
+// The automation-node catalog contract is owned by @elizaos/shared so the Node
+// API can type its route handlers without importing this React-adjacent module.
+export type {
+  AutomationNodeCatalogResponse,
+  AutomationNodeClass,
+  AutomationNodeDescriptor,
+} from "@elizaos/shared";
 
 export interface AutomationRoomBinding {
   conversationId: string | null;
@@ -1701,28 +1701,6 @@ export interface AutomationListResponse {
   summary: AutomationSummary;
   workflowStatus: import("./client-types-chat").WorkflowStatusResponse | null;
   workflowFetchError: string | null;
-}
-
-export interface AutomationNodeDescriptor {
-  id: string;
-  label: string;
-  description: string;
-  class: AutomationNodeClass;
-  source: string;
-  backingCapability: string;
-  ownerScoped: boolean;
-  requiresSetup: boolean;
-  availability: "enabled" | "disabled";
-  disabledReason?: string;
-}
-
-export interface AutomationNodeCatalogResponse {
-  nodes: AutomationNodeDescriptor[];
-  summary: {
-    total: number;
-    enabled: number;
-    disabled: number;
-  };
 }
 
 export type { LifeOpsOccurrenceActionResult } from "@elizaos/shared";

--- a/packages/ui/src/i18n/index.ts
+++ b/packages/ui/src/i18n/index.ts
@@ -1,3 +1,4 @@
+import { normalizeLanguage } from "@elizaos/shared";
 import {
   DEFAULT_UI_LANGUAGE,
   ensureLanguageLoaded,
@@ -7,9 +8,13 @@ import {
   type UiLanguage,
 } from "./messages";
 
-export type TranslationVars = Record<string, unknown>;
+// `normalizeLanguage` (and the language-code constants below) are owned by
+// @elizaos/shared so Node route handlers can normalize without the renderer's
+// message dictionaries. Re-exported here to preserve the `@elizaos/ui/i18n`
+// public surface.
+export { normalizeLanguage };
 
-const UI_LANGUAGE_SET = new Set<string>(UI_LANGUAGES);
+export type TranslationVars = Record<string, unknown>;
 
 function interpolate(template: string, vars?: TranslationVars): string {
   if (!vars) return template;
@@ -18,28 +23,6 @@ function interpolate(template: string, vars?: TranslationVars): string {
     if (raw == null) return "";
     return String(raw);
   });
-}
-
-export function normalizeLanguage(input: unknown): UiLanguage {
-  if (typeof input !== "string") return DEFAULT_UI_LANGUAGE;
-  const trimmed = input.trim();
-  if (!trimmed) return DEFAULT_UI_LANGUAGE;
-  if (UI_LANGUAGE_SET.has(trimmed)) return trimmed as UiLanguage;
-
-  const lower = trimmed.toLowerCase();
-  if (lower === "zh" || lower === "zh-cn" || lower.startsWith("zh-hans")) {
-    return "zh-CN";
-  }
-  if (lower === "en" || lower.startsWith("en-")) {
-    return "en";
-  }
-  if (lower.startsWith("ko")) return "ko";
-  if (lower.startsWith("es")) return "es";
-  if (lower.startsWith("pt")) return "pt";
-  if (lower.startsWith("vi")) return "vi";
-  if (lower.startsWith("tl") || lower.startsWith("fil")) return "tl";
-  if (lower.startsWith("ja")) return "ja";
-  return DEFAULT_UI_LANGUAGE;
 }
 
 function messageForLanguage(lang: UiLanguage): MessageDict {

--- a/packages/ui/src/i18n/messages.ts
+++ b/packages/ui/src/i18n/messages.ts
@@ -1,19 +1,14 @@
+import {
+  DEFAULT_UI_LANGUAGE,
+  UI_LANGUAGES,
+  type UiLanguage,
+} from "@elizaos/shared";
 import en from "./locales/en.json" with { type: "json" };
 
-export const UI_LANGUAGES = [
-  "en",
-  "zh-CN",
-  "ko",
-  "es",
-  "pt",
-  "vi",
-  "tl",
-  "ja",
-] as const;
-
-export type UiLanguage = (typeof UI_LANGUAGES)[number];
-
-export const DEFAULT_UI_LANGUAGE: UiLanguage = "en";
+// Canonical language codes live in @elizaos/shared (React-free, Node-safe).
+// Re-exported here so renderer consumers keep importing them from
+// `@elizaos/ui/i18n` alongside the message dictionaries below.
+export { DEFAULT_UI_LANGUAGE, UI_LANGUAGES, type UiLanguage };
 
 export type MessageDict = Record<string, string>;
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -490,8 +490,10 @@ export {
 } from "./hooks/useRenderGuard";
 export { useTimeout } from "./hooks/useTimeout";
 export type { UiLanguage } from "./i18n/index";
+// `./i18n/index` already re-exports the full `./i18n/messages` surface
+// (language codes, MESSAGES, ensureLanguageLoaded); re-exporting messages again
+// here would double-surface those names and make the barrel ambiguous.
 export * from "./i18n/index";
-export * from "./i18n/messages";
 export { ContentLayout } from "./layouts/content-layout/content-layout";
 export * from "./layouts/index";
 export { PageLayout } from "./layouts/page-layout/page-layout";

--- a/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
+++ b/plugins/plugin-hyperliquid/src/automation-node-contributor.ts
@@ -9,7 +9,7 @@ import {
   type RuntimeCapabilityNodeSpec,
   registerAutomationNodeContributor,
 } from "@elizaos/app-core/api/automation-node-contributors";
-import type { AutomationNodeDescriptor } from "@elizaos/ui";
+import type { AutomationNodeDescriptor } from "@elizaos/shared";
 
 /**
  * Automation catalog nodes owned by the Hyperliquid plugin: the Hyperliquid

--- a/plugins/plugin-personal-assistant/src/automation-node-contributor.ts
+++ b/plugins/plugin-personal-assistant/src/automation-node-contributor.ts
@@ -4,6 +4,7 @@ import {
 } from "@elizaos/app-core/api/automation-node-contributors";
 import { logger } from "@elizaos/core";
 import type {
+  AutomationNodeDescriptor,
   IPermissionsRegistry,
   LifeOpsDiscordConnectorStatus,
   LifeOpsGoogleConnectorStatus,
@@ -11,7 +12,6 @@ import type {
   LifeOpsTelegramConnectorStatus,
   PermissionState,
 } from "@elizaos/shared";
-import type { AutomationNodeDescriptor } from "@elizaos/ui";
 import { LifeOpsService } from "./lifeops/service";
 
 const PERMISSIONS_REGISTRY_SERVICE = "eliza_permissions_registry";

--- a/plugins/plugin-wallet/src/automation-node-contributor.ts
+++ b/plugins/plugin-wallet/src/automation-node-contributor.ts
@@ -10,7 +10,7 @@ import {
   type RuntimeCapabilityNodeSpec,
   registerAutomationNodeContributor,
 } from "@elizaos/app-core/api/automation-node-contributors";
-import type { AutomationNodeDescriptor } from "@elizaos/ui";
+import type { AutomationNodeDescriptor } from "@elizaos/shared";
 
 const WALLET_AUTOMATION_NODE_SPECS: RuntimeCapabilityNodeSpec[] = [
   {


### PR DESCRIPTION
Parent: #12093 (item 6). Closes #12410.

## Problem
The Node-reachable `@elizaos/app-core` graph (API/server boot) imported registration surfaces (`normalizeLanguage`, `isElizaOS`, the `AutomationNode*` catalog types) from React-adjacent `@elizaos/ui` sub-surfaces, and `@elizaos/ui` published a broad `./*` catch-all export that mapped any path onto its internal `dist/*` files.

## What changed
- **`@elizaos/shared`** gains three React-free modules that Node route/service code imports directly, as the single source of truth:
  - `i18n/language` — `UI_LANGUAGES` / `DEFAULT_UI_LANGUAGE` / `UiLanguage` / `normalizeLanguage`
  - `platform/eliza-os` — `userAgentHasElizaOSMarker` / `isAospElizaUserAgent` / `isElizaOS`
  - `contracts/automation-nodes` — `AutomationNodeClass` / `AutomationNodeDescriptor` / `AutomationNodeCatalogResponse`
  `@elizaos/ui` re-exports each from shared (its `i18n`, `platform/aosp-user-agent`, and `api/client-types-config` now forward the definitions), so the renderer surface is unchanged.
- **app-core Node modules** import from `@elizaos/shared` instead of the React UI sub-surfaces: `i18n-locale-routes` (`normalizeLanguage`), `services/app-updates/update-policy` (`isElizaOS`), and the three automation route/classifier files (`AutomationNode*` types). The three plugin automation-node contributors (wallet/hyperliquid/personal-assistant) follow.
- **`packages/ui/package.json`** drops the catch-all `./*` export and adds curated entries (`./App`, `./browser`, `./build-variant`, `./themes`, `./utils/*`, `./services/*`). Every real subpath in the repo now resolves via a curated (non-catch-all) export; the only remaining wildcards are the `.css` asset globs.
- **`packages/app/main.tsx`** uses the `./navigation` entry instead of `./navigation/index`.

## Done when — all met
- [x] `packages/ui/package.json` has no broad `./*` wildcard export for internal files.
- [x] Node-reachable app-core modules do not import React UI internals (`@elizaos/ui`, `/i18n`, `/platform`) — verified by grep + a static test.
- [x] Desktop windows still render through curated `@elizaos/ui` subpath entrypoints (`AppWindowRenderer` / `DetachedShellRoot` imports were already curated directory exports; none depended on `./*`).

## Tests
- `packages/app-core/src/api/node-ui-decoupling.test.ts` — statically proves the five Node modules carry no forbidden UI imports, checks the moved surfaces behave identically to the old `@elizaos/ui/i18n` surface (14 language samples), exercises `isElizaOS`/marker detection, types the automation-node contract, and asserts the export map has no `./*` while keeping the curated entrypoints. **11/11.**
- `packages/shared/src/i18n/language.test.ts` + `packages/shared/src/platform/eliza-os.test.ts` — real unit coverage for the new shared modules. **7/7.**

## Verification (scoped; worktree shares parent node_modules)
| Check | Result |
|---|---|
| shared / ui / app-core typecheck | No real errors. Remaining diagnostics are pre-existing worktree env noise only: `TS2688` (missing global type roots), `iwer` (`spatial/__e2e__/immersive-fixture.ts`), and an unbuilt `@elizaos/plugin-elizacloud/host-routes` dist in `../agent`. |
| `node-ui-decoupling` | 11/11 |
| shared `i18n/language` + `platform/eliza-os` | 7/7 |
| app-core `i18n-locale-routes` | 5/5 |
| ui `i18n/messages` | 1/1 |
| `plugin-wallet` automation-node-contributor | 4/4 |
| biome check (22 touched files) | clean |

Note: two `test/live-agent/automations-compat-routes.test.ts` assertions (`action:CODE_TASK`) fail identically **with and without** this change in this bare worktree — a pre-existing environment gap (runtime catalog), not caused by this refactor (the automation edits are `import type` only, erased at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)