### PR TITLE
feat(#12354): iOS local-agent streaming adapter for the Bun runtime bridge

### DIFF
--- a/.github/issue-evidence/12354-adapter-test.txt
+++ b/.github/issue-evidence/12354-adapter-test.txt
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/wf_f7a1641e-e50-11/packages/ui
+
+
+ Test Files  1 passed (1)
+      Tests  4 passed (4)
+   Start at  22:12:23
+   Duration  598ms (transform 222ms, setup 147ms, import 136ms, tests 34ms, environment 0ms)
+

--- a/.github/issue-evidence/12354-bridge-stream-test.txt
+++ b/.github/issue-evidence/12354-bridge-stream-test.txt
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/wf_f7a1641e-e50-11/plugins/plugin-capacitor-bridge
+
+
+ Test Files  1 passed (1)
+      Tests  7 passed (7)
+   Start at  22:11:53
+   Duration  28.09s (transform 24.16s, setup 0ms, import 25.98s, tests 15ms, environment 0ms)
+

--- a/.github/issue-evidence/12354-ios-streaming-adapter.md
+++ b/.github/issue-evidence/12354-ios-streaming-adapter.md
@@ -1,0 +1,73 @@
+# #12354 — iOS local-agent streaming adapter for the Bun runtime bridge
+
+Phase-2 item 5 of #12180. Adds incremental chat-token streaming to the iOS
+full-Bun runtime bridge so `POST /api/conversations/:id/messages/stream` renders
+token-by-token on iOS local mode instead of the buffered single-frame SSE.
+
+## What changed
+
+| Layer | File | Change |
+| --- | --- | --- |
+| Bridge JS | `plugins/plugin-capacitor-bridge/src/ios/bridge.ts` | `http_request_stream` NDJSON method; `streamConversationMessageResponse` emits response head → one base64 SSE `token` chunk per model token (running `fullText`) → `complete`, each via a `stream_emit` host-call; `handleDirectConversationMessage` / `maybeGenerateIosNativeConversationReply` gain an `onToken` hook. `bufferedConversationStreamResponse` stays only as the buffered fallback. |
+| Native (Swift) | `.../FullBunEngineHost.swift` | `stream_emit` host-call case → `streamEventSink` → `agentStreamResponse`/`agentStreamChunk`/`agentStreamComplete` Capacitor events (Android contract). Added to the host-call allowlist. |
+| Native (Swift) | `.../ElizaBunRuntimePlugin.swift` | Wires `streamEventSink` to `notifyListeners` in `load()`. |
+| Plugin types | `plugins/plugin-native-bun-runtime/src/definitions.ts` | Declares `addListener` + `AgentStreamEventName` on the plugin surface. |
+| Contract | `packages/native/bun-runtime/BRIDGE_CONTRACT.md` | Documents `http_request_stream` + `stream_emit`. |
+| TS adapter | `packages/ui/src/api/ios-streaming-agent-plugin.ts` | `createIosStreamingAgentPlugin(runtime)` satisfies `NativeStreamingAgentPlugin` so `createNativeStreamingResponse` is used unmodified. Pre-allocates `streamId`, returns it synchronously, fires the blocking native call in the background (the native call blocks until the stream ends — listeners must be live first). |
+| TS transport | `packages/ui/src/api/ios-local-agent-transport.ts` + `packages/app-core/src/api/ios-local-agent-transport.ts` (mirror) | Route `isStreamingRequest` requests through the streaming adapter; buffered path is the fallback. |
+
+## Design note — why the native call is fire-and-forget
+
+The embedded Bun engine's C ABI (`eliza_bun_engine_call`) is a single
+request→single response call that holds `g_call_mutex` for the whole call and
+services the per-token `stream_emit` host-calls **inline** while it waits
+(`packages/native/bun-runtime/Sources/ElizaBunEngineShim/eliza_bun_engine_shim.c`).
+So a `call({method:"http_request_stream"})` blocks until the stream completes,
+but the token events reach the WebView **live** via `notifyListeners` during the
+call. The TS adapter therefore returns the pre-allocated `streamId`
+synchronously and fires the blocking call in the background, so the caller's
+`agentStream*` listeners are attached before any event fires (asserted in the
+adapter test).
+
+## Verification — done this session (real, headless)
+
+- **Bridge streaming unit tests** — `plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts`
+  (7 tests, deterministic fake emitter + fake runtime, no device): head → one
+  chunk per token with running `fullText` → complete; >1 chunk per turn; 404 for
+  unknown conversation; graceful failure still terminates; `fetchBackendStream`
+  routing; unsafe-path rejection. Output: `12354-bridge-stream-test.txt`.
+- **iOS streaming adapter unit tests** — `packages/ui/src/api/ios-streaming-agent-plugin.test.ts`
+  (4 tests): `NativeStreamingAgentPlugin` type-guard; synchronous `streamId` +
+  arg forwarding; **token-by-token through `createNativeStreamingResponse` with
+  a listeners-attached-before-emit assertion**; `onStreamError` on call
+  rejection. Output: `12354-adapter-test.txt`.
+- **Regression** — `plugin-capacitor-bridge` `bridge.routes.test.ts` (15) +
+  `shared/stdio-bridge.test.ts` (7) stay green; `packages/ui`
+  `android-native-agent-transport.test.ts` + `client-agent-stream.test.ts` stay
+  green (27 total with the adapter suite).
+- **Typecheck** — `plugin-native-bun-runtime`, `packages/ui`,
+  `packages/app-core` `tsgo --noEmit` clean for all touched files. (The repo's
+  worktree ships `src/i18n/generated/*` as a build-time codegen artifact; it was
+  generated locally via `packages/shared/scripts/generate-keywords.mjs` so tests
+  run — those generated files are gitignored and not part of this PR.)
+- **Lint** — Biome clean on every touched file (one pre-existing import-sort
+  finding in `bridge.ts` predates this branch and is on an import block this PR
+  does not modify).
+
+## Verification — NOT done this session (honest N/A)
+
+- **`bun run --cwd packages/app capture:ios-sim` with token-by-token recording /
+  device console `agentStreamChunk` logs** — **N/A this session.** A genuine
+  on-device capture requires building `ElizaBunEngine.xcframework` (the iOS Bun
+  fork — the shipped `artifacts/ElizaBunEngine.xcframework` here carries only
+  `Info.plist`, no compiled slices) and rebuilding + reinstalling the Capacitor
+  app with the Swift changes and a loaded on-device model. That engine build is a
+  multi-hour toolchain build not feasible in this session's budget; the app
+  currently installed on the booted iPhone 16 Pro simulator is a stale build
+  without these changes, so screenshotting it would prove nothing (per
+  `PR_EVIDENCE.md`). The streaming logic is instead proven by the deterministic
+  unit tests above, which drive the exact `agentStream*` frame contract the
+  device path emits. **The Swift changes compile-check only in the iOS build**
+  (no standalone `swiftc` — they import `Capacitor` / `ElizaBunEngine`); brace/
+  paren balance verified, helper symbols (`stringValue`/`intValue`/
+  `stringMapValue`/`notifyListeners`) confirmed present.

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -14,8 +14,13 @@ import {
   recordIosNativeAgentBootHeartbeat,
   recordIosNativeAgentBootPhase,
 } from "@elizaos/ui/api/ios-local-agent-transport";
+import { createIosStreamingAgentPlugin } from "@elizaos/ui/api/ios-streaming-agent-plugin";
 import { createIttpAgentTransport } from "@elizaos/ui/api/ittp-agent-transport";
-import type { AgentRequestTransport } from "@elizaos/ui/api/transport";
+import { createNativeStreamingResponse } from "@elizaos/ui/api/native-agent-stream";
+import {
+  type AgentRequestTransport,
+  isStreamingRequest,
+} from "@elizaos/ui/api/transport";
 import {
   installElizaBridge,
   registerElizaBridgeCapability,
@@ -77,6 +82,14 @@ interface FullBunRuntimePlugin {
     method: string;
     args?: unknown;
   }): Promise<{ result: unknown }>;
+  // Native → WebView chat-stream events (`agentStream*`), emitted by the engine's
+  // `stream_emit` host-call while `http_request_stream` runs (#12354). Optional
+  // here because older engine builds predate it; the streaming path checks for
+  // it and falls back to buffered when absent.
+  addListener?: (
+    eventName: string,
+    listener: (event: unknown) => void,
+  ) => Promise<{ remove: () => void | Promise<void> }>;
 }
 
 interface PrimedFullBunRuntime {
@@ -406,6 +419,7 @@ function wrapFullBunRuntime(
     start: runtime.start.bind(runtime),
     getStatus: runtime.getStatus.bind(runtime),
     call: runtime.call.bind(runtime),
+    addListener: runtime.addListener?.bind(runtime),
   };
 }
 
@@ -804,11 +818,59 @@ function nativeResultToResponse(
   });
 }
 
+/**
+ * Try to serve the request as an incremental token stream over the full-Bun
+ * runtime's `http_request_stream` bridge (#12354). Returns `null` when the
+ * request is not an SSE stream, the runtime is unavailable, or the stream head
+ * never arrives — the caller then falls back to the buffered path (which fakes a
+ * single-frame SSE), so a streaming failure never drops the chat reply.
+ */
+async function tryFullBunStreamingResponse(
+  options: IosLocalAgentNativeRequestOptions,
+): Promise<Response | null> {
+  const runtime = await getFullBunRuntime();
+  if (!runtime?.addListener) return null;
+  const plugin = createIosStreamingAgentPlugin(
+    { call: runtime.call, addListener: runtime.addListener },
+    (error) => {
+      console.warn("[ios-local-agent] stream request failed after head", {
+        path: options.path?.slice(0, 120) ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+  const response = await createNativeStreamingResponse(plugin, {
+    method: options.method,
+    path: options.path,
+    headers: options.headers,
+    body: options.body ?? null,
+    timeoutMs: options.timeoutMs,
+  });
+  // Any streamed head proves the in-process runtime is alive — feed the same
+  // heartbeat the buffered path records so boot-time stalls don't burn the
+  // startup poll's failure budget.
+  recordIosNativeAgentBootHeartbeat();
+  return response;
+}
+
 async function dispatchIosLocalAgentRequest(
   request: Request,
   context?: { timeoutMs?: number },
 ): Promise<Response> {
   const options = await requestToNativeBridgeOptions(request, context);
+
+  // Route the chat token stream (POST …/messages/stream, or any
+  // Accept: text/event-stream request) through the streaming bridge so tokens
+  // render incrementally instead of the buffered single-frame fallback.
+  if (isStreamingRequest(request.url, request.headers)) {
+    try {
+      const streamed = await tryFullBunStreamingResponse(options);
+      if (streamed) return streamed;
+    } catch {
+      // Stream couldn't start — fall through to the buffered request path.
+    }
+  }
+
   return nativeResultToResponse(
     await handleIosLocalAgentNativeRequest(options),
   );

--- a/packages/native/bun-runtime/BRIDGE_CONTRACT.md
+++ b/packages/native/bun-runtime/BRIDGE_CONTRACT.md
@@ -119,12 +119,26 @@ Required native host-call methods today:
 - `llama_generate`
 - `llama_free`
 - `llama_cancel`
+- `stream_emit` — one chat-stream event pushed from the bridge while an
+  `http_request_stream` call is in flight. Payload:
+  `{ streamId, kind: "response" | "chunk" | "complete", ... }`. The native host
+  forwards it to the WebView as the matching `agentStream*` event
+  (`agentStreamResponse` / `agentStreamChunk` / `agentStreamComplete`), mirroring
+  the Android streaming contract. Returns `{ "delivered": true|false }`.
 
 Required methods today:
 
 - `status` -> `{ "ready": true, "engine": "bun", "transport": "bun-host-ipc", "bridgeVersion": "bun-ios:3" }`
 - `http_request` / `http_fetch` with `{ method, path, headers, body,
   timeoutMs }` -> `{ status, statusText, headers, body }`
+- `http_request_stream` with `{ method, path, headers, body, streamId,
+  timeoutMs }` -> `{ streamId, done: true }`. Streams the response body as
+  ordered `stream_emit` host-calls (response head → token chunks → complete)
+  rather than buffering; the caller pre-allocates `streamId` and attaches its
+  `agentStream*` listeners before invoking, because the call blocks until the
+  stream completes. Only `POST /api/conversations/:id/messages/stream` streams;
+  any other path returns a `501` stream so the caller falls back to buffered
+  `http_request`.
 - `send_message` with `{ message, conversationId? }` -> `{ reply, text,
   conversationId, response }`
 

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -14,8 +14,14 @@ import {
   handleIosLocalAgentRequest,
   startIosLocalAgentKernel,
 } from "./ios-local-agent-kernel";
+import { createIosStreamingAgentPlugin } from "./ios-streaming-agent-plugin";
 import { createIttpAgentTransport } from "./ittp-agent-transport";
-import { type AgentRequestTransport, headersToRecord } from "./transport";
+import { createNativeStreamingResponse } from "./native-agent-stream";
+import {
+  type AgentRequestTransport,
+  headersToRecord,
+  isStreamingRequest,
+} from "./transport";
 
 let transport: AgentRequestTransport | null = null;
 let globalRequestHandlerInstalled = false;
@@ -319,6 +325,14 @@ interface FullBunRuntimePlugin {
     method: string;
     args?: unknown;
   }): Promise<{ result: unknown }>;
+  // Native → WebView chat-stream events (`agentStream*`), emitted by the engine's
+  // `stream_emit` host-call while `http_request_stream` runs (#12354). Optional
+  // here because older engine builds predate it; the streaming path checks for
+  // it and falls back to buffered when absent.
+  addListener?: (
+    eventName: string,
+    listener: (event: unknown) => void,
+  ) => Promise<{ remove: () => void | Promise<void> }>;
 }
 
 interface PrimedFullBunRuntime {
@@ -639,6 +653,7 @@ function wrapFullBunRuntime(
     start: runtime.start.bind(runtime),
     getStatus: runtime.getStatus.bind(runtime),
     call: runtime.call.bind(runtime),
+    addListener: runtime.addListener?.bind(runtime),
   };
 }
 
@@ -927,11 +942,56 @@ function nativeResultToResponse(
   });
 }
 
+/**
+ * Try to serve the request as an incremental token stream over the full-Bun
+ * runtime's `http_request_stream` bridge (#12354). Returns `null` when the
+ * request is not an SSE stream, the runtime is unavailable, or the stream head
+ * never arrives — the caller then falls back to the buffered path (which fakes a
+ * single-frame SSE), so a streaming failure never drops the chat reply.
+ */
+async function tryFullBunStreamingResponse(
+  options: IosLocalAgentNativeRequestOptions,
+): Promise<Response | null> {
+  const runtime = await getFullBunRuntime();
+  if (!runtime?.addListener) return null;
+  const plugin = createIosStreamingAgentPlugin(
+    { call: runtime.call, addListener: runtime.addListener },
+    (error) => {
+      console.warn("[ios-local-agent] stream request failed after head", {
+        path: options.path?.slice(0, 120) ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+  const response = await createNativeStreamingResponse(plugin, {
+    method: options.method,
+    path: options.path,
+    headers: options.headers,
+    body: options.body ?? null,
+    timeoutMs: options.timeoutMs,
+  });
+  recordIosNativeAgentBootHeartbeat();
+  return response;
+}
+
 async function dispatchIosLocalAgentRequest(
   request: Request,
   context?: { timeoutMs?: number },
 ): Promise<Response> {
   const options = await requestToNativeBridgeOptions(request, context);
+
+  // Route the chat token stream (POST …/messages/stream, or any
+  // Accept: text/event-stream request) through the streaming bridge so tokens
+  // render incrementally instead of the buffered single-frame fallback.
+  if (isStreamingRequest(request.url, request.headers)) {
+    try {
+      const streamed = await tryFullBunStreamingResponse(options);
+      if (streamed) return streamed;
+    } catch {
+      // Stream couldn't start — fall through to the buffered request path.
+    }
+  }
+
   return nativeResultToResponse(
     await handleIosLocalAgentNativeRequest(options),
   );

--- a/packages/ui/src/api/ios-streaming-agent-plugin.test.ts
+++ b/packages/ui/src/api/ios-streaming-agent-plugin.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the iOS streaming adapter (#12354). They drive
+ * `createIosStreamingAgentPlugin` with a fake ElizaBunRuntime whose
+ * `http_request_stream` `call` fans `agentStream*` events out through the
+ * `addListener`-registered listeners — the same shape the native `stream_emit`
+ * host-call produces — and assert the adapter satisfies the
+ * `NativeStreamingAgentPlugin` contract that `createNativeStreamingResponse`
+ * consumes, end-to-end, with no device.
+ *
+ * The load-bearing property is ordering: the native call blocks until the
+ * stream completes, so `requestStream` must resolve a `streamId` BEFORE the
+ * events fire, or the caller's listeners miss every token.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createIosStreamingAgentPlugin,
+  type IosStreamingRuntime,
+} from "./ios-streaming-agent-plugin";
+import {
+  createNativeStreamingResponse,
+  supportsNativeStreaming,
+} from "./native-agent-stream";
+
+type Listener = (event: unknown) => void;
+
+/**
+ * A runtime whose `http_request_stream` call, once invoked, emits a response
+ * head, one chunk per `tokens` entry, then a complete — through whatever
+ * listeners are currently registered. It records whether listeners were live
+ * when the call was invoked so the ordering guarantee can be asserted.
+ */
+function makeFakeRuntime(tokens: string[]): {
+  runtime: IosStreamingRuntime;
+  listenerCountAtCall: () => number;
+  callArgs: () => unknown;
+} {
+  const listeners = new Map<string, Set<Listener>>();
+  let listenerCountAtCall = -1;
+  let recordedArgs: unknown = null;
+
+  const emit = (eventName: string, data: unknown): void => {
+    for (const listener of listeners.get(eventName) ?? []) listener(data);
+  };
+
+  const runtime: IosStreamingRuntime = {
+    async call(options): Promise<{ result: unknown }> {
+      recordedArgs = options.args;
+      const streamId =
+        (options.args as { streamId?: string } | undefined)?.streamId ?? "s";
+      // Deliver on a later macrotask, mimicking Capacitor's event dispatch —
+      // events land after the caller has attached its listeners.
+      await new Promise((r) => setTimeout(r, 0));
+      // Snapshot listener count at emit time: the fire-and-forget design is only
+      // correct if the caller attached its `agentStream*` listeners before now.
+      listenerCountAtCall = [...listeners.values()].reduce(
+        (n, set) => n + set.size,
+        0,
+      );
+      emit("agentStreamResponse", {
+        streamId,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/event-stream" },
+      });
+      for (const token of tokens) {
+        emit("agentStreamChunk", {
+          streamId,
+          dataBase64: Buffer.from(token, "utf8").toString("base64"),
+        });
+      }
+      emit("agentStreamComplete", { streamId, error: null });
+      return { result: { streamId, done: true } };
+    },
+    async addListener(eventName, listener) {
+      const set = listeners.get(eventName) ?? new Set<Listener>();
+      set.add(listener);
+      listeners.set(eventName, set);
+      return {
+        remove: () => {
+          set.delete(listener);
+        },
+      };
+    },
+  };
+
+  return {
+    runtime,
+    listenerCountAtCall: () => listenerCountAtCall,
+    callArgs: () => recordedArgs,
+  };
+}
+
+describe("createIosStreamingAgentPlugin", () => {
+  it("satisfies the NativeStreamingAgentPlugin type guard", () => {
+    const { runtime } = makeFakeRuntime([]);
+    const plugin = createIosStreamingAgentPlugin(runtime);
+    expect(supportsNativeStreaming(plugin)).toBe(true);
+  });
+
+  it("resolves a streamId synchronously and forwards the request args", async () => {
+    const { runtime, callArgs } = makeFakeRuntime(["hi"]);
+    const plugin = createIosStreamingAgentPlugin(runtime);
+    const { streamId } = await plugin.requestStream({
+      method: "POST",
+      path: "/api/conversations/c1/messages/stream",
+      headers: { accept: "text/event-stream" },
+      body: JSON.stringify({ text: "hi" }),
+    });
+    expect(streamId).toMatch(/^ios-stream-/);
+    // Let the fire-and-forget call run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callArgs()).toMatchObject({
+      method: "POST",
+      path: "/api/conversations/c1/messages/stream",
+      streamId,
+    });
+  });
+
+  it("streams token-by-token through createNativeStreamingResponse", async () => {
+    const { runtime, listenerCountAtCall } = makeFakeRuntime([
+      "Hel",
+      "lo ",
+      "world",
+    ]);
+    const plugin = createIosStreamingAgentPlugin(runtime);
+
+    const response = await createNativeStreamingResponse(plugin, {
+      method: "POST",
+      path: "/api/conversations/c1/messages/stream",
+      headers: { accept: "text/event-stream" },
+      body: null,
+    });
+
+    expect(response.status).toBe(200);
+    // Listeners were attached before the native call fired its events — otherwise
+    // tokens would be lost (the whole point of the fire-and-forget design).
+    expect(listenerCountAtCall()).toBe(3);
+
+    const text = await response.text();
+    expect(text).toBe("Hello world");
+  });
+
+  it("surfaces a call rejection to onStreamError without throwing to the caller", async () => {
+    const onError = vi.fn();
+    const runtime: IosStreamingRuntime = {
+      async call(): Promise<{ result: unknown }> {
+        throw new Error("bridge exploded");
+      },
+      async addListener() {
+        return { remove: () => {} };
+      },
+    };
+    const plugin = createIosStreamingAgentPlugin(runtime, onError);
+    const { streamId } = await plugin.requestStream({
+      method: "POST",
+      path: "/api/conversations/c1/messages/stream",
+    });
+    expect(streamId).toMatch(/^ios-stream-/);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onError).toHaveBeenCalledOnce();
+    expect(String(onError.mock.calls[0][0])).toContain("bridge exploded");
+  });
+});

--- a/packages/ui/src/api/ios-streaming-agent-plugin.ts
+++ b/packages/ui/src/api/ios-streaming-agent-plugin.ts
@@ -1,0 +1,91 @@
+/**
+ * iOS adapter that satisfies `NativeStreamingAgentPlugin` over the in-process
+ * ElizaBunRuntime bridge (#12354). It lets `createNativeStreamingResponse`
+ * (native-agent-stream.ts) turn the iOS local agent's chat token stream into a
+ * live `ReadableStream`-bodied `Response` exactly as it does for Android — no
+ * changes to the streaming primitive.
+ *
+ * Wire model: unlike a socket, the native `call({method:"http_request_stream"})`
+ * blocks until the whole stream finishes (the embedded Bun engine's C ABI is a
+ * single request→response call, and it services the per-token `stream_emit`
+ * host-calls inline while it waits). So `requestStream` cannot wait on that
+ * promise before returning a `streamId` — the caller must attach its
+ * `agentStream*` listeners FIRST. This adapter therefore pre-allocates the
+ * `streamId`, returns it synchronously, and fires the blocking native call in
+ * the background; the events it emits arrive after listeners are live.
+ */
+
+import type {
+  NativeStreamAgentRequestOptions,
+  NativeStreamingAgentPlugin,
+  NativeStreamListenerHandle,
+} from "./native-agent-stream";
+
+/** The minimal ElizaBunRuntime surface the streaming adapter drives. */
+export interface IosStreamingRuntime {
+  call(options: {
+    method: string;
+    args?: unknown;
+  }): Promise<{ result: unknown }>;
+  addListener(
+    eventName: string,
+    listener: (event: unknown) => void,
+  ): Promise<{ remove: () => void | Promise<void> }>;
+}
+
+/** Generate an unguessable, single-use stream identity. */
+function newStreamId(): string {
+  const uuid =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `ios-stream-${uuid}`;
+}
+
+/**
+ * Build a `NativeStreamingAgentPlugin` backed by the iOS runtime bridge. The
+ * `onStreamError` hook (optional) observes a native call that rejects after the
+ * stream head was already delivered — the response body is already terminated by
+ * an `agentStreamComplete` event in the normal path, so this is purely for
+ * diagnostics, never for control flow.
+ */
+export function createIosStreamingAgentPlugin(
+  runtime: IosStreamingRuntime,
+  onStreamError?: (error: unknown) => void,
+): NativeStreamingAgentPlugin {
+  return {
+    requestStream(
+      options: NativeStreamAgentRequestOptions,
+    ): Promise<{ streamId: string }> {
+      const streamId = newStreamId();
+      // Fire-and-forget: the call blocks until the stream completes, but the
+      // token events already reached the WebView through the listeners the
+      // caller attached before awaiting this resolved streamId.
+      void runtime
+        .call({
+          method: "http_request_stream",
+          args: {
+            method: options.method,
+            path: options.path,
+            headers: options.headers,
+            body: options.body,
+            timeoutMs: options.timeoutMs,
+            streamId,
+          },
+        })
+        .catch((error) => {
+          onStreamError?.(error);
+        });
+      return Promise.resolve({ streamId });
+    },
+    addListener(
+      eventName:
+        | "agentStreamResponse"
+        | "agentStreamChunk"
+        | "agentStreamComplete",
+      listener: (event: unknown) => void,
+    ): Promise<NativeStreamListenerHandle> {
+      return runtime.addListener(eventName, listener);
+    },
+  };
+}

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Streaming-path tests for the iOS bridge's chat token stream (#12354). They
+ * drive `streamConversationMessageResponse` / `fetchBackendStream` end-to-end
+ * with a fake in-memory runtime whose `messageService` emits tokens
+ * incrementally, plus a fake stream emitter standing in for the native
+ * `stream_emit` host-call → `notifyListeners` bridge. No device, no model on
+ * disk (so the native-llama path is skipped and the deterministic
+ * message-service path runs).
+ *
+ * They prove the contract the Android `agentStream*` events and
+ * `createNativeStreamingResponse` consume: exactly one `response` head, one
+ * `chunk` per model token (SSE `token` frames with a running `fullText`), and a
+ * terminal `complete` — never the buffered single-frame fallback.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	fetchBackendStream,
+	type IosBridgeBackend,
+	type StreamEmitFrame,
+	streamConversationMessageResponse,
+} from "./bridge.ts";
+
+const CONVERSATION_ID = "conv-stream-1";
+const ROOM_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+
+/**
+ * A runtime whose message service streams the given tokens one-by-one through
+ * the `onResponse` callback — the same shape the real messageService uses when
+ * generation is available but no on-device model file is installed.
+ */
+function createStreamingRuntime(tokens: string[]): IAgentRuntime {
+	return {
+		agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		character: { name: "Eliza" },
+		async ensureConnection(): Promise<void> {},
+		async createMemory(): Promise<UUID> {
+			return crypto.randomUUID() as UUID;
+		},
+		messageService: {
+			async handleMessage(
+				_runtime: IAgentRuntime,
+				_message: unknown,
+				onResponse: (content: { text?: string } | null) => Promise<unknown[]>,
+			): Promise<void> {
+				for (const token of tokens) {
+					await onResponse({ text: token });
+				}
+			},
+		},
+	} as unknown as IAgentRuntime;
+}
+
+function makeBackendWithConversation(runtime: IAgentRuntime): IosBridgeBackend {
+	const conversations = new Map<string, never>();
+	conversations.set(CONVERSATION_ID, {
+		id: CONVERSATION_ID,
+		title: "Stream",
+		roomId: ROOM_ID,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	} as never);
+	return {
+		runtime,
+		dispatchRoute: async () => null,
+		conversations:
+			conversations as unknown as IosBridgeBackend["conversations"],
+		close: async () => {},
+	};
+}
+
+/** Collect emitted frames; return the collector + emitter. */
+function collector() {
+	const frames: StreamEmitFrame[] = [];
+	const emit = (frame: StreamEmitFrame): void => {
+		frames.push(frame);
+	};
+	return { frames, emit };
+}
+
+/** Decode a `chunk` frame's base64 back into the SSE `data:` JSON payload. */
+function decodeChunk(frame: StreamEmitFrame): Record<string, unknown> {
+	if (frame.kind !== "chunk") throw new Error("not a chunk frame");
+	const sse = Buffer.from(frame.dataBase64, "base64").toString("utf8");
+	const line = sse.split("\n").find((l) => l.startsWith("data:"));
+	if (!line) throw new Error(`no data line in ${JSON.stringify(sse)}`);
+	return JSON.parse(line.slice(5).trim()) as Record<string, unknown>;
+}
+
+describe("iOS bridge — streamConversationMessageResponse", () => {
+	it("emits response → one chunk per token (running fullText) → complete", async () => {
+		const runtime = createStreamingRuntime(["Hello", " there", " friend"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		await streamConversationMessageResponse(
+			backend,
+			CONVERSATION_ID,
+			{ text: "hi" },
+			"stream-a",
+			emit,
+		);
+
+		// Head, one token chunk per model token, a done chunk, and complete.
+		expect(frames[0]).toMatchObject({ kind: "response", status: 200 });
+		expect(frames[0]).toMatchObject({
+			headers: { "content-type": "text/event-stream; charset=utf-8" },
+		});
+		expect(frames.at(-1)).toEqual({
+			streamId: "stream-a",
+			kind: "complete",
+			error: null,
+		});
+
+		const chunks = frames.filter((f) => f.kind === "chunk");
+		const tokenChunks = chunks
+			.map(decodeChunk)
+			.filter((p) => p.type === "token");
+		expect(tokenChunks.map((p) => p.text)).toEqual([
+			"Hello",
+			" there",
+			" friend",
+		]);
+		// fullText accumulates across tokens.
+		expect(tokenChunks.map((p) => p.fullText)).toEqual([
+			"Hello",
+			"Hello there",
+			"Hello there friend",
+		]);
+
+		const done = chunks.map(decodeChunk).find((p) => p.type === "done");
+		expect(done).toMatchObject({
+			type: "done",
+			completed: true,
+			fullText: "Hello there friend",
+		});
+
+		// Every frame carries the pre-allocated streamId.
+		for (const frame of frames) expect(frame.streamId).toBe("stream-a");
+	});
+
+	it("delivers more than one stream chunk per turn (real incremental stream)", async () => {
+		const runtime = createStreamingRuntime(["a", "b", "c", "d"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		await streamConversationMessageResponse(
+			backend,
+			CONVERSATION_ID,
+			{ text: "hi" },
+			"stream-b",
+			emit,
+		);
+
+		const tokenChunks = frames
+			.filter((f) => f.kind === "chunk")
+			.map(decodeChunk)
+			.filter((p) => p.type === "token");
+		expect(tokenChunks.length).toBeGreaterThan(1);
+	});
+
+	it("emits a 404 stream for an unknown conversation without throwing", async () => {
+		const runtime = createStreamingRuntime(["ignored"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		await streamConversationMessageResponse(
+			backend,
+			"does-not-exist",
+			{ text: "hi" },
+			"stream-c",
+			emit,
+		);
+
+		expect(frames[0]).toMatchObject({ kind: "response", status: 404 });
+		expect(frames.at(-1)).toMatchObject({ kind: "complete" });
+	});
+
+	it("surfaces a generation failure as an SSE error chunk, still terminating", async () => {
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+			character: { name: "Eliza" },
+			async ensureConnection(): Promise<void> {},
+			async createMemory(): Promise<UUID> {
+				return crypto.randomUUID() as UUID;
+			},
+			messageService: {
+				async handleMessage(): Promise<void> {
+					throw new Error("boom");
+				},
+			},
+		} as unknown as IAgentRuntime;
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		await streamConversationMessageResponse(
+			backend,
+			CONVERSATION_ID,
+			{ text: "hi" },
+			"stream-d",
+			emit,
+		);
+
+		// The message-service path catches its own error and streams a graceful
+		// fallback sentence, so the turn still completes with a done frame.
+		expect(frames[0]).toMatchObject({ kind: "response", status: 200 });
+		const done = frames
+			.filter((f) => f.kind === "chunk")
+			.map(decodeChunk)
+			.find((p) => p.type === "done");
+		expect(done).toBeDefined();
+		expect(String(done?.fullText)).toContain("unavailable");
+		expect(frames.at(-1)).toMatchObject({ kind: "complete" });
+	});
+});
+
+describe("iOS bridge — fetchBackendStream routing", () => {
+	it("routes POST /messages/stream through the streaming path", async () => {
+		const runtime = createStreamingRuntime(["hi"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		const result = await fetchBackendStream(
+			backend,
+			{
+				method: "POST",
+				path: `/api/conversations/${CONVERSATION_ID}/messages/stream`,
+				streamId: "stream-e",
+			},
+			"stream-e",
+			emit,
+		);
+
+		expect(result).toEqual({ streamId: "stream-e", done: true });
+		expect(frames[0]).toMatchObject({ kind: "response", status: 200 });
+		expect(frames.some((f) => f.kind === "chunk")).toBe(true);
+	});
+
+	it("returns a 501 stream for a non-conversation-stream path (buffered fallback)", async () => {
+		const runtime = createStreamingRuntime(["hi"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { frames, emit } = collector();
+
+		await fetchBackendStream(
+			backend,
+			{ method: "GET", path: "/api/local-inference/downloads/stream" },
+			"stream-f",
+			emit,
+		);
+
+		expect(frames[0]).toMatchObject({ kind: "response", status: 501 });
+		expect(frames.at(-1)).toMatchObject({ kind: "complete" });
+	});
+
+	it("rejects an unsafe path", async () => {
+		const runtime = createStreamingRuntime(["hi"]);
+		const backend = makeBackendWithConversation(runtime);
+		const { emit } = collector();
+
+		await expect(
+			fetchBackendStream(
+				backend,
+				{ method: "POST", path: "http://evil/api" },
+				"stream-g",
+				emit,
+			),
+		).rejects.toThrow(/starts with/);
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -12,6 +12,7 @@ import {
 	type Memory,
 	type MemoryMetadata,
 	ModelType,
+	type StreamChunkCallback,
 	stringToUuid,
 	type UUID,
 } from "@elizaos/core";
@@ -98,6 +99,35 @@ interface HttpRequestPayload {
 	bodyEncoding?: unknown;
 	timeoutMs?: unknown;
 }
+
+interface HttpStreamRequestPayload extends HttpRequestPayload {
+	/**
+	 * The stream identity the caller pre-allocated so it can attach
+	 * `agentStream*` listeners before this request runs (the native `call`
+	 * blocks until the stream finishes, so listeners must be live first).
+	 */
+	streamId?: unknown;
+}
+
+/**
+ * One outbound stream event, carried from the bridge to the WebView as a
+ * `stream_emit` host-call. The kinds mirror the Android `agentStream*` Capacitor
+ * events so `createNativeStreamingResponse` consumes iOS streams unmodified:
+ * `response` (head) → `chunk` (base64 SSE bytes) → `complete`.
+ */
+export type StreamEmitFrame =
+	| {
+			streamId: string;
+			kind: "response";
+			status: number;
+			statusText?: string;
+			headers?: Record<string, string>;
+	  }
+	| { streamId: string; kind: "chunk"; dataBase64: string }
+	| { streamId: string; kind: "complete"; error?: string | null };
+
+/** Delivers one stream event to the native host (→ `notifyListeners`). */
+export type StreamEmitter = (frame: StreamEmitFrame) => Promise<void> | void;
 
 export interface IosBridgeBackend {
 	/**
@@ -889,6 +919,70 @@ async function fetchBackend(
 		error: `No iOS local route for ${method} ${pathname}`,
 		code: "not_found",
 	});
+}
+
+const CONVERSATION_STREAM_PATH =
+	/^\/api\/conversations\/([^/]+)\/messages\/stream$/;
+
+/**
+ * Serve the chat token stream (`POST /api/conversations/:id/messages/stream`)
+ * incrementally: the caller pre-allocated `streamId`, listeners are already
+ * attached WebView-side, and each token reaches the page as a `stream_emit`
+ * host-call while this request is in flight. Resolves once the stream completes.
+ *
+ * Only the conversation stream endpoint streams; any other `/stream` path is not
+ * a token stream and returns `501` so the caller falls back to the buffered
+ * request path rather than hanging on events that never arrive.
+ */
+export async function fetchBackendStream(
+	backend: IosBridgeBackend,
+	payload: HttpStreamRequestPayload,
+	streamId: string,
+	emit: StreamEmitter,
+): Promise<{ streamId: string; done: true }> {
+	const rawPath = typeof payload.path === "string" ? payload.path.trim() : "";
+	if (!rawPath || !isSafeLocalPath(rawPath)) {
+		throw new Error(
+			"iOS bridge http_request_stream requires a path that starts with / and is not an absolute URL",
+		);
+	}
+	const method = normalizeMethod(payload.method);
+	const { pathname } = splitPathAndQuery(rawPath);
+	const match = CONVERSATION_STREAM_PATH.exec(pathname);
+
+	if (method !== "POST" || !match) {
+		await emit({
+			streamId,
+			kind: "response",
+			status: 501,
+			statusText: statusTextForCode(501),
+			headers: { "content-type": "application/json; charset=utf-8" },
+		});
+		await emit({
+			streamId,
+			kind: "chunk",
+			dataBase64: Buffer.from(
+				JSON.stringify({
+					error: `No iOS local stream route for ${method} ${pathname}`,
+					code: "streaming_not_supported",
+				}),
+				"utf8",
+			).toString("base64"),
+		});
+		await emit({ streamId, kind: "complete", error: null });
+		return { streamId, done: true };
+	}
+
+	const conversationId = decodeURIComponent(match[1] ?? "");
+	const body = parseRequestBody(payload);
+	await streamConversationMessageResponse(
+		backend,
+		conversationId,
+		body,
+		streamId,
+		emit,
+	);
+	return { streamId, done: true };
 }
 
 function parseJsonBody(body: string): unknown {
@@ -2480,6 +2574,7 @@ function cleanIosNativeConversationReply(raw: string): string {
 async function maybeGenerateIosNativeConversationReply(
 	runtime: IAgentRuntime,
 	prompt: string,
+	onToken?: StreamChunkCallback,
 ): Promise<Record<string, unknown> | null> {
 	const installed = readInstalledModels().filter(
 		(model) => !isEmbeddingModel(model),
@@ -2500,6 +2595,9 @@ async function maybeGenerateIosNativeConversationReply(
 			maxTokens: 32,
 			temperature: 0,
 			stopSequences: ["<end_of_turn>", "<start_of_turn>"],
+			// When the caller is streaming, forward incremental model tokens so the
+			// hot chat stream renders progressively instead of one buffered frame.
+			...(onToken ? { onStreamChunk: onToken } : {}),
 		},
 		IOS_NATIVE_LLAMA_PROVIDER,
 	);
@@ -3623,6 +3721,7 @@ async function handleDirectConversationMessage(
 	backend: IosBridgeBackend,
 	conversation: IosConversation,
 	input: Record<string, unknown>,
+	onToken?: (token: string, accumulated: string) => void,
 ): Promise<Record<string, unknown>> {
 	const prompt =
 		typeof input.text === "string"
@@ -3671,9 +3770,24 @@ async function handleDirectConversationMessage(
 		// Best effort. Some adapters persist inside messageService.
 	}
 
+	// Track cumulative streamed text so incremental model chunks accumulate into
+	// the running `fullText` the client SSE parser expects. Emit tokens verbatim
+	// — inter-token whitespace is load-bearing, so no per-chunk trim/strip here
+	// (reasoning-block cleanup already happens in the model handler before the
+	// chunk reaches us, and the terminal `done` frame carries the final text).
+	let streamedAccumulated = "";
+	const emitToken = onToken
+		? (chunk: string): void => {
+				if (!chunk) return;
+				streamedAccumulated += chunk;
+				onToken(chunk, streamedAccumulated);
+			}
+		: undefined;
+
 	const nativeReply = await maybeGenerateIosNativeConversationReply(
 		backend.runtime,
 		prompt,
+		emitToken ? (chunk) => emitToken(chunk) : undefined,
 	).catch((error) => ({
 		text:
 			error instanceof Error
@@ -3713,7 +3827,10 @@ async function handleDirectConversationMessage(
 			runtime,
 			message,
 			async (content) => {
-				if (content?.text) chunks.push(content.text);
+				if (content?.text) {
+					chunks.push(content.text);
+					emitToken?.(content.text);
+				}
 				return [];
 			},
 		);
@@ -3808,6 +3925,141 @@ function bufferedConversationStreamResponse(
 		bodyBase64: Buffer.from(body, "utf8").toString("base64"),
 		bodyEncoding: "utf-8",
 	};
+}
+
+const SSE_STREAM_HEADERS: Record<string, string> = {
+	"content-type": "text/event-stream; charset=utf-8",
+	"cache-control": "no-cache, no-transform",
+	connection: "keep-alive",
+};
+
+function sseChunkBase64(payload: Record<string, unknown>): string {
+	return Buffer.from(sseEvent(payload), "utf8").toString("base64");
+}
+
+/**
+ * Drive the chat token stream for `POST /api/conversations/:id/messages/stream`
+ * over the native stream contract: emit the SSE response head, one `chunk` per
+ * incremental model token, then `complete`. Replaces
+ * `bufferedConversationStreamResponse` on the hot path so tokens render
+ * incrementally on iOS local mode (#12354).
+ *
+ * The emitter is the seam that reaches the WebView (via a `stream_emit`
+ * host-call → `notifyListeners`); a fake emitter unit-tests the whole flow with
+ * no device. A cached turn or a conversation lookup miss still resolves through
+ * this path — the client sees the same `token`/`done` frames as a live turn.
+ */
+export async function streamConversationMessageResponse(
+	backend: IosBridgeBackend,
+	conversationId: string,
+	body: Record<string, unknown>,
+	streamId: string,
+	emit: StreamEmitter,
+): Promise<void> {
+	const conversation = backend.conversations.get(conversationId);
+	if (!conversation) {
+		await emit({
+			streamId,
+			kind: "response",
+			status: 404,
+			statusText: statusTextForCode(404),
+			headers: { "content-type": "application/json; charset=utf-8" },
+		});
+		await emit({
+			streamId,
+			kind: "chunk",
+			dataBase64: Buffer.from(
+				JSON.stringify({ error: "Conversation not found" }),
+				"utf8",
+			).toString("base64"),
+		});
+		await emit({ streamId, kind: "complete", error: null });
+		return;
+	}
+
+	await emit({
+		streamId,
+		kind: "response",
+		status: 200,
+		statusText: statusTextForCode(200),
+		headers: SSE_STREAM_HEADERS,
+	});
+
+	// A serialized emit tail: keep `chunk` frames in generation order even though
+	// `emit` may be async, and let `complete` await every prior chunk.
+	let emitTail: Promise<void> = Promise.resolve();
+	const enqueueChunk = (payload: Record<string, unknown>): void => {
+		const dataBase64 = sseChunkBase64(payload);
+		emitTail = emitTail.then(() =>
+			Promise.resolve(emit({ streamId, kind: "chunk", dataBase64 })),
+		);
+	};
+
+	let streamedAny = false;
+	let result: Record<string, unknown>;
+	try {
+		const cached = cachedConversationMessageResult(conversation, body);
+		if (cached) {
+			result = cached;
+			const cachedText = typeof cached.text === "string" ? cached.text : "";
+			if (cachedText) {
+				streamedAny = true;
+				enqueueChunk({ type: "token", text: cachedText, fullText: cachedText });
+			}
+		} else {
+			result = await handleDirectConversationMessage(
+				backend,
+				conversation,
+				body,
+				(token, accumulated) => {
+					streamedAny = true;
+					enqueueChunk({ type: "token", text: token, fullText: accumulated });
+				},
+			);
+		}
+	} catch (error) {
+		await emitTail;
+		await emit({
+			streamId,
+			kind: "chunk",
+			dataBase64: sseChunkBase64({
+				type: "error",
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		});
+		await emit({ streamId, kind: "complete", error: null });
+		return;
+	}
+
+	const fullText = typeof result.text === "string" ? result.text : "";
+	// If the model handler produced no incremental tokens (e.g. a provider that
+	// only resolves the whole reply), emit the full text as one token so the
+	// client still renders content before `done`.
+	if (!streamedAny && fullText) {
+		enqueueChunk({ type: "token", text: fullText, fullText });
+	}
+
+	const agentName =
+		typeof result.agentName === "string" && result.agentName.trim()
+			? result.agentName
+			: "Eliza";
+	enqueueChunk({
+		type: "done",
+		fullText,
+		agentName,
+		completed: true,
+		...(typeof result.failureKind === "string"
+			? { failureKind: result.failureKind }
+			: {}),
+		...(result.localInference &&
+		typeof result.localInference === "object" &&
+		!Array.isArray(result.localInference)
+			? { localInference: result.localInference }
+			: {}),
+	});
+
+	await emitTail;
+	await emit({ streamId, kind: "complete", error: null });
 }
 
 export async function handleDirectCoreRoute(
@@ -4148,6 +4400,31 @@ async function dispatchBridgeRequest(
 			return fetchBackend(
 				backendForFetch,
 				(request.payload ?? {}) as HttpRequestPayload,
+			);
+		}
+		case "http_request_stream": {
+			const streamPayload = (request.payload ?? {}) as HttpStreamRequestPayload;
+			const streamId =
+				typeof streamPayload.streamId === "string" &&
+				streamPayload.streamId.trim()
+					? streamPayload.streamId.trim()
+					: `ios-stream-${crypto.randomUUID()}`;
+			const backendForStream = await awaitIosBridgeBackend(
+				host,
+				bridgeTimeoutMs(payload.timeoutMs),
+				method,
+			);
+			// Each frame reaches the WebView as a `stream_emit` host-call, which the
+			// native host translates into an `agentStream*` Capacitor event. The
+			// call blocks until the stream finishes; tokens are already delivered by
+			// then, so the caller's listeners (attached before this ran) saw them
+			// live.
+			return fetchBackendStream(
+				backendForStream,
+				streamPayload,
+				streamId,
+				(frame) =>
+					callIosHost("stream_emit", frame, 30 * 60_000).then(() => {}),
 			);
 		}
 		case "send_message": {

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/ElizaBunRuntimePlugin.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/ElizaBunRuntimePlugin.swift
@@ -49,6 +49,15 @@ public class ElizaBunRuntimePlugin: CAPPlugin, CAPBridgedPlugin {
         // Construct lazily on first start to avoid holding the JSVirtualMachine
         // when the app launches without the runtime.
         runtime = nil
+        // Route the engine's chat-stream `stream_emit` host-calls to the WebView
+        // as `agentStream*` Capacitor events (#12354). The bridge's
+        // `http_request_stream` handler fires these per token; the TS adapter
+        // rebuilds a live ReadableStream from them.
+        FullBunEngineHost.shared.streamEventSink = { [weak self] eventName, data in
+            DispatchQueue.main.async {
+                self?.notifyListeners(eventName, data: data)
+            }
+        }
         runNativeFullBunSmokeIfRequested()
         prewarmFullBunRuntimeIfRequested()
     }

--- a/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/FullBunEngineHost.swift
+++ b/plugins/plugin-native-bun-runtime/ios/Sources/ElizaBunRuntimePlugin/FullBunEngineHost.swift
@@ -38,9 +38,10 @@ private let fullBunHostCallCallback: @convention(c) (
 ///   `ELIZA_MAX_PROTOCOL_LINE_BYTES` (16 MiB) cap prevents unbounded reads.
 /// - Host-call allowlist: only `llama_hardware_info`, `llama_load_model`,
 ///   `llama_generate`, `llama_free`, `llama_cancel`, `eliza_tts_synthesize`,
-///   `eliza_asr_transcribe`, `keep_awake_set`, `bg_download_start`,
-///   `bg_download_status`, and `bg_download_cancel` are dispatched by
-///   `handleHostCall`. All other method names return `{"ok":false,"error":"..."}`.
+///   `eliza_asr_transcribe`, `keep_awake_set`, `stream_emit`,
+///   `bg_download_start`, `bg_download_status`, and `bg_download_cancel` are
+///   dispatched by `handleHostCall`. All other method names return
+///   `{"ok":false,"error":"..."}`.
 /// - `http_fetch` (JSContext compat path): loopback/local-agent URLs are
 ///   rejected at `HTTPBridge.isLocalLoopback` before a URLRequest is created.
 ///   External fetches go through URLSession with the standard iOS ATS policy.
@@ -92,6 +93,12 @@ final class FullBunEngineHost {
     private var callFn: CallFn?
     private var freeFn: FreeFn?
     private var running = false
+
+    /// Delivers one `agentStream*` event to the WebView. Set by the plugin so
+    /// the `stream_emit` host-call (fired per token while `http_request_stream`
+    /// is in flight) reaches `CAPPlugin.notifyListeners` (#12354). Nil until the
+    /// plugin wires it; a stream emit with no sink is a no-op envelope.
+    var streamEventSink: ((_ eventName: String, _ data: [String: Any]) -> Void)?
 
     private init() {}
 
@@ -408,6 +415,13 @@ final class FullBunEngineHost {
                 let enabled = boolValue(payload, "enabled") ?? false
                 KeepAwakeBridge.shared.setEnabled(enabled)
                 return encodeHostEnvelope(ok: true, result: ["enabled": NSNumber(value: enabled)])
+            case "stream_emit":
+                // One chat-stream event (response head / token chunk / complete)
+                // fired by the bridge's `http_request_stream` handler while it
+                // runs. Forward it to the WebView as the matching `agentStream*`
+                // Capacitor event so the TS adapter reconstructs a live
+                // ReadableStream (#12354).
+                return handleStreamEmit(payload)
             case "bg_download_start":
                 // Route the large on-device model file through a native
                 // background URLSession so the ~5 GB transfer survives the app
@@ -553,6 +567,54 @@ final class FullBunEngineHost {
             "cancelled": true,
             "context_id": NSNumber(value: contextId),
         ])
+    }
+
+    /// Translate one `stream_emit` frame into the matching `agentStream*`
+    /// Capacitor event and hand it to the WebView. The frame `kind` mirrors the
+    /// Android streaming contract so `createNativeStreamingResponse` consumes it
+    /// unmodified: `response` → `agentStreamResponse`, `chunk` →
+    /// `agentStreamChunk`, `complete` → `agentStreamComplete` (#12354).
+    private func handleStreamEmit(_ payload: [String: Any]) -> String {
+        guard let streamId = stringValue(payload, "streamId"), !streamId.isEmpty else {
+            return encodeHostEnvelope(ok: false, error: "stream_emit requires streamId")
+        }
+        guard let kind = stringValue(payload, "kind") else {
+            return encodeHostEnvelope(ok: false, error: "stream_emit requires kind")
+        }
+        guard let sink = streamEventSink else {
+            // No WebView listener is wired (e.g. a smoke harness). Acknowledge so
+            // the bridge keeps streaming rather than tearing the turn down.
+            return encodeHostEnvelope(ok: true, result: ["delivered": false])
+        }
+
+        switch kind {
+        case "response":
+            var data: [String: Any] = [
+                "streamId": streamId,
+                "status": NSNumber(value: intValue(payload, "status") ?? 200),
+            ]
+            if let statusText = stringValue(payload, "statusText") {
+                data["statusText"] = statusText
+            }
+            if let headers = stringMapValue(payload, "headers") {
+                data["headers"] = headers
+            }
+            sink("agentStreamResponse", data)
+        case "chunk":
+            guard let dataBase64 = stringValue(payload, "dataBase64") else {
+                return encodeHostEnvelope(ok: false, error: "stream_emit chunk requires dataBase64")
+            }
+            sink("agentStreamChunk", ["streamId": streamId, "dataBase64": dataBase64])
+        case "complete":
+            var data: [String: Any] = ["streamId": streamId]
+            if let error = stringValue(payload, "error") {
+                data["error"] = error
+            }
+            sink("agentStreamComplete", data)
+        default:
+            return encodeHostEnvelope(ok: false, error: "stream_emit unknown kind: \(kind)")
+        }
+        return encodeHostEnvelope(ok: true, result: ["delivered": true])
     }
 
     private func handleTtsSynthesize(_ payload: [String: Any]) -> String {

--- a/plugins/plugin-native-bun-runtime/src/definitions.ts
+++ b/plugins/plugin-native-bun-runtime/src/definitions.ts
@@ -89,6 +89,24 @@ export interface CallResult {
   result: unknown;
 }
 
+/** Handle returned by `addListener`; call `remove` to detach the listener. */
+export interface PluginListenerHandle {
+  remove: () => Promise<void>;
+}
+
+/**
+ * Chat token-stream events the native side pushes to the WebView while a
+ * `call({ method: "http_request_stream" })` runs (#12354). They mirror the
+ * Android `Agent` plugin's streaming contract so the shared
+ * `createNativeStreamingResponse` adapter reconstructs a live `ReadableStream`:
+ * one `agentStreamResponse` head, then `agentStreamChunk` per token, then
+ * `agentStreamComplete`.
+ */
+export type AgentStreamEventName =
+  | "agentStreamResponse"
+  | "agentStreamChunk"
+  | "agentStreamComplete";
+
 export interface LocalTtsStatusResult {
   ready: boolean;
   status: "assets-ready" | "engine-ready" | "ready" | "missing" | "unavailable";
@@ -149,4 +167,13 @@ export interface ElizaBunRuntimePlugin {
    * traffic from the React UI into the agent.
    */
   call(options: CallOptions): Promise<CallResult>;
+  /**
+   * Subscribe to a native event. Used for the chat token stream: the streaming
+   * adapter attaches `agentStream*` listeners before invoking
+   * `call({ method: "http_request_stream" })` (#12354).
+   */
+  addListener(
+    eventName: AgentStreamEventName,
+    listener: (event: unknown) => void,
+  ): Promise<PluginListenerHandle>;
 }


### PR DESCRIPTION
Closes #12354

Phase-2 item 5 of #12180 (parent), built on the merged #12293 foundation slice
(shared stdio kernel, port-gating). Adds incremental chat-token streaming to the
iOS full-Bun runtime bridge so `POST /api/conversations/:id/messages/stream`
renders **token-by-token** on iOS local mode instead of the buffered
single-frame SSE fallback.

## What & why

The iOS local agent already runs the backend in-process over a sealed stdio
bridge, but chat replies arrived as one buffered SSE frame
(`bufferedConversationStreamResponse`) — the whole reply popped in at once. This
adds a genuine streaming path matching the Android `agentStream*` contract, so
the shared `createNativeStreamingResponse` primitive is reused **unmodified**.

**Wire model (settled by the parent research, Decision 2):** the embedded Bun
engine's C ABI (`eliza_bun_engine_call`) is a single request→response call that
services per-token `stream_emit` host-calls **inline** while it blocks. So the
adapter pre-allocates a `streamId`, returns it synchronously, and fires the
blocking `call({method:"http_request_stream"})` in the background — the caller's
`agentStream*` listeners are attached before any event fires (asserted in tests).

### Layers

| Layer | File | Change |
| --- | --- | --- |
| Bridge JS | `plugins/plugin-capacitor-bridge/src/ios/bridge.ts` | `http_request_stream` NDJSON method; `streamConversationMessageResponse` emits response head → one base64 SSE `token` chunk per model token (running `fullText`) → `complete` via `stream_emit` host-calls; `handleDirectConversationMessage` / `maybeGenerateIosNativeConversationReply` gain an `onToken` hook. `bufferedConversationStreamResponse` stays only as the `http_request` fallback. |
| Swift | `.../FullBunEngineHost.swift` | `stream_emit` host-call case → `streamEventSink` → `agentStreamResponse`/`Chunk`/`Complete` events; allowlist updated. |
| Swift | `.../ElizaBunRuntimePlugin.swift` | Wires `streamEventSink` to `notifyListeners` in `load()`. |
| Plugin types | `plugins/plugin-native-bun-runtime/src/definitions.ts` | Declares `addListener` + `AgentStreamEventName`. |
| Contract | `packages/native/bun-runtime/BRIDGE_CONTRACT.md` | Documents `http_request_stream` + `stream_emit`. |
| TS adapter | `packages/ui/src/api/ios-streaming-agent-plugin.ts` (new) | `createIosStreamingAgentPlugin(runtime)` satisfies `NativeStreamingAgentPlugin`. |
| TS transport | `packages/ui/src/api/ios-local-agent-transport.ts` + `packages/app-core/.../ios-local-agent-transport.ts` (mirror) | Route `isStreamingRequest` through the streaming adapter; buffered path is the fallback. |

## Done-when (from the issue)

- ✅ `POST …/messages/stream` renders tokens incrementally on iOS local mode — the streaming path emits one SSE `token` frame per model token with a running `fullText`, delivered live via `notifyListeners` (proven by unit tests driving the exact frame contract; on-device recording is N/A this session — see below).
- ✅ `bufferedConversationStreamResponse` is not used for the hot chat stream — the hot path is `http_request_stream` → `fetchBackendStream` → `streamConversationMessageResponse`; the buffered function remains only as the non-stream `http_request` fallback.
- ✅ Store-mode loopback protection stays intact — no change to `shouldBridgeFetchUrl` / store-build loopback throws; streaming rides the existing `eliza-local-agent://ipc` transport.

## Evidence checklist (per PR_EVIDENCE.md)

- **Scoped unit tests (real, headless):**
  - `plugins/plugin-capacitor-bridge/src/ios/bridge.stream.test.ts` — 7 tests, deterministic fake emitter + fake runtime: head → per-token chunk (running `fullText`) → complete; >1 chunk/turn; 404; graceful failure; routing; unsafe path. Output: `.github/issue-evidence/12354-bridge-stream-test.txt`.
  - `packages/ui/src/api/ios-streaming-agent-plugin.test.ts` — 4 tests: type-guard; synchronous `streamId` + arg forwarding; **token-by-token through `createNativeStreamingResponse` with a listeners-attached-before-emit assertion**; `onStreamError` on rejection. Output: `.github/issue-evidence/12354-adapter-test.txt`.
- **Regression:** `bridge.routes.test.ts` (15) + `shared/stdio-bridge.test.ts` (7) + ui `android-native-agent-transport.test.ts` + `client-agent-stream.test.ts` stay green.
- **Typecheck:** `tsgo --noEmit` clean for all touched files in `plugin-native-bun-runtime`, `packages/ui`, `packages/app-core`. (`src/i18n/generated/*` is a gitignored codegen artifact — regenerated locally via `packages/shared/scripts/generate-keywords.mjs` so tests import `@elizaos/core`; not part of this PR.)
- **Lint:** Biome clean on every touched file (one pre-existing `bridge.ts` import-sort finding predates this branch on an import block this PR does not modify).
- **Backend structured logs / frontend console+network:** N/A this session — requires a running on-device build (see below).
- **Before/after screenshots + video walkthrough (`capture:ios-sim`):** **N/A - device capture not feasible this session.** A genuine capture needs `ElizaBunEngine.xcframework` built from the iOS Bun fork (the in-repo artifact carries only `Info.plist`, no compiled slices) plus a full Capacitor rebuild+reinstall with the Swift changes and an on-device model — a multi-hour engine build outside this session's budget. The installed sim build is stale (pre-change), so a screenshot would prove nothing (PR_EVIDENCE.md). The streaming logic is instead proven by unit tests exercising the exact `agentStream*` frame contract the device emits.
- **Real-LLM trajectories:** N/A - this is transport/bridge plumbing; the reply-generation model call is unchanged (only an `onToken` hook is added).
- **Swift compile:** compiles in the iOS build only (imports `Capacitor`/`ElizaBunEngine`; no standalone `swiftc` on this host). Brace/paren balance + helper symbols (`stringValue`/`intValue`/`stringMapValue`/`notifyListeners`) verified.

## Commands run
- `bun run --cwd plugins/plugin-capacitor-bridge test src/ios/bridge.stream.test.ts src/ios/bridge.routes.test.ts src/shared/stdio-bridge.test.ts` → 29 passed
- `bun run --cwd packages/ui test src/api/ios-streaming-agent-plugin.test.ts src/api/android-native-agent-transport.test.ts src/api/client-agent-stream.test.ts` → 27 passed
- `bun run --cwd {plugin-native-bun-runtime,packages/ui,packages/app-core} typecheck` → clean for touched files (pre-existing generated-i18n gaps unrelated)
- Biome check on all touched files → clean

## Remaining gaps
- On-device / simulator token-by-token recording + device console `agentStreamChunk` logs are **not** attached (N/A rationale above). A follow-up capture PR once the engine framework is built would close this. The rest of the parent #12180 phases (Android stdio switch, desktop transport, media scheme handlers, port removal) are separate items, not in this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
