### PR TITLE
chore(#12238): comment cleanup B08 — feed core markets prose headers (comment-only)

### DIFF
--- a/packages/feed/packages/core/markets/index.ts
+++ b/packages/feed/packages/core/markets/index.ts
@@ -1,3 +1,4 @@
+/** Barrel for Feed's market domain — perpetuals, prediction markets, and their shared primitives. */
 export * from "./perps";
 export * from "./prediction";
 export * from "./shared/common";

--- a/packages/feed/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/feed/packages/core/markets/perps/PerpMarketService.ts
@@ -1,3 +1,11 @@
+/**
+ * Core service for the perpetuals market: opening and closing leveraged long/short
+ * positions, applying synthetic-microstructure execution prices, batch price updates,
+ * and liquidations. Depends only on the injected `PerpServiceDeps` ports (DB, wallet,
+ * fees, clock, broadcast) so the domain logic stays free of concrete infrastructure;
+ * quote-state upkeep is delegated to `PerpQuoteStateService`. Enforces the
+ * `MAX_PERP_USER_EXPOSURE` cap and position-integrity invariants from `./utils`.
+ */
 import {
   calculateTradeImpact,
   getInitialReserves,

--- a/packages/feed/packages/core/markets/perps/PerpQuoteStateService.ts
+++ b/packages/feed/packages/core/markets/perps/PerpQuoteStateService.ts
@@ -1,3 +1,9 @@
+/**
+ * Maintains persisted bid/ask/spread/depth quote state for perp markets, evolving it over
+ * time so spreads and depth relax during quiet periods when the canonical price barely
+ * moves. Deliberately narrow: it touches only the DB port and clock, with no wallet, fee,
+ * or trade-execution wiring (those live in `PerpMarketService`).
+ */
 import type { ClockPort } from "../shared/common";
 import {
   evolveSyntheticPerpQuoteState,

--- a/packages/feed/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/feed/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for `PerpMarketService` open/close/liquidation flows, driven by in-memory
+ * fakes for the wallet and DB ports (no real database).
+ */
 import { beforeEach, describe, expect, it } from "bun:test";
 import type { WalletPort } from "../../shared/common";
 import { PerpMarketService } from "../PerpMarketService";

--- a/packages/feed/packages/core/markets/perps/__tests__/microstructure.test.ts
+++ b/packages/feed/packages/core/markets/perps/__tests__/microstructure.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the synthetic perp microstructure math — quote-state derivation,
+ * execution pricing, and mid drift — over pure in-memory market records.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   evolveSyntheticPerpQuoteState,

--- a/packages/feed/packages/core/markets/perps/adapters/drizzle/PerpDbAdapter.ts
+++ b/packages/feed/packages/core/markets/perps/adapters/drizzle/PerpDbAdapter.ts
@@ -1,3 +1,10 @@
+/**
+ * Drizzle-backed implementation of `PerpDbPort` — the concrete persistence adapter that
+ * maps perp market snapshots and positions between DB rows and domain records for
+ * `PerpMarketService`. Uses `PerpMarketSnapshot` as the single source of market-level
+ * stats, mints snowflake IDs when none are supplied, and accepts a transaction client via
+ * constructor injection so callers can compose reads/writes atomically.
+ */
 import {
   type PerpPosition as DbPerpPosition,
   db as defaultDb,

--- a/packages/feed/packages/core/markets/perps/index.ts
+++ b/packages/feed/packages/core/markets/perps/index.ts
@@ -1,3 +1,4 @@
+/** Server-side barrel for the perpetuals domain (services, Drizzle adapter, microstructure, types). For browser-safe utilities use `./client`. */
 export * from "./adapters/drizzle/PerpDbAdapter";
 export * from "./microstructure";
 export * from "./PerpMarketService";

--- a/packages/feed/packages/core/markets/perps/microstructure.ts
+++ b/packages/feed/packages/core/markets/perps/microstructure.ts
@@ -1,3 +1,9 @@
+/**
+ * Synthetic order-book microstructure for perp markets: derives a bid/ask/spread/depth
+ * quote state around the canonical market price and computes size-aware execution prices
+ * and post-trade mid drift. There is no real order book — liquidity regime and price
+ * impact are modelled from the market record so single trades move price realistically.
+ */
 import { clamp } from "@feed/shared";
 import type { PerpMarketRecord } from "./types";
 

--- a/packages/feed/packages/core/markets/perps/types.ts
+++ b/packages/feed/packages/core/markets/perps/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Domain records, ports, and I/O shapes for the perpetuals market: market snapshots,
+ * positions, open/close trade inputs and results, and the `PerpDbPort` persistence and
+ * `PerpServiceDeps` dependency contracts. The DB-facing records mirror stored rows; the
+ * ports keep `PerpMarketService` decoupled from Drizzle and wallet/fee implementations.
+ */
 import type {
   BroadcastPort,
   CachePort,

--- a/packages/feed/packages/core/markets/perps/utils.ts
+++ b/packages/feed/packages/core/markets/perps/utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Pure, browser-safe helpers for perp positions: liquidation checks, effective leverage
+ * coercion, exposure sizing, and open-position integrity validation. No DB or wallet
+ * dependencies, so these are re-exported from `./client` for client components.
+ */
 import type { PerpSide } from "./types";
 
 export const MAX_PERP_USER_EXPOSURE = 1_000_000;

--- a/packages/feed/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/feed/packages/core/markets/prediction/PredictionMarketService.ts
@@ -1,3 +1,10 @@
+/**
+ * Core service for YES/NO prediction markets: buying and selling shares against the CPMM
+ * pricing model, cancelling positions, and resolving markets to an outcome. Depends only
+ * on the injected `PredictionServiceDeps` ports (DB, wallet, fees, cache, clock, broadcast)
+ * so the domain stays infrastructure-free. Enforces trade minimums and caps single-trade
+ * odds movement at `MAX_ODDS_MOVE_PER_TRADE` unless a caller overrides it per trade.
+ */
 import { BadRequestError, NotFoundError } from "@feed/shared";
 import { PredictionPricing } from "./pricing";
 import type {

--- a/packages/feed/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
+++ b/packages/feed/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for `PredictionMarketService` buy/sell/resolve flows against the real CPMM
+ * pricing, using in-memory fakes for the wallet, DB, cache, and broadcast ports.
+ */
 import { beforeEach, describe, expect, it } from "bun:test";
 import type {
   BroadcastPort,

--- a/packages/feed/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/feed/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -1,3 +1,10 @@
+/**
+ * Drizzle-backed implementation of `PredictionDbPort` — persistence adapter mapping
+ * markets, positions, questions, and price-history rows to/from domain records for
+ * `PredictionMarketService`. Encodes YES/NO as a boolean column, mints snowflake IDs, and
+ * distinguishes small human question numbers from large snowflake-like ids so lookups do
+ * not misinterpret one as the other. Accepts a transaction client for atomic composition.
+ */
 import {
   db,
   markets,

--- a/packages/feed/packages/core/markets/prediction/adapters/drizzle/__tests__/PredictionDbAdapter.test.ts
+++ b/packages/feed/packages/core/markets/prediction/adapters/drizzle/__tests__/PredictionDbAdapter.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit test guarding `PredictionDbAdapter.getQuestion` against reinterpreting large
+ * snowflake-like ids as small question numbers, using a mocked Drizzle client.
+ */
 import { describe, expect, mock, test } from "bun:test";
 import { PredictionDbAdapter } from "../PredictionDbAdapter";
 

--- a/packages/feed/packages/core/markets/prediction/index.ts
+++ b/packages/feed/packages/core/markets/prediction/index.ts
@@ -1,3 +1,4 @@
+/** Server-side barrel for the prediction-market domain (service, Drizzle adapter, CPMM pricing, types). For browser-safe utilities use `./client`. */
 export * from "./adapters/drizzle/PredictionDbAdapter";
 export * from "./PredictionMarketService";
 export * from "./positionSnapshot";

--- a/packages/feed/packages/core/markets/prediction/positionSnapshot.ts
+++ b/packages/feed/packages/core/markets/prediction/positionSnapshot.ts
@@ -1,3 +1,10 @@
+/**
+ * Derives the live valuation of a prediction-market position — cost basis, current
+ * probability and unit price, mark-to-market value, and unrealized PnL — from its shares
+ * and the current CPMM pool. For resolved markets the outcome fixes the unit price; for
+ * open markets value is a fee-aware sell preview, with a caller-selectable fallback when
+ * that preview cannot be computed.
+ */
 import { PredictionPricing } from "./pricing";
 
 export interface PredictionPositionSnapshot {

--- a/packages/feed/packages/core/markets/prediction/types.ts
+++ b/packages/feed/packages/core/markets/prediction/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Domain records, ports, and I/O shapes for prediction markets: questions, markets,
+ * positions, price snapshots, the buy/sell/cancel/resolve trade inputs and results, and
+ * the `PredictionDbPort` persistence and `PredictionServiceDeps` dependency contracts that
+ * keep `PredictionMarketService` decoupled from Drizzle and wallet/fee implementations.
+ */
 import type {
   BroadcastPort,
   CachePort,

--- a/packages/feed/packages/core/markets/shared/common.ts
+++ b/packages/feed/packages/core/markets/shared/common.ts
@@ -1,3 +1,9 @@
+/**
+ * Primitives shared by both market domains (prediction and perp): the `MarketKind`
+ * discriminator, fee configuration and processing contracts, and the hexagonal ports
+ * (wallet, cache, clock, broadcast, fee outbox) that the market services depend on so
+ * the core domain stays free of any concrete DB, wallet, or transport implementation.
+ */
 export type MarketKind = "prediction" | "perp";
 
 export interface FeeConfig {

--- a/packages/feed/packages/core/markets/shared/index.ts
+++ b/packages/feed/packages/core/markets/shared/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for market primitives shared across perp and prediction domains (fees, ports, market kind). */
 export * from "./common";


### PR DESCRIPTION
## Comment cleanup — B08 slice: `packages/feed/packages/core` markets domain

Part of #12238 (batch B08 of the repo-wide comment cleanup, parent #12181). **Comment-only; `check:comment-only` PASSES.**

This slice covers the header-less files in feed's `core` markets domain (perpetuals + prediction), a coherent, self-contained subtree (issue workflow rule 1: one directory subtree per PR).

### What changed
- Added a prose file header to every header-less in-scope file in `packages/feed/packages/core/markets/**` — 19 files:
  - Services/adapters: `PerpMarketService`, `PerpQuoteStateService`, `PerpDbAdapter`, `PredictionMarketService`, `PredictionDbAdapter`, `positionSnapshot`, `microstructure`
  - Types/primitives: `perps/types`, `prediction/types`, `shared/common`, `perps/utils`
  - Barrels (1-line): `markets/index`, `perps/index`, `prediction/index`, `shared/index`
  - Tests (1-3 line, surface + harness realness): 4 `__tests__` files
- Headers written from reading each file and `packages/feed/CLAUDE.md`; described in feed's architecture terms (hexagonal ports, CPMM pricing, synthetic microstructure).
- Files already at the bar (e.g. `storage/**`, `pricing.ts`, `client.ts`) left untouched.

### Tallies
- Files touched: **19** (all additions, +91 lines, 0 deletions)
- Headers added: **19**
- Churn comments removed: **0** — the `core` churn grep found only a string literal (`"Position no longer exists..."`), not a comment; nothing to delete/rewrite.
- filesFlagged (purpose undeterminable): **none**

### Verification
- `node scripts/assert-comment-only-diff.mjs origin/develop` -> `OK — 19 source file(s) changed; every code token identical to origin/develop. Comments only.`
- Trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).**

Refs #12238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
