### PR TITLE
feat(scripts): shared workspace/submodule discovery seam (#12332)

### DIFF
--- a/.github/issue-evidence/12332-workspace-discovery-seam.md
+++ b/.github/issue-evidence/12332-workspace-discovery-seam.md
@@ -1,0 +1,98 @@
+# #12332 — Script decoupling foundation: shared workspace/submodule discovery seam
+
+Phase 0 of the script-decoupling effort (#12189). Adds a single, zero-dependency
+discovery seam the script layer can read instead of each script carrying its own
+glob walker. **No existing scripts were migrated** — that is phase 1 (#12333).
+
+## What changed
+
+New files (only):
+
+- `packages/scripts/lib/workspaces.mjs` — exports exactly:
+  - `expandWorkspaceGlobs(patterns, opts)` — npm/Bun `workspaces` glob expansion:
+    `*` = one segment, `**` = any depth (incl. base dir), leading `!` subtracts
+    (exclude-wins, last-match-wins). Generalizes the proven expander from
+    `packages/scripts/turbo-cache-key.mjs` and adds `**` support.
+  - `listWorkspaceDirs(opts)` — root `package.json` `workspaces` expanded, kept
+    only where a `package.json` exists.
+  - `listPackages(opts)` — maps each dir to `{ name, dir, packageJson }`.
+  - `listSubmodules(opts)` — parses root `.gitmodules` into
+    `{ path, url, branch, initialized }`.
+  - `opts.repoRoot` overrides the auto-discovered repo root; dependency-free
+    (node builtins + reading `package.json` / `.gitmodules`).
+- `packages/scripts/lib/workspaces.d.ts` — typed signatures for the four exports.
+- `packages/scripts/__tests__/workspaces-lib.test.ts` — synthetic glob-semantics
+  tests + live-repo parity tests.
+
+## Verification (real output)
+
+### `bun test packages/scripts/__tests__/workspaces-lib.test.ts`
+
+```
+-------------------------------------|---------|---------|-------------------
+File                                 | % Funcs | % Lines | Uncovered Line #s
+-------------------------------------|---------|---------|-------------------
+All files                            |  100.00 |   96.84 |
+ packages/scripts/lib/workspaces.mjs |  100.00 |   96.84 | 53-54,61-62
+-------------------------------------|---------|---------|-------------------
+
+ 15 pass
+ 0 fail
+ 16 expect() calls
+Ran 15 tests across 1 file.
+```
+
+Coverage covers: simple `*`, nested `*/*`, `**` (incl. base dir), negation
+(`!packages/feed` excluded), later-positive re-add, hidden/`node_modules`/`dist`
+dirs skipped, dirs without `package.json` skipped, name mapping, `.gitmodules`
+parsing with init state, absent-`.gitmodules` → `[]`, plus live-repo parity:
+`@elizaos/plugin-sql` present at `plugins/plugin-sql`, `packages/feed` excluded,
+no duplicate package names, `listSubmodules()` paths == `.gitmodules` paths.
+
+### Live parity sanity
+
+`node -e "import('./packages/scripts/lib/workspaces.mjs').then(...)"`:
+
+```
+plugin-sql dir: plugins/plugin-sql
+feed excluded (exact packages/feed present): false
+submodules: [
+  { path: plugins/plugin-local-inference/native/llama.cpp, url: https://github.com/elizaOS/llama.cpp.git, branch: main, initialized: false },
+  { path: plugins/plugin-local-inference/native/whisper.cpp, url: https://github.com/ggerganov/whisper.cpp.git, branch: master, initialized: false },
+  { path: plugins/plugin-agent-orchestrator/vendor/opencode, url: https://github.com/elizaOS/opencode.git, branch: dev, initialized: false },
+  { path: packages/research/robot/vendor/asimov-1, url: https://github.com/asimovinc/asimov-1.git, branch: main, initialized: false },
+  { path: upstreams/electrobun, url: https://github.com/elizaOS/electrobun.git, branch: develop, initialized: false }
+]
+```
+
+(Submodules read `initialized: false` in this fresh worktree because they are
+un-checked-out gitlink placeholders — the field flips true once a working tree
+is present.)
+
+### Lint (workspace biome, pinned version)
+
+```
+$ ./node_modules/.bin/biome lint packages/scripts/lib/workspaces.mjs packages/scripts/lib/workspaces.d.ts packages/scripts/__tests__/workspaces-lib.test.ts
+Checked 3 files in 1020ms. No fixes applied.
+```
+
+### Typecheck (new .d.ts + test)
+
+```
+$ ./node_modules/.bin/tsc --noEmit --skipLibCheck --strict --ignoreConfig --types bun --allowJs packages/scripts/lib/workspaces.d.ts packages/scripts/__tests__/workspaces-lib.test.ts
+EXIT=0
+```
+
+### Error-policy ratchet (new J3 annotations)
+
+```
+$ bun run audit:error-policy-ratchet
+[error-policy-ratchet] base origin/develop (...); 0 changed production source file(s)
+[error-policy-ratchet] no new fallback-slop in touched files
+```
+
+Note: the full `bun run verify` runs the entire turbo typecheck/lint graph plus
+several audits over ~279 workspaces; the targeted commands above cover the new
+files. The one pre-existing `audit:scripts` finding
+(`audit:error-policy-ratchet:self-test` orphan root script) exists on
+`origin/develop` and is unrelated to this change.

--- a/packages/scripts/__tests__/workspaces-lib.test.ts
+++ b/packages/scripts/__tests__/workspaces-lib.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit + live-repo-parity tests for the workspace/submodule discovery seam
+ * (packages/scripts/lib/workspaces.mjs). Synthetic cases exercise glob
+ * semantics against throwaway temp trees; parity cases assert the lib agrees
+ * with the real repo's package.json and .gitmodules. Deterministic, no network.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  expandWorkspaceGlobs,
+  listPackages,
+  listSubmodules,
+  listWorkspaceDirs,
+} from "../lib/workspaces.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function makeRepo(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "workspaces-lib-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function writePackage(root: string, dir: string, name?: string): void {
+  writeFile(
+    root,
+    path.join(dir, "package.json"),
+    JSON.stringify(name ? { name } : {}, null, 2),
+  );
+}
+
+function writeRootPackage(root: string, workspaces: string[]): void {
+  writeFile(
+    root,
+    "package.json",
+    JSON.stringify({ type: "module", workspaces }, null, 2),
+  );
+}
+
+describe("expandWorkspaceGlobs — glob semantics", () => {
+  test("simple `*` matches one segment of directories", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "packages/a"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages/b"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages/a/nested"), { recursive: true });
+
+    const dirs = expandWorkspaceGlobs(["packages/*"], { repoRoot: root });
+    expect(dirs).toEqual(["packages/a", "packages/b"]);
+  });
+
+  test("nested `*/*` matches exactly two segments deep", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "packages/group/one"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages/group/two"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages/solo"), { recursive: true });
+
+    const dirs = expandWorkspaceGlobs(["packages/*/*"], { repoRoot: root });
+    expect(dirs).toEqual(["packages/group/one", "packages/group/two"]);
+  });
+
+  test("`**` matches any depth including the base directory", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "packages/a/deep/deeper"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, "packages/b"), { recursive: true });
+
+    const dirs = expandWorkspaceGlobs(["packages/**"], { repoRoot: root });
+    expect(dirs).toEqual([
+      "packages",
+      "packages/a",
+      "packages/a/deep",
+      "packages/a/deep/deeper",
+      "packages/b",
+    ]);
+  });
+
+  test("negation subtracts an earlier match (exclude-wins)", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "packages/keep"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages/feed"), { recursive: true });
+
+    const dirs = expandWorkspaceGlobs(["packages/*", "!packages/feed"], {
+      repoRoot: root,
+    });
+    expect(dirs).toEqual(["packages/keep"]);
+  });
+
+  test("later positive pattern re-adds a previously negated dir (last-match-wins)", () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, "packages/feed"), { recursive: true });
+
+    const dirs = expandWorkspaceGlobs(
+      ["packages/*", "!packages/feed", "packages/feed"],
+      { repoRoot: root },
+    );
+    expect(dirs).toEqual(["packages/feed"]);
+  });
+});
+
+describe("listWorkspaceDirs — package.json filtering", () => {
+  test("keeps only directories that contain a package.json", () => {
+    const root = makeRepo();
+    writeRootPackage(root, ["packages/*"]);
+    writePackage(root, "packages/real", "@x/real");
+    fs.mkdirSync(path.join(root, "packages/empty"), { recursive: true });
+
+    expect(listWorkspaceDirs({ repoRoot: root })).toEqual(["packages/real"]);
+  });
+
+  test("hidden and build dirs are skipped by `**` traversal", () => {
+    const root = makeRepo();
+    writeRootPackage(root, ["packages/**"]);
+    writePackage(root, "packages", "@x/packages-root");
+    writePackage(root, "packages/live", "@x/live");
+    writePackage(root, "packages/live/node_modules/dep", "dep");
+    writePackage(root, "packages/live/dist", "dist-pkg");
+    writePackage(root, "packages/.hidden", "hidden-pkg");
+
+    expect(listWorkspaceDirs({ repoRoot: root })).toEqual([
+      "packages",
+      "packages/live",
+    ]);
+  });
+
+  test("negation excludes a workspace with a package.json", () => {
+    const root = makeRepo();
+    writeRootPackage(root, ["packages/*", "!packages/feed"]);
+    writePackage(root, "packages/core", "@x/core");
+    writePackage(root, "packages/feed", "@x/feed");
+
+    expect(listWorkspaceDirs({ repoRoot: root })).toEqual(["packages/core"]);
+  });
+});
+
+describe("listPackages — name mapping", () => {
+  test("maps each workspace dir to { name, dir, packageJson }", () => {
+    const root = makeRepo();
+    writeRootPackage(root, ["packages/*"]);
+    writePackage(root, "packages/alpha", "@x/alpha");
+    writePackage(root, "packages/beta");
+
+    const packages = listPackages({ repoRoot: root });
+    expect(packages).toEqual([
+      {
+        name: "@x/alpha",
+        dir: "packages/alpha",
+        packageJson: { name: "@x/alpha" },
+      },
+      { name: undefined, dir: "packages/beta", packageJson: {} },
+    ]);
+  });
+});
+
+describe("listSubmodules — .gitmodules parsing", () => {
+  test("parses path/url/branch and marks initialization state", () => {
+    const root = makeRepo();
+    writeFile(
+      root,
+      ".gitmodules",
+      [
+        '[submodule "vendor/checked-out"]',
+        "\t# a comment line that must be ignored",
+        "\tpath = vendor/checked-out",
+        "\turl = https://example.com/a.git",
+        "\tbranch = main",
+        "",
+        '[submodule "vendor/placeholder"]',
+        "\tpath = vendor/placeholder",
+        "\turl = https://example.com/b.git",
+        "",
+      ].join("\n"),
+    );
+    writeFile(root, "vendor/checked-out/.git", "gitdir: ../../.git/modules/x");
+    fs.mkdirSync(path.join(root, "vendor/placeholder"), { recursive: true });
+
+    expect(listSubmodules({ repoRoot: root })).toEqual([
+      {
+        path: "vendor/checked-out",
+        url: "https://example.com/a.git",
+        branch: "main",
+        initialized: true,
+      },
+      {
+        path: "vendor/placeholder",
+        url: "https://example.com/b.git",
+        branch: undefined,
+        initialized: false,
+      },
+    ]);
+  });
+
+  test("returns an empty list when .gitmodules is absent", () => {
+    const root = makeRepo();
+    expect(listSubmodules({ repoRoot: root })).toEqual([]);
+  });
+});
+
+describe("live-repo parity", () => {
+  test("plugin-sql appears in listPackages with a matching dir", () => {
+    const pkg = listPackages({ repoRoot: REPO_ROOT }).find(
+      (p) => p.name === "@elizaos/plugin-sql",
+    );
+    expect(pkg).toBeDefined();
+    expect(pkg?.dir).toBe("plugins/plugin-sql");
+  });
+
+  test("packages/feed is excluded from listWorkspaceDirs", () => {
+    const dirs = listWorkspaceDirs({ repoRoot: REPO_ROOT });
+    expect(dirs).not.toContain("packages/feed");
+  });
+
+  test("no duplicate package names across the workspace", () => {
+    const names = listPackages({ repoRoot: REPO_ROOT })
+      .map((p) => p.name)
+      .filter((name): name is string => Boolean(name));
+    const seen = new Map<string, number>();
+    for (const name of names) seen.set(name, (seen.get(name) ?? 0) + 1);
+    const duplicates = [...seen.entries()].filter(([, count]) => count > 1);
+    expect(duplicates).toEqual([]);
+  });
+
+  test("listSubmodules entries match .gitmodules declarations", () => {
+    const gitmodules = fs.readFileSync(
+      path.join(REPO_ROOT, ".gitmodules"),
+      "utf8",
+    );
+    const declaredPaths = [...gitmodules.matchAll(/^\s*path\s*=\s*(.+)$/gm)].map(
+      (m) => m[1].trim(),
+    );
+    const libPaths = listSubmodules({ repoRoot: REPO_ROOT }).map((s) => s.path);
+    expect(libPaths.sort()).toEqual([...declaredPaths].sort());
+  });
+});

--- a/packages/scripts/lib/workspaces.d.ts
+++ b/packages/scripts/lib/workspaces.d.ts
@@ -1,0 +1,41 @@
+export interface WorkspaceDiscoveryOptions {
+  /** Repo root to resolve globs against. Defaults to this repo's root. */
+  repoRoot?: string;
+}
+
+export interface WorkspacePackage {
+  /** package.json `name`; undefined for a private, unnamed package. */
+  name: string | undefined;
+  /** Workspace-relative directory (POSIX-separated). */
+  dir: string;
+  /** Parsed package.json. */
+  packageJson: Record<string, unknown> & { name?: string };
+}
+
+export interface Submodule {
+  /** Repo-relative submodule path from .gitmodules. */
+  path: string;
+  /** Remote URL, if declared. */
+  url: string | undefined;
+  /** Tracked branch, if declared. */
+  branch: string | undefined;
+  /** True when the submodule working tree is checked out on disk. */
+  initialized: boolean;
+}
+
+export declare function expandWorkspaceGlobs(
+  patterns: string[],
+  opts?: WorkspaceDiscoveryOptions,
+): string[];
+
+export declare function listWorkspaceDirs(
+  opts?: WorkspaceDiscoveryOptions,
+): string[];
+
+export declare function listPackages(
+  opts?: WorkspaceDiscoveryOptions,
+): WorkspacePackage[];
+
+export declare function listSubmodules(
+  opts?: WorkspaceDiscoveryOptions,
+): Submodule[];

--- a/packages/scripts/lib/workspaces.mjs
+++ b/packages/scripts/lib/workspaces.mjs
@@ -1,0 +1,251 @@
+/**
+ * Shared, zero-dependency discovery seam for the repo's Bun/Node workspaces and
+ * git submodules. This is the single source of truth the script layer reads to
+ * answer "which directories are workspaces?", "what package lives where?", and
+ * "which submodules does .gitmodules declare?" — replacing the ad-hoc glob
+ * walkers each script used to carry (the migration of those callers is #12333).
+ *
+ * The glob expander implements the npm/Bun `workspaces` semantics used by the
+ * root package.json: `*` matches a single path segment, `**` matches any number
+ * of segments, and a leading `!` pattern subtracts from earlier matches
+ * (exclude-wins, last-match-wins ordering). It is deliberately dependency-free —
+ * only node builtins plus reading package.json / .gitmodules — so any script or
+ * test can import it without pulling in the build graph.
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+function normalizePath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function resolveRepoRoot(opts) {
+  return opts?.repoRoot ? path.resolve(opts.repoRoot) : DEFAULT_REPO_ROOT;
+}
+
+// Compile one workspace glob segment-pattern to a RegExp over the "/"-joined
+// relative path. `**` spans segments (including zero), `*` stays within one.
+function workspaceGlobToRegExp(glob) {
+  let pattern = "";
+  for (let i = 0; i < glob.length; i += 1) {
+    const char = glob[i];
+    // A `/**` suffix (or `/**/`) must match zero-or-more trailing segments,
+    // including none — so `packages/**` matches `packages` itself. Consume the
+    // preceding `/` with the `**` so the separator is optional too.
+    if (char === "/" && glob[i + 1] === "*" && glob[i + 2] === "*") {
+      if (glob[i + 3] === "/") {
+        pattern += "(?:/.*)?/";
+        i += 3;
+      } else {
+        pattern += "(?:/.*)?";
+        i += 2;
+      }
+    } else if (char === "*") {
+      if (glob[i + 1] === "*") {
+        pattern += ".*";
+        i += 1;
+      } else {
+        pattern += "[^/]*";
+      }
+    } else if (/[.+^${}()|[\]\\]/.test(char)) {
+      pattern += `\\${char}`;
+    } else {
+      pattern += char;
+    }
+  }
+  return new RegExp(`^${pattern}$`);
+}
+
+// Walk the tree expanding one positive glob into concrete directories. A `*`
+// segment enumerates children; a `**` segment matches this directory and every
+// descendant directory; a literal segment descends by name.
+function expandPositiveGlob(repoRoot, pattern) {
+  let dirs = [repoRoot];
+  const parts = pattern.split("/");
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    const next = [];
+    for (const dir of dirs) {
+      if (part === "**") {
+        // Match zero-or-more segments: keep this dir and add all descendants.
+        for (const descendant of walkDirs(dir)) next.push(descendant);
+        continue;
+      }
+      if (part === "*") {
+        for (const entry of readDirEntries(dir)) {
+          if (entry.isDirectory()) next.push(path.join(dir, entry.name));
+        }
+        continue;
+      }
+      const candidate = path.join(dir, part);
+      try {
+        if (statSync(candidate).isDirectory()) next.push(candidate);
+      } catch {
+        // error-policy:J3 path does not exist — this glob branch yields nothing
+      }
+    }
+    dirs = next;
+  }
+  return dirs;
+}
+
+function readDirEntries(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // error-policy:J3 unreadable dir contributes no members
+    return [];
+  }
+}
+
+// Depth-first directory list rooted at `start` (inclusive), skipping hidden and
+// heavy build/vendor dirs so `**` expansion stays bounded and deterministic.
+const WALK_SKIP_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+]);
+
+function walkDirs(start) {
+  const out = [start];
+  for (const entry of readDirEntries(start)) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+    if (WALK_SKIP_DIRS.has(entry.name)) continue;
+    out.push(...walkDirs(path.join(start, entry.name)));
+  }
+  return out;
+}
+
+/**
+ * Expand a list of workspace glob patterns (npm/Bun `workspaces` semantics)
+ * into a deduped, sorted list of relative directory paths. Positive patterns
+ * add matches; a leading `!` pattern removes earlier matches (exclude-wins).
+ */
+export function expandWorkspaceGlobs(patterns, opts) {
+  const repoRoot = resolveRepoRoot(opts);
+  const matchers = patterns.map((glob) => {
+    const negated = glob.startsWith("!");
+    return {
+      negated,
+      regExp: workspaceGlobToRegExp(negated ? glob.slice(1) : glob),
+    };
+  });
+
+  function isMember(relativeDir) {
+    let member = false;
+    for (const { negated, regExp } of matchers) {
+      if (regExp.test(relativeDir)) member = !negated;
+    }
+    return member;
+  }
+
+  const dirs = new Set();
+  for (const glob of patterns) {
+    if (glob.startsWith("!")) continue;
+    for (const dir of expandPositiveGlob(repoRoot, glob)) {
+      const relativeDir = normalizePath(path.relative(repoRoot, dir));
+      if (!relativeDir || !isMember(relativeDir)) continue;
+      dirs.add(relativeDir);
+    }
+  }
+  return [...dirs].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * List every workspace directory declared in the root package.json — expanded
+ * from the `workspaces` globs, negations applied, keeping only directories that
+ * actually contain a package.json.
+ */
+export function listWorkspaceDirs(opts) {
+  const repoRoot = resolveRepoRoot(opts);
+  const rootPackage = readJson(path.join(repoRoot, "package.json"));
+  const patterns = rootPackage.workspaces ?? [];
+  return expandWorkspaceGlobs(patterns, { repoRoot }).filter((relativeDir) =>
+    existsSync(path.join(repoRoot, relativeDir, "package.json")),
+  );
+}
+
+/**
+ * List every workspace as `{ name, dir, packageJson }`, where `name` is the
+ * package.json `name` field (may be undefined for a private, unnamed package)
+ * and `dir` is the workspace-relative directory.
+ */
+export function listPackages(opts) {
+  const repoRoot = resolveRepoRoot(opts);
+  return listWorkspaceDirs({ repoRoot }).map((dir) => {
+    const packageJson = readJson(path.join(repoRoot, dir, "package.json"));
+    return { name: packageJson.name, dir, packageJson };
+  });
+}
+
+// Minimal INI parser for .gitmodules: sections keyed by `[submodule "name"]`,
+// with `path` / `url` / `branch` values. Indentation and comment lines (`#`,
+// `;`) are ignored; unknown keys are dropped.
+function parseGitmodules(text) {
+  const sections = [];
+  let current = null;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    const sectionMatch = line.match(/^\[submodule\s+"(.+)"\]$/);
+    if (sectionMatch) {
+      current = { section: sectionMatch[1] };
+      sections.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const kvMatch = line.match(/^([A-Za-z][A-Za-z0-9_-]*)\s*=\s*(.*)$/);
+    if (!kvMatch) continue;
+    current[kvMatch[1]] = kvMatch[2].trim();
+  }
+  return sections;
+}
+
+/**
+ * Parse the root `.gitmodules` into `{ path, url, branch, initialized }` per
+ * submodule. `initialized` is true when the submodule's working tree is present
+ * on disk (a `.git` gitfile or non-empty checkout), false when only the gitlink
+ * placeholder exists. Returns an empty list when `.gitmodules` is absent.
+ */
+export function listSubmodules(opts) {
+  const repoRoot = resolveRepoRoot(opts);
+  const gitmodulesPath = path.join(repoRoot, ".gitmodules");
+  if (!existsSync(gitmodulesPath)) return [];
+  const sections = parseGitmodules(readFileSync(gitmodulesPath, "utf8"));
+  return sections
+    .filter((section) => typeof section.path === "string")
+    .map((section) => ({
+      path: section.path,
+      url: section.url,
+      branch: section.branch,
+      initialized: isSubmoduleInitialized(path.join(repoRoot, section.path)),
+    }));
+}
+
+function isSubmoduleInitialized(absPath) {
+  if (existsSync(path.join(absPath, ".git"))) return true;
+  const entries = readDirEntries(absPath);
+  return entries.length > 0;
+}


### PR DESCRIPTION
Closes #12332

## What & why

Phase 0 of the script-decoupling effort (#12189). Adds a single, zero-dependency **workspace/submodule discovery seam** the script layer can read instead of each script re-implementing its own workspace glob walker. **No existing scripts are migrated** — that is phase 1 (#12333), explicitly out of scope here.

New files (only):

- **`packages/scripts/lib/workspaces.mjs`** — exports exactly:
  - `expandWorkspaceGlobs(patterns, opts)` — npm/Bun `workspaces` glob semantics: `*` = one segment, `**` = any depth (including the base dir), leading `!` subtracts earlier matches (exclude-wins, last-match-wins). Generalizes the proven expander in `packages/scripts/turbo-cache-key.mjs` and **adds `**` support**.
  - `listWorkspaceDirs(opts)` — root `package.json` `workspaces` expanded, negations applied, kept only where a `package.json` exists.
  - `listPackages(opts)` — maps each dir to `{ name, dir, packageJson }`.
  - `listSubmodules(opts)` — parses root `.gitmodules` into `{ path, url, branch, initialized }`.
  - `opts.repoRoot` overrides the auto-discovered root; dependency-free (node builtins + reading `package.json` / `.gitmodules`).
- **`packages/scripts/lib/workspaces.d.ts`** — typed signatures for the four exports.
- **`packages/scripts/__tests__/workspaces-lib.test.ts`** — synthetic glob-semantics tests + live-repo parity tests.

## Verification (real output)

### `bun test packages/scripts/__tests__/workspaces-lib.test.ts`

```
-------------------------------------|---------|---------|-------------------
File                                 | % Funcs | % Lines | Uncovered Line #s
-------------------------------------|---------|---------|-------------------
All files                            |  100.00 |   96.84 |
 packages/scripts/lib/workspaces.mjs |  100.00 |   96.84 | 53-54,61-62
-------------------------------------|---------|---------|-------------------

 15 pass
 0 fail
 16 expect() calls
Ran 15 tests across 1 file.
```

Covers: simple `*`, nested `*/*`, `**` (incl. base dir), negation (`!packages/feed` excluded), later-positive re-add, hidden/`node_modules`/`dist` skipped, dirs without `package.json` skipped, name mapping, `.gitmodules` parsing with init state, absent-`.gitmodules` → `[]`, plus **live-repo parity**: `@elizaos/plugin-sql` present at `plugins/plugin-sql`, `packages/feed` excluded, no duplicate package names, `listSubmodules()` paths == `.gitmodules` paths.

### Live parity sanity

```
plugin-sql dir: plugins/plugin-sql
exact packages/feed present: false
submodules: 5 entries matching .gitmodules (llama.cpp, whisper.cpp, opencode, asimov-1, electrobun)
```

### Lint (workspace-pinned biome) & typecheck

```
$ ./node_modules/.bin/biome lint packages/scripts/lib/workspaces.mjs packages/scripts/lib/workspaces.d.ts packages/scripts/__tests__/workspaces-lib.test.ts
Checked 3 files in 1020ms. No fixes applied.

$ tsc --noEmit --strict --types bun --allowJs workspaces.d.ts workspaces-lib.test.ts
EXIT=0
```

### Error-policy ratchet

```
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files
```

Full `bun run verify` runs the entire turbo graph over ~279 workspaces; the targeted commands above cover the new files. The lone `audit:scripts` finding (`audit:error-policy-ratchet:self-test` orphan) pre-exists on `develop` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)