### PR TITLE
docs(#12241): add root build config headers

### DIFF
--- a/plugins/plugin-build-externals.ts
+++ b/plugins/plugin-build-externals.ts
@@ -1,3 +1,11 @@
+/**
+ * Plugin build helper for deriving Bun.build externals from package metadata.
+ *
+ * Runtime, peer, optional, and caller-supplied dependencies are externalized so
+ * plugin bundles do not inline transitive packages that expect Node internals at
+ * top-level import time.
+ */
+
 import { readFile } from "node:fs/promises";
 
 export interface ExternalsFromPackageJsonOptions {

--- a/plugins/tsup.plugin-packages.shared.ts
+++ b/plugins/tsup.plugin-packages.shared.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared tsup configuration for workspace plugin packages that emit unbundled ESM.
+ *
+ * The build discovers source entries, rewrites relative TypeScript import
+ * specifiers to runtime `.js` paths, and cleans the package `dist/` directory
+ * once before esbuild writes per-file output.
+ */
+
 import { existsSync, promises as fsp, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Root Vitest configuration for workspace tests that run directly against source.
+ *
+ * The aliases point package imports at their TypeScript entry points so targeted
+ * package tests can execute without first building every workspace.
+ */
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";


### PR DESCRIPTION
Part of #12241.

## What
- Adds purpose-explaining prose headers to B11 root/plugin build helper files:
  - `vitest.config.ts`
  - `plugins/tsup.plugin-packages.shared.ts`
  - `plugins/plugin-build-externals.ts`
- Comments only; no code or string/template changes.

## Verification
- PASS: `bun run check:comment-only`
- PASS: targeted header self-audit printed nothing for the three touched files
- PASS with warnings: `bunx biome check vitest.config.ts plugins/tsup.plugin-packages.shared.ts plugins/plugin-build-externals.ts` exited 0. Existing `noUndeclaredEnvVars` warnings remain for `npm_package_json` in `plugins/tsup.plugin-packages.shared.ts`; this PR is comments-only, so I did not make code changes.
- PASS: `git diff --check`

## Evidence notes
- Real-LLM trajectories: N/A, comments-only.
- Screenshots/video/audio/domain artifacts: N/A, comments-only.
- Functional diff guard: `scripts/assert-comment-only-diff.mjs` proves code tokens are identical to `origin/develop`.
