### PR TITLE
chore(#12236): comment cleanup B06 — cloud/shared billing + crypto + types (comment-only)

### DIFF
--- a/packages/cloud/shared/drizzle.config.ts
+++ b/packages/cloud/shared/drizzle.config.ts
@@ -1,3 +1,10 @@
+/**
+ * drizzle-kit configuration for the cloud database. Points introspection,
+ * studio, and migration generation at the schemas in `src/db/schemas` and
+ * emits SQL to `src/db/migrations`. `NODE_ENV` selects which `.env` file loads
+ * the target connection (local PGlite / staging / production Neon).
+ */
+
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
 

--- a/packages/cloud/shared/src/billing/credit-markup.test.ts
+++ b/packages/cloud/shared/src/billing/credit-markup.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the credit-markup arithmetic; pure functions, no I/O or mocks. */
+
 import { describe, expect, test } from "vitest";
 import {
   calculateCreditMarkup,

--- a/packages/cloud/shared/src/billing/index.ts
+++ b/packages/cloud/shared/src/billing/index.ts
@@ -1,3 +1,4 @@
+/** Public surface of the isomorphic billing math: markup, credit-markup, and Twilio SMS billing. */
 export {
   type CreditMarkupBreakdown,
   type CreditMarkupInput,

--- a/packages/cloud/shared/src/billing/markup.test.ts
+++ b/packages/cloud/shared/src/billing/markup.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the gateway markup, USD rounding, and Twilio SMS billing helpers; pure functions, no I/O. */
+
 import { describe, expect, test } from "vitest";
 import {
   applyMarkup,

--- a/packages/cloud/shared/src/db/crypto/agent-backups.ts
+++ b/packages/cloud/shared/src/db/crypto/agent-backups.ts
@@ -1,3 +1,12 @@
+/**
+ * Field-level encryption for `agent_sandbox_backups.state_data`.
+ *
+ * Wraps the shared field-crypto primitives to encrypt/decrypt agent backup
+ * state under the org DEK. Both directions are idempotent — already-encrypted
+ * input passes through encrypt untouched, and plaintext passes through decrypt
+ * untouched — via the `kms-aes-256-gcm` envelope type guard.
+ */
+
 import type {
   AgentBackupPlainStateData,
   AgentBackupStoredStateData,

--- a/packages/cloud/shared/src/db/crypto/api-keys.ts
+++ b/packages/cloud/shared/src/db/crypto/api-keys.ts
@@ -1,10 +1,10 @@
 /**
  * API-key plaintext encryption helpers (D-1).
  *
- * The plaintext API key itself is sensitive (it grants access). We continue
- * to store a SHA-256 `key_hash` for fast lookup during auth, but the raw
- * plaintext is now encrypted at rest under the org's DEK so a DB-only
- * compromise cannot exfiltrate live keys.
+ * The plaintext API key itself is sensitive (it grants access). A SHA-256
+ * `key_hash` is stored for fast lookup during auth, while the raw plaintext is
+ * encrypted at rest under the org's DEK so a DB-only compromise cannot
+ * exfiltrate live keys.
  *
  * The one-time reveal flow on creation works by decrypting in-memory right
  * after insert — the plaintext never persists outside the encrypted columns.

--- a/packages/cloud/shared/src/db/crypto/index.ts
+++ b/packages/cloud/shared/src/db/crypto/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for field-level crypto: per-table encrypt/decrypt helpers plus the shared primitives and KMS client. */
 export * as apiKeyCrypto from "./api-keys";
 export * as conversationCrypto from "./conversations";
 export * from "./field-crypto";

--- a/packages/cloud/shared/src/db/utils/jsonb.ts
+++ b/packages/cloud/shared/src/db/utils/jsonb.ts
@@ -1,3 +1,5 @@
+/** Binds JS values as explicit JSONB query parameters, sidestepping driver-specific object binding. */
+
 import { type SQL, sql } from "drizzle-orm";
 
 function safeJsonStringify(value: unknown): string {

--- a/packages/cloud/shared/src/index.ts
+++ b/packages/cloud/shared/src/index.ts
@@ -1,3 +1,4 @@
+/** Package root barrel: re-exports the billing, db, lib, and types subpackages as namespaces. */
 export * as billing from "./billing/index.ts";
 export * as db from "./db/index.ts";
 export * as lib from "./lib/index.ts";

--- a/packages/cloud/shared/src/types/cloud-api.ts
+++ b/packages/cloud/shared/src/types/cloud-api.ts
@@ -1,1 +1,2 @@
+/** Re-export of the cloud API DTO types from their canonical home in `lib/types`. */
 export * from "../lib/types/cloud-api";

--- a/packages/cloud/shared/src/types/index.ts
+++ b/packages/cloud/shared/src/types/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for the cloud transport types: API DTOs, Worker env bindings, and Stripe queue payloads. */
 export * from "./cloud-api.ts";
 export * from "./cloud-worker-env.ts";
 export * from "./stripe-queue-message.ts";


### PR DESCRIPTION
## Comment cleanup B06 (slice: cloud/shared billing + crypto + types)

Part of #12236 / parent #12181. **Comment-only change — zero functional diff, machine-checked.**

This is the first slice of batch B06 (`packages/cloud/shared/**`, 1350 files total). Scope kept to one coherent, load-bearing subtree: the isomorphic billing math, the DB field-crypto helpers, and the transport-type barrels.

### What changed
- **Prose headers added** where missing (11 files touched):
  - Barrels (1-line): `src/index.ts`, `src/billing/index.ts`, `src/types/index.ts`, `src/types/cloud-api.ts`, `src/db/crypto/index.ts`
  - Modules: `drizzle.config.ts` (drizzle-kit config + `NODE_ENV` env selection), `src/db/utils/jsonb.ts` (JSONB param binding), `src/db/crypto/agent-backups.ts` (idempotent field-crypto for backup state)
  - Test files (1-line, harness-honest): `src/billing/credit-markup.test.ts`, `src/billing/markup.test.ts` (pure functions, no I/O/mocks)
- **Churn rewritten to present tense** (1 comment): `src/db/crypto/api-keys.ts` — "the raw plaintext is now encrypted at rest" / "We continue to store…" → present-tense statement of the at-rest encryption invariant.
- Files already at the bar (`credit-markup.ts`, `markup.ts`, `field-crypto.ts`, `kms-client.ts`, `conversations.ts`, `users.ts`, `platform-credentials.ts`, `cloud-worker-env.ts`, `stripe-queue-message.ts`, `crypto.test.ts`) were left untouched.

### Tallies
- Files touched: 11 · Headers added: 10 · Churn rewritten: 1 · Commented-out code deleted: 0
- filesFlagged (purpose undeterminable): none

### Verify
```
$ node scripts/assert-comment-only-diff.mjs origin/develop
[assert-comment-only-diff] OK — 11 source file(s) changed; every code token identical to origin/develop. Comments only.
```
**comment-only; `check:comment-only` PASSES.**

Evidence rows — trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Refs #12236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
