### PR TITLE
feat(#12351): Range/206 media over the local-agent IPC path + scheme-URL attachment guard

### DIFF
--- a/.github/issue-evidence/12351-native-media-ipc-range/test-output.md
+++ b/.github/issue-evidence/12351-native-media-ipc-range/test-output.md
@@ -1,0 +1,17 @@
+# #12351 — Range/206 media over the local-agent IPC path — test evidence
+
+Captured 2026-07-04T02:20:43Z on develop @ 50bfa04a682
+
+## agent: media-store + media-runtime (Range/206 byte serving)
+```
+ Test Files  2 passed (2)
+      Tests  55 passed (55)
+   Duration  5.05s (transform 8.03s, setup 204ms, import 9.23s, tests 39ms, environment 110ms)
+```
+
+## ui: attachment-url scheme allowlist (eliza-local-agent://ipc)
+```
+ Test Files  1 passed (1)
+      Tests  27 passed (27)
+   Duration  137ms (transform 37ms, setup 30ms, import 18ms, tests 4ms, environment 0ms)
+```

--- a/packages/agent/src/api/media-runtime.test.ts
+++ b/packages/agent/src/api/media-runtime.test.ts
@@ -286,4 +286,33 @@ describe("mediaFileRoute", () => {
     } as never);
     expect(result?.status).toBe(404);
   });
+
+  it("forwards a Range header → 206 with the requested byte slice", async () => {
+    // The native scheme handlers (iOS/Android/Electrobun) dispatch media over
+    // this in-process route; a forwarded `Range` header is what lets an
+    // `<audio>`/`<video>` element seek. `dispatchRoute` lowercases request
+    // headers, so the handler reads `ctx.headers.range`.
+    const { fileName } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const result = await mediaFileRoute.routeHandler?.({
+      params: { filename: fileName },
+      method: "GET",
+      headers: { range: "bytes=3-6" },
+    } as never);
+    expect(result?.status).toBe(206);
+    expect(result?.headers?.["Content-Range"]).toBe("bytes 3-6/10");
+    expect(result?.headers?.["Accept-Ranges"]).toBe("bytes");
+    expect((result?.body as Buffer).equals(Buffer.from("3456"))).toBe(true);
+  });
+
+  it("serves the full 200 when no Range header is present", async () => {
+    const { fileName } = persistMediaBytes(Buffer.from("full-body"), "audio/mpeg");
+    const result = await mediaFileRoute.routeHandler?.({
+      params: { filename: fileName },
+      method: "GET",
+      headers: {},
+    } as never);
+    expect(result?.status).toBe(200);
+    expect(result?.headers?.["Accept-Ranges"]).toBe("bytes");
+    expect((result?.body as Buffer).equals(Buffer.from("full-body"))).toBe(true);
+  });
 });

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -66,11 +66,16 @@ async function rehostRemoteMediaUrl(url: string): Promise<string | null> {
 const MEDIA_URL_PREFIX = "/api/media/";
 
 /**
- * Public GET route for stored media. On HTTP platforms (browser, desktop,
- * Android) the pre-auth `serveMediaFile` handler answers first and this route
- * is never reached; it exists for iOS, where requests are dispatched in-process
- * over `runtime.routes` with no HTTP server. The native bridge base64-encodes
- * the returned `Buffer` body losslessly.
+ * Public GET route for stored media. On HTTP platforms with a listening port
+ * the pre-auth `serveMediaFile` handler answers first and this route is never
+ * reached; it exists for the port-free native IPC path — iOS/desktop/Android
+ * native scheme handlers (`eliza-local-agent://ipc/api/media/…`) that dispatch
+ * in-process over `runtime.routes` with no HTTP server. The native bridge
+ * base64-encodes the returned `Buffer` body losslessly.
+ *
+ * The `Range` request header is forwarded so `handleMediaRouteRequest` can
+ * answer `206 Partial Content`, which is what lets `<audio>`/`<video>` seek
+ * over the native scheme handler.
  */
 export const mediaFileRoute: Route = {
   type: "GET",
@@ -86,6 +91,8 @@ export const mediaFileRoute: Route = {
     const result = handleMediaRouteRequest(
       `${MEDIA_URL_PREFIX}${filename}`,
       ctx.method ?? "GET",
+      // `dispatchRoute` lowercases request headers before building the context.
+      ctx.headers?.range,
     );
     return {
       status: result.status,

--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -38,10 +38,21 @@ function mediaPath(fileName: string): string {
 function makeRes(): {
   res: ServerResponse;
   get: () => { status: number; headers: Record<string, unknown>; body: string };
+  /**
+   * Resolves once the piped read stream has finished writing. The Range path
+   * pipes `createReadStream(...).pipe(res)`, which opens the file on a later
+   * tick; awaiting this keeps that async read from racing `afterAll`'s temp-dir
+   * cleanup and surfacing as an unhandled ENOENT.
+   */
+  whenEnded: () => Promise<void>;
 } {
   let status = 0;
   let headers: Record<string, unknown> = {};
   const chunks: Buffer[] = [];
+  let resolveEnded: (() => void) | undefined;
+  const ended = new Promise<void>((resolve) => {
+    resolveEnded = resolve;
+  });
   const res = {
     writeHead(s: number, h: Record<string, unknown>) {
       status = s;
@@ -51,6 +62,7 @@ function makeRes(): {
     end(body?: unknown) {
       if (typeof body === "string") chunks.push(Buffer.from(body));
       else if (Buffer.isBuffer(body)) chunks.push(body);
+      resolveEnded?.();
     },
     // createReadStream(...).pipe(res) calls write/end
     write(chunk: Buffer | string) {
@@ -69,6 +81,7 @@ function makeRes(): {
   } as unknown as ServerResponse;
   return {
     res,
+    whenEnded: () => ended,
     get: () => ({
       status,
       headers,
@@ -371,6 +384,110 @@ describe("handleMediaRouteRequest (in-process / iOS path)", () => {
     expect(handleMediaRouteRequest("/api/media/x.png", "POST").status).toBe(
       405,
     );
+  });
+
+  it("advertises Accept-Ranges: bytes so the WebView knows seeking works", () => {
+    const { url } = persistMediaBytes(Buffer.from("ranged"), "video/mp4");
+    expect(handleMediaRouteRequest(url, "GET").headers["Accept-Ranges"]).toBe(
+      "bytes",
+    );
+    // HEAD too — a player probes with HEAD before requesting ranges.
+    expect(handleMediaRouteRequest(url, "HEAD").headers["Accept-Ranges"]).toBe(
+      "bytes",
+    );
+  });
+
+  it("serves a satisfiable Range as 206 with the exact byte slice", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=2-5");
+    expect(res.status).toBe(206);
+    expect(res.headers["Content-Range"]).toBe("bytes 2-5/10");
+    expect(res.headers["Content-Length"]).toBe("4");
+    expect((res.body as Buffer).equals(Buffer.from("2345"))).toBe(true);
+  });
+
+  it("clamps an open-ended Range (bytes=N-) to the end of the file", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=7-");
+    expect(res.status).toBe(206);
+    expect(res.headers["Content-Range"]).toBe("bytes 7-9/10");
+    expect((res.body as Buffer).equals(Buffer.from("789"))).toBe(true);
+  });
+
+  it("serves a suffix Range (bytes=-N) as the last N bytes", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=-3");
+    expect(res.status).toBe(206);
+    expect(res.headers["Content-Range"]).toBe("bytes 7-9/10");
+    expect((res.body as Buffer).equals(Buffer.from("789"))).toBe(true);
+  });
+
+  it("clamps a too-large end to the last byte (partial overlap)", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=5-999");
+    expect(res.status).toBe(206);
+    expect(res.headers["Content-Range"]).toBe("bytes 5-9/10");
+    expect((res.body as Buffer).equals(Buffer.from("56789"))).toBe(true);
+  });
+
+  it("416s a Range whose start is past the end of the file", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=50-60");
+    expect(res.status).toBe(416);
+    expect(res.headers["Content-Range"]).toBe("bytes */10");
+  });
+
+  it("ignores a malformed Range and serves the full 200", () => {
+    const bytes = Buffer.from("0123456789");
+    const { url } = persistMediaBytes(bytes, "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "GET", "bytes=abc");
+    expect(res.status).toBe(200);
+    expect(res.headers["Content-Length"]).toBe("10");
+    expect((res.body as Buffer).equals(bytes)).toBe(true);
+  });
+
+  it("ignores a Range on a HEAD request (headers only, no 206)", () => {
+    const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const res = handleMediaRouteRequest(url, "HEAD", "bytes=2-5");
+    expect(res.status).toBe(200);
+    expect(res.body).toBeUndefined();
+  });
+});
+
+describe("serveMediaFile Range (HTTP path)", () => {
+  it("answers a satisfiable Range with 206 + Content-Range + sliced bytes", async () => {
+    const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const { res, get, whenEnded } = makeRes();
+    const handled = serveMediaFile(
+      { method: "GET", headers: { range: "bytes=2-5" } } as never,
+      res,
+      url,
+    );
+    expect(handled).toBe(true);
+    await whenEnded();
+    const out = get();
+    expect(out.status).toBe(206);
+    expect(out.headers["Content-Range"]).toBe("bytes 2-5/10");
+    expect(Number(out.headers["Content-Length"])).toBe(4);
+    expect(out.body).toBe("2345");
+  });
+
+  it("answers an out-of-bounds Range with 416", () => {
+    const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const { res, get } = makeRes();
+    serveMediaFile(
+      { method: "GET", headers: { range: "bytes=50-60" } } as never,
+      res,
+      url,
+    );
+    const out = get();
+    expect(out.status).toBe(416);
+    expect(out.headers["Content-Range"]).toBe("bytes */10");
   });
 });
 

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -628,15 +628,58 @@ function resolveMediaFile(
 }
 
 /**
- * Serve a media file for the IN-PROCESS route path (iOS, where no HTTP server
- * runs and requests are dispatched over `runtime.routes`). Returns a
- * RouteHandlerResult-shaped object with a `Buffer` body; the native bridge
- * base64-encodes it losslessly. No Range support — the in-process path buffers
- * the whole file, which is fine for local on-device media.
+ * Parse a single-range `Range: bytes=<start>-<end>` header against a known file
+ * size. Returns the resolved inclusive `[start, end]` byte window, `null` when
+ * the header is absent or not a byte-range we serve (caller sends the full 200),
+ * or `{ unsatisfiable: true }` when the range is syntactically valid but out of
+ * bounds (caller sends 416). Multi-range (`bytes=0-1,3-4`) is intentionally not
+ * supported — it collapses to a full 200, which every media consumer accepts.
+ *
+ * Shared by the HTTP serve path (`serveMediaFile`) and the in-process/native
+ * IPC path (`handleMediaRouteRequest`) so audio/video seek behaves identically
+ * whether the bytes ride a Node HTTP response or a native scheme handler
+ * (iOS `WKURLSchemeHandler`, Android `shouldInterceptRequest`, Electrobun).
+ */
+function parseByteRange(
+  rangeHeader: string | undefined,
+  size: number,
+): { start: number; end: number } | { unsatisfiable: true } | null {
+  if (!rangeHeader) return null;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) return null;
+  const startRaw = match[1];
+  const endRaw = match[2];
+  // `bytes=-N` is a suffix range: the last N bytes.
+  if (!startRaw && endRaw) {
+    const suffix = Number.parseInt(endRaw, 10);
+    if (Number.isNaN(suffix) || suffix <= 0) return { unsatisfiable: true };
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+  const start = startRaw ? Number.parseInt(startRaw, 10) : 0;
+  let end = endRaw ? Number.parseInt(endRaw, 10) : size - 1;
+  if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= size) {
+    return { unsatisfiable: true };
+  }
+  end = Math.min(end, size - 1);
+  return { start, end };
+}
+
+/**
+ * Serve a media file for the IN-PROCESS route path (iOS/desktop/Android native
+ * scheme handlers, where the WebView reaches the on-device agent over IPC with
+ * no HTTP server). Returns a RouteHandlerResult-shaped object with a `Buffer`
+ * body; the native bridge base64-encodes it losslessly.
+ *
+ * Honors a single-range `Range: bytes=…` header so `<audio>`/`<video>` can seek
+ * over the native scheme: a satisfiable range yields `206 Partial Content` with
+ * `Content-Range` and only the requested byte slice, an out-of-bounds range
+ * yields `416`, and no range yields the full `200`. `Accept-Ranges: bytes` is
+ * always advertised so the WebView knows seeking is available.
  */
 export function handleMediaRouteRequest(
   pathname: string,
   method: string,
+  rangeHeader?: string,
 ): { status: number; headers: Record<string, string>; body?: Buffer } {
   const TEXT = { "Content-Type": "text/plain; charset=utf-8" };
   if (method !== "GET" && method !== "HEAD") {
@@ -659,9 +702,39 @@ export function handleMediaRouteRequest(
   const headers: Record<string, string> = {
     "Content-Type": resolved.contentType,
     "Cache-Control": "public, max-age=31536000, immutable",
-    "Content-Length": String(resolved.size),
+    "Accept-Ranges": "bytes",
     ...mediaSecurityHeaders(resolved.name, resolved.contentType),
   };
+
+  const range = method === "GET" ? parseByteRange(rangeHeader, resolved.size) : null;
+  if (range && "unsatisfiable" in range) {
+    return {
+      status: 416,
+      headers: {
+        ...TEXT,
+        "Content-Range": `bytes */${resolved.size}`,
+        "Accept-Ranges": "bytes",
+      },
+      body: Buffer.from("Range not satisfiable"),
+    };
+  }
+  if (range) {
+    const length = range.end - range.start + 1;
+    return {
+      status: 206,
+      headers: {
+        ...headers,
+        "Content-Range": `bytes ${range.start}-${range.end}/${resolved.size}`,
+        "Content-Length": String(length),
+      },
+      body: fs.readFileSync(resolved.filePath).subarray(
+        range.start,
+        range.end + 1,
+      ),
+    };
+  }
+
+  headers["Content-Length"] = String(resolved.size);
   if (method === "HEAD") return { status: 200, headers };
   return { status: 200, headers, body: fs.readFileSync(resolved.filePath) };
 }
@@ -698,41 +771,25 @@ export function serveMediaFile(
     ...mediaSecurityHeaders(resolved.name, contentType),
   };
 
-  const range = req.headers.range;
-  if (range && method === "GET") {
-    const match = /^bytes=(\d*)-(\d*)$/.exec(range.trim());
-    if (match) {
-      const startRaw = match[1];
-      const endRaw = match[2];
-      let start = startRaw ? Number.parseInt(startRaw, 10) : 0;
-      let end = endRaw ? Number.parseInt(endRaw, 10) : size - 1;
-      if (!startRaw && endRaw) {
-        // suffix range: last N bytes
-        start = Math.max(0, size - Number.parseInt(endRaw, 10));
-        end = size - 1;
-      }
-      if (
-        Number.isNaN(start) ||
-        Number.isNaN(end) ||
-        start > end ||
-        start >= size
-      ) {
-        res.writeHead(416, {
-          "Content-Range": `bytes */${size}`,
-          "Content-Type": "text/plain; charset=utf-8",
-        });
-        res.end("Range not satisfiable");
-        return true;
-      }
-      end = Math.min(end, size - 1);
-      res.writeHead(206, {
-        ...baseHeaders,
-        "Content-Range": `bytes ${start}-${end}/${size}`,
-        "Content-Length": end - start + 1,
-      });
-      fs.createReadStream(filePath, { start, end }).pipe(res);
-      return true;
-    }
+  const range = method === "GET" ? parseByteRange(req.headers.range, size) : null;
+  if (range && "unsatisfiable" in range) {
+    res.writeHead(416, {
+      "Content-Range": `bytes */${size}`,
+      "Content-Type": "text/plain; charset=utf-8",
+    });
+    res.end("Range not satisfiable");
+    return true;
+  }
+  if (range) {
+    res.writeHead(206, {
+      ...baseHeaders,
+      "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+      "Content-Length": range.end - range.start + 1,
+    });
+    fs.createReadStream(filePath, { start: range.start, end: range.end }).pipe(
+      res,
+    );
+    return true;
   }
 
   res.writeHead(200, { ...baseHeaders, "Content-Length": size });

--- a/packages/ui/src/utils/attachment-url.test.ts
+++ b/packages/ui/src/utils/attachment-url.test.ts
@@ -36,6 +36,45 @@ describe("isSafeAttachmentUrl", () => {
       expect(isSafeAttachmentUrl("data:,hello")).toBe(true);
     });
 
+    it("accepts the on-device local-agent IPC media scheme", () => {
+      // How `/api/media/<hash>` resolves in mobile/desktop local mode (no HTTP
+      // port); a native scheme handler serves the bytes over IPC.
+      expect(
+        isSafeAttachmentUrl("eliza-local-agent://ipc/api/media/abc123.png"),
+      ).toBe(true);
+      expect(
+        isSafeAttachmentUrl(
+          "eliza-local-agent://ipc/api/media/abc.mp4?x=1#t=3",
+        ),
+      ).toBe(true);
+      // The bare base and a trailing-slash base are both valid app roots.
+      expect(isSafeAttachmentUrl("eliza-local-agent://ipc")).toBe(true);
+      expect(isSafeAttachmentUrl("eliza-local-agent://ipc/")).toBe(true);
+      // Case-insensitive on both scheme and the fixed authority.
+      expect(
+        isSafeAttachmentUrl("ELIZA-LOCAL-AGENT://IPC/api/media/a.png"),
+      ).toBe(true);
+    });
+
+    it("rejects a local-agent IPC URL with any other authority", () => {
+      // Only the fixed `ipc` authority is trusted; a look-alike host is a
+      // different, untrusted target.
+      expect(
+        isSafeAttachmentUrl("eliza-local-agent://evil/api/media/a.png"),
+      ).toBe(false);
+      expect(
+        isSafeAttachmentUrl("eliza-local-agent://ipcevil/api/media/a.png"),
+      ).toBe(false);
+      expect(isSafeAttachmentUrl("eliza-local-agent://ipc.evil.com/a")).toBe(
+        false,
+      );
+      // No authority at all (single slash) is not the IPC identity.
+      expect(isSafeAttachmentUrl("eliza-local-agent:/ipc/api/media/a")).toBe(
+        false,
+      );
+      expect(isSafeAttachmentUrl("eliza-local-agent:ipc")).toBe(false);
+    });
+
     it("tolerates surrounding whitespace on safe URLs", () => {
       expect(isSafeAttachmentUrl("  https://example.com/a.png  ")).toBe(true);
       expect(isSafeAttachmentUrl("\thttps://example.com/a.png\n")).toBe(true);

--- a/packages/ui/src/utils/attachment-url.ts
+++ b/packages/ui/src/utils/attachment-url.ts
@@ -13,13 +13,18 @@
  * A URL is considered safe ONLY when it is one of:
  *  - an `http://` or `https://` URL;
  *  - a root-relative / app URL (begins with `/`, e.g. `/api/media/<hash>`);
+ *  - the on-device local-agent IPC scheme `eliza-local-agent://ipc/…`, which is
+ *    how a served `/api/media/<hash>` path resolves in mobile/desktop local mode
+ *    (no HTTP port): a native scheme handler serves the bytes over IPC. This is
+ *    the ONLY custom scheme permitted, and only for its fixed `ipc` authority;
+ *    it is a same-app capability, not an attacker-controlled `foo://` sink;
  *  - a `blob:` URL;
  *  - a `data:` URL whose media type is in the allowlist
  *    (`image/*`, `audio/*`, `video/*`, `application/pdf`, `text/plain`).
  *
  * Everything else returns `false`: other/unknown schemes (`javascript:`,
- * `vbscript:`, `file:`, `mailto:`, custom `foo://`, ...), `data:` URLs with a
- * non-allowlisted media type (notably `data:text/html` and
+ * `vbscript:`, `file:`, `mailto:`, any other custom `foo://`, ...), `data:` URLs
+ * with a non-allowlisted media type (notably `data:text/html` and
  * `data:image/svg+xml`, both script-capable), empty / whitespace-only input,
  * and malformed input.
  *
@@ -43,6 +48,36 @@ const SAFE_DATA_MEDIA_TYPES_EXACT = new Set<string>([
 
 // Disallowed even though they would match a prefix above: both can run script.
 const UNSAFE_DATA_MEDIA_TYPES = new Set<string>(["image/svg+xml", "text/html"]);
+
+/**
+ * The on-device local-agent IPC identity, kept in sync with
+ * `MOBILE_LOCAL_AGENT_IPC_BASE` in `first-run/mobile-runtime-mode.ts`. A served
+ * `/api/media/<hash>` path resolves to `eliza-local-agent://ipc/api/media/…`
+ * when the app runs the bundled agent over IPC (no HTTP port). Duplicated as a
+ * bare constant here so this guard stays a zero-import leaf (it is imported into
+ * hot render paths); the value is a frozen wire identity, not a moving target.
+ */
+const LOCAL_AGENT_IPC_SCHEME = "eliza-local-agent";
+const LOCAL_AGENT_IPC_HOST = "ipc";
+
+/**
+ * True for `eliza-local-agent://ipc` and `eliza-local-agent://ipc/…` only.
+ * `sanitized` is the whitespace/control-stripped, scheme-sanitized input; the
+ * scheme is already known to be `eliza-local-agent`. Chromium treats this
+ * non-special authority as path data (`eliza-local-agent://ipc/x` →
+ * authority-less, `//ipc/x` in the path), so match on the literal
+ * `//<host>` prefix rather than trusting `URL.hostname`.
+ */
+function isLocalAgentIpcUrl(sanitized: string): boolean {
+  const afterScheme = sanitized
+    .slice(`${LOCAL_AGENT_IPC_SCHEME}:`.length)
+    .toLowerCase();
+  const authority = `//${LOCAL_AGENT_IPC_HOST}`;
+  if (afterScheme === authority) return true;
+  // Only `/`, `?`, or `#` may follow the fixed authority — never another host
+  // char (which would make `//ipcevil/…` a different, disallowed authority).
+  return /^\/\/ipc(?:[/?#]|$)/.test(afterScheme);
+}
 
 /**
  * Strip ASCII whitespace and C0/DEL control characters the way a browser does
@@ -107,6 +142,11 @@ export function isSafeAttachmentUrl(url: string): boolean {
     case "https":
     case "blob":
       return true;
+    case LOCAL_AGENT_IPC_SCHEME:
+      // The bundled on-device agent's media, served over IPC in local mode.
+      // Restricted to the fixed `ipc` authority; any other authority is a
+      // different, untrusted target and stays rejected.
+      return isLocalAgentIpcUrl(sanitized);
     case "data": {
       // Parse the media type out of `data:[<media type>][;base64],<data>`.
       // Use the sanitized string so control-char obfuscation inside the


### PR DESCRIPTION
Closes #12351 (partial — see **Scope delivered vs deferred** and **Gaps**).

Parent: #12180 (local-agent transport over IPC). Route family 7 / Decision 4 (DOM media over `eliza-local-agent://` scheme handlers with Range/206).

## What & why

When the app runs the bundled agent over IPC (mobile local mode, and desktop once the IPC api-base lands), a served `/api/media/<hash>` path resolves to `eliza-local-agent://ipc/api/media/<hash>` and there is **no HTTP port** — a native scheme handler serves the bytes over IPC. Two shared, load-bearing pieces were missing and are fixed here:

1. **Range/206 on the in-process media path.** The IPC route the native scheme handlers dispatch through (`mediaFileRoute` → `handleMediaRouteRequest`) buffered the whole file and always answered `200`, so `<audio>`/`<video>` could not seek over IPC. `handleMediaRouteRequest` now honors a single-range `Range: bytes=…` header (satisfiable → `206 Partial Content` + `Content-Range` + the requested slice; out-of-bounds → `416`; none → full `200`; `Accept-Ranges: bytes` always advertised), and `mediaFileRoute` forwards `ctx.headers.range`. The Range-parsing logic is extracted into one `parseByteRange` helper shared by the HTTP serve path (`serveMediaFile`) and the IPC path, so seek behaves identically on both; the HTTP path keeps byte-for-byte behavior.

2. **DOM-media scheme allowance.** `isSafeAttachmentUrl` (the attachment `src`/`href` scheme allowlist) rejected every custom scheme via its `default` branch, so `eliza-local-agent://ipc/api/media/…` URLs were blanked out and all agent-attachment media broke in local IPC mode. It now permits the `eliza-local-agent` scheme **only for its fixed `ipc` authority** (`ipcevil`, `evil`, `ipc.evil.com`, and non-authority forms stay rejected) — a same-app capability identity, not an attacker-controlled `foo://` sink. The check is a self-contained string test so `attachment-url.ts` stays a zero-import leaf on the hot render path.

## Scope delivered vs deferred

| Issue "Done when" bullet | Status |
| --- | --- |
| Support Range and 206 responses so audio and video can seek | **Done** on the shared IPC byte-serving path (`handleMediaRouteRequest`) + HTTP path, fully unit-tested |
| No DOM media request depends on the old local API proxy path (scheme URLs survive the attachment guard) | **Done** for the guarded agent-attachment path (`isSafeAttachmentUrl`); the unguarded app-controlled media paths (transcript/voice-preview/music-player) already pass the scheme through |
| iOS `WKURLSchemeHandler` native handler wiring | **Deferred** — see Gaps |
| Android `shouldInterceptRequest` native handler wiring | **Deferred** — see Gaps |
| Electrobun custom-scheme native handler wiring | **Deferred** — see Gaps |
| Per-platform play/seek recordings on sim/emulator/desktop | **Deferred** — see Gaps |

## Evidence checklist (per PR_EVIDENCE.md)

- **Unit tests (real code path):** `packages/agent/src/api/media-store.test.ts` + `media-runtime.test.ts` — satisfiable / open-ended (`bytes=N-`) / suffix (`bytes=-N`) / over-large / out-of-bounds (`416`) / malformed (full `200`) ranges, `Accept-Ranges` on GET+HEAD, HEAD-ignores-range, and the full `mediaFileRoute.routeHandler` dispatch with a forwarded `Range` header producing `206`. `packages/ui/src/utils/attachment-url.test.ts` — accept (bare base, trailing slash, query/fragment, case-insensitive scheme+authority) and reject (look-alike authorities, single-slash, no-authority). **55 + 27 tests green** — see `.github/issue-evidence/12351-native-media-ipc-range/test-output.md`.
- **Backend structured logs:** N/A — the change is pure byte-serving/guard logic with no new log lines; behavior is asserted by unit tests.
- **Frontend console/network traces (no old localhost path):** N/A - not headlessly reproducible in this worktree (no native build; the scheme-URL network trace only exists once a native handler is registered, which is deferred).
- **Before/after screenshots + video (desktop+mobile):** N/A - requires a running native build with a registered scheme handler (deferred); no user-visible UI surface changes in this slice.
- **Real-LLM trajectories:** N/A - no agent/action/provider/prompt/model behavior changed.
- **Per-platform capture (iOS sim / Android emu / desktop):** N/A - iOS Pods are not installed in this worktree and Android emulator / Electrobun submodule are unavailable here; the native handlers those captures would exercise are deferred.

## Commands run

- `bun run --cwd packages/agent vitest run src/api/media-store.test.ts src/api/media-runtime.test.ts` → 55 passed
- `bun run --cwd packages/ui vitest run src/utils/attachment-url.test.ts` → 27 passed
- `bunx @biomejs/biome@2.5.1 lint <touched files>` → clean
- Typecheck: the touched files (`media-store.ts`, `media-runtime.ts`, `attachment-url.ts`) produce **zero** errors; the package-wide `typecheck` reds in this worktree are pre-existing environment gaps unrelated to this change (missing generated `core/src/i18n/generated/validation-keyword-data`, missing `iwer` dev dep, unresolved `@types/node`/`react` type libs in the shared-node_modules worktree).

## Gaps (honest)

The native scheme handlers — iOS `WKURLSchemeHandler` (registered in `ElizaBridgeViewController.webViewConfiguration`), Android `shouldInterceptRequest`, and the Electrobun custom-scheme handler — are **not implemented in this PR**. Reasons:

1. **Not verifiable in this worktree.** iOS Pods are not installed (a full `cap sync` + `pod install` + web build is required and is fragile in a shared-node_modules worktree); no Android emulator is running; the Electrobun scheme handler lives in the `upstreams/electrobun` submodule which is **not checked out** (empty dir) here.
2. **Regression risk without a real build.** On iOS a `WKURLSchemeHandler` for `eliza-local-agent` intercepts **all** loads of that scheme, including the API `fetch` traffic that the already-working buffered/streaming IPC transport (#12293/#12441) relies on. Shipping that intercept unverified could silently break the stabilized IPC path. Per the repo's "prove the real thing, no larp" standard, an unverified native intercept is worse than a tested foundation with an explicit gap.

What this PR delivers is the **shared, tested foundation every native handler calls into**: the Range/206 byte-serving contract on the in-process route, and the DOM-media scheme allowance so `<img>/<audio>/<video>` survive the attachment guard once a handler is registered. The three native handlers + per-platform play/seek captures should land as a follow-up on a branch where each platform can be built and recorded on a real device/simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
