### PR TITLE
feat(#12355): desktop local-agent IPC — api-base switch, RPC schema, main-process request path

### DIFF
--- a/.github/issue-evidence/12355-desktop-ipc-rpc/README.md
+++ b/.github/issue-evidence/12355-desktop-ipc-rpc/README.md
@@ -1,0 +1,44 @@
+# #12355 — Desktop local-agent IPC: Electrobun RPC + IPC api-base + no-listener proof
+
+Phase 2 of #12180, building on the merged #12293 foundation slice (shared stdio
+kernel, port-gating, dormant desktop resolver).
+
+## What this slice lands (main-process side, fully unit-tested, non-breaking)
+
+| Piece | File |
+|---|---|
+| IPC-mode gate + `eliza-local-agent://ipc` api base | `packages/app-core/platforms/electrobun/src/api-base.ts` |
+| `localAgentRequest` / `localAgentStreamRequest` RPC schema + stream push events | `.../src/rpc-schema.ts` |
+| Buffered request handler (path validation, dispatcher seam) | `.../src/local-agent-request.ts` |
+| Main-process NDJSON stdio client codec | `.../src/local-agent-stdio-dispatcher.ts` |
+| Child-stdio → dispatcher attach + process-wide registry | `.../src/local-agent-stdio-attach.ts`, `.../src/local-agent-dispatcher-registry.ts` |
+| Handler registration | `.../src/rpc-handlers.ts` |
+
+Default boot (no `ELIZA_DESKTOP_LOCAL_AGENT_IPC`) is byte-for-byte identical to
+today: loopback HTTP api base, port bound, renderer never addresses the IPC base
+so the handler is unreachable. `ELIZA_API_EXPOSE_PORT=1` always wins and keeps
+the loopback HTTP path (dev tooling / LAN / e2e harnesses).
+
+## Evidence
+
+| Artifact | File |
+|---|---|
+| Electrobun unit tests — api-base IPC switch, stdio dispatcher, attach/registry, request handler (50 pass) | `electrobun-unit-tests.txt` |
+| No-TCP-listener proof — real child harness asserts the agent port is NOT bound with `skipListen`, IS bound without it (#12293 primitive, 9 pass) | `agent-skip-listen-no-port-proof.txt` |
+
+## Device-gated remainder (needs a real desktop; cannot be proven headlessly)
+
+The behavior-flipping child-side pieces + `PR_EVIDENCE.md` desktop captures:
+
+- Child `eliza start` honoring `localAgentMode` + running the NDJSON stdio server
+  (kernel exists as `createStdioBridge`; the child entry does not yet read an env
+  to enable it, so the main-process spawn flip is not wired — attaching the
+  bridge to a child that does not speak it would be broken).
+- `AgentManager` spawn flip: `stdin: "pipe"`, `attachLocalAgentStdioBridge`, and
+  IPC-native readiness (today's readiness/health poll assumes an HTTP port).
+- `localAgentStreamRequest` child-side streaming consumer (the handler throws
+  loudly until it lands).
+- `bun run --cwd packages/app capture:linux-desktop` / `capture:windows-desktop`,
+  `lsof -iTCP -sTCP:LISTEN -n | grep -E '31337|2138'` printing nothing in IPC
+  mode, main-process logs of `localAgentRequest`, frontend network trace with
+  zero `127.0.0.1` agent calls.

--- a/.github/issue-evidence/12355-desktop-ipc-rpc/agent-skip-listen-no-port-proof.txt
+++ b/.github/issue-evidence/12355-desktop-ipc-rpc/agent-skip-listen-no-port-proof.txt
@@ -1,0 +1,21 @@
+▲ [WARNING] The condition "types" here will never be used as it comes after "default" [package.json]
+
+    package.json:151:6:
+      151 │       "types": "./src/services/app-session-gate.d.ts"
+          ╵       ~~~~~~~
+
+  The "default" condition comes earlier and will always be chosen:
+
+    package.json:150:6:
+      150 │       "default": "./dist/services/app-session-gate.js",
+          ╵       ~~~~~~~~~
+
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/wf_f7a1641e-e50-18/packages/agent
+
+
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+   Start at  22:21:14
+   Duration  3.81s (transform 38ms, setup 39ms, import 10ms, tests 3.62s, environment 30ms)
+

--- a/.github/issue-evidence/12355-desktop-ipc-rpc/electrobun-unit-tests.txt
+++ b/.github/issue-evidence/12355-desktop-ipc-rpc/electrobun-unit-tests.txt
@@ -1,0 +1,9 @@
+
+ RUN  v4.1.5 /Users/shawwalters/eliza-workspace/milady/eliza/.claude/worktrees/wf_f7a1641e-e50-18/packages/app-core/platforms/electrobun
+
+
+ Test Files  4 passed (4)
+      Tests  50 passed (50)
+   Start at  22:21:03
+   Duration  5.47s (transform 4.24s, setup 0ms, import 5.53s, tests 33ms, environment 0ms)
+

--- a/packages/app-core/platforms/electrobun/src/api-base.test.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.test.ts
@@ -3,9 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  DESKTOP_LOCAL_AGENT_IPC_BASE,
   type PersistedDeployment,
   resolveCloudHostedAgentApiBase,
   resolveDesktopRuntimeModeWithDeployment,
+  resolveInitialApiBase,
+  resolveLocalAgentIpcMode,
+  resolveRendererFacingApiBase,
 } from "./api-base";
 import { readPersistedDeployment } from "./persisted-deployment";
 
@@ -243,5 +247,95 @@ describe("end-to-end: persisted cloud target → external mode", () => {
     expect(resolution.externalApi.base).toBe(CLOUD_AGENT_URL);
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("resolveLocalAgentIpcMode — desktop IPC transport gate (#12355)", () => {
+  it("is off by default (no flag set)", () => {
+    expect(resolveLocalAgentIpcMode({})).toBe(false);
+  });
+
+  it("is on when ELIZA_DESKTOP_LOCAL_AGENT_IPC is a truthy flag", () => {
+    for (const value of ["1", "true", "yes", "on", "TRUE", "On"]) {
+      expect(
+        resolveLocalAgentIpcMode({ ELIZA_DESKTOP_LOCAL_AGENT_IPC: value }),
+      ).toBe(true);
+    }
+  });
+
+  it("is off for a falsy/unknown flag value", () => {
+    for (const value of ["0", "false", "no", "off", "", "maybe"]) {
+      expect(
+        resolveLocalAgentIpcMode({ ELIZA_DESKTOP_LOCAL_AGENT_IPC: value }),
+      ).toBe(false);
+    }
+  });
+
+  it("ELIZA_API_EXPOSE_PORT=1 wins — keeps the loopback HTTP path even if IPC is requested", () => {
+    expect(
+      resolveLocalAgentIpcMode({
+        ELIZA_DESKTOP_LOCAL_AGENT_IPC: "1",
+        ELIZA_API_EXPOSE_PORT: "1",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveInitialApiBase — IPC scheme vs loopback (#12355)", () => {
+  it("default local mode keeps the loopback HTTP base (byte-for-byte identical to today)", () => {
+    expect(resolveInitialApiBase({})).toBe("http://127.0.0.1:31337");
+  });
+
+  it("local-agent IPC mode returns the eliza-local-agent://ipc scheme", () => {
+    expect(resolveInitialApiBase({ ELIZA_DESKTOP_LOCAL_AGENT_IPC: "1" })).toBe(
+      DESKTOP_LOCAL_AGENT_IPC_BASE,
+    );
+  });
+
+  it("external mode (ELIZA_DESKTOP_API_BASE) wins over IPC mode", () => {
+    expect(
+      resolveInitialApiBase({
+        ELIZA_DESKTOP_LOCAL_AGENT_IPC: "1",
+        ELIZA_DESKTOP_API_BASE: "http://10.0.0.9:31337",
+      }),
+    ).toBe("http://10.0.0.9:31337");
+  });
+
+  it("ELIZA_API_EXPOSE_PORT=1 keeps the loopback base even with IPC requested", () => {
+    expect(
+      resolveInitialApiBase({
+        ELIZA_DESKTOP_LOCAL_AGENT_IPC: "1",
+        ELIZA_API_EXPOSE_PORT: "1",
+      }),
+    ).toBe("http://127.0.0.1:31337");
+  });
+});
+
+describe("resolveRendererFacingApiBase — IPC scheme vs dev-server/loopback (#12355)", () => {
+  it("IPC mode returns the IPC scheme even when a dev-server URL is set (no port to proxy)", () => {
+    expect(
+      resolveRendererFacingApiBase(
+        {
+          ELIZA_DESKTOP_LOCAL_AGENT_IPC: "1",
+          ELIZA_RENDERER_URL: "http://127.0.0.1:2138",
+        },
+        31337,
+      ),
+    ).toBe(DESKTOP_LOCAL_AGENT_IPC_BASE);
+  });
+
+  it("default mode prefers the loopback dev-server origin (unchanged)", () => {
+    expect(
+      resolveRendererFacingApiBase(
+        { ELIZA_RENDERER_URL: "http://127.0.0.1:2138" },
+        31337,
+      ),
+    ).toBe("http://127.0.0.1:2138");
+  });
+
+  it("default mode with no dev server returns the loopback API port (unchanged)", () => {
+    expect(resolveRendererFacingApiBase({}, 31337)).toBe(
+      "http://127.0.0.1:31337",
+    );
   });
 });

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -1,6 +1,19 @@
-import { resolveDesktopApiPort } from "@elizaos/shared";
+import { resolveApiExposePort, resolveDesktopApiPort } from "@elizaos/shared";
 import { DEFAULT_API_PORT } from "./constants";
 import { logger } from "./logger";
+
+/**
+ * Renderer-facing API base for the desktop local-agent IPC transport (#12180
+ * phase 2 / #12355). When local-agent IPC mode is active the renderer's API base
+ * is this custom scheme instead of `http://127.0.0.1:<port>`: requests to it are
+ * routed through the Electrobun `localAgentRequest`/`localAgentStreamRequest` RPC
+ * methods (main process → in-process route kernel), so the agent binds no TCP
+ * listener. Mirrors the mobile local-agent IPC base string the iOS/Android
+ * transports already use, so one renderer resolver chain serves every platform.
+ */
+export const DESKTOP_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
+
+const LOCAL_AGENT_IPC_ENV_KEY = "ELIZA_DESKTOP_LOCAL_AGENT_IPC";
 
 type ExternalApiBaseEnvKey =
   | "ELIZA_DESKTOP_TEST_API_BASE"
@@ -194,12 +207,35 @@ export function resolveDesktopRuntimeModeSignal(
   return null;
 }
 
+/**
+ * True when the desktop local agent should reach the runtime over native
+ * Electrobun IPC (`localAgentRequest`/`localAgentStreamRequest`) rather than a
+ * loopback HTTP port (#12180 / #12355). Opt-in via `ELIZA_DESKTOP_LOCAL_AGENT_IPC`.
+ *
+ * `ELIZA_API_EXPOSE_PORT=1` wins: when the operator explicitly re-opens the
+ * agent's TCP listener (dev tooling, LAN access, e2e/Playwright HTTP harnesses)
+ * the api base stays the loopback HTTP URL so those flows keep working. Off by
+ * default, so a desktop boot with neither flag set is byte-for-byte identical to
+ * today (loopback HTTP api base, port bound).
+ */
+export function resolveLocalAgentIpcMode(
+  env: Record<string, string | undefined>,
+): boolean {
+  if (resolveApiExposePort(env) === true) return false;
+  const raw = env[LOCAL_AGENT_IPC_ENV_KEY];
+  return isEnabledFlag(raw);
+}
+
 export function resolveInitialApiBase(
   env: Record<string, string | undefined>,
 ): string | null {
   const resolution = resolveDesktopRuntimeMode(env);
   if (resolution.mode === "external") {
     return resolution.externalApi.base;
+  }
+
+  if (resolveLocalAgentIpcMode(env)) {
+    return DESKTOP_LOCAL_AGENT_IPC_BASE;
   }
 
   const agentPort = resolveDesktopApiPort(env) || DEFAULT_API_PORT;
@@ -245,6 +281,12 @@ export function resolveRendererFacingApiBase(
   env: Record<string, string | undefined>,
   apiListenPort: number,
 ): string {
+  // Local-agent IPC mode has no reachable HTTP listener to proxy to; the
+  // renderer must address the IPC scheme so requests ride the Electrobun RPC
+  // transport instead of a same-origin dev-server proxy or a loopback port.
+  if (resolveLocalAgentIpcMode(env)) {
+    return DESKTOP_LOCAL_AGENT_IPC_BASE;
+  }
   const fromDevServer = resolveHttpLoopbackRendererOriginForApiClient(env);
   if (fromDevServer) return fromDevServer;
   return `http://127.0.0.1:${apiListenPort}`;

--- a/packages/app-core/platforms/electrobun/src/local-agent-dispatcher-registry.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-dispatcher-registry.ts
@@ -1,0 +1,43 @@
+/**
+ * Process-wide registry for the active desktop local-agent dispatcher (#12180 /
+ * #12355). The `localAgentRequest` RPC handler resolves the dispatcher from here
+ * rather than importing the agent-child lifecycle directly, keeping the handler
+ * decoupled from spawn/readiness plumbing and unit-testable.
+ *
+ * In local-agent IPC mode (`ELIZA_DESKTOP_LOCAL_AGENT_IPC=1`) the agent-child
+ * spawn attaches a {@link LocalAgentStdioDispatcher} bound to the child's stdio
+ * bridge via {@link setActiveLocalAgentDispatcher}. In default (loopback HTTP)
+ * mode nothing registers a dispatcher and the renderer never addresses the IPC
+ * api base, so the handler is never reached; if it is (misconfiguration — the
+ * IPC api base was pushed without a live dispatcher) it throws loudly rather
+ * than silently opening a socket the feature exists to remove.
+ */
+
+import type { LocalAgentDispatcher } from "./local-agent-request";
+
+let activeDispatcher: LocalAgentDispatcher | null = null;
+
+/** Register the dispatcher the agent child attached over its stdio bridge. */
+export function setActiveLocalAgentDispatcher(
+  dispatcher: LocalAgentDispatcher | null,
+): void {
+  activeDispatcher = dispatcher;
+}
+
+/** The active dispatcher, or `null` when the agent child is not IPC-connected. */
+export function getActiveLocalAgentDispatcher(): LocalAgentDispatcher | null {
+  return activeDispatcher;
+}
+
+/**
+ * Resolve the active dispatcher or throw. The `localAgentRequest` handler uses
+ * this so a request that arrives with no live IPC bridge fails observably.
+ */
+export function requireActiveLocalAgentDispatcher(): LocalAgentDispatcher {
+  if (!activeDispatcher) {
+    throw new Error(
+      "localAgentRequest received but no local-agent IPC dispatcher is attached: the agent child is not running in local-agent IPC mode (ELIZA_DESKTOP_LOCAL_AGENT_IPC=1).",
+    );
+  }
+  return activeDispatcher;
+}

--- a/packages/app-core/platforms/electrobun/src/local-agent-request.test.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-request.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createLocalAgentRequestHandler,
+  type LocalAgentDispatcher,
+  type NormalizedLocalAgentRequest,
+  normalizeLocalAgentRequest,
+} from "./local-agent-request";
+
+/**
+ * Unit tests for the desktop `localAgentRequest` main-process handler (#12355):
+ * param normalization/validation and the dispatcher forwarding contract. The
+ * dispatcher is a deterministic in-memory fake (no spawned child) — the
+ * per-platform NDJSON stdio leg is proven by the desktop capture lane.
+ */
+
+describe("normalizeLocalAgentRequest", () => {
+  it("normalizes a minimal GET request (defaults method + empty headers)", () => {
+    expect(normalizeLocalAgentRequest({ path: "/api/health" })).toEqual({
+      path: "/api/health",
+      method: "GET",
+      headers: {},
+      body: null,
+      timeoutMs: undefined,
+    });
+  });
+
+  it("uppercases the method and drops a body on GET/HEAD is rejected loudly", () => {
+    expect(
+      normalizeLocalAgentRequest({
+        path: "/api/messaging/send",
+        method: "post",
+        headers: { "content-type": "application/json" },
+        body: '{"text":"hi"}',
+        timeoutMs: 5000,
+      }),
+    ).toEqual({
+      path: "/api/messaging/send",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"text":"hi"}',
+      timeoutMs: 5000,
+    });
+  });
+
+  it("throws when path is missing", () => {
+    expect(() => normalizeLocalAgentRequest({})).toThrow(
+      /path must be a non-empty string/,
+    );
+  });
+
+  it("throws when path is not agent-relative (absolute URL)", () => {
+    expect(() =>
+      normalizeLocalAgentRequest({ path: "http://127.0.0.1:31337/api/health" }),
+    ).toThrow(/must be agent-relative/);
+  });
+
+  it("throws when a body is sent with GET", () => {
+    expect(() =>
+      normalizeLocalAgentRequest({
+        path: "/api/health",
+        method: "GET",
+        body: "x",
+      }),
+    ).toThrow(/must not carry a body/);
+  });
+
+  it("drops non-string header values and a non-object params throws", () => {
+    expect(
+      normalizeLocalAgentRequest({
+        path: "/api/x",
+        method: "POST",
+        headers: { a: "1", b: 2, c: "3" },
+      }).headers,
+    ).toEqual({ a: "1", c: "3" });
+    expect(() => normalizeLocalAgentRequest(null)).toThrow(
+      /params must be an object/,
+    );
+  });
+
+  it("ignores a non-positive or non-finite timeout", () => {
+    expect(
+      normalizeLocalAgentRequest({ path: "/api/x", timeoutMs: 0 }).timeoutMs,
+    ).toBeUndefined();
+    expect(
+      normalizeLocalAgentRequest({ path: "/api/x", timeoutMs: Number.NaN })
+        .timeoutMs,
+    ).toBeUndefined();
+  });
+});
+
+describe("createLocalAgentRequestHandler", () => {
+  it("forwards the normalized request to the dispatcher and returns its result", async () => {
+    const seen: NormalizedLocalAgentRequest[] = [];
+    const dispatcher: LocalAgentDispatcher = {
+      request: async (req) => {
+        seen.push(req);
+        return { status: 200, body: '{"ok":true}', headers: { x: "y" } };
+      },
+    };
+    const handler = createLocalAgentRequestHandler(dispatcher);
+
+    const result = await handler({
+      path: "/api/health",
+      method: "get",
+    });
+
+    expect(result).toEqual({
+      status: 200,
+      body: '{"ok":true}',
+      headers: { x: "y" },
+    });
+    expect(seen).toEqual([
+      {
+        path: "/api/health",
+        method: "GET",
+        headers: {},
+        body: null,
+        timeoutMs: undefined,
+      },
+    ]);
+  });
+
+  it("propagates a dispatcher rejection (never fabricates a success response)", async () => {
+    const dispatcher: LocalAgentDispatcher = {
+      request: vi
+        .fn()
+        .mockRejectedValue(new Error("child stdio bridge closed")),
+    };
+    const handler = createLocalAgentRequestHandler(dispatcher);
+
+    await expect(handler({ path: "/api/health" })).rejects.toThrow(
+      /child stdio bridge closed/,
+    );
+  });
+
+  it("rejects a bad path before touching the dispatcher", async () => {
+    const request = vi.fn();
+    const handler = createLocalAgentRequestHandler({ request });
+
+    await expect(handler({ path: "not-relative" } as never)).rejects.toThrow(
+      /must be agent-relative/,
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/local-agent-request.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-request.ts
@@ -1,0 +1,118 @@
+/**
+ * Main-process handler for the desktop local-agent IPC transport (#12180 phase
+ * 2 / #12355). The renderer's `desktop-local-agent-transport` calls the
+ * `localAgentRequest` Electrobun RPC method with an agent-relative path; this
+ * module normalizes that request and forwards it to the on-device runtime over a
+ * `LocalAgentDispatcher` seam — never a loopback socket. In local-agent IPC mode
+ * the agent binds no TCP listener (`ELIZA_DESKTOP_LOCAL_AGENT_IPC=1` →
+ * `localAgentMode`), so the dispatcher rides the child's NDJSON stdio bridge.
+ *
+ * The path is validated to be agent-relative (`/api/...`), NOT an absolute URL:
+ * IPC mode has no HTTP origin, so an absolute or non-relative path is a
+ * programming error and rejected loudly rather than silently coerced. The
+ * dispatcher is injected so the framing/normalization logic is exercised in unit
+ * tests without a spawned child, and so a future streaming dispatcher plugs into
+ * the same seam.
+ */
+
+import type {
+  LocalAgentRequestOptions,
+  LocalAgentRequestResult,
+} from "./rpc-schema";
+
+/**
+ * Buffered local-agent request the main process forwards to the on-device
+ * runtime. `path` is agent-relative and already validated; the dispatcher joins
+ * it to the in-process route kernel over whichever transport it owns (child
+ * stdio bridge today).
+ */
+export interface NormalizedLocalAgentRequest {
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+  timeoutMs?: number;
+}
+
+/**
+ * Transport seam between the `localAgentRequest` RPC handler and the on-device
+ * runtime. Implementations own the actual bytes (NDJSON stdio frames to the
+ * agent child, an in-process `dispatchRoute` call in tests, etc.). A rejected
+ * promise surfaces to the renderer as a thrown RPC error — the handler never
+ * swallows a dispatch failure into a synthetic success response, because that
+ * would hide a broken pipeline behind a fake 200.
+ */
+export interface LocalAgentDispatcher {
+  request(
+    request: NormalizedLocalAgentRequest,
+  ): Promise<LocalAgentRequestResult>;
+}
+
+const METHODS_WITHOUT_BODY = new Set(["GET", "HEAD"]);
+
+/**
+ * Validate and normalize raw `localAgentRequest` params. Throws on a missing or
+ * non-relative path, or a body sent with a method that forbids one — an IPC
+ * request that assumes an HTTP origin is a bug, not something to paper over.
+ */
+export function normalizeLocalAgentRequest(
+  params: unknown,
+): NormalizedLocalAgentRequest {
+  if (!params || typeof params !== "object") {
+    throw new Error("localAgentRequest params must be an object.");
+  }
+  const record = params as Record<string, unknown>;
+  if (typeof record.path !== "string" || record.path.length === 0) {
+    throw new Error("localAgentRequest path must be a non-empty string.");
+  }
+  if (!record.path.startsWith("/")) {
+    throw new Error(
+      `localAgentRequest path must be agent-relative (start with "/"); got "${record.path}". Local-agent IPC mode has no HTTP origin.`,
+    );
+  }
+
+  const method =
+    typeof record.method === "string" && record.method.length > 0
+      ? record.method.toUpperCase()
+      : "GET";
+
+  const headers =
+    record.headers && typeof record.headers === "object"
+      ? Object.fromEntries(
+          Object.entries(record.headers as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : {};
+
+  const rawBody = typeof record.body === "string" ? record.body : null;
+  if (rawBody !== null && METHODS_WITHOUT_BODY.has(method)) {
+    throw new Error(
+      `localAgentRequest method ${method} must not carry a body.`,
+    );
+  }
+  const body = METHODS_WITHOUT_BODY.has(method) ? null : rawBody;
+
+  const timeoutMs =
+    typeof record.timeoutMs === "number" &&
+    Number.isFinite(record.timeoutMs) &&
+    record.timeoutMs > 0
+      ? record.timeoutMs
+      : undefined;
+
+  return { path: record.path, method, headers, body, timeoutMs };
+}
+
+/**
+ * Build the `localAgentRequest` RPC handler bound to `dispatcher`. Registered in
+ * the Electrobun main-process RPC map; the renderer never reaches it unless the
+ * api base is the `eliza-local-agent://ipc` scheme (local-agent IPC mode).
+ */
+export function createLocalAgentRequestHandler(
+  dispatcher: LocalAgentDispatcher,
+): (params: LocalAgentRequestOptions) => Promise<LocalAgentRequestResult> {
+  return async (params) => {
+    const normalized = normalizeLocalAgentRequest(params);
+    return dispatcher.request(normalized);
+  };
+}

--- a/packages/app-core/platforms/electrobun/src/local-agent-stdio-attach.test.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-stdio-attach.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getActiveLocalAgentDispatcher,
+  requireActiveLocalAgentDispatcher,
+  setActiveLocalAgentDispatcher,
+} from "./local-agent-dispatcher-registry";
+import {
+  attachLocalAgentStdioBridge,
+  type LocalAgentChildStdio,
+} from "./local-agent-stdio-attach";
+
+/**
+ * Tests the child-stdio → dispatcher attachment + the process-wide dispatcher
+ * registry (#12355): a request written to the fake child's stdin is answered by
+ * feeding a response frame from its stdout, and detach clears the registry and
+ * rejects in-flight requests. No spawned process — the fake child is a controlled
+ * async stdout queue.
+ */
+
+afterEach(() => {
+  setActiveLocalAgentDispatcher(null);
+});
+
+/** A controllable fake child: captured stdin lines + a pushable stdout queue. */
+function makeFakeChild(): {
+  child: LocalAgentChildStdio;
+  stdinLines: string[];
+  pushStdout: (line: string) => void;
+  endStdout: () => void;
+} {
+  const stdinLines: string[] = [];
+  const queue: string[] = [];
+  const waiters: Array<(v: IteratorResult<string>) => void> = [];
+  let ended = false;
+
+  const pushStdout = (line: string): void => {
+    const waiter = waiters.shift();
+    if (waiter) waiter({ value: line, done: false });
+    else queue.push(line);
+  };
+  const endStdout = (): void => {
+    ended = true;
+    const waiter = waiters.shift();
+    if (waiter) waiter({ value: undefined as never, done: true });
+  };
+
+  const stdout: AsyncIterable<string> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<string>> {
+          if (queue.length > 0) {
+            return Promise.resolve({
+              value: queue.shift() as string,
+              done: false,
+            });
+          }
+          if (ended)
+            return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise((resolve) => waiters.push(resolve));
+        },
+      };
+    },
+  };
+
+  return {
+    child: { stdin: { write: (line) => stdinLines.push(line) }, stdout },
+    stdinLines,
+    pushStdout,
+    endStdout,
+  };
+}
+
+describe("attachLocalAgentStdioBridge", () => {
+  it("registers the dispatcher and round-trips a request via stdin/stdout", async () => {
+    const { child, stdinLines, pushStdout } = makeFakeChild();
+    const { detach } = attachLocalAgentStdioBridge(child);
+
+    expect(getActiveLocalAgentDispatcher()).not.toBeNull();
+
+    const promise = requireActiveLocalAgentDispatcher().request({
+      path: "/api/health",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+
+    // Wait a tick for the frame to be written.
+    await Promise.resolve();
+    expect(stdinLines).toHaveLength(1);
+    const sent = JSON.parse(stdinLines[0]);
+    expect(sent.payload.path).toBe("/api/health");
+
+    pushStdout(
+      JSON.stringify({
+        id: sent.id,
+        ok: true,
+        result: { status: 200, body: "OK" },
+      }),
+    );
+
+    await expect(promise).resolves.toEqual({ status: 200, body: "OK" });
+    detach("test done");
+    expect(getActiveLocalAgentDispatcher()).toBeNull();
+  });
+
+  it("detach rejects in-flight requests and clears the registry", async () => {
+    const { child } = makeFakeChild();
+    const { detach } = attachLocalAgentStdioBridge(child);
+    const dispatcher = requireActiveLocalAgentDispatcher();
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    detach("agent exited");
+    await expect(promise).rejects.toThrow(/agent exited/);
+    expect(getActiveLocalAgentDispatcher()).toBeNull();
+  });
+
+  it("tears down when the child stdout closes", async () => {
+    const { child, endStdout } = makeFakeChild();
+    const { dispatcher } = attachLocalAgentStdioBridge(child);
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    endStdout();
+    await expect(promise).rejects.toThrow(/stdout closed/);
+    expect(getActiveLocalAgentDispatcher()).toBeNull();
+  });
+});
+
+describe("local-agent dispatcher registry", () => {
+  it("requireActiveLocalAgentDispatcher throws with a clear message when unset", () => {
+    setActiveLocalAgentDispatcher(null);
+    expect(() => requireActiveLocalAgentDispatcher()).toThrow(
+      /no local-agent IPC dispatcher is attached/,
+    );
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/local-agent-stdio-attach.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-stdio-attach.ts
@@ -1,0 +1,71 @@
+/**
+ * Wires the agent child's stdio pipe to a {@link LocalAgentStdioDispatcher} and
+ * registers it as the process-wide active dispatcher (#12180 / #12355).
+ *
+ * Called from the agent-child spawn path only in local-agent IPC mode
+ * (`ELIZA_DESKTOP_LOCAL_AGENT_IPC=1`, `localAgentMode` on the child). The child
+ * binds no TCP listener; the renderer's `localAgentRequest` RPC calls ride this
+ * dispatcher over the NDJSON stdio frames instead. `detach()` (on child exit /
+ * shutdown) rejects every in-flight request and clears the registry so a
+ * subsequent request fails loudly rather than hanging on a dead pipe.
+ *
+ * The child multiplexes its human-readable logs on the same stdout pipe, so the
+ * line pump forwards every line to the dispatcher, which ignores anything that
+ * is not a JSON response frame keyed by a pending request id.
+ */
+
+import { setActiveLocalAgentDispatcher } from "./local-agent-dispatcher-registry";
+import {
+  LocalAgentStdioDispatcher,
+  type StdioFrameWriter,
+} from "./local-agent-stdio-dispatcher";
+
+/** The child stdio surface this attach helper needs. */
+export interface LocalAgentChildStdio {
+  /** Child stdin — request frames are written here as NDJSON lines. */
+  stdin: StdioFrameWriter;
+  /** Child stdout — response frames (and logs) arrive here line by line. */
+  stdout: AsyncIterable<string>;
+}
+
+export interface LocalAgentStdioAttachment {
+  dispatcher: LocalAgentStdioDispatcher;
+  /** Tear down: reject in-flight requests, clear the registry. Idempotent. */
+  detach: (reason: string) => void;
+}
+
+/**
+ * Attach `child` to a fresh dispatcher, register it, and start pumping stdout
+ * lines into it. The stdout pump runs until the iterable ends or `detach` is
+ * called; a pump failure (pipe error) tears the attachment down with the error.
+ */
+export function attachLocalAgentStdioBridge(
+  child: LocalAgentChildStdio,
+): LocalAgentStdioAttachment {
+  const dispatcher = new LocalAgentStdioDispatcher(child.stdin);
+  setActiveLocalAgentDispatcher(dispatcher);
+
+  let detached = false;
+  const detach = (reason: string): void => {
+    if (detached) return;
+    detached = true;
+    dispatcher.dispose(reason);
+    setActiveLocalAgentDispatcher(null);
+  };
+
+  void (async () => {
+    try {
+      for await (const line of child.stdout) {
+        if (detached) return;
+        dispatcher.handleLine(line);
+      }
+      detach("agent child stdout closed");
+    } catch (err) {
+      detach(
+        `agent child stdout errored: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  })();
+
+  return { dispatcher, detach };
+}

--- a/packages/app-core/platforms/electrobun/src/local-agent-stdio-dispatcher.test.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-stdio-dispatcher.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LocalAgentStdioDispatcher,
+  type StdioFrameWriter,
+} from "./local-agent-stdio-dispatcher";
+
+/**
+ * Unit tests for the main-process client of the desktop local-agent NDJSON
+ * stdio bridge (#12355): request framing, id correlation, timeout, and
+ * error-frame-to-rejection translation. Drives a deterministic in-memory writer
+ * (no spawned child); the real child-side kernel is proven by the capture lane.
+ */
+
+function makeWriter(): { writer: StdioFrameWriter; lines: string[] } {
+  const lines: string[] = [];
+  return { writer: { write: (line) => lines.push(line) }, lines };
+}
+
+describe("LocalAgentStdioDispatcher", () => {
+  it("frames a request as NDJSON with a monotonic id and resolves on the matching response", async () => {
+    const { writer, lines } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+
+    const promise = dispatcher.request({
+      path: "/api/health",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+
+    expect(lines).toHaveLength(1);
+    const sent = JSON.parse(lines[0]);
+    expect(sent.id).toBe(1);
+    expect(sent.method).toBe("local_agent_request");
+    expect(sent.payload).toEqual({
+      path: "/api/health",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+
+    dispatcher.handleLine(
+      JSON.stringify({
+        id: 1,
+        ok: true,
+        result: { status: 200, body: '{"ok":true}' },
+      }),
+    );
+
+    await expect(promise).resolves.toEqual({
+      status: 200,
+      body: '{"ok":true}',
+    });
+  });
+
+  it("correlates out-of-order responses by id", async () => {
+    const { writer } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+
+    const first = dispatcher.request({
+      path: "/api/a",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    const second = dispatcher.request({
+      path: "/api/b",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+
+    dispatcher.handleLine(
+      JSON.stringify({ id: 2, ok: true, result: { status: 201 } }),
+    );
+    dispatcher.handleLine(
+      JSON.stringify({ id: 1, ok: true, result: { status: 200 } }),
+    );
+
+    await expect(first).resolves.toEqual({ status: 200 });
+    await expect(second).resolves.toEqual({ status: 201 });
+  });
+
+  it("rejects on an error frame with the child's message", async () => {
+    const { writer } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    dispatcher.handleLine(
+      JSON.stringify({ id: 1, ok: false, error: "route not found" }),
+    );
+    await expect(promise).rejects.toThrow(/route not found/);
+  });
+
+  it("ignores non-JSON lines and unknown ids (child multiplexes logs on stdout)", async () => {
+    const { writer } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    dispatcher.handleLine("[Agent] some plain log line");
+    dispatcher.handleLine(
+      JSON.stringify({ id: 999, ok: true, result: { status: 200 } }),
+    );
+    dispatcher.handleLine(
+      JSON.stringify({ id: 1, ok: true, result: { status: 204 } }),
+    );
+    await expect(promise).resolves.toEqual({ status: 204 });
+  });
+
+  it("rejects a response frame whose result has no numeric status", async () => {
+    const { writer } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    dispatcher.handleLine(
+      JSON.stringify({ id: 1, ok: true, result: { body: "nope" } }),
+    );
+    await expect(promise).rejects.toThrow(/missing a numeric status/);
+  });
+
+  it("times out a request with no response", async () => {
+    vi.useFakeTimers();
+    try {
+      const { writer } = makeWriter();
+      const dispatcher = new LocalAgentStdioDispatcher(writer, 100);
+      const promise = dispatcher.request({
+        path: "/api/slow",
+        method: "GET",
+        headers: {},
+        body: null,
+      });
+      const assertion = expect(promise).rejects.toThrow(
+        /timed out after 100ms/,
+      );
+      await vi.advanceTimersByTimeAsync(101);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose() rejects all in-flight requests (pipe closed)", async () => {
+    const { writer } = makeWriter();
+    const dispatcher = new LocalAgentStdioDispatcher(writer);
+    const promise = dispatcher.request({
+      path: "/api/x",
+      method: "GET",
+      headers: {},
+      body: null,
+    });
+    dispatcher.dispose("agent child exited");
+    await expect(promise).rejects.toThrow(/agent child exited/);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/local-agent-stdio-dispatcher.ts
+++ b/packages/app-core/platforms/electrobun/src/local-agent-stdio-dispatcher.ts
@@ -1,0 +1,169 @@
+/**
+ * Client half of the desktop local-agent NDJSON stdio bridge (#12180 / #12355).
+ *
+ * The agent child, booted in `localAgentMode` (no TCP listener), speaks the
+ * platform-neutral NDJSON frame protocol on its stdio pipe — the same framing
+ * `createStdioBridge` (the server kernel in `@elizaos/plugin-capacitor-bridge`)
+ * writes back. This module is the main-process peer: it serializes a normalized
+ * local-agent request into a request frame, writes the line to the child's
+ * stdin, and resolves when the matching response frame arrives on stdout. It
+ * owns request/response correlation (monotonic ids), timeout, and the
+ * error-frame-to-rejection translation, so a failed dispatch surfaces as a
+ * thrown RPC error rather than a fabricated 200.
+ *
+ * Buffered request/response only — the streaming leg
+ * (`localAgentStreamRequest`) is added with its child-side consumer.
+ */
+
+import type {
+  LocalAgentDispatcher,
+  NormalizedLocalAgentRequest,
+} from "./local-agent-request";
+import type { LocalAgentRequestResult } from "./rpc-schema";
+
+/** Method label the child dispatches to its in-process route kernel. */
+const LOCAL_AGENT_REQUEST_METHOD = "local_agent_request" as const;
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Sink for outbound request frames — the child process's stdin writer. */
+export interface StdioFrameWriter {
+  write(line: string): void;
+}
+
+interface PendingRequest {
+  resolve: (result: LocalAgentRequestResult) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface StdioResponseFrame {
+  id?: unknown;
+  ok?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+function isLocalAgentRequestResult(
+  value: unknown,
+): value is LocalAgentRequestResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { status?: unknown }).status === "number"
+  );
+}
+
+/**
+ * Buffered stdio-bridge dispatcher. Construct one per agent child with a writer
+ * bound to the child's stdin; feed every stdout line to {@link handleLine}. The
+ * child correlates responses by echoing the request `id`.
+ */
+export class LocalAgentStdioDispatcher implements LocalAgentDispatcher {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+
+  constructor(
+    private readonly writer: StdioFrameWriter,
+    private readonly defaultTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  ) {}
+
+  request(
+    request: NormalizedLocalAgentRequest,
+  ): Promise<LocalAgentRequestResult> {
+    const id = this.nextId++;
+    const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
+    return new Promise<LocalAgentRequestResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `localAgentRequest ${request.method} ${request.path} timed out after ${timeoutMs}ms.`,
+          ),
+        );
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+
+      const frame = JSON.stringify({
+        id,
+        method: LOCAL_AGENT_REQUEST_METHOD,
+        payload: {
+          path: request.path,
+          method: request.method,
+          headers: request.headers,
+          body: request.body,
+        },
+      });
+      try {
+        this.writer.write(`${frame}\n`);
+      } catch (err) {
+        this.settleError(
+          id,
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    });
+  }
+
+  /**
+   * Feed one raw stdout line from the child. Non-JSON lines and frames without a
+   * numeric id we are waiting on are ignored (the child multiplexes logs on the
+   * same pipe). A matched frame settles its pending request.
+   */
+  handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let frame: StdioResponseFrame;
+    try {
+      frame = JSON.parse(trimmed) as StdioResponseFrame;
+    } catch {
+      return;
+    }
+    if (typeof frame.id !== "number") return;
+    const pending = this.pending.get(frame.id);
+    if (!pending) return;
+
+    if (frame.ok === false) {
+      this.settleError(
+        frame.id,
+        new Error(
+          typeof frame.error === "string"
+            ? frame.error
+            : "localAgentRequest failed.",
+        ),
+      );
+      return;
+    }
+    if (!isLocalAgentRequestResult(frame.result)) {
+      this.settleError(
+        frame.id,
+        new Error("localAgentRequest response frame missing a numeric status."),
+      );
+      return;
+    }
+    this.settleResult(frame.id, frame.result);
+  }
+
+  /** Reject every in-flight request — call when the child stdio pipe closes. */
+  dispose(reason: string): void {
+    for (const id of [...this.pending.keys()]) {
+      this.settleError(id, new Error(reason));
+    }
+  }
+
+  private settleResult(id: number, result: LocalAgentRequestResult): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+    pending.resolve(result);
+  }
+
+  private settleError(id: number, error: Error): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(id);
+    pending.reject(error);
+  }
+}

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -83,6 +83,8 @@ import {
 } from "./inbox-rpc";
 import { isKioskShellMode } from "./kiosk-mode";
 import { LaunchOrchestrator } from "./launch";
+import { requireActiveLocalAgentDispatcher } from "./local-agent-dispatcher-registry";
+import { createLocalAgentRequestHandler } from "./local-agent-request";
 import { logger } from "./logger";
 import {
   getAgentManager,
@@ -692,6 +694,26 @@ export function buildBunRpcHandlers({
       };
     },
     desktopHttpRequest,
+
+    // ---- Local-agent IPC transport (#12180 / #12355) ----
+    // Buffered agent request routed over the child stdio bridge (no loopback
+    // socket). The dispatcher is attached by the agent-child spawn only in
+    // local-agent IPC mode; in default HTTP mode the renderer never addresses
+    // the IPC api base, so this handler is not reached.
+    localAgentRequest: createLocalAgentRequestHandler({
+      request: (request) =>
+        requireActiveLocalAgentDispatcher().request(request),
+    }),
+    // Streaming (chat token SSE) over the IPC bridge is registered so the wire
+    // contract exists for the renderer's native streaming adapter; the
+    // child-side streaming consumer lands with the desktop capture proof
+    // (#12180 phase 4). It fails loudly rather than silently degrading to a
+    // non-streaming or socket path.
+    localAgentStreamRequest: async () => {
+      throw new Error(
+        "localAgentStreamRequest is not yet available: the desktop IPC streaming leg lands with its child-side consumer (#12180 phase 4).",
+      );
+    },
 
     // ---- Renderer diagnostics ----
     rendererReportDiagnostic: async (

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -187,6 +187,62 @@ export interface DesktopHttpRequestResult {
   body?: string | null;
 }
 
+/**
+ * A buffered local-agent request routed over Electrobun RPC (#12180 / #12355).
+ *
+ * `path` is agent-relative (`/api/health`, `/api/messaging/...`), NOT an
+ * absolute URL: local-agent IPC mode has no HTTP origin — the main process
+ * joins the path to the in-process route kernel and never opens a socket. The
+ * renderer's `desktop-local-agent-transport` derives `path` from the
+ * `eliza-local-agent://ipc` api base.
+ */
+export interface LocalAgentRequestOptions {
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+  timeoutMs?: number;
+}
+
+export interface LocalAgentRequestResult {
+  status: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+}
+
+/**
+ * A streaming local-agent request (chat token SSE) routed over Electrobun RPC.
+ * The main process opens the response with `LocalAgentStreamOpen`, pushes body
+ * chunks as `localAgentStreamChunk` events keyed by `streamId`, and terminates
+ * with a `localAgentStreamEnd` event. Mirrors the mobile native streaming
+ * contract (`createNativeStreamingResponse`) so one renderer streaming adapter
+ * serves every platform.
+ */
+export interface LocalAgentStreamRequestOptions {
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+}
+
+export interface LocalAgentStreamOpen {
+  streamId: string;
+  status: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+}
+
+export interface LocalAgentStreamChunkEvent {
+  streamId: string;
+  chunk: string;
+}
+
+export interface LocalAgentStreamEndEvent {
+  streamId: string;
+  error?: string;
+}
+
 export interface WindowBounds {
   x: number;
   y: number;
@@ -1600,6 +1656,14 @@ export type ElizaDesktopRPCSchema = {
         params: DesktopHttpRequestOptions;
         response: DesktopHttpRequestResult;
       };
+      localAgentRequest: {
+        params: LocalAgentRequestOptions;
+        response: LocalAgentRequestResult;
+      };
+      localAgentStreamRequest: {
+        params: LocalAgentStreamRequestOptions;
+        response: LocalAgentStreamOpen;
+      };
       desktopOpenLogsFolder: { params: undefined; response: undefined };
       desktopCreateBugReportBundle: {
         params: {
@@ -2349,6 +2413,12 @@ export type ElizaDesktopRPCSchema = {
         token?: string;
         externalApiBase?: string | null;
       };
+
+      // Local-agent IPC streaming push events (#12180 / #12355): a
+      // localAgentStreamRequest response is delivered as an ordered sequence of
+      // chunk events terminated by an end event, all keyed by `streamId`.
+      localAgentStreamChunk: LocalAgentStreamChunkEvent;
+      localAgentStreamEnd: LocalAgentStreamEndEvent;
 
       // Share target
       shareTargetReceived: { url: string; text?: string };


### PR DESCRIPTION
Closes #12355 · Part of #12180 (phase 2) · builds on the merged #12293 foundation slice.

## What & why

Routes the desktop local agent toward native Electrobun RPC instead of a loopback HTTP port. This PR lands the **main-process-side foundation** — fully unit-tested and non-breaking by default — that every downstream piece (and the renderer's dormant transport from #12293) keys off:

- **`eliza-local-agent://ipc` as the local-mode api base.** New `resolveLocalAgentIpcMode` gate (opt-in `ELIZA_DESKTOP_LOCAL_AGENT_IPC`; `ELIZA_API_EXPOSE_PORT=1` always wins and keeps loopback HTTP for dev/LAN/e2e). `resolveInitialApiBase` + `resolveRendererFacingApiBase` return the IPC scheme in that mode. **Default boot (neither flag) is byte-for-byte identical to today.**
- **Electrobun RPC schema.** `localAgentRequest` + `localAgentStreamRequest` request methods and `localAgentStreamChunk` / `localAgentStreamEnd` push events, matching the renderer transport contract shipped dormant in #12293.
- **Main-process request path.** `local-agent-request` (path-validated buffered handler over an injectable dispatcher seam) → `local-agent-stdio-dispatcher` (NDJSON client codec: id correlation, timeout, error-frame→rejection; the main-process peer of `createStdioBridge`) → `local-agent-stdio-attach` + `local-agent-dispatcher-registry` (attach a child's stdio to the dispatcher and register it process-wide). `rpc-handlers` registers `localAgentRequest` against the registry; the streaming handler throws loudly (its child-side consumer is device-gated).

The renderer never addresses the IPC api base in default mode, so the handler is unreachable until the flag flips — exactly the inert-by-default discipline of #12293.

## Done-when coverage

- `/api/health` + client calls round-trip through desktop RPC in local mode → **buffered request path implemented + unit-tested** (`local-agent-request`, `local-agent-stdio-dispatcher`, `local-agent-stdio-attach`). End-to-end token round-trip needs the child-side stdio server (device-gated remainder).
- No default local-mode TCP listener for the agent API port → **`skipListen`/`localAgentMode` port gate (#12293) proven** by a real child harness that asserts the port is NOT bound with `skipListen` and IS bound without it (`agent-skip-listen-no-port-proof.txt`, 9 pass). `resolveLocalAgentIpcMode` forwards `localAgentMode` intent via the api-base scheme.
- External mode + explicit port exposure still work → **unit-tested** (`resolveInitialApiBase`/`resolveRendererFacingApiBase` external + `ELIZA_API_EXPOSE_PORT` cases).

## Commands run

| Command | Result |
|---|---|
| electrobun unit tests (api-base, stdio dispatcher, attach/registry, request handler) | 50 pass |
| full electrobun suite (regression) | 483 pass / 65 files |
| `agent` `server-skip-listen.test.ts` (no-TCP-listener proof) | 9 pass |
| `ui` `desktop-local-agent-transport.test.ts` (dormant resolver regression) | 8 pass |
| electrobun `tsgo --noEmit` | 0 new errors (2 pre-existing `index.ts:848/849` on develop, unrelated) |
| `ui` `tsgo --noEmit` | 0 new errors (1 pre-existing unrelated `iwer` module) |
| biome check (touched files) | clean |

## Evidence (`.github/issue-evidence/12355-desktop-ipc-rpc/`)

| Row | Status |
|---|---|
| Unit tests (real output) | ✅ `electrobun-unit-tests.txt` |
| No-listener proof | ✅ `agent-skip-listen-no-port-proof.txt` (real child harness, TCP-connect probe) |
| Backend logs | N/A - handler unreachable in default mode; fires only under the device-gated flag flip |
| Frontend console/network | N/A - renderer never addresses the IPC base until the flag flips |
| Screenshots / video / per-platform capture | N/A - no user-visible behavior change in this slice (see #12293's identical rationale); desktop capture belongs to the behavior-flipping child-side PR |
| Real-LLM trajectory | N/A - no agent/action/prompt/model behavior change |
| Domain artifacts | N/A - transport wiring only |

## Remaining gaps (device-gated remainder — honest)

- Child `eliza start` honoring `localAgentMode` + running the NDJSON stdio server. The kernel (`createStdioBridge`) exists, but the child entry reads no env to enable it yet, so the main-process spawn flip is deliberately **not** wired (attaching the bridge to a child that does not speak it would be broken). `attachLocalAgentStdioBridge` is the ready seam.
- `AgentManager` spawn flip (`stdin: "pipe"` + IPC-native readiness) — today's readiness/health poll assumes an HTTP port; re-plumbing it needs a running desktop to verify.
- `localAgentStreamRequest` child-side streaming consumer (handler throws loudly until it lands).
- `capture:linux-desktop` / `capture:windows-desktop`, `lsof` no-listener proof in IPC mode, main-process `localAgentRequest` logs, zero-`127.0.0.1` frontend network trace — all require a real desktop this headless macOS host cannot provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
