### PR TITLE
chore(#12239): comment cleanup B09 — packages/feed/apps/cli prose headers (comment-only)

### DIFF
--- a/packages/feed/apps/cli/src/__tests__/db.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/db.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the `db` command's Docker-compose startup recovery predicate.
+ * Pure string classification, no real Docker or DB.
+ */
+
 import { describe, expect, test } from "bun:test";
 
 import { isRecoverableComposeStartError } from "../commands/db.js";

--- a/packages/feed/apps/cli/src/__tests__/run-game.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/run-game.test.ts
@@ -1,7 +1,6 @@
 /**
- * CLI game command tests.
- *
- * The public CLI no longer advertises simulation. These tests verify that the
+ * CLI game command tests. Spawn the real CLI entrypoint and assert on its
+ * output: the public CLI does not advertise simulation, so these verify the
  * help text stays honest and the legacy command fails with a clear message.
  */
 

--- a/packages/feed/apps/cli/src/__tests__/train-parallel-deps.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/train-parallel-deps.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests that the `train-parallel` command wires its agent/runtime/coordinator
+ * dependencies correctly. Uses `mock.module` stubs for `@feed/agents` and
+ * `@feed/db`, so no real agents or database are touched.
+ */
+
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 const configureTrainingDependencies = mock(() => {});

--- a/packages/feed/apps/cli/src/__tests__/train-parallel-generation.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/train-parallel-generation.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests the `train-parallel` generation flow end to end against mocked agents
+ * and DB (via `mock.module`), writing real trajectory/manifest files into temp
+ * dirs and asserting the emitted artifacts and arg parsing.
+ */
+
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/packages/feed/apps/cli/src/__tests__/train-pipeline.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/train-pipeline.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests that the `train pipeline` command forwards flags to the underlying
+ * Python training pipeline. Spawns the real CLI entrypoint in dry-run mode and
+ * asserts on the composed command, without running actual training.
+ */
+
 import { describe, expect, test } from "bun:test";
 import { dirname, resolve } from "node:path";
 import { spawnSync } from "bun";

--- a/packages/feed/apps/cli/src/__tests__/training-artifacts.test.ts
+++ b/packages/feed/apps/cli/src/__tests__/training-artifacts.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests for the training-artifact manifest writers, exercising real filesystem
+ * writes into temp dirs and asserting the emitted schema/version/tag fields.
+ */
+
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/packages/feed/apps/cli/src/cli-utils.ts
+++ b/packages/feed/apps/cli/src/cli-utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Argv helpers shared across Feed CLI commands, kept separate from `lib/args.ts`
+ * (the general parser) for the fail-fast flag lookups that exit the process on
+ * misuse rather than returning undefined.
+ */
+
 import { logger } from "./lib/logger.js";
 
 /**

--- a/packages/feed/apps/cli/src/commands/admin.ts
+++ b/packages/feed/apps/cli/src/commands/admin.ts
@@ -1,12 +1,8 @@
 #!/usr/bin/env bun
 
 /**
- * @fileoverview Admin user management commands
- *
- * Provides commands for checking, granting, and revoking admin privileges,
- * as well as listing all admin users in the system.
- *
- * @module cli/commands/admin
+ * `admin` CLI domain: check, grant, and revoke the admin flag on users and list
+ * current admins. Writes directly against the `users` table via `@feed/db`.
  */
 
 import { asc, closeDatabase, db, eq, or, sql, users } from "@feed/db";

--- a/packages/feed/apps/cli/src/commands/agent.ts
+++ b/packages/feed/apps/cli/src/commands/agent.ts
@@ -1,12 +1,9 @@
 #!/usr/bin/env bun
 
 /**
- * @fileoverview Agent management commands
- *
- * Provides commands for creating test agents, listing agents, and managing
- * autonomous features for agents. Also includes Agent0 integration configuration.
- *
- * @module cli/commands/agent
+ * `agent` CLI domain: create test agents, list agents, toggle autonomous
+ * features, and configure Agent0 integration. Operates on `@feed/db` records
+ * and the `@feed/agents` factory (`createTestAgent`).
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";

--- a/packages/feed/apps/cli/src/commands/db.ts
+++ b/packages/feed/apps/cli/src/commands/db.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env bun
 
 /**
- * @fileoverview Database management commands
- *
- * Provides commands for managing the PostgreSQL database container, running migrations,
- * seeding data, and checking database status using Docker and docker-compose.
- *
- * @module cli/commands/db
+ * `db` CLI domain: bring the Postgres container up/down via docker-compose, run
+ * Drizzle migrations, seed game data, and report status. Startup shells out to
+ * `docker`/`docker-compose`; `isRecoverableComposeStartError` classifies stale
+ * Docker-network failures so start can retry rather than hard-fail.
  */
 
 import { existsSync } from "node:fs";

--- a/packages/feed/apps/cli/src/generate-actor-images.ts
+++ b/packages/feed/apps/cli/src/generate-actor-images.ts
@@ -1,59 +1,11 @@
 /**
- * @fileoverview Actor and Organization Image Generation CLI
- *
- * Generates profile pictures and banner images for all actors and organizations
- * using OpenAI's gpt-image-1.5 model for maximum realism.
- *
- * **Generated Images:**
- * - Actor profile pictures (square, portrait style)
- * - Actor banner images (landscape)
- * - Organization logos (square, satirical parodies)
- * - Organization banners (landscape)
- *
- * **Features:**
- * - Concurrent generation (max 3 at a time for rate limiting)
- * - Automatic skip for existing images (use --force to regenerate all)
- * - Satirical logo generation using company name mappings
- * - Template-based prompt rendering
- * - Progress tracking and error reporting
- * - Automatic directory creation
- *
- * **Requirements:**
- * - `OPENAI_API_KEY` environment variable must be set
- * - Actor data files must exist in `packages/engine/src/data/actors/` and `packages/engine/src/data/organizations/` (TypeScript files)
- * - Output directories must be writable:
- *   - `public/images/actors/`
- *   - `public/images/actor-banners/`
- *   - `public/images/organizations/`
- *   - `public/images/org-banners/`
- *
- * **Image Specifications:**
- * - Actor PFP: Square (1024x1024), high quality portrait
- * - Actor Banner: Landscape (1536x1024), thematic background
- * - Org Logo: Square (1024x1024), satirical parody
- * - Org Banner: Landscape (1536x1024), branded background
- *
- * @module cli/generate-actor-images
- * @category CLI - Content Generation
- *
- * @example
- * ```bash
- * # Set API key
- * export OPENAI_API_KEY=your_key_here
- *
- * # Generate all missing images
- * bun run src/generate-actor-images.ts
- *
- * # Force regenerate all images (overwrite existing)
- * bun run src/generate-actor-images.ts --force
- * ```
- *
- * @see {@link openai} for OpenAI SDK
- * @see {@link ../prompts} for image generation prompts
- * @since v0.2.0
- *
- * **Environment Variables:**
- * @env {string} OPENAI_API_KEY - Required: direct OpenAI API key (gpt-image-1.5 is OpenAI-only)
+ * One-shot CLI that generates profile pictures and banners for every actor and
+ * organization via OpenAI's gpt-image-1.5, writing PNGs into `public/images/{actors,
+ * actor-banners,organizations,org-banners}/`. Reads actor/org definitions from
+ * `packages/engine/src/data/`, renders template prompts, and generates at most 3
+ * images concurrently to stay under rate limits. Existing images are skipped
+ * unless `--force` is passed. Requires `OPENAI_API_KEY` (gpt-image-1.5 is
+ * OpenAI-only). PFPs/logos are square 1024x1024; banners are 1536x1024.
  */
 
 import { access, mkdir, rm, writeFile } from "node:fs/promises";

--- a/packages/feed/apps/cli/src/generate-world.ts
+++ b/packages/feed/apps/cli/src/generate-world.ts
@@ -1,65 +1,12 @@
 #!/usr/bin/env bun
 
 /**
- * @fileoverview Game World Narrative Generator CLI
- *
- * Generates complete game narratives with all NPC actions, events, conversations,
- * and social media posts. Creates a detailed timeline of events leading to a
- * predetermined outcome (SUCCESS or FAILURE).
- *
- * **Core Features:**
- * - Full narrative generation with NPC behaviors
- * - Day-by-day timeline simulation (default: 30 days)
- * - Configurable outcome (YES/NO for prediction market)
- * - Event-driven architecture with detailed logging
- * - JSON export for integration with other systems
- * - Verbose mode for detailed event tracking
- *
- * **Generated Content:**
- * - NPC actions and behaviors
- * - Conversations between NPCs
- * - News articles and publications
- * - Rumors and speculation
- * - Clues pointing to outcome
- * - Market developments
- * - Feed posts (news, reactions, threads)
- *
- * **Event Types:**
- * - `world:started` - World generation begins
- * - `day:begins` - New day starts
- * - `npc:action` - NPC performs action
- * - `npc:conversation` - NPCs converse
- * - `news:published` - News article published
- * - `rumor:spread` - Rumor spreads
- * - `clue:revealed` - Clue about outcome revealed
- * - `development:occurred` - Major development happens
- * - `feed:post` - Social media post created
- * - `outcome:revealed` - Final outcome revealed
- *
- * @module cli/generate-world
- * @category CLI - Game Generation
- *
- * @example
- * ```bash
- * # Generate with default settings (SUCCESS outcome)
- * bun run src/cli/generate-world.ts
- *
- * # Generate with specific outcome
- * bun run src/cli/generate-world.ts --outcome=FAILURE
- *
- * # Generate with verbose logging
- * bun run src/cli/generate-world.ts --verbose
- *
- * # Save to file
- * bun run src/cli/generate-world.ts --save=world.json
- *
- * # Get JSON output only (for piping)
- * bun run src/cli/generate-world.ts --json
- * ```
- *
- * @see {@link GameWorld} for world generation implementation
- * @see {@link ../engine/GameWorld.ts} for implementation details
- * @since v0.1.0
+ * CLI wrapper over the engine's `GameWorld` narrative generator: simulates a
+ * day-by-day timeline (default 30 days) of NPC actions, conversations, news,
+ * rumors, clues, and feed posts that lead to a predetermined market outcome
+ * (YES/NO). Emits typed lifecycle events (`world:started`, `day:begins`,
+ * `npc:action`, `outcome:revealed`, …) for verbose logging and can export the
+ * result as JSON. Flags: `--outcome`, `--verbose`, `--save=<file>`, `--json`.
  */
 
 import { writeFile } from "node:fs/promises";

--- a/packages/feed/apps/cli/src/index.ts
+++ b/packages/feed/apps/cli/src/index.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env bun
 
 /**
- * @fileoverview Feed CLI - Unified command-line interface for Feed operations
- *
- * Provides a comprehensive CLI for managing database, admin users, game state,
- * training pipelines, models, agents, and system status.
- *
- * @module cli/index
- * @packageDocumentation
+ * Entrypoint for the Feed CLI (`bun apps/cli/src/index.ts`). Loads root `.env`
+ * before any other import, then dispatches the first argv token to a domain
+ * handler — db, admin, game, training, models, agents, status. Each domain
+ * lives in `commands/`; this file owns only arg routing, help text, and the
+ * Sentry init/flush wrapper around every run.
  */
 
 import { resolve } from "node:path";

--- a/packages/feed/apps/cli/src/lib/args.ts
+++ b/packages/feed/apps/cli/src/lib/args.ts
@@ -1,10 +1,7 @@
 /**
- * @fileoverview Command-line argument parsing utilities
- *
- * Provides functions for parsing CLI arguments into structured formats,
- * extracting flags, options, and positional arguments.
- *
- * @module cli/lib/args
+ * General argv parser for the Feed CLI: splits a raw arg array into a command,
+ * positionals, boolean flags, and `--key value` / `--key=value` options, and
+ * exposes typed accessors over the result. Shared by all `commands/` handlers.
  */
 
 /**

--- a/packages/feed/apps/cli/src/lib/logger.ts
+++ b/packages/feed/apps/cli/src/lib/logger.ts
@@ -1,9 +1,7 @@
 /**
- * @fileoverview CLI logging utilities
- *
- * Provides structured logging functions for CLI output with consistent formatting.
- *
- * @module cli/lib/logger
+ * Structured console logger for CLI output, with level prefixes and emoji
+ * indicators. Debug output is gated on the `DEBUG` env var. Shared by every
+ * `commands/` handler in place of raw `console.log`.
  */
 
 /**

--- a/packages/feed/apps/cli/src/lib/training-artifacts.ts
+++ b/packages/feed/apps/cli/src/lib/training-artifacts.ts
@@ -1,3 +1,11 @@
+/**
+ * Manifest schema and writers for Feed training artifacts — trajectory exports
+ * and parallel-generation runs. Each writer stamps a versioned, tagged sidecar
+ * JSON next to the produced data so downstream training/scoring tools can
+ * discover and validate a run's provenance. Consumed by the `train` and
+ * `train-parallel` CLI commands.
+ */
+
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 

--- a/packages/feed/apps/cli/src/migrate-images-to-blob.ts
+++ b/packages/feed/apps/cli/src/migrate-images-to-blob.ts
@@ -1,29 +1,8 @@
 /**
- * @fileoverview Migrate Actor Images to Vercel Blob Storage
- *
- * Uploads existing images from public/images to Vercel Blob storage.
- * Maintains the same path structure for compatibility with existing code.
- *
- * **What it does:**
- * - Reads all images from public/images/actors, actor-banners, organizations, org-banners
- * - Uploads each to Vercel Blob with the same path structure (e.g., images/actors/sam-worldman.jpg)
- * - Skips images that already exist in blob storage
- * - Uses concurrent uploads for speed
- *
- * **Requirements:**
- * - `BLOB_READ_WRITE_TOKEN` environment variable must be set
- *
- * @module cli/migrate-images-to-blob
- * @category CLI - Migration
- *
- * @example
- * ```bash
- * # Set Vercel Blob token
- * export BLOB_READ_WRITE_TOKEN=your_token_here
- *
- * # Run migration
- * bun run src/cli/migrate-images-to-blob.ts
- * ```
+ * One-shot migration that uploads local `public/images/{actors,actor-banners,
+ * organizations,org-banners}/` files to Vercel Blob, preserving the same path
+ * so existing image references keep resolving. Uploads concurrently and skips
+ * blobs that already exist. Requires `BLOB_READ_WRITE_TOKEN`.
  */
 
 import { readdir, readFile } from "node:fs/promises";

--- a/packages/feed/apps/cli/src/sentry.ts
+++ b/packages/feed/apps/cli/src/sentry.ts
@@ -1,3 +1,10 @@
+/**
+ * Sentry wiring for the Feed CLI: initializes the `@sentry/bun` client per
+ * command run and flushes captured exceptions before the process exits.
+ * No-ops when `DISABLE_SENTRY=true` or no `SENTRY_DSN` is configured, so local
+ * and CI runs stay silent. Release is derived from Sentry/Vercel commit-sha env vars.
+ */
+
 import * as Sentry from "@sentry/bun";
 
 type CliSentryContext = {


### PR DESCRIPTION
Part of #12181 (comment cleanup swarm). Batch **B09** — slice: `packages/feed/apps/cli`.

**Comment-only; `bun run check:comment-only` PASSES** (`scripts/assert-comment-only-diff.mjs`: 18 source files changed, every code token identical to `origin/develop` — zero functional diff).

## What changed

18 files under `packages/feed/apps/cli/src`:

- **Added prose headers** to files with none: `cli-utils.ts`, `sentry.ts`, `lib/training-artifacts.ts`, and 5 test files (`__tests__/db`, `training-artifacts`, `train-parallel-deps`, `train-parallel-generation`, `train-pipeline`).
- **Converted `@fileoverview`/`@module` template headers to plain prose** per the #12181 convention (position is the signal, no tags): `index.ts`, `lib/logger.ts`, `lib/args.ts`, `commands/{admin,agent,db}.ts`, `generate-actor-images.ts`, `generate-world.ts`, `migrate-images-to-blob.ts`. The three generate/migrate scripts also lost oversized `@example`/`@see`/`@since`/`@env` blocks (well over the ~25-line ceiling), rewritten to tight prose.
- **Churn rewrite:** `__tests__/run-game.test.ts` header — "no longer advertises simulation" → present-tense "does not advertise simulation".

## Tallies

- Files touched: **18** (10 source, 6 test, 2 lib) — headers added/repaired: **17**; churn line rewritten: **1**.
- filesFlagged (purpose undeterminable): **none**.
- Left as-is (already prose, at the bar): `commands/{game,model,status,test,train,train-parallel}.ts`.

## Evidence

- Trajectory / screenshot / video / audio / domain-artifact: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`)**.
- `check:comment-only`: `OK — 18 source file(s) changed; every code token identical to origin/develop. Comments only.`

Refs #12239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
