### PR TITLE
fix(android): atomic crash-safe agent asset extraction — no more extract-failed brick loop (#12453)

### DIFF
--- a/.github/issue-evidence/12453-android-atomic-extraction/RUN-STATUS.md
+++ b/.github/issue-evidence/12453-android-atomic-extraction/RUN-STATUS.md
@@ -1,0 +1,90 @@
+# #12453 — Atomic crash-safe Android agent asset extraction — RUN STATUS
+
+Fix for the non-atomic asset-extraction wipe that dropped the on-device agent
+into a permanent `extract-failed` crashloop. Part of #12185.
+
+## What changed (source of truth)
+
+- `packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java`
+  - `extractAssetsIfNeeded()` rewritten around an **atomic stage-into-temp +
+    rename swap** (`files/agent.staging/` → `files/agent/`, via `files/agent.trash/`).
+    The working extraction is **never wiped before the replacement is fully
+    staged and stamped**.
+  - `.apk-stamp` is written **inside the staged tree** so it lands with the swap
+    and never runs ahead of a completed extraction.
+  - **Missing-assets guard**: a UI-only / WebView-debug APK lacking
+    `assets/agent/*` keeps the existing extraction and logs loudly instead of
+    wiping (no variant-swap brick).
+  - **Last-good fallback**: on staging failure, fall back to the existing
+    bootable extraction and leave the stamp unchanged (retry next boot) rather
+    than loop on a wipe.
+  - **Interrupted-swap recovery**: a swap that died between its two renames is
+    restored from `files/agent.trash/` on the next boot.
+  - `onCreate()` now calls `startForeground()` **before** any diagnostic IO /
+    `getHistoricalProcessExitReasons`, so the FGS-start timeout can't kill the
+    process mid-copy. The heavy copy stays off the main thread on `startWorker`.
+- `.../ai/elizaos/app/ElizaAssetExtractionPolicy.java` — new pure decision class
+  (`apkChanged`, `decide` → `USE_EXISTING | STAGE_AND_SWAP | KEEP_MISSING_ASSETS
+  | FAIL_NO_ASSETS`). Follows the repo's `*Policy` pattern (like
+  `ElizaAgentWatchdogPolicy` / `InferenceMemoryPolicy`): Android-free so the
+  crash-safety invariants are JVM-unit-testable without a device.
+- `.../app/src/test/java/ai/elizaos/app/ElizaAssetExtractionPolicyTest.java` —
+  12 JVM unit tests over the full input space.
+
+## Verification performed
+
+| Check | Result | Artifact |
+|---|---|---|
+| Pure policy compiles (OpenJDK 21) | PASS (exit 0) | `unit-test-output.txt` |
+| Policy unit tests (JUnit 4.13.2) | **PASS — 12/12** | `unit-test-output.txt` |
+| Full `ElizaAgentService.java` javac vs real android-36 SDK + androidx.core 1.17.0 | **PASS — exit 0, 0 errors** | `javac-fullclass.txt` |
+| `./gradlew :app:assembleDebug` | **BLOCKED (env, not code)** | `gradle-config-blocker.txt` |
+| On-device (emulator) run | **DEFERRED (env)** | see below |
+
+The unit tests directly assert the three brick-avoidance invariants:
+- **when-to-wipe** — `STAGE_AND_SWAP` (the only wiping/stamping action) occurs
+  iff the APK ships assets AND (it changed OR no valid extraction exists);
+- **missing-assets guard** — a no-`assets/agent/*` build over a valid extraction
+  always resolves to `KEEP_MISSING_ASSETS`, never a wipe;
+- **never-destroy-last-good** — with a bootable extraction present, no input ever
+  resolves to `FAIL_NO_ASSETS`.
+
+## Why gradle assemble + on-device are deferred (precise reason)
+
+`./gradlew :app:compileDebugJavaWithJavac` fails at **settings evaluation**,
+before any `:app` Java compiles, because this git worktree has **no installed
+`node_modules`** and the parent eliza checkout's `node_modules` is empty
+(`total 0`). The generated `capacitor.settings.gradle` includes ~30
+`@capacitor+*@8.x` subprojects under `node_modules/.bun/…/android` that do not
+exist on disk (exact error in `gradle-config-blocker.txt`).
+
+Unblocking requires `bun install` + `npx cap sync android` at the eliza root,
+then the NDK/CMake native build — a large, slow chain. The host is under an
+active concurrent test swarm (load avg ~53, down from ~223) and the #12453
+reporter hit the emulator dead/OOM from that same swarm. Per the task's
+conservative-under-load directive, the change is compile-verified at the Java
+level against the real Android SDK (the authoritative check for this diff)
+instead of forcing a full assemble that would contend with the swarm and change
+nothing about the code's correctness. No emulator/device is attached
+(`adb devices` empty; `emulator` binary absent from PATH).
+
+## What a green on-device run needs (recipe for the #12185 lane)
+
+1. `bun install` at the eliza root; `npx cap sync android` in
+   `packages/app-core/platforms/android` to regenerate `capacitor.settings.gradle`
+   for the installed capacitor 8.x versions.
+2. Stage the gitignored `app/libs/android-js-engine-release.aar` (present in the
+   parent checkout at `packages/app-core/platforms/android/app/libs/`).
+3. `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:assembleDebug` → BUILD SUCCESSFUL.
+4. Boot a fresh arm64/x86_64 AVD with headroom; `adb install -r` the APK.
+5. **Repro + prove the fix** (the three #12453 failure modes):
+   - **Interrupted extraction**: force-stop the app ~mid-copy during first cold
+     boot, relaunch → assert it boots the last-good extraction (no permanent
+     `extract-failed` loop). Capture logcat + `files/agent/agent.log`.
+   - **Variant swap**: `adb install -r` a UI-only (no `assets/agent/*`) APK over
+     a full-agent install → assert the full-agent extraction survives and the
+     agent still boots; look for the loud `[ElizaAgentService] … KEEPING the
+     existing agent extraction` log line.
+   - **FGS ordering**: confirm no `Timeout executing service` /
+     `bg anr: … failed to complete startup` during a loaded cold boot.
+   Land logcat + `agent.log` + an `installed-apk-asset-audit.txt` here.

--- a/.github/issue-evidence/12453-android-atomic-extraction/gradle-config-blocker.txt
+++ b/.github/issue-evidence/12453-android-atomic-extraction/gradle-config-blocker.txt
@@ -1,0 +1,19 @@
+# Gradle configuration blocker (worktree provisioning gap, NOT a code issue)
+
+$ ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew :app:compileDebugJavaWithJavac --offline --no-daemon
+
+FAILURE: Build failed with an exception.
+* What went wrong:
+Configuring project ':capacitor-push-notifications' without an existing directory is not allowed.
+The configured projectDirectory '.../agent-aa23d2c0aa332e01d/node_modules/.bun/@capacitor+push-notifications@8.0.3+.../@capacitor/push-notifications/android' does not exist.
+BUILD FAILED in 17s
+
+Root cause: this git worktree has no installed node_modules, and the parent
+eliza checkout's node_modules is empty (total 0). The generated
+capacitor.settings.gradle includes ~30 capacitor subprojects at
+node_modules/.bun/@capacitor+*@8.x paths that are absent. Gradle fails at
+settings evaluation, BEFORE any :app Java compilation. This is a workspace
+provisioning gap (needs 'bun install' + 'npx cap sync android' at the eliza
+root), not a defect in the #12453 change. The change is compile-verified
+instead via full-class javac against the real android-36 SDK (see
+javac-fullclass.txt).

--- a/.github/issue-evidence/12453-android-atomic-extraction/javac-fullclass.txt
+++ b/.github/issue-evidence/12453-android-atomic-extraction/javac-fullclass.txt
@@ -1,0 +1,15 @@
+# Full-class javac of the modified ElizaAgentService.java against the real
+# Android SDK (android-36) + androidx.core 1.17.0, with its self-contained
+# ai.elizaos.app siblings and stubbed generated BuildConfig/R/MainActivity.
+# This is the authoritative Java-level compile check of the #12453 change.
+
+javac real exit=0
+error count: 0
+
+classes produced:
+ElizaAgentService.class
+ElizaAgentService$1.class
+ElizaAgentService$2.class
+ElizaAgentService$WatchdogThread.class
+ElizaAssetExtractionPolicy.class
+ElizaAssetExtractionPolicy$Action.class

--- a/.github/issue-evidence/12453-android-atomic-extraction/unit-test-output.txt
+++ b/.github/issue-evidence/12453-android-atomic-extraction/unit-test-output.txt
@@ -1,0 +1,11 @@
+# ElizaAssetExtractionPolicyTest — JVM unit run (JUnit 4.13.2, OpenJDK 21)
+# Pure crash-safety decision logic for #12453. No device required.
+$ javac -cp junit:hamcrest ElizaAssetExtractionPolicy.java ElizaAssetExtractionPolicyTest.java  ->  exit 0
+$ java org.junit.runner.JUnitCore ai.elizaos.app.ElizaAssetExtractionPolicyTest
+
+JUnit version 4.13.2
+............
+Time: 0.029
+
+OK (12 tests)
+

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -10,6 +10,7 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
 import android.content.res.AssetManager;
 import android.net.LocalSocket;
@@ -88,6 +89,14 @@ public class ElizaAgentService extends Service {
     // trick, no custom domain, no symlinks: the binary just sits in the
     // app's writable data dir at canonical names.
     private static final String AGENT_DIR_NAME = "agent";
+    // Sibling dirs of AGENT_DIR_NAME under getFilesDir(), on the same filesystem
+    // so File.renameTo() between them is an atomic rename(2). Asset refreshes
+    // extract into the staging dir and swap it into place; the trash dir holds
+    // the previous extraction across the two-rename swap so a crash between them
+    // still leaves a recoverable last-good copy (#12453).
+    private static final String AGENT_STAGING_DIR_NAME = "agent.staging";
+    private static final String AGENT_TRASH_DIR_NAME = "agent.trash";
+    private static final String AGENT_STAMP_NAME = ".apk-stamp";
     private static final String AGENT_STATE_DIR_NAME = ".eliza";
     private static final String AGENT_BUNDLE_NAME = "agent-bundle.js";
     private static final String AGENT_LAUNCH_SCRIPT = "launch.sh";
@@ -624,12 +633,19 @@ public class ElizaAgentService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        appendDiagnosticEvent("service-onCreate", null);
-        logRecentApplicationExitReasons("service-onCreate");
         ensureNotificationChannel();
 
         Notification notification = buildNotification("Eliza agent", "Starting…");
 
+        // Enter the foreground BEFORE any diagnostic IO. Android's FGS-start
+        // timeout begins ticking at onCreate; spending it on the synchronous
+        // getHistoricalProcessExitReasons() + diagnostic file writes below (or,
+        // on a slow/loaded device, the later ~170 MB asset copy) trips
+        // "Timeout executing service" and AMS kills the process mid-work — which
+        // feeds the interrupted-extraction crashloop in #12453. startForeground()
+        // first stops that clock. The heavy asset copy stays off the main thread
+        // on the startWorker (requestAgentStart), so onCreate only needs to keep
+        // the FGS-start critical path free of blocking IO.
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 startForeground(
@@ -658,7 +674,13 @@ public class ElizaAgentService extends Service {
             foregroundStartDenied = true;
             shuttingDown = true;
             stopSelf();
+            return;
         }
+
+        // FGS is up; these diagnostic reads can no longer trip the FGS-start
+        // timeout.
+        appendDiagnosticEvent("service-onCreate", null);
+        logRecentApplicationExitReasons("service-onCreate");
     }
 
     @Override
@@ -896,39 +918,114 @@ public class ElizaAgentService extends Service {
     }
 
     /**
-     * Copy assets/agent/** into the app's data dir on first launch.
-     * Idempotent: skips files that already exist on disk and are
-     * non-empty. Sets +x on bun, the musl loader, and launch.sh.
+     * Materialise assets/agent/** into the app's data dir, crash-safely.
+     *
+     * <p>The extracted agent (~170 MB: agent-bundle.js + bun + ABI libs) lives
+     * in {@code files/agent/}. When the installed APK changes, the new payload
+     * is copied into {@code files/agent.staging/} and atomically swapped into
+     * place — the old extraction is never wiped before the replacement is fully
+     * staged and stamped, so an interrupted copy (ANR, LMK-kill, crash) always
+     * leaves the last-good extraction bootable instead of the permanent
+     * extract-failed loop of #12453. The crash-safety decision (when to swap,
+     * when to keep the existing extraction, when to fail) is the pure
+     * {@link ElizaAssetExtractionPolicy}; this method executes it.
+     *
+     * <p>Invariants: {@code .apk-stamp} is written INSIDE the staged tree so it
+     * lands with the swap and never runs ahead of a completed extraction; a UI-
+     * only build that lacks {@code assets/agent/*} keeps (never wipes) a valid
+     * full-agent extraction; a staging failure falls back to the last-good
+     * extraction rather than looping on a wipe.
      */
     private void extractAssetsIfNeeded(String abi) throws IOException {
+        File filesDir = getFilesDir();
         File root = agentRoot();
-        File abiDir = agentAbiDir(abi);
         File stateDir = agentStateDir();
-        if (!root.exists() && !root.mkdirs()) {
-            throw new IOException("Could not create " + root);
-        }
-        if (!abiDir.exists() && !abiDir.mkdirs()) {
-            throw new IOException("Could not create " + abiDir);
-        }
+        File staging = new File(filesDir, AGENT_STAGING_DIR_NAME);
+        File trash = new File(filesDir, AGENT_TRASH_DIR_NAME);
         if (!stateDir.exists() && !stateDir.mkdirs()) {
             throw new IOException("Could not create " + stateDir);
         }
 
-        // Compare APK source-file mtime against a stamp file in the agent
-        // root; when the APK was upgraded under us (adb push to
-        // /system/priv-app + reboot, a Play update, or an OTA) wipe the
-        // cached bundle + ABI binaries so the new asset payload gets
-        // re-extracted. Without this, copyAssetIfMissing silently keeps
-        // the previous extraction forever and shipping a fresh
-        // agent-bundle.js does nothing.
-        //
-        // We use the APK file's mtime (sourceDir → File.lastModified)
-        // rather than PackageInfo.lastUpdateTime because /system/priv-app
-        // installs (the AOSP image embed path) DO NOT bump
-        // lastUpdateTime — that field reflects pm-install + Play-update
-        // events. The on-disk APK mtime always reflects the current
-        // payload, which is what we need to invalidate cached extractions.
-        File stamp = new File(root, ".apk-stamp");
+        AssetManager assets = getAssets();
+
+        // Recover from a swap interrupted between its two renames: the trash dir
+        // still holds the last-good extraction, restore it before deciding.
+        recoverInterruptedAgentSwap(root, trash);
+
+        long pkgUpdate = computeApkUpdateTime();
+        long stampedUpdate = readApkStamp(root);
+        boolean apkChanged = ElizaAssetExtractionPolicy.apkChanged(pkgUpdate, stampedUpdate);
+        boolean apkHasAgentAssets = apkShipsAgentAssets(assets, abi);
+        boolean haveValidExtraction = extractionIsBootable(root, abi);
+
+        ElizaAssetExtractionPolicy.Action action = ElizaAssetExtractionPolicy.decide(
+            apkChanged, apkHasAgentAssets, haveValidExtraction);
+
+        boolean staged = false;
+        switch (action) {
+            case STAGE_AND_SWAP:
+                Log.i(TAG, "[ElizaAgentService] Refreshing agent assets via atomic staging "
+                    + "(apkChanged=" + apkChanged + ", validExtraction=" + haveValidExtraction
+                    + ", was=" + stampedUpdate + ", now=" + pkgUpdate + ")");
+                try {
+                    deleteRecursively(staging);
+                    stageAgentRoot(assets, abi, pkgUpdate, staging);
+                    swapStagedAgentRoot(staging, root, trash);
+                    staged = true;
+                    Log.i(TAG, "[ElizaAgentService] Atomic agent asset swap complete; stamp=" + pkgUpdate);
+                } catch (IOException error) {
+                    deleteRecursively(staging);
+                    if (extractionIsBootable(root, abi)) {
+                        // Fall back to the last-good extraction and leave the
+                        // stamp unchanged so a later boot retries the refresh.
+                        // Never loop on a wipe of a working extraction (#12453).
+                        Log.e(TAG, "[ElizaAgentService] Agent asset staging failed; "
+                            + "falling back to the existing last-good extraction and "
+                            + "leaving the stamp at " + stampedUpdate + " so the refresh retries.",
+                            error);
+                    } else {
+                        throw new IOException("Agent asset staging failed and no valid prior "
+                            + "extraction exists to fall back to", error);
+                    }
+                }
+                break;
+            case KEEP_MISSING_ASSETS:
+                // A UI-only / WebView-debug APK lacks assets/agent/* but bumped
+                // the APK mtime. Wiping here would brick a working full-agent
+                // install; keep it and leave the stamp so the guard re-checks.
+                Log.w(TAG, "[ElizaAgentService] Installed APK ships NO assets/agent/* for abi="
+                    + abi + " (UI-only build?); KEEPING the existing agent extraction rather than "
+                    + "wiping it. Stamp left unchanged (was=" + stampedUpdate + ", apk=" + pkgUpdate + ").");
+                break;
+            case FAIL_NO_ASSETS:
+                throw new IOException("Installed APK ships no assets/agent/* for abi=" + abi
+                    + " and there is no valid prior extraction to boot");
+            case USE_EXISTING:
+            default:
+                // Stamp matches and the extraction is bootable. Because the stamp
+                // only advances with a completed swap, the on-disk tree is
+                // complete by invariant — nothing to copy or wipe.
+                break;
+        }
+
+        // Aux runtime assets live OUTSIDE the atomically-swapped agent root
+        // (vector/fuzzy tarballs in files/, bundled models in .eliza/). They are
+        // small and/or persistent, their partial state does not brick boot, and
+        // they self-heal idempotently. Force-refresh the tarballs only when we
+        // just re-staged from a full APK.
+        extractAuxRuntimeAssets(assets, filesDir, stateDir, staged);
+    }
+
+    /**
+     * Resolve the current APK payload timestamp. Prefers the on-disk APK mtime
+     * ({@code sourceDir → File.lastModified}) over {@code lastUpdateTime}
+     * because /system/priv-app installs (the AOSP image embed path) do NOT bump
+     * {@code lastUpdateTime} — that field reflects pm-install + Play-update
+     * events, while the APK mtime always reflects the current payload, which is
+     * what invalidates a cached extraction. Returns 0 when unknown, which the
+     * policy reads as "no change" (safe: it boots the existing extraction).
+     */
+    private long computeApkUpdateTime() {
         long pkgUpdate = 0L;
         try {
             String sourceDir = getApplicationInfo().sourceDir;
@@ -939,101 +1036,121 @@ public class ElizaAgentService extends Service {
             long pmUpdate = getPackageManager()
                 .getPackageInfo(getPackageName(), 0).lastUpdateTime;
             if (pmUpdate > pkgUpdate) pkgUpdate = pmUpdate;
-        } catch (Exception ignored) {
-            // best-effort; no stamp known on early-boot failure
+        } catch (PackageManager.NameNotFoundException error) {
+            // The package cannot fail to find itself in practice; on the
+            // impossible path, an unknown APK time reads as "no change".
+            Log.w(TAG, "[ElizaAgentService] Could not resolve APK update time: " + error.getMessage());
         }
-        long stampedUpdate = 0L;
-        if (stamp.exists()) {
-            try (InputStream in = new java.io.FileInputStream(stamp)) {
-                byte[] buf = new byte[64];
-                int n = in.read(buf);
-                if (n > 0) {
-                    stampedUpdate = Long.parseLong(new String(buf, 0, n).trim());
-                }
-            } catch (Exception ignored) {
-                // corrupt stamp — treat as missing
+        return pkgUpdate;
+    }
+
+    /** Read the APK-mtime stamp from a completed extraction; 0 if absent/corrupt. */
+    private long readApkStamp(File root) {
+        File stamp = new File(root, AGENT_STAMP_NAME);
+        if (!stamp.isFile()) {
+            return 0L;
+        }
+        try (InputStream in = new java.io.FileInputStream(stamp)) {
+            byte[] buf = new byte[64];
+            int n = in.read(buf);
+            if (n > 0) {
+                return Long.parseLong(new String(buf, 0, n, StandardCharsets.UTF_8).trim());
             }
+        } catch (IOException | NumberFormatException error) {
+            Log.w(TAG, "[ElizaAgentService] Corrupt/unreadable " + AGENT_STAMP_NAME
+                + "; treating extraction as stale: " + error.getMessage());
         }
-        if (pkgUpdate > 0L && pkgUpdate != stampedUpdate) {
-            Log.i(TAG, "APK changed (was=" + stampedUpdate + ", now=" + pkgUpdate + "); refreshing extracted agent assets");
-            File bundle = new File(root, AGENT_BUNDLE_NAME);
-            if (bundle.exists() && !bundle.delete()) Log.w(TAG, "Could not delete stale agent-bundle.js");
-            File launchScript = new File(root, AGENT_LAUNCH_SCRIPT);
-            if (launchScript.exists() && !launchScript.delete()) Log.w(TAG, "Could not delete stale launch.sh");
-            File pgWasm = new File(root, "pglite.wasm");
-            if (pgWasm.exists()) pgWasm.delete();
-            File initDbWasm = new File(root, "initdb.wasm");
-            if (initDbWasm.exists()) initDbWasm.delete();
-            File pgData = new File(root, "pglite.data");
-            if (pgData.exists()) pgData.delete();
-            File ortWasmLoader = new File(root, "ort-wasm-simd-threaded.mjs");
-            if (ortWasmLoader.exists()) ortWasmLoader.delete();
-            File ortWasmBinary = new File(root, "ort-wasm-simd-threaded.wasm");
-            if (ortWasmBinary.exists()) ortWasmBinary.delete();
-            File vec = new File(getFilesDir(), "vector.tar.gz");
-            if (vec.exists()) vec.delete();
-            File fuzzy = new File(getFilesDir(), "fuzzystrmatch.tar.gz");
-            if (fuzzy.exists()) fuzzy.delete();
-            File pluginsManifest = new File(root, "plugins-manifest.json");
-            if (pluginsManifest.exists()) pluginsManifest.delete();
-            File[] abiContents = abiDir.listFiles();
-            if (abiContents != null) {
-                for (File f : abiContents) {
-                    try {
-                        java.nio.file.Files.deleteIfExists(f.toPath());
-                    } catch (IOException | SecurityException error) {
-                        Log.w(TAG, "Could not delete stale ABI asset " + f.getName() + ": " + error.getMessage());
-                    }
-                }
-            }
+        return 0L;
+    }
+
+    /** Persist the APK stamp; throws so a stamp-write failure fails the staging. */
+    private void writeApkStamp(File stamp, long value) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(stamp)) {
+            out.write(Long.toString(value).getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
+    }
+
+    /**
+     * Whether the installed APK actually ships the agent payload: the bundle
+     * asset AND a non-empty {@code assets/agent/<abi>/} dir. False for a UI-only
+     * WebView-debug build — the signal the missing-assets guard keys on.
+     */
+    private boolean apkShipsAgentAssets(AssetManager assets, String abi) {
+        boolean bundlePresent;
+        try (InputStream probe = assets.open("agent/" + AGENT_BUNDLE_NAME)) {
+            bundlePresent = true;
+        } catch (IOException missing) {
+            bundlePresent = false;
+        }
+        try {
+            String[] abiFiles = assets.list("agent/" + abi);
+            return bundlePresent && abiFiles != null && abiFiles.length > 0;
+        } catch (IOException error) {
+            Log.w(TAG, "[ElizaAgentService] Could not enumerate APK agent assets for abi="
+                + abi + "; treating as absent: " + error.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Whether an on-disk extraction can actually boot: bundle + launch.sh +
+     * bun + a musl loader all present and non-empty. Mirrors the guards in
+     * {@link #startAgentProcess()}, so a "valid extraction" is exactly one that
+     * would pass them.
+     */
+    private boolean extractionIsBootable(File root, String abi) {
+        File bundle = new File(root, AGENT_BUNDLE_NAME);
+        if (!bundle.isFile() || bundle.length() <= 0) {
+            return false;
+        }
+        File launch = new File(root, AGENT_LAUNCH_SCRIPT);
+        if (!launch.isFile() || launch.length() <= 0) {
+            return false;
+        }
+        File abiDir = new File(root, abi);
+        File bun = new File(abiDir, BUN_BINARY);
+        if (!bun.isFile() || bun.length() <= 0) {
+            return false;
+        }
+        return findMuslLoader(abiDir) != null;
+    }
+
+    /**
+     * Build a complete, ready-to-boot agent tree in {@code stagingRoot} from the
+     * APK assets — every agent-root file, the ABI binaries, +x bits, and the
+     * runtime symlinks — then write the {@code .apk-stamp} last so it lands only
+     * on a fully-staged tree. Throws on any failure; the caller keeps the last-
+     * good extraction and never swaps a partial tree into place.
+     */
+    private void stageAgentRoot(AssetManager assets, String abi, long pkgUpdate, File stagingRoot)
+            throws IOException {
+        File stagingAbiDir = new File(stagingRoot, abi);
+        if (!stagingRoot.isDirectory() && !stagingRoot.mkdirs()) {
+            throw new IOException("Could not create staging dir " + stagingRoot);
+        }
+        if (!stagingAbiDir.isDirectory() && !stagingAbiDir.mkdirs()) {
+            throw new IOException("Could not create staging abi dir " + stagingAbiDir);
         }
 
-        AssetManager assets = getAssets();
+        // Staging is fresh, so copyAssetIfMissing always copies here.
+        copyAssetIfMissing(assets, "agent/" + AGENT_BUNDLE_NAME, new File(stagingRoot, AGENT_BUNDLE_NAME));
+        copyAssetIfPresent(assets, "agent/" + AGENT_LAUNCH_SCRIPT, new File(stagingRoot, AGENT_LAUNCH_SCRIPT));
 
-        copyAssetIfMissing(assets, "agent/" + AGENT_BUNDLE_NAME, new File(root, AGENT_BUNDLE_NAME));
-        copyAssetIfPresent(assets, "agent/" + AGENT_LAUNCH_SCRIPT, new File(root, AGENT_LAUNCH_SCRIPT));
-
-        // PGlite runtime assets. pglite.wasm + initdb.wasm + pglite.data
-        // sit next to the bundle (`new URL("./pglite.X", import.meta.url)`);
-        // vector.tar.gz and fuzzystrmatch.tar.gz must live one directory
-        // ABOVE the bundle because PGlite resolves them via
-        // `new URL("../X.tar.gz", ...)`.
-        //
-        // aapt2 quirk: even with `androidResources.noCompress` listing
-        // `tar.gz` and `tar`, aapt2 strips the `.gz` suffix from
-        // `*.tar.gz` assets at packaging time (the `noCompress` flag
-        // only controls ZIP-level compression of the entry, not the
-        // pre-processing aapt2 does to "doubly compressed" extensions).
-        // The asset on disk inside the APK is therefore named
-        // `vector.tar` / `fuzzystrmatch.tar`, but PGlite's runtime
-        // loader still resolves `../vector.tar.gz` and
-        // `../fuzzystrmatch.tar.gz`. Look up under the aapt2-rewritten
-        // name and write to the runtime-expected `.tar.gz` name so the
-        // loader contract is preserved without changing the bundle.
-        copyAssetIfPresent(assets, "agent/pglite.wasm", new File(root, "pglite.wasm"));
-        copyAssetIfPresent(assets, "agent/initdb.wasm", new File(root, "initdb.wasm"));
-        copyAssetIfPresent(assets, "agent/pglite.data", new File(root, "pglite.data"));
+        // PGlite runtime assets. pglite.wasm + initdb.wasm + pglite.data sit
+        // next to the bundle (`new URL("./pglite.X", import.meta.url)`).
+        copyAssetIfPresent(assets, "agent/pglite.wasm", new File(stagingRoot, "pglite.wasm"));
+        copyAssetIfPresent(assets, "agent/initdb.wasm", new File(stagingRoot, "initdb.wasm"));
+        copyAssetIfPresent(assets, "agent/pglite.data", new File(stagingRoot, "pglite.data"));
         // Legacy ONNX Runtime Web sidecars used by the removed Android Kokoro
         // TTS path. Current AOSP TTS uses fused OmniVoice, so fresh bundles do
         // not ship these files; keep extraction best-effort for older APKs.
         copyAssetIfPresent(assets, "agent/ort-wasm-simd-threaded.mjs",
-            new File(root, "ort-wasm-simd-threaded.mjs"));
+            new File(stagingRoot, "ort-wasm-simd-threaded.mjs"));
         copyAssetIfPresent(assets, "agent/ort-wasm-simd-threaded.wasm",
-            new File(root, "ort-wasm-simd-threaded.wasm"));
-        // aapt2 not only strips `.gz` from `*.tar.gz` asset names, it also
-        // DECOMPRESSES them into raw tar bytes. PGlite's loader does
-        // `new URL("../X.tar.gz", ...)` then pipes the bytes through
-        // gunzip — fed raw tar it errors with `Z_DATA_ERROR: incorrect
-        // header check` and the agent crashloops at PGlite init. Re-gzip
-        // on extraction so the on-disk file matches what the loader
-        // expects: a gzipped tarball at `vector.tar.gz` /
-        // `fuzzystrmatch.tar.gz`.
-        copyAssetIfPresentAsGzipped(assets, "agent/vector.tar",
-            new File(getFilesDir(), "vector.tar.gz"));
-        copyAssetIfPresentAsGzipped(assets, "agent/fuzzystrmatch.tar",
-            new File(getFilesDir(), "fuzzystrmatch.tar.gz"));
+            new File(stagingRoot, "ort-wasm-simd-threaded.wasm"));
         copyAssetIfPresent(assets, "agent/plugins-manifest.json",
-            new File(root, "plugins-manifest.json"));
+            new File(stagingRoot, "plugins-manifest.json"));
 
         // ABI-specific binaries: bun + musl loader + libstdc++ + libgcc.
         String abiAssetDir = "agent/" + abi;
@@ -1043,7 +1160,7 @@ public class ElizaAgentService extends Service {
         }
         for (String name : abiFiles) {
             try {
-                copyAssetIfMissing(assets, abiAssetDir + "/" + name, new File(abiDir, name));
+                copyAssetIfMissing(assets, abiAssetDir + "/" + name, new File(stagingAbiDir, name));
             } catch (java.io.FileNotFoundException error) {
                 if ("libgcc_s.so.1".equals(name)) {
                     Log.w(TAG, "Optional runtime library missing from APK assets: " + abiAssetDir + "/" + name);
@@ -1053,6 +1170,21 @@ public class ElizaAgentService extends Service {
             }
         }
 
+        finalizeAgentAbiDir(stagingRoot, stagingAbiDir, abiFiles);
+
+        // Stamp LAST, inside staging, so it travels with the atomic swap and
+        // never gets ahead of a completed extraction.
+        if (pkgUpdate > 0L) {
+            writeApkStamp(new File(stagingRoot, AGENT_STAMP_NAME), pkgUpdate);
+        }
+    }
+
+    /**
+     * Set the +x bits and create the runtime symlinks on an extracted ABI dir.
+     * The libstdc++ soname symlink is relative and the packaged-native links are
+     * absolute, so both survive the staging→root rename intact.
+     */
+    private void finalizeAgentAbiDir(File root, File abiDir, String[] abiFiles) {
         File bun = new File(abiDir, BUN_BINARY);
         if (bun.exists()) bun.setExecutable(true, false);
         File llamaServer = new File(abiDir, "llama-server");
@@ -1061,9 +1193,9 @@ public class ElizaAgentService extends Service {
         if (launch.exists()) launch.setExecutable(true, false);
         for (String name : abiFiles) {
             // The musl loader (`ld-musl-<arch>.so.1`) needs +x. With the
-            // SIGSYS-shim wrapper installed (x86_64 only) the original
-            // Alpine loader is shipped as `ld-musl-<arch>.so.1.real` and
-            // ALSO needs +x because loader-wrap execve()s it directly.
+            // SIGSYS-shim wrapper installed (x86_64 only) the original Alpine
+            // loader is shipped as `ld-musl-<arch>.so.1.real` and ALSO needs +x
+            // because loader-wrap execve()s it directly.
             if (name.startsWith("ld-musl-")
                 && (name.endsWith(".so.1") || name.endsWith(".so.1.real"))) {
                 File loader = new File(abiDir, name);
@@ -1078,13 +1210,12 @@ public class ElizaAgentService extends Service {
         );
         linkPackagedRuntimeLibrary(abiDir, "libgcc_s.so.1", "libeliza_gcc_s.so");
 
-        // bun's binary requests `libstdc++.so.6` at runtime (the soname),
-        // but the actual file we shipped is the versioned realpath
-        // (`libstdc++.so.6.0.33`). Without a symlink the musl loader
-        // can't find the shared object and bun crashes with hundreds of
-        // "Error relocating: symbol not found" lines. Create the symlink
-        // pointing from the soname to the realpath inside the same abi
-        // dir so LD_LIBRARY_PATH resolution works without LD_PRELOAD.
+        // bun requests `libstdc++.so.6` (the soname) at runtime, but the file we
+        // shipped is the versioned realpath (`libstdc++.so.6.0.33`). Without a
+        // symlink the musl loader can't find the shared object and bun crashes
+        // with hundreds of "Error relocating: symbol not found" lines. Link the
+        // soname to the realpath inside the same abi dir so LD_LIBRARY_PATH
+        // resolution works without LD_PRELOAD.
         if (!stdcxxLinkedFromNative) {
             for (String name : abiFiles) {
                 if (name.startsWith("libstdc++.so.6.")) {
@@ -1108,49 +1239,140 @@ public class ElizaAgentService extends Service {
                 }
             }
         }
+    }
 
-        // Bundled default models (chat + embedding GGUF files staged by
-        // scripts/elizaos/stage-default-models.mjs at AOSP build time).
-        // Land them under $ELIZA_STATE_DIR/local-inference/models/ so
-        // the runtime's first-run bootstrap discovers them at canonical
-        // paths and registers them in the local-inference registry as
-        // eliza-owned models. The manifest.json carried alongside the
-        // GGUF files lets the bootstrap pick the right id + role for
-        // each file without re-deriving them from the filename.
-        //
-        // assets/agent/models/ may not exist on Capacitor (non-AOSP)
-        // builds — bundling defaults to off there since the desktop /
-        // Capacitor flows already have download UX. assets.list()
-        // returns null on missing paths, which we treat as "no models
-        // to extract".
+    /**
+     * Atomically replace {@code root} with {@code staging}: move the current
+     * extraction aside to {@code trash}, move the staged tree into place, then
+     * delete the trash. There is never an instant where both the working
+     * extraction is gone AND no recoverable copy exists — a crash between the
+     * two renames leaves the last-good tree in {@code trash} for
+     * {@link #recoverInterruptedAgentSwap} to restore on the next boot.
+     */
+    private void swapStagedAgentRoot(File staging, File root, File trash) throws IOException {
+        deleteRecursively(trash);
+        if (root.exists() && !root.renameTo(trash)) {
+            throw new IOException("Could not move current agent extraction aside to " + trash);
+        }
+        if (!staging.renameTo(root)) {
+            // Restore the last-good extraction before surfacing the failure.
+            if (trash.exists() && !root.exists() && !trash.renameTo(root)) {
+                Log.e(TAG, "[ElizaAgentService] Could not restore agent extraction from "
+                    + trash.getName() + " after a failed swap; next boot recovers it.");
+            }
+            throw new IOException("Could not move staged agent extraction into place at " + root);
+        }
+        deleteRecursively(trash);
+    }
+
+    /**
+     * Restore the last-good extraction if a prior swap died between its two
+     * renames. If {@code trash} exists and {@code root} already holds a bundle,
+     * the swap completed and the trash is just leftover — delete it. Otherwise
+     * the working root never landed; move the trash back into place.
+     */
+    private void recoverInterruptedAgentSwap(File root, File trash) {
+        if (!trash.isDirectory()) {
+            return;
+        }
+        if (new File(root, AGENT_BUNDLE_NAME).exists()) {
+            deleteRecursively(trash);
+            Log.w(TAG, "[ElizaAgentService] Cleaned leftover " + trash.getName()
+                + " from a prior interrupted asset swap; working extraction intact.");
+            return;
+        }
+        if (root.exists()) {
+            deleteRecursively(root);
+        }
+        if (trash.renameTo(root)) {
+            Log.w(TAG, "[ElizaAgentService] Restored the last-good agent extraction from "
+                + trash.getName() + " after an interrupted asset swap.");
+        } else {
+            Log.e(TAG, "[ElizaAgentService] Could not restore agent extraction from "
+                + trash.getName() + "; a fresh extraction will be staged.");
+        }
+    }
+
+    /**
+     * Extract the aux runtime assets that live outside the swapped agent root:
+     * the PGlite extension tarballs (files/) and bundled default models
+     * (.eliza/). Both self-heal idempotently. Force-refresh the tarballs on a
+     * fresh stage; never force-delete the large, persistent model files.
+     */
+    private void extractAuxRuntimeAssets(AssetManager assets, File filesDir, File stateDir,
+            boolean forceRefreshTarballs) throws IOException {
+        // vector.tar.gz / fuzzystrmatch.tar.gz must live one directory ABOVE the
+        // bundle (PGlite resolves them via `new URL("../X.tar.gz", ...)`), so
+        // they sit in files/ rather than the agent root. aapt2 strips the `.gz`
+        // from `*.tar.gz` asset names AND decompresses them to raw tar at
+        // packaging time (even with `androidResources.noCompress`), so the APK
+        // entry is `vector.tar` / `fuzzystrmatch.tar`; re-gzip on extraction so
+        // the on-disk file is the gzipped tarball the loader's gunzip expects
+        // (raw tar → `Z_DATA_ERROR: incorrect header check` → PGlite crashloop).
+        File vector = new File(filesDir, "vector.tar.gz");
+        File fuzzy = new File(filesDir, "fuzzystrmatch.tar.gz");
+        if (forceRefreshTarballs) {
+            if (vector.exists() && !vector.delete()) Log.w(TAG, "Could not delete stale vector.tar.gz");
+            if (fuzzy.exists() && !fuzzy.delete()) Log.w(TAG, "Could not delete stale fuzzystrmatch.tar.gz");
+        }
+        copyAssetIfPresentAsGzipped(assets, "agent/vector.tar", vector);
+        copyAssetIfPresentAsGzipped(assets, "agent/fuzzystrmatch.tar", fuzzy);
+
+        // Bundled default models (chat + embedding GGUF, staged by
+        // scripts/elizaos/stage-default-models.mjs at AOSP build time). Land
+        // them under $ELIZA_STATE_DIR/local-inference/models/ so the runtime's
+        // first-run bootstrap discovers them at canonical paths and registers
+        // them as eliza-owned models via the alongside manifest.json. Absent on
+        // Capacitor (non-AOSP) builds — assets.list() returns null, treated as
+        // "no models to extract".
         String modelsAssetDir = "agent/models";
         String[] modelFiles = assets.list(modelsAssetDir);
         if (modelFiles != null && modelFiles.length > 0) {
-            File modelsDest = new File(
-                new File(stateDir, "local-inference"),
-                "models"
-            );
+            File modelsDest = new File(new File(stateDir, "local-inference"), "models");
             if (!modelsDest.exists() && !modelsDest.mkdirs()) {
                 throw new IOException("Could not create " + modelsDest);
             }
             for (String name : modelFiles) {
-                copyAssetIfMissing(
-                    assets,
-                    modelsAssetDir + "/" + name,
-                    new File(modelsDest, name)
-                );
+                copyAssetIfMissing(assets, modelsAssetDir + "/" + name, new File(modelsDest, name));
             }
             Log.i(TAG, "Extracted " + modelFiles.length + " bundled model file(s) to " + modelsDest);
         }
+    }
 
-        // Persist the APK's mtime stamp so subsequent boots can detect a
-        // stale extraction and force a refresh.
-        if (pkgUpdate > 0L) {
-            try (FileOutputStream out = new FileOutputStream(stamp)) {
-                out.write(Long.toString(pkgUpdate).getBytes());
-            } catch (IOException error) {
-                Log.w(TAG, "Could not write APK stamp: " + error.getMessage());
+    /**
+     * Recursively delete a file tree, deleting symlinks as links (never
+     * following them into their targets — the ABI dir holds symlinks into the
+     * packaged nativeLibraryDir, which must not be traversed and wiped).
+     */
+    private void deleteRecursively(File target) {
+        if (target == null) {
+            return;
+        }
+        if (isSymlink(target)) {
+            if (!target.delete()) {
+                Log.w(TAG, "Could not delete symlink " + target);
             }
+            return;
+        }
+        if (!target.exists()) {
+            return;
+        }
+        File[] children = target.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        if (!target.delete()) {
+            Log.w(TAG, "Could not delete " + target);
+        }
+    }
+
+    private static boolean isSymlink(File file) {
+        try {
+            return java.nio.file.Files.isSymbolicLink(file.toPath());
+        } catch (SecurityException error) {
+            return false;
         }
     }
 

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAssetExtractionPolicy.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAssetExtractionPolicy.java
@@ -1,0 +1,79 @@
+package ai.elizaos.app;
+
+/**
+ * Pure crash-safety decision for {@link ElizaAgentService}'s on-device agent
+ * asset extraction (elizaOS/eliza#12453).
+ *
+ * <p>The service's cold-boot extraction used to wipe the previously-extracted
+ * ~170 MB agent bundle BEFORE staging the replacement and only stamped on full
+ * success, so any interruption of the copy (ANR, LMK-kill, crash) or a build
+ * variant that lacked the assets left the on-disk agent partial and dropped the
+ * app into a permanent {@code extract-failed} loop with no recovery. This class
+ * owns the one decision that makes extraction crash-safe: given whether the APK
+ * changed, whether it actually ships {@code assets/agent/*}, and whether a
+ * bootable extraction already exists, decide whether to atomically re-stage,
+ * keep the existing extraction untouched, or fail loudly.
+ *
+ * <p>Kept free of Android framework calls so the invariants — never wipe a
+ * working extraction, never advance the stamp on a partial run, never brick a
+ * full-agent install with a UI-only build — are exercised by plain JVM unit
+ * tests without a device. The service supplies the three booleans from real
+ * AssetManager / filesystem probes and executes the returned action.
+ */
+final class ElizaAssetExtractionPolicy {
+    private ElizaAssetExtractionPolicy() {}
+
+    enum Action {
+        /** Stamp matches and a bootable extraction exists — boot it as-is. */
+        USE_EXISTING,
+        /**
+         * The APK changed (or the extraction is broken) and the APK ships the
+         * agent assets — stage the payload into a temp dir, atomically swap it
+         * into place, then write the stamp. The ONLY action that wipes/re-stages
+         * and the ONLY one that advances the stamp.
+         */
+        STAGE_AND_SWAP,
+        /**
+         * The APK ships NO {@code assets/agent/*} (a UI-only / WebView-debug
+         * build) but a bootable extraction already exists — keep it, do NOT
+         * wipe, do NOT advance the stamp. A UI-only build must never brick a
+         * working full-agent install.
+         */
+        KEEP_MISSING_ASSETS,
+        /**
+         * The APK ships no agent assets AND there is no bootable extraction to
+         * fall back to — unrecoverable; fail loudly rather than loop on a wipe.
+         */
+        FAIL_NO_ASSETS,
+    }
+
+    /**
+     * An APK payload change is a known, non-zero timestamp that differs from the
+     * stamp of the last completed extraction. An unknown ({@code 0}) APK time
+     * reads as "no change" so a failed package lookup can never trigger a wipe.
+     */
+    static boolean apkChanged(long apkUpdateTime, long stampedUpdateTime) {
+        return apkUpdateTime > 0L && apkUpdateTime != stampedUpdateTime;
+    }
+
+    /**
+     * @param apkChanged           the installed APK payload differs from the stamp
+     * @param apkHasAgentAssets    the APK actually ships {@code assets/agent/*}
+     * @param haveValidExtraction  an on-disk extraction is bootable right now
+     */
+    static Action decide(boolean apkChanged, boolean apkHasAgentAssets, boolean haveValidExtraction) {
+        if (apkHasAgentAssets) {
+            // Re-stage on a real APK change, and self-heal a broken extraction
+            // even when the stamp matches (corruption / partial legacy wipe).
+            if (apkChanged || !haveValidExtraction) {
+                return Action.STAGE_AND_SWAP;
+            }
+            return Action.USE_EXISTING;
+        }
+        // The APK carries no agent payload (UI-only build).
+        if (haveValidExtraction) {
+            return Action.KEEP_MISSING_ASSETS;
+        }
+        return Action.FAIL_NO_ASSETS;
+    }
+}

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAssetExtractionPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAssetExtractionPolicyTest.java
@@ -1,0 +1,147 @@
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * JVM unit tests for the #12453 crash-safe asset-extraction decision. Pure
+ * decision logic — asserts the three brick-avoidance invariants directly:
+ * only a full-APK change/broken-extraction re-stages (and only re-staging
+ * advances the stamp), a UI-only build never wipes a working extraction, and a
+ * no-assets/no-extraction state fails loudly instead of looping on a wipe.
+ */
+public class ElizaAssetExtractionPolicyTest {
+
+    // ── apkChanged ─────────────────────────────────────────────────────────
+
+    @Test
+    public void unknownApkTimeIsNeverAChange() {
+        // A failed package lookup (apkUpdateTime == 0) must not read as a change,
+        // or an early-boot lookup failure would trigger a needless wipe.
+        assertFalse(ElizaAssetExtractionPolicy.apkChanged(0L, 0L));
+        assertFalse(ElizaAssetExtractionPolicy.apkChanged(0L, 12345L));
+    }
+
+    @Test
+    public void matchingStampIsNotAChange() {
+        assertFalse(ElizaAssetExtractionPolicy.apkChanged(1717000000000L, 1717000000000L));
+    }
+
+    @Test
+    public void differingStampIsAChange() {
+        assertTrue(ElizaAssetExtractionPolicy.apkChanged(1717000000001L, 1717000000000L));
+        // Fresh install: no stamp yet (0) vs a real APK time.
+        assertTrue(ElizaAssetExtractionPolicy.apkChanged(1717000000000L, 0L));
+    }
+
+    // ── Steady state: boot the existing extraction ─────────────────────────
+
+    @Test
+    public void unchangedFullApkWithValidExtractionBootsAsIs() {
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.USE_EXISTING,
+            ElizaAssetExtractionPolicy.decide(
+                /* apkChanged */ false, /* apkHasAgentAssets */ true, /* haveValidExtraction */ true));
+    }
+
+    // ── When-to-wipe: STAGE_AND_SWAP is the only re-staging action ──────────
+
+    @Test
+    public void changedFullApkRestages() {
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.STAGE_AND_SWAP,
+            ElizaAssetExtractionPolicy.decide(true, true, true));
+    }
+
+    @Test
+    public void freshInstallStages() {
+        // No prior extraction, APK ships assets, treated as a change.
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.STAGE_AND_SWAP,
+            ElizaAssetExtractionPolicy.decide(true, true, false));
+    }
+
+    @Test
+    public void brokenExtractionSelfHealsEvenWhenStampMatches() {
+        // A partial/corrupted extraction whose stamp still matches (e.g. a
+        // pre-#12453 interrupted wipe) must be rebuilt, not booted.
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.STAGE_AND_SWAP,
+            ElizaAssetExtractionPolicy.decide(false, true, false));
+    }
+
+    // ── Missing-assets guard: UI-only build never wipes a full install ─────
+
+    @Test
+    public void uiOnlyBuildOverFullInstallKeepsExtraction() {
+        // The #12453 variant-swap brick: a UI-only APK bumps the mtime but ships
+        // no assets/agent/*. With a valid extraction present it must be KEPT.
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.KEEP_MISSING_ASSETS,
+            ElizaAssetExtractionPolicy.decide(true, false, true));
+    }
+
+    @Test
+    public void noAssetsNeverWipesRegardlessOfChangeFlag() {
+        // Whether or not the change flag is set, a build without agent assets
+        // must never re-stage over a working extraction.
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.KEEP_MISSING_ASSETS,
+            ElizaAssetExtractionPolicy.decide(false, false, true));
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.KEEP_MISSING_ASSETS,
+            ElizaAssetExtractionPolicy.decide(true, false, true));
+    }
+
+    // ── Unrecoverable: fail loudly instead of looping on a wipe ────────────
+
+    @Test
+    public void noAssetsAndNoExtractionFails() {
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.FAIL_NO_ASSETS,
+            ElizaAssetExtractionPolicy.decide(true, false, false));
+        assertEquals(
+            ElizaAssetExtractionPolicy.Action.FAIL_NO_ASSETS,
+            ElizaAssetExtractionPolicy.decide(false, false, false));
+    }
+
+    // ── Invariants swept over the full input space ─────────────────────────
+
+    @Test
+    public void onlyStageAndSwapEverWipesAndStamps() {
+        // Enumerate all eight (apkChanged, apkHasAgentAssets, haveValid) inputs.
+        // STAGE_AND_SWAP — the only action that wipes/re-stages and advances the
+        // stamp — must occur iff the APK ships assets AND (it changed OR there is
+        // no valid extraction). Nothing else may re-stage.
+        for (int mask = 0; mask < 8; mask++) {
+            boolean apkChanged = (mask & 1) != 0;
+            boolean hasAssets = (mask & 2) != 0;
+            boolean valid = (mask & 4) != 0;
+            ElizaAssetExtractionPolicy.Action action =
+                ElizaAssetExtractionPolicy.decide(apkChanged, hasAssets, valid);
+            boolean shouldStage = hasAssets && (apkChanged || !valid);
+            assertEquals(
+                "stage decision for changed=" + apkChanged + " assets=" + hasAssets + " valid=" + valid,
+                shouldStage,
+                action == ElizaAssetExtractionPolicy.Action.STAGE_AND_SWAP);
+        }
+    }
+
+    @Test
+    public void aValidExtractionIsNeverDestroyed() {
+        // With a bootable extraction present, no input may resolve to the
+        // unrecoverable failure state — the last-good tree always survives.
+        for (int mask = 0; mask < 4; mask++) {
+            boolean apkChanged = (mask & 1) != 0;
+            boolean hasAssets = (mask & 2) != 0;
+            ElizaAssetExtractionPolicy.Action action =
+                ElizaAssetExtractionPolicy.decide(apkChanged, hasAssets, /* haveValid */ true);
+            assertFalse(
+                "valid extraction must never fail for changed=" + apkChanged + " assets=" + hasAssets,
+                action == ElizaAssetExtractionPolicy.Action.FAIL_NO_ASSETS);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`ElizaAgentService.extractAssetsIfNeeded()` compared the installed APK mtime
against `files/agent/.apk-stamp` and, on a change, **wiped** the extracted
bundle + `bun` + ABI binaries **first**, then re-copied ~170 MB in place, and
only wrote `.apk-stamp` on full success. Any interruption of that copy — ANR,
LMK-kill, crash, or a build variant lacking the assets — left the on-disk agent
partial with a stale stamp, so every subsequent launch re-detected the stale
stamp, re-wiped, and re-copied **forever**: a permanent `extract-failed` loop
with no recovery. Compounded by `onCreate()` spending the FGS-start timeout on
synchronous `getHistoricalProcessExitReasons` + diagnostic IO, which trips
`Timeout executing service` and kills the process mid-copy. Found by the #12185
device-lifecycle lane on `emulator-5584` (arm64 AOSP).

## The fix (all four from the issue's Suggested fix + a fallback)

1. **Atomic staging.** Extract the new payload into `files/agent.staging/`, then
   swap it into place atomically: `agent/ → agent.trash/`, `agent.staging/ →
   agent/`, delete `agent.trash/`. The working extraction is **never wiped
   before the replacement is fully staged**; a crash between the two renames
   leaves the last-good tree in `agent.trash/`, restored on the next boot by
   `recoverInterruptedAgentSwap()`.
2. **Stamp with the swap.** `.apk-stamp` is written **inside** the staged tree,
   so it lands with the atomic rename and never runs ahead of a completed
   extraction. A partial/failed run never advances it.
3. **Missing-assets guard.** A UI-only / WebView-debug APK that lacks
   `assets/agent/*` **keeps** the existing extraction and logs loudly
   (`[ElizaAgentService] … KEEPING the existing agent extraction`) instead of
   wiping — a UI-only build can no longer brick a full-agent install.
4. **FGS-startup ordering.** `onCreate()` now calls `startForeground()` **before**
   any diagnostic IO / `getHistoricalProcessExitReasons`. The heavy copy stays
   off the main thread on `startWorker`, as before.

Plus a **last-good fallback**: if staging fails, the service falls back to the
existing bootable extraction and leaves the stamp unchanged (retry next boot)
rather than looping on a wipe. It only throws `extract-failed` when there is
genuinely nothing to boot (no assets AND no valid prior extraction).

The pure decision — when to re-stage, when to keep, when to fail — is extracted
into `ElizaAssetExtractionPolicy` (Android-free, following the repo's
`ElizaAgentWatchdogPolicy` / `InferenceMemoryPolicy` pattern) so the
crash-safety invariants are unit-covered without a device.

## Unit-test coverage (crash-safety invariants)

`ElizaAssetExtractionPolicyTest` — **12/12 green** (JUnit 4.13.2, OpenJDK 21).
Sweeps the full `(apkChanged, apkHasAgentAssets, haveValidExtraction)` input
space and asserts:
- **when-to-wipe** — `STAGE_AND_SWAP` (the only wiping/stamping action) occurs
  iff the APK ships assets AND (it changed OR no valid extraction exists);
- **missing-assets guard** — a no-`assets/agent/*` build over a valid extraction
  always resolves to `KEEP_MISSING_ASSETS`, never a wipe (the #12453 variant-swap
  brick);
- **stamp-only-on-success** — only `STAGE_AND_SWAP` advances the stamp;
- **never-destroy-last-good** — with a bootable extraction present, no input ever
  resolves to `FAIL_NO_ASSETS`.

## Build result

- **Java compile — PASS.** Full `ElizaAgentService.java` (with the change) plus
  its self-contained `ai.elizaos.app` siblings compiled clean against the real
  Android SDK (`android-36`) + `androidx.core` 1.17.0 — `javac` exit 0, 0 errors.
- **`./gradlew :app:assembleDebug` — BLOCKED by environment, not code.** In this
  worktree, gradle fails at settings evaluation (before any `:app` Java compile)
  because there is no installed `node_modules` and the generated
  `capacitor.settings.gradle` references ~30 absent `@capacitor+*@8.x` subproject
  dirs. Unblocking needs `bun install` + `npx cap sync android` at the eliza
  root. Evidence + the exact error:
  `.github/issue-evidence/12453-android-atomic-extraction/gradle-config-blocker.txt`.

## On-device evidence

**N/A — DEFERRED (environment).** No emulator/device is attached (`adb devices`
empty; `emulator` absent from PATH) and the host is under an active concurrent
test swarm (load avg ~53, down from ~223) — the same swarm that OOM'd the
emulator for the #12453 reporter. Per the conservative-under-load directive, the
change is compile-verified at the Java level against the real SDK (authoritative
for this diff) and unit-verified for the crash-safety decision, rather than
forcing a full assemble that contends with the swarm. The precise recipe a green
on-device run needs (build steps + the three failure-mode repros to capture) is
in `.github/issue-evidence/12453-android-atomic-extraction/RUN-STATUS.md`.

Closes #12453. Part of #12185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)