### PR TITLE
docs(#12241): add contracts package headers

### DIFF
--- a/packages/contracts/src/contracts-drift.test.ts
+++ b/packages/contracts/src/contracts-drift.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Drift tests for literal contract exports consumed outside @elizaos/contracts.
+ *
+ * Runtime assertions pin the exported tuple values while expectTypeOf checks
+ * keep their public union types aligned with those literals.
+ */
+
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
 	type BscTradeRoutePreference,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Barrel exports for every public type contract module in this package.
+ */
+
 export * from './cloud-topology.js';
 export * from './deployment.js';
 export * from './roles.js';


### PR DESCRIPTION
## Summary

Adds purpose prose headers to the two remaining headerless `packages/contracts/src` files on current `develop`:

- `packages/contracts/src/contracts-drift.test.ts`
- `packages/contracts/src/index.ts`

This is part of B11 in #12241 and is comment-only.

## Verification

- `bun run check:comment-only` — PASS (`2 source file(s) changed; every code token identical to origin/develop`)
- `bun run --cwd packages/contracts test` — PASS (1 file, 10 tests)
- `bun run --cwd packages/contracts typecheck` — PASS
- `bun run --cwd packages/contracts lint:check` — PASS (`Checked 10 files`)
- `git diff --check` — PASS
- Header self-audit for `packages/contracts/src/*.ts` — PASS (prints nothing)

## Evidence

- Diffstat: `2 files changed, 11 insertions(+)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio: N/A — no UI, audio, or runtime behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: N/A — contract comments only; no chain state, wallet state, generated artifacts, or DB rows changed.
