### PR TITLE
chore(#12241): comment cleanup B11 — scripts/** prose headers, churn removal (comment-only)

### DIFF
--- a/scripts/ai-qa/route-catalog.ts
+++ b/scripts/ai-qa/route-catalog.ts
@@ -1,3 +1,11 @@
+/**
+ * Route catalog and shared types for the AI-QA screenshot tooling.
+ *
+ * Enumerates every dashboard route the QA scripts visit, the per-route
+ * ready-checks that gate a capture, the viewport sizes and themes to render,
+ * and the settings-section map. Built on top of the app-core dev route catalog
+ * and consumed by the review-screenshots / review-walkthrough scripts.
+ */
 import { buildRouteCatalog } from "../../packages/app-core/src/api/dev-route-catalog";
 
 export type ReadyCheck =

--- a/scripts/check-even-research-audit.mjs
+++ b/scripts/check-even-research-audit.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * CI gate that the Even Realities smartglasses upstream research is complete:
+ * every requested reference repo is checked out under research/even-realities,
+ * the upstream-audit and smartglasses docs exist, and the implemented facewear
+ * surface files are present. Exits non-zero on any gap. `--self-test` exercises
+ * the gate logic against synthetic inputs.
+ */
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 

--- a/scripts/check-smartglasses-completion-gate.mjs
+++ b/scripts/check-smartglasses-completion-gate.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Smartglasses completion gate: combines the software-readiness check with the
+ * freshness of the latest hardware-smoke report and prints a JSON summary,
+ * exiting non-zero unless both pass. The hardware report path and its max age
+ * come from CLI args or SMARTGLASSES_REPORT_PATH / SMARTGLASSES_COMPLETION_MAX_AGE_MS.
+ * `--self-test` exercises the gate logic against synthetic inputs.
+ */
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/scripts/cloud/mock-stack-up.mjs
+++ b/scripts/cloud/mock-stack-up.mjs
@@ -417,9 +417,9 @@ async function main() {
       }
     }
 
-    // packages/cloud-frontend was consolidated into packages/app (#9093); the
-    // standalone frontend no longer exists. Skip its boot gracefully when the
-    // dir is absent so the mock stack still comes up (api + control-plane).
+    // The apex frontend lives in packages/app; there is no standalone
+    // packages/cloud-frontend (#9093). Skip its boot gracefully when the dir is
+    // absent so the mock stack still comes up (api + control-plane).
     const frontendDir = path.join(REPO_ROOT, "packages/cloud-frontend");
     if (!flags.noFrontend && !existsSync(frontendDir)) {
       process.stderr.write(

--- a/scripts/e2e-recordings/capture-android-emu.mjs
+++ b/scripts/e2e-recordings/capture-android-emu.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Captures Android emulator e2e evidence: boots (or reuses) an AVD, installs the
+ * app APK, drives it against a host agent, and collects a screenshot plus logcat
+ * into the issue-evidence dir. Exits with SKIP_EXIT_CODE (77) when no emulator
+ * is available. Shares arg parsing and manifest writing with the other native
+ * capture scripts via native-capture-common.mjs.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import {

--- a/scripts/e2e-recordings/capture-ios-sim.mjs
+++ b/scripts/e2e-recordings/capture-ios-sim.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Captures iOS Simulator e2e evidence: boots a simulator, builds and installs
+ * the app (unless --skip-build), drives it against a host agent, and collects a
+ * screenshot plus video into the issue-evidence dir. Exits with SKIP_EXIT_CODE
+ * (77) when no simulator is available. Shares arg parsing and manifest writing
+ * with the other native capture scripts via native-capture-common.mjs.
+ */
 import fs from "node:fs";
 import path from "node:path";
 import {

--- a/scripts/e2e-recordings/native-capture-common.mjs
+++ b/scripts/e2e-recordings/native-capture-common.mjs
@@ -1,3 +1,10 @@
+/**
+ * Shared helpers for the native capture scripts (capture-android-emu,
+ * capture-ios-sim): CLI/env arg parsing, evidence-path resolution, capture
+ * logging, starting the device-facing host agent, artifact copying, and writing
+ * the capture manifest. SKIP_EXIT_CODE (77) is the agreed "device unavailable,
+ * skip cleanly" exit code across those scripts.
+ */
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";

--- a/scripts/e2e-recordings/suites.mjs
+++ b/scripts/e2e-recordings/suites.mjs
@@ -1,3 +1,9 @@
+/**
+ * Declarative catalog of the UI end-to-end recording suites (name, working
+ * directory, run script, coverage blurb, and any record-mode env). The
+ * run-all.mjs orchestrator iterates this list to execute each suite and collect
+ * its screenshots, traces, and videos into RECORDINGS_DIR.
+ */
 import path from "node:path";
 
 export const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");

--- a/scripts/lifeops-bench/export-action-manifest.ts
+++ b/scripts/lifeops-bench/export-action-manifest.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+/**
+ * Exports the LifeOps planner action manifest as JSON for the LifeOps bench.
+ *
+ * Loads the personal-assistant plus its connector plugins (bluebubbles,
+ * contacts, imessage, phone, todos), builds the planner tool definitions from
+ * their actions, and emits each as a function-tool entry annotated with the
+ * source plugin and planner metadata (tags, contexts, priority, surfaces,
+ * risk/cost). The bench consumes the manifest to drive and score action selection.
+ */
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";

--- a/scripts/lifeops/collect-11632-live-validation-status.mjs
+++ b/scripts/lifeops/collect-11632-live-validation-status.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Collects the live-validation readiness status for the LifeOps HITL work
+ * (issue #11632) by probing each connector group's required env vars (model
+ * provider, Google, and others) and writing a status.json under the issue's
+ * evidence dir. Reports which connector groups are configured so the live
+ * validation run knows what it can actually exercise.
+ */
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";

--- a/scripts/personality-bench-bridge.mjs
+++ b/scripts/personality-bench-bridge.mjs
@@ -1,3 +1,10 @@
+/**
+ * Translation tables and turn-index helpers bridging personality-bench scenario
+ * keys to the runtime's style / trait / scope-mode configuration. Maps each
+ * scenario's style key, trait key, and scope-variant name onto the concrete
+ * style names, trait options, and enforcement modes the bench applies and then
+ * scores against assistant turns.
+ */
 export const STYLE_KEY_TO_STYLE = Object.freeze({
   no_hedging: "no-hedging",
   haiku: "haiku",

--- a/scripts/verify-smartglasses-software.mjs
+++ b/scripts/verify-smartglasses-software.mjs
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
+/**
+ * Runs the facewear plugin's software-readiness steps in sequence — lint,
+ * typecheck, tests, app-registration verification, and the smartglasses example
+ * software checks — failing on the first failing step. This is the software half
+ * of the smartglasses completion gate (the hardware half needs a real device).
+ */
 import { spawnSync } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";

--- a/scripts/view-audit/serve-spa.mjs
+++ b/scripts/view-audit/serve-spa.mjs
@@ -1,3 +1,9 @@
+/**
+ * Serves the built app SPA (packages/app/dist) with a minimal mock agent API so
+ * the renderer boots to the shell without a live backend. The view-audit
+ * crawlers hit this server to screenshot every view; mocked endpoints return
+ * empty/skeleton data, which is sufficient for layout and spacing review.
+ */
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
Part of #12241 (comment cleanup batch B11 — peripheral packages + scripts + CI + root files).

## Scope
Slice: root `scripts/**`. This PR handles the 12 header-less source files in that subtree plus one churn-phrased comment.

**Comment-only; `check:comment-only` PASSES** — `scripts/assert-comment-only-diff.mjs` confirms the code token stream is byte-for-byte identical to `origin/develop`:

```
[assert-comment-only-diff] OK — 13 source file(s) changed; every code token identical to origin/develop. Comments only.
```

## Tallies
- Files touched: 13
- Prose headers added: 12 (all previously header-less `scripts/**` source files)
- Churn comments rewritten present-tense: 1 (`scripts/cloud/mock-stack-up.mjs` — "was consolidated … no longer exists" rewritten to a durable present-tense statement of where the apex frontend lives, keeping the `#9093` anchor)
- filesFlagged (purpose undeterminable): none

Header-less self-audit over `scripts/**` now prints nothing.

## Evidence
- Trajectory / screenshot / video / audio / domain-artifact rows: N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`).

Refs #12241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
