### PR TITLE
chore(#12234): comment cleanup B04 — local-inference prose headers, churn removal (comment-only)

### DIFF
--- a/packages/ui/src/components/local-inference/ActiveModelBar.stories.tsx
+++ b/packages/ui/src/components/local-inference/ActiveModelBar.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ActiveModelBar — ready, loading, error, busy, and unknown-model states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   ActiveModelState,

--- a/packages/ui/src/components/local-inference/ActiveModelBar.tsx
+++ b/packages/ui/src/components/local-inference/ActiveModelBar.tsx
@@ -1,3 +1,9 @@
+/**
+ * Compact active-model status strip for the local-inference panel: the loaded
+ * model's display name, its load/ready/error state, and an Unload button.
+ * Renders nothing when no model is loaded.
+ */
+
 import type {
   ActiveModelState,
   InstalledModel,

--- a/packages/ui/src/components/local-inference/DeviceBridgeStatus.stories.tsx
+++ b/packages/ui/src/components/local-inference/DeviceBridgeStatus.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for DeviceBridgeStatusBar — connected, offline-pending, no-device, and null states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { DeviceBridgeStatus } from "../../api/client-local-inference";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/local-inference/DeviceBridgeStatus.tsx
+++ b/packages/ui/src/components/local-inference/DeviceBridgeStatus.tsx
@@ -1,3 +1,9 @@
+/**
+ * Single-line status bar for the paired on-device inference bridge (a desktop
+ * fronting a phone/tablet runtime): connection dot, capability summary, and the
+ * loaded model filename. Renders nothing until a bridge status arrives.
+ */
+
 import type { DeviceBridgeStatus } from "../../api/client-local-inference";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
 import { useTranslation } from "../../state/TranslationContext.hooks";

--- a/packages/ui/src/components/local-inference/DevicesPanel.stories.tsx
+++ b/packages/ui/src/components/local-inference/DevicesPanel.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for DevicesPanel — multi-device, single CPU-only, and empty/null states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { DeviceBridgeStatus } from "../../api/client-local-inference";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/local-inference/DownloadProgress.stories.tsx
+++ b/packages/ui/src/components/local-inference/DownloadProgress.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for DownloadProgress — just-started, downloading, nearly-done, completed, and unknown-total states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { DownloadJob } from "../../api/client-local-inference";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/local-inference/DownloadProgress.tsx
+++ b/packages/ui/src/components/local-inference/DownloadProgress.tsx
@@ -1,3 +1,8 @@
+/**
+ * Progress bar for one model-download job: percent, bytes received/total,
+ * throughput, and ETA. Shared by the download queue and the per-model cards.
+ */
+
 import type { DownloadJob } from "../../api/client-local-inference";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { formatBytes, formatEta, progressPercent } from "./hub-utils";

--- a/packages/ui/src/components/local-inference/DownloadQueue.stories.tsx
+++ b/packages/ui/src/components/local-inference/DownloadQueue.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for DownloadQueue — single-downloading, empty, queued-and-downloading, failed-job, and unknown-model states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   CatalogModel,

--- a/packages/ui/src/components/local-inference/FirstRunOffer.stories.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for FirstRunOffer — needs-download, in-progress, default-enqueued, no-recommendation, and hidden-when-satisfied states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   CatalogModel,

--- a/packages/ui/src/components/local-inference/FirstRunOffer.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.tsx
@@ -1,3 +1,10 @@
+/**
+ * First-run banner prompting download of the default local model when no
+ * Eliza-owned model is installed (or one is still downloading). Picks the
+ * recommended model for the detected hardware and hides itself once a local
+ * model is present and no download is in flight.
+ */
+
 import type {
   CatalogModel,
   DownloadJob,

--- a/packages/ui/src/components/local-inference/HardwareBadge.stories.tsx
+++ b/packages/ui/src/components/local-inference/HardwareBadge.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for HardwareBadge — Apple Silicon, CUDA, CPU-only, Vulkan, and OS-fallback-warning hardware profiles. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type { HardwareProbe } from "../../api/client-local-inference";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/local-inference/HardwareBadge.tsx
+++ b/packages/ui/src/components/local-inference/HardwareBadge.tsx
@@ -1,3 +1,9 @@
+/**
+ * Inline hardware summary for the model hub — CPU/RAM/chip, GPU backend + VRAM,
+ * and the recommended model preset — read from a `HardwareProbe`. Flags a
+ * limited GPU probe when only the OS-fallback detector ran.
+ */
+
 import { AlertTriangle, Cpu, Gauge, HardDrive } from "lucide-react";
 import type { HardwareProbe } from "../../api/client-local-inference";
 import { useTranslation } from "../../state/TranslationContext.hooks";

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
@@ -1,3 +1,10 @@
+/**
+ * Top-level local-inference settings surface: the model hub (curated catalog +
+ * download queue), active-model bar, hardware badge, connected device bridges,
+ * and the voice sub-model updater. Streams live download/active deltas over SSE
+ * and drives the hub through the local-inference API client.
+ */
+
 import type { VoiceModelId } from "@elizaos/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../api";
@@ -443,9 +450,8 @@ function VoiceModelUpdatesSection() {
     autoUpdateOnCellular: false,
     autoUpdateOnMetered: false,
   });
-  // #12087 Item 25: owner-tier gating comes from the canonical role context, not
-  // a per-endpoint `isOwner` flag threaded through fetched state. The
-  // voice-preferences endpoint's owner flag is no longer consumed here.
+  // #12087 Item 25: owner-tier gating comes from the canonical role context
+  // (useRole), not a per-endpoint `isOwner` flag threaded through fetched state.
   const { isOwner } = useRole();
   const [installations, setInstallations] = useState<
     ReadonlyArray<VoiceModelInstallationView>

--- a/packages/ui/src/components/local-inference/ModelCard.stories.tsx
+++ b/packages/ui/src/components/local-inference/ModelCard.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ModelCard — default, won't-fit, downloading, failed, installed, active, and download-unavailable states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   ActiveModelState,

--- a/packages/ui/src/components/local-inference/ModelCard.tsx
+++ b/packages/ui/src/components/local-inference/ModelCard.tsx
@@ -1,3 +1,9 @@
+/**
+ * Full-detail card for one catalog model: fit-for-hardware badge, runtime class,
+ * size/quant metadata, and the download / activate / verify / uninstall
+ * actions. The compact row variant used by the hub grid lives in ModelHubView.
+ */
+
 import type {
   ActiveModelState,
   CatalogModel,

--- a/packages/ui/src/components/local-inference/ModelHubView.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.tsx
@@ -1,3 +1,10 @@
+/**
+ * Catalog browser for the local-inference hub: groups models by capability
+ * bucket (small/mid/large/xl), marks the hardware-recommended bucket, and
+ * renders each model as a compact row with download/activate/verify actions.
+ * Off-platform generic-GGUF picks are flagged not-runnable.
+ */
+
 import { CheckCircle2 } from "lucide-react";
 import { useMemo } from "react";
 import type {

--- a/packages/ui/src/components/local-inference/ModelUpdatesPanel.stories.tsx
+++ b/packages/ui/src/components/local-inference/ModelUpdatesPanel.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for ModelUpdatesPanel — owner, non-owner, checking, and never-checked states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { TranslationProvider } from "../../state/TranslationProvider";

--- a/packages/ui/src/components/local-inference/ProvidersList.tsx
+++ b/packages/ui/src/components/local-inference/ProvidersList.tsx
@@ -1,3 +1,10 @@
+/**
+ * Grid of inference providers (cloud API, subscription, local, device bridge)
+ * showing enable state, supported vs currently-registered model slots, and a
+ * configure link. Polls the local-inference providers endpoint every 10s while
+ * the document is visible so provider state follows env/config changes.
+ */
+
 import { Cloud, Cpu, KeyRound, Settings, Smartphone } from "lucide-react";
 import type { ComponentType } from "react";
 import { useCallback, useEffect, useState } from "react";

--- a/packages/ui/src/components/local-inference/RoutingMatrix.tsx
+++ b/packages/ui/src/components/local-inference/RoutingMatrix.tsx
@@ -1,3 +1,10 @@
+/**
+ * Per-slot inference routing controls: a routing-policy selector (manual / auto
+ * by device / on-device only / cloud only) plus a preferred-provider dropdown
+ * per agent model slot. Agent-controllable via useAgentElement; reads device
+ * tier and public registrations from the local-inference API.
+ */
+
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { client } from "../../api";

--- a/packages/ui/src/components/local-inference/SlotAssignments.stories.tsx
+++ b/packages/ui/src/components/local-inference/SlotAssignments.stories.tsx
@@ -1,3 +1,5 @@
+/** Storybook stories for SlotAssignments — all-auto, custom, single-model, unverified-bundle, and empty states. */
+
 import type { Meta, StoryObj } from "@storybook/react";
 import type {
   InstalledModel,

--- a/packages/ui/src/components/local-inference/hub-utils.test.ts
+++ b/packages/ui/src/components/local-inference/hub-utils.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit coverage for the model-hub display helpers (pure functions, no DOM).
+ */
+
 import { describe, expect, it } from "vitest";
 import { displayModelName } from "./hub-utils";
 

--- a/packages/ui/src/components/local-inference/runtime-class-ui.test.ts
+++ b/packages/ui/src/components/local-inference/runtime-class-ui.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the runtime-class labeling + platform-servability helpers,
+ * with the platform guard mocked to exercise each frontend platform.
+ */
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FrontendPlatform } from "../../platform/platform-guards";
 
@@ -18,9 +23,6 @@ afterEach(() => {
   getFrontendPlatform.mockReset();
 });
 
-// RuntimeClass collapsed to the single fused Eliza-1 tier (eliza-1-only cutover,
-// #9033); the generic-gguf path was removed, so the helpers only handle the one
-// class now.
 describe("runtimeClassBadge", () => {
   it("labels fused Eliza-1 as eliza-1", () => {
     expect(runtimeClassBadge("fused-eliza1")).toBe("eliza-1");

--- a/packages/ui/src/components/local-inference/slot-metadata.ts
+++ b/packages/ui/src/components/local-inference/slot-metadata.ts
@@ -1,3 +1,8 @@
+/**
+ * Descriptors for the agent model slots surfaced in the local-inference routing
+ * and assignment UIs — a user-facing label and description per ModelType slot.
+ */
+
 import type { AgentModelSlot } from "../../api/client-local-inference";
 
 export type LocalInferenceSlotDescriptor = {

--- a/packages/ui/src/components/local-inference/useDeviceBridgeStatus.test.ts
+++ b/packages/ui/src/components/local-inference/useDeviceBridgeStatus.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit coverage for the device-bridge stream URL builder — token query-param
+ * handling and separator choice; pure, no EventSource.
+ */
+
 import { describe, expect, it } from "vitest";
 import { buildDeviceBridgeStatusStreamUrl } from "./useDeviceBridgeStatus";
 

--- a/packages/ui/src/components/local-inference/useDeviceBridgeStatus.ts
+++ b/packages/ui/src/components/local-inference/useDeviceBridgeStatus.ts
@@ -1,3 +1,10 @@
+/**
+ * Subscribes to the device-bridge status SSE stream and returns the latest
+ * `DeviceBridgeStatus`, or null on native IPC bases that EventSource cannot
+ * open. `buildDeviceBridgeStatusStreamUrl` appends the auth token as a query
+ * param since EventSource cannot set headers.
+ */
+
 import { useEffect, useState } from "react";
 import type { DeviceBridgeStatus } from "../../api/client-local-inference";
 import { resolveApiUrl } from "../../utils/asset-url";

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
 
+/**
+ * Unit coverage for the home-surface model-status hook: it stays `not-required`
+ * for cloud/remote/unauthenticated runtimes and derives readiness from the hub
+ * fetch. Runtime-mode and the API client are mocked (jsdom, no network).
+ */
+
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UseRuntimeModeResult } from "../../hooks/useRuntimeMode";


### PR DESCRIPTION
Part of #12181 (comment-slop cleanup swarm). Batch **B04**, slice `packages/ui/src/components/local-inference/`.

## What this is

**Comment-only.** Zero functional diff — `bun run check:comment-only` **PASSES** (26 source files changed; every code token identical to `origin/develop`, comments/whitespace only).

## Changes

Per the parent convention (root `CLAUDE.md` "Slop and Comment Cleanup"):

- **Prose file headers added** to 22 files that lacked one: 12 source (`ActiveModelBar`, `DeviceBridgeStatus`, `DownloadProgress`, `HardwareBadge`, `FirstRunOffer`, `ProvidersList`, `ModelCard`, `ModelHubView`, `LocalInferencePanel`, `RoutingMatrix`, `slot-metadata`, `useDeviceBridgeStatus`), 4 tests (1–3 lines each, naming the surface + harness realness), 10 Storybook story files (1-line, listing the states exercised).
- **Churn removed:** rewrote a `// … no longer consumed here` change-narration comment in `LocalInferencePanel.tsx` to present-tense rationale (keeps the `#12087` anchor); deleted a stale, inaccurate change-narration comment in `runtime-class-ui.test.ts` (claimed the generic-gguf path was removed, but the source still handles both runtime classes).

### Left intentionally untouched (accuracy over coverage)
Files that already carry a purpose-explaining JSDoc header were not double-headed: `DevicesPanel`, `DownloadQueue`, `SlotAssignments`, `hub-utils`, `runtime-class-ui`, `ModelUpdatesPanel`, `useHomeModelStatus`, and the existing stories-smoke test.

## Tallies
- Files touched: 26 · Headers added: 22 · Churn lines removed/rewritten: 2
- filesFlagged (purpose undeterminable): none

## Verification
```
node scripts/assert-comment-only-diff.mjs origin/develop
[assert-comment-only-diff] OK — 26 source file(s) changed; every code token identical to origin/develop. Comments only.
```

Refs #12234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
