### PR TITLE
chore(#12231): comment cleanup B01 — prose headers for packages/core/src/types (comment-only)

### DIFF
--- a/packages/core/src/types/access-context.ts
+++ b/packages/core/src/types/access-context.ts
@@ -1,3 +1,10 @@
+/**
+ * Access-control context threaded through memory reads: identifies the requester
+ * a retrieval runs on behalf of so a database adapter can filter results down to
+ * what that requester is permitted to see. Part of the canonical `@elizaos/core`
+ * type system; enforcement composes with the opt-in Postgres RLS in `plugin-sql`
+ * and is a no-op when omitted (single-tenant reads stay unfiltered).
+ */
 import type { RoleName } from "../roles";
 import type { UUID } from "./primitives";
 

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -1,3 +1,9 @@
+/**
+ * Character-authoring and agent-record types: `Character` (personality, bio,
+ * settings, examples, plugins) and the runtime `Agent` record that extends it
+ * with status/enabled/lifecycle fields. These define how an agent is configured;
+ * consumed by the runtime, the character loader, and schema validation.
+ */
 import type { DocumentSourceItem } from "./documents";
 import type { Content, JsonObject, JsonValue } from "./primitives";
 import type { State } from "./state";

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -1,3 +1,10 @@
+/**
+ * Plugin-component contracts — the things a plugin registers into the runtime:
+ * `Action` (validate + handler), `Provider` (context injected into the prompt),
+ * and their supporting shapes (parameter schemas, handler/validator signatures,
+ * action modes, message-handler plan/extract results). The heart of the
+ * action/provider surface that the message loop dispatches against.
+ */
 import type { ConnectorAccountPolicy } from "./connector-account-policy";
 import type {
 	AgentContext,

--- a/packages/core/src/types/context-object.ts
+++ b/packages/core/src/types/context-object.ts
@@ -1,3 +1,9 @@
+/**
+ * Neutral in-memory representation of a prompt-assembly context: messages, tools,
+ * provider segments, and metadata collected before rendering into a model call.
+ * Event-typed and role-tagged so producers (providers, actions) and the renderer
+ * agree on a single intermediate shape independent of any model's wire format.
+ */
 import type { Action } from "./components";
 import type { AgentContext, ContextDefinition } from "./contexts";
 import type { Memory } from "./memory";

--- a/packages/core/src/types/contexts.ts
+++ b/packages/core/src/types/contexts.ts
@@ -1,3 +1,9 @@
+/**
+ * Agent-context taxonomy and gating types: the `FirstPartyAgentContext` union of
+ * named capability contexts (memory, documents, messaging, finance, …), context
+ * sensitivity/cache scopes, and the `RoleGate` / `ContextGate` shapes that decide
+ * which contexts and providers apply to a given turn.
+ */
 import type { Role } from "./environment";
 import type { JsonValue } from "./primitives";
 

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -1,3 +1,9 @@
+/**
+ * Database-adapter contract and its row/log types: `IDatabaseAdapter`, run/log
+ * body shapes, patch ops, and the participant/entity query result types. Defines
+ * the persistence boundary the runtime reads and writes through; implemented by
+ * `plugin-sql` and the in-memory fallback adapter.
+ */
 import type { AccessContext } from "./access-context";
 import type { Agent } from "./agent";
 import type {

--- a/packages/core/src/types/documents.ts
+++ b/packages/core/src/types/documents.ts
@@ -1,3 +1,8 @@
+/**
+ * Document-ingestion types: a `DocumentItem` (content + metadata + optional
+ * embedding similarity) and the source descriptors (path / directory) used when
+ * loading documents into memory. Consumed by the documents feature bundle.
+ */
 import type { MemoryMetadata } from "./memory";
 import type { Content, UUID } from "./primitives";
 

--- a/packages/core/src/types/environment.ts
+++ b/packages/core/src/types/environment.ts
@@ -1,3 +1,9 @@
+/**
+ * Social-graph and world-model types: `Entity`, `Component`, `Room`, `World`,
+ * `Participant`, `Relationship`, and the `Role` enum for world-scoped access
+ * control. These model who and where an agent is interacting with; consumed
+ * throughout memory, messaging, and the trust/roles subsystems.
+ */
 import type { ChannelType, Metadata, UUID } from "./primitives";
 import type { WorldSettings } from "./settings";
 

--- a/packages/core/src/types/evaluator.ts
+++ b/packages/core/src/types/evaluator.ts
@@ -1,3 +1,8 @@
+/**
+ * Evaluator contracts: the post-response processing step run after the agent
+ * replies. Defines the `Evaluator` interface plus its run/prompt/processor
+ * context shapes and the pluggable `EvaluatorProcessor` chain.
+ */
 import type { ActionResult, HandlerCallback } from "./components";
 import type { Memory } from "./memory";
 import type { JSONSchema, ModelTypeName } from "./model";

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -1,3 +1,9 @@
+/**
+ * Runtime event system: the `EventType` enum and the per-event payload shapes an
+ * agent emits and plugins subscribe to (world/entity/room/message/voice/model/
+ * pipeline events). The typed contract that decouples event producers from
+ * consumers across the runtime and plugins.
+ */
 import type { HandlerCallback } from "./components";
 import type { Entity, Room, World } from "./environment";
 import type { Memory } from "./memory";

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -1,3 +1,9 @@
+/**
+ * Memory record types: `Memory` (the stored unit — content, embedding, scope,
+ * room/entity/world ids) plus the `MemoryType` and `MemoryScope` enumerations.
+ * The central data shape the runtime persists, embeds, and retrieves through the
+ * database adapter.
+ */
 import type { Content, MetadataValue, UUID } from "./primitives";
 
 /**

--- a/packages/core/src/types/message-service.ts
+++ b/packages/core/src/types/message-service.ts
@@ -1,3 +1,8 @@
+/**
+ * Message-processing contracts for the incoming-message loop: options controlling
+ * a turn (retries, multi-step, streaming, continue-after-actions) and the result
+ * shapes the message service returns. Consumed by the runtime message handler.
+ */
 import type {
 	AgentContext,
 	HandlerCallback,

--- a/packages/core/src/types/message-source.ts
+++ b/packages/core/src/types/message-source.ts
@@ -1,3 +1,8 @@
+/**
+ * Well-known `source` sentinels for messages the agent originates or routes
+ * internally (client chat, sub-agent, coding-agent, agent greeting), so routing
+ * and gating code can branch on provenance without magic strings.
+ */
 export const MESSAGE_SOURCE_CLIENT_CHAT = "client_chat" as const;
 export const MESSAGE_SOURCE_SUB_AGENT = "sub_agent" as const;
 export const MESSAGE_SOURCE_CODING_AGENT = "coding-agent" as const;

--- a/packages/core/src/types/messaging.ts
+++ b/packages/core/src/types/messaging.ts
@@ -1,3 +1,9 @@
+/**
+ * Messaging transport contracts: `TargetInfo` and send-handler signatures for
+ * delivering a message to a platform, the socket/stream event payloads, UI
+ * control messages, and the `IMessagingAdapter` server/channel model. The seam
+ * between the runtime and connector plugins that actually send messages.
+ */
 import type { Memory } from "./memory";
 import type { Content, UUID } from "./primitives";
 import type { IAgentRuntime } from "./runtime";

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1,3 +1,9 @@
+/**
+ * Model-layer types: the `ModelType` registry, LLM-mode overrides, generation
+ * params/results, tool-definition and tool-call shapes, chat-message parts, and
+ * response-skeleton/sampler structures. Defines the model-agnostic interface the
+ * runtime calls through (`useModel`) and that model plugins implement.
+ */
 import type { StreamChunkCallback } from "./components";
 import type { AgentContext } from "./contexts";
 import type { JsonValue } from "./primitives";

--- a/packages/core/src/types/pairing.ts
+++ b/packages/core/src/types/pairing.ts
@@ -1,3 +1,8 @@
+/**
+ * DM-pairing workflow types: `PairingRequest` / `PairingChannel` / allowlist
+ * entries for the flow where a user proves access to a bot over a DM channel via
+ * a short code. Consumed by the pairing services and messaging connectors.
+ */
 import type { UUID } from "./primitives";
 
 /**

--- a/packages/core/src/types/payment.ts
+++ b/packages/core/src/types/payment.ts
@@ -1,3 +1,8 @@
+/**
+ * x402 paid-route types: per-route `PaymentConfigDefinition`, the built-in
+ * network/asset presets, and character-level payment defaults. Describe how a
+ * plugin route declares a price and which chain/asset settles it.
+ */
 import type { JsonObject } from "./primitives";
 
 /**

--- a/packages/core/src/types/pipeline-hooks.ts
+++ b/packages/core/src/types/pipeline-hooks.ts
@@ -1,3 +1,10 @@
+/**
+ * Pipeline-hook types for the single `registerPipelineHook` / `applyPipelineHooks`
+ * extension model: the phase enumeration (message compose/reply, model I/O,
+ * post-persist, stream chunks) and handler shapes. One registration + ordering
+ * model lets the runtime attach a uniform metrics/logging envelope to every hook.
+ * Rationale: `docs/PIPELINE_HOOKS.md`.
+ */
 import type { AgentContext } from "./contexts";
 import type { Room } from "./environment";
 import type { Memory } from "./memory";

--- a/packages/core/src/types/plugin-store.ts
+++ b/packages/core/src/types/plugin-store.ts
@@ -1,3 +1,9 @@
+/**
+ * Generic plugin data-store contract: a small adapter-agnostic CRUD + schema-
+ * registration interface so plugins can persist custom tables (goals, todos, …)
+ * without casting `runtime.db` to Drizzle types. Works across SQL and in-memory
+ * adapters; deliberately not a full ORM (no joins/subqueries).
+ */
 import type { UUID } from "./primitives";
 
 /**

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1,3 +1,9 @@
+/**
+ * The `Plugin` contract itself: the object a plugin's `src/index.ts` exports,
+ * aggregating its actions, providers, evaluators, services, models, routes,
+ * events, and schema. The top-level unit the agent's plugin loader resolves,
+ * validates, and wires into the runtime.
+ */
 import type { AppPackageRouteContext } from "../api/route-helpers";
 import type { ConnectorSourceDefinition } from "../connectors";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -1,3 +1,9 @@
+/**
+ * Foundational scalar and JSON types shared across the whole type system: `UUID`,
+ * `Content`, `Media`, `Metadata`, the JSON value/object unions, and channel-type
+ * enums. The leaf dependency most other `types/*` modules build on; keep it
+ * free of runtime-specific imports so browser/edge builds can consume it.
+ */
 import type { InteractionBlock } from "./interactions";
 
 /**

--- a/packages/core/src/types/prompt-batcher.ts
+++ b/packages/core/src/types/prompt-batcher.ts
@@ -1,3 +1,8 @@
+/**
+ * Types for the prompt batcher, which coalesces prompt sections across turns into
+ * batched ("drained") model calls. Describes section frequency, per-drain
+ * metadata, and the batching contract the runtime util implements.
+ */
 import type { Memory } from "./memory";
 import type { GenerateTextParams } from "./model";
 import type { Content } from "./primitives";

--- a/packages/core/src/types/prompt-optimization-score-card.ts
+++ b/packages/core/src/types/prompt-optimization-score-card.ts
@@ -1,3 +1,9 @@
+/**
+ * `ScoreCard`: in-memory aggregation of DPE `ScoreSignal`s into a single weighted
+ * `composite` for one trace row. Single-path ingest (`addAll` delegates to `add`)
+ * avoids drift; malformed (NaN) signals are dropped at aggregate time so one bad
+ * plugin signal cannot poison a score. Pairs with `prompt-optimization-trace`.
+ */
 import {
 	DEFAULT_SIGNAL_WEIGHTS,
 	type ScoreCardData,

--- a/packages/core/src/types/prompt-optimization-trace.ts
+++ b/packages/core/src/types/prompt-optimization-trace.ts
@@ -1,3 +1,9 @@
+/**
+ * Dynamic-prompt-execution (DPE) optimization payloads: additive `ScoreSignal`s,
+ * an aggregated `ScoreCardData` snapshot, and one `ExecutionTrace` row per attempt.
+ * Plain JSON-friendly structs (no ORM coupling) so traces can be appended to logs
+ * or analytics; `traceVersion` lets offline consumers pin parsers.
+ */
 import type { UUID } from "./primitives";
 
 /**

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -1,3 +1,10 @@
+/**
+ * The runtime-facing interface surface: `IAgentRuntime` (the contract plugins and
+ * services program against) plus the message-target and connector-account types
+ * it exposes for multi-account messaging connectors. Sits atop the type system —
+ * it pulls together components, memory, model, and database types into the single
+ * object the whole framework passes around.
+ */
 import type { ReportedError } from "../errors";
 import type { Logger } from "../logger";
 import type { ContextRegistry } from "../runtime/context-registry";

--- a/packages/core/src/types/search.ts
+++ b/packages/core/src/types/search.ts
@@ -1,3 +1,8 @@
+/**
+ * Search-surface types: category filter definitions and options that describe how
+ * a searchable domain (by string/number/enum/date facets) presents its filters.
+ * Consumed by search providers and UI that render filterable result sets.
+ */
 import type { AgentContext } from "./components";
 import type { JsonValue } from "./primitives";
 import type { ServiceTypeName } from "./service";

--- a/packages/core/src/types/service.ts
+++ b/packages/core/src/types/service.ts
@@ -1,3 +1,9 @@
+/**
+ * Service abstraction: the `ServiceTypeRegistry` (extended by plugins via module
+ * augmentation) and the long-lived-singleton `Service` base contract. Services are
+ * clients/schedulers/connectors the runtime starts once and shares across the
+ * message loop.
+ */
 import type { JsonValue, Metadata } from "./primitives";
 import type { IAgentRuntime } from "./runtime";
 

--- a/packages/core/src/types/settings.ts
+++ b/packages/core/src/types/settings.ts
@@ -1,3 +1,8 @@
+/**
+ * Settings types: `RuntimeSettings` key/value strings and `SettingDefinition`
+ * metadata (required, secret, dependencies) used to describe and validate a
+ * plugin's or character's configurable settings.
+ */
 import type { JsonValue } from "./primitives";
 
 /**

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,3 +1,9 @@
+/**
+ * Per-turn `State`: the composed working context passed through the message loop —
+ * provider values, working memory, action plans, and the structured-output schema
+ * rows. Built fresh each turn from providers and consumed by prompt assembly and
+ * action handlers.
+ */
 import type { ActionResult, ProviderValue } from "./components";
 import type { Entity, Room, World } from "./environment";
 

--- a/packages/core/src/types/swarm-coordinator.ts
+++ b/packages/core/src/types/swarm-coordinator.ts
@@ -1,3 +1,8 @@
+/**
+ * Multi-agent swarm-coordination types: the coordinator service token, bind-state
+ * machine, and swarm event/listener and chat-routing shapes used to route a chat
+ * session across a coordinated group of agents.
+ */
 export const SWARM_COORDINATOR_SERVICE_TYPE = "SWARM_COORDINATOR";
 
 export interface SwarmCoordinatorBindState {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -1,3 +1,9 @@
+/**
+ * Scheduled/background task types: `Task`, `TaskStatus`, and the `TaskWorker`
+ * contract the runtime invokes when a task of a given name is due. Two gates
+ * exist by design — `shouldRun` (scheduler, no message/state) and `canExecute`
+ * (action-time, full context for auth). Backs the task scheduler service.
+ */
 import type { Memory } from "./memory";
 import type { JsonValue, UUID } from "./primitives";
 import type { IAgentRuntime } from "./runtime";

--- a/packages/core/src/types/tee.ts
+++ b/packages/core/src/types/tee.ts
@@ -1,3 +1,11 @@
+/**
+ * Legacy plugin-tee attestation shapes (`TEEMode`, `TeeAgent`,
+ * `RemoteAttestationQuote`, …) modeling the original Phala/dstack deterministic
+ * key-derivation + TDX-quote surface. NOT the trust contract the agent boot path
+ * uses — the canonical, provider-neutral evidence + fail-closed policy lives in
+ * `packages/agent/src/services/tee-evidence.ts` and `tee-policy.ts`; add new
+ * confidential-compute fields there, not here.
+ */
 import type { JsonObject } from "./primitives";
 
 /**

--- a/packages/core/src/types/testing.ts
+++ b/packages/core/src/types/testing.ts
@@ -1,3 +1,7 @@
+/**
+ * Minimal in-runtime test-harness types: `TestSuite` / `TestCase` that a plugin
+ * exports so the agent can run its self-tests against a live `IAgentRuntime`.
+ */
 import type { IAgentRuntime } from "./runtime";
 
 /**

--- a/packages/core/src/types/trigger.ts
+++ b/packages/core/src/types/trigger.ts
@@ -1,3 +1,9 @@
+/**
+ * Trigger-configuration types for scheduled and event-driven agent activations:
+ * interval/once/cron/event triggers whose target is either a workflow dispatch or
+ * a prompt-automation turn, plus per-run bookkeeping records. Consumed by the
+ * trigger-scheduling service.
+ */
 import type { UUID } from "./primitives";
 
 export const TRIGGER_SCHEMA_VERSION = 1 as const;


### PR DESCRIPTION
## Comment cleanup B01 — slice: `packages/core/src/types/`

Part of #12231 (parent #12181). **Comment-only change; `check:comment-only` PASSES** —
every code token is byte-for-byte identical to `origin/develop` (verified by
`scripts/assert-comment-only-diff.mjs`).

### What changed
Added a prose file header to the **34 header-less files** in
`packages/core/src/types/` — the canonical `@elizaos/core` type system. Each header
was written from reading the file: first sentence states what the module defines in
system terms (never repeats the filename), then relationships/invariants as warranted.
Length scales with weight; no header exceeds the ~25-line ceiling.

- **Files touched:** 34 (all in `packages/core/src/types/`)
- **Headers added:** 34
- **Churn comments removed:** 0 — the churn grep over this slice found no
  change-narration/restatement comment lines to delete or rewrite.
- **Files flagged (purpose undeterminable):** none.

The rest of batch B01 (`packages/prompts` / `logger` / `registry` / `skills` and the
remaining `packages/core` subtrees) is out of scope for this PR — the pilot set
(prompts/logger/registry/skills) already carries headers on `develop`, and remaining
core subtrees ship as separate ≤50-file slices per the parent's merge-pain rules.

### Verification
```
$ node scripts/assert-comment-only-diff.mjs origin/develop
[assert-comment-only-diff] OK — 34 source file(s) changed; every code token identical to origin/develop. Comments only.
```
Header self-audit over `packages/core/src/types/**` prints nothing (no header-less files remain).

### Evidence (per PR_EVIDENCE.md)
- Real-LLM trajectories — N/A: comments-only change, zero functional diff (machine-checked).
- Screenshots / video / audio / domain artifacts — N/A: comments-only change, zero functional diff.
- Machine proof: `check:comment-only` output above (token-stream identical).

Refs #12231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
