### PR TITLE
refactor(#12412): single-source {{name}}/escape helpers in core, re-export from shared

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/character.ts
+++ b/packages/core/src/features/basic-capabilities/providers/character.ts
@@ -1,4 +1,8 @@
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
+import {
+	replaceIndexedNameTokens,
+	replaceNameTokens,
+} from "../../../name-tokens.ts";
 import { buildCanonicalSystemPrompt } from "../../../runtime/system-prompt.ts";
 import { getTrajectoryContext } from "../../../trajectory-context.ts";
 import type {
@@ -24,18 +28,10 @@ function resolveCharacterPlaceholders(
 	agentName: string,
 	exampleNames: string[] = [],
 ): string {
-	let resolved = (text ?? "")
-		.replaceAll("{{agentName}}", agentName)
-		.replaceAll("{{name}}", agentName);
-
-	exampleNames.forEach((name, index) => {
-		const slot = index + 1;
-		resolved = resolved
-			.replaceAll(`{{name${slot}}}`, name)
-			.replaceAll(`{{user${slot}}}`, name);
-	});
-
-	return resolved;
+	return replaceIndexedNameTokens(
+		replaceNameTokens(text ?? "", agentName),
+		exampleNames,
+	);
 }
 
 function resolveCharacterList(

--- a/packages/core/src/name-tokens.test.ts
+++ b/packages/core/src/name-tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { replaceNameTokens } from "./name-tokens";
+import { replaceIndexedNameTokens, replaceNameTokens } from "./name-tokens";
 import { getRecentMessagesData } from "./recent-messages-state";
 import type { Memory, State } from "./types";
 
@@ -31,6 +31,47 @@ describe("replaceNameTokens (canonical core impl)", () => {
 
 	it("returns falsey input unchanged", () => {
 		expect(replaceNameTokens("", "Momo")).toBe("");
+	});
+
+	it("leaves indexed tokens for replaceIndexedNameTokens", () => {
+		// `{{name}}` must not consume `{{name1}}`; the two helpers own disjoint
+		// token shapes and compose in either order.
+		expect(replaceNameTokens("{{name}} vs {{name1}}", "Momo")).toBe(
+			"Momo vs {{name1}}",
+		);
+	});
+});
+
+describe("replaceIndexedNameTokens (canonical core impl)", () => {
+	it("resolves {{nameN}} / {{userN}} against the positional array", () => {
+		expect(
+			replaceIndexedNameTokens("{{name1}} met {{user2}}", ["Ada", "Bo"]),
+		).toBe("Ada met Bo");
+	});
+
+	it("tolerates whitespace inside the braces", () => {
+		expect(replaceIndexedNameTokens("hi {{ name1 }}", ["Ada"])).toBe("hi Ada");
+	});
+
+	it("leaves out-of-range slots untouched (never blanks a token)", () => {
+		// The former `.replaceAll` mirrors iterated the name pool, so an unfilled
+		// slot was simply skipped and left literal; preserve that.
+		expect(replaceIndexedNameTokens("{{name3}}", ["Ada"])).toBe("{{name3}}");
+		expect(replaceIndexedNameTokens("{{name1}}", [])).toBe("{{name1}}");
+	});
+
+	it("inserts names containing $-sequences literally", () => {
+		// The `.replaceAll(placeholder, value)` mirrors corrupted these: `$$` ->
+		// `$`, `$&` -> matched token, `$1` -> capture group. The replacer-function
+		// impl inserts them verbatim.
+		expect(replaceIndexedNameTokens("{{name1}}", ["Cash$$"])).toBe("Cash$$");
+		expect(replaceIndexedNameTokens("{{name1}}", ["M$&M"])).toBe("M$&M");
+		expect(replaceIndexedNameTokens("{{user1}}", ["A$1P"])).toBe("A$1P");
+		expect(replaceIndexedNameTokens("{{name1}}", ["net$"])).toBe("net$");
+	});
+
+	it("returns falsey input unchanged", () => {
+		expect(replaceIndexedNameTokens("", ["Ada"])).toBe("");
 	});
 });
 

--- a/packages/core/src/name-tokens.ts
+++ b/packages/core/src/name-tokens.ts
@@ -20,3 +20,30 @@ export function replaceNameTokens(text: string, name: string): string {
 		.replace(/\{\{\s*name\s*\}\}/g, () => name)
 		.replace(/\{\{\s*agentName\s*\}\}/g, () => name);
 }
+
+/**
+ * Resolve indexed example-participant tokens (`{{name1}}` / `{{user1}}` …) in
+ * example-conversation templates against a positional `names` array (slot 1 ->
+ * `names[0]`). Whitespace inside the braces (`{{ name1 }}`) is tolerated, and an
+ * out-of-range index is left untouched so a partial name pool never blanks a
+ * token.
+ *
+ * Same canonical-owner rationale and `$`-safety as `replaceNameTokens`: a
+ * replacer function inserts the name literally, so a generated name containing
+ * `$&` / `$1` / `$$` is not re-read as a `String.replace` substitution pattern.
+ * The core prompt builder (`composeRandomUser`) and the character provider both
+ * resolve these tokens through this one implementation.
+ */
+export function replaceIndexedNameTokens(
+	text: string,
+	names: readonly string[],
+): string {
+	if (!text) return text;
+	return text.replace(
+		/\{\{\s*(?:name|user)(\d+)\s*\}\}/g,
+		(match, slot: string) => {
+			const name = names[Number(slot) - 1];
+			return name === undefined ? match : name;
+		},
+	);
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,6 +2,7 @@ import Handlebars from "handlebars";
 import z from "zod";
 
 import logger from "./logger";
+import { replaceIndexedNameTokens } from "./name-tokens";
 import type { TemplateType } from "./types/agent";
 import type { Entity } from "./types/environment";
 import type { Memory } from "./types/memory";
@@ -356,19 +357,13 @@ const composeRandomUser = (
 	seed = "prompt-users",
 ) => {
 	// {{nameX}}/{{userX}} placeholders only appear in example-conversation
-	// templates; production system/response templates have none. Skip the name
-	// generation + 20 full-string replaceAll passes when no placeholder exists.
+	// templates; production system/response templates have none. Skip the
+	// deterministic-name generation entirely when no placeholder is present.
 	if (!template.includes("{{name") && !template.includes("{{user")) {
 		return template;
 	}
 	const exampleNames = getDeterministicNames(length, seed);
-	let result = template;
-	for (let i = 0; i < exampleNames.length; i++) {
-		result = result.replaceAll(`{{name${i + 1}}}`, exampleNames[i]);
-		result = result.replaceAll(`{{user${i + 1}}}`, exampleNames[i]);
-	}
-
-	return result;
+	return replaceIndexedNameTokens(template, exampleNames);
 };
 
 export const formatPosts = ({

--- a/packages/shared/src/utils/name-tokens.test.ts
+++ b/packages/shared/src/utils/name-tokens.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { replaceNameTokens, tokenizeNameOccurrences } from "./name-tokens";
+import {
+  replaceIndexedNameTokens,
+  replaceNameTokens,
+  tokenizeNameOccurrences,
+} from "./name-tokens";
 
 /**
  * Character-name token helpers. `replaceNameTokens` expands `{{name}}` /
@@ -34,6 +38,18 @@ describe("replaceNameTokens", () => {
 
   it("returns empty/falsey input unchanged", () => {
     expect(replaceNameTokens("", "Momo")).toBe("");
+  });
+});
+
+describe("replaceIndexedNameTokens (re-exported from core)", () => {
+  it("resolves indexed example-slot tokens $-safely", () => {
+    expect(
+      replaceIndexedNameTokens("{{name1}} met {{user2}}", ["Ada", "Bo"]),
+    ).toBe("Ada met Bo");
+    // Same $-sequence protection as replaceNameTokens; the former `.replaceAll`
+    // mirrors mangled these.
+    expect(replaceIndexedNameTokens("{{name1}}", ["Cash$$"])).toBe("Cash$$");
+    expect(replaceIndexedNameTokens("{{name1}}", ["M$&M"])).toBe("M$&M");
   });
 });
 

--- a/packages/shared/src/utils/name-tokens.ts
+++ b/packages/shared/src/utils/name-tokens.ts
@@ -1,9 +1,10 @@
-// `replaceNameTokens` is owned by `@elizaos/core` (canonical `{{name}}` /
-// `{{agentName}}` substitution — whitespace-tolerant, `$`-sequence safe) and
+// `replaceNameTokens` (`{{name}}` / `{{agentName}}`) and
+// `replaceIndexedNameTokens` (`{{name1}}` / `{{user1}}` example slots) are owned
+// by `@elizaos/core` — both whitespace-tolerant and `$`-sequence safe — and
 // re-exported here so existing `@elizaos/shared` / `@elizaos/ui` consumers keep
-// their import path. The core symbol is exported from both the node and browser
-// barrels, so this re-export resolves in browser bundles too.
-export { replaceNameTokens } from "@elizaos/core";
+// their import path. The core symbols are exported from both the node and
+// browser barrels, so this re-export resolves in browser bundles too.
+export { replaceIndexedNameTokens, replaceNameTokens } from "@elizaos/core";
 
 /**
  * Reverse of `replaceNameTokens` — rewrite whole-word occurrences of the


### PR DESCRIPTION
Closes #12412 (Refs #12093 item 7).

## Premise

`@elizaos/core` must own helpers `core` cannot import from `@elizaos/shared` (core → shared is forbidden), following the `env-utils` precedent (core owns `isTruthyEnvValue`, shared re-exports via `export { … } from "@elizaos/core"`).

A prior sweep (#12457) already consolidated `replaceNameTokens` + `getRecentMessagesData`, reconciled the drifted `{{name}}` regex, and cleaned up `system-prompt.ts` / `recent-context.ts` / plugin-manager `relevance.ts`. This PR removes the **last two remaining hand-inlined mirrors** of the name-token substitution that still lived in core's prompt-building path.

## What changed

The two mirrors used `.replaceAll(placeholder, value)`, which is **not `$`-safe**: JS treats `$$`, `$&`, `$1` in the replacement *string* as substitution patterns, so:
- `"{{name}}".replaceAll("{{name}}", "Cash$$")` → `"Cash$"` (should be `Cash$$`)
- `"{{name}}".replaceAll("{{name}}", "M$&M")` → `"M{{name}}M"` (`$&` re-expanded the matched token)

- **`packages/core/src/name-tokens.ts`** — add canonical `replaceIndexedNameTokens(text, names)` for `{{name1}}`/`{{user1}}` example-slot tokens: whitespace-tolerant, `$`-safe via a replacer function, out-of-range slots left literal (never blanks a token).
- **`packages/core/src/utils.ts`** (`composeRandomUser`) and **`packages/core/src/features/basic-capabilities/providers/character.ts`** (`resolveCharacterPlaceholders`) — drop their `.replaceAll` loops; both now delegate to the canonical `replaceNameTokens` + `replaceIndexedNameTokens`.
- **`packages/shared/src/utils/name-tokens.ts`** — re-export `replaceIndexedNameTokens` alongside `replaceNameTokens` (env-utils owner-in-core / re-export-in-shared pattern).
- Tests extended in core + shared `name-tokens.test.ts`.

**Behavior change (strict improvement):** the CHARACTER provider now tolerates `{{ name }}` whitespace and inserts `$`-containing names literally, matching the canonical helper everywhere. No keep-in-sync mirrors remain in core's prompt path.

## Verification

`bunx vitest run packages/core/src/name-tokens.test.ts`:
```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

`bun run --cwd packages/shared test src/utils/name-tokens.test.ts`:
```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

`bun run --cwd packages/core test src/name-tokens.test.ts src/features/basic-capabilities/providers/character.test.ts src/__tests__/callback-templates.test.ts`:
```
 Test Files  3 passed (3)
      Tests  22 passed (22)
```
(character provider + the compose/callback-template path that exercises `composeRandomUser`)

`bun run --cwd packages/core test src/features/basic-capabilities/providers/recentMessages.test.ts`:
```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

**Typecheck** (`bun run --cwd packages/core typecheck` and `… packages/shared`): the only errors are pre-existing `Cannot find module '@elizaos/cloud-routing'` / `'@elizaos/contracts'` (those workspace packages are not built/present in the worktree) — confirmed identical with my edits stashed on the base commit. **Zero** new errors are attributable to this change (verified with `grep -v cloud-routing | grep -v @elizaos/contracts` → empty).

**Lint:** `bunx biome check <6 touched files>` → `Checked 6 files. No fixes applied.`

## Evidence — the `$`-sequence bug being fixed

Before (the mirrors, reproduced directly):
```
"hi {{name}}".replaceAll("{{name}}", "Cash$$")  → "hi Cash$"
"hi {{name}}".replaceAll("{{name}}", "M$&M")    → "hi M{{name}}M"
```
After (canonical helper, from the new passing tests):
```
replaceNameTokens("hello {{name}}", "Cash$$")       → "hello Cash$$"
replaceIndexedNameTokens("{{name1}}", ["M$&M"])     → "M$&M"
replaceIndexedNameTokens("{{user1}}", ["A$1P"])     → "A$1P"
```

N/A rows: no UI-rendered change (pure server helper), no model/prompt-trajectory behavioral change beyond the literal-name fix, no new endpoints.
