### PR TITLE
chore(#12242): comment cleanup B12 — prose headers, churn removal (comment-only)

### DIFF
--- a/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
+++ b/plugins/plugin-contacts/src/components/ContactsAppView.test.ts
@@ -176,8 +176,8 @@ describe("ContactsAppView — list → detail navigation", () => {
       screen.getByRole("heading", { level: 2, name: "Ada Lovelace" }),
     ).toBeTruthy();
 
-    // Phone numbers no longer use a tel: OS handoff — each renders the number
-    // text plus in-app "Call" and "Text" controls. The duplicate "+15550100"
+    // Phone numbers render as number text plus in-app "Call" and "Text"
+    // controls rather than a tel: OS handoff. The duplicate "+15550100"
     // collapses to a single entry (dedupePreservingOrder), so two phone rows →
     // two Call + two Text controls.
     expect(screen.queryByRole("link", { name: /tel:/ })).toBeNull();

--- a/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsSpatialView.test.tsx
@@ -1,3 +1,4 @@
+/** Render tests for the documents spatial view over the TUI surface (deterministic static markup). */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-documents/src/document-presenter.test.ts
+++ b/plugins/plugin-documents/src/document-presenter.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for presentDocument: deterministic mapping of document Memory metadata to display cards (no runtime). */
 import type { Memory, UUID } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { presentDocument } from "./document-presenter";

--- a/plugins/plugin-documents/src/document-presenter.ts
+++ b/plugins/plugin-documents/src/document-presenter.ts
@@ -1,3 +1,4 @@
+/** Maps a stored document `Memory` into the display-card shape the documents view renders — provenance kind, title, and derived metadata. */
 import type { Memory } from "@elizaos/core";
 import type { DocumentVisibilityScope } from "./service-loader.js";
 

--- a/plugins/plugin-documents/src/index.ts
+++ b/plugins/plugin-documents/src/index.ts
@@ -1,3 +1,4 @@
+/** Public entry for @elizaos/plugin-documents: the HTTP route plugin plus its documents view, presenter, and type re-exports. */
 export {
   type DocumentCard,
   type DocumentSearchHit,

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -1,3 +1,10 @@
+/**
+ * REST route handlers for the document store: list, stats, semantic/keyword
+ * search, single fetch, fragment listing, single + bulk upload, URL/YouTube
+ * ingestion, and delete. Persistence and search are delegated to the runtime
+ * document service (resolved from `@elizaos/agent/api/documents-service-loader`);
+ * this module handles HTTP shaping and access-control scoping only.
+ */
 import type {
   AgentRuntime,
   IFileStorageService,

--- a/plugins/plugin-documents/test/plugin.test.ts
+++ b/plugins/plugin-documents/test/plugin.test.ts
@@ -1,10 +1,11 @@
+/** Manifest test for @elizaos/plugin-documents: asserts the index loads and the plugin registers its route surface, with the heavy UI renderer barrel mocked out for the node environment. */
 import { describe, expect, it, vi } from "vitest";
 
-// The plugin index now re-exports the browser DocumentsView, which statically
-// pulls the heavy `@elizaos/ui` renderer barrel (react-router et al.) — not
-// resolvable under this node test environment and irrelevant to a manifest
-// check. Mock it to the inert `client` surface the view touches (the same
-// isolation every view test in this plugin uses) so the index loads here.
+// The plugin index re-exports the browser DocumentsView, which statically pulls
+// the heavy `@elizaos/ui` renderer barrel (react-router et al.) — not resolvable
+// under this node test environment and irrelevant to a manifest check. Mock it
+// to the inert `client` surface the view touches (the same isolation every view
+// test in this plugin uses) so the index loads here.
 vi.mock("@elizaos/ui", () => ({
   client: { getBaseUrl: () => "http://test.local", sendChatMessage: () => {} },
 }));

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -1,3 +1,4 @@
+/** Route-handler tests for the documents REST surface, driving handleDocumentsRoutes against a mocked document service and fetch impl. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DocumentRouteContext } from "../src/routes.js";
 import {

--- a/plugins/plugin-documents/vite.config.views.ts
+++ b/plugins/plugin-documents/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite bundle config for the documents dashboard view (emits to dist/views). */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-documents/vitest.config.ts
+++ b/plugins/plugin-documents/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for @elizaos/plugin-documents: extends the shared base config with the package's local aliases. */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsSpatialView.test.tsx
@@ -1,3 +1,4 @@
+/** Render tests for the relationships spatial view over the TUI surface (deterministic static markup, no live runtime). */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-relationships/src/db/index.ts
+++ b/plugins/plugin-relationships/src/db/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the relationships knowledge-graph drizzle schema. */
 export * from "./schema.js";

--- a/plugins/plugin-relationships/src/index.ts
+++ b/plugins/plugin-relationships/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public entry for `@elizaos/plugin-relationships`: the entity graph-CRUD action,
+ * the relationships views (browser + spatial/TUI), the drizzle schema, and the
+ * entity-graph provider.
+ */
 export type { EntityActionParameters } from "./actions/entity.js";
 export { entityAction } from "./actions/entity.js";
 export {

--- a/plugins/plugin-relationships/src/plugin.test.ts
+++ b/plugins/plugin-relationships/src/plugin.test.ts
@@ -1,3 +1,4 @@
+/** Contract tests asserting @elizaos/plugin-relationships registers its action, provider, and schema. */
 import { describe, expect, it } from "vitest";
 
 import { entityAction } from "./actions/entity.js";

--- a/plugins/plugin-relationships/src/types.ts
+++ b/plugins/plugin-relationships/src/types.ts
@@ -3,11 +3,11 @@
  *
  * These mirror the canonical LifeOps shapes in
  * `plugins/plugin-personal-assistant/src/lifeops/entities/types.ts` and
- * `plugins/plugin-personal-assistant/src/lifeops/relationships/types.ts`. The richer
- * lifeops shapes (identities array, attributes map, retired status, sentiment
- * trend, type registries) will be ported here in a follow-up pass; for now we
- * expose the minimal Entity / Relationship surface that matches the DB schema
- * in `db/schema.ts`.
+ * `plugins/plugin-personal-assistant/src/lifeops/relationships/types.ts`. This
+ * module exposes the minimal Entity / Relationship surface that matches the DB
+ * schema in `db/schema.ts`; the richer lifeops shapes (identities array,
+ * attributes map, retired status, sentiment trend, type registries) live only
+ * in plugin-personal-assistant and are not mirrored here.
  */
 
 export const RELATIONSHIPS_LOG_PREFIX = "[Relationships]";

--- a/plugins/plugin-relationships/vite.config.views.ts
+++ b/plugins/plugin-relationships/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite bundle config for the relationships dashboard view (emits to dist/views). */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-relationships/vitest.config.ts
+++ b/plugins/plugin-relationships/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for @elizaos/plugin-relationships: extends the shared base config with the package's local aliases. */
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/plugins/plugin-reminders/src/db/index.ts
+++ b/plugins/plugin-reminders/src/db/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the plugin-reminders drizzle schema (the `app_reminders` tables). */
 export * from "./schema.ts";

--- a/plugins/plugin-reminders/src/index.ts
+++ b/plugins/plugin-reminders/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public entry for `@elizaos/plugin-reminders`: re-exports the `app_reminders`
+ * drizzle schema, the plugin object, and the non-destructive
+ * `app_lifeops`→`app_reminders` migration service.
+ */
 export * from "./db/schema.ts";
 export { remindersPlugin } from "./plugin.ts";
 export {

--- a/plugins/plugin-reminders/src/services/migration.test.ts
+++ b/plugins/plugin-reminders/src/services/migration.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the reminder-table copy migration, driven by a scripted in-memory SQL executor (no live database). */
 import { describe, expect, it } from "vitest";
 import {
   MIGRATED_REMINDER_TABLES,

--- a/plugins/plugin-reminders/vitest.config.ts
+++ b/plugins/plugin-reminders/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for @elizaos/plugin-reminders: node environment over the src + test suites. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-todos/build.ts
+++ b/plugins/plugin-todos/build.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+/** Build entry for @elizaos/plugin-todos: bundles the Node plugin and the browser view through the shared buildPlugin helper. */
 import { buildPlugin } from "../plugin-build";
 
 await buildPlugin({

--- a/plugins/plugin-todos/src/actions/todo.test.ts
+++ b/plugins/plugin-todos/src/actions/todo.test.ts
@@ -1,3 +1,4 @@
+/** Unit tests for the TODO umbrella action and CURRENT_TODOS provider, driven against a deterministic in-memory FakeTodosService (no live database). */
 import type {
   ActionResult,
   HandlerOptions,

--- a/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosSpatialView.test.tsx
@@ -1,3 +1,4 @@
+/** Render tests for the todos spatial view over the TUI surface (deterministic static markup). */
 import { visibleWidth } from "@elizaos/tui";
 import { SpatialSurface } from "@elizaos/ui/spatial";
 import {

--- a/plugins/plugin-todos/src/db/index.ts
+++ b/plugins/plugin-todos/src/db/index.ts
@@ -1,1 +1,2 @@
+/** Barrel for the plugin-todos drizzle schema. */
 export * from "./schema.js";

--- a/plugins/plugin-todos/src/db/schema.ts
+++ b/plugins/plugin-todos/src/db/schema.ts
@@ -1,3 +1,8 @@
+/**
+ * Drizzle schema for @elizaos/plugin-todos: the `todos` table under
+ * `pgSchema("todos")`, plus its row/insert types and lookup indexes. The runtime
+ * registers migrations from this schema via the plugin's `schema` field.
+ */
 import { sql } from "drizzle-orm";
 import {
   index,

--- a/plugins/plugin-todos/src/index.ts
+++ b/plugins/plugin-todos/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public entry for `@elizaos/plugin-todos`: assembles the plugin (the `TODO`
+ * umbrella action, the `CURRENT_TODOS` provider, `TodosService`, the todos
+ * schema, and the `TodosView` dashboard view) and re-exports its types, service,
+ * schema, and views. Hard-depends on `@elizaos/plugin-sql`.
+ */
 import type { Plugin } from "@elizaos/core";
 
 import { todoAction } from "./actions/todo.js";

--- a/plugins/plugin-todos/src/providers/current-todos.ts
+++ b/plugins/plugin-todos/src/providers/current-todos.ts
@@ -1,3 +1,4 @@
+/** CURRENT_TODOS provider (position -5): injects the user's pending + in-progress todos as a markdown checklist into the planner context each turn in the tasks/todos/automation contexts. */
 import type {
   IAgentRuntime,
   Memory,

--- a/plugins/plugin-todos/src/service.ts
+++ b/plugins/plugin-todos/src/service.ts
@@ -1,3 +1,8 @@
+/**
+ * TodosService — the drizzle-backed CRUD store for user-scoped todos. Rows are
+ * scoped by `(agentId, entityId)` with optional `roomId`/`worldId` narrowing.
+ * Requires `runtime.db` from `@elizaos/plugin-sql`; throws if it is absent.
+ */
 import { type IAgentRuntime, logger, Service, type UUID } from "@elizaos/core";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";

--- a/plugins/plugin-todos/src/types.ts
+++ b/plugins/plugin-todos/src/types.ts
@@ -1,3 +1,4 @@
+/** Shared constants and types for @elizaos/plugin-todos: the service type + log prefix, the todo status enum, and the provider context tags. */
 export const TODOS_LOG_PREFIX = "[Todos]";
 export const TODOS_SERVICE_TYPE = "todos";
 

--- a/plugins/plugin-todos/vite.config.views.ts
+++ b/plugins/plugin-todos/vite.config.views.ts
@@ -1,3 +1,4 @@
+/** Vite bundle config for the todos dashboard view (emits to dist/views). */
 import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
 
 export default createViewBundleConfig({

--- a/plugins/plugin-todos/vitest.config.ts
+++ b/plugins/plugin-todos/vitest.config.ts
@@ -1,3 +1,4 @@
+/** Vitest config for @elizaos/plugin-todos: pins node resolution conditions for the SQL-backed suite. */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Comment cleanup B12 (partial slice) — LifeOps + assistant plugins

Part of #12242 (parent #12181). **Comment-only; `check:comment-only` PASSES** —
the TypeScript token stream is byte-for-byte identical to `origin/develop`
(verified by `scripts/assert-comment-only-diff.mjs`).

### Scope of this PR
A tight, fully-covered slice of four small assistant plugins:
`plugin-reminders`, `plugin-relationships`, `plugin-todos`, `plugin-documents`,
plus two churn fixes in adjacent `plugin-form`/`plugin-contacts` files.

Develop had already grown headers on most B12 files since the issue snapshot
(`8a2b993282`); this PR closes the remaining headerless files in these four
plugins and rewrites the churn-flagged comments in their subtrees.

### Tally
- **32 files changed** — 69 insertions, 12 deletions.
- **29 prose file headers added** (barrels → 1 line; services/schema → 2–6 lines;
  test files → 1 line naming the surface + how real the harness is; config/build
  files → 1 line).
- **3 churn comments rewritten to present tense** (no code touched):
  - `plugin-relationships/src/types.ts` — "…will be ported here in a follow-up
    pass; for now we expose…" → present-tense statement of what the module
    exposes and where the richer shapes live.
  - `plugin-documents/test/plugin.test.ts` — "The plugin index now re-exports…"
    → "The plugin index re-exports…" (+ added file header).
  - `plugin-contacts/src/components/ContactsAppView.test.ts` — "Phone numbers no
    longer use a tel: OS handoff…" → present-tense description of the rendered
    controls.

### Files flagged (NOT fabricated — left as-is)
Four files already carry good prose headers positioned *after* their import
block (`plugin-relationships/src/db/schema.ts`, `.../src/plugin.ts`,
`plugin-reminders/src/db/schema.ts`, `.../src/plugin.ts`). Left untouched — the
header content is correct; only its position (below imports) trips the
position-strict self-audit. Moving them is a mechanical follow-up.

### Evidence
- `bun run check:comment-only` → `OK — 32 source file(s) changed; every code
  token identical to origin/develop. Comments only.`
- Real-LLM trajectory / screenshots / video / audio / domain artifacts:
  **N/A — comments-only change, zero functional diff** (machine-checked by
  `scripts/assert-comment-only-diff.mjs`).

Refs #12242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
