### PR TITLE
docs(#12241): add docs test header

### DIFF
--- a/packages/docs/test/docs.test.js
+++ b/packages/docs/test/docs.test.js
@@ -1,3 +1,10 @@
+/**
+ * Docs site integrity tests for Mintlify navigation and markdown links.
+ *
+ * Runs against the real files on disk so docs.json, redirects, frontmatter,
+ * local assets, and internal links stay deployable together.
+ */
+
 import assert from "node:assert";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";


### PR DESCRIPTION
## Summary

Adds a purpose prose header to the remaining headerless `packages/docs` source file:

- `packages/docs/test/docs.test.js`

This is part of B11 in #12241 and is comment-only.

## Verification

- `bun run check:comment-only` — PASS (`1 source file(s) changed; every code token identical to origin/develop`)
- `bun run --cwd packages/docs test` — PASS (15 tests)
- `git diff --check` — PASS
- Header self-audit for `packages/docs/test/docs.test.js` — PASS (prints nothing)

## Evidence

- Diffstat: `1 file changed, 7 insertions(+)`
- Real-LLM trajectories: N/A — comments-only change, zero functional diff machine-checked by `scripts/assert-comment-only-diff.mjs`.
- Screenshots/video/audio: N/A — no UI, rendered docs page, audio, or runtime behavior changed.
- Backend/frontend logs: N/A — no runtime path changed.
- Domain artifacts: N/A — test comment only; no generated artifacts, docs content, redirects, or deploy output changed.
