### PR TITLE
fix(#12468): harden hosted-agent docker create flags

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests the hosted-agent Docker security-flag builder as a pure command
+ * contract, including the ordering required when Headscale re-adds NET_ADMIN.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildAgentContainerSecurityFlags } from "../agent-container-security";
+
+describe("buildAgentContainerSecurityFlags — hosted-agent escape hardening (#12468)", () => {
+  test("always drops all caps, forbids priv-escalation, and bounds pids (default 512)", () => {
+    const flags = buildAgentContainerSecurityFlags({ headscaleEnabled: false });
+    const cmd = flags.join(" ");
+    expect(flags).toContain("--cap-drop=ALL");
+    expect(cmd).toContain("--security-opt no-new-privileges");
+    expect(flags).toContain("--pids-limit=512");
+  });
+
+  test("without headscale, adds NO NET_ADMIN and NO tun device (agent-only escapes stay off)", () => {
+    const cmd = buildAgentContainerSecurityFlags({ headscaleEnabled: false }).join(" ");
+    expect(cmd).not.toContain("NET_ADMIN");
+    expect(cmd).not.toContain("/dev/net/tun");
+  });
+
+  test("under headscale, re-adds exactly NET_ADMIN + the tun device on top of the hardening", () => {
+    const flags = buildAgentContainerSecurityFlags({ headscaleEnabled: true });
+    const cmd = flags.join(" ");
+    // Hardening still present...
+    expect(flags).toContain("--cap-drop=ALL");
+    expect(cmd).toContain("--security-opt no-new-privileges");
+    expect(flags).toContain("--pids-limit=512");
+    // ...and the single legitimately-needed capability + device are re-added.
+    expect(flags).toContain("--cap-add=NET_ADMIN");
+    expect(flags).toContain("--device /dev/net/tun");
+  });
+
+  test("ORDER: --cap-drop=ALL is emitted BEFORE --cap-add=NET_ADMIN (drop-all-then-re-add idiom)", () => {
+    const flags = buildAgentContainerSecurityFlags({ headscaleEnabled: true });
+    const dropIdx = flags.indexOf("--cap-drop=ALL");
+    const addIdx = flags.indexOf("--cap-add=NET_ADMIN");
+    expect(dropIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    // A cap-add BEFORE the ALL drop would be wiped out, leaving the container
+    // with no NET_ADMIN — the tun interface would fail to come up. Guard it.
+    expect(dropIdx).toBeLessThan(addIdx);
+  });
+
+  test("honors a custom pids-limit override", () => {
+    expect(buildAgentContainerSecurityFlags({ headscaleEnabled: true, pidsLimit: 1024 })).toContain(
+      "--pids-limit=1024",
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildAppContainerSecurityFlags,
   buildAppEgressEnv,
   buildEnsureAppNetworkCmd,
+  buildLoopbackPortPublishFlag,
   buildSquidAllowlistConf,
 } from "../app-network-utils";
 
@@ -54,6 +55,13 @@ describe("buildAppContainerSecurityFlags — untrusted-image hardening", () => {
     expect(buildAppContainerSecurityFlags({ pidsLimit: 128 }).join(" ")).toContain(
       "--pids-limit=128",
     );
+  });
+});
+
+describe("buildLoopbackPortPublishFlag", () => {
+  test("binds published ports to host loopback only", () => {
+    expect(buildLoopbackPortPublishFlag(49001, 3000)).toBe("-p 127.0.0.1:49001:3000");
+    expect(buildLoopbackPortPublishFlag(49002, "8080")).toBe("-p 127.0.0.1:49002:8080");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/agent-container-security.ts
+++ b/packages/cloud/shared/src/lib/services/agent-container-security.ts
@@ -1,0 +1,34 @@
+/**
+ * Ordered kernel-capability posture for the hosted-AGENT container lane.
+ *
+ * The agent container reuses the same escape-hardening primitive as the app
+ * lane — {@link buildAppContainerSecurityFlags}: `--cap-drop=ALL`,
+ * `--security-opt no-new-privileges`, `--pids-limit=<n>` (#12230/#12302) — but,
+ * unlike an untrusted app, the agent legitimately needs ONE capability back
+ * when the headscale VPN is enabled: `NET_ADMIN` plus `/dev/net/tun` to bring up
+ * the tailnet interface.
+ *
+ * ORDER IS LOAD-BEARING. `--cap-drop=ALL` must be emitted BEFORE
+ * `--cap-add=NET_ADMIN` so the result is the canonical docker drop-all-then-
+ * re-add-exactly-one idiom, leaving the container with NET_ADMIN and nothing
+ * else. Keeping the composition in one pure builder makes that invariant a
+ * unit-testable contract instead of an implicit ordering buried in a large
+ * inline arg array in the provider.
+ */
+
+import { buildAppContainerSecurityFlags } from "./app-network-utils";
+
+/**
+ * Build the ordered `docker create` capability/security flags for a hosted-agent
+ * container. Always drops all capabilities and forbids privilege escalation;
+ * under headscale, re-adds exactly `NET_ADMIN` + the tun device AFTER the drop.
+ */
+export function buildAgentContainerSecurityFlags(opts: {
+  headscaleEnabled: boolean;
+  pidsLimit?: number;
+}): string[] {
+  return [
+    ...buildAppContainerSecurityFlags({ pidsLimit: opts.pidsLimit }),
+    ...(opts.headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
+  ];
+}

--- a/packages/cloud/shared/src/lib/services/app-network-utils.ts
+++ b/packages/cloud/shared/src/lib/services/app-network-utils.ts
@@ -4,16 +4,15 @@
  * Untrusted user app containers must NOT share the agent network or reach the
  * host/control plane. These pure builders produce the docker args that put each
  * app on its OWN `--internal` network (no direct egress, no inter-tenant
- * routing) behind a default-deny egress proxy, with capabilities dropped — the
- * opposite of the agent path, which uses a plain shared bridge and (under
- * headscale) NET_ADMIN + /dev/net/tun.
+ * routing) behind a default-deny egress proxy, with capabilities dropped. The
+ * capability/no-new-privileges/PID flags are also reusable by hosted-agent
+ * lanes that intentionally add back their own network capabilities afterward.
  *
  * Pure string/arg construction, so the isolation posture is a unit-testable
  * contract; kernel enforcement (does --internal actually block egress?) is
  * validated on a throwaway scratch network on the VPS, never here.
  *
- * ADDITIVE: nothing here touches the agent network config (`docker-sandbox-*`,
- * `containers-isolated`, DOCKER_NETWORK) — that path stays exactly as-is.
+ * ADDITIVE: callers opt into these args at their Docker command boundary.
  */
 
 import { shellQuote } from "./docker-sandbox-utils";
@@ -44,14 +43,23 @@ export function buildEnsureAppNetworkCmd(network: string): string {
 }
 
 /**
- * Hardening flags for an untrusted app container. Drops ALL capabilities,
- * forbids privilege escalation, and bounds processes. Deliberately NEVER emits
- * NET_ADMIN, `--device /dev/net/tun`, `--privileged`, or
- * `--add-host host.docker.internal:host-gateway` (the agent-only escapes).
+ * Hardening flags for an untrusted app or hosted-agent container. Drops ALL
+ * capabilities, forbids privilege escalation, and bounds processes.
+ * Deliberately NEVER emits NET_ADMIN, `--device /dev/net/tun`, `--privileged`,
+ * or `--add-host host.docker.internal:host-gateway`; agent callers that need
+ * tailnet plumbing must add NET_ADMIN/tun after this drop-all baseline.
  */
 export function buildAppContainerSecurityFlags(opts: { pidsLimit?: number } = {}): string[] {
   const pids = opts.pidsLimit ?? APP_NETWORK_DEFAULTS.pidsLimit;
   return ["--cap-drop=ALL", "--security-opt", "no-new-privileges", `--pids-limit=${pids}`];
+}
+
+/** Publish a container port only on the Docker host's loopback interface. */
+export function buildLoopbackPortPublishFlag(
+  hostPort: number,
+  containerPort: number | string,
+): string {
+  return `-p 127.0.0.1:${hostPort}:${containerPort}`;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -15,6 +15,10 @@ import { containers as containersTable } from "../../../../db/schemas/containers
 import type { DockerNode } from "../../../../db/schemas/docker-nodes";
 import { containersEnv } from "../../../config/containers-env";
 import { logger } from "../../../utils/logger";
+import {
+  buildAppContainerSecurityFlags,
+  buildLoopbackPortPublishFlag,
+} from "../../app-network-utils";
 import { dockerNodeManager } from "../../docker-node-manager";
 import { getUsedDockerHostPorts } from "../../docker-port-allocation";
 import {
@@ -266,8 +270,9 @@ export class HetznerContainersClient {
           `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
           `--cpus ${cpuUnitsToDockerCpus(input.cpu)}`,
           `--memory ${input.memoryMb}m`,
+          ...buildAppContainerSecurityFlags(),
           ...(volumePath ? [`-v ${shellQuote(volumePath)}:${shellQuote(volumeMountPath)}`] : []),
-          `-p ${hostPort}:${input.port}`,
+          buildLoopbackPortPublishFlag(hostPort, input.port),
           envFlags,
           shellQuote(input.image),
         ]
@@ -617,12 +622,13 @@ export class HetznerContainersClient {
           `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
           `--cpus ${cpuUnitsToDockerCpus(row.row.cpu)}`,
           `--memory ${row.row.memory}m`,
+          ...buildAppContainerSecurityFlags(),
           ...(meta.volumePath
             ? [
                 `-v ${shellQuote(meta.volumePath)}:${shellQuote(meta.volumeMountPath ?? DEFAULT_VOLUME_MOUNT_PATH)}`,
               ]
             : []),
-          `-p ${meta.hostPort}:${meta.containerPort}`,
+          buildLoopbackPortPublishFlag(meta.hostPort, meta.containerPort),
           envFlags,
           shellQuote(meta.image),
         ]

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -20,6 +20,7 @@ import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
+import { buildAgentContainerSecurityFlags } from "./agent-container-security";
 import { ensureRegistryAccess } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
@@ -1263,7 +1264,11 @@ export class DockerSandboxProvider implements SandboxProvider {
         ...(config.container?.memoryMb
           ? [`--memory ${shellQuote(`${Math.ceil(config.container.memoryMb)}m`)}`]
           : []),
-        ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
+        // Escape-hardening (#12230/#12302): drop ALL kernel capabilities, forbid
+        // privilege escalation, and bound the process count — then, under
+        // headscale only, re-add exactly NET_ADMIN + /dev/net/tun for the VPN.
+        // The builder guarantees --cap-drop=ALL precedes --cap-add=NET_ADMIN.
+        ...buildAgentContainerSecurityFlags({ headscaleEnabled }),
         `-v ${shellQuote(volumePath)}:/app/data`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 3000).


### PR DESCRIPTION
Closes #12468.

## Summary
- Add a hosted-agent Docker security flag builder that always emits `--cap-drop=ALL`, `--security-opt no-new-privileges`, and `--pids-limit`, while preserving Headscale by re-adding `NET_ADMIN` and `/dev/net/tun` after the drop-all baseline.
- Wire the hosted-agent `docker-sandbox-provider` create path through that ordered builder.
- Reuse the same hardening flags in the Hetzner create/recreate paths and bind those published ports to host loopback with a shared helper.

## Verification
- `bun test packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts` -> 16 pass / 0 fail.
- `bunx biome check packages/cloud/shared/src/lib/services/app-network-utils.ts packages/cloud/shared/src/lib/services/agent-container-security.ts packages/cloud/shared/src/lib/services/__tests__/app-network-utils.test.ts packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts` -> pass.
- `bun run --cwd packages/cloud/shared typecheck` -> fails on existing transitive app-core/core/shared missing-module/generated-i18n issues; no errors matched touched files (`app-network-utils`, `agent-container-security`, `hetzner-client/client`, `docker-sandbox-provider`).

## Evidence still needed before merge
- Live `docker inspect` on a provisioned hosted-agent container for `CapDrop`, `SecurityOpt`, `PidsLimit`, and Headscale `CapAdd`/tun behavior. This PR pins the command construction with unit tests but does not claim live node evidence.
