### PR TITLE
docs(#12241): add Bun iOS runtime script headers

### DIFF
--- a/packages/native/bun-runtime/scripts/build-ios-bun-engine.mjs
+++ b/packages/native/bun-runtime/scripts/build-ios-bun-engine.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Builds the vendored ElizaBunEngine xcframework from an iOS-capable Bun fork.
+ *
+ * The harness stages the fork output, links the Eliza C ABI shim, enforces the
+ * no-JIT App Store runtime profile, and writes the framework artifact consumed
+ * by the iOS app build when full-Bun mode is enabled.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/packages/native/bun-runtime/scripts/check-upstream-support.mjs
+++ b/packages/native/bun-runtime/scripts/check-upstream-support.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Probes the installed Bun binary for native iOS compile-target support.
+ *
+ * The check documents whether upstream Bun can produce `bun-ios-*` standalone
+ * targets yet; strict mode lets CI fail when the fork-only framework path is
+ * still required.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";

--- a/packages/native/bun-runtime/scripts/ios-app-store-runtime-policy.mjs
+++ b/packages/native/bun-runtime/scripts/ios-app-store-runtime-policy.mjs
@@ -1,3 +1,11 @@
+/**
+ * Shared App Store execution policy for the iOS full-Bun engine.
+ *
+ * Build scripts and verifiers import these constants so device slices are
+ * checked against one no-JIT, no-loader, no-subprocess policy instead of
+ * duplicating symbol and build-setting lists.
+ */
+
 export const appStoreExecutionProfile = "ios-app-store-nojit";
 
 export const appStoreRuntimeEnv = {

--- a/packages/native/bun-runtime/scripts/ios-app-store-runtime-policy.test.mjs
+++ b/packages/native/bun-runtime/scripts/ios-app-store-runtime-policy.test.mjs
@@ -1,3 +1,11 @@
+/**
+ * Deterministic coverage for the iOS App Store runtime-policy helpers.
+ *
+ * The tests feed synthetic `nm` and string output through the policy parser so
+ * forbidden import families and remediation text stay stable without requiring
+ * a real framework binary.
+ */
+
 import assert from "node:assert/strict";
 import test from "node:test";
 import {

--- a/packages/native/bun-runtime/scripts/script-utils.mjs
+++ b/packages/native/bun-runtime/scripts/script-utils.mjs
@@ -1,3 +1,11 @@
+/**
+ * Small command-line helpers shared by the Bun iOS runtime scripts.
+ *
+ * They keep argument parsing, checked subprocess execution, captured output,
+ * and `[bun-ios-runtime]` failure formatting consistent across the build,
+ * smoke, and verification entry points.
+ */
+
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 

--- a/packages/native/bun-runtime/scripts/smoke-ios-bun-engine.mjs
+++ b/packages/native/bun-runtime/scripts/smoke-ios-bun-engine.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Checks that a built iOS app bundle contains the full Bun engine prerequisites.
+ *
+ * This smoke step validates the staged agent bundle and exported Eliza C ABI
+ * symbols before a device or simulator run attempts to exercise the Capacitor
+ * bridge.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";

--- a/packages/native/bun-runtime/scripts/verify-ios-app-store.mjs
+++ b/packages/native/bun-runtime/scripts/verify-ios-app-store.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Verifies that the iOS full-Bun engine and app bundle obey App Store runtime policy.
+ *
+ * The verifier inspects xcframework slices or embedded app frameworks for ABI
+ * metadata, forbidden entitlements, unsafe network policy, and imports that
+ * imply JIT, dynamic loading, or process-spawn paths.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/packages/native/bun-runtime/scripts/verify-ios-app-store.test.mjs
+++ b/packages/native/bun-runtime/scripts/verify-ios-app-store.test.mjs
@@ -1,3 +1,11 @@
+/**
+ * Deterministic coverage for iOS app-bundle policy checks.
+ *
+ * The tests build temporary app fixtures and synthetic symbol output so the
+ * verifier catches unsafe local-network policy and forbidden runtime imports
+ * without requiring an actual signed iOS app.
+ */
+
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";


### PR DESCRIPTION
Part of #12241.

## What
- Adds purpose-explaining prose headers to the eight `packages/native/bun-runtime/scripts/*.mjs` files in B11 scope.
- Comments only; no code or string/template changes.

## Verification
- PASS: `bun run check:comment-only`
- PASS: `bun run --cwd packages/native/bun-runtime test`
- PASS: B11 native header self-audit printed nothing:
  `git ls-files 'packages/native/**' | grep -E '\.(ts|tsx|js|mjs|cjs|jsx)$' | grep -vE '\.d\.ts$|/generated/|\.generated\.|node_modules|/dist/|/vendor/' | while read f; do awk ...; done`
- PASS with warnings: `bunx biome check <8 touched files>` exited 0. Existing warnings remain in `build-ios-bun-engine.mjs`, `ios-app-store-runtime-policy.mjs`, and `verify-ios-app-store.mjs`; this PR is comments-only, so I did not make code changes to address them.
- PASS: `git diff --check`

## Evidence notes
- Real-LLM trajectories: N/A, comments-only.
- Screenshots/video/audio/domain artifacts: N/A, comments-only.
- Functional diff guard: `scripts/assert-comment-only-diff.mjs` proves code tokens are identical to `origin/develop`.
