### PR TITLE
fix(#12352): clean Android stdio validation issues

### DIFF
--- a/.github/issue-evidence/12352-android-stdio-switch/unit-tests.txt
+++ b/.github/issue-evidence/12352-android-stdio-switch/unit-tests.txt
@@ -6,4 +6,3 @@
       Tests  54 passed (54)
    Start at  22:13:14
    Duration  15.19s (transform 30.99s, setup 0ms, import 40.31s, tests 11.98s, environment 2ms)
-

--- a/packages/agent/src/api/dispatch-route-onchunk.test.ts
+++ b/packages/agent/src/api/dispatch-route-onchunk.test.ts
@@ -21,7 +21,7 @@ describe("dispatchRoute onChunk sink (#12352)", () => {
     const route: Route = {
       type: "POST",
       path: "/api/stream",
-      handler: async (_req, res) => {
+      handler: async (_req: unknown, res: unknown) => {
         const r = res as unknown as {
           setHeader: (k: string, v: string) => void;
           write: (c: string) => void;
@@ -60,7 +60,7 @@ describe("dispatchRoute onChunk sink (#12352)", () => {
     const route: Route = {
       type: "GET",
       path: "/api/plain",
-      handler: async (_req, res) => {
+      handler: async (_req: unknown, res: unknown) => {
         (res as unknown as { json: (b: unknown) => void }).json({ ok: true });
       },
     } as unknown as Route;
@@ -87,8 +87,11 @@ describe("dispatchRoute onChunk sink (#12352)", () => {
     const route: Route = {
       type: "POST",
       path: "/api/stream",
-      handler: async (_req, res) => {
-        const r = res as unknown as { write: (c: string) => void; end: () => void };
+      handler: async (_req: unknown, res: unknown) => {
+        const r = res as unknown as {
+          write: (c: string) => void;
+          end: () => void;
+        };
         r.write("a");
         r.write("b");
         r.end();

--- a/packages/agent/src/runtime/eliza-local-agent-port-gate.test.ts
+++ b/packages/agent/src/runtime/eliza-local-agent-port-gate.test.ts
@@ -36,7 +36,9 @@ describe("agent local-agent IPC port gate (#12352)", () => {
   });
 
   it("binds the port in local-agent mode when ELIZA_API_EXPOSE_PORT opts back in", () => {
-    expect(shouldSkipApiListen(true, { ELIZA_API_EXPOSE_PORT: "1" })).toBe(false);
+    expect(shouldSkipApiListen(true, { ELIZA_API_EXPOSE_PORT: "1" })).toBe(
+      false,
+    );
     expect(shouldSkipApiListen(true, { ELIZA_API_EXPOSE_PORT: "true" })).toBe(
       false,
     );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -274,7 +274,6 @@ export * from "./lifeops-normalize/index.js";
 export * from "./local-inference/index.js";
 export * from "./loopback-trust.js";
 export * from "./meetings.js";
-export * from "./platform/aosp-user-agent.js";
 export * from "./platform/eliza-os.js";
 export * from "./platform/is-native-server.js";
 export * from "./process-guards.js";

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.test.ts
@@ -18,9 +18,10 @@ import {
 const runtime = {} as IAgentRuntime;
 
 /** A dispatchRoute that returns a fixed buffered result for the matched path. */
-function fixedRoute(
-	result: RouteHandlerResult | null,
-): { route: AndroidDispatchRoute; calls: Array<Record<string, unknown>> } {
+function fixedRoute(result: RouteHandlerResult | null): {
+	route: AndroidDispatchRoute;
+	calls: Array<Record<string, unknown>>;
+} {
 	const calls: Array<Record<string, unknown>> = [];
 	const route: AndroidDispatchRoute = async (args) => {
 		calls.push(args as unknown as Record<string, unknown>);

--- a/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/dispatch.ts
@@ -74,7 +74,9 @@ function isSafeLocalPath(path: string): boolean {
 }
 
 function normalizeMethod(value: unknown): string {
-	const method = (typeof value === "string" ? value : "GET").trim().toUpperCase();
+	const method = (typeof value === "string" ? value : "GET")
+		.trim()
+		.toUpperCase();
 	if (!/^[A-Z]{1,16}$/.test(method)) {
 		throw new Error("Unsupported HTTP method");
 	}
@@ -280,7 +282,9 @@ export async function dispatchStreamingRequest(
 		emitHead(result.status, result.headers ?? {});
 		for await (const frame of result.stream) {
 			const buf =
-				typeof frame === "string" ? Buffer.from(frame, "utf8") : Buffer.from(frame);
+				typeof frame === "string"
+					? Buffer.from(frame, "utf8")
+					: Buffer.from(frame);
 			if (buf.length > 0) sink.emitChunk(buf.toString("base64"));
 		}
 		return;

--- a/plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/stdio-bridge.test.ts
@@ -210,7 +210,11 @@ describe("createStdioBridge — incremental streaming", () => {
 			sink.emitError("late error");
 		});
 		await bridge.handleLine(
-			JSON.stringify({ id: "s-2", method: "http_request_stream", stream: true }),
+			JSON.stringify({
+				id: "s-2",
+				method: "http_request_stream",
+				stream: true,
+			}),
 		);
 		await bridge.drain();
 


### PR DESCRIPTION
## Summary

Follow-up to #12473 after local validation found issues that would make the merged branch noisy/red in this worktree:

- add explicit handler parameter types in `dispatch-route-onchunk.test.ts` so `packages/agent` typecheck no longer reports implicit `any` in the new test
- apply Biome formatting to the Android stdio switch tests/dispatch helper
- remove an extra terminal blank line from the #12352 unit-test evidence log
- remove the duplicate `platform/aosp-user-agent` root barrel export from `@elizaos/shared`; `platform/eliza-os` already exports the AOSP helpers plus `isElizaOS`, and exporting both created TS2308 duplicate root exports

Refs #12352.

## Validation

- `git merge-tree --write-tree HEAD origin/develop` clean
- `git diff --check origin/develop...HEAD` clean
- `bunx biome check` on the follow-up files: clean
- `bun run --cwd packages/agent test -- dispatch-route-onchunk eliza-local-agent-port-gate server-skip-listen dispatch-route.x402`: 4 files / 26 tests passed
- `bun run --cwd plugins/plugin-capacitor-bridge test -- stdio-bridge android/dispatch`: 2 files / 20 tests passed
- `bun run --cwd packages/agent typecheck`: no errors in touched files after this fix; still blocked locally by unrelated optional package resolution for `@elizaos/plugin-streaming`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, and `@elizaos/plugin-meetings`

`plugins/plugin-capacitor-bridge` iOS `bridge.routes` was attempted before this follow-up and is blocked in this reused shared-node_modules worktree by Vite failing to resolve the `@elizaos/core` package entry; the new Android/stdout bridge suites pass.
