### PR TITLE
chore(#12237): comment cleanup B07 — plugin-cloud-apps headers + churn removal (comment-only)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/ad-attribution.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/ad-attribution.test.ts
@@ -1,3 +1,6 @@
+/**
+ * GET_AD_CAMPAIGN_ATTRIBUTION action tests: campaign attribution reporting. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/ad-campaigns.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/ad-campaigns.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Ad-campaign management action tests (SET_AD_CAMPAIGN_DAYPARTING, performance reports). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type {
   DuplicateAdCampaignInput,

--- a/plugins/plugin-cloud-apps/__tests__/ad-inventory.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/ad-inventory.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Ad-inventory action tests (CREATE_AD_SLOT and related slot management). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { CreateAdSlotInput } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Tests for record/removeAppDeployFact — the durable "app is live at <url>" memory facts. Runs against the runtime's in-memory memory store; no SDK involved.
+ */
 import { describe, expect, it } from "bun:test";
 import { recordAppDeployFact, removeAppDeployFact } from "../src/app-facts.ts";
 import { makeApp, makeRoomMessage, memoryRuntime } from "./helpers";

--- a/plugins/plugin-cloud-apps/__tests__/backup-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/backup-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * BACKUP_APP action tests: on-demand app backup snapshots. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/book-influencer.test.ts
@@ -1,3 +1,6 @@
+/**
+ * BOOK_INFLUENCER action tests, including the two-phase money confirm before a paid booking. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type {
   CreateBookingInput,

--- a/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
@@ -1,3 +1,6 @@
+/**
+ * CLOUD_APPS provider tests: app inventory injected into planner context, plus the 60s cache and invalidation. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   FakeElizaCloudClient,

--- a/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * CREATE_APP tests covering the pure parseCreateAppIntent parser and the action end to end. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { CreateAppInput } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * DELETE_APP action tests: the destructive two-phase confirm, the frozen-target guard, and honest partial-failure reporting. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/deploy-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * DEPLOY_APP action tests: the completion gate (poll to READY, then reachability-probe the production_url before claiming live). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real. The reachability probe is injected.
+ */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/deploy-frontend.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-frontend.test.ts
@@ -1,3 +1,6 @@
+/**
+ * DEPLOY_FRONTEND action tests: frontend hosting deploy. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Tests for the pure deploy-gate logic — classifyDeployStatus and runDeployGate with injected status/probe functions. No SDK or runtime.
+ */
 import { describe, expect, it } from "bun:test";
 import type { AppDeployStatusResponse, AppResponse } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/get-app-deploy-status.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app-deploy-status.test.ts
@@ -1,3 +1,6 @@
+/**
+ * GET_APP_DEPLOY_STATUS tests covering the pure formatDeployStatus mapping and the action. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { AppDeployStatusResponse } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/get-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app-earnings.test.ts
@@ -1,3 +1,6 @@
+/**
+ * GET_APP_EARNINGS action tests: read-only earnings breakdown (withdrawable/pending/lifetime/withdrawn). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * GET_APP action tests: single-app detail resolved by name or id. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/influencer.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/influencer.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Influencer-profile action tests (CREATE_INFLUENCER_PROFILE and related). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { CreateInfluencerProfileInput } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
@@ -1,3 +1,6 @@
+/**
+ * LIST_CLOUD_APPS action tests: the user's app inventory (name / url / status). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/press-releases.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/press-releases.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Press-release action tests (DRAFT_PRESS_RELEASE and related growth actions). The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type {
   CreatePressReleaseInput,

--- a/plugins/plugin-cloud-apps/__tests__/reachability.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reachability.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Tests for the pure reachability probe (probeReachable, respondedLive, healthUrl) with an injected fetch. Asserts the probe uses redirect:"manual" to mirror the server's live decision. No SDK or runtime.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   type FetchLike,
@@ -44,10 +47,10 @@ describe("probeReachable", () => {
   });
 
   it("REGRESSION: does NOT follow redirects — mirrors the server's probe (redirect: manual)", async () => {
-    // A redirecting /health used to be chased with redirect:"follow"; if the
-    // redirect target failed, the client probe contradicted the server's READY
-    // with a false "not live". The server's probeUrlReachable uses
-    // redirect:"manual" and treats the 3xx itself as "the app answered".
+    // The probe must not follow redirects: it uses redirect:"manual" and treats
+    // a 3xx as "the app answered", mirroring the server's probeUrlReachable.
+    // Following redirects would let a failed redirect target contradict the
+    // server's READY with a false "not live".
     let seenInit: Parameters<FetchLike>[1];
     const result = await probeReachable("https://app.example/health", {
       fetchImpl: (_url, init) => {

--- a/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/reference-resolution.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Tests for the ambiguity-safe app resolver (matchAppByReference / findAppByReference / resolveApp): id then exact name/slug then whole-word then fragment; ties are ambiguous. Pure, no SDK.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   extractAppReference,

--- a/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
@@ -1,3 +1,6 @@
+/**
+ * REGENERATE_APP_API_KEY action tests: key rotation and the one-time reveal of the new key. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import {
   captureCallback,

--- a/plugins/plugin-cloud-apps/__tests__/rollback-frontend.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/rollback-frontend.test.ts
@@ -1,3 +1,6 @@
+/**
+ * ROLLBACK_FRONTEND tests covering the pure selectRollbackTarget selector and the action. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { AppFrontendDeploymentDto } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/safety.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/safety.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Tests for the two-phase confirm state machine (readStructuredConfirmation and the conflicting-target/amount/domain guards). Pure — planner-boolean parsing, never prose. No SDK.
+ */
 import { describe, expect, it } from "bun:test";
 import {
   buildConnectorCta,

--- a/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
@@ -1,3 +1,6 @@
+/**
+ * UPDATE_APP tests covering the pure parseUpdateAppIntent parser and the action. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { UpdateAppInput } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
@@ -1,3 +1,6 @@
+/**
+ * UPDATE_MONETIZATION tests covering the pure parseMonetizationIntent parser and the range-guarded action. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { UpdateAppMonetizationInput } from "@elizaos/cloud-sdk";
 import {

--- a/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
@@ -1,3 +1,6 @@
+/**
+ * WITHDRAW_APP_EARNINGS action tests: the money-out two-phase confirm and the frozen-snapshot guard. The @elizaos/cloud-sdk client is faked (helpers.ts, SDK boundary only); the action runs for real.
+ */
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { WithdrawAppEarningsRequest } from "@elizaos/cloud-sdk";
 import type { ConnectorCta } from "../src/safety.ts";

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -63,8 +63,8 @@ const GATEWAY_DOWN_STATUSES = new Set([502, 503, 504]);
  * the container is up and serving; a network error / abort (no status at all) is
  * NOT reachable. Using this instead of a strict-2xx check keeps the DEPLOY_APP
  * completion gate from contradicting the server's own live decision (an
- * auth-gated app, or one with no `/health` route, is live per the server but was
- * previously reported "not live").
+ * auth-gated app, or one with no `/health` route, is live per the server but a
+ * strict-2xx check would report "not live").
  */
 export function respondedLive(result: ReachabilityResult): boolean {
   return (

--- a/plugins/plugin-cloud-apps/test/scenarios/cloud-apps-structured-confirm.scenario.ts
+++ b/plugins/plugin-cloud-apps/test/scenarios/cloud-apps-structured-confirm.scenario.ts
@@ -1,3 +1,10 @@
+/**
+ * Proves the two-phase confirm end to end on the pr-deterministic scenario lane:
+ * the real gated actions run through the real @elizaos/cloud-sdk client against a
+ * loopback cloud API (node:http mock), so the confirm state machine, frozen-target
+ * snapshot, and idempotent server outcomes are exercised over a real transport
+ * rather than the SDK boundary being faked (as in __tests__).
+ */
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import type {


### PR DESCRIPTION
## Comment cleanup B07 (slice: `plugins/plugin-cloud-apps`)

Part of #12181, batch #12237. **Comment-only change — `check:comment-only` PASSES** (the code token stream is byte-for-byte identical to `origin/develop`, machine-checked by `scripts/assert-comment-only-diff.mjs`).

### What changed
- **Prose headers on 26 test files + 1 scenario** under `plugins/plugin-cloud-apps`. Each 1–3 line header states the action/surface under test and how real the harness is — per the package `CLAUDE.md`, `__tests__/helpers.ts` fakes **only** the `@elizaos/cloud-sdk` client (SDK boundary); the actions, formatters, and two-phase confirm machine run for real. Pure-helper suites (deploy-gate, domain-intent, reachability, reference-resolution, safety) are labelled as pure/no-SDK. The scenario header notes it drives the real SDK over a loopback cloud API.
- **2 churn-phrased comments rewritten to present tense** (durable invariant kept, phantom "used to / previously" removed):
  - `__tests__/reachability.test.ts` — regression comment now states the invariant ("the probe must not follow redirects: `redirect:"manual"`, mirroring the server").
  - `src/reachability.ts` — JSDoc now says "a strict-2xx check would report 'not live'" instead of "was previously reported".

### Not touched (already at the bar)
4 test files already carry good headers and were left alone: `buy-app-domain`, `check-app-domain`, `domain-intent`, `list-app-domains`. Src modules already had headers, so only the reachability JSDoc rewrite applies there. "no longer talking about" comments in `delete-app.ts` / `withdraw-app-earnings.ts` / `safety.ts` are durable intent (frozen-target guard), not history — kept.

### Tallies
- Files touched: **28** (26 test + 1 src + 1 scenario)
- Headers added: **27** (26 test files + 1 scenario)
- Churn comments rewritten: **2**
- filesFlagged (purpose undeterminable): **0**

### Evidence
```
[assert-comment-only-diff] OK — 28 source file(s) changed; every code token identical to origin/develop. Comments only.
```
Trajectory / screenshot / video / audio / domain-artifact rows: **N/A — comments-only change, zero functional diff (machine-checked by `scripts/assert-comment-only-diff.mjs`)**.

Refs #12237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
