### PR TITLE
test(#12365): add typed-message step to onboarding-confused-user e2e (#12178 WI-3)

### DIFF
--- a/.github/issue-evidence/12365-onboarding-composer-unlock.md
+++ b/.github/issue-evidence/12365-onboarding-composer-unlock.md
@@ -1,0 +1,84 @@
+# #12365 — Unlock onboarding composer with deterministic conductor replies (#12178 WI-3)
+
+## Summary
+
+The composer-unlock feature (unlocked composer during onboarding + deterministic
+in-chat conductor replies + the "no server send pre-completion" invariant) landed
+on develop in commit `5121d5f84ae` ("feat(ui): opaque full-screen onboarding +
+unlocked composer (#12178 WI-2/WI-3) (#12437)"). Verified every "Done when" and
+Verification bullet against develop; all are satisfied EXCEPT the
+`onboarding-confused-user e2e typed-message step`, which was never added. This PR
+adds that missing e2e coverage and corrects a stale "locked composer" comment.
+
+## What each Done-when bullet maps to (on develop)
+
+- **Typing during onboarding always yields an in-transcript reply within one
+  frame** — `packages/ui/src/first-run/use-first-run-conductor.ts`
+  `handleFirstRunText` seeds a local user turn + a deterministic assistant reply
+  (`FIRST_RUN_TEXT_REPLY`, no clocks/RNG), keyed on flow position
+  (choosing/provisioning/wrapUp/error). Monotonic `textTurnSeqRef` ids prevent
+  same-millisecond dedup.
+- **Network sends blocked before completion except intended first-run actions** —
+  `packages/ui/src/state/AppContext.tsx` `sendActionMessage`: the `"conductor"`
+  case (free text while `firstRunComplete !== true`) calls `tryHandleFirstRunText`
+  and returns `Promise.resolve()`, never `rawSendActionMessage`. Reserved
+  `__first_run__:` prefix is dropped unconditionally
+  (`classifyActionMessage` → `"first-run"`).
+- **Confused-user + fuzz tests cover interleaved free-text and choice picks** —
+  `use-first-run-conductor.fuzz.test.ts` + `use-first-run-conductor.test.ts` +
+  `first-run-action-channel.test.ts`, plus (added here) the confused-user e2e
+  typed-message step.
+
+## This PR's change
+
+`packages/app/test/ui-smoke/onboarding-confused-user.spec.ts`:
+- New spec `typing free text during onboarding gets an in-transcript reply and
+  never reaches the server`: types free text into the unlocked composer BEFORE
+  picking a runtime, asserts the local user turn + the conductor's "choosing"
+  reply both render, asserts a second impatient send is also acknowledged
+  (monotonic ids), asserts `firstRunPosts.length === 0` and zero typed text
+  reaching the server, then finishes by tapping through (one POST, zero leaks).
+- Corrected a stale "locked composer" comment (composer is now unlocked).
+
+## Evidence
+
+### Unit + fuzz tests (real vitest, jsdom) — PASS
+
+```
+bun run --cwd packages/ui test \
+  src/first-run/use-first-run-conductor.test.ts \
+  src/first-run/use-first-run-conductor.fuzz.test.ts \
+  src/first-run/first-run-action-channel.test.ts \
+  src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+
+Test Files  4 passed (4)
+     Tests  59 passed (59)
+```
+
+### Playwright discovery of the new e2e — PASS
+
+```
+CI=true npx playwright test --config playwright.ui-smoke.config.ts \
+  onboarding-confused-user --list
+
+[chromium] › onboarding-confused-user.spec.ts:73:3 › confused-user onboarding ›
+  typing free text during onboarding gets an in-transcript reply and never reaches the server
+[chromium] › ... double-clicking every choice ...
+[chromium] › ... a failing first-run POST re-offers UNLOCKED choices ...
+[chromium] › ... reloading mid-onboarding re-seeds ...
+Total: 4 tests in 1 file
+```
+
+Spec compiles + is discovered; `biome check` clean.
+
+### e2e live run — N/A (worktree cannot boot the renderer stack)
+
+The full `test:e2e` webServer builds the app renderer (`packages/app build:web`),
+which requires the complete workspace install layout. This isolated agent
+worktree shares the parent clone's `node_modules` by directory walk-up and lacks
+per-package installs; the renderer vite build fails at
+`core/src/features/documents/utils.ts` (`"Buffer" is not exported by
+"__vite-browser-external"`) — a browser-externalization issue in the shared-tree
+build environment that is orthogonal to this change and would break every e2e
+spec equally. The spec runs in CI, which has a full install. See
+`reference_worktree_shares_parent_node_modules.md`.

--- a/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
@@ -70,6 +70,80 @@ test.describe("confused-user onboarding", () => {
     await expectNoPageDiagnostics(page, testInfo.title);
   });
 
+  test("typing free text during onboarding gets an in-transcript reply and never reaches the server", async ({
+    page,
+  }) => {
+    await injectFullCapabilityHost(page);
+    const state = await installHomeRoutes(page);
+    await seedAppStorage(page, { "eliza:first-run-complete": "" });
+    const leaks = trackSentinelLeaks(page);
+    // The confused user types instead of tapping. Every keystroke-send must be
+    // answered locally by the conductor and NEVER reach the agent as a chat
+    // POST — capture any body that carries the typed sentence.
+    const chatSends: string[] = [];
+    page.on("request", (request) => {
+      if (request.method() !== "POST") return;
+      const body = request.postData();
+      if (body?.includes("does this thing even work")) {
+        chatSends.push(`${request.url()} :: ${body.slice(0, 200)}`);
+      }
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expectChatFirstOnboarding(page);
+
+    // Type a question BEFORE picking a runtime: the "choosing" persona answers.
+    const composer = page.getByTestId("chat-composer-textarea");
+    await composer.fill("does this thing even work?");
+    await composer.press("Enter");
+
+    // The typed sentence appears as a local user turn, and the conductor's
+    // deterministic not-ready reply appears within the transcript.
+    await expect(
+      page.getByText("does this thing even work?", { exact: false }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByText("pick one of the options above", { exact: false }),
+    ).toBeVisible({ timeout: 15_000 });
+    await screenshot(page, "typed-free-text-reply");
+
+    // A second impatient send is acknowledged too (monotonic ids — never deduped).
+    await composer.fill("hello?? are you there");
+    await composer.press("Enter");
+    await expect(
+      page.getByText("hello?? are you there", { exact: false }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Nothing was POSTed to /api/first-run, and no typed text leaked as a send.
+    expect(
+      state.firstRunPosts.length,
+      "typing free text must not trigger any first-run POST",
+    ).toBe(0);
+    expect(
+      chatSends,
+      "typed free text must never reach the server before completion",
+    ).toEqual([]);
+    expect(leaks).toEqual([]);
+
+    // The user can still finish by tapping through — proving the composer never
+    // blocked the flow. One POST at the end, still zero leaks.
+    await page.getByTestId(RUNTIME_CHOICE("local")).click();
+    const onDevice = page.getByTestId(PROVIDER_CHOICE("on-device"));
+    await expect(onDevice).toBeVisible({ timeout: 15_000 });
+    await onDevice.click();
+    const skip = page.getByTestId(TUTORIAL_CHOICE("skip"));
+    await expect(skip).toBeVisible({ timeout: 30_000 });
+    await skip.click();
+
+    await expectOnboardingAutoCollapse(page);
+    await settleHomeEntrance(page);
+    await screenshot(page, "typed-then-tapped-home");
+
+    expect(state.firstRunPosts.length).toBe(1);
+    expect(chatSends).toEqual([]);
+    expect(leaks).toEqual([]);
+  });
+
   test("double-clicking every choice still yields exactly one POST and no sentinel leaks", async ({
     page,
   }) => {
@@ -184,7 +258,7 @@ test.describe("confused-user onboarding", () => {
     await page.reload({ waitUntil: "domcontentloaded" });
 
     // Nothing was persisted (no POST yet) → the conductor re-seeds a fresh,
-    // fully interactive onboarding: locked composer, unlocked runtime CHOICE.
+    // fully interactive onboarding: unlocked composer + unlocked runtime CHOICE.
     await expectChatFirstOnboarding(page);
     await screenshot(page, "after-reload-fresh-onboarding");
 


### PR DESCRIPTION
Closes #12365

## What & why

The onboarding composer-unlock feature (#12178 WI-3) — unlocked composer during
first-run, deterministic in-chat conductor replies, and the "nothing reaches the
server before `firstRunComplete`" invariant — **already landed on develop** in
`5121d5f84ae` ("feat(ui): opaque full-screen onboarding + unlocked composer
(#12178 WI-2/WI-3) (#12437)"). I verified every "Done when" / Verification bullet
of #12365 against develop; all are satisfied **except one**: the issue's
Verification list calls for an `onboarding-confused-user e2e typed-message step`,
which was never added.

This PR fills that single gap:

- **New e2e** in `packages/app/test/ui-smoke/onboarding-confused-user.spec.ts`:
  `typing free text during onboarding gets an in-transcript reply and never
  reaches the server`. It types free text into the unlocked composer BEFORE
  picking a runtime, asserts the local user turn + the conductor's deterministic
  "choosing" reply both render in-transcript, asserts a second impatient send is
  also acknowledged (monotonic ids — never deduped), asserts **zero** POSTs to
  `/api/first-run` and **zero** typed text reaching the server, then finishes by
  tapping through (exactly one POST, zero `__first_run__:` leaks) to prove the
  composer never blocked the flow.
- Corrected a stale `locked composer` comment left over from the pre-unlock
  contract.

## Where the shipped behavior lives (for reviewers)

- Free-text reply: `packages/ui/src/first-run/use-first-run-conductor.ts`
  (`handleFirstRunText`, `FIRST_RUN_TEXT_REPLY`, `textTurnSeqRef`).
- Security invariant: `packages/ui/src/state/AppContext.tsx` `sendActionMessage`
  — the `"conductor"` branch never calls `rawSendActionMessage`.
- Classification / reserved prefix:
  `packages/ui/src/first-run/first-run-action-channel.ts`
  (`classifyActionMessage`, `FIRST_RUN_ACTION_PREFIX`).
- Composer unlock: `packages/ui/src/components/shell/ContinuousChatOverlay.tsx`
  (`submitText` routes typed text through `sendActionMessage` when
  `firstRunOpen`; textarea no longer `disabled`; placeholder "Ask me anything —
  or pick an option").

## Evidence checklist (PR_EVIDENCE.md)

| Evidence | Status |
| --- | --- |
| Unit + fuzz tests (real vitest/jsdom) | ✅ 4 files, 59 tests pass — `use-first-run-conductor{,.fuzz}.test.ts`, `first-run-action-channel.test.ts`, `ContinuousChatOverlay.firstrun.test.tsx` |
| New e2e discovered + compiles | ✅ `playwright ... --list` shows the new spec; `biome check` clean |
| e2e live run (browser) | N/A — this isolated agent worktree cannot boot the renderer webServer (shared-tree `build:web` fails on `core/src/features/documents/utils.ts` `Buffer`/`__vite-browser-external`, an environment issue orthogonal to this change that breaks all e2e specs equally). Runs in CI (full install). See `.github/issue-evidence/12365-onboarding-composer-unlock.md`. |
| Real-LLM trajectories | N/A — no agent/action/prompt/model behavior changed; the conductor reply is a deterministic local constant with no model call. |
| Backend structured logs | N/A — no server code changed; the whole point is that free text never reaches the server. |
| Before/after screenshots + video | N/A — no user-visible rendering change (the composer-unlock UI shipped in #12437); this PR only adds a test + fixes a comment. |
| Domain artifacts | N/A — test-only change. |

## Commands run

- `bun run --cwd packages/ui test src/first-run/use-first-run-conductor.test.ts src/first-run/use-first-run-conductor.fuzz.test.ts src/first-run/first-run-action-channel.test.ts src/components/shell/ContinuousChatOverlay.firstrun.test.tsx` → **59 passed**
- `CI=true npx playwright test --config playwright.ui-smoke.config.ts onboarding-confused-user --list` → **4 tests discovered** (incl. the new one)
- `bunx @biomejs/biome check packages/app/test/ui-smoke/onboarding-confused-user.spec.ts` → **clean**

## Gaps / honesty

- The e2e was **not executed live** in this worktree — the renderer stack can't
  build here (documented above + in the evidence file). The spec is discovered,
  type-checks, and is lint-clean; correctness of the underlying conductor path is
  additionally proven by the 59 passing unit/fuzz tests. CI will execute it.
- Full-repo `bun run verify` was not run in this worktree (shared node_modules
  topology makes it unreliable); the touched file passes `biome check` and the
  affected `@elizaos/ui` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)