### PR TITLE
chore(#12232): comment cleanup B02 — prose headers, churn removal (comment-only)

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -668,9 +668,7 @@ const dedupeTargets = {
   // depends on. Building from src against the same `@elizaos/core` source the
   // runtime uses keeps the adapter and the runtime in lockstep.
   //
-  // The on-disk layout is `plugins/plugin-sql/src/index.node.ts`. (An earlier
-  // refactor staged a `plugins/plugin-sql/typescript/` mirror; that's gone
-  // now and the path here was stale.)
+  // The on-disk layout is `plugins/plugin-sql/src/index.node.ts`.
   "@elizaos/plugin-sql": path.resolve(
     repoRoot,
     "plugins",

--- a/packages/agent/src/api/avatar-routes.ts
+++ b/packages/agent/src/api/avatar-routes.ts
@@ -2,9 +2,9 @@ import fs from "node:fs";
 import type http from "node:http";
 import path from "node:path";
 
-// Lazy memoized loader — previously module-scope `await import`, which forced
-// @elizaos/plugin-discord to load on every agent boot just for two pure path
-// helpers. Now only loads on the first /api/avatar/discord/* request.
+// Lazy memoized loader: @elizaos/plugin-discord loads only on the first
+// /api/avatar/discord/* request. A module-scope `await import` would load the
+// whole plugin on every agent boot just for two pure path helpers.
 type DiscordAvatarModule = {
   getDiscordAvatarCacheDir: () => string;
   getDiscordAvatarCachePath: (fileName: string) => string;

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -96,10 +96,9 @@ interface DiscordProfileLike {
   username?: string;
 }
 
-// Lazy memoized loader — previously module-scope `await import`, which forced
-// @elizaos/plugin-discord (and its transitive deps) to load on every agent
-// boot. Now only loads when a conversation actually contains Discord-sourced
-// messages.
+// Lazy memoized loader: @elizaos/plugin-discord (and its transitive deps) loads
+// only when a conversation actually contains Discord-sourced messages. A
+// module-scope `await import` would load it on every agent boot.
 type DiscordConversationModule = {
   cacheDiscordAvatarForRuntime: (
     runtime: AgentRuntime,

--- a/packages/agent/src/api/server-route-dispatch.ts
+++ b/packages/agent/src/api/server-route-dispatch.ts
@@ -10,10 +10,10 @@ import { handlePushTokenRoute } from "./push-token-routes.ts";
 import { tryHandleRuntimePluginRoute } from "./runtime-plugin-routes.ts";
 import type { ServerState } from "./server-types.ts";
 
-// Lazy memoized loaders — previously these were module-scope `await import`,
-// which forced @elizaos/plugin-computeruse and @elizaos/plugin-elizacloud to
-// load whenever this module was reached in the static graph (i.e. on every
-// agent boot). Now each plugin only loads when its route group is first hit.
+// Lazy memoized loaders: each plugin loads only when its route group is first
+// hit. A module-scope `await import` would pull @elizaos/plugin-computeruse and
+// @elizaos/plugin-elizacloud into the static graph, loading them on every agent
+// boot even when their routes are never touched.
 type ComputeUsePluginModule = {
   handleSandboxRoute: (...args: unknown[]) => Promise<boolean>;
 };

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -63,12 +63,11 @@ import { type WebSocket, WebSocketServer } from "ws";
 import { installPlugin as installPluginDirect } from "../services/plugin-installer.ts";
 import { handlePluginDirectoryRoutes } from "./plugin-directory-routes.ts";
 
-// `@elizaos/plugin-browser` and `@elizaos/plugin-x402` were previously
-// imported via module-scope top-level await, which forced both plugins to
-// load (and pulled their transitive native deps) whenever anything imported
-// `@elizaos/agent`. That blocked container boot in cloud sandboxes. They are
-// now lazily loaded. X402 is loaded only when runtime routes need validation;
-// browser is loaded on first browser route hit so neither gates API bind.
+// `@elizaos/plugin-browser` and `@elizaos/plugin-x402` load lazily: X402 only
+// when runtime routes need validation, browser on the first browser route hit,
+// so neither gates the API bind. A module-scope top-level await here would load
+// both plugins (and their transitive native deps) whenever anything imported
+// `@elizaos/agent`, which blocks container boot in cloud sandboxes.
 type BrowserPluginModule = typeof import("@elizaos/plugin-browser");
 type X402PluginModule = typeof import("@elizaos/plugin-x402");
 

--- a/packages/import-conversations/src/adapters/document-service.test.ts
+++ b/packages/import-conversations/src/adapters/document-service.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for createDocumentServiceSink: scope binding, idempotent clientDocumentId derivation, and status mapping against an in-memory fake DocumentService. */
+
 import { describe, expect, it } from "vitest";
 import type { SinkDocument } from "../core/sink.ts";
 import {

--- a/packages/import-conversations/src/adapters/document-service.ts
+++ b/packages/import-conversations/src/adapters/document-service.ts
@@ -1,3 +1,11 @@
+/**
+ * Adapts a runtime DocumentService onto the pipeline's injectable `DocumentSink`
+ * port, so ingested transcripts land as scoped, searchable knowledge documents.
+ * `createDocumentServiceSink` binds the world/room/entity scope context once and
+ * derives a stable `clientDocumentId` (sha256-of-content UUIDv4) per document so
+ * re-imports are idempotent rather than duplicated.
+ */
+
 import { createHash } from "node:crypto";
 import type {
   DocumentScope,

--- a/packages/import-conversations/src/adapters/index.ts
+++ b/packages/import-conversations/src/adapters/index.ts
@@ -1,1 +1,3 @@
+/** Barrel for the storage adapters that bridge the ingestion pipeline to a concrete runtime DocumentService. */
+
 export * from "./document-service.ts";

--- a/packages/import-conversations/src/core/manifest.test.ts
+++ b/packages/import-conversations/src/core/manifest.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the uninstall manifest key + idempotency helpers. Deterministic, in-memory. */
+
 import { describe, expect, it } from "vitest";
 import {
   classifyConversation,

--- a/packages/import-conversations/src/core/pipeline.test.ts
+++ b/packages/import-conversations/src/core/pipeline.test.ts
@@ -1,3 +1,5 @@
+/** End-to-end tests for the ingestion pipeline (redact → render → sink) driven through an in-memory DocumentSink; no runtime, no live model. */
+
 import { describe, expect, it } from "vitest";
 import {
   conv,

--- a/packages/import-conversations/src/core/redact.test.ts
+++ b/packages/import-conversations/src/core/redact.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for redactText secret-scrubbing over representative token/key shapes. Deterministic. */
+
 import { describe, expect, it } from "vitest";
 import { containsSecret, REDACTED_PLACEHOLDER, redactText } from "./redact.ts";
 

--- a/packages/import-conversations/src/core/registry.test.ts
+++ b/packages/import-conversations/src/core/registry.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for ConversationImporterRegistry registration, lookup, and source-detection dispatch. Deterministic. */
+
 import { describe, expect, it } from "vitest";
 import {
   type ConversationImporter,

--- a/packages/import-conversations/src/core/render.test.ts
+++ b/packages/import-conversations/src/core/render.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for transcript rendering (headers, message formatting). Deterministic, string-in/string-out. */
+
 import { describe, expect, it } from "vitest";
 import { renderConversation, renderHeader, renderMessage } from "./render.ts";
 import type { NormalizedConversation, NormalizedMessage } from "./types.ts";

--- a/packages/import-conversations/src/core/report.test.ts
+++ b/packages/import-conversations/src/core/report.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the plan/apply ReportBuilder counters and summary shape. Deterministic. */
+
 import { describe, expect, it } from "vitest";
 import {
   notImported,

--- a/packages/import-conversations/src/parsers/chatgpt.test.ts
+++ b/packages/import-conversations/src/parsers/chatgpt.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the ChatGPT export parser: conversation-tree flattening and normalization, over tmp-file fixtures. Deterministic. */
+
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/import-conversations/src/parsers/claude.test.ts
+++ b/packages/import-conversations/src/parsers/claude.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the Claude export parser: detect() and parse() over tmp-file/zip fixtures. Deterministic. */
+
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/packages/import-conversations/src/parsers/claude.ts
+++ b/packages/import-conversations/src/parsers/claude.ts
@@ -1,3 +1,11 @@
+/**
+ * Parser for Claude data exports (a `conversations.json` array, optionally
+ * inside a zip). Registers as a `ConversationImporter` and streams each
+ * conversation into the normalized message contract, keeping document-extract
+ * attachment text by default. Uses the bounded JSON-array and zip-entry readers
+ * so large exports stay within memory.
+ */
+
 import { createReadStream, existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import path from "node:path";

--- a/packages/import-conversations/src/parsers/hermes.test.ts
+++ b/packages/import-conversations/src/parsers/hermes.test.ts
@@ -1,3 +1,5 @@
+/** Unit tests for the Hermes home parser: detect() and session/memory normalization over tmp-dir fixtures. Deterministic. */
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";

--- a/packages/import-conversations/src/parsers/hermes.ts
+++ b/packages/import-conversations/src/parsers/hermes.ts
@@ -1,3 +1,10 @@
+/**
+ * Parser for Hermes agent home directories (per-session files plus optional
+ * `memories/*.md` notes). Registers as a `ConversationImporter` and normalizes
+ * each session into the shared message contract; chain-of-thought reasoning and
+ * `tool` messages are opt-in, daily memory notes are on by default.
+ */
+
 import { createReadStream, existsSync } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";

--- a/packages/import-conversations/src/parsers/json-array-stream.ts
+++ b/packages/import-conversations/src/parsers/json-array-stream.ts
@@ -1,3 +1,9 @@
+/**
+ * Bounded streaming reader for a top-level JSON array, used to walk a
+ * conversation export's `conversations.json` one object at a time without
+ * loading the whole file into memory.
+ */
+
 import type { Readable } from "node:stream";
 
 /**

--- a/packages/import-conversations/src/parsers/zip-entry.ts
+++ b/packages/import-conversations/src/parsers/zip-entry.ts
@@ -1,3 +1,11 @@
+/**
+ * Minimal zip reader: locate a single entry via the end-of-central-directory
+ * record and stream its inflated bytes. Lets the export parsers read
+ * `conversations.json` straight out of a `.zip` without unpacking the archive
+ * or pulling in a zip dependency. Handles zip64 sentinels; rejects encrypted
+ * entries.
+ */
+
 import { createReadStream } from "node:fs";
 import { open } from "node:fs/promises";
 import { Readable } from "node:stream";

--- a/packages/import-conversations/vitest.config.ts
+++ b/packages/import-conversations/vitest.config.ts
@@ -1,3 +1,5 @@
+/** Vitest config for @elizaos/import-conversations unit tests (node env). */
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/plugin-remote-manifest/src/index.ts
+++ b/packages/plugin-remote-manifest/src/index.ts
@@ -1,3 +1,5 @@
+/** Barrel re-export for the default "." entry of @elizaos/plugin-remote-manifest (manifest, permissions, store, wire types). */
+
 export type {
   RemotePluginConsentRequestInput,
   RemotePluginPermissionDiff,

--- a/packages/plugin-remote-manifest/src/json.ts
+++ b/packages/plugin-remote-manifest/src/json.ts
@@ -1,3 +1,5 @@
+/** Internal `isJsonObject` type guard shared by the manifest validator and store. */
+
 import type { JsonObject, JsonValue } from "./types.js";
 
 export function isJsonObject(

--- a/packages/plugin-remote-manifest/src/manifest.ts
+++ b/packages/plugin-remote-manifest/src/manifest.ts
@@ -1,3 +1,10 @@
+/**
+ * Consent-request builder and permission-diff utility over a `plugin.json`
+ * manifest. Turns a manifest's declared permission tags into the consent
+ * request the host prompts on, and computes what changes between two manifests
+ * on upgrade.
+ */
+
 import {
   flattenRemotePluginPermissions,
   normalizeRemotePluginPermissions,

--- a/packages/plugin-remote-manifest/src/permissions.ts
+++ b/packages/plugin-remote-manifest/src/permissions.ts
@@ -1,3 +1,9 @@
+/**
+ * Permission model helpers for remote plugins: normalize/flatten grants,
+ * merge and diff permission sets, and parse legacy permission shapes into the
+ * current host/Bun grant representation defined in types.ts.
+ */
+
 import {
   BUN_PERMISSIONS,
   type BunPermission,

--- a/packages/plugin-remote-manifest/src/store.ts
+++ b/packages/plugin-remote-manifest/src/store.ts
@@ -1,3 +1,10 @@
+/**
+ * On-disk install store for remote plugins: reads/writes the install registry,
+ * installs and uninstalls plugin artifacts, and loads/bootstraps installed
+ * plugins for the host runtime. Owns the atomic staging (mkdtemp + rename)
+ * install layout under the state dir.
+ */
+
 import {
   cpSync,
   existsSync,

--- a/packages/plugin-remote-manifest/src/types.ts
+++ b/packages/plugin-remote-manifest/src/types.ts
@@ -1,3 +1,11 @@
+/**
+ * Single source of truth for the remote-plugin protocol: the host + Bun sandbox
+ * permission constant tuples, the `plugin.json` manifest interfaces, install-source
+ * and consent-request shapes, and the worker↔host wire envelope types. Consumed
+ * across the desktop runtime (agent bridge, host shims, worker runtime, sub-agent).
+ * Permission tuples are `as const` because the union types are derived from them.
+ */
+
 export const HOST_PERMISSIONS = [
   "windows",
   "tray",

--- a/packages/plugin-remote-manifest/src/validation.ts
+++ b/packages/plugin-remote-manifest/src/validation.ts
@@ -1,3 +1,10 @@
+/**
+ * Safe parser/validator for `plugin.json`: `validateRemotePluginManifest` takes
+ * untrusted JSON and returns a typed `RemotePluginManifest` or a structured
+ * rejection, never trusting unvalidated fields. The trust boundary between an
+ * on-disk/downloaded manifest and the install store.
+ */
+
 import { isJsonObject } from "./json.js";
 import { isRemotePluginIsolation } from "./permissions.js";
 import {

--- a/packages/plugin-sub-agent-claude-code/src/plugin.ts
+++ b/packages/plugin-sub-agent-claude-code/src/plugin.ts
@@ -1,3 +1,4 @@
+/** Compatibility re-export of the Claude Code sub-agent Plugin descriptor from @elizaos/plugin-remote-manifest; the wrapper's dist/plugin.js host entry points here. */
 export {
   default,
   plugin,

--- a/packages/plugin-sub-agent-claude-code/src/sandbox.ts
+++ b/packages/plugin-sub-agent-claude-code/src/sandbox.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the OS-level sandbox helpers (macOS sandbox-exec, Linux bwrap) for the Claude Code sub-agent from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/sub-agent-claude-code/sandbox";

--- a/packages/plugin-sub-agent-claude-code/src/session-recorder.ts
+++ b/packages/plugin-sub-agent-claude-code/src/session-recorder.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the Claude Code sub-agent session recorder from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/sub-agent-claude-code/session-recorder";

--- a/packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts
+++ b/packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the Claude Code sub-agent service from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/sub-agent-claude-code/sub-agent-service";

--- a/packages/plugin-sub-agent-claude-code/src/worker.ts
+++ b/packages/plugin-sub-agent-claude-code/src/worker.ts
@@ -1,1 +1,2 @@
+/** Compatibility worker entry that boots the Claude Code sub-agent worker runtime from @elizaos/plugin-remote-manifest; the wrapper's dist/worker.js points here. */
 import "@elizaos/plugin-remote-manifest/sub-agent-claude-code/worker";

--- a/packages/plugin-worker-runtime/src/bootstrap.ts
+++ b/packages/plugin-worker-runtime/src/bootstrap.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker bootstrap() entry point from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/bootstrap";

--- a/packages/plugin-worker-runtime/src/descriptor.ts
+++ b/packages/plugin-worker-runtime/src/descriptor.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker-runtime descriptor builder from @elizaos/plugin-remote-manifest; keeps the historical @elizaos/plugin-worker-runtime/descriptor import path working. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/descriptor";

--- a/packages/plugin-worker-runtime/src/dispatch.ts
+++ b/packages/plugin-worker-runtime/src/dispatch.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker-runtime dispatch loop from @elizaos/plugin-remote-manifest; keeps the historical @elizaos/plugin-worker-runtime/dispatch import path working. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/dispatch";

--- a/packages/plugin-worker-runtime/src/envelope.ts
+++ b/packages/plugin-worker-runtime/src/envelope.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker↔host wire envelope helpers from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/envelope";

--- a/packages/plugin-worker-runtime/src/error.ts
+++ b/packages/plugin-worker-runtime/src/error.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker-runtime error rehydration helpers from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/error";

--- a/packages/plugin-worker-runtime/src/index.ts
+++ b/packages/plugin-worker-runtime/src/index.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker-runtime public API from @elizaos/plugin-remote-manifest; keeps the historical @elizaos/plugin-worker-runtime import path working. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime";

--- a/packages/plugin-worker-runtime/src/runtime-proxy.ts
+++ b/packages/plugin-worker-runtime/src/runtime-proxy.ts
@@ -1,1 +1,2 @@
+/** Compatibility re-export of the worker-runtime host-proxy from @elizaos/plugin-remote-manifest. */
 export * from "@elizaos/plugin-remote-manifest/worker-runtime/runtime-proxy";

--- a/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
+++ b/packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts
@@ -1,15 +1,10 @@
 /**
- * Bug regression test for isImageLine() crash scenario
- *
- * Bug: When isImageLine() used startsWith() and terminal doesn't support images,
- * it would return false for lines containing image escape sequences, causing TUI to
- * crash with "Rendered line exceeds terminal width" error.
- *
- * Fix: Changed to use includes() to detect escape sequences anywhere in the line.
- *
- * This test demonstrates:
- * 1. The bug scenario with the old implementation
- * 2. That the fix works correctly
+ * Regression test for isImageLine(): a line carrying an iTerm2/kitty image
+ * escape sequence anywhere in it must be detected as an image line, not only
+ * when the sequence starts the line. A miss lets an oversized base64 image line
+ * reach the terminal-width check and crash the TUI with "Rendered line exceeds
+ * terminal width". Deterministic — imports the real isImageLine from
+ * terminal-image, no terminal I/O.
  */
 
 import assert from "node:assert";
@@ -68,7 +63,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
       const lineWithImageSequence =
         "Read image file [image/jpeg]\x1b]1337;File=size=800,600;inline=1:base64data...\x07";
 
-      // New implementation should return true (FIX!)
+      // isImageLine detects the escape sequence mid-line
       const newResult = isImageLine(lineWithImageSequence);
       assert.strictEqual(
         newResult,
@@ -212,7 +207,7 @@ describe("Bug regression: isImageLine() crash with image escape sequences", () =
       // Verify line is very long
       assert(crashLine.length > 300000, "Test line should be > 300KB");
 
-      // New implementation should detect it (prevents crash)
+      // detected mid-line, so the width check is skipped
       const detected = isImageLine(crashLine);
       assert.strictEqual(
         detected,


### PR DESCRIPTION
## Comment cleanup B02 — slice 1 (remote-plugin runtime + conversation importer)

Part of #12181 batch **B02** (#12232). **Comment-only change; `check:comment-only` PASSES** — the code token stream is byte-for-byte identical to `origin/develop` (machine-checked by `scripts/assert-comment-only-diff.mjs`).

This is one coherent slice of the B02 batch (the issue plans ~21 PRs per batch). It covers the remote-plugin runtime packages and the conversation-import package end-to-end, plus the churn-comment rewrites the batch's churn grep flagged in `packages/agent` and `packages/tui`.

### What changed (42 files)

**Prose file headers added:**
- `packages/plugin-worker-runtime/src/**` — 7 compatibility re-export files (1-line headers)
- `packages/plugin-sub-agent-claude-code/src/**` — 5 compatibility re-export files (1-line headers)
- `packages/plugin-remote-manifest/src/**` — 7 core source files (`index`, `json`, `types`, `permissions`, `manifest`, `validation`, `store`), described in the package's own architecture terms from its `CLAUDE.md`
- `packages/import-conversations/src/**` — source files (adapters, parsers, streaming/zip readers) + co-located test files (1–3 line headers stating surface + deterministic harness) + `vitest.config.ts`

**Churn comments rewritten present-tense / de-narrated (no code touched):**
- `packages/agent/src/api/{server-route-dispatch,avatar-routes,conversation-routes,server}.ts` — the lazy-loader rationale ("previously module-scope `await import`, which forced… Now…") rewritten to present-tense fact: *why* the loader is lazy, no phantom prior version.
- `packages/agent/scripts/build-mobile-bundle.mjs` — dropped a stale "an earlier refactor staged a mirror; that's gone now" diff-story; kept the durable on-disk-layout fact.
- `packages/tui/test/bug-regression-isimageline-startswith-bug.test.ts` — regression-test header rewritten to state the invariant under test; two in-body "New implementation should…" notes rewritten present-tense.

Durable churn-flagged comments were **kept** where they describe runtime behavior rather than a code edit (e.g. `import-conversations/src/core/pipeline.test.ts` "old document was deleted, new one stored" — the v1/v2 documents are runtime state the assertions check, not a version story).

### filesFlagged
None — every header in this slice was written from reading the file and its package `CLAUDE.md`. Files not yet headered in these paths are left for the batch's remaining slice PRs (accuracy over coverage: no header was pattern-stamped).

### Evidence
- `bun run check:comment-only` → `OK — 42 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Real-LLM trajectory / screenshots / video / audio / domain artifacts: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Refs #12232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
