### PR TITLE
perf(voice): cut endpoint wait + wire streaming ASR partials + TTFA budgets + memory budget (#12254)

### DIFF
--- a/.github/issue-evidence/12254-voice-latency/endpoint-wait-before-after.md
+++ b/.github/issue-evidence/12254-voice-latency/endpoint-wait-before-after.md
@@ -1,0 +1,134 @@
+# #12254 — Voice latency: before/after evidence
+
+Branch `feat/12254-voice-latency` vs base `origin/develop` (a7db79c3fe0).
+Host: macOS arm64 (M-series), Bun 1.3.14. No fused `libelizainference` build is
+present on this host (only `libllama` + shim under
+`~/.eliza/local-inference/bin/`), so every measurement below states exactly
+which lane produced it.
+
+## 1. Endpoint wait (the dominant knob) — deterministic VAD timeline
+
+Method: a scripted utterance (19 speech windows ≈ 608 ms at 0.92 speech
+probability, then sustained silence at 0.02) fed through the real
+`VadDetector` state machine on its 32 ms window clock; the endpoint wait is
+`speech-end.timestampMs − last-speech-window-end`. Deterministic — the state
+machine is driven by scripted probabilities, so these numbers are exact
+(quantized up to one 32 ms window). Script: the "measured endpoint wait" test
+in `plugins/plugin-local-inference/src/services/voice/vad.v1-v4.test.ts`
+(same harness as the standalone measurement below).
+
+| Config | BEFORE (develop) | AFTER (this branch) | Δ |
+| --- | --- | --- | --- |
+| Shipped default, no semantic EOT (fixed-VAD) | **704 ms** | **512 ms** (500 floor) | **−192 ms** |
+| Fused `FfiEotScorer` composite live (`semanticEotActive`) | **704 ms** (no gate existed) | **320 ms** (300 default) | **−384 ms** |
+| Explicit `endHangoverMs: 700` (override preserved) | 704 ms | 704 ms | 0 |
+
+Raw runs:
+
+```
+BEFORE (develop @ a7db79c3fe0):
+default config (shipped): endpoint-wait=704ms (last-speech=608ms speech-end=1312ms)
+
+AFTER (this branch):
+default (no semantic EOT — fixed-VAD floor):    endpoint-wait=512ms (last-speech=608ms speech-end=1120ms)
+semanticEotActive:true (fused EOT live):        endpoint-wait=320ms (last-speech=608ms speech-end=928ms)
+explicit endHangoverMs:700 (pre-change value):  endpoint-wait=704ms (last-speech=608ms speech-end=1312ms)
+```
+
+Projection onto the measured hybrid E2E from
+`research/VOICE_VALIDATION_RUNBOOK.md:131` (~770–870 ms TTFA + the endpoint
+wait on top): cutting the endpoint wait 700→500 saves 200 ms on every turn
+today; 700→300 saves 400 ms once the fused EOT scorer ships in the production
+build — which is what brings speech-end→first-audio under the ≤800 ms good /
+toward the ≤500 ms great target (§7). The 500 ms fixed-VAD floor matches
+OpenAI Realtime `silence_duration_ms=500` and LiveKit
+`min_endpointing_delay=500` (research §1); 300 ms is permitted only when the
+semantic scorer gates commitment (mid-clause P<0.4 still extends the wait via
+`EOT_HANGOVER_EXTENSION_MS`).
+
+## 2. Turn-taking non-regression — workbench `--logic` lane vs baseline
+
+`bun run --cwd plugins/plugin-local-inference voice:workbench -- --logic
+--baseline src/services/voice/__fixtures__/voice-workbench-logic-baseline.json`
+
+| Metric | BEFORE | AFTER |
+| --- | --- | --- |
+| Overall | PASS — 18 ran, 0 skipped | PASS — 18 ran, 0 skipped |
+| EOT false-trigger rate (mean/worst, n=18) | 0 / 0 | 0 / 0 |
+| Respond accuracy | 1 | 1 |
+| WER | 0 | 0 |
+| First-audio (ms, logic-lane synthetic) | 250 | 250 |
+| Regressions vs golden baseline | none | none |
+
+Full reports: `workbench-logic-{before,after}.report.{json,md}` in this
+directory. The `pauses-midutterance` (pauses/eot class) scenario passes in
+both runs. Note the logic lane exercises the shipped EOT/respond decision
+logic over the corpus; the acoustic-layer premature-cutoff rate at the new
+hangover needs the real lane (see N/A section).
+
+## 3. Streaming-ASR partial stabilization (fake-FFI lane)
+
+The fused streaming decoder reports `asrStreamSupported() == 0` on every
+shipped build today (the C-side W7 decoder has not landed), so the streaming
+path cannot be exercised for real anywhere — including CI. Evidence is the
+scripted-FFI test lane, which drives the REAL adapter + bridge code:
+
+- `engine-bridge-asr-mode.test.ts` — a real `EngineVoiceBridge` (mocked
+  `loadElizaInferenceFfi` only) picks streaming + LocalAgreement-2
+  stabilization when the fake advertises the decoder, keeps the interim batch
+  adapter byte-identical when it does not (today's state), and honours the
+  `ELIZA_VOICE_STREAMING_ASR` kill switch and `ELIZA_LOCAL_ASR_BACKEND` pin.
+- `__tests__/streaming-transcriber.test.ts` — feeder/wrapper never emit a
+  retracted word (seeded property test over random hypothesis churn); this
+  run found and fixed a real retraction bug in `LocalAgreementBuffer` /
+  `PartialStabilizer` (a longer agreement could rewrite committed words).
+
+## 4. Memory budget — allocator wire-up
+
+`voice-budget-loaders.test.ts` drives arm/disarm cycles for all five loader
+call sites (`GgmlSileroVad.load`, `GgmlWakeWordModel.load`,
+`tryBuildFusedEotClassifier`, `VoicePipeline.run` TTS transient,
+`FfiStreamingBackend.load` text-target + drafter): reservation rows appear
+while armed, the allocator is empty after close/dispose/unload, and an
+over-budget arm throws `VoiceLifecycleError("ram-pressure")` before any
+native session opens.
+
+## 5. Verification commands run
+
+```
+bun run --cwd plugins/plugin-local-inference typecheck        # clean
+bun run --cwd plugins/plugin-local-inference lint:check       # clean
+bunx vitest run src/services/voice/ src/services/ffi-unload-ordering.test.ts \
+  src/services/memory-arbiter.test.ts src/services/memory-monitor.test.ts
+  # 1035 tests: 1031 passed, 3 skipped, 1 failed
+  # (nlms-echo-canceller.test.ts 5s timeout under 106-file parallel load —
+  #  untouched echo-domain file; passes in isolation in 3.4s)
+bun run --cwd plugins/plugin-local-inference voice:workbench -- --logic --baseline ...  # PASS, no regressions (before AND after)
+```
+
+## 6. N/A rows (with reasons)
+
+- **`GET /api/dev/voice-latency` before/after against a running app**: N/A —
+  the per-stage traces are only produced by live voice turns through the
+  fused pipeline, and no fused `libelizainference` build exists on this host
+  (or anywhere yet with the streaming decoder); a booted app would return an
+  empty trace table. The deterministic VAD-timeline measurement above is the
+  honest equivalent for the endpoint stage (the only stage this change
+  moves — decision #6 explicitly excludes synthesis/chunking).
+- **Workbench `--real` lane / real-lane ASR decode p90 (work item 3)**: N/A —
+  requires the fused lib + `ELIZA_ASR_BUNDLE` artifacts, absent on this host.
+  Consequence honoured in code: the interim-batch `stepSeconds` default STAYS
+  1.2 s (not lowered to 0.8) until the real-lane per-pass decode p90 is
+  measured below the candidate step; `ELIZA_ASR_STEP_SECONDS` + per-pass
+  `decodeStats()` timing landed so that measurement is a one-liner on
+  provisioned hardware.
+- **voicebench `speechEndToFirstAudio*Ms` p95/p99**: N/A — the suite drives
+  cloud providers (Groq Whisper/Orpheus or ElevenLabs; no keys on this host)
+  over pre-segmented fixture audio, so the endpoint wait this PR cuts is not
+  inside its measurement window either.
+- **Captured audio + narrated walkthrough**: N/A — no reachable device or
+  desktop run exercises the changed code path (the local fused voice loop)
+  without the fused build; the cloud TTS paths a desktop run would use are
+  untouched by this PR.
+- **Real-LLM trajectories**: N/A — no agent/action/provider/prompt/model
+  behavior changes; this PR is voice-runtime latency/memory plumbing.

--- a/.github/issue-evidence/12254-voice-latency/workbench-logic-after.report.json
+++ b/.github/issue-evidence/12254-voice-latency/workbench-logic-after.report.json
@@ -1,0 +1,272 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 18,
+  "scenariosRan": 18,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 44,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 18,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": null,
+    "eotLatencyP95Ms": null,
+    "der": {
+      "count": 18,
+      "mean": 0.0133,
+      "worst": 0.2394
+    },
+    "respondAccuracy": {
+      "count": 18,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 18,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 38,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    }
+  }
+}

--- a/.github/issue-evidence/12254-voice-latency/workbench-logic-after.report.md
+++ b/.github/issue-evidence/12254-voice-latency/workbench-logic-after.report.md
@@ -1,0 +1,43 @@
+# Voice Workbench report
+
+**Overall:** PASS — 18 ran, 0 skipped of 18
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 44 |
+| EOT false-trigger rate | 0 | 0 | 18 |
+| EOT latency p50 (ms) | — | | |
+| EOT latency p95 (ms) | — | | |
+| Diarization DER | 0.0133 | 0.2394 | 18 |
+| Respond accuracy | 1 | 1 | 18 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 18 |
+| First-audio (ms) | 250 | 250 | 38 |
+| Echo rejection rate | 1 | 1 | 2 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |

--- a/.github/issue-evidence/12254-voice-latency/workbench-logic-before.report.json
+++ b/.github/issue-evidence/12254-voice-latency/workbench-logic-before.report.json
@@ -1,0 +1,272 @@
+{
+  "schemaVersion": 1,
+  "overall": "pass",
+  "scenariosTotal": 18,
+  "scenariosRan": 18,
+  "scenariosSkipped": 0,
+  "scenarios": [
+    {
+      "scenarioId": "multi-voice-greeting",
+      "classes": [
+        "multi-voice",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "respond-vs-bystander",
+      "classes": [
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 9,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "pauses-midutterance",
+      "classes": [
+        "pauses",
+        "eot"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "entity-from-speech",
+      "classes": [
+        "entity-extraction",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 7,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "transcription-mode-dictation",
+      "classes": [
+        "transcription-mode",
+        "long-form-monologue"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 5,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-agent-room-address",
+      "classes": [
+        "multi-agent-room",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "noisy-room-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "music-background-commands",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "far-field-reverb",
+      "classes": [
+        "robustness",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "background-talkers",
+      "classes": [
+        "robustness",
+        "overlapping-speech",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 6,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-self-trigger",
+      "classes": [
+        "echo-rejection",
+        "respond-no-respond"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "multi-speaker-name-capture",
+      "classes": [
+        "diarization",
+        "entity-extraction",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-clean",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "diarization"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-names-noisy",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition",
+        "robustness"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 13,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "confusable-name-garbled-transcript",
+      "classes": [
+        "entity-extraction",
+        "name-disambiguation",
+        "multi-speaker",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 11,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "echo-mistranscribed",
+      "classes": [
+        "echo-rejection"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 8,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-enrollment-inference",
+      "classes": [
+        "owner-security",
+        "voice-recognition"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 15,
+      "failedCaseKinds": []
+    },
+    {
+      "scenarioId": "owner-vs-intruder",
+      "classes": [
+        "owner-security",
+        "respond-no-respond",
+        "multi-speaker"
+      ],
+      "status": "ran",
+      "verdict": "pass",
+      "caseCount": 10,
+      "failedCaseKinds": []
+    }
+  ],
+  "metrics": {
+    "wer": {
+      "count": 44,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotFalseTriggerRate": {
+      "count": 18,
+      "mean": 0,
+      "worst": 0
+    },
+    "eotLatencyP50Ms": null,
+    "eotLatencyP95Ms": null,
+    "der": {
+      "count": 18,
+      "mean": 0.0133,
+      "worst": 0.2394
+    },
+    "respondAccuracy": {
+      "count": 18,
+      "mean": 1,
+      "worst": 1
+    },
+    "entityF1": {
+      "count": 5,
+      "mean": 1,
+      "worst": 1
+    },
+    "voiceEntityMatchRate": {
+      "count": 18,
+      "mean": 1,
+      "worst": 1
+    },
+    "firstAudioMs": {
+      "count": 38,
+      "mean": 250,
+      "worst": 250
+    },
+    "echoRejectionRate": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "ownerAccuracy": {
+      "count": 2,
+      "mean": 1,
+      "worst": 1
+    },
+    "impostorAcceptRate": {
+      "count": 2,
+      "mean": 0,
+      "worst": 0
+    }
+  }
+}

--- a/.github/issue-evidence/12254-voice-latency/workbench-logic-before.report.md
+++ b/.github/issue-evidence/12254-voice-latency/workbench-logic-before.report.md
@@ -1,0 +1,43 @@
+# Voice Workbench report
+
+**Overall:** PASS — 18 ran, 0 skipped of 18
+
+## Metrics
+
+| Metric | Mean | Worst | n |
+| --- | --- | --- | --- |
+| WER | 0 | 0 | 44 |
+| EOT false-trigger rate | 0 | 0 | 18 |
+| EOT latency p50 (ms) | — | | |
+| EOT latency p95 (ms) | — | | |
+| Diarization DER | 0.0133 | 0.2394 | 18 |
+| Respond accuracy | 1 | 1 | 18 |
+| Entity F1 | 1 | 1 | 5 |
+| Voice→entity match | 1 | 1 | 18 |
+| First-audio (ms) | 250 | 250 | 38 |
+| Echo rejection rate | 1 | 1 | 2 |
+| Owner accuracy | 1 | 1 | 2 |
+| Impostor-accept rate | 0 | 0 | 2 |
+
+## Scenarios
+
+| Scenario | Classes | Verdict | Cases | Failed |
+| --- | --- | --- | --- | --- |
+| multi-voice-greeting | multi-voice, diarization | pass | 8 | — |
+| respond-vs-bystander | respond-no-respond, multi-speaker | pass | 9 | — |
+| pauses-midutterance | pauses, eot | pass | 7 | — |
+| entity-from-speech | entity-extraction, voice-recognition | pass | 7 | — |
+| transcription-mode-dictation | transcription-mode, long-form-monologue | pass | 5 | — |
+| multi-agent-room-address | multi-agent-room, respond-no-respond | pass | 8 | — |
+| noisy-room-commands | robustness, respond-no-respond | pass | 8 | — |
+| music-background-commands | robustness, respond-no-respond | pass | 8 | — |
+| far-field-reverb | robustness, respond-no-respond | pass | 6 | — |
+| background-talkers | robustness, overlapping-speech, multi-speaker | pass | 6 | — |
+| echo-self-trigger | echo-rejection, respond-no-respond | pass | 10 | — |
+| multi-speaker-name-capture | diarization, entity-extraction, multi-speaker, voice-recognition | pass | 13 | — |
+| confusable-names-clean | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, diarization | pass | 11 | — |
+| confusable-names-noisy | entity-extraction, name-disambiguation, multi-speaker, voice-recognition, robustness | pass | 13 | — |
+| confusable-name-garbled-transcript | entity-extraction, name-disambiguation, multi-speaker, voice-recognition | pass | 11 | — |
+| echo-mistranscribed | echo-rejection | pass | 8 | — |
+| owner-enrollment-inference | owner-security, voice-recognition | pass | 15 | — |
+| owner-vs-intruder | owner-security, respond-no-respond, multi-speaker | pass | 10 | — |

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1372,6 +1372,33 @@ export class LocalInferenceEngine {
 		]);
 
 		const micSource = opts.micSource ?? new DesktopMicSource();
+
+		// Fused end-of-turn scorer (ABI v11) — resolved BEFORE the VAD because
+		// its availability decides the endpoint hangover default (#12254): a
+		// live semantic EOT gate permits a 300 ms end-hangover; without one the
+		// fixed-VAD floor is 500 ms. The composite blends the fused semantic
+		// scorer (P(<end_of_turn>) over the loaded text model) with the
+		// heuristic syntactic co-signal; null on a pre-v11 library, in which
+		// case the resolver below falls through to the legacy detectors.
+		const bridgeFfi = bridge.ffi;
+		const fusedEot =
+			opts.turnDetector === false || !bridgeFfi
+				? null
+				: await eotMod.tryBuildFusedEotClassifier({
+						ffi: bridgeFfi,
+						getContext: () => {
+							const ctx = bridge.ffiCtx;
+							if (ctx === null) {
+								throw new VoiceStartupError(
+									"missing-ffi",
+									"[voice] Cannot initialize fused EOT scorer: FFI context is not loaded.",
+								);
+							}
+							return ctx;
+						},
+					});
+		const semanticEotActive = fusedEot !== null;
+
 		const vad =
 			opts.vad ??
 			(await vadMod.createSileroVadDetector({
@@ -1389,7 +1416,15 @@ export class LocalInferenceEngine {
 							return ctx;
 						}
 					: undefined,
+				config: { semanticEotActive },
 			}));
+		logger.info(
+			`[LocalInferenceEngine] voice endpoint: endHangoverMs=${vad.endHangoverMs} (${
+				semanticEotActive
+					? "fused semantic EOT active"
+					: "fixed-VAD floor — fused semantic EOT unavailable"
+			})`,
+		);
 
 		// ASR — throws `AsrUnavailableError` when the fused decoder is
 		// unavailable (the fused build is the sole on-device ASR runtime). Gated
@@ -1424,29 +1459,6 @@ export class LocalInferenceEngine {
 				"[voice] useEliza1Eot:true requested but the in-process Eliza-1 EOT scorer is unavailable on the FFI runtime — use the GGUF turn detector by setting useEliza1Eot:false.",
 			);
 		}
-		// Fused end-of-turn scorer (ABI v11): the model-based turn detector now
-		// runs in-process through libelizainference — a composite of the fused
-		// semantic scorer (P(<end_of_turn>) over the loaded text model) and the
-		// heuristic syntactic co-signal. Built only when the loaded fused build
-		// wires the v11 EOT symbol; null on a pre-v11 library, in which case the
-		// resolver falls through to the heuristic-only classifier.
-		const bridgeFfi = bridge.ffi;
-		const fusedEot =
-			opts.turnDetector === false || !bridgeFfi
-				? null
-				: eotMod.tryBuildFusedEotClassifier({
-						ffi: bridgeFfi,
-						getContext: () => {
-							const ctx = bridge.ffiCtx;
-							if (ctx === null) {
-								throw new VoiceStartupError(
-									"missing-ffi",
-									"[voice] Cannot initialize fused EOT scorer: FFI context is not loaded.",
-								);
-							}
-							return ctx;
-						},
-					});
 		// Resolver order: prefer the fused composite EOT (v11), then the legacy
 		// in-process Eliza-1 scorer + GGUF turn detector (both null on the FFI
 		// runtime — they needed node-llama controlledEvaluate), then the
@@ -1639,6 +1651,8 @@ export class LocalInferenceEngine {
 			stopMicRing();
 			void micSource.stop();
 			transcriber.dispose();
+			// Release the fused EOT scorer's voice-budget reservation.
+			fusedEot?.dispose();
 			wakeWord?.reset();
 			// G5.d: tear down only the per-room barge-in binding. The bridge
 			// owns the coordinator lifecycle and disposes it in

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
@@ -11,6 +11,8 @@
  *     here, then forwarded to runtimes that expose `describeImage`.
  */
 
+import { statSync } from "node:fs";
+import { logger } from "@elizaos/core";
 import type {
 	BackendPlan,
 	GenerateArgs,
@@ -24,6 +26,11 @@ import type {
 	LlmStreamingBinding,
 } from "./llm-streaming-binding";
 import { resolveGuidedDecodeForParams } from "./structured-output";
+import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	type VoiceBudget,
+} from "./voice/voice-budget";
 
 /**
  * Constructor-injected adapter that resolves the FFI binding, context, and
@@ -121,8 +128,17 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 
 	private session: FfiBackendSession | null = null;
 	private loadedPath: string | null = null;
+	/** Voice-budget reservations for the loaded weights (text target +
+	 *  optional separate MTP drafter). Released on unload. */
+	private budgetReservations: BudgetReservation[] = [];
+	private readonly budgetOverride: VoiceBudget | null;
 
-	constructor(private readonly runtime: FfiBackendRuntime) {}
+	constructor(
+		private readonly runtime: FfiBackendRuntime,
+		opts: { budget?: VoiceBudget } = {},
+	) {
+		this.budgetOverride = opts.budget ?? null;
+	}
 
 	async available(): Promise<boolean> {
 		return this.runtime.supported();
@@ -138,8 +154,62 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 
 	async load(plan: BackendPlan): Promise<void> {
 		if (this.session) await this.unload();
-		this.session = await this.runtime.acquire(plan);
+		// Reserve the text-target weights against the cross-model voice budget
+		// BEFORE loading (allocator contract, `voice-budget.ts`). Sized to the
+		// GGUF on disk — the mmap resident ceiling. `BudgetExhaustedError` is a
+		// hard load failure: the model genuinely does not fit this tier's
+		// co-resident budget. A path with no stat-able file carries nothing to
+		// account (the runtime's own acquire decides whether that is fatal).
+		const textBytes = fileSizeOrNull(plan.modelPath);
+		if (textBytes !== null) {
+			const budget = this.budgetOverride ?? (await ensureSharedVoiceBudget());
+			this.budgetReservations.push(
+				await budget.reserve({
+					modelId: plan.modelPath,
+					role: "text-target",
+					bytes: textBytes,
+				}),
+			);
+		}
+		try {
+			this.session = await this.runtime.acquire(plan);
+		} catch (err) {
+			this.releaseBudgetReservations();
+			throw err;
+		}
 		this.loadedPath = plan.modelPath;
+		// A separate MTP drafter GGUF is only known post-acquire; reserve it
+		// now. Embedded-draft-head MTP shares the text weights — no extra
+		// reservation.
+		const draftPath = this.session.draftModelPath;
+		const draftBytes = draftPath ? fileSizeOrNull(draftPath) : null;
+		if (draftPath && draftBytes !== null) {
+			const budget = this.budgetOverride ?? (await ensureSharedVoiceBudget());
+			try {
+				this.budgetReservations.push(
+					await budget.reserve({
+						modelId: draftPath,
+						role: "drafter",
+						bytes: draftBytes,
+					}),
+				);
+			} catch (err) {
+				logger.error(
+					{
+						draftPath,
+						error: err instanceof Error ? err.message : String(err),
+					},
+					"[FfiStreamingBackend] drafter weights exceed the voice budget — unloading",
+				);
+				await this.unload();
+				throw err;
+			}
+		}
+	}
+
+	private releaseBudgetReservations(): void {
+		for (const r of this.budgetReservations) r.release();
+		this.budgetReservations = [];
 	}
 
 	async unload(): Promise<void> {
@@ -155,6 +225,7 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 		} finally {
 			this.session = null;
 			this.loadedPath = null;
+			this.releaseBudgetReservations();
 		}
 	}
 
@@ -415,4 +486,14 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
  */
 function slotFilename(conversationId: string, slotId: number): string {
 	return `${conversationId}__slot${slotId}.kv`;
+}
+
+/** Size of a regular file on disk, or null when it cannot be stat-ed. */
+function fileSizeOrNull(filePath: string): number | null {
+	try {
+		const stat = statSync(filePath);
+		return stat.isFile() ? stat.size : null;
+	} catch {
+		return null;
+	}
 }

--- a/plugins/plugin-local-inference/src/services/voice/__tests__/streaming-transcriber.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/__tests__/streaming-transcriber.test.ts
@@ -1,16 +1,18 @@
 /**
- * Streaming-ASR integration tests for item A1 / W7.
+ * Streaming-ASR integration tests against a scripted (mock) FFI.
  *
  * Covers:
- *   1. `FfiStreamingTranscriber` against a mocked FFI delivers monotonically
- *      growing partials in feed order and a final on flush. (Complements the
- *      partial-coverage in `voice/transcriber.test.ts` — this version walks
- *      through an utterance one frame at a time and checks the partials are
- *      append-only.)
+ *   1. `FfiStreamingTranscriber` delivers monotonically growing partials in
+ *      feed order and a final on flush.
  *   2. `dispose()` cleans up the native handle without flushing first.
- *   3. `pickStreamingMode` selection table (the integration gate).
- *   4. `StreamingAsrFeeder` forwards `partial` / `words` events,
- *      finalizes once, and emits final tokens via `onFinalTokens`.
+ *   3. `pickStreamingMode` selection table + the `ELIZA_VOICE_STREAMING_ASR`
+ *      default-on env flag.
+ *   4. `StreamingAsrFeeder` stabilizes partials through the word-level
+ *      LocalAgreement-2 gate (never a retracted word — property-tested under
+ *      random hypothesis churn), announces committed words once, finalizes
+ *      once, and emits final tokens via `onFinalTokens`.
+ *   5. `StabilizedStreamingTranscriber` re-emits only committed-prefix
+ *      partials/words to its subscribers and passes finals through.
  */
 
 import { describe, expect, it } from "vitest";
@@ -21,7 +23,10 @@ import type {
 } from "../ffi-bindings";
 import {
 	pickStreamingMode,
+	readStreamingAsrEnabledFromEnv,
+	StabilizedStreamingTranscriber,
 	StreamingAsrFeeder,
+	WordAgreementGate,
 } from "../streaming-asr/streaming-pipeline-adapter";
 import { ASR_SAMPLE_RATE, FfiStreamingTranscriber } from "../transcriber";
 import type {
@@ -242,7 +247,7 @@ describe("pickStreamingMode", () => {
 /* ---- StreamingAsrFeeder -------------------------------------------- */
 
 describe("StreamingAsrFeeder", () => {
-	it("forwards partial + words events and emits final tokens on finalize", async () => {
+	it("emits LocalAgreement-2 committed prefixes + words, and final tokens on finalize", async () => {
 		const script: ScriptedStream = {
 			partials: [{ partial: "" }, { partial: "hi" }, { partial: "hi there" }],
 			final: { partial: "hi there friend", tokens: [1, 2, 3] },
@@ -275,9 +280,12 @@ describe("StreamingAsrFeeder", () => {
 		feeder.feedFrame(PCM_FRAME(160, 10));
 		feeder.feedFrame(PCM_FRAME(160, 20));
 
-		expect(partials.length).toBe(3);
-		expect(partials.map((p) => p.partial)).toEqual(["", "hi", "hi there"]);
-		// "words" fires on the FIRST partial with at least one recognized word.
+		// LocalAgreement-2: "hi" is only committed once it has appeared at the
+		// same position in two consecutive hypotheses ("hi", "hi there") — one
+		// stabilized partial, no raw-hypothesis passthrough.
+		expect(partials.map((p) => p.partial)).toEqual(["hi"]);
+		expect(feeder.getLatestPartial()?.partial).toBe("hi");
+		// "words" fires once, on the first COMMITTED word.
 		expect(words).toEqual([["hi"]]);
 
 		const final = await feeder.finalize();
@@ -296,6 +304,75 @@ describe("StreamingAsrFeeder", () => {
 
 		feeder.dispose();
 		transcriber.dispose();
+	});
+
+	it("forwards already-stabilized partials without double-gating", async () => {
+		const script: ScriptedStream = {
+			partials: [{ partial: "" }, { partial: "hi" }, { partial: "hi there" }],
+			final: { partial: "hi there friend" },
+		};
+		const { ffi } = scriptedFfi(script);
+		const stabilized = new StabilizedStreamingTranscriber(
+			new FfiStreamingTranscriber({ ffi, getContext: () => 1n }),
+		);
+
+		const partials: string[] = [];
+		const words: string[][] = [];
+		const feeder = new StreamingAsrFeeder({
+			transcriber: stabilized,
+			events: {
+				onPartial: (u) => partials.push(u.partial),
+				onWords: (w) => words.push([...w]),
+			},
+		});
+
+		feeder.feedFrame(PCM_FRAME(160, 0));
+		feeder.feedFrame(PCM_FRAME(160, 10));
+		feeder.feedFrame(PCM_FRAME(160, 20));
+
+		// One stabilization point: the wrapper committed "hi"; the feeder
+		// forwards it as-is (no second LocalAgreement window of lag).
+		expect(partials).toEqual(["hi"]);
+		expect(words).toEqual([["hi"]]);
+
+		await feeder.finalize();
+		feeder.dispose();
+		stabilized.dispose();
+	});
+
+	it("never emits a retracted word under random hypothesis churn (property)", () => {
+		// Deterministic LCG so failures reproduce.
+		let seed = 0xc0ffee;
+		const rand = () => {
+			seed = (seed * 1664525 + 1013904223) >>> 0;
+			return seed / 0xffffffff;
+		};
+		const vocab = ["the", "cat", "cap", "sat", "sit", "on", "a", "mat", "map"];
+		for (let trial = 0; trial < 50; trial++) {
+			const gate = new WordAgreementGate();
+			let surfaced: string[] = [];
+			// A hypothesis stream that grows overall but churns its tail.
+			let stable: string[] = [];
+			for (let step = 0; step < 40; step++) {
+				if (rand() < 0.6) {
+					stable = [...stable, vocab[Math.floor(rand() * vocab.length)]];
+				}
+				const churnLen = Math.floor(rand() * 3);
+				const churn = Array.from(
+					{ length: churnLen },
+					() => vocab[Math.floor(rand() * vocab.length)],
+				);
+				const hypothesis = [...stable, ...churn].join(" ");
+				const update = gate.transform({ partial: hypothesis, isFinal: false });
+				if (update === null) continue;
+				const next = update.partial.length === 0 ? [] : update.partial.split(" ");
+				// Monotonic committed prefix: every previously surfaced word is
+				// still present at the same position.
+				expect(next.length).toBeGreaterThanOrEqual(surfaced.length);
+				expect(next.slice(0, surfaced.length)).toEqual(surfaced);
+				surfaced = next;
+			}
+		}
 	});
 
 	it("drops feeds received after finalize()", async () => {
@@ -335,5 +412,113 @@ describe("StreamingAsrFeeder", () => {
 		await feeder.finalize();
 		await expect(feeder.finalize()).rejects.toThrow(/twice/i);
 		feeder.dispose();
+	});
+});
+
+/* ---- StabilizedStreamingTranscriber --------------------------------- */
+
+describe("StabilizedStreamingTranscriber", () => {
+	it("emits only committed-prefix partials and withholds raw-hypothesis words", async () => {
+		const script: ScriptedStream = {
+			// The tail word churns ("sa" → "cap" → "sat on") — only the agreed
+			// prefix may surface.
+			partials: [
+				{ partial: "the cat sa" },
+				{ partial: "the cat cap" },
+				{ partial: "the cat sat on" },
+			],
+			final: { partial: "the cat sat on a mat", tokens: [1, 2, 3, 4, 5, 6] },
+		};
+		const { ffi } = scriptedFfi(script);
+		const inner = new FfiStreamingTranscriber({ ffi, getContext: () => 1n });
+		const stabilized = new StabilizedStreamingTranscriber(inner);
+		const events = collect(stabilized);
+
+		for (let i = 0; i < 3; i++) stabilized.feed(PCM_FRAME(1600, i * 100));
+
+		const partials = events
+			.filter(
+				(e): e is TranscriberEvent & { kind: "partial" } =>
+					e.kind === "partial",
+			)
+			.map((e) => e.update.partial);
+		// Window pairs: (sa,cap) agree on "the cat"; (cap,"sat on") agree on
+		// "the cat" — no growth, suppressed.
+		expect(partials).toEqual(["the cat"]);
+
+		const wordEvents = events.filter(
+			(e): e is TranscriberEvent & { kind: "words" } => e.kind === "words",
+		);
+		expect(wordEvents).toHaveLength(1);
+		expect(wordEvents[0]?.words).toEqual(["the", "cat"]);
+
+		// The final passes through unchanged, ids intact.
+		const final = await stabilized.flush();
+		expect(final.partial).toBe("the cat sat on a mat");
+		expect(final.tokens).toEqual([1, 2, 3, 4, 5, 6]);
+		const finalEvents = events.filter((e) => e.kind === "final");
+		expect(finalEvents).toHaveLength(1);
+
+		stabilized.dispose();
+	});
+
+	it("drops raw-hypothesis token ids from stabilized partials", () => {
+		const gate = new WordAgreementGate();
+		expect(gate.transform({ partial: "hello there", isFinal: false, tokens: [7, 8] })).toBeNull();
+		const update = gate.transform({
+			partial: "hello there friend",
+			isFinal: false,
+			tokens: [7, 8, 9],
+		});
+		expect(update?.partial).toBe("hello there");
+		expect(update?.tokens).toBeUndefined();
+	});
+
+	it("resets the agreement window at segment boundaries (final)", async () => {
+		const script: ScriptedStream = {
+			partials: [{ partial: "alpha" }, { partial: "alpha beta" }],
+			final: { partial: "alpha beta" },
+		};
+		const { ffi } = scriptedFfi(script);
+		const inner = new FfiStreamingTranscriber({ ffi, getContext: () => 1n });
+		const stabilized = new StabilizedStreamingTranscriber(inner);
+		const events = collect(stabilized);
+
+		stabilized.feed(PCM_FRAME(160, 0));
+		stabilized.feed(PCM_FRAME(160, 10));
+		await stabilized.flush();
+
+		// Next segment gets a fresh window: a single hypothesis commits nothing.
+		stabilized.feed(PCM_FRAME(160, 100));
+		const partialsAfterFinal = events.filter(
+			(e, i) =>
+				e.kind === "partial" && i > events.findIndex((x) => x.kind === "final"),
+		);
+		expect(partialsAfterFinal).toHaveLength(0);
+
+		stabilized.dispose();
+	});
+});
+
+/* ---- ELIZA_VOICE_STREAMING_ASR flag ---------------------------------- */
+
+describe("readStreamingAsrEnabledFromEnv", () => {
+	it("defaults ON when unset", () => {
+		expect(readStreamingAsrEnabledFromEnv({})).toBe(true);
+	});
+
+	it.each(["0", "false", "off", "no", "FALSE", " Off "])(
+		"disables on %j",
+		(raw) => {
+			expect(
+				readStreamingAsrEnabledFromEnv({ ELIZA_VOICE_STREAMING_ASR: raw }),
+			).toBe(false);
+		},
+	);
+
+	it.each(["1", "true", "on", "yes"])("stays enabled on %j", (raw) => {
+		expect(
+			readStreamingAsrEnabledFromEnv({ ELIZA_VOICE_STREAMING_ASR: raw }),
+		).toBe(true);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/__tests__/streaming-transcriber.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/__tests__/streaming-transcriber.test.ts
@@ -365,7 +365,8 @@ describe("StreamingAsrFeeder", () => {
 				const hypothesis = [...stable, ...churn].join(" ");
 				const update = gate.transform({ partial: hypothesis, isFinal: false });
 				if (update === null) continue;
-				const next = update.partial.length === 0 ? [] : update.partial.split(" ");
+				const next =
+					update.partial.length === 0 ? [] : update.partial.split(" ");
 				// Monotonic committed prefix: every previously surfaced word is
 				// still present at the same position.
 				expect(next.length).toBeGreaterThanOrEqual(surfaced.length);
@@ -464,7 +465,13 @@ describe("StabilizedStreamingTranscriber", () => {
 
 	it("drops raw-hypothesis token ids from stabilized partials", () => {
 		const gate = new WordAgreementGate();
-		expect(gate.transform({ partial: "hello there", isFinal: false, tokens: [7, 8] })).toBeNull();
+		expect(
+			gate.transform({
+				partial: "hello there",
+				isFinal: false,
+				tokens: [7, 8],
+			}),
+		).toBeNull();
 		const update = gate.transform({
 			partial: "hello there friend",
 			isFinal: false,
@@ -507,14 +514,18 @@ describe("readStreamingAsrEnabledFromEnv", () => {
 		expect(readStreamingAsrEnabledFromEnv({})).toBe(true);
 	});
 
-	it.each(["0", "false", "off", "no", "FALSE", " Off "])(
-		"disables on %j",
-		(raw) => {
-			expect(
-				readStreamingAsrEnabledFromEnv({ ELIZA_VOICE_STREAMING_ASR: raw }),
-			).toBe(false);
-		},
-	);
+	it.each([
+		"0",
+		"false",
+		"off",
+		"no",
+		"FALSE",
+		" Off ",
+	])("disables on %j", (raw) => {
+		expect(
+			readStreamingAsrEnabledFromEnv({ ELIZA_VOICE_STREAMING_ASR: raw }),
+		).toBe(false);
+	});
 
 	it.each(["1", "true", "on", "yes"])("stays enabled on %j", (raw) => {
 		expect(

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge-asr-mode.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge-asr-mode.test.ts
@@ -1,0 +1,174 @@
+/**
+ * ASR drive-mode gating at the engine-bridge transcriber seam (#12254).
+ * Constructs real bridges over a mocked `loadElizaInferenceFfi` (no native
+ * library): a streaming-capable fake yields a `StabilizedStreamingTranscriber`
+ * with committed-prefix partials; an unsupported build (today's state) or the
+ * `ELIZA_VOICE_STREAMING_ASR` kill switch yields the interim batch adapter.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fakeFfi } from "./__test-helpers__/fake-ffi";
+import { EngineVoiceBridge } from "./engine-bridge";
+import type { ElizaInferenceFfi } from "./ffi-bindings";
+import type { VoiceLifecycleLoaders } from "./lifecycle";
+import type { MmapRegionHandle, RefCountedResource } from "./shared-resources";
+import { StabilizedStreamingTranscriber } from "./streaming-asr/streaming-pipeline-adapter";
+import { FfiBatchTranscriber } from "./transcriber";
+import type { TranscriberEvent } from "./types";
+import { writeVoicePresetFile } from "./voice-preset-format";
+
+const ffiHolder = vi.hoisted(() => ({
+	current: null as unknown,
+}));
+
+vi.mock("./ffi-bindings", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./ffi-bindings")>();
+	return {
+		...actual,
+		loadElizaInferenceFfi: () => {
+			if (!ffiHolder.current) {
+				throw new Error("test forgot to set ffiHolder.current");
+			}
+			return ffiHolder.current;
+		},
+	};
+});
+
+function lifecycleLoadersOk(): VoiceLifecycleLoaders {
+	const region: MmapRegionHandle = {
+		id: "region-ok",
+		path: "/tmp/tts-ok",
+		sizeBytes: 1024,
+		async evictPages() {},
+		async release() {},
+	};
+	const refc: RefCountedResource = { id: "refc-ok", async release() {} };
+	return {
+		loadTtsRegion: async () => region,
+		loadAsrRegion: async () => region,
+		loadVoiceCaches: async () => refc,
+		loadVoiceSchedulerNodes: async () => refc,
+	};
+}
+
+describe("EngineVoiceBridge ASR drive mode (#12254)", () => {
+	let bundleRoot: string;
+	let savedFlag: string | undefined;
+	let savedBackendPin: string | undefined;
+
+	beforeEach(() => {
+		bundleRoot = mkdtempSync(path.join(tmpdir(), "eliza-asr-mode-"));
+		mkdirSync(path.join(bundleRoot, "cache"), { recursive: true });
+		const embedding = new Float32Array(16);
+		for (let i = 0; i < embedding.length; i++) embedding[i] = (i + 1) / 100;
+		writeFileSync(
+			path.join(bundleRoot, "cache", "voice-preset-default.bin"),
+			Buffer.from(writeVoicePresetFile({ embedding, phrases: [] })),
+		);
+		// A lib file must exist on disk (loadElizaInferenceFfi itself is mocked)
+		// and an asr/ region so the bundle reports ASR available.
+		mkdirSync(path.join(bundleRoot, "lib"), { recursive: true });
+		for (const name of [
+			"libelizainference.dylib",
+			"libelizainference.so",
+			"elizainference.dll",
+		]) {
+			writeFileSync(path.join(bundleRoot, "lib", name), "fake");
+		}
+		mkdirSync(path.join(bundleRoot, "asr"), { recursive: true });
+		writeFileSync(path.join(bundleRoot, "asr", "asr-model.gguf"), "fake");
+		savedFlag = process.env.ELIZA_VOICE_STREAMING_ASR;
+		savedBackendPin = process.env.ELIZA_LOCAL_ASR_BACKEND;
+		delete process.env.ELIZA_VOICE_STREAMING_ASR;
+		delete process.env.ELIZA_LOCAL_ASR_BACKEND;
+	});
+
+	afterEach(() => {
+		rmSync(bundleRoot, { recursive: true, force: true });
+		if (savedFlag === undefined) delete process.env.ELIZA_VOICE_STREAMING_ASR;
+		else process.env.ELIZA_VOICE_STREAMING_ASR = savedFlag;
+		if (savedBackendPin === undefined)
+			delete process.env.ELIZA_LOCAL_ASR_BACKEND;
+		else process.env.ELIZA_LOCAL_ASR_BACKEND = savedBackendPin;
+	});
+
+	async function armedBridge(
+		ffi: ElizaInferenceFfi,
+	): Promise<EngineVoiceBridge> {
+		ffiHolder.current = ffi;
+		const bridge = EngineVoiceBridge.start({
+			bundleRoot,
+			useFfiBackend: true,
+			lifecycleLoaders: lifecycleLoadersOk(),
+		});
+		await bridge.arm();
+		return bridge;
+	}
+
+	it("picks streaming + stabilization when the fused decoder is live (default flag ON)", async () => {
+		const bridge = await armedBridge(
+			fakeFfi("hello there world", { asrStreamSupported: true }),
+		);
+		const transcriber = bridge.createStreamingTranscriber();
+		expect(transcriber).toBeInstanceOf(StabilizedStreamingTranscriber);
+
+		// Per-frame partials reach subscribers as committed prefixes: the fake
+		// repeats the same hypothesis, so LocalAgreement-2 commits on frame 2.
+		const events: TranscriberEvent[] = [];
+		transcriber.on((e) => events.push(e));
+		const frame = {
+			pcm: new Float32Array(1600).fill(0.05),
+			sampleRate: 16_000,
+			timestampMs: 0,
+		};
+		transcriber.feed(frame);
+		transcriber.feed({ ...frame, timestampMs: 100 });
+		const partials = events.filter((e) => e.kind === "partial");
+		expect(partials).toHaveLength(1);
+		expect(
+			partials[0]?.kind === "partial" ? partials[0].update.partial : "",
+		).toBe("hello there world");
+
+		// The final seeds the drafter identically to batch.
+		const final = await transcriber.flush();
+		expect(final.partial).toBe("hello there world");
+
+		transcriber.dispose();
+		bridge.dispose();
+	});
+
+	it("keeps the batch adapter byte-identical when the build reports unsupported (today)", async () => {
+		const bridge = await armedBridge(
+			fakeFfi("hello", { asrStreamSupported: false }),
+		);
+		const transcriber = bridge.createStreamingTranscriber();
+		expect(transcriber).toBeInstanceOf(FfiBatchTranscriber);
+		transcriber.dispose();
+		bridge.dispose();
+	});
+
+	it("ELIZA_VOICE_STREAMING_ASR=0 pins batch even on a streaming-capable build", async () => {
+		process.env.ELIZA_VOICE_STREAMING_ASR = "0";
+		const bridge = await armedBridge(
+			fakeFfi("hello", { asrStreamSupported: true }),
+		);
+		const transcriber = bridge.createStreamingTranscriber();
+		expect(transcriber).toBeInstanceOf(FfiBatchTranscriber);
+		transcriber.dispose();
+		bridge.dispose();
+	});
+
+	it("an explicit ELIZA_LOCAL_ASR_BACKEND=fused pin wins over the capability gate", async () => {
+		process.env.ELIZA_LOCAL_ASR_BACKEND = "fused";
+		const bridge = await armedBridge(
+			fakeFfi("hello", { asrStreamSupported: true }),
+		);
+		const transcriber = bridge.createStreamingTranscriber();
+		expect(transcriber).toBeInstanceOf(StabilizedStreamingTranscriber);
+		transcriber.dispose();
+		bridge.dispose();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -103,9 +103,19 @@ import {
 	SpeakerPresetCache,
 } from "./speaker-preset-cache";
 import {
+	pickStreamingMode,
+	readStreamingAsrEnabledFromEnv,
+	StabilizedStreamingTranscriber,
+	type StreamingPipelineMode,
+} from "./streaming-asr/streaming-pipeline-adapter";
+import {
 	ASR_SAMPLE_RATE,
 	AsrUnavailableError,
 	createStreamingTranscriber,
+	DEFAULT_ASR_STEP_SECONDS,
+	ffiSupportsStreamingAsr,
+	readAsrBackendPreferenceFromEnv,
+	readAsrStepSecondsFromEnv,
 	resampleLinear,
 } from "./transcriber";
 import type {
@@ -121,6 +131,10 @@ import type {
 	TtsBackend,
 	VadEventSource,
 } from "./types";
+import {
+	KOKORO_TTS_TRANSIENT_PEAK_BYTES,
+	OMNIVOICE_TTS_TRANSIENT_PEAK_BYTES,
+} from "./voice-budget";
 import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec";
 
 const SAMPLE_RATE_DEFAULT = 24_000;
@@ -1701,11 +1715,15 @@ export class EngineVoiceBridge {
 	/**
 	 * Construct a `StreamingTranscriber` for live ASR — the contract the
 	 * voice turn controller (W9) feeds mic frames into and the barge-in
-	 * word-confirm gate (W1) listens to. Resolves the adapter chain:
-	 *   fused `libelizainference` streaming ASR (final path, gated on a
-	 *   working decoder AND a bundled ASR model) → fused batch ASR over the
-	 *   same bundled model → `AsrUnavailableError`. The Eliza-1 bridge runs
-	 *   only the fused path; the whisper.cpp interim fallback has been removed.
+	 * word-confirm gate (W1) listens to. The drive mode is picked by
+	 * `pickStreamingMode` (#12254): the fused streaming decoder when the
+	 * loaded build advertises one, the ASR bundle is present, and
+	 * `ELIZA_VOICE_STREAMING_ASR` is not disabled (default on) — else the
+	 * interim windowed-batch adapter, announced at INFO. In streaming mode
+	 * the transcriber is wrapped in `StabilizedStreamingTranscriber`
+	 * (word-level LocalAgreement-2) so subscribers only ever see a
+	 * monotonic committed prefix. No fused decoder at all →
+	 * `AsrUnavailableError`; the whisper.cpp fallback has been removed.
 	 *
 	 * Pass W1's `vad` event stream to gate decoding to active speech
 	 * windows. Caller owns the returned transcriber's lifecycle (`dispose()`).
@@ -1714,13 +1732,62 @@ export class EngineVoiceBridge {
 		vad?: VadEventSource;
 	}): StreamingTranscriber {
 		this.assertVoiceOn("create streaming transcriber");
+		return this.constructTranscriber(opts);
+	}
+
+	/** Last ASR drive mode announced, so the pick is logged once per change. */
+	private loggedAsrDriveMode: StreamingPipelineMode | null = null;
+
+	/**
+	 * Shared transcriber construction (mode pick + loud announcement +
+	 * streaming-partial stabilization). `createStreamingTranscriber` adds the
+	 * voice-on assertion; `resolveTranscriber` adds the deferred-failure
+	 * wrapper for the pipeline path.
+	 */
+	private constructTranscriber(opts?: {
+		vad?: VadEventSource;
+	}): StreamingTranscriber {
 		const contextRef = this.ffiContextRef;
-		return createStreamingTranscriber({
+		// An explicit ELIZA_LOCAL_ASR_BACKEND pin wins over the capability
+		// gate; otherwise streaming is picked exactly when supported + present
+		// + not disabled by ELIZA_VOICE_STREAMING_ASR.
+		const envPrefer = readAsrBackendPreferenceFromEnv();
+		const mode: StreamingPipelineMode =
+			envPrefer === "fused"
+				? "streaming"
+				: envPrefer === "ffi-batch"
+					? "batch"
+					: pickStreamingMode({
+							ffiSupportsStreaming: ffiSupportsStreamingAsr(this.ffi),
+							asrBundlePresent: this.asrAvailable,
+							enableStreaming: readStreamingAsrEnabledFromEnv(),
+						});
+		if (this.loggedAsrDriveMode !== mode) {
+			this.loggedAsrDriveMode = mode;
+			if (mode === "streaming") {
+				logger.info(
+					"[EngineVoiceBridge] ASR drive mode: streaming — fused eliza_inference_asr_stream_* decoder with LocalAgreement-2 partial stabilization",
+				);
+			} else {
+				logger.info(
+					`[EngineVoiceBridge] ASR drive mode: batch — fused streaming decoder ${
+						ffiSupportsStreamingAsr(this.ffi)
+							? "disabled (ELIZA_VOICE_STREAMING_ASR/ELIZA_LOCAL_ASR_BACKEND)"
+							: "unavailable on this build (asrStreamSupported() == 0)"
+					}; interim windowed re-transcription at stepSeconds=${readAsrStepSecondsFromEnv() ?? DEFAULT_ASR_STEP_SECONDS}`,
+				);
+			}
+		}
+		const transcriber = createStreamingTranscriber({
 			ffi: this.ffi,
 			getContext: contextRef ? () => contextRef.ensure() : undefined,
 			asrBundlePresent: this.asrAvailable,
 			vad: opts?.vad,
+			prefer: mode === "streaming" ? "fused" : "ffi-batch",
 		});
+		return mode === "streaming"
+			? new StabilizedStreamingTranscriber(transcriber)
+			: transcriber;
 	}
 
 	/**
@@ -2026,11 +2093,23 @@ export class EngineVoiceBridge {
 		events?: VoicePipelineEvents,
 	): VoicePipeline {
 		const transcriber = this.resolveTranscriber();
+		// Per-turn TTS transient reservation (#12254): sized to the measured
+		// decode peak of the backend actually wired. Backends without a
+		// measured table entry (test stubs/overrides) carry no reservation.
+		const ttsTransientBytes =
+			this.backend instanceof FfiOmniVoiceBackend
+				? OMNIVOICE_TTS_TRANSIENT_PEAK_BYTES
+				: this.backend instanceof KokoroTtsBackend
+					? KOKORO_TTS_TRANSIENT_PEAK_BYTES
+					: null;
 		const deps: VoicePipelineDeps = {
 			scheduler: this.scheduler,
 			transcriber,
 			drafter: new MtpDraftProposer(textRunner),
 			verifier: new MtpTargetVerifier(textRunner),
+			...(ttsTransientBytes !== null
+				? { ttsTransientReservation: { bytes: ttsTransientBytes } }
+				: {}),
 		};
 		return new VoicePipeline(deps, config, events);
 	}
@@ -2046,13 +2125,8 @@ export class EngineVoiceBridge {
 	 * silent cloud fallback.
 	 */
 	private resolveTranscriber(): StreamingTranscriber {
-		const ctxRef = this.ffiContextRef;
 		try {
-			return createStreamingTranscriber({
-				ffi: this.ffi,
-				getContext: ctxRef ? () => ctxRef.ensure() : undefined,
-				asrBundlePresent: this.asrAvailable,
-			});
+			return this.constructTranscriber();
 		} catch (err) {
 			if (err instanceof AsrUnavailableError) {
 				return new MissingAsrTranscriber(err.message);

--- a/plugins/plugin-local-inference/src/services/voice/eot-classifier.ts
+++ b/plugins/plugin-local-inference/src/services/voice/eot-classifier.ts
@@ -41,6 +41,13 @@ import type {
 } from "./eliza1-eot-scorer";
 import { Eliza1EotScorer } from "./eliza1-eot-scorer";
 import { FfiEotScorer, type FfiEotScorerOptions } from "./fused-eot-scorer";
+import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	FUSED_EOT_SCORER_RESERVE_BYTES,
+	reserveOrRamPressure,
+	type VoiceBudget,
+} from "./voice-budget";
 
 // ---------------------------------------------------------------------------
 // Interface
@@ -360,16 +367,26 @@ export class CompositeEotClassifier implements EotClassifier {
 	private readonly model: FfiEotScorer;
 	private readonly heuristic: HeuristicEotClassifier;
 	private readonly confidenceCutoff: number;
+	/** Voice-budget reservation for the scorer's dedicated native scoring
+	 *  context; held for the session, released via `dispose()`. */
+	private readonly reservation: BudgetReservation | null;
 
 	constructor(options: {
 		model: FfiEotScorer;
 		heuristic?: HeuristicEotClassifier;
 		confidenceCutoff?: number;
+		reservation?: BudgetReservation | null;
 	}) {
 		this.model = options.model;
 		this.heuristic = options.heuristic ?? new HeuristicEotClassifier();
 		this.confidenceCutoff =
 			options.confidenceCutoff ?? COMPOSITE_HEURISTIC_CONFIDENCE_CUTOFF;
+		this.reservation = options.reservation ?? null;
+	}
+
+	/** Release the voice-budget reservation. Idempotent; call at session teardown. */
+	dispose(): void {
+		this.reservation?.release();
 	}
 
 	private async blend(
@@ -413,10 +430,26 @@ export class CompositeEotClassifier implements EotClassifier {
  * Build a composite EOT classifier backed by the fused FFI scorer, or null when
  * the loaded fused build does not wire the v11 EOT symbol (a pre-v11 library) —
  * the caller then falls back to a heuristic-only classifier.
+ *
+ * Reserves the scorer's dedicated scoring-context envelope against the voice
+ * budget at session arm; the caller releases it via `dispose()` at teardown.
+ * An over-budget arm throws `VoiceLifecycleError("ram-pressure")`.
  */
-export function tryBuildFusedEotClassifier(
-	options: FfiEotScorerOptions,
-): CompositeEotClassifier | null {
+export async function tryBuildFusedEotClassifier(
+	options: FfiEotScorerOptions & {
+		/** Voice-budget override; defaults to the process-wide shared budget. */
+		budget?: VoiceBudget;
+	},
+): Promise<CompositeEotClassifier | null> {
 	if (!FfiEotScorer.isSupported(options.ffi)) return null;
-	return new CompositeEotClassifier({ model: new FfiEotScorer(options) });
+	const budget = options.budget ?? (await ensureSharedVoiceBudget());
+	const reservation = await reserveOrRamPressure(budget, {
+		modelId: options.modelLabel ?? "eliza-1-fused-eot",
+		role: "turn-detector",
+		bytes: FUSED_EOT_SCORER_RESERVE_BYTES,
+	});
+	return new CompositeEotClassifier({
+		model: new FfiEotScorer(options),
+		reservation,
+	});
 }

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -343,15 +343,29 @@ export {
 	type WavFileAudioSinkOptions,
 } from "./system-audio-sink";
 export {
+	LocalAgreementBuffer,
+	type PickStreamingModeArgs,
+	pickStreamingMode,
+	readStreamingAsrEnabledFromEnv,
+	StabilizedStreamingTranscriber,
+	StreamingAsrFeeder,
+	type StreamingAsrFeederEvents,
+	type StreamingPipelineMode,
+	WordAgreementGate,
+} from "./streaming-asr/streaming-pipeline-adapter";
+export {
 	ASR_SAMPLE_RATE,
+	type AsrDecodePassStats,
 	AsrUnavailableError,
 	BaseStreamingTranscriber,
 	type CreateStreamingTranscriberOptions,
 	createStreamingTranscriber,
+	DEFAULT_ASR_STEP_SECONDS,
 	FfiBatchTranscriber,
 	type FfiBatchTranscriberOptions,
 	FfiStreamingTranscriber,
 	ffiSupportsStreamingAsr,
+	readAsrStepSecondsFromEnv,
 	resampleLinear,
 } from "./transcriber";
 export {
@@ -366,6 +380,8 @@ export * from "./types";
 export {
 	createSileroVadDetector,
 	createVadDetector,
+	END_HANGOVER_FIXED_VAD_MS,
+	END_HANGOVER_SEMANTIC_EOT_MS,
 	type ExternalVadAdapter,
 	GgmlSileroVad,
 	NativeSileroVad,
@@ -391,9 +407,16 @@ export {
 	createVoiceBudget,
 	createVoiceBudgetForTest,
 	DEFAULT_VOICE_BUNDLE_RESERVE_MB,
+	ensureSharedVoiceBudget,
+	FUSED_EOT_SCORER_RESERVE_BYTES,
+	KOKORO_TTS_TRANSIENT_PEAK_BYTES,
+	OMNIVOICE_TTS_TRANSIENT_PEAK_BYTES,
 	pickVoiceTierSlot,
 	priorityClassForRole,
 	type ReservationSnapshot,
+	reserveOrRamPressure,
+	setSharedVoiceBudgetForTest,
+	VAD_RESERVE_BYTES,
 	VOICE_ENSEMBLE_BUDGETS,
 	type VoiceBudget,
 	type VoiceBundleFitDecision,
@@ -401,6 +424,7 @@ export {
 	type VoiceTierSlot,
 	voiceEnsemblePeakMb,
 	voiceEnsembleSteadyStateMb,
+	WAKE_WORD_RESERVE_BYTES,
 } from "./voice-budget";
 export {
 	type ArbiterPreloader,

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -337,12 +337,6 @@ export {
 	voicePresetPath,
 } from "./speaker-preset-cache";
 export {
-	SystemAudioSink,
-	type SystemAudioSinkOptions,
-	WavFileAudioSink,
-	type WavFileAudioSinkOptions,
-} from "./system-audio-sink";
-export {
 	LocalAgreementBuffer,
 	type PickStreamingModeArgs,
 	pickStreamingMode,
@@ -353,6 +347,12 @@ export {
 	type StreamingPipelineMode,
 	WordAgreementGate,
 } from "./streaming-asr/streaming-pipeline-adapter";
+export {
+	SystemAudioSink,
+	type SystemAudioSinkOptions,
+	WavFileAudioSink,
+	type WavFileAudioSinkOptions,
+} from "./system-audio-sink";
 export {
 	ASR_SAMPLE_RATE,
 	type AsrDecodePassStats,

--- a/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/partial-stabilizer.ts
@@ -17,11 +17,12 @@
  * jitter, small enough that the stable prefix tracks the speaker
  * within ~one extra frame.
  *
- * Wiring: the streaming-ASR adapter calls `feed(partial)` per frame; the
- * `stable` portion is what flows into `splitTranscriptToTokens` and the
- * drafter. `pending` is suffix-only, fed to UI for visual feedback. The
- * stabilizer is feature-flagged off until the streaming-ASR backend is
- * wired (see `voice/pipeline.ts`'s `usePartialStabilizer`).
+ * Consumer split (#12254): this character-prefix variant serves UI caption
+ * rendering, where sub-word agreement ("sa" → "sat") keeps captions
+ * responsive and `pending` gives visual feedback. The drafter / barge-in
+ * word-confirm consumers use the word-level `LocalAgreementBuffer` /
+ * `WordAgreementGate` in `streaming-asr/streaming-pipeline-adapter.ts`,
+ * applied automatically by the engine bridge in streaming mode.
  *
  * No `any`, no fallbacks: a malformed partial (e.g. an empty string)
  * collapses the stable prefix to whatever the agreement window still
@@ -116,7 +117,13 @@ export class PartialStabilizer {
 			}
 			if (agreed.length === 0) break;
 		}
-		if (agreed.length > this.committed.length) {
+		// Extend committed only when the new agreement PRESERVES what was
+		// already committed — a longer agreement that disagrees inside the
+		// committed span must not rewrite it (monotonic contract).
+		if (
+			agreed.length > this.committed.length &&
+			agreed.startsWith(this.committed)
+		) {
 			this.committed = agreed;
 		}
 		return {

--- a/plugins/plugin-local-inference/src/services/voice/pipeline.ts
+++ b/plugins/plugin-local-inference/src/services/voice/pipeline.ts
@@ -46,6 +46,12 @@ import type {
 	TranscriptionAudio,
 	VerifierStreamEvent,
 } from "./types";
+import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	reserveOrRamPressure,
+	type VoiceBudget,
+} from "./voice-budget";
 
 /**
  * Split a transcript string into contiguous text tokens. The fused ASR
@@ -136,6 +142,15 @@ export interface VoicePipelineDeps {
 	transcriber: StreamingTranscriber;
 	drafter: DraftProposer;
 	verifier: TargetVerifier;
+	/**
+	 * When set, `run()` reserves `bytes` under role `"tts"` against the voice
+	 * budget for the duration of the turn — the TTS backend's transient decode
+	 * peak (OmniVoice MaskGIT ~1.17 GB / Kokoro ~100 MB; see `voice-budget.ts`).
+	 * Released when the turn settles, whatever the exit reason. Over-budget
+	 * turns throw `VoiceLifecycleError("ram-pressure")` before ASR starts.
+	 * `budget` defaults to the process-wide shared budget.
+	 */
+	ttsTransientReservation?: { bytes: number; budget?: VoiceBudget };
 }
 
 export interface VoicePipelineConfig {
@@ -219,6 +234,10 @@ export class VoicePipeline {
 	 * can plug straight in once it ships.
 	 */
 	private readonly partialStabilizer: PartialStabilizer | null;
+	private readonly ttsTransientReservation: {
+		bytes: number;
+		budget?: VoiceBudget;
+	} | null;
 	private active: PipelineRun | null = null;
 
 	constructor(
@@ -230,6 +249,7 @@ export class VoicePipeline {
 		this.transcriber = deps.transcriber;
 		this.drafter = deps.drafter;
 		this.verifier = deps.verifier;
+		this.ttsTransientReservation = deps.ttsTransientReservation ?? null;
 		this.maxDraftTokens = Math.max(1, Math.floor(config.maxDraftTokens));
 		this.maxGeneratedTokens = Math.max(
 			1,
@@ -281,6 +301,20 @@ export class VoicePipeline {
 				"[voice-pipeline] a turn is already running; cancel() it or await the previous run() first",
 			);
 		}
+		// Reserve the TTS transient decode peak for the turn (#12254). The
+		// reservation covers the synth passes this turn dispatches; releasing
+		// in `finally` returns the budget whatever the exit reason.
+		let ttsReservation: BudgetReservation | null = null;
+		if (this.ttsTransientReservation) {
+			const budget =
+				this.ttsTransientReservation.budget ??
+				(await ensureSharedVoiceBudget());
+			ttsReservation = await reserveOrRamPressure(budget, {
+				modelId: "tts-transient",
+				role: "tts",
+				bytes: this.ttsTransientReservation.bytes,
+			});
+		}
 		const cancel = { cancelled: false };
 		const done = this.execute(audio, cancel);
 		this.active = { cancel, done };
@@ -288,6 +322,7 @@ export class VoicePipeline {
 			return await done;
 		} finally {
 			this.active = null;
+			ttsReservation?.release();
 		}
 	}
 

--- a/plugins/plugin-local-inference/src/services/voice/shared-resources.ts
+++ b/plugins/plugin-local-inference/src/services/voice/shared-resources.ts
@@ -43,6 +43,8 @@ export type ResidentModelRole =
 	| "speaker-id"
 	| "vision"
 	| "embedding"
+	| "turn-detector"
+	| "wake-word"
 	| "vad"
 	| "asr"
 	| "tts"
@@ -53,7 +55,10 @@ export type ResidentModelRole =
  * `emotion < speaker-id < vision/mmproj < embedding < vad < ASR <
  * TTS < text-target`. The cold-3 set (`emotion`, `speaker-id`) is cheap to
  * load on demand, so evicting them is the first reclamation step under
- * sustained pressure. See `.swarm/research/R9-memory.md` §4.1.
+ * sustained pressure. The MB-scale session-arm auxiliaries (`turn-detector`,
+ * `wake-word`) slot into the warm band below the VAD: cheap to drop, but
+ * losing them degrades turn-taking mid-session. See
+ * `.swarm/research/R9-memory.md` §4.1.
  */
 export const RESIDENT_ROLE_PRIORITY: Readonly<
 	Record<ResidentModelRole, number>
@@ -63,6 +68,8 @@ export const RESIDENT_ROLE_PRIORITY: Readonly<
 	"speaker-id": 18,
 	vision: 20,
 	embedding: 25,
+	"turn-detector": 28,
+	"wake-word": 30,
 	vad: 35,
 	asr: 40,
 	tts: 50,

--- a/plugins/plugin-local-inference/src/services/voice/streaming-asr/streaming-pipeline-adapter.ts
+++ b/plugins/plugin-local-inference/src/services/voice/streaming-asr/streaming-pipeline-adapter.ts
@@ -1,41 +1,33 @@
 /**
- * Streaming-ASR pipeline adapter (item A1 / W7).
+ * Streaming-ASR mode selection + partial stabilization for the engine
+ * bridge's live ASR path (#12254).
  *
- * The base `VoicePipeline` in `voice/pipeline.ts` drives a `StreamingTranscriber`
- * as a batch: it pushes the WHOLE VAD-gated utterance buffer in a single
- * `feed()` call, awaits `flush()`, and only then splits the final transcript
- * into tokens for the drafter/verifier loop. That works for the fused
- * batch decoder, but it leaves the biggest
- * H2 UX seam (incremental partials → planner / barge-in word-confirm /
- * speculative-on-pause) untapped when the fused build is in streaming mode.
+ * `EngineVoiceBridge.createStreamingTranscriber` picks the transcription
+ * drive mode via `pickStreamingMode` — the fused streaming decoder is used
+ * only when the loaded build advertises it (`asrStreamSupported() === 1`),
+ * the ASR bundle is on disk, AND `ELIZA_VOICE_STREAMING_ASR` is not
+ * disabled (default ON when supported). Any other combination keeps the
+ * interim windowed-batch adapter (`FfiBatchTranscriber`), announced loudly
+ * at the bridge — never a silent downgrade.
  *
- * Rather than rewrite `pipeline.ts` (the Phase 0/1 agent owns it), this
- * module is a small WRAPPER the engine bridge can use to deliver PCM
- * chunks to a `StreamingTranscriber` as they arrive from the mic / VAD,
- * surface every `partial` event to the turn controller via `onPartial`,
- * and only finalize on `speech-end`. Behind a flag — when the fused
- * library advertises `asrStreamSupported() === false` or the flag is off
- * the caller keeps using `VoicePipeline.transcribeAll` exactly as today.
+ * In streaming mode every raw hypothesis is passed through a word-level
+ * LocalAgreement-2 gate before downstream consumers see it, so the
+ * speculative drafter, barge-in word-confirm, and turn-signal refresh only
+ * ever observe a monotonically growing committed prefix — never a
+ * retracted word. Two stabilizer variants serve two consumer classes:
  *
- * Integration point (documented for the Phase 0/1 agent so they can wire
- * it without merge friction):
+ *   - `LocalAgreementBuffer` (word-level, here) — feeds the drafter /
+ *     verifier / word-confirm consumers, which operate on word tokens.
+ *   - `PartialStabilizer` (`../partial-stabilizer.ts`, character-prefix) —
+ *     serves UI caption rendering, where sub-word agreement ("sa" → "sat")
+ *     keeps captions responsive.
  *
- *   1. `EngineVoiceBridge` decides whether streaming is available via
- *      `pickStreamingMode({ ffi, asrBundlePresent, flag })`. When the
- *      mode is `"streaming"`, the bridge constructs `StreamingAsrFeeder`
- *      once per turn (passing the same transcriber that would have been
- *      handed to `VoicePipeline`) and routes mic PCM frames through
- *      `feeder.feedFrame(frame)` instead of buffering them.
- *   2. The feeder forwards every transcriber `partial` event to
- *      `onPartial(update)`. When VAD reports `speech-end` the caller
- *      calls `await feeder.finalize()`; the returned `TranscriptUpdate`
- *      is the final and is used to seed the drafter/verifier loop exactly
- *      as before (`splitTranscriptToTokens(final.partial, 0, final.tokens)`).
- *   3. The batch path (`VoicePipeline.transcribeAll`) is unchanged for
- *      every other adapter — there is no fork in `pipeline.ts` itself.
- *
- * This file is intentionally small and side-effect-free so it can land
- * during the merge window without touching files other agents own.
+ * `StreamingAsrFeeder` is the per-turn drive for connector integrations:
+ * route mic PCM through `feedFrame()`, `finalize()` on VAD `speech-end`;
+ * the final transcript seeds the drafter exactly like the batch path
+ * (`splitTranscriptToTokens(final.partial, 0, final.tokens)`). The batch
+ * path (`VoicePipeline.transcribeAll`) is unchanged — no fork in
+ * `pipeline.ts`.
  */
 
 import { splitTranscriptToTokens } from "../pipeline";
@@ -43,6 +35,8 @@ import type {
 	PcmFrame,
 	StreamingTranscriber,
 	TextToken,
+	TranscriberEvent,
+	TranscriberEventListener,
 	TranscriptUpdate,
 } from "../types";
 
@@ -128,9 +122,18 @@ export class LocalAgreementBuffer {
 			agreedLen = matchLen;
 			if (agreedLen === 0) break;
 		}
-		// Extend committed if the new agreement is longer.
+		// Extend committed only when the new agreement PRESERVES the already
+		// committed words — a longer agreement that disagrees inside the
+		// committed prefix must not rewrite it (once committed, never
+		// retracted; the hypotheses will converge and extend later).
 		if (agreedLen > this.committed.length) {
-			this.committed = first.slice(0, agreedLen);
+			const candidate = first.slice(0, agreedLen);
+			const preservesCommitted = this.committed.every(
+				(word, i) => candidate[i] === word,
+			);
+			if (preservesCommitted) {
+				this.committed = candidate;
+			}
 		}
 		return this.committed;
 	}
@@ -150,16 +153,26 @@ export class LocalAgreementBuffer {
 /** Available transcription drive modes. */
 export type StreamingPipelineMode = "streaming" | "batch";
 
+/**
+ * `ELIZA_VOICE_STREAMING_ASR` — the streaming-ASR kill switch. Default ON:
+ * when the fused build advertises a working streaming decoder it is used
+ * (with partial stabilization). Set `0` / `false` / `off` / `no` to pin the
+ * interim batch adapter.
+ */
+export function readStreamingAsrEnabledFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	const raw = env.ELIZA_VOICE_STREAMING_ASR?.trim().toLowerCase();
+	if (!raw) return true;
+	return !(raw === "0" || raw === "false" || raw === "off" || raw === "no");
+}
+
 export interface PickStreamingModeArgs {
 	/** True only when the loaded fused library advertises a working streaming decoder. */
 	ffiSupportsStreaming: boolean;
 	/** True only when the bundled ASR model is present on disk. */
 	asrBundlePresent: boolean;
-	/**
-	 * Feature flag — defaults to FALSE so the streaming path stays opt-in
-	 * until the Phase 0/1 partial-stabilizer wiring lands. Once that lands
-	 * the engine bridge flips this default to true.
-	 */
+	/** `readStreamingAsrEnabledFromEnv()` at the bridge — default ON. */
 	enableStreaming: boolean;
 }
 
@@ -182,18 +195,150 @@ export function pickStreamingMode(
 	return "streaming";
 }
 
+/* ==================================================================== *
+ * Word-agreement gate — shared partial-stabilization transform.
+ * ==================================================================== */
+
+/** Whitespace word split. Keeps punctuation attached to its word. */
+function splitWords(text: string): string[] {
+	const trimmed = text.trim();
+	return trimmed.length === 0 ? [] : trimmed.split(/\s+/);
+}
+
+/**
+ * Applies word-level LocalAgreement-n to a stream of raw `partial`
+ * hypotheses. `transform()` returns a committed-prefix update when the
+ * agreed prefix grew, `null` to suppress (no growth — downstream already
+ * saw everything committed). The committed prefix is monotonically
+ * non-decreasing; a word, once surfaced, is never retracted. Token ids are
+ * dropped from stabilized partials (they describe the raw hypothesis, not
+ * the committed prefix); the authoritative `final` keeps its ids.
+ */
+export class WordAgreementGate {
+	private readonly buffer: LocalAgreementBuffer;
+	private surfacedWordCount = 0;
+
+	constructor(agreementCount = 2) {
+		this.buffer = new LocalAgreementBuffer(agreementCount);
+	}
+
+	transform(update: TranscriptUpdate): TranscriptUpdate | null {
+		const committed = this.buffer.stable(splitWords(update.partial));
+		if (committed.length <= this.surfacedWordCount) return null;
+		this.surfacedWordCount = committed.length;
+		const { tokens: _tokens, ...rest } = update;
+		return { ...rest, partial: committed.join(" "), isFinal: false };
+	}
+
+	/** The committed stable word list (read-only view). */
+	committedWords(): ReadonlyArray<string> {
+		return this.buffer.getCommitted();
+	}
+
+	/** Clear all state. Call at utterance boundaries. */
+	reset(): void {
+		this.buffer.reset();
+		this.surfacedWordCount = 0;
+	}
+}
+
+/**
+ * `StreamingTranscriber` decorator that stabilizes `partial` events through
+ * a `WordAgreementGate` before its own subscribers see them. The engine
+ * bridge wraps the fused streaming transcriber with this in streaming mode,
+ * so the turn controller's existing subscription observes only monotonic
+ * committed-prefix partials — no turn-controller edits needed.
+ *
+ * Event contract:
+ *   - `partial` — emitted only when the committed prefix grows, carrying the
+ *     committed text (raw-hypothesis metadata preserved, token ids dropped).
+ *   - `words`  — emitted once per segment, the first time the COMMITTED
+ *     prefix contains ≥1 word (the inner raw-hypothesis `words` event is
+ *     withheld so barge-in word-confirm cannot fire on an unstable word).
+ *   - `final`  — passed through unchanged (authoritative), resets the gate.
+ */
+export class StabilizedStreamingTranscriber implements StreamingTranscriber {
+	private readonly listeners = new Set<TranscriberEventListener>();
+	private readonly gate: WordAgreementGate;
+	private wordsEmitted = false;
+	private innerUnsub: (() => void) | null;
+
+	constructor(
+		readonly inner: StreamingTranscriber,
+		agreementCount = 2,
+	) {
+		this.gate = new WordAgreementGate(agreementCount);
+		this.innerUnsub = inner.on((event) => this.onInnerEvent(event));
+	}
+
+	feed(frame: PcmFrame): void {
+		this.inner.feed(frame);
+	}
+
+	flush(): Promise<TranscriptUpdate> {
+		return this.inner.flush();
+	}
+
+	on(listener: TranscriberEventListener): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	dispose(): void {
+		this.innerUnsub?.();
+		this.innerUnsub = null;
+		this.listeners.clear();
+		this.inner.dispose();
+	}
+
+	private onInnerEvent(event: TranscriberEvent): void {
+		switch (event.kind) {
+			case "partial": {
+				const update = this.gate.transform(event.update);
+				if (!update) return;
+				this.emit({ kind: "partial", update });
+				if (!this.wordsEmitted) {
+					const words = this.gate.committedWords();
+					if (words.length > 0) {
+						this.wordsEmitted = true;
+						this.emit({ kind: "words", words: [...words] });
+					}
+				}
+				return;
+			}
+			case "words":
+				// Withheld: derived from the raw hypothesis. The stabilized
+				// `words` event above replaces it once the prefix commits.
+				return;
+			case "final":
+				this.gate.reset();
+				this.wordsEmitted = false;
+				this.emit(event);
+				return;
+		}
+	}
+
+	private emit(event: TranscriberEvent): void {
+		for (const l of this.listeners) l(event);
+	}
+}
+
 export interface StreamingAsrFeederEvents {
 	/**
-	 * Called for every transcriber `partial` event the feeder observes
-	 * BEFORE the segment is finalized. Includes the running `partial`
-	 * text, `isFinal: false`, and (when the fused build supplied them)
-	 * the shared text-model token ids.
+	 * Called when the segment's stabilized transcript grows, BEFORE the
+	 * segment is finalized. Every raw hypothesis passes through a
+	 * word-level `WordAgreementGate` (LocalAgreement-2) first, so this
+	 * only ever carries a monotonically growing committed prefix — a word,
+	 * once delivered, is never retracted. When the transcriber is already
+	 * a `StabilizedStreamingTranscriber` the feeder forwards its (already
+	 * stabilized) partials as-is rather than double-gating.
 	 */
 	onPartial?(update: TranscriptUpdate): void;
 	/**
-	 * Called the first time ≥1 real word is recognized in the segment.
+	 * Called the first time ≥1 COMMITTED word is recognized in the segment.
 	 * Wired into the turn controller's word-confirm gate so the agent
-	 * only barge-in-cancels on real speech, not blips.
+	 * only barge-in-cancels on real, stable speech — not a blip or an
+	 * unconfirmed first hypothesis.
 	 */
 	onWords?(words: ReadonlyArray<string>): void;
 	/**
@@ -222,6 +367,9 @@ export interface StreamingAsrFeederEvents {
 export class StreamingAsrFeeder {
 	private readonly transcriber: StreamingTranscriber;
 	private readonly events: StreamingAsrFeederEvents;
+	/** Non-null unless the transcriber is already stabilized upstream. */
+	private readonly gate: WordAgreementGate | null;
+	private wordsAnnounced = false;
 	private latestPartial: TranscriptUpdate | null = null;
 	private finalized = false;
 	private unsubscribe: (() => void) | null = null;
@@ -232,14 +380,36 @@ export class StreamingAsrFeeder {
 	}) {
 		this.transcriber = args.transcriber;
 		this.events = args.events ?? {};
+		// One stabilization point per stream: when the bridge already wrapped
+		// the transcriber, its partials are committed prefixes — re-gating
+		// them would only add a hypothesis of lag.
+		this.gate =
+			args.transcriber instanceof StabilizedStreamingTranscriber
+				? null
+				: new WordAgreementGate();
 		this.unsubscribe = this.transcriber.on((event) => {
 			switch (event.kind) {
-				case "partial":
-					this.latestPartial = event.update;
-					this.events.onPartial?.(event.update);
+				case "partial": {
+					const update = this.gate
+						? this.gate.transform(event.update)
+						: event.update;
+					if (!update) break;
+					this.latestPartial = update;
+					this.events.onPartial?.(update);
+					if (this.gate && !this.wordsAnnounced) {
+						const words = this.gate.committedWords();
+						if (words.length > 0) {
+							this.wordsAnnounced = true;
+							this.events.onWords?.([...words]);
+						}
+					}
 					break;
+				}
 				case "words":
-					this.events.onWords?.(event.words);
+					// With a local gate the raw-hypothesis `words` event is
+					// withheld — the committed-prefix announcement above
+					// replaces it. Already-stabilized streams forward theirs.
+					if (!this.gate) this.events.onWords?.(event.words);
 					break;
 				case "final":
 					// Final events are surfaced via `finalize()`'s return value so
@@ -279,7 +449,7 @@ export class StreamingAsrFeeder {
 		return final;
 	}
 
-	/** The most recent `partial` snapshot observed, or `null` until the first decode lands. */
+	/** The most recent stabilized `partial`, or `null` until the first prefix commits. */
 	getLatestPartial(): TranscriptUpdate | null {
 		return this.latestPartial;
 	}

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.test.ts
@@ -15,8 +15,10 @@ import {
 	ASR_SAMPLE_RATE,
 	AsrUnavailableError,
 	createStreamingTranscriber,
+	DEFAULT_ASR_STEP_SECONDS,
 	FfiBatchTranscriber,
 	FfiStreamingTranscriber,
+	readAsrStepSecondsFromEnv,
 	resampleLinear,
 } from "./transcriber";
 import type {
@@ -188,6 +190,46 @@ describe("FfiBatchTranscriber — windowed batch ASR (interim)", () => {
 		await t.flush();
 		expect(fed.some((n) => n === 1600)).toBe(true);
 		t.dispose();
+	});
+
+	it("reads the step cadence from ELIZA_ASR_STEP_SECONDS (default 1.2 s) and records per-pass decode timings", async () => {
+		expect(readAsrStepSecondsFromEnv({})).toBeNull();
+		expect(
+			readAsrStepSecondsFromEnv({ ELIZA_ASR_STEP_SECONDS: "0.8" }),
+		).toBeCloseTo(0.8);
+		expect(
+			readAsrStepSecondsFromEnv({ ELIZA_ASR_STEP_SECONDS: "-1" }),
+		).toBeNull();
+		expect(
+			readAsrStepSecondsFromEnv({ ELIZA_ASR_STEP_SECONDS: "nope" }),
+		).toBeNull();
+		expect(DEFAULT_ASR_STEP_SECONDS).toBe(1.2);
+
+		const saved = process.env.ELIZA_ASR_STEP_SECONDS;
+		process.env.ELIZA_ASR_STEP_SECONDS = "0.5";
+		try {
+			const ffi = makeFakeFfi({
+				streamSupported: false,
+				transcribe: () => "x",
+			});
+			const t = new FfiBatchTranscriber({ ffi, getContext: () => 1n });
+			// With a 0.5 s step, a 0.6 s frame triggers an interim decode pass
+			// (the 1.2 s default would not decode until flush).
+			t.feed({
+				pcm: new Float32Array(ASR_SAMPLE_RATE * 0.6).fill(0.05),
+				sampleRate: ASR_SAMPLE_RATE,
+				timestampMs: 0,
+			});
+			await t.flush();
+			const stats = t.decodeStats();
+			expect(stats.passes).toBeGreaterThanOrEqual(2); // interim + final
+			expect(stats.totalMs).toBeGreaterThanOrEqual(0);
+			expect(stats.lastMs).toBeLessThanOrEqual(stats.totalMs + 1e-6);
+			t.dispose();
+		} finally {
+			if (saved === undefined) delete process.env.ELIZA_ASR_STEP_SECONDS;
+			else process.env.ELIZA_ASR_STEP_SECONDS = saved;
+		}
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.ts
@@ -531,7 +531,9 @@ export class FfiBatchTranscriber extends BaseStreamingTranscriber {
 		const windowSeconds = opts.windowSeconds ?? 6.0;
 		const overlapSeconds = Math.min(opts.overlapSeconds ?? 1.0, windowSeconds);
 		const stepSeconds =
-			opts.stepSeconds ?? readAsrStepSecondsFromEnv() ?? DEFAULT_ASR_STEP_SECONDS;
+			opts.stepSeconds ??
+			readAsrStepSecondsFromEnv() ??
+			DEFAULT_ASR_STEP_SECONDS;
 		this.windowSamples = Math.round(windowSeconds * ASR_SAMPLE_RATE);
 		this.overlapSamples = Math.round(overlapSeconds * ASR_SAMPLE_RATE);
 		this.stepSamples = Math.round(stepSeconds * ASR_SAMPLE_RATE);

--- a/plugins/plugin-local-inference/src/services/voice/transcriber.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcriber.ts
@@ -429,6 +429,38 @@ export class FfiStreamingTranscriber extends BaseStreamingTranscriber {
  * Fused batch (interim streaming) path — eliza_inference_asr_transcribe.
  * ==================================================================== */
 
+/**
+ * Interim-batch partial cadence (s). Partials go stale by up to one step, so
+ * a shorter step cuts interim staleness — but decodes serialize on the shared
+ * ASR mutex, so a step shorter than the per-pass decode time just queues.
+ * 1.2 s stays the default until a real-lane measurement shows per-pass decode
+ * p90 below the candidate step (#12254 work item 3; target 0.8 s). Tune via
+ * `ELIZA_ASR_STEP_SECONDS`.
+ */
+export const DEFAULT_ASR_STEP_SECONDS = 1.2;
+
+/** Read `ELIZA_ASR_STEP_SECONDS` — a positive float — or null when unset/invalid. */
+export function readAsrStepSecondsFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): number | null {
+	const raw = env.ELIZA_ASR_STEP_SECONDS?.trim();
+	if (!raw) return null;
+	const value = Number.parseFloat(raw);
+	return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+/** Per-pass decode timing for the interim batch adapter (`decodeStats()`). */
+export interface AsrDecodePassStats {
+	/** Decode passes run since construction/reset. */
+	passes: number;
+	/** Wall-clock ms spent inside `asrTranscribe` across all passes. */
+	totalMs: number;
+	/** Slowest single pass, ms. */
+	maxMs: number;
+	/** Most recent pass, ms. */
+	lastMs: number;
+}
+
 export interface FfiBatchTranscriberOptions {
 	ffi: ElizaInferenceFfi;
 	getContext: () => ElizaInferenceContextHandle;
@@ -439,7 +471,8 @@ export interface FfiBatchTranscriberOptions {
 	windowSeconds?: number;
 	/** Trailing overlap kept when committing a prefix chunk, seconds. Default 1.0. */
 	overlapSeconds?: number;
-	/** Minimum new audio (seconds) accumulated before the next decode pass. Default 1.2. */
+	/** Minimum new audio (seconds) accumulated before the next decode pass.
+	 *  Default `ELIZA_ASR_STEP_SECONDS` env else `DEFAULT_ASR_STEP_SECONDS`. */
 	stepSeconds?: number;
 }
 
@@ -480,6 +513,14 @@ export class FfiBatchTranscriber extends BaseStreamingTranscriber {
 	/** Decode chain — `asr_transcribe` calls serialize on the native ASR mutex anyway. */
 	private decodeChain: Promise<void> = Promise.resolve();
 
+	/** Per-pass decode timing — the measurement that gates a shorter step. */
+	private readonly passStats: AsrDecodePassStats = {
+		passes: 0,
+		totalMs: 0,
+		maxMs: 0,
+		lastMs: 0,
+	};
+
 	constructor(opts: FfiBatchTranscriberOptions) {
 		super(opts.vad, {
 			...opts.metadata,
@@ -489,21 +530,34 @@ export class FfiBatchTranscriber extends BaseStreamingTranscriber {
 		this.getContext = opts.getContext;
 		const windowSeconds = opts.windowSeconds ?? 6.0;
 		const overlapSeconds = Math.min(opts.overlapSeconds ?? 1.0, windowSeconds);
-		const stepSeconds = opts.stepSeconds ?? 1.2;
+		const stepSeconds =
+			opts.stepSeconds ?? readAsrStepSecondsFromEnv() ?? DEFAULT_ASR_STEP_SECONDS;
 		this.windowSamples = Math.round(windowSeconds * ASR_SAMPLE_RATE);
 		this.overlapSamples = Math.round(overlapSeconds * ASR_SAMPLE_RATE);
 		this.stepSamples = Math.round(stepSeconds * ASR_SAMPLE_RATE);
 	}
 
+	/** Snapshot of per-pass decode timings (copies; safe to hold). */
+	decodeStats(): AsrDecodePassStats {
+		return { ...this.passStats };
+	}
+
 	private decodeWindow(pcm16k: Float32Array): string {
 		if (pcm16k.length === 0) return "";
-		return this.ffi
+		const started = performance.now();
+		const text = this.ffi
 			.asrTranscribe({
 				ctx: this.getContext(),
 				pcm: pcm16k,
 				sampleRateHz: ASR_SAMPLE_RATE,
 			})
 			.trim();
+		const elapsed = performance.now() - started;
+		this.passStats.passes += 1;
+		this.passStats.totalMs += elapsed;
+		this.passStats.lastMs = elapsed;
+		if (elapsed > this.passStats.maxMs) this.passStats.maxMs = elapsed;
+		return text;
 	}
 
 	protected onFrame(frame: PcmFrame): void {

--- a/plugins/plugin-local-inference/src/services/voice/vad.ts
+++ b/plugins/plugin-local-inference/src/services/voice/vad.ts
@@ -36,13 +36,6 @@ import type {
 	ElizaInferenceFfi,
 	NativeVadHandle,
 } from "./ffi-bindings";
-import {
-	type BudgetReservation,
-	ensureSharedVoiceBudget,
-	reserveOrRamPressure,
-	VAD_RESERVE_BYTES,
-	type VoiceBudget,
-} from "./voice-budget";
 import type {
 	EnergyGateEvent,
 	EnergyGateListener,
@@ -50,6 +43,13 @@ import type {
 	VadEvent,
 	VadEventListener,
 } from "./types";
+import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	reserveOrRamPressure,
+	VAD_RESERVE_BYTES,
+	type VoiceBudget,
+} from "./voice-budget";
 
 /** Thrown when the Silero VAD backend cannot be loaded — the native VAD FFI
  *  is missing or ABI-only, the model file is absent, or the model is corrupt.

--- a/plugins/plugin-local-inference/src/services/voice/vad.ts
+++ b/plugins/plugin-local-inference/src/services/voice/vad.ts
@@ -36,6 +36,13 @@ import type {
 	ElizaInferenceFfi,
 	NativeVadHandle,
 } from "./ffi-bindings";
+import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	reserveOrRamPressure,
+	VAD_RESERVE_BYTES,
+	type VoiceBudget,
+} from "./voice-budget";
 import type {
 	EnergyGateEvent,
 	EnergyGateListener,
@@ -122,13 +129,17 @@ export class GgmlSileroVad {
 	readonly sampleRate: number;
 	readonly windowSamples = SILERO_WINDOW_16K;
 	private closed = false;
+	/** Voice-budget reservation held while the native session is open. */
+	private readonly reservation: BudgetReservation | null;
 
 	private constructor(
 		private readonly ffi: ElizaInferenceFfi,
 		private readonly handle: NativeVadHandle,
 		sampleRate: number,
+		reservation: BudgetReservation | null,
 	) {
 		this.sampleRate = sampleRate;
+		this.reservation = reservation;
 	}
 
 	/** True when the libelizainference build exports the native VAD ABI and
@@ -143,6 +154,8 @@ export class GgmlSileroVad {
 		ffi: ElizaInferenceFfi;
 		ctx: ElizaInferenceContextHandle | (() => ElizaInferenceContextHandle);
 		sampleRate?: number;
+		/** Voice-budget override; defaults to the process-wide shared budget. */
+		budget?: VoiceBudget;
 	}): Promise<GgmlSileroVad> {
 		const sampleRate = opts.sampleRate ?? 16_000;
 		validateSileroSampleRate(sampleRate);
@@ -163,9 +176,22 @@ export class GgmlSileroVad {
 				"[voice] Native GGML Silero VAD support probe succeeded, but the required VAD FFI methods are missing.",
 			);
 		}
-		const ctx = typeof opts.ctx === "function" ? opts.ctx() : opts.ctx;
-		const handle = opts.ffi.vadOpen({ ctx, sampleRateHz: sampleRate });
-		return new GgmlSileroVad(opts.ffi, handle, sampleRate);
+		// Reserve before the native session opens; an over-budget arm throws
+		// `VoiceLifecycleError("ram-pressure")` and nothing is loaded.
+		const budget = opts.budget ?? (await ensureSharedVoiceBudget());
+		const reservation = await reserveOrRamPressure(budget, {
+			modelId: "silero-vad-v5",
+			role: "vad",
+			bytes: VAD_RESERVE_BYTES,
+		});
+		try {
+			const ctx = typeof opts.ctx === "function" ? opts.ctx() : opts.ctx;
+			const handle = opts.ffi.vadOpen({ ctx, sampleRateHz: sampleRate });
+			return new GgmlSileroVad(opts.ffi, handle, sampleRate, reservation);
+		} catch (err) {
+			reservation.release();
+			throw err;
+		}
 	}
 
 	async process(window: Float32Array): Promise<number> {
@@ -201,6 +227,7 @@ export class GgmlSileroVad {
 			throw new Error("[voice] GgmlSileroVad.close missing FFI method");
 		}
 		vadClose(this.handle);
+		this.reservation?.release();
 	}
 }
 
@@ -336,8 +363,18 @@ export interface VadDetectorConfig {
 	 * Default false until the streaming-ASR fast path (V2) ships.
 	 */
 	fastEndpointEnabled?: boolean;
+	/**
+	 * True when a semantic end-of-turn scorer (the fused `FfiEotScorer`
+	 * composite) is live for this session. Decides the `endHangoverMs`
+	 * default: 300 ms with a semantic gate in front, 500 ms fixed-VAD floor
+	 * without one (research §1 — production fixed-VAD defaults cluster at
+	 * 500 ms; ~200 ms is safe only when a semantic model makes the real
+	 * call). Ignored when `endHangoverMs` is set explicitly.
+	 */
+	semanticEotActive?: boolean;
 	/** Consecutive ms paused before the segment *ends* (finalize the turn).
-	 *  Default 700 ms. Must be ≥ `pauseHangoverMs`. */
+	 *  Default `END_HANGOVER_SEMANTIC_EOT_MS` (300) when `semanticEotActive`,
+	 *  else `END_HANGOVER_FIXED_VAD_MS` (500). Must be ≥ `pauseHangoverMs`. */
 	endHangoverMs?: number;
 	/** A segment shorter than this (from onset to end) is reclassified as a
 	 *  `blip` rather than `speech-end`. Default 250 ms. */
@@ -370,6 +407,19 @@ export interface VadDetectorConfig {
 	energyGate?: RmsEnergyGateConfig;
 }
 
+/**
+ * Endpoint-wait defaults (issue #12254). The end-hangover is the silence the
+ * user sits through between their last word and turn finalization — the
+ * single largest tunable latency knob in the voice loop. With a semantic EOT
+ * scorer live the acoustic wait can drop to 300 ms (the scorer catches
+ * mid-thought pauses the timer cannot); without one, 500 ms is the
+ * fixed-VAD floor (OpenAI/LiveKit production defaults — see
+ * `research/VOICE_PIPELINE_RESEARCH_2026.md` §1). Never go below the floor
+ * without a semantic gate.
+ */
+export const END_HANGOVER_SEMANTIC_EOT_MS = 300;
+export const END_HANGOVER_FIXED_VAD_MS = 500;
+
 type SegmentPhase = "idle" | "speaking" | "paused";
 
 export type { VadLike } from "./types.js";
@@ -397,6 +447,8 @@ export interface CreateVadDetectorOptions {
 	externalVad?: ExternalVadAdapter | null;
 	config?: VadDetectorConfig;
 	prefer?: VadProviderPreference;
+	/** Voice-budget override; defaults to the process-wide shared budget. */
+	budget?: VoiceBudget;
 }
 
 export function vadProviderOrder(
@@ -468,6 +520,7 @@ export async function resolveVadProvider(
 						ffi: opts.ffi,
 						ctx: opts.ctx,
 						sampleRate,
+						...(opts.budget ? { budget: opts.budget } : {}),
 					}),
 				};
 			}
@@ -500,7 +553,8 @@ export class VadDetector {
 	private readonly pauseHangoverMs: number;
 	private readonly fastPauseHangoverMs: number;
 	private readonly fastEndpointEnabled: boolean;
-	private readonly endHangoverMs: number;
+	/** Effective endpoint hangover (ms) — public so session arm can log it. */
+	readonly endHangoverMs: number;
 	private readonly minSpeechMs: number;
 	private readonly activeHeartbeatMs: number;
 	// V4 — adaptive hangover state.
@@ -548,7 +602,10 @@ export class VadDetector {
 			this.fastEndpointEnabled
 				? this.fastPauseHangoverMs
 				: this.pauseHangoverMs,
-			config.endHangoverMs ?? 700,
+			config.endHangoverMs ??
+				(config.semanticEotActive
+					? END_HANGOVER_SEMANTIC_EOT_MS
+					: END_HANGOVER_FIXED_VAD_MS),
 		);
 		this.minSpeechMs = config.minSpeechMs ?? 250;
 		this.activeHeartbeatMs = config.activeHeartbeatMs ?? 200;

--- a/plugins/plugin-local-inference/src/services/voice/vad.v1-v4.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/vad.v1-v4.test.ts
@@ -1,5 +1,5 @@
 /**
- * V1 / V4 — fast-endpoint and adaptive-hangover VAD tests.
+ * V1 / V4 / endpoint-hangover VAD tests (deterministic scripted Silero).
  *
  * V1: when `fastEndpointEnabled` is true, the detector uses
  * `fastPauseHangoverMs` instead of the conservative 220 ms default.
@@ -8,11 +8,21 @@
  * trajectory (energy trailing off) collapses the pause hangover to the
  * configured floor — the detector decides "you stopped talking" sooner
  * when the audio confirms it.
+ *
+ * Endpoint hangover (#12254): the `endHangoverMs` default is 300 ms when a
+ * semantic EOT gate is live, 500 ms fixed-VAD floor otherwise; explicit
+ * config always wins. Includes a timeline measurement of the wait between
+ * last speech and `speech-end`.
  */
 
 import { describe, expect, it } from "vitest";
 import type { PcmFrame, VadEvent } from "./types";
-import { VadDetector, type VadLike } from "./vad";
+import {
+	END_HANGOVER_FIXED_VAD_MS,
+	END_HANGOVER_SEMANTIC_EOT_MS,
+	VadDetector,
+	type VadLike,
+} from "./vad";
 
 const SR = 16_000;
 const FRAME = 512;
@@ -218,5 +228,82 @@ describe("V4 — adaptive hangover on sharp RMS drop", () => {
 		if (pause?.type !== "speech-pause") throw new Error("missing");
 		// Floor is 64 ms (~2 windows). Pause shouldn't fire before that.
 		expect(pause.pauseDurationMs).toBeGreaterThanOrEqual(64);
+	});
+});
+
+describe("endpoint hangover defaults (#12254)", () => {
+	const silero = () => new ScriptedSileroWithEnergy([0.9]);
+
+	it("defaults to the 500 ms fixed-VAD floor without a semantic EOT gate", () => {
+		expect(new VadDetector(silero(), {}).endHangoverMs).toBe(
+			END_HANGOVER_FIXED_VAD_MS,
+		);
+		expect(END_HANGOVER_FIXED_VAD_MS).toBe(500);
+	});
+
+	it("defaults to 300 ms when semanticEotActive is true", () => {
+		expect(
+			new VadDetector(silero(), { semanticEotActive: true }).endHangoverMs,
+		).toBe(END_HANGOVER_SEMANTIC_EOT_MS);
+		expect(END_HANGOVER_SEMANTIC_EOT_MS).toBe(300);
+	});
+
+	it("explicit endHangoverMs always wins over the semantic default", () => {
+		expect(
+			new VadDetector(silero(), {
+				semanticEotActive: true,
+				endHangoverMs: 700,
+			}).endHangoverMs,
+		).toBe(700);
+		expect(
+			new VadDetector(silero(), {
+				semanticEotActive: false,
+				endHangoverMs: 250,
+			}).endHangoverMs,
+		).toBe(250);
+	});
+
+	it("never drops below the pause hangover", () => {
+		expect(
+			new VadDetector(silero(), {
+				semanticEotActive: true,
+				pauseHangoverMs: 400,
+			}).endHangoverMs,
+		).toBe(400);
+	});
+
+	it("measured endpoint wait: speech-end fires ~endHangoverMs after last speech", async () => {
+		// ~600 ms of speech (19 windows), then sustained silence.
+		const measure = async (config: {
+			semanticEotActive?: boolean;
+		}): Promise<number> => {
+			const probs = [
+				...Array.from({ length: 19 }, () => 0.92),
+				...Array.from({ length: 60 }, () => 0.02),
+			];
+			const det = new VadDetector(new ScriptedSileroWithEnergy(probs), config);
+			let lastSpeechMs = 0;
+			let endMs: number | null = null;
+			det.onVadEvent((e) => {
+				if (e.type === "speech-end") endMs = e.timestampMs;
+			});
+			let ts = 0;
+			for (let w = 0; w < probs.length; w++) {
+				const rms = probs[w] > 0.5 ? 0.25 : 0.0005;
+				await det.pushFrame(frameWithRms(rms, ts));
+				if (probs[w] > 0.5) lastSpeechMs = ts + FRAME_MS;
+				ts += FRAME_MS;
+			}
+			if (endMs === null) throw new Error("speech-end never fired");
+			return endMs - lastSpeechMs;
+		};
+
+		const fixedWait = await measure({});
+		const semanticWait = await measure({ semanticEotActive: true });
+		// Quantized to the 32 ms window clock: 500 → ≤544, 300 → ≤352.
+		expect(fixedWait).toBeGreaterThanOrEqual(500);
+		expect(fixedWait).toBeLessThanOrEqual(544);
+		expect(semanticWait).toBeGreaterThanOrEqual(300);
+		expect(semanticWait).toBeLessThanOrEqual(352);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget-loaders.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget-loaders.test.ts
@@ -9,8 +9,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { classifyDeviceTier } from "../device-tier";
 import type { BackendPlan } from "../backend";
+import { classifyDeviceTier } from "../device-tier";
 import {
 	type FfiBackendRuntime,
 	type FfiBackendSession,
@@ -436,7 +436,9 @@ describe("FfiStreamingBackend budget wire-up", () => {
 		const modelPath = writeGguf("huge.gguf", 32 * MB);
 		const budget = testBudget(16 * MB);
 		const backend = new FfiStreamingBackend(fakeRuntime({}), { budget });
-		await expect(backend.load({ modelPath } as unknown as BackendPlan)).rejects.toMatchObject({
+		await expect(
+			backend.load({ modelPath } as unknown as BackendPlan),
+		).rejects.toMatchObject({
 			name: "BudgetExhaustedError",
 		});
 		expect(backend.hasLoadedModel()).toBe(false);

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget-loaders.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget-loaders.test.ts
@@ -1,0 +1,445 @@
+/**
+ * VoiceBudget loader wire-up tests (#12254): every model loader reserves
+ * against the allocator before loading and releases on close/dispose/unload.
+ * Deterministic — fake FFI bindings, injected test budgets, tmp GGUF files;
+ * no native library and no hardware probe.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { classifyDeviceTier } from "../device-tier";
+import type { BackendPlan } from "../backend";
+import {
+	type FfiBackendRuntime,
+	type FfiBackendSession,
+	FfiStreamingBackend,
+} from "../ffi-streaming-backend";
+import type { HardwareProbe } from "../types";
+import { tryBuildFusedEotClassifier } from "./eot-classifier";
+import type {
+	ElizaInferenceContextHandle,
+	ElizaInferenceFfi,
+	ElizaInferenceRegion,
+} from "./ffi-bindings";
+import { VoiceLifecycleError } from "./lifecycle";
+import type { DraftProposer, TargetVerifier } from "./pipeline";
+import { VoicePipeline } from "./pipeline";
+import { InMemoryAudioSink } from "./ring-buffer";
+import { VoiceScheduler } from "./scheduler";
+import type {
+	SpeakerPreset,
+	StreamingTranscriber,
+	TranscriptUpdate,
+} from "./types";
+import { GgmlSileroVad } from "./vad";
+import {
+	createVoiceBudgetForTest,
+	FUSED_EOT_SCORER_RESERVE_BYTES,
+	reserveOrRamPressure,
+	VAD_RESERVE_BYTES,
+	type VoiceBudget,
+	WAKE_WORD_RESERVE_BYTES,
+} from "./voice-budget";
+import { GgmlWakeWordModel, WakeWordUnavailableError } from "./wake-word";
+
+const MB = 1024 * 1024;
+
+const maxProbe: HardwareProbe = {
+	totalRamGb: 64,
+	freeRamGb: 48,
+	gpu: { backend: "cuda", totalVramGb: 24, freeVramGb: 22 },
+	cpuCores: 16,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "xl",
+	source: "capacitor-llama",
+};
+
+function testBudget(totalBytes: number): VoiceBudget {
+	return createVoiceBudgetForTest({
+		totalBytes,
+		assessment: classifyDeviceTier(maxProbe),
+	});
+}
+
+/** Fake fused FFI with working VAD + wake-word + EOT surfaces. */
+function fakeVoiceFfi(
+	overrides: Partial<ElizaInferenceFfi> = {},
+): ElizaInferenceFfi {
+	const base: ElizaInferenceFfi = {
+		libraryPath: "/tmp/fake",
+		libraryAbiVersion: "11",
+		create: (): ElizaInferenceContextHandle => 1n,
+		destroy: () => {},
+		mmapAcquire: (
+			_c: ElizaInferenceContextHandle,
+			_r: ElizaInferenceRegion,
+		) => {},
+		mmapEvict: (
+			_c: ElizaInferenceContextHandle,
+			_r: ElizaInferenceRegion,
+		) => {},
+		ttsSynthesize: () => {
+			throw new Error("not used");
+		},
+		asrTranscribe: () => {
+			throw new Error("not used");
+		},
+		ttsStreamSupported: () => false,
+		ttsSynthesizeStream: () => {
+			throw new Error("not used");
+		},
+		cancelTts: () => {},
+		setVerifierCallback: () => ({ close: () => {} }),
+		vadSupported: () => true,
+		vadOpen: () => 7n,
+		vadProcess: () => 0.1,
+		vadReset: () => {},
+		vadClose: () => {},
+		asrStreamSupported: () => false,
+		asrStreamOpen: () => {
+			throw new Error("not used");
+		},
+		asrStreamFeed: () => {},
+		asrStreamPartial: () => ({ partial: "" }),
+		asrStreamFinish: () => ({ partial: "" }),
+		asrStreamClose: () => {},
+		close: () => {},
+	};
+	return { ...base, ...overrides };
+}
+
+describe("reserveOrRamPressure", () => {
+	it("maps allocator exhaustion to VoiceLifecycleError(ram-pressure)", async () => {
+		const budget = testBudget(1 * MB);
+		await expect(
+			reserveOrRamPressure(budget, {
+				modelId: "too-big",
+				role: "vad",
+				bytes: 8 * MB,
+			}),
+		).rejects.toMatchObject({
+			name: "VoiceLifecycleError",
+			code: "ram-pressure",
+		});
+	});
+
+	it("passes a fitting reservation through untouched", async () => {
+		const budget = testBudget(16 * MB);
+		const r = await reserveOrRamPressure(budget, {
+			modelId: "ok",
+			role: "vad",
+			bytes: 2 * MB,
+		});
+		expect(r.role).toBe("vad");
+		r.release();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});
+
+describe("GgmlSileroVad budget wire-up", () => {
+	it("reserves at load and releases on close (allocator empty)", async () => {
+		const budget = testBudget(16 * MB);
+		const vad = await GgmlSileroVad.load({
+			ffi: fakeVoiceFfi(),
+			ctx: () => 1n,
+			budget,
+		});
+		const rows = budget.snapshot();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.role).toBe("vad");
+		expect(rows[0]?.bytes).toBe(VAD_RESERVE_BYTES);
+		vad.close();
+		expect(budget.snapshot()).toHaveLength(0);
+		vad.close(); // idempotent
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("over-budget arm throws ram-pressure and loads nothing", async () => {
+		let opened = 0;
+		const ffi = fakeVoiceFfi({
+			vadOpen: () => {
+				opened++;
+				return 7n;
+			},
+		});
+		await expect(
+			GgmlSileroVad.load({ ffi, ctx: () => 1n, budget: testBudget(1 * MB) }),
+		).rejects.toMatchObject({ code: "ram-pressure" });
+		expect(opened).toBe(0);
+	});
+
+	it("releases the reservation when the native open throws", async () => {
+		const budget = testBudget(16 * MB);
+		const ffi = fakeVoiceFfi({
+			vadOpen: () => {
+				throw new Error("native open failed");
+			},
+		});
+		await expect(
+			GgmlSileroVad.load({ ffi, ctx: () => 1n, budget }),
+		).rejects.toThrow(/native open failed/);
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});
+
+describe("GgmlWakeWordModel budget wire-up", () => {
+	const wakeFfi = (overrides: Partial<ElizaInferenceFfi> = {}) =>
+		fakeVoiceFfi({
+			wakewordSupported: () => true,
+			wakewordOpen: () => 9n,
+			wakewordScore: () => 0.01,
+			wakewordReset: () => {},
+			wakewordClose: () => {},
+			...overrides,
+		});
+
+	it("reserves at load and releases on close", async () => {
+		const budget = testBudget(16 * MB);
+		const model = await GgmlWakeWordModel.load({
+			ffi: wakeFfi(),
+			ctx: () => 1n,
+			headName: "hey-eliza",
+			budget,
+		});
+		const rows = budget.snapshot();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.role).toBe("wake-word");
+		expect(rows[0]?.bytes).toBe(WAKE_WORD_RESERVE_BYTES);
+		model.close();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("releases the reservation when the native open rejects the head", async () => {
+		const budget = testBudget(16 * MB);
+		const ffi = wakeFfi({
+			wakewordOpen: () => {
+				throw new Error("bad head");
+			},
+		});
+		await expect(
+			GgmlWakeWordModel.load({
+				ffi,
+				ctx: () => 1n,
+				headName: "nope",
+				budget,
+			}),
+		).rejects.toThrow(WakeWordUnavailableError);
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});
+
+describe("tryBuildFusedEotClassifier budget wire-up", () => {
+	const eotFfi = () =>
+		fakeVoiceFfi({
+			eotSupported: () => true,
+			eotScore: () => ({ targetProb: 0.5 }),
+			tokenize: () => new Int32Array([1]),
+		});
+
+	it("reserves at build and releases on dispose", async () => {
+		const budget = testBudget(64 * MB);
+		const classifier = await tryBuildFusedEotClassifier({
+			ffi: eotFfi(),
+			getContext: () => 1n,
+			budget,
+		});
+		expect(classifier).not.toBeNull();
+		const rows = budget.snapshot();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.role).toBe("turn-detector");
+		expect(rows[0]?.bytes).toBe(FUSED_EOT_SCORER_RESERVE_BYTES);
+		classifier?.dispose();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("reserves nothing when the build lacks the EOT ABI", async () => {
+		const budget = testBudget(64 * MB);
+		const classifier = await tryBuildFusedEotClassifier({
+			ffi: fakeVoiceFfi(),
+			getContext: () => 1n,
+			budget,
+		});
+		expect(classifier).toBeNull();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});
+
+describe("VoicePipeline per-turn TTS transient reservation", () => {
+	function makePreset(): SpeakerPreset {
+		const embedding = new Float32Array([0.1, 0.2]);
+		return {
+			voiceId: "default",
+			embedding,
+			bytes: new Uint8Array(embedding.buffer.slice(0)),
+		};
+	}
+
+	class SilentBackend {
+		async synthesize(args: {
+			phrase: { id: number; fromIndex: number; toIndex: number };
+			cancelSignal: { cancelled: boolean };
+			onKernelTick?: () => void;
+		}) {
+			args.onKernelTick?.();
+			return {
+				phraseId: args.phrase.id,
+				fromIndex: args.phrase.fromIndex,
+				toIndex: args.phrase.toIndex,
+				pcm: new Float32Array(8).fill(0.1),
+				sampleRate: 24000,
+			};
+		}
+	}
+
+	function fakeTranscriber(transcript: string): StreamingTranscriber {
+		return {
+			feed: () => {},
+			async flush(): Promise<TranscriptUpdate> {
+				return { partial: transcript, isFinal: true };
+			},
+			on: () => () => {},
+			dispose: () => {},
+		};
+	}
+
+	function buildPipeline(args: {
+		budget: VoiceBudget;
+		bytes: number;
+		onTurnStarted?: () => void;
+	}): VoicePipeline {
+		const scheduler = new VoiceScheduler(
+			{
+				chunkerConfig: { maxTokensPerPhrase: 4 },
+				preset: makePreset(),
+				ringBufferCapacity: 4096,
+				sampleRate: 24000,
+			},
+			{ backend: new SilentBackend(), sink: new InMemoryAudioSink() },
+		);
+		const drafter: DraftProposer = {
+			propose: async () => [],
+		};
+		const verifier: TargetVerifier = {
+			verify: async () => {
+				args.onTurnStarted?.();
+				return { accepted: [], done: true };
+			},
+		};
+		return new VoicePipeline(
+			{
+				scheduler,
+				transcriber: fakeTranscriber("hello there"),
+				drafter,
+				verifier,
+				ttsTransientReservation: { bytes: args.bytes, budget: args.budget },
+			},
+			{ maxDraftTokens: 4 },
+		);
+	}
+
+	it("reserves role=tts for the duration of the turn and releases after", async () => {
+		const budget = testBudget(256 * MB);
+		let rowsDuringTurn = -1;
+		const pipeline = buildPipeline({
+			budget,
+			bytes: 100 * MB,
+			onTurnStarted: () => {
+				rowsDuringTurn = budget
+					.snapshot()
+					.filter((r) => r.role === "tts").length;
+			},
+		});
+		const result = await pipeline.run({
+			pcm: new Float32Array(2400),
+			sampleRate: 16_000,
+		});
+		expect(result).toBe("done");
+		expect(rowsDuringTurn).toBe(1);
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("an over-budget turn fails loud with ram-pressure before ASR", async () => {
+		const budget = testBudget(16 * MB);
+		const pipeline = buildPipeline({ budget, bytes: 100 * MB });
+		await expect(
+			pipeline.run({ pcm: new Float32Array(2400), sampleRate: 16_000 }),
+		).rejects.toBeInstanceOf(VoiceLifecycleError);
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});
+
+describe("FfiStreamingBackend budget wire-up", () => {
+	const tmpDir = mkdtempSync(path.join(os.tmpdir(), "voice-budget-ffi-"));
+	afterAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeGguf(name: string, bytes: number): string {
+		const p = path.join(tmpDir, name);
+		writeFileSync(p, Buffer.alloc(bytes, 1));
+		return p;
+	}
+
+	function fakeRuntime(session: Partial<FfiBackendSession>): FfiBackendRuntime {
+		return {
+			supported: () => true,
+			async acquire(): Promise<FfiBackendSession> {
+				return {
+					binding: {} as FfiBackendSession["binding"],
+					ctx: {} as FfiBackendSession["ctx"],
+					runner: {} as FfiBackendSession["runner"],
+					tokenize: () => new Int32Array(),
+					mtp: null,
+					draftModelPath: null,
+					mmprojPath: null,
+					...session,
+				};
+			},
+			async release(): Promise<void> {},
+		};
+	}
+
+	it("reserves text-target (file size) at load and releases on unload", async () => {
+		const modelPath = writeGguf("target.gguf", 3 * MB);
+		const budget = testBudget(64 * MB);
+		const backend = new FfiStreamingBackend(fakeRuntime({}), { budget });
+		await backend.load({ modelPath } as unknown as BackendPlan);
+		const rows = budget.snapshot();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.role).toBe("text-target");
+		expect(rows[0]?.bytes).toBe(3 * MB);
+		await backend.unload();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("reserves a separate MTP drafter GGUF under role=drafter", async () => {
+		const modelPath = writeGguf("target2.gguf", 3 * MB);
+		const draftPath = writeGguf("drafter.gguf", 1 * MB);
+		const budget = testBudget(64 * MB);
+		const backend = new FfiStreamingBackend(
+			fakeRuntime({ draftModelPath: draftPath }),
+			{ budget },
+		);
+		await backend.load({ modelPath } as unknown as BackendPlan);
+		const roles = budget.snapshot().map((r) => r.role);
+		expect(roles).toContain("text-target");
+		expect(roles).toContain("drafter");
+		await backend.unload();
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+
+	it("a text-target that cannot fit fails the load loudly", async () => {
+		const modelPath = writeGguf("huge.gguf", 32 * MB);
+		const budget = testBudget(16 * MB);
+		const backend = new FfiStreamingBackend(fakeRuntime({}), { budget });
+		await expect(backend.load({ modelPath } as unknown as BackendPlan)).rejects.toMatchObject({
+			name: "BudgetExhaustedError",
+		});
+		expect(backend.hasLoadedModel()).toBe(false);
+		expect(budget.snapshot()).toHaveLength(0);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/voice-budget.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice-budget.ts
@@ -28,17 +28,16 @@
  * (TTS engine, ASR loader, etc.) holds the typed reservation and runs
  * `release()` on unload.
  *
- * Wire-up plan (handed to follow-up commits, NOT done by I9):
- *   - `ffi-streaming-backend.ts`     → `reserve(role="text-target")` + `reserve(role="drafter")` at spawn.
- *   - `voice/pipeline.ts`    → `reserve(role="tts", bytes=transientPeakMb*MB)` per synth.
- *   - `voice/wake-word.ts`, `vad.ts`, `eot-classifier.ts` → reserve at session arm.
- *   - I2/I3 add `emotion` + `speaker-id` reservations when those models register.
- *
- * NOTE: the wire-up is intentionally separate from the allocator
- * implementation because the in-flight I-agents (I1/I2/I3/I5) own those
- * loader files and we must not race their edits. The allocator + the
- * `evictionPriority` hooks are in place; the loaders adopt it as they
- * land.
+ * Live call sites (#12254): `ffi-streaming-backend.ts` reserves
+ * `text-target` + `drafter` (weights file sizes) at load; `voice/pipeline.ts`
+ * reserves the TTS transient peak per voice turn; `GgmlSileroVad.load`,
+ * `GgmlWakeWordModel.load`, and `tryBuildFusedEotClassifier` reserve at
+ * session arm and release on close/dispose. Loaders without an injected
+ * budget fall through to the process-wide shared budget
+ * (`ensureSharedVoiceBudget`). Reservation failure maps to
+ * `VoiceLifecycleError("ram-pressure")` via `reserveOrRamPressure` — never
+ * log-and-continue. `emotion` + `speaker-id` reservations land when those
+ * models register.
  */
 
 import {
@@ -47,7 +46,9 @@ import {
 	type DeviceTierAssessment,
 	effectiveModelMemoryGb,
 } from "../device-tier";
+import { probeHardware } from "../hardware";
 import type { HardwareProbe } from "../types";
+import { VoiceLifecycleError } from "./lifecycle";
 import {
 	RESIDENT_ROLE_PRIORITY,
 	type ResidentModelRole,
@@ -632,4 +633,78 @@ export function createVoiceBudgetForTest(args: {
 		totalBytes: args.totalBytes,
 		assessment: args.assessment,
 	});
+}
+
+/* ==================================================================== *
+ * Shared process-wide budget + loader reservation envelopes (#12254).
+ * ==================================================================== */
+
+/**
+ * Per-component reservation envelopes for the small always-armed voice
+ * models, sourced from the R9 §2.3 ensemble table above:
+ *   - VAD: Silero v5 GGML weights + recurrent state (`vadMb` = 2 MB).
+ *   - Wake word: openWakeWord backbone + head (`wakeWordMb` = 4 MB).
+ *   - Fused EOT scorer: no separate weights (it scores P(<end_of_turn>)
+ *     through the resident text model) — this covers its dedicated native
+ *     scoring context (≤128-token KV cleared per call + logits buffer).
+ */
+export const VAD_RESERVE_BYTES = 2 * BYTES_PER_MB;
+export const WAKE_WORD_RESERVE_BYTES = 4 * BYTES_PER_MB;
+export const FUSED_EOT_SCORER_RESERVE_BYTES = 8 * BYTES_PER_MB;
+
+/**
+ * Per-turn TTS transient decode peaks reserved by `VoicePipeline.run()`:
+ * OmniVoice's MaskGIT decode peak is ~1.17 GB measured on Metal
+ * (`transientTtsBufferMb` above); Kokoro's ONNX/GGML compute path is kept
+ * at the table's 100 MB envelope.
+ */
+export const OMNIVOICE_TTS_TRANSIENT_PEAK_BYTES = Math.round(
+	1.17 * BYTES_PER_GB,
+);
+export const KOKORO_TTS_TRANSIENT_PEAK_BYTES = 100 * BYTES_PER_MB;
+
+/**
+ * Reserve against `budget`, translating allocator exhaustion into the
+ * lifecycle's structured RAM-pressure failure so an over-budget arm
+ * surfaces exactly like an over-budget mmap (`lifecycle.ts` error
+ * taxonomy). All loader call sites go through this — no log-and-continue.
+ */
+export async function reserveOrRamPressure(
+	budget: VoiceBudget,
+	args: {
+		modelId: string;
+		role: ResidentModelRole;
+		bytes: number;
+		priority?: AllocationPriority;
+	},
+): Promise<BudgetReservation> {
+	try {
+		return await budget.reserve(args);
+	} catch (err) {
+		if (err instanceof BudgetExhaustedError) {
+			throw new VoiceLifecycleError("ram-pressure", err.message);
+		}
+		throw err;
+	}
+}
+
+let sharedBudget: Promise<VoiceBudget> | null = null;
+
+/**
+ * The process-wide budget every loader falls back to when no budget is
+ * injected. Memory is a process-wide resource, so one allocator instance
+ * arbitrates all reservations; the hardware probe runs once and is cached.
+ */
+export function ensureSharedVoiceBudget(): Promise<VoiceBudget> {
+	if (!sharedBudget) {
+		sharedBudget = probeHardware().then((probe) =>
+			createVoiceBudget({ probe }),
+		);
+	}
+	return sharedBudget;
+}
+
+/** Test seam — pin (or clear, with `null`) the shared budget instance. */
+export function setSharedVoiceBudgetForTest(budget: VoiceBudget | null): void {
+	sharedBudget = budget ? Promise.resolve(budget) : null;
 }

--- a/plugins/plugin-local-inference/src/services/voice/wake-word.ts
+++ b/plugins/plugin-local-inference/src/services/voice/wake-word.ts
@@ -42,6 +42,13 @@ import type {
 	NativeWakeWordHandle,
 } from "./ffi-bindings";
 import {
+	type BudgetReservation,
+	ensureSharedVoiceBudget,
+	reserveOrRamPressure,
+	type VoiceBudget,
+	WAKE_WORD_RESERVE_BYTES,
+} from "./voice-budget";
+import {
 	OpenWakeWordGgmlModel,
 	WakeWordGgmlUnavailableError,
 } from "./wake-word-ggml";
@@ -196,6 +203,8 @@ export class GgmlWakeWordModel implements WakeWordModel {
 	private constructor(
 		private readonly ffi: ElizaInferenceFfi,
 		private readonly handle: NativeWakeWordHandle,
+		/** Voice-budget reservation held while the native session is open. */
+		private readonly reservation: BudgetReservation | null,
 	) {}
 
 	/**
@@ -218,6 +227,8 @@ export class GgmlWakeWordModel implements WakeWordModel {
 		ffi: ElizaInferenceFfi;
 		ctx: ElizaInferenceContextHandle | (() => ElizaInferenceContextHandle);
 		headName: string;
+		/** Voice-budget override; defaults to the process-wide shared budget. */
+		budget?: VoiceBudget;
 	}): Promise<GgmlWakeWordModel> {
 		if (!GgmlWakeWordModel.isSupported(opts.ffi)) {
 			throw new WakeWordUnavailableError(
@@ -236,6 +247,14 @@ export class GgmlWakeWordModel implements WakeWordModel {
 				"[wake-word] Wake-word support probe succeeded, but the required FFI methods are missing on the binding.",
 			);
 		}
+		// Reserve before the native session opens; an over-budget arm throws
+		// `VoiceLifecycleError("ram-pressure")` and nothing is loaded.
+		const budget = opts.budget ?? (await ensureSharedVoiceBudget());
+		const reservation = await reserveOrRamPressure(budget, {
+			modelId: "openwakeword",
+			role: "wake-word",
+			bytes: WAKE_WORD_RESERVE_BYTES,
+		});
 		const ctx = typeof opts.ctx === "function" ? opts.ctx() : opts.ctx;
 		let handle: NativeWakeWordHandle;
 		try {
@@ -245,6 +264,7 @@ export class GgmlWakeWordModel implements WakeWordModel {
 				headName: opts.headName,
 			});
 		} catch (err) {
+			reservation.release();
 			throw new WakeWordUnavailableError(
 				"model-load-failed",
 				`[wake-word] failed to open native wake-word session for head '${opts.headName}': ${
@@ -252,7 +272,7 @@ export class GgmlWakeWordModel implements WakeWordModel {
 				}`,
 			);
 		}
-		return new GgmlWakeWordModel(opts.ffi, handle);
+		return new GgmlWakeWordModel(opts.ffi, handle, reservation);
 	}
 
 	async scoreFrame(frame: Float32Array): Promise<number> {
@@ -286,6 +306,7 @@ export class GgmlWakeWordModel implements WakeWordModel {
 		if (this.closed) return;
 		this.closed = true;
 		this.ffi.wakewordClose?.(this.handle);
+		this.reservation?.release();
 	}
 }
 


### PR DESCRIPTION
Sub-issue 2 of the voice UX + optimization swarm (#12187). Attacks the endpoint wait first (parent design decision #6), wires the streaming-ASR partial path behind its capability gate, and adopts the voice memory budget in the loaders.

## Headline: before/after latency

**Endpoint wait (speech end → turn finalization) — the dominant knob.** Deterministic measurement through the real `VadDetector` state machine (scripted 608 ms utterance + silence, 32 ms window clock; exact numbers, quantized up to one window):

| Config | BEFORE (develop) | AFTER | Δ |
| --- | --- | --- | --- |
| Shipped default, no semantic EOT (fixed-VAD) | **704 ms** | **512 ms** (500 ms floor) | **−192 ms** |
| Fused `FfiEotScorer` composite live | **704 ms** | **320 ms** (300 ms default) | **−384 ms** |
| Explicit `endHangoverMs` override | 704 ms | unchanged | 0 |

Projected onto the measured hybrid E2E (`research/VOICE_VALIDATION_RUNBOOK.md:131`, ~770–870 ms TTFA + endpoint wait): −200 ms on every turn today, −400 ms once the fused EOT scorer ships — the step that brings speech-end→first-audio under the ≤800 ms good target (research §7). The 500 ms fixed-VAD floor matches OpenAI Realtime / LiveKit production defaults; 300 ms is allowed only with the semantic gate live (`semanticEotActive`), which still extends the wait on mid-clause P<0.4. `ELIZA_PAUSE_HANGOVER_MS` and explicit `endHangoverMs` still win. The session arm logs the chosen hangover at INFO (`[LocalInferenceEngine] voice endpoint: endHangoverMs=…`).

**Turn-taking non-regression.** Workbench `--logic` lane vs the golden baseline, before AND after: **PASS, 18/18 scenarios, EOT false-trigger rate 0/0, no regressions** (reports committed under `.github/issue-evidence/12254-voice-latency/`).

## What was wired vs deferred

**Wired:**
- **Streaming-ASR gate + partial stabilization at the bridge seam** (`engine-bridge.ts createStreamingTranscriber`): drive mode picked by `pickStreamingMode` — fused streaming decoder when `asrStreamSupported()==1` + ASR bundle present + `ELIZA_VOICE_STREAMING_ASR` not disabled (**default ON when supported**; `ELIZA_LOCAL_ASR_BACKEND` pin wins). The pick is announced at INFO — the batch fallback is loud, never silent. In streaming mode the transcriber is wrapped in `StabilizedStreamingTranscriber` (word-level LocalAgreement-2), so the turn controller's existing subscription sees only a monotonically growing committed prefix — **no turn-controller edits**, and `words` (the barge-in word-confirm trigger) fires only on committed words. Batch path is byte-identical when unsupported (asserted by test).
- **`StreamingAsrFeeder` stabilization** (issue work item 2): every hypothesis passes a `WordAgreementGate` before `onPartial`/`onWords` fire; skips double-gating when handed an already-stabilized transcriber. Property test (seeded random hypothesis churn): a surfaced word is never retracted.
- **Found + fixed a real retraction bug** in `LocalAgreementBuffer` and char-level `PartialStabilizer`: a longer agreement could silently *rewrite* already-committed words, violating both classes' documented monotonic contract. Committed prefixes now only ever extend. Consumer split documented: word-level gate → drafter/word-confirm; char-level `PartialStabilizer` → UI captions.
- **Interim-batch staleness knob** (work item 3): `stepSeconds` is env-tunable (`ELIZA_ASR_STEP_SECONDS`) and `FfiBatchTranscriber.decodeStats()` records per-pass decode timings so the 1.2→0.8 s decision is a one-line measurement on provisioned hardware.
- **`VoiceBudget.reserve()` in all five loader call sites** (work item 5, the allocator header's own plan): `GgmlSileroVad.load` (role `vad`), `GgmlWakeWordModel.load` (`wake-word`, new role), `tryBuildFusedEotClassifier` (`turn-detector`, new role; released via `dispose()` at session teardown), `VoicePipeline.run` (per-turn `tts` transient peak — OmniVoice 1.17 GB measured / Kokoro 100 MB), `FfiStreamingBackend.load` (`text-target` + separate MTP `drafter`, sized to the GGUF on disk). Defaults to a process-wide shared budget; over-budget arm throws `VoiceLifecycleError("ram-pressure")` **before** any native session opens; close/dispose/unload releases everything (allocator-empty asserted in tests).

**Deferred, with reasons:**
- **Live streaming partials end-to-end on real hardware**: the fused streaming decoder (`eliza_inference_asr_stream_*`) reports unsupported on every shipped build — the C-side (W7) decoder has not landed in any `libelizainference` binary, so no host anywhere can exercise it for real. This PR lands the complete gating + stabilization so the path lights up the moment a streaming-capable build ships; today's builds are asserted byte-identical to the batch path.
- **Lowering `stepSeconds` 1.2 → 0.8 by default**: gated (per the issue) on real-lane per-pass decode p90 staying below the step — decodes serialize on the shared ASR mutex, so a shorter step would just queue. No fused lib + ASR bundle on this host to measure; env knob + `decodeStats()` instrumentation landed so the measured decision is trivial to take.
- **EOT commit-threshold tuning (P≥0.9 → P≥0.7)**: `eot-classifier.ts` threshold lines belong to the turn-taking sub-issue #12255; the two changes compose in either order (this PR's reservation edit there is line-disjoint).
- **Workbench `maxFirstAudioMs` ceiling enforcement**: the real-lane ceiling is owned by the workbench sub-issue #12258; this PR supplies the endpoint-stage numbers.

## Verification

- `bun run --cwd plugins/plugin-local-inference typecheck` — clean for this branch's code. Two pre-existing TS2308 errors surface from `packages/shared/src/index.ts` on current develop (duplicate `isAospElizaUserAgent`/`userAgentHasElizaOSMarker` star-exports from `platform/eliza-os.ts` + `platform/aosp-user-agent.ts`, landed by the recent barrel refactor) — this branch touches **zero** files under `packages/shared` (`git diff origin/develop...HEAD` confirms).
- `bun run --cwd plugins/plugin-local-inference lint:check` — clean. `bun run audit:error-policy-ratchet` — "no new fallback-slop in touched files".
- Tests: full voice-dir sweep (106 files / 1035 tests): 1031 passed, 3 skipped, 1 failed — `nlms-echo-canceller.test.ts` 5 s timeout under 106-file parallel load only; untouched echo-domain file, passes in isolation (3.4 s). Post-rebase (over the merged diarization sibling #12257) the 19 touched/adjacent suites re-ran green: **251/251**.
- New tests: endpoint-hangover defaults + measured endpoint wait (`vad.v1-v4.test.ts`), bridge ASR drive-mode gate over a mocked FFI incl. kill switch + env pin (`engine-bridge-asr-mode.test.ts`), feeder/wrapper stabilization + never-retract property (`__tests__/streaming-transcriber.test.ts`), all five loader reserve/release cycles + ram-pressure + allocator-empty (`voice-budget-loaders.test.ts`), step-env + decode-stats (`transcriber.test.ts`).
- Workbench `--logic` lane vs golden baseline: PASS before and after, no regressions.

## Evidence (`.github/issue-evidence/12254-voice-latency/`)

- `endpoint-wait-before-after.md` — methodology + the tables above + raw runs.
- `workbench-logic-{before,after}.report.{json,md}` — hand-reviewed.
- Backend `[ClassName]` logs: the ASR drive-mode pick (`[EngineVoiceBridge] ASR drive mode: …`) and the endpoint config line (`[LocalInferenceEngine] voice endpoint: endHangoverMs=…`) are exercised by the bridge/engine test lanes; no live fused build exists to capture them from a production session (see N/A).
- **N/A rows** (each with reason, detailed in the evidence doc): `GET /api/dev/voice-latency` before/after against a running app (per-stage traces only come from live fused-pipeline turns; no fused `libelizainference` build exists on this host — an app boot yields an empty trace table; the deterministic VAD-timeline measurement is the honest equivalent for the endpoint stage, the only stage this PR moves); workbench `--real` lane + real-lane decode p90 (fused lib + `ELIZA_ASR_BUNDLE` absent); voicebench p95/p99 (drives cloud Groq/ElevenLabs providers — no keys — over pre-segmented fixtures, so the endpoint wait isn't inside its measurement window); captured audio + narrated walkthrough (no reachable device/desktop run exercises the changed local fused path without the fused build; the cloud TTS paths a desktop run would use are untouched); real-LLM trajectories (no agent/action/provider/prompt/model behavior change — voice-runtime latency/memory plumbing only).

Closes #12254. Part of #12187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
